### PR TITLE
docs: gate getting-started core-concepts snippets with compiled examples

### DIFF
--- a/crates/tenferro-ad/examples/eager_backward.rs
+++ b/crates/tenferro-ad/examples/eager_backward.rs
@@ -1,0 +1,12 @@
+use tenferro_ad::{EagerRuntime, Tensor};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = EagerRuntime::new();
+    let x = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?)?;
+    let loss = x.mul(&x)?.reduce_sum(&[0])?;
+    loss.backward()?;
+
+    assert_eq!(x.grad()?.unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
+
+    Ok(())
+}

--- a/crates/tenferro-runtime/examples/direct_tensor_execution.rs
+++ b/crates/tenferro-runtime/examples/direct_tensor_execution.rs
@@ -1,0 +1,14 @@
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{Tensor, TensorOpsExt};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut backend = CpuBackend::new();
+
+    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])?;
+    let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])?;
+
+    let c = a.matmul(&b, &mut backend)?;
+    assert_eq!(c.shape(), &[2, 2]);
+
+    Ok(())
+}

--- a/crates/tenferro-runtime/examples/traced_graph_execution.rs
+++ b/crates/tenferro-runtime/examples/traced_graph_execution.rs
@@ -1,0 +1,17 @@
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let a = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
+    let b = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0])?;
+    let sum = (&a + &b)?;
+
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(&sum)?;
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    let result = executor.run(&program)?;
+
+    assert_eq!(result.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+
+    Ok(())
+}

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -62,6 +62,10 @@ Use `from_vec_col_major` for tensor construction. Data copied from PyTorch,
 NumPy, JAX, or C-style examples must be explicitly reordered at the boundary
 before entering tenferro.
 
+Read values back with `as_slice::<T>()` on `Tensor`, or `as_slice()` on
+`TypedTensor<T>`. Both return `Result<&[T]>` and yield `Err` on a dtype
+mismatch, not `Option`.
+
 ## Direct Tensor Execution
 
 `Tensor` operations run immediately through an explicit backend. Use this for
@@ -122,6 +126,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 <!-- end-snippet-source -->
+
+Here `Tensor` is `tenferro_ad`'s re-export of `tenferro_runtime::Tensor` — the
+same type as the concrete tensor used in the sections above, so values move
+between the eager and direct APIs without conversion.
 
 ## Traced Graph Execution
 

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -67,17 +67,24 @@ before entering tenferro.
 `Tensor` operations run immediately through an explicit backend. Use this for
 ordinary tensor computation without autodiff when runtime dtype is useful.
 
+<!-- snippet-source: crates/tenferro-runtime/examples/direct_tensor_execution.rs -->
 ```rust
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{Tensor, TensorOpsExt};
 
-let mut backend = CpuBackend::new();
-let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
-let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut backend = CpuBackend::new();
 
-let c = a.matmul(&b, &mut backend).unwrap();
-assert_eq!(c.shape(), &[2, 2]);
+    let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])?;
+    let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])?;
+
+    let c = a.matmul(&b, &mut backend)?;
+    assert_eq!(c.shape(), &[2, 2]);
+
+    Ok(())
+}
 ```
+<!-- end-snippet-source -->
 
 `TypedTensor<T>` is the compile-time scalar type layer. It is useful when the
 project already knows it is working with `f64`, `f32`, complex values, or
@@ -99,16 +106,22 @@ gradients.
 This is not the forward-mode AD/JVP API. Use `TracedTensor` for `grad`, `vjp`,
 `jvp`, and HVP via composition on traced graphs.
 
+<!-- snippet-source: crates/tenferro-ad/examples/eager_backward.rs -->
 ```rust
 use tenferro_ad::{EagerRuntime, Tensor};
 
-let ctx = EagerRuntime::new();
-let x = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap()).unwrap();
-let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
-loss.backward().unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let ctx = EagerRuntime::new();
+    let x = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?)?;
+    let loss = x.mul(&x)?.reduce_sum(&[0])?;
+    loss.backward()?;
 
-assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
+    assert_eq!(x.grad()?.unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
+
+    Ok(())
+}
 ```
+<!-- end-snippet-source -->
 
 ## Traced Graph Execution
 
@@ -116,21 +129,27 @@ assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
 lowers that graph into a reusable program, and a `GraphExecutor<B>` runs the
 program on a backend.
 
+<!-- snippet-source: crates/tenferro-runtime/examples/traced_graph_execution.rs -->
 ```rust
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
 
-let a = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-let b = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
-let sum = (&a + &b).unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let a = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
+    let b = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0])?;
+    let sum = (&a + &b)?;
 
-let mut compiler = GraphCompiler::new();
-let program = compiler.compile(&sum).unwrap();
-let mut executor = GraphExecutor::new(CpuBackend::new());
-let result = executor.run(&program).unwrap();
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(&sum)?;
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    let result = executor.run(&program)?;
 
-assert_eq!(result.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+    assert_eq!(result.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+
+    Ok(())
+}
 ```
