### PR TITLE
Replenish CPU buffer pool after panic unwinds

### DIFF
--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fmt;
 use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
@@ -134,6 +135,12 @@ impl<'a> BufferPoolLoan<'a> {
 impl Drop for BufferPoolLoan<'_> {
     fn drop(&mut self) {
         if let Some(buffers) = self.buffers.take() {
+            let mut buffers = buffers;
+            if thread::panicking() {
+                buffers.replenish_in_flight_retained();
+            } else {
+                buffers.clear_in_flight_retained();
+            }
             *self.target = buffers;
         }
     }

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -173,7 +173,7 @@ fn with_linalg_pool_restores_backend_pool_and_context() {
 }
 
 #[test]
-fn linalg_pool_acquire_then_panic_keeps_retained_stats_consistent() {
+fn linalg_pool_acquire_then_panic_replenishes_retained_buffer() {
     let mut backend = CpuBackend::with_threads(1).unwrap();
     <f64 as PoolScalar>::pool_release(&mut backend.buffers, Vec::with_capacity(1024));
     assert_eq!(backend.buffer_pool_len(), 1);
@@ -191,8 +191,11 @@ fn linalg_pool_acquire_then_panic_keeps_retained_stats_consistent() {
     }));
 
     assert!(result.is_err());
-    assert_eq!(backend.buffer_pool_len(), 0);
-    assert_eq!(backend.buffers.retained_capacity_bytes(), 0);
+    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(
+        backend.buffers.retained_capacity_bytes(),
+        1024 * std::mem::size_of::<f64>()
+    );
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/buffer_pool.rs
+++ b/crates/tenferro-cpu/src/buffer_pool.rs
@@ -73,6 +73,13 @@ pub struct BufferPool {
     bool_pool: BTreeMap<usize, Vec<Vec<bool>>>,
     c64_pool: BTreeMap<usize, Vec<Vec<Complex64>>>,
     c32_pool: BTreeMap<usize, Vec<Vec<Complex32>>>,
+    f64_in_flight: BTreeMap<usize, usize>,
+    f32_in_flight: BTreeMap<usize, usize>,
+    i32_in_flight: BTreeMap<usize, usize>,
+    i64_in_flight: BTreeMap<usize, usize>,
+    bool_in_flight: BTreeMap<usize, usize>,
+    c64_in_flight: BTreeMap<usize, usize>,
+    c32_in_flight: BTreeMap<usize, usize>,
     retained_capacity_bytes: usize,
     max_retained_capacity_bytes: usize,
 }
@@ -117,10 +124,11 @@ pub trait PoolScalar: Copy + Sized + Send + Sync + private::Sealed {
     ///
     /// The returned vector may contain uninitialized or stale elements. Reading
     /// any element before writing it is undefined behavior. Once acquired, the
-    /// buffer is removed from pool retention accounting. If the caller panics
-    /// before returning it with [`PoolScalar::pool_release`], the in-flight vector
-    /// is dropped rather than reinserted into the pool so partially initialized
-    /// buffers are not retained.
+    /// buffer is removed from pool retention accounting. When this is used
+    /// inside a [`crate::CpuBackend`] pool loan, retained buffers that are lost
+    /// during panic unwinding are replenished with empty replacement buffers of
+    /// the same capacity. The partially initialized in-flight vector itself is
+    /// not reinserted.
     ///
     /// # Examples
     ///
@@ -226,8 +234,47 @@ fn smallest_pool_candidate<T>(
         .map(|&capacity| (capacity.saturating_mul(size_of::<T>()), kind))
 }
 
+fn increment_in_flight(in_flight: &mut BTreeMap<usize, usize>, cap: usize) {
+    if cap > 0 {
+        *in_flight.entry(cap).or_default() += 1;
+    }
+}
+
+fn decrement_in_flight(in_flight: &mut BTreeMap<usize, usize>, cap: usize) {
+    if cap == 0 {
+        return;
+    }
+    let Some(count) = in_flight.get_mut(&cap) else {
+        return;
+    };
+    *count -= 1;
+    if *count == 0 {
+        in_flight.remove(&cap);
+    }
+}
+
+fn replenish_in_flight_for<T>(
+    pool: &mut BTreeMap<usize, Vec<Vec<T>>>,
+    in_flight: &mut BTreeMap<usize, usize>,
+    retained_capacity_bytes: &mut usize,
+) {
+    for (&cap, &count) in in_flight.iter() {
+        for _ in 0..count {
+            let mut replacement = Vec::new();
+            if replacement.try_reserve_exact(cap).is_err() {
+                continue;
+            }
+            let actual_cap = replacement.capacity();
+            *retained_capacity_bytes =
+                retained_capacity_bytes.saturating_add(actual_cap.saturating_mul(size_of::<T>()));
+            pool.entry(actual_cap).or_default().push(replacement);
+        }
+    }
+    in_flight.clear();
+}
+
 macro_rules! impl_pool_scalar {
-    ($ty:ty, $field:ident, $zero:expr) => {
+    ($ty:ty, $field:ident, $in_flight:ident, $zero:expr) => {
         impl PoolScalar for $ty {
             fn pool_zero() -> Self {
                 $zero
@@ -240,6 +287,7 @@ macro_rules! impl_pool_scalar {
                         pool.retained_capacity_bytes = pool
                             .retained_capacity_bytes
                             .saturating_sub(buf.capacity().saturating_mul(size_of::<Self>()));
+                        increment_in_flight(&mut pool.$in_flight, buf.capacity());
                         // SAFETY: raw acquire requires caller full-overwrite; len <= capacity here.
                         unsafe { buf.set_len(len) };
                         buf
@@ -259,6 +307,7 @@ macro_rules! impl_pool_scalar {
                         pool.retained_capacity_bytes = pool
                             .retained_capacity_bytes
                             .saturating_sub(buf.capacity().saturating_mul(size_of::<Self>()));
+                        increment_in_flight(&mut pool.$in_flight, buf.capacity());
                         buf.resize(len, Self::pool_zero());
                         buf.fill(Self::pool_zero());
                         buf
@@ -270,6 +319,7 @@ macro_rules! impl_pool_scalar {
             fn pool_release(pool: &mut BufferPool, buf: Vec<Self>) {
                 let cap = buf.capacity();
                 if cap > 0 {
+                    decrement_in_flight(&mut pool.$in_flight, cap);
                     pool.retained_capacity_bytes = pool
                         .retained_capacity_bytes
                         .saturating_add(cap.saturating_mul(size_of::<Self>()));
@@ -281,13 +331,13 @@ macro_rules! impl_pool_scalar {
     };
 }
 
-impl_pool_scalar!(f64, f64_pool, 0.0);
-impl_pool_scalar!(f32, f32_pool, 0.0);
-impl_pool_scalar!(i32, i32_pool, 0);
-impl_pool_scalar!(i64, i64_pool, 0);
-impl_pool_scalar!(bool, bool_pool, false);
-impl_pool_scalar!(Complex64, c64_pool, Complex64::new(0.0, 0.0));
-impl_pool_scalar!(Complex32, c32_pool, Complex32::new(0.0, 0.0));
+impl_pool_scalar!(f64, f64_pool, f64_in_flight, 0.0);
+impl_pool_scalar!(f32, f32_pool, f32_in_flight, 0.0);
+impl_pool_scalar!(i32, i32_pool, i32_in_flight, 0);
+impl_pool_scalar!(i64, i64_pool, i64_in_flight, 0);
+impl_pool_scalar!(bool, bool_pool, bool_in_flight, false);
+impl_pool_scalar!(Complex64, c64_pool, c64_in_flight, Complex64::new(0.0, 0.0));
+impl_pool_scalar!(Complex32, c32_pool, c32_in_flight, Complex32::new(0.0, 0.0));
 
 impl BufferPool {
     /// Create an empty typed buffer pool.
@@ -326,6 +376,13 @@ impl BufferPool {
             bool_pool: BTreeMap::new(),
             c64_pool: BTreeMap::new(),
             c32_pool: BTreeMap::new(),
+            f64_in_flight: BTreeMap::new(),
+            f32_in_flight: BTreeMap::new(),
+            i32_in_flight: BTreeMap::new(),
+            i64_in_flight: BTreeMap::new(),
+            bool_in_flight: BTreeMap::new(),
+            c64_in_flight: BTreeMap::new(),
+            c32_in_flight: BTreeMap::new(),
             retained_capacity_bytes: 0,
             max_retained_capacity_bytes,
         }
@@ -559,7 +616,57 @@ impl BufferPool {
         self.bool_pool.clear();
         self.c64_pool.clear();
         self.c32_pool.clear();
+        self.clear_in_flight_retained();
         self.retained_capacity_bytes = 0;
+    }
+
+    pub(crate) fn clear_in_flight_retained(&mut self) {
+        self.f64_in_flight.clear();
+        self.f32_in_flight.clear();
+        self.i32_in_flight.clear();
+        self.i64_in_flight.clear();
+        self.bool_in_flight.clear();
+        self.c64_in_flight.clear();
+        self.c32_in_flight.clear();
+    }
+
+    pub(crate) fn replenish_in_flight_retained(&mut self) {
+        replenish_in_flight_for(
+            &mut self.f64_pool,
+            &mut self.f64_in_flight,
+            &mut self.retained_capacity_bytes,
+        );
+        replenish_in_flight_for(
+            &mut self.f32_pool,
+            &mut self.f32_in_flight,
+            &mut self.retained_capacity_bytes,
+        );
+        replenish_in_flight_for(
+            &mut self.i32_pool,
+            &mut self.i32_in_flight,
+            &mut self.retained_capacity_bytes,
+        );
+        replenish_in_flight_for(
+            &mut self.i64_pool,
+            &mut self.i64_in_flight,
+            &mut self.retained_capacity_bytes,
+        );
+        replenish_in_flight_for(
+            &mut self.bool_pool,
+            &mut self.bool_in_flight,
+            &mut self.retained_capacity_bytes,
+        );
+        replenish_in_flight_for(
+            &mut self.c64_pool,
+            &mut self.c64_in_flight,
+            &mut self.retained_capacity_bytes,
+        );
+        replenish_in_flight_for(
+            &mut self.c32_pool,
+            &mut self.c32_in_flight,
+            &mut self.retained_capacity_bytes,
+        );
+        self.enforce_retention_limit();
     }
 
     fn enforce_retention_limit(&mut self) {

--- a/crates/tenferro-cpu/src/buffer_pool/tests.rs
+++ b/crates/tenferro-cpu/src/buffer_pool/tests.rs
@@ -111,6 +111,38 @@ fn acquire_updates_retained_capacity_stats() {
 }
 
 #[test]
+fn replenish_in_flight_retained_restores_lost_capacity() {
+    let mut pool = BufferPool::new();
+    <f64 as PoolScalar>::pool_release(&mut pool, Vec::with_capacity(8));
+
+    let _in_flight = unsafe { <f64 as PoolScalar>::pool_acquire(&mut pool, 8) };
+    assert_eq!(pool.retained_capacity_bytes(), 0);
+    assert!(pool.is_empty());
+
+    pool.replenish_in_flight_retained();
+
+    assert_eq!(pool.len(), 1);
+    assert_eq!(pool.retained_capacity_bytes(), 8 * size_of::<f64>());
+    assert!(!pool.is_empty());
+}
+
+#[test]
+fn replenish_in_flight_retained_skips_successfully_released_buffers() {
+    let mut pool = BufferPool::new();
+    <f64 as PoolScalar>::pool_release(&mut pool, Vec::with_capacity(8));
+
+    let buf = unsafe { <f64 as PoolScalar>::pool_acquire(&mut pool, 8) };
+    <f64 as PoolScalar>::pool_release(&mut pool, buf);
+
+    let stats_before = pool.stats();
+    pool.replenish_in_flight_retained();
+
+    assert_eq!(pool.stats(), stats_before);
+    assert_eq!(pool.len(), 1);
+    assert_eq!(pool.retained_capacity_bytes(), 8 * size_of::<f64>());
+}
+
+#[test]
 fn stats_counts_typed_capacity_bytes() {
     let mut pool = BufferPool::new();
     <f64 as PoolScalar>::pool_release(&mut pool, Vec::with_capacity(3));

--- a/docs/worklogs/2026-06-25-buffer-pool-panic-replenishment.md
+++ b/docs/worklogs/2026-06-25-buffer-pool-panic-replenishment.md
@@ -1,0 +1,62 @@
+# Buffer Pool Panic Replenishment
+
+## Summary
+
+Fixes #1164 by making `CpuBackend` pool loans replenish retained buffer
+capacity when a panic unwinds through the loan. The fix preserves the safety
+rule that partially initialized in-flight vectors are not reinserted into the
+pool.
+
+## Context Read
+
+- `crates/tenferro-cpu/src/buffer_pool.rs`
+- `crates/tenferro-cpu/src/backend.rs`
+- `crates/tenferro-cpu/src/backend/tests.rs`
+- `crates/tenferro-cpu/src/buffer_pool/tests.rs`
+- GitHub issue #1164
+
+## Root Cause
+
+`PoolScalar::pool_acquire` removes a retained vector from the pool and returns
+a plain `Vec<T>`. If a kernel panics before the vector is returned with
+`pool_release`, the vector is dropped during unwinding. `BufferPoolLoan`
+restored the loaned pool object to the backend, but it had no record of retained
+capacities that were checked out and then lost.
+
+## Decision
+
+Track only pool-backed in-flight capacities inside `BufferPool`. A successful
+`pool_release` decrements the matching in-flight count. When `BufferPoolLoan`
+drops during panic unwinding, it replenishes remaining in-flight capacities with
+empty same-capacity replacement vectors, then restores the pool to the backend.
+On normal loan completion, it clears in-flight records so escaped output buffers
+are not duplicated back into the pool.
+
+This avoids retaining a potentially partially initialized vector while still
+preventing repeated caught panics from progressively draining the backend's hot
+buffer pool.
+
+## Verification
+
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-cpu linalg_pool_acquire_then_panic_replenishes_retained_buffer -- --nocapture`
+- `cargo test -p tenferro-cpu replenish_in_flight_retained -- --nocapture`
+- `cargo test -p tenferro-cpu`
+- `cargo clippy -p tenferro-cpu --all-targets -- -D warnings`
+- `cargo test -p tenferro-cpu --release`
+- `cargo llvm-cov -p tenferro-cpu --release --json --output-path /tmp/tenferro-cpu-coverage-1164.json`
+- `cargo llvm-cov --workspace --release --json --output-path /tmp/tenferro-workspace-coverage-1164.json`
+- `python3 scripts/check-coverage.py /tmp/tenferro-workspace-coverage-1164.json`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --workspace --release`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+
+## Residual Risk
+
+The replenishment hook is tied to unwinding through `BufferPoolLoan`. If a
+caller catches a panic entirely inside a loaned closure and continues normally,
+the loan cannot distinguish that internal panic from an ordinary successful
+operation. That pattern is outside the reported backend boundary and should be
+handled by the caller if needed.


### PR DESCRIPTION
> [!IMPORTANT]
> New features must start as a feature request issue.
> Please do not open a new-feature implementation PR before maintainers accept
> the issue and agree that implementation should start.
>
> If you already have prototype code, link to a fork branch, gist, or
> repository from the feature request issue instead of opening a PR.
>
> New-feature PRs opened before an accepted issue may be closed and redirected
> to an issue.
>
> If you are using an AI agent for a bug-fix PR, use or follow the
> repository-local `tenferro-bugfix-pr` workflow before editing code.

## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1164

## Summary

`BufferPoolLoan` previously restored the loaned pool object after panic unwinding, but a retained buffer acquired with `PoolScalar::pool_acquire` could still be dropped before `pool_release`, causing repeated caught panics to progressively drain the retained pool.

This PR tracks pool-backed in-flight capacities inside `BufferPool`. Successful releases decrement the matching in-flight count. If a panic unwinds through `BufferPoolLoan`, remaining in-flight retained capacities are replenished with empty same-capacity replacement vectors before the pool is restored. Normal loan completion clears the in-flight records so output buffers that intentionally escape the loan are not duplicated back into the pool.

The fix stays within bug-fix scope: it changes internal CPU buffer-pool accounting/replenishment only, adds no public API, and preserves the existing safety rule that partially initialized in-flight vectors are not reinserted.

Same-root-cause scan covered the typed `PoolScalar` macro implementation, direct `pool_acquire`/`pool_acquire_zeroed` paths, successful `pool_release`, `BufferPoolLoan` drop, and CPU backend loan call sites. Related behavior intentionally deferred: a panic caught entirely inside a loaned closure cannot be observed by `BufferPoolLoan`; callers that catch internally must handle that boundary themselves.

## Work log

- `docs/worklogs/2026-06-25-buffer-pool-panic-replenishment.md`

## Verification

- `cargo fmt --all --check`
- `cargo test -p tenferro-cpu linalg_pool_acquire_then_panic_replenishes_retained_buffer -- --nocapture`
- `cargo test -p tenferro-cpu replenish_in_flight_retained -- --nocapture`
- `cargo test -p tenferro-cpu`
- `cargo clippy -p tenferro-cpu --all-targets -- -D warnings`
- `cargo test -p tenferro-cpu --release`
- `cargo llvm-cov -p tenferro-cpu --release --json --output-path /tmp/tenferro-cpu-coverage-1164.json`
- `cargo llvm-cov --workspace --release --json --output-path /tmp/tenferro-workspace-coverage-1164.json`
- `python3 scripts/check-coverage.py /tmp/tenferro-workspace-coverage-1164.json`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1164.json`

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. Not applicable; this is a bug fix.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
