### PR TITLE
[codex] Fix Terasaki NaN, validation, and docs batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ tenferro-rs is a multi-crate workspace. There is intentionally no `tenferro` fac
 Create a binary crate that depends on `tenferro-runtime` and `tenferro-cpu`.
 The same runnable example lives at
 `crates/tenferro-runtime/examples/cpu_quickstart.rs`.
+For a local checkout, the full setup notes are in
+[`docs/getting-started/index.md`](docs/getting-started/index.md), including the
+empty `[workspace]` table needed by scratch crates created inside this
+repository.
 
 <!-- snippet-source: crates/tenferro-runtime/examples/cpu_quickstart.rs -->
 ```rust

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -851,9 +851,7 @@ impl EagerTensor {
         value: TensorValue,
     ) -> Result<Self> {
         let Some(first) = tensors.first() else {
-            return Err(Error::Internal(
-                "nary eager value op requires at least one input tensor".to_string(),
-            ));
+            return Err(empty_nary_input_error(&op));
         };
 
         let ctx = Arc::clone(&first.ctx);
@@ -896,9 +894,7 @@ impl EagerTensor {
     pub(crate) fn nary_op(tensors: &[&Self], op: StdTensorOp) -> Result<Self> {
         let total_started = std::time::Instant::now();
         let Some(first) = tensors.first() else {
-            return Err(Error::Internal(
-                "nary eager op requires at least one input tensor".to_string(),
-            ));
+            return Err(empty_nary_input_error(&op));
         };
 
         let ctx = Arc::clone(&first.ctx);
@@ -976,5 +972,19 @@ impl EagerTensor {
         record_eager_op_profile("nary_op.total", total_started.elapsed());
         maybe_print_eager_op_profile();
         result
+    }
+}
+
+fn empty_nary_input_error(op: &StdTensorOp) -> Error {
+    Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
+        op: eager_validation_op_name(op),
+        message: "operation requires at least one input tensor".to_string(),
+    })
+}
+
+fn eager_validation_op_name(op: &StdTensorOp) -> &'static str {
+    match op {
+        StdTensorOp::Concatenate { .. } => "concatenate",
+        _ => "eager_nary_op",
     }
 }

--- a/crates/tenferro-ad/tests/eager_tensor.rs
+++ b/crates/tenferro-ad/tests/eager_tensor.rs
@@ -172,6 +172,19 @@ fn matrix_eager_input_uses_column_major_values() {
 }
 
 #[test]
+fn eager_concatenate_empty_reports_typed_validation_error() {
+    let err = EagerTensor::concatenate(&[], 0).unwrap_err();
+
+    assert!(matches!(
+        err,
+        tenferro_ad::Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
+            op: "concatenate",
+            ..
+        })
+    ));
+}
+
+#[test]
 fn untracked_eager_intermediate_can_later_feed_tracked_ad() {
     let ctx = test_ctx();
     let plain = EagerTensor::from_tensor_in(

--- a/crates/tenferro-cpu/src/elementwise.rs
+++ b/crates/tenferro-cpu/src/elementwise.rs
@@ -11,8 +11,8 @@ use strided_kernel::{
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::ConjElem;
 use tenferro_tensor::{
-    col_major_strides, CompareDir, Tensor, TensorOwnedView, TensorRank, TensorRead, TensorValue,
-    TensorView, TypedTensor, TypedTensorView,
+    col_major_strides, CompareDir, DType, Tensor, TensorOwnedView, TensorRank, TensorRead,
+    TensorValue, TensorView, TypedTensor, TypedTensorView,
 };
 
 use super::{
@@ -30,6 +30,22 @@ macro_rules! dispatch_ternary_result_with_pool {
             _ => Err(crate::Error::backend_failure($op, "dtype mismatch")),
         }
     };
+}
+
+fn dtype_pair_error(op: &'static str, lhs: DType, rhs: DType) -> crate::Error {
+    if lhs == rhs {
+        crate::Error::backend_failure(op, format!("unsupported dtype {lhs:?}"))
+    } else {
+        crate::Error::DTypeMismatch { op, lhs, rhs }
+    }
+}
+
+fn tensor_pair_error(op: &'static str, lhs: &Tensor, rhs: &Tensor) -> crate::Error {
+    dtype_pair_error(op, lhs.dtype(), rhs.dtype())
+}
+
+fn read_pair_error(op: &'static str, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Error {
+    dtype_pair_error(op, lhs.dtype(), rhs.dtype())
 }
 
 pub(crate) trait Tier2Elem: Copy + Clone + One + Zero + Send + Sync {
@@ -59,7 +75,9 @@ macro_rules! impl_tier2_elem_real {
             }
 
             fn max_elem(self, other: Self) -> Self {
-                if self >= other {
+                if self.is_nan() || other.is_nan() {
+                    <$ty>::NAN
+                } else if self >= other {
                     self
                 } else {
                     other
@@ -67,7 +85,9 @@ macro_rules! impl_tier2_elem_real {
             }
 
             fn min_elem(self, other: Self) -> Self {
-                if self <= other {
+                if self.is_nan() || other.is_nan() {
+                    <$ty>::NAN
+                } else if self <= other {
                     self
                 } else {
                     other
@@ -105,7 +125,11 @@ macro_rules! impl_tier2_elem_complex {
             }
 
             fn max_elem(self, other: Self) -> Self {
-                if self.norm_sqr() >= other.norm_sqr() {
+                let lhs_norm = self.norm_sqr();
+                let rhs_norm = other.norm_sqr();
+                if lhs_norm.is_nan() || rhs_norm.is_nan() {
+                    Self::new(<$real>::NAN, <$real>::NAN)
+                } else if lhs_norm >= rhs_norm {
                     self
                 } else {
                     other
@@ -113,7 +137,11 @@ macro_rules! impl_tier2_elem_complex {
             }
 
             fn min_elem(self, other: Self) -> Self {
-                if self.norm_sqr() <= other.norm_sqr() {
+                let lhs_norm = self.norm_sqr();
+                let rhs_norm = other.norm_sqr();
+                if lhs_norm.is_nan() || rhs_norm.is_nan() {
+                    Self::new(<$real>::NAN, <$real>::NAN)
+                } else if lhs_norm <= rhs_norm {
                     self
                 } else {
                     other
@@ -237,11 +265,7 @@ pub(crate) fn add_with_pool(
             let scalar = complex_scalar_tensor(typed_host_data("add", b)?[0])?;
             Ok(Tensor::C64(typed_add_with_pool(buffers, a, &scalar)?))
         }
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "add",
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        }),
+        _ => Err(tensor_pair_error("add", lhs, rhs)),
     }
 }
 
@@ -362,11 +386,7 @@ pub(crate) fn add_read_with_pool(
     dispatch!(C32);
     dispatch!(C64);
 
-    Err(crate::Error::DTypeMismatch {
-        op: "add",
-        lhs: lhs.dtype(),
-        rhs: rhs.dtype(),
-    })
+    Err(read_pair_error("add", lhs, rhs))
 }
 
 /// Multiply two CPU tensors elementwise.
@@ -398,11 +418,7 @@ fn binary_read_with_pool(
         return f(buffers, lhs, rhs);
     }
 
-    Err(crate::Error::DTypeMismatch {
-        op,
-        lhs: lhs.dtype(),
-        rhs: rhs.dtype(),
-    })
+    Err(read_pair_error(op, lhs, rhs))
 }
 
 pub(crate) fn mul_with_pool(
@@ -433,11 +449,7 @@ pub(crate) fn mul_with_pool(
             let scalar = complex_scalar_tensor(typed_host_data("mul", b)?[0])?;
             Ok(Tensor::C64(typed_mul_with_pool(buffers, a, &scalar)?))
         }
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "mul",
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        }),
+        _ => Err(tensor_pair_error("mul", lhs, rhs)),
     }
 }
 
@@ -1920,11 +1932,7 @@ pub(crate) fn maximum_with_pool(
         (Tensor::C64(a), Tensor::C64(b)) => {
             Ok(Tensor::C64(typed_maximum_with_pool(buffers, a, b)?))
         }
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "maximum",
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        }),
+        _ => Err(tensor_pair_error("maximum", lhs, rhs)),
     }
 }
 
@@ -1956,11 +1964,7 @@ pub(crate) fn maximum_read_with_pool(
                 x.max_elem(y)
             })?,
         )),
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "maximum",
-            lhs: lhs_dtype,
-            rhs: rhs_dtype,
-        }),
+        _ => Err(dtype_pair_error("maximum", lhs_dtype, rhs_dtype)),
     }
 }
 
@@ -2000,11 +2004,7 @@ pub(crate) fn minimum_with_pool(
         (Tensor::C64(a), Tensor::C64(b)) => {
             Ok(Tensor::C64(typed_minimum_with_pool(buffers, a, b)?))
         }
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "minimum",
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        }),
+        _ => Err(tensor_pair_error("minimum", lhs, rhs)),
     }
 }
 
@@ -2036,11 +2036,7 @@ pub(crate) fn minimum_read_with_pool(
                 x.min_elem(y)
             })?,
         )),
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "minimum",
-            lhs: lhs_dtype,
-            rhs: rhs_dtype,
-        }),
+        _ => Err(dtype_pair_error("minimum", lhs_dtype, rhs_dtype)),
     }
 }
 

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -43,6 +43,39 @@ fn ensure_host_tensor(op: &'static str, input: &Tensor) -> crate::Result<()> {
     }
 }
 
+fn validate_reduced_axes_nonempty(
+    op: &'static str,
+    shape: &[usize],
+    axes: &[usize],
+) -> crate::Result<()> {
+    validate_axes(op, axes, shape.len())?;
+    for &axis in axes {
+        if shape[axis] == 0 {
+            return Err(crate::Error::InvalidConfig {
+                op,
+                message: format!("cannot reduce over zero-length axis {axis}"),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn nan_propagating_max<T: Float>(a: T, b: T) -> T {
+    if a.is_nan() || b.is_nan() {
+        T::nan()
+    } else {
+        a.max(b)
+    }
+}
+
+fn nan_propagating_min<T: Float>(a: T, b: T) -> T {
+    if a.is_nan() || b.is_nan() {
+        T::nan()
+    } else {
+        a.min(b)
+    }
+}
+
 pub fn reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_sum(t, axes)?)),
@@ -230,22 +263,28 @@ pub(crate) fn reduce_max_read(input: TensorRead<'_>, axes: &[usize]) -> crate::R
             ensure_host_tensor("reduce_max", input)?;
             reduce_max(input, axes)
         }
-        TensorRead::View(TensorView::F32(t)) => Ok(Tensor::F32(typed_reduce_view(
-            &t,
-            axes,
-            |x| x,
-            |a, b| a.max(b),
-            f32::neg_infinity(),
-            "reduce_max",
-        )?)),
-        TensorRead::View(TensorView::F64(t)) => Ok(Tensor::F64(typed_reduce_view(
-            &t,
-            axes,
-            |x| x,
-            |a, b| a.max(b),
-            f64::neg_infinity(),
-            "reduce_max",
-        )?)),
+        TensorRead::View(TensorView::F32(t)) => {
+            validate_reduced_axes_nonempty("reduce_max", t.shape(), axes)?;
+            Ok(Tensor::F32(typed_reduce_view(
+                &t,
+                axes,
+                |x| x,
+                nan_propagating_max,
+                f32::neg_infinity(),
+                "reduce_max",
+            )?))
+        }
+        TensorRead::View(TensorView::F64(t)) => {
+            validate_reduced_axes_nonempty("reduce_max", t.shape(), axes)?;
+            Ok(Tensor::F64(typed_reduce_view(
+                &t,
+                axes,
+                |x| x,
+                nan_propagating_max,
+                f64::neg_infinity(),
+                "reduce_max",
+            )?))
+        }
         view => Err(crate::Error::backend_failure(
             "reduce_max",
             format!("unsupported dtype {:?}", view.dtype()),
@@ -288,22 +327,28 @@ pub(crate) fn reduce_min_read(input: TensorRead<'_>, axes: &[usize]) -> crate::R
             ensure_host_tensor("reduce_min", input)?;
             reduce_min(input, axes)
         }
-        TensorRead::View(TensorView::F32(t)) => Ok(Tensor::F32(typed_reduce_view(
-            &t,
-            axes,
-            |x| x,
-            |a, b| a.min(b),
-            f32::infinity(),
-            "reduce_min",
-        )?)),
-        TensorRead::View(TensorView::F64(t)) => Ok(Tensor::F64(typed_reduce_view(
-            &t,
-            axes,
-            |x| x,
-            |a, b| a.min(b),
-            f64::infinity(),
-            "reduce_min",
-        )?)),
+        TensorRead::View(TensorView::F32(t)) => {
+            validate_reduced_axes_nonempty("reduce_min", t.shape(), axes)?;
+            Ok(Tensor::F32(typed_reduce_view(
+                &t,
+                axes,
+                |x| x,
+                nan_propagating_min,
+                f32::infinity(),
+                "reduce_min",
+            )?))
+        }
+        TensorRead::View(TensorView::F64(t)) => {
+            validate_reduced_axes_nonempty("reduce_min", t.shape(), axes)?;
+            Ok(Tensor::F64(typed_reduce_view(
+                &t,
+                axes,
+                |x| x,
+                nan_propagating_min,
+                f64::infinity(),
+                "reduce_min",
+            )?))
+        }
         view => Err(crate::Error::backend_failure(
             "reduce_min",
             format!("unsupported dtype {:?}", view.dtype()),
@@ -440,11 +485,12 @@ pub fn typed_reduce_max<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Res
 where
     T: Float + Send + Sync,
 {
+    validate_reduced_axes_nonempty("reduce_max", input.shape(), axes)?;
     typed_reduce(
         input,
         axes,
         |x| x,
-        |a, b| a.max(b),
+        nan_propagating_max,
         T::neg_infinity(),
         "reduce_max",
     )
@@ -454,11 +500,12 @@ pub fn typed_reduce_min<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Res
 where
     T: Float + Send + Sync,
 {
+    validate_reduced_axes_nonempty("reduce_min", input.shape(), axes)?;
     typed_reduce(
         input,
         axes,
         |x| x,
-        |a, b| a.min(b),
+        nan_propagating_min,
         T::infinity(),
         "reduce_min",
     )

--- a/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
@@ -566,6 +566,87 @@ fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
 }
 
 #[test]
+fn equal_bool_add_and_mul_report_unsupported_dtype_not_mismatch() {
+    let lhs = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, false]).unwrap());
+    let rhs = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, true]).unwrap());
+
+    assert!(matches!(
+        add(&lhs, &rhs),
+        Err(crate::Error::BackendFailure {
+            op: "add",
+            message,
+        }) if message == "unsupported dtype Bool"
+    ));
+    assert!(matches!(
+        mul(&lhs, &rhs),
+        Err(crate::Error::BackendFailure {
+            op: "mul",
+            message,
+        }) if message == "unsupported dtype Bool"
+    ));
+}
+
+#[test]
+fn maximum_and_minimum_propagate_nan_independent_of_argument_order() {
+    let nan_lhs =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![f64::NAN, 1.0]).unwrap());
+    let nan_rhs =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, f64::NAN]).unwrap());
+
+    let max_lr = maximum(&nan_lhs, &nan_rhs).unwrap();
+    let max_rl = maximum(&nan_rhs, &nan_lhs).unwrap();
+    let min_lr = minimum(&nan_lhs, &nan_rhs).unwrap();
+    let min_rl = minimum(&nan_rhs, &nan_lhs).unwrap();
+
+    for tensor in [&max_lr, &max_rl, &min_lr, &min_rl] {
+        let data = tensor.as_slice::<f64>().unwrap();
+        assert!(data[0].is_nan(), "expected NaN at index 0, got {:?}", data);
+        assert!(data[1].is_nan(), "expected NaN at index 1, got {:?}", data);
+    }
+}
+
+#[test]
+fn reduce_max_and_min_propagate_nan_instead_of_leaking_sentinel() {
+    let mixed =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![3], vec![f64::NAN, 1.0, 2.0]).unwrap());
+    let all_nan =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![f64::NAN, f64::NAN]).unwrap());
+
+    assert!(reduce_max(&mixed, &[0]).unwrap().as_slice::<f64>().unwrap()[0].is_nan());
+    assert!(reduce_min(&mixed, &[0]).unwrap().as_slice::<f64>().unwrap()[0].is_nan());
+    assert!(reduce_max(&all_nan, &[0])
+        .unwrap()
+        .as_slice::<f64>()
+        .unwrap()[0]
+        .is_nan());
+    assert!(reduce_min(&all_nan, &[0])
+        .unwrap()
+        .as_slice::<f64>()
+        .unwrap()[0]
+        .is_nan());
+}
+
+#[test]
+fn reduce_max_and_min_reject_zero_length_reduced_axis() {
+    let empty = Tensor::F64(TypedTensor::from_vec_col_major(vec![0], Vec::<f64>::new()).unwrap());
+
+    assert!(matches!(
+        reduce_max(&empty, &[0]),
+        Err(crate::Error::InvalidConfig {
+            op: "reduce_max",
+            ..
+        })
+    ));
+    assert!(matches!(
+        reduce_min(&empty, &[0]),
+        Err(crate::Error::InvalidConfig {
+            op: "reduce_min",
+            ..
+        })
+    ));
+}
+
+#[test]
 fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
     let lhs_f64 =
         Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.5f64, -3.0]).unwrap());

--- a/crates/tenferro-einsum/src/syntax/notation.rs
+++ b/crates/tenferro-einsum/src/syntax/notation.rs
@@ -24,6 +24,17 @@ pub(crate) fn char_to_label(c: char) -> Result<u32> {
 ///
 /// Returns `(lhs, rhs)` where `lhs` is the input side and `rhs` is the output side.
 pub(crate) fn split_and_validate_notation(notation: &str) -> Result<(&str, &str)> {
+    if notation.contains("...") {
+        return Err(Error::InvalidArgument(
+            "einsum ellipsis '...' is not supported yet".into(),
+        ));
+    }
+    if notation.contains('.') {
+        return Err(Error::InvalidArgument(
+            "einsum label '.' is reserved for ellipsis, which is not supported yet".into(),
+        ));
+    }
+
     let parts: Vec<&str> = notation.split("->").collect();
     if parts.len() != 2 {
         return Err(Error::InvalidArgument(format!(

--- a/crates/tenferro-einsum/src/syntax/subscripts/tests.rs
+++ b/crates/tenferro-einsum/src/syntax/subscripts/tests.rs
@@ -12,3 +12,15 @@ fn parse_rejects_parenthesized_order_without_discarding_it() {
                 && message.contains("NestedEinsum::parse")
     ));
 }
+
+#[test]
+fn parse_rejects_ellipsis_with_specific_error() {
+    let err = Subscripts::parse("...ij,...jk->...ik").unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::InvalidArgument(message)
+            if message.contains("ellipsis")
+                && message.contains("not supported")
+    ));
+}

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -669,6 +669,7 @@ fn apply_unary_fft(
 ) -> Result<TracedTensor> {
     validate_n(op_name, n)?;
     let axis = normalize_axis(op_name, axis, input.rank)?;
+    validate_resolved_transform_len(op_name, input, n, axis)?;
     let op = Arc::new(FftOp::new(kind, axis, n, norm));
     let mut outputs = apply(op, &[input])?;
     outputs
@@ -693,6 +694,28 @@ fn normalize_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
 
 fn validate_n(op: &'static str, n: Option<usize>) -> Result<()> {
     if n == Some(0) {
+        return Err(fft_config_error(
+            op,
+            "tenferro-fft transform length n must be positive",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_resolved_transform_len(
+    op: &'static str,
+    input: &TracedTensor,
+    n: Option<usize>,
+    axis: usize,
+) -> Result<()> {
+    if n.is_some() {
+        return Ok(());
+    }
+    if input
+        .try_concrete_shape()
+        .and_then(|shape| shape.get(axis).copied())
+        == Some(0)
+    {
         return Err(fft_config_error(
             op,
             "tenferro-fft transform length n must be positive",

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -358,6 +358,16 @@ fn traced_fft_rejects_invalid_dtype_axis_and_length() {
     };
     assert!(err.to_string().contains("positive"), "{err}");
 
+    let zero_axis = TracedTensor::from_tensor_concrete_shape(Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![0], Vec::<f64>::new()).unwrap(),
+    ))
+    .unwrap();
+    let err = match zero_axis.rfft(None, -1, FftNorm::Backward) {
+        Ok(_) => panic!("expected rfft to reject zero-length input axis"),
+        Err(err) => err,
+    };
+    assert!(err.to_string().contains("positive"), "{err}");
+
     let err = match x.rfft(None, 3, FftNorm::Backward) {
         Ok(_) => panic!("expected rfft to reject out-of-bounds axis"),
         Err(err) => err,

--- a/crates/tenferro-gpu/src/webgpu/gemm.rs
+++ b/crates/tenferro-gpu/src/webgpu/gemm.rs
@@ -73,7 +73,7 @@ fn free_axes(rank: usize, contracting: &[usize], batch: &[usize]) -> AxisVec {
 }
 
 fn dense_strides(shape: &[usize]) -> crate::Result<Vec<usize>> {
-    col_major_strides(shape)
+    col_major_strides(shape)?
         .into_iter()
         .map(|stride| {
             usize::try_from(stride).map_err(|_| {

--- a/crates/tenferro-gpu/src/webgpu/memory.rs
+++ b/crates/tenferro-gpu/src/webgpu/memory.rs
@@ -83,7 +83,7 @@ pub(super) fn upload_typed<T: CubeElement + Clone + Send + Sync + 'static>(
         typed.shape().to_vec(),
         Buffer::Backend(Arc::new(WebGpuBuffer::new(handle, host_data.len()))),
         webgpu_placement(device_ordinal),
-    ))
+    )?)
 }
 
 pub(super) fn download_typed<T: CubeElement + Clone + 'static>(
@@ -106,7 +106,7 @@ pub(super) fn download_typed<T: CubeElement + Clone + 'static>(
         return Ok(TypedTensor::from_vec_col_major(
             typed.shape().to_vec(),
             Vec::new(),
-        ));
+        )?);
     }
 
     let bytes = client
@@ -116,7 +116,7 @@ pub(super) fn download_typed<T: CubeElement + Clone + 'static>(
     Ok(TypedTensor::from_vec_col_major(
         typed.shape().to_vec(),
         data,
-    ))
+    )?)
 }
 
 fn upload_bool(
@@ -143,7 +143,7 @@ fn upload_bool(
         typed.shape().to_vec(),
         Buffer::Backend(Arc::new(WebGpuBuffer::new(handle, host_data.len()))),
         webgpu_placement(device_ordinal),
-    ))
+    )?)
 }
 
 fn download_bool(
@@ -166,7 +166,7 @@ fn download_bool(
         return Ok(TypedTensor::from_vec_col_major(
             typed.shape().to_vec(),
             Vec::new(),
-        ));
+        )?);
     }
 
     let bytes = client
@@ -176,5 +176,5 @@ fn download_bool(
     Ok(TypedTensor::from_vec_col_major(
         typed.shape().to_vec(),
         data,
-    ))
+    )?)
 }

--- a/crates/tenferro-gpu/src/webgpu/mod.rs
+++ b/crates/tenferro-gpu/src/webgpu/mod.rs
@@ -268,12 +268,12 @@ fn typed_from_webgpu<T: Send + Sync + 'static>(
     shape: Vec<usize>,
     buffer: WebGpuBuffer<T>,
     device_ordinal: usize,
-) -> TypedTensor<T> {
-    TypedTensor::from_buffer_col_major(
+) -> crate::Result<TypedTensor<T>> {
+    Ok(TypedTensor::from_buffer_col_major(
         shape,
         Buffer::Backend(Arc::new(buffer)),
         webgpu_placement(device_ordinal),
-    )
+    )?)
 }
 
 fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
@@ -289,11 +289,11 @@ fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
         )
     })?;
     let handle = rt.client().empty(bytes);
-    Ok(typed_from_webgpu(
+    typed_from_webgpu(
         shape.to_vec(),
         WebGpuBuffer::new(handle, len),
         rt.device_ordinal(),
-    ))
+    )
 }
 
 fn webgpu_placement(device_ordinal: usize) -> Placement {

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -32,9 +32,27 @@ tenferro-runtime = { path = "/path/to/tenferro-rs/crates/tenferro-runtime" }
 tenferro-cpu = { path = "/path/to/tenferro-rs/crates/tenferro-cpu" }
 ```
 
