### PR TITLE
Fix public panic risks in reductions and extension metadata

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -103,6 +103,12 @@ rules from `tensor4all-agent-rules`.
   computing output ranks or indexing shape arrays. Symbolic-shape traced values
   must not be forced through concrete-shape helpers unless the API explicitly
   returns a symbolic-shape error.
+- Repeated public-boundary input validation must live in shared helpers or
+  fallible metadata/validation functions when sibling operation surfaces need
+  the same rank, axis, dtype, shape, padding, or linalg checks. Do not duplicate
+  hand-written checks across owned/read, eager/traced, CPU/GPU, or extension
+  paths when a helper can enforce validation before fast paths and reduce public
+  panic risk.
 - Parallel operation surfaces must keep validation and promotion semantics in
   parity across owned/read, eager/traced, CPU/GPU, and extension wrapper paths.
   A bug in one surface should trigger an audit of the corresponding surfaces

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -255,8 +255,8 @@ impl ExtensionOp for ReadPathFallbackProbe {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-ad/src/eager_exec/tests.rs
+++ b/crates/tenferro-ad/src/eager_exec/tests.rs
@@ -329,8 +329,8 @@ impl ExtensionOp for TestExtension {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -347,7 +347,7 @@ impl TracedTensorAdExt for TracedTensor {
             let program = compiler.compile(self)?;
             Arc::new(executor.run(&program)?)
         };
-        checkpoint_tensor(self, data);
+        checkpoint_tensor(self, data)?;
         Ok(())
     }
 

--- a/crates/tenferro-ad/tests/extension_op.rs
+++ b/crates/tenferro-ad/tests/extension_op.rs
@@ -79,8 +79,8 @@ impl ExtensionOp for TestScaleBy2 {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -213,17 +213,17 @@ impl ExtensionOp for TestSwap {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         // (a, b) -> (b, a). We report the swapped meta so downstream
         // consumers see the correct shape for each output slot.
         assert_eq!(
             input_dtypes[0], input_dtypes[1],
             "TestSwap expects matching dtypes"
         );
-        vec![
+        Ok(vec![
             (input_dtypes[1], input_shapes[1].to_vec()),
             (input_dtypes[0], input_shapes[0].to_vec()),
-        ]
+        ])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -315,8 +315,8 @@ impl ExtensionOp for TestNoAd {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -367,8 +367,8 @@ impl ExtensionOp for TestProbeIdentity {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -414,8 +414,8 @@ impl ExtensionOp for TestProbeLinear {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -564,8 +564,8 @@ impl ExtensionOp for TestBadOutputCount {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-ad/tests/graph_compile.rs
+++ b/crates/tenferro-ad/tests/graph_compile.rs
@@ -53,8 +53,8 @@ impl ExtensionOp for ConstantDebugExtension {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-ad/tests/numpy_api.rs
+++ b/crates/tenferro-ad/tests/numpy_api.rs
@@ -44,8 +44,8 @@ impl ExtensionOp for TestExtensionOp {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -80,16 +80,16 @@ enum GemmAnalysisCacheKind {
 }
 
 impl GemmAnalysisPlan {
-    fn matches<L, R, T>(&self, lhs: &L, rhs: &R, config: &DotGeneralConfig) -> bool
+    fn matches<L, R, T>(&self, lhs: &L, rhs: &R, config: &DotGeneralConfig) -> crate::Result<bool>
     where
         L: TypedTensorRead<T>,
         R: TypedTensorRead<T>,
     {
-        self.lhs_shape.as_slice() == lhs.shape()
+        Ok(self.lhs_shape.as_slice() == lhs.shape()
             && self.rhs_shape.as_slice() == rhs.shape()
-            && self.lhs_strides.as_slice() == lhs.strides().as_slice()
-            && self.rhs_strides.as_slice() == rhs.strides().as_slice()
-            && self.config.matches(config)
+            && self.lhs_strides.as_slice() == lhs.strides()?.as_slice()
+            && self.rhs_strides.as_slice() == rhs.strides()?.as_slice()
+            && self.config.matches(config))
     }
 }
 
@@ -113,9 +113,9 @@ impl GemmConfigKey {
 
 trait TypedTensorRead<T> {
     fn shape(&self) -> &[usize];
-    fn strides(&self) -> SmallVec<[isize; 8]>;
+    fn strides(&self) -> crate::Result<SmallVec<[isize; 8]>>;
     fn offset(&self) -> isize;
-    fn host_data_opt(&self) -> Option<&[T]>;
+    fn host_data_opt(&self) -> crate::Result<Option<&[T]>>;
 }
 
 impl<T: Clone> TypedTensorRead<T> for TypedTensor<T> {
@@ -123,23 +123,19 @@ impl<T: Clone> TypedTensorRead<T> for TypedTensor<T> {
         self.layout().shape()
     }
 
-    fn strides(&self) -> SmallVec<[isize; 8]> {
-        // Invariant: owned tensors validate compact shape products at construction.
-        col_major_strides(self.shape())
-            .expect("owned tensor shape has valid column-major strides")
-            .into_iter()
-            .collect()
+    fn strides(&self) -> crate::Result<SmallVec<[isize; 8]>> {
+        Ok(col_major_strides(self.shape())?.into_iter().collect())
     }
 
     fn offset(&self) -> isize {
         0
     }
 
-    fn host_data_opt(&self) -> Option<&[T]> {
-        match self.buffer() {
+    fn host_data_opt(&self) -> crate::Result<Option<&[T]>> {
+        Ok(match self.buffer() {
             Buffer::Host(v) => Some(v.as_slice()),
             Buffer::Backend(_) => None,
-        }
+        })
     }
 }
 
@@ -148,23 +144,19 @@ impl<T: 'static> TypedTensorRead<T> for TypedTensorView<'_, T> {
         self.shape()
     }
 
-    fn strides(&self) -> SmallVec<[isize; 8]> {
-        self.strides().iter().copied().collect()
+    fn strides(&self) -> crate::Result<SmallVec<[isize; 8]>> {
+        Ok(self.strides().iter().copied().collect())
     }
 
     fn offset(&self) -> isize {
         self.offset()
     }
 
-    fn host_data_opt(&self) -> Option<&[T]> {
+    fn host_data_opt(&self) -> crate::Result<Option<&[T]>> {
         if self.backend_buffer().is_some() {
-            None
+            Ok(None)
         } else {
-            // Invariant: host tensor views validate their physical slice range at construction.
-            Some(
-                self.host_storage()
-                    .expect("host tensor view has a valid physical slice"),
-            )
+            Ok(Some(self.host_storage()?))
         }
     }
 }
@@ -174,7 +166,7 @@ impl<T: Clone> TypedTensorRead<T> for std::borrow::Cow<'_, TypedTensor<T>> {
         self.as_ref().shape()
     }
 
-    fn strides(&self) -> SmallVec<[isize; 8]> {
+    fn strides(&self) -> crate::Result<SmallVec<[isize; 8]>> {
         self.as_ref().strides()
     }
 
@@ -182,7 +174,7 @@ impl<T: Clone> TypedTensorRead<T> for std::borrow::Cow<'_, TypedTensor<T>> {
         self.as_ref().offset()
     }
 
-    fn host_data_opt(&self) -> Option<&[T]> {
+    fn host_data_opt(&self) -> crate::Result<Option<&[T]>> {
         self.as_ref().host_data_opt()
     }
 }
@@ -244,16 +236,19 @@ impl GemmAnalysisCache {
         lhs: &L,
         rhs: &R,
         config: &DotGeneralConfig,
-    ) -> Option<Option<GemmDims>>
+    ) -> crate::Result<Option<Option<GemmDims>>>
     where
         L: TypedTensorRead<T>,
         R: TypedTensorRead<T>,
     {
-        self.slots
-            .get(slot)
-            .and_then(|entry| entry.get(kind))
-            .filter(|plan| plan.matches(lhs, rhs, config))
-            .map(|plan| plan.dims.clone())
+        let Some(entry) = self.slots.get(slot).and_then(|entry| entry.get(kind)) else {
+            return Ok(None);
+        };
+        if entry.matches(lhs, rhs, config)? {
+            Ok(Some(entry.dims.clone()))
+        } else {
+            Ok(None)
+        }
     }
 
     // Cache entries mirror the full analyzed GEMM key to avoid rebuilding a temporary key object.
@@ -567,7 +562,11 @@ fn is_identity_perm(perm: &[usize]) -> bool {
     perm.iter().enumerate().all(|(i, &p)| i == p)
 }
 
-fn analyse_gemm<L, R, T>(lhs: &L, rhs: &R, config: &DotGeneralConfig) -> Option<GemmDims>
+fn analyse_gemm<L, R, T>(
+    lhs: &L,
+    rhs: &R,
+    config: &DotGeneralConfig,
+) -> crate::Result<Option<GemmDims>>
 where
     L: TypedTensorRead<T>,
     R: TypedTensorRead<T>,
@@ -584,15 +583,17 @@ where
         .filter(|d| !config.rhs_contracting_dims.contains(d) && !config.rhs_batch_dims.contains(d))
         .collect();
 
-    let lhs_strides = lhs.strides();
-    let rhs_strides = rhs.strides();
+    let lhs_strides = lhs.strides()?;
+    let rhs_strides = rhs.strides()?;
 
     let batch_shapes: SmallVec<[usize; 8]> = config
         .lhs_batch_dims
         .iter()
         .map(|&d| lhs_shape[d])
         .collect();
-    let batch_total = checked_product(&batch_shapes)?;
+    let Some(batch_total) = checked_product(&batch_shapes) else {
+        return Ok(None);
+    };
 
     let lhs_free_shapes: SmallVec<[usize; 8]> = lhs_free.iter().map(|&d| lhs_shape[d]).collect();
     let rhs_free_shapes: SmallVec<[usize; 8]> = rhs_free.iter().map(|&d| rhs_shape[d]).collect();
@@ -602,9 +603,15 @@ where
         .map(|&d| lhs_shape[d])
         .collect();
 
-    let m = checked_product(&lhs_free_shapes)?;
-    let n = checked_product(&rhs_free_shapes)?;
-    let k = checked_product(&contract_shapes)?;
+    let Some(m) = checked_product(&lhs_free_shapes) else {
+        return Ok(None);
+    };
+    let Some(n) = checked_product(&rhs_free_shapes) else {
+        return Ok(None);
+    };
+    let Some(k) = checked_product(&contract_shapes) else {
+        return Ok(None);
+    };
 
     let lhs_free_strides: SmallVec<[isize; 8]> = lhs_free.iter().map(|&d| lhs_strides[d]).collect();
     let rhs_free_strides: SmallVec<[isize; 8]> = rhs_free.iter().map(|&d| rhs_strides[d]).collect();
@@ -635,23 +642,34 @@ where
         || !is_identity_order(&stride_sort_order(&rhs_batch_strides))
         || stride_sort_order(&lhs_contract_strides) != stride_sort_order(&rhs_contract_strides)
     {
-        return None;
+        return Ok(None);
     }
 
-    let (_, a_rs) = try_fuse_dims(&lhs_free_shapes, &lhs_free_strides)?;
-    let (_, a_cs) = try_fuse_dims(&contract_shapes, &lhs_contract_strides)?;
-    let (_, b_rs) = try_fuse_dims(&contract_shapes, &rhs_contract_strides)?;
-    let (_, b_cs) = try_fuse_dims(&rhs_free_shapes, &rhs_free_strides)?;
-    let (_, a_bs) = try_fuse_dims(&batch_shapes, &lhs_batch_strides)?;
-    let (_, b_bs) = try_fuse_dims(&batch_shapes, &rhs_batch_strides)?;
+    let Some((_, a_rs)) = try_fuse_dims(&lhs_free_shapes, &lhs_free_strides) else {
+        return Ok(None);
+    };
+    let Some((_, a_cs)) = try_fuse_dims(&contract_shapes, &lhs_contract_strides) else {
+        return Ok(None);
+    };
+    let Some((_, b_rs)) = try_fuse_dims(&contract_shapes, &rhs_contract_strides) else {
+        return Ok(None);
+    };
+    let Some((_, b_cs)) = try_fuse_dims(&rhs_free_shapes, &rhs_free_strides) else {
+        return Ok(None);
+    };
+    let Some((_, a_bs)) = try_fuse_dims(&batch_shapes, &lhs_batch_strides) else {
+        return Ok(None);
+    };
+    let Some((_, b_bs)) = try_fuse_dims(&batch_shapes, &rhs_batch_strides) else {
+        return Ok(None);
+    };
 
     let mut out_shape = SmallVec::<[usize; 8]>::new();
     out_shape.extend_from_slice(&lhs_free_shapes);
     out_shape.extend_from_slice(&rhs_free_shapes);
     out_shape.extend_from_slice(&batch_shapes);
 
-    let out_strides: SmallVec<[isize; 8]> =
-        col_major_strides(&out_shape).ok()?.into_iter().collect();
+    let out_strides: SmallVec<[isize; 8]> = col_major_strides(&out_shape)?.into_iter().collect();
     let nm = lhs_free_shapes.len();
     let nn = rhs_free_shapes.len();
     let out_m_shapes = &out_shape[..nm];
@@ -661,11 +679,17 @@ where
     let out_b_shapes = &out_shape[nm + nn..];
     let out_b_strides = &out_strides[nm + nn..];
 
-    let (_, c_rs) = try_fuse_dims(out_m_shapes, out_m_strides)?;
-    let (_, c_cs) = try_fuse_dims(out_n_shapes, out_n_strides)?;
-    let (_, c_bs) = try_fuse_dims(out_b_shapes, out_b_strides)?;
+    let Some((_, c_rs)) = try_fuse_dims(out_m_shapes, out_m_strides) else {
+        return Ok(None);
+    };
+    let Some((_, c_cs)) = try_fuse_dims(out_n_shapes, out_n_strides) else {
+        return Ok(None);
+    };
+    let Some((_, c_bs)) = try_fuse_dims(out_b_shapes, out_b_strides) else {
+        return Ok(None);
+    };
 
-    Some(GemmDims {
+    Ok(Some(GemmDims {
         m,
         n,
         k,
@@ -680,7 +704,7 @@ where
         c_cs,
         c_bs,
         out_shape,
-    })
+    }))
 }
 
 fn analyse_gemm_cached<L, R, T>(
@@ -697,21 +721,21 @@ where
 {
     let cache_slot = cache_slot.filter(|&slot| slot < cache.max_slots);
     if let Some(slot) = cache_slot {
-        if let Some(cached) = cache.cached_dims(slot, cache_kind, lhs, rhs, config) {
+        if let Some(cached) = cache.cached_dims(slot, cache_kind, lhs, rhs, config)? {
             return Ok(cached);
         }
     }
 
     validate_dot_general(lhs, rhs, config)?;
-    let dims = analyse_gemm(lhs, rhs, config);
+    let dims = analyse_gemm(lhs, rhs, config)?;
     if let Some(slot) = cache_slot {
         cache.store(
             slot,
             cache_kind,
             lhs.shape().iter().copied().collect(),
             rhs.shape().iter().copied().collect(),
-            lhs.strides(),
-            rhs.strides(),
+            lhs.strides()?,
+            rhs.strides()?,
             GemmConfigKey::from_config(config),
             dims.clone(),
         );
@@ -944,10 +968,10 @@ where
         )?));
     }
 
-    let Some(a_data) = lhs.host_data_opt().map(<[T]>::as_ptr) else {
+    let Some(a_data) = lhs.host_data_opt()?.map(<[T]>::as_ptr) else {
         return Ok(None);
     };
-    let Some(b_data) = rhs.host_data_opt().map(<[T]>::as_ptr) else {
+    let Some(b_data) = rhs.host_data_opt()?.map(<[T]>::as_ptr) else {
         return Ok(None);
     };
     let a_base = lhs.offset();
@@ -1286,10 +1310,10 @@ where
         return Ok(None);
     }
 
-    let Some(a_data) = lhs.host_data_opt().map(<[T]>::as_ptr) else {
+    let Some(a_data) = lhs.host_data_opt()?.map(<[T]>::as_ptr) else {
         return Ok(None);
     };
-    let Some(b_data) = rhs.host_data_opt().map(<[T]>::as_ptr) else {
+    let Some(b_data) = rhs.host_data_opt()?.map(<[T]>::as_ptr) else {
         return Ok(None);
     };
     let a_base = lhs.offset();
@@ -1382,10 +1406,10 @@ where
         return Ok(None);
     }
 
-    let Some(a_data) = lhs.host_data_opt().map(<[T]>::as_ptr) else {
+    let Some(a_data) = lhs.host_data_opt()?.map(<[T]>::as_ptr) else {
         return Ok(None);
     };
-    let Some(b_data) = rhs.host_data_opt().map(<[T]>::as_ptr) else {
+    let Some(b_data) = rhs.host_data_opt()?.map(<[T]>::as_ptr) else {
         return Ok(None);
     };
     let a_base = lhs.offset();

--- a/crates/tenferro-cpu/src/gemm/strided_dot.rs
+++ b/crates/tenferro-cpu/src/gemm/strided_dot.rs
@@ -41,13 +41,14 @@ where
     R: TypedTensorRead<T>,
     T: 'static,
 {
-    let Some(data) = read.host_data_opt() else {
+    let Some(data) = read.host_data_opt()? else {
         return Err(Error::backend_failure(
             "dot_general",
             "CPU dot_general requires host-backed inputs",
         ));
     };
-    strided_einsum2::StridedView::new(data, read.shape(), read.strides().as_slice(), read.offset())
+    let strides = read.strides()?;
+    strided_einsum2::StridedView::new(data, read.shape(), strides.as_slice(), read.offset())
         .map_err(map_strided_error)
 }
 

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -60,6 +60,34 @@ fn validate_reduced_axes_nonempty(
     Ok(())
 }
 
+fn reduction_empty_axes_noop(
+    op: &'static str,
+    input: &Tensor,
+    axes: &[usize],
+) -> crate::Result<Option<Tensor>> {
+    validate_axes(op, axes, input.shape().len())?;
+    Ok(axes.is_empty().then(|| input.clone()))
+}
+
+fn reduction_read_empty_axes_noop(
+    op: &'static str,
+    input: &TensorRead<'_>,
+    axes: &[usize],
+) -> crate::Result<Option<Tensor>> {
+    validate_axes(op, axes, input.shape().len())?;
+    if !axes.is_empty() {
+        return Ok(None);
+    }
+
+    match input.clone() {
+        TensorRead::Tensor(input) => {
+            ensure_host_tensor(op, input)?;
+            Ok(Some(input.clone()))
+        }
+        TensorRead::View(input) => Ok(Some(view_to_contiguous_tensor(input)?)),
+    }
+}
+
 fn nan_propagating_max<T: Float>(a: T, b: T) -> T {
     if a.is_nan() || b.is_nan() {
         T::nan()
@@ -77,6 +105,10 @@ fn nan_propagating_min<T: Float>(a: T, b: T) -> T {
 }
 
 pub fn reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+    if let Some(output) = reduction_empty_axes_noop("reduce_sum", input, axes)? {
+        return Ok(output);
+    }
+
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_sum(t, axes)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_sum(t, axes)?)),
@@ -92,6 +124,10 @@ pub fn reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
 }
 
 pub(crate) fn reduce_sum_read(input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
+    if let Some(output) = reduction_read_empty_axes_noop("reduce_sum", &input, axes)? {
+        return Ok(output);
+    }
+
     match input {
         TensorRead::Tensor(input) => {
             ensure_host_tensor("reduce_sum", input)?;
@@ -153,6 +189,10 @@ pub(crate) fn reduce_sum_read(input: TensorRead<'_>, axes: &[usize]) -> crate::R
 }
 
 pub fn reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+    if let Some(output) = reduction_empty_axes_noop("reduce_prod", input, axes)? {
+        return Ok(output);
+    }
+
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_prod(t, axes)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_prod(t, axes)?)),
@@ -168,6 +208,10 @@ pub fn reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
 }
 
 pub(crate) fn reduce_prod_read(input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
+    if let Some(output) = reduction_read_empty_axes_noop("reduce_prod", &input, axes)? {
+        return Ok(output);
+    }
+
     match input {
         TensorRead::Tensor(input) => {
             ensure_host_tensor("reduce_prod", input)?;
@@ -229,9 +273,8 @@ pub(crate) fn reduce_prod_read(input: TensorRead<'_>, axes: &[usize]) -> crate::
 }
 
 pub fn reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-    validate_axes("reduce_max", axes, input.shape().len())?;
-    if axes.is_empty() {
-        return Ok(input.clone());
+    if let Some(output) = reduction_empty_axes_noop("reduce_max", input, axes)? {
+        return Ok(output);
     }
 
     match input {
@@ -247,15 +290,8 @@ pub fn reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
 }
 
 pub(crate) fn reduce_max_read(input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-    validate_axes("reduce_max", axes, input.shape().len())?;
-    if axes.is_empty() {
-        return match input {
-            TensorRead::Tensor(input) => {
-                ensure_host_tensor("reduce_max", input)?;
-                Ok(input.clone())
-            }
-            TensorRead::View(input) => view_to_contiguous_tensor(input),
-        };
+    if let Some(output) = reduction_read_empty_axes_noop("reduce_max", &input, axes)? {
+        return Ok(output);
     }
 
     match input {
@@ -293,9 +329,8 @@ pub(crate) fn reduce_max_read(input: TensorRead<'_>, axes: &[usize]) -> crate::R
 }
 
 pub fn reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-    validate_axes("reduce_min", axes, input.shape().len())?;
-    if axes.is_empty() {
-        return Ok(input.clone());
+    if let Some(output) = reduction_empty_axes_noop("reduce_min", input, axes)? {
+        return Ok(output);
     }
 
     match input {
@@ -311,15 +346,8 @@ pub fn reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
 }
 
 pub(crate) fn reduce_min_read(input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-    validate_axes("reduce_min", axes, input.shape().len())?;
-    if axes.is_empty() {
-        return match input {
-            TensorRead::Tensor(input) => {
-                ensure_host_tensor("reduce_min", input)?;
-                Ok(input.clone())
-            }
-            TensorRead::View(input) => view_to_contiguous_tensor(input),
-        };
+    if let Some(output) = reduction_read_empty_axes_noop("reduce_min", &input, axes)? {
+        return Ok(output);
     }
 
     match input {
@@ -369,7 +397,7 @@ where
     M: Fn(T) -> T + Copy + Sync,
     R: Fn(T, T) -> T + Copy + Sync,
 {
-    validate_axes(label, axes, input.shape().len())?;
+    validate_reduced_axes_nonempty(label, input.shape(), axes)?;
     if axes.is_empty() {
         return Ok(input.clone());
     }
@@ -414,7 +442,7 @@ where
     R: Fn(T, T) -> T + Copy + Sync,
     TR: TensorRank,
 {
-    validate_axes(label, axes, input.shape().len())?;
+    validate_reduced_axes_nonempty(label, input.shape(), axes)?;
     if axes.is_empty() {
         return view_to_dyn_contiguous(input);
     }

--- a/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
@@ -627,9 +627,23 @@ fn reduce_max_and_min_propagate_nan_instead_of_leaking_sentinel() {
 }
 
 #[test]
-fn reduce_max_and_min_reject_zero_length_reduced_axis() {
+fn reduce_sum_zero_length_axis_is_rejected_like_other_reductions() {
     let empty = Tensor::F64(TypedTensor::from_vec_col_major(vec![0], Vec::<f64>::new()).unwrap());
 
+    assert!(matches!(
+        reduce_sum(&empty, &[0]),
+        Err(crate::Error::InvalidConfig {
+            op: "reduce_sum",
+            ..
+        })
+    ));
+    assert!(matches!(
+        reduce_prod(&empty, &[0]),
+        Err(crate::Error::InvalidConfig {
+            op: "reduce_prod",
+            ..
+        })
+    ));
     assert!(matches!(
         reduce_max(&empty, &[0]),
         Err(crate::Error::InvalidConfig {
@@ -644,6 +658,30 @@ fn reduce_max_and_min_reject_zero_length_reduced_axis() {
             ..
         })
     ));
+}
+
+#[test]
+fn empty_reduction_axes_are_noop_before_dtype_dispatch() {
+    let bool_tensor = TypedTensor::from_vec_col_major(vec![2], vec![true, false]).unwrap();
+    let bools = Tensor::Bool(bool_tensor.clone());
+    let mut backend = CpuBackend::new();
+
+    let sum_owned = reduce_sum(&bools, &[]).unwrap();
+    let prod_owned = reduce_prod(&bools, &[]).unwrap();
+    let sum_read = backend
+        .reduce_sum_read(TensorRead::from_tensor(&bools), &[])
+        .unwrap();
+    let prod_read = backend
+        .reduce_prod_read(
+            TensorRead::from_view(TensorView::Bool(bool_tensor.as_view())),
+            &[],
+        )
+        .unwrap();
+
+    for tensor in [sum_owned, prod_owned, sum_read, prod_read] {
+        assert_eq!(tensor.shape(), &[2]);
+        assert_eq!(tensor.as_slice::<bool>().unwrap(), &[true, false]);
+    }
 }
 
 #[test]

--- a/crates/tenferro-cpu/tests/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/runtime_error_tests.rs
@@ -181,41 +181,89 @@ fn cpu_reshape_concatenate_scatter_use_checked_boundary_arithmetic_contract() {
 }
 
 #[test]
-fn cpu_reduce_max_min_validate_axes_before_empty_fast_path() {
+fn cpu_reductions_use_common_empty_axes_validation_helpers() {
     let reduction = include_str!("../src/reduction.rs");
-    for (start, end, op) in [
+
+    for (start, end, empty_check) in [
+        (
+            "fn reduction_empty_axes_noop",
+            "fn reduction_read_empty_axes_noop",
+            "axes.is_empty()",
+        ),
+        (
+            "fn reduction_read_empty_axes_noop",
+            "fn nan_propagating_max",
+            "if !axes.is_empty()",
+        ),
+    ] {
+        let section = source_section(reduction, start, end);
+        let validate_pos = section
+            .find("validate_axes(op, axes, input.shape().len())?;")
+            .unwrap_or_else(|| panic!("{start} should validate axes through the common helper"));
+        let empty_pos = section
+            .find(empty_check)
+            .unwrap_or_else(|| panic!("{start} should have an empty-axis fast path"));
+        assert!(
+            validate_pos < empty_pos,
+            "{start} must validate axes before empty-axis fast path"
+        );
+    }
+
+    for (start, end, helper, op) in [
+        (
+            "pub fn reduce_sum",
+            "pub(crate) fn reduce_sum_read",
+            "reduction_empty_axes_noop",
+            "reduce_sum",
+        ),
+        (
+            "pub(crate) fn reduce_sum_read",
+            "pub fn reduce_prod",
+            "reduction_read_empty_axes_noop",
+            "reduce_sum",
+        ),
+        (
+            "pub fn reduce_prod",
+            "pub(crate) fn reduce_prod_read",
+            "reduction_empty_axes_noop",
+            "reduce_prod",
+        ),
+        (
+            "pub(crate) fn reduce_prod_read",
+            "pub fn reduce_max",
+            "reduction_read_empty_axes_noop",
+            "reduce_prod",
+        ),
         (
             "pub fn reduce_max",
             "pub(crate) fn reduce_max_read",
+            "reduction_empty_axes_noop",
             "reduce_max",
         ),
         (
             "pub(crate) fn reduce_max_read",
             "pub fn reduce_min",
+            "reduction_read_empty_axes_noop",
             "reduce_max",
         ),
         (
             "pub fn reduce_min",
             "pub(crate) fn reduce_min_read",
+            "reduction_empty_axes_noop",
             "reduce_min",
         ),
         (
             "pub(crate) fn reduce_min_read",
             "fn typed_reduce<",
+            "reduction_read_empty_axes_noop",
             "reduce_min",
         ),
     ] {
         let section = source_section(reduction, start, end);
-        let validate = format!("validate_axes(\"{op}\", axes, input.shape().len())?;");
-        let validate_pos = section
-            .find(&validate)
-            .unwrap_or_else(|| panic!("{start} should validate axes"));
-        let empty_pos = section
-            .find("if axes.is_empty()")
-            .unwrap_or_else(|| panic!("{start} should have an empty-axis fast path"));
+        let call = format!("{helper}(\"{op}\",");
         assert!(
-            validate_pos < empty_pos,
-            "{start} must validate axes before empty-axis fast path"
+            section.contains(&call),
+            "{start} should route empty-axis handling through {helper}"
         );
     }
 }

--- a/crates/tenferro-einsum/src/extension.rs
+++ b/crates/tenferro-einsum/src/extension.rs
@@ -31,7 +31,9 @@ use tenferro_ops::{ExtensionRegistryError, ExtensionRuleSet};
 use tenferro_runtime::extension::{
     ExecInstruction, ExecOp, ExecProgram, ExtensionCacheKey, ExtensionExecutionContext,
 };
-use tenferro_tensor::{DType, RuntimeCacheControl, Tensor, TensorBackend, TensorRead};
+use tenferro_tensor::{
+    DType, Error as TensorError, RuntimeCacheControl, Tensor, TensorBackend, TensorRead,
+};
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
@@ -209,17 +211,32 @@ impl ExtensionOp for EinsumExtensionOp {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         if input_shapes.len() != self.subscripts.inputs.len()
             || input_dtypes.len() != input_shapes.len()
         {
-            return Vec::new();
+            return Err(TensorError::InvalidConfig {
+                op: "einsum",
+                message: format!(
+                    "expected {} input metadata entries, got dtypes={} shapes={}",
+                    self.subscripts.inputs.len(),
+                    input_dtypes.len(),
+                    input_shapes.len()
+                ),
+            });
         }
 
         let mut label_dims: HashMap<u32, SymDim> = HashMap::new();
         for (labels, shape) in self.subscripts.inputs.iter().zip(input_shapes.iter()) {
             if labels.len() != shape.len() {
-                return Vec::new();
+                return Err(TensorError::InvalidConfig {
+                    op: "einsum",
+                    message: format!(
+                        "subscript rank {} does not match input rank {}",
+                        labels.len(),
+                        shape.len()
+                    ),
+                });
             }
             for (&label, dim) in labels.iter().zip(shape.iter()) {
                 if let Some(existing) = label_dims.get(&label) {
@@ -227,7 +244,11 @@ impl ExtensionOp for EinsumExtensionOp {
                         (existing.constant_value(), dim.constant_value())
                     {
                         if lhs != rhs {
-                            return Vec::new();
+                            return Err(TensorError::ShapeMismatch {
+                                op: "einsum",
+                                lhs: vec![lhs],
+                                rhs: vec![rhs],
+                            });
                         }
                     }
                 } else {
@@ -244,12 +265,25 @@ impl ExtensionOp for EinsumExtensionOp {
                 .iter()
                 .map(|label| label_dims.get(label).cloned())
                 .collect::<Option<Vec<_>>>()
-                .unwrap_or_default(),
+                .ok_or_else(|| TensorError::InvalidConfig {
+                    op: "einsum",
+                    message: "output labels must be present in input metadata".into(),
+                })?,
         };
         if output_shape.len() != self.subscripts.output.len() {
-            return Vec::new();
+            return Err(TensorError::InvalidConfig {
+                op: "einsum",
+                message: format!(
+                    "output rank {} does not match subscript rank {}",
+                    output_shape.len(),
+                    self.subscripts.output.len()
+                ),
+            });
         }
-        vec![(promote_dtypes(input_dtypes.iter().copied()), output_shape)]
+        Ok(vec![(
+            promote_dtypes(input_dtypes.iter().copied()),
+            output_shape,
+        )])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-einsum/src/extension/tests.rs
+++ b/crates/tenferro-einsum/src/extension/tests.rs
@@ -14,17 +14,19 @@ fn infer_output_meta_uses_output_labels_and_promotes_dtype() {
     let lhs_shape = [SymDim::from(2usize), SymDim::from(3usize)];
     let rhs_shape = [SymDim::from(3usize), SymDim::from(4usize)];
 
-    let meta = op.infer_output_meta(
-        &[DType::F32, DType::F64],
-        &[lhs_shape.as_slice(), rhs_shape.as_slice()],
-    );
+    let meta = op
+        .infer_output_meta(
+            &[DType::F32, DType::F64],
+            &[lhs_shape.as_slice(), rhs_shape.as_slice()],
+        )
+        .unwrap();
 
     assert_eq!(meta[0].0, DType::F64);
     assert_eq!(meta[0].1, vec![SymDim::from(2usize), SymDim::from(4usize)]);
 }
 
 #[test]
-fn infer_output_meta_returns_empty_for_invalid_extension_metadata() {
+fn infer_output_meta_returns_error_for_invalid_extension_metadata() {
     let op = EinsumExtensionOp::new(EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]));
     let lhs_shape = [SymDim::from(2usize), SymDim::from(3usize)];
     let bad_rhs_rank = [SymDim::from(3usize)];
@@ -35,19 +37,19 @@ fn infer_output_meta_returns_empty_for_invalid_extension_metadata() {
             &[DType::F64],
             &[lhs_shape.as_slice(), bad_rhs_rank.as_slice()]
         )
-        .is_empty());
+        .is_err());
     assert!(op
         .infer_output_meta(
             &[DType::F64, DType::F64],
             &[lhs_shape.as_slice(), bad_rhs_rank.as_slice()]
         )
-        .is_empty());
+        .is_err());
     assert!(op
         .infer_output_meta(
             &[DType::F64, DType::F64],
             &[lhs_shape.as_slice(), bad_rhs_extent.as_slice()]
         )
-        .is_empty());
+        .is_err());
 }
 
 #[test]

--- a/crates/tenferro-einsum/src/traced.rs
+++ b/crates/tenferro-einsum/src/traced.rs
@@ -264,7 +264,7 @@ fn expand_traced_einsum_graph(
         })
         .collect::<Result<_>>()?;
     let input_sym_shape_refs: Vec<_> = input_sym_shapes.iter().map(Vec::as_slice).collect();
-    let output_metas = op.infer_output_meta(&input_dtypes, &input_sym_shape_refs);
+    let output_metas = op.infer_output_meta(&input_dtypes, &input_sym_shape_refs)?;
     let input_dim_shapes = traced_dim_expr_shapes(inputs);
 
     let outputs = extension::apply_expanded_graph(inputs, output_metas, |builder, input_refs| {

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -229,25 +229,35 @@ impl ExtensionOp for FftOp {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        // Public FFT constructors validate dtype/axis/n before building this
-        // op. The extension trait is non-fallible, so direct invalid trait
-        // calls return an output-count mismatch sentinel instead of panicking.
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         let [input_dtype] = input_dtypes else {
-            return Vec::new();
+            return Err(tenferro_tensor::Error::InvalidConfig {
+                op: "tenferro-fft",
+                message: format!("expected 1 input dtype, got {}", input_dtypes.len()),
+            });
         };
         let [input_shape] = input_shapes else {
-            return Vec::new();
+            return Err(tenferro_tensor::Error::InvalidConfig {
+                op: "tenferro-fft",
+                message: format!("expected 1 input shape, got {}", input_shapes.len()),
+            });
         };
         if self.axis >= input_shape.len() {
-            return Vec::new();
+            return Err(tenferro_tensor::Error::AxisOutOfBounds {
+                op: "tenferro-fft",
+                axis: self.axis,
+                rank: input_shape.len(),
+            });
         }
 
         let mut out_shape = input_shape.to_vec();
         let output_dtype = match self.kind {
             FftKind::C2C { .. } => {
                 if !matches!(input_dtype, DType::C32 | DType::C64) {
-                    return Vec::new();
+                    return Err(tenferro_tensor::Error::backend_failure(
+                        "tenferro-fft",
+                        format!("unsupported dtype {input_dtype:?} for complex FFT"),
+                    ));
                 }
                 *input_dtype
             }
@@ -257,7 +267,12 @@ impl ExtensionOp for FftOp {
                 match input_dtype {
                     DType::F32 => DType::C32,
                     DType::F64 => DType::C64,
-                    _ => return Vec::new(),
+                    _ => {
+                        return Err(tenferro_tensor::Error::backend_failure(
+                            "tenferro-fft",
+                            format!("unsupported dtype {input_dtype:?} for real FFT"),
+                        ));
+                    }
                 }
             }
             FftKind::C2R => {
@@ -268,7 +283,12 @@ impl ExtensionOp for FftOp {
                 match input_dtype {
                     DType::C32 => DType::F32,
                     DType::C64 => DType::F64,
-                    _ => return Vec::new(),
+                    _ => {
+                        return Err(tenferro_tensor::Error::backend_failure(
+                            "tenferro-fft",
+                            format!("unsupported dtype {input_dtype:?} for inverse real FFT"),
+                        ));
+                    }
                 }
             }
         };
@@ -277,7 +297,7 @@ impl ExtensionOp for FftOp {
             out_shape[self.axis] = transform_len_dim(self.n, &input_shape[self.axis]);
         }
 
-        vec![(output_dtype, out_shape)]
+        Ok(vec![(output_dtype, out_shape)])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -1124,14 +1144,14 @@ mod tests {
         let op = FftOp::new(FftKind::R2C { onesided: true }, 0, None, FftNorm::Backward);
         let shape = [SymDim::from(4usize)];
 
-        assert!(op.infer_output_meta(&[], &[&shape]).is_empty());
-        assert!(op.infer_output_meta(&[DType::F64], &[]).is_empty());
-        assert!(op.infer_output_meta(&[DType::I64], &[&shape]).is_empty());
+        assert!(op.infer_output_meta(&[], &[&shape]).is_err());
+        assert!(op.infer_output_meta(&[DType::F64], &[]).is_err());
+        assert!(op.infer_output_meta(&[DType::I64], &[&shape]).is_err());
 
         let bad_axis = FftOp::new(FftKind::C2C { forward: true }, 2, None, FftNorm::Backward);
         assert!(bad_axis
             .infer_output_meta(&[DType::C64], &[&shape])
-            .is_empty());
+            .is_err());
     }
 
     #[test]

--- a/crates/tenferro-internal-ops/src/ext_op.rs
+++ b/crates/tenferro-internal-ops/src/ext_op.rs
@@ -131,8 +131,8 @@ pub type ExtensionLoweringResult =
 ///         &self,
 ///         dtypes: &[DType],
 ///         shapes: &[&[SymDim]],
-///     ) -> Vec<(DType, Vec<SymDim>)> {
-///         vec![(dtypes[0], shapes[0].to_vec())]
+///     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+///         Ok(vec![(dtypes[0], shapes[0].to_vec())])
 ///     }
 ///     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
 ///         Ok(vec![inputs[0].clone()])
@@ -188,24 +188,26 @@ pub trait ExtensionOp: Debug + Send + Sync + 'static {
     /// `Arc<dyn ExtensionOp>` value.
     fn input_count(&self) -> usize;
 
-    /// Number of outputs. MUST match the length of the vector returned by
-    /// [`Self::infer_output_meta`].
+    /// Number of outputs. MUST match the length of the vector returned by a
+    /// successful [`Self::infer_output_meta`] call.
     fn output_count(&self) -> usize;
 
     // ----- Shape and dtype inference (spec Section 7) -----
 
     /// Infer output dtypes and shapes for each output slot.
     ///
-    /// `input_dtypes.len()` and `input_shapes.len()` both equal
-    /// `self.input_count()`. The returned vector MUST have length
-    /// `self.output_count()`, one `(dtype, shape)` entry per output slot.
-    /// Shapes use [`SymDim`] so extension ops compose with graph-global
-    /// symbolic metadata.
+    /// Implementations MUST validate arity, rank, dtype, axis, and other
+    /// input-derived metadata before indexing shape arrays. Invalid public
+    /// input must return a typed error rather than an empty sentinel or panic.
+    ///
+    /// On success, the returned vector MUST have length `self.output_count()`,
+    /// one `(dtype, shape)` entry per output slot. Shapes use [`SymDim`] so
+    /// extension ops compose with graph-global symbolic metadata.
     fn infer_output_meta(
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)>;
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>>;
 
     // ----- Forward execution dispatch (spec Section 8) -----
 

--- a/crates/tenferro-internal-ops/src/tests/catalog_kind_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/catalog_kind_tests.rs
@@ -43,8 +43,8 @@ impl ExtensionOp for CatalogExt {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-internal-ops/src/tests/ext_op_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/ext_op_tests.rs
@@ -82,8 +82,8 @@ impl ExtensionOp for NoInlineRuleOp {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -127,8 +127,8 @@ impl ExtensionOp for FamilyOnlyOp {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -177,8 +177,8 @@ impl ExtensionOp for PayloadOp {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
+++ b/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
@@ -480,8 +480,8 @@ impl ExtensionOp for RuleOnlyExt {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -267,42 +267,57 @@ impl ExtensionOp for LinalgExtensionOp {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         if input_dtypes.len() != self.input_count() || input_shapes.len() != self.input_count() {
-            return Vec::new();
+            return Err(Error::InvalidConfig {
+                op: "tenferro-linalg",
+                message: format!(
+                    "expected {} input metadata entries, got dtypes={} shapes={}",
+                    self.input_count(),
+                    input_dtypes.len(),
+                    input_shapes.len()
+                ),
+            });
         }
-        match self.op {
-            LinalgOp::Cholesky
-            | LinalgOp::FullPivLuSolve { .. }
-            | LinalgOp::TriangularSolve { .. } => {
-                let output_shape = if self.input_count() == 1 {
-                    input_shapes[0].to_vec()
-                } else {
-                    input_shapes[1].to_vec()
-                };
-                vec![(promote_dtypes(input_dtypes), output_shape)]
+        let metas = match self.op {
+            LinalgOp::Cholesky => {
+                require_matrix_meta("tenferro-linalg.cholesky", input_shapes[0])?;
+                vec![(promote_dtypes(input_dtypes), input_shapes[0].to_vec())]
+            }
+            LinalgOp::FullPivLuSolve { .. } => {
+                require_matrix_meta("tenferro-linalg.full_piv_lu_solve", input_shapes[0])?;
+                require_matrix_meta("tenferro-linalg.full_piv_lu_solve", input_shapes[1])?;
+                vec![(promote_dtypes(input_dtypes), input_shapes[1].to_vec())]
+            }
+            LinalgOp::TriangularSolve { .. } => {
+                require_matrix_meta("tenferro-linalg.triangular_solve", input_shapes[0])?;
+                require_matrix_meta("tenferro-linalg.triangular_solve", input_shapes[1])?;
+                vec![(promote_dtypes(input_dtypes), input_shapes[1].to_vec())]
             }
             LinalgOp::LuSolvePrepared { .. } => {
+                require_matrix_meta("tenferro-linalg.lu_solve_prepared_lu", input_shapes[0])?;
+                require_matrix_meta("tenferro-linalg.lu_solve_prepared_rhs", input_shapes[3])?;
                 vec![(
                     promote_dtypes(&[input_dtypes[0], input_dtypes[3]]),
                     input_shapes[3].to_vec(),
                 )]
             }
-            LinalgOp::Lu => lu_meta(input_dtypes[0], input_shapes[0]),
-            LinalgOp::LuFactor => lu_factor_meta(input_dtypes[0], input_shapes[0]),
-            LinalgOp::FullPivLu => full_piv_lu_meta(input_dtypes[0], input_shapes[0]),
-            LinalgOp::Svd { .. } => svd_meta(input_dtypes[0], input_shapes[0]),
+            LinalgOp::Lu => lu_meta(input_dtypes[0], input_shapes[0])?,
+            LinalgOp::LuFactor => lu_factor_meta(input_dtypes[0], input_shapes[0])?,
+            LinalgOp::FullPivLu => full_piv_lu_meta(input_dtypes[0], input_shapes[0])?,
+            LinalgOp::Svd { .. } => svd_meta(input_dtypes[0], input_shapes[0])?,
             LinalgOp::SvdVals { .. } => {
-                vec![svd_values_meta(input_dtypes[0], input_shapes[0])]
+                vec![svd_values_meta(input_dtypes[0], input_shapes[0])?]
             }
-            LinalgOp::Qr => qr_meta(input_dtypes[0], input_shapes[0]),
-            LinalgOp::Eigh { .. } => eigh_meta(input_dtypes[0], input_shapes[0]),
-            LinalgOp::EighVals { .. } => vec![eigh_values_meta(input_dtypes[0], input_shapes[0])],
-            LinalgOp::Eig { input_dtype } => eig_meta(input_dtype, input_shapes[0]),
+            LinalgOp::Qr => qr_meta(input_dtypes[0], input_shapes[0])?,
+            LinalgOp::Eigh { .. } => eigh_meta(input_dtypes[0], input_shapes[0])?,
+            LinalgOp::EighVals { .. } => vec![eigh_values_meta(input_dtypes[0], input_shapes[0])?],
+            LinalgOp::Eig { input_dtype } => eig_meta(input_dtype, input_shapes[0])?,
             LinalgOp::EigVals { input_dtype } => {
-                vec![eig_values_meta(input_dtype, input_shapes[0])]
+                vec![eig_values_meta(input_dtype, input_shapes[0])?]
             }
-        }
+        };
+        Ok(metas)
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -412,104 +427,126 @@ fn execute_linalg<B: LinalgBackend>(
     }
 }
 
-fn lu_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
-    let m = shape[0].clone();
-    let n = shape[1].clone();
+fn require_matrix_meta(op: &'static str, shape: &[SymDim]) -> tenferro_tensor::Result<()> {
+    if shape.len() < 2 {
+        return Err(Error::RankMismatch {
+            op,
+            expected: 2,
+            actual: shape.len(),
+        });
+    }
+    Ok(())
+}
+
+fn matrix_meta_parts<'a>(
+    op: &'static str,
+    shape: &'a [SymDim],
+) -> tenferro_tensor::Result<(SymDim, SymDim, &'a [SymDim])> {
+    require_matrix_meta(op, shape)?;
+    Ok((shape[0].clone(), shape[1].clone(), &shape[2..]))
+}
+
+fn lu_meta(dtype: DType, shape: &[SymDim]) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+    let (m, n, batch) = matrix_meta_parts("tenferro-linalg.lu", shape)?;
     let k = m.clone().min(n.clone());
-    let batch = &shape[2..];
-    vec![
+    Ok(vec![
         (dtype, matrix_shape(m.clone(), m, batch)),
         (dtype, matrix_shape(shape[0].clone(), k.clone(), batch)),
         (dtype, matrix_shape(k, n, batch)),
         (dtype, batch.to_vec()),
-    ]
+    ])
 }
 
-fn lu_factor_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
-    let m = shape[0].clone();
-    let n = shape[1].clone();
+fn lu_factor_meta(
+    dtype: DType,
+    shape: &[SymDim],
+) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+    let (m, n, batch) = matrix_meta_parts("tenferro-linalg.lu_factor", shape)?;
     let k = m.min(n);
-    let batch = &shape[2..];
-    vec![
+    Ok(vec![
         (dtype, shape.to_vec()),
         (DType::I32, vector_shape(k, batch)),
         (dtype, batch.to_vec()),
-    ]
+    ])
 }
 
-fn full_piv_lu_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
-    let n = shape[0].clone();
-    let batch = &shape[2..];
-    vec![
+fn full_piv_lu_meta(
+    dtype: DType,
+    shape: &[SymDim],
+) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+    let (n, _, batch) = matrix_meta_parts("tenferro-linalg.full_piv_lu", shape)?;
+    Ok(vec![
         (dtype, matrix_shape(n.clone(), n.clone(), batch)),
         (dtype, matrix_shape(n.clone(), n.clone(), batch)),
         (dtype, matrix_shape(n.clone(), n.clone(), batch)),
         (dtype, matrix_shape(n.clone(), n, batch)),
         (singular_values_dtype(dtype), batch.to_vec()),
-    ]
+    ])
 }
 
-fn svd_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
-    let m = shape[0].clone();
-    let n = shape[1].clone();
+fn svd_meta(dtype: DType, shape: &[SymDim]) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+    let (m, n, batch) = matrix_meta_parts("tenferro-linalg.svd", shape)?;
     let k = m.clone().min(n.clone());
-    let batch = &shape[2..];
-    vec![
+    Ok(vec![
         (dtype, matrix_shape(m, k.clone(), batch)),
         (singular_values_dtype(dtype), vector_shape(k.clone(), batch)),
         (dtype, matrix_shape(k, n, batch)),
-    ]
+    ])
 }
 
-fn svd_values_meta(dtype: DType, shape: &[SymDim]) -> (DType, Vec<SymDim>) {
-    let m = shape[0].clone();
-    let n = shape[1].clone();
+fn svd_values_meta(
+    dtype: DType,
+    shape: &[SymDim],
+) -> tenferro_tensor::Result<(DType, Vec<SymDim>)> {
+    let (m, n, batch) = matrix_meta_parts("tenferro-linalg.svd_values", shape)?;
     let k = m.min(n);
-    let batch = &shape[2..];
-    (singular_values_dtype(dtype), vector_shape(k, batch))
+    Ok((singular_values_dtype(dtype), vector_shape(k, batch)))
 }
 
-fn qr_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
-    let m = shape[0].clone();
-    let n = shape[1].clone();
+fn qr_meta(dtype: DType, shape: &[SymDim]) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+    let (m, n, batch) = matrix_meta_parts("tenferro-linalg.qr", shape)?;
     let k = m.clone().min(n.clone());
-    let batch = &shape[2..];
-    vec![
+    Ok(vec![
         (dtype, matrix_shape(m, k.clone(), batch)),
         (dtype, matrix_shape(k, n, batch)),
-    ]
+    ])
 }
 
-fn eigh_meta(dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
-    let n = shape[0].clone();
-    let batch = &shape[2..];
-    vec![
+fn eigh_meta(dtype: DType, shape: &[SymDim]) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+    let (n, _, batch) = matrix_meta_parts("tenferro-linalg.eigh", shape)?;
+    Ok(vec![
         (singular_values_dtype(dtype), vector_shape(n.clone(), batch)),
         (dtype, matrix_shape(n.clone(), n, batch)),
-    ]
+    ])
 }
 
-fn eigh_values_meta(dtype: DType, shape: &[SymDim]) -> (DType, Vec<SymDim>) {
-    let n = shape[0].clone();
-    let batch = &shape[2..];
-    (singular_values_dtype(dtype), vector_shape(n, batch))
+fn eigh_values_meta(
+    dtype: DType,
+    shape: &[SymDim],
+) -> tenferro_tensor::Result<(DType, Vec<SymDim>)> {
+    let (n, _, batch) = matrix_meta_parts("tenferro-linalg.eigh_values", shape)?;
+    Ok((singular_values_dtype(dtype), vector_shape(n, batch)))
 }
 
-fn eig_meta(input_dtype: DType, shape: &[SymDim]) -> Vec<(DType, Vec<SymDim>)> {
+fn eig_meta(
+    input_dtype: DType,
+    shape: &[SymDim],
+) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
     let dtype = eig_output_dtype(input_dtype);
-    let n = shape[0].clone();
-    let batch = &shape[2..];
-    vec![
+    let (n, _, batch) = matrix_meta_parts("tenferro-linalg.eig", shape)?;
+    Ok(vec![
         (dtype, vector_shape(n.clone(), batch)),
         (dtype, matrix_shape(n.clone(), n, batch)),
-    ]
+    ])
 }
 
-fn eig_values_meta(input_dtype: DType, shape: &[SymDim]) -> (DType, Vec<SymDim>) {
+fn eig_values_meta(
+    input_dtype: DType,
+    shape: &[SymDim],
+) -> tenferro_tensor::Result<(DType, Vec<SymDim>)> {
     let dtype = eig_output_dtype(input_dtype);
-    let n = shape[0].clone();
-    let batch = &shape[2..];
-    (dtype, vector_shape(n, batch))
+    let (n, _, batch) = matrix_meta_parts("tenferro-linalg.eig_values", shape)?;
+    Ok((dtype, vector_shape(n, batch)))
 }
 
 fn matrix_shape(rows: SymDim, cols: SymDim, batch: &[SymDim]) -> Vec<SymDim> {

--- a/crates/tenferro-linalg/src/extension/tests.rs
+++ b/crates/tenferro-linalg/src/extension/tests.rs
@@ -39,10 +39,16 @@ fn eager_linalg_rejects_cuda_tensor_when_cuda_feature_is_disabled() {
 }
 
 #[test]
-fn infer_output_meta_returns_empty_on_input_count_mismatch() {
+fn infer_output_meta_returns_error_on_input_count_mismatch() {
     let op = LinalgExtensionOp::new(LinalgOp::Cholesky);
 
-    let metas = op.infer_output_meta(&[], &[]);
+    let err = op.infer_output_meta(&[], &[]).unwrap_err();
 
-    assert!(metas.is_empty());
+    assert!(matches!(
+        err,
+        Error::InvalidConfig {
+            op: "tenferro-linalg",
+            ..
+        }
+    ));
 }

--- a/crates/tenferro-linalg/tests/traced_ad_explicit.rs
+++ b/crates/tenferro-linalg/tests/traced_ad_explicit.rs
@@ -6,7 +6,7 @@ use tenferro_ad::AdContext;
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::TracedTensorLinalgExt;
 use tenferro_runtime::{DType, Error, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
-use tenferro_tensor::TypedTensor;
+use tenferro_tensor::{Error as TensorError, TypedTensor};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
@@ -134,6 +134,28 @@ fn assert_invalid_ad_graph_build(
     }
 }
 
+fn assert_traced_op_rank_mismatch<T>(
+    result: std::thread::Result<tenferro_runtime::Result<T>>,
+    linalg_op: &'static str,
+    actual: usize,
+) {
+    let err = match result.unwrap_or_else(|_| panic!("{linalg_op} should return Err, not panic")) {
+        Ok(_) => panic!("{linalg_op} should reject rank < 2 inputs"),
+        Err(err) => err,
+    };
+    match err {
+        Error::TensorRuntime(TensorError::RankMismatch {
+            op,
+            expected: 2,
+            actual: got,
+        }) => {
+            assert_eq!(op, linalg_op);
+            assert_eq!(got, actual);
+        }
+        other => panic!("expected RankMismatch for {linalg_op}, got {other:?}"),
+    }
+}
+
 #[test]
 fn svd_singular_value_sum_jvp_uses_extension_ad_rule() {
     let ad = ad_context();
@@ -176,38 +198,24 @@ fn full_piv_lu_solve_grad_uses_extension_ad_rule() {
 
 #[test]
 fn full_piv_lu_solve_grad_rejects_rank1_operands_without_panic() {
-    let ad = ad_context();
     let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![2.0, 3.0])).unwrap();
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![4.0, 9.0])).unwrap();
-    let x = a.full_piv_lu_solve(&b).unwrap();
-    let loss = reduce_all(&x);
 
-    let result = catch_unwind(AssertUnwindSafe(|| ad.grad(&loss, &a)));
+    let result = catch_unwind(AssertUnwindSafe(|| a.full_piv_lu_solve(&b)));
 
-    assert_invalid_ad_graph_build(
-        result,
-        "vjp",
-        "tenferro-linalg.full_piv_lu_solve",
-        "rank >= 2",
-    );
+    assert_traced_op_rank_mismatch(result, "tenferro-linalg.full_piv_lu_solve", 1);
 }
 
 #[test]
 fn triangular_solve_grad_rejects_rank1_operands_without_panic() {
-    let ad = ad_context();
     let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![2.0, 3.0])).unwrap();
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![4.0, 9.0])).unwrap();
-    let x = a.triangular_solve(&b, true, true, false, false).unwrap();
-    let loss = reduce_all(&x);
 
-    let result = catch_unwind(AssertUnwindSafe(|| ad.grad(&loss, &a)));
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        a.triangular_solve(&b, true, true, false, false)
+    }));
 
-    assert_invalid_ad_graph_build(
-        result,
-        "vjp",
-        "tenferro-linalg.triangular_solve",
-        "rank >= 2",
-    );
+    assert_traced_op_rank_mismatch(result, "tenferro-linalg.triangular_solve", 1);
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/traced_extension.rs
@@ -294,6 +294,44 @@ fn traced_inv_rejects_rank_less_than_two_without_panicking() {
     ));
 }
 
+fn assert_linalg_rank_mismatch<T>(name: &str, result: tenferro_runtime::Result<T>, actual: usize) {
+    let err = match result {
+        Ok(_) => panic!("{name} should reject rank < 2 inputs"),
+        Err(err) => err,
+    };
+    assert!(
+        matches!(
+            err,
+            Error::TensorRuntime(TensorError::RankMismatch {
+                expected: 2,
+                actual: got,
+                ..
+            }) if got == actual
+        ),
+        "expected rank mismatch for {name}, got {err:?}"
+    );
+}
+
+#[test]
+fn traced_linalg_metadata_helpers_reject_rank_less_than_two_without_panicking() {
+    let scalar = TracedTensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
+    let vector = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+
+    assert_linalg_rank_mismatch("svd scalar", scalar.svd(), 0);
+    assert_linalg_rank_mismatch("svd vector", vector.svd(), 1);
+    assert_linalg_rank_mismatch("qr vector", vector.qr(), 1);
+    assert_linalg_rank_mismatch("lu vector", vector.lu(), 1);
+    assert_linalg_rank_mismatch("full_piv_lu vector", vector.full_piv_lu(), 1);
+    assert_linalg_rank_mismatch("eigh vector", vector.eigh(), 1);
+    assert_linalg_rank_mismatch("eig vector", vector.eig(), 1);
+    assert_linalg_rank_mismatch("eigvalsh vector", vector.eigvalsh(), 1);
+    assert_linalg_rank_mismatch("eigvals vector", vector.eigvals(), 1);
+    assert_linalg_rank_mismatch("solve vector", vector.solve(&vector), 1);
+    assert_linalg_rank_mismatch("slogdet vector", vector.slogdet(), 1);
+    assert_linalg_rank_mismatch("det vector", vector.det(), 1);
+    assert_linalg_rank_mismatch("pinv vector", vector.pinv(), 1);
+}
+
 #[test]
 fn traced_linalg_helpers_reject_symbolic_shapes_without_panicking() {
     let matrix = TracedTensor::input_symbolic_shape(DType::F64, 2).unwrap();

--- a/crates/tenferro-runtime/src/ad_support.rs
+++ b/crates/tenferro-runtime/src/ad_support.rs
@@ -93,7 +93,7 @@ pub fn resolve_roots(tensor: &TracedTensor) -> Vec<Arc<Graph<StdTensorOp>>> {
     tensor.resolve_roots()
 }
 
-pub fn checkpoint_tensor(tensor: &mut TracedTensor, data: Arc<Tensor>) {
+pub fn checkpoint_tensor(tensor: &mut TracedTensor, data: Arc<Tensor>) -> Result<()> {
     let old_graph = tensor.graph.clone();
     let old_output_key = old_graph.values()[tensor.val].key.clone();
     let old_inputs = (*tensor.inputs_map).clone();
@@ -106,13 +106,9 @@ pub fn checkpoint_tensor(tensor: &mut TracedTensor, data: Arc<Tensor>) {
     let new_metadata_scope = register_scoped_value_metadata(
         new_graph.values()[leaf_val].key.clone(),
         concrete_meta.clone(),
-    )
-    // The replacement checkpoint input key is freshly allocated here.
-    .expect("fresh checkpoint input metadata registration failed");
+    )?;
     let old_output_metadata_scope =
-        register_scoped_value_metadata(old_output_key.clone(), concrete_meta)
-            // Checkpoint aliases re-register metadata for the captured output key.
-            .expect("checkpoint output metadata registration failed");
+        register_scoped_value_metadata(old_output_key.clone(), concrete_meta)?;
     let node = CheckpointNode {
         graph: old_graph,
         alias_key: new_key.clone(),
@@ -138,6 +134,7 @@ pub fn checkpoint_tensor(tensor: &mut TracedTensor, data: Arc<Tensor>) {
     }
     merged.insert(new_key, data);
     tensor.inputs_map = Arc::new(merged);
+    Ok(())
 }
 
 pub fn allocate_input_key() -> TensorInputKey {

--- a/crates/tenferro-runtime/src/exec/tests.rs
+++ b/crates/tenferro-runtime/src/exec/tests.rs
@@ -574,8 +574,8 @@ impl ExtensionOp for TestExtension {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-runtime/src/extension.rs
+++ b/crates/tenferro-runtime/src/extension.rs
@@ -107,8 +107,8 @@ pub fn execute_lowered_program_with_backend_cache<B: TensorBackend + 'static>(
 /// #         &self,
 /// #         dtypes: &[DType],
 /// #         shapes: &[&[SymDim]],
-/// #     ) -> Vec<(DType, Vec<SymDim>)> {
-/// #         vec![(dtypes[0], shapes[0].to_vec())]
+/// #     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+/// #         Ok(vec![(dtypes[0], shapes[0].to_vec())])
 /// #     }
 /// #     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
 /// #         Ok(vec![inputs[0].clone()])
@@ -159,7 +159,7 @@ pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Result<Vec<T
         .collect();
     let input_shape_refs: Vec<&[SymDim]> = input_shape_storage.iter().map(Vec::as_slice).collect();
 
-    let output_metas = op.infer_output_meta(&input_dtypes, &input_shape_refs);
+    let output_metas = op.infer_output_meta(&input_dtypes, &input_shape_refs)?;
     if output_metas.len() != op.output_count() {
         return Err(Error::InvalidGraphBuild {
             op: "extension::apply",

--- a/crates/tenferro-runtime/src/extension/tests.rs
+++ b/crates/tenferro-runtime/src/extension/tests.rs
@@ -42,10 +42,10 @@ impl ExtensionOp for TestExtension {
         &self,
         dtypes: &[DType],
         shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        (0..self.inferred_outputs)
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok((0..self.inferred_outputs)
             .map(|_| (dtypes[0], shapes[0].to_vec()))
-            .collect()
+            .collect())
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-runtime/src/extension_runtime.rs
+++ b/crates/tenferro-runtime/src/extension_runtime.rs
@@ -412,8 +412,8 @@ impl<B: TensorBackend + 'static> ExtensionExecutor<B> {
     ///         &self,
     ///         input_dtypes: &[DType],
     ///         input_shapes: &[&[SymDim]],
-    ///     ) -> Vec<(DType, Vec<SymDim>)> {
-    ///         vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ///     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+    ///         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     ///     }
     ///
     ///     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-runtime/src/extension_runtime/tests.rs
+++ b/crates/tenferro-runtime/src/extension_runtime/tests.rs
@@ -75,8 +75,8 @@ impl ExtensionOp for TestExtension {
         &self,
         _input_dtypes: &[DType],
         _input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(DType::F64, vec![])]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(DType::F64, vec![])])
     }
 
     fn eager_execute(&self, _inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-runtime/src/graph/cache/tests.rs
+++ b/crates/tenferro-runtime/src/graph/cache/tests.rs
@@ -312,8 +312,8 @@ impl ExtensionOp for CollidingExtension {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-runtime/src/graph/lowering_view/tests.rs
+++ b/crates/tenferro-runtime/src/graph/lowering_view/tests.rs
@@ -45,8 +45,8 @@ impl ExtensionOp for DummyExtension {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-runtime/src/shape_infer.rs
+++ b/crates/tenferro-runtime/src/shape_infer.rs
@@ -209,7 +209,7 @@ pub fn infer_output_shapes(
         | StdTensorOp::ReduceProd { axes, .. }
         | StdTensorOp::ReduceMax { axes, .. }
         | StdTensorOp::ReduceMin { axes, .. } => {
-            vec![reduced_shape(require_input(op, input_shapes, 0)?, axes)]
+            vec![reduced_shape(require_input(op, input_shapes, 0)?, axes)?]
         }
         StdTensorOp::ExtractDiag { axis_a, axis_b } => {
             vec![extract_diag_shape(
@@ -349,7 +349,7 @@ pub fn infer_extension_output_meta(
         .collect();
     let symdim_refs: Vec<&[SymDim]> = symdim_storage.iter().map(Vec::as_slice).collect();
 
-    let metas = op.infer_output_meta(input_dtypes, &symdim_refs);
+    let metas = op.infer_output_meta(input_dtypes, &symdim_refs)?;
 
     let tensor_map: Vec<(u64, usize)> = (0..input_shapes.len())
         .map(|input_idx| (input_idx as u64, input_idx))
@@ -397,7 +397,7 @@ fn extension_first_output_dtype(op: &dyn ExtensionOp, input_dtypes: &[DType]) ->
     // be handled through [`infer_extension_output_meta`], which
     // `compile_std_to_exec` prefers for the `Extension` arm.
     let empty_rows: Vec<&[SymDim]> = (0..op.input_count()).map(|_| [].as_slice()).collect();
-    let metas = op.infer_output_meta(input_dtypes, &empty_rows);
+    let metas = op.infer_output_meta(input_dtypes, &empty_rows)?;
     if metas.is_empty() {
         return Err(shape_infer_error(format!(
             "ExtensionOp::infer_output_meta for family {:?} returned an \
@@ -477,12 +477,32 @@ fn permute_shape(input_shape: &[DimExpr], perm: &[usize]) -> Vec<DimExpr> {
     perm.iter().map(|&axis| input_shape[axis].clone()).collect()
 }
 
-fn reduced_shape(input_shape: &[DimExpr], axes: &[usize]) -> Vec<DimExpr> {
-    input_shape
+fn validate_reduction_axes(input_shape: &[DimExpr], axes: &[usize]) -> Result<()> {
+    let mut seen = vec![false; input_shape.len()];
+    for &axis in axes {
+        if axis >= input_shape.len() {
+            return Err(shape_infer_error(format!(
+                "reduction axis {axis} out of bounds for rank {}",
+                input_shape.len()
+            )));
+        }
+        if seen[axis] {
+            return Err(shape_infer_error(format!(
+                "duplicate reduction axis {axis}"
+            )));
+        }
+        seen[axis] = true;
+    }
+    Ok(())
+}
+
+fn reduced_shape(input_shape: &[DimExpr], axes: &[usize]) -> Result<Vec<DimExpr>> {
+    validate_reduction_axes(input_shape, axes)?;
+    Ok(input_shape
         .iter()
         .enumerate()
         .filter_map(|(axis, dim)| (!axes.contains(&axis)).then_some(dim.clone()))
-        .collect()
+        .collect())
 }
 
 fn same_or_scalar_broadcast_shape(

--- a/crates/tenferro-runtime/src/shape_infer/tests.rs
+++ b/crates/tenferro-runtime/src/shape_infer/tests.rs
@@ -89,6 +89,21 @@ fn invalid_shape_configs_return_errors_instead_of_panicking() {
 }
 
 #[test]
+fn reduction_shape_inference_rejects_invalid_axes() {
+    let shape = DimExpr::from_concrete(&[2, 3]);
+    let invalid_ops = [
+        StdTensorOp::ReduceSum { axes: vec![2] },
+        StdTensorOp::ReduceProd { axes: vec![0, 0] },
+        StdTensorOp::ReduceMax { axes: vec![3] },
+        StdTensorOp::ReduceMin { axes: vec![1, 1] },
+    ];
+
+    for op in invalid_ops {
+        assert!(infer_output_shapes(&op, &[&shape]).is_err(), "{op:?}");
+    }
+}
+
+#[test]
 fn concatenate_rejects_non_axis_dimension_mismatch() {
     let lhs = DimExpr::from_concrete(&[2, 3]);
     let rhs = DimExpr::from_concrete(&[4, 3]);

--- a/crates/tenferro-runtime/tests/extension_runtime.rs
+++ b/crates/tenferro-runtime/tests/extension_runtime.rs
@@ -57,8 +57,8 @@ impl ExtensionOp for IdentityRuntimeOp {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/crates/tenferro-runtime/tests/public_surface_contract.rs
+++ b/crates/tenferro-runtime/tests/public_surface_contract.rs
@@ -9,6 +9,20 @@ fn repo_file(path: &str) -> String {
     std::fs::read_to_string(root).expect("source file must be readable")
 }
 
+fn assert_no_panic_helpers(path: &str, source: &str) {
+    for (line_idx, line) in source.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("///") || trimmed.starts_with("//!") || trimmed.starts_with("//") {
+            continue;
+        }
+        assert!(
+            !line.contains(".expect(") && !line.contains(".unwrap("),
+            "{path}:{} must not use expect/unwrap in publicly reachable implementation paths: {line}",
+            line_idx + 1
+        );
+    }
+}
+
 #[test]
 fn graph_program_exposes_read_only_lowering_view_for_owner_crates() {
     let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
@@ -47,4 +61,17 @@ fn traced_tensor_graph_and_attached_data_are_accessor_based() {
         source.contains("pub fn attached_data(&self)"),
         "TracedTensor should expose optional attached data through an accessor"
     );
+}
+
+#[test]
+fn tensor_checkpoint_and_cpu_gemm_public_paths_avoid_panic_helpers() {
+    for path in [
+        "crates/tenferro-tensor/src/types.rs",
+        "crates/tenferro-runtime/src/ad_support.rs",
+        "crates/tenferro-cpu/src/gemm/mod.rs",
+        "crates/tenferro-cpu/src/gemm/strided_dot.rs",
+    ] {
+        let source = repo_file(path);
+        assert_no_panic_helpers(path, &source);
+    }
 }

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -455,6 +455,10 @@ pub trait TensorStructural {
 
 /// Reduction operations.
 ///
+/// Reducing over an axis whose extent is zero returns an error for every
+/// reduction operation. Passing an empty `axes` slice is a no-op and returns the
+/// input values unchanged.
+///
 /// # Examples
 ///
 /// ```rust

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -635,8 +635,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// ```
     pub fn n_elements(&self) -> usize {
         // Invariant: public view constructors validate logical element count.
-        checked_view_element_count(self.shape(), "TypedTensorView::n_elements")
-            .expect("TypedTensorView layout shape was validated at construction")
+        match checked_view_element_count(self.shape(), "TypedTensorView::n_elements") {
+            Ok(n) => n,
+            Err(err) => {
+                unreachable!("TypedTensorView layout shape is validated at construction: {err}")
+            }
+        }
     }
 
     /// Return layout metadata for this view.
@@ -1121,8 +1125,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     pub fn n_elements(&self) -> usize {
         // Invariant: public mutable view constructors validate logical element count.
-        checked_view_element_count(self.shape(), "TypedTensorViewMut::n_elements")
-            .expect("TypedTensorViewMut layout shape was validated at construction")
+        match checked_view_element_count(self.shape(), "TypedTensorViewMut::n_elements") {
+            Ok(n) => n,
+            Err(err) => {
+                unreachable!("TypedTensorViewMut layout shape is validated at construction: {err}")
+            }
+        }
     }
 
     /// Return layout metadata for this view.
@@ -3433,8 +3441,12 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     /// ```
     pub fn n_elements(&self) -> usize {
         // Invariant: owned tensor constructors validate compact shape length against buffer length.
-        try_shape_product(self.shape(), "TypedTensor::n_elements")
-            .expect("TypedTensor compact shape was validated at construction")
+        match try_shape_product(self.shape(), "TypedTensor::n_elements") {
+            Ok(n) => n,
+            Err(err) => {
+                unreachable!("TypedTensor compact shape is validated at construction: {err}")
+            }
+        }
     }
 
     /// Tensor shape.

--- a/crates/tenferro-xla/tests/unsupported.rs
+++ b/crates/tenferro-xla/tests/unsupported.rs
@@ -39,8 +39,8 @@ impl ExtensionOp for RuntimeOnlyExtension {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        vec![(input_dtypes[0], input_shapes[0].to_vec())]
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {

--- a/docs/spec/extension-op.md
+++ b/docs/spec/extension-op.md
@@ -160,22 +160,25 @@ pub trait ExtensionOp: std::fmt::Debug + Send + Sync + 'static {
     fn input_count(&self) -> usize;
 
     /// Number of outputs. MUST match the length of the returned
-    /// `Vec` from `infer_output_meta`.
+    /// `Vec` from a successful `infer_output_meta` call.
     fn output_count(&self) -> usize;
 
     // ----- Shape and dtype inference (Section 7) -----
 
     /// Infer output dtype and shape for each output slot.
     ///
-    /// Returned vector length MUST equal `self.output_count()`. Shapes use
-    /// graph-global `SymDim` (symbolic dimensions). Input metadata is given as
-    /// explicit `SymDim` / `DType` slices; callers that start from `TensorMeta`
-    /// must choose `exact_shape` or `bound_shape` deliberately.
+    /// Implementations MUST validate arity, rank, dtype, axis, and other
+    /// input-derived metadata before indexing shape arrays. Invalid public
+    /// input must return a typed error rather than an empty sentinel or panic.
+    /// Returned vector length MUST equal `self.output_count()` on success.
+    /// Shapes use graph-global `SymDim` (symbolic dimensions). Input metadata
+    /// is given as explicit `SymDim` / `DType` slices; callers that start from
+    /// `TensorMeta` must choose `exact_shape` or `bound_shape` deliberately.
     fn infer_output_meta(
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)>;
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>>;
 
     /// Optionally expand this extension into standard tensor graph operations.
     ///
@@ -549,7 +552,7 @@ fn infer_output_meta(
     &self,
     input_dtypes: &[DType],
     input_shapes: &[&[SymDim]],
-) -> Vec<(DType, Vec<SymDim>)>;
+) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>>;
 ```
 
 This method's responsibility mirrors
@@ -560,9 +563,9 @@ extension.
 ### Contract
 
 - `input_dtypes.len()` and `input_shapes.len()` MUST both equal
-  `self.input_count()`. Callers (`compile_std_to_exec`, eager execution)
-  guarantee this.
-- The returned vector MUST have length `self.output_count()`.
+  `self.input_count()`. Implementations MUST validate this before indexing,
+  even when current callers are expected to pass checked metadata.
+- The returned vector MUST have length `self.output_count()` on success.
 - Each `(dtype, shape)` pair gives the inferred dtype and symbolic shape
   for the corresponding output slot.
 - Shapes are expressed as `Vec<SymDim>`. `TensorMeta` does not expose a
@@ -574,6 +577,8 @@ extension.
 - If the implementer needs dimension arithmetic (e.g. output dim =
   `lhs_m * rhs_n`), it MUST use the `SymDim` arithmetic API. Collapsing
   an unknown symbolic input to `0` or panicking is a contract violation.
+- Invalid arity, rank, dtype, axis, or shape metadata MUST return a typed
+  `tenferro_tensor::Error` rather than an empty vector sentinel.
 
 ### Symbolic-shape interaction
 
@@ -581,21 +586,19 @@ Per [`../design/dynamic-symbolic-shapes.md`](../design/dynamic-symbolic-shapes.m
 every extension's `infer_output_meta` MUST be **total** over both concrete and
 symbolic inputs. Total means:
 
-- The method returns without panicking for any `input_shapes` that would
-  also be accepted by the ambient core ops this extension composes with.
+- The method returns `Ok` or a typed `Err` without panicking for public input
+  metadata, including invalid metadata supplied through the trait boundary.
 - Where the output dimension is symbolic, the returned `SymDim` explicitly
   represents the symbolic expression rather than silently collapsing to
   a constant.
 
 ### Failure signature
 
-- An implementer that returns the wrong number of outputs causes
-  `compile_std_to_exec` to panic when assigning output slot metadata
-  (the panic already exists for core ops; see
-  `crates/tenferro-runtime/src/compiler/mod.rs`). The same panic applies to
-  extensions.
-- An implementer that panics on valid symbolic inputs surfaces as a
-  hard crash in symbolic-shape composition tests. This is a contract violation.
+- An implementer that returns `Ok` with the wrong number of outputs MUST be
+  rejected by the graph/runtime metadata layer with a typed graph-build or
+  invalid-config error that includes the extension `family_id`.
+- An implementer that panics on public metadata input surfaces as a hard crash
+  in symbolic-shape and boundary-safety tests. This is a contract violation.
 
 ---
 

--- a/docs/worklogs/2026-06-22-public-panic-reductions-extension-meta.md
+++ b/docs/worklogs/2026-06-22-public-panic-reductions-extension-meta.md
@@ -1,0 +1,63 @@
+# 2026-06-22 Public Panic, Reduction, and Extension Metadata Fixes
+
+## Summary
+
+Addressed issues #1139 and #1140 together because both were public-boundary
+validation failures:
+
+- CPU reductions now reject zero-length reduced axes consistently for
+  `reduce_sum`, `reduce_prod`, `reduce_max`, and `reduce_min`.
+- Public panic helpers in tensor element counts, checkpointing, and CPU GEMM
+  borrowed-input paths were removed or converted to fallible propagation.
+- `ExtensionOp::infer_output_meta` now returns `tenferro_tensor::Result` so
+  extension metadata validation can report typed errors instead of empty
+  sentinels or panics.
+- Linalg extension metadata helpers now validate rank before indexing shapes.
+- Follow-up CI coverage failure fixed: rank-1 linalg solve tests now assert the
+  traced operation returns a typed `RankMismatch` without panicking, and the
+  metadata error `op` names use the public linalg operation names.
+
+## Context Read
+
+- Issue scope: #1139 reduction zero-length axis inconsistency and #1140
+  public `.expect()` calls in `n_elements()` / `checkpoint_tensor()`.
+- Source audited around CPU reduction owned/read paths, runtime reduction shape
+  inference, tensor element-count APIs, checkpoint graph data attachment, CPU
+  GEMM borrowed reads, and extension metadata inference.
+- Additional mini-agent audit findings reviewed: reduction same-root parity,
+  public panic risk in linalg extension metadata helpers, and source-contract
+  coverage gaps for GEMM and reductions.
+
+## Decisions
+
+- Kept empty reduction axes as a no-op, but moved validation into shared helpers
+  before dtype dispatch so owned/read paths and all four reductions share the
+  same boundary behavior.
+- Treated zero-length reduced axes as invalid for all reduction kinds, matching
+  existing max/min behavior and avoiding identity-value special casing for
+  sum/prod on empty domains.
+- Changed the canonical `ExtensionOp::infer_output_meta` trait method to return
+  `Result` rather than adding a parallel `try_*` API. This keeps malformed
+  extension metadata in the normal typed-error path and removes the old empty
+  vector sentinel.
+- Added repository guidance requiring repeated public-boundary input checks to
+  be helperized when sibling surfaces need the same validation.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-linalg traced_linalg_metadata_helpers_reject_rank_less_than_two_without_panicking -- --nocapture`
+- `cargo test -p tenferro-tensor -p tenferro-internal-ops -p tenferro-runtime -p tenferro-ad -p tenferro-cpu -p tenferro-einsum -p tenferro-fft -p tenferro-linalg`
+- `cargo test -p tenferro-xla --no-run`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --manifest-path ext/tropical/Cargo.toml --no-run`
+- `cargo test -p tenferro-linalg --features autodiff --test traced_ad_explicit --release`
+
+## Remaining Risks
+
+- `n_elements()` still relies on construction-time tensor shape validation for
+  the impossible overflow case; source-contract tests now prevent public
+  `.expect()` / `.unwrap()` regressions in the touched public paths.
+- Full workspace CI may include feature combinations not exercised locally,
+  especially GPU/XLA runtime environments.

--- a/ext/tropical/src/extension.rs
+++ b/ext/tropical/src/extension.rs
@@ -40,6 +40,13 @@ const TROPICAL_EINSUM_JVP_FAMILY_ID: &str = "tenferro-ext-tropical.einsum_jvp.v1
 #[cfg(feature = "autodiff")]
 const TROPICAL_EINSUM_VJP_FAMILY_ID: &str = "tenferro-ext-tropical.einsum_vjp.v1";
 
+fn invalid_config(op: &'static str, message: impl Into<String>) -> tenferro_tensor::Error {
+    tenferro_tensor::Error::InvalidConfig {
+        op,
+        message: message.into(),
+    }
+}
+
 #[derive(Debug)]
 struct TropicalRuntime {
     family_id: &'static str,
@@ -167,10 +174,12 @@ impl ExtensionOp for TropicalEinsumOp {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
-        infer_tropical_output_meta(&self.subscripts, input_dtypes, input_shapes)
-            .into_iter()
-            .collect()
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        let meta =
+            infer_tropical_output_meta(&self.subscripts, input_dtypes, input_shapes).ok_or_else(
+                || invalid_config("tropical_einsum", "invalid tropical einsum metadata"),
+            )?;
+        Ok(vec![meta])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -237,14 +246,25 @@ impl ExtensionOp for TropicalEinsumJvpOp {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         if input_dtypes.len() != self.input_count() || input_shapes.len() != self.input_count() {
-            return Vec::new();
+            return Err(invalid_config(
+                "tropical_einsum_jvp",
+                format!(
+                    "expected {} input metadata entries, got dtypes={} shapes={}",
+                    self.input_count(),
+                    input_dtypes.len(),
+                    input_shapes.len()
+                ),
+            ));
         }
         let Some(primal) =
             infer_tropical_output_meta(&self.subscripts, &input_dtypes[..2], &input_shapes[..2])
         else {
-            return Vec::new();
+            return Err(invalid_config(
+                "tropical_einsum_jvp",
+                "invalid tropical einsum primal metadata",
+            ));
         };
         for &active in &self.active_inputs {
             let Some(position) = self
@@ -252,14 +272,20 @@ impl ExtensionOp for TropicalEinsumJvpOp {
                 .iter()
                 .position(|candidate| *candidate == active)
             else {
-                return Vec::new();
+                return Err(invalid_config(
+                    "tropical_einsum_jvp",
+                    "active input is missing from the active input set",
+                ));
             };
             let tangent_idx = 2 + position;
             if active >= 2 || input_dtypes[tangent_idx] != input_dtypes[active] {
-                return Vec::new();
+                return Err(invalid_config(
+                    "tropical_einsum_jvp",
+                    "active input tangent metadata does not match primal metadata",
+                ));
             }
         }
-        vec![primal]
+        Ok(vec![primal])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
@@ -351,22 +377,36 @@ impl ExtensionOp for TropicalEinsumVjpOp {
         &self,
         input_dtypes: &[DType],
         input_shapes: &[&[SymDim]],
-    ) -> Vec<(DType, Vec<SymDim>)> {
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         if input_dtypes.len() != 3 || input_shapes.len() != 3 || self.active_input >= 2 {
-            return Vec::new();
+            return Err(invalid_config(
+                "tropical_einsum_vjp",
+                format!(
+                    "expected 3 input metadata entries and active input < 2, got dtypes={} shapes={} active_input={}",
+                    input_dtypes.len(),
+                    input_shapes.len(),
+                    self.active_input
+                ),
+            ));
         }
         if infer_tropical_output_meta(&self.subscripts, &input_dtypes[..2], &input_shapes[..2])
             .is_none()
         {
-            return Vec::new();
+            return Err(invalid_config(
+                "tropical_einsum_vjp",
+                "invalid tropical einsum primal metadata",
+            ));
         }
         if input_dtypes[2] != input_dtypes[self.active_input] {
-            return Vec::new();
+            return Err(invalid_config(
+                "tropical_einsum_vjp",
+                "cotangent dtype does not match active primal dtype",
+            ));
         }
-        vec![(
+        Ok(vec![(
             input_dtypes[self.active_input],
             input_shapes[self.active_input].to_vec(),
-        )]
+        )])
     }
 
     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {


### PR DESCRIPTION
## Summary

- fix #1139 by making zero-length reduced axes error consistently for sum/prod/max/min while preserving empty-axes no-op behavior through shared helpers
- fix #1140 by removing public `.expect()` / `.unwrap()` panic helpers from tensor element counts, checkpointing, and CPU GEMM borrowed-read paths
- make `ExtensionOp::infer_output_meta` fallible and update linalg/einsum/fft metadata inference to return typed errors instead of empty sentinels or panics
- add repository guidance requiring repeated public-boundary input validation to be helperized

Fixes #1139.
Fixes #1140.

Work log: `docs/worklogs/2026-06-22-public-panic-reductions-extension-meta.md`

## Verification

- `cargo fmt --all`
- `cargo fmt --all --check`
- `cargo test -p tenferro-linalg traced_linalg_metadata_helpers_reject_rank_less_than_two_without_panicking -- --nocapture`
- `cargo test -p tenferro-tensor -p tenferro-internal-ops -p tenferro-runtime -p tenferro-ad -p tenferro-cpu -p tenferro-einsum -p tenferro-fft -p tenferro-linalg`
- `cargo test -p tenferro-xla --no-run`