### PR TITLE
[codex] Fix terasaki bug batch and remove legacy APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "36af0974014a12c681977105c5564257dd38441e" }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "77527ecb647fecd4918ea2d06d0065ddce4e5b1c" }
 strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082" }
 strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082" }
 strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", features = ["parallel"] }

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -67,11 +67,24 @@ rules from `tensor4all-agent-rules`.
   `panic`, `unwrap`, `expect`, unchecked indexing, poisoned-lock unwraps, or
   debug-only assertions. If an invariant is truly internal, keep it close to the
   proof; otherwise return a typed error.
+- When a bug exposes a public API design mismatch, prefer the cleanest
+  root-cause design fix by changing the canonical API contract. API
+  compatibility is not a goal unless the task explicitly requires it. Do not
+  preserve a panicking or lossy public API by adding a parallel `try_*`
+  compatibility escape; normally make the canonical operation return a typed
+  `Result`. Keep `try_*` names only when they are the intended canonical Rust
+  API, not a workaround for avoiding a cleaner API change.
+- If the cleanest fix requires reshaping `tidu` AD-transform APIs used by
+  tenferro, make that upstream API cleanup the preferred repair path and
+  optimize for the long-term clean `tidu` contract first. Do not hide a
+  tenferro bug behind lossy `tidu` error categories or local compatibility
+  shims when a clearer `tidu` contract is the root-cause fix.
 - Public cache, runtime, extension, and AD registry locks must not silently
   ignore poison by reporting empty/default state. If the method can return a
-  `Result`, return a typed poison error; if the legacy API cannot return a
-  `Result`, provide a fallible `try_*` API and make the legacy wrapper fail
-  visibly rather than fabricating success.
+  `Result`, return a typed poison error. If a non-`Result` API must remain
+  because of an explicitly approved compatibility or trait constraint, document
+  that reason near the wrapper and make failures visible rather than fabricating
+  success.
 - Public traced/eager helpers must validate rank and axis counts before
   computing output ranks or indexing shape arrays. Symbolic-shape traced values
   must not be forced through concrete-shape helpers unless the API explicitly
@@ -166,7 +179,7 @@ rules from `tensor4all-agent-rules`.
   `tenferro::linalg`, or `tenferro::fft`; users import operation crates
   directly.
 - Users import operation crates directly and register runtimes explicitly, for
-  example `tenferro_einsum::einsum` plus
+  example `tenferro_einsum::traced_tensor::einsum` plus
   `executor.register_extension(tenferro_einsum::register_runtime)`.
 - Extension runtime dispatch must fail explicitly when a runtime owner is
   available but the extension family is not registered. Do not silently fall
@@ -193,8 +206,8 @@ rules from `tensor4all-agent-rules`.
 - Extension crates depend on the runtime, tensor, AD, or GPU crate they need;
   dependency flow must not require a facade crate to depend back on them.
 - Extension AD rules should be owned by an explicit `tenferro_ad::AdContext`
-  or rule set. Process-global registration may remain only as a compatibility
-  bridge, not as the primary design for new APIs.
+  or rule set. Do not add process-global registration shims; a legacy bridge
+  may exist only when explicitly approved by the task or maintainer decision.
 
 ## Oracle Gate
 
@@ -595,7 +608,7 @@ Tests follow implementation ownership.
   device transfer behavior. Any change to those conventions must update that
   document in the same PR.
 - CUDA `eig` (non-symmetric eigenvalue decomposition, LAPACK `dgeev`) is not
-  provided by cuSOLVER. `CubeclBackend::eig` returns `BackendFailure`; users
+  provided by cuSOLVER. `CudaBackend::eig` returns `BackendFailure`; users
   must explicitly download to CPU and compute via `CpuBackend::eig`.
 
 ## Documentation Policy

--- a/ai/contribution-workflows/bugfix-pr.md
+++ b/ai/contribution-workflows/bugfix-pr.md
@@ -37,12 +37,20 @@ It may proceed as a bug-fix PR only when all of these are true:
 
 - The target behavior is already intended by current docs, tests, issue
   discussion, or existing API contracts.
-- The fix can be implemented without new public API.
 - The fix can be implemented without a new operation family, backend,
   dependency, feature flag, or architectural layer.
 - The fix does not change roadmap direction or require design acceptance.
 
 If any condition fails, stop the PR path and switch to issue intake.
+
+When the bug exposes a flawed public contract, prioritize the cleanest
+root-cause design fix even if that changes the canonical public API. API
+compatibility is not a goal unless the task explicitly requires it. Do not add
+`try_*` compatibility escape hatches merely to avoid a cleaner API change.
+If tenferro depends on an insufficient `tidu` AD-transform API, tidu API cleanup
+is part of the bug contract and should be the first-class repair path. Prefer a
+long-term clean, maintainable `tidu` contract over lossy tenferro-side adapters,
+generic error mapping, or compatibility shims.
 
 ## Step 2: Reproducer And Expected Result
 

--- a/ai/contribution-workflows/repository-remediation.md
+++ b/ai/contribution-workflows/repository-remediation.md
@@ -65,6 +65,10 @@ Proceed in this workflow when the fix stays within existing intended behavior:
 - missing required rustdoc examples for existing public items;
 - incorrect behavior covered by current API contracts, docs, or tests;
 - missing regression tests for an already intended behavior;
+- public API cleanup, removal, or reshaping needed to repair a confirmed bug
+  contract at its root cause;
+- `tidu` AD-transform API cleanup needed to express the confirmed tenferro bug
+  contract without lossy local adapters;
 - internal performance, layout, cache, or allocation problems;
 - hidden materialization or avoidable clones where the correct boundary is
   already defined by `REPOSITORY_RULES.md`;
@@ -102,9 +106,10 @@ misidentifying the same code as a bug.
 
 ### Design Gate
 
-Do not implement directly when a finding requires any of the following:
+Do not implement directly when a finding requires any of the following and the
+task or linked maintainer discussion has not explicitly authorized that scope:
 
-- new public API or removal of a public API with compatibility impact;
+- new public API unrelated to repairing the confirmed bug contract;
 - crate-boundary or publishability changes;
 - new operation family, backend, dependency, or feature flag;
 - AD semantics policy that current docs/tests do not define;
@@ -114,6 +119,17 @@ Do not implement directly when a finding requires any of the following:
 
 For design-gated findings, draft or update a focused issue or design document
 instead of stretching the remediation PR.
+
+For confirmed bug contracts, treat API design cleanup as the preferred repair
+path. Change the canonical public contract into the cleanest root-cause design
+instead of adding `try_*` escape hatches solely to preserve a legacy
+panic/defaulting wrapper. API compatibility is not a goal unless the task
+explicitly requires it; `try_*` may remain only when it is the canonical Rust API
+for that operation.
+If a tenferro remediation is blocked by an underspecified `tidu` API, reshape
+the `tidu` contract as the first-class repair path. Prefer the long-term clean,
+maintainable `tidu` API over tenferro-local string matching, generic
+`Internal` errors, or compatibility shims.
 
 ## Batch And Commit Rules
 

--- a/crates/tenferro-ad/src/context.rs
+++ b/crates/tenferro-ad/src/context.rs
@@ -5,8 +5,7 @@ use tenferro_runtime::{Result, TracedTensor};
 
 /// Explicit automatic-differentiation context.
 ///
-/// `AdContext` owns the extension AD rules used by traced AD transforms. It is
-/// the preferred alternative to process-global extension rule registration.
+/// `AdContext` owns the extension AD rules used by traced AD transforms.
 ///
 /// # Examples
 ///

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -34,7 +34,7 @@ use crate::eager_exec::{
 use crate::error::{ContextId, Error, Result};
 use crate::metadata::{
     metadata_scopes_for_scope, push_metadata_scope, register_scoped_metadata_batch,
-    register_scoped_value_metadata, tensor_meta_from_tensor, MetadataScope,
+    register_scoped_value_metadata, tensor_meta_from_tensor, GlobalMetadataScope,
 };
 use crate::traced::next_input_key;
 
@@ -413,17 +413,11 @@ impl EagerRuntime {
     /// use tenferro_ad::{EagerRuntime};
     ///
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
-    /// ctx.clear_extension_caches();
-    /// assert_eq!(ctx.cache_stats().extensions.entries, 0);
+    /// ctx.clear_extension_caches()?;
+    /// assert_eq!(ctx.cache_stats()?.extensions.entries, 0);
+    /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
-    pub fn clear_extension_caches(&self) {
-        // Compatibility wrapper: callers needing poison visibility should use
-        // `try_clear_extension_caches`; this boundary must not panic on poison.
-        let _ = self.try_clear_extension_caches();
-    }
-
-    /// Fallibly clear generic extension runtime cache entries.
-    pub fn try_clear_extension_caches(&self) -> Result<()> {
+    pub fn clear_extension_caches(&self) -> Result<()> {
         self.lock_extension_executor()?.clear_caches();
         Ok(())
     }
@@ -437,18 +431,12 @@ impl EagerRuntime {
     /// use tenferro_ad::{EagerRuntime};
     ///
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
-    /// ctx.clear_caches();
-    /// assert_eq!(ctx.cache_stats().extensions.entries, 0);
+    /// ctx.clear_caches()?;
+    /// assert_eq!(ctx.cache_stats()?.extensions.entries, 0);
+    /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
-    pub fn clear_caches(&self) {
-        // Compatibility wrapper: callers needing poison visibility should use
-        // `try_clear_caches`; this boundary must not panic on poison.
-        let _ = self.try_clear_caches();
-    }
-
-    /// Fallibly clear every cache owned by this eager context.
-    pub fn try_clear_caches(&self) -> Result<()> {
-        self.try_clear_extension_caches()
+    pub fn clear_caches(&self) -> Result<()> {
+        self.clear_extension_caches()
     }
 
     /// Return eager runtime cache-entry and retained-byte stats.
@@ -460,43 +448,23 @@ impl EagerRuntime {
     /// use tenferro_ad::{EagerRuntime};
     ///
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
-    /// let stats = ctx.cache_stats();
+    /// let stats = ctx.cache_stats()?;
     /// assert_eq!(stats.extensions.entries, 0);
+    /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
-    pub fn cache_stats(&self) -> EagerRuntimeCacheStats {
-        // Compatibility wrapper: callers needing poison visibility should use
-        // `try_cache_stats`; stats default to empty when the runtime is poisoned.
-        self.try_cache_stats().unwrap_or_default()
-    }
-
-    /// Fallibly return eager runtime cache-entry and retained-byte stats.
-    pub fn try_cache_stats(&self) -> Result<EagerRuntimeCacheStats> {
+    pub fn cache_stats(&self) -> Result<EagerRuntimeCacheStats> {
         Ok(EagerRuntimeCacheStats {
             extensions: self.lock_extension_executor()?.cache_stats(),
         })
     }
 
     /// Return the extension cache retention limits.
-    pub fn extension_cache_limits(&self) -> ExtensionCacheLimits {
-        // Compatibility wrapper: callers needing poison visibility should use
-        // `try_extension_cache_limits`.
-        self.try_extension_cache_limits().unwrap_or_default()
-    }
-
-    /// Fallibly return the extension cache retention limits.
-    pub fn try_extension_cache_limits(&self) -> Result<ExtensionCacheLimits> {
+    pub fn extension_cache_limits(&self) -> Result<ExtensionCacheLimits> {
         Ok(self.lock_extension_executor()?.cache_limits())
     }
 
     /// Replace extension cache retention limits.
-    pub fn set_extension_cache_limits(&self, limits: ExtensionCacheLimits) {
-        // Compatibility wrapper: callers needing poison visibility should use
-        // `try_set_extension_cache_limits`; this boundary must not panic on poison.
-        let _ = self.try_set_extension_cache_limits(limits);
-    }
-
-    /// Fallibly replace extension cache retention limits.
-    pub fn try_set_extension_cache_limits(&self, limits: ExtensionCacheLimits) -> Result<()> {
+    pub fn set_extension_cache_limits(&self, limits: ExtensionCacheLimits) -> Result<()> {
         self.lock_extension_executor()?.set_cache_limits(limits);
         Ok(())
     }
@@ -719,19 +687,13 @@ impl EagerRuntime {
     /// let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
     /// let _ = loss.backward().unwrap();
     ///
-    /// ctx.clear_grads();
+    /// ctx.clear_grads()?;
     ///
-    /// assert!(x.grad().is_none());
-    /// assert!(y.grad().is_none());
+    /// assert!(x.grad()?.is_none());
+    /// assert!(y.grad()?.is_none());
+    /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
-    pub fn clear_grads(&self) {
-        // Compatibility wrapper: callers needing poison visibility should use
-        // `try_clear_grads`; this boundary must not panic on poison.
-        let _ = self.try_clear_grads();
-    }
-
-    /// Fallibly clear all live gradient slots tracked by this context.
-    pub fn try_clear_grads(&self) -> Result<()> {
+    pub fn clear_grads(&self) -> Result<()> {
         let mut poisoned_slot = false;
         self.lock_grad_slots()?.retain(|_, slot| {
             if let Some(slot) = slot.upgrade() {
@@ -793,7 +755,7 @@ impl EagerRuntime {
     /// let loss = p.exp().unwrap().reduce_sum(&[0]).unwrap();
     /// let _ = loss.backward().unwrap();
     ///
-    /// let grad = p.grad().unwrap();
+    /// let grad = p.grad().unwrap().unwrap();
     /// assert_eq!(grad.shape(), &[2]);
     /// ```
     pub fn variable_from(self: &Arc<Self>, tensor: Tensor) -> EagerTensor {
@@ -856,10 +818,10 @@ impl EagerRuntime {
 /// let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
 /// let _cotangents = loss.backward().unwrap();
 ///
-/// assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[4.0, 8.0, 12.0]);
+/// assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[4.0, 8.0, 12.0]);
 /// x.clear_grad();
 ///
-/// assert!(x.grad().is_none());
+/// assert!(x.grad().unwrap().is_none());
 /// ```
 #[derive(Clone)]
 pub struct EagerTensor {
@@ -869,7 +831,7 @@ pub struct EagerTensor {
     pub(crate) trace: Option<Trace<StdTensorOp>>,
     pub(crate) requires_grad: bool,
     grad_slot: GradSlot,
-    pub(crate) metadata_scopes: Vec<Arc<MetadataScope>>,
+    pub(crate) metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
     pub(crate) ctx: Arc<EagerRuntime>,
 }
 
@@ -915,7 +877,7 @@ impl EagerTensor {
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]), ctx);
     ///
-    /// assert!(x.grad().is_none());
+    /// assert!(x.grad().unwrap().is_none());
     /// ```
     pub fn requires_grad_in(tensor: Tensor, ctx: Arc<EagerRuntime>) -> Self {
         Self::new_leaf(ctx, tensor, true)
@@ -924,7 +886,9 @@ impl EagerTensor {
     pub(crate) fn new_leaf(ctx: Arc<EagerRuntime>, tensor: Tensor, requires_grad: bool) -> Self {
         let key = eager_val_key();
         let metadata_scope =
-            register_scoped_value_metadata(key.clone(), tensor_meta_from_tensor(&tensor));
+            register_scoped_value_metadata(key.clone(), tensor_meta_from_tensor(&tensor))
+                // Eager leaf keys are freshly allocated for this context.
+                .expect("fresh eager leaf metadata registration failed");
         let tensor = Arc::new(tensor);
         let grad_slot = Arc::new(Mutex::new(None));
         if requires_grad {
@@ -949,7 +913,7 @@ impl EagerTensor {
         tensor: Tensor,
         requires_grad: bool,
         trace: Option<Trace<StdTensorOp>>,
-        metadata_scopes: Vec<Arc<MetadataScope>>,
+        metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
     ) -> Self {
         Self::new_result_arc(
             ctx,
@@ -967,7 +931,7 @@ impl EagerTensor {
         tensor: Arc<Tensor>,
         requires_grad: bool,
         trace: Option<Trace<StdTensorOp>>,
-        metadata_scopes: Vec<Arc<MetadataScope>>,
+        metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
     ) -> Self {
         let grad_slot = Arc::new(Mutex::new(None));
         if requires_grad {
@@ -992,7 +956,7 @@ impl EagerTensor {
         value: TensorValue,
         requires_grad: bool,
         trace: Option<Trace<StdTensorOp>>,
-        metadata_scopes: Vec<Arc<MetadataScope>>,
+        metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
     ) -> Self {
         let grad_slot = Arc::new(Mutex::new(None));
         if requires_grad {
@@ -1044,7 +1008,7 @@ impl EagerTensor {
     /// let y = x.detach();
     ///
     /// assert_eq!(y.data().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
-    /// assert!(y.grad().is_none());
+    /// assert!(y.grad().unwrap().is_none());
     /// ```
     pub fn detach(&self) -> Self {
         Self::new_untracked_value_result(self.ctx.clone(), self.value.as_ref().clone())
@@ -1088,7 +1052,15 @@ impl EagerTensor {
             return tensor.as_ref();
         }
         self.materialized_cache
-            .get_or_init(|| Arc::new(self.value.to_tensor()))
+            .get_or_init(|| {
+                // `EagerTensor` stores a validated TensorValue, so materialization
+                // failure here would be an internal value construction bug.
+                Arc::new(
+                    self.value
+                        .to_tensor()
+                        .expect("validated eager tensor value"),
+                )
+            })
             .as_ref()
     }
 
@@ -1120,7 +1092,7 @@ impl EagerTensor {
     /// callers that need owned materialized data after lazy view storage is
     /// introduced.
     pub fn to_tensor(&self) -> Result<Tensor> {
-        self.value.try_to_tensor().map_err(Error::from)
+        self.value.to_tensor().map_err(Error::from)
     }
 
     pub(crate) fn materialized_arc(&self) -> Result<Arc<Tensor>> {
@@ -1131,7 +1103,7 @@ impl EagerTensor {
             return Ok(Arc::clone(tensor));
         }
 
-        let materialized = Arc::new(self.value.try_to_tensor().map_err(Error::from)?);
+        let materialized = Arc::new(self.value.to_tensor().map_err(Error::from)?);
         let _ = self.materialized_cache.set(Arc::clone(&materialized));
         Ok(self
             .materialized_cache
@@ -1165,17 +1137,11 @@ impl EagerTensor {
     /// let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
     /// let _cotangents = loss.backward().unwrap();
     ///
-    /// let grad = x.grad().unwrap();
+    /// let grad = x.grad()?.unwrap();
     /// assert_eq!(grad.shape(), &[2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
-    pub fn grad(&self) -> Option<Arc<Tensor>> {
-        // Compatibility wrapper: callers needing poison visibility should use
-        // `try_grad`; this boundary must not panic on poison.
-        self.try_grad().ok().flatten()
-    }
-
-    /// Fallibly return the accumulated gradient currently stored for this tensor.
-    pub fn try_grad(&self) -> Result<Option<Arc<Tensor>>> {
+    pub fn grad(&self) -> Result<Option<Arc<Tensor>>> {
         self.grad_slot
             .lock()
             .map_err(|_| Error::Internal("gradient slot lock poisoned".to_string()))
@@ -1200,19 +1166,13 @@ impl EagerTensor {
     /// let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
     /// let _ = loss.backward().unwrap();
     ///
-    /// x.clear_grad();
+    /// x.clear_grad()?;
     ///
-    /// assert!(x.grad().is_none());
-    /// assert!(y.grad().is_some());
+    /// assert!(x.grad()?.is_none());
+    /// assert!(y.grad()?.is_some());
+    /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
-    pub fn clear_grad(&self) {
-        // Compatibility wrapper: callers needing poison visibility should use
-        // `try_clear_grad`; this boundary must not panic on poison.
-        let _ = self.try_clear_grad();
-    }
-
-    /// Fallibly clear the accumulated gradient stored for this tensor.
-    pub fn try_clear_grad(&self) -> Result<()> {
+    pub fn clear_grad(&self) -> Result<()> {
         *self
             .grad_slot
             .lock()
@@ -1351,7 +1311,8 @@ impl EagerTensor {
             .iter()
             .map(|&output_id| graph.values()[output_id].key.clone())
             .collect();
-        let recorded_graph = RecordedGraph::new(Arc::clone(&graph), graph_input_keys, output_keys);
+        let recorded_graph = RecordedGraph::new(Arc::clone(&graph), graph_input_keys, output_keys)
+            .map_err(eager_record_error)?;
         let recorded = record_eager_recorded_graph_outputs(
             &mut recorder,
             recorded_graph,
@@ -1414,7 +1375,7 @@ impl EagerTensor {
     /// let loss = x.add(&x).unwrap().reduce_sum(&[0]).unwrap();
     /// let _cotangents = loss.backward().unwrap();
     ///
-    /// assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[4.0, 4.0, 4.0]);
+    /// assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[4.0, 4.0, 4.0]);
     /// ```
     pub fn backward(&self) -> Result<HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>> {
         if !self.shape().is_empty() {
@@ -1426,7 +1387,7 @@ impl EagerTensor {
         let value = self.materialized_arc()?;
         let mut backend = self.ctx.lock_backend()?;
         let mut extension_executor = self.ctx.lock_extension_executor()?;
-        let seed = Arc::new(one_like_tensor(value.as_ref(), &mut *backend));
+        let seed = Arc::new(one_like_tensor(value.as_ref(), &mut *backend)?);
         let mut callbacks = TenferroBackwardCallbacks::new(
             &mut *backend,
             Some(&mut *extension_executor),
@@ -1436,7 +1397,7 @@ impl EagerTensor {
         if let Some(extension_rules) = &self.ctx.extension_rules {
             ad_ctx = ad_ctx.with_extension_rules(extension_rules.clone());
         }
-        let cotangents = eager::try_backward(
+        let cotangents = eager::backward(
             &self.key,
             self.trace.as_ref(),
             seed,
@@ -1473,7 +1434,7 @@ pub(crate) fn eager_value(tensor: &EagerTensor) -> Result<EagerInput<StdTensorOp
 
 pub(crate) struct RecordedEagerOutputs {
     pub(crate) traces: Vec<EagerOutput<StdTensorOp>>,
-    pub(crate) metadata_scope: Arc<MetadataScope>,
+    pub(crate) metadata_scope: Arc<GlobalMetadataScope>,
 }
 
 pub(crate) fn record_eager_outputs(
@@ -1483,7 +1444,8 @@ pub(crate) fn record_eager_outputs(
 ) -> Result<RecordedEagerOutputs> {
     let mut recorder = Recorder::new(EagerTensorKeySource);
     let graph_input_keys = recorder.fresh_input_keys::<StdTensorOp>(inputs.len());
-    let graph = RecordedGraph::from_primitive(op.clone(), graph_input_keys);
+    let graph =
+        RecordedGraph::from_primitive(op.clone(), graph_input_keys).map_err(eager_record_error)?;
     let retained_values = graph
         .output_keys()
         .iter()
@@ -1504,7 +1466,9 @@ pub(crate) fn record_eager_recorded_graph_outputs(
         .iter()
         .map(|tensor| eager_value(tensor))
         .collect::<Result<_>>()?;
-    let traces = recorder.record_graph(graph, &input_values, outputs, retained_values);
+    let traces = recorder
+        .record_graph(graph, &input_values, outputs, retained_values)
+        .map_err(eager_record_error)?;
 
     let mut registrations = Vec::new();
     for trace in &traces {
@@ -1521,8 +1485,12 @@ pub(crate) fn record_eager_recorded_graph_outputs(
 
     Ok(RecordedEagerOutputs {
         traces,
-        metadata_scope: Arc::new(register_scoped_metadata_batch(registrations)),
+        metadata_scope: Arc::new(register_scoped_metadata_batch(registrations)?),
     })
+}
+
+fn eager_record_error(err: tidu::eager::EagerRecordError) -> Error {
+    Error::Internal(format!("invalid eager recording metadata: {err}"))
 }
 
 pub(crate) fn exec_single_output(
@@ -1563,29 +1531,28 @@ pub(crate) fn exec_single_output_read(
     ))
 }
 
-pub(crate) fn zero_like_tensor<B: TensorBackend>(input: &Tensor, backend: &mut B) -> Tensor {
+pub(crate) fn zero_like_tensor<B: TensorBackend>(
+    input: &Tensor,
+    backend: &mut B,
+) -> Result<Tensor> {
     let host = match input {
-        Tensor::F32(tensor) => Tensor::F32(TypedTensor::zeros(tensor.shape().to_vec())),
-        Tensor::F64(tensor) => Tensor::F64(TypedTensor::zeros(tensor.shape().to_vec())),
-        Tensor::I32(tensor) => Tensor::I32(TypedTensor::zeros(tensor.shape().to_vec())),
-        Tensor::I64(tensor) => Tensor::I64(TypedTensor::zeros(tensor.shape().to_vec())),
+        Tensor::F32(tensor) => Tensor::F32(TypedTensor::zeros(tensor.shape().to_vec())?),
+        Tensor::F64(tensor) => Tensor::F64(TypedTensor::zeros(tensor.shape().to_vec())?),
+        Tensor::I32(tensor) => Tensor::I32(TypedTensor::zeros(tensor.shape().to_vec())?),
+        Tensor::I64(tensor) => Tensor::I64(TypedTensor::zeros(tensor.shape().to_vec())?),
         Tensor::Bool(tensor) => Tensor::Bool(TypedTensor::from_vec_col_major(
             tensor.shape().to_vec(),
             vec![false; tensor.n_elements()],
-        )),
-        Tensor::C32(tensor) => Tensor::C32(TypedTensor::zeros(tensor.shape().to_vec())),
-        Tensor::C64(tensor) => Tensor::C64(TypedTensor::zeros(tensor.shape().to_vec())),
+        )?),
+        Tensor::C32(tensor) => Tensor::C32(TypedTensor::zeros(tensor.shape().to_vec())?),
+        Tensor::C64(tensor) => Tensor::C64(TypedTensor::zeros(tensor.shape().to_vec())?),
     };
-    backend
-        .upload_host_tensor(&host)
-        .unwrap_or_else(|err| panic!("zero_like upload failed: {}", err))
+    backend.upload_host_tensor(&host).map_err(Error::from)
 }
 
-pub(crate) fn one_like_tensor<B: TensorBackend>(input: &Tensor, backend: &mut B) -> Tensor {
-    let zero = zero_like_tensor(input, backend);
-    backend
-        .exp(&zero)
-        .unwrap_or_else(|err| panic!("one_like exp failed: {}", err))
+pub(crate) fn one_like_tensor<B: TensorBackend>(input: &Tensor, backend: &mut B) -> Result<Tensor> {
+    let zero = zero_like_tensor(input, backend)?;
+    backend.exp(&zero).map_err(Error::from)
 }
 
 #[cfg(test)]

--- a/crates/tenferro-ad/src/eager/backward.rs
+++ b/crates/tenferro-ad/src/eager/backward.rs
@@ -15,7 +15,7 @@ use crate::eager_exec::{exec_op_on_tensors, exec_op_on_tensors_with_extension_ex
 use crate::extension_runtime::ExtensionExecutor;
 use crate::metadata::{
     push_metadata_scope, register_scoped_live_graph_metadata, tensor_meta_from_tensor,
-    MetadataScope,
+    GlobalMetadataScope,
 };
 
 use super::zero_like_tensor;
@@ -23,14 +23,14 @@ use super::zero_like_tensor;
 pub(crate) struct TenferroBackwardCallbacks<'a, B: TensorBackend + 'static> {
     backend: &'a mut B,
     extension_executor: Option<&'a mut ExtensionExecutor<B>>,
-    metadata_scopes: Vec<Arc<MetadataScope>>,
+    metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
 }
 
 impl<'a, B: TensorBackend + 'static> TenferroBackwardCallbacks<'a, B> {
     pub(crate) fn new(
         backend: &'a mut B,
         extension_executor: Option<&'a mut ExtensionExecutor<B>>,
-        metadata_scopes: Vec<Arc<MetadataScope>>,
+        metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
     ) -> Self {
         Self {
             backend,
@@ -83,7 +83,10 @@ pub(super) fn eager_forward_value<B: TensorBackend>(
     let base = initial_data
         .get(&base_key)
         .unwrap_or_else(|| panic!("missing base eager value for {:?}", base_key));
-    let value = Arc::new(zero_like_tensor(base.as_ref(), backend));
+    // tidu's eager callback trait is infallible here; backend zero creation has
+    // already been validated by the surrounding backward pass setup.
+    let value =
+        Arc::new(zero_like_tensor(base.as_ref(), backend).expect("eager tangent zero creation"));
     all_values.insert(key.clone(), Arc::clone(&value));
     value
 }
@@ -129,16 +132,32 @@ fn zero_from_exact_metadata<B: TensorBackend>(
         .map(|dim| dim.constant_value())
         .collect::<Option<Vec<_>>>()?;
     let host = match meta.dtype {
-        DType::F32 => Tensor::F32(TypedTensor::zeros(shape)),
-        DType::F64 => Tensor::F64(TypedTensor::zeros(shape)),
-        DType::I32 => Tensor::I32(TypedTensor::zeros(shape)),
-        DType::I64 => Tensor::I64(TypedTensor::zeros(shape)),
+        // The zero tensor shape comes from exact tensor metadata, so shape/product
+        // overflow would indicate an earlier metadata-validation bug.
+        DType::F32 => Tensor::F32(TypedTensor::zeros(shape).expect("exact metadata zero shape")),
+        // The zero tensor shape comes from exact tensor metadata, so shape/product
+        // overflow would indicate an earlier metadata-validation bug.
+        DType::F64 => Tensor::F64(TypedTensor::zeros(shape).expect("exact metadata zero shape")),
+        // The zero tensor shape comes from exact tensor metadata, so shape/product
+        // overflow would indicate an earlier metadata-validation bug.
+        DType::I32 => Tensor::I32(TypedTensor::zeros(shape).expect("exact metadata zero shape")),
+        // The zero tensor shape comes from exact tensor metadata, so shape/product
+        // overflow would indicate an earlier metadata-validation bug.
+        DType::I64 => Tensor::I64(TypedTensor::zeros(shape).expect("exact metadata zero shape")),
         DType::Bool => {
             let len = shape.iter().product();
-            Tensor::Bool(TypedTensor::from_vec_col_major(shape, vec![false; len]))
+            // The boolean buffer length is computed from the same exact shape.
+            Tensor::Bool(
+                TypedTensor::from_vec_col_major(shape, vec![false; len])
+                    .expect("exact metadata bool zero shape/data match"),
+            )
         }
-        DType::C32 => Tensor::C32(TypedTensor::zeros(shape)),
-        DType::C64 => Tensor::C64(TypedTensor::zeros(shape)),
+        // The zero tensor shape comes from exact tensor metadata, so shape/product
+        // overflow would indicate an earlier metadata-validation bug.
+        DType::C32 => Tensor::C32(TypedTensor::zeros(shape).expect("exact metadata zero shape")),
+        // The zero tensor shape comes from exact tensor metadata, so shape/product
+        // overflow would indicate an earlier metadata-validation bug.
+        DType::C64 => Tensor::C64(TypedTensor::zeros(shape).expect("exact metadata zero shape")),
     };
     Some(
         backend
@@ -158,7 +177,7 @@ fn prefill_missing_linear_zero_values<B: TensorBackend>(
             continue;
         }
         let Some(meta) = ctx
-            .try_metadata_of(&ValueRef::External(value.key.clone()))
+            .metadata_if_available(&ValueRef::External(value.key.clone()))
             .cloned()
         else {
             continue;
@@ -243,7 +262,9 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
         }
 
         let metadata_scope =
-            register_scoped_live_graph_metadata(graph, &live_values, input_metadata);
+            register_scoped_live_graph_metadata(graph, &live_values, input_metadata)
+                // The replay graph and live set were produced by the eager recorder.
+                .expect("eager replay metadata registration failed");
         push_metadata_scope(&mut self.metadata_scopes, Arc::new(metadata_scope));
 
         all_values
@@ -275,7 +296,7 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
             })
             .collect::<Vec<_>>();
 
-        tidu::try_linear_transpose_with_builder(linear, &mut builder, &cotangent_seed_ids, ctx).map(
+        tidu::linear_transpose_with_builder(linear, &mut builder, &cotangent_seed_ids, ctx).map(
             |cotangent_ids| {
                 cotangent_ids
                     .into_iter()

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -94,20 +94,20 @@ fn eager_runtime_public_helpers_do_not_unwrap_poisoned_locks() {
     }));
     assert!(poisoned.is_err());
 
-    assert!(ctx.try_clear_extension_caches().is_err());
-    assert!(ctx.try_cache_stats().is_err());
-    assert!(ctx.try_extension_cache_limits().is_err());
+    assert!(ctx.clear_extension_caches().is_err());
+    assert!(ctx.cache_stats().is_err());
+    assert!(ctx.extension_cache_limits().is_err());
     assert!(ctx
-        .try_set_extension_cache_limits(ExtensionCacheLimits::new(NonZeroUsize::new(1).unwrap(),))
+        .set_extension_cache_limits(ExtensionCacheLimits::new(NonZeroUsize::new(1).unwrap(),))
         .is_err());
     assert!(ctx.with_extension_caches_mut(|_| ()).is_err());
 
     assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        ctx.clear_extension_caches();
-        ctx.clear_caches();
+        let _ = ctx.clear_extension_caches();
+        let _ = ctx.clear_caches();
         let _ = ctx.cache_stats();
         let _ = ctx.extension_cache_limits();
-        ctx.set_extension_cache_limits(ExtensionCacheLimits::default());
+        let _ = ctx.set_extension_cache_limits(ExtensionCacheLimits::default());
     }))
     .is_ok());
 }
@@ -133,7 +133,7 @@ fn eager_runtime_backend_closure_reports_poisoned_backend_lock() {
 fn eager_index_select_reports_poisoned_backend_lock() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         Arc::clone(&ctx),
     );
     let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -154,7 +154,7 @@ fn eager_index_select_reports_poisoned_backend_lock() {
 fn eager_runtime_gradient_helpers_do_not_unwrap_poisoned_locks() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]),
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
         ctx.clone(),
     );
     let poisoned_slot = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -163,11 +163,11 @@ fn eager_runtime_gradient_helpers_do_not_unwrap_poisoned_locks() {
     }));
     assert!(poisoned_slot.is_err());
 
-    assert!(x.try_grad().is_err());
-    assert!(x.try_clear_grad().is_err());
+    assert!(x.grad().is_err());
+    assert!(x.clear_grad().is_err());
     assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        assert!(x.grad().is_none());
-        x.clear_grad();
+        let _ = x.grad();
+        let _ = x.clear_grad();
     }))
     .is_ok());
 
@@ -177,9 +177,9 @@ fn eager_runtime_gradient_helpers_do_not_unwrap_poisoned_locks() {
     }));
     assert!(poisoned_registry.is_err());
 
-    assert!(ctx.try_clear_grads().is_err());
+    assert!(ctx.clear_grads().is_err());
     assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        ctx.clear_grads();
+        let _ = ctx.clear_grads();
     }))
     .is_ok());
 }
@@ -274,12 +274,26 @@ impl<B: TensorBackend + 'static> ExtensionRuntime<B> for ReadPathFallbackRuntime
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
         op.eager_execute(inputs)
     }
+
+    fn execute_reads(
+        &self,
+        op: &dyn ExtensionOp,
+        inputs: &[TensorRead<'_>],
+        ctx: &mut ExtensionExecutionContext<'_, B>,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let materialized_inputs: Vec<Tensor> = inputs
+            .iter()
+            .map(TensorRead::to_tensor)
+            .collect::<tenferro_tensor::Result<_>>()?;
+        let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
+        self.execute(op, &input_refs, ctx)
+    }
 }
 
 #[test]
 fn tensor_read_extension_path_errors_when_runtime_family_is_missing() {
     let op = StdTensorOp::Extension(Arc::new(ReadPathFallbackProbe));
-    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let reads = [TensorRead::from_tensor(&input)];
     let mut backend = CpuBackend::new();
     let mut extension_executor = ExtensionExecutor::<CpuBackend>::new();
@@ -311,7 +325,7 @@ fn eager_extension_dispatch_does_not_initialize_lazy_view_materialization_cache(
     .expect("register read-path fallback runtime");
 
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx,
     );
     let x_t = x.transpose(&[1, 0]).unwrap();
@@ -346,7 +360,7 @@ fn eager_forward_helpers_synthesize_tangent_values_from_primal_data() {
     let user = TensorInputKey::User { id: 7 };
     let base_key = ValueKey::Input(user.clone());
     let tangent_key = ValueKey::Input(user.tangent_of(11));
-    let base = Arc::new(Tensor::from_vec_col_major(vec![2], vec![4.0_f64, 5.0]));
+    let base = Arc::new(Tensor::from_vec_col_major(vec![2], vec![4.0_f64, 5.0]).unwrap());
     let initial_data = HashMap::from([(base_key.clone(), Arc::clone(&base))]);
 
     assert_eq!(missing_tangent_base_key(&base_key), None);
@@ -355,8 +369,8 @@ fn eager_forward_helpers_synthesize_tangent_values_from_primal_data() {
         Some(base_key.clone())
     );
     assert_eq!(
-        eager_forward_input_metadata(&tangent_key, &initial_data).shape,
-        vec![SymDim::from(2usize)]
+        eager_forward_input_metadata(&tangent_key, &initial_data).exact_shape(),
+        Some(vec![SymDim::from(2usize)])
     );
 
     let mut all_values = HashMap::new();
@@ -369,11 +383,13 @@ fn eager_forward_helpers_synthesize_tangent_values_from_primal_data() {
 fn standard_graph_op_executes_untracked_outputs_without_trace() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let lhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         ctx.clone(),
     );
-    let rhs =
-        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]), ctx);
+    let rhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(),
+        ctx,
+    );
 
     let outputs =
         EagerTensor::standard_graph_op(&[&lhs, &rhs], |keys| Ok(build_add_mul_reduce_graph(keys)))
@@ -390,11 +406,13 @@ fn standard_graph_op_executes_untracked_outputs_without_trace() {
 fn standard_graph_op_records_one_tracked_graph_and_backpropagates() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let lhs = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         ctx.clone(),
     );
-    let rhs =
-        EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]), ctx);
+    let rhs = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(),
+        ctx,
+    );
 
     let mut outputs =
         EagerTensor::standard_graph_op(&[&lhs, &rhs], |keys| Ok(build_add_mul_reduce_graph(keys)))
@@ -406,8 +424,14 @@ fn standard_graph_op_records_one_tracked_graph_and_backpropagates() {
     assert_eq!(loss.debug_trace_saved_value_count(), Some(5));
 
     loss.backward().expect("backward through recorded graph");
-    assert_eq!(lhs.grad().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
-    assert_eq!(rhs.grad().unwrap().as_slice::<f64>().unwrap(), &[7.0, 10.0]);
+    assert_eq!(
+        lhs.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
+        &[3.0, 4.0]
+    );
+    assert_eq!(
+        rhs.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
+        &[7.0, 10.0]
+    );
 }
 
 #[test]
@@ -426,10 +450,14 @@ fn standard_graph_op_rejects_empty_and_cross_context_inputs() {
 
     let lhs_ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let rhs_ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
-    let lhs =
-        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![1], vec![1.0_f64]), lhs_ctx);
-    let rhs =
-        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![1], vec![2.0_f64]), rhs_ctx);
+    let lhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+        lhs_ctx,
+    );
+    let rhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap(),
+        rhs_ctx,
+    );
 
     let err = match EagerTensor::standard_graph_op(&[&lhs, &rhs], |_| {
         panic!("cross-context inputs should fail before graph construction")
@@ -444,16 +472,16 @@ fn standard_graph_op_rejects_empty_and_cross_context_inputs() {
 fn zero_like_tensor_covers_non_f64_dtypes() {
     let mut backend = CpuBackend::new();
     let cases = [
-        Tensor::from_vec_col_major(vec![1], vec![1.0_f32]),
-        Tensor::from_vec_col_major(vec![1], vec![1_i32]),
-        Tensor::from_vec_col_major(vec![1], vec![1_i64]),
-        Tensor::from_vec_col_major(vec![2], vec![true, false]),
-        Tensor::from_vec_col_major(vec![1], vec![num_complex::Complex32::new(1.0, -1.0)]),
-        Tensor::from_vec_col_major(vec![1], vec![num_complex::Complex64::new(1.0, -1.0)]),
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f32]).unwrap(),
+        Tensor::from_vec_col_major(vec![1], vec![1_i32]).unwrap(),
+        Tensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap(),
+        Tensor::from_vec_col_major(vec![2], vec![true, false]).unwrap(),
+        Tensor::from_vec_col_major(vec![1], vec![num_complex::Complex32::new(1.0, -1.0)]).unwrap(),
+        Tensor::from_vec_col_major(vec![1], vec![num_complex::Complex64::new(1.0, -1.0)]).unwrap(),
     ];
 
     for input in cases {
-        let zero = zero_like_tensor(&input, &mut backend);
+        let zero = zero_like_tensor(&input, &mut backend).unwrap();
         assert_eq!(zero.shape(), input.shape());
     }
 }
@@ -461,8 +489,8 @@ fn zero_like_tensor_covers_non_f64_dtypes() {
 #[test]
 fn eager_backend_delegates_broadcast_multiply_fusion_to_cpu_backend() {
     let mut backend = EagerBackend::cpu(CpuBackend::new());
-    let lhs = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]);
-    let rhs = Tensor::from_vec_col_major(vec![3], vec![5.0_f64, 7.0, 11.0]);
+    let lhs = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![3], vec![5.0_f64, 7.0, 11.0]).unwrap();
 
     let out = backend
         .execute_broadcast_multiply(
@@ -487,7 +515,7 @@ fn eager_backend_delegates_broadcast_multiply_fusion_to_cpu_backend() {
 fn untracked_nary_ops_consume_lazy_views_without_materializing_inputs() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx,
     );
     let x_t = x.transpose(&[1, 0]).unwrap();

--- a/crates/tenferro-ad/src/eager_builder.rs
+++ b/crates/tenferro-ad/src/eager_builder.rs
@@ -71,7 +71,12 @@ impl<'a, B: TensorBackend + 'static> EagerPrimitiveBuilder<'a, B> {
         let base = self.external_data.get(&base_key).unwrap_or_else(|| {
             panic!("EagerPrimitiveBuilder: missing tangent base {:?}", base_key)
         });
-        let zero = Arc::new(zero_like_tensor(base.as_ref(), self.backend));
+        // tidu's PrimitiveBuilder trait has no error channel here; the backward
+        // setup has already validated that backend zero creation is available.
+        let zero = Arc::new(
+            zero_like_tensor(base.as_ref(), self.backend)
+                .expect("eager primitive tangent zero creation"),
+        );
         self.external_data.insert(key.clone(), Arc::clone(&zero));
         zero
     }
@@ -135,22 +140,23 @@ fn missing_tangent_base_key(key: &ValueKey<StdTensorOp>) -> Option<ValueKey<StdT
     Some(ValueKey::Input((**of).clone()))
 }
 
-fn zero_like_tensor<B: TensorBackend>(input: &Tensor, backend: &mut B) -> Tensor {
+fn zero_like_tensor<B: TensorBackend>(
+    input: &Tensor,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
     let host = match input {
-        Tensor::F32(tensor) => Tensor::F32(TypedTensor::zeros(tensor.shape().to_vec())),
-        Tensor::F64(tensor) => Tensor::F64(TypedTensor::zeros(tensor.shape().to_vec())),
-        Tensor::I32(tensor) => Tensor::I32(TypedTensor::zeros(tensor.shape().to_vec())),
-        Tensor::I64(tensor) => Tensor::I64(TypedTensor::zeros(tensor.shape().to_vec())),
+        Tensor::F32(tensor) => Tensor::F32(TypedTensor::zeros(tensor.shape().to_vec())?),
+        Tensor::F64(tensor) => Tensor::F64(TypedTensor::zeros(tensor.shape().to_vec())?),
+        Tensor::I32(tensor) => Tensor::I32(TypedTensor::zeros(tensor.shape().to_vec())?),
+        Tensor::I64(tensor) => Tensor::I64(TypedTensor::zeros(tensor.shape().to_vec())?),
         Tensor::Bool(tensor) => Tensor::Bool(TypedTensor::from_vec_col_major(
             tensor.shape().to_vec(),
             vec![false; tensor.n_elements()],
-        )),
-        Tensor::C32(tensor) => Tensor::C32(TypedTensor::zeros(tensor.shape().to_vec())),
-        Tensor::C64(tensor) => Tensor::C64(TypedTensor::zeros(tensor.shape().to_vec())),
+        )?),
+        Tensor::C32(tensor) => Tensor::C32(TypedTensor::zeros(tensor.shape().to_vec())?),
+        Tensor::C64(tensor) => Tensor::C64(TypedTensor::zeros(tensor.shape().to_vec())?),
     };
-    backend
-        .upload_host_tensor(&host)
-        .unwrap_or_else(|err| panic!("eager primitive zero_like upload failed: {}", err))
+    backend.upload_host_tensor(&host)
 }
 
 #[cfg(test)]

--- a/crates/tenferro-ad/src/eager_builder/tests.rs
+++ b/crates/tenferro-ad/src/eager_builder/tests.rs
@@ -17,7 +17,9 @@ use super::{missing_tangent_base_key, zero_like_tensor, EagerPrimitiveBuilder};
 fn debug_summarizes_builder_without_tensor_payloads() {
     let mut backend = CpuBackend::new();
     let mut builder = EagerPrimitiveBuilder::new(&mut backend);
-    let id = builder.push_tensor(Arc::new(Tensor::from_vec_col_major(vec![1], vec![1.0_f64])));
+    let id = builder.push_tensor(Arc::new(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+    ));
     let _tensor = builder.tensor(id);
 
     let debug = format!("{builder:?}");
@@ -43,14 +45,12 @@ fn debug_reports_extension_executor_presence() {
 fn new_builder_executes_standard_primitives_without_extension_executor() {
     let mut backend = CpuBackend::new();
     let mut builder = EagerPrimitiveBuilder::new(&mut backend);
-    let lhs = builder.push_tensor(Arc::new(Tensor::from_vec_col_major(
-        vec![2],
-        vec![1.0_f64, 2.0],
-    )));
-    let rhs = builder.push_tensor(Arc::new(Tensor::from_vec_col_major(
-        vec![2],
-        vec![3.0_f64, 4.0],
-    )));
+    let lhs = builder.push_tensor(Arc::new(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
+    ));
+    let rhs = builder.push_tensor(Arc::new(
+        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(),
+    ));
 
     let outputs = PrimitiveBuilder::add_primitive(
         &mut builder,
@@ -75,7 +75,7 @@ fn missing_tangent_external_uses_zero_like_primal_fallback() {
     let tangent_key = ValueKey::Input(primal_input.tangent_of(3));
     builder.external_data.insert(
         primal_key,
-        Arc::new(Tensor::from_vec_col_major(vec![2], vec![5.0_f64, 7.0])),
+        Arc::new(Tensor::from_vec_col_major(vec![2], vec![5.0_f64, 7.0]).unwrap()),
     );
 
     let outputs = PrimitiveBuilder::add_primitive(
@@ -115,54 +115,55 @@ fn missing_tangent_base_key_accepts_only_input_tangent_keys() {
 
 #[test]
 fn zero_like_tensor_covers_all_dtypes() {
-    assert_zero_like_matches(Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![1.0_f32, -2.0],
-    )));
-    assert_zero_like_matches(Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![1.0_f64, -2.0],
-    )));
-    assert_zero_like_matches(Tensor::I32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![1_i32, -2],
-    )));
-    assert_zero_like_matches(Tensor::I64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![1_i64, -2],
-    )));
-    assert_zero_like_matches(Tensor::Bool(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![true, false],
-    )));
-    assert_zero_like_matches(Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(1.0, 2.0), Complex32::new(-3.0, 4.0)],
-    )));
-    assert_zero_like_matches(Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 4.0)],
-    )));
+    assert_zero_like_matches(Tensor::F32(
+        TypedTensor::from_vec_col_major(vec![2], vec![1.0_f32, -2.0]).unwrap(),
+    ));
+    assert_zero_like_matches(Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2], vec![1.0_f64, -2.0]).unwrap(),
+    ));
+    assert_zero_like_matches(Tensor::I32(
+        TypedTensor::from_vec_col_major(vec![2], vec![1_i32, -2]).unwrap(),
+    ));
+    assert_zero_like_matches(Tensor::I64(
+        TypedTensor::from_vec_col_major(vec![2], vec![1_i64, -2]).unwrap(),
+    ));
+    assert_zero_like_matches(Tensor::Bool(
+        TypedTensor::from_vec_col_major(vec![2], vec![true, false]).unwrap(),
+    ));
+    assert_zero_like_matches(Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex32::new(1.0, 2.0), Complex32::new(-3.0, 4.0)],
+        )
+        .unwrap(),
+    ));
+    assert_zero_like_matches(Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 4.0)],
+        )
+        .unwrap(),
+    ));
 }
 
 fn assert_zero_like_matches(input: Tensor) {
     let shape = input.shape().to_vec();
     let mut backend = CpuBackend::new();
-    let zero = zero_like_tensor(&input, &mut backend);
+    let zero = zero_like_tensor(&input, &mut backend).unwrap();
 
     assert_eq!(zero.shape(), shape.as_slice());
     match zero {
-        Tensor::F32(tensor) => assert_eq!(tensor.as_slice(), &[0.0_f32, 0.0]),
-        Tensor::F64(tensor) => assert_eq!(tensor.as_slice(), &[0.0_f64, 0.0]),
-        Tensor::I32(tensor) => assert_eq!(tensor.as_slice(), &[0_i32, 0]),
-        Tensor::I64(tensor) => assert_eq!(tensor.as_slice(), &[0_i64, 0]),
-        Tensor::Bool(tensor) => assert_eq!(tensor.as_slice(), &[false, false]),
+        Tensor::F32(tensor) => assert_eq!(tensor.as_slice().unwrap(), &[0.0_f32, 0.0]),
+        Tensor::F64(tensor) => assert_eq!(tensor.as_slice().unwrap(), &[0.0_f64, 0.0]),
+        Tensor::I32(tensor) => assert_eq!(tensor.as_slice().unwrap(), &[0_i32, 0]),
+        Tensor::I64(tensor) => assert_eq!(tensor.as_slice().unwrap(), &[0_i64, 0]),
+        Tensor::Bool(tensor) => assert_eq!(tensor.as_slice().unwrap(), &[false, false]),
         Tensor::C32(tensor) => assert_eq!(
-            tensor.as_slice(),
+            tensor.as_slice().unwrap(),
             &[Complex32::new(0.0, 0.0), Complex32::new(0.0, 0.0)]
         ),
         Tensor::C64(tensor) => assert_eq!(
-            tensor.as_slice(),
+            tensor.as_slice().unwrap(),
             &[Complex64::new(0.0, 0.0), Complex64::new(0.0, 0.0)]
         ),
     }

--- a/crates/tenferro-ad/src/eager_exec.rs
+++ b/crates/tenferro-ad/src/eager_exec.rs
@@ -92,14 +92,14 @@ fn promote_binary<'a>(
 }
 
 fn materialize_tensor_read(input: TensorRead<'_>) -> Result<Tensor> {
-    input.try_to_tensor().map_err(Error::from)
+    input.to_tensor().map_err(Error::from)
 }
 
 fn concrete_tensor_read(input: TensorRead<'_>) -> Result<ConcreteTensorRead<'_>> {
     match input {
         TensorRead::Tensor(tensor) => Ok(ConcreteTensorRead::Borrowed(tensor)),
         TensorRead::View(view) => Ok(ConcreteTensorRead::Owned(Box::new(
-            view.try_to_tensor().map_err(Error::from)?,
+            view.to_tensor().map_err(Error::from)?,
         ))),
     }
 }
@@ -295,7 +295,7 @@ fn shape_of_host_tensor(axis: usize, shape: &[usize]) -> Result<Tensor> {
     Ok(Tensor::F64(TypedTensor::from_vec_col_major(
         vec![],
         vec![size],
-    )))
+    )?))
 }
 
 fn execute_generated_host_output_on_backend_reads<B: TensorBackend>(
@@ -304,7 +304,7 @@ fn execute_generated_host_output_on_backend_reads<B: TensorBackend>(
     backend: &mut B,
 ) -> Result<Option<Tensor>> {
     let host = match op {
-        StdTensorOp::Constant { dtype, bytes } => constant_tensor(*dtype, bytes),
+        StdTensorOp::Constant { dtype, bytes } => constant_tensor(*dtype, bytes)?,
         StdTensorOp::ShapeOf { axis } => shape_of_host_tensor(*axis, inputs[0].shape())?,
         _ => return Ok(None),
     };
@@ -317,7 +317,7 @@ fn execute_generated_host_output_on_backend_tensors<B: TensorBackend>(
     backend: &mut B,
 ) -> Result<Option<Tensor>> {
     let host = match op {
-        StdTensorOp::Constant { dtype, bytes } => constant_tensor(*dtype, bytes),
+        StdTensorOp::Constant { dtype, bytes } => constant_tensor(*dtype, bytes)?,
         StdTensorOp::ShapeOf { axis } => shape_of_host_tensor(*axis, inputs[0].shape())?,
         _ => return Ok(None),
     };
@@ -786,7 +786,7 @@ fn exec_standard_op_on_tensors<B: TensorBackend>(
 
 fn resolve_tensor_shape_exprs(inputs: &[&Tensor], exprs: &[DimExpr]) -> Result<Vec<usize>> {
     let input_shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
-    DimExpr::try_eval_all(exprs, &input_shapes).map_err(|err| {
+    DimExpr::eval_all(exprs, &input_shapes).map_err(|err| {
         invalid_config(
             "eager shape expression",
             format!("failed to resolve eager shape expression: {err}"),
@@ -799,7 +799,7 @@ fn resolve_tensor_read_shape_exprs(
     exprs: &[DimExpr],
 ) -> Result<Vec<usize>> {
     let input_shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
-    DimExpr::try_eval_all(exprs, &input_shapes).map_err(|err| {
+    DimExpr::eval_all(exprs, &input_shapes).map_err(|err| {
         invalid_config(
             "eager shape expression",
             format!("failed to resolve eager shape expression: {err}"),
@@ -807,30 +807,30 @@ fn resolve_tensor_read_shape_exprs(
     })
 }
 
-fn constant_tensor(dtype: DType, bytes: &[u8]) -> Tensor {
-    match dtype {
+fn constant_tensor(dtype: DType, bytes: &[u8]) -> Result<Tensor> {
+    Ok(match dtype {
         DType::F64 => Tensor::F64(TypedTensor::from_vec_col_major(
             vec![],
-            vec![f64::from_le_bytes(exact_bytes::<8>(dtype, bytes))],
-        )),
+            vec![f64::from_le_bytes(exact_bytes::<8>(dtype, bytes)?)],
+        )?),
         DType::F32 => Tensor::F32(TypedTensor::from_vec_col_major(
             vec![],
-            vec![f32::from_le_bytes(exact_bytes::<4>(dtype, bytes))],
-        )),
+            vec![f32::from_le_bytes(exact_bytes::<4>(dtype, bytes)?)],
+        )?),
         DType::I32 => Tensor::I32(TypedTensor::from_vec_col_major(
             vec![],
-            vec![i32::from_le_bytes(exact_bytes::<4>(dtype, bytes))],
-        )),
+            vec![i32::from_le_bytes(exact_bytes::<4>(dtype, bytes)?)],
+        )?),
         DType::I64 => Tensor::I64(TypedTensor::from_vec_col_major(
             vec![],
-            vec![i64::from_le_bytes(exact_bytes::<8>(dtype, bytes))],
-        )),
+            vec![i64::from_le_bytes(exact_bytes::<8>(dtype, bytes)?)],
+        )?),
         DType::Bool => Tensor::Bool(TypedTensor::from_vec_col_major(
             vec![],
-            vec![exact_bytes::<1>(dtype, bytes)[0] != 0],
-        )),
+            vec![exact_bytes::<1>(dtype, bytes)?[0] != 0],
+        )?),
         DType::C64 => {
-            let data = exact_bytes::<16>(dtype, bytes);
+            let data = exact_bytes::<16>(dtype, bytes)?;
             let mut re_bytes = [0u8; 8];
             let mut im_bytes = [0u8; 8];
             re_bytes.copy_from_slice(&data[..8]);
@@ -840,10 +840,10 @@ fn constant_tensor(dtype: DType, bytes: &[u8]) -> Tensor {
             Tensor::C64(TypedTensor::from_vec_col_major(
                 vec![],
                 vec![Complex64::new(re, im)],
-            ))
+            )?)
         }
         DType::C32 => {
-            let data = exact_bytes::<8>(dtype, bytes);
+            let data = exact_bytes::<8>(dtype, bytes)?;
             let mut re_bytes = [0u8; 4];
             let mut im_bytes = [0u8; 4];
             re_bytes.copy_from_slice(&data[..4]);
@@ -853,23 +853,26 @@ fn constant_tensor(dtype: DType, bytes: &[u8]) -> Tensor {
             Tensor::C32(TypedTensor::from_vec_col_major(
                 vec![],
                 vec![Complex32::new(re, im)],
-            ))
+            )?)
         }
-    }
+    })
 }
 
-fn exact_bytes<const N: usize>(dtype: DType, bytes: &[u8]) -> [u8; N] {
+fn exact_bytes<const N: usize>(dtype: DType, bytes: &[u8]) -> Result<[u8; N]> {
     if bytes.len() != N {
-        panic!(
-            "constant {:?} expected {} bytes, got {}",
-            dtype,
-            N,
-            bytes.len()
-        );
+        return Err(invalid_config(
+            "Constant",
+            format!(
+                "constant {:?} expected {} bytes, got {}",
+                dtype,
+                N,
+                bytes.len()
+            ),
+        ));
     }
     let mut out = [0u8; N];
     out.copy_from_slice(bytes);
-    out
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/crates/tenferro-ad/src/eager_exec/tests.rs
+++ b/crates/tenferro-ad/src/eager_exec/tests.rs
@@ -16,7 +16,7 @@ use tenferro_ops::SymDim;
 use tenferro_tensor::{DType, Tensor, TypedTensor};
 
 fn f64t(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn scalar(v: f64) -> Tensor {
@@ -24,12 +24,12 @@ fn scalar(v: f64) -> Tensor {
 }
 
 fn i64_scalar(v: i64) -> Tensor {
-    Tensor::I64(TypedTensor::from_vec_col_major(vec![], vec![v]))
+    Tensor::I64(TypedTensor::from_vec_col_major(vec![], vec![v]).unwrap())
 }
 
 fn data(t: &Tensor) -> Vec<f64> {
     match t {
-        Tensor::F64(inner) => inner.host_data().to_vec(),
+        Tensor::F64(inner) => inner.host_data().unwrap().to_vec(),
         _ => panic!("expected F64"),
     }
 }

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -716,7 +716,7 @@ impl EagerTensor {
             return Ok(Self::new_untracked_value_result(ctx, value));
         }
 
-        let output = Arc::new(value.try_to_tensor().map_err(Error::from)?);
+        let output = Arc::new(value.to_tensor().map_err(Error::from)?);
         let outputs = vec![Arc::clone(&output)];
         let mut recorded = record_eager_outputs(&op, &outputs, tensors)?;
         let trace = recorded.traces.pop().ok_or_else(|| {

--- a/crates/tenferro-ad/src/eager_tensor.rs
+++ b/crates/tenferro-ad/src/eager_tensor.rs
@@ -242,14 +242,14 @@ pub fn apply_standard_graph(
     EagerTensor::standard_graph_op(inputs, build_graph)
 }
 
-/// Try a backend fused broadcast-multiply for untracked eager tensors.
+/// Execute a backend fused broadcast-multiply for untracked eager tensors.
 ///
 /// Returns `None` when either input participates in AD or the backend does not
 /// provide a fused implementation, so callers can fall back to ordinary eager
 /// `StdTensorOp` execution without changing gradients.
 #[doc(hidden)]
 #[allow(clippy::too_many_arguments)]
-pub fn try_backend_broadcast_multiply_untracked(
+pub fn backend_broadcast_multiply_untracked(
     lhs: &EagerTensor,
     lhs_shape: &[usize],
     lhs_dims: &[usize],

--- a/crates/tenferro-ad/src/extension.rs
+++ b/crates/tenferro-ad/src/extension.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use computegraph::GraphOperation;
-use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_runtime::ad_support::push_metadata_scope;
 use tenferro_runtime::{Error, Result};
@@ -11,15 +10,10 @@ use tenferro_tensor::Tensor;
 
 use crate::eager::{record_eager_outputs, EagerTensor};
 
-pub use tenferro_ops::ext_op::ExtensionAdRule as ExtensionAdRuleTrait;
-pub use tenferro_ops::ext_op::{
-    is_extension_rule_registered, lookup_extension_rule, register_extension_rule,
-    ExtensionAdRule as _ExtensionAdRuleReexport, ExtensionOp as _ExtensionOpReexport,
-    ExtensionRegistryError, ExtensionRuleSet,
-};
+pub use tenferro_ops::ext_op::{ExtensionAdRule, ExtensionRegistryError, ExtensionRuleSet};
 pub use tenferro_runtime::extension::{
     apply, ExtensionCacheKey, ExtensionCacheLimits, ExtensionCacheSelector, ExtensionCacheStore,
-    ExtensionExecutionContext, ExtensionExecutor, ExtensionFamilyId, ExtensionOpTrait,
+    ExtensionExecutionContext, ExtensionExecutor, ExtensionFamilyId, ExtensionOp,
     ExtensionRegistry, ExtensionRuntime, ExtensionRuntimeRegistryError,
 };
 

--- a/crates/tenferro-ad/src/lib.rs
+++ b/crates/tenferro-ad/src/lib.rs
@@ -66,6 +66,6 @@ pub(crate) mod metadata {
     pub use tenferro_runtime::ad_support::{
         metadata_scopes_for_scope, push_metadata_scope, register_scoped_live_graph_metadata,
         register_scoped_metadata_batch, register_scoped_value_metadata, tensor_meta_from_tensor,
-        MetadataScope,
+        GlobalMetadataScope,
     };
 }

--- a/crates/tenferro-ad/src/shape_packing.rs
+++ b/crates/tenferro-ad/src/shape_packing.rs
@@ -68,7 +68,7 @@ fn index_select_config(
     let indices = Tensor::I64(TypedTensor::from_vec_col_major(
         vec![positions.len(), 1],
         index_data,
-    ));
+    )?);
 
     let config = GatherConfig {
         offset_dims,

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -16,7 +16,7 @@ use tenferro_runtime::ad_support::{
 };
 use tenferro_runtime::{Error, GraphCompiler, GraphExecutor, Result, TracedTensor};
 use tenferro_tensor::TensorBackend;
-use tidu::{try_linear_transpose, try_linearize, ADRuleError};
+use tidu::{linear_transpose, linearize, ADRuleError};
 
 static NEXT_DIFF_PASS_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -25,7 +25,7 @@ fn next_pass_id() -> u64 {
 }
 
 pub(crate) fn next_input_key() -> TensorInputKey {
-    tenferro_runtime::ad_support::fresh_input_key()
+    tenferro_runtime::ad_support::allocate_input_key()
 }
 
 fn error_shape_hint(tensor: &TracedTensor) -> Vec<usize> {
@@ -42,11 +42,15 @@ fn shape_guard_context(extension_rules: Option<&ExtensionRuleSet>) -> ShapeGuard
     }
 }
 
-fn vjp_error_from_linearize(err: ADRuleError) -> Error {
+fn ad_rule_error(transform: &'static str, err: ADRuleError) -> Error {
     match err {
         ADRuleError::Unsupported { op, .. } => {
-            Error::Internal(format!("unsupported vjp AD rule for {op}"))
+            Error::Internal(format!("unsupported {transform} AD rule for {op}"))
         }
+        ADRuleError::InvalidInput { op, message, .. } => Error::InvalidGraphBuild {
+            op: transform,
+            message: format!("{op}: {message}"),
+        },
     }
 }
 
@@ -64,12 +68,9 @@ pub(crate) fn jvp_with_rules(
     tangent: &TracedTensor,
     extension_rules: &ExtensionRuleSet,
 ) -> Result<TracedTensor> {
-    jvp_optional_result_with_rules(output, wrt, tangent, Some(extension_rules))?.ok_or_else(|| {
-        Error::Internal(format!(
-            "jvp output is inactive for {:?}",
-            leaf_input_key(wrt)
-        ))
-    })
+    let wrt_input_key = leaf_input_key(wrt)?;
+    jvp_optional_impl(output, wrt, tangent, Some(extension_rules))?
+        .ok_or_else(|| Error::Internal(format!("jvp output is inactive for {:?}", wrt_input_key)))
 }
 
 pub(crate) fn grad_optional_with_rules(
@@ -83,9 +84,9 @@ pub(crate) fn grad_optional_with_rules(
         });
     }
 
-    let ones = ones_tensor(output.dtype, vec![]);
+    let ones = ones_tensor(output.dtype, vec![])?;
     let seed = TracedTensor::from_tensor_concrete_shape(ones);
-    vjp_optional_result_with_rules(output, wrt, &seed, Some(extension_rules))
+    vjp_optional_impl(output, wrt, &seed, Some(extension_rules))
 }
 
 pub(crate) fn jvp_optional_with_rules(
@@ -94,7 +95,7 @@ pub(crate) fn jvp_optional_with_rules(
     tangent: &TracedTensor,
     extension_rules: &ExtensionRuleSet,
 ) -> Result<Option<TracedTensor>> {
-    jvp_optional_result_with_rules(output, wrt, tangent, Some(extension_rules))
+    jvp_optional_impl(output, wrt, tangent, Some(extension_rules))
 }
 
 pub(crate) fn vjp_with_rules(
@@ -103,14 +104,9 @@ pub(crate) fn vjp_with_rules(
     cotangent: &TracedTensor,
     extension_rules: &ExtensionRuleSet,
 ) -> Result<TracedTensor> {
-    vjp_optional_result_with_rules(output, wrt, cotangent, Some(extension_rules))?.ok_or_else(
-        || {
-            Error::Internal(format!(
-                "vjp output is inactive for {:?}",
-                leaf_input_key(wrt)
-            ))
-        },
-    )
+    let wrt_input_key = leaf_input_key(wrt)?;
+    vjp_optional_impl(output, wrt, cotangent, Some(extension_rules))?
+        .ok_or_else(|| Error::Internal(format!("vjp output is inactive for {:?}", wrt_input_key)))
 }
 
 pub(crate) fn vjp_optional_with_rules(
@@ -119,7 +115,7 @@ pub(crate) fn vjp_optional_with_rules(
     cotangent: &TracedTensor,
     extension_rules: &ExtensionRuleSet,
 ) -> Result<Option<TracedTensor>> {
-    vjp_optional_result_with_rules(output, wrt, cotangent, Some(extension_rules))
+    vjp_optional_impl(output, wrt, cotangent, Some(extension_rules))
 }
 
 fn grad_with_optional_rules(
@@ -133,14 +129,11 @@ fn grad_with_optional_rules(
         });
     }
 
-    let ones = ones_tensor(output.dtype, vec![]);
+    let ones = ones_tensor(output.dtype, vec![])?;
     let seed = TracedTensor::from_tensor_concrete_shape(ones);
-    vjp_optional_result_with_rules(output, wrt, &seed, extension_rules)?.ok_or_else(|| {
-        Error::Internal(format!(
-            "grad output is inactive for {:?}",
-            leaf_input_key(wrt)
-        ))
-    })
+    let wrt_input_key = leaf_input_key(wrt)?;
+    vjp_optional_impl(output, wrt, &seed, extension_rules)?
+        .ok_or_else(|| Error::Internal(format!("grad output is inactive for {:?}", wrt_input_key)))
 }
 
 /// Automatic differentiation helpers for [`TracedTensor`].
@@ -274,39 +267,6 @@ pub trait TracedTensorAdExt {
         tangent: &TracedTensor,
     ) -> Result<Option<TracedTensor>>;
 
-    /// Fallible forward-mode Jacobian-vector product.
-    ///
-    /// This is an alias for [`jvp_optional`](Self::jvp_optional), retained for
-    /// callers that adopted the explicit fallible name before the compact
-    /// method became fallible.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_ad::TracedTensorAdExt;
-    /// use tenferro_cpu::CpuBackend;
-    /// use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
-    ///
-    /// fn eval(tensor: &TracedTensor) -> tenferro_runtime::Tensor {
-    ///     let mut compiler = GraphCompiler::new();
-    ///     let program = compiler.compile(tensor).unwrap();
-    ///     let mut executor = GraphExecutor::new(CpuBackend::new());
-    ///     executor.run(&program).unwrap()
-    /// }
-    ///
-    /// let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]);
-    /// let tangent = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]);
-    /// let y = &x * &x;
-    /// let dy = y.jvp_optional_result(&x, &tangent).unwrap().unwrap();
-    ///
-    /// assert_eq!(eval(&dy).as_slice::<f64>().unwrap(), &[12.0]);
-    /// ```
-    fn jvp_optional_result(
-        &self,
-        wrt: &TracedTensor,
-        tangent: &TracedTensor,
-    ) -> Result<Option<TracedTensor>>;
-
     /// Reverse-mode vector-Jacobian product.
     ///
     /// Complex cotangents use tenferro's Hermitian real-inner-product
@@ -357,44 +317,6 @@ pub trait TracedTensorAdExt {
         wrt: &TracedTensor,
         cotangent: &TracedTensor,
     ) -> Result<Option<TracedTensor>>;
-
-    /// Fallible reverse-mode vector-Jacobian product.
-    ///
-    /// This is an alias for [`vjp_optional`](Self::vjp_optional), retained for
-    /// callers that adopted the explicit fallible name before the compact
-    /// method became fallible.
-    ///
-    /// Complex cotangents use tenferro's Hermitian real-inner-product
-    /// convention. Non-real complex cotangent seeds therefore need an explicit
-    /// seed-convention comparison when matching JAX. See
-    /// <https://tensor4all.org/tenferro-rs/guides/complex-ad.html>.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_ad::TracedTensorAdExt;
-    /// use tenferro_cpu::CpuBackend;
-    /// use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
-    ///
-    /// fn eval(tensor: &TracedTensor) -> tenferro_runtime::Tensor {
-    ///     let mut compiler = GraphCompiler::new();
-    ///     let program = compiler.compile(tensor).unwrap();
-    ///     let mut executor = GraphExecutor::new(CpuBackend::new());
-    ///     executor.run(&program).unwrap()
-    /// }
-    ///
-    /// let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]);
-    /// let cotangent = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]);
-    /// let y = &x * &x;
-    /// let dx = y.vjp_optional_result(&x, &cotangent).unwrap().unwrap();
-    ///
-    /// assert_eq!(eval(&dx).as_slice::<f64>().unwrap(), &[12.0]);
-    /// ```
-    fn vjp_optional_result(
-        &self,
-        wrt: &TracedTensor,
-        cotangent: &TracedTensor,
-    ) -> Result<Option<TracedTensor>>;
 }
 
 impl TracedTensorAdExt for TracedTensor {
@@ -409,9 +331,9 @@ impl TracedTensorAdExt for TracedTensor {
             });
         }
 
-        let ones = ones_tensor(self.dtype, vec![]);
+        let ones = ones_tensor(self.dtype, vec![])?;
         let seed = TracedTensor::from_tensor_concrete_shape(ones);
-        vjp_optional_result_with_rules(self, wrt, &seed, None)
+        vjp_optional_impl(self, wrt, &seed, None)
     }
 
     fn checkpoint<B: TensorBackend>(
@@ -430,11 +352,9 @@ impl TracedTensorAdExt for TracedTensor {
     }
 
     fn jvp(&self, wrt: &TracedTensor, tangent: &TracedTensor) -> Result<TracedTensor> {
+        let wrt_input_key = leaf_input_key(wrt)?;
         self.jvp_optional(wrt, tangent)?.ok_or_else(|| {
-            Error::Internal(format!(
-                "jvp output is inactive for {:?}",
-                leaf_input_key(wrt)
-            ))
+            Error::Internal(format!("jvp output is inactive for {:?}", wrt_input_key))
         })
     }
 
@@ -443,23 +363,13 @@ impl TracedTensorAdExt for TracedTensor {
         wrt: &TracedTensor,
         tangent: &TracedTensor,
     ) -> Result<Option<TracedTensor>> {
-        self.jvp_optional_result(wrt, tangent)
-    }
-
-    fn jvp_optional_result(
-        &self,
-        wrt: &TracedTensor,
-        tangent: &TracedTensor,
-    ) -> Result<Option<TracedTensor>> {
-        jvp_optional_result_with_rules(self, wrt, tangent, None)
+        jvp_optional_impl(self, wrt, tangent, None)
     }
 
     fn vjp(&self, wrt: &TracedTensor, cotangent: &TracedTensor) -> Result<TracedTensor> {
+        let wrt_input_key = leaf_input_key(wrt)?;
         self.vjp_optional(wrt, cotangent)?.ok_or_else(|| {
-            Error::Internal(format!(
-                "vjp output is inactive for {:?}",
-                leaf_input_key(wrt)
-            ))
+            Error::Internal(format!("vjp output is inactive for {:?}", wrt_input_key))
         })
     }
 
@@ -468,25 +378,17 @@ impl TracedTensorAdExt for TracedTensor {
         wrt: &TracedTensor,
         cotangent: &TracedTensor,
     ) -> Result<Option<TracedTensor>> {
-        self.vjp_optional_result(wrt, cotangent)
-    }
-
-    fn vjp_optional_result(
-        &self,
-        wrt: &TracedTensor,
-        cotangent: &TracedTensor,
-    ) -> Result<Option<TracedTensor>> {
-        vjp_optional_result_with_rules(self, wrt, cotangent, None)
+        vjp_optional_impl(self, wrt, cotangent, None)
     }
 }
 
-fn jvp_optional_result_with_rules(
+fn jvp_optional_impl(
     output: &TracedTensor,
     wrt: &TracedTensor,
     tangent: &TracedTensor,
     extension_rules: Option<&ExtensionRuleSet>,
 ) -> Result<Option<TracedTensor>> {
-    let wrt_input_key = leaf_input_key(wrt);
+    let wrt_input_key = leaf_input_key(wrt)?;
     let output_key = output.graph().values()[output.val].key.clone();
     let checkpoint_chain = tensor_checkpoint_chain(output);
     let aliases = checkpoint_chain
@@ -501,7 +403,7 @@ fn jvp_optional_result_with_rules(
     roots.extend(checkpoint_graphs.iter().cloned());
     let view = resolve(roots);
     let mut ad_ctx = shape_guard_context(extension_rules);
-    let linear = try_linearize(
+    let linear = linearize(
         &view,
         std::slice::from_ref(&output_key),
         std::slice::from_ref(&wrt_input_key),
@@ -509,11 +411,11 @@ fn jvp_optional_result_with_rules(
         &mut ad_ctx,
         &aliases,
     )
-    .map_err(|err| Error::Internal(err.to_string()))?;
+    .map_err(|err| ad_rule_error("jvp", err))?;
     let Some(tangent_output) = linear.tangent_outputs()[0] else {
         return Ok(None);
     };
-    let tangent_input_key = linear_input_key(linear.as_graph(), linear.tangent_inputs()[0].1);
+    let tangent_input_key = linear_input_key(linear.as_graph(), linear.tangent_inputs()[0].1)?;
     let tangent_data =
         tangent
             .attached_data()
@@ -528,7 +430,7 @@ fn jvp_optional_result_with_rules(
             ValueKey::Input(tangent_input_key.clone()),
             tensor_meta_from_tensor(tangent_data.as_ref()),
         )],
-    );
+    )?;
 
     let mut inputs_map = (*tensor_inputs_map(output)).clone();
     if let Some(chain) = &checkpoint_chain {
@@ -561,13 +463,13 @@ fn jvp_optional_result_with_rules(
     })))
 }
 
-fn vjp_optional_result_with_rules(
+fn vjp_optional_impl(
     output: &TracedTensor,
     wrt: &TracedTensor,
     cotangent: &TracedTensor,
     extension_rules: Option<&ExtensionRuleSet>,
 ) -> Result<Option<TracedTensor>> {
-    let wrt_input_key = leaf_input_key(wrt);
+    let wrt_input_key = leaf_input_key(wrt)?;
     let output_key = output.graph().values()[output.val].key.clone();
     let checkpoint_chain = tensor_checkpoint_chain(output);
     let aliases = checkpoint_chain
@@ -582,7 +484,7 @@ fn vjp_optional_result_with_rules(
     roots.extend(checkpoint_graphs.iter().cloned());
     let view = resolve(roots);
     let mut ad_ctx = shape_guard_context(extension_rules);
-    let linear = try_linearize(
+    let linear = linearize(
         &view,
         std::slice::from_ref(&output_key),
         std::slice::from_ref(&wrt_input_key),
@@ -590,23 +492,23 @@ fn vjp_optional_result_with_rules(
         &mut ad_ctx,
         &aliases,
     )
-    .map_err(vjp_error_from_linearize)?;
+    .map_err(|err| ad_rule_error("vjp", err))?;
     if linear.tangent_outputs()[0].is_none() {
         return Ok(None);
     }
-    let linear_seed_key = linear_input_key(linear.as_graph(), linear.tangent_inputs()[0].1);
+    let linear_seed_key = linear_input_key(linear.as_graph(), linear.tangent_inputs()[0].1)?;
     let linear_metadata_scope = register_scoped_graph_metadata(
         linear.as_graph(),
         vec![(
             ValueKey::Input(linear_seed_key),
-            registered_meta(&wrt.graph().values()[wrt.val].key),
+            registered_meta(&wrt.graph().values()[wrt.val].key)?,
         )],
-    );
+    )?;
     ad_ctx.refresh_global_metadata();
-    let transposed = try_linear_transpose(&linear, &mut ad_ctx)
-        .map_err(|err| Error::Internal(err.to_string()))?;
+    let transposed =
+        linear_transpose(&linear, &mut ad_ctx).map_err(|err| ad_rule_error("vjp", err))?;
     let cotangent_input_key =
-        linear_input_key(transposed.as_graph(), transposed.tangent_inputs()[0].1);
+        linear_input_key(transposed.as_graph(), transposed.tangent_inputs()[0].1)?;
     let cotangent_data =
         cotangent
             .attached_data()
@@ -621,7 +523,7 @@ fn vjp_optional_result_with_rules(
             ValueKey::Input(cotangent_input_key.clone()),
             tensor_meta_from_tensor(cotangent_data.as_ref()),
         )],
-    );
+    )?;
     let linear_graph = Arc::new(linear.into_graph());
     let Some(cotangent_output) = transposed.tangent_outputs()[0] else {
         return Ok(None);

--- a/crates/tenferro-ad/tests/ad.rs
+++ b/crates/tenferro-ad/tests/ad.rs
@@ -99,31 +99,31 @@ fn finite_diff_tensor_directional(
 }
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn i64_tensor(shape: Vec<usize>, data: Vec<i64>) -> Tensor {
-    Tensor::I64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::I64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn bool_tensor(shape: Vec<usize>, data: Vec<bool>) -> Tensor {
-    Tensor::Bool(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::Bool(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn c64_tensor(shape: Vec<usize>, data: Vec<Complex64>) -> Tensor {
-    Tensor::C64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::C64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn get_f64_data(tensor: &Tensor) -> &[f64] {
     match tensor {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner.host_data().unwrap(),
         _ => panic!("expected f64 tensor"),
     }
 }
 
 fn get_c64_data(tensor: &Tensor) -> &[Complex64] {
     match tensor {
-        Tensor::C64(inner) => inner.host_data(),
+        Tensor::C64(inner) => inner.host_data().unwrap(),
         _ => panic!("expected c64 tensor"),
     }
 }
@@ -155,7 +155,7 @@ fn register_graph_metadata_for_test(
                 match known.get(key).cloned() {
                     Some(meta) => meta,
                     None => {
-                        let meta = lookup_global_metadata(key).unwrap_or_else(|| {
+                        let meta = lookup_global_metadata(key).unwrap().unwrap_or_else(|| {
                             panic!("test metadata registration missing input {:?}", key)
                         });
                         known.insert(key.clone(), meta.clone());
@@ -167,16 +167,18 @@ fn register_graph_metadata_for_test(
         let input_shape_exprs: Vec<Vec<DimExpr>> = input_metas
             .iter()
             .enumerate()
-            .map(|(input_idx, meta)| DimExpr::input_shape(input_idx, meta.shape.len()))
+            .map(|(input_idx, meta)| DimExpr::input_shape(input_idx, meta.rank()))
             .collect();
         let input_shape_refs: Vec<&[DimExpr]> =
             input_shape_exprs.iter().map(Vec::as_slice).collect();
         let input_dtypes: Vec<DType> = input_metas.iter().map(|meta| meta.dtype).collect();
-        let output_dtype = infer_output_dtype(&op_node.operation, &input_dtypes);
-        let resolved_inputs: Vec<&[SymDim]> = input_metas
+        let output_dtype = infer_output_dtype(&op_node.operation, &input_dtypes).unwrap();
+        let resolved_inputs: Vec<Vec<SymDim>> = input_metas
             .iter()
-            .map(|meta| meta.shape.as_slice())
+            .map(|meta| meta.bound_shape().unwrap())
             .collect();
+        let resolved_input_refs: Vec<&[SymDim]> =
+            resolved_inputs.iter().map(Vec::as_slice).collect();
 
         for (&output_id, extents) in op_node
             .outputs
@@ -185,7 +187,7 @@ fn register_graph_metadata_for_test(
         {
             let resolved_extents = extents
                 .into_iter()
-                .map(|extent| extent.map(|dim| SymDim::from_dim_expr(&dim, &resolved_inputs)))
+                .map(|extent| extent.map(|dim| SymDim::from_dim_expr(&dim, &resolved_input_refs)))
                 .collect();
             let meta = TensorMeta::with_extents(output_dtype, resolved_extents);
             let key = graph.values()[output_id].key.clone();
@@ -194,7 +196,7 @@ fn register_graph_metadata_for_test(
         }
     }
 
-    register_scoped_global_metadata_batch(registrations)
+    register_scoped_global_metadata_batch(registrations).unwrap()
 }
 
 fn eval_tensor(traced: TracedTensor) -> Tensor {
@@ -285,7 +287,8 @@ fn grad_from_graph_with_inputs_and_cotangent(
         0,
         &mut ad_ctx,
         &HashMap::new(),
-    );
+    )
+    .unwrap();
     let _linear_metadata_scope = register_graph_metadata_for_test(
         linear.as_graph(),
         vec![(
@@ -299,7 +302,7 @@ fn grad_from_graph_with_inputs_and_cotangent(
         .iter()
         .map(|(_, local_id)| *local_id)
         .collect();
-    let transposed = linear_transpose(&linear, &mut ad_ctx);
+    let transposed = linear_transpose(&linear, &mut ad_ctx).unwrap();
     let linear_graph = Arc::new(linear.into_graph());
     let grad_key = transposed.tangent_outputs()[0]
         .map(|id| transposed.as_graph().values()[id].key.clone())
@@ -342,19 +345,16 @@ fn grad_from_graph_with_inputs_and_cotangent(
 
 fn zeros_by_dtype(dtype: DType, shape: Vec<usize>) -> Tensor {
     match dtype {
-        DType::F32 => Tensor::F32(TypedTensor::zeros(shape)),
-        DType::F64 => Tensor::F64(TypedTensor::zeros(shape)),
-        DType::I32 => Tensor::I32(TypedTensor::zeros(shape)),
-        DType::I64 => Tensor::I64(TypedTensor::zeros(shape)),
+        DType::F32 => Tensor::F32(TypedTensor::zeros(shape).unwrap()),
+        DType::F64 => Tensor::F64(TypedTensor::zeros(shape).unwrap()),
+        DType::I32 => Tensor::I32(TypedTensor::zeros(shape).unwrap()),
+        DType::I64 => Tensor::I64(TypedTensor::zeros(shape).unwrap()),
         DType::Bool => {
             let n_elements = shape.iter().product();
-            Tensor::Bool(TypedTensor::from_vec_col_major(
-                shape,
-                vec![false; n_elements],
-            ))
+            Tensor::Bool(TypedTensor::from_vec_col_major(shape, vec![false; n_elements]).unwrap())
         }
-        DType::C32 => Tensor::C32(TypedTensor::zeros(shape)),
-        DType::C64 => Tensor::C64(TypedTensor::zeros(shape)),
+        DType::C32 => Tensor::C32(TypedTensor::zeros(shape).unwrap()),
+        DType::C64 => Tensor::C64(TypedTensor::zeros(shape).unwrap()),
     }
 }
 
@@ -398,7 +398,8 @@ fn jvp_from_graph_with_inputs(
         0,
         &mut ad_ctx,
         &HashMap::new(),
-    );
+    )
+    .unwrap();
     let _linear_metadata_scope = register_graph_metadata_for_test(
         linear.as_graph(),
         vec![(
@@ -672,7 +673,8 @@ fn transpose_primal_unary_op_with_inputs(
         90_000,
         &mut ad_ctx,
         &HashMap::new(),
-    );
+    )
+    .unwrap();
     let tangent_input_key = input_key.tangent_of(90_000);
     let _linear_metadata_scope = register_graph_metadata_for_test(
         linear.as_graph(),
@@ -682,7 +684,7 @@ fn transpose_primal_unary_op_with_inputs(
         )],
     );
     ad_ctx.refresh_global_metadata();
-    let transposed = linear_transpose(&linear, &mut ad_ctx);
+    let transposed = linear_transpose(&linear, &mut ad_ctx).unwrap();
     let linear_graph = Arc::new(linear.into_graph());
     let cotangent_input_key =
         match &transposed.as_graph().values()[transposed.tangent_inputs()[0].1].key {
@@ -823,8 +825,8 @@ fn assert_grad_matches_finite_diff_rhs(
 #[test]
 fn grad_x_squared() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
-    let y = &x * &x;
-    let loss = y.reduce_sum(&[0]);
+    let y = (&x * &x).unwrap();
+    let loss = y.reduce_sum(&[0]).unwrap();
     assert_eq!(loss.rank, 0);
     let grad = loss.grad(&x).unwrap();
 
@@ -838,8 +840,8 @@ fn grad_extract_diag_sum() {
         vec![3, 3],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
     ));
-    let diag = a.extract_diag(0, 1);
-    let loss = diag.reduce_sum(&[0]);
+    let diag = a.extract_diag(0, 1).unwrap();
+    let loss = diag.reduce_sum(&[0]).unwrap();
     assert_eq!(loss.rank, 0);
     let grad = loss.grad(&a).unwrap();
 
@@ -854,8 +856,8 @@ fn grad_extract_diag_sum() {
 #[test]
 fn grad_embed_diag_sum() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![2.0, -1.0, 4.0]));
-    let diag = x.embed_diag(0, 1);
-    let loss = diag.reduce_sum(&[0, 1]);
+    let diag = x.embed_diag(0, 1).unwrap();
+    let loss = diag.reduce_sum(&[0, 1]).unwrap();
     assert_eq!(loss.rank, 0);
     let grad = loss.grad(&x).unwrap();
 
@@ -875,7 +877,7 @@ fn jvp_extract_diag() {
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
     ));
 
-    let diag = a.extract_diag(0, 1);
+    let diag = a.extract_diag(0, 1).unwrap();
     let jvp = diag.jvp(&a, &da).unwrap();
 
     let result = eval_tensor(jvp);
@@ -888,7 +890,7 @@ fn jvp_embed_diag() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![3.0, 4.0, 5.0]));
     let dx = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![0.5, -1.0, 2.0]));
 
-    let diag = x.embed_diag(0, 1);
+    let diag = x.embed_diag(0, 1).unwrap();
     let jvp = diag.jvp(&x, &dx).unwrap();
 
     let result = eval_tensor(jvp);
@@ -906,7 +908,7 @@ fn grad_matmul_sum() {
 
     let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 3], a_data.clone()));
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], b_data.clone()));
-    let loss = matmul(&a, &b).sum(&[0, 1]);
+    let loss = matmul(&a, &b).unwrap().reduce_sum(&[0, 1]).unwrap();
     assert_eq!(loss.rank, 0);
     let grad = loss.grad(&a).unwrap();
 
@@ -916,7 +918,7 @@ fn grad_matmul_sum() {
     let f = |xs: &[f64]| {
         let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 3], xs.to_vec()));
         let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], b_data.clone()));
-        eval_scalar(matmul(&a, &b).sum(&[0, 1]))
+        eval_scalar(matmul(&a, &b).unwrap().reduce_sum(&[0, 1]).unwrap())
     };
 
     for (index, &grad_value) in grad_data.iter().enumerate().take(a_data.len()) {
@@ -936,8 +938,8 @@ fn grad_matmul_sum_wrt_rhs() {
 
     let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 3], a_data.clone()));
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], b_data.clone()));
-    let matmul = a.dot_general(&b, matmul_config());
-    let loss = matmul.reduce_sum(&[0, 1]);
+    let matmul = a.dot_general(&b, matmul_config()).unwrap();
+    let loss = matmul.reduce_sum(&[0, 1]).unwrap();
     assert_eq!(loss.rank, 0);
     let grad = loss.grad(&b).unwrap();
 
@@ -947,8 +949,8 @@ fn grad_matmul_sum_wrt_rhs() {
     let f = |xs: &[f64]| {
         let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 3], a_data.clone()));
         let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], xs.to_vec()));
-        let matmul = a.dot_general(&b, matmul_config());
-        let loss = matmul.reduce_sum(&[0, 1]);
+        let matmul = a.dot_general(&b, matmul_config()).unwrap();
+        let loss = matmul.reduce_sum(&[0, 1]).unwrap();
         eval_scalar(loss)
     };
 
@@ -967,8 +969,8 @@ fn grad_matmul_sum_shared_input() {
     let a_data = vec![1.0, 2.0, 3.0, 4.0];
 
     let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], a_data.clone()));
-    let matmul = a.dot_general(&a, matmul_config());
-    let loss = matmul.reduce_sum(&[0, 1]);
+    let matmul = a.dot_general(&a, matmul_config()).unwrap();
+    let loss = matmul.reduce_sum(&[0, 1]).unwrap();
     let grad = loss.grad(&a).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -976,8 +978,8 @@ fn grad_matmul_sum_shared_input() {
 
     let f = |xs: &[f64]| {
         let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], xs.to_vec()));
-        let matmul = a.dot_general(&a, matmul_config());
-        let loss = matmul.reduce_sum(&[0, 1]);
+        let matmul = a.dot_general(&a, matmul_config()).unwrap();
+        let loss = matmul.reduce_sum(&[0, 1]).unwrap();
         eval_scalar(loss)
     };
 
@@ -1000,8 +1002,8 @@ fn grad_batched_matmul_sum() {
 
     let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(a_shape.clone(), a_data.clone()));
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(b_shape.clone(), b_data.clone()));
-    let product = a.dot_general(&b, batched_matmul_config());
-    let loss = product.reduce_sum(&[0, 1, 2]);
+    let product = a.dot_general(&b, batched_matmul_config()).unwrap();
+    let loss = product.reduce_sum(&[0, 1, 2]).unwrap();
     let grad = loss.grad(&a).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -1011,8 +1013,8 @@ fn grad_batched_matmul_sum() {
         let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(a_shape.clone(), xs.to_vec()));
         let b =
             TracedTensor::from_tensor_concrete_shape(f64_tensor(b_shape.clone(), b_data.clone()));
-        let product = a.dot_general(&b, batched_matmul_config());
-        let loss = product.reduce_sum(&[0, 1, 2]);
+        let product = a.dot_general(&b, batched_matmul_config()).unwrap();
+        let loss = product.reduce_sum(&[0, 1, 2]).unwrap();
         eval_scalar(loss)
     };
 
@@ -1030,7 +1032,7 @@ fn grad_batched_matmul_sum() {
 fn grad_mul_sum_wrt_both_inputs() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
     let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![4.0, 5.0, 6.0]));
-    let loss = (&x * &y).reduce_sum(&[0]);
+    let loss = (&x * &y).unwrap().reduce_sum(&[0]).unwrap();
 
     let grad_x = loss.grad(&x).unwrap();
     let grad_y = loss.grad(&y).unwrap();
@@ -1047,7 +1049,7 @@ fn jvp_elementwise_mul() {
     let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![4.0, 5.0, 6.0]));
     let dx = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 0.0, 0.0]));
 
-    let prod = &x * &y;
+    let prod = (&x * &y).unwrap();
     let jvp = prod.jvp(&x, &dx).unwrap();
 
     let result = eval_tensor(jvp);
@@ -1060,7 +1062,7 @@ fn jvp_elementwise_mul_y_tangent() {
     let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![4.0, 5.0, 6.0]));
     let dy = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![0.0, -1.0, 2.0]));
 
-    let prod = &x * &y;
+    let prod = (&x * &y).unwrap();
     let jvp = prod.jvp(&y, &dy).unwrap();
 
     let result = eval_tensor(jvp);
@@ -1073,7 +1075,7 @@ fn jvp_elementwise_add_y_tangent() {
     let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![4.0, 5.0, 6.0]));
     let dy = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![0.5, -1.0, 2.0]));
 
-    let sum = &x + &y;
+    let sum = (&x + &y).unwrap();
     let jvp = sum.jvp(&y, &dy).unwrap();
 
     let result = eval_tensor(jvp);
@@ -1083,7 +1085,7 @@ fn jvp_elementwise_add_y_tangent() {
 #[test]
 fn grad_neg_sum() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, -2.0, 3.0]));
-    let loss = (-&x).reduce_sum(&[0]);
+    let loss = (-&x).reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let result = eval_tensor(grad);
@@ -1096,7 +1098,7 @@ fn grad_conj_sum_complex() {
         vec![2],
         vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
     ));
-    let loss = x.conj().reduce_sum(&[0]);
+    let loss = x.conj().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let result = eval_tensor(grad);
@@ -1114,7 +1116,7 @@ fn scale_real_eval_and_grad_sum() {
     let y_eval = eval_tensor(y);
     assert_close_slice(get_f64_data(&y_eval), &[2.0, 4.0, 6.0]);
 
-    let loss = x.scale_real(2.0).reduce_sum(&[0]);
+    let loss = x.scale_real(2.0).reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
     let grad_eval = eval_tensor(grad);
     assert_close_slice(get_f64_data(&grad_eval), &[2.0, 2.0, 2.0]);
@@ -1135,7 +1137,7 @@ fn scale_complex_eval_and_grad_complex_sum() {
         &[Complex64::new(3.5, -0.5), Complex64::new(-0.75, 4.75)],
     );
 
-    let loss = x.scale_complex(factor).reduce_sum(&[0]);
+    let loss = x.scale_complex(factor).reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
     let grad_eval = eval_tensor(grad);
     assert_close_slice_c64(get_c64_data(&grad_eval), &[factor.conj(), factor.conj()]);
@@ -1235,7 +1237,7 @@ fn elementwise_extrema_ties_split_cotangents_like_jax() {
     let dx = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![10.0, 20.0]));
     let dy = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![30.0, 40.0]));
     let cotangent = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![4.0, 6.0]));
-    let maximum = traced_tensor::maximum(&x, &y);
+    let maximum = traced_tensor::maximum(&x, &y).unwrap();
 
     let max_jvp_x = maximum.jvp(&x, &dx).unwrap();
     let max_jvp_y = maximum.jvp(&y, &dy).unwrap();
@@ -1244,7 +1246,7 @@ fn elementwise_extrema_ties_split_cotangents_like_jax() {
 
     let min_lhs = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![2.0, 3.0]));
     let min_rhs = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![2.0, 4.0]));
-    let minimum = traced_tensor::minimum(&min_lhs, &min_rhs);
+    let minimum = traced_tensor::minimum(&min_lhs, &min_rhs).unwrap();
     let min_vjp_lhs = minimum.vjp(&min_lhs, &cotangent).unwrap();
     let min_vjp_rhs = minimum.vjp(&min_rhs, &cotangent).unwrap();
 
@@ -1286,7 +1288,7 @@ fn clamp_ad_uses_strict_jax_boundary_masks() {
     let cotangent =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![10.0, 20.0, 30.0, 40.0]));
 
-    let clamped = traced_tensor::clamp(&input, &lower, &upper);
+    let clamped = traced_tensor::clamp(&input, &lower, &upper).unwrap();
     let input_jvp = clamped.jvp(&input, &d_input).unwrap();
     let lower_jvp = clamped.jvp(&lower, &d_lower).unwrap();
     let upper_jvp = clamped.jvp(&upper, &d_upper).unwrap();
@@ -1320,7 +1322,7 @@ fn complex_div_and_pow_vjps_conjugate_holomorphic_coefficients() {
     let y = TracedTensor::from_tensor_concrete_shape(c64_tensor(vec![2], y_data.clone()));
     let cotangent =
         TracedTensor::from_tensor_concrete_shape(c64_tensor(vec![2], cotangent_data.clone()));
-    let quotient = x.div(&y);
+    let quotient = x.div(&y).unwrap();
 
     let div_vjp_x = eval_tensor(quotient.vjp(&x, &cotangent).unwrap());
     let div_vjp_y = eval_tensor(quotient.vjp(&y, &cotangent).unwrap());
@@ -1339,7 +1341,7 @@ fn complex_div_and_pow_vjps_conjugate_holomorphic_coefficients() {
     assert_close_slice_c64(get_c64_data(&div_vjp_x), &expected_div_x);
     assert_close_slice_c64(get_c64_data(&div_vjp_y), &expected_div_y);
 
-    let pow = x.pow(&y);
+    let pow = x.pow(&y).unwrap();
     let pow_vjp_x = eval_tensor(pow.vjp(&x, &cotangent).unwrap());
     let pow_vjp_y = eval_tensor(pow.vjp(&y, &cotangent).unwrap());
 
@@ -1790,14 +1792,14 @@ fn convert_ad_treats_integer_and_bool_boundaries_as_inactive_like_jax_float0() {
 
     assert!(
         real.convert(DType::I64)
-            .jvp_optional_result(&real, &real_tangent)
+            .jvp_optional(&real, &real_tangent)
             .unwrap()
             .is_none(),
         "float-to-integer convert has no output tangent"
     );
     assert!(
         real.convert(DType::Bool)
-            .jvp_optional_result(&real, &real_tangent)
+            .jvp_optional(&real, &real_tangent)
             .unwrap()
             .is_none(),
         "float-to-bool convert has no output tangent"
@@ -1805,7 +1807,7 @@ fn convert_ad_treats_integer_and_bool_boundaries_as_inactive_like_jax_float0() {
     assert!(
         integer
             .convert(DType::F64)
-            .jvp_optional_result(&integer, &integer_tangent)
+            .jvp_optional(&integer, &integer_tangent)
             .unwrap()
             .is_none(),
         "integer inputs have float0-like inactive tangents"
@@ -1813,7 +1815,7 @@ fn convert_ad_treats_integer_and_bool_boundaries_as_inactive_like_jax_float0() {
     assert!(
         boolean
             .convert(DType::F64)
-            .jvp_optional_result(&boolean, &boolean_tangent)
+            .jvp_optional(&boolean, &boolean_tangent)
             .unwrap()
             .is_none(),
         "bool inputs have float0-like inactive tangents"
@@ -1821,7 +1823,7 @@ fn convert_ad_treats_integer_and_bool_boundaries_as_inactive_like_jax_float0() {
 
     assert!(
         real.convert(DType::I64)
-            .vjp_optional_result(
+            .vjp_optional(
                 &real,
                 &TracedTensor::from_tensor_concrete_shape(i64_tensor(vec![2], vec![3, -4])),
             )
@@ -1831,7 +1833,7 @@ fn convert_ad_treats_integer_and_bool_boundaries_as_inactive_like_jax_float0() {
     );
     assert!(
         real.convert(DType::Bool)
-            .vjp_optional_result(
+            .vjp_optional(
                 &real,
                 &TracedTensor::from_tensor_concrete_shape(bool_tensor(vec![2], vec![true, false])),
             )
@@ -1842,7 +1844,7 @@ fn convert_ad_treats_integer_and_bool_boundaries_as_inactive_like_jax_float0() {
     assert!(
         integer
             .convert(DType::F64)
-            .vjp_optional_result(
+            .vjp_optional(
                 &integer,
                 &TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![3.0, -4.0])),
             )
@@ -1853,7 +1855,7 @@ fn convert_ad_treats_integer_and_bool_boundaries_as_inactive_like_jax_float0() {
     assert!(
         boolean
             .convert(DType::F64)
-            .vjp_optional_result(
+            .vjp_optional(
                 &boolean,
                 &TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![3.0, -4.0])),
             )
@@ -1876,7 +1878,7 @@ fn vjp_matmul() {
     let cotangent =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![1.0, 1.0, 1.0, 1.0]));
 
-    let y = a.dot_general(&b, matmul_config());
+    let y = a.dot_general(&b, matmul_config()).unwrap();
     let vjp = y.vjp(&a, &cotangent).unwrap();
 
     let result = eval_tensor(vjp);
@@ -1893,7 +1895,7 @@ fn grad_nonscalar_errors() {
         vec![3, 2],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     ));
-    let y = a.dot_general(&b, matmul_config());
+    let y = a.dot_general(&b, matmul_config()).unwrap();
 
     assert!(y.grad(&a).is_err());
 }
@@ -1901,7 +1903,7 @@ fn grad_nonscalar_errors() {
 #[test]
 fn grad_full_vector_reduction() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]));
-    let loss = x.reduce_sum(&[0]);
+    let loss = x.reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let result = eval_tensor(grad);

--- a/crates/tenferro-ad/tests/ad/reductions_and_indexing.rs
+++ b/crates/tenferro-ad/tests/ad/reductions_and_indexing.rs
@@ -210,7 +210,7 @@ fn test_reduce_min_vjp() {
 fn grad_broadcast_reduce() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
     let y = x.broadcast_in_dim(&[3, 3], &[0]);
-    let loss = y.reduce_sum(&[0, 1]);
+    let loss = y.reduce_sum(&[0, 1]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let result = eval_tensor(grad);
@@ -221,7 +221,7 @@ fn grad_broadcast_reduce() {
 fn grad_broadcast_add_singleton_lhs() {
     let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![1], vec![1.0]));
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
-    let loss = (&a + &b).sum(&[0]);
+    let loss = (&a + &b).unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&a).unwrap();
 
     let result = eval_tensor(grad);
@@ -232,7 +232,7 @@ fn grad_broadcast_add_singleton_lhs() {
 fn grad_reshape() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]));
     let y = x.reshape(&[2, 2]);
-    let loss = y.reduce_sum(&[0, 1]);
+    let loss = y.reduce_sum(&[0, 1]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let result = eval_tensor(grad);
@@ -246,8 +246,8 @@ fn grad_transpose() {
         vec![2, 3],
         vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
     ));
-    let y = a.transpose(&[1, 0]);
-    let loss = y.reduce_sum(&[0, 1]);
+    let y = a.transpose(&[1, 0]).unwrap();
+    let loss = y.reduce_sum(&[0, 1]).unwrap();
     let grad = loss.grad(&a).unwrap();
 
     let result = eval_tensor(grad);
@@ -259,7 +259,7 @@ fn grad_transpose() {
 fn grad_exp() {
     let x_data = vec![0.2, -0.7, 1.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
-    let loss = x.exp().sum(&[0]);
+    let loss = x.exp().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -269,7 +269,7 @@ fn grad_exp() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec()));
-        eval_scalar(x.exp().sum(&[0]))
+        eval_scalar(x.exp().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -278,7 +278,7 @@ fn grad_exp() {
 fn grad_log() {
     let x_data = vec![0.8, 1.5, 2.4];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
-    let loss = x.log().reduce_sum(&[0]);
+    let loss = x.log().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -288,7 +288,7 @@ fn grad_log() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec()));
-        eval_scalar(x.log().reduce_sum(&[0]))
+        eval_scalar(x.log().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -298,7 +298,7 @@ fn grad_sin_cos() {
     let x_data = vec![0.2, -0.7, 1.3];
 
     let x_sin = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
-    let sin_loss = x_sin.sin().reduce_sum(&[0]);
+    let sin_loss = x_sin.sin().reduce_sum(&[0]).unwrap();
     let sin_grad = sin_loss.grad(&x_sin).unwrap();
     let sin_grad_tensor = eval_tensor(sin_grad);
     let sin_grad_data = get_f64_data(&sin_grad_tensor);
@@ -307,12 +307,12 @@ fn grad_sin_cos() {
 
     let f_sin = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec()));
-        eval_scalar(x.sin().reduce_sum(&[0]))
+        eval_scalar(x.sin().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(sin_grad_data, &x_data, f_sin);
 
     let x_cos = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
-    let cos_loss = x_cos.cos().reduce_sum(&[0]);
+    let cos_loss = x_cos.cos().reduce_sum(&[0]).unwrap();
     let cos_grad = cos_loss.grad(&x_cos).unwrap();
     let cos_grad_tensor = eval_tensor(cos_grad);
     let cos_grad_data = get_f64_data(&cos_grad_tensor);
@@ -321,7 +321,7 @@ fn grad_sin_cos() {
 
     let f_cos = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec()));
-        eval_scalar(x.cos().reduce_sum(&[0]))
+        eval_scalar(x.cos().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(cos_grad_data, &x_data, f_cos);
 }
@@ -333,7 +333,7 @@ fn grad_div() {
 
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
     let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], y_data.clone()));
-    let loss = (&x / &y).reduce_sum(&[0]);
+    let loss = (&x / &y).unwrap().reduce_sum(&[0]).unwrap();
 
     let grad_x = loss.grad(&x).unwrap();
     let grad_y = loss.grad(&y).unwrap();
@@ -354,7 +354,7 @@ fn grad_div() {
     let f = |lhs: &[f64], rhs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], lhs.to_vec()));
         let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], rhs.to_vec()));
-        eval_scalar((&x / &y).reduce_sum(&[0]))
+        eval_scalar((&x / &y).unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff_lhs(grad_x_data, &x_data, &y_data, &f);
     assert_grad_matches_finite_diff_rhs(grad_y_data, &x_data, &y_data, &f);
@@ -364,7 +364,7 @@ fn grad_div() {
 fn grad_sqrt() {
     let x_data = vec![0.8, 1.5, 3.2];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
-    let loss = x.sqrt().reduce_sum(&[0]);
+    let loss = x.sqrt().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -374,7 +374,7 @@ fn grad_sqrt() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec()));
-        eval_scalar(x.sqrt().reduce_sum(&[0]))
+        eval_scalar(x.sqrt().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -383,7 +383,7 @@ fn grad_sqrt() {
 fn grad_tanh() {
     let x_data = vec![0.2, -0.7, 1.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
-    let loss = x.tanh().reduce_sum(&[0]);
+    let loss = x.tanh().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -393,7 +393,7 @@ fn grad_tanh() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec()));
-        eval_scalar(x.tanh().reduce_sum(&[0]))
+        eval_scalar(x.tanh().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -404,7 +404,7 @@ fn grad_pow() {
     let y_data = vec![2.0, 2.0, 2.0];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
     let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], y_data.clone()));
-    let loss = x.pow(&y).reduce_sum(&[0]);
+    let loss = x.pow(&y).unwrap().reduce_sum(&[0]).unwrap();
 
     let grad_x = loss.grad(&x).unwrap();
     let grad_x_tensor = eval_tensor(grad_x);
@@ -415,7 +415,7 @@ fn grad_pow() {
     let f = |lhs: &[f64], rhs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], lhs.to_vec()));
         let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], rhs.to_vec()));
-        eval_scalar(x.pow(&y).reduce_sum(&[0]))
+        eval_scalar(x.pow(&y).unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff_lhs(grad_x_data, &x_data, &y_data, &f);
 }
@@ -426,7 +426,7 @@ fn grad_pow_wrt_base_handles_zero_base_integer_exponent() {
     let y_data = vec![2.0_f64, 3.0, 4.0];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
     let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], y_data.clone()));
-    let loss = x.pow(&y).reduce_sum(&[0]);
+    let loss = x.pow(&y).unwrap().reduce_sum(&[0]).unwrap();
 
     let grad_x = loss.grad(&x).unwrap();
     let grad_x_tensor = eval_tensor(grad_x);
@@ -437,7 +437,7 @@ fn grad_pow_wrt_base_handles_zero_base_integer_exponent() {
     let f = |lhs: &[f64], rhs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], lhs.to_vec()));
         let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], rhs.to_vec()));
-        eval_scalar(x.pow(&y).reduce_sum(&[0]))
+        eval_scalar(x.pow(&y).unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff_lhs(grad_x_data, &x_data, &y_data, &f);
 }
@@ -448,7 +448,7 @@ fn grad_pow_wrt_exponent() {
     let y_data = vec![0.5, 1.5, 2.0];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
     let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], y_data.clone()));
-    let loss = x.pow(&y).reduce_sum(&[0]);
+    let loss = x.pow(&y).unwrap().reduce_sum(&[0]).unwrap();
 
     let grad_y = loss.grad(&y).unwrap();
     let grad_y_tensor = eval_tensor(grad_y);
@@ -463,7 +463,7 @@ fn grad_pow_wrt_exponent() {
     let f = |lhs: &[f64], rhs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], lhs.to_vec()));
         let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], rhs.to_vec()));
-        eval_scalar(x.pow(&y).reduce_sum(&[0]))
+        eval_scalar(x.pow(&y).unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff_rhs(grad_y_data, &x_data, &y_data, &f);
 }
@@ -472,7 +472,7 @@ fn grad_pow_wrt_exponent() {
 fn grad_abs() {
     let x_data = vec![-1.7, 0.8, 2.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
-    let loss = x.abs().reduce_sum(&[0]);
+    let loss = x.abs().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -482,7 +482,7 @@ fn grad_abs() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec()));
-        eval_scalar(x.abs().reduce_sum(&[0]))
+        eval_scalar(x.abs().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -491,7 +491,7 @@ fn grad_abs() {
 fn grad_sign() {
     let x_data = vec![-1.7, 0.8, 2.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
-    let loss = x.sign().reduce_sum(&[0]);
+    let loss = x.sign().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -500,7 +500,7 @@ fn grad_sign() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec()));
-        eval_scalar(x.sign().reduce_sum(&[0]))
+        eval_scalar(x.sign().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -509,7 +509,7 @@ fn grad_sign() {
 fn grad_rsqrt() {
     let x_data = vec![0.8, 1.5, 3.2];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
-    let loss = x.rsqrt().reduce_sum(&[0]);
+    let loss = x.rsqrt().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -519,7 +519,7 @@ fn grad_rsqrt() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec()));
-        eval_scalar(x.rsqrt().reduce_sum(&[0]))
+        eval_scalar(x.rsqrt().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -528,7 +528,7 @@ fn grad_rsqrt() {
 fn grad_expm1() {
     let x_data = vec![0.2, -0.7, 1.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
-    let loss = x.expm1().reduce_sum(&[0]);
+    let loss = x.expm1().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -538,7 +538,7 @@ fn grad_expm1() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec()));
-        eval_scalar(x.expm1().reduce_sum(&[0]))
+        eval_scalar(x.expm1().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -547,7 +547,7 @@ fn grad_expm1() {
 fn grad_log1p() {
     let x_data = vec![0.2, 0.7, 1.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone()));
-    let loss = x.log1p().reduce_sum(&[0]);
+    let loss = x.log1p().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -557,7 +557,7 @@ fn grad_log1p() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec()));
-        eval_scalar(x.log1p().reduce_sum(&[0]))
+        eval_scalar(x.log1p().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -625,7 +625,7 @@ fn grad_traced_index_select_repeated_positions_accumulates() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![10.0, 20.0, 30.0]));
 
     let selected = x.index_select(0, &[1, 1, 2]).unwrap();
-    let loss = (&selected * &weights).reduce_sum(&[0]);
+    let loss = (&selected * &weights).unwrap().reduce_sum(&[0]).unwrap();
     let grad = eval_tensor(loss.grad(&x).unwrap());
 
     assert_eq!(grad.shape(), &[3]);
@@ -654,7 +654,11 @@ fn hvp_traced_index_select_repeated_positions_accumulates() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![0.5, -1.0, 2.0]));
 
     let selected = x.index_select(0, &[1, 1, 2]).unwrap();
-    let loss = (&(&selected * &selected) * &weights).reduce_sum(&[0]);
+    let selected_squared = (&selected * &selected).unwrap();
+    let loss = (&selected_squared * &weights)
+        .unwrap()
+        .reduce_sum(&[0])
+        .unwrap();
     let grad = loss.grad(&x).unwrap();
     let hvp = eval_tensor(grad.jvp(&x, &tangent).unwrap());
 
@@ -1051,21 +1055,21 @@ fn dropped_traced_graph_releases_registered_metadata() {
     let y;
 
     {
-        let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]);
+        let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
         leaf_key = ValueKey::Input(x.input_key().expect("leaf input key"));
 
-        y = &x + &x;
+        y = (&x + &x).unwrap();
         derived_key = y.graph().values()[y.val].key.clone();
 
-        assert!(lookup_global_metadata(&leaf_key).is_some());
-        assert!(lookup_global_metadata(&derived_key).is_some());
+        assert!(lookup_global_metadata(&leaf_key).unwrap().is_some());
+        assert!(lookup_global_metadata(&derived_key).unwrap().is_some());
     }
 
-    assert!(lookup_global_metadata(&leaf_key).is_some());
-    assert!(lookup_global_metadata(&derived_key).is_some());
+    assert!(lookup_global_metadata(&leaf_key).unwrap().is_some());
+    assert!(lookup_global_metadata(&derived_key).unwrap().is_some());
 
     drop(y);
 
-    assert!(lookup_global_metadata(&leaf_key).is_none());
-    assert!(lookup_global_metadata(&derived_key).is_none());
+    assert!(lookup_global_metadata(&leaf_key).unwrap().is_none());
+    assert!(lookup_global_metadata(&derived_key).unwrap().is_none());
 }

--- a/crates/tenferro-ad/tests/ad_structural_primitives.rs
+++ b/crates/tenferro-ad/tests/ad_structural_primitives.rs
@@ -53,19 +53,19 @@ fn eager_maximum_and_minimum_gradients_match_finite_diff() {
     let min_weights = vec![1.5_f64, -0.25, 0.75, 2.25];
 
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![4], x_data.clone()),
+        Tensor::from_vec_col_major(vec![4], x_data.clone()).unwrap(),
         ctx.clone(),
     );
     let y = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![4], y_data.clone()),
+        Tensor::from_vec_col_major(vec![4], y_data.clone()).unwrap(),
         ctx.clone(),
     );
     let max_weights_tensor = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![4], max_weights.clone()),
+        Tensor::from_vec_col_major(vec![4], max_weights.clone()).unwrap(),
         ctx.clone(),
     );
     let min_weights_tensor = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![4], min_weights.clone()),
+        Tensor::from_vec_col_major(vec![4], min_weights.clone()).unwrap(),
         ctx.clone(),
     );
 
@@ -86,8 +86,8 @@ fn eager_maximum_and_minimum_gradients_match_finite_diff() {
     let loss = max_loss.add(&min_loss).unwrap();
     let _ = loss.backward().unwrap();
 
-    let grad_x = x.grad().unwrap();
-    let grad_y = y.grad().unwrap();
+    let grad_x = x.grad().unwrap().unwrap();
+    let grad_y = y.grad().unwrap().unwrap();
 
     let loss_for_x = |xs: &[f64]| {
         let max_part = weighted_sum(
@@ -135,19 +135,19 @@ fn eager_select_gradients_match_finite_diff() {
     let weights = vec![0.5_f64, -1.0, 2.0, 1.25];
 
     let condition = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![4], condition_data.clone()),
+        Tensor::from_vec_col_major(vec![4], condition_data.clone()).unwrap(),
         ctx.clone(),
     );
     let on_true = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![4], true_data.clone()),
+        Tensor::from_vec_col_major(vec![4], true_data.clone()).unwrap(),
         ctx.clone(),
     );
     let on_false = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![4], false_data.clone()),
+        Tensor::from_vec_col_major(vec![4], false_data.clone()).unwrap(),
         ctx.clone(),
     );
     let weights_tensor = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![4], weights.clone()),
+        Tensor::from_vec_col_major(vec![4], weights.clone()).unwrap(),
         ctx.clone(),
     );
 
@@ -181,11 +181,11 @@ fn eager_select_gradients_match_finite_diff() {
     };
 
     assert_close(
-        f64_data(on_true.grad().unwrap().as_ref()),
+        f64_data(on_true.grad().unwrap().unwrap().as_ref()),
         &finite_diff_unary(loss_for_true, &true_data),
     );
     assert_close(
-        f64_data(on_false.grad().unwrap().as_ref()),
+        f64_data(on_false.grad().unwrap().unwrap().as_ref()),
         &finite_diff_unary(loss_for_false, &false_data),
     );
 }
@@ -199,19 +199,19 @@ fn eager_clamp_gradients_match_finite_diff() {
     let weights = vec![0.5_f64, -1.25, 2.0, 0.75];
 
     let input = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![4], input_data.clone()),
+        Tensor::from_vec_col_major(vec![4], input_data.clone()).unwrap(),
         ctx.clone(),
     );
     let lower = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![4], lower_data.clone()),
+        Tensor::from_vec_col_major(vec![4], lower_data.clone()).unwrap(),
         ctx.clone(),
     );
     let upper = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![4], upper_data.clone()),
+        Tensor::from_vec_col_major(vec![4], upper_data.clone()).unwrap(),
         ctx.clone(),
     );
     let weights_tensor = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![4], weights.clone()),
+        Tensor::from_vec_col_major(vec![4], weights.clone()).unwrap(),
         ctx.clone(),
     );
 
@@ -235,18 +235,18 @@ fn eager_clamp_gradients_match_finite_diff() {
     };
 
     assert_close(
-        f64_data(input.grad().unwrap().as_ref()),
+        f64_data(input.grad().unwrap().unwrap().as_ref()),
         &finite_diff_unary(|xs| loss_with(xs, &lower_data, &upper_data), &input_data),
     );
     assert_close(
-        f64_data(lower.grad().unwrap().as_ref()),
+        f64_data(lower.grad().unwrap().unwrap().as_ref()),
         &finite_diff_unary(
             |lows| loss_with(&input_data, lows, &upper_data),
             &lower_data,
         ),
     );
     assert_close(
-        f64_data(upper.grad().unwrap().as_ref()),
+        f64_data(upper.grad().unwrap().unwrap().as_ref()),
         &finite_diff_unary(
             |highs| loss_with(&input_data, &lower_data, highs),
             &upper_data,
@@ -261,11 +261,11 @@ fn eager_extract_diag_rectangular_gradient_matches_finite_diff() {
     let weights = vec![0.5_f64, -1.25];
 
     let input = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2, 3], input_data.clone()),
+        Tensor::from_vec_col_major(vec![2, 3], input_data.clone()).unwrap(),
         ctx.clone(),
     );
     let weights_tensor = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], weights.clone()),
+        Tensor::from_vec_col_major(vec![2], weights.clone()).unwrap(),
         ctx.clone(),
     );
 
@@ -280,7 +280,7 @@ fn eager_extract_diag_rectangular_gradient_matches_finite_diff() {
 
     let loss_for_input = |values: &[f64]| weights[0] * values[0] + weights[1] * values[3];
 
-    let grad = input.grad().unwrap();
+    let grad = input.grad().unwrap().unwrap();
     assert_eq!(grad.shape(), &[2, 3]);
     assert_close(
         f64_data(&grad),
@@ -299,11 +299,11 @@ fn eager_embed_diag_shifted_axis_gradient_matches_finite_diff() {
     ];
 
     let input = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(input_shape.clone(), input_data.clone()),
+        Tensor::from_vec_col_major(input_shape.clone(), input_data.clone()).unwrap(),
         ctx.clone(),
     );
     let weights_tensor = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3, 2, 3], weights.clone()),
+        Tensor::from_vec_col_major(vec![3, 2, 3], weights.clone()).unwrap(),
         ctx.clone(),
     );
 
@@ -327,7 +327,7 @@ fn eager_embed_diag_shifted_axis_gradient_matches_finite_diff() {
             .sum()
     };
 
-    let grad = input.grad().unwrap();
+    let grad = input.grad().unwrap().unwrap();
     assert_eq!(grad.shape(), input_shape.as_slice());
     assert_close(
         f64_data(&grad),
@@ -344,19 +344,19 @@ fn eager_concatenate_gradients_match_finite_diff() {
     let weights = vec![0.5_f64, -1.0, 2.0, 1.5, -0.25, 0.75];
 
     let left = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2], left_data.clone()),
+        Tensor::from_vec_col_major(vec![2], left_data.clone()).unwrap(),
         ctx.clone(),
     );
     let middle = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![1], middle_data.clone()),
+        Tensor::from_vec_col_major(vec![1], middle_data.clone()).unwrap(),
         ctx.clone(),
     );
     let right = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], right_data.clone()),
+        Tensor::from_vec_col_major(vec![3], right_data.clone()).unwrap(),
         ctx.clone(),
     );
     let weights_tensor = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![6], weights.clone()),
+        Tensor::from_vec_col_major(vec![6], weights.clone()).unwrap(),
         ctx.clone(),
     );
 
@@ -400,15 +400,15 @@ fn eager_concatenate_gradients_match_finite_diff() {
     };
 
     assert_close(
-        f64_data(left.grad().unwrap().as_ref()),
+        f64_data(left.grad().unwrap().unwrap().as_ref()),
         &finite_diff_unary(loss_for_left, &left_data),
     );
     assert_close(
-        f64_data(middle.grad().unwrap().as_ref()),
+        f64_data(middle.grad().unwrap().unwrap().as_ref()),
         &finite_diff_unary(loss_for_middle, &middle_data),
     );
     assert_close(
-        f64_data(right.grad().unwrap().as_ref()),
+        f64_data(right.grad().unwrap().unwrap().as_ref()),
         &finite_diff_unary(loss_for_right, &right_data),
     );
 }

--- a/crates/tenferro-ad/tests/binding_validation.rs
+++ b/crates/tenferro-ad/tests/binding_validation.rs
@@ -11,11 +11,11 @@ use tenferro_tensor::DType;
 
 #[test]
 fn unexpected_binding_for_data_carrying_leaf() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let y = x.clone();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
-    let extra = Tensor::from_vec_col_major(vec![2], vec![9.0_f64, 9.0]);
+    let extra = Tensor::from_vec_col_major(vec![2], vec![9.0_f64, 9.0]).unwrap();
     let err = y
         .run_with_inputs_auto(&mut engine, &[(&x, &extra)])
         .expect_err("binding a non-placeholder must fail");
@@ -47,7 +47,7 @@ fn duplicate_binding() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
     let y = x.clone();
 
-    let bound = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let bound = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let err = y
         .run_with_inputs_auto(&mut engine, &[(&x, &bound), (&x, &bound)])
@@ -61,7 +61,7 @@ fn placeholder_dtype_mismatch() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
     let y = x.clone();
 
-    let wrong_dtype = Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]);
+    let wrong_dtype = Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let err = y
         .run_with_inputs_auto(&mut engine, &[(&x, &wrong_dtype)])
@@ -84,7 +84,7 @@ fn placeholder_shape_mismatch_for_concrete_shape_placeholder() {
     let x = TracedTensor::input_concrete_shape(DType::F64, &[2, 3]);
     let y = x.clone();
 
-    let wrong_shape = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
+    let wrong_shape = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let err = y
         .run_with_inputs_auto(&mut engine, &[(&x, &wrong_shape)])
@@ -104,7 +104,7 @@ fn placeholder_rank_mismatch_for_symbolic_shape_placeholder() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let y = x.clone();
 
-    let wrong_rank = Tensor::from_vec_col_major(vec![4], vec![1.0_f64; 4]);
+    let wrong_rank = Tensor::from_vec_col_major(vec![4], vec![1.0_f64; 4]).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let err = y
         .run_with_inputs_auto(&mut engine, &[(&x, &wrong_rank)])
@@ -129,7 +129,7 @@ fn symbolic_shape_placeholder_accepts_any_shape_of_matching_rank() {
     let y = x.clone();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
-    let bound = Tensor::from_vec_col_major(vec![7], vec![1.0_f64; 7]);
+    let bound = Tensor::from_vec_col_major(vec![7], vec![1.0_f64; 7]).unwrap();
     let out = y
         .run_with_inputs_auto(&mut engine, &[(&x, &bound)])
         .expect("rank-only placeholder accepts arbitrary shape of that rank");
@@ -139,8 +139,8 @@ fn symbolic_shape_placeholder_accepts_any_shape_of_matching_rank() {
 #[test]
 fn executor_run_with_inputs_validates_and_uses_bound_tensors() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = &x + &x;
-    let bound = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let y = (&x + &x).unwrap();
+    let bound = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler
@@ -161,7 +161,7 @@ fn executor_run_with_inputs_validates_and_uses_bound_tensors() {
         .unwrap_err();
     assert!(matches!(err, Error::DuplicateBinding { .. }));
 
-    let concrete = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let concrete = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let err = executor
         .run_with_inputs(&program, &[(&concrete, &bound)])
         .unwrap_err();
@@ -171,7 +171,7 @@ fn executor_run_with_inputs_validates_and_uses_bound_tensors() {
 #[test]
 fn compile_with_input_specs_validates_specs_without_tensor_values() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = &x + &x;
+    let y = (&x + &x).unwrap();
     let shape = [2usize];
 
     let mut compiler = GraphCompiler::new();
@@ -214,7 +214,7 @@ fn compile_with_input_specs_validates_specs_without_tensor_values() {
         .unwrap_err();
     assert!(matches!(err, Error::PlaceholderShapeMismatch { .. }));
 
-    let data_leaf = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let data_leaf = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let err = compiler
         .compile_with_input_specs(&data_leaf, &[(&data_leaf, DType::F64, shape.as_slice())])
         .unwrap_err();

--- a/crates/tenferro-ad/tests/cache_management.rs
+++ b/crates/tenferro-ad/tests/cache_management.rs
@@ -5,8 +5,8 @@ use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
 fn compiler_clear_caches_clears_compile_entries() {
     let mut compiler = GraphCompiler::new();
 
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let y = &x + &x;
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y = (&x + &x).unwrap();
     let _ = compiler.compile(&y).expect("compile");
 
     let before = compiler.cache_stats();
@@ -22,8 +22,8 @@ fn compiler_clear_caches_clears_compile_entries() {
 #[test]
 fn executor_clear_caches_leaves_no_extension_entries_without_extensions() {
     let mut compiler = GraphCompiler::new();
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let y = &x + &x;
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y = (&x + &x).unwrap();
     let program = compiler.compile(&y).expect("compile");
     let mut executor = GraphExecutor::new(CpuBackend::new());
 
@@ -40,8 +40,8 @@ fn executor_clear_caches_leaves_no_extension_entries_without_extensions() {
 
 #[test]
 fn executor_clear_caches_clears_executor_owned_runtime_caches() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let y = &x + &x;
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y = (&x + &x).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&y).expect("compile");
     let mut executor = GraphExecutor::new(CpuBackend::new());

--- a/crates/tenferro-ad/tests/checkpoint.rs
+++ b/crates/tenferro-ad/tests/checkpoint.rs
@@ -8,12 +8,12 @@ const TOL: f64 = 1.0e-6;
 const FD_H: f64 = 1.0e-6;
 
 fn f64_scalar(value: f64) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![value]))
+    Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![value]).unwrap())
 }
 
 fn get_f64_scalar(tensor: &Tensor) -> f64 {
     match tensor {
-        Tensor::F64(inner) => inner.host_data()[0],
+        Tensor::F64(inner) => inner.host_data().unwrap()[0],
         other => panic!("expected F64 tensor, got {:?}", other.dtype()),
     }
 }
@@ -29,7 +29,7 @@ fn checkpoint_preserves_eval_value() {
     let mut compiler = GraphCompiler::new();
     let mut executor = GraphExecutor::new(CpuBackend::new());
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
-    let mut y = &x * &x;
+    let mut y = (&x * &x).unwrap();
 
     y.checkpoint(&mut compiler, &mut executor).unwrap();
 
@@ -43,12 +43,12 @@ fn checkpoint_downstream_eval_uses_leaf() {
     let mut compiler = GraphCompiler::new();
     let mut executor = GraphExecutor::new(CpuBackend::new());
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
-    let mut y = &x * &x;
+    let mut y = (&x * &x).unwrap();
 
     y.checkpoint(&mut compiler, &mut executor).unwrap();
 
     let one = TracedTensor::from_tensor_concrete_shape(f64_scalar(1.0));
-    let z = &y + &one;
+    let z = (&y + &one).unwrap();
     let value = get_f64_scalar(&z.run_with(&mut engine).unwrap());
     assert!((value - 10.0).abs() < 1.0e-12);
 }
@@ -61,10 +61,10 @@ fn checkpoint_grad_correct() {
     let mut executor = GraphExecutor::new(CpuBackend::new());
 
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(x_value));
-    let mut y = &x * &x;
+    let mut y = (&x * &x).unwrap();
     y.checkpoint(&mut compiler, &mut executor).unwrap();
 
-    let z = &y * &y;
+    let z = (&y * &y).unwrap();
     let grad = z.grad(&x).unwrap();
     let grad = grad;
     let grad_value = get_f64_scalar(&grad.run_with(&mut engine).unwrap());
@@ -80,9 +80,9 @@ fn checkpoint_hvp_correct() {
     let mut executor = GraphExecutor::new(CpuBackend::new());
 
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(x_value));
-    let mut y = &x * &x;
+    let mut y = (&x * &x).unwrap();
     y.checkpoint(&mut compiler, &mut executor).unwrap();
-    let z = &y * &y;
+    let z = (&y * &y).unwrap();
 
     let grad = z.grad(&x).unwrap();
     let v = TracedTensor::from_tensor_concrete_shape(f64_scalar(1.0));
@@ -96,11 +96,11 @@ fn checkpoint_hvp_correct() {
 
     let fd_grad = |value: f64| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(value));
-        let mut y = &x * &x;
+        let mut y = (&x * &x).unwrap();
         let mut compiler = GraphCompiler::new();
         let mut executor = GraphExecutor::new(CpuBackend::new());
         y.checkpoint(&mut compiler, &mut executor).unwrap();
-        let z = &y * &y;
+        let z = (&y * &y).unwrap();
         let grad = z.grad(&x).unwrap();
         get_f64_scalar(&eval_tensor(grad))
     };
@@ -124,7 +124,7 @@ fn checkpoint_loop_grad_correct() {
     let mut x = TracedTensor::from_tensor_concrete_shape(f64_scalar(x0_value));
 
     for _ in 0..steps {
-        x = &a * &x.cos();
+        x = (&a * &x.cos()).unwrap();
         x.checkpoint(&mut compiler, &mut executor).unwrap();
     }
 
@@ -155,13 +155,13 @@ fn grad_both_independently_checkpointed_add_wrt_rhs() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(2.0));
     let y = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
 
-    let mut x2 = &x * &x;
-    let mut y2 = &y * &y;
+    let mut x2 = (&x * &x).unwrap();
+    let mut y2 = (&y * &y).unwrap();
 
     x2.checkpoint(&mut compiler, &mut executor).unwrap();
     y2.checkpoint(&mut compiler, &mut executor).unwrap();
 
-    let z = &x2 + &y2;
+    let z = (&x2 + &y2).unwrap();
 
     let grad_y = z.grad(&y).unwrap();
     let grad_y = grad_y;
@@ -181,13 +181,13 @@ fn grad_both_independently_checkpointed_add_wrt_lhs() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(2.0));
     let y = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
 
-    let mut x2 = &x * &x;
-    let mut y2 = &y * &y;
+    let mut x2 = (&x * &x).unwrap();
+    let mut y2 = (&y * &y).unwrap();
 
     x2.checkpoint(&mut compiler, &mut executor).unwrap();
     y2.checkpoint(&mut compiler, &mut executor).unwrap();
 
-    let z = &x2 + &y2;
+    let z = (&x2 + &y2).unwrap();
 
     let grad_x = z.grad(&x).unwrap();
     let grad_x = grad_x;
@@ -207,13 +207,13 @@ fn grad_both_independently_checkpointed_mul_wrt_rhs() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(2.0));
     let y = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
 
-    let mut x2 = &x * &x;
-    let mut y2 = &y * &y;
+    let mut x2 = (&x * &x).unwrap();
+    let mut y2 = (&y * &y).unwrap();
 
     x2.checkpoint(&mut compiler, &mut executor).unwrap();
     y2.checkpoint(&mut compiler, &mut executor).unwrap();
 
-    let z = &x2 * &y2;
+    let z = (&x2 * &y2).unwrap();
 
     let grad_y = z.grad(&y).unwrap();
     let grad_y = grad_y;
@@ -238,11 +238,11 @@ fn grad_both_independently_checkpointed_matches_fd() {
     let mut executor = GraphExecutor::new(CpuBackend::new());
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(x_val));
     let y = TracedTensor::from_tensor_concrete_shape(f64_scalar(y_val));
-    let mut x2 = &x * &x;
-    let mut y2 = &y * &y;
+    let mut x2 = (&x * &x).unwrap();
+    let mut y2 = (&y * &y).unwrap();
     x2.checkpoint(&mut compiler, &mut executor).unwrap();
     y2.checkpoint(&mut compiler, &mut executor).unwrap();
-    let z = &x2 + &y2;
+    let z = (&x2 + &y2).unwrap();
     let grad_y = z.grad(&y).unwrap();
     let ad_value = get_f64_scalar(&grad_y.run_with(&mut engine).unwrap());
     assert!(
@@ -260,13 +260,13 @@ fn grad_mul_both_independently_checkpointed_wrt_rhs() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(2.0));
     let y = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
 
-    let mut x2 = &x * &x;
-    let mut y2 = &y * &y;
+    let mut x2 = (&x * &x).unwrap();
+    let mut y2 = (&y * &y).unwrap();
 
     x2.checkpoint(&mut compiler, &mut executor).unwrap();
     y2.checkpoint(&mut compiler, &mut executor).unwrap();
 
-    let z = &x2 * &y2;
+    let z = (&x2 * &y2).unwrap();
 
     let grad_y = z.grad(&y).unwrap();
     let grad_y = grad_y;
@@ -286,13 +286,13 @@ fn grad_mul_both_independently_checkpointed_wrt_lhs() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(2.0));
     let y = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
 
-    let mut x2 = &x * &x;
-    let mut y2 = &y * &y;
+    let mut x2 = (&x * &x).unwrap();
+    let mut y2 = (&y * &y).unwrap();
 
     x2.checkpoint(&mut compiler, &mut executor).unwrap();
     y2.checkpoint(&mut compiler, &mut executor).unwrap();
 
-    let z = &x2 * &y2;
+    let z = (&x2 * &y2).unwrap();
 
     let grad_x = z.grad(&x).unwrap();
     let grad_x = grad_x;
@@ -316,11 +316,11 @@ fn grad_mul_both_independently_checkpointed_matches_fd() {
     let mut executor = GraphExecutor::new(CpuBackend::new());
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(x_val));
     let y = TracedTensor::from_tensor_concrete_shape(f64_scalar(y_val));
-    let mut x2 = &x * &x;
-    let mut y2 = &y * &y;
+    let mut x2 = (&x * &x).unwrap();
+    let mut y2 = (&y * &y).unwrap();
     x2.checkpoint(&mut compiler, &mut executor).unwrap();
     y2.checkpoint(&mut compiler, &mut executor).unwrap();
-    let z = &x2 * &y2;
+    let z = (&x2 * &y2).unwrap();
     let grad_y = z.grad(&y).unwrap();
     let ad_value = get_f64_scalar(&grad_y.run_with(&mut engine).unwrap());
     assert!(

--- a/crates/tenferro-ad/tests/checkpoint_truncate_integration.rs
+++ b/crates/tenferro-ad/tests/checkpoint_truncate_integration.rs
@@ -8,16 +8,16 @@ const TOL: f64 = 1.0e-4;
 const FD_H: f64 = 1.0e-5;
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn f64_scalar(value: f64) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![value]))
+    Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![value]).unwrap())
 }
 
 fn get_f64_scalar(tensor: &Tensor) -> f64 {
     match tensor {
-        Tensor::F64(inner) => inner.host_data()[0],
+        Tensor::F64(inner) => inner.host_data().unwrap()[0],
         other => panic!("expected F64 tensor, got {:?}", other.dtype()),
     }
 }
@@ -36,12 +36,12 @@ fn checkpoint_truncate_loop_grad() {
     let mut x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x0_data.clone()));
 
     for _ in 0..steps {
-        x = &a * &x;
-        x = x.dynamic_truncate(&size, 0);
+        x = (&a * &x).unwrap();
+        x = x.dynamic_truncate(&size, 0).unwrap();
         x.checkpoint(&mut compiler, &mut executor).unwrap();
     }
 
-    let loss = x.reduce_sum(&[0]);
+    let loss = x.reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&a).unwrap();
     let grad_value = get_f64_scalar(&grad.run_with(&mut engine).unwrap());
 

--- a/crates/tenferro-ad/tests/convenience_api.rs
+++ b/crates/tenferro-ad/tests/convenience_api.rs
@@ -7,81 +7,90 @@ use tenferro_tensor::DType;
 
 #[test]
 fn traced_tensor_new_and_tensor_as_slice_cover_common_f64_flow() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let b = TracedTensor::from_vec_col_major(vec![2, 3], vec![6.0_f64, 5.0, 4.0, 3.0, 2.0, 1.0]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![2, 3], vec![6.0_f64, 5.0, 4.0, 3.0, 2.0, 1.0])
+        .unwrap();
 
-    let sum = &a + &b;
+    let sum = (&a + &b).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = sum.run_with(&mut engine).unwrap();
 
     assert_eq!(
-        result.as_slice::<f64>(),
-        Some([7.0, 7.0, 7.0, 7.0, 7.0, 7.0].as_slice())
+        result.as_slice::<f64>().unwrap(),
+        [7.0, 7.0, 7.0, 7.0, 7.0, 7.0].as_slice()
     );
-    assert_eq!(result.as_slice::<f32>(), None);
+    assert!(result.as_slice::<f32>().is_err());
 }
 
 #[test]
 fn tensor_scalar_is_reexported_from_tenferro() {
-    let tensor = <f64 as TensorScalar>::into_tensor(vec![2], vec![1.0, 2.0]);
+    let tensor = <f64 as TensorScalar>::into_tensor(vec![2], vec![1.0, 2.0]).unwrap();
 
-    assert_eq!(tensor.as_slice::<f64>(), Some([1.0, 2.0].as_slice()));
+    assert_eq!(tensor.as_slice::<f64>().unwrap(), [1.0, 2.0].as_slice());
 }
 
 #[test]
 fn traced_tensor_shape_helpers_and_aliases_cover_public_surface() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let b = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
 
     assert_eq!(a.try_concrete_shape(), Some(vec![2, 3]));
     assert!(a.input_key().is_some());
-    assert!((&a + &a).input_key().is_none());
-    assert_eq!(a.axis_sym_dim(0).constant_value(), Some(2));
+    assert!((&a + &a).unwrap().input_key().is_none());
+    assert_eq!(a.axis_sym_dim(0).unwrap().constant_value(), Some(2));
     assert_eq!(a.sym_shape().unwrap().len(), 2);
 
     let symbolic = TracedTensor::input_symbolic_shape(DType::F64, 2);
     assert_eq!(symbolic.try_concrete_shape(), None);
     assert!(symbolic.sym_shape().is_none());
-    assert!(symbolic.axis_sym_dim(1).constant_value().is_none());
+    assert!(symbolic.axis_sym_dim(1).unwrap().constant_value().is_none());
 
-    let m = a.axis_sym_dim(0);
-    let k = a.axis_sym_dim(1);
-    let n = b.axis_sym_dim(1);
-    let broad = a.broadcast_in_dim_sym(&[m, k, n], &[0, 1], &[&b]);
+    let m = a.axis_sym_dim(0).unwrap();
+    let k = a.axis_sym_dim(1).unwrap();
+    let n = b.axis_sym_dim(1).unwrap();
+    let broad = a.broadcast_in_dim_sym(&[m, k, n], &[0, 1], &[&b]).unwrap();
     assert_eq!(broad.rank, 3);
 
-    assert_eq!(a.broadcast(&[2, 3], &[0, 1]).rank, 2);
-    assert_eq!(a.reduce_max(&[0]).rank, 1);
-    assert_eq!(a.reduce_min(&[1]).rank, 1);
-    assert_eq!(a.reduce_prod(&[0, 1]).rank, 0);
+    assert_eq!(a.broadcast_in_dim(&[2, 3], &[0, 1]).rank, 2);
+    assert_eq!(a.reduce_max(&[0]).unwrap().rank, 1);
+    assert_eq!(a.reduce_min(&[1]).unwrap().rank, 1);
+    assert_eq!(a.reduce_prod(&[0, 1]).unwrap().rank, 0);
 }
 
 #[test]
 fn traced_tensor_scaling_covers_dtype_specific_constants() {
-    let f32_tensor = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![1],
-        vec![1.0_f32],
-    ));
+    let f32_tensor = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f32]).unwrap(),
+    );
     assert_eq!(f32_tensor.scale_real(2.5).dtype, DType::F32);
 
-    let i64_tensor =
-        TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(vec![1], vec![2_i64]));
+    let i64_tensor = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![1], vec![2_i64]).unwrap(),
+    );
     assert_eq!(i64_tensor.scale_real(2.5).dtype, DType::I64);
 
-    let c64_tensor = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![1],
-        vec![Complex64::new(1.0, 2.0)],
-    ));
+    let real_complex_scaled = i64_tensor.scale_complex(Complex64::new(0.0, 1.0));
+    assert_eq!(real_complex_scaled.dtype, DType::C64);
+    let mut engine = tenferro_runtime::GraphExecutor::new(CpuBackend::new());
+    let real_complex_result = real_complex_scaled.run_with(&mut engine).unwrap();
+    assert_eq!(
+        real_complex_result.as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(0.0, 2.0)]
+    );
+
+    let c64_tensor = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 2.0)]).unwrap(),
+    );
     assert_eq!(c64_tensor.scale_real(2.0).dtype, DType::C64);
     assert_eq!(
         c64_tensor.scale_complex(Complex64::new(0.0, 1.0)).dtype,
         DType::C64
     );
 
-    let c32_tensor = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![1],
-        vec![Complex32::new(1.0, 2.0)],
-    ));
+    let c32_tensor = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![1], vec![Complex32::new(1.0, 2.0)]).unwrap(),
+    );
     assert_eq!(c32_tensor.scale_real(2.0).dtype, DType::C32);
     assert_eq!(
         c32_tensor.scale_complex(Complex64::new(0.0, 1.0)).dtype,

--- a/crates/tenferro-ad/tests/cpu_backend.rs
+++ b/crates/tenferro-ad/tests/cpu_backend.rs
@@ -10,23 +10,23 @@ use tenferro_runtime::GraphExecutor;
 use tenferro_tensor::{DotGeneralConfig, Tensor, TypedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn f32_tensor(shape: Vec<usize>, data: Vec<f32>) -> Tensor {
-    Tensor::F32(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F32(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn get_f64_data(t: &Tensor) -> &[f64] {
     match t {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner.host_data().unwrap(),
         _ => panic!("expected F64"),
     }
 }
 
 fn get_f32_data(t: &Tensor) -> &[f32] {
     match t {
-        Tensor::F32(inner) => inner.host_data(),
+        Tensor::F32(inner) => inner.host_data().unwrap(),
         _ => panic!("expected F32"),
     }
 }
@@ -51,7 +51,7 @@ fn test_faer_gemm_basic_f64() {
         lhs_batch_dims: vec![],
         rhs_batch_dims: vec![],
     };
-    let tc = ta.dot_general(&tb, config);
+    let tc = ta.dot_general(&tb, config).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tc.run_with(&mut engine).unwrap();
@@ -73,7 +73,7 @@ fn test_faer_gemm_basic_f32() {
         lhs_batch_dims: vec![],
         rhs_batch_dims: vec![],
     };
-    let tc = ta.dot_general(&tb, config);
+    let tc = ta.dot_general(&tb, config).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tc.run_with(&mut engine).unwrap();
@@ -103,7 +103,7 @@ fn test_faer_gemm_identity() {
         lhs_batch_dims: vec![],
         rhs_batch_dims: vec![],
     };
-    let tc = ta.dot_general(&ti, config);
+    let tc = ta.dot_general(&ti, config).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tc.run_with(&mut engine).unwrap();
@@ -144,7 +144,7 @@ fn test_batched_gemm() {
         lhs_batch_dims: vec![2],       // batch over dim 2
         rhs_batch_dims: vec![2],       // batch over dim 2
     };
-    let tc = ta.dot_general(&tb, config);
+    let tc = ta.dot_general(&tb, config).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tc.run_with(&mut engine).unwrap();
@@ -180,16 +180,18 @@ fn test_strided_input_via_transpose_and_dot_general() {
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let ta = TracedTensor::from_tensor_concrete_shape(a);
     let tb = TracedTensor::from_tensor_concrete_shape(b);
-    let ta_t = ta.transpose(&[1, 0]);
-    let tc = ta_t.dot_general(
-        &tb,
-        DotGeneralConfig {
-            lhs_contracting_dims: vec![1],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: vec![],
-            rhs_batch_dims: vec![],
-        },
-    );
+    let ta_t = ta.transpose(&[1, 0]).unwrap();
+    let tc = ta_t
+        .dot_general(
+            &tb,
+            DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+        )
+        .unwrap();
 
     let result = tc.run_with(&mut engine).unwrap();
     let data = get_f64_data(&result);
@@ -215,7 +217,7 @@ fn test_vector_dot_product() {
         lhs_batch_dims: vec![],
         rhs_batch_dims: vec![],
     };
-    let tc = tv.dot_general(&tw, config);
+    let tc = tv.dot_general(&tw, config).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tc.run_with(&mut engine).unwrap();

--- a/crates/tenferro-ad/tests/dot_general_validation.rs
+++ b/crates/tenferro-ad/tests/dot_general_validation.rs
@@ -7,7 +7,7 @@ use tenferro_runtime::traced::TracedTensor;
 use tenferro_tensor::{DotGeneralConfig, Tensor, TypedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn assert_panic_contains(config: DotGeneralConfig, expected_substring: &str) {
@@ -16,7 +16,7 @@ fn assert_panic_contains(config: DotGeneralConfig, expected_substring: &str) {
     let b =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![5.0, 6.0, 7.0, 8.0]));
     let result = catch_unwind(AssertUnwindSafe(|| {
-        let _ = a.dot_general(&b, config);
+        let _ = a.dot_general(&b, config).unwrap();
     }));
     match result {
         Err(panic_payload) => {
@@ -77,7 +77,7 @@ fn traced_dot_general_accepts_valid_config() {
         lhs_batch_dims: vec![],
         rhs_batch_dims: vec![],
     };
-    let c = a.dot_general(&b, config);
+    let c = a.dot_general(&b, config).unwrap();
     let mut engine = tenferro_runtime::GraphExecutor::new(CpuBackend::new());
     let result = c.run_with(&mut engine).unwrap();
     let data = result.as_slice::<f64>().unwrap();
@@ -236,7 +236,7 @@ fn traced_dot_general_accepts_batched_valid_config() {
         lhs_batch_dims: vec![0, 2],
         rhs_batch_dims: vec![1, 2],
     };
-    let c = a.dot_general(&b, config);
+    let c = a.dot_general(&b, config).unwrap();
     let mut engine = tenferro_runtime::GraphExecutor::new(CpuBackend::new());
     let result = c.run_with(&mut engine).unwrap();
     let data = result.as_slice::<f64>().unwrap();

--- a/crates/tenferro-ad/tests/dtype_propagation.rs
+++ b/crates/tenferro-ad/tests/dtype_propagation.rs
@@ -6,7 +6,7 @@ use tenferro_tensor::{DType, DotGeneralConfig, GatherConfig, ScatterConfig};
 fn test_add_preserves_f32() {
     let op = StdTensorOp::Add;
     assert_eq!(
-        infer_output_dtype(&op, &[DType::F32, DType::F32]),
+        infer_output_dtype(&op, &[DType::F32, DType::F32]).unwrap(),
         DType::F32
     );
 }
@@ -15,7 +15,7 @@ fn test_add_preserves_f32() {
 fn test_add_preserves_c32() {
     let op = StdTensorOp::Add;
     assert_eq!(
-        infer_output_dtype(&op, &[DType::C32, DType::C32]),
+        infer_output_dtype(&op, &[DType::C32, DType::C32]).unwrap(),
         DType::C32
     );
 }
@@ -26,7 +26,7 @@ fn test_convert_uses_target_dtype() {
         from: DType::F32,
         to: DType::F64,
     };
-    assert_eq!(infer_output_dtype(&op, &[DType::F32]), DType::F64);
+    assert_eq!(infer_output_dtype(&op, &[DType::F32]).unwrap(), DType::F64);
 }
 
 #[test]
@@ -35,17 +35,17 @@ fn test_constant_uses_variant_dtype() {
         dtype: DType::C64,
         bytes: vec![],
     };
-    assert_eq!(infer_output_dtype(&op, &[]), DType::C64);
+    assert_eq!(infer_output_dtype(&op, &[]).unwrap(), DType::C64);
 }
 
 #[test]
 fn test_abs_complex_outputs_real_dtype() {
     assert_eq!(
-        infer_output_dtype(&StdTensorOp::Abs, &[DType::C32]),
+        infer_output_dtype(&StdTensorOp::Abs, &[DType::C32]).unwrap(),
         DType::F32
     );
     assert_eq!(
-        infer_output_dtype(&StdTensorOp::Abs, &[DType::C64]),
+        infer_output_dtype(&StdTensorOp::Abs, &[DType::C64]).unwrap(),
         DType::F64
     );
 }
@@ -53,7 +53,7 @@ fn test_abs_complex_outputs_real_dtype() {
 #[test]
 fn test_reduce_sum_preserves_dtype() {
     let op = StdTensorOp::ReduceSum { axes: vec![0] };
-    assert_eq!(infer_output_dtype(&op, &[DType::F32]), DType::F32);
+    assert_eq!(infer_output_dtype(&op, &[DType::F32]).unwrap(), DType::F32);
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn test_dot_general_preserves_lhs_dtype() {
         },
     };
     assert_eq!(
-        infer_output_dtype(&op, &[DType::F32, DType::F32]),
+        infer_output_dtype(&op, &[DType::F32, DType::F32]).unwrap(),
         DType::F32
     );
 }
@@ -82,7 +82,7 @@ fn test_indexing_dtype_inference_ignores_index_operands() {
         slice_sizes: vec![1],
     });
     assert_eq!(
-        infer_output_dtype(&gather, &[DType::C64, DType::I64]),
+        infer_output_dtype(&gather, &[DType::C64, DType::I64]).unwrap(),
         DType::C64
     );
 
@@ -90,7 +90,7 @@ fn test_indexing_dtype_inference_ignores_index_operands() {
         slice_sizes: vec![1],
     };
     assert_eq!(
-        infer_output_dtype(&dynamic_slice, &[DType::F32, DType::I64]),
+        infer_output_dtype(&dynamic_slice, &[DType::F32, DType::I64]).unwrap(),
         DType::F32
     );
 
@@ -101,7 +101,7 @@ fn test_indexing_dtype_inference_ignores_index_operands() {
         index_vector_dim: 1,
     });
     assert_eq!(
-        infer_output_dtype(&scatter, &[DType::F32, DType::I64, DType::F32]),
+        infer_output_dtype(&scatter, &[DType::F32, DType::I64, DType::F32]).unwrap(),
         DType::F32
     );
 
@@ -109,7 +109,8 @@ fn test_indexing_dtype_inference_ignores_index_operands() {
         infer_output_dtype(
             &StdTensorOp::DynamicUpdateSlice,
             &[DType::F32, DType::F32, DType::I64],
-        ),
+        )
+        .unwrap(),
         DType::F32
     );
 }

--- a/crates/tenferro-ad/tests/dynamic_truncate.rs
+++ b/crates/tenferro-ad/tests/dynamic_truncate.rs
@@ -16,34 +16,37 @@ const TOL: f64 = 1.0e-5;
 const FD_H: f64 = 1.0e-5;
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn f64_scalar(value: f64) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![value]))
+    Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![value]).unwrap())
 }
 
 fn i64_scalar(value: i64) -> Tensor {
-    Tensor::I64(TypedTensor::from_vec_col_major(vec![], vec![value]))
+    Tensor::I64(TypedTensor::from_vec_col_major(vec![], vec![value]).unwrap())
 }
 
 fn backend_f64_scalar() -> Tensor {
-    Tensor::F64(TypedTensor::from_buffer_col_major(
-        vec![],
-        Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(11, 1))),
-        Placement {
-            memory_kind: MemoryKind::Device,
-            device: Some(DeviceId {
-                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
-                ordinal: 0,
-            }),
-        },
-    ))
+    Tensor::F64(
+        TypedTensor::from_buffer_col_major(
+            vec![],
+            Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(11, 1))),
+            Placement {
+                memory_kind: MemoryKind::Device,
+                device: Some(DeviceId {
+                    kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+                    ordinal: 0,
+                }),
+            },
+        )
+        .unwrap(),
+    )
 }
 
 fn get_f64_data(tensor: &Tensor) -> Vec<f64> {
     match tensor {
-        Tensor::F64(inner) => inner.host_data().to_vec(),
+        Tensor::F64(inner) => inner.host_data().unwrap().to_vec(),
         other => panic!("expected F64 tensor, got {:?}", other.dtype()),
     }
 }
@@ -57,7 +60,7 @@ fn dynamic_truncate_basic() {
     ));
     let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
 
-    let result = x.dynamic_truncate(&size, 0);
+    let result = x.dynamic_truncate(&size, 0).unwrap();
     let data = get_f64_data(&result.run_with(&mut engine).unwrap());
     assert_eq!(data, vec![1.0, 2.0, 3.0]);
 }
@@ -71,7 +74,7 @@ fn dynamic_truncate_2d_axis1() {
     ));
     let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(2.0));
 
-    let result = x.dynamic_truncate(&size, 1);
+    let result = x.dynamic_truncate(&size, 1).unwrap();
     let out = result.run_with(&mut engine).unwrap();
     assert_eq!(out.shape(), &[2, 2]);
     assert_eq!(get_f64_data(&out), vec![1.0, 5.0, 2.0, 6.0]);
@@ -83,7 +86,7 @@ fn dynamic_truncate_clamps_oversize() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
     let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(10.0));
 
-    let result = x.dynamic_truncate(&size, 0);
+    let result = x.dynamic_truncate(&size, 0).unwrap();
     let data = get_f64_data(&result.run_with(&mut engine).unwrap());
     assert_eq!(data, vec![1.0, 2.0, 3.0]);
 }
@@ -94,7 +97,7 @@ fn dynamic_truncate_accepts_i64_size() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]));
     let size = TracedTensor::from_tensor_concrete_shape(i64_scalar(2));
 
-    let result = x.dynamic_truncate(&size, 0);
+    let result = x.dynamic_truncate(&size, 0).unwrap();
     let out = result.run_with(&mut engine).unwrap();
     assert_eq!(out.shape(), &[2]);
     assert_eq!(get_f64_data(&out), vec![1.0, 2.0]);
@@ -105,7 +108,7 @@ fn dynamic_truncate_rejects_backend_size_binding_on_cpu() {
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]));
     let size = TracedTensor::input_concrete_shape(DType::F64, &[]);
-    let result = x.dynamic_truncate(&size, 0);
+    let result = x.dynamic_truncate(&size, 0).unwrap();
 
     let err = result
         .run_with_inputs_auto(&mut engine, &[(&size, &backend_f64_scalar())])
@@ -126,7 +129,7 @@ fn pad_to_match_basic() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
     let reference = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![0.0; 5]));
 
-    let result = x.pad_to_match(&reference, 0);
+    let result = x.pad_to_match(&reference, 0).unwrap();
     let data = get_f64_data(&result.run_with(&mut engine).unwrap());
     assert_eq!(data, vec![1.0, 2.0, 3.0, 0.0, 0.0]);
 }
@@ -137,7 +140,7 @@ fn pad_to_match_no_op_when_same_size() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]));
     let reference = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![0.0; 4]));
 
-    let result = x.pad_to_match(&reference, 0);
+    let result = x.pad_to_match(&reference, 0).unwrap();
     let data = get_f64_data(&result.run_with(&mut engine).unwrap());
     assert_eq!(data, vec![1.0, 2.0, 3.0, 4.0]);
 }
@@ -151,8 +154,8 @@ fn dynamic_truncate_vjp_correct() {
     ));
     let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
 
-    let truncated = x.dynamic_truncate(&size, 0);
-    let loss = (&truncated * &truncated).reduce_sum(&[0]);
+    let truncated = x.dynamic_truncate(&size, 0).unwrap();
+    let loss = (&truncated * &truncated).unwrap().reduce_sum(&[0]).unwrap();
 
     let grad = loss.grad(&x).unwrap();
     let grad_data = get_f64_data(&grad.run_with(&mut engine).unwrap());
@@ -168,8 +171,8 @@ fn dynamic_truncate_jvp_correct() {
     ));
     let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
 
-    let truncated = x.dynamic_truncate(&size, 0);
-    let loss = (&truncated * &truncated).reduce_sum(&[0]);
+    let truncated = x.dynamic_truncate(&size, 0).unwrap();
+    let loss = (&truncated * &truncated).unwrap().reduce_sum(&[0]).unwrap();
 
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![1.0; 5]));
     let jvp_result = loss.jvp(&x, &v).unwrap();
@@ -189,8 +192,8 @@ fn dynamic_truncate_hvp_correct() {
         vec![1.0, 2.0, 3.0, 4.0, 5.0],
     ));
     let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
-    let truncated = x.dynamic_truncate(&size, 0);
-    let loss = (&truncated * &truncated).reduce_sum(&[0]);
+    let truncated = x.dynamic_truncate(&size, 0).unwrap();
+    let loss = (&truncated * &truncated).unwrap().reduce_sum(&[0]).unwrap();
 
     let grad = loss.grad(&x).unwrap();
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![1.0; 5]));
@@ -218,8 +221,8 @@ fn dynamic_truncate_hvp_finite_diff() {
         let mut engine = GraphExecutor::new(CpuBackend::new());
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], values.to_vec()));
         let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
-        let truncated = x.dynamic_truncate(&size, 0);
-        let loss = (&truncated * &truncated).reduce_sum(&[0]);
+        let truncated = x.dynamic_truncate(&size, 0).unwrap();
+        let loss = (&truncated * &truncated).unwrap().reduce_sum(&[0]).unwrap();
         let grad = loss.grad(&x).unwrap();
         get_f64_data(&grad.run_with(&mut engine).unwrap())
     };
@@ -241,8 +244,8 @@ fn dynamic_truncate_hvp_finite_diff() {
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], x_data));
     let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0));
-    let truncated = x.dynamic_truncate(&size, 0);
-    let loss = (&truncated * &truncated).reduce_sum(&[0]);
+    let truncated = x.dynamic_truncate(&size, 0).unwrap();
+    let loss = (&truncated * &truncated).unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], v_data));
     let hv = grad.jvp(&x, &v).unwrap();
@@ -269,8 +272,8 @@ fn pad_to_match_vjp_correct() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
     let reference = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![0.0; 5]));
 
-    let padded = x.pad_to_match(&reference, 0);
-    let loss = (&padded * &padded).reduce_sum(&[0]);
+    let padded = x.pad_to_match(&reference, 0).unwrap();
+    let loss = (&padded * &padded).unwrap().reduce_sum(&[0]).unwrap();
 
     let grad = loss.grad(&x).unwrap();
     let grad_data = get_f64_data(&grad.run_with(&mut engine).unwrap());
@@ -283,8 +286,8 @@ fn pad_to_match_jvp_correct() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
     let reference = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![0.0; 5]));
 
-    let padded = x.pad_to_match(&reference, 0);
-    let loss = (&padded * &padded).reduce_sum(&[0]);
+    let padded = x.pad_to_match(&reference, 0).unwrap();
+    let loss = (&padded * &padded).unwrap().reduce_sum(&[0]).unwrap();
 
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 1.0, 1.0]));
     let jvp_result = loss.jvp(&x, &v).unwrap();
@@ -301,8 +304,8 @@ fn pad_to_match_hvp_correct() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0]));
     let reference = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![0.0; 5]));
 
-    let padded = x.pad_to_match(&reference, 0);
-    let loss = (&padded * &padded).reduce_sum(&[0]);
+    let padded = x.pad_to_match(&reference, 0).unwrap();
+    let loss = (&padded * &padded).unwrap().reduce_sum(&[0]).unwrap();
 
     let grad = loss.grad(&x).unwrap();
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 1.0, 1.0]));

--- a/crates/tenferro-ad/tests/eager_fixed_pivot_cross.rs
+++ b/crates/tenferro-ad/tests/eager_fixed_pivot_cross.rs
@@ -35,7 +35,8 @@ fn take_axis_rows_cols_and_block_select_static_indices() {
                 7.0, 8.0, 9.0, //
                 10.0, 11.0, 12.0,
             ],
-        ),
+        )
+        .unwrap(),
         test_ctx(),
     );
 
@@ -76,11 +77,12 @@ fn take_block_backward_accumulates_to_source() {
                 7.0, 8.0, 9.0, //
                 10.0, 11.0, 12.0,
             ],
-        ),
+        )
+        .unwrap(),
         ctx.clone(),
     );
     let weights = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx,
     );
 
@@ -89,7 +91,7 @@ fn take_block_backward_accumulates_to_source() {
     let _ = loss.backward().unwrap();
 
     assert_close_slice(
-        f64_data(x.grad().unwrap().as_ref()),
+        f64_data(x.grad().unwrap().unwrap().as_ref()),
         &[0.0, 0.0, 0.0, 5.0, 0.0, 10.0, 0.0, 0.0, 0.0, 2.0, 0.0, 4.0],
         TOL,
     );

--- a/crates/tenferro-ad/tests/eager_runtime_api.rs
+++ b/crates/tenferro-ad/tests/eager_runtime_api.rs
@@ -8,16 +8,19 @@ use tenferro_runtime::Tensor;
 fn eager_runtime_replaces_eager_context_public_name() {
     let runtime = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         runtime.clone(),
     );
     let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
 
     loss.backward().unwrap();
 
-    assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
-    runtime.clear_grads();
-    assert!(x.grad().is_none());
+    assert_eq!(
+        x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
+        &[2.0, 4.0]
+    );
+    runtime.clear_grads().unwrap();
+    assert!(x.grad().unwrap().is_none());
 }
 
 #[test]

--- a/crates/tenferro-ad/tests/eager_tensor.rs
+++ b/crates/tenferro-ad/tests/eager_tensor.rs
@@ -89,11 +89,11 @@ fn matmul_config() -> DotGeneralConfig {
 
 fn eager_matmul_sum(lhs: &[f64], rhs: &[f64]) -> f64 {
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], lhs.to_vec()),
+        Tensor::from_vec_col_major(vec![2, 3], lhs.to_vec()).unwrap(),
         test_ctx(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3, 2], rhs.to_vec()),
+        Tensor::from_vec_col_major(vec![3, 2], rhs.to_vec()).unwrap(),
         test_ctx(),
     );
     let loss = a
@@ -113,7 +113,7 @@ fn test_ctx() -> Arc<EagerRuntime> {
 #[test]
 fn eager_tensor_exposes_metadata_read_and_materialization_without_data_accessor() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap(),
         test_ctx(),
     );
 
@@ -132,7 +132,7 @@ fn eager_tensor_exposes_metadata_read_and_materialization_without_data_accessor(
 #[test]
 fn untracked_eager_transpose_is_exposed_as_borrowed_view_until_materialized() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap(),
         test_ctx(),
     );
 
@@ -154,7 +154,7 @@ fn untracked_eager_transpose_is_exposed_as_borrowed_view_until_materialized() {
 #[test]
 fn matrix_eager_input_uses_column_major_values() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap(),
         test_ctx(),
     );
     let y = x.add(&x).unwrap();
@@ -167,21 +167,25 @@ fn matrix_eager_input_uses_column_major_values() {
 fn untracked_eager_intermediate_can_later_feed_tracked_ad() {
     let ctx = test_ctx();
     let plain = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         ctx.clone(),
     );
     let scale = plain.add(&plain).unwrap();
     assert!(!scale.tracks_grad());
 
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]).unwrap(),
         ctx,
     );
     let loss = x.mul(&scale).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
 
-    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
-    x.clear_grad();
+    assert_close_slice(
+        f64_data(x.grad().unwrap().unwrap().as_ref()),
+        &[2.0, 4.0, 6.0],
+        TOL,
+    );
+    x.clear_grad().unwrap();
 }
 
 #[test]
@@ -196,7 +200,8 @@ fn eager_dot_general_with_conj_uses_untracked_fast_path() {
                 Complex64::new(-1.0, 0.75),
                 Complex64::new(0.5, 1.5),
             ],
-        ),
+        )
+        .unwrap(),
         ctx.clone(),
     );
     let rhs = EagerTensor::from_tensor_in(
@@ -208,7 +213,8 @@ fn eager_dot_general_with_conj_uses_untracked_fast_path() {
                 Complex64::new(-2.0, 0.25),
                 Complex64::new(1.5, -0.75),
             ],
-        ),
+        )
+        .unwrap(),
         ctx,
     );
     let config = matmul_config();
@@ -233,11 +239,12 @@ fn eager_gather_keeps_indices_integer_for_complex_operand() {
                 Complex64::new(2.0, -1.0),
                 Complex64::new(3.0, 0.5),
             ],
-        ),
+        )
+        .unwrap(),
         test_ctx(),
     );
     let indices = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 1], vec![2_i64, 0]),
+        Tensor::from_vec_col_major(vec![2, 1], vec![2_i64, 0]).unwrap(),
         test_ctx(),
     );
 
@@ -271,7 +278,8 @@ fn eager_index_select_keeps_indices_integer_for_complex_operand() {
                 Complex64::new(2.0, -1.0),
                 Complex64::new(3.0, 0.5),
             ],
-        ),
+        )
+        .unwrap(),
         test_ctx(),
     );
 
@@ -287,11 +295,11 @@ fn eager_index_select_keeps_indices_integer_for_complex_operand() {
 #[test]
 fn eager_stack_trailing_axis_and_index_select_primal() {
     let x0 = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         test_ctx(),
     );
     let x1 = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]),
+        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(),
         test_ctx(),
     );
 
@@ -309,7 +317,7 @@ fn eager_stack_trailing_axis_and_index_select_primal() {
 #[test]
 fn eager_index_select_rejects_invalid_axis_and_position() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         test_ctx(),
     );
 
@@ -332,11 +340,11 @@ fn eager_stack_rejects_empty_mismatched_shapes_and_invalid_axis() {
     assert!(empty_err.contains("stack requires at least one input"));
 
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         test_ctx(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![3.0_f64, 4.0, 5.0]),
+        Tensor::from_vec_col_major(vec![3], vec![3.0_f64, 4.0, 5.0]).unwrap(),
         test_ctx(),
     );
     let shape_err = EagerTensor::stack(&[&a, &b], -1).err().unwrap().to_string();
@@ -346,7 +354,7 @@ fn eager_stack_rejects_empty_mismatched_shapes_and_invalid_axis() {
     assert!(axis_err.contains("axis"), "got: {axis_err}");
 
     let c = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]),
+        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(),
         test_ctx(),
     );
     let out = EagerTensor::stack(&[&a, &c], 0).unwrap();
@@ -358,11 +366,11 @@ fn eager_stack_rejects_empty_mismatched_shapes_and_invalid_axis() {
 fn eager_index_select_repeated_positions_accumulates_grad() {
     let ctx = test_ctx();
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         ctx.clone(),
     );
     let weights = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]),
+        Tensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]).unwrap(),
         ctx,
     );
 
@@ -371,7 +379,7 @@ fn eager_index_select_repeated_positions_accumulates_grad() {
     let _ = loss.backward().unwrap();
 
     assert_close_slice(
-        f64_data(x.grad().unwrap().as_ref()),
+        f64_data(x.grad().unwrap().unwrap().as_ref()),
         &[0.0, 30.0, 30.0],
         TOL,
     );
@@ -381,12 +389,12 @@ fn eager_index_select_repeated_positions_accumulates_grad() {
 fn eager_x_squared_gradient_matches_finite_difference() {
     let x_data = vec![1.0, 2.0, 3.0];
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], x_data.clone()),
+        Tensor::from_vec_col_major(vec![3], x_data.clone()).unwrap(),
         test_ctx(),
     );
     let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
-    let grad = x.grad().unwrap();
+    let grad = x.grad().unwrap().unwrap();
 
     let grad_data = f64_data(grad.as_ref());
     let expected: Vec<f64> = (0..x_data.len())
@@ -404,17 +412,25 @@ fn eager_x_squared_gradient_matches_finite_difference() {
 #[test]
 fn eager_repeated_backward_accumulates_across_calls() {
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         test_ctx(),
     );
 
     let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
-    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
+    assert_close_slice(
+        f64_data(x.grad().unwrap().unwrap().as_ref()),
+        &[2.0, 4.0, 6.0],
+        TOL,
+    );
 
     let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
-    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[4.0, 8.0, 12.0], TOL);
+    assert_close_slice(
+        f64_data(x.grad().unwrap().unwrap().as_ref()),
+        &[4.0, 8.0, 12.0],
+        TOL,
+    );
 }
 
 #[test]
@@ -423,11 +439,11 @@ fn eager_matmul_gradients_match_finite_difference() {
     let b_data = vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0];
 
     let a = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2, 3], a_data.clone()),
+        Tensor::from_vec_col_major(vec![2, 3], a_data.clone()).unwrap(),
         test_ctx(),
     );
     let b = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3, 2], b_data.clone()),
+        Tensor::from_vec_col_major(vec![3, 2], b_data.clone()).unwrap(),
         test_ctx(),
     );
     let loss = a
@@ -437,8 +453,8 @@ fn eager_matmul_gradients_match_finite_difference() {
         .unwrap();
     let _cotangents = loss.backward().unwrap();
 
-    let grad_a = a.grad().unwrap();
-    let grad_b = b.grad().unwrap();
+    let grad_a = a.grad().unwrap().unwrap();
+    let grad_b = b.grad().unwrap().unwrap();
     let grad_a_data = f64_data(grad_a.as_ref());
     let grad_b_data = f64_data(grad_b.as_ref());
 
@@ -456,13 +472,13 @@ fn eager_matmul_gradients_match_finite_difference() {
 #[test]
 fn eager_exp_gradient_matches_primal() {
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![0.0, 1.0, 2.0]),
+        Tensor::from_vec_col_major(vec![3], vec![0.0, 1.0, 2.0]).unwrap(),
         test_ctx(),
     );
     let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
 
-    let grad = x.grad().unwrap();
+    let grad = x.grad().unwrap().unwrap();
     let expected = vec![1.0, 1.0_f64.exp(), 2.0_f64.exp()];
     assert_close_slice(f64_data(grad.as_ref()), &expected, TOL);
 }
@@ -470,13 +486,13 @@ fn eager_exp_gradient_matches_primal() {
 #[test]
 fn eager_fan_out_accumulates_gradient() {
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap(),
         test_ctx(),
     );
     let loss = x.add(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
 
-    let grad = x.grad().unwrap();
+    let grad = x.grad().unwrap().unwrap();
     assert_close_slice(f64_data(grad.as_ref()), &[2.0, 2.0, 2.0], TOL);
 }
 
@@ -484,78 +500,106 @@ fn eager_fan_out_accumulates_gradient() {
 fn eager_clear_grad_resets_only_one_leaf() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         ctx.clone(),
     );
     let y = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
 
     let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
 
-    x.clear_grad();
+    x.clear_grad().unwrap();
 
-    assert!(x.grad().is_none());
-    assert_close_slice(f64_data(y.grad().unwrap().as_ref()), &[1.0, 2.0, 3.0], TOL);
+    assert!(x.grad().unwrap().is_none());
+    assert_close_slice(
+        f64_data(y.grad().unwrap().unwrap().as_ref()),
+        &[1.0, 2.0, 3.0],
+        TOL,
+    );
 
     let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
 
-    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
-    assert_close_slice(f64_data(y.grad().unwrap().as_ref()), &[1.0, 2.0, 3.0], TOL);
+    assert_close_slice(
+        f64_data(x.grad().unwrap().unwrap().as_ref()),
+        &[2.0, 4.0, 6.0],
+        TOL,
+    );
+    assert_close_slice(
+        f64_data(y.grad().unwrap().unwrap().as_ref()),
+        &[1.0, 2.0, 3.0],
+        TOL,
+    );
 }
 
 #[test]
 fn eager_context_clear_grads_resets_all_live_leaves() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         ctx.clone(),
     );
     let y = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
 
     let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
 
-    ctx.clear_grads();
+    ctx.clear_grads().unwrap();
 
-    assert!(x.grad().is_none());
-    assert!(y.grad().is_none());
+    assert!(x.grad().unwrap().is_none());
+    assert!(y.grad().unwrap().is_none());
 
     let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
 
-    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[4.0, 5.0, 6.0], TOL);
-    assert_close_slice(f64_data(y.grad().unwrap().as_ref()), &[1.0, 2.0, 3.0], TOL);
+    assert_close_slice(
+        f64_data(x.grad().unwrap().unwrap().as_ref()),
+        &[4.0, 5.0, 6.0],
+        TOL,
+    );
+    assert_close_slice(
+        f64_data(y.grad().unwrap().unwrap().as_ref()),
+        &[1.0, 2.0, 3.0],
+        TOL,
+    );
 }
 
 #[test]
 fn eager_unrelated_backward_keeps_existing_leaf_grad() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         ctx.clone(),
     );
     let y = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
 
     let loss_x = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss_x.backward().unwrap();
-    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
+    assert_close_slice(
+        f64_data(x.grad().unwrap().unwrap().as_ref()),
+        &[2.0, 4.0, 6.0],
+        TOL,
+    );
 
     let loss_y = y.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss_y.backward().unwrap();
 
-    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[2.0, 4.0, 6.0], TOL);
     assert_close_slice(
-        f64_data(y.grad().unwrap().as_ref()),
+        f64_data(x.grad().unwrap().unwrap().as_ref()),
+        &[2.0, 4.0, 6.0],
+        TOL,
+    );
+    assert_close_slice(
+        f64_data(y.grad().unwrap().unwrap().as_ref()),
         &[8.0, 10.0, 12.0],
         TOL,
     );
@@ -565,11 +609,11 @@ fn eager_unrelated_backward_keeps_existing_leaf_grad() {
 fn eager_tracks_grad_reports_leaf_state() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let plain = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         ctx.clone(),
     );
     let leaf = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]).unwrap(),
         ctx,
     );
 
@@ -589,51 +633,55 @@ fn eager_context_and_tensor_are_backend_erased_public_types() {
     assert_send_sync::<EagerTensor>();
     assert_send_sync::<EagerRuntime>();
 
-    let ctx: Arc<EagerRuntime> = EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1));
-    let x = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]));
+    let ctx: Arc<EagerRuntime> =
+        EagerRuntime::with_cpu_backend(CpuBackend::with_threads(1).unwrap());
+    let x = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap());
     let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     loss.backward().unwrap();
 
-    assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
+    assert_eq!(
+        x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
+        &[2.0, 4.0]
+    );
 }
 
 #[test]
 fn eager_detach_cuts_one_gradient_path() {
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap(),
         test_ctx(),
     );
     let detached = x.detach();
     let loss = detached.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
     let _cotangents = loss.backward().unwrap();
 
-    let grad = x.grad().unwrap();
+    let grad = x.grad().unwrap().unwrap();
     assert_close_slice(f64_data(grad.as_ref()), &[1.0, 2.0, 3.0], TOL);
-    assert!(detached.grad().is_none());
+    assert!(detached.grad().unwrap().is_none());
 }
 
 #[test]
 fn eager_untracked_tensor_behaves_like_plain_tensor() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap(),
         test_ctx(),
     );
     let y = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3], vec![4.0, 5.0, 6.0]).unwrap(),
         test_ctx(),
     );
     let z = x.mul(&y).unwrap();
 
     assert_close_slice(f64_data(z.data()), &[4.0, 10.0, 18.0], TOL);
-    assert!(x.grad().is_none());
-    assert!(y.grad().is_none());
-    assert!(z.grad().is_none());
+    assert!(x.grad().unwrap().is_none());
+    assert!(y.grad().unwrap().is_none());
+    assert!(z.grad().unwrap().is_none());
 }
 
 #[test]
 fn eager_structural_primal_ops_transpose_and_reshape() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         test_ctx(),
     );
 
@@ -657,7 +705,7 @@ fn eager_structural_primal_ops_transpose_and_reshape() {
 #[test]
 fn eager_untracked_structural_ops_return_lazy_views() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         test_ctx(),
     );
 
@@ -683,7 +731,7 @@ fn eager_untracked_structural_ops_return_lazy_views() {
 #[test]
 fn eager_tracked_structural_ops_return_lazy_views_and_backprop() {
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         test_ctx(),
     );
 
@@ -698,18 +746,18 @@ fn eager_tracked_structural_ops_return_lazy_views_and_backprop() {
 
     let loss = transposed.reduce_sum(&[0, 1]).unwrap();
     let _cotangents = loss.backward().unwrap();
-    let grad = x.grad().unwrap();
+    let grad = x.grad().unwrap().unwrap();
     assert_close_slice(f64_data(grad.as_ref()), &[1.0; 6], TOL);
 }
 
 #[test]
 fn eager_elementwise_primal_ops_div_abs_and_sin() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![8.0_f64, -6.0, 9.0]),
+        Tensor::from_vec_col_major(vec![3], vec![8.0_f64, -6.0, 9.0]).unwrap(),
         test_ctx(),
     );
     let y = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![2.0_f64, 3.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![2.0_f64, 3.0, 3.0]).unwrap(),
         test_ctx(),
     );
 
@@ -720,7 +768,7 @@ fn eager_elementwise_primal_ops_div_abs_and_sin() {
     assert_close_slice(f64_data(abs.data()), &[8.0, 6.0, 9.0], TOL);
 
     let angles = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![0.0_f64, std::f64::consts::FRAC_PI_2]),
+        Tensor::from_vec_col_major(vec![2], vec![0.0_f64, std::f64::consts::FRAC_PI_2]).unwrap(),
         test_ctx(),
     );
     let sin = angles.sin().unwrap();
@@ -733,14 +781,15 @@ fn eager_diagonal_primal_ops_extract_diag_and_tril() {
         Tensor::from_vec_col_major(
             vec![3, 3],
             vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-        ),
+        )
+        .unwrap(),
         test_ctx(),
     );
     let diag = matrix.extract_diag(0, 1).unwrap();
     assert_close_slice(f64_data(diag.data()), &[1.0, 5.0, 9.0], TOL);
 
     let lower = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
         test_ctx(),
     )
     .tril(0)
@@ -751,7 +800,7 @@ fn eager_diagonal_primal_ops_extract_diag_and_tril() {
 #[test]
 fn eager_reduction_primal_ops_reduce_prod() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
         test_ctx(),
     );
 
@@ -773,7 +822,8 @@ fn eager_slice_primal() {
             vec![
                 1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
             ],
-        ),
+        )
+        .unwrap(),
         test_ctx(),
     );
 
@@ -797,7 +847,8 @@ fn eager_untracked_slice_returns_lazy_view() {
             vec![
                 1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
             ],
-        ),
+        )
+        .unwrap(),
         test_ctx(),
     );
 
@@ -822,7 +873,7 @@ fn eager_untracked_slice_returns_lazy_view() {
 #[test]
 fn eager_broadcast_in_dim_primal() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         test_ctx(),
     );
     let y = x.broadcast_in_dim(&[3, 2], &[0]).unwrap();
@@ -834,7 +885,7 @@ fn eager_broadcast_in_dim_primal() {
 #[test]
 fn eager_untracked_broadcast_in_dim_returns_lazy_view() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         test_ctx(),
     );
     let y = x.broadcast_in_dim(&[3, 2], &[0]).unwrap();
@@ -852,7 +903,7 @@ fn eager_untracked_broadcast_in_dim_returns_lazy_view() {
 #[test]
 fn eager_pad_primal() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         test_ctx(),
     );
     let y = x
@@ -870,7 +921,7 @@ fn eager_pad_primal() {
 #[test]
 fn eager_reverse_primal() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]),
+        Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
         test_ctx(),
     );
     let y = x.reverse(&[0]).unwrap();
@@ -881,11 +932,11 @@ fn eager_reverse_primal() {
 #[test]
 fn eager_concatenate_primal() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         test_ctx(),
     );
     let y = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]),
+        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(),
         test_ctx(),
     );
     let z = EagerTensor::concatenate(&[&x, &y], 0).unwrap();
@@ -897,11 +948,11 @@ fn eager_concatenate_primal() {
 #[test]
 fn eager_gather_primal() {
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![5], vec![10.0_f64, 20.0, 30.0, 40.0, 50.0]),
+        Tensor::from_vec_col_major(vec![5], vec![10.0_f64, 20.0, 30.0, 40.0, 50.0]).unwrap(),
         test_ctx(),
     );
     let indices = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![4_i64, 1, 0]),
+        Tensor::from_vec_col_major(vec![3], vec![4_i64, 1, 0]).unwrap(),
         test_ctx(),
     );
     let y = x
@@ -930,11 +981,12 @@ fn eager_dynamic_slice_primal() {
                 1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0,
                 15.0, 16.0,
             ],
-        ),
+        )
+        .unwrap(),
         test_ctx(),
     );
     let starts = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![2_i64, 3]),
+        Tensor::from_vec_col_major(vec![2], vec![2_i64, 3]).unwrap(),
         test_ctx(),
     );
     let y = x.dynamic_slice(&starts, &[2, 2]).unwrap();
@@ -949,7 +1001,8 @@ fn eager_conj_primal() {
         Tensor::from_vec_col_major(
             vec![2],
             vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
-        ),
+        )
+        .unwrap(),
         test_ctx(),
     );
     let y = x.conj().unwrap();
@@ -963,21 +1016,21 @@ fn eager_conj_primal() {
 #[test]
 fn eager_analytic_primal_ops_sign_log_sqrt_rsqrt_cos_tanh_expm1_log1p() {
     let sign_input = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![-2.0_f64, 0.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![-2.0_f64, 0.0, 3.0]).unwrap(),
         test_ctx(),
     );
     let sign = sign_input.sign().unwrap();
     assert_close_slice(f64_data(sign.data()), &[-1.0, 0.0, 1.0], TOL);
 
     let log_input = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, std::f64::consts::E]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, std::f64::consts::E]).unwrap(),
         test_ctx(),
     );
     let log = log_input.log().unwrap();
     assert_close_slice(f64_data(log.data()), &[0.0, 1.0], TOL);
 
     let sqrt_input = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap(),
         test_ctx(),
     );
     let sqrt = sqrt_input.sqrt().unwrap();
@@ -986,28 +1039,28 @@ fn eager_analytic_primal_ops_sign_log_sqrt_rsqrt_cos_tanh_expm1_log1p() {
     assert_close_slice(f64_data(rsqrt.data()), &[1.0, 0.5], TOL);
 
     let angles = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![0.0_f64, std::f64::consts::PI]),
+        Tensor::from_vec_col_major(vec![2], vec![0.0_f64, std::f64::consts::PI]).unwrap(),
         test_ctx(),
     );
     let cos = angles.cos().unwrap();
     assert_close_slice(f64_data(cos.data()), &[1.0, -1.0], TOL);
 
     let tanh_input = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]),
+        Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]).unwrap(),
         test_ctx(),
     );
     let tanh = tanh_input.tanh().unwrap();
     assert_close_slice(f64_data(tanh.data()), &[0.0, 1.0_f64.tanh()], TOL);
 
     let expm1_input = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]),
+        Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]).unwrap(),
         test_ctx(),
     );
     let expm1 = expm1_input.expm1().unwrap();
     assert_close_slice(f64_data(expm1.data()), &[0.0, 1.0_f64.exp_m1()], TOL);
 
     let log1p_input = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap(),
         test_ctx(),
     );
     let log1p = log1p_input.log1p().unwrap();
@@ -1017,22 +1070,22 @@ fn eager_analytic_primal_ops_sign_log_sqrt_rsqrt_cos_tanh_expm1_log1p() {
 #[test]
 fn eager_pow_maximum_and_minimum_primal() {
     let base = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 9.0]),
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 9.0]).unwrap(),
         test_ctx(),
     );
     let exp = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 0.5]),
+        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 0.5]).unwrap(),
         test_ctx(),
     );
     let pow = base.pow(&exp).unwrap();
     assert_close_slice(f64_data(pow.data()), &[8.0, 3.0], TOL);
 
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![8.0_f64, -2.0, 9.0]),
+        Tensor::from_vec_col_major(vec![3], vec![8.0_f64, -2.0, 9.0]).unwrap(),
         test_ctx(),
     );
     let y = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![2.0_f64, 5.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![2.0_f64, 5.0, 3.0]).unwrap(),
         test_ctx(),
     );
     let maximum = x.maximum(&y).unwrap();
@@ -1044,15 +1097,15 @@ fn eager_pow_maximum_and_minimum_primal() {
 #[test]
 fn eager_select_primal() {
     let condition = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![false, true, true]),
+        Tensor::from_vec_col_major(vec![3], vec![false, true, true]).unwrap(),
         test_ctx(),
     );
     let on_true = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]),
+        Tensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]).unwrap(),
         test_ctx(),
     );
     let on_false = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         test_ctx(),
     );
     let y = EagerTensor::select(&condition, &on_true, &on_false).unwrap();
@@ -1063,7 +1116,7 @@ fn eager_select_primal() {
 #[test]
 fn eager_embed_diag_and_triu_primal() {
     let diagonal = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         test_ctx(),
     );
     let embedded = diagonal.embed_diag(0, 1).unwrap();
@@ -1078,7 +1131,8 @@ fn eager_embed_diag_and_triu_primal() {
         Tensor::from_vec_col_major(
             vec![3, 3],
             vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-        ),
+        )
+        .unwrap(),
         test_ctx(),
     );
     let upper = matrix.triu(0).unwrap();

--- a/crates/tenferro-ad/tests/eager_tensor/context_and_promotion.rs
+++ b/crates/tenferro-ad/tests/eager_tensor/context_and_promotion.rs
@@ -11,10 +11,13 @@ fn context_id_is_unique() {
 fn same_context_true_for_shared_ctx() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]),
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
         ctx.clone(),
     );
-    let y = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![1], vec![2.0_f64]), ctx);
+    let y = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap(),
+        ctx,
+    );
     assert!(x.same_context(&y));
     assert_eq!(x.ctx_id(), y.ctx_id());
 }
@@ -23,8 +26,14 @@ fn same_context_true_for_shared_ctx() {
 fn same_context_false_for_different_ctx() {
     let ctx_a = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let ctx_b = EagerRuntime::with_cpu_backend(CpuBackend::new());
-    let x = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![1], vec![1.0_f64]), ctx_a);
-    let y = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![1], vec![2.0_f64]), ctx_b);
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+        ctx_a,
+    );
+    let y = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap(),
+        ctx_b,
+    );
     assert!(!x.same_context(&y));
     assert_ne!(x.ctx_id(), y.ctx_id());
 }
@@ -32,7 +41,7 @@ fn same_context_false_for_different_ctx() {
 #[test]
 fn constant_from_creates_untracked_leaf() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
-    let c = ctx.constant_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]));
+    let c = ctx.constant_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap());
     assert_eq!(c.ctx_id(), ctx.id());
     assert!(!c.tracks_grad());
     assert_eq!(f64_data(c.data()), &[1.0, 2.0]);
@@ -41,13 +50,13 @@ fn constant_from_creates_untracked_leaf() {
 #[test]
 fn variable_from_creates_tracked_leaf() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
-    let p = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]));
+    let p = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap());
     assert_eq!(p.ctx_id(), ctx.id());
     assert!(p.tracks_grad());
     // backward should work on a tracked variable
     let loss = p.exp().unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
-    assert!(p.grad().is_some());
+    assert!(p.grad().unwrap().is_some());
 }
 
 #[test]
@@ -55,11 +64,11 @@ fn cross_context_add_rejected() {
     let ctx_a = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let ctx_b = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         ctx_a,
     );
     let y = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]),
+        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(),
         ctx_b,
     );
     let msg = match x.add(&y) {
@@ -74,11 +83,11 @@ fn cross_context_mul_rejected() {
     let ctx_a = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let ctx_b = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         ctx_a,
     );
     let y = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]),
+        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(),
         ctx_b,
     );
     let msg = match x.mul(&y) {
@@ -93,11 +102,11 @@ fn cross_context_tracked_tensors_rejected() {
     let ctx_a = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let ctx_b = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         ctx_a,
     );
     let y = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]),
+        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(),
         ctx_b,
     );
     let msg = match x.add(&y) {
@@ -111,11 +120,11 @@ fn cross_context_tracked_tensors_rejected() {
 fn constant_from_can_cross_context() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         ctx.clone(),
     );
     // Import a fixed mask from a raw tensor into the same context
-    let c = ctx.constant_from(Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]));
+    let c = ctx.constant_from(Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap());
     let z = x.add(&c).unwrap();
     assert_eq!(f64_data(z.data()), &[4.0, 6.0]);
 }
@@ -125,7 +134,7 @@ fn detach_into_different_context() {
     let ctx_a = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let ctx_b = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         ctx_a,
     );
     let d = x.detach_into(&ctx_b);
@@ -134,7 +143,7 @@ fn detach_into_different_context() {
     assert_eq!(f64_data(d.data()), &[1.0, 2.0]);
     // Can operate with tensors from ctx_b now
     let y = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]),
+        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(),
         ctx_b,
     );
     let z = d.add(&y).unwrap();
@@ -146,14 +155,14 @@ fn detach_into_still_accessible_in_original_context() {
     let ctx_a = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let ctx_b = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         ctx_a.clone(),
     );
     let d = x.detach_into(&ctx_b);
     // Original tensor still in ctx_a, should work fine
     let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
-    assert!(x.grad().is_some());
+    assert!(x.grad().unwrap().is_some());
     // d is in ctx_b, x is in ctx_a
     assert_ne!(d.ctx_id(), x.ctx_id());
 }
@@ -162,11 +171,11 @@ fn detach_into_still_accessible_in_original_context() {
 fn promote_i64_add_f64_eager() {
     let ctx = test_ctx();
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1_i64, 2]),
+        Tensor::from_vec_col_major(vec![2], vec![1_i64, 2]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![0.5_f64, 1.0]),
+        Tensor::from_vec_col_major(vec![2], vec![0.5_f64, 1.0]).unwrap(),
         ctx.clone(),
     );
     // I64 + F64 should promote to F64
@@ -179,11 +188,11 @@ fn promote_i64_add_f64_eager() {
 fn promote_i64_mul_c64_eager() {
     let ctx = test_ctx();
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![1], vec![3_i64]),
+        Tensor::from_vec_col_major(vec![1], vec![3_i64]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 0.0)]),
+        Tensor::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 0.0)]).unwrap(),
         ctx,
     );
     // I64 * C64 should promote to C64
@@ -199,15 +208,17 @@ fn promote_i64_mul_c64_eager() {
 fn clamp_promotes_all_three_operands_to_common_dtype() {
     let ctx = test_ctx();
     let input = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap(),
         ctx.clone(),
     );
     let lower = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![0.0_f32, 0.0]),
+        Tensor::from_vec_col_major(vec![2], vec![0.0_f32, 0.0]).unwrap(),
         ctx.clone(),
     );
-    let upper =
-        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![1.5_f64, 1.5]), ctx);
+    let upper = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.5_f64, 1.5]).unwrap(),
+        ctx,
+    );
 
     let out = input.clamp(&lower, &upper).unwrap();
 
@@ -219,11 +230,13 @@ fn clamp_promotes_all_three_operands_to_common_dtype() {
 fn promote_f32_add_f64_eager() {
     let ctx = test_ctx();
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap(),
         ctx.clone(),
     );
-    let b =
-        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![0.5_f64, 1.0]), ctx);
+    let b = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![0.5_f64, 1.0]).unwrap(),
+        ctx,
+    );
     // F32 + F64 should promote to F64
     let z = a.add(&b).unwrap();
     assert_eq!(z.data().dtype(), DType::F64);
@@ -235,11 +248,13 @@ fn promote_same_dtype_no_conversion_penalty() {
     // Same-dtype ops should work without any conversion overhead
     let ctx = test_ctx();
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         ctx.clone(),
     );
-    let b =
-        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]), ctx);
+    let b = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(),
+        ctx,
+    );
     let z = a.add(&b).unwrap();
     assert_eq!(z.data().dtype(), DType::F64);
     assert_eq!(z.data().as_slice::<f64>().unwrap(), &[4.0, 6.0]);

--- a/crates/tenferro-ad/tests/engine_eval.rs
+++ b/crates/tenferro-ad/tests/engine_eval.rs
@@ -19,11 +19,11 @@ fn eval_exec_ir_non_consuming_preserves_caller_inputs() {
         n_slots: 3,
     };
 
-    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![2.0]));
-    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![3.0]));
+    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![2.0]).unwrap());
+    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![3.0]).unwrap());
     let inputs = vec![lhs, rhs];
 
-    let mut engine = GraphExecutor::new(CpuBackend::with_threads(1));
+    let mut engine = GraphExecutor::new(CpuBackend::with_threads(1).unwrap());
     let outputs = engine
         .eval_exec_ir_non_consuming(&program, &inputs)
         .expect("non-consuming eval should succeed");

--- a/crates/tenferro-ad/tests/exec_dispatch.rs
+++ b/crates/tenferro-ad/tests/exec_dispatch.rs
@@ -20,23 +20,23 @@ fn empty_extents(output_count: usize) -> Vec<Vec<ShapeExtent<DimExpr>>> {
 }
 
 fn scalar_tensor(value: f64) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![value]))
+    Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![value]).unwrap())
 }
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn scalar_value(tensor: &Tensor) -> f64 {
     match tensor {
-        Tensor::F64(inner) => inner.host_data()[0],
+        Tensor::F64(inner) => inner.host_data().unwrap()[0],
         other => panic!("expected scalar f64 tensor, got {other:?}"),
     }
 }
 
 fn scalar_c64_value(tensor: &Tensor) -> Complex64 {
     match tensor {
-        Tensor::C64(inner) => inner.host_data()[0],
+        Tensor::C64(inner) => inner.host_data().unwrap()[0],
         other => panic!("expected scalar c64 tensor, got {other:?}"),
     }
 }
@@ -649,7 +649,7 @@ fn eval_exec_ir_reclaims_last_use_host_buffers() {
 #[test]
 fn graph_executor_does_not_reclaim_borrowed_input_slots() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = (&x + &x).neg();
+    let y = (&x + &x).unwrap().neg();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])

--- a/crates/tenferro-ad/tests/extension_op.rs
+++ b/crates/tenferro-ad/tests/extension_op.rs
@@ -20,15 +20,12 @@ mod api_and_registry;
 mod support;
 use std::any::Any;
 use std::hash::Hasher;
-use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 use support::RunTraced;
 
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use num_complex::{Complex32, Complex64};
-use tenferro_ad::extension::{
-    apply_eager, register_extension_rule, ExtensionAdRuleTrait, ExtensionRuleSet,
-};
+use tenferro_ad::extension::{apply_eager, ExtensionAdRule, ExtensionRuleSet};
 use tenferro_cpu::CpuBackend;
 use tenferro_ops::ad::PrimitiveRuleBuilder;
 use tenferro_ops::dim_expr::DimExpr;
@@ -37,29 +34,8 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeGuardContext, SymDim};
 use tenferro_runtime::extension::{apply, ExtensionExecutionContext, ExtensionRuntime};
 use tenferro_runtime::{GraphExecutor, Tensor, TracedTensor};
-use tenferro_tensor::{DType, TensorBackend, TypedTensor};
+use tenferro_tensor::{DType, TensorBackend, TensorRead, TypedTensor};
 use tidu::ADRuleResult;
-
-// ----------------------------------------------------------------------
-// Test-only AD rule registration guard. Integration tests may share a process,
-// so register each family at most once per process.
-// ----------------------------------------------------------------------
-fn register_rule_once(rule: Arc<dyn ExtensionAdRuleTrait>) {
-    static REGISTERED: OnceLock<Mutex<Vec<&'static str>>> = OnceLock::new();
-    let guard = REGISTERED.get_or_init(|| Mutex::new(Vec::new()));
-    let mut ids = guard.lock().expect("test rule registry mutex");
-    let family_id = rule.family_id();
-    if ids.contains(&family_id) {
-        return;
-    }
-    if let Err(err) = register_extension_rule(rule) {
-        match err {
-            tenferro_ad::extension::ExtensionRegistryError::DuplicateRule { .. } => {}
-            other => panic!("register_extension_rule failed: {other}"),
-        }
-    }
-    ids.push(family_id);
-}
 
 // ----------------------------------------------------------------------
 // TestScaleBy2: single-input, single-output. y = x + x (= 2x).
@@ -112,12 +88,11 @@ impl ExtensionOp for TestScaleBy2 {
         // Reuse the same strategy the AD rules use: output = input + input.
         match input {
             Tensor::F64(inner) => {
-                let data = inner.host_data();
+                let data = inner.host_data().unwrap();
                 let sum: Vec<f64> = data.iter().map(|&v| v + v).collect();
-                Ok(vec![Tensor::F64(TypedTensor::from_vec_col_major(
-                    input.shape().to_vec(),
-                    sum,
-                ))])
+                Ok(vec![Tensor::F64(
+                    TypedTensor::from_vec_col_major(input.shape().to_vec(), sum).unwrap(),
+                )])
             }
             other => Err(tenferro_tensor::Error::backend_failure(
                 "extension",
@@ -130,14 +105,10 @@ impl ExtensionOp for TestScaleBy2 {
     }
 }
 
-fn ensure_scale_by_2_registered() {
-    register_rule_once(Arc::new(TestScaleBy2Rule));
-}
-
 #[derive(Debug)]
 struct TestScaleBy2Rule;
 
-impl ExtensionAdRuleTrait for TestScaleBy2Rule {
+impl ExtensionAdRule for TestScaleBy2Rule {
     fn family_id(&self) -> &'static str {
         "tenferro-tests.scale_by_2.v1"
     }
@@ -189,6 +160,20 @@ impl ExtensionAdRuleTrait for TestScaleBy2Rule {
             None => Ok(vec![None]),
         }
     }
+}
+
+fn scale_by_2_rules() -> ExtensionRuleSet {
+    ExtensionRuleSet::new()
+        .with_rule(Arc::new(TestScaleBy2Rule))
+        .expect("scale_by_2 rule registration")
+}
+
+fn scale_by_2_ad_context() -> AdContext {
+    AdContext::builder()
+        .with_core_rules()
+        .with_extension_rules(scale_by_2_rules())
+        .build()
+        .expect("scale_by_2 AD context")
 }
 
 // ----------------------------------------------------------------------
@@ -247,14 +232,10 @@ impl ExtensionOp for TestSwap {
     }
 }
 
-fn ensure_swap_registered() {
-    register_rule_once(Arc::new(TestSwapRule));
-}
-
 #[derive(Debug)]
 struct TestSwapRule;
 
-impl ExtensionAdRuleTrait for TestSwapRule {
+impl ExtensionAdRule for TestSwapRule {
     fn family_id(&self) -> &'static str {
         "tenferro-tests.swap.v1"
     }
@@ -282,6 +263,20 @@ impl ExtensionAdRuleTrait for TestSwapRule {
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![cotangent_out[1], cotangent_out[0]])
     }
+}
+
+fn swap_rules() -> ExtensionRuleSet {
+    ExtensionRuleSet::new()
+        .with_rule(Arc::new(TestSwapRule))
+        .expect("swap rule registration")
+}
+
+fn swap_ad_context() -> AdContext {
+    AdContext::builder()
+        .with_core_rules()
+        .with_extension_rules(swap_rules())
+        .build()
+        .expect("swap AD context")
 }
 
 // ----------------------------------------------------------------------
@@ -430,15 +425,10 @@ impl ExtensionOp for TestProbeLinear {
     }
 }
 
-fn ensure_probe_registered() {
-    register_rule_once(Arc::new(TestProbeIdentityRule));
-    register_rule_once(Arc::new(TestProbeLinearRule));
-}
-
 #[derive(Debug)]
 struct TestProbeIdentityRule;
 
-impl ExtensionAdRuleTrait for TestProbeIdentityRule {
+impl ExtensionAdRule for TestProbeIdentityRule {
     fn family_id(&self) -> &'static str {
         "tenferro-tests.probe_identity.v1"
     }
@@ -491,7 +481,7 @@ impl ExtensionAdRuleTrait for TestProbeIdentityRule {
 #[derive(Debug)]
 struct TestProbeLinearRule;
 
-impl ExtensionAdRuleTrait for TestProbeLinearRule {
+impl ExtensionAdRule for TestProbeLinearRule {
     fn family_id(&self) -> &'static str {
         "tenferro-tests.probe_linear.v1"
     }
@@ -589,6 +579,22 @@ impl ExtensionOp for TestBadOutputCount {
 // Helpers
 // ----------------------------------------------------------------------
 
+fn probe_rules() -> ExtensionRuleSet {
+    ExtensionRuleSet::new()
+        .with_rule(Arc::new(TestProbeIdentityRule))
+        .expect("probe identity rule registration")
+        .with_rule(Arc::new(TestProbeLinearRule))
+        .expect("probe linear rule registration")
+}
+
+fn probe_ad_context() -> AdContext {
+    AdContext::builder()
+        .with_core_rules()
+        .with_extension_rules(probe_rules())
+        .build()
+        .expect("probe AD context")
+}
+
 fn hash_shape(shape: &[usize], hasher: &mut dyn Hasher) {
     hasher.write_usize(shape.len());
     for &dim in shape {
@@ -598,7 +604,7 @@ fn hash_shape(shape: &[usize], hasher: &mut dyn Hasher) {
 
 fn f64_slice(tensor: &Tensor) -> &[f64] {
     match tensor {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner.host_data().unwrap(),
         _ => panic!("expected F64 tensor"),
     }
 }
@@ -620,6 +626,20 @@ impl<B: TensorBackend + 'static> ExtensionRuntime<B> for TestRuntime {
         _ctx: &mut ExtensionExecutionContext<'_, B>,
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
         op.eager_execute(inputs)
+    }
+
+    fn execute_reads(
+        &self,
+        op: &dyn ExtensionOp,
+        inputs: &[TensorRead<'_>],
+        ctx: &mut ExtensionExecutionContext<'_, B>,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let materialized_inputs: Vec<Tensor> = inputs
+            .iter()
+            .map(TensorRead::to_tensor)
+            .collect::<tenferro_tensor::Result<_>>()?;
+        let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
+        self.execute(op, &input_refs, ctx)
     }
 }
 
@@ -652,10 +672,8 @@ fn register_test_eager_runtime(runtime: &EagerRuntime, family_id: &'static str) 
 
 #[test]
 fn scale_by_2_forward_roundtrip() {
-    ensure_scale_by_2_registered();
-
-    let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
-    let outputs = apply(Arc::new(TestScaleBy2), &[&x]);
+    let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let outputs = apply(Arc::new(TestScaleBy2), &[&x]).unwrap();
     assert_eq!(outputs.len(), 1);
     let y = outputs.into_iter().next().unwrap();
 
@@ -669,17 +687,16 @@ fn scale_by_2_forward_roundtrip() {
 
 #[test]
 fn scale_by_2_grad_against_reduce_sum() {
-    ensure_scale_by_2_registered();
-
     // loss = sum(scale_by_2(x))    =>   dloss/dx = [2, 2, 2, 2]
-    let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let scaled = apply(Arc::new(TestScaleBy2), &[&x])
+        .unwrap()
         .into_iter()
         .next()
         .unwrap();
-    let loss = scaled.reduce_sum(&[0]);
+    let loss = scaled.reduce_sum(&[0]).unwrap();
 
-    let g = loss.grad(&x).expect("grad build");
+    let g = scale_by_2_ad_context().grad(&loss, &x).expect("grad build");
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let grad_out = g.run_with(&mut engine).unwrap();
 
@@ -689,12 +706,11 @@ fn scale_by_2_grad_against_reduce_sum() {
 
 #[test]
 fn scale_by_2_eager_backward_uses_registered_rule() {
-    ensure_scale_by_2_registered();
-
-    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let ad = scale_by_2_ad_context();
+    let ctx = EagerRuntime::with_cpu_backend_and_ad_context(CpuBackend::new(), &ad);
     register_test_eager_runtime(&ctx, "tenferro-tests.scale_by_2.v1");
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]),
+        Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
         ctx,
     );
     let scaled = apply_eager(Arc::new(TestScaleBy2), &[&x])
@@ -707,19 +723,20 @@ fn scale_by_2_eager_backward_uses_registered_rule() {
     let _ = loss.backward().expect("eager backward");
 
     assert_eq!(
-        x.grad().unwrap().as_slice::<f64>().unwrap(),
+        x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
         &[2.0, 2.0, 2.0, 2.0]
     );
 }
 
 #[test]
 fn ad_context_uses_owned_extension_rules_without_global_fallback() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let scaled = apply(Arc::new(TestScaleBy2), &[&x])
+        .unwrap()
         .into_iter()
         .next()
         .unwrap();
-    let loss = scaled.reduce_sum(&[0]);
+    let loss = scaled.reduce_sum(&[0]).unwrap();
 
     let empty_ad = AdContext::builder().build().unwrap();
     let err = match empty_ad.grad(&loss, &x) {
@@ -748,7 +765,7 @@ fn ad_context_uses_owned_extension_rules_without_global_fallback() {
     let grad_out = grad.run_with(&mut engine).unwrap();
     assert_eq!(f64_slice(&grad_out), &[2.0, 2.0]);
 
-    let dx = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0]);
+    let dx = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0]).unwrap();
     let jvp = ad.jvp(&scaled, &x, &dx).expect("jvp should build");
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let jvp_out = jvp.run_with(&mut engine).unwrap();
@@ -762,7 +779,7 @@ fn ad_context_uses_owned_extension_rules_without_global_fallback() {
     let jvp_out = jvp.run_with(&mut engine).unwrap();
     assert_eq!(f64_slice(&jvp_out), &[6.0, 10.0]);
 
-    let dy = TracedTensor::from_vec_col_major(vec![2], vec![7.0_f64, 11.0]);
+    let dy = TracedTensor::from_vec_col_major(vec![2], vec![7.0_f64, 11.0]).unwrap();
     let vjp = ad.vjp(&scaled, &x, &dy).expect("vjp should build");
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let vjp_out = vjp.run_with(&mut engine).unwrap();
@@ -806,7 +823,7 @@ fn eager_runtime_ad_context_uses_owned_extension_rules_without_global_fallback()
     let empty_ctx = EagerRuntime::with_cpu_backend_and_ad_context(CpuBackend::new(), &empty_ad);
     register_test_eager_runtime(&empty_ctx, "tenferro-tests.scale_by_2.v1");
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         empty_ctx,
     );
     let scaled = apply_eager(Arc::new(TestScaleBy2), &[&x])
@@ -830,8 +847,10 @@ fn eager_runtime_ad_context_uses_owned_extension_rules_without_global_fallback()
         .unwrap();
     let ctx = EagerRuntime::with_cpu_backend_and_ad_context(CpuBackend::new(), &ad);
     register_test_eager_runtime(&ctx, "tenferro-tests.scale_by_2.v1");
-    let x =
-        EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]), ctx);
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
+        ctx,
+    );
     let scaled = apply_eager(Arc::new(TestScaleBy2), &[&x])
         .expect("eager extension apply")
         .into_iter()
@@ -841,17 +860,19 @@ fn eager_runtime_ad_context_uses_owned_extension_rules_without_global_fallback()
 
     let _ = loss.backward().expect("eager backward");
 
-    assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 2.0]);
+    assert_eq!(
+        x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
+        &[2.0, 2.0]
+    );
 }
 
 fn assert_probe_identity_eager_backward(probe: Tensor) {
-    ensure_probe_registered();
-
-    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let ad = probe_ad_context();
+    let ctx = EagerRuntime::with_cpu_backend_and_ad_context(CpuBackend::new(), &ad);
     register_test_eager_runtime(&ctx, "tenferro-tests.probe_identity.v1");
     register_test_eager_runtime(&ctx, "tenferro-tests.probe_linear.v1");
     let x = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2], vec![5.0_f64, 7.0]),
+        Tensor::from_vec_col_major(vec![2], vec![5.0_f64, 7.0]).unwrap(),
         ctx.clone(),
     );
     let probe_shape = probe.shape().to_vec();
@@ -865,33 +886,51 @@ fn assert_probe_identity_eager_backward(probe: Tensor) {
 
     let _ = loss.backward().expect("eager backward");
 
-    assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[1.0, 1.0]);
+    assert_eq!(
+        x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
+        &[1.0, 1.0]
+    );
 }
 
 #[test]
 fn eager_backward_materializes_missing_tangent_zeros_for_all_probe_dtypes() {
-    assert_probe_identity_eager_backward(Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]));
-    assert_probe_identity_eager_backward(Tensor::from_vec_col_major(vec![2], vec![1_i32, 2]));
-    assert_probe_identity_eager_backward(Tensor::from_vec_col_major(vec![2], vec![1_i64, 2]));
-    assert_probe_identity_eager_backward(Tensor::from_vec_col_major(vec![2], vec![true, false]));
-    assert_probe_identity_eager_backward(Tensor::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(1.0, -1.0), Complex32::new(2.0, -2.0)],
-    ));
-    assert_probe_identity_eager_backward(Tensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, -1.0), Complex64::new(2.0, -2.0)],
-    ));
+    assert_probe_identity_eager_backward(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap(),
+    );
+    assert_probe_identity_eager_backward(
+        Tensor::from_vec_col_major(vec![2], vec![1_i32, 2]).unwrap(),
+    );
+    assert_probe_identity_eager_backward(
+        Tensor::from_vec_col_major(vec![2], vec![1_i64, 2]).unwrap(),
+    );
+    assert_probe_identity_eager_backward(
+        Tensor::from_vec_col_major(vec![2], vec![true, false]).unwrap(),
+    );
+    assert_probe_identity_eager_backward(
+        Tensor::from_vec_col_major(
+            vec![2],
+            vec![Complex32::new(1.0, -1.0), Complex32::new(2.0, -2.0)],
+        )
+        .unwrap(),
+    );
+    assert_probe_identity_eager_backward(
+        Tensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, -1.0), Complex64::new(2.0, -2.0)],
+        )
+        .unwrap(),
+    );
 }
 
 #[test]
 fn missing_extension_rule_errors_in_traced_grad() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let y = apply(Arc::new(TestNoAd), &[&x])
+        .unwrap()
         .into_iter()
         .next()
         .expect("single output");
-    let loss = y.reduce_sum(&[0]);
+    let loss = y.reduce_sum(&[0]).unwrap();
 
     let err = match loss.grad(&x) {
         Ok(_) => panic!("missing extension AD rule unexpectedly succeeded"),
@@ -905,8 +944,10 @@ fn missing_extension_rule_errors_in_traced_grad() {
 fn missing_extension_rule_errors_in_eager_backward() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     register_test_eager_runtime(&ctx, "tenferro-tests.no_ad.v1");
-    let x =
-        EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]), ctx);
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
+        ctx,
+    );
     let y = apply_eager(Arc::new(TestNoAd), &[&x])
         .expect("forward-only eager extension apply")
         .into_iter()

--- a/crates/tenferro-ad/tests/extension_op/api_and_registry.rs
+++ b/crates/tenferro-ad/tests/extension_op/api_and_registry.rs
@@ -2,21 +2,20 @@ use super::*;
 
 #[test]
 fn apply_rejects_wrong_input_count() {
-    let panic = catch_unwind(AssertUnwindSafe(|| {
-        let _ = apply(Arc::new(TestScaleBy2), &[]);
-    }));
+    let err = apply(Arc::new(TestScaleBy2), &[]).unwrap_err();
 
-    assert!(panic.is_err());
+    assert!(err.to_string().contains("expects 1 inputs, got 0"));
 }
 
 #[test]
 fn apply_rejects_mismatched_output_metadata_count() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let panic = catch_unwind(AssertUnwindSafe(|| {
-        let _ = apply(Arc::new(TestBadOutputCount), &[&x]);
-    }));
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let err = apply(Arc::new(TestBadOutputCount), &[&x]).unwrap_err();
 
-    assert!(panic.is_err());
+    let message = err.to_string();
+    assert!(message.contains("tenferro-tests.bad_output_count.v1"));
+    assert!(message.contains("produced 1 output metadata entries"));
+    assert!(message.contains("declared 2 outputs"));
 }
 
 #[test]
@@ -32,7 +31,10 @@ fn apply_eager_rejects_empty_input_list() {
 #[test]
 fn apply_eager_rejects_wrong_input_count() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
-    let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![1], vec![1.0_f64]), ctx);
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+        ctx,
+    );
 
     let err = match apply_eager(Arc::new(TestSwap), &[&x]) {
         Ok(_) => panic!("wrong eager extension input count unexpectedly succeeded"),
@@ -46,10 +48,14 @@ fn apply_eager_rejects_wrong_input_count() {
 fn apply_eager_rejects_cross_context_inputs() {
     let lhs_ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let rhs_ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
-    let lhs =
-        EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![1], vec![1.0_f64]), lhs_ctx);
-    let rhs =
-        EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![1], vec![2.0_f64]), rhs_ctx);
+    let lhs = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+        lhs_ctx,
+    );
+    let rhs = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap(),
+        rhs_ctx,
+    );
 
     let err = match apply_eager(Arc::new(TestSwap), &[&lhs, &rhs]) {
         Ok(_) => panic!("cross-context eager extension inputs unexpectedly succeeded"),
@@ -65,7 +71,10 @@ fn apply_eager_rejects_cross_context_inputs() {
 #[test]
 fn apply_eager_reports_missing_extension_runtime() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
-    let x = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![1], vec![1.0_f64]), ctx);
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+        ctx,
+    );
 
     let err = match apply_eager(Arc::new(TestScaleBy2), &[&x]) {
         Ok(_) => panic!("unregistered eager extension runtime unexpectedly succeeded"),
@@ -85,7 +94,7 @@ fn apply_eager_untracked_forward_returns_untracked_result() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     register_test_eager_runtime(&ctx, "tenferro-tests.scale_by_2.v1");
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         ctx,
     );
 
@@ -102,8 +111,9 @@ fn apply_eager_untracked_forward_returns_untracked_result() {
 
 #[test]
 fn graph_executor_reports_missing_extension_runtime() {
-    let x = TracedTensor::from_vec_col_major(vec![1], vec![1.0_f64]);
+    let x = TracedTensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
     let y = apply(Arc::new(TestScaleBy2), &[&x])
+        .unwrap()
         .into_iter()
         .next()
         .unwrap();
@@ -126,7 +136,10 @@ fn graph_executor_reports_missing_extension_runtime() {
 fn apply_eager_rejects_mismatched_output_count() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     register_test_eager_runtime(&ctx, "tenferro-tests.bad_output_count.v1");
-    let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![1], vec![1.0_f64]), ctx);
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+        ctx,
+    );
 
     let err = match apply_eager(Arc::new(TestBadOutputCount), &[&x]) {
         Ok(_) => panic!("bad eager extension output count unexpectedly succeeded"),
@@ -144,20 +157,20 @@ fn apply_eager_rejects_mismatched_output_count() {
 
 #[test]
 fn scale_by_2_grad_through_symbolic_placeholder() {
-    ensure_scale_by_2_registered();
-
     // Same loss but with an input_symbolic_shape placeholder so the AD
     // path exercises the deferred zero-tangent policy (spec
     // Section 10).
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
     let scaled = apply(Arc::new(TestScaleBy2), &[&x])
+        .unwrap()
         .into_iter()
         .next()
         .unwrap();
-    let loss = scaled.reduce_sum(&[0]);
+    let loss = scaled.reduce_sum(&[0]).unwrap();
 
-    let g = loss.grad(&x).expect("grad build");
-    let bound = Tensor::from_vec_col_major(vec![5], vec![10.0_f64, 20.0, 30.0, 40.0, 50.0]);
+    let g = scale_by_2_ad_context().grad(&loss, &x).expect("grad build");
+    let bound =
+        Tensor::from_vec_col_major(vec![5], vec![10.0_f64, 20.0, 30.0, 40.0, 50.0]).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let grad_out = g
@@ -170,11 +183,9 @@ fn scale_by_2_grad_through_symbolic_placeholder() {
 
 #[test]
 fn swap_forward_roundtrip() {
-    ensure_swap_registered();
-
-    let a = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let b = TracedTensor::from_vec_col_major(vec![2], vec![100.0_f64, 200.0]);
-    let outputs = apply(Arc::new(TestSwap), &[&a, &b]);
+    let a = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![2], vec![100.0_f64, 200.0]).unwrap();
+    let outputs = apply(Arc::new(TestSwap), &[&a, &b]).unwrap();
     assert_eq!(outputs.len(), 2);
     let mut iter = outputs.into_iter();
     let out_first = iter.next().unwrap();
@@ -192,22 +203,21 @@ fn swap_forward_roundtrip() {
 
 #[test]
 fn swap_grad_routes_cotangents_across_inputs() {
-    ensure_swap_registered();
-
     // loss = sum(out0 + out1)   where (out0, out1) = swap(a, b)
     //       = sum(b + a)
     // => dloss/da = ones_like(a),  dloss/db = ones_like(b)
-    let a = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
-    let b = TracedTensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]);
-    let swapped = apply(Arc::new(TestSwap), &[&a, &b]);
+    let a = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]).unwrap();
+    let swapped = apply(Arc::new(TestSwap), &[&a, &b]).unwrap();
     let mut iter = swapped.into_iter();
     let out0 = iter.next().unwrap();
     let out1 = iter.next().unwrap();
-    let combined = &out0 + &out1;
-    let loss = combined.reduce_sum(&[0]);
+    let combined = (&out0 + &out1).unwrap();
+    let loss = combined.reduce_sum(&[0]).unwrap();
 
-    let grad_a = loss.grad(&a).expect("grad a");
-    let grad_b = loss.grad(&b).expect("grad b");
+    let ad = swap_ad_context();
+    let grad_a = ad.grad(&loss, &a).expect("grad a");
+    let grad_b = ad.grad(&loss, &b).expect("grad b");
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let ga = grad_a.run_with(&mut engine).unwrap().clone();
@@ -219,19 +229,17 @@ fn swap_grad_routes_cotangents_across_inputs() {
 
 #[test]
 fn swap_grad_routes_only_through_active_output() {
-    ensure_swap_registered();
-
     // loss = sum(out1)  where (out0, out1) = swap(a, b)  (so out1 = a)
     // => dloss/da = ones_like(a)
-    let a = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
-    let b = TracedTensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]);
-    let swapped = apply(Arc::new(TestSwap), &[&a, &b]);
+    let a = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]).unwrap();
+    let swapped = apply(Arc::new(TestSwap), &[&a, &b]).unwrap();
     let mut iter = swapped.into_iter();
     let _out0 = iter.next().unwrap();
     let out1 = iter.next().unwrap();
-    let loss = out1.reduce_sum(&[0]);
+    let loss = out1.reduce_sum(&[0]).unwrap();
 
-    let grad_a = loss.grad(&a).expect("grad a");
+    let grad_a = swap_ad_context().grad(&loss, &a).expect("grad a");
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let ga = grad_a.run_with(&mut engine).unwrap().clone();
     assert_eq!(f64_slice(&ga), &[1.0, 1.0, 1.0]);
@@ -270,8 +278,9 @@ fn extension_carrier_hash_and_eq_are_stable() {
 fn duplicate_rule_registration_is_rejected() {
     use tenferro_ad::extension::ExtensionRegistryError;
 
-    ensure_scale_by_2_registered();
-    let err = register_extension_rule(Arc::new(TestScaleBy2Rule))
+    let mut rules = scale_by_2_rules();
+    let err = rules
+        .register_rule(Arc::new(TestScaleBy2Rule))
         .expect_err("second rule registration must error");
     assert!(matches!(
         err,
@@ -287,7 +296,7 @@ fn malformed_family_id_is_rejected() {
 
     #[derive(Debug)]
     struct BadRule;
-    impl ExtensionAdRuleTrait for BadRule {
+    impl ExtensionAdRule for BadRule {
         fn family_id(&self) -> &'static str {
             "no-version-suffix"
         }
@@ -315,8 +324,9 @@ fn malformed_family_id_is_rejected() {
         }
     }
 
-    let err =
-        register_extension_rule(Arc::new(BadRule)).expect_err("malformed family_id must error");
+    let err = ExtensionRuleSet::new()
+        .with_rule(Arc::new(BadRule))
+        .expect_err("malformed family_id must error");
     assert!(matches!(
         err,
         ExtensionRegistryError::MalformedFamilyId { .. }

--- a/crates/tenferro-ad/tests/fallible_api.rs
+++ b/crates/tenferro-ad/tests/fallible_api.rs
@@ -6,11 +6,11 @@ use tenferro_tensor::{Error as TensorError, Tensor};
 
 #[test]
 fn traced_jvp_vjp_return_errors_for_inactive_inputs() {
-    let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]);
-    let y = TracedTensor::from_vec_col_major(vec![], vec![4.0_f64]);
-    let tangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]);
-    let cotangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]);
-    let loss = &y * &y;
+    let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap();
+    let y = TracedTensor::from_vec_col_major(vec![], vec![4.0_f64]).unwrap();
+    let tangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
+    let cotangent = TracedTensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
+    let loss = (&y * &y).unwrap();
 
     let _ = loss.jvp(&x, &tangent).unwrap_err();
     let _ = loss.vjp(&x, &cotangent).unwrap_err();
@@ -20,8 +20,8 @@ fn traced_jvp_vjp_return_errors_for_inactive_inputs() {
 
 #[test]
 fn traced_jvp_vjp_return_errors_for_symbolic_seed_tensors() {
-    let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]);
-    let loss = &x * &x;
+    let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap();
+    let loss = (&x * &x).unwrap();
     let tangent = TracedTensor::input_symbolic_shape(DType::F64, 0);
     let cotangent = TracedTensor::input_symbolic_shape(DType::F64, 0);
 
@@ -40,11 +40,11 @@ fn traced_jvp_vjp_return_errors_for_symbolic_seed_tensors() {
 fn eager_binary_methods_return_shape_errors() {
     let ctx = EagerRuntime::new();
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         ctx.clone(),
     );
     let y = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         ctx,
     );
 

--- a/crates/tenferro-ad/tests/gpu_ad_tests.rs
+++ b/crates/tenferro-ad/tests/gpu_ad_tests.rs
@@ -4,12 +4,12 @@ use tenferro_ad::TracedTensorAdExt;
 mod support;
 use support::RunTraced;
 use tenferro_cpu::CpuBackend;
-use tenferro_gpu::{download_tensor, upload_tensor, CubeclBackend};
+use tenferro_gpu::{download_tensor, upload_tensor, CudaBackend};
 use tenferro_runtime::{DotGeneralConfig, GraphExecutor, Tensor, TracedTensor, TypedTensor};
 use tenferro_tensor::Buffer;
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn assert_f64_tensor_close(actual: &Tensor, expected: &Tensor, rtol: f64, atol: f64) {
@@ -18,8 +18,9 @@ fn assert_f64_tensor_close(actual: &Tensor, expected: &Tensor, rtol: f64, atol: 
             assert_eq!(actual.shape(), expected.shape());
             for (idx, (&actual, &expected)) in actual
                 .host_data()
+                .unwrap()
                 .iter()
-                .zip(expected.host_data().iter())
+                .zip(expected.host_data().unwrap().iter())
                 .enumerate()
             {
                 let tol = atol + rtol * expected.abs();
@@ -53,13 +54,13 @@ fn eval_cpu_tensor(engine: &mut GraphExecutor<CpuBackend>, tensor: &mut TracedTe
     tensor.run_with(engine).unwrap().clone()
 }
 
-fn eval_gpu_tensor(engine: &mut GraphExecutor<CubeclBackend>, tensor: &mut TracedTensor) -> Tensor {
+fn eval_gpu_tensor(engine: &mut GraphExecutor<CudaBackend>, tensor: &mut TracedTensor) -> Tensor {
     let evaluated = tensor.run_with(engine).unwrap();
     assert_device_backed(&evaluated);
     download_tensor(engine.backend().runtime(), &evaluated).unwrap()
 }
 
-fn upload_traced(backend: &CubeclBackend, tensor: &Tensor) -> TracedTensor {
+fn upload_traced(backend: &CudaBackend, tensor: &Tensor) -> TracedTensor {
     TracedTensor::from_tensor_concrete_shape(upload_tensor(backend.runtime(), tensor).unwrap())
 }
 
@@ -117,7 +118,7 @@ fn test_gpu_matmul_vjp() {
     let cpu_grad_a = eval_cpu_tensor(&mut cpu_engine, &mut grad_a_cpu);
     let cpu_grad_b = eval_cpu_tensor(&mut cpu_engine, &mut grad_b_cpu);
 
-    let gpu_backend = CubeclBackend::new(0).unwrap();
+    let gpu_backend = CudaBackend::new(0).unwrap();
     let a_gpu = upload_traced(&gpu_backend, &a_host);
     let b_gpu = upload_traced(&gpu_backend, &b_host);
     let cotangent_gpu = upload_traced(&gpu_backend, &cotangent_host);

--- a/crates/tenferro-ad/tests/gpu_f32_fusion.rs
+++ b/crates/tenferro-ad/tests/gpu_f32_fusion.rs
@@ -4,14 +4,14 @@
 
 mod support;
 use support::RunTraced;
-use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CubeclBackend};
+use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CudaBackend};
 use tenferro_runtime::{GraphExecutor, Tensor, TracedTensor, TypedTensor};
 
 fn f32_tensor(shape: Vec<usize>, data: Vec<f32>) -> Tensor {
-    Tensor::F32(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F32(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
-fn upload_traced(backend: &CubeclBackend, tensor: &Tensor) -> TracedTensor {
+fn upload_traced(backend: &CudaBackend, tensor: &Tensor) -> TracedTensor {
     TracedTensor::from_tensor_concrete_shape(upload_tensor(backend.runtime(), tensor).unwrap())
 }
 
@@ -26,7 +26,7 @@ fn test_f32_gpu_fusion_chain_e2e() {
     let b_host = f32_tensor(vec![3], vec![0.5, -1.0, 2.0]);
     let c_host = f32_tensor(vec![3], vec![0.1, 0.1, 0.1]);
 
-    let gpu_backend = CubeclBackend::new(0).unwrap();
+    let gpu_backend = CudaBackend::new(0).unwrap();
     let a = upload_traced(&gpu_backend, &a_host);
     let b = upload_traced(&gpu_backend, &b_host);
     let c = upload_traced(&gpu_backend, &c_host);

--- a/crates/tenferro-ad/tests/graph_compile.rs
+++ b/crates/tenferro-ad/tests/graph_compile.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-use tenferro_runtime::extension::{apply, ExtensionOpTrait};
+use tenferro_runtime::extension::{apply, ExtensionOp};
 use tenferro_runtime::{CompilerOptions, OptimizerConfig};
 use tenferro_runtime::{DType, GraphCompiler, TracedTensor};
 use tenferro_runtime::{SymDim, Tensor};
@@ -17,7 +17,7 @@ impl std::fmt::Debug for ConstantDebugExtension {
     }
 }
 
-impl ExtensionOpTrait for ConstantDebugExtension {
+impl ExtensionOp for ConstantDebugExtension {
     fn family_id(&self) -> &'static str {
         "tenferro-tests.graph_compile_constant_debug.v1"
     }
@@ -26,14 +26,14 @@ impl ExtensionOpTrait for ConstantDebugExtension {
         hasher.write_u64(0);
     }
 
-    fn payload_eq(&self, other: &dyn ExtensionOpTrait) -> bool {
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
         other
             .as_any()
             .downcast_ref::<ConstantDebugExtension>()
             .is_some_and(|other| self.payload == other.payload)
     }
 
-    fn clone_arc(&self) -> Arc<dyn ExtensionOpTrait> {
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
         Arc::new(self.clone())
     }
 
@@ -64,8 +64,8 @@ impl ExtensionOpTrait for ConstantDebugExtension {
 
 #[test]
 fn graph_compiler_compiles_without_backend() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let y = &x + &x;
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y = (&x + &x).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&y).unwrap();
@@ -78,7 +78,7 @@ fn graph_compiler_compiles_without_backend() {
 #[test]
 fn graph_compiler_validates_placeholder_specs() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = &x + &x;
+    let y = (&x + &x).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler
@@ -123,8 +123,9 @@ fn graph_compiler_cache_is_bounded_and_reports_stats() {
     let mut compiler = GraphCompiler::new();
     compiler.set_compile_cache_capacity(NonZeroUsize::new(1).unwrap());
 
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let _ = compiler.compile(&(&x + &x)).unwrap();
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y = (&x + &x).unwrap();
+    let _ = compiler.compile(&y).unwrap();
     let _ = compiler.compile(&x.neg()).unwrap();
 
     let stats = compiler.cache_stats();
@@ -136,7 +137,7 @@ fn graph_compiler_cache_is_bounded_and_reports_stats() {
 #[test]
 fn graph_compiler_compiler_options_setter_clears_compile_cache() {
     let mut compiler = GraphCompiler::new();
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let _ = compiler.compile(&x.neg()).unwrap();
     assert_eq!(compiler.compile_cache_len(), 1);
 
@@ -158,7 +159,7 @@ fn graph_compiler_cache_distinguishes_symbolic_input_shapes() {
     compiler.set_compile_cache_capacity(NonZeroUsize::new(4).unwrap());
 
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = &x + &x;
+    let y = (&x + &x).unwrap();
 
     let _ = compiler
         .compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])
@@ -175,10 +176,10 @@ fn graph_compiler_cache_distinguishes_dtypes() {
     let mut compiler = GraphCompiler::new();
     compiler.set_compile_cache_capacity(NonZeroUsize::new(4).unwrap());
 
-    let x_f64 = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let y_f64 = &x_f64 + &x_f64;
-    let x_f32 = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]);
-    let y_f32 = &x_f32 + &x_f32;
+    let x_f64 = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y_f64 = (&x_f64 + &x_f64).unwrap();
+    let x_f32 = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap();
+    let y_f32 = (&x_f32 + &x_f32).unwrap();
 
     let _ = compiler.compile(&y_f64).unwrap();
     let _ = compiler.compile(&y_f32).unwrap();
@@ -191,9 +192,13 @@ fn graph_compiler_cache_distinguishes_extension_payload_eq_despite_hash_collisio
     let mut compiler = GraphCompiler::new();
     compiler.set_compile_cache_capacity(NonZeroUsize::new(4).unwrap());
 
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let y1 = apply(Arc::new(ConstantDebugExtension { payload: 1 }), &[&x]).remove(0);
-    let y2 = apply(Arc::new(ConstantDebugExtension { payload: 2 }), &[&x]).remove(0);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y1 = apply(Arc::new(ConstantDebugExtension { payload: 1 }), &[&x])
+        .unwrap()
+        .remove(0);
+    let y2 = apply(Arc::new(ConstantDebugExtension { payload: 2 }), &[&x])
+        .unwrap()
+        .remove(0);
 
     let _ = compiler.compile(&y1).unwrap();
     let _ = compiler.compile(&y2).unwrap();
@@ -203,8 +208,8 @@ fn graph_compiler_cache_distinguishes_extension_payload_eq_despite_hash_collisio
 
 #[test]
 fn graph_compiler_compile_many_returns_multi_output_program() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let y = &x + &x;
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y = (&x + &x).unwrap();
     let z = x.neg();
 
     let mut compiler = GraphCompiler::new();

--- a/crates/tenferro-ad/tests/graph_executor.rs
+++ b/crates/tenferro-ad/tests/graph_executor.rs
@@ -6,8 +6,8 @@ use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor
 
 #[test]
 fn graph_executor_runs_compiled_single_output_program() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let y = &x + &x;
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y = (&x + &x).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&y).unwrap();
@@ -20,9 +20,9 @@ fn graph_executor_runs_compiled_single_output_program() {
 
 #[test]
 fn graph_executor_runs_compiled_multi_output_program() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let sum = &x + &x;
-    let product = &x * &x;
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let sum = (&x + &x).unwrap();
+    let product = (&x * &x).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile_many(&[&sum, &product]).unwrap();
@@ -37,8 +37,8 @@ fn graph_executor_runs_compiled_multi_output_program() {
 
 #[test]
 fn checkpoint_uses_explicit_compiler_and_executor() {
-    let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]);
-    let mut y = &x * &x;
+    let x = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap();
+    let mut y = (&x * &x).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let mut executor = GraphExecutor::new(CpuBackend::new());
@@ -51,8 +51,8 @@ fn checkpoint_uses_explicit_compiler_and_executor() {
 
 #[test]
 fn checkpoint_reuses_existing_cached_data_without_recompiling() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let mut y = &x + &x;
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let mut y = (&x + &x).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let mut executor = GraphExecutor::new(CpuBackend::new());
@@ -67,14 +67,14 @@ fn checkpoint_reuses_existing_cached_data_without_recompiling() {
 
 #[test]
 fn checkpoint_gradient_runs_through_graph_executor() {
-    let x = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]);
-    let mut y = &x * &x;
+    let x = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
+    let mut y = (&x * &x).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let mut executor = GraphExecutor::new(CpuBackend::new());
     y.checkpoint(&mut compiler, &mut executor).unwrap();
 
-    let z = &y * &y;
+    let z = (&y * &y).unwrap();
     let grad = z.grad(&x).unwrap();
     let program = compiler.compile(&grad).unwrap();
     let out = executor.run(&program).unwrap();
@@ -85,7 +85,7 @@ fn checkpoint_gradient_runs_through_graph_executor() {
 #[test]
 fn graph_executor_validates_runtime_bindings() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = &x + &x;
+    let y = (&x + &x).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler
@@ -93,11 +93,11 @@ fn graph_executor_validates_runtime_bindings() {
         .unwrap();
     let mut executor = GraphExecutor::new(CpuBackend::new());
 
-    let ok = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    let ok = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
     let out = executor.run_with_inputs(&program, &[(&x, &ok)]).unwrap();
     assert_eq!(out.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
 
-    let wrong_shape = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let wrong_shape = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let err = executor
         .run_with_inputs(&program, &[(&x, &wrong_shape)])
         .unwrap_err();
@@ -107,7 +107,7 @@ fn graph_executor_validates_runtime_bindings() {
 #[test]
 fn graph_executor_rejects_invalid_runtime_bindings() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = &x + &x;
+    let y = (&x + &x).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler
@@ -115,13 +115,13 @@ fn graph_executor_rejects_invalid_runtime_bindings() {
         .unwrap();
     let mut executor = GraphExecutor::new(CpuBackend::new());
 
-    let bound = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let bound = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let err = executor
         .run_with_inputs(&program, &[(&x, &bound), (&x, &bound)])
         .unwrap_err();
     assert!(matches!(err, Error::DuplicateBinding { .. }), "got {err:?}");
 
-    let data_leaf = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let data_leaf = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let err = executor
         .run_with_inputs(&program, &[(&data_leaf, &bound)])
         .unwrap_err();
@@ -139,7 +139,7 @@ fn graph_executor_rejects_invalid_runtime_bindings() {
         "got {err:?}"
     );
 
-    let wrong_dtype = Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]);
+    let wrong_dtype = Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap();
     let err = executor
         .run_with_inputs(&program, &[(&x, &wrong_dtype)])
         .unwrap_err();
@@ -178,9 +178,9 @@ fn graph_executor_eval_exec_ir_rejects_wrong_input_count() {
         n_slots: 3,
     };
     let inputs = vec![
-        Tensor::from_vec_col_major(vec![], vec![2.0_f64]),
-        Tensor::from_vec_col_major(vec![], vec![3.0_f64]),
-        Tensor::from_vec_col_major(vec![], vec![5.0_f64]),
+        Tensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap(),
+        Tensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap(),
+        Tensor::from_vec_col_major(vec![], vec![5.0_f64]).unwrap(),
     ];
 
     let mut executor = GraphExecutor::new(CpuBackend::new());
@@ -194,8 +194,8 @@ fn graph_executor_eval_exec_ir_rejects_wrong_input_count() {
 
 #[test]
 fn graph_executor_cache_stats_are_separate_from_compiler_stats() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let y = &x + &x;
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y = (&x + &x).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&y).unwrap();
@@ -225,7 +225,7 @@ fn graph_executor_runtime_cache_controls_are_available() {
 #[test]
 fn graph_executor_synthesizes_deferred_zero_tangents_from_primal_binding() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let loss = (&x * &x).reduce_sum(&[0]);
+    let loss = (&x * &x).unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let mut compiler = GraphCompiler::new();
@@ -234,7 +234,7 @@ fn graph_executor_synthesizes_deferred_zero_tangents_from_primal_binding() {
         .unwrap();
     let mut executor = GraphExecutor::new(CpuBackend::new());
 
-    let bound = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let bound = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let out = executor.run_with_inputs(&program, &[(&x, &bound)]).unwrap();
 
     assert_eq!(out.shape(), &[4]);

--- a/crates/tenferro-ad/tests/hvp.rs
+++ b/crates/tenferro-ad/tests/hvp.rs
@@ -12,7 +12,7 @@ use tenferro_runtime::{DotGeneralConfig, GraphExecutor, Tensor, TypedTensor};
 
 const TOL: f64 = 1e-5;
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn f64_scalar(val: f64) -> Tensor {
@@ -21,7 +21,7 @@ fn f64_scalar(val: f64) -> Tensor {
 
 fn get_f64_data(t: &Tensor) -> &[f64] {
     match t {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner.host_data().unwrap(),
         _ => panic!("expected F64"),
     }
 }
@@ -55,6 +55,7 @@ fn matvec(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
             rhs_batch_dims: vec![],
         },
     )
+    .unwrap()
 }
 
 fn vector_dot(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
@@ -67,6 +68,7 @@ fn vector_dot(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
             rhs_batch_dims: vec![],
         },
     )
+    .unwrap()
 }
 
 // ═════════════════════════════════════════════════════════════
@@ -82,7 +84,8 @@ fn hvp_for_scalar_cubic() {
     let x_val = 2.5_f64;
 
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(x_val));
-    let y = &(&x * &x) * &x;
+    let x_squared = (&x * &x).unwrap();
+    let y = (&x_squared * &x).unwrap();
 
     let g = y.grad(&x).unwrap(); // reverse: f'(x) = 3x^2
     let v = TracedTensor::from_tensor_concrete_shape(f64_scalar(1.0));
@@ -134,7 +137,7 @@ fn hvp_for_vector_exp_sum() {
     let n = x_data.len();
 
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![n], x_data.clone()));
-    let y = x.exp().reduce_sum(&[0]);
+    let y = x.exp().reduce_sum(&[0]).unwrap();
 
     let g = y.grad(&x).unwrap(); // shape [n]
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![n], v_data.clone()));

--- a/crates/tenferro-ad/tests/iterative_ad.rs
+++ b/crates/tenferro-ad/tests/iterative_ad.rs
@@ -25,12 +25,12 @@ const TOL: f64 = 1e-6;
 const FD_H: f64 = 1e-6;
 
 fn f64_scalar(val: f64) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![val]))
+    Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![val]).unwrap())
 }
 
 fn get_f64_scalar(t: &Tensor) -> f64 {
     match t {
-        Tensor::F64(inner) => inner.host_data()[0],
+        Tensor::F64(inner) => inner.host_data().unwrap()[0],
         _ => panic!("expected F64"),
     }
 }
@@ -91,7 +91,7 @@ fn fixed_point_traced(
 
     for iter in 1..=max_iter {
         // Build graph: x_new = a * cos(x)
-        let x_new = a * &x.cos();
+        let x_new = (a * &x.cos()).unwrap();
 
         // Convergence check — eval() must NOT break the graph
         let x_check = x_new.clone();
@@ -212,7 +212,7 @@ fn graph_size_grows_linearly() {
         let a = TracedTensor::from_tensor_concrete_shape(f64_scalar(0.8));
         let mut x = TracedTensor::from_tensor_concrete_shape(f64_scalar(0.5));
         for _ in 0..k {
-            x = &a * &x.cos();
+            x = (&a * &x.cos()).unwrap();
         }
         total_ops(x.graph())
     }

--- a/crates/tenferro-ad/tests/memory_order_api.rs
+++ b/crates/tenferro-ad/tests/memory_order_api.rs
@@ -4,7 +4,8 @@ use tenferro_runtime::{GraphCompiler, GraphExecutor, Tensor, TracedTensor};
 #[test]
 fn traced_tensor_row_major_constructor_stores_column_major_input() {
     let traced =
-        TracedTensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        TracedTensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&traced).unwrap();
@@ -19,19 +20,19 @@ fn traced_tensor_row_major_constructor_stores_column_major_input() {
 
 #[test]
 fn traced_tensor_col_major_constructor_keeps_physical_order() {
-    let traced = TracedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 3, 2, 4]);
+    let traced = TracedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 3, 2, 4]).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&traced).unwrap();
     let out = GraphExecutor::new(CpuBackend::new()).run(&program).unwrap();
     assert_eq!(
-        out.try_into_vec_col_major::<i64>().unwrap(),
+        out.into_vec_col_major::<i64>().unwrap(),
         (vec![2, 2], vec![1, 3, 2, 4]),
     );
 }
 
 #[test]
 fn tensor_row_major_constructor_remains_available_through_facade() {
-    let tensor = Tensor::from_vec_row_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let tensor = Tensor::from_vec_row_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     assert_eq!(tensor.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
 }

--- a/crates/tenferro-ad/tests/numpy_api.rs
+++ b/crates/tenferro-ad/tests/numpy_api.rs
@@ -57,9 +57,10 @@ impl ExtensionOp for TestExtensionOp {
 
 #[test]
 fn traced_add_uses_numpy_broadcasting_for_rank_padding_and_singletons() {
-    let lhs = TracedTensor::from_vec_row_major(vec![3, 1], vec![1.0_f64, 2.0, 3.0]);
-    let rhs = TracedTensor::from_vec_row_major(vec![1, 4], vec![10.0_f64, 20.0, 30.0, 40.0]);
-    let y = traced_tensor::add(&lhs, &rhs);
+    let lhs = TracedTensor::from_vec_row_major(vec![3, 1], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let rhs =
+        TracedTensor::from_vec_row_major(vec![1, 4], vec![10.0_f64, 20.0, 30.0, 40.0]).unwrap();
+    let y = traced_tensor::add(&lhs, &rhs).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&y).unwrap();
@@ -68,25 +69,25 @@ fn traced_add_uses_numpy_broadcasting_for_rank_padding_and_singletons() {
 
     assert_eq!(out.shape(), &[3, 4]);
     assert_eq!(
-        out.try_into_vec_row_major::<f64>().unwrap().1,
+        out.into_vec_row_major::<f64>().unwrap().1,
         vec![11.0, 21.0, 31.0, 41.0, 12.0, 22.0, 32.0, 42.0, 13.0, 23.0, 33.0, 43.0,]
     );
 }
 
 #[test]
 fn traced_tensor_module_exposes_initial_elementwise_free_functions() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]);
-    let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]);
-    let cond = traced_tensor::compare(&x, &y, CompareDir::Gt);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
+    let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
+    let cond = traced_tensor::compare(&x, &y, CompareDir::Gt).unwrap();
 
-    let _ = traced_tensor::sub(&x, &y);
-    let _ = traced_tensor::mul(&x, &y);
-    let _ = traced_tensor::div(&x, &y);
-    let _ = traced_tensor::pow(&x, &y);
-    let _ = traced_tensor::maximum(&x, &y);
-    let _ = traced_tensor::minimum(&x, &y);
-    let _ = traced_tensor::where_select(&cond, &x, &y);
-    let _ = traced_tensor::clamp(&x, &y, &x);
+    let _ = traced_tensor::sub(&x, &y).unwrap();
+    let _ = traced_tensor::mul(&x, &y).unwrap();
+    let _ = traced_tensor::div(&x, &y).unwrap();
+    let _ = traced_tensor::pow(&x, &y).unwrap();
+    let _ = traced_tensor::maximum(&x, &y).unwrap();
+    let _ = traced_tensor::minimum(&x, &y).unwrap();
+    let _ = traced_tensor::where_select(&cond, &x, &y).unwrap();
+    let _ = traced_tensor::clamp(&x, &y, &x).unwrap();
     let _ = traced_tensor::neg(&x);
     let _ = traced_tensor::abs(&x);
     let _ = traced_tensor::sign(&x);
@@ -111,14 +112,14 @@ fn traced_unary_methods_forward_to_distinct_primal_ops() {
         executor.run(&program).unwrap()
     }
 
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap();
     assert_eq!(run(&x.neg()).as_slice::<f64>().unwrap(), &[-1.0, -4.0]);
     assert_eq!(run(&x.abs()).as_slice::<f64>().unwrap(), &[1.0, 4.0]);
     assert_eq!(run(&x.sign()).as_slice::<f64>().unwrap(), &[1.0, 1.0]);
     assert_eq!(run(&x.sqrt()).as_slice::<f64>().unwrap(), &[1.0, 2.0]);
     assert_eq!(run(&x.rsqrt()).as_slice::<f64>().unwrap(), &[1.0, 0.5]);
 
-    let analytic = TracedTensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]);
+    let analytic = TracedTensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]).unwrap();
     let exp = run(&analytic.exp());
     let log = run(&x.log());
     let sin = run(&analytic.sin());
@@ -137,7 +138,8 @@ fn traced_unary_methods_forward_to_distinct_primal_ops() {
     let z = TracedTensor::from_vec_col_major(
         vec![2],
         vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, -4.0)],
-    );
+    )
+    .unwrap();
     assert_eq!(
         run(&z.conj()).as_slice::<Complex64>().unwrap(),
         &[Complex64::new(1.0, -2.0), Complex64::new(3.0, 4.0)]
@@ -146,12 +148,12 @@ fn traced_unary_methods_forward_to_distinct_primal_ops() {
 
 #[test]
 fn traced_compare_returns_bool_and_where_select_accepts_bool_condition() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]);
-    let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]);
-    let cond = traced_tensor::compare(&x, &y, CompareDir::Gt);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
+    let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
+    let cond = traced_tensor::compare(&x, &y, CompareDir::Gt).unwrap();
     assert_eq!(cond.dtype, DType::Bool);
 
-    let selected = traced_tensor::where_select(&cond, &x, &y);
+    let selected = traced_tensor::where_select(&cond, &x, &y).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let cond_program = compiler.compile(&cond).unwrap();
@@ -163,7 +165,7 @@ fn traced_compare_returns_bool_and_where_select_accepts_bool_condition() {
     assert_eq!(cond_out.dtype(), DType::Bool);
     assert_eq!(cond_out.as_slice::<bool>().unwrap(), &[true, false]);
     assert_eq!(
-        selected_out.try_into_vec_col_major::<f64>().unwrap().1,
+        selected_out.into_vec_col_major::<f64>().unwrap().1,
         vec![2.0, 8.0]
     );
 }
@@ -172,11 +174,11 @@ fn traced_compare_returns_bool_and_where_select_accepts_bool_condition() {
 fn eager_add_uses_numpy_broadcasting_for_rank_padding_and_singletons() {
     let ctx = EagerRuntime::new();
     let lhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_row_major(vec![3, 1], vec![1.0_f64, 2.0, 3.0]),
+        Tensor::from_vec_row_major(vec![3, 1], vec![1.0_f64, 2.0, 3.0]).unwrap(),
         ctx.clone(),
     );
     let rhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_row_major(vec![1, 4], vec![10.0_f64, 20.0, 30.0, 40.0]),
+        Tensor::from_vec_row_major(vec![1, 4], vec![10.0_f64, 20.0, 30.0, 40.0]).unwrap(),
         ctx,
     );
 
@@ -184,11 +186,7 @@ fn eager_add_uses_numpy_broadcasting_for_rank_padding_and_singletons() {
 
     assert_eq!(out.data().shape(), &[3, 4]);
     assert_eq!(
-        out.data()
-            .clone()
-            .try_into_vec_row_major::<f64>()
-            .unwrap()
-            .1,
+        out.data().clone().into_vec_row_major::<f64>().unwrap().1,
         vec![11.0, 21.0, 31.0, 41.0, 12.0, 22.0, 32.0, 42.0, 13.0, 23.0, 33.0, 43.0,]
     );
 }
@@ -197,11 +195,13 @@ fn eager_add_uses_numpy_broadcasting_for_rank_padding_and_singletons() {
 fn eager_tensor_module_exposes_initial_elementwise_free_functions() {
     let ctx = EagerRuntime::new();
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]),
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap(),
         ctx.clone(),
     );
-    let y =
-        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]), ctx);
+    let y = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap(),
+        ctx,
+    );
     let cond = eager_tensor::compare(&x, &y, CompareDir::Gt).unwrap();
 
     let _ = eager_tensor::sub(&x, &y).unwrap();
@@ -231,7 +231,7 @@ fn eager_tensor_module_exposes_initial_elementwise_free_functions() {
 fn eager_tensor_module_covers_conversion_matmul_standard_op_and_fusion() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         ctx.clone(),
     );
 
@@ -254,11 +254,11 @@ fn eager_tensor_module_covers_conversion_matmul_standard_op_and_fusion() {
     );
 
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
     let product = eager_tensor::matmul(&a, &b).unwrap();
@@ -269,14 +269,14 @@ fn eager_tensor_module_covers_conversion_matmul_standard_op_and_fusion() {
     );
 
     let lhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]),
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
         ctx.clone(),
     );
     let rhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![5.0_f64, 7.0, 11.0]),
+        Tensor::from_vec_col_major(vec![3], vec![5.0_f64, 7.0, 11.0]).unwrap(),
         ctx.clone(),
     );
-    let fused = eager_tensor::try_backend_broadcast_multiply_untracked(
+    let fused = eager_tensor::backend_broadcast_multiply_untracked(
         &lhs,
         &[2, 3],
         &[0],
@@ -293,10 +293,10 @@ fn eager_tensor_module_covers_conversion_matmul_standard_op_and_fusion() {
     );
 
     let tracked = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]),
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
         ctx.clone(),
     );
-    let skipped = eager_tensor::try_backend_broadcast_multiply_untracked(
+    let skipped = eager_tensor::backend_broadcast_multiply_untracked(
         &tracked,
         &[2, 3],
         &[0],
@@ -309,7 +309,7 @@ fn eager_tensor_module_covers_conversion_matmul_standard_op_and_fusion() {
 
     let other_ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let other = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         other_ctx,
     );
     let err = eager_tensor::add(&x, &other).err().unwrap();
@@ -320,11 +320,13 @@ fn eager_tensor_module_covers_conversion_matmul_standard_op_and_fusion() {
 fn eager_compare_returns_bool_and_where_select_accepts_bool_condition() {
     let ctx = EagerRuntime::new();
     let x = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]),
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap(),
         ctx.clone(),
     );
-    let y =
-        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]), ctx);
+    let y = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap(),
+        ctx,
+    );
 
     let cond = eager_tensor::compare(&x, &y, CompareDir::Gt).unwrap();
     let selected = eager_tensor::where_select(&cond, &x, &y).unwrap();
@@ -335,7 +337,7 @@ fn eager_compare_returns_bool_and_where_select_accepts_bool_condition() {
         selected
             .data()
             .clone()
-            .try_into_vec_col_major::<f64>()
+            .into_vec_col_major::<f64>()
             .unwrap()
             .1,
         vec![2.0, 8.0]
@@ -345,14 +347,14 @@ fn eager_compare_returns_bool_and_where_select_accepts_bool_condition() {
 #[test]
 fn tensor_add_uses_numpy_broadcasting_with_explicit_backend() {
     let mut backend = CpuBackend::new();
-    let lhs = Tensor::from_vec_row_major(vec![3, 1], vec![1.0_f64, 2.0, 3.0]);
-    let rhs = Tensor::from_vec_row_major(vec![1, 4], vec![10.0_f64, 20.0, 30.0, 40.0]);
+    let lhs = Tensor::from_vec_row_major(vec![3, 1], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let rhs = Tensor::from_vec_row_major(vec![1, 4], vec![10.0_f64, 20.0, 30.0, 40.0]).unwrap();
 
     let out = tenferro_runtime::tensor::add(&lhs, &rhs, &mut backend).unwrap();
 
     assert_eq!(out.shape(), &[3, 4]);
     assert_eq!(
-        out.try_into_vec_row_major::<f64>().unwrap().1,
+        out.into_vec_row_major::<f64>().unwrap().1,
         vec![11.0, 21.0, 31.0, 41.0, 12.0, 22.0, 32.0, 42.0, 13.0, 23.0, 33.0, 43.0,]
     );
 }
@@ -360,8 +362,8 @@ fn tensor_add_uses_numpy_broadcasting_with_explicit_backend() {
 #[test]
 fn tensor_module_exposes_initial_elementwise_free_functions() {
     let mut backend = CpuBackend::new();
-    let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]);
-    let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]);
+    let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
+    let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
     let cond = tenferro_runtime::tensor::compare(&x, &y, CompareDir::Gt, &mut backend).unwrap();
 
     let _ = tenferro_runtime::tensor::sub(&x, &y, &mut backend).unwrap();
@@ -390,8 +392,8 @@ fn tensor_module_exposes_initial_elementwise_free_functions() {
 #[test]
 fn tensor_compare_returns_bool_and_where_select_accepts_bool_condition() {
     let mut backend = CpuBackend::new();
-    let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]);
-    let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]);
+    let x = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 4.0]).unwrap();
+    let y = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]).unwrap();
 
     let cond = tenferro_runtime::tensor::compare(&x, &y, CompareDir::Gt, &mut backend).unwrap();
     let selected = tenferro_runtime::tensor::where_select(&cond, &x, &y, &mut backend).unwrap();
@@ -399,7 +401,7 @@ fn tensor_compare_returns_bool_and_where_select_accepts_bool_condition() {
     assert_eq!(cond.dtype(), DType::Bool);
     assert_eq!(cond.as_slice::<bool>().unwrap(), &[true, false]);
     assert_eq!(
-        selected.try_into_vec_col_major::<f64>().unwrap().1,
+        selected.into_vec_col_major::<f64>().unwrap().1,
         vec![2.0, 8.0]
     );
 }
@@ -407,14 +409,15 @@ fn tensor_compare_returns_bool_and_where_select_accepts_bool_condition() {
 #[test]
 fn typed_tensor_add_uses_numpy_broadcasting_with_explicit_backend() {
     let mut backend = CpuBackend::new();
-    let lhs = TypedTensor::<f64>::from_vec_row_major(vec![3, 1], vec![1.0, 2.0, 3.0]);
-    let rhs = TypedTensor::<f64>::from_vec_row_major(vec![1, 4], vec![10.0, 20.0, 30.0, 40.0]);
+    let lhs = TypedTensor::<f64>::from_vec_row_major(vec![3, 1], vec![1.0, 2.0, 3.0]).unwrap();
+    let rhs =
+        TypedTensor::<f64>::from_vec_row_major(vec![1, 4], vec![10.0, 20.0, 30.0, 40.0]).unwrap();
 
     let out = tenferro_runtime::typed_tensor::add(&lhs, &rhs, &mut backend).unwrap();
 
     assert_eq!(out.shape(), &[3, 4]);
     assert_eq!(
-        out.try_into_vec_row_major().unwrap().1,
+        out.into_vec_row_major().unwrap().1,
         vec![11.0, 21.0, 31.0, 41.0, 12.0, 22.0, 32.0, 42.0, 13.0, 23.0, 33.0, 43.0,]
     );
 }
@@ -422,8 +425,8 @@ fn typed_tensor_add_uses_numpy_broadcasting_with_explicit_backend() {
 #[test]
 fn typed_tensor_module_exposes_initial_elementwise_free_functions() {
     let mut backend = CpuBackend::new();
-    let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]);
-    let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]);
+    let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
+    let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
     let cond =
         tenferro_runtime::typed_tensor::compare(&x, &y, CompareDir::Gt, &mut backend).unwrap();
 
@@ -453,14 +456,14 @@ fn typed_tensor_module_exposes_initial_elementwise_free_functions() {
 #[test]
 fn typed_tensor_compare_returns_bool_and_where_select_accepts_bool_condition() {
     let mut backend = CpuBackend::new();
-    let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]);
-    let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]);
+    let x = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 4.0]).unwrap();
+    let y = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 8.0]).unwrap();
 
     let cond: TypedTensor<bool> =
         tenferro_runtime::typed_tensor::compare(&x, &y, CompareDir::Gt, &mut backend).unwrap();
     let selected =
         tenferro_runtime::typed_tensor::where_select(&cond, &x, &y, &mut backend).unwrap();
 
-    assert_eq!(cond.host_data(), &[true, false]);
-    assert_eq!(selected.try_into_vec_col_major().unwrap().1, vec![2.0, 8.0]);
+    assert_eq!(cond.host_data().unwrap(), &[true, false]);
+    assert_eq!(selected.into_vec_col_major().unwrap().1, vec![2.0, 8.0]);
 }

--- a/crates/tenferro-ad/tests/primitive_ops.rs
+++ b/crates/tenferro-ad/tests/primitive_ops.rs
@@ -8,23 +8,23 @@ use tenferro_runtime::GraphExecutor;
 use tenferro_tensor::{DotGeneralConfig, Tensor, TypedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn i64_tensor(shape: Vec<usize>, data: Vec<i64>) -> Tensor {
-    Tensor::I64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::I64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn get_f64_data(t: &Tensor) -> &[f64] {
     match t {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner.host_data().unwrap(),
         _ => panic!("expected F64"),
     }
 }
 
 fn get_i64_data(t: &Tensor) -> &[i64] {
     match t {
-        Tensor::I64(inner) => inner.host_data(),
+        Tensor::I64(inner) => inner.host_data().unwrap(),
         _ => panic!("expected I64"),
     }
 }
@@ -35,7 +35,7 @@ fn test_add() {
     let b = f64_tensor(vec![3], vec![4.0, 5.0, 6.0]);
     let ta = TracedTensor::from_tensor_concrete_shape(a);
     let tb = TracedTensor::from_tensor_concrete_shape(b);
-    let tc = &ta + &tb;
+    let tc = (&ta + &tb).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tc.run_with(&mut engine).unwrap();
     assert_eq!(get_f64_data(&result), &[5.0, 7.0, 9.0]);
@@ -47,7 +47,7 @@ fn test_add_broadcast_scalar_plus_vector() {
     let vector = f64_tensor(vec![3], vec![1.0, 2.0, 3.0]);
     let ta = TracedTensor::from_tensor_concrete_shape(scalar);
     let tb = TracedTensor::from_tensor_concrete_shape(vector);
-    let tc = &ta + &tb;
+    let tc = (&ta + &tb).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tc.run_with(&mut engine).unwrap();
     assert_eq!(result.shape(), &[3]);
@@ -60,7 +60,7 @@ fn test_mul() {
     let b = f64_tensor(vec![3], vec![4.0, 5.0, 6.0]);
     let ta = TracedTensor::from_tensor_concrete_shape(a);
     let tb = TracedTensor::from_tensor_concrete_shape(b);
-    let tc = &ta * &tb;
+    let tc = (&ta * &tb).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tc.run_with(&mut engine).unwrap();
     assert_eq!(get_f64_data(&result), &[4.0, 10.0, 18.0]);
@@ -72,7 +72,7 @@ fn test_mul_broadcast_column_times_row() {
     let row = f64_tensor(vec![1, 4], vec![10.0, 20.0, 30.0, 40.0]);
     let ta = TracedTensor::from_tensor_concrete_shape(column);
     let tb = TracedTensor::from_tensor_concrete_shape(row);
-    let tc = &ta * &tb;
+    let tc = (&ta * &tb).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tc.run_with(&mut engine).unwrap();
     assert_eq!(result.shape(), &[3, 4]);
@@ -88,7 +88,7 @@ fn test_div_broadcast_vector_by_scalar() {
     let scalar = f64_tensor(vec![], vec![2.0]);
     let ta = TracedTensor::from_tensor_concrete_shape(vector);
     let tb = TracedTensor::from_tensor_concrete_shape(scalar);
-    let tc = &ta / &tb;
+    let tc = (&ta / &tb).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tc.run_with(&mut engine).unwrap();
     assert_eq!(get_f64_data(&result), &[1.0, 2.0, 4.0]);
@@ -125,7 +125,7 @@ fn test_scale_real_i64_rounds_factor() {
 fn test_pow_broadcast_vector_with_scalar_exponent() {
     let base = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![2.0, 3.0, 4.0]));
     let exp = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![], vec![2.0]));
-    let out = pow(&base, &exp);
+    let out = pow(&base, &exp).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = out.run_with(&mut engine).unwrap();
     assert_eq!(result.shape(), &[3]);
@@ -146,10 +146,13 @@ fn test_neg() {
 fn traced_abs_of_complex_tensor_returns_real_tensor() {
     use num_complex::Complex64;
 
-    let x = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(3.0, 4.0), Complex64::new(5.0, 12.0)],
-    ));
+    let x = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(3.0, 4.0), Complex64::new(5.0, 12.0)],
+        )
+        .unwrap(),
+    );
     let y = x.abs();
     assert_eq!(y.dtype, DType::F64);
 
@@ -171,7 +174,7 @@ fn test_dot_general() {
         lhs_batch_dims: vec![],
         rhs_batch_dims: vec![],
     };
-    let tc = ta.dot_general(&tb, config);
+    let tc = ta.dot_general(&tb, config).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tc.run_with(&mut engine).unwrap();
     // C = [[22, 49], [28, 64]] col-major: [22, 28, 49, 64]
@@ -183,7 +186,7 @@ fn test_broadcast_reduce() {
     let v = f64_tensor(vec![3], vec![1.0, 2.0, 3.0]);
     let tv = TracedTensor::from_tensor_concrete_shape(v);
     let tb = tv.broadcast_in_dim(&[3, 2], &[0]);
-    let tr = tb.reduce_sum(&[1]);
+    let tr = tb.reduce_sum(&[1]).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tr.run_with(&mut engine).unwrap();
     assert_eq!(get_f64_data(&result), &[2.0, 4.0, 6.0]);
@@ -193,7 +196,7 @@ fn test_broadcast_reduce() {
 fn test_transpose() {
     let a = f64_tensor(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     let ta = TracedTensor::from_tensor_concrete_shape(a);
-    let tb = ta.transpose(&[1, 0]);
+    let tb = ta.transpose(&[1, 0]).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tb.run_with(&mut engine).unwrap();
     assert_eq!(get_f64_data(&result), &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
@@ -213,14 +216,17 @@ fn test_reshape() {
 fn traced_index_select_keeps_indices_integer_for_complex_operand() {
     use num_complex::Complex64;
 
-    let x = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![3],
-        vec![
-            Complex64::new(1.0, 1.0),
-            Complex64::new(2.0, -1.0),
-            Complex64::new(3.0, 0.5),
-        ],
-    ));
+    let x = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(
+            vec![3],
+            vec![
+                Complex64::new(1.0, 1.0),
+                Complex64::new(2.0, -1.0),
+                Complex64::new(3.0, 0.5),
+            ],
+        )
+        .unwrap(),
+    );
     let y = x.index_select(-1, &[2, 0]).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let out = y.run_with(&mut engine).unwrap();
@@ -246,15 +252,17 @@ fn traced_stack_trailing_axis_and_index_select_feed_batched_dot_general() {
         .unwrap()
         .index_select(-1, &[1, 0])
         .unwrap();
-    let c = a.dot_general(
-        &b,
-        DotGeneralConfig {
-            lhs_contracting_dims: vec![1],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: vec![2],
-            rhs_batch_dims: vec![2],
-        },
-    );
+    let c = a
+        .dot_general(
+            &b,
+            DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![2],
+                rhs_batch_dims: vec![2],
+            },
+        )
+        .unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let out = c.run_with(&mut engine).unwrap();
@@ -325,10 +333,9 @@ fn traced_stack_rejects_empty_mismatched_invalid_axis_and_symbolic_shapes() {
 
 #[test]
 fn traced_stack_positive_axis_promotes_mixed_input_dtypes() {
-    let a = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![2],
-        vec![1.0_f32, 2.0],
-    ));
+    let a = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap(),
+    );
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![3.0, 4.0]));
 
     let out = TracedTensor::stack(&[&a, &b], 0).unwrap();
@@ -345,8 +352,8 @@ fn test_run_many_traced() {
     let b = f64_tensor(vec![2], vec![3.0, 4.0]);
     let ta = TracedTensor::from_tensor_concrete_shape(a);
     let tb = TracedTensor::from_tensor_concrete_shape(b);
-    let sum = &ta + &tb;
-    let prod = &ta * &tb;
+    let sum = (&ta + &tb).unwrap();
+    let prod = (&ta * &tb).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let results = run_many_traced_with(&mut engine, &[&sum, &prod]).unwrap();
     assert_eq!(get_f64_data(&results[0]), &[4.0, 6.0]);
@@ -361,8 +368,8 @@ fn test_chained_ops() {
     let ta = TracedTensor::from_tensor_concrete_shape(a);
     let tb = TracedTensor::from_tensor_concrete_shape(b);
     let tc = TracedTensor::from_tensor_concrete_shape(c);
-    let sum = &ta + &tb;
-    let result = &sum * &tc;
+    let sum = (&ta + &tb).unwrap();
+    let result = (&sum * &tc).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let out = result.run_with(&mut engine).unwrap();
     assert_eq!(get_f64_data(&out), &[40.0, 120.0]);

--- a/crates/tenferro-ad/tests/segment_tests.rs
+++ b/crates/tenferro-ad/tests/segment_tests.rs
@@ -5,10 +5,10 @@ use tenferro_runtime::{DType, ExtensionCacheStore, ExtensionExecutionContext, Gr
 use tenferro_tensor::{DotGeneralConfig, Tensor, TensorValue, TypedTensor};
 
 #[cfg(feature = "cuda")]
-use tenferro_gpu::{download_tensor, upload_tensor, CubeclBackend};
+use tenferro_gpu::{download_tensor, upload_tensor, CudaBackend};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn scalar_extents(
@@ -139,10 +139,18 @@ fn cpu_parity_inputs() -> Vec<Tensor> {
 fn assert_tensor_eq(lhs: &Tensor, rhs: &Tensor) {
     assert_eq!(lhs.shape(), rhs.shape());
     match (lhs, rhs) {
-        (Tensor::F32(lhs), Tensor::F32(rhs)) => assert_eq!(lhs.host_data(), rhs.host_data()),
-        (Tensor::F64(lhs), Tensor::F64(rhs)) => assert_eq!(lhs.host_data(), rhs.host_data()),
-        (Tensor::C32(lhs), Tensor::C32(rhs)) => assert_eq!(lhs.host_data(), rhs.host_data()),
-        (Tensor::C64(lhs), Tensor::C64(rhs)) => assert_eq!(lhs.host_data(), rhs.host_data()),
+        (Tensor::F32(lhs), Tensor::F32(rhs)) => {
+            assert_eq!(lhs.host_data().unwrap(), rhs.host_data().unwrap())
+        }
+        (Tensor::F64(lhs), Tensor::F64(rhs)) => {
+            assert_eq!(lhs.host_data().unwrap(), rhs.host_data().unwrap())
+        }
+        (Tensor::C32(lhs), Tensor::C32(rhs)) => {
+            assert_eq!(lhs.host_data().unwrap(), rhs.host_data().unwrap())
+        }
+        (Tensor::C64(lhs), Tensor::C64(rhs)) => {
+            assert_eq!(lhs.host_data().unwrap(), rhs.host_data().unwrap())
+        }
         _ => panic!("dtype mismatch: lhs={lhs:?} rhs={rhs:?}"),
     }
 }
@@ -250,14 +258,14 @@ fn segmented_value_dispatch_preserves_terminal_lazy_broadcast_multiply_view() {
         "terminal broadcast-multiply segment should preserve a lazy output view"
     );
 
-    let output = outputs.pop().unwrap().to_tensor();
+    let output = outputs.pop().unwrap().to_tensor().unwrap();
     assert_eq!(output.shape(), &[2, 2, 4, 3]);
     let Tensor::F64(output) = output else {
         panic!("expected f64 output")
     };
     let lhs = inputs[0].as_slice::<f64>().unwrap();
     let rhs = inputs[1].as_slice::<f64>().unwrap();
-    let actual = output.host_data();
+    let actual = output.host_data().unwrap();
     for t in 0..3 {
         for o in 0..4 {
             for k in 0..2 {
@@ -368,7 +376,7 @@ fn gpu_host_boundary_inputs() -> Vec<Tensor> {
 }
 
 #[cfg(feature = "cuda")]
-fn upload_all(backend: &CubeclBackend, tensors: &[Tensor]) -> Vec<Tensor> {
+fn upload_all(backend: &CudaBackend, tensors: &[Tensor]) -> Vec<Tensor> {
     tensors
         .iter()
         .map(|tensor| upload_tensor(backend.runtime(), tensor).unwrap())
@@ -376,7 +384,7 @@ fn upload_all(backend: &CubeclBackend, tensors: &[Tensor]) -> Vec<Tensor> {
 }
 
 #[cfg(feature = "cuda")]
-fn download_all(backend: &CubeclBackend, tensors: &[Tensor]) -> Vec<Tensor> {
+fn download_all(backend: &CudaBackend, tensors: &[Tensor]) -> Vec<Tensor> {
     tensors
         .iter()
         .map(|tensor| download_tensor(backend.runtime(), tensor).unwrap())
@@ -389,7 +397,7 @@ fn segmented_dispatch_matches_unsegmented_dispatch_on_cubecl_host_boundaries() {
     let program = gpu_host_boundary_program();
     let host_inputs = gpu_host_boundary_inputs();
 
-    let mut gpu_unsegmented = CubeclBackend::new(0).unwrap();
+    let mut gpu_unsegmented = CudaBackend::new(0).unwrap();
     let unsegmented_inputs = upload_all(&gpu_unsegmented, &host_inputs);
     let mut extension_caches = ExtensionCacheStore::new();
     let mut unsegmented_context =
@@ -400,7 +408,7 @@ fn segmented_dispatch_matches_unsegmented_dispatch_on_cubecl_host_boundaries() {
     drop(unsegmented_context);
     let unsegmented_host = download_all(&gpu_unsegmented, &unsegmented);
 
-    let gpu_segmented_backend = CubeclBackend::new(0).unwrap();
+    let gpu_segmented_backend = CudaBackend::new(0).unwrap();
     let segmented_inputs = upload_all(&gpu_segmented_backend, &host_inputs);
     let mut gpu_segmented = GraphExecutor::new(gpu_segmented_backend);
     let segmented = gpu_segmented

--- a/crates/tenferro-ad/tests/shape_of.rs
+++ b/crates/tenferro-ad/tests/shape_of.rs
@@ -5,14 +5,14 @@ use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{GraphExecutor, Tensor, TracedTensor, TypedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn get_f64_scalar(tensor: &Tensor) -> f64 {
     match tensor {
         Tensor::F64(inner) => {
             assert_eq!(inner.shape(), &[] as &[usize]);
-            inner.host_data()[0]
+            inner.host_data().unwrap()[0]
         }
         other => panic!("expected F64 tensor, got {:?}", other.dtype()),
     }
@@ -22,9 +22,9 @@ fn get_f64_scalar(tensor: &Tensor) -> f64 {
 fn shape_of_returns_axis_size() {
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 5, 7], vec![0.0; 105]));
-    let s0 = x.shape_of(0);
-    let s1 = x.shape_of(1);
-    let s2 = x.shape_of(2);
+    let s0 = x.shape_of(0).unwrap();
+    let s1 = x.shape_of(1).unwrap();
+    let s2 = x.shape_of(2).unwrap();
 
     assert_eq!(get_f64_scalar(&s0.run_with(&mut engine).unwrap()), 3.0);
     assert_eq!(get_f64_scalar(&s1.run_with(&mut engine).unwrap()), 5.0);
@@ -34,6 +34,6 @@ fn shape_of_returns_axis_size() {
 #[test]
 fn shape_of_grad_is_zero() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4, 3], vec![0.0; 12]));
-    let s = x.shape_of(0);
+    let s = x.shape_of(0).unwrap();
     assert!(s.grad_optional(&x).unwrap().is_none());
 }

--- a/crates/tenferro-ad/tests/sym_dim.rs
+++ b/crates/tenferro-ad/tests/sym_dim.rs
@@ -3,17 +3,21 @@ use support::RunTraced;
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::error::Error;
 use tenferro_runtime::GraphExecutor;
-use tenferro_runtime::{Tensor, TracedTensor, TypedTensor};
+use tenferro_runtime::{SymDim, Tensor, TracedTensor, TypedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn get_f64_data(tensor: &Tensor) -> &[f64] {
     match tensor {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner.host_data().unwrap(),
         other => panic!("expected f64 tensor, got {other:?}"),
     }
+}
+
+fn sym_size(input: &TracedTensor, axis: usize) -> SymDim {
+    input.sym_size(axis).unwrap()
 }
 
 #[test]
@@ -22,8 +26,8 @@ fn reshape_sym_uses_symbolic_input_axes() {
         vec![2, 3, 4],
         (1..=24).map(|value| value as f64).collect(),
     ));
-    let rows = x.sym_size(0) * x.sym_size(1);
-    let cols = x.sym_size(2);
+    let rows = sym_size(&x, 0) * sym_size(&x, 1);
+    let cols = sym_size(&x, 2);
     let y = x.reshape_sym(&[rows, cols]).unwrap();
 
     assert_eq!(y.rank, 2);
@@ -45,8 +49,8 @@ fn reshape_sym_supports_mixed_usize_arithmetic() {
     ));
     let y = x
         .reshape_sym(&[
-            2usize * x.sym_size(0).max(1usize),
-            (x.sym_size(1) * x.sym_size(2).min(4usize)) / 2usize,
+            2usize * sym_size(&x, 0).max(1usize),
+            (sym_size(&x, 1) * sym_size(&x, 2).min(4usize)) / 2usize,
         ])
         .unwrap();
 
@@ -72,7 +76,7 @@ fn reshape_sym_rejects_symbolic_dims_from_another_tensor() {
         (1..=6).rev().map(|v| v as f64).collect(),
     ));
 
-    let err = match b.reshape_sym(&[a.sym_size(0), b.sym_size(1)]) {
+    let err = match b.reshape_sym(&[sym_size(&a, 0), sym_size(&b, 1)]) {
         Ok(_) => panic!("reshape_sym should reject symbolic dimensions from another tensor"),
         Err(err) => err,
     };
@@ -89,8 +93,8 @@ fn sym_dim_sub_and_div_operators() {
     ));
     // reshape [12] -> [dim0 - 2, dim0 / 2] = [10, 6]... that doesn't multiply to 12
     // Instead: reshape [12] -> [dim0 / 4, dim0 / 3] = [3, 4]
-    let a = x.sym_size(0) / 4usize;
-    let b = x.sym_size(0) / 3usize;
+    let a = sym_size(&x, 0) / 4usize;
+    let b = sym_size(&x, 0) / 3usize;
     let y = x.reshape_sym(&[a, b]).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
@@ -105,8 +109,8 @@ fn sym_dim_sub_operator() {
         (1..=6).map(|v| v as f64).collect(),
     ));
     // reshape [6] -> [dim0 - 4, dim0 - 3] = [2, 3]
-    let a = x.sym_size(0) - 4usize;
-    let b = x.sym_size(0) - 3usize;
+    let a = sym_size(&x, 0) - 4usize;
+    let b = sym_size(&x, 0) - 3usize;
     let y = x.reshape_sym(&[a, b]).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
@@ -122,8 +126,8 @@ fn sym_dim_usize_lhs_operators() {
     ));
     // 12usize / dim0 = 2, dim0 + 0usize = 6 -- but need product = 6
     // Use: 3usize + (dim0 - dim0) = 3, dim0 - 4usize = 2 => [3, 2]
-    let a = 3usize + (x.sym_size(0) - x.sym_size(0));
-    let b = x.sym_size(0) - 4usize;
+    let a = 3usize + (sym_size(&x, 0) - sym_size(&x, 0));
+    let b = sym_size(&x, 0) - 4usize;
     let y = x.reshape_sym(&[a, b]).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
@@ -139,8 +143,8 @@ fn sym_dim_usize_sub_and_div_lhs() {
         (1..=6).map(|v| v as f64).collect(),
     ));
     // 5usize - dim0 = 3, 6usize / dim1 = 2 => [3, 2]
-    let a = 5usize - x.sym_size(0);
-    let b = 6usize / x.sym_size(1);
+    let a = 5usize - sym_size(&x, 0);
+    let b = 6usize / sym_size(&x, 1);
     let y = x.reshape_sym(&[a, b]).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
@@ -155,8 +159,8 @@ fn sym_dim_min_max_methods() {
         (1..=6).map(|v| v as f64).collect(),
     ));
     // min(dim0, dim1) = 2, max(dim0, dim1) = 3 => [2, 3]
-    let a = x.sym_size(0).min(x.sym_size(1));
-    let b = x.sym_size(0).max(x.sym_size(1));
+    let a = sym_size(&x, 0).min(sym_size(&x, 1));
+    let b = sym_size(&x, 0).max(sym_size(&x, 1));
     let y = x.reshape_sym(&[a, b]).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
@@ -171,7 +175,7 @@ fn sym_dim_min_max_methods() {
 fn reshape_sym_graph_reuse_with_different_shapes() {
     // Helper: build a flatten graph from a 2-D input tensor.
     fn build_flatten(input: &TracedTensor) -> TracedTensor {
-        let total = input.sym_size(0) * input.sym_size(1);
+        let total = sym_size(input, 0) * sym_size(input, 1);
         input.reshape_sym(&[total]).unwrap()
     }
 

--- a/crates/tenferro-ad/tests/symbolic_grad.rs
+++ b/crates/tenferro-ad/tests/symbolic_grad.rs
@@ -27,12 +27,12 @@ fn f64_data(tensor: &Tensor) -> &[f64] {
 fn grad_of_sum_of_squares_against_symbolic_input() {
     // f(x) = sum(x * x), df/dx = 2 * x
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let sq = &x * &x;
-    let loss = sq.reduce_sum(&[0]);
+    let sq = (&x * &x).unwrap();
+    let loss = sq.reduce_sum(&[0]).unwrap();
 
     let g = loss.grad(&x).expect("grad build");
 
-    let bound = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let bound = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let grad_out = g
         .run_with_inputs_auto(&mut engine, &[(&x, &bound)])
@@ -46,21 +46,21 @@ fn grad_of_sum_of_squares_against_symbolic_input() {
 fn grad_evaluates_with_different_shapes_from_same_symbolic_graph() {
     // Same symbolic grad graph, eval with shape [3] then shape [5].
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let sq = &x * &x;
-    let loss = sq.reduce_sum(&[0]);
+    let sq = (&x * &x).unwrap();
+    let loss = sq.reduce_sum(&[0]).unwrap();
     let g_template = loss.grad(&x).expect("grad build");
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
 
     let g1 = g_template.clone();
-    let b1 = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    let b1 = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
     let out1 = g1
         .run_with_inputs_auto(&mut engine, &[(&x, &b1)])
         .expect("eval1");
     assert_eq!(f64_data(&out1), &[2.0, 4.0, 6.0]);
 
     let g2 = g_template.clone();
-    let b2 = Tensor::from_vec_col_major(vec![5], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0]);
+    let b2 = Tensor::from_vec_col_major(vec![5], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0]).unwrap();
     let out2 = g2
         .run_with_inputs_auto(&mut engine, &[(&x, &b2)])
         .expect("eval2");
@@ -73,14 +73,14 @@ fn grad_of_dot_product_against_two_symbolic_inputs() {
     // df/da = b, df/db = a
     let a = TracedTensor::input_symbolic_shape(DType::F64, 1);
     let b = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let loss = (&a * &b).reduce_sum(&[0]);
+    let loss = (&a * &b).unwrap().reduce_sum(&[0]).unwrap();
 
     let grad_a = loss.grad(&a).expect("grad a");
     let grad_b = loss.grad(&b).expect("grad b");
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
-    let ta = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
-    let tb = Tensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]);
+    let ta = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let tb = Tensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]).unwrap();
 
     let out_a = grad_a
         .run_with_inputs_auto(&mut engine, &[(&a, &ta), (&b, &tb)])
@@ -97,12 +97,12 @@ fn grad_of_dot_product_against_two_symbolic_inputs() {
 fn grad_with_concrete_shape_placeholder() {
     // input_concrete_shape placeholder works for AD too.
     let x = TracedTensor::input_concrete_shape(DType::F64, &[3]);
-    let sq = &x * &x;
-    let loss = sq.reduce_sum(&[0]);
+    let sq = (&x * &x).unwrap();
+    let loss = sq.reduce_sum(&[0]).unwrap();
     let g = loss.grad(&x).expect("grad build");
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
-    let bound = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    let bound = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
     let out = g
         .run_with_inputs_auto(&mut engine, &[(&x, &bound)])
         .expect("eval grad");

--- a/crates/tenferro-ad/tests/symbolic_input.rs
+++ b/crates/tenferro-ad/tests/symbolic_input.rs
@@ -27,7 +27,7 @@ fn identity_on_symbolic_input_rank_1() {
     let y = x.clone();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
-    let bound = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let bound = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let out = y
         .run_with_inputs_auto(&mut engine, &[(&x, &bound)])
         .expect("run_with_inputs");
@@ -40,11 +40,11 @@ fn identity_on_symbolic_input_rank_1() {
 fn addition_of_two_symbolic_inputs() {
     let a = TracedTensor::input_symbolic_shape(DType::F64, 1);
     let b = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = &a + &b;
+    let y = (&a + &b).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
-    let ta = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
-    let tb = Tensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]);
+    let ta = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let tb = Tensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]).unwrap();
     let out = y
         .run_with_inputs_auto(&mut engine, &[(&a, &ta), (&b, &tb)])
         .expect("run_with_inputs");
@@ -56,10 +56,11 @@ fn addition_of_two_symbolic_inputs() {
 #[test]
 fn matrix_symbolic_input_uses_column_major_values() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 2);
-    let y = &x + &x;
+    let y = (&x + &x).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
-    let bound = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let bound =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap();
     let out = y
         .run_with_inputs_auto(&mut engine, &[(&x, &bound)])
         .expect("run_with_inputs");
@@ -72,13 +73,13 @@ fn matrix_symbolic_input_uses_column_major_values() {
 fn same_symbolic_graph_reused_with_different_shapes() {
     // Build the graph once.
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let graph = &x + &x;
+    let graph = (&x + &x).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
 
     // First eval: shape [2].
     let g1 = graph.clone();
-    let bound_small = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let bound_small = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let out_small = g1
         .run_with_inputs_auto(&mut engine, &[(&x, &bound_small)])
         .expect("small eval");
@@ -87,7 +88,7 @@ fn same_symbolic_graph_reused_with_different_shapes() {
 
     // Second eval: shape [5].
     let g2 = graph.clone();
-    let bound_big = Tensor::from_vec_col_major(vec![5], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0]);
+    let bound_big = Tensor::from_vec_col_major(vec![5], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0]).unwrap();
     let out_big = g2
         .run_with_inputs_auto(&mut engine, &[(&x, &bound_big)])
         .expect("big eval");
@@ -102,7 +103,8 @@ fn concrete_shape_placeholder_accepts_exact_shape() {
     let y = x.clone();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
-    let bound = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let bound =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let out = y
         .run_with_inputs_auto(&mut engine, &[(&x, &bound)])
         .expect("run_with_inputs");
@@ -116,12 +118,12 @@ fn mixed_graph_static_and_placeholder_inputs() {
     // Binary ops that broadcast (like `+`) require both operands' shape_hint
     // to match or be concrete, so we use `input_concrete_shape` for the
     // placeholder here.
-    let static_leaf = TracedTensor::from_vec_col_major(vec![2], vec![100.0_f64, 200.0]);
+    let static_leaf = TracedTensor::from_vec_col_major(vec![2], vec![100.0_f64, 200.0]).unwrap();
     let placeholder = TracedTensor::input_concrete_shape(DType::F64, &[2]);
-    let sum = &static_leaf + &placeholder;
+    let sum = (&static_leaf + &placeholder).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
-    let bound = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let bound = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let out = sum
         .run_with_inputs_auto(&mut engine, &[(&placeholder, &bound)])
         .expect("run_with_inputs");
@@ -132,9 +134,9 @@ fn mixed_graph_static_and_placeholder_inputs() {
 
 #[test]
 fn eval_with_empty_bindings_behaves_like_eval_for_all_static_graph() {
-    let a = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let b = TracedTensor::from_vec_col_major(vec![2], vec![10.0_f64, 20.0]);
-    let y = &a + &b;
+    let a = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![2], vec![10.0_f64, 20.0]).unwrap();
+    let y = (&a + &b).unwrap();
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let out = y
@@ -162,7 +164,7 @@ fn symbolic_placeholder_is_concrete_shape_false() {
 
 #[test]
 fn from_tensor_symbolic_shape_drops_shape_but_keeps_data() {
-    let tensor = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let tensor = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let x = TracedTensor::from_tensor_symbolic_shape(tensor);
     assert!(!x.is_concrete_shape());
 

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -43,9 +43,6 @@ blas-mkl = [
     "strided-einsum2/blas-mkl",
     "strided-einsum2/parallel",
 ]
-src-openblas = ["blas-openblas"]
-src-accelerate = ["blas-accelerate"]
-src-intel-mkl-dynamic-parallel = ["blas-mkl"]
 
 [dependencies]
 tenferro-tensor = { path = "../tenferro-tensor", version = "0.1.0" }

--- a/crates/tenferro-cpu/benches/cpu_install_overhead.rs
+++ b/crates/tenferro-cpu/benches/cpu_install_overhead.rs
@@ -6,12 +6,12 @@ fn bench_cpu_context_entry_overhead(c: &mut Criterion) {
     let mut group = c.benchmark_group("cpu_context_entry_overhead/one_thread");
 
     group.bench_function("ctx_install_inline_empty", |b| {
-        let ctx = CpuContext::with_threads(1);
+        let ctx = CpuContext::with_threads(1).unwrap();
         b.iter(|| ctx.install(|| black_box(1usize)));
     });
 
     group.bench_function("backend_install_inline_empty", |b| {
-        let backend = CpuBackend::with_threads(1);
+        let backend = CpuBackend::with_threads(1).unwrap();
         b.iter(|| backend.install(|| black_box(1usize)));
     });
 
@@ -24,7 +24,7 @@ fn bench_cpu_context_entry_overhead(c: &mut Criterion) {
     });
 
     group.bench_function("ctx_install_inline_with_buffer_pool", |b| {
-        let ctx = CpuContext::with_threads(1);
+        let ctx = CpuContext::with_threads(1).unwrap();
         let mut buffers = BufferPool::new();
         b.iter(|| {
             let mut taken = std::mem::take(black_box(&mut buffers));
@@ -38,7 +38,7 @@ fn bench_cpu_context_entry_overhead(c: &mut Criterion) {
     });
 
     group.bench_function("ctx_install_inline_with_buffer_pool_and_cache", |b| {
-        let ctx = CpuContext::with_threads(1);
+        let ctx = CpuContext::with_threads(1).unwrap();
         let mut buffers = BufferPool::new();
         let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
         b.iter(|| {

--- a/crates/tenferro-cpu/benches/dot_general_overhead.rs
+++ b/crates/tenferro-cpu/benches/dot_general_overhead.rs
@@ -57,7 +57,7 @@ fn complex_tensor(shape: &[usize], seed: usize) -> Tensor {
             Complex64::new(real, imag)
         })
         .collect();
-    Tensor::from_vec_col_major(shape.to_vec(), data)
+    Tensor::from_vec_col_major(shape.to_vec(), data).unwrap()
 }
 
 fn build_mps_fixture(sites: usize, phys_dim: usize, bond_dim: usize) -> MpsFixture {
@@ -80,7 +80,7 @@ fn build_mps_fixture(sites: usize, phys_dim: usize, bond_dim: usize) -> MpsFixtu
 }
 
 fn scalar_one() -> Tensor {
-    Tensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 0.0)])
+    Tensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 0.0)]).unwrap()
 }
 
 fn inner_fresh_backend_cache(
@@ -179,7 +179,7 @@ fn bench_dot_general_overhead(c: &mut Criterion) {
 
         group.bench_function(BenchmarkId::new("fresh_backend_cache", &params), |b| {
             b.iter(|| {
-                let mut backend = CpuBackend::with_threads(1);
+                let mut backend = CpuBackend::with_threads(1).unwrap();
                 let output = inner_fresh_backend_cache(
                     black_box(&mut backend),
                     black_box(&fixture.bra_tensors),
@@ -194,7 +194,7 @@ fn bench_dot_general_overhead(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     (
-                        CpuBackend::with_threads(1),
+                        CpuBackend::with_threads(1).unwrap(),
                         <CpuBackend as BackendRuntimeCache>::RuntimeCache::default(),
                     )
                 },
@@ -216,7 +216,7 @@ fn bench_dot_general_overhead(c: &mut Criterion) {
             b.iter_batched(
                 || {
                     (
-                        CpuBackend::with_threads(1),
+                        CpuBackend::with_threads(1).unwrap(),
                         <CpuBackend as BackendRuntimeCache>::RuntimeCache::default(),
                     )
                 },

--- a/crates/tenferro-cpu/benches/pairwise_contraction.rs
+++ b/crates/tenferro-cpu/benches/pairwise_contraction.rs
@@ -76,7 +76,7 @@ fn complex_tensor(shape: &[usize], seed: usize) -> Tensor {
             Complex64::new(real, imag)
         })
         .collect();
-    Tensor::from_vec_col_major(shape.to_vec(), data)
+    Tensor::from_vec_col_major(shape.to_vec(), data).unwrap()
 }
 
 fn build_fixtures(phys_dim: usize, chi: usize) -> Fixtures {
@@ -241,7 +241,7 @@ fn bench_pairwise_contraction(c: &mut Criterion) {
             let case_params = format!("{}/{}", case.name(), params);
 
             group.bench_function(BenchmarkId::new("normal_per_call", &case_params), |b| {
-                let mut backend = CpuBackend::with_threads(threads);
+                let mut backend = CpuBackend::with_threads(threads).unwrap();
                 b.iter(|| {
                     let output = run_case_normal(
                         black_box(&mut backend),
@@ -256,7 +256,7 @@ fn bench_pairwise_contraction(c: &mut Criterion) {
             group.bench_function(
                 BenchmarkId::new("cached_analysis_per_call", &case_params),
                 |b| {
-                    let mut backend = CpuBackend::with_threads(threads);
+                    let mut backend = CpuBackend::with_threads(threads).unwrap();
                     let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
                     b.iter(|| {
                         let output = run_case_cached(

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -301,7 +301,7 @@ impl CpuBackend {
     /// use tenferro_cpu::CpuBackend;
     ///
     /// let backend = CpuBackend::try_new()
-    ///     .unwrap_or_else(|_| CpuBackend::with_threads(1));
+    ///     .unwrap_or_else(|_| CpuBackend::with_threads(1).unwrap());
     /// let _ = backend.num_threads();
     /// ```
     pub fn try_new() -> crate::Result<Self> {
@@ -316,7 +316,7 @@ impl CpuBackend {
     /// use std::sync::Arc;
     /// use tenferro_cpu::{CpuBackend, CpuContext};
     ///
-    /// let ctx = Arc::new(CpuContext::with_threads(2));
+    /// let ctx = Arc::new(CpuContext::with_threads(2).unwrap());
     /// let backend = CpuBackend::from_context(ctx);
     /// assert_eq!(backend.num_threads(), 2);
     /// ```
@@ -351,7 +351,7 @@ impl CpuBackend {
     /// use std::sync::Arc;
     /// use tenferro_cpu::{CpuBackend, CpuContext};
     ///
-    /// let ctx = Arc::new(CpuContext::with_threads(1));
+    /// let ctx = Arc::new(CpuContext::with_threads(1).unwrap());
     /// let backend = CpuBackend::from_context_with_buffer_pool_limit(ctx, 0);
     /// assert_eq!(backend.buffer_pool_limit_bytes(), 0);
     /// ```
@@ -385,61 +385,50 @@ impl CpuBackend {
     /// ```
     /// use tenferro_cpu::CpuBackend;
     ///
-    /// let backend = CpuBackend::with_threads(2);
+    /// let backend = CpuBackend::with_threads(2).unwrap();
     /// assert_eq!(backend.num_threads(), 2);
     /// ```
-    pub fn with_threads(num_threads: usize) -> Self {
-        match Self::try_with_threads(num_threads) {
-            Ok(backend) => backend,
-            Err(err) => panic!("{err}"),
-        }
-    }
-
-    /// Try to create a CPU backend with a custom thread count.
     ///
-    /// # Examples
+    /// # Errors
     ///
-    /// ```
-    /// use tenferro_cpu::CpuBackend;
-    ///
-    /// let backend = CpuBackend::try_with_threads(1).unwrap();
-    /// assert_eq!(backend.num_threads(), 1);
-    /// ```
-    pub fn try_with_threads(num_threads: usize) -> crate::Result<Self> {
-        CpuContext::try_with_threads(num_threads)
+    /// Returns an error when `num_threads` is zero or Rayon rejects the pool.
+    pub fn with_threads(num_threads: usize) -> crate::Result<Self> {
+        CpuContext::with_threads(num_threads)
             .map(|ctx| Self::from_context(Arc::new(ctx)))
             .map_err(|err| match err {
                 crate::Error::InvalidConfig { message, .. } => crate::Error::InvalidConfig {
-                    op: "CpuBackend::try_with_threads",
+                    op: "CpuBackend::with_threads",
                     message,
                 },
                 crate::Error::BackendFailure { message, .. } => {
-                    crate::Error::backend_failure("CpuBackend::try_with_threads", message)
+                    crate::Error::backend_failure("CpuBackend::with_threads", message)
                 }
                 err => err,
             })
     }
 
-    /// Try to create a CPU backend with a custom thread count and provider.
+    /// Create a CPU backend with a custom thread count and provider.
     ///
     /// # Examples
     ///
     /// ```
     /// use tenferro_cpu::{CpuBackend, CpuBackendKind};
     ///
-    /// let backend = CpuBackend::try_with_threads_and_kind(
+    /// let backend = CpuBackend::with_threads_and_kind(
     ///     1,
     ///     CpuBackendKind::default_compiled(),
     /// )?;
     /// assert_eq!(backend.num_threads(), 1);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn try_with_threads_and_kind(
-        num_threads: usize,
-        kind: CpuBackendKind,
-    ) -> crate::Result<Self> {
-        ensure_cpu_backend_kind_available(kind, "CpuBackend::try_with_threads_and_kind")?;
-        CpuContext::try_with_threads(num_threads)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `num_threads` is zero, Rayon rejects the pool, or
+    /// the selected provider is unavailable.
+    pub fn with_threads_and_kind(num_threads: usize, kind: CpuBackendKind) -> crate::Result<Self> {
+        ensure_cpu_backend_kind_available(kind, "CpuBackend::with_threads_and_kind")?;
+        CpuContext::with_threads(num_threads)
             .map(|ctx| Self {
                 ctx: Arc::new(ctx),
                 buffers: BufferPool::new(),
@@ -447,11 +436,11 @@ impl CpuBackend {
             })
             .map_err(|err| match err {
                 crate::Error::InvalidConfig { message, .. } => crate::Error::InvalidConfig {
-                    op: "CpuBackend::try_with_threads_and_kind",
+                    op: "CpuBackend::with_threads_and_kind",
                     message,
                 },
                 crate::Error::BackendFailure { message, .. } => {
-                    crate::Error::backend_failure("CpuBackend::try_with_threads_and_kind", message)
+                    crate::Error::backend_failure("CpuBackend::with_threads_and_kind", message)
                 }
                 err => err,
             })
@@ -478,7 +467,7 @@ impl CpuBackend {
     /// ```
     /// use tenferro_cpu::CpuBackend;
     ///
-    /// let backend = CpuBackend::with_threads(2);
+    /// let backend = CpuBackend::with_threads(2).unwrap();
     /// assert_eq!(backend.num_threads(), 2);
     /// ```
     pub fn num_threads(&self) -> usize {
@@ -540,7 +529,7 @@ impl CpuBackend {
     /// use tenferro_cpu::{CpuBackend, CpuContext};
     ///
     /// let backend = CpuBackend::from_context_with_buffer_pool_limit(
-    ///     Arc::new(CpuContext::with_threads(1)),
+    ///     Arc::new(CpuContext::with_threads(1).unwrap()),
     ///     4096,
     /// );
     /// assert_eq!(backend.buffer_pool_limit_bytes(), 4096);
@@ -595,7 +584,7 @@ impl CpuBackend {
     /// ```
     /// use tenferro_cpu::CpuBackend;
     ///
-    /// let backend = CpuBackend::with_threads(1);
+    /// let backend = CpuBackend::with_threads(1).unwrap();
     /// let value = backend.install(|| 1 + 1);
     /// assert_eq!(value, 2);
     /// ```

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -53,20 +53,19 @@ fn explicit_blas_backend_kind_constructor_records_selection() {
 }
 
 #[test]
-fn try_with_threads_and_kind_records_selection_and_validates_threads() {
-    let backend =
-        CpuBackend::try_with_threads_and_kind(1, CpuBackendKind::default_compiled()).unwrap();
+fn with_threads_and_kind_records_selection_and_validates_threads() {
+    let backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::default_compiled()).unwrap();
     assert_eq!(backend.num_threads(), 1);
     assert_eq!(backend.kind(), CpuBackendKind::default_compiled());
 
-    let err = match CpuBackend::try_with_threads_and_kind(0, CpuBackendKind::default_compiled()) {
+    let err = match CpuBackend::with_threads_and_kind(0, CpuBackendKind::default_compiled()) {
         Ok(_) => panic!("expected invalid thread count to fail"),
         Err(err) => err,
     };
     assert!(matches!(
         err,
         crate::Error::InvalidConfig {
-            op: "CpuBackend::try_with_threads_and_kind",
+            op: "CpuBackend::with_threads_and_kind",
             ..
         }
     ));
@@ -88,7 +87,7 @@ fn unavailable_blas_backend_kind_reports_config_errors() {
     ));
 
     let mut backend = CpuBackend {
-        ctx: Arc::new(CpuContext::with_threads(1)),
+        ctx: Arc::new(CpuContext::with_threads(1).unwrap()),
         buffers: BufferPool::new(),
         kind: CpuBackendKind::Blas,
     };
@@ -99,8 +98,8 @@ fn unavailable_blas_backend_kind_reports_config_errors() {
     assert_eq!(retained, 1);
     assert_eq!(backend.buffer_pool_len(), 1);
 
-    let lhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]);
-    let rhs = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]);
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![0],
         rhs_contracting_dims: vec![0],
@@ -159,7 +158,7 @@ fn cpu_session_profile_helpers_cover_current_profile_mode() {
 
 #[test]
 fn with_linalg_pool_restores_backend_pool_and_context() {
-    let mut backend = CpuBackend::with_threads(1);
+    let mut backend = CpuBackend::with_threads(1).unwrap();
 
     let len_inside_pool = backend.with_linalg_pool(|pool| {
         <f64 as PoolScalar>::pool_release(pool, vec![1.0, 2.0, 3.0, 4.0]);
@@ -179,7 +178,7 @@ fn cached_faer_gemm_pool_helper_enters_owned_rayon_pool() {
     let ambient_threads = rayon::current_num_threads();
     let configured_threads = if ambient_threads == 2 { 3 } else { 2 };
     let mut backend =
-        CpuBackend::try_with_threads_and_kind(configured_threads, CpuBackendKind::Faer).unwrap();
+        CpuBackend::with_threads_and_kind(configured_threads, CpuBackendKind::Faer).unwrap();
     let mut cache = gemm::GemmAnalysisCache::default();
 
     let seen_threads =
@@ -192,8 +191,8 @@ fn cached_faer_gemm_pool_helper_enters_owned_rayon_pool() {
 fn cached_dot_dispatch_reports_dtype_mismatches() {
     let mut backend = CpuBackend::new();
     let mut cache = gemm::GemmAnalysisCache::default();
-    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![1.0]));
-    let rhs = Tensor::F32(TypedTensor::from_vec_col_major(vec![1], vec![1.0]));
+    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![1.0]).unwrap());
+    let rhs = Tensor::F32(TypedTensor::from_vec_col_major(vec![1], vec![1.0]).unwrap());
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![0],
         rhs_contracting_dims: vec![0],
@@ -222,8 +221,6 @@ fn cached_dot_dispatch_reports_dtype_mismatches() {
 }
 
 #[test]
-fn with_threads_panics_on_invalid_thread_count() {
-    let panic = std::panic::catch_unwind(|| CpuBackend::with_threads(0));
-
-    assert!(panic.is_err());
+fn with_threads_rejects_invalid_thread_count() {
+    assert!(CpuBackend::with_threads(0).is_err());
 }

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -13,7 +13,7 @@ use crate::{Error, Result};
 /// ```
 /// use tenferro_cpu::CpuContext;
 ///
-/// let ctx = CpuContext::with_threads(1);
+/// let ctx = CpuContext::with_threads(1).unwrap();
 /// let value = ctx.install(|| 1 + 1);
 /// assert_eq!(value, 2);
 /// assert_eq!(ctx.num_threads(), 1);
@@ -37,8 +37,9 @@ impl CpuContext {
     /// assert!(ctx.num_threads() >= 1);
     /// ```
     pub fn from_env() -> Self {
-        Self::try_from_env()
-            .unwrap_or_else(|_| Self::with_threads(super::affinity::available_parallelism()))
+        Self::try_from_env().unwrap_or_else(|_| {
+            Self::with_threads(super::affinity::available_parallelism()).unwrap()
+        })
     }
 
     /// Try to create a CPU context from `RAYON_NUM_THREADS`.
@@ -49,7 +50,7 @@ impl CpuContext {
     /// use tenferro_cpu::CpuContext;
     ///
     /// let ctx = CpuContext::try_from_env()
-    ///     .unwrap_or_else(|_| CpuContext::with_threads(1));
+    ///     .unwrap_or_else(|_| CpuContext::with_threads(1).unwrap());
     /// assert!(ctx.num_threads() >= 1);
     /// ```
     pub fn try_from_env() -> Result<Self> {
@@ -59,7 +60,7 @@ impl CpuContext {
                     op: "CpuContext::try_from_env",
                     message: format!("invalid RAYON_NUM_THREADS value {value:?}: {err}"),
                 })?;
-                Self::try_with_threads(num_threads).map_err(|err| match err {
+                Self::with_threads(num_threads).map_err(|err| match err {
                     Error::InvalidConfig { message, .. } => Error::InvalidConfig {
                         op: "CpuContext::try_from_env",
                         message: format!("invalid RAYON_NUM_THREADS value {value:?}: {message}"),
@@ -68,7 +69,7 @@ impl CpuContext {
                 })
             }
             Err(env::VarError::NotPresent) => {
-                Self::try_with_threads(super::affinity::available_parallelism())
+                Self::with_threads(super::affinity::available_parallelism())
             }
             Err(err) => Err(Error::InvalidConfig {
                 op: "CpuContext::try_from_env",
@@ -84,39 +85,17 @@ impl CpuContext {
     /// ```
     /// use tenferro_cpu::CpuContext;
     ///
-    /// let ctx = CpuContext::with_threads(2);
+    /// let ctx = CpuContext::with_threads(2).unwrap();
     /// assert_eq!(ctx.num_threads(), 2);
     /// ```
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics when `num_threads` is invalid or Rayon rejects the pool. This is
-    /// the compatibility wrapper; new runtime-facing code should use
-    /// [`CpuContext::try_with_threads`] to receive a typed error.
-    pub fn with_threads(num_threads: usize) -> Self {
-        // Intentional compatibility panic wrapper. Keep `try_with_threads` as
-        // the non-panicking API so audits do not mistake this for an unhandled
-        // validation path.
-        match Self::try_with_threads(num_threads) {
-            Ok(ctx) => ctx,
-            Err(err) => panic!("{err}"),
-        }
-    }
-
-    /// Try to create a CPU context with a fixed parallelism hint.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_cpu::CpuContext;
-    ///
-    /// let ctx = CpuContext::try_with_threads(1).unwrap();
-    /// assert_eq!(ctx.num_threads(), 1);
-    /// ```
-    pub fn try_with_threads(num_threads: usize) -> Result<Self> {
+    /// Returns an error when `num_threads` is zero or Rayon rejects the pool.
+    pub fn with_threads(num_threads: usize) -> Result<Self> {
         if num_threads == 0 {
             return Err(Error::InvalidConfig {
-                op: "CpuContext::try_with_threads",
+                op: "CpuContext::with_threads",
                 message: "thread count must be at least 1".into(),
             });
         }
@@ -128,7 +107,7 @@ impl CpuContext {
                     .num_threads(num_threads)
                     .build()
                     .map_err(|err| Error::InvalidConfig {
-                        op: "CpuContext::try_with_threads",
+                        op: "CpuContext::with_threads",
                         message: format!("failed to build CPU thread pool: {err}"),
                     })?,
             ))
@@ -143,7 +122,7 @@ impl CpuContext {
     /// ```
     /// use tenferro_cpu::CpuContext;
     ///
-    /// let ctx = CpuContext::with_threads(2);
+    /// let ctx = CpuContext::with_threads(2).unwrap();
     /// assert_eq!(ctx.num_threads(), 2);
     /// ```
     pub fn num_threads(&self) -> usize {
@@ -157,7 +136,7 @@ impl CpuContext {
     /// ```
     /// use tenferro_cpu::CpuContext;
     ///
-    /// let ctx = CpuContext::with_threads(1);
+    /// let ctx = CpuContext::with_threads(1).unwrap();
     /// let value = ctx.install(|| 1 + 1);
     /// assert_eq!(value, 2);
     /// ```

--- a/crates/tenferro-cpu/src/context/tests.rs
+++ b/crates/tenferro-cpu/src/context/tests.rs
@@ -1,6 +1,6 @@
 use super::CpuContext;
 
 #[test]
-fn try_with_threads_rejects_zero() {
-    assert!(CpuContext::try_with_threads(0).is_err());
+fn with_threads_rejects_zero() {
+    assert!(CpuContext::with_threads(0).is_err());
 }

--- a/crates/tenferro-cpu/src/elementwise.rs
+++ b/crates/tenferro-cpu/src/elementwise.rs
@@ -164,7 +164,9 @@ fn complex_scalar_tensor<T>(scalar: T) -> TypedTensor<Complex<T>>
 where
     T: Copy + Clone + Zero,
 {
+    // Invariant: scalar shape `[]` always requires exactly one value.
     TypedTensor::from_vec_col_major(vec![], vec![Complex::new(scalar, T::zero())])
+        .expect("scalar complex tensor has a valid compact shape")
 }
 
 fn complex_scalar_tensor_from_tensor<T>(
@@ -1114,7 +1116,7 @@ struct LazyOuterProductStrideSpec<'a> {
 }
 
 fn lazy_outer_product_strides(spec: LazyOuterProductStrideSpec<'_>) -> crate::Result<Vec<isize>> {
-    let base_strides = col_major_strides(spec.base_shape);
+    let base_strides = col_major_strides(spec.base_shape)?;
     let mut logical_strides = vec![None; spec.output_shape.len()];
     let mut base_axis = 0usize;
 

--- a/crates/tenferro-cpu/src/elementwise/tests.rs
+++ b/crates/tenferro-cpu/src/elementwise/tests.rs
@@ -30,7 +30,7 @@ fn rank_n_outer_product_fast_path_accepts_matrix_operands() {
             })
         })
         .collect();
-    assert_eq!(out.as_slice(), expected.as_slice());
+    assert_eq!(out.as_slice().unwrap(), expected.as_slice());
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn batched_outer_product_fast_path_accepts_shared_batch_axis() {
             (0..4).flat_map(move |o| (0..2).map(move |j| lhs_data[j + 2 * t] * rhs_data[o + 4 * t]))
         })
         .collect();
-    assert_eq!(out.as_slice(), expected.as_slice());
+    assert_eq!(out.as_slice().unwrap(), expected.as_slice());
 }
 
 #[test]
@@ -153,14 +153,10 @@ fn broadcast_multiply_fallback_handles_permuted_elementwise_without_materializat
     let mut buffers = BufferPool::default();
     let lhs_data: Vec<f64> = (0..24).map(|i| (i + 1) as f64).collect();
     let rhs_data: Vec<f64> = (0..24).map(|i| (100 + i) as f64).collect();
-    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3, 4],
-        lhs_data.clone(),
-    ));
-    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4, 2, 3],
-        rhs_data.clone(),
-    ));
+    let lhs =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 3, 4], lhs_data.clone()).unwrap());
+    let rhs =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![4, 2, 3], rhs_data.clone()).unwrap());
 
     let out = broadcast_multiply_read_with_pool(
         &mut buffers,
@@ -213,9 +209,9 @@ fn lazy_outer_product_lhs_prefix_preserves_logical_output_order() {
     .expect("non-canonical lhs physical order should use lazy outer-product output");
 
     assert_eq!(out.shape, vec![2, 3, 4]);
-    assert_ne!(out.strides, col_major_strides(&out.shape));
+    assert_ne!(out.strides, col_major_strides(&out.shape).unwrap());
     let value = lazy_outer_product_value(Tensor::F64(out.base), out.shape, out.strides).unwrap();
-    let tensor = value.to_tensor();
+    let tensor = value.to_tensor().unwrap();
     let expected: Vec<f64> = (0..4)
         .flat_map(|k| {
             (0..3).flat_map(move |j| (0..2).map(move |i| lhs_data[i * 3 + j] * rhs_data[k]))
@@ -246,9 +242,9 @@ fn lazy_outer_product_rhs_prefix_preserves_logical_output_order() {
     .expect("rhs-prefix output should still support lazy non-canonical lhs order");
 
     assert_eq!(out.shape, vec![4, 2, 3]);
-    assert_ne!(out.strides, col_major_strides(&out.shape));
+    assert_ne!(out.strides, col_major_strides(&out.shape).unwrap());
     let value = lazy_outer_product_value(Tensor::F64(out.base), out.shape, out.strides).unwrap();
-    let tensor = value.to_tensor();
+    let tensor = value.to_tensor().unwrap();
     let expected: Vec<f64> = (0..3)
         .flat_map(|j| {
             (0..2).flat_map(move |i| (0..4).map(move |k| rhs_data[k] * lhs_data[i * 3 + j]))
@@ -300,13 +296,13 @@ fn assert_backend_failure<T>(result: crate::Result<T>, op: &'static str) {
 #[test]
 fn typed_view_helpers_cover_scalar_and_validation_paths() {
     let mut buffers = BufferPool::default();
-    let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 4.0]);
-    let rhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![10.0, 20.0]);
-    let scalar = TypedTensor::<f64>::from_vec_col_major(vec![], vec![2.0]);
-    let short = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![99.0]);
-    let pred = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]);
-    let lower = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, 2.0]);
-    let upper = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 5.0]);
+    let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 4.0]).unwrap();
+    let rhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![10.0, 20.0]).unwrap();
+    let scalar = TypedTensor::<f64>::from_vec_col_major(vec![], vec![2.0]).unwrap();
+    let short = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![99.0]).unwrap();
+    let pred = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]).unwrap();
+    let lower = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, 2.0]).unwrap();
+    let upper = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 5.0]).unwrap();
 
     let lhs_view = lhs.as_view();
     let rhs_view = rhs.as_view();
@@ -321,7 +317,7 @@ fn typed_view_helpers_cover_scalar_and_validation_paths() {
             x + y
         })
         .unwrap();
-    assert_eq!(same_shape.as_slice(), &[11.0, 24.0]);
+    assert_eq!(same_shape.as_slice().unwrap(), &[11.0, 24.0]);
 
     let scalar_lhs = typed_binary_view_with_pool(
         "test_binary",
@@ -331,7 +327,7 @@ fn typed_view_helpers_cover_scalar_and_validation_paths() {
         |x, y| x * y,
     )
     .unwrap();
-    assert_eq!(scalar_lhs.as_slice(), &[20.0, 40.0]);
+    assert_eq!(scalar_lhs.as_slice().unwrap(), &[20.0, 40.0]);
 
     let scalar_rhs = typed_binary_view_with_pool(
         "test_binary",
@@ -341,7 +337,7 @@ fn typed_view_helpers_cover_scalar_and_validation_paths() {
         |x, y| x * y,
     )
     .unwrap();
-    assert_eq!(scalar_rhs.as_slice(), &[2.0, 8.0]);
+    assert_eq!(scalar_rhs.as_slice().unwrap(), &[2.0, 8.0]);
 
     assert_shape_mismatch(
         typed_binary_view_with_pool(
@@ -356,7 +352,7 @@ fn typed_view_helpers_cover_scalar_and_validation_paths() {
 
     let negated =
         typed_unary_view_with_pool("test_unary", &mut buffers, &lhs_view, |x| -x).unwrap();
-    assert_eq!(negated.as_slice(), &[-1.0, -4.0]);
+    assert_eq!(negated.as_slice().unwrap(), &[-1.0, -4.0]);
 
     let compared = typed_same_shape_binary_view_with_pool(
         "test_same_shape",
@@ -366,7 +362,7 @@ fn typed_view_helpers_cover_scalar_and_validation_paths() {
         |x, y| x < y,
     )
     .unwrap();
-    assert_eq!(compared.as_slice(), &[true, true]);
+    assert_eq!(compared.as_slice().unwrap(), &[true, true]);
     assert_shape_mismatch(
         typed_same_shape_binary_view_with_pool(
             "test_same_shape",
@@ -380,7 +376,7 @@ fn typed_view_helpers_cover_scalar_and_validation_paths() {
 
     let selected =
         typed_select_view_with_pool(&mut buffers, &pred_view, &lhs_view, &rhs_view).unwrap();
-    assert_eq!(selected.as_slice(), &[1.0, 20.0]);
+    assert_eq!(selected.as_slice().unwrap(), &[1.0, 20.0]);
     assert_shape_mismatch(
         typed_select_view_with_pool(&mut buffers, &pred_view, &short_view, &rhs_view),
         "select",
@@ -392,7 +388,7 @@ fn typed_view_helpers_cover_scalar_and_validation_paths() {
 
     let clamped =
         typed_clamp_view_with_pool(&mut buffers, &lhs_view, &lower_view, &upper_view).unwrap();
-    assert_eq!(clamped.as_slice(), &[1.0, 4.0]);
+    assert_eq!(clamped.as_slice().unwrap(), &[1.0, 4.0]);
     assert_shape_mismatch(
         typed_clamp_view_with_pool(&mut buffers, &lhs_view, &short_view, &upper_view),
         "clamp",
@@ -405,19 +401,20 @@ fn typed_view_helpers_cover_scalar_and_validation_paths() {
 
 #[test]
 fn read_as_cpu_view_covers_tensor_and_view_variants() {
-    let f32_tensor = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]));
-    let f64_tensor = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]));
-    let i32_tensor = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![1_i32, 2]));
-    let i64_tensor = Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![1_i64, 2]));
-    let bool_tensor = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]));
-    let c32_tensor = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![c32(1.0, 0.0), c32(0.0, 1.0)],
-    ));
-    let c64_tensor = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![c64(1.0, 0.0), c64(0.0, 1.0)],
-    ));
+    let f32_tensor =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap());
+    let f64_tensor =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap());
+    let i32_tensor = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![1_i32, 2]).unwrap());
+    let i64_tensor = Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![1_i64, 2]).unwrap());
+    let bool_tensor =
+        Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]).unwrap());
+    let c32_tensor = Tensor::C32(
+        TypedTensor::from_vec_col_major(vec![2], vec![c32(1.0, 0.0), c32(0.0, 1.0)]).unwrap(),
+    );
+    let c64_tensor = Tensor::C64(
+        TypedTensor::from_vec_col_major(vec![2], vec![c64(1.0, 0.0), c64(0.0, 1.0)]).unwrap(),
+    );
 
     match read_as_cpu_view(TensorRead::from_tensor(&f32_tensor)) {
         CpuReadView::F32(view) => assert_eq!(view.shape(), &[2]),
@@ -448,15 +445,15 @@ fn read_as_cpu_view_covers_tensor_and_view_variants() {
         _ => panic!("expected c64 tensor read view"),
     }
 
-    let f32_view_source = TypedTensor::<f32>::from_vec_col_major(vec![1], vec![3.0]);
-    let f64_view_source = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![3.0]);
-    let i32_view_source = TypedTensor::<i32>::from_vec_col_major(vec![1], vec![3]);
-    let i64_view_source = TypedTensor::<i64>::from_vec_col_major(vec![1], vec![3]);
-    let bool_view_source = TypedTensor::<bool>::from_vec_col_major(vec![1], vec![true]);
+    let f32_view_source = TypedTensor::<f32>::from_vec_col_major(vec![1], vec![3.0]).unwrap();
+    let f64_view_source = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![3.0]).unwrap();
+    let i32_view_source = TypedTensor::<i32>::from_vec_col_major(vec![1], vec![3]).unwrap();
+    let i64_view_source = TypedTensor::<i64>::from_vec_col_major(vec![1], vec![3]).unwrap();
+    let bool_view_source = TypedTensor::<bool>::from_vec_col_major(vec![1], vec![true]).unwrap();
     let c32_view_source =
-        TypedTensor::<Complex<f32>>::from_vec_col_major(vec![1], vec![c32(3.0, 0.0)]);
+        TypedTensor::<Complex<f32>>::from_vec_col_major(vec![1], vec![c32(3.0, 0.0)]).unwrap();
     let c64_view_source =
-        TypedTensor::<Complex<f64>>::from_vec_col_major(vec![1], vec![c64(3.0, 0.0)]);
+        TypedTensor::<Complex<f64>>::from_vec_col_major(vec![1], vec![c64(3.0, 0.0)]).unwrap();
 
     match read_as_cpu_view(TensorRead::from_view(TensorView::F32(
         f32_view_source.as_view(),
@@ -506,35 +503,39 @@ fn read_as_cpu_view_covers_tensor_and_view_variants() {
 fn tensor_read_elementwise_dispatch_covers_view_and_complex_scalar_branches() {
     let mut buffers = BufferPool::default();
 
-    let f32_a = TypedTensor::<f32>::from_vec_col_major(vec![2], vec![1.0, -2.0]);
-    let f32_b = TypedTensor::<f32>::from_vec_col_major(vec![2], vec![3.0, 4.0]);
-    let f32_scalar = TypedTensor::<f32>::from_vec_col_major(vec![], vec![2.0]);
-    let f64_a = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![-3.0, 0.0, 4.0]);
-    let f64_b = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 5.0]);
-    let f64_scalar = TypedTensor::<f64>::from_vec_col_major(vec![], vec![2.0]);
-    let i32_a = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 4]);
-    let i32_b = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![2, 3]);
-    let i64_a = TypedTensor::<i64>::from_vec_col_major(vec![2], vec![5, -1]);
-    let i64_b = TypedTensor::<i64>::from_vec_col_major(vec![2], vec![2, -1]);
-    let bool_a = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]);
-    let bool_b = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![false, false]);
-    let pred = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]);
+    let f32_a = TypedTensor::<f32>::from_vec_col_major(vec![2], vec![1.0, -2.0]).unwrap();
+    let f32_b = TypedTensor::<f32>::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap();
+    let f32_scalar = TypedTensor::<f32>::from_vec_col_major(vec![], vec![2.0]).unwrap();
+    let f64_a = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![-3.0, 0.0, 4.0]).unwrap();
+    let f64_b = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 5.0]).unwrap();
+    let f64_scalar = TypedTensor::<f64>::from_vec_col_major(vec![], vec![2.0]).unwrap();
+    let i32_a = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 4]).unwrap();
+    let i32_b = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![2, 3]).unwrap();
+    let i64_a = TypedTensor::<i64>::from_vec_col_major(vec![2], vec![5, -1]).unwrap();
+    let i64_b = TypedTensor::<i64>::from_vec_col_major(vec![2], vec![2, -1]).unwrap();
+    let bool_a = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]).unwrap();
+    let bool_b = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![false, false]).unwrap();
+    let pred = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]).unwrap();
     let c32_a = TypedTensor::<Complex<f32>>::from_vec_col_major(
         vec![2],
         vec![c32(3.0, 4.0), c32(0.0, 2.0)],
-    );
+    )
+    .unwrap();
     let c32_b = TypedTensor::<Complex<f32>>::from_vec_col_major(
         vec![2],
         vec![c32(1.0, 0.0), c32(0.0, 2.0)],
-    );
+    )
+    .unwrap();
     let c64_a = TypedTensor::<Complex<f64>>::from_vec_col_major(
         vec![2],
         vec![c64(3.0, 4.0), c64(0.0, 2.0)],
-    );
+    )
+    .unwrap();
     let c64_b = TypedTensor::<Complex<f64>>::from_vec_col_major(
         vec![2],
         vec![c64(1.0, 0.0), c64(0.0, 2.0)],
-    );
+    )
+    .unwrap();
 
     let f32_b_tensor = Tensor::F32(f32_b.clone());
     let f64_b_tensor = Tensor::F64(f64_b.clone());
@@ -856,7 +857,7 @@ fn broadcast_multiply_read_and_value_cover_dtypes_and_error_paths() {
     .unwrap()
     .expect("non-canonical f32 outer product should stay lazy");
     assert!(matches!(value_f32, TensorValue::View(_)));
-    assert_eq!(value_f32.to_tensor().shape(), &lhs_shape);
+    assert_eq!(value_f32.to_tensor().unwrap().shape(), &lhs_shape);
 
     let lhs_i32_data = [1_i32, 2, 3, 4, 5, 6];
     let rhs_i32_data = [2_i32, 3, 4, 5];
@@ -940,8 +941,10 @@ fn broadcast_multiply_read_and_value_cover_dtypes_and_error_paths() {
     .expect("non-canonical c64 outer product should stay lazy");
     assert!(matches!(value_c64, TensorValue::View(_)));
 
-    let same_shape_i64_lhs = Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![2, 3]));
-    let same_shape_i64_rhs = Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![4, 5]));
+    let same_shape_i64_lhs =
+        Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![2, 3]).unwrap());
+    let same_shape_i64_rhs =
+        Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![4, 5]).unwrap());
     let materialized = broadcast_multiply_value_with_pool(
         &mut buffers,
         TensorRead::from_tensor(&same_shape_i64_lhs),
@@ -955,12 +958,14 @@ fn broadcast_multiply_read_and_value_cover_dtypes_and_error_paths() {
     .expect("same-shape multiply should materialize");
     assert!(matches!(materialized, TensorValue::Tensor(_)));
     assert_eq!(
-        materialized.to_tensor().as_slice::<i64>().unwrap(),
+        materialized.to_tensor().unwrap().as_slice::<i64>().unwrap(),
         &[8, 15]
     );
 
-    let bool_lhs = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]));
-    let bool_rhs = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, true]));
+    let bool_lhs =
+        Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]).unwrap());
+    let bool_rhs =
+        Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, true]).unwrap());
     assert!(broadcast_multiply_read_with_pool(
         &mut buffers,
         TensorRead::from_tensor(&bool_lhs),

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -124,7 +124,11 @@ impl<T: Clone> TypedTensorRead<T> for TypedTensor<T> {
     }
 
     fn strides(&self) -> SmallVec<[isize; 8]> {
-        col_major_strides(self.shape()).into_iter().collect()
+        // Invariant: owned tensors validate compact shape products at construction.
+        col_major_strides(self.shape())
+            .expect("owned tensor shape has valid column-major strides")
+            .into_iter()
+            .collect()
     }
 
     fn offset(&self) -> isize {
@@ -156,7 +160,11 @@ impl<T: 'static> TypedTensorRead<T> for TypedTensorView<'_, T> {
         if self.backend_buffer().is_some() {
             None
         } else {
-            Some(self.as_physical_slice())
+            // Invariant: host tensor views validate their physical slice range at construction.
+            Some(
+                self.as_physical_slice()
+                    .expect("host tensor view has a valid physical slice"),
+            )
         }
     }
 }
@@ -642,7 +650,8 @@ where
     out_shape.extend_from_slice(&rhs_free_shapes);
     out_shape.extend_from_slice(&batch_shapes);
 
-    let out_strides: SmallVec<[isize; 8]> = col_major_strides(&out_shape).into_iter().collect();
+    let out_strides: SmallVec<[isize; 8]> =
+        col_major_strides(&out_shape).ok()?.into_iter().collect();
     let nm = lhs_free_shapes.len();
     let nn = rhs_free_shapes.len();
     let out_m_shapes = &out_shape[..nm];
@@ -932,7 +941,7 @@ where
             dims.out_shape.into_vec(),
             Buffer::Host(data),
             default_placement(),
-        )));
+        )?));
     }
 
     let Some(a_data) = lhs.host_data_opt().map(<[T]>::as_ptr) else {
@@ -1002,7 +1011,7 @@ where
         dims.out_shape.into_vec(),
         Buffer::Host(out_data),
         default_placement(),
-    )))
+    )?))
 }
 
 #[cfg(feature = "cpu-blas")]
@@ -1253,7 +1262,7 @@ where
             dims.out_shape.into_vec(),
             Buffer::Host(data),
             default_placement(),
-        )));
+        )?));
     }
 
     let a_rs = normalize_singleton_stride(dims.a_rs, dims.m, dims.k);
@@ -1326,7 +1335,7 @@ where
         dims.out_shape.into_vec(),
         Buffer::Host(out),
         default_placement(),
-    )))
+    )?))
 }
 
 #[cfg(feature = "cpu-blas")]
@@ -1356,7 +1365,7 @@ where
             dims.out_shape.into_vec(),
             Buffer::Host(data),
             default_placement(),
-        )));
+        )?));
     }
 
     let a_rs = normalize_singleton_stride(dims.a_rs, dims.m, dims.k);
@@ -1417,7 +1426,7 @@ where
         dims.out_shape.into_vec(),
         Buffer::Host(out),
         default_placement(),
-    )))
+    )?))
 }
 
 fn normalize_singleton_stride(stride: isize, extent: usize, fallback: usize) -> isize {

--- a/crates/tenferro-cpu/src/gemm/strided_dot.rs
+++ b/crates/tenferro-cpu/src/gemm/strided_dot.rs
@@ -93,9 +93,5 @@ where
     )
     .map_err(map_strided_error)?;
 
-    Ok(TypedTensor::from_buffer_col_major(
-        out_shape,
-        Buffer::Host(out_data),
-        default_placement(),
-    ))
+    TypedTensor::from_buffer_col_major(out_shape, Buffer::Host(out_data), default_placement())
 }

--- a/crates/tenferro-cpu/src/gemm/tests.rs
+++ b/crates/tenferro-cpu/src/gemm/tests.rs
@@ -69,8 +69,8 @@ fn checked_product_rejects_product_overflow() {
 
 #[test]
 fn gemm_analysis_cache_keeps_direct_and_canonical_candidates_separate() {
-    let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]);
-    let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![0.0; 6]);
+    let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]).unwrap();
+    let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![0.0; 6]).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![0, 1],
         rhs_contracting_dims: vec![1, 0],
@@ -93,7 +93,7 @@ fn gemm_analysis_cache_keeps_direct_and_canonical_candidates_separate() {
     let (_lhs_perm, rhs_perm, canonical_config) =
         canonical_gemm_layout(&config, lhs.shape().len(), rhs.shape().len());
     assert_eq!(rhs_perm.as_slice(), &[1, 0]);
-    let rhs_canonical = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]);
+    let rhs_canonical = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]).unwrap();
     let canonical = analyse_gemm_cached(
         &mut cache,
         Some(7),
@@ -115,8 +115,8 @@ fn gemm_analysis_cache_keeps_direct_and_canonical_candidates_separate() {
 
 #[test]
 fn gemm_analysis_cache_reuses_matching_direct_plan_and_reports_stats() {
-    let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]);
-    let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![0.0; 6]);
+    let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]).unwrap();
+    let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![0.0; 6]).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -161,12 +161,14 @@ fn gemm_analysis_cache_reuses_matching_direct_plan_and_reports_stats() {
 #[test]
 fn faer_read_transposed_view_uses_strided_dot_without_materializing_input() {
     let lhs_source =
-        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
     let lhs_view = lhs_source.as_view().transpose_view([1, 0]).unwrap();
     let rhs = TypedTensor::<f64>::from_vec_col_major(
         vec![3, 2],
         vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0],
-    );
+    )
+    .unwrap();
     let rhs = Tensor::F64(rhs);
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
@@ -176,7 +178,7 @@ fn faer_read_transposed_view_uses_strided_dot_without_materializing_input() {
     };
     let mut buffers = BufferPool::new();
     let mut cache = GemmAnalysisCache::default();
-    let ctx = CpuContext::with_threads(1);
+    let ctx = CpuContext::with_threads(1).unwrap();
 
     let dispatch_count_before = strided_dot::test_dispatch_count();
     let out = dot_general_faer_read_cached(
@@ -199,8 +201,10 @@ fn faer_read_transposed_view_uses_strided_dot_without_materializing_input() {
 #[cfg(feature = "cpu-blas")]
 #[test]
 fn blas_dot_general_contract_trailing_rhs_dim() {
-    let lhs = TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let rhs = TypedTensor::from_vec_col_major(vec![2, 3], vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0]);
+    let lhs =
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0]).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![1],
@@ -213,7 +217,7 @@ fn blas_dot_general_contract_trailing_rhs_dim() {
         .expect("dot_general should succeed");
 
     assert_eq!(out.shape(), &[2, 2]);
-    assert_eq!(out.host_data(), &[89.0, 116.0, 98.0, 128.0]);
+    assert_eq!(out.host_data().unwrap(), &[89.0, 116.0, 98.0, 128.0]);
 }
 
 #[cfg(feature = "cpu-blas")]
@@ -316,7 +320,7 @@ fn faer_strided_gemm_accumulates_with_nontrivial_beta() {
     let a = [1.0, 0.0, 0.0, 1.0];
     let b = [10.0, 20.0, 30.0, 40.0];
     let mut c = [1.0, 2.0, 3.0, 4.0];
-    let ctx = CpuContext::with_threads(1);
+    let ctx = CpuContext::with_threads(1).unwrap();
 
     unsafe {
         <f64 as FaerGemm>::strided_gemm(
@@ -347,7 +351,7 @@ fn faer_strided_gemm_accumulates_with_unit_beta_without_prescaling() {
     let a = [1.0, 0.0, 0.0, 1.0];
     let b = [10.0, 20.0, 30.0, 40.0];
     let mut c = [1.0, 2.0, 3.0, 4.0];
-    let ctx = CpuContext::with_threads(1);
+    let ctx = CpuContext::with_threads(1).unwrap();
 
     unsafe {
         <f64 as FaerGemm>::strided_gemm(

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -141,7 +141,7 @@ where
 {
     // SAFETY: the following fill writes every pooled output element.
     let mut out = pooled_uninit_tensor(buffers, shape)?;
-    out.host_data_mut().fill(fill);
+    out.host_data_mut()?.fill(fill);
     Ok(out)
 }
 
@@ -155,7 +155,7 @@ where
 {
     // SAFETY: copy_from_slice writes every pooled output element.
     let mut out = pooled_uninit_tensor(buffers, tensor.shape().to_vec())?;
-    out.host_data_mut()
+    out.host_data_mut()?
         .copy_from_slice(typed_host_data(op, tensor)?);
     Ok(out)
 }
@@ -389,11 +389,11 @@ fn typed_slice<T: Copy + Clone + PoolScalar>(
     let mut out_idx = vec![0usize; rank];
     let mut in_idx = vec![0usize; rank];
 
-    for out_value in out.host_data_mut().iter_mut() {
+    for out_value in out.host_data_mut()?.iter_mut() {
         for axis in 0..rank {
             in_idx[axis] = config.starts[axis] + out_idx[axis] * config.strides[axis];
         }
-        *out_value = *input.get(&in_idx);
+        *out_value = *input.get(&in_idx)?;
         advance_col_major_index(&mut out_idx, &out_shape);
     }
 
@@ -497,7 +497,7 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar>(
     let mut out_idx = vec![0usize; rank];
     let mut in_idx = vec![0usize; rank];
 
-    for out_value in out.host_data_mut().iter_mut() {
+    for out_value in out.host_data_mut()?.iter_mut() {
         let concat_idx = out_idx[axis];
         let input_pos = segment_ends.partition_point(|&end| concat_idx >= end);
         if input_pos == segment_ends.len() {
@@ -514,7 +514,7 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar>(
 
         in_idx.copy_from_slice(&out_idx);
         in_idx[axis] -= axis_base;
-        *out_value = *inputs[input_pos].get(&in_idx);
+        *out_value = *inputs[input_pos].get(&in_idx)?;
         advance_col_major_index(&mut out_idx, &out_shape);
     }
 
@@ -545,7 +545,7 @@ fn typed_reverse<T: Copy + Clone + PoolScalar>(
     let mut out_idx = vec![0usize; rank];
     let mut in_idx = vec![0usize; rank];
 
-    for out_value in out.host_data_mut().iter_mut() {
+    for out_value in out.host_data_mut()?.iter_mut() {
         for axis in 0..rank {
             in_idx[axis] = if reverse_axis[axis] {
                 input_shape[axis] - 1 - out_idx[axis]
@@ -553,7 +553,7 @@ fn typed_reverse<T: Copy + Clone + PoolScalar>(
                 out_idx[axis]
             };
         }
-        *out_value = *input.get(&in_idx);
+        *out_value = *input.get(&in_idx)?;
         advance_col_major_index(&mut out_idx, input_shape);
     }
 
@@ -921,7 +921,7 @@ fn typed_gather<T: Copy + Clone + PoolScalar>(
     let mut window_offsets = vec![0usize; rank];
     let mut index_scratch = vec![0usize; start_indices.shape.len()];
 
-    for out_value in out.host_data_mut().iter_mut() {
+    for out_value in out.host_data_mut()?.iter_mut() {
         batch_axis = 0;
         window_offsets.fill(0);
         for out_axis in 0..out_rank {
@@ -955,7 +955,7 @@ fn typed_gather<T: Copy + Clone + PoolScalar>(
             operand_idx[axis] += window_offsets[axis];
         }
 
-        *out_value = *operand.get(&operand_idx);
+        *out_value = *operand.get(&operand_idx)?;
         advance_col_major_index(&mut out_idx, &out_shape);
     }
 
@@ -1190,8 +1190,8 @@ where
                 operand_idx[operand_axis] += window_idx[window_axis];
             }
 
-            let value = *updates.get(&update_idx);
-            let slot = out.get_mut(&operand_idx);
+            let value = *updates.get(&update_idx)?;
+            let slot = out.get_mut(&operand_idx)?;
             *slot = *slot + value;
             advance_col_major_index(&mut window_idx, &window_shape_updates);
         }
@@ -1248,11 +1248,11 @@ fn typed_dynamic_slice<T: Copy + Clone + PoolScalar>(
     let mut out_idx = vec![0usize; out_shape.len()];
     let mut input_idx = vec![0usize; out_shape.len()];
 
-    for out_value in out.host_data_mut().iter_mut() {
+    for out_value in out.host_data_mut()?.iter_mut() {
         for axis in 0..out_shape.len() {
             input_idx[axis] = clamped_starts[axis] + out_idx[axis];
         }
-        *out_value = *input.get(&input_idx);
+        *out_value = *input.get(&input_idx)?;
         advance_col_major_index(&mut out_idx, &out_shape);
     }
 
@@ -1305,11 +1305,11 @@ fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar>(
     let mut update_idx = vec![0usize; update_shape.len()];
     let mut operand_idx = vec![0usize; operand_shape.len()];
 
-    for update_value in update.as_slice() {
+    for update_value in update.as_slice()? {
         for axis in 0..update_shape.len() {
             operand_idx[axis] = clamped_starts[axis] + update_idx[axis];
         }
-        *out.get_mut(&operand_idx) = *update_value;
+        *out.get_mut(&operand_idx)? = *update_value;
         advance_col_major_index(&mut update_idx, update_shape);
     }
 
@@ -1410,7 +1410,7 @@ fn typed_pad_with_fill<T: Copy + Clone + PoolScalar>(
     let mut input_idx = vec![0usize; input_shape.len()];
     let mut out_idx = vec![0usize; input_shape.len()];
 
-    for input_value in input.as_slice() {
+    for input_value in input.as_slice()? {
         let mut in_bounds = true;
         for axis in 0..input_shape.len() {
             let out_pos = config.edge_padding_low[axis]
@@ -1422,7 +1422,7 @@ fn typed_pad_with_fill<T: Copy + Clone + PoolScalar>(
             out_idx[axis] = out_pos as usize;
         }
         if in_bounds {
-            *out.get_mut(&out_idx) = *input_value;
+            *out.get_mut(&out_idx)? = *input_value;
         }
         advance_col_major_index(&mut input_idx, input_shape);
     }

--- a/crates/tenferro-cpu/src/indexing_alloc.rs
+++ b/crates/tenferro-cpu/src/indexing_alloc.rs
@@ -20,5 +20,5 @@ where
     let len = checked_shape_product("cpu_pooled_output", &shape)?;
     // SAFETY: callers use this helper only for pooled outputs that are fully overwritten.
     let data = unsafe { T::pool_acquire(buffers, len) };
-    Ok(TypedTensor::from_vec_col_major(shape, data))
+    TypedTensor::from_vec_col_major(shape, data)
 }

--- a/crates/tenferro-cpu/src/inject.rs
+++ b/crates/tenferro-cpu/src/inject.rs
@@ -17,24 +17,14 @@
 //!   providers).  tenferro's consumer path remains LP64; the `cblas-inject`
 //!   and `lapack-inject` crates transparently bridge the integer types.
 //!
-//! ## Existing typed wrappers vs raw-pointer API
+//! ## Raw-pointer provider API
 //!
-//! - [`register_blas_gemm_fn_ptrs`] and
-//!   [`register_lapack_full_piv_lu_fn_ptrs`] accept typed LP64 function
-//!   pointers and remain available for backwards compatibility.
-//! - The new raw-pointer entry points
-//!   ([`register_blas_gemm_provider_ptrs`],
-//!   [`register_lapack_provider_ptrs`]) accept opaque `*const c_void`
-//!   pointers together with a [`ProviderAbi`] selector.  They cover the
-//!   full GEMM and LAPACK surface.
+//! [`register_blas_gemm_provider_ptrs`] and [`register_lapack_provider_ptrs`]
+//! accept opaque `*const c_void` pointers together with a [`ProviderAbi`]
+//! selector. They are the only public registration API, so LP64 and ILP64
+//! providers use the same contract.
 
 use std::ffi::c_void;
-
-use cblas_inject::{CgemmFnPtr, DgemmFnPtr, SgemmFnPtr, ZgemmFnPtr};
-use lapack_inject::{
-    Cgesc2Lp64FnPtr, Cgetc2Lp64FnPtr, Dgesc2Lp64FnPtr, Dgetc2Lp64FnPtr, Sgesc2Lp64FnPtr,
-    Sgetc2Lp64FnPtr, Zgesc2Lp64FnPtr, Zgetc2Lp64FnPtr,
-};
 
 // --- Public types --------------------------------------------------------
 
@@ -310,118 +300,6 @@ impl LapackProviderPtrSet {
     }
 }
 
-// --- Typed function-pointer sets (compatibility wrappers) ----------------
-
-/// Set of CBLAS GEMM function pointers to register in one call.
-///
-/// Any field set to `None` is skipped, so callers can register only the
-/// scalar types they plan to use.
-///
-/// # Examples
-///
-/// ```rust
-/// use tenferro_cpu::inject::{register_blas_gemm_fn_ptrs, BlasGemmFnPtrSet};
-///
-/// unsafe {
-///     register_blas_gemm_fn_ptrs(BlasGemmFnPtrSet::new())?;
-/// }
-/// # Ok::<(), tenferro_cpu::inject::ProviderRegistrationError>(())
-/// ```
-#[derive(Debug, Clone, Copy, Default)]
-pub struct BlasGemmFnPtrSet {
-    /// Fortran `sgemm` function pointer.
-    pub sgemm: Option<SgemmFnPtr>,
-    /// Fortran `dgemm` function pointer.
-    pub dgemm: Option<DgemmFnPtr>,
-    /// Fortran `cgemm` function pointer.
-    pub cgemm: Option<CgemmFnPtr>,
-    /// Fortran `zgemm` function pointer.
-    pub zgemm: Option<ZgemmFnPtr>,
-}
-
-impl BlasGemmFnPtrSet {
-    /// Create an empty set (all pointers are `None`).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_cpu::inject::BlasGemmFnPtrSet;
-    ///
-    /// let ptrs = BlasGemmFnPtrSet::new();
-    /// assert!(ptrs.dgemm.is_none());
-    /// ```
-    pub const fn new() -> Self {
-        Self {
-            sgemm: None,
-            dgemm: None,
-            cgemm: None,
-            zgemm: None,
-        }
-    }
-}
-
-/// Set of LAPACK complete-pivoting LU function pointers to register.
-///
-/// tenferro currently uses `xGETC2` for the factorization and `xGESC2` for
-/// solves. Any field set to `None` is skipped.
-///
-/// # Examples
-///
-/// ```rust
-/// use tenferro_cpu::inject::{
-///     register_lapack_full_piv_lu_fn_ptrs, LapackFullPivLuFnPtrSet,
-/// };
-///
-/// unsafe {
-///     register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet::new())?;
-/// }
-/// # Ok::<(), tenferro_cpu::inject::ProviderRegistrationError>(())
-/// ```
-#[derive(Debug, Clone, Copy, Default)]
-pub struct LapackFullPivLuFnPtrSet {
-    /// Fortran `sgetc2` LP64 function pointer.
-    pub sgetc2: Option<Sgetc2Lp64FnPtr>,
-    /// Fortran `sgesc2` LP64 function pointer.
-    pub sgesc2: Option<Sgesc2Lp64FnPtr>,
-    /// Fortran `dgetc2` LP64 function pointer.
-    pub dgetc2: Option<Dgetc2Lp64FnPtr>,
-    /// Fortran `dgesc2` LP64 function pointer.
-    pub dgesc2: Option<Dgesc2Lp64FnPtr>,
-    /// Fortran `cgetc2` LP64 function pointer.
-    pub cgetc2: Option<Cgetc2Lp64FnPtr>,
-    /// Fortran `cgesc2` LP64 function pointer.
-    pub cgesc2: Option<Cgesc2Lp64FnPtr>,
-    /// Fortran `zgetc2` LP64 function pointer.
-    pub zgetc2: Option<Zgetc2Lp64FnPtr>,
-    /// Fortran `zgesc2` LP64 function pointer.
-    pub zgesc2: Option<Zgesc2Lp64FnPtr>,
-}
-
-impl LapackFullPivLuFnPtrSet {
-    /// Create an empty set (all pointers are `None`).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_cpu::inject::LapackFullPivLuFnPtrSet;
-    ///
-    /// let ptrs = LapackFullPivLuFnPtrSet::new();
-    /// assert!(ptrs.dgetc2.is_none());
-    /// ```
-    pub const fn new() -> Self {
-        Self {
-            sgetc2: None,
-            sgesc2: None,
-            dgetc2: None,
-            dgesc2: None,
-            cgetc2: None,
-            cgesc2: None,
-            zgetc2: None,
-            zgesc2: None,
-        }
-    }
-}
-
 // --- Status helpers ------------------------------------------------------
 
 /// Map a `cblas-inject` status code to a `Result`.
@@ -451,110 +329,6 @@ fn lapack_registration_status(
         2 => Err(ProviderRegistrationError::AlreadyRegistered { symbol }),
         _ => Err(ProviderRegistrationError::UnknownStatus { symbol, status }),
     }
-}
-
-// --- Compatibility wrappers (typed LP64) ---------------------------------
-
-/// Register CBLAS GEMM function pointers in one call.
-///
-/// This is a thin bulk wrapper over `cblas-inject`'s LP64 registration
-/// entry points.
-///
-/// # Safety
-///
-/// Each provided function pointer must have the exact Fortran BLAS ABI
-/// expected by `cblas-inject`.
-///
-/// # Examples
-///
-/// ```rust
-/// use tenferro_cpu::inject::{register_blas_gemm_fn_ptrs, BlasGemmFnPtrSet};
-///
-/// unsafe {
-///     register_blas_gemm_fn_ptrs(BlasGemmFnPtrSet::new())?;
-/// }
-/// # Ok::<(), tenferro_cpu::inject::ProviderRegistrationError>(())
-/// ```
-pub unsafe fn register_blas_gemm_fn_ptrs(
-    ptrs: BlasGemmFnPtrSet,
-) -> Result<(), ProviderRegistrationError> {
-    if let Some(f) = ptrs.sgemm {
-        let status = unsafe { cblas_inject::cblas_inject_register_sgemm_lp64(f as *const c_void) };
-        blas_registration_status("sgemm", status)?;
-    }
-    if let Some(f) = ptrs.dgemm {
-        let status = unsafe { cblas_inject::cblas_inject_register_dgemm_lp64(f as *const c_void) };
-        blas_registration_status("dgemm", status)?;
-    }
-    if let Some(f) = ptrs.cgemm {
-        let status = unsafe { cblas_inject::cblas_inject_register_cgemm_lp64(f as *const c_void) };
-        blas_registration_status("cgemm", status)?;
-    }
-    if let Some(f) = ptrs.zgemm {
-        let status = unsafe { cblas_inject::cblas_inject_register_zgemm_lp64(f as *const c_void) };
-        blas_registration_status("zgemm", status)?;
-    }
-    Ok(())
-}
-
-/// Register LAPACK complete-pivoting LU function pointers in one call.
-///
-/// This is a thin bulk wrapper over `lapack-inject`'s per-symbol
-/// `register_*` functions.
-///
-/// # Safety
-///
-/// Each provided function pointer must have the exact Fortran LAPACK ABI
-/// expected by `lapack-inject`.
-///
-/// # Examples
-///
-/// ```rust
-/// use tenferro_cpu::inject::{
-///     register_lapack_full_piv_lu_fn_ptrs, LapackFullPivLuFnPtrSet,
-/// };
-///
-/// unsafe {
-///     register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet::new())?;
-/// }
-/// # Ok::<(), tenferro_cpu::inject::ProviderRegistrationError>(())
-/// ```
-pub unsafe fn register_lapack_full_piv_lu_fn_ptrs(
-    ptrs: LapackFullPivLuFnPtrSet,
-) -> Result<(), ProviderRegistrationError> {
-    if let Some(f) = ptrs.sgetc2 {
-        let status = unsafe { lapack_inject::register_sgetc2_lp64(f) };
-        lapack_registration_status("sgetc2", status)?;
-    }
-    if let Some(f) = ptrs.sgesc2 {
-        let status = unsafe { lapack_inject::register_sgesc2_lp64(f) };
-        lapack_registration_status("sgesc2", status)?;
-    }
-    if let Some(f) = ptrs.dgetc2 {
-        let status = unsafe { lapack_inject::register_dgetc2_lp64(f) };
-        lapack_registration_status("dgetc2", status)?;
-    }
-    if let Some(f) = ptrs.dgesc2 {
-        let status = unsafe { lapack_inject::register_dgesc2_lp64(f) };
-        lapack_registration_status("dgesc2", status)?;
-    }
-    if let Some(f) = ptrs.cgetc2 {
-        let status = unsafe { lapack_inject::register_cgetc2_lp64(f) };
-        lapack_registration_status("cgetc2", status)?;
-    }
-    if let Some(f) = ptrs.cgesc2 {
-        let status = unsafe { lapack_inject::register_cgesc2_lp64(f) };
-        lapack_registration_status("cgesc2", status)?;
-    }
-    if let Some(f) = ptrs.zgetc2 {
-        let status = unsafe { lapack_inject::register_zgetc2_lp64(f) };
-        lapack_registration_status("zgetc2", status)?;
-    }
-    if let Some(f) = ptrs.zgesc2 {
-        let status = unsafe { lapack_inject::register_zgesc2_lp64(f) };
-        lapack_registration_status("zgesc2", status)?;
-    }
-    Ok(())
 }
 
 // --- Raw-pointer BLAS GEMM registration ----------------------------------

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -162,7 +162,7 @@ pub(crate) fn typed_view_from_view<'a, T: Copy + 'static, R: TensorRank>(
         return Err(cpu_backend_buffer_error(op));
     }
     StridedView::new(
-        view.as_physical_slice(),
+        view.as_physical_slice()?,
         view.shape(),
         view.strides(),
         view.offset(),
@@ -260,7 +260,9 @@ where
 }
 
 pub(crate) fn tensor_from_array<T: Clone>(array: StridedArray<T>) -> TypedTensor<T> {
+    // Invariant: `StridedArray` owns data whose length matches its validated dimensions.
     TypedTensor::from_vec_col_major(array.dims().to_vec(), array.into_data())
+        .expect("strided array dimensions match owned data length")
 }
 
 pub(crate) fn default_placement() -> Placement {

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -352,10 +352,7 @@ where
             .map_err(|err| crate::Error::backend_failure(label, err))?;
     }
 
-    Ok(TypedTensor::from_vec_col_major(
-        output_shape,
-        current.into_data(),
-    ))
+    TypedTensor::from_vec_col_major(output_shape, current.into_data())
 }
 
 pub(crate) fn typed_reduce_view<T, M, R, TR>(
@@ -400,10 +397,7 @@ where
             .map_err(|err| crate::Error::backend_failure(label, err))?;
     }
 
-    Ok(TypedTensor::from_vec_col_major(
-        output_shape,
-        current.into_data(),
-    ))
+    TypedTensor::from_vec_col_major(output_shape, current.into_data())
 }
 
 fn view_to_dyn_contiguous<T, R>(input: &TypedTensorView<'_, T, R>) -> crate::Result<TypedTensor<T>>
@@ -412,8 +406,8 @@ where
     R: TensorRank,
 {
     let compact = input.to_contiguous()?;
-    let (shape, data) = compact.try_into_vec_col_major()?;
-    Ok(TypedTensor::from_vec_col_major(shape, data))
+    let (shape, data) = compact.into_vec_col_major()?;
+    TypedTensor::from_vec_col_major(shape, data)
 }
 
 fn view_to_contiguous_tensor(input: TensorView<'_>) -> crate::Result<Tensor> {

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -155,7 +155,7 @@ where
     // SAFETY: every pooled element is initialized with `fill` before returning.
     let mut data = unsafe { T::pool_acquire(buffers, len) };
     data.fill(fill);
-    Ok(TypedTensor::from_vec_col_major(shape, data))
+    TypedTensor::from_vec_col_major(shape, data)
 }
 
 fn clone_host_tensor_from_pool<T>(
@@ -173,11 +173,11 @@ where
     // SAFETY: copy_from_slice initializes every pooled element before returning.
     let mut data = unsafe { T::pool_acquire(buffers, input.len()) };
     data.copy_from_slice(input);
-    Ok(TypedTensor::from_buffer_col_major(
+    TypedTensor::from_buffer_col_major(
         tensor.shape().to_vec(),
         crate::Buffer::Host(data),
         tensor.placement().clone(),
-    ))
+    )
 }
 
 pub fn transpose(input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
@@ -442,11 +442,11 @@ pub fn typed_reshape<T: Clone + 'static>(
             rhs: shape.to_vec(),
         });
     }
-    Ok(TypedTensor::from_buffer_col_major(
+    TypedTensor::from_buffer_col_major(
         shape.to_vec(),
         tensor.buffer().clone(),
         tensor.placement().clone(),
-    ))
+    )
 }
 
 #[cfg(test)]
@@ -595,9 +595,7 @@ pub(crate) fn typed_embed_diagonal<T: Copy + Zero + Clone>(
     axis_a: usize,
     axis_b: usize,
 ) -> crate::Result<TypedTensor<T>> {
-    typed_embed_diagonal_impl(tensor, axis_a, axis_b, |shape| {
-        Ok(TypedTensor::zeros(shape))
-    })
+    typed_embed_diagonal_impl(tensor, axis_a, axis_b, TypedTensor::zeros)
 }
 
 pub(crate) fn typed_embed_diagonal_with_pool<T>(
@@ -666,7 +664,7 @@ where
                 src_axis += 1;
             }
         }
-        *out.get_mut(&out_idx) = value;
+        *out.get_mut(&out_idx)? = value;
     }
     Ok(out)
 }
@@ -732,7 +730,7 @@ fn typed_triangular_mask<T: Copy + Zero + Clone>(
 
     let (batch_count, block_size) = checked_triangular_extent(op, tensor.shape(), rows, cols)?;
     let mut out = tensor.clone();
-    let data = out.host_data_mut();
+    let data = out.host_data_mut()?;
 
     // Intentionally sequential: triangular masks are index-dependent in the
     // innermost matrix plane and remain a dedicated CPU-kernel exception.
@@ -786,7 +784,7 @@ where
 
     let (batch_count, block_size) = checked_triangular_extent(op, tensor.shape(), rows, cols)?;
     let mut out = clone_host_tensor_from_pool(buffers, op, tensor)?;
-    let data = out.host_data_mut();
+    let data = out.host_data_mut()?;
 
     // Intentionally sequential: triangular masks are index-dependent in the
     // innermost matrix plane and remain a dedicated CPU-kernel exception.

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -28,49 +28,49 @@ use tenferro_tensor::{DType, Tensor, TensorRead, TensorView, TypedTensor};
 
 fn get_f64(t: &Tensor, idx: &[usize]) -> f64 {
     match t {
-        Tensor::F64(inner) => *inner.get(idx),
+        Tensor::F64(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected F64 tensor"),
     }
 }
 
 fn get_c64(t: &Tensor, idx: &[usize]) -> Complex64 {
     match t {
-        Tensor::C64(inner) => *inner.get(idx),
+        Tensor::C64(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected C64 tensor"),
     }
 }
 
 fn get_f32(t: &Tensor, idx: &[usize]) -> f32 {
     match t {
-        Tensor::F32(inner) => *inner.get(idx),
+        Tensor::F32(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected F32 tensor"),
     }
 }
 
 fn get_c32(t: &Tensor, idx: &[usize]) -> Complex32 {
     match t {
-        Tensor::C32(inner) => *inner.get(idx),
+        Tensor::C32(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected C32 tensor"),
     }
 }
 
 fn get_i64(t: &Tensor, idx: &[usize]) -> i64 {
     match t {
-        Tensor::I64(inner) => *inner.get(idx),
+        Tensor::I64(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected I64 tensor"),
     }
 }
 
 fn get_i32(t: &Tensor, idx: &[usize]) -> i32 {
     match t {
-        Tensor::I32(inner) => *inner.get(idx),
+        Tensor::I32(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected I32 tensor"),
     }
 }
 
 fn get_bool(t: &Tensor, idx: &[usize]) -> bool {
     match t {
-        Tensor::Bool(inner) => *inner.get(idx),
+        Tensor::Bool(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected Bool tensor"),
     }
 }

--- a/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
@@ -65,12 +65,10 @@ fn expect_duplicate_axis(result: crate::Result<Tensor>, op: &'static str) {
 #[test]
 fn cpu_indexing_dispatch_covers_supported_dtypes() {
     let mut backend = CpuBackend::new();
-    let indices = Tensor::from_vec_col_major(vec![2], vec![0_i64, 2]);
+    let indices = Tensor::from_vec_col_major(vec![2], vec![0_i64, 2]).unwrap();
 
-    let f32_operand = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![1.0, 2.0, 3.0],
-    ));
+    let f32_operand =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap());
     assert_eq!(
         gather(&f32_operand, &indices, &simple_gather_config())
             .unwrap()
@@ -78,14 +76,17 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         &[2]
     );
 
-    let c32_operand = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![
-            Complex32::new(1.0, 0.0),
-            Complex32::new(2.0, 1.0),
-            Complex32::new(3.0, 2.0),
-        ],
-    ));
+    let c32_operand = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![3],
+            vec![
+                Complex32::new(1.0, 0.0),
+                Complex32::new(2.0, 1.0),
+                Complex32::new(3.0, 2.0),
+            ],
+        )
+        .unwrap(),
+    );
     assert_eq!(
         gather(&c32_operand, &indices, &simple_gather_config())
             .unwrap()
@@ -93,14 +94,17 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         &[2]
     );
 
-    let c64_operand = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![
-            Complex64::new(1.0, 0.0),
-            Complex64::new(2.0, 1.0),
-            Complex64::new(3.0, 2.0),
-        ],
-    ));
+    let c64_operand = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![3],
+            vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(2.0, 1.0),
+                Complex64::new(3.0, 2.0),
+            ],
+        )
+        .unwrap(),
+    );
     assert_eq!(
         gather(&c64_operand, &indices, &simple_gather_config())
             .unwrap()
@@ -108,7 +112,7 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         &[2]
     );
 
-    let i32_operand = Tensor::from_vec_col_major(vec![3], vec![1_i32, 2, 3]);
+    let i32_operand = Tensor::from_vec_col_major(vec![3], vec![1_i32, 2, 3]).unwrap();
     assert_eq!(
         gather(&i32_operand, &indices, &simple_gather_config())
             .unwrap()
@@ -116,7 +120,7 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         &[2]
     );
 
-    let i64_operand = Tensor::from_vec_col_major(vec![3], vec![1_i64, 2, 3]);
+    let i64_operand = Tensor::from_vec_col_major(vec![3], vec![1_i64, 2, 3]).unwrap();
     assert_eq!(
         gather(&i64_operand, &indices, &simple_gather_config())
             .unwrap()
@@ -124,7 +128,7 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         &[2]
     );
 
-    let bool_operand = Tensor::from_vec_col_major(vec![3], vec![true, false, true]);
+    let bool_operand = Tensor::from_vec_col_major(vec![3], vec![true, false, true]).unwrap();
     assert_eq!(
         gather(&bool_operand, &indices, &simple_gather_config())
             .unwrap()
@@ -132,12 +136,13 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         &[2]
     );
 
-    let scatter_indices = Tensor::from_vec_col_major(vec![2, 2], vec![0_i64, 1, 0, 1]);
+    let scatter_indices = Tensor::from_vec_col_major(vec![2, 2], vec![0_i64, 1, 0, 1]).unwrap();
 
-    let f32_updates = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![5.0, 6.0]));
+    let f32_updates =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![5.0, 6.0]).unwrap());
     assert_eq!(
         scatter(
-            &Tensor::F32(TypedTensor::zeros(vec![2, 2])),
+            &Tensor::F32(TypedTensor::zeros(vec![2, 2]).unwrap()),
             &scatter_indices,
             &f32_updates,
             &diagonal_scatter_config(),
@@ -147,13 +152,16 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         &[2, 2]
     );
 
-    let c32_updates = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(5.0, 1.0), Complex32::new(6.0, 2.0)],
-    ));
+    let c32_updates = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex32::new(5.0, 1.0), Complex32::new(6.0, 2.0)],
+        )
+        .unwrap(),
+    );
     assert_eq!(
         scatter(
-            &Tensor::C32(TypedTensor::zeros(vec![2, 2])),
+            &Tensor::C32(TypedTensor::zeros(vec![2, 2]).unwrap()),
             &scatter_indices,
             &c32_updates,
             &diagonal_scatter_config(),
@@ -163,13 +171,16 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         &[2, 2]
     );
 
-    let c64_updates = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(5.0, 1.0), Complex64::new(6.0, 2.0)],
-    ));
+    let c64_updates = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(5.0, 1.0), Complex64::new(6.0, 2.0)],
+        )
+        .unwrap(),
+    );
     assert_eq!(
         scatter(
-            &Tensor::C64(TypedTensor::zeros(vec![2, 2])),
+            &Tensor::C64(TypedTensor::zeros(vec![2, 2]).unwrap()),
             &scatter_indices,
             &c64_updates,
             &diagonal_scatter_config(),
@@ -181,9 +192,9 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
 
     assert_eq!(
         scatter(
-            &Tensor::from_vec_col_major(vec![2, 2], vec![0_i64; 4]),
+            &Tensor::from_vec_col_major(vec![2, 2], vec![0_i64; 4]).unwrap(),
             &scatter_indices,
-            &Tensor::from_vec_col_major(vec![2], vec![1_i64, 2]),
+            &Tensor::from_vec_col_major(vec![2], vec![1_i64, 2]).unwrap(),
             &diagonal_scatter_config(),
         )
         .unwrap()
@@ -192,18 +203,18 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
     );
     assert!(matches!(
         scatter(
-            &Tensor::from_vec_col_major(vec![2, 2], vec![false; 4]),
+            &Tensor::from_vec_col_major(vec![2, 2], vec![false; 4]).unwrap(),
             &scatter_indices,
-            &Tensor::from_vec_col_major(vec![2], vec![true, false]),
+            &Tensor::from_vec_col_major(vec![2], vec![true, false]).unwrap(),
             &diagonal_scatter_config(),
         ),
         Err(crate::Error::BackendFailure { op: "scatter", .. })
     ));
     assert!(matches!(
         scatter(
-            &Tensor::F32(TypedTensor::zeros(vec![2, 2])),
+            &Tensor::F32(TypedTensor::zeros(vec![2, 2]).unwrap()),
             &scatter_indices,
-            &Tensor::F64(TypedTensor::zeros(vec![2])),
+            &Tensor::F64(TypedTensor::zeros(vec![2]).unwrap()),
             &diagonal_scatter_config(),
         ),
         Err(crate::Error::DTypeMismatch { op: "scatter", .. })
@@ -235,7 +246,7 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
         &[2]
     );
 
-    let starts = Tensor::from_vec_col_major(vec![1], vec![1_i64]);
+    let starts = Tensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap();
     assert_eq!(
         dynamic_slice(&f32_operand, &starts, &[2]).unwrap().shape(),
         &[2]
@@ -308,7 +319,7 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
 #[test]
 fn cpu_indexing_validation_covers_error_branches() {
     let mut backend = CpuBackend::new();
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
 
     expect_rank_mismatch(
         backend.slice(
@@ -366,14 +377,12 @@ fn cpu_indexing_validation_covers_error_branches() {
         "slice",
     );
 
-    let matrix = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 2.0, 3.0, 4.0],
-    ));
+    let matrix =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
     expect_rank_mismatch(
         backend.dynamic_slice(
             &matrix,
-            &Tensor::from_vec_col_major(vec![2], vec![0_i64, 0]),
+            &Tensor::from_vec_col_major(vec![2], vec![0_i64, 0]).unwrap(),
             &[1],
         ),
         "dynamic_slice",
@@ -381,7 +390,7 @@ fn cpu_indexing_validation_covers_error_branches() {
     expect_invalid_config(
         backend.dynamic_slice(
             &matrix,
-            &Tensor::from_vec_col_major(vec![1, 1], vec![0_i64]),
+            &Tensor::from_vec_col_major(vec![1, 1], vec![0_i64]).unwrap(),
             &[1, 1],
         ),
         "dynamic_slice",
@@ -389,7 +398,7 @@ fn cpu_indexing_validation_covers_error_branches() {
     expect_invalid_config(
         backend.dynamic_slice(
             &matrix,
-            &Tensor::from_vec_col_major(vec![1], vec![0_i64]),
+            &Tensor::from_vec_col_major(vec![1], vec![0_i64]).unwrap(),
             &[1, 1],
         ),
         "dynamic_slice",
@@ -451,17 +460,15 @@ fn cpu_indexing_validation_covers_error_branches() {
         "pad",
     );
 
-    let operand_2d = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 2.0, 3.0, 4.0],
-    ));
-    let idx = Tensor::from_vec_col_major(vec![1, 1], vec![0_i64]);
-    let idx2 = Tensor::from_vec_col_major(vec![1, 2], vec![0_i64, 0]);
+    let operand_2d =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
+    let idx = Tensor::from_vec_col_major(vec![1, 1], vec![0_i64]).unwrap();
+    let idx2 = Tensor::from_vec_col_major(vec![1, 2], vec![0_i64, 0]).unwrap();
 
     expect_invalid_config(
         gather(
             &operand_2d,
-            &Tensor::F32(TypedTensor::from_vec_col_major(vec![1, 1], vec![0.5])),
+            &Tensor::F32(TypedTensor::from_vec_col_major(vec![1, 1], vec![0.5]).unwrap()),
             &valid_gather_2d_config(),
         ),
         "index_tensor",
@@ -469,10 +476,7 @@ fn cpu_indexing_validation_covers_error_branches() {
     expect_invalid_config(
         gather(
             &operand_2d,
-            &Tensor::F32(TypedTensor::from_vec_col_major(
-                vec![1, 1],
-                vec![16_777_218.0],
-            )),
+            &Tensor::F32(TypedTensor::from_vec_col_major(vec![1, 1], vec![16_777_218.0]).unwrap()),
             &valid_gather_2d_config(),
         ),
         "index_tensor",
@@ -480,10 +484,9 @@ fn cpu_indexing_validation_covers_error_branches() {
     expect_invalid_config(
         gather(
             &operand_2d,
-            &Tensor::F64(TypedTensor::from_vec_col_major(
-                vec![1, 1],
-                vec![9_007_199_254_740_994.0],
-            )),
+            &Tensor::F64(
+                TypedTensor::from_vec_col_major(vec![1, 1], vec![9_007_199_254_740_994.0]).unwrap(),
+            ),
             &valid_gather_2d_config(),
         ),
         "index_tensor",
@@ -534,7 +537,7 @@ fn cpu_indexing_validation_covers_error_branches() {
     };
     expect_duplicate_axis(gather(&operand_2d, &idx, &gather_cfg), "gather");
 
-    let updates = Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![5.0]));
+    let updates = Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![5.0]).unwrap());
     let mut scatter_cfg = diagonal_scatter_config();
     scatter_cfg.inserted_window_dims = vec![2];
     expect_axis_oob(
@@ -593,7 +596,8 @@ fn cpu_indexing_validation_covers_error_branches() {
     );
 
     let scatter_cfg = diagonal_scatter_config();
-    let bad_batch_updates = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1], vec![5.0]));
+    let bad_batch_updates =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1], vec![5.0]).unwrap());
     expect_invalid_config(
         scatter(&operand_2d, &idx2, &bad_batch_updates, &scatter_cfg),
         "scatter",
@@ -605,7 +609,7 @@ fn cpu_indexing_validation_covers_error_branches() {
         scatter_dims_to_operand_dims: vec![0, 1],
         index_vector_dim: 1,
     };
-    let updates_2d = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1], vec![5.0]));
+    let updates_2d = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1], vec![5.0]).unwrap());
     expect_axis_oob(
         scatter(&operand_2d, &idx2, &updates_2d, &scatter_cfg),
         "scatter",
@@ -617,17 +621,16 @@ fn cpu_indexing_validation_covers_error_branches() {
         scatter_dims_to_operand_dims: vec![0, 1],
         index_vector_dim: 1,
     };
-    let updates_3d = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1, 1], vec![5.0]));
+    let updates_3d =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1, 1], vec![5.0]).unwrap());
     expect_duplicate_axis(
         scatter(&operand_2d, &idx2, &updates_3d, &scatter_cfg),
         "scatter",
     );
 
     let scatter_cfg = diagonal_scatter_config();
-    let mismatched_updates = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![1.0, 2.0, 3.0],
-    ));
+    let mismatched_updates =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap());
     expect_invalid_config(
         scatter(&operand_2d, &idx2, &mismatched_updates, &scatter_cfg),
         "scatter",
@@ -638,8 +641,10 @@ fn cpu_indexing_validation_covers_error_branches() {
 fn cpu_exec_session_covers_dot_errors_and_reclaim_dispatch() {
     let mut backend = CpuBackend::new();
     backend.with_backend_session(|exec| {
-        let f32_vec = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
-        let f64_vec = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
+        let f32_vec =
+            Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
+        let f64_vec =
+            Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
         let dot_cfg = DotGeneralConfig {
             lhs_contracting_dims: vec![0],
             rhs_contracting_dims: vec![0],
@@ -654,9 +659,9 @@ fn cpu_exec_session_covers_dot_errors_and_reclaim_dispatch() {
             })
         ));
 
-        exec.reclaim_buffer(Tensor::F32(TypedTensor::zeros(vec![1])));
-        exec.reclaim_buffer(Tensor::F64(TypedTensor::zeros(vec![1])));
-        exec.reclaim_buffer(Tensor::C32(TypedTensor::zeros(vec![1])));
-        exec.reclaim_buffer(Tensor::C64(TypedTensor::zeros(vec![1])));
+        exec.reclaim_buffer(Tensor::F32(TypedTensor::zeros(vec![1]).unwrap()));
+        exec.reclaim_buffer(Tensor::F64(TypedTensor::zeros(vec![1]).unwrap()));
+        exec.reclaim_buffer(Tensor::C32(TypedTensor::zeros(vec![1]).unwrap()));
+        exec.reclaim_buffer(Tensor::C64(TypedTensor::zeros(vec![1]).unwrap()));
     });
 }

--- a/crates/tenferro-cpu/src/tests/cpu_stub_tests.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_stub_tests.rs
@@ -19,7 +19,7 @@ fn backend_tensor_f64(handle_id: u64, len: usize) -> Tensor {
         vec![len],
         Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(handle_id, len))),
         opaque_backend_placement(),
-    ))
+    ).unwrap())
 }
 
 fn assert_backend_download_error(result: crate::Result<Tensor>, expected_op: &'static str) {
@@ -41,7 +41,7 @@ fn cpu_backend_rejects_backend_view_without_download() {
         vec![2],
         Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(7, 2))),
         opaque_backend_placement(),
-    );
+    ).unwrap();
 
     let err = backend.to_contiguous(&tensor.as_view()).unwrap_err();
 
@@ -57,12 +57,12 @@ fn cpu_backend_rejects_backend_view_without_download() {
 #[test]
 fn cpu_backend_rejects_backend_copy_back_without_download() {
     let mut backend = crate::CpuBackend::new();
-    let src = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
+    let src = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
     let mut dst = TypedTensor::<f64>::from_buffer_col_major(
         vec![2],
         Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(8, 2))),
         opaque_backend_placement(),
-    );
+    ).unwrap();
 
     let err = backend
         .copy_from_contiguous(&src, &mut dst.as_view_mut())
@@ -84,11 +84,11 @@ fn cpu_dot_general_read_rejects_backend_view_without_panic() {
         vec![2, 2],
         Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(9, 4))),
         opaque_backend_placement(),
-    );
+    ).unwrap();
     let rhs = Tensor::F64(TypedTensor::<f64>::from_vec_col_major(
         vec![2, 2],
         vec![1.0, 2.0, 3.0, 4.0],
-    ));
+    ).unwrap());
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -143,7 +143,7 @@ fn cpu_reduce_read_rejects_backend_views_without_download() {
         vec![2],
         Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(11, 2))),
         opaque_backend_placement(),
-    );
+    ).unwrap();
 
     assert_backend_download_error(
         backend.reduce_sum_read(
@@ -178,19 +178,19 @@ fn cpu_reduce_read_rejects_backend_views_without_download() {
 #[test]
 fn cpu_materialize_tensor_read_covers_host_tensor_and_view_dtypes() {
     let tensors = [
-        Tensor::F32(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f32])),
-        Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f64])),
-        Tensor::I32(TypedTensor::from_vec_col_major(vec![1], vec![1_i32])),
-        Tensor::I64(TypedTensor::from_vec_col_major(vec![1], vec![1_i64])),
-        Tensor::Bool(TypedTensor::from_vec_col_major(vec![1], vec![true])),
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f32]).unwrap()),
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap()),
+        Tensor::I32(TypedTensor::from_vec_col_major(vec![1], vec![1_i32]).unwrap()),
+        Tensor::I64(TypedTensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap()),
+        Tensor::Bool(TypedTensor::from_vec_col_major(vec![1], vec![true]).unwrap()),
         Tensor::C32(TypedTensor::from_vec_col_major(
             vec![1],
             vec![Complex32::new(1.0, 0.0)],
-        )),
+        ).unwrap()),
         Tensor::C64(TypedTensor::from_vec_col_major(
             vec![1],
             vec![Complex64::new(1.0, 0.0)],
-        )),
+        ).unwrap()),
     ];
     for tensor in &tensors {
         let materialized =

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -6,8 +6,8 @@ fn test_reclaim_buffer_returns_host_buffer_to_pool() {
     assert_eq!(backend.buffer_pool_len(), 0);
     let t = TensorElementwise::add(
         &mut backend,
-        &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0])),
-        &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0])),
+        &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap()),
+        &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap()),
     )
     .unwrap();
     backend.reclaim_buffer(t);
@@ -17,20 +17,15 @@ fn test_reclaim_buffer_returns_host_buffer_to_pool() {
 #[test]
 fn test_elementwise_add_acquires_output_from_pool() {
     let mut backend = CpuBackend::new();
-    backend.reclaim_buffer(Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4],
-        vec![0.0; 4],
-    )));
+    backend.reclaim_buffer(Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![4], vec![0.0; 4]).unwrap(),
+    ));
     assert_eq!(backend.buffer_pool_len(), 1);
 
-    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4],
-        vec![1.0, 2.0, 3.0, 4.0],
-    ));
-    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4],
-        vec![4.0, 3.0, 2.0, 1.0],
-    ));
+    let lhs =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![4], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
+    let rhs =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![4], vec![4.0, 3.0, 2.0, 1.0]).unwrap());
     let out = backend.add(&lhs, &rhs).unwrap();
 
     assert_eq!(backend.buffer_pool_len(), 0);
@@ -43,11 +38,8 @@ fn test_elementwise_add_acquires_output_from_pool() {
 #[test]
 fn test_broadcast_multiply_fusion_computes_outer_product_without_materialized_inputs() {
     let mut backend = CpuBackend::new();
-    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![2.0, 3.0, 5.0],
-    ));
-    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![7.0, 11.0]));
+    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![2.0, 3.0, 5.0]).unwrap());
+    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![7.0, 11.0]).unwrap());
 
     let out = backend
         .execute_broadcast_multiply(
@@ -71,19 +63,17 @@ fn test_broadcast_multiply_fusion_computes_outer_product_without_materialized_in
 #[test]
 fn test_materialize_tensor_read_covers_host_tensor_and_view_variants() {
     let tensors = [
-        Tensor::F32(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f32])),
-        Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f64])),
-        Tensor::I32(TypedTensor::from_vec_col_major(vec![1], vec![1_i32])),
-        Tensor::I64(TypedTensor::from_vec_col_major(vec![1], vec![1_i64])),
-        Tensor::Bool(TypedTensor::from_vec_col_major(vec![1], vec![true])),
-        Tensor::C32(TypedTensor::from_vec_col_major(
-            vec![1],
-            vec![Complex32::new(1.0, 0.0)],
-        )),
-        Tensor::C64(TypedTensor::from_vec_col_major(
-            vec![1],
-            vec![Complex64::new(1.0, 0.0)],
-        )),
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f32]).unwrap()),
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap()),
+        Tensor::I32(TypedTensor::from_vec_col_major(vec![1], vec![1_i32]).unwrap()),
+        Tensor::I64(TypedTensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap()),
+        Tensor::Bool(TypedTensor::from_vec_col_major(vec![1], vec![true]).unwrap()),
+        Tensor::C32(
+            TypedTensor::from_vec_col_major(vec![1], vec![Complex32::new(1.0, 0.0)]).unwrap(),
+        ),
+        Tensor::C64(
+            TypedTensor::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 0.0)]).unwrap(),
+        ),
     ];
 
     for tensor in &tensors {
@@ -123,16 +113,13 @@ fn test_materialize_tensor_read_covers_host_tensor_and_view_variants() {
 #[test]
 fn test_structural_transpose_acquires_output_from_pool() {
     let mut backend = CpuBackend::new();
-    backend.reclaim_buffer(Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4],
-        vec![0.0; 4],
-    )));
+    backend.reclaim_buffer(Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![4], vec![0.0; 4]).unwrap(),
+    ));
     assert_eq!(backend.buffer_pool_len(), 1);
 
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 2.0, 3.0, 4.0],
-    ));
+    let input =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
     let out = backend.transpose(&input, &[1, 0]).unwrap();
 
     assert_eq!(backend.buffer_pool_len(), 0);
@@ -147,16 +134,13 @@ fn test_structural_transpose_acquires_output_from_pool() {
 #[test]
 fn test_convert_acquires_output_from_dtype_pool() {
     let mut backend = CpuBackend::new();
-    backend.reclaim_buffer(Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![4],
-        vec![0.0; 4],
-    )));
+    backend.reclaim_buffer(Tensor::F32(
+        TypedTensor::from_vec_col_major(vec![4], vec![0.0; 4]).unwrap(),
+    ));
     assert_eq!(backend.buffer_pool_len(), 1);
 
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4],
-        vec![1.25, 2.5, 3.75, 4.0],
-    ));
+    let input =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![4], vec![1.25, 2.5, 3.75, 4.0]).unwrap());
     let out = backend.convert(&input, DType::F32).unwrap();
 
     assert_eq!(backend.buffer_pool_len(), 0);
@@ -169,16 +153,13 @@ fn test_convert_acquires_output_from_dtype_pool() {
 #[test]
 fn test_slice_acquires_output_from_pool() {
     let mut backend = CpuBackend::new();
-    backend.reclaim_buffer(Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![0.0; 2],
-    )));
+    backend.reclaim_buffer(Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2], vec![0.0; 2]).unwrap(),
+    ));
     assert_eq!(backend.buffer_pool_len(), 1);
 
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4],
-        vec![1.0, 2.0, 3.0, 4.0],
-    ));
+    let input =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![4], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
     let config = SliceConfig {
         starts: vec![1],
         limits: vec![3],
@@ -196,13 +177,12 @@ fn test_slice_acquires_output_from_pool() {
 #[test]
 fn test_pad_acquires_and_zeroes_output_from_pool() {
     let mut backend = CpuBackend::new();
-    backend.reclaim_buffer(Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4],
-        vec![9.0; 4],
-    )));
+    backend.reclaim_buffer(Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![4], vec![9.0; 4]).unwrap(),
+    ));
     assert_eq!(backend.buffer_pool_len(), 1);
 
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
     let config = PadConfig {
         edge_padding_low: vec![1],
         edge_padding_high: vec![1],
@@ -222,18 +202,15 @@ fn test_pad_acquires_and_zeroes_output_from_pool() {
 #[test]
 fn test_dynamic_update_slice_acquires_clone_from_pool() {
     let mut backend = CpuBackend::new();
-    backend.reclaim_buffer(Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4],
-        vec![9.0; 4],
-    )));
+    backend.reclaim_buffer(Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![4], vec![9.0; 4]).unwrap(),
+    ));
     assert_eq!(backend.buffer_pool_len(), 1);
 
-    let operand = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4],
-        vec![0.0, 1.0, 2.0, 3.0],
-    ));
-    let update = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![7.0, 8.0]));
-    let starts = Tensor::I64(TypedTensor::from_vec_col_major(vec![1], vec![1]));
+    let operand =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![4], vec![0.0, 1.0, 2.0, 3.0]).unwrap());
+    let update = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![7.0, 8.0]).unwrap());
+    let starts = Tensor::I64(TypedTensor::from_vec_col_major(vec![1], vec![1]).unwrap());
     let out = backend
         .dynamic_update_slice(&operand, &update, &starts)
         .unwrap();
@@ -250,28 +227,26 @@ fn test_dynamic_update_slice_acquires_clone_from_pool() {
 #[test]
 fn test_reclaim_buffer_covers_all_dtypes() {
     let mut backend = CpuBackend::new();
-    let f32_t = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]));
+    let f32_t = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap());
     backend.reclaim_buffer(f32_t);
-    let c32_t = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![1],
-        vec![Complex32::new(1.0, 0.0)],
-    ));
+    let c32_t = Tensor::C32(
+        TypedTensor::from_vec_col_major(vec![1], vec![Complex32::new(1.0, 0.0)]).unwrap(),
+    );
     backend.reclaim_buffer(c32_t);
-    let c64_t = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![1],
-        vec![Complex64::new(1.0, 0.0)],
-    ));
+    let c64_t = Tensor::C64(
+        TypedTensor::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 0.0)]).unwrap(),
+    );
     backend.reclaim_buffer(c64_t);
     assert!(backend.buffer_pool_len() >= 3);
 }
 
 #[test]
 fn test_install_with_pool_preserves_buffers() {
-    let mut backend = CpuBackend::with_threads(1);
+    let mut backend = CpuBackend::with_threads(1).unwrap();
     let t = TensorElementwise::add(
         &mut backend,
-        &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0])),
-        &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0])),
+        &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap()),
+        &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap()),
     )
     .unwrap();
     assert_eq!(get_f64(&t, &[0]), 4.0);
@@ -281,11 +256,10 @@ fn test_install_with_pool_preserves_buffers() {
 
 #[test]
 fn test_with_linalg_pool_restores_buffers_after_panic() {
-    let mut backend = CpuBackend::with_threads(1);
-    backend.reclaim_buffer(Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![1.0, 2.0],
-    )));
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    backend.reclaim_buffer(Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap(),
+    ));
     assert_eq!(backend.buffer_pool_len(), 1);
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -298,11 +272,10 @@ fn test_with_linalg_pool_restores_buffers_after_panic() {
 
 #[test]
 fn test_backend_session_restores_buffers_after_panic() {
-    let mut backend = CpuBackend::with_threads(1);
-    backend.reclaim_buffer(Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![1.0, 2.0],
-    )));
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    backend.reclaim_buffer(Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap(),
+    ));
     assert_eq!(backend.buffer_pool_len(), 1);
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -317,8 +290,8 @@ fn test_backend_session_restores_buffers_after_panic() {
 fn test_exec_session_read_reductions_and_reclaim_cover_typed_paths() {
     let mut backend = CpuBackend::new();
     backend.with_backend_session(|exec| {
-        let lhs = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-        let rhs = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
+        let lhs = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+        let rhs = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
         let added = exec
             .add_read(TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs))
             .unwrap();
@@ -358,34 +331,27 @@ fn test_exec_session_read_reductions_and_reclaim_cover_typed_paths() {
             &[3.0]
         );
 
-        exec.reclaim_buffer(Tensor::F32(TypedTensor::from_vec_col_major(
-            vec![1],
-            vec![0.0_f32],
-        )));
-        exec.reclaim_buffer(Tensor::F64(TypedTensor::from_vec_col_major(
-            vec![1],
-            vec![0.0_f64],
-        )));
-        exec.reclaim_buffer(Tensor::I32(TypedTensor::from_vec_col_major(
-            vec![1],
-            vec![0_i32],
-        )));
-        exec.reclaim_buffer(Tensor::I64(TypedTensor::from_vec_col_major(
-            vec![1],
-            vec![0_i64],
-        )));
-        exec.reclaim_buffer(Tensor::Bool(TypedTensor::from_vec_col_major(
-            vec![1],
-            vec![false],
-        )));
-        exec.reclaim_buffer(Tensor::C32(TypedTensor::from_vec_col_major(
-            vec![1],
-            vec![Complex32::new(0.0, 0.0)],
-        )));
-        exec.reclaim_buffer(Tensor::C64(TypedTensor::from_vec_col_major(
-            vec![1],
-            vec![Complex64::new(0.0, 0.0)],
-        )));
+        exec.reclaim_buffer(Tensor::F32(
+            TypedTensor::from_vec_col_major(vec![1], vec![0.0_f32]).unwrap(),
+        ));
+        exec.reclaim_buffer(Tensor::F64(
+            TypedTensor::from_vec_col_major(vec![1], vec![0.0_f64]).unwrap(),
+        ));
+        exec.reclaim_buffer(Tensor::I32(
+            TypedTensor::from_vec_col_major(vec![1], vec![0_i32]).unwrap(),
+        ));
+        exec.reclaim_buffer(Tensor::I64(
+            TypedTensor::from_vec_col_major(vec![1], vec![0_i64]).unwrap(),
+        ));
+        exec.reclaim_buffer(Tensor::Bool(
+            TypedTensor::from_vec_col_major(vec![1], vec![false]).unwrap(),
+        ));
+        exec.reclaim_buffer(Tensor::C32(
+            TypedTensor::from_vec_col_major(vec![1], vec![Complex32::new(0.0, 0.0)]).unwrap(),
+        ));
+        exec.reclaim_buffer(Tensor::C64(
+            TypedTensor::from_vec_col_major(vec![1], vec![Complex64::new(0.0, 0.0)]).unwrap(),
+        ));
     });
 
     assert!(backend.buffer_pool_len() >= 7);
@@ -618,8 +584,8 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
 
     impl TensorFusion for DefaultOnlyExec {}
 
-    let lhs = Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f64]);
-    let rhs = Tensor::from_vec_col_major(vec![1, 1], vec![3.0_f64]);
+    let lhs = Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f64]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1, 1], vec![3.0_f64]).unwrap();
     let one_shape = [1usize, 1];
     let lhs_data = [2.0_f64];
     let rhs_data = [3.0_f64];
@@ -653,7 +619,7 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         } if message.contains("borrowed tensor views")
     ));
 
-    let reduce_input = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]);
+    let reduce_input = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap();
     let reduce_view_shape = [2usize];
     let reduce_view_data = [2.0_f64, 3.0];
     assert_eq!(
@@ -854,11 +820,14 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
 
 #[test]
 fn test_pool_backed_elementwise_public_paths_cover_dtypes_and_scalars() {
-    let f32_scalar = Tensor::F32(TypedTensor::from_vec_col_major(vec![], vec![2.0]));
-    let c32_vec = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(1.0, 1.0), Complex32::new(-3.0, 0.5)],
-    ));
+    let f32_scalar = Tensor::F32(TypedTensor::from_vec_col_major(vec![], vec![2.0]).unwrap());
+    let c32_vec = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex32::new(1.0, 1.0), Complex32::new(-3.0, 0.5)],
+        )
+        .unwrap(),
+    );
     assert_eq!(
         add(&f32_scalar, &c32_vec)
             .unwrap()
@@ -888,11 +857,14 @@ fn test_pool_backed_elementwise_public_paths_cover_dtypes_and_scalars() {
         Complex32::new(2.0, 2.0)
     );
 
-    let f64_scalar = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![4.0]));
-    let c64_vec = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, -1.0), Complex64::new(0.0, 2.0)],
-    ));
+    let f64_scalar = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![4.0]).unwrap());
+    let c64_vec = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, -1.0), Complex64::new(0.0, 2.0)],
+        )
+        .unwrap(),
+    );
     assert_c64_close(
         div(&c64_vec, &f64_scalar)
             .unwrap()
@@ -901,22 +873,30 @@ fn test_pool_backed_elementwise_public_paths_cover_dtypes_and_scalars() {
         Complex64::new(0.0, 0.5),
     );
 
-    assert!(neg(&Tensor::from_vec_col_major(vec![1], vec![1_i64]))
-        .unwrap_err()
-        .to_string()
-        .contains("I64"));
-    assert!(conj(&Tensor::from_vec_col_major(vec![1], vec![1_i64])).is_err());
-    assert!(abs(&Tensor::from_vec_col_major(vec![1], vec![1_i64])).is_err());
-    assert!(sign(&Tensor::from_vec_col_major(vec![1], vec![1_i64])).is_err());
+    assert!(
+        neg(&Tensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap())
+            .unwrap_err()
+            .to_string()
+            .contains("I64")
+    );
+    assert!(conj(&Tensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap()).is_err());
+    assert!(abs(&Tensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap()).is_err());
+    assert!(sign(&Tensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap()).is_err());
 
-    let a = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(3.0, 4.0), Complex64::new(1.0, 0.0)],
-    ));
-    let b = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(0.0, 2.0), Complex64::new(5.0, 0.0)],
-    ));
+    let a = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(3.0, 4.0), Complex64::new(1.0, 0.0)],
+        )
+        .unwrap(),
+    );
+    let b = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(0.0, 2.0), Complex64::new(5.0, 0.0)],
+        )
+        .unwrap(),
+    );
     assert_c64_close(
         get_c64(&maximum(&a, &b).unwrap(), &[0]),
         Complex64::new(3.0, 4.0),
@@ -926,7 +906,7 @@ fn test_pool_backed_elementwise_public_paths_cover_dtypes_and_scalars() {
         Complex64::new(0.0, 2.0),
     );
     assert!(get_bool(&compare(&a, &b, &CompareDir::Ge).unwrap(), &[0]));
-    let pred = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, true]));
+    let pred = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, true]).unwrap());
     assert_c64_close(
         get_c64(&select(&pred, &a, &b).unwrap(), &[1]),
         Complex64::new(1.0, 0.0),
@@ -939,7 +919,7 @@ fn test_pool_backed_elementwise_public_paths_cover_dtypes_and_scalars() {
 
 #[test]
 fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
-    let real = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 4.0]);
+    let real = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 4.0]).unwrap();
     assert_f64_close(
         crate::analytic::exp(&real)
             .unwrap()
@@ -976,10 +956,9 @@ fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
         0.0,
     );
 
-    let complex = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![1],
-        vec![Complex64::new(1.0, 0.0)],
-    ));
+    let complex = Tensor::C64(
+        TypedTensor::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 0.0)]).unwrap(),
+    );
     assert_c64_close(
         crate::analytic::log(&complex)
             .unwrap()
@@ -991,8 +970,8 @@ fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
     assert!(crate::analytic::cos(&complex).is_ok());
     assert!(crate::analytic::tanh(&complex).is_ok());
 
-    let base = Tensor::from_vec_col_major(vec![2], vec![2.0_f32, 3.0]);
-    let exponent = Tensor::from_vec_col_major(vec![2], vec![3.0_f32, 2.0]);
+    let base = Tensor::from_vec_col_major(vec![2], vec![2.0_f32, 3.0]).unwrap();
+    let exponent = Tensor::from_vec_col_major(vec![2], vec![3.0_f32, 2.0]).unwrap();
     assert_eq!(
         crate::analytic::pow(&base, &exponent)
             .unwrap()
@@ -1000,33 +979,35 @@ fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
             .unwrap(),
         &[8.0, 9.0]
     );
-    assert!(crate::analytic::exp(&Tensor::from_vec_col_major(vec![1], vec![1_i64])).is_err());
+    assert!(
+        crate::analytic::exp(&Tensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap()).is_err()
+    );
     assert!(crate::analytic::pow(&real, &base).is_err());
 }
 
 #[test]
 fn test_pool_backed_structural_public_paths_cover_dispatch_and_helpers() {
-    let matrix = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let matrix = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let transposed = transpose(&matrix, &[1, 0]).unwrap();
     assert_eq!(transposed.shape(), &[2, 2]);
     assert_eq!(transposed.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
 
-    let typed = TypedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 2, 3, 4]);
+    let typed = TypedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 2, 3, 4]).unwrap();
     let typed_t = crate::structural::typed_transpose(&typed, &[1, 0]).unwrap();
-    assert_eq!(typed_t.host_data(), &[1, 3, 2, 4]);
+    assert_eq!(typed_t.host_data().unwrap(), &[1, 3, 2, 4]);
 
-    let row = TypedTensor::from_vec_col_major(vec![1, 2], vec![5.0_f32, 6.0]);
+    let row = TypedTensor::from_vec_col_major(vec![1, 2], vec![5.0_f32, 6.0]).unwrap();
     let typed_b = crate::structural::typed_broadcast_in_dim(&row, &[2, 2], &[0, 1]).unwrap();
-    assert_eq!(typed_b.host_data(), &[5.0, 5.0, 6.0, 6.0]);
+    assert_eq!(typed_b.host_data().unwrap(), &[5.0, 5.0, 6.0, 6.0]);
 
-    let scalar = Tensor::from_vec_col_major(vec![], vec![7.0_f64]);
+    let scalar = Tensor::from_vec_col_major(vec![], vec![7.0_f64]).unwrap();
     let broadcasted = broadcast_in_dim(&scalar, &[2, 2], &[]).unwrap();
     assert_eq!(
         broadcasted.as_slice::<f64>().unwrap(),
         &[7.0, 7.0, 7.0, 7.0]
     );
 
-    let i64_matrix = Tensor::from_vec_col_major(vec![2, 2], vec![1_i64, 2, 3, 4]);
+    let i64_matrix = Tensor::from_vec_col_major(vec![2, 2], vec![1_i64, 2, 3, 4]).unwrap();
     let as_c64 = crate::structural::convert(&i64_matrix, DType::C64).unwrap();
     assert_eq!(as_c64.dtype(), DType::C64);
     let as_f32 = crate::structural::convert(&as_c64, DType::F32).unwrap();
@@ -1043,46 +1024,49 @@ fn test_pool_backed_structural_public_paths_cover_dispatch_and_helpers() {
     assert_eq!(embedded.as_slice::<f64>().unwrap(), &[1.0, 0.0, 0.0, 4.0]);
 
     let typed_diag = crate::structural::typed_extract_diagonal(
-        &TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
+        &TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
         0,
         1,
     )
     .unwrap();
-    assert_eq!(typed_diag.host_data(), &[1.0, 4.0]);
+    assert_eq!(typed_diag.host_data().unwrap(), &[1.0, 4.0]);
     let typed_embedded = crate::structural::typed_embed_diagonal(&typed_diag, 0, 1).unwrap();
-    assert_eq!(typed_embedded.host_data(), &[1.0, 0.0, 0.0, 4.0]);
+    assert_eq!(typed_embedded.host_data().unwrap(), &[1.0, 0.0, 0.0, 4.0]);
 
     let lower = tril(&matrix, 0).unwrap();
     assert_eq!(lower.as_slice::<f64>().unwrap(), &[1.0, 2.0, 0.0, 4.0]);
     let upper = triu(&matrix, 0).unwrap();
     assert_eq!(upper.as_slice::<f64>().unwrap(), &[1.0, 0.0, 3.0, 4.0]);
     let typed_lower = crate::structural::typed_tril(
-        &TypedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 2, 3, 4]),
+        &TypedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 2, 3, 4]).unwrap(),
         0,
     )
     .unwrap();
-    assert_eq!(typed_lower.host_data(), &[1, 2, 0, 4]);
+    assert_eq!(typed_lower.host_data().unwrap(), &[1, 2, 0, 4]);
     let typed_upper = crate::structural::typed_triu(
-        &TypedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 2, 3, 4]),
+        &TypedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 2, 3, 4]).unwrap(),
         0,
     )
     .unwrap();
-    assert_eq!(typed_upper.host_data(), &[1, 0, 3, 4]);
+    assert_eq!(typed_upper.host_data().unwrap(), &[1, 0, 3, 4]);
     assert!(crate::structural::typed_tril(
-        &TypedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]),
+        &TypedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
         0
     )
     .is_err());
 
-    let c32_matrix = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![
-            Complex32::new(1.0, 0.0),
-            Complex32::new(2.0, 0.0),
-            Complex32::new(3.0, 0.0),
-            Complex32::new(4.0, 0.0),
-        ],
-    ));
+    let c32_matrix = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex32::new(1.0, 0.0),
+                Complex32::new(2.0, 0.0),
+                Complex32::new(3.0, 0.0),
+                Complex32::new(4.0, 0.0),
+            ],
+        )
+        .unwrap(),
+    );
     assert_eq!(transpose(&c32_matrix, &[1, 0]).unwrap().dtype(), DType::C32);
     assert_eq!(tril(&c32_matrix, 0).unwrap().dtype(), DType::C32);
 }
@@ -1095,13 +1079,14 @@ fn exercise_read_delegate_ops<B>(backend: &mut B)
 where
     B: TensorElementwise + TensorAnalytic + TensorStructural + TensorDot + ?Sized,
 {
-    let lhs = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]);
-    let rhs = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 8.0]);
-    let pred = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]));
-    let lower = Tensor::from_vec_col_major(vec![2], vec![1.5_f64, 3.0]);
-    let upper = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 6.0]);
-    let view = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 4.0]);
-    let matrix = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let lhs = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 8.0]).unwrap();
+    let pred = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]).unwrap());
+    let lower = Tensor::from_vec_col_major(vec![2], vec![1.5_f64, 3.0]).unwrap();
+    let upper = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 6.0]).unwrap();
+    let view = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 4.0]).unwrap();
+    let matrix =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
 
     assert_f64_slice_eq(
         &backend
@@ -1267,7 +1252,7 @@ where
         lhs_batch_dims: vec![],
         rhs_batch_dims: vec![],
     };
-    let rhs_matrix = Tensor::from_vec_col_major(vec![2, 2], vec![5.0_f64, 6.0, 7.0, 8.0]);
+    let rhs_matrix = Tensor::from_vec_col_major(vec![2, 2], vec![5.0_f64, 6.0, 7.0, 8.0]).unwrap();
     assert_eq!(
         backend
             .dot_general_read(

--- a/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
@@ -2,47 +2,47 @@ use super::*;
 
 #[test]
 fn test_zeros_ones() {
-    let z = TypedTensor::<f64>::zeros(vec![2, 3]);
+    let z = TypedTensor::<f64>::zeros(vec![2, 3]).unwrap();
     assert_eq!(z.shape(), &[2, 3]);
     assert_eq!(z.n_elements(), 6);
     for i in 0..2 {
         for j in 0..3 {
-            assert_eq!(*z.get(&[i, j]), 0.0);
+            assert_eq!(*z.get(&[i, j]).unwrap(), 0.0);
         }
     }
 
-    let o = TypedTensor::<f64>::ones(vec![2, 3]);
+    let o = TypedTensor::<f64>::ones(vec![2, 3]).unwrap();
     for i in 0..2 {
         for j in 0..3 {
-            assert_eq!(*o.get(&[i, j]), 1.0);
+            assert_eq!(*o.get(&[i, j]).unwrap(), 1.0);
         }
     }
 }
 
 #[test]
 fn test_from_vec_uses_column_major_indices() {
-    let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    assert_eq!(*t.get(&[0, 0]), 1.0);
-    assert_eq!(*t.get(&[1, 0]), 2.0);
-    assert_eq!(*t.get(&[0, 1]), 3.0);
-    assert_eq!(*t.get(&[1, 1]), 4.0);
-    assert_eq!(*t.get(&[0, 2]), 5.0);
-    assert_eq!(*t.get(&[1, 2]), 6.0);
+    let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
+    assert_eq!(*t.get(&[0, 0]).unwrap(), 1.0);
+    assert_eq!(*t.get(&[1, 0]).unwrap(), 2.0);
+    assert_eq!(*t.get(&[0, 1]).unwrap(), 3.0);
+    assert_eq!(*t.get(&[1, 1]).unwrap(), 4.0);
+    assert_eq!(*t.get(&[0, 2]).unwrap(), 5.0);
+    assert_eq!(*t.get(&[1, 2]).unwrap(), 6.0);
 }
 
 #[test]
 fn test_tensor_metadata() {
-    let t = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1.0, 2.0]));
+    let t = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1.0, 2.0]).unwrap());
     assert_eq!(t.shape(), &[2, 1]);
     assert_eq!(t.dtype(), DType::F64);
 }
 
 #[test]
 fn test_reshape() {
-    let t = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let t = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
     let r = reshape(&t, &[3, 2]).unwrap();
     assert_eq!(r.shape(), &[3, 2]);
     assert_eq!(get_f64(&r, &[0, 0]), 1.0);
@@ -55,14 +55,11 @@ fn test_reshape() {
 
 #[test]
 fn test_add_mul() {
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 2.0, 3.0, 4.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![10.0, 20.0, 30.0, 40.0],
-    ));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
+    let b = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 2], vec![10.0, 20.0, 30.0, 40.0]).unwrap(),
+    );
     let sum = add(&a, &b).unwrap();
     let prod = mul(&a, &b).unwrap();
 
@@ -79,14 +76,8 @@ fn test_add_mul() {
 
 #[test]
 fn test_add_mul_i64() {
-    let a = Tensor::I64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1, 2, 3, 4],
-    ));
-    let b = Tensor::I64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![10, 20, 30, 40],
-    ));
+    let a = Tensor::I64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1, 2, 3, 4]).unwrap());
+    let b = Tensor::I64(TypedTensor::from_vec_col_major(vec![2, 2], vec![10, 20, 30, 40]).unwrap());
     let sum = add(&a, &b).unwrap();
     let prod = mul(&a, &b).unwrap();
 
@@ -103,11 +94,9 @@ fn test_add_mul_i64() {
 
 #[test]
 fn test_add_mul_rank0_broadcast() {
-    let scalar = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![2.0]));
-    let tensor = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 2.0, 3.0, 4.0],
-    ));
+    let scalar = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![2.0]).unwrap());
+    let tensor =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
 
     let scalar_plus_tensor = add(&scalar, &tensor).unwrap();
     let tensor_plus_scalar = add(&tensor, &scalar).unwrap();
@@ -133,11 +122,14 @@ fn test_add_mul_rank0_broadcast() {
 
 #[test]
 fn test_mul_rank0_real_scalar_broadcasts_over_complex_tensor() {
-    let scalar = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![2.0]));
-    let tensor = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
-    ));
+    let scalar = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![2.0]).unwrap());
+    let tensor = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
+        )
+        .unwrap(),
+    );
 
     let scalar_times_tensor = mul(&scalar, &tensor).unwrap();
     let tensor_times_scalar = mul(&tensor, &scalar).unwrap();
@@ -151,14 +143,16 @@ fn test_mul_rank0_real_scalar_broadcasts_over_complex_tensor() {
 
 #[test]
 fn test_mul_rank0_complex_scalar_broadcasts_over_complex_tensor() {
-    let scalar = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![],
-        vec![Complex64::new(2.0, -1.0)],
-    ));
-    let tensor = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
-    ));
+    let scalar = Tensor::C64(
+        TypedTensor::from_vec_col_major(vec![], vec![Complex64::new(2.0, -1.0)]).unwrap(),
+    );
+    let tensor = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
+        )
+        .unwrap(),
+    );
     let output = mul(&scalar, &tensor).unwrap();
 
     assert_c64_close(get_c64(&output, &[0]), Complex64::new(4.0, 3.0));
@@ -167,33 +161,32 @@ fn test_mul_rank0_complex_scalar_broadcasts_over_complex_tensor() {
 
 #[test]
 fn test_rank0_typed_tensor_behaves_like_scalar() {
-    let mut zeros = TypedTensor::<f64>::zeros(vec![]);
+    let mut zeros = TypedTensor::<f64>::zeros(vec![]).unwrap();
     assert_eq!(zeros.shape(), &[] as &[usize]);
     assert_eq!(zeros.n_elements(), 1);
-    assert_eq!(zeros.linear_offset(&[]), 0);
-    assert_eq!(zeros.get(&[]), &0.0);
+    assert_eq!(zeros.linear_offset(&[]).unwrap(), 0);
+    assert_eq!(zeros.get(&[]).unwrap(), &0.0);
 
-    *zeros.get_mut(&[]) = 2.5;
-    assert_eq!(zeros.host_data(), &[2.5]);
+    *zeros.get_mut(&[]).unwrap() = 2.5;
+    assert_eq!(zeros.host_data().unwrap(), &[2.5]);
 
-    let ones = TypedTensor::<f64>::ones(vec![]);
+    let ones = TypedTensor::<f64>::ones(vec![]).unwrap();
     assert_eq!(ones.shape(), &[] as &[usize]);
     assert_eq!(ones.n_elements(), 1);
-    assert_eq!(ones.get(&[]), &1.0);
+    assert_eq!(ones.get(&[]).unwrap(), &1.0);
 
-    let scalar = TypedTensor::<f64>::from_vec_col_major(vec![], vec![7.0]);
+    let scalar = TypedTensor::<f64>::from_vec_col_major(vec![], vec![7.0]).unwrap();
     assert_eq!(scalar.shape(), &[] as &[usize]);
     assert_eq!(scalar.n_elements(), 1);
-    assert_eq!(scalar.linear_offset(&[]), 0);
-    assert_eq!(scalar.get(&[]), &7.0);
+    assert_eq!(scalar.linear_offset(&[]).unwrap(), 0);
+    assert_eq!(scalar.get(&[]).unwrap(), &7.0);
 }
 
 #[test]
 fn test_reduce_sum() {
-    let t = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let t = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
     let r = reduce_sum(&t, &[0]).unwrap();
     assert_eq!(r.shape(), &[3]);
     assert_eq!(get_f64(&r, &[0]), 3.0);
@@ -207,10 +200,9 @@ fn test_reduce_sum() {
 
 #[test]
 fn test_reduce_prod() {
-    let t = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let t = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
 
     let r = reduce_prod(&t, &[0]).unwrap();
     assert_eq!(r.shape(), &[3]);
@@ -225,10 +217,9 @@ fn test_reduce_prod() {
 
 #[test]
 fn test_reduce_max_and_min() {
-    let t = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let t = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
 
     let max_cols = reduce_max(&t, &[0]).unwrap();
     assert_eq!(max_cols.shape(), &[3]);
@@ -252,10 +243,9 @@ fn test_reduce_max_and_min() {
 
 #[test]
 fn test_backend_reduce_prod_max_and_min_delegate_to_cpu_reduction_impls() {
-    let t = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let t = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
     let mut backend = CpuBackend::new();
 
     let prod = backend.reduce_prod(&t, &[0]).unwrap();
@@ -276,10 +266,10 @@ fn test_backend_reduce_prod_max_and_min_delegate_to_cpu_reduction_impls() {
 
 #[test]
 fn test_slice() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4, 4],
-        (1..=16).map(|value| value as f64).collect(),
-    ));
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![4, 4], (1..=16).map(|value| value as f64).collect())
+            .unwrap(),
+    );
     let mut backend = CpuBackend::new();
     let out = backend
         .slice(
@@ -301,10 +291,9 @@ fn test_slice() {
 
 #[test]
 fn test_reverse_axis_zero() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
     let mut backend = CpuBackend::new();
     let out = backend.reverse(&input, &[0]).unwrap();
 
@@ -319,20 +308,21 @@ fn test_reverse_axis_zero() {
 
 #[test]
 fn test_reverse_accepts_i64_data_tensor() {
-    let input = Tensor::from_vec_col_major(vec![3], vec![1_i64, 2, 3]);
+    let input = Tensor::from_vec_col_major(vec![3], vec![1_i64, 2, 3]).unwrap();
     let mut backend = CpuBackend::new();
 
     let out = backend.reverse(&input, &[0]).unwrap();
 
     assert_eq!(out.dtype(), DType::I64);
     assert_eq!(out.shape(), &[3]);
-    assert_eq!(out.as_slice::<i64>(), Some([3, 2, 1].as_slice()));
+    assert_eq!(out.as_slice::<i64>().unwrap(), [3, 2, 1].as_slice());
 }
 
 #[test]
 fn tensor_index_select_trailing_axis_returns_expected_values() {
     let mut backend = CpuBackend::new();
-    let input = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let input =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
 
     let out = input.index_select(-1, &[2, 0, 2], &mut backend).unwrap();
 
@@ -348,7 +338,7 @@ fn tensor_index_select_trailing_axis_returns_expected_values() {
 #[test]
 fn tensor_index_select_rejects_invalid_axis_and_position() {
     let mut backend = CpuBackend::new();
-    let input = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    let input = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
 
     let axis_err = input.index_select(-2, &[0], &mut backend).unwrap_err();
     assert!(axis_err.to_string().contains("index_select"));
@@ -363,14 +353,14 @@ fn tensor_index_select_rejects_invalid_axis_and_position() {
 fn tensor_stack_trailing_axis_packs_scalars_vectors_and_matrices() {
     let mut backend = CpuBackend::new();
 
-    let a = Tensor::from_vec_col_major(vec![], vec![1.0_f64]);
-    let b = Tensor::from_vec_col_major(vec![], vec![2.0_f64]);
+    let a = Tensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
     let scalars = Tensor::stack(&[&a, &b], -1, &mut backend).unwrap();
     assert_eq!(scalars.shape(), &[2]);
     assert_eq!(scalars.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
 
-    let v0 = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let v1 = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
+    let v0 = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let v1 = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
     let vectors = Tensor::stack(&[&v0, &v1], -1, &mut backend).unwrap();
     assert_eq!(vectors.shape(), &[2, 2]);
     assert_f64_close(get_f64(&vectors, &[0, 0]), 1.0);
@@ -378,8 +368,8 @@ fn tensor_stack_trailing_axis_packs_scalars_vectors_and_matrices() {
     assert_f64_close(get_f64(&vectors, &[0, 1]), 3.0);
     assert_f64_close(get_f64(&vectors, &[1, 1]), 4.0);
 
-    let m0 = Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0]);
-    let m1 = Tensor::from_vec_col_major(vec![2, 1], vec![3.0_f64, 4.0]);
+    let m0 = Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0]).unwrap();
+    let m1 = Tensor::from_vec_col_major(vec![2, 1], vec![3.0_f64, 4.0]).unwrap();
     let matrices = Tensor::stack(&[&m0, &m1], -1, &mut backend).unwrap();
     assert_eq!(matrices.shape(), &[2, 1, 2]);
     assert_f64_close(get_f64(&matrices, &[0, 0, 0]), 1.0);
@@ -391,11 +381,12 @@ fn tensor_stack_trailing_axis_packs_scalars_vectors_and_matrices() {
 #[test]
 fn tensor_index_select_reuses_reclaimed_cpu_buffer() {
     let mut backend = CpuBackend::new();
-    let reusable = Tensor::from_vec_col_major(vec![2, 3], vec![0.0_f64; 6]);
+    let reusable = Tensor::from_vec_col_major(vec![2, 3], vec![0.0_f64; 6]).unwrap();
     let expected_ptr = reusable.as_slice::<f64>().unwrap().as_ptr();
     backend.reclaim_buffer(reusable);
 
-    let input = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let input =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let out = input.index_select(-1, &[2, 0, 1], &mut backend).unwrap();
 
     assert_eq!(out.as_slice::<f64>().unwrap().as_ptr(), expected_ptr);
@@ -404,12 +395,12 @@ fn tensor_index_select_reuses_reclaimed_cpu_buffer() {
 #[test]
 fn tensor_stack_reuses_reclaimed_cpu_buffer() {
     let mut backend = CpuBackend::new();
-    let reusable = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4]);
+    let reusable = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4]).unwrap();
     let expected_ptr = reusable.as_slice::<f64>().unwrap().as_ptr();
     backend.reclaim_buffer(reusable);
 
-    let x0 = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let x1 = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
+    let x0 = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let x1 = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
     let out = Tensor::stack(&[&x0, &x1], -1, &mut backend).unwrap();
 
     assert_eq!(out.as_slice::<f64>().unwrap().as_ptr(), expected_ptr);
@@ -417,10 +408,7 @@ fn tensor_stack_reuses_reclaimed_cpu_buffer() {
 
 #[test]
 fn test_reverse_axis_out_of_bounds_returns_error() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![1.0, 2.0, 3.0],
-    ));
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap());
     let mut backend = CpuBackend::new();
 
     let err = backend.reverse(&input, &[1]).unwrap_err();
@@ -437,11 +425,11 @@ fn test_reverse_axis_out_of_bounds_returns_error() {
 
 #[test]
 fn test_gather_rejects_fractional_float_indices() {
-    let operand = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![5],
-        vec![10.0, 20.0, 30.0, 40.0, 50.0],
-    ));
-    let start_indices = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1], vec![1.5]));
+    let operand = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![5], vec![10.0, 20.0, 30.0, 40.0, 50.0]).unwrap(),
+    );
+    let start_indices =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1], vec![1.5]).unwrap());
     let mut backend = CpuBackend::new();
 
     let err = backend
@@ -459,14 +447,12 @@ fn test_gather_rejects_fractional_float_indices() {
 
 #[test]
 fn test_gather_rejects_complex_indices() {
-    let operand = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![5],
-        vec![10.0, 20.0, 30.0, 40.0, 50.0],
-    ));
-    let start_indices = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![1, 1],
-        vec![Complex64::new(1.0, 0.0)],
-    ));
+    let operand = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![5], vec![10.0, 20.0, 30.0, 40.0, 50.0]).unwrap(),
+    );
+    let start_indices = Tensor::C64(
+        TypedTensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 0.0)]).unwrap(),
+    );
     let mut backend = CpuBackend::new();
 
     let err = backend
@@ -484,8 +470,8 @@ fn test_gather_rejects_complex_indices() {
 
 #[test]
 fn test_dynamic_slice_rejects_oversized_window() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
-    let starts = Tensor::from_vec_col_major(vec![1], vec![0_i64]);
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
+    let starts = Tensor::from_vec_col_major(vec![1], vec![0_i64]).unwrap();
     let mut backend = CpuBackend::new();
 
     let err = backend.dynamic_slice(&input, &starts, &[3]).unwrap_err();
@@ -501,14 +487,12 @@ fn test_dynamic_slice_rejects_oversized_window() {
 
 #[test]
 fn test_large_float_index_outside_exact_integer_range_returns_error() {
-    let operand = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![5],
-        vec![10.0, 20.0, 30.0, 40.0, 50.0],
-    ));
-    let start_indices = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![1, 1],
-        vec![9_007_199_254_740_995.0f64],
-    ));
+    let operand = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![5], vec![10.0, 20.0, 30.0, 40.0, 50.0]).unwrap(),
+    );
+    let start_indices = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![1, 1], vec![9_007_199_254_740_995.0f64]).unwrap(),
+    );
     let mut backend = CpuBackend::new();
 
     let err = backend
@@ -526,10 +510,8 @@ fn test_large_float_index_outside_exact_integer_range_returns_error() {
 
 #[test]
 fn test_invalid_slice_config_returns_error() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 2.0, 3.0, 4.0],
-    ));
+    let input =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
     let mut backend = CpuBackend::new();
 
     let err = backend
@@ -550,7 +532,7 @@ fn test_invalid_slice_config_returns_error() {
 
 #[test]
 fn test_invalid_pad_config_returns_error() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
     let mut backend = CpuBackend::new();
 
     let err = backend
@@ -568,11 +550,10 @@ fn test_invalid_pad_config_returns_error() {
 
 #[test]
 fn test_gather_rejects_malformed_offset_dims() {
-    let operand = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3, 2],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
-    let start_indices = Tensor::from_vec_col_major(vec![3, 1], vec![0_i64, 1, 2]);
+    let operand = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
+    let start_indices = Tensor::from_vec_col_major(vec![3, 1], vec![0_i64, 1, 2]).unwrap();
     let mut backend = CpuBackend::new();
     let config = GatherConfig {
         offset_dims: vec![2],
@@ -593,12 +574,11 @@ fn test_gather_rejects_malformed_offset_dims() {
 
 #[test]
 fn test_scatter_rejects_update_window_dim_out_of_bounds() {
-    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3, 3]));
-    let scatter_indices = Tensor::from_vec_col_major(vec![3, 2], vec![0_i64, 0, 1, 1, 2, 2]);
-    let updates = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3, 3, 3],
-        vec![0.0; 27],
-    ));
+    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3, 3]).unwrap());
+    let scatter_indices =
+        Tensor::from_vec_col_major(vec![3, 2], vec![0_i64, 0, 1, 1, 2, 2]).unwrap();
+    let updates =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3, 3, 3], vec![0.0; 27]).unwrap());
     let mut backend = CpuBackend::new();
     let config = ScatterConfig {
         update_window_dims: vec![0, 3],
@@ -622,9 +602,10 @@ fn test_scatter_rejects_update_window_dim_out_of_bounds() {
 
 #[test]
 fn test_scatter_rejects_too_many_update_window_dims() {
-    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3, 3]));
-    let scatter_indices = Tensor::from_vec_col_major(vec![3, 2], vec![0_i64, 0, 1, 1, 2, 2]);
-    let updates = Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![0.0; 3]));
+    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3, 3]).unwrap());
+    let scatter_indices =
+        Tensor::from_vec_col_major(vec![3, 2], vec![0_i64, 0, 1, 1, 2, 2]).unwrap();
+    let updates = Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![0.0; 3]).unwrap());
     let mut backend = CpuBackend::new();
     let config = ScatterConfig {
         update_window_dims: vec![0, 1],
@@ -645,14 +626,12 @@ fn test_scatter_rejects_too_many_update_window_dims() {
 
 #[test]
 fn test_concatenate_axis_zero() {
-    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
-    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3],
-        vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0],
-    ));
+    let lhs = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
+    let rhs = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0]).unwrap(),
+    );
     let mut backend = CpuBackend::new();
     let out = backend.concatenate(&[&lhs, &rhs], 0).unwrap();
 

--- a/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
@@ -36,9 +36,8 @@ fn cpu_context_try_from_env_rejects_zero_rayon_num_threads() {
 }
 
 #[test]
-#[should_panic(expected = "thread count must be at least 1")]
-fn cpu_context_with_threads_zero_panics_for_compatibility() {
-    let _ctx = CpuContext::with_threads(0);
+fn cpu_context_with_threads_zero_returns_error() {
+    assert!(CpuContext::with_threads(0).is_err());
 }
 
 #[test]
@@ -66,12 +65,12 @@ fn cpu_backend_try_new_propagates_invalid_rayon_num_threads() {
 
 #[test]
 fn test_with_backend_session_runs_compiled_ops() {
-    let mut backend = CpuBackend::with_threads(2);
+    let mut backend = CpuBackend::with_threads(2).unwrap();
     let result = backend.with_backend_session(|session| {
         session
             .add(
-                &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0])),
-                &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0])),
+                &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap()),
+                &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap()),
             )
             .unwrap()
     });
@@ -81,19 +80,19 @@ fn test_with_backend_session_runs_compiled_ops() {
 
 #[test]
 fn cpu_context_install_enters_owned_pool() {
-    let ctx = CpuContext::with_threads(2);
+    let ctx = CpuContext::with_threads(2).unwrap();
     let seen_threads = ctx.install(rayon::current_num_threads);
     assert_eq!(seen_threads, 2);
 }
 
 #[test]
 fn cpu_install_accepts_send_state() {
-    let ctx = CpuContext::with_threads(2);
+    let ctx = CpuContext::with_threads(2).unwrap();
     let state = Arc::new(41usize);
     let seen = ctx.install(|| *state + 1);
     assert_eq!(seen, 42);
 
-    let backend = CpuBackend::with_threads(2);
+    let backend = CpuBackend::with_threads(2).unwrap();
     let state = Arc::new(20usize);
     let seen = backend.install(|| *state + 2);
     assert_eq!(seen, 22);
@@ -101,14 +100,14 @@ fn cpu_install_accepts_send_state() {
 
 #[test]
 fn cpu_backend_exec_session_enters_owned_pool() {
-    let mut backend = CpuBackend::with_threads(2);
+    let mut backend = CpuBackend::with_threads(2).unwrap();
     let seen_threads = backend.with_backend_session(|_| rayon::current_num_threads());
     assert_eq!(seen_threads, 2);
 }
 
 #[test]
 fn cpu_backend_shared_context() {
-    let ctx = Arc::new(CpuContext::with_threads(3));
+    let ctx = Arc::new(CpuContext::with_threads(3).unwrap());
     let b1 = CpuBackend::from_context(ctx.clone());
     let b2 = CpuBackend::from_context(ctx);
     assert!(Arc::ptr_eq(&b1.ctx, &b2.ctx));
@@ -121,7 +120,7 @@ fn cpu_affinity_available_parallelism_reports_positive_count() {
 
 #[test]
 fn cpu_backend_from_context_shares_runtime_owner() {
-    let ctx = Arc::new(CpuContext::with_threads(3));
+    let ctx = Arc::new(CpuContext::with_threads(3).unwrap());
     let b1 = CpuBackend::from_context(ctx.clone());
     let b2 = CpuBackend::from_context(ctx);
     assert_eq!(b1.num_threads(), 3);
@@ -131,19 +130,19 @@ fn cpu_backend_from_context_shares_runtime_owner() {
 #[cfg(feature = "cpu-faer")]
 #[test]
 fn cpu_context_faer_policy_is_seq_for_one_thread() {
-    let ctx = CpuContext::with_threads(1);
+    let ctx = CpuContext::with_threads(1).unwrap();
     assert!(matches!(ctx.faer_par(), faer::Par::Seq));
 }
 
 #[test]
 fn cpu_context_with_threads_reports_requested_size() {
-    let ctx = CpuContext::with_threads(2);
+    let ctx = CpuContext::with_threads(2).unwrap();
     assert_eq!(ctx.num_threads(), 2);
 }
 
 #[test]
 fn cpu_context_install_executes_closure() {
-    let ctx = CpuContext::with_threads(1);
+    let ctx = CpuContext::with_threads(1).unwrap();
     let seen = ctx.install(|| 1 + 1);
     assert_eq!(seen, 2);
 }

--- a/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
@@ -2,16 +2,18 @@ use super::*;
 
 #[test]
 fn test_dot_general_matmul() {
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3, 4],
-        vec![
-            1.0, 5.0, 9.0, 2.0, 6.0, 10.0, 3.0, 7.0, 11.0, 4.0, 8.0, 12.0,
-        ],
-    ));
+    let a = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap(),
+    );
+    let b = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![3, 4],
+            vec![
+                1.0, 5.0, 9.0, 2.0, 6.0, 10.0, 3.0, 7.0, 11.0, 4.0, 8.0, 12.0,
+            ],
+        )
+        .unwrap(),
+    );
     let mut backend = CpuBackend::new();
     let c = backend
         .dot_general(
@@ -48,14 +50,8 @@ fn test_dot_general_with_conj_matches_materialized_complex_matmul() {
         Complex64::new(0.5, 3.0),
         Complex64::new(-1.0, -2.0),
     ];
-    let lhs = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        lhs_data.clone(),
-    ));
-    let rhs = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        rhs_data.clone(),
-    ));
+    let lhs = Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], lhs_data.clone()).unwrap());
+    let rhs = Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], rhs_data.clone()).unwrap());
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -83,7 +79,8 @@ fn test_dot_general_with_conj_matches_materialized_complex_matmul() {
 
 #[test]
 fn test_dot_general_read_accepts_tensor_and_view_inputs() {
-    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let rhs_shape = [3usize, 2];
     let rhs_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
     let rhs_view = TensorView::f64(&rhs_shape, &rhs_data).unwrap();
@@ -122,9 +119,11 @@ fn test_dot_general_read_accepts_tensor_and_view_inputs() {
 #[test]
 fn test_dot_general_read_accepts_transposed_host_view_input() {
     let lhs_source =
-        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
     let lhs_view = lhs_source.as_view().transpose_view([1, 0]).unwrap();
-    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0]);
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0]).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -149,12 +148,14 @@ fn test_dot_general_read_accepts_transposed_host_view_input() {
 #[test]
 fn test_dot_general_read_blas_negative_stride_view_falls_back() {
     let lhs_source =
-        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
     let lhs_view = lhs_source
         .as_view()
         .try_slice_axis(1, StridedSliceSpec::reverse())
         .unwrap();
-    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0]);
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0]).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -177,14 +178,8 @@ fn test_dot_general_read_blas_negative_stride_view_falls_back() {
 
 #[test]
 fn test_dot_general_inner_product_returns_rank0_scalar() {
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![1.0, 2.0, 3.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![4.0, 5.0, 6.0],
-    ));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![4.0, 5.0, 6.0]).unwrap());
     let mut backend = CpuBackend::new();
     let c = backend
         .dot_general(
@@ -204,8 +199,8 @@ fn test_dot_general_inner_product_returns_rank0_scalar() {
 
 #[test]
 fn test_dot_general_zero_sized_matmul_returns_empty_matrix() {
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![0, 0], Vec::new()));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![0, 0], Vec::new()));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![0, 0], Vec::new()).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![0, 0], Vec::new()).unwrap());
     let mut backend = CpuBackend::new();
     let c = backend
         .dot_general(
@@ -222,15 +217,15 @@ fn test_dot_general_zero_sized_matmul_returns_empty_matrix() {
 
     assert_eq!(c.shape(), &[0, 0]);
     match c {
-        Tensor::F64(inner) => assert!(inner.host_data().is_empty()),
+        Tensor::F64(inner) => assert!(inner.host_data().unwrap().is_empty()),
         _ => panic!("expected F64 tensor"),
     }
 }
 
 #[test]
 fn test_dot_general_zero_contracting_dim_returns_zero_filled_output() {
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 0], Vec::new()));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![0, 3], Vec::new()));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 0], Vec::new()).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![0, 3], Vec::new()).unwrap());
     let mut backend = CpuBackend::new();
     let c = backend
         .dot_general(
@@ -247,25 +242,32 @@ fn test_dot_general_zero_contracting_dim_returns_zero_filled_output() {
 
     assert_eq!(c.shape(), &[2, 3]);
     match c {
-        Tensor::F64(inner) => assert_eq!(inner.host_data(), &[0.0; 6]),
+        Tensor::F64(inner) => assert_eq!(inner.host_data().unwrap(), &[0.0; 6]),
         _ => panic!("expected F64 tensor"),
     }
 }
 
 #[test]
 fn test_dot_general_falls_back_for_unfusable_lhs_batch_layout() {
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2, 2, 2],
-        vec![
-            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
-        ],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2, 2, 2],
-        vec![
-            1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0,
-        ],
-    ));
+    let a = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2, 2, 2],
+            vec![
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+                16.0,
+            ],
+        )
+        .unwrap(),
+    );
+    let b = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2, 2, 2],
+            vec![
+                1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0,
+            ],
+        )
+        .unwrap(),
+    );
     let mut backend = CpuBackend::new();
     let c = backend
         .dot_general(
@@ -301,10 +303,9 @@ fn test_dot_general_falls_back_for_unfusable_lhs_batch_layout() {
 
 #[test]
 fn test_transpose() {
-    let t = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let t = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
     let tr = transpose(&t, &[1, 0]).unwrap();
     assert_eq!(tr.shape(), &[3, 2]);
     assert_eq!(get_f64(&tr, &[0, 0]), 1.0);
@@ -317,17 +318,14 @@ fn test_transpose() {
 
 #[test]
 fn test_broadcast_in_dim() {
-    let scalar = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![5.0]));
+    let scalar = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![5.0]).unwrap());
     let broadcast = broadcast_in_dim(&scalar, &[3], &[]).unwrap();
     assert_eq!(broadcast.shape(), &[3]);
     assert_eq!(get_f64(&broadcast, &[0]), 5.0);
     assert_eq!(get_f64(&broadcast, &[1]), 5.0);
     assert_eq!(get_f64(&broadcast, &[2]), 5.0);
 
-    let v = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![1.0, 2.0, 3.0],
-    ));
+    let v = Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap());
     let m = broadcast_in_dim(&v, &[3, 2], &[0]).unwrap();
     assert_eq!(m.shape(), &[3, 2]);
     for j in 0..2 {
@@ -339,15 +337,18 @@ fn test_broadcast_in_dim() {
 
 #[test]
 fn test_tril_3x3() {
-    let t = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3, 3],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-    ));
+    let t = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![3, 3],
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+        )
+        .unwrap(),
+    );
     let lower = tril(&t, 0).unwrap();
     assert_eq!(lower.shape(), &[3, 3]);
     assert_eq!(
         match &lower {
-            Tensor::F64(inner) => inner.host_data(),
+            Tensor::F64(inner) => inner.host_data().unwrap(),
             _ => panic!("expected f64 tensor"),
         },
         &[1.0, 2.0, 3.0, 0.0, 5.0, 6.0, 0.0, 0.0, 9.0]
@@ -356,15 +357,18 @@ fn test_tril_3x3() {
 
 #[test]
 fn test_triu_3x3() {
-    let t = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3, 3],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-    ));
+    let t = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![3, 3],
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+        )
+        .unwrap(),
+    );
     let upper = triu(&t, 0).unwrap();
     assert_eq!(upper.shape(), &[3, 3]);
     assert_eq!(
         match &upper {
-            Tensor::F64(inner) => inner.host_data(),
+            Tensor::F64(inner) => inner.host_data().unwrap(),
             _ => panic!("expected f64 tensor"),
         },
         &[1.0, 0.0, 0.0, 4.0, 5.0, 0.0, 7.0, 8.0, 9.0]
@@ -373,34 +377,32 @@ fn test_triu_3x3() {
 
 #[test]
 fn test_tril_triu_zero_sized_batch_return_empty_tensor() {
-    let t = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2, 0], Vec::new()));
+    let t = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2, 0], Vec::new()).unwrap());
 
     let lower = tril(&t, 0).unwrap();
     assert_eq!(lower.shape(), &[2, 2, 0]);
     match lower {
-        Tensor::F64(inner) => assert!(inner.host_data().is_empty()),
+        Tensor::F64(inner) => assert!(inner.host_data().unwrap().is_empty()),
         _ => panic!("expected f64 tensor"),
     }
 
     let upper = triu(&t, 0).unwrap();
     assert_eq!(upper.shape(), &[2, 2, 0]);
     match upper {
-        Tensor::F64(inner) => assert!(inner.host_data().is_empty()),
+        Tensor::F64(inner) => assert!(inner.host_data().unwrap().is_empty()),
         _ => panic!("expected f64 tensor"),
     }
 }
 
 #[test]
 fn test_tril_triu_extreme_offsets_do_not_overflow() {
-    let t = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 2.0, 3.0, 4.0],
-    ));
+    let t =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
 
     let lower_min = tril(&t, i64::MIN).unwrap();
     assert_eq!(
         match &lower_min {
-            Tensor::F64(inner) => inner.host_data(),
+            Tensor::F64(inner) => inner.host_data().unwrap(),
             _ => panic!("expected f64 tensor"),
         },
         &[0.0, 0.0, 0.0, 0.0]
@@ -409,7 +411,7 @@ fn test_tril_triu_extreme_offsets_do_not_overflow() {
     let upper_min = triu(&t, i64::MIN).unwrap();
     assert_eq!(
         match &upper_min {
-            Tensor::F64(inner) => inner.host_data(),
+            Tensor::F64(inner) => inner.host_data().unwrap(),
             _ => panic!("expected f64 tensor"),
         },
         &[1.0, 2.0, 3.0, 4.0]
@@ -418,7 +420,7 @@ fn test_tril_triu_extreme_offsets_do_not_overflow() {
     let lower_max = tril(&t, i64::MAX).unwrap();
     assert_eq!(
         match &lower_max {
-            Tensor::F64(inner) => inner.host_data(),
+            Tensor::F64(inner) => inner.host_data().unwrap(),
             _ => panic!("expected f64 tensor"),
         },
         &[1.0, 2.0, 3.0, 4.0]
@@ -427,7 +429,7 @@ fn test_tril_triu_extreme_offsets_do_not_overflow() {
     let upper_max = triu(&t, i64::MAX).unwrap();
     assert_eq!(
         match &upper_max {
-            Tensor::F64(inner) => inner.host_data(),
+            Tensor::F64(inner) => inner.host_data().unwrap(),
             _ => panic!("expected f64 tensor"),
         },
         &[0.0, 0.0, 0.0, 0.0]
@@ -455,7 +457,7 @@ fn test_triangular_masks_use_checked_index_arithmetic_contract() {
 
 #[test]
 fn test_neg_and_conj() {
-    let t = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, -7.0]));
+    let t = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, -7.0]).unwrap());
     let n = neg(&t).unwrap();
     assert_eq!(get_f64(&n, &[0]), -3.0);
     assert_eq!(get_f64(&n, &[1]), 7.0);
@@ -469,20 +471,19 @@ fn test_neg_and_conj() {
 fn test_cpu_backend_analytic_ops_real() {
     let mut backend = CpuBackend::new();
 
-    let exp_input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![0.0, 1.0]));
+    let exp_input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![0.0, 1.0]).unwrap());
     let exp_out = backend.exp(&exp_input).unwrap();
     assert_f64_close(get_f64(&exp_out, &[0]), 1.0);
     assert_f64_close(get_f64(&exp_out, &[1]), std::f64::consts::E);
 
-    let log_input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 4.0]));
+    let log_input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 4.0]).unwrap());
     let log_out = backend.log(&log_input).unwrap();
     assert_f64_close(get_f64(&log_out, &[0]), 0.0);
     assert_f64_close(get_f64(&log_out, &[1]), 4.0_f64.ln());
 
-    let trig_input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![0.0, std::f64::consts::FRAC_PI_2],
-    ));
+    let trig_input = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2], vec![0.0, std::f64::consts::FRAC_PI_2]).unwrap(),
+    );
     let sin_out = backend.sin(&trig_input).unwrap();
     let cos_out = backend.cos(&trig_input).unwrap();
     assert_f64_close(get_f64(&sin_out, &[0]), 0.0);
@@ -490,12 +491,12 @@ fn test_cpu_backend_analytic_ops_real() {
     assert_f64_close(get_f64(&cos_out, &[0]), 1.0);
     assert_f64_close(get_f64(&cos_out, &[1]), 0.0);
 
-    let tanh_input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![0.0, 1.0]));
+    let tanh_input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![0.0, 1.0]).unwrap());
     let tanh_out = backend.tanh(&tanh_input).unwrap();
     assert_f64_close(get_f64(&tanh_out, &[0]), 0.0);
     assert_f64_close(get_f64(&tanh_out, &[1]), 1.0_f64.tanh());
 
-    let sqrt_input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 4.0]));
+    let sqrt_input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 4.0]).unwrap());
     let sqrt_out = backend.sqrt(&sqrt_input).unwrap();
     let rsqrt_out = backend.rsqrt(&sqrt_input).unwrap();
     assert_f64_close(get_f64(&sqrt_out, &[0]), 1.0);
@@ -510,8 +511,8 @@ fn test_cpu_backend_analytic_ops_real() {
     assert_f64_close(get_f64(&log1p_out, &[0]), 2.0_f64.ln());
     assert_f64_close(get_f64(&log1p_out, &[1]), 5.0_f64.ln());
 
-    let pow_base = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![2.0, 9.0]));
-    let pow_exp = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 0.5]));
+    let pow_base = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![2.0, 9.0]).unwrap());
+    let pow_exp = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 0.5]).unwrap());
     let pow_out = backend.pow(&pow_base, &pow_exp).unwrap();
     assert_f64_close(get_f64(&pow_out, &[0]), 8.0);
     assert_f64_close(get_f64(&pow_out, &[1]), 3.0);
@@ -521,26 +522,35 @@ fn test_cpu_backend_analytic_ops_real() {
 fn test_cpu_backend_analytic_ops_complex() {
     let mut backend = CpuBackend::new();
 
-    let exp_input = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(0.0, 0.0), Complex64::new(1.0, 1.0)],
-    ));
+    let exp_input = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(0.0, 0.0), Complex64::new(1.0, 1.0)],
+        )
+        .unwrap(),
+    );
     let exp_out = backend.exp(&exp_input).unwrap();
     assert_c64_close(get_c64(&exp_out, &[0]), Complex64::new(1.0, 0.0));
     assert_c64_close(get_c64(&exp_out, &[1]), Complex64::new(1.0, 1.0).exp());
 
-    let log_input = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, -0.5)],
-    ));
+    let log_input = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, -0.5)],
+        )
+        .unwrap(),
+    );
     let log_out = backend.log(&log_input).unwrap();
     assert_c64_close(get_c64(&log_out, &[0]), Complex64::new(1.0, 0.0).ln());
     assert_c64_close(get_c64(&log_out, &[1]), Complex64::new(2.0, -0.5).ln());
 
-    let trig_input = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(0.0, 0.0), Complex64::new(0.5, -0.25)],
-    ));
+    let trig_input = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(0.0, 0.0), Complex64::new(0.5, -0.25)],
+        )
+        .unwrap(),
+    );
     let sin_out = backend.sin(&trig_input).unwrap();
     let cos_out = backend.cos(&trig_input).unwrap();
     let tanh_out = backend.tanh(&trig_input).unwrap();
@@ -551,10 +561,13 @@ fn test_cpu_backend_analytic_ops_complex() {
     assert_c64_close(get_c64(&tanh_out, &[0]), Complex64::new(0.0, 0.0).tanh());
     assert_c64_close(get_c64(&tanh_out, &[1]), Complex64::new(0.5, -0.25).tanh());
 
-    let sqrt_input = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, 0.0), Complex64::new(4.0, 3.0)],
-    ));
+    let sqrt_input = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, 0.0), Complex64::new(4.0, 3.0)],
+        )
+        .unwrap(),
+    );
     let sqrt_out = backend.sqrt(&sqrt_input).unwrap();
     let rsqrt_out = backend.rsqrt(&sqrt_input).unwrap();
     assert_c64_close(get_c64(&sqrt_out, &[0]), Complex64::new(1.0, 0.0).sqrt());
@@ -589,14 +602,20 @@ fn test_cpu_backend_analytic_ops_complex() {
         (Complex64::new(2.0, -0.5) + Complex64::new(1.0, 0.0)).ln(),
     );
 
-    let pow_base = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, 1.0), Complex64::new(2.0, -1.0)],
-    ));
-    let pow_exp = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(2.0, 0.0), Complex64::new(0.5, 0.25)],
-    ));
+    let pow_base = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, 1.0), Complex64::new(2.0, -1.0)],
+        )
+        .unwrap(),
+    );
+    let pow_exp = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(2.0, 0.0), Complex64::new(0.5, 0.25)],
+        )
+        .unwrap(),
+    );
     let pow_out = backend.pow(&pow_base, &pow_exp).unwrap();
     assert_c64_close(
         get_c64(&pow_out, &[0]),
@@ -610,20 +629,23 @@ fn test_cpu_backend_analytic_ops_complex() {
 
 #[test]
 fn test_extract_diagonal() {
-    let square = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3, 3],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-    ));
+    let square = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![3, 3],
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+        )
+        .unwrap(),
+    );
     let d = extract_diagonal(&square, 0, 1).unwrap();
     assert_eq!(d.shape(), &[3]);
     assert_eq!(get_f64(&d, &[0]), 1.0);
     assert_eq!(get_f64(&d, &[1]), 5.0);
     assert_eq!(get_f64(&d, &[2]), 9.0);
 
-    let cube = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3, 3],
-        (1..=18).map(|x| x as f64).collect(),
-    ));
+    let cube = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3, 3], (1..=18).map(|x| x as f64).collect())
+            .unwrap(),
+    );
     let diag = extract_diagonal(&cube, 1, 2).unwrap();
     assert_eq!(diag.shape(), &[2, 3]);
     assert_eq!(get_f64(&diag, &[0, 0]), 1.0);
@@ -633,10 +655,7 @@ fn test_extract_diagonal() {
 
 #[test]
 fn test_embed_diagonal() {
-    let v = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![1.0, 2.0, 3.0],
-    ));
+    let v = Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap());
     let m = embed_diagonal(&v, 0, 1).unwrap();
     assert_eq!(m.shape(), &[3, 3]);
     assert_eq!(get_f64(&m, &[0, 0]), 1.0);
@@ -648,8 +667,8 @@ fn test_embed_diagonal() {
 
 #[test]
 fn test_cpu_backend_dispatches_tensor_backend_ops() {
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0]));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap());
     let mut backend = CpuBackend::new();
     let out = TensorElementwise::add(&mut backend, &a, &b).unwrap();
     assert_eq!(get_f64(&out, &[0]), 4.0);
@@ -658,34 +677,18 @@ fn test_cpu_backend_dispatches_tensor_backend_ops() {
 
 #[test]
 fn test_tier2_elementwise_ops_real() {
-    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![8.0, -2.0, 9.0],
-    ));
-    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![2.0, 5.0, 3.0],
-    ));
-    let pred = Tensor::Bool(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![false, true, true],
-    ));
-    let on_true = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![10.0, 20.0, 30.0],
-    ));
-    let on_false = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![1.0, 2.0, 3.0],
-    ));
-    let lower = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![-1.0, -1.0, 0.0],
-    ));
-    let upper = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![1.0, 0.25, 4.0],
-    ));
+    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![8.0, -2.0, 9.0]).unwrap());
+    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![2.0, 5.0, 3.0]).unwrap());
+    let pred =
+        Tensor::Bool(TypedTensor::from_vec_col_major(vec![3], vec![false, true, true]).unwrap());
+    let on_true =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![10.0, 20.0, 30.0]).unwrap());
+    let on_false =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap());
+    let lower =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![-1.0, -1.0, 0.0]).unwrap());
+    let upper =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![1.0, 0.25, 4.0]).unwrap());
     let mut backend = CpuBackend::new();
 
     let div = backend.div(&lhs, &rhs).unwrap();
@@ -751,18 +754,27 @@ fn test_tier2_elementwise_ops_real() {
 
 #[test]
 fn test_tier2_elementwise_ops_complex() {
-    let input = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(3.0, 4.0), Complex64::new(0.0, 0.0)],
-    ));
-    let lhs = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(3.0, 4.0), Complex64::new(1.0, 0.0)],
-    ));
-    let rhs = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 2.0)],
-    ));
+    let input = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(3.0, 4.0), Complex64::new(0.0, 0.0)],
+        )
+        .unwrap(),
+    );
+    let lhs = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(3.0, 4.0), Complex64::new(1.0, 0.0)],
+        )
+        .unwrap(),
+    );
+    let rhs = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 2.0)],
+        )
+        .unwrap(),
+    );
     let mut backend = CpuBackend::new();
 
     let abs = backend.abs(&input).unwrap();

--- a/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[test]
 fn elementwise_add_accepts_transposed_host_view_input() {
-    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     let b = a.as_view().transpose_view([1, 0]).unwrap();
     let mut backend = CpuBackend::new();
 
@@ -19,11 +19,14 @@ fn elementwise_add_accepts_transposed_host_view_input() {
 
 #[test]
 fn elementwise_add_read_promotes_rank0_f64_view_with_c64_tensor() {
-    let scalar = TypedTensor::<f64>::from_vec_col_major(vec![], vec![2.0]);
-    let rhs = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, -1.0), Complex64::new(-3.0, 0.5)],
-    ));
+    let scalar = TypedTensor::<f64>::from_vec_col_major(vec![], vec![2.0]).unwrap();
+    let rhs = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, -1.0), Complex64::new(-3.0, 0.5)],
+        )
+        .unwrap(),
+    );
     let mut backend = CpuBackend::new();
 
     let out = backend
@@ -42,11 +45,14 @@ fn elementwise_add_read_promotes_rank0_f64_view_with_c64_tensor() {
 
 #[test]
 fn elementwise_add_read_promotes_c32_tensor_with_rank0_f32_view() {
-    let lhs = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(1.0, -1.0), Complex32::new(-3.0, 0.5)],
-    ));
-    let scalar = TypedTensor::<f32>::from_vec_col_major(vec![], vec![2.0]);
+    let lhs = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex32::new(1.0, -1.0), Complex32::new(-3.0, 0.5)],
+        )
+        .unwrap(),
+    );
+    let scalar = TypedTensor::<f32>::from_vec_col_major(vec![], vec![2.0]).unwrap();
     let mut backend = CpuBackend::new();
 
     let out = backend
@@ -65,7 +71,7 @@ fn elementwise_add_read_promotes_c32_tensor_with_rank0_f32_view() {
 
 #[test]
 fn reduce_sum_accepts_transposed_host_view_input() {
-    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     let b = a.as_view().transpose_view([1, 0]).unwrap();
     let mut backend = CpuBackend::new();
 
@@ -81,7 +87,8 @@ fn reduce_sum_accepts_transposed_host_view_input() {
 fn reduce_read_views_cover_dtype_and_validation_branches() {
     let mut backend = CpuBackend::new();
 
-    let f32s = TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let f32s =
+        TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     assert_eq!(
         backend
             .reduce_sum_read(TensorRead::from_view(TensorView::F32(f32s.as_view())), &[0])
@@ -99,7 +106,8 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
         &[2.0, 4.0]
     );
 
-    let f64s = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let f64s =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     assert_eq!(
         backend
             .reduce_min_read(TensorRead::from_view(TensorView::F64(f64s.as_view())), &[0])
@@ -109,7 +117,7 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
         &[1.0, 3.0]
     );
 
-    let i32s = TypedTensor::<i32>::from_vec_col_major(vec![2, 2], vec![1, 2, 3, 4]);
+    let i32s = TypedTensor::<i32>::from_vec_col_major(vec![2, 2], vec![1, 2, 3, 4]).unwrap();
     assert_eq!(
         backend
             .reduce_sum_read(TensorRead::from_view(TensorView::I32(i32s.as_view())), &[0])
@@ -119,7 +127,7 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
         &[3, 7]
     );
 
-    let i64s = TypedTensor::<i64>::from_vec_col_major(vec![2, 2], vec![1, 2, 3, 4]);
+    let i64s = TypedTensor::<i64>::from_vec_col_major(vec![2, 2], vec![1, 2, 3, 4]).unwrap();
     assert_eq!(
         backend
             .reduce_prod_read(TensorRead::from_view(TensorView::I64(i64s.as_view())), &[0])
@@ -132,7 +140,8 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
     let c32s = TypedTensor::<Complex32>::from_vec_col_major(
         vec![2],
         vec![Complex32::new(1.0, 1.0), Complex32::new(2.0, -1.0)],
-    );
+    )
+    .unwrap();
     assert_eq!(
         backend
             .reduce_sum_read(TensorRead::from_view(TensorView::C32(c32s.as_view())), &[0])
@@ -145,7 +154,8 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
     let c64s = TypedTensor::<Complex64>::from_vec_col_major(
         vec![2],
         vec![Complex64::new(1.0, 1.0), Complex64::new(2.0, -1.0)],
-    );
+    )
+    .unwrap();
     assert_eq!(
         backend
             .reduce_prod_read(TensorRead::from_view(TensorView::C64(c64s.as_view())), &[0])
@@ -155,7 +165,7 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
         &[Complex64::new(3.0, 1.0)]
     );
 
-    let bools = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]);
+    let bools = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]).unwrap();
     assert!(matches!(
         backend.reduce_sum_read(
             TensorRead::from_view(TensorView::Bool(bools.as_view())),
@@ -215,7 +225,7 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
 fn reduce_read_empty_axes_materializes_views_for_all_dtypes() {
     let mut backend = CpuBackend::new();
 
-    let f32s = TypedTensor::<f32>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
+    let f32s = TypedTensor::<f32>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
     assert_eq!(
         backend
             .reduce_max_read(TensorRead::from_view(TensorView::F32(f32s.as_view())), &[])
@@ -225,7 +235,7 @@ fn reduce_read_empty_axes_materializes_views_for_all_dtypes() {
         &[1.0, 2.0]
     );
 
-    let f64s = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
+    let f64s = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
     assert_eq!(
         backend
             .reduce_min_read(TensorRead::from_view(TensorView::F64(f64s.as_view())), &[])
@@ -235,7 +245,7 @@ fn reduce_read_empty_axes_materializes_views_for_all_dtypes() {
         &[1.0, 2.0]
     );
 
-    let i32s = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]);
+    let i32s = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]).unwrap();
     assert_eq!(
         backend
             .reduce_max_read(TensorRead::from_view(TensorView::I32(i32s.as_view())), &[])
@@ -245,7 +255,7 @@ fn reduce_read_empty_axes_materializes_views_for_all_dtypes() {
         &[1, 2]
     );
 
-    let i64s = TypedTensor::<i64>::from_vec_col_major(vec![2], vec![1, 2]);
+    let i64s = TypedTensor::<i64>::from_vec_col_major(vec![2], vec![1, 2]).unwrap();
     assert_eq!(
         backend
             .reduce_min_read(TensorRead::from_view(TensorView::I64(i64s.as_view())), &[])
@@ -255,7 +265,7 @@ fn reduce_read_empty_axes_materializes_views_for_all_dtypes() {
         &[1, 2]
     );
 
-    let bools = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]);
+    let bools = TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]).unwrap();
     assert_eq!(
         backend
             .reduce_max_read(
@@ -269,7 +279,8 @@ fn reduce_read_empty_axes_materializes_views_for_all_dtypes() {
     );
 
     let c32s =
-        TypedTensor::<Complex32>::from_vec_col_major(vec![1], vec![Complex32::new(1.0, -1.0)]);
+        TypedTensor::<Complex32>::from_vec_col_major(vec![1], vec![Complex32::new(1.0, -1.0)])
+            .unwrap();
     assert_eq!(
         backend
             .reduce_min_read(TensorRead::from_view(TensorView::C32(c32s.as_view())), &[])
@@ -280,7 +291,8 @@ fn reduce_read_empty_axes_materializes_views_for_all_dtypes() {
     );
 
     let c64s =
-        TypedTensor::<Complex64>::from_vec_col_major(vec![1], vec![Complex64::new(2.0, 3.0)]);
+        TypedTensor::<Complex64>::from_vec_col_major(vec![1], vec![Complex64::new(2.0, 3.0)])
+            .unwrap();
     assert_eq!(
         backend
             .reduce_max_read(TensorRead::from_view(TensorView::C64(c64s.as_view())), &[])
@@ -295,10 +307,8 @@ fn reduce_read_empty_axes_materializes_views_for_all_dtypes() {
 fn reduce_read_tensors_cover_host_dtype_dispatch() {
     let mut backend = CpuBackend::new();
 
-    let f32s = Tensor::F32(TypedTensor::<f32>::from_vec_col_major(
-        vec![2],
-        vec![2.0, 3.0],
-    ));
+    let f32s =
+        Tensor::F32(TypedTensor::<f32>::from_vec_col_major(vec![2], vec![2.0, 3.0]).unwrap());
     assert_eq!(
         backend
             .reduce_sum_read(TensorRead::from_tensor(&f32s), &[0])
@@ -316,10 +326,8 @@ fn reduce_read_tensors_cover_host_dtype_dispatch() {
         &[3.0]
     );
 
-    let f64s = Tensor::F64(TypedTensor::<f64>::from_vec_col_major(
-        vec![2],
-        vec![2.0, 3.0],
-    ));
+    let f64s =
+        Tensor::F64(TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 3.0]).unwrap());
     assert_eq!(
         backend
             .reduce_prod_read(TensorRead::from_tensor(&f64s), &[0])
@@ -337,7 +345,7 @@ fn reduce_read_tensors_cover_host_dtype_dispatch() {
         &[2.0]
     );
 
-    let i32s = Tensor::I32(TypedTensor::<i32>::from_vec_col_major(vec![2], vec![2, 3]));
+    let i32s = Tensor::I32(TypedTensor::<i32>::from_vec_col_major(vec![2], vec![2, 3]).unwrap());
     assert_eq!(
         backend
             .reduce_prod_read(TensorRead::from_tensor(&i32s), &[0])
@@ -354,7 +362,7 @@ fn reduce_read_tensors_cover_host_dtype_dispatch() {
         })
     ));
 
-    let i64s = Tensor::I64(TypedTensor::<i64>::from_vec_col_major(vec![2], vec![2, 3]));
+    let i64s = Tensor::I64(TypedTensor::<i64>::from_vec_col_major(vec![2], vec![2, 3]).unwrap());
     assert_eq!(
         backend
             .reduce_sum_read(TensorRead::from_tensor(&i64s), &[0])
@@ -371,10 +379,8 @@ fn reduce_read_tensors_cover_host_dtype_dispatch() {
         })
     ));
 
-    let bools = Tensor::Bool(TypedTensor::<bool>::from_vec_col_major(
-        vec![2],
-        vec![true, false],
-    ));
+    let bools =
+        Tensor::Bool(TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]).unwrap());
     assert!(matches!(
         backend.reduce_sum_read(TensorRead::from_tensor(&bools), &[0]),
         Err(crate::Error::BackendFailure {
@@ -390,10 +396,13 @@ fn reduce_read_tensors_cover_host_dtype_dispatch() {
         })
     ));
 
-    let c32s = Tensor::C32(TypedTensor::<Complex32>::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(1.0, 1.0), Complex32::new(2.0, -1.0)],
-    ));
+    let c32s = Tensor::C32(
+        TypedTensor::<Complex32>::from_vec_col_major(
+            vec![2],
+            vec![Complex32::new(1.0, 1.0), Complex32::new(2.0, -1.0)],
+        )
+        .unwrap(),
+    );
     assert_eq!(
         backend
             .reduce_sum_read(TensorRead::from_tensor(&c32s), &[0])
@@ -403,10 +412,13 @@ fn reduce_read_tensors_cover_host_dtype_dispatch() {
         &[Complex32::new(3.0, 0.0)]
     );
 
-    let c64s = Tensor::C64(TypedTensor::<Complex64>::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, 1.0), Complex64::new(2.0, -1.0)],
-    ));
+    let c64s = Tensor::C64(
+        TypedTensor::<Complex64>::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, 1.0), Complex64::new(2.0, -1.0)],
+        )
+        .unwrap(),
+    );
     assert_eq!(
         backend
             .reduce_prod_read(TensorRead::from_tensor(&c64s), &[0])
@@ -419,14 +431,15 @@ fn reduce_read_tensors_cover_host_dtype_dispatch() {
 
 #[test]
 fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
-    let lhs_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![8.0f32, -2.0]));
-    let rhs_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![2.0f32, 5.0]));
-    let pred_bool = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![false, true]));
-    let lower_f32 = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![-1.0f32, -1.0],
-    ));
-    let upper_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 4.0]));
+    let lhs_f32 =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![8.0f32, -2.0]).unwrap());
+    let rhs_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![2.0f32, 5.0]).unwrap());
+    let pred_bool =
+        Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![false, true]).unwrap());
+    let lower_f32 =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![-1.0f32, -1.0]).unwrap());
+    let upper_f32 =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 4.0]).unwrap());
 
     let div_out = div(&lhs_f32, &rhs_f32).unwrap();
     assert_eq!(get_f32(&div_out, &[0]), 4.0);
@@ -460,26 +473,41 @@ fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
     assert_eq!(get_f32(&clamp_out, &[0]), 1.0);
     assert_eq!(get_f32(&clamp_out, &[1]), -1.0);
 
-    let input_c32 = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(3.0, 4.0), Complex32::new(0.0, 0.0)],
-    ));
-    let lhs_c32 = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(3.0, 4.0), Complex32::new(1.0, 0.0)],
-    ));
-    let rhs_c32 = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(1.0, 0.0), Complex32::new(0.0, 2.0)],
-    ));
-    let lower_c32 = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(0.5, 0.0), Complex32::new(0.5, 0.0)],
-    ));
-    let upper_c32 = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(4.0, 0.0), Complex32::new(2.0, 2.0)],
-    ));
+    let input_c32 = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex32::new(3.0, 4.0), Complex32::new(0.0, 0.0)],
+        )
+        .unwrap(),
+    );
+    let lhs_c32 = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex32::new(3.0, 4.0), Complex32::new(1.0, 0.0)],
+        )
+        .unwrap(),
+    );
+    let rhs_c32 = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex32::new(1.0, 0.0), Complex32::new(0.0, 2.0)],
+        )
+        .unwrap(),
+    );
+    let lower_c32 = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex32::new(0.5, 0.0), Complex32::new(0.5, 0.0)],
+        )
+        .unwrap(),
+    );
+    let upper_c32 = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex32::new(4.0, 0.0), Complex32::new(2.0, 2.0)],
+        )
+        .unwrap(),
+    );
 
     let abs_c32 = abs(&input_c32).unwrap();
     assert_eq!(abs_c32.dtype(), DType::F32);
@@ -505,7 +533,7 @@ fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
     let clamp_c32 = clamp(&lhs_c32, &lower_c32, &upper_c32).unwrap();
     assert_eq!(get_c32(&clamp_c32, &[0]), Complex32::new(4.0, 0.0));
 
-    let scalar_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![], vec![2.0f32]));
+    let scalar_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![], vec![2.0f32]).unwrap());
     let add_c32 = add(&scalar_f32, &rhs_c32).unwrap();
     assert_eq!(get_c32(&add_c32, &[0]), Complex32::new(3.0, 0.0));
 
@@ -523,14 +551,14 @@ fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
     assert!(matches!(
         div(
             &lhs_f32,
-            &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]))
+            &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap())
         ),
         Err(crate::Error::DTypeMismatch { op: "div", .. })
     ));
     assert!(matches!(
         clamp(
             &lhs_f32,
-            &Tensor::F32(TypedTensor::from_vec_col_major(vec![1], vec![0.0f32])),
+            &Tensor::F32(TypedTensor::from_vec_col_major(vec![1], vec![0.0f32]).unwrap()),
             &upper_f32
         ),
         Err(crate::Error::ShapeMismatch { op: "clamp", .. })
@@ -539,19 +567,25 @@ fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
 
 #[test]
 fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
-    let lhs_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.5f64, -3.0]));
-    let rhs_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![2.0f64, 4.0]));
-    let scalar_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![2.0f64]));
-    let pred_bool = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![false, true]));
-    let lower_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![0.0f64, -2.0]));
-    let upper_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![2.0f64, 3.0]));
-    let short_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![1.0f64]));
-    let lhs_i32 = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![1i32, 3]));
-    let rhs_i32 = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![2i32, 3]));
-    let lhs_i64 = Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![5i64, -1]));
-    let rhs_i64 = Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![2i64, -1]));
-    let lhs_bool = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]));
-    let rhs_bool = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![false, false]));
+    let lhs_f64 =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.5f64, -3.0]).unwrap());
+    let rhs_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![2.0f64, 4.0]).unwrap());
+    let scalar_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![2.0f64]).unwrap());
+    let pred_bool =
+        Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![false, true]).unwrap());
+    let lower_f64 =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![0.0f64, -2.0]).unwrap());
+    let upper_f64 =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![2.0f64, 3.0]).unwrap());
+    let short_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![1.0f64]).unwrap());
+    let lhs_i32 = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![1i32, 3]).unwrap());
+    let rhs_i32 = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![2i32, 3]).unwrap());
+    let lhs_i64 = Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![5i64, -1]).unwrap());
+    let rhs_i64 = Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![2i64, -1]).unwrap());
+    let lhs_bool =
+        Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]).unwrap());
+    let rhs_bool =
+        Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![false, false]).unwrap());
 
     let add_out = add(&lhs_f64, &rhs_f64).unwrap();
     assert_eq!(get_f64(&add_out, &[0]), 3.5);
@@ -563,7 +597,7 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
 
     let div_out = div(
         &rhs_f64,
-        &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![2.0, 2.0])),
+        &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![2.0, 2.0]).unwrap()),
     )
     .unwrap();
     assert_eq!(get_f64(&div_out, &[0]), 1.0);
@@ -620,22 +654,34 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
     assert_eq!(get_f64(&clamp_out, &[0]), 1.5);
     assert_eq!(get_f64(&clamp_out, &[1]), -2.0);
 
-    let lhs_c64 = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(3.0, 4.0), Complex64::new(1.0, 0.0)],
-    ));
-    let rhs_c64 = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 2.0)],
-    ));
-    let lower_c64 = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(0.5, 0.0), Complex64::new(0.5, 0.0)],
-    ));
-    let upper_c64 = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(4.0, 0.0), Complex64::new(2.0, 2.0)],
-    ));
+    let lhs_c64 = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(3.0, 4.0), Complex64::new(1.0, 0.0)],
+        )
+        .unwrap(),
+    );
+    let rhs_c64 = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, 0.0), Complex64::new(0.0, 2.0)],
+        )
+        .unwrap(),
+    );
+    let lower_c64 = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(0.5, 0.0), Complex64::new(0.5, 0.0)],
+        )
+        .unwrap(),
+    );
+    let upper_c64 = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(4.0, 0.0), Complex64::new(2.0, 2.0)],
+        )
+        .unwrap(),
+    );
 
     let add_left_scalar = add(&scalar_f64, &rhs_c64).unwrap();
     assert_c64_close(get_c64(&add_left_scalar, &[0]), Complex64::new(3.0, 0.0));
@@ -657,10 +703,13 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
 
     let div_c64 = div(
         &lhs_c64,
-        &Tensor::C64(TypedTensor::from_vec_col_major(
-            vec![2],
-            vec![Complex64::new(1.0, 1.0), Complex64::new(1.0, 0.0)],
-        )),
+        &Tensor::C64(
+            TypedTensor::from_vec_col_major(
+                vec![2],
+                vec![Complex64::new(1.0, 1.0), Complex64::new(1.0, 0.0)],
+            )
+            .unwrap(),
+        ),
     )
     .unwrap();
     assert_c64_close(get_c64(&div_c64, &[0]), Complex64::new(3.5, 0.5));
@@ -688,7 +737,7 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
     assert_c64_close(get_c64(&clamp_c64, &[0]), Complex64::new(4.0, 0.0));
     assert_c64_close(get_c64(&clamp_c64, &[1]), Complex64::new(1.0, 0.0));
 
-    let lhs_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]));
+    let lhs_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap());
 
     assert!(matches!(
         add(&lhs_f32, &rhs_f64),
@@ -762,15 +811,18 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
 
 #[test]
 fn test_reduction_helpers_cover_complex_and_error_paths() {
-    let complex = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![
-            Complex32::new(1.0, 1.0),
-            Complex32::new(2.0, 0.0),
-            Complex32::new(3.0, -1.0),
-            Complex32::new(4.0, 2.0),
-        ],
-    ));
+    let complex = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex32::new(1.0, 1.0),
+                Complex32::new(2.0, 0.0),
+                Complex32::new(3.0, -1.0),
+                Complex32::new(4.0, 2.0),
+            ],
+        )
+        .unwrap(),
+    );
     let sum = reduce_sum(&complex, &[0]).unwrap();
     assert_eq!(get_c32(&sum, &[0]), Complex32::new(3.0, 1.0));
     assert_eq!(get_c32(&sum, &[1]), Complex32::new(7.0, 1.0));
@@ -780,7 +832,7 @@ fn test_reduction_helpers_cover_complex_and_error_paths() {
 
     assert!(matches!(
         reduce_sum(
-            &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0])),
+            &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap()),
             &[2]
         ),
         Err(crate::Error::AxisOutOfBounds {
@@ -790,7 +842,7 @@ fn test_reduction_helpers_cover_complex_and_error_paths() {
     ));
     assert!(matches!(
         reduce_prod(
-            &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0])),
+            &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap()),
             &[0, 0]
         ),
         Err(crate::Error::DuplicateAxis {
@@ -813,7 +865,7 @@ fn test_reduction_helpers_cover_complex_and_error_paths() {
         })
     ));
 
-    let real = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]));
+    let real = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap());
     assert!(matches!(
         reduce_max(&real, &[2]),
         Err(crate::Error::AxisOutOfBounds {
@@ -832,15 +884,14 @@ fn test_reduction_helpers_cover_complex_and_error_paths() {
 
 #[test]
 fn test_structural_helpers_cover_f32_success_and_error_paths() {
-    let matrix = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0f32, 2.0, 3.0, 4.0],
-    ));
+    let matrix = Tensor::F32(
+        TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0f32, 2.0, 3.0, 4.0]).unwrap(),
+    );
     let transposed = transpose(&matrix, &[1, 0]).unwrap();
     assert_eq!(transposed.shape(), &[2, 2]);
     assert_eq!(get_f32(&transposed, &[1, 0]), 3.0);
 
-    let scalar = Tensor::F32(TypedTensor::from_vec_col_major(vec![], vec![5.0f32]));
+    let scalar = Tensor::F32(TypedTensor::from_vec_col_major(vec![], vec![5.0f32]).unwrap());
     let broadcast = broadcast_in_dim(&scalar, &[2], &[]).unwrap();
     assert_eq!(get_f32(&broadcast, &[1]), 5.0);
 
@@ -849,7 +900,7 @@ fn test_structural_helpers_cover_f32_success_and_error_paths() {
     assert_eq!(get_f32(&diag, &[1]), 4.0);
 
     let embedded = embed_diagonal(
-        &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![7.0f32, 8.0])),
+        &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![7.0f32, 8.0]).unwrap()),
         0,
         1,
     )
@@ -878,7 +929,7 @@ fn test_structural_helpers_cover_f32_success_and_error_paths() {
     ));
     assert!(matches!(
         broadcast_in_dim(
-            &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0])),
+            &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap()),
             &[3, 2],
             &[0]
         ),
@@ -896,7 +947,7 @@ fn test_structural_helpers_cover_f32_success_and_error_paths() {
     ));
     assert!(matches!(
         embed_diagonal(
-            &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0])),
+            &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap()),
             0,
             2
         ),
@@ -905,7 +956,7 @@ fn test_structural_helpers_cover_f32_success_and_error_paths() {
             ..
         })
     ));
-    let vector = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]));
+    let vector = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap());
     assert!(matches!(
         tril(&vector, 0),
         Err(crate::Error::RankMismatch { op: "tril", .. })

--- a/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
@@ -2,11 +2,10 @@ use super::*;
 
 #[test]
 fn test_gather_1d_indices() {
-    let operand = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![5],
-        vec![10.0, 20.0, 30.0, 40.0, 50.0],
-    ));
-    let start_indices = Tensor::from_vec_col_major(vec![3, 1], vec![0_i64, 2, 4]);
+    let operand = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![5], vec![10.0, 20.0, 30.0, 40.0, 50.0]).unwrap(),
+    );
+    let start_indices = Tensor::from_vec_col_major(vec![3, 1], vec![0_i64, 2, 4]).unwrap();
 
     let out = gather(&operand, &start_indices, &simple_gather_config()).unwrap();
 
@@ -18,16 +17,18 @@ fn test_gather_1d_indices() {
 
 #[test]
 fn test_gather_accepts_i64_indices() {
-    let operand = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![5],
-        vec![10.0, 20.0, 30.0, 40.0, 50.0],
-    ));
-    let start_indices = Tensor::from_vec_col_major(vec![3, 1], vec![0_i64, 2, 4]);
+    let operand = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![5], vec![10.0, 20.0, 30.0, 40.0, 50.0]).unwrap(),
+    );
+    let start_indices = Tensor::from_vec_col_major(vec![3, 1], vec![0_i64, 2, 4]).unwrap();
 
     let out = gather(&operand, &start_indices, &simple_gather_config()).unwrap();
 
     assert_eq!(start_indices.dtype(), DType::I64);
-    assert_eq!(start_indices.as_slice::<i64>(), Some([0, 2, 4].as_slice()));
+    assert_eq!(
+        start_indices.as_slice::<i64>().unwrap(),
+        [0, 2, 4].as_slice()
+    );
     assert_eq!(out.shape(), &[3]);
     assert_eq!(get_f64(&out, &[0]), 10.0);
     assert_eq!(get_f64(&out, &[1]), 30.0);
@@ -36,11 +37,10 @@ fn test_gather_accepts_i64_indices() {
 
 #[test]
 fn test_gather_with_implicit_index_vector_dim() {
-    let operand = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![5],
-        vec![10.0, 20.0, 30.0, 40.0, 50.0],
-    ));
-    let start_indices = Tensor::from_vec_col_major(vec![3], vec![4_i64, 1, 0]);
+    let operand = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![5], vec![10.0, 20.0, 30.0, 40.0, 50.0]).unwrap(),
+    );
+    let start_indices = Tensor::from_vec_col_major(vec![3], vec![4_i64, 1, 0]).unwrap();
     let config = GatherConfig {
         offset_dims: vec![],
         collapsed_slice_dims: vec![0],
@@ -58,12 +58,11 @@ fn test_gather_with_implicit_index_vector_dim() {
 
 #[test]
 fn test_scatter_accepts_i64_indices() {
-    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3]));
-    let scatter_indices = Tensor::from_vec_col_major(vec![3, 2], vec![0_i64, 1, 2, 0, 1, 2]);
-    let updates = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![5.0, 6.0, 7.0],
-    ));
+    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3]).unwrap());
+    let scatter_indices =
+        Tensor::from_vec_col_major(vec![3, 2], vec![0_i64, 1, 2, 0, 1, 2]).unwrap();
+    let updates =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![5.0, 6.0, 7.0]).unwrap());
 
     let out = scatter(
         &operand,
@@ -82,12 +81,11 @@ fn test_scatter_accepts_i64_indices() {
 
 #[test]
 fn test_scatter_to_diagonal() {
-    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3]));
-    let scatter_indices = Tensor::from_vec_col_major(vec![3, 2], vec![0_i64, 1, 2, 0, 1, 2]);
-    let updates = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![5.0, 6.0, 7.0],
-    ));
+    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3]).unwrap());
+    let scatter_indices =
+        Tensor::from_vec_col_major(vec![3, 2], vec![0_i64, 1, 2, 0, 1, 2]).unwrap();
+    let updates =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![5.0, 6.0, 7.0]).unwrap());
 
     let out = scatter(
         &operand,
@@ -107,12 +105,10 @@ fn test_scatter_to_diagonal() {
 
 #[test]
 fn test_scatter_skips_negative_and_out_of_bounds_windows() {
-    let operand = Tensor::F64(TypedTensor::zeros(vec![4]));
-    let scatter_indices = Tensor::from_vec_col_major(vec![3, 1], vec![-1_i64, 2, 4]);
-    let updates = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![5.0, 6.0, 7.0],
-    ));
+    let operand = Tensor::F64(TypedTensor::zeros(vec![4]).unwrap());
+    let scatter_indices = Tensor::from_vec_col_major(vec![3, 1], vec![-1_i64, 2, 4]).unwrap();
+    let updates =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![5.0, 6.0, 7.0]).unwrap());
     let config = ScatterConfig {
         update_window_dims: vec![],
         inserted_window_dims: vec![0],
@@ -130,10 +126,9 @@ fn test_scatter_skips_negative_and_out_of_bounds_windows() {
 
 #[test]
 fn test_pad_adds_zero_edges() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
     let config = PadConfig {
         edge_padding_low: vec![1, 1],
         edge_padding_high: vec![1, 1],
@@ -153,7 +148,7 @@ fn test_pad_adds_zero_edges() {
 
 #[test]
 fn test_pad_with_interior_spacing() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
     let config = PadConfig {
         edge_padding_low: vec![1],
         edge_padding_high: vec![1],
@@ -171,13 +166,17 @@ fn test_pad_with_interior_spacing() {
 
 #[test]
 fn test_dynamic_slice_clamps_starts() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4, 4],
-        vec![
-            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
-        ],
-    ));
-    let starts = Tensor::from_vec_col_major(vec![2], vec![2_i64, 3]);
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![4, 4],
+            vec![
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+                16.0,
+            ],
+        )
+        .unwrap(),
+    );
+    let starts = Tensor::from_vec_col_major(vec![2], vec![2_i64, 3]).unwrap();
 
     let out = dynamic_slice(&input, &starts, &[2, 2]).unwrap();
 
@@ -190,13 +189,17 @@ fn test_dynamic_slice_clamps_starts() {
 
 #[test]
 fn test_dynamic_slice_accepts_i64_starts() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4, 4],
-        vec![
-            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
-        ],
-    ));
-    let starts = Tensor::from_vec_col_major(vec![2], vec![2_i64, 3]);
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![4, 4],
+            vec![
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+                16.0,
+            ],
+        )
+        .unwrap(),
+    );
+    let starts = Tensor::from_vec_col_major(vec![2], vec![2_i64, 3]).unwrap();
 
     let out = dynamic_slice(&input, &starts, &[2, 2]).unwrap();
 
@@ -210,15 +213,12 @@ fn test_dynamic_slice_accepts_i64_starts() {
 
 #[test]
 fn test_dynamic_update_slice_clamps_starts() {
-    let operand = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![5],
-        vec![10.0, 11.0, 12.0, 13.0, 14.0],
-    ));
-    let update = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![1.0, 2.0, 3.0],
-    ));
-    let starts = Tensor::from_vec_col_major(vec![1], vec![4_i64]);
+    let operand = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![5], vec![10.0, 11.0, 12.0, 13.0, 14.0]).unwrap(),
+    );
+    let update =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap());
+    let starts = Tensor::from_vec_col_major(vec![1], vec![4_i64]).unwrap();
 
     let out = dynamic_update_slice(&operand, &update, &starts).unwrap();
 
@@ -228,12 +228,15 @@ fn test_dynamic_update_slice_clamps_starts() {
 
 #[test]
 fn test_slice_concatenate_and_reverse_edge_cases() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4, 3],
-        vec![
-            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
-        ],
-    ));
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![4, 3],
+            vec![
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+            ],
+        )
+        .unwrap(),
+    );
     let config = SliceConfig {
         starts: vec![0, 0],
         limits: vec![4, 3],
@@ -247,9 +250,9 @@ fn test_slice_concatenate_and_reverse_edge_cases() {
     assert_eq!(get_f64(&sliced, &[0, 1]), 9.0);
     assert_eq!(get_f64(&sliced, &[1, 1]), 11.0);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1.0, 2.0]));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![3.0, 4.0]));
-    let c = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![5.0, 6.0]));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1.0, 2.0]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![3.0, 4.0]).unwrap());
+    let c = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![5.0, 6.0]).unwrap());
     let concatenated = backend.concatenate(&[&a, &b, &c], 1).unwrap();
     assert_eq!(concatenated.shape(), &[2, 3]);
     assert_eq!(get_f64(&concatenated, &[0, 0]), 1.0);
@@ -264,10 +267,8 @@ fn test_slice_concatenate_and_reverse_edge_cases() {
 
 #[test]
 fn test_structural_convert_helper_returns_result() {
-    let input = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![1.25_f32, -2.5_f32],
-    ));
+    let input =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.25_f32, -2.5_f32]).unwrap());
 
     let output = crate::structural::convert(&input, DType::F64).unwrap();
 
@@ -280,26 +281,26 @@ fn test_structural_convert_helper_returns_result() {
 #[test]
 fn test_backend_convert_supports_real_complex_and_precision_changes() {
     let mut backend = CpuBackend::new();
-    let f32_input = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![1.25_f32, -2.5_f32],
-    ));
-    let f64_input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![1.25_f64, -2.5_f64],
-    ));
-    let i64_input = Tensor::I64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![1_i64, -2_i64],
-    ));
-    let c32_input = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex32::new(1.25, -0.5), Complex32::new(-2.5, 4.0)],
-    ));
-    let c64_input = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.25, -0.5), Complex64::new(-2.5, 4.0)],
-    ));
+    let f32_input =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.25_f32, -2.5_f32]).unwrap());
+    let f64_input =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.25_f64, -2.5_f64]).unwrap());
+    let i64_input =
+        Tensor::I64(TypedTensor::from_vec_col_major(vec![2], vec![1_i64, -2_i64]).unwrap());
+    let c32_input = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex32::new(1.25, -0.5), Complex32::new(-2.5, 4.0)],
+        )
+        .unwrap(),
+    );
+    let c64_input = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.25, -0.5), Complex64::new(-2.5, 4.0)],
+        )
+        .unwrap(),
+    );
 
     let cases = [
         (&f32_input, DType::F32),
@@ -335,59 +336,79 @@ fn test_backend_convert_supports_real_complex_and_precision_changes() {
         assert_eq!(output.dtype(), to);
 
         match (input.dtype(), &output) {
-            (DType::F32, Tensor::F32(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
-            (DType::F32, Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
-            (DType::F32, Tensor::I64(inner)) => assert_eq!(inner.host_data(), &[1, -2]),
+            (DType::F32, Tensor::F32(inner)) => {
+                assert_eq!(inner.host_data().unwrap(), &[1.25, -2.5])
+            }
+            (DType::F32, Tensor::F64(inner)) => {
+                assert_eq!(inner.host_data().unwrap(), &[1.25, -2.5])
+            }
+            (DType::F32, Tensor::I64(inner)) => assert_eq!(inner.host_data().unwrap(), &[1, -2]),
             (DType::F32, Tensor::C32(inner)) => assert_eq!(
-                inner.host_data(),
+                inner.host_data().unwrap(),
                 &[Complex32::new(1.25, 0.0), Complex32::new(-2.5, 0.0)]
             ),
             (DType::F32, Tensor::C64(inner)) => assert_eq!(
-                inner.host_data(),
+                inner.host_data().unwrap(),
                 &[Complex64::new(1.25, 0.0), Complex64::new(-2.5, 0.0)]
             ),
-            (DType::F64, Tensor::F32(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
-            (DType::F64, Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
-            (DType::F64, Tensor::I64(inner)) => assert_eq!(inner.host_data(), &[1, -2]),
+            (DType::F64, Tensor::F32(inner)) => {
+                assert_eq!(inner.host_data().unwrap(), &[1.25, -2.5])
+            }
+            (DType::F64, Tensor::F64(inner)) => {
+                assert_eq!(inner.host_data().unwrap(), &[1.25, -2.5])
+            }
+            (DType::F64, Tensor::I64(inner)) => assert_eq!(inner.host_data().unwrap(), &[1, -2]),
             (DType::F64, Tensor::C32(inner)) => assert_eq!(
-                inner.host_data(),
+                inner.host_data().unwrap(),
                 &[Complex32::new(1.25, 0.0), Complex32::new(-2.5, 0.0)]
             ),
             (DType::F64, Tensor::C64(inner)) => assert_eq!(
-                inner.host_data(),
+                inner.host_data().unwrap(),
                 &[Complex64::new(1.25, 0.0), Complex64::new(-2.5, 0.0)]
             ),
-            (DType::I64, Tensor::F32(inner)) => assert_eq!(inner.host_data(), &[1.0, -2.0]),
-            (DType::I64, Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[1.0, -2.0]),
-            (DType::I64, Tensor::I64(inner)) => assert_eq!(inner.host_data(), &[1, -2]),
+            (DType::I64, Tensor::F32(inner)) => {
+                assert_eq!(inner.host_data().unwrap(), &[1.0, -2.0])
+            }
+            (DType::I64, Tensor::F64(inner)) => {
+                assert_eq!(inner.host_data().unwrap(), &[1.0, -2.0])
+            }
+            (DType::I64, Tensor::I64(inner)) => assert_eq!(inner.host_data().unwrap(), &[1, -2]),
             (DType::I64, Tensor::C32(inner)) => assert_eq!(
-                inner.host_data(),
+                inner.host_data().unwrap(),
                 &[Complex32::new(1.0, 0.0), Complex32::new(-2.0, 0.0)]
             ),
             (DType::I64, Tensor::C64(inner)) => assert_eq!(
-                inner.host_data(),
+                inner.host_data().unwrap(),
                 &[Complex64::new(1.0, 0.0), Complex64::new(-2.0, 0.0)]
             ),
-            (DType::C32, Tensor::F32(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
-            (DType::C32, Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
-            (DType::C32, Tensor::I64(inner)) => assert_eq!(inner.host_data(), &[1, -2]),
+            (DType::C32, Tensor::F32(inner)) => {
+                assert_eq!(inner.host_data().unwrap(), &[1.25, -2.5])
+            }
+            (DType::C32, Tensor::F64(inner)) => {
+                assert_eq!(inner.host_data().unwrap(), &[1.25, -2.5])
+            }
+            (DType::C32, Tensor::I64(inner)) => assert_eq!(inner.host_data().unwrap(), &[1, -2]),
             (DType::C32, Tensor::C32(inner)) => assert_eq!(
-                inner.host_data(),
+                inner.host_data().unwrap(),
                 &[Complex32::new(1.25, -0.5), Complex32::new(-2.5, 4.0)]
             ),
             (DType::C32, Tensor::C64(inner)) => assert_eq!(
-                inner.host_data(),
+                inner.host_data().unwrap(),
                 &[Complex64::new(1.25, -0.5), Complex64::new(-2.5, 4.0)]
             ),
-            (DType::C64, Tensor::F32(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
-            (DType::C64, Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[1.25, -2.5]),
-            (DType::C64, Tensor::I64(inner)) => assert_eq!(inner.host_data(), &[1, -2]),
+            (DType::C64, Tensor::F32(inner)) => {
+                assert_eq!(inner.host_data().unwrap(), &[1.25, -2.5])
+            }
+            (DType::C64, Tensor::F64(inner)) => {
+                assert_eq!(inner.host_data().unwrap(), &[1.25, -2.5])
+            }
+            (DType::C64, Tensor::I64(inner)) => assert_eq!(inner.host_data().unwrap(), &[1, -2]),
             (DType::C64, Tensor::C32(inner)) => assert_eq!(
-                inner.host_data(),
+                inner.host_data().unwrap(),
                 &[Complex32::new(1.25, -0.5), Complex32::new(-2.5, 4.0)]
             ),
             (DType::C64, Tensor::C64(inner)) => assert_eq!(
-                inner.host_data(),
+                inner.host_data().unwrap(),
                 &[Complex64::new(1.25, -0.5), Complex64::new(-2.5, 4.0)]
             ),
             _ => unreachable!("unexpected conversion case"),
@@ -399,16 +420,17 @@ fn test_backend_convert_supports_real_complex_and_precision_changes() {
 fn test_cpu_supports_i32_and_bool_structural_paths() {
     let mut backend = CpuBackend::new();
 
-    let i32_tensor = Tensor::from_vec_col_major(vec![2], vec![-1_i32, 0]);
+    let i32_tensor = Tensor::from_vec_col_major(vec![2], vec![-1_i32, 0]).unwrap();
     let i32_as_bool = backend.convert(&i32_tensor, DType::Bool).unwrap();
     assert_eq!(i32_as_bool.as_slice::<bool>().unwrap(), &[true, false]);
 
-    let bool_tensor = Tensor::from_vec_col_major(vec![2], vec![true, false]);
+    let bool_tensor = Tensor::from_vec_col_major(vec![2], vec![true, false]).unwrap();
     let bool_as_i64 = backend.convert(&bool_tensor, DType::I64).unwrap();
     assert_eq!(bool_as_i64.as_slice::<i64>().unwrap(), &[1, 0]);
 
     let bool_matrix =
-        Tensor::from_vec_col_major(vec![2, 3], vec![true, false, false, true, true, false]);
+        Tensor::from_vec_col_major(vec![2, 3], vec![true, false, false, true, true, false])
+            .unwrap();
     let transposed = transpose(&bool_matrix, &[1, 0]).unwrap();
     assert_eq!(transposed.shape(), &[3, 2]);
     assert_eq!(
@@ -430,9 +452,9 @@ fn test_cpu_supports_i32_and_bool_structural_paths() {
         &[false, true, false, false]
     );
 
-    let starts = Tensor::from_vec_col_major(vec![1], vec![1_i32]);
+    let starts = Tensor::from_vec_col_major(vec![1], vec![1_i32]).unwrap();
     let sliced = dynamic_slice(
-        &Tensor::from_vec_col_major(vec![3], vec![true, false, true]),
+        &Tensor::from_vec_col_major(vec![3], vec![true, false, true]).unwrap(),
         &starts,
         &[2],
     )
@@ -440,7 +462,7 @@ fn test_cpu_supports_i32_and_bool_structural_paths() {
     assert_eq!(sliced.as_slice::<bool>().unwrap(), &[false, true]);
 
     let upper = triu(
-        &Tensor::from_vec_col_major(vec![2, 2], vec![true, true, false, true]),
+        &Tensor::from_vec_col_major(vec![2, 2], vec![true, true, false, true]).unwrap(),
         0,
     )
     .unwrap();
@@ -450,7 +472,7 @@ fn test_cpu_supports_i32_and_bool_structural_paths() {
     );
 
     let i32_sum = reduce_sum(
-        &Tensor::from_vec_col_major(vec![2, 2], vec![1_i32, 2, 3, 4]),
+        &Tensor::from_vec_col_major(vec![2, 2], vec![1_i32, 2, 3, 4]).unwrap(),
         &[0],
     )
     .unwrap();
@@ -466,7 +488,7 @@ fn test_backend_default_and_buffer_pool_len() {
 
 #[test]
 fn test_backend_buffer_pool_controls_report_and_update_limits() {
-    let ctx = Arc::new(CpuContext::with_threads(1));
+    let ctx = Arc::new(CpuContext::with_threads(1).unwrap());
     let mut backend = CpuBackend::from_context_with_buffer_pool_limit(ctx, 64);
 
     assert_eq!(backend.num_threads(), 1);
@@ -487,12 +509,15 @@ fn test_backend_buffer_pool_controls_report_and_update_limits() {
 
 #[test]
 fn test_backend_mul_neg_conj_dispatch() {
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, -2.0]));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0]));
-    let c = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2],
-        vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
-    ));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, -2.0]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap());
+    let c = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2],
+            vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
+        )
+        .unwrap(),
+    );
     let mut backend = CpuBackend::new();
 
     let prod = TensorElementwise::mul(&mut backend, &a, &b).unwrap();
@@ -511,12 +536,10 @@ fn test_backend_mul_neg_conj_dispatch() {
 #[test]
 fn test_backend_structural_ops_dispatch() {
     let mut backend = CpuBackend::new();
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 2.0, 3.0, 4.0],
-    ));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
 
-    let scalar = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![5.0]));
+    let scalar = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![5.0]).unwrap());
     let broadcast = backend.broadcast_in_dim(&scalar, &[2, 2], &[]).unwrap();
     assert_eq!(broadcast.shape(), &[2, 2]);
     assert_eq!(get_f64(&broadcast, &[0, 0]), 5.0);
@@ -527,7 +550,7 @@ fn test_backend_structural_ops_dispatch() {
     assert_eq!(get_f64(&diag, &[0]), 1.0);
     assert_eq!(get_f64(&diag, &[1]), 4.0);
 
-    let d = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![10.0, 20.0]));
+    let d = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![10.0, 20.0]).unwrap());
     let embedded = backend.embed_diagonal(&d, 0, 1).unwrap();
     assert_eq!(embedded.shape(), &[2, 2]);
     assert_eq!(get_f64(&embedded, &[0, 0]), 10.0);
@@ -557,30 +580,32 @@ fn test_backend_dot_general_f32_c32_and_dtype_mismatch() {
         rhs_batch_dims: vec![],
     };
 
-    let a_f32 = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![1, 2],
-        vec![1.0f32, 2.0],
-    ));
-    let b_f32 = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![2, 1],
-        vec![3.0f32, 4.0],
-    ));
+    let a_f32 =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![1, 2], vec![1.0f32, 2.0]).unwrap());
+    let b_f32 =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![2, 1], vec![3.0f32, 4.0]).unwrap());
     let out_f32 = backend.dot_general(&a_f32, &b_f32, &config).unwrap();
     assert_eq!(out_f32.shape(), &[1, 1]);
 
-    let a_c32 = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![1, 2],
-        vec![Complex32::new(1.0, 0.0), Complex32::new(2.0, 0.0)],
-    ));
-    let b_c32 = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2, 1],
-        vec![Complex32::new(3.0, 0.0), Complex32::new(4.0, 0.0)],
-    ));
+    let a_c32 = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![1, 2],
+            vec![Complex32::new(1.0, 0.0), Complex32::new(2.0, 0.0)],
+        )
+        .unwrap(),
+    );
+    let b_c32 = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2, 1],
+            vec![Complex32::new(3.0, 0.0), Complex32::new(4.0, 0.0)],
+        )
+        .unwrap(),
+    );
     let out_c32 = backend.dot_general(&a_c32, &b_c32, &config).unwrap();
     assert_eq!(out_c32.shape(), &[1, 1]);
 
-    let f64_t = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
-    let f32_t = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]));
+    let f64_t = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
+    let f32_t = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap());
     let err = backend.dot_general(&f64_t, &f32_t, &config).unwrap_err();
     assert!(matches!(
         err,
@@ -595,11 +620,10 @@ fn test_backend_dot_general_f32_c32_and_dtype_mismatch() {
 fn test_backend_gather_scatter_dynamic_slice_dispatch() {
     let mut backend = CpuBackend::new();
 
-    let operand = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![5],
-        vec![10.0, 20.0, 30.0, 40.0, 50.0],
-    ));
-    let start_indices = Tensor::from_vec_col_major(vec![3, 1], vec![0_i64, 2, 4]);
+    let operand = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![5], vec![10.0, 20.0, 30.0, 40.0, 50.0]).unwrap(),
+    );
+    let start_indices = Tensor::from_vec_col_major(vec![3, 1], vec![0_i64, 2, 4]).unwrap();
     let gathered = backend
         .gather(&operand, &start_indices, &simple_gather_config())
         .unwrap();
@@ -607,12 +631,11 @@ fn test_backend_gather_scatter_dynamic_slice_dispatch() {
     assert_eq!(get_f64(&gathered, &[0]), 10.0);
     assert_eq!(get_f64(&gathered, &[2]), 50.0);
 
-    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3]));
-    let scatter_indices = Tensor::from_vec_col_major(vec![3, 2], vec![0_i64, 1, 2, 0, 1, 2]);
-    let updates = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3],
-        vec![5.0, 6.0, 7.0],
-    ));
+    let operand = Tensor::F64(TypedTensor::zeros(vec![3, 3]).unwrap());
+    let scatter_indices =
+        Tensor::from_vec_col_major(vec![3, 2], vec![0_i64, 1, 2, 0, 1, 2]).unwrap();
+    let updates =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![5.0, 6.0, 7.0]).unwrap());
     let scattered = backend
         .scatter(
             &operand,
@@ -625,13 +648,17 @@ fn test_backend_gather_scatter_dynamic_slice_dispatch() {
     assert_eq!(get_f64(&scattered, &[1, 1]), 6.0);
     assert_eq!(get_f64(&scattered, &[2, 2]), 7.0);
 
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4, 4],
-        vec![
-            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
-        ],
-    ));
-    let starts = Tensor::from_vec_col_major(vec![2], vec![2_i64, 3]);
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![4, 4],
+            vec![
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+                16.0,
+            ],
+        )
+        .unwrap(),
+    );
+    let starts = Tensor::from_vec_col_major(vec![2], vec![2_i64, 3]).unwrap();
     let ds = backend.dynamic_slice(&input, &starts, &[2, 2]).unwrap();
     assert_eq!(ds.shape(), &[2, 2]);
     assert_eq!(get_f64(&ds, &[0, 0]), 11.0);

--- a/crates/tenferro-cpu/src/tests/eager_api_tests.rs
+++ b/crates/tenferro-cpu/src/tests/eager_api_tests.rs
@@ -6,8 +6,8 @@ use tenferro_tensor::{
 
 #[test]
 fn tensor_new_and_typed_tensor_as_slice_work() {
-    let tensor = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let typed = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![7.0, 8.0]);
+    let tensor = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let typed = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![7.0, 8.0]).unwrap();
 
     assert_eq!(tensor.shape(), &[2, 3]);
     assert_eq!(
@@ -23,8 +23,8 @@ fn eager_tensor_elementwise_and_structural_methods_match_backend_results() {
     fn needs_backend(_ctx: &mut impl TensorBackend) {}
     needs_backend(&mut ctx);
 
-    let a = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
-    let b = Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]);
+    let a = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]).unwrap();
     let sum = ctx.add(&a, &b).unwrap();
     let product = ctx.mul(&a, &b).unwrap();
     let negated = ctx.neg(&a).unwrap();
@@ -39,11 +39,11 @@ fn eager_tensor_elementwise_and_structural_methods_match_backend_results() {
         Some([-1.0, -2.0, -3.0].as_slice())
     );
 
-    let matrix = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let matrix = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let transposed = ctx.transpose(&matrix, &[1, 0]).unwrap();
     let reshaped = ctx.reshape(&matrix, &[3, 2]).unwrap();
     let reduced = ctx.reduce_sum(&matrix, &[1]).unwrap();
-    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let matmul_config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],

--- a/crates/tenferro-cpu/tests/inject_dual_abi_tests.rs
+++ b/crates/tenferro-cpu/tests/inject_dual_abi_tests.rs
@@ -9,7 +9,7 @@ use tenferro_cpu::inject::{
     LapackProviderPtrSet, ProviderAbi, ProviderRegistrationError,
 };
 use tenferro_cpu::CpuBackend;
-use tenferro_tensor::{DotGeneralConfig, Tensor, TensorBackend, TypedTensor};
+use tenferro_tensor::{DotGeneralConfig, Tensor, TensorDot, TypedTensor};
 
 static TEST_LOCK: Mutex<()> = Mutex::new(());
 
@@ -204,14 +204,10 @@ fn ilp64_gemm_provider_reaches_lp64_consumer() {
 
     DGEMM_ILP64_CALLS.store(0, Ordering::SeqCst);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 3.0, 2.0, 4.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![5.0, 7.0, 6.0, 8.0],
-    ));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0]).unwrap());
+    let b =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![5.0, 7.0, 6.0, 8.0]).unwrap());
 
     let mut backend = CpuBackend::new();
     let c = backend.dot_general(
@@ -227,7 +223,7 @@ fn ilp64_gemm_provider_reaches_lp64_consumer() {
 
     assert_eq!(DGEMM_ILP64_CALLS.load(Ordering::SeqCst), 1);
     match c {
-        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[19.0, 43.0, 22.0, 50.0]),
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data().unwrap(), &[19.0, 43.0, 22.0, 50.0]),
         _ => panic!("expected f64 tensor"),
     }
 }

--- a/crates/tenferro-cpu/tests/inject_tests.rs
+++ b/crates/tenferro-cpu/tests/inject_tests.rs
@@ -5,8 +5,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, Once};
 
 use tenferro_cpu::inject::{
-    register_blas_gemm_fn_ptrs, register_lapack_full_piv_lu_fn_ptrs, register_lapack_provider_ptrs,
-    BlasGemmFnPtrSet, LapackFullPivLuFnPtrSet, LapackProviderPtrSet, ProviderAbi,
+    register_blas_gemm_provider_ptrs, register_lapack_provider_ptrs, BlasGemmProviderPtrSet,
+    LapackProviderPtrSet, ProviderAbi,
 };
 use tenferro_cpu::{CpuBackend, CpuBackendKind};
 use tenferro_tensor::{DotGeneralConfig, Tensor, TensorDot, TypedTensor};
@@ -21,26 +21,25 @@ static DGETRS_CALLS: AtomicUsize = AtomicUsize::new(0);
 
 fn register_test_ptrs_once() {
     REGISTER_ONCE.call_once(|| unsafe {
-        register_blas_gemm_fn_ptrs(BlasGemmFnPtrSet {
-            dgemm: Some(test_dgemm),
-            ..BlasGemmFnPtrSet::new()
-        })
+        register_blas_gemm_provider_ptrs(
+            ProviderAbi::Lp64,
+            BlasGemmProviderPtrSet {
+                dgemm: Some(test_dgemm as *const c_void),
+                ..BlasGemmProviderPtrSet::new()
+            },
+        )
         .expect("test dgemm registration should succeed");
-        register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet {
-            dgetc2: Some(test_dgetc2),
-            dgesc2: Some(test_dgesc2),
-            ..LapackFullPivLuFnPtrSet::new()
-        })
-        .expect("test dgetc2/dgesc2 registration should succeed");
         register_lapack_provider_ptrs(
             ProviderAbi::Lp64,
             LapackProviderPtrSet {
+                dgetc2: Some(test_dgetc2 as *const c_void),
+                dgesc2: Some(test_dgesc2 as *const c_void),
                 dgetrf: Some(test_dgetrf as *const c_void),
                 dgetrs: Some(test_dgetrs as *const c_void),
                 ..LapackProviderPtrSet::new()
             },
         )
-        .expect("test dgetrf/dgetrs registration should succeed");
+        .expect("test LAPACK registration should succeed");
     });
 }
 
@@ -177,14 +176,10 @@ fn provider_inject_dot_general_uses_registered_blas() {
     register_test_ptrs_once();
     DGEMM_CALLS.store(0, Ordering::SeqCst);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 3.0, 2.0, 4.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![5.0, 7.0, 6.0, 8.0],
-    ));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0]).unwrap());
+    let b =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![5.0, 7.0, 6.0, 8.0]).unwrap());
 
     let mut backend = CpuBackend::with_kind(CpuBackendKind::Blas).unwrap();
     assert_eq!(backend.kind(), CpuBackendKind::Blas);
@@ -201,7 +196,7 @@ fn provider_inject_dot_general_uses_registered_blas() {
 
     assert_eq!(DGEMM_CALLS.load(Ordering::SeqCst), 1);
     match c {
-        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[19.0, 43.0, 22.0, 50.0]),
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data().unwrap(), &[19.0, 43.0, 22.0, 50.0]),
         _ => panic!("expected f64 tensor"),
     }
 }
@@ -214,8 +209,8 @@ fn provider_inject_dot_general_singleton_contract_uses_registered_blas() {
     register_test_ptrs_once();
     DGEMM_CALLS.store(0, Ordering::SeqCst);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 2], vec![1.0, 2.0]));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 2], vec![3.0, 4.0]));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 2], vec![1.0, 2.0]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 2], vec![3.0, 4.0]).unwrap());
 
     let mut backend = CpuBackend::with_kind(CpuBackendKind::Blas).unwrap();
     let c = backend.dot_general(
@@ -231,7 +226,7 @@ fn provider_inject_dot_general_singleton_contract_uses_registered_blas() {
 
     assert_eq!(DGEMM_CALLS.load(Ordering::SeqCst), 1);
     match c {
-        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[3.0, 6.0, 4.0, 8.0]),
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data().unwrap(), &[3.0, 6.0, 4.0, 8.0]),
         _ => panic!("expected f64 tensor"),
     }
 }
@@ -244,11 +239,10 @@ fn provider_inject_dot_general_rhs_singleton_contract_uses_registered_blas() {
     register_test_ptrs_once();
     DGEMM_CALLS.store(0, Ordering::SeqCst);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![2.0]));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 1, 2],
-        vec![3.0, 4.0, 5.0, 6.0],
-    ));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![2.0]).unwrap());
+    let b = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 1, 2], vec![3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
 
     let mut backend = CpuBackend::with_kind(CpuBackendKind::Blas).unwrap();
     let c = backend.dot_general(
@@ -264,7 +258,7 @@ fn provider_inject_dot_general_rhs_singleton_contract_uses_registered_blas() {
 
     assert_eq!(DGEMM_CALLS.load(Ordering::SeqCst), 1);
     match c {
-        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[6.0, 8.0, 10.0, 12.0]),
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data().unwrap(), &[6.0, 8.0, 10.0, 12.0]),
         _ => panic!("expected f64 tensor"),
     }
 }

--- a/crates/tenferro-cpu/tests/provider_feature_contract.rs
+++ b/crates/tenferro-cpu/tests/provider_feature_contract.rs
@@ -115,23 +115,6 @@ fn cpu_provider_features_select_matching_source_and_einsum_provider() {
 }
 
 #[test]
-fn legacy_source_provider_features_delegate_to_public_provider_features() {
-    let manifest = manifest("tenferro-cpu");
-
-    for (legacy, replacement) in [
-        ("src-openblas", "blas-openblas"),
-        ("src-accelerate", "blas-accelerate"),
-        ("src-intel-mkl-dynamic-parallel", "blas-mkl"),
-    ] {
-        let values = feature_values(&manifest, legacy);
-        assert!(
-            values.contains(replacement),
-            "`{legacy}` should delegate to `{replacement}`, got:\n{values}"
-        );
-    }
-}
-
-#[test]
 fn public_cpu_user_crates_expose_provider_passthrough_features() {
     for crate_name in PASSTHROUGH_CRATES {
         let manifest = manifest(crate_name);

--- a/crates/tenferro-cpu/tests/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/runtime_error_tests.rs
@@ -9,11 +9,11 @@ use tenferro_tensor::{
 };
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn f32_tensor(shape: Vec<usize>, data: Vec<f32>) -> Tensor {
-    Tensor::F32(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F32(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn source_section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
@@ -25,17 +25,20 @@ fn source_section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
 
 fn backend_f64_tensor(shape: Vec<usize>) -> Tensor {
     let len = shape.iter().product();
-    Tensor::F64(TypedTensor::from_buffer_col_major(
-        shape,
-        Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(7, len))),
-        Placement {
-            memory_kind: MemoryKind::Device,
-            device: Some(DeviceId {
-                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
-                ordinal: 0,
-            }),
-        },
-    ))
+    Tensor::F64(
+        TypedTensor::from_buffer_col_major(
+            shape,
+            Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(7, len))),
+            Placement {
+                memory_kind: MemoryKind::Device,
+                device: Some(DeviceId {
+                    kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+                    ordinal: 0,
+                }),
+            },
+        )
+        .unwrap(),
+    )
 }
 
 #[test]
@@ -218,8 +221,8 @@ fn cpu_reduce_max_min_validate_axes_before_empty_fast_path() {
 }
 
 #[test]
-fn cpu_backend_try_with_threads_rejects_zero_without_panicking() {
-    let err = match CpuBackend::try_with_threads(0) {
+fn cpu_backend_with_threads_rejects_zero_without_panicking() {
+    let err = match CpuBackend::with_threads(0) {
         Ok(_) => panic!("zero threads should be rejected"),
         Err(err) => err,
     };
@@ -227,7 +230,7 @@ fn cpu_backend_try_with_threads_rejects_zero_without_panicking() {
     assert!(matches!(
         err,
         Error::InvalidConfig {
-            op: "CpuBackend::try_with_threads",
+            op: "CpuBackend::with_threads",
             ..
         }
     ));

--- a/crates/tenferro-einsum/benches/einsum_cpu_bench.rs
+++ b/crates/tenferro-einsum/benches/einsum_cpu_bench.rs
@@ -20,7 +20,7 @@ fn bench_threads() -> usize {
 }
 
 fn cpu_ctx(threads: usize) -> Arc<EagerRuntime> {
-    EagerRuntime::with_cpu_backend(CpuBackend::with_threads(threads))
+    EagerRuntime::with_cpu_backend(CpuBackend::with_threads(threads).unwrap())
 }
 
 fn f64_tensor(shape: Vec<usize>, seed: usize) -> Tensor {
@@ -28,7 +28,7 @@ fn f64_tensor(shape: Vec<usize>, seed: usize) -> Tensor {
     let data = (0..len)
         .map(|idx| ((idx * 17 + seed * 31 + 7) % 997) as f64 / 997.0 - 0.5)
         .collect();
-    Tensor::from_vec_col_major(shape, data)
+    Tensor::from_vec_col_major(shape, data).unwrap()
 }
 
 fn c64_tensor(shape: Vec<usize>, seed: usize) -> Tensor {
@@ -40,7 +40,7 @@ fn c64_tensor(shape: Vec<usize>, seed: usize) -> Tensor {
             Complex64::new(re, im)
         })
         .collect();
-    Tensor::from_vec_col_major(shape, data)
+    Tensor::from_vec_col_major(shape, data).unwrap()
 }
 
 fn eager(ctx: &Arc<EagerRuntime>, tensor: Tensor) -> EagerTensor {

--- a/crates/tenferro-einsum/benches/mps_inner_product.rs
+++ b/crates/tenferro-einsum/benches/mps_inner_product.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
-use tenferro_einsum::einsum;
+use tenferro_einsum::traced_tensor::einsum;
 use tenferro_runtime::{
     GraphCompiler, GraphExecutor, GraphProgram, Tensor, TracedTensor, TypedTensor,
 };
@@ -34,7 +34,7 @@ fn complex_tensor(shape: &[usize], seed: usize) -> Tensor {
             Complex64::new(real, imag)
         })
         .collect();
-    Tensor::C64(TypedTensor::from_vec_col_major(shape.to_vec(), data))
+    Tensor::C64(TypedTensor::from_vec_col_major(shape.to_vec(), data).unwrap())
 }
 
 fn build_mps_fixture(sites: usize, phys_dim: usize, bond_dim: usize) -> MpsFixture {
@@ -61,7 +61,8 @@ fn build_inner_product_graph(
     bra: &[TracedTensor],
     ket: &[TracedTensor],
 ) -> TracedTensor {
-    let mut env = TracedTensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 0.0)]);
+    let mut env =
+        TracedTensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 0.0)]).unwrap();
     for (bra_core, ket_core) in bra.iter().zip(ket) {
         let bra_core = bra_core.conj();
         env = einsum(compiler, &[&env, &bra_core, ket_core], "ab,acr,bcs->rs")
@@ -94,7 +95,7 @@ fn bench_mps_inner_product(c: &mut Criterion) {
     for &chi in CHIS {
         let fixture = build_mps_fixture(L, PHYS_DIM, chi);
         let compiled = compile_mps_inner_product(&fixture);
-        let mut engine = GraphExecutor::new(CpuBackend::with_threads(1));
+        let mut engine = GraphExecutor::new(CpuBackend::with_threads(1).unwrap());
         engine
             .register_extension(tenferro_einsum::register_runtime)
             .expect("einsum runtime registration should succeed");
@@ -123,7 +124,7 @@ fn bench_mps_inner_product(c: &mut Criterion) {
             move |b| {
                 b.iter(|| {
                     let compiled = compile_mps_inner_product(black_box(&fixture));
-                    let mut engine = GraphExecutor::new(CpuBackend::with_threads(1));
+                    let mut engine = GraphExecutor::new(CpuBackend::with_threads(1).unwrap());
                     engine
                         .register_extension(tenferro_einsum::register_runtime)
                         .expect("einsum runtime registration should succeed");

--- a/crates/tenferro-einsum/benches/mps_inner_product_compile.rs
+++ b/crates/tenferro-einsum/benches/mps_inner_product_compile.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use num_complex::Complex64;
-use tenferro_einsum::einsum;
+use tenferro_einsum::traced_tensor::einsum;
 use tenferro_runtime::{DType, GraphCompiler, GraphProgram, TracedTensor};
 
 const PHYS_DIM: usize = 2;
@@ -29,7 +29,8 @@ fn build_inner_product_graph(
     bra: &[TracedTensor],
     ket: &[TracedTensor],
 ) -> TracedTensor {
-    let mut env = TracedTensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 0.0)]);
+    let mut env =
+        TracedTensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 0.0)]).unwrap();
     for (bra_core, ket_core) in bra.iter().zip(ket) {
         let bra_core = bra_core.conj();
         env = einsum(compiler, &[&env, &bra_core, ket_core], "ab,acr,bcs->rs")

--- a/crates/tenferro-einsum/src/eager.rs
+++ b/crates/tenferro-einsum/src/eager.rs
@@ -34,11 +34,11 @@ impl TensorValue<'_> {
         }
     }
 
-    fn into_tensor(self) -> Tensor {
+    fn into_tensor(self) -> Result<Tensor> {
         match self {
-            Self::Borrowed(tensor) => tensor.clone(),
+            Self::Borrowed(tensor) => Ok(tensor.clone()),
             Self::View(view) => view.to_tensor(),
-            Self::Owned(tensor) => tensor,
+            Self::Owned(tensor) => Ok(tensor),
         }
     }
 
@@ -144,7 +144,7 @@ fn broadcast_typed_view<'a, T: 'static, R: TensorRank>(
     dims: &[usize],
 ) -> Result<TypedTensorView<'a, T>> {
     let (shape, strides) = broadcast_shape_strides(&view, shape, dims)?;
-    TypedTensorView::from_slice(shape, strides, view.offset(), view.as_physical_slice())
+    TypedTensorView::from_slice(shape, strides, view.offset(), view.as_physical_slice()?)
 }
 
 fn broadcast_tensor_view<'a>(
@@ -215,10 +215,10 @@ impl LabeledTensor<'_> {
         self.tensor.tensor_read()
     }
 
-    fn tensor_cow(&self) -> Cow<'_, Tensor> {
+    fn tensor_cow(&self) -> Result<Cow<'_, Tensor>> {
         match self.tensor() {
-            Some(tensor) => Cow::Borrowed(tensor),
-            None => Cow::Owned(self.tensor_read().to_tensor()),
+            Some(tensor) => Ok(Cow::Borrowed(tensor)),
+            None => Ok(Cow::Owned(self.tensor_read().to_tensor()?)),
         }
     }
 
@@ -347,7 +347,7 @@ fn reduce_tensor<'a>(
         .filter(|(axis, _)| !reduce_set.contains(axis))
         .map(|(_, label)| *label)
         .collect();
-    let operand_tensor = operand.tensor_cow();
+    let operand_tensor = operand.tensor_cow()?;
     let tensor = exec.reduce_sum(&operand_tensor, &reduce_axes)?;
     operand.reclaim_if_owned(exec);
     Ok(LabeledTensor {
@@ -374,7 +374,7 @@ fn diagonalize_repeated<'a>(
             return Ok(operand);
         };
 
-        let operand_tensor = operand.tensor_cow();
+        let operand_tensor = operand.tensor_cow()?;
         let tensor = exec.extract_diagonal(&operand_tensor, axis_a, axis_b)?;
         let mut labels = operand.labels.clone();
         labels.remove(axis_b);
@@ -406,7 +406,7 @@ fn embed_repeated<'a>(
             if output_count > current_count {
                 let axis_a = find_label_axis(&operand.labels, label)?;
                 let axis_b = axis_a + 1;
-                let operand_tensor = operand.tensor_cow();
+                let operand_tensor = operand.tensor_cow()?;
                 let tensor = exec.embed_diagonal(&operand_tensor, axis_a, axis_b)?;
                 let mut labels = operand.labels.clone();
                 labels.insert(axis_b, label);
@@ -447,7 +447,7 @@ fn transpose_to_labels<'a>(
         return Ok(operand);
     }
 
-    let operand_tensor = operand.tensor_cow();
+    let operand_tensor = operand.tensor_cow()?;
     let tensor = exec.transpose(&operand_tensor, &perm)?;
     operand.reclaim_if_owned(exec);
     Ok(LabeledTensor {
@@ -513,8 +513,8 @@ fn outer_product<'a>(
         ) {
             (Some(lhs_read), Some(rhs_read)) => exec.mul_read(lhs_read?, rhs_read?)?,
             _ => {
-                let lhs_input = lhs.tensor_cow();
-                let rhs_input = rhs.tensor_cow();
+                let lhs_input = lhs.tensor_cow()?;
+                let rhs_input = rhs.tensor_cow()?;
                 let lhs_tensor = exec.broadcast_in_dim(&lhs_input, &combined_shape, &lhs_dims)?;
                 let rhs_tensor = exec.broadcast_in_dim(&rhs_input, &combined_shape, &rhs_dims)?;
                 let tensor = exec.mul(&lhs_tensor, &rhs_tensor)?;
@@ -723,7 +723,7 @@ fn eager_einsum_exec_values<'a>(
         let reduced = reduce_tensor(exec, operand, &reduce_labels)?;
         let embedded = embed_repeated(exec, reduced, output_labels)?;
         let reordered = transpose_to_labels(exec, embedded, output_labels)?;
-        return Ok(reordered.tensor.into_tensor());
+        return reordered.tensor.into_tensor();
     }
 
     for step_idx in 0..tree.step_count() {
@@ -767,7 +767,7 @@ fn eager_einsum_exec_values<'a>(
     let reordered = profile_eager_einsum_section("exec.final_transpose", || {
         transpose_to_labels(exec, reduced, output_labels)
     })?;
-    Ok(reordered.tensor.into_tensor())
+    reordered.tensor.into_tensor()
 }
 
 /// Run a whole einsum contraction tree in one backend session.
@@ -835,7 +835,7 @@ fn eager_einsum_exec_binary_read_fast(
         labels: subscripts.inputs[1].clone(),
     };
     execute_binary_dot_fast_plan(exec, lhs, rhs, plan, true)
-        .map(|result| result.tensor.into_tensor())
+        .and_then(|result| result.tensor.into_tensor())
 }
 
 fn try_eager_einsum_binary_read_fast(

--- a/crates/tenferro-einsum/src/eager/tests.rs
+++ b/crates/tenferro-einsum/src/eager/tests.rs
@@ -14,7 +14,7 @@ use crate::{ContractionTree, Subscripts};
 
 #[test]
 fn tensor_value_view_paths_materialize_and_read() {
-    let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let view_shape = [2usize];
     let view_data = [3.0_f64, 4.0];
     let view = TensorView::f64(&view_shape, &view_data).unwrap();
@@ -31,7 +31,7 @@ fn tensor_value_view_paths_materialize_and_read() {
     assert!(view_value.as_tensor().is_none());
     assert_eq!(view_value.tensor_read().shape(), &[2]);
     assert_eq!(
-        view_value.into_tensor().as_slice::<f64>().unwrap(),
+        view_value.into_tensor().unwrap().as_slice::<f64>().unwrap(),
         &[3.0, 4.0]
     );
 }
@@ -58,7 +58,7 @@ fn generic_outer_product_with_views_uses_broadcast_path() {
         .with_backend_session(|exec| binary_contract(exec, lhs, rhs, &[0, 1], true))
         .unwrap();
     let labels = result.labels;
-    let tensor = result.tensor.into_tensor();
+    let tensor = result.tensor.into_tensor().unwrap();
 
     assert_eq!(labels, vec![0, 1]);
     assert_eq!(tensor.shape(), &[2, 3]);
@@ -70,8 +70,8 @@ fn generic_outer_product_with_views_uses_broadcast_path() {
 
 #[test]
 fn generic_outer_product_uses_broadcast_views_without_materialized_broadcast_ops() {
-    let lhs = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let rhs = Tensor::from_vec_col_major(vec![3], vec![3.0_f64, 4.0, 5.0]);
+    let lhs = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![3], vec![3.0_f64, 4.0, 5.0]).unwrap();
     let lhs = LabeledTensor {
         tensor: TensorValue::Borrowed(&lhs),
         labels: vec![0],
@@ -87,7 +87,7 @@ fn generic_outer_product_uses_broadcast_views_without_materialized_broadcast_ops
     };
 
     let result = binary_contract(&mut backend, lhs, rhs, &[0, 1], true).unwrap();
-    let tensor = result.tensor.into_tensor();
+    let tensor = result.tensor.into_tensor().unwrap();
 
     assert_eq!(result.labels, vec![0, 1]);
     assert_eq!(tensor.shape(), &[2, 3]);
@@ -99,8 +99,8 @@ fn generic_outer_product_uses_broadcast_views_without_materialized_broadcast_ops
 
 #[test]
 fn generic_outer_product_uses_target_order_without_final_transpose() {
-    let lhs = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let rhs = Tensor::from_vec_col_major(vec![3], vec![3.0_f64, 4.0, 5.0]);
+    let lhs = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![3], vec![3.0_f64, 4.0, 5.0]).unwrap();
     let lhs = LabeledTensor {
         tensor: TensorValue::Borrowed(&lhs),
         labels: vec![0],
@@ -116,7 +116,7 @@ fn generic_outer_product_uses_target_order_without_final_transpose() {
     };
 
     let result = binary_contract(&mut backend, lhs, rhs, &[1, 0], true).unwrap();
-    let tensor = result.tensor.into_tensor();
+    let tensor = result.tensor.into_tensor().unwrap();
 
     assert_eq!(result.labels, vec![1, 0]);
     assert_eq!(tensor.shape(), &[3, 2]);
@@ -128,8 +128,8 @@ fn generic_outer_product_uses_target_order_without_final_transpose() {
 
 #[test]
 fn generic_binary_contract_reduces_then_builds_dot_config() {
-    let lhs = Tensor::from_vec_col_major(vec![2, 3, 4], vec![1.0_f64; 24]);
-    let rhs = Tensor::from_vec_col_major(vec![3, 5], vec![2.0_f64; 15]);
+    let lhs = Tensor::from_vec_col_major(vec![2, 3, 4], vec![1.0_f64; 24]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![3, 5], vec![2.0_f64; 15]).unwrap();
     let lhs = LabeledTensor {
         tensor: TensorValue::Borrowed(&lhs),
         labels: vec![0, 1, 9],
@@ -144,7 +144,7 @@ fn generic_binary_contract_reduces_then_builds_dot_config() {
         .with_backend_session(|exec| binary_contract(exec, lhs, rhs, &[0, 2], false))
         .unwrap();
     let labels = result.labels;
-    let tensor = result.tensor.into_tensor();
+    let tensor = result.tensor.into_tensor().unwrap();
 
     assert_eq!(labels, vec![0, 2]);
     assert_eq!(tensor.shape(), &[2, 5]);
@@ -429,15 +429,15 @@ fn generic_read_exec_reduces_single_view_input() {
 
 #[test]
 fn binary_read_fast_path_rejects_non_fast_shapes_and_labels() {
-    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
+    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
     let mut ctx = CpuBackend::new();
 
     let subscripts = Subscripts::parse("ij,jk->ik").unwrap();
     let one_input = [TensorRead::from_tensor(&lhs)];
     assert!(try_eager_einsum_binary_read_fast(&mut ctx, &one_input, &subscripts).is_none());
 
-    let flat_rhs = Tensor::from_vec_col_major(vec![6], vec![1.0_f64; 6]);
+    let flat_rhs = Tensor::from_vec_col_major(vec![6], vec![1.0_f64; 6]).unwrap();
     let rank_mismatch = [
         TensorRead::from_tensor(&lhs),
         TensorRead::from_tensor(&flat_rhs),

--- a/crates/tenferro-einsum/src/eager_tensor.rs
+++ b/crates/tenferro-einsum/src/eager_tensor.rs
@@ -24,9 +24,7 @@ use crate::cache::{
     saturating_sum, vec_retained_bytes, EINSUM_EAGER_EXPANDED_PROGRAMS_CACHE,
     EINSUM_EXTENSION_FAMILY_ID,
 };
-use crate::extension::{
-    ensure_einsum_extension_rule_registered, register_runtime, EinsumExtensionOp,
-};
+use crate::extension::{register_runtime, EinsumExtensionOp};
 use crate::optimize::{
     default_auto_options, hash_einsum_plan_spec, resolve_plan_spec, EinsumPlanSpec,
 };
@@ -102,7 +100,6 @@ pub fn einsum_subscripts(
         return Ok(result);
     }
 
-    ensure_einsum_extension_rule_registered().map_err(|err| Error::Internal(err.to_string()))?;
     if let Some(first) = inputs.first() {
         first
             .runtime()
@@ -588,7 +585,7 @@ fn try_execute_eager_broadcast_multiply_pattern(
     let rhs = slot_tensor(slots, rhs_bc.inputs[0])?;
     let lhs_shape = eval_shape_exprs(slots, &lhs_bc.inputs, lhs_shape_exprs)?;
     let rhs_shape = eval_shape_exprs(slots, &rhs_bc.inputs, rhs_shape_exprs)?;
-    let Some(output) = tenferro_ad::eager_tensor::try_backend_broadcast_multiply_untracked(
+    let Some(output) = tenferro_ad::eager_tensor::backend_broadcast_multiply_untracked(
         lhs, &lhs_shape, lhs_dims, rhs, &rhs_shape, rhs_dims,
     )?
     else {
@@ -611,7 +608,9 @@ fn eval_shape_exprs(
         .iter()
         .map(|tensor| tensor.shape())
         .collect::<Vec<_>>();
-    Ok(DimExpr::eval_all(shape, &input_shapes))
+    DimExpr::eval_all(shape, &input_shapes).map_err(|err| Error::InvalidCompiledGraph {
+        message: format!("invalid eager einsum shape expression: {err}"),
+    })
 }
 
 fn slot_tensor(slots: &[Option<EagerTensor>], slot: usize) -> Result<&EagerTensor> {

--- a/crates/tenferro-einsum/src/eager_tensor/tests.rs
+++ b/crates/tenferro-einsum/src/eager_tensor/tests.rs
@@ -9,11 +9,11 @@ use crate::{ContractionTree, Subscripts};
 fn binary_einsum_col_major_matmul_uses_direct_dot_general_fast_path() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let lhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap(),
         ctx.clone(),
     );
     let rhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]),
+        Tensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]).unwrap(),
         ctx.clone(),
     );
 
@@ -21,7 +21,7 @@ fn binary_einsum_col_major_matmul_uses_direct_dot_general_fast_path() {
 
     assert_eq!(out.data().shape(), &[4, 3]);
     assert_eq!(out.data().as_slice::<f64>().unwrap(), &[2.0_f64; 12]);
-    assert_eq!(ctx.cache_stats().extensions.entries, 0);
+    assert_eq!(ctx.cache_stats().unwrap().extensions.entries, 0);
 }
 
 #[test]
@@ -30,12 +30,18 @@ fn whole_program_untracked_matches_per_op_nary_result() {
     let a_data: Vec<f64> = (0..6).map(|i| i as f64 + 1.0).collect();
     let b_data: Vec<f64> = (0..12).map(|i| i as f64 * 0.5 - 2.0).collect();
     let c_data: Vec<f64> = (0..20).map(|i| (i as f64).sin()).collect();
-    let a =
-        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2, 3], a_data), ctx.clone());
-    let b =
-        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![3, 4], b_data), ctx.clone());
-    let c =
-        EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![4, 5], c_data), ctx.clone());
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 3], a_data).unwrap(),
+        ctx.clone(),
+    );
+    let b = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![3, 4], b_data).unwrap(),
+        ctx.clone(),
+    );
+    let c = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![4, 5], c_data).unwrap(),
+        ctx.clone(),
+    );
 
     // Reference: default per-op N-ary path.
     let reference = einsum(&[&a, &b, &c], "ij,jk,kl->il").unwrap();
@@ -62,11 +68,11 @@ fn whole_program_untracked_matches_per_op_nary_result() {
 fn whole_program_untracked_rejects_tracked_inputs() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let a = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap(),
         ctx.clone(),
     );
 
@@ -79,15 +85,15 @@ fn whole_program_untracked_rejects_tracked_inputs() {
 fn nary_eager_einsum_expands_to_standard_ops_with_runtime_cache() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]),
+        Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap(),
         ctx.clone(),
     );
     let c = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]),
+        Tensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]).unwrap(),
         ctx.clone(),
     );
 
@@ -95,41 +101,41 @@ fn nary_eager_einsum_expands_to_standard_ops_with_runtime_cache() {
 
     assert_eq!(out.data().shape(), &[2, 5]);
     assert_eq!(out.data().as_slice::<f64>().unwrap(), &[12.0_f64; 10]);
-    assert_eq!(ctx.cache_stats().extensions.entries, 1);
+    assert_eq!(ctx.cache_stats().unwrap().extensions.entries, 1);
 }
 
 #[test]
 fn nary_eager_einsum_expanded_standard_ops_reuse_runtime_cache() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]),
+        Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap(),
         ctx.clone(),
     );
     let c = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]),
+        Tensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]).unwrap(),
         ctx.clone(),
     );
 
     let first = einsum(&[&a, &b, &c], "ij,jk,kl->il").unwrap();
 
     assert_eq!(first.data().shape(), &[2, 5]);
-    let after_first = ctx.cache_stats().extensions;
+    let after_first = ctx.cache_stats().unwrap().extensions;
     assert_eq!(after_first.entries, 1);
     assert!(after_first.retained_bytes > 0);
 
     let second = einsum(&[&a, &b, &c], "ij,jk,kl->il").unwrap();
 
     assert_eq!(second.data().shape(), &[2, 5]);
-    let after_second = ctx.cache_stats().extensions;
+    let after_second = ctx.cache_stats().unwrap().extensions;
     assert_eq!(after_second.entries, 1);
     assert_eq!(after_second.retained_bytes, after_first.retained_bytes);
 
-    ctx.clear_extension_caches();
-    assert_eq!(ctx.cache_stats().extensions.entries, 0);
+    ctx.clear_extension_caches().unwrap();
+    assert_eq!(ctx.cache_stats().unwrap().extensions.entries, 0);
 }
 
 #[test]
@@ -142,16 +148,16 @@ fn expanded_eager_einsum_cache_hit_preserves_lazy_view_output() {
     let lhs_data: Vec<f64> = (0..k * j * t).map(|idx| idx as f64 + 1.0).collect();
     let rhs_data: Vec<f64> = (0..o * t).map(|idx| idx as f64 + 101.0).collect();
     let lhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![k, j, t], lhs_data),
+        Tensor::from_vec_col_major(vec![k, j, t], lhs_data).unwrap(),
         ctx.clone(),
     );
     let rhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![o, t], rhs_data),
+        Tensor::from_vec_col_major(vec![o, t], rhs_data).unwrap(),
         ctx.clone(),
     );
 
     let first = einsum(&[&lhs, &rhs], "kjt,ot->jkot").unwrap();
-    assert_eq!(ctx.cache_stats().extensions.entries, 1);
+    assert_eq!(ctx.cache_stats().unwrap().extensions.entries, 1);
     assert!(matches!(
         first.tensor_read(),
         TensorRead::View(TensorView::F64(_))
@@ -159,7 +165,7 @@ fn expanded_eager_einsum_cache_hit_preserves_lazy_view_output() {
 
     let second = einsum(&[&lhs, &rhs], "kjt,ot->jkot").unwrap();
 
-    assert_eq!(ctx.cache_stats().extensions.entries, 1);
+    assert_eq!(ctx.cache_stats().unwrap().extensions.entries, 1);
     match second.tensor_read() {
         TensorRead::View(TensorView::F64(view)) => {
             assert_eq!(view.shape(), &[j, k, o, t]);
@@ -176,15 +182,15 @@ fn expanded_eager_einsum_cache_hit_preserves_lazy_view_output() {
 fn nary_eager_einsum_expanded_standard_ops_preserve_backward() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let a = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]),
+        Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap(),
         ctx.clone(),
     );
     let c = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]),
+        Tensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]).unwrap(),
         ctx,
     );
 
@@ -194,22 +200,25 @@ fn nary_eager_einsum_expanded_standard_ops_preserve_backward() {
         .unwrap();
     let _ = loss.backward().unwrap();
 
-    assert_eq!(a.grad().unwrap().as_slice::<f64>().unwrap(), &[20.0; 6]);
+    assert_eq!(
+        a.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
+        &[20.0; 6]
+    );
 }
 
 #[test]
 fn tracked_whole_program_einsum_records_one_graph_residual() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let a = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]),
+        Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap(),
         ctx.clone(),
     );
     let c = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]),
+        Tensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]).unwrap(),
         ctx,
     );
 
@@ -223,24 +232,33 @@ fn tracked_whole_program_einsum_records_one_graph_residual() {
     let loss = out.reduce_sum(&[0, 1]).unwrap();
     let _ = loss.backward().unwrap();
 
-    assert_eq!(a.grad().unwrap().as_slice::<f64>().unwrap(), &[20.0; 6]);
-    assert_eq!(b.grad().unwrap().as_slice::<f64>().unwrap(), &[10.0; 12]);
-    assert_eq!(c.grad().unwrap().as_slice::<f64>().unwrap(), &[6.0; 20]);
+    assert_eq!(
+        a.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
+        &[20.0; 6]
+    );
+    assert_eq!(
+        b.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
+        &[10.0; 12]
+    );
+    assert_eq!(
+        c.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
+        &[6.0; 20]
+    );
 }
 
 #[test]
 fn eager_outer_product_can_use_untracked_backend_broadcast_multiply() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let lhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]),
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
         ctx.clone(),
     );
     let rhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3], vec![5.0_f64, 7.0, 11.0]),
+        Tensor::from_vec_col_major(vec![3], vec![5.0_f64, 7.0, 11.0]).unwrap(),
         ctx,
     );
 
-    let out = tenferro_ad::eager_tensor::try_backend_broadcast_multiply_untracked(
+    let out = tenferro_ad::eager_tensor::backend_broadcast_multiply_untracked(
         &lhs,
         &[2, 3],
         &[0],
@@ -269,11 +287,11 @@ fn eager_outer_product_can_return_lazy_noncompact_output() {
     let lhs_data: Vec<f64> = (0..k * j * t).map(|idx| idx as f64 + 1.0).collect();
     let rhs_data: Vec<f64> = (0..o * t).map(|idx| idx as f64 + 101.0).collect();
     let lhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![k, j, t], lhs_data.clone()),
+        Tensor::from_vec_col_major(vec![k, j, t], lhs_data.clone()).unwrap(),
         ctx.clone(),
     );
     let rhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![o, t], rhs_data.clone()),
+        Tensor::from_vec_col_major(vec![o, t], rhs_data.clone()).unwrap(),
         ctx,
     );
 

--- a/crates/tenferro-einsum/src/extension.rs
+++ b/crates/tenferro-einsum/src/extension.rs
@@ -15,8 +15,6 @@ use computegraph::types::{ValueKey, ValueRef};
 use smallvec::SmallVec;
 use tenferro_extension_macros::define_extension_runtime;
 #[cfg(feature = "autodiff")]
-use tenferro_extension_macros::define_idempotent_rule_registration;
-#[cfg(feature = "autodiff")]
 use tenferro_ops::ad::context::ShapeGuardContext;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::ad::PrimitiveRuleBuilder;
@@ -28,6 +26,8 @@ use tenferro_ops::ext_op::{ExtensionLoweringError, ExtensionLoweringResult, Exte
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::sym_dim::SymDim;
+#[cfg(feature = "autodiff")]
+use tenferro_ops::{ExtensionRegistryError, ExtensionRuleSet};
 use tenferro_runtime::extension::{
     ExecInstruction, ExecOp, ExecProgram, ExtensionCacheKey, ExtensionExecutionContext,
 };
@@ -305,10 +305,8 @@ fn concrete_sym_shape_slices(input_shapes: &[&[SymDim]]) -> Option<Vec<Vec<usize
 }
 
 #[cfg(feature = "autodiff")]
-define_idempotent_rule_registration! {
-    register_fn = ensure_einsum_extension_rule_registered,
-    rule_type = EinsumAdRule,
-    visibility = pub(crate),
+pub fn ad_rules() -> Result<ExtensionRuleSet, ExtensionRegistryError> {
+    ExtensionRuleSet::new().with_rule(Arc::new(EinsumAdRule))
 }
 
 #[derive(Debug)]
@@ -383,8 +381,8 @@ impl ExtensionAdRule for EinsumAdRule {
         };
         let primal_input_shapes: Vec<Vec<SymDim>> = inputs
             .iter()
-            .map(|input| ctx.shape_of(input).to_vec())
-            .collect();
+            .map(|input| ctx.shape_of(input).map(|shape| shape.to_vec()))
+            .collect::<Result<_, _>>()?;
         let cotangent_shape = op.output_shape_hint.clone().ok_or_else(|| {
             ADRuleError::unsupported(
                 "einsum VJP requires an output shape hint for cotangent planning",
@@ -427,7 +425,7 @@ impl ExtensionAdRule for EinsumAdRule {
                     builder,
                     inputs[input_idx].clone(),
                     ctx,
-                ));
+                )?);
             }
 
             let output_shape_hint = primal_input_shapes[active_idx].clone();
@@ -1310,13 +1308,13 @@ fn conjugate_primal_if_complex(
     builder: &mut dyn PrimitiveRuleBuilder,
     input: ValueRef<StdTensorOp>,
     ctx: &mut ShapeGuardContext,
-) -> ValueRef<StdTensorOp> {
-    match ctx.dtype_of(&input) {
+) -> ADRuleResult<ValueRef<StdTensorOp>> {
+    Ok(match ctx.dtype_of(&input)? {
         DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => input,
         DType::C32 | DType::C64 => ValueRef::Local(
             builder.add_operation(StdTensorOp::Conj, vec![input], OperationRole::Primary)[0],
         ),
-    }
+    })
 }
 
 fn promote_dtypes(dtypes: impl IntoIterator<Item = DType>) -> DType {

--- a/crates/tenferro-einsum/src/extension/tests.rs
+++ b/crates/tenferro-einsum/src/extension/tests.rs
@@ -118,10 +118,9 @@ fn runtime_input_index_vec_stays_inline_for_common_arity() {
 
 #[test]
 fn execute_einsum_extension_reads_consumes_strided_view_inputs() {
-    let base = Arc::new(Tensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let base = Arc::new(
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
     let view = TensorOwnedView::from_parts(Arc::clone(&base), vec![3, 2], vec![2, 1], 0).unwrap();
     let input = TensorRead::from_view(view.tensor_view());
     let op = EinsumExtensionOp::new(EinsumSubscripts::new(&[&[0, 1]], &[0, 1]));

--- a/crates/tenferro-einsum/src/lib.rs
+++ b/crates/tenferro-einsum/src/lib.rs
@@ -64,6 +64,8 @@ pub(crate) mod util;
 
 pub use cache::EINSUM_EXTENSION_FAMILY_ID;
 pub use error::{Error, Result};
+#[cfg(feature = "autodiff")]
+pub use extension::ad_rules;
 pub use extension::register_runtime;
 pub use optimize::EinsumOptimize;
 pub use planning::tree::{ContractionOptimizerOptions, ContractionTree};
@@ -71,7 +73,6 @@ pub use subscripts::{parse_einsum_subscripts, EinsumSubscripts};
 pub use syntax::nested::NestedEinsum;
 pub use syntax::subscripts::Subscripts;
 pub use tensordot::TensorDotAxes;
-pub use traced::{einsum, einsum_subscripts, einsum_subscripts_with, einsum_with};
 
 #[cfg(test)]
 mod tests;

--- a/crates/tenferro-einsum/src/tensordot.rs
+++ b/crates/tenferro-einsum/src/tensordot.rs
@@ -116,8 +116,8 @@ pub(crate) fn validate_traced_contract_dims(
         .iter()
         .zip(config.rhs_contracting_dims.iter())
     {
-        let lhs_dim = lhs.axis_sym_dim(lhs_axis);
-        let rhs_dim = rhs.axis_sym_dim(rhs_axis);
+        let lhs_dim = lhs.axis_sym_dim(lhs_axis)?;
+        let rhs_dim = rhs.axis_sym_dim(rhs_axis)?;
         if lhs_dim == rhs_dim {
             continue;
         }

--- a/crates/tenferro-einsum/src/tensordot/tests.rs
+++ b/crates/tenferro-einsum/src/tensordot/tests.rs
@@ -44,8 +44,8 @@ fn validate_traced_contract_dims_allows_symbolic_and_rejects_concrete_mismatch()
     .unwrap();
     validate_traced_contract_dims(&lhs, &rhs, &config).unwrap();
 
-    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let rhs = TracedTensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]);
+    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let rhs = TracedTensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]).unwrap();
     let err = validate_traced_contract_dims(&lhs, &rhs, &config).unwrap_err();
     assert!(err.to_string().contains("contracted dimensions differ"));
 }

--- a/crates/tenferro-einsum/src/tests/eager_tests.rs
+++ b/crates/tenferro-einsum/src/tests/eager_tests.rs
@@ -6,7 +6,7 @@ use crate::Subscripts;
 
 fn assert_f64_tensor(tensor: &Tensor, shape: &[usize], expected: &[f64]) {
     assert_eq!(tensor.shape(), shape);
-    assert_eq!(tensor.as_slice::<f64>(), Some(expected));
+    assert_eq!(tensor.as_slice::<f64>().unwrap(), expected);
 }
 
 #[test]
@@ -15,47 +15,47 @@ fn eager_einsum_executes_binary_and_ternary_contractions() {
     fn needs_backend(_ctx: &mut impl TensorBackend) {}
     needs_backend(&mut ctx);
 
-    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let matmul = eager_einsum(&mut ctx, &[&a, &b], "ij,jk->ik").unwrap();
     assert_eq!(matmul.shape(), &[2, 2]);
     assert_eq!(
-        matmul.as_slice::<f64>(),
-        Some([22.0, 28.0, 49.0, 64.0].as_slice())
+        matmul.as_slice::<f64>().unwrap(),
+        [22.0, 28.0, 49.0, 64.0].as_slice()
     );
 
-    let c = Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0]);
+    let c = Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0]).unwrap();
     let chain = eager_einsum(&mut ctx, &[&a, &b, &c], "ij,jk,kl->il").unwrap();
     assert_eq!(chain.shape(), &[2, 1]);
-    assert_eq!(chain.as_slice::<f64>(), Some([120.0, 156.0].as_slice()));
+    assert_eq!(chain.as_slice::<f64>().unwrap(), [120.0, 156.0].as_slice());
 }
 
 #[test]
 fn eager_einsum_handles_outer_products_and_diagonal_patterns() {
     let mut ctx = CpuBackend::new();
 
-    let lhs = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let rhs = Tensor::from_vec_col_major(vec![3], vec![3.0_f64, 4.0, 5.0]);
+    let lhs = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![3], vec![3.0_f64, 4.0, 5.0]).unwrap();
     let outer = eager_einsum(&mut ctx, &[&lhs, &rhs], "i,j->ij").unwrap();
     assert_eq!(outer.shape(), &[2, 3]);
     assert_eq!(
-        outer.as_slice::<f64>(),
-        Some([3.0, 6.0, 4.0, 8.0, 5.0, 10.0].as_slice())
+        outer.as_slice::<f64>().unwrap(),
+        [3.0, 6.0, 4.0, 8.0, 5.0, 10.0].as_slice()
     );
 
-    let matrix = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let matrix = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let diagonal = eager_einsum(&mut ctx, &[&matrix], "ii->i").unwrap();
     let trace = eager_einsum(&mut ctx, &[&matrix], "ii->").unwrap();
     assert_eq!(diagonal.shape(), &[2]);
-    assert_eq!(diagonal.as_slice::<f64>(), Some([1.0, 4.0].as_slice()));
+    assert_eq!(diagonal.as_slice::<f64>().unwrap(), [1.0, 4.0].as_slice());
     assert_eq!(trace.shape(), &[] as &[usize]);
-    assert_eq!(trace.as_slice::<f64>(), Some([5.0].as_slice()));
+    assert_eq!(trace.as_slice::<f64>().unwrap(), [5.0].as_slice());
 
     let embedded = eager_einsum(&mut ctx, &[&lhs], "i->ii").unwrap();
     assert_eq!(embedded.shape(), &[2, 2]);
     assert_eq!(
-        embedded.as_slice::<f64>(),
-        Some([1.0, 0.0, 0.0, 2.0].as_slice())
+        embedded.as_slice::<f64>().unwrap(),
+        [1.0, 0.0, 0.0, 2.0].as_slice()
     );
 }
 
@@ -67,14 +67,15 @@ fn eager_einsum_handles_higher_rank_repeated_labels() {
         vec![
             1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
         ],
-    );
+    )
+    .unwrap();
 
     let diagonal = eager_einsum(&mut ctx, &[&tensor], "iij->ij").unwrap();
 
     assert_eq!(diagonal.shape(), &[2, 3]);
     assert_eq!(
-        diagonal.as_slice::<f64>(),
-        Some([1.0, 4.0, 5.0, 8.0, 9.0, 12.0].as_slice())
+        diagonal.as_slice::<f64>().unwrap(),
+        [1.0, 4.0, 5.0, 8.0, 9.0, 12.0].as_slice()
     );
 }
 
@@ -84,7 +85,8 @@ fn eager_einsum_handles_three_or_more_repeated_labels() {
     let cube = Tensor::from_vec_col_major(
         vec![2, 2, 2],
         vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
-    );
+    )
+    .unwrap();
 
     let diagonal = eager_einsum(&mut ctx, &[&cube], "iii->i").unwrap();
     assert_f64_tensor(&diagonal, &[2], &[1.0, 8.0]);
@@ -92,11 +94,12 @@ fn eager_einsum_handles_three_or_more_repeated_labels() {
     let hypercube = Tensor::from_vec_col_major(
         vec![2, 2, 2, 2],
         (1..=16).map(|value| value as f64).collect(),
-    );
+    )
+    .unwrap();
     let trace = eager_einsum(&mut ctx, &[&hypercube], "iiii->").unwrap();
     assert_f64_tensor(&trace, &[], &[17.0]);
 
-    let rhs = Tensor::from_vec_col_major(vec![3], vec![2.0_f64, 3.0, 5.0]);
+    let rhs = Tensor::from_vec_col_major(vec![3], vec![2.0_f64, 3.0, 5.0]).unwrap();
     let mixed = eager_einsum(&mut ctx, &[&cube, &rhs], "iii,j->ij").unwrap();
     assert_f64_tensor(&mixed, &[2, 3], &[2.0, 16.0, 3.0, 24.0, 5.0, 40.0]);
 }
@@ -107,8 +110,8 @@ fn eager_einsum_read_views_match_owned_inputs() {
     let b_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
     let a_shape = [2, 3];
     let b_shape = [3, 2];
-    let a_owned = Tensor::from_vec_col_major(a_shape.to_vec(), a_data.to_vec());
-    let b_owned = Tensor::from_vec_col_major(b_shape.to_vec(), b_data.to_vec());
+    let a_owned = Tensor::from_vec_col_major(a_shape.to_vec(), a_data.to_vec()).unwrap();
+    let b_owned = Tensor::from_vec_col_major(b_shape.to_vec(), b_data.to_vec()).unwrap();
 
     let mut owned_ctx = CpuBackend::new();
     let owned = eager_einsum(&mut owned_ctx, &[&a_owned, &b_owned], "ij,jk->ik").unwrap();
@@ -128,8 +131,8 @@ fn eager_einsum_read_views_match_owned_inputs() {
 #[test]
 fn eager_einsum_binary_contract_reorders_fast_path_output() {
     let mut ctx = CpuBackend::new();
-    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
 
     let result = eager_einsum(&mut ctx, &[&a, &b], "ij,jk->ki").unwrap();
 
@@ -168,13 +171,13 @@ fn eager_einsum_read_fast_path_handles_batched_contracts() {
     let read = eager_einsum_read_subscripts(&mut read_ctx, &inputs, &subscripts).unwrap();
 
     assert_eq!(read.shape(), &[2, 2, 2]);
-    assert_eq!(read.as_slice::<f64>(), Some(expected.as_slice()));
+    assert_eq!(read.as_slice::<f64>().unwrap(), expected.as_slice());
 }
 
 #[test]
 fn eager_einsum_rejects_empty_inputs_and_operand_count_mismatch() {
     let mut ctx = CpuBackend::new();
-    let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
 
     let empty = eager_einsum(&mut ctx, &[], "->").unwrap_err();
     assert!(matches!(
@@ -200,24 +203,25 @@ fn eager_einsum_owned_matches_borrowed_for_representative_cases() {
     let cases: Vec<(&str, Vec<Tensor>)> = vec![
         (
             "ii->i",
-            vec![Tensor::from_vec_col_major(
-                vec![2, 2],
-                vec![1.0_f64, 2.0, 3.0, 4.0],
-            )],
+            vec![Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap()],
         ),
         (
             "ij,jk->ik",
             vec![
-                Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
-                Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+                Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+                    .unwrap(),
+                Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+                    .unwrap(),
             ],
         ),
         (
             "ij,jk,kl->il",
             vec![
-                Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
-                Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
-                Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0]),
+                Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+                    .unwrap(),
+                Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+                    .unwrap(),
+                Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0]).unwrap(),
             ],
         ),
         (
@@ -226,27 +230,31 @@ fn eager_einsum_owned_matches_borrowed_for_representative_cases() {
                 Tensor::from_vec_col_major(
                     vec![2, 2, 2],
                     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
-                ),
+                )
+                .unwrap(),
                 Tensor::from_vec_col_major(
                     vec![2, 2, 2],
                     vec![2.0_f64, 1.0, 0.5, 3.0, 1.5, 2.5, 4.0, 0.25],
-                ),
+                )
+                .unwrap(),
             ],
         ),
         (
             "bi,bj,bk->bijk",
             vec![
-                Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
-                Tensor::from_vec_col_major(vec![2, 3], vec![2.0_f64, 3.0, 4.0, 5.0, 6.0, 7.0]),
-                Tensor::from_vec_col_major(vec![2, 2], vec![1.5_f64, 0.5, 2.5, 1.0]),
+                Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
+                Tensor::from_vec_col_major(vec![2, 3], vec![2.0_f64, 3.0, 4.0, 5.0, 6.0, 7.0])
+                    .unwrap(),
+                Tensor::from_vec_col_major(vec![2, 2], vec![1.5_f64, 0.5, 2.5, 1.0]).unwrap(),
             ],
         ),
         (
             "bi,bj,bk->ijk",
             vec![
-                Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
-                Tensor::from_vec_col_major(vec![2, 3], vec![2.0_f64, 3.0, 4.0, 5.0, 6.0, 7.0]),
-                Tensor::from_vec_col_major(vec![2, 2], vec![1.5_f64, 0.5, 2.5, 1.0]),
+                Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
+                Tensor::from_vec_col_major(vec![2, 3], vec![2.0_f64, 3.0, 4.0, 5.0, 6.0, 7.0])
+                    .unwrap(),
+                Tensor::from_vec_col_major(vec![2, 2], vec![1.5_f64, 0.5, 2.5, 1.0]).unwrap(),
             ],
         ),
     ];
@@ -275,8 +283,8 @@ fn eager_einsum_owned_matches_borrowed_for_representative_cases() {
 #[test]
 fn eager_einsum_owned_reclaims_consumed_input_buffers() {
     let mut ctx = CpuBackend::new();
-    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
 
     let result = eager_einsum_owned(&mut ctx, vec![a, b], "ij,jk->ik").unwrap();
 

--- a/crates/tenferro-einsum/src/traced.rs
+++ b/crates/tenferro-einsum/src/traced.rs
@@ -15,8 +15,6 @@ use crate::cache::{
     einsum_subscripts_retained_bytes, saturating_sum, vec_retained_bytes, ParsedEinsum,
     EINSUM_EXTENSION_FAMILY_ID, EINSUM_PARSE_CACHE, EINSUM_STATIC_PLANS_CACHE,
 };
-#[cfg(feature = "autodiff")]
-use crate::extension::ensure_einsum_extension_rule_registered;
 use crate::extension::EinsumExtensionOp;
 use crate::optimize::{
     hash_einsum_plan_spec, plan_spec_from_optimize, resolve_einsum_strategy_with_spec,
@@ -115,9 +113,6 @@ pub fn einsum_subscripts_with(
         return Ok(result);
     }
 
-    #[cfg(feature = "autodiff")]
-    ensure_einsum_extension_rule_registered().map_err(|err| Error::Internal(err.to_string()))?;
-
     let subs = Subscripts::from(subscripts);
 
     let (plan_spec, static_tree) = if let Some(shapes) = concrete_shapes(inputs) {
@@ -165,7 +160,7 @@ pub fn einsum_subscripts_with(
 
     let op =
         EinsumExtensionOp::with_output_shape_hint(subscripts.clone(), output_shape_hint, plan_spec);
-    let outputs = extension::try_apply(Arc::new(op), inputs)?;
+    let outputs = extension::apply(Arc::new(op), inputs)?;
     outputs
         .into_iter()
         .next()
@@ -186,17 +181,13 @@ fn expand_traced_einsum_graph(
     let input_dtypes: Vec<_> = inputs.iter().map(|tensor| tensor.dtype).collect();
     let input_sym_shapes: Vec<Vec<SymDim>> = inputs
         .iter()
-        .map(|tensor| {
-            tensor
-                .sym_shape()
-                .map(|shape| shape.to_vec())
-                .unwrap_or_else(|| {
-                    (0..tensor.rank)
-                        .map(|axis| tensor.axis_sym_dim(axis))
-                        .collect()
-                })
+        .map(|tensor| match tensor.sym_shape() {
+            Some(shape) => Ok(shape.to_vec()),
+            None => (0..tensor.rank)
+                .map(|axis| tensor.axis_sym_dim(axis))
+                .collect(),
         })
-        .collect();
+        .collect::<Result<_>>()?;
     let input_sym_shape_refs: Vec<_> = input_sym_shapes.iter().map(Vec::as_slice).collect();
     let output_metas = op.infer_output_meta(&input_dtypes, &input_sym_shape_refs);
     let input_dim_shapes = traced_dim_expr_shapes(inputs);
@@ -270,8 +261,8 @@ fn try_direct_binary_dot_general(
     };
 
     let result = match plan.operand_order {
-        BinaryDotOperandOrder::Original => inputs[0].dot_general(inputs[1], plan.config),
-        BinaryDotOperandOrder::Swapped => inputs[1].dot_general(inputs[0], plan.config),
+        BinaryDotOperandOrder::Original => inputs[0].dot_general(inputs[1], plan.config)?,
+        BinaryDotOperandOrder::Swapped => inputs[1].dot_general(inputs[0], plan.config)?,
     };
     Ok(Some(result))
 }
@@ -388,14 +379,12 @@ fn infer_symbolic_output_shape(
 ) -> Result<Vec<SymDim>> {
     let mut label_dims = std::collections::HashMap::new();
     for (labels, tensor) in subscripts.inputs.iter().zip(inputs.iter()) {
-        let shape: Vec<_> = tensor
-            .sym_shape()
-            .map(|shape| shape.to_vec())
-            .unwrap_or_else(|| {
-                (0..tensor.rank)
-                    .map(|axis| tensor.axis_sym_dim(axis))
-                    .collect()
-            });
+        let shape: Vec<_> = match tensor.sym_shape() {
+            Some(shape) => shape.to_vec(),
+            None => (0..tensor.rank)
+                .map(|axis| tensor.axis_sym_dim(axis))
+                .collect::<Result<_>>()?,
+        };
         if labels.len() != shape.len() {
             return Err(Error::ContractionError(format!(
                 "einsum input rank mismatch: labels={}, shape={}",

--- a/crates/tenferro-einsum/src/traced/tests.rs
+++ b/crates/tenferro-einsum/src/traced/tests.rs
@@ -6,9 +6,9 @@ use crate::EinsumOptimize;
 
 #[test]
 fn concrete_traced_nary_einsum_expands_to_standard_graph() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let b = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
-    let c = TracedTensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
+    let c = TracedTensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]).unwrap();
     let mut compiler = GraphCompiler::new();
 
     let out = einsum(&mut compiler, &[&a, &b, &c], "ij,jk,kl->il").unwrap();

--- a/crates/tenferro-einsum/src/traced_tensor.rs
+++ b/crates/tenferro-einsum/src/traced_tensor.rs
@@ -1,7 +1,7 @@
 //! Traced tensor einsum operations.
 //!
 //! This module is the canonical traced tensor namespace for the einsum
-//! extension crate. Root-level re-exports remain available for compatibility.
+//! extension crate.
 
 use tenferro_runtime::error::Result;
 use tenferro_runtime::TracedTensor;
@@ -36,5 +36,5 @@ pub fn tensordot(
 ) -> Result<TracedTensor> {
     let config = crate::tensordot::dot_general_config(axes, lhs.rank, rhs.rank)?;
     crate::tensordot::validate_traced_contract_dims(lhs, rhs, &config)?;
-    Ok(lhs.dot_general(rhs, config))
+    lhs.dot_general(rhs, config)
 }

--- a/crates/tenferro-einsum/src/typed_eager.rs
+++ b/crates/tenferro-einsum/src/typed_eager.rs
@@ -17,9 +17,9 @@ pub(crate) fn typed_eager_einsum<T: TensorScalar>(
     let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
     let result = eager_einsum_read_subscripts(ctx, &reads, &subscripts)?;
     let actual = result.dtype();
-    T::try_into_typed(result).ok_or_else(|| Error::DTypeMismatch {
+    T::into_typed(result).map_err(|_| Error::DTypeMismatch {
         op: "typed_eager_einsum",
-        lhs: actual,
-        rhs: T::dtype(),
+        lhs: T::dtype(),
+        rhs: actual,
     })
 }

--- a/crates/tenferro-einsum/src/typed_eager_tests.rs
+++ b/crates/tenferro-einsum/src/typed_eager_tests.rs
@@ -118,10 +118,9 @@ impl TensorDot for WrongDTypeBackend {
         _rhs: &Tensor,
         _config: &DotGeneralConfig,
     ) -> tenferro_tensor::Result<Tensor> {
-        Ok(Tensor::F64(TypedTensor::from_vec_col_major(
-            vec![2, 2],
-            vec![1.0, 2.0, 3.0, 4.0],
-        )))
+        Ok(Tensor::F64(
+            TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap(),
+        ))
     }
 }
 
@@ -145,14 +144,16 @@ fn typed_einsum_f64() {
     }
     let mut ctx = CpuBackend::new();
     let lhs =
-        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
     let rhs =
-        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
 
     let result = typed_eager_einsum(&mut ctx, &[&lhs, &rhs], "ij,jk->ik").unwrap();
 
     assert_eq!(result.shape(), &[2, 2]);
-    assert_eq!(result.as_slice(), &[22.0, 28.0, 49.0, 64.0]);
+    assert_eq!(result.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
 }
 
 #[test]
@@ -162,10 +163,11 @@ fn eager_einsum_subscripts_and_read_views_use_integer_api() {
         std::env::set_var("TENFERRO_PROFILE_EAGER_EINSUM_PRINT_EVERY", "1");
     }
     let mut ctx = CpuBackend::new();
-    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let rhs_shape = [3usize, 2];
     let rhs_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
-    let rhs = Tensor::from_vec_col_major(rhs_shape.to_vec(), rhs_data.to_vec());
+    let rhs = Tensor::from_vec_col_major(rhs_shape.to_vec(), rhs_data.to_vec()).unwrap();
     let subscripts = Subscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
 
     let borrowed = eager_einsum_subscripts(&mut ctx, &[&lhs, &rhs], &subscripts).unwrap();
@@ -188,8 +190,8 @@ fn eager_einsum_subscripts_and_read_views_use_integer_api() {
 
 #[test]
 fn eager_einsum_owned_matches_borrowed() {
-    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
 
     let mut borrowed_ctx = CpuBackend::new();
     let borrowed = eager_einsum(&mut borrowed_ctx, &[&a, &b], "ij,jk->ik").unwrap();
@@ -205,9 +207,10 @@ fn eager_einsum_owned_matches_borrowed() {
 #[test]
 fn eager_einsum_owned_subscripts_handles_three_operands() {
     let mut ctx = CpuBackend::new();
-    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let b = Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0]);
-    let c = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 1.0, 3.0]);
+    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let b =
+        Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0]).unwrap();
+    let c = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 1.0, 3.0]).unwrap();
     let subscripts = Subscripts::new(&[&[0, 1], &[1, 2], &[2, 3]], &[0, 3]);
 
     let result = eager_einsum_owned_subscripts(&mut ctx, vec![a, b, c], &subscripts).unwrap();
@@ -222,24 +225,28 @@ fn eager_einsum_owned_subscripts_handles_three_operands() {
 #[test]
 fn typed_einsum_f64_three_operands() {
     let mut ctx = CpuBackend::new();
-    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
     let b =
-        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0]);
-    let c = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 1.0, 3.0]);
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![7.0, 8.0, 9.0, 10.0, 11.0, 12.0])
+            .unwrap();
+    let c = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0, 0.0, 1.0, 3.0]).unwrap();
 
     let result = typed_eager_einsum(&mut ctx, &[&a, &b, &c], "ij,jk,kl->il").unwrap();
 
     assert_eq!(result.shape(), &[2, 2]);
-    assert_eq!(result.as_slice(), &[152.0, 200.0, 385.0, 508.0]);
+    assert_eq!(result.as_slice().unwrap(), &[152.0, 200.0, 385.0, 508.0]);
 }
 
 #[test]
 fn typed_einsum_reports_dtype_mismatch_from_backend_result() {
     let mut ctx = WrongDTypeBackend;
     let lhs =
-        TypedTensor::<f32>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        TypedTensor::<f32>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
     let rhs =
-        TypedTensor::<f32>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        TypedTensor::<f32>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
 
     let err = typed_eager_einsum(&mut ctx, &[&lhs, &rhs], "ij,jk->ik").unwrap_err();
 
@@ -247,16 +254,16 @@ fn typed_einsum_reports_dtype_mismatch_from_backend_result() {
         err,
         tenferro_tensor::Error::DTypeMismatch {
             op: "typed_eager_einsum",
-            lhs: DType::F64,
-            rhs: DType::F32,
+            lhs: DType::F32,
+            rhs: DType::F64,
         }
     ));
 }
 
 #[test]
 fn tensor_backend_default_cached_methods_delegate_to_backend_ops() {
-    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1], vec![1.0]));
-    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1], vec![3.0]));
+    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1], vec![1.0]).unwrap());
+    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1], vec![3.0]).unwrap());
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],

--- a/crates/tenferro-einsum/tests/eager_tensor.rs
+++ b/crates/tenferro-einsum/tests/eager_tensor.rs
@@ -24,11 +24,11 @@ fn test_ctx() -> Arc<EagerRuntime> {
 fn eager_tensor_einsum_matmul_primal_matches_expected_values() {
     let ctx = test_ctx();
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
 
@@ -42,14 +42,16 @@ fn eager_tensor_einsum_matmul_primal_matches_expected_values() {
 fn eager_tensor_tensordot_count_contracts_last_lhs_with_first_rhs_axes() {
     let ctx = test_ctx();
     let lhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3, 4], (1..=24).map(f64::from).collect::<Vec<_>>()),
+        Tensor::from_vec_col_major(vec![2, 3, 4], (1..=24).map(f64::from).collect::<Vec<_>>())
+            .unwrap(),
         ctx.clone(),
     );
     let rhs = EagerTensor::from_tensor_in(
         Tensor::from_vec_col_major(
             vec![3, 4, 2],
             (1..=24).map(|value| f64::from(value) * 0.5).collect(),
-        ),
+        )
+        .unwrap(),
         ctx.clone(),
     );
 
@@ -63,11 +65,11 @@ fn eager_tensor_tensordot_count_contracts_last_lhs_with_first_rhs_axes() {
 fn eager_tensor_tensordot_explicit_axes_accept_negative_indices() {
     let ctx = test_ctx();
     let lhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
     let rhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
 
@@ -89,11 +91,11 @@ fn eager_tensor_tensordot_explicit_axes_accept_negative_indices() {
 fn eager_tensor_tensordot_rejects_shape_mismatch() {
     let ctx = test_ctx();
     let lhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap(),
         ctx.clone(),
     );
     let rhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]),
+        Tensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]).unwrap(),
         ctx.clone(),
     );
 
@@ -109,11 +111,11 @@ fn eager_tensor_tensordot_rejects_shape_mismatch() {
 fn eager_tensor_tensordot_rejects_explicit_out_of_bounds_axis() {
     let ctx = test_ctx();
     let lhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap(),
         ctx.clone(),
     );
     let rhs = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]),
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap(),
         ctx.clone(),
     );
 
@@ -136,11 +138,11 @@ fn eager_tensor_tensordot_rejects_explicit_out_of_bounds_axis() {
 fn eager_tensor_einsum_integer_subscripts_match_string_path() {
     let ctx = test_ctx();
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
     let subscripts = EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]);
@@ -155,11 +157,11 @@ fn eager_tensor_einsum_integer_subscripts_match_string_path() {
 fn eager_tensor_einsum_backward_populates_input_grads() {
     let ctx = test_ctx();
     let a = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
 
@@ -167,8 +169,8 @@ fn eager_tensor_einsum_backward_populates_input_grads() {
     let loss = c.reduce_sum(&[0, 1]).unwrap();
     let _cotangents = loss.backward().unwrap();
 
-    let grad_a = a.grad().unwrap();
-    let grad_b = b.grad().unwrap();
+    let grad_a = a.grad().unwrap().unwrap();
+    let grad_b = b.grad().unwrap().unwrap();
 
     assert_eq!(grad_a.shape(), &[2, 3]);
     assert_eq!(grad_b.shape(), &[3, 2]);
@@ -180,11 +182,11 @@ fn eager_tensor_einsum_backward_populates_input_grads() {
 fn eager_tensor_einsum_repeated_backward_accumulates_across_calls() {
     let ctx = test_ctx();
     let a = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
 
@@ -192,11 +194,11 @@ fn eager_tensor_einsum_repeated_backward_accumulates_across_calls() {
     let loss = c.reduce_sum(&[0, 1]).unwrap();
     let _ = loss.backward().unwrap();
     assert_eq!(
-        f64_data(a.grad().unwrap().as_ref()),
+        f64_data(a.grad().unwrap().unwrap().as_ref()),
         &[5.0, 5.0, 7.0, 7.0, 9.0, 9.0]
     );
     assert_eq!(
-        f64_data(b.grad().unwrap().as_ref()),
+        f64_data(b.grad().unwrap().unwrap().as_ref()),
         &[3.0, 7.0, 11.0, 3.0, 7.0, 11.0]
     );
 
@@ -204,11 +206,11 @@ fn eager_tensor_einsum_repeated_backward_accumulates_across_calls() {
     let loss = c.reduce_sum(&[0, 1]).unwrap();
     let _ = loss.backward().unwrap();
     assert_eq!(
-        f64_data(a.grad().unwrap().as_ref()),
+        f64_data(a.grad().unwrap().unwrap().as_ref()),
         &[10.0, 10.0, 14.0, 14.0, 18.0, 18.0]
     );
     assert_eq!(
-        f64_data(b.grad().unwrap().as_ref()),
+        f64_data(b.grad().unwrap().unwrap().as_ref()),
         &[6.0, 14.0, 22.0, 6.0, 14.0, 22.0]
     );
 }
@@ -217,11 +219,11 @@ fn eager_tensor_einsum_repeated_backward_accumulates_across_calls() {
 fn eager_tensor_einsum_context_clear_grads_resets_all_live_leaves() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let a = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]),
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
         ctx.clone(),
     );
 
@@ -229,21 +231,21 @@ fn eager_tensor_einsum_context_clear_grads_resets_all_live_leaves() {
     let loss = c.reduce_sum(&[0, 1]).unwrap();
     let _ = loss.backward().unwrap();
 
-    ctx.clear_grads();
+    ctx.clear_grads().unwrap();
 
-    assert!(a.grad().is_none());
-    assert!(b.grad().is_none());
+    assert!(a.grad().unwrap().is_none());
+    assert!(b.grad().unwrap().is_none());
 
     let c = einsum(&[&a, &b], "ij,jk->ik").unwrap();
     let loss = c.reduce_sum(&[0, 1]).unwrap();
     let _ = loss.backward().unwrap();
 
     assert_eq!(
-        f64_data(a.grad().unwrap().as_ref()),
+        f64_data(a.grad().unwrap().unwrap().as_ref()),
         &[5.0, 5.0, 7.0, 7.0, 9.0, 9.0]
     );
     assert_eq!(
-        f64_data(b.grad().unwrap().as_ref()),
+        f64_data(b.grad().unwrap().unwrap().as_ref()),
         &[3.0, 7.0, 11.0, 3.0, 7.0, 11.0]
     );
 }

--- a/crates/tenferro-einsum/tests/runtime_buffer_pool.rs
+++ b/crates/tenferro-einsum/tests/runtime_buffer_pool.rs
@@ -2,12 +2,12 @@ use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{GraphCompiler, GraphExecutor, Tensor, TracedTensor, TypedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn get_f64_data(tensor: &Tensor) -> &[f64] {
     match tensor {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner.host_data().unwrap(),
         _ => panic!("expected F64"),
     }
 }
@@ -27,7 +27,9 @@ fn cpu_backend_pool_reuses_nary_einsum_intermediates() {
     let ta1 = TracedTensor::from_tensor_concrete_shape(a.clone());
     let tb1 = TracedTensor::from_tensor_concrete_shape(b.clone());
     let tc1 = TracedTensor::from_tensor_concrete_shape(c.clone());
-    let out1 = tenferro_einsum::einsum(&mut compiler, &[&ta1, &tb1, &tc1], "ij,jk,kl->il").unwrap();
+    let out1 =
+        tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&ta1, &tb1, &tc1], "ij,jk,kl->il")
+            .unwrap();
     let program1 = compiler.compile(&out1).unwrap();
 
     let result1 = engine.run(&program1).unwrap();
@@ -39,7 +41,9 @@ fn cpu_backend_pool_reuses_nary_einsum_intermediates() {
     let ta2 = TracedTensor::from_tensor_concrete_shape(a);
     let tb2 = TracedTensor::from_tensor_concrete_shape(b);
     let tc2 = TracedTensor::from_tensor_concrete_shape(c);
-    let out2 = tenferro_einsum::einsum(&mut compiler, &[&ta2, &tb2, &tc2], "ij,jk,kl->il").unwrap();
+    let out2 =
+        tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&ta2, &tb2, &tc2], "ij,jk,kl->il")
+            .unwrap();
     let program2 = compiler.compile(&out2).unwrap();
 
     let result2 = engine.run(&program2).unwrap();

--- a/crates/tenferro-einsum/tests/traced_ad_migration.rs
+++ b/crates/tenferro-einsum/tests/traced_ad_migration.rs
@@ -6,7 +6,7 @@ use tenferro_einsum::EinsumOptimize;
 use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::from_vec_col_major(shape, data)
+    Tensor::from_vec_col_major(shape, data).unwrap()
 }
 
 fn run_traced(tensor: &TracedTensor) -> Tensor {
@@ -98,14 +98,14 @@ fn grad_einsum_matmul_real_uses_extension_ad_rule() {
     ));
     let mut compiler = GraphCompiler::new();
 
-    let y = tenferro_einsum::einsum_with(
+    let y = tenferro_einsum::traced_tensor::einsum_with(
         &mut compiler,
         &[&a, &b],
         "ij,jk->ik",
         EinsumOptimize::Path(vec![(0, 1)]),
     )
     .unwrap();
-    let grad_a = y.reduce_sum(&[0, 1]).grad(&a).unwrap();
+    let grad_a = y.reduce_sum(&[0, 1]).unwrap().grad(&a).unwrap();
     let result = run_traced(&grad_a);
 
     assert_eq!(result.shape(), &[2, 3]);
@@ -123,14 +123,14 @@ fn grad_einsum_matmul_real_matches_finite_diff_for_both_inputs() {
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], b_data.clone()));
     let mut compiler = GraphCompiler::new();
 
-    let y = tenferro_einsum::einsum_with(
+    let y = tenferro_einsum::traced_tensor::einsum_with(
         &mut compiler,
         &[&a, &b],
         "ij,jk->ik",
         EinsumOptimize::Path(vec![(0, 1)]),
     )
     .unwrap();
-    let loss = y.reduce_sum(&[0, 1]);
+    let loss = y.reduce_sum(&[0, 1]).unwrap();
     let grad_a = run_traced(&loss.grad(&a).unwrap());
     let grad_b = run_traced(&loss.grad(&b).unwrap());
 
@@ -138,14 +138,14 @@ fn grad_einsum_matmul_real_matches_finite_diff_for_both_inputs() {
         let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 3], lhs.to_vec()));
         let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], rhs.to_vec()));
         let mut compiler = GraphCompiler::new();
-        let y = tenferro_einsum::einsum_with(
+        let y = tenferro_einsum::traced_tensor::einsum_with(
             &mut compiler,
             &[&a, &b],
             "ij,jk->ik",
             EinsumOptimize::Path(vec![(0, 1)]),
         )
         .unwrap();
-        run_traced(&y.reduce_sum(&[0, 1]))
+        run_traced(&y.reduce_sum(&[0, 1]).unwrap())
             .as_slice::<f64>()
             .unwrap()[0]
     };
@@ -173,14 +173,14 @@ fn symbolic_grad_einsum_with_explicit_path_uses_extension_ad_rule() {
     let c = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let mut compiler = GraphCompiler::new();
 
-    let y = tenferro_einsum::einsum_with(
+    let y = tenferro_einsum::traced_tensor::einsum_with(
         &mut compiler,
         &[&a, &b, &c],
         "ij,jk,kl->il",
         tenferro_einsum::EinsumOptimize::Path(vec![(1, 2), (0, 1)]),
     )
     .unwrap();
-    let loss = y.reduce_sum(&[0, 1]);
+    let loss = y.reduce_sum(&[0, 1]).unwrap();
     let grad_a = loss.grad(&a).unwrap();
     let grad_b = loss.grad(&b).unwrap();
     let grad_c = loss.grad(&c).unwrap();

--- a/crates/tenferro-einsum/tests/traced_correctness.rs
+++ b/crates/tenferro-einsum/tests/traced_correctness.rs
@@ -21,12 +21,12 @@ mod ported_and_paths;
 // ============================================================================
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn get_f64_data(t: &Tensor) -> &[f64] {
     match t {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner.host_data().unwrap(),
         _ => panic!("expected F64"),
     }
 }
@@ -53,7 +53,9 @@ fn einsum<C: TestEinsumContext>(
     inputs: &[&TracedTensor],
     subscripts: &str,
 ) -> Result<TracedTensor> {
-    ctx.with_compiler(|compiler| tenferro_einsum::einsum(compiler, inputs, subscripts))
+    ctx.with_compiler(|compiler| {
+        tenferro_einsum::traced_tensor::einsum(compiler, inputs, subscripts)
+    })
 }
 
 fn einsum_with<C: TestEinsumContext>(
@@ -63,7 +65,7 @@ fn einsum_with<C: TestEinsumContext>(
     optimize: EinsumOptimize,
 ) -> Result<TracedTensor> {
     ctx.with_compiler(|compiler| {
-        tenferro_einsum::einsum_with(compiler, inputs, subscripts, optimize)
+        tenferro_einsum::traced_tensor::einsum_with(compiler, inputs, subscripts, optimize)
     })
 }
 
@@ -95,7 +97,7 @@ fn extension_cache_entries(compiler: &GraphCompiler) -> usize {
 /// Read a single element from a v2 Tensor by multi-index (col-major).
 fn get_v2(t: &Tensor, idx: &[usize]) -> f64 {
     match t {
-        Tensor::F64(inner) => *inner.get(idx),
+        Tensor::F64(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected F64"),
     }
 }
@@ -133,7 +135,7 @@ fn assert_close(a: f64, b: f64, label: &str) {
 
 fn symbolic_identity_2d(input: &TracedTensor) -> TracedTensor {
     input
-        .reshape_sym(&[input.sym_size(0), input.sym_size(1)])
+        .reshape_sym(&[input.sym_size(0).unwrap(), input.sym_size(1).unwrap()])
         .unwrap()
 }
 
@@ -144,8 +146,8 @@ fn symbolic_identity_2d(input: &TracedTensor) -> TracedTensor {
 #[test]
 fn traced_tensor_namespace_exposes_einsum() {
     let mut compiler = GraphCompiler::new();
-    let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]);
-    let b = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
     let y = tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&a, &b], "ij,jk->ik").unwrap();
 
     assert_eq!(y.rank, 2);
@@ -156,11 +158,13 @@ fn traced_tensor_namespace_tensordot_count_contracts_last_lhs_with_first_rhs_axe
     let lhs = TracedTensor::from_vec_col_major(
         vec![2, 3, 4],
         (1..=24).map(f64::from).collect::<Vec<_>>(),
-    );
+    )
+    .unwrap();
     let rhs = TracedTensor::from_vec_col_major(
         vec![3, 4, 2],
         (1..=24).map(|value| f64::from(value) * 0.5).collect(),
-    );
+    )
+    .unwrap();
 
     let out =
         tenferro_einsum::traced_tensor::tensordot(&lhs, &rhs, TensorDotAxes::Count(2)).unwrap();
@@ -176,8 +180,10 @@ fn traced_tensor_namespace_tensordot_count_contracts_last_lhs_with_first_rhs_axe
 
 #[test]
 fn traced_tensor_namespace_tensordot_explicit_axes_accept_negative_indices() {
-    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let rhs = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
+    let rhs = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
 
     let out = tenferro_einsum::traced_tensor::tensordot(
         &lhs,
@@ -197,8 +203,8 @@ fn traced_tensor_namespace_tensordot_explicit_axes_accept_negative_indices() {
 
 #[test]
 fn traced_tensor_namespace_tensordot_rejects_invalid_axes() {
-    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let rhs = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
+    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let rhs = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
 
     let duplicate = match tenferro_einsum::traced_tensor::tensordot(
         &lhs,

--- a/crates/tenferro-einsum/tests/traced_correctness/ported_and_paths.rs
+++ b/crates/tenferro-einsum/tests/traced_correctness/ported_and_paths.rs
@@ -476,12 +476,12 @@ fn einsum_with_path_rejects_structurally_invalid_paths() {
 // ============================================================================
 
 fn c64_tensor(shape: Vec<usize>, data: Vec<Complex64>) -> Tensor {
-    Tensor::C64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::C64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn get_c64(t: &Tensor, idx: &[usize]) -> Complex64 {
     match t {
-        Tensor::C64(inner) => *inner.get(idx),
+        Tensor::C64(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected C64"),
     }
 }
@@ -667,19 +667,19 @@ fn einsum_binary_diag_ii_jk_to_ijk() {
 fn einsum_binary_diag_iij_jk_to_ik() {
     // "iij,jk->ik" — diagonal extraction + contraction
     let a = {
-        let mut t = TypedTensor::<f64>::zeros(vec![2, 2, 3]);
-        *t.get_mut(&[0, 0, 0]) = 1.0;
-        *t.get_mut(&[1, 1, 0]) = 4.0;
-        *t.get_mut(&[0, 0, 1]) = 2.0;
-        *t.get_mut(&[1, 1, 1]) = 5.0;
-        *t.get_mut(&[0, 0, 2]) = 3.0;
-        *t.get_mut(&[1, 1, 2]) = 6.0;
+        let mut t = TypedTensor::<f64>::zeros(vec![2, 2, 3]).unwrap();
+        *t.get_mut(&[0, 0, 0]).unwrap() = 1.0;
+        *t.get_mut(&[1, 1, 0]).unwrap() = 4.0;
+        *t.get_mut(&[0, 0, 1]).unwrap() = 2.0;
+        *t.get_mut(&[1, 1, 1]).unwrap() = 5.0;
+        *t.get_mut(&[0, 0, 2]).unwrap() = 3.0;
+        *t.get_mut(&[1, 1, 2]).unwrap() = 6.0;
         Tensor::F64(t)
     };
     let b = {
-        let mut t = TypedTensor::<f64>::zeros(vec![3, 2]);
-        *t.get_mut(&[0, 0]) = 1.0;
-        *t.get_mut(&[1, 1]) = 1.0;
+        let mut t = TypedTensor::<f64>::zeros(vec![3, 2]).unwrap();
+        *t.get_mut(&[0, 0]).unwrap() = 1.0;
+        *t.get_mut(&[1, 1]).unwrap() = 1.0;
         Tensor::F64(t)
     };
 
@@ -700,16 +700,16 @@ fn einsum_binary_diag_iij_jk_to_ik() {
 fn einsum_binary_diag_ii_jj_to_ij() {
     // "ii,jj->ij" — outer product of two traces
     let a = {
-        let mut t = TypedTensor::<f64>::zeros(vec![3, 3]);
-        *t.get_mut(&[0, 0]) = 1.0;
-        *t.get_mut(&[1, 1]) = 2.0;
-        *t.get_mut(&[2, 2]) = 3.0;
+        let mut t = TypedTensor::<f64>::zeros(vec![3, 3]).unwrap();
+        *t.get_mut(&[0, 0]).unwrap() = 1.0;
+        *t.get_mut(&[1, 1]).unwrap() = 2.0;
+        *t.get_mut(&[2, 2]).unwrap() = 3.0;
         Tensor::F64(t)
     };
     let b = {
-        let mut t = TypedTensor::<f64>::zeros(vec![2, 2]);
-        *t.get_mut(&[0, 0]) = 10.0;
-        *t.get_mut(&[1, 1]) = 20.0;
+        let mut t = TypedTensor::<f64>::zeros(vec![2, 2]).unwrap();
+        *t.get_mut(&[0, 0]).unwrap() = 10.0;
+        *t.get_mut(&[1, 1]).unwrap() = 20.0;
         Tensor::F64(t)
     };
 
@@ -904,7 +904,7 @@ fn einsum_complex_trace() {
     let expected = get_c64(&a, &[0, 0]) + get_c64(&a, &[1, 1]);
     match result {
         Tensor::C64(inner) => {
-            assert_close_c64(inner.host_data()[0], expected, "complex_trace");
+            assert_close_c64(inner.host_data().unwrap()[0], expected, "complex_trace");
         }
         _ => panic!("expected C64"),
     }

--- a/crates/tenferro-einsum/tests/traced_extension.rs
+++ b/crates/tenferro-einsum/tests/traced_extension.rs
@@ -5,11 +5,11 @@ use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TensorValue,
 
 #[test]
 fn concrete_traced_einsum_executes_without_extension_runtime() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 2, 3], vec![1.0_f64; 12]);
-    let b = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 2, 3], vec![1.0_f64; 12]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
     let mut compiler = GraphCompiler::new();
 
-    let c = tenferro_einsum::einsum(&mut compiler, &[&a, &b], "iij,jk->ik").unwrap();
+    let c = tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&a, &b], "iij,jk->ik").unwrap();
     let program = compiler.compile(&c).unwrap();
 
     let mut executor = GraphExecutor::new(CpuBackend::new());
@@ -22,11 +22,11 @@ fn concrete_traced_einsum_executes_without_extension_runtime() {
 
 #[test]
 fn traced_binary_col_major_matmul_uses_direct_dot_general_without_extension_runtime() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let b = TracedTensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]).unwrap();
     let mut compiler = GraphCompiler::new();
 
-    let c = tenferro_einsum::einsum(&mut compiler, &[&a, &b], "ji,kj->ki").unwrap();
+    let c = tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&a, &b], "ji,kj->ki").unwrap();
     let program = compiler.compile(&c).unwrap();
 
     let mut executor = GraphExecutor::new(CpuBackend::new());
@@ -39,8 +39,8 @@ fn traced_binary_col_major_matmul_uses_direct_dot_general_without_extension_runt
 
 #[test]
 fn traced_binary_tree_col_major_matmul_uses_direct_dot_general_without_extension_runtime() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let b = TracedTensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]).unwrap();
     let subs = tenferro_einsum::Subscripts::parse("ji,kj->ki").unwrap();
     let lhs_shape = [2, 3];
     let rhs_shape = [4, 2];
@@ -48,7 +48,7 @@ fn traced_binary_tree_col_major_matmul_uses_direct_dot_general_without_extension
     let tree = tenferro_einsum::ContractionTree::from_pairs(&subs, &shapes, &[(0, 1)]).unwrap();
     let mut compiler = GraphCompiler::new();
 
-    let c = tenferro_einsum::einsum_with(
+    let c = tenferro_einsum::traced_tensor::einsum_with(
         &mut compiler,
         &[&a, &b],
         "ji,kj->ki",
@@ -67,10 +67,11 @@ fn traced_binary_tree_col_major_matmul_uses_direct_dot_general_without_extension
 
 #[test]
 fn traced_einsum_final_permutation_can_return_lazy_value() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
     let mut compiler = GraphCompiler::new();
 
-    let out = tenferro_einsum::einsum(&mut compiler, &[&a], "ij->ji").unwrap();
+    let out = tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&a], "ij->ji").unwrap();
     let program = compiler.compile(&out).unwrap();
 
     let mut executor = GraphExecutor::new(CpuBackend::new());
@@ -86,7 +87,7 @@ fn traced_einsum_final_permutation_can_return_lazy_value() {
         TensorValue::Tensor(_) => panic!("final einsum permutation should stay as a lazy view"),
     }
     assert_eq!(
-        values[0].to_tensor().as_slice::<f64>().unwrap(),
+        values[0].to_tensor().unwrap().as_slice::<f64>().unwrap(),
         &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
     );
 }
@@ -103,7 +104,7 @@ fn traced_symbolic_binary_tree_col_major_matmul_uses_direct_dot_general_without_
     let tree = tenferro_einsum::ContractionTree::from_pairs(&subs, &shapes, &[(0, 1)]).unwrap();
     let mut compiler = GraphCompiler::new();
 
-    let c = tenferro_einsum::einsum_with(
+    let c = tenferro_einsum::traced_tensor::einsum_with(
         &mut compiler,
         &[&a, &b],
         "ji,kj->ki",
@@ -114,8 +115,8 @@ fn traced_symbolic_binary_tree_col_major_matmul_uses_direct_dot_general_without_
         .compile_with_input_specs(&c, &[(&a, DType::F64, &[2, 3]), (&b, DType::F64, &[4, 2])])
         .unwrap();
 
-    let a_value = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let b_value = Tensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]);
+    let a_value = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let b_value = Tensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]).unwrap();
     let mut executor = GraphExecutor::new(CpuBackend::new());
     let out = executor
         .run_with_inputs(&program, &[(&a, &a_value), (&b, &b_value)])
@@ -146,7 +147,8 @@ fn runtime_einsum_caches_are_extension_owned() {
     let y = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let mut compiler = GraphCompiler::new();
 
-    let dot = tenferro_einsum::einsum(&mut compiler, &[&x, &y], "iij,jk->ik").unwrap();
+    let dot =
+        tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&x, &y], "iij,jk->ik").unwrap();
     let program = compiler
         .compile_with_input_specs(
             &dot,
@@ -158,8 +160,8 @@ fn runtime_einsum_caches_are_extension_owned() {
     executor
         .register_extension(tenferro_einsum::register_runtime)
         .unwrap();
-    let x_value = Tensor::from_vec_col_major(vec![2, 2, 3], vec![1.0_f64; 12]);
-    let y_value = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
+    let x_value = Tensor::from_vec_col_major(vec![2, 2, 3], vec![1.0_f64; 12]).unwrap();
+    let y_value = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
     let out = executor
         .run_with_inputs(&program, &[(&x, &x_value), (&y, &y_value)])
         .unwrap();
@@ -171,18 +173,20 @@ fn runtime_einsum_caches_are_extension_owned() {
 #[test]
 #[cfg(feature = "autodiff")]
 fn traced_einsum_grad_uses_extension_ad_rule() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let b = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
     let mut compiler = GraphCompiler::new();
 
-    let y = tenferro_einsum::einsum_with(
+    let y = tenferro_einsum::traced_tensor::einsum_with(
         &mut compiler,
         &[&a, &b],
         "ij,jk->ik",
         tenferro_einsum::EinsumOptimize::Path(vec![(0, 1)]),
     )
     .unwrap();
-    let grad_a = y.reduce_sum(&[0, 1]).grad(&a).unwrap();
+    let grad_a = y.reduce_sum(&[0, 1]).unwrap().grad(&a).unwrap();
     let program = compiler.compile(&grad_a).unwrap();
 
     let mut executor = GraphExecutor::new(CpuBackend::new());

--- a/crates/tenferro-einsum/tests/traced_graph_cache.rs
+++ b/crates/tenferro-einsum/tests/traced_graph_cache.rs
@@ -5,7 +5,9 @@ use std::num::NonZeroUsize;
 use tenferro_ad::EagerRuntime;
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::{
-    eager_tensor::einsum as eager_einsum, einsum, einsum_with, parse_einsum_subscripts,
+    eager_tensor::einsum as eager_einsum,
+    parse_einsum_subscripts,
+    traced_tensor::{einsum, einsum_with},
     ContractionOptimizerOptions, ContractionTree, EinsumOptimize,
 };
 use tenferro_runtime::extension::ExtensionCacheLimits;
@@ -21,11 +23,13 @@ fn run_static_matmul(compiler: &mut GraphCompiler, rows: usize, cols: usize, mid
     let a = TracedTensor::from_vec_col_major(
         vec![rows, rows, mid],
         (0..rows * rows * mid).map(|i| i as f64).collect::<Vec<_>>(),
-    );
+    )
+    .unwrap();
     let b = TracedTensor::from_vec_col_major(
         vec![mid, cols],
         (0..mid * cols).map(|i| i as f64).collect::<Vec<_>>(),
-    );
+    )
+    .unwrap();
     let _ = einsum(compiler, &[&a, &b], "iij,jk->ik").expect("einsum");
 }
 
@@ -41,11 +45,13 @@ fn runtime_matmul_values(rows: usize, cols: usize, mid: usize) -> (Tensor, Tenso
     let a = Tensor::from_vec_col_major(
         vec![rows, rows, mid],
         (0..rows * rows * mid).map(|i| i as f64).collect::<Vec<_>>(),
-    );
+    )
+    .unwrap();
     let b = Tensor::from_vec_col_major(
         vec![mid, cols],
         (0..mid * cols).map(|i| i as f64).collect::<Vec<_>>(),
-    );
+    )
+    .unwrap();
     (a, b)
 }
 
@@ -91,14 +97,20 @@ fn run_eager_extension_matmul(
     cols: usize,
     mid: usize,
 ) -> Tensor {
-    let a = ctx.constant_from(Tensor::from_vec_col_major(
-        vec![rows, rows, mid],
-        (0..rows * rows * mid).map(|i| i as f64).collect::<Vec<_>>(),
-    ));
-    let b = ctx.constant_from(Tensor::from_vec_col_major(
-        vec![mid, cols],
-        (0..mid * cols).map(|i| i as f64).collect::<Vec<_>>(),
-    ));
+    let a = ctx.constant_from(
+        Tensor::from_vec_col_major(
+            vec![rows, rows, mid],
+            (0..rows * rows * mid).map(|i| i as f64).collect::<Vec<_>>(),
+        )
+        .unwrap(),
+    );
+    let b = ctx.constant_from(
+        Tensor::from_vec_col_major(
+            vec![mid, cols],
+            (0..mid * cols).map(|i| i as f64).collect::<Vec<_>>(),
+        )
+        .unwrap(),
+    );
     eager_einsum(&[&a, &b], "iij,jk->ik")
         .expect("eager einsum")
         .data()
@@ -115,8 +127,8 @@ fn runtime_cache_entries(executor: &GraphExecutor<CpuBackend>) -> usize {
 
 #[test]
 fn traced_einsum_uses_extension_compile_caches_and_runtime() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 2, 3], vec![1.0_f64; 12]);
-    let b = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 2, 3], vec![1.0_f64; 12]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
     let mut compiler = GraphCompiler::new();
 
     let out = einsum(&mut compiler, &[&a, &b], "iij,jk->ik").unwrap();
@@ -171,37 +183,44 @@ fn eager_einsum_expansion_reuses_runtime_owned_expanded_program_cache() {
 
     let out = run_eager_extension_matmul(&ctx, 2, 4, 3);
     assert_eq!(out.shape(), &[2, 4]);
-    let entries_after_first = ctx.cache_stats().extensions.entries;
+    let entries_after_first = ctx.cache_stats().unwrap().extensions.entries;
     assert_eq!(entries_after_first, 1);
 
     let _ = run_eager_extension_matmul(&ctx, 2, 4, 3);
-    assert_eq!(ctx.cache_stats().extensions.entries, entries_after_first);
+    assert_eq!(
+        ctx.cache_stats().unwrap().extensions.entries,
+        entries_after_first
+    );
 
     let other_ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let _ = run_eager_extension_matmul(&other_ctx, 2, 4, 3);
-    assert_eq!(ctx.cache_stats().extensions.entries, entries_after_first);
-    assert_eq!(other_ctx.cache_stats().extensions.entries, 1);
+    assert_eq!(
+        ctx.cache_stats().unwrap().extensions.entries,
+        entries_after_first
+    );
+    assert_eq!(other_ctx.cache_stats().unwrap().extensions.entries, 1);
 }
 
 #[test]
 fn eager_einsum_expansion_respects_runtime_cache_limits() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
-    ctx.set_extension_cache_limits(ExtensionCacheLimits::new(NonZeroUsize::new(3).unwrap()));
+    ctx.set_extension_cache_limits(ExtensionCacheLimits::new(NonZeroUsize::new(3).unwrap()))
+        .unwrap();
 
     for mid in 1..=5 {
         let _ = run_eager_extension_matmul(&ctx, 2, 2, mid);
     }
 
-    let stats = ctx.cache_stats();
+    let stats = ctx.cache_stats().unwrap();
     assert_eq!(stats.extensions.entries, 3);
     assert!(stats.extensions.retained_bytes > 0);
     assert_eq!(
-        ctx.extension_cache_limits().max_entries(),
+        ctx.extension_cache_limits().unwrap().max_entries(),
         NonZeroUsize::new(3).unwrap()
     );
 
-    ctx.clear_caches();
-    assert_eq!(ctx.cache_stats().extensions.entries, 0);
+    ctx.clear_caches().unwrap();
+    assert_eq!(ctx.cache_stats().unwrap().extensions.entries, 0);
 }
 
 #[test]
@@ -254,9 +273,9 @@ fn traced_static_tree_einsum_expands_without_runtime_exec_program_cache() {
 
     let mut executor = GraphExecutor::new(CpuBackend::new());
     register_runtime(&mut executor);
-    let a_value = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let b_value = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
-    let c_value = Tensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]);
+    let a_value = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let b_value = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
+    let c_value = Tensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]).unwrap();
 
     let first = executor
         .run_with_inputs(&program, &[(&a, &a_value), (&b, &b_value), (&c, &c_value)])
@@ -320,9 +339,9 @@ fn runtime_planned_einsum_cache_distinguishes_plan_spec() {
 
     let mut executor = GraphExecutor::new(CpuBackend::new());
     register_runtime(&mut executor);
-    let a_value = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let b_value = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
-    let c_value = Tensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]);
+    let a_value = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let b_value = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
+    let c_value = Tensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]).unwrap();
 
     let _ = executor
         .run_with_inputs(
@@ -389,9 +408,9 @@ fn runtime_planned_einsum_honors_explicit_path_execution_order() {
 
     let mut executor = GraphExecutor::new(CpuBackend::new());
     register_runtime(&mut executor);
-    let a_value = Tensor::from_vec_col_major(vec![1, 1], vec![1.0e308_f64]);
-    let b_value = Tensor::from_vec_col_major(vec![1, 1], vec![1.0e308_f64]);
-    let c_value = Tensor::from_vec_col_major(vec![1, 1], vec![1.0e-308_f64]);
+    let a_value = Tensor::from_vec_col_major(vec![1, 1], vec![1.0e308_f64]).unwrap();
+    let b_value = Tensor::from_vec_col_major(vec![1, 1], vec![1.0e308_f64]).unwrap();
+    let c_value = Tensor::from_vec_col_major(vec![1, 1], vec![1.0e-308_f64]).unwrap();
 
     let left_result = executor
         .run_with_inputs(
@@ -442,7 +461,9 @@ fn extension_runtime_cache_limits_bound_runtime_planned_einsum_entries() {
 fn compiler_and_executor_clear_caches_clear_extension_einsum_entries() {
     let mut compiler = GraphCompiler::new();
     run_static_matmul(&mut compiler, 2, 2, 3);
-    let out = TracedTensor::from_vec_col_major(vec![1], vec![1.0_f64]).neg();
+    let out = TracedTensor::from_vec_col_major(vec![1], vec![1.0_f64])
+        .unwrap()
+        .neg();
     let _ = compiler.compile(&out).unwrap();
     assert!(compiler.cache_stats().compile.entries > 0);
     assert!(compiler.cache_stats().extensions.entries > 0);
@@ -466,8 +487,8 @@ fn compiler_and_executor_clear_caches_clear_extension_einsum_entries() {
 
 #[test]
 fn custom_static_auto_options_do_not_reuse_default_extension_cache_entry() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let b = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
     let mut compiler = GraphCompiler::new();
 
     let _ = einsum(&mut compiler, &[&a, &b], "ij,jk->ik").unwrap();
@@ -493,9 +514,9 @@ fn custom_static_auto_options_do_not_reuse_default_extension_cache_entry() {
 
 #[test]
 fn concrete_traced_einsum_static_cache_distinguishes_plan_spec() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let b = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
-    let c = TracedTensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
+    let c = TracedTensor::from_vec_col_major(vec![4, 5], vec![1.0_f64; 20]).unwrap();
     let mut compiler = GraphCompiler::new();
 
     let _ = einsum_with(
@@ -610,12 +631,16 @@ fn symbolic_einsum_rejects_nan_auto_options() {
 
 #[test]
 fn parsed_integer_subscripts_trace_through_extension() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let b = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
     let subscripts = parse_einsum_subscripts("ij,jk->ik").unwrap();
     let mut compiler = GraphCompiler::new();
 
-    let out = tenferro_einsum::einsum_subscripts(&mut compiler, &[&a, &b], &subscripts).unwrap();
+    let out =
+        tenferro_einsum::traced_tensor::einsum_subscripts(&mut compiler, &[&a, &b], &subscripts)
+            .unwrap();
     let program = compiler.compile(&out).unwrap();
     let mut executor = GraphExecutor::new(CpuBackend::new());
     register_runtime(&mut executor);

--- a/crates/tenferro-einsum/tests/webgpu_eager_tensor.rs
+++ b/crates/tenferro-einsum/tests/webgpu_eager_tensor.rs
@@ -58,8 +58,10 @@ fn eager_tensor_einsum_runs_rank2_f32_matmul_on_webgpu_when_adapter_available() 
 
     let runtime = WebGpuRuntime::new_default().unwrap();
     let ctx = EagerRuntime::with_webgpu_backend(WebGpuBackend::from_runtime(runtime.clone()));
-    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0]);
-    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0]);
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0]).unwrap();
     let lhs =
         EagerTensor::from_tensor_in(upload_webgpu_tensor(&runtime, &lhs).unwrap(), ctx.clone());
     let rhs = EagerTensor::from_tensor_in(upload_webgpu_tensor(&runtime, &rhs).unwrap(), ctx);
@@ -88,13 +90,15 @@ fn eager_tensor_einsum_runs_batched_f32_matmul_on_webgpu_when_adapter_available(
         vec![
             1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0, 10.0, 40.0, 20.0, 50.0, 30.0, 60.0,
         ],
-    );
+    )
+    .unwrap();
     let rhs = Tensor::from_vec_col_major(
         vec![3, 2, 2],
         vec![
             7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0, 70.0, 90.0, 110.0, 80.0, 100.0, 120.0,
         ],
-    );
+    )
+    .unwrap();
     let lhs =
         EagerTensor::from_tensor_in(upload_webgpu_tensor(&runtime, &lhs).unwrap(), ctx.clone());
     let rhs = EagerTensor::from_tensor_in(upload_webgpu_tensor(&runtime, &rhs).unwrap(), ctx);
@@ -129,8 +133,8 @@ fn eager_tensor_einsum_runs_rank2_c32_matmul_on_webgpu_when_adapter_available() 
         Complex32::new(7.0, 1.0),
         Complex32::new(8.0, -0.75),
     ];
-    let lhs = Tensor::from_vec_col_major(vec![2, 2], lhs_data.clone());
-    let rhs = Tensor::from_vec_col_major(vec![2, 2], rhs_data.clone());
+    let lhs = Tensor::from_vec_col_major(vec![2, 2], lhs_data.clone()).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![2, 2], rhs_data.clone()).unwrap();
     let lhs =
         EagerTensor::from_tensor_in(upload_webgpu_tensor(&runtime, &lhs).unwrap(), ctx.clone());
     let rhs = EagerTensor::from_tensor_in(upload_webgpu_tensor(&runtime, &rhs).unwrap(), ctx);
@@ -153,7 +157,8 @@ fn traced_einsum_runs_rank2_f32_matmul_on_webgpu_when_adapter_available() {
     let lhs = TracedTensor::input_concrete_shape(DType::F32, &[2, 3]);
     let rhs = TracedTensor::input_concrete_shape(DType::F32, &[3, 2]);
     let mut compiler = GraphCompiler::new();
-    let out = tenferro_einsum::einsum(&mut compiler, &[&lhs, &rhs], "ij,jk->ik").unwrap();
+    let out =
+        tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&lhs, &rhs], "ij,jk->ik").unwrap();
     let program = compiler
         .compile_with_input_specs(
             &out,
@@ -161,9 +166,10 @@ fn traced_einsum_runs_rank2_f32_matmul_on_webgpu_when_adapter_available() {
         )
         .unwrap();
     let runtime = WebGpuRuntime::new_default().unwrap();
-    let lhs_host = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let lhs_host =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap();
     let rhs_host =
-        Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0]);
+        Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0]).unwrap();
     let lhs_gpu = upload_webgpu_tensor(&runtime, &lhs_host).unwrap();
     let rhs_gpu = upload_webgpu_tensor(&runtime, &rhs_host).unwrap();
     let mut executor = GraphExecutor::new(WebGpuBackend::from_runtime(runtime.clone()));
@@ -191,7 +197,8 @@ fn traced_einsum_runs_batched_f32_matmul_on_webgpu_when_adapter_available() {
     let lhs = TracedTensor::input_concrete_shape(DType::F32, &[2, 3, 2]);
     let rhs = TracedTensor::input_concrete_shape(DType::F32, &[3, 2, 2]);
     let mut compiler = GraphCompiler::new();
-    let out = tenferro_einsum::einsum(&mut compiler, &[&lhs, &rhs], "ikb,kjb->ijb").unwrap();
+    let out = tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&lhs, &rhs], "ikb,kjb->ijb")
+        .unwrap();
     let program = compiler
         .compile_with_input_specs(
             &out,
@@ -207,13 +214,15 @@ fn traced_einsum_runs_batched_f32_matmul_on_webgpu_when_adapter_available() {
         vec![
             1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0, 10.0, 40.0, 20.0, 50.0, 30.0, 60.0,
         ],
-    );
+    )
+    .unwrap();
     let rhs_host = Tensor::from_vec_col_major(
         vec![3, 2, 2],
         vec![
             7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0, 70.0, 90.0, 110.0, 80.0, 100.0, 120.0,
         ],
-    );
+    )
+    .unwrap();
     let lhs_gpu = upload_webgpu_tensor(&runtime, &lhs_host).unwrap();
     let rhs_gpu = upload_webgpu_tensor(&runtime, &rhs_host).unwrap();
     let mut executor = GraphExecutor::new(WebGpuBackend::from_runtime(runtime.clone()));

--- a/crates/tenferro-fft/examples/traced_fft.rs
+++ b/crates/tenferro-fft/examples/traced_fft.rs
@@ -12,7 +12,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Complex64::new(3.0, 0.0),
             Complex64::new(4.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
     let y = traced_tensor::fft(&x, None, -1, FftNorm::Backward)?;
 
     let mut compiler = GraphCompiler::new();

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -43,10 +43,8 @@ use num_complex::Complex;
 use num_traits::{Float, FromPrimitive, Zero};
 use rustfft::{FftNum, FftPlanner};
 #[cfg(feature = "autodiff")]
-use tenferro_ad::extension::ExtensionAdRuleTrait;
+use tenferro_ad::extension::{ExtensionAdRule, ExtensionRegistryError, ExtensionRuleSet};
 use tenferro_extension_macros::define_extension_runtime;
-#[cfg(feature = "autodiff")]
-use tenferro_extension_macros::define_idempotent_rule_registration;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::ad::PrimitiveRuleBuilder;
 #[cfg(feature = "autodiff")]
@@ -54,10 +52,10 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::ShapeGuardContext;
 use tenferro_ops::SymDim;
-use tenferro_runtime::extension::{try_apply, ExtensionExecutionContext, ExtensionOpTrait};
+use tenferro_runtime::extension::{apply, ExtensionExecutionContext, ExtensionOp};
 use tenferro_runtime::{Error, Result, TracedTensor};
 use tenferro_tensor::{
-    DType, DeviceKind, MemoryKind, Placement, Tensor, TensorBackend, TypedTensor,
+    DType, DeviceKind, MemoryKind, Placement, Tensor, TensorBackend, TensorRead, TypedTensor,
 };
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
@@ -77,9 +75,45 @@ pub const FFT_EXTENSION_FAMILY_ID: &str = "tenferro-fft.fft.v1";
 /// Traced tensor FFT operations.
 ///
 /// This module is the canonical traced tensor namespace for the FFT extension
-/// crate. Root-level functions remain available for compatibility.
+/// crate.
 pub mod traced_tensor {
-    pub use crate::{fft, ifft, irfft, rfft};
+    use super::{FftNorm, Result, TracedTensor};
+
+    pub fn fft(
+        input: &TracedTensor,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+    ) -> Result<TracedTensor> {
+        super::fft(input, n, axis, norm)
+    }
+
+    pub fn ifft(
+        input: &TracedTensor,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+    ) -> Result<TracedTensor> {
+        super::ifft(input, n, axis, norm)
+    }
+
+    pub fn rfft(
+        input: &TracedTensor,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+    ) -> Result<TracedTensor> {
+        super::rfft(input, n, axis, norm)
+    }
+
+    pub fn irfft(
+        input: &TracedTensor,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+    ) -> Result<TracedTensor> {
+        super::irfft(input, n, axis, norm)
+    }
 }
 
 /// FFT normalization convention.
@@ -155,7 +189,7 @@ impl FftOp {
     }
 }
 
-impl ExtensionOpTrait for FftOp {
+impl ExtensionOp for FftOp {
     fn family_id(&self) -> &'static str {
         FFT_EXTENSION_FAMILY_ID
     }
@@ -185,14 +219,14 @@ impl ExtensionOpTrait for FftOp {
         hasher.write_u8(norm);
     }
 
-    fn payload_eq(&self, other: &dyn ExtensionOpTrait) -> bool {
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
         other
             .as_any()
             .downcast_ref::<FftOp>()
             .is_some_and(|that| self == that)
     }
 
-    fn clone_arc(&self) -> Arc<dyn ExtensionOpTrait> {
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
         Arc::new(self.clone())
     }
 
@@ -282,34 +316,34 @@ fn execute_host_fft_op(op: &FftOp, inputs: &[&Tensor]) -> tenferro_tensor::Resul
             Tensor::C64(TypedTensor::from_vec_col_major(
                 output_shape_c2c(input.shape(), op.axis, op.n)?,
                 execute_c2c(input, op.axis, op.n, forward, op.norm)?,
-            ))
+            )?)
         }
         (FftKind::C2C { forward }, Tensor::C32(input)) => {
             Tensor::C32(TypedTensor::from_vec_col_major(
                 output_shape_c2c(input.shape(), op.axis, op.n)?,
                 execute_c2c(input, op.axis, op.n, forward, op.norm)?,
-            ))
+            )?)
         }
         (FftKind::R2C { onesided }, Tensor::F64(input)) => {
             Tensor::C64(TypedTensor::from_vec_col_major(
                 output_shape_r2c(input.shape(), op.axis, op.n, onesided)?,
                 execute_r2c(input, op.axis, op.n, onesided, op.norm)?,
-            ))
+            )?)
         }
         (FftKind::R2C { onesided }, Tensor::F32(input)) => {
             Tensor::C32(TypedTensor::from_vec_col_major(
                 output_shape_r2c(input.shape(), op.axis, op.n, onesided)?,
                 execute_r2c(input, op.axis, op.n, onesided, op.norm)?,
-            ))
+            )?)
         }
         (FftKind::C2R, Tensor::C64(input)) => Tensor::F64(TypedTensor::from_vec_col_major(
             output_shape_c2r(input.shape(), op.axis, op.n)?,
             execute_c2r(input, op.axis, op.n, op.norm)?,
-        )),
+        )?),
         (FftKind::C2R, Tensor::C32(input)) => Tensor::F32(TypedTensor::from_vec_col_major(
             output_shape_c2r(input.shape(), op.axis, op.n)?,
             execute_c2r(input, op.axis, op.n, op.norm)?,
-        )),
+        )?),
         (kind, other) => {
             return Err(tenferro_tensor::Error::DTypeMismatch {
                 op: match kind {
@@ -360,14 +394,14 @@ fn validate_host_fft_input(op: &'static str, input: &Tensor) -> tenferro_tensor:
 struct FftAdRule;
 
 #[cfg(feature = "autodiff")]
-impl ExtensionAdRuleTrait for FftAdRule {
+impl ExtensionAdRule for FftAdRule {
     fn family_id(&self) -> &'static str {
         FFT_EXTENSION_FAMILY_ID
     }
 
     fn linearize(
         &self,
-        op: &dyn ExtensionOpTrait,
+        op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         _primal_in: &[ValueKey<StdTensorOp>],
         _primal_out: &[ValueKey<StdTensorOp>],
@@ -399,7 +433,7 @@ impl ExtensionAdRuleTrait for FftAdRule {
 
     fn transpose_rule(
         &self,
-        op: &dyn ExtensionOpTrait,
+        op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         _inputs: &[ValueRef<StdTensorOp>],
@@ -434,9 +468,8 @@ impl ExtensionAdRuleTrait for FftAdRule {
 }
 
 #[cfg(feature = "autodiff")]
-define_idempotent_rule_registration! {
-    register_fn = register_fft,
-    rule_type = FftAdRule,
+pub fn ad_rules() -> std::result::Result<ExtensionRuleSet, ExtensionRegistryError> {
+    ExtensionRuleSet::new().with_rule(Arc::new(FftAdRule))
 }
 
 fn execute_fft_extension<B: TensorBackend + 'static>(
@@ -447,11 +480,28 @@ fn execute_fft_extension<B: TensorBackend + 'static>(
     execute_host_fft_op(op, inputs)
 }
 
+fn execute_fft_extension_reads<B: TensorBackend + 'static>(
+    op: &FftOp,
+    inputs: &[TensorRead<'_>],
+    ctx: &mut ExtensionExecutionContext<'_, B>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    let _ = ctx;
+    // rustfft consumes compact host tensors; materialization is explicit so
+    // backend-backed views produce a normal error instead of an implicit path.
+    let materialized_inputs: Vec<Tensor> = inputs
+        .iter()
+        .map(TensorRead::to_tensor)
+        .collect::<tenferro_tensor::Result<_>>()?;
+    let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
+    execute_host_fft_op(op, &input_refs)
+}
+
 define_extension_runtime! {
     runtime = FftRuntime,
     family_id = FFT_EXTENSION_FAMILY_ID,
     op_type = FftOp,
     execute = execute_fft_extension,
+    execute_reads = execute_fft_extension_reads,
     register_fn = register_runtime,
 }
 
@@ -478,12 +528,7 @@ define_extension_runtime! {
 /// let out = executor.run(&program).unwrap();
 /// assert_eq!(out.as_slice::<Complex64>().unwrap()[0], Complex64::new(3.0, 0.0));
 /// ```
-pub fn fft(
-    input: &TracedTensor,
-    n: Option<usize>,
-    axis: isize,
-    norm: FftNorm,
-) -> Result<TracedTensor> {
+fn fft(input: &TracedTensor, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<TracedTensor> {
     let kind = match input.dtype {
         DType::C32 | DType::C64 => FftKind::C2C { forward: true },
         DType::F32 | DType::F64 => FftKind::R2C { onesided: false },
@@ -520,7 +565,7 @@ pub fn fft(
 /// let out = executor.run(&program).unwrap();
 /// assert_eq!(out.as_slice::<Complex64>().unwrap()[0], Complex64::new(1.0, 0.0));
 /// ```
-pub fn ifft(
+fn ifft(
     input: &TracedTensor,
     n: Option<usize>,
     axis: isize,
@@ -566,7 +611,7 @@ pub fn ifft(
 /// assert_eq!(out.shape(), &[2]);
 /// assert_eq!(out.as_slice::<Complex64>().unwrap()[0], Complex64::new(3.0, 0.0));
 /// ```
-pub fn rfft(
+fn rfft(
     input: &TracedTensor,
     n: Option<usize>,
     axis: isize,
@@ -614,7 +659,7 @@ pub fn rfft(
 /// let out = executor.run(&program).unwrap();
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
 /// ```
-pub fn irfft(
+fn irfft(
     input: &TracedTensor,
     n: Option<usize>,
     axis: isize,
@@ -637,12 +682,10 @@ fn apply_unary_fft(
     axis: isize,
     norm: FftNorm,
 ) -> Result<TracedTensor> {
-    #[cfg(feature = "autodiff")]
-    register_fft().map_err(|err| Error::Internal(err.to_string()))?;
     validate_n(op_name, n)?;
     let axis = normalize_axis(op_name, axis, input.rank)?;
     let op = Arc::new(FftOp::new(kind, axis, n, norm));
-    let mut outputs = try_apply(op, &[input])?;
+    let mut outputs = apply(op, &[input])?;
     outputs
         .pop()
         .ok_or_else(|| Error::Internal("FFT extension declares exactly one output".into()))
@@ -710,7 +753,7 @@ fn fft_ad_family_id(kind: FftKind) -> &'static str {
 }
 
 #[cfg(feature = "autodiff")]
-fn fft_payload<'a>(op: &'a dyn ExtensionOpTrait, rule: ADRuleKind) -> ADRuleResult<&'a FftOp> {
+fn fft_payload<'a>(op: &'a dyn ExtensionOp, rule: ADRuleKind) -> ADRuleResult<&'a FftOp> {
     op.as_any()
         .downcast_ref::<FftOp>()
         .ok_or_else(|| ADRuleError::unsupported(FFT_EXTENSION_FAMILY_ID, rule))
@@ -819,7 +862,7 @@ where
     let fft_len = transform_len(in_shape, axis, n)?;
     let out_shape = output_shape_c2c(in_shape, axis, n)?;
     let out_axis_len = out_shape[axis];
-    let input_data = input.host_data();
+    let input_data = input.host_data()?;
     let mut output = uninit_output_vec(out_shape.iter().product());
     let mut planner = FftPlanner::<T>::new();
     let fft_plan = if forward {
@@ -866,7 +909,7 @@ where
     let fft_len = transform_len(in_shape, axis, n)?;
     let out_shape = output_shape_r2c(in_shape, axis, n, onesided)?;
     let out_axis_len = out_shape[axis];
-    let input_data = input.host_data();
+    let input_data = input.host_data()?;
     let mut output = uninit_output_vec(out_shape.iter().product());
     let mut planner = FftPlanner::<T>::new();
     let fft_plan = planner.plan_fft_forward(fft_len);
@@ -908,7 +951,7 @@ where
     let out_shape = output_shape_c2r(in_shape, axis, n)?;
     let out_axis_len = out_shape[axis];
     let expected_half = out_axis_len / 2 + 1;
-    let input_data = input.host_data();
+    let input_data = input.host_data()?;
     let mut output = uninit_output_vec(out_shape.iter().product());
     let mut planner = FftPlanner::<T>::new();
     let fft_plan = planner.plan_fft_inverse(out_axis_len);

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 #[cfg(feature = "autodiff")]
 use tenferro_ad::TracedTensorAdExt;
 use tenferro_cpu::CpuBackend;
-use tenferro_fft::{fft, ifft, irfft, rfft, FftNorm};
+use tenferro_fft::{
+    traced_tensor::{fft, ifft, irfft, rfft},
+    FftNorm,
+};
 use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
 use tenferro_tensor::{
     Buffer, BufferHandle, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, TypedTensor,
@@ -94,17 +97,20 @@ fn finite_diff_c64_directional(
 
 fn cuda_c64_tensor(shape: Vec<usize>) -> Tensor {
     let len = shape.iter().product();
-    Tensor::C64(TypedTensor::from_buffer_col_major(
-        shape,
-        Buffer::Backend(Arc::new(BufferHandle::<Complex64>::new_with_len(7, len))),
-        Placement {
-            memory_kind: MemoryKind::Device,
-            device: Some(DeviceId {
-                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
-                ordinal: 0,
-            }),
-        },
-    ))
+    Tensor::C64(
+        TypedTensor::from_buffer_col_major(
+            shape,
+            Buffer::Backend(Arc::new(BufferHandle::<Complex64>::new_with_len(7, len))),
+            Placement {
+                memory_kind: MemoryKind::Device,
+                device: Some(DeviceId {
+                    kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+                    ordinal: 0,
+                }),
+            },
+        )
+        .unwrap(),
+    )
 }
 
 #[test]
@@ -114,7 +120,7 @@ fn publishes_extension_family_id() {
 
 #[test]
 fn traced_tensor_namespace_exposes_fft() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let y = tenferro_fft::traced_tensor::rfft(&x, None, -1, FftNorm::Backward).unwrap();
 
     assert_eq!(y.rank, 1);
@@ -178,7 +184,8 @@ fn fft_c64_matches_numpy_convention() {
             Complex64::new(3.0, 0.0),
             Complex64::new(4.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
     let y = fft(&x, None, -1, FftNorm::Backward).unwrap();
     let out = run(&y);
 
@@ -199,7 +206,8 @@ fn fft_with_longer_transform_uses_zero_padded_lanes() {
     let x = TracedTensor::from_vec_col_major(
         vec![2],
         vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
-    );
+    )
+    .unwrap();
     let y = fft(&x, Some(4), -1, FftNorm::Backward).unwrap();
     let out = run(&y);
 
@@ -225,7 +233,8 @@ fn fft_c32_uses_host_runtime() {
             Complex32::new(3.0, 0.0),
             Complex32::new(4.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
     let y = fft(&x, None, -1, FftNorm::Backward).unwrap();
     let out = run(&y);
 
@@ -250,7 +259,8 @@ fn ifft_c64_applies_backward_normalization() {
             Complex64::new(-2.0, 0.0),
             Complex64::new(-2.0, -2.0),
         ],
-    );
+    )
+    .unwrap();
     let y = ifft(&spectrum, None, -1, FftNorm::Backward).unwrap();
     let out = run(&y);
 
@@ -267,7 +277,7 @@ fn ifft_c64_applies_backward_normalization() {
 
 #[test]
 fn rfft_f64_returns_onesided_spectrum() {
-    let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let y = rfft(&x, None, -1, FftNorm::Backward).unwrap();
     let out = run(&y);
 
@@ -284,7 +294,7 @@ fn rfft_f64_returns_onesided_spectrum() {
 
 #[test]
 fn rfft_f32_returns_onesided_spectrum() {
-    let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f32, 2.0, 3.0, 4.0]);
+    let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f32, 2.0, 3.0, 4.0]).unwrap();
     let y = rfft(&x, None, -1, FftNorm::Backward).unwrap();
     let out = run(&y);
 
@@ -308,7 +318,8 @@ fn irfft_c64_reconstructs_real_signal() {
             Complex64::new(-2.0, 2.0),
             Complex64::new(-2.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
     let y = irfft(&spectrum, Some(4), -1, FftNorm::Backward).unwrap();
     let out = run(&y);
 
@@ -325,7 +336,8 @@ fn irfft_c32_reconstructs_real_signal() {
             Complex32::new(-2.0, 2.0),
             Complex32::new(-2.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
     let y = irfft(&spectrum, Some(4), -1, FftNorm::Backward).unwrap();
     let out = run(&y);
 
@@ -335,14 +347,14 @@ fn irfft_c32_reconstructs_real_signal() {
 
 #[test]
 fn traced_fft_rejects_invalid_dtype_axis_and_length() {
-    let int_input = TracedTensor::from_vec_col_major(vec![2], vec![1_i64, 2]);
+    let int_input = TracedTensor::from_vec_col_major(vec![2], vec![1_i64, 2]).unwrap();
     let err = match fft(&int_input, None, -1, FftNorm::Backward) {
         Ok(_) => panic!("expected fft to reject integer input"),
         Err(err) => err,
     };
     assert!(err.to_string().contains("floating"), "{err}");
 
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let err = match rfft(&x, Some(0), -1, FftNorm::Backward) {
         Ok(_) => panic!("expected rfft to reject zero transform length"),
         Err(err) => err,
@@ -367,7 +379,8 @@ fn fft_c64_jvp_applies_fft_to_tangent() {
             Complex64::new(3.0, 0.0),
             Complex64::new(4.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
     let dx = TracedTensor::from_vec_col_major(
         vec![4],
         vec![
@@ -376,7 +389,8 @@ fn fft_c64_jvp_applies_fft_to_tangent() {
             Complex64::new(0.0, 0.0),
             Complex64::new(-1.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
 
     let y = fft(&x, None, -1, FftNorm::Backward).unwrap();
     let dy = y.jvp(&x, &dx).unwrap();
@@ -408,8 +422,8 @@ fn fft_c64_jvp_matches_finite_diff() {
         Complex64::new(-0.4, 0.2),
         Complex64::new(0.1, -0.5),
     ];
-    let x = TracedTensor::from_vec_col_major(vec![4], data.clone());
-    let dx = TracedTensor::from_vec_col_major(vec![4], tangent_data.clone());
+    let x = TracedTensor::from_vec_col_major(vec![4], data.clone()).unwrap();
+    let dx = TracedTensor::from_vec_col_major(vec![4], tangent_data.clone()).unwrap();
 
     let y = fft(&x, None, -1, FftNorm::Backward).unwrap();
     let dy = y.jvp(&x, &dx).unwrap();
@@ -417,7 +431,7 @@ fn fft_c64_jvp_matches_finite_diff() {
 
     let expected = finite_diff_c64_directional(
         |xs| {
-            let x = TracedTensor::from_vec_col_major(vec![4], xs.to_vec());
+            let x = TracedTensor::from_vec_col_major(vec![4], xs.to_vec()).unwrap();
             let y = fft(&x, None, -1, FftNorm::Backward).unwrap();
             run(&y).as_slice::<Complex64>().unwrap().to_vec()
         },
@@ -439,7 +453,8 @@ fn fft_c64_vjp_uses_inverse_transform_with_adjoint_normalization() {
             Complex64::new(3.0, 0.0),
             Complex64::new(4.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
     let cotangent = TracedTensor::from_vec_col_major(
         vec![4],
         vec![
@@ -448,7 +463,8 @@ fn fft_c64_vjp_uses_inverse_transform_with_adjoint_normalization() {
             Complex64::new(-1.0, 0.5),
             Complex64::new(0.25, -2.0),
         ],
-    );
+    )
+    .unwrap();
 
     let y = fft(&x, None, -1, FftNorm::Backward).unwrap();
     let dx = y.vjp(&x, &cotangent).unwrap();
@@ -476,7 +492,8 @@ fn ifft_c64_vjp_uses_forward_transform_with_adjoint_normalization() {
             Complex64::new(-2.0, 0.0),
             Complex64::new(-2.0, -2.0),
         ],
-    );
+    )
+    .unwrap();
     let cotangent = TracedTensor::from_vec_col_major(
         vec![4],
         vec![
@@ -485,7 +502,8 @@ fn ifft_c64_vjp_uses_forward_transform_with_adjoint_normalization() {
             Complex64::new(-1.0, 0.5),
             Complex64::new(0.25, -2.0),
         ],
-    );
+    )
+    .unwrap();
 
     let y = ifft(&x, None, -1, FftNorm::Backward).unwrap();
     let dx = y.vjp(&x, &cotangent).unwrap();
@@ -505,7 +523,7 @@ fn ifft_c64_vjp_uses_forward_transform_with_adjoint_normalization() {
 #[test]
 #[cfg(feature = "autodiff")]
 fn rfft_vjp_unsupported_error_names_rfft_and_vjp() {
-    let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let cotangent = TracedTensor::from_vec_col_major(
         vec![3],
         vec![
@@ -513,10 +531,11 @@ fn rfft_vjp_unsupported_error_names_rfft_and_vjp() {
             Complex64::new(0.5, -1.0),
             Complex64::new(2.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
 
     let y = rfft(&x, None, -1, FftNorm::Backward).unwrap();
-    let err = match y.vjp_optional_result(&x, &cotangent) {
+    let err = match y.vjp_optional(&x, &cotangent) {
         Ok(_) => panic!("rfft VJP should remain unsupported"),
         Err(err) => err,
     };
@@ -538,7 +557,8 @@ fn irfft_jvp_unsupported_error_names_irfft_and_jvp() {
             Complex64::new(-2.0, 2.0),
             Complex64::new(-2.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
     let tangent = TracedTensor::from_vec_col_major(
         vec![3],
         vec![
@@ -546,10 +566,11 @@ fn irfft_jvp_unsupported_error_names_irfft_and_jvp() {
             Complex64::new(1.0, -0.5),
             Complex64::new(0.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
 
     let y = irfft(&spectrum, Some(4), -1, FftNorm::Backward).unwrap();
-    let err = match y.jvp_optional_result(&spectrum, &tangent) {
+    let err = match y.jvp_optional(&spectrum, &tangent) {
         Ok(_) => panic!("irfft JVP should remain unsupported"),
         Err(err) => err,
     };

--- a/crates/tenferro-gpu/examples/cuda_quickstart.rs
+++ b/crates/tenferro-gpu/examples/cuda_quickstart.rs
@@ -1,4 +1,4 @@
-use tenferro_gpu::{download_tensor, upload_tensor, CubeclBackend as CudaBackend};
+use tenferro_gpu::{download_tensor, upload_tensor, CudaBackend};
 use tenferro_tensor::{Tensor, TensorElementwise};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -7,8 +7,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let mut backend = CudaBackend::new(0)?;
-    let cpu_a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let cpu_b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
+    let cpu_a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let cpu_b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
 
     let gpu_a = upload_tensor(backend.runtime(), &cpu_a)?;
     let gpu_b = upload_tensor(backend.runtime(), &cpu_b)?;

--- a/crates/tenferro-gpu/src/cubecl/dispatch.rs
+++ b/crates/tenferro-gpu/src/cubecl/dispatch.rs
@@ -1,12 +1,12 @@
 use cubecl::client::ComputeClient;
 use cubecl::prelude::*;
-use cubecl_cuda::CudaRuntime;
+use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 use std::sync::Arc;
 
 use crate::config::CompareDir;
-use crate::cubecl::CubeclRuntime;
+use crate::cubecl::CudaRuntime;
 use crate::types::{
-    Buffer, ComputeDevice, CubeclBuffer, DeviceKind, GpuBackendKind, MemoryKind, Placement, Tensor,
+    Buffer, CubeclBuffer, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Tensor,
     TensorRank, TypedTensor, TypedTensorView, TypedTensorViewMut,
 };
 
@@ -116,19 +116,19 @@ pub(crate) fn cubecl_view_mut_buffer<'a, T: 'static>(
         })
 }
 
-pub(crate) fn cubecl_shape_and_strides(shape: &[usize]) -> (Vec<usize>, Vec<usize>) {
+pub(crate) fn cubecl_shape_and_strides(shape: &[usize]) -> crate::Result<(Vec<usize>, Vec<usize>)> {
     // CubeCL CUDA kernels still receive a dynamic metadata pointer for tensor
     // args. Rank-0 tensors need one dense metadata element so that launch
     // argument layout stays consistent, while tenferro keeps the public shape
     // as `[]` and passes the logical rank separately where needed.
     if shape.is_empty() {
-        return (vec![1], vec![1]);
+        return Ok((vec![1], vec![1]));
     }
-    let strides = crate::types::col_major_strides(shape)
+    let strides = crate::types::col_major_strides(shape)?
         .into_iter()
         .map(|stride| stride as usize)
         .collect();
-    (shape.to_vec(), strides)
+    Ok((shape.to_vec(), strides))
 }
 
 fn checked_shape_product(op: &'static str, shape: &[usize]) -> crate::Result<usize> {
@@ -195,10 +195,10 @@ fn validate_raw_ternary_shapes<TA, TB, TC>(
 pub(crate) fn typed_tensor_binding<T: CubeElement + Clone>(
     tensor: &TypedTensor<T, impl TensorRank>,
     op: &'static str,
-) -> crate::Result<TensorBinding<CudaRuntime>> {
+) -> crate::Result<TensorBinding<CubeclCudaRuntime>> {
     let buffer = cubecl_buffer(tensor, op)?;
     validate_cubecl_buffer_len(tensor, buffer, op)?;
-    let (shape, strides) = cubecl_shape_and_strides(tensor.shape());
+    let (shape, strides) = cubecl_shape_and_strides(tensor.shape())?;
 
     // SAFETY: `buffer.handle()` references the CubeCL allocation for `tensor`.
     // The checked invariant above proves `buffer.element_len()` equals the dense
@@ -211,7 +211,7 @@ pub(crate) fn typed_tensor_binding<T: CubeElement + Clone>(
 }
 
 pub(crate) fn ensure_resident_on_runtime<T: 'static>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     tensor: &TypedTensor<T, impl TensorRank>,
     op: &'static str,
 ) -> crate::Result<()> {
@@ -220,7 +220,7 @@ pub(crate) fn ensure_resident_on_runtime<T: 'static>(
 }
 
 pub(crate) fn ensure_view_resident_on_runtime<T: 'static>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     view: &TypedTensorView<'_, T, impl TensorRank>,
     op: &'static str,
 ) -> crate::Result<()> {
@@ -229,7 +229,7 @@ pub(crate) fn ensure_view_resident_on_runtime<T: 'static>(
 }
 
 pub(crate) fn ensure_view_mut_resident_on_runtime<T: 'static>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     view: &TypedTensorViewMut<'_, T, impl TensorRank>,
     op: &'static str,
 ) -> crate::Result<()> {
@@ -238,7 +238,7 @@ pub(crate) fn ensure_view_mut_resident_on_runtime<T: 'static>(
 }
 
 fn ensure_placement_resident_on_runtime(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     placement: &Placement,
     op: &'static str,
 ) -> crate::Result<()> {
@@ -281,13 +281,13 @@ pub(crate) fn typed_from_cubecl<T: Send + Sync + 'static>(
     shape: Vec<usize>,
     buffer: CubeclBuffer<T>,
     device_ordinal: usize,
-) -> TypedTensor<T> {
+) -> crate::Result<TypedTensor<T>> {
     TypedTensor::from_buffer_col_major(
         shape,
         Buffer::Backend(Arc::new(buffer)),
         Placement {
             memory_kind: MemoryKind::Device,
-            device: Some(ComputeDevice {
+            device: Some(DeviceId {
                 kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
                 ordinal: device_ordinal,
             }),
@@ -296,7 +296,7 @@ pub(crate) fn typed_from_cubecl<T: Send + Sync + 'static>(
 }
 
 pub(crate) fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     shape: &[usize],
 ) -> crate::Result<TypedTensor<T>> {
     let len = checked_shape_product("cubecl_alloc_output", shape)?;
@@ -307,30 +307,30 @@ pub(crate) fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
         )
     })?;
     let handle = rt.client().empty(byte_len);
-    Ok(typed_from_cubecl(
+    typed_from_cubecl(
         shape.to_vec(),
         CubeclBuffer::new(handle, len),
         rt.device_ordinal(),
-    ))
+    )
 }
 
 pub(crate) fn alloc_bool_output(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     shape: &[usize],
 ) -> crate::Result<TypedTensor<bool>> {
     let len = checked_shape_product("cubecl_alloc_bool_output", shape)?;
     let handle = rt.client().empty(len);
-    Ok(typed_from_cubecl(
+    typed_from_cubecl(
         shape.to_vec(),
         CubeclBuffer::new(handle, len),
         rt.device_ordinal(),
-    ))
+    )
 }
 
 pub(crate) fn typed_tensor_array_arg<T: CubeElement + Clone>(
     tensor: &TypedTensor<T, impl TensorRank>,
     op: &'static str,
-) -> crate::Result<ArrayArg<CudaRuntime>> {
+) -> crate::Result<ArrayArg<CubeclCudaRuntime>> {
     let buffer = cubecl_buffer(tensor, op)?;
     validate_cubecl_buffer_len(tensor, buffer, op)?;
 
@@ -344,7 +344,7 @@ pub(crate) fn typed_tensor_array_arg<T: CubeElement + Clone>(
 pub(crate) fn typed_view_array_arg<T: CubeElement + Clone>(
     view: &TypedTensorView<'_, T, impl TensorRank>,
     op: &'static str,
-) -> crate::Result<ArrayArg<CudaRuntime>> {
+) -> crate::Result<ArrayArg<CubeclCudaRuntime>> {
     let buffer = cubecl_view_buffer(view, op)?;
 
     // SAFETY: `TensorLayout` validation at view construction proves the
@@ -357,7 +357,7 @@ pub(crate) fn typed_view_array_arg<T: CubeElement + Clone>(
 pub(crate) fn typed_view_mut_array_arg<T: CubeElement + Clone>(
     view: &TypedTensorViewMut<'_, T, impl TensorRank>,
     op: &'static str,
-) -> crate::Result<ArrayArg<CudaRuntime>> {
+) -> crate::Result<ArrayArg<CubeclCudaRuntime>> {
     let buffer = cubecl_view_mut_buffer(view, op)?;
 
     // SAFETY: `TypedTensorViewMut` construction validates both reachable
@@ -369,7 +369,7 @@ pub(crate) fn typed_view_mut_array_arg<T: CubeElement + Clone>(
 pub(crate) fn bool_tensor_array_arg(
     tensor: &TypedTensor<bool, impl TensorRank>,
     op: &'static str,
-) -> crate::Result<ArrayArg<CudaRuntime>> {
+) -> crate::Result<ArrayArg<CubeclCudaRuntime>> {
     let buffer = cubecl_buffer(tensor, op)?;
     validate_cubecl_buffer_len(tensor, buffer, op)?;
 
@@ -383,7 +383,7 @@ pub(crate) fn typed_tensor_array_arg_as<T, U>(
     tensor: &TypedTensor<T, impl TensorRank>,
     len: usize,
     op: &'static str,
-) -> crate::Result<ArrayArg<CudaRuntime>>
+) -> crate::Result<ArrayArg<CubeclCudaRuntime>>
 where
     T: CubeElement + Clone,
     U: CubeElement + Clone,
@@ -424,16 +424,16 @@ where
 }
 
 pub(crate) fn launch_unary<TIn, TOut>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     input: &TypedTensor<TIn>,
     out_shape: &[usize],
     op: &'static str,
     launch: impl FnOnce(
-        &ComputeClient<CudaRuntime>,
+        &ComputeClient<CubeclCudaRuntime>,
         CubeCount,
         CubeDim,
-        ArrayArg<CudaRuntime>,
-        ArrayArg<CudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
     ),
 ) -> crate::Result<TypedTensor<TOut>>
 where
@@ -467,16 +467,16 @@ where
 }
 
 pub(crate) fn launch_unary_tensor<TIn, TOut>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     input: &TypedTensor<TIn>,
     out_shape: &[usize],
     op: &'static str,
     launch: impl FnOnce(
-        &ComputeClient<CudaRuntime>,
+        &ComputeClient<CubeclCudaRuntime>,
         CubeCount,
         CubeDim,
-        TensorBinding<CudaRuntime>,
-        TensorBinding<CudaRuntime>,
+        TensorBinding<CubeclCudaRuntime>,
+        TensorBinding<CubeclCudaRuntime>,
     ),
 ) -> crate::Result<TypedTensor<TOut>>
 where
@@ -508,12 +508,17 @@ where
 }
 
 pub(crate) fn launch_nullary_into<TOut>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     output: &TypedTensor<TOut>,
     op: &'static str,
     count: CubeCount,
     dim: CubeDim,
-    launch: impl FnOnce(&ComputeClient<CudaRuntime>, CubeCount, CubeDim, ArrayArg<CudaRuntime>),
+    launch: impl FnOnce(
+        &ComputeClient<CubeclCudaRuntime>,
+        CubeCount,
+        CubeDim,
+        ArrayArg<CubeclCudaRuntime>,
+    ),
 ) -> crate::Result<()>
 where
     TOut: CubeElement + Clone,
@@ -531,18 +536,18 @@ where
 }
 
 pub(crate) fn launch_unary_tensor_into<TIn, TOut>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     output: &TypedTensor<TOut>,
     input: &TypedTensor<TIn>,
     op: &'static str,
     count: CubeCount,
     dim: CubeDim,
     launch: impl FnOnce(
-        &ComputeClient<CudaRuntime>,
+        &ComputeClient<CubeclCudaRuntime>,
         CubeCount,
         CubeDim,
-        TensorBinding<CudaRuntime>,
-        TensorBinding<CudaRuntime>,
+        TensorBinding<CubeclCudaRuntime>,
+        TensorBinding<CubeclCudaRuntime>,
     ),
 ) -> crate::Result<()>
 where
@@ -565,18 +570,18 @@ where
 }
 
 pub(crate) fn launch_binary<TLhs, TRhs, TOut>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     lhs: &TypedTensor<TLhs>,
     rhs: &TypedTensor<TRhs>,
     out_shape: &[usize],
     op: &'static str,
     launch: impl FnOnce(
-        &ComputeClient<CudaRuntime>,
+        &ComputeClient<CubeclCudaRuntime>,
         CubeCount,
         CubeDim,
-        ArrayArg<CudaRuntime>,
-        ArrayArg<CudaRuntime>,
-        ArrayArg<CudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
     ),
 ) -> crate::Result<TypedTensor<TOut>>
 where
@@ -614,18 +619,18 @@ where
 }
 
 pub(crate) fn launch_compare_bool<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     lhs: &TypedTensor<T>,
     rhs: &TypedTensor<T>,
     out_shape: &[usize],
     op: &'static str,
     launch: impl FnOnce(
-        &ComputeClient<CudaRuntime>,
+        &ComputeClient<CubeclCudaRuntime>,
         CubeCount,
         CubeDim,
-        ArrayArg<CudaRuntime>,
-        ArrayArg<CudaRuntime>,
-        ArrayArg<CudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
     ),
 ) -> crate::Result<TypedTensor<bool>>
 where
@@ -658,18 +663,18 @@ where
 }
 
 pub(crate) fn launch_binary_tensor<TLhs, TRhs, TOut>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     lhs: &TypedTensor<TLhs>,
     rhs: &TypedTensor<TRhs>,
     out_shape: &[usize],
     op: &'static str,
     launch: impl FnOnce(
-        &ComputeClient<CudaRuntime>,
+        &ComputeClient<CubeclCudaRuntime>,
         CubeCount,
         CubeDim,
-        TensorBinding<CudaRuntime>,
-        TensorBinding<CudaRuntime>,
-        TensorBinding<CudaRuntime>,
+        TensorBinding<CubeclCudaRuntime>,
+        TensorBinding<CubeclCudaRuntime>,
+        TensorBinding<CubeclCudaRuntime>,
     ),
 ) -> crate::Result<TypedTensor<TOut>>
 where
@@ -705,20 +710,20 @@ where
 }
 
 pub(crate) fn launch_select_bool<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     pred: &TypedTensor<bool>,
     on_true: &TypedTensor<T>,
     on_false: &TypedTensor<T>,
     out_shape: &[usize],
     op: &'static str,
     launch: impl FnOnce(
-        &ComputeClient<CudaRuntime>,
+        &ComputeClient<CubeclCudaRuntime>,
         CubeCount,
         CubeDim,
-        ArrayArg<CudaRuntime>,
-        ArrayArg<CudaRuntime>,
-        ArrayArg<CudaRuntime>,
-        ArrayArg<CudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
     ),
 ) -> crate::Result<TypedTensor<T>>
 where
@@ -754,20 +759,20 @@ where
 }
 
 pub(crate) fn launch_ternary<TA, TB, TC, TOut>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     a: &TypedTensor<TA>,
     b: &TypedTensor<TB>,
     c: &TypedTensor<TC>,
     out_shape: &[usize],
     op: &'static str,
     launch: impl FnOnce(
-        &ComputeClient<CudaRuntime>,
+        &ComputeClient<CubeclCudaRuntime>,
         CubeCount,
         CubeDim,
-        ArrayArg<CudaRuntime>,
-        ArrayArg<CudaRuntime>,
-        ArrayArg<CudaRuntime>,
-        ArrayArg<CudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
+        ArrayArg<CubeclCudaRuntime>,
     ),
 ) -> crate::Result<TypedTensor<TOut>>
 where
@@ -901,7 +906,7 @@ macro_rules! launch_binary_elementwise_kernel {
             $lhs.shape(),
             $op,
             |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                crate::kernels::elementwise::$kernel::launch_unchecked::<$scalar, CudaRuntime>(
+                crate::kernels::elementwise::$kernel::launch_unchecked::<$scalar, CubeclCudaRuntime>(
                     client, count, dim, out, lhs_arg, rhs_arg,
                 );
             },
@@ -918,7 +923,7 @@ macro_rules! launch_unary_elementwise_kernel {
             $input.shape(),
             $op,
             |client, count, dim, out, input_arg| unsafe {
-                crate::kernels::elementwise::$kernel::launch_unchecked::<$scalar, CudaRuntime>(
+                crate::kernels::elementwise::$kernel::launch_unchecked::<$scalar, CubeclCudaRuntime>(
                     client, count, dim, out, input_arg,
                 );
             },

--- a/crates/tenferro-gpu/src/cubecl/fusion/launch.rs
+++ b/crates/tenferro-gpu/src/cubecl/fusion/launch.rs
@@ -8,11 +8,11 @@ use crate::backend::ElementwiseFusionPlan;
 use crate::cubecl::dispatch::{
     alloc_output, cube_count_for_len, cube_dim_1d, ensure_resident_on_runtime,
 };
-use crate::cubecl::runtime::CubeclRuntime;
+use crate::cubecl::runtime::CudaRuntime;
 use crate::types::TypedTensor;
 
 pub(crate) fn launch<T>(
-    runtime: &CubeclRuntime,
+    runtime: &CudaRuntime,
     classified: ClassifiedFusion<'_, T>,
 ) -> crate::Result<Vec<TypedTensor<T>>>
 where

--- a/crates/tenferro-gpu/src/cubecl/fusion/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/fusion/mod.rs
@@ -5,11 +5,11 @@ mod launch;
 use classify::classify;
 
 use crate::backend::ElementwiseFusionPlan;
-use crate::cubecl::CubeclBackend;
+use crate::cubecl::CudaBackend;
 use crate::Tensor;
 
 pub(crate) fn execute_elementwise_fusion(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     inputs: &[&Tensor],
     plan: &ElementwiseFusionPlan,
 ) -> crate::Result<Option<Vec<Tensor>>> {

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -1,7 +1,7 @@
 use std::ffi::c_void;
 
 use cubecl::prelude::{CubeElement, CubePrimitive};
-use cubecl_cuda::CudaRuntime;
+use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 
@@ -13,7 +13,7 @@ use super::ffi::cutensor::{
     CudaDataType, CutensorComputeDescriptor, CutensorCudaStream, CutensorHandle, CutensorOperator,
     CutensorWorksizePreference, OperationDescriptor, Plan, PlanPreference, TensorDescriptor,
 };
-use super::{CubeclBackend, CubeclRuntime};
+use super::{CudaBackend, CudaRuntime};
 use crate::config::DotGeneralConfig;
 use crate::kernels::structural;
 use crate::{col_major_strides, Error, Tensor, TypedTensor};
@@ -95,7 +95,7 @@ impl Workspace {
 }
 
 pub(super) fn dot_general(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     lhs: &Tensor,
     rhs: &Tensor,
     config: &DotGeneralConfig,
@@ -118,7 +118,7 @@ pub(super) fn dot_general(
 }
 
 pub(super) fn dot_general_with_conj(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     lhs: &Tensor,
     rhs: &Tensor,
     config: &DotGeneralConfig,
@@ -147,7 +147,7 @@ pub(super) fn dot_general_with_conj(
 }
 
 fn dot_general_typed<T>(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     lhs: &TypedTensor<T>,
     rhs: &TypedTensor<T>,
     config: &DotGeneralConfig,
@@ -159,7 +159,7 @@ where
 }
 
 fn dot_general_typed_with_conj<T>(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     lhs: &TypedTensor<T>,
     rhs: &TypedTensor<T>,
     config: &DotGeneralConfig,
@@ -267,11 +267,11 @@ fn cutensor_conj_op<T: CutensorScalar>(conj: bool) -> CutensorOperator {
     }
 }
 
-fn raw_stream(rt: &CubeclRuntime) -> crate::Result<CutensorCudaStream> {
+fn raw_stream(rt: &CudaRuntime) -> crate::Result<CutensorCudaStream> {
     Ok(rt.raw_cuda_stream()? as usize as CutensorCudaStream)
 }
 
-fn alloc_workspace(rt: &CubeclRuntime, workspace_size: u64) -> crate::Result<Workspace> {
+fn alloc_workspace(rt: &CudaRuntime, workspace_size: u64) -> crate::Result<Workspace> {
     if workspace_size == 0 {
         return Ok(Workspace::none());
     }
@@ -293,7 +293,7 @@ fn alloc_workspace(rt: &CubeclRuntime, workspace_size: u64) -> crate::Result<Wor
 }
 
 fn typed_device_ptr<T: 'static>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     tensor: &TypedTensor<T>,
 ) -> crate::Result<*mut c_void> {
     ensure_resident_on_runtime(rt, tensor, OP)?;
@@ -308,7 +308,7 @@ fn typed_device_ptr<T: 'static>(
     Ok(resource.resource().ptr as usize as *mut c_void)
 }
 
-fn zero_alloc<T>(rt: &CubeclRuntime, shape: &[usize]) -> crate::Result<TypedTensor<T>>
+fn zero_alloc<T>(rt: &CudaRuntime, shape: &[usize]) -> crate::Result<TypedTensor<T>>
 where
     T: CutensorScalar,
 {
@@ -320,7 +320,7 @@ where
         cube_count_for_len(output.n_elements())?,
         cube_dim_1d(),
         |client, count, dim, out| unsafe {
-            structural::fill_zero_kernel::launch_unchecked::<T, CudaRuntime>(
+            structural::fill_zero_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                 client, count, dim, out,
             );
         },
@@ -397,9 +397,9 @@ fn build_layout<T>(
     let lhs_extents = dims_to_i64(lhs.shape())?;
     let rhs_extents = dims_to_i64(rhs.shape())?;
     let output_extents = dims_to_i64(&output_shape)?;
-    let lhs_strides = strides_to_i64(&col_major_strides(lhs.shape()))?;
-    let rhs_strides = strides_to_i64(&col_major_strides(rhs.shape()))?;
-    let output_strides = strides_to_i64(&col_major_strides(&output_shape))?;
+    let lhs_strides = strides_to_i64(&col_major_strides(lhs.shape())?)?;
+    let rhs_strides = strides_to_i64(&col_major_strides(rhs.shape())?)?;
+    let output_strides = strides_to_i64(&col_major_strides(&output_shape)?)?;
 
     Ok(DotGeneralLayout {
         lhs_modes,

--- a/crates/tenferro-gpu/src/cubecl/interop.rs
+++ b/crates/tenferro-gpu/src/cubecl/interop.rs
@@ -3,18 +3,18 @@
 //! This module is intentionally narrow: it exposes the launch, allocation, and
 //! pointer bridges needed by operation-family crates that provide CUDA kernels
 //! against tenferro's CubeCL runtime, without exposing the backend's raw buffer
-//! representation on `CubeclRuntime` or `CubeclBuffer` themselves.
+//! representation on `CudaRuntime` or `CubeclBuffer` themselves.
 
 use std::ffi::c_void;
 use std::fmt;
 
 use cubecl::client::ComputeClient;
 use cubecl::prelude::{ArrayArg, CubeCount, CubeDim, CubeElement, TensorBinding};
-use cubecl_cuda::CudaRuntime;
+use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 
 use crate::{TensorRank, TypedTensor};
 
-use super::{dispatch, CubeclRuntime};
+use super::{dispatch, CudaRuntime};
 
 /// CubeCL-owned byte allocation kept alive for CUDA-library workspace calls.
 pub struct DeviceByteBuffer {
@@ -56,21 +56,21 @@ impl DeviceByteBuffer {
 /// This is for operation-family kernel launches that cannot be implemented
 /// inside `tenferro-gpu` without creating a dependency cycle.
 pub fn with_cubecl_client<R>(
-    rt: &CubeclRuntime,
-    launch: impl FnOnce(&ComputeClient<CudaRuntime>) -> R,
+    rt: &CudaRuntime,
+    launch: impl FnOnce(&ComputeClient<CubeclCudaRuntime>) -> R,
 ) -> R {
     launch(rt.client())
 }
 
 /// Flush the CubeCL client after an unchecked kernel launch.
-pub fn flush_cubecl_client(rt: &CubeclRuntime, op: &'static str) -> crate::Result<()> {
+pub fn flush_cubecl_client(rt: &CudaRuntime, op: &'static str) -> crate::Result<()> {
     rt.client()
         .flush()
         .map_err(|err| crate::Error::backend_failure(op, format!("CubeCL launch failed: {err:?}")))
 }
 
 /// Return the CUDA stream pointer for libraries that must enqueue onto CubeCL's stream.
-pub fn raw_cuda_stream(rt: &CubeclRuntime, op: &'static str) -> crate::Result<u64> {
+pub fn raw_cuda_stream(rt: &CudaRuntime, op: &'static str) -> crate::Result<u64> {
     rt.raw_cuda_stream()
         .map_err(|err| crate::Error::backend_failure(op, err.to_string()))
 }
@@ -87,7 +87,7 @@ pub fn cube_dim_1d() -> CubeDim {
 
 /// Allocate a dense GPU tensor on the runtime's device.
 pub fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     shape: &[usize],
 ) -> crate::Result<TypedTensor<T>> {
     dispatch::alloc_output(rt, shape)
@@ -106,7 +106,7 @@ pub fn ensure_typed_tensor_resident<T: 'static>(
 pub fn typed_tensor_binding<T: CubeElement + Clone>(
     tensor: &TypedTensor<T, impl TensorRank>,
     op: &'static str,
-) -> crate::Result<TensorBinding<CudaRuntime>> {
+) -> crate::Result<TensorBinding<CubeclCudaRuntime>> {
     dispatch::typed_tensor_binding(tensor, op)
 }
 
@@ -114,13 +114,13 @@ pub fn typed_tensor_binding<T: CubeElement + Clone>(
 pub fn typed_tensor_array_arg<T: CubeElement + Clone>(
     tensor: &TypedTensor<T, impl TensorRank>,
     op: &'static str,
-) -> crate::Result<ArrayArg<CudaRuntime>> {
+) -> crate::Result<ArrayArg<CubeclCudaRuntime>> {
     dispatch::typed_tensor_array_arg(tensor, op)
 }
 
 /// Return a raw CUDA device pointer for a CubeCL-backed tensor.
 pub fn typed_device_ptr<T: 'static>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     tensor: &TypedTensor<T, impl TensorRank>,
     op: &'static str,
 ) -> crate::Result<*mut c_void> {
@@ -137,7 +137,11 @@ pub fn typed_device_ptr<T: 'static>(
 }
 
 /// Upload host data into a dense GPU tensor on the runtime's device.
-pub fn upload_typed_tensor<T>(rt: &CubeclRuntime, shape: Vec<usize>, data: Vec<T>) -> TypedTensor<T>
+pub fn upload_typed_tensor<T>(
+    rt: &CudaRuntime,
+    shape: Vec<usize>,
+    data: Vec<T>,
+) -> crate::Result<TypedTensor<T>>
 where
     T: CubeElement + Clone + Send + Sync + 'static,
 {
@@ -152,7 +156,7 @@ where
 
 /// Download a dense CubeCL-backed typed tensor to host memory.
 pub fn download_typed_tensor<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     tensor: &TypedTensor<T, impl TensorRank>,
     op: &'static str,
 ) -> crate::Result<TypedTensor<T>>
@@ -162,10 +166,7 @@ where
     dispatch::ensure_resident_on_runtime(rt, tensor, op)?;
     let buffer = dispatch::cubecl_buffer(tensor, op)?;
     if tensor.n_elements() == 0 {
-        return Ok(TypedTensor::from_vec_col_major(
-            tensor.shape().to_vec(),
-            Vec::new(),
-        ));
+        return TypedTensor::from_vec_col_major(tensor.shape().to_vec(), Vec::new());
     }
     rt.synchronize()?;
     let bytes = rt
@@ -174,15 +175,12 @@ where
         .map_err(|err| {
             crate::Error::backend_failure(op, format!("failed to download tensor: {err:?}"))
         })?;
-    Ok(TypedTensor::from_vec_col_major(
-        tensor.shape().to_vec(),
-        T::from_bytes(&bytes).to_vec(),
-    ))
+    TypedTensor::from_vec_col_major(tensor.shape().to_vec(), T::from_bytes(&bytes).to_vec())
 }
 
 /// Allocate a CubeCL-owned byte workspace and return its CUDA pointer.
 pub fn alloc_device_bytes(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     nbytes: usize,
     op: &'static str,
 ) -> crate::Result<DeviceByteBuffer> {
@@ -195,7 +193,7 @@ pub fn alloc_device_bytes(
 
 /// Upload bytes into a CubeCL-owned workspace and return its CUDA pointer.
 pub fn upload_device_bytes(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     bytes: &[u8],
     op: &'static str,
 ) -> crate::Result<DeviceByteBuffer> {
@@ -207,7 +205,7 @@ pub fn upload_device_bytes(
 }
 
 fn device_bytes_from_handle(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     handle: cubecl_runtime::server::Handle,
     op: &'static str,
 ) -> crate::Result<DeviceByteBuffer> {

--- a/crates/tenferro-gpu/src/cubecl/memory.rs
+++ b/crates/tenferro-gpu/src/cubecl/memory.rs
@@ -2,14 +2,14 @@
 
 use cubecl::client::ComputeClient;
 use cubecl::prelude::CubeElement;
-use cubecl_cuda::CudaRuntime;
+use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 use num_complex::{Complex32, Complex64};
 use std::sync::Arc;
 
 use super::dispatch;
-use crate::cubecl::runtime::CubeclRuntime;
+use crate::cubecl::runtime::CudaRuntime;
 use crate::types::{
-    Buffer, ComputeDevice, CubeclBuffer, DeviceKind, GpuBackendKind, MemoryKind, Placement, Tensor,
+    Buffer, CubeclBuffer, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Tensor,
     TypedTensor,
 };
 
@@ -18,12 +18,12 @@ use crate::types::{
 /// # Examples
 ///
 /// ```
-/// use tenferro_gpu::{upload_tensor, CubeclRuntime};
+/// use tenferro_gpu::{upload_tensor, CudaRuntime};
 /// use tenferro_tensor::{Result, Tensor};
 ///
-/// let _upload: fn(&CubeclRuntime, &Tensor) -> Result<Tensor> = upload_tensor;
+/// let _upload: fn(&CudaRuntime, &Tensor) -> Result<Tensor> = upload_tensor;
 /// ```
-pub fn upload_tensor(rt: &CubeclRuntime, tensor: &Tensor) -> crate::Result<Tensor> {
+pub fn upload_tensor(rt: &CudaRuntime, tensor: &Tensor) -> crate::Result<Tensor> {
     let client = rt.client();
     match tensor {
         Tensor::F64(t) => upload_typed::<f64>(client, rt.device_ordinal(), t).map(Tensor::F64),
@@ -45,12 +45,12 @@ pub fn upload_tensor(rt: &CubeclRuntime, tensor: &Tensor) -> crate::Result<Tenso
 /// # Examples
 ///
 /// ```
-/// use tenferro_gpu::{download_tensor, CubeclRuntime};
+/// use tenferro_gpu::{download_tensor, CudaRuntime};
 /// use tenferro_tensor::{Result, Tensor};
 ///
-/// let _download: fn(&CubeclRuntime, &Tensor) -> Result<Tensor> = download_tensor;
+/// let _download: fn(&CudaRuntime, &Tensor) -> Result<Tensor> = download_tensor;
 /// ```
-pub fn download_tensor(rt: &CubeclRuntime, tensor: &Tensor) -> crate::Result<Tensor> {
+pub fn download_tensor(rt: &CudaRuntime, tensor: &Tensor) -> crate::Result<Tensor> {
     ensure_tensor_resident_on_runtime(rt, tensor, "download")?;
     match tensor {
         Tensor::F64(t) => download_typed::<f64>(rt, t).map(Tensor::F64),
@@ -68,12 +68,12 @@ pub fn download_tensor(rt: &CubeclRuntime, tensor: &Tensor) -> crate::Result<Ten
 /// # Examples
 ///
 /// ```
-/// use tenferro_gpu::{device_ptr, CubeclRuntime};
+/// use tenferro_gpu::{device_ptr, CudaRuntime};
 /// use tenferro_tensor::{Result, Tensor};
 ///
-/// let _device_ptr: fn(&CubeclRuntime, &Tensor) -> Result<u64> = device_ptr;
+/// let _device_ptr: fn(&CudaRuntime, &Tensor) -> Result<u64> = device_ptr;
 /// ```
-pub fn device_ptr(rt: &CubeclRuntime, tensor: &Tensor) -> crate::Result<u64> {
+pub fn device_ptr(rt: &CudaRuntime, tensor: &Tensor) -> crate::Result<u64> {
     ensure_tensor_resident_on_runtime(rt, tensor, "device_ptr")?;
     let handle = cubecl_handle(tensor)?;
     let resource = rt
@@ -84,7 +84,7 @@ pub fn device_ptr(rt: &CubeclRuntime, tensor: &Tensor) -> crate::Result<u64> {
 }
 
 fn upload_typed<T: CubeElement + Clone + Send + Sync + 'static>(
-    client: &ComputeClient<CudaRuntime>,
+    client: &ComputeClient<CubeclCudaRuntime>,
     device_ordinal: usize,
     typed: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>> {
@@ -102,21 +102,21 @@ fn upload_typed<T: CubeElement + Clone + Send + Sync + 'static>(
     };
 
     let handle = client.create_from_slice(T::as_bytes(host_data));
-    Ok(TypedTensor::from_buffer_col_major(
+    TypedTensor::from_buffer_col_major(
         typed.shape().to_vec(),
         Buffer::Backend(Arc::new(CubeclBuffer::new(handle, host_data.len()))),
         Placement {
             memory_kind: MemoryKind::Device,
-            device: Some(ComputeDevice {
+            device: Some(DeviceId {
                 kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
                 ordinal: device_ordinal,
             }),
         },
-    ))
+    )
 }
 
 fn download_typed<T: CubeElement + Clone + 'static>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     typed: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>> {
     let handle = match typed.buffer() {
@@ -130,10 +130,7 @@ fn download_typed<T: CubeElement + Clone + 'static>(
     };
 
     if typed.n_elements() == 0 {
-        return Ok(TypedTensor::from_vec_col_major(
-            typed.shape().to_vec(),
-            Vec::new(),
-        ));
+        return TypedTensor::from_vec_col_major(typed.shape().to_vec(), Vec::new());
     }
 
     rt.synchronize()?;
@@ -142,14 +139,11 @@ fn download_typed<T: CubeElement + Clone + 'static>(
         .read_one(handle)
         .map_err(|err| crate::Error::backend_failure("download", format!("{err:?}")))?;
     let data = T::from_bytes(&bytes).to_vec();
-    Ok(TypedTensor::from_vec_col_major(
-        typed.shape().to_vec(),
-        data,
-    ))
+    TypedTensor::from_vec_col_major(typed.shape().to_vec(), data)
 }
 
 fn upload_bool(
-    client: &ComputeClient<CudaRuntime>,
+    client: &ComputeClient<CubeclCudaRuntime>,
     device_ordinal: usize,
     typed: &TypedTensor<bool>,
 ) -> crate::Result<TypedTensor<bool>> {
@@ -168,23 +162,20 @@ fn upload_bool(
 
     let bytes: Vec<u8> = host_data.iter().map(|&value| u8::from(value)).collect();
     let handle = client.create_from_slice(&bytes);
-    Ok(TypedTensor::from_buffer_col_major(
+    TypedTensor::from_buffer_col_major(
         typed.shape().to_vec(),
         Buffer::Backend(Arc::new(CubeclBuffer::new(handle, host_data.len()))),
         Placement {
             memory_kind: MemoryKind::Device,
-            device: Some(ComputeDevice {
+            device: Some(DeviceId {
                 kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
                 ordinal: device_ordinal,
             }),
         },
-    ))
+    )
 }
 
-fn download_bool(
-    rt: &CubeclRuntime,
-    typed: &TypedTensor<bool>,
-) -> crate::Result<TypedTensor<bool>> {
+fn download_bool(rt: &CudaRuntime, typed: &TypedTensor<bool>) -> crate::Result<TypedTensor<bool>> {
     let handle = match typed.buffer() {
         Buffer::Host(_) => {
             return Err(crate::Error::backend_failure(
@@ -196,10 +187,7 @@ fn download_bool(
     };
 
     if typed.n_elements() == 0 {
-        return Ok(TypedTensor::from_vec_col_major(
-            typed.shape().to_vec(),
-            Vec::new(),
-        ));
+        return TypedTensor::from_vec_col_major(typed.shape().to_vec(), Vec::new());
     }
 
     rt.synchronize()?;
@@ -208,14 +196,11 @@ fn download_bool(
         .read_one(handle)
         .map_err(|err| crate::Error::backend_failure("download", format!("{err:?}")))?;
     let data = bytes.iter().map(|&byte| byte != 0).collect();
-    Ok(TypedTensor::from_vec_col_major(
-        typed.shape().to_vec(),
-        data,
-    ))
+    TypedTensor::from_vec_col_major(typed.shape().to_vec(), data)
 }
 
 fn ensure_tensor_resident_on_runtime(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     tensor: &Tensor,
     op: &'static str,
 ) -> crate::Result<()> {

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -36,7 +36,7 @@
 //! convention).
 //!
 //! ```rust
-//! use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CubeclBackend};
+//! use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CudaBackend};
 //! use tenferro_tensor::{Tensor, TensorElementwise, TypedTensor};
 //!
 //! fn main() -> tenferro_tensor::Result<()> {
@@ -45,7 +45,7 @@
 //! }
 //!
 //! // 1. Create the GPU backend (device ordinal 0)
-//! let mut backend = CubeclBackend::new(0)?;
+//! let mut backend = CudaBackend::new(0)?;
 //!
 //! // 2. Create tensors on the CPU
 //! let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
@@ -91,7 +91,7 @@ use cubecl::prelude::{
     Numeric as CubeNumeric,
 };
 use cubecl::prelude::{Int as CubeInt, StorageType, TensorBinding, Type};
-use cubecl_cuda::CudaRuntime;
+use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 use num_complex::{Complex32, Complex64};
 use tenferro_core_ops::PrimitiveOpKind;
 use tenferro_tensor::CacheStats;
@@ -107,7 +107,7 @@ use crate::config::{
 use crate::kernels::reduce::{self as cubecl_reduce, ReduceStrategy};
 use crate::kernels::{diagonal, elementwise, indexing, structural};
 use crate::{
-    Buffer, ComputeDevice, DeviceKind, GpuBackendKind, MemoryKind, Placement, Tensor, TensorRank,
+    Buffer, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Tensor, TensorRank,
     TensorViewCanonicalization, TypedTensor, TypedTensorView, TypedTensorViewMut,
 };
 
@@ -131,7 +131,7 @@ use dispatch::{
 };
 
 pub use memory::{device_ptr, download_tensor, upload_tensor};
-pub use runtime::{gpu_available, CubeclRuntime};
+pub use runtime::{gpu_available, CudaRuntime};
 
 fn unsupported_dtype(op: &'static str, dtype: crate::DType) -> crate::Error {
     crate::Error::backend_failure(op, format!("unsupported dtype {dtype:?}"))
@@ -145,7 +145,7 @@ fn op_name(
 }
 
 fn ensure_atomic_add_supported<T: CubePrimitive>(
-    client: &ComputeClient<CudaRuntime>,
+    client: &ComputeClient<CubeclCudaRuntime>,
     op: &'static str,
 ) -> crate::Result<()> {
     let elem = T::as_type_native_unchecked().elem_type();
@@ -222,22 +222,22 @@ fn scatter_update_len(meta: &ScatterLaunchMeta) -> crate::Result<usize> {
 /// # Examples
 ///
 /// ```
-/// use tenferro_gpu::CubeclBackend;
+/// use tenferro_gpu::CudaBackend;
 ///
-/// let _ctor: fn(usize) -> tenferro_tensor::Result<CubeclBackend> = CubeclBackend::new;
+/// let _ctor: fn(usize) -> tenferro_tensor::Result<CudaBackend> = CudaBackend::new;
 /// ```
-pub struct CubeclBackend {
+pub struct CudaBackend {
     // CUDA library handles are dropped before `rt`; Rust drops fields in
     // declaration order, so cache-owned handles release while the CUDA primary
-    // context is still retained by `CubeclRuntime`.
+    // context is still retained by `CudaRuntime`.
     cutensor: OnceCell<crate::Result<ffi::cutensor::CutensorHandle>>,
     extension_cache: CudaExtensionCache,
-    rt: CubeclRuntime,
+    rt: CudaRuntime,
 }
 
-impl fmt::Debug for CubeclBackend {
+impl fmt::Debug for CudaBackend {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CubeclBackend")
+        f.debug_struct("CudaBackend")
             .field("runtime", &self.rt)
             .field("cuda_extension_cache", &self.extension_cache)
             .field("cutensor_initialized", &self.cutensor.get().is_some())
@@ -354,30 +354,15 @@ impl CudaExtensionCache {
     /// ```
     /// use tenferro_gpu::CudaExtensionCache;
     ///
-    /// assert!(CudaExtensionCache::new().is_empty());
+    /// assert!(CudaExtensionCache::new().is_empty()?);
+    /// # Ok::<(), tenferro_gpu::Error>(())
     /// ```
-    pub fn is_empty(&self) -> bool {
-        // Compatibility panic wrapper; use `try_is_empty` where lock poison
-        // must be reported as a typed backend error.
-        self.try_is_empty()
-            .expect("CUDA extension cache lock poisoned")
-    }
-
-    /// Fallibly return whether no extension state has been initialized.
-    pub fn try_is_empty(&self) -> crate::Result<bool> {
+    pub fn is_empty(&self) -> crate::Result<bool> {
         Ok(self.lock_inner()?.entries.is_empty())
     }
 
     /// Remove every cached CUDA extension state value.
-    pub fn clear(&self) {
-        // Compatibility panic wrapper; use `try_clear` where lock poison must
-        // be reported as a typed backend error.
-        self.try_clear()
-            .expect("CUDA extension cache lock poisoned");
-    }
-
-    /// Fallibly remove every cached CUDA extension state value.
-    pub fn try_clear(&self) -> crate::Result<()> {
+    pub fn clear(&self) -> crate::Result<()> {
         let mut inner = self.lock_inner()?;
         inner.entries.clear();
         inner.order.clear();
@@ -386,15 +371,7 @@ impl CudaExtensionCache {
     }
 
     /// Snapshot the number of retained entries and logical retained bytes.
-    pub fn stats(&self) -> CacheStats {
-        // Compatibility panic wrapper; use `try_stats` where lock poison must
-        // be reported as a typed backend error.
-        self.try_stats()
-            .expect("CUDA extension cache lock poisoned")
-    }
-
-    /// Fallibly snapshot the number of retained entries and logical retained bytes.
-    pub fn try_stats(&self) -> crate::Result<CacheStats> {
+    pub fn stats(&self) -> crate::Result<CacheStats> {
         let inner = self.lock_inner()?;
         Ok(CacheStats {
             entries: inner.entries.len(),
@@ -403,28 +380,12 @@ impl CudaExtensionCache {
     }
 
     /// Return the configured entry bound.
-    pub fn max_entries(&self) -> NonZeroUsize {
-        // Compatibility panic wrapper; use `try_max_entries` where lock poison
-        // must be reported as a typed backend error.
-        self.try_max_entries()
-            .expect("CUDA extension cache lock poisoned")
-    }
-
-    /// Fallibly return the configured entry bound.
-    pub fn try_max_entries(&self) -> crate::Result<NonZeroUsize> {
+    pub fn max_entries(&self) -> crate::Result<NonZeroUsize> {
         Ok(self.lock_inner()?.max_entries)
     }
 
     /// Replace the entry bound and evict oldest entries if needed.
-    pub fn set_max_entries(&self, max_entries: NonZeroUsize) {
-        // Compatibility panic wrapper; use `try_set_max_entries` where lock
-        // poison must be reported as a typed backend error.
-        self.try_set_max_entries(max_entries)
-            .expect("CUDA extension cache lock poisoned");
-    }
-
-    /// Fallibly replace the entry bound and evict oldest entries if needed.
-    pub fn try_set_max_entries(&self, max_entries: NonZeroUsize) -> crate::Result<()> {
+    pub fn set_max_entries(&self, max_entries: NonZeroUsize) -> crate::Result<()> {
         let mut inner = self.lock_inner()?;
         inner.max_entries = max_entries;
         inner.evict_to_limit();
@@ -505,21 +466,21 @@ impl<T: 'static> Deref for CudaExtensionCacheGuard<'_, T> {
     }
 }
 
-impl CubeclBackend {
+impl CudaBackend {
     /// Create a new CubeCL backend for the given CUDA device ordinal.
     ///
     /// # Examples
     ///
     /// ```
-    /// use tenferro_gpu::CubeclBackend;
+    /// use tenferro_gpu::CudaBackend;
     ///
-    /// let _ctor: fn(usize) -> tenferro_tensor::Result<CubeclBackend> = CubeclBackend::new;
+    /// let _ctor: fn(usize) -> tenferro_tensor::Result<CudaBackend> = CudaBackend::new;
     /// ```
     pub fn new(device_ordinal: usize) -> crate::Result<Self> {
         Ok(Self {
             cutensor: OnceCell::new(),
             extension_cache: CudaExtensionCache::new(),
-            rt: CubeclRuntime::new(device_ordinal)?,
+            rt: CudaRuntime::new(device_ordinal)?,
         })
     }
 
@@ -528,11 +489,11 @@ impl CubeclBackend {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_gpu::{CubeclBackend, CubeclRuntime};
+    /// use tenferro_gpu::{CudaBackend, CudaRuntime};
     ///
-    /// let _runtime: fn(&CubeclBackend) -> &CubeclRuntime = CubeclBackend::runtime;
+    /// let _runtime: fn(&CudaBackend) -> &CudaRuntime = CudaBackend::runtime;
     /// ```
-    pub fn runtime(&self) -> &CubeclRuntime {
+    pub fn runtime(&self) -> &CudaRuntime {
         &self.rt
     }
 
@@ -552,23 +513,26 @@ impl CubeclBackend {
     }
 
     /// Clear CUDA extension-owned backend state.
-    pub fn clear_cuda_extension_cache(&self) {
-        self.extension_cache.clear();
+    pub fn clear_cuda_extension_cache(&self) -> crate::Result<()> {
+        self.extension_cache.clear()
     }
 
     /// Return CUDA extension cache stats.
-    pub fn cuda_extension_cache_stats(&self) -> CacheStats {
+    pub fn cuda_extension_cache_stats(&self) -> crate::Result<CacheStats> {
         self.extension_cache.stats()
     }
 
     /// Return the CUDA extension cache entry bound.
-    pub fn cuda_extension_cache_max_entries(&self) -> NonZeroUsize {
+    pub fn cuda_extension_cache_max_entries(&self) -> crate::Result<NonZeroUsize> {
         self.extension_cache.max_entries()
     }
 
     /// Configure the CUDA extension cache entry bound.
-    pub fn set_cuda_extension_cache_max_entries(&self, max_entries: NonZeroUsize) {
-        self.extension_cache.set_max_entries(max_entries);
+    pub fn set_cuda_extension_cache_max_entries(
+        &self,
+        max_entries: NonZeroUsize,
+    ) -> crate::Result<()> {
+        self.extension_cache.set_max_entries(max_entries)
     }
 
     fn transpose_typed<T>(
@@ -587,7 +551,7 @@ impl CubeclBackend {
             &output_shape,
             "transpose",
             |client, count, dim, out, input_arg| unsafe {
-                structural::transpose_kernel::launch_unchecked::<T, CudaRuntime>(
+                structural::transpose_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -615,7 +579,7 @@ impl CubeclBackend {
             shape,
             "broadcast_in_dim",
             |client, count, dim, out, input_arg| unsafe {
-                structural::broadcast_in_dim_kernel::launch_unchecked::<T, CudaRuntime>(
+                structural::broadcast_in_dim_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -643,7 +607,7 @@ impl CubeclBackend {
             input.shape(),
             "reverse",
             |client, count, dim, out, input_arg| unsafe {
-                structural::reverse_kernel::launch_unchecked::<T, CudaRuntime>(
+                structural::reverse_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -684,12 +648,12 @@ impl CubeclBackend {
             Buffer::Backend(Arc::new(crate::CubeclBuffer::new(handle, len))),
             Placement {
                 memory_kind: MemoryKind::Device,
-                device: Some(ComputeDevice {
+                device: Some(DeviceId {
                     kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
                     ordinal: self.runtime().device_ordinal(),
                 }),
             },
-        ))
+        )?)
     }
 
     fn to_contiguous_view_typed<T, R>(
@@ -717,7 +681,7 @@ impl CubeclBackend {
             // the backing allocation, and `ensure_view_resident_on_runtime`
             // proves this is a CubeCL buffer on this CUDA runtime. The launch
             // domain covers every logical output element exactly once.
-            structural::view_to_contiguous_kernel::launch_unchecked::<T, CudaRuntime>(
+            structural::view_to_contiguous_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                 self.runtime().client(),
                 cube_count_for_len(len)?,
                 cube_dim_1d(),
@@ -767,7 +731,7 @@ impl CubeclBackend {
             // runtime. The destination view has validated reachable offsets
             // and no overlap, and the launch domain covers each source element
             // and destination logical coordinate exactly once.
-            structural::contiguous_to_view_kernel::launch_unchecked::<T, CudaRuntime>(
+            structural::contiguous_to_view_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                 self.runtime().client(),
                 cube_count_for_len(len)?,
                 cube_dim_1d(),
@@ -795,7 +759,7 @@ impl CubeclBackend {
             input.shape(),
             "convert",
             |client, count, dim, out, input_arg| unsafe {
-                structural::convert_float_to_float::launch_unchecked::<Out, In, CudaRuntime>(
+                structural::convert_float_to_float::launch_unchecked::<Out, In, CubeclCudaRuntime>(
                     client, count, dim, out, input_arg,
                 );
             },
@@ -812,7 +776,7 @@ impl CubeclBackend {
                 // `input` has `n` elements and `out` has `2 * n` scalar
                 // components. The kernel launches exactly `n` logical input
                 // positions and guards with `ABSOLUTE_POS < input.len()`.
-                structural::convert_f32_to_c32_raw::launch_unchecked::<CudaRuntime>(
+                structural::convert_f32_to_c32_raw::launch_unchecked::<CubeclCudaRuntime>(
                     client,
                     cube_count_for_len(n)?,
                     cube_dim_1d(),
@@ -834,7 +798,7 @@ impl CubeclBackend {
                 // `input` has `n` elements and `out` has `2 * n` scalar
                 // components. The kernel launches exactly `n` logical input
                 // positions and guards with `ABSOLUTE_POS < input.len()`.
-                structural::convert_f32_to_c64_raw::launch_unchecked::<CudaRuntime>(
+                structural::convert_f32_to_c64_raw::launch_unchecked::<CubeclCudaRuntime>(
                     client,
                     cube_count_for_len(n)?,
                     cube_dim_1d(),
@@ -856,7 +820,7 @@ impl CubeclBackend {
                 // `input` has `n` elements and `out` has `2 * n` scalar
                 // components. The kernel launches exactly `n` logical input
                 // positions and guards with `ABSOLUTE_POS < input.len()`.
-                structural::convert_f64_to_c32_raw::launch_unchecked::<CudaRuntime>(
+                structural::convert_f64_to_c32_raw::launch_unchecked::<CubeclCudaRuntime>(
                     client,
                     cube_count_for_len(n)?,
                     cube_dim_1d(),
@@ -878,7 +842,7 @@ impl CubeclBackend {
                 // `input` has `n` elements and `out` has `2 * n` scalar
                 // components. The kernel launches exactly `n` logical input
                 // positions and guards with `ABSOLUTE_POS < input.len()`.
-                structural::convert_f64_to_c64_raw::launch_unchecked::<CudaRuntime>(
+                structural::convert_f64_to_c64_raw::launch_unchecked::<CubeclCudaRuntime>(
                     client,
                     cube_count_for_len(n)?,
                     cube_dim_1d(),
@@ -898,9 +862,9 @@ impl CubeclBackend {
         &self,
         input: &TypedTensor<InFloat>,
         launch: impl FnOnce(
-            &cubecl::client::ComputeClient<CudaRuntime>,
-            ArrayArg<CudaRuntime>,
-            ArrayArg<CudaRuntime>,
+            &cubecl::client::ComputeClient<CubeclCudaRuntime>,
+            ArrayArg<CubeclCudaRuntime>,
+            ArrayArg<CubeclCudaRuntime>,
             usize,
         ) -> crate::Result<()>,
     ) -> crate::Result<TypedTensor<OutComplex>>
@@ -937,7 +901,7 @@ impl CubeclBackend {
             input.shape(),
             "convert",
             |client, count, dim, out, input_arg| unsafe {
-                structural::convert_c32_to_f32::launch_unchecked::<CudaRuntime>(
+                structural::convert_c32_to_f32::launch_unchecked::<CubeclCudaRuntime>(
                     client, count, dim, out, input_arg,
                 );
             },
@@ -954,7 +918,7 @@ impl CubeclBackend {
             input.shape(),
             "convert",
             |client, count, dim, out, input_arg| unsafe {
-                structural::convert_c32_to_f64::launch_unchecked::<CudaRuntime>(
+                structural::convert_c32_to_f64::launch_unchecked::<CubeclCudaRuntime>(
                     client, count, dim, out, input_arg,
                 );
             },
@@ -971,7 +935,7 @@ impl CubeclBackend {
             input.shape(),
             "convert",
             |client, count, dim, out, input_arg| unsafe {
-                structural::convert_c64_to_f32::launch_unchecked::<CudaRuntime>(
+                structural::convert_c64_to_f32::launch_unchecked::<CubeclCudaRuntime>(
                     client, count, dim, out, input_arg,
                 );
             },
@@ -988,7 +952,7 @@ impl CubeclBackend {
             input.shape(),
             "convert",
             |client, count, dim, out, input_arg| unsafe {
-                structural::convert_c64_to_f64::launch_unchecked::<CudaRuntime>(
+                structural::convert_c64_to_f64::launch_unchecked::<CubeclCudaRuntime>(
                     client, count, dim, out, input_arg,
                 );
             },
@@ -1009,9 +973,11 @@ impl CubeclBackend {
             input.shape(),
             "convert",
             |client, count, dim, out, input_arg| unsafe {
-                structural::convert_complex_to_complex::launch_unchecked::<Out, In, CudaRuntime>(
-                    client, count, dim, out, input_arg,
-                );
+                structural::convert_complex_to_complex::launch_unchecked::<
+                    Out,
+                    In,
+                    CubeclCudaRuntime,
+                >(client, count, dim, out, input_arg);
             },
         )
     }
@@ -1033,7 +999,7 @@ impl CubeclBackend {
             &output_shape,
             "extract_diagonal",
             |client, count, dim, out, input_arg| unsafe {
-                diagonal::extract_diagonal_kernel::launch_unchecked::<T, CudaRuntime>(
+                diagonal::extract_diagonal_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -1067,7 +1033,7 @@ impl CubeclBackend {
             cube_count_for_len(output.n_elements())?,
             cube_dim_1d(),
             |client, count, dim, out| unsafe {
-                structural::fill_zero_kernel::launch_unchecked::<T, CudaRuntime>(
+                structural::fill_zero_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                     client, count, dim, out,
                 );
             },
@@ -1080,7 +1046,7 @@ impl CubeclBackend {
             cube_count_for_len(input.n_elements())?,
             cube_dim_1d(),
             |client, count, dim, out, input_arg| unsafe {
-                diagonal::embed_diagonal_copy_kernel::launch_unchecked::<T, CudaRuntime>(
+                diagonal::embed_diagonal_copy_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -1114,7 +1080,7 @@ impl CubeclBackend {
             input.shape(),
             "tril",
             |client, count, dim, out, input_arg| unsafe {
-                diagonal::tril_kernel::launch_unchecked::<T, CudaRuntime>(
+                diagonal::tril_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -1144,7 +1110,7 @@ impl CubeclBackend {
             input.shape(),
             "triu",
             |client, count, dim, out, input_arg| unsafe {
-                diagonal::triu_kernel::launch_unchecked::<T, CudaRuntime>(
+                diagonal::triu_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -1162,9 +1128,9 @@ impl CubeclBackend {
         axis: usize,
         op: &'static str,
         launch: impl FnOnce(
-            &ComputeClient<CudaRuntime>,
-            TensorBinding<CudaRuntime>,
-            TensorBinding<CudaRuntime>,
+            &ComputeClient<CubeclCudaRuntime>,
+            TensorBinding<CubeclCudaRuntime>,
+            TensorBinding<CubeclCudaRuntime>,
         ) -> crate::kernels::Result<()>,
     ) -> crate::Result<TypedTensor<T>>
     where
@@ -1221,7 +1187,7 @@ impl CubeclBackend {
         )?;
         self.reduce_axes_typed(input, axes, op, |backend, current, axis| {
             backend.launch_reduce_axis_typed(current, axis, op, |client, input, output| {
-                cubecl_reduce::launch_sum_float::<CudaRuntime, F>(
+                cubecl_reduce::launch_sum_float::<CubeclCudaRuntime, F>(
                     client,
                     input,
                     output,
@@ -1243,7 +1209,7 @@ impl CubeclBackend {
         )?;
         self.reduce_axes_typed(input, axes, op, |backend, current, axis| {
             backend.launch_reduce_axis_typed(current, axis, op, |client, input, output| {
-                cubecl_reduce::launch_sum_complex::<CudaRuntime, C>(
+                cubecl_reduce::launch_sum_complex::<CubeclCudaRuntime, C>(
                     client,
                     input,
                     output,
@@ -1265,7 +1231,7 @@ impl CubeclBackend {
         )?;
         self.reduce_axes_typed(input, axes, op, |backend, current, axis| {
             backend.launch_reduce_axis_typed(current, axis, op, |client, input, output| {
-                cubecl_reduce::launch_sum_int::<CudaRuntime, I>(
+                cubecl_reduce::launch_sum_int::<CubeclCudaRuntime, I>(
                     client,
                     input,
                     output,
@@ -1287,7 +1253,7 @@ impl CubeclBackend {
         )?;
         self.reduce_axes_typed(input, axes, op, |backend, current, axis| {
             backend.launch_reduce_axis_typed(current, axis, op, |client, input, output| {
-                cubecl_reduce::launch_prod_float::<CudaRuntime, F>(
+                cubecl_reduce::launch_prod_float::<CubeclCudaRuntime, F>(
                     client,
                     input,
                     output,
@@ -1309,7 +1275,7 @@ impl CubeclBackend {
         )?;
         self.reduce_axes_typed(input, axes, op, |backend, current, axis| {
             backend.launch_reduce_axis_typed(current, axis, op, |client, input, output| {
-                cubecl_reduce::launch_prod_complex::<CudaRuntime, C>(
+                cubecl_reduce::launch_prod_complex::<CubeclCudaRuntime, C>(
                     client,
                     input,
                     output,
@@ -1331,7 +1297,7 @@ impl CubeclBackend {
         )?;
         self.reduce_axes_typed(input, axes, op, |backend, current, axis| {
             backend.launch_reduce_axis_typed(current, axis, op, |client, input, output| {
-                cubecl_reduce::launch_prod_int::<CudaRuntime, I>(
+                cubecl_reduce::launch_prod_int::<CubeclCudaRuntime, I>(
                     client,
                     input,
                     output,
@@ -1353,7 +1319,7 @@ impl CubeclBackend {
         )?;
         self.reduce_axes_typed(input, axes, op, |backend, current, axis| {
             backend.launch_reduce_axis_typed(current, axis, op, |client, input, output| {
-                cubecl_reduce::launch_max_float::<CudaRuntime, F>(
+                cubecl_reduce::launch_max_float::<CubeclCudaRuntime, F>(
                     client,
                     input,
                     output,
@@ -1375,7 +1341,7 @@ impl CubeclBackend {
         )?;
         self.reduce_axes_typed(input, axes, op, |backend, current, axis| {
             backend.launch_reduce_axis_typed(current, axis, op, |client, input, output| {
-                cubecl_reduce::launch_min_float::<CudaRuntime, F>(
+                cubecl_reduce::launch_min_float::<CubeclCudaRuntime, F>(
                     client,
                     input,
                     output,
@@ -1402,7 +1368,7 @@ impl CubeclBackend {
             &output_shape,
             "slice",
             |client, count, dim, out, input_arg| unsafe {
-                indexing::slice_kernel::launch_unchecked::<T, CudaRuntime>(
+                indexing::slice_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -1449,7 +1415,7 @@ impl CubeclBackend {
             slice_sizes,
             "dynamic_slice",
             |client, count, dim, out, input_arg, starts_arg| unsafe {
-                indexing::dynamic_slice_kernel::launch_unchecked::<T, I, CudaRuntime>(
+                indexing::dynamic_slice_kernel::launch_unchecked::<T, I, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -1477,7 +1443,7 @@ impl CubeclBackend {
             &output_shape,
             "pad",
             |client, count, dim, out, input_arg| unsafe {
-                indexing::pad_kernel::launch_unchecked::<T, CudaRuntime>(
+                indexing::pad_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -1510,7 +1476,7 @@ impl CubeclBackend {
                 cube_count_for_len(input.n_elements())?,
                 cube_dim_1d(),
                 |client, count, dim, out, input_arg| unsafe {
-                    structural::concatenate_copy_kernel::launch_unchecked::<T, CudaRuntime>(
+                    structural::concatenate_copy_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                         client,
                         count,
                         dim,
@@ -1545,7 +1511,7 @@ impl CubeclBackend {
             &meta.output_shape,
             "gather",
             |client, count, dim, out, operand_arg, indices_arg| unsafe {
-                indexing::gather_kernel::launch_unchecked::<T, I, CudaRuntime>(
+                indexing::gather_kernel::launch_unchecked::<T, I, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -1595,7 +1561,7 @@ impl CubeclBackend {
             cube_count_for_len(output.n_elements())?,
             cube_dim_1d(),
             |client, count, dim, out_arg, operand_arg| unsafe {
-                indexing::scatter_copy_kernel::launch_unchecked::<T, CudaRuntime>(
+                indexing::scatter_copy_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -1623,7 +1589,7 @@ impl CubeclBackend {
             // validates every logical tensor buffer length. The launch domain
             // is `scatter_update_len(meta)`, and the kernel maps each launched
             // update through the validated metadata before indexing.
-            indexing::scatter_float_kernel::launch_unchecked::<T, I, CudaRuntime>(
+            indexing::scatter_float_kernel::launch_unchecked::<T, I, CubeclCudaRuntime>(
                 client,
                 cube_count_for_len(update_len)?,
                 cube_dim_1d(),
@@ -1674,7 +1640,7 @@ impl CubeclBackend {
             cube_count_for_len(output.n_elements())?,
             cube_dim_1d(),
             |client, count, dim, out_arg, operand_arg| unsafe {
-                indexing::scatter_copy_kernel::launch_unchecked::<T, CudaRuntime>(
+                indexing::scatter_copy_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                     client,
                     count,
                     dim,
@@ -1713,7 +1679,7 @@ impl CubeclBackend {
             // backing allocations. The launch domain is
             // `scatter_update_len(meta)` and the kernel indexes via the
             // validated metadata.
-            indexing::scatter_complex_kernel::launch_unchecked::<T, F, I, CudaRuntime>(
+            indexing::scatter_complex_kernel::launch_unchecked::<T, F, I, CubeclCudaRuntime>(
                 client,
                 cube_count_for_len(update_len)?,
                 cube_dim_1d(),
@@ -1735,11 +1701,11 @@ impl CubeclBackend {
     }
 }
 
-impl BackendRuntimeCache for CubeclBackend {
+impl BackendRuntimeCache for CudaBackend {
     type RuntimeCache = ();
 }
 
-impl TensorElementwise for CubeclBackend {
+impl TensorElementwise for CudaBackend {
     fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         dispatch::dispatch_binary_float_complex!(
             self,
@@ -1795,7 +1761,7 @@ impl TensorElementwise for CubeclBackend {
                 tensor.shape(),
                 op,
                 |client, count, dim, out, input_arg| unsafe {
-                    elementwise::conj_complex::launch_unchecked::<Complex32, CudaRuntime>(
+                    elementwise::conj_complex::launch_unchecked::<Complex32, CubeclCudaRuntime>(
                         client, count, dim, out, input_arg,
                     );
                 },
@@ -1807,7 +1773,7 @@ impl TensorElementwise for CubeclBackend {
                 tensor.shape(),
                 op,
                 |client, count, dim, out, input_arg| unsafe {
-                    elementwise::conj_complex::launch_unchecked::<Complex64, CudaRuntime>(
+                    elementwise::conj_complex::launch_unchecked::<Complex64, CubeclCudaRuntime>(
                         client, count, dim, out, input_arg,
                     );
                 },
@@ -1868,7 +1834,7 @@ impl TensorElementwise for CubeclBackend {
                 lhs.shape(),
                 op,
                 |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                    elementwise::compare_float_bool::launch_unchecked::<f32, CudaRuntime>(
+                    elementwise::compare_float_bool::launch_unchecked::<f32, CubeclCudaRuntime>(
                         client,
                         count,
                         dim,
@@ -1887,7 +1853,7 @@ impl TensorElementwise for CubeclBackend {
                 lhs.shape(),
                 op,
                 |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                    elementwise::compare_float_bool::launch_unchecked::<f64, CudaRuntime>(
+                    elementwise::compare_float_bool::launch_unchecked::<f64, CubeclCudaRuntime>(
                         client,
                         count,
                         dim,
@@ -1926,7 +1892,7 @@ impl TensorElementwise for CubeclBackend {
                     pred.shape(),
                     op,
                     |client, count, dim, out, pred_arg, true_arg, false_arg| unsafe {
-                        elementwise::select_bool_float::launch_unchecked::<f32, CudaRuntime>(
+                        elementwise::select_bool_float::launch_unchecked::<f32, CubeclCudaRuntime>(
                             client, count, dim, out, pred_arg, true_arg, false_arg,
                         );
                     },
@@ -1942,7 +1908,7 @@ impl TensorElementwise for CubeclBackend {
                     pred.shape(),
                     op,
                     |client, count, dim, out, pred_arg, true_arg, false_arg| unsafe {
-                        elementwise::select_bool_float::launch_unchecked::<f64, CudaRuntime>(
+                        elementwise::select_bool_float::launch_unchecked::<f64, CubeclCudaRuntime>(
                             client, count, dim, out, pred_arg, true_arg, false_arg,
                         );
                     },
@@ -1971,7 +1937,7 @@ impl TensorElementwise for CubeclBackend {
                 input.shape(),
                 op,
                 |client, count, dim, out, input_arg, lower_arg, upper_arg| unsafe {
-                    elementwise::clamp_float::launch_unchecked::<f32, CudaRuntime>(
+                    elementwise::clamp_float::launch_unchecked::<f32, CubeclCudaRuntime>(
                         client, count, dim, out, input_arg, lower_arg, upper_arg,
                     );
                 },
@@ -1985,7 +1951,7 @@ impl TensorElementwise for CubeclBackend {
                 input.shape(),
                 op,
                 |client, count, dim, out, input_arg, lower_arg, upper_arg| unsafe {
-                    elementwise::clamp_float::launch_unchecked::<f64, CudaRuntime>(
+                    elementwise::clamp_float::launch_unchecked::<f64, CubeclCudaRuntime>(
                         client, count, dim, out, input_arg, lower_arg, upper_arg,
                     );
                 },
@@ -2000,7 +1966,7 @@ impl TensorElementwise for CubeclBackend {
     }
 }
 
-impl TensorAnalytic for CubeclBackend {
+impl TensorAnalytic for CudaBackend {
     fn exp(&mut self, input: &Tensor) -> crate::Result<Tensor> {
         dispatch::dispatch_unary_float_only!(self, input, PrimitiveOpKind::Exp, exp_float)
     }
@@ -2042,7 +2008,7 @@ impl TensorAnalytic for CubeclBackend {
     }
 }
 
-impl TensorStructural for CubeclBackend {
+impl TensorStructural for CudaBackend {
     fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
         match input {
             Tensor::F32(t) => self.transpose_typed(t, perm).map(Tensor::F32),
@@ -2070,37 +2036,37 @@ impl TensorStructural for CubeclBackend {
                 shape.to_vec(),
                 t.buffer().clone(),
                 t.placement().clone(),
-            ))),
+            )?)),
             Tensor::F64(t) => Ok(Tensor::F64(TypedTensor::from_buffer_col_major(
                 shape.to_vec(),
                 t.buffer().clone(),
                 t.placement().clone(),
-            ))),
+            )?)),
             Tensor::I32(t) => Ok(Tensor::I32(TypedTensor::from_buffer_col_major(
                 shape.to_vec(),
                 t.buffer().clone(),
                 t.placement().clone(),
-            ))),
+            )?)),
             Tensor::I64(t) => Ok(Tensor::I64(TypedTensor::from_buffer_col_major(
                 shape.to_vec(),
                 t.buffer().clone(),
                 t.placement().clone(),
-            ))),
+            )?)),
             Tensor::Bool(t) => Ok(Tensor::Bool(TypedTensor::from_buffer_col_major(
                 shape.to_vec(),
                 t.buffer().clone(),
                 t.placement().clone(),
-            ))),
+            )?)),
             Tensor::C32(t) => Ok(Tensor::C32(TypedTensor::from_buffer_col_major(
                 shape.to_vec(),
                 t.buffer().clone(),
                 t.placement().clone(),
-            ))),
+            )?)),
             Tensor::C64(t) => Ok(Tensor::C64(TypedTensor::from_buffer_col_major(
                 shape.to_vec(),
                 t.buffer().clone(),
                 t.placement().clone(),
-            ))),
+            )?)),
         }
     }
 
@@ -2255,7 +2221,7 @@ impl TensorStructural for CubeclBackend {
     }
 }
 
-impl TensorReduction for CubeclBackend {
+impl TensorReduction for CudaBackend {
     fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         let op = op_name(
             PrimitiveOpKind::ReduceSum,
@@ -2323,7 +2289,7 @@ impl TensorReduction for CubeclBackend {
     }
 }
 
-impl TensorDot for CubeclBackend {
+impl TensorDot for CudaBackend {
     fn dot_general(
         &mut self,
         lhs: &Tensor,
@@ -2345,7 +2311,7 @@ impl TensorDot for CubeclBackend {
     }
 }
 
-impl TensorIndexing for CubeclBackend {
+impl TensorIndexing for CudaBackend {
     fn gather(
         &mut self,
         operand: &Tensor,
@@ -2694,7 +2660,7 @@ impl TensorIndexing for CubeclBackend {
     }
 }
 
-impl TensorDeviceTransfer for CubeclBackend {
+impl TensorDeviceTransfer for CudaBackend {
     fn download_to_host(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
         download_tensor(self.runtime(), tensor)
     }
@@ -2707,7 +2673,7 @@ impl TensorDeviceTransfer for CubeclBackend {
 macro_rules! impl_cubecl_view_canonicalization {
     ($($ty:ty),* $(,)?) => {
         $(
-            impl<R> TensorViewCanonicalization<$ty, R> for CubeclBackend
+            impl<R> TensorViewCanonicalization<$ty, R> for CudaBackend
             where
                 R: TensorRank,
             {
@@ -2715,7 +2681,7 @@ macro_rules! impl_cubecl_view_canonicalization {
                     &mut self,
                     view: &TypedTensorView<'_, $ty, R>,
                 ) -> crate::Result<TypedTensor<$ty, R>> {
-                    self.to_contiguous_view_typed(view, "CubeclBackend::to_contiguous")
+                    self.to_contiguous_view_typed(view, "CudaBackend::to_contiguous")
                 }
 
                 fn copy_from_contiguous(
@@ -2726,7 +2692,7 @@ macro_rules! impl_cubecl_view_canonicalization {
                     self.copy_contiguous_to_view_typed(
                         src,
                         dst,
-                        "CubeclBackend::copy_from_contiguous",
+                        "CudaBackend::copy_from_contiguous",
                     )
                 }
             }
@@ -2736,7 +2702,7 @@ macro_rules! impl_cubecl_view_canonicalization {
 
 impl_cubecl_view_canonicalization!(f32, f64, i32, i64, Complex32, Complex64);
 
-impl<R> TensorViewCanonicalization<bool, R> for CubeclBackend
+impl<R> TensorViewCanonicalization<bool, R> for CudaBackend
 where
     R: TensorRank,
 {
@@ -2745,7 +2711,7 @@ where
         _view: &TypedTensorView<'_, bool, R>,
     ) -> crate::Result<TypedTensor<bool, R>> {
         Err(unsupported_dtype(
-            "CubeclBackend::to_contiguous",
+            "CudaBackend::to_contiguous",
             crate::DType::Bool,
         ))
     }
@@ -2756,13 +2722,13 @@ where
         _dst: &mut TypedTensorViewMut<'_, bool, R>,
     ) -> crate::Result<()> {
         Err(unsupported_dtype(
-            "CubeclBackend::copy_from_contiguous",
+            "CudaBackend::copy_from_contiguous",
             crate::DType::Bool,
         ))
     }
 }
 
-impl TensorFusion for CubeclBackend {
+impl TensorFusion for CudaBackend {
     fn execute_elementwise_fusion(
         &mut self,
         inputs: &[&Tensor],
@@ -2772,13 +2738,13 @@ impl TensorFusion for CubeclBackend {
     }
 }
 
-impl BackendCachedDot for CubeclBackend {}
+impl BackendCachedDot for CudaBackend {}
 
-impl BackendSessionHost for CubeclBackend {}
+impl BackendSessionHost for CudaBackend {}
 
-impl TensorBuffer for CubeclBackend {}
+impl TensorBuffer for CudaBackend {}
 
-impl TensorBackend for CubeclBackend {}
+impl TensorBackend for CudaBackend {}
 
 fn validate_permutation(op: &'static str, perm: &[usize], rank: usize) -> crate::Result<()> {
     ensure_rank(op, rank, perm.len())?;
@@ -2899,7 +2865,9 @@ fn cubecl_reshape_metadata<T: CubeElement + Clone>(
     }
 
     let (buffer, _, placement) = tensor.into_parts();
-    Ok(TypedTensor::from_buffer_col_major(shape, buffer, placement))
+    Ok(TypedTensor::from_buffer_col_major(
+        shape, buffer, placement,
+    )?)
 }
 
 fn validate_slice(input_shape: &[usize], config: &SliceConfig) -> crate::Result<Vec<usize>> {

--- a/crates/tenferro-gpu/src/cubecl/runtime.rs
+++ b/crates/tenferro-gpu/src/cubecl/runtime.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use cubecl::client::ComputeClient;
 use cubecl::stream_id::StreamId;
 use cubecl::Runtime;
-use cubecl_cuda::{CudaDevice, CudaRuntime};
+use cubecl_cuda::{CudaDevice, CudaRuntime as CubeclCudaRuntime};
 use cudarc::driver::sys::{CUcontext, CUdevice};
 use cudarc::runtime::{result as cuda_result, sys::cudaStream_t};
 
@@ -15,7 +15,7 @@ use cudarc::runtime::{result as cuda_result, sys::cudaStream_t};
 pub fn gpu_available() -> bool {
     std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         let device = CudaDevice::new(0);
-        let _ = CudaRuntime::client(&device);
+        let _ = CubeclCudaRuntime::client(&device);
     }))
     .is_ok()
 }
@@ -25,22 +25,22 @@ pub fn gpu_available() -> bool {
 /// # Examples
 ///
 /// ```
-/// use tenferro_gpu::CubeclRuntime;
+/// use tenferro_gpu::CudaRuntime;
 ///
-/// let _ctor: fn(usize) -> tenferro_tensor::Result<CubeclRuntime> = CubeclRuntime::new;
-/// let _sync: fn(&CubeclRuntime) -> tenferro_tensor::Result<()> =
-///     CubeclRuntime::synchronize;
+/// let _ctor: fn(usize) -> tenferro_tensor::Result<CudaRuntime> = CudaRuntime::new;
+/// let _sync: fn(&CudaRuntime) -> tenferro_tensor::Result<()> =
+///     CudaRuntime::synchronize;
 /// ```
-pub struct CubeclRuntime {
-    client: ComputeClient<CudaRuntime>,
+pub struct CudaRuntime {
+    client: ComputeClient<CubeclCudaRuntime>,
     device_ordinal: usize,
     cuda_device: CUdevice,
     cuda_context: CUcontext,
 }
 
-impl fmt::Debug for CubeclRuntime {
+impl fmt::Debug for CudaRuntime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("CubeclRuntime")
+        f.debug_struct("CudaRuntime")
             .field("device_ordinal", &self.device_ordinal)
             .finish_non_exhaustive()
     }
@@ -49,17 +49,17 @@ impl fmt::Debug for CubeclRuntime {
 // SAFETY: CUDA primary contexts and CubeCL clients are owned handles. Backend
 // methods set the context current before raw CUDA-library calls, and
 // higher-level eager execution serializes backend access through a mutex.
-unsafe impl Send for CubeclRuntime {}
+unsafe impl Send for CudaRuntime {}
 
-impl CubeclRuntime {
+impl CudaRuntime {
     /// Initialize the CubeCL CUDA runtime on the given device ordinal.
     ///
     /// # Examples
     ///
     /// ```
-    /// use tenferro_gpu::CubeclRuntime;
+    /// use tenferro_gpu::CudaRuntime;
     ///
-    /// let _ctor: fn(usize) -> tenferro_tensor::Result<CubeclRuntime> = CubeclRuntime::new;
+    /// let _ctor: fn(usize) -> tenferro_tensor::Result<CudaRuntime> = CudaRuntime::new;
     /// ```
     pub fn new(device_ordinal: usize) -> crate::Result<Self> {
         cudarc::runtime::result::device::set(device_ordinal as i32).map_err(|err| {
@@ -95,7 +95,7 @@ impl CubeclRuntime {
             )
         })?;
         let device = CudaDevice::new(device_ordinal);
-        let client = CudaRuntime::client(&device);
+        let client = CubeclCudaRuntime::client(&device);
         Ok(Self {
             client,
             device_ordinal,
@@ -104,7 +104,7 @@ impl CubeclRuntime {
         })
     }
 
-    pub(crate) fn client(&self) -> &ComputeClient<CudaRuntime> {
+    pub(crate) fn client(&self) -> &ComputeClient<CubeclCudaRuntime> {
         &self.client
     }
 
@@ -113,9 +113,9 @@ impl CubeclRuntime {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_gpu::CubeclRuntime;
+    /// use tenferro_gpu::CudaRuntime;
     ///
-    /// let _device_ordinal: fn(&CubeclRuntime) -> usize = CubeclRuntime::device_ordinal;
+    /// let _device_ordinal: fn(&CudaRuntime) -> usize = CudaRuntime::device_ordinal;
     /// ```
     pub fn device_ordinal(&self) -> usize {
         self.device_ordinal
@@ -154,10 +154,10 @@ impl CubeclRuntime {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_gpu::CubeclRuntime;
+    /// use tenferro_gpu::CudaRuntime;
     ///
-    /// let _sync: fn(&CubeclRuntime) -> tenferro_tensor::Result<()> =
-    ///     CubeclRuntime::synchronize;
+    /// let _sync: fn(&CudaRuntime) -> tenferro_tensor::Result<()> =
+    ///     CudaRuntime::synchronize;
     /// ```
     pub fn synchronize(&self) -> crate::Result<()> {
         const OP: &str = "cubecl_runtime_synchronize";
@@ -169,7 +169,7 @@ impl CubeclRuntime {
     }
 }
 
-impl Drop for CubeclRuntime {
+impl Drop for CudaRuntime {
     fn drop(&mut self) {
         // Drop cannot surface errors, but the runtime must not release the
         // primary context while queued kernels may still reference it.

--- a/crates/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
@@ -7,15 +7,14 @@ use crate::cubecl::dispatch::{
 };
 use crate::cubecl::CudaExtensionCache;
 use crate::{
-    Buffer, ComputeDevice, CubeclBuffer, DeviceKind, GpuBackendKind, MemoryKind, Placement,
-    TypedTensor,
+    Buffer, CubeclBuffer, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, TypedTensor,
 };
 
 #[test]
 fn cubecl_metadata_uses_dense_column_major_strides() {
-    assert_eq!(cubecl_shape_and_strides(&[]), (vec![1], vec![1]));
+    assert_eq!(cubecl_shape_and_strides(&[]).unwrap(), (vec![1], vec![1]));
     assert_eq!(
-        cubecl_shape_and_strides(&[2, 3, 4]),
+        cubecl_shape_and_strides(&[2, 3, 4]).unwrap(),
         (vec![2, 3, 4], vec![1, 2, 6])
     );
 }
@@ -56,8 +55,8 @@ fn cuda_extension_cache_is_type_indexed_and_lazy() {
 #[test]
 fn cuda_extension_cache_reports_stats_and_clear() {
     let cache = CudaExtensionCache::new();
-    assert_eq!(cache.stats().entries, 0);
-    assert_eq!(cache.stats().retained_bytes, 0);
+    assert_eq!(cache.stats().unwrap().entries, 0);
+    assert_eq!(cache.stats().unwrap().retained_bytes, 0);
 
     let _usize = cache.get_or_try_init::<usize>(|| Ok(17)).unwrap();
     drop(_usize);
@@ -66,17 +65,17 @@ fn cuda_extension_cache_reports_stats_and_clear() {
         .unwrap();
     drop(_string);
 
-    let stats = cache.stats();
+    let stats = cache.stats().unwrap();
     assert_eq!(stats.entries, 2);
     assert!(stats.retained_bytes >= std::mem::size_of::<usize>());
 
-    cache.clear();
-    assert!(cache.is_empty());
-    assert_eq!(cache.stats().entries, 0);
+    cache.clear().unwrap();
+    assert!(cache.is_empty().unwrap());
+    assert_eq!(cache.stats().unwrap().entries, 0);
 }
 
 #[test]
-fn cuda_extension_cache_try_methods_report_poisoned_lock() {
+fn cuda_extension_cache_methods_report_poisoned_lock() {
     let cache = CudaExtensionCache::new();
     let poisoned = panic::catch_unwind(panic::AssertUnwindSafe(|| {
         let _guard = cache.inner.lock().unwrap();
@@ -84,10 +83,10 @@ fn cuda_extension_cache_try_methods_report_poisoned_lock() {
     }));
     assert!(poisoned.is_err());
 
-    assert!(cache.try_is_empty().is_err());
-    assert!(cache.try_stats().is_err());
-    assert!(cache.try_clear().is_err());
-    assert!(cache.try_max_entries().is_err());
+    assert!(cache.is_empty().is_err());
+    assert!(cache.stats().is_err());
+    assert!(cache.clear().is_err());
+    assert!(cache.max_entries().is_err());
     assert!(cache.get_or_try_init::<usize>(|| Ok(17)).is_err());
 }
 
@@ -110,7 +109,7 @@ fn cuda_extension_cache_has_configurable_entry_bound() {
         .unwrap();
     assert_eq!(value.as_str(), "gpu");
     drop(value);
-    assert_eq!(cache.stats().entries, 1);
+    assert_eq!(cache.stats().unwrap().entries, 1);
 
     let value = cache
         .get_or_try_init::<usize>(|| {
@@ -176,10 +175,11 @@ fn cubecl_tensor_with_len(shape: Vec<usize>, len: usize) -> TypedTensor<f32> {
         Buffer::Backend(std::sync::Arc::new(CubeclBuffer::new(handle, len))),
         Placement {
             memory_kind: MemoryKind::Device,
-            device: Some(ComputeDevice {
+            device: Some(DeviceId {
                 kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
                 ordinal: 0,
             }),
         },
     )
+    .unwrap()
 }

--- a/crates/tenferro-gpu/src/cubecl/tests/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/mod.rs
@@ -1,7 +1,7 @@
 use num_complex::{Complex32, Complex64};
 
 use crate::config::{GatherConfig, ScatterConfig};
-use crate::cubecl::{download_tensor, upload_tensor, CubeclBackend};
+use crate::cubecl::{download_tensor, upload_tensor, CudaBackend};
 use crate::{Tensor, TypedTensor};
 use tenferro_cpu::CpuBackend;
 
@@ -18,44 +18,44 @@ fn cpu_backend() -> CpuBackend {
     CpuBackend::new()
 }
 
-fn gpu_backend() -> CubeclBackend {
-    CubeclBackend::new(0).unwrap()
+fn gpu_backend() -> CudaBackend {
+    CudaBackend::new(0).unwrap()
 }
 
-fn upload(backend: &CubeclBackend, tensor: &Tensor) -> Tensor {
+fn upload(backend: &CudaBackend, tensor: &Tensor) -> Tensor {
     upload_tensor(backend.runtime(), tensor).unwrap()
 }
 
-fn download(backend: &CubeclBackend, tensor: &Tensor) -> Tensor {
+fn download(backend: &CudaBackend, tensor: &Tensor) -> Tensor {
     download_tensor(backend.runtime(), tensor).unwrap()
 }
 
 fn tensor_f32(shape: Vec<usize>, data: Vec<f32>) -> Tensor {
-    Tensor::F32(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F32(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn tensor_f64(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn tensor_i64(shape: Vec<usize>, data: Vec<i64>) -> Tensor {
-    Tensor::I64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::I64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn tensor_i32(shape: Vec<usize>, data: Vec<i32>) -> Tensor {
-    Tensor::I32(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::I32(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn tensor_bool(shape: Vec<usize>, data: Vec<bool>) -> Tensor {
-    Tensor::Bool(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::Bool(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn tensor_c32(shape: Vec<usize>, data: Vec<Complex32>) -> Tensor {
-    Tensor::C32(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::C32(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn tensor_c64(shape: Vec<usize>, data: Vec<Complex64>) -> Tensor {
-    Tensor::C64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::C64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn assert_tensor_close(actual: &Tensor, expected: &Tensor, tol: f64) {

--- a/crates/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
@@ -3,7 +3,7 @@ use cubecl::prelude::*;
 use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 
 use crate::cubecl::memory::{device_ptr, download_tensor, upload_tensor};
-use crate::cubecl::{gpu_available, CubeclBackend, CubeclRuntime};
+use crate::cubecl::{gpu_available, CudaBackend, CudaRuntime};
 use crate::{Error, Tensor};
 use tenferro_tensor::TensorElementwise;
 
@@ -43,19 +43,20 @@ fn cube_count_for_len_rejects_u32_overflow() {
 }
 
 gpu_test!(test_runtime_init, {
-    let rt = CubeclRuntime::new(0);
+    let rt = CudaRuntime::new(0);
     assert!(rt.is_ok(), "CubeCL runtime should init on device 0");
 });
 
 gpu_test!(test_raw_stream_extraction, {
-    let rt = CubeclRuntime::new(0).unwrap();
+    let rt = CudaRuntime::new(0).unwrap();
     let stream_ptr = rt.raw_cuda_stream().unwrap();
     assert!(stream_ptr != 0, "Raw CUstream should be non-null");
 });
 
 gpu_test!(test_upload_download_f64, {
-    let rt = CubeclRuntime::new(0).unwrap();
-    let host = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let rt = CudaRuntime::new(0).unwrap();
+    let host =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let gpu = upload_tensor(&rt, &host).unwrap();
 
     assert_eq!(gpu.dtype(), crate::DType::F64);
@@ -69,8 +70,8 @@ gpu_test!(test_upload_download_f64, {
 });
 
 gpu_test!(test_upload_download_i64, {
-    let rt = CubeclRuntime::new(0).unwrap();
-    let host = Tensor::from_vec_col_major(vec![2, 3], vec![1_i64, -2, 3, -4, 5, -6]);
+    let rt = CudaRuntime::new(0).unwrap();
+    let host = Tensor::from_vec_col_major(vec![2, 3], vec![1_i64, -2, 3, -4, 5, -6]).unwrap();
     let gpu = upload_tensor(&rt, &host).unwrap();
 
     assert_eq!(gpu.dtype(), crate::DType::I64);
@@ -84,8 +85,8 @@ gpu_test!(test_upload_download_i64, {
 });
 
 gpu_test!(test_upload_download_i32, {
-    let rt = CubeclRuntime::new(0).unwrap();
-    let host = Tensor::from_vec_col_major(vec![2, 3], vec![1_i32, -2, 3, -4, 5, -6]);
+    let rt = CudaRuntime::new(0).unwrap();
+    let host = Tensor::from_vec_col_major(vec![2, 3], vec![1_i32, -2, 3, -4, 5, -6]).unwrap();
     let gpu = upload_tensor(&rt, &host).unwrap();
 
     assert_eq!(gpu.dtype(), crate::DType::I32);
@@ -99,8 +100,9 @@ gpu_test!(test_upload_download_i32, {
 });
 
 gpu_test!(test_upload_download_bool, {
-    let rt = CubeclRuntime::new(0).unwrap();
-    let host = Tensor::from_vec_col_major(vec![2, 3], vec![true, false, true, true, false, false]);
+    let rt = CudaRuntime::new(0).unwrap();
+    let host = Tensor::from_vec_col_major(vec![2, 3], vec![true, false, true, true, false, false])
+        .unwrap();
     let gpu = upload_tensor(&rt, &host).unwrap();
 
     assert_eq!(gpu.dtype(), crate::DType::Bool);
@@ -114,8 +116,8 @@ gpu_test!(test_upload_download_bool, {
 });
 
 gpu_test!(test_download_empty_host_f64_rejects_before_fast_path, {
-    let rt = CubeclRuntime::new(0).unwrap();
-    let host = Tensor::from_vec_col_major(vec![0], Vec::<f64>::new());
+    let rt = CudaRuntime::new(0).unwrap();
+    let host = Tensor::from_vec_col_major(vec![0], Vec::<f64>::new()).unwrap();
 
     let err = download_tensor(&rt, &host).unwrap_err();
 
@@ -123,8 +125,8 @@ gpu_test!(test_download_empty_host_f64_rejects_before_fast_path, {
 });
 
 gpu_test!(test_download_empty_host_bool_rejects_before_fast_path, {
-    let rt = CubeclRuntime::new(0).unwrap();
-    let host = Tensor::from_vec_col_major(vec![0], Vec::<bool>::new());
+    let rt = CudaRuntime::new(0).unwrap();
+    let host = Tensor::from_vec_col_major(vec![0], Vec::<bool>::new()).unwrap();
 
     let err = download_tensor(&rt, &host).unwrap_err();
 
@@ -138,9 +140,9 @@ fn assert_download_rejects_host_tensor_before_empty_fast_path(err: Error) {
 gpu_test!(test_upload_download_c64, {
     use num_complex::Complex64;
 
-    let rt = CubeclRuntime::new(0).unwrap();
+    let rt = CudaRuntime::new(0).unwrap();
     let data = vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)];
-    let host = Tensor::from_vec_col_major(vec![2], data.clone());
+    let host = Tensor::from_vec_col_major(vec![2], data.clone()).unwrap();
 
     let gpu = upload_tensor(&rt, &host).unwrap();
     let back = download_tensor(&rt, &gpu).unwrap();
@@ -149,8 +151,8 @@ gpu_test!(test_upload_download_c64, {
 });
 
 gpu_test!(test_pointer_bridge, {
-    let rt = CubeclRuntime::new(0).unwrap();
-    let host = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let rt = CudaRuntime::new(0).unwrap();
+    let host = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
 
     let gpu = upload_tensor(&rt, &host).unwrap();
     let ptr = device_ptr(&rt, &gpu).unwrap();
@@ -159,10 +161,10 @@ gpu_test!(test_pointer_bridge, {
 });
 
 gpu_test!(test_backend_add_matches_cpu_reference, {
-    let mut backend = CubeclBackend::new(0).unwrap();
+    let mut backend = CudaBackend::new(0).unwrap();
     let mut cpu = tenferro_cpu::CpuBackend::new();
-    let a = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
-    let b = Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]);
+    let a = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]).unwrap();
     let gpu_a = upload_tensor(backend.runtime(), &a).unwrap();
     let gpu_b = upload_tensor(backend.runtime(), &b).unwrap();
     let expected = cpu.add(&a, &b).unwrap();
@@ -176,7 +178,7 @@ gpu_test!(test_backend_add_matches_cpu_reference, {
 });
 
 gpu_test!(test_trivial_cube_kernel, {
-    let rt = CubeclRuntime::new(0).unwrap();
+    let rt = CudaRuntime::new(0).unwrap();
     let client = rt.client();
 
     let a_data = vec![1.0_f64, 2.0, 3.0, 4.0];
@@ -207,9 +209,9 @@ gpu_test!(test_trivial_cube_kernel, {
 gpu_test!(test_full_round_trip_all_dtypes, {
     use num_complex::{Complex32, Complex64};
 
-    let rt = CubeclRuntime::new(0).unwrap();
+    let rt = CudaRuntime::new(0).unwrap();
 
-    let t = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let t = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let gpu = upload_tensor(&rt, &t).unwrap();
     let back = download_tensor(&rt, &gpu).unwrap();
     assert_eq!(
@@ -217,7 +219,7 @@ gpu_test!(test_full_round_trip_all_dtypes, {
         t.as_slice::<f64>().unwrap()
     );
 
-    let t = Tensor::from_vec_col_major(vec![3], vec![1.0_f32, 2.0, 3.0]);
+    let t = Tensor::from_vec_col_major(vec![3], vec![1.0_f32, 2.0, 3.0]).unwrap();
     let gpu = upload_tensor(&rt, &t).unwrap();
     let back = download_tensor(&rt, &gpu).unwrap();
     assert_eq!(
@@ -225,7 +227,7 @@ gpu_test!(test_full_round_trip_all_dtypes, {
         t.as_slice::<f32>().unwrap()
     );
 
-    let t = Tensor::from_vec_col_major(vec![3], vec![1_i64, -2, 3]);
+    let t = Tensor::from_vec_col_major(vec![3], vec![1_i64, -2, 3]).unwrap();
     let gpu = upload_tensor(&rt, &t).unwrap();
     let back = download_tensor(&rt, &gpu).unwrap();
     assert_eq!(
@@ -233,7 +235,7 @@ gpu_test!(test_full_round_trip_all_dtypes, {
         t.as_slice::<i64>().unwrap()
     );
 
-    let t = Tensor::from_vec_col_major(vec![3], vec![1_i32, -2, 3]);
+    let t = Tensor::from_vec_col_major(vec![3], vec![1_i32, -2, 3]).unwrap();
     let gpu = upload_tensor(&rt, &t).unwrap();
     let back = download_tensor(&rt, &gpu).unwrap();
     assert_eq!(
@@ -241,7 +243,7 @@ gpu_test!(test_full_round_trip_all_dtypes, {
         t.as_slice::<i32>().unwrap()
     );
 
-    let t = Tensor::from_vec_col_major(vec![4], vec![true, false, false, true]);
+    let t = Tensor::from_vec_col_major(vec![4], vec![true, false, false, true]).unwrap();
     let gpu = upload_tensor(&rt, &t).unwrap();
     let back = download_tensor(&rt, &gpu).unwrap();
     assert_eq!(
@@ -252,7 +254,8 @@ gpu_test!(test_full_round_trip_all_dtypes, {
     let t = Tensor::from_vec_col_major(
         vec![2],
         vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
-    );
+    )
+    .unwrap();
     let gpu = upload_tensor(&rt, &t).unwrap();
     let back = download_tensor(&rt, &gpu).unwrap();
     assert_eq!(
@@ -263,7 +266,8 @@ gpu_test!(test_full_round_trip_all_dtypes, {
     let t = Tensor::from_vec_col_major(
         vec![2],
         vec![Complex32::new(1.0, 2.0), Complex32::new(3.0, 4.0)],
-    );
+    )
+    .unwrap();
     let gpu = upload_tensor(&rt, &t).unwrap();
     let back = download_tensor(&rt, &gpu).unwrap();
     assert_eq!(
@@ -273,8 +277,8 @@ gpu_test!(test_full_round_trip_all_dtypes, {
 });
 
 gpu_test!(test_pointer_and_stream_bridge, {
-    let rt = CubeclRuntime::new(0).unwrap();
-    let t = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let rt = CudaRuntime::new(0).unwrap();
+    let t = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let gpu = upload_tensor(&rt, &t).unwrap();
 
     let ptr = device_ptr(&rt, &gpu).unwrap();

--- a/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
@@ -323,7 +323,7 @@ fn cuda_to_contiguous_bool_view_returns_backend_failure() {
     assert!(matches!(
         err,
         Error::BackendFailure {
-            op: "CubeclBackend::to_contiguous",
+            op: "CudaBackend::to_contiguous",
             ref message,
         } if message.contains("unsupported dtype")
     ));
@@ -333,14 +333,14 @@ fn cuda_to_contiguous_bool_view_returns_backend_failure() {
 #[ignore]
 fn cuda_to_contiguous_host_view_returns_upload_hint() {
     let mut gpu = gpu_backend();
-    let host = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]);
+    let host = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]).unwrap();
 
     let err = gpu.to_contiguous(&host.as_view()).unwrap_err();
 
     assert!(matches!(
         err,
         Error::BackendFailure {
-            op: "CubeclBackend::to_contiguous",
+            op: "CudaBackend::to_contiguous",
             ref message,
         } if message.contains("upload_tensor()")
     ));
@@ -350,7 +350,7 @@ fn cuda_to_contiguous_host_view_returns_upload_hint() {
 #[ignore]
 fn cuda_copy_from_contiguous_host_source_returns_upload_hint() {
     let mut gpu = gpu_backend();
-    let src = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]);
+    let src = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]).unwrap();
     let dst_host = tensor_i32(vec![2], vec![0, 0]);
     let mut gpu_dst = upload(&gpu, &dst_host);
     let Tensor::I32(dst) = &mut gpu_dst else {
@@ -364,7 +364,7 @@ fn cuda_copy_from_contiguous_host_source_returns_upload_hint() {
     assert!(matches!(
         err,
         Error::BackendFailure {
-            op: "CubeclBackend::copy_from_contiguous",
+            op: "CudaBackend::copy_from_contiguous",
             ref message,
         } if message.contains("upload_tensor()")
     ));
@@ -379,7 +379,7 @@ fn cuda_copy_from_contiguous_host_destination_returns_upload_hint() {
     let Tensor::I32(src) = &gpu_src else {
         panic!("expected i32 tensor");
     };
-    let mut dst = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![0, 0]);
+    let mut dst = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![0, 0]).unwrap();
 
     let err = gpu
         .copy_from_contiguous(src, &mut dst.as_view_mut())
@@ -388,7 +388,7 @@ fn cuda_copy_from_contiguous_host_destination_returns_upload_hint() {
     assert!(matches!(
         err,
         Error::BackendFailure {
-            op: "CubeclBackend::copy_from_contiguous",
+            op: "CudaBackend::copy_from_contiguous",
             ref message,
         } if message.contains("upload_tensor()")
     ));

--- a/crates/tenferro-gpu/src/lib.rs
+++ b/crates/tenferro-gpu/src/lib.rs
@@ -33,10 +33,8 @@ mod webgpu;
 
 #[cfg(feature = "cuda")]
 pub use cubecl::{
-    device_ptr, download_tensor, gpu_available, upload_tensor, CubeclBackend, CubeclRuntime,
+    device_ptr, download_tensor, gpu_available, upload_tensor, CudaBackend, CudaRuntime,
 };
-#[cfg(feature = "cuda")]
-pub use cubecl::{CubeclBackend as CudaBackend, CubeclRuntime as CudaRuntime};
 #[cfg(feature = "cuda")]
 #[doc(hidden)]
 pub use cubecl::{CudaExtensionCache, CudaExtensionCacheGuard};

--- a/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -216,7 +216,7 @@ fn cubecl_raw_device_pointer_paths_validate_runtime_residency() {
     let memory_source = cubecl_source("memory.rs");
     let memory_ptr = source_section(
         &memory_source,
-        "pub fn device_ptr(rt: &CubeclRuntime, tensor: &Tensor) -> crate::Result<u64> {",
+        "pub fn device_ptr(rt: &CudaRuntime, tensor: &Tensor) -> crate::Result<u64> {",
         "fn upload_typed<",
     );
     assert_ordered_needles(
@@ -314,7 +314,7 @@ fn cubecl_scatter_validates_all_device_inputs_before_binding() {
     let scatter_complex = source_section(
         &mod_source,
         "    fn scatter_complex_typed<",
-        "impl BackendRuntimeCache for CubeclBackend",
+        "impl BackendRuntimeCache for CudaBackend",
     );
     assert_ordered_needles(
         "scatter_complex_typed",
@@ -337,7 +337,7 @@ fn cubecl_runtime_initializes_context_before_client_and_syncs_on_drop() {
         "    pub(crate) fn client(&self)",
     );
     assert_ordered_needles(
-        "CubeclRuntime::new",
+        "CudaRuntime::new",
         new_source,
         &[
             "cudarc::runtime::result::device::set",
@@ -349,9 +349,9 @@ fn cubecl_runtime_initializes_context_before_client_and_syncs_on_drop() {
         ],
     );
 
-    let drop_source = source_section(&runtime_source, "impl Drop for CubeclRuntime", "}");
+    let drop_source = source_section(&runtime_source, "impl Drop for CudaRuntime", "}");
     assert_ordered_needles(
-        "CubeclRuntime::drop",
+        "CudaRuntime::drop",
         drop_source,
         &[
             "let _ = self.synchronize();",
@@ -410,6 +410,6 @@ fn cubecl_i64_index_conversion_does_not_roundtrip_through_host() {
 #[cfg(feature = "cuda")]
 #[test]
 fn cubecl_runtime_exposes_explicit_synchronize() {
-    let _sync: fn(&tenferro_gpu::CubeclRuntime) -> tenferro_tensor::Result<()> =
-        tenferro_gpu::CubeclRuntime::synchronize;
+    let _sync: fn(&tenferro_gpu::CudaRuntime) -> tenferro_tensor::Result<()> =
+        tenferro_gpu::CudaRuntime::synchronize;
 }

--- a/crates/tenferro-gpu/tests/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/public_surface_contract.rs
@@ -138,8 +138,8 @@ fn public_backend_names_are_provider_specific() {
         "WebGPU backend should have an explicit public WebGpuBackend name"
     );
     assert!(
-        lib_rs.contains("CubeclBackend"),
-        "the existing CubeclBackend compatibility name should remain while downstream users migrate"
+        !lib_rs.contains("CubeclBackend") && !lib_rs.contains("CubeclRuntime"),
+        "CubeCL implementation names should not remain as public CUDA backend aliases"
     );
 }
 

--- a/crates/tenferro-gpu/tests/webgpu_matmul_runtime.rs
+++ b/crates/tenferro-gpu/tests/webgpu_matmul_runtime.rs
@@ -88,8 +88,8 @@ fn assert_c32_dot_general_with_conj_matches_cpu(
 ) {
     let lhs_len = lhs_shape.iter().product();
     let rhs_len = rhs_shape.iter().product();
-    let lhs = Tensor::from_vec_col_major(lhs_shape.clone(), c32_values(lhs_len, 0.25));
-    let rhs = Tensor::from_vec_col_major(rhs_shape.clone(), c32_values(rhs_len, -0.75));
+    let lhs = Tensor::from_vec_col_major(lhs_shape.clone(), c32_values(lhs_len, 0.25)).unwrap();
+    let rhs = Tensor::from_vec_col_major(rhs_shape.clone(), c32_values(rhs_len, -0.75)).unwrap();
     let config = dot_general_config_for_shapes(&lhs_shape, &rhs_shape);
 
     let mut cpu = CpuBackend::new();
@@ -192,8 +192,10 @@ fn webgpu_f32_dot_general_with_conj_is_identity_when_adapter_available() {
     }
 
     let mut backend = WebGpuBackend::new_default().unwrap();
-    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0]);
-    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0]);
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0]).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -227,8 +229,10 @@ fn webgpu_dot_general_runs_rank2_f32_matmul_when_adapter_available() {
     }
 
     let mut backend = WebGpuBackend::new_default().unwrap();
-    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0]);
-    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0]);
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0]).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -261,13 +265,15 @@ fn webgpu_dot_general_supports_batched_f32_contract_shape_when_adapter_available
         vec![
             1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0, 10.0, 40.0, 20.0, 50.0, 30.0, 60.0,
         ],
-    );
+    )
+    .unwrap();
     let rhs = Tensor::from_vec_col_major(
         vec![3, 2, 2],
         vec![
             7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0, 70.0, 90.0, 110.0, 80.0, 100.0, 120.0,
         ],
-    );
+    )
+    .unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -301,8 +307,8 @@ fn webgpu_dot_general_packs_noncontiguous_lhs_free_axes_when_adapter_available()
         1.0_f32, 4.0, 2.0, 5.0, 3.0, 6.0, 10.0, 40.0, 20.0, 50.0, 30.0, 60.0,
     ];
     let rhs_data = vec![7.0_f32, 9.0, 11.0, 8.0, 10.0, 12.0];
-    let lhs = Tensor::from_vec_col_major(vec![2, 3, 2], lhs_data.clone());
-    let rhs = Tensor::from_vec_col_major(vec![3, 2], rhs_data.clone());
+    let lhs = Tensor::from_vec_col_major(vec![2, 3, 2], lhs_data.clone()).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![3, 2], rhs_data.clone()).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -358,8 +364,8 @@ fn webgpu_dot_general_supports_batched_c32_contract_shape_when_adapter_available
         Complex32::new(100.0, 0.5),
         Complex32::new(120.0, -0.25),
     ];
-    let lhs = Tensor::from_vec_col_major(vec![2, 3, 2], lhs_data.clone());
-    let rhs = Tensor::from_vec_col_major(vec![3, 2, 2], rhs_data.clone());
+    let lhs = Tensor::from_vec_col_major(vec![2, 3, 2], lhs_data.clone()).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![3, 2, 2], rhs_data.clone()).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -392,8 +398,8 @@ fn webgpu_dot_general_rejects_f64_and_c64_without_cpu_fallback_when_adapter_avai
         rhs_batch_dims: vec![],
     };
 
-    let lhs_f64 = Tensor::from_vec_col_major(vec![1, 1], vec![1.0_f64]);
-    let rhs_f64 = Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f64]);
+    let lhs_f64 = Tensor::from_vec_col_major(vec![1, 1], vec![1.0_f64]).unwrap();
+    let rhs_f64 = Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f64]).unwrap();
     let lhs_f64 = backend.upload_host_tensor(&lhs_f64).unwrap();
     let rhs_f64 = backend.upload_host_tensor(&rhs_f64).unwrap();
     let err = backend
@@ -404,8 +410,8 @@ fn webgpu_dot_general_rejects_f64_and_c64_without_cpu_fallback_when_adapter_avai
         "unexpected f64 error: {err}"
     );
 
-    let lhs_c64 = Tensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 0.5)]);
-    let rhs_c64 = Tensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(2.0, -0.25)]);
+    let lhs_c64 = Tensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 0.5)]).unwrap();
+    let rhs_c64 = Tensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(2.0, -0.25)]).unwrap();
     let lhs_c64 = backend.upload_host_tensor(&lhs_c64).unwrap();
     let rhs_c64 = backend.upload_host_tensor(&rhs_c64).unwrap();
     let err = backend
@@ -436,8 +442,8 @@ fn webgpu_dot_general_runs_rank2_c32_matmul_when_adapter_available() {
         Complex32::new(7.0, 1.0),
         Complex32::new(8.0, -0.75),
     ];
-    let lhs = Tensor::from_vec_col_major(vec![2, 2], lhs_data.clone());
-    let rhs = Tensor::from_vec_col_major(vec![2, 2], rhs_data.clone());
+    let lhs = Tensor::from_vec_col_major(vec![2, 2], lhs_data.clone()).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![2, 2], rhs_data.clone()).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],

--- a/crates/tenferro-internal-extension-macros/src/lib.rs
+++ b/crates/tenferro-internal-extension-macros/src/lib.rs
@@ -15,7 +15,7 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
-use syn::{parse_macro_input, DeriveInput, Expr, ExprLit, Ident, Lit, Path, Token, Visibility};
+use syn::{parse_macro_input, DeriveInput, Expr, ExprLit, Ident, Lit, Path, Token};
 
 #[derive(Debug, Default)]
 struct ExtensionArgs {
@@ -29,15 +29,9 @@ struct RuntimeArgs {
     family_id: Path,
     op_type: Path,
     execute: Path,
-    execute_reads: Option<Path>,
+    execute_reads: Path,
     register_fn: Ident,
     backend_bound: Path,
-}
-
-struct RuleRegistrationArgs {
-    register_fn: Ident,
-    rule_type: Path,
-    visibility: Visibility,
 }
 
 impl Parse for ExtensionArgs {
@@ -106,46 +100,10 @@ impl Parse for RuntimeArgs {
             family_id: required(family_id, "family_id")?,
             op_type: required(op_type, "op_type")?,
             execute: required(execute, "execute")?,
-            execute_reads,
+            execute_reads: required(execute_reads, "execute_reads")?,
             register_fn: required(register_fn, "register_fn")?,
             backend_bound: backend_bound
                 .unwrap_or_else(|| syn::parse_quote!(tenferro_tensor::TensorBackend)),
-        })
-    }
-}
-
-impl Parse for RuleRegistrationArgs {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let mut register_fn = None;
-        let mut rule_type = None;
-        let mut visibility = None;
-
-        while !input.is_empty() {
-            let key: Ident = input.parse()?;
-            input.parse::<Token![=]>()?;
-            match key.to_string().as_str() {
-                "register_fn" => register_fn = Some(input.parse()?),
-                "rule_type" => rule_type = Some(input.parse()?),
-                "visibility" => visibility = Some(input.parse()?),
-                other => {
-                    return Err(syn::Error::new(
-                        key.span(),
-                        format!(
-                            "unsupported define_idempotent_rule_registration argument {other:?}"
-                        ),
-                    ));
-                }
-            }
-            if input.is_empty() {
-                break;
-            }
-            input.parse::<Token![,]>()?;
-        }
-
-        Ok(Self {
-            register_fn: required(register_fn, "register_fn")?,
-            rule_type: required(rule_type, "rule_type")?,
-            visibility: visibility.unwrap_or(Visibility::Inherited),
         })
     }
 }
@@ -170,21 +128,12 @@ pub fn derive_extension_family_id(input: TokenStream) -> TokenStream {
 /// The `execute` function must have this signature:
 /// `fn<B: BackendBound + 'static>(&OpType, &[&Tensor], &mut ExtensionExecutionContext<'_, B>)`.
 ///
-/// `execute_reads` is optional. When supplied, it must have this signature:
+/// `execute_reads` is required. It must have this signature:
 /// `fn<B: BackendBound + 'static>(&OpType, &[TensorRead<'_>], &mut ExtensionExecutionContext<'_, B>)`.
 #[proc_macro]
 pub fn define_extension_runtime(input: TokenStream) -> TokenStream {
     let args = parse_macro_input!(input as RuntimeArgs);
     expand_extension_runtime(args).into()
-}
-
-/// Generate an idempotent process-global extension AD rule registration helper.
-///
-/// The generated function returns `Ok(())` when the rule is already registered.
-#[proc_macro]
-pub fn define_idempotent_rule_registration(input: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(input as RuleRegistrationArgs);
-    expand_idempotent_rule_registration(args).into()
 }
 
 fn expand_extension_family_id(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
@@ -231,26 +180,6 @@ fn expand_extension_runtime(args: RuntimeArgs) -> proc_macro2::TokenStream {
         register_fn,
         backend_bound,
     } = args;
-    let execute_reads_method = execute_reads.map(|execute_reads| {
-        quote! {
-            fn execute_reads(
-                &self,
-                op: &dyn tenferro_runtime::extension::ExtensionOpTrait,
-                inputs: &[tenferro_tensor::TensorRead<'_>],
-                ctx: &mut tenferro_runtime::extension::ExtensionExecutionContext<'_, B>,
-            ) -> tenferro_tensor::Result<Vec<tenferro_tensor::Tensor>> {
-                let op = op
-                    .as_any()
-                    .downcast_ref::<#op_type>()
-                    .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-                        op: "extension_runtime",
-                        message: format!("payload type mismatch for {}", #family_id),
-                    })?;
-                #execute_reads(op, inputs, ctx)
-            }
-        }
-    });
-
     quote! {
         #[derive(Debug, Default)]
         pub(crate) struct #runtime;
@@ -264,7 +193,7 @@ fn expand_extension_runtime(args: RuntimeArgs) -> proc_macro2::TokenStream {
 
             fn execute(
                 &self,
-                op: &dyn tenferro_runtime::extension::ExtensionOpTrait,
+                op: &dyn tenferro_runtime::extension::ExtensionOp,
                 inputs: &[&tenferro_tensor::Tensor],
                 ctx: &mut tenferro_runtime::extension::ExtensionExecutionContext<'_, B>,
             ) -> tenferro_tensor::Result<Vec<tenferro_tensor::Tensor>> {
@@ -278,7 +207,21 @@ fn expand_extension_runtime(args: RuntimeArgs) -> proc_macro2::TokenStream {
                 #execute(op, inputs, ctx)
             }
 
-            #execute_reads_method
+            fn execute_reads(
+                &self,
+                op: &dyn tenferro_runtime::extension::ExtensionOp,
+                inputs: &[tenferro_tensor::TensorRead<'_>],
+                ctx: &mut tenferro_runtime::extension::ExtensionExecutionContext<'_, B>,
+            ) -> tenferro_tensor::Result<Vec<tenferro_tensor::Tensor>> {
+                let op = op
+                    .as_any()
+                    .downcast_ref::<#op_type>()
+                    .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
+                        op: "extension_runtime",
+                        message: format!("payload type mismatch for {}", #family_id),
+                    })?;
+                #execute_reads(op, inputs, ctx)
+            }
         }
 
         pub fn #register_fn<B: #backend_bound + 'static>(
@@ -288,26 +231,6 @@ fn expand_extension_runtime(args: RuntimeArgs) -> proc_macro2::TokenStream {
             tenferro_runtime::extension::ExtensionRuntimeRegistryError,
         > {
             executor.registry_mut().register(std::sync::Arc::new(#runtime))
-        }
-    }
-}
-
-fn expand_idempotent_rule_registration(args: RuleRegistrationArgs) -> proc_macro2::TokenStream {
-    let RuleRegistrationArgs {
-        register_fn,
-        rule_type,
-        visibility,
-    } = args;
-
-    quote! {
-        #visibility fn #register_fn() -> std::result::Result<
-            (),
-            tenferro_ops::ExtensionRegistryError,
-        > {
-            match tenferro_ops::register_extension_rule(std::sync::Arc::new(#rule_type)) {
-                Ok(()) | Err(tenferro_ops::ExtensionRegistryError::DuplicateRule { .. }) => Ok(()),
-                Err(err) => Err(err),
-            }
         }
     }
 }

--- a/crates/tenferro-internal-extension-macros/src/tests.rs
+++ b/crates/tenferro-internal-extension-macros/src/tests.rs
@@ -1,7 +1,4 @@
-use super::{
-    expand_extension_family_id, expand_extension_runtime, expand_idempotent_rule_registration,
-    to_snake_case, ExtensionArgs,
-};
+use super::{expand_extension_family_id, expand_extension_runtime, to_snake_case, ExtensionArgs};
 use syn::DeriveInput;
 
 #[test]
@@ -74,6 +71,7 @@ fn extension_runtime_macro_generates_runtime_impl_and_register_function() {
         family_id = TINY_EXTENSION_FAMILY_ID,
         op_type = TinyExtensionOp,
         execute = execute_tiny_extension,
+        execute_reads = execute_tiny_extension_reads,
         register_fn = register_tiny_runtime,
     });
     let source = tokens.to_string();
@@ -83,6 +81,7 @@ fn extension_runtime_macro_generates_runtime_impl_and_register_function() {
     assert!(source.contains("ExtensionRuntime < B >"));
     assert!(source.contains("downcast_ref :: < TinyExtensionOp >"));
     assert!(source.contains("execute_tiny_extension (op , inputs , ctx)"));
+    assert!(source.contains("execute_tiny_extension_reads (op , inputs , ctx)"));
     assert!(source.contains("pub fn register_tiny_runtime"));
 }
 
@@ -93,6 +92,7 @@ fn extension_runtime_macro_accepts_custom_backend_bound() {
         family_id = LINALG_EXTENSION_FAMILY_ID,
         op_type = LinalgExtensionOp,
         execute = execute_linalg_extension,
+        execute_reads = execute_linalg_extension_reads,
         register_fn = register_runtime,
         backend_bound = crate::backend::LinalgBackend,
     });
@@ -102,7 +102,7 @@ fn extension_runtime_macro_accepts_custom_backend_bound() {
 }
 
 #[test]
-fn extension_runtime_macro_generates_optional_read_executor() {
+fn extension_runtime_macro_generates_required_read_executor() {
     let tokens = expand_extension_runtime(syn::parse_quote! {
         runtime = EinsumRuntime,
         family_id = EINSUM_EXTENSION_FAMILY_ID,
@@ -116,19 +116,4 @@ fn extension_runtime_macro_generates_optional_read_executor() {
     assert!(source.contains("fn execute_reads"));
     assert!(source.contains("TensorRead < '_ >"));
     assert!(source.contains("execute_einsum_extension_reads (op , inputs , ctx)"));
-}
-
-#[test]
-fn idempotent_rule_registration_macro_generates_duplicate_guard() {
-    let tokens = expand_idempotent_rule_registration(syn::parse_quote! {
-        register_fn = ensure_einsum_extension_rule_registered,
-        rule_type = EinsumAdRule,
-        visibility = pub(crate),
-    });
-    let source = tokens.to_string();
-
-    assert!(source.contains("pub (crate) fn ensure_einsum_extension_rule_registered"));
-    assert!(source.contains("tenferro_ops :: register_extension_rule"));
-    assert!(source.contains("std :: sync :: Arc :: new (EinsumAdRule)"));
-    assert!(source.contains("ExtensionRegistryError :: DuplicateRule"));
 }

--- a/crates/tenferro-internal-ops/Cargo.toml
+++ b/crates/tenferro-internal-ops/Cargo.toml
@@ -16,10 +16,9 @@ name = "tenferro_ops"
 [features]
 default = ["autodiff"]
 autodiff = ["dep:tidu"]
-gpu = []
-cuda = ["gpu"]
-webgpu = ["gpu"]
-rocm = ["gpu"]
+cuda = []
+webgpu = []
+rocm = []
 
 [dependencies]
 tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.1.0" }

--- a/crates/tenferro-internal-ops/src/ad/context.rs
+++ b/crates/tenferro-internal-ops/src/ad/context.rs
@@ -16,11 +16,9 @@ use computegraph::graph::Graph;
 use computegraph::types::{ValueKey, ValueRef};
 use tenferro_tensor::DType;
 
-use crate::dim_expr::DimExpr;
+use crate::dim_expr::{DimExpr, DimExprEvalError};
 #[cfg(feature = "autodiff")]
-use crate::ext_op::{
-    lookup_extension_rule as lookup_global_extension_rule, ExtensionAdRule, ExtensionRuleSet,
-};
+use crate::ext_op::{ExtensionAdRule, ExtensionRuleSet};
 use crate::shape_extent::ShapeExtent;
 use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
@@ -41,6 +39,49 @@ pub enum MetadataRegistryError {
     /// A previous panic poisoned the global metadata mutex.
     #[error("AD global metadata registry lock poisoned")]
     LockPoisoned,
+}
+
+/// Error returned when shape-guard metadata cannot be resolved.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ShapeGuardError {
+    /// A local graph value was queried before a graph was attached.
+    #[error("cannot resolve local value {local_id} without an attached graph")]
+    LocalWithoutAttachedGraph {
+        /// Graph-local value id.
+        local_id: usize,
+    },
+    /// A local graph value id is outside the attached graph's value table.
+    #[error("local value {local_id} is out of bounds for the attached graph")]
+    LocalOutOfBounds {
+        /// Graph-local value id.
+        local_id: usize,
+    },
+    /// No metadata was registered for the resolved value key.
+    #[error("missing TensorMeta for {key:?}")]
+    MissingMetadata {
+        /// Resolved value key.
+        key: ValueKey<StdTensorOp>,
+    },
+    /// Metadata exists, but at least one axis is only bounded or unknown.
+    #[error("TensorMeta for {key:?} does not have an exact shape; query extents instead")]
+    NonExactShape {
+        /// Resolved value key.
+        key: ValueKey<StdTensorOp>,
+    },
+}
+
+/// Result type used by shape-guard metadata queries.
+pub type ShapeGuardResult<T> = Result<T, ShapeGuardError>;
+
+#[cfg(feature = "autodiff")]
+impl From<ShapeGuardError> for tidu::ADRuleError {
+    fn from(err: ShapeGuardError) -> Self {
+        tidu::ADRuleError::invalid_input(
+            "tenferro.shape_guard",
+            tidu::ADRuleKind::Jvp,
+            err.to_string(),
+        )
+    }
 }
 
 /// Global metadata registry.
@@ -78,10 +119,8 @@ impl Drop for GlobalMetadataScope {
 
 /// Per-value tensor metadata used by AD rules.
 ///
-/// `shape` is expressed in graph-global [`SymDim`] terms rather than op-local
-/// [`DimExpr`] references. It is retained as a compatibility bound shape; use
-/// [`TensorMeta::exact_shape`] when a caller needs proof that every dimension is
-/// exact.
+/// Shape information is stored as per-axis [`ShapeExtent`] values. Callers must
+/// explicitly choose whether they need an exact shape or only a known bound.
 ///
 /// # Examples
 ///
@@ -90,14 +129,12 @@ impl Drop for GlobalMetadataScope {
 /// use tenferro_tensor::DType;
 ///
 /// let meta = TensorMeta::exact(DType::F64, vec![SymDim::from(2usize), SymDim::from(3usize)]);
-/// assert_eq!(meta.shape.len(), 2);
+/// assert_eq!(meta.rank(), 2);
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TensorMeta {
     /// Element dtype of the tensor value.
     pub dtype: DType,
-    /// Compatibility shape used by existing callers; not proof of exactness.
-    pub shape: Vec<SymDim>,
     /// Per-axis shape guarantees.
     pub extents: Vec<ShapeExtent<SymDim>>,
 }
@@ -116,18 +153,10 @@ impl TensorMeta {
     /// ```
     pub fn exact(dtype: DType, shape: Vec<SymDim>) -> Self {
         let extents = shape.iter().cloned().map(ShapeExtent::exact).collect();
-        Self {
-            dtype,
-            shape,
-            extents,
-        }
+        Self { dtype, extents }
     }
 
     /// Construct metadata from per-axis extents.
-    ///
-    /// The compatibility `shape` field is populated from each known bound. An
-    /// unknown extent is represented with a zero placeholder until all callers
-    /// consume extent metadata directly.
     ///
     /// # Examples
     ///
@@ -142,20 +171,12 @@ impl TensorMeta {
     /// assert_eq!(meta.exact_shape(), None);
     /// ```
     pub fn with_extents(dtype: DType, extents: Vec<ShapeExtent<SymDim>>) -> Self {
-        let shape = extents
-            .iter()
-            .map(|extent| {
-                extent
-                    .bound_expr()
-                    .cloned()
-                    .unwrap_or_else(|| SymDim::from(0usize))
-            })
-            .collect();
-        Self {
-            dtype,
-            shape,
-            extents,
-        }
+        Self { dtype, extents }
+    }
+
+    /// Return the tensor rank known by this metadata record.
+    pub fn rank(&self) -> usize {
+        self.extents.len()
     }
 
     /// Return the per-axis shape guarantees.
@@ -191,6 +212,17 @@ impl TensorMeta {
         self.extents
             .iter()
             .map(|extent| extent.as_exact().cloned())
+            .collect()
+    }
+
+    /// Return one known bound per axis when every axis has a bound.
+    ///
+    /// This is intentionally separate from [`TensorMeta::exact_shape`]: a bound
+    /// is not proof of the runtime size.
+    pub fn bound_shape(&self) -> Option<Vec<SymDim>> {
+        self.extents
+            .iter()
+            .map(|extent| extent.bound_expr().cloned())
             .collect()
     }
 }
@@ -275,8 +307,8 @@ impl ShapeGuardContext {
 
     /// Use an explicit extension AD rule set for this context.
     ///
-    /// When an explicit rule set is attached, extension AD lookup does not fall
-    /// back to the process-global compatibility registry.
+    /// Extension AD lookup is context-owned: a context without an attached rule
+    /// set has no extension AD rules.
     ///
     /// # Examples
     ///
@@ -284,7 +316,7 @@ impl ShapeGuardContext {
     /// use tenferro_ops::{ExtensionRuleSet, ShapeGuardContext};
     ///
     /// let ctx = ShapeGuardContext::default().with_extension_rules(ExtensionRuleSet::new());
-    /// assert!(ctx.lookup_extension_rule("example.missing.v1").is_none());
+    /// assert!(ctx.extension_rule_for("example.missing.v1").is_none());
     /// ```
     #[cfg(feature = "autodiff")]
     pub fn with_extension_rules(mut self, rules: ExtensionRuleSet) -> Self {
@@ -294,15 +326,13 @@ impl ShapeGuardContext {
 
     /// Look up an extension AD rule using this context's ownership policy.
     ///
-    /// Contexts without an explicit rule set use the process-global registry as
-    /// a temporary compatibility bridge.
+    /// Contexts without an explicit rule set have no extension AD rules.
     #[doc(hidden)]
     #[cfg(feature = "autodiff")]
-    pub fn lookup_extension_rule(&self, family_id: &str) -> Option<Arc<dyn ExtensionAdRule>> {
-        match &self.extension_rules {
-            Some(rules) => rules.lookup_rule(family_id),
-            None => lookup_global_extension_rule(family_id),
-        }
+    pub(crate) fn extension_rule_for(&self, family_id: &str) -> Option<Arc<dyn ExtensionAdRule>> {
+        self.extension_rules
+            .as_ref()
+            .and_then(|rules| rules.lookup_rule(family_id))
     }
 
     /// Returns the guards recorded so far.
@@ -350,11 +380,18 @@ impl ShapeGuardContext {
     /// let mut ctx = ShapeGuardContext::default();
     /// ctx.insert_metadata(key, TensorMeta::exact(DType::F64, vec![SymDim::from(4usize)]));
     ///
-    /// let shape = ctx.shape_of(&value);
+    /// let shape = ctx.shape_of(&value).unwrap();
     /// assert_eq!(shape, &[SymDim::from(4usize)]);
     /// ```
-    pub fn shape_of(&mut self, val: &ValueRef<StdTensorOp>) -> &[SymDim] {
-        &self.metadata_of(val).shape
+    pub fn shape_of(&mut self, val: &ValueRef<StdTensorOp>) -> ShapeGuardResult<Vec<SymDim>> {
+        let key = self.resolve_key(val)?.clone();
+        self.ensure_metadata_loaded(&key);
+        let meta = self
+            .metadata
+            .get(&key)
+            .ok_or_else(|| ShapeGuardError::MissingMetadata { key: key.clone() })?;
+        meta.exact_shape()
+            .ok_or(ShapeGuardError::NonExactShape { key })
     }
 
     /// Return per-axis shape guarantees for a value reference.
@@ -376,11 +413,14 @@ impl ShapeGuardContext {
     ///     TensorMeta::with_extents(DType::F64, vec![ShapeExtent::upper_bound(SymDim::from(8usize))]),
     /// );
     ///
-    /// let extents = ctx.extents_of(&value);
+    /// let extents = ctx.extents_of(&value).unwrap();
     /// assert_eq!(extents[0], ShapeExtent::upper_bound(SymDim::from(8usize)));
     /// ```
-    pub fn extents_of(&mut self, val: &ValueRef<StdTensorOp>) -> &[ShapeExtent<SymDim>] {
-        self.metadata_of(val).extents()
+    pub fn extents_of(
+        &mut self,
+        val: &ValueRef<StdTensorOp>,
+    ) -> ShapeGuardResult<&[ShapeExtent<SymDim>]> {
+        self.metadata_of(val).map(TensorMeta::extents)
     }
 
     /// Return the exact shape for a value reference, if all axes are exact.
@@ -402,16 +442,20 @@ impl ShapeGuardContext {
     ///     TensorMeta::with_extents(DType::F64, vec![ShapeExtent::upper_bound(SymDim::from(8usize))]),
     /// );
     ///
-    /// let maybe_shape = ctx.exact_shape_of(&value);
+    /// let maybe_shape = ctx.exact_shape_of(&value).unwrap();
     /// assert_eq!(maybe_shape, None);
     /// ```
-    pub fn exact_shape_of(&mut self, val: &ValueRef<StdTensorOp>) -> Option<Vec<SymDim>> {
-        self.metadata_of(val).exact_shape()
+    pub fn exact_shape_of(
+        &mut self,
+        val: &ValueRef<StdTensorOp>,
+    ) -> ShapeGuardResult<Option<Vec<SymDim>>> {
+        self.metadata_of(val).map(TensorMeta::exact_shape)
     }
 
     #[doc(hidden)]
-    pub fn try_shape_of(&mut self, val: &ValueRef<StdTensorOp>) -> Option<&[SymDim]> {
-        self.try_metadata_of(val).map(|meta| meta.shape.as_slice())
+    pub fn shape_if_available(&mut self, val: &ValueRef<StdTensorOp>) -> Option<Vec<SymDim>> {
+        self.metadata_if_available(val)
+            .and_then(TensorMeta::exact_shape)
     }
 
     /// Return the dtype metadata for a value reference.
@@ -430,11 +474,11 @@ impl ShapeGuardContext {
     /// let mut ctx = ShapeGuardContext::default();
     /// ctx.insert_metadata(key, TensorMeta::exact(DType::F64, vec![SymDim::from(4usize)]));
     ///
-    /// let dtype = ctx.dtype_of(&value);
+    /// let dtype = ctx.dtype_of(&value).unwrap();
     /// assert_eq!(dtype, DType::F64);
     /// ```
-    pub fn dtype_of(&mut self, val: &ValueRef<StdTensorOp>) -> DType {
-        self.metadata_of(val).dtype
+    pub fn dtype_of(&mut self, val: &ValueRef<StdTensorOp>) -> ShapeGuardResult<DType> {
+        self.metadata_of(val).map(|meta| meta.dtype)
     }
 
     /// Return the complete metadata record for a value reference.
@@ -453,32 +497,21 @@ impl ShapeGuardContext {
     /// let mut ctx = ShapeGuardContext::default();
     /// ctx.insert_metadata(key, TensorMeta::exact(DType::F64, vec![SymDim::from(4usize)]));
     ///
-    /// let meta = ctx.metadata_of(&value);
+    /// let meta = ctx.metadata_of(&value).unwrap();
     /// assert_eq!(meta.dtype, DType::F64);
     /// ```
-    pub fn metadata_of(&mut self, val: &ValueRef<StdTensorOp>) -> &TensorMeta {
-        // Compatibility panic wrapper for AD rules whose graph-local metadata
-        // invariants have already been established; use `try_metadata_of` for
-        // user-provided or partially built graph values.
-        let key = self.resolve_key(val).clone();
-        if !self.metadata.contains_key(&key) && self.use_global_registry {
-            if let Some(meta) = lookup_global_metadata(&key) {
-                self.metadata.insert(key.clone(), meta);
-            }
-        }
+    pub fn metadata_of(&mut self, val: &ValueRef<StdTensorOp>) -> ShapeGuardResult<&TensorMeta> {
+        let key = self.resolve_key(val)?.clone();
+        self.ensure_metadata_loaded(&key);
         self.metadata
             .get(&key)
-            .unwrap_or_else(|| panic!("ShapeGuardContext: missing TensorMeta for {:?}", key))
+            .ok_or(ShapeGuardError::MissingMetadata { key })
     }
 
     #[doc(hidden)]
-    pub fn try_metadata_of(&mut self, val: &ValueRef<StdTensorOp>) -> Option<&TensorMeta> {
-        let key = self.try_resolve_key(val)?.clone();
-        if !self.metadata.contains_key(&key) && self.use_global_registry {
-            if let Some(meta) = lookup_global_metadata(&key) {
-                self.metadata.insert(key.clone(), meta);
-            }
-        }
+    pub fn metadata_if_available(&mut self, val: &ValueRef<StdTensorOp>) -> Option<&TensorMeta> {
+        let key = self.resolve_key_if_available(val)?.clone();
+        self.ensure_metadata_loaded(&key);
         self.metadata.get(&key)
     }
 
@@ -500,7 +533,7 @@ impl ShapeGuardContext {
         self.metadata.extend(entries);
     }
 
-    fn try_resolve_key<'a>(
+    fn resolve_key_if_available<'a>(
         &'a self,
         val: &'a ValueRef<StdTensorOp>,
     ) -> Option<&'a ValueKey<StdTensorOp>> {
@@ -513,18 +546,33 @@ impl ShapeGuardContext {
         }
     }
 
-    fn resolve_key<'a>(&'a self, val: &'a ValueRef<StdTensorOp>) -> &'a ValueKey<StdTensorOp> {
-        // Compatibility panic wrapper for established graph-local invariants.
-        // `try_resolve_key` underpins fallible query paths.
-        self.try_resolve_key(val).unwrap_or_else(|| match val {
-            ValueRef::External(_) => unreachable!("external value keys are always resolvable"),
-            ValueRef::Local(local_id) if self.local_keys.is_none() => panic!(
-                "ShapeGuardContext: cannot resolve local value {local_id} without an attached graph"
-            ),
-            ValueRef::Local(local_id) => {
-                panic!("ShapeGuardContext: local value {local_id} is out of bounds")
+    fn resolve_key<'a>(
+        &'a self,
+        val: &'a ValueRef<StdTensorOp>,
+    ) -> ShapeGuardResult<&'a ValueKey<StdTensorOp>> {
+        match val {
+            ValueRef::External(key) => Ok(key),
+            ValueRef::Local(local_id) if self.local_keys.is_none() => {
+                Err(ShapeGuardError::LocalWithoutAttachedGraph {
+                    local_id: *local_id,
+                })
             }
-        })
+            ValueRef::Local(local_id) => self
+                .local_keys
+                .as_ref()
+                .and_then(|keys| keys.get(*local_id))
+                .ok_or(ShapeGuardError::LocalOutOfBounds {
+                    local_id: *local_id,
+                }),
+        }
+    }
+
+    fn ensure_metadata_loaded(&mut self, key: &ValueKey<StdTensorOp>) {
+        if !self.metadata.contains_key(key) && self.use_global_registry {
+            if let Ok(Some(meta)) = lookup_global_metadata(key) {
+                self.metadata.insert(key.clone(), meta);
+            }
+        }
     }
 }
 
@@ -541,16 +589,10 @@ impl ShapeGuardContext {
 /// use tenferro_ops::std_tensor_op::StdTensorOp;
 ///
 /// let key = ValueKey::<StdTensorOp>::Input(TensorInputKey::User { id: 99 });
-/// let meta = lookup_global_metadata(&key);
+/// let meta = lookup_global_metadata(&key).unwrap();
 /// assert!(meta.is_none());
 /// ```
-pub fn lookup_global_metadata(key: &ValueKey<StdTensorOp>) -> Option<TensorMeta> {
-    try_lookup_global_metadata(key).ok().flatten()
-}
-
-/// Fallibly look up a single metadata entry from the global registry.
-#[doc(hidden)]
-pub fn try_lookup_global_metadata(
+pub fn lookup_global_metadata(
     key: &ValueKey<StdTensorOp>,
 ) -> Result<Option<TensorMeta>, MetadataRegistryError> {
     let guard = global_metadata_registry()
@@ -560,15 +602,7 @@ pub fn try_lookup_global_metadata(
 }
 
 #[doc(hidden)]
-pub fn register_scoped_global_metadata_batch<I>(entries: I) -> GlobalMetadataScope
-where
-    I: IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
-{
-    try_register_scoped_global_metadata_batch(entries).unwrap_or_else(|err| panic!("{err}"))
-}
-
-#[doc(hidden)]
-pub fn try_register_scoped_global_metadata_batch<I>(
+pub fn register_scoped_global_metadata_batch<I>(
     entries: I,
 ) -> Result<GlobalMetadataScope, MetadataRegistryError>
 where
@@ -611,25 +645,24 @@ fn release_scoped_global_metadata(keys: &[ValueKey<StdTensorOp>]) {
 }
 
 /// Resolve a [`DimExpr`] to a concrete `usize`.
-///
-/// Currently this evaluates the expression without any input shapes, which
-/// works for `DimExpr::Const` and expressions composed entirely from constants.
-/// `DimExpr::InputDim` references will panic, which is currently a programming
-/// invariant enforced by the linalg AD callers.
 #[doc(hidden)]
-pub fn resolve_dim(dim: &DimExpr) -> usize {
+pub fn resolve_dim(dim: &DimExpr) -> Result<usize, DimExprEvalError> {
     dim.eval(&[])
 }
 
 /// Resolve matrix dimensions and record their ordering as a guard.
 #[doc(hidden)]
-pub fn resolve_and_guard(m: &DimExpr, n: &DimExpr, ctx: &mut ShapeGuardContext) -> (usize, usize) {
-    let m_size = resolve_dim(m);
-    let n_size = resolve_dim(n);
+pub fn resolve_and_guard(
+    m: &DimExpr,
+    n: &DimExpr,
+    ctx: &mut ShapeGuardContext,
+) -> Result<(usize, usize), DimExprEvalError> {
+    let m_size = resolve_dim(m)?;
+    let n_size = resolve_dim(n)?;
     ctx.guards.push(ShapeGuard {
         dim_a: m_size,
         dim_b: n_size,
         ordering: m_size.cmp(&n_size),
     });
-    (m_size, n_size)
+    Ok((m_size, n_size))
 }

--- a/crates/tenferro-internal-ops/src/ad/contraction.rs
+++ b/crates/tenferro-internal-ops/src/ad/contraction.rs
@@ -21,10 +21,10 @@ pub fn linearize_dot_general(
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let lhs_rank = ctx
-        .shape_of(&ValueRef::External(primal_in[0].clone()))
+        .shape_of(&ValueRef::External(primal_in[0].clone()))?
         .len();
     let rhs_rank = ctx
-        .shape_of(&ValueRef::External(primal_in[1].clone()))
+        .shape_of(&ValueRef::External(primal_in[1].clone()))?
         .len();
     config
         .validate_dims_with_ranks(lhs_rank, rhs_rank)
@@ -121,13 +121,13 @@ pub fn linearize_reduce_prod(
     tangent_in: &[Option<LocalValueId>],
     axes: &[usize],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(dx) = tangent_in[0] else {
-        return vec![None];
+        return Ok(vec![None]);
     };
 
     let input_shape = ctx
-        .shape_of(&ValueRef::External(primal_in[0].clone()))
+        .shape_of(&ValueRef::External(primal_in[0].clone()))?
         .to_vec();
     let kept_dims = kept_dims(input_shape.len(), axes);
     let prod_broadcast = broadcast_reduction_output(
@@ -137,7 +137,7 @@ pub fn linearize_reduce_prod(
         &input_shape,
         &kept_dims,
     );
-    let input_dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let input_dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let coeff = reduce_prod_derivative_coeff(
         builder,
         ValueRef::External(primal_in[0].clone()),
@@ -163,7 +163,7 @@ pub fn linearize_reduce_prod(
             active_mask: vec![true],
         },
     )[0];
-    vec![Some(out)]
+    Ok(vec![Some(out)])
 }
 
 pub fn linearize_reduce_chooser(
@@ -173,13 +173,13 @@ pub fn linearize_reduce_chooser(
     tangent_in: &[Option<LocalValueId>],
     axes: &[usize],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(dx) = tangent_in[0] else {
-        return vec![None];
+        return Ok(vec![None]);
     };
 
     let input_shape = ctx
-        .shape_of(&ValueRef::External(primal_in[0].clone()))
+        .shape_of(&ValueRef::External(primal_in[0].clone()))?
         .to_vec();
     let kept_dims = kept_dims(input_shape.len(), axes);
     let answer_broadcast = broadcast_reduction_output(
@@ -194,7 +194,7 @@ pub fn linearize_reduce_chooser(
         ValueRef::External(primal_in[0].clone()),
         ValueRef::Local(answer_broadcast),
     );
-    let input_dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let input_dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let numeric_indicators = numeric_indicators(builder, indicators, input_dtype);
     let weighted_tangent = builder.add_operation(
         StdTensorOp::Mul,
@@ -220,7 +220,7 @@ pub fn linearize_reduce_chooser(
             active_mask: vec![true, false],
         },
     )[0];
-    vec![Some(out)]
+    Ok(vec![Some(out)])
 }
 
 pub fn transpose_dot_general(
@@ -236,8 +236,8 @@ pub fn transpose_dot_general(
         None => return Ok(vec![None, None]),
     };
 
-    let lhs_rank = ctx.shape_of(&inputs[0]).len();
-    let rhs_rank = ctx.shape_of(&inputs[1]).len();
+    let lhs_rank = ctx.shape_of(&inputs[0])?.len();
+    let rhs_rank = ctx.shape_of(&inputs[1])?.len();
     let lhs_dtype = dtype_of_or_real(ctx, &inputs[0]);
     let rhs_dtype = dtype_of_or_real(ctx, &inputs[1]);
     let output_dtype = promote_dtype(lhs_dtype, rhs_dtype);
@@ -269,7 +269,7 @@ pub fn transpose_dot_general(
     let mut result = vec![None, None];
 
     if active_mask[0] {
-        let rhs_conj = conjugate_primal_if_complex(builder, inputs[1].clone(), ctx);
+        let rhs_conj = conjugate_primal_if_complex(builder, inputs[1].clone(), ctx)?;
         let rhs_conj = convert_fixed_ref_to_dtype(builder, rhs_conj, rhs_dtype, output_dtype);
         let (transpose_config, new_lhs_rank, new_rhs_rank, perm) =
             transpose_plan_for_lhs(config, lhs_rank, rhs_rank, &lhs_free, &rhs_free)?;
@@ -293,7 +293,7 @@ pub fn transpose_dot_general(
     }
 
     if active_mask[1] {
-        let lhs_conj = conjugate_primal_if_complex(builder, inputs[0].clone(), ctx);
+        let lhs_conj = conjugate_primal_if_complex(builder, inputs[0].clone(), ctx)?;
         let lhs_conj = convert_fixed_ref_to_dtype(builder, lhs_conj, lhs_dtype, output_dtype);
         let (transpose_config, new_lhs_rank, new_rhs_rank, perm) =
             transpose_plan_for_rhs(config, lhs_rank, rhs_rank, &lhs_free, &rhs_free)?;
@@ -325,14 +325,14 @@ pub fn transpose_reduce_sum(
     op: &StdTensorOp,
     inputs: &[ValueRef<StdTensorOp>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::ReduceSum { axes } = op else {
         unreachable!("transpose_reduce_sum expects ReduceSum");
     };
 
     match cotangent_out[0] {
         Some(ct) => {
-            let input_shape = ctx.shape_of(&inputs[0]).to_vec();
+            let input_shape = ctx.shape_of(&inputs[0])?.to_vec();
             let kept_dims = (0..input_shape.len())
                 .filter(|dim| !axes.contains(dim))
                 .collect::<Vec<_>>();
@@ -364,9 +364,9 @@ pub fn transpose_reduce_sum(
                 op_inputs,
                 OperationRole::Linearized { active_mask },
             );
-            vec![Some(out[0])]
+            Ok(vec![Some(out[0])])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }
 
@@ -376,14 +376,14 @@ pub fn transpose_reduce_prod(
     inputs: &[ValueRef<StdTensorOp>],
     op: &StdTensorOp,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::ReduceProd { axes } = op else {
         unreachable!("transpose_reduce_prod expects ReduceProd");
     };
 
     match cotangent_out[0] {
         Some(ct) => {
-            let input_shape = ctx.shape_of(&inputs[0]).to_vec();
+            let input_shape = ctx.shape_of(&inputs[0])?.to_vec();
             let kept_dims = kept_dims(input_shape.len(), axes);
             let cotangent = normalize_reduction_cotangent(builder, ct, &kept_dims);
             let (shape, needs_shape_source) = sym_shape_to_dim_expr(&input_shape, 1);
@@ -412,7 +412,7 @@ pub fn transpose_reduce_prod(
                 &input_shape,
                 &kept_dims,
             );
-            let input_dtype = ctx.dtype_of(&inputs[0]);
+            let input_dtype = ctx.dtype_of(&inputs[0])?;
             let coeff = reduce_prod_derivative_coeff(
                 builder,
                 inputs[0].clone(),
@@ -431,9 +431,9 @@ pub fn transpose_reduce_prod(
                     active_mask: vec![false, true],
                 },
             )[0];
-            vec![Some(out)]
+            Ok(vec![Some(out)])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }
 
@@ -443,7 +443,7 @@ pub fn transpose_reduce_chooser(
     inputs: &[ValueRef<StdTensorOp>],
     op: &StdTensorOp,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let axes = match op {
         StdTensorOp::ReduceMax { axes } | StdTensorOp::ReduceMin { axes } => axes,
         _ => unreachable!("transpose_reduce_chooser expects ReduceMax or ReduceMin"),
@@ -451,7 +451,7 @@ pub fn transpose_reduce_chooser(
 
     match cotangent_out[0] {
         Some(ct) => {
-            let input_shape = ctx.shape_of(&inputs[0]).to_vec();
+            let input_shape = ctx.shape_of(&inputs[0])?.to_vec();
             let kept_dims = kept_dims(input_shape.len(), axes);
             let cotangent = normalize_reduction_cotangent(builder, ct, &kept_dims);
             let (shape, needs_shape_source) = sym_shape_to_dim_expr(&input_shape, 1);
@@ -485,7 +485,7 @@ pub fn transpose_reduce_chooser(
                 inputs[0].clone(),
                 ValueRef::Local(answer_broadcast),
             );
-            let input_dtype = ctx.dtype_of(&inputs[0]);
+            let input_dtype = ctx.dtype_of(&inputs[0])?;
             let numeric_indicators = numeric_indicators(builder, indicators, input_dtype);
             let counts = reduction_location_counts(builder, numeric_indicators, axes);
             let counts_broadcast = broadcast_reduction_output(
@@ -512,9 +512,9 @@ pub fn transpose_reduce_chooser(
                     active_mask: vec![false, true],
                 },
             )[0];
-            vec![Some(out)]
+            Ok(vec![Some(out)])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }
 

--- a/crates/tenferro-internal-ops/src/ad/diagonal.rs
+++ b/crates/tenferro-internal-ops/src/ad/diagonal.rs
@@ -1,6 +1,7 @@
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::PrimitiveRuleBuilder;
 use computegraph::types::{LocalValueId, OperationRole, ValueRef};
+use tidu::ADRuleResult;
 
 use crate::std_tensor_op::StdTensorOp;
 
@@ -9,7 +10,7 @@ pub fn linearize_extract_diag(
     tangent_in: &[Option<LocalValueId>],
     axis_a: usize,
     axis_b: usize,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     // TODO: ExtractDiag/EmbedDiag could be replaced by Gather/Scatter
     match tangent_in[0] {
         Some(dx) => {
@@ -20,9 +21,9 @@ pub fn linearize_extract_diag(
                     active_mask: vec![true],
                 },
             );
-            vec![Some(out[0])]
+            Ok(vec![Some(out[0])])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }
 
@@ -31,7 +32,7 @@ pub fn linearize_embed_diag(
     tangent_in: &[Option<LocalValueId>],
     axis_a: usize,
     axis_b: usize,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     // TODO: ExtractDiag/EmbedDiag could be replaced by Gather/Scatter
     match tangent_in[0] {
         Some(dx) => {
@@ -42,9 +43,9 @@ pub fn linearize_embed_diag(
                     active_mask: vec![true],
                 },
             );
-            vec![Some(out[0])]
+            Ok(vec![Some(out[0])])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }
 
@@ -55,7 +56,7 @@ pub fn transpose_extract_diag(
     axis_a: usize,
     axis_b: usize,
     _ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     // TODO: ExtractDiag/EmbedDiag could be replaced by Gather/Scatter
     match cotangent_out[0] {
         Some(ct) => {
@@ -80,9 +81,9 @@ pub fn transpose_extract_diag(
                     active_mask: vec![true, false],
                 },
             );
-            vec![Some(padded_axis_b[0])]
+            Ok(vec![Some(padded_axis_b[0])])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }
 
@@ -93,7 +94,7 @@ pub fn transpose_embed_diag(
     axis_a: usize,
     axis_b: usize,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     // TODO: ExtractDiag/EmbedDiag could be replaced by Gather/Scatter
     match cotangent_out[0] {
         Some(ct) => {
@@ -109,7 +110,7 @@ pub fn transpose_embed_diag(
                 },
             );
             if axis_b < axis_a {
-                let rank = ctx.shape_of(&inputs[0]).len();
+                let rank = ctx.shape_of(&inputs[0])?.len();
                 let mut perm: Vec<usize> = (0..rank).collect();
                 let diag_axis = perm.remove(axis_b);
                 perm.insert(axis_a, diag_axis);
@@ -120,10 +121,10 @@ pub fn transpose_embed_diag(
                         active_mask: vec![true],
                     },
                 );
-                return vec![Some(transposed[0])];
+                return Ok(vec![Some(transposed[0])]);
             }
-            vec![Some(out[0])]
+            Ok(vec![Some(out[0])])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }

--- a/crates/tenferro-internal-ops/src/ad/dynamic.rs
+++ b/crates/tenferro-internal-ops/src/ad/dynamic.rs
@@ -114,7 +114,7 @@ pub fn transpose_pad_to_match(
     // For concrete input metadata the adjoint is just a prefix slice back to
     // the original input shape. This keeps the transposed graph statically
     // shape-exact across checkpoint aliases.
-    if let Some(input_shape) = ctx.try_shape_of(&inputs[0]) {
+    if let Some(input_shape) = ctx.shape_if_available(&inputs[0]) {
         assert!(
             axis < input_shape.len(),
             "transpose_pad_to_match: axis {axis} out of bounds for rank {}",
@@ -172,10 +172,10 @@ fn static_truncated_shape(
     ctx: &mut ShapeGuardContext,
 ) -> Option<Vec<usize>> {
     let input_shape = ctx
-        .try_shape_of(&ValueRef::External(primal_in[0].clone()))?
+        .shape_if_available(&ValueRef::External(primal_in[0].clone()))?
         .to_vec();
     let output_shape = ctx
-        .try_shape_of(&ValueRef::External(primal_out[0].clone()))?
+        .shape_if_available(&ValueRef::External(primal_out[0].clone()))?
         .to_vec();
     if axis >= input_shape.len() || input_shape.len() != output_shape.len() {
         return None;

--- a/crates/tenferro-internal-ops/src/ad/indexing.rs
+++ b/crates/tenferro-internal-ops/src/ad/indexing.rs
@@ -31,6 +31,7 @@
 
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::{GatherConfig, ScatterConfig};
+use tidu::ADRuleResult;
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::zeros::build_zero_like;
@@ -148,21 +149,27 @@ pub fn linearize_dynamic_update_slice(
     primal_in: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     if tangent_in[0].is_none() && tangent_in[1].is_none() {
-        return vec![None];
+        return Ok(vec![None]);
     }
 
     let operand = ValueRef::External(primal_in[0].clone());
     let update = ValueRef::External(primal_in[1].clone());
-    let d_operand = tangent_in[0].unwrap_or_else(|| {
-        let meta = ctx.metadata_of(&operand);
-        build_zero_like(builder, meta.dtype, operand, meta.shape.len())
-    });
-    let d_update = tangent_in[1].unwrap_or_else(|| {
-        let meta = ctx.metadata_of(&update);
-        build_zero_like(builder, meta.dtype, update, meta.shape.len())
-    });
+    let d_operand = match tangent_in[0] {
+        Some(tangent) => tangent,
+        None => {
+            let meta = ctx.metadata_of(&operand)?;
+            build_zero_like(builder, meta.dtype, operand, meta.rank())
+        }
+    };
+    let d_update = match tangent_in[1] {
+        Some(tangent) => tangent,
+        None => {
+            let meta = ctx.metadata_of(&update)?;
+            build_zero_like(builder, meta.dtype, update, meta.rank())
+        }
+    };
 
     let out = builder.add_operation(
         StdTensorOp::DynamicUpdateSlice,
@@ -175,7 +182,7 @@ pub fn linearize_dynamic_update_slice(
             active_mask: vec![tangent_in[0].is_some(), tangent_in[1].is_some(), false],
         },
     );
-    vec![Some(out[0])]
+    Ok(vec![Some(out[0])])
 }
 
 /// Reverse-mode AD rule for `Gather(operand, start_indices, config)`.
@@ -195,19 +202,19 @@ pub fn transpose_gather(
     mode: &OperationRole,
     config: &GatherConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
-        None => return vec![None, None],
+        None => return Ok(vec![None, None]),
     };
 
     let active_mask = match mode {
         OperationRole::Linearized { active_mask } => active_mask.clone(),
-        OperationRole::Primary => return vec![None, None],
+        OperationRole::Primary => return Ok(vec![None, None]),
     };
 
     if !active_mask.first().copied().unwrap_or(false) {
-        return vec![None, None];
+        return Ok(vec![None, None]);
     }
 
     let inverse_config = ScatterConfig {
@@ -217,8 +224,8 @@ pub fn transpose_gather(
         index_vector_dim: config.index_vector_dim,
     };
 
-    let operand_meta = ctx.metadata_of(&inputs[0]);
-    let operand_rank = operand_meta.shape.len();
+    let operand_meta = ctx.metadata_of(&inputs[0])?;
+    let operand_rank = operand_meta.rank();
     let operand_dtype = operand_meta.dtype;
     let zero_operand = build_zero_like(builder, operand_dtype, inputs[0].clone(), operand_rank);
 
@@ -234,7 +241,7 @@ pub fn transpose_gather(
         },
     );
 
-    vec![Some(out[0]), None]
+    Ok(vec![Some(out[0]), None])
 }
 
 /// Reverse-mode AD rule for `GatherDynamicSliceSizes`.
@@ -253,20 +260,20 @@ pub fn transpose_gather_dynamic_slice_sizes(
     start_index_map: &[usize],
     index_vector_dim: usize,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let mut result = vec![None; inputs.len()];
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
-        None => return result,
+        None => return Ok(result),
     };
 
     let active_mask = match mode {
         OperationRole::Linearized { active_mask } => active_mask,
-        OperationRole::Primary => return result,
+        OperationRole::Primary => return Ok(result),
     };
 
     if !active_mask.first().copied().unwrap_or(false) {
-        return result;
+        return Ok(result);
     }
 
     let inverse_config = ScatterConfig {
@@ -276,8 +283,8 @@ pub fn transpose_gather_dynamic_slice_sizes(
         index_vector_dim,
     };
 
-    let operand_meta = ctx.metadata_of(&inputs[0]);
-    let operand_rank = operand_meta.shape.len();
+    let operand_meta = ctx.metadata_of(&inputs[0])?;
+    let operand_rank = operand_meta.rank();
     let operand_dtype = operand_meta.dtype;
     let zero_operand = build_zero_like(builder, operand_dtype, inputs[0].clone(), operand_rank);
 
@@ -294,7 +301,7 @@ pub fn transpose_gather_dynamic_slice_sizes(
     );
 
     result[0] = Some(out[0]);
-    result
+    Ok(result)
 }
 
 /// Reverse-mode AD rule for `DynamicSlice`.
@@ -307,26 +314,26 @@ pub fn transpose_dynamic_slice(
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
-        None => return vec![None, None],
+        None => return Ok(vec![None, None]),
     };
 
     let active_mask = match mode {
         OperationRole::Linearized { active_mask } => active_mask,
-        OperationRole::Primary => return vec![None, None],
+        OperationRole::Primary => return Ok(vec![None, None]),
     };
     if !active_mask.first().copied().unwrap_or(false) {
-        return vec![None, None];
+        return Ok(vec![None, None]);
     }
 
-    let operand_meta = ctx.metadata_of(&inputs[0]);
+    let operand_meta = ctx.metadata_of(&inputs[0])?;
     let zero_operand = build_zero_like(
         builder,
         operand_meta.dtype,
         inputs[0].clone(),
-        operand_meta.shape.len(),
+        operand_meta.rank(),
     );
     let out = builder.add_operation(
         StdTensorOp::DynamicUpdateSlice,
@@ -339,7 +346,7 @@ pub fn transpose_dynamic_slice(
             active_mask: vec![false, true, false],
         },
     );
-    vec![Some(out[0]), None]
+    Ok(vec![Some(out[0]), None])
 }
 
 /// Reverse-mode AD rule for `DynamicUpdateSlice`.
@@ -353,25 +360,25 @@ pub fn transpose_dynamic_update_slice(
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
-        None => return vec![None, None, None],
+        None => return Ok(vec![None, None, None]),
     };
 
     let active_mask = match mode {
         OperationRole::Linearized { active_mask } => active_mask,
-        OperationRole::Primary => return vec![None, None, None],
+        OperationRole::Primary => return Ok(vec![None, None, None]),
     };
 
     let mut result = vec![None, None, None];
     if active_mask.first().copied().unwrap_or(false) {
-        let update_meta = ctx.metadata_of(&inputs[1]);
+        let update_meta = ctx.metadata_of(&inputs[1])?;
         let zero_update = build_zero_like(
             builder,
             update_meta.dtype,
             inputs[1].clone(),
-            update_meta.shape.len(),
+            update_meta.rank(),
         );
         let operand_ct = builder.add_operation(
             StdTensorOp::DynamicUpdateSlice,
@@ -390,7 +397,7 @@ pub fn transpose_dynamic_update_slice(
     if active_mask.get(1).copied().unwrap_or(false) {
         let Some(update_shape) = exact_usize_shape(ctx, &inputs[1], "DynamicUpdateSlice transpose")
         else {
-            return result;
+            return Ok(result);
         };
         let update_ct = builder.add_operation(
             StdTensorOp::DynamicSlice {
@@ -404,7 +411,7 @@ pub fn transpose_dynamic_update_slice(
         result[1] = Some(update_ct);
     }
 
-    result
+    Ok(result)
 }
 
 /// Forward-mode AD rule for `Scatter(operand, scatter_indices, updates, config)`.
@@ -432,17 +439,17 @@ pub fn linearize_scatter(
     tangent_in: &[Option<LocalValueId>],
     config: &ScatterConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let d_operand = tangent_in[0];
     let d_updates = tangent_in[2];
 
     match (d_operand, d_updates) {
-        (None, None) => vec![None],
-        (Some(d_op), None) => vec![Some(d_op)],
+        (None, None) => Ok(vec![None]),
+        (Some(d_op), None) => Ok(vec![Some(d_op)]),
         (None, Some(d_up)) => {
             let operand_key = ValueRef::External(primal_in[0].clone());
-            let operand_meta = ctx.metadata_of(&operand_key);
-            let operand_rank = operand_meta.shape.len();
+            let operand_meta = ctx.metadata_of(&operand_key)?;
+            let operand_rank = operand_meta.rank();
             let operand_dtype = operand_meta.dtype;
             let zero_operand =
                 build_zero_like(builder, operand_dtype, operand_key.clone(), operand_rank);
@@ -457,7 +464,7 @@ pub fn linearize_scatter(
                     active_mask: vec![false, false, true],
                 },
             );
-            vec![Some(out[0])]
+            Ok(vec![Some(out[0])])
         }
         (Some(d_op), Some(d_up)) => {
             let out = builder.add_operation(
@@ -471,7 +478,7 @@ pub fn linearize_scatter(
                     active_mask: vec![true, false, true],
                 },
             );
-            vec![Some(out[0])]
+            Ok(vec![Some(out[0])])
         }
     }
 }
@@ -496,15 +503,15 @@ pub fn transpose_scatter(
     mode: &OperationRole,
     config: &ScatterConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
-        None => return vec![None, None, None],
+        None => return Ok(vec![None, None, None]),
     };
 
     let active_mask = match mode {
         OperationRole::Linearized { active_mask } => active_mask.clone(),
-        OperationRole::Primary => return vec![None, None, None],
+        OperationRole::Primary => return Ok(vec![None, None, None]),
     };
 
     let operand_active = active_mask.first().copied().unwrap_or(false);
@@ -517,12 +524,12 @@ pub fn transpose_scatter(
     }
 
     if updates_active {
-        let operand_shape = ctx.shape_of(&inputs[0]).to_vec();
-        let updates_shape = ctx.shape_of(&inputs[2]).to_vec();
+        let operand_shape = ctx.shape_of(&inputs[0])?.to_vec();
+        let updates_shape = ctx.shape_of(&inputs[2])?.to_vec();
         let Some(inverse) =
             compute_inverse_gather(&operand_shape, &updates_shape, config, &inputs[2])
         else {
-            return result;
+            return Ok(result);
         };
 
         let out = match inverse {
@@ -563,7 +570,7 @@ pub fn transpose_scatter(
         result[2] = Some(out[0]);
     }
 
-    result
+    Ok(result)
 }
 
 enum InverseGather {
@@ -643,7 +650,8 @@ fn exact_usize_shape(
     value: &ValueRef<StdTensorOp>,
     _op_name: &'static str,
 ) -> Option<Vec<usize>> {
-    ctx.exact_shape_of(value)?
+    ctx.exact_shape_of(value)
+        .ok()??
         .into_iter()
         .map(|dim| dim.constant_value())
         .collect()

--- a/crates/tenferro-internal-ops/src/ad/mod.rs
+++ b/crates/tenferro-internal-ops/src/ad/mod.rs
@@ -117,22 +117,6 @@ pub fn linearize(
     primal_out: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut context::ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
-    match try_linearize(op, builder, primal_in, primal_out, tangent_in, ctx) {
-        Ok(tangents) => tangents,
-        Err(err) => panic!("{err}"),
-    }
-}
-
-/// Fallible forward-mode AD (JVP) for `StdTensorOp`.
-#[cfg(feature = "autodiff")]
-pub fn try_linearize(
-    op: &StdTensorOp,
-    builder: &mut dyn PrimitiveRuleBuilder,
-    primal_in: &[ValueKey<StdTensorOp>],
-    primal_out: &[ValueKey<StdTensorOp>],
-    tangent_in: &[Option<LocalValueId>],
-    ctx: &mut context::ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     if let StdTensorOp::Extension(ext) = op {
         return linearize_extension_rule(
@@ -161,22 +145,6 @@ pub fn try_linearize(
 /// here.
 #[cfg(feature = "autodiff")]
 pub fn transpose_rule(
-    op: &StdTensorOp,
-    builder: &mut impl PrimitiveRuleBuilder,
-    cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
-    mode: &OperationRole,
-    ctx: &mut context::ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
-    match try_transpose_rule(op, builder, cotangent_out, inputs, mode, ctx) {
-        Ok(cotangents) => cotangents,
-        Err(err) => panic!("{err}"),
-    }
-}
-
-/// Fallible reverse-mode AD (VJP) for `StdTensorOp`.
-#[cfg(feature = "autodiff")]
-pub fn try_transpose_rule(
     op: &StdTensorOp,
     builder: &mut impl PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],

--- a/crates/tenferro-internal-ops/src/ad/registry.rs
+++ b/crates/tenferro-internal-ops/src/ad/registry.rs
@@ -359,7 +359,7 @@ fn transpose_add(
     _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(semiring::transpose_add(builder, cotangent_out, inputs, ctx))
+    semiring::transpose_add(builder, cotangent_out, inputs, ctx)
 }
 
 fn linearize_mul(
@@ -381,13 +381,7 @@ fn transpose_mul(
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(semiring::transpose_mul(
-        builder,
-        cotangent_out,
-        inputs,
-        mode,
-        ctx,
-    ))
+    semiring::transpose_mul(builder, cotangent_out, inputs, mode, ctx)
 }
 
 fn linearize_neg(
@@ -420,9 +414,7 @@ fn linearize_conj(
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(semiring::linearize_conj(
-        builder, primal_in, tangent_in, ctx,
-    ))
+    semiring::linearize_conj(builder, primal_in, tangent_in, ctx)
 }
 
 fn transpose_conj(
@@ -433,12 +425,7 @@ fn transpose_conj(
     _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(semiring::transpose_conj(
-        builder,
-        cotangent_out,
-        inputs,
-        ctx,
-    ))
+    semiring::transpose_conj(builder, cotangent_out, inputs, ctx)
 }
 
 fn linearize_div(
@@ -780,13 +767,7 @@ fn transpose_reduce_sum(
     _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(contraction::transpose_reduce_sum(
-        builder,
-        cotangent_out,
-        op,
-        inputs,
-        ctx,
-    ))
+    contraction::transpose_reduce_sum(builder, cotangent_out, op, inputs, ctx)
 }
 
 fn linearize_reduce_prod(
@@ -800,9 +781,7 @@ fn linearize_reduce_prod(
     let StdTensorOp::ReduceProd { axes } = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(contraction::linearize_reduce_prod(
-        builder, primal_in, primal_out, tangent_in, axes, ctx,
-    ))
+    contraction::linearize_reduce_prod(builder, primal_in, primal_out, tangent_in, axes, ctx)
 }
 
 fn transpose_reduce_prod(
@@ -813,13 +792,7 @@ fn transpose_reduce_prod(
     _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(contraction::transpose_reduce_prod(
-        builder,
-        cotangent_out,
-        inputs,
-        op,
-        ctx,
-    ))
+    contraction::transpose_reduce_prod(builder, cotangent_out, inputs, op, ctx)
 }
 
 fn linearize_reduce_max(
@@ -833,9 +806,7 @@ fn linearize_reduce_max(
     let StdTensorOp::ReduceMax { axes } = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(contraction::linearize_reduce_chooser(
-        builder, primal_in, primal_out, tangent_in, axes, ctx,
-    ))
+    contraction::linearize_reduce_chooser(builder, primal_in, primal_out, tangent_in, axes, ctx)
 }
 
 fn linearize_reduce_min(
@@ -849,9 +820,7 @@ fn linearize_reduce_min(
     let StdTensorOp::ReduceMin { axes } = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(contraction::linearize_reduce_chooser(
-        builder, primal_in, primal_out, tangent_in, axes, ctx,
-    ))
+    contraction::linearize_reduce_chooser(builder, primal_in, primal_out, tangent_in, axes, ctx)
 }
 
 fn transpose_reduce_max(
@@ -862,13 +831,7 @@ fn transpose_reduce_max(
     _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(contraction::transpose_reduce_chooser(
-        builder,
-        cotangent_out,
-        inputs,
-        op,
-        ctx,
-    ))
+    contraction::transpose_reduce_chooser(builder, cotangent_out, inputs, op, ctx)
 }
 
 fn transpose_reduce_min(
@@ -879,13 +842,7 @@ fn transpose_reduce_min(
     _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(contraction::transpose_reduce_chooser(
-        builder,
-        cotangent_out,
-        inputs,
-        op,
-        ctx,
-    ))
+    contraction::transpose_reduce_chooser(builder, cotangent_out, inputs, op, ctx)
 }
 
 fn linearize_transpose(
@@ -941,13 +898,7 @@ fn transpose_reshape(
     _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(structural::transpose_reshape(
-        builder,
-        cotangent_out,
-        op,
-        inputs,
-        ctx,
-    ))
+    structural::transpose_reshape(builder, cotangent_out, op, inputs, ctx)
 }
 
 fn linearize_broadcast_in_dim(
@@ -977,14 +928,7 @@ fn transpose_broadcast_in_dim(
     let StdTensorOp::BroadcastInDim { shape, dims } = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(structural::transpose_broadcast_in_dim(
-        builder,
-        cotangent_out,
-        shape,
-        dims,
-        inputs,
-        ctx,
-    ))
+    structural::transpose_broadcast_in_dim(builder, cotangent_out, shape, dims, inputs, ctx)
 }
 
 fn linearize_convert(
@@ -1036,7 +980,7 @@ macro_rules! diagonal_rule {
             let StdTensorOp::$variant { axis_a, axis_b } = op else {
                 unreachable!("catalog kind mismatch")
             };
-            Ok($lin_call(builder, tangent_in, *axis_a, *axis_b))
+            $lin_call(builder, tangent_in, *axis_a, *axis_b)
         }
 
         fn $trans(
@@ -1050,14 +994,7 @@ macro_rules! diagonal_rule {
             let StdTensorOp::$variant { axis_a, axis_b } = op else {
                 unreachable!("catalog kind mismatch")
             };
-            Ok($trans_call(
-                builder,
-                cotangent_out,
-                inputs,
-                *axis_a,
-                *axis_b,
-                ctx,
-            ))
+            $trans_call(builder, cotangent_out, inputs, *axis_a, *axis_b, ctx)
         }
     };
 }
@@ -1151,14 +1088,7 @@ fn transpose_gather(
     let StdTensorOp::Gather(config) = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(indexing::transpose_gather(
-        builder,
-        cotangent_out,
-        inputs,
-        mode,
-        config,
-        ctx,
-    ))
+    indexing::transpose_gather(builder, cotangent_out, inputs, mode, config, ctx)
 }
 
 fn linearize_gather_dynamic_slice_sizes(
@@ -1209,7 +1139,7 @@ fn transpose_gather_dynamic_slice_sizes(
     else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(indexing::transpose_gather_dynamic_slice_sizes(
+    indexing::transpose_gather_dynamic_slice_sizes(
         builder,
         cotangent_out,
         inputs,
@@ -1219,7 +1149,7 @@ fn transpose_gather_dynamic_slice_sizes(
         start_index_map,
         *index_vector_dim,
         ctx,
-    ))
+    )
 }
 
 fn linearize_scatter(
@@ -1233,9 +1163,7 @@ fn linearize_scatter(
     let StdTensorOp::Scatter(config) = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(indexing::linearize_scatter(
-        builder, primal_in, tangent_in, config, ctx,
-    ))
+    indexing::linearize_scatter(builder, primal_in, tangent_in, config, ctx)
 }
 
 fn transpose_scatter(
@@ -1249,14 +1177,7 @@ fn transpose_scatter(
     let StdTensorOp::Scatter(config) = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(indexing::transpose_scatter(
-        builder,
-        cotangent_out,
-        inputs,
-        mode,
-        config,
-        ctx,
-    ))
+    indexing::transpose_scatter(builder, cotangent_out, inputs, mode, config, ctx)
 }
 
 fn linearize_slice(
@@ -1284,14 +1205,7 @@ fn transpose_slice(
     let StdTensorOp::Slice(config) = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(structural::transpose_slice(
-        builder,
-        cotangent_out,
-        inputs,
-        mode,
-        config,
-        ctx,
-    ))
+    structural::transpose_slice(builder, cotangent_out, inputs, mode, config, ctx)
 }
 
 fn linearize_dynamic_slice(
@@ -1321,13 +1235,7 @@ fn transpose_dynamic_slice(
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(indexing::transpose_dynamic_slice(
-        builder,
-        cotangent_out,
-        inputs,
-        mode,
-        ctx,
-    ))
+    indexing::transpose_dynamic_slice(builder, cotangent_out, inputs, mode, ctx)
 }
 
 fn linearize_dynamic_update_slice(
@@ -1338,9 +1246,7 @@ fn linearize_dynamic_update_slice(
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(indexing::linearize_dynamic_update_slice(
-        builder, primal_in, tangent_in, ctx,
-    ))
+    indexing::linearize_dynamic_update_slice(builder, primal_in, tangent_in, ctx)
 }
 
 fn transpose_dynamic_update_slice(
@@ -1351,13 +1257,7 @@ fn transpose_dynamic_update_slice(
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(indexing::transpose_dynamic_update_slice(
-        builder,
-        cotangent_out,
-        inputs,
-        mode,
-        ctx,
-    ))
+    indexing::transpose_dynamic_update_slice(builder, cotangent_out, inputs, mode, ctx)
 }
 
 fn linearize_pad(
@@ -1385,14 +1285,7 @@ fn transpose_pad(
     let StdTensorOp::Pad(config) = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(structural::transpose_pad(
-        builder,
-        cotangent_out,
-        inputs,
-        mode,
-        config,
-        ctx,
-    ))
+    structural::transpose_pad(builder, cotangent_out, inputs, mode, config, ctx)
 }
 
 fn linearize_concatenate(
@@ -1406,14 +1299,7 @@ fn linearize_concatenate(
     let StdTensorOp::Concatenate { axis, input_count } = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(structural::linearize_concatenate(
-        builder,
-        primal_in,
-        tangent_in,
-        *axis,
-        *input_count,
-        ctx,
-    ))
+    structural::linearize_concatenate(builder, primal_in, tangent_in, *axis, *input_count, ctx)
 }
 
 fn transpose_concatenate(
@@ -1427,7 +1313,7 @@ fn transpose_concatenate(
     let StdTensorOp::Concatenate { axis, input_count } = op else {
         unreachable!("catalog kind mismatch")
     };
-    Ok(structural::transpose_concatenate(
+    structural::transpose_concatenate(
         builder,
         cotangent_out,
         inputs,
@@ -1435,7 +1321,7 @@ fn transpose_concatenate(
         *axis,
         *input_count,
         ctx,
-    ))
+    )
 }
 
 fn linearize_reverse(

--- a/crates/tenferro-internal-ops/src/ad/semiring.rs
+++ b/crates/tenferro-internal-ops/src/ad/semiring.rs
@@ -1,4 +1,5 @@
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
+use tidu::ADRuleResult;
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::support::{
@@ -127,13 +128,15 @@ pub fn linearize_conj(
     primal_in: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     match tangent_in[0] {
         Some(dx) => {
-            let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
-            vec![Some(conjugate_linear_if_dtype_complex(builder, dx, dtype))]
+            let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
+            Ok(vec![Some(conjugate_linear_if_dtype_complex(
+                builder, dx, dtype,
+            ))])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }
 
@@ -142,13 +145,13 @@ pub fn transpose_add(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     match cotangent_out[0] {
         Some(ct) => {
             let lhs_dtype = dtype_of_or_real(ctx, &inputs[0]);
             let rhs_dtype = dtype_of_or_real(ctx, &inputs[1]);
             let output_dtype = promote_dtype(lhs_dtype, rhs_dtype);
-            vec![
+            Ok(vec![
                 Some(project_linear_to_dtype(
                     builder,
                     ct,
@@ -161,9 +164,9 @@ pub fn transpose_add(
                     output_dtype,
                     rhs_dtype,
                 )),
-            ]
+            ])
         }
-        None => vec![None, None],
+        None => Ok(vec![None, None]),
     }
 }
 
@@ -173,15 +176,15 @@ pub fn transpose_mul(
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
-        None => return vec![None, None],
+        None => return Ok(vec![None, None]),
     };
 
     let active_mask = match mode {
         OperationRole::Linearized { active_mask } => active_mask,
-        OperationRole::Primary => return vec![None, None],
+        OperationRole::Primary => return Ok(vec![None, None]),
     };
 
     let lhs_dtype = dtype_of_or_real(ctx, &inputs[0]);
@@ -190,7 +193,7 @@ pub fn transpose_mul(
     let mut result = vec![None, None];
 
     if active_mask[0] {
-        let rhs_conj = conjugate_primal_if_complex(builder, inputs[1].clone(), ctx);
+        let rhs_conj = conjugate_primal_if_complex(builder, inputs[1].clone(), ctx)?;
         let rhs_conj = convert_fixed_ref_to_dtype(builder, rhs_conj, rhs_dtype, output_dtype);
         let out = builder.add_operation(
             StdTensorOp::Mul,
@@ -208,7 +211,7 @@ pub fn transpose_mul(
     }
 
     if active_mask[1] {
-        let lhs_conj = conjugate_primal_if_complex(builder, inputs[0].clone(), ctx);
+        let lhs_conj = conjugate_primal_if_complex(builder, inputs[0].clone(), ctx)?;
         let lhs_conj = convert_fixed_ref_to_dtype(builder, lhs_conj, lhs_dtype, output_dtype);
         let out = builder.add_operation(
             StdTensorOp::Mul,
@@ -225,7 +228,7 @@ pub fn transpose_mul(
         ));
     }
 
-    result
+    Ok(result)
 }
 
 pub fn transpose_neg(
@@ -252,12 +255,14 @@ pub fn transpose_conj(
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     match cotangent_out[0] {
         Some(ct) => {
-            let dtype = ctx.dtype_of(&inputs[0]);
-            vec![Some(conjugate_linear_if_dtype_complex(builder, ct, dtype))]
+            let dtype = ctx.dtype_of(&inputs[0])?;
+            Ok(vec![Some(conjugate_linear_if_dtype_complex(
+                builder, ct, dtype,
+            ))])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }

--- a/crates/tenferro-internal-ops/src/ad/structural.rs
+++ b/crates/tenferro-internal-ops/src/ad/structural.rs
@@ -1,5 +1,6 @@
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::{PadConfig, SliceConfig};
+use tidu::ADRuleResult;
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::support::is_differentiable_dtype;
@@ -24,9 +25,10 @@ fn shape_exprs_match_primal_input(
         return false;
     }
 
-    let input_shape = ctx
-        .shape_of(&ValueRef::External(primal_in[0].clone()))
-        .to_vec();
+    let Ok(input_shape) = ctx.shape_of(&ValueRef::External(primal_in[0].clone())) else {
+        return false;
+    };
+    let input_shape = input_shape.to_vec();
     if input_shape.len() != shape.len() {
         return false;
     }
@@ -250,12 +252,12 @@ pub fn linearize_concatenate(
     axis: usize,
     input_count: usize,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     if tangent_in.iter().all(Option::is_none) {
-        return vec![None];
+        return Ok(vec![None]);
     }
     if input_count == 1 {
-        return vec![tangent_in[0]];
+        return Ok(vec![tangent_in[0]]);
     }
 
     let mut inputs = Vec::with_capacity(input_count);
@@ -268,8 +270,8 @@ pub fn linearize_concatenate(
             }
             None => {
                 let anchor = ValueRef::External(primal_in[input_index].clone());
-                let meta = ctx.metadata_of(&anchor);
-                let zero = build_zero_like(builder, meta.dtype, anchor, meta.shape.len());
+                let meta = ctx.metadata_of(&anchor)?;
+                let zero = build_zero_like(builder, meta.dtype, anchor, meta.rank());
                 inputs.push(ValueRef::Local(zero));
                 active_mask.push(false);
             }
@@ -281,7 +283,7 @@ pub fn linearize_concatenate(
         inputs,
         OperationRole::Linearized { active_mask },
     );
-    vec![Some(out[0])]
+    Ok(vec![Some(out[0])])
 }
 
 pub fn linearize_reverse(
@@ -340,7 +342,7 @@ pub fn transpose_reshape(
     op: &StdTensorOp,
     inputs: &[ValueRef<StdTensorOp>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Reshape { to_shape: _ } = op else {
         unreachable!("transpose_reshape expects Reshape");
     };
@@ -348,7 +350,7 @@ pub fn transpose_reshape(
     let mut result = Vec::with_capacity(inputs.len());
     let primary = match cotangent_out[0] {
         Some(ct) => {
-            let input_rank = ctx.shape_of(&inputs[0]).len();
+            let input_rank = ctx.shape_of(&inputs[0])?.len();
             let remapped_to_shape = DimExpr::input_shape(1, input_rank);
             let needs_shape_source =
                 DimExpr::max_input_idx_all(&remapped_to_shape).is_some_and(|idx| idx > 0);
@@ -374,7 +376,7 @@ pub fn transpose_reshape(
     for _ in 1..inputs.len() {
         result.push(None);
     }
-    result
+    Ok(result)
 }
 
 pub fn transpose_broadcast_in_dim(
@@ -384,7 +386,7 @@ pub fn transpose_broadcast_in_dim(
     dims: &[usize],
     inputs: &[ValueRef<StdTensorOp>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let (reduce_axes, needs_input_shape_restore) =
         broadcast_transpose_reduce_axes(shape, dims, inputs, ctx);
 
@@ -417,7 +419,7 @@ pub fn transpose_broadcast_in_dim(
                 reduced
             };
             if needs_input_shape_restore {
-                let input_rank = ctx.shape_of(&inputs[0]).len();
+                let input_rank = ctx.shape_of(&inputs[0])?.len();
                 let reshaped = builder.add_operation(
                     StdTensorOp::Reshape {
                         to_shape: DimExpr::input_shape(1, input_rank),
@@ -440,7 +442,7 @@ pub fn transpose_broadcast_in_dim(
     for _ in 1..inputs.len() {
         result.push(None);
     }
-    result
+    Ok(result)
 }
 
 fn broadcast_transpose_reduce_axes(
@@ -514,7 +516,7 @@ fn collect_known_input_shapes(
 ) -> Option<Vec<Vec<SymDim>>> {
     let mut shapes = Vec::with_capacity(inputs.len());
     for input in inputs {
-        shapes.push(ctx.try_shape_of(input)?.to_vec());
+        shapes.push(ctx.shape_if_available(input)?.to_vec());
     }
     Some(shapes)
 }
@@ -600,18 +602,18 @@ pub fn transpose_slice(
     mode: &OperationRole,
     config: &SliceConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(ct) = cotangent_out[0] else {
-        return vec![None];
+        return Ok(vec![None]);
     };
     if !first_input_active(mode) {
-        return vec![None];
+        return Ok(vec![None]);
     }
 
-    let input_shape = ctx.shape_of(&inputs[0]);
+    let input_shape = ctx.shape_of(&inputs[0])?;
     let rank = input_shape.len();
     if config.starts.len() != rank || config.limits.len() != rank || config.strides.len() != rank {
-        return vec![None];
+        return Ok(vec![None]);
     }
 
     let mut edge_padding_low = Vec::with_capacity(rank);
@@ -619,14 +621,14 @@ pub fn transpose_slice(
     let mut interior_padding = Vec::with_capacity(rank);
 
     for axis in 0..rank {
-        let Some(input_extent) = try_static_dim(input_shape, axis) else {
-            return vec![None];
+        let Some(input_extent) = try_static_dim(&input_shape, axis) else {
+            return Ok(vec![None]);
         };
         let start = config.starts[axis];
         let limit = config.limits[axis];
         let stride = config.strides[axis];
         if stride == 0 || start > limit || limit > input_extent {
-            return vec![None];
+            return Ok(vec![None]);
         }
 
         let selected_len = if limit == start {
@@ -638,10 +640,10 @@ pub fn transpose_slice(
             0
         } else {
             let Some(covered_minus_one) = (selected_len - 1).checked_mul(stride) else {
-                return vec![None];
+                return Ok(vec![None]);
             };
             let Some(covered) = covered_minus_one.checked_add(1) else {
-                return vec![None];
+                return Ok(vec![None]);
             };
             covered
         };
@@ -652,7 +654,7 @@ pub fn transpose_slice(
             try_usize_to_i64(high),
             try_usize_to_i64(stride - 1),
         ) else {
-            return vec![None];
+            return Ok(vec![None]);
         };
         edge_padding_low.push(low);
         edge_padding_high.push(high);
@@ -670,7 +672,7 @@ pub fn transpose_slice(
             active_mask: vec![true],
         },
     );
-    vec![Some(out[0])]
+    Ok(vec![Some(out[0])])
 }
 
 pub fn transpose_pad(
@@ -680,21 +682,21 @@ pub fn transpose_pad(
     mode: &OperationRole,
     config: &PadConfig,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(ct) = cotangent_out[0] else {
-        return vec![None];
+        return Ok(vec![None]);
     };
     if !first_input_active(mode) {
-        return vec![None];
+        return Ok(vec![None]);
     }
 
-    let input_shape = ctx.shape_of(&inputs[0]);
+    let input_shape = ctx.shape_of(&inputs[0])?;
     let rank = input_shape.len();
     if config.edge_padding_low.len() != rank
         || config.edge_padding_high.len() != rank
         || config.interior_padding.len() != rank
     {
-        return vec![None];
+        return Ok(vec![None]);
     }
 
     let mut starts = Vec::with_capacity(rank);
@@ -704,15 +706,15 @@ pub fn transpose_pad(
     let mut edge_padding_high = Vec::with_capacity(rank);
 
     for axis in 0..rank {
-        let Some(input_extent) = try_static_dim(input_shape, axis) else {
-            return vec![None];
+        let Some(input_extent) = try_static_dim(&input_shape, axis) else {
+            return Ok(vec![None]);
         };
         let input_extent_i = input_extent as i128;
         let low = i128::from(config.edge_padding_low[axis]);
         let high = i128::from(config.edge_padding_high[axis]);
         let interior = i128::from(config.interior_padding[axis]);
         if interior < 0 {
-            return vec![None];
+            return Ok(vec![None]);
         }
         let stride = interior + 1;
         let base = if input_extent == 0 {
@@ -722,19 +724,19 @@ pub fn transpose_pad(
         };
         let output_extent = low + high + base;
         if output_extent < 0 {
-            return vec![None];
+            return Ok(vec![None]);
         }
 
         let first_kept = if low < 0 {
             let Some(first_kept) = try_ceil_div_i128(-low, stride) else {
-                return vec![None];
+                return Ok(vec![None]);
             };
             first_kept
         } else {
             0
         };
         let Some(first_dropped_after) = try_ceil_div_i128(output_extent - low, stride) else {
-            return vec![None];
+            return Ok(vec![None]);
         };
         let j_start = clamp_i128(first_kept, 0, input_extent_i);
         let mut j_end = clamp_i128(first_dropped_after, 0, input_extent_i);
@@ -751,7 +753,7 @@ pub fn transpose_pad(
             (empty, empty)
         };
         if !(0 <= slice_start && slice_start <= slice_limit && slice_limit <= output_extent) {
-            return vec![None];
+            return Ok(vec![None]);
         }
 
         let (Some(start), Some(limit), Some(stride), Some(low), Some(high)) = (
@@ -761,7 +763,7 @@ pub fn transpose_pad(
             try_i128_to_i64(j_start),
             try_i128_to_i64(input_extent_i - j_end),
         ) else {
-            return vec![None];
+            return Ok(vec![None]);
         };
         starts.push(start);
         limits.push(limit);
@@ -784,7 +786,7 @@ pub fn transpose_pad(
 
     if edge_padding_low.iter().all(|&pad| pad == 0) && edge_padding_high.iter().all(|&pad| pad == 0)
     {
-        return vec![Some(sliced)];
+        return Ok(vec![Some(sliced)]);
     }
 
     let out = builder.add_operation(
@@ -798,7 +800,7 @@ pub fn transpose_pad(
             active_mask: vec![true],
         },
     );
-    vec![Some(out[0])]
+    Ok(vec![Some(out[0])])
 }
 
 pub fn transpose_reverse(
@@ -834,35 +836,35 @@ pub fn transpose_concatenate(
     axis: usize,
     input_count: usize,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(ct) = cotangent_out[0] else {
-        return vec![None; input_count];
+        return Ok(vec![None; input_count]);
     };
     let active_mask = match mode {
         OperationRole::Linearized { active_mask } => active_mask,
-        OperationRole::Primary => return vec![None; input_count],
+        OperationRole::Primary => return Ok(vec![None; input_count]),
     };
 
     let mut result = vec![None; input_count];
     let mut axis_offset = 0usize;
     let mut concrete_shapes = Vec::with_capacity(input_count);
     for input in inputs.iter().take(input_count) {
-        let input_shape = ctx.shape_of(input);
+        let input_shape = ctx.shape_of(input)?;
         let rank = input_shape.len();
         if axis >= rank {
-            return vec![None; input_count];
+            return Ok(vec![None; input_count]);
         }
         let Some(concrete_shape) = input_shape
             .iter()
             .map(SymDim::constant_value)
             .collect::<Option<Vec<_>>>()
         else {
-            return vec![None; input_count];
+            return Ok(vec![None; input_count]);
         };
         concrete_shapes.push(concrete_shape);
     }
     if concrete_shapes.len() != input_count {
-        return vec![None; input_count];
+        return Ok(vec![None; input_count]);
     }
 
     for input_index in 0..input_count {
@@ -870,7 +872,7 @@ pub fn transpose_concatenate(
         let rank = input_shape.len();
         let axis_extent = input_shape[axis];
         let Some(next_axis_offset) = axis_offset.checked_add(axis_extent) else {
-            return vec![None; input_count];
+            return Ok(vec![None; input_count]);
         };
         if active_mask.get(input_index).copied().unwrap_or(false) {
             let starts = vec_with_axis(rank, axis, axis_offset, 0);
@@ -902,7 +904,7 @@ pub fn transpose_concatenate(
         axis_offset = next_axis_offset;
     }
 
-    result
+    Ok(result)
 }
 
 fn first_input_active(mode: &OperationRole) -> bool {

--- a/crates/tenferro-internal-ops/src/ad/support.rs
+++ b/crates/tenferro-internal-ops/src/ad/support.rs
@@ -1,6 +1,7 @@
 use computegraph::types::{LocalValueId, OperationRole, ValueRef};
 use tenferro_core_ops::PrimitiveOpKind;
 use tenferro_tensor::DType;
+use tidu::ADRuleResult;
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::PrimitiveRuleBuilder;
@@ -223,7 +224,7 @@ pub(crate) fn promote_dtype_div_like(lhs: DType, rhs: DType) -> DType {
 }
 
 pub(crate) fn dtype_of_or_real(ctx: &mut ShapeGuardContext, val: &ValueRef<StdTensorOp>) -> DType {
-    ctx.try_metadata_of(val)
+    ctx.metadata_if_available(val)
         .map(|metadata| metadata.dtype)
         .unwrap_or(DType::F64)
 }
@@ -233,9 +234,9 @@ pub fn conjugate_primal_if_complex(
     builder: &mut dyn PrimitiveRuleBuilder,
     input: ValueRef<StdTensorOp>,
     ctx: &mut ShapeGuardContext,
-) -> ValueRef<StdTensorOp> {
-    let dtype = ctx.dtype_of(&input);
-    conjugate_primal_if_dtype_complex(builder, input, dtype)
+) -> ADRuleResult<ValueRef<StdTensorOp>> {
+    let dtype = ctx.dtype_of(&input)?;
+    Ok(conjugate_primal_if_dtype_complex(builder, input, dtype))
 }
 
 #[doc(hidden)]

--- a/crates/tenferro-internal-ops/src/ad/tests/contraction_tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/contraction_tests.rs
@@ -31,7 +31,7 @@ fn dot_general_transpose_rejects_out_of_bounds_dims_without_panicking() {
     };
 
     let err = op
-        .try_linear_transpose_rule(
+        .transpose_rule(
             &mut builder,
             &[Some(cotangent)],
             &[ValueRef::External(lhs), ValueRef::External(rhs)],

--- a/crates/tenferro-internal-ops/src/ad/tests/elementwise_tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/elementwise_tests.rs
@@ -92,13 +92,15 @@ fn linearize_elementwise_inactive_inputs_return_none_without_ops() {
         StdTensorOp::Clamp,
     ] {
         let mut builder = GraphBuilder::<StdTensorOp>::new();
-        let result = op.jvp_rule(
-            &mut builder,
-            &keys,
-            &[input_key(4)],
-            &[None, None, None],
-            &mut ctx,
-        );
+        let result = op
+            .jvp_rule(
+                &mut builder,
+                &keys,
+                &[input_key(4)],
+                &[None, None, None],
+                &mut ctx,
+            )
+            .unwrap();
         assert_eq!(result, vec![None], "{op:?}");
         assert!(
             builder.build().operations().is_empty(),
@@ -115,13 +117,15 @@ fn linearize_div_with_two_active_inputs_sums_both_terms() {
     let mut ctx = ShapeGuardContext::default();
     let op = StdTensorOp::Div;
 
-    let result = op.jvp_rule(
-        &mut builder,
-        &[input_key(12), input_key(13)],
-        &[input_key(14)],
-        &[Some(dx), Some(dy)],
-        &mut ctx,
-    );
+    let result = op
+        .jvp_rule(
+            &mut builder,
+            &[input_key(12), input_key(13)],
+            &[input_key(14)],
+            &[Some(dx), Some(dy)],
+            &mut ctx,
+        )
+        .unwrap();
 
     assert!(result[0].is_some());
     let graph = builder.build();
@@ -137,13 +141,15 @@ fn linearize_extrema_uses_jax_balanced_tie_masks() {
 
     let mut max_builder = GraphBuilder::<StdTensorOp>::new();
     let dx = max_builder.add_input(tensor_input(20));
-    let result = StdTensorOp::Maximum.jvp_rule(
-        &mut max_builder,
-        &[input_key(21), input_key(22)],
-        &[],
-        &[Some(dx), None],
-        &mut ctx,
-    );
+    let result = StdTensorOp::Maximum
+        .jvp_rule(
+            &mut max_builder,
+            &[input_key(21), input_key(22)],
+            &[],
+            &[Some(dx), None],
+            &mut ctx,
+        )
+        .unwrap();
     assert!(result[0].is_some());
     let graph = max_builder.build();
     assert_eq!(graph.operations()[0].operation, StdTensorOp::Maximum);
@@ -170,13 +176,15 @@ fn linearize_extrema_uses_jax_balanced_tie_masks() {
 
     let mut min_builder = GraphBuilder::<StdTensorOp>::new();
     let dy = min_builder.add_input(tensor_input(23));
-    let result = StdTensorOp::Minimum.jvp_rule(
-        &mut min_builder,
-        &[input_key(24), input_key(25)],
-        &[],
-        &[None, Some(dy)],
-        &mut ctx,
-    );
+    let result = StdTensorOp::Minimum
+        .jvp_rule(
+            &mut min_builder,
+            &[input_key(24), input_key(25)],
+            &[],
+            &[None, Some(dy)],
+            &mut ctx,
+        )
+        .unwrap();
     assert!(result[0].is_some());
     let graph = min_builder.build();
     assert_eq!(graph.operations()[0].operation, StdTensorOp::Minimum);
@@ -210,13 +218,15 @@ fn linearize_clamp_builds_nested_selects_for_active_bounds() {
     let dupper = builder.add_input(tensor_input(32));
     let mut ctx = ShapeGuardContext::default();
 
-    let result = StdTensorOp::Clamp.jvp_rule(
-        &mut builder,
-        &[input_key(33), input_key(34), input_key(35)],
-        &[],
-        &[Some(dx), Some(dlower), Some(dupper)],
-        &mut ctx,
-    );
+    let result = StdTensorOp::Clamp
+        .jvp_rule(
+            &mut builder,
+            &[input_key(33), input_key(34), input_key(35)],
+            &[],
+            &[Some(dx), Some(dlower), Some(dupper)],
+            &mut ctx,
+        )
+        .unwrap();
 
     assert!(result[0].is_some());
     let graph = builder.build();
@@ -240,36 +250,42 @@ fn transpose_elementwise_handles_missing_or_inactive_cotangents() {
     ];
 
     assert_eq!(
-        StdTensorOp::Div.transpose_rule(
-            &mut builder,
-            &[None],
-            &inputs,
-            &OperationRole::Primary,
-            &mut ctx
-        ),
+        StdTensorOp::Div
+            .transpose_rule(
+                &mut builder,
+                &[None],
+                &inputs,
+                &OperationRole::Primary,
+                &mut ctx
+            )
+            .unwrap(),
         vec![None, None]
     );
     let abs_ct = builder.add_input(tensor_input(42));
     assert_eq!(
-        StdTensorOp::Abs.transpose_rule(
-            &mut builder,
-            &[Some(abs_ct)],
-            &[inputs[0].clone()],
-            &OperationRole::Primary,
-            &mut ctx,
-        ),
+        StdTensorOp::Abs
+            .transpose_rule(
+                &mut builder,
+                &[Some(abs_ct)],
+                &[inputs[0].clone()],
+                &OperationRole::Primary,
+                &mut ctx,
+            )
+            .unwrap(),
         vec![None]
     );
     assert_eq!(
-        StdTensorOp::Maximum.transpose_rule(
-            &mut builder,
-            &[None],
-            &inputs,
-            &OperationRole::Linearized {
-                active_mask: vec![true, true],
-            },
-            &mut ctx,
-        ),
+        StdTensorOp::Maximum
+            .transpose_rule(
+                &mut builder,
+                &[None],
+                &inputs,
+                &OperationRole::Linearized {
+                    active_mask: vec![true, true],
+                },
+                &mut ctx,
+            )
+            .unwrap(),
         vec![None, None]
     );
 }
@@ -285,15 +301,17 @@ fn transpose_select_splits_cotangent_only_to_active_value_inputs() {
         ValueRef::External(input_key(53)),
     ];
 
-    let result = StdTensorOp::Select.transpose_rule(
-        &mut builder,
-        &[Some(ct)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![false, true, false],
-        },
-        &mut ctx,
-    );
+    let result = StdTensorOp::Select
+        .transpose_rule(
+            &mut builder,
+            &[Some(ct)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![false, true, false],
+            },
+            &mut ctx,
+        )
+        .unwrap();
 
     assert_eq!(result[0], None);
     assert!(result[1].is_some());
@@ -316,29 +334,33 @@ fn transpose_clamp_covers_lower_only_and_inner_paths() {
 
     let mut lower_builder = GraphBuilder::<StdTensorOp>::new();
     let lower_ct = lower_builder.add_input(tensor_input(63));
-    let result = StdTensorOp::Clamp.transpose_rule(
-        &mut lower_builder,
-        &[Some(lower_ct)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![false, true, false],
-        },
-        &mut ctx,
-    );
+    let result = StdTensorOp::Clamp
+        .transpose_rule(
+            &mut lower_builder,
+            &[Some(lower_ct)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![false, true, false],
+            },
+            &mut ctx,
+        )
+        .unwrap();
     assert_eq!(result[0], None);
     assert!(result[1].is_some());
     assert_eq!(result[2], None);
 
     let mut full_builder = GraphBuilder::<StdTensorOp>::new();
     let full_ct = full_builder.add_input(tensor_input(64));
-    let result = StdTensorOp::Clamp.transpose_rule(
-        &mut full_builder,
-        &[Some(full_ct)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![true, true, true],
-        },
-        &mut ctx,
-    );
+    let result = StdTensorOp::Clamp
+        .transpose_rule(
+            &mut full_builder,
+            &[Some(full_ct)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![true, true, true],
+            },
+            &mut ctx,
+        )
+        .unwrap();
     assert!(result.iter().all(Option::is_some));
 }

--- a/crates/tenferro-internal-ops/src/ad/tests/indexing_tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/indexing_tests.rs
@@ -65,7 +65,9 @@ fn linearize_gather_reuses_primal_indices_and_emits_gather() {
     let primal_in = vec![operand_key.clone(), indices_key.clone()];
     let tangent_in = [Some(operand_tangent), None];
 
-    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op
+        .jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx)
+        .unwrap();
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("output tangent must be active");
@@ -97,7 +99,9 @@ fn linearize_gather_inactive_tangent_returns_none() {
     let primal_in = vec![operand_key, indices_key];
     let tangent_in: [Option<LocalValueId>; 2] = [None, None];
 
-    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op
+        .jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx)
+        .unwrap();
     assert_eq!(result, vec![None]);
     assert!(builder.build().operations().is_empty());
 }
@@ -128,7 +132,9 @@ fn linearize_dynamic_gather_reuses_primal_indices_and_shape_sources() {
     let primal_in = vec![operand_key, indices_key.clone(), shape_source_key.clone()];
     let tangent_in = [Some(operand_tangent), None, None];
 
-    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op
+        .jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx)
+        .unwrap();
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("output tangent must be active");
@@ -164,7 +170,9 @@ fn linearize_dynamic_slice_reuses_primal_starts() {
     let primal_in = vec![operand_key, starts_key.clone()];
     let tangent_in = [Some(operand_tangent), None];
 
-    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op
+        .jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx)
+        .unwrap();
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("output tangent must be active");
@@ -200,7 +208,9 @@ fn linearize_dynamic_slice_inactive_tangent_returns_none() {
     let primal_in = vec![operand_key, starts_key];
     let tangent_in: [Option<LocalValueId>; 2] = [None, None];
 
-    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op
+        .jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx)
+        .unwrap();
     assert_eq!(result, vec![None]);
     assert!(builder.build().operations().is_empty());
 }
@@ -219,7 +229,9 @@ fn linearize_dynamic_update_slice_reuses_primal_starts() {
     let primal_in = vec![operand_key, update_key, starts_key.clone()];
     let tangent_in = [Some(operand_tangent), Some(update_tangent), None];
 
-    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op
+        .jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx)
+        .unwrap();
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("output tangent must be active");
@@ -267,7 +279,8 @@ fn transpose_dynamic_slice_emits_dynamic_update_slice() {
             active_mask: vec![true, false],
         },
         &mut ctx,
-    );
+    )
+    .unwrap();
 
     assert!(result[0].is_some(), "operand cotangent must be active");
     assert_eq!(result[1], None, "starts cotangent must stay None");
@@ -312,15 +325,17 @@ fn transpose_dynamic_update_slice_returns_operand_and_update_cotangents() {
         ValueRef::External(update_key),
         ValueRef::External(starts_key.clone()),
     ];
-    let result = StdTensorOp::DynamicUpdateSlice.transpose_rule(
-        &mut builder,
-        &[Some(cot)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![true, true, false],
-        },
-        &mut ctx,
-    );
+    let result = StdTensorOp::DynamicUpdateSlice
+        .transpose_rule(
+            &mut builder,
+            &[Some(cot)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![true, true, false],
+            },
+            &mut ctx,
+        )
+        .unwrap();
 
     assert!(result[0].is_some(), "operand cotangent must be active");
     assert!(result[1].is_some(), "update cotangent must be active");
@@ -368,15 +383,17 @@ fn transpose_gather_emits_scatter_with_inverted_config() {
         ValueRef::External(indices_key.clone()),
     ];
 
-    let result = op.transpose_rule(
-        &mut builder,
-        &[Some(cot)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![true, false],
-        },
-        &mut ctx,
-    );
+    let result = op
+        .transpose_rule(
+            &mut builder,
+            &[Some(cot)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![true, false],
+            },
+            &mut ctx,
+        )
+        .unwrap();
     assert!(result[0].is_some(), "operand cotangent must be active");
     assert_eq!(result[1], None, "indices cotangent must stay None");
 
@@ -431,15 +448,17 @@ fn transpose_gather_inactive_path_returns_all_none() {
 
     let op = StdTensorOp::Gather(rank1_gather_config());
 
-    let result = op.transpose_rule(
-        &mut builder,
-        &[None],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![true, false],
-        },
-        &mut ctx,
-    );
+    let result = op
+        .transpose_rule(
+            &mut builder,
+            &[None],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![true, false],
+            },
+            &mut ctx,
+        )
+        .unwrap();
     assert_eq!(result, vec![None, None]);
     assert!(builder.build().operations().is_empty());
 }
@@ -480,15 +499,17 @@ fn transpose_dynamic_gather_emits_scatter_and_ignores_shape_sources() {
         ValueRef::External(shape_source_key),
     ];
 
-    let result = op.transpose_rule(
-        &mut builder,
-        &[Some(cot)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![true, false, false],
-        },
-        &mut ctx,
-    );
+    let result = op
+        .transpose_rule(
+            &mut builder,
+            &[Some(cot)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![true, false, false],
+            },
+            &mut ctx,
+        )
+        .unwrap();
 
     assert!(result[0].is_some(), "operand cotangent must be active");
     assert_eq!(result[1], None, "indices cotangent must stay None");
@@ -541,15 +562,17 @@ fn transpose_scatter_returns_none_for_mismatched_update_window_dims() {
         ValueRef::External(updates_key),
     ];
 
-    let result = op.transpose_rule(
-        &mut builder,
-        &[Some(cot)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![false, false, true],
-        },
-        &mut ctx,
-    );
+    let result = op
+        .transpose_rule(
+            &mut builder,
+            &[Some(cot)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![false, false, true],
+            },
+            &mut ctx,
+        )
+        .unwrap();
 
     assert_eq!(result, vec![None, None, None]);
     assert!(builder.build().operations().is_empty());

--- a/crates/tenferro-internal-ops/src/ad/tests/indexing_tests/scatter.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/indexing_tests/scatter.rs
@@ -11,7 +11,9 @@ fn linearize_scatter_inactive_tangents_returns_none() {
     let op = StdTensorOp::Scatter(rank1_scatter_config());
     let primal_in = vec![operand_key, indices_key, updates_key];
     let tangent_in: [Option<LocalValueId>; 3] = [None, None, None];
-    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op
+        .jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx)
+        .unwrap();
     assert_eq!(result, vec![None]);
     assert!(builder.build().operations().is_empty());
 }
@@ -40,7 +42,9 @@ fn linearize_scatter_operand_only_is_identity_passthrough() {
     let primal_in = vec![operand_key, indices_key, updates_key];
     let tangent_in = [Some(operand_tangent), None, None];
 
-    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op
+        .jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx)
+        .unwrap();
     assert_eq!(
         result,
         vec![Some(operand_tangent)],
@@ -81,7 +85,9 @@ fn linearize_scatter_updates_only_uses_zero_operand() {
     ];
     let tangent_in = [None, None, Some(updates_tangent)];
 
-    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op
+        .jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx)
+        .unwrap();
     assert_eq!(result.len(), 1);
     let _ = result[0].expect("output tangent must be active");
 
@@ -152,7 +158,9 @@ fn linearize_scatter_both_tangents_emit_single_scatter() {
     let primal_in = vec![operand_key, indices_key.clone(), updates_key];
     let tangent_in = [Some(operand_tangent), None, Some(updates_tangent)];
 
-    let result = op.jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx);
+    let result = op
+        .jvp_rule(&mut builder, &primal_in, &[], &tangent_in, &mut ctx)
+        .unwrap();
     assert_eq!(result.len(), 1);
     let _ = result[0].expect("output tangent must be active");
 
@@ -200,15 +208,17 @@ fn transpose_scatter_emits_identity_for_operand_and_gather_for_updates() {
         ValueRef::External(updates_key),
     ];
 
-    let result = op.transpose_rule(
-        &mut builder,
-        &[Some(cot)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![true, false, true],
-        },
-        &mut ctx,
-    );
+    let result = op
+        .transpose_rule(
+            &mut builder,
+            &[Some(cot)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![true, false, true],
+            },
+            &mut ctx,
+        )
+        .unwrap();
     assert_eq!(
         result[0],
         Some(cot),
@@ -270,15 +280,17 @@ fn transpose_scatter_updates_only_emits_only_gather() {
         ValueRef::External(updates_key),
     ];
 
-    let result = op.transpose_rule(
-        &mut builder,
-        &[Some(cot)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![false, false, true],
-        },
-        &mut ctx,
-    );
+    let result = op
+        .transpose_rule(
+            &mut builder,
+            &[Some(cot)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![false, false, true],
+            },
+            &mut ctx,
+        )
+        .unwrap();
     assert_eq!(
         result[0], None,
         "operand cotangent is None when operand is inactive"
@@ -323,15 +335,17 @@ fn transpose_scatter_operand_only_is_identity_and_no_ops() {
         ValueRef::External(updates_key),
     ];
 
-    let result = op.transpose_rule(
-        &mut builder,
-        &[Some(cot)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![true, false, false],
-        },
-        &mut ctx,
-    );
+    let result = op
+        .transpose_rule(
+            &mut builder,
+            &[Some(cot)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![true, false, false],
+            },
+            &mut ctx,
+        )
+        .unwrap();
     assert_eq!(
         result,
         vec![Some(cot), None, None],
@@ -363,15 +377,17 @@ fn transpose_scatter_inactive_updates_returns_all_none() {
     ];
 
     let op = StdTensorOp::Scatter(rank1_scatter_config());
-    let result = op.transpose_rule(
-        &mut builder,
-        &[Some(cot)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![false, false, false],
-        },
-        &mut ctx,
-    );
+    let result = op
+        .transpose_rule(
+            &mut builder,
+            &[Some(cot)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![false, false, false],
+            },
+            &mut ctx,
+        )
+        .unwrap();
     assert_eq!(result, vec![None, None, None]);
     assert!(builder.build().operations().is_empty());
 }
@@ -409,15 +425,17 @@ fn transpose_scatter_window_dims_derive_slice_sizes_from_updates_shape() {
         ValueRef::External(updates_key),
     ];
 
-    let result = op.transpose_rule(
-        &mut builder,
-        &[Some(cot)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![false, false, true],
-        },
-        &mut ctx,
-    );
+    let result = op
+        .transpose_rule(
+            &mut builder,
+            &[Some(cot)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![false, false, true],
+            },
+            &mut ctx,
+        )
+        .unwrap();
     assert!(result[2].is_some());
 
     let graph = builder.build();
@@ -472,15 +490,17 @@ fn transpose_scatter_symbolic_window_dim_emits_dynamic_gather() {
         ValueRef::External(indices_key),
         ValueRef::External(updates_key.clone()),
     ];
-    let result = op.transpose_rule(
-        &mut builder,
-        &[Some(cot)],
-        &inputs,
-        &OperationRole::Linearized {
-            active_mask: vec![false, false, true],
-        },
-        &mut ctx,
-    );
+    let result = op
+        .transpose_rule(
+            &mut builder,
+            &[Some(cot)],
+            &inputs,
+            &OperationRole::Linearized {
+                active_mask: vec![false, false, true],
+            },
+            &mut ctx,
+        )
+        .unwrap();
 
     assert!(result[2].is_some());
     let graph = builder.build();

--- a/crates/tenferro-internal-ops/src/ad/tests/mod.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/mod.rs
@@ -36,19 +36,19 @@ fn meta(dtype: DType, shape: &[usize]) -> TensorMeta {
 
 #[test]
 fn resolve_dim_const() {
-    assert_eq!(resolve_dim(&DimExpr::Const(7)), 7);
+    assert_eq!(resolve_dim(&DimExpr::Const(7)).unwrap(), 7);
 }
 
 #[test]
 fn resolve_dim_const_expr() {
     let expr = DimExpr::min(DimExpr::Const(3), DimExpr::Const(5));
-    assert_eq!(resolve_dim(&expr), 3);
+    assert_eq!(resolve_dim(&expr).unwrap(), 3);
 }
 
 #[test]
 fn resolve_and_guard_records_greater() {
     let mut ctx = ShapeGuardContext::default();
-    let (m, n) = resolve_and_guard(&DimExpr::Const(5), &DimExpr::Const(3), &mut ctx);
+    let (m, n) = resolve_and_guard(&DimExpr::Const(5), &DimExpr::Const(3), &mut ctx).unwrap();
     assert_eq!((m, n), (5, 3));
     assert_eq!(
         ctx.guards(),
@@ -63,7 +63,7 @@ fn resolve_and_guard_records_greater() {
 #[test]
 fn resolve_and_guard_records_less() {
     let mut ctx = ShapeGuardContext::default();
-    let (m, n) = resolve_and_guard(&DimExpr::Const(2), &DimExpr::Const(4), &mut ctx);
+    let (m, n) = resolve_and_guard(&DimExpr::Const(2), &DimExpr::Const(4), &mut ctx).unwrap();
     assert_eq!((m, n), (2, 4));
     assert_eq!(ctx.guards()[0].ordering, Ordering::Less);
 }
@@ -71,7 +71,7 @@ fn resolve_and_guard_records_less() {
 #[test]
 fn resolve_and_guard_records_equal() {
     let mut ctx = ShapeGuardContext::default();
-    let (m, n) = resolve_and_guard(&DimExpr::Const(3), &DimExpr::Const(3), &mut ctx);
+    let (m, n) = resolve_and_guard(&DimExpr::Const(3), &DimExpr::Const(3), &mut ctx).unwrap();
     assert_eq!((m, n), (3, 3));
     assert_eq!(ctx.guards()[0].ordering, Ordering::Equal);
 }
@@ -79,8 +79,8 @@ fn resolve_and_guard_records_equal() {
 #[test]
 fn guards_accumulate() {
     let mut ctx = ShapeGuardContext::default();
-    resolve_and_guard(&DimExpr::Const(5), &DimExpr::Const(3), &mut ctx);
-    resolve_and_guard(&DimExpr::Const(2), &DimExpr::Const(4), &mut ctx);
+    resolve_and_guard(&DimExpr::Const(5), &DimExpr::Const(3), &mut ctx).unwrap();
+    resolve_and_guard(&DimExpr::Const(2), &DimExpr::Const(4), &mut ctx).unwrap();
     assert_eq!(ctx.guards().len(), 2);
     assert_eq!(ctx.guards()[0].ordering, Ordering::Greater);
     assert_eq!(ctx.guards()[1].ordering, Ordering::Less);
@@ -89,7 +89,7 @@ fn guards_accumulate() {
 #[test]
 fn clear_guards_empties() {
     let mut ctx = ShapeGuardContext::default();
-    resolve_and_guard(&DimExpr::Const(5), &DimExpr::Const(3), &mut ctx);
+    resolve_and_guard(&DimExpr::Const(5), &DimExpr::Const(3), &mut ctx).unwrap();
     ctx.clear_guards();
     assert!(ctx.guards().is_empty());
 }
@@ -101,9 +101,9 @@ fn shape_and_dtype_queries_work_for_concrete_input_values() {
     ctx.insert_metadata(key.clone(), meta(DType::F64, &[2, 3]));
 
     let val = ValueRef::External(key);
-    assert_eq!(ctx.dtype_of(&val), DType::F64);
+    assert_eq!(ctx.dtype_of(&val).unwrap(), DType::F64);
     assert_eq!(
-        ctx.shape_of(&val),
+        ctx.shape_of(&val).unwrap(),
         &[SymDim::from(2usize), SymDim::from(3usize)]
     );
 }
@@ -133,7 +133,7 @@ fn shape_queries_work_for_symbolic_input_values() {
     );
 
     assert_eq!(
-        ctx.shape_of(&ValueRef::External(key)),
+        ctx.shape_of(&ValueRef::External(key)).unwrap(),
         symbolic_shape.as_slice()
     );
 }
@@ -146,28 +146,32 @@ fn metadata_exposes_exact_extents() {
     ctx.insert_metadata(key.clone(), meta.clone());
 
     let val = ValueRef::External(key);
-    assert_eq!(ctx.extents_of(&val), meta.extents());
-    assert_eq!(ctx.exact_shape_of(&val), Some(meta.shape.clone()));
+    assert_eq!(ctx.extents_of(&val).unwrap(), meta.extents());
+    assert_eq!(ctx.exact_shape_of(&val).unwrap(), meta.exact_shape());
 }
 
 #[test]
 fn metadata_exact_shape_rejects_upper_bound() {
     let key = input_key(701);
     let mut ctx = ShapeGuardContext::default();
-    let meta = TensorMeta {
-        dtype: DType::F64,
-        shape: vec![SymDim::from(4usize)],
-        extents: vec![ShapeExtent::upper_bound(SymDim::from(4usize))],
-    };
+    let meta = TensorMeta::with_extents(
+        DType::F64,
+        vec![ShapeExtent::upper_bound(SymDim::from(4usize))],
+    );
     ctx.insert_metadata(key.clone(), meta);
 
-    assert_eq!(ctx.exact_shape_of(&ValueRef::External(key)), None);
+    let value = ValueRef::External(key);
+    assert_eq!(ctx.exact_shape_of(&value).unwrap(), None);
+    assert!(matches!(
+        ctx.shape_of(&value),
+        Err(crate::ad::context::ShapeGuardError::NonExactShape { .. })
+    ));
 }
 
 #[test]
-fn try_metadata_of_returns_none_for_unattached_or_bad_local_values() {
+fn metadata_if_available_returns_none_for_unattached_or_bad_local_values() {
     let mut ctx = ShapeGuardContext::default();
-    assert!(ctx.try_metadata_of(&ValueRef::Local(0)).is_none());
+    assert!(ctx.metadata_if_available(&ValueRef::Local(0)).is_none());
 
     let mut builder = GraphBuilder::<StdTensorOp>::new();
     let input = builder.add_input(tensor_input(710));
@@ -175,7 +179,9 @@ fn try_metadata_of_returns_none_for_unattached_or_bad_local_values() {
     let graph = builder.build();
     ctx.attach_graph(&graph);
 
-    assert!(ctx.try_metadata_of(&ValueRef::Local(usize::MAX)).is_none());
+    assert!(ctx
+        .metadata_if_available(&ValueRef::Local(usize::MAX))
+        .is_none());
 }
 
 #[test]
@@ -198,9 +204,9 @@ fn metadata_queries_resolve_local_values_through_attached_graph() {
     ctx.insert_metadata(graph.values()[sum].key.clone(), meta(DType::F64, &[2, 3]));
 
     let local_sum = ValueRef::Local(sum);
-    assert_eq!(ctx.dtype_of(&local_sum), DType::F64);
+    assert_eq!(ctx.dtype_of(&local_sum).unwrap(), DType::F64);
     assert_eq!(
-        ctx.shape_of(&local_sum),
+        ctx.shape_of(&local_sum).unwrap(),
         &[SymDim::from(2usize), SymDim::from(3usize)]
     );
 }
@@ -279,10 +285,10 @@ fn representative_graph_values_all_have_queryable_tensor_metadata() {
 
     for local_id in 0..graph.values().len() {
         let value = ValueRef::Local(local_id);
-        let metadata = ctx.metadata_of(&value);
+        let metadata = ctx.metadata_of(&value).unwrap();
         assert_eq!(metadata.dtype, DType::F64);
         assert!(
-            !metadata.shape.is_empty() || local_id == reduce,
+            metadata.rank() > 0 || local_id == reduce,
             "missing shape metadata for local value {local_id}"
         );
     }

--- a/crates/tenferro-internal-ops/src/ad/tests/structural_tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/structural_tests.rs
@@ -48,13 +48,15 @@ fn linearize_reshape_reuses_dynamic_shape_sources_as_inactive_inputs() {
         ],
     };
 
-    let result = op.jvp_rule(
-        &mut builder,
-        &[data_key, shape_key.clone()],
-        &[],
-        &[Some(data_tangent), None],
-        &mut ctx,
-    );
+    let result = op
+        .jvp_rule(
+            &mut builder,
+            &[data_key, shape_key.clone()],
+            &[],
+            &[Some(data_tangent), None],
+            &mut ctx,
+        )
+        .unwrap();
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("reshape tangent output must be active");
@@ -102,7 +104,8 @@ fn transpose_reshape_returns_none_for_dynamic_shape_sources() {
         &inputs,
         &linear_mode(&[true, false]),
         &mut ctx,
-    );
+    )
+    .unwrap();
 
     assert_eq!(result.len(), 2);
     assert!(result[0].is_some());
@@ -145,13 +148,15 @@ fn linearize_broadcast_reuses_dynamic_shape_sources_as_inactive_inputs() {
         dims: vec![1],
     };
 
-    let result = op.jvp_rule(
-        &mut builder,
-        &[data_key, shape_key.clone()],
-        &[],
-        &[Some(data_tangent), None],
-        &mut ctx,
-    );
+    let result = op
+        .jvp_rule(
+            &mut builder,
+            &[data_key, shape_key.clone()],
+            &[],
+            &[Some(data_tangent), None],
+            &mut ctx,
+        )
+        .unwrap();
 
     assert_eq!(result.len(), 1);
     let tangent_out = result[0].expect("broadcast tangent output must be active");
@@ -195,7 +200,8 @@ fn transpose_broadcast_returns_none_for_dynamic_shape_sources() {
         &inputs,
         &linear_mode(&[true, false]),
         &mut ctx,
-    );
+    )
+    .unwrap();
 
     assert_eq!(result.len(), 2);
     assert!(result[0].is_some());
@@ -221,7 +227,8 @@ fn transpose_broadcast_reduces_singleton_input_axes() {
         &inputs,
         &linear_mode(&[true]),
         &mut ctx,
-    );
+    )
+    .unwrap();
 
     assert_eq!(result.len(), 1);
     let cotangent_in = result[0].expect("broadcast cotangent input must be active");
@@ -270,7 +277,8 @@ fn transpose_broadcast_restores_non_monotonic_dimension_order() {
         &inputs,
         &linear_mode(&[true]),
         &mut ctx,
-    );
+    )
+    .unwrap();
 
     assert_eq!(result.len(), 1);
     let cotangent_in = result[0].expect("broadcast cotangent input must be active");
@@ -310,7 +318,8 @@ fn transpose_concatenate_returns_none_for_symbolic_concat_axis() {
         &inputs,
         &linear_mode(&[true]),
         &mut ctx,
-    );
+    )
+    .unwrap();
 
     assert_eq!(result, vec![None]);
     assert!(builder.build().operations().is_empty());

--- a/crates/tenferro-internal-ops/src/dim_expr.rs
+++ b/crates/tenferro-internal-ops/src/dim_expr.rs
@@ -19,7 +19,7 @@
 ///         axis: 1,
 ///     },
 /// );
-/// assert_eq!(expr.eval(&[&[3, 4]]), 12);
+/// assert_eq!(expr.eval(&[&[3, 4]]).unwrap(), 12);
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum DimExpr {
@@ -76,13 +76,6 @@ pub enum DimExprEvalError {
 impl DimExpr {
     /// Evaluate the expression using actual input tensor shapes.
     ///
-    /// # Panics
-    ///
-    /// Panics if an `InputDim` node references an `input_idx` that is
-    /// out of bounds for `input_shapes`, an `axis` that is out of bounds
-    /// for the corresponding shape slice, a subtraction would underflow,
-    /// or a floor-division divisor evaluates to zero.
-    ///
     /// # Examples
     ///
     /// ```rust
@@ -95,19 +88,9 @@ impl DimExpr {
     ///     },
     ///     DimExpr::Const(2),
     /// );
-    /// assert_eq!(expr.eval(&[&[5, 7]]), 7);
+    /// assert_eq!(expr.eval(&[&[5, 7]]).unwrap(), 7);
     /// ```
-    pub fn eval(&self, input_shapes: &[&[usize]]) -> usize {
-        self.try_eval(input_shapes)
-            .unwrap_or_else(|err| panic!("{err}"))
-    }
-
-    /// Fallibly evaluate the expression using actual input tensor shapes.
-    ///
-    /// This is the runtime-facing API. Use it when malformed symbolic shapes
-    /// are possible user input; [`Self::eval`] is retained as the compatibility
-    /// panic wrapper.
-    pub fn try_eval(&self, input_shapes: &[&[usize]]) -> Result<usize, DimExprEvalError> {
+    pub fn eval(&self, input_shapes: &[&[usize]]) -> Result<usize, DimExprEvalError> {
         match self {
             Self::Const(v) => Ok(*v),
             Self::InputDim { input_idx, axis } => input_shapes
@@ -127,33 +110,33 @@ impl DimExpr {
                         })
                 }),
             Self::Add(a, b) => {
-                let lhs = a.try_eval(input_shapes)?;
-                let rhs = b.try_eval(input_shapes)?;
+                let lhs = a.eval(input_shapes)?;
+                let rhs = b.eval(input_shapes)?;
                 lhs.checked_add(rhs)
                     .ok_or(DimExprEvalError::AddOverflow { lhs, rhs })
             }
             Self::Sub(a, b) => {
-                let lhs = a.try_eval(input_shapes)?;
-                let rhs = b.try_eval(input_shapes)?;
+                let lhs = a.eval(input_shapes)?;
+                let rhs = b.eval(input_shapes)?;
                 lhs.checked_sub(rhs)
                     .ok_or(DimExprEvalError::SubUnderflow { lhs, rhs })
             }
             Self::Mul(a, b) => {
-                let lhs = a.try_eval(input_shapes)?;
-                let rhs = b.try_eval(input_shapes)?;
+                let lhs = a.eval(input_shapes)?;
+                let rhs = b.eval(input_shapes)?;
                 lhs.checked_mul(rhs)
                     .ok_or(DimExprEvalError::MulOverflow { lhs, rhs })
             }
             Self::FloorDiv(a, b) => {
-                let lhs = a.try_eval(input_shapes)?;
-                let rhs = b.try_eval(input_shapes)?;
+                let lhs = a.eval(input_shapes)?;
+                let rhs = b.eval(input_shapes)?;
                 if rhs == 0 {
                     return Err(DimExprEvalError::FloorDivByZero { lhs, rhs });
                 }
                 Ok(lhs / rhs)
             }
-            Self::Min(a, b) => Ok(a.try_eval(input_shapes)?.min(b.try_eval(input_shapes)?)),
-            Self::Max(a, b) => Ok(a.try_eval(input_shapes)?.max(b.try_eval(input_shapes)?)),
+            Self::Min(a, b) => Ok(a.eval(input_shapes)?.min(b.eval(input_shapes)?)),
+            Self::Max(a, b) => Ok(a.eval(input_shapes)?.max(b.eval(input_shapes)?)),
         }
     }
 
@@ -244,7 +227,7 @@ impl DimExpr {
     /// use tenferro_ops::dim_expr::DimExpr;
     ///
     /// let expr = DimExpr::add(DimExpr::Const(2), DimExpr::Const(3));
-    /// assert_eq!(expr.eval(&[]), 5);
+    /// assert_eq!(expr.eval(&[]).unwrap(), 5);
     /// ```
     // Public constructor names mirror the DimExpr variants; operator traits are a separate API choice.
     #[allow(clippy::should_implement_trait)]
@@ -260,7 +243,7 @@ impl DimExpr {
     /// use tenferro_ops::dim_expr::DimExpr;
     ///
     /// let expr = DimExpr::sub(DimExpr::Const(7), DimExpr::Const(2));
-    /// assert_eq!(expr.eval(&[]), 5);
+    /// assert_eq!(expr.eval(&[]).unwrap(), 5);
     /// ```
     // Public constructor names mirror the DimExpr variants; operator traits are a separate API choice.
     #[allow(clippy::should_implement_trait)]
@@ -276,7 +259,7 @@ impl DimExpr {
     /// use tenferro_ops::dim_expr::DimExpr;
     ///
     /// let expr = DimExpr::mul(DimExpr::Const(3), DimExpr::Const(4));
-    /// assert_eq!(expr.eval(&[]), 12);
+    /// assert_eq!(expr.eval(&[]).unwrap(), 12);
     /// ```
     // Public constructor names mirror the DimExpr variants; operator traits are a separate API choice.
     #[allow(clippy::should_implement_trait)]
@@ -292,7 +275,7 @@ impl DimExpr {
     /// use tenferro_ops::dim_expr::DimExpr;
     ///
     /// let expr = DimExpr::floor_div(DimExpr::Const(9), DimExpr::Const(2));
-    /// assert_eq!(expr.eval(&[]), 4);
+    /// assert_eq!(expr.eval(&[]).unwrap(), 4);
     /// ```
     pub fn floor_div(a: Self, b: Self) -> Self {
         Self::FloorDiv(Box::new(a), Box::new(b))
@@ -306,7 +289,7 @@ impl DimExpr {
     /// use tenferro_ops::dim_expr::DimExpr;
     ///
     /// let expr = DimExpr::min(DimExpr::Const(3), DimExpr::Const(5));
-    /// assert_eq!(expr.eval(&[]), 3);
+    /// assert_eq!(expr.eval(&[]).unwrap(), 3);
     /// ```
     pub fn min(a: Self, b: Self) -> Self {
         Self::Min(Box::new(a), Box::new(b))
@@ -320,7 +303,7 @@ impl DimExpr {
     /// use tenferro_ops::dim_expr::DimExpr;
     ///
     /// let expr = DimExpr::max(DimExpr::Const(3), DimExpr::Const(5));
-    /// assert_eq!(expr.eval(&[]), 5);
+    /// assert_eq!(expr.eval(&[]).unwrap(), 5);
     /// ```
     pub fn max(a: Self, b: Self) -> Self {
         Self::Max(Box::new(a), Box::new(b))
@@ -385,18 +368,13 @@ impl DimExpr {
     ///     DimExpr::InputDim { input_idx: 0, axis: 0 },
     ///     DimExpr::Const(4),
     /// ];
-    /// assert_eq!(DimExpr::eval_all(&exprs, &[&[3, 5]]), vec![3, 4]);
+    /// assert_eq!(DimExpr::eval_all(&exprs, &[&[3, 5]]).unwrap(), vec![3, 4]);
     /// ```
-    pub fn eval_all(exprs: &[Self], input_shapes: &[&[usize]]) -> Vec<usize> {
-        exprs.iter().map(|e| e.eval(input_shapes)).collect()
-    }
-
-    /// Fallibly evaluate a slice of expressions against actual input shapes.
-    pub fn try_eval_all(
+    pub fn eval_all(
         exprs: &[Self],
         input_shapes: &[&[usize]],
     ) -> Result<Vec<usize>, DimExprEvalError> {
-        exprs.iter().map(|e| e.try_eval(input_shapes)).collect()
+        exprs.iter().map(|e| e.eval(input_shapes)).collect()
     }
 
     /// Remap all `InputDim` references in a slice of expressions.

--- a/crates/tenferro-internal-ops/src/ext_op.rs
+++ b/crates/tenferro-internal-ops/src/ext_op.rs
@@ -12,10 +12,9 @@
 //!   type-erased `Arc<dyn ExtensionOp>` carrier can satisfy
 //!   `Clone + Hash + Eq + Send + Sync + 'static` (computegraph's
 //!   `GraphOperation` requirements).
-//! - AD rules are registered separately through [`ExtensionAdRule`] and
-//!   [`register_extension_rule`]. A rule may emit core [`StdTensorOp`] values
-//!   and registered `Extension` values so out-of-tree operations remain in the
-//!   same graph.
+//! - AD rules are owned by explicit [`ExtensionRuleSet`] values. A rule may
+//!   emit core [`StdTensorOp`] values and registered `Extension` values so
+//!   out-of-tree operations remain in the same graph.
 //! - Extension ops themselves do not require process-global registration.
 //!   Frontends carry them directly as `Arc<dyn ExtensionOp>`.
 
@@ -41,8 +40,6 @@ use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
 #[cfg(feature = "autodiff")]
 use std::collections::HashMap;
-#[cfg(feature = "autodiff")]
-use std::sync::{OnceLock, RwLock};
 
 /// Error returned when an extension cannot expand itself into standard ops.
 ///
@@ -292,9 +289,6 @@ pub enum ExtensionRegistryError {
     /// `"<crate-name>.<op-name>.v<major>"`.
     #[error("family_id {family_id:?} does not match the namespaced format")]
     MalformedFamilyId { family_id: &'static str },
-    /// The global AD rule registry lock was poisoned by another thread.
-    #[error("extension rule registry lock poisoned")]
-    PoisonedRegistry,
 }
 
 #[cfg(feature = "autodiff")]
@@ -302,9 +296,9 @@ type RuleMap = HashMap<&'static str, Arc<dyn ExtensionAdRule>>;
 
 /// Explicit, owned set of extension AD rules.
 ///
-/// This is the non-global rule container used by higher-level AD contexts.
-/// The process-global registry remains available as a compatibility bridge for
-/// callers that use [`register_extension_rule`].
+/// This is the rule container used by higher-level AD contexts. Extension AD
+/// intentionally has no process-global fallback; callers must pass the rule set
+/// that their graph needs.
 #[cfg(feature = "autodiff")]
 #[derive(Clone, Default)]
 pub struct ExtensionRuleSet {
@@ -501,12 +495,6 @@ impl ExtensionRuleSet {
 }
 
 #[cfg(feature = "autodiff")]
-fn rule_registry() -> &'static RwLock<RuleMap> {
-    static REG: OnceLock<RwLock<RuleMap>> = OnceLock::new();
-    REG.get_or_init(|| RwLock::new(HashMap::new()))
-}
-
-#[cfg(feature = "autodiff")]
 fn is_valid_family_id(family_id: &str) -> bool {
     // Required shape: `<crate>.<op>.v<major>` with at least one non-empty
     // `<crate>` chunk, at least one non-empty `<op>` chunk (which may itself
@@ -564,31 +552,6 @@ fn validate_rule_insert(
     Ok(())
 }
 
-/// Register a new extension AD rule.
-///
-/// The rule's `family_id` MUST follow the reserved format
-/// `"<crate-name>.<op-name>.v<major>"`. Registering a rule does not require
-/// registering the primal op first; frontends carry the op payload directly.
-#[cfg(feature = "autodiff")]
-pub fn register_extension_rule(
-    rule: Arc<dyn ExtensionAdRule>,
-) -> Result<(), ExtensionRegistryError> {
-    let family_id = rule.family_id();
-    if !is_valid_family_id(family_id) {
-        return Err(ExtensionRegistryError::MalformedFamilyId { family_id });
-    }
-    let mut guard = rule_registry()
-        .write()
-        .map_err(|_| ExtensionRegistryError::PoisonedRegistry)?;
-    insert_rule(&mut guard, rule)
-}
-
-/// Look up an extension AD rule by `family_id`.
-#[cfg(feature = "autodiff")]
-pub fn lookup_extension_rule(family_id: &str) -> Option<Arc<dyn ExtensionAdRule>> {
-    rule_registry().read().ok()?.get(family_id).cloned()
-}
-
 /// Emit a registered extension linearization rule.
 #[cfg(feature = "autodiff")]
 pub fn linearize_extension_rule(
@@ -599,7 +562,7 @@ pub fn linearize_extension_rule(
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    match ctx.lookup_extension_rule(op.family_id()) {
+    match ctx.extension_rule_for(op.family_id()) {
         Some(rule) => rule.linearize(op, builder, primal_in, primal_out, tangent_in, ctx),
         None => Err(ADRuleError::unsupported(op.family_id(), ADRuleKind::Jvp)),
     }
@@ -615,19 +578,13 @@ pub fn transpose_extension_rule(
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    match ctx.lookup_extension_rule(op.family_id()) {
+    match ctx.extension_rule_for(op.family_id()) {
         Some(rule) => rule.transpose_rule(op, builder, cotangent_out, inputs, mode, ctx),
         None => Err(ADRuleError::unsupported(
             op.family_id(),
             ADRuleKind::Transpose,
         )),
     }
-}
-
-/// Returns `true` when an AD rule with `family_id` is currently registered.
-#[cfg(feature = "autodiff")]
-pub fn is_extension_rule_registered(family_id: &str) -> bool {
-    lookup_extension_rule(family_id).is_some()
 }
 
 /// Thin adapter that lets a generic `H: Hasher` satisfy the object-safe

--- a/crates/tenferro-internal-ops/src/lib.rs
+++ b/crates/tenferro-internal-ops/src/lib.rs
@@ -33,8 +33,7 @@ pub use ad::context::{ShapeGuard, ShapeGuardContext, TensorMeta};
 pub use ext_op::ExtensionOp;
 #[cfg(feature = "autodiff")]
 pub use ext_op::{
-    is_extension_rule_registered, linearize_extension_rule, lookup_extension_rule,
-    register_extension_rule, transpose_extension_rule, ExtensionAdRule, ExtensionOp,
+    linearize_extension_rule, transpose_extension_rule, ExtensionAdRule, ExtensionOp,
     ExtensionRegistryError, ExtensionRuleSet,
 };
 pub use shape_extent::ShapeExtent;

--- a/crates/tenferro-internal-ops/src/std_tensor_op.rs
+++ b/crates/tenferro-internal-ops/src/std_tensor_op.rs
@@ -469,19 +469,8 @@ impl Primitive for StdTensorOp {
         primal_out: &[ValueKey<Self>],
         tangent_in: &[Option<LocalValueId>],
         ctx: &mut Self::ADContext,
-    ) -> Vec<Option<LocalValueId>> {
-        crate::ad::linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
-    }
-
-    fn try_jvp_rule(
-        &self,
-        builder: &mut impl PrimitiveBuilder<Self>,
-        primal_in: &[ValueKey<Self>],
-        primal_out: &[ValueKey<Self>],
-        tangent_in: &[Option<LocalValueId>],
-        ctx: &mut Self::ADContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        crate::ad::try_linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
+        crate::ad::linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
     }
 
     fn transpose_rule(
@@ -491,21 +480,9 @@ impl Primitive for StdTensorOp {
         inputs: &[PrimitiveValue<Self>],
         mode: &OperationRole,
         ctx: &mut Self::ADContext,
-    ) -> Vec<Option<LocalValueId>> {
-        let inputs = inputs.iter().cloned().map(Into::into).collect::<Vec<_>>();
-        crate::ad::transpose_rule(self, builder, cotangent_out, &inputs, mode, ctx)
-    }
-
-    fn try_linear_transpose_rule(
-        &self,
-        builder: &mut impl PrimitiveBuilder<Self>,
-        cotangent_out: &[Option<LocalValueId>],
-        inputs: &[PrimitiveValue<Self>],
-        mode: &OperationRole,
-        ctx: &mut Self::ADContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let inputs = inputs.iter().cloned().map(Into::into).collect::<Vec<_>>();
-        crate::ad::try_transpose_rule(self, builder, cotangent_out, &inputs, mode, ctx)
+        crate::ad::transpose_rule(self, builder, cotangent_out, &inputs, mode, ctx)
     }
 }
 
@@ -518,19 +495,8 @@ impl StdTensorOp {
         primal_out: &[ValueKey<Self>],
         tangent_in: &[Option<LocalValueId>],
         ctx: &mut crate::ad::context::ShapeGuardContext,
-    ) -> Vec<Option<LocalValueId>> {
-        crate::ad::linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
-    }
-
-    pub(crate) fn try_jvp_rule(
-        &self,
-        builder: &mut computegraph::graph::GraphBuilder<Self>,
-        primal_in: &[ValueKey<Self>],
-        primal_out: &[ValueKey<Self>],
-        tangent_in: &[Option<LocalValueId>],
-        ctx: &mut crate::ad::context::ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        crate::ad::try_linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
+        crate::ad::linearize(self, builder, primal_in, primal_out, tangent_in, ctx)
     }
 
     pub(crate) fn transpose_rule(
@@ -540,18 +506,7 @@ impl StdTensorOp {
         inputs: &[computegraph::ValueRef<Self>],
         mode: &OperationRole,
         ctx: &mut crate::ad::context::ShapeGuardContext,
-    ) -> Vec<Option<LocalValueId>> {
-        crate::ad::transpose_rule(self, builder, cotangent_out, inputs, mode, ctx)
-    }
-
-    pub(crate) fn try_linear_transpose_rule(
-        &self,
-        builder: &mut impl crate::ad::PrimitiveRuleBuilder,
-        cotangent_out: &[Option<LocalValueId>],
-        inputs: &[computegraph::ValueRef<Self>],
-        mode: &OperationRole,
-        ctx: &mut crate::ad::context::ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        crate::ad::try_transpose_rule(self, builder, cotangent_out, inputs, mode, ctx)
+        crate::ad::transpose_rule(self, builder, cotangent_out, inputs, mode, ctx)
     }
 }

--- a/crates/tenferro-internal-ops/src/tests/dim_expr_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/dim_expr_tests.rs
@@ -4,7 +4,7 @@ use crate::dim_expr::{DimExpr, DimExprEvalError};
 
 #[test]
 fn test_const_eval() {
-    assert_eq!(DimExpr::Const(42).eval(&[]), 42);
+    assert_eq!(DimExpr::Const(42).eval(&[]).unwrap(), 42);
 }
 
 #[test]
@@ -13,7 +13,7 @@ fn test_input_dim_eval() {
         input_idx: 0,
         axis: 1,
     };
-    assert_eq!(e.eval(&[&[3, 7, 5]]), 7);
+    assert_eq!(e.eval(&[&[3, 7, 5]]).unwrap(), 7);
 }
 
 #[test]
@@ -29,19 +29,29 @@ fn test_arithmetic() {
             axis: 1,
         },
     );
-    assert_eq!(e.eval(shapes), 12);
-    assert_eq!(DimExpr::add(e.clone(), DimExpr::Const(3)).eval(shapes), 15);
-    assert_eq!(DimExpr::floor_div(e, DimExpr::Const(4)).eval(shapes), 3);
+    assert_eq!(e.eval(shapes).unwrap(), 12);
+    assert_eq!(
+        DimExpr::add(e.clone(), DimExpr::Const(3))
+            .eval(shapes)
+            .unwrap(),
+        15
+    );
+    assert_eq!(
+        DimExpr::floor_div(e, DimExpr::Const(4))
+            .eval(shapes)
+            .unwrap(),
+        3
+    );
 }
 
 #[test]
-fn try_eval_reports_bad_input_refs_and_arithmetic_errors() {
+fn eval_reports_bad_input_refs_and_arithmetic_errors() {
     let input = DimExpr::InputDim {
         input_idx: 0,
         axis: 1,
     };
     assert!(matches!(
-        input.try_eval(&[&[3]]),
+        input.eval(&[&[3]]),
         Err(DimExprEvalError::AxisOutOfBounds {
             input_idx: 0,
             axis: 1,
@@ -54,7 +64,7 @@ fn try_eval_reports_bad_input_refs_and_arithmetic_errors() {
         axis: 0,
     };
     assert!(matches!(
-        missing.try_eval(&[&[3]]),
+        missing.eval(&[&[3]]),
         Err(DimExprEvalError::InputOutOfBounds {
             input_idx: 2,
             input_count: 1
@@ -63,7 +73,7 @@ fn try_eval_reports_bad_input_refs_and_arithmetic_errors() {
 
     let add = DimExpr::add(DimExpr::Const(usize::MAX), DimExpr::Const(1));
     assert!(matches!(
-        add.try_eval(&[]),
+        add.eval(&[]),
         Err(DimExprEvalError::AddOverflow {
             lhs: usize::MAX,
             rhs: 1
@@ -72,7 +82,7 @@ fn try_eval_reports_bad_input_refs_and_arithmetic_errors() {
 
     let mul = DimExpr::mul(DimExpr::Const(usize::MAX), DimExpr::Const(2));
     assert!(matches!(
-        mul.try_eval(&[]),
+        mul.eval(&[]),
         Err(DimExprEvalError::MulOverflow {
             lhs: usize::MAX,
             rhs: 2
@@ -81,41 +91,47 @@ fn try_eval_reports_bad_input_refs_and_arithmetic_errors() {
 
     let sub = DimExpr::sub(DimExpr::Const(2), DimExpr::Const(5));
     assert!(matches!(
-        sub.try_eval(&[]),
+        sub.eval(&[]),
         Err(DimExprEvalError::SubUnderflow { lhs: 2, rhs: 5 })
     ));
 
     let div = DimExpr::floor_div(DimExpr::Const(8), DimExpr::Const(0));
     assert!(matches!(
-        div.try_eval(&[]),
+        div.eval(&[]),
         Err(DimExprEvalError::FloorDivByZero { lhs: 8, rhs: 0 })
     ));
 }
 
 #[test]
-#[should_panic(expected = "DimExpr::Sub underflow")]
-fn test_sub_underflow_panics_instead_of_wrapping() {
+fn sub_underflow_returns_error_instead_of_wrapping() {
     let expr = DimExpr::sub(DimExpr::Const(2), DimExpr::Const(5));
-    let _ = expr.eval(&[]);
+    assert!(matches!(
+        expr.eval(&[]),
+        Err(DimExprEvalError::SubUnderflow { lhs: 2, rhs: 5 })
+    ));
 }
 
 #[test]
-#[should_panic(expected = "DimExpr::FloorDiv divide by zero")]
-fn floor_div_zero_const_divisor_panics_with_clear_message() {
+fn floor_div_zero_const_divisor_returns_error() {
     let expr = DimExpr::floor_div(DimExpr::Const(8), DimExpr::Const(0));
-    let _ = expr.eval(&[]);
+    assert!(matches!(
+        expr.eval(&[]),
+        Err(DimExprEvalError::FloorDivByZero { lhs: 8, rhs: 0 })
+    ));
 }
 
 #[test]
-#[should_panic(expected = "DimExpr::FloorDiv divide by zero")]
-fn floor_div_zero_shape_derived_divisor_panics_with_clear_message() {
+fn floor_div_zero_shape_derived_divisor_returns_error() {
     let axis = DimExpr::InputDim {
         input_idx: 0,
         axis: 0,
     };
     let zero = DimExpr::sub(axis.clone(), axis);
     let expr = DimExpr::floor_div(DimExpr::Const(8), zero);
-    let _ = expr.eval(&[&[4]]);
+    assert!(matches!(
+        expr.eval(&[&[4]]),
+        Err(DimExprEvalError::FloorDivByZero { lhs: 8, rhs: 0 })
+    ));
 }
 
 #[test]
@@ -131,7 +147,7 @@ fn test_min_max() {
             axis: 1,
         },
     );
-    assert_eq!(e_min.eval(shapes), 3);
+    assert_eq!(e_min.eval(shapes).unwrap(), 3);
     let e_max = DimExpr::max(
         DimExpr::InputDim {
             input_idx: 0,
@@ -142,7 +158,7 @@ fn test_min_max() {
             axis: 1,
         },
     );
-    assert_eq!(e_max.eval(shapes), 7);
+    assert_eq!(e_max.eval(shapes).unwrap(), 7);
 }
 
 #[test]
@@ -302,11 +318,7 @@ fn test_small_helpers_cover_false_and_empty_paths() {
         axis: 0,
     }
     .is_const());
-    assert_eq!(DimExpr::eval_all(&[], &[]), Vec::<usize>::new());
-    assert_eq!(
-        DimExpr::try_eval_all(&[], &[]).unwrap(),
-        Vec::<usize>::new()
-    );
+    assert_eq!(DimExpr::eval_all(&[], &[]).unwrap(), Vec::<usize>::new());
     assert_eq!(DimExpr::remap_all(&[], 0, 1), Vec::<DimExpr>::new());
     assert_eq!(DimExpr::max_input_idx_all(&[DimExpr::Const(1)]), None);
     assert_eq!(DimExpr::from(&DimExpr::Const(9)), DimExpr::Const(9));

--- a/crates/tenferro-internal-ops/src/tests/ext_op_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/ext_op_tests.rs
@@ -1,4 +1,4 @@
-//! Coverage tests for `ext_op` registry + validation.
+//! Coverage tests for `ext_op` rule-set validation and extension dispatch.
 
 use std::any::Any;
 use std::collections::hash_map::DefaultHasher;
@@ -13,24 +13,13 @@ use tidu::{ADRuleKind, ADRuleResult};
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::PrimitiveRuleBuilder;
 use crate::ext_op::{
-    is_extension_rule_registered, linearize_extension_rule, lookup_extension_rule,
-    register_extension_rule, transpose_extension_rule, ExtensionAdRule, ExtensionOp,
+    linearize_extension_rule, transpose_extension_rule, ExtensionAdRule, ExtensionOp,
     ExtensionRegistryError,
 };
 use crate::input_key::TensorInputKey;
 use crate::std_tensor_op::StdTensorOp;
 use crate::{ExtensionFamilyId, ExtensionRuleSet, SymDim};
 use tenferro_tensor::{DType, Tensor};
-
-#[test]
-fn global_extension_rule_registry_does_not_expect_on_poison_contract() {
-    let source = include_str!("../ext_op.rs");
-
-    assert!(
-        !source.contains("extension rule registry RwLock poisoned"),
-        "global extension rule registry should return errors/None on poison instead of panicking"
-    );
-}
 
 #[derive(Debug)]
 struct CoverageRule {
@@ -299,10 +288,15 @@ fn extension_payload_does_not_affect_tensor_input_arity() {
 fn register_and_lookup_rule_roundtrips() {
     let family = "covtest.register_rule.v1";
     let rule: Arc<dyn ExtensionAdRule> = Arc::new(CoverageRule { family });
-    register_extension_rule(rule).expect("first rule registration should succeed");
+    let mut rules = ExtensionRuleSet::new();
+    rules
+        .register_rule(rule)
+        .expect("first rule registration should succeed");
 
-    assert!(is_extension_rule_registered(family));
-    let looked_up = lookup_extension_rule(family).expect("rule should be registered");
+    assert!(rules.is_rule_registered(family));
+    let looked_up = rules
+        .lookup_rule(family)
+        .expect("rule should be registered");
     assert_eq!(looked_up.family_id(), family);
 }
 
@@ -310,10 +304,13 @@ fn register_and_lookup_rule_roundtrips() {
 fn register_rule_rejects_duplicate_family_id() {
     let family = "covtest.duplicate_rule.v1";
     let first: Arc<dyn ExtensionAdRule> = Arc::new(CoverageRule { family });
-    register_extension_rule(first).expect("first rule registration should succeed");
+    let mut rules = ExtensionRuleSet::new();
+    rules
+        .register_rule(first)
+        .expect("first rule registration should succeed");
 
     let second: Arc<dyn ExtensionAdRule> = Arc::new(CoverageRule { family });
-    match register_extension_rule(second) {
+    match rules.register_rule(second) {
         Err(ExtensionRegistryError::DuplicateRule { family_id }) => {
             assert_eq!(family_id, family);
         }
@@ -326,7 +323,7 @@ fn register_rule_rejects_malformed_family_id() {
     let bad = "covtest.bad_rule";
     let rule: Arc<dyn ExtensionAdRule> = Arc::new(CoverageRule { family: bad });
 
-    match register_extension_rule(rule) {
+    match ExtensionRuleSet::new().with_rule(rule) {
         Err(ExtensionRegistryError::MalformedFamilyId { family_id }) => {
             assert_eq!(family_id, bad);
         }
@@ -335,11 +332,8 @@ fn register_rule_rejects_malformed_family_id() {
 }
 
 #[test]
-fn explicit_empty_rule_set_does_not_fallback_to_global_registry() {
+fn empty_rule_set_does_not_use_process_global_fallback() {
     let family = "covtest.global_only.v1";
-    register_extension_rule(Arc::new(CoverageRule { family }))
-        .expect("global sentinel rule should register");
-
     let op = FamilyOnlyOp { family };
     let mut builder = GraphBuilder::<StdTensorOp>::new();
     let dx = builder.add_input(TensorInputKey::User { id: 10_201 });
@@ -447,7 +441,7 @@ fn register_rule_rejects_malformed_family_ids() {
     ];
     for bad in cases {
         let rule: Arc<dyn ExtensionAdRule> = Arc::new(CoverageRule { family: bad });
-        match register_extension_rule(rule) {
+        match ExtensionRuleSet::new().with_rule(rule) {
             Err(ExtensionRegistryError::MalformedFamilyId { family_id }) => {
                 assert_eq!(family_id, bad);
             }

--- a/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
@@ -1,8 +1,8 @@
 use crate::ad::context::ShapeGuardContext;
 use crate::dim_expr::DimExpr;
-use crate::ext_op::{register_extension_rule, ExtensionAdRule, ExtensionOp};
+use crate::ext_op::{ExtensionAdRule, ExtensionOp};
 use crate::std_tensor_op::StdTensorOp;
-use crate::{SymDim, TensorMeta};
+use crate::{ExtensionRuleSet, SymDim, TensorMeta};
 use computegraph::graph::{Graph, GraphBuilder};
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use computegraph::GraphOperation;
@@ -128,13 +128,15 @@ fn run_linearize_case(
             active.then(|| builder.add_input(tensor_input_key(300 + offset as u64)))
         })
         .collect();
-    let result = op.jvp_rule(
-        &mut builder,
-        &primal_in,
-        &primal_out,
-        &tangent_in,
-        &mut ad_ctx,
-    );
+    let result = op
+        .jvp_rule(
+            &mut builder,
+            &primal_in,
+            &primal_out,
+            &tangent_in,
+            &mut ad_ctx,
+        )
+        .unwrap();
     (result, builder.build())
 }
 
@@ -171,13 +173,15 @@ fn run_transpose_case_with_input_shape(
     } else if let Some(shape) = input_shape {
         seed_uniform_ref_metadata(&mut ad_ctx, &inputs, shape);
     }
-    let result = op.transpose_rule(
-        &mut builder,
-        &[cotangent],
-        &inputs,
-        &linear_mode(active_mask),
-        &mut ad_ctx,
-    );
+    let result = op
+        .transpose_rule(
+            &mut builder,
+            &[cotangent],
+            &inputs,
+            &linear_mode(active_mask),
+            &mut ad_ctx,
+        )
+        .unwrap();
     (result, cotangent, builder.build())
 }
 
@@ -215,13 +219,15 @@ fn run_transpose_case_with_input_shapes(
             ),
         );
     }
-    let result = op.transpose_rule(
-        &mut builder,
-        &[cotangent],
-        &inputs,
-        &linear_mode(active_mask),
-        &mut ad_ctx,
-    );
+    let result = op
+        .transpose_rule(
+            &mut builder,
+            &[cotangent],
+            &inputs,
+            &linear_mode(active_mask),
+            &mut ad_ctx,
+        )
+        .unwrap();
     (result, cotangent, builder.build())
 }
 
@@ -438,13 +444,15 @@ fn test_std_tensor_op_linearize_add_delegates_to_ad_module() {
         ValueKey::Input(TensorInputKey::User { id: 11 }),
     ];
 
-    let result = StdTensorOp::add().jvp_rule(
-        &mut builder,
-        &primal_in,
-        &[],
-        &[Some(dx), Some(dy)],
-        &mut ad_ctx,
-    );
+    let result = StdTensorOp::add()
+        .jvp_rule(
+            &mut builder,
+            &primal_in,
+            &[],
+            &[Some(dx), Some(dy)],
+            &mut ad_ctx,
+        )
+        .unwrap();
 
     assert_eq!(result.len(), 1);
     assert!(result[0].is_some());
@@ -469,13 +477,15 @@ fn test_std_tensor_op_transpose_rule_add_fans_out_cotangent() {
         ValueRef::External(ValueKey::Input(TensorInputKey::User { id: 11 })),
     ];
 
-    let result = StdTensorOp::add().transpose_rule(
-        &mut builder,
-        &[Some(ct)],
-        &inputs,
-        &OperationRole::Primary,
-        &mut ad_ctx,
-    );
+    let result = StdTensorOp::add()
+        .transpose_rule(
+            &mut builder,
+            &[Some(ct)],
+            &inputs,
+            &OperationRole::Primary,
+            &mut ad_ctx,
+        )
+        .unwrap();
 
     assert_eq!(result, vec![Some(ct), Some(ct)]);
     let graph = builder.build();
@@ -506,13 +516,15 @@ fn test_std_tensor_op_mul_transpose_skips_real_conjugates_and_keeps_complex_conj
     let cotangent = builder.add_input(tensor_input_key(401));
     let inputs = external_inputs(510, 2);
     seed_uniform_ref_metadata_with_dtype(&mut ad_ctx, &inputs, DType::C64, sym_shape(&[2]));
-    let complex_result = StdTensorOp::Mul.transpose_rule(
-        &mut builder,
-        &[Some(cotangent)],
-        &inputs,
-        &linear_mode(&[true, true]),
-        &mut ad_ctx,
-    );
+    let complex_result = StdTensorOp::Mul
+        .transpose_rule(
+            &mut builder,
+            &[Some(cotangent)],
+            &inputs,
+            &linear_mode(&[true, true]),
+            &mut ad_ctx,
+        )
+        .unwrap();
     let complex_graph = builder.build();
 
     assert!(complex_result.iter().all(Option::is_some));
@@ -535,8 +547,9 @@ fn test_std_tensor_op_conj_ad_skips_real_identity_and_keeps_complex_conjugation(
         TensorMeta::exact(DType::F64, sym_shape(&[2])),
     );
     let tangent = builder.add_input(tensor_input_key(540));
-    let real_linearized =
-        StdTensorOp::Conj.jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
+    let real_linearized = StdTensorOp::Conj
+        .jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx)
+        .unwrap();
     let real_linear_graph = builder.build();
     assert_eq!(real_linearized, vec![Some(tangent)]);
     assert!(real_linear_graph.operations().is_empty());
@@ -551,13 +564,15 @@ fn test_std_tensor_op_conj_ad_skips_real_identity_and_keeps_complex_conjugation(
         sym_shape(&[2]),
     );
     let cotangent = builder.add_input(tensor_input_key(542));
-    let real_transposed = StdTensorOp::Conj.transpose_rule(
-        &mut builder,
-        &[Some(cotangent)],
-        &[input],
-        &linear_mode(&[true]),
-        &mut ad_ctx,
-    );
+    let real_transposed = StdTensorOp::Conj
+        .transpose_rule(
+            &mut builder,
+            &[Some(cotangent)],
+            &[input],
+            &linear_mode(&[true]),
+            &mut ad_ctx,
+        )
+        .unwrap();
     let real_transpose_graph = builder.build();
     assert_eq!(real_transposed, vec![Some(cotangent)]);
     assert!(real_transpose_graph.operations().is_empty());
@@ -570,8 +585,9 @@ fn test_std_tensor_op_conj_ad_skips_real_identity_and_keeps_complex_conjugation(
         TensorMeta::exact(DType::C64, sym_shape(&[2])),
     );
     let tangent = builder.add_input(tensor_input_key(560));
-    let complex_linearized =
-        StdTensorOp::Conj.jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
+    let complex_linearized = StdTensorOp::Conj
+        .jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx)
+        .unwrap();
     let complex_linear_graph = builder.build();
     assert!(complex_linearized[0].is_some());
     assert_eq!(complex_linear_graph.operations().len(), 1);
@@ -590,13 +606,15 @@ fn test_std_tensor_op_conj_ad_skips_real_identity_and_keeps_complex_conjugation(
         sym_shape(&[2]),
     );
     let cotangent = builder.add_input(tensor_input_key(562));
-    let complex_transposed = StdTensorOp::Conj.transpose_rule(
-        &mut builder,
-        &[Some(cotangent)],
-        &[input],
-        &linear_mode(&[true]),
-        &mut ad_ctx,
-    );
+    let complex_transposed = StdTensorOp::Conj
+        .transpose_rule(
+            &mut builder,
+            &[Some(cotangent)],
+            &[input],
+            &linear_mode(&[true]),
+            &mut ad_ctx,
+        )
+        .unwrap();
     let complex_transpose_graph = builder.build();
     assert!(complex_transposed[0].is_some());
     assert_eq!(complex_transpose_graph.operations().len(), 1);
@@ -777,13 +795,15 @@ fn test_std_tensor_op_dynamic_truncate_linearize_uses_static_slice_for_narrowed_
         TensorMeta::exact(DType::F64, vec![SymDim::from(2usize)]),
     );
 
-    let result = StdTensorOp::DynamicTruncate { axis: 0 }.jvp_rule(
-        &mut builder,
-        &primal_in,
-        &primal_out,
-        &[Some(tangent), None],
-        &mut ad_ctx,
-    );
+    let result = StdTensorOp::DynamicTruncate { axis: 0 }
+        .jvp_rule(
+            &mut builder,
+            &primal_in,
+            &primal_out,
+            &[Some(tangent), None],
+            &mut ad_ctx,
+        )
+        .unwrap();
     let graph = builder.build();
 
     assert!(result[0].is_some());
@@ -1035,13 +1055,15 @@ fn test_std_tensor_op_elementwise_special_cases_are_covered() {
     let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let cotangent = builder.add_input(tensor_input_key(920));
-    let div_primal_mode = StdTensorOp::Div.transpose_rule(
-        &mut builder,
-        &[Some(cotangent)],
-        &external_inputs(921, 2),
-        &OperationRole::Primary,
-        &mut ad_ctx,
-    );
+    let div_primal_mode = StdTensorOp::Div
+        .transpose_rule(
+            &mut builder,
+            &[Some(cotangent)],
+            &external_inputs(921, 2),
+            &OperationRole::Primary,
+            &mut ad_ctx,
+        )
+        .unwrap();
     assert_eq!(div_primal_mode, vec![None, None]);
     assert!(builder.build().operations().is_empty());
 
@@ -1158,13 +1180,15 @@ fn test_std_tensor_op_transpose_none_or_inactive_paths_return_none() {
         let mut builder = GraphBuilder::<StdTensorOp>::new();
         let mut ad_ctx = ShapeGuardContext::default();
         let cotangent = builder.add_input(tensor_input_key(900));
-        let result = op.transpose_rule(
-            &mut builder,
-            &[Some(cotangent)],
-            &external_inputs(901, 1),
-            &OperationRole::Primary,
-            &mut ad_ctx,
-        );
+        let result = op
+            .transpose_rule(
+                &mut builder,
+                &[Some(cotangent)],
+                &external_inputs(901, 1),
+                &OperationRole::Primary,
+                &mut ad_ctx,
+            )
+            .unwrap();
         assert_eq!(result, vec![None], "unexpected inactive path for {op:?}");
         assert!(
             builder.build().operations().is_empty(),

--- a/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
+++ b/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
@@ -33,8 +33,9 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
     let identity_reshape = StdTensorOp::Reshape {
         to_shape: shape![2, 2],
     };
-    let identity_reshape_result =
-        identity_reshape.jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
+    let identity_reshape_result = identity_reshape
+        .jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx)
+        .unwrap();
     let identity_reshape_graph = builder.build();
     assert_eq!(identity_reshape_result, vec![Some(tangent)]);
     assert!(identity_reshape_graph.operations().is_empty());
@@ -78,8 +79,9 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
         shape: shape![2, 3],
         dims: vec![0, 1],
     };
-    let identity_broadcast_result =
-        identity_broadcast.jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx);
+    let identity_broadcast_result = identity_broadcast
+        .jvp_rule(&mut builder, &primal_in, &[], &[Some(tangent)], &mut ad_ctx)
+        .unwrap();
     let identity_broadcast_graph = builder.build();
     assert_eq!(identity_broadcast_result, vec![Some(tangent)]);
     assert!(identity_broadcast_graph.operations().is_empty());
@@ -126,7 +128,8 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
         &external_inputs(911, 1),
         &linear_mode(&[true]),
         &mut ad_ctx,
-    );
+    )
+    .unwrap();
     assert_eq!(result, vec![Some(cotangent)]);
     assert!(builder.build().operations().is_empty());
 
@@ -259,7 +262,8 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
         &external_inputs(930, 1),
         &linear_mode(&[true]),
         &mut ad_ctx,
-    );
+    )
+    .unwrap();
     assert_eq!(none_broadcast, vec![None]);
     assert!(builder.build().operations().is_empty());
 }
@@ -323,13 +327,15 @@ fn test_std_tensor_op_contraction_special_cases_cover_none_and_scalar_paths() {
     let mut ad_ctx = ShapeGuardContext::default();
     let cotangent = builder.add_input(tensor_input_key(980));
     seed_dot_general_ref_metadata(&mut ad_ctx, &external_inputs(981, 2));
-    let primal_mode_result = matmul.transpose_rule(
-        &mut builder,
-        &[Some(cotangent)],
-        &external_inputs(981, 2),
-        &OperationRole::Primary,
-        &mut ad_ctx,
-    );
+    let primal_mode_result = matmul
+        .transpose_rule(
+            &mut builder,
+            &[Some(cotangent)],
+            &external_inputs(981, 2),
+            &OperationRole::Primary,
+            &mut ad_ctx,
+        )
+        .unwrap();
     assert_eq!(primal_mode_result, vec![None, None]);
     assert!(builder.build().operations().is_empty());
 
@@ -417,13 +423,15 @@ fn test_std_tensor_op_contraction_special_cases_cover_none_and_scalar_paths() {
             ),
         );
     }
-    let complex_transpose_result = scalar_contract.transpose_rule(
-        &mut builder,
-        &[Some(cotangent)],
-        &inputs,
-        &linear_mode(&[true, false]),
-        &mut ad_ctx,
-    );
+    let complex_transpose_result = scalar_contract
+        .transpose_rule(
+            &mut builder,
+            &[Some(cotangent)],
+            &inputs,
+            &linear_mode(&[true, false]),
+            &mut ad_ctx,
+        )
+        .unwrap();
     let complex_transpose_graph = builder.build();
     assert!(complex_transpose_result[0].is_some());
     assert_eq!(complex_transpose_result[1], None);
@@ -520,30 +528,34 @@ impl ExtensionAdRule for RuleOnlyIdentityAd {
 }
 
 #[test]
-fn extension_try_linearize_uses_registered_rule() {
+fn extension_linearize_uses_registered_rule() {
     let family = "stdtensor.rule_only_identity.v1";
-    let _ = register_extension_rule(Arc::new(RuleOnlyIdentityAd { family }));
+    let rules = ExtensionRuleSet::new()
+        .with_rule(Arc::new(RuleOnlyIdentityAd { family }))
+        .expect("extension rule should register");
     let op = StdTensorOp::Extension(Arc::new(RuleOnlyExt { family }));
     let mut builder = GraphBuilder::<StdTensorOp>::new();
-    let mut ad_ctx = ShapeGuardContext::default();
+    let mut ad_ctx = ShapeGuardContext::default().with_extension_rules(rules);
     let dx = builder.add_input(tensor_input_key(900));
     let result = op
-        .try_jvp_rule(&mut builder, &[], &[], &[Some(dx)], &mut ad_ctx)
+        .jvp_rule(&mut builder, &[], &[], &[Some(dx)], &mut ad_ctx)
         .expect("registered extension rule should linearize");
 
     assert_eq!(result, vec![Some(dx)]);
 }
 
 #[test]
-fn extension_try_transpose_uses_registered_rule() {
+fn extension_transpose_uses_registered_rule() {
     let family = "stdtensor.rule_only_transpose.v1";
-    let _ = register_extension_rule(Arc::new(RuleOnlyIdentityAd { family }));
+    let rules = ExtensionRuleSet::new()
+        .with_rule(Arc::new(RuleOnlyIdentityAd { family }))
+        .expect("extension rule should register");
     let op = StdTensorOp::Extension(Arc::new(RuleOnlyExt { family }));
     let mut builder = GraphBuilder::<StdTensorOp>::new();
-    let mut ad_ctx = ShapeGuardContext::default();
+    let mut ad_ctx = ShapeGuardContext::default().with_extension_rules(rules);
     let ct = builder.add_input(tensor_input_key(901));
     let result = op
-        .try_linear_transpose_rule(
+        .transpose_rule(
             &mut builder,
             &[Some(ct)],
             &external_inputs(910, 1),
@@ -556,14 +568,14 @@ fn extension_try_transpose_uses_registered_rule() {
 }
 
 #[test]
-fn extension_try_linearize_reports_missing_rule() {
+fn extension_linearize_reports_missing_rule() {
     let family = "stdtensor.missing_rule.v1";
     let op = StdTensorOp::Extension(Arc::new(RuleOnlyExt { family }));
     let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ad_ctx = ShapeGuardContext::default();
     let dx = builder.add_input(tensor_input_key(920));
     let err = op
-        .try_jvp_rule(&mut builder, &[], &[], &[Some(dx)], &mut ad_ctx)
+        .jvp_rule(&mut builder, &[], &[], &[Some(dx)], &mut ad_ctx)
         .expect_err("missing extension rule should be an AD error");
 
     assert_eq!(err.rule(), ADRuleKind::Jvp);

--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -14,7 +14,7 @@
 //!     .build()
 //!     .unwrap();
 //! let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]);
-//! let (_u, s, _vt) = tenferro_linalg::svd(&x).unwrap();
+//! let (_u, s, _vt) = tenferro_linalg::traced_tensor::svd(&x).unwrap();
 //! let loss = s.reduce_sum(&[0]);
 //! let grad = ad.grad(&loss, &x).unwrap();
 //! assert_eq!(grad.rank, 2);
@@ -24,8 +24,7 @@ use std::sync::Arc;
 
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_ad::extension::{
-    is_extension_rule_registered, register_extension_rule as register_rule, ExtensionAdRuleTrait,
-    ExtensionOpTrait, ExtensionRegistryError, ExtensionRuleSet,
+    ExtensionAdRule, ExtensionOp, ExtensionRegistryError, ExtensionRuleSet,
 };
 use tenferro_ops::ad::PrimitiveRuleBuilder;
 use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -50,41 +49,17 @@ pub fn ad_rules() -> Result<ExtensionRuleSet, ExtensionRegistryError> {
     ExtensionRuleSet::new().with_rule(Arc::new(LinalgAdRule))
 }
 
-/// Register the `tenferro-linalg` extension AD rule.
-///
-/// This process-global registration API is retained as a compatibility bridge.
-/// Prefer explicit [`ad_rules`] ownership through `tenferro_ad::AdContext`.
-///
-/// # Examples
-///
-/// ```rust
-/// tenferro_linalg::register_extension_rule().unwrap();
-/// ```
-pub fn register_extension_rule() -> Result<(), ExtensionRegistryError> {
-    if is_extension_rule_registered(LINALG_EXTENSION_FAMILY_ID) {
-        return Ok(());
-    }
-    let rules = ad_rules()?;
-    let Some(rule) = rules.lookup_rule(LINALG_EXTENSION_FAMILY_ID) else {
-        return Ok(());
-    };
-    match register_rule(rule) {
-        Ok(()) | Err(ExtensionRegistryError::DuplicateRule { .. }) => Ok(()),
-        Err(err) => Err(err),
-    }
-}
-
 #[derive(Debug)]
 struct LinalgAdRule;
 
-impl ExtensionAdRuleTrait for LinalgAdRule {
+impl ExtensionAdRule for LinalgAdRule {
     fn family_id(&self) -> &'static str {
         LINALG_EXTENSION_FAMILY_ID
     }
 
     fn linearize(
         &self,
-        op: &dyn ExtensionOpTrait,
+        op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         primal_in: &[ValueKey<StdTensorOp>],
         primal_out: &[ValueKey<StdTensorOp>],
@@ -92,9 +67,9 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_ad_op(op, ADRuleKind::Jvp)?;
-        let tangents = match op.op() {
+        match op.op() {
             LinalgOp::Lu => rules::linearize_lu(builder, primal_in, primal_out, tangent_in, ctx),
-            LinalgOp::LuFactor => vec![None; op.output_count()],
+            LinalgOp::LuFactor => Ok(vec![None; op.output_count()]),
             LinalgOp::LuSolvePrepared {
                 transpose_a,
                 conjugate_a,
@@ -147,19 +122,27 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
             LinalgOp::EighVals { eps } => {
                 rules::linearize_eigh_values(builder, primal_in, tangent_in, eps, ctx)
             }
-            LinalgOp::Eig { input_dtype } => {
-                rules::linearize_eig(builder, primal_in, primal_out, tangent_in, input_dtype, ctx)
-            }
-            LinalgOp::EigVals { input_dtype } => {
-                rules::linearize_eig_values(builder, primal_in, tangent_in, input_dtype, ctx)
-            }
-        };
-        Ok(tangents)
+            LinalgOp::Eig { input_dtype } => Ok(rules::linearize_eig(
+                builder,
+                primal_in,
+                primal_out,
+                tangent_in,
+                input_dtype,
+                ctx,
+            )),
+            LinalgOp::EigVals { input_dtype } => Ok(rules::linearize_eig_values(
+                builder,
+                primal_in,
+                tangent_in,
+                input_dtype,
+                ctx,
+            )),
+        }
     }
 
     fn transpose_rule(
         &self,
-        op: &dyn ExtensionOpTrait,
+        op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         inputs: &[ValueRef<StdTensorOp>],
@@ -168,7 +151,7 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_ad_op(op, ADRuleKind::Transpose)?;
         let mut builder = DynBuilder(builder);
-        let cotangents = match op.op() {
+        match op.op() {
             LinalgOp::TriangularSolve {
                 left_side,
                 lower,
@@ -185,7 +168,7 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
             LinalgOp::LuSolvePrepared {
                 transpose_a,
                 conjugate_a,
-            } => rules::transpose_lu_solve_prepared(
+            } => Ok(rules::transpose_lu_solve_prepared(
                 &mut builder,
                 cotangent_out,
                 inputs,
@@ -193,7 +176,7 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
                 transpose_a,
                 conjugate_a,
                 ctx,
-            ),
+            )),
             LinalgOp::FullPivLuSolve { transpose_a } => rules::transpose_full_piv_lu_solve(
                 &mut builder,
                 cotangent_out,
@@ -212,9 +195,8 @@ impl ExtensionAdRuleTrait for LinalgAdRule {
             | LinalgOp::Eigh { .. }
             | LinalgOp::EighVals { .. }
             | LinalgOp::Eig { .. }
-            | LinalgOp::EigVals { .. } => vec![None; op.input_count()],
-        };
-        Ok(cotangents)
+            | LinalgOp::EigVals { .. } => Ok(vec![None; op.input_count()]),
+        }
     }
 }
 
@@ -231,11 +213,11 @@ impl PrimitiveRuleBuilder for DynBuilder<'_> {
     }
 }
 
-fn downcast_ad_op(op: &dyn ExtensionOpTrait, kind: ADRuleKind) -> ADRuleResult<&LinalgExtensionOp> {
+fn downcast_ad_op(op: &dyn ExtensionOp, kind: ADRuleKind) -> ADRuleResult<&LinalgExtensionOp> {
     op.as_any()
         .downcast_ref::<LinalgExtensionOp>()
         .ok_or_else(|| {
-            ADRuleError::unsupported("tenferro-linalg.linalg.v1 payload type mismatch", kind)
+            ADRuleError::invalid_input("tenferro-linalg.linalg.v1", kind, "payload type mismatch")
         })
 }
 

--- a/crates/tenferro-linalg/src/ad/rules/mod.rs
+++ b/crates/tenferro-linalg/src/ad/rules/mod.rs
@@ -30,6 +30,7 @@ pub(crate) use tenferro_ops::ad::support::{
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::DType;
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 mod solve;
 mod support;
@@ -52,16 +53,16 @@ use support::*;
 fn primal_input_shape(
     ctx: &mut ShapeGuardContext,
     primal_in: &[ValueKey<StdTensorOp>],
-) -> Vec<DimExpr> {
-    let shape = ctx.shape_of(&ValueRef::External(primal_in[0].clone()));
+) -> Option<Vec<DimExpr>> {
+    let shape = ctx.shape_if_available(&ValueRef::External(primal_in[0].clone()))?;
     if let Some(concrete) = shape
         .iter()
         .map(|dim| dim.constant_value())
         .collect::<Option<Vec<_>>>()
     {
-        DimExpr::from_concrete(&concrete)
+        Some(DimExpr::from_concrete(&concrete))
     } else {
-        DimExpr::input_shape(0, shape.len())
+        Some(DimExpr::input_shape(0, shape.len()))
     }
 }
 
@@ -69,12 +70,20 @@ fn primal_matrix_input_shape(
     ctx: &mut ShapeGuardContext,
     primal_in: &[ValueKey<StdTensorOp>],
 ) -> Option<Vec<DimExpr>> {
-    let input_shape = primal_input_shape(ctx, primal_in);
+    let input_shape = primal_input_shape(ctx, primal_in)?;
     (input_shape.len() >= 2).then_some(input_shape)
 }
 
 fn linalg_std_op(op: LinalgOp) -> StdTensorOp {
     StdTensorOp::Extension(Arc::new(LinalgExtensionOp::new(op)))
+}
+
+fn invalid_dim_expr(op: &'static str, err: impl std::fmt::Display) -> ADRuleError {
+    ADRuleError::invalid_input(
+        format!("tenferro-linalg.{op}"),
+        ADRuleKind::Jvp,
+        format!("invalid matrix dimension expression: {err}"),
+    )
 }
 
 pub(crate) fn linearize_lu(
@@ -83,17 +92,18 @@ pub(crate) fn linearize_lu(
     primal_out: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(da) = tangent_in[0] else {
-        return vec![None, None, None, None];
+        return Ok(vec![None, None, None, None]);
     };
 
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in) else {
-        return vec![None, None, None, None];
+        return Ok(vec![None, None, None, None]);
     };
     let input_shape = input_shape.as_slice();
     let (m, n, batch_shape) = matrix_shape_parts(input_shape, "linearize_lu");
-    let (m_size, n_size) = resolve_and_guard(m, n, ctx);
+    let (m_size, n_size) =
+        resolve_and_guard(m, n, ctx).map_err(|err| invalid_dim_expr("linearize_lu", err))?;
     let k = DimExpr::min(m.clone(), n.clone());
     let k_size = m_size.min(n_size);
     let rank = input_shape.len();
@@ -182,7 +192,7 @@ pub(crate) fn linearize_lu(
         du_full
     };
 
-    vec![None, Some(dl), Some(du), None]
+    Ok(vec![None, Some(dl), Some(du), None])
 }
 
 pub(crate) fn linearize_full_piv_lu(
@@ -191,19 +201,20 @@ pub(crate) fn linearize_full_piv_lu(
     primal_out: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(da) = tangent_in[0] else {
-        return vec![None, None, None, None, None];
+        return Ok(vec![None, None, None, None, None]);
     };
 
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in) else {
-        return vec![None, None, None, None, None];
+        return Ok(vec![None, None, None, None, None]);
     };
     let input_shape = input_shape.as_slice();
     let (rows, cols, _batch_shape) = matrix_shape_parts(input_shape, "linearize_full_piv_lu");
-    let (rows_size, cols_size) = resolve_and_guard(rows, cols, ctx);
+    let (rows_size, cols_size) = resolve_and_guard(rows, cols, ctx)
+        .map_err(|err| invalid_dim_expr("linearize_full_piv_lu", err))?;
     if rows_size != cols_size {
-        return vec![None, None, None, None, None];
+        return Ok(vec![None, None, None, None, None]);
     }
 
     let rank = input_shape.len();
@@ -263,7 +274,7 @@ pub(crate) fn linearize_full_piv_lu(
         rank,
     );
 
-    vec![None, Some(dl), Some(du), None, None]
+    Ok(vec![None, Some(dl), Some(du), None, None])
 }
 
 pub(crate) fn linearize_eig(
@@ -375,19 +386,20 @@ pub(crate) fn linearize_svd(
     tangent_in: &[Option<LocalValueId>],
     eps: f64,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(da) = tangent_in[0] else {
-        return vec![None, None, None];
+        return Ok(vec![None, None, None]);
     };
 
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in) else {
-        return vec![None, None, None];
+        return Ok(vec![None, None, None]);
     };
     let input_shape = input_shape.as_slice();
     let (m, n, batch_shape) = matrix_shape_parts(input_shape, "linearize_svd");
-    let (m_size, n_size) = resolve_and_guard(m, n, ctx);
+    let (m_size, n_size) =
+        resolve_and_guard(m, n, ctx).map_err(|err| invalid_dim_expr("linearize_svd", err))?;
     let matrix_rank = input_shape.len();
-    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let k = DimExpr::min(m.clone(), n.clone());
     let u = ValueRef::External(primal_out[0].clone());
     let s = ValueRef::External(primal_out[1].clone());
@@ -540,7 +552,7 @@ pub(crate) fn linearize_svd(
 
     let dvt = adjoint_matrix_linear(builder, dv, matrix_rank, dtype);
 
-    vec![Some(du), Some(ds), Some(dvt)]
+    Ok(vec![Some(du), Some(ds), Some(dvt)])
 }
 
 pub(crate) fn linearize_svd_values(
@@ -549,17 +561,17 @@ pub(crate) fn linearize_svd_values(
     tangent_in: &[Option<LocalValueId>],
     eps: f64,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(da) = tangent_in[0] else {
-        return vec![None];
+        return Ok(vec![None]);
     };
 
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in) else {
-        return vec![None];
+        return Ok(vec![None]);
     };
     let input_shape = input_shape.as_slice();
     let matrix_rank = input_shape.len();
-    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let svd_outputs = builder.add_operation(
         linalg_std_op(LinalgOp::Svd { eps }),
         vec![ValueRef::External(primal_in[0].clone())],
@@ -583,7 +595,7 @@ pub(crate) fn linearize_svd_values(
         vec![true, false],
         matrix_rank,
     );
-    vec![Some(extract_diag_linear(builder, ds_mat))]
+    Ok(vec![Some(extract_diag_linear(builder, ds_mat))])
 }
 
 pub(crate) fn linearize_eigh(
@@ -593,19 +605,19 @@ pub(crate) fn linearize_eigh(
     tangent_in: &[Option<LocalValueId>],
     eps: f64,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(da) = tangent_in[0] else {
-        return vec![None, None];
+        return Ok(vec![None, None]);
     };
 
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in) else {
-        return vec![None, None];
+        return Ok(vec![None, None]);
     };
     let input_shape = input_shape.as_slice();
     let matrix_rank = input_shape.len();
-    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let w = ValueRef::External(primal_out[0].clone());
-    let w_dtype = ctx.dtype_of(&w);
+    let w_dtype = ctx.dtype_of(&w)?;
     let v = ValueRef::External(primal_out[1].clone());
     let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank, dtype);
 
@@ -656,7 +668,7 @@ pub(crate) fn linearize_eigh(
         matrix_rank,
     );
 
-    vec![Some(dw), Some(dv)]
+    Ok(vec![Some(dw), Some(dv)])
 }
 
 pub(crate) fn linearize_eigh_values(
@@ -665,17 +677,17 @@ pub(crate) fn linearize_eigh_values(
     tangent_in: &[Option<LocalValueId>],
     eps: f64,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(da) = tangent_in[0] else {
-        return vec![None];
+        return Ok(vec![None]);
     };
 
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in) else {
-        return vec![None];
+        return Ok(vec![None]);
     };
     let input_shape = input_shape.as_slice();
     let matrix_rank = input_shape.len();
-    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let eigh_outputs = builder.add_operation(
         linalg_std_op(LinalgOp::Eigh { eps }),
         vec![ValueRef::External(primal_in[0].clone())],
@@ -699,7 +711,7 @@ pub(crate) fn linearize_eigh_values(
         matrix_rank,
     );
 
-    vec![Some(extract_diag_linear(builder, projected))]
+    Ok(vec![Some(extract_diag_linear(builder, projected))])
 }
 
 pub(crate) fn linearize_cholesky(
@@ -708,17 +720,17 @@ pub(crate) fn linearize_cholesky(
     primal_out: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(da) = tangent_in[0] else {
-        return vec![None];
+        return Ok(vec![None]);
     };
 
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in) else {
-        return vec![None];
+        return Ok(vec![None]);
     };
     let input_shape = input_shape.as_slice();
     let matrix_rank = input_shape.len();
-    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let l = ValueRef::External(primal_out[0].clone());
     let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank, dtype);
     let l_conj = conjugate_primal_if_dtype_complex(builder, l.clone(), dtype);
@@ -767,7 +779,7 @@ pub(crate) fn linearize_cholesky(
         matrix_rank,
     );
 
-    vec![Some(dl)]
+    Ok(vec![Some(dl)])
 }
 
 pub(crate) fn linearize_qr(
@@ -776,19 +788,20 @@ pub(crate) fn linearize_qr(
     primal_out: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(da) = tangent_in[0] else {
-        return vec![None, None];
+        return Ok(vec![None, None]);
     };
 
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in) else {
-        return vec![None, None];
+        return Ok(vec![None, None]);
     };
     let input_shape = input_shape.as_slice();
     let (m, n, batch_shape) = matrix_shape_parts(input_shape, "linearize_qr");
-    let (m_size, n_size) = resolve_and_guard(m, n, ctx);
+    let (m_size, n_size) =
+        resolve_and_guard(m, n, ctx).map_err(|err| invalid_dim_expr("linearize_qr", err))?;
     let matrix_rank = input_shape.len();
-    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let q = ValueRef::External(primal_out[0].clone());
     let r = ValueRef::External(primal_out[1].clone());
 
@@ -928,7 +941,7 @@ pub(crate) fn linearize_qr(
             dr = linear_add(builder, dr, dr_trailing_full);
         }
 
-        return vec![Some(dq), Some(dr)];
+        return Ok(vec![Some(dq), Some(dr)]);
     }
 
     let r_h = adjoint_matrix_fixed(builder, r.clone(), matrix_rank, dtype);
@@ -984,5 +997,5 @@ pub(crate) fn linearize_qr(
         matrix_rank,
     );
 
-    vec![Some(dq), Some(dr)]
+    Ok(vec![Some(dq), Some(dr)])
 }

--- a/crates/tenferro-linalg/src/ad/rules/solve.rs
+++ b/crates/tenferro-linalg/src/ad/rules/solve.rs
@@ -1,7 +1,9 @@
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_ops::ad::context::ShapeGuardContext;
 use tenferro_ops::ad::PrimitiveRuleBuilder;
+use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use crate::extension::LinalgOp;
 
@@ -55,7 +57,7 @@ pub(crate) fn linearize_triangular_solve(
     tangent_in: &[Option<LocalValueId>],
     flags: TriangularSolveFlags,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     // Equation: op(A) @ X = B  (left_side=true)
     //       or  X @ op(A) = B  (left_side=false)
     // where op = identity (transpose_a=false) or transpose (transpose_a=true).
@@ -66,18 +68,18 @@ pub(crate) fn linearize_triangular_solve(
     // When tangent_in[0] (dA) is present, we compute the correction:
     //   -d(op(A)) @ X  or  -X @ d(op(A))
     let lhs_rank = ctx
-        .shape_of(&ValueRef::External(primal_in[0].clone()))
+        .shape_of(&ValueRef::External(primal_in[0].clone()))?
         .len();
     let rhs_rank = ctx
-        .shape_of(&ValueRef::External(primal_in[1].clone()))
+        .shape_of(&ValueRef::External(primal_in[1].clone()))?
         .len();
-    if lhs_rank < 2 || rhs_rank < 2 || lhs_rank != rhs_rank {
-        return vec![None];
-    }
+    validate_matrix_operands("triangular_solve", ADRuleKind::Jvp, lhs_rank, rhs_rank)?;
+    let lhs_ref = ValueRef::External(primal_in[0].clone());
+    validate_square_matrix_input("triangular_solve", ADRuleKind::Jvp, &lhs_ref, ctx)?;
     let rank = lhs_rank;
     let rhs_tangent = triangular_solve_rhs_tangent(builder, primal_out, tangent_in, flags, rank);
     let Some(rhs_tangent) = rhs_tangent else {
-        return vec![None];
+        return Ok(vec![None]);
     };
 
     let out = builder.add_operation(
@@ -90,7 +92,7 @@ pub(crate) fn linearize_triangular_solve(
             active_mask: vec![false, true],
         },
     );
-    vec![Some(out[0])]
+    Ok(vec![Some(out[0])])
 }
 
 #[derive(Clone, Copy)]
@@ -112,16 +114,16 @@ fn linearize_linear_solve(
     transpose_a: bool,
     ctx: &mut ShapeGuardContext,
     kind: LinearSolveOp,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let lhs_rank = ctx
-        .shape_of(&ValueRef::External(primal_in[0].clone()))
+        .shape_of(&ValueRef::External(primal_in[0].clone()))?
         .len();
     let rhs_rank = ctx
-        .shape_of(&ValueRef::External(primal_in[1].clone()))
+        .shape_of(&ValueRef::External(primal_in[1].clone()))?
         .len();
-    if lhs_rank < 2 || rhs_rank < 2 || lhs_rank != rhs_rank {
-        return vec![None];
-    }
+    validate_matrix_operands(kind.op_name(), ADRuleKind::Jvp, lhs_rank, rhs_rank)?;
+    let lhs_ref = ValueRef::External(primal_in[0].clone());
+    validate_square_matrix_input(kind.op_name(), ADRuleKind::Jvp, &lhs_ref, ctx)?;
     let rank = lhs_rank;
     let mut rhs_tangent = tangent_in[1];
 
@@ -142,7 +144,7 @@ fn linearize_linear_solve(
     }
 
     let Some(rhs_tangent) = rhs_tangent else {
-        return vec![None];
+        return Ok(vec![None]);
     };
 
     let out = builder.add_operation(
@@ -155,7 +157,7 @@ fn linearize_linear_solve(
             active_mask: vec![false, true],
         },
     );
-    vec![Some(out[0])]
+    Ok(vec![Some(out[0])])
 }
 
 pub(crate) fn linearize_lu_solve_prepared(
@@ -166,21 +168,25 @@ pub(crate) fn linearize_lu_solve_prepared(
     transpose_a: bool,
     conjugate_a: bool,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let lhs_rank = ctx
-        .shape_of(&ValueRef::External(primal_in[0].clone()))
+        .shape_of(&ValueRef::External(primal_in[0].clone()))?
         .len();
     let rhs_rank = ctx
-        .shape_of(&ValueRef::External(primal_in[3].clone()))
+        .shape_of(&ValueRef::External(primal_in[3].clone()))?
         .len();
-    if lhs_rank < 2 || rhs_rank < 2 || lhs_rank != rhs_rank {
-        return vec![None];
-    }
+    validate_matrix_operands("lu_solve_prepared", ADRuleKind::Jvp, lhs_rank, rhs_rank)?;
+    validate_square_matrix_input(
+        "lu_solve_prepared",
+        ADRuleKind::Jvp,
+        &ValueRef::External(primal_in[0].clone()),
+        ctx,
+    )?;
     let rank = lhs_rank;
     let mut rhs_tangent = tangent_in[3];
 
     if let Some(da) = tangent_in[0] {
-        let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()));
+        let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
         let d_op_a = match (transpose_a, conjugate_a) {
             (false, false) => da,
             (true, false) => transpose_matrix_linear(builder, da, rank),
@@ -198,7 +204,7 @@ pub(crate) fn linearize_lu_solve_prepared(
     }
 
     let Some(rhs_tangent) = rhs_tangent else {
-        return vec![None];
+        return Ok(vec![None]);
     };
 
     let out = builder.add_operation(
@@ -216,7 +222,7 @@ pub(crate) fn linearize_lu_solve_prepared(
             active_mask: vec![false, false, false, true],
         },
     );
-    vec![Some(out[0])]
+    Ok(vec![Some(out[0])])
 }
 
 pub(crate) fn linearize_full_piv_lu_solve(
@@ -226,7 +232,7 @@ pub(crate) fn linearize_full_piv_lu_solve(
     tangent_in: &[Option<LocalValueId>],
     transpose_a: bool,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     linearize_linear_solve(
         builder,
         primal_in,
@@ -236,6 +242,75 @@ pub(crate) fn linearize_full_piv_lu_solve(
         ctx,
         LinearSolveOp::FullPivLuSolve,
     )
+}
+
+fn invalid_input(op: &'static str, rule: ADRuleKind, message: impl Into<String>) -> ADRuleError {
+    ADRuleError::invalid_input(format!("{LINALG_AD_OP_PREFIX}{op}"), rule, message)
+}
+
+const LINALG_AD_OP_PREFIX: &str = "tenferro-linalg.";
+
+impl LinearSolveOp {
+    fn op_name(self) -> &'static str {
+        match self {
+            LinearSolveOp::FullPivLuSolve => "full_piv_lu_solve",
+        }
+    }
+}
+
+fn validate_matrix_operands(
+    op: &'static str,
+    rule: ADRuleKind,
+    lhs_rank: usize,
+    rhs_rank: usize,
+) -> ADRuleResult<()> {
+    if lhs_rank < 2 || rhs_rank < 2 {
+        return Err(invalid_input(
+            op,
+            rule,
+            format!("expected matrix operands with rank >= 2, got ranks {lhs_rank} and {rhs_rank}"),
+        ));
+    }
+    if lhs_rank != rhs_rank {
+        return Err(invalid_input(
+            op,
+            rule,
+            format!("expected matrix operands with matching ranks, got {lhs_rank} and {rhs_rank}"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_square_matrix_input(
+    op: &'static str,
+    rule: ADRuleKind,
+    input: &ValueRef<StdTensorOp>,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<()> {
+    let shape = ctx.shape_of(input)?;
+    let (Some(rows), Some(cols)) = (shape[0].constant_value(), shape[1].constant_value()) else {
+        return Ok(());
+    };
+    let (rows_size, cols_size) = tenferro_ops::ad::context::resolve_and_guard(
+        &DimExpr::Const(rows),
+        &DimExpr::Const(cols),
+        ctx,
+    )
+    .map_err(|err| {
+        invalid_input(
+            op,
+            rule,
+            format!("invalid matrix dimension expression: {err}"),
+        )
+    })?;
+    if rows_size != cols_size {
+        return Err(invalid_input(
+            op,
+            rule,
+            format!("expected square matrix operand, got {rows_size}x{cols_size}"),
+        ));
+    }
+    Ok(())
 }
 
 fn triangular_solve_rhs_tangent(
@@ -280,17 +355,21 @@ pub(crate) fn transpose_triangular_solve(
     mode: &OperationRole,
     flags: TriangularSolveFlags,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(ct) = cotangent_out[0] else {
-        return vec![None, None];
+        return Ok(vec![None, None]);
     };
     let OperationRole::Linearized { active_mask } = mode else {
-        return vec![None, None];
+        return Ok(vec![None, None]);
     };
 
     let mut result = vec![None, None];
     if active_mask[0] || active_mask[1] {
-        let dtype = ctx.dtype_of(&inputs[0]);
+        let rank = ctx.shape_of(&inputs[0])?.len();
+        let rhs_rank = ctx.shape_of(&inputs[1])?.len();
+        validate_matrix_operands("triangular_solve", ADRuleKind::Transpose, rank, rhs_rank)?;
+        validate_square_matrix_input("triangular_solve", ADRuleKind::Transpose, &inputs[0], ctx)?;
+        let dtype = ctx.dtype_of(&inputs[0])?;
         let conjugated_a = conjugate_primal_if_dtype_complex(builder, inputs[0].clone(), dtype);
         let out = builder.add_operation(
             flags.transposed().std_op(),
@@ -301,7 +380,6 @@ pub(crate) fn transpose_triangular_solve(
         );
         let rhs_cotangent = out[0];
         if active_mask[0] {
-            let rank = ctx.shape_of(&inputs[0]).len();
             let solution = builder.add_operation(
                 linalg_std_op(LinalgOp::TriangularSolve {
                     left_side: flags.left_side,
@@ -334,7 +412,7 @@ pub(crate) fn transpose_triangular_solve(
         }
     }
 
-    result
+    Ok(result)
 }
 
 fn transpose_linear_solve(
@@ -345,17 +423,21 @@ fn transpose_linear_solve(
     transpose_a: bool,
     ctx: &mut ShapeGuardContext,
     kind: LinearSolveOp,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(ct) = cotangent_out[0] else {
-        return vec![None, None];
+        return Ok(vec![None, None]);
     };
     let OperationRole::Linearized { active_mask } = mode else {
-        return vec![None, None];
+        return Ok(vec![None, None]);
     };
 
     let mut result = vec![None, None];
     if active_mask[0] || active_mask[1] {
-        let dtype = ctx.dtype_of(&inputs[0]);
+        let rank = ctx.shape_of(&inputs[0])?.len();
+        let rhs_rank = ctx.shape_of(&inputs[1])?.len();
+        validate_matrix_operands(kind.op_name(), ADRuleKind::Transpose, rank, rhs_rank)?;
+        validate_square_matrix_input(kind.op_name(), ADRuleKind::Transpose, &inputs[0], ctx)?;
+        let dtype = ctx.dtype_of(&inputs[0])?;
         let conjugated_a = conjugate_primal_if_dtype_complex(builder, inputs[0].clone(), dtype);
         let out = builder.add_operation(
             linear_solve_op(kind, !transpose_a),
@@ -366,7 +448,6 @@ fn transpose_linear_solve(
         );
         let rhs_cotangent = out[0];
         if active_mask[0] {
-            let rank = ctx.shape_of(&inputs[0]).len();
             let solution = builder.add_operation(
                 linear_solve_op(kind, transpose_a),
                 inputs.to_vec(),
@@ -387,7 +468,7 @@ fn transpose_linear_solve(
         }
     }
 
-    result
+    Ok(result)
 }
 
 pub(crate) fn transpose_lu_solve_prepared(
@@ -437,7 +518,7 @@ pub(crate) fn transpose_full_piv_lu_solve(
     mode: &OperationRole,
     transpose_a: bool,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     transpose_linear_solve(
         builder,
         cotangent_out,

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -356,7 +356,7 @@ impl LinalgBackend for CpuBackend {
         ensure_host_tensor("full_piv_lu_solve", b)?;
         ensure_supported_linalg_pair("full_piv_lu_solve", a, b)?;
         if has_zero_dim(a.shape()) || has_zero_dim(b.shape()) {
-            return Ok(zeros_like_tensor(b));
+            return zeros_like_tensor(b);
         }
 
         let (rhs, restore_shape) = if let Some(matrix_rhs_shape) = batched_vector_rhs_shape(a, b) {
@@ -807,7 +807,7 @@ impl LinalgBackend for CpuBackend {
             });
         }
         if has_zero_dim(a.shape()) || has_zero_dim(b.shape()) {
-            return Ok(zeros_like_tensor(b));
+            return zeros_like_tensor(b);
         }
 
         let (rhs, restore_shape) = if let Some(matrix_rhs_shape) = batched_vector_rhs_shape(a, b) {
@@ -848,7 +848,7 @@ impl LinalgBackend for CpuBackend {
         ensure_host_tensor("solve", b)?;
         ensure_supported_linalg_pair("solve", a, b)?;
         if has_zero_dim(a.shape()) || has_zero_dim(b.shape()) {
-            return Ok(zeros_like_tensor(b));
+            return zeros_like_tensor(b);
         }
 
         let (rhs, restore_shape) = if let Some(matrix_rhs_shape) = batched_vector_rhs_shape(a, b) {
@@ -991,37 +991,41 @@ fn batched_vector_rhs_shape(a: &Tensor, b: &Tensor) -> Option<Vec<usize>> {
     Some(rhs_shape)
 }
 
-fn zeros_like_tensor(input: &Tensor) -> Tensor {
-    match input {
-        Tensor::F32(t) => Tensor::F32(TypedTensor::zeros(t.shape().to_vec())),
-        Tensor::F64(t) => Tensor::F64(TypedTensor::zeros(t.shape().to_vec())),
-        Tensor::I32(t) => Tensor::I32(TypedTensor::zeros(t.shape().to_vec())),
-        Tensor::I64(t) => Tensor::I64(TypedTensor::zeros(t.shape().to_vec())),
+fn zeros_like_tensor(input: &Tensor) -> tenferro_tensor::Result<Tensor> {
+    Ok(match input {
+        Tensor::F32(t) => Tensor::F32(TypedTensor::zeros(t.shape().to_vec())?),
+        Tensor::F64(t) => Tensor::F64(TypedTensor::zeros(t.shape().to_vec())?),
+        Tensor::I32(t) => Tensor::I32(TypedTensor::zeros(t.shape().to_vec())?),
+        Tensor::I64(t) => Tensor::I64(TypedTensor::zeros(t.shape().to_vec())?),
         Tensor::Bool(t) => Tensor::Bool(TypedTensor::from_vec_col_major(
             t.shape().to_vec(),
             vec![false; t.n_elements()],
-        )),
-        Tensor::C32(t) => Tensor::C32(TypedTensor::zeros(t.shape().to_vec())),
-        Tensor::C64(t) => Tensor::C64(TypedTensor::zeros(t.shape().to_vec())),
-    }
+        )?),
+        Tensor::C32(t) => Tensor::C32(TypedTensor::zeros(t.shape().to_vec())?),
+        Tensor::C64(t) => Tensor::C64(TypedTensor::zeros(t.shape().to_vec())?),
+    })
 }
 
-fn complex32_real_part_tensor(values: TypedTensor<Complex32>) -> TypedTensor<f32> {
+fn complex32_real_part_tensor(
+    values: TypedTensor<Complex32>,
+) -> tenferro_tensor::Result<TypedTensor<f32>> {
     let mut out = TypedTensor::from_vec_col_major(
         values.shape().to_vec(),
-        values.host_data().iter().map(|value| value.re).collect(),
-    );
+        values.host_data()?.iter().map(|value| value.re).collect(),
+    )?;
     out.set_placement(values.placement().clone());
-    out
+    Ok(out)
 }
 
-fn complex64_real_part_tensor(values: TypedTensor<Complex64>) -> TypedTensor<f64> {
+fn complex64_real_part_tensor(
+    values: TypedTensor<Complex64>,
+) -> tenferro_tensor::Result<TypedTensor<f64>> {
     let mut out = TypedTensor::from_vec_col_major(
         values.shape().to_vec(),
-        values.host_data().iter().map(|value| value.re).collect(),
-    );
+        values.host_data()?.iter().map(|value| value.re).collect(),
+    )?;
     out.set_placement(values.placement().clone());
-    out
+    Ok(out)
 }
 
 fn svd_output_count_error(count: usize) -> Error {
@@ -1054,7 +1058,7 @@ fn full_piv_lu_c32_outputs_to_public_tensors(
             Tensor::C32(l),
             Tensor::C32(u),
             Tensor::C32(q),
-            Tensor::F32(complex32_real_part_tensor(parity)),
+            Tensor::F32(complex32_real_part_tensor(parity)?),
         ]),
         _ => Err(full_piv_lu_output_count_error(count)),
     }
@@ -1078,7 +1082,7 @@ fn full_piv_lu_c64_outputs_to_public_tensors(
             Tensor::C64(l),
             Tensor::C64(u),
             Tensor::C64(q),
-            Tensor::F64(complex64_real_part_tensor(parity)),
+            Tensor::F64(complex64_real_part_tensor(parity)?),
         ]),
         _ => Err(full_piv_lu_output_count_error(count)),
     }
@@ -1097,7 +1101,7 @@ fn svd_c32_outputs_to_public_tensors(
     ) {
         (Some(u), Some(values), Some(vt), None) => Ok(vec![
             Tensor::C32(u),
-            Tensor::F32(complex32_real_part_tensor(values)),
+            Tensor::F32(complex32_real_part_tensor(values)?),
             Tensor::C32(vt),
         ]),
         _ => Err(svd_output_count_error(count)),
@@ -1117,7 +1121,7 @@ fn svd_c64_outputs_to_public_tensors(
     ) {
         (Some(u), Some(values), Some(vt), None) => Ok(vec![
             Tensor::C64(u),
-            Tensor::F64(complex64_real_part_tensor(values)),
+            Tensor::F64(complex64_real_part_tensor(values)?),
             Tensor::C64(vt),
         ]),
         _ => Err(svd_output_count_error(count)),
@@ -1131,7 +1135,7 @@ fn eigh_c32_outputs_to_public_tensors(
     let mut outputs = outputs.into_iter();
     match (outputs.next(), outputs.next(), outputs.next()) {
         (Some(values), Some(vectors), None) => Ok(vec![
-            Tensor::F32(complex32_real_part_tensor(values)),
+            Tensor::F32(complex32_real_part_tensor(values)?),
             Tensor::C32(vectors),
         ]),
         _ => Err(eigh_output_count_error(count)),
@@ -1145,7 +1149,7 @@ fn eigh_c64_outputs_to_public_tensors(
     let mut outputs = outputs.into_iter();
     match (outputs.next(), outputs.next(), outputs.next()) {
         (Some(values), Some(vectors), None) => Ok(vec![
-            Tensor::F64(complex64_real_part_tensor(values)),
+            Tensor::F64(complex64_real_part_tensor(values)?),
             Tensor::C64(vectors),
         ]),
         _ => Err(eigh_output_count_error(count)),
@@ -1201,13 +1205,15 @@ fn apply_lu_pivots_typed<T: Clone>(
     let batch_total = batch_count(&shape[2..]);
     let matrix_stride = rows * cols;
     let pivot_stride = k;
-    let mut data = Vec::with_capacity(input.host_data().len());
+    let input_data = input.host_data()?;
+    let pivot_data = pivots.host_data()?;
+    let mut data = Vec::with_capacity(input_data.len());
 
     for batch in 0..batch_total {
         let mut perm: Vec<usize> = (0..rows).collect();
         let pivot_offset = batch * pivot_stride;
         for step in 0..k {
-            let pivot_one_based = pivots.host_data()[pivot_offset + step];
+            let pivot_one_based = pivot_data[pivot_offset + step];
             if pivot_one_based <= 0 {
                 return Err(Error::backend_failure(
                     "lu_solve_prepared",
@@ -1237,12 +1243,12 @@ fn apply_lu_pivots_typed<T: Clone>(
         let batch_offset = batch * matrix_stride;
         for col in 0..cols {
             for &source_row in &row_map {
-                data.push(input.host_data()[batch_offset + source_row + col * rows].clone());
+                data.push(input_data[batch_offset + source_row + col * rows].clone());
             }
         }
     }
 
-    Ok(TypedTensor::from_vec_col_major(shape.to_vec(), data))
+    TypedTensor::from_vec_col_major(shape.to_vec(), data)
 }
 
 fn validate_lu_solve_prepared_shapes(

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -121,7 +121,10 @@ fn tensor_from_vec_with_template<T: Clone, U>(
     data: Vec<T>,
     template: &TypedTensor<U>,
 ) -> TypedTensor<T> {
-    let mut tensor = TypedTensor::from_vec_col_major(shape, data);
+    // faer outputs are assembled from validated matrix dimensions and buffers
+    // sized by the same dimensions, so mismatch here is an internal backend bug.
+    let mut tensor =
+        TypedTensor::from_vec_col_major(shape, data).expect("faer output shape/data match");
     tensor.set_placement(template.placement().clone());
     tensor
 }
@@ -138,7 +141,11 @@ fn tensor_from_pooled_slice_with_template<T: Clone + PoolScalar, U>(
 }
 
 fn refill_tensor_from_slice<T: Copy>(tensor: &mut TypedTensor<T>, data: &[T]) {
-    tensor.host_data_mut().copy_from_slice(data);
+    // Batch scratch tensors are created as host tensors by this module.
+    tensor
+        .host_data_mut()
+        .expect("faer batch scratch tensor is host-backed")
+        .copy_from_slice(data);
 }
 
 fn col_major_vec_from_mat<T: Copy + PoolScalar>(
@@ -559,14 +566,14 @@ where
     let mut batch_input = tensor_from_pooled_slice_with_template(
         buffers,
         core_shape.to_vec(),
-        &input.host_data()[first_range],
+        &input.host_data()?[first_range],
         input,
     );
 
     for batch_idx in 0..batch_count {
         if batch_idx > 0 {
             let range = checked_slice_range(op_name, batch_idx, slice_size)?;
-            refill_tensor_from_slice(&mut batch_input, &input.host_data()[range]);
+            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[range]);
         }
         let batch_output = op(buffers, &batch_input)?;
 
@@ -588,7 +595,7 @@ where
         }
 
         match &mut out_data {
-            Some(data) => data.extend_from_slice(batch_output.host_data()),
+            Some(data) => data.extend_from_slice(batch_output.host_data()?),
             None => {
                 return Err(invalid_config(
                     op_name,
@@ -637,14 +644,14 @@ where
     let mut batch_input = tensor_from_pooled_slice_with_template(
         buffers,
         core_shape.to_vec(),
-        &input.host_data()[first_range],
+        &input.host_data()?[first_range],
         input,
     );
 
     for batch_idx in 0..batch_count {
         if batch_idx > 0 {
             let range = checked_slice_range(op_name, batch_idx, slice_size)?;
-            refill_tensor_from_slice(&mut batch_input, &input.host_data()[range]);
+            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[range]);
         }
         let batch_outputs = op(buffers, &batch_input)?;
 
@@ -680,7 +687,7 @@ where
                     rhs: out_shapes[idx].clone(),
                 });
             }
-            out_data[idx].extend_from_slice(batch_output.host_data());
+            out_data[idx].extend_from_slice(batch_output.host_data()?);
         }
     }
 
@@ -727,14 +734,14 @@ where
     let mut batch_input = tensor_from_pooled_slice_with_template(
         buffers,
         core_shape.to_vec(),
-        &input.host_data()[first_range],
+        &input.host_data()?[first_range],
         input,
     );
 
     for batch_idx in 0..batch_count {
         if batch_idx > 0 {
             let range = checked_slice_range(op_name, batch_idx, slice_size)?;
-            refill_tensor_from_slice(&mut batch_input, &input.host_data()[range]);
+            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[range]);
         }
         let batch_outputs = op(buffers, &batch_input)?;
 
@@ -770,7 +777,7 @@ where
                     rhs: out_shapes[idx].clone(),
                 });
             }
-            out_data[idx].extend_from_slice(batch_output.host_data());
+            out_data[idx].extend_from_slice(batch_output.host_data()?);
         }
     }
 
@@ -833,13 +840,13 @@ where
     let mut batch_a = tensor_from_pooled_slice_with_template(
         buffers,
         a_core_shape.to_vec(),
-        &a.host_data()[first_a_range],
+        &a.host_data()?[first_a_range],
         a,
     );
     let mut batch_b = tensor_from_pooled_slice_with_template(
         buffers,
         b_core_shape.to_vec(),
-        &b.host_data()[first_b_range],
+        &b.host_data()?[first_b_range],
         b,
     );
 
@@ -847,8 +854,8 @@ where
         if batch_idx > 0 {
             let a_range = checked_slice_range(op_name, batch_idx, a_slice_size)?;
             let b_range = checked_slice_range(op_name, batch_idx, b_slice_size)?;
-            refill_tensor_from_slice(&mut batch_a, &a.host_data()[a_range]);
-            refill_tensor_from_slice(&mut batch_b, &b.host_data()[b_range]);
+            refill_tensor_from_slice(&mut batch_a, &a.host_data()?[a_range]);
+            refill_tensor_from_slice(&mut batch_b, &b.host_data()?[b_range]);
         }
         let batch_output = op(buffers, &batch_a, &batch_b)?;
 
@@ -870,7 +877,7 @@ where
         }
 
         match &mut out_data {
-            Some(data) => data.extend_from_slice(batch_output.host_data()),
+            Some(data) => data.extend_from_slice(batch_output.host_data()?),
             None => {
                 return Err(invalid_config(
                     op_name,
@@ -903,7 +910,7 @@ macro_rules! impl_faer_linalg_for_real {
     ) -> tenferro_tensor::Result<TypedTensor<Self>> {
         let n = square_matrix_dim(input, "cholesky")?;
         let mut l = Mat::zeros(n, n);
-        l.copy_from(MatRef::from_column_major_slice(input.host_data(), n, n));
+        l.copy_from(MatRef::from_column_major_slice(input.host_data()?, n, n));
         let mut mem = MemBuffer::new(
             faer::linalg::cholesky::llt::factor::cholesky_in_place_scratch::<Self>(
                 n,
@@ -935,7 +942,7 @@ macro_rules! impl_faer_linalg_for_real {
         let (m, n) = matrix_dims(input, "lu")?;
         let k = m.min(n);
         let mut lu = Mat::zeros(m, n);
-        lu.copy_from(MatRef::from_column_major_slice(input.host_data(), m, n));
+        lu.copy_from(MatRef::from_column_major_slice(input.host_data()?, m, n));
         let mut perm = vec![0usize; m];
         let mut perm_inv = vec![0usize; m];
         let mut mem = MemBuffer::new(
@@ -989,7 +996,7 @@ macro_rules! impl_faer_linalg_for_real {
         let (m, n) = matrix_dims(input, "lu_factor")?;
         let k = m.min(n);
         let mut lu = Mat::zeros(m, n);
-        lu.copy_from(MatRef::from_column_major_slice(input.host_data(), m, n));
+        lu.copy_from(MatRef::from_column_major_slice(input.host_data()?, m, n));
         let mut perm = vec![0usize; m];
         let mut perm_inv = vec![0usize; m];
         let mut mem = MemBuffer::new(
@@ -1031,7 +1038,7 @@ macro_rules! impl_faer_linalg_for_real {
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let n = square_matrix_dim(input, "full_piv_lu")?;
         let mut lu = Mat::zeros(n, n);
-        lu.copy_from(MatRef::from_column_major_slice(input.host_data(), n, n));
+        lu.copy_from(MatRef::from_column_major_slice(input.host_data()?, n, n));
         let mut row_perm = vec![0usize; n];
         let mut row_perm_inv = vec![0usize; n];
         let mut col_perm = vec![0usize; n];
@@ -1095,7 +1102,7 @@ macro_rules! impl_faer_linalg_for_real {
         }
 
         let mut lu = Mat::zeros(n, n);
-        lu.copy_from(MatRef::from_column_major_slice(a.host_data(), n, n));
+        lu.copy_from(MatRef::from_column_major_slice(a.host_data()?, n, n));
         let mut row_perm = vec![0usize; n];
         let mut row_perm_inv = vec![0usize; n];
         let mut col_perm = vec![0usize; n];
@@ -1125,8 +1132,8 @@ macro_rules! impl_faer_linalg_for_real {
             }
         }
 
-        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
-        rhs_data.extend_from_slice(b.host_data());
+        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data()?.len());
+        rhs_data.extend_from_slice(b.host_data()?);
         let rhs = MatMut::from_column_major_slice_mut(&mut rhs_data, n, b_cols);
         let mut mem = MemBuffer::new(
             faer::linalg::lu::full_pivoting::solve::solve_in_place_scratch::<usize, Self>(
@@ -1178,7 +1185,7 @@ macro_rules! impl_faer_linalg_for_real {
         }
 
         let mut lu = Mat::zeros(n, n);
-        lu.copy_from(MatRef::from_column_major_slice(a.host_data(), n, n));
+        lu.copy_from(MatRef::from_column_major_slice(a.host_data()?, n, n));
         let mut row_perm = vec![0usize; n];
         let mut row_perm_inv = vec![0usize; n];
         let mut mem = MemBuffer::new(
@@ -1204,8 +1211,8 @@ macro_rules! impl_faer_linalg_for_real {
             }
         }
 
-        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
-        rhs_data.extend_from_slice(b.host_data());
+        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data()?.len());
+        rhs_data.extend_from_slice(b.host_data()?);
         let rhs = MatMut::from_column_major_slice_mut(&mut rhs_data, n, b_cols);
         let mut mem = MemBuffer::new(if transpose_a {
             faer::linalg::lu::partial_pivoting::solve::solve_transpose_in_place_scratch::<
@@ -1254,7 +1261,7 @@ macro_rules! impl_faer_linalg_for_real {
     ) -> tenferro_tensor::Result<TypedTensor<Self>> {
         let n = square_matrix_dim(a, "triangular_solve")?;
         let (b_rows, b_cols) = matrix_dims(b, "triangular_solve")?;
-        let a_mat = MatRef::from_column_major_slice(a.host_data(), n, n);
+        let a_mat = MatRef::from_column_major_slice(a.host_data()?, n, n);
 
         if left_side {
             if b_rows != n {
@@ -1264,8 +1271,8 @@ macro_rules! impl_faer_linalg_for_real {
                     rhs: vec![b_rows],
                 });
             }
-            let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
-            rhs_data.extend_from_slice(b.host_data());
+            let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data()?.len());
+            rhs_data.extend_from_slice(b.host_data()?);
             let rhs = MatMut::from_column_major_slice_mut(&mut rhs_data, n, b_cols);
             match (transpose_a, lower, unit_diagonal) {
                 (false, true, false) => {
@@ -1335,7 +1342,7 @@ macro_rules! impl_faer_linalg_for_real {
                 });
             }
             let nrhs = b_rows;
-            let mut rhs_transposed = transpose_col_major_data(buffers, b.host_data(), nrhs, n);
+            let mut rhs_transposed = transpose_col_major_data(buffers, b.host_data()?, nrhs, n);
             let rhs = MatMut::from_column_major_slice_mut(&mut rhs_transposed, n, nrhs);
             match (transpose_a, lower, unit_diagonal) {
                 (false, true, false) => {
@@ -1408,7 +1415,7 @@ macro_rules! impl_faer_linalg_for_real {
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "svd")?;
         let k = m.min(n);
-        let mat = MatRef::from_column_major_slice(input.host_data(), m, n);
+        let mat = MatRef::from_column_major_slice(input.host_data()?, m, n);
         let mut u = Mat::zeros(m, k);
         let mut v = Mat::zeros(n, k);
         let mut s = Diag::zeros(k);
@@ -1456,7 +1463,7 @@ macro_rules! impl_faer_linalg_for_real {
     ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
         let (m, n) = matrix_dims(input, "svd_values")?;
         let k = m.min(n);
-        let mat = MatRef::from_column_major_slice(input.host_data(), m, n);
+        let mat = MatRef::from_column_major_slice(input.host_data()?, m, n);
         let mut s = Diag::zeros(k);
         let mut mem = MemBuffer::new(faer::linalg::svd::svd_scratch::<Self>(
             m,
@@ -1488,7 +1495,7 @@ macro_rules! impl_faer_linalg_for_real {
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "qr")?;
         let k = m.min(n);
-        let mat = MatRef::from_column_major_slice(input.host_data(), m, n);
+        let mat = MatRef::from_column_major_slice(input.host_data()?, m, n);
         let block_size =
             faer::linalg::qr::no_pivoting::factor::recommended_block_size::<Self>(m, n);
         let mut qr = Mat::zeros(m, n);
@@ -1548,7 +1555,7 @@ macro_rules! impl_faer_linalg_for_real {
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let n = square_matrix_dim(input, "eigh")?;
-        let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
+        let mat = MatRef::from_column_major_slice(input.host_data()?, n, n);
         let mut values = Diag::zeros(n);
         let mut vectors = Mat::zeros(n, n);
         let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<Self>(
@@ -1585,7 +1592,7 @@ macro_rules! impl_faer_linalg_for_real {
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
         let n = square_matrix_dim(input, "eigh_values")?;
-        let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
+        let mat = MatRef::from_column_major_slice(input.host_data()?, n, n);
         let mut values = Diag::zeros(n);
         let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<Self>(
             n,
@@ -1640,7 +1647,7 @@ macro_rules! impl_faer_linalg_for_complex {
         let n = square_matrix_dim(input, "cholesky")?;
         let mut l = Mat::zeros(n, n);
         l.copy_from(MatRef::from_column_major_slice(
-            $to_faer_slice(input.host_data()),
+            $to_faer_slice(input.host_data()?),
             n,
             n,
         ));
@@ -1676,7 +1683,7 @@ macro_rules! impl_faer_linalg_for_complex {
         let k = m.min(n);
         let mut lu = Mat::zeros(m, n);
         lu.copy_from(MatRef::from_column_major_slice(
-            $to_faer_slice(input.host_data()),
+            $to_faer_slice(input.host_data()?),
             m,
             n,
         ));
@@ -1733,7 +1740,7 @@ macro_rules! impl_faer_linalg_for_complex {
         let k = m.min(n);
         let mut lu = Mat::zeros(m, n);
         lu.copy_from(MatRef::from_column_major_slice(
-            $to_faer_slice(input.host_data()),
+            $to_faer_slice(input.host_data()?),
             m,
             n,
         ));
@@ -1779,7 +1786,7 @@ macro_rules! impl_faer_linalg_for_complex {
         let n = square_matrix_dim(input, "full_piv_lu")?;
         let mut lu = Mat::zeros(n, n);
         lu.copy_from(MatRef::from_column_major_slice(
-            $to_faer_slice(input.host_data()),
+            $to_faer_slice(input.host_data()?),
             n,
             n,
         ));
@@ -1848,7 +1855,7 @@ macro_rules! impl_faer_linalg_for_complex {
 
         let mut lu = Mat::zeros(n, n);
         lu.copy_from(MatRef::from_column_major_slice(
-            $to_faer_slice(a.host_data()),
+            $to_faer_slice(a.host_data()?),
             n,
             n,
         ));
@@ -1882,8 +1889,8 @@ macro_rules! impl_faer_linalg_for_complex {
             }
         }
 
-        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
-        rhs_data.extend_from_slice(b.host_data());
+        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data()?.len());
+        rhs_data.extend_from_slice(b.host_data()?);
         let rhs = MatMut::from_column_major_slice_mut(
             $to_faer_slice_mut(&mut rhs_data),
             n,
@@ -1940,7 +1947,7 @@ macro_rules! impl_faer_linalg_for_complex {
 
         let mut lu = Mat::zeros(n, n);
         lu.copy_from(MatRef::from_column_major_slice(
-            $to_faer_slice(a.host_data()),
+            $to_faer_slice(a.host_data()?),
             n,
             n,
         ));
@@ -1970,8 +1977,8 @@ macro_rules! impl_faer_linalg_for_complex {
             }
         }
 
-        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
-        rhs_data.extend_from_slice(b.host_data());
+        let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data()?.len());
+        rhs_data.extend_from_slice(b.host_data()?);
         let rhs =
             MatMut::from_column_major_slice_mut($to_faer_slice_mut(&mut rhs_data), n, b_cols);
         let mut mem = MemBuffer::new(if transpose_a {
@@ -2020,7 +2027,7 @@ macro_rules! impl_faer_linalg_for_complex {
     ) -> tenferro_tensor::Result<TypedTensor<Self>> {
         let n = square_matrix_dim(a, "triangular_solve")?;
         let (b_rows, b_cols) = matrix_dims(b, "triangular_solve")?;
-        let a_mat = MatRef::from_column_major_slice($to_faer_slice(a.host_data()), n, n);
+        let a_mat = MatRef::from_column_major_slice($to_faer_slice(a.host_data()?), n, n);
 
         if left_side {
             if b_rows != n {
@@ -2030,8 +2037,8 @@ macro_rules! impl_faer_linalg_for_complex {
                     rhs: vec![b_rows],
                 });
             }
-            let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data().len());
-            rhs_data.extend_from_slice(b.host_data());
+            let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data()?.len());
+            rhs_data.extend_from_slice(b.host_data()?);
             let rhs = MatMut::from_column_major_slice_mut(
                 $to_faer_slice_mut(&mut rhs_data),
                 n,
@@ -2105,7 +2112,7 @@ macro_rules! impl_faer_linalg_for_complex {
                 });
             }
             let nrhs = b_rows;
-            let mut rhs_transposed = transpose_col_major_data(buffers, b.host_data(), nrhs, n);
+            let mut rhs_transposed = transpose_col_major_data(buffers, b.host_data()?, nrhs, n);
             let rhs = MatMut::from_column_major_slice_mut(
                 $to_faer_slice_mut(&mut rhs_transposed),
                 n,
@@ -2182,7 +2189,7 @@ macro_rules! impl_faer_linalg_for_complex {
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "svd")?;
         let k = m.min(n);
-        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), m, n);
+        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()?), m, n);
         let mut u = Mat::zeros(m, k);
         let mut v = Mat::zeros(n, k);
         let mut s = Diag::zeros(k);
@@ -2234,7 +2241,7 @@ macro_rules! impl_faer_linalg_for_complex {
     ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
         let (m, n) = matrix_dims(input, "svd_values")?;
         let k = m.min(n);
-        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), m, n);
+        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()?), m, n);
         let mut s = Diag::zeros(k);
         let mut mem = MemBuffer::new(faer::linalg::svd::svd_scratch::<$faer_complex>(
             m,
@@ -2271,7 +2278,7 @@ macro_rules! impl_faer_linalg_for_complex {
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "qr")?;
         let k = m.min(n);
-        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), m, n);
+        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()?), m, n);
         let block_size =
             faer::linalg::qr::no_pivoting::factor::recommended_block_size::<$faer_complex>(m, n);
         let mut qr = Mat::zeros(m, n);
@@ -2331,7 +2338,7 @@ macro_rules! impl_faer_linalg_for_complex {
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let n = square_matrix_dim(input, "eigh")?;
-        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), n, n);
+        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()?), n, n);
         let mut values = Diag::zeros(n);
         let mut vectors = Mat::zeros(n, n);
         let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<$faer_complex>(
@@ -2371,7 +2378,7 @@ macro_rules! impl_faer_linalg_for_complex {
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
         let n = square_matrix_dim(input, "eigh_values")?;
-        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), n, n);
+        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()?), n, n);
         let mut values = Diag::zeros(n);
         let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<$faer_complex>(
             n,
@@ -2519,7 +2526,7 @@ pub(crate) fn lu_factor<T: FaerLinalg>(
     let mut batch_input = tensor_from_pooled_slice_with_template(
         buffers,
         vec![m, n],
-        &input.host_data()[first_range],
+        &input.host_data()?[first_range],
         input,
     );
 
@@ -2527,12 +2534,12 @@ pub(crate) fn lu_factor<T: FaerLinalg>(
         if batch > 0 {
             let start = batch * matrix_len;
             let end = start + matrix_len;
-            refill_tensor_from_slice(&mut batch_input, &input.host_data()[start..end]);
+            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[start..end]);
         }
         let (packed, pivots, parity) = T::lu_factor_2d(ctx, buffers, &batch_input)?;
-        lu_data.extend_from_slice(packed.host_data());
-        pivot_data.extend_from_slice(pivots.host_data());
-        parity_data.extend_from_slice(parity.host_data());
+        lu_data.extend_from_slice(packed.host_data()?);
+        pivot_data.extend_from_slice(pivots.host_data()?);
+        parity_data.extend_from_slice(parity.host_data()?);
     }
 
     Ok((
@@ -2834,7 +2841,7 @@ macro_rules! impl_eig_real_2d {
             input: &TypedTensor<$real>,
         ) -> tenferro_tensor::Result<Vec<TypedTensor<$complex>>> {
             let n = square_matrix_dim(input, "eig")?;
-            let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
+            let mat = MatRef::from_column_major_slice(input.host_data()?, n, n);
             let mut u_real = Mat::zeros(n, n);
             let mut s_re = Diag::zeros(n);
             let mut s_im = Diag::zeros(n);
@@ -2880,7 +2887,7 @@ macro_rules! impl_eig_values_real_2d {
             input: &TypedTensor<$real>,
         ) -> tenferro_tensor::Result<TypedTensor<$complex>> {
             let n = square_matrix_dim(input, "eig_values")?;
-            let mat = MatRef::from_column_major_slice(input.host_data(), n, n);
+            let mat = MatRef::from_column_major_slice(input.host_data()?, n, n);
             let mut s_re = Diag::zeros(n);
             let mut s_im = Diag::zeros(n);
             let mut mem = MemBuffer::new(faer::linalg::evd::evd_scratch::<$real>(
@@ -2924,7 +2931,7 @@ macro_rules! impl_eig_complex_2d {
             input: &TypedTensor<$complex>,
         ) -> tenferro_tensor::Result<Vec<TypedTensor<$complex>>> {
             let n = square_matrix_dim(input, "eig")?;
-            let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), n, n);
+            let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()?), n, n);
             let mut u = Mat::zeros(n, n);
             let mut s = Diag::zeros(n);
             let mut mem = MemBuffer::new(faer::linalg::evd::evd_scratch::<$faer_complex>(
@@ -2972,7 +2979,7 @@ macro_rules! impl_eig_values_complex_2d {
             input: &TypedTensor<$complex>,
         ) -> tenferro_tensor::Result<TypedTensor<$complex>> {
             let n = square_matrix_dim(input, "eig_values")?;
-            let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()), n, n);
+            let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()?), n, n);
             let mut s = Diag::zeros(n);
             let mut mem = MemBuffer::new(faer::linalg::evd::evd_scratch::<$faer_complex>(
                 n,
@@ -3066,12 +3073,12 @@ pub(crate) fn eig(
         let vector_shape = matrix_with_batch_shape(n, n, batch_shape);
         return match input {
             Tensor::F32(_) | Tensor::C32(_) => Ok(vec![
-                Tensor::C32(TypedTensor::from_vec_col_major(value_shape, Vec::new())),
-                Tensor::C32(TypedTensor::from_vec_col_major(vector_shape, Vec::new())),
+                Tensor::C32(TypedTensor::from_vec_col_major(value_shape, Vec::new())?),
+                Tensor::C32(TypedTensor::from_vec_col_major(vector_shape, Vec::new())?),
             ]),
             Tensor::F64(_) | Tensor::C64(_) => Ok(vec![
-                Tensor::C64(TypedTensor::from_vec_col_major(value_shape, Vec::new())),
-                Tensor::C64(TypedTensor::from_vec_col_major(vector_shape, Vec::new())),
+                Tensor::C64(TypedTensor::from_vec_col_major(value_shape, Vec::new())?),
+                Tensor::C64(TypedTensor::from_vec_col_major(vector_shape, Vec::new())?),
             ]),
             _ => Err(tenferro_tensor::Error::backend_failure(
                 "eig",
@@ -3149,11 +3156,11 @@ pub(crate) fn eig_values(
             Tensor::F32(_) | Tensor::C32(_) => Ok(Tensor::C32(TypedTensor::from_vec_col_major(
                 value_shape,
                 Vec::new(),
-            ))),
+            )?)),
             Tensor::F64(_) | Tensor::C64(_) => Ok(Tensor::C64(TypedTensor::from_vec_col_major(
                 value_shape,
                 Vec::new(),
-            ))),
+            )?)),
             _ => Err(tenferro_tensor::Error::backend_failure(
                 "eig_values",
                 format!("unsupported dtype {:?}", input.dtype()),

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/cholesky.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/cholesky.rs
@@ -51,7 +51,7 @@ fn cholesky_2d<T: LapackCholesky>(
 ) -> tenferro_tensor::Result<TypedTensor<T>> {
     let n = square_matrix_dim(input, "cholesky")?;
     let n_i32 = dim_i32(n, "cholesky")?;
-    let mut factor = input.host_data().to_vec();
+    let mut factor = input.host_data()?.to_vec();
     let mut info = 0;
     T::potrf(b'L', n_i32, &mut factor, n_i32, &mut info);
     if info > 0 {
@@ -61,11 +61,7 @@ fn cholesky_2d<T: LapackCholesky>(
         ));
     }
     check_lapack_info("cholesky", "dpotrf", info)?;
-    Ok(tensor_from_vec_with_template(
-        vec![n, n],
-        lower_triangle_from_lapack(&factor, n, n),
-        input,
-    ))
+    tensor_from_vec_with_template(vec![n, n], lower_triangle_from_lapack(&factor, n, n), input)
 }
 
 pub(crate) fn cholesky<T: LapackCholesky>(
@@ -74,11 +70,11 @@ pub(crate) fn cholesky<T: LapackCholesky>(
 ) -> tenferro_tensor::Result<TypedTensor<T>> {
     if has_zero_dim(input.shape()) {
         let (n, batch_shape) = square_core_and_batch_result(input, "cholesky")?;
-        return Ok(tensor_from_vec_with_template(
+        return tensor_from_vec_with_template(
             matrix_with_batch_shape(n, n, batch_shape),
             Vec::new(),
             input,
-        ));
+        );
     }
     batched_single("cholesky", buffers, input, cholesky_2d)
 }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eig.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eig.rs
@@ -68,7 +68,7 @@ macro_rules! impl_eig_real_2d {
         ) -> tenferro_tensor::Result<Vec<TypedTensor<$complex>>> {
             let n = square_matrix_dim(input, "eig")?;
             let n_i32 = dim_i32(n, "eig")?;
-            let mut a = input.host_data().to_vec();
+            let mut a = input.host_data()?.to_vec();
             let mut values_re = vec![0.0 as $real; n];
             let mut values_im = vec![0.0 as $real; n];
             let mut vl = vec![0.0 as $real; 1];
@@ -118,8 +118,8 @@ macro_rules! impl_eig_real_2d {
             let (vectors, values) = $convert(&vectors_real, &values_re, &values_im, n);
 
             Ok(vec![
-                tensor_from_vec_with_template(vec![n], values, input),
-                tensor_from_vec_with_template(vec![n, n], vectors, input),
+                tensor_from_vec_with_template(vec![n], values, input)?,
+                tensor_from_vec_with_template(vec![n, n], vectors, input)?,
             ])
         }
     };
@@ -133,7 +133,7 @@ macro_rules! impl_eig_values_real_2d {
         ) -> tenferro_tensor::Result<TypedTensor<$complex>> {
             let n = square_matrix_dim(input, "eig_values")?;
             let n_i32 = dim_i32(n, "eig_values")?;
-            let mut a = input.host_data().to_vec();
+            let mut a = input.host_data()?.to_vec();
             let mut values_re = vec![0.0 as $real; n];
             let mut values_im = vec![0.0 as $real; n];
             let mut vl = vec![0.0 as $real; 1];
@@ -182,7 +182,7 @@ macro_rules! impl_eig_values_real_2d {
             check_lapack_info("eig_values", $routine, info)?;
             let values = $convert(buffers, &values_re, &values_im, n);
 
-            Ok(tensor_from_vec_with_template(vec![n], values, input))
+            tensor_from_vec_with_template(vec![n], values, input)
         }
     };
 }
@@ -195,7 +195,7 @@ macro_rules! impl_eig_complex_2d {
         ) -> tenferro_tensor::Result<Vec<TypedTensor<$complex>>> {
             let n = square_matrix_dim(input, "eig")?;
             let n_i32 = dim_i32(n, "eig")?;
-            let mut a = input.host_data().to_vec();
+            let mut a = input.host_data()?.to_vec();
             let mut values = vec![<$complex>::new(0.0, 0.0); n];
             let mut vl = vec![<$complex>::new(0.0, 0.0); 1];
             let mut vectors = vec![<$complex>::new(0.0, 0.0); n * n];
@@ -244,8 +244,8 @@ macro_rules! impl_eig_complex_2d {
             check_lapack_info("eig", $routine, info)?;
 
             Ok(vec![
-                tensor_from_vec_with_template(vec![n], values, input),
-                tensor_from_vec_with_template(vec![n, n], vectors, input),
+                tensor_from_vec_with_template(vec![n], values, input)?,
+                tensor_from_vec_with_template(vec![n, n], vectors, input)?,
             ])
         }
     };
@@ -259,7 +259,7 @@ macro_rules! impl_eig_values_complex_2d {
         ) -> tenferro_tensor::Result<TypedTensor<$complex>> {
             let n = square_matrix_dim(input, "eig_values")?;
             let n_i32 = dim_i32(n, "eig_values")?;
-            let mut a = input.host_data().to_vec();
+            let mut a = input.host_data()?.to_vec();
             let mut values = vec![<$complex>::new(0.0, 0.0); n];
             let mut vl = vec![<$complex>::new(0.0, 0.0); 1];
             let mut vr = vec![<$complex>::new(0.0, 0.0); 1];
@@ -307,7 +307,7 @@ macro_rules! impl_eig_values_complex_2d {
             }
             check_lapack_info("eig_values", $routine, info)?;
 
-            Ok(tensor_from_vec_with_template(vec![n], values, input))
+            tensor_from_vec_with_template(vec![n], values, input)
         }
     };
 }
@@ -419,11 +419,11 @@ fn zero_dim_eig_values_output(input: &Tensor) -> tenferro_tensor::Result<Tensor>
         Tensor::F32(_) | Tensor::C32(_) => Ok(Tensor::C32(TypedTensor::from_vec_col_major(
             value_shape,
             Vec::new(),
-        ))),
+        )?)),
         Tensor::F64(_) | Tensor::C64(_) => Ok(Tensor::C64(TypedTensor::from_vec_col_major(
             value_shape,
             Vec::new(),
-        ))),
+        )?)),
         _ => Err(tenferro_tensor::Error::backend_failure(
             "eig_values",
             format!("unsupported dtype {:?}", input.dtype()),

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eigh.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eigh.rs
@@ -33,7 +33,7 @@ macro_rules! impl_real_eigh {
             ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
                 let n = square_matrix_dim(input, "eigh")?;
                 let n_i32 = dim_i32(n, "eigh")?;
-                let mut vectors = input.host_data().to_vec();
+                let mut vectors = input.host_data()?.to_vec();
                 let mut values = vec![0.0 as $scalar; n];
                 let mut query = vec![0.0 as $scalar; 1];
                 let mut info = 0;
@@ -69,8 +69,8 @@ macro_rules! impl_real_eigh {
                 check_lapack_info("eigh", $routine, info)?;
 
                 Ok(vec![
-                    tensor_from_vec_with_template(vec![n], values, input),
-                    tensor_from_vec_with_template(vec![n, n], vectors, input),
+                    tensor_from_vec_with_template(vec![n], values, input)?,
+                    tensor_from_vec_with_template(vec![n, n], vectors, input)?,
                 ])
             }
 
@@ -80,7 +80,7 @@ macro_rules! impl_real_eigh {
             ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
                 let n = square_matrix_dim(input, "eigh_values")?;
                 let n_i32 = dim_i32(n, "eigh_values")?;
-                let mut work_matrix = input.host_data().to_vec();
+                let mut work_matrix = input.host_data()?.to_vec();
                 let mut values = vec![0.0 as $scalar; n];
                 let mut query = vec![0.0 as $scalar; 1];
                 let mut info = 0;
@@ -115,7 +115,7 @@ macro_rules! impl_real_eigh {
                 }
                 check_lapack_info("eigh_values", $routine, info)?;
 
-                Ok(tensor_from_vec_with_template(vec![n], values, input))
+                tensor_from_vec_with_template(vec![n], values, input)
             }
         }
     };
@@ -132,7 +132,7 @@ macro_rules! impl_complex_eigh {
             ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
                 let n = square_matrix_dim(input, "eigh")?;
                 let n_i32 = dim_i32(n, "eigh")?;
-                let mut vectors = input.host_data().to_vec();
+                let mut vectors = input.host_data()?.to_vec();
                 let mut values = vec![0.0 as $real; n];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
                 let mut rwork = vec![0.0 as $real; (3 * n).saturating_sub(2).max(1)];
@@ -178,8 +178,8 @@ macro_rules! impl_complex_eigh {
                             .map(|value| <$complex>::new(value, 0.0))
                             .collect(),
                         input,
-                    ),
-                    tensor_from_vec_with_template(vec![n, n], vectors, input),
+                    )?,
+                    tensor_from_vec_with_template(vec![n, n], vectors, input)?,
                 ])
             }
 
@@ -189,7 +189,7 @@ macro_rules! impl_complex_eigh {
             ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
                 let n = square_matrix_dim(input, "eigh_values")?;
                 let n_i32 = dim_i32(n, "eigh_values")?;
-                let mut work_matrix = input.host_data().to_vec();
+                let mut work_matrix = input.host_data()?.to_vec();
                 let mut values = vec![0.0 as $real; n];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
                 let mut rwork = vec![0.0 as $real; (3 * n).saturating_sub(2).max(1)];
@@ -227,7 +227,7 @@ macro_rules! impl_complex_eigh {
                 }
                 check_lapack_info("eigh_values", $routine, info)?;
 
-                Ok(tensor_from_vec_with_template(vec![n], values, input))
+                tensor_from_vec_with_template(vec![n], values, input)
             }
         }
     };
@@ -256,12 +256,12 @@ pub(crate) fn eigh<T: LapackEigh>(
                 vector_with_batch_shape(n, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
         ]);
     }
     batched_multi("eigh", buffers, input, eigh_2d)
@@ -280,11 +280,11 @@ pub(crate) fn eigh_values<T: LapackEigh>(
 ) -> tenferro_tensor::Result<TypedTensor<T::Real>> {
     if has_zero_dim(input.shape()) {
         let (n, batch_shape) = square_core_and_batch_result(input, "eigh_values")?;
-        return Ok(tensor_from_vec_with_template(
+        return tensor_from_vec_with_template(
             vector_with_batch_shape(n, batch_shape),
             Vec::new(),
             input,
-        ));
+        );
     }
 
     let (core_shape, batch_shape) =
@@ -302,16 +302,12 @@ pub(crate) fn eigh_values<T: LapackEigh>(
         let end = start + slice_size;
         let batch_input = tensor_from_vec_with_template(
             core_shape.to_vec(),
-            input.host_data()[start..end].to_vec(),
+            input.host_data()?[start..end].to_vec(),
             input,
-        );
+        )?;
         let values = eigh_values_2d(buffers, &batch_input)?;
-        data.extend_from_slice(values.host_data());
+        data.extend_from_slice(values.host_data()?);
     }
 
-    Ok(tensor_from_vec_with_template(
-        vector_with_batch_shape(n, batch_shape),
-        data,
-        input,
-    ))
+    tensor_from_vec_with_template(vector_with_batch_shape(n, batch_shape), data, input)
 }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
@@ -454,7 +454,7 @@ fn full_piv_lu_2d<T: LapackFullPivLu>(
     input: &TypedTensor<T>,
 ) -> tenferro_tensor::Result<Vec<TypedTensor<T>>> {
     let n = square_matrix_dim(input, "full_piv_lu")?;
-    let mut lu = input.host_data().to_vec();
+    let mut lu = input.host_data()?.to_vec();
     let (ipiv, jpiv, _info) = factor_getc2("full_piv_lu", &mut lu, n)?;
 
     let row_perm = permutation_from_lapack_pivots(&ipiv, "full_piv_lu")?;
@@ -483,11 +483,11 @@ fn full_piv_lu_2d<T: LapackFullPivLu>(
     };
 
     Ok(vec![
-        tensor_from_vec_with_template(vec![n, n], p_data, input),
-        tensor_from_vec_with_template(vec![n, n], l_data, input),
-        tensor_from_vec_with_template(vec![n, n], u_data, input),
-        tensor_from_vec_with_template(vec![n, n], q_data, input),
-        tensor_from_vec_with_template(vec![], vec![parity], input),
+        tensor_from_vec_with_template(vec![n, n], p_data, input)?,
+        tensor_from_vec_with_template(vec![n, n], l_data, input)?,
+        tensor_from_vec_with_template(vec![n, n], u_data, input)?,
+        tensor_from_vec_with_template(vec![n, n], q_data, input)?,
+        tensor_from_vec_with_template(vec![], vec![parity], input)?,
     ])
 }
 
@@ -508,9 +508,9 @@ fn solve_2d<T: LapackFullPivLu>(
     }
 
     let mut lu = if transpose_a {
-        transpose_col_major_data(a.host_data(), n, n)
+        transpose_col_major_data(a.host_data()?, n, n)
     } else {
-        a.host_data().to_vec()
+        a.host_data()?.to_vec()
     };
     let (ipiv, jpiv, info) = factor_getc2("full_piv_lu_solve", &mut lu, n)?;
     if info > 0 {
@@ -520,7 +520,7 @@ fn solve_2d<T: LapackFullPivLu>(
         ));
     }
 
-    let mut rhs = b.host_data().to_vec();
+    let mut rhs = b.host_data()?.to_vec();
     let n_i32 = dim_i32(n, "full_piv_lu_solve")?;
     for col in 0..b_cols {
         let start = col * n;
@@ -538,7 +538,7 @@ fn solve_2d<T: LapackFullPivLu>(
         T::apply_inverse_scale(&mut rhs[start..end], scale);
     }
 
-    Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs, b))
+    tensor_from_vec_with_template(vec![n, b_cols], rhs, b)
 }
 
 pub(crate) fn full_piv_lu<T: LapackFullPivLu>(
@@ -553,27 +553,27 @@ pub(crate) fn full_piv_lu<T: LapackFullPivLu>(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
             tensor_from_vec_with_template(
                 batch_shape.to_vec(),
                 vec![T::one(); parity_elements],
                 input,
-            ),
+            )?,
         ]);
     }
     super::helpers::batched_multi("full_piv_lu", buffers, input, full_piv_lu_2d)
@@ -602,11 +602,7 @@ pub(crate) fn full_piv_lu_solve<T: LapackFullPivLu>(
                 rhs: b_batch_shape.to_vec(),
             });
         }
-        return Ok(tensor_from_vec_with_template(
-            b.shape().to_vec(),
-            Vec::new(),
-            b,
-        ));
+        return tensor_from_vec_with_template(b.shape().to_vec(), Vec::new(), b);
     }
     batched_binary_result("full_piv_lu_solve", buffers, a, b, |buffers, a, b| {
         solve_2d(buffers, a, b, transpose_a)

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/helpers.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/helpers.rs
@@ -34,10 +34,10 @@ pub(crate) fn tensor_from_vec_with_template<T: Clone, U>(
     shape: Vec<usize>,
     data: Vec<T>,
     template: &TypedTensor<U>,
-) -> TypedTensor<T> {
-    let mut tensor = TypedTensor::from_vec_col_major(shape, data);
+) -> tenferro_tensor::Result<TypedTensor<T>> {
+    let mut tensor = TypedTensor::from_vec_col_major(shape, data)?;
     tensor.set_placement(template.placement().clone());
-    tensor
+    Ok(tensor)
 }
 
 fn tensor_from_pooled_slice_with_template<T: PoolScalar, U>(
@@ -45,14 +45,18 @@ fn tensor_from_pooled_slice_with_template<T: PoolScalar, U>(
     shape: Vec<usize>,
     data: &[T],
     template: &TypedTensor<U>,
-) -> TypedTensor<T> {
+) -> tenferro_tensor::Result<TypedTensor<T>> {
     let mut owned = buffers.acquire_with_capacity::<T>(data.len());
     owned.extend_from_slice(data);
     tensor_from_vec_with_template(shape, owned, template)
 }
 
-fn refill_tensor_from_slice<T: Copy>(tensor: &mut TypedTensor<T>, data: &[T]) {
-    tensor.host_data_mut().copy_from_slice(data);
+fn refill_tensor_from_slice<T: Copy>(
+    tensor: &mut TypedTensor<T>,
+    data: &[T],
+) -> tenferro_tensor::Result<()> {
+    tensor.host_data_mut()?.copy_from_slice(data);
+    Ok(())
 }
 
 pub(crate) fn split_core_and_batch_result<'a, T>(
@@ -240,15 +244,15 @@ where
     let mut batch_input = tensor_from_pooled_slice_with_template(
         buffers,
         core_shape.to_vec(),
-        &input.host_data()[first_range],
+        &input.host_data()?[first_range],
         input,
-    );
+    )?;
 
     for batch_idx in 0..batch_count {
         if batch_idx > 0 {
             let start = batch_idx * slice_size;
             let end = start + slice_size;
-            refill_tensor_from_slice(&mut batch_input, &input.host_data()[start..end]);
+            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[start..end])?;
         }
         let batch_output = op(buffers, &batch_input)?;
 
@@ -266,7 +270,7 @@ where
         }
 
         match &mut out_data {
-            Some(data) => data.extend_from_slice(batch_output.host_data()),
+            Some(data) => data.extend_from_slice(batch_output.host_data()?),
             None => {
                 return Err(tenferro_tensor::Error::InvalidConfig {
                     op: op_name,
@@ -285,7 +289,7 @@ where
         op: op_name,
         message: "missing output data".into(),
     })?;
-    Ok(tensor_from_vec_with_template(out_shape, out_data, input))
+    tensor_from_vec_with_template(out_shape, out_data, input)
 }
 
 pub(crate) fn batched_multi<T, F>(
@@ -319,15 +323,15 @@ where
     let mut batch_input = tensor_from_pooled_slice_with_template(
         buffers,
         core_shape.to_vec(),
-        &input.host_data()[first_range],
+        &input.host_data()?[first_range],
         input,
-    );
+    )?;
 
     for batch_idx in 0..batch_count {
         if batch_idx > 0 {
             let start = batch_idx * slice_size;
             let end = start + slice_size;
-            refill_tensor_from_slice(&mut batch_input, &input.host_data()[start..end]);
+            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[start..end])?;
         }
         let batch_outputs = op(buffers, &batch_input)?;
 
@@ -367,18 +371,18 @@ where
                     rhs: out_shapes[idx].clone(),
                 });
             }
-            out_data[idx].extend_from_slice(batch_output.host_data());
+            out_data[idx].extend_from_slice(batch_output.host_data()?);
         }
     }
 
-    Ok(out_shapes
+    out_shapes
         .into_iter()
         .zip(out_data)
         .map(|(mut out_shape, out_data)| {
             out_shape.extend_from_slice(batch_shape);
             tensor_from_vec_with_template(out_shape, out_data, input)
         })
-        .collect())
+        .collect()
 }
 
 pub(crate) fn batched_multi_convert<InT: PoolScalar, OutT: Clone, F>(
@@ -411,15 +415,15 @@ where
     let mut batch_input = tensor_from_pooled_slice_with_template(
         buffers,
         core_shape.to_vec(),
-        &input.host_data()[first_range],
+        &input.host_data()?[first_range],
         input,
-    );
+    )?;
 
     for batch_idx in 0..batch_count {
         if batch_idx > 0 {
             let start = batch_idx * slice_size;
             let end = start + slice_size;
-            refill_tensor_from_slice(&mut batch_input, &input.host_data()[start..end]);
+            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[start..end])?;
         }
         let batch_outputs = op(buffers, &batch_input)?;
 
@@ -459,18 +463,18 @@ where
                     rhs: out_shapes[idx].clone(),
                 });
             }
-            out_data[idx].extend_from_slice(batch_output.host_data());
+            out_data[idx].extend_from_slice(batch_output.host_data()?);
         }
     }
 
-    Ok(out_shapes
+    out_shapes
         .into_iter()
         .zip(out_data)
         .map(|(mut out_shape, out_data)| {
             out_shape.extend_from_slice(batch_shape);
             tensor_from_vec_with_template(out_shape, out_data, input)
         })
-        .collect())
+        .collect()
 }
 
 pub(crate) fn batched_binary_result<T, F>(
@@ -520,15 +524,15 @@ where
     let mut batch_a = tensor_from_pooled_slice_with_template(
         buffers,
         a_core_shape.to_vec(),
-        &a.host_data()[a_first_range],
+        &a.host_data()?[a_first_range],
         a,
-    );
+    )?;
     let mut batch_b = tensor_from_pooled_slice_with_template(
         buffers,
         b_core_shape.to_vec(),
-        &b.host_data()[b_first_range],
+        &b.host_data()?[b_first_range],
         b,
-    );
+    )?;
 
     for batch_idx in 0..batch_count {
         if batch_idx > 0 {
@@ -536,8 +540,8 @@ where
             let a_end = a_start + a_slice_size;
             let b_start = batch_idx * b_slice_size;
             let b_end = b_start + b_slice_size;
-            refill_tensor_from_slice(&mut batch_a, &a.host_data()[a_start..a_end]);
-            refill_tensor_from_slice(&mut batch_b, &b.host_data()[b_start..b_end]);
+            refill_tensor_from_slice(&mut batch_a, &a.host_data()?[a_start..a_end])?;
+            refill_tensor_from_slice(&mut batch_b, &b.host_data()?[b_start..b_end])?;
         }
         let batch_output = op(buffers, &batch_a, &batch_b)?;
 
@@ -555,7 +559,7 @@ where
         }
 
         match &mut out_data {
-            Some(data) => data.extend_from_slice(batch_output.host_data()),
+            Some(data) => data.extend_from_slice(batch_output.host_data()?),
             None => {
                 return Err(tenferro_tensor::Error::InvalidConfig {
                     op: op_name,
@@ -574,7 +578,7 @@ where
         op: op_name,
         message: "missing output data".into(),
     })?;
-    Ok(tensor_from_vec_with_template(out_shape, out_data, b))
+    tensor_from_vec_with_template(out_shape, out_data, b)
 }
 
 pub(crate) fn zero_dim_eig_outputs(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -599,12 +603,12 @@ pub(crate) fn zero_dim_eig_outputs(input: &Tensor) -> tenferro_tensor::Result<Ve
     let vector_shape = matrix_with_batch_shape(n, n, batch_shape);
     match input {
         Tensor::F32(_) | Tensor::C32(_) => Ok(vec![
-            Tensor::C32(TypedTensor::from_vec_col_major(value_shape, Vec::new())),
-            Tensor::C32(TypedTensor::from_vec_col_major(vector_shape, Vec::new())),
+            Tensor::C32(TypedTensor::from_vec_col_major(value_shape, Vec::new())?),
+            Tensor::C32(TypedTensor::from_vec_col_major(vector_shape, Vec::new())?),
         ]),
         Tensor::F64(_) | Tensor::C64(_) => Ok(vec![
-            Tensor::C64(TypedTensor::from_vec_col_major(value_shape, Vec::new())),
-            Tensor::C64(TypedTensor::from_vec_col_major(vector_shape, Vec::new())),
+            Tensor::C64(TypedTensor::from_vec_col_major(value_shape, Vec::new())?),
+            Tensor::C64(TypedTensor::from_vec_col_major(vector_shape, Vec::new())?),
         ]),
         _ => Err(tenferro_tensor::Error::backend_failure(
             "eig",

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs
@@ -87,7 +87,7 @@ fn lu_2d<T: LapackLu>(
     let k = m.min(n);
     let m_i32 = dim_i32(m, "lu")?;
     let n_i32 = dim_i32(n, "lu")?;
-    let mut lu = input.host_data().to_vec();
+    let mut lu = input.host_data()?.to_vec();
     let mut ipiv = vec![0_i32; k];
     let mut info = 0;
     T::getrf(m_i32, n_i32, &mut lu, m_i32, &mut ipiv, &mut info);
@@ -137,10 +137,10 @@ fn lu_2d<T: LapackLu>(
     let u_data = leading_upper_triangle_from_lapack(&lu, m, k, n);
 
     Ok(vec![
-        tensor_from_vec_with_template(vec![m, m], p_data, input),
-        tensor_from_vec_with_template(vec![m, k], l_data, input),
-        tensor_from_vec_with_template(vec![k, n], u_data, input),
-        tensor_from_vec_with_template(vec![], vec![parity], input),
+        tensor_from_vec_with_template(vec![m, m], p_data, input)?,
+        tensor_from_vec_with_template(vec![m, k], l_data, input)?,
+        tensor_from_vec_with_template(vec![k, n], u_data, input)?,
+        tensor_from_vec_with_template(vec![], vec![parity], input)?,
     ])
 }
 
@@ -151,7 +151,7 @@ fn lu_factor_2d<T: LapackLu>(
     let k = m.min(n);
     let m_i32 = dim_i32(m, "lu_factor")?;
     let n_i32 = dim_i32(n, "lu_factor")?;
-    let mut lu = input.host_data().to_vec();
+    let mut lu = input.host_data()?.to_vec();
     let mut ipiv = vec![0_i32; k];
     let mut info = 0;
     T::getrf(m_i32, n_i32, &mut lu, m_i32, &mut ipiv, &mut info);
@@ -169,9 +169,9 @@ fn lu_factor_2d<T: LapackLu>(
     };
 
     Ok((
-        tensor_from_vec_with_template(vec![m, n], lu, input),
-        tensor_from_vec_with_template(vec![k], ipiv, input),
-        tensor_from_vec_with_template(vec![], vec![parity], input),
+        tensor_from_vec_with_template(vec![m, n], lu, input)?,
+        tensor_from_vec_with_template(vec![k], ipiv, input)?,
+        tensor_from_vec_with_template(vec![], vec![parity], input)?,
     ))
 }
 
@@ -188,22 +188,22 @@ pub(crate) fn lu<T: LapackLu>(
                 matrix_with_batch_shape(m, m, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(k, n, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
             tensor_from_vec_with_template(
                 batch_shape.to_vec(),
                 vec![T::one(); parity_elements],
                 input,
-            ),
+            )?,
         ]);
     }
     batched_multi("lu", buffers, input, lu_2d)
@@ -218,17 +218,17 @@ pub(crate) fn lu_factor<T: LapackLu>(
         let k = m.min(n);
         let parity_elements = batch_element_count("lu_factor", batch_shape)?;
         return Ok((
-            tensor_from_vec_with_template(input.shape().to_vec(), Vec::new(), input),
+            tensor_from_vec_with_template(input.shape().to_vec(), Vec::new(), input)?,
             tensor_from_vec_with_template(
                 vector_with_batch_shape(k, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
             tensor_from_vec_with_template(
                 batch_shape.to_vec(),
                 vec![T::one(); parity_elements],
                 input,
-            ),
+            )?,
         ));
     }
 
@@ -245,18 +245,18 @@ pub(crate) fn lu_factor<T: LapackLu>(
         let end = start + matrix_len;
         let batch_input = tensor_from_vec_with_template(
             vec![m, n],
-            input.host_data()[start..end].to_vec(),
+            input.host_data()?[start..end].to_vec(),
             input,
-        );
+        )?;
         let (packed, pivots, parity) = lu_factor_2d(&batch_input)?;
-        lu_data.extend_from_slice(packed.host_data());
-        pivot_data.extend_from_slice(pivots.host_data());
-        parity_data.extend_from_slice(parity.host_data());
+        lu_data.extend_from_slice(packed.host_data()?);
+        pivot_data.extend_from_slice(pivots.host_data()?);
+        parity_data.extend_from_slice(parity.host_data()?);
     }
 
     Ok((
-        tensor_from_vec_with_template(input.shape().to_vec(), lu_data, input),
-        tensor_from_vec_with_template(vector_with_batch_shape(k, batch_shape), pivot_data, input),
-        tensor_from_vec_with_template(batch_shape.to_vec(), parity_data, input),
+        tensor_from_vec_with_template(input.shape().to_vec(), lu_data, input)?,
+        tensor_from_vec_with_template(vector_with_batch_shape(k, batch_shape), pivot_data, input)?,
+        tensor_from_vec_with_template(batch_shape.to_vec(), parity_data, input)?,
     ))
 }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr.rs
@@ -29,7 +29,7 @@ macro_rules! impl_real_qr {
                 let n_i32 = dim_i32(n, "qr")?;
                 let k_i32 = dim_i32(k, "qr")?;
 
-                let mut qr = input.host_data().to_vec();
+                let mut qr = input.host_data()?.to_vec();
                 let mut tau = vec![0.0 as $scalar; k];
                 let mut query = vec![0.0 as $scalar; 1];
                 let mut info = 0;
@@ -72,8 +72,8 @@ macro_rules! impl_real_qr {
                 check_lapack_info("qr", $orgqr_name, info)?;
 
                 Ok(vec![
-                    tensor_from_vec_with_template(vec![m, k], q, input),
-                    tensor_from_vec_with_template(vec![k, n], r, input),
+                    tensor_from_vec_with_template(vec![m, k], q, input)?,
+                    tensor_from_vec_with_template(vec![k, n], r, input)?,
                 ])
             }
         }
@@ -93,7 +93,7 @@ macro_rules! impl_complex_qr {
                 let n_i32 = dim_i32(n, "qr")?;
                 let k_i32 = dim_i32(k, "qr")?;
 
-                let mut qr = input.host_data().to_vec();
+                let mut qr = input.host_data()?.to_vec();
                 let mut tau = vec![<$complex>::new(0.0, 0.0); k];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
                 let mut info = 0;
@@ -136,8 +136,8 @@ macro_rules! impl_complex_qr {
                 check_lapack_info("qr", $ungqr_name, info)?;
 
                 Ok(vec![
-                    tensor_from_vec_with_template(vec![m, k], q, input),
-                    tensor_from_vec_with_template(vec![k, n], r, input),
+                    tensor_from_vec_with_template(vec![m, k], q, input)?,
+                    tensor_from_vec_with_template(vec![k, n], r, input)?,
                 ])
             }
         }
@@ -182,12 +182,12 @@ pub(crate) fn qr<T: LapackQr>(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(k, n, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
         ]);
     }
     batched_multi("qr", buffers, input, qr_2d)

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/solve.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/solve.rs
@@ -137,7 +137,7 @@ fn solve_2d<T: LapackSolve>(
 
     let n_i32 = dim_i32(n, "solve")?;
     let b_cols_i32 = dim_i32(b_cols, "solve")?;
-    let mut lu = a.host_data().to_vec();
+    let mut lu = a.host_data()?.to_vec();
     let mut ipiv = vec![0_i32; n];
     let mut info = 0;
     T::getrf(n_i32, n_i32, &mut lu, n_i32, &mut ipiv, &mut info);
@@ -149,7 +149,7 @@ fn solve_2d<T: LapackSolve>(
         ));
     }
 
-    let mut rhs = b.host_data().to_vec();
+    let mut rhs = b.host_data()?.to_vec();
     let mut info = 0;
     T::getrs(
         if transpose_a { b'T' } else { b'N' },
@@ -164,7 +164,7 @@ fn solve_2d<T: LapackSolve>(
     );
     check_lapack_info("solve", "getrs", info)?;
 
-    Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs, b))
+    tensor_from_vec_with_template(vec![n, b_cols], rhs, b)
 }
 
 pub(crate) fn solve<T: LapackSolve>(
@@ -190,11 +190,7 @@ pub(crate) fn solve<T: LapackSolve>(
                 rhs: b_batch_shape.to_vec(),
             });
         }
-        return Ok(tensor_from_vec_with_template(
-            b.shape().to_vec(),
-            Vec::new(),
-            b,
-        ));
+        return tensor_from_vec_with_template(b.shape().to_vec(), Vec::new(), b);
     }
 
     batched_binary_result("solve", buffers, a, b, |buffers, a, b| {

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
@@ -36,7 +36,7 @@ macro_rules! impl_real_svd {
                 let n_i32 = dim_i32(n, "svd")?;
                 let k_i32 = dim_i32(k, "svd")?;
 
-                let mut a = input.host_data().to_vec();
+                let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $scalar; k];
                 let mut u = vec![0.0 as $scalar; m * k];
                 let mut vt = vec![0.0 as $scalar; k * n];
@@ -60,9 +60,9 @@ macro_rules! impl_real_svd {
                 check_lapack_info("svd", $routine, info)?;
 
                 Ok(vec![
-                    tensor_from_vec_with_template(vec![m, k], u, input),
-                    tensor_from_vec_with_template(vec![k], s, input),
-                    tensor_from_vec_with_template(vec![k, n], vt, input),
+                    tensor_from_vec_with_template(vec![m, k], u, input)?,
+                    tensor_from_vec_with_template(vec![k], s, input)?,
+                    tensor_from_vec_with_template(vec![k, n], vt, input)?,
                 ])
             }
 
@@ -75,7 +75,7 @@ macro_rules! impl_real_svd {
                 let m_i32 = dim_i32(m, "svd_values")?;
                 let n_i32 = dim_i32(n, "svd_values")?;
 
-                let mut a = input.host_data().to_vec();
+                let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $scalar; k];
                 let mut query = vec![0.0 as $scalar; 1];
                 let mut info = 0;
@@ -120,7 +120,7 @@ macro_rules! impl_real_svd {
                 }
                 check_lapack_info("svd_values", $routine, info)?;
 
-                Ok(tensor_from_vec_with_template(vec![k], s, input))
+                tensor_from_vec_with_template(vec![k], s, input)
             }
         }
     };
@@ -141,7 +141,7 @@ macro_rules! impl_complex_svd {
                 let n_i32 = dim_i32(n, "svd")?;
                 let k_i32 = dim_i32(k, "svd")?;
 
-                let mut a = input.host_data().to_vec();
+                let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $real; k];
                 let mut u = vec![<$complex>::new(0.0, 0.0); m * k];
                 let mut vt = vec![<$complex>::new(0.0, 0.0); k * n];
@@ -166,15 +166,15 @@ macro_rules! impl_complex_svd {
                 check_lapack_info("svd", $routine, info)?;
 
                 Ok(vec![
-                    tensor_from_vec_with_template(vec![m, k], u, input),
+                    tensor_from_vec_with_template(vec![m, k], u, input)?,
                     tensor_from_vec_with_template(
                         vec![k],
                         s.into_iter()
                             .map(|value| <$complex>::new(value, 0.0))
                             .collect(),
                         input,
-                    ),
-                    tensor_from_vec_with_template(vec![k, n], vt, input),
+                    )?,
+                    tensor_from_vec_with_template(vec![k, n], vt, input)?,
                 ])
             }
 
@@ -187,7 +187,7 @@ macro_rules! impl_complex_svd {
                 let m_i32 = dim_i32(m, "svd_values")?;
                 let n_i32 = dim_i32(n, "svd_values")?;
 
-                let mut a = input.host_data().to_vec();
+                let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $real; k];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
                 let mut rwork = vec![0.0 as $real; 5 * k.max(1)];
@@ -235,7 +235,7 @@ macro_rules! impl_complex_svd {
                 }
                 check_lapack_info("svd_values", $routine, info)?;
 
-                Ok(tensor_from_vec_with_template(vec![k], s, input))
+                tensor_from_vec_with_template(vec![k], s, input)
             }
         }
     };
@@ -267,17 +267,17 @@ pub(crate) fn svd<T: LapackSvd>(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
             tensor_from_vec_with_template(
                 vector_with_batch_shape(k, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(k, n, batch_shape),
                 Vec::new(),
                 input,
-            ),
+            )?,
         ]);
     }
     batched_multi("svd", buffers, input, svd_2d)
@@ -297,11 +297,11 @@ pub(crate) fn svd_values<T: LapackSvd>(
     if has_zero_dim(input.shape()) {
         let (matrix_shape, batch_shape) = split_core_and_batch_result(input, 2, "svd_values")?;
         let k = matrix_shape[0].min(matrix_shape[1]);
-        return Ok(tensor_from_vec_with_template(
+        return tensor_from_vec_with_template(
             vector_with_batch_shape(k, batch_shape),
             Vec::new(),
             input,
-        ));
+        );
     }
 
     let (core_shape, batch_shape) = split_core_and_batch_result(input, 2, "svd_values")?;
@@ -318,15 +318,11 @@ pub(crate) fn svd_values<T: LapackSvd>(
         let end = start + slice_size;
         let batch_input = tensor_from_vec_with_template(
             core_shape.to_vec(),
-            input.host_data()[start..end].to_vec(),
+            input.host_data()?[start..end].to_vec(),
             input,
-        );
+        )?;
         let values = svd_values_2d(buffers, &batch_input)?;
-        data.extend_from_slice(values.host_data());
+        data.extend_from_slice(values.host_data()?);
     }
-    Ok(tensor_from_vec_with_template(
-        vector_with_batch_shape(k, batch_shape),
-        data,
-        input,
-    ))
+    tensor_from_vec_with_template(vector_with_batch_shape(k, batch_shape), data, input)
 }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/triangular_solve.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/triangular_solve.rs
@@ -117,7 +117,7 @@ fn solve_left<T: LapackTriangularSolve>(
         });
     }
 
-    let mut rhs = b.host_data().to_vec();
+    let mut rhs = b.host_data()?.to_vec();
     let mut info = 0;
     T::trtrs(
         if lower { b'L' } else { b'U' },
@@ -125,14 +125,14 @@ fn solve_left<T: LapackTriangularSolve>(
         if unit_diagonal { b'U' } else { b'N' },
         dim_i32(n, "triangular_solve")?,
         dim_i32(b_cols, "triangular_solve")?,
-        a.host_data(),
+        a.host_data()?,
         dim_i32(n, "triangular_solve")?,
         &mut rhs,
         dim_i32(n, "triangular_solve")?,
         &mut info,
     );
     check_lapack_info("triangular_solve", "trtrs", info)?;
-    Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs, b))
+    tensor_from_vec_with_template(vec![n, b_cols], rhs, b)
 }
 
 fn solve_right<T: LapackTriangularSolve>(
@@ -152,7 +152,7 @@ fn solve_right<T: LapackTriangularSolve>(
         });
     }
 
-    let mut rhs_t = transpose_col_major_data(b.host_data(), b_rows, n);
+    let mut rhs_t = transpose_col_major_data(b.host_data()?, b_rows, n);
     let mut info = 0;
     T::trtrs(
         if lower { b'L' } else { b'U' },
@@ -160,7 +160,7 @@ fn solve_right<T: LapackTriangularSolve>(
         if unit_diagonal { b'U' } else { b'N' },
         dim_i32(n, "triangular_solve")?,
         dim_i32(b_rows, "triangular_solve")?,
-        a.host_data(),
+        a.host_data()?,
         dim_i32(n, "triangular_solve")?,
         &mut rhs_t,
         dim_i32(n, "triangular_solve")?,
@@ -168,7 +168,7 @@ fn solve_right<T: LapackTriangularSolve>(
     );
     check_lapack_info("triangular_solve", "trtrs", info)?;
     let result = transpose_col_major_data(&rhs_t, n, b_rows);
-    Ok(tensor_from_vec_with_template(vec![b_rows, n], result, b))
+    tensor_from_vec_with_template(vec![b_rows, n], result, b)
 }
 
 fn triangular_solve_2d<T: LapackTriangularSolve>(
@@ -214,11 +214,7 @@ pub(crate) fn triangular_solve<T: LapackTriangularSolve>(
                 rhs: b_batch_shape.to_vec(),
             });
         }
-        return Ok(tensor_from_vec_with_template(
-            b.shape().to_vec(),
-            Vec::new(),
-            b,
-        ));
+        return tensor_from_vec_with_template(b.shape().to_vec(), Vec::new(), b);
     }
     batched_binary_result("triangular_solve", buffers, a, b, |buffers, a, b| {
         triangular_solve_2d(buffers, a, b, left_side, lower, transpose_a, unit_diagonal)

--- a/crates/tenferro-linalg/src/cpu/tests/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/backend.rs
@@ -3,19 +3,17 @@ use super::*;
 #[test]
 fn test_solve_zero_dim_returns_zeros() {
     let mut backend = CpuBackend::new();
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 0], vec![]));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![0, 1], vec![]));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 0], vec![]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![0, 1], vec![]).unwrap());
     let x = backend.solve(&a, &b).unwrap();
     assert_eq!(x.shape(), &[0, 1]);
 }
 
 #[test]
 fn test_solve_with_1d_vector_rhs() {
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![2.0, 1.0, 0.0, 3.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![5.0, 7.0]));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![2.0, 1.0, 0.0, 3.0]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![5.0, 7.0]).unwrap());
     let mut backend = CpuBackend::new();
     let x = backend.solve(&a, &b).unwrap();
     assert_eq!(x.shape(), &[2]);
@@ -32,14 +30,15 @@ fn test_solve_with_1d_vector_rhs() {
 
 #[test]
 fn test_solve_with_batched_vector_rhs() {
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2, 2],
-        vec![2.0, 1.0, 0.0, 3.0, 1.0, 0.0, 1.0, 2.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![5.0, 7.0, 3.0, 4.0],
-    ));
+    let a = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2, 2],
+            vec![2.0, 1.0, 0.0, 3.0, 1.0, 0.0, 1.0, 2.0],
+        )
+        .unwrap(),
+    );
+    let b =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![5.0, 7.0, 3.0, 4.0]).unwrap());
     let mut backend = CpuBackend::new();
     let x = backend.solve(&a, &b).unwrap();
     assert_eq!(x.shape(), &[2, 2]);
@@ -48,11 +47,10 @@ fn test_solve_with_batched_vector_rhs() {
 #[test]
 fn test_triangular_solve_dtype_mismatch_and_unsupported() {
     let mut backend = CpuBackend::new();
-    let a_f32 = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0f32, 0.0, 0.0, 1.0],
-    ));
-    let b_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1.0, 2.0]));
+    let a_f32 = Tensor::F32(
+        TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0f32, 0.0, 0.0, 1.0]).unwrap(),
+    );
+    let b_f64 = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1.0, 2.0]).unwrap());
     let err = backend
         .triangular_solve(&a_f32, &b_f64, true, true, false, false)
         .unwrap_err();
@@ -64,11 +62,9 @@ fn test_triangular_solve_dtype_mismatch_and_unsupported() {
         }
     ));
 
-    let a_i64 = Tensor::I64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1_i64, 0, 0, 1],
-    ));
-    let b_i64 = Tensor::I64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1_i64, 2]));
+    let a_i64 =
+        Tensor::I64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 0, 0, 1]).unwrap());
+    let b_i64 = Tensor::I64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1_i64, 2]).unwrap());
     let err = backend
         .triangular_solve(&a_i64, &b_i64, true, true, false, false)
         .unwrap_err();
@@ -84,11 +80,9 @@ fn test_triangular_solve_dtype_mismatch_and_unsupported() {
 #[test]
 fn test_linalg_returns_errors_for_unsupported_dtypes() {
     let mut backend = CpuBackend::new();
-    let i64_matrix = Tensor::I64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1_i64, 0, 0, 1],
-    ));
-    let i64_rhs = Tensor::I64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1_i64, 2]));
+    let i64_matrix =
+        Tensor::I64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 0, 0, 1]).unwrap());
+    let i64_rhs = Tensor::I64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1_i64, 2]).unwrap());
 
     assert!(backend.cholesky(&i64_matrix).is_err());
     assert!(backend.svd(&i64_matrix).is_err());
@@ -104,30 +98,24 @@ fn test_linalg_returns_errors_for_unsupported_dtypes() {
 #[test]
 fn test_solve_zero_dim_rhs_returns_zeros() {
     let mut backend = CpuBackend::new();
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 0.0, 0.0, 1.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![0], vec![]));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![0], vec![]).unwrap());
     let x = backend.solve(&a, &b).unwrap();
     assert_eq!(x.shape(), &[0]);
 }
 
 #[test]
 fn test_solve_with_regular_matrix_rhs() {
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![2.0, 1.0, 0.0, 3.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![5.0, 7.0, 3.0, 4.0],
-    ));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![2.0, 1.0, 0.0, 3.0]).unwrap());
+    let b =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![5.0, 7.0, 3.0, 4.0]).unwrap());
     let mut backend = CpuBackend::new();
     let x = backend.solve(&a, &b).unwrap();
     assert_eq!(x.shape(), &[2, 2]);
     let x_data = match &x {
-        Tensor::F64(inner) => inner.host_data().to_vec(),
+        Tensor::F64(inner) => inner.host_data().unwrap().to_vec(),
         _ => panic!("expected f64 tensor"),
     };
     let recon = matmul_f64(&[2.0, 1.0, 0.0, 3.0], &x_data, 2, 2, 2);
@@ -139,17 +127,15 @@ fn test_solve_with_regular_matrix_rhs() {
 
 #[test]
 fn test_lu_unsupported_dtype_returns_error() {
-    let input = Tensor::I64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1_i64, 0, 0, 1],
-    ));
+    let input =
+        Tensor::I64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 0, 0, 1]).unwrap());
     let mut backend = CpuBackend::new();
     assert!(backend.lu(&input).is_err());
 }
 
 #[test]
 fn test_lu_zero_sized_batch_outputs_empty_parity() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2, 0], Vec::new()));
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2, 0], Vec::new()).unwrap());
     let mut backend = CpuBackend::new();
     let outputs = backend.lu(&input).unwrap();
 
@@ -160,7 +146,7 @@ fn test_lu_zero_sized_batch_outputs_empty_parity() {
     assert_eq!(outputs[3].shape(), &[0]);
     for output in outputs {
         match output {
-            Tensor::F64(inner) => assert!(inner.host_data().is_empty()),
+            Tensor::F64(inner) => assert!(inner.host_data().unwrap().is_empty()),
             other => panic!("expected f64 tensor, got {:?}", other.dtype()),
         }
     }
@@ -168,10 +154,8 @@ fn test_lu_zero_sized_batch_outputs_empty_parity() {
 
 #[test]
 fn test_svd_unsupported_dtype_returns_error() {
-    let input = Tensor::I64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1_i64, 0, 0, 1],
-    ));
+    let input =
+        Tensor::I64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 0, 0, 1]).unwrap());
     let mut backend = CpuBackend::new();
     assert!(backend.svd(&input).is_err());
 }
@@ -179,9 +163,9 @@ fn test_svd_unsupported_dtype_returns_error() {
 #[cfg(feature = "cpu-faer")]
 #[test]
 fn test_faer_svd_decomposition_failure_returns_error() {
-    let ctx = CpuContext::with_threads(1);
+    let ctx = CpuContext::with_threads(1).unwrap();
     let mut buffers = BufferPool::new();
-    let input = TypedTensor::from_vec_col_major(vec![2, 2], vec![f64::NAN, 0.0, 0.0, 1.0]);
+    let input = TypedTensor::from_vec_col_major(vec![2, 2], vec![f64::NAN, 0.0, 0.0, 1.0]).unwrap();
 
     let err = faer_linalg::svd(&ctx, &mut buffers, &input).unwrap_err();
 
@@ -191,12 +175,11 @@ fn test_faer_svd_decomposition_failure_returns_error() {
 #[cfg(feature = "cpu-faer")]
 #[test]
 fn test_faer_eig_decomposition_failure_returns_error() {
-    let ctx = CpuContext::with_threads(1);
+    let ctx = CpuContext::with_threads(1).unwrap();
     let mut buffers = BufferPool::new();
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![f64::NAN, 0.0, 0.0, 1.0],
-    ));
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 2], vec![f64::NAN, 0.0, 0.0, 1.0]).unwrap(),
+    );
 
     let err = faer_linalg::eig(&ctx, &mut buffers, &input).unwrap_err();
 
@@ -205,20 +188,17 @@ fn test_faer_eig_decomposition_failure_returns_error() {
 
 #[test]
 fn test_qr_unsupported_dtype_returns_error() {
-    let input = Tensor::I64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1_i64, 0, 0, 1],
-    ));
+    let input =
+        Tensor::I64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1_i64, 0, 0, 1]).unwrap());
     let mut backend = CpuBackend::new();
     assert!(backend.qr(&input).is_err());
 }
 
 #[test]
 fn test_eig_returns_complex_outputs_for_real_input() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![0.0, -1.0, 1.0, 0.0],
-    ));
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 2], vec![0.0, -1.0, 1.0, 0.0]).unwrap(),
+    );
     let mut backend = CpuBackend::new();
     let outputs = backend.eig(&input).unwrap();
     assert_eq!(outputs.len(), 2);

--- a/crates/tenferro-linalg/src/cpu/tests/dtype.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/dtype.rs
@@ -82,14 +82,14 @@ fn diag_c32_from_real(values: &[f32]) -> Vec<Complex32> {
 
 fn f32_data(tensor: &Tensor) -> &[f32] {
     match tensor {
-        Tensor::F32(inner) => inner.host_data(),
+        Tensor::F32(inner) => inner.host_data().unwrap(),
         other => panic!("expected F32 tensor, got {:?}", other.dtype()),
     }
 }
 
 fn c32_data(tensor: &Tensor) -> &[Complex32] {
     match tensor {
-        Tensor::C32(inner) => inner.host_data(),
+        Tensor::C32(inner) => inner.host_data().unwrap(),
         other => panic!("expected C32 tensor, got {:?}", other.dtype()),
     }
 }
@@ -128,10 +128,9 @@ fn cpu_linalg_accepts_f32_happy_paths() {
     let lower = vec![2.0, 0.5, 0.0, 1.5];
     let spd = matmul_f32(&lower, &transpose_f32(&lower, 2, 2), 2, 2, 2);
     let chol = backend
-        .cholesky(&Tensor::F32(TypedTensor::from_vec_col_major(
-            vec![2, 2],
-            spd.clone(),
-        )))
+        .cholesky(&Tensor::F32(
+            TypedTensor::from_vec_col_major(vec![2, 2], spd.clone()).unwrap(),
+        ))
         .unwrap();
     let chol_recon = matmul_f32(
         f32_data(&chol),
@@ -143,10 +142,8 @@ fn cpu_linalg_accepts_f32_happy_paths() {
     assert_f32_slice_close(&chol_recon, &spd, tol);
 
     let rectangular = vec![1.0, 2.0, 3.0, 4.0, 0.5, -1.0];
-    let input = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![3, 2],
-        rectangular.clone(),
-    ));
+    let input =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![3, 2], rectangular.clone()).unwrap());
     let qr = backend.qr(&input).unwrap();
     assert_eq!(qr[0].shape(), &[3, 2]);
     assert_eq!(qr[1].shape(), &[2, 2]);
@@ -174,10 +171,9 @@ fn cpu_linalg_accepts_f32_happy_paths() {
 
     let symmetric = vec![4.0, 1.0, 1.0, 3.0];
     let eigh = backend
-        .eigh(&Tensor::F32(TypedTensor::from_vec_col_major(
-            vec![2, 2],
-            symmetric.clone(),
-        )))
+        .eigh(&Tensor::F32(
+            TypedTensor::from_vec_col_major(vec![2, 2], symmetric.clone()).unwrap(),
+        ))
         .unwrap();
     assert_f32_slice_close(
         &matmul_f32(
@@ -192,22 +188,18 @@ fn cpu_linalg_accepts_f32_happy_paths() {
     );
 
     let eig = backend
-        .eig(&Tensor::F32(TypedTensor::from_vec_col_major(
-            vec![2, 2],
-            vec![1.0, 0.0, 0.0, 3.0],
-        )))
+        .eig(&Tensor::F32(
+            TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 3.0]).unwrap(),
+        ))
         .unwrap();
     assert_eq!(eig[0].dtype(), DType::C32);
     assert_eq!(eig[1].dtype(), DType::C32);
 
-    let a = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![3.0, 1.0, 1.0, 2.0],
-    ));
-    let b = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![5.0, 1.0, -2.0, 4.0],
-    ));
+    let a =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![2, 2], vec![3.0, 1.0, 1.0, 2.0]).unwrap());
+    let b = Tensor::F32(
+        TypedTensor::from_vec_col_major(vec![2, 2], vec![5.0, 1.0, -2.0, 4.0]).unwrap(),
+    );
     let x = backend.solve(&a, &b).unwrap();
     assert_f32_slice_close(
         &matmul_f32(f32_data(&a), f32_data(&x), 2, 2, 2),
@@ -215,11 +207,9 @@ fn cpu_linalg_accepts_f32_happy_paths() {
         tol,
     );
 
-    let triangular = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![2.0, 1.0, 0.0, 3.0],
-    ));
-    let rhs = Tensor::F32(TypedTensor::from_vec_col_major(vec![2, 1], vec![5.0, 7.0]));
+    let triangular =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![2, 2], vec![2.0, 1.0, 0.0, 3.0]).unwrap());
+    let rhs = Tensor::F32(TypedTensor::from_vec_col_major(vec![2, 1], vec![5.0, 7.0]).unwrap());
     let y = backend
         .triangular_solve(&triangular, &rhs, true, true, false, false)
         .unwrap();
@@ -229,10 +219,8 @@ fn cpu_linalg_accepts_f32_happy_paths() {
         tol,
     );
 
-    let lu_input = Tensor::F32(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![0.0, 1.0, 1.0, 0.0],
-    ));
+    let lu_input =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]).unwrap());
     let lu = backend.lu(&lu_input).unwrap();
     assert_eq!(lu.len(), 4);
     assert_eq!(lu[3].shape(), &[] as &[usize]);
@@ -260,10 +248,9 @@ fn cpu_linalg_accepts_c32_happy_paths() {
     ];
     let spd = matmul_c32(&lower, &conjugate_transpose_c32(&lower, 2, 2), 2, 2, 2);
     let chol = backend
-        .cholesky(&Tensor::C32(TypedTensor::from_vec_col_major(
-            vec![2, 2],
-            spd.clone(),
-        )))
+        .cholesky(&Tensor::C32(
+            TypedTensor::from_vec_col_major(vec![2, 2], spd.clone()).unwrap(),
+        ))
         .unwrap();
     assert_c32_slice_close(
         &matmul_c32(
@@ -285,10 +272,8 @@ fn cpu_linalg_accepts_c32_happy_paths() {
         Complex32::new(-0.25, 1.5),
         Complex32::new(3.0, 0.75),
     ];
-    let input = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![3, 2],
-        rectangular.clone(),
-    ));
+    let input =
+        Tensor::C32(TypedTensor::from_vec_col_major(vec![3, 2], rectangular.clone()).unwrap());
     let qr = backend.qr(&input).unwrap();
     assert_c32_slice_close(
         &matmul_c32(c32_data(&qr[0]), c32_data(&qr[1]), 3, 2, 2),
@@ -319,10 +304,9 @@ fn cpu_linalg_accepts_c32_happy_paths() {
     );
 
     let eigh = backend
-        .eigh(&Tensor::C32(TypedTensor::from_vec_col_major(
-            vec![2, 2],
-            spd.clone(),
-        )))
+        .eigh(&Tensor::C32(
+            TypedTensor::from_vec_col_major(vec![2, 2], spd.clone()).unwrap(),
+        ))
         .unwrap();
     assert_eq!(eigh[0].dtype(), DType::F32);
     assert_eq!(eigh[1].dtype(), DType::C32);
@@ -344,32 +328,41 @@ fn cpu_linalg_accepts_c32_happy_paths() {
         2.0e-3,
     );
 
-    let eig_input = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![
-            Complex32::new(0.0, 0.0),
-            Complex32::new(1.0, 0.0),
-            Complex32::new(-1.0, 0.0),
-            Complex32::new(0.0, 0.0),
-        ],
-    ));
+    let eig_input = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex32::new(0.0, 0.0),
+                Complex32::new(1.0, 0.0),
+                Complex32::new(-1.0, 0.0),
+                Complex32::new(0.0, 0.0),
+            ],
+        )
+        .unwrap(),
+    );
     let eig = backend.eig(&eig_input).unwrap();
     assert_eq!(eig[0].dtype(), DType::C32);
     assert_eq!(eig[1].dtype(), DType::C32);
 
-    let a = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![
-            Complex32::new(3.0, 0.0),
-            Complex32::new(1.0, -1.0),
-            Complex32::new(1.0, 0.5),
-            Complex32::new(2.0, 0.0),
-        ],
-    ));
-    let b = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2, 1],
-        vec![Complex32::new(5.0, 1.0), Complex32::new(1.0, -2.0)],
-    ));
+    let a = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex32::new(3.0, 0.0),
+                Complex32::new(1.0, -1.0),
+                Complex32::new(1.0, 0.5),
+                Complex32::new(2.0, 0.0),
+            ],
+        )
+        .unwrap(),
+    );
+    let b = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2, 1],
+            vec![Complex32::new(5.0, 1.0), Complex32::new(1.0, -2.0)],
+        )
+        .unwrap(),
+    );
     let x = backend.solve(&a, &b).unwrap();
     assert_c32_slice_close(
         &matmul_c32(c32_data(&a), c32_data(&x), 2, 2, 1),
@@ -377,15 +370,18 @@ fn cpu_linalg_accepts_c32_happy_paths() {
         2.0e-3,
     );
 
-    let triangular = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![
-            Complex32::new(2.0, 0.0),
-            Complex32::new(1.0, -0.5),
-            Complex32::new(0.0, 0.0),
-            Complex32::new(3.0, 0.0),
-        ],
-    ));
+    let triangular = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex32::new(2.0, 0.0),
+                Complex32::new(1.0, -0.5),
+                Complex32::new(0.0, 0.0),
+                Complex32::new(3.0, 0.0),
+            ],
+        )
+        .unwrap(),
+    );
     let y = backend
         .triangular_solve(&triangular, &b, true, true, false, false)
         .unwrap();

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn svd_canonicalizes_transposed_host_view_before_lapack() {
     let data = vec![1.0, -2.0, 3.0, 0.5, -1.0, 4.0];
-    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], data.clone());
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], data.clone()).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap();
     let outputs = CpuBackend::new().svd_read(TensorView::F64(view)).unwrap();
 
@@ -31,10 +31,13 @@ fn test_batched_cholesky() {
     let a0 = matmul_f64(&l0, &transpose_f64(&l0, 3, 3), 3, 3, 3);
     let a1 = matmul_f64(&l1, &transpose_f64(&l1, 3, 3), 3, 3, 3);
 
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3, 3, 2],
-        a0.iter().chain(a1.iter()).copied().collect(),
-    ));
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![3, 3, 2],
+            a0.iter().chain(a1.iter()).copied().collect(),
+        )
+        .unwrap(),
+    );
     let mut backend = CpuBackend::new();
     let out = backend.cholesky(&input).unwrap();
 
@@ -55,10 +58,13 @@ fn test_batched_svd() {
     let a1 = vec![
         2.0, -1.0, 0.5, 3.0, -0.25, 1.5, -2.0, 0.75, 1.0, 2.5, -1.0, 4.0,
     ];
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4, 3, 2],
-        a0.iter().chain(a1.iter()).copied().collect(),
-    ));
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![4, 3, 2],
+            a0.iter().chain(a1.iter()).copied().collect(),
+        )
+        .unwrap(),
+    );
     let mut backend = CpuBackend::new();
     let out = backend.svd(&input).unwrap();
 
@@ -83,10 +89,13 @@ fn test_batched_svd() {
 fn test_batched_qr() {
     let a0 = [1.0, 2.0, 3.0, 4.0, 0.5, -1.0];
     let a1 = [2.0, -1.0, 0.5, 3.0, -0.25, 1.5];
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3, 2, 2],
-        a0.iter().chain(a1.iter()).copied().collect(),
-    ));
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![3, 2, 2],
+            a0.iter().chain(a1.iter()).copied().collect(),
+        )
+        .unwrap(),
+    );
     let mut backend = CpuBackend::new();
     let out = backend.qr(&input).unwrap();
 
@@ -111,14 +120,17 @@ fn test_batched_solve() {
     let l1 = vec![1.5, -0.5, 1.0, 0.0, 2.0, 0.75, 0.0, 0.0, 1.25];
     let a0 = matmul_f64(&l0, &transpose_f64(&l0, 3, 3), 3, 3, 3);
     let a1 = matmul_f64(&l1, &transpose_f64(&l1, 3, 3), 3, 3, 3);
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3, 3, 2],
-        a0.iter().chain(a1.iter()).copied().collect(),
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![3, 1, 2],
-        vec![1.0, 2.0, 3.0, -1.0, 4.0, 0.5],
-    ));
+    let a = Tensor::F64(
+        TypedTensor::from_vec_col_major(
+            vec![3, 3, 2],
+            a0.iter().chain(a1.iter()).copied().collect(),
+        )
+        .unwrap(),
+    );
+    let b = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![3, 1, 2], vec![1.0, 2.0, 3.0, -1.0, 4.0, 0.5])
+            .unwrap(),
+    );
 
     let mut backend = CpuBackend::new();
     let x = backend.solve(&a, &b).unwrap();
@@ -139,8 +151,8 @@ fn test_batched_solve() {
 fn test_triangular_solve_lower() {
     let l_data = vec![2.0, 1.0, -0.5, 0.0, 3.0, 1.25, 0.0, 0.0, 1.5];
     let b_data = vec![1.0, -2.0, 0.5];
-    let l = Tensor::F64(TypedTensor::from_vec_col_major(vec![3, 3], l_data.clone()));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![3, 1], b_data.clone()));
+    let l = Tensor::F64(TypedTensor::from_vec_col_major(vec![3, 3], l_data.clone()).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![3, 1], b_data.clone()).unwrap());
 
     let mut backend = CpuBackend::new();
     let x = backend
@@ -149,7 +161,7 @@ fn test_triangular_solve_lower() {
 
     assert_eq!(x.shape(), &[3, 1]);
     let x_data = match &x {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner.host_data().unwrap(),
         _ => panic!("expected f64 tensor"),
     };
     let recon = matmul_f64(&l_data, x_data, 3, 3, 1);
@@ -162,8 +174,8 @@ fn test_triangular_solve_lower() {
 fn test_triangular_solve_right_side_unit_transpose() {
     let a_data = vec![1.0, 2.0, 0.0, 1.0];
     let b_data = vec![7.0, 5.0];
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], a_data.clone()));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 2], b_data.clone()));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], a_data.clone()).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 2], b_data.clone()).unwrap());
 
     let mut backend = CpuBackend::new();
     let x = backend
@@ -172,7 +184,7 @@ fn test_triangular_solve_right_side_unit_transpose() {
 
     assert_eq!(x.shape(), &[1, 2]);
     let x_data = match &x {
-        Tensor::F64(inner) => inner.host_data().to_vec(),
+        Tensor::F64(inner) => inner.host_data().unwrap().to_vec(),
         _ => panic!("expected f64 tensor"),
     };
     let recon = matmul_f64(&x_data, &transpose_f64(&a_data, 2, 2), 1, 2, 2);
@@ -210,15 +222,17 @@ fn test_triangular_solve_covers_all_real_branch_combinations() {
                         matmul_f64(&expected_x, &op_a, 2, 2, 2)
                     };
 
-                    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], a_data));
-                    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], b_data));
+                    let a =
+                        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], a_data).unwrap());
+                    let b =
+                        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], b_data).unwrap());
                     let mut backend = CpuBackend::new();
                     let x = backend
                         .triangular_solve(&a, &b, left_side, lower, transpose_a, unit_diagonal)
                         .unwrap();
 
                     let x_data = match &x {
-                        Tensor::F64(inner) => inner.host_data(),
+                        Tensor::F64(inner) => inner.host_data().unwrap(),
                         _ => panic!("expected f64 tensor"),
                     };
                     for (actual, expected) in x_data.iter().zip(expected_x.iter()) {
@@ -246,19 +260,25 @@ fn test_batched_complex_solve() {
     ];
     let a0 = matmul_c64(&l0, &conjugate_transpose_c64(&l0, 2, 2), 2, 2, 2);
     let a1 = matmul_c64(&l1, &conjugate_transpose_c64(&l1, 2, 2), 2, 2, 2);
-    let a = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2, 2, 2],
-        a0.iter().chain(a1.iter()).copied().collect(),
-    ));
-    let b = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2, 1, 2],
-        vec![
-            Complex64::new(1.0, -1.0),
-            Complex64::new(0.5, 2.0),
-            Complex64::new(-2.0, 0.25),
-            Complex64::new(1.5, -0.75),
-        ],
-    ));
+    let a = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2, 2],
+            a0.iter().chain(a1.iter()).copied().collect(),
+        )
+        .unwrap(),
+    );
+    let b = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 1, 2],
+            vec![
+                Complex64::new(1.0, -1.0),
+                Complex64::new(0.5, 2.0),
+                Complex64::new(-2.0, 0.25),
+                Complex64::new(1.5, -0.75),
+            ],
+        )
+        .unwrap(),
+    );
 
     let mut backend = CpuBackend::new();
     let x = backend.solve(&a, &b).unwrap();
@@ -279,14 +299,14 @@ fn test_batched_complex_solve() {
 fn test_real_solve_non_batched() {
     let a_data = vec![3.0, 1.0, 1.0, 2.0];
     let b_data = vec![5.0, 1.0, -2.0, 4.0];
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], a_data.clone()));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], b_data.clone()));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], a_data.clone()).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], b_data.clone()).unwrap());
 
     let mut backend = CpuBackend::new();
     let x = backend.solve(&a, &b).unwrap();
 
     let x_data = match &x {
-        Tensor::F64(inner) => inner.host_data(),
+        Tensor::F64(inner) => inner.host_data().unwrap(),
         _ => panic!("expected f64 tensor"),
     };
     let recon = matmul_f64(&a_data, x_data, 2, 2, 2);
@@ -297,10 +317,8 @@ fn test_real_solve_non_batched() {
 
 #[test]
 fn test_real_lu_returns_permutation_factors_and_parity() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![0.0, 1.0, 1.0, 0.0],
-    ));
+    let input =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]).unwrap());
     let mut backend = CpuBackend::new();
     let outputs = backend.lu(&input).unwrap();
 
@@ -320,10 +338,8 @@ fn test_real_lu_returns_permutation_factors_and_parity() {
 
 #[test]
 fn test_real_eig_returns_complex_outputs() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 0.0, 0.0, 3.0],
-    ));
+    let input =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 3.0]).unwrap());
     let mut backend = CpuBackend::new();
     let outputs = backend.eig(&input).unwrap();
 
@@ -357,10 +373,13 @@ fn test_batched_complex_eigh() {
     ];
     let a0 = matmul_c64(&l0, &conjugate_transpose_c64(&l0, 2, 2), 2, 2, 2);
     let a1 = matmul_c64(&l1, &conjugate_transpose_c64(&l1, 2, 2), 2, 2, 2);
-    let input = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2, 2, 2],
-        a0.iter().chain(a1.iter()).copied().collect(),
-    ));
+    let input = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2, 2],
+            a0.iter().chain(a1.iter()).copied().collect(),
+        )
+        .unwrap(),
+    );
 
     let mut backend = CpuBackend::new();
     let out = backend.eigh(&input).unwrap();
@@ -391,7 +410,7 @@ fn test_batched_complex_eigh() {
 #[test]
 fn test_real_eigh() {
     let a_data = vec![4.0, 1.0, 1.0, 3.0];
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], a_data.clone()));
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], a_data.clone()).unwrap());
 
     let mut backend = CpuBackend::new();
     let out = backend.eigh(&input).unwrap();
@@ -401,7 +420,7 @@ fn test_real_eigh() {
     assert_eq!(out[1].shape(), &[2, 2]);
 
     let values = match &out[0] {
-        Tensor::F64(inner) => inner.host_data().to_vec(),
+        Tensor::F64(inner) => inner.host_data().unwrap().to_vec(),
         _ => panic!("expected f64 tensor"),
     };
     let vectors = matrix_f64_from_tensor(&out[1], 2, 2);
@@ -419,10 +438,8 @@ fn test_real_eigh() {
 
 #[test]
 fn test_real_cholesky_returns_error_for_non_positive_definite_input() {
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 2.0, 2.0, 1.0],
-    ));
+    let input =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 2.0, 1.0]).unwrap());
     let mut backend = CpuBackend::new();
     let err = backend.cholesky(&input).unwrap_err();
     assert!(matches!(
@@ -433,11 +450,9 @@ fn test_real_cholesky_returns_error_for_non_positive_definite_input() {
 
 #[test]
 fn test_real_solve_returns_error_for_singular_matrix() {
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 2.0, 2.0, 4.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1.0, 1.0]));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 2.0, 4.0]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1.0, 1.0]).unwrap());
     let mut backend = CpuBackend::new();
     let err = backend.solve(&a, &b).unwrap_err();
     assert!(matches!(
@@ -455,7 +470,7 @@ fn test_complex_cholesky() {
         Complex64::new(1.5, 0.0),
     ];
     let a = matmul_c64(&l, &conjugate_transpose_c64(&l, 2, 2), 2, 2, 2);
-    let input = Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], a.clone()));
+    let input = Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], a.clone()).unwrap());
 
     let mut backend = CpuBackend::new();
     let out = backend.cholesky(&input).unwrap();
@@ -470,15 +485,18 @@ fn test_complex_cholesky() {
 
 #[test]
 fn test_complex_cholesky_returns_error_for_non_positive_definite_input() {
-    let input = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![
-            Complex64::new(1.0, 0.0),
-            Complex64::new(2.0, 0.0),
-            Complex64::new(2.0, 0.0),
-            Complex64::new(1.0, 0.0),
-        ],
-    ));
+    let input = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(2.0, 0.0),
+                Complex64::new(2.0, 0.0),
+                Complex64::new(1.0, 0.0),
+            ],
+        )
+        .unwrap(),
+    );
     let mut backend = CpuBackend::new();
     let err = backend.cholesky(&input).unwrap_err();
     assert!(matches!(
@@ -497,10 +515,8 @@ fn test_complex_qr() {
         Complex64::new(-0.25, 1.5),
         Complex64::new(3.0, 0.75),
     ];
-    let input = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![3, 2],
-        input_data.clone(),
-    ));
+    let input =
+        Tensor::C64(TypedTensor::from_vec_col_major(vec![3, 2], input_data.clone()).unwrap());
 
     let mut backend = CpuBackend::new();
     let out = backend.qr(&input).unwrap();
@@ -527,10 +543,8 @@ fn test_complex_svd() {
         Complex64::new(-0.25, 1.5),
         Complex64::new(3.0, 0.75),
     ];
-    let input = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![3, 2],
-        input_data.clone(),
-    ));
+    let input =
+        Tensor::C64(TypedTensor::from_vec_col_major(vec![3, 2], input_data.clone()).unwrap());
     let mut backend = CpuBackend::new();
     let out = backend.svd(&input).unwrap();
 
@@ -566,8 +580,8 @@ fn test_complex_triangular_solve_right_side_unit_transpose() {
         Complex64::new(1.0, 0.0),
     ];
     let b_data = vec![Complex64::new(2.0, 1.0), Complex64::new(-1.0, 0.5)];
-    let a = Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], a_data.clone()));
-    let b = Tensor::C64(TypedTensor::from_vec_col_major(vec![1, 2], b_data.clone()));
+    let a = Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], a_data.clone()).unwrap());
+    let b = Tensor::C64(TypedTensor::from_vec_col_major(vec![1, 2], b_data.clone()).unwrap());
 
     let mut backend = CpuBackend::new();
     let x = backend
@@ -576,7 +590,7 @@ fn test_complex_triangular_solve_right_side_unit_transpose() {
 
     assert_eq!(x.shape(), &[1, 2]);
     let x_data = match &x {
-        Tensor::C64(inner) => inner.host_data().to_vec(),
+        Tensor::C64(inner) => inner.host_data().unwrap().to_vec(),
         _ => panic!("expected c64 tensor"),
     };
     let recon = matmul_c64(&x_data, &transpose_c64(&a_data, 2, 2), 1, 2, 2);
@@ -629,15 +643,17 @@ fn test_triangular_solve_covers_all_complex_branch_combinations() {
                         matmul_c64(&expected_x, &op_a, 2, 2, 2)
                     };
 
-                    let a = Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], a_data));
-                    let b = Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], b_data));
+                    let a =
+                        Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], a_data).unwrap());
+                    let b =
+                        Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], b_data).unwrap());
                     let mut backend = CpuBackend::new();
                     let x = backend
                         .triangular_solve(&a, &b, left_side, lower, transpose_a, unit_diagonal)
                         .unwrap();
 
                     let x_data = match &x {
-                        Tensor::C64(inner) => inner.host_data(),
+                        Tensor::C64(inner) => inner.host_data().unwrap(),
                         _ => panic!("expected c64 tensor"),
                     };
                     for (actual, expected) in x_data.iter().zip(expected_x.iter()) {
@@ -651,19 +667,25 @@ fn test_triangular_solve_covers_all_complex_branch_combinations() {
 
 #[test]
 fn test_complex_solve_returns_error_for_singular_matrix() {
-    let a = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![
-            Complex64::new(1.0, 0.0),
-            Complex64::new(2.0, 0.0),
-            Complex64::new(2.0, 0.0),
-            Complex64::new(4.0, 0.0),
-        ],
-    ));
-    let b = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2, 1],
-        vec![Complex64::new(1.0, 0.0), Complex64::new(1.0, 0.0)],
-    ));
+    let a = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(2.0, 0.0),
+                Complex64::new(2.0, 0.0),
+                Complex64::new(4.0, 0.0),
+            ],
+        )
+        .unwrap(),
+    );
+    let b = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 1],
+            vec![Complex64::new(1.0, 0.0), Complex64::new(1.0, 0.0)],
+        )
+        .unwrap(),
+    );
     let mut backend = CpuBackend::new();
     let err = backend.solve(&a, &b).unwrap_err();
     assert!(matches!(

--- a/crates/tenferro-linalg/src/cpu/tests/mod.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/mod.rs
@@ -25,49 +25,49 @@ use tenferro_tensor::types::{DType, Tensor, TensorRead, TensorView, TypedTensor}
 
 fn get_f64(t: &Tensor, idx: &[usize]) -> f64 {
     match t {
-        Tensor::F64(inner) => *inner.get(idx),
+        Tensor::F64(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected F64 tensor"),
     }
 }
 
 fn get_c64(t: &Tensor, idx: &[usize]) -> Complex64 {
     match t {
-        Tensor::C64(inner) => *inner.get(idx),
+        Tensor::C64(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected C64 tensor"),
     }
 }
 
 fn get_f32(t: &Tensor, idx: &[usize]) -> f32 {
     match t {
-        Tensor::F32(inner) => *inner.get(idx),
+        Tensor::F32(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected F32 tensor"),
     }
 }
 
 fn get_c32(t: &Tensor, idx: &[usize]) -> Complex32 {
     match t {
-        Tensor::C32(inner) => *inner.get(idx),
+        Tensor::C32(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected C32 tensor"),
     }
 }
 
 fn get_i64(t: &Tensor, idx: &[usize]) -> i64 {
     match t {
-        Tensor::I64(inner) => *inner.get(idx),
+        Tensor::I64(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected I64 tensor"),
     }
 }
 
 fn get_i32(t: &Tensor, idx: &[usize]) -> i32 {
     match t {
-        Tensor::I32(inner) => *inner.get(idx),
+        Tensor::I32(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected I32 tensor"),
     }
 }
 
 fn get_bool(t: &Tensor, idx: &[usize]) -> bool {
     match t {
-        Tensor::Bool(inner) => *inner.get(idx),
+        Tensor::Bool(inner) => *inner.get(idx).unwrap(),
         _ => panic!("expected Bool tensor"),
     }
 }

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -4,8 +4,10 @@ use std::sync::Arc;
 
 use tenferro_extension_macros::define_extension_runtime;
 use tenferro_ops::SymDim;
-use tenferro_runtime::extension::{ExtensionExecutionContext, ExtensionOpTrait};
-use tenferro_tensor::{DType, DeviceKind, Error, GpuBackendKind, MemoryKind, Placement, Tensor};
+use tenferro_runtime::extension::{ExtensionExecutionContext, ExtensionOp};
+use tenferro_tensor::{
+    DType, DeviceKind, Error, GpuBackendKind, MemoryKind, Placement, Tensor, TensorRead,
+};
 
 use crate::backend::LinalgBackend;
 
@@ -174,7 +176,7 @@ fn execute_cuda_eager_linalg(
     inputs: &[&Tensor],
     device_ordinal: usize,
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
-    let mut backend = tenferro_gpu::CubeclBackend::new(device_ordinal)?;
+    let mut backend = tenferro_gpu::CudaBackend::new(device_ordinal)?;
     execute_linalg(op, inputs, &mut backend)
 }
 
@@ -194,7 +196,7 @@ fn execute_cuda_eager_linalg(
     ))
 }
 
-impl ExtensionOpTrait for LinalgExtensionOp {
+impl ExtensionOp for LinalgExtensionOp {
     fn family_id(&self) -> &'static str {
         LINALG_EXTENSION_FAMILY_ID
     }
@@ -238,14 +240,14 @@ impl ExtensionOpTrait for LinalgExtensionOp {
         }
     }
 
-    fn payload_eq(&self, other: &dyn ExtensionOpTrait) -> bool {
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
         other
             .as_any()
             .downcast_ref::<Self>()
             .is_some_and(|that| self == that)
     }
 
-    fn clone_arc(&self) -> Arc<dyn ExtensionOpTrait> {
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
         Arc::new(self.clone())
     }
 
@@ -336,11 +338,27 @@ fn execute_linalg_extension<B: LinalgBackend + 'static>(
     execute_linalg(op.op(), inputs, ctx.backend_mut())
 }
 
+fn execute_linalg_extension_reads<B: LinalgBackend + 'static>(
+    op: &LinalgExtensionOp,
+    inputs: &[TensorRead<'_>],
+    ctx: &mut ExtensionExecutionContext<'_, B>,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
+    // Linalg backends currently operate on compact tensors; materialization is
+    // explicit here so borrowed views cannot silently bypass backend errors.
+    let materialized_inputs: Vec<Tensor> = inputs
+        .iter()
+        .map(TensorRead::to_tensor)
+        .collect::<tenferro_tensor::Result<_>>()?;
+    let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
+    execute_linalg_extension(op, &input_refs, ctx)
+}
+
 define_extension_runtime! {
     runtime = LinalgRuntime,
     family_id = LINALG_EXTENSION_FAMILY_ID,
     op_type = LinalgExtensionOp,
     execute = execute_linalg_extension,
+    execute_reads = execute_linalg_extension_reads,
     register_fn = register_runtime,
     backend_bound = LinalgBackend,
 }

--- a/crates/tenferro-linalg/src/extension/tests.rs
+++ b/crates/tenferro-linalg/src/extension/tests.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use tenferro_runtime::extension::ExtensionOpTrait;
+use tenferro_runtime::extension::ExtensionOp;
 use tenferro_tensor::{
-    Buffer, BufferHandle, ComputeDevice, DeviceKind, Error, GpuBackendKind, MemoryKind, Placement,
+    Buffer, BufferHandle, DeviceId, DeviceKind, Error, GpuBackendKind, MemoryKind, Placement,
     Tensor, TypedTensor,
 };
 
@@ -10,17 +10,20 @@ use super::{LinalgExtensionOp, LinalgOp};
 
 #[test]
 fn eager_linalg_rejects_cuda_tensor_when_cuda_feature_is_disabled() {
-    let tensor = Tensor::F64(TypedTensor::from_buffer_col_major(
-        vec![2, 2],
-        Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(7, 4))),
-        Placement {
-            memory_kind: MemoryKind::Device,
-            device: Some(ComputeDevice {
-                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
-                ordinal: 0,
-            }),
-        },
-    ));
+    let tensor = Tensor::F64(
+        TypedTensor::from_buffer_col_major(
+            vec![2, 2],
+            Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(7, 4))),
+            Placement {
+                memory_kind: MemoryKind::Device,
+                device: Some(DeviceId {
+                    kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+                    ordinal: 0,
+                }),
+            },
+        )
+        .unwrap(),
+    );
     let op = LinalgExtensionOp::new(LinalgOp::Cholesky);
 
     let err = op.eager_execute(&[&tensor]).unwrap_err();

--- a/crates/tenferro-linalg/src/gpu/linalg.rs
+++ b/crates/tenferro-linalg/src/gpu/linalg.rs
@@ -3,7 +3,7 @@ use std::ops::Neg;
 use std::os::raw::c_char;
 
 use cubecl::prelude::{ComplexCore, CubeElement, CubePrimitive};
-use cubecl_cuda::CudaRuntime;
+use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
 use cudarc::runtime::{result as cuda_result, sys::cudaStream_t};
 use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
@@ -21,7 +21,7 @@ use tenferro_gpu::cuda_interop::{
 };
 // validate_nonsingular_gpu uses backend ops (extract_diagonal, abs, reduce_min)
 // then downloads a single scalar — no bulk host roundtrip.
-use tenferro_gpu::{download_tensor, CubeclBackend, CubeclRuntime};
+use tenferro_gpu::{download_tensor, CudaBackend, CudaRuntime};
 use tenferro_tensor::config::SliceConfig;
 use tenferro_tensor::{
     DType, Error, Tensor, TensorElementwise, TensorReduction, TensorStructural, TypedTensor,
@@ -38,7 +38,7 @@ trait LinalgScalar:
     const NEEDS_RWORK: bool;
 
     fn copy_svd_v_to_vt(
-        rt: &CubeclRuntime,
+        rt: &CudaRuntime,
         v: &TypedTensor<Self>,
         vt_shape: &[usize],
         op: &'static str,
@@ -52,7 +52,7 @@ impl LinalgScalar for f32 {
     const NEEDS_RWORK: bool = false;
 
     fn copy_svd_v_to_vt(
-        rt: &CubeclRuntime,
+        rt: &CudaRuntime,
         v: &TypedTensor<Self>,
         vt_shape: &[usize],
         op: &'static str,
@@ -68,7 +68,7 @@ impl LinalgScalar for f64 {
     const NEEDS_RWORK: bool = false;
 
     fn copy_svd_v_to_vt(
-        rt: &CubeclRuntime,
+        rt: &CudaRuntime,
         v: &TypedTensor<Self>,
         vt_shape: &[usize],
         op: &'static str,
@@ -84,7 +84,7 @@ impl LinalgScalar for Complex32 {
     const NEEDS_RWORK: bool = true;
 
     fn copy_svd_v_to_vt(
-        rt: &CubeclRuntime,
+        rt: &CudaRuntime,
         v: &TypedTensor<Self>,
         vt_shape: &[usize],
         op: &'static str,
@@ -100,7 +100,7 @@ impl LinalgScalar for Complex64 {
     const NEEDS_RWORK: bool = true;
 
     fn copy_svd_v_to_vt(
-        rt: &CubeclRuntime,
+        rt: &CudaRuntime,
         v: &TypedTensor<Self>,
         vt_shape: &[usize],
         op: &'static str,
@@ -162,9 +162,7 @@ fn ensure_cubecl_resident_typed<T: 'static>(
     ensure_typed_tensor_resident(input, op)
 }
 
-fn linalg_handles(
-    backend: &CubeclBackend,
-) -> Result<CudaExtensionCacheGuard<'_, CudaLinalgHandles>> {
+fn linalg_handles(backend: &CudaBackend) -> Result<CudaExtensionCacheGuard<'_, CudaLinalgHandles>> {
     backend
         .cuda_extension_cache()
         .get_or_try_init(CudaLinalgHandles::load)
@@ -186,7 +184,7 @@ impl Workspace {
     }
 }
 
-pub(super) fn cholesky(backend: &mut CubeclBackend, input: &Tensor) -> Result<Tensor> {
+pub(super) fn cholesky(backend: &mut CudaBackend, input: &Tensor) -> Result<Tensor> {
     match input {
         Tensor::F32(t) => cholesky_typed(backend, t).map(Tensor::F32),
         Tensor::F64(t) => cholesky_typed(backend, t).map(Tensor::F64),
@@ -199,7 +197,7 @@ pub(super) fn cholesky(backend: &mut CubeclBackend, input: &Tensor) -> Result<Te
 }
 
 pub(super) fn triangular_solve(
-    backend: &mut CubeclBackend,
+    backend: &mut CudaBackend,
     a: &Tensor,
     b: &Tensor,
     left_side: bool,
@@ -236,7 +234,7 @@ pub(super) fn triangular_solve(
     }
 }
 
-pub(super) fn lu(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Tensor>> {
+pub(super) fn lu(backend: &mut CudaBackend, input: &Tensor) -> Result<Vec<Tensor>> {
     match input {
         Tensor::F32(t) => lu_typed(backend, t).map(|(p, l, u, parity)| {
             vec![
@@ -276,7 +274,7 @@ pub(super) fn lu(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Tens
     }
 }
 
-pub(super) fn lu_factor(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Tensor>> {
+pub(super) fn lu_factor(backend: &mut CudaBackend, input: &Tensor) -> Result<Vec<Tensor>> {
     match input {
         Tensor::F32(t) => lu_factor_typed(backend, t).map(|(packed_lu, pivots, parity)| {
             vec![
@@ -312,7 +310,7 @@ pub(super) fn lu_factor(backend: &mut CubeclBackend, input: &Tensor) -> Result<V
     }
 }
 
-pub(super) fn full_piv_lu(_backend: &mut CubeclBackend, _input: &Tensor) -> Result<Vec<Tensor>> {
+pub(super) fn full_piv_lu(_backend: &mut CudaBackend, _input: &Tensor) -> Result<Vec<Tensor>> {
     Err(Error::backend_failure(
         "full_piv_lu",
         "complete-pivoting LU is not implemented for the CubeCL backend",
@@ -320,7 +318,7 @@ pub(super) fn full_piv_lu(_backend: &mut CubeclBackend, _input: &Tensor) -> Resu
 }
 
 pub(super) fn full_piv_lu_solve(
-    _backend: &mut CubeclBackend,
+    _backend: &mut CudaBackend,
     _a: &Tensor,
     _b: &Tensor,
     _transpose_a: bool,
@@ -331,7 +329,7 @@ pub(super) fn full_piv_lu_solve(
     ))
 }
 
-pub(super) fn svd(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Tensor>> {
+pub(super) fn svd(backend: &mut CudaBackend, input: &Tensor) -> Result<Vec<Tensor>> {
     match input {
         Tensor::F32(t) => svd_typed(backend, t)
             .map(|(u, s, vt)| vec![Tensor::F32(u), Tensor::F32(s), Tensor::F32(vt)]),
@@ -347,7 +345,7 @@ pub(super) fn svd(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Ten
     }
 }
 
-pub(super) fn svd_values(backend: &mut CubeclBackend, input: &Tensor) -> Result<Tensor> {
+pub(super) fn svd_values(backend: &mut CudaBackend, input: &Tensor) -> Result<Tensor> {
     match input {
         Tensor::F32(t) => svd_values_typed(backend, t).map(Tensor::F32),
         Tensor::F64(t) => svd_values_typed(backend, t).map(Tensor::F64),
@@ -359,7 +357,7 @@ pub(super) fn svd_values(backend: &mut CubeclBackend, input: &Tensor) -> Result<
     }
 }
 
-pub(super) fn qr(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Tensor>> {
+pub(super) fn qr(backend: &mut CudaBackend, input: &Tensor) -> Result<Vec<Tensor>> {
     match input {
         Tensor::F32(t) => qr_typed(backend, t).map(|(q, r)| vec![Tensor::F32(q), Tensor::F32(r)]),
         Tensor::F64(t) => qr_typed(backend, t).map(|(q, r)| vec![Tensor::F64(q), Tensor::F64(r)]),
@@ -371,7 +369,7 @@ pub(super) fn qr(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Tens
     }
 }
 
-pub(super) fn eigh(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Tensor>> {
+pub(super) fn eigh(backend: &mut CudaBackend, input: &Tensor) -> Result<Vec<Tensor>> {
     match input {
         Tensor::F32(t) => eigh_typed(backend, t).map(|(w, v)| vec![Tensor::F32(w), Tensor::F32(v)]),
         Tensor::F64(t) => eigh_typed(backend, t).map(|(w, v)| vec![Tensor::F64(w), Tensor::F64(v)]),
@@ -383,7 +381,7 @@ pub(super) fn eigh(backend: &mut CubeclBackend, input: &Tensor) -> Result<Vec<Te
     }
 }
 
-pub(super) fn eigh_values(backend: &mut CubeclBackend, input: &Tensor) -> Result<Tensor> {
+pub(super) fn eigh_values(backend: &mut CudaBackend, input: &Tensor) -> Result<Tensor> {
     match input {
         Tensor::F32(t) => eigh_values_typed(backend, t).map(Tensor::F32),
         Tensor::F64(t) => eigh_values_typed(backend, t).map(Tensor::F64),
@@ -395,7 +393,7 @@ pub(super) fn eigh_values(backend: &mut CubeclBackend, input: &Tensor) -> Result
     }
 }
 
-pub(super) fn eig(_backend: &mut CubeclBackend, _input: &Tensor) -> Result<Vec<Tensor>> {
+pub(super) fn eig(_backend: &mut CudaBackend, _input: &Tensor) -> Result<Vec<Tensor>> {
     Err(Error::backend_failure(
         "eig",
         "non-symmetric eigendecomposition is not supported on the CubeCL GPU backend \
@@ -405,7 +403,7 @@ pub(super) fn eig(_backend: &mut CubeclBackend, _input: &Tensor) -> Result<Vec<T
     ))
 }
 
-pub(super) fn solve(backend: &mut CubeclBackend, a: &Tensor, b: &Tensor) -> Result<Tensor> {
+pub(super) fn solve(backend: &mut CudaBackend, a: &Tensor, b: &Tensor) -> Result<Tensor> {
     const OP: &str = "solve";
 
     backend.runtime().set_current_cuda_context(OP)?;
@@ -441,7 +439,7 @@ pub(super) fn solve(backend: &mut CubeclBackend, a: &Tensor, b: &Tensor) -> Resu
 }
 
 pub(super) fn lu_solve_prepared(
-    backend: &mut CubeclBackend,
+    backend: &mut CudaBackend,
     a: &Tensor,
     packed_lu: &Tensor,
     pivots: &Tensor,
@@ -509,7 +507,7 @@ pub(super) fn lu_solve_prepared(
     }
 }
 
-fn cholesky_typed<T>(backend: &CubeclBackend, input: &TypedTensor<T>) -> Result<TypedTensor<T>>
+fn cholesky_typed<T>(backend: &CudaBackend, input: &TypedTensor<T>) -> Result<TypedTensor<T>>
 where
     T: LinalgScalar,
 {
@@ -569,7 +567,7 @@ where
 }
 
 fn triangular_solve_typed<T>(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     a: &TypedTensor<T>,
     b: &TypedTensor<T>,
     left_side: bool,
@@ -598,7 +596,7 @@ where
 }
 
 fn triangular_solve_typed_with_op<T>(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     a: &TypedTensor<T>,
     b: &TypedTensor<T>,
     left_side: bool,
@@ -711,7 +709,7 @@ where
 }
 
 fn lu_typed<T>(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     input: &TypedTensor<T>,
 ) -> Result<(
     TypedTensor<T>,
@@ -738,7 +736,7 @@ where
 }
 
 fn lu_factor_typed<T>(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     input: &TypedTensor<T>,
 ) -> Result<(TypedTensor<T>, TypedTensor<i32>, TypedTensor<T>)>
 where
@@ -798,7 +796,7 @@ where
     }
 
     let host_info = download_device_tensor(backend.runtime(), &info, OP)?;
-    for &info_value in host_info.host_data() {
+    for &info_value in host_info.host_data()? {
         if info_value < 0 {
             return Err(Error::backend_failure(
                 OP,
@@ -815,7 +813,7 @@ where
 }
 
 fn lu_solve_prepared_typed<T>(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     packed_lu: &TypedTensor<T>,
     pivots: &TypedTensor<i32>,
     b: &TypedTensor<T>,
@@ -882,7 +880,7 @@ where
 }
 
 fn copy_svd_v_to_vt_real<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     v: &TypedTensor<T>,
     vt_shape: &[usize],
     op: &'static str,
@@ -896,7 +894,7 @@ where
 }
 
 fn copy_svd_v_to_vt_complex<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     v: &TypedTensor<T>,
     vt_shape: &[usize],
     op: &'static str,
@@ -910,7 +908,7 @@ where
 }
 
 fn launch_svd_v_to_vt_real<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     v: &TypedTensor<T>,
     vt: &TypedTensor<T>,
     op: &'static str,
@@ -925,7 +923,7 @@ where
     let v_arg = typed_tensor_binding(v, op)?;
     let launch_count = cube_count_for_len(vt.n_elements())?;
     with_cubecl_client(rt, |client| unsafe {
-        cubecl_linalg::svd_v_to_vt_real::launch_unchecked::<T, CudaRuntime>(
+        cubecl_linalg::svd_v_to_vt_real::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
             launch_count,
             cube_dim_1d(),
@@ -938,7 +936,7 @@ where
 }
 
 fn launch_svd_v_to_vt_complex<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     v: &TypedTensor<T>,
     vt: &TypedTensor<T>,
     op: &'static str,
@@ -953,7 +951,7 @@ where
     let v_arg = typed_tensor_binding(v, op)?;
     let launch_count = cube_count_for_len(vt.n_elements())?;
     with_cubecl_client(rt, |client| unsafe {
-        cubecl_linalg::svd_v_to_vt_complex::launch_unchecked::<T, CudaRuntime>(
+        cubecl_linalg::svd_v_to_vt_complex::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
             launch_count,
             cube_dim_1d(),
@@ -966,7 +964,7 @@ where
 }
 
 fn svd_typed<T>(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     input: &TypedTensor<T>,
 ) -> Result<(
     TypedTensor<T>,
@@ -1163,7 +1161,7 @@ where
 }
 
 fn svd_values_typed<T>(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     input: &TypedTensor<T>,
 ) -> Result<TypedTensor<T::Real>>
 where
@@ -1342,7 +1340,7 @@ where
 }
 
 fn qr_typed<T>(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     input: &TypedTensor<T>,
 ) -> Result<(TypedTensor<T>, TypedTensor<T>)>
 where
@@ -1458,7 +1456,7 @@ where
 }
 
 fn eigh_typed<T>(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     input: &TypedTensor<T>,
 ) -> Result<(TypedTensor<T::Real>, TypedTensor<T>)>
 where
@@ -1535,7 +1533,7 @@ where
 }
 
 fn eigh_values_typed<T>(
-    backend: &CubeclBackend,
+    backend: &CudaBackend,
     input: &TypedTensor<T>,
 ) -> Result<TypedTensor<T::Real>>
 where
@@ -1610,7 +1608,7 @@ where
 }
 
 fn build_lu_outputs_device<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     lu: &TypedTensor<T>,
     pivots: &TypedTensor<i32>,
     m: usize,
@@ -1651,7 +1649,7 @@ where
     let pivots_arg = typed_tensor_array_arg(pivots, "lu")?;
     let launch_count = cube_count_for_len(launch_len)?;
     with_cubecl_client(rt, |client| unsafe {
-        cubecl_linalg::lu_extract_outputs::launch_unchecked::<T, CudaRuntime>(
+        cubecl_linalg::lu_extract_outputs::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
             launch_count,
             cube_dim_1d(),
@@ -1671,7 +1669,7 @@ where
 }
 
 fn build_lu_parity_device<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     pivots: &TypedTensor<i32>,
     k: usize,
     batch_shape: &[usize],
@@ -1684,7 +1682,7 @@ where
     let pivots_arg = typed_tensor_array_arg(pivots, "lu_factor")?;
     let launch_count = cube_count_for_len(parity.n_elements())?;
     with_cubecl_client(rt, |client| unsafe {
-        cubecl_linalg::lu_parity::launch_unchecked::<T, CudaRuntime>(
+        cubecl_linalg::lu_parity::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
             launch_count,
             cube_dim_1d(),
@@ -1698,7 +1696,7 @@ where
 }
 
 fn fill_one_device_tensor<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     shape: &[usize],
     op: &'static str,
 ) -> Result<TypedTensor<T>>
@@ -1709,7 +1707,7 @@ where
     let out_arg = typed_tensor_binding(&out, op)?;
     let launch_count = cube_count_for_len(out.n_elements())?;
     with_cubecl_client(rt, |client| unsafe {
-        cubecl_linalg::fill_one_kernel::launch_unchecked::<T, CudaRuntime>(
+        cubecl_linalg::fill_one_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
             launch_count,
             cube_dim_1d(),
@@ -1721,7 +1719,7 @@ where
 }
 
 fn apply_lu_pivots_typed<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     input: &TypedTensor<T>,
     pivots: &TypedTensor<i32>,
     inverse: bool,
@@ -1739,7 +1737,7 @@ where
     let pivots_arg = typed_tensor_array_arg(pivots, "lu_solve_prepared")?;
     let launch_count = cube_count_for_len(out.n_elements())?;
     with_cubecl_client(rt, |client| unsafe {
-        cubecl_linalg::lu_apply_pivots::launch_unchecked::<T, CudaRuntime>(
+        cubecl_linalg::lu_apply_pivots::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
             launch_count,
             cube_dim_1d(),
@@ -1756,7 +1754,7 @@ where
 }
 
 fn zero_sized_lu_factor_outputs<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     shape: &[usize],
 ) -> Result<(TypedTensor<T>, TypedTensor<i32>, TypedTensor<T>)>
 where
@@ -1777,22 +1775,22 @@ where
     ))
 }
 
-fn raw_stream(rt: &CubeclRuntime, op: &'static str) -> Result<CudaStream> {
+fn raw_stream(rt: &CudaRuntime, op: &'static str) -> Result<CudaStream> {
     raw_cuda_stream(rt, op).map(|stream| stream as usize as CudaStream)
 }
 
-fn sync_stream(rt: &CubeclRuntime, op: &'static str) -> Result<()> {
+fn sync_stream(rt: &CudaRuntime, op: &'static str) -> Result<()> {
     let stream = raw_stream(rt, op)? as cudaStream_t;
     unsafe { cuda_result::stream::synchronize(stream) }.map_err(|err| {
         Error::backend_failure(op, format!("CUDA stream synchronize failed: {err:?}"))
     })
 }
 
-fn alloc_workspace_bytes(rt: &CubeclRuntime, nbytes: usize, op: &'static str) -> Result<Workspace> {
+fn alloc_workspace_bytes(rt: &CudaRuntime, nbytes: usize, op: &'static str) -> Result<Workspace> {
     alloc_device_bytes(rt, nbytes, op).map(Workspace::from_device)
 }
 
-fn alloc_workspace_elems<T>(rt: &CubeclRuntime, len: i32, op: &'static str) -> Result<Workspace>
+fn alloc_workspace_elems<T>(rt: &CudaRuntime, len: i32, op: &'static str) -> Result<Workspace>
 where
     T: CubeElement + Clone,
 {
@@ -1802,7 +1800,7 @@ where
 }
 
 fn typed_device_ptr<T: 'static>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     tensor: &TypedTensor<T>,
     op: &'static str,
 ) -> Result<*mut c_void> {
@@ -1810,7 +1808,7 @@ fn typed_device_ptr<T: 'static>(
 }
 
 fn clone_device_tensor<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     tensor: &TypedTensor<T>,
     op: &'static str,
 ) -> Result<TypedTensor<T>>
@@ -1834,7 +1832,7 @@ where
 }
 
 fn upload_pointer_array(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     pointers: &[usize],
     op: &'static str,
 ) -> Result<Workspace> {
@@ -1846,7 +1844,7 @@ fn upload_pointer_array(
 }
 
 fn download_device_tensor<T>(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     tensor: &TypedTensor<T>,
     op: &'static str,
 ) -> Result<TypedTensor<T>>
@@ -1858,7 +1856,7 @@ where
 }
 
 fn copy_device_to_device(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     dst: *mut c_void,
     src: *const c_void,
     nbytes: usize,
@@ -1984,13 +1982,13 @@ fn check_solver_info(op: &'static str, call: &'static str, info: i32) -> Result<
 }
 
 fn check_solver_info_tensor(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     info: &TypedTensor<i32>,
     op: &'static str,
     call: &'static str,
 ) -> Result<()> {
     let host_info = download_device_tensor(rt, info, op)?;
-    for &value in host_info.host_data() {
+    for &value in host_info.host_data()? {
         check_solver_info(op, call, value)?;
     }
     Ok(())
@@ -2054,7 +2052,7 @@ unsafe fn batch_const_ptr<T>(base: *const c_void, offset: usize) -> *const c_voi
 }
 
 fn zero_like_linalg_device_tensor(
-    rt: &CubeclRuntime,
+    rt: &CudaRuntime,
     input: &Tensor,
     op: &'static str,
 ) -> Result<Tensor> {
@@ -2093,7 +2091,7 @@ fn batched_vector_rhs_shape(a: &Tensor, b: &Tensor) -> Option<Vec<usize>> {
 /// download 1 scalar → check > 0.
 ///
 /// Only the final scalar (8 bytes) is transferred to host.
-fn validate_nonsingular_gpu(backend: &mut CubeclBackend, u: &Tensor) -> Result<()> {
+fn validate_nonsingular_gpu(backend: &mut CudaBackend, u: &Tensor) -> Result<()> {
     let diag = backend.extract_diagonal(u, 0, 1)?;
 
     // abs — convert complex to real first (complex abs not supported)
@@ -2114,8 +2112,14 @@ fn validate_nonsingular_gpu(backend: &mut CubeclBackend, u: &Tensor) -> Result<(
     backend.runtime().synchronize()?;
     let host_min = download_tensor(backend.runtime(), &min_val)?;
     let is_singular = match &host_min {
-        Tensor::F64(t) => t.host_data()[0] == 0.0 || !t.host_data()[0].is_finite(),
-        Tensor::F32(t) => t.host_data()[0] == 0.0 || !t.host_data()[0].is_finite(),
+        Tensor::F64(t) => {
+            let value = t.host_data()?[0];
+            value == 0.0 || !value.is_finite()
+        }
+        Tensor::F32(t) => {
+            let value = t.host_data()?[0];
+            value == 0.0 || !value.is_finite()
+        }
         _ => {
             return Err(Error::backend_failure(
                 "solve",

--- a/crates/tenferro-linalg/src/gpu/mod.rs
+++ b/crates/tenferro-linalg/src/gpu/mod.rs
@@ -2,12 +2,12 @@ mod ffi;
 mod kernels;
 mod linalg;
 
-use tenferro_gpu::CubeclBackend;
+use tenferro_gpu::CudaBackend;
 use tenferro_tensor::{DType, Error, Tensor, TensorView, TensorViewCanonicalization};
 
 use crate::backend::LinalgBackend;
 
-impl LinalgBackend for CubeclBackend {
+impl LinalgBackend for CudaBackend {
     fn cholesky(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         linalg::cholesky(self, input)
     }

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -40,15 +40,11 @@ mod traced;
 pub mod traced_tensor;
 
 #[cfg(feature = "autodiff")]
+pub use ad::ad_rules;
+#[cfg(feature = "autodiff")]
 pub use ad::support::{
     all_linalg_ad_support, linalg_ad_support, LinalgAdOpKind, LinalgAdOutputSupport,
     LinalgAdRuleSupport, LinalgAdSupport,
 };
-#[cfg(feature = "autodiff")]
-pub use ad::{ad_rules, register_extension_rule};
 pub use backend::LinalgBackend;
 pub use extension::{register_runtime, LINALG_EXTENSION_FAMILY_ID};
-pub use traced::{
-    cholesky, det, eig, eigh, eigh_with_eps, eigvals, eigvalsh, full_piv_lu, full_piv_lu_solve,
-    inv, lu, norm, pinv, pinv_with_rtol, qr, slogdet, solve, svd, svd_with_eps, triangular_solve,
-};

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use num_complex::{Complex32, Complex64};
-use tenferro_runtime::extension::try_apply;
+use tenferro_runtime::extension::apply;
 use tenferro_runtime::{CompareDir, DType, DotGeneralConfig, Error, Result, TracedTensor};
 
 use crate::extension::{LinalgExtensionOp, LinalgOp};
@@ -41,7 +41,7 @@ pub fn svd_with_eps(
     eps: f64,
 ) -> Result<(TracedTensor, TracedTensor, TracedTensor)> {
     three_outputs(
-        try_apply(
+        apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::Svd { eps })),
             &[a],
         )?,
@@ -64,7 +64,7 @@ pub fn svd_with_eps(
 /// ```
 pub fn qr(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
     two_outputs(
-        try_apply(Arc::new(LinalgExtensionOp::new(LinalgOp::Qr)), &[a])?,
+        apply(Arc::new(LinalgExtensionOp::new(LinalgOp::Qr)), &[a])?,
         "qr",
     )
 }
@@ -100,7 +100,7 @@ pub fn eigh(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
 /// ```
 pub fn eigh_with_eps(a: &TracedTensor, eps: f64) -> Result<(TracedTensor, TracedTensor)> {
     two_outputs(
-        try_apply(
+        apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::Eigh { eps })),
             &[a],
         )?,
@@ -122,7 +122,7 @@ pub fn eigh_with_eps(a: &TracedTensor, eps: f64) -> Result<(TracedTensor, Traced
 /// ```
 pub fn cholesky(a: &TracedTensor) -> Result<TracedTensor> {
     one_output(
-        try_apply(Arc::new(LinalgExtensionOp::new(LinalgOp::Cholesky)), &[a])?,
+        apply(Arc::new(LinalgExtensionOp::new(LinalgOp::Cholesky)), &[a])?,
         "cholesky",
     )
 }
@@ -144,7 +144,7 @@ pub fn cholesky(a: &TracedTensor) -> Result<TracedTensor> {
 /// ```
 pub fn lu(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor, TracedTensor, TracedTensor)> {
     four_outputs(
-        try_apply(Arc::new(LinalgExtensionOp::new(LinalgOp::Lu)), &[a])?,
+        apply(Arc::new(LinalgExtensionOp::new(LinalgOp::Lu)), &[a])?,
         "lu",
     )
 }
@@ -180,7 +180,7 @@ pub fn full_piv_lu(
     TracedTensor,
 )> {
     five_outputs(
-        try_apply(Arc::new(LinalgExtensionOp::new(LinalgOp::FullPivLu)), &[a])?,
+        apply(Arc::new(LinalgExtensionOp::new(LinalgOp::FullPivLu)), &[a])?,
         "full_piv_lu",
     )
 }
@@ -200,7 +200,7 @@ pub fn full_piv_lu(
 /// ```
 pub fn eig(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
     two_outputs(
-        try_apply(
+        apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::Eig {
                 input_dtype: a.dtype,
             })),
@@ -225,7 +225,7 @@ pub fn eig(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
 /// ```
 pub fn solve(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
     let mut factor_outputs =
-        try_apply(Arc::new(LinalgExtensionOp::new(LinalgOp::LuFactor)), &[a])?.into_iter();
+        apply(Arc::new(LinalgExtensionOp::new(LinalgOp::LuFactor)), &[a])?.into_iter();
     let (packed_lu, pivots) = match (
         factor_outputs.next(),
         factor_outputs.next(),
@@ -236,7 +236,7 @@ pub fn solve(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
         _ => return Err(unexpected_output_count("lu_factor", 3)),
     };
     one_output(
-        try_apply(
+        apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::LuSolvePrepared {
                 transpose_a: false,
                 conjugate_a: false,
@@ -262,7 +262,7 @@ pub fn solve(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
 /// ```
 pub fn full_piv_lu_solve(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
     one_output(
-        try_apply(
+        apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::FullPivLuSolve {
                 transpose_a: false,
             })),
@@ -294,7 +294,7 @@ pub fn triangular_solve(
     unit_diagonal: bool,
 ) -> Result<TracedTensor> {
     one_output(
-        try_apply(
+        apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::TriangularSolve {
                 left_side,
                 lower,
@@ -322,7 +322,7 @@ pub fn triangular_solve(
 /// ```
 pub fn slogdet(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
     let mut factor_outputs =
-        try_apply(Arc::new(LinalgExtensionOp::new(LinalgOp::LuFactor)), &[a])?.into_iter();
+        apply(Arc::new(LinalgExtensionOp::new(LinalgOp::LuFactor)), &[a])?.into_iter();
     let (packed_lu, parity) = match (
         factor_outputs.next(),
         factor_outputs.next(),
@@ -332,10 +332,10 @@ pub fn slogdet(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
         (Some(packed_lu), Some(_pivots), Some(parity), None) => (packed_lu, parity),
         _ => return Err(unexpected_output_count("lu_factor", 3)),
     };
-    let diag_u = packed_lu.extract_diag(0, 1);
-    let sign_u = diag_u.sign().reduce_prod(&[0]);
-    let sign = &parity * &sign_u;
-    let logabsdet = diag_u.abs().log().reduce_sum(&[0]);
+    let diag_u = packed_lu.extract_diag(0, 1)?;
+    let sign_u = diag_u.sign().reduce_prod(&[0])?;
+    let sign = (&parity * &sign_u)?;
+    let logabsdet = diag_u.abs().log().reduce_sum(&[0])?;
     Ok((sign, logabsdet))
 }
 
@@ -353,7 +353,7 @@ pub fn slogdet(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
 /// ```
 pub fn det(a: &TracedTensor) -> Result<TracedTensor> {
     let (sign, logabsdet) = slogdet(a)?;
-    Ok(&sign * &logabsdet.exp())
+    &sign * &logabsdet.exp()
 }
 
 /// Build a traced matrix inverse op.
@@ -371,7 +371,7 @@ pub fn det(a: &TracedTensor) -> Result<TracedTensor> {
 pub fn inv(a: &TracedTensor) -> Result<TracedTensor> {
     ensure_min_rank("inv", a.rank, 2)?;
     let shape = require_concrete_shape("inv", a)?;
-    let eye = eye_like(a, shape[0]);
+    let eye = eye_like(a, shape[0])?;
     solve(a, &eye)
 }
 
@@ -453,21 +453,21 @@ pub fn pinv_with_rtol(a: &TracedTensor, rtol: f64) -> Result<TracedTensor> {
     require_concrete_shape("pinv_with_rtol", a)?;
     let (u, s, vt) = svd(a)?;
     let abs_s = s.abs();
-    let s_max = abs_s.reduce_max(&[0]);
-    let s_max_shape = s_max.concrete_shape();
-    let threshold = &s_max * &broadcast_scalar(scalar_real(s.dtype, rtol.max(0.0)), &s_max_shape);
-    let s_shape = s.concrete_shape();
-    let threshold = broadcast_batch_scalar_to_leading_axis(&threshold, &s_shape);
-    let mask = abs_s.compare(&threshold, CompareDir::Gt);
+    let s_max = abs_s.reduce_max(&[0])?;
+    let s_max_shape = s_max.concrete_shape()?;
+    let threshold = &s_max * &broadcast_scalar(scalar_real(s.dtype, rtol.max(0.0)), &s_max_shape)?;
+    let s_shape = s.concrete_shape()?;
+    let threshold = broadcast_batch_scalar_to_leading_axis(&threshold?, &s_shape)?;
+    let mask = abs_s.compare(&threshold, CompareDir::Gt)?;
     let mask = mask.convert(s.dtype);
-    let ones = ones_like(&s);
-    let denom = &s + &(&ones + &(-&mask));
-    let s_inv = &mask / &denom;
+    let ones = ones_like(&s)?;
+    let denom = (&s + &(&ones + &(-&mask))?)?;
+    let s_inv = (&mask / &denom)?;
 
-    let v = vt.conj().transpose(&matrix_transpose_perm(vt.rank));
-    let uh = u.conj().transpose(&matrix_transpose_perm(u.rank));
-    let vs = scale_matrix_columns(&v, &s_inv);
-    Ok(matmul_preserve_trailing_batch(&vs, &uh))
+    let v = vt.conj().transpose(&matrix_transpose_perm(vt.rank))?;
+    let uh = u.conj().transpose(&matrix_transpose_perm(u.rank))?;
+    let vs = scale_matrix_columns(&v, &s_inv)?;
+    matmul_preserve_trailing_batch(&vs, &uh)
 }
 
 /// Build a traced vector, matrix, or tensor norm op.
@@ -500,16 +500,16 @@ pub fn norm(
     validate_axes("norm", a.rank, &axes)?;
 
     let out = match axes.len() {
-        1 => vector_norm(a, axes[0], ord),
+        1 => vector_norm(a, axes[0], ord)?,
         2 => matrix_norm(a, &axes, ord)?,
         _ => {
             let abs = a.abs();
             match ord {
-                None => frobenius_norm(&abs, &axes),
-                Some(p) if p == f64::INFINITY => abs.reduce_max(&axes),
-                Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(&axes),
-                Some(0.0) => count_nonzero(&abs, &axes),
-                Some(p) => p_norm(&abs, &axes, p),
+                None => frobenius_norm(&abs, &axes)?,
+                Some(p) if p == f64::INFINITY => abs.reduce_max(&axes)?,
+                Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(&axes)?,
+                Some(0.0) => count_nonzero(&abs, &axes)?,
+                Some(p) => p_norm(&abs, &axes, p)?,
             }
         }
     };
@@ -599,14 +599,31 @@ fn five_outputs(
 
 fn scalar_real(dtype: DType, value: f64) -> TracedTensor {
     match dtype {
-        DType::F64 => TracedTensor::from_vec_col_major(vec![], vec![value]),
-        DType::F32 => TracedTensor::from_vec_col_major(vec![], vec![value as f32]),
-        DType::I32 => TracedTensor::from_vec_col_major(vec![], vec![value.round() as i32]),
-        DType::I64 => TracedTensor::from_vec_col_major(vec![], vec![value.round() as i64]),
-        DType::Bool => TracedTensor::from_vec_col_major(vec![], vec![value != 0.0]),
-        DType::C64 => TracedTensor::from_vec_col_major(vec![], vec![Complex64::new(value, 0.0)]),
+        // Rank-0 scalar constants always have exactly one element.
+        DType::F64 => {
+            TracedTensor::from_vec_col_major(vec![], vec![value]).expect("scalar constant")
+        }
+        // Rank-0 scalar constants always have exactly one element.
+        DType::F32 => {
+            TracedTensor::from_vec_col_major(vec![], vec![value as f32]).expect("scalar constant")
+        }
+        // Rank-0 scalar constants always have exactly one element.
+        DType::I32 => TracedTensor::from_vec_col_major(vec![], vec![value.round() as i32])
+            .expect("scalar constant"),
+        // Rank-0 scalar constants always have exactly one element.
+        DType::I64 => TracedTensor::from_vec_col_major(vec![], vec![value.round() as i64])
+            .expect("scalar constant"),
+        // Rank-0 scalar constants always have exactly one element.
+        DType::Bool => {
+            TracedTensor::from_vec_col_major(vec![], vec![value != 0.0]).expect("scalar constant")
+        }
+        // Rank-0 scalar constants always have exactly one element.
+        DType::C64 => TracedTensor::from_vec_col_major(vec![], vec![Complex64::new(value, 0.0)])
+            .expect("scalar constant"),
+        // Rank-0 scalar constants always have exactly one element.
         DType::C32 => {
             TracedTensor::from_vec_col_major(vec![], vec![Complex32::new(value as f32, 0.0)])
+                .expect("scalar constant")
         }
     }
 }
@@ -659,37 +676,40 @@ fn one_scalar(dtype: DType) -> TracedTensor {
     scalar_real(dtype, 1.0)
 }
 
-fn ones_like(input: &TracedTensor) -> TracedTensor {
-    let shape = input.concrete_shape();
+fn ones_like(input: &TracedTensor) -> Result<TracedTensor> {
+    let shape = input.concrete_shape()?;
     broadcast_scalar(one_scalar(input.dtype), &shape)
 }
 
-fn eye_like(anchor: &TracedTensor, size: usize) -> TracedTensor {
+fn eye_like(anchor: &TracedTensor, size: usize) -> Result<TracedTensor> {
     let mut vector_shape = vec![size];
-    let anchor_shape = anchor.concrete_shape();
+    let anchor_shape = anchor.concrete_shape()?;
     vector_shape.extend_from_slice(&anchor_shape[2..]);
-    let diagonal = broadcast_scalar(one_scalar(anchor.dtype), &vector_shape);
+    let diagonal = broadcast_scalar(one_scalar(anchor.dtype), &vector_shape)?;
     diagonal.embed_diag(0, 1)
 }
 
-fn broadcast_scalar(input: TracedTensor, shape: &[usize]) -> TracedTensor {
-    let input_shape = input.concrete_shape();
+fn broadcast_scalar(input: TracedTensor, shape: &[usize]) -> Result<TracedTensor> {
+    let input_shape = input.concrete_shape()?;
     if input_shape == shape {
-        return input;
+        return Ok(input);
     }
-    input.broadcast_in_dim(shape, &[])
+    Ok(input.broadcast_in_dim(shape, &[]))
 }
 
-fn broadcast_batch_scalar_to_leading_axis(input: &TracedTensor, shape: &[usize]) -> TracedTensor {
-    let input_shape = input.concrete_shape();
+fn broadcast_batch_scalar_to_leading_axis(
+    input: &TracedTensor,
+    shape: &[usize],
+) -> Result<TracedTensor> {
+    let input_shape = input.concrete_shape()?;
     if input_shape == shape {
-        return input.clone();
+        return Ok(input.clone());
     }
     let dims: Vec<usize> = (1..shape.len()).collect();
-    input.broadcast_in_dim(shape, &dims)
+    Ok(input.broadcast_in_dim(shape, &dims))
 }
 
-fn matmul_preserve_trailing_batch(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
+fn matmul_preserve_trailing_batch(lhs: &TracedTensor, rhs: &TracedTensor) -> Result<TracedTensor> {
     let rank = lhs.rank;
     let batch_dims: Vec<usize> = (2..rank).collect();
     lhs.dot_general(
@@ -709,15 +729,15 @@ fn matrix_transpose_perm(rank: usize) -> Vec<usize> {
     perm
 }
 
-fn frobenius_norm(abs: &TracedTensor, axes: &[usize]) -> TracedTensor {
-    let squared = abs.pow(&scalar_real(abs.dtype, 2.0));
-    squared.reduce_sum(axes).sqrt()
+fn frobenius_norm(abs: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
+    let squared = abs.pow(&scalar_real(abs.dtype, 2.0))?;
+    Ok(squared.reduce_sum(axes)?.sqrt())
 }
 
-fn p_norm(abs: &TracedTensor, axes: &[usize], p: f64) -> TracedTensor {
-    let power = abs.pow(&scalar_real(abs.dtype, p));
+fn p_norm(abs: &TracedTensor, axes: &[usize], p: f64) -> Result<TracedTensor> {
+    let power = abs.pow(&scalar_real(abs.dtype, p))?;
     let inv_p = scalar_real(abs.dtype, 1.0 / p);
-    power.reduce_sum(axes).pow(&inv_p)
+    power.reduce_sum(axes)?.pow(&inv_p)
 }
 
 fn default_pinv_rtol(dtype: DType, max_dim: usize) -> f64 {
@@ -729,7 +749,7 @@ fn default_pinv_rtol(dtype: DType, max_dim: usize) -> f64 {
     eps * max_dim as f64
 }
 
-fn vector_norm(a: &TracedTensor, axis: usize, ord: Option<f64>) -> TracedTensor {
+fn vector_norm(a: &TracedTensor, axis: usize, ord: Option<f64>) -> Result<TracedTensor> {
     let abs = a.abs();
     match ord {
         None => frobenius_norm(&abs, &[axis]),
@@ -741,9 +761,9 @@ fn vector_norm(a: &TracedTensor, axis: usize, ord: Option<f64>) -> TracedTensor 
 }
 
 fn matrix_norm(a: &TracedTensor, axes: &[usize], ord: Option<f64>) -> Result<TracedTensor> {
-    let matrix = move_axes_to_front(a, axes);
+    let matrix = move_axes_to_front(a, axes)?;
     let abs = matrix.abs();
-    Ok(match ord {
+    match ord {
         None => frobenius_norm(&abs, &[0, 1]),
         Some(p) if p == f64::INFINITY => matrix_row_sum_norm(&abs, true),
         Some(p) if p == f64::NEG_INFINITY => matrix_row_sum_norm(&abs, false),
@@ -759,12 +779,12 @@ fn matrix_norm(a: &TracedTensor, axes: &[usize], ord: Option<f64>) -> Result<Tra
         }
         Some(0.0) => count_nonzero(&abs, &[0, 1]),
         Some(p) => p_norm(&abs, &[0, 1], p),
-    })
+    }
 }
 
 fn svd_values(a: &TracedTensor) -> Result<TracedTensor> {
     one_output(
-        try_apply(
+        apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::SvdVals { eps: 1e-12 })),
             &[a],
         )?,
@@ -774,7 +794,7 @@ fn svd_values(a: &TracedTensor) -> Result<TracedTensor> {
 
 fn eigh_values(a: &TracedTensor) -> Result<TracedTensor> {
     one_output(
-        try_apply(
+        apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::EighVals { eps: 1e-12 })),
             &[a],
         )?,
@@ -784,7 +804,7 @@ fn eigh_values(a: &TracedTensor) -> Result<TracedTensor> {
 
 fn eig_values(a: &TracedTensor) -> Result<TracedTensor> {
     one_output(
-        try_apply(
+        apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::EigVals {
                 input_dtype: a.dtype,
             })),
@@ -794,9 +814,10 @@ fn eig_values(a: &TracedTensor) -> Result<TracedTensor> {
     )
 }
 
-fn scale_matrix_columns(matrix: &TracedTensor, scale: &TracedTensor) -> TracedTensor {
-    let matrix_shape = matrix.concrete_shape();
-    let mut scale_shape = vec![1, scale.concrete_shape()[0]];
+fn scale_matrix_columns(matrix: &TracedTensor, scale: &TracedTensor) -> Result<TracedTensor> {
+    let matrix_shape = matrix.concrete_shape()?;
+    let scale_shape_input = scale.concrete_shape()?;
+    let mut scale_shape = vec![1, scale_shape_input[0]];
     scale_shape.extend_from_slice(&matrix_shape[2..]);
     let dims: Vec<usize> = (0..matrix_shape.len()).collect();
     let scale = scale
@@ -805,13 +826,13 @@ fn scale_matrix_columns(matrix: &TracedTensor, scale: &TracedTensor) -> TracedTe
     matrix * &scale
 }
 
-fn count_nonzero(abs: &TracedTensor, axes: &[usize]) -> TracedTensor {
-    let mask = abs.compare(&zero_scalar(abs.dtype), CompareDir::Gt);
+fn count_nonzero(abs: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
+    let mask = abs.compare(&zero_scalar(abs.dtype), CompareDir::Gt)?;
     mask.convert(abs.dtype).reduce_sum(axes)
 }
 
-fn matrix_row_sum_norm(abs: &TracedTensor, take_max: bool) -> TracedTensor {
-    let row_sums = abs.reduce_sum(&[1]);
+fn matrix_row_sum_norm(abs: &TracedTensor, take_max: bool) -> Result<TracedTensor> {
+    let row_sums = abs.reduce_sum(&[1])?;
     if take_max {
         row_sums.reduce_max(&[0])
     } else {
@@ -819,8 +840,8 @@ fn matrix_row_sum_norm(abs: &TracedTensor, take_max: bool) -> TracedTensor {
     }
 }
 
-fn matrix_col_sum_norm(abs: &TracedTensor, take_max: bool) -> TracedTensor {
-    let col_sums = abs.reduce_sum(&[0]);
+fn matrix_col_sum_norm(abs: &TracedTensor, take_max: bool) -> Result<TracedTensor> {
+    let col_sums = abs.reduce_sum(&[0])?;
     if take_max {
         col_sums.reduce_max(&[0])
     } else {
@@ -828,9 +849,9 @@ fn matrix_col_sum_norm(abs: &TracedTensor, take_max: bool) -> TracedTensor {
     }
 }
 
-fn move_axes_to_front(tensor: &TracedTensor, axes: &[usize]) -> TracedTensor {
+fn move_axes_to_front(tensor: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
     if axes.iter().enumerate().all(|(index, &axis)| index == axis) {
-        return tensor.clone();
+        return Ok(tensor.clone());
     }
 
     let mut selected = vec![false; tensor.rank];

--- a/crates/tenferro-linalg/src/traced_tensor.rs
+++ b/crates/tenferro-linalg/src/traced_tensor.rs
@@ -1,7 +1,7 @@
 //! Traced tensor linear algebra operations.
 //!
 //! This module is the canonical traced tensor namespace for the linalg
-//! extension crate. Root-level re-exports remain available for compatibility.
+//! extension crate.
 
 pub use crate::traced::{
     cholesky, det, eig, eigh, eigh_with_eps, eigvals, eigvalsh, full_piv_lu, full_piv_lu_solve,

--- a/crates/tenferro-linalg/tests/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/backend_errors.rs
@@ -13,35 +13,35 @@ use tenferro_tensor::{
 };
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn f32_tensor(shape: Vec<usize>, data: Vec<f32>) -> Tensor {
-    Tensor::F32(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F32(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn c64_tensor(shape: Vec<usize>, data: Vec<Complex64>) -> Tensor {
-    Tensor::C64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::C64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn c32_tensor(shape: Vec<usize>, data: Vec<Complex32>) -> Tensor {
-    Tensor::C32(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::C32(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn i32_tensor(shape: Vec<usize>, data: Vec<i32>) -> Tensor {
-    Tensor::I32(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::I32(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn f64_values(tensor: &Tensor) -> Vec<f64> {
     match tensor {
-        Tensor::F64(tensor) => tensor.host_data().to_vec(),
+        Tensor::F64(tensor) => tensor.host_data().unwrap().to_vec(),
         other => panic!("expected F64 tensor, got {:?}", other.dtype()),
     }
 }
 
 fn c64_values(tensor: &Tensor) -> Vec<Complex64> {
     match tensor {
-        Tensor::C64(tensor) => tensor.host_data().to_vec(),
+        Tensor::C64(tensor) => tensor.host_data().unwrap().to_vec(),
         other => panic!("expected C64 tensor, got {:?}", other.dtype()),
     }
 }
@@ -55,11 +55,14 @@ fn opaque_backend_placement() -> Placement {
 
 fn backend_f64_tensor(shape: Vec<usize>, handle_id: u64) -> Tensor {
     let len = shape.iter().product();
-    Tensor::F64(TypedTensor::<f64>::from_buffer_col_major(
-        shape,
-        Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(handle_id, len))),
-        opaque_backend_placement(),
-    ))
+    Tensor::F64(
+        TypedTensor::<f64>::from_buffer_col_major(
+            shape,
+            Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(handle_id, len))),
+            opaque_backend_placement(),
+        )
+        .unwrap(),
+    )
 }
 
 fn assert_backend_download_error<T>(result: tenferro_tensor::Result<T>, expected_op: &'static str) {
@@ -204,7 +207,8 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         }
     }
 
-    let input = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0]);
+    let input =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0]).unwrap();
     let mut backend = DefaultOnlyLinalgBackend;
 
     let err = backend.lu_factor(&Tensor::F64(input.clone())).unwrap_err();
@@ -248,7 +252,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         } if message.contains("does not implement")
     ));
 
-    let pivots = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![1, 2]));
+    let pivots = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![1, 2]).unwrap());
     let err = backend
         .lu_solve_prepared(
             &Tensor::F64(input.clone()),
@@ -319,8 +323,8 @@ fn cpu_lu_factor_covers_pivoted_real_and_complex_dtypes() {
     let a = f32_tensor(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]);
     let factors = backend.lu_factor(&a).unwrap();
     assert!(matches!(&factors[0], Tensor::F32(t) if t.shape() == [2, 2]));
-    assert!(matches!(&factors[1], Tensor::I32(t) if t.host_data() == [2, 2]));
-    assert!(matches!(&factors[2], Tensor::F32(t) if t.host_data() == [-1.0]));
+    assert!(matches!(&factors[1], Tensor::I32(t) if t.host_data().unwrap() == [2, 2]));
+    assert!(matches!(&factors[2], Tensor::F32(t) if t.host_data().unwrap() == [-1.0]));
 
     let a = c32_tensor(
         vec![2, 2],
@@ -333,8 +337,10 @@ fn cpu_lu_factor_covers_pivoted_real_and_complex_dtypes() {
     );
     let factors = backend.lu_factor(&a).unwrap();
     assert!(matches!(&factors[0], Tensor::C32(t) if t.shape() == [2, 2]));
-    assert!(matches!(&factors[1], Tensor::I32(t) if t.host_data() == [1, 2]));
-    assert!(matches!(&factors[2], Tensor::C32(t) if t.host_data() == [Complex32::new(1.0, 0.0)]));
+    assert!(matches!(&factors[1], Tensor::I32(t) if t.host_data().unwrap() == [1, 2]));
+    assert!(
+        matches!(&factors[2], Tensor::C32(t) if t.host_data().unwrap() == [Complex32::new(1.0, 0.0)])
+    );
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
@@ -56,9 +56,9 @@ fn lapack_batched_helpers_reuse_input_scratch_instead_of_copying_per_batch() {
     );
 
     for needle in [
-        "input.host_data()[start..end].to_vec()",
-        "a.host_data()[a_start..a_end].to_vec()",
-        "b.host_data()[b_start..b_end].to_vec()",
+        "input.host_data().unwrap()[start..end].to_vec()",
+        "a.host_data().unwrap()[a_start..a_end].to_vec()",
+        "b.host_data().unwrap()[b_start..b_end].to_vec()",
     ] {
         assert!(
             !batched_helpers.contains(needle),

--- a/crates/tenferro-linalg/tests/eager_tensor.rs
+++ b/crates/tenferro-linalg/tests/eager_tensor.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, OnceLock};
 use tenferro_ad::{AdContext, EagerRuntime, EagerTensor, Tensor};
 use tenferro_cpu::CpuBackend;
 #[cfg(feature = "cuda")]
-use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CubeclBackend};
+use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CudaBackend};
 
 fn test_ctx() -> Arc<EagerRuntime> {
     static CTX: OnceLock<Arc<EagerRuntime>> = OnceLock::new();
@@ -63,7 +63,7 @@ fn well_conditioned_4x4() -> Vec<f64> {
 #[test]
 fn svd_returns_correct_shapes() {
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]).unwrap(),
         test_ctx(),
     );
     let (u, s, vt) = tenferro_linalg::eager_tensor::svd(&a).unwrap();
@@ -77,7 +77,7 @@ fn svd_returns_correct_shapes() {
 fn svd_singular_value_sum_backward_does_not_panic() {
     let ctx = ad_test_ctx();
     let a = EagerTensor::requires_grad_in(
-        Tensor::from_vec_col_major(vec![4, 4], well_conditioned_4x4()),
+        Tensor::from_vec_col_major(vec![4, 4], well_conditioned_4x4()).unwrap(),
         ctx,
     );
     let (_, s, _) = tenferro_linalg::eager_tensor::svd(&a).unwrap();
@@ -85,13 +85,13 @@ fn svd_singular_value_sum_backward_does_not_panic() {
 
     loss.backward().unwrap();
 
-    assert!(a.grad().is_some());
+    assert!(a.grad().unwrap().is_some());
 }
 
 #[test]
 fn qr_returns_correct_shapes() {
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap(),
         test_ctx(),
     );
     let (q, r) = tenferro_linalg::eager_tensor::qr(&a).unwrap();
@@ -103,7 +103,7 @@ fn qr_returns_correct_shapes() {
 #[test]
 fn cholesky_of_identity() {
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap(),
         test_ctx(),
     );
     let l = tenferro_linalg::eager_tensor::cholesky(&a).unwrap();
@@ -115,7 +115,7 @@ fn cholesky_of_identity() {
 #[test]
 fn lu_returns_expected_factors_for_swap_matrix() {
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 1.0, 1.0, 0.0]),
+        Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 1.0, 1.0, 0.0]).unwrap(),
         test_ctx(),
     );
     let (p, l, u, parity) = tenferro_linalg::eager_tensor::lu(&a).unwrap();
@@ -134,11 +134,11 @@ fn lu_returns_expected_factors_for_swap_matrix() {
 #[test]
 fn full_piv_lu_solve_returns_expected_solution() {
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]),
+        Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]).unwrap(),
         test_ctx(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 1], vec![-1.0_f64, 5.0]),
+        Tensor::from_vec_col_major(vec![2, 1], vec![-1.0_f64, 5.0]).unwrap(),
         test_ctx(),
     );
     let x = tenferro_linalg::eager_tensor::full_piv_lu_solve(&a, &b).unwrap();
@@ -150,11 +150,11 @@ fn full_piv_lu_solve_returns_expected_solution() {
 #[test]
 fn solve_returns_expected_solution() {
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]),
+        Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap(),
         test_ctx(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 8.0]),
+        Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 8.0]).unwrap(),
         test_ctx(),
     );
     let x = tenferro_linalg::eager_tensor::solve(&a, &b).unwrap();
@@ -170,18 +170,19 @@ fn batched_solve_sum_backward_wrt_matrix_uses_native_batch_layout() {
         Tensor::from_vec_col_major(
             vec![2, 2, 2],
             vec![2.0_f64, 0.0, 0.0, 4.0, 3.0, 0.0, 0.0, 5.0],
-        ),
+        )
+        .unwrap(),
         ctx.clone(),
     );
     let b = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 1, 2], vec![4.0_f64, 8.0, 6.0, 10.0]),
+        Tensor::from_vec_col_major(vec![2, 1, 2], vec![4.0_f64, 8.0, 6.0, 10.0]).unwrap(),
         ctx,
     );
 
     let x = tenferro_linalg::eager_tensor::solve(&a, &b).unwrap();
     let loss = x.reduce_sum(&[0, 1, 2]).unwrap();
     let _ = loss.backward().unwrap();
-    let grad = a.grad().unwrap();
+    let grad = a.grad().unwrap().unwrap();
 
     assert_eq!(grad.shape(), &[2, 2, 2]);
     assert_close_slice(
@@ -194,7 +195,7 @@ fn batched_solve_sum_backward_wrt_matrix_uses_native_batch_layout() {
 #[test]
 fn eig_returns_expected_complex_values_for_diagonal_matrix() {
     let a = EagerTensor::from_tensor_in(
-        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]).unwrap(),
         test_ctx(),
     );
     let (values, vectors) = tenferro_linalg::eager_tensor::eig(&a).unwrap();
@@ -223,9 +224,9 @@ fn cuda_eager_solve_uses_registered_linalg_runtime() {
         return;
     }
 
-    let a_host = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 1.0, 1.0, 2.0]);
-    let b_host = Tensor::from_vec_col_major(vec![2, 1], vec![5.0_f64, 1.0]);
-    let upload_backend = CubeclBackend::new(0).unwrap();
+    let a_host = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 1.0, 1.0, 2.0]).unwrap();
+    let b_host = Tensor::from_vec_col_major(vec![2, 1], vec![5.0_f64, 1.0]).unwrap();
+    let upload_backend = CudaBackend::new(0).unwrap();
     let a_gpu = upload_tensor(upload_backend.runtime(), &a_host).unwrap();
     let b_gpu = upload_tensor(upload_backend.runtime(), &b_host).unwrap();
     let ctx = EagerRuntime::with_cuda_backend(upload_backend);
@@ -234,7 +235,7 @@ fn cuda_eager_solve_uses_registered_linalg_runtime() {
 
     let x = tenferro_linalg::eager_tensor::solve(&a, &b).unwrap();
 
-    let download_backend = CubeclBackend::new(0).unwrap();
+    let download_backend = CudaBackend::new(0).unwrap();
     let x_host = download_tensor(download_backend.runtime(), x.data()).unwrap();
     assert_eq!(x_host.shape(), &[2, 1]);
     assert_close_slice(f64_data(&x_host), &[1.8, -0.4], 1.0e-9);

--- a/crates/tenferro-linalg/tests/full_piv_lu.rs
+++ b/crates/tenferro-linalg/tests/full_piv_lu.rs
@@ -4,7 +4,7 @@ use tenferro_linalg::LinalgBackend;
 use tenferro_tensor::{DType, DotGeneralConfig, Tensor, TensorDot, TensorStructural, TypedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn f64_data(tensor: &Tensor) -> &[f64] {
@@ -58,15 +58,18 @@ fn full_piv_lu_reconstructs_permuted_matrix() {
 
 #[test]
 fn full_piv_lu_complex_parity_uses_real_counterpart_dtype() {
-    let a = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![
-            Complex64::new(0.0, 0.0),
-            Complex64::new(2.0, 1.0),
-            Complex64::new(1.0, -1.0),
-            Complex64::new(3.0, 0.0),
-        ],
-    ));
+    let a = Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex64::new(0.0, 0.0),
+                Complex64::new(2.0, 1.0),
+                Complex64::new(1.0, -1.0),
+                Complex64::new(3.0, 0.0),
+            ],
+        )
+        .unwrap(),
+    );
     let mut backend = CpuBackend::new();
 
     let outputs = backend.full_piv_lu(&a).unwrap();

--- a/crates/tenferro-linalg/tests/gpu_linalg.rs
+++ b/crates/tenferro-linalg/tests/gpu_linalg.rs
@@ -3,7 +3,7 @@
 // Run with: cargo test --features cuda -- --ignored
 use num_complex::{Complex32, Complex64};
 use tenferro_cpu::CpuBackend;
-use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CubeclBackend};
+use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CudaBackend};
 use tenferro_linalg::LinalgBackend;
 use tenferro_tensor::{Error, Tensor, TypedTensor};
 
@@ -11,32 +11,32 @@ fn cpu_backend() -> CpuBackend {
     CpuBackend::new()
 }
 
-fn gpu_backend() -> CubeclBackend {
-    CubeclBackend::new(0).unwrap()
+fn gpu_backend() -> CudaBackend {
+    CudaBackend::new(0).unwrap()
 }
 
-fn upload(backend: &CubeclBackend, tensor: &Tensor) -> Tensor {
+fn upload(backend: &CudaBackend, tensor: &Tensor) -> Tensor {
     upload_tensor(backend.runtime(), tensor).unwrap()
 }
 
-fn download(backend: &CubeclBackend, tensor: &Tensor) -> Tensor {
+fn download(backend: &CudaBackend, tensor: &Tensor) -> Tensor {
     download_tensor(backend.runtime(), tensor).unwrap()
 }
 
 fn tensor_f32(shape: Vec<usize>, data: Vec<f32>) -> Tensor {
-    Tensor::F32(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F32(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn tensor_f64(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn tensor_c32(shape: Vec<usize>, data: Vec<Complex32>) -> Tensor {
-    Tensor::C32(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::C32(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn tensor_c64(shape: Vec<usize>, data: Vec<Complex64>) -> Tensor {
-    Tensor::C64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::C64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn assert_tensor_close(actual: &Tensor, expected: &Tensor, tol: f64) {

--- a/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
@@ -72,7 +72,7 @@ fn tenferro_gpu_no_longer_owns_linalg_specific_ffi_or_kernels() {
     for needle in ["CudaLinalgHandles", "linalg_handles", "cusolver", "cublas"] {
         assert!(
             !cubecl_mod.contains(needle),
-            "CubeclBackend should not expose linalg-specific state: found {needle}"
+            "CudaBackend should not expose linalg-specific state: found {needle}"
         );
     }
 }

--- a/crates/tenferro-linalg/tests/inject_dual_abi_tests.rs
+++ b/crates/tenferro-linalg/tests/inject_dual_abi_tests.rs
@@ -205,14 +205,10 @@ fn ilp64_gemm_provider_reaches_lp64_consumer() {
 
     DGEMM_ILP64_CALLS.store(0, Ordering::SeqCst);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 3.0, 2.0, 4.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![5.0, 7.0, 6.0, 8.0],
-    ));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0]).unwrap());
+    let b =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![5.0, 7.0, 6.0, 8.0]).unwrap());
 
     let mut backend = CpuBackend::new();
     let c = backend.dot_general(
@@ -228,7 +224,7 @@ fn ilp64_gemm_provider_reaches_lp64_consumer() {
 
     assert_eq!(DGEMM_ILP64_CALLS.load(Ordering::SeqCst), 1);
     match c {
-        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[19.0, 43.0, 22.0, 50.0]),
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data().unwrap(), &[19.0, 43.0, 22.0, 50.0]),
         _ => panic!("expected f64 tensor"),
     }
 }
@@ -257,11 +253,9 @@ fn ilp64_lapack_full_piv_lu_bridges_integer_arrays() {
     DGETC2_ILP64_CALLS.store(0, Ordering::SeqCst);
     DGESC2_ILP64_CALLS.store(0, Ordering::SeqCst);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 0.0, 0.0, 1.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![4.0, 8.0]));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![4.0, 8.0]).unwrap());
 
     let mut backend = CpuBackend::new();
     let x = backend.full_piv_lu_solve(&a, &b, false);
@@ -269,7 +263,7 @@ fn ilp64_lapack_full_piv_lu_bridges_integer_arrays() {
     assert_eq!(DGETC2_ILP64_CALLS.load(Ordering::SeqCst), 1);
     assert_eq!(DGESC2_ILP64_CALLS.load(Ordering::SeqCst), 1);
     match x {
-        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[4.0, 8.0]),
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data().unwrap(), &[4.0, 8.0]),
         _ => panic!("expected f64 tensor"),
     }
 }
@@ -298,7 +292,7 @@ fn ilp64_lapack_qr_workspace_query() {
     DGEQRF_ILP64_CALLS.store(0, Ordering::SeqCst);
     DORGQR_ILP64_CALLS.store(0, Ordering::SeqCst);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1.0, 2.0]));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![1.0, 2.0]).unwrap());
 
     let mut backend = CpuBackend::new();
     let result = backend.qr(&a);

--- a/crates/tenferro-linalg/tests/inject_tests.rs
+++ b/crates/tenferro-linalg/tests/inject_tests.rs
@@ -5,8 +5,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, Once};
 
 use tenferro_cpu::inject::{
-    register_blas_gemm_fn_ptrs, register_lapack_full_piv_lu_fn_ptrs, register_lapack_provider_ptrs,
-    BlasGemmFnPtrSet, LapackFullPivLuFnPtrSet, LapackProviderPtrSet, ProviderAbi,
+    register_blas_gemm_provider_ptrs, register_lapack_provider_ptrs, BlasGemmProviderPtrSet,
+    LapackProviderPtrSet, ProviderAbi,
 };
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::LinalgBackend;
@@ -22,26 +22,25 @@ static DGETRS_CALLS: AtomicUsize = AtomicUsize::new(0);
 
 fn register_test_ptrs_once() {
     REGISTER_ONCE.call_once(|| unsafe {
-        register_blas_gemm_fn_ptrs(BlasGemmFnPtrSet {
-            dgemm: Some(test_dgemm),
-            ..BlasGemmFnPtrSet::new()
-        })
+        register_blas_gemm_provider_ptrs(
+            ProviderAbi::Lp64,
+            BlasGemmProviderPtrSet {
+                dgemm: Some(test_dgemm as *const c_void),
+                ..BlasGemmProviderPtrSet::new()
+            },
+        )
         .expect("test dgemm registration should succeed");
-        register_lapack_full_piv_lu_fn_ptrs(LapackFullPivLuFnPtrSet {
-            dgetc2: Some(test_dgetc2),
-            dgesc2: Some(test_dgesc2),
-            ..LapackFullPivLuFnPtrSet::new()
-        })
-        .expect("test dgetc2/dgesc2 registration should succeed");
         register_lapack_provider_ptrs(
             ProviderAbi::Lp64,
             LapackProviderPtrSet {
+                dgetc2: Some(test_dgetc2 as *const c_void),
+                dgesc2: Some(test_dgesc2 as *const c_void),
                 dgetrf: Some(test_dgetrf as *const c_void),
                 dgetrs: Some(test_dgetrs as *const c_void),
                 ..LapackProviderPtrSet::new()
             },
         )
-        .expect("test dgetrf/dgetrs registration should succeed");
+        .expect("test LAPACK registration should succeed");
     });
 }
 
@@ -178,14 +177,10 @@ fn provider_inject_dot_general_uses_registered_blas() {
     register_test_ptrs_once();
     DGEMM_CALLS.store(0, Ordering::SeqCst);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 3.0, 2.0, 4.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![5.0, 7.0, 6.0, 8.0],
-    ));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0]).unwrap());
+    let b =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![5.0, 7.0, 6.0, 8.0]).unwrap());
 
     let mut backend = CpuBackend::new();
     let c = backend.dot_general(
@@ -201,7 +196,7 @@ fn provider_inject_dot_general_uses_registered_blas() {
 
     assert_eq!(DGEMM_CALLS.load(Ordering::SeqCst), 1);
     match c {
-        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[19.0, 43.0, 22.0, 50.0]),
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data().unwrap(), &[19.0, 43.0, 22.0, 50.0]),
         _ => panic!("expected f64 tensor"),
     }
 }
@@ -214,8 +209,8 @@ fn provider_inject_dot_general_singleton_contract_uses_registered_blas() {
     register_test_ptrs_once();
     DGEMM_CALLS.store(0, Ordering::SeqCst);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 2], vec![1.0, 2.0]));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 2], vec![3.0, 4.0]));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 2], vec![1.0, 2.0]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 2], vec![3.0, 4.0]).unwrap());
 
     let mut backend = CpuBackend::new();
     let c = backend.dot_general(
@@ -231,7 +226,7 @@ fn provider_inject_dot_general_singleton_contract_uses_registered_blas() {
 
     assert_eq!(DGEMM_CALLS.load(Ordering::SeqCst), 1);
     match c {
-        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[3.0, 6.0, 4.0, 8.0]),
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data().unwrap(), &[3.0, 6.0, 4.0, 8.0]),
         _ => panic!("expected f64 tensor"),
     }
 }
@@ -244,11 +239,10 @@ fn provider_inject_dot_general_rhs_singleton_contract_uses_registered_blas() {
     register_test_ptrs_once();
     DGEMM_CALLS.store(0, Ordering::SeqCst);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![2.0]));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 1, 2],
-        vec![3.0, 4.0, 5.0, 6.0],
-    ));
+    let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![2.0]).unwrap());
+    let b = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![2, 1, 2], vec![3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
 
     let mut backend = CpuBackend::new();
     let c = backend.dot_general(
@@ -264,7 +258,7 @@ fn provider_inject_dot_general_rhs_singleton_contract_uses_registered_blas() {
 
     assert_eq!(DGEMM_CALLS.load(Ordering::SeqCst), 1);
     match c {
-        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[6.0, 8.0, 10.0, 12.0]),
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data().unwrap(), &[6.0, 8.0, 10.0, 12.0]),
         _ => panic!("expected f64 tensor"),
     }
 }
@@ -278,11 +272,9 @@ fn provider_inject_full_piv_lu_solve_uses_registered_lapack() {
     DGETC2_CALLS.store(0, Ordering::SeqCst);
     DGESC2_CALLS.store(0, Ordering::SeqCst);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 0.0, 0.0, 1.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![4.0, 8.0]));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![4.0, 8.0]).unwrap());
 
     let mut backend = CpuBackend::new();
     let x = backend.full_piv_lu_solve(&a, &b, false);
@@ -290,7 +282,7 @@ fn provider_inject_full_piv_lu_solve_uses_registered_lapack() {
     assert_eq!(DGETC2_CALLS.load(Ordering::SeqCst), 1);
     assert_eq!(DGESC2_CALLS.load(Ordering::SeqCst), 1);
     match x {
-        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[4.0, 8.0]),
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data().unwrap(), &[4.0, 8.0]),
         _ => panic!("expected f64 tensor"),
     }
 }
@@ -304,11 +296,9 @@ fn provider_inject_solve_uses_registered_lapack_getrf_getrs() {
     DGETRF_CALLS.store(0, Ordering::SeqCst);
     DGETRS_CALLS.store(0, Ordering::SeqCst);
 
-    let a = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 0.0, 0.0, 1.0],
-    ));
-    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![4.0, 8.0]));
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0]).unwrap());
+    let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 1], vec![4.0, 8.0]).unwrap());
 
     let mut backend = CpuBackend::new();
     let x = backend.solve(&a, &b);
@@ -316,7 +306,7 @@ fn provider_inject_solve_uses_registered_lapack_getrf_getrs() {
     assert_eq!(DGETRF_CALLS.load(Ordering::SeqCst), 1);
     assert_eq!(DGETRS_CALLS.load(Ordering::SeqCst), 1);
     match x {
-        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data(), &[4.0, 8.0]),
+        Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data().unwrap(), &[4.0, 8.0]),
         _ => panic!("expected f64 tensor"),
     }
 }

--- a/crates/tenferro-linalg/tests/traced_ad_explicit.rs
+++ b/crates/tenferro-linalg/tests/traced_ad_explicit.rs
@@ -1,16 +1,18 @@
 #![cfg(feature = "autodiff")]
 
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
 use tenferro_ad::AdContext;
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+use tenferro_runtime::{DType, Error, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
 use tenferro_tensor::TypedTensor;
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn c64_tensor(shape: Vec<usize>, data: Vec<num_complex::Complex64>) -> Tensor {
-    Tensor::C64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::C64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn get_f64_data(tensor: &Tensor) -> &[f64] {
@@ -37,7 +39,7 @@ fn eval_many(outputs: &[&TracedTensor]) -> Vec<Tensor> {
 
 fn reduce_all(tensor: &TracedTensor) -> TracedTensor {
     let axes: Vec<usize> = (0..tensor.rank).collect();
-    tensor.reduce_sum(&axes)
+    tensor.reduce_sum(&axes).unwrap()
 }
 
 fn weighted_square_sum(
@@ -46,16 +48,16 @@ fn weighted_square_sum(
     weights: Vec<f64>,
 ) -> TracedTensor {
     let weights = TracedTensor::from_tensor_concrete_shape(f64_tensor(shape, weights));
-    let squared = tensor * tensor;
-    reduce_all(&(&squared * &weights))
+    let squared = (tensor * tensor).unwrap();
+    reduce_all(&(&squared * &weights).unwrap())
 }
 
 fn assert_finite_tensor(tensor: &Tensor) {
-    if let Some(values) = tensor.as_slice::<f64>() {
+    if let Ok(values) = tensor.as_slice::<f64>() {
         assert!(values.iter().all(|value| value.is_finite()), "{values:?}");
         return;
     }
-    if let Some(values) = tensor.as_slice::<num_complex::Complex64>() {
+    if let Ok(values) = tensor.as_slice::<num_complex::Complex64>() {
         assert!(
             values
                 .iter()
@@ -107,6 +109,31 @@ fn ad_context() -> AdContext {
         .unwrap()
 }
 
+fn assert_invalid_ad_graph_build(
+    result: std::thread::Result<tenferro_runtime::Result<TracedTensor>>,
+    transform: &'static str,
+    linalg_op: &str,
+    detail: &str,
+) {
+    let err = result
+        .unwrap_or_else(|_| panic!("{linalg_op} {transform} should return Err, not panic"))
+        .unwrap_err();
+    match err {
+        Error::InvalidGraphBuild { op, message } => {
+            assert_eq!(op, transform);
+            assert!(
+                message.contains(linalg_op),
+                "expected {linalg_op} in message, got: {message}"
+            );
+            assert!(
+                message.contains(detail),
+                "expected {detail:?} in message, got: {message}"
+            );
+        }
+        other => panic!("expected InvalidGraphBuild, got {other:?}"),
+    }
+}
+
 #[test]
 fn svd_singular_value_sum_jvp_uses_extension_ad_rule() {
     let ad = ad_context();
@@ -119,8 +146,8 @@ fn svd_singular_value_sum_jvp_uses_extension_ad_rule() {
         vec![1.0, 0.0, 0.0, 0.0, 2.0, 0.0],
     ));
 
-    let (_u, s, _vt) = tenferro_linalg::svd(&a).unwrap();
-    let y = s.reduce_sum(&[0]);
+    let (_u, s, _vt) = tenferro_linalg::traced_tensor::svd(&a).unwrap();
+    let y = s.reduce_sum(&[0]).unwrap();
     let dy = ad.jvp(&y, &a, &da).unwrap();
     let out = eval(&dy);
 
@@ -135,12 +162,90 @@ fn full_piv_lu_solve_grad_uses_extension_ad_rule() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![0.0, 2.0, 1.0, 3.0]));
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], vec![-1.0, 5.0]));
 
-    let x = tenferro_linalg::full_piv_lu_solve(&a, &b).unwrap();
-    let loss = x.reduce_sum(&[0, 1]);
+    let x = tenferro_linalg::traced_tensor::full_piv_lu_solve(&a, &b).unwrap();
+    let loss = x.reduce_sum(&[0, 1]).unwrap();
     let grad_b = ad.grad(&loss, &b).unwrap();
     let out = eval(&grad_b);
 
     assert_eq!(out.shape(), &[2, 1]);
+}
+
+#[test]
+fn full_piv_lu_solve_grad_rejects_rank1_operands_without_panic() {
+    let ad = ad_context();
+    let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![2.0, 3.0]));
+    let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![4.0, 9.0]));
+    let x = tenferro_linalg::traced_tensor::full_piv_lu_solve(&a, &b).unwrap();
+    let loss = reduce_all(&x);
+
+    let result = catch_unwind(AssertUnwindSafe(|| ad.grad(&loss, &a)));
+
+    assert_invalid_ad_graph_build(
+        result,
+        "vjp",
+        "tenferro-linalg.full_piv_lu_solve",
+        "rank >= 2",
+    );
+}
+
+#[test]
+fn triangular_solve_grad_rejects_rank1_operands_without_panic() {
+    let ad = ad_context();
+    let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![2.0, 3.0]));
+    let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![4.0, 9.0]));
+    let x =
+        tenferro_linalg::traced_tensor::triangular_solve(&a, &b, true, true, false, false).unwrap();
+    let loss = reduce_all(&x);
+
+    let result = catch_unwind(AssertUnwindSafe(|| ad.grad(&loss, &a)));
+
+    assert_invalid_ad_graph_build(
+        result,
+        "vjp",
+        "tenferro-linalg.triangular_solve",
+        "rank >= 2",
+    );
+}
+
+#[test]
+fn full_piv_lu_solve_jvp_rejects_non_square_lhs_without_panic() {
+    let ad = ad_context();
+    let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(
+        vec![2, 3],
+        vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+    ));
+    let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], vec![4.0, 9.0]));
+    let da = TracedTensor::from_tensor_concrete_shape(f64_tensor(
+        vec![2, 3],
+        vec![0.1, 0.0, 0.0, 0.0, 0.1, 0.0],
+    ));
+    let x = tenferro_linalg::traced_tensor::full_piv_lu_solve(&a, &b).unwrap();
+    let loss = reduce_all(&x);
+
+    let result = catch_unwind(AssertUnwindSafe(|| ad.jvp(&loss, &a, &da)));
+
+    assert_invalid_ad_graph_build(result, "jvp", "tenferro-linalg.full_piv_lu_solve", "square");
+}
+
+#[test]
+fn triangular_solve_jvp_rejects_non_square_lhs_without_panic() {
+    let ad = ad_context();
+    let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(
+        vec![2, 3],
+        vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+    ));
+    let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], vec![4.0, 9.0]));
+    let da = TracedTensor::from_tensor_concrete_shape(f64_tensor(
+        vec![2, 3],
+        vec![0.1, 0.0, 0.0, 0.0, 0.1, 0.0],
+    ));
+    let x =
+        tenferro_linalg::traced_tensor::triangular_solve(&a, &b, true, true, false, false).unwrap();
+    let loss = reduce_all(&x);
+
+    let result = catch_unwind(AssertUnwindSafe(|| ad.jvp(&loss, &a, &da)));
+
+    assert_invalid_ad_graph_build(result, "jvp", "tenferro-linalg.triangular_solve", "square");
 }
 
 #[test]
@@ -149,8 +254,8 @@ fn svd_values_grad_matches_finite_diff() {
     let data = vec![3.0, 0.1, 0.2, 0.3, 2.0, 0.4];
     let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], data.clone()));
 
-    let (_u, s, _vt) = tenferro_linalg::svd(&a).unwrap();
-    let loss = s.reduce_sum(&[0]);
+    let (_u, s, _vt) = tenferro_linalg::traced_tensor::svd(&a).unwrap();
+    let loss = s.reduce_sum(&[0]).unwrap();
     let grad = ad.grad(&loss, &a).unwrap();
     let out = eval(&grad);
 
@@ -161,8 +266,8 @@ fn svd_values_grad_matches_finite_diff() {
             |xs| {
                 let input =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], xs.to_vec()));
-                let (_u, s, _vt) = tenferro_linalg::svd(&input).unwrap();
-                get_f64_data(&eval(&s.reduce_sum(&[0])))[0]
+                let (_u, s, _vt) = tenferro_linalg::traced_tensor::svd(&input).unwrap();
+                get_f64_data(&eval(&s.reduce_sum(&[0]).unwrap()))[0]
             },
             &data,
             idx,
@@ -186,7 +291,8 @@ fn spectral_norm_jvp_matches_finite_diff_through_values_only_svd() {
     let tangent =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], tangent_data.clone()));
 
-    let norm = tenferro_linalg::norm(&matrix, Some(2.0), Some(&[0, 1]), false).unwrap();
+    let norm =
+        tenferro_linalg::traced_tensor::norm(&matrix, Some(2.0), Some(&[0, 1]), false).unwrap();
     let actual = eval(&ad.jvp(&norm, &matrix, &tangent).unwrap());
 
     assert_close_scalar(
@@ -196,7 +302,9 @@ fn spectral_norm_jvp_matches_finite_diff_through_values_only_svd() {
             |xs| {
                 let input =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], xs.to_vec()));
-                let norm = tenferro_linalg::norm(&input, Some(2.0), Some(&[0, 1]), false).unwrap();
+                let norm =
+                    tenferro_linalg::traced_tensor::norm(&input, Some(2.0), Some(&[0, 1]), false)
+                        .unwrap();
                 get_f64_data(&eval(&norm))[0]
             },
             &data,
@@ -228,35 +336,36 @@ fn remaining_linalg_ops_jvp_match_finite_diff_except_full_piv_lu() {
     let rhs = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], rhs_data.clone()));
     let drhs = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], drhs_data.clone()));
 
-    let chol_loss = reduce_all(&tenferro_linalg::cholesky(&spd).unwrap());
+    let chol_loss = reduce_all(&tenferro_linalg::traced_tensor::cholesky(&spd).unwrap());
     let chol_tangent = ad.jvp(&chol_loss, &spd, &dspd).unwrap();
 
-    let (q, r) = tenferro_linalg::qr(&general).unwrap();
-    let qr_loss = &reduce_all(&q) + &reduce_all(&r);
+    let (q, r) = tenferro_linalg::traced_tensor::qr(&general).unwrap();
+    let qr_loss = (&reduce_all(&q) + &reduce_all(&r)).unwrap();
     let qr_tangent = ad.jvp(&qr_loss, &general, &dgeneral).unwrap();
 
-    let (eigh_values, _eigh_vectors) = tenferro_linalg::eigh(&spd).unwrap();
+    let (eigh_values, _eigh_vectors) = tenferro_linalg::traced_tensor::eigh(&spd).unwrap();
     let eigh_loss = reduce_all(&eigh_values);
     let eigh_tangent = ad.jvp(&eigh_loss, &spd, &dspd).unwrap();
 
-    let (eig_values, _eig_vectors) = tenferro_linalg::eig(&general).unwrap();
+    let (eig_values, _eig_vectors) = tenferro_linalg::traced_tensor::eig(&general).unwrap();
     let eig_loss = reduce_all(&eig_values);
     let eig_tangent = ad.jvp(&eig_loss, &general, &dgeneral).unwrap();
 
-    let solve_loss = reduce_all(&tenferro_linalg::solve(&general, &rhs).unwrap());
+    let solve_loss = reduce_all(&tenferro_linalg::traced_tensor::solve(&general, &rhs).unwrap());
     let solve_tangent = ad.jvp(&solve_loss, &rhs, &drhs).unwrap();
     let triangular_loss = reduce_all(
-        &tenferro_linalg::triangular_solve(&general, &rhs, true, true, false, false).unwrap(),
+        &tenferro_linalg::traced_tensor::triangular_solve(&general, &rhs, true, true, false, false)
+            .unwrap(),
     );
     let triangular_tangent = ad.jvp(&triangular_loss, &rhs, &drhs).unwrap();
 
-    let (_p, lu_l, lu_u, _parity) = tenferro_linalg::lu(&general).unwrap();
-    let lu_loss = &reduce_all(&lu_l) + &reduce_all(&lu_u);
+    let (_p, lu_l, lu_u, _parity) = tenferro_linalg::traced_tensor::lu(&general).unwrap();
+    let lu_loss = (&reduce_all(&lu_l) + &reduce_all(&lu_u)).unwrap();
     let lu_tangent = ad.jvp(&lu_loss, &general, &dgeneral).unwrap();
 
     let (_p, full_lu_l, full_lu_u, _q, _full_parity) =
-        tenferro_linalg::full_piv_lu(&general).unwrap();
-    let full_lu_loss = &reduce_all(&full_lu_l) + &reduce_all(&full_lu_u);
+        tenferro_linalg::traced_tensor::full_piv_lu(&general).unwrap();
+    let full_lu_loss = (&reduce_all(&full_lu_l) + &reduce_all(&full_lu_u)).unwrap();
     let full_lu_tangent = ad.jvp(&full_lu_loss, &general, &dgeneral).unwrap();
 
     let outputs = [
@@ -278,7 +387,7 @@ fn remaining_linalg_ops_jvp_match_finite_diff_except_full_piv_lu() {
             |xs| {
                 let input =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], xs.to_vec()));
-                let loss = reduce_all(&tenferro_linalg::cholesky(&input).unwrap());
+                let loss = reduce_all(&tenferro_linalg::traced_tensor::cholesky(&input).unwrap());
                 get_f64_data(&eval(&loss))[0]
             },
             &spd_data,
@@ -294,8 +403,8 @@ fn remaining_linalg_ops_jvp_match_finite_diff_except_full_piv_lu() {
             |xs| {
                 let input =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], xs.to_vec()));
-                let (q, r) = tenferro_linalg::qr(&input).unwrap();
-                let loss = &reduce_all(&q) + &reduce_all(&r);
+                let (q, r) = tenferro_linalg::traced_tensor::qr(&input).unwrap();
+                let loss = (&reduce_all(&q) + &reduce_all(&r)).unwrap();
                 get_f64_data(&eval(&loss))[0]
             },
             &general_data,
@@ -311,7 +420,7 @@ fn remaining_linalg_ops_jvp_match_finite_diff_except_full_piv_lu() {
             |xs| {
                 let input =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], xs.to_vec()));
-                let (values, _vectors) = tenferro_linalg::eigh(&input).unwrap();
+                let (values, _vectors) = tenferro_linalg::traced_tensor::eigh(&input).unwrap();
                 get_f64_data(&eval(&reduce_all(&values)))[0]
             },
             &spd_data,
@@ -327,7 +436,7 @@ fn remaining_linalg_ops_jvp_match_finite_diff_except_full_piv_lu() {
             |xs| {
                 let input =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], xs.to_vec()));
-                let (values, _vectors) = tenferro_linalg::eig(&input).unwrap();
+                let (values, _vectors) = tenferro_linalg::traced_tensor::eig(&input).unwrap();
                 get_c64_data(&eval(&reduce_all(&values)))[0]
             },
             &general_data,
@@ -343,7 +452,8 @@ fn remaining_linalg_ops_jvp_match_finite_diff_except_full_piv_lu() {
             |xs| {
                 let rhs =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], xs.to_vec()));
-                let loss = reduce_all(&tenferro_linalg::solve(&general, &rhs).unwrap());
+                let loss =
+                    reduce_all(&tenferro_linalg::traced_tensor::solve(&general, &rhs).unwrap());
                 get_f64_data(&eval(&loss))[0]
             },
             &rhs_data,
@@ -360,8 +470,10 @@ fn remaining_linalg_ops_jvp_match_finite_diff_except_full_piv_lu() {
                 let rhs =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], xs.to_vec()));
                 let loss = reduce_all(
-                    &tenferro_linalg::triangular_solve(&general, &rhs, true, true, false, false)
-                        .unwrap(),
+                    &tenferro_linalg::traced_tensor::triangular_solve(
+                        &general, &rhs, true, true, false, false,
+                    )
+                    .unwrap(),
                 );
                 get_f64_data(&eval(&loss))[0]
             },
@@ -378,8 +490,8 @@ fn remaining_linalg_ops_jvp_match_finite_diff_except_full_piv_lu() {
             |xs| {
                 let input =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], xs.to_vec()));
-                let (_p, l, u, _parity) = tenferro_linalg::lu(&input).unwrap();
-                let loss = &reduce_all(&l) + &reduce_all(&u);
+                let (_p, l, u, _parity) = tenferro_linalg::traced_tensor::lu(&input).unwrap();
+                let loss = (&reduce_all(&l) + &reduce_all(&u)).unwrap();
                 get_f64_data(&eval(&loss))[0]
             },
             &general_data,
@@ -402,7 +514,7 @@ fn eigvalsh_jvp_matches_finite_diff_through_values_only_eigh() {
     let tangent =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], tangent_data.clone()));
 
-    let values = tenferro_linalg::eigvalsh(&matrix).unwrap();
+    let values = tenferro_linalg::traced_tensor::eigvalsh(&matrix).unwrap();
     let loss = reduce_all(&values);
     let actual = eval(&ad.jvp(&loss, &matrix, &tangent).unwrap());
 
@@ -413,7 +525,7 @@ fn eigvalsh_jvp_matches_finite_diff_through_values_only_eigh() {
             |xs| {
                 let input =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], xs.to_vec()));
-                let values = tenferro_linalg::eigvalsh(&input).unwrap();
+                let values = tenferro_linalg::traced_tensor::eigvalsh(&input).unwrap();
                 get_f64_data(&eval(&reduce_all(&values)))[0]
             },
             &data,
@@ -433,7 +545,7 @@ fn eigvals_jvp_matches_finite_diff() {
     let tangent =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], tangent_data.clone()));
 
-    let values = tenferro_linalg::eigvals(&matrix).unwrap();
+    let values = tenferro_linalg::traced_tensor::eigvals(&matrix).unwrap();
     let loss = reduce_all(&values);
     let actual = eval(&ad.jvp(&loss, &matrix, &tangent).unwrap());
 
@@ -444,7 +556,7 @@ fn eigvals_jvp_matches_finite_diff() {
             |xs| {
                 let input =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], xs.to_vec()));
-                let values = tenferro_linalg::eigvals(&input).unwrap();
+                let values = tenferro_linalg::traced_tensor::eigvals(&input).unwrap();
                 get_c64_data(&eval(&reduce_all(&values)))[0]
             },
             &data,
@@ -470,7 +582,7 @@ fn solve_matrix_operand_jvp_matches_finite_diff() {
     ));
     let rhs = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], rhs_data.clone()));
 
-    let loss = reduce_all(&tenferro_linalg::solve(&matrix, &rhs).unwrap());
+    let loss = reduce_all(&tenferro_linalg::traced_tensor::solve(&matrix, &rhs).unwrap());
     let tangent = ad.jvp(&loss, &matrix, &matrix_tangent).unwrap();
     let result = eval(&tangent);
 
@@ -485,7 +597,8 @@ fn solve_matrix_operand_jvp_matches_finite_diff() {
                     vec![2, 1],
                     rhs_data.clone(),
                 ));
-                let loss = reduce_all(&tenferro_linalg::solve(&matrix, &rhs).unwrap());
+                let loss =
+                    reduce_all(&tenferro_linalg::traced_tensor::solve(&matrix, &rhs).unwrap());
                 get_f64_data(&eval(&loss))[0]
             },
             &matrix_data,
@@ -512,7 +625,8 @@ fn triangular_solve_matrix_operand_jvp_matches_finite_diff() {
     let rhs = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], rhs_data.clone()));
 
     let loss = reduce_all(
-        &tenferro_linalg::triangular_solve(&matrix, &rhs, true, true, false, false).unwrap(),
+        &tenferro_linalg::traced_tensor::triangular_solve(&matrix, &rhs, true, true, false, false)
+            .unwrap(),
     );
     let tangent = ad.jvp(&loss, &matrix, &matrix_tangent).unwrap();
     let result = eval(&tangent);
@@ -529,8 +643,10 @@ fn triangular_solve_matrix_operand_jvp_matches_finite_diff() {
                     rhs_data.clone(),
                 ));
                 let loss = reduce_all(
-                    &tenferro_linalg::triangular_solve(&matrix, &rhs, true, true, false, false)
-                        .unwrap(),
+                    &tenferro_linalg::traced_tensor::triangular_solve(
+                        &matrix, &rhs, true, true, false, false,
+                    )
+                    .unwrap(),
                 );
                 get_f64_data(&eval(&loss))[0]
             },
@@ -557,10 +673,10 @@ fn svd_vector_observable_jvp_matches_finite_diff() {
         matrix_tangent_data.clone(),
     ));
 
-    let (u, _s, vt) = tenferro_linalg::svd(&matrix).unwrap();
+    let (u, _s, vt) = tenferro_linalg::traced_tensor::svd(&matrix).unwrap();
     let u_loss = weighted_square_sum(&u, vec![3, 2], u_weights.clone());
     let vt_loss = weighted_square_sum(&vt, vec![2, 2], vt_weights.clone());
-    let loss = &u_loss + &vt_loss;
+    let loss = (&u_loss + &vt_loss).unwrap();
     let tangent = ad.jvp(&loss, &matrix, &matrix_tangent).unwrap();
     let result = eval(&tangent);
 
@@ -571,10 +687,11 @@ fn svd_vector_observable_jvp_matches_finite_diff() {
             |xs| {
                 let matrix =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], xs.to_vec()));
-                let (u, _s, vt) = tenferro_linalg::svd(&matrix).unwrap();
+                let (u, _s, vt) = tenferro_linalg::traced_tensor::svd(&matrix).unwrap();
                 let u_loss = weighted_square_sum(&u, vec![3, 2], u_weights.clone());
                 let vt_loss = weighted_square_sum(&vt, vec![2, 2], vt_weights.clone());
-                get_f64_data(&eval(&(&u_loss + &vt_loss)))[0]
+                let loss = (&u_loss + &vt_loss).unwrap();
+                get_f64_data(&eval(&loss))[0]
             },
             &matrix_data,
             &matrix_tangent_data,
@@ -598,7 +715,7 @@ fn eigh_vector_observable_jvp_matches_finite_diff() {
         matrix_tangent_data.clone(),
     ));
 
-    let (_values, vectors) = tenferro_linalg::eigh(&matrix).unwrap();
+    let (_values, vectors) = tenferro_linalg::traced_tensor::eigh(&matrix).unwrap();
     let loss = weighted_square_sum(&vectors, vec![2, 2], vector_weights.clone());
     let tangent = ad.jvp(&loss, &matrix, &matrix_tangent).unwrap();
     let result = eval(&tangent);
@@ -610,7 +727,7 @@ fn eigh_vector_observable_jvp_matches_finite_diff() {
             |xs| {
                 let matrix =
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], xs.to_vec()));
-                let (_values, vectors) = tenferro_linalg::eigh(&matrix).unwrap();
+                let (_values, vectors) = tenferro_linalg::traced_tensor::eigh(&matrix).unwrap();
                 let loss = weighted_square_sum(&vectors, vec![2, 2], vector_weights.clone());
                 get_f64_data(&eval(&loss))[0]
             },
@@ -630,11 +747,13 @@ fn solve_and_triangular_solve_grad_use_extension_transpose_rules() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0]));
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], vec![4.0, 8.0]));
 
-    let solve_loss = reduce_all(&tenferro_linalg::solve(&a, &b).unwrap());
+    let solve_loss = reduce_all(&tenferro_linalg::traced_tensor::solve(&a, &b).unwrap());
     let solve_grad_b = ad.grad(&solve_loss, &b).unwrap();
 
-    let triangular_loss =
-        reduce_all(&tenferro_linalg::triangular_solve(&a, &b, true, true, false, false).unwrap());
+    let triangular_loss = reduce_all(
+        &tenferro_linalg::traced_tensor::triangular_solve(&a, &b, true, true, false, false)
+            .unwrap(),
+    );
     let triangular_grad_b = ad.grad(&triangular_loss, &b).unwrap();
 
     let results = eval_many(&[&solve_grad_b, &triangular_grad_b]);
@@ -656,8 +775,8 @@ fn complex_eigh_values_grad_executes_with_complex_input_dtype() {
             num_complex::Complex64::new(2.0, 0.0),
         ],
     ));
-    let (values, _vectors) = tenferro_linalg::eigh(&h).unwrap();
-    let loss = values.reduce_sum(&[0]);
+    let (values, _vectors) = tenferro_linalg::traced_tensor::eigh(&h).unwrap();
+    let loss = values.reduce_sum(&[0]).unwrap();
 
     let grad = ad.grad(&loss, &h).unwrap();
     let out = eval(&grad);
@@ -680,8 +799,8 @@ fn batched_solve_sum_grad_wrt_matrix_uses_native_batch_layout() {
         vec![4.0, 8.0, 6.0, 10.0],
     ));
 
-    let x = tenferro_linalg::solve(&a, &b).unwrap();
-    let loss = x.reduce_sum(&[0, 1, 2]);
+    let x = tenferro_linalg::traced_tensor::solve(&a, &b).unwrap();
+    let loss = x.reduce_sum(&[0, 1, 2]).unwrap();
     let grad_a = ad.grad(&loss, &a).unwrap();
     let out = eval(&grad_a);
 

--- a/crates/tenferro-linalg/tests/traced_correctness.rs
+++ b/crates/tenferro-linalg/tests/traced_correctness.rs
@@ -3,7 +3,7 @@ use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{GraphCompiler, GraphExecutor, Tensor, TracedTensor, TypedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
-    Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
+    Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
 fn get_f64_data(tensor: &Tensor) -> &[f64] {
@@ -26,7 +26,7 @@ fn run_many(outputs: &[&TracedTensor]) -> Vec<Tensor> {
 
 #[test]
 fn traced_tensor_namespace_exposes_svd() {
-    let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]).unwrap();
     let (_u, s, _vt) = tenferro_linalg::traced_tensor::svd(&a).unwrap();
 
     assert_eq!(s.rank, 1);
@@ -36,7 +36,7 @@ fn traced_tensor_namespace_exposes_svd() {
 fn svd_traced_tensor_returns_three_outputs() {
     let a =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![1.0, 0.0, 0.0, 2.0]));
-    let (u, s, vt) = tenferro_linalg::svd(&a).unwrap();
+    let (u, s, vt) = tenferro_linalg::traced_tensor::svd(&a).unwrap();
     let results = run_many(&[&u, &s, &vt]);
 
     assert_eq!(results[0].shape(), &[2, 2]);
@@ -52,7 +52,7 @@ fn svd_traced_tensor_returns_three_outputs() {
 fn qr_traced_tensor_returns_q_and_r() {
     let a =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0]));
-    let (q, r) = tenferro_linalg::qr(&a).unwrap();
+    let (q, r) = tenferro_linalg::traced_tensor::qr(&a).unwrap();
     let results = run_many(&[&q, &r]);
 
     assert_eq!(results[0].shape(), &[2, 2]);
@@ -65,7 +65,7 @@ fn qr_traced_tensor_returns_q_and_r() {
 fn eigh_traced_tensor_returns_values_and_vectors() {
     let a =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![1.0, 0.0, 0.0, 3.0]));
-    let (values, vectors) = tenferro_linalg::eigh(&a).unwrap();
+    let (values, vectors) = tenferro_linalg::traced_tensor::eigh(&a).unwrap();
     let results = run_many(&[&values, &vectors]);
 
     assert_eq!(results[0].shape(), &[2]);
@@ -82,9 +82,10 @@ fn linalg_single_output_traced_tensor_functions_eval() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![4.0, 0.0, 0.0, 9.0]));
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], vec![8.0, 27.0]));
 
-    let chol = tenferro_linalg::cholesky(&a).unwrap();
-    let solved = tenferro_linalg::solve(&a, &b).unwrap();
-    let triangular = tenferro_linalg::triangular_solve(&a, &b, true, true, false, false).unwrap();
+    let chol = tenferro_linalg::traced_tensor::cholesky(&a).unwrap();
+    let solved = tenferro_linalg::traced_tensor::solve(&a, &b).unwrap();
+    let triangular =
+        tenferro_linalg::traced_tensor::triangular_solve(&a, &b, true, true, false, false).unwrap();
     let results = run_many(&[&chol, &solved, &triangular]);
 
     assert_eq!(get_f64_data(&results[0]), &[2.0, 0.0, 0.0, 3.0]);
@@ -96,7 +97,7 @@ fn linalg_single_output_traced_tensor_functions_eval() {
 fn lu_traced_tensor_returns_four_outputs() {
     let a =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]));
-    let (p, l, u, parity) = tenferro_linalg::lu(&a).unwrap();
+    let (p, l, u, parity) = tenferro_linalg::traced_tensor::lu(&a).unwrap();
     let results = run_many(&[&p, &l, &u, &parity]);
 
     assert_eq!(results[0].shape(), &[2, 2]);
@@ -111,7 +112,7 @@ fn full_piv_lu_solve_traced_tensor_eval() {
     let a =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![0.0, 2.0, 1.0, 3.0]));
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], vec![-1.0, 5.0]));
-    let x = tenferro_linalg::full_piv_lu_solve(&a, &b).unwrap();
+    let x = tenferro_linalg::traced_tensor::full_piv_lu_solve(&a, &b).unwrap();
     let results = run_many(&[&x]);
 
     assert_eq!(results[0].shape(), &[2, 1]);
@@ -122,7 +123,7 @@ fn full_piv_lu_solve_traced_tensor_eval() {
 fn eig_traced_tensor_returns_complex_outputs() {
     let a =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![1.0, 0.0, 0.0, 3.0]));
-    let (values, vectors) = tenferro_linalg::eig(&a).unwrap();
+    let (values, vectors) = tenferro_linalg::traced_tensor::eig(&a).unwrap();
     let results = run_many(&[&values, &vectors]);
 
     assert_eq!(results[0].shape(), &[2]);
@@ -143,11 +144,11 @@ fn determinant_inverse_and_eigenvalue_helpers_eval() {
     let a =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0]));
 
-    let (sign, logabsdet) = tenferro_linalg::slogdet(&a).unwrap();
-    let determinant = tenferro_linalg::det(&a).unwrap();
-    let inverse = tenferro_linalg::inv(&a).unwrap();
-    let eigvals = tenferro_linalg::eigvals(&a).unwrap();
-    let eigvalsh = tenferro_linalg::eigvalsh(&a).unwrap();
+    let (sign, logabsdet) = tenferro_linalg::traced_tensor::slogdet(&a).unwrap();
+    let determinant = tenferro_linalg::traced_tensor::det(&a).unwrap();
+    let inverse = tenferro_linalg::traced_tensor::inv(&a).unwrap();
+    let eigvals = tenferro_linalg::traced_tensor::eigvals(&a).unwrap();
+    let eigvalsh = tenferro_linalg::traced_tensor::eigvalsh(&a).unwrap();
     let results = run_many(&[
         &sign,
         &logabsdet,
@@ -181,8 +182,8 @@ fn pseudoinverse_and_norm_eval() {
     let a =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![2.0, 0.0, 0.0, 4.0]));
 
-    let pseudo_inverse = tenferro_linalg::pinv(&a).unwrap();
-    let frob = tenferro_linalg::norm(&a, None, Some(&[0, 1]), false).unwrap();
+    let pseudo_inverse = tenferro_linalg::traced_tensor::pinv(&a).unwrap();
+    let frob = tenferro_linalg::traced_tensor::norm(&a, None, Some(&[0, 1]), false).unwrap();
     let results = run_many(&[&pseudo_inverse, &frob]);
 
     assert_tensor_f64_eq(get_f64_data(&results[0]), &[0.5, 0.0, 0.0, 0.25]);
@@ -196,13 +197,22 @@ fn norm_supports_vector_zero_and_matrix_induced_orders() {
     let matrix =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0]));
 
-    let zero_norm = tenferro_linalg::norm(&vector, Some(0.0), Some(&[0]), false).unwrap();
-    let matrix_one = tenferro_linalg::norm(&matrix, Some(1.0), Some(&[0, 1]), false).unwrap();
-    let matrix_neg_one = tenferro_linalg::norm(&matrix, Some(-1.0), Some(&[0, 1]), false).unwrap();
+    let zero_norm =
+        tenferro_linalg::traced_tensor::norm(&vector, Some(0.0), Some(&[0]), false).unwrap();
+    let matrix_one =
+        tenferro_linalg::traced_tensor::norm(&matrix, Some(1.0), Some(&[0, 1]), false).unwrap();
+    let matrix_neg_one =
+        tenferro_linalg::traced_tensor::norm(&matrix, Some(-1.0), Some(&[0, 1]), false).unwrap();
     let matrix_inf =
-        tenferro_linalg::norm(&matrix, Some(f64::INFINITY), Some(&[0, 1]), false).unwrap();
-    let matrix_neg_inf =
-        tenferro_linalg::norm(&matrix, Some(f64::NEG_INFINITY), Some(&[0, 1]), false).unwrap();
+        tenferro_linalg::traced_tensor::norm(&matrix, Some(f64::INFINITY), Some(&[0, 1]), false)
+            .unwrap();
+    let matrix_neg_inf = tenferro_linalg::traced_tensor::norm(
+        &matrix,
+        Some(f64::NEG_INFINITY),
+        Some(&[0, 1]),
+        false,
+    )
+    .unwrap();
     let results = run_many(&[
         &zero_norm,
         &matrix_one,

--- a/crates/tenferro-linalg/tests/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/traced_extension.rs
@@ -8,45 +8,39 @@ use tenferro_tensor::Error as TensorError;
 fn traced_with_dtype(dtype: DType, shape: Vec<usize>) -> TracedTensor {
     let n_elements = shape.iter().product();
     let tensor = match dtype {
-        DType::F32 => Tensor::F32(TypedTensor::from_vec_col_major(
-            shape,
-            vec![1.0_f32; n_elements],
-        )),
-        DType::F64 => Tensor::F64(TypedTensor::from_vec_col_major(
-            shape,
-            vec![1.0_f64; n_elements],
-        )),
-        DType::I32 => Tensor::I32(TypedTensor::from_vec_col_major(
-            shape,
-            vec![1_i32; n_elements],
-        )),
-        DType::I64 => Tensor::I64(TypedTensor::from_vec_col_major(
-            shape,
-            vec![1_i64; n_elements],
-        )),
-        DType::Bool => Tensor::Bool(TypedTensor::from_vec_col_major(
-            shape,
-            vec![true; n_elements],
-        )),
-        DType::C32 => Tensor::C32(TypedTensor::from_vec_col_major(
-            shape,
-            vec![Complex32::new(1.0, 0.5); n_elements],
-        )),
-        DType::C64 => Tensor::C64(TypedTensor::from_vec_col_major(
-            shape,
-            vec![Complex64::new(1.0, 0.5); n_elements],
-        )),
+        DType::F32 => {
+            Tensor::F32(TypedTensor::from_vec_col_major(shape, vec![1.0_f32; n_elements]).unwrap())
+        }
+        DType::F64 => {
+            Tensor::F64(TypedTensor::from_vec_col_major(shape, vec![1.0_f64; n_elements]).unwrap())
+        }
+        DType::I32 => {
+            Tensor::I32(TypedTensor::from_vec_col_major(shape, vec![1_i32; n_elements]).unwrap())
+        }
+        DType::I64 => {
+            Tensor::I64(TypedTensor::from_vec_col_major(shape, vec![1_i64; n_elements]).unwrap())
+        }
+        DType::Bool => {
+            Tensor::Bool(TypedTensor::from_vec_col_major(shape, vec![true; n_elements]).unwrap())
+        }
+        DType::C32 => Tensor::C32(
+            TypedTensor::from_vec_col_major(shape, vec![Complex32::new(1.0, 0.5); n_elements])
+                .unwrap(),
+        ),
+        DType::C64 => Tensor::C64(
+            TypedTensor::from_vec_col_major(shape, vec![Complex64::new(1.0, 0.5); n_elements])
+                .unwrap(),
+        ),
     };
     TracedTensor::from_tensor_concrete_shape(tensor)
 }
 
 #[test]
 fn svd_executes_after_runtime_registration() {
-    let a = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0_f64, 0.0, 0.0, 2.0],
-    ));
-    let (u, s, vt) = tenferro_linalg::svd(&a).unwrap();
+    let a = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]).unwrap(),
+    );
+    let (u, s, vt) = tenferro_linalg::traced_tensor::svd(&a).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile_many(&[&u, &s, &vt]).unwrap();
@@ -64,23 +58,25 @@ fn svd_executes_after_runtime_registration() {
 
 #[test]
 fn complex_svd_runtime_singular_values_match_traced_real_dtype() {
-    let a = TracedTensor::from_tensor_concrete_shape(Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![
-            Complex64::new(3.0, 0.5),
-            Complex64::new(0.2, -0.4),
-            Complex64::new(-0.1, 0.3),
-            Complex64::new(2.0, -0.2),
-        ],
-    )));
-    let (_u, s, _vt) = tenferro_linalg::svd(&a).unwrap();
+    let a = TracedTensor::from_tensor_concrete_shape(Tensor::C64(
+        TypedTensor::from_vec_col_major(
+            vec![2, 2],
+            vec![
+                Complex64::new(3.0, 0.5),
+                Complex64::new(0.2, -0.4),
+                Complex64::new(-0.1, 0.3),
+                Complex64::new(2.0, -0.2),
+            ],
+        )
+        .unwrap(),
+    ));
+    let (_u, s, _vt) = tenferro_linalg::traced_tensor::svd(&a).unwrap();
     assert_eq!(s.dtype, DType::F64);
 
-    let weights = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![2],
-        vec![0.5_f64, 2.0],
-    ));
-    let weighted = &s * &weights;
+    let weights = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![2], vec![0.5_f64, 2.0]).unwrap(),
+    );
+    let weighted = (&s * &weights).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile_many(&[&s, &weighted]).unwrap();
@@ -98,11 +94,10 @@ fn complex_svd_runtime_singular_values_match_traced_real_dtype() {
 
 #[test]
 fn missing_runtime_reports_linalg_family() {
-    let a = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0_f64, 0.0, 0.0, 1.0],
-    ));
-    let y = tenferro_linalg::cholesky(&a).unwrap();
+    let a = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap(),
+    );
+    let y = tenferro_linalg::traced_tensor::cholesky(&a).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&y).unwrap();
@@ -117,11 +112,10 @@ fn missing_runtime_reports_linalg_family() {
 
 #[test]
 fn full_piv_lu_multi_output_slots_are_preserved() {
-    let a = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![2, 2],
-        vec![0.0_f64, 2.0, 1.0, 3.0],
-    ));
-    let (p, l, u, q, parity) = tenferro_linalg::full_piv_lu(&a).unwrap();
+    let a = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 1.0, 3.0]).unwrap(),
+    );
+    let (p, l, u, q, parity) = tenferro_linalg::traced_tensor::full_piv_lu(&a).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile_many(&[&p, &l, &u, &q, &parity]).unwrap();
@@ -140,44 +134,43 @@ fn full_piv_lu_multi_output_slots_are_preserved() {
 
 #[test]
 fn traced_metadata_matches_linalg_extension_shapes_and_dtypes() {
-    let rectangular = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![3, 4, 2],
-        vec![1.0_f64; 24],
-    ));
-    let square = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![3, 3, 2],
-        vec![1.0_f64; 18],
-    ));
+    let rectangular = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![3, 4, 2], vec![1.0_f64; 24]).unwrap(),
+    );
+    let square = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![3, 3, 2], vec![1.0_f64; 18]).unwrap(),
+    );
     let complex_square = TracedTensor::from_tensor_concrete_shape(Tensor::C64(
-        TypedTensor::from_vec_col_major(vec![2, 2], vec![Complex64::new(1.0, 0.0); 4]),
+        TypedTensor::from_vec_col_major(vec![2, 2], vec![Complex64::new(1.0, 0.0); 4]).unwrap(),
     ));
     let ints = TracedTensor::from_tensor_concrete_shape(Tensor::I64(
-        TypedTensor::from_vec_col_major(vec![2, 2], vec![1, 0, 0, 2]),
+        TypedTensor::from_vec_col_major(vec![2, 2], vec![1, 0, 0, 2]).unwrap(),
     ));
 
-    let (u, s, vt) = tenferro_linalg::svd(&rectangular).unwrap();
-    assert_eq!(u.concrete_shape(), vec![3, 3, 2]);
-    assert_eq!(s.concrete_shape(), vec![3, 2]);
-    assert_eq!(vt.concrete_shape(), vec![3, 4, 2]);
+    let (u, s, vt) = tenferro_linalg::traced_tensor::svd(&rectangular).unwrap();
+    assert_eq!(u.concrete_shape().unwrap(), vec![3, 3, 2]);
+    assert_eq!(s.concrete_shape().unwrap(), vec![3, 2]);
+    assert_eq!(vt.concrete_shape().unwrap(), vec![3, 4, 2]);
 
-    let (q, r) = tenferro_linalg::qr(&rectangular).unwrap();
-    assert_eq!(q.concrete_shape(), vec![3, 3, 2]);
-    assert_eq!(r.concrete_shape(), vec![3, 4, 2]);
+    let (q, r) = tenferro_linalg::traced_tensor::qr(&rectangular).unwrap();
+    assert_eq!(q.concrete_shape().unwrap(), vec![3, 3, 2]);
+    assert_eq!(r.concrete_shape().unwrap(), vec![3, 4, 2]);
 
-    let (values, vectors) = tenferro_linalg::eig(&ints).unwrap();
+    let (values, vectors) = tenferro_linalg::traced_tensor::eig(&ints).unwrap();
     assert_eq!(values.dtype, DType::C64);
     assert_eq!(vectors.dtype, DType::C64);
 
-    let (eigh_values, eigh_vectors) = tenferro_linalg::eigh(&square).unwrap();
-    assert_eq!(eigh_values.concrete_shape(), vec![3, 2]);
-    assert_eq!(eigh_vectors.concrete_shape(), vec![3, 3, 2]);
+    let (eigh_values, eigh_vectors) = tenferro_linalg::traced_tensor::eigh(&square).unwrap();
+    assert_eq!(eigh_values.concrete_shape().unwrap(), vec![3, 2]);
+    assert_eq!(eigh_vectors.concrete_shape().unwrap(), vec![3, 3, 2]);
 
     let (complex_eigh_values, complex_eigh_vectors) =
-        tenferro_linalg::eigh(&complex_square).unwrap();
+        tenferro_linalg::traced_tensor::eigh(&complex_square).unwrap();
     assert_eq!(complex_eigh_values.dtype, DType::F64);
     assert_eq!(complex_eigh_vectors.dtype, DType::C64);
 
-    let (p, l, u, q, parity) = tenferro_linalg::full_piv_lu(&complex_square).unwrap();
+    let (p, l, u, q, parity) =
+        tenferro_linalg::traced_tensor::full_piv_lu(&complex_square).unwrap();
     assert_eq!(p.dtype, DType::C64);
     assert_eq!(l.dtype, DType::C64);
     assert_eq!(u.dtype, DType::C64);
@@ -203,12 +196,12 @@ fn traced_metadata_promotes_linalg_dtypes_broadly() {
     for (a_dtype, b_dtype, expected_dtype) in promotion_cases {
         let a = traced_with_dtype(a_dtype, vec![2, 2]);
         let b = traced_with_dtype(b_dtype, vec![2, 1]);
-        let solved = tenferro_linalg::solve(&a, &b).unwrap();
+        let solved = tenferro_linalg::traced_tensor::solve(&a, &b).unwrap();
         assert_eq!(solved.dtype, expected_dtype);
-        assert_eq!(solved.concrete_shape(), vec![2, 1]);
+        assert_eq!(solved.concrete_shape().unwrap(), vec![2, 1]);
     }
 
-    let triangular = tenferro_linalg::triangular_solve(
+    let triangular = tenferro_linalg::traced_tensor::triangular_solve(
         &traced_with_dtype(DType::Bool, vec![2, 2]),
         &traced_with_dtype(DType::F32, vec![2, 1]),
         true,
@@ -218,7 +211,7 @@ fn traced_metadata_promotes_linalg_dtypes_broadly() {
     )
     .unwrap();
     assert_eq!(triangular.dtype, DType::F32);
-    assert_eq!(triangular.concrete_shape(), vec![2, 1]);
+    assert_eq!(triangular.concrete_shape().unwrap(), vec![2, 1]);
 }
 
 #[test]
@@ -233,11 +226,11 @@ fn traced_metadata_covers_eig_output_dtype_rules() {
         (DType::Bool, DType::C64),
     ] {
         let a = traced_with_dtype(input_dtype, vec![2, 2]);
-        let (values, vectors) = tenferro_linalg::eig(&a).unwrap();
+        let (values, vectors) = tenferro_linalg::traced_tensor::eig(&a).unwrap();
         assert_eq!(values.dtype, expected_dtype);
         assert_eq!(vectors.dtype, expected_dtype);
-        assert_eq!(values.concrete_shape(), vec![2]);
-        assert_eq!(vectors.concrete_shape(), vec![2, 2]);
+        assert_eq!(values.concrete_shape().unwrap(), vec![2]);
+        assert_eq!(vectors.concrete_shape().unwrap(), vec![2, 2]);
     }
 }
 
@@ -245,7 +238,8 @@ fn traced_metadata_covers_eig_output_dtype_rules() {
 fn traced_norm_rejects_integer_and_bool_dtypes_before_scalar_rounding() {
     for dtype in [DType::I32, DType::I64, DType::Bool] {
         let tensor = traced_with_dtype(dtype, vec![3]);
-        let err = match tenferro_linalg::norm(&tensor, Some(2.0), Some(&[0]), false) {
+        let err = match tenferro_linalg::traced_tensor::norm(&tensor, Some(2.0), Some(&[0]), false)
+        {
             Ok(_) => panic!("expected unsupported dtype error for {dtype:?}"),
             Err(err) => err,
         };
@@ -260,7 +254,7 @@ fn traced_norm_rejects_integer_and_bool_dtypes_before_scalar_rounding() {
             "expected unsupported dtype error for {dtype:?}, got {err:?}"
         );
 
-        let err = match tenferro_linalg::pinv_with_rtol(&tensor, 1.0e-12) {
+        let err = match tenferro_linalg::traced_tensor::pinv_with_rtol(&tensor, 1.0e-12) {
             Ok(_) => panic!("expected unsupported dtype error for {dtype:?}"),
             Err(err) => err,
         };
@@ -279,9 +273,9 @@ fn traced_norm_rejects_integer_and_bool_dtypes_before_scalar_rounding() {
 
 #[test]
 fn traced_inv_rejects_rank_less_than_two_without_panicking() {
-    let scalar = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]);
+    let scalar = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
 
-    let err = tenferro_linalg::inv(&scalar).unwrap_err();
+    let err = tenferro_linalg::traced_tensor::inv(&scalar).unwrap_err();
 
     assert!(matches!(
         err,
@@ -298,15 +292,15 @@ fn traced_linalg_helpers_reject_symbolic_shapes_without_panicking() {
     let matrix = TracedTensor::input_symbolic_shape(DType::F64, 2);
 
     for (op, result) in [
-        ("inv", tenferro_linalg::inv(&matrix)),
-        ("pinv", tenferro_linalg::pinv(&matrix)),
+        ("inv", tenferro_linalg::traced_tensor::inv(&matrix)),
+        ("pinv", tenferro_linalg::traced_tensor::pinv(&matrix)),
         (
             "pinv_with_rtol",
-            tenferro_linalg::pinv_with_rtol(&matrix, 1.0e-12),
+            tenferro_linalg::traced_tensor::pinv_with_rtol(&matrix, 1.0e-12),
         ),
         (
             "norm",
-            tenferro_linalg::norm(&matrix, Some(2.0), Some(&[0, 1]), true),
+            tenferro_linalg::traced_tensor::norm(&matrix, Some(2.0), Some(&[0, 1]), true),
         ),
     ] {
         let err = result.unwrap_err();
@@ -325,9 +319,10 @@ fn traced_linalg_helpers_reject_symbolic_shapes_without_panicking() {
 
 #[test]
 fn traced_norm_rejects_out_of_range_axis_without_panicking() {
-    let tensor = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    let tensor = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
 
-    let err = tenferro_linalg::norm(&tensor, Some(2.0), Some(&[5]), false).unwrap_err();
+    let err =
+        tenferro_linalg::traced_tensor::norm(&tensor, Some(2.0), Some(&[5]), false).unwrap_err();
 
     assert!(matches!(
         err,
@@ -343,7 +338,7 @@ fn traced_norm_rejects_out_of_range_axis_without_panicking() {
 fn traced_pinv_rejects_integer_and_bool_dtypes_before_scalar_rounding() {
     for dtype in [DType::I32, DType::I64, DType::Bool] {
         let tensor = traced_with_dtype(dtype, vec![2, 2]);
-        let err = match tenferro_linalg::pinv(&tensor) {
+        let err = match tenferro_linalg::traced_tensor::pinv(&tensor) {
             Ok(_) => panic!("expected unsupported dtype error for {dtype:?}"),
             Err(err) => err,
         };

--- a/crates/tenferro-runtime/examples/column_major_memory.rs
+++ b/crates/tenferro-runtime/examples/column_major_memory.rs
@@ -2,9 +2,14 @@ use tenferro_runtime::{Tensor, TypedTensor};
 
 fn main() {
     let typed =
-        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
-    assert_eq!(typed.as_slice(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0])
+            .unwrap();
+    assert_eq!(typed.as_slice().unwrap(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
 
-    let dynamic = Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    assert_eq!(dynamic.as_slice::<f64>().unwrap(), typed.as_slice());
+    let dynamic =
+        Tensor::from_vec_row_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    assert_eq!(
+        dynamic.as_slice::<f64>().unwrap(),
+        typed.as_slice().unwrap()
+    );
 }

--- a/crates/tenferro-runtime/examples/cpu_quickstart.rs
+++ b/crates/tenferro-runtime/examples/cpu_quickstart.rs
@@ -4,8 +4,8 @@ use tenferro_runtime::{tensor, Tensor};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut backend = CpuBackend::new();
 
-    let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
-    let b = Tensor::from_vec_col_major(vec![2, 2], vec![5.0_f64, 7.0, 6.0, 8.0]);
+    let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])?;
+    let b = Tensor::from_vec_col_major(vec![2, 2], vec![5.0_f64, 7.0, 6.0, 8.0])?;
 
     let c = tensor::matmul(&a, &b, &mut backend)?;
 

--- a/crates/tenferro-runtime/src/ad_support.rs
+++ b/crates/tenferro-runtime/src/ad_support.rs
@@ -6,20 +6,21 @@ use std::sync::Arc;
 
 use computegraph::graph::Graph;
 use computegraph::types::{LocalValueId, ValueKey};
+pub use tenferro_ops::ad::context::GlobalMetadataScope;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{DType, Tensor, TypedTensor};
 
 pub use crate::checkpoint::CheckpointNode;
-use crate::metadata::MetadataScope as RuntimeMetadataScope;
 pub use crate::metadata::{
     metadata_scopes_for_scope, metadata_scopes_with_new, metadata_scopes_with_scope,
     push_metadata_scope, register_scoped_graph_metadata, register_scoped_live_graph_metadata,
     register_scoped_metadata_batch, register_scoped_value_metadata, registered_meta,
-    tensor_meta_from_tensor, MetadataScope,
+    tensor_meta_from_tensor,
 };
 use crate::sym_dim::SymDim;
 use crate::traced::{next_input_key, next_traced_id, TracedTensor};
+use crate::{Error, Result};
 
 /// Parts required to construct a traced tensor from an AD transform.
 pub struct TracedTensorParts {
@@ -32,7 +33,7 @@ pub struct TracedTensorParts {
     pub inputs_map: Arc<HashMap<TensorInputKey, Arc<Tensor>>>,
     pub extra_roots: Vec<Arc<Graph<StdTensorOp>>>,
     pub checkpoint_chain: Option<Arc<CheckpointNode>>,
-    pub metadata_scopes: Vec<Arc<RuntimeMetadataScope>>,
+    pub metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
 }
 
 impl fmt::Debug for TracedTensorParts {
@@ -84,7 +85,7 @@ pub fn checkpoint_chain(tensor: &TracedTensor) -> Option<Arc<CheckpointNode>> {
     tensor.checkpoint_chain.clone()
 }
 
-pub fn metadata_scopes(tensor: &TracedTensor) -> &[Arc<RuntimeMetadataScope>] {
+pub fn metadata_scopes(tensor: &TracedTensor) -> &[Arc<GlobalMetadataScope>] {
     &tensor.metadata_scopes
 }
 
@@ -105,9 +106,13 @@ pub fn checkpoint_tensor(tensor: &mut TracedTensor, data: Arc<Tensor>) {
     let new_metadata_scope = register_scoped_value_metadata(
         new_graph.values()[leaf_val].key.clone(),
         concrete_meta.clone(),
-    );
+    )
+    // The replacement checkpoint input key is freshly allocated here.
+    .expect("fresh checkpoint input metadata registration failed");
     let old_output_metadata_scope =
-        register_scoped_value_metadata(old_output_key.clone(), concrete_meta);
+        register_scoped_value_metadata(old_output_key.clone(), concrete_meta)
+            // Checkpoint aliases re-register metadata for the captured output key.
+            .expect("checkpoint output metadata registration failed");
     let node = CheckpointNode {
         graph: old_graph,
         alias_key: new_key.clone(),
@@ -135,40 +140,48 @@ pub fn checkpoint_tensor(tensor: &mut TracedTensor, data: Arc<Tensor>) {
     tensor.inputs_map = Arc::new(merged);
 }
 
-pub fn metadata_scopes_for_new_leaf(scope: RuntimeMetadataScope) -> Vec<Arc<RuntimeMetadataScope>> {
-    metadata_scopes_for_scope(scope)
-}
-
-pub fn fresh_input_key() -> TensorInputKey {
+pub fn allocate_input_key() -> TensorInputKey {
     next_input_key()
 }
 
-pub fn leaf_input_key(tensor: &TracedTensor) -> TensorInputKey {
+pub fn leaf_input_key(tensor: &TracedTensor) -> Result<TensorInputKey> {
     match &tensor.graph.values()[tensor.val].key {
-        ValueKey::Input(key) => key.clone(),
-        other => panic!("expected traced leaf input, got {:?}", other),
+        ValueKey::Input(key) => Ok(key.clone()),
+        other => Err(Error::InvalidGraphBuild {
+            op: "ad_support::leaf_input_key",
+            message: format!("expected traced leaf input, got {other:?}"),
+        }),
     }
 }
 
-pub fn linear_input_key(graph: &Graph<StdTensorOp>, local_id: LocalValueId) -> TensorInputKey {
+pub fn linear_input_key(
+    graph: &Graph<StdTensorOp>,
+    local_id: LocalValueId,
+) -> Result<TensorInputKey> {
     match &graph.values()[local_id].key {
-        ValueKey::Input(key) => key.clone(),
-        other => panic!("expected linear graph input, got {:?}", other),
+        ValueKey::Input(key) => Ok(key.clone()),
+        other => Err(Error::InvalidGraphBuild {
+            op: "ad_support::linear_input_key",
+            message: format!("expected linear graph input, got {other:?}"),
+        }),
     }
 }
 
-pub fn ones_tensor(dtype: DType, shape: Vec<usize>) -> Tensor {
+pub fn ones_tensor(dtype: DType, shape: Vec<usize>) -> Result<Tensor> {
     match dtype {
-        DType::F32 => Tensor::F32(TypedTensor::ones(shape)),
-        DType::F64 => Tensor::F64(TypedTensor::ones(shape)),
-        DType::I32 => Tensor::I32(TypedTensor::ones(shape)),
-        DType::I64 => Tensor::I64(TypedTensor::ones(shape)),
+        DType::F32 => Ok(Tensor::F32(TypedTensor::ones(shape)?)),
+        DType::F64 => Ok(Tensor::F64(TypedTensor::ones(shape)?)),
+        DType::I32 => Ok(Tensor::I32(TypedTensor::ones(shape)?)),
+        DType::I64 => Ok(Tensor::I64(TypedTensor::ones(shape)?)),
         DType::Bool => {
             let len = shape.iter().product();
-            Tensor::Bool(TypedTensor::from_vec_col_major(shape, vec![true; len]))
+            Ok(Tensor::Bool(TypedTensor::from_vec_col_major(
+                shape,
+                vec![true; len],
+            )?))
         }
-        DType::C32 => Tensor::C32(TypedTensor::ones(shape)),
-        DType::C64 => Tensor::C64(TypedTensor::ones(shape)),
+        DType::C32 => Ok(Tensor::C32(TypedTensor::ones(shape)?)),
+        DType::C64 => Ok(Tensor::C64(TypedTensor::ones(shape)?)),
     }
 }
 

--- a/crates/tenferro-runtime/src/ad_support/tests.rs
+++ b/crates/tenferro-runtime/src/ad_support/tests.rs
@@ -7,16 +7,16 @@ use tenferro_tensor::{DType, Tensor};
 
 use crate::sym_dim::SymDim;
 
-use super::{fresh_input_key, tensor_from_parts, TracedTensorParts};
+use super::{allocate_input_key, tensor_from_parts, TracedTensorParts};
 
 #[test]
 fn traced_tensor_parts_debug_summarizes_without_graph_payload() {
-    let input_key = fresh_input_key();
+    let input_key = allocate_input_key();
     let mut builder = GraphBuilder::new();
     let val = builder.add_input(input_key.clone());
     builder.set_outputs(vec![val]);
     let graph = Arc::new(builder.build());
-    let data = Arc::new(Tensor::from_vec_col_major(vec![1], vec![2.0_f64]));
+    let data = Arc::new(Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap());
     let inputs_map = Arc::new(HashMap::from([(input_key, Arc::clone(&data))]));
     let parts = TracedTensorParts {
         rank: 1,
@@ -42,12 +42,12 @@ fn traced_tensor_parts_debug_summarizes_without_graph_payload() {
 
 #[test]
 fn tensor_from_parts_preserves_summary_fields() {
-    let input_key = fresh_input_key();
+    let input_key = allocate_input_key();
     let mut builder = GraphBuilder::new();
     let val = builder.add_input(input_key.clone());
     builder.set_outputs(vec![val]);
     let graph = Arc::new(builder.build());
-    let data = Arc::new(Tensor::from_vec_col_major(vec![1], vec![3.0_f64]));
+    let data = Arc::new(Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap());
     let inputs_map = Arc::new(HashMap::from([(input_key.clone(), Arc::clone(&data))]));
     let parts = TracedTensorParts {
         rank: 1,

--- a/crates/tenferro-runtime/src/compiler/mod.rs
+++ b/crates/tenferro-runtime/src/compiler/mod.rs
@@ -112,7 +112,7 @@ pub fn compile_std_to_exec_with_options(
                     let extents = exact_extents_from_shapes(&shapes);
                     (dtypes, shapes, extents)
                 } else {
-                    let dtype = infer_output_dtype(&instr.operation, &input_dtypes);
+                    let dtype = infer_output_dtype(&instr.operation, &input_dtypes)?;
                     let shapes = infer_output_shapes(&instr.operation, &input_shapes_refs)?;
                     let extents = infer_output_extents(&instr.operation, &input_shapes_refs)?;
                     if shapes.len() != instr.outputs.len() {

--- a/crates/tenferro-runtime/src/compiler/tests.rs
+++ b/crates/tenferro-runtime/src/compiler/tests.rs
@@ -1101,14 +1101,11 @@ fn test_full_pipeline_multi_free_dim_decomp_runs_correctly() {
     //                       RHS = sequential 0..20, reshaped as [4, 5].
     let lhs_data: Vec<f64> = (0..24).map(|x| x as f64).collect();
     let rhs_data: Vec<f64> = (0..20).map(|x| x as f64).collect();
-    let lhs = Tensor::F64(TypedTensor::<f64>::from_vec_col_major(
-        vec![2, 3, 4],
-        lhs_data.clone(),
-    ));
-    let rhs = Tensor::F64(TypedTensor::<f64>::from_vec_col_major(
-        vec![4, 5],
-        rhs_data.clone(),
-    ));
+    let lhs = Tensor::F64(
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3, 4], lhs_data.clone()).unwrap(),
+    );
+    let rhs =
+        Tensor::F64(TypedTensor::<f64>::from_vec_col_major(vec![4, 5], rhs_data.clone()).unwrap());
 
     let mut executor = GraphExecutor::new(CpuBackend::default());
     let mut outputs = executor
@@ -1137,7 +1134,13 @@ fn test_full_pipeline_multi_free_dim_decomp_runs_correctly() {
             }
         }
     }
-    for (i, (got, want)) in typed.host_data().iter().zip(expected.iter()).enumerate() {
+    for (i, (got, want)) in typed
+        .host_data()
+        .unwrap()
+        .iter()
+        .zip(expected.iter())
+        .enumerate()
+    {
         assert!(
             (got - want).abs() < 1e-9,
             "index {i}: got {got}, expected {want}"

--- a/crates/tenferro-runtime/src/exec.rs
+++ b/crates/tenferro-runtime/src/exec.rs
@@ -112,8 +112,8 @@ impl<'a> ExecSlot<'a> {
     pub(crate) fn into_tensor(self) -> Result<Tensor> {
         match self {
             Self::Owned(tensor) => Ok(tensor),
-            Self::Value(value) => Ok(value.try_to_tensor()?),
-            Self::Read(read) => Ok(read.try_to_tensor()?),
+            Self::Value(value) => Ok(value.to_tensor()?),
+            Self::Read(read) => Ok(read.to_tensor()?),
         }
     }
 
@@ -121,7 +121,7 @@ impl<'a> ExecSlot<'a> {
         match self {
             Self::Owned(tensor) => Ok(TensorValue::from_tensor(tensor)),
             Self::Value(value) => Ok(value),
-            Self::Read(read) => Ok(TensorValue::from_tensor(read.try_to_tensor()?)),
+            Self::Read(read) => Ok(TensorValue::from_tensor(read.to_tensor()?)),
         }
     }
 }
@@ -491,7 +491,7 @@ fn tensor_value_for_lazy_view<'input>(
             Ok(output)
         }
         Some(ExecSlot::Read(read)) => {
-            let output = TensorValue::from_tensor(read.try_to_tensor()?);
+            let output = TensorValue::from_tensor(read.to_tensor()?);
             slots[slot] = Some(ExecSlot::Read(read));
             Ok(output)
         }
@@ -520,7 +520,7 @@ pub(crate) fn resolve_tensor_shape_exprs(
     for &slot in input_slots {
         input_shapes.push(slot_ref(slots, slot, "input", "resolve_tensor_shape_exprs")?.shape());
     }
-    DimExpr::try_eval_all(exprs, &input_shapes).map_err(|err| Error::InvalidCompiledGraph {
+    DimExpr::eval_all(exprs, &input_shapes).map_err(|err| Error::InvalidCompiledGraph {
         message: format!("shape expression evaluation failed: {err}"),
     })
 }
@@ -886,23 +886,23 @@ pub(crate) fn constant_tensor(dtype: DType, bytes: &[u8]) -> Result<Tensor> {
         DType::F64 => Ok(Tensor::F64(TypedTensor::from_vec_col_major(
             vec![],
             vec![f64::from_le_bytes(exact_bytes::<8>(dtype, bytes)?)],
-        ))),
+        )?)),
         DType::F32 => Ok(Tensor::F32(TypedTensor::from_vec_col_major(
             vec![],
             vec![f32::from_le_bytes(exact_bytes::<4>(dtype, bytes)?)],
-        ))),
+        )?)),
         DType::I32 => Ok(Tensor::I32(TypedTensor::from_vec_col_major(
             vec![],
             vec![i32::from_le_bytes(exact_bytes::<4>(dtype, bytes)?)],
-        ))),
+        )?)),
         DType::I64 => Ok(Tensor::I64(TypedTensor::from_vec_col_major(
             vec![],
             vec![i64::from_le_bytes(exact_bytes::<8>(dtype, bytes)?)],
-        ))),
+        )?)),
         DType::Bool => Ok(Tensor::Bool(TypedTensor::from_vec_col_major(
             vec![],
             vec![exact_bytes::<1>(dtype, bytes)?[0] != 0],
-        ))),
+        )?)),
         DType::C64 => {
             let data = exact_bytes::<16>(dtype, bytes)?;
             let mut re_bytes = [0u8; 8];
@@ -914,7 +914,7 @@ pub(crate) fn constant_tensor(dtype: DType, bytes: &[u8]) -> Result<Tensor> {
             Ok(Tensor::C64(TypedTensor::from_vec_col_major(
                 vec![],
                 vec![Complex64::new(re, im)],
-            )))
+            )?))
         }
         DType::C32 => {
             let data = exact_bytes::<8>(dtype, bytes)?;
@@ -927,7 +927,7 @@ pub(crate) fn constant_tensor(dtype: DType, bytes: &[u8]) -> Result<Tensor> {
             Ok(Tensor::C32(TypedTensor::from_vec_col_major(
                 vec![],
                 vec![Complex32::new(re, im)],
-            )))
+            )?))
         }
     }
 }

--- a/crates/tenferro-runtime/src/exec/dispatch.rs
+++ b/crates/tenferro-runtime/src/exec/dispatch.rs
@@ -319,7 +319,7 @@ fn execute_shape_of_host<B: TensorBackend>(
     let host = Tensor::F64(tenferro_tensor::TypedTensor::from_vec_col_major(
         vec![],
         vec![input.shape()[*axis] as f64],
-    ));
+    )?);
     slots[inst.output_slots[0]] = Some(ExecSlot::Owned(backend.upload_host_tensor(&host)?));
     Ok(())
 }

--- a/crates/tenferro-runtime/src/exec/tests.rs
+++ b/crates/tenferro-runtime/src/exec/tests.rs
@@ -142,7 +142,7 @@ fn exec_instruction_single_output_metadata_stays_inline() {
 
 #[test]
 fn lazy_view_input_conversion_shares_live_owned_tensor() {
-    let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let mut slots = vec![Some(ExecSlot::Owned(tensor))];
 
     let value = tensor_value_for_lazy_view(&mut slots, 0, false).unwrap();
@@ -157,10 +157,9 @@ fn lazy_view_input_conversion_shares_live_owned_tensor() {
 
 #[test]
 fn exec_accessors_reject_bad_input_slot_index_without_panicking() {
-    let slots = [Some(ExecSlot::Owned(Tensor::from_vec_col_major(
-        vec![1],
-        vec![1.0_f64],
-    )))];
+    let slots = [Some(ExecSlot::Owned(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+    ))];
 
     let err = get(&slots, &[], 0).unwrap_err();
 
@@ -171,10 +170,9 @@ fn exec_accessors_reject_bad_input_slot_index_without_panicking() {
 
 #[test]
 fn exec_accessors_reject_out_of_range_slot_without_panicking() {
-    let slots = [Some(ExecSlot::Owned(Tensor::from_vec_col_major(
-        vec![1],
-        vec![1.0_f64],
-    )))];
+    let slots = [Some(ExecSlot::Owned(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+    ))];
 
     let err = get(&slots, &[4], 0).unwrap_err();
 
@@ -188,8 +186,8 @@ fn initialize_exec_slots_rejects_input_count_mismatch_without_panicking() {
     let program = empty_program(1);
     let mut slots = Vec::new();
     let inputs = vec![
-        ExecSlot::Owned(Tensor::from_vec_col_major(vec![1], vec![1.0_f64])),
-        ExecSlot::Owned(Tensor::from_vec_col_major(vec![1], vec![2.0_f64])),
+        ExecSlot::Owned(Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap()),
+        ExecSlot::Owned(Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap()),
     ];
 
     let err = initialize_exec_slots_in(&program, inputs, &mut slots).unwrap_err();
@@ -203,10 +201,9 @@ fn initialize_exec_slots_rejects_input_count_mismatch_without_panicking() {
 fn collect_outputs_rejects_out_of_range_slot_without_panicking() {
     let mut program = empty_program(1);
     program.output_slots = vec![3];
-    let mut slots = vec![Some(ExecSlot::Owned(Tensor::from_vec_col_major(
-        vec![1],
-        vec![1.0_f64],
-    )))];
+    let mut slots = vec![Some(ExecSlot::Owned(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+    ))];
 
     let err = collect_outputs_from(&program, &mut slots).unwrap_err();
 

--- a/crates/tenferro-runtime/src/extension.rs
+++ b/crates/tenferro-runtime/src/extension.rs
@@ -3,16 +3,16 @@
 //! This module exposes the Stage 6 `ExtensionOp` mechanism through the
 //! runtime crate. External crates implement
 //! [`tenferro_ops::ext_op::ExtensionOp`] and build traced graphs containing
-//! the extension via [`try_apply`] or the compatibility wrapper [`apply`].
+//! the extension via [`apply`].
 //!
 //! See `docs/spec/extension-op.md` for the normative contract.
 //!
 //! # Examples
 //!
 //! ```rust
-//! use tenferro_runtime::extension::{try_apply, ExtensionOpTrait};
+//! use tenferro_runtime::extension::{apply, ExtensionOp};
 //!
-//! // Construct an `Arc<dyn ExtensionOpTrait>` and call `try_apply(op, &[input])`
+//! // Construct an `Arc<dyn ExtensionOp>` and call `apply(op, &[input])`
 //! // to lower it into a `TracedTensor`.
 //! ```
 
@@ -21,7 +21,6 @@ use std::sync::Arc;
 
 use computegraph::graph::GraphBuilder;
 use computegraph::types::{OperationRole, ValueRef};
-use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::SymDim;
 use tenferro_tensor::{Tensor, TensorBackend};
@@ -41,7 +40,7 @@ pub use crate::shape_infer::{
     infer_output_dtype, infer_output_extents, infer_output_shapes, promote_dtype,
     promote_dtype_div_like, promote_dtype_for_binary_op, promote_dtypes,
 };
-pub use tenferro_ops::ext_op::ExtensionOp as ExtensionOpTrait;
+pub use tenferro_ops::ext_op::ExtensionOp;
 pub use tenferro_ops::ExtensionFamilyId;
 
 pub use crate::extension_cache::{
@@ -89,18 +88,18 @@ pub fn execute_lowered_program_with_backend_cache<B: TensorBackend + 'static>(
 /// ```rust
 /// # use std::any::Any;
 /// use std::sync::Arc;
-/// use tenferro_runtime::extension::{try_apply, ExtensionOpTrait};
+/// use tenferro_runtime::extension::{apply, ExtensionOp};
 /// use tenferro_runtime::{DType, SymDim, Tensor, TracedTensor};
 ///
 /// # #[derive(Clone, Debug)]
 /// # struct IdentityExt;
-/// # impl ExtensionOpTrait for IdentityExt {
+/// # impl ExtensionOp for IdentityExt {
 /// #     fn family_id(&self) -> &'static str { "example.identity.v1" }
 /// #     fn payload_hash(&self, _hasher: &mut dyn std::hash::Hasher) {}
-/// #     fn payload_eq(&self, other: &dyn ExtensionOpTrait) -> bool {
+/// #     fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
 /// #         other.as_any().downcast_ref::<IdentityExt>().is_some()
 /// #     }
-/// #     fn clone_arc(&self) -> Arc<dyn ExtensionOpTrait> { Arc::new(self.clone()) }
+/// #     fn clone_arc(&self) -> Arc<dyn ExtensionOp> { Arc::new(self.clone()) }
 /// #     fn as_any(&self) -> &dyn Any { self }
 /// #     fn input_count(&self) -> usize { 1 }
 /// #     fn output_count(&self) -> usize { 1 }
@@ -115,69 +114,19 @@ pub fn execute_lowered_program_with_backend_cache<B: TensorBackend + 'static>(
 /// #         Ok(vec![inputs[0].clone()])
 /// #     }
 /// # }
-/// let op: Arc<dyn ExtensionOpTrait> = Arc::new(IdentityExt);
+/// let op: Arc<dyn ExtensionOp> = Arc::new(IdentityExt);
 /// let a = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-/// let outputs = try_apply(op, &[&a])?;
+/// let outputs = apply(op, &[&a])?;
 /// assert_eq!(outputs.len(), 1);
 /// # Ok::<(), tenferro_runtime::Error>(())
 /// ```
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics on validation errors. This is the compatibility wrapper for legacy
-/// call sites; new runtime-facing code should use [`try_apply`] so malformed
-/// extension metadata is returned as [`Error::InvalidGraphBuild`].
-pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Vec<TracedTensor> {
-    // Intentional compatibility panic wrapper. Keep `try_apply` as the
-    // non-panicking API so audits do not mistake this for an unhandled error.
-    try_apply(op, inputs).expect("extension::apply validation failed")
-}
-
-/// Fallibly apply an extension op in the traced graph.
-///
-/// This is the non-panicking variant of [`apply`]. It returns
-/// [`Error::InvalidGraphBuild`] when the extension receives the wrong number of
-/// inputs or when [`ExtensionOp::infer_output_meta`] returns metadata whose
-/// count does not match [`ExtensionOp::output_count`].
-///
-/// # Examples
-///
-/// ```rust
-/// # use std::any::Any;
-/// use std::sync::Arc;
-/// use tenferro_runtime::extension::{try_apply, ExtensionOpTrait};
-/// use tenferro_runtime::{DType, SymDim, Tensor, TracedTensor};
-///
-/// # #[derive(Clone, Debug)]
-/// # struct IdentityExt;
-/// # impl ExtensionOpTrait for IdentityExt {
-/// #     fn family_id(&self) -> &'static str { "example.identity.v1" }
-/// #     fn payload_hash(&self, _hasher: &mut dyn std::hash::Hasher) {}
-/// #     fn payload_eq(&self, other: &dyn ExtensionOpTrait) -> bool {
-/// #         other.as_any().downcast_ref::<IdentityExt>().is_some()
-/// #     }
-/// #     fn clone_arc(&self) -> Arc<dyn ExtensionOpTrait> { Arc::new(self.clone()) }
-/// #     fn as_any(&self) -> &dyn Any { self }
-/// #     fn input_count(&self) -> usize { 1 }
-/// #     fn output_count(&self) -> usize { 1 }
-/// #     fn infer_output_meta(
-/// #         &self,
-/// #         dtypes: &[DType],
-/// #         shapes: &[&[SymDim]],
-/// #     ) -> Vec<(DType, Vec<SymDim>)> {
-/// #         vec![(dtypes[0], shapes[0].to_vec())]
-/// #     }
-/// #     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-/// #         Ok(vec![inputs[0].clone()])
-/// #     }
-/// # }
-/// let op: Arc<dyn ExtensionOpTrait> = Arc::new(IdentityExt);
-/// let a = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-/// let outputs = try_apply(op, &[&a])?;
-/// assert_eq!(outputs.len(), 1);
-/// # Ok::<(), tenferro_runtime::Error>(())
-/// ```
-pub fn try_apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Result<Vec<TracedTensor>> {
+/// Returns [`Error::InvalidGraphBuild`] when the extension receives the wrong
+/// number of inputs or when [`ExtensionOp::infer_output_meta`] returns metadata
+/// whose count does not match [`ExtensionOp::output_count`].
+pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Result<Vec<TracedTensor>> {
     if inputs.len() != op.input_count() {
         return Err(Error::InvalidGraphBuild {
             op: "extension::apply",
@@ -236,12 +185,7 @@ pub fn try_apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Result<V
     let outputs = builder.add_operation(carrier, op_inputs, OperationRole::Primary);
     builder.set_outputs(outputs.clone());
     let graph = Arc::new(builder.build());
-    Ok(traced_outputs_from_graph(
-        inputs,
-        graph,
-        &outputs,
-        output_metas,
-    ))
+    traced_outputs_from_graph(inputs, graph, &outputs, output_metas)
 }
 
 /// Apply an extension-provided lowering as ordinary traced graph operations.
@@ -264,20 +208,18 @@ pub fn apply_expanded_graph(
         .collect();
     let outputs = build(&mut builder, &op_inputs)?;
     if outputs.len() != output_metas.len() {
-        return Err(Error::Internal(format!(
-            "extension expanded graph returned {} outputs for {} output metadata entries",
-            outputs.len(),
-            output_metas.len()
-        )));
+        return Err(Error::InvalidGraphBuild {
+            op: "extension::apply_expanded_graph",
+            message: format!(
+                "extension expanded graph returned {} outputs for {} output metadata entries",
+                outputs.len(),
+                output_metas.len()
+            ),
+        });
     }
     builder.set_outputs(outputs.clone());
     let graph = Arc::new(builder.build());
-    Ok(traced_outputs_from_graph(
-        inputs,
-        graph,
-        &outputs,
-        output_metas,
-    ))
+    traced_outputs_from_graph(inputs, graph, &outputs, output_metas)
 }
 
 fn traced_outputs_from_graph(
@@ -285,11 +227,11 @@ fn traced_outputs_from_graph(
     graph: Arc<computegraph::graph::Graph<StdTensorOp>>,
     outputs: &[usize],
     output_metas: Vec<(tenferro_tensor::DType, Vec<SymDim>)>,
-) -> Vec<TracedTensor> {
+) -> Result<Vec<TracedTensor>> {
     let metadata_scope = Arc::new(register_scoped_graph_metadata(
         graph.as_ref(),
         std::iter::empty(),
-    ));
+    )?);
 
     let mut merged_map = HashMap::new();
     let mut extra_roots = Vec::new();
@@ -307,7 +249,7 @@ fn traced_outputs_from_graph(
     let merged_map = Arc::new(merged_map);
 
     let all_inputs_concrete = inputs.iter().all(|t| t.shape_hint.is_some());
-    outputs
+    Ok(outputs
         .iter()
         .zip(output_metas)
         .map(|(&val, (dtype, shape))| {
@@ -330,7 +272,7 @@ fn traced_outputs_from_graph(
                 metadata_scopes: metadata_scopes.clone(),
             }
         })
-        .collect()
+        .collect())
 }
 
 #[cfg(test)]

--- a/crates/tenferro-runtime/src/extension/tests.rs
+++ b/crates/tenferro-runtime/src/extension/tests.rs
@@ -11,18 +11,18 @@ struct TestExtension {
     inferred_outputs: usize,
 }
 
-impl ExtensionOpTrait for TestExtension {
+impl ExtensionOp for TestExtension {
     fn family_id(&self) -> &'static str {
         "test.extension"
     }
 
     fn payload_hash(&self, _hasher: &mut dyn std::hash::Hasher) {}
 
-    fn payload_eq(&self, other: &dyn ExtensionOpTrait) -> bool {
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
         other.as_any().downcast_ref::<Self>().is_some()
     }
 
-    fn clone_arc(&self) -> Arc<dyn ExtensionOpTrait> {
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
         Arc::new(self.clone())
     }
 
@@ -54,15 +54,15 @@ impl ExtensionOpTrait for TestExtension {
 }
 
 #[test]
-fn try_apply_returns_error_for_input_count_mismatch() {
+fn apply_returns_error_for_input_count_mismatch() {
     let op = Arc::new(TestExtension {
         input_count: 2,
         output_count: 1,
         inferred_outputs: 1,
     });
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
 
-    let Err(err) = try_apply(op, &[&x]) else {
+    let Err(err) = apply(op, &[&x]) else {
         panic!("input count mismatch should be an error");
     };
 
@@ -72,15 +72,15 @@ fn try_apply_returns_error_for_input_count_mismatch() {
 }
 
 #[test]
-fn try_apply_returns_error_for_output_metadata_count_mismatch() {
+fn apply_returns_error_for_output_metadata_count_mismatch() {
     let op = Arc::new(TestExtension {
         input_count: 1,
         output_count: 2,
         inferred_outputs: 1,
     });
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
 
-    let Err(err) = try_apply(op, &[&x]) else {
+    let Err(err) = apply(op, &[&x]) else {
         panic!("output metadata mismatch should be an error");
     };
 
@@ -113,7 +113,7 @@ fn execute_lowered_program_with_backend_cache_rejects_nested_extension_ops() {
     };
     let mut backend = tenferro_cpu::CpuBackend::new();
     let mut backend_cache = Default::default();
-    let input = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]);
+    let input = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
 
     let err = execute_lowered_program_with_backend_cache(
         &mut backend,
@@ -130,8 +130,8 @@ fn execute_lowered_program_with_backend_cache_rejects_nested_extension_ops() {
 
 #[test]
 fn apply_expanded_graph_builds_standard_op_without_extension() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let y = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
 
     let outputs = apply_expanded_graph(
         &[&x, &y],
@@ -154,7 +154,7 @@ fn apply_expanded_graph_builds_standard_op_without_extension() {
 
 #[test]
 fn apply_expanded_graph_rejects_output_metadata_count_mismatch() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
 
     let result = apply_expanded_graph(&[&x], vec![], |builder, inputs| {
         Ok(builder.add_operation(StdTensorOp::Neg, inputs.to_vec(), OperationRole::Primary))

--- a/crates/tenferro-runtime/src/extension_runtime.rs
+++ b/crates/tenferro-runtime/src/extension_runtime.rs
@@ -144,50 +144,15 @@ pub trait ExtensionRuntime<B: TensorBackend + 'static>: Debug + Send + Sync + 's
 
     /// Execute the extension op on borrowed tensor reads.
     ///
-    /// Runtime implementations that can consume strided views should override
-    /// this method. The default fallback preserves compatibility with
-    /// tensor-only runtimes by materializing view reads at this explicit ABI
-    /// boundary before delegating to [`ExtensionRuntime::execute`].
+    /// Implementations that need compact tensors must materialize inputs here
+    /// explicitly. Keeping this method required prevents implicit read-path
+    /// fallbacks from hiding backend or view handling bugs.
     fn execute_reads(
         &self,
         op: &dyn ExtensionOp,
         inputs: &[TensorRead<'_>],
         ctx: &mut ExtensionExecutionContext<'_, B>,
-    ) -> tenferro_tensor::Result<Vec<Tensor>> {
-        let concrete_inputs = concrete_tensor_reads(inputs)?;
-        let input_refs: Vec<&Tensor> = concrete_inputs
-            .iter()
-            .map(ConcreteTensorRead::tensor)
-            .collect();
-        self.execute(op, &input_refs, ctx)
-    }
-}
-
-enum ConcreteTensorRead<'a> {
-    Borrowed(&'a Tensor),
-    Owned(Box<Tensor>),
-}
-
-impl ConcreteTensorRead<'_> {
-    fn tensor(&self) -> &Tensor {
-        match self {
-            Self::Borrowed(tensor) => tensor,
-            Self::Owned(tensor) => tensor.as_ref(),
-        }
-    }
-}
-
-fn concrete_tensor_reads<'a>(
-    inputs: &[TensorRead<'a>],
-) -> tenferro_tensor::Result<Vec<ConcreteTensorRead<'a>>> {
-    let mut concrete_inputs = Vec::with_capacity(inputs.len());
-    for input in inputs {
-        concrete_inputs.push(match input {
-            TensorRead::Tensor(tensor) => ConcreteTensorRead::Borrowed(tensor),
-            TensorRead::View(view) => ConcreteTensorRead::Owned(Box::new(view.try_to_tensor()?)),
-        });
-    }
-    Ok(concrete_inputs)
+    ) -> tenferro_tensor::Result<Vec<Tensor>>;
 }
 
 fn validate_runtime_output_count(
@@ -471,6 +436,20 @@ impl<B: TensorBackend + 'static> ExtensionExecutor<B> {
     ///         _ctx: &mut ExtensionExecutionContext<'_, CpuBackend>,
     ///     ) -> tenferro_tensor::Result<Vec<Tensor>> {
     ///         op.eager_execute(inputs)
+    ///     }
+    ///
+    ///     fn execute_reads(
+    ///         &self,
+    ///         op: &dyn ExtensionOp,
+    ///         inputs: &[TensorRead<'_>],
+    ///         ctx: &mut ExtensionExecutionContext<'_, CpuBackend>,
+    ///     ) -> tenferro_tensor::Result<Vec<Tensor>> {
+    ///         let materialized_inputs: Vec<Tensor> = inputs
+    ///             .iter()
+    ///             .map(TensorRead::to_tensor)
+    ///             .collect::<tenferro_tensor::Result<_>>()?;
+    ///         let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
+    ///         self.execute(op, &input_refs, ctx)
     ///     }
     /// }
     ///

--- a/crates/tenferro-runtime/src/extension_runtime/tests.rs
+++ b/crates/tenferro-runtime/src/extension_runtime/tests.rs
@@ -80,6 +80,8 @@ impl ExtensionOp for TestExtension {
     }
 
     fn eager_execute(&self, _inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![Tensor::from_vec_col_major(vec![], vec![1.0_f64])])
+        Ok(vec![
+            Tensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap()
+        ])
     }
 }

--- a/crates/tenferro-runtime/src/graph/compiler.rs
+++ b/crates/tenferro-runtime/src/graph/compiler.rs
@@ -559,7 +559,7 @@ fn default_tensors_equivalent(lhs: &Arc<Tensor>, rhs: &Arc<Tensor>) -> bool {
 
 fn default_slices_equivalent<T: TensorScalar + PartialEq>(lhs: &Tensor, rhs: &Tensor) -> bool {
     match (lhs.as_slice::<T>(), rhs.as_slice::<T>()) {
-        (Some(lhs), Some(rhs)) => lhs == rhs,
+        (Ok(lhs), Ok(rhs)) => lhs == rhs,
         // Backend-resident defaults cannot be inspected here; only the same
         // Arc<Tensor> is considered equivalent by `default_tensors_equivalent`.
         _ => false,
@@ -571,20 +571,33 @@ fn tangent_primal_root(key: &TensorInputKey) -> &TensorInputKey {
 }
 
 fn zeros_tensor(dtype: DType, shape: Vec<usize>) -> Tensor {
+    // Invariant: compiler default zeros are derived from already-validated tensor shapes.
     match dtype {
-        DType::F32 => Tensor::F32(tenferro_tensor::TypedTensor::zeros(shape)),
-        DType::F64 => Tensor::F64(tenferro_tensor::TypedTensor::zeros(shape)),
-        DType::I32 => Tensor::I32(tenferro_tensor::TypedTensor::zeros(shape)),
-        DType::I64 => Tensor::I64(tenferro_tensor::TypedTensor::zeros(shape)),
+        DType::F32 => Tensor::F32(
+            tenferro_tensor::TypedTensor::zeros(shape).expect("validated default tensor shape"),
+        ),
+        DType::F64 => Tensor::F64(
+            tenferro_tensor::TypedTensor::zeros(shape).expect("validated default tensor shape"),
+        ),
+        DType::I32 => Tensor::I32(
+            tenferro_tensor::TypedTensor::zeros(shape).expect("validated default tensor shape"),
+        ),
+        DType::I64 => Tensor::I64(
+            tenferro_tensor::TypedTensor::zeros(shape).expect("validated default tensor shape"),
+        ),
         DType::Bool => {
             let len = shape.iter().product();
-            Tensor::Bool(tenferro_tensor::TypedTensor::from_vec_col_major(
-                shape,
-                vec![false; len],
-            ))
+            Tensor::Bool(
+                tenferro_tensor::TypedTensor::from_vec_col_major(shape, vec![false; len])
+                    .expect("validated bool default tensor shape"),
+            )
         }
-        DType::C32 => Tensor::C32(tenferro_tensor::TypedTensor::zeros(shape)),
-        DType::C64 => Tensor::C64(tenferro_tensor::TypedTensor::zeros(shape)),
+        DType::C32 => Tensor::C32(
+            tenferro_tensor::TypedTensor::zeros(shape).expect("validated default tensor shape"),
+        ),
+        DType::C64 => Tensor::C64(
+            tenferro_tensor::TypedTensor::zeros(shape).expect("validated default tensor shape"),
+        ),
     }
 }
 
@@ -599,11 +612,11 @@ mod tests {
 
     #[test]
     fn compile_many_rejects_conflicting_default_inputs_for_same_key() {
-        let x = TracedTensor::from_vec_col_major(vec![1], vec![1.0_f64]);
+        let x = TracedTensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
         let y1 = x.neg();
         let mut y2 = x.neg();
         let key = x.input_key().expect("concrete traced tensor has input key");
-        let replacement = Arc::new(Tensor::from_vec_col_major(vec![1], vec![2.0_f64]));
+        let replacement = Arc::new(Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap());
         let mut inputs = (*y2.inputs_map).clone();
         inputs.insert(key.clone(), replacement);
         y2.inputs_map = Arc::new(inputs);
@@ -625,16 +638,22 @@ mod tests {
                 ordinal: 0,
             }),
         };
-        let lhs = Arc::new(Tensor::F64(TypedTensor::from_buffer_col_major(
-            vec![2],
-            Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(1, 2))),
-            placement.clone(),
-        )));
-        let rhs = Arc::new(Tensor::F64(TypedTensor::from_buffer_col_major(
-            vec![2],
-            Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(2, 2))),
-            placement,
-        )));
+        let lhs = Arc::new(Tensor::F64(
+            TypedTensor::from_buffer_col_major(
+                vec![2],
+                Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(1, 2))),
+                placement.clone(),
+            )
+            .unwrap(),
+        ));
+        let rhs = Arc::new(Tensor::F64(
+            TypedTensor::from_buffer_col_major(
+                vec![2],
+                Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(2, 2))),
+                placement,
+            )
+            .unwrap(),
+        ));
 
         assert!(
             !default_tensors_equivalent(&lhs, &rhs),

--- a/crates/tenferro-runtime/src/graph/executor.rs
+++ b/crates/tenferro-runtime/src/graph/executor.rs
@@ -1153,17 +1153,33 @@ fn tangent_primal_root(key: &TensorInputKey) -> &TensorInputKey {
 }
 
 fn zeros_tensor(dtype: DType, shape: Vec<usize>) -> Tensor {
+    // Invariant: executor deferred zeros are derived from already-validated tensor shapes.
     match dtype {
-        DType::F32 => Tensor::F32(TypedTensor::zeros(shape)),
-        DType::F64 => Tensor::F64(TypedTensor::zeros(shape)),
-        DType::I32 => Tensor::I32(TypedTensor::zeros(shape)),
-        DType::I64 => Tensor::I64(TypedTensor::zeros(shape)),
+        DType::F32 => {
+            Tensor::F32(TypedTensor::zeros(shape).expect("validated default tensor shape"))
+        }
+        DType::F64 => {
+            Tensor::F64(TypedTensor::zeros(shape).expect("validated default tensor shape"))
+        }
+        DType::I32 => {
+            Tensor::I32(TypedTensor::zeros(shape).expect("validated default tensor shape"))
+        }
+        DType::I64 => {
+            Tensor::I64(TypedTensor::zeros(shape).expect("validated default tensor shape"))
+        }
         DType::Bool => {
             let len = shape.iter().product();
-            Tensor::Bool(TypedTensor::from_vec_col_major(shape, vec![false; len]))
+            Tensor::Bool(
+                TypedTensor::from_vec_col_major(shape, vec![false; len])
+                    .expect("validated bool default tensor shape"),
+            )
         }
-        DType::C32 => Tensor::C32(TypedTensor::zeros(shape)),
-        DType::C64 => Tensor::C64(TypedTensor::zeros(shape)),
+        DType::C32 => {
+            Tensor::C32(TypedTensor::zeros(shape).expect("validated default tensor shape"))
+        }
+        DType::C64 => {
+            Tensor::C64(TypedTensor::zeros(shape).expect("validated default tensor shape"))
+        }
     }
 }
 

--- a/crates/tenferro-runtime/src/graph/executor/tests.rs
+++ b/crates/tenferro-runtime/src/graph/executor/tests.rs
@@ -7,15 +7,13 @@ use crate::{Error, GraphCompiler, TracedTensor};
 #[test]
 fn borrowed_input_execution_retains_executor_slot_workspace_capacity() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = &x + &x;
+    let y = (&x + &x).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&y, &[(&x, DType::F64, &[4])])
         .unwrap();
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![4],
-        vec![1.0, 2.0, 3.0, 4.0],
-    ));
+    let input =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![4], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
     let mut executor = GraphExecutor::new(CpuBackend::new());
 
     assert_eq!(executor.borrowed_slot_workspace_capacity, 0);
@@ -37,15 +35,13 @@ fn borrowed_input_execution_retains_executor_slot_workspace_capacity() {
 #[test]
 fn borrowed_input_value_execution_retains_workspace_and_lazy_output() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 2);
-    let y = x.transpose(&[1, 0]);
+    let y = x.transpose(&[1, 0]).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&y, &[(&x, DType::F64, &[2, 2])])
         .unwrap();
-    let input = Tensor::F64(TypedTensor::from_vec_col_major(
-        vec![2, 2],
-        vec![1.0, 2.0, 3.0, 4.0],
-    ));
+    let input =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
     let mut executor = GraphExecutor::new(CpuBackend::new());
 
     let outputs = executor
@@ -79,7 +75,7 @@ fn borrowed_input_workspace_does_not_retype_static_slot_vec() {
 #[test]
 fn compile_with_input_specs_rejects_computed_placeholder_specs() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = &x + &x;
+    let y = (&x + &x).unwrap();
     let mut compiler = GraphCompiler::new();
 
     let err = compiler

--- a/crates/tenferro-runtime/src/graph/lowering_view.rs
+++ b/crates/tenferro-runtime/src/graph/lowering_view.rs
@@ -276,7 +276,14 @@ impl<'a> GraphInstructionView<'a> {
         let mut shape = Vec::with_capacity(extents.len());
         for (axis, extent) in extents.iter().enumerate() {
             match extent {
-                ShapeExtent::Exact(dim) => shape.push(dim.eval(input_shapes)),
+                ShapeExtent::Exact(dim) => shape.push(dim.eval(input_shapes).map_err(|err| {
+                    GraphProgramLoweringShapeError::InvalidDimExpr {
+                        op: self.op_name(),
+                        output_index,
+                        axis,
+                        source: err,
+                    }
+                })?),
                 ShapeExtent::UpperBound(_) => {
                     return Err(GraphProgramLoweringShapeError::NonStatic {
                         op: self.op_name(),
@@ -438,6 +445,16 @@ pub enum GraphProgramLoweringShapeError {
         output_index: usize,
         axis: usize,
         kind: &'static str,
+    },
+    /// Static shape evaluation failed for an exact dimension expression.
+    #[error(
+        "ExecOp::{op} output {output_index} axis {axis} has invalid dimension expression: {source}"
+    )]
+    InvalidDimExpr {
+        op: &'static str,
+        output_index: usize,
+        axis: usize,
+        source: tenferro_ops::dim_expr::DimExprEvalError,
     },
 }
 

--- a/crates/tenferro-runtime/src/metadata.rs
+++ b/crates/tenferro-runtime/src/metadata.rs
@@ -4,8 +4,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tenferro_ops::ad::context::{
-    try_lookup_global_metadata, try_register_scoped_global_metadata_batch, GlobalMetadataScope,
-    TensorMeta,
+    lookup_global_metadata, register_scoped_global_metadata_batch, GlobalMetadataScope, TensorMeta,
 };
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -15,8 +14,6 @@ use tenferro_tensor::Tensor;
 
 use crate::shape_infer::{infer_extension_output_meta, infer_output_dtype, infer_output_extents};
 use crate::{Error, Result};
-
-pub type MetadataScope = GlobalMetadataScope;
 
 pub(crate) fn tensor_meta(dtype: DType, shape: Vec<SymDim>) -> TensorMeta {
     TensorMeta::exact(dtype, shape)
@@ -42,43 +39,19 @@ pub fn tensor_meta_from_tensor(tensor: &Tensor) -> TensorMeta {
 pub fn register_scoped_value_metadata(
     key: ValueKey<StdTensorOp>,
     meta: TensorMeta,
-) -> MetadataScope {
-    // Compatibility wrapper for infallible constructors; new runtime paths
-    // should call `try_register_scoped_value_metadata` and propagate errors.
-    try_register_scoped_value_metadata(key, meta).unwrap_or_else(|err| panic!("{err}"))
-}
-
-pub fn try_register_scoped_value_metadata(
-    key: ValueKey<StdTensorOp>,
-    meta: TensorMeta,
-) -> Result<MetadataScope> {
-    try_register_scoped_global_metadata_batch([(key, meta)])
+) -> Result<GlobalMetadataScope> {
+    register_scoped_global_metadata_batch([(key, meta)])
         .map_err(|err| metadata_error(err.to_string()))
 }
 
 pub fn register_scoped_metadata_batch(
     entries: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
-) -> MetadataScope {
-    // Compatibility wrapper for infallible constructors; new runtime paths
-    // should call `try_register_scoped_metadata_batch` and propagate errors.
-    try_register_scoped_metadata_batch(entries).unwrap_or_else(|err| panic!("{err}"))
+) -> Result<GlobalMetadataScope> {
+    register_scoped_global_metadata_batch(entries).map_err(|err| metadata_error(err.to_string()))
 }
 
-pub fn try_register_scoped_metadata_batch(
-    entries: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
-) -> Result<MetadataScope> {
-    try_register_scoped_global_metadata_batch(entries)
-        .map_err(|err| metadata_error(err.to_string()))
-}
-
-pub fn registered_meta(key: &ValueKey<StdTensorOp>) -> TensorMeta {
-    // Compatibility wrapper for legacy callers that require a value; use
-    // `try_registered_meta` on any path where metadata absence is recoverable.
-    try_registered_meta(key).unwrap_or_else(|err| panic!("{err}"))
-}
-
-pub fn try_registered_meta(key: &ValueKey<StdTensorOp>) -> Result<TensorMeta> {
-    try_lookup_global_metadata(key)
+pub fn registered_meta(key: &ValueKey<StdTensorOp>) -> Result<TensorMeta> {
+    lookup_global_metadata(key)
         .map_err(|err| metadata_error(err.to_string()))?
         .ok_or_else(|| metadata_error(format!("missing registered metadata for {:?}", key)))
 }
@@ -86,17 +59,8 @@ pub fn try_registered_meta(key: &ValueKey<StdTensorOp>) -> Result<TensorMeta> {
 pub fn register_scoped_graph_metadata(
     graph: &Graph<StdTensorOp>,
     seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
-) -> MetadataScope {
-    // Compatibility wrapper for constructors that cannot return `Result`; new
-    // graph-building paths should call `try_register_scoped_graph_metadata`.
-    try_register_scoped_graph_metadata(graph, seeded).unwrap_or_else(|err| panic!("{err}"))
-}
-
-pub fn try_register_scoped_graph_metadata(
-    graph: &Graph<StdTensorOp>,
-    seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
-) -> Result<MetadataScope> {
-    try_register_scoped_global_metadata_batch(graph_metadata_registrations(graph, None, seeded)?)
+) -> Result<GlobalMetadataScope> {
+    register_scoped_global_metadata_batch(graph_metadata_registrations(graph, None, seeded)?)
         .map_err(|err| metadata_error(err.to_string()))
 }
 
@@ -104,19 +68,8 @@ pub fn register_scoped_live_graph_metadata(
     graph: &Graph<StdTensorOp>,
     live_values: &HashSet<LocalValueId>,
     seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
-) -> MetadataScope {
-    // Compatibility wrapper for constructors that cannot return `Result`; new
-    // graph-building paths should call `try_register_scoped_live_graph_metadata`.
-    try_register_scoped_live_graph_metadata(graph, live_values, seeded)
-        .unwrap_or_else(|err| panic!("{err}"))
-}
-
-pub fn try_register_scoped_live_graph_metadata(
-    graph: &Graph<StdTensorOp>,
-    live_values: &HashSet<LocalValueId>,
-    seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
-) -> Result<MetadataScope> {
-    try_register_scoped_global_metadata_batch(graph_metadata_registrations(
+) -> Result<GlobalMetadataScope> {
+    register_scoped_global_metadata_batch(graph_metadata_registrations(
         graph,
         Some(live_values),
         seeded,
@@ -125,21 +78,21 @@ pub fn try_register_scoped_live_graph_metadata(
 }
 
 pub fn metadata_scopes_with_new<'a>(
-    scope: MetadataScope,
-    inherited: impl IntoIterator<Item = &'a [Arc<MetadataScope>]>,
-) -> Vec<Arc<MetadataScope>> {
+    scope: GlobalMetadataScope,
+    inherited: impl IntoIterator<Item = &'a [Arc<GlobalMetadataScope>]>,
+) -> Vec<Arc<GlobalMetadataScope>> {
     let scope = Arc::new(scope);
     metadata_scopes_with_scope(scope, inherited)
 }
 
-pub fn metadata_scopes_for_scope(scope: MetadataScope) -> Vec<Arc<MetadataScope>> {
+pub fn metadata_scopes_for_scope(scope: GlobalMetadataScope) -> Vec<Arc<GlobalMetadataScope>> {
     vec![Arc::new(scope)]
 }
 
 pub fn metadata_scopes_with_scope<'a>(
-    scope: Arc<MetadataScope>,
-    inherited: impl IntoIterator<Item = &'a [Arc<MetadataScope>]>,
-) -> Vec<Arc<MetadataScope>> {
+    scope: Arc<GlobalMetadataScope>,
+    inherited: impl IntoIterator<Item = &'a [Arc<GlobalMetadataScope>]>,
+) -> Vec<Arc<GlobalMetadataScope>> {
     let mut scopes = Vec::new();
     let mut seen = HashSet::new();
     push_metadata_scope_seen(&mut scopes, &mut seen, scope);
@@ -147,16 +100,19 @@ pub fn metadata_scopes_with_scope<'a>(
     scopes
 }
 
-pub fn push_metadata_scope(scopes: &mut Vec<Arc<MetadataScope>>, scope: Arc<MetadataScope>) {
+pub fn push_metadata_scope(
+    scopes: &mut Vec<Arc<GlobalMetadataScope>>,
+    scope: Arc<GlobalMetadataScope>,
+) {
     if scopes.iter().all(|existing| !Arc::ptr_eq(existing, &scope)) {
         scopes.push(scope);
     }
 }
 
 fn push_metadata_scope_seen(
-    scopes: &mut Vec<Arc<MetadataScope>>,
-    seen: &mut HashSet<*const MetadataScope>,
-    scope: Arc<MetadataScope>,
+    scopes: &mut Vec<Arc<GlobalMetadataScope>>,
+    seen: &mut HashSet<*const GlobalMetadataScope>,
+    scope: Arc<GlobalMetadataScope>,
 ) {
     if seen.insert(Arc::as_ptr(&scope)) {
         scopes.push(scope);
@@ -164,9 +120,9 @@ fn push_metadata_scope_seen(
 }
 
 fn extend_metadata_scopes<'a>(
-    scopes: &mut Vec<Arc<MetadataScope>>,
-    seen: &mut HashSet<*const MetadataScope>,
-    inherited: impl IntoIterator<Item = &'a [Arc<MetadataScope>]>,
+    scopes: &mut Vec<Arc<GlobalMetadataScope>>,
+    seen: &mut HashSet<*const GlobalMetadataScope>,
+    inherited: impl IntoIterator<Item = &'a [Arc<GlobalMetadataScope>]>,
 ) {
     for source in inherited {
         for scope in source {
@@ -212,7 +168,7 @@ fn graph_metadata_registrations(
                 if let Some(meta) = known.get(key).cloned() {
                     return Ok(meta);
                 }
-                try_lookup_global_metadata(key)
+                lookup_global_metadata(key)
                     .map_err(|err| metadata_error(err.to_string()))?
                     .ok_or_else(|| metadata_error(format!("missing input metadata for {:?}", key)))
             })
@@ -233,17 +189,15 @@ fn infer_output_metas(op: &StdTensorOp, input_metas: &[TensorMeta]) -> Result<Ve
     let input_shape_exprs: Vec<Vec<DimExpr>> = input_metas
         .iter()
         .enumerate()
-        .map(|(input_idx, meta)| DimExpr::input_shape(input_idx, meta.shape.len()))
+        .map(|(input_idx, meta)| DimExpr::input_shape(input_idx, meta.rank()))
         .collect();
     let input_shape_refs: Vec<&[DimExpr]> = input_shape_exprs.iter().map(Vec::as_slice).collect();
     let input_dtypes: Vec<DType> = input_metas.iter().map(|meta| meta.dtype).collect();
+    let resolved_inputs = resolved_bound_shapes(input_metas)?;
+    let resolved_input_refs: Vec<&[SymDim]> = resolved_inputs.iter().map(Vec::as_slice).collect();
 
     if let StdTensorOp::Extension(ext) = op {
         let metas = infer_extension_output_meta(ext.as_ref(), &input_dtypes, &input_shape_refs)?;
-        let resolved_inputs: Vec<&[SymDim]> = input_metas
-            .iter()
-            .map(|meta| meta.shape.as_slice())
-            .collect();
         return Ok(metas
             .into_iter()
             .map(|(dtype, shape)| {
@@ -251,28 +205,37 @@ fn infer_output_metas(op: &StdTensorOp, input_metas: &[TensorMeta]) -> Result<Ve
                     dtype,
                     shape
                         .iter()
-                        .map(|dim| SymDim::from_dim_expr(dim, &resolved_inputs))
+                        .map(|dim| SymDim::from_dim_expr(dim, &resolved_input_refs))
                         .collect(),
                 )
             })
             .collect());
     }
 
-    let output_dtype = infer_output_dtype(op, &input_dtypes);
+    let output_dtype = infer_output_dtype(op, &input_dtypes)?;
     Ok(infer_output_extents(op, &input_shape_refs)?
         .into_iter()
         .map(|extents| {
-            let resolved_inputs: Vec<&[SymDim]> = input_metas
-                .iter()
-                .map(|meta| meta.shape.as_slice())
-                .collect();
             let resolved_extents = extents
                 .into_iter()
-                .map(|extent| extent.map(|dim| SymDim::from_dim_expr(&dim, &resolved_inputs)))
+                .map(|extent| extent.map(|dim| SymDim::from_dim_expr(&dim, &resolved_input_refs)))
                 .collect();
             TensorMeta::with_extents(output_dtype, resolved_extents)
         })
         .collect())
+}
+
+fn resolved_bound_shapes(input_metas: &[TensorMeta]) -> Result<Vec<Vec<SymDim>>> {
+    input_metas
+        .iter()
+        .map(|meta| {
+            meta.bound_shape().ok_or_else(|| {
+                metadata_error(
+                    "metadata contains an unknown shape extent; cannot resolve output metadata",
+                )
+            })
+        })
+        .collect()
 }
 
 fn metadata_error(message: impl Into<String>) -> Error {

--- a/crates/tenferro-runtime/src/scalar_semantics.rs
+++ b/crates/tenferro-runtime/src/scalar_semantics.rs
@@ -29,9 +29,9 @@ fn scalar_size_value(size_tensor: &Tensor) -> Result<f64> {
     }
 
     match size_tensor {
-        Tensor::F64(inner) => Ok(inner.host_data()[0]),
-        Tensor::F32(inner) => Ok(inner.host_data()[0] as f64),
-        Tensor::I64(inner) => Ok(inner.host_data()[0] as f64),
+        Tensor::F64(inner) => Ok(inner.host_data()?[0]),
+        Tensor::F32(inner) => Ok(inner.host_data()?[0] as f64),
+        Tensor::I64(inner) => Ok(inner.host_data()?[0] as f64),
         _ => Err(Error::Internal(
             "DynamicTruncate size must be an f32, f64, or i64 scalar".into(),
         )),

--- a/crates/tenferro-runtime/src/segment/tests.rs
+++ b/crates/tenferro-runtime/src/segment/tests.rs
@@ -141,10 +141,10 @@ fn segmented_eval_executes_single_broadcast_multiply_pairs() {
     };
     let mut backend = CpuBackend::new();
     let inputs = vec![
-        Tensor::from_vec_col_major(vec![2], vec![10.0_f64, 20.0]),
-        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
-        Tensor::from_vec_col_major(vec![2], vec![5.0_f64, 7.0]),
-        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]),
+        Tensor::from_vec_col_major(vec![2], vec![10.0_f64, 20.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![2], vec![5.0_f64, 7.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
     ];
 
     let outputs = eval_exec_segmented(&mut backend, &program, inputs).unwrap();
@@ -168,7 +168,7 @@ fn segmented_eval_executes_reused_broadcast_multiply_pair() {
         n_slots: 3,
     };
     let mut backend = CpuBackend::new();
-    let inputs = vec![Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0])];
+    let inputs = vec![Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap()];
 
     let outputs = eval_exec_segmented(&mut backend, &program, inputs).unwrap();
 

--- a/crates/tenferro-runtime/src/shape_infer.rs
+++ b/crates/tenferro-runtime/src/shape_infer.rs
@@ -96,19 +96,22 @@ pub fn promote_dtype_div_like(lhs: DType, rhs: DType) -> DType {
 
 /// Infer output dtype for a single instruction given its op and input dtypes.
 ///
-/// Panics if the input dtypes are inconsistent for the op (shouldn't happen
-/// in well-formed SSA programs). For `StdTensorOp::Extension`, prefer the
-/// combined `infer_extension_output_meta` helper — this function only
-/// returns the first output's dtype, which is sufficient for single-output
-/// extensions but loses information for multi-output ones.
-pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> DType {
-    match op {
+/// For `StdTensorOp::Extension`, prefer the combined
+/// [`infer_extension_output_meta`] helper when shape metadata is also needed.
+/// This function returns only the first output's dtype.
+pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> Result<DType> {
+    let dtype = match op {
         StdTensorOp::Constant { dtype, .. } => *dtype,
         StdTensorOp::Convert { to, .. } => *to,
-        StdTensorOp::Extension(ext) => extension_first_output_dtype(ext.as_ref(), input_dtypes),
+        StdTensorOp::Extension(ext) => {
+            return extension_first_output_dtype(ext.as_ref(), input_dtypes)
+        }
         StdTensorOp::Compare(_) => DType::Bool,
-        StdTensorOp::Abs => real_dtype_for_abs(input_dtypes[0]),
-        StdTensorOp::Select => promote_dtype(input_dtypes[1], input_dtypes[2]),
+        StdTensorOp::Abs => real_dtype_for_abs(dtype_input(op, input_dtypes, 0)?),
+        StdTensorOp::Select => promote_dtype(
+            dtype_input(op, input_dtypes, 1)?,
+            dtype_input(op, input_dtypes, 2)?,
+        ),
         StdTensorOp::Clamp => promote_dtypes(input_dtypes.iter().copied()),
         // Binary / ternary / N-ary ops — promote input dtypes.
         StdTensorOp::Add
@@ -118,12 +121,22 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> DType {
         | StdTensorOp::DotGeneral { .. }
         | StdTensorOp::Concatenate { .. }
         | StdTensorOp::PadToMatch { .. }
-        | StdTensorOp::DynamicTruncate { .. } => promote_dtype(input_dtypes[0], input_dtypes[1]),
-        StdTensorOp::Div | StdTensorOp::Pow => {
-            promote_dtype_div_like(input_dtypes[0], input_dtypes[1])
-        }
-        StdTensorOp::Scatter(_) => promote_dtype(input_dtypes[0], input_dtypes[2]),
-        StdTensorOp::DynamicUpdateSlice => promote_dtype(input_dtypes[0], input_dtypes[1]),
+        | StdTensorOp::DynamicTruncate { .. } => promote_dtype(
+            dtype_input(op, input_dtypes, 0)?,
+            dtype_input(op, input_dtypes, 1)?,
+        ),
+        StdTensorOp::Div | StdTensorOp::Pow => promote_dtype_div_like(
+            dtype_input(op, input_dtypes, 0)?,
+            dtype_input(op, input_dtypes, 1)?,
+        ),
+        StdTensorOp::Scatter(_) => promote_dtype(
+            dtype_input(op, input_dtypes, 0)?,
+            dtype_input(op, input_dtypes, 2)?,
+        ),
+        StdTensorOp::DynamicUpdateSlice => promote_dtype(
+            dtype_input(op, input_dtypes, 0)?,
+            dtype_input(op, input_dtypes, 1)?,
+        ),
         // Unary / structural — output dtype equals input dtype.
         StdTensorOp::Neg
         | StdTensorOp::Conj
@@ -153,9 +166,19 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> DType {
         | StdTensorOp::DynamicSlice { .. }
         | StdTensorOp::Slice(_)
         | StdTensorOp::Pad(_)
-        | StdTensorOp::Reverse { .. } => input_dtypes[0],
+        | StdTensorOp::Reverse { .. } => dtype_input(op, input_dtypes, 0)?,
         StdTensorOp::ShapeOf { .. } => DType::F64,
-    }
+    };
+    Ok(dtype)
+}
+
+fn dtype_input(op: &StdTensorOp, input_dtypes: &[DType], index: usize) -> Result<DType> {
+    input_dtypes.get(index).copied().ok_or_else(|| {
+        shape_infer_error(format!(
+            "{op:?} missing input dtype at index {index}; got {} input dtypes",
+            input_dtypes.len()
+        ))
+    })
 }
 
 fn real_dtype_for_abs(dtype: DType) -> DType {
@@ -304,7 +327,7 @@ pub fn infer_output_shapes(
 ///
 /// Most existing shape rules produce exact dimensions. Runtime-sized operators
 /// can instead report a known upper bound so metadata consumers do not treat a
-/// compatibility shape as proof of exactness.
+/// bound expression as proof of exactness.
 ///
 pub fn infer_output_extents(
     op: &StdTensorOp,
@@ -402,7 +425,7 @@ fn dim_expr_to_sym_dim(expr: &DimExpr, input_idx: usize, axis: usize) -> SymDim 
     }
 }
 
-fn extension_first_output_dtype(op: &dyn ExtensionOp, input_dtypes: &[DType]) -> DType {
+fn extension_first_output_dtype(op: &dyn ExtensionOp, input_dtypes: &[DType]) -> Result<DType> {
     // For dtype-only queries we synthesise a rank-0 shape list per input so
     // the extension's `infer_output_meta` stays total even when shapes are
     // unknown to the caller. Extensions whose dtype depends on shape must
@@ -411,13 +434,13 @@ fn extension_first_output_dtype(op: &dyn ExtensionOp, input_dtypes: &[DType]) ->
     let empty_rows: Vec<&[SymDim]> = (0..op.input_count()).map(|_| [].as_slice()).collect();
     let metas = op.infer_output_meta(input_dtypes, &empty_rows);
     if metas.is_empty() {
-        panic!(
+        return Err(shape_infer_error(format!(
             "ExtensionOp::infer_output_meta for family {:?} returned an \
              empty meta list; expected at least one output",
             op.family_id()
-        );
+        )));
     }
-    metas[0].0
+    Ok(metas[0].0)
 }
 
 fn require_input<'a>(

--- a/crates/tenferro-runtime/src/shape_packing.rs
+++ b/crates/tenferro-runtime/src/shape_packing.rs
@@ -82,7 +82,7 @@ fn index_select_config(
     let indices = Tensor::I64(TypedTensor::from_vec_col_major(
         vec![positions.len(), 1],
         index_data,
-    ));
+    )?);
 
     let config = GatherConfig {
         offset_dims,
@@ -253,7 +253,9 @@ fn apply_nary_concatenate(
             out_dtype,
             out_shape.iter().copied().map(SymDim::from).collect(),
         ),
-    );
+    )
+    // Stack builds a fresh graph output after validating all concrete shapes.
+    .expect("fresh stack output metadata registration failed");
 
     let mut inputs_map = HashMap::new();
     let mut extra_roots = Vec::new();

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -7,6 +7,7 @@ use computegraph::graph::{Graph, GraphBuilder};
 use computegraph::types::{OperationRole, ValueKey, ValueRef};
 use computegraph::LocalValueId;
 use num_complex::{Complex32, Complex64};
+use tenferro_ops::ad::context::GlobalMetadataScope;
 use tenferro_ops::broadcast::{broadcast_input_plan, broadcast_shape, broadcast_shapes};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::input_key::TensorInputKey;
@@ -19,7 +20,7 @@ use crate::checkpoint::CheckpointNode;
 use crate::metadata::{
     concrete_tensor_meta, metadata_scopes_for_scope, metadata_scopes_with_new, push_metadata_scope,
     register_scoped_graph_metadata, register_scoped_value_metadata, symbolic_input_meta,
-    tensor_meta, MetadataScope,
+    tensor_meta,
 };
 use crate::scalar_semantics::round_real_to_i64;
 
@@ -50,7 +51,7 @@ pub struct TracedTensor {
     pub(crate) inputs_map: Arc<HashMap<TensorInputKey, Arc<Tensor>>>,
     pub(crate) extra_roots: Vec<Arc<Graph<StdTensorOp>>>,
     pub(crate) checkpoint_chain: Option<Arc<CheckpointNode>>,
-    pub(crate) metadata_scopes: Vec<Arc<MetadataScope>>,
+    pub(crate) metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
 }
 
 impl fmt::Debug for TracedTensor {
@@ -75,16 +76,21 @@ pub(crate) fn try_concrete_shape(tensor: &TracedTensor) -> Option<Vec<usize>> {
         .collect()
 }
 
-pub(crate) fn concrete_shape(tensor: &TracedTensor) -> Vec<usize> {
+pub(crate) fn concrete_shape(tensor: &TracedTensor) -> Result<Vec<usize>> {
     tensor
         .shape_hint
         .as_ref()
-        .unwrap_or_else(|| panic!("missing shape hint for traced tensor {}", tensor.id))
+        .ok_or_else(|| Error::InvalidGraphBuild {
+            op: "TracedTensor::concrete_shape",
+            message: format!("missing shape hint for traced tensor {}", tensor.id),
+        })?
         .iter()
         .map(|dim| {
-            dim.constant_value().unwrap_or_else(|| {
-                panic!("symbolic dimension in shape hint for tensor {}", tensor.id)
-            })
+            dim.constant_value()
+                .ok_or_else(|| Error::InvalidGraphBuild {
+                    op: "TracedTensor::concrete_shape",
+                    message: format!("symbolic dimension in shape hint for tensor {}", tensor.id),
+                })
         })
         .collect()
 }
@@ -93,67 +99,73 @@ pub(crate) fn concrete_shape(tensor: &TracedTensor) -> Vec<usize> {
 ///
 /// Expanding singleton axes are first reshaped away so the existing
 /// `BroadcastInDim` transpose rule reduces them correctly during VJP.
-pub(crate) fn broadcast_to(tensor: &TracedTensor, target_shape: &[usize]) -> TracedTensor {
-    let tensor_shape = concrete_shape(tensor);
+pub(crate) fn broadcast_to(tensor: &TracedTensor, target_shape: &[usize]) -> Result<TracedTensor> {
+    let tensor_shape = concrete_shape(tensor)?;
     if tensor_shape == target_shape {
-        return tensor.clone();
+        return Ok(tensor.clone());
     }
 
-    let plan =
-        broadcast_input_plan(&tensor_shape, target_shape).unwrap_or_else(|err| panic!("{err}"));
+    let plan = broadcast_input_plan(&tensor_shape, target_shape).map_err(|err| {
+        Error::InvalidGraphBuild {
+            op: "broadcast_to",
+            message: err.to_string(),
+        }
+    })?;
 
     let source = if plan.source_shape == tensor_shape {
         tensor.clone()
     } else {
         tensor.reshape(&plan.source_shape)
     };
-    source.broadcast_in_dim(target_shape, &plan.dims)
+    Ok(source.broadcast_in_dim(target_shape, &plan.dims))
 }
 
 /// Broadcast two tensors to a common shape.
-pub(crate) fn broadcast_binary(a: &TracedTensor, b: &TracedTensor) -> (TracedTensor, TracedTensor) {
+pub(crate) fn broadcast_binary(
+    a: &TracedTensor,
+    b: &TracedTensor,
+) -> Result<(TracedTensor, TracedTensor)> {
     if a.shape_hint == b.shape_hint && a.rank == b.rank {
-        return (a.clone(), b.clone());
+        return Ok((a.clone(), b.clone()));
     }
     if (try_concrete_shape(a).is_none() || try_concrete_shape(b).is_none()) && a.rank == b.rank {
-        return (a.clone(), b.clone());
+        return Ok((a.clone(), b.clone()));
     }
-    let a_shape = concrete_shape(a);
-    let b_shape = concrete_shape(b);
-    let target = broadcast_shape(&a_shape, &b_shape).unwrap_or_else(|_| {
-        panic!(
-            "incompatible shapes for broadcast: {:?} and {:?}",
-            a_shape, b_shape
-        )
-    });
-    (broadcast_to(a, &target), broadcast_to(b, &target))
+    let a_shape = concrete_shape(a)?;
+    let b_shape = concrete_shape(b)?;
+    let target = broadcast_shape(&a_shape, &b_shape).map_err(|err| Error::InvalidGraphBuild {
+        op: "broadcast_binary",
+        message: err.to_string(),
+    })?;
+    Ok((broadcast_to(a, &target)?, broadcast_to(b, &target)?))
 }
 
 pub(crate) fn broadcast_ternary(
     a: &TracedTensor,
     b: &TracedTensor,
     c: &TracedTensor,
-) -> (TracedTensor, TracedTensor, TracedTensor) {
-    let a_shape = concrete_shape(a);
-    let b_shape = concrete_shape(b);
-    let c_shape = concrete_shape(c);
+) -> Result<(TracedTensor, TracedTensor, TracedTensor)> {
+    let a_shape = concrete_shape(a)?;
+    let b_shape = concrete_shape(b)?;
+    let c_shape = concrete_shape(c)?;
     let target = broadcast_shapes([a_shape.as_slice(), b_shape.as_slice(), c_shape.as_slice()])
-        .unwrap_or_else(|err| panic!("{err}"));
-    (
-        broadcast_to(a, &target),
-        broadcast_to(b, &target),
-        broadcast_to(c, &target),
-    )
+        .map_err(|err| Error::InvalidGraphBuild {
+            op: "broadcast_ternary",
+            message: err.to_string(),
+        })?;
+    Ok((
+        broadcast_to(a, &target)?,
+        broadcast_to(b, &target)?,
+        broadcast_to(c, &target)?,
+    ))
 }
 
 fn scale_with_constant(input: &TracedTensor, op: StdTensorOp) -> TracedTensor {
     let scalar = apply_nullary(op, 0, input.dtype, Some(vec![]));
-    let input_shape = concrete_shape(input);
-    let factor = broadcast_to(&scalar, &input_shape);
     apply_binary(
         StdTensorOp::Mul,
         input,
-        &factor,
+        &scalar,
         input.rank,
         input.shape_hint.clone(),
     )
@@ -200,18 +212,57 @@ fn validate_traced_axis(tensor: &TracedTensor, axis: usize, op: &'static str) ->
     Ok(())
 }
 
-impl std::ops::Add for &TracedTensor {
-    type Output = TracedTensor;
+fn validate_traced_insert_axis(rank: usize, axis: usize, op: &'static str) -> Result<()> {
+    if axis > rank {
+        return Err(Error::InvalidGraphBuild {
+            op,
+            message: format!("axis {axis} out of bounds for rank {rank} insertion"),
+        });
+    }
+    Ok(())
+}
 
-    fn add(self, rhs: &TracedTensor) -> TracedTensor {
+fn validate_traced_perm(rank: usize, perm: &[usize], op: &'static str) -> Result<()> {
+    if perm.len() != rank {
+        return Err(Error::InvalidGraphBuild {
+            op,
+            message: format!(
+                "permutation length {} does not match rank {rank}",
+                perm.len()
+            ),
+        });
+    }
+    let mut seen = vec![false; rank];
+    for &axis in perm {
+        if axis >= rank {
+            return Err(Error::InvalidGraphBuild {
+                op,
+                message: format!("permutation axis {axis} out of bounds for rank {rank}"),
+            });
+        }
+        if seen[axis] {
+            return Err(Error::InvalidGraphBuild {
+                op,
+                message: format!("duplicate permutation axis {axis}"),
+            });
+        }
+        seen[axis] = true;
+    }
+    Ok(())
+}
+
+impl std::ops::Add for &TracedTensor {
+    type Output = Result<TracedTensor>;
+
+    fn add(self, rhs: &TracedTensor) -> Result<TracedTensor> {
         TracedTensor::add(self, rhs)
     }
 }
 
 impl std::ops::Mul for &TracedTensor {
-    type Output = TracedTensor;
+    type Output = Result<TracedTensor>;
 
-    fn mul(self, rhs: &TracedTensor) -> TracedTensor {
+    fn mul(self, rhs: &TracedTensor) -> Result<TracedTensor> {
         TracedTensor::mul(self, rhs)
     }
 }
@@ -241,9 +292,9 @@ impl std::ops::Neg for &TracedTensor {
 }
 
 impl std::ops::Div for &TracedTensor {
-    type Output = TracedTensor;
+    type Output = Result<TracedTensor>;
 
-    fn div(self, rhs: &TracedTensor) -> TracedTensor {
+    fn div(self, rhs: &TracedTensor) -> Result<TracedTensor> {
         TracedTensor::div(self, rhs)
     }
 }
@@ -318,7 +369,9 @@ impl TracedTensor {
         let metadata_scope = register_scoped_value_metadata(
             graph.values()[val].key.clone(),
             concrete_tensor_meta(dtype, &shape),
-        );
+        )
+        // Fresh input keys are unique within this constructor.
+        .expect("fresh concrete traced input metadata registration failed");
 
         let mut map = HashMap::new();
         map.insert(key, Arc::clone(&data));
@@ -371,7 +424,9 @@ impl TracedTensor {
         let metadata_scope = register_scoped_value_metadata(
             graph.values()[val].key.clone(),
             symbolic_input_meta(dtype, id, rank),
-        );
+        )
+        // Fresh input keys are unique within this constructor.
+        .expect("fresh symbolic traced input metadata registration failed");
 
         let mut map = HashMap::new();
         map.insert(key, Arc::clone(&data));
@@ -420,7 +475,9 @@ impl TracedTensor {
         let metadata_scope = register_scoped_value_metadata(
             graph.values()[val].key.clone(),
             concrete_tensor_meta(dtype, &shape),
-        );
+        )
+        // Fresh input keys are unique within this constructor.
+        .expect("fresh concrete traced placeholder metadata registration failed");
 
         Self {
             id,
@@ -464,7 +521,9 @@ impl TracedTensor {
         let metadata_scope = register_scoped_value_metadata(
             graph.values()[val].key.clone(),
             symbolic_input_meta(dtype, id, rank),
-        );
+        )
+        // Fresh input keys are unique within this constructor.
+        .expect("fresh symbolic traced placeholder metadata registration failed");
 
         Self {
             id,
@@ -495,11 +554,14 @@ impl TracedTensor {
     /// let a = TracedTensor::from_vec_col_major(
     ///     vec![2, 3],
     ///     vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0],
-    /// );
+    /// )?;
     /// assert_eq!(a.rank, 2);
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
-    pub fn from_vec_col_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Self {
-        Self::from_tensor_concrete_shape(Tensor::from_vec_col_major(shape, data))
+    pub fn from_vec_col_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Result<Self> {
+        Ok(Self::from_tensor_concrete_shape(
+            Tensor::from_vec_col_major(shape, data)?,
+        ))
     }
 
     /// Build a concrete-shape [`TracedTensor`] leaf from row-major typed
@@ -518,11 +580,14 @@ impl TracedTensor {
     /// let a = TracedTensor::from_vec_row_major(
     ///     vec![2, 3],
     ///     vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    /// );
+    /// )?;
     /// assert_eq!(a.rank, 2);
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
-    pub fn from_vec_row_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Self {
-        Self::from_tensor_concrete_shape(Tensor::from_vec_row_major(shape, data))
+    pub fn from_vec_row_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Result<Self> {
+        Ok(Self::from_tensor_concrete_shape(
+            Tensor::from_vec_row_major(shape, data)?,
+        ))
     }
 
     /// Returns `true` iff every dim of this tensor's `shape_hint` is a
@@ -571,7 +636,7 @@ impl TracedTensor {
     ///
     /// This mirrors the existing traced frontend behavior for composite ops
     /// that require concrete ranks and sizes at graph construction time.
-    pub fn concrete_shape(&self) -> Vec<usize> {
+    pub fn concrete_shape(&self) -> Result<Vec<usize>> {
         concrete_shape(self)
     }
 
@@ -597,15 +662,15 @@ impl TracedTensor {
     /// let y = x.add(&z);
     /// let y2 = &x + &z;
     /// ```
-    pub fn add(&self, other: &TracedTensor) -> TracedTensor {
-        let (lhs, rhs) = broadcast_binary(self, other);
-        apply_binary(
+    pub fn add(&self, other: &TracedTensor) -> Result<TracedTensor> {
+        let (lhs, rhs) = broadcast_binary(self, other)?;
+        Ok(apply_binary(
             StdTensorOp::Add,
             &lhs,
             &rhs,
             lhs.rank,
             lhs.shape_hint.clone(),
-        )
+        ))
     }
 
     /// Elementwise multiplication with NumPy-style broadcasting.
@@ -621,15 +686,15 @@ impl TracedTensor {
     /// let y = x.mul(&z);
     /// let y2 = &x * &z;
     /// ```
-    pub fn mul(&self, other: &TracedTensor) -> TracedTensor {
-        let (lhs, rhs) = broadcast_binary(self, other);
-        apply_binary(
+    pub fn mul(&self, other: &TracedTensor) -> Result<TracedTensor> {
+        let (lhs, rhs) = broadcast_binary(self, other)?;
+        Ok(apply_binary(
             StdTensorOp::Mul,
             &lhs,
             &rhs,
             lhs.rank,
             lhs.shape_hint.clone(),
-        )
+        ))
     }
 
     /// Elementwise division with NumPy-style broadcasting.
@@ -645,27 +710,27 @@ impl TracedTensor {
     /// let y = x.div(&z);
     /// let y2 = &x / &z;
     /// ```
-    pub fn div(&self, other: &TracedTensor) -> TracedTensor {
-        let (lhs, rhs) = broadcast_binary(self, other);
-        apply_binary(
+    pub fn div(&self, other: &TracedTensor) -> Result<TracedTensor> {
+        let (lhs, rhs) = broadcast_binary(self, other)?;
+        Ok(apply_binary(
             StdTensorOp::Div,
             &lhs,
             &rhs,
             lhs.rank,
             lhs.shape_hint.clone(),
-        )
+        ))
     }
 
     /// Elementwise comparison with NumPy-style broadcasting.
-    pub fn compare(&self, other: &TracedTensor, dir: CompareDir) -> TracedTensor {
-        let (lhs, rhs) = broadcast_binary(self, other);
-        apply_binary(
+    pub fn compare(&self, other: &TracedTensor, dir: CompareDir) -> Result<TracedTensor> {
+        let (lhs, rhs) = broadcast_binary(self, other)?;
+        Ok(apply_binary(
             StdTensorOp::Compare(dir),
             &lhs,
             &rhs,
             lhs.rank,
             lhs.shape_hint.clone(),
-        )
+        ))
     }
 
     fn apply_same_shape_unary(&self, op: StdTensorOp) -> TracedTensor {
@@ -757,7 +822,8 @@ impl TracedTensor {
 
     /// Scale by a complex scalar: `y = factor * x`.
     ///
-    /// This currently supports complex tensors only. For real scaling, prefer
+    /// Real and bool tensors are promoted to `C64` before scaling. For a real
+    /// scalar factor that should preserve the input dtype, prefer
     /// [`scale_real`](Self::scale_real).
     ///
     /// # Examples
@@ -779,9 +845,8 @@ impl TracedTensor {
                 StdTensorOp::constant(Complex32::new(factor.re as f32, factor.im as f32)),
             ),
             DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => {
-                panic!(
-                    "scale_complex only supports complex tensors; use scale_real for real tensors"
-                )
+                let promoted = self.convert(DType::C64);
+                scale_with_constant(&promoted, StdTensorOp::constant(factor))
             }
         }
     }
@@ -887,15 +952,15 @@ impl TracedTensor {
     /// # let exp = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 2.0]);
     /// let y = base.pow(&exp);
     /// ```
-    pub fn pow(&self, other: &TracedTensor) -> TracedTensor {
-        let (lhs, rhs) = broadcast_binary(self, other);
-        apply_binary(
+    pub fn pow(&self, other: &TracedTensor) -> Result<TracedTensor> {
+        let (lhs, rhs) = broadcast_binary(self, other)?;
+        Ok(apply_binary(
             StdTensorOp::Pow,
             &lhs,
             &rhs,
             lhs.rank,
             lhs.shape_hint.clone(),
-        )
+        ))
     }
 
     /// Elementwise `exp(x) - 1`.
@@ -972,37 +1037,15 @@ impl TracedTensor {
     /// #     lhs_batch_dims: vec![],
     /// #     rhs_batch_dims: vec![],
     /// # };
-    /// let y = a.dot_general(&b, config);
-    /// ```
-    pub fn dot_general(&self, other: &TracedTensor, config: DotGeneralConfig) -> TracedTensor {
-        self.try_dot_general(other, config)
-            .expect("DotGeneral config dimension validation failed")
-    }
-
-    /// Fallible generalized tensor contraction.
-    ///
-    /// This returns a typed runtime error when the dimension-numbering
-    /// configuration is invalid for the two operand ranks. [`Self::dot_general`]
-    /// is retained as a compatibility wrapper that panics on the same
-    /// validation failure.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use tenferro_runtime::{DotGeneralConfig, TracedTensor};
-    /// # let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    /// # let b = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
-    /// let config = DotGeneralConfig {
-    ///     lhs_contracting_dims: vec![1],
-    ///     rhs_contracting_dims: vec![0],
-    ///     lhs_batch_dims: vec![],
-    ///     rhs_batch_dims: vec![],
-    /// };
-    /// let y = a.try_dot_general(&b, config)?;
-    /// assert_eq!(y.rank, 2);
+    /// let y = a.dot_general(&b, config)?;
     /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
-    pub fn try_dot_general(
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the dimension-numbering configuration is invalid
+    /// for the operand ranks.
+    pub fn dot_general(
         &self,
         other: &TracedTensor,
         config: DotGeneralConfig,
@@ -1057,16 +1100,15 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]);
-    /// let y = x.reduce_sum(&[0]);
-    /// let y2 = x.sum(&[0]);
+    /// let y = x.reduce_sum(&[0])?;
+    /// let y2 = x.reduce_sum(&[0])?;
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
-    pub fn reduce_sum(&self, axes: &[usize]) -> TracedTensor {
-        self.try_reduce_sum(axes)
-            .expect("TracedTensor::reduce_sum axis validation failed")
-    }
-
-    /// Fallibly sum over the given axes.
-    pub fn try_reduce_sum(&self, axes: &[usize]) -> Result<TracedTensor> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when an axis is out of bounds or duplicated.
+    pub fn reduce_sum(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_sum")?;
         Ok(apply_unary(
@@ -1089,15 +1131,14 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]);
-    /// let y = x.reduce_max(&[0]);
+    /// let y = x.reduce_max(&[0])?;
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
-    pub fn reduce_max(&self, axes: &[usize]) -> TracedTensor {
-        self.try_reduce_max(axes)
-            .expect("TracedTensor::reduce_max axis validation failed")
-    }
-
-    /// Fallibly reduce by taking the maximum along the given axes.
-    pub fn try_reduce_max(&self, axes: &[usize]) -> Result<TracedTensor> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when an axis is out of bounds or duplicated.
+    pub fn reduce_max(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_max")?;
         Ok(apply_unary(
@@ -1120,15 +1161,14 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]);
-    /// let y = x.reduce_min(&[0]);
+    /// let y = x.reduce_min(&[0])?;
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
-    pub fn reduce_min(&self, axes: &[usize]) -> TracedTensor {
-        self.try_reduce_min(axes)
-            .expect("TracedTensor::reduce_min axis validation failed")
-    }
-
-    /// Fallibly reduce by taking the minimum along the given axes.
-    pub fn try_reduce_min(&self, axes: &[usize]) -> Result<TracedTensor> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when an axis is out of bounds or duplicated.
+    pub fn reduce_min(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_min")?;
         Ok(apply_unary(
@@ -1148,15 +1188,14 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]);
-    /// let y = x.reduce_prod(&[0]);
+    /// let y = x.reduce_prod(&[0])?;
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
-    pub fn reduce_prod(&self, axes: &[usize]) -> TracedTensor {
-        self.try_reduce_prod(axes)
-            .expect("TracedTensor::reduce_prod axis validation failed")
-    }
-
-    /// Fallibly reduce by taking the product along the given axes.
-    pub fn try_reduce_prod(&self, axes: &[usize]) -> Result<TracedTensor> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when an axis is out of bounds or duplicated.
+    pub fn reduce_prod(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_prod")?;
         Ok(apply_unary(
@@ -1210,17 +1249,16 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    /// let rows = x.sym_size(0);
-    /// let cols = x.sym_size(1);
+    /// let rows = x.sym_size(0)?;
+    /// let cols = x.sym_size(1)?;
     /// let y = x.reshape_sym(&[rows * cols]).unwrap();
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
-    pub fn sym_size(&self, axis: usize) -> SymDim {
-        self.try_sym_size(axis)
-            .expect("TracedTensor::sym_size axis validation failed")
-    }
-
-    /// Fallibly return a symbolic expression for the size of one axis.
-    pub fn try_sym_size(&self, axis: usize) -> Result<SymDim> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `axis` is out of bounds.
+    pub fn sym_size(&self, axis: usize) -> Result<SymDim> {
         validate_traced_axis(self, axis, "TracedTensor::sym_size")?;
         Ok(self
             .shape_hint
@@ -1249,19 +1287,17 @@ impl TracedTensor {
     ///
     /// let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
     /// // Concrete axis: reports the constant size.
-    /// assert_eq!(a.axis_sym_dim(0).constant_value(), Some(2));
+    /// assert_eq!(a.axis_sym_dim(0).unwrap().constant_value(), Some(2));
     ///
     /// let b = TracedTensor::input_symbolic_shape(DType::F64, 2);
     /// // Fully symbolic leaf: reports a TensorAxis reference.
-    /// assert!(b.axis_sym_dim(0).constant_value().is_none());
+    /// assert!(b.axis_sym_dim(0).unwrap().constant_value().is_none());
     /// ```
-    pub fn axis_sym_dim(&self, axis: usize) -> SymDim {
-        self.try_axis_sym_dim(axis)
-            .expect("TracedTensor::axis_sym_dim axis validation failed")
-    }
-
-    /// Fallibly return the canonical `SymDim` for `axis`.
-    pub fn try_axis_sym_dim(&self, axis: usize) -> Result<SymDim> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `axis` is out of bounds.
+    pub fn axis_sym_dim(&self, axis: usize) -> Result<SymDim> {
         validate_traced_axis(self, axis, "TracedTensor::axis_sym_dim")?;
         match self.shape_hint.as_ref().and_then(|shape| shape.get(axis)) {
             Some(dim) => Ok(dim.clone()),
@@ -1301,9 +1337,10 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    /// let rows = x.sym_size(0);
-    /// let cols = x.sym_size(1);
+    /// let rows = x.sym_size(0)?;
+    /// let cols = x.sym_size(1)?;
     /// let y = x.reshape_sym(&[rows * cols]).unwrap();
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
     pub fn reshape_sym(&self, shape: &[SymDim]) -> Result<TracedTensor> {
         let tensor_map = [(self.id, 0usize)];
@@ -1328,7 +1365,7 @@ impl TracedTensor {
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]);
     /// let y = x.broadcast_in_dim(&[2, 3], &[1]);
-    /// let y2 = x.broadcast(&[2, 3], &[1]);
+    /// let y2 = x.broadcast_in_dim(&[2, 3], &[1]);
     /// ```
     pub fn broadcast_in_dim(&self, shape: &[usize], dims: &[usize]) -> TracedTensor {
         apply_unary(
@@ -1359,13 +1396,6 @@ impl TracedTensor {
     /// any references to `self`. Usually the simplest correct thing is to
     /// pass each unique non-self reference tensor once.
     ///
-    /// # Panics
-    ///
-    /// Compatibility wrapper that panics if a `SymDim` in `shape` references a
-    /// traced tensor that is neither `self` nor any tensor listed in
-    /// `shape_refs`. Use [`Self::try_broadcast_in_dim_sym`] for user-provided
-    /// symbolic shapes.
-    ///
     /// # Examples
     ///
     /// ```
@@ -1373,34 +1403,16 @@ impl TracedTensor {
     ///
     /// let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
     /// let b = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
-    /// let m = a.axis_sym_dim(0);
-    /// let k = a.axis_sym_dim(1);
-    /// let n = b.axis_sym_dim(1);
+    /// let m = a.axis_sym_dim(0)?;
+    /// let k = a.axis_sym_dim(1)?;
+    /// let n = b.axis_sym_dim(1)?;
     /// // Broadcast `a[m, k]` to `[m, k, n]`, placing `a`'s axes at 0, 1
     /// // and taking `n` from `b` as an auxiliary shape reference.
-    /// let a_b = a.broadcast_in_dim_sym(&[m, k, n], &[0, 1], &[&b]);
+    /// let a_b = a.broadcast_in_dim_sym(&[m, k, n], &[0, 1], &[&b])?;
     /// assert_eq!(a_b.rank, 3);
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
     pub fn broadcast_in_dim_sym(
-        &self,
-        shape: &[SymDim],
-        dims: &[usize],
-        shape_refs: &[&TracedTensor],
-    ) -> TracedTensor {
-        // Intentional compatibility panic wrapper for callers that already
-        // prove every symbolic shape reference is listed in `shape_refs`.
-        self.try_broadcast_in_dim_sym(shape, dims, shape_refs)
-            .expect("TracedTensor::broadcast_in_dim_sym shape reference validation failed")
-    }
-
-    /// Fallibly broadcast into a symbolic target shape with explicit dimension
-    /// placement.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `shape` contains a symbolic tensor-axis reference
-    /// that is neither `self` nor any tensor listed in `shape_refs`.
-    pub fn try_broadcast_in_dim_sym(
         &self,
         shape: &[SymDim],
         dims: &[usize],
@@ -1462,21 +1474,28 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    /// let y = x.transpose(&[1, 0]);
+    /// let y = x.transpose(&[1, 0])?;
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
-    pub fn transpose(&self, perm: &[usize]) -> TracedTensor {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `perm` is not a valid permutation of the tensor
+    /// axes.
+    pub fn transpose(&self, perm: &[usize]) -> Result<TracedTensor> {
+        validate_traced_perm(self.rank, perm, "TracedTensor::transpose")?;
         let out_shape_hint = self
             .shape_hint
             .as_ref()
             .map(|shape| perm.iter().map(|&p| shape[p].clone()).collect());
-        apply_unary(
+        Ok(apply_unary(
             StdTensorOp::Transpose {
                 perm: perm.to_vec(),
             },
             self,
             self.rank,
             out_shape_hint,
-        )
+        ))
     }
 
     /// Extract the diagonal along two axes.
@@ -1486,13 +1505,23 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]);
-    /// let y = x.extract_diag(0, 1);
+    /// let y = x.extract_diag(0, 1)?;
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
-    pub fn extract_diag(&self, axis_a: usize, axis_b: usize) -> TracedTensor {
-        assert!(
-            axis_a < self.rank && axis_b < self.rank && axis_a != axis_b,
-            "extract_diag: invalid axes"
-        );
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when either axis is out of bounds or the two axes are
+    /// equal.
+    pub fn extract_diag(&self, axis_a: usize, axis_b: usize) -> Result<TracedTensor> {
+        validate_traced_axis(self, axis_a, "TracedTensor::extract_diag")?;
+        validate_traced_axis(self, axis_b, "TracedTensor::extract_diag")?;
+        if axis_a == axis_b {
+            return Err(Error::InvalidGraphBuild {
+                op: "TracedTensor::extract_diag",
+                message: "diagonal axes must be distinct".into(),
+            });
+        }
         let out_shape_hint = self.shape_hint.as_ref().map(|shape| {
             shape
                 .iter()
@@ -1500,12 +1529,12 @@ impl TracedTensor {
                 .filter_map(|(axis, dim)| (axis != axis_b).then_some(dim.clone()))
                 .collect()
         });
-        apply_unary(
+        Ok(apply_unary(
             StdTensorOp::ExtractDiag { axis_a, axis_b },
             self,
             self.rank - 1,
             out_shape_hint,
-        )
+        ))
     }
 
     /// Embed a vector or lower-rank tensor along a diagonal.
@@ -1515,50 +1544,28 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]);
-    /// let y = x.embed_diag(0, 1);
+    /// let y = x.embed_diag(0, 1)?;
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
-    pub fn embed_diag(&self, axis_a: usize, axis_b: usize) -> TracedTensor {
-        assert!(
-            axis_a < self.rank && axis_b <= self.rank,
-            "embed_diag: invalid axes"
-        );
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `axis_a` is out of bounds or `axis_b` is not a
+    /// valid insertion axis.
+    pub fn embed_diag(&self, axis_a: usize, axis_b: usize) -> Result<TracedTensor> {
+        validate_traced_axis(self, axis_a, "TracedTensor::embed_diag")?;
+        validate_traced_insert_axis(self.rank, axis_b, "TracedTensor::embed_diag")?;
         let out_shape_hint = self.shape_hint.as_ref().map(|shape| {
             let mut out_shape = shape.clone();
             out_shape.insert(axis_b, shape[axis_a].clone());
             out_shape
         });
-        apply_unary(
+        Ok(apply_unary(
             StdTensorOp::EmbedDiag { axis_a, axis_b },
             self,
             self.rank + 1,
             out_shape_hint,
-        )
-    }
-
-    /// Alias for [`Self::reduce_sum`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use tenferro_runtime::TracedTensor;
-    /// # let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]);
-    /// let y = x.sum(&[0]);
-    /// ```
-    pub fn sum(&self, axes: &[usize]) -> TracedTensor {
-        self.reduce_sum(axes)
-    }
-
-    /// Alias for [`Self::broadcast_in_dim`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use tenferro_runtime::TracedTensor;
-    /// # let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]);
-    /// let y = x.broadcast(&[2, 3], &[1]);
-    /// ```
-    pub fn broadcast(&self, shape: &[usize], dims: &[usize]) -> TracedTensor {
-        self.broadcast_in_dim(shape, dims)
+        ))
     }
 
     /// Return the runtime size of one axis as a scalar `f64` tensor.
@@ -1572,25 +1579,25 @@ impl TracedTensor {
     /// use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    /// let cols = x.shape_of(1);
+    /// let cols = x.shape_of(1)?;
     /// let mut compiler = GraphCompiler::new();
     /// let program = compiler.compile(&cols).unwrap();
     /// let out = GraphExecutor::new(CpuBackend::new()).run(&program).unwrap();
     /// assert_eq!(out.shape(), &[] as &[usize]);
     /// ```
-    pub fn shape_of(&self, axis: usize) -> TracedTensor {
-        assert!(
-            axis < self.rank,
-            "axis {axis} out of bounds for rank {}",
-            self.rank
-        );
-        apply_unary_with_dtype(
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `axis` is out of bounds.
+    pub fn shape_of(&self, axis: usize) -> Result<TracedTensor> {
+        validate_traced_axis(self, axis, "TracedTensor::shape_of")?;
+        Ok(apply_unary_with_dtype(
             StdTensorOp::ShapeOf { axis },
             self,
             0,
             Some(vec![]),
             DType::F64,
-        )
+        ))
     }
 
     /// Truncate this tensor along `axis` to the first `size` elements.
@@ -1607,30 +1614,31 @@ impl TracedTensor {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]);
     /// let size = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]);
-    /// let y = x.dynamic_truncate(&size, 0);
+    /// let y = x.dynamic_truncate(&size, 0)?;
     /// let mut compiler = GraphCompiler::new();
     /// let program = compiler.compile(&y).unwrap();
     /// let out = GraphExecutor::new(CpuBackend::new()).run(&program).unwrap();
     /// assert_eq!(out.shape(), &[2]);
     /// ```
-    pub fn dynamic_truncate(&self, size: &TracedTensor, axis: usize) -> TracedTensor {
-        assert!(
-            axis < self.rank,
-            "axis {axis} out of bounds for rank {}",
-            self.rank
-        );
-        assert!(
-            size.rank == 0,
-            "dynamic_truncate size must be a scalar tensor, got rank {}",
-            size.rank
-        );
-        apply_binary(
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `axis` is out of bounds or `size` is not scalar.
+    pub fn dynamic_truncate(&self, size: &TracedTensor, axis: usize) -> Result<TracedTensor> {
+        validate_traced_axis(self, axis, "TracedTensor::dynamic_truncate")?;
+        if size.rank != 0 {
+            return Err(Error::InvalidGraphBuild {
+                op: "TracedTensor::dynamic_truncate",
+                message: format!("size must be a scalar tensor, got rank {}", size.rank),
+            });
+        }
+        Ok(apply_binary(
             StdTensorOp::DynamicTruncate { axis },
             self,
             size,
             self.rank,
             None,
-        )
+        ))
     }
 
     /// Pad this tensor with zeros along `axis` to match `reference.shape[axis]`.
@@ -1645,30 +1653,26 @@ impl TracedTensor {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
     /// let reference = TracedTensor::from_vec_col_major(vec![4], vec![0.0_f64, 0.0, 0.0, 0.0]);
-    /// let y = x.pad_to_match(&reference, 0);
+    /// let y = x.pad_to_match(&reference, 0)?;
     /// let mut compiler = GraphCompiler::new();
     /// let program = compiler.compile(&y).unwrap();
     /// let out = GraphExecutor::new(CpuBackend::new()).run(&program).unwrap();
     /// assert_eq!(out.shape(), &[4]);
     /// ```
-    pub fn pad_to_match(&self, reference: &TracedTensor, axis: usize) -> TracedTensor {
-        assert!(
-            axis < self.rank,
-            "axis {axis} out of bounds for rank {}",
-            self.rank
-        );
-        assert!(
-            axis < reference.rank,
-            "reference axis {axis} out of bounds for rank {}",
-            reference.rank
-        );
-        apply_binary(
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `axis` is out of bounds for either tensor.
+    pub fn pad_to_match(&self, reference: &TracedTensor, axis: usize) -> Result<TracedTensor> {
+        validate_traced_axis(self, axis, "TracedTensor::pad_to_match")?;
+        validate_traced_axis(reference, axis, "TracedTensor::pad_to_match")?;
+        Ok(apply_binary(
             StdTensorOp::PadToMatch { axis },
             self,
             reference,
             self.rank,
             reference.shape_hint.clone(),
-        )
+        ))
     }
 }
 
@@ -1678,7 +1682,9 @@ pub(crate) fn apply_unary(
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
 ) -> TracedTensor {
-    let out_dtype = crate::shape_infer::infer_output_dtype(&op, &[input.dtype]);
+    let out_dtype = crate::shape_infer::infer_output_dtype(&op, &[input.dtype])
+        // Traced unary builders only pass built-in unary ops with one input dtype.
+        .expect("built-in traced unary dtype inference failed");
     apply_unary_with_dtype(op, input, out_rank, out_shape_hint, out_dtype)
 }
 
@@ -1825,7 +1831,9 @@ pub(crate) fn apply_binary(
     out_shape_hint: Option<Vec<SymDim>>,
 ) -> TracedTensor {
     let input_dtype = crate::shape_infer::promote_dtype_for_binary_op(&op, lhs.dtype, rhs.dtype);
-    let out_dtype = crate::shape_infer::infer_output_dtype(&op, &[lhs.dtype, rhs.dtype]);
+    let out_dtype = crate::shape_infer::infer_output_dtype(&op, &[lhs.dtype, rhs.dtype])
+        // Traced binary builders only pass built-in binary ops with both input dtypes.
+        .expect("built-in traced binary dtype inference failed");
 
     // Insert Convert ops when an input dtype differs from the primitive input dtype.
     let lhs = if lhs.dtype != input_dtype {
@@ -1857,9 +1865,15 @@ pub(crate) fn apply_broadcast_binary_op(
     op: StdTensorOp,
     lhs: &TracedTensor,
     rhs: &TracedTensor,
-) -> TracedTensor {
-    let (lhs, rhs) = broadcast_binary(lhs, rhs);
-    apply_binary(op, &lhs, &rhs, lhs.rank, lhs.shape_hint.clone())
+) -> Result<TracedTensor> {
+    let (lhs, rhs) = broadcast_binary(lhs, rhs)?;
+    Ok(apply_binary(
+        op,
+        &lhs,
+        &rhs,
+        lhs.rank,
+        lhs.shape_hint.clone(),
+    ))
 }
 
 pub(crate) fn apply_broadcast_ternary_op(
@@ -1867,16 +1881,16 @@ pub(crate) fn apply_broadcast_ternary_op(
     first: &TracedTensor,
     second: &TracedTensor,
     third: &TracedTensor,
-) -> TracedTensor {
-    let (first, second, third) = broadcast_ternary(first, second, third);
-    apply_ternary(
+) -> Result<TracedTensor> {
+    let (first, second, third) = broadcast_ternary(first, second, third)?;
+    Ok(apply_ternary(
         op,
         &first,
         &second,
         &third,
         first.rank,
         first.shape_hint.clone(),
-    )
+    ))
 }
 
 pub(crate) fn apply_ternary(
@@ -1888,7 +1902,9 @@ pub(crate) fn apply_ternary(
     out_shape_hint: Option<Vec<SymDim>>,
 ) -> TracedTensor {
     let out_dtype =
-        crate::shape_infer::infer_output_dtype(&op, &[first.dtype, second.dtype, third.dtype]);
+        crate::shape_infer::infer_output_dtype(&op, &[first.dtype, second.dtype, third.dtype])
+            // Traced ternary builders only pass built-in ternary ops with all input dtypes.
+            .expect("built-in traced ternary dtype inference failed");
     let (first, second, third) = match op {
         StdTensorOp::Select => {
             let value_dtype = crate::shape_infer::promote_dtype(second.dtype, third.dtype);
@@ -2060,14 +2076,20 @@ fn register_single_output_metadata(
     output: LocalValueId,
     dtype: DType,
     shape_hint: &Option<Vec<SymDim>>,
-) -> MetadataScope {
+) -> GlobalMetadataScope {
     if let Some(shape) = shape_hint {
+        // Fresh graph output keys are generated in this builder, so metadata
+        // registration failure would indicate a global metadata invariant bug.
         register_scoped_value_metadata(
             graph.values()[output].key.clone(),
             tensor_meta(dtype, shape.clone()),
         )
+        .expect("fresh traced graph output metadata registration failed")
     } else {
+        // Fresh graph output keys are generated in this builder, so metadata
+        // registration failure would indicate a global metadata invariant bug.
         register_scoped_graph_metadata(graph, std::iter::empty())
+            .expect("fresh traced graph metadata registration failed")
     }
 }
 

--- a/crates/tenferro-runtime/src/traced/tests.rs
+++ b/crates/tenferro-runtime/src/traced/tests.rs
@@ -1,9 +1,9 @@
 use crate::{DType, DotGeneralConfig, TracedTensor};
 
 #[test]
-fn try_dot_general_returns_error_for_invalid_config() {
-    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let rhs = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
+fn dot_general_returns_error_for_invalid_config() {
+    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let rhs = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![2],
         rhs_contracting_dims: vec![0],
@@ -11,7 +11,7 @@ fn try_dot_general_returns_error_for_invalid_config() {
         rhs_batch_dims: vec![],
     };
 
-    let Err(err) = lhs.try_dot_general(&rhs, config) else {
+    let Err(err) = lhs.dot_general(&rhs, config) else {
         panic!("invalid dim config should be a typed runtime error");
     };
 
@@ -23,9 +23,9 @@ fn try_dot_general_returns_error_for_invalid_config() {
 }
 
 #[test]
-fn try_dot_general_keeps_existing_success_metadata() {
-    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-    let rhs = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]);
+fn dot_general_keeps_existing_success_metadata() {
+    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let rhs = TracedTensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -34,7 +34,7 @@ fn try_dot_general_keeps_existing_success_metadata() {
     };
 
     let out = lhs
-        .try_dot_general(&rhs, config)
+        .dot_general(&rhs, config)
         .expect("valid dot_general config should build a traced tensor");
 
     assert_eq!(out.rank, 2);
@@ -42,10 +42,10 @@ fn try_dot_general_keeps_existing_success_metadata() {
 }
 
 #[test]
-fn try_reductions_reject_invalid_axes_instead_of_saturating_rank() {
-    let x = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
+fn reductions_reject_invalid_axes_instead_of_saturating_rank() {
+    let x = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
 
-    let out_of_bounds = x.try_reduce_max(&[2]).unwrap_err();
+    let out_of_bounds = x.reduce_max(&[2]).unwrap_err();
     assert!(
         out_of_bounds
             .to_string()
@@ -53,22 +53,22 @@ fn try_reductions_reject_invalid_axes_instead_of_saturating_rank() {
         "{out_of_bounds}"
     );
 
-    let duplicate = x.try_reduce_min(&[0, 0]).unwrap_err();
+    let duplicate = x.reduce_min(&[0, 0]).unwrap_err();
     assert!(
         duplicate.to_string().contains("duplicate reduction axis 0"),
         "{duplicate}"
     );
 
-    let y = x.try_reduce_sum(&[1]).unwrap();
+    let y = x.reduce_sum(&[1]).unwrap();
     assert_eq!(y.rank, 1);
     assert_eq!(y.try_concrete_shape().unwrap(), &[2]);
 }
 
 #[test]
-fn try_symbolic_axis_accessors_reject_invalid_axes() {
-    let x = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
+fn symbolic_axis_accessors_reject_invalid_axes() {
+    let x = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
 
-    let sym_size_err = x.try_sym_size(2).unwrap_err();
+    let sym_size_err = x.sym_size(2).unwrap_err();
     assert!(
         sym_size_err
             .to_string()
@@ -76,7 +76,7 @@ fn try_symbolic_axis_accessors_reject_invalid_axes() {
         "{sym_size_err}"
     );
 
-    let axis_err = x.try_axis_sym_dim(2).unwrap_err();
+    let axis_err = x.axis_sym_dim(2).unwrap_err();
     assert!(
         axis_err
             .to_string()
@@ -84,17 +84,17 @@ fn try_symbolic_axis_accessors_reject_invalid_axes() {
         "{axis_err}"
     );
 
-    assert_eq!(x.try_axis_sym_dim(0).unwrap().constant_value(), Some(2));
+    assert_eq!(x.axis_sym_dim(0).unwrap().constant_value(), Some(2));
 }
 
 #[test]
-fn try_broadcast_in_dim_sym_rejects_missing_shape_reference() {
+fn broadcast_in_dim_sym_rejects_missing_shape_reference() {
     let lhs = TracedTensor::input_symbolic_shape(DType::F64, 1);
     let rhs = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let target_shape = [lhs.axis_sym_dim(0), rhs.axis_sym_dim(0)];
+    let target_shape = [lhs.axis_sym_dim(0).unwrap(), rhs.axis_sym_dim(0).unwrap()];
 
     let err = lhs
-        .try_broadcast_in_dim_sym(&target_shape, &[0], &[])
+        .broadcast_in_dim_sym(&target_shape, &[0], &[])
         .unwrap_err();
 
     let message = err.to_string();

--- a/crates/tenferro-runtime/src/traced_tensor.rs
+++ b/crates/tenferro-runtime/src/traced_tensor.rs
@@ -6,7 +6,7 @@
 
 use tenferro_ops::std_tensor_op::StdTensorOp;
 
-use crate::{CompareDir, DType, DotGeneralConfig};
+use crate::{CompareDir, DType, DotGeneralConfig, Error, Result};
 
 pub use crate::traced::{TracedTensor, TracedTensorId};
 
@@ -40,7 +40,7 @@ pub fn convert(input: &TracedTensor, to: DType) -> TracedTensor {
 /// # let y = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
 /// let z = tenferro_runtime::traced_tensor::add(&x, &y);
 /// ```
-pub fn add(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
+pub fn add(lhs: &TracedTensor, rhs: &TracedTensor) -> Result<TracedTensor> {
     lhs.add(rhs)
 }
 
@@ -73,7 +73,7 @@ macro_rules! binary_method_fn {
         /// # let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]);
         #[doc = concat!("let z = tenferro_runtime::traced_tensor::", stringify!($name), "(&x, &y);")]
         /// ```
-        pub fn $name(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
+        pub fn $name(lhs: &TracedTensor, rhs: &TracedTensor) -> Result<TracedTensor> {
             lhs.$method(rhs)
         }
     };
@@ -115,7 +115,7 @@ unary_fn!(log1p, log1p, "Elementwise `log(1 + x)`.");
 /// # let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]);
 /// let z = tenferro_runtime::traced_tensor::sub(&x, &y);
 /// ```
-pub fn sub(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
+pub fn sub(lhs: &TracedTensor, rhs: &TracedTensor) -> Result<TracedTensor> {
     add(lhs, &neg(rhs))
 }
 
@@ -129,7 +129,7 @@ pub fn sub(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
 /// # let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]);
 /// let z = tenferro_runtime::traced_tensor::maximum(&x, &y);
 /// ```
-pub fn maximum(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
+pub fn maximum(lhs: &TracedTensor, rhs: &TracedTensor) -> Result<TracedTensor> {
     crate::traced::apply_broadcast_binary_op(StdTensorOp::Maximum, lhs, rhs)
 }
 
@@ -143,7 +143,7 @@ pub fn maximum(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
 /// # let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 8.0]);
 /// let z = tenferro_runtime::traced_tensor::minimum(&x, &y);
 /// ```
-pub fn minimum(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
+pub fn minimum(lhs: &TracedTensor, rhs: &TracedTensor) -> Result<TracedTensor> {
     crate::traced::apply_broadcast_binary_op(StdTensorOp::Minimum, lhs, rhs)
 }
 
@@ -160,7 +160,7 @@ pub fn minimum(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
 /// let z = tenferro_runtime::traced_tensor::compare(&x, &y, CompareDir::Gt);
 /// assert_eq!(z.dtype, tenferro_runtime::DType::Bool);
 /// ```
-pub fn compare(lhs: &TracedTensor, rhs: &TracedTensor, dir: CompareDir) -> TracedTensor {
+pub fn compare(lhs: &TracedTensor, rhs: &TracedTensor, dir: CompareDir) -> Result<TracedTensor> {
     crate::traced::apply_broadcast_binary_op(StdTensorOp::Compare(dir), lhs, rhs)
 }
 
@@ -181,7 +181,7 @@ pub fn where_select(
     condition: &TracedTensor,
     on_true: &TracedTensor,
     on_false: &TracedTensor,
-) -> TracedTensor {
+) -> Result<TracedTensor> {
     crate::traced::apply_broadcast_ternary_op(StdTensorOp::Select, condition, on_true, on_false)
 }
 
@@ -196,7 +196,11 @@ pub fn where_select(
 /// # let upper = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]);
 /// let z = tenferro_runtime::traced_tensor::clamp(&x, &lower, &upper);
 /// ```
-pub fn clamp(input: &TracedTensor, lower: &TracedTensor, upper: &TracedTensor) -> TracedTensor {
+pub fn clamp(
+    input: &TracedTensor,
+    lower: &TracedTensor,
+    upper: &TracedTensor,
+) -> Result<TracedTensor> {
     crate::traced::apply_broadcast_ternary_op(StdTensorOp::Clamp, input, lower, upper)
 }
 
@@ -210,9 +214,19 @@ pub fn clamp(input: &TracedTensor, lower: &TracedTensor, upper: &TracedTensor) -
 /// # use tenferro_runtime::TracedTensor;
 /// # let a = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
 /// # let b = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
-/// let c = tenferro_runtime::traced_tensor::matmul(&a, &b);
+/// let c = tenferro_runtime::traced_tensor::matmul(&a, &b)?;
+/// # Ok::<(), tenferro_runtime::Error>(())
 /// ```
-pub fn matmul(a: &TracedTensor, b: &TracedTensor) -> TracedTensor {
+pub fn matmul(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
+    if a.rank == 0 || b.rank == 0 {
+        return Err(Error::InvalidGraphBuild {
+            op: "traced_tensor::matmul",
+            message: format!(
+                "matmul requires rank >= 1 for both inputs, got {} and {}",
+                a.rank, b.rank
+            ),
+        });
+    }
     let config = DotGeneralConfig {
         lhs_contracting_dims: vec![a.rank - 1],
         rhs_contracting_dims: vec![0],

--- a/crates/tenferro-runtime/src/typed_tensor.rs
+++ b/crates/tenferro-runtime/src/typed_tensor.rs
@@ -30,7 +30,7 @@ pub fn add<T: TensorScalar>(
     let (lhs, rhs) = broadcast_binary_read(lhs, rhs, backend)?;
     let out =
         backend.with_backend_session(|exec| exec.add_read(lhs.tensor_read(), rhs.tensor_read()))?;
-    try_into_typed_result("add", out)
+    into_typed_result("add", out)
 }
 
 macro_rules! unary_fn {
@@ -51,7 +51,7 @@ macro_rules! unary_fn {
             backend: &mut impl TensorBackend,
         ) -> Result<TypedTensor<T>> {
             let out = backend.with_backend_session(|exec| exec.$method(T::tensor_read(input)))?;
-            try_into_typed_result(stringify!($name), out)
+            into_typed_result(stringify!($name), out)
         }
     };
 }
@@ -78,7 +78,7 @@ macro_rules! binary_fn {
             let (lhs, rhs) = broadcast_binary_read(lhs, rhs, backend)?;
             let out =
                 backend.with_backend_session(|exec| exec.$method(lhs.tensor_read(), rhs.tensor_read()))?;
-            try_into_typed_result(stringify!($name), out)
+            into_typed_result(stringify!($name), out)
         }
     };
 }
@@ -145,7 +145,7 @@ pub fn sub<T: TensorScalar>(
     let out = backend.with_backend_session(|exec| {
         exec.add_read(lhs.tensor_read(), TensorRead::from_tensor(&neg_rhs))
     })?;
-    try_into_typed_result("sub", out)
+    into_typed_result("sub", out)
 }
 
 /// Elementwise comparison with NumPy-style broadcasting.
@@ -173,7 +173,7 @@ pub fn compare<T: TensorScalar>(
     let out = backend.with_backend_session(|exec| {
         exec.compare_read(lhs.tensor_read(), rhs.tensor_read(), &dir)
     })?;
-    try_into_typed_result("compare", out)
+    into_typed_result("compare", out)
 }
 
 /// Select values from `on_true` or `on_false` using a condition tensor.
@@ -206,7 +206,7 @@ pub fn where_select<T: TensorScalar>(
             on_false.tensor_read(),
         )
     })?;
-    try_into_typed_result("where_select", out)
+    into_typed_result("where_select", out)
 }
 
 /// Clamp values elementwise between lower and upper bounds.
@@ -236,7 +236,7 @@ pub fn clamp<T: TensorScalar>(
             upper.tensor_read(),
         )
     })?;
-    try_into_typed_result("clamp", out)
+    into_typed_result("clamp", out)
 }
 
 /// Matrix multiplication helper for rank-2 typed tensors.
@@ -267,7 +267,7 @@ pub fn matmul<T: TensorScalar>(
     let out = backend.with_backend_session(|exec| {
         exec.dot_general_read(T::tensor_read(a), T::tensor_read(b), &config)
     })?;
-    try_into_typed_result("matmul", out)
+    into_typed_result("matmul", out)
 }
 
 /// Sum elements across one or more axes.
@@ -292,7 +292,7 @@ pub fn reduce_sum<T: TensorScalar>(
 ) -> Result<TypedTensor<T>> {
     let out =
         backend.with_backend_session(|exec| exec.reduce_sum_read(T::tensor_read(input), axes))?;
-    try_into_typed_result("reduce_sum", out)
+    into_typed_result("reduce_sum", out)
 }
 
 /// Reshape a typed tensor through the backend structural operation.
@@ -314,7 +314,7 @@ pub fn reshape<T: TensorScalar>(
 ) -> Result<TypedTensor<T>> {
     let out =
         backend.with_backend_session(|exec| exec.reshape_read(T::tensor_read(input), shape))?;
-    try_into_typed_result("reshape", out)
+    into_typed_result("reshape", out)
 }
 
 /// Permute typed tensor axes through the backend structural operation.
@@ -336,7 +336,7 @@ pub fn transpose<T: TensorScalar>(
 ) -> Result<TypedTensor<T>> {
     let out =
         backend.with_backend_session(|exec| exec.transpose_read(T::tensor_read(input), perm))?;
-    try_into_typed_result("transpose", out)
+    into_typed_result("transpose", out)
 }
 
 /// Broadcast a typed tensor into a larger shape.
@@ -363,7 +363,7 @@ pub fn broadcast_in_dim<T: TensorScalar>(
     let out = backend.with_backend_session(|exec| {
         exec.broadcast_in_dim_read(T::tensor_read(input), shape, dims)
     })?;
-    try_into_typed_result("broadcast_in_dim", out)
+    into_typed_result("broadcast_in_dim", out)
 }
 
 enum ReadInput<'a> {
@@ -435,12 +435,9 @@ fn broadcast_error(err: impl std::fmt::Display) -> Error {
     Error::backend_failure("broadcast", err.to_string())
 }
 
-fn try_into_typed_result<T: TensorScalar>(
-    op: &'static str,
-    tensor: Tensor,
-) -> Result<TypedTensor<T>> {
+fn into_typed_result<T: TensorScalar>(op: &'static str, tensor: Tensor) -> Result<TypedTensor<T>> {
     let actual = tensor.dtype();
-    T::try_into_typed(tensor).ok_or(Error::DTypeMismatch {
+    T::into_typed(tensor).map_err(|_| Error::DTypeMismatch {
         op,
         lhs: T::dtype(),
         rhs: actual,

--- a/crates/tenferro-runtime/tests/extension_runtime.rs
+++ b/crates/tenferro-runtime/tests/extension_runtime.rs
@@ -90,6 +90,20 @@ impl ExtensionRuntime<CpuBackend> for IdentityRuntime {
         assert!(ctx.caches_mut().get::<String>(&key).is_some());
         Ok(vec![inputs[0].clone()])
     }
+
+    fn execute_reads(
+        &self,
+        op: &dyn ExtensionOp,
+        inputs: &[TensorRead<'_>],
+        ctx: &mut ExtensionExecutionContext<'_, CpuBackend>,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let materialized_inputs: Vec<Tensor> = inputs
+            .iter()
+            .map(TensorRead::to_tensor)
+            .collect::<tenferro_tensor::Result<_>>()?;
+        let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
+        self.execute(op, &input_refs, ctx)
+    }
 }
 
 #[derive(Debug)]
@@ -112,6 +126,20 @@ impl ExtensionRuntime<CpuBackend> for WrongOutputCountRuntime {
         Ok(std::iter::repeat_with(|| inputs[0].clone())
             .take(self.return_count)
             .collect())
+    }
+
+    fn execute_reads(
+        &self,
+        op: &dyn ExtensionOp,
+        inputs: &[TensorRead<'_>],
+        ctx: &mut ExtensionExecutionContext<'_, CpuBackend>,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let materialized_inputs: Vec<Tensor> = inputs
+            .iter()
+            .map(TensorRead::to_tensor)
+            .collect::<tenferro_tensor::Result<_>>()?;
+        let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
+        self.execute(op, &input_refs, ctx)
     }
 }
 
@@ -169,7 +197,7 @@ fn extension_executor_executes_registered_runtime_and_manages_caches() {
     assert_eq!(executor.cache_limits().max_entries().get(), 2);
 
     let mut backend = CpuBackend::new();
-    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let output = executor
         .execute(&mut backend, &IdentityRuntimeOp { family }, &[&input])
         .expect("extension execution");
@@ -192,7 +220,7 @@ fn extension_executor_rejects_runtime_output_count_mismatch() {
         .expect("runtime registration");
     let mut executor = ExtensionExecutor::with_parts(registry, Default::default());
     let mut backend = CpuBackend::new();
-    let input = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]);
+    let input = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
 
     let err = executor
         .execute(&mut backend, &IdentityRuntimeOp { family }, &[&input])
@@ -236,7 +264,7 @@ fn extension_executor_rejects_read_runtime_output_count_mismatch() {
         }))
         .expect("runtime registration");
     let mut executor = ExtensionExecutor::with_parts(registry, Default::default());
-    let input = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]);
+    let input = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
     let read = TensorRead::from_tensor(&input);
     let mut backend = CpuBackend::new();
 
@@ -279,14 +307,17 @@ fn extension_executor_read_fallback_reports_backend_view_materialization_error_w
         .register(Arc::new(IdentityRuntime { family }))
         .expect("runtime registration");
     let mut executor = ExtensionExecutor::with_parts(registry, Default::default());
-    let base = Arc::new(Tensor::F64(TypedTensor::<f64>::from_buffer_col_major(
-        vec![1],
-        Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(91, 1))),
-        Placement {
-            memory_kind: MemoryKind::Device,
-            device: None,
-        },
-    )));
+    let base = Arc::new(Tensor::F64(
+        TypedTensor::<f64>::from_buffer_col_major(
+            vec![1],
+            Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(91, 1))),
+            Placement {
+                memory_kind: MemoryKind::Device,
+                device: None,
+            },
+        )
+        .unwrap(),
+    ));
     let view = TensorOwnedView::from_tensor(base);
     let read = view.tensor_read();
     let mut backend = CpuBackend::new();
@@ -319,10 +350,9 @@ fn extension_executor_default_read_path_materializes_views_at_runtime_boundary()
         .expect("runtime registration");
     let mut executor = ExtensionExecutor::with_parts(registry, Default::default());
 
-    let base = Arc::new(Tensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let base = Arc::new(
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
     let view = TensorOwnedView::from_parts(Arc::clone(&base), vec![3, 2], vec![2, 1], 0).unwrap();
     let read = TensorRead::from_view(view.tensor_view());
     let mut backend = CpuBackend::new();
@@ -344,7 +374,7 @@ fn extension_executor_default_read_path_materializes_views_at_runtime_boundary()
 fn extension_executor_reports_missing_runtime() {
     let mut executor = ExtensionExecutor::<CpuBackend>::new();
     let mut backend = CpuBackend::new();
-    let input = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]);
+    let input = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
     let err = executor
         .execute(
             &mut backend,

--- a/crates/tenferro-runtime/tests/graph_default_input_placement.rs
+++ b/crates/tenferro-runtime/tests/graph_default_input_placement.rs
@@ -118,8 +118,9 @@ impl BackendSessionHost for UploadRejectingBackend {}
 impl TensorBackend for UploadRejectingBackend {}
 
 fn scalar_default_program() -> tenferro_runtime::GraphProgram {
-    let scalar =
-        TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(vec![], vec![1.0_f64]));
+    let scalar = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap(),
+    );
     GraphCompiler::new().compile(&scalar).unwrap()
 }
 
@@ -149,7 +150,7 @@ fn explicit_scalar_binding_is_not_auto_uploaded() {
     let program = GraphCompiler::new()
         .compile_with_input_specs(&scalar, &[(&scalar, DType::F64, &[])])
         .unwrap();
-    let bound = Tensor::from_vec_col_major(vec![], vec![7.0_f64]);
+    let bound = Tensor::from_vec_col_major(vec![], vec![7.0_f64]).unwrap();
 
     let owned = GraphExecutor::new(UploadRejectingBackend)
         .run_many_with_inputs(&program, &[(&scalar, &bound)])
@@ -164,10 +165,9 @@ fn explicit_scalar_binding_is_not_auto_uploaded() {
 
 #[test]
 fn non_scalar_default_input_is_not_auto_uploaded() {
-    let vector = TracedTensor::from_tensor_concrete_shape(Tensor::from_vec_col_major(
-        vec![1],
-        vec![3.0_f64],
-    ));
+    let vector = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap(),
+    );
     let program = GraphCompiler::new().compile(&vector).unwrap();
 
     let owned = GraphExecutor::new(UploadRejectingBackend)
@@ -183,14 +183,17 @@ fn non_scalar_default_input_is_not_auto_uploaded() {
 
 #[test]
 fn backend_resident_scalar_default_input_is_not_reuploaded() {
-    let tensor = Tensor::F64(TypedTensor::from_buffer_col_major(
-        vec![],
-        Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(1, 1))),
-        Placement {
-            memory_kind: MemoryKind::Other("test-backend".to_string()),
-            device: None,
-        },
-    ));
+    let tensor = Tensor::F64(
+        TypedTensor::from_buffer_col_major(
+            vec![],
+            Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(1, 1))),
+            Placement {
+                memory_kind: MemoryKind::Other("test-backend".to_string()),
+                device: None,
+            },
+        )
+        .unwrap(),
+    );
     let scalar = TracedTensor::from_tensor_concrete_shape(tensor);
     let program = GraphCompiler::new().compile(&scalar).unwrap();
 

--- a/crates/tenferro-runtime/tests/public_surface_contract.rs
+++ b/crates/tenferro-runtime/tests/public_surface_contract.rs
@@ -11,8 +11,8 @@ fn repo_file(path: &str) -> String {
 
 #[test]
 fn graph_program_exposes_read_only_lowering_view_for_owner_crates() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let y = &x + &x;
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y = (&x + &x).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&y).unwrap();
 

--- a/crates/tenferro-runtime/tests/runtime_public_api.rs
+++ b/crates/tenferro-runtime/tests/runtime_public_api.rs
@@ -6,8 +6,8 @@ use tenferro_runtime::{
 
 #[test]
 fn runtime_crate_exposes_traced_graph_execution_api() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let y = &x + &x;
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let y = (&x + &x).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&y).unwrap();
@@ -21,7 +21,7 @@ fn runtime_crate_exposes_traced_graph_execution_api() {
 #[test]
 fn tensor_module_free_functions_cover_eager_runtime_paths() {
     let mut backend = CpuBackend::new();
-    let input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
 
     let converted = tensor::convert(&input, DType::F32, &mut backend).unwrap();
     assert_eq!(converted.dtype(), DType::F32);
@@ -43,12 +43,12 @@ fn tensor_module_free_functions_cover_eager_runtime_paths() {
 #[test]
 fn graph_executor_runs_elementwise_and_reduction_with_borrowed_inputs() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = (&x + &x).reduce_sum(&[0]);
+    let y = (&x + &x).unwrap().reduce_sum(&[0]).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])
         .unwrap();
-    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let mut executor = GraphExecutor::new(CpuBackend::new());
 
     let out = executor
@@ -63,15 +63,15 @@ fn graph_executor_runs_elementwise_and_reduction_with_borrowed_inputs() {
 #[test]
 fn traced_broadcast_binary_accepts_symbolic_same_rank_input() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let y = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
 
-    let z = &x + &y;
+    let z = (&x + &y).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&z, &[(&x, DType::F64, &[2])])
         .unwrap();
-    let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
+    let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
     let out = GraphExecutor::new(CpuBackend::new())
         .run_with_input_reads(&program, &[(&x, TensorRead::from_tensor(&input))])
         .unwrap();
@@ -81,9 +81,9 @@ fn traced_broadcast_binary_accepts_symbolic_same_rank_input() {
 
 #[test]
 fn traced_reduction_with_too_many_axes_returns_error_without_rank_underflow() {
-    let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]);
+    let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
 
-    let err = x.try_reduce_max(&[0, 1, 2]).unwrap_err().to_string();
+    let err = x.reduce_max(&[0, 1, 2]).unwrap_err().to_string();
 
     assert!(err.contains("axis 2 out of bounds for rank 2"), "{err}");
 }
@@ -92,15 +92,17 @@ fn traced_reduction_with_too_many_axes_returns_error_without_rank_underflow() {
 fn graph_executor_runs_dot_general_with_borrowed_inputs() {
     let lhs = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let rhs = TracedTensor::input_symbolic_shape(DType::F64, 2);
-    let product = lhs.dot_general(
-        &rhs,
-        DotGeneralConfig {
-            lhs_contracting_dims: vec![1],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: vec![],
-            rhs_batch_dims: vec![],
-        },
-    );
+    let product = lhs
+        .dot_general(
+            &rhs,
+            DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+        )
+        .unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(
@@ -108,8 +110,10 @@ fn graph_executor_runs_dot_general_with_borrowed_inputs() {
             &[(&lhs, DType::F64, &[2, 3]), (&rhs, DType::F64, &[3, 2])],
         )
         .unwrap();
-    let lhs_data = Tensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    let rhs_data = Tensor::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let lhs_data =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs_data =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let mut executor = GraphExecutor::new(CpuBackend::new());
 
     let out = executor
@@ -130,12 +134,13 @@ fn graph_executor_runs_dot_general_with_borrowed_inputs() {
 #[test]
 fn graph_executor_can_return_final_transpose_as_lazy_value() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 2);
-    let y = (&x + &x).transpose(&[1, 0]);
+    let y = (&x + &x).unwrap().transpose(&[1, 0]).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&y, &[(&x, DType::F64, &[2, 3])])
         .unwrap();
-    let input = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let input =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
     let mut executor = GraphExecutor::new(CpuBackend::new());
 
     let compact = executor
@@ -160,7 +165,7 @@ fn graph_executor_can_return_final_transpose_as_lazy_value() {
         TensorValue::Tensor(_) => panic!("final transpose should stay as a lazy owned view"),
     }
     assert_eq!(
-        values[0].to_tensor().as_slice::<f64>().unwrap(),
+        values[0].to_tensor().unwrap().as_slice::<f64>().unwrap(),
         &[2.0, 6.0, 10.0, 4.0, 8.0, 12.0]
     );
 }
@@ -170,15 +175,17 @@ fn graph_executor_public_helpers_and_borrowed_input_errors_are_covered() {
     let mut executor = GraphExecutor::<CpuBackend>::default();
     executor.extension_executor_mut().clear_caches();
     assert_eq!(executor.cache_stats().extensions.entries, 0);
-    executor.reclaim_outputs(vec![Tensor::from_vec_col_major(vec![1], vec![0.0_f64])]);
+    executor.reclaim_outputs(vec![
+        Tensor::from_vec_col_major(vec![1], vec![0.0_f64]).unwrap()
+    ]);
 
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let y = &x + &x;
+    let y = (&x + &x).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])
         .unwrap();
-    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
 
     let out = executor
         .run_with_input_reads(&program, &[(&x, TensorRead::from_tensor(&input))])
@@ -190,7 +197,7 @@ fn graph_executor_public_helpers_and_borrowed_input_errors_are_covered() {
         .unwrap_err();
     assert!(matches!(unbound, Error::UnboundPlaceholder { .. }));
 
-    let concrete = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let concrete = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let unexpected = executor
         .run_many_with_input_reads(&program, &[(&concrete, TensorRead::from_tensor(&input))])
         .unwrap_err();
@@ -207,19 +214,19 @@ fn graph_executor_public_helpers_and_borrowed_input_errors_are_covered() {
         .unwrap_err();
     assert!(matches!(duplicate, Error::DuplicateBinding { .. }));
 
-    let f32_input = Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]);
+    let f32_input = Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap();
     let dtype = executor
         .run_many_with_input_reads(&program, &[(&x, TensorRead::from_tensor(&f32_input))])
         .unwrap_err();
     assert!(matches!(dtype, Error::PlaceholderDtypeMismatch { .. }));
 
-    let rank_input = Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 2.0]);
+    let rank_input = Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 2.0]).unwrap();
     let rank = executor
         .run_many_with_input_reads(&program, &[(&x, TensorRead::from_tensor(&rank_input))])
         .unwrap_err();
     assert!(matches!(rank, Error::PlaceholderRankMismatch { .. }));
 
-    let shape_input = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    let shape_input = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
     let shape = executor
         .run_many_with_input_reads(&program, &[(&x, TensorRead::from_tensor(&shape_input))])
         .unwrap_err();

--- a/crates/tenferro-runtime/tests/typed_tensor_ops.rs
+++ b/crates/tenferro-runtime/tests/typed_tensor_ops.rs
@@ -15,26 +15,36 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
 #[test]
 fn typed_tensor_reduction_and_structural_wrappers_preserve_values() {
     let mut backend = CpuBackend::new();
-    let x = TypedTensor::<f64>::from_vec_row_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let x = TypedTensor::<f64>::from_vec_row_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
 
     let row_sums = typed_tensor::reduce_sum(&x, &[1], &mut backend).unwrap();
     assert_eq!(row_sums.shape(), &[2]);
-    assert_close(row_sums.host_data(), &[6.0, 15.0]);
+    assert_close(row_sums.host_data().unwrap(), &[6.0, 15.0]);
 
     let total = typed_tensor::reduce_sum(&x, &[0, 1], &mut backend).unwrap();
     assert_eq!(total.shape(), &[]);
-    assert_close(total.host_data(), &[21.0]);
+    assert_close(total.host_data().unwrap(), &[21.0]);
 
     let reshaped = typed_tensor::reshape(&x, &[3, 2], &mut backend).unwrap();
     assert_eq!(reshaped.shape(), &[3, 2]);
-    assert_close(reshaped.host_data(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    assert_close(
+        reshaped.host_data().unwrap(),
+        &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
+    );
 
     let transposed = typed_tensor::transpose(&x, &[1, 0], &mut backend).unwrap();
     assert_eq!(transposed.shape(), &[3, 2]);
-    assert_close(transposed.host_data(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    assert_close(
+        transposed.host_data().unwrap(),
+        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+    );
 
-    let row = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![10.0, 20.0, 30.0]);
+    let row = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![10.0, 20.0, 30.0]).unwrap();
     let broadcast = typed_tensor::broadcast_in_dim(&row, &[2, 3], &[1], &mut backend).unwrap();
     assert_eq!(broadcast.shape(), &[2, 3]);
-    assert_close(broadcast.host_data(), &[10.0, 10.0, 20.0, 20.0, 30.0, 30.0]);
+    assert_close(
+        broadcast.host_data().unwrap(),
+        &[10.0, 10.0, 20.0, 20.0, 30.0, 30.0],
+    );
 }

--- a/crates/tenferro-tensor-core/src/lib.rs
+++ b/crates/tenferro-tensor-core/src/lib.rs
@@ -903,21 +903,6 @@ impl<'a, T> HostTensorView<'a, T> {
         self.offset == 0 && self.is_compact_col_major()
     }
 
-    /// Alias for [`HostTensorView::is_compact_col_major`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor_core::HostTensor;
-    ///
-    /// let tensor = HostTensor::from_vec_col_major(vec![1], vec![1_i64])?;
-    /// assert!(tensor.as_view().is_contiguous_col_major());
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
-    /// ```
-    pub fn is_contiguous_col_major(&self) -> bool {
-        self.is_compact_col_major()
-    }
-
     /// Borrow the slice-contiguous backing region for this view.
     ///
     /// # Examples

--- a/crates/tenferro-tensor-core/tests/core.rs
+++ b/crates/tenferro-tensor-core/tests/core.rs
@@ -662,7 +662,7 @@ fn view_validation_reports_rank_permutation_and_slice_errors() {
 
     let tensor = HostTensor::from_vec_col_major(vec![2, 2], vec![1_i32, 2, 3, 4]).unwrap();
     let view = tensor.as_view();
-    assert!(view.is_contiguous_col_major());
+    assert!(view.is_compact_col_major());
     assert!(matches!(
         view.transpose_view(&[0]).unwrap_err(),
         Error::InvalidPermutationLength {

--- a/crates/tenferro-tensor/benches/element_access.rs
+++ b/crates/tenferro-tensor/benches/element_access.rs
@@ -6,13 +6,13 @@ const INDEX_COUNT: usize = 4096;
 fn typed_tensor<const R: usize>(shape: [usize; R]) -> TypedTensor<f64> {
     let len = shape.iter().product();
     let data = (0..len).map(|value| value as f64).collect();
-    TypedTensor::from_vec_col_major(shape.to_vec(), data)
+    TypedTensor::from_vec_col_major(shape.to_vec(), data).unwrap()
 }
 
 fn dynamic_tensor<const R: usize>(shape: [usize; R]) -> Tensor {
     let len = shape.iter().product();
     let data = (0..len).map(|value| value as f64).collect();
-    Tensor::from_vec_col_major(shape.to_vec(), data)
+    Tensor::from_vec_col_major(shape.to_vec(), data).unwrap()
 }
 
 fn index_workload<const R: usize>(shape: [usize; R]) -> Vec<[usize; R]> {
@@ -48,7 +48,7 @@ fn bench_rank<const R: usize>(c: &mut Criterion, name: &str, shape: [usize; R]) 
     let mut group = c.benchmark_group(format!("element_access/{name}/col_major"));
 
     group.bench_function(BenchmarkId::new("direct_slice", INDEX_COUNT), |b| {
-        let data = tensor.as_slice();
+        let data = tensor.as_slice().unwrap();
         b.iter(|| {
             let mut sum = 0.0;
             for &offset in &offsets {
@@ -62,7 +62,7 @@ fn bench_rank<const R: usize>(c: &mut Criterion, name: &str, shape: [usize; R]) 
         b.iter_batched(
             || tensor.clone(),
             |mut tensor| {
-                let data = tensor.host_data_mut();
+                let data = tensor.host_data_mut().unwrap();
                 for &offset in &offsets {
                     data[black_box(offset)] += black_box(1.0);
                 }
@@ -76,7 +76,7 @@ fn bench_rank<const R: usize>(c: &mut Criterion, name: &str, shape: [usize; R]) 
         b.iter(|| {
             let mut sum = 0usize;
             for index in &indices {
-                sum = sum.wrapping_add(tensor.linear_offset(black_box(index.as_slice())));
+                sum = sum.wrapping_add(tensor.linear_offset(black_box(index.as_slice())).unwrap());
             }
             black_box(sum)
         });
@@ -86,17 +86,7 @@ fn bench_rank<const R: usize>(c: &mut Criterion, name: &str, shape: [usize; R]) 
         b.iter(|| {
             let mut sum = 0.0;
             for index in &indices {
-                sum += *black_box(tensor.get(black_box(index.as_slice())));
-            }
-            black_box(sum)
-        });
-    });
-
-    group.bench_function(BenchmarkId::new("try_get", INDEX_COUNT), |b| {
-        b.iter(|| {
-            let mut sum = 0.0;
-            for index in &indices {
-                sum += *black_box(tensor.try_get(black_box(index.as_slice())).unwrap());
+                sum += *black_box(tensor.get(black_box(index.as_slice())).unwrap());
             }
             black_box(sum)
         });
@@ -106,7 +96,9 @@ fn bench_rank<const R: usize>(c: &mut Criterion, name: &str, shape: [usize; R]) 
         b.iter(|| {
             let mut sum = 0.0;
             for index in &indices {
-                sum += *black_box(unsafe { tensor.get_unchecked(black_box(index.as_slice())) });
+                sum += *black_box(unsafe {
+                    tensor.get_unchecked(black_box(index.as_slice())).unwrap()
+                });
             }
             black_box(sum)
         });
@@ -117,22 +109,9 @@ fn bench_rank<const R: usize>(c: &mut Criterion, name: &str, shape: [usize; R]) 
             || tensor.clone(),
             |mut tensor| {
                 for index in &indices {
-                    *tensor.get_mut(black_box(index.as_slice())) += black_box(1.0);
+                    *tensor.get_mut(black_box(index.as_slice())).unwrap() += black_box(1.0);
                 }
-                black_box(tensor.as_slice()[0])
-            },
-            BatchSize::SmallInput,
-        );
-    });
-
-    group.bench_function(BenchmarkId::new("try_get_mut", INDEX_COUNT), |b| {
-        b.iter_batched(
-            || tensor.clone(),
-            |mut tensor| {
-                for index in &indices {
-                    *tensor.try_get_mut(black_box(index.as_slice())).unwrap() += black_box(1.0);
-                }
-                black_box(tensor.as_slice()[0])
+                black_box(tensor.as_slice().unwrap()[0])
             },
             BatchSize::SmallInput,
         );
@@ -144,10 +123,12 @@ fn bench_rank<const R: usize>(c: &mut Criterion, name: &str, shape: [usize; R]) 
             |mut tensor| {
                 for index in &indices {
                     unsafe {
-                        *tensor.get_unchecked_mut(black_box(index.as_slice())) += black_box(1.0);
+                        *tensor
+                            .get_unchecked_mut(black_box(index.as_slice()))
+                            .unwrap() += black_box(1.0);
                     }
                 }
-                black_box(tensor.as_slice()[0])
+                black_box(tensor.as_slice().unwrap()[0])
             },
             BatchSize::SmallInput,
         );
@@ -175,7 +156,8 @@ fn bench_rank2_fixed(c: &mut Criterion) {
         b.iter(|| {
             let mut sum = 0usize;
             for [i, j] in &indices {
-                sum = sum.wrapping_add(tensor.linear_offset2(black_box(*i), black_box(*j)));
+                sum =
+                    sum.wrapping_add(tensor.linear_offset2(black_box(*i), black_box(*j)).unwrap());
             }
             black_box(sum)
         });
@@ -185,7 +167,7 @@ fn bench_rank2_fixed(c: &mut Criterion) {
         b.iter(|| {
             let mut sum = 0.0;
             for [i, j] in &indices {
-                sum += *black_box(tensor.get2(black_box(*i), black_box(*j)));
+                sum += *black_box(tensor.get2(black_box(*i), black_box(*j)).unwrap());
             }
             black_box(sum)
         });
@@ -196,9 +178,9 @@ fn bench_rank2_fixed(c: &mut Criterion) {
             || tensor.clone(),
             |mut tensor| {
                 for [i, j] in &indices {
-                    *tensor.get_mut2(black_box(*i), black_box(*j)) += black_box(1.0);
+                    *tensor.get_mut2(black_box(*i), black_box(*j)).unwrap() += black_box(1.0);
                 }
-                black_box(tensor.as_slice()[0])
+                black_box(tensor.as_slice().unwrap()[0])
             },
             BatchSize::SmallInput,
         );
@@ -217,11 +199,11 @@ fn bench_rank3_fixed(c: &mut Criterion) {
         b.iter(|| {
             let mut sum = 0usize;
             for [i, j, k] in &indices {
-                sum = sum.wrapping_add(tensor.linear_offset3(
-                    black_box(*i),
-                    black_box(*j),
-                    black_box(*k),
-                ));
+                sum = sum.wrapping_add(
+                    tensor
+                        .linear_offset3(black_box(*i), black_box(*j), black_box(*k))
+                        .unwrap(),
+                );
             }
             black_box(sum)
         });
@@ -231,7 +213,11 @@ fn bench_rank3_fixed(c: &mut Criterion) {
         b.iter(|| {
             let mut sum = 0.0;
             for [i, j, k] in &indices {
-                sum += *black_box(tensor.get3(black_box(*i), black_box(*j), black_box(*k)));
+                sum += *black_box(
+                    tensor
+                        .get3(black_box(*i), black_box(*j), black_box(*k))
+                        .unwrap(),
+                );
             }
             black_box(sum)
         });
@@ -242,9 +228,11 @@ fn bench_rank3_fixed(c: &mut Criterion) {
             || tensor.clone(),
             |mut tensor| {
                 for [i, j, k] in &indices {
-                    *tensor.get_mut3(black_box(*i), black_box(*j), black_box(*k)) += black_box(1.0);
+                    *tensor
+                        .get_mut3(black_box(*i), black_box(*j), black_box(*k))
+                        .unwrap() += black_box(1.0);
                 }
-                black_box(tensor.as_slice()[0])
+                black_box(tensor.as_slice().unwrap()[0])
             },
             BatchSize::SmallInput,
         );
@@ -263,6 +251,7 @@ fn bench_linear_iteration(c: &mut Criterion) {
         b.iter(|| {
             let sum = tensor
                 .as_slice()
+                .unwrap()
                 .iter()
                 .fold(0.0, |acc, value| acc + black_box(*value));
             black_box(sum)
@@ -273,6 +262,7 @@ fn bench_linear_iteration(c: &mut Criterion) {
         b.iter(|| {
             let sum = tensor
                 .iter()
+                .unwrap()
                 .fold(0.0, |acc, value| acc + black_box(*value));
             black_box(sum)
         });
@@ -292,10 +282,10 @@ fn bench_linear_iteration(c: &mut Criterion) {
         b.iter_batched(
             || tensor.clone(),
             |mut tensor| {
-                for value in tensor.iter_mut() {
+                for value in tensor.iter_mut().unwrap() {
                     *value += black_box(1.0);
                 }
-                black_box(tensor.as_slice()[0])
+                black_box(tensor.as_slice().unwrap()[0])
             },
             BatchSize::SmallInput,
         );

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -554,8 +554,8 @@ pub trait TensorDot: TensorElementwise {
         match (lhs.as_tensor(), rhs.as_tensor()) {
             (Some(lhs), Some(rhs)) => self.dot_general(lhs, rhs, config),
             _ => {
-                let lhs = lhs.try_to_tensor()?;
-                let rhs = rhs.try_to_tensor()?;
+                let lhs = lhs.to_tensor()?;
+                let rhs = rhs.to_tensor()?;
                 self.dot_general(&lhs, &rhs, config)
             }
         }
@@ -609,14 +609,14 @@ pub trait TensorDot: TensorElementwise {
         let lhs_ref = if let Some(tensor) = lhs.as_tensor() {
             tensor
         } else {
-            lhs_tmp = lhs.try_to_tensor()?;
+            lhs_tmp = lhs.to_tensor()?;
             &lhs_tmp
         };
         let rhs_tmp;
         let rhs_ref = if let Some(tensor) = rhs.as_tensor() {
             tensor
         } else {
-            rhs_tmp = rhs.try_to_tensor()?;
+            rhs_tmp = rhs.to_tensor()?;
             &rhs_tmp
         };
         self.dot_general_with_conj(lhs_ref, rhs_ref, config, lhs_conj, rhs_conj)
@@ -655,8 +655,8 @@ pub trait SessionCachedDot: TensorDot {
         match (lhs.as_tensor(), rhs.as_tensor()) {
             (Some(lhs), Some(rhs)) => self.dot_general_cached(cache_slot, lhs, rhs, config),
             _ => {
-                let lhs = lhs.try_to_tensor()?;
-                let rhs = rhs.try_to_tensor()?;
+                let lhs = lhs.to_tensor()?;
+                let rhs = rhs.to_tensor()?;
                 self.dot_general_cached(cache_slot, &lhs, &rhs, config)
             }
         }
@@ -697,14 +697,14 @@ pub trait SessionCachedDot: TensorDot {
         let lhs_ref = if let Some(tensor) = lhs.as_tensor() {
             tensor
         } else {
-            lhs_tmp = lhs.try_to_tensor()?;
+            lhs_tmp = lhs.to_tensor()?;
             &lhs_tmp
         };
         let rhs_tmp;
         let rhs_ref = if let Some(tensor) = rhs.as_tensor() {
             tensor
         } else {
-            rhs_tmp = rhs.try_to_tensor()?;
+            rhs_tmp = rhs.to_tensor()?;
             &rhs_tmp
         };
         self.dot_general_with_conj_cached(cache_slot, lhs_ref, rhs_ref, config, lhs_conj, rhs_conj)
@@ -917,8 +917,8 @@ pub trait BackendCachedDot: BackendRuntimeCache + TensorDot {
         match (lhs.as_tensor(), rhs.as_tensor()) {
             (Some(lhs), Some(rhs)) => self.dot_general_cached(cache, cache_slot, lhs, rhs, config),
             _ => {
-                let lhs = lhs.try_to_tensor()?;
-                let rhs = rhs.try_to_tensor()?;
+                let lhs = lhs.to_tensor()?;
+                let rhs = rhs.to_tensor()?;
                 self.dot_general_cached(cache, cache_slot, &lhs, &rhs, config)
             }
         }
@@ -961,14 +961,14 @@ pub trait BackendCachedDot: BackendRuntimeCache + TensorDot {
         let lhs_ref = if let Some(tensor) = lhs.as_tensor() {
             tensor
         } else {
-            lhs_tmp = lhs.try_to_tensor()?;
+            lhs_tmp = lhs.to_tensor()?;
             &lhs_tmp
         };
         let rhs_tmp;
         let rhs_ref = if let Some(tensor) = rhs.as_tensor() {
             tensor
         } else {
-            rhs_tmp = rhs.try_to_tensor()?;
+            rhs_tmp = rhs.to_tensor()?;
             &rhs_tmp
         };
         self.dot_general_with_conj_cached(

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -15,7 +15,7 @@ struct DefaultReadBackend {
 }
 
 fn marker() -> Tensor {
-    Tensor::from_vec_col_major(vec![1], vec![42.0_f64])
+    Tensor::from_vec_col_major(vec![1], vec![42.0_f64]).unwrap()
 }
 
 impl TensorElementwise for DefaultReadBackend {
@@ -318,10 +318,10 @@ impl TensorBackend for DefaultReadBackend {}
 
 #[test]
 fn default_read_methods_delegate_owned_tensors_and_reject_views() {
-    let a = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]);
-    let b = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]);
-    let pred = Tensor::from_vec_col_major(vec![1], vec![true]);
-    let view_source = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![3.0]);
+    let a = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
+    let pred = Tensor::from_vec_col_major(vec![1], vec![true]).unwrap();
+    let view_source = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![3.0]).unwrap();
     let mut backend = DefaultReadBackend::default();
 
     backend
@@ -465,7 +465,7 @@ fn default_read_methods_delegate_owned_tensors_and_reject_views() {
 
 #[test]
 fn tensor_index_select_builds_gather_config_and_validates_inputs() {
-    let input = Tensor::from_vec_col_major(vec![2, 3], vec![0.0_f64; 6]);
+    let input = Tensor::from_vec_col_major(vec![2, 3], vec![0.0_f64; 6]).unwrap();
     let mut backend = DefaultReadBackend::default();
 
     input.index_select(-1, &[2, 0], &mut backend).unwrap();
@@ -492,8 +492,8 @@ fn tensor_index_select_builds_gather_config_and_validates_inputs() {
 
 #[test]
 fn tensor_stack_reshapes_then_concatenates_and_validates_inputs() {
-    let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    let b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
+    let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
     let mut backend = DefaultReadBackend::default();
 
     Tensor::stack(&[&a, &b], -1, &mut backend).unwrap();
@@ -505,7 +505,7 @@ fn tensor_stack_reshapes_then_concatenates_and_validates_inputs() {
     let empty_err = Tensor::stack(&empty, 0, &mut backend).unwrap_err();
     assert!(empty_err.to_string().contains("at least one input"));
 
-    let c = Tensor::from_vec_col_major(vec![3], vec![0.0_f64; 3]);
+    let c = Tensor::from_vec_col_major(vec![3], vec![0.0_f64; 3]).unwrap();
     let shape_err = Tensor::stack(&[&a, &c], 0, &mut backend).unwrap_err();
     assert!(shape_err.to_string().contains("shape mismatch"));
 

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -1,13 +1,12 @@
-use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 use num_complex::{Complex32, Complex64};
 
 use crate::types::{
-    col_major_strides, flat_to_multi, materialize_typed_view_col_major, try_col_major_strides,
-    Buffer, BufferHandle, DType, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Rank,
-    StridedSliceSpec, Tensor, TensorBufferRef, TensorBufferRefMut, TensorLayout, TensorOwnedView,
-    TensorRank, TensorRead, TensorScalar, TensorValue, TensorView, TypedTensor, TypedTensorView,
+    col_major_strides, flat_to_multi, materialize_typed_view_col_major, Buffer, BufferHandle,
+    DType, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Rank, StridedSliceSpec,
+    Tensor, TensorBufferRef, TensorBufferRefMut, TensorLayout, TensorOwnedView, TensorRank,
+    TensorRead, TensorScalar, TensorValue, TensorView, TypedTensor, TypedTensorView,
     TypedTensorViewMut,
 };
 use crate::{Error, SliceConfig};
@@ -21,20 +20,17 @@ fn tensor_scalar_roundtrip<T>(shape: Vec<usize>, data: Vec<T>)
 where
     T: TensorScalar + PartialEq + std::fmt::Debug,
 {
-    let tensor = T::into_tensor(shape.clone(), data.clone());
+    let tensor = T::into_tensor(shape.clone(), data.clone()).unwrap();
 
     assert_eq!(tensor.shape(), shape.as_slice());
-    assert_eq!(T::try_as_slice(&tensor), Some(data.as_slice()));
-    assert_eq!(tensor.as_slice::<T>(), Some(data.as_slice()));
+    assert_eq!(T::as_slice(&tensor).unwrap(), data.as_slice());
+    assert_eq!(tensor.as_slice::<T>().unwrap(), data.as_slice());
 
     let mut mutable = tensor.clone();
-    assert_eq!(
-        T::try_as_slice_mut(&mut mutable).map(|slice| &*slice),
-        Some(data.as_slice())
-    );
+    assert_eq!(T::as_slice_mut(&mut mutable).unwrap(), data.as_slice());
 
-    let typed = T::try_into_typed(tensor).unwrap();
-    assert_eq!(typed.as_slice(), data.as_slice());
+    let typed = T::into_typed(tensor).unwrap();
+    assert_eq!(typed.as_slice().unwrap(), data.as_slice());
 }
 
 macro_rules! tensor_scalar_roundtrip_test {
@@ -48,36 +44,37 @@ macro_rules! tensor_scalar_roundtrip_test {
 
 #[test]
 fn tensor_scalar_tensor_read_covers_all_variants() {
-    let f64s = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![1.0]);
+    let f64s = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![1.0]).unwrap();
     assert_eq!(f64::tensor_read(&f64s).dtype(), DType::F64);
 
-    let f32s = TypedTensor::<f32>::from_vec_col_major(vec![1], vec![1.0]);
+    let f32s = TypedTensor::<f32>::from_vec_col_major(vec![1], vec![1.0]).unwrap();
     assert_eq!(f32::tensor_read(&f32s).dtype(), DType::F32);
 
-    let i64s = TypedTensor::<i64>::from_vec_col_major(vec![1], vec![1]);
+    let i64s = TypedTensor::<i64>::from_vec_col_major(vec![1], vec![1]).unwrap();
     assert_eq!(i64::tensor_read(&i64s).dtype(), DType::I64);
 
-    let i32s = TypedTensor::<i32>::from_vec_col_major(vec![1], vec![1]);
+    let i32s = TypedTensor::<i32>::from_vec_col_major(vec![1], vec![1]).unwrap();
     assert_eq!(i32::tensor_read(&i32s).dtype(), DType::I32);
 
-    let bools = TypedTensor::<bool>::from_vec_col_major(vec![1], vec![true]);
+    let bools = TypedTensor::<bool>::from_vec_col_major(vec![1], vec![true]).unwrap();
     assert_eq!(bool::tensor_read(&bools).dtype(), DType::Bool);
 
     let c64s =
-        TypedTensor::<Complex64>::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 2.0)]);
+        TypedTensor::<Complex64>::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 2.0)])
+            .unwrap();
     assert_eq!(Complex64::tensor_read(&c64s).dtype(), DType::C64);
 
     let c32s =
-        TypedTensor::<Complex32>::from_vec_col_major(vec![1], vec![Complex32::new(1.0, 2.0)]);
+        TypedTensor::<Complex32>::from_vec_col_major(vec![1], vec![Complex32::new(1.0, 2.0)])
+            .unwrap();
     assert_eq!(Complex32::tensor_read(&c32s).dtype(), DType::C32);
 }
 
 #[test]
 fn tensor_value_keeps_owned_transpose_as_view_until_materialized() {
-    let tensor = Arc::new(Tensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0],
-    ));
+    let tensor = Arc::new(
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap(),
+    );
     let value = TensorValue::from_tensor_arc(tensor);
     let transposed = value.transpose_view([1, 0]).unwrap();
 
@@ -87,7 +84,7 @@ fn tensor_value_keeps_owned_transpose_as_view_until_materialized() {
         TensorRead::Tensor(_) => panic!("owned transpose should be exposed as a view"),
     }
 
-    let materialized = transposed.to_tensor();
+    let materialized = transposed.to_tensor().unwrap();
     assert_eq!(materialized.shape(), &[3, 2]);
     assert_eq!(
         materialized.as_slice::<f64>().unwrap(),
@@ -97,10 +94,9 @@ fn tensor_value_keeps_owned_transpose_as_view_until_materialized() {
 
 #[test]
 fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
-    let base = Arc::new(Tensor::from_vec_col_major(
-        vec![2, 3],
-        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
-    ));
+    let base = Arc::new(
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
+    );
     let owned = TensorOwnedView::from_tensor(Arc::clone(&base));
 
     assert_eq!(owned.dtype(), DType::F64);
@@ -116,7 +112,7 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
         other => panic!("owned view should expose TensorRead::View, got {other:?}"),
     }
     assert_eq!(
-        owned.to_tensor().as_slice::<f64>().unwrap(),
+        owned.to_tensor().unwrap().as_slice::<f64>().unwrap(),
         &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     );
 
@@ -124,7 +120,7 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
         TensorOwnedView::from_parts(Arc::clone(&base), vec![3, 2], vec![2, 1], 0).unwrap();
     assert_eq!(explicit.shape(), &[3, 2]);
     assert_eq!(
-        explicit.to_tensor().as_slice::<f64>().unwrap(),
+        explicit.to_tensor().unwrap().as_slice::<f64>().unwrap(),
         &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
     );
 
@@ -144,7 +140,7 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
         .unwrap();
     assert_eq!(sliced.shape(), &[2, 2]);
     assert_eq!(
-        sliced.to_tensor().as_slice::<f64>().unwrap(),
+        sliced.to_tensor().unwrap().as_slice::<f64>().unwrap(),
         &[3.0, 4.0, 5.0, 6.0]
     );
 
@@ -182,7 +178,7 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
     assert_eq!(value.shape(), &[2, 3]);
     assert!(matches!(value.tensor_read(), TensorRead::Tensor(_)));
     assert_eq!(
-        value.to_tensor().as_slice::<f64>().unwrap(),
+        value.to_tensor().unwrap().as_slice::<f64>().unwrap(),
         &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
     );
 
@@ -204,6 +200,7 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
             })
             .unwrap()
             .to_tensor()
+            .unwrap()
             .as_slice::<f64>()
             .unwrap(),
         &[2.0, 4.0]
@@ -219,11 +216,11 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
 
 #[test]
 fn col_major_helpers_cover_scalar_and_higher_rank_shapes() {
-    assert_eq!(col_major_strides(&[]), Vec::<isize>::new());
-    assert_eq!(col_major_strides(&[2, 3, 4]), vec![1, 2, 6]);
-    assert_eq!(try_col_major_strides(&[2, 3, 4]).unwrap(), vec![1, 2, 6]);
+    assert_eq!(col_major_strides(&[]).unwrap(), Vec::<isize>::new());
+    assert_eq!(col_major_strides(&[2, 3, 4]).unwrap(), vec![1, 2, 6]);
+    assert_eq!(col_major_strides(&[2, 3, 4]).unwrap(), vec![1, 2, 6]);
     assert!(matches!(
-        try_col_major_strides(&[usize::MAX, 2]),
+        col_major_strides(&[usize::MAX, 2]),
         Err(Error::InvalidConfig { .. })
     ));
 
@@ -279,7 +276,7 @@ fn device_model_has_first_class_webgpu_backend_kind() {
 
 #[test]
 fn default_placement_is_unpinned_host_without_device() {
-    let tensor = TypedTensor::<f64>::zeros(vec![2]);
+    let tensor = TypedTensor::<f64>::zeros(vec![2]).unwrap();
 
     assert_eq!(tensor.placement().memory_kind, MemoryKind::UnpinnedHost);
     assert_eq!(tensor.placement().device, None);
@@ -304,19 +301,20 @@ fn gpu_placement_is_metadata_only() {
 
 #[test]
 fn typed_tensor_rank_zero_access_and_mutation_work() {
-    let mut tensor = TypedTensor::<f64>::from_vec_col_major(vec![], vec![7.0_f64]);
+    let mut tensor = TypedTensor::<f64>::from_vec_col_major(vec![], vec![7.0_f64]).unwrap();
 
     assert_eq!(tensor.n_elements(), 1);
-    assert_eq!(tensor.linear_offset(&[]), 0);
-    assert_eq!(*tensor.get(&[]), 7.0);
+    assert_eq!(tensor.linear_offset(&[]).unwrap(), 0);
+    assert_eq!(*tensor.get(&[]).unwrap(), 7.0);
 
-    *tensor.get_mut(&[]) = 9.5;
-    assert_eq!(tensor.host_data(), &[9.5]);
+    *tensor.get_mut(&[]).unwrap() = 9.5;
+    assert_eq!(tensor.host_data().unwrap(), &[9.5]);
 }
 
 #[test]
 fn typed_tensor_static_rank_constructs_compact_layout() {
-    let tensor = TypedTensor::<f64, Rank<2>>::from_vec_col_major([2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let tensor =
+        TypedTensor::<f64, Rank<2>>::from_vec_col_major([2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     assert_eq!(tensor.shape(), &[2, 2]);
     assert_eq!(tensor.layout().strides(), &[1, 2]);
     assert!(tensor.layout().is_compact_col_major());
@@ -324,7 +322,7 @@ fn typed_tensor_static_rank_constructs_compact_layout() {
 
 #[test]
 fn typed_tensor_try_into_rank_validates_rank() {
-    let tensor = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]);
+    let tensor = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]).unwrap();
 
     let err = tensor.try_into_rank::<3>().unwrap_err();
 
@@ -351,7 +349,8 @@ fn typed_tensor_try_into_rank_preserves_backend_buffer_and_placement() {
         vec![2, 3],
         Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(42, 6))),
         placement.clone(),
-    );
+    )
+    .unwrap();
 
     let ranked = tensor.try_into_rank::<2>().unwrap();
 
@@ -372,7 +371,8 @@ fn typed_tensor_try_into_rank_preserves_backend_buffer_and_placement() {
 
 #[test]
 fn typed_tensor_as_view_preserves_rank_and_layout() {
-    let tensor = TypedTensor::<f64, Rank<2>>::from_vec_col_major([2, 2], vec![1.0, 2.0, 3.0, 4.0]);
+    let tensor =
+        TypedTensor::<f64, Rank<2>>::from_vec_col_major([2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
     let view = tensor.as_view();
     assert_eq!(view.shape(), &[2, 2]);
     assert_eq!(view.strides(), &[1, 2]);
@@ -391,7 +391,8 @@ fn typed_tensor_view_backend_as_slice_returns_backend_failure() {
                 ordinal: 0,
             }),
         },
-    );
+    )
+    .unwrap();
 
     let err = tensor.as_view().as_slice().unwrap_err();
 
@@ -424,7 +425,8 @@ fn typed_tensor_view_as_slice_rejects_non_contiguous_layout() {
 
 #[test]
 fn typed_tensor_view_transpose_is_metadata_only() {
-    let tensor = TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 3], vec![1, 2, 3, 4, 5, 6]);
+    let tensor =
+        TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 3], vec![1, 2, 3, 4, 5, 6]).unwrap();
     let view = tensor.as_view().transpose_view([1, 0]).unwrap();
     assert_eq!(view.shape(), &[3, 2]);
     assert_eq!(view.strides(), &[2, 1]);
@@ -433,11 +435,12 @@ fn typed_tensor_view_transpose_is_metadata_only() {
 
 #[test]
 fn non_contiguous_host_view_to_contiguous_preserves_column_major_order() {
-    let tensor = TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 3], vec![1, 2, 3, 4, 5, 6]);
+    let tensor =
+        TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 3], vec![1, 2, 3, 4, 5, 6]).unwrap();
     let view = tensor.as_view().transpose_view([1, 0]).unwrap();
     let compact = view.to_contiguous().unwrap();
     assert_eq!(compact.shape(), &[3, 2]);
-    assert_eq!(compact.as_slice(), &[1, 3, 5, 2, 4, 6]);
+    assert_eq!(compact.as_slice().unwrap(), &[1, 3, 5, 2, 4, 6]);
 }
 
 #[test]
@@ -450,12 +453,13 @@ fn non_contiguous_host_view_to_contiguous_preserves_host_placement() {
         [2, 2],
         Buffer::Host(vec![1, 2, 3, 4]),
         placement.clone(),
-    );
+    )
+    .unwrap();
     let view = tensor.as_view().transpose_view([1, 0]).unwrap();
 
     let compact = view.to_contiguous().unwrap();
 
-    assert_eq!(compact.as_slice(), &[1, 3, 2, 4]);
+    assert_eq!(compact.as_slice().unwrap(), &[1, 3, 2, 4]);
     assert_eq!(compact.placement(), &placement);
 }
 
@@ -466,7 +470,7 @@ fn non_contiguous_host_view_to_contiguous_ignores_singleton_axis_stride_overflow
 
     let compact = view.to_contiguous().unwrap();
 
-    assert_eq!(compact.as_slice(), &[20]);
+    assert_eq!(compact.as_slice().unwrap(), &[20]);
 }
 
 #[test]
@@ -481,7 +485,8 @@ fn typed_tensor_view_backend_to_contiguous_returns_backend_failure() {
                 ordinal: 0,
             }),
         },
-    );
+    )
+    .unwrap();
 
     let err = tensor.as_view().to_contiguous().unwrap_err();
 
@@ -497,20 +502,22 @@ fn typed_tensor_view_backend_to_contiguous_returns_backend_failure() {
 
 #[test]
 fn mutable_host_copy_back_writes_strided_output() {
-    let mut tensor = TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 2], vec![0, 0, 0, 0]);
+    let mut tensor =
+        TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 2], vec![0, 0, 0, 0]).unwrap();
     {
         let mut out = tensor.as_view_mut().transpose_view([1, 0]).unwrap();
-        let scratch = TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 2], vec![1, 2, 3, 4]);
+        let scratch =
+            TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 2], vec![1, 2, 3, 4]).unwrap();
         out.copy_from_contiguous(&scratch).unwrap();
     }
-    assert_eq!(tensor.as_slice(), &[1, 3, 2, 4]);
+    assert_eq!(tensor.as_slice().unwrap(), &[1, 3, 2, 4]);
 }
 
 #[test]
 fn mutable_host_copy_back_ignores_singleton_axis_stride_overflow() {
     let mut data = vec![10_i32, 20];
     let mut view = TypedTensorViewMut::from_slice(vec![1], vec![isize::MAX], 1, &mut data).unwrap();
-    let scratch = TypedTensor::<i32>::from_vec_col_major(vec![1], vec![99]);
+    let scratch = TypedTensor::<i32>::from_vec_col_major(vec![1], vec![99]).unwrap();
 
     view.copy_from_contiguous(&scratch).unwrap();
 
@@ -519,8 +526,10 @@ fn mutable_host_copy_back_ignores_singleton_axis_stride_overflow() {
 
 #[test]
 fn mutable_host_copy_back_rejects_shape_mismatch() {
-    let mut tensor = TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 2], vec![0, 0, 0, 0]);
-    let scratch = TypedTensor::<i32, Rank<2>>::from_vec_col_major([4, 1], vec![1, 2, 3, 4]);
+    let mut tensor =
+        TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 2], vec![0, 0, 0, 0]).unwrap();
+    let scratch =
+        TypedTensor::<i32, Rank<2>>::from_vec_col_major([4, 1], vec![1, 2, 3, 4]).unwrap();
     let mut out = tensor.as_view_mut().transpose_view([1, 0]).unwrap();
 
     let err = out.copy_from_contiguous(&scratch).unwrap_err();
@@ -537,7 +546,7 @@ fn mutable_host_copy_back_rejects_shape_mismatch() {
 
 #[test]
 fn mutable_host_copy_back_rejects_backend_source() {
-    let mut tensor = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![0, 0]);
+    let mut tensor = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![0, 0]).unwrap();
     let scratch = TypedTensor::<i32>::from_buffer_col_major(
         vec![2],
         Buffer::Backend(Arc::new(BufferHandle::<i32>::new_with_len(79, 2))),
@@ -548,7 +557,8 @@ fn mutable_host_copy_back_rejects_backend_source() {
                 ordinal: 0,
             }),
         },
-    );
+    )
+    .unwrap();
     let mut out = tensor.as_view_mut();
 
     let err = out.copy_from_contiguous(&scratch).unwrap_err();
@@ -575,8 +585,9 @@ fn mutable_typed_tensor_view_backend_copy_from_contiguous_returns_backend_failur
                 ordinal: 0,
             }),
         },
-    );
-    let scratch = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]);
+    )
+    .unwrap();
+    let scratch = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]).unwrap();
     let mut out = tensor.as_view_mut();
 
     let err = out.copy_from_contiguous(&scratch).unwrap_err();
@@ -599,7 +610,7 @@ fn mutable_typed_tensor_view_rejects_overlapping_layout() {
 
 #[test]
 fn typed_tensor_owned_layout_is_always_compact() {
-    let tensor = TypedTensor::<i32>::from_vec_col_major(vec![3], vec![1, 2, 3]);
+    let tensor = TypedTensor::<i32>::from_vec_col_major(vec![3], vec![1, 2, 3]).unwrap();
     assert_eq!(
         tensor.layout(),
         &TensorLayout::compact(vec![3].into()).unwrap()
@@ -607,22 +618,21 @@ fn typed_tensor_owned_layout_is_always_compact() {
 }
 
 #[test]
-fn typed_tensor_backend_buffer_layout_length_mismatch_panics() {
-    let mismatched = catch_unwind(AssertUnwindSafe(|| {
-        TypedTensor::<f64>::from_buffer_col_major(
-            vec![1],
-            Buffer::Backend(Arc::new(BufferHandle::<f64>::new(9))),
-            Placement {
-                memory_kind: MemoryKind::Device,
-                device: Some(DeviceId {
-                    kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
-                    ordinal: 0,
-                }),
-            },
-        );
-    }));
+fn typed_tensor_backend_buffer_layout_length_mismatch_returns_error() {
+    let err = TypedTensor::<f64>::from_buffer_col_major(
+        vec![1],
+        Buffer::Backend(Arc::new(BufferHandle::<f64>::new(9))),
+        Placement {
+            memory_kind: MemoryKind::Device,
+            device: Some(DeviceId {
+                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+                ordinal: 0,
+            }),
+        },
+    )
+    .unwrap_err();
 
-    assert!(mismatched.is_err());
+    assert!(matches!(err, Error::InvalidConfig { .. }));
 }
 
 #[test]
@@ -642,9 +652,9 @@ fn typed_tensor_static_rank_shape_conversion_reports_rank_mismatch() {
 fn tensor_owned_export_returns_column_major_buffer() {
     let data = vec![1.0_f64, 2.0, 3.0, 4.0];
     let ptr = data.as_ptr();
-    let tensor = Tensor::from_vec_col_major(vec![2, 2], data);
+    let tensor = Tensor::from_vec_col_major(vec![2, 2], data).unwrap();
 
-    let (shape, out) = tensor.try_into_vec_col_major::<f64>().unwrap();
+    let (shape, out) = tensor.into_vec_col_major::<f64>().unwrap();
 
     assert_eq!(shape, vec![2, 2]);
     assert_eq!(out.as_ptr(), ptr);
@@ -653,7 +663,8 @@ fn tensor_owned_export_returns_column_major_buffer() {
 #[test]
 fn tensor_owned_export_reports_dtype_mismatch() {
     let err = Tensor::from_vec_col_major(vec![1], vec![1.0_f64])
-        .try_into_vec_col_major::<f32>()
+        .unwrap()
+        .into_vec_col_major::<f32>()
         .unwrap_err();
 
     assert!(matches!(err, Error::DTypeMismatch { .. }));
@@ -680,9 +691,10 @@ fn backend_buffer_handle_metadata_and_host_export_errors_are_explicit() {
                 ordinal: 0,
             }),
         },
-    );
-    let col_err = tensor.clone().try_into_vec_col_major().unwrap_err();
-    let row_err = tensor.try_into_vec_row_major().unwrap_err();
+    )
+    .unwrap();
+    let col_err = tensor.clone().into_vec_col_major().unwrap_err();
+    let row_err = tensor.into_vec_row_major().unwrap_err();
 
     assert!(matches!(col_err, Error::BackendFailure { .. }));
     assert!(col_err
@@ -715,43 +727,46 @@ fn tensor_buffer_refs_cover_backend_metadata() {
 #[test]
 fn typed_tensor_explicit_memory_order_constructors_match_logical_matrix() {
     let row =
-        TypedTensor::<f64>::from_vec_row_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        TypedTensor::<f64>::from_vec_row_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
     let col =
-        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0])
+            .unwrap();
 
     assert_eq!(row.shape(), &[2, 3]);
-    assert_eq!(row.as_slice(), col.as_slice());
-    assert_eq!(row.get(&[0, 0]), &1.0);
-    assert_eq!(row.get(&[1, 0]), &4.0);
-    assert_eq!(row.get(&[0, 2]), &3.0);
-    assert_eq!(row.get(&[1, 2]), &6.0);
+    assert_eq!(row.as_slice().unwrap(), col.as_slice().unwrap());
+    assert_eq!(row.get(&[0, 0]).unwrap(), &1.0);
+    assert_eq!(row.get(&[1, 0]).unwrap(), &4.0);
+    assert_eq!(row.get(&[0, 2]).unwrap(), &3.0);
+    assert_eq!(row.get(&[1, 2]).unwrap(), &6.0);
 }
 
 #[test]
 fn typed_tensor_explicit_memory_order_exports_requested_order() {
     let tensor =
-        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0])
+            .unwrap();
 
-    let (shape, col) = tensor.clone().try_into_vec_col_major().unwrap();
+    let (shape, col) = tensor.clone().into_vec_col_major().unwrap();
     assert_eq!(shape, vec![2, 3]);
     assert_eq!(col, vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
 
-    let (shape, row) = tensor.try_into_vec_row_major().unwrap();
+    let (shape, row) = tensor.into_vec_row_major().unwrap();
     assert_eq!(shape, vec![2, 3]);
     assert_eq!(row, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 }
 
 #[test]
 fn tensor_explicit_memory_order_roundtrips_dynamic_dtype() {
-    let tensor = Tensor::from_vec_row_major(vec![2, 2], vec![1_i64, 2, 3, 4]);
+    let tensor = Tensor::from_vec_row_major(vec![2, 2], vec![1_i64, 2, 3, 4]).unwrap();
 
     assert_eq!(tensor.as_slice::<i64>().unwrap(), &[1, 3, 2, 4]);
     assert_eq!(
-        tensor.clone().try_into_vec_col_major::<i64>().unwrap(),
+        tensor.clone().into_vec_col_major::<i64>().unwrap(),
         (vec![2, 2], vec![1, 3, 2, 4]),
     );
     assert_eq!(
-        tensor.try_into_vec_row_major::<i64>().unwrap(),
+        tensor.into_vec_row_major::<i64>().unwrap(),
         (vec![2, 2], vec![1, 2, 3, 4]),
     );
 }
@@ -759,108 +774,123 @@ fn tensor_explicit_memory_order_roundtrips_dynamic_dtype() {
 #[test]
 fn col_major_typed_tensor_uses_logical_indices() {
     let tensor =
-        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0])
+            .unwrap();
 
-    assert_eq!(*tensor.get(&[0, 2]), 3.0);
-    assert_eq!(*tensor.get(&[1, 0]), 4.0);
+    assert_eq!(*tensor.get(&[0, 2]).unwrap(), 3.0);
+    assert_eq!(*tensor.get(&[1, 0]).unwrap(), 4.0);
 }
 
 #[test]
 fn typed_tensor_linear_offsets_cover_higher_rank_shapes() {
-    let tensor = TypedTensor::<f64>::zeros(vec![2, 3, 5]);
+    let tensor = TypedTensor::<f64>::zeros(vec![2, 3, 5]).unwrap();
 
-    assert_eq!(tensor.linear_offset(&[1, 2, 4]), 1 + 2 * 2 + 4 * 2 * 3);
+    assert_eq!(
+        tensor.linear_offset(&[1, 2, 4]).unwrap(),
+        1 + 2 * 2 + 4 * 2 * 3
+    );
 }
 
 #[test]
 fn typed_tensor_iterators_follow_physical_buffer_order() {
     let tensor =
-        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0])
+            .unwrap();
     assert_eq!(
-        tensor.iter().copied().collect::<Vec<_>>(),
+        tensor.iter().unwrap().copied().collect::<Vec<_>>(),
         vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
     );
 
-    let mut tensor = TypedTensor::<i64>::from_vec_col_major(vec![3], vec![1_i64, 2, 3]);
-    for value in tensor.iter_mut() {
+    let mut tensor = TypedTensor::<i64>::from_vec_col_major(vec![3], vec![1_i64, 2, 3]).unwrap();
+    for value in tensor.iter_mut().unwrap() {
         *value *= 2;
     }
-    assert_eq!(tensor.as_slice(), &[2, 4, 6]);
+    assert_eq!(tensor.as_slice().unwrap(), &[2, 4, 6]);
 }
 
 #[test]
 fn tensor_iterators_are_typed_by_requested_scalar() {
-    let mut tensor = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
+    let mut tensor = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
 
     assert_eq!(
         tensor.iter::<f64>().unwrap().copied().collect::<Vec<_>>(),
         vec![1.0, 2.0, 3.0]
     );
-    assert!(tensor.iter::<f32>().is_none());
+    assert!(tensor.iter::<f32>().is_err());
 
     for value in tensor.iter_mut::<f64>().unwrap() {
         *value += 1.0;
     }
 
     assert_eq!(tensor.as_slice::<f64>().unwrap(), &[2.0, 3.0, 4.0]);
-    assert!(tensor.as_slice_mut::<f32>().is_none());
+    assert!(tensor.as_slice_mut::<f32>().is_err());
 }
 
 #[test]
 fn typed_tensor_checked_and_unchecked_accessors_work() {
     let mut tensor =
-        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0])
+            .unwrap();
 
-    assert_eq!(tensor.as_physical_slice(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
-    assert_eq!(tensor.try_get(&[1, 2]), Some(&6.0));
-    assert_eq!(tensor.try_get(&[2, 0]), None);
-    assert_eq!(tensor.try_get(&[0]), None);
+    assert_eq!(tensor.host_data().unwrap(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    assert_eq!(tensor.get(&[1, 2]).unwrap(), &6.0);
+    assert!(tensor.get(&[2, 0]).is_err());
+    assert!(tensor.get(&[0]).is_err());
 
-    *tensor.try_get_mut(&[0, 1]).unwrap() = 20.0;
-    assert_eq!(tensor.as_physical_slice()[2], 20.0);
+    *tensor.get_mut(&[0, 1]).unwrap() = 20.0;
+    assert_eq!(tensor.host_data().unwrap()[2], 20.0);
 
-    tensor.as_physical_slice_mut()[0] = 10.0;
-    assert_eq!(unsafe { *tensor.get_unchecked(&[0, 0]) }, 10.0);
+    tensor.host_data_mut().unwrap()[0] = 10.0;
+    assert_eq!(unsafe { *tensor.get_unchecked(&[0, 0]).unwrap() }, 10.0);
 
     unsafe {
-        *tensor.get_unchecked_mut(&[1, 0]) = 40.0;
+        *tensor.get_unchecked_mut(&[1, 0]).unwrap() = 40.0;
     }
-    assert_eq!(tensor.try_get(&[1, 0]), Some(&40.0));
+    assert_eq!(tensor.get(&[1, 0]).unwrap(), &40.0);
 }
 
 #[test]
 fn typed_tensor_rank_fixed_accessors_use_column_major_offsets() {
-    let mut col2 = TypedTensor::<i64>::from_vec_col_major(vec![2, 3], vec![1_i64, 2, 3, 4, 5, 6]);
+    let mut col2 =
+        TypedTensor::<i64>::from_vec_col_major(vec![2, 3], vec![1_i64, 2, 3, 4, 5, 6]).unwrap();
 
-    assert_eq!(col2.linear_offset2(1, 2), 5);
-    assert_eq!(*col2.get2(1, 2), 6);
-    *col2.get_mut2(0, 1) = 30;
-    assert_eq!(col2.as_physical_slice()[2], 30);
+    assert_eq!(col2.linear_offset2(1, 2).unwrap(), 5);
+    assert_eq!(*col2.get2(1, 2).unwrap(), 6);
+    *col2.get_mut2(0, 1).unwrap() = 30;
+    assert_eq!(col2.host_data().unwrap()[2], 30);
 
-    let mut col3 = TypedTensor::<i64>::from_vec_col_major(vec![2, 3, 2], (0_i64..12).collect());
+    let mut col3 =
+        TypedTensor::<i64>::from_vec_col_major(vec![2, 3, 2], (0_i64..12).collect()).unwrap();
 
-    assert_eq!(col3.linear_offset3(1, 2, 1), 11);
-    assert_eq!(*col3.get3(1, 2, 1), 11);
-    *col3.get_mut3(0, 1, 1) = 60;
-    assert_eq!(col3.as_physical_slice()[8], 60);
+    assert_eq!(col3.linear_offset3(1, 2, 1).unwrap(), 11);
+    assert_eq!(*col3.get3(1, 2, 1).unwrap(), 11);
+    *col3.get_mut3(0, 1, 1).unwrap() = 60;
+    assert_eq!(col3.host_data().unwrap()[8], 60);
 }
 
 #[test]
 fn tensor_checked_accessors_are_typed_and_use_physical_order() {
-    let mut tensor = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let mut tensor =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap();
 
     assert_eq!(
-        tensor.as_physical_slice::<f64>().unwrap(),
+        tensor.as_slice::<f64>().unwrap(),
         &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]
     );
-    assert_eq!(tensor.linear_offset(&[1, 0]), 1);
-    assert_eq!(tensor.linear_offset2(1, 0), 1);
-    assert_eq!(tensor.try_get::<f64>(&[1, 2]), Some(&6.0));
-    assert_eq!(tensor.try_get::<f32>(&[1, 2]), None);
-    assert_eq!(tensor.try_get::<f64>(&[2, 0]), None);
+    assert_eq!(tensor.linear_offset(&[1, 0]).unwrap(), 1);
+    assert_eq!(tensor.linear_offset2(1, 0).unwrap(), 1);
+    assert_eq!(tensor.get::<f64>(&[1, 2]).unwrap(), &6.0);
+    assert!(matches!(
+        tensor.get::<f32>(&[1, 2]),
+        Err(Error::DTypeMismatch { .. })
+    ));
+    assert!(matches!(
+        tensor.get::<f64>(&[2, 0]),
+        Err(Error::InvalidConfig { .. })
+    ));
 
-    tensor.as_physical_slice_mut::<f64>().unwrap()[0] = 10.0;
-    *tensor.try_get_mut::<f64>(&[0, 1]).unwrap() = 20.0;
+    tensor.as_slice_mut::<f64>().unwrap()[0] = 10.0;
+    *tensor.get_mut::<f64>(&[0, 1]).unwrap() = 20.0;
 
     assert_eq!(
         unsafe { *tensor.get_unchecked::<f64>(&[0, 0]).unwrap() },
@@ -871,99 +901,116 @@ fn tensor_checked_accessors_are_typed_and_use_physical_order() {
     }
 
     assert_eq!(
-        tensor.as_physical_slice::<f64>().unwrap(),
+        tensor.as_slice::<f64>().unwrap(),
         &[10.0, 40.0, 20.0, 5.0, 3.0, 6.0]
     );
 }
 
 #[test]
-fn typed_tensor_panics_cover_length_and_indexing_errors() {
-    let mismatched =
-        catch_unwind(|| TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0]));
-    assert!(mismatched.is_err());
-
-    let tensor = TypedTensor::<f64>::zeros(vec![2, 3]);
-    let rank_mismatch = catch_unwind(AssertUnwindSafe(|| tensor.linear_offset(&[0])));
-    assert!(rank_mismatch.is_err());
-
-    let oob = catch_unwind(AssertUnwindSafe(|| tensor.linear_offset(&[2, 0])));
-    assert!(oob.is_err());
-}
-
-#[test]
-fn typed_tensor_try_apis_report_shape_arithmetic_errors() {
+fn typed_tensor_accessors_report_length_and_indexing_errors() {
     assert!(matches!(
-        TypedTensor::<f64>::try_from_vec_col_major(vec![usize::MAX, 2], Vec::new()),
-        Err(Error::InvalidConfig { .. })
-    ));
-    assert!(matches!(
-        TypedTensor::<f64>::try_from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0]),
-        Err(Error::InvalidConfig { .. })
-    ));
-    assert!(matches!(
-        TypedTensor::<f64>::try_zeros(vec![usize::MAX, 2]),
-        Err(Error::InvalidConfig { .. })
-    ));
-    assert!(matches!(
-        TypedTensor::<f64>::try_ones(vec![usize::MAX, 2]),
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0]),
         Err(Error::InvalidConfig { .. })
     ));
 
-    let tensor = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]);
-    assert_eq!(tensor.try_n_elements().unwrap(), 6);
-    assert_eq!(tensor.try_linear_offset(&[1, 2]).unwrap(), 5);
+    let tensor = TypedTensor::<f64>::zeros(vec![2, 3]).unwrap();
     assert!(matches!(
-        tensor.try_linear_offset(&[2, 0]),
+        tensor.linear_offset(&[0]),
+        Err(Error::RankMismatch { .. })
+    ));
+
+    assert!(matches!(
+        tensor.linear_offset(&[2, 0]),
         Err(Error::InvalidConfig { .. })
     ));
 }
 
 #[test]
-fn tensor_try_constructors_report_shape_arithmetic_errors() {
+fn typed_tensor_apis_report_shape_arithmetic_errors() {
     assert!(matches!(
-        Tensor::try_from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0]),
+        TypedTensor::<f64>::from_vec_col_major(vec![usize::MAX, 2], Vec::new()),
         Err(Error::InvalidConfig { .. })
     ));
     assert!(matches!(
-        Tensor::try_from_vec_row_major(vec![usize::MAX, 2], Vec::<f64>::new()),
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0]),
         Err(Error::InvalidConfig { .. })
     ));
-}
-
-#[test]
-fn typed_tensor_ranked_try_accessors_return_none_instead_of_panicking() {
-    let tensor = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]);
-
-    assert_eq!(tensor.try_linear_offset2(1, 2), Some(5));
-    assert_eq!(tensor.try_linear_offset2(10, 0), None);
-    assert_eq!(tensor.try_get2(10, 0), None);
-
-    let rank3 = TypedTensor::<f64>::from_vec_col_major(vec![2, 3, 2], vec![0.0; 12]);
-    assert_eq!(rank3.try_linear_offset3(1, 2, 1), Some(11));
-    assert_eq!(rank3.try_linear_offset3(1, 2, 99), None);
-    assert_eq!(rank3.try_get3(1, 2, 99), None);
-}
-
-#[test]
-fn tensor_ranked_try_linear_offsets_return_errors_instead_of_panicking() {
-    let tensor = Tensor::from_vec_col_major(vec![2, 3], vec![0.0_f64; 6]);
-
-    assert_eq!(tensor.try_linear_offset2(1, 2).unwrap(), 5);
     assert!(matches!(
-        tensor.try_linear_offset2(10, 0),
+        TypedTensor::<f64>::zeros(vec![usize::MAX, 2]),
+        Err(Error::InvalidConfig { .. })
+    ));
+    assert!(matches!(
+        TypedTensor::<f64>::ones(vec![usize::MAX, 2]),
         Err(Error::InvalidConfig { .. })
     ));
 
-    let rank3 = Tensor::from_vec_col_major(vec![2, 3, 2], vec![0.0_f64; 12]);
-    assert_eq!(rank3.try_linear_offset3(1, 2, 1).unwrap(), 11);
+    let tensor = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]).unwrap();
+    assert_eq!(tensor.n_elements(), 6);
+    assert_eq!(tensor.linear_offset(&[1, 2]).unwrap(), 5);
     assert!(matches!(
-        rank3.try_linear_offset3(1, 2, 99),
+        tensor.linear_offset(&[2, 0]),
         Err(Error::InvalidConfig { .. })
     ));
 }
 
 #[test]
-fn backend_buffers_panic_when_host_access_is_requested() {
+fn tensor_constructors_report_shape_arithmetic_errors() {
+    assert!(matches!(
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0]),
+        Err(Error::InvalidConfig { .. })
+    ));
+    assert!(matches!(
+        Tensor::from_vec_row_major(vec![usize::MAX, 2], Vec::<f64>::new()),
+        Err(Error::InvalidConfig { .. })
+    ));
+}
+
+#[test]
+fn typed_tensor_ranked_accessors_return_errors_instead_of_panicking() {
+    let tensor = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]).unwrap();
+
+    assert_eq!(tensor.linear_offset2(1, 2).unwrap(), 5);
+    assert!(matches!(
+        tensor.linear_offset2(10, 0),
+        Err(Error::InvalidConfig { .. })
+    ));
+    assert!(matches!(
+        tensor.get2(10, 0),
+        Err(Error::InvalidConfig { .. })
+    ));
+
+    let rank3 = TypedTensor::<f64>::from_vec_col_major(vec![2, 3, 2], vec![0.0; 12]).unwrap();
+    assert_eq!(rank3.linear_offset3(1, 2, 1).unwrap(), 11);
+    assert!(matches!(
+        rank3.linear_offset3(1, 2, 99),
+        Err(Error::InvalidConfig { .. })
+    ));
+    assert!(matches!(
+        rank3.get3(1, 2, 99),
+        Err(Error::InvalidConfig { .. })
+    ));
+}
+
+#[test]
+fn tensor_ranked_linear_offsets_return_errors_instead_of_panicking() {
+    let tensor = Tensor::from_vec_col_major(vec![2, 3], vec![0.0_f64; 6]).unwrap();
+
+    assert_eq!(tensor.linear_offset2(1, 2).unwrap(), 5);
+    assert!(matches!(
+        tensor.linear_offset2(10, 0),
+        Err(Error::InvalidConfig { .. })
+    ));
+
+    let rank3 = Tensor::from_vec_col_major(vec![2, 3, 2], vec![0.0_f64; 12]).unwrap();
+    assert_eq!(rank3.linear_offset3(1, 2, 1).unwrap(), 11);
+    assert!(matches!(
+        rank3.linear_offset3(1, 2, 99),
+        Err(Error::InvalidConfig { .. })
+    ));
+}
+
+#[test]
+fn backend_buffers_return_errors_when_host_access_is_requested() {
     let placement = Placement {
         memory_kind: MemoryKind::Other("backend".to_string()),
         device: Some(DeviceId {
@@ -975,31 +1022,25 @@ fn backend_buffers_panic_when_host_access_is_requested() {
         vec![1],
         Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(7, 1))),
         placement.clone(),
-    );
+    )
+    .unwrap();
     assert_eq!(tensor.placement().device.as_ref().unwrap().ordinal, 0);
 
-    assert!(tensor.try_host_data().is_err());
+    assert!(tensor.host_data().is_err());
     let erased = Tensor::F64(tensor.clone());
-    assert_eq!(erased.as_slice::<f64>(), None);
-    assert_eq!(erased.try_get::<f64>(&[0]), None);
-
-    let host_data = catch_unwind(AssertUnwindSafe(|| tensor.host_data()));
-    assert!(host_data.is_err());
+    assert!(erased.as_slice::<f64>().is_err());
+    assert!(erased.get::<f64>(&[0]).is_err());
 
     let mut mutable_tensor = TypedTensor::<f64>::from_buffer_col_major(
         vec![1],
         Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(8, 1))),
         placement,
-    );
-    assert!(mutable_tensor.try_host_data_mut().is_err());
+    )
+    .unwrap();
+    assert!(mutable_tensor.host_data_mut().is_err());
     let mut erased_mut = Tensor::F64(mutable_tensor.clone());
-    assert_eq!(erased_mut.as_slice_mut::<f64>(), None);
-    assert_eq!(erased_mut.try_get_mut::<f64>(&[0]), None);
-
-    let host_data_mut = catch_unwind(AssertUnwindSafe(|| {
-        let _ = mutable_tensor.host_data_mut();
-    }));
-    assert!(host_data_mut.is_err());
+    assert!(erased_mut.as_slice_mut::<f64>().is_err());
+    assert!(erased_mut.get_mut::<f64>(&[0]).is_err());
 }
 
 #[test]
@@ -1014,7 +1055,8 @@ fn typed_tensor_metadata_accessors_accept_non_clone_elements() {
             9, 6,
         ))),
         placement,
-    );
+    )
+    .unwrap();
 
     assert_eq!(tensor.shape(), &[2, 3]);
     assert_eq!(tensor.rank(), 2);
@@ -1025,18 +1067,19 @@ fn typed_tensor_metadata_accessors_accept_non_clone_elements() {
 
 #[test]
 fn tensor_shape_and_dtype_cover_all_variants() {
-    let f32_tensor = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]));
-    let f64_tensor = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![3.0_f64]));
-    let i32_tensor = Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![1_i32, -2]));
-    let c32_tensor = Tensor::C32(TypedTensor::from_vec_col_major(
-        vec![1],
-        vec![Complex32::new(1.0, -2.0)],
-    ));
-    let c64_tensor = Tensor::C64(TypedTensor::from_vec_col_major(
-        vec![1, 1],
-        vec![Complex64::new(-3.0, 4.0)],
-    ));
-    let bool_tensor = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]));
+    let f32_tensor =
+        Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap());
+    let f64_tensor = Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap());
+    let i32_tensor =
+        Tensor::I32(TypedTensor::from_vec_col_major(vec![2], vec![1_i32, -2]).unwrap());
+    let c32_tensor = Tensor::C32(
+        TypedTensor::from_vec_col_major(vec![1], vec![Complex32::new(1.0, -2.0)]).unwrap(),
+    );
+    let c64_tensor = Tensor::C64(
+        TypedTensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(-3.0, 4.0)]).unwrap(),
+    );
+    let bool_tensor =
+        Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]).unwrap());
 
     assert_eq!(f32_tensor.shape(), &[2]);
     assert_eq!(f32_tensor.dtype(), DType::F32);
@@ -1098,7 +1141,7 @@ fn tensor_view_covers_dtype_shape_and_materialization() {
     for (view, dtype) in views.iter().zip(dtypes) {
         assert_eq!(view.dtype(), dtype);
         assert_eq!(view.shape(), &[2]);
-        let tensor = view.to_tensor();
+        let tensor = view.to_tensor().unwrap();
         assert_eq!(tensor.dtype(), dtype);
         assert_eq!(tensor.shape(), &[2]);
     }
@@ -1115,7 +1158,8 @@ fn typed_tensor_view_materializes_sliced_host_layouts() {
     assert_eq!(
         materialize_typed_view_col_major(&view, "test")
             .unwrap()
-            .as_slice(),
+            .as_slice()
+            .unwrap(),
         &[1, 4, 2, 5, 3, 6]
     );
 
@@ -1124,7 +1168,8 @@ fn typed_tensor_view_materializes_sliced_host_layouts() {
     assert_eq!(
         materialize_typed_view_col_major(&transposed, "test")
             .unwrap()
-            .as_slice(),
+            .as_slice()
+            .unwrap(),
         &[1, 2, 3, 4, 5, 6]
     );
 
@@ -1133,7 +1178,8 @@ fn typed_tensor_view_materializes_sliced_host_layouts() {
     assert_eq!(
         materialize_typed_view_col_major(&reversed_cols, "test")
             .unwrap()
-            .as_slice(),
+            .as_slice()
+            .unwrap(),
         &[3, 6, 2, 5, 1, 4]
     );
 
@@ -1143,7 +1189,8 @@ fn typed_tensor_view_materializes_sliced_host_layouts() {
     assert_eq!(
         materialize_typed_view_col_major(&every_other_col, "test")
             .unwrap()
-            .as_slice(),
+            .as_slice()
+            .unwrap(),
         &[1, 4, 3, 6]
     );
     assert!(view.try_reshape(&[6]).is_err());
@@ -1160,7 +1207,7 @@ fn tensor_view_covers_strided_i32_and_bool() {
         TensorView::I32(TypedTensorView::from_slice([2, 2], [2, 1], 0, &i32_data).unwrap());
     assert_eq!(i32_view.dtype(), DType::I32);
     assert_eq!(
-        i32_view.to_tensor().as_slice::<i32>().unwrap(),
+        i32_view.to_tensor().unwrap().as_slice::<i32>().unwrap(),
         &[1, 3, 2, 4]
     );
 
@@ -1169,7 +1216,7 @@ fn tensor_view_covers_strided_i32_and_bool() {
         TensorView::Bool(TypedTensorView::from_slice([3], [-1], 2, &bool_data).unwrap());
     assert_eq!(bool_view.dtype(), DType::Bool);
     assert_eq!(
-        bool_view.to_tensor().as_slice::<bool>().unwrap(),
+        bool_view.to_tensor().unwrap().as_slice::<bool>().unwrap(),
         &[true, true, false]
     );
 }
@@ -1201,7 +1248,7 @@ fn strided_tensor_view_mut_updates_sliced_host_layouts() {
     assert_eq!(view.get(&[0, 2]), Some(&30));
 
     let materialized = materialize_typed_view_col_major(&view.as_read_only(), "test").unwrap();
-    assert_eq!(materialized.as_slice(), &[1, 4, 2, 5, 30, 600]);
+    assert_eq!(materialized.as_slice().unwrap(), &[1, 4, 2, 5, 30, 600]);
 }
 
 #[test]
@@ -1219,7 +1266,7 @@ fn strided_tensor_view_mut_rejects_aliasing_layouts() {
     let mut data = [1_i32, 2, 3];
     let mut reversed = TypedTensorViewMut::from_slice([3], [-1], 2, &mut data).unwrap();
     *reversed.get_mut(&[2]).unwrap() = 10;
-    assert_eq!(reversed.as_physical_slice(), &[10, 2, 3]);
+    assert_eq!(reversed.as_physical_slice().unwrap(), &[10, 2, 3]);
 
     let mut data = [1_i32, 2];
     let singleton_zero_stride =
@@ -1242,7 +1289,7 @@ fn strided_tensor_view_mut_multi_slice_returns_option() {
         *left.get_mut(&[2]).unwrap() = 30;
         *right.get_mut(&[0]).unwrap() = 40;
     }
-    assert_eq!(view.as_physical_slice(), &[1, 2, 30, 40, 5, 6]);
+    assert_eq!(view.as_physical_slice().unwrap(), &[1, 2, 30, 40, 5, 6]);
 
     assert!(view
         .try_multi_slice_mut(
@@ -1267,7 +1314,8 @@ fn typed_tensor_view_mut_covers_i32_and_bool_strided_layouts() {
     assert_eq!(
         materialize_typed_view_col_major(&i32_view.as_read_only(), "test")
             .unwrap()
-            .as_slice(),
+            .as_slice()
+            .unwrap(),
         &[1, 3, 2, 40]
     );
 
@@ -1277,7 +1325,8 @@ fn typed_tensor_view_mut_covers_i32_and_bool_strided_layouts() {
     assert_eq!(
         materialize_typed_view_col_major(&bool_view.as_read_only(), "test")
             .unwrap()
-            .as_slice(),
+            .as_slice()
+            .unwrap(),
         &[true, true, true]
     );
 }
@@ -1314,7 +1363,8 @@ fn strided_tensor_view_validation_covers_error_edges() {
     assert_eq!(
         materialize_typed_view_col_major(&empty, "test")
             .unwrap()
-            .as_slice(),
+            .as_slice()
+            .unwrap(),
         &[] as &[i32]
     );
     assert_eq!(empty.get(&[0, 0]), None);
@@ -1337,9 +1387,9 @@ fn strided_tensor_view_validation_covers_error_edges() {
     ));
 
     let view = TypedTensorView::from_slice([3], [1], 0, &data).unwrap();
-    assert_eq!(view.try_get(&[1]), Some(&2));
-    assert_eq!(view.try_linear_offset(&[0, 0]), None);
-    assert_eq!(view.try_linear_offset(&[3]), None);
+    assert_eq!(view.get(&[1]), Some(&2));
+    assert_eq!(view.linear_offset(&[0, 0]), None);
+    assert_eq!(view.linear_offset(&[3]), None);
 
     assert!(matches!(
         TypedTensorView::<i32>::from_slice([usize::MAX, 2], [1, 1], 0, &[]),
@@ -1404,7 +1454,8 @@ fn typed_tensor_view_slice_transpose_and_reshape_cover_boundaries() {
     assert_eq!(
         materialize_typed_view_col_major(&empty, "test")
             .unwrap()
-            .as_slice(),
+            .as_slice()
+            .unwrap(),
         &[] as &[i32]
     );
 
@@ -1440,7 +1491,7 @@ fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cas
         *high.get_mut(&[0]).unwrap() = 40;
         *low.get_mut(&[1]).unwrap() = 20;
     }
-    assert_eq!(view.as_physical_slice(), &[0, 1, 20, 3, 40, 5]);
+    assert_eq!(view.as_physical_slice().unwrap(), &[0, 1, 20, 3, 40, 5]);
 
     let mut data = [0_i32, 1, 2, 3];
     let mut view = TypedTensorViewMut::from_slice([4], [1], 0, &mut data).unwrap();
@@ -1454,7 +1505,7 @@ fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cas
         assert_eq!(empty.n_elements(), 0);
         *right.get_mut(&[0]).unwrap() = 20;
     }
-    assert_eq!(view.as_physical_slice(), &[0, 1, 20, 3]);
+    assert_eq!(view.as_physical_slice().unwrap(), &[0, 1, 20, 3]);
 
     let mut data = [0_i32, 1, 2, 3];
     let mut view = TypedTensorViewMut::from_slice([4], [1], 0, &mut data).unwrap();
@@ -1468,7 +1519,7 @@ fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cas
         assert_eq!(empty.n_elements(), 0);
         *left.get_mut(&[1]).unwrap() = 10;
     }
-    assert_eq!(view.as_physical_slice(), &[0, 10, 2, 3]);
+    assert_eq!(view.as_physical_slice().unwrap(), &[0, 10, 2, 3]);
 
     let mut data = [0_i32, 1, 2, 3];
     let mut view = TypedTensorViewMut::from_slice([4], [1], 0, &mut data).unwrap();
@@ -1494,7 +1545,7 @@ fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cas
         *reversed_high.get_mut(&[2]).unwrap() = 30;
         *low.get_mut(&[2]).unwrap() = 20;
     }
-    assert_eq!(view.as_physical_slice(), &[0, 1, 20, 30, 4, 5]);
+    assert_eq!(view.as_physical_slice().unwrap(), &[0, 1, 20, 30, 4, 5]);
 
     let mut data = [0_i32, 1, 2, 3, 4, 5];
     let mut view = TypedTensorViewMut::from_slice([6], [1], 0, &mut data).unwrap();
@@ -1508,14 +1559,14 @@ fn strided_tensor_view_mut_multi_slice_covers_empty_reverse_and_conservative_cas
 
 #[test]
 fn tensor_read_wraps_owned_tensor_or_borrowed_view() {
-    let tensor = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
+    let tensor = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
     let read_tensor = TensorRead::from_tensor(&tensor);
 
     assert_eq!(read_tensor.dtype(), DType::F64);
     assert_eq!(read_tensor.shape(), &[2]);
     assert!(read_tensor.as_tensor().is_some());
     assert_eq!(
-        read_tensor.to_tensor().as_slice::<f64>().unwrap(),
+        read_tensor.to_tensor().unwrap().as_slice::<f64>().unwrap(),
         &[3.0, 4.0]
     );
 
@@ -1527,7 +1578,7 @@ fn tensor_read_wraps_owned_tensor_or_borrowed_view() {
     assert_eq!(read_view.shape(), &[2]);
     assert!(read_view.as_tensor().is_none());
     assert_eq!(
-        read_view.to_tensor().as_slice::<f64>().unwrap(),
+        read_view.to_tensor().unwrap().as_slice::<f64>().unwrap(),
         &[5.0, 6.0]
     );
 }
@@ -1583,9 +1634,9 @@ tensor_scalar_roundtrip_test!(
 
 #[test]
 fn tensor_as_slice_returns_none_for_dtype_mismatch() {
-    let tensor = <f64 as TensorScalar>::into_tensor(vec![2], vec![1.0, 2.0]);
+    let tensor = <f64 as TensorScalar>::into_tensor(vec![2], vec![1.0, 2.0]).unwrap();
 
-    assert_eq!(tensor.as_slice::<f32>(), None);
+    assert!(tensor.as_slice::<f32>().is_err());
 }
 
 #[test]

--- a/crates/tenferro-tensor/src/tests/types_tests/strided_dynamic.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests/strided_dynamic.rs
@@ -10,7 +10,7 @@ fn tensor_view_covers_all_dtype_variants() {
             assert_eq!(view.dtype(), $dtype);
             assert_eq!(view.shape(), &[2, 2]);
             assert_eq!(
-                view.to_tensor().as_slice::<$ty>().unwrap(),
+                view.to_tensor().unwrap().as_slice::<$ty>().unwrap(),
                 &[$a, $c, $b, $d]
             );
         }};
@@ -60,11 +60,12 @@ fn typed_tensor_view_mut_covers_all_dtype_variants() {
             assert_eq!(view.shape(), &[2, 2]);
             assert_eq!(view.strides(), &[2, 1]);
             assert_eq!(view.offset(), 0);
-            *view.try_get_mut(&[1, 1]).unwrap() = $replacement;
+            *view.get_mut(&[1, 1]).unwrap() = $replacement;
             assert_eq!(
                 materialize_typed_view_col_major(&view.as_read_only(), "test")
                     .unwrap()
-                    .as_slice(),
+                    .as_slice()
+                    .unwrap(),
                 &[$a, $c, $b, $replacement]
             );
             let read = TensorView::$variant(view.as_read_only());
@@ -127,7 +128,8 @@ fn typed_tensor_view_mut_multi_slice_covers_all_dtype_variants() {
             assert_eq!(
                 materialize_typed_view_col_major(&view.as_read_only(), "test")
                     .unwrap()
-                    .as_slice(),
+                    .as_slice()
+                    .unwrap(),
                 &[$a, $left, $right, $d]
             );
         }};

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -85,9 +85,6 @@ pub struct DeviceId {
     pub ordinal: usize,
 }
 
-/// Backwards-compatible internal alias during the crate-boundary migration.
-pub type ComputeDevice = DeviceId;
-
 /// Placement metadata for a tensor buffer.
 ///
 /// # Examples
@@ -610,13 +607,16 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     ///
     /// let data = [1_i32, 2];
     /// let view = TypedTensorView::from_slice(vec![2], vec![1], 0, &data)?;
-    /// assert_eq!(view.as_physical_slice(), &[1, 2]);
+    /// assert_eq!(view.as_physical_slice()?, &[1, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn as_physical_slice(&self) -> &'a [T] {
+    pub fn as_physical_slice(&self) -> crate::Result<&'a [T]> {
         match &self.buffer {
-            TensorBufferRef::Host(data) => data,
-            TensorBufferRef::Backend(_) => panic!("as_physical_slice called on backend buffer"),
+            TensorBufferRef::Host(data) => Ok(data),
+            TensorBufferRef::Backend(_) => Err(crate::Error::backend_failure(
+                "TypedTensorView::as_physical_slice",
+                "backend buffers cannot be inspected as host slices; download explicitly first",
+            )),
         }
     }
 
@@ -630,16 +630,11 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// let data = [0_i32; 6];
     /// let view = TypedTensorView::from_slice(vec![2, 3], vec![1, 2], 0, &data)?;
     /// assert_eq!(view.n_elements(), 6);
-    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     pub fn n_elements(&self) -> usize {
-        // Compatibility panic wrapper; use `try_n_elements` for untrusted
-        // view metadata.
-        self.try_n_elements().unwrap_or_else(|err| panic!("{err}"))
-    }
-
-    pub fn try_n_elements(&self) -> crate::Result<usize> {
-        try_shape_product(self.shape(), "TypedTensorView::try_n_elements")
+        // Invariant: public view constructors validate logical element count.
+        checked_view_element_count(self.shape(), "TypedTensorView::n_elements")
+            .expect("TypedTensorView layout shape was validated at construction")
     }
 
     /// Return layout metadata for this view.
@@ -692,10 +687,10 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     ///
     /// let data = [1_i32, 2, 3];
     /// let view = TypedTensorView::from_slice(vec![3], vec![-1], 2, &data)?;
-    /// assert_eq!(view.try_linear_offset(&[2]), Some(0));
+    /// assert_eq!(view.linear_offset(&[2]), Some(0));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn try_linear_offset(&self, indices: &[usize]) -> Option<usize> {
+    pub fn linear_offset(&self, indices: &[usize]) -> Option<usize> {
         checked_view_offset(self.shape(), self.strides(), self.offset(), indices)
     }
 
@@ -714,27 +709,11 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     pub fn get(&self, indices: &[usize]) -> Option<&T> {
-        let offset = self.try_linear_offset(indices)?;
+        let offset = self.linear_offset(indices)?;
         match &self.buffer {
             TensorBufferRef::Host(data) => data.get(offset),
             TensorBufferRef::Backend(_) => None,
         }
-    }
-
-    /// Explicit alias for [`TypedTensorView::get`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor::TypedTensorView;
-    ///
-    /// let data = [1_i32];
-    /// let view = TypedTensorView::from_slice(vec![1], vec![1], 0, &data)?;
-    /// assert_eq!(view.try_get(&[0]), Some(&1));
-    /// # Ok::<(), tenferro_tensor::Error>(())
-    /// ```
-    pub fn try_get(&self, indices: &[usize]) -> Option<&T> {
-        self.get(indices)
     }
 
     /// Borrow the contiguous host slice covered by this view.
@@ -796,11 +775,7 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
         )?;
         let shape = R::shape_from_vec(self.shape().to_vec().into())
             .map_err(|err| tensor_layout_error(op, err))?;
-        Ok(TypedTensor::from_buffer_col_major(
-            shape,
-            Buffer::Host(data),
-            self.placement.clone(),
-        ))
+        TypedTensor::from_buffer_col_major(shape, Buffer::Host(data), self.placement.clone())
     }
 
     /// Return a metadata-only axis permutation.
@@ -1085,13 +1060,16 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     ///
     /// let mut data = [1_i32, 2];
     /// let view = TypedTensorViewMut::from_slice(vec![2], vec![1], 0, &mut data)?;
-    /// assert_eq!(view.as_physical_slice(), &[1, 2]);
+    /// assert_eq!(view.as_physical_slice()?, &[1, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn as_physical_slice(&self) -> &[T] {
+    pub fn as_physical_slice(&self) -> crate::Result<&[T]> {
         match &self.buffer {
-            TensorBufferRefMut::Host(data) => data,
-            TensorBufferRefMut::Backend(_) => panic!("as_physical_slice called on backend buffer"),
+            TensorBufferRefMut::Host(data) => Ok(data),
+            TensorBufferRefMut::Backend(_) => Err(crate::Error::backend_failure(
+                "TypedTensorViewMut::as_physical_slice",
+                "backend buffers cannot be inspected as host slices; download explicitly first",
+            )),
         }
     }
 
@@ -1104,16 +1082,17 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     ///
     /// let mut data = [1_i32, 2];
     /// let mut view = TypedTensorViewMut::from_slice(vec![2], vec![1], 0, &mut data)?;
-    /// view.as_physical_slice_mut()[0] = 3;
+    /// view.as_physical_slice_mut()?[0] = 3;
     /// assert_eq!(view.get(&[0]), Some(&3));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn as_physical_slice_mut(&mut self) -> &mut [T] {
+    pub fn as_physical_slice_mut(&mut self) -> crate::Result<&mut [T]> {
         match &mut self.buffer {
-            TensorBufferRefMut::Host(data) => data,
-            TensorBufferRefMut::Backend(_) => {
-                panic!("as_physical_slice_mut called on backend buffer")
-            }
+            TensorBufferRefMut::Host(data) => Ok(data),
+            TensorBufferRefMut::Backend(_) => Err(crate::Error::backend_failure(
+                "TypedTensorViewMut::as_physical_slice_mut",
+                "backend buffers cannot be mutated as host slices; download explicitly first",
+            )),
         }
     }
 
@@ -1127,16 +1106,11 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// let mut data = [0_i32; 6];
     /// let view = TypedTensorViewMut::from_slice(vec![2, 3], vec![1, 2], 0, &mut data)?;
     /// assert_eq!(view.n_elements(), 6);
-    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     pub fn n_elements(&self) -> usize {
-        // Compatibility panic wrapper; use `try_n_elements` for untrusted
-        // view metadata.
-        self.try_n_elements().unwrap_or_else(|err| panic!("{err}"))
-    }
-
-    pub fn try_n_elements(&self) -> crate::Result<usize> {
-        try_shape_product(self.shape(), "TypedTensorViewMut::try_n_elements")
+        // Invariant: public mutable view constructors validate logical element count.
+        checked_view_element_count(self.shape(), "TypedTensorViewMut::n_elements")
+            .expect("TypedTensorViewMut layout shape was validated at construction")
     }
 
     /// Return layout metadata for this view.
@@ -1189,10 +1163,10 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     ///
     /// let mut data = [1_i32, 2, 3];
     /// let view = TypedTensorViewMut::from_slice(vec![3], vec![-1], 2, &mut data)?;
-    /// assert_eq!(view.try_linear_offset(&[2]), Some(0));
+    /// assert_eq!(view.linear_offset(&[2]), Some(0));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn try_linear_offset(&self, indices: &[usize]) -> Option<usize> {
+    pub fn linear_offset(&self, indices: &[usize]) -> Option<usize> {
         checked_view_offset(self.shape(), self.strides(), self.offset(), indices)
     }
 
@@ -1209,7 +1183,7 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     pub fn get(&self, indices: &[usize]) -> Option<&T> {
-        let offset = self.try_linear_offset(indices)?;
+        let offset = self.linear_offset(indices)?;
         match &self.buffer {
             TensorBufferRefMut::Host(data) => data.get(offset),
             TensorBufferRefMut::Backend(_) => None,
@@ -1230,44 +1204,11 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     pub fn get_mut(&mut self, indices: &[usize]) -> Option<&mut T> {
-        let offset = self.try_linear_offset(indices)?;
+        let offset = self.linear_offset(indices)?;
         match &mut self.buffer {
             TensorBufferRefMut::Host(data) => data.get_mut(offset),
             TensorBufferRefMut::Backend(_) => None,
         }
-    }
-
-    /// Explicit alias for [`TypedTensorViewMut::get`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor::TypedTensorViewMut;
-    ///
-    /// let mut data = [1_i32];
-    /// let view = TypedTensorViewMut::from_slice(vec![1], vec![1], 0, &mut data)?;
-    /// assert_eq!(view.try_get(&[0]), Some(&1));
-    /// # Ok::<(), tenferro_tensor::Error>(())
-    /// ```
-    pub fn try_get(&self, indices: &[usize]) -> Option<&T> {
-        self.get(indices)
-    }
-
-    /// Explicit alias for [`TypedTensorViewMut::get_mut`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor::TypedTensorViewMut;
-    ///
-    /// let mut data = [1_i32];
-    /// let mut view = TypedTensorViewMut::from_slice(vec![1], vec![1], 0, &mut data)?;
-    /// *view.try_get_mut(&[0]).unwrap() = 2;
-    /// assert_eq!(view.get(&[0]), Some(&2));
-    /// # Ok::<(), tenferro_tensor::Error>(())
-    /// ```
-    pub fn try_get_mut(&mut self, indices: &[usize]) -> Option<&mut T> {
-        self.get_mut(indices)
     }
 
     /// Copy compact column-major host tensor values into this mutable view.
@@ -1723,8 +1664,9 @@ pub enum DType {
 /// ```
 /// use tenferro_tensor::TensorScalar;
 ///
-/// let tensor = <f64 as TensorScalar>::into_tensor(vec![2], vec![1.0, 2.0]);
-/// assert_eq!(tensor.as_slice::<f64>(), Some([1.0, 2.0].as_slice()));
+/// let tensor = <f64 as TensorScalar>::into_tensor(vec![2], vec![1.0, 2.0])?;
+/// assert_eq!(tensor.as_slice::<f64>()?, [1.0, 2.0].as_slice());
+/// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
 pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// Real-valued counterpart of this scalar type.
@@ -1743,7 +1685,7 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     fn dtype() -> DType;
 
     /// Wrap typed column-major data into a [`Tensor`] enum variant.
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor;
+    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> crate::Result<Tensor>;
 
     /// Borrow a typed tensor as a dtype-erased [`TensorRead`] view.
     ///
@@ -1762,38 +1704,38 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// ```
     fn tensor_read(tensor: &TypedTensor<Self>) -> TensorRead<'_>;
 
-    /// Try to borrow the host data from a [`Tensor`].
-    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]>;
+    /// Borrow the host data from a [`Tensor`].
+    fn as_slice(tensor: &Tensor) -> crate::Result<&[Self]>;
 
-    /// Try to mutably borrow the host data from a [`Tensor`].
+    /// Mutably borrow the host data from a [`Tensor`].
     ///
     /// # Examples
     ///
     /// ```
     /// use tenferro_tensor::{Tensor, TensorScalar};
     ///
-    /// let mut tensor = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]);
-    /// <f64 as TensorScalar>::try_as_slice_mut(&mut tensor).unwrap()[0] = 3.0;
+    /// let mut tensor = Tensor::from_vec_col_major(vec![1], vec![2.0_f64])?;
+    /// <f64 as TensorScalar>::as_slice_mut(&mut tensor)?[0] = 3.0;
     ///
-    /// assert_eq!(tensor.as_slice::<f64>().unwrap(), &[3.0]);
+    /// assert_eq!(tensor.as_slice::<f64>()?, &[3.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]>;
+    fn as_slice_mut(tensor: &mut Tensor) -> crate::Result<&mut [Self]>;
 
-    /// Try to extract a [`TypedTensor<Self>`] from a dynamic [`Tensor`].
-    ///
-    /// Returns `None` if the tensor dtype does not match `Self`.
+    /// Extract a [`TypedTensor<Self>`] from a dynamic [`Tensor`].
     ///
     /// # Examples
     ///
     /// ```
     /// use tenferro_tensor::{Tensor, TensorScalar};
     ///
-    /// let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    /// let typed = <f64 as TensorScalar>::try_into_typed(tensor).unwrap();
+    /// let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
+    /// let typed = <f64 as TensorScalar>::into_typed(tensor)?;
     ///
-    /// assert_eq!(typed.as_slice(), &[1.0, 2.0]);
+    /// assert_eq!(typed.as_slice()?, &[1.0, 2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>>;
+    fn into_typed(tensor: Tensor) -> crate::Result<TypedTensor<Self>>;
 }
 
 mod private {
@@ -1808,264 +1750,69 @@ mod private {
     impl Sealed for num_complex::Complex32 {}
 }
 
-impl TensorScalar for f64 {
-    type Real = f64;
+macro_rules! impl_tensor_scalar {
+    ($ty:ty, $real:ty, $dtype:ident, $variant:ident) => {
+        impl TensorScalar for $ty {
+            type Real = $real;
 
-    fn dtype() -> DType {
-        DType::F64
-    }
+            fn dtype() -> DType {
+                DType::$dtype
+            }
 
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Tensor::F64(TypedTensor::from_vec_col_major(shape, data))
-    }
+            fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> crate::Result<Tensor> {
+                TypedTensor::from_vec_col_major(shape, data).map(Tensor::$variant)
+            }
 
-    fn tensor_read(tensor: &TypedTensor<Self>) -> TensorRead<'_> {
-        TensorRead::from_view(TensorView::F64(tensor.as_view()))
-    }
+            fn tensor_read(tensor: &TypedTensor<Self>) -> TensorRead<'_> {
+                TensorRead::from_view(TensorView::$variant(tensor.as_view()))
+            }
 
-    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
-        match tensor {
-            Tensor::F64(t) => t.try_host_data().ok(),
-            _ => None,
+            fn as_slice(tensor: &Tensor) -> crate::Result<&[Self]> {
+                let actual = tensor.dtype();
+                match tensor {
+                    Tensor::$variant(t) => t.host_data(),
+                    _ => Err(crate::Error::DTypeMismatch {
+                        op: "Tensor::as_slice",
+                        lhs: Self::dtype(),
+                        rhs: actual,
+                    }),
+                }
+            }
+
+            fn as_slice_mut(tensor: &mut Tensor) -> crate::Result<&mut [Self]> {
+                let actual = tensor.dtype();
+                match tensor {
+                    Tensor::$variant(t) => t.host_data_mut(),
+                    _ => Err(crate::Error::DTypeMismatch {
+                        op: "Tensor::as_slice_mut",
+                        lhs: Self::dtype(),
+                        rhs: actual,
+                    }),
+                }
+            }
+
+            fn into_typed(tensor: Tensor) -> crate::Result<TypedTensor<Self>> {
+                let actual = tensor.dtype();
+                match tensor {
+                    Tensor::$variant(inner) => Ok(inner),
+                    _ => Err(crate::Error::DTypeMismatch {
+                        op: "TensorScalar::into_typed",
+                        lhs: Self::dtype(),
+                        rhs: actual,
+                    }),
+                }
+            }
         }
-    }
-
-    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
-        match tensor {
-            Tensor::F64(t) => t.try_host_data_mut().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
-        match tensor {
-            Tensor::F64(inner) => Some(inner),
-            _ => None,
-        }
-    }
+    };
 }
 
-impl TensorScalar for f32 {
-    type Real = f32;
-
-    fn dtype() -> DType {
-        DType::F32
-    }
-
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Tensor::F32(TypedTensor::from_vec_col_major(shape, data))
-    }
-
-    fn tensor_read(tensor: &TypedTensor<Self>) -> TensorRead<'_> {
-        TensorRead::from_view(TensorView::F32(tensor.as_view()))
-    }
-
-    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
-        match tensor {
-            Tensor::F32(t) => t.try_host_data().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
-        match tensor {
-            Tensor::F32(t) => t.try_host_data_mut().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
-        match tensor {
-            Tensor::F32(inner) => Some(inner),
-            _ => None,
-        }
-    }
-}
-
-impl TensorScalar for i64 {
-    type Real = i64;
-
-    fn dtype() -> DType {
-        DType::I64
-    }
-
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Tensor::I64(TypedTensor::from_vec_col_major(shape, data))
-    }
-
-    fn tensor_read(tensor: &TypedTensor<Self>) -> TensorRead<'_> {
-        TensorRead::from_view(TensorView::I64(tensor.as_view()))
-    }
-
-    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
-        match tensor {
-            Tensor::I64(t) => t.try_host_data().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
-        match tensor {
-            Tensor::I64(t) => t.try_host_data_mut().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
-        match tensor {
-            Tensor::I64(inner) => Some(inner),
-            _ => None,
-        }
-    }
-}
-
-impl TensorScalar for i32 {
-    type Real = i32;
-
-    fn dtype() -> DType {
-        DType::I32
-    }
-
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Tensor::I32(TypedTensor::from_vec_col_major(shape, data))
-    }
-
-    fn tensor_read(tensor: &TypedTensor<Self>) -> TensorRead<'_> {
-        TensorRead::from_view(TensorView::I32(tensor.as_view()))
-    }
-
-    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
-        match tensor {
-            Tensor::I32(t) => t.try_host_data().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
-        match tensor {
-            Tensor::I32(t) => t.try_host_data_mut().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
-        match tensor {
-            Tensor::I32(inner) => Some(inner),
-            _ => None,
-        }
-    }
-}
-
-impl TensorScalar for bool {
-    type Real = bool;
-
-    fn dtype() -> DType {
-        DType::Bool
-    }
-
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Tensor::Bool(TypedTensor::from_vec_col_major(shape, data))
-    }
-
-    fn tensor_read(tensor: &TypedTensor<Self>) -> TensorRead<'_> {
-        TensorRead::from_view(TensorView::Bool(tensor.as_view()))
-    }
-
-    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
-        match tensor {
-            Tensor::Bool(t) => t.try_host_data().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
-        match tensor {
-            Tensor::Bool(t) => t.try_host_data_mut().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
-        match tensor {
-            Tensor::Bool(inner) => Some(inner),
-            _ => None,
-        }
-    }
-}
-
-impl TensorScalar for Complex64 {
-    type Real = f64;
-
-    fn dtype() -> DType {
-        DType::C64
-    }
-
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Tensor::C64(TypedTensor::from_vec_col_major(shape, data))
-    }
-
-    fn tensor_read(tensor: &TypedTensor<Self>) -> TensorRead<'_> {
-        TensorRead::from_view(TensorView::C64(tensor.as_view()))
-    }
-
-    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
-        match tensor {
-            Tensor::C64(t) => t.try_host_data().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
-        match tensor {
-            Tensor::C64(t) => t.try_host_data_mut().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
-        match tensor {
-            Tensor::C64(inner) => Some(inner),
-            _ => None,
-        }
-    }
-}
-
-impl TensorScalar for Complex32 {
-    type Real = f32;
-
-    fn dtype() -> DType {
-        DType::C32
-    }
-
-    fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> Tensor {
-        Tensor::C32(TypedTensor::from_vec_col_major(shape, data))
-    }
-
-    fn tensor_read(tensor: &TypedTensor<Self>) -> TensorRead<'_> {
-        TensorRead::from_view(TensorView::C32(tensor.as_view()))
-    }
-
-    fn try_as_slice(tensor: &Tensor) -> Option<&[Self]> {
-        match tensor {
-            Tensor::C32(t) => t.try_host_data().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_as_slice_mut(tensor: &mut Tensor) -> Option<&mut [Self]> {
-        match tensor {
-            Tensor::C32(t) => t.try_host_data_mut().ok(),
-            _ => None,
-        }
-    }
-
-    fn try_into_typed(tensor: Tensor) -> Option<TypedTensor<Self>> {
-        match tensor {
-            Tensor::C32(inner) => Some(inner),
-            _ => None,
-        }
-    }
-}
+impl_tensor_scalar!(f64, f64, F64, F64);
+impl_tensor_scalar!(f32, f32, F32, F32);
+impl_tensor_scalar!(i64, i64, I64, I64);
+impl_tensor_scalar!(i32, i32, I32, I32);
+impl_tensor_scalar!(bool, bool, Bool, Bool);
+impl_tensor_scalar!(Complex64, f64, C64, C64);
+impl_tensor_scalar!(Complex32, f32, C32, C32);
 
 /// Dynamic tensor enum over the supported scalar types.
 ///
@@ -2226,12 +1973,7 @@ impl TensorOwnedView {
         TensorRead::from_view(self.tensor_view())
     }
 
-    pub fn to_tensor(&self) -> Tensor {
-        self.try_to_tensor()
-            .unwrap_or_else(|err| panic!("TensorOwnedView::to_tensor failed: {err}"))
-    }
-
-    /// Try to materialize this owned view into an owned compact tensor.
+    /// Materialize this owned view into an owned compact tensor.
     ///
     /// This returns an explicit error for backend-backed views because no
     /// backend context is available for an implicit download.
@@ -2244,12 +1986,12 @@ impl TensorOwnedView {
     ///
     /// let base = Arc::new(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]));
     /// let view = TensorOwnedView::from_tensor(base);
-    /// let tensor = view.try_to_tensor()?;
+    /// let tensor = view.to_tensor()?;
     /// assert_eq!(tensor.shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn try_to_tensor(&self) -> crate::Result<Tensor> {
-        self.tensor_view().try_to_tensor()
+    pub fn to_tensor(&self) -> crate::Result<Tensor> {
+        self.tensor_view().to_tensor()
     }
 
     pub fn transpose_view(&self, axes: impl AsRef<[usize]>) -> crate::Result<Self> {
@@ -2386,12 +2128,7 @@ impl TensorValue {
         }
     }
 
-    pub fn to_tensor(&self) -> Tensor {
-        self.try_to_tensor()
-            .unwrap_or_else(|err| panic!("TensorValue::to_tensor failed: {err}"))
-    }
-
-    /// Try to materialize this tensor value into an owned compact tensor.
+    /// Materialize this tensor value into an owned compact tensor.
     ///
     /// Compact tensor values are cloned. Lazy host views are materialized.
     /// Backend-backed views return an explicit error instead of panicking.
@@ -2405,14 +2142,14 @@ impl TensorValue {
     ///     vec![2],
     ///     vec![1.0_f64, 2.0],
     /// ));
-    /// let tensor = value.try_to_tensor()?;
+    /// let tensor = value.to_tensor()?;
     /// assert_eq!(tensor.shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn try_to_tensor(&self) -> crate::Result<Tensor> {
+    pub fn to_tensor(&self) -> crate::Result<Tensor> {
         match self {
             Self::Tensor(tensor) => Ok(tensor.as_ref().clone()),
-            Self::View(view) => view.try_to_tensor(),
+            Self::View(view) => view.to_tensor(),
         }
     }
 
@@ -2789,10 +2526,6 @@ impl<'a> TensorView<'a> {
     /// an explicit device transfer before materializing backend views on the
     /// host.
     ///
-    /// # Panics
-    ///
-    /// Panics when called on a backend-backed view.
-    ///
     /// # Examples
     ///
     /// ```rust
@@ -2800,54 +2533,32 @@ impl<'a> TensorView<'a> {
     ///
     /// let data = [1.0_f64, 2.0];
     /// let view = TensorView::f64(&[2], &data)?;
-    /// let tensor = view.to_tensor();
+    /// let tensor = view.to_tensor()?;
     /// assert_eq!(tensor.dtype(), DType::F64);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn to_tensor(&self) -> Tensor {
-        self.try_to_tensor()
-            .unwrap_or_else(|err| panic!("TensorView::to_tensor failed: {err}"))
-    }
-
-    /// Try to materialize this host view into an owned tensor.
-    ///
-    /// This is the checked counterpart to [`TensorView::to_tensor`]. It clones
-    /// host view data but returns an explicit error for backend-backed views
-    /// because there is no backend context available for download.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor::{DType, TensorView};
-    ///
-    /// let data = [1.0_f64, 2.0];
-    /// let view = TensorView::f64(&[2], &data)?;
-    /// let tensor = view.try_to_tensor()?;
-    /// assert_eq!(tensor.dtype(), DType::F64);
-    /// # Ok::<(), tenferro_tensor::Error>(())
-    /// ```
-    pub fn try_to_tensor(&self) -> crate::Result<Tensor> {
+    pub fn to_tensor(&self) -> crate::Result<Tensor> {
         match self {
             Self::F32(t) => {
-                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::F32)
+                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::F32)
             }
             Self::F64(t) => {
-                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::F64)
+                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::F64)
             }
             Self::I32(t) => {
-                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::I32)
+                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::I32)
             }
             Self::I64(t) => {
-                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::I64)
+                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::I64)
             }
             Self::Bool(t) => {
-                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::Bool)
+                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::Bool)
             }
             Self::C32(t) => {
-                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::C32)
+                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::C32)
             }
             Self::C64(t) => {
-                materialize_typed_view_col_major(t, "TensorView::try_to_tensor").map(Tensor::C64)
+                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::C64)
             }
         }
     }
@@ -2890,10 +2601,6 @@ impl<'a> TensorRead<'a> {
     /// backend-specific `TensorViewCanonicalization` method or an explicit
     /// device transfer before materializing backend views on the host.
     ///
-    /// # Panics
-    ///
-    /// Panics when called on a backend-backed view.
-    ///
     /// # Examples
     ///
     /// ```rust
@@ -2901,36 +2608,14 @@ impl<'a> TensorRead<'a> {
     ///
     /// let data = [1_i32, 2, 3];
     /// let read = TensorRead::from_view(TensorView::i32(&[3], &data)?);
-    /// let tensor = read.to_tensor();
+    /// let tensor = read.to_tensor()?;
     /// assert_eq!(tensor.shape(), &[3]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn to_tensor(&self) -> Tensor {
-        self.try_to_tensor()
-            .unwrap_or_else(|err| panic!("TensorRead::to_tensor failed: {err}"))
-    }
-
-    /// Try to convert an owned tensor reference or host view into an owned tensor.
-    ///
-    /// This is the checked counterpart to [`TensorRead::to_tensor`]. It clones
-    /// owned tensor inputs and materializes host views, but returns an explicit
-    /// error for backend-backed views.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor::{TensorRead, TensorView};
-    ///
-    /// let data = [1_i32, 2, 3];
-    /// let read = TensorRead::from_view(TensorView::i32(&[3], &data)?);
-    /// let tensor = read.try_to_tensor()?;
-    /// assert_eq!(tensor.shape(), &[3]);
-    /// # Ok::<(), tenferro_tensor::Error>(())
-    /// ```
-    pub fn try_to_tensor(&self) -> crate::Result<Tensor> {
+    pub fn to_tensor(&self) -> crate::Result<Tensor> {
         match self {
             Self::Tensor(tensor) => Ok((*tensor).clone()),
-            Self::View(view) => view.try_to_tensor(),
+            Self::View(view) => view.to_tensor(),
         }
     }
 }
@@ -2940,13 +2625,12 @@ impl<'a> TensorRead<'a> {
 /// # Examples
 ///
 /// ```rust
-/// use tenferro_tensor::{col_major_strides, try_col_major_strides};
+/// use tenferro_tensor::col_major_strides;
 ///
-/// assert_eq!(col_major_strides(&[2, 3]), vec![1, 2]);
-/// assert_eq!(try_col_major_strides(&[2, 3])?, vec![1, 2]);
+/// assert_eq!(col_major_strides(&[2, 3])?, vec![1, 2]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn try_col_major_strides(shape: &[usize]) -> crate::Result<Vec<isize>> {
+pub fn col_major_strides(shape: &[usize]) -> crate::Result<Vec<isize>> {
     let mut strides = Vec::with_capacity(shape.len());
     let mut stride = 1isize;
     for &extent in shape {
@@ -2963,19 +2647,6 @@ pub fn try_col_major_strides(shape: &[usize]) -> crate::Result<Vec<isize>> {
             })?;
     }
     Ok(strides)
-}
-
-pub fn col_major_strides(shape: &[usize]) -> Vec<isize> {
-    // Compatibility panic wrapper; use `try_col_major_strides` when shape
-    // dimensions come from users or compiled graph metadata.
-    try_col_major_strides(shape).unwrap_or_else(|err| panic!("col_major_strides failed: {err}"))
-}
-
-fn linear_offset(shape: &[usize], indices: &[usize]) -> usize {
-    // Compatibility panic wrapper; public checked APIs call
-    // `try_linear_offset_for_shape` and return an explicit error.
-    try_linear_offset_for_shape(shape, indices, "linear_offset")
-        .unwrap_or_else(|err| panic!("linear_offset failed: {err}"))
 }
 
 fn try_linear_offset_for_shape(
@@ -3040,12 +2711,6 @@ fn try_checked_shape_len(shape: &[usize], data_len: usize, op: &'static str) -> 
         });
     }
     Ok(())
-}
-
-fn checked_shape_len(shape: &[usize], data_len: usize, op: &'static str) {
-    // Compatibility panic wrapper for legacy infallible constructors. New
-    // constructor code should use `try_checked_shape_len`.
-    try_checked_shape_len(shape, data_len, op).unwrap_or_else(|err| panic!("{err}"));
 }
 
 fn try_compact_layout<R: TensorRank>(
@@ -3549,22 +3214,30 @@ fn slice_axis_specs(
     Ok(slices)
 }
 
-fn row_major_offset(shape: &[usize], indices: &[usize]) -> usize {
+fn row_major_offset(shape: &[usize], indices: &[usize], op: &'static str) -> crate::Result<usize> {
     let mut stride = 1usize;
     let mut offset = 0usize;
     for (&dim, &index) in shape.iter().rev().zip(indices.iter().rev()) {
-        offset = offset
-            .checked_add(
-                index
-                    .checked_mul(stride)
-                    .unwrap_or_else(|| panic!("row-major offset multiply overflows")),
-            )
-            .unwrap_or_else(|| panic!("row-major offset add overflows"));
+        offset =
+            offset
+                .checked_add(index.checked_mul(stride).ok_or_else(|| {
+                    crate::Error::InvalidConfig {
+                        op,
+                        message: "row-major offset multiply overflows".to_string(),
+                    }
+                })?)
+                .ok_or_else(|| crate::Error::InvalidConfig {
+                    op,
+                    message: "row-major offset add overflows".to_string(),
+                })?;
         stride = stride
             .checked_mul(dim)
-            .unwrap_or_else(|| panic!("row-major offset stride overflows"));
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op,
+                message: "row-major offset stride overflows".to_string(),
+            })?;
     }
-    offset
+    Ok(offset)
 }
 
 fn for_each_index(shape: &[usize], mut f: impl FnMut(&[usize])) {
@@ -3628,30 +3301,47 @@ fn try_row_major_to_col_major<T: Clone>(
 ) -> crate::Result<Vec<T>> {
     try_checked_shape_len(shape, data.len(), op)?;
     let mut out = Vec::with_capacity(data.len());
+    let mut error = None;
     for_each_index(shape, |index| {
-        out.push(data[row_major_offset(shape, index)].clone());
+        if error.is_some() {
+            return;
+        }
+        match row_major_offset(shape, index, op) {
+            Ok(offset) => out.push(data[offset].clone()),
+            Err(err) => error = Some(err),
+        }
     });
+    if let Some(err) = error {
+        return Err(err);
+    }
     Ok(out)
 }
 
-fn row_major_to_col_major<T: Clone>(shape: &[usize], data: Vec<T>) -> Vec<T> {
-    // Compatibility panic wrapper; use `try_row_major_to_col_major` from new
-    // fallible constructors.
-    try_row_major_to_col_major(shape, data, "from_vec_row_major")
-        .unwrap_or_else(|err| panic!("{err}"))
-}
-
-fn col_major_to_row_major<T: Clone>(shape: &[usize], data: Vec<T>) -> Vec<T> {
-    checked_shape_len(shape, data.len(), "try_into_vec_row_major");
+fn col_major_to_row_major<T: Clone>(
+    shape: &[usize],
+    data: Vec<T>,
+    op: &'static str,
+) -> crate::Result<Vec<T>> {
+    try_checked_shape_len(shape, data.len(), op)?;
     if shape.is_empty() {
-        return data;
+        return Ok(data);
     }
 
     let mut out = Vec::with_capacity(data.len());
+    let mut error = None;
     for_each_row_major_index(shape, |index| {
-        out.push(data[linear_offset(shape, index)].clone());
+        if error.is_some() {
+            return;
+        }
+        match try_linear_offset_for_shape(shape, index, op) {
+            Ok(offset) => out.push(data[offset].clone()),
+            Err(err) => error = Some(err),
+        }
     });
-    out
+    if let Some(err) = error {
+        return Err(err);
+    }
+    Ok(out)
 }
 
 pub(crate) fn materialize_typed_view_col_major<T: Clone + 'static, R: TensorRank>(
@@ -3665,7 +3355,7 @@ pub(crate) fn materialize_typed_view_col_major<T: Clone + 'static, R: TensorRank
         &view.buffer,
         op,
     )?;
-    Ok(TypedTensor::from_vec_col_major(view.shape().to_vec(), data))
+    TypedTensor::from_vec_col_major(view.shape().to_vec(), data)
 }
 
 pub(crate) fn default_placement() -> Placement {
@@ -3679,10 +3369,8 @@ fn typed_tensor_from_vec_col_major<T, R: TensorRank>(
     shape: impl Into<R::Shape>,
     data: Vec<T>,
     op: &'static str,
-) -> TypedTensor<T, R> {
-    // Compatibility panic wrapper; prefer
-    // `TypedTensor::try_from_vec_col_major` for user-provided shapes/data.
-    try_typed_tensor_from_vec_col_major(shape, data, op).unwrap_or_else(|err| panic!("{err}"))
+) -> crate::Result<TypedTensor<T, R>> {
+    try_typed_tensor_from_vec_col_major(shape, data, op)
 }
 
 fn try_typed_tensor_from_vec_col_major<T, R: TensorRank>(
@@ -3702,10 +3390,8 @@ fn try_typed_tensor_from_vec_col_major<T, R: TensorRank>(
 fn typed_tensor_from_vec_row_major<T: Clone, R: TensorRank>(
     shape: impl Into<R::Shape>,
     data: Vec<T>,
-) -> TypedTensor<T, R> {
-    // Compatibility panic wrapper; prefer
-    // `TypedTensor::try_from_vec_row_major` for user-provided shapes/data.
-    try_typed_tensor_from_vec_row_major(shape, data).unwrap_or_else(|err| panic!("{err}"))
+) -> crate::Result<TypedTensor<T, R>> {
+    try_typed_tensor_from_vec_row_major(shape, data)
 }
 
 fn try_typed_tensor_from_vec_row_major<T: Clone, R: TensorRank>(
@@ -3723,10 +3409,8 @@ fn try_typed_tensor_from_vec_row_major<T: Clone, R: TensorRank>(
 
 fn typed_tensor_zeros<T: Clone + Zero, R: TensorRank>(
     shape: impl Into<R::Shape>,
-) -> TypedTensor<T, R> {
-    // Compatibility panic wrapper; prefer `TypedTensor::try_zeros` for
-    // user-provided shapes.
-    try_typed_tensor_zeros(shape).unwrap_or_else(|err| panic!("{err}"))
+) -> crate::Result<TypedTensor<T, R>> {
+    try_typed_tensor_zeros(shape)
 }
 
 fn try_typed_tensor_zeros<T: Clone + Zero, R: TensorRank>(
@@ -3743,10 +3427,8 @@ fn try_typed_tensor_zeros<T: Clone + Zero, R: TensorRank>(
 
 fn typed_tensor_ones<T: Clone + One + Zero, R: TensorRank>(
     shape: impl Into<R::Shape>,
-) -> TypedTensor<T, R> {
-    // Compatibility panic wrapper; prefer `TypedTensor::try_ones` for
-    // user-provided shapes.
-    try_typed_tensor_ones(shape).unwrap_or_else(|err| panic!("{err}"))
+) -> crate::Result<TypedTensor<T, R>> {
+    try_typed_tensor_ones(shape)
 }
 
 fn try_typed_tensor_ones<T: Clone + One + Zero, R: TensorRank>(
@@ -3765,11 +3447,8 @@ fn typed_tensor_from_buffer_col_major<T: 'static, R: TensorRank>(
     shape: impl Into<R::Shape>,
     buffer: Buffer<T>,
     placement: Placement,
-) -> TypedTensor<T, R> {
-    // Compatibility panic wrapper; prefer
-    // `TypedTensor::try_from_buffer_col_major` for user-provided shapes.
+) -> crate::Result<TypedTensor<T, R>> {
     try_typed_tensor_from_buffer_col_major(shape, buffer, placement)
-        .unwrap_or_else(|err| panic!("{err}"))
 }
 
 fn try_typed_tensor_from_buffer_col_major<T: 'static, R: TensorRank>(
@@ -3798,13 +3477,8 @@ impl<T: Clone + Zero, R: TensorRank> TypedTensor<T, R> {
     /// let t = TypedTensor::<f64>::zeros(vec![2, 3]);
     /// assert_eq!(t.n_elements(), 6);
     /// ```
-    pub fn zeros(shape: impl Into<R::Shape>) -> Self {
+    pub fn zeros(shape: impl Into<R::Shape>) -> crate::Result<Self> {
         typed_tensor_zeros(shape)
-    }
-
-    /// Try to allocate a zero-filled tensor.
-    pub fn try_zeros(shape: impl Into<R::Shape>) -> crate::Result<Self> {
-        try_typed_tensor_zeros(shape)
     }
 }
 
@@ -3819,13 +3493,8 @@ impl<T: Clone + One + Zero, R: TensorRank> TypedTensor<T, R> {
     /// let t = TypedTensor::<f64>::ones(vec![2]);
     /// assert_eq!(t.host_data(), &[1.0, 1.0]);
     /// ```
-    pub fn ones(shape: impl Into<R::Shape>) -> Self {
+    pub fn ones(shape: impl Into<R::Shape>) -> crate::Result<Self> {
         typed_tensor_ones(shape)
-    }
-
-    /// Try to allocate a one-filled tensor.
-    pub fn try_ones(shape: impl Into<R::Shape>) -> crate::Result<Self> {
-        try_typed_tensor_ones(shape)
     }
 }
 
@@ -3854,23 +3523,11 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
         shape: impl Into<R::Shape>,
         buffer: Buffer<T>,
         placement: Placement,
-    ) -> Self
-    where
-        T: 'static,
-    {
-        typed_tensor_from_buffer_col_major(shape, buffer, placement)
-    }
-
-    /// Try to create a tensor from an existing buffer and compact column-major layout.
-    pub fn try_from_buffer_col_major(
-        shape: impl Into<R::Shape>,
-        buffer: Buffer<T>,
-        placement: Placement,
     ) -> crate::Result<Self>
     where
         T: 'static,
     {
-        try_typed_tensor_from_buffer_col_major(shape, buffer, placement)
+        typed_tensor_from_buffer_col_major(shape, buffer, placement)
     }
 
     /// Convert this tensor into static rank metadata after validating its rank.
@@ -3912,14 +3569,9 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.n_elements(), 6);
     /// ```
     pub fn n_elements(&self) -> usize {
-        // Compatibility panic wrapper; use `try_n_elements` for untrusted
-        // shape metadata.
-        self.try_n_elements().unwrap_or_else(|err| panic!("{err}"))
-    }
-
-    /// Try to return the number of logical elements in this tensor.
-    pub fn try_n_elements(&self) -> crate::Result<usize> {
-        try_shape_product(self.shape(), "TypedTensor::try_n_elements")
+        // Invariant: owned tensor constructors validate compact shape length against buffer length.
+        try_shape_product(self.shape(), "TypedTensor::n_elements")
+            .expect("TypedTensor compact shape was validated at construction")
     }
 
     /// Tensor shape.
@@ -4113,13 +3765,8 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
     /// assert_eq!(t.get(&[1, 0]), &2.0);
     /// ```
-    pub fn from_vec_col_major(shape: impl Into<R::Shape>, data: Vec<T>) -> Self {
+    pub fn from_vec_col_major(shape: impl Into<R::Shape>, data: Vec<T>) -> crate::Result<Self> {
         typed_tensor_from_vec_col_major(shape, data, "from_vec_col_major")
-    }
-
-    /// Try to create a tensor from a column-major buffer.
-    pub fn try_from_vec_col_major(shape: impl Into<R::Shape>, data: Vec<T>) -> crate::Result<Self> {
-        try_typed_tensor_from_vec_col_major(shape, data, "from_vec_col_major")
     }
 
     /// Create a tensor from a row-major buffer.
@@ -4134,13 +3781,8 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// let t = TypedTensor::<f64>::from_vec_row_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
     /// assert_eq!(t.as_slice(), &[1.0, 3.0, 2.0, 4.0]);
     /// ```
-    pub fn from_vec_row_major(shape: impl Into<R::Shape>, data: Vec<T>) -> Self {
+    pub fn from_vec_row_major(shape: impl Into<R::Shape>, data: Vec<T>) -> crate::Result<Self> {
         typed_tensor_from_vec_row_major(shape, data)
-    }
-
-    /// Try to create a tensor from a row-major buffer.
-    pub fn try_from_vec_row_major(shape: impl Into<R::Shape>, data: Vec<T>) -> crate::Result<Self> {
-        try_typed_tensor_from_vec_row_major(shape, data)
     }
 
     /// Consume this tensor and return its owned column-major host buffer.
@@ -4151,16 +3793,16 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
-    /// let (shape, data) = t.try_into_vec_col_major().unwrap();
+    /// let (shape, data) = t.into_vec_col_major().unwrap();
     /// assert_eq!(shape, vec![2]);
     /// assert_eq!(data, vec![1.0, 2.0]);
     /// ```
-    pub fn try_into_vec_col_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
+    pub fn into_vec_col_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
         let shape = self.shape().to_vec();
         match self.buffer {
             Buffer::Host(data) => Ok((shape, data)),
             Buffer::Backend(_) => Err(crate::Error::backend_failure(
-                "try_into_vec_col_major",
+                "into_vec_col_major",
                 "backend buffers cannot be exported as host Vec",
             )),
         }
@@ -4174,18 +3816,18 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 3.0, 2.0, 4.0]);
-    /// let (_, data) = t.try_into_vec_row_major().unwrap();
+    /// let (_, data) = t.into_vec_row_major().unwrap();
     /// assert_eq!(data, vec![1.0, 2.0, 3.0, 4.0]);
     /// ```
-    pub fn try_into_vec_row_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
+    pub fn into_vec_row_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
         let shape = self.shape().to_vec();
         match self.buffer {
             Buffer::Host(data) => {
-                let data = col_major_to_row_major(&shape, data);
+                let data = col_major_to_row_major(&shape, data, "into_vec_row_major")?;
                 Ok((shape, data))
             }
             Buffer::Backend(_) => Err(crate::Error::backend_failure(
-                "try_into_vec_row_major",
+                "into_vec_row_major",
                 "backend buffers cannot be exported as host Vec",
             )),
         }
@@ -4193,32 +3835,20 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
 
     /// Borrow the host buffer.
     ///
-    /// This is a compatibility panic wrapper. New runtime-facing code should
-    /// use [`TypedTensor::try_host_data`] so backend buffers report an error
-    /// instead of being mistaken for host memory.
-    ///
     /// # Examples
     ///
     /// ```rust
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
-    /// assert_eq!(t.host_data(), &[1.0, 2.0]);
+    /// assert_eq!(t.host_data()?, &[1.0, 2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn host_data(&self) -> &[T] {
-        self.try_host_data()
-            .unwrap_or_else(|err| panic!("host_data failed: {err}"))
-    }
-
-    /// Try to borrow the host buffer.
-    ///
-    /// Returns an explicit error for backend buffers. Tensor core does not
-    /// implicitly download backend-native allocations.
-    pub fn try_host_data(&self) -> crate::Result<&[T]> {
+    pub fn host_data(&self) -> crate::Result<&[T]> {
         match &self.buffer {
             Buffer::Host(v) => Ok(v),
             Buffer::Backend(_) => Err(crate::Error::backend_failure(
-                "TypedTensor::try_host_data",
+                "TypedTensor::host_data",
                 "backend buffers cannot be inspected as host slices; download explicitly first",
             )),
         }
@@ -4235,17 +3865,14 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
-    /// assert_eq!(t.as_slice(), &[1.0, 2.0]);
+    /// assert_eq!(t.as_slice()?, &[1.0, 2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn as_slice(&self) -> &[T] {
+    pub fn as_slice(&self) -> crate::Result<&[T]> {
         self.host_data()
     }
 
     /// Mutably borrow the host buffer.
-    ///
-    /// This is a compatibility panic wrapper. New runtime-facing code should
-    /// use [`TypedTensor::try_host_data_mut`] so backend buffers report an
-    /// error instead of being mistaken for host memory.
     ///
     /// # Examples
     ///
@@ -4253,23 +3880,15 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let mut t = TypedTensor::<f64>::zeros(vec![2]);
-    /// t.host_data_mut()[0] = 3.0;
-    /// assert_eq!(t.host_data(), &[3.0, 0.0]);
+    /// t.host_data_mut()?[0] = 3.0;
+    /// assert_eq!(t.host_data()?, &[3.0, 0.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn host_data_mut(&mut self) -> &mut [T] {
-        self.try_host_data_mut()
-            .unwrap_or_else(|err| panic!("host_data_mut failed: {err}"))
-    }
-
-    /// Try to mutably borrow the host buffer.
-    ///
-    /// Returns an explicit error for backend buffers. Tensor core does not
-    /// expose host mutation for backend-native allocations.
-    pub fn try_host_data_mut(&mut self) -> crate::Result<&mut [T]> {
+    pub fn host_data_mut(&mut self) -> crate::Result<&mut [T]> {
         match &mut self.buffer {
             Buffer::Host(v) => Ok(v),
             Buffer::Backend(_) => Err(crate::Error::backend_failure(
-                "TypedTensor::try_host_data_mut",
+                "TypedTensor::host_data_mut",
                 "backend buffers cannot be mutated as host slices; download explicitly first",
             )),
         }
@@ -4283,15 +3902,11 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let t = TypedTensor::<f64>::zeros(vec![2, 3]);
-    /// assert_eq!(t.linear_offset(&[1, 2]), 5);
+    /// assert_eq!(t.linear_offset(&[1, 2])?, 5);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn linear_offset(&self, indices: &[usize]) -> usize {
-        linear_offset(self.shape(), indices)
-    }
-
-    /// Try to compute the linear physical-buffer offset for a logical index.
-    pub fn try_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
-        try_linear_offset_for_shape(self.shape(), indices, "TypedTensor::try_linear_offset")
+    pub fn linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
+        try_linear_offset_for_shape(self.shape(), indices, "TypedTensor::linear_offset")
     }
 
     /// Borrow a single element by multi-index.
@@ -4302,11 +3917,17 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
-    /// assert_eq!(t.get(&[1]), &2.0);
+    /// assert_eq!(t.get(&[1])?, &2.0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn get(&self, indices: &[usize]) -> &T {
-        let off = self.linear_offset(indices);
-        &self.host_data()[off]
+    pub fn get(&self, indices: &[usize]) -> crate::Result<&T> {
+        let off = self.linear_offset(indices)?;
+        self.host_data()?
+            .get(off)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "TypedTensor::get",
+                message: format!("linear offset {off} is outside host buffer"),
+            })
     }
 
     /// Mutably borrow a single element by multi-index.
@@ -4317,12 +3938,18 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let mut t = TypedTensor::<f64>::zeros(vec![1]);
-    /// *t.get_mut(&[0]) = 7.0;
-    /// assert_eq!(t.host_data(), &[7.0]);
+    /// *t.get_mut(&[0])? = 7.0;
+    /// assert_eq!(t.host_data()?, &[7.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn get_mut(&mut self, indices: &[usize]) -> &mut T {
-        let off = self.linear_offset(indices);
-        &mut self.host_data_mut()[off]
+    pub fn get_mut(&mut self, indices: &[usize]) -> crate::Result<&mut T> {
+        let off = self.linear_offset(indices)?;
+        self.host_data_mut()?
+            .get_mut(off)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "TypedTensor::get_mut",
+                message: format!("linear offset {off} is outside host buffer"),
+            })
     }
 }
 
@@ -4341,17 +3968,11 @@ impl Tensor {
     /// assert_eq!(t.shape(), &[2, 2]);
     /// assert_eq!(t.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
     /// ```
-    pub fn from_vec_col_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Self {
-        T::into_tensor(shape, data)
-    }
-
-    /// Try to create a tensor from a shape and column-major flat data.
-    pub fn try_from_vec_col_major<T: TensorScalar>(
+    pub fn from_vec_col_major<T: TensorScalar>(
         shape: Vec<usize>,
         data: Vec<T>,
     ) -> crate::Result<Self> {
-        try_checked_shape_len(&shape, data.len(), "Tensor::try_from_vec_col_major")?;
-        Ok(T::into_tensor(shape, data))
+        T::into_tensor(shape, data)
     }
 
     /// Create a tensor from a shape and row-major flat data.
@@ -4365,18 +3986,12 @@ impl Tensor {
     /// assert_eq!(t.shape(), &[2, 2]);
     /// assert_eq!(t.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
     /// ```
-    pub fn from_vec_row_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Self {
-        let data = row_major_to_col_major(&shape, data);
-        Self::from_vec_col_major(shape, data)
-    }
-
-    /// Try to create a tensor from a shape and row-major flat data.
-    pub fn try_from_vec_row_major<T: TensorScalar>(
+    pub fn from_vec_row_major<T: TensorScalar>(
         shape: Vec<usize>,
         data: Vec<T>,
     ) -> crate::Result<Self> {
-        let data = try_row_major_to_col_major(&shape, data, "Tensor::try_from_vec_row_major")?;
-        Ok(T::into_tensor(shape, data))
+        let data = try_row_major_to_col_major(&shape, data, "Tensor::from_vec_row_major")?;
+        Self::from_vec_col_major(shape, data)
     }
 
     /// Tensor shape.
@@ -4480,8 +4095,8 @@ impl Tensor {
     /// assert_eq!(t.as_slice::<f64>(), Some([1.0, 2.0, 3.0].as_slice()));
     /// assert_eq!(t.as_slice::<f32>(), None);
     /// ```
-    pub fn as_slice<T: TensorScalar>(&self) -> Option<&[T]> {
-        T::try_as_slice(self)
+    pub fn as_slice<T: TensorScalar>(&self) -> crate::Result<&[T]> {
+        T::as_slice(self)
     }
 
     /// Consume this tensor and return its owned column-major buffer when the
@@ -4493,16 +4108,11 @@ impl Tensor {
     /// use tenferro_tensor::Tensor;
     ///
     /// let t = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]);
-    /// assert_eq!(t.try_into_vec_col_major::<f64>().unwrap().1, vec![2.0]);
+    /// assert_eq!(t.into_vec_col_major::<f64>().unwrap().1, vec![2.0]);
     /// ```
-    pub fn try_into_vec_col_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
-        let actual = self.dtype();
-        let typed = T::try_into_typed(self).ok_or(crate::Error::DTypeMismatch {
-            op: "try_into_vec_col_major",
-            lhs: T::dtype(),
-            rhs: actual,
-        })?;
-        typed.try_into_vec_col_major()
+    pub fn into_vec_col_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
+        let typed = T::into_typed(self)?;
+        typed.into_vec_col_major()
     }
 
     /// Consume this tensor and return a row-major buffer when the dtype matches.
@@ -4513,16 +4123,11 @@ impl Tensor {
     /// use tenferro_tensor::Tensor;
     ///
     /// let t = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
-    /// assert_eq!(t.try_into_vec_row_major::<f64>().unwrap().1, vec![1.0, 2.0, 3.0, 4.0]);
+    /// assert_eq!(t.into_vec_row_major::<f64>().unwrap().1, vec![1.0, 2.0, 3.0, 4.0]);
     /// ```
-    pub fn try_into_vec_row_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
-        let actual = self.dtype();
-        let typed = T::try_into_typed(self).ok_or(crate::Error::DTypeMismatch {
-            op: "try_into_vec_row_major",
-            lhs: T::dtype(),
-            rhs: actual,
-        })?;
-        typed.try_into_vec_row_major()
+    pub fn into_vec_row_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
+        let typed = T::into_typed(self)?;
+        typed.into_vec_row_major()
     }
 }
 

--- a/crates/tenferro-tensor/src/types/accessors.rs
+++ b/crates/tenferro-tensor/src/types/accessors.rs
@@ -1,22 +1,4 @@
-use super::{
-    linear_offset, try_linear_offset_for_shape, Tensor, TensorRank, TensorScalar, TypedTensor,
-};
-
-fn try_linear_offset(shape: &[usize], indices: &[usize]) -> Option<usize> {
-    if indices.len() != shape.len() {
-        return None;
-    }
-    let mut offset = 0usize;
-    let mut stride = 1usize;
-    for (&idx, &extent) in indices.iter().zip(shape) {
-        if idx >= extent {
-            return None;
-        }
-        offset = offset.checked_add(idx.checked_mul(stride)?)?;
-        stride = stride.checked_mul(extent)?;
-    }
-    Some(offset)
-}
+use super::{try_linear_offset_for_shape, Tensor, TensorRank, TensorScalar, TypedTensor};
 
 fn debug_assert_index_in_bounds(shape: &[usize], indices: &[usize]) {
     debug_assert_eq!(indices.len(), shape.len());
@@ -43,50 +25,7 @@ fn linear_offset_unchecked(shape: &[usize], indices: &[usize]) -> usize {
     offset
 }
 
-fn linear_offset2(shape: &[usize], i: usize, j: usize) -> usize {
-    // Compatibility panic wrapper; public non-panicking callers use
-    // `try_linear_offset2`/`try_get2`.
-    try_linear_offset2(shape, i, j).unwrap_or_else(|| panic!("rank-2 index out of bounds"))
-}
-
-fn try_linear_offset2(shape: &[usize], i: usize, j: usize) -> Option<usize> {
-    if shape.len() != 2 || i >= shape[0] || j >= shape[1] {
-        return None;
-    }
-    i.checked_add(shape[0].checked_mul(j)?)
-}
-
-fn linear_offset3(shape: &[usize], i: usize, j: usize, k: usize) -> usize {
-    // Compatibility panic wrapper; public non-panicking callers use
-    // `try_linear_offset3`/`try_get3`.
-    try_linear_offset3(shape, i, j, k).unwrap_or_else(|| panic!("rank-3 index out of bounds"))
-}
-
-fn try_linear_offset3(shape: &[usize], i: usize, j: usize, k: usize) -> Option<usize> {
-    if shape.len() != 3 || i >= shape[0] || j >= shape[1] || k >= shape[2] {
-        return None;
-    }
-    let inner = j.checked_add(shape[1].checked_mul(k)?)?;
-    i.checked_add(shape[0].checked_mul(inner)?)
-}
-
 impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
-    /// View the tensor data as a flat slice in physical memory order.
-    ///
-    /// This is an explicit alias for [`TypedTensor::as_slice`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::TypedTensor;
-    ///
-    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
-    /// assert_eq!(t.as_physical_slice(), &[1.0, 2.0]);
-    /// ```
-    pub fn as_physical_slice(&self) -> &[T] {
-        self.host_data()
-    }
-
     /// Iterate over the contiguous column-major host buffer.
     ///
     /// # Examples
@@ -95,26 +34,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
-    /// let sum: f64 = t.iter().copied().sum();
+    /// let sum: f64 = t.iter()?.copied().sum();
     /// assert_eq!(sum, 3.0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn iter(&self) -> std::slice::Iter<'_, T> {
-        self.host_data().iter()
-    }
-
-    /// Mutably view the tensor data as a flat slice in physical memory order.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::TypedTensor;
-    ///
-    /// let mut t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
-    /// t.as_physical_slice_mut()[1] = 5.0;
-    /// assert_eq!(t.as_physical_slice(), &[1.0, 5.0]);
-    /// ```
-    pub fn as_physical_slice_mut(&mut self) -> &mut [T] {
-        self.host_data_mut()
+    pub fn iter(&self) -> crate::Result<std::slice::Iter<'_, T>> {
+        Ok(self.host_data()?.iter())
     }
 
     /// Mutably iterate over the contiguous column-major host buffer.
@@ -125,13 +50,14 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let mut t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
-    /// for value in t.iter_mut() {
+    /// for value in t.iter_mut()? {
     ///     *value *= 2.0;
     /// }
-    /// assert_eq!(t.as_slice(), &[2.0, 4.0]);
+    /// assert_eq!(t.as_slice()?, &[2.0, 4.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, T> {
-        self.host_data_mut().iter_mut()
+    pub fn iter_mut(&mut self) -> crate::Result<std::slice::IterMut<'_, T>> {
+        Ok(self.host_data_mut()?.iter_mut())
     }
 
     /// Compute the linear physical-buffer offset for a rank-2 logical index.
@@ -142,20 +68,11 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]);
-    /// assert_eq!(t.linear_offset2(1, 2), 5);
+    /// assert_eq!(t.linear_offset2(1, 2)?, 5);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Compatibility wrapper for hot valid-index paths. Panics on rank or
-    /// bounds errors; use [`Self::try_linear_offset2`] for user input.
-    pub fn linear_offset2(&self, i: usize, j: usize) -> usize {
-        linear_offset2(self.shape(), i, j)
-    }
-
-    /// Try to compute the linear physical-buffer offset for a rank-2 logical index.
-    pub fn try_linear_offset2(&self, i: usize, j: usize) -> Option<usize> {
-        try_linear_offset2(self.shape(), i, j)
+    pub fn linear_offset2(&self, i: usize, j: usize) -> crate::Result<usize> {
+        try_linear_offset_for_shape(self.shape(), &[i, j], "TypedTensor::linear_offset2")
     }
 
     /// Compute the linear physical-buffer offset for a rank-3 logical index.
@@ -166,38 +83,11 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 3, 2], vec![0.0; 12]);
-    /// assert_eq!(t.linear_offset3(1, 2, 1), 11);
+    /// assert_eq!(t.linear_offset3(1, 2, 1)?, 11);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Compatibility wrapper for hot valid-index paths. Panics on rank or
-    /// bounds errors; use [`Self::try_linear_offset3`] for user input.
-    pub fn linear_offset3(&self, i: usize, j: usize, k: usize) -> usize {
-        linear_offset3(self.shape(), i, j, k)
-    }
-
-    /// Try to compute the linear physical-buffer offset for a rank-3 logical index.
-    pub fn try_linear_offset3(&self, i: usize, j: usize, k: usize) -> Option<usize> {
-        try_linear_offset3(self.shape(), i, j, k)
-    }
-
-    /// Try to borrow a single element by multi-index.
-    ///
-    /// Returns `None` when the rank or any index is out of bounds.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::TypedTensor;
-    ///
-    /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
-    /// assert_eq!(t.try_get(&[1]), Some(&2.0));
-    /// assert_eq!(t.try_get(&[2]), None);
-    /// ```
-    pub fn try_get(&self, indices: &[usize]) -> Option<&T> {
-        let off = try_linear_offset(self.shape(), indices)?;
-        self.try_host_data().ok()?.get(off)
+    pub fn linear_offset3(&self, i: usize, j: usize, k: usize) -> crate::Result<usize> {
+        try_linear_offset_for_shape(self.shape(), &[i, j, k], "TypedTensor::linear_offset3")
     }
 
     /// Borrow a single element by rank-2 logical index.
@@ -208,23 +98,17 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
-    /// assert_eq!(t.get2(1, 0), &2.0);
+    /// assert_eq!(t.get2(1, 0)?, &2.0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Compatibility wrapper for hot valid-index paths. Panics on rank,
-    /// bounds, or backend-buffer host access errors; use [`Self::try_get2`]
-    /// for user input.
-    pub fn get2(&self, i: usize, j: usize) -> &T {
-        let off = self.linear_offset2(i, j);
-        &self.host_data()[off]
-    }
-
-    /// Try to borrow a single element by rank-2 logical index.
-    pub fn try_get2(&self, i: usize, j: usize) -> Option<&T> {
-        let off = self.try_linear_offset2(i, j)?;
-        self.try_host_data().ok()?.get(off)
+    pub fn get2(&self, i: usize, j: usize) -> crate::Result<&T> {
+        let off = self.linear_offset2(i, j)?;
+        self.host_data()?
+            .get(off)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "TypedTensor::get2",
+                message: format!("linear offset {off} is outside host buffer"),
+            })
     }
 
     /// Borrow a single element by rank-3 logical index.
@@ -235,23 +119,17 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let t = TypedTensor::<f64>::from_vec_col_major(vec![1, 1, 2], vec![3.0, 4.0]);
-    /// assert_eq!(t.get3(0, 0, 1), &4.0);
+    /// assert_eq!(t.get3(0, 0, 1)?, &4.0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Compatibility wrapper for hot valid-index paths. Panics on rank,
-    /// bounds, or backend-buffer host access errors; use [`Self::try_get3`]
-    /// for user input.
-    pub fn get3(&self, i: usize, j: usize, k: usize) -> &T {
-        let off = self.linear_offset3(i, j, k);
-        &self.host_data()[off]
-    }
-
-    /// Try to borrow a single element by rank-3 logical index.
-    pub fn try_get3(&self, i: usize, j: usize, k: usize) -> Option<&T> {
-        let off = self.try_linear_offset3(i, j, k)?;
-        self.try_host_data().ok()?.get(off)
+    pub fn get3(&self, i: usize, j: usize, k: usize) -> crate::Result<&T> {
+        let off = self.linear_offset3(i, j, k)?;
+        self.host_data()?
+            .get(off)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "TypedTensor::get3",
+                message: format!("linear offset {off} is outside host buffer"),
+            })
     }
 
     /// Borrow a single element by multi-index without release-mode bounds
@@ -270,29 +148,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let t = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]);
-    /// assert_eq!(unsafe { *t.get_unchecked(&[1]) }, 2.0);
+    /// assert_eq!(unsafe { *t.get_unchecked(&[1])? }, 2.0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub unsafe fn get_unchecked(&self, indices: &[usize]) -> &T {
+    pub unsafe fn get_unchecked(&self, indices: &[usize]) -> crate::Result<&T> {
         let off = linear_offset_unchecked(self.shape(), indices);
-        unsafe { self.host_data().get_unchecked(off) }
-    }
-
-    /// Try to mutably borrow a single element by multi-index.
-    ///
-    /// Returns `None` when the rank or any index is out of bounds.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::TypedTensor;
-    ///
-    /// let mut t = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![1.0]);
-    /// *t.try_get_mut(&[0]).unwrap() = 2.0;
-    /// assert_eq!(t.as_slice(), &[2.0]);
-    /// ```
-    pub fn try_get_mut(&mut self, indices: &[usize]) -> Option<&mut T> {
-        let off = try_linear_offset(self.shape(), indices)?;
-        self.try_host_data_mut().ok()?.get_mut(off)
+        Ok(unsafe { self.host_data()?.get_unchecked(off) })
     }
 
     /// Mutably borrow a single element by rank-2 logical index.
@@ -303,24 +164,18 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let mut t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]);
-    /// *t.get_mut2(1, 0) = 5.0;
-    /// assert_eq!(t.as_slice(), &[1.0, 5.0, 3.0, 4.0]);
+    /// *t.get_mut2(1, 0)? = 5.0;
+    /// assert_eq!(t.as_slice()?, &[1.0, 5.0, 3.0, 4.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Compatibility wrapper for hot valid-index paths. Panics on rank,
-    /// bounds, or backend-buffer host access errors; use [`Self::try_get_mut2`]
-    /// for user input.
-    pub fn get_mut2(&mut self, i: usize, j: usize) -> &mut T {
-        let off = self.linear_offset2(i, j);
-        &mut self.host_data_mut()[off]
-    }
-
-    /// Try to mutably borrow a single element by rank-2 logical index.
-    pub fn try_get_mut2(&mut self, i: usize, j: usize) -> Option<&mut T> {
-        let off = self.try_linear_offset2(i, j)?;
-        self.try_host_data_mut().ok()?.get_mut(off)
+    pub fn get_mut2(&mut self, i: usize, j: usize) -> crate::Result<&mut T> {
+        let off = self.linear_offset2(i, j)?;
+        self.host_data_mut()?
+            .get_mut(off)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "TypedTensor::get_mut2",
+                message: format!("linear offset {off} is outside host buffer"),
+            })
     }
 
     /// Mutably borrow a single element by rank-3 logical index.
@@ -331,24 +186,18 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// use tenferro_tensor::TypedTensor;
     ///
     /// let mut t = TypedTensor::<f64>::from_vec_col_major(vec![1, 1, 2], vec![3.0, 4.0]);
-    /// *t.get_mut3(0, 0, 1) = 5.0;
-    /// assert_eq!(t.as_slice(), &[3.0, 5.0]);
+    /// *t.get_mut3(0, 0, 1)? = 5.0;
+    /// assert_eq!(t.as_slice()?, &[3.0, 5.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Compatibility wrapper for hot valid-index paths. Panics on rank,
-    /// bounds, or backend-buffer host access errors; use [`Self::try_get_mut3`]
-    /// for user input.
-    pub fn get_mut3(&mut self, i: usize, j: usize, k: usize) -> &mut T {
-        let off = self.linear_offset3(i, j, k);
-        &mut self.host_data_mut()[off]
-    }
-
-    /// Try to mutably borrow a single element by rank-3 logical index.
-    pub fn try_get_mut3(&mut self, i: usize, j: usize, k: usize) -> Option<&mut T> {
-        let off = self.try_linear_offset3(i, j, k)?;
-        self.try_host_data_mut().ok()?.get_mut(off)
+    pub fn get_mut3(&mut self, i: usize, j: usize, k: usize) -> crate::Result<&mut T> {
+        let off = self.linear_offset3(i, j, k)?;
+        self.host_data_mut()?
+            .get_mut(off)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "TypedTensor::get_mut3",
+                message: format!("linear offset {off} is outside host buffer"),
+            })
     }
 
     /// Mutably borrow a single element by multi-index without release-mode
@@ -370,11 +219,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// unsafe {
     ///     *t.get_unchecked_mut(&[0]) = 2.0;
     /// }
-    /// assert_eq!(t.as_slice(), &[2.0]);
+    /// assert_eq!(t.as_slice()?, &[2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub unsafe fn get_unchecked_mut(&mut self, indices: &[usize]) -> &mut T {
+    pub unsafe fn get_unchecked_mut(&mut self, indices: &[usize]) -> crate::Result<&mut T> {
         let off = linear_offset_unchecked(self.shape(), indices);
-        unsafe { self.host_data_mut().get_unchecked_mut(off) }
+        Ok(unsafe { self.host_data_mut()?.get_unchecked_mut(off) })
     }
 }
 
@@ -387,15 +237,11 @@ impl Tensor {
     /// use tenferro_tensor::Tensor;
     ///
     /// let t = Tensor::from_vec_col_major(vec![2, 3], vec![0.0_f64; 6]);
-    /// assert_eq!(t.linear_offset(&[1, 2]), 5);
+    /// assert_eq!(t.linear_offset(&[1, 2])?, 5);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn linear_offset(&self, indices: &[usize]) -> usize {
-        linear_offset(self.shape(), indices)
-    }
-
-    /// Try to compute the linear physical-buffer offset for a logical index.
-    pub fn try_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
-        try_linear_offset_for_shape(self.shape(), indices, "Tensor::try_linear_offset")
+    pub fn linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
+        try_linear_offset_for_shape(self.shape(), indices, "Tensor::linear_offset")
     }
 
     /// Compute the linear physical-buffer offset for a rank-2 logical index.
@@ -406,20 +252,11 @@ impl Tensor {
     /// use tenferro_tensor::Tensor;
     ///
     /// let t = Tensor::from_vec_col_major(vec![2, 3], vec![0.0_f64; 6]);
-    /// assert_eq!(t.linear_offset2(1, 2), 5);
+    /// assert_eq!(t.linear_offset2(1, 2)?, 5);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Compatibility wrapper for hot valid-index paths. Panics on rank or
-    /// bounds errors; use [`Self::try_linear_offset2`] for user input.
-    pub fn linear_offset2(&self, i: usize, j: usize) -> usize {
-        linear_offset2(self.shape(), i, j)
-    }
-
-    /// Try to compute the linear physical-buffer offset for a rank-2 logical index.
-    pub fn try_linear_offset2(&self, i: usize, j: usize) -> crate::Result<usize> {
-        try_linear_offset_for_shape(self.shape(), &[i, j], "Tensor::try_linear_offset2")
+    pub fn linear_offset2(&self, i: usize, j: usize) -> crate::Result<usize> {
+        try_linear_offset_for_shape(self.shape(), &[i, j], "Tensor::linear_offset2")
     }
 
     /// Compute the linear physical-buffer offset for a rank-3 logical index.
@@ -430,25 +267,14 @@ impl Tensor {
     /// use tenferro_tensor::Tensor;
     ///
     /// let t = Tensor::from_vec_col_major(vec![2, 3, 2], vec![0.0_f64; 12]);
-    /// assert_eq!(t.linear_offset3(1, 2, 1), 11);
+    /// assert_eq!(t.linear_offset3(1, 2, 1)?, 11);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Compatibility wrapper for hot valid-index paths. Panics on rank or
-    /// bounds errors; use [`Self::try_linear_offset3`] for user input.
-    pub fn linear_offset3(&self, i: usize, j: usize, k: usize) -> usize {
-        linear_offset3(self.shape(), i, j, k)
+    pub fn linear_offset3(&self, i: usize, j: usize, k: usize) -> crate::Result<usize> {
+        try_linear_offset_for_shape(self.shape(), &[i, j, k], "Tensor::linear_offset3")
     }
 
-    /// Try to compute the linear physical-buffer offset for a rank-3 logical index.
-    pub fn try_linear_offset3(&self, i: usize, j: usize, k: usize) -> crate::Result<usize> {
-        try_linear_offset_for_shape(self.shape(), &[i, j, k], "Tensor::try_linear_offset3")
-    }
-
-    /// Try to borrow the host data as a typed physical-memory-order slice.
-    ///
-    /// This is an explicit alias for [`Tensor::as_slice`].
+    /// Borrow a single typed element by multi-index.
     ///
     /// # Examples
     ///
@@ -456,53 +282,21 @@ impl Tensor {
     /// use tenferro_tensor::Tensor;
     ///
     /// let t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    /// assert_eq!(t.as_physical_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    /// assert_eq!(t.get::<f64>(&[1])?, &2.0);
+    /// assert!(t.get::<f32>(&[1]).is_err());
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn as_physical_slice<T: TensorScalar>(&self) -> Option<&[T]> {
-        self.as_slice::<T>()
+    pub fn get<T: TensorScalar>(&self, indices: &[usize]) -> crate::Result<&T> {
+        let off = self.linear_offset(indices)?;
+        self.as_slice::<T>()?
+            .get(off)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "Tensor::get",
+                message: format!("linear offset {off} is outside host buffer"),
+            })
     }
 
-    /// Try to mutably borrow the host data as a typed physical-memory-order
-    /// slice.
-    ///
-    /// This is an explicit alias for [`Tensor::as_slice_mut`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::Tensor;
-    ///
-    /// let mut t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    /// t.as_physical_slice_mut::<f64>().unwrap()[1] = 5.0;
-    /// assert_eq!(t.as_physical_slice::<f64>().unwrap(), &[1.0, 5.0]);
-    /// ```
-    pub fn as_physical_slice_mut<T: TensorScalar>(&mut self) -> Option<&mut [T]> {
-        self.as_slice_mut::<T>()
-    }
-
-    /// Try to borrow a single typed element by multi-index.
-    ///
-    /// Returns `None` when the dtype does not match `T`, the rank does not
-    /// match, or any index is out of bounds.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tenferro_tensor::Tensor;
-    ///
-    /// let t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    /// assert_eq!(t.try_get::<f64>(&[1]), Some(&2.0));
-    /// assert_eq!(t.try_get::<f32>(&[1]), None);
-    /// ```
-    pub fn try_get<T: TensorScalar>(&self, indices: &[usize]) -> Option<&T> {
-        let off = try_linear_offset(self.shape(), indices)?;
-        self.as_slice::<T>()?.get(off)
-    }
-
-    /// Try to mutably borrow a single typed element by multi-index.
-    ///
-    /// Returns `None` when the dtype does not match `T`, the rank does not
-    /// match, or any index is out of bounds.
+    /// Mutably borrow a single typed element by multi-index.
     ///
     /// # Examples
     ///
@@ -510,19 +304,25 @@ impl Tensor {
     /// use tenferro_tensor::Tensor;
     ///
     /// let mut t = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]);
-    /// *t.try_get_mut::<f64>(&[0]).unwrap() = 2.0;
-    /// assert_eq!(t.as_slice::<f64>().unwrap(), &[2.0]);
+    /// *t.get_mut::<f64>(&[0])? = 2.0;
+    /// assert_eq!(t.as_slice::<f64>()?, &[2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn try_get_mut<T: TensorScalar>(&mut self, indices: &[usize]) -> Option<&mut T> {
-        let off = try_linear_offset(self.shape(), indices)?;
-        self.as_slice_mut::<T>()?.get_mut(off)
+    pub fn get_mut<T: TensorScalar>(&mut self, indices: &[usize]) -> crate::Result<&mut T> {
+        let off = self.linear_offset(indices)?;
+        self.as_slice_mut::<T>()?
+            .get_mut(off)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "Tensor::get_mut",
+                message: format!("linear offset {off} is outside host buffer"),
+            })
     }
 
     /// Try to borrow a single typed element by multi-index without
     /// release-mode bounds checks.
     ///
-    /// Returns `None` when the dtype does not match `T`. Debug builds still
-    /// validate the rank and bounds.
+    /// Debug builds still validate the rank and bounds. Dtype and backend
+    /// host-access failures are still reported as errors.
     ///
     /// # Safety
     ///
@@ -535,19 +335,20 @@ impl Tensor {
     /// use tenferro_tensor::Tensor;
     ///
     /// let t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    /// assert_eq!(unsafe { *t.get_unchecked::<f64>(&[1]).unwrap() }, 2.0);
+    /// assert_eq!(unsafe { *t.get_unchecked::<f64>(&[1])? }, 2.0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub unsafe fn get_unchecked<T: TensorScalar>(&self, indices: &[usize]) -> Option<&T> {
+    pub unsafe fn get_unchecked<T: TensorScalar>(&self, indices: &[usize]) -> crate::Result<&T> {
         let off = linear_offset_unchecked(self.shape(), indices);
         let data = self.as_slice::<T>()?;
-        Some(unsafe { data.get_unchecked(off) })
+        Ok(unsafe { data.get_unchecked(off) })
     }
 
     /// Try to mutably borrow a single typed element by multi-index without
     /// release-mode bounds checks.
     ///
-    /// Returns `None` when the dtype does not match `T`. Debug builds still
-    /// validate the rank and bounds.
+    /// Debug builds still validate the rank and bounds. Dtype and backend
+    /// host-access failures are still reported as errors.
     ///
     /// # Safety
     ///
@@ -561,22 +362,21 @@ impl Tensor {
     ///
     /// let mut t = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]);
     /// unsafe {
-    ///     *t.get_unchecked_mut::<f64>(&[0]).unwrap() = 2.0;
+    ///     *t.get_unchecked_mut::<f64>(&[0])? = 2.0;
     /// }
-    /// assert_eq!(t.as_slice::<f64>().unwrap(), &[2.0]);
+    /// assert_eq!(t.as_slice::<f64>()?, &[2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     pub unsafe fn get_unchecked_mut<T: TensorScalar>(
         &mut self,
         indices: &[usize],
-    ) -> Option<&mut T> {
+    ) -> crate::Result<&mut T> {
         let off = linear_offset_unchecked(self.shape(), indices);
         let data = self.as_slice_mut::<T>()?;
-        Some(unsafe { data.get_unchecked_mut(off) })
+        Ok(unsafe { data.get_unchecked_mut(off) })
     }
 
-    /// Try to mutably borrow the host data as a typed slice.
-    ///
-    /// Returns `None` if the tensor dtype does not match `T`.
+    /// Mutably borrow the host data as a typed slice.
     ///
     /// # Examples
     ///
@@ -584,18 +384,16 @@ impl Tensor {
     /// use tenferro_tensor::Tensor;
     ///
     /// let mut t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    /// t.as_slice_mut::<f64>().unwrap()[0] = 3.0;
-    /// assert_eq!(t.as_slice::<f64>().unwrap(), &[3.0, 2.0]);
-    /// assert_eq!(t.as_slice_mut::<f32>(), None);
+    /// t.as_slice_mut::<f64>()?[0] = 3.0;
+    /// assert_eq!(t.as_slice::<f64>()?, &[3.0, 2.0]);
+    /// assert!(t.as_slice_mut::<f32>().is_err());
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn as_slice_mut<T: TensorScalar>(&mut self) -> Option<&mut [T]> {
-        T::try_as_slice_mut(self)
+    pub fn as_slice_mut<T: TensorScalar>(&mut self) -> crate::Result<&mut [T]> {
+        T::as_slice_mut(self)
     }
 
-    /// Try to iterate over the contiguous host buffer in physical memory
-    /// order.
-    ///
-    /// Returns `None` if the tensor dtype does not match `T`.
+    /// Iterate over the contiguous host buffer in physical memory order.
     ///
     /// # Examples
     ///
@@ -603,18 +401,16 @@ impl Tensor {
     /// use tenferro_tensor::Tensor;
     ///
     /// let t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    /// let sum: f64 = t.iter::<f64>().unwrap().copied().sum();
+    /// let sum: f64 = t.iter::<f64>()?.copied().sum();
     /// assert_eq!(sum, 3.0);
-    /// assert!(t.iter::<f32>().is_none());
+    /// assert!(t.iter::<f32>().is_err());
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn iter<T: TensorScalar>(&self) -> Option<std::slice::Iter<'_, T>> {
-        self.as_slice::<T>().map(|slice| slice.iter())
+    pub fn iter<T: TensorScalar>(&self) -> crate::Result<std::slice::Iter<'_, T>> {
+        Ok(self.as_slice::<T>()?.iter())
     }
 
-    /// Try to mutably iterate over the contiguous host buffer in physical
-    /// memory order.
-    ///
-    /// Returns `None` if the tensor dtype does not match `T`.
+    /// Mutably iterate over the contiguous host buffer in physical memory order.
     ///
     /// # Examples
     ///
@@ -622,28 +418,27 @@ impl Tensor {
     /// use tenferro_tensor::Tensor;
     ///
     /// let mut t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-    /// for value in t.iter_mut::<f64>().unwrap() {
+    /// for value in t.iter_mut::<f64>()? {
     ///     *value += 1.0;
     /// }
-    /// assert_eq!(t.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
-    /// assert!(t.iter_mut::<f32>().is_none());
+    /// assert_eq!(t.as_slice::<f64>()?, &[2.0, 3.0]);
+    /// assert!(t.iter_mut::<f32>().is_err());
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn iter_mut<T: TensorScalar>(&mut self) -> Option<std::slice::IterMut<'_, T>> {
-        self.as_slice_mut::<T>().map(|slice| slice.iter_mut())
+    pub fn iter_mut<T: TensorScalar>(&mut self) -> crate::Result<std::slice::IterMut<'_, T>> {
+        Ok(self.as_slice_mut::<T>()?.iter_mut())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{linear_offset2, linear_offset3, linear_offset_unchecked, try_linear_offset};
+    use super::{linear_offset_unchecked, try_linear_offset_for_shape};
 
     #[test]
     fn linear_offset_helpers_check_overflow() {
         let shape = [usize::MAX, 3];
 
-        assert_eq!(try_linear_offset(&shape, &[0, 2]), None);
+        assert!(try_linear_offset_for_shape(&shape, &[0, 2], "test").is_err());
         assert!(std::panic::catch_unwind(|| linear_offset_unchecked(&shape, &[0, 2])).is_err());
-        assert!(std::panic::catch_unwind(|| linear_offset2(&shape, 0, 2)).is_err());
-        assert!(std::panic::catch_unwind(|| linear_offset3(&[usize::MAX, 3, 2], 0, 2, 1)).is_err());
     }
 }

--- a/crates/tenferro-tensor/src/types/shape_packing.rs
+++ b/crates/tenferro-tensor/src/types/shape_packing.rs
@@ -64,7 +64,7 @@ fn index_select_parts(
     let indices = Tensor::I64(TypedTensor::from_vec_col_major(
         vec![positions.len(), 1],
         index_data,
-    ));
+    )?);
 
     let config = GatherConfig {
         offset_dims,

--- a/crates/tenferro-tensor/src/validate/mod.rs
+++ b/crates/tenferro-tensor/src/validate/mod.rs
@@ -85,8 +85,9 @@ pub fn check_singular_diagonal<T: DiagSingularity + Copy + std::fmt::Debug>(
     let batch_total: usize = t.shape()[2..].iter().product();
     let batch_total = batch_total.max(1);
     let slice_size = rows * cols;
+    let data = t.host_data()?;
     for batch_idx in 0..batch_total {
-        let batch = &t.host_data()[batch_idx * slice_size..(batch_idx + 1) * slice_size];
+        let batch = &data[batch_idx * slice_size..(batch_idx + 1) * slice_size];
         for i in 0..n {
             let diag = batch[i + i * rows];
             if diag.is_singular_or_nonfinite() {

--- a/crates/tenferro-tensor/src/validate/tests.rs
+++ b/crates/tenferro-tensor/src/validate/tests.rs
@@ -7,9 +7,13 @@ macro_rules! float_singular_tests {
         mod $mod_name {
             use super::*;
 
+            fn tensor(shape: Vec<usize>, data: Vec<$t>) -> TypedTensor<$t> {
+                TypedTensor::<$t>::from_vec_col_major(shape, data).unwrap()
+            }
+
             #[test]
             fn nonsquare_tall_nonsingular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![3, 2],
                     vec![
                         2.0 as $t, 1.0 as $t, 0.0 as $t, 0.0 as $t, 5.0 as $t, 4.0 as $t,
@@ -20,7 +24,7 @@ macro_rules! float_singular_tests {
 
             #[test]
             fn nonsquare_tall_singular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![3, 2],
                     vec![
                         0.0 as $t, 1.0 as $t, 0.0 as $t, 0.0 as $t, 0.0 as $t, 4.0 as $t,
@@ -32,7 +36,7 @@ macro_rules! float_singular_tests {
 
             #[test]
             fn nonsquare_wide_nonsingular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 3],
                     vec![
                         2.0 as $t, 0.0 as $t, 1.0 as $t, 3.0 as $t, 0.0 as $t, 4.0 as $t,
@@ -43,7 +47,7 @@ macro_rules! float_singular_tests {
 
             #[test]
             fn nonsquare_wide_singular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 3],
                     vec![
                         0.0 as $t, 0.0 as $t, 1.0 as $t, 3.0 as $t, 0.0 as $t, 4.0 as $t,
@@ -55,27 +59,21 @@ macro_rules! float_singular_tests {
 
             #[test]
             fn zero_diagonal() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
-                    vec![2, 2],
-                    vec![0.0 as $t, 1.0 as $t, 1.0 as $t, 0.0 as $t],
-                );
+                let t = tensor(vec![2, 2], vec![0.0 as $t, 1.0 as $t, 1.0 as $t, 0.0 as $t]);
                 let err = check_singular_diagonal(&t).unwrap_err();
                 assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
             }
 
             #[test]
             fn nan_diagonal() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
-                    vec![2, 2],
-                    vec![<$t>::NAN, 1.0 as $t, 0.0 as $t, 1.0 as $t],
-                );
+                let t = tensor(vec![2, 2], vec![<$t>::NAN, 1.0 as $t, 0.0 as $t, 1.0 as $t]);
                 let err = check_singular_diagonal(&t).unwrap_err();
                 assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
             }
 
             #[test]
             fn inf_diagonal() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 2],
                     vec![<$t>::INFINITY, 1.0 as $t, 0.0 as $t, 1.0 as $t],
                 );
@@ -85,7 +83,7 @@ macro_rules! float_singular_tests {
 
             #[test]
             fn neg_inf_diagonal() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 2],
                     vec![<$t>::NEG_INFINITY, 1.0 as $t, 0.0 as $t, 1.0 as $t],
                 );
@@ -95,20 +93,20 @@ macro_rules! float_singular_tests {
 
             #[test]
             fn single_element_singular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(vec![1, 1], vec![0.0 as $t]);
+                let t = tensor(vec![1, 1], vec![0.0 as $t]);
                 let err = check_singular_diagonal(&t).unwrap_err();
                 assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
             }
 
             #[test]
             fn single_element_nonsingular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(vec![1, 1], vec![5.0 as $t]);
+                let t = tensor(vec![1, 1], vec![5.0 as $t]);
                 assert!(check_singular_diagonal(&t).is_ok());
             }
 
             #[test]
             fn batched_singular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 2, 2],
                     vec![
                         1.0 as $t, 0.0 as $t, 0.0 as $t, 2.0 as $t, 0.0 as $t, 0.0 as $t,
@@ -121,7 +119,7 @@ macro_rules! float_singular_tests {
 
             #[test]
             fn batched_nonsingular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 2, 2],
                     vec![
                         1.0 as $t, 0.0 as $t, 0.0 as $t, 2.0 as $t, 3.0 as $t, 0.0 as $t,
@@ -139,9 +137,13 @@ macro_rules! complex_singular_tests {
         mod $mod_name {
             use super::*;
 
+            fn tensor(shape: Vec<usize>, data: Vec<$t>) -> TypedTensor<$t> {
+                TypedTensor::<$t>::from_vec_col_major(shape, data).unwrap()
+            }
+
             #[test]
             fn nonsquare_tall_nonsingular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![3, 2],
                     vec![
                         <$t>::new(2.0 as $float, 0.0 as $float),
@@ -157,7 +159,7 @@ macro_rules! complex_singular_tests {
 
             #[test]
             fn nonsquare_tall_singular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![3, 2],
                     vec![
                         <$t>::new(0.0 as $float, 0.0 as $float),
@@ -174,7 +176,7 @@ macro_rules! complex_singular_tests {
 
             #[test]
             fn nonsquare_wide_nonsingular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 3],
                     vec![
                         <$t>::new(2.0 as $float, 0.0 as $float),
@@ -190,7 +192,7 @@ macro_rules! complex_singular_tests {
 
             #[test]
             fn nonsquare_wide_singular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 3],
                     vec![
                         <$t>::new(0.0 as $float, 0.0 as $float),
@@ -207,7 +209,7 @@ macro_rules! complex_singular_tests {
 
             #[test]
             fn nonsingular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 2],
                     vec![
                         <$t>::new(2.0 as $float, 0.0 as $float),
@@ -221,7 +223,7 @@ macro_rules! complex_singular_tests {
 
             #[test]
             fn zero_diagonal() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 2],
                     vec![
                         <$t>::new(0.0 as $float, 0.0 as $float),
@@ -236,7 +238,7 @@ macro_rules! complex_singular_tests {
 
             #[test]
             fn nan_diagonal() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 2],
                     vec![
                         <$t>::new(<$float>::NAN, 0.0 as $float),
@@ -251,7 +253,7 @@ macro_rules! complex_singular_tests {
 
             #[test]
             fn inf_diagonal() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 2],
                     vec![
                         <$t>::new(1.0 as $float, <$float>::INFINITY),
@@ -266,7 +268,7 @@ macro_rules! complex_singular_tests {
 
             #[test]
             fn neg_inf_diagonal() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 2],
                     vec![
                         <$t>::new(<$float>::NEG_INFINITY, 0.0 as $float),
@@ -281,26 +283,20 @@ macro_rules! complex_singular_tests {
 
             #[test]
             fn single_element_singular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
-                    vec![1, 1],
-                    vec![<$t>::new(0.0 as $float, 0.0 as $float)],
-                );
+                let t = tensor(vec![1, 1], vec![<$t>::new(0.0 as $float, 0.0 as $float)]);
                 let err = check_singular_diagonal(&t).unwrap_err();
                 assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
             }
 
             #[test]
             fn single_element_nonsingular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
-                    vec![1, 1],
-                    vec![<$t>::new(5.0 as $float, 0.0 as $float)],
-                );
+                let t = tensor(vec![1, 1], vec![<$t>::new(5.0 as $float, 0.0 as $float)]);
                 assert!(check_singular_diagonal(&t).is_ok());
             }
 
             #[test]
             fn batched_singular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 2, 2],
                     vec![
                         <$t>::new(1.0 as $float, 0.0 as $float),
@@ -319,7 +315,7 @@ macro_rules! complex_singular_tests {
 
             #[test]
             fn batched_nonsingular() {
-                let t = TypedTensor::<$t>::from_vec_col_major(
+                let t = tensor(
                     vec![2, 2, 2],
                     vec![
                         <$t>::new(1.0 as $float, 0.0 as $float),
@@ -351,7 +347,7 @@ fn rank_less_than_two_returns_error_instead_of_panicking() {
         } else {
             vec![1.0, 2.0, 3.0]
         };
-        let t = TypedTensor::<f64>::from_vec_col_major(shape.clone(), data);
+        let t = TypedTensor::<f64>::from_vec_col_major(shape.clone(), data).unwrap();
         let err = check_singular_diagonal(&t).unwrap_err();
         assert!(matches!(
             err,
@@ -369,7 +365,8 @@ fn f64_batched_error_includes_batch_index_and_position() {
     let t = TypedTensor::<f64>::from_vec_col_major(
         vec![2, 2, 2],
         vec![1.0, 0.0, 0.0, 2.0, 3.0, 0.0, 0.0, 0.0],
-    );
+    )
+    .unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
     let msg = match &err {
         Error::BackendFailure { message, .. } => message.clone(),
@@ -387,7 +384,7 @@ fn f64_batched_error_includes_batch_index_and_position() {
 
 #[test]
 fn f64_unbatched_error_omits_batch_index_and_includes_position() {
-    let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]);
+    let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]).unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
     let msg = match &err {
         Error::BackendFailure { message, .. } => message.clone(),
@@ -405,7 +402,7 @@ fn f64_unbatched_error_omits_batch_index_and_includes_position() {
 
 #[test]
 fn f64_unbatched_error_second_diagonal_reports_correct_position() {
-    let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![3.0, 1.0, 1.0, 0.0]);
+    let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![3.0, 1.0, 1.0, 0.0]).unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
     let msg = match &err {
         Error::BackendFailure { message, .. } => message.clone(),
@@ -422,7 +419,8 @@ fn f64_batched_error_first_batch_reports_correct_position() {
     let t = TypedTensor::<f64>::from_vec_col_major(
         vec![2, 2, 2],
         vec![0.0, 1.0, 1.0, 2.0, 3.0, 0.0, 0.0, 4.0],
-    );
+    )
+    .unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
     let msg = match &err {
         Error::BackendFailure { message, .. } => message.clone(),
@@ -440,7 +438,8 @@ fn f64_batched_error_first_batch_reports_correct_position() {
 
 #[test]
 fn f32_unbatched_error_includes_exact_position() {
-    let t = TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![0.0f32, 1.0, 1.0, 0.0]);
+    let t =
+        TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![0.0f32, 1.0, 1.0, 0.0]).unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
     let msg = match &err {
         Error::BackendFailure { message, .. } => message.clone(),
@@ -466,7 +465,8 @@ fn c64_unbatched_error_includes_exact_position() {
             Complex64::new(1.0, 0.0),
             Complex64::new(0.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
     let msg = match &err {
         Error::BackendFailure { message, .. } => message.clone(),
@@ -492,7 +492,8 @@ fn c32_unbatched_error_includes_exact_position() {
             Complex32::new(1.0, 0.0),
             Complex32::new(0.0, 0.0),
         ],
-    );
+    )
+    .unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
     let msg = match &err {
         Error::BackendFailure { message, .. } => message.clone(),
@@ -517,30 +518,36 @@ macro_rules! validate_nonsingular_u_test {
 
             #[test]
             fn singular() {
-                let t = Tensor::$variant(TypedTensor::<$inner>::from_vec_col_major(
-                    vec![2, 2],
-                    vec![
-                        <$inner>::zero(),
-                        <$inner>::one(),
-                        <$inner>::one(),
-                        <$inner>::zero(),
-                    ],
-                ));
+                let t = Tensor::$variant(
+                    TypedTensor::<$inner>::from_vec_col_major(
+                        vec![2, 2],
+                        vec![
+                            <$inner>::zero(),
+                            <$inner>::one(),
+                            <$inner>::one(),
+                            <$inner>::zero(),
+                        ],
+                    )
+                    .unwrap(),
+                );
                 let err = validate_nonsingular_u(&t).unwrap_err();
                 assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
             }
 
             #[test]
             fn nonsingular() {
-                let t = Tensor::$variant(TypedTensor::<$inner>::from_vec_col_major(
-                    vec![2, 2],
-                    vec![
-                        <$inner>::one(),
-                        <$inner>::zero(),
-                        <$inner>::zero(),
-                        <$inner>::one() + <$inner>::one(),
-                    ],
-                ));
+                let t = Tensor::$variant(
+                    TypedTensor::<$inner>::from_vec_col_major(
+                        vec![2, 2],
+                        vec![
+                            <$inner>::one(),
+                            <$inner>::zero(),
+                            <$inner>::zero(),
+                            <$inner>::one() + <$inner>::one(),
+                        ],
+                    )
+                    .unwrap(),
+                );
                 assert!(validate_nonsingular_u(&t).is_ok());
             }
         }

--- a/crates/tenferro-xla/src/lowering/shape.rs
+++ b/crates/tenferro-xla/src/lowering/shape.rs
@@ -25,6 +25,16 @@ pub(crate) fn static_output_shape(
             axis,
             kind,
         }),
+        Err(GraphProgramLoweringShapeError::InvalidDimExpr {
+            op,
+            output_index,
+            axis,
+            source,
+        }) => Err(Error::InvalidProgram {
+            message: format!(
+                "ExecOp::{op} output {output_index} axis {axis} has invalid dimension expression: {source}"
+            ),
+        }),
     }
 }
 

--- a/crates/tenferro-xla/src/lowering/shape/tests.rs
+++ b/crates/tenferro-xla/src/lowering/shape/tests.rs
@@ -4,7 +4,7 @@ use tenferro_runtime::{GraphCompiler, TracedTensor};
 
 #[test]
 fn missing_output_shape_metadata_maps_to_invalid_program() {
-    let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]);
+    let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&x.neg()).unwrap();
     let inst = program.lowering_view().instructions().next().unwrap();

--- a/crates/tenferro-xla/tests/public_api.rs
+++ b/crates/tenferro-xla/tests/public_api.rs
@@ -38,7 +38,7 @@ fn xla_executor_options_debug_and_lowering_are_stable() {
     assert!(debug.contains("has_loaded_pjrt_plugin"));
     assert_eq!(XlaExecutor::default().options(), options);
 
-    let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]);
+    let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&x.neg()).unwrap();
     let module = executor.lower_to_stablehlo(&program).unwrap();

--- a/crates/tenferro-xla/tests/stablehlo_lowering.rs
+++ b/crates/tenferro-xla/tests/stablehlo_lowering.rs
@@ -4,7 +4,7 @@ use tenferro_xla::lower_to_stablehlo;
 #[test]
 fn lowers_elementwise_reduce_and_static_shapes() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 2);
-    let y = (&x + &x).reduce_sum(&[0]);
+    let y = (&x + &x).unwrap().reduce_sum(&[0]).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&y, &[(&x, DType::F64, &[2, 3])])
@@ -26,6 +26,7 @@ fn lowers_structural_ops_and_convert() {
     let y = x
         .broadcast_in_dim(&[2, 3], &[1])
         .transpose(&[1, 0])
+        .unwrap()
         .reshape(&[6])
         .convert(DType::F64);
     let mut compiler = GraphCompiler::new();
@@ -49,15 +50,17 @@ fn lowers_structural_ops_and_convert() {
 fn lowers_unbatched_dot_general() {
     let lhs = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let rhs = TracedTensor::input_symbolic_shape(DType::F64, 2);
-    let product = lhs.dot_general(
-        &rhs,
-        DotGeneralConfig {
-            lhs_contracting_dims: vec![1],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: vec![],
-            rhs_batch_dims: vec![],
-        },
-    );
+    let product = lhs
+        .dot_general(
+            &rhs,
+            DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+        )
+        .unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(
@@ -76,20 +79,24 @@ fn lowers_unbatched_dot_general() {
 
 #[test]
 fn lowers_concrete_nary_einsum_via_standard_ops() {
-    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0])
+        .unwrap();
     let mid = TracedTensor::from_vec_col_major(
         vec![3, 4],
         vec![
             10.0_f64, 20.0, 30.0, 11.0, 21.0, 31.0, 12.0, 22.0, 32.0, 13.0, 23.0, 33.0,
         ],
-    );
+    )
+    .unwrap();
     let rhs = TracedTensor::from_vec_col_major(
         vec![4, 2],
         vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
-    );
+    )
+    .unwrap();
     let mut compiler = GraphCompiler::new();
     let product =
-        tenferro_einsum::einsum(&mut compiler, &[&lhs, &mid, &rhs], "ij,jk,kl->il").unwrap();
+        tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&lhs, &mid, &rhs], "ij,jk,kl->il")
+            .unwrap();
     let program = compiler.compile(&product).unwrap();
 
     let module = lower_to_stablehlo(&program).unwrap();
@@ -108,7 +115,8 @@ fn lowers_static_symbolic_nary_einsum_extension_via_standard_ops() {
     let rhs = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let mut compiler = GraphCompiler::new();
     let product =
-        tenferro_einsum::einsum(&mut compiler, &[&lhs, &mid, &rhs], "ij,jk,kl->il").unwrap();
+        tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&lhs, &mid, &rhs], "ij,jk,kl->il")
+            .unwrap();
     let program = compiler
         .compile_with_input_specs(
             &product,
@@ -133,15 +141,17 @@ fn lowers_static_symbolic_nary_einsum_extension_via_standard_ops() {
 fn batched_dot_general_transposes_stablehlo_batch_first_result() {
     let lhs = TracedTensor::input_symbolic_shape(DType::F64, 3);
     let rhs = TracedTensor::input_symbolic_shape(DType::F64, 3);
-    let product = lhs.dot_general(
-        &rhs,
-        DotGeneralConfig {
-            lhs_contracting_dims: vec![2],
-            rhs_contracting_dims: vec![1],
-            lhs_batch_dims: vec![0],
-            rhs_batch_dims: vec![0],
-        },
-    );
+    let product = lhs
+        .dot_general(
+            &rhs,
+            DotGeneralConfig {
+                lhs_contracting_dims: vec![2],
+                rhs_contracting_dims: vec![1],
+                lhs_batch_dims: vec![0],
+                rhs_batch_dims: vec![0],
+            },
+        )
+        .unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(
@@ -165,7 +175,7 @@ fn batched_dot_general_transposes_stablehlo_batch_first_result() {
 
 #[test]
 fn lowers_multi_output_program_and_special_scalar_constants() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let scaled_nan = x.scale_real(f64::NAN);
     let scaled_neg_inf = x.scale_real(f64::NEG_INFINITY);
     let scaled_pos_inf = x.scale_real(f64::INFINITY);
@@ -190,7 +200,7 @@ fn lowers_multi_output_program_and_special_scalar_constants() {
 
 #[test]
 fn lowers_f32_scalar_constant() {
-    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]);
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap();
     let scaled = x.scale_real(2.5);
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&scaled).unwrap();

--- a/crates/tenferro-xla/tests/unsupported.rs
+++ b/crates/tenferro-xla/tests/unsupported.rs
@@ -1,25 +1,25 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use tenferro_runtime::extension::{try_apply, ExtensionOpTrait};
+use tenferro_runtime::extension::{apply, ExtensionOp};
 use tenferro_runtime::{DType, GraphCompiler, SymDim, Tensor, TracedTensor};
 use tenferro_xla::{lower_to_stablehlo, Error};
 
 #[derive(Clone, Debug)]
 struct RuntimeOnlyExtension;
 
-impl ExtensionOpTrait for RuntimeOnlyExtension {
+impl ExtensionOp for RuntimeOnlyExtension {
     fn family_id(&self) -> &'static str {
         "test.runtime_only.v1"
     }
 
     fn payload_hash(&self, _hasher: &mut dyn std::hash::Hasher) {}
 
-    fn payload_eq(&self, other: &dyn ExtensionOpTrait) -> bool {
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
         other.as_any().downcast_ref::<Self>().is_some()
     }
 
-    fn clone_arc(&self) -> Arc<dyn ExtensionOpTrait> {
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
         Arc::new(self.clone())
     }
 
@@ -51,7 +51,7 @@ impl ExtensionOpTrait for RuntimeOnlyExtension {
 #[test]
 fn rejects_i64_dtype_before_emitting_mlir() {
     let x = TracedTensor::input_symbolic_shape(DType::I64, 1);
-    let y = &x + &x;
+    let y = (&x + &x).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&y, &[(&x, DType::I64, &[2])])
@@ -72,7 +72,7 @@ fn rejects_i64_dtype_before_emitting_mlir() {
 fn rejects_dynamic_upper_bound_extents() {
     let data = TracedTensor::input_symbolic_shape(DType::F64, 1);
     let size = TracedTensor::input_symbolic_shape(DType::F64, 0);
-    let y = data.dynamic_truncate(&size, 0);
+    let y = data.dynamic_truncate(&size, 0).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&y, &[(&data, DType::F64, &[4]), (&size, DType::F64, &[])])
@@ -107,7 +107,7 @@ fn rejects_unsupported_static_op() {
 #[test]
 fn rejects_extension_without_standard_op_lowering() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1);
-    let outputs = try_apply(Arc::new(RuntimeOnlyExtension), &[&x]).unwrap();
+    let outputs = apply(Arc::new(RuntimeOnlyExtension), &[&x]).unwrap();
     let y = outputs.into_iter().next().unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler

--- a/crates/tenferro-xla/tests/xla_tool_execution.rs
+++ b/crates/tenferro-xla/tests/xla_tool_execution.rs
@@ -80,16 +80,18 @@ fn run_hlo_module(config: &XlaToolConfig, prefix: &str, module: &tenferro_xla::S
 fn stablehlo_dot_add_reduce_module() -> tenferro_xla::StableHloModule {
     let lhs = TracedTensor::input_symbolic_shape(DType::F32, 2);
     let rhs = TracedTensor::input_symbolic_shape(DType::F32, 2);
-    let dot = lhs.dot_general(
-        &rhs,
-        DotGeneralConfig {
-            lhs_contracting_dims: vec![1],
-            rhs_contracting_dims: vec![0],
-            lhs_batch_dims: vec![],
-            rhs_batch_dims: vec![],
-        },
-    );
-    let y = (&dot + &dot).reduce_sum(&[0]);
+    let dot = lhs
+        .dot_general(
+            &rhs,
+            DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            },
+        )
+        .unwrap();
+    let y = (&dot + &dot).unwrap().reduce_sum(&[0]).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(
@@ -106,7 +108,8 @@ fn stablehlo_nary_einsum_module() -> tenferro_xla::StableHloModule {
     let rhs = TracedTensor::input_symbolic_shape(DType::F32, 2);
     let mut compiler = GraphCompiler::new();
     let product =
-        tenferro_einsum::einsum(&mut compiler, &[&lhs, &mid, &rhs], "ij,jk,kl->il").unwrap();
+        tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&lhs, &mid, &rhs], "ij,jk,kl->il")
+            .unwrap();
     let program = compiler
         .compile_with_input_specs(
             &product,

--- a/docs/design/contraction-pipeline.md
+++ b/docs/design/contraction-pipeline.md
@@ -104,7 +104,7 @@ CPU execution is handled by `CpuBackend`:
 
 ## CubeCL/CUDA Execution
 
-When a compiled program is evaluated with `CubeclBackend`, the same graph-level
+When a compiled program is evaluated with `CudaBackend`, the same graph-level
 ops run on GPU if supported:
 
 - `dot_general` can route through CubeCL/CUDA and cuTENSOR/cuBLAS-backed paths,
@@ -112,7 +112,7 @@ ops run on GPU if supported:
 - unsupported dtypes or operations return `BackendFailure`.
 
 There is no current separate direct `CudaBackend` contraction pipeline. Future
-GPU contraction improvements should extend `CubeclBackend` and preserve the
+GPU contraction improvements should extend `CudaBackend` and preserve the
 explicit placement policy described in [gpu-backend-design.md](./gpu-backend-design.md).
 
 ## Planner Safety

--- a/docs/design/einsum.md
+++ b/docs/design/einsum.md
@@ -172,7 +172,7 @@ contiguous block for the underlying tensor backend.
 ## GPU Interaction
 
 Einsum itself remains backend-agnostic at the graph level. GPU execution happens
-when a compiled program is evaluated with `CubeclBackend` from
+when a compiled program is evaluated with `CudaBackend` from
 `crates/tenferro-gpu/src/cubecl/`.
 
 Current GPU status:

--- a/docs/design/exec-session.md
+++ b/docs/design/exec-session.md
@@ -67,18 +67,18 @@ re-enter the pool.
 
 ### CubeCL/CUDA
 
-`CubeclBackend` is the current CUDA GPU backend. It uses CubeCL/CubeCL-CUDA and
+`CudaBackend` is the current CUDA GPU backend. It uses CubeCL/CubeCL-CUDA and
 runtime-loaded CUDA libraries from `crates/tenferro-gpu/src/cubecl/`.
 
-Today `CubeclBackend` does not define a separate exec-session struct. It uses
+Today `CudaBackend` does not define a separate exec-session struct. It uses
 the default `TensorBackend::with_backend_session` adapter, so each `BackendSession`
 call forwards to the backend method. The backend method launches CubeCL kernels
 or calls the relevant cuTENSOR/cuSOLVER/cuBLAS wrapper against the backend's
-`CubeclRuntime`.
+`CudaRuntime`.
 
 | CPU concept | CubeCL/CUDA concept |
 |---|---|
-| `CpuContext` (thread count and Rayon pool) | `CubeclRuntime` (CUDA device/client) |
+| `CpuContext` (thread count and Rayon pool) | `CudaRuntime` (CUDA device/client) |
 | `Par::rayon(0)` / `Par::Seq` | CubeCL launch through the stored runtime |
 | `BufferPool` (host `Vec<T>`) | CubeCL device buffers plus upload/download helpers |
 | faer/rayon CPU work | kernel launch on stream |
@@ -87,7 +87,7 @@ or calls the relevant cuTENSOR/cuSOLVER/cuBLAS wrapper against the backend's
 Future CubeCL work may introduce a dedicated GPU exec session if there is a
 measurable benefit from binding temporary workspace, stream state, or device
 buffer pooling across an entire compiled program. That should extend
-`CubeclBackend`; it should not add a separate `CudaBackend` type.
+`CudaBackend`; it should not add a separate `CudaBackend` type.
 
 ### Default (no-op)
 

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -1,9 +1,8 @@
 # GPU Backend Design
 
 This document is developer-facing. Public user docs describe GPU providers as
-explicit backend choices. CUDA is exposed as `tenferro_gpu::CudaBackend`, with
-`CubeclBackend` retained as a backwards-compatible CUDA alias while downstream
-users migrate. WebGPU is exposed as `tenferro_gpu::WebGpuBackend`. Backend
+explicit backend choices. CUDA is exposed as `tenferro_gpu::CudaBackend`.
+WebGPU is exposed as `tenferro_gpu::WebGpuBackend`. Backend
 features are additive provider choices: `cuda` and `webgpu` are both explicit,
 neither is enabled by default as a GPU provider, and downstream crates may
 enable either or both. Eager and operation crates should propagate the same
@@ -75,8 +74,7 @@ crates/tenferro-gpu/src/webgpu/
 ```
 
 The provider-specific public backend types are `tenferro_gpu::CudaBackend` and
-`tenferro_gpu::WebGpuBackend`. `CubeclBackend` remains a compatibility alias for
-`CudaBackend`; new code should use provider-specific names. CUDA is selected by
+`tenferro_gpu::WebGpuBackend`; CubeCL naming is an implementation detail. CUDA is selected by
 enabling the `cuda` feature, which depends on the workspace-pinned CubeCL fork
 and the CubeCL CUDA runtime. WebGPU is selected by enabling the `webgpu`
 feature, which depends on CubeCL-WGPU and the CubeK matmul provider. Enabling
@@ -121,9 +119,8 @@ use workspace dependencies or a deliberate crates.io/git dependency.
 ## Runtime And Library Loading
 
 `CudaRuntime::new(device_ordinal)` initializes CUDA and creates the CubeCL CUDA
-client for one device. `CubeclRuntime` remains a compatibility alias for
-`CudaRuntime`. GPU kernels are JIT-compiled by CubeCL, so local CUDA toolkit
-configuration matters.
+client for one device. GPU kernels are JIT-compiled by CubeCL, so local CUDA
+toolkit configuration matters.
 
 `WebGpuRuntime::new(device_ordinal)` creates a CubeCL-WGPU client for a WebGPU
 adapter. WebGPU runtime initialization must not call CUDA driver/runtime APIs,
@@ -219,10 +216,10 @@ instead. That module intentionally exposes only the bridges that cannot live in
 - byte workspaces kept alive for CUDA library calls,
 - scoped access to the CubeCL client for operation-owned kernel launches.
 
-`CubeclRuntime::client`, `CubeclRuntime::raw_cuda_stream`, `CubeclBuffer`
+`CudaRuntime::client`, `CudaRuntime::raw_cuda_stream`, `CubeclBuffer`
 fields, and raw `CubeclBuffer` constructors are not public API. Public tensor
-users should use `CubeclBackend`, `upload_tensor`, `download_tensor`,
-`device_ptr`, and `CubeclRuntime::synchronize`.
+users should use `CudaBackend`, `upload_tensor`, `download_tensor`,
+`device_ptr`, and `CudaRuntime::synchronize`.
 
 ## Kernel Metadata Contract
 
@@ -371,7 +368,7 @@ cuSOLVER rejects null U/V pointers on that path.
 
 The published [`Devices and GPU`](../guides/devices-and-gpu.md) guide contains
 the current CUDA operation and dtype matrix. Keep that matrix synchronized with
-the `CubeclBackend` `TensorBackend` implementation when adding or removing CUDA
+the `CudaBackend` `TensorBackend` implementation when adding or removing CUDA
 dispatch arms.
 
 General eigendecomposition (`eig`, LAPACK `dgeev` style) is not provided by

--- a/docs/design/supported-ops.md
+++ b/docs/design/supported-ops.md
@@ -61,7 +61,7 @@ subset of each op.
 ### CUDA/CubeCL Status
 
 The public GPU crate exposes this backend as
-`tenferro_gpu::CubeclBackend` behind the `cuda` feature. It is backed
+`tenferro_gpu::CudaBackend` behind the `cuda` feature. It is backed
 by CubeCL/CubeCL-CUDA and runtime-loaded cuTENSOR, cuSOLVER, and cuBLAS.
 Static kernels live in `crates/tenferro-gpu/src/kernels`.
 

--- a/docs/design/tensor-prims.md
+++ b/docs/design/tensor-prims.md
@@ -31,7 +31,7 @@ tenferro-tensor
     Tensor, TypedTensor<T, R>, TypedTensorView, TensorBackend, BackendSession
         │
         ├── tenferro_cpu::CpuBackend
-        └── tenferro_gpu::CubeclBackend (feature = "cuda")
+        └── tenferro_gpu::CudaBackend (feature = "cuda")
         ▲
         │
 tenferro-tensor-core
@@ -82,7 +82,7 @@ faer or BLAS/LAPACK for GEMM and linalg. `CpuBackend` stores the runtime
 provider selection for an individual backend instance. `CpuBackend::new()`
 chooses the compiled default provider: BLAS if `cpu-blas` is compiled,
 otherwise faer. Explicit constructors such as `CpuBackend::with_kind` and
-`CpuBackend::try_with_threads_and_kind` can select any provider compiled into
+`CpuBackend::with_threads_and_kind` can select any provider compiled into
 the binary. `CpuContext` stores the CPU thread count as the single source of
 truth for tenferro-owned CPU parallelism and owns the Rayon thread pool used by
 multi-thread contexts.
@@ -97,7 +97,7 @@ remains provider-owned.
 
 ## CubeCL Backend
 
-`tenferro_gpu::CubeclBackend` is the current GPU backend under the `cuda`
+`tenferro_gpu::CudaBackend` is the current GPU backend under the `cuda`
 feature. It targets NVIDIA CUDA through CubeCL/CubeCL-CUDA and uses runtime-loaded
 cuTENSOR, cuSOLVER, and cuBLAS where needed.
 
@@ -153,5 +153,5 @@ of the linalg extension backend surface, with CPU implementations under
 `crates/tenferro-linalg/src/gpu`.
 
 General eigendecomposition is a permanent CUDA limitation for cuSOLVER:
-`CubeclBackend::eig` returns `BackendFailure`, and callers must explicitly
+`CudaBackend::eig` returns `BackendFailure`, and callers must explicitly
 download to CPU if they want CPU `eig`.

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -13,7 +13,7 @@ reuse.
 | --- | --- | --- |
 | Data layer | The value you pass around | `TypedTensor<T>`, `Tensor`, `EagerTensor`, `TracedTensor` |
 | Execution model | When operations run | Direct, eager, traced compile/run |
-| Backend/device | Where operations run | `CpuBackend` or `tenferro_gpu::CubeclBackend` |
+| Backend/device | Where operations run | `CpuBackend` or `tenferro_gpu::CudaBackend` |
 
 CUDA is not a separate tensor type. The same concrete, eager, and traced APIs
 can run supported operations on CUDA tensors when data is explicitly uploaded
@@ -102,7 +102,7 @@ let x = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]
 let loss = (&x * &x).reduce_sum(&[0]).unwrap();
 loss.backward().unwrap();
 
-assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
+assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
 ```
 
 ## Traced Graph Execution

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -63,9 +63,7 @@ tenferro-cpu = { path = "/path/to/tenferro-rs/crates/tenferro-cpu", default-feat
 
 The explicit provider features are `blas-openblas`, `blas-accelerate`, and
 `blas-mkl`. Cargo features are additive, so tenferro rejects builds that enable
-more than one explicit BLAS provider. The legacy `src-openblas`,
-`src-accelerate`, and `src-intel-mkl-dynamic-parallel` names remain aliases for
-the corresponding explicit provider features.
+more than one explicit BLAS provider.
 
 Provider build scripts may need environment variables when using system
 installations. OpenBLAS setups commonly use `OPENBLAS_LIB_DIR`; MKL setups

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -26,7 +26,7 @@ This page is for readers who already know either `torch` or `jax.numpy` and want
 | Matrix multiply | `torch.matmul(a, b)` | `jnp.matmul(a, b)` | `tenferro_runtime::tensor::matmul(&a, &b, &mut ctx)` | `tenferro_runtime::traced_tensor::matmul(&a, &b)` |
 | Reshape | `x.reshape(shape)` | `jnp.reshape(x, shape)` | `tenferro_runtime::tensor::reshape(&x, &shape, &mut ctx)` | `x.reshape(&shape)` |
 | Transpose | `x.transpose(0, 1)` | `jnp.transpose(x, axes)` | `tenferro_runtime::tensor::transpose(&x, &perm, &mut ctx)` | `x.transpose(&perm)` |
-| Broadcast | `x.expand(...)` / implicit broadcast | implicit broadcast in many ops | backend-level op | `x.broadcast(&shape, &dims)` |
+| Broadcast | `x.expand(...)` / implicit broadcast | implicit broadcast in many ops | backend-level op | `x.broadcast_in_dim(&shape, &dims)` |
 | Reduce sum | `x.sum(dim=...)` | `jnp.sum(x, axis=...)` | `tenferro_runtime::tensor::reduce_sum(&x, &axes, &mut ctx)` | `x.reduce_sum(&axes)` |
 | Einsum | `torch.einsum(spec, ...)` | `jnp.einsum(spec, ...)` | `tenferro_einsum::eager_tensor::einsum(...)` | `tenferro_einsum::traced_tensor::einsum(&mut compiler, ...)` plus `register_runtime` |
 | SVD | `torch.linalg.svd(x)` | `jnp.linalg.svd(x)` | `tenferro_linalg::LinalgBackend::svd(&mut ctx, &x)?` | `tenferro_linalg::traced_tensor::svd(&x)?` |

--- a/docs/guides/autodiff.md
+++ b/docs/guides/autodiff.md
@@ -176,7 +176,7 @@ provides the corresponding rules and the caller includes those rules in an
 `AdContext`. If an extension does not support a given AD path, tenferro reports
 that path as unsupported rather than silently returning an incorrect gradient.
 
-The process-global extension-rule registration API is retained as a
-compatibility bridge for older helpers. New code should prefer explicit context
-ownership. See [Custom Tensor Operations](custom-operations.md) for the
-extension model.
+There is no process-global extension-rule registry. Extension AD must be owned
+by an explicit `AdContext` so tests and applications cannot accidentally depend
+on hidden process state. See [Custom Tensor Operations](custom-operations.md)
+for the extension model.

--- a/docs/guides/custom-operations.md
+++ b/docs/guides/custom-operations.md
@@ -41,7 +41,7 @@ An extension crate is responsible for:
 
 Keep operation identity and runtime caches separate.
 
-The `ExtensionOpTrait` value is the operation's graph identity. It participates
+The `ExtensionOp` value is the operation's graph identity. It participates
 in hashing, equality, graph comparison, and AD rule lookup. Put parameters that
 change the meaning of the operation there: axes, normalization mode, algorithm
 choice, and similar values. Do not hide unbounded plan caches, vendor handles,
@@ -70,22 +70,22 @@ users a way to clear it and inspect retained entries.
 
 ## Implementing An Extension Op
 
-Implement `tenferro_runtime::extension::ExtensionOpTrait` for the operation
+Implement `tenferro_runtime::extension::ExtensionOp` for the operation
 descriptor. It carries operation parameters such as axes, modes, constants, or
 kernel configuration. Tensor-valued parameters should usually be normal inputs,
 not descriptor fields.
 
 Extension operation descriptors do not need process-global registration. Construct
-`Arc<dyn ExtensionOpTrait>` and pass it to `tenferro_runtime::extension::apply` for
+`Arc<dyn ExtensionOp>` and pass it to `tenferro_runtime::extension::apply` for
 traced tensors or `apply_eager` for eager tensors.
 
-For AD, implement `tenferro_ad::extension::ExtensionAdRuleTrait`, put the rule
+For AD, implement `tenferro_ad::extension::ExtensionAdRule`, put the rule
 in a `tenferro_ad::extension::ExtensionRuleSet`, and attach that set with
 `tenferro_ad::AdContext::builder().with_extension_rules(...)`. Rule builders
 expose incoming tangents/cotangents and helper methods for emitting tensor
 operations, so extension authors do not need to handle graph IDs directly. The
-process-global `register_extension_rule` helper remains available only for
-compatibility with older global lookup paths.
+extension crate should expose a small `ad_rules()` helper that constructs the
+fresh rule set its operations need.
 
 When porting Julia `frule` / `rrule` code:
 
@@ -97,7 +97,7 @@ When porting Julia `frule` / `rrule` code:
 
 The lower-level adapter API remains available for specialized extension
 authors who need direct graph-builder control. New extension authors should
-start with `ExtensionAdRuleTrait` plus an explicit `ExtensionRuleSet`.
+start with `ExtensionAdRule` plus an explicit `ExtensionRuleSet`.
 The old `ExtensionFactory` / `register_extension` op-registration API has been
 removed; operation descriptors are carried directly in the graph.
 

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -70,7 +70,7 @@ For a time-axis diagram, see [Execution Models](execution-models.md).
 
 <!-- snippet-source: crates/tenferro-gpu/examples/cuda_quickstart.rs -->
 ```rust
-use tenferro_gpu::{download_tensor, upload_tensor, CubeclBackend as CudaBackend};
+use tenferro_gpu::{download_tensor, upload_tensor, CudaBackend};
 use tenferro_tensor::{Tensor, TensorElementwise};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -228,22 +228,22 @@ let y = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![2], vec![3
 
 let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
 loss.backward().unwrap();
-assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
+assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
 
 let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
 loss.backward().unwrap();
-assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[6.0, 8.0]);
+assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[6.0, 8.0]);
 
-x.clear_grad();
-assert!(x.grad().is_none());
+x.clear_grad().unwrap();
+assert!(x.grad().unwrap().is_none());
 
 let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
 loss.backward().unwrap();
-assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
+assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
 
-ctx.clear_grads();
-assert!(x.grad().is_none());
-assert!(y.grad().is_none());
+ctx.clear_grads().unwrap();
+assert!(x.grad().unwrap().is_none());
+assert!(y.grad().unwrap().is_none());
 ```
 
 `matmul` participates in the same eager reverse-mode workflow:
@@ -269,7 +269,7 @@ let loss = y.mul(&y).unwrap().reduce_sum(&[0, 1]).unwrap();
 assert_eq!(loss.data().as_slice::<f64>().unwrap(), &[1685.0]);
 
 loss.backward().unwrap();
-assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[182.0, 410.0]);
+assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[182.0, 410.0]);
 ```
 
 ## When To Use Each Immediate Layer

--- a/docs/guides/memory-order.md
+++ b/docs/guides/memory-order.md
@@ -85,7 +85,7 @@ Owned export returns the column-major host buffer:
 use tenferro_runtime::Tensor;
 
 let tensor = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
-let (shape, data) = tensor.try_into_vec_col_major::<f64>().unwrap();
+let (shape, data) = tensor.into_vec_col_major::<f64>().unwrap();
 
 assert_eq!(shape, vec![2, 2]);
 assert_eq!(data, vec![1.0, 3.0, 2.0, 4.0]);

--- a/docs/guides/parallelism-and-caching.md
+++ b/docs/guides/parallelism-and-caching.md
@@ -34,7 +34,7 @@ configuration error if the requested provider was not compiled into the binary:
 use tenferro_cpu::CpuBackend;
 use tenferro_cpu::CpuBackendKind;
 
-let backend = CpuBackend::try_with_threads_and_kind(4, CpuBackendKind::Faer).unwrap();
+let backend = CpuBackend::with_threads_and_kind(4, CpuBackendKind::Faer).unwrap();
 assert_eq!(backend.num_threads(), 4);
 assert_eq!(backend.kind(), CpuBackendKind::Faer);
 ```
@@ -48,7 +48,7 @@ parallelism policy:
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::GraphExecutor;
 
-let executor = GraphExecutor::new(CpuBackend::with_threads(4));
+let executor = GraphExecutor::new(CpuBackend::with_threads(4).unwrap());
 assert_eq!(executor.backend().num_threads(), 4);
 ```
 
@@ -151,7 +151,7 @@ use tenferro_runtime::{GraphCompiler, GraphExecutor};
 let eager = EagerRuntime::with_cpu_backend(CpuBackend::new());
 eager.set_extension_cache_limits(ExtensionCacheLimits::new(
     NonZeroUsize::new(128).unwrap(),
-));
+)).unwrap();
 
 let mut compiler = GraphCompiler::new();
 compiler.set_compile_cache_capacity(NonZeroUsize::new(128).unwrap());
@@ -193,7 +193,7 @@ let mut executor = GraphExecutor::new(CpuBackend::new());
 
 compiler.clear_caches();
 executor.clear_caches();
-eager.clear_caches();
+eager.clear_caches().unwrap();
 ```
 
 For CPU executors, `clear_all_caches()` also clears the CPU buffer pool:

--- a/docs/guides/tensor-operations.md
+++ b/docs/guides/tensor-operations.md
@@ -82,7 +82,7 @@ assert_eq!(x.shape(), &[2, 2]);
 assert_eq!(x.get(&[1, 0]), &2.0);
 
 *x.get_mut(&[0, 1]) = 5.0;
-assert_eq!(x.try_get(&[1, 1]), Some(&4.0));
+assert_eq!(x.get(&[1, 1]), Some(&4.0));
 
 let sum: f64 = x.iter().copied().sum();
 assert_eq!(sum, 12.0);
@@ -161,7 +161,7 @@ assert_eq!(x.as_slice(), &[2.0, 4.0, 6.0]);
 
 There is no public closure-style `TypedTensor::map` or `mapv` method in the
 current public API. For host-only transformations, use `iter`, `iter_mut`,
-`as_slice`, `host_data_mut`, or `as_physical_slice_mut`. For tensor math,
+`as_slice`, `as_slice_mut`, `host_data`, or `host_data_mut`. For tensor math,
 reductions, or shape operations that should use backend execution, use typed
 wrappers or the runtime-dtype `Tensor`, `EagerTensor`, or `TracedTensor`
 operation API.
@@ -231,7 +231,7 @@ let x = ctx.variable_from(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0,
 let y = (&x * &x).reduce_sum(&[0]).unwrap();
 
 y.backward().unwrap();
-assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
+assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
 ```
 
 ## Traced Tensor Example

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -24,7 +24,7 @@ An error like `expected GPU tensor ... use upload_tensor()` means a CUDA
 backend operation received CPU data. Upload first:
 
 ```rust
-use tenferro_gpu::{upload_tensor, CubeclBackend as CudaBackend};
+use tenferro_gpu::{upload_tensor, CudaBackend};
 use tenferro_tensor::{Tensor, TensorBackend};
 
 let backend = CudaBackend::new(0).unwrap();
@@ -39,7 +39,7 @@ Host access methods read CPU memory. If a tensor lives on CUDA memory, download
 it before inspecting values:
 
 ```rust
-use tenferro_gpu::{download_tensor, upload_tensor, CubeclBackend as CudaBackend};
+use tenferro_gpu::{download_tensor, upload_tensor, CudaBackend};
 use tenferro_tensor::{Tensor, TensorBackend};
 
 let backend = CudaBackend::new(0).unwrap();
@@ -64,8 +64,8 @@ supported scalar type.
 `Tensor::from_vec_col_major` expects tenferro's physical column-major order.
 When porting PyTorch, NumPy, or JAX examples that use row-major flat data, use
 `Tensor::from_vec_row_major` at the import boundary. If another library expects
-row-major output, export with `try_into_vec_row_major::<T>()`; use
-`try_into_vec_col_major::<T>()` when the consumer expects tenferro's physical
+row-major output, export with `into_vec_row_major::<T>()`; use
+`into_vec_col_major::<T>()` when the consumer expects tenferro's physical
 order.
 See [Memory Order](memory-order.md).
 

--- a/docs/plans/2026-02-13-api-skeleton-impl.md
+++ b/docs/plans/2026-02-13-api-skeleton-impl.md
@@ -745,7 +745,7 @@ strided-traits = { git = "https://github.com/tensor4all/strided-rs" }
 //! # Examples
 //!
 //! ```ignore
-//! use tenferro_einsum::{einsum, Subscripts};
+//! use tenferro_einsum::{traced_tensor::einsum, Subscripts};
 //! use tenferro_tensor::{Tensor, MemoryOrder};
 //! use tenferro_device::Device;
 //!

--- a/docs/plans/2026-02-17-tenferro-burn-poc-design.md
+++ b/docs/plans/2026-02-17-tenferro-burn-poc-design.md
@@ -77,7 +77,7 @@ use burn_ndarray::NdArray;
 
 impl TensorNetworkOps for NdArray<f64> {
     fn tn_einsum(subscripts: &str, inputs: Vec<FloatTensor<Self>>) -> FloatTensor<Self> {
-        // burn_to_tenferro → tenferro_einsum::einsum → tenferro_to_burn
+        // burn_to_tenferro → tenferro_einsum::traced_tensor::einsum → tenferro_to_burn
         todo!()
     }
 }

--- a/docs/plans/2026-02-17-tenferro-burn-poc-impl.md
+++ b/docs/plans/2026-02-17-tenferro-burn-poc-impl.md
@@ -335,7 +335,7 @@ impl TensorNetworkOps for NdArray<f64> {
         _inputs: Vec<FloatTensor<Self>>,
     ) -> FloatTensor<Self> {
         // 1. Convert each input: burn_to_tenferro(input)
-        // 2. Call tenferro_einsum::einsum(subscripts, &tf_inputs)
+        // 2. Call tenferro_einsum::traced_tensor::einsum(subscripts, &tf_inputs)
         // 3. Convert result: tenferro_to_burn(result, device)
         todo!()
     }

--- a/docs/plans/2026-02-22-linalg-backend-impl.md
+++ b/docs/plans/2026-02-22-linalg-backend-impl.md
@@ -798,7 +798,7 @@ git commit -m "refactor(linalg): remove old FaerOps trait"
 
 Change:
 ```rust
-use tenferro_linalg::{svd, svd_frule, svd_rrule, SvdCotangent, SvdOptions};
+use tenferro_linalg::{traced_tensor::svd, svd_frule, svd_rrule, SvdCotangent, SvdOptions};
 ```
 Add:
 ```rust

--- a/docs/plans/2026-02-25-linalg-cpu-completion-design.md
+++ b/docs/plans/2026-02-25-linalg-cpu-completion-design.md
@@ -42,7 +42,8 @@ The crate is more mature than the issue description assumes:
 Near no-op since no GPU code exists. Actions:
 
 - Add module-level doc comments clarifying CPU-only status
-- Add `#[cfg(not(feature = "gpu"))]` compile-time assertion on faer backend
+- Add compile-time assertions against concrete backend features such as `cuda`,
+  `webgpu`, and `rocm` on the faer backend
 - Document in `backend/mod.rs` where future GPU backends would slot in
 - Verify `cargo test -p tenferro-linalg` still passes
 

--- a/docs/plans/2026-03-08-api-contract-bulk-batch.md
+++ b/docs/plans/2026-03-08-api-contract-bulk-batch.md
@@ -67,7 +67,7 @@ Keep `Neg` unchanged.
 
 **Step 2: Route all overloads through the checked helpers**
 
-Delete the panic wrapper helper usage and return the checked result directly from the trait methods.
+Delete the infallible helper usage and return the checked result directly from the trait methods.
 
 **Step 3: Update docs/examples to use `.unwrap()` where operator syntax is still shown**
 

--- a/docs/plans/2026-03-10-tensor-ad-oracles-surface-gap-design.md
+++ b/docs/plans/2026-03-10-tensor-ad-oracles-surface-gap-design.md
@@ -46,12 +46,12 @@ an existing public API with materially matching semantics.
 
 Examples:
 
-- `eigh` maps to `tenferro_linalg::eigen`
-- `eigvals` maps to `tenferro_linalg::eig(...).values`
-- `eigvalsh` maps to `tenferro_linalg::eigen(...).values`
-- `svdvals` maps to `tenferro_linalg::svd(...).s`
-- `matrix_norm` and `vector_norm` map to `tenferro_linalg::norm`
-- `pinv_singular` maps to `tenferro_linalg::pinv`
+- `eigh` maps to `tenferro_linalg::traced_tensor::eigen`
+- `eigvals` maps to `tenferro_linalg::traced_tensor::eig(...).values`
+- `eigvalsh` maps to `tenferro_linalg::traced_tensor::eigen(...).values`
+- `svdvals` maps to `tenferro_linalg::traced_tensor::svd(...).s`
+- `matrix_norm` and `vector_norm` map to `tenferro_linalg::traced_tensor::norm`
+- `pinv_singular` maps to `tenferro_linalg::traced_tensor::pinv`
 
 These families should not spawn product implementation issues. They belong in
 the replay backlog.
@@ -145,7 +145,7 @@ A family counts as covered by existing public surface when:
 
 This is why `eigh` maps to `eigen`, why `svdvals` does not require a new
 `svdvals` symbol, and why `vecdot` or simple `multi_dot` chains can stay in
-the replay backlog through `tenferro_einsum::einsum`.
+the replay backlog through `tenferro_einsum::traced_tensor::einsum`.
 
 ## Issue Strategy
 

--- a/docs/plans/2026-03-20-tenferro-linalg-prims-cuda-consolidation.md
+++ b/docs/plans/2026-03-20-tenferro-linalg-prims-cuda-consolidation.md
@@ -14,7 +14,7 @@
 
 **Current State:** The protocol split is only partial today. `TensorLinalgPrims` and `LinalgCapabilityOp` already live in `tenferro-linalg-prims`, but `TensorLinalgContextFor`, the backend marker types, the tensor-level CPU implementation, and the internal slice-level `LinalgBackend`/provider modules still live in `tenferro-linalg`. This plan finishes that split instead of redoing it from scratch.
 
-**Public API guardrail:** The public `tenferro_linalg::svd(&mut ctx, &tensor, options)` signature should stay unchanged while `tenferro-linalg` becomes CPU/GPU-generic. Backend ownership moves, but the user-facing API does not. The backend/kernel contract remains `TensorLinalgPrims::thin_svd(ctx, a) -> SvdTensorResult<T>`.
+**Public API guardrail:** The public `tenferro_linalg::traced_tensor::svd(&mut ctx, &tensor, options)` signature should stay unchanged while `tenferro-linalg` becomes CPU/GPU-generic. Backend ownership moves, but the user-facing API does not. The backend/kernel contract remains `TensorLinalgPrims::thin_svd(ctx, a) -> SvdTensorResult<T>`.
 
 **SVD layering guardrail:** `SvdOptions` stays in `tenferro-linalg` as public/composite-layer policy, not in `tenferro-linalg-prims`. The `options == None` path is already close to backend-generic because it can return the backend-produced tensors directly. The `options != None` path is not generic today because it reads CPU slices to truncate/repack outputs. CUDA support must not paper over that with GPU→CPU fallback.
 

--- a/docs/plans/2026-03-31-tenferro-linearize-hard-cut-plan.md
+++ b/docs/plans/2026-03-31-tenferro-linearize-hard-cut-plan.md
@@ -490,7 +490,7 @@ Before considering the branch complete, verify all of the following:
 
 ## Notes For Execution
 
-- If a stage exposes a large red surface, do **not** paper over it with compatibility wrappers.
+- If a stage exposes a large red surface, do **not** paper over it with temporary shims.
 - If a crate cannot be made green without reviving legacy types, stop and redesign that stage before continuing.
 - If QR/SVD block the linalg stage, land the easy single-output linalg ops first and keep QR/SVD as the last linalg subtask inside Stage C.
 - The “disable downstream crates” strategy means “do not include them in the current verification target”, not “break their source on purpose”.

--- a/docs/plans/2026-04-13-tenferro-eager-grad-accumulation-plan.md
+++ b/docs/plans/2026-04-13-tenferro-eager-grad-accumulation-plan.md
@@ -27,11 +27,11 @@ fn eager_repeated_backward_accumulates_across_calls() {
 
     let loss = (&x * &x).reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
-    assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
+    assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
 
     let loss = (&x * &x).reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
-    assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[4.0, 8.0, 12.0]);
+    assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[4.0, 8.0, 12.0]);
 }
 ```
 
@@ -63,13 +63,13 @@ fn eager_einsum_ad_backward_accumulates_across_calls() {
     let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
     let loss = c.reduce_sum(&[0, 1]).unwrap();
     let _ = loss.backward().unwrap();
-    let grad_a_once = a.grad().unwrap();
+    let grad_a_once = a.grad().unwrap().unwrap();
 
     let c = eager_einsum_ad(&[&a, &b], "ij,jk->ik").unwrap();
     let loss = c.reduce_sum(&[0, 1]).unwrap();
     let _ = loss.backward().unwrap();
 
-    let grad_a_twice = a.grad().unwrap();
+    let grad_a_twice = a.grad().unwrap().unwrap();
     assert_eq!(
         grad_a_twice.as_slice::<f64>().unwrap(),
         &grad_a_once
@@ -324,14 +324,14 @@ use tenferro::{EagerTensor, Tensor};
 let x = EagerTensor::requires_grad(Tensor::new(vec![2], vec![1.0_f64, 2.0]));
 let loss = (&x * &x).reduce_sum(&[0]).unwrap();
 let _ = loss.backward().unwrap();
-assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
+assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
 
 let loss = (&x * &x).reduce_sum(&[0]).unwrap();
 let _ = loss.backward().unwrap();
-assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[4.0, 8.0]);
+assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[4.0, 8.0]);
 
 x.clear_grad();
-assert!(x.grad().is_none());
+assert!(x.grad().unwrap().is_none());
 ```
 
 Also update the "When to use eager vs lazy" table so it distinguishes:

--- a/docs/plans/2026-05-02-docs-einsum-cleanup-plan.md
+++ b/docs/plans/2026-05-02-docs-einsum-cleanup-plan.md
@@ -92,7 +92,7 @@ Expected: PASS.
 
 **Step 1: Replace stale direct-backend design claims**
 
-Rewrite `docs/design/gpu-backend-design.md` around the current `CubeclBackend` implementation in `tenferro-tensor/src/cubecl/`, the `cubecl` feature, explicit upload/download policy, CUDA-only status, and lazy runtime loading of cuTENSOR/cuSOLVER/cuBLAS. Clearly state that ROCm is a stub and GPU benchmarking is out of scope for this batch.
+Rewrite `docs/design/gpu-backend-design.md` around the current `CudaBackend` implementation in `tenferro-tensor/src/cubecl/`, the `cubecl` feature, explicit upload/download policy, CUDA-only status, and lazy runtime loading of cuTENSOR/cuSOLVER/cuBLAS. Clearly state that ROCm is a stub and GPU benchmarking is out of scope for this batch.
 
 **Step 2: Align einsum design status**
 

--- a/docs/plans/2026-05-03-tenferro-cubecl-reduction-design.md
+++ b/docs/plans/2026-05-03-tenferro-cubecl-reduction-design.md
@@ -227,7 +227,7 @@ explicitly if unavailable.
 Recommended PR sequence:
 
 1. Create `tenferro-cubecl`, adapt the reduction family, and route
-   `CubeclBackend` reductions through the new crate.
+   `CudaBackend` reductions through the new crate.
 2. Refine reduction routines and performance if the first implementation keeps
    conservative algorithms.
 3. Add further kernel families under the established crate boundary, starting

--- a/docs/plans/2026-05-03-tenferro-cubecl-reduction-plan.md
+++ b/docs/plans/2026-05-03-tenferro-cubecl-reduction-plan.md
@@ -930,7 +930,7 @@ git commit -m "feat: implement tenferro cubecl reductions"
 
 ---
 
-### Task 6: Route `CubeclBackend` Reductions Through `tenferro-cubecl`
+### Task 6: Route `CudaBackend` Reductions Through `tenferro-cubecl`
 
 **Files:**
 
@@ -992,7 +992,7 @@ fn cubecl_reshape_metadata<T: CubeElement + Clone>(
 
 **Step 4: Add a generic single-axis allocation/launch helper**
 
-In the `impl CubeclBackend` block, add a helper that allocates keepdims output, creates `TensorBinding`s, and calls a closure:
+In the `impl CudaBackend` block, add a helper that allocates keepdims output, creates `TensorBinding`s, and calls a closure:
 
 ```rust
 fn launch_reduce_axis_typed<T>(
@@ -1463,7 +1463,7 @@ Suggested PR body:
 
 - Adds `tenferro-cubecl` as the dedicated CubeCL kernel crate.
 - Moves GPU reduction launch/kernels behind the new crate boundary.
-- Routes `CubeclBackend` reductions through `tenferro-cubecl`.
+- Routes `CudaBackend` reductions through `tenferro-cubecl`.
 - Adds GPU `i64` `reduce_sum` and `reduce_prod` support.
 - Keeps `i64` max/min and complex max/min unsupported.
 

--- a/docs/plans/2026-05-04-dynamic-symbolic-shapes-829.md
+++ b/docs/plans/2026-05-04-dynamic-symbolic-shapes-829.md
@@ -235,18 +235,17 @@ fn metadata_exposes_exact_extents() {
 
     let extents = ctx.extents_of(&ValRef::External(key));
     assert_eq!(extents, meta.extents());
-    assert_eq!(ctx.exact_shape_of(&ValRef::External(key)), Some(meta.shape.clone()));
+    assert_eq!(ctx.exact_shape_of(&ValRef::External(key)), meta.exact_shape());
 }
 
 #[test]
 fn metadata_exact_shape_rejects_upper_bound() {
     let key = input_key(701);
     let mut ctx = ShapeGuardContext::default();
-    let meta = TensorMeta {
-        dtype: DType::F64,
-        shape: vec![SymDim::from(4usize)],
-        extents: vec![ShapeExtent::upper_bound(SymDim::from(4usize))],
-    };
+    let meta = TensorMeta::with_extents(
+        DType::F64,
+        vec![ShapeExtent::upper_bound(SymDim::from(4usize))],
+    );
     ctx.insert_metadata(key.clone(), meta);
     assert_eq!(ctx.exact_shape_of(&ValRef::External(key)), None);
 }
@@ -304,7 +303,7 @@ impl TensorMeta {
 ```
 
 The `shape` field stays temporarily for existing callers. Treat it as a
-compatibility bound shape, not proof of exactness.
+an explicit bound shape, not proof of exactness.
 
 Add `ShapeGuardContext` accessors:
 
@@ -430,11 +429,13 @@ let output_dtype = infer_output_dtype(op, &input_dtypes);
 infer_output_extents(op, &input_shape_refs)
     .into_iter()
     .map(|extents| {
-        let resolved_inputs: Vec<&[SymDim]> =
-            input_metas.iter().map(|meta| meta.shape.as_slice()).collect();
+        let resolved_inputs: Vec<Vec<SymDim>> =
+            input_metas.iter().map(|meta| meta.bound_shape().unwrap()).collect();
+        let resolved_input_refs: Vec<&[SymDim]> =
+            resolved_inputs.iter().map(Vec::as_slice).collect();
         let resolved_extents = extents
             .into_iter()
-            .map(|extent| extent.map(|dim| SymDim::from_dim_expr(&dim, &resolved_inputs)))
+            .map(|extent| extent.map(|dim| SymDim::from_dim_expr(&dim, &resolved_input_refs)))
             .collect();
         TensorMeta::with_extents(output_dtype, resolved_extents)
     })

--- a/docs/plans/2026-05-12-memory-order-implementation.md
+++ b/docs/plans/2026-05-12-memory-order-implementation.md
@@ -38,13 +38,13 @@ fn tensor_owned_export_is_zero_copy_only_for_matching_order() {
     let ptr = data.as_ptr();
     let tensor = Tensor::from_vec_row_major(vec![2, 2], data);
 
-    let (shape, out) = tensor.try_into_vec_row_major::<f64>().unwrap();
+    let (shape, out) = tensor.into_vec_row_major::<f64>().unwrap();
 
     assert_eq!(shape, vec![2, 2]);
     assert_eq!(out.as_ptr(), ptr);
 
     let mismatch = Tensor::from_vec_row_major(vec![2], vec![1.0_f64])
-        .try_into_vec_col_major::<f64>()
+        .into_vec_col_major::<f64>()
         .unwrap_err();
     assert!(mismatch.to_string().contains("memory order"));
 }

--- a/docs/plans/2026-05-12-owned-contiguous-memory-order-design.md
+++ b/docs/plans/2026-05-12-owned-contiguous-memory-order-design.md
@@ -64,8 +64,8 @@ Tensor::from_vec_row_major(shape, data)
 Owned export should distinguish zero-copy extraction from layout conversion:
 
 ```rust
-tensor.try_into_vec_col_major()
-tensor.try_into_vec_row_major()
+tensor.into_vec_col_major()
+tensor.into_vec_row_major()
 tensor.to_col_major()
 tensor.to_row_major()
 ```

--- a/docs/plans/2026-05-12-user-docs-gpu-guides-design.md
+++ b/docs/plans/2026-05-12-user-docs-gpu-guides-design.md
@@ -61,7 +61,7 @@ pub mod cuda {
     pub use tenferro_tensor::cubecl::{
         download_tensor,
         upload_tensor,
-        CubeclBackend as CudaBackend,
+        CudaBackend,
     };
 }
 ```

--- a/docs/plans/2026-05-12-user-docs-gpu-guides.md
+++ b/docs/plans/2026-05-12-user-docs-gpu-guides.md
@@ -54,7 +54,7 @@ In `tenferro/src/lib.rs`, below the existing public re-exports, add:
 #[cfg(feature = "cubecl")]
 pub mod cuda {
     pub use tenferro_tensor::cubecl::{
-        download_tensor, gpu_available, upload_tensor, CubeclBackend as CudaBackend,
+        download_tensor, gpu_available, upload_tensor, CudaBackend,
     };
 }
 ```

--- a/docs/plans/2026-05-14-issue-856-index-select-plan.md
+++ b/docs/plans/2026-05-14-issue-856-index-select-plan.md
@@ -885,7 +885,7 @@ fn eager_index_select_repeated_positions_accumulates_grad() {
     let loss = (&selected * &weights).reduce_sum(&[0]).unwrap();
     let _ = loss.backward().unwrap();
 
-    assert_close_slice(f64_data(x.grad().unwrap().as_ref()), &[0.0, 30.0, 30.0], TOL);
+    assert_close_slice(f64_data(x.grad().unwrap().unwrap().as_ref()), &[0.0, 30.0, 30.0], TOL);
 }
 ```
 

--- a/docs/plans/2026-05-16-remove-row-major-design.md
+++ b/docs/plans/2026-05-16-remove-row-major-design.md
@@ -41,8 +41,8 @@ Remove:
   unnecessary.
 - `from_vec_row_major`, `from_vec_col_major`, and `from_vec_with_order` when
   they only exist to expose layout choice.
-- `to_row_major`, `to_col_major`, `to_order`, `try_into_vec_row_major`,
-  `try_into_vec_col_major`, and `try_into_vec_with_order`.
+- `to_row_major`, `to_col_major`, `to_order`, `into_vec_row_major`,
+  `into_vec_col_major`, and `try_into_vec_with_order`.
 - row-major behavior claims from user-facing docs.
 - row-major-specific production tests.
 

--- a/docs/plans/2026-05-16-remove-row-major-implementation.md
+++ b/docs/plans/2026-05-16-remove-row-major-implementation.md
@@ -231,7 +231,7 @@ Mention that NumPy/PyTorch row-major flat buffers must be converted before const
 Run:
 
 ```bash
-rg -n "MemoryOrder|RowMajor|from_vec_row_major|from_vec_col_major|from_vec_with_order|to_row_major|to_col_major|to_order|try_into_vec_row_major|try_into_vec_col_major|try_into_vec_with_order|row-major|row major" README.md tenferro tenferro-tensor docs/guides docs/getting-started
+rg -n "MemoryOrder|RowMajor|from_vec_row_major|from_vec_col_major|from_vec_with_order|to_row_major|to_col_major|to_order|into_vec_row_major|into_vec_col_major|try_into_vec_with_order|row-major|row major" README.md tenferro tenferro-tensor docs/guides docs/getting-started
 ```
 
 Expected: only intentional plain-English statements about external row-major formats remain; no removed API names remain in active docs or source.
@@ -310,7 +310,7 @@ Expected: PASS.
 Run:
 
 ```bash
-rg -n "MemoryOrder|RowMajor|from_vec_row_major|from_vec_col_major|from_vec_with_order|to_row_major|to_col_major|to_order|try_into_vec_row_major|try_into_vec_col_major|try_into_vec_with_order" tenferro tenferro-tensor docs/guides docs/getting-started README.md
+rg -n "MemoryOrder|RowMajor|from_vec_row_major|from_vec_col_major|from_vec_with_order|to_row_major|to_col_major|to_order|into_vec_row_major|into_vec_col_major|try_into_vec_with_order" tenferro tenferro-tensor docs/guides docs/getting-started README.md
 ```
 
 Expected: no matches.

--- a/docs/plans/2026-05-22-context-engine-refactor-design.md
+++ b/docs/plans/2026-05-22-context-engine-refactor-design.md
@@ -180,11 +180,11 @@ convert into the internal column-major buffer at construction time.
 Add explicit exports:
 
 ```rust
-typed.try_into_vec_col_major()
-typed.try_into_vec_row_major()
+typed.into_vec_col_major()
+typed.into_vec_row_major()
 
-tensor.try_into_vec_col_major::<T>()
-tensor.try_into_vec_row_major::<T>()
+tensor.into_vec_col_major::<T>()
+tensor.into_vec_row_major::<T>()
 ```
 
 If a borrowed export is added, name it `to_vec_*` or `try_to_vec_*` so ownership

--- a/docs/plans/2026-05-22-context-engine-refactor.md
+++ b/docs/plans/2026-05-22-context-engine-refactor.md
@@ -72,11 +72,11 @@ fn typed_tensor_explicit_memory_order_exports_requested_order() {
         vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0],
     );
 
-    let (shape, col) = tensor.clone().try_into_vec_col_major().unwrap();
+    let (shape, col) = tensor.clone().into_vec_col_major().unwrap();
     assert_eq!(shape, vec![2, 3]);
     assert_eq!(col, vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
 
-    let (shape, row) = tensor.try_into_vec_row_major().unwrap();
+    let (shape, row) = tensor.into_vec_row_major().unwrap();
     assert_eq!(shape, vec![2, 3]);
     assert_eq!(row, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 }
@@ -90,11 +90,11 @@ fn tensor_explicit_memory_order_roundtrips_dynamic_dtype() {
 
     assert_eq!(tensor.as_slice::<i64>().unwrap(), &[1, 3, 2, 4]);
     assert_eq!(
-        tensor.clone().try_into_vec_col_major::<i64>().unwrap(),
+        tensor.clone().into_vec_col_major::<i64>().unwrap(),
         (vec![2, 2], vec![1, 3, 2, 4]),
     );
     assert_eq!(
-        tensor.try_into_vec_row_major::<i64>().unwrap(),
+        tensor.into_vec_row_major::<i64>().unwrap(),
         (vec![2, 2], vec![1, 2, 3, 4]),
     );
 }
@@ -108,7 +108,7 @@ Run:
 cargo test -p tenferro-tensor explicit_memory_order
 ```
 
-Expected: FAIL because `from_vec_row_major`, `from_vec_col_major`, `try_into_vec_row_major`, and `try_into_vec_col_major` do not exist.
+Expected: FAIL because `from_vec_row_major`, `from_vec_col_major`, `into_vec_row_major`, and `into_vec_col_major` do not exist.
 
 **Step 3: Implement generic order conversion helpers**
 
@@ -171,7 +171,7 @@ fn row_major_to_col_major<T: Clone>(shape: &[usize], data: Vec<T>) -> Vec<T> {
 }
 
 fn col_major_to_row_major<T: Clone>(shape: &[usize], data: Vec<T>) -> Vec<T> {
-    checked_shape_len(shape, data.len(), "try_into_vec_row_major");
+    checked_shape_len(shape, data.len(), "into_vec_row_major");
     if shape.is_empty() {
         return data;
     }
@@ -208,23 +208,23 @@ pub fn from_vec_row_major(shape: Vec<usize>, data: Vec<T>) -> Self {
     Self::from_vec_col_major(shape, data)
 }
 
-pub fn try_into_vec_col_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
+pub fn into_vec_col_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
     match self.buffer {
         Buffer::Host(data) => Ok((self.shape, data)),
         Buffer::Backend(_) => Err(crate::Error::BackendFailure {
-            op: "try_into_vec_col_major",
+            op: "into_vec_col_major",
             message: "backend buffers cannot be exported as host Vec".into(),
         }),
         #[cfg(feature = "cubecl")]
         Buffer::Cubecl(_) => Err(crate::Error::BackendFailure {
-            op: "try_into_vec_col_major",
+            op: "into_vec_col_major",
             message: "GPU buffers cannot be exported as host Vec".into(),
         }),
     }
 }
 
-pub fn try_into_vec_row_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
-    let (shape, data) = self.try_into_vec_col_major()?;
+pub fn into_vec_row_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
+    let (shape, data) = self.into_vec_col_major()?;
     let row_major = col_major_to_row_major(&shape, data);
     Ok((shape, row_major))
 }
@@ -238,9 +238,9 @@ pub fn from_vec(shape: Vec<usize>, data: Vec<T>) -> Self {
     Self::from_vec_col_major(shape, data)
 }
 
-#[deprecated(note = "use try_into_vec_col_major or try_into_vec_row_major")]
+#[deprecated(note = "use into_vec_col_major or into_vec_row_major")]
 pub fn try_into_vec(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
-    self.try_into_vec_col_major()
+    self.into_vec_col_major()
 }
 ```
 
@@ -255,24 +255,24 @@ pub fn from_vec_row_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> S
     T::into_tensor(shape.clone(), row_major_to_col_major(&shape, data))
 }
 
-pub fn try_into_vec_col_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
+pub fn into_vec_col_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
     let actual = self.dtype();
     let typed = T::try_into_typed(self).ok_or(crate::Error::DTypeMismatch {
-        op: "try_into_vec_col_major",
+        op: "into_vec_col_major",
         lhs: T::dtype(),
         rhs: actual,
     })?;
-    typed.try_into_vec_col_major()
+    typed.into_vec_col_major()
 }
 
-pub fn try_into_vec_row_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
+pub fn into_vec_row_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
     let actual = self.dtype();
     let typed = T::try_into_typed(self).ok_or(crate::Error::DTypeMismatch {
-        op: "try_into_vec_row_major",
+        op: "into_vec_row_major",
         lhs: T::dtype(),
         rhs: actual,
     })?;
-    typed.try_into_vec_row_major()
+    typed.into_vec_row_major()
 }
 ```
 
@@ -331,7 +331,7 @@ fn traced_tensor_col_major_constructor_keeps_physical_order() {
 
     let compiled = traced.compile_with_inputs(&[]).unwrap();
     assert_eq!(
-        compiled.inputs[0].clone().try_into_vec_col_major::<i64>().unwrap(),
+        compiled.inputs[0].clone().into_vec_col_major::<i64>().unwrap(),
         (vec![2, 2], vec![1, 3, 2, 4]),
     );
 }
@@ -421,9 +421,9 @@ fn eager_runtime_replaces_eager_context_public_name() {
 
     loss.backward().unwrap();
 
-    assert_eq!(x.grad().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
+    assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
     runtime.clear_grads();
-    assert!(x.grad().is_none());
+    assert!(x.grad().unwrap().is_none());
 }
 ```
 
@@ -1301,8 +1301,8 @@ Rules:
 
 - Use `from_vec_col_major` when existing expected slices are already column-major physical buffers.
 - Use `from_vec_row_major` only when the data is written in human row-major matrix order and expected logical values assume that.
-- Use `try_into_vec_col_major` when tests assert physical buffer order.
-- Use `try_into_vec_row_major` when docs/tests are demonstrating user-facing row-major export.
+- Use `into_vec_col_major` when tests assert physical buffer order.
+- Use `into_vec_row_major` when docs/tests are demonstrating user-facing row-major export.
 
 Most existing tests in this repository use column-major buffers; default to `_col_major` unless the test name or expected values clearly describe row-major import/export.
 

--- a/docs/plans/2026-05-25-no-facade-crate-boundaries-design.md
+++ b/docs/plans/2026-05-25-no-facade-crate-boundaries-design.md
@@ -278,7 +278,7 @@ Recommended user-facing imports:
 ```rust
 use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
 use tenferro_tensor::{CpuBackend, Tensor};
-use tenferro_linalg::solve;
+use tenferro_linalg::traced_tensor::solve;
 ```
 
 ### `tenferro-gpu` Instead Of Vendor-Specific Crates
@@ -289,9 +289,9 @@ crate keeps the first split simple while preserving room for vendor-specific
 features or modules:
 
 ```rust
-use tenferro_gpu::CubeclBackend;
+use tenferro_gpu::CudaBackend;
 
-let backend = CubeclBackend::cuda(0)?;
+let backend = CudaBackend::cuda(0)?;
 let mut executor = tenferro_runtime::GraphExecutor::new(backend);
 ```
 
@@ -533,12 +533,12 @@ such as `tenferro/autodiff`, `tenferro/cuda`, or
 default = ["cpu-faer"]
 cpu-faer = ["tenferro-tensor/cpu-faer"]
 cpu-blas = ["tenferro-tensor/cpu-blas"]
-gpu = []
 cuda = []
 rocm = []
 ```
 
-Primal extension crates may expose empty `gpu`, `cuda`, or `rocm` features
+Primal extension crates may expose empty concrete backend features such as `cuda`
+or `rocm`
 only if they gate their own GPU-specific primal code. They must not forward
 those features into `tenferro-tensor` or `tenferro-runtime`. GPU execution is
 selected by using `tenferro-gpu` as the backend crate.
@@ -812,10 +812,10 @@ should be vendor-neutral and should not require CubeCL dependencies.
 The orphan-rule-safe pattern for GPU is:
 
 - `TensorBackend` and backend-facing traits live in `tenferro-tensor`.
-- `CubeclBackend` and any GPU buffer types that require CubeCL/vendor
+- `CudaBackend` and any GPU buffer types that require CubeCL/vendor
   dependencies live in `tenferro-gpu`.
 - `tenferro-gpu` implements `tenferro_tensor::TensorBackend` for its local
-  `CubeclBackend` type. This is legal because the implementing type is local to
+  `CudaBackend` type. This is legal because the implementing type is local to
   `tenferro-gpu`.
 - Third-party backend crates follow the same pattern: define their backend type
   locally and implement the public traits from `tenferro-tensor`.
@@ -841,7 +841,7 @@ it. The public user-facing boundary should still be only `tenferro-gpu`.
 Recommended `tenferro-gpu` modules:
 
 ```text
-tenferro_gpu::backend       CubeclBackend and TensorBackend impl
+tenferro_gpu::backend       CudaBackend and TensorBackend impl
 tenferro_gpu::memory        upload_tensor, download_tensor, device buffer store
 tenferro_gpu::device        availability and DeviceId validation
 tenferro_gpu::cuda          CUDA-specific runtime and FFI, behind feature
@@ -853,19 +853,19 @@ tenferro_gpu::kernels       GPU kernels and fusion codegen
 Recommended public API:
 
 ```rust
-use tenferro_gpu::{download_tensor, upload_tensor, CubeclBackend};
+use tenferro_gpu::{download_tensor, upload_tensor, CudaBackend};
 use tenferro_tensor::{DeviceId, DeviceKind, GpuBackendKind};
 
 let device = DeviceId {
     kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
     ordinal: 0,
 };
-let mut backend = CubeclBackend::new(device)?;
+let mut backend = CudaBackend::new(device)?;
 let gpu_x = upload_tensor(&mut backend, &cpu_x)?;
 let cpu_x = download_tensor(&mut backend, &gpu_x)?;
 ```
 
-`CubeclBackend::cuda(0)` can exist as a convenience constructor, but the
+`CudaBackend::cuda(0)` can exist as a convenience constructor, but the
 canonical constructor should accept the vendor-neutral `DeviceId`. That keeps
 runtime construction aligned with tensor placement metadata while still
 isolating driver validation in `tenferro-gpu`.
@@ -899,10 +899,10 @@ let out = executor.run(&program)?;
 GPU usage is also explicit:
 
 ```rust
-use tenferro_gpu::{download_tensor, upload_tensor, CubeclBackend};
+use tenferro_gpu::{download_tensor, upload_tensor, CudaBackend};
 use tenferro_runtime::GraphExecutor;
 
-let backend = CubeclBackend::cuda(0)?;
+let backend = CudaBackend::cuda(0)?;
 let mut executor = GraphExecutor::new(backend);
 ```
 

--- a/docs/plans/2026-05-25-numpy-style-free-function-api-plan.md
+++ b/docs/plans/2026-05-25-numpy-style-free-function-api-plan.md
@@ -356,7 +356,7 @@ fn traced_add_uses_numpy_broadcasting_for_rank_padding_and_singletons() {
 
     assert_eq!(out.shape(), &[3, 4]);
     assert_eq!(
-        out.try_into_vec_row_major::<f64>().unwrap().1,
+        out.into_vec_row_major::<f64>().unwrap().1,
         vec![
             11.0, 21.0, 31.0, 41.0,
             12.0, 22.0, 32.0, 42.0,
@@ -570,7 +570,7 @@ fn eager_add_uses_numpy_broadcasting_for_rank_padding_and_singletons() {
 
     assert_eq!(out.data().shape(), &[3, 4]);
     assert_eq!(
-        out.data().clone().try_into_vec_row_major::<f64>().unwrap().1,
+        out.data().clone().into_vec_row_major::<f64>().unwrap().1,
         vec![
             11.0, 21.0, 31.0, 41.0,
             12.0, 22.0, 32.0, 42.0,
@@ -669,7 +669,7 @@ fn tensor_add_uses_numpy_broadcasting_with_explicit_backend() {
 
     assert_eq!(out.shape(), &[3, 4]);
     assert_eq!(
-        out.try_into_vec_row_major::<f64>().unwrap().1,
+        out.into_vec_row_major::<f64>().unwrap().1,
         vec![
             11.0, 21.0, 31.0, 41.0,
             12.0, 22.0, 32.0, 42.0,
@@ -771,7 +771,7 @@ fn typed_tensor_add_uses_numpy_broadcasting_with_explicit_backend() {
 
     assert_eq!(out.shape, vec![3, 4]);
     assert_eq!(
-        out.try_into_vec_row_major().unwrap(),
+        out.into_vec_row_major().unwrap(),
         vec![
             11.0, 21.0, 31.0, 41.0,
             12.0, 22.0, 32.0, 42.0,
@@ -948,7 +948,7 @@ git commit -m "feat: align extension traced tensor namespaces"
 Run:
 
 ```bash
-rg -n "tenferro::(linalg|einsum|fft)|tenferro_linalg::(svd|qr|cholesky|eig|eigh|solve)|tenferro_einsum::einsum|tenferro_fft::(fft|ifft|rfft|irfft)|\\.add\\(|\\.mul\\(" README.md docs tenferro*/src
+rg -n "tenferro::(linalg|einsum|fft)|tenferro_linalg::(svd|qr|cholesky|eig|eigh|solve)|tenferro_einsum::traced_tensor::einsum|tenferro_fft::(fft|ifft|rfft|irfft)|\\.add\\(|\\.mul\\(" README.md docs tenferro*/src
 ```
 
 Identify docs that should prefer canonical module free functions.

--- a/docs/plans/2026-05-26-no-facade-crate-boundaries-implementation.md
+++ b/docs/plans/2026-05-26-no-facade-crate-boundaries-implementation.md
@@ -131,7 +131,7 @@ owned by `tenferro-tensor`.
 **Step 3: Move GPU implementation**
 
 Move CubeCL/CUDA implementation into `tenferro-gpu`, define local
-`CubeclBackend` and `CubeclBuffer<T>`, and implement `TensorBackend` plus
+`CudaBackend` and `CubeclBuffer<T>`, and implement `TensorBackend` plus
 `BackendBuffer<T>` there.
 
 **Step 4: Verify**

--- a/docs/plans/2026-05-27-issue-912-refactor-roadmap.md
+++ b/docs/plans/2026-05-27-issue-912-refactor-roadmap.md
@@ -562,13 +562,13 @@ static PRIMITIVE_AD_RULES: &[PrimitiveAdRule] = &[
 ];
 ```
 
-Move the current `try_linearize` and `try_transpose_rule` match arm bodies into
+Move the current `linearize` and `transpose_rule` match arm bodies into
 small private wrapper functions. Keep `StdTensorOp::Extension(_)` handling in
 `ad/mod.rs`, outside the primitive registry.
 
 **Step 4: Replace lookup**
 
-In `try_linearize`:
+In `linearize`:
 
 ```rust
 let Some(kind) = op.primitive_kind() else {
@@ -1012,7 +1012,7 @@ runtime, memory, upload/download, and FFI library loading in `tenferro-gpu`.
 Under `#[cfg(feature = "cuda")]`:
 
 ```rust
-impl crate::backend::LinalgBackend for tenferro_gpu::cubecl::CubeclBackend {
+impl crate::backend::LinalgBackend for tenferro_gpu::cubecl::CudaBackend {
     fn svd(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         crate::gpu::svd(self, input)
     }

--- a/docs/plans/historical/einsum-extension-migration-audit.md
+++ b/docs/plans/historical/einsum-extension-migration-audit.md
@@ -113,7 +113,7 @@ not-needed    intentionally replaced or removed with reason
 | Source item | Current path | Target | Verification | Status |
 |-------------|--------------|--------|--------------|--------|
 | Einsum extension AD rule type | `EinsumExtensionAdRule` in `tenferro/src/einsum_extension.rs` | `crates/tenferro-einsum/src/ad.rs`, gated by `autodiff` | `rg -n "EinsumExtensionAdRule|ExtensionAdRule" crates/tenferro-einsum/src` | pending |
-| Rule registration | `ensure_einsum_extension_rule_registered` | `tenferro-einsum` registration helper, gated by `autodiff` | `rg -n "ensure_.*rule_registered|register_extension" crates/tenferro-einsum/src` | pending |
+| Rule ownership | `ad_rules()` | explicit `ExtensionRuleSet` helper, gated by `autodiff` | `rg -n "pub fn ad_rules|ExtensionRuleSet" crates/tenferro-einsum/src` | done |
 | Linearize rule | `linearize_einsum_extension` | `crates/tenferro-einsum/src/ad.rs`; preserve output-shape hints | `rg -n "linearize_einsum_extension|linearize" crates/tenferro-einsum/src` | pending |
 | Transpose rule | `transpose_einsum_extension` | `crates/tenferro-einsum/src/ad.rs`; preserve repeated/new label behavior | `rg -n "transpose_einsum_extension|transpose" crates/tenferro-einsum/src` | pending |
 | AD tests for traced einsum | `tenferro/tests/einsum_ad.rs` | `crates/tenferro-einsum/tests/ad.rs`, gated by `autodiff` | `cargo test -p tenferro-einsum --features autodiff --test ad` | pending |

--- a/docs/spec/extension-op.md
+++ b/docs/spec/extension-op.md
@@ -60,7 +60,6 @@ everything else.
 
 This document does **not** own:
 
-- compatibility global registry internals
 - cross-process graph serialization format (Section 11, Section 15)
 - per-extension semantics (those live with each extension crate)
 
@@ -169,10 +168,9 @@ pub trait ExtensionOp: std::fmt::Debug + Send + Sync + 'static {
     /// Infer output dtype and shape for each output slot.
     ///
     /// Returned vector length MUST equal `self.output_count()`. Shapes use
-    /// graph-global `SymDim` (symbolic dimensions), consistent with
-    /// `TensorMeta::shape` in `crates/tenferro-internal-ops/src/ad/context.rs`. Input
-    /// metadata is given as slices of `SymDim` / `DType`; see Section 7
-    /// for the detailed invariants.
+    /// graph-global `SymDim` (symbolic dimensions). Input metadata is given as
+    /// explicit `SymDim` / `DType` slices; callers that start from `TensorMeta`
+    /// must choose `exact_shape` or `bound_shape` deliberately.
     fn infer_output_meta(
         &self,
         input_dtypes: &[DType],
@@ -567,8 +565,9 @@ extension.
 - The returned vector MUST have length `self.output_count()`.
 - Each `(dtype, shape)` pair gives the inferred dtype and symbolic shape
   for the corresponding output slot.
-- Shapes are expressed as `Vec<SymDim>` to match
-  `TensorMeta::shape` (see `crates/tenferro-internal-ops/src/ad/context.rs:49-109`).
+- Shapes are expressed as `Vec<SymDim>`. `TensorMeta` does not expose a
+  public shape field; callers must pass an exact or bound shape
+  intentionally (see `crates/tenferro-internal-ops/src/ad/context.rs`).
   Concrete and symbolic inputs use the same representation:
   `SymDim::from(usize)` for concrete extents, symbolic placeholders for
   unknown-at-build-time dimensions.
@@ -749,28 +748,12 @@ pub enum ExtensionRegistryError {
 }
 ```
 
-### Compatibility global lookup
-
-The process-global AD rule registry and its `register_extension_rule` helper
-remain a compatibility bridge for older global lookup flows. It is not the
-primary extension AD path. Code that needs reproducible tests, multiple
-independent AD contexts, or explicit dependency ownership SHOULD use
-`ExtensionRuleSet` instead.
-
-The compatibility API exposes a rule lookup function:
-
-```rust
-pub fn lookup_extension_rule(family_id: &str) -> Option<std::sync::Arc<dyn ExtensionAdRule>>;
-```
-
-Lookup MUST NOT panic on a missing `family_id`. Callers decide how to
-handle absence (see Section 12).
-
 ### Thread safety
 
 An `ExtensionRuleSet` MUST be safe to clone and read from any thread used by AD
-graph construction. The compatibility global registry MUST also be safe to read
-from any thread; writes happen only during initialization.
+graph construction. Extension AD rule lookup MUST NOT consult hidden
+process-global or thread-local state; the active `ExtensionRuleSet` is the only
+owner of extension AD rules for a transform.
 
 ### Failure signature
 
@@ -787,8 +770,8 @@ from any thread; writes happen only during initialization.
 
 Extension AD is registered independently from the primal op. Extension crates
 implement `ExtensionAdRule` and add it to an `ExtensionRuleSet`. Rule
-signatures mirror `Primitive::try_linearize` and
-`Primitive::try_transpose_rule` and return `ADRuleResult<_>` so missing rules
+signatures mirror `Primitive::jvp_rule` and
+`Primitive::transpose_rule` and return `ADRuleResult<_>` so missing rules
 can propagate without panic:
 
 ```rust
@@ -924,7 +907,7 @@ these error types / behaviours in the listed scenarios.
 | Graph references an unregistered `family_id` at eager or graph runtime execution time | Return a backend/config error with `family_id` and registration guidance. |
 | Graph references an unregistered `family_id` at compile time | Return `Error::Unsupported` from `compile_std_to_exec`. |
 | AD rules (`linearize` / `transpose_rule`) encounter an `Extension` with no rule in the active `ExtensionRuleSet` | Return `ADRuleError::Unsupported` with `family_id` and rule kind; traced `grad` / eager `backward` propagate it through the public `Error` type re-exported by the owning surface crate. |
-| Duplicate AD rule `family_id` in one `ExtensionRuleSet` or the compatibility global registry | Rule registration MUST reject with `ExtensionRegistryError::DuplicateRule`. |
+| Duplicate AD rule `family_id` in one `ExtensionRuleSet` | Rule registration MUST reject with `ExtensionRegistryError::DuplicateRule`. |
 | Arity mismatch: `input_count()` disagrees with the `primal_in.len()` the dispatcher passed | `Error::InvalidConfig { op: "extension", message: "family_id=<id>: expected N inputs, got M" }`. |
 | Output shape disagrees with `infer_output_meta` result length | `Error::InvalidConfig` with `family_id` and the mismatched counts. |
 | Extension runtime returns a tensor on the wrong device | Propagate to the caller as a backend failure (the core pipeline does not re-locate tensors). |

--- a/docs/superpowers/plans/2026-06-16-eager-recorded-graph-vjp-implementation.md
+++ b/docs/superpowers/plans/2026-06-16-eager-recorded-graph-vjp-implementation.md
@@ -4,7 +4,7 @@
 
 **Goal:** Implement graph-invocation eager recording in tidu and use it from tenferro tracked eager einsum to collapse the backward path from per-input recomputation to one shared transposed DAG.
 
-**Architecture:** First change tidu's eager tape so every trace node stores a `RecordedGraph`, with no `Recorder::record(op, ...)` or `try_build_single_op_linear` path. Then update tenferro to record ordinary eager primitives as one-op recorded graphs and tracked eager einsum as one multi-op recorded graph. Finally publish PRs in dependency order: tidu-rs first, tenferro-rs second with the tidu rev pinned to the merged or PR commit.
+**Architecture:** First change tidu's eager tape so every trace node stores a `RecordedGraph`, with no `Recorder::record(op, ...)` or `build_single_op_linear` path. Then update tenferro to record ordinary eager primitives as one-op recorded graphs and tracked eager einsum as one multi-op recorded graph. Finally publish PRs in dependency order: tidu-rs first, tenferro-rs second with the tidu rev pinned to the merged or PR commit.
 
 **Tech Stack:** Rust, tidu, computegraph, tenferro-ad, tenferro-einsum, GitHub PRs, cargo nextest/cargo test.
 
@@ -16,7 +16,7 @@ tidu-rs:
 
 - Modify `src/eager/record.rs`: add `RecordedGraph`, replace `Recorder::record` with `Recorder::record_graph`, and move one-op graph construction into `RecordedGraph::from_primitive`.
 - Modify `src/eager/trace.rs`: store `RecordedGraph` on `TraceNode`, remove `operation` and `primal_in_keys`.
-- Modify `src/eager/backward.rs`: replace `try_build_single_op_linear` with `TraceNode::computation().try_linearize(...)`.
+- Modify `src/eager/backward.rs`: replace `build_single_op_linear` with `TraceNode::computation().linearize(...)`.
 - Modify `src/eager/mod.rs`: export `RecordedGraph`.
 - Modify `tests/eager_record_tests.rs` and `tests/eager_backward_tests.rs`: update tests to use `RecordedGraph` and add multi-op graph tests.
 - Modify `examples/eager_reverse_mode.rs`, `docs/guides/eager-integration.md`, `docs/tutorials/eager-reverse-mode.md`, and docs index pages that mention primitive recording.
@@ -108,7 +108,7 @@ pub struct RecordedGraph<Op: GraphOperation> {
 }
 ```
 
-with `new`, `from_primitive`, `as_graph`, `input_keys`, `output_keys`, and `try_linearize(output_slots, ctx)`.
+with `new`, `from_primitive`, `as_graph`, `input_keys`, `output_keys`, and `linearize(output_slots, ctx)`.
 
 The concrete one-op constructor is:
 
@@ -139,15 +139,15 @@ Downstream frontends use this helper to allocate per-invocation graph input keys
 
 `TraceNode` stores `computation: RecordedGraph<Op>`, `primal_out_keys`, `saved_data`, and `input_edges`. Remove `operation`, `primal_in_keys`, and their accessors.
 
-- [ ] **Step 4: Remove `try_build_single_op_linear`**
+- [ ] **Step 4: Remove `build_single_op_linear`**
 
-`try_backward` calls:
+`backward` calls:
 
 ```rust
-let linear = node.computation().try_linearize(&active_output_slots, ctx)?;
+let linear = node.computation().linearize(&active_output_slots, ctx)?;
 ```
 
-and no helper named `try_build_single_op_linear` remains.
+and no helper named `build_single_op_linear` remains.
 
 - [ ] **Step 5: Verify green**
 
@@ -155,7 +155,7 @@ Run:
 
 ```bash
 cargo nextest run --release --test eager_record_tests --test eager_backward_tests
-rg "try_build_single_op_linear|Recorder::record\\(" src tests examples docs
+rg "build_single_op_linear|Recorder::record\\(" src tests examples docs
 ```
 
 Expected: tests pass; search returns no production use of the removed APIs.
@@ -351,6 +351,6 @@ Open a draft PR against `main`, link issue #1060 and the tidu PR, enable auto-me
 
 ## Self-Review
 
-- Spec coverage: graph-only tidu recording, `try_build_single_op_linear` removal, tracked einsum one-node recording, conservative O(N) residual, docs update, and PR monitoring are covered.
+- Spec coverage: graph-only tidu recording, `build_single_op_linear` removal, tracked einsum one-node recording, conservative O(N) residual, docs update, and PR monitoring are covered.
 - Placeholder scan: no task depends on an unspecified file; constructor signatures may be adjusted only where the implementation task defines them.
 - Type consistency: `RecordedGraph`, `record_graph`, `EagerInput`, `EagerOutput`, and `BackwardExecutor` are used consistently across tidu and tenferro tasks.

--- a/docs/superpowers/specs/2026-06-16-eager-recorded-graph-vjp-design.md
+++ b/docs/superpowers/specs/2026-06-16-eager-recorded-graph-vjp-design.md
@@ -130,7 +130,7 @@ pub struct RecordedGraph<Op: GraphOperation> {
 ```
 
 `input_keys` is aligned with the eager input order. These keys are the `wrt`
-inputs for `try_linearize`.
+inputs for `linearize`.
 
 `output_keys` is aligned with the eager output slot order. These keys select
 which graph outputs are active when only some eager outputs receive cotangents.
@@ -195,7 +195,7 @@ linearization and for aligning returned cotangents with `input_edges`.
 
 ## Backward Flow
 
-`try_backward` remains responsible for walking the eager tape in reverse
+`backward` remains responsible for walking the eager tape in reverse
 topological order and accumulating cotangents on eager value keys. The per-node
 work becomes graph-only:
 
@@ -209,7 +209,7 @@ let cotangent_in =
 ```
 
 `RecordedGraph::linearize` resolves its graph and calls tidu's existing
-`try_linearize`:
+`linearize`:
 
 ```rust
 let selected_outputs = output_slots
@@ -217,7 +217,7 @@ let selected_outputs = output_slots
     .map(|slot| self.output_keys[*slot].clone())
     .collect::<Vec<_>>();
 
-try_linearize(
+linearize(
     &resolve(vec![self.graph.clone()]),
     &selected_outputs,
     &self.input_keys,
@@ -234,11 +234,11 @@ is required for the normal eager path.
 
 The first API-preserving step can keep the current `BackwardExecutor` method
 name, but the intended downstream implementation is whole-program execution.
-tidu already has `try_linear_transpose`, which produces a transposed graph from a
+tidu already has `linear_transpose`, which produces a transposed graph from a
 `LinearizedGraph`. The tenferro eager backward executor should move away from
-`try_linear_transpose_with_builder` for the composite path and instead:
+`linear_transpose_with_builder` for the composite path and instead:
 
-1. Build the transposed graph once with `try_linear_transpose`.
+1. Build the transposed graph once with `linear_transpose`.
 2. Bind cotangent seeds as graph inputs.
 3. Bind retained primal values as external data.
 4. Run the transposed graph with the backend executor.

--- a/docs/tutorial-code/src/bin/complex_ad_convention.rs
+++ b/docs/tutorial-code/src/bin/complex_ad_convention.rs
@@ -32,10 +32,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Complex64::new(0.0, std::f64::consts::FRAC_PI_2),
         Complex64::new(std::f64::consts::LN_2, 0.0),
     ];
-    let z = TracedTensor::from_vec_col_major(vec![2], z_data.clone());
+    let z = TracedTensor::from_vec_col_major(vec![2], z_data.clone())?;
 
     let holomorphic_loss = z.exp().reduce_sum(&[0]);
-    let tenferro_grad = holomorphic_loss.grad(&z)?;
+    let tenferro_grad = holomorphic_loss?.grad(&z)?;
     let tenferro_grad_value = run(&tenferro_grad)?;
     let expected_grad: Vec<_> = z_data.iter().map(|z| z.exp().conj()).collect();
     assert_complex_slice_close(
@@ -44,8 +44,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let magnitude = z.abs();
-    let real_loss = (&magnitude * &magnitude).reduce_sum(&[0]);
-    let real_loss_grad = real_loss.grad(&z)?;
+    let real_loss = (&magnitude * &magnitude)?.reduce_sum(&[0]);
+    let real_loss_grad = real_loss?.grad(&z)?;
     let real_loss_grad_value = run(&real_loss_grad)?;
     let expected_real_loss_grad: Vec<_> = z_data.iter().map(|z| *z * 2.0).collect();
     assert_complex_slice_close(
@@ -56,10 +56,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let scalar_z = TracedTensor::from_vec_col_major(
         vec![1],
         vec![Complex64::new(0.0, std::f64::consts::FRAC_PI_2)],
-    );
+    )?;
     let y = scalar_z.exp();
     let seed = Complex64::new(2.0, -3.0);
-    let cotangent = TracedTensor::from_vec_col_major(vec![1], vec![seed]);
+    let cotangent = TracedTensor::from_vec_col_major(vec![1], vec![seed])?;
     let vjp = y.vjp(&scalar_z, &cotangent)?;
     let vjp_value = run(&vjp)?;
     let expected_vjp = seed

--- a/docs/tutorial-code/src/bin/dynamic_shape_truncated_svd.rs
+++ b/docs/tutorial-code/src/bin/dynamic_shape_truncated_svd.rs
@@ -14,13 +14,13 @@ fn assert_close(actual: &[f64], expected: &[f64], tolerance: f64) {
     }
 }
 
-fn diagonal_matrix(diagonal: &[f64]) -> Tensor {
+fn diagonal_matrix(diagonal: &[f64]) -> Result<Tensor, tenferro_runtime::Error> {
     let n = diagonal.len();
     let mut values = vec![0.0_f64; n * n];
     for (index, value) in diagonal.iter().enumerate() {
         values[index + index * n] = *value;
     }
-    Tensor::from_vec_col_major(vec![n, n], values)
+    Ok(Tensor::from_vec_col_major(vec![n, n], values)?)
 }
 
 fn truncated_expected(diagonal: &[f64], threshold: f64) -> Vec<f64> {
@@ -60,15 +60,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let x = TracedTensor::input_concrete_shape(DType::F64, &[4, 4]);
     let (u, s, vt) = tenferro_linalg::traced_tensor::svd_with_eps(&x, 1.0e-12)?;
 
-    let threshold = TracedTensor::from_vec_col_major(vec![], vec![0.5_f64]);
+    let threshold = TracedTensor::from_vec_col_major(vec![], vec![0.5_f64])?;
     let keep_count = s
-        .compare(&threshold, CompareDir::Gt)
+        .compare(&threshold, CompareDir::Gt)?
         .convert(DType::F64)
-        .reduce_sum(&[0]);
+        .reduce_sum(&[0])?;
 
-    let u_truncated = u.dynamic_truncate(&keep_count, 1);
-    let s_truncated = s.dynamic_truncate(&keep_count, 0);
-    let vt_truncated = vt.dynamic_truncate(&keep_count, 0);
+    let u_truncated = u.dynamic_truncate(&keep_count, 1)?;
+    let s_truncated = s.dynamic_truncate(&keep_count, 0)?;
+    let vt_truncated = vt.dynamic_truncate(&keep_count, 0)?;
 
     let mut compiler = GraphCompiler::new();
     let reconstructed = tenferro_einsum::traced_tensor::einsum_with(
@@ -85,7 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     executor.register_extension(tenferro_linalg::register_runtime)?;
     executor.register_extension(tenferro_einsum::register_runtime)?;
 
-    let rank2 = diagonal_matrix(&[4.0, 3.0, 0.1, 0.01]);
+    let rank2 = diagonal_matrix(&[4.0, 3.0, 0.1, 0.01])?;
     run_case(
         &mut executor,
         &reconstructed_program,
@@ -96,7 +96,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &truncated_expected(&[4.0, 3.0, 0.1, 0.01], 0.5),
     )?;
 
-    let rank3 = diagonal_matrix(&[4.0, 3.0, 2.0, 0.01]);
+    let rank3 = diagonal_matrix(&[4.0, 3.0, 2.0, 0.01])?;
     run_case(
         &mut executor,
         &reconstructed_program,

--- a/docs/tutorial-code/src/bin/eager_autodiff_pytorch_style.rs
+++ b/docs/tutorial-code/src/bin/eager_autodiff_pytorch_style.rs
@@ -13,7 +13,10 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let runtime = EagerRuntime::new();
-    let x = runtime.variable_from(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]));
+    let x = runtime.variable_from(Tensor::from_vec_col_major(
+        vec![3],
+        vec![1.0_f64, 2.0, 3.0],
+    )?);
 
     let prediction = x.mul(&x).unwrap();
     let loss = prediction.reduce_sum(&[0])?;
@@ -24,13 +27,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     loss.backward()?;
 
     let grad = x
-        .grad()
+        .grad()?
         .expect("tracked variable should receive a gradient");
     assert_eq!(grad.shape(), &[3]);
     assert_close(grad.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
 
-    x.clear_grad();
-    assert!(x.grad().is_none());
+    x.clear_grad()?;
+    assert!(x.grad()?.is_none());
 
     Ok(())
 }

--- a/docs/tutorial-code/src/bin/einsum_subscripts_to_gradients.rs
+++ b/docs/tutorial-code/src/bin/einsum_subscripts_to_gradients.rs
@@ -14,16 +14,25 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
     }
 }
 
-fn matrix_a() -> Tensor {
-    Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0])
+fn matrix_a() -> Result<Tensor, Box<dyn std::error::Error>> {
+    Ok(Tensor::from_vec_col_major(
+        vec![2, 3],
+        vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0],
+    )?)
 }
 
-fn matrix_b() -> Tensor {
-    Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f64, 9.0, 11.0, 8.0, 10.0, 12.0])
+fn matrix_b() -> Result<Tensor, Box<dyn std::error::Error>> {
+    Ok(Tensor::from_vec_col_major(
+        vec![3, 2],
+        vec![7.0_f64, 9.0, 11.0, 8.0, 10.0, 12.0],
+    )?)
 }
 
-fn matrix_c() -> TracedTensor {
-    TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0])
+fn matrix_c() -> Result<TracedTensor, Box<dyn std::error::Error>> {
+    Ok(TracedTensor::from_vec_col_major(
+        vec![2, 2],
+        vec![1.0_f64, 3.0, 2.0, 4.0],
+    )?)
 }
 
 fn run(tensor: &TracedTensor) -> Result<Tensor, Box<dyn std::error::Error>> {
@@ -36,8 +45,8 @@ fn run(tensor: &TracedTensor) -> Result<Tensor, Box<dyn std::error::Error>> {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let runtime = EagerRuntime::new();
-    let a = runtime.variable_from(matrix_a());
-    let b = runtime.variable_from(matrix_b());
+    let a = runtime.variable_from(matrix_a()?);
+    let b = runtime.variable_from(matrix_b()?);
     let product = tenferro_einsum::eager_tensor::einsum(&[&a, &b], "ij,jk->ik")?;
 
     assert_eq!(product.data().shape(), &[2, 2]);
@@ -46,9 +55,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &[58.0, 139.0, 64.0, 154.0],
     );
 
-    let a = TracedTensor::from_tensor_concrete_shape(matrix_a());
-    let b = TracedTensor::from_tensor_concrete_shape(matrix_b());
-    let c = matrix_c();
+    let a = TracedTensor::from_tensor_concrete_shape(matrix_a()?);
+    let b = TracedTensor::from_tensor_concrete_shape(matrix_b()?);
+    let c = matrix_c()?;
 
     let mut compiler = GraphCompiler::new();
     let auto = tenferro_einsum::traced_tensor::einsum_with(
@@ -81,7 +90,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "ij,jk->ik",
         EinsumOptimize::Path(vec![(0, 1)]),
     )?;
-    let grad_a = y.reduce_sum(&[0, 1]).grad(&a)?;
+    let grad_a = y.reduce_sum(&[0, 1])?.grad(&a)?;
     let grad_value = run(&grad_a)?;
 
     assert_eq!(grad_value.shape(), &[2, 3]);

--- a/docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs
+++ b/docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs
@@ -21,8 +21,8 @@ fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runti
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
-    let y = (&x * &x).reduce_sum(&[0]);
+    let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0])?;
+    let y = (&x * &x)?.reduce_sum(&[0])?;
 
     let y_value = run(&y)?;
     assert_eq!(y_value.shape(), &[]);
@@ -33,7 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(grad_value.shape(), &[3]);
     assert_close(grad_value.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
 
-    let tangent = TracedTensor::from_vec_col_major(vec![3], vec![0.1_f64, 1.0, -2.0]);
+    let tangent = TracedTensor::from_vec_col_major(vec![3], vec![0.1_f64, 1.0, -2.0])?;
     let directional = y.jvp(&x, &tangent)?;
     let directional_value = run(&directional)?;
     assert_eq!(directional_value.shape(), &[]);

--- a/docs/tutorial-code/src/bin/typed_tensor_non_ad.rs
+++ b/docs/tutorial-code/src/bin/typed_tensor_non_ad.rs
@@ -15,29 +15,30 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut backend = CpuBackend::new();
 
-    let x = TypedTensor::<f64>::from_vec_row_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let x = TypedTensor::<f64>::from_vec_row_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])?;
     assert_eq!(x.shape(), &[2, 3]);
     assert_eq!(x.rank(), 2);
-    assert_eq!(x.host_data(), &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    assert_eq!(x.host_data()?, &[1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
 
-    let column_offsets = TypedTensor::<f64>::from_vec_col_major(vec![1, 3], vec![10.0, 20.0, 30.0]);
+    let column_offsets =
+        TypedTensor::<f64>::from_vec_col_major(vec![1, 3], vec![10.0, 20.0, 30.0])?;
     let shifted = typed_tensor::add(&x, &column_offsets, &mut backend)?;
-    assert_close(shifted.host_data(), &[11.0, 14.0, 22.0, 25.0, 33.0, 36.0]);
+    assert_close(shifted.host_data()?, &[11.0, 14.0, 22.0, 25.0, 33.0, 36.0]);
 
     let squared = typed_tensor::mul(&shifted, &shifted, &mut backend)?;
     let squared_total = typed_tensor::reduce_sum(&squared, &[0, 1], &mut backend)?;
     assert_eq!(squared_total.shape(), &[]);
-    assert_close(squared_total.host_data(), &[3811.0]);
+    assert_close(squared_total.host_data()?, &[3811.0]);
 
     let transposed = typed_tensor::transpose(&x, &[1, 0], &mut backend)?;
     assert_eq!(transposed.shape(), &[3, 2]);
-    assert_close(transposed.host_data(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    assert_close(transposed.host_data()?, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 
     let weights =
-        TypedTensor::<f64>::from_vec_row_major(vec![3, 2], vec![0.5, 1.0, -1.0, 2.0, 1.5, -0.5]);
+        TypedTensor::<f64>::from_vec_row_major(vec![3, 2], vec![0.5, 1.0, -1.0, 2.0, 1.5, -0.5])?;
     let projected = typed_tensor::matmul(&x, &weights, &mut backend)?;
     assert_eq!(projected.shape(), &[2, 2]);
-    assert_close(projected.host_data(), &[3.0, 6.0, 3.5, 11.0]);
+    assert_close(projected.host_data()?, &[3.0, 6.0, 3.5, 11.0]);
 
     Ok(())
 }

--- a/docs/tutorial-code/src/bin/xla_einsum_backend.rs
+++ b/docs/tutorial-code/src/bin/xla_einsum_backend.rs
@@ -13,21 +13,27 @@ fn assert_close(actual: &[f64], expected: &[f64]) {
     }
 }
 
-fn lhs_value() -> Tensor {
-    Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0])
+fn lhs_value() -> Result<Tensor, Box<dyn std::error::Error>> {
+    Ok(Tensor::from_vec_col_major(
+        vec![2, 3],
+        vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0],
+    )?)
 }
 
-fn middle_value() -> Tensor {
-    Tensor::from_vec_col_major(
+fn middle_value() -> Result<Tensor, Box<dyn std::error::Error>> {
+    Ok(Tensor::from_vec_col_major(
         vec![3, 4],
         vec![
             10.0_f64, 20.0, 30.0, 11.0, 21.0, 31.0, 12.0, 22.0, 32.0, 13.0, 23.0, 33.0,
         ],
-    )
+    )?)
 }
 
-fn tail_value() -> Tensor {
-    Tensor::from_vec_col_major(vec![4, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
+fn tail_value() -> Result<Tensor, Box<dyn std::error::Error>> {
+    Ok(Tensor::from_vec_col_major(
+        vec![4, 2],
+        vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+    )?)
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -35,11 +41,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let a = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let b = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let c = TracedTensor::input_symbolic_shape(DType::F64, 2);
-    let product = tenferro_einsum::einsum(&mut compiler, &[&a, &b, &c], "ij,jk,kl->il")?;
+    let product =
+        tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&a, &b, &c], "ij,jk,kl->il")?;
 
-    let a_value = lhs_value();
-    let b_value = middle_value();
-    let c_value = tail_value();
+    let a_value = lhs_value()?;
+    let b_value = middle_value()?;
+    let c_value = tail_value()?;
     let program = compiler.compile_with_input_specs(
         &product,
         &[

--- a/docs/tutorials/eager-autodiff-pytorch-style.md
+++ b/docs/tutorials/eager-autodiff-pytorch-style.md
@@ -40,8 +40,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(grad.shape(), &[3]);
     assert_close(grad.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);
 
-    x.clear_grad();
-    assert!(x.grad().is_none());
+    x.clear_grad().unwrap();
+    assert!(x.grad().unwrap().is_none());
 
     Ok(())
 }

--- a/docs/tutorials/xla-einsum-backend.md
+++ b/docs/tutorials/xla-einsum-backend.md
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let a = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let b = TracedTensor::input_symbolic_shape(DType::F64, 2);
     let c = TracedTensor::input_symbolic_shape(DType::F64, 2);
-    let product = tenferro_einsum::einsum(&mut compiler, &[&a, &b, &c], "ij,jk,kl->il")?;
+    let product = tenferro_einsum::traced_tensor::einsum(&mut compiler, &[&a, &b, &c], "ij,jk,kl->il")?;
 
     let a_value = lhs_value();
     let b_value = middle_value();

--- a/docs/worklogs/2026-05-30-einsum-plan-spec-payload.md
+++ b/docs/worklogs/2026-05-30-einsum-plan-spec-payload.md
@@ -57,7 +57,7 @@ operands.
   policies through `EinsumOptimize`; exposing an additional plan-spec type would
   add API weight without a current caller need.
 - **No exact `ctx.shape_of(Local(ct))` dependency in transpose rules.** The
-  current `tidu::try_transpose` path creates cotangent seed locals before their
+  current `tidu::linear_transpose` path creates cotangent seed locals before their
   metadata is registered. The einsum AD rule instead uses the extension output
   shape hint that traced and eager construction now attach.
 - **No broad cache redesign.** The change only extends einsum-specific cache

--- a/docs/worklogs/2026-05-31-tidu-eager-api-boundary.md
+++ b/docs/worklogs/2026-05-31-tidu-eager-api-boundary.md
@@ -16,8 +16,8 @@ and made trace node/edge internals private. This tenferro PR then:
 - pins `tidu` to the merged commit containing the new eager boundary
 - stores opaque `tidu::eager::Trace` handles instead of `GradNode` internals
 - records eager operations through `tidu::eager::Recorder`
-- runs backward through `tidu::eager::try_backward`
-- executes transpose through `tidu::emit::try_transpose_fragment`
+- runs backward through `tidu::eager::backward`
+- executes transpose through `tidu::emit::linear_transpose_with_builder`
 
 No public tenferro eager tensor API is changed.
 

--- a/docs/worklogs/2026-06-01-gpu-synchronize-api.md
+++ b/docs/worklogs/2026-06-01-gpu-synchronize-api.md
@@ -8,7 +8,7 @@ This change adds an explicit host-side synchronization API for eager and direct
 CUDA backend execution:
 
 - `EagerRuntime::synchronize()` for eager code,
-- `CubeclRuntime::synchronize()` for direct CubeCL CUDA backend integrations.
+- `CudaRuntime::synchronize()` for direct CubeCL CUDA backend integrations.
 
 Eager CPU runtimes return immediately. Eager CUDA runtimes synchronize the
 current backend stream without downloading tensor data.

--- a/docs/worklogs/2026-06-13-webgpu-complex-gemm.md
+++ b/docs/worklogs/2026-06-13-webgpu-complex-gemm.md
@@ -7,7 +7,7 @@ Date: 2026-06-13
 This work adds a first-class WebGPU provider path to `tenferro-gpu` while
 keeping CUDA and WebGPU as explicit additive provider features. It introduces
 `WebGpuBackend`/`WebGpuRuntime`, preserves `CudaBackend` plus the existing
-`CubeclBackend` compatibility alias, and adds `GpuBackendKind::WebGpu` for
+`CudaBackend` compatibility alias, and adds `GpuBackendKind::WebGpu` for
 placement metadata.
 
 `tenferro-ad` now accepts `WebGpuBackend` through `EagerRuntime`, and

--- a/docs/worklogs/2026-06-18-terasaki-bug-batch-2.md
+++ b/docs/worklogs/2026-06-18-terasaki-bug-batch-2.md
@@ -40,11 +40,10 @@ rules where possible so the rule set stays usable.
 - Runtime and tensor shape arithmetic now uses fallible checked paths for
   `DimExpr` evaluation, shape inference, graph compilation, accessors, tensor
   constructors, and fused einsum dimension products.
-- Public panic surfaces now have fallible alternatives and compatibility-wrapper
-  comments where the panic API remains: tensor accessors/constructors,
-  `extension::apply`, traced symbolic axis helpers, reductions, tropical
-  composition helpers, CPU context/cache helpers, and CUDA extension cache
-  helpers.
+- Public panic surfaces now use checked `Result` APIs: tensor
+  accessors/constructors, `extension::apply`, traced symbolic axis helpers,
+  reductions, tropical composition helpers, CPU context/cache helpers, and CUDA
+  extension cache helpers.
 - AD structural/indexing/linalg rules fail closed on malformed metadata,
   symbolic non-concrete shapes, invalid rank, mismatched scatter/gather window
   metadata, non-square LU variants, and invalid extension metadata instead of

--- a/docs/worklogs/2026-06-18-terasaki-bug-batch-3.md
+++ b/docs/worklogs/2026-06-18-terasaki-bug-batch-3.md
@@ -1,0 +1,77 @@
+# Terasaki Bug Batch 3
+
+## Summary
+
+Fixed the #1111-#1119 `terasakisatoshi` bug batch as one non-squash PR
+candidate, then used the same audit rules to remove legacy compatibility APIs
+that would keep the underlying design problems alive.
+
+The final direction is intentionally compatibility-breaking: public panic shims,
+process-global AD registration helpers, ambiguous feature aliases, stale root
+operation re-exports, and compatibility shape/accessor aliases were removed
+instead of preserving them behind `try_*` or alias wrappers.
+
+## Classification Ledger
+
+- Fixed in this PR: #1111, #1112, #1113, #1114, #1116, #1117, #1118, and #1119.
+- Docs/enhancement outside this bug-fix batch: #1115 and #1054.
+- Related design cleanup included in scope: `tidu` AD rule error contract,
+  tensor public panic shims, explicit extension AD rule sets, required
+  `execute_reads`, exact-vs-bound tensor metadata, and concrete backend feature
+  names.
+
+## Same-Root-Cause Sweep
+
+- Replaced public panic/defaulting APIs with typed `Result`-returning canonical
+  operations instead of adding `try_*` compatibility escapes.
+- Removed legacy public aliases: root operation re-exports, `Cubecl*` public
+  backend names, `Extension*Trait` names, `TropicalEinsumKind`,
+  `MetadataScope`, owned-tensor `as_physical_slice*`, and
+  `is_contiguous_col_major`.
+- Removed process-global extension AD rule registration and made callers pass
+  explicit rule sets or contexts.
+- Split scratch-buffer acquisition into full-overwrite uninitialized buffers
+  and read-before-write zeroed buffers, with one-line invariants at
+  uninitialized acquisitions.
+- Made `TensorMeta` store only extents; callers now choose `exact_shape()` or
+  `bound_shape()` explicitly.
+- Made extension runtimes implement `execute_reads` explicitly; the macro no
+  longer permits an omitted read executor.
+- Removed the `tenferro-internal-ops/gpu` umbrella feature alias; downstream
+  code uses `cuda`, `webgpu`, or `rocm` explicitly.
+
+## Rule Updates
+
+- `REPOSITORY_RULES.md`, `bugfix-pr.md`, and `repository-remediation.md` now
+  prefer root-cause API redesign over compatibility shims unless compatibility
+  is explicitly required.
+- The remediation workflow requires same-root-cause searches, source comments
+  for intentional false positives, and rule inventory before adding new audit
+  rules.
+- Standard extension rules now disallow new process-global registration shims
+  unless a maintainer explicitly approves a legacy bridge.
+
+## Verification
+
+Local verification before push:
+
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo check --workspace --all-targets`
+- `cargo check -p tenferro-cpu --features provider-inject --all-targets`
+- `cargo check -p tenferro-linalg --features provider-inject --all-targets`
+- `cargo check -p tenferro-gpu --features cuda`
+- `cargo check -p tenferro-ad --features cuda`
+- `cargo check -p tenferro-linalg --features cuda,autodiff`
+- `cargo check -p tenferro-einsum --features autodiff --all-targets`
+- `cargo test -p tenferro-internal-extension-macros`
+- `cargo test -p tenferro-internal-ops metadata`
+- `cargo test -p tenferro-tensor accessors`
+- `cargo test -p tenferro-tensor-core view_validation_reports_rank_permutation_and_slice_errors`
+- `cargo test -p tenferro-runtime --test public_surface_contract`
+- `cargo test -p tenferro-gpu --test public_surface_contract`
+- `cargo test -p tenferro-cpu --test provider_feature_contract`
+
+No cloud GPU runtime checks were used; GPU coverage here is local source
+contract tests plus CUDA feature compilation.

--- a/ext/tropical/Cargo.toml
+++ b/ext/tropical/Cargo.toml
@@ -31,7 +31,7 @@ tenferro-internal-ops = { path = "../../crates/tenferro-internal-ops", default-f
 tenferro-runtime = { path = "../../crates/tenferro-runtime" }
 tenferro-tensor = { path = "../../crates/tenferro-tensor" }
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7", optional = true }
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "36af0974014a12c681977105c5564257dd38441e", optional = true }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "77527ecb647fecd4918ea2d06d0065ddce4e5b1c", optional = true }
 num-traits = "0.2"
 tropical-gemm = { version = "0.2", default-features = false, optional = true }
 

--- a/ext/tropical/benches/tropical_matmul.rs
+++ b/ext/tropical/benches/tropical_matmul.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
-use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
 use tenferro_tensor::Tensor;
 
 const DIRECT_SIZES: &[(usize, usize, usize)] = &[(16, 16, 16), (32, 32, 32), (64, 32, 64)];
@@ -11,7 +11,7 @@ fn f64_tensor(shape: Vec<usize>, seed: usize) -> Tensor {
     let data = (0..len)
         .map(|idx| ((idx * 17 + seed * 31 + 7) % 997) as f64 / 997.0 - 0.5)
         .collect();
-    Tensor::from_vec_col_major(shape, data)
+    Tensor::from_vec_col_major(shape, data).unwrap()
 }
 
 fn consume(result: &tenferro_ext_tropical::einsum::TropicalEinsumResult) {
@@ -45,7 +45,7 @@ fn bench_direct_matmul(c: &mut Criterion) {
             |bench| {
                 bench.iter(|| {
                     let result = tropical_einsum_with_argmax(
-                        TropicalEinsumKind::MaxPlus,
+                        TropicalKind::MaxPlus,
                         &[black_box(&lhs), black_box(&rhs)],
                         "ij,jk->ik",
                     )
@@ -70,7 +70,7 @@ fn bench_permuted_fallback(c: &mut Criterion) {
             |bench| {
                 bench.iter(|| {
                     let result = tropical_einsum_with_argmax(
-                        TropicalEinsumKind::MaxPlus,
+                        TropicalKind::MaxPlus,
                         &[black_box(&lhs), black_box(&rhs)],
                         "ji,jk->ik",
                     )
@@ -95,7 +95,7 @@ fn bench_multi_contracted_fallback(c: &mut Criterion) {
             |bench| {
                 bench.iter(|| {
                     let result = tropical_einsum_with_argmax(
-                        TropicalEinsumKind::MaxPlus,
+                        TropicalKind::MaxPlus,
                         &[black_box(&lhs), black_box(&rhs)],
                         "kji,ljk->il",
                     )

--- a/ext/tropical/src/einsum.rs
+++ b/ext/tropical/src/einsum.rs
@@ -8,13 +8,13 @@
 //! # Examples
 //!
 //! ```
-//! use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+//! use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
 //! use tenferro_tensor::Tensor;
 //!
 //! let a = Tensor::from_vec_col_major(vec![2, 2], vec![10.0_f64, 0.0, 1.0, 5.0]);
 //! let b = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 10.0, 0.0, 1.0]);
 //! let result = tropical_einsum_with_argmax(
-//!     TropicalEinsumKind::MaxPlus,
+//!     TropicalKind::MaxPlus,
 //!     &[&a, &b],
 //!     "ij,jk->ik",
 //! )?;
@@ -29,24 +29,9 @@ use tenferro_einsum::{ContractionTree, Subscripts};
 use tenferro_tensor::{DType, Tensor, TensorScalar};
 
 use crate::cpu::{tropical_gemm_with_argmax, TropicalGemmKind};
+use crate::TropicalKind;
 
 const OP: &str = "tropical_einsum_with_argmax";
-
-/// Tropical einsum semiring flavor.
-///
-/// This is an alias for the crate-level [`crate::TropicalKind`], kept here so
-/// callers can import einsum-specific APIs from one module without introducing a
-/// second semiring enum.
-///
-/// # Examples
-///
-/// ```
-/// use tenferro_ext_tropical::{einsum::TropicalEinsumKind, TropicalKind};
-///
-/// assert_eq!(TropicalEinsumKind::MaxPlus, TropicalKind::MaxPlus);
-/// assert_ne!(TropicalEinsumKind::MaxPlus, TropicalEinsumKind::MinPlus);
-/// ```
-pub type TropicalEinsumKind = crate::TropicalKind;
 
 /// Argmax metadata captured for one pairwise tropical contraction step.
 ///
@@ -55,12 +40,12 @@ pub type TropicalEinsumKind = crate::TropicalKind;
 /// # Examples
 ///
 /// ```
-/// use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+/// use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
 /// use tenferro_tensor::Tensor;
 ///
 /// let a = Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]);
 /// let b = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f64, 2.0]);
-/// let result = tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
+/// let result = tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
 ///
 /// assert_eq!(result.argmax[0].indices(), &[0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
@@ -96,12 +81,12 @@ impl TropicalArgmaxStep {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+    /// use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
     /// use tenferro_tensor::Tensor;
     ///
     /// let a = Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]);
     /// let b = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f64, 2.0]);
-    /// let result = tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
+    /// let result = tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
     ///
     /// assert_eq!(result.argmax[0].indices(), &[0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
@@ -116,12 +101,12 @@ impl TropicalArgmaxStep {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+    /// use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
     /// use tenferro_tensor::Tensor;
     ///
     /// let a = Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]);
     /// let b = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f64, 2.0]);
-    /// let result = tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
+    /// let result = tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
     ///
     /// assert_eq!(result.argmax[0].output_shape(), &[1, 1]);
     /// # Ok::<(), tenferro_tensor::Error>(())
@@ -136,12 +121,12 @@ impl TropicalArgmaxStep {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+    /// use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
     /// use tenferro_tensor::Tensor;
     ///
     /// let a = Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]);
     /// let b = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f64, 2.0]);
-    /// let result = tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
+    /// let result = tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
     ///
     /// assert_eq!(result.argmax[0].output_subscripts(), &[b'i' as u32, b'k' as u32]);
     /// # Ok::<(), tenferro_tensor::Error>(())
@@ -156,12 +141,12 @@ impl TropicalArgmaxStep {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+    /// use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
     /// use tenferro_tensor::Tensor;
     ///
     /// let a = Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]);
     /// let b = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f64, 2.0]);
-    /// let result = tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
+    /// let result = tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
     ///
     /// assert_eq!(result.argmax[0].contracted_subscripts(), &[b'j' as u32]);
     /// # Ok::<(), tenferro_tensor::Error>(())
@@ -178,12 +163,12 @@ impl TropicalArgmaxStep {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+    /// use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
     /// use tenferro_tensor::Tensor;
     ///
     /// let a = Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]);
     /// let b = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f64, 2.0]);
-    /// let result = tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
+    /// let result = tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
     ///
     /// assert_eq!(result.argmax[0].contracted_shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
@@ -201,12 +186,12 @@ impl TropicalArgmaxStep {
     /// # Examples
     ///
     /// ```
-    /// use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+    /// use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
     /// use tenferro_tensor::Tensor;
     ///
     /// let a = Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]);
     /// let b = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f64, 2.0]);
-    /// let result = tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
+    /// let result = tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
     ///
     /// assert_eq!(result.argmax[0].winner_coordinates(0).unwrap(), vec![0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
@@ -223,12 +208,12 @@ impl TropicalArgmaxStep {
 /// # Examples
 ///
 /// ```
-/// use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+/// use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
 /// use tenferro_tensor::Tensor;
 ///
 /// let a = Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f32]);
 /// let b = Tensor::from_vec_col_major(vec![1, 1], vec![3.0_f32]);
-/// let result = tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
+/// let result = tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ik")?;
 ///
 /// assert_eq!(result.output.as_slice::<f32>().unwrap(), &[5.0]);
 /// assert_eq!(result.argmax.len(), 1);
@@ -257,18 +242,18 @@ pub struct TropicalEinsumResult {
 /// # Examples
 ///
 /// ```
-/// use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+/// use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
 /// use tenferro_tensor::Tensor;
 ///
 /// let a = Tensor::from_vec_col_major(vec![2, 2], vec![10.0_f64, 0.0, 1.0, 5.0]);
 /// let b = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 10.0, 0.0, 1.0]);
-/// let result = tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ki")?;
+/// let result = tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ki")?;
 ///
 /// assert_eq!(result.output.as_slice::<f64>().unwrap(), &[11.0, 10.0, 15.0, 6.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
 pub fn tropical_einsum_with_argmax(
-    kind: TropicalEinsumKind,
+    kind: TropicalKind,
     inputs: &[&Tensor],
     notation: &str,
 ) -> tenferro_tensor::Result<TropicalEinsumResult> {
@@ -293,7 +278,7 @@ pub fn tropical_einsum_with_argmax(
 /// ```
 /// use tenferro_einsum::Subscripts;
 /// use tenferro_ext_tropical::einsum::{
-///     tropical_einsum_subscripts_with_argmax, TropicalEinsumKind,
+///     tropical_einsum_subscripts_with_argmax, TropicalKind,
 /// };
 /// use tenferro_tensor::Tensor;
 ///
@@ -301,14 +286,14 @@ pub fn tropical_einsum_with_argmax(
 /// let b = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f64, 2.0]);
 /// let subscripts = Subscripts::parse("ij,jk->ik").unwrap();
 /// let result =
-///     tropical_einsum_subscripts_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], &subscripts)?;
+///     tropical_einsum_subscripts_with_argmax(TropicalKind::MaxPlus, &[&a, &b], &subscripts)?;
 ///
 /// assert_eq!(result.output.as_slice::<f64>().unwrap(), &[3.0]);
 /// assert_eq!(result.argmax[0].indices(), &[0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
 pub fn tropical_einsum_subscripts_with_argmax(
-    kind: TropicalEinsumKind,
+    kind: TropicalKind,
     inputs: &[&Tensor],
     subscripts: &Subscripts,
 ) -> tenferro_tensor::Result<TropicalEinsumResult> {
@@ -398,7 +383,7 @@ pub fn tropical_einsum_subscripts_with_argmax(
 }
 
 fn execute_typed<T>(
-    kind: TropicalEinsumKind,
+    kind: TropicalKind,
     inputs: &[&Tensor],
     subscripts: &Subscripts,
     lhs_subs: &[u32],
@@ -441,7 +426,7 @@ where
 
 #[allow(clippy::too_many_arguments)]
 fn execute_target_order_gemm_typed<T>(
-    kind: TropicalEinsumKind,
+    kind: TropicalKind,
     inputs: &[&Tensor],
     lhs: &[T],
     rhs: &[T],
@@ -466,7 +451,7 @@ where
             contracted_shape,
         );
         return Ok(TropicalEinsumResult {
-            output: Tensor::from_vec_col_major(requested_shape, Vec::<T>::new()),
+            output: Tensor::from_vec_col_major(requested_shape, Vec::<T>::new())?,
             argmax: vec![argmax_step],
         });
     }
@@ -542,14 +527,14 @@ where
         contracted_shape,
     );
     Ok(TropicalEinsumResult {
-        output: Tensor::from_vec_col_major(requested_shape, values),
+        output: Tensor::from_vec_col_major(requested_shape, values)?,
         argmax: vec![argmax_step],
     })
 }
 
 #[allow(clippy::too_many_arguments)]
 fn execute_fallback_typed<T>(
-    kind: TropicalEinsumKind,
+    kind: TropicalKind,
     inputs: &[&Tensor],
     lhs: &[T],
     rhs: &[T],
@@ -576,7 +561,7 @@ where
             contracted_shape,
         );
         return Ok(TropicalEinsumResult {
-            output: Tensor::from_vec_col_major(requested_shape, Vec::<T>::new()),
+            output: Tensor::from_vec_col_major(requested_shape, Vec::<T>::new())?,
             argmax: vec![argmax_step],
         });
     }
@@ -640,7 +625,7 @@ where
         contracted_shape,
     );
     Ok(TropicalEinsumResult {
-        output: Tensor::from_vec_col_major(requested_shape, values),
+        output: Tensor::from_vec_col_major(requested_shape, values)?,
         argmax: vec![argmax_step],
     })
 }
@@ -816,22 +801,22 @@ fn offset_for_axes(
         })
 }
 
-fn tropical_identity<T: Float>(kind: TropicalEinsumKind) -> T {
+fn tropical_identity<T: Float>(kind: TropicalKind) -> T {
     match kind {
-        TropicalEinsumKind::MaxPlus => T::neg_infinity(),
-        TropicalEinsumKind::MinPlus => T::infinity(),
+        TropicalKind::MaxPlus => T::neg_infinity(),
+        TropicalKind::MinPlus => T::infinity(),
     }
 }
 
 fn tropical_candidate_is_better<T: Float>(
-    kind: TropicalEinsumKind,
+    kind: TropicalKind,
     candidate: T,
     best: T,
     has_ordered_candidate: bool,
 ) -> bool {
     match kind {
-        TropicalEinsumKind::MaxPlus => !has_ordered_candidate || candidate > best,
-        TropicalEinsumKind::MinPlus => !has_ordered_candidate || candidate < best,
+        TropicalKind::MaxPlus => !has_ordered_candidate || candidate > best,
+        TropicalKind::MinPlus => !has_ordered_candidate || candidate < best,
     }
 }
 

--- a/ext/tropical/src/extension.rs
+++ b/ext/tropical/src/extension.rs
@@ -10,7 +10,7 @@ use tenferro_einsum::Subscripts;
 use tenferro_ops::ad::PrimitiveRuleBuilder;
 use tenferro_ops::ext_op::ExtensionOp;
 #[cfg(feature = "autodiff")]
-use tenferro_ops::ext_op::{register_extension_rule, ExtensionAdRule};
+use tenferro_ops::ext_op::ExtensionAdRule;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::std_tensor_op::StdTensorOp;
 #[cfg(feature = "autodiff")]
@@ -23,7 +23,7 @@ use tenferro_runtime::{
 };
 #[cfg(not(feature = "autodiff"))]
 use tenferro_tensor::TensorBackend;
-use tenferro_tensor::{DType, Tensor};
+use tenferro_tensor::{DType, Tensor, TensorRead};
 #[cfg(feature = "autodiff")]
 use tenferro_tensor::{TensorBackend, TensorScalar};
 #[cfg(feature = "autodiff")]
@@ -58,12 +58,28 @@ impl<B: TensorBackend + 'static> ExtensionRuntime<B> for TropicalRuntime {
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
         op.eager_execute(inputs)
     }
+
+    fn execute_reads(
+        &self,
+        op: &dyn ExtensionOp,
+        inputs: &[TensorRead<'_>],
+        ctx: &mut ExtensionExecutionContext<'_, B>,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        // Tropical CPU kernels consume compact host tensors, so view
+        // materialization is an explicit runtime choice.
+        let materialized_inputs: Vec<Tensor> = inputs
+            .iter()
+            .map(TensorRead::to_tensor)
+            .collect::<tenferro_tensor::Result<_>>()?;
+        let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
+        self.execute(op, &input_refs, ctx)
+    }
 }
 
 /// Register tropical extension runtimes on a graph or eager executor.
 ///
 /// The runtime executor is intentionally thin: it delegates to each tropical
-/// extension op's [`tenferro_runtime::extension::ExtensionOpTrait::eager_execute`].
+/// extension op's [`tenferro_runtime::extension::ExtensionOp::eager_execute`].
 /// AD rules are registered separately through `tropical_ad_rules` when the
 /// `autodiff` feature is enabled.
 ///
@@ -551,41 +567,6 @@ pub fn tropical_ad_rules() -> Result<ExtensionRuleSet, ExtensionRegistryError> {
     Ok(rules)
 }
 
-/// Register tropical traced einsum AD rules in the process-global registry.
-///
-/// Prefer [`tropical_ad_rules`] with an explicit `tenferro_ad::AdContext` for
-/// tests and applications. This helper exists for compatibility with global
-/// extension-rule lookup and treats duplicate registration as success.
-///
-/// # Errors
-///
-/// Returns [`tenferro_ops::ExtensionRegistryError`] if a malformed family id is
-/// detected while registering the rules.
-///
-/// # Examples
-///
-/// ```
-/// tenferro_ext_tropical::register_tropical_ad_rules().unwrap();
-/// ```
-#[cfg(feature = "autodiff")]
-pub fn register_tropical_ad_rules() -> Result<(), ExtensionRegistryError> {
-    register_rule_idempotent(Arc::new(TropicalEinsumAdRule))?;
-    register_rule_idempotent(Arc::new(TropicalEinsumJvpAdRule))?;
-    Ok(())
-}
-
-#[cfg(feature = "autodiff")]
-fn register_rule_idempotent(rule: Arc<dyn ExtensionAdRule>) -> Result<(), ExtensionRegistryError> {
-    let family_id = rule.family_id();
-    match register_extension_rule(rule) {
-        Ok(()) => Ok(()),
-        Err(ExtensionRegistryError::DuplicateRule {
-            family_id: duplicate,
-        }) if duplicate == family_id => Ok(()),
-        Err(err) => Err(err),
-    }
-}
-
 fn infer_tropical_output_meta(
     subscripts: &Subscripts,
     input_dtypes: &[DType],
@@ -706,7 +687,7 @@ where
             *out_value += *tangent_value;
         }
     }
-    Ok(Tensor::from_vec_col_major(output_shape, out))
+    Ok(Tensor::from_vec_col_major(output_shape, out)?)
 }
 
 #[cfg(feature = "autodiff")]
@@ -746,7 +727,7 @@ where
         })?;
         *slot += ct;
     }
-    Ok(Tensor::from_vec_col_major(active_shape, out))
+    Ok(Tensor::from_vec_col_major(active_shape, out)?)
 }
 
 #[cfg(feature = "autodiff")]
@@ -804,7 +785,7 @@ fn typed_slice<'a, T>(tensor: &'a Tensor, op: &'static str) -> tenferro_tensor::
 where
     T: TensorScalar,
 {
-    tensor.as_slice::<T>().ok_or_else(|| {
+    tensor.as_slice::<T>().map_err(|_| {
         invalid_config(
             op,
             format!("expected compact host {:?} tensor", tensor.dtype()),

--- a/ext/tropical/src/lib.rs
+++ b/ext/tropical/src/lib.rs
@@ -25,12 +25,12 @@
 //!
 //! ```
 //! use tenferro_cpu::CpuBackend;
-//! use tenferro_ext_tropical::tropical_dot_general;
+//! use tenferro_ext_tropical::traced::tropical_dot_general;
 //! use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
 //!
 //! let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
 //! let b = TracedTensor::from_vec_col_major(vec![2, 2], vec![10.0_f64, 20.0, 30.0, 40.0]);
-//! let out = tropical_dot_general(&a, &b);
+//! let out = tropical_dot_general(&a, &b).unwrap();
 //!
 //! let mut compiler = GraphCompiler::new();
 //! let program = compiler.compile(&out).unwrap();
@@ -47,13 +47,8 @@ pub mod traced;
 
 pub use extension::register_runtime;
 #[cfg(feature = "autodiff")]
-pub use extension::{register_tropical_ad_rules, tropical_ad_rules};
+pub use extension::tropical_ad_rules;
 pub use newtype::{MaxMul, MaxPlus, MinPlus};
-pub use traced::{
-    min_plus_dot_general, min_plus_dot_general_fused, tropical_dot_general,
-    tropical_dot_general_fused, tropical_reduce_sum, try_min_plus_dot_general,
-    try_min_plus_dot_general_fused, try_tropical_dot_general, try_tropical_dot_general_fused,
-};
 
 /// Tropical semiring flavor used by traced and future fused tropical ops.
 ///

--- a/ext/tropical/src/traced.rs
+++ b/ext/tropical/src/traced.rs
@@ -54,25 +54,25 @@ fn try_require_contracting_axes_compatible(
     Ok(())
 }
 
-fn try_tropical_dot_general_impl(
+fn checked_tropical_dot_general_impl(
     a: &TracedTensor,
     b: &TracedTensor,
-    reduce: impl FnOnce(&TracedTensor) -> TracedTensor,
+    reduce: impl FnOnce(&TracedTensor) -> Result<TracedTensor>,
     label: &str,
 ) -> Result<TracedTensor> {
     try_require_rank2(a, &format!("{label}.a"))?;
     try_require_rank2(b, &format!("{label}.b"))?;
     try_require_contracting_axes_compatible(a, b, label)?;
 
-    let m = a.try_axis_sym_dim(0)?;
-    let k = a.try_axis_sym_dim(1)?;
-    let n = b.try_axis_sym_dim(1)?;
+    let m = a.axis_sym_dim(0)?;
+    let k = a.axis_sym_dim(1)?;
+    let n = b.axis_sym_dim(1)?;
     let target_shape = [m, k, n];
 
-    let a_b = a.try_broadcast_in_dim_sym(&target_shape, &[0, 1], &[b])?;
-    let b_b = b.try_broadcast_in_dim_sym(&target_shape, &[1, 2], &[a])?;
-    let sum = a_b.add(&b_b);
-    Ok(reduce(&sum))
+    let a_b = a.broadcast_in_dim_sym(&target_shape, &[0, 1], &[b])?;
+    let b_b = b.broadcast_in_dim_sym(&target_shape, &[1, 2], &[a])?;
+    let sum = a_b.add(&b_b)?;
+    reduce(&sum)
 }
 
 /// Max-plus matrix multiplication on rank-2 traced tensors.
@@ -80,11 +80,10 @@ fn try_tropical_dot_general_impl(
 /// Computes `out[i, j] = max_k(a[i, k] + b[k, j])` by composing
 /// `BroadcastInDim`, `Add`, and `ReduceMax` graph operations.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Compatibility wrapper that panics if either input is not rank 2, or if
-/// concrete contracting axes differ. Use [`try_tropical_dot_general`] on new
-/// user-facing paths.
+/// Returns an error if either input is not rank 2 or if concrete contracting
+/// dimensions are known and incompatible.
 ///
 /// # Examples
 ///
@@ -95,28 +94,15 @@ fn try_tropical_dot_general_impl(
 ///
 /// let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
 /// let b = TracedTensor::from_vec_col_major(vec![2, 2], vec![10.0_f64, 20.0, 30.0, 40.0]);
-/// let c = tropical_dot_general(&a, &b);
+/// let c = tropical_dot_general(&a, &b).unwrap();
 /// let mut compiler = GraphCompiler::new();
 /// let program = compiler.compile(&c).unwrap();
 /// let mut executor = GraphExecutor::new(CpuBackend::new());
 /// let out = executor.run(&program).unwrap();
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[23.0, 24.0, 43.0, 44.0]);
 /// ```
-#[must_use]
-pub fn tropical_dot_general(a: &TracedTensor, b: &TracedTensor) -> TracedTensor {
-    // Intentional compatibility panic wrapper; use `try_tropical_dot_general`
-    // where invalid user shapes must be reported without unwinding.
-    try_tropical_dot_general(a, b).unwrap_or_else(|err| panic!("{err}"))
-}
-
-/// Fallible max-plus matrix multiplication on rank-2 traced tensors.
-///
-/// # Errors
-///
-/// Returns an error if either input is not rank 2 or if concrete contracting
-/// dimensions are known and incompatible.
-pub fn try_tropical_dot_general(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
-    try_tropical_dot_general_impl(a, b, |sum| sum.reduce_max(&[1]), "tropical_dot_general")
+pub fn tropical_dot_general(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
+    checked_tropical_dot_general_impl(a, b, |sum| sum.reduce_max(&[1]), "tropical_dot_general")
 }
 
 /// Min-plus matrix multiplication on rank-2 traced tensors.
@@ -124,11 +110,10 @@ pub fn try_tropical_dot_general(a: &TracedTensor, b: &TracedTensor) -> Result<Tr
 /// Computes `out[i, j] = min_k(a[i, k] + b[k, j])` by composing
 /// `BroadcastInDim`, `Add`, and `ReduceMin` graph operations.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Compatibility wrapper that panics if either input is not rank 2, or if
-/// concrete contracting axes differ. Use [`try_min_plus_dot_general`] on new
-/// user-facing paths.
+/// Returns an error if either input is not rank 2 or if concrete contracting
+/// dimensions are known and incompatible.
 ///
 /// # Examples
 ///
@@ -139,28 +124,15 @@ pub fn try_tropical_dot_general(a: &TracedTensor, b: &TracedTensor) -> Result<Tr
 ///
 /// let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
 /// let b = TracedTensor::from_vec_col_major(vec![2, 2], vec![5.0_f64, 6.0, 7.0, 8.0]);
-/// let c = min_plus_dot_general(&a, &b);
+/// let c = min_plus_dot_general(&a, &b).unwrap();
 /// let mut compiler = GraphCompiler::new();
 /// let program = compiler.compile(&c).unwrap();
 /// let mut executor = GraphExecutor::new(CpuBackend::new());
 /// let out = executor.run(&program).unwrap();
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[6.0, 7.0, 8.0, 9.0]);
 /// ```
-#[must_use]
-pub fn min_plus_dot_general(a: &TracedTensor, b: &TracedTensor) -> TracedTensor {
-    // Intentional compatibility panic wrapper; use `try_min_plus_dot_general`
-    // where invalid user shapes must be reported without unwinding.
-    try_min_plus_dot_general(a, b).unwrap_or_else(|err| panic!("{err}"))
-}
-
-/// Fallible min-plus matrix multiplication on rank-2 traced tensors.
-///
-/// # Errors
-///
-/// Returns an error if either input is not rank 2 or if concrete contracting
-/// dimensions are known and incompatible.
-pub fn try_min_plus_dot_general(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
-    try_tropical_dot_general_impl(a, b, |sum| sum.reduce_min(&[1]), "min_plus_dot_general")
+pub fn min_plus_dot_general(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
+    checked_tropical_dot_general_impl(a, b, |sum| sum.reduce_min(&[1]), "min_plus_dot_general")
 }
 
 /// Fused binary tropical einsum over traced tensors.
@@ -238,7 +210,7 @@ pub fn tropical_einsum_subscripts(
     subscripts: &Subscripts,
 ) -> Result<TracedTensor> {
     validate_tropical_einsum_inputs(inputs, subscripts)?;
-    let outputs = extension::try_apply(
+    let outputs = extension::apply(
         Arc::new(TropicalEinsumOp::new(kind, subscripts.clone())),
         inputs,
     )?;
@@ -253,10 +225,10 @@ pub fn tropical_einsum_subscripts(
 /// Computes `out[i, j] = max_k(a[i, k] + b[k, j])` through the tropical
 /// extension executor rather than a broadcast/reduce composition.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if either input is not rank 2 or the concrete contracting dimensions
-/// are incompatible.
+/// Returns an error if either input is not rank 2 or if concrete contracting
+/// dimensions are known and incompatible.
 ///
 /// # Examples
 ///
@@ -267,7 +239,7 @@ pub fn tropical_einsum_subscripts(
 ///
 /// let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
 /// let b = TracedTensor::from_vec_col_major(vec![2, 2], vec![10.0_f64, 20.0, 30.0, 40.0]);
-/// let out = tropical_dot_general_fused(&a, &b);
+/// let out = tropical_dot_general_fused(&a, &b).unwrap();
 ///
 /// let mut compiler = GraphCompiler::new();
 /// let program = compiler.compile(&out).unwrap();
@@ -276,18 +248,7 @@ pub fn tropical_einsum_subscripts(
 /// let value = executor.run(&program).unwrap();
 /// assert_eq!(value.as_slice::<f64>().unwrap(), &[23.0, 24.0, 43.0, 44.0]);
 /// ```
-#[must_use]
-pub fn tropical_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> TracedTensor {
-    try_tropical_dot_general_fused(a, b).unwrap_or_else(|err| panic!("{err}"))
-}
-
-/// Fallible fused max-plus matrix multiplication on rank-2 traced tensors.
-///
-/// # Errors
-///
-/// Returns an error if either input is not rank 2 or if concrete contracting
-/// dimensions are known and incompatible.
-pub fn try_tropical_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
+pub fn tropical_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
     try_fused_dot_general_impl(TropicalKind::MaxPlus, a, b, "tropical_dot_general_fused")
 }
 
@@ -296,10 +257,10 @@ pub fn try_tropical_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> Res
 /// Computes `out[i, j] = min_k(a[i, k] + b[k, j])` through the tropical
 /// extension executor rather than a broadcast/reduce composition.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if either input is not rank 2 or the concrete contracting dimensions
-/// are incompatible.
+/// Returns an error if either input is not rank 2 or if concrete contracting
+/// dimensions are known and incompatible.
 ///
 /// # Examples
 ///
@@ -310,7 +271,7 @@ pub fn try_tropical_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> Res
 ///
 /// let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
 /// let b = TracedTensor::from_vec_col_major(vec![2, 2], vec![5.0_f64, 6.0, 7.0, 8.0]);
-/// let out = min_plus_dot_general_fused(&a, &b);
+/// let out = min_plus_dot_general_fused(&a, &b).unwrap();
 ///
 /// let mut compiler = GraphCompiler::new();
 /// let program = compiler.compile(&out).unwrap();
@@ -319,18 +280,7 @@ pub fn try_tropical_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> Res
 /// let value = executor.run(&program).unwrap();
 /// assert_eq!(value.as_slice::<f64>().unwrap(), &[6.0, 7.0, 8.0, 9.0]);
 /// ```
-#[must_use]
-pub fn min_plus_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> TracedTensor {
-    try_min_plus_dot_general_fused(a, b).unwrap_or_else(|err| panic!("{err}"))
-}
-
-/// Fallible fused min-plus matrix multiplication on rank-2 traced tensors.
-///
-/// # Errors
-///
-/// Returns an error if either input is not rank 2 or if concrete contracting
-/// dimensions are known and incompatible.
-pub fn try_min_plus_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
+pub fn min_plus_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
     try_fused_dot_general_impl(TropicalKind::MinPlus, a, b, "min_plus_dot_general_fused")
 }
 
@@ -462,8 +412,7 @@ fn validate_tropical_einsum_inputs(
 /// let out = executor.run(&program).unwrap();
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[5.0]);
 /// ```
-#[must_use]
-pub fn tropical_reduce_sum(a: &TracedTensor, axes: &[usize]) -> TracedTensor {
+pub fn tropical_reduce_sum(a: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
     a.reduce_max(axes)
 }
 
@@ -473,19 +422,19 @@ mod tests {
 
     #[test]
     fn compositional_dot_general_try_api_rejects_rank_mismatch() {
-        let lhs = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]);
-        let rhs = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]);
+        let lhs = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
+        let rhs = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
 
-        let err = try_tropical_dot_general(&lhs, &rhs).unwrap_err();
+        let err = tropical_dot_general(&lhs, &rhs).unwrap_err();
         assert!(err.to_string().contains("requires rank-2 input"));
     }
 
     #[test]
     fn compositional_dot_general_try_api_rejects_contracting_dim_mismatch() {
-        let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]);
-        let rhs = TracedTensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]);
+        let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+        let rhs = TracedTensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]).unwrap();
 
-        let err = try_min_plus_dot_general(&lhs, &rhs).unwrap_err();
+        let err = min_plus_dot_general(&lhs, &rhs).unwrap_err();
         assert!(err.to_string().contains("contracting axes must match"));
     }
 }

--- a/ext/tropical/tests/smoke.rs
+++ b/ext/tropical/tests/smoke.rs
@@ -1,7 +1,7 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use tenferro_einsum::Subscripts;
 use tenferro_ext_tropical::{
-    traced::{tropical_einsum_subscripts, try_tropical_dot_general_fused},
+    traced::{tropical_dot_general_fused, tropical_einsum_subscripts},
     MaxPlus, MinPlus, TropicalKind,
 };
 use tenferro_runtime::{DType, TracedTensor};
@@ -15,9 +15,9 @@ fn tropical_crate_exports_core_types() {
 
 #[test]
 fn traced_einsum_validation_rejects_inputs_before_extension_shape_inference() {
-    let f64_lhs = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]);
-    let f64_rhs = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]);
-    let f32_rhs = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f32; 4]);
+    let f64_lhs = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+    let f64_rhs = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();
+    let f32_rhs = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f32; 4]).unwrap();
     let i32_rhs = TracedTensor::input_concrete_shape(DType::I32, &[2, 2]);
     let matmul = Subscripts::parse("ij,jk->ik").unwrap();
     let missing_output = Subscripts::parse("ij,jk->ix").unwrap();
@@ -56,12 +56,12 @@ fn traced_einsum_accepts_symbolic_shapes_without_panicking() {
 }
 
 #[test]
-fn fused_dot_general_has_fallible_validation_entrypoint() {
+fn fused_dot_general_validates_inputs() {
     let scalar = TracedTensor::input_concrete_shape(DType::F64, &[]);
     let matrix = TracedTensor::input_concrete_shape(DType::F64, &[2, 2]);
     let lhs = TracedTensor::input_concrete_shape(DType::F64, &[2, 3]);
     let rhs = TracedTensor::input_concrete_shape(DType::F64, &[4, 2]);
 
-    assert!(try_tropical_dot_general_fused(&scalar, &matrix).is_err());
-    assert!(try_tropical_dot_general_fused(&lhs, &rhs).is_err());
+    assert!(tropical_dot_general_fused(&scalar, &matrix).is_err());
+    assert!(tropical_dot_general_fused(&lhs, &rhs).is_err());
 }

--- a/ext/tropical/tests/tropical_ad.rs
+++ b/ext/tropical/tests/tropical_ad.rs
@@ -2,7 +2,7 @@
 
 use tenferro_ad::AdContext;
 use tenferro_cpu::CpuBackend;
-use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
 use tenferro_ext_tropical::traced::tropical_dot_general_fused;
 use tenferro_ext_tropical::tropical_ad_rules;
 use tenferro_runtime::{GraphCompiler, GraphExecutor, Tensor, TracedTensor};
@@ -40,9 +40,9 @@ fn assert_f64_close(actual: &[f64], expected: &[f64], tolerance: f64) {
 }
 
 fn max_plus_eager_ij_jk_to_ik(a_data: Vec<f64>, b_data: Vec<f64>) -> Vec<f64> {
-    let a = Tensor::from_vec_col_major(vec![2, 2], a_data);
-    let b = Tensor::from_vec_col_major(vec![2, 2], b_data);
-    let out = tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ik")
+    let a = Tensor::from_vec_col_major(vec![2, 2], a_data).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2, 2], b_data).unwrap();
+    let out = tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ik")
         .expect("eager tropical einsum");
     out.output.as_slice::<f64>().expect("f64 output").to_vec()
 }
@@ -120,10 +120,10 @@ fn assert_sum_gradients(
     expected_a: &[f64],
     expected_b: &[f64],
 ) {
-    let a = TracedTensor::from_vec_col_major(a_shape, a_data);
-    let b = TracedTensor::from_vec_col_major(b_shape, b_data);
-    let out = tropical_dot_general_fused(&a, &b);
-    let loss = out.reduce_sum(&[0, 1]);
+    let a = TracedTensor::from_vec_col_major(a_shape, a_data).unwrap();
+    let b = TracedTensor::from_vec_col_major(b_shape, b_data).unwrap();
+    let out = tropical_dot_general_fused(&a, &b).unwrap();
+    let loss = out.reduce_sum(&[0, 1]).unwrap();
     let ad = tropical_ad();
 
     let grad_a = ad.grad(&loss, &a).expect("grad wrt a");
@@ -140,11 +140,11 @@ fn finite_difference_jvp_matches_unique_winner_max_plus_lhs_and_rhs() {
     let da_data = vec![0.25_f64, -0.5, 0.75, 1.25];
     let db_data = vec![-0.4_f64, 0.3, 1.1, -0.2];
 
-    let a = TracedTensor::from_vec_col_major(vec![2, 2], a_data.clone());
-    let b = TracedTensor::from_vec_col_major(vec![2, 2], b_data.clone());
-    let da = TracedTensor::from_vec_col_major(vec![2, 2], da_data.clone());
-    let db = TracedTensor::from_vec_col_major(vec![2, 2], db_data.clone());
-    let out = tropical_dot_general_fused(&a, &b);
+    let a = TracedTensor::from_vec_col_major(vec![2, 2], a_data.clone()).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![2, 2], b_data.clone()).unwrap();
+    let da = TracedTensor::from_vec_col_major(vec![2, 2], da_data.clone()).unwrap();
+    let db = TracedTensor::from_vec_col_major(vec![2, 2], db_data.clone()).unwrap();
+    let out = tropical_dot_general_fused(&a, &b).unwrap();
     let ad = tropical_ad();
 
     let jvp_a = ad.jvp(&out, &a, &da).expect("jvp wrt a");
@@ -170,11 +170,12 @@ fn finite_difference_gradient_matches_unique_winner_weighted_scalarization() {
     let b_data = vec![2.0_f64, 0.0, -1.0, 5.0];
     let weights_data = vec![0.5_f64, -1.25, 2.0, 0.75];
 
-    let a = TracedTensor::from_vec_col_major(vec![2, 2], a_data.clone());
-    let b = TracedTensor::from_vec_col_major(vec![2, 2], b_data.clone());
-    let weights = TracedTensor::from_vec_col_major(vec![2, 2], weights_data.clone());
-    let out = tropical_dot_general_fused(&a, &b);
-    let loss = (&out * &weights).reduce_sum(&[0, 1]);
+    let a = TracedTensor::from_vec_col_major(vec![2, 2], a_data.clone()).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![2, 2], b_data.clone()).unwrap();
+    let weights = TracedTensor::from_vec_col_major(vec![2, 2], weights_data.clone()).unwrap();
+    let out = tropical_dot_general_fused(&a, &b).unwrap();
+    let weighted = (&out * &weights).unwrap();
+    let loss = weighted.reduce_sum(&[0, 1]).unwrap();
     let ad = tropical_ad();
 
     let grad_a = ad.grad(&loss, &a).expect("grad wrt a");
@@ -198,14 +199,14 @@ fn finite_difference_gradient_matches_unique_winner_weighted_scalarization() {
 fn traced_fused_forward_matches_eager_max_plus_einsum() {
     let a_data = vec![1.0_f64, 2.0, 3.0, 4.0];
     let b_data = vec![10.0_f64, 20.0, 30.0, 40.0];
-    let a = TracedTensor::from_vec_col_major(vec![2, 2], a_data.clone());
-    let b = TracedTensor::from_vec_col_major(vec![2, 2], b_data.clone());
-    let fused = tropical_dot_general_fused(&a, &b);
+    let a = TracedTensor::from_vec_col_major(vec![2, 2], a_data.clone()).unwrap();
+    let b = TracedTensor::from_vec_col_major(vec![2, 2], b_data.clone()).unwrap();
+    let fused = tropical_dot_general_fused(&a, &b).unwrap();
 
-    let eager_a = Tensor::from_vec_col_major(vec![2, 2], a_data);
-    let eager_b = Tensor::from_vec_col_major(vec![2, 2], b_data);
+    let eager_a = Tensor::from_vec_col_major(vec![2, 2], a_data).unwrap();
+    let eager_b = Tensor::from_vec_col_major(vec![2, 2], b_data).unwrap();
     let eager = tropical_einsum_with_argmax(
-        TropicalEinsumKind::MaxPlus,
+        TropicalKind::MaxPlus,
         &[&eager_a, &eager_b],
         "ij,jk->ik",
     )

--- a/ext/tropical/tests/tropical_einsum.rs
+++ b/ext/tropical/tests/tropical_einsum.rs
@@ -1,13 +1,13 @@
-use tenferro_ext_tropical::einsum::{tropical_einsum_with_argmax, TropicalEinsumKind};
+use tenferro_ext_tropical::{einsum::tropical_einsum_with_argmax, TropicalKind};
 use tenferro_tensor::{Error, Tensor};
 
 #[test]
 fn maxplus_matmul_uses_shared_einsum_lowering() {
-    let a = Tensor::from_vec_col_major(vec![2, 2], vec![10.0_f64, 0.0, 1.0, 5.0]);
-    let b = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 10.0, 0.0, 1.0]);
+    let a = Tensor::from_vec_col_major(vec![2, 2], vec![10.0_f64, 0.0, 1.0, 5.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 10.0, 0.0, 1.0]).unwrap();
 
     let result =
-        tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ik").unwrap();
+        tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ik").unwrap();
 
     assert_eq!(result.output.shape(), &[2, 2]);
     assert_eq!(
@@ -19,11 +19,11 @@ fn maxplus_matmul_uses_shared_einsum_lowering() {
 
 #[test]
 fn output_permutation_matches_subscripts() {
-    let a = Tensor::from_vec_col_major(vec![2, 2], vec![10.0_f64, 0.0, 1.0, 5.0]);
-    let b = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 10.0, 0.0, 1.0]);
+    let a = Tensor::from_vec_col_major(vec![2, 2], vec![10.0_f64, 0.0, 1.0, 5.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 10.0, 0.0, 1.0]).unwrap();
 
     let result =
-        tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ki").unwrap();
+        tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ki").unwrap();
 
     assert_eq!(result.output.shape(), &[2, 2]);
     assert_eq!(
@@ -35,16 +35,18 @@ fn output_permutation_matches_subscripts() {
 
 #[test]
 fn rectangular_output_permutation_matches_subscripts() {
-    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 10.0, 0.0, 2.0, 6.0]);
+    let a =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 10.0, 0.0, 2.0, 6.0]).unwrap();
     let b = Tensor::from_vec_col_major(
         vec![3, 4],
         vec![
             0.0, 1.0, 2.0, 5.0, 0.0, 1.0, -10.0, 20.0, 0.0, 3.0, 3.0, 3.0,
         ],
-    );
+    )
+    .unwrap();
 
     let result =
-        tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ki").unwrap();
+        tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ki").unwrap();
 
     assert_eq!(result.output.shape(), &[4, 2]);
     assert_eq!(
@@ -56,11 +58,11 @@ fn rectangular_output_permutation_matches_subscripts() {
 
 #[test]
 fn minplus_matmul_uses_shared_einsum_lowering() {
-    let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f32, 4.0, 3.0, 2.0]);
-    let b = Tensor::from_vec_col_major(vec![2, 2], vec![5.0_f32, 6.0, 7.0, 1.0]);
+    let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f32, 4.0, 3.0, 2.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2, 2], vec![5.0_f32, 6.0, 7.0, 1.0]).unwrap();
 
     let result =
-        tropical_einsum_with_argmax(TropicalEinsumKind::MinPlus, &[&a, &b], "ij,jk->ik").unwrap();
+        tropical_einsum_with_argmax(TropicalKind::MinPlus, &[&a, &b], "ij,jk->ik").unwrap();
 
     assert_eq!(result.output.shape(), &[2, 2]);
     assert_eq!(
@@ -72,11 +74,11 @@ fn minplus_matmul_uses_shared_einsum_lowering() {
 
 #[test]
 fn ties_keep_first_winner_through_einsum() {
-    let a = Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]);
-    let b = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f64, 2.0]);
+    let a = Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f64, 2.0]).unwrap();
 
     let result =
-        tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ik").unwrap();
+        tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ik").unwrap();
 
     assert_eq!(result.output.as_slice::<f64>().unwrap(), &[3.0]);
     assert_eq!(result.argmax[0].indices(), &[0]);
@@ -87,14 +89,16 @@ fn batched_maxplus_matmul_supports_natural_batch_first_subscripts() {
     let a = Tensor::from_vec_col_major(
         vec![2, 2, 2],
         vec![1.0_f64, 2.0, 4.0, 0.0, 5.0, 1.0, 0.0, 7.0],
-    );
+    )
+    .unwrap();
     let b = Tensor::from_vec_col_major(
         vec![2, 2, 2],
         vec![0.0_f64, 3.0, 2.0, 5.0, 10.0, 4.0, 1.0, 0.0],
-    );
+    )
+    .unwrap();
 
     let result =
-        tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "bij,bjk->bik")
+        tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "bij,bjk->bik")
             .unwrap();
 
     assert_eq!(result.output.shape(), &[2, 2, 2]);
@@ -112,14 +116,16 @@ fn target_order_batched_maxplus_matmul_applies_requested_output_permutation() {
     let a = Tensor::from_vec_col_major(
         vec![2, 2, 2],
         vec![1.0_f64, 4.0, 5.0, 0.0, 2.0, 0.0, 1.0, 7.0],
-    );
+    )
+    .unwrap();
     let b = Tensor::from_vec_col_major(
         vec![2, 2, 2],
         vec![0.0_f64, 2.0, 10.0, 1.0, 3.0, 5.0, 4.0, 0.0],
-    );
+    )
+    .unwrap();
 
     let result =
-        tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ijb,jkb->bik")
+        tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ijb,jkb->bik")
             .unwrap();
 
     assert_eq!(result.output.shape(), &[2, 2, 2]);
@@ -132,11 +138,12 @@ fn target_order_batched_maxplus_matmul_applies_requested_output_permutation() {
 
 #[test]
 fn fallback_handles_input_permutation_and_records_argmax() {
-    let transposed_left = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 5.0, 4.0, 0.0]);
-    let right = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 10.0, 1.0]);
+    let transposed_left =
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 5.0, 4.0, 0.0]).unwrap();
+    let right = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 2.0, 10.0, 1.0]).unwrap();
 
     let result = tropical_einsum_with_argmax(
-        TropicalEinsumKind::MaxPlus,
+        TropicalKind::MaxPlus,
         &[&transposed_left, &right],
         "ji,jk->ik",
     )
@@ -157,19 +164,21 @@ fn fallback_matches_reference_for_multi_contracted_permuted_labels() {
         vec![
             0.0_f64, 4.0, 1.0, 3.0, 2.0, 5.0, 6.0, 1.0, 7.0, 0.0, 8.0, 2.0,
         ],
-    );
+    )
+    .unwrap();
     let rhs = Tensor::from_vec_col_major(
         vec![2, 3, 2],
         vec![
             1.0_f64, 0.0, 2.0, 4.0, 0.0, 3.0, 5.0, 1.0, 0.0, 2.0, 4.0, 6.0,
         ],
-    );
+    )
+    .unwrap();
 
     let result =
-        tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&lhs, &rhs], "kji,ljk->il")
+        tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&lhs, &rhs], "kji,ljk->il")
             .unwrap();
     let expected = reference_tropical_einsum_f64(
-        TropicalEinsumKind::MaxPlus,
+        TropicalKind::MaxPlus,
         &lhs,
         b"kji",
         &rhs,
@@ -189,14 +198,16 @@ fn fallback_matches_reference_for_multi_contracted_permuted_labels() {
 
 #[test]
 fn fallback_matches_reference_for_minplus_output_permutation() {
-    let lhs = Tensor::from_vec_col_major(vec![3, 2], vec![4.0_f64, 1.0, 5.0, 0.0, 3.0, 2.0]);
-    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![2.0_f64, 4.0, 1.0, 5.0, 0.0, 3.0]);
+    let lhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![4.0_f64, 1.0, 5.0, 0.0, 3.0, 2.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![2.0_f64, 4.0, 1.0, 5.0, 0.0, 3.0]).unwrap();
 
     let result =
-        tropical_einsum_with_argmax(TropicalEinsumKind::MinPlus, &[&lhs, &rhs], "ji,jk->ki")
+        tropical_einsum_with_argmax(TropicalKind::MinPlus, &[&lhs, &rhs], "ji,jk->ki")
             .unwrap();
     let expected =
-        reference_tropical_einsum_f64(TropicalEinsumKind::MinPlus, &lhs, b"ji", &rhs, b"jk", b"ki");
+        reference_tropical_einsum_f64(TropicalKind::MinPlus, &lhs, b"ji", &rhs, b"jk", b"ki");
 
     assert_eq!(result.output.shape(), expected.shape);
     assert_eq!(result.output.as_slice::<f64>().unwrap(), expected.values);
@@ -205,14 +216,15 @@ fn fallback_matches_reference_for_minplus_output_permutation() {
 
 #[test]
 fn fallback_matches_reference_for_nan_and_all_nan_cells() {
-    let lhs = Tensor::from_vec_col_major(vec![2, 2], vec![f64::NAN, 1.0, f64::NAN, f64::NAN]);
-    let rhs = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 0.0, f64::NAN, 2.0]);
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 2], vec![f64::NAN, 1.0, f64::NAN, f64::NAN]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64, 0.0, f64::NAN, 2.0]).unwrap();
 
     let result =
-        tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&lhs, &rhs], "ji,jk->ik")
+        tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&lhs, &rhs], "ji,jk->ik")
             .unwrap();
     let expected =
-        reference_tropical_einsum_f64(TropicalEinsumKind::MaxPlus, &lhs, b"ji", &rhs, b"jk", b"ik");
+        reference_tropical_einsum_f64(TropicalKind::MaxPlus, &lhs, b"ji", &rhs, b"jk", b"ik");
 
     assert_eq!(result.output.shape(), expected.shape);
     assert_eq!(result.output.as_slice::<f64>().unwrap(), expected.values);
@@ -221,11 +233,11 @@ fn fallback_matches_reference_for_nan_and_all_nan_cells() {
 
 #[test]
 fn fallback_ties_keep_first_contracted_winner() {
-    let transposed_left = Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f32, 1.0]);
-    let right = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f32, 2.0]);
+    let transposed_left = Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f32, 1.0]).unwrap();
+    let right = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f32, 2.0]).unwrap();
 
     let result = tropical_einsum_with_argmax(
-        TropicalEinsumKind::MaxPlus,
+        TropicalKind::MaxPlus,
         &[&transposed_left, &right],
         "ji,jk->ik",
     )
@@ -237,11 +249,11 @@ fn fallback_ties_keep_first_contracted_winner() {
 
 #[test]
 fn multi_contracted_modes_expose_fused_winner_coordinates() {
-    let a = Tensor::from_vec_col_major(vec![1, 2, 2], vec![0.0_f64, 5.0, 3.0, 1.0]);
-    let b = Tensor::from_vec_col_major(vec![2, 2, 1], vec![0.0_f64, 0.0, 0.0, 0.0]);
+    let a = Tensor::from_vec_col_major(vec![1, 2, 2], vec![0.0_f64, 5.0, 3.0, 1.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2, 2, 1], vec![0.0_f64, 0.0, 0.0, 0.0]).unwrap();
 
     let result =
-        tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ijk,jkl->il").unwrap();
+        tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ijk,jkl->il").unwrap();
     let step = &result.argmax[0];
 
     assert_eq!(result.output.as_slice::<f64>().unwrap(), &[5.0]);
@@ -253,11 +265,11 @@ fn multi_contracted_modes_expose_fused_winner_coordinates() {
 
 #[test]
 fn empty_outputs_allow_zero_sized_contracted_modes() {
-    let a = Tensor::from_vec_col_major(vec![0, 0], Vec::<f64>::new());
-    let b = Tensor::from_vec_col_major(vec![0, 4], Vec::<f64>::new());
+    let a = Tensor::from_vec_col_major(vec![0, 0], Vec::<f64>::new()).unwrap();
+    let b = Tensor::from_vec_col_major(vec![0, 4], Vec::<f64>::new()).unwrap();
 
     let result =
-        tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &[&a, &b], "ij,jk->ik").unwrap();
+        tropical_einsum_with_argmax(TropicalKind::MaxPlus, &[&a, &b], "ij,jk->ik").unwrap();
 
     assert_eq!(result.output.shape(), &[0, 4]);
     assert!(result.output.as_slice::<f64>().unwrap().is_empty());
@@ -267,8 +279,8 @@ fn empty_outputs_allow_zero_sized_contracted_modes() {
 
 #[test]
 fn unsupported_cases_return_invalid_config() {
-    let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
-    let b = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]);
+    let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
 
     let unsupported = [
         ("three inputs", vec![&a, &b, &a], "ij,jk,kl->il"),
@@ -279,7 +291,7 @@ fn unsupported_cases_return_invalid_config() {
     ];
 
     for (case, inputs, notation) in unsupported {
-        let err = tropical_einsum_with_argmax(TropicalEinsumKind::MaxPlus, &inputs, notation)
+        let err = tropical_einsum_with_argmax(TropicalKind::MaxPlus, &inputs, notation)
             .unwrap_err();
         assert!(
             matches!(
@@ -293,9 +305,9 @@ fn unsupported_cases_return_invalid_config() {
         );
     }
 
-    let int_tensor = Tensor::from_vec_col_major(vec![2, 2], vec![1_i32, 2, 3, 4]);
+    let int_tensor = Tensor::from_vec_col_major(vec![2, 2], vec![1_i32, 2, 3, 4]).unwrap();
     let err = tropical_einsum_with_argmax(
-        TropicalEinsumKind::MaxPlus,
+        TropicalKind::MaxPlus,
         &[&int_tensor, &int_tensor],
         "ij,jk->ik",
     )
@@ -308,10 +320,10 @@ fn unsupported_cases_return_invalid_config() {
         }
     ));
 
-    let zero_lhs = Tensor::from_vec_col_major(vec![2, 0], Vec::<f64>::new());
-    let zero_rhs = Tensor::from_vec_col_major(vec![0, 4], Vec::<f64>::new());
+    let zero_lhs = Tensor::from_vec_col_major(vec![2, 0], Vec::<f64>::new()).unwrap();
+    let zero_rhs = Tensor::from_vec_col_major(vec![0, 4], Vec::<f64>::new()).unwrap();
     let err = tropical_einsum_with_argmax(
-        TropicalEinsumKind::MaxPlus,
+        TropicalKind::MaxPlus,
         &[&zero_lhs, &zero_rhs],
         "ij,jk->ik",
     )
@@ -332,7 +344,7 @@ struct ReferenceResult {
 }
 
 fn reference_tropical_einsum_f64(
-    kind: TropicalEinsumKind,
+    kind: TropicalKind,
     lhs: &Tensor,
     lhs_labels: &[u8],
     rhs: &Tensor,
@@ -377,8 +389,8 @@ fn reference_tropical_einsum_f64(
 
     for _ in 0..output_len {
         let mut best = match kind {
-            TropicalEinsumKind::MaxPlus => f64::NEG_INFINITY,
-            TropicalEinsumKind::MinPlus => f64::INFINITY,
+            TropicalKind::MaxPlus => f64::NEG_INFINITY,
+            TropicalKind::MinPlus => f64::INFINITY,
             _ => unreachable!("unknown tropical kind"),
         };
         let mut winner = 0_u32;
@@ -403,8 +415,8 @@ fn reference_tropical_einsum_f64(
             );
             let candidate = lhs_data[lhs_offset] + rhs_data[rhs_offset];
             let better = match kind {
-                TropicalEinsumKind::MaxPlus => !has_ordered_candidate || candidate > best,
-                TropicalEinsumKind::MinPlus => !has_ordered_candidate || candidate < best,
+                TropicalKind::MaxPlus => !has_ordered_candidate || candidate > best,
+                TropicalKind::MinPlus => !has_ordered_candidate || candidate < best,
                 _ => unreachable!("unknown tropical kind"),
             };
             if !candidate.is_nan() && better {

--- a/scripts/check-linalg-ad-boundaries.py
+++ b/scripts/check-linalg-ad-boundaries.py
@@ -57,7 +57,7 @@ def main() -> int:
     for needle in [
         '#[cfg(feature = "autodiff")]\nmod ad;',
         '#[cfg(feature = "autodiff")]\npub mod eager_tensor;',
-        '#[cfg(feature = "autodiff")]\npub use ad::{ad_rules, register_extension_rule};',
+        '#[cfg(feature = "autodiff")]\npub use ad::ad_rules;',
     ]:
         if needle not in linalg_lib.read_text(encoding="utf-8"):
             findings.append(f"crates/tenferro-linalg/src/lib.rs missing gated item: {needle!r}")


### PR DESCRIPTION
> [!IMPORTANT]
> New features must start as a feature request issue.
> Please do not open a new-feature implementation PR before maintainers accept
> the issue and agree that implementation should start.
>
> If you already have prototype code, link to a fork branch, gist, or
> repository from the feature request issue instead of opening a PR.
>
> New-feature PRs opened before an accepted issue may be closed and redirected
> to an issue.
>
> If you are using an AI agent for a bug-fix PR, use or follow the
> repository-local `tenferro-bugfix-pr` workflow before editing code.

## Type

- [x] Bug fix
- [x] Documentation
- [x] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1111
Fixes #1112
Fixes #1113
Fixes #1114
Fixes #1116
Fixes #1117
Fixes #1118
Fixes #1119
Refs #1115
Refs #1054

## Summary

This is the next Terasaki bug batch, kept as a single non-squash PR candidate.
It fixes the current substantive #1111-#1119 bug reports and then removes the old compatibility APIs that would preserve the same failure modes.

Main changes:

- Replace public panic/defaulting paths with canonical typed-error APIs, including traced dot/scale validation, CPU thread count validation, linalg solve AD validation, CPU conversion checks, FFT/GPU shape arithmetic checks, and related docs/tests.
- Remove legacy public surface: root operation re-exports, process-global extension AD registration, old trait/type aliases, owned tensor physical-slice aliases, `TensorMeta.shape`, vague `gpu` feature aliases, and optional extension `execute_reads` fallback.
- Keep the long-term clean design as the repair path: `tidu` error API cleanup is used directly, extension AD uses explicit rule sets, scratch buffers distinguish full-overwrite uninitialized acquisition from zeroed read-before-write acquisition, and metadata callers must choose exact vs bound shape explicitly.
- Update repository/workflow rules so future bug batches search same-root-cause patterns, avoid `try_*` compatibility escapes unless they are the canonical Rust API, and leave comments/tests for intentional false positives.

## Work log

- `docs/worklogs/2026-06-18-terasaki-bug-batch-3.md`

## Verification

Local checks run before push:

- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo check -p tenferro-cpu --features provider-inject --all-targets`
- `cargo check -p tenferro-linalg --features provider-inject --all-targets`
- `cargo check -p tenferro-gpu --features cuda`
- `cargo check -p tenferro-ad --features cuda`
- `cargo check -p tenferro-linalg --features cuda,autodiff`
- `cargo check -p tenferro-einsum --features autodiff --all-targets`
- `cargo test -p tenferro-internal-extension-macros`
- `cargo test -p tenferro-internal-ops metadata`
- `cargo test -p tenferro-tensor accessors`
- `cargo test -p tenferro-tensor-core view_validation_reports_rank_permutation_and_slice_errors`
- `cargo test -p tenferro-runtime --test public_surface_contract`
- `cargo test -p tenferro-gpu --test public_surface_contract`
- `cargo test -p tenferro-cpu --test provider_feature_contract`

No cloud GPU runtime checks were used; GPU coverage here is local source-contract tests plus CUDA feature compilation.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [ ] If this implements a new feature, the linked issue has been accepted by
      maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from
      `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and
      linked it above.