+If you create a scratch binary crate inside the `tenferro-rs` checkout, add an
+empty `[workspace]` table to that scratch crate's `Cargo.toml`. Otherwise Cargo
+will treat it as an unlisted member of the parent workspace and report a
+workspace-membership error.
+
+For a scratch crate directly under the checkout root, relative paths are less
+error-prone:
+
+```toml
+[workspace]
+
+[dependencies]
+tenferro-runtime = { path = "../crates/tenferro-runtime" }
+tenferro-cpu = { path = "../crates/tenferro-cpu" }
+```
+
 The first build still needs network access unless dependencies are already
 vendored or cached. The workspace pins git dependencies and uses crates.io
 packages even when the tenferro crates themselves are local path dependencies.
+The default `cpu-faer` provider may take several minutes to compile the first
+time on a fresh machine; later incremental builds are much faster.
 
 With default features, this compiles the `cpu-faer` provider, so
 `CpuBackend::new()` uses faer. To use the LAPACK/BLAS CPU provider, enable
@@ -121,7 +139,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 <!-- end-snippet-source -->
 
 Expected output: the program exits silently because the shape and value
-assertions pass.
+assertions pass. The `from_vec_col_major` buffer is column-major: the leftmost
+axis varies fastest in memory.
 
 ## Next Steps
 