+<!-- end-snippet-source -->
 
 Traced mode is the right API for `grad`, `vjp`, `jvp`, and HVP via composition
 on traced graphs, symbolic inputs, graph optimization, and repeated execution.

--- a/docs/worklogs/2026-06-20-core-concepts-snippet-gating.md
+++ b/docs/worklogs/2026-06-20-core-concepts-snippet-gating.md
@@ -24,8 +24,8 @@ downstream crate, which surfaced the `E0599`.
 ## Root cause
 
 `scripts/check-doc-snippets.py` only verifies code blocks wrapped in
-`<!-- snippet-source: PATH -->` / `<!-- end-snippet-source -->` markers (it syncs
-them from real example files, which CI compiles). The `index.md` First CPU
+`snippet-source` / `end-snippet-source` HTML-comment markers (it syncs them from
+real example files, which CI compiles). The `index.md` First CPU
 Program is marker-backed (`crates/tenferro-runtime/examples/cpu_quickstart.rs`)
 and stayed correct; the core-concepts concept snippets were hand-written and
 **unmarked**, so they were never compile-checked and the Direct snippet rotted.

--- a/docs/worklogs/2026-06-20-core-concepts-snippet-gating.md
+++ b/docs/worklogs/2026-06-20-core-concepts-snippet-gating.md
@@ -1,0 +1,71 @@
+# Work log: gate getting-started core-concepts snippets with compiled examples
+
+- Date: 2026-06-20
+- Type: AI-assisted bug fix (documentation correctness)
+- Branch: `fix/core-concepts-direct-snippet-compile`
+
+## Summary
+
+`docs/getting-started/core-concepts.md` "Direct Tensor Execution" snippet did
+not compile: `let a = Tensor::from_vec_col_major(...)` / `let b = ...` omitted
+`?`/`.unwrap()`, so `a.matmul(&b, &mut backend)` was called on a
+`Result<Tensor, _>` and failed with `E0599: no method named matmul ... for enum
+Result`. A reader copy-pasting the snippet could not build it.
+
+## How it was found
+
+A **source-blind documentation audit** (the method added to
+`tensor4all-agent-rules` `rules/common/docs-and-tests.md`): a doc-only agent was
+given only README + `docs/getting-started/` (no source, no repo links) and asked
+to write a minimal integration program from the docs alone. The main agent then
+compile-checked the doc snippets against the real crates as an external
+downstream crate, which surfaced the `E0599`.
+
+## Root cause
+
+`scripts/check-doc-snippets.py` only verifies code blocks wrapped in
+`<!-- snippet-source: PATH -->` / `<!-- end-snippet-source -->` markers (it syncs
+them from real example files, which CI compiles). The `index.md` First CPU
+Program is marker-backed (`crates/tenferro-runtime/examples/cpu_quickstart.rs`)
+and stayed correct; the core-concepts concept snippets were hand-written and
+**unmarked**, so they were never compile-checked and the Direct snippet rotted.
+
+## Change
+
+Back all three concept snippets with real, CI-compiled examples and wire them
+via snippet-source markers:
+
+- `crates/tenferro-runtime/examples/direct_tensor_execution.rs` (fixed: `?`)
+- `crates/tenferro-runtime/examples/traced_graph_execution.rs`
+- `crates/tenferro-ad/examples/eager_backward.rs`
+
+This both fixes the Direct snippet and prevents the whole section from rotting
+again, consistent with the already-marker-backed Memory Model snippet
+(`column_major_memory.rs`) in the same file.
+
+## Rejected / deferred alternatives
+
+- Minimal fix (add `.unwrap()` to the two lines only): rejected — leaves the
+  snippet unmarked and able to rot again; does not address the root cause.
+- New repository audit rule "flag unmarked code blocks in user-facing docs":
+  considered; the mechanical snippet-source gate is stronger for these snippets.
+  A general rule could still be proposed separately if unmarked blocks recur.
+
+## Deferred (other audit findings, doc-clarity only — not compile bugs)
+
+- `as_slice::<T>()` returns `Result<&[T]>` (not `Option`); undocumented.
+- No copy-pasteable dependency (path placeholder / crates.io `"..."`; no git URL).
+- Error type not named; no `Debug`/print example; MSRV/edition unstated.
+- Eager example imports `Tensor` from `tenferro_ad` with no deps block shown.
+- `pytorch-jax-mapping.md` column-major fragment is illustrative (not a program).
+
+## Verification
+
+- `cargo run -p tenferro-runtime --example direct_tensor_execution` — ok
+- `cargo run -p tenferro-runtime --example traced_graph_execution` — ok
+- `cargo run -p tenferro-ad --example eager_backward` — ok
+- `python3 scripts/check-doc-snippets.py --check` — `doc-snippets-ok`
+- `cargo fmt --all --check` — ok
+- `cargo clippy -p tenferro-runtime -p tenferro-ad --examples` — ok
+- Not run (unrelated to this change): full `cargo test --workspace --release`,
+  coverage, `cargo doc`.

--- a/docs/worklogs/2026-06-20-core-concepts-snippet-gating.md
+++ b/docs/worklogs/2026-06-20-core-concepts-snippet-gating.md
@@ -51,12 +51,18 @@ again, consistent with the already-marker-backed Memory Model snippet
   considered; the mechanical snippet-source gate is stronger for these snippets.
   A general rule could still be proposed separately if unmarked blocks recur.
 
+## Signposts added in this PR (from the doer's refuted false positives)
+
+The source-blind doer guessed `as_slice` returned `Option` (it returns `Result`)
+and flagged `tenferro_ad::Tensor` vs `tenferro_runtime::Tensor` as a clash (they
+are the same re-exported type). Both false positives mark spots the docs invite
+misreading, so `core-concepts.md` now states each explicitly — a false positive
+turned into a signpost rather than discarded.
+
 ## Deferred (other audit findings, doc-clarity only — not compile bugs)
 
-- `as_slice::<T>()` returns `Result<&[T]>` (not `Option`); undocumented.
 - No copy-pasteable dependency (path placeholder / crates.io `"..."`; no git URL).
 - Error type not named; no `Debug`/print example; MSRV/edition unstated.
-- Eager example imports `Tensor` from `tenferro_ad` with no deps block shown.
 - `pytorch-jax-mapping.md` column-major fragment is illustrative (not a program).
 
 ## Verification


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] Documentation

## Related issue

None. Found via a source-blind documentation audit (doc-only agent given only
README + `docs/getting-started/`, then compile-checking the doc snippets against
the real crates as an external downstream crate).

## Summary

The **"Direct Tensor Execution"** snippet in
`docs/getting-started/core-concepts.md` did not compile. The
`from_vec_col_major` constructors were missing `?`/`.unwrap()`, so
`a.matmul(&b, &mut backend)` was called on a `Result<Tensor, _>`:

```
error[E0599]: no method named `matmul` found for enum `Result<Tensor, Error>`
```

A reader copy-pasting the snippet could not build it.

**Root cause:** `scripts/check-doc-snippets.py` only compile-checks code blocks
backed by `<!-- snippet-source: PATH -->` markers (it syncs them from real
example files, which CI compiles). `index.md`'s First CPU Program is backed by
`crates/tenferro-runtime/examples/cpu_quickstart.rs` and stayed correct, but the
core-concepts concept snippets were hand-written, **unmarked**, and never
compile-checked — so the Direct snippet rotted.

**Change:** back all three concept snippets with real, CI-compiled examples and
wire them via snippet-source markers:

- `crates/tenferro-runtime/examples/direct_tensor_execution.rs` (fixed: `?`)
- `crates/tenferro-runtime/examples/traced_graph_execution.rs`
- `crates/tenferro-ad/examples/eager_backward.rs`

This fixes the broken snippet and prevents the section from rotting again,
consistent with the already-backed Memory Model snippet (`column_major_memory.rs`)
in the same file.

**Scope gate (AI-assisted bug fix):** applied. No new public API, operation
family, backend, dependency, feature flag, architectural layer, or AD change —
docs-only correctness plus example files.

**Same-root-cause search:** the other two unmarked core-concepts snippets (Eager,
Traced) compile today but had the same rot risk; they are gated here too.

**Signposts added (from the audit's refuted false positives):** `as_slice::<T>()`
/ `as_slice()` return `Result<&[T]>` (not `Option`); and `tenferro_ad::Tensor` is
a re-export of `tenferro_runtime::Tensor` (same type). A doc-induced false
positive marks exactly where a newcomer would misread, so it becomes a signpost
rather than a discard.

**Deferred** (doc-clarity only, not compile bugs): no copy-pasteable dependency
(path placeholder / crates.io `"..."`, no git URL); error type unnamed; no
print/`Debug` example; MSRV/edition unstated; the `pytorch-jax-mapping.md`
column-major fragment is illustrative (not a program).

## Work log

`docs/worklogs/2026-06-20-core-concepts-snippet-gating.md`

## Checklist

- [x] I read `CONTRIBUTING.md` / `AGENTS.md` / `REPOSITORY_RULES.md`.
- [x] I added/updated docs and the backing examples.
- [x] Bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md` applied.
- [x] Work log added under `docs/worklogs/` and linked above.

## Verification

```
cargo run -p tenferro-runtime --example direct_tensor_execution   # ok
cargo run -p tenferro-runtime --example traced_graph_execution    # ok
cargo run -p tenferro-ad      --example eager_backward            # ok
python3 scripts/check-doc-snippets.py --check                     # doc-snippets-ok
cargo fmt --all --check                                           # ok
cargo clippy -p tenferro-runtime -p tenferro-ad --examples        # ok
```

Not run locally (unrelated to this docs/examples change; left to CI): full
`cargo test --workspace --release`, coverage, `cargo doc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
