### PR TITLE
[codex] Harden issue 1209-1220 validation contracts

### DIFF
--- a/crates/tenferro-ad/src/ad_rule_error.rs
+++ b/crates/tenferro-ad/src/ad_rule_error.rs
@@ -1,0 +1,12 @@
+use tenferro_runtime::Error;
+use tidu::ADRuleError;
+
+pub(crate) fn ad_rule_error(transform: &'static str, err: ADRuleError) -> Error {
+    match err {
+        ADRuleError::Unsupported { op, .. } => Error::UnsupportedAdRule { transform, op },
+        ADRuleError::InvalidInput { op, message, .. } => Error::InvalidGraphBuild {
+            op: transform,
+            message: format!("{op}: {message}"),
+        },
+    }
+}

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -1447,8 +1447,8 @@ impl EagerTensor {
         let callback_error = callbacks.take_error();
         drop(callbacks);
         let cotangents = match (cotangents_result, callback_error) {
-            (_, Some(err)) => return Err(Error::Internal(err.to_string())),
-            (Err(err), None) => return Err(Error::Internal(err.to_string())),
+            (_, Some(err)) => return Err(crate::ad_rule_error::ad_rule_error("backward", err)),
+            (Err(err), None) => return Err(crate::ad_rule_error::ad_rule_error("backward", err)),
             (Ok(cotangents), None) => cotangents,
         };
         self.ctx.store_grads(&cotangents, &mut backend)?;

--- a/crates/tenferro-ad/src/lib.rs
+++ b/crates/tenferro-ad/src/lib.rs
@@ -29,6 +29,7 @@
 //! assert_eq!(dx.rank, 0);
 //! ```
 
+mod ad_rule_error;
 mod context;
 mod eager;
 mod eager_backend;

--- a/crates/tenferro-ad/src/shape_packing.rs
+++ b/crates/tenferro-ad/src/shape_packing.rs
@@ -4,8 +4,17 @@ use crate::eager::EagerTensor;
 use crate::error::{Error, Result};
 
 fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
-    let normalized = if axis < 0 { rank as isize + axis } else { axis };
-    if normalized < 0 || normalized >= rank as isize {
+    let normalized = if axis >= 0 {
+        axis as usize
+    } else {
+        rank.checked_sub(axis.unsigned_abs())
+            .ok_or(tenferro_tensor::Error::AxisOutOfBounds {
+                op,
+                axis: axis.unsigned_abs(),
+                rank,
+            })?
+    };
+    if normalized >= rank {
         return Err(tenferro_tensor::Error::AxisOutOfBounds {
             op,
             axis: axis.unsigned_abs(),
@@ -13,24 +22,37 @@ fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> Result
         }
         .into());
     }
-    Ok(normalized as usize)
+    Ok(normalized)
 }
 
 fn normalize_insert_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
-    let normalized = if axis < 0 {
-        rank as isize + 1 + axis
+    let insert_rank = rank
+        .checked_add(1)
+        .ok_or(tenferro_tensor::Error::AxisOutOfBounds {
+            op,
+            axis: axis.unsigned_abs(),
+            rank,
+        })?;
+    let normalized = if axis >= 0 {
+        axis as usize
     } else {
-        axis
+        insert_rank.checked_sub(axis.unsigned_abs()).ok_or(
+            tenferro_tensor::Error::AxisOutOfBounds {
+                op,
+                axis: axis.unsigned_abs(),
+                rank: insert_rank,
+            },
+        )?
     };
-    if normalized < 0 || normalized > rank as isize {
+    if normalized > rank {
         return Err(tenferro_tensor::Error::AxisOutOfBounds {
             op,
             axis: axis.unsigned_abs(),
-            rank: rank + 1,
+            rank: insert_rank,
         }
         .into());
     }
-    Ok(normalized as usize)
+    Ok(normalized)
 }
 
 fn index_select_config(
@@ -276,5 +298,24 @@ impl EagerTensor {
             .collect::<Result<Vec<_>>>()?;
         let refs = expanded.iter().collect::<Vec<_>>();
         Self::concatenate(&refs, axis)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_existing_axis, normalize_insert_axis};
+
+    #[test]
+    fn axis_normalization_handles_ranks_larger_than_isize_max() {
+        assert_eq!(normalize_existing_axis("test", 0, usize::MAX).unwrap(), 0);
+        assert_eq!(
+            normalize_existing_axis("test", -1, usize::MAX).unwrap(),
+            usize::MAX - 1
+        );
+        assert_eq!(
+            normalize_insert_axis("test", -1, usize::MAX - 1).unwrap(),
+            usize::MAX - 1
+        );
+        assert!(normalize_insert_axis("test", -1, usize::MAX).is_err());
     }
 }

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use crate::ad_rule_error::ad_rule_error;
 use computegraph::resolve::resolve;
 use computegraph::types::ValueKey;
 use tenferro_ops::input_key::TensorInputKey;
@@ -16,7 +17,7 @@ use tenferro_runtime::ad_support::{
 };
 use tenferro_runtime::{Error, GraphCompiler, GraphExecutor, Result, TracedTensor};
 use tenferro_tensor::TensorBackend;
-use tidu::{linear_transpose, linearize, ADRuleError};
+use tidu::{linear_transpose, linearize};
 
 static NEXT_DIFF_PASS_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -39,18 +40,6 @@ fn shape_guard_context(extension_rules: Option<&ExtensionRuleSet>) -> ShapeGuard
     match extension_rules {
         Some(rules) => ctx.with_extension_rules(rules.clone()),
         None => ctx,
-    }
-}
-
-fn ad_rule_error(transform: &'static str, err: ADRuleError) -> Error {
-    match err {
-        ADRuleError::Unsupported { op, .. } => {
-            Error::Internal(format!("unsupported {transform} AD rule for {op}"))
-        }
-        ADRuleError::InvalidInput { op, message, .. } => Error::InvalidGraphBuild {
-            op: transform,
-            message: format!("{op}: {message}"),
-        },
     }
 }
 
@@ -86,7 +75,7 @@ pub(crate) fn grad_optional_with_rules(
 
     let ones = ones_tensor(output.dtype, vec![])?;
     let seed = TracedTensor::from_tensor_concrete_shape(ones)?;
-    vjp_optional_impl(output, wrt, &seed, Some(extension_rules))
+    vjp_optional_impl(output, wrt, &seed, Some(extension_rules), "grad")
 }
 
 pub(crate) fn jvp_optional_with_rules(
@@ -105,7 +94,7 @@ pub(crate) fn vjp_with_rules(
     extension_rules: &ExtensionRuleSet,
 ) -> Result<TracedTensor> {
     let wrt_input_key = leaf_input_key(wrt)?;
-    vjp_optional_impl(output, wrt, cotangent, Some(extension_rules))?
+    vjp_optional_impl(output, wrt, cotangent, Some(extension_rules), "vjp")?
         .ok_or_else(|| Error::Internal(format!("vjp output is inactive for {:?}", wrt_input_key)))
 }
 
@@ -115,7 +104,7 @@ pub(crate) fn vjp_optional_with_rules(
     cotangent: &TracedTensor,
     extension_rules: &ExtensionRuleSet,
 ) -> Result<Option<TracedTensor>> {
-    vjp_optional_impl(output, wrt, cotangent, Some(extension_rules))
+    vjp_optional_impl(output, wrt, cotangent, Some(extension_rules), "vjp")
 }
 
 fn grad_with_optional_rules(
@@ -132,7 +121,7 @@ fn grad_with_optional_rules(
     let ones = ones_tensor(output.dtype, vec![])?;
     let seed = TracedTensor::from_tensor_concrete_shape(ones)?;
     let wrt_input_key = leaf_input_key(wrt)?;
-    vjp_optional_impl(output, wrt, &seed, extension_rules)?
+    vjp_optional_impl(output, wrt, &seed, extension_rules, "grad")?
         .ok_or_else(|| Error::Internal(format!("grad output is inactive for {:?}", wrt_input_key)))
 }
 
@@ -333,7 +322,7 @@ impl TracedTensorAdExt for TracedTensor {
 
         let ones = ones_tensor(self.dtype, vec![])?;
         let seed = TracedTensor::from_tensor_concrete_shape(ones)?;
-        vjp_optional_impl(self, wrt, &seed, None)
+        vjp_optional_impl(self, wrt, &seed, None, "grad")
     }
 
     fn checkpoint<B: TensorBackend>(
@@ -378,7 +367,7 @@ impl TracedTensorAdExt for TracedTensor {
         wrt: &TracedTensor,
         cotangent: &TracedTensor,
     ) -> Result<Option<TracedTensor>> {
-        vjp_optional_impl(self, wrt, cotangent, None)
+        vjp_optional_impl(self, wrt, cotangent, None, "vjp")
     }
 }
 
@@ -468,6 +457,7 @@ fn vjp_optional_impl(
     wrt: &TracedTensor,
     cotangent: &TracedTensor,
     extension_rules: Option<&ExtensionRuleSet>,
+    transform: &'static str,
 ) -> Result<Option<TracedTensor>> {
     let wrt_input_key = leaf_input_key(wrt)?;
     let output_key = output.graph().values()[output.val].key.clone();
@@ -492,7 +482,7 @@ fn vjp_optional_impl(
         &mut ad_ctx,
         &aliases,
     )
-    .map_err(|err| ad_rule_error("vjp", err))?;
+    .map_err(|err| ad_rule_error(transform, err))?;
     if linear.tangent_outputs()[0].is_none() {
         return Ok(None);
     }
@@ -506,7 +496,7 @@ fn vjp_optional_impl(
     )?;
     ad_ctx.refresh_global_metadata();
     let transposed =
-        linear_transpose(&linear, &mut ad_ctx).map_err(|err| ad_rule_error("vjp", err))?;
+        linear_transpose(&linear, &mut ad_ctx).map_err(|err| ad_rule_error(transform, err))?;
     let cotangent_input_key =
         linear_input_key(transposed.as_graph(), transposed.tangent_inputs()[0].1)?;
     let cotangent_data =

--- a/crates/tenferro-ad/tests/extension_op.rs
+++ b/crates/tenferro-ad/tests/extension_op.rs
@@ -33,7 +33,7 @@ use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeGuardContext, SymDim};
 use tenferro_runtime::extension::{apply, ExtensionExecutionContext, ExtensionRuntime};
-use tenferro_runtime::{GraphExecutor, Tensor, TracedTensor};
+use tenferro_runtime::{Error as RuntimeError, GraphExecutor, Tensor, TracedTensor};
 use tenferro_tensor::{DType, TensorBackend, TensorRead, TypedTensor};
 use tidu::ADRuleResult;
 
@@ -935,7 +935,13 @@ fn missing_extension_rule_errors_in_traced_grad() {
         Err(err) => err,
     };
 
-    assert!(err.to_string().contains("tenferro-tests.no_ad.v1"));
+    assert!(matches!(
+        err,
+        RuntimeError::UnsupportedAdRule {
+            transform: "grad",
+            ref op,
+        } if op == "tenferro-tests.no_ad.v1"
+    ));
 }
 
 #[test]
@@ -958,5 +964,11 @@ fn missing_extension_rule_errors_in_eager_backward() {
         .backward()
         .expect_err("missing extension AD rule should error");
 
-    assert!(err.to_string().contains("tenferro-tests.no_ad.v1"));
+    assert!(matches!(
+        err,
+        RuntimeError::UnsupportedAdRule {
+            transform: "backward",
+            ref op,
+        } if op == "tenferro-tests.no_ad.v1"
+    ));
 }

--- a/crates/tenferro-cpu/src/affinity.rs
+++ b/crates/tenferro-cpu/src/affinity.rs
@@ -133,8 +133,10 @@ fn platform_process_cpu_affinity_count() -> Option<usize> {
     }
 
     let mut group_count: Word = 0;
-    // SAFETY: Windows accepts a null group array to query the required group
-    // count; `group_count` is a live output variable.
+    // SAFETY: Windows accepts a null group array to query the required processor-group
+    // count. That probe is the expected failure path: `group_count` is a live output
+    // variable and a nonzero count after a failed call is the value needed for the
+    // second call below.
     let ok = unsafe {
         GetProcessGroupAffinity(
             process,

--- a/crates/tenferro-cpu/src/affinity/tests.rs
+++ b/crates/tenferro-cpu/src/affinity/tests.rs
@@ -40,3 +40,14 @@ fn available_parallelism_helpers_report_positive_counts() {
         assert!(count >= 1);
     }
 }
+
+#[test]
+fn windows_group_affinity_probe_documents_expected_failure_path() {
+    let source = include_str!("../affinity.rs");
+    assert!(
+        source.contains("expected failure path")
+            && source.contains("required processor-group")
+            && source.contains("count. That probe"),
+        "Windows GetProcessGroupAffinity null-array probe must document that failure with a count is expected"
+    );
+}

--- a/crates/tenferro-cpu/src/buffer_pool.rs
+++ b/crates/tenferro-cpu/src/buffer_pool.rs
@@ -675,6 +675,13 @@ impl BufferPool {
                 self.retained_capacity_bytes = 0;
                 return;
             };
+            if evicted_bytes == 0 {
+                if self.is_empty() {
+                    self.retained_capacity_bytes = 0;
+                    return;
+                }
+                continue;
+            }
             self.retained_capacity_bytes =
                 self.retained_capacity_bytes.saturating_sub(evicted_bytes);
         }

--- a/crates/tenferro-cpu/src/buffer_pool/tests.rs
+++ b/crates/tenferro-cpu/src/buffer_pool/tests.rs
@@ -195,3 +195,12 @@ fn zero_retention_limit_drops_released_buffers() {
     assert!(pool.is_empty());
     assert_eq!(pool.retained_capacity_bytes(), 0);
 }
+
+#[test]
+fn retention_limit_documents_zero_byte_eviction_progress() {
+    let source = include_str!("../buffer_pool.rs");
+    assert!(
+        source.contains("evicted_bytes == 0"),
+        "retention-limit eviction must explicitly handle zero-byte retained entries"
+    );
+}

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -157,7 +157,11 @@ impl CpuContext {
         }
     }
 
-    /// Return the faer parallelism policy for this context.
+    /// Return the faer parallelism policy for work run inside this context.
+    ///
+    /// `Par::rayon(0)` is intentional for multi-threaded contexts: faer reads
+    /// `rayon::current_num_threads()`, so calls made under [`Self::install`]
+    /// inherit this context's Rayon pool size.
     #[cfg(feature = "cpu-faer")]
     #[doc(hidden)]
     pub fn faer_par(&self) -> faer::Par {

--- a/crates/tenferro-cpu/src/gemm/tests.rs
+++ b/crates/tenferro-cpu/src/gemm/tests.rs
@@ -129,6 +129,32 @@ fn gemm_analysis_cache_keeps_direct_and_canonical_candidates_separate() {
 }
 
 #[test]
+fn canonical_gemm_layout_remains_behind_dot_general_validation() {
+    let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]).unwrap();
+    let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![0.0; 6]).unwrap();
+    let invalid = DotGeneralConfig {
+        lhs_contracting_dims: vec![2],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let mut cache = GemmAnalysisCache::default();
+
+    assert!(
+        analyse_gemm_cached(
+            &mut cache,
+            None,
+            GemmAnalysisCacheKind::Canonical,
+            &lhs,
+            &rhs,
+            &invalid,
+        )
+        .is_err(),
+        "canonical GEMM analysis must validate configs before canonicalizing layouts"
+    );
+}
+
+#[test]
 fn gemm_analysis_cache_reuses_matching_direct_plan_and_reports_stats() {
     let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]).unwrap();
     let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![0.0; 6]).unwrap();

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -949,14 +949,13 @@ fn typed_gather<T: Copy + Clone + PoolScalar>(
         }
     }
 
-    for (component, &operand_dim) in config.start_index_map.iter().enumerate() {
+    for &operand_dim in &config.start_index_map {
         let _ = clamp_window_start(
             "gather",
             0,
             operand_shape[operand_dim],
             config.slice_sizes[operand_dim],
         )?;
-        let _ = component;
     }
 
     // SAFETY: the gather loop below assigns every output coordinate exactly once.
@@ -1171,6 +1170,9 @@ where
         window_shape_updates[pos] = dim;
         window_shape[window_dims[pos]] = dim;
     }
+    for axis in 0..op_rank {
+        let _ = clamp_window_start("scatter", 0, operand_shape[axis], window_shape[axis])?;
+    }
 
     let batch_elems = checked_product("scatter", "batch shape", &batch_shape)?;
     let window_elems = checked_product("scatter", "window update shape", &window_shape_updates)?;
@@ -1184,7 +1186,6 @@ where
     let mut index_scratch = vec![0usize; scatter_indices.shape.len()];
 
     for _ in 0..batch_elems {
-        let mut window_fits = true;
         operand_base.fill(0);
         for (component, &operand_dim) in config.scatter_dims_to_operand_dims.iter().enumerate() {
             let start = index_component(
@@ -1201,21 +1202,6 @@ where
                 operand_shape[operand_dim],
                 window_shape[operand_dim],
             )?;
-        }
-        if !window_fits {
-            advance_col_major_index(&mut batch_idx, &batch_shape);
-            continue;
-        }
-
-        for axis in 0..op_rank {
-            if operand_base[axis] + window_shape[axis] > operand_shape[axis] {
-                window_fits = false;
-                break;
-            }
-        }
-        if !window_fits {
-            advance_col_major_index(&mut batch_idx, &batch_shape);
-            continue;
         }
 
         window_idx.fill(0);

--- a/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
@@ -158,6 +158,25 @@ fn cpu_context_faer_policy_is_seq_for_one_thread() {
     assert!(matches!(ctx.faer_par(), faer::Par::Seq));
 }
 
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn cpu_context_faer_policy_uses_current_context_pool_for_multithreaded_context() {
+    let ctx = CpuContext::with_threads(2).unwrap();
+    let par = ctx.install(|| ctx.faer_par());
+    assert_eq!(par.degree(), 2);
+}
+
+#[test]
+fn performance_notes_match_current_cpu_threading_contract() {
+    let notes = include_str!("../../../../../docs/performance/tt-inner-product-overhead.md");
+    assert!(
+        !notes.contains("The faer backend is therefore run without a tenferro-owned Rayon pool")
+            && !notes.contains("maps multi-threaded execution to `Par::rayon(n)`")
+            && !notes.contains("The global-Rayon columns became the production policy"),
+        "performance notes must describe CpuContext::install plus Par::rayon(0), not the stale global-Rayon policy"
+    );
+}
+
 #[test]
 fn cpu_context_with_threads_reports_requested_size() {
     let ctx = CpuContext::with_threads(2).unwrap();

--- a/crates/tenferro-cpu/tests/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/runtime_error_tests.rs
@@ -217,6 +217,15 @@ fn cpu_reshape_concatenate_scatter_use_checked_boundary_arithmetic_contract() {
 
     let scatter_section = source_section(indexing, "fn typed_scatter", "fn typed_dynamic_slice");
     assert!(
+        !source_section(indexing, "fn typed_gather", "fn typed_scatter")
+            .contains("let _ = component"),
+        "CPU gather validation should not need placeholder assignments for enumerated components"
+    );
+    assert!(
+        !scatter_section.contains("window_fits"),
+        "CPU scatter must not keep dead window-fit branches after clamp_window_start validation"
+    );
+    assert!(
         !scatter_section
             .contains("checked_product(\"scatter\", \"batch shape\", &batch_shape)?.max(1)"),
         "CPU scatter must not force a phantom iteration over zero-size batch domains"

--- a/crates/tenferro-einsum/src/extension.rs
+++ b/crates/tenferro-einsum/src/extension.rs
@@ -1360,26 +1360,8 @@ fn conjugate_primal_if_complex(
 fn promote_dtypes(dtypes: impl IntoIterator<Item = DType>) -> DType {
     dtypes
         .into_iter()
-        .reduce(promote_dtype)
+        .reduce(tenferro_tensor::validate::promote_dtype)
         .unwrap_or(DType::F64)
-}
-
-fn promote_dtype(lhs: DType, rhs: DType) -> DType {
-    use DType::*;
-    match (lhs, rhs) {
-        (Bool, Bool) => Bool,
-        (Bool, other) | (other, Bool) => other,
-        (I32, I32) => I32,
-        (I32, I64) | (I64, I32) | (I64, I64) => I64,
-        (I32 | I64, F32 | F64) | (F32 | F64, I32 | I64) => F64,
-        (I32 | I64, C32 | C64) | (C32 | C64, I32 | I64) => C64,
-        (F32, F32) => F32,
-        (F32, F64) | (F64, F32) | (F64, F64) => F64,
-        (F32, C32) | (C32, F32) | (C32, C32) => C32,
-        (F32, C64) | (C64, F32) => C64,
-        (F64, C32 | C64) | (C32 | C64, F64) => C64,
-        (C32, C64) | (C64, C32) | (C64, C64) => C64,
-    }
 }
 
 #[cfg(test)]

--- a/crates/tenferro-einsum/src/extension/tests.rs
+++ b/crates/tenferro-einsum/src/extension/tests.rs
@@ -26,6 +26,34 @@ fn infer_output_meta_uses_output_labels_and_promotes_dtype() {
 }
 
 #[test]
+fn extension_dtype_promotion_delegates_to_canonical_tensor_rules() {
+    let source = include_str!("../extension.rs");
+    assert!(
+        !source.contains("fn promote_dtype("),
+        "einsum extension metadata must not duplicate the canonical dtype promotion lattice"
+    );
+
+    let dtypes = [
+        DType::Bool,
+        DType::I32,
+        DType::I64,
+        DType::F32,
+        DType::F64,
+        DType::C32,
+        DType::C64,
+    ];
+    for lhs in dtypes {
+        for rhs in dtypes {
+            assert_eq!(
+                promote_dtypes([lhs, rhs]),
+                tenferro_tensor::validate::promote_dtype(lhs, rhs),
+                "promotion mismatch for {lhs:?}, {rhs:?}"
+            );
+        }
+    }
+}
+
+#[test]
 fn infer_output_meta_returns_error_for_invalid_extension_metadata() {
     let op = EinsumExtensionOp::new(EinsumSubscripts::new(&[&[0, 1], &[1, 2]], &[0, 2]));
     let lhs_shape = [SymDim::from(2usize), SymDim::from(3usize)];

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -703,15 +703,23 @@ fn normalize_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
     if rank == 0 {
         return Err(fft_config_error(op, "tenferro-fft requires rank >= 1"));
     }
-    let rank_isize = rank as isize;
-    let normalized = if axis < 0 { rank_isize + axis } else { axis };
-    if normalized < 0 || normalized >= rank_isize {
+    let normalized = if axis >= 0 {
+        axis as usize
+    } else {
+        rank.checked_sub(axis.unsigned_abs()).ok_or_else(|| {
+            fft_config_error(
+                op,
+                format!("tenferro-fft axis {axis} out of bounds for rank {rank}"),
+            )
+        })?
+    };
+    if normalized >= rank {
         return Err(fft_config_error(
             op,
             format!("tenferro-fft axis {axis} out of bounds for rank {rank}"),
         ));
     }
-    Ok(normalized as usize)
+    Ok(normalized)
 }
 
 fn validate_n(op: &'static str, n: Option<usize>) -> Result<()> {
@@ -1216,6 +1224,16 @@ mod tests {
             .expect_err("default irfft output length should reject overflow");
 
         assert!(err.to_string().contains("overflows usize"), "{err}");
+    }
+
+    #[test]
+    fn normalize_axis_handles_large_rank_without_isize_cast_wrap() {
+        assert_eq!(normalize_axis("fft", 0, usize::MAX).unwrap(), 0);
+        assert_eq!(
+            normalize_axis("fft", -1, usize::MAX).unwrap(),
+            usize::MAX - 1
+        );
+        assert!(normalize_axis("fft", isize::MIN, 3).is_err());
     }
 
     #[test]

--- a/crates/tenferro-internal-ops/src/ad/dynamic.rs
+++ b/crates/tenferro-internal-ops/src/ad/dynamic.rs
@@ -1,5 +1,6 @@
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::SliceConfig;
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::PrimitiveRuleBuilder;
@@ -103,23 +104,28 @@ pub fn transpose_pad_to_match(
     mode: &OperationRole,
     axis: usize,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(ct) = cotangent_out[0] else {
-        return vec![None, None];
+        return Ok(vec![None, None]);
     };
     if !first_input_active(mode) {
-        return vec![None, None];
+        return Ok(vec![None, None]);
     }
 
     // For concrete input metadata the adjoint is just a prefix slice back to
     // the original input shape. This keeps the transposed graph statically
     // shape-exact across checkpoint aliases.
     if let Some(input_shape) = ctx.shape_if_available(&inputs[0]) {
-        assert!(
-            axis < input_shape.len(),
-            "transpose_pad_to_match: axis {axis} out of bounds for rank {}",
-            input_shape.len()
-        );
+        if axis >= input_shape.len() {
+            return Err(ADRuleError::invalid_input(
+                "PadToMatch",
+                ADRuleKind::Transpose,
+                format!(
+                    "axis {axis} out of bounds for input rank {}",
+                    input_shape.len()
+                ),
+            ));
+        }
         if let Some(limits) = input_shape
             .iter()
             .map(|dim| dim.constant_value())
@@ -137,7 +143,7 @@ pub fn transpose_pad_to_match(
                     active_mask: vec![true],
                 },
             );
-            return vec![Some(out[0]), None];
+            return Ok(vec![Some(out[0]), None]);
         }
     }
 
@@ -155,7 +161,7 @@ pub fn transpose_pad_to_match(
             active_mask: vec![true, false],
         },
     );
-    vec![Some(out[0]), None]
+    Ok(vec![Some(out[0]), None])
 }
 
 fn first_input_active(mode: &OperationRole) -> bool {

--- a/crates/tenferro-internal-ops/src/ad/registry.rs
+++ b/crates/tenferro-internal-ops/src/ad/registry.rs
@@ -1492,14 +1492,7 @@ fn transpose_pad_to_match(
         ADRuleKind::Transpose,
         StdTensorOp::PadToMatch { axis } => axis
     );
-    Ok(dynamic::transpose_pad_to_match(
-        builder,
-        cotangent_out,
-        inputs,
-        mode,
-        *axis,
-        ctx,
-    ))
+    dynamic::transpose_pad_to_match(builder, cotangent_out, inputs, mode, *axis, ctx)
 }
 
 fn linearize_constant(

--- a/crates/tenferro-internal-ops/src/ad/support.rs
+++ b/crates/tenferro-internal-ops/src/ad/support.rs
@@ -180,21 +180,7 @@ fn is_complex_dtype(dtype: DType) -> bool {
 }
 
 pub(crate) fn promote_dtype(lhs: DType, rhs: DType) -> DType {
-    use DType::*;
-    match (lhs, rhs) {
-        (Bool, Bool) => Bool,
-        (Bool, other) | (other, Bool) => other,
-        (I32, I32) => I32,
-        (I32, I64) | (I64, I32) | (I64, I64) => I64,
-        (I32 | I64, F32 | F64) | (F32 | F64, I32 | I64) => F64,
-        (I32 | I64, C32 | C64) | (C32 | C64, I32 | I64) => C64,
-        (F32, F32) => F32,
-        (F32, F64) | (F64, F32) | (F64, F64) => F64,
-        (F32, C32) | (C32, F32) | (C32, C32) => C32,
-        (F32, C64) | (C64, F32) => C64,
-        (F64, C32 | C64) | (C32 | C64, F64) => C64,
-        (C32, C64) | (C64, C32) | (C64, C64) => C64,
-    }
+    tenferro_tensor::validate::promote_dtype(lhs, rhs)
 }
 
 pub(crate) fn promote_dtype_div_like(lhs: DType, rhs: DType) -> DType {

--- a/crates/tenferro-internal-ops/src/ad/support/tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/support/tests.rs
@@ -53,3 +53,31 @@ fn promote_dtype_covers_supported_pairs_without_runtime_unreachable() {
     assert_eq!(promote_dtype(DType::F64, DType::C32), DType::C64);
     assert_eq!(promote_dtype(DType::C32, DType::C64), DType::C64);
 }
+
+#[test]
+fn promote_dtype_delegates_to_canonical_tensor_validation_rules() {
+    let source = include_str!("../support.rs");
+    assert!(
+        source.contains("tenferro_tensor::validate::promote_dtype"),
+        "AD support must delegate to the canonical tensor dtype promotion lattice"
+    );
+
+    let dtypes = [
+        DType::Bool,
+        DType::I32,
+        DType::I64,
+        DType::F32,
+        DType::F64,
+        DType::C32,
+        DType::C64,
+    ];
+    for lhs in dtypes {
+        for rhs in dtypes {
+            assert_eq!(
+                promote_dtype(lhs, rhs),
+                tenferro_tensor::validate::promote_dtype(lhs, rhs),
+                "promotion mismatch for {lhs:?}, {rhs:?}"
+            );
+        }
+    }
+}

--- a/crates/tenferro-internal-ops/src/ad/tests/structural_tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/structural_tests.rs
@@ -9,6 +9,7 @@ use crate::dim_expr::DimExpr;
 use crate::input_key::TensorInputKey;
 use crate::std_tensor_op::StdTensorOp;
 use crate::{ShapeExtent, SymDim, TensorMeta};
+use tidu::ADRuleError;
 
 fn tensor_input(id: u64) -> TensorInputKey {
     TensorInputKey::User { id }
@@ -178,6 +179,35 @@ fn transpose_reshape_accepts_upper_bound_input_metadata() {
             active_mask: vec![true, false],
         }
     );
+}
+
+#[test]
+fn transpose_pad_to_match_rejects_axis_outside_input_metadata() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let mut ctx = ShapeGuardContext::default();
+    let cotangent = builder.add_input(tensor_input(18));
+    let input = input_key(19);
+    let reference = input_key(20);
+    ctx.insert_metadata(input.clone(), meta(&[3]));
+
+    let err = StdTensorOp::PadToMatch { axis: 1 }
+        .transpose_rule(
+            &mut builder,
+            &[Some(cotangent)],
+            &[ValueRef::External(input), ValueRef::External(reference)],
+            &linear_mode(&[true, false]),
+            &mut ctx,
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ADRuleError::InvalidInput {
+            ref op,
+            ref message,
+            ..
+        } if op == "PadToMatch" && message.contains("axis 1")
+    ));
 }
 
 #[test]

--- a/crates/tenferro-internal-ops/src/axis.rs
+++ b/crates/tenferro-internal-ops/src/axis.rs
@@ -22,12 +22,16 @@ pub enum AxisError {
 /// assert!(normalize_axis(3, 3).is_err());
 /// ```
 pub fn normalize_axis(axis: isize, rank: usize) -> Result<usize, AxisError> {
-    let rank_i = rank as isize;
-    let normalized = if axis < 0 { rank_i + axis } else { axis };
-    if normalized < 0 || normalized >= rank_i {
+    let normalized = if axis >= 0 {
+        axis as usize
+    } else {
+        rank.checked_sub(axis.unsigned_abs())
+            .ok_or(AxisError::OutOfBounds { axis, rank })?
+    };
+    if normalized >= rank {
         return Err(AxisError::OutOfBounds { axis, rank });
     }
-    Ok(normalized as usize)
+    Ok(normalized)
 }
 
 /// Normalize a list of possibly-negative axes and reject duplicates.

--- a/crates/tenferro-internal-ops/src/tests/normalization_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/normalization_tests.rs
@@ -39,8 +39,11 @@ fn normalize_axis_accepts_negative_axes_and_rejects_out_of_bounds() {
     assert_eq!(normalize_axis(0, 3).unwrap(), 0);
     assert_eq!(normalize_axis(-1, 3).unwrap(), 2);
     assert_eq!(normalize_axis(-3, 3).unwrap(), 0);
+    assert_eq!(normalize_axis(0, usize::MAX).unwrap(), 0);
+    assert_eq!(normalize_axis(-1, usize::MAX).unwrap(), usize::MAX - 1);
     assert!(normalize_axis(3, 3).is_err());
     assert!(normalize_axis(-4, 3).is_err());
+    assert!(normalize_axis(isize::MIN, 3).is_err());
 }
 
 #[test]

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -581,26 +581,8 @@ fn promote_dtypes(dtypes: &[DType]) -> DType {
     dtypes
         .iter()
         .copied()
-        .reduce(promote_dtype)
+        .reduce(tenferro_tensor::validate::promote_dtype)
         .unwrap_or(DType::F64)
-}
-
-fn promote_dtype(lhs: DType, rhs: DType) -> DType {
-    use DType::*;
-    match (lhs, rhs) {
-        (Bool, Bool) => Bool,
-        (Bool, other) | (other, Bool) => other,
-        (I32, I32) => I32,
-        (I32, I64) | (I64, I32) | (I64, I64) => I64,
-        (I32 | I64, F32 | F64) | (F32 | F64, I32 | I64) => F64,
-        (I32 | I64, C32 | C64) | (C32 | C64, I32 | I64) => C64,
-        (F32, F32) => F32,
-        (F32, F64) | (F64, F32) | (F64, F64) => F64,
-        (F32, C32) | (C32, F32) | (C32, C32) => C32,
-        (F32, C64) | (C64, F32) => C64,
-        (F64, C32 | C64) | (C32 | C64, F64) => C64,
-        (C32, C64) | (C64, C32) | (C64, C64) => C64,
-    }
 }
 
 fn hash_dtype(hasher: &mut dyn Hasher, dtype: DType) {

--- a/crates/tenferro-linalg/src/extension/tests.rs
+++ b/crates/tenferro-linalg/src/extension/tests.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 
 use tenferro_runtime::extension::ExtensionOp;
 use tenferro_tensor::{
-    Buffer, BufferHandle, DeviceId, DeviceKind, Error, GpuBackendKind, MemoryKind, Placement,
-    Tensor, TypedTensor,
+    Buffer, BufferHandle, DType, DeviceId, DeviceKind, Error, GpuBackendKind, MemoryKind,
+    Placement, Tensor, TypedTensor,
 };
 
-use super::{LinalgExtensionOp, LinalgOp};
+use super::{promote_dtypes, LinalgExtensionOp, LinalgOp};
 
 #[test]
 fn eager_linalg_rejects_cuda_tensor_when_cuda_feature_is_disabled() {
@@ -51,4 +51,32 @@ fn infer_output_meta_returns_error_on_input_count_mismatch() {
             ..
         }
     ));
+}
+
+#[test]
+fn extension_dtype_promotion_delegates_to_canonical_tensor_rules() {
+    let source = include_str!("../extension.rs");
+    assert!(
+        !source.contains("fn promote_dtype("),
+        "linalg extension metadata must not duplicate the canonical dtype promotion lattice"
+    );
+
+    let dtypes = [
+        DType::Bool,
+        DType::I32,
+        DType::I64,
+        DType::F32,
+        DType::F64,
+        DType::C32,
+        DType::C64,
+    ];
+    for lhs in dtypes {
+        for rhs in dtypes {
+            assert_eq!(
+                promote_dtypes(&[lhs, rhs]),
+                tenferro_tensor::validate::promote_dtype(lhs, rhs),
+                "promotion mismatch for {lhs:?}, {rhs:?}"
+            );
+        }
+    }
 }

--- a/crates/tenferro-runtime/src/error.rs
+++ b/crates/tenferro-runtime/src/error.rs
@@ -102,6 +102,16 @@ pub enum Error {
         message: String,
     },
 
+    /// An AD transform requires a primitive or extension rule that is not
+    /// registered for the requested operation.
+    #[error("unsupported {transform} AD rule for {op}")]
+    UnsupportedAdRule {
+        /// AD transform that requested the rule, such as `grad` or `backward`.
+        transform: &'static str,
+        /// Operation or extension family identifier that has no applicable rule.
+        op: String,
+    },
+
     /// Lowering rejected an inconsistent compiled graph.
     #[error("invalid compiled graph: {message}")]
     InvalidCompiledGraph {

--- a/crates/tenferro-runtime/src/shape_packing.rs
+++ b/crates/tenferro-runtime/src/shape_packing.rs
@@ -18,8 +18,17 @@ use crate::traced::{
 use crate::TracedTensor;
 
 fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
-    let normalized = if axis < 0 { rank as isize + axis } else { axis };
-    if normalized < 0 || normalized >= rank as isize {
+    let normalized = if axis >= 0 {
+        axis as usize
+    } else {
+        rank.checked_sub(axis.unsigned_abs())
+            .ok_or(tenferro_tensor::Error::AxisOutOfBounds {
+                op,
+                axis: axis.unsigned_abs(),
+                rank,
+            })?
+    };
+    if normalized >= rank {
         return Err(tenferro_tensor::Error::AxisOutOfBounds {
             op,
             axis: axis.unsigned_abs(),
@@ -27,24 +36,37 @@ fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> Result
         }
         .into());
     }
-    Ok(normalized as usize)
+    Ok(normalized)
 }
 
 fn normalize_insert_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
-    let normalized = if axis < 0 {
-        rank as isize + 1 + axis
+    let insert_rank = rank
+        .checked_add(1)
+        .ok_or(tenferro_tensor::Error::AxisOutOfBounds {
+            op,
+            axis: axis.unsigned_abs(),
+            rank,
+        })?;
+    let normalized = if axis >= 0 {
+        axis as usize
     } else {
-        axis
+        insert_rank.checked_sub(axis.unsigned_abs()).ok_or(
+            tenferro_tensor::Error::AxisOutOfBounds {
+                op,
+                axis: axis.unsigned_abs(),
+                rank: insert_rank,
+            },
+        )?
     };
-    if normalized < 0 || normalized > rank as isize {
+    if normalized > rank {
         return Err(tenferro_tensor::Error::AxisOutOfBounds {
             op,
             axis: axis.unsigned_abs(),
-            rank: rank + 1,
+            rank: insert_rank,
         }
         .into());
     }
-    Ok(normalized as usize)
+    Ok(normalized)
 }
 
 fn index_select_config(
@@ -334,5 +356,24 @@ fn apply_nary_concatenate(
         extra_roots,
         checkpoint_chain,
         metadata_scopes: metadata_scopes_with_new(metadata_scope, inherited_scopes),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_existing_axis, normalize_insert_axis};
+
+    #[test]
+    fn axis_normalization_handles_ranks_larger_than_isize_max() {
+        assert_eq!(normalize_existing_axis("test", 0, usize::MAX).unwrap(), 0);
+        assert_eq!(
+            normalize_existing_axis("test", -1, usize::MAX).unwrap(),
+            usize::MAX - 1
+        );
+        assert_eq!(
+            normalize_insert_axis("test", -1, usize::MAX - 1).unwrap(),
+            usize::MAX - 1
+        );
+        assert!(normalize_insert_axis("test", -1, usize::MAX).is_err());
     }
 }

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -1785,3 +1785,16 @@ fn runtime_error_formats_include_op_name() {
 
     assert!(err.to_string().contains("dot_general"));
 }
+
+#[test]
+fn n_elements_invariant_checks_do_not_use_unsafe_unreachable() {
+    let source = include_str!("../types.rs");
+    assert!(
+        !source.contains("unreachable_unchecked"),
+        "n_elements invariant checks must never use unsafe unreachable_unchecked"
+    );
+    assert!(
+        source.contains("TypedTensor compact shape is validated at construction"),
+        "n_elements panic path should document the constructor-validation invariant"
+    );
+}

--- a/crates/tenferro-tensor/src/types/accessors.rs
+++ b/crates/tenferro-tensor/src/types/accessors.rs
@@ -12,10 +12,23 @@ fn linear_offset_unchecked(shape: &[usize], indices: &[usize]) -> usize {
     let mut offset = 0usize;
     let mut stride = 1usize;
     for (&idx, &extent) in indices.iter().zip(shape) {
-        offset = offset.wrapping_add(idx.wrapping_mul(stride));
-        stride = stride.wrapping_mul(extent);
+        let term = idx
+            .checked_mul(stride)
+            .unwrap_or_else(|| linear_offset_invariant_violation(shape));
+        offset = offset
+            .checked_add(term)
+            .unwrap_or_else(|| linear_offset_invariant_violation(shape));
+        stride = stride
+            .checked_mul(extent)
+            .unwrap_or_else(|| linear_offset_invariant_violation(shape));
     }
     offset
+}
+
+#[cold]
+#[track_caller]
+fn linear_offset_invariant_violation(shape: &[usize]) -> ! {
+    panic!("linear offset overflow for validated tensor shape {shape:?}");
 }
 
 impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
@@ -432,6 +445,9 @@ mod tests {
         let shape = [usize::MAX, 3];
 
         assert!(try_linear_offset_for_shape(&shape, &[0, 2], "test").is_err());
-        assert!(std::panic::catch_unwind(|| linear_offset_unchecked(&shape, &[0, 2])).is_ok());
+        assert!(
+            std::panic::catch_unwind(|| linear_offset_unchecked(&shape, &[0, 2])).is_err(),
+            "unchecked offset helper must not silently wrap when its shape invariant is violated"
+        );
     }
 }

--- a/crates/tenferro-tensor/src/types/shape_packing.rs
+++ b/crates/tenferro-tensor/src/types/shape_packing.rs
@@ -3,31 +3,51 @@ use crate::{GatherConfig, TensorBackend};
 use super::{Tensor, TypedTensor};
 
 fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> crate::Result<usize> {
-    let normalized = if axis < 0 { rank as isize + axis } else { axis };
-    if normalized < 0 || normalized >= rank as isize {
+    let normalized = if axis >= 0 {
+        axis as usize
+    } else {
+        rank.checked_sub(axis.unsigned_abs())
+            .ok_or(crate::Error::AxisOutOfBounds {
+                op,
+                axis: axis.unsigned_abs(),
+                rank,
+            })?
+    };
+    if normalized >= rank {
         return Err(crate::Error::AxisOutOfBounds {
             op,
             axis: axis.unsigned_abs(),
             rank,
         });
     }
-    Ok(normalized as usize)
+    Ok(normalized)
 }
 
 fn normalize_insert_axis(op: &'static str, axis: isize, rank: usize) -> crate::Result<usize> {
-    let normalized = if axis < 0 {
-        rank as isize + 1 + axis
+    let insert_rank = rank.checked_add(1).ok_or(crate::Error::AxisOutOfBounds {
+        op,
+        axis: axis.unsigned_abs(),
+        rank,
+    })?;
+    let normalized = if axis >= 0 {
+        axis as usize
     } else {
-        axis
+        insert_rank
+            .checked_sub(axis.unsigned_abs())
+            .ok_or(crate::Error::AxisOutOfBounds {
+                op,
+                axis: axis.unsigned_abs(),
+                rank: insert_rank,
+            })?
     };
-    if normalized < 0 || normalized > rank as isize {
+    if normalized > rank {
         return Err(crate::Error::AxisOutOfBounds {
             op,
             axis: axis.unsigned_abs(),
-            rank: rank + 1,
+            rank: insert_rank,
         });
     }
-    Ok(normalized as usize)
+    Ok(normalized)
 }
 
 fn index_select_parts(
@@ -152,5 +172,24 @@ impl Tensor {
             let refs = expanded.iter().collect::<Vec<_>>();
             exec.concatenate(&refs, axis)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_existing_axis, normalize_insert_axis};
+
+    #[test]
+    fn axis_normalization_handles_ranks_larger_than_isize_max() {
+        assert_eq!(normalize_existing_axis("test", 0, usize::MAX).unwrap(), 0);
+        assert_eq!(
+            normalize_existing_axis("test", -1, usize::MAX).unwrap(),
+            usize::MAX - 1
+        );
+        assert_eq!(
+            normalize_insert_axis("test", -1, usize::MAX - 1).unwrap(),
+            usize::MAX - 1
+        );
+        assert!(normalize_insert_axis("test", -1, usize::MAX).is_err());
     }
 }

--- a/crates/tenferro-tensor/src/validate/mod.rs
+++ b/crates/tenferro-tensor/src/validate/mod.rs
@@ -289,9 +289,8 @@ pub fn check_singular_diagonal<T: DiagSingularity + Copy + std::fmt::Debug>(
     let rows = t.shape()[0];
     let cols = t.shape()[1];
     let n = rows.min(cols);
-    let batch_total: usize = t.shape()[2..].iter().product();
-    let batch_total = batch_total.max(1);
-    let slice_size = rows * cols;
+    let batch_total = checked_shape_product("solve", "batch shape", &t.shape()[2..])?;
+    let slice_size = checked_shape_product("solve", "matrix shape", &t.shape()[..2])?;
     let data = t.host_data()?;
     for batch_idx in 0..batch_total {
         let batch = &data[batch_idx * slice_size..(batch_idx + 1) * slice_size];

--- a/crates/tenferro-tensor/src/validate/tests.rs
+++ b/crates/tenferro-tensor/src/validate/tests.rs
@@ -410,6 +410,16 @@ fn f64_batched_error_includes_batch_index_and_position() {
 }
 
 #[test]
+fn singular_diagonal_uses_checked_shape_products_before_indexing() {
+    let source = include_str!("mod.rs");
+    assert!(
+        !source.contains("t.shape()[2..].iter().product()")
+            && !source.contains("let slice_size = rows * cols"),
+        "singular diagonal validation must not use unchecked shape products before indexing"
+    );
+}
+
+#[test]
 fn f64_unbatched_error_omits_batch_index_and_includes_position() {
     let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]).unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();

--- a/docs/performance/tt-inner-product-overhead.md
+++ b/docs/performance/tt-inner-product-overhead.md
@@ -235,15 +235,17 @@ pub enum Parallelism {
 }
 ```
 
-Both APIs describe the requested thread count, not the thread pool that must run
-the work. faer and spindle rely on the current or global Rayon context through
+Both APIs describe the requested thread count, not a thread-pool handle. faer
+and spindle rely on the current or global Rayon context through
 `rayon::current_num_threads`, `rayon::scope`, `into_par_iter`, and
 `spindle::for_each`.
 
-The faer backend is therefore run without a tenferro-owned Rayon pool.
+The current faer backend runs GEMM work inside `CpuContext::install`.
 `CpuContext` stores the requested thread count, maps one thread to `Par::Seq`,
-and maps multi-threaded execution to `Par::rayon(n)`. faer/rayon then uses the
-current or global Rayon pool directly.
+and maps multi-threaded execution to `Par::rayon(0)` while executing inside the
+context-owned Rayon pool. faer expands `Par::rayon(0)` through
+`rayon::current_num_threads()`, so `CpuContext::with_threads(n)` still controls
+the faer parallelism degree for work run under the context.
 
 The benchmark below is cached `site_update`, `Complex64`, `d = 2`, with all
 known BLAS/OpenMP thread pools set to one thread. Times are Criterion means in
@@ -265,16 +267,16 @@ increasing faer thread count does not help; it usually adds parallel dispatch
 overhead. The important optimization is removing per-GEMM `install`, not making
 each tiny GEMM parallel.
 
-The global-Rayon columns became the production policy. This removes the pool
-entry cost, but it also means `CpuContext` no longer provides pool isolation or
-affinity. Its `num_threads` value is a faer parallelism hint rather than a
-private worker-pool size.
+The production policy keeps `CpuContext` as the owner of CPU execution scope.
+This preserves pool isolation for backends that enter through
+`CpuContext::install`; within that scope, faer uses `Par::rayon(0)` to read the
+current context pool size instead of receiving `n` as an independent count.
 
 Design implications:
 
 - For one-thread faer, `Par::Seq` avoids Rayon dispatch.
-- For multi-thread faer, prefer process- or MPI-level workload partitioning when
-  pool isolation and CPU affinity matter.
+- For multi-thread faer, call faer-backed kernels from within
+  `CpuContext::install` so `Par::rayon(0)` observes the configured context pool.
 - Add a small-shape policy that keeps tiny faer GEMMs sequential even when the
   backend context has more than one thread.
 - A true pool-handle patch would need changes across faer, spindle, and the
@@ -310,8 +312,9 @@ This preserves Rayon pool semantics, but it is expensive for tiny GEMMs.
 - For the `cpu-blas` backend, LAPACK-backed linalg methods now use the same
   caller-thread pool wrapper. This covers `cholesky`, `triangular_solve`, `lu`,
   `full_piv_lu`, `full_piv_lu_solve`, `svd`, `qr`, `eigh`, and `eig`. The
-  `cpu-faer` backend now also avoids a tenferro-owned Rayon pool and passes the
-  `CpuContext` thread count to faer as `Par::Seq` or `Par::rayon(n)`.
+  `cpu-faer` backend uses `CpuContext::install`; one-thread contexts pass
+  `Par::Seq`, and multi-thread contexts pass `Par::rayon(0)` so faer reads the
+  current context pool size.
 - The BLAS conjugation path now detects row-contiguous conjugated operands before
   acquiring an output buffer for a direct BLAS attempt that cannot succeed.
 

--- a/docs/worklogs/2026-06-26-issue-1209-1220-remediation.md
+++ b/docs/worklogs/2026-06-26-issue-1209-1220-remediation.md
@@ -1,0 +1,102 @@
+# Issue 1209-1220 Remediation
+
+## Summary
+
+This work log records the batched remediation for GitHub issues #1209 through
+#1220 plus same-root-cause findings from repository-wide read-only subagent
+audits. The batch is scoped to fixes that preserve current documented
+contracts, add regression/source-contract coverage for false positives, and
+record design-gated items where the issue text conflicts with active specs.
+
+Claude review was initially requested for each implementation plan/result. One
+Group 1 review attempt timed out without output, and the user then explicitly
+cancelled Claude review because it was too slow. No later Claude reviews were
+run.
+
+## Context Read
+
+- `AGENTS.md`
+- `REPOSITORY_RULES.md`
+- `CONTRIBUTING.md`
+- `ai/contribution-workflows/repository-remediation.md`
+- Shared tensor4all rules: common repository, common performance,
+  common docs-and-tests, Rust performance, Rust numerical
+- GitHub issues #1209 through #1220
+- Read-only subagent audits for AD/error boundaries, tensor shape/index/GEMM
+  safety, CPU runtime/resources, CPU indexing, and repo-wide same-pattern risks
+
+## Classification Ledger
+
+| Issue/finding | Classification | Current evidence | Status |
+| --- | --- | --- | --- |
+| #1209 Windows group-affinity condition | False positive with evidence | The first `GetProcessGroupAffinity` call intentionally passes a null group array to query the required count. In that two-call pattern, `ok == 0 && group_count > 0` is the path that has useful count data; `ok != 0` is unexpected and falls back. | Done: source comment/contract evidence; no behavior change. |
+| #1210 `typed_scatter` `window_fits` | Auto Fix | `clamp_window_start` rejects oversized windows and clamps starts so the later fit checks are unreachable. | Done: removed dead control flow and added regression/source-contract coverage. |
+| #1211 `faer_par()` thread count | False positive with evidence | Repository CPU threading contract requires `Par::Seq` for one-thread contexts and `Par::rayon(0)` inside `CpuContext::install` for multi-thread contexts. | Done: added contract evidence and fixed stale docs that described old global-Rayon behavior. |
+| #1212 degenerate `Clamp` AD | Design Gate | The issue matches current CPU behavior for `lower > upper`, but active specs conflict: primitive spec describes `min(max(x, lower), upper)`, while CPU computes `max(lower, min(upper, x))`, and the AD spec documents the upper-bound mask without a `lower < upper` guard. | Deferred: no semantic change in this remediation PR; conflict recorded for follow-up. |
+| #1213 duplicate AD dtype promotion | Auto Fix | AD support duplicates the canonical promotion lattice from `tenferro_tensor::validate::promote_dtype`. Same pattern appears in einsum and linalg extension metadata. | Done: delegated to canonical promotion and added parity coverage. |
+| #1214 buffer-pool retention progress | Auto Fix | `enforce_retention_limit` can subtract zero bytes if a zero-capacity retained bucket reaches eviction. | Done: made eviction progress robust and covered the zero-byte edge. |
+| #1215 unchecked accessor wrapping arithmetic | Auto Fix / contract hardening | Unsafe unchecked accessors use `wrapping_add` / `wrapping_mul`; safe offsets are checked and constructors validate shape products. | Done: replaced wrapping arithmetic with checked invariant enforcement and regression coverage. |
+| #1216 negative-axis normalization | Auto Fix | Tensor, runtime, AD, FFT, and internal-op axis helpers perform unchecked `rank as isize` / addition. | Done: hardened normalization and added edge-case tests. |
+| #1217 `n_elements()` `unreachable!()` | False positive with evidence | The report claims UB, but the code uses `unreachable!()`, not `unreachable_unchecked`; constructors validate owned/view logical counts. | Done: added source-contract coverage; no behavior change. |
+| #1218 unsupported AD mapped to internal error | Auto Fix | Traced and eager AD collapse `ADRuleError::Unsupported` into `Error::Internal`. | Done: added a typed runtime error variant and regression tests. |
+| #1219 `canonical_gemm_layout` coverage | False positive with evidence | Production CPU canonicalization is reached after `analyse_gemm_cached` validation; validation rejects out-of-range, duplicate, and overlapping dot-general axes. | Done: added invariant/source-contract coverage rather than changing canonicalization semantics. |
+| #1220 `transpose_pad_to_match` assert | Auto Fix | The AD transpose helper asserts on inconsistent metadata rank instead of returning `ADRuleError::InvalidInput`. | Done: returned a typed AD-rule error and added regression coverage. |
+| GPU linalg raw byte products | Verify First / Deferred | Repo-wide audit found raw byte multiplications in CUDA linalg paths. | Out of this issue batch unless the active fix touches GPU linalg; record as follow-up risk. |
+| CPU concat/pad stale defensive guards | Verify First / Deferred | CPU indexing audit found potentially stale defensive branches outside #1210. | Defer until boundary tests are narrowed; not required for the `typed_scatter` cleanup. |
+
+## Commit Groups
+
+1. `6b2bb65f` AD and extension metadata hardening: #1213, #1218,
+   #1220, plus canonical promotion parity in einsum/linalg.
+2. `cf00bdd8` Tensor/index validation hardening: #1215, #1216,
+   #1217, #1219, plus same axis-normalization and singular-diagonal
+   shape-product findings.
+3. This commit: CPU runtime/indexing cleanup: #1209, #1210, #1211,
+   #1214, plus stale CPU threading docs.
+
+## Verification
+
+Targeted red/green checks run during implementation:
+
+- `cargo test -p tenferro-internal-ops promote_dtype_delegates_to_canonical_tensor_validation_rules --release`
+- `cargo test -p tenferro-internal-ops transpose_pad_to_match_rejects_axis_outside_input_metadata --release`
+- `cargo test -p tenferro-ad missing_extension_rule_errors --release`
+- `cargo test -p tenferro-einsum extension_dtype_promotion_delegates_to_canonical_tensor_rules --release`
+- `cargo test -p tenferro-linalg extension_dtype_promotion_delegates_to_canonical_tensor_rules --release`
+- `cargo test -p tenferro-tensor linear_offset_helpers_check_overflow --release`
+- `cargo test -p tenferro-tensor axis_normalization_handles_ranks_larger_than_isize_max --release`
+- `cargo test -p tenferro-tensor singular_diagonal_uses_checked_shape_products_before_indexing --release`
+- `cargo test -p tenferro-tensor n_elements_invariant_checks_do_not_use_unsafe_unreachable --release`
+- `cargo test -p tenferro-runtime axis_normalization_handles_ranks_larger_than_isize_max --release`
+- `cargo test -p tenferro-ad axis_normalization_handles_ranks_larger_than_isize_max --release`
+- `cargo test -p tenferro-internal-ops normalize_axis_accepts_negative_axes_and_rejects_out_of_bounds --release`
+- `cargo test -p tenferro-fft normalize_axis_handles_large_rank_without_isize_cast_wrap --release`
+- `cargo test -p tenferro-cpu canonical_gemm_layout_remains_behind_dot_general_validation --release`
+- `cargo test -p tenferro-cpu --test runtime_error_tests cpu_reshape_concatenate_scatter_use_checked_boundary_arithmetic_contract --release`
+- `cargo test -p tenferro-cpu retention_limit_documents_zero_byte_eviction_progress --release`
+- `cargo test -p tenferro-cpu performance_notes_match_current_cpu_threading_contract --release`
+- `cargo test -p tenferro-cpu windows_group_affinity_probe_documents_expected_failure_path --release`
+- `cargo test -p tenferro-cpu cpu_context_faer_policy_uses_current_context_pool_for_multithreaded_context --release`
+- `cargo test -p tenferro-cpu --test runtime_error_tests scatter_negative_start_indices_clamp_like_dynamic_slice --release`
+
+Final pre-PR workspace verification after `git fetch origin` and confirming
+`origin/main...HEAD` is `0 3`:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path /tmp/tenferro-coverage.json`
+- `python3 scripts/check-coverage.py /tmp/tenferro-coverage.json`
+  (`147/147 files passed`)
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
+
+## Residual Risks
+
+- #1212 requires an explicit clamp semantics decision before code or AD masks
+  are changed.
+- GPU linalg raw byte-size findings are same broad safety class but outside the
+  current CPU/tensor/AD issue batch.
+- Some false-positive issues should be closed by PR discussion rather than by
+  silently modifying correct code.


### PR DESCRIPTION
## Summary

- Harden AD extension failure paths with a typed unsupported-rule error, canonical dtype promotion delegation, and a fallible `transpose_pad_to_match` path.
- Harden tensor/index validation by replacing unchecked wrapping offset math, fixing negative-axis normalization overflow paths, and documenting source contracts for validated invariants.
- Clean up CPU runtime/indexing contracts around scatter windows, buffer-pool retention progress, Windows affinity probing, and current `CpuContext` threading behavior.
- Record the batch audit, classifications, reproduction/regression evidence, and deferred follow-ups in `docs/worklogs/2026-06-26-issue-1209-1220-remediation.md`.

## Issue Status

Fully resolved:

- Fixes #1210
- Fixes #1213
- Fixes #1214
- Fixes #1215
- Fixes #1216
- Fixes #1218
- Fixes #1220

Referenced with evidence or explicit deferral:

- Refs #1209: Windows group-affinity two-call probe is intentional; source-contract evidence added.
- Refs #1211: `Par::rayon(0)` is intentional inside `CpuContext::install`; source-contract evidence and stale docs fixed.
- Refs #1212: deferred because Clamp CPU behavior, primitive spec, and AD mask spec currently conflict for `lower > upper`.
- Refs #1217: report is false positive; code uses `unreachable!()`, not `unreachable_unchecked`; source-contract coverage added.
- Refs #1219: canonical GEMM layout is guarded by dot-general validation; invariant coverage added.

## Verification

- `git fetch origin`
- `git rev-list --left-right --count origin/main...HEAD` -> `0 3`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path /tmp/tenferro-coverage.json`
- `python3 scripts/check-coverage.py /tmp/tenferro-coverage.json` -> `147/147 files passed`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