--- a/docs/guides/autodiff.md
+++ b/docs/guides/autodiff.md
@@ -11,7 +11,22 @@ explicitly. For eager forward execution and scalar loss accumulation semantics, 
 
 ## Setup
 
+For a published build, depend on the AD, runtime, and backend crates:
+
 ```toml
+[dependencies]
+tenferro-ad = "..."
+tenferro-runtime = "..."
+tenferro-cpu = "..."
+```
+
+When working from a local checkout, use paths that match your project layout.
+For a scratch crate created directly inside the `tenferro-rs` checkout, include
+an empty `[workspace]` table:
+
+```toml
+[workspace]
+
 [dependencies]
 tenferro-ad = { path = "../crates/tenferro-ad" }
 tenferro-runtime = { path = "../crates/tenferro-runtime" }
@@ -23,6 +38,10 @@ Extension AD examples also need that extension crate's AD feature. For linalg:
 ```toml
 tenferro-linalg = { path = "../crates/tenferro-linalg", features = ["autodiff"] }
 ```
+
+In code that uses extension operations during traced execution, also register
+the extension runtime on the `GraphExecutor` and add the extension rule set to
+`AdContext` when differentiating through that operation family.
 
 - `grad` for reverse mode on scalar losses
 - `vjp` for vector-Jacobian products

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -134,6 +134,62 @@ For XLA/PJRT GPU verification, add the PJRT plugin path separately:
 export TENFERRO_PJRT_GPU_PLUGIN=/path/to/pjrt_c_api_gpu_plugin.so
 ```
 
