### PR TITLE
Document linalg FFI safety contracts

### DIFF
--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/cholesky.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/cholesky.rs
@@ -15,6 +15,8 @@ pub(crate) trait LapackCholesky: Clone + Copy + Default + PoolScalar {
 
 impl LapackCholesky for f64 {
     fn potrf(uplo: u8, n: i32, factor: &mut [Self], lda: i32, info: &mut i32) {
+        // SAFETY: callers pass a mutable column-major `lda x n` factor buffer,
+        // validated i32 dimensions, and a live `info` output for this call.
         unsafe {
             lapack::dpotrf(uplo, n, factor, lda, info);
         }
@@ -23,6 +25,8 @@ impl LapackCholesky for f64 {
 
 impl LapackCholesky for f32 {
     fn potrf(uplo: u8, n: i32, factor: &mut [Self], lda: i32, info: &mut i32) {
+        // SAFETY: callers pass a mutable column-major `lda x n` factor buffer,
+        // validated i32 dimensions, and a live `info` output for this call.
         unsafe {
             lapack::spotrf(uplo, n, factor, lda, info);
         }
@@ -31,6 +35,8 @@ impl LapackCholesky for f32 {
 
 impl LapackCholesky for Complex32 {
     fn potrf(uplo: u8, n: i32, factor: &mut [Self], lda: i32, info: &mut i32) {
+        // SAFETY: callers pass a mutable column-major `lda x n` factor buffer,
+        // validated i32 dimensions, and a live `info` output for this call.
         unsafe {
             lapack::cpotrf(uplo, n, factor, lda, info);
         }
@@ -39,6 +45,8 @@ impl LapackCholesky for Complex32 {
 
 impl LapackCholesky for Complex64 {
     fn potrf(uplo: u8, n: i32, factor: &mut [Self], lda: i32, info: &mut i32) {
+        // SAFETY: callers pass a mutable column-major `lda x n` factor buffer,
+        // validated i32 dimensions, and a live `info` output for this call.
         unsafe {
             lapack::zpotrf(uplo, n, factor, lda, info);
         }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eig.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eig.rs
@@ -85,6 +85,8 @@ macro_rules! impl_eig_real_2d {
             let mut vectors_real = vec![0.0 as $real; n * n];
             let mut query = vec![0.0 as $real; 1];
             let mut info = 0;
+            // SAFETY: all matrix/vector buffers match the validated `n x n`
+            // problem, and `lwork = -1` makes `query` the only workspace output.
             unsafe {
                 $geev(
                     b'N',
@@ -106,6 +108,8 @@ macro_rules! impl_eig_real_2d {
             check_lapack_info("eig", concat!($routine, "(work query)"), info)?;
             let lwork = work_len(query[0] as f64, "eig", $routine)?;
             let mut work = vec![0.0 as $real; lwork as usize];
+            // SAFETY: buffers and leading dimensions match the validated
+            // problem, and `work` uses the length returned by the LAPACK query.
             unsafe {
                 $geev(
                     b'N',
@@ -150,6 +154,8 @@ macro_rules! impl_eig_values_real_2d {
             let mut vr = vec![0.0 as $real; 1];
             let mut query = vec![0.0 as $real; 1];
             let mut info = 0;
+            // SAFETY: all matrix/vector buffers match the validated `n x n`
+            // problem, and `lwork = -1` makes `query` the only workspace output.
             unsafe {
                 $geev(
                     b'N',
@@ -171,6 +177,8 @@ macro_rules! impl_eig_values_real_2d {
             check_lapack_info("eig_values", concat!($routine, "(work query)"), info)?;
             let lwork = work_len(query[0] as f64, "eig_values", $routine)?;
             let mut work = vec![0.0 as $real; lwork as usize];
+            // SAFETY: buffers and leading dimensions match the validated
+            // problem, and `work` uses the length returned by the LAPACK query.
             unsafe {
                 $geev(
                     b'N',
@@ -212,6 +220,8 @@ macro_rules! impl_eig_complex_2d {
             let mut query = vec![<$complex>::new(0.0, 0.0); 1];
             let mut rwork = vec![0.0 as $real; 2 * n.max(1)];
             let mut info = 0;
+            // SAFETY: all complex matrix/vector buffers and real workspace
+            // match the validated `n x n` problem; `lwork = -1` queries workspace.
             unsafe {
                 $geev(
                     b'N',
@@ -233,6 +243,8 @@ macro_rules! impl_eig_complex_2d {
             check_lapack_info("eig", concat!($routine, "(work query)"), info)?;
             let lwork = work_len(query[0].re as f64, "eig", $routine)?;
             let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+            // SAFETY: buffers, real workspace, and leading dimensions match
+            // the validated problem, and `work` has the queried length.
             unsafe {
                 $geev(
                     b'N',
@@ -276,6 +288,8 @@ macro_rules! impl_eig_values_complex_2d {
             let mut query = vec![<$complex>::new(0.0, 0.0); 1];
             let mut rwork = vec![0.0 as $real; 2 * n.max(1)];
             let mut info = 0;
+            // SAFETY: all complex matrix/vector buffers and real workspace
+            // match the validated `n x n` problem; `lwork = -1` queries workspace.
             unsafe {
                 $geev(
                     b'N',
@@ -297,6 +311,8 @@ macro_rules! impl_eig_values_complex_2d {
             check_lapack_info("eig_values", concat!($routine, "(work query)"), info)?;
             let lwork = work_len(query[0].re as f64, "eig_values", $routine)?;
             let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+            // SAFETY: buffers, real workspace, and leading dimensions match
+            // the validated problem, and `work` has the queried length.
             unsafe {
                 $geev(
                     b'N',

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eigh.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eigh.rs
@@ -37,6 +37,8 @@ macro_rules! impl_real_eigh {
                 let mut values = vec![0.0 as $scalar; n];
                 let mut query = vec![0.0 as $scalar; 1];
                 let mut info = 0;
+                // SAFETY: `vectors` is a mutable column-major `n x n` buffer,
+                // `values` has `n` entries, and `lwork = -1` writes only the query slot.
                 unsafe {
                     $syev(
                         b'V',
@@ -53,6 +55,8 @@ macro_rules! impl_real_eigh {
                 check_lapack_info("eigh", concat!($routine, "(work query)"), info)?;
                 let lwork = work_len(query[0] as f64, "eigh", $routine)?;
                 let mut work = vec![0.0 as $scalar; lwork as usize];
+                // SAFETY: dimensions and `lwork` come from validated shape
+                // metadata plus the LAPACK query; all mutable buffers are live.
                 unsafe {
                     $syev(
                         b'V',
@@ -84,6 +88,8 @@ macro_rules! impl_real_eigh {
                 let mut values = vec![0.0 as $scalar; n];
                 let mut query = vec![0.0 as $scalar; 1];
                 let mut info = 0;
+                // SAFETY: `work_matrix` is a mutable column-major `n x n`
+                // buffer, `values` has `n` entries, and `lwork = -1` queries workspace.
                 unsafe {
                     $syev(
                         b'N',
@@ -100,6 +106,8 @@ macro_rules! impl_real_eigh {
                 check_lapack_info("eigh_values", concat!($routine, "(work query)"), info)?;
                 let lwork = work_len(query[0] as f64, "eigh_values", $routine)?;
                 let mut work = vec![0.0 as $scalar; lwork as usize];
+                // SAFETY: dimensions and `lwork` come from validated shape
+                // metadata plus the LAPACK query; all mutable buffers are live.
                 unsafe {
                     $syev(
                         b'N',
@@ -137,6 +145,8 @@ macro_rules! impl_complex_eigh {
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
                 let mut rwork = vec![0.0 as $real; (3 * n).saturating_sub(2).max(1)];
                 let mut info = 0;
+                // SAFETY: `vectors`, `values`, and `rwork` satisfy LAPACK's
+                // Hermitian eigensolver dimensions; `lwork = -1` writes only `query`.
                 unsafe {
                     $heev(
                         b'V',
@@ -154,6 +164,8 @@ macro_rules! impl_complex_eigh {
                 check_lapack_info("eigh", concat!($routine, "(work query)"), info)?;
                 let lwork = work_len(query[0].re as f64, "eigh", $routine)?;
                 let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                // SAFETY: `vectors`, `values`, `work`, and `rwork` match the
+                // validated `n x n` problem and queried workspace length.
                 unsafe {
                     $heev(
                         b'V',
@@ -194,6 +206,8 @@ macro_rules! impl_complex_eigh {
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
                 let mut rwork = vec![0.0 as $real; (3 * n).saturating_sub(2).max(1)];
                 let mut info = 0;
+                // SAFETY: `work_matrix`, `values`, and `rwork` satisfy LAPACK's
+                // Hermitian eigensolver dimensions; `lwork = -1` writes only `query`.
                 unsafe {
                     $heev(
                         b'N',
@@ -211,6 +225,8 @@ macro_rules! impl_complex_eigh {
                 check_lapack_info("eigh_values", concat!($routine, "(work query)"), info)?;
                 let lwork = work_len(query[0].re as f64, "eigh_values", $routine)?;
                 let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                // SAFETY: `work_matrix`, `values`, `work`, and `rwork` match
+                // the validated `n x n` problem and queried workspace length.
                 unsafe {
                     $heev(
                         b'N',

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
@@ -145,6 +145,9 @@ impl LapackFullPivLu for f32 {
         jpiv: &mut [i32],
         info: &mut i32,
     ) {
+        // SAFETY: `data` stores an `lda x n` LAPACK column-major matrix,
+        // pivot arrays have length at least `n`, and all pointers are valid
+        // for the duration of the FFI call.
         unsafe {
             sgetc2_ffi(
                 &n,
@@ -166,6 +169,9 @@ impl LapackFullPivLu for f32 {
         jpiv: &[i32],
         scale: &mut Self::Scale,
     ) {
+        // SAFETY: `data` stores the factorized `lda x n` matrix, `rhs` has
+        // length at least `n`, pivot arrays have length at least `n`, and
+        // LAPACK only writes through `rhs` and `scale`.
         unsafe {
             sgesc2_ffi(
                 &n,
@@ -283,6 +289,9 @@ impl LapackFullPivLu for Complex32 {
         jpiv: &mut [i32],
         info: &mut i32,
     ) {
+        // SAFETY: `data` stores an `lda x n` LAPACK column-major matrix,
+        // pivot arrays have length at least `n`, and all pointers are valid
+        // for the duration of the FFI call.
         unsafe {
             cgetc2_ffi(
                 &n,
@@ -304,6 +313,9 @@ impl LapackFullPivLu for Complex32 {
         jpiv: &[i32],
         scale: &mut Self::Scale,
     ) {
+        // SAFETY: `data` stores the factorized `lda x n` matrix, `rhs` has
+        // length at least `n`, pivot arrays have length at least `n`, and
+        // LAPACK only writes through `rhs` and `scale`.
         unsafe {
             cgesc2_ffi(
                 &n,

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs
@@ -25,6 +25,8 @@ impl LapackLu for f64 {
     }
 
     fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        // SAFETY: callers validate `m`, `n`, and `lda`, provide a mutable
+        // column-major `lda x n` matrix, `min(m, n)` pivots, and live `info`.
         unsafe {
             lapack::dgetrf(m, n, data, lda, ipiv, info);
         }
@@ -41,6 +43,8 @@ impl LapackLu for f32 {
     }
 
     fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        // SAFETY: callers validate `m`, `n`, and `lda`, provide a mutable
+        // column-major `lda x n` matrix, `min(m, n)` pivots, and live `info`.
         unsafe {
             lapack::sgetrf(m, n, data, lda, ipiv, info);
         }
@@ -57,6 +61,8 @@ impl LapackLu for Complex32 {
     }
 
     fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        // SAFETY: callers validate `m`, `n`, and `lda`, provide a mutable
+        // column-major `lda x n` matrix, `min(m, n)` pivots, and live `info`.
         unsafe {
             lapack::cgetrf(m, n, data, lda, ipiv, info);
         }
@@ -73,6 +79,8 @@ impl LapackLu for Complex64 {
     }
 
     fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        // SAFETY: callers validate `m`, `n`, and `lda`, provide a mutable
+        // column-major `lda x n` matrix, `min(m, n)` pivots, and live `info`.
         unsafe {
             lapack::zgetrf(m, n, data, lda, ipiv, info);
         }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr.rs
@@ -33,6 +33,8 @@ macro_rules! impl_real_qr {
                 let mut tau = vec![0.0 as $scalar; k];
                 let mut query = vec![0.0 as $scalar; 1];
                 let mut info = 0;
+                // SAFETY: `qr` is a mutable column-major `m x n` buffer,
+                // `tau` has `k` entries, and `lwork = -1` makes `query` the only workspace output.
                 unsafe {
                     $geqrf(
                         m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut query, -1, &mut info,
@@ -41,6 +43,8 @@ macro_rules! impl_real_qr {
                 check_lapack_info("qr", concat!($geqrf_name, "(work query)"), info)?;
                 let lwork = work_len(query[0] as f64, "qr", $geqrf_name)?;
                 let mut work = vec![0.0 as $scalar; lwork as usize];
+                // SAFETY: dimensions and `lwork` come from validated inputs
+                // and the LAPACK workspace query; `qr`, `tau`, `work`, and `info` are live.
                 unsafe {
                     $geqrf(
                         m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut work, lwork, &mut info,
@@ -56,6 +60,8 @@ macro_rules! impl_real_qr {
                 }
 
                 let mut query = vec![0.0 as $scalar; 1];
+                // SAFETY: `q` stores the first `k` reflectors in an `m x k`
+                // column-major buffer, `tau` has `k` entries, and query workspace is length 1.
                 unsafe {
                     $orgqr(
                         m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut query, -1, &mut info,
@@ -64,6 +70,8 @@ macro_rules! impl_real_qr {
                 check_lapack_info("qr", concat!($orgqr_name, "(work query)"), info)?;
                 let lwork = work_len(query[0] as f64, "qr", $orgqr_name)?;
                 let mut work = vec![0.0 as $scalar; lwork as usize];
+                // SAFETY: `q`, `tau`, and `work` satisfy the dimensions and
+                // workspace length returned by the preceding LAPACK query.
                 unsafe {
                     $orgqr(
                         m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut work, lwork, &mut info,
@@ -97,6 +105,8 @@ macro_rules! impl_complex_qr {
                 let mut tau = vec![<$complex>::new(0.0, 0.0); k];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
                 let mut info = 0;
+                // SAFETY: `qr` is a mutable column-major `m x n` buffer,
+                // `tau` has `k` entries, and `lwork = -1` makes `query` the only workspace output.
                 unsafe {
                     $geqrf(
                         m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut query, -1, &mut info,
@@ -105,6 +115,8 @@ macro_rules! impl_complex_qr {
                 check_lapack_info("qr", concat!($geqrf_name, "(work query)"), info)?;
                 let lwork = work_len(query[0].re as f64, "qr", $geqrf_name)?;
                 let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                // SAFETY: dimensions and `lwork` come from validated inputs
+                // and the LAPACK workspace query; `qr`, `tau`, `work`, and `info` are live.
                 unsafe {
                     $geqrf(
                         m_i32, n_i32, &mut qr, m_i32, &mut tau, &mut work, lwork, &mut info,
@@ -120,6 +132,8 @@ macro_rules! impl_complex_qr {
                 }
 
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
+                // SAFETY: `q` stores the first `k` reflectors in an `m x k`
+                // column-major buffer, `tau` has `k` entries, and query workspace is length 1.
                 unsafe {
                     $ungqr(
                         m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut query, -1, &mut info,
@@ -128,6 +142,8 @@ macro_rules! impl_complex_qr {
                 check_lapack_info("qr", concat!($ungqr_name, "(work query)"), info)?;
                 let lwork = work_len(query[0].re as f64, "qr", $ungqr_name)?;
                 let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                // SAFETY: `q`, `tau`, and `work` satisfy the dimensions and
+                // workspace length returned by the preceding LAPACK query.
                 unsafe {
                     $ungqr(
                         m_i32, k_i32, k_i32, &mut q, m_i32, &tau, &mut work, lwork, &mut info,

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/solve.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/solve.rs
@@ -25,6 +25,8 @@ pub(crate) trait LapackSolve: Clone + Copy + PoolScalar {
 
 impl LapackSolve for f64 {
     fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        // SAFETY: callers validate dimensions and provide a mutable
+        // column-major `lda x n` matrix, pivot storage, and live `info`.
         unsafe {
             lapack::dgetrf(m, n, data, lda, ipiv, info);
         }
@@ -41,6 +43,8 @@ impl LapackSolve for f64 {
         ldb: i32,
         info: &mut i32,
     ) {
+        // SAFETY: `a` holds a prior getrf factorization, `ipiv` matches it,
+        // `b` is a mutable `ldb x nrhs` RHS buffer, and all dims are validated.
         unsafe {
             lapack::dgetrs(trans, n, nrhs, a, lda, ipiv, b, ldb, info);
         }
@@ -49,6 +53,8 @@ impl LapackSolve for f64 {
 
 impl LapackSolve for f32 {
     fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        // SAFETY: callers validate dimensions and provide a mutable
+        // column-major `lda x n` matrix, pivot storage, and live `info`.
         unsafe {
             lapack::sgetrf(m, n, data, lda, ipiv, info);
         }
@@ -65,6 +71,8 @@ impl LapackSolve for f32 {
         ldb: i32,
         info: &mut i32,
     ) {
+        // SAFETY: `a` holds a prior getrf factorization, `ipiv` matches it,
+        // `b` is a mutable `ldb x nrhs` RHS buffer, and all dims are validated.
         unsafe {
             lapack::sgetrs(trans, n, nrhs, a, lda, ipiv, b, ldb, info);
         }
@@ -73,6 +81,8 @@ impl LapackSolve for f32 {
 
 impl LapackSolve for Complex32 {
     fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        // SAFETY: callers validate dimensions and provide a mutable
+        // column-major `lda x n` matrix, pivot storage, and live `info`.
         unsafe {
             lapack::cgetrf(m, n, data, lda, ipiv, info);
         }
@@ -89,6 +99,8 @@ impl LapackSolve for Complex32 {
         ldb: i32,
         info: &mut i32,
     ) {
+        // SAFETY: `a` holds a prior getrf factorization, `ipiv` matches it,
+        // `b` is a mutable `ldb x nrhs` RHS buffer, and all dims are validated.
         unsafe {
             lapack::cgetrs(trans, n, nrhs, a, lda, ipiv, b, ldb, info);
         }
@@ -97,6 +109,8 @@ impl LapackSolve for Complex32 {
 
 impl LapackSolve for Complex64 {
     fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32) {
+        // SAFETY: callers validate dimensions and provide a mutable
+        // column-major `lda x n` matrix, pivot storage, and live `info`.
         unsafe {
             lapack::zgetrf(m, n, data, lda, ipiv, info);
         }
@@ -113,6 +127,8 @@ impl LapackSolve for Complex64 {
         ldb: i32,
         info: &mut i32,
     ) {
+        // SAFETY: `a` holds a prior getrf factorization, `ipiv` matches it,
+        // `b` is a mutable `ldb x nrhs` RHS buffer, and all dims are validated.
         unsafe {
             lapack::zgetrs(trans, n, nrhs, a, lda, ipiv, b, ldb, info);
         }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
@@ -43,6 +43,8 @@ macro_rules! impl_real_svd {
                 let mut vt = vec![0.0 as $scalar; k * n];
                 let mut query = vec![0.0 as $scalar; 1];
                 let mut info = 0;
+                // SAFETY: `a`, `s`, `u`, and `vt` match the validated SVD
+                // dimensions, and `lwork = -1` makes `query` the workspace output.
                 unsafe {
                     $gesvd(
                         b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
@@ -52,6 +54,8 @@ macro_rules! impl_real_svd {
                 check_lapack_info("svd", concat!($routine, "(work query)"), info)?;
                 let lwork = work_len(query[0] as f64, "svd", $routine)?;
                 let mut work = vec![0.0 as $scalar; lwork as usize];
+                // SAFETY: buffers and leading dimensions match the validated
+                // SVD problem, and `work` uses the queried workspace length.
                 unsafe {
                     $gesvd(
                         b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
@@ -80,6 +84,8 @@ macro_rules! impl_real_svd {
                 let mut s = vec![0.0 as $scalar; k];
                 let mut query = vec![0.0 as $scalar; 1];
                 let mut info = 0;
+                // SAFETY: `a` and `s` match the validated SVD dimensions;
+                // no-vector mode ignores the dummy U/VT buffers, and `lwork = -1` queries workspace.
                 unsafe {
                     $gesvd(
                         b'N',
@@ -101,6 +107,8 @@ macro_rules! impl_real_svd {
                 check_lapack_info("svd_values", concat!($routine, "(work query)"), info)?;
                 let lwork = work_len(query[0] as f64, "svd_values", $routine)?;
                 let mut work = vec![0.0 as $scalar; lwork as usize];
+                // SAFETY: `a`, `s`, dummy no-vector buffers, and `work`
+                // satisfy the validated SVD dimensions and queried workspace length.
                 unsafe {
                     $gesvd(
                         b'N',
@@ -149,6 +157,8 @@ macro_rules! impl_complex_svd {
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
                 let mut rwork = vec![0.0 as $real; 5 * k.max(1)];
                 let mut info = 0;
+                // SAFETY: `a`, `s`, `u`, `vt`, and `rwork` match the
+                // validated complex SVD dimensions; `lwork = -1` queries workspace.
                 unsafe {
                     $gesvd(
                         b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
@@ -158,6 +168,8 @@ macro_rules! impl_complex_svd {
                 check_lapack_info("svd", concat!($routine, "(work query)"), info)?;
                 let lwork = work_len(query[0].re as f64, "svd", $routine)?;
                 let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                // SAFETY: buffers, real workspace, and leading dimensions
+                // match the validated complex SVD problem and queried workspace length.
                 unsafe {
                     $gesvd(
                         b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
@@ -193,6 +205,8 @@ macro_rules! impl_complex_svd {
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
                 let mut rwork = vec![0.0 as $real; 5 * k.max(1)];
                 let mut info = 0;
+                // SAFETY: `a`, `s`, and `rwork` match the validated complex
+                // SVD dimensions; no-vector mode ignores dummy U/VT buffers, and `lwork = -1` queries workspace.
                 unsafe {
                     $gesvd(
                         b'N',
@@ -215,6 +229,8 @@ macro_rules! impl_complex_svd {
                 check_lapack_info("svd_values", concat!($routine, "(work query)"), info)?;
                 let lwork = work_len(query[0].re as f64, "svd_values", $routine)?;
                 let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                // SAFETY: `a`, `s`, dummy no-vector buffers, `work`, and
+                // `rwork` satisfy the validated complex SVD dimensions and queried workspace length.
                 unsafe {
                     $gesvd(
                         b'N',

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/triangular_solve.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/triangular_solve.rs
@@ -37,6 +37,8 @@ impl LapackTriangularSolve for f64 {
         ldb: i32,
         info: &mut i32,
     ) {
+        // SAFETY: callers validate the triangular matrix and RHS shapes,
+        // provide column-major `a`/`b` buffers matching `lda`/`ldb`, and live `info`.
         unsafe {
             lapack::dtrtrs(uplo, trans, diag, n, nrhs, a, lda, b, ldb, info);
         }
@@ -56,6 +58,8 @@ impl LapackTriangularSolve for f32 {
         ldb: i32,
         info: &mut i32,
     ) {
+        // SAFETY: callers validate the triangular matrix and RHS shapes,
+        // provide column-major `a`/`b` buffers matching `lda`/`ldb`, and live `info`.
         unsafe {
             lapack::strtrs(uplo, trans, diag, n, nrhs, a, lda, b, ldb, info);
         }
@@ -75,6 +79,8 @@ impl LapackTriangularSolve for Complex32 {
         ldb: i32,
         info: &mut i32,
     ) {
+        // SAFETY: callers validate the triangular matrix and RHS shapes,
+        // provide column-major `a`/`b` buffers matching `lda`/`ldb`, and live `info`.
         unsafe {
             lapack::ctrtrs(uplo, trans, diag, n, nrhs, a, lda, b, ldb, info);
         }
@@ -94,6 +100,8 @@ impl LapackTriangularSolve for Complex64 {
         ldb: i32,
         info: &mut i32,
     ) {
+        // SAFETY: callers validate the triangular matrix and RHS shapes,
+        // provide column-major `a`/`b` buffers matching `lda`/`ldb`, and live `info`.
         unsafe {
             lapack::ztrtrs(uplo, trans, diag, n, nrhs, a, lda, b, ldb, info);
         }

--- a/crates/tenferro-linalg/src/gpu/linalg.rs
+++ b/crates/tenferro-linalg/src/gpu/linalg.rs
@@ -546,8 +546,16 @@ where
     for batch in 0..batch_total {
         let a_offset =
             checked_batch_offset(OP, "cholesky matrix batch offset", batch, matrix_stride)?;
-        let batch_a = unsafe { batch_ptr::<T>(first_ptr, a_offset) };
-        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+        // SAFETY: `a_offset` and `batch` were checked against the matrix and
+        // info strides, and both base pointers come from live device tensors.
+        let (batch_a, batch_info) = unsafe {
+            (
+                batch_ptr::<T>(first_ptr, a_offset),
+                batch_ptr::<i32>(info_ptr, batch).cast::<i32>(),
+            )
+        };
+        // SAFETY: the batch pointers, workspace, dimensions, and stream-bound
+        // handle satisfy cuSOLVER potrf's in-place matrix and info contracts.
         unsafe {
             handles.cusolver().potrf(
                 T::DATA_TYPE,
@@ -659,13 +667,21 @@ where
                 checked_batch_offset(op, "triangular matrix batch offset", batch, a_stride)?;
             let b_offset =
                 checked_batch_offset(op, "triangular rhs batch offset", batch, out_stride)?;
-            let batch_a = unsafe { batch_const_ptr::<T>(a_ptr.cast_const(), a_offset) };
-            let batch_b = unsafe { batch_ptr::<T>(out_ptr, b_offset) };
+            // SAFETY: checked offsets keep both pointers inside the live
+            // triangular matrix and RHS device allocations for this batch.
+            let (batch_a, batch_b) = unsafe {
+                (
+                    batch_const_ptr::<T>(a_ptr.cast_const(), a_offset),
+                    batch_ptr::<T>(out_ptr, b_offset),
+                )
+            };
             a_pointers.push(batch_a as usize);
             b_pointers.push(batch_b as usize);
         }
         let a_array = upload_pointer_array(backend.runtime(), &a_pointers, op)?;
         let b_array = upload_pointer_array(backend.runtime(), &b_pointers, op)?;
+        // SAFETY: uploaded pointer arrays contain one valid matrix/RHS device
+        // pointer per batch, and scalar dimensions/leading dimensions are validated.
         unsafe {
             handles.cublas().trsm_batched(
                 T::DATA_TYPE,
@@ -685,8 +701,16 @@ where
             )?;
         }
     } else {
-        let batch_a = unsafe { batch_const_ptr::<T>(a_ptr.cast_const(), 0) };
-        let batch_b = unsafe { batch_ptr::<T>(out_ptr, 0) };
+        // SAFETY: zero offset points at the first element of the live matrix
+        // and RHS device allocations already validated for this single batch.
+        let (batch_a, batch_b) = unsafe {
+            (
+                batch_const_ptr::<T>(a_ptr.cast_const(), 0),
+                batch_ptr::<T>(out_ptr, 0),
+            )
+        };
+        // SAFETY: pointers, scalar dimensions, and leading dimensions satisfy
+        // cuBLAS trsm for the validated single-batch triangular solve.
         unsafe {
             handles.cublas().trsm(
                 T::DATA_TYPE,
@@ -778,9 +802,17 @@ where
     for batch in 0..batch_total {
         let a_offset = checked_batch_offset(OP, "lu matrix batch offset", batch, matrix_stride)?;
         let pivot_offset = checked_batch_offset(OP, "lu pivot batch offset", batch, k)?;
-        let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
-        let batch_pivots = unsafe { batch_ptr::<i32>(pivots_ptr, pivot_offset) };
-        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+        // SAFETY: checked matrix, pivot, and info offsets stay inside their
+        // live device allocations for this batch.
+        let (batch_a, batch_pivots, batch_info) = unsafe {
+            (
+                batch_ptr::<T>(a_ptr, a_offset),
+                batch_ptr::<i32>(pivots_ptr, pivot_offset),
+                batch_ptr::<i32>(info_ptr, batch).cast::<i32>(),
+            )
+        };
+        // SAFETY: batch pointers, dimensions, workspace, and stream-bound
+        // handle satisfy cuSOLVER getrf's in-place LU and pivot contracts.
         unsafe {
             handles.cusolver().getrf(
                 T::DATA_TYPE,
@@ -923,6 +955,8 @@ where
     let vt_arg = typed_tensor_binding(vt, op)?;
     let v_arg = typed_tensor_binding(v, op)?;
     let launch_count = cube_count_for_len(vt.n_elements())?;
+    // SAFETY: tensor bindings describe live CUDA tensors, and `launch_count`
+    // covers exactly the output domain for the V-to-VT copy kernel.
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::svd_v_to_vt_real::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
@@ -951,6 +985,8 @@ where
     let vt_arg = typed_tensor_binding(vt, op)?;
     let v_arg = typed_tensor_binding(v, op)?;
     let launch_count = cube_count_for_len(vt.n_elements())?;
+    // SAFETY: tensor bindings describe live CUDA tensors, and `launch_count`
+    // covers exactly the output domain for the conjugating V-to-VT copy kernel.
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::svd_v_to_vt_complex::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
@@ -1056,12 +1092,19 @@ where
                     )?;
                     let u_offset = checked_batch_offset(OP, "svd u batch offset", batch, u_stride)?;
                     let v_offset = checked_batch_offset(OP, "svd v batch offset", batch, v_stride)?;
-                    let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
-                    let batch_s =
-                        unsafe { batch_ptr::<<T as LinalgScalar>::Real>(s_ptr, s_offset) };
-                    let batch_u = unsafe { batch_ptr::<T>(u_ptr, u_offset) };
-                    let batch_v = unsafe { batch_ptr::<T>(v_ptr, v_offset) };
-                    let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+                    // SAFETY: all offsets are checked against their per-batch
+                    // strides and each base pointer belongs to a live device tensor.
+                    let (batch_a, batch_s, batch_u, batch_v, batch_info) = unsafe {
+                        (
+                            batch_ptr::<T>(a_ptr, a_offset),
+                            batch_ptr::<<T as LinalgScalar>::Real>(s_ptr, s_offset),
+                            batch_ptr::<T>(u_ptr, u_offset),
+                            batch_ptr::<T>(v_ptr, v_offset),
+                            batch_ptr::<i32>(info_ptr, batch).cast::<i32>(),
+                        )
+                    };
+                    // SAFETY: batch pointers, workspaces, dimensions, and
+                    // gesvdj params satisfy cuSOLVER's vector SVD contract.
                     unsafe {
                         handles.cusolver().gesvdj(
                             T::DATA_TYPE,
@@ -1128,11 +1171,19 @@ where
                     checked_batch_offset(OP, "svd singular value batch offset", batch, s_stride)?;
                 let u_offset = checked_batch_offset(OP, "svd u batch offset", batch, u_stride)?;
                 let vt_offset = checked_batch_offset(OP, "svd vt batch offset", batch, vt_stride)?;
-                let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
-                let batch_s = unsafe { batch_ptr::<<T as LinalgScalar>::Real>(s_ptr, s_offset) };
-                let batch_u = unsafe { batch_ptr::<T>(u_ptr, u_offset) };
-                let batch_vt = unsafe { batch_ptr::<T>(vt_ptr, vt_offset) };
-                let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+                // SAFETY: all offsets are checked against their per-batch
+                // strides and each base pointer belongs to a live device tensor.
+                let (batch_a, batch_s, batch_u, batch_vt, batch_info) = unsafe {
+                    (
+                        batch_ptr::<T>(a_ptr, a_offset),
+                        batch_ptr::<<T as LinalgScalar>::Real>(s_ptr, s_offset),
+                        batch_ptr::<T>(u_ptr, u_offset),
+                        batch_ptr::<T>(vt_ptr, vt_offset),
+                        batch_ptr::<i32>(info_ptr, batch).cast::<i32>(),
+                    )
+                };
+                // SAFETY: batch pointers, workspace/rwork, dimensions, and
+                // stream-bound handle satisfy cuSOLVER gesvd's thin SVD contract.
                 unsafe {
                     handles.cusolver().gesvd(
                         T::DATA_TYPE,
@@ -1242,11 +1293,19 @@ where
                     checked_batch_offset(OP, "svd_values u batch offset", batch, u_stride)?;
                 let v_offset =
                     checked_batch_offset(OP, "svd_values v batch offset", batch, v_stride)?;
-                let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
-                let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, s_offset) };
-                let batch_u = unsafe { batch_ptr::<T>(u_ptr, u_offset) };
-                let batch_v = unsafe { batch_ptr::<T>(v_ptr, v_offset) };
-                let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+                // SAFETY: all offsets are checked against their per-batch
+                // strides and each base pointer belongs to a live device tensor.
+                let (batch_a, batch_s, batch_u, batch_v, batch_info) = unsafe {
+                    (
+                        batch_ptr::<T>(a_ptr, a_offset),
+                        batch_ptr::<T::Real>(s_ptr, s_offset),
+                        batch_ptr::<T>(u_ptr, u_offset),
+                        batch_ptr::<T>(v_ptr, v_offset),
+                        batch_ptr::<i32>(info_ptr, batch).cast::<i32>(),
+                    )
+                };
+                // SAFETY: batch pointers, scratch U/V buffers, workspace, and
+                // params satisfy cuSOLVER gesvdj's no-vector SVD contract.
                 unsafe {
                     handles.cusolver().gesvdj(
                         T::DATA_TYPE,
@@ -1309,9 +1368,17 @@ where
                     batch,
                     s_stride,
                 )?;
-                let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
-                let batch_s = unsafe { batch_ptr::<T::Real>(s_ptr, s_offset) };
-                let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+                // SAFETY: checked offsets keep the input, singular-value, and
+                // info pointers inside live device allocations for this batch.
+                let (batch_a, batch_s, batch_info) = unsafe {
+                    (
+                        batch_ptr::<T>(a_ptr, a_offset),
+                        batch_ptr::<T::Real>(s_ptr, s_offset),
+                        batch_ptr::<i32>(info_ptr, batch).cast::<i32>(),
+                    )
+                };
+                // SAFETY: no-vector gesvd permits null U/VT pointers with
+                // unit leading dimensions; other pointers and workspace are validated.
                 unsafe {
                     handles.cusolver().gesvd(
                         T::DATA_TYPE,
@@ -1406,10 +1473,18 @@ where
     for batch in 0..batch_total {
         let work_offset = checked_batch_offset(OP, "qr work batch offset", batch, work_stride)?;
         let q_offset = checked_batch_offset(OP, "qr q batch offset", batch, q_stride)?;
-        let batch_work = unsafe { batch_ptr::<T>(work_ptr, work_offset) };
-        let batch_q = unsafe { batch_ptr::<T>(q_ptr, q_offset) };
-        let batch_geqrf_info = unsafe { batch_ptr::<i32>(geqrf_info_ptr, batch).cast::<i32>() };
-        let batch_orgqr_info = unsafe { batch_ptr::<i32>(orgqr_info_ptr, batch).cast::<i32>() };
+        // SAFETY: checked offsets keep work, Q, and info pointers inside
+        // their live device allocations for this batch.
+        let (batch_work, batch_q, batch_geqrf_info, batch_orgqr_info) = unsafe {
+            (
+                batch_ptr::<T>(work_ptr, work_offset),
+                batch_ptr::<T>(q_ptr, q_offset),
+                batch_ptr::<i32>(geqrf_info_ptr, batch).cast::<i32>(),
+                batch_ptr::<i32>(orgqr_info_ptr, batch).cast::<i32>(),
+            )
+        };
+        // SAFETY: batch pointers, tau/workspace buffers, dimensions, and
+        // stream-bound handle satisfy cuSOLVER geqrf's QR factorization contract.
         unsafe {
             handles.cusolver().geqrf(
                 T::DATA_TYPE,
@@ -1432,6 +1507,8 @@ where
             q_stride * std::mem::size_of::<T>(),
             OP,
         )?;
+        // SAFETY: `batch_q` contains the copied reflectors, `tau` and
+        // workspace are live, and dimensions match the validated reduced-Q shape.
         unsafe {
             handles.cusolver().orgqr(
                 T::DATA_TYPE,
@@ -1509,9 +1586,17 @@ where
         let a_offset = checked_batch_offset(OP, "eigh matrix batch offset", batch, matrix_stride)?;
         let values_offset =
             checked_batch_offset(OP, "eigh values batch offset", batch, values_stride)?;
-        let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
-        let batch_w = unsafe { batch_ptr::<T::Real>(values_ptr, values_offset) };
-        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+        // SAFETY: checked offsets keep matrix, eigenvalue, and info pointers
+        // inside live device allocations for this batch.
+        let (batch_a, batch_w, batch_info) = unsafe {
+            (
+                batch_ptr::<T>(a_ptr, a_offset),
+                batch_ptr::<T::Real>(values_ptr, values_offset),
+                batch_ptr::<i32>(info_ptr, batch).cast::<i32>(),
+            )
+        };
+        // SAFETY: batch pointers, workspace, dimensions, and stream-bound
+        // handle satisfy cuSOLVER syevd's vector eigensolver contract.
         unsafe {
             handles.cusolver().syevd(
                 T::DATA_TYPE,
@@ -1584,9 +1669,17 @@ where
             checked_batch_offset(OP, "eigh_values matrix batch offset", batch, matrix_stride)?;
         let values_offset =
             checked_batch_offset(OP, "eigh_values values batch offset", batch, values_stride)?;
-        let batch_a = unsafe { batch_ptr::<T>(a_ptr, a_offset) };
-        let batch_w = unsafe { batch_ptr::<T::Real>(values_ptr, values_offset) };
-        let batch_info = unsafe { batch_ptr::<i32>(info_ptr, batch).cast::<i32>() };
+        // SAFETY: checked offsets keep matrix, eigenvalue, and info pointers
+        // inside live device allocations for this batch.
+        let (batch_a, batch_w, batch_info) = unsafe {
+            (
+                batch_ptr::<T>(a_ptr, a_offset),
+                batch_ptr::<T::Real>(values_ptr, values_offset),
+                batch_ptr::<i32>(info_ptr, batch).cast::<i32>(),
+            )
+        };
+        // SAFETY: batch pointers, workspace, dimensions, and stream-bound
+        // handle satisfy cuSOLVER syevd's no-vector eigensolver contract.
         unsafe {
             handles.cusolver().syevd(
                 T::DATA_TYPE,
@@ -1649,6 +1742,8 @@ where
     let work_arg = typed_tensor_binding(lu, "lu")?;
     let pivots_arg = typed_tensor_array_arg(pivots, "lu")?;
     let launch_count = cube_count_for_len(launch_len)?;
+    // SAFETY: tensor bindings describe live CUDA tensors, and `launch_count`
+    // covers the maximum P/L/U/parity output domain consumed by the kernel.
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::lu_extract_outputs::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
@@ -1682,6 +1777,8 @@ where
     let parity_arg = typed_tensor_binding(&parity, "lu_factor")?;
     let pivots_arg = typed_tensor_array_arg(pivots, "lu_factor")?;
     let launch_count = cube_count_for_len(parity.n_elements())?;
+    // SAFETY: tensor bindings describe live CUDA tensors, and `launch_count`
+    // covers exactly the parity output domain.
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::lu_parity::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
@@ -1707,6 +1804,8 @@ where
     let out = alloc_output::<T>(rt, shape)?;
     let out_arg = typed_tensor_binding(&out, op)?;
     let launch_count = cube_count_for_len(out.n_elements())?;
+    // SAFETY: `out_arg` describes a live CUDA output tensor, and
+    // `launch_count` covers every output element exactly once.
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::fill_one_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
@@ -1737,6 +1836,8 @@ where
     let input_arg = typed_tensor_binding(input, "lu_solve_prepared")?;
     let pivots_arg = typed_tensor_array_arg(pivots, "lu_solve_prepared")?;
     let launch_count = cube_count_for_len(out.n_elements())?;
+    // SAFETY: tensor bindings describe live CUDA tensors, pivot metadata
+    // matches the validated LU shape, and `launch_count` covers the output domain.
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::lu_apply_pivots::launch_unchecked::<T, CubeclCudaRuntime>(
             client,
@@ -1782,6 +1883,8 @@ fn raw_stream(rt: &CudaRuntime, op: &'static str) -> Result<CudaStream> {
 
 fn sync_stream(rt: &CudaRuntime, op: &'static str) -> Result<()> {
     let stream = raw_stream(rt, op)? as cudaStream_t;
+    // SAFETY: `raw_stream` returns the live CUDA stream owned by this runtime's
+    // current context; synchronizing it does not outlive the runtime.
     unsafe { cuda_result::stream::synchronize(stream) }.map_err(|err| {
         Error::backend_failure(op, format!("CUDA stream synchronize failed: {err:?}"))
     })
@@ -1867,6 +1970,8 @@ fn copy_device_to_device(
         return Ok(());
     }
     let stream = raw_stream(rt, op)? as cudaStream_t;
+    // SAFETY: callers pass device pointers obtained from live tensors or
+    // workspaces, `nbytes` is checked before zero-size return, and the stream is current.
     unsafe { cuda_result::memcpy_dtod_async(dst, src, nbytes, stream) }
         .map_err(|err| Error::backend_failure(op, format!("cudaMemcpyAsync DtoD failed: {err:?}")))
 }
@@ -2152,6 +2257,8 @@ fn complex32_magnitude(
         return Ok(output);
     }
     let launch_count = cube_count_for_len(output.n_elements())?;
+    // SAFETY: bindings describe live CUDA tensors, and `launch_count` covers
+    // exactly the complex32 magnitude output domain.
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::complex32_magnitude::launch_unchecked::<CubeclCudaRuntime>(
             client,
@@ -2176,6 +2283,8 @@ fn complex64_magnitude(
         return Ok(output);
     }
     let launch_count = cube_count_for_len(output.n_elements())?;
+    // SAFETY: bindings describe live CUDA tensors, and `launch_count` covers
+    // exactly the complex64 magnitude output domain.
     with_cubecl_client(rt, |client| unsafe {
         cubecl_linalg::complex64_magnitude::launch_unchecked::<CubeclCudaRuntime>(
             client,

--- a/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
@@ -36,6 +36,18 @@ fn cpu_lapack_eig_source() -> String {
     .unwrap_or_else(|err| panic!("LAPACK eig source should be readable: {err}"))
 }
 
+fn cpu_lapack_source(path: &str) -> String {
+    fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("cpu")
+            .join("linalg")
+            .join("lapack_linalg")
+            .join(path),
+    )
+    .unwrap_or_else(|err| panic!("LAPACK source {path} should be readable: {err}"))
+}
+
 fn cpu_faer_linalg_source() -> String {
     fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -57,6 +69,28 @@ fn cpu_backend_source() -> String {
     .unwrap_or_else(|err| panic!("CPU linalg backend source should be readable: {err}"))
 }
 
+fn assert_unsafe_blocks_have_safety_comments(path: &str, source: &str) {
+    let lines: Vec<_> = source.lines().collect();
+    let mut missing = Vec::new();
+    for (idx, line) in lines.iter().enumerate() {
+        if !line.contains("unsafe {") {
+            continue;
+        }
+        let window_start = idx.saturating_sub(3);
+        let has_safety = lines[window_start..idx]
+            .iter()
+            .any(|candidate| candidate.trim_start().starts_with("// SAFETY:"));
+        if !has_safety {
+            missing.push(format!("{}:{}", path, idx + 1));
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "LAPACK unsafe blocks need local SAFETY comments:\n{}",
+        missing.join("\n")
+    );
+}
+
 fn source_section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
     let start_idx = source
         .find(start)
@@ -67,6 +101,23 @@ fn source_section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
         .map(|offset| start_idx + offset)
         .unwrap_or(source.len());
     &source[start_idx..end_idx]
+}
+
+#[test]
+fn lapack_ffi_unsafe_blocks_document_safety_invariants() {
+    for path in [
+        "cholesky.rs",
+        "eig.rs",
+        "eigh.rs",
+        "full_piv_lu.rs",
+        "lu.rs",
+        "qr.rs",
+        "solve.rs",
+        "svd.rs",
+        "triangular_solve.rs",
+    ] {
+        assert_unsafe_blocks_have_safety_comments(path, &cpu_lapack_source(path));
+    }
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
@@ -56,6 +56,33 @@ fn assert_before(section: &str, earlier: &str, later: &str) {
     );
 }
 
+fn assert_unsafe_blocks_have_safety_comments(path: &str, source: &str) {
+    let lines: Vec<_> = source.lines().collect();
+    let mut missing = Vec::new();
+    for (idx, line) in lines.iter().enumerate() {
+        if !line.contains("unsafe {") {
+            continue;
+        }
+        let window_start = idx.saturating_sub(3);
+        let has_safety = lines[window_start..idx]
+            .iter()
+            .any(|candidate| candidate.trim_start().starts_with("// SAFETY:"));
+        if !has_safety {
+            missing.push(format!("{}:{}", path, idx + 1));
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "GPU linalg unsafe blocks need local SAFETY comments:\n{}",
+        missing.join("\n")
+    );
+}
+
+#[test]
+fn gpu_linalg_unsafe_blocks_document_safety_invariants() {
+    assert_unsafe_blocks_have_safety_comments("src/gpu/linalg.rs", &linalg_source());
+}
+
 #[test]
 fn tenferro_gpu_no_longer_owns_linalg_specific_ffi_or_kernels() {
     for path in [

--- a/docs/worklogs/2026-06-25-ffi-safety-comments.md
+++ b/docs/worklogs/2026-06-25-ffi-safety-comments.md
@@ -1,0 +1,73 @@
+# FFI Safety Comment Sweep
+
+## Summary
+
+Fixes #1169 by documenting the local safety invariants for LAPACK and CUDA
+linalg `unsafe` blocks. The change does not alter linalg algorithms, public API,
+or backend dispatch; it keeps the unsafe contracts reviewable at each FFI or
+unchecked kernel launch site.
+
+## Context Read
+
+- `CONTRIBUTING.md`
+- `AGENTS.md`
+- `REPOSITORY_RULES.md`
+- `ai/contribution-workflows/bugfix-pr.md`
+- `ai/contribution-workflows/repository-remediation.md`
+- GitHub issue #1169 and reopen comment after #1203
+- `crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/*.rs`
+- `crates/tenferro-linalg/src/gpu/linalg.rs`
+- `crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs`
+- `crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs`
+
+## Classification Ledger
+
+Issue #1169 is a repository-rule remediation finding: many LAPACK and CUDA
+linalg `unsafe` blocks existed without nearby `// SAFETY:` comments. It is an
+auto-fix because the intended behavior is already defined by
+`REPOSITORY_RULES.md`: every unsafe block must document the validation
+invariant next to the block. No new public API, dependency, feature flag,
+backend, or AD semantics were needed.
+
+The same-root-cause scan covered the full CPU LAPACK linalg wrapper directory
+and `src/gpu/linalg.rs`, the file named by the issue for cuSOLVER/cuBLAS/CUDA
+kernel call sites. The PR adds source-contract tests that fail if future
+`unsafe {` blocks in those scopes lack a nearby `// SAFETY:` comment.
+
+## Decisions
+
+- Keep comments local to each unsafe block rather than moving safety contracts
+  into module-level prose, because the repository rule asks reviewers to see
+  the validation invariant adjacent to the unsafe operation.
+- In the GPU path, group adjacent pointer-construction calls into one unsafe
+  block when they share the same checked-offset contract. The grouping keeps the
+  unsafe scope narrow while avoiding repeated comments for equivalent pointer
+  derivations in a single batch iteration.
+- Use source-contract tests instead of behavioral numerical tests for this
+  specific finding. The behavior already has linalg coverage; the regression is
+  absence of local safety documentation.
+
+## Verification
+
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-linalg --test cpu_linalg_source_contract lapack_ffi_unsafe_blocks_document_safety_invariants -- --nocapture`
+- `cargo test -p tenferro-linalg --test gpu_linalg_source_contract gpu_linalg_unsafe_blocks_document_safety_invariants -- --nocapture`
+- `cargo test -p tenferro-linalg`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path /tmp/tenferro-workspace-coverage-1169.json`
+- `python3 scripts/check-coverage.py /tmp/tenferro-workspace-coverage-1169.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --worktree --output-json /tmp/repository-rules-review-1169-worktree.json`
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1169.json`
+
+## Residual Risk
+
+The source-contract tests intentionally check only literal `unsafe {` blocks in
+the CPU LAPACK wrapper directory and `src/gpu/linalg.rs`. They will not detect
+`unsafe fn`, macro-generated unsafe blocks that do not contain the literal text,
+or future FFI files outside those scopes. That is acceptable for #1169 because
+the issue named these linalg paths; broader repository-wide unsafe linting can
+be handled by a separate rule or audit if needed.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] Documentation
- [x] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1169

## Summary

Documents the local `// SAFETY:` invariants for the CPU LAPACK linalg wrappers and CUDA linalg unsafe blocks named by #1169.

This stays within bug-fix/remediation scope: no public API, algorithm, backend dispatch, dependency, feature flag, or AD semantics changed. The GPU edits only group adjacent pointer derivations when they share the same checked-offset contract.

Same-root-cause scan covered the full `crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/` directory and `crates/tenferro-linalg/src/gpu/linalg.rs`. Added source-contract tests so future literal `unsafe {` blocks in those scopes need a nearby `// SAFETY:` comment.

## Work log

- `docs/worklogs/2026-06-25-ffi-safety-comments.md`

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. Not applicable; this is not a new feature.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.

Verification:

- `cargo fmt --all --check`
- `cargo test -p tenferro-linalg --test cpu_linalg_source_contract lapack_ffi_unsafe_blocks_document_safety_invariants -- --nocapture`
- `cargo test -p tenferro-linalg --test gpu_linalg_source_contract gpu_linalg_unsafe_blocks_document_safety_invariants -- --nocapture`
- `cargo test -p tenferro-linalg`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path /tmp/tenferro-workspace-coverage-1169.json`
- `python3 scripts/check-coverage.py /tmp/tenferro-workspace-coverage-1169.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --worktree --output-json /tmp/repository-rules-review-1169-worktree.json`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1169.json`

Residual risk:

The source-contract tests intentionally target the linalg paths named by #1169. They do not attempt repository-wide unsafe linting for future unrelated FFI files.