### PR TITLE
[codex] Fix layout overflow and AD one-like seeds

### DIFF
--- a/crates/tenferro-internal-ops/src/ad/analytic.rs
+++ b/crates/tenferro-internal-ops/src/ad/analytic.rs
@@ -3,8 +3,10 @@ use crate::ad::support::{
     conjugate_primal_if_any_dtype_complex, convert_fixed_ref_to_dtype, convert_linear_to_dtype,
     dtype_of_or_real, project_linear_to_dtype, promote_dtype_div_like,
 };
+use crate::ad::zeros::build_one_like;
 use crate::ad::PrimitiveRuleBuilder;
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
+use tidu::ADRuleResult;
 
 use crate::std_tensor_op::StdTensorOp;
 
@@ -80,10 +82,11 @@ fn emit_fixed_div(
 fn emit_one_like_fixed(
     builder: &mut dyn PrimitiveRuleBuilder,
     anchor: ValueRef<StdTensorOp>,
-) -> LocalValueId {
-    let neg = emit_fixed_neg(builder, anchor.clone());
-    let zero = emit_fixed_add(builder, anchor, ValueRef::Local(neg));
-    emit_fixed_unary(builder, StdTensorOp::Exp, ValueRef::Local(zero))
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<LocalValueId> {
+    let dtype = dtype_of_or_real(ctx, &anchor);
+    let rank = ctx.rank_of(&anchor)?;
+    Ok(build_one_like(builder, dtype, anchor, rank))
 }
 
 fn emit_linear_mul_fixed(
@@ -237,21 +240,22 @@ pub fn linearize_tanh(
     builder: &mut dyn PrimitiveRuleBuilder,
     primal_out: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
-) -> Vec<Option<LocalValueId>> {
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     match tangent_in[0] {
         Some(dx) => {
             let y = ValueRef::External(primal_out[0].clone());
             let y_sq = emit_fixed_mul(builder, y.clone(), y.clone());
-            let one = emit_one_like_fixed(builder, y);
+            let one = emit_one_like_fixed(builder, y, ctx)?;
             let neg_y_sq = emit_fixed_neg(builder, ValueRef::Local(y_sq));
             let coeff = emit_fixed_add(builder, ValueRef::Local(one), ValueRef::Local(neg_y_sq));
-            vec![Some(emit_linear_mul_fixed(
+            Ok(vec![Some(emit_linear_mul_fixed(
                 builder,
                 ValueRef::Local(coeff),
                 dx,
-            ))]
+            ))])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }
 
@@ -306,14 +310,14 @@ pub fn linearize_pow(
     primal_out: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let lhs_dtype = dtype_of_or_real(ctx, &ValueRef::External(primal_in[0].clone()));
     let rhs_dtype = dtype_of_or_real(ctx, &ValueRef::External(primal_in[1].clone()));
     let output_dtype = promote_dtype_div_like(lhs_dtype, rhs_dtype);
     let mut terms = Vec::with_capacity(2);
 
     if let Some(dx) = tangent_in[0] {
-        let one = emit_one_like_fixed(builder, ValueRef::External(primal_in[1].clone()));
+        let one = emit_one_like_fixed(builder, ValueRef::External(primal_in[1].clone()), ctx)?;
         let exponent_minus_one = emit_fixed_sub(
             builder,
             ValueRef::External(primal_in[1].clone()),
@@ -384,8 +388,8 @@ pub fn linearize_pow(
     }
 
     match terms.as_slice() {
-        [] => vec![None],
-        [only] => vec![Some(*only)],
+        [] => Ok(vec![None]),
+        [only] => Ok(vec![Some(*only)]),
         [lhs, rhs] => {
             let sum = builder.add_operation(
                 StdTensorOp::Add,
@@ -394,7 +398,7 @@ pub fn linearize_pow(
                     active_mask: vec![true, true],
                 },
             );
-            vec![Some(sum[0])]
+            Ok(vec![Some(sum[0])])
         }
         _ => unreachable!("pow linearization creates at most two terms"),
     }
@@ -404,19 +408,20 @@ pub fn linearize_expm1(
     builder: &mut dyn PrimitiveRuleBuilder,
     primal_out: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
-) -> Vec<Option<LocalValueId>> {
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     match tangent_in[0] {
         Some(dx) => {
             let y = ValueRef::External(primal_out[0].clone());
-            let one = emit_one_like_fixed(builder, y.clone());
+            let one = emit_one_like_fixed(builder, y.clone(), ctx)?;
             let coeff = emit_fixed_add(builder, y, ValueRef::Local(one));
-            vec![Some(emit_linear_mul_fixed(
+            Ok(vec![Some(emit_linear_mul_fixed(
                 builder,
                 ValueRef::Local(coeff),
                 dx,
-            ))]
+            ))])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }
 
@@ -424,19 +429,20 @@ pub fn linearize_log1p(
     builder: &mut dyn PrimitiveRuleBuilder,
     primal_in: &[ValueKey<StdTensorOp>],
     tangent_in: &[Option<LocalValueId>],
-) -> Vec<Option<LocalValueId>> {
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     match tangent_in[0] {
         Some(dx) => {
             let x = ValueRef::External(primal_in[0].clone());
-            let one = emit_one_like_fixed(builder, x.clone());
+            let one = emit_one_like_fixed(builder, x.clone(), ctx)?;
             let denom = emit_fixed_add(builder, x, ValueRef::Local(one));
-            vec![Some(emit_linear_div_fixed_denominator(
+            Ok(vec![Some(emit_linear_div_fixed_denominator(
                 builder,
                 dx,
                 ValueRef::Local(denom),
-            ))]
+            ))])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }
 
@@ -537,22 +543,22 @@ pub fn transpose_tanh(
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     if !unary_is_active(mode) {
-        return vec![None];
+        return Ok(vec![None]);
     }
     match cotangent_out[0] {
         Some(ct) => {
             let tanh_x = emit_fixed_unary(builder, StdTensorOp::Tanh, inputs[0].clone());
             let tanh_sq = emit_fixed_mul(builder, ValueRef::Local(tanh_x), ValueRef::Local(tanh_x));
-            let one = emit_one_like_fixed(builder, inputs[0].clone());
+            let one = emit_one_like_fixed(builder, inputs[0].clone(), ctx)?;
             let neg_tanh_sq = emit_fixed_neg(builder, ValueRef::Local(tanh_sq));
             let coeff = emit_fixed_add(builder, ValueRef::Local(one), ValueRef::Local(neg_tanh_sq));
             let coeff =
                 conjugate_for_unary_input_dtype(builder, ValueRef::Local(coeff), inputs, ctx);
-            vec![Some(emit_linear_mul_fixed(builder, coeff, ct))]
+            Ok(vec![Some(emit_linear_mul_fixed(builder, coeff, ct))])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }
 
@@ -620,15 +626,15 @@ pub fn transpose_pow(
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
-        None => return vec![None, None],
+        None => return Ok(vec![None, None]),
     };
 
     let active_mask = match mode {
         OperationRole::Linearized { active_mask } => active_mask,
-        OperationRole::Primary => return vec![None, None],
+        OperationRole::Primary => return Ok(vec![None, None]),
     };
 
     let lhs_dtype = dtype_of_or_real(ctx, &inputs[0]);
@@ -637,7 +643,7 @@ pub fn transpose_pow(
     let mut result = vec![None, None];
 
     if active_mask[0] {
-        let one = emit_one_like_fixed(builder, inputs[1].clone());
+        let one = emit_one_like_fixed(builder, inputs[1].clone(), ctx)?;
         let exponent_minus_one = emit_fixed_sub(builder, inputs[1].clone(), ValueRef::Local(one));
         let promoted_base =
             convert_fixed_ref_to_dtype(builder, inputs[0].clone(), lhs_dtype, output_dtype);
@@ -686,7 +692,7 @@ pub fn transpose_pow(
         ));
     }
 
-    result
+    Ok(result)
 }
 
 pub fn transpose_expm1(
@@ -716,13 +722,13 @@ pub fn transpose_log1p(
     inputs: &[ValueRef<StdTensorOp>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     if !unary_is_active(mode) {
-        return vec![None];
+        return Ok(vec![None]);
     }
     match cotangent_out[0] {
         Some(ct) => {
-            let one = emit_one_like_fixed(builder, inputs[0].clone());
+            let one = emit_one_like_fixed(builder, inputs[0].clone(), ctx)?;
             let denom = emit_fixed_add(builder, inputs[0].clone(), ValueRef::Local(one));
             let denominator =
                 conjugate_for_unary_input_dtype(builder, ValueRef::Local(denom), inputs, ctx);
@@ -733,8 +739,8 @@ pub fn transpose_log1p(
                     active_mask: vec![true, false],
                 },
             );
-            vec![Some(out[0])]
+            Ok(vec![Some(out[0])])
         }
-        None => vec![None],
+        None => Ok(vec![None]),
     }
 }

--- a/crates/tenferro-internal-ops/src/ad/contraction.rs
+++ b/crates/tenferro-internal-ops/src/ad/contraction.rs
@@ -7,7 +7,7 @@ use crate::ad::support::{
     conjugate_primal_if_complex, conjugate_primal_if_dtype_complex, convert_fixed_ref_to_dtype,
     convert_linear_to_dtype, dtype_of_or_real, project_linear_to_dtype, promote_dtype,
 };
-use crate::ad::zeros::build_zero_like;
+use crate::ad::zeros::{build_one_like, build_zero_like};
 use crate::ad::PrimitiveRuleBuilder;
 use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
@@ -712,66 +712,6 @@ fn reduce_prod_derivative_coeff(
         ],
         OperationRole::Primary,
     )[0]
-}
-
-fn build_one_like(
-    builder: &mut dyn PrimitiveRuleBuilder,
-    dtype: DType,
-    anchor: ValueRef<StdTensorOp>,
-    anchor_rank: usize,
-) -> LocalValueId {
-    build_scalar_like(builder, dtype, one_bytes(dtype), anchor, anchor_rank)
-}
-
-fn build_scalar_like(
-    builder: &mut dyn PrimitiveRuleBuilder,
-    dtype: DType,
-    bytes: Vec<u8>,
-    anchor: ValueRef<StdTensorOp>,
-    anchor_rank: usize,
-) -> LocalValueId {
-    let scalar = builder.add_operation(
-        StdTensorOp::Constant { dtype, bytes },
-        vec![],
-        OperationRole::Primary,
-    )[0];
-    if anchor_rank == 0 {
-        return scalar;
-    }
-
-    let shape: Vec<DimExpr> = (0..anchor_rank)
-        .map(|axis| DimExpr::InputDim { input_idx: 1, axis })
-        .collect();
-    builder.add_operation(
-        StdTensorOp::BroadcastInDim {
-            shape,
-            dims: vec![],
-        },
-        vec![ValueRef::Local(scalar), anchor],
-        OperationRole::Primary,
-    )[0]
-}
-
-fn one_bytes(dtype: DType) -> Vec<u8> {
-    match dtype {
-        DType::F32 => 1.0_f32.to_le_bytes().to_vec(),
-        DType::F64 => 1.0_f64.to_le_bytes().to_vec(),
-        DType::I32 => 1_i32.to_le_bytes().to_vec(),
-        DType::I64 => 1_i64.to_le_bytes().to_vec(),
-        DType::Bool => vec![1],
-        DType::C32 => {
-            let mut bytes = Vec::with_capacity(8);
-            bytes.extend_from_slice(&1.0_f32.to_le_bytes());
-            bytes.extend_from_slice(&0.0_f32.to_le_bytes());
-            bytes
-        }
-        DType::C64 => {
-            let mut bytes = Vec::with_capacity(16);
-            bytes.extend_from_slice(&1.0_f64.to_le_bytes());
-            bytes.extend_from_slice(&0.0_f64.to_le_bytes());
-            bytes
-        }
-    }
 }
 
 fn reduction_location_indicators(

--- a/crates/tenferro-internal-ops/src/ad/registry.rs
+++ b/crates/tenferro-internal-ops/src/ad/registry.rs
@@ -677,7 +677,16 @@ analytic_linearize!(linearize_exp, analytic::linearize_exp, primal_out);
 analytic_linearize!(linearize_log, analytic::linearize_log, primal_in);
 analytic_linearize!(linearize_sin, analytic::linearize_sin, primal_in);
 analytic_linearize!(linearize_cos, analytic::linearize_cos, primal_in);
-analytic_linearize!(linearize_tanh, analytic::linearize_tanh, primal_out);
+fn linearize_tanh(
+    _op: &StdTensorOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    analytic::linearize_tanh(builder, primal_out, tangent_in, ctx)
+}
 analytic_linearize!(linearize_sqrt, analytic::linearize_sqrt, primal_out);
 fn linearize_rsqrt(
     _op: &StdTensorOp,
@@ -699,12 +708,28 @@ fn linearize_pow(
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(analytic::linearize_pow(
-        builder, primal_in, primal_out, tangent_in, ctx,
-    ))
+    analytic::linearize_pow(builder, primal_in, primal_out, tangent_in, ctx)
 }
-analytic_linearize!(linearize_expm1, analytic::linearize_expm1, primal_out);
-analytic_linearize!(linearize_log1p, analytic::linearize_log1p, primal_in);
+fn linearize_expm1(
+    _op: &StdTensorOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    _primal_in: &[ValueKey<StdTensorOp>],
+    primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    analytic::linearize_expm1(builder, primal_out, tangent_in, ctx)
+}
+fn linearize_log1p(
+    _op: &StdTensorOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    primal_in: &[ValueKey<StdTensorOp>],
+    _primal_out: &[ValueKey<StdTensorOp>],
+    tangent_in: &[Option<LocalValueId>],
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    analytic::linearize_log1p(builder, primal_in, tangent_in, ctx)
+}
 
 macro_rules! analytic_transpose {
     ($name:ident, $callee:path) => {
@@ -725,12 +750,39 @@ analytic_transpose!(transpose_exp, analytic::transpose_exp);
 analytic_transpose!(transpose_log, analytic::transpose_log);
 analytic_transpose!(transpose_sin, analytic::transpose_sin);
 analytic_transpose!(transpose_cos, analytic::transpose_cos);
-analytic_transpose!(transpose_tanh, analytic::transpose_tanh);
+fn transpose_tanh(
+    _op: &StdTensorOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    analytic::transpose_tanh(builder, cotangent_out, inputs, mode, ctx)
+}
 analytic_transpose!(transpose_sqrt, analytic::transpose_sqrt);
 analytic_transpose!(transpose_rsqrt, analytic::transpose_rsqrt);
-analytic_transpose!(transpose_pow, analytic::transpose_pow);
+fn transpose_pow(
+    _op: &StdTensorOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    analytic::transpose_pow(builder, cotangent_out, inputs, mode, ctx)
+}
 analytic_transpose!(transpose_expm1, analytic::transpose_expm1);
-analytic_transpose!(transpose_log1p, analytic::transpose_log1p);
+fn transpose_log1p(
+    _op: &StdTensorOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    analytic::transpose_log1p(builder, cotangent_out, inputs, mode, ctx)
+}
 
 fn linearize_dot_general(
     op: &StdTensorOp,

--- a/crates/tenferro-internal-ops/src/ad/tests/elementwise_tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/elementwise_tests.rs
@@ -78,6 +78,59 @@ fn zero_like_covers_scalar_and_broadcasted_dtype_paths() {
 }
 
 #[test]
+fn one_like_uses_dtype_aware_constant_without_exp_shortcut() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let anchor = builder.add_input(tensor_input(1));
+
+    let scalar_one =
+        super::super::zeros::build_one_like(&mut builder, DType::I64, ValueRef::Local(anchor), 0);
+    let vector_one =
+        super::super::zeros::build_one_like(&mut builder, DType::F64, ValueRef::Local(anchor), 2);
+    let graph = builder.build();
+
+    assert!(
+        graph
+            .operations()
+            .iter()
+            .all(|op| op.operation != StdTensorOp::Exp),
+        "one-like seed helper must not synthesize constants through Exp"
+    );
+
+    let (scalar_op_id, _) = graph.values()[scalar_one]
+        .producer
+        .expect("scalar one must be produced by a constant op");
+    match graph.operations()[scalar_op_id].operation.clone() {
+        StdTensorOp::Constant { dtype, bytes } => {
+            assert_eq!(dtype, DType::I64);
+            assert_eq!(bytes, 1_i64.to_le_bytes().to_vec());
+        }
+        other => panic!("expected constant one, got {other:?}"),
+    }
+
+    let (broadcast_op_id, _) = graph.values()[vector_one]
+        .producer
+        .expect("ranked one must be produced by broadcast");
+    let op = &graph.operations()[broadcast_op_id];
+    assert_eq!(
+        op.operation,
+        StdTensorOp::BroadcastInDim {
+            shape: vec![
+                crate::dim_expr::DimExpr::InputDim {
+                    input_idx: 1,
+                    axis: 0
+                },
+                crate::dim_expr::DimExpr::InputDim {
+                    input_idx: 1,
+                    axis: 1
+                },
+            ],
+            dims: vec![],
+        }
+    );
+    assert_eq!(op.inputs[1], ValueRef::Local(anchor));
+}
+
+#[test]
 fn linearize_elementwise_inactive_inputs_return_none_without_ops() {
     let mut ctx = ShapeGuardContext::default();
     let keys = vec![input_key(1), input_key(2), input_key(3)];

--- a/crates/tenferro-internal-ops/src/ad/zeros.rs
+++ b/crates/tenferro-internal-ops/src/ad/zeros.rs
@@ -11,16 +11,32 @@ pub(super) fn build_zero_like(
     anchor: ValueRef<StdTensorOp>,
     anchor_rank: usize,
 ) -> LocalValueId {
-    let zero_scalar = builder.add_operation(
-        StdTensorOp::Constant {
-            dtype,
-            bytes: zero_bytes(dtype),
-        },
+    build_scalar_like(builder, dtype, zero_bytes(dtype), anchor, anchor_rank)
+}
+
+pub(super) fn build_one_like(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    dtype: DType,
+    anchor: ValueRef<StdTensorOp>,
+    anchor_rank: usize,
+) -> LocalValueId {
+    build_scalar_like(builder, dtype, one_bytes(dtype), anchor, anchor_rank)
+}
+
+fn build_scalar_like(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    dtype: DType,
+    bytes: Vec<u8>,
+    anchor: ValueRef<StdTensorOp>,
+    anchor_rank: usize,
+) -> LocalValueId {
+    let scalar = builder.add_operation(
+        StdTensorOp::Constant { dtype, bytes },
         vec![],
         OperationRole::Primary,
     )[0];
     if anchor_rank == 0 {
-        return zero_scalar;
+        return scalar;
     }
 
     let shape: Vec<DimExpr> = (0..anchor_rank)
@@ -31,7 +47,7 @@ pub(super) fn build_zero_like(
             shape,
             dims: vec![],
         },
-        vec![ValueRef::Local(zero_scalar), anchor],
+        vec![ValueRef::Local(scalar), anchor],
         OperationRole::Primary,
     );
     out[0]
@@ -53,6 +69,28 @@ fn zero_bytes(dtype: DType) -> Vec<u8> {
         DType::C64 => {
             let mut bytes = Vec::with_capacity(16);
             bytes.extend_from_slice(&0.0_f64.to_le_bytes());
+            bytes.extend_from_slice(&0.0_f64.to_le_bytes());
+            bytes
+        }
+    }
+}
+
+fn one_bytes(dtype: DType) -> Vec<u8> {
+    match dtype {
+        DType::F32 => 1.0_f32.to_le_bytes().to_vec(),
+        DType::F64 => 1.0_f64.to_le_bytes().to_vec(),
+        DType::I32 => 1_i32.to_le_bytes().to_vec(),
+        DType::I64 => 1_i64.to_le_bytes().to_vec(),
+        DType::Bool => vec![1],
+        DType::C32 => {
+            let mut bytes = Vec::with_capacity(8);
+            bytes.extend_from_slice(&1.0_f32.to_le_bytes());
+            bytes.extend_from_slice(&0.0_f32.to_le_bytes());
+            bytes
+        }
+        DType::C64 => {
+            let mut bytes = Vec::with_capacity(16);
+            bytes.extend_from_slice(&1.0_f64.to_le_bytes());
             bytes.extend_from_slice(&0.0_f64.to_le_bytes());
             bytes
         }

--- a/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
@@ -118,6 +118,9 @@ fn run_linearize_case(
     let mut ad_ctx = ShapeGuardContext::default();
     let primal_in = add_input_keys(&mut builder, 100, n_primal_in);
     let primal_out = add_input_keys(&mut builder, 200, n_primal_out);
+    for key in primal_in.iter().chain(primal_out.iter()) {
+        ad_ctx.insert_metadata(key.clone(), TensorMeta::exact(DType::F64, sym_shape(&[2])));
+    }
     if matches!(&op, StdTensorOp::DotGeneral { .. }) {
         seed_dot_general_input_metadata(&mut ad_ctx, &primal_in);
     }
@@ -172,6 +175,8 @@ fn run_transpose_case_with_input_shape(
         seed_dot_general_ref_metadata(&mut ad_ctx, &inputs);
     } else if let Some(shape) = input_shape {
         seed_uniform_ref_metadata(&mut ad_ctx, &inputs, shape);
+    } else {
+        seed_uniform_ref_metadata(&mut ad_ctx, &inputs, sym_shape(&[2]));
     }
     let result = op
         .transpose_rule(
@@ -957,6 +962,13 @@ fn test_std_tensor_op_analytic_linearize_emits_ops_for_remaining_variants() {
 
     let (tanh_result, tanh_graph) = run_linearize_case(StdTensorOp::Tanh, 0, 1, &[true]);
     assert!(tanh_result[0].is_some());
+    assert!(
+        tanh_graph
+            .operations()
+            .iter()
+            .all(|op| op.operation != StdTensorOp::Exp),
+        "tanh linearization should build its one-like coefficient from constants, not Exp"
+    );
     assert_eq!(
         tanh_graph.operations().last().unwrap().operation,
         StdTensorOp::Mul

--- a/crates/tenferro-tensor-core/src/layout.rs
+++ b/crates/tenferro-tensor-core/src/layout.rs
@@ -1,6 +1,6 @@
 use crate::{
-    checked_product, col_major_strides, validate_permutation, DynRank, Error, Result, ShapeVec,
-    SliceSpec, StrideVec, TensorRank,
+    checked_logical_element_count, checked_product, col_major_strides, validate_permutation,
+    DynRank, Error, Result, ShapeVec, SliceSpec, StrideVec, TensorRank,
 };
 use smallvec::SmallVec;
 use std::collections::HashSet;
@@ -221,6 +221,7 @@ impl<R: TensorRank> TensorLayout<R> {
         offset: isize,
         buffer_len: usize,
     ) -> Result<Self> {
+        checked_logical_element_count(shape.as_ref())?;
         validate_reachable_bounds(shape.as_ref(), strides.as_ref(), offset, buffer_len)?;
         Ok(Self {
             shape,

--- a/crates/tenferro-tensor-core/src/lib.rs
+++ b/crates/tenferro-tensor-core/src/lib.rs
@@ -375,6 +375,13 @@ fn checked_product(shape: &[usize]) -> Result<usize> {
     })
 }
 
+fn checked_logical_element_count(shape: &[usize]) -> Result<usize> {
+    if shape.contains(&0) {
+        return Ok(0);
+    }
+    checked_product(shape)
+}
+
 fn checked_shape_len(shape: &[usize], data_len: usize) -> Result<usize> {
     validate_shape_metadata(shape)?;
     let expected = checked_product(shape)?;
@@ -445,6 +452,7 @@ fn validate_view_bounds<T>(
     strides: &[isize],
     offset: isize,
 ) -> Result<()> {
+    checked_logical_element_count(shape)?;
     layout::validate_reachable_bounds(shape, strides, offset, data.len())
 }
 

--- a/crates/tenferro-tensor-core/tests/core.rs
+++ b/crates/tenferro-tensor-core/tests/core.rs
@@ -217,6 +217,19 @@ fn compact_layout_reports_stride_overflow() {
 }
 
 #[test]
+fn layout_rejects_non_empty_broadcast_shape_product_overflow() {
+    let huge_extent = usize::MAX / 2 + 1;
+    let err = TensorLayout::<DynRank>::from_parts(
+        vec![huge_extent, huge_extent].into(),
+        vec![0, 0].into(),
+        0,
+        1,
+    )
+    .unwrap_err();
+    assert!(matches!(err, Error::IntegerOverflow));
+}
+
+#[test]
 fn compact_host_tensor_view_reuses_checked_col_major_stride_helper() {
     let source = include_str!("../src/lib.rs");
     let helper = source
@@ -341,14 +354,11 @@ fn mutable_layout_rejects_large_ambiguous_layout_without_exact_fallback() {
 }
 
 #[test]
-fn mutable_layout_rejects_huge_non_empty_zero_stride_before_product_overflow() {
+fn layout_rejects_huge_non_empty_zero_stride_before_product_overflow() {
     let huge_extent = isize::MAX as usize + 1;
-    let layout =
-        TensorLayout::<DynRank>::from_parts(vec![huge_extent, 3].into(), vec![0, 1].into(), 0, 3)
-            .unwrap();
     assert!(matches!(
-        layout.validate_mutable_no_overlap(),
-        Err(Error::OverlappingMutableLayout)
+        TensorLayout::<DynRank>::from_parts(vec![huge_extent, 3].into(), vec![0, 1].into(), 0, 3),
+        Err(Error::IntegerOverflow)
     ));
 }
 

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -1498,6 +1498,18 @@ fn strided_tensor_view_validation_covers_error_edges() {
         Err(Error::InvalidConfig { .. })
     ));
     assert!(matches!(
+        TypedTensorView::<i32>::from_slice(
+            [usize::MAX / 2 + 1, usize::MAX / 2 + 1],
+            [0, 0],
+            0,
+            &[7],
+        ),
+        Err(Error::InvalidConfig { .. })
+    ));
+    let empty_after_large_prefix =
+        TypedTensorView::from_slice([2, usize::MAX, 0], [0, 0, 1], 0, &[7]).unwrap();
+    assert_eq!(empty_after_large_prefix.n_elements(), 0);
+    assert!(matches!(
         TypedTensorView::<i32>::from_slice([3], [isize::MAX], 0, &[]),
         Err(Error::InvalidConfig { .. })
     ));

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -2790,17 +2790,16 @@ fn tensor_layout_error(op: &'static str, err: tenferro_tensor_core::Error) -> cr
 }
 
 fn checked_view_element_count(shape: &[usize], op: &'static str) -> crate::Result<usize> {
+    if shape.contains(&0) {
+        return Ok(0);
+    }
     shape.iter().try_fold(1usize, |product, &dim| {
-        if dim == 0 {
-            Ok(0)
-        } else {
-            product
-                .checked_mul(dim)
-                .ok_or_else(|| crate::Error::InvalidConfig {
-                    op,
-                    message: format!("shape product overflows for shape {shape:?}"),
-                })
-        }
+        product
+            .checked_mul(dim)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op,
+                message: format!("shape product overflows for shape {shape:?}"),
+            })
     })
 }
 

--- a/docs/worklogs/2026-06-25-layout-overflow-ad-one-like.md
+++ b/docs/worklogs/2026-06-25-layout-overflow-ad-one-like.md
@@ -1,0 +1,61 @@
+# Layout Overflow And AD One-Like Fixes
+
+## Summary
+
+Fixes #1206 and #1207 in one related bug-fix batch. The changes reject
+non-empty logical tensor layouts whose shape product overflows, while preserving
+empty-view behavior, and replace the AD analytic one-like shortcut that built
+constant one through `Exp(0)`.
+
+## Context Read
+
+- GitHub issues #1206 and #1207
+- `REPOSITORY_RULES.md`
+- `crates/tenferro-tensor-core/src/lib.rs`
+- `crates/tenferro-tensor-core/src/layout.rs`
+- `crates/tenferro-tensor/src/types.rs`
+- `crates/tenferro-internal-ops/src/ad/analytic.rs`
+- `crates/tenferro-internal-ops/src/ad/zeros.rs`
+- `crates/tenferro-internal-ops/src/ad/contraction.rs`
+
+## Root Cause
+
+#1206 came from validating only reachable physical bounds in
+`TensorLayout::from_parts`. A non-empty broadcast layout with zero strides can
+touch only one buffer element while still having an overflowing logical element
+count, which made later `n_elements()` overflow paths reachable.
+
+#1207 came from `emit_one_like_fixed` constructing one as
+`Exp(anchor + -anchor)`. That made a constant seed depend on an analytic
+operation and on the anchor's arithmetic semantics, instead of using the
+existing graph constant and broadcast machinery.
+
+## Decision
+
+Add a shared tensor-core logical element-count helper for layout and host-view
+validation. The helper is zero-aware: any zero dimension means the logical count
+is zero, so empty views with large earlier dimensions remain valid.
+
+Move the existing contraction one-like constant builder into the shared AD
+zero-like helper module. Analytic AD rules now build dtype-aware scalar one
+constants and broadcast them to the anchor rank, matching the existing
+zero-like pattern and avoiding `Exp` as a constant shortcut.
+
+## Verification
+
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-tensor-core -p tenferro-tensor -p tenferro-internal-ops`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `/Users/hiroshi/.local/bin/python3.11 scripts/check-docs-site.py`
+
+## Residual Risk
+
+The default system `python3` on this machine is 3.9, while
+`scripts/check-docs-site.py` requires Python 3.11 or newer for guide dependency
+snippet parsing. The docs-site check passed with the local Python 3.11
+interpreter.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1206
Fixes #1207

## Summary

This fixes two repository-rule bug findings in one focused batch.

- #1206: reject non-empty layouts and typed views whose logical shape product overflows, even when zero strides make the reachable physical buffer range small. Empty shapes still produce zero logical elements, so empty views with large earlier dimensions remain valid.
- #1207: replace the analytic AD `Exp(0)` one-like shortcut with a dtype-aware `Constant` plus `BroadcastInDim` helper shared with the existing zero-like AD seed path.

## Work log

- `docs/worklogs/2026-06-25-layout-overflow-ad-one-like.md`

## Bug-fix scope

Bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md` was applied. Both findings are Auto Fix items under the remediation workflow: they enforce existing layout/AD contracts without new public APIs, dependencies, operation families, feature flags, or AD semantics.

Classification ledger:

- #1206: Auto Fix. Current source accepted non-empty broadcast layouts with overflowing logical element counts; fixed in tensor-core layout/view validation and mirrored at the typed tensor view boundary.
- #1207: Auto Fix. Current analytic AD seed construction used an analytic op to synthesize constant one; fixed by reusing graph constant/broadcast construction.

Same-root-cause scan:

- Checked tensor-core layout construction, host view validation, and typed tensor view validation around logical element-count calculation. The owning compact tensor shape-length path was left unchanged because it validates concrete storage length rather than metadata-only broadcast/view reachability.
- Checked the AD one-like helper in contraction rules and moved it into the shared AD seed helper module so analytic and contraction rules use the same constant/broadcast pattern.

## Verification

- `cargo fmt --all --check`
- `cargo test -p tenferro-tensor-core -p tenferro-tensor -p tenferro-internal-ops`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `/Users/hiroshi/.local/bin/python3.11 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json` -> pass, no findings

Note: the default system `python3` on this machine is 3.9, so `scripts/check-docs-site.py` was run with the local Python 3.11 interpreter required by that checker.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