+## WebGPU Quickstart
+
+WebGPU is experimental and currently useful for explicit transfer plus
+`F32`/`C32` `dot_general` and einsum paths. For a WebGPU-only binary, disable
+default features on `tenferro-gpu` unless the same crate also needs the default
+CPU provider stack:
+
+```toml
+[dependencies]
+tenferro-gpu = { version = "...", default-features = false, features = ["webgpu"] }
+tenferro-tensor = "..."
+```
+
+For a local scratch crate inside the checkout, use matching path dependencies
+and add an empty `[workspace]` table as described in
+[Getting Started](../getting-started/index.md).
+
+```rust
+use tenferro_gpu::{
+    download_webgpu_tensor, upload_webgpu_tensor, webgpu_available, WebGpuBackend,
+};
+use tenferro_tensor::{DotGeneralConfig, Tensor, TensorDot};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if !webgpu_available() {
+        return Ok(());
+    }
+
+    let mut backend = WebGpuBackend::new_default()?;
+    let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0])?;
+    let rhs = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0])?;
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+
+    let gpu_lhs = upload_webgpu_tensor(backend.runtime(), &lhs)?;
+    let gpu_rhs = upload_webgpu_tensor(backend.runtime(), &rhs)?;
+    let gpu_out = backend.dot_general(&gpu_lhs, &gpu_rhs, &config)?;
+    let out = download_webgpu_tensor(backend.runtime(), &gpu_out)?;
+
+    assert_eq!(out.shape(), &[2, 2]);
+    assert_eq!(out.as_slice::<f32>().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+    backend.runtime().synchronize()?;
+    Ok(())
+}
+```
+
+`DotGeneralConfig` uses StableHLO-style dimension-number fields:
+`lhs_contracting_dims`, `rhs_contracting_dims`, `lhs_batch_dims`, and
+`rhs_batch_dims`. Direct backend code can use the lower-level
+`backend.runtime().synchronize()` barrier; eager code can use
+`EagerRuntime::synchronize()`.
+
 ## CUDA Across Tensor Layers
 
 | Tensor model | How CUDA fits |

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -9,6 +9,8 @@ gradient accumulation and `backward()`.
 
 ## Setup
 
+For a published build, depend on the crates you use:
+
 ```toml
 [dependencies]
 tenferro-runtime = "..."
@@ -20,7 +22,24 @@ tenferro-einsum = { version = "...", features = ["autodiff"] }
 ```
 
 When working from a local checkout, replace the versions with `path = "..."`
-entries that match your project layout.
+entries that match your project layout. For a scratch crate created directly
+inside the `tenferro-rs` checkout, include an empty `[workspace]` table so Cargo
+does not try to enroll the scratch crate in the parent workspace:
+
+```toml
+[workspace]
+
+[dependencies]
+tenferro-runtime = { path = "../crates/tenferro-runtime" }
+tenferro-cpu = { path = "../crates/tenferro-cpu" }
+tenferro-tensor = { path = "../crates/tenferro-tensor" }
+tenferro-ad = { path = "../crates/tenferro-ad" }
+tenferro-linalg = { path = "../crates/tenferro-linalg" }
+tenferro-einsum = { path = "../crates/tenferro-einsum", features = ["autodiff"] }
+```
+
+The first local build can spend several minutes compiling the default
+`cpu-faer` stack. That is expected on a fresh machine.
 
 Most direct tensor examples start by importing the CPU backend and concrete
 tensor types:
@@ -183,6 +202,9 @@ assert_eq!(flat.shape(), &[6]);
 let col_sum = a.reduce_sum(&[0], &mut backend).unwrap();
 assert_eq!(col_sum.shape(), &[3]);
 ```
+
+The `reduce_sum(&[0])` call removes axis `0`. For this `[2, 3]` tensor, that
+means summing down each column and keeping one value per column.
 
 ## Einsum
 

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -7,6 +7,17 @@ construction uses `GraphCompilerEinsumExt`; eager execution uses
 Compiled execution also requires explicit runtime registration for einsum
 extension ops.
 
+When working from a local checkout, use paths that match your project layout.
+For a scratch crate created directly inside the `tenferro-rs` checkout, include
+an empty `[workspace]` table so Cargo does not try to enroll it in the parent
+workspace:
+
+```toml
+[workspace]
+```
+
+Then add the dependencies:
+
 ```toml
 [dependencies]
 tenferro-runtime = { path = "../crates/tenferro-runtime" }
@@ -15,7 +26,19 @@ tenferro-ad = { path = "../crates/tenferro-ad" }
 tenferro-einsum = { path = "../crates/tenferro-einsum", features = ["autodiff"] }
 ```
 
-Graph-only users can omit `tenferro-ad` and the `autodiff` feature.
+For published crates, use the same crate set with version requirements:
+
+```toml
+[dependencies]
+tenferro-runtime = "..."
+tenferro-cpu = "..."
+tenferro-ad = "..."
+tenferro-einsum = { version = "...", features = ["autodiff"] }
+```
+
+Graph-only users can omit `tenferro-ad` and the `autodiff` feature. The traced
+examples below are fragments; copy them into `fn main() -> Result<(), Box<dyn
+std::error::Error>>` when turning them into a standalone `src/main.rs`.
 
 ## Traced Matrix Multiply
 

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -8,6 +8,16 @@ compile/run workflow.
 
 ## Setup
 
+When working from a local checkout, use paths that match your project layout.
+For a scratch crate created directly inside the `tenferro-rs` checkout, include
+an empty `[workspace]` table:
+
+```toml
+[workspace]
+```
+
+Then add the dependencies:
+
 ```toml
 [dependencies]
 tenferro-runtime = { path = "../crates/tenferro-runtime" }
@@ -16,8 +26,20 @@ tenferro-ad = { path = "../crates/tenferro-ad" }
 tenferro-linalg = { path = "../crates/tenferro-linalg", features = ["autodiff"] }
 ```
 
+For published crates, use the same crate set with version requirements:
+
+```toml
+[dependencies]
+tenferro-runtime = "..."
+tenferro-cpu = "..."
+tenferro-ad = "..."
+tenferro-linalg = { version = "...", features = ["autodiff"] }
+```
+
 Concrete graph/runtime users can omit `tenferro-ad` and the `autodiff` feature
 when they do not need eager linalg helpers or linalg AD rules.
+The examples below are Rust fragments; copy them into `fn main() -> Result<(),
+Box<dyn std::error::Error>>` for a standalone binary.
 
 ## Layer Coverage
 

--- a/docs/guides/tenferro-fft.md
+++ b/docs/guides/tenferro-fft.md
@@ -11,6 +11,16 @@ extension machinery directly.
 
 ## Setup
 
+When working from a local checkout, use paths that match your project layout.
+For a scratch crate created directly inside the `tenferro-rs` checkout, include
+an empty `[workspace]` table:
+
+```toml
+[workspace]
+```
+
+Then add the dependencies:
+
 ```toml
 [dependencies]
 num-complex = "0.4"
@@ -20,7 +30,22 @@ tenferro-ad = { path = "../crates/tenferro-ad" }
 tenferro-fft = { path = "../crates/tenferro-fft", features = ["autodiff"] }
 ```
 
-Graph-only users can omit `tenferro-ad` and the `autodiff` feature.
+For published crates, use the same crate set with version requirements:
+
+```toml
+[dependencies]
+num-complex = "0.4"
+tenferro-runtime = "..."
+tenferro-cpu = "..."
+tenferro-ad = "..."
+tenferro-fft = { version = "...", features = ["autodiff"] }
+```
+
+Graph-only users can omit `tenferro-ad` and the `autodiff` feature. The
+`traced_tensor` module path in rustdoc contains the traced-graph FFT helpers
+implemented by `TracedTensorFftExt`. `rustfft` is pulled in automatically by
+`tenferro-fft`, and the first local build can take a few minutes on a fresh
+machine.
 
 ## Current API
 

--- a/docs/worklogs/2026-06-20-terasaki-nan-doc-batch.md
+++ b/docs/worklogs/2026-06-20-terasaki-nan-doc-batch.md
@@ -1,0 +1,73 @@
+# Terasaki NaN And Docs Batch
+
+## Summary
+
+Fixed a bounded follow-up batch of open `terasakisatoshi` reports:
+
+- #1129: empty eager concatenate now reports a typed tensor validation error
+  instead of `Error::Internal`.
+- #1130: same-dtype unsupported CPU `Bool` arithmetic reports unsupported dtype
+  instead of a self-contradictory dtype mismatch.
+- #1131: einsum ellipsis is rejected at parse validation with a specific
+  unsupported-ellipsis error instead of being treated as literal labels.
+- #1132: traced FFT rejects a concrete zero-length implicit transform axis at
+  API validation time.
+- #1133 and #1134: CPU maximum/minimum and reduce_max/reduce_min propagate NaN
+  in the same order-independent style expected by JAX/PyTorch users; zero-length
+  reduced axes return typed validation errors instead of sentinel values.
+- #1054 and #1115: first-user docs now cover local checkout setup, scratch
+  workspace isolation, dependency snippets, column-major and reduction-axis
+  notes, extension runtime setup context, README discoverability, and the
+  missing WebGPU quickstart details.
+- The WebGPU backend now compiles under its `webgpu` feature after the
+  fallible `TypedTensor::from_*` constructor migration, which keeps the new
+  WebGPU guide example attached to a checked public surface.
+
+## Context Read
+
+- `AGENTS.md`, shared tensor4all rules, and `REPOSITORY_RULES.md`.
+- Open GitHub issues #1054, #1115, #1129, #1130, #1131, #1132, #1133, #1134.
+- Affected modules in `tenferro-ad`, `tenferro-cpu`, `tenferro-einsum`,
+  `tenferro-fft`, README, getting-started docs, eager/autodiff guides,
+  extension guides, and GPU docs.
+
+## Decisions
+
+- Kept #1131 small: this PR does not implement ellipsis semantics. It turns the
+  previous misleading parser behavior into a clear unsupported-feature error,
+  which matches the issue's short-term acceptance path.
+- Treated same-dtype unsupported CPU arithmetic as backend unsupported dtype,
+  while preserving `DTypeMismatch` for genuinely different dtypes.
+- Used explicit NaN propagation helpers for CPU max/min reductions rather than
+  relying on `Float::max`/`Float::min`, whose NaN behavior is not the numerical
+  API contract users expect from JAX/PyTorch-style tensor operations.
+- Rejected zero-length reduced axes for min/max because the old identity
+  sentinels (`+/-inf`) were observable user values, not valid reductions.
+- Documented local path examples as layout-dependent and added `[workspace]`
+  only to scratch-crate examples inside the repository checkout.
+- Added WebGPU documentation as experimental direct-backend usage, not as a
+  promise of broad GPU operation coverage.
+- Kept the WebGPU code fix limited to feature-compilation follow-through:
+  propagate fallible tensor constructors and fix dense-stride `Result`
+  handling without changing kernel semantics.
+
+## Verification
+
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-ad --test eager_tensor`
+- `cargo test -p tenferro-cpu --lib`
+- `cargo test -p tenferro-einsum --lib`
+- `cargo test -p tenferro-fft --test fft_ops`
+- `cargo check -p tenferro-gpu --no-default-features --features webgpu`
+- `cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_backend_contract`
+- `cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_matmul_runtime`
+- `python3 scripts/check-guide-dependency-snippets.py`
+- `python3 scripts/check-doc-snippets.py`
+- `python3 scripts/check-docs-site.py`
+- `cargo doc --workspace --no-deps`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `git diff --check`


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] Documentation
- [ ] Refactor / cleanup
- [x] Implementation of accepted issue

## Related issue

Fixes #1054
Fixes #1115
Fixes #1129
Fixes #1130
Fixes #1131
Fixes #1132
Fixes #1133
Fixes #1134

## Summary

This PR closes the remaining open `terasakisatoshi` batch that is safe to handle locally in one PR:

- returns typed validation errors for empty eager concatenate and zero-length implicit FFT transforms
- rejects einsum ellipsis with a specific unsupported-feature error instead of misparsing `.` labels
- reports same-dtype unsupported CPU Bool arithmetic as unsupported dtype, while preserving real dtype mismatches
- aligns CPU `maximum`/`minimum` and `reduce_max`/`reduce_min` NaN behavior with JAX/PyTorch expectations, including order-independent NaN propagation and zero-length-axis validation
- restores WebGPU feature compilation after fallible tensor constructor migration
- fills first-user docs gaps across README, getting-started, eager/autodiff, extension guides, and the WebGPU guide

## Work log

See `docs/worklogs/2026-06-20-terasaki-nan-doc-batch.md`.

## Validation

- `cargo fmt --all --check`
- `cargo test -p tenferro-ad --test eager_tensor`
- `cargo test -p tenferro-cpu --lib`
- `cargo test -p tenferro-einsum --lib`
- `cargo test -p tenferro-fft --test fft_ops`
- `cargo check -p tenferro-gpu --no-default-features --features webgpu`
- `cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_backend_contract`
- `cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer --test webgpu_matmul_runtime`
- `python3 scripts/check-guide-dependency-snippets.py`
- `python3 scripts/check-doc-snippets.py`
- `python3 scripts/check-docs-site.py`
- `cargo doc --workspace --no-deps`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json` (`Verdict: pass`)
- `git diff --check`

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
