### PR TITLE
[codex] Fix Terasaki bug batch edge cases

### DIFF
--- a/crates/tenferro-ad/tests/ad.rs
+++ b/crates/tenferro-ad/tests/ad.rs
@@ -855,6 +855,23 @@ fn grad_extract_diag_sum() {
 }
 
 #[test]
+fn grad_extract_diag_reversed_rectangular_axes_sum() {
+    let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(
+        vec![2, 3],
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ))
+    .unwrap();
+    let diag = a.extract_diag(1, 0).unwrap();
+    assert_eq!(diag.try_concrete_shape(), Some(vec![2]));
+    let loss = diag.reduce_sum(&[0]).unwrap();
+    let grad = loss.grad(&a).unwrap();
+
+    let result = eval_tensor(grad);
+    assert_eq!(result.shape(), &[2, 3]);
+    assert_close_slice(get_f64_data(&result), &[1.0, 0.0, 0.0, 1.0, 0.0, 0.0]);
+}
+
+#[test]
 fn grad_embed_diag_sum() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![2.0, -1.0, 4.0]))
         .unwrap();
@@ -1363,6 +1380,50 @@ fn clamp_ad_uses_strict_jax_boundary_masks() {
     assert_close_slice(get_f64_data(&results[3]), &[0.0, 0.0, 0.0, 0.0]);
     assert_close_slice(get_f64_data(&results[4]), &[10.0, 0.0, 0.0, 0.0]);
     assert_close_slice(get_f64_data(&results[5]), &[0.0, 0.0, 0.0, 40.0]);
+}
+
+#[test]
+fn clamp_ad_handles_degenerate_bounds_like_min_max() {
+    let input =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![0.0, 4.0, 8.0])).unwrap();
+    let lower =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![5.0, 5.0, 5.0])).unwrap();
+    let upper =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![3.0, 3.0, 3.0])).unwrap();
+    let d_input =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![10.0, 20.0, 30.0]))
+            .unwrap();
+    let d_lower =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0])).unwrap();
+    let d_upper =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![4.0, 5.0, 6.0])).unwrap();
+    let cotangent =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![7.0, 8.0, 9.0])).unwrap();
+
+    let clamped = input.clamp(&lower, &upper).unwrap();
+    let primal = eval_tensor(clamped.clone());
+    let input_jvp = clamped.jvp(&input, &d_input).unwrap();
+    let lower_jvp = clamped.jvp(&lower, &d_lower).unwrap();
+    let upper_jvp = clamped.jvp(&upper, &d_upper).unwrap();
+    let input_vjp = clamped.vjp(&input, &cotangent).unwrap();
+    let lower_vjp = clamped.vjp(&lower, &cotangent).unwrap();
+    let upper_vjp = clamped.vjp(&upper, &cotangent).unwrap();
+
+    let results = run_many_traced_with(
+        &mut GraphExecutor::new(CpuBackend::new()),
+        &[
+            &input_jvp, &lower_jvp, &upper_jvp, &input_vjp, &lower_vjp, &upper_vjp,
+        ],
+    )
+    .unwrap();
+
+    assert_close_slice(get_f64_data(&primal), &[3.0, 3.0, 3.0]);
+    assert_close_slice(get_f64_data(&results[0]), &[0.0, 0.0, 0.0]);
+    assert_close_slice(get_f64_data(&results[1]), &[0.0, 0.0, 0.0]);
+    assert_close_slice(get_f64_data(&results[2]), &[4.0, 5.0, 6.0]);
+    assert_close_slice(get_f64_data(&results[3]), &[0.0, 0.0, 0.0]);
+    assert_close_slice(get_f64_data(&results[4]), &[0.0, 0.0, 0.0]);
+    assert_close_slice(get_f64_data(&results[5]), &[7.0, 8.0, 9.0]);
 }
 
 #[test]

--- a/crates/tenferro-ad/tests/dtype_propagation.rs
+++ b/crates/tenferro-ad/tests/dtype_propagation.rs
@@ -114,3 +114,24 @@ fn test_indexing_dtype_inference_ignores_index_operands() {
         DType::F32
     );
 }
+
+#[test]
+fn test_dynamic_shape_ops_preserve_data_dtype() {
+    assert_eq!(
+        infer_output_dtype(
+            &StdTensorOp::DynamicTruncate { axis: 0 },
+            &[DType::F32, DType::F64],
+        )
+        .unwrap(),
+        DType::F32
+    );
+
+    assert_eq!(
+        infer_output_dtype(
+            &StdTensorOp::PadToMatch { axis: 0 },
+            &[DType::F32, DType::F64],
+        )
+        .unwrap(),
+        DType::F32
+    );
+}

--- a/crates/tenferro-ad/tests/dynamic_truncate.rs
+++ b/crates/tenferro-ad/tests/dynamic_truncate.rs
@@ -19,6 +19,10 @@ fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
+fn f32_tensor(shape: Vec<usize>, data: Vec<f32>) -> Tensor {
+    Tensor::F32(TypedTensor::from_vec_col_major(shape, data).unwrap())
+}
+
 fn f64_scalar(value: f64) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![value]).unwrap())
 }
@@ -48,6 +52,13 @@ fn get_f64_data(tensor: &Tensor) -> Vec<f64> {
     match tensor {
         Tensor::F64(inner) => inner.host_data().unwrap().to_vec(),
         other => panic!("expected F64 tensor, got {:?}", other.dtype()),
+    }
+}
+
+fn get_f32_data(tensor: &Tensor) -> Vec<f32> {
+    match tensor {
+        Tensor::F32(inner) => inner.host_data().unwrap().to_vec(),
+        other => panic!("expected F32 tensor, got {:?}", other.dtype()),
     }
 }
 
@@ -108,6 +119,22 @@ fn dynamic_truncate_accepts_i64_size() {
 }
 
 #[test]
+fn dynamic_truncate_preserves_data_dtype_and_size_dtype() {
+    let mut engine = GraphExecutor::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor_concrete_shape(f32_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]))
+        .unwrap();
+    let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(2.0)).unwrap();
+
+    let result = x.dynamic_truncate(&size, 0).unwrap();
+    assert_eq!(result.dtype, DType::F32);
+
+    let out = result.run_with(&mut engine).unwrap();
+    assert_eq!(out.dtype(), DType::F32);
+    assert_eq!(out.shape(), &[2]);
+    assert_eq!(get_f32_data(&out), vec![1.0, 2.0]);
+}
+
+#[test]
 fn dynamic_truncate_rejects_backend_size_binding_on_cpu() {
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]))
@@ -152,6 +179,30 @@ fn pad_to_match_no_op_when_same_size() {
     let result = x.pad_to_match(&reference, 0).unwrap();
     let data = get_f64_data(&result.run_with(&mut engine).unwrap());
     assert_eq!(data, vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn pad_to_match_preserves_data_dtype_and_infers_output_shape() {
+    let mut engine = GraphExecutor::new(CpuBackend::new());
+    let x = TracedTensor::from_tensor_concrete_shape(f32_tensor(
+        vec![3, 2],
+        vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+    ))
+    .unwrap();
+    let reference =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5, 7], vec![0.0; 35])).unwrap();
+
+    let result = x.pad_to_match(&reference, 0).unwrap();
+    assert_eq!(result.dtype, DType::F32);
+    assert_eq!(result.try_concrete_shape().unwrap(), vec![5, 2]);
+
+    let out = result.run_with(&mut engine).unwrap();
+    assert_eq!(out.dtype(), DType::F32);
+    assert_eq!(out.shape(), &[5, 2]);
+    assert_eq!(
+        get_f32_data(&out),
+        vec![1.0, 2.0, 3.0, 0.0, 0.0, 4.0, 5.0, 6.0, 0.0, 0.0]
+    );
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/elementwise.rs
+++ b/crates/tenferro-cpu/src/elementwise.rs
@@ -25,8 +25,6 @@ macro_rules! dispatch_ternary_result_with_pool {
         match ($a, $b, $c) {
             (Tensor::F32($x), Tensor::F32($y), Tensor::F32($z)) => Ok(Tensor::F32($body?)),
             (Tensor::F64($x), Tensor::F64($y), Tensor::F64($z)) => Ok(Tensor::F64($body?)),
-            (Tensor::C32($x), Tensor::C32($y), Tensor::C32($z)) => Ok(Tensor::C32($body?)),
-            (Tensor::C64($x), Tensor::C64($y), Tensor::C64($z)) => Ok(Tensor::C64($body?)),
             _ => Err(crate::Error::backend_failure($op, "dtype mismatch")),
         }
     };
@@ -48,9 +46,32 @@ fn read_pair_error(op: &'static str, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -
     dtype_pair_error(op, lhs.dtype(), rhs.dtype())
 }
 
+fn is_complex_dtype(dtype: DType) -> bool {
+    matches!(dtype, DType::C32 | DType::C64)
+}
+
+fn ordered_complex_error(op: &'static str) -> crate::Error {
+    crate::Error::InvalidConfig {
+        op,
+        message: "complex tensors do not have a total order; compute abs/norm explicitly before ordered operations".into(),
+    }
+}
+
+fn reject_complex_ordered_dtypes(op: &'static str, dtypes: &[DType]) -> crate::Result<()> {
+    if dtypes.iter().copied().any(is_complex_dtype) {
+        return Err(ordered_complex_error(op));
+    }
+    Ok(())
+}
+
 pub(crate) trait Tier2Elem: Copy + Clone + One + Zero + Send + Sync {
     fn abs_elem(self) -> Self;
     fn sign_elem(self) -> Self;
+}
+
+// Keep ordering separate from abs/sign so complex tensors cannot silently pick
+// a magnitude ordering. Callers should compute abs/norm explicitly first.
+pub(crate) trait OrderedElem: Copy + Clone + Send + Sync {
     fn max_elem(self, other: Self) -> Self;
     fn min_elem(self, other: Self) -> Self;
 }
@@ -73,7 +94,9 @@ macro_rules! impl_tier2_elem_real {
                     self.signum()
                 }
             }
+        }
 
+        impl OrderedElem for $ty {
             fn max_elem(self, other: Self) -> Self {
                 if self.is_nan() || other.is_nan() {
                     <$ty>::NAN
@@ -121,42 +144,6 @@ macro_rules! impl_tier2_elem_complex {
                     Self::zero()
                 } else {
                     self / self.abs_elem()
-                }
-            }
-
-            fn max_elem(self, other: Self) -> Self {
-                let lhs_norm = self.norm_sqr();
-                let rhs_norm = other.norm_sqr();
-                if lhs_norm.is_nan() || rhs_norm.is_nan() {
-                    Self::new(<$real>::NAN, <$real>::NAN)
-                } else if lhs_norm >= rhs_norm {
-                    self
-                } else {
-                    other
-                }
-            }
-
-            fn min_elem(self, other: Self) -> Self {
-                let lhs_norm = self.norm_sqr();
-                let rhs_norm = other.norm_sqr();
-                if lhs_norm.is_nan() || rhs_norm.is_nan() {
-                    Self::new(<$real>::NAN, <$real>::NAN)
-                } else if lhs_norm <= rhs_norm {
-                    self
-                } else {
-                    other
-                }
-            }
-        }
-
-        impl CompareElem for Complex<$real> {
-            fn compare_elem(self, other: Self, dir: &CompareDir) -> bool {
-                match dir {
-                    CompareDir::Eq => self == other,
-                    CompareDir::Lt => self.norm_sqr() < other.norm_sqr(),
-                    CompareDir::Le => self.norm_sqr() <= other.norm_sqr(),
-                    CompareDir::Gt => self.norm_sqr() > other.norm_sqr(),
-                    CompareDir::Ge => self.norm_sqr() >= other.norm_sqr(),
                 }
             }
         }
@@ -747,7 +734,7 @@ fn typed_clamp_view_with_pool<T, I, L, U>(
     upper: &TypedTensorView<'_, T, U>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Tier2Elem + PoolScalar + 'static,
+    T: OrderedElem + PoolScalar + 'static,
     I: TensorRank,
     L: TensorRank,
     U: TensorRank,
@@ -773,7 +760,7 @@ where
         &typed_view_from_view("clamp", input)?,
         &typed_view_from_view("clamp", lower)?,
         &typed_view_from_view("clamp", upper)?,
-        |x, lo, hi| lo.max_elem(hi.min_elem(x)),
+        |x, lo, hi| hi.min_elem(lo.max_elem(x)),
     )
     .map_err(|err| crate::Error::backend_failure("clamp", err))?;
     Ok(tensor_from_array(out))
@@ -1919,18 +1906,14 @@ pub(crate) fn maximum_with_pool(
     lhs: &Tensor,
     rhs: &Tensor,
 ) -> crate::Result<Tensor> {
+    reject_complex_ordered_dtypes("maximum", &[lhs.dtype(), rhs.dtype()])?;
+
     match (lhs, rhs) {
         (Tensor::F32(a), Tensor::F32(b)) => {
             Ok(Tensor::F32(typed_maximum_with_pool(buffers, a, b)?))
         }
         (Tensor::F64(a), Tensor::F64(b)) => {
             Ok(Tensor::F64(typed_maximum_with_pool(buffers, a, b)?))
-        }
-        (Tensor::C32(a), Tensor::C32(b)) => {
-            Ok(Tensor::C32(typed_maximum_with_pool(buffers, a, b)?))
-        }
-        (Tensor::C64(a), Tensor::C64(b)) => {
-            Ok(Tensor::C64(typed_maximum_with_pool(buffers, a, b)?))
         }
         _ => Err(tensor_pair_error("maximum", lhs, rhs)),
     }
@@ -1943,6 +1926,8 @@ pub(crate) fn maximum_read_with_pool(
 ) -> crate::Result<Tensor> {
     let lhs_dtype = lhs.dtype();
     let rhs_dtype = rhs.dtype();
+    reject_complex_ordered_dtypes("maximum", &[lhs_dtype, rhs_dtype])?;
+
     match (read_as_cpu_view(lhs), read_as_cpu_view(rhs)) {
         (CpuReadView::F32(a), CpuReadView::F32(b)) => Ok(Tensor::F32(
             typed_same_shape_binary_view_with_pool("maximum", buffers, &a, &b, |x, y| {
@@ -1950,16 +1935,6 @@ pub(crate) fn maximum_read_with_pool(
             })?,
         )),
         (CpuReadView::F64(a), CpuReadView::F64(b)) => Ok(Tensor::F64(
-            typed_same_shape_binary_view_with_pool("maximum", buffers, &a, &b, |x, y| {
-                x.max_elem(y)
-            })?,
-        )),
-        (CpuReadView::C32(a), CpuReadView::C32(b)) => Ok(Tensor::C32(
-            typed_same_shape_binary_view_with_pool("maximum", buffers, &a, &b, |x, y| {
-                x.max_elem(y)
-            })?,
-        )),
-        (CpuReadView::C64(a), CpuReadView::C64(b)) => Ok(Tensor::C64(
             typed_same_shape_binary_view_with_pool("maximum", buffers, &a, &b, |x, y| {
                 x.max_elem(y)
             })?,
@@ -1991,18 +1966,14 @@ pub(crate) fn minimum_with_pool(
     lhs: &Tensor,
     rhs: &Tensor,
 ) -> crate::Result<Tensor> {
+    reject_complex_ordered_dtypes("minimum", &[lhs.dtype(), rhs.dtype()])?;
+
     match (lhs, rhs) {
         (Tensor::F32(a), Tensor::F32(b)) => {
             Ok(Tensor::F32(typed_minimum_with_pool(buffers, a, b)?))
         }
         (Tensor::F64(a), Tensor::F64(b)) => {
             Ok(Tensor::F64(typed_minimum_with_pool(buffers, a, b)?))
-        }
-        (Tensor::C32(a), Tensor::C32(b)) => {
-            Ok(Tensor::C32(typed_minimum_with_pool(buffers, a, b)?))
-        }
-        (Tensor::C64(a), Tensor::C64(b)) => {
-            Ok(Tensor::C64(typed_minimum_with_pool(buffers, a, b)?))
         }
         _ => Err(tensor_pair_error("minimum", lhs, rhs)),
     }
@@ -2015,6 +1986,8 @@ pub(crate) fn minimum_read_with_pool(
 ) -> crate::Result<Tensor> {
     let lhs_dtype = lhs.dtype();
     let rhs_dtype = rhs.dtype();
+    reject_complex_ordered_dtypes("minimum", &[lhs_dtype, rhs_dtype])?;
+
     match (read_as_cpu_view(lhs), read_as_cpu_view(rhs)) {
         (CpuReadView::F32(a), CpuReadView::F32(b)) => Ok(Tensor::F32(
             typed_same_shape_binary_view_with_pool("minimum", buffers, &a, &b, |x, y| {
@@ -2022,16 +1995,6 @@ pub(crate) fn minimum_read_with_pool(
             })?,
         )),
         (CpuReadView::F64(a), CpuReadView::F64(b)) => Ok(Tensor::F64(
-            typed_same_shape_binary_view_with_pool("minimum", buffers, &a, &b, |x, y| {
-                x.min_elem(y)
-            })?,
-        )),
-        (CpuReadView::C32(a), CpuReadView::C32(b)) => Ok(Tensor::C32(
-            typed_same_shape_binary_view_with_pool("minimum", buffers, &a, &b, |x, y| {
-                x.min_elem(y)
-            })?,
-        )),
-        (CpuReadView::C64(a), CpuReadView::C64(b)) => Ok(Tensor::C64(
             typed_same_shape_binary_view_with_pool("minimum", buffers, &a, &b, |x, y| {
                 x.min_elem(y)
             })?,
@@ -2064,6 +2027,8 @@ pub(crate) fn compare_with_pool(
     rhs: &Tensor,
     dir: &CompareDir,
 ) -> crate::Result<Tensor> {
+    reject_complex_ordered_dtypes("compare", &[lhs.dtype(), rhs.dtype()])?;
+
     match (lhs, rhs) {
         (Tensor::F32(a), Tensor::F32(b)) => {
             Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
@@ -2078,12 +2043,6 @@ pub(crate) fn compare_with_pool(
             Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
         }
         (Tensor::Bool(a), Tensor::Bool(b)) => {
-            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
-        }
-        (Tensor::C32(a), Tensor::C32(b)) => {
-            Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
-        }
-        (Tensor::C64(a), Tensor::C64(b)) => {
             Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
         }
         _ => Err(crate::Error::DTypeMismatch {
@@ -2102,6 +2061,8 @@ pub(crate) fn compare_read_with_pool(
 ) -> crate::Result<Tensor> {
     let lhs_dtype = lhs.dtype();
     let rhs_dtype = rhs.dtype();
+    reject_complex_ordered_dtypes("compare", &[lhs_dtype, rhs_dtype])?;
+
     match (read_as_cpu_view(lhs), read_as_cpu_view(rhs)) {
         (CpuReadView::F32(a), CpuReadView::F32(b)) => Ok(Tensor::Bool(
             typed_same_shape_binary_view_with_pool("compare", buffers, &a, &b, |x, y| {
@@ -2124,16 +2085,6 @@ pub(crate) fn compare_read_with_pool(
             })?,
         )),
         (CpuReadView::Bool(a), CpuReadView::Bool(b)) => Ok(Tensor::Bool(
-            typed_same_shape_binary_view_with_pool("compare", buffers, &a, &b, |x, y| {
-                x.compare_elem(y, dir)
-            })?,
-        )),
-        (CpuReadView::C32(a), CpuReadView::C32(b)) => Ok(Tensor::Bool(
-            typed_same_shape_binary_view_with_pool("compare", buffers, &a, &b, |x, y| {
-                x.compare_elem(y, dir)
-            })?,
-        )),
-        (CpuReadView::C64(a), CpuReadView::C64(b)) => Ok(Tensor::Bool(
             typed_same_shape_binary_view_with_pool("compare", buffers, &a, &b, |x, y| {
                 x.compare_elem(y, dir)
             })?,
@@ -2279,6 +2230,8 @@ pub(crate) fn clamp_with_pool(
     lower: &Tensor,
     upper: &Tensor,
 ) -> crate::Result<Tensor> {
+    reject_complex_ordered_dtypes("clamp", &[input.dtype(), lower.dtype(), upper.dtype()])?;
+
     dispatch_ternary_result_with_pool!("clamp", input, lower, upper, |x, lo, hi| {
         typed_clamp_with_pool(buffers, x, lo, hi)
     })
@@ -2292,6 +2245,9 @@ pub(crate) fn clamp_read_with_pool(
 ) -> crate::Result<Tensor> {
     let input_dtype = input.dtype();
     let lower_dtype = lower.dtype();
+    let upper_dtype = upper.dtype();
+    reject_complex_ordered_dtypes("clamp", &[input_dtype, lower_dtype, upper_dtype])?;
+
     match (
         read_as_cpu_view(input),
         read_as_cpu_view(lower),
@@ -2302,12 +2258,6 @@ pub(crate) fn clamp_read_with_pool(
         ),
         (CpuReadView::F64(input), CpuReadView::F64(lower), CpuReadView::F64(upper)) => Ok(
             Tensor::F64(typed_clamp_view_with_pool(buffers, &input, &lower, &upper)?),
-        ),
-        (CpuReadView::C32(input), CpuReadView::C32(lower), CpuReadView::C32(upper)) => Ok(
-            Tensor::C32(typed_clamp_view_with_pool(buffers, &input, &lower, &upper)?),
-        ),
-        (CpuReadView::C64(input), CpuReadView::C64(lower), CpuReadView::C64(upper)) => Ok(
-            Tensor::C64(typed_clamp_view_with_pool(buffers, &input, &lower, &upper)?),
         ),
         _ => Err(crate::Error::DTypeMismatch {
             op: "clamp",
@@ -2660,7 +2610,7 @@ pub(crate) fn typed_maximum_with_pool<T>(
     rhs: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Tier2Elem + PoolScalar,
+    T: OrderedElem + PoolScalar,
 {
     if lhs.shape() != rhs.shape() {
         return Err(crate::Error::ShapeMismatch {
@@ -2687,7 +2637,7 @@ pub(crate) fn typed_minimum_with_pool<T>(
     rhs: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Tier2Elem + PoolScalar,
+    T: OrderedElem + PoolScalar,
 {
     if lhs.shape() != rhs.shape() {
         return Err(crate::Error::ShapeMismatch {
@@ -2779,7 +2729,7 @@ pub(crate) fn typed_clamp_with_pool<T>(
     upper: &TypedTensor<T>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Tier2Elem + PoolScalar,
+    T: OrderedElem + PoolScalar,
 {
     if input.shape() != lower.shape() {
         return Err(crate::Error::ShapeMismatch {
@@ -2802,7 +2752,7 @@ where
         &typed_view("clamp", input)?,
         &typed_view("clamp", lower)?,
         &typed_view("clamp", upper)?,
-        |x, lo, hi| lo.max_elem(hi.min_elem(x)),
+        |x, lo, hi| hi.min_elem(lo.max_elem(x)),
     )
     .map_err(|err| crate::Error::backend_failure("clamp", err))?;
     Ok(tensor_from_array(out))

--- a/crates/tenferro-cpu/src/elementwise/tests.rs
+++ b/crates/tenferro-cpu/src/elementwise/tests.rs
@@ -362,6 +362,32 @@ fn assert_backend_failure<T>(result: crate::Result<T>, op: &'static str) {
     ));
 }
 
+fn assert_invalid_config_contains<T>(result: crate::Result<T>, op: &'static str, expected: &str) {
+    assert!(matches!(
+        result,
+        Err(crate::Error::InvalidConfig {
+            op: actual,
+            ref message,
+        }) if actual == op && message.contains(expected)
+    ));
+}
+
+#[test]
+fn complex_ordered_ops_are_explicitly_rejected() {
+    let lhs = Tensor::C64(TypedTensor::from_vec_col_major(vec![1], vec![c64(1.0, 0.0)]).unwrap());
+    let rhs = Tensor::C64(TypedTensor::from_vec_col_major(vec![1], vec![c64(0.0, 1.0)]).unwrap());
+
+    for (op, result) in [
+        ("maximum", maximum(&lhs, &rhs)),
+        ("minimum", minimum(&lhs, &rhs)),
+        ("compare", compare(&lhs, &rhs, &CompareDir::Le)),
+    ] {
+        assert_invalid_config_contains(result, op, "total order");
+    }
+
+    assert_invalid_config_contains(clamp(&lhs, &rhs, &lhs), "clamp", "total order");
+}
+
 #[test]
 fn typed_view_helpers_cover_scalar_and_validation_paths() {
     let mut buffers = BufferPool::default();
@@ -458,6 +484,20 @@ fn typed_view_helpers_cover_scalar_and_validation_paths() {
     let clamped =
         typed_clamp_view_with_pool(&mut buffers, &lhs_view, &lower_view, &upper_view).unwrap();
     assert_eq!(clamped.as_slice().unwrap(), &[1.0, 4.0]);
+
+    let degenerate_lower: TypedTensor<f64> =
+        TypedTensor::from_vec_col_major(vec![2], vec![5.0_f64, 5.0]).unwrap();
+    let degenerate_upper: TypedTensor<f64> =
+        TypedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 3.0]).unwrap();
+    let degenerate = typed_clamp_view_with_pool(
+        &mut buffers,
+        &lhs_view,
+        &degenerate_lower.as_view(),
+        &degenerate_upper.as_view(),
+    )
+    .unwrap();
+    assert_eq!(degenerate.as_slice().unwrap(), &[3.0, 3.0]);
+
     assert_shape_mismatch(
         typed_clamp_view_with_pool(&mut buffers, &lhs_view, &short_view, &upper_view),
         "clamp",
@@ -761,26 +801,23 @@ fn tensor_read_elementwise_dispatch_covers_view_and_complex_scalar_branches() {
         c32(0.6, 0.8),
     );
 
-    let max_c32 = maximum_read_with_pool(
-        &mut buffers,
-        TensorRead::from_view(TensorView::C32(c32_a.as_view())),
-        TensorRead::from_tensor(&c32_b_tensor),
-    )
-    .unwrap();
-    assert_c32_close(
-        max_c32.as_slice::<Complex<f32>>().unwrap()[0],
-        c32(3.0, 4.0),
+    assert_invalid_config_contains(
+        maximum_read_with_pool(
+            &mut buffers,
+            TensorRead::from_view(TensorView::C32(c32_a.as_view())),
+            TensorRead::from_tensor(&c32_b_tensor),
+        ),
+        "maximum",
+        "total order",
     );
-
-    let min_c64 = minimum_read_with_pool(
-        &mut buffers,
-        TensorRead::from_view(TensorView::C64(c64_a.as_view())),
-        TensorRead::from_tensor(&c64_b_tensor),
-    )
-    .unwrap();
-    assert_c64_close(
-        min_c64.as_slice::<Complex<f64>>().unwrap()[0],
-        c64(1.0, 0.0),
+    assert_invalid_config_contains(
+        minimum_read_with_pool(
+            &mut buffers,
+            TensorRead::from_view(TensorView::C64(c64_a.as_view())),
+            TensorRead::from_tensor(&c64_b_tensor),
+        ),
+        "minimum",
+        "total order",
     );
 
     let cmp_i32 = compare_read_with_pool(
@@ -810,14 +847,16 @@ fn tensor_read_elementwise_dispatch_covers_view_and_complex_scalar_branches() {
     .unwrap();
     assert_eq!(cmp_bool.as_slice::<bool>().unwrap(), &[false, true]);
 
-    let cmp_c32 = compare_read_with_pool(
-        &mut buffers,
-        TensorRead::from_view(TensorView::C32(c32_a.as_view())),
-        TensorRead::from_view(TensorView::C32(c32_b.as_view())),
-        &CompareDir::Gt,
-    )
-    .unwrap();
-    assert_eq!(cmp_c32.as_slice::<bool>().unwrap(), &[true, false]);
+    assert_invalid_config_contains(
+        compare_read_with_pool(
+            &mut buffers,
+            TensorRead::from_view(TensorView::C32(c32_a.as_view())),
+            TensorRead::from_view(TensorView::C32(c32_b.as_view())),
+            &CompareDir::Gt,
+        ),
+        "compare",
+        "total order",
+    );
 
     let select_i64 = select_read_with_pool(
         &mut buffers,
@@ -868,28 +907,25 @@ fn tensor_read_elementwise_dispatch_covers_view_and_complex_scalar_branches() {
         "select",
     );
 
-    let clamp_c32 = clamp_read_with_pool(
-        &mut buffers,
-        TensorRead::from_view(TensorView::C32(c32_a.as_view())),
-        TensorRead::from_view(TensorView::C32(c32_b.as_view())),
-        TensorRead::from_view(TensorView::C32(c32_a.as_view())),
-    )
-    .unwrap();
-    assert_c32_close(
-        clamp_c32.as_slice::<Complex<f32>>().unwrap()[0],
-        c32(3.0, 4.0),
+    assert_invalid_config_contains(
+        clamp_read_with_pool(
+            &mut buffers,
+            TensorRead::from_view(TensorView::C32(c32_a.as_view())),
+            TensorRead::from_view(TensorView::C32(c32_b.as_view())),
+            TensorRead::from_view(TensorView::C32(c32_a.as_view())),
+        ),
+        "clamp",
+        "total order",
     );
-
-    let clamp_c64 = clamp_read_with_pool(
-        &mut buffers,
-        TensorRead::from_view(TensorView::C64(c64_a.as_view())),
-        TensorRead::from_view(TensorView::C64(c64_b.as_view())),
-        TensorRead::from_view(TensorView::C64(c64_a.as_view())),
-    )
-    .unwrap();
-    assert_c64_close(
-        clamp_c64.as_slice::<Complex<f64>>().unwrap()[1],
-        c64(0.0, 2.0),
+    assert_invalid_config_contains(
+        clamp_read_with_pool(
+            &mut buffers,
+            TensorRead::from_view(TensorView::C64(c64_a.as_view())),
+            TensorRead::from_view(TensorView::C64(c64_b.as_view())),
+            TensorRead::from_view(TensorView::C64(c64_a.as_view())),
+        ),
+        "clamp",
+        "total order",
     );
 
     assert_dtype_mismatch(

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -897,24 +897,39 @@ fn test_pool_backed_elementwise_public_paths_cover_dtypes_and_scalars() {
         )
         .unwrap(),
     );
-    assert_c64_close(
-        get_c64(&maximum(&a, &b).unwrap(), &[0]),
-        Complex64::new(3.0, 4.0),
-    );
-    assert_c64_close(
-        get_c64(&minimum(&a, &b).unwrap(), &[0]),
-        Complex64::new(0.0, 2.0),
-    );
-    assert!(get_bool(&compare(&a, &b, &CompareDir::Ge).unwrap(), &[0]));
+    assert!(matches!(
+        maximum(&a, &b),
+        Err(crate::Error::InvalidConfig {
+            op: "maximum",
+            ref message,
+        }) if message.contains("total order")
+    ));
+    assert!(matches!(
+        minimum(&a, &b),
+        Err(crate::Error::InvalidConfig {
+            op: "minimum",
+            ref message,
+        }) if message.contains("total order")
+    ));
+    assert!(matches!(
+        compare(&a, &b, &CompareDir::Ge),
+        Err(crate::Error::InvalidConfig {
+            op: "compare",
+            ref message,
+        }) if message.contains("total order")
+    ));
     let pred = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, true]).unwrap());
     assert_c64_close(
         get_c64(&select(&pred, &a, &b).unwrap(), &[1]),
         Complex64::new(1.0, 0.0),
     );
-    assert_c64_close(
-        get_c64(&clamp(&a, &b, &a).unwrap(), &[1]),
-        Complex64::new(5.0, 0.0),
-    );
+    assert!(matches!(
+        clamp(&a, &b, &a),
+        Err(crate::Error::InvalidConfig {
+            op: "clamp",
+            ref message,
+        }) if message.contains("total order")
+    ));
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
@@ -786,11 +786,18 @@ fn test_tier2_elementwise_ops_complex() {
     assert_c64_close(get_c64(&sign, &[0]), Complex64::new(0.6, 0.8));
     assert_c64_close(get_c64(&sign, &[1]), Complex64::new(0.0, 0.0));
 
-    let maximum = backend.maximum(&lhs, &rhs).unwrap();
-    assert_c64_close(get_c64(&maximum, &[0]), Complex64::new(3.0, 4.0));
-    assert_c64_close(get_c64(&maximum, &[1]), Complex64::new(0.0, 2.0));
-
-    let minimum = backend.minimum(&lhs, &rhs).unwrap();
-    assert_c64_close(get_c64(&minimum, &[0]), Complex64::new(1.0, 0.0));
-    assert_c64_close(get_c64(&minimum, &[1]), Complex64::new(1.0, 0.0));
+    assert!(matches!(
+        backend.maximum(&lhs, &rhs),
+        Err(crate::Error::InvalidConfig {
+            op: "maximum",
+            ref message,
+        }) if message.contains("total order")
+    ));
+    assert!(matches!(
+        backend.minimum(&lhs, &rhs),
+        Err(crate::Error::InvalidConfig {
+            op: "minimum",
+            ref message,
+        }) if message.contains("total order")
+    ));
 }

--- a/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
@@ -1,5 +1,15 @@
 use super::*;
 
+fn assert_ordered_complex_error<T>(result: crate::Result<T>, op: &'static str) {
+    assert!(matches!(
+        result,
+        Err(crate::Error::InvalidConfig {
+            op: actual,
+            ref message,
+        }) if actual == op && message.contains("total order")
+    ));
+}
+
 #[test]
 fn elementwise_add_accepts_transposed_host_view_input() {
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap();
@@ -517,21 +527,15 @@ fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
     let sign_c32 = sign(&input_c32).unwrap();
     assert_eq!(get_c32(&sign_c32, &[1]), Complex32::new(0.0, 0.0));
 
-    let max_c32 = maximum(&lhs_c32, &rhs_c32).unwrap();
-    assert_eq!(get_c32(&max_c32, &[0]), Complex32::new(3.0, 4.0));
-
-    let min_c32 = minimum(&lhs_c32, &rhs_c32).unwrap();
-    assert_eq!(get_c32(&min_c32, &[1]), Complex32::new(1.0, 0.0));
-
-    let cmp_c32 = compare(&lhs_c32, &rhs_c32, &CompareDir::Eq).unwrap();
-    assert!(!get_bool(&cmp_c32, &[0]));
+    assert_ordered_complex_error(maximum(&lhs_c32, &rhs_c32), "maximum");
+    assert_ordered_complex_error(minimum(&lhs_c32, &rhs_c32), "minimum");
+    assert_ordered_complex_error(compare(&lhs_c32, &rhs_c32, &CompareDir::Eq), "compare");
 
     let select_c32 = select(&pred_bool, &lhs_c32, &rhs_c32).unwrap();
     assert_eq!(get_c32(&select_c32, &[0]), Complex32::new(1.0, 0.0));
     assert_eq!(get_c32(&select_c32, &[1]), Complex32::new(1.0, 0.0));
 
-    let clamp_c32 = clamp(&lhs_c32, &lower_c32, &upper_c32).unwrap();
-    assert_eq!(get_c32(&clamp_c32, &[0]), Complex32::new(4.0, 0.0));
+    assert_ordered_complex_error(clamp(&lhs_c32, &lower_c32, &upper_c32), "clamp");
 
     let scalar_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![], vec![2.0f32]).unwrap());
     let add_c32 = add(&scalar_f32, &rhs_c32).unwrap();
@@ -839,22 +843,16 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
     let conj_c64 = conj(&lhs_c64).unwrap();
     assert_c64_close(get_c64(&conj_c64, &[0]), Complex64::new(3.0, -4.0));
 
-    let compare_lt = compare(&lhs_c64, &rhs_c64, &CompareDir::Lt).unwrap();
-    let compare_le = compare(&lhs_c64, &rhs_c64, &CompareDir::Le).unwrap();
-    let compare_gt = compare(&lhs_c64, &rhs_c64, &CompareDir::Gt).unwrap();
-    let compare_ge = compare(&lhs_c64, &rhs_c64, &CompareDir::Ge).unwrap();
-    assert!(!get_bool(&compare_lt, &[0]));
-    assert!(!get_bool(&compare_le, &[0]));
-    assert!(get_bool(&compare_gt, &[0]));
-    assert!(get_bool(&compare_ge, &[0]));
+    assert_ordered_complex_error(compare(&lhs_c64, &rhs_c64, &CompareDir::Lt), "compare");
+    assert_ordered_complex_error(compare(&lhs_c64, &rhs_c64, &CompareDir::Le), "compare");
+    assert_ordered_complex_error(compare(&lhs_c64, &rhs_c64, &CompareDir::Gt), "compare");
+    assert_ordered_complex_error(compare(&lhs_c64, &rhs_c64, &CompareDir::Ge), "compare");
 
     let select_c64 = select(&pred_bool, &lhs_c64, &rhs_c64).unwrap();
     assert_c64_close(get_c64(&select_c64, &[0]), Complex64::new(1.0, 0.0));
     assert_c64_close(get_c64(&select_c64, &[1]), Complex64::new(1.0, 0.0));
 
-    let clamp_c64 = clamp(&lhs_c64, &lower_c64, &upper_c64).unwrap();
-    assert_c64_close(get_c64(&clamp_c64, &[0]), Complex64::new(4.0, 0.0));
-    assert_c64_close(get_c64(&clamp_c64, &[1]), Complex64::new(1.0, 0.0));
+    assert_ordered_complex_error(clamp(&lhs_c64, &lower_c64, &upper_c64), "clamp");
 
     let lhs_f32 = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap());
 

--- a/crates/tenferro-einsum/src/builder.rs
+++ b/crates/tenferro-einsum/src/builder.rs
@@ -45,6 +45,7 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::DotGeneralConfig;
 
 use crate::planning::tree::ContractionTree;
+use crate::util::map_label_occurrences;
 use crate::{Error, Result};
 
 pub(crate) type AxisVec = SmallVec<[usize; 4]>;
@@ -85,6 +86,16 @@ fn find_label_axis(labels: &[u32], label: u32) -> Result<usize> {
         .iter()
         .position(|candidate| *candidate == label)
         .ok_or_else(|| builder_invalid_argument(format!("missing label {label} in {labels:?}")))
+}
+
+fn map_label_axes(source_labels: &[u32], target_labels: &[u32]) -> Result<AxisVec> {
+    map_label_occurrences(source_labels, target_labels)
+        .map(|axes| axes.into_iter().collect())
+        .ok_or_else(|| {
+            builder_invalid_argument(format!(
+                "cannot map label occurrences {source_labels:?} into {target_labels:?}"
+            ))
+        })
 }
 
 fn local_shape(rank: usize) -> Vec<DimExpr> {
@@ -376,10 +387,7 @@ fn binary_contract(
     }
 
     // Build permutation
-    let perm: AxisVec = target_labels
-        .iter()
-        .map(|l| find_label_axis(current_labels, *l))
-        .collect::<Result<_>>()?;
+    let perm = map_label_axes(&target_labels, current_labels)?;
 
     if perm.iter().enumerate().all(|(i, &p)| i == p) {
         return Ok(result);
@@ -432,16 +440,8 @@ fn outer_product(
     }
 
     // Broadcast both to combined shape, then Mul
-    let lhs_dims: AxisVec = lhs
-        .labels
-        .iter()
-        .map(|l| find_label_axis(&combined_labels, *l))
-        .collect::<Result<_>>()?;
-    let rhs_dims: AxisVec = rhs
-        .labels
-        .iter()
-        .map(|l| find_label_axis(&combined_labels, *l))
-        .collect::<Result<_>>()?;
+    let lhs_dims = map_label_axes(&lhs.labels, &combined_labels)?;
+    let rhs_dims = map_label_axes(&rhs.labels, &combined_labels)?;
 
     let lhs_shape =
         combined_shape_for_broadcast(&combined_labels, lhs, rhs, BroadcastPrimary::Lhs)?;
@@ -633,10 +633,7 @@ pub(crate) fn build_einsum_graph_dim_expr(
         if result.labels == *output_labels {
             return Ok(localize_value_ref(builder, result.val, &result.shape));
         }
-        let perm: AxisVec = output_labels
-            .iter()
-            .map(|l| find_label_axis(&result.labels, *l))
-            .collect::<Result<_>>()?;
+        let perm = map_label_axes(output_labels, &result.labels)?;
         if perm.iter().enumerate().all(|(i, &p)| i == p) {
             return Ok(localize_value_ref(builder, result.val, &result.shape));
         }
@@ -698,10 +695,7 @@ pub(crate) fn build_einsum_graph_dim_expr(
         return Ok(localize_value_ref(builder, result.val, &result.shape));
     }
 
-    let perm: AxisVec = output_labels
-        .iter()
-        .map(|l| find_label_axis(&result.labels, *l))
-        .collect::<Result<_>>()?;
+    let perm = map_label_axes(output_labels, &result.labels)?;
     if perm.iter().enumerate().all(|(i, &p)| i == p) {
         return Ok(localize_value_ref(builder, result.val, &result.shape));
     }

--- a/crates/tenferro-einsum/src/eager.rs
+++ b/crates/tenferro-einsum/src/eager.rs
@@ -8,6 +8,7 @@ use tenferro_tensor::{
 };
 
 use crate::binary_dot::{try_build_binary_dot_plan, BinaryDotPlan};
+use crate::util::map_label_occurrences;
 use crate::{ContractionTree, Subscripts};
 
 mod profile;
@@ -304,6 +305,14 @@ fn find_label_axis(labels: &[u32], label: u32) -> Result<usize> {
         .ok_or_else(|| eager_invalid_config(format!("label {label} missing from tensor labels")))
 }
 
+fn map_label_axes(source_labels: &[u32], target_labels: &[u32]) -> Result<Vec<usize>> {
+    map_label_occurrences(source_labels, target_labels).ok_or_else(|| {
+        eager_invalid_config(format!(
+            "cannot map label occurrences {source_labels:?} into {target_labels:?}"
+        ))
+    })
+}
+
 fn label_size(label: u32, operands: &[&LabeledTensor<'_>]) -> Result<usize> {
     for operand in operands {
         if let Some(axis) = operand
@@ -435,10 +444,7 @@ fn transpose_to_labels<'a>(
         return Ok(operand);
     }
 
-    let perm: Vec<usize> = target_labels
-        .iter()
-        .map(|label| find_label_axis(&operand.labels, *label))
-        .collect::<Result<_>>()?;
+    let perm = map_label_axes(target_labels, &operand.labels)?;
     if perm
         .iter()
         .enumerate()
@@ -487,16 +493,8 @@ fn outer_product<'a>(
         .iter()
         .map(|label| label_size(*label, &[&lhs, &rhs]))
         .collect::<Result<_>>()?;
-    let lhs_dims: Vec<usize> = lhs
-        .labels
-        .iter()
-        .map(|label| find_label_axis(&combined_labels, *label))
-        .collect::<Result<_>>()?;
-    let rhs_dims: Vec<usize> = rhs
-        .labels
-        .iter()
-        .map(|label| find_label_axis(&combined_labels, *label))
-        .collect::<Result<_>>()?;
+    let lhs_dims = map_label_axes(&lhs.labels, &combined_labels)?;
+    let rhs_dims = map_label_axes(&rhs.labels, &combined_labels)?;
 
     let tensor = match exec.execute_broadcast_multiply(
         lhs.tensor.tensor_read(),

--- a/crates/tenferro-einsum/src/extension.rs
+++ b/crates/tenferro-einsum/src/extension.rs
@@ -48,6 +48,8 @@ use crate::optimize::default_auto_options;
 #[cfg(feature = "autodiff")]
 use crate::optimize::jax_path_to_v1_pairs;
 use crate::optimize::{hash_einsum_plan_spec, plan_specs_equal, resolve_plan_spec, EinsumPlanSpec};
+#[cfg(feature = "autodiff")]
+use crate::util::map_label_occurrences;
 use crate::{
     ContractionTree, EinsumSubscripts, Error as EinsumError, Result as EinsumResult, Subscripts,
 };
@@ -888,22 +890,6 @@ fn broadcast_einsum_vjp_to_input_shape(
         broadcast,
         input_labels,
     ))
-}
-
-#[cfg(feature = "autodiff")]
-fn map_label_occurrences(source_labels: &[u32], target_labels: &[u32]) -> Option<Vec<usize>> {
-    let mut used = vec![false; target_labels.len()];
-    source_labels
-        .iter()
-        .map(|label| {
-            let axis = target_labels
-                .iter()
-                .enumerate()
-                .find_map(|(axis, target)| (!used[axis] && target == label).then_some(axis))?;
-            used[axis] = true;
-            Some(axis)
-        })
-        .collect()
 }
 
 #[cfg(feature = "autodiff")]

--- a/crates/tenferro-einsum/src/util.rs
+++ b/crates/tenferro-einsum/src/util.rs
@@ -80,3 +80,48 @@ pub(crate) fn intermediate_subs(
     }
     output
 }
+
+/// Map each source label occurrence to a distinct matching target axis.
+///
+/// Repeated labels are occurrence-sensitive: mapping `["i", "j", "i"]` into
+/// `["i", "i", "j"]` must use axes `[0, 2, 1]`, not `[0, 2, 0]`.
+pub(crate) fn map_label_occurrences(
+    source_labels: &[u32],
+    target_labels: &[u32],
+) -> Option<Vec<usize>> {
+    let mut used = vec![false; target_labels.len()];
+    source_labels
+        .iter()
+        .map(|label| {
+            let axis = target_labels
+                .iter()
+                .enumerate()
+                .find_map(|(axis, target)| (!used[axis] && target == label).then_some(axis))?;
+            used[axis] = true;
+            Some(axis)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_label_occurrences;
+
+    #[test]
+    fn label_occurrence_mapping_uses_each_target_axis_once() {
+        assert_eq!(
+            map_label_occurrences(
+                &[b'i' as u32, b'j' as u32, b'i' as u32],
+                &[b'i' as u32, b'i' as u32, b'j' as u32,]
+            ),
+            Some(vec![0, 2, 1])
+        );
+        assert_eq!(
+            map_label_occurrences(
+                &[b'i' as u32, b'i' as u32, b'i' as u32],
+                &[b'i' as u32, b'i' as u32,]
+            ),
+            None
+        );
+    }
+}

--- a/crates/tenferro-einsum/tests/eager_tensor.rs
+++ b/crates/tenferro-einsum/tests/eager_tensor.rs
@@ -44,6 +44,40 @@ fn eager_tensor_einsum_matmul_primal_matches_expected_values() {
 }
 
 #[test]
+fn eager_tensor_einsum_repeated_output_occurrences_keep_axis_order() {
+    let ctx = test_ctx();
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 3], (1..=6).map(f64::from).collect()).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+
+    let out = [&a].einsum("ij->iji").unwrap();
+    let materialized = out.materialized().unwrap();
+
+    assert_eq!(materialized.shape(), &[2, 3, 2]);
+    for i in 0..2 {
+        for j in 0..3 {
+            for k in 0..2 {
+                let expected = if i == k {
+                    *a.materialized()
+                        .unwrap()
+                        .as_ref()
+                        .get::<f64>(&[i, j])
+                        .unwrap()
+                } else {
+                    0.0
+                };
+                assert_eq!(
+                    *materialized.as_ref().get::<f64>(&[i, j, k]).unwrap(),
+                    expected
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn eager_tensor_tensordot_count_contracts_last_lhs_with_first_rhs_axes() {
     let ctx = test_ctx();
     let lhs = EagerTensor::from_tensor_in(

--- a/crates/tenferro-einsum/tests/public_surface_contract.rs
+++ b/crates/tenferro-einsum/tests/public_surface_contract.rs
@@ -21,7 +21,7 @@ fn einsum_vjp_broadcast_active_mask_matches_dynamic_inputs() {
     let section = source
         .split_once("fn broadcast_einsum_vjp_to_input_shape")
         .and_then(|(_, rest)| {
-            rest.split_once("fn map_label_occurrences")
+            rest.split_once("fn project_repeated_labels_to_diagonal")
                 .map(|(body, _)| body)
         })
         .expect("broadcast_einsum_vjp_to_input_shape source section should exist");

--- a/crates/tenferro-einsum/tests/traced_correctness/ported_and_paths.rs
+++ b/crates/tenferro-einsum/tests/traced_correctness/ported_and_paths.rs
@@ -811,6 +811,33 @@ fn einsum_input_output_repeated_ii_to_ii() {
 }
 
 #[test]
+fn einsum_input_output_repeated_ij_to_iji_preserves_occurrences() {
+    // "ij->iji" — the second `i` occurrence must map to the newly embedded
+    // diagonal axis, not back to the first `i` axis.
+    let data: Vec<f64> = (1..=6).map(f64::from).collect();
+    let a = f64_tensor(vec![2, 3], data);
+
+    let mut engine = GraphExecutor::new(CpuBackend::new());
+    let ta = TracedTensor::from_tensor_concrete_shape(a.clone()).unwrap();
+    let ty = einsum(&mut engine, &[&ta], "ij->iji").unwrap();
+    let result = ty.run_with(&mut engine).unwrap();
+
+    assert_eq!(result.shape(), &[2, 3, 2]);
+    for i in 0..2 {
+        for j in 0..3 {
+            for k in 0..2 {
+                let expected = if i == k { get_v2(&a, &[i, j]) } else { 0.0 };
+                assert_close(
+                    get_v2(&result, &[i, j, k]),
+                    expected,
+                    &format!("ij_to_iji[{i},{j},{k}]"),
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn einsum_unit_extent_contraction() {
     // "abcdef,ace->bdf" — contraction with unit-extent dimensions
     let a = f64_tensor(vec![1, 1, 1, 1, 1, 1], vec![2.0]);

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -436,9 +436,9 @@ impl ExtensionAdRule for FftAdRule {
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        _inputs: &[ValueRef<StdTensorOp>],
-        _mode: &OperationRole,
-        _ctx: &mut ShapeGuardContext,
+        inputs: &[ValueRef<StdTensorOp>],
+        mode: &OperationRole,
+        ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let fft_op = fft_payload(op, ADRuleKind::Transpose)?;
         if !matches!(fft_op.kind, FftKind::C2C { .. }) {
@@ -446,6 +446,9 @@ impl ExtensionAdRule for FftAdRule {
                 fft_ad_family_id(fft_op.kind),
                 ADRuleKind::Transpose,
             ));
+        }
+        if !linear_transpose_input_active(mode, 0) {
+            return Ok(vec![None]);
         }
 
         match cotangent_out[0] {
@@ -460,11 +463,77 @@ impl ExtensionAdRule for FftAdRule {
                         active_mask: vec![true],
                     },
                 );
-                Ok(vec![Some(outputs[0])])
+                let restored =
+                    restore_c2c_adjoint_input_length(builder, outputs[0], inputs, fft_op, ctx)?;
+                Ok(vec![Some(restored)])
             }
             None => Ok(vec![None]),
         }
     }
+}
+
+#[cfg(feature = "autodiff")]
+fn linear_transpose_input_active(mode: &OperationRole, input_index: usize) -> bool {
+    match mode {
+        // Direct transpose-rule tests use `Primary` for globally linear
+        // extension ops. Only an explicit Linearized active mask suppresses an
+        // inactive cotangent path.
+        OperationRole::Primary => true,
+        OperationRole::Linearized { active_mask } => {
+            active_mask.get(input_index).copied().unwrap_or(false)
+        }
+    }
+}
+
+#[cfg(feature = "autodiff")]
+fn restore_c2c_adjoint_input_length(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    adjoint: LocalValueId,
+    inputs: &[ValueRef<StdTensorOp>],
+    fft_op: &FftOp,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<LocalValueId> {
+    let Some(transform_len) = fft_op.n else {
+        return Ok(adjoint);
+    };
+    let Some(input) = inputs.first() else {
+        return Err(ADRuleError::invalid_input(
+            FFT_EXTENSION_FAMILY_ID,
+            ADRuleKind::Transpose,
+            "FFT transpose rule expected one primal input",
+        ));
+    };
+    if ctx
+        .shape_of(input)
+        .ok()
+        .and_then(|shape| shape.get(fft_op.axis).and_then(SymDim::constant_value))
+        == Some(transform_len)
+    {
+        return Ok(adjoint);
+    }
+
+    let size = builder.add_operation(
+        StdTensorOp::ShapeOf { axis: fft_op.axis },
+        vec![input.clone()],
+        OperationRole::Linearized {
+            active_mask: vec![false],
+        },
+    )[0];
+    let truncated = builder.add_operation(
+        StdTensorOp::DynamicTruncate { axis: fft_op.axis },
+        vec![ValueRef::Local(adjoint), ValueRef::Local(size)],
+        OperationRole::Linearized {
+            active_mask: vec![true, false],
+        },
+    )[0];
+    let padded = builder.add_operation(
+        StdTensorOp::PadToMatch { axis: fft_op.axis },
+        vec![ValueRef::Local(truncated), input.clone()],
+        OperationRole::Linearized {
+            active_mask: vec![true, false],
+        },
+    )[0];
+    Ok(padded)
 }
 
 /// Return the explicit FFT extension AD rule set.
@@ -1242,5 +1311,29 @@ mod tests {
             .expect_err("lane layout should reject stride overflow");
 
         assert!(err.to_string().contains("overflows usize"), "{err}");
+    }
+
+    #[cfg(feature = "autodiff")]
+    #[test]
+    fn fft_transpose_rule_respects_inactive_linearized_input() {
+        let rule = FftAdRule;
+        let op = FftOp::new(FftKind::C2C { forward: true }, 0, None, FftNorm::Backward);
+        let mut builder = computegraph::graph::GraphBuilder::<StdTensorOp>::new();
+        let cotangent = builder.add_input(tenferro_ops::input_key::TensorInputKey::User { id: 0 });
+        let result = rule
+            .transpose_rule(
+                &op,
+                &mut builder,
+                &[Some(cotangent)],
+                &[],
+                &OperationRole::Linearized {
+                    active_mask: vec![false],
+                },
+                &mut ShapeGuardContext::default(),
+            )
+            .unwrap();
+
+        assert_eq!(result, vec![None]);
+        assert!(builder.build().operations().is_empty());
     }
 }

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -1,8 +1,6 @@
 use num_complex::{Complex32, Complex64};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
-#[cfg(feature = "autodiff")]
-use tenferro_ad::TracedTensorAdExt;
 use tenferro_cpu::CpuBackend;
 use tenferro_fft::{FftNorm, TracedTensorFftExt};
 use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
@@ -63,6 +61,14 @@ fn assert_f32_close(actual: &[f32], expected: &[f32]) {
     for (idx, (a, e)) in actual.iter().zip(expected).enumerate() {
         assert!((a - e).abs() < 1e-5, "idx {idx}: actual={a}, expected={e}");
     }
+}
+
+#[cfg(feature = "autodiff")]
+fn fft_ad_context() -> tenferro_ad::AdContext {
+    tenferro_ad::AdContext::builder()
+        .with_extension_rules(tenferro_fft::ad_rules().unwrap())
+        .build()
+        .unwrap()
 }
 
 #[cfg(feature = "autodiff")]
@@ -443,7 +449,7 @@ fn fft_c64_jvp_applies_fft_to_tangent() {
     .unwrap();
 
     let y = x.fft(None, -1, FftNorm::Backward).unwrap();
-    let dy = y.jvp(&x, &dx).unwrap();
+    let dy = fft_ad_context().jvp(&y, &x, &dx).unwrap();
     let out = run(&dy);
 
     assert_c64_close(
@@ -476,7 +482,7 @@ fn fft_c64_jvp_matches_finite_diff() {
     let dx = TracedTensor::from_vec_col_major(vec![4], tangent_data.clone()).unwrap();
 
     let y = x.fft(None, -1, FftNorm::Backward).unwrap();
-    let dy = y.jvp(&x, &dx).unwrap();
+    let dy = fft_ad_context().jvp(&y, &x, &dx).unwrap();
     let out = run(&dy);
 
     let expected = finite_diff_c64_directional(
@@ -517,7 +523,7 @@ fn fft_c64_vjp_uses_inverse_transform_with_adjoint_normalization() {
     .unwrap();
 
     let y = x.fft(None, -1, FftNorm::Backward).unwrap();
-    let dx = y.vjp(&x, &cotangent).unwrap();
+    let dx = fft_ad_context().vjp(&y, &x, &cotangent).unwrap();
     let out = run(&dx);
 
     assert_c64_close(
@@ -527,6 +533,71 @@ fn fft_c64_vjp_uses_inverse_transform_with_adjoint_normalization() {
             Complex64::new(1.0, 2.25),
             Complex64::new(-2.25, 4.5),
             Complex64::new(3.0, -1.25),
+        ],
+    );
+}
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn fft_c64_vjp_longer_transform_slices_to_input_length() {
+    let x = TracedTensor::from_vec_col_major(
+        vec![2],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+    )
+    .unwrap();
+    let cotangent = TracedTensor::from_vec_col_major(
+        vec![4],
+        vec![
+            Complex64::new(1.0, 1.0),
+            Complex64::new(2.0, -1.0),
+            Complex64::new(-1.0, 0.5),
+            Complex64::new(0.25, -2.0),
+        ],
+    )
+    .unwrap();
+
+    let y = x.fft(Some(4), -1, FftNorm::Backward).unwrap();
+    let dx = fft_ad_context().vjp(&y, &x, &cotangent).unwrap();
+    let out = run(&dx);
+
+    assert_eq!(out.shape(), &[2]);
+    assert_c64_close(
+        out.as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(2.25, -1.5), Complex64::new(1.0, 2.25)],
+    );
+}
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn fft_c64_vjp_shorter_transform_pads_to_input_length() {
+    let x = TracedTensor::from_vec_col_major(
+        vec![4],
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let cotangent = TracedTensor::from_vec_col_major(
+        vec![2],
+        vec![Complex64::new(3.0, 1.0), Complex64::new(-1.0, 2.0)],
+    )
+    .unwrap();
+
+    let y = x.fft(Some(2), -1, FftNorm::Backward).unwrap();
+    let dx = fft_ad_context().vjp(&y, &x, &cotangent).unwrap();
+    let out = run(&dx);
+
+    assert_eq!(out.shape(), &[4]);
+    assert_c64_close(
+        out.as_slice::<Complex64>().unwrap(),
+        &[
+            Complex64::new(2.0, 3.0),
+            Complex64::new(4.0, -1.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
         ],
     );
 }
@@ -556,7 +627,7 @@ fn ifft_c64_vjp_uses_forward_transform_with_adjoint_normalization() {
     .unwrap();
 
     let y = x.ifft(None, -1, FftNorm::Backward).unwrap();
-    let dx = y.vjp(&x, &cotangent).unwrap();
+    let dx = fft_ad_context().vjp(&y, &x, &cotangent).unwrap();
     let out = run(&dx);
 
     assert_c64_close(
@@ -585,7 +656,7 @@ fn rfft_vjp_unsupported_error_names_rfft_and_vjp() {
     .unwrap();
 
     let y = x.rfft(None, -1, FftNorm::Backward).unwrap();
-    let err = match y.vjp_optional(&x, &cotangent) {
+    let err = match fft_ad_context().vjp_optional(&y, &x, &cotangent) {
         Ok(_) => panic!("rfft VJP should remain unsupported"),
         Err(err) => err,
     };
@@ -620,7 +691,7 @@ fn irfft_jvp_unsupported_error_names_irfft_and_jvp() {
     .unwrap();
 
     let y = spectrum.irfft(Some(4), -1, FftNorm::Backward).unwrap();
-    let err = match y.jvp_optional(&spectrum, &tangent) {
+    let err = match fft_ad_context().jvp_optional(&y, &spectrum, &tangent) {
         Ok(_) => panic!("irfft JVP should remain unsupported"),
         Err(err) => err,
     };

--- a/crates/tenferro-internal-ops/src/ad/diagonal.rs
+++ b/crates/tenferro-internal-ops/src/ad/diagonal.rs
@@ -1,4 +1,5 @@
 use crate::ad::context::ShapeGuardContext;
+use crate::ad::support::linear_transpose_input_active;
 use crate::ad::PrimitiveRuleBuilder;
 use computegraph::types::{LocalValueId, OperationRole, ValueRef};
 use tidu::ADRuleResult;
@@ -53,15 +54,24 @@ pub fn transpose_extract_diag(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     axis_a: usize,
     axis_b: usize,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    if !linear_transpose_input_active(mode, 0) {
+        return Ok(vec![None]);
+    }
+
     // TODO: ExtractDiag/EmbedDiag could be replaced by Gather/Scatter
     match cotangent_out[0] {
         Some(ct) => {
+            let source_axis = if axis_a < axis_b { axis_a } else { axis_a - 1 };
             let out = builder.add_operation(
-                StdTensorOp::EmbedDiag { axis_a, axis_b },
+                StdTensorOp::EmbedDiag {
+                    axis_a: source_axis,
+                    axis_b,
+                },
                 vec![ValueRef::Local(ct)],
                 OperationRole::Linearized {
                     active_mask: vec![true],
@@ -91,10 +101,15 @@ pub fn transpose_embed_diag(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     axis_a: usize,
     axis_b: usize,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    if !linear_transpose_input_active(mode, 0) {
+        return Ok(vec![None]);
+    }
+
     // TODO: ExtractDiag/EmbedDiag could be replaced by Gather/Scatter
     match cotangent_out[0] {
         Some(ct) => {

--- a/crates/tenferro-internal-ops/src/ad/dynamic.rs
+++ b/crates/tenferro-internal-ops/src/ad/dynamic.rs
@@ -3,6 +3,7 @@ use tenferro_tensor::SliceConfig;
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use crate::ad::context::ShapeGuardContext;
+use crate::ad::support::linear_transpose_input_active;
 use crate::ad::PrimitiveRuleBuilder;
 use crate::std_tensor_op::StdTensorOp;
 
@@ -56,8 +57,13 @@ pub fn transpose_dynamic_truncate(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     axis: usize,
 ) -> Vec<Option<LocalValueId>> {
+    if !linear_transpose_input_active(mode, 0) {
+        return vec![None, None];
+    }
+
     match cotangent_out[0] {
         Some(ct) => {
             let out = builder.add_operation(
@@ -165,10 +171,7 @@ pub fn transpose_pad_to_match(
 }
 
 fn first_input_active(mode: &OperationRole) -> bool {
-    matches!(
-        mode,
-        OperationRole::Linearized { active_mask } if active_mask.first().copied().unwrap_or(false)
-    )
+    linear_transpose_input_active(mode, 0)
 }
 
 fn static_truncated_shape(

--- a/crates/tenferro-internal-ops/src/ad/elementwise.rs
+++ b/crates/tenferro-internal-ops/src/ad/elementwise.rs
@@ -523,8 +523,14 @@ pub fn linearize_clamp(
     let input_gt_lower = emit_fixed_compare(builder, CompareDir::Gt, input.clone(), lower.clone());
     let input_lt_upper = emit_fixed_compare(builder, CompareDir::Lt, input.clone(), upper.clone());
     let lower_gt_input = emit_fixed_compare(builder, CompareDir::Gt, lower.clone(), input.clone());
-    let lower_lt_upper = emit_fixed_compare(builder, CompareDir::Lt, lower, upper.clone());
-    let upper_lt_input = emit_fixed_compare(builder, CompareDir::Lt, upper, input);
+    let lower_lt_upper = emit_fixed_compare(builder, CompareDir::Lt, lower.clone(), upper.clone());
+    let max_input_lower = emit_fixed_binary(builder, StdTensorOp::Maximum, input, lower);
+    let upper_lt_max_input_lower = emit_fixed_compare(
+        builder,
+        CompareDir::Lt,
+        upper,
+        ValueRef::Local(max_input_lower),
+    );
 
     let mut terms = Vec::new();
     if let Some(d_input) = tangent_in[0] {
@@ -545,7 +551,7 @@ pub fn linearize_clamp(
         terms.push(mask_active_by_conditions(
             builder,
             d_upper,
-            &[upper_lt_input],
+            &[upper_lt_max_input_lower],
         ));
     }
 
@@ -799,18 +805,25 @@ pub fn transpose_clamp(
         inputs[1].clone(),
         inputs[2].clone(),
     );
-    let upper_lt_input = emit_fixed_compare(
+    let max_input_lower = emit_fixed_binary(
+        builder,
+        StdTensorOp::Maximum,
+        inputs[0].clone(),
+        inputs[1].clone(),
+    );
+    let upper_lt_max_input_lower = emit_fixed_compare(
         builder,
         CompareDir::Lt,
         inputs[2].clone(),
-        inputs[0].clone(),
+        ValueRef::Local(max_input_lower),
     );
 
     let input_ct = input_active
         .then(|| mask_active_by_conditions(builder, ct, &[input_gt_lower, input_lt_upper]));
     let lower_ct = lower_active
         .then(|| mask_active_by_conditions(builder, ct, &[lower_gt_input, lower_lt_upper]));
-    let upper_ct = upper_active.then(|| mask_active_by_conditions(builder, ct, &[upper_lt_input]));
+    let upper_ct =
+        upper_active.then(|| mask_active_by_conditions(builder, ct, &[upper_lt_max_input_lower]));
 
     vec![input_ct, lower_ct, upper_ct]
 }

--- a/crates/tenferro-internal-ops/src/ad/registry.rs
+++ b/crates/tenferro-internal-ops/src/ad/registry.rs
@@ -373,10 +373,10 @@ fn transpose_add(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
-    _mode: &OperationRole,
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    semiring::transpose_add(builder, cotangent_out, inputs, ctx)
+    semiring::transpose_add(builder, cotangent_out, inputs, mode, ctx)
 }
 
 fn linearize_mul(
@@ -417,10 +417,10 @@ fn transpose_neg(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     _inputs: &[ValueRef<StdTensorOp>],
-    _mode: &OperationRole,
+    mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(semiring::transpose_neg(builder, cotangent_out))
+    Ok(semiring::transpose_neg(builder, cotangent_out, mode))
 }
 
 fn linearize_conj(
@@ -439,10 +439,10 @@ fn transpose_conj(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
-    _mode: &OperationRole,
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    semiring::transpose_conj(builder, cotangent_out, inputs, ctx)
+    semiring::transpose_conj(builder, cotangent_out, inputs, mode, ctx)
 }
 
 fn linearize_div(
@@ -921,11 +921,11 @@ fn transpose_transpose(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     _inputs: &[ValueRef<StdTensorOp>],
-    _mode: &OperationRole,
+    mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let perm = catalog_payload!(op, ADRuleKind::Transpose, StdTensorOp::Transpose { perm } => perm);
-    structural::transpose_transpose(builder, cotangent_out, perm)
+    structural::transpose_transpose(builder, cotangent_out, mode, perm)
 }
 
 fn linearize_reshape(
@@ -946,10 +946,10 @@ fn transpose_reshape(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
-    _mode: &OperationRole,
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    structural::transpose_reshape(builder, cotangent_out, op, inputs, ctx)
+    structural::transpose_reshape(builder, cotangent_out, op, inputs, mode, ctx)
 }
 
 fn linearize_broadcast_in_dim(
@@ -975,7 +975,7 @@ fn transpose_broadcast_in_dim(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
-    _mode: &OperationRole,
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let (shape, dims) = catalog_payload!(
@@ -983,7 +983,7 @@ fn transpose_broadcast_in_dim(
         ADRuleKind::Transpose,
         StdTensorOp::BroadcastInDim { shape, dims } => (shape, dims)
     );
-    structural::transpose_broadcast_in_dim(builder, cotangent_out, shape, dims, inputs, ctx)
+    structural::transpose_broadcast_in_dim(builder, cotangent_out, shape, dims, inputs, mode, ctx)
 }
 
 fn linearize_convert(
@@ -1046,7 +1046,7 @@ macro_rules! diagonal_rule {
             builder: &mut dyn PrimitiveRuleBuilder,
             cotangent_out: &[Option<LocalValueId>],
             inputs: &[ValueRef<StdTensorOp>],
-            _mode: &OperationRole,
+            mode: &OperationRole,
             ctx: &mut ShapeGuardContext,
         ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
             let (axis_a, axis_b) = catalog_payload!(
@@ -1054,7 +1054,7 @@ macro_rules! diagonal_rule {
                 ADRuleKind::Transpose,
                 StdTensorOp::$variant { axis_a, axis_b } => (axis_a, axis_b)
             );
-            $trans_call(builder, cotangent_out, inputs, *axis_a, *axis_b, ctx)
+            $trans_call(builder, cotangent_out, inputs, mode, *axis_a, *axis_b, ctx)
         }
     };
 }
@@ -1093,11 +1093,11 @@ macro_rules! triangular_rule {
             builder: &mut dyn PrimitiveRuleBuilder,
             cotangent_out: &[Option<LocalValueId>],
             _inputs: &[ValueRef<StdTensorOp>],
-            _mode: &OperationRole,
+            mode: &OperationRole,
             _ctx: &mut ShapeGuardContext,
         ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
             let k = catalog_payload!(op, ADRuleKind::Transpose, StdTensorOp::$variant { k } => k);
-            Ok($trans_call(builder, cotangent_out, *k))
+            Ok($trans_call(builder, cotangent_out, mode, *k))
         }
     };
 }
@@ -1449,7 +1449,7 @@ fn transpose_dynamic_truncate(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
-    _mode: &OperationRole,
+    mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let axis = catalog_payload!(
@@ -1461,6 +1461,7 @@ fn transpose_dynamic_truncate(
         builder,
         cotangent_out,
         inputs,
+        mode,
         *axis,
     ))
 }

--- a/crates/tenferro-internal-ops/src/ad/semiring.rs
+++ b/crates/tenferro-internal-ops/src/ad/semiring.rs
@@ -4,7 +4,8 @@ use tidu::ADRuleResult;
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::support::{
     conjugate_linear_if_dtype_complex, conjugate_primal_if_complex, convert_fixed_ref_to_dtype,
-    convert_linear_to_dtype, dtype_of_or_real, project_linear_to_dtype, promote_dtype,
+    convert_linear_to_dtype, dtype_of_or_real, linear_transpose_input_active,
+    project_linear_to_dtype, promote_dtype,
 };
 use crate::ad::PrimitiveRuleBuilder;
 use crate::std_tensor_op::StdTensorOp;
@@ -144,6 +145,7 @@ pub fn transpose_add(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     match cotangent_out[0] {
@@ -151,20 +153,11 @@ pub fn transpose_add(
             let lhs_dtype = dtype_of_or_real(ctx, &inputs[0]);
             let rhs_dtype = dtype_of_or_real(ctx, &inputs[1]);
             let output_dtype = promote_dtype(lhs_dtype, rhs_dtype);
-            Ok(vec![
-                Some(project_linear_to_dtype(
-                    builder,
-                    ct,
-                    output_dtype,
-                    lhs_dtype,
-                )),
-                Some(project_linear_to_dtype(
-                    builder,
-                    ct,
-                    output_dtype,
-                    rhs_dtype,
-                )),
-            ])
+            let lhs = linear_transpose_input_active(mode, 0)
+                .then(|| project_linear_to_dtype(builder, ct, output_dtype, lhs_dtype));
+            let rhs = linear_transpose_input_active(mode, 1)
+                .then(|| project_linear_to_dtype(builder, ct, output_dtype, rhs_dtype));
+            Ok(vec![lhs, rhs])
         }
         None => Ok(vec![None, None]),
     }
@@ -234,7 +227,12 @@ pub fn transpose_mul(
 pub fn transpose_neg(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
+    mode: &OperationRole,
 ) -> Vec<Option<LocalValueId>> {
+    if !linear_transpose_input_active(mode, 0) {
+        return vec![None];
+    }
+
     match cotangent_out[0] {
         Some(ct) => {
             let out = builder.add_operation(
@@ -254,8 +252,13 @@ pub fn transpose_conj(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    if !linear_transpose_input_active(mode, 0) {
+        return Ok(vec![None]);
+    }
+
     match cotangent_out[0] {
         Some(ct) => {
             let dtype = ctx.dtype_of(&inputs[0])?;

--- a/crates/tenferro-internal-ops/src/ad/structural.rs
+++ b/crates/tenferro-internal-ops/src/ad/structural.rs
@@ -3,7 +3,7 @@ use tenferro_tensor::{PadConfig, SliceConfig};
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use crate::ad::context::{ShapeGuardContext, ShapeGuardError};
-use crate::ad::support::is_differentiable_dtype;
+use crate::ad::support::{is_differentiable_dtype, linear_transpose_input_active};
 use crate::ad::zeros::build_zero_like;
 use crate::ad::PrimitiveRuleBuilder;
 use crate::dim_expr::DimExpr;
@@ -314,8 +314,13 @@ pub fn linearize_reverse(
 pub fn transpose_transpose(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
+    mode: &OperationRole,
     perm: &[usize],
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    if !linear_transpose_input_active(mode, 0) {
+        return Ok(vec![None]);
+    }
+
     let mut inv = vec![0; perm.len()];
     let mut seen = vec![false; perm.len()];
     for (index, &value) in perm.iter().enumerate() {
@@ -363,6 +368,7 @@ pub fn transpose_reshape(
     cotangent_out: &[Option<LocalValueId>],
     op: &StdTensorOp,
     inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Reshape { to_shape: _ } = op else {
@@ -370,6 +376,11 @@ pub fn transpose_reshape(
     };
 
     let mut result = Vec::with_capacity(inputs.len());
+    if !linear_transpose_input_active(mode, 0) {
+        result.resize(inputs.len(), None);
+        return Ok(result);
+    }
+
     let primary = match cotangent_out[0] {
         Some(ct) => {
             let input_rank = ctx.rank_of(&inputs[0])?;
@@ -407,8 +418,15 @@ pub fn transpose_broadcast_in_dim(
     shape: &[DimExpr],
     dims: &[usize],
     inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    if !linear_transpose_input_active(mode, 0) {
+        let mut result = Vec::with_capacity(inputs.len());
+        result.resize(inputs.len(), None);
+        return Ok(result);
+    }
+
     let (reduce_axes, needs_input_shape_restore) =
         broadcast_transpose_reduce_axes(shape, dims, inputs, ctx)?;
 
@@ -591,11 +609,7 @@ pub fn transpose_convert(
         return vec![None];
     }
 
-    let is_active = matches!(
-        mode,
-        OperationRole::Linearized { active_mask } if active_mask.first().copied().unwrap_or(false)
-    );
-    if !is_active {
+    if !linear_transpose_input_active(mode, 0) {
         return vec![None];
     }
 
@@ -617,8 +631,13 @@ pub fn transpose_convert(
 pub fn transpose_tril(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
+    mode: &OperationRole,
     k: i64,
 ) -> Vec<Option<LocalValueId>> {
+    if !linear_transpose_input_active(mode, 0) {
+        return vec![None];
+    }
+
     match cotangent_out[0] {
         Some(ct) => {
             let out = builder.add_operation(
@@ -637,8 +656,13 @@ pub fn transpose_tril(
 pub fn transpose_triu(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
+    mode: &OperationRole,
     k: i64,
 ) -> Vec<Option<LocalValueId>> {
+    if !linear_transpose_input_active(mode, 0) {
+        return vec![None];
+    }
+
     match cotangent_out[0] {
         Some(ct) => {
             let out = builder.add_operation(
@@ -903,11 +927,6 @@ pub fn transpose_concatenate(
     let Some(ct) = cotangent_out[0] else {
         return Ok(vec![None; input_count]);
     };
-    let active_mask = match mode {
-        OperationRole::Linearized { active_mask } => active_mask,
-        OperationRole::Primary => return Ok(vec![None; input_count]),
-    };
-
     let mut result = vec![None; input_count];
     let mut axis_offset = 0usize;
     let mut concrete_shapes = Vec::with_capacity(input_count);
@@ -939,7 +958,7 @@ pub fn transpose_concatenate(
         let Some(next_axis_offset) = axis_offset.checked_add(axis_extent) else {
             return Ok(vec![None; input_count]);
         };
-        if active_mask.get(input_index).copied().unwrap_or(false) {
+        if linear_transpose_input_active(mode, input_index) {
             let starts = vec_with_axis(rank, axis, axis_offset, 0);
             let limits = input_shape
                 .iter()
@@ -973,10 +992,7 @@ pub fn transpose_concatenate(
 }
 
 fn first_input_active(mode: &OperationRole) -> bool {
-    matches!(
-        mode,
-        OperationRole::Linearized { active_mask } if active_mask.first().copied().unwrap_or(false)
-    )
+    linear_transpose_input_active(mode, 0)
 }
 
 fn vec_with_axis(rank: usize, axis: usize, axis_value: usize, other_value: usize) -> Vec<usize> {

--- a/crates/tenferro-internal-ops/src/ad/support.rs
+++ b/crates/tenferro-internal-ops/src/ad/support.rs
@@ -175,6 +175,18 @@ pub(crate) fn is_differentiable_dtype(dtype: DType) -> bool {
     matches!(dtype, DType::F32 | DType::F64 | DType::C32 | DType::C64)
 }
 
+pub(crate) fn linear_transpose_input_active(mode: &OperationRole, input_index: usize) -> bool {
+    match mode {
+        // Direct transpose-rule tests use `Primary` for globally linear
+        // primitives. Only an explicit Linearized active mask suppresses an
+        // inactive cotangent path.
+        OperationRole::Primary => true,
+        OperationRole::Linearized { active_mask } => {
+            active_mask.get(input_index).copied().unwrap_or(false)
+        }
+    }
+}
+
 fn is_complex_dtype(dtype: DType) -> bool {
     matches!(dtype, DType::C32 | DType::C64)
 }

--- a/crates/tenferro-internal-ops/src/ad/tests/structural_tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/structural_tests.rs
@@ -487,6 +487,53 @@ fn transpose_embed_diag_accepts_upper_bound_input_metadata_for_rank_only_perm() 
 }
 
 #[test]
+fn transpose_diagonal_rules_respect_inactive_data_input() {
+    let mut extract_builder = GraphBuilder::<StdTensorOp>::new();
+    let mut extract_ctx = ShapeGuardContext::default();
+    let extract_ct = extract_builder.add_input(tensor_input(57));
+    let extract_input = input_key(58);
+    extract_ctx.insert_metadata(extract_input.clone(), meta(&[2, 2]));
+
+    let extract_result = StdTensorOp::ExtractDiag {
+        axis_a: 0,
+        axis_b: 1,
+    }
+    .transpose_rule(
+        &mut extract_builder,
+        &[Some(extract_ct)],
+        &[ValueRef::External(extract_input)],
+        &linear_mode(&[false]),
+        &mut extract_ctx,
+    )
+    .unwrap();
+
+    assert_eq!(extract_result, vec![None]);
+    assert!(extract_builder.build().operations().is_empty());
+
+    let mut embed_builder = GraphBuilder::<StdTensorOp>::new();
+    let mut embed_ctx = ShapeGuardContext::default();
+    let embed_ct = embed_builder.add_input(tensor_input(59));
+    let embed_input = input_key(60);
+    embed_ctx.insert_metadata(embed_input.clone(), meta(&[2]));
+
+    let embed_result = StdTensorOp::EmbedDiag {
+        axis_a: 0,
+        axis_b: 1,
+    }
+    .transpose_rule(
+        &mut embed_builder,
+        &[Some(embed_ct)],
+        &[ValueRef::External(embed_input)],
+        &linear_mode(&[false]),
+        &mut embed_ctx,
+    )
+    .unwrap();
+
+    assert_eq!(embed_result, vec![None]);
+    assert!(embed_builder.build().operations().is_empty());
+}
+
+#[test]
 fn transpose_concatenate_returns_none_for_symbolic_concat_axis() {
     let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();

--- a/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
+++ b/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
@@ -283,6 +283,54 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
 }
 
 #[test]
+fn test_std_tensor_op_linear_transpose_rules_respect_inactive_inputs() {
+    let (add_result, _, add_graph) = run_transpose_case(StdTensorOp::Add, 2, &[true, false], true);
+    assert_eq!(add_result.len(), 2);
+    assert!(add_result[0].is_some());
+    assert_eq!(add_result[1], None);
+    assert!(add_graph.operations().is_empty());
+
+    let (neg_result, _, neg_graph) = run_transpose_case(StdTensorOp::Neg, 1, &[false], true);
+    assert_eq!(neg_result, vec![None]);
+    assert!(neg_graph.operations().is_empty());
+
+    let (transpose_result, _, transpose_graph) = run_transpose_case(
+        StdTensorOp::Transpose { perm: vec![1, 0] },
+        1,
+        &[false],
+        true,
+    );
+    assert_eq!(transpose_result, vec![None]);
+    assert!(transpose_graph.operations().is_empty());
+
+    let (reshape_result, _, reshape_graph) = run_transpose_case_with_input_shape(
+        StdTensorOp::Reshape {
+            to_shape: shape![4],
+        },
+        1,
+        &[false],
+        true,
+        Some(vec![SymDim::from(2usize), SymDim::from(2usize)]),
+    );
+    assert_eq!(reshape_result, vec![None]);
+    assert!(reshape_graph.operations().is_empty());
+
+    let (tril_result, _, tril_graph) =
+        run_transpose_case(StdTensorOp::Tril { k: 0 }, 1, &[false], true);
+    assert_eq!(tril_result, vec![None]);
+    assert!(tril_graph.operations().is_empty());
+
+    let (truncate_result, _, truncate_graph) = run_transpose_case(
+        StdTensorOp::DynamicTruncate { axis: 0 },
+        2,
+        &[false, false],
+        true,
+    );
+    assert_eq!(truncate_result, vec![None, None]);
+    assert!(truncate_graph.operations().is_empty());
+}
+
+#[test]
 fn test_std_tensor_op_convert_linearize_and_transpose_swap_dtypes() {
     let convert = StdTensorOp::Convert {
         from: DType::F64,

--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -216,6 +216,7 @@ fn downcast_ad_op(op: &dyn ExtensionOp, kind: ADRuleKind) -> ADRuleResult<&Linal
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::extension::DEFAULT_DECOMPOSITION_AD_EPS;
     use computegraph::graph::GraphBuilder;
     use tenferro_ops::input_key::TensorInputKey;
     use tenferro_ops::{ShapeExtent, SymDim, TensorMeta};
@@ -471,11 +472,19 @@ mod tests {
             LinalgOp::Cholesky,
             LinalgOp::Lu,
             LinalgOp::FullPivLu,
-            LinalgOp::Svd { eps: 1e-12 },
-            LinalgOp::SvdVals { eps: 1e-12 },
+            LinalgOp::Svd {
+                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            },
+            LinalgOp::SvdVals {
+                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            },
             LinalgOp::Qr,
-            LinalgOp::Eigh { eps: 1e-12 },
-            LinalgOp::EighVals { eps: 1e-12 },
+            LinalgOp::Eigh {
+                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            },
+            LinalgOp::EighVals {
+                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            },
             LinalgOp::Eig {
                 input_dtype: DType::F64,
             },

--- a/crates/tenferro-linalg/src/ad/support/tests.rs
+++ b/crates/tenferro-linalg/src/ad/support/tests.rs
@@ -1,5 +1,7 @@
 use tenferro_tensor::DType;
 
+use crate::extension::DEFAULT_DECOMPOSITION_AD_EPS;
+
 use super::*;
 
 #[test]
@@ -20,12 +22,29 @@ fn manifest_internal_mapping_covers_linalg_op_variants() {
             LinalgOp::FullPivLuSolve { transpose_a: false },
             LinalgAdOpKind::FullPivLuSolve,
         ),
-        (LinalgOp::Svd { eps: 1.0e-12 }, LinalgAdOpKind::Svd),
-        (LinalgOp::SvdVals { eps: 1.0e-12 }, LinalgAdOpKind::SvdVals),
-        (LinalgOp::Qr, LinalgAdOpKind::Qr),
-        (LinalgOp::Eigh { eps: 1.0e-12 }, LinalgAdOpKind::Eigh),
         (
-            LinalgOp::EighVals { eps: 1.0e-12 },
+            LinalgOp::Svd {
+                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            },
+            LinalgAdOpKind::Svd,
+        ),
+        (
+            LinalgOp::SvdVals {
+                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            },
+            LinalgAdOpKind::SvdVals,
+        ),
+        (LinalgOp::Qr, LinalgAdOpKind::Qr),
+        (
+            LinalgOp::Eigh {
+                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            },
+            LinalgAdOpKind::Eigh,
+        ),
+        (
+            LinalgOp::EighVals {
+                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            },
             LinalgAdOpKind::EighVals,
         ),
         (

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -4,7 +4,7 @@ use tenferro_ad::error::{Error, Result};
 use tenferro_ad::extension::apply_eager;
 use tenferro_ad::EagerTensor;
 
-use crate::extension::{LinalgExtensionOp, LinalgOp};
+use crate::extension::{LinalgExtensionOp, LinalgOp, DEFAULT_DECOMPOSITION_AD_EPS};
 use crate::register_runtime;
 
 /// Linear algebra extension methods for [`EagerTensor`].
@@ -121,7 +121,13 @@ fn apply_linalg_eager(op: LinalgOp, inputs: &[&EagerTensor]) -> Result<Vec<Eager
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
 pub fn svd(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor, EagerTensor)> {
-    let mut outputs = apply_linalg_eager(LinalgOp::Svd { eps: 0.0 }, &[a])?.into_iter();
+    let mut outputs = apply_linalg_eager(
+        LinalgOp::Svd {
+            eps: DEFAULT_DECOMPOSITION_AD_EPS,
+        },
+        &[a],
+    )?
+    .into_iter();
     match (
         outputs.next(),
         outputs.next(),
@@ -358,7 +364,12 @@ pub fn cholesky(a: &EagerTensor) -> Result<EagerTensor> {
 /// ```
 pub fn eigh(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
     two_outputs(
-        apply_linalg_eager(LinalgOp::Eigh { eps: 0.0 }, &[a])?,
+        apply_linalg_eager(
+            LinalgOp::Eigh {
+                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            },
+            &[a],
+        )?,
         "eigh",
     )
 }

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -16,6 +16,8 @@ mod tests;
 
 pub const LINALG_EXTENSION_FAMILY_ID: &str = "tenferro-linalg.linalg.v1";
 
+pub(crate) const DEFAULT_DECOMPOSITION_AD_EPS: f64 = 1e-12;
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[doc(hidden)]
 pub(crate) enum LinalgOp {

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -4,7 +4,7 @@ use num_complex::{Complex32, Complex64};
 use tenferro_runtime::extension::apply;
 use tenferro_runtime::{CompareDir, DType, DotGeneralConfig, Error, Result, TracedTensor};
 
-use crate::extension::{LinalgExtensionOp, LinalgOp};
+use crate::extension::{LinalgExtensionOp, LinalgOp, DEFAULT_DECOMPOSITION_AD_EPS};
 
 /// Linear algebra extension methods for [`TracedTensor`].
 pub trait TracedTensorLinalgExt {
@@ -157,7 +157,7 @@ impl TracedTensorLinalgExt for TracedTensor {
 /// assert_eq!(vt.rank, 2);
 /// ```
 pub fn svd(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor, TracedTensor)> {
-    svd_with_eps(a, 1e-12)
+    svd_with_eps(a, DEFAULT_DECOMPOSITION_AD_EPS)
 }
 
 /// Build a traced singular value decomposition op with an explicit epsilon.
@@ -219,7 +219,7 @@ pub fn qr(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
 /// assert_eq!(vectors.rank, 2);
 /// ```
 pub fn eigh(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
-    eigh_with_eps(a, 1e-12)
+    eigh_with_eps(a, DEFAULT_DECOMPOSITION_AD_EPS)
 }
 
 /// Build a traced Hermitian eigenvalue decomposition op with an explicit epsilon.
@@ -911,7 +911,9 @@ fn matrix_norm(a: &TracedTensor, axes: &[usize], ord: Option<f64>) -> Result<Tra
 fn svd_values(a: &TracedTensor) -> Result<TracedTensor> {
     one_output(
         apply(
-            Arc::new(LinalgExtensionOp::new(LinalgOp::SvdVals { eps: 1e-12 })),
+            Arc::new(LinalgExtensionOp::new(LinalgOp::SvdVals {
+                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            })),
             &[a],
         )?,
         "svd_values",
@@ -921,7 +923,9 @@ fn svd_values(a: &TracedTensor) -> Result<TracedTensor> {
 fn eigh_values(a: &TracedTensor) -> Result<TracedTensor> {
     one_output(
         apply(
-            Arc::new(LinalgExtensionOp::new(LinalgOp::EighVals { eps: 1e-12 })),
+            Arc::new(LinalgExtensionOp::new(LinalgOp::EighVals {
+                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            })),
             &[a],
         )?,
         "eigh_values",

--- a/crates/tenferro-linalg/tests/eager_tensor.rs
+++ b/crates/tenferro-linalg/tests/eager_tensor.rs
@@ -41,6 +41,26 @@ fn assert_close_slice(actual: &[f64], expected: &[f64], tol: f64) {
     }
 }
 
+fn assert_finite_f64_tensor(tensor: &Tensor) {
+    let values = f64_data(tensor);
+    assert!(
+        values.iter().all(|value| value.is_finite()),
+        "expected finite f64 tensor, got {values:?}"
+    );
+}
+
+fn weighted_square_sum(input: &EagerTensor, weights: Vec<f64>) -> EagerTensor {
+    let weights = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(input.shape().to_vec(), weights).unwrap(),
+        input.runtime().clone(),
+    )
+    .unwrap();
+    let squared = input.mul(input).unwrap();
+    let weighted = squared.mul(&weights).unwrap();
+    let axes: Vec<usize> = (0..input.shape().len()).collect();
+    weighted.reduce_sum(&axes).unwrap()
+}
+
 fn matmul2(lhs: &[f64], rhs: &[f64]) -> [f64; 4] {
     let mut out = [0.0; 4];
     for col in 0..2 {
@@ -102,6 +122,25 @@ fn svd_singular_value_sum_backward_does_not_panic() {
     loss.backward().unwrap();
 
     assert!(a.grad().unwrap().is_some());
+}
+
+#[test]
+fn svd_vector_observable_backward_grad_is_finite() {
+    let ctx = ad_test_ctx();
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.2, -0.3, 0.7, 0.4, 1.5, -0.8]).unwrap(),
+        ctx,
+    )
+    .unwrap();
+    let (u, _s, vt) = a.svd().unwrap();
+    let u_loss = weighted_square_sum(&u, vec![0.5, -0.2, 0.7, 1.1, -0.4, 0.3]);
+    let vt_loss = weighted_square_sum(&vt, vec![1.3, -0.6, 0.8, 0.2]);
+    let loss = u_loss.add(&vt_loss).unwrap();
+
+    loss.backward().unwrap();
+
+    let grad = a.grad().unwrap().unwrap();
+    assert_finite_f64_tensor(grad.as_ref());
 }
 
 #[test]
@@ -271,6 +310,23 @@ fn eigh_returns_expected_values_for_diagonal_matrix() {
         &[1.0, 3.0],
         1.0e-12,
     );
+}
+
+#[test]
+fn eigh_vector_observable_backward_grad_is_finite() {
+    let ctx = ad_test_ctx();
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.2, 0.2, 4.0]).unwrap(),
+        ctx,
+    )
+    .unwrap();
+    let (_values, vectors) = a.eigh().unwrap();
+    let loss = weighted_square_sum(&vectors, vec![0.6, -0.7, 1.3, 0.4]);
+
+    loss.backward().unwrap();
+
+    let grad = a.grad().unwrap().unwrap();
+    assert_finite_f64_tensor(grad.as_ref());
 }
 
 #[test]

--- a/crates/tenferro-runtime/src/shape_infer.rs
+++ b/crates/tenferro-runtime/src/shape_infer.rs
@@ -59,12 +59,44 @@ pub fn promote_dtype_div_like(lhs: DType, rhs: DType) -> DType {
     promote_dtype(lhs, rhs)
 }
 
+fn is_complex_dtype(dtype: DType) -> bool {
+    matches!(dtype, DType::C32 | DType::C64)
+}
+
+fn ordered_dtype_op_name(op: &StdTensorOp) -> Option<&'static str> {
+    // Complex values have no total order; keep magnitude ordering explicit by
+    // rejecting ordered primitives before dtype promotion.
+    match op {
+        StdTensorOp::Compare(_) => Some("Compare"),
+        StdTensorOp::Maximum => Some("Maximum"),
+        StdTensorOp::Minimum => Some("Minimum"),
+        StdTensorOp::Clamp => Some("Clamp"),
+        StdTensorOp::ReduceMax { axes } if !axes.is_empty() => Some("ReduceMax"),
+        StdTensorOp::ReduceMin { axes } if !axes.is_empty() => Some("ReduceMin"),
+        _ => None,
+    }
+}
+
+fn reject_complex_ordered_dtypes(op: &StdTensorOp, input_dtypes: &[DType]) -> Result<()> {
+    let Some(op_name) = ordered_dtype_op_name(op) else {
+        return Ok(());
+    };
+    if input_dtypes.iter().copied().any(is_complex_dtype) {
+        return Err(shape_infer_error(format!(
+            "{op_name} does not support complex dtypes because complex numbers have no total order"
+        )));
+    }
+    Ok(())
+}
+
 /// Infer output dtype for a single instruction given its op and input dtypes.
 ///
 /// For `StdTensorOp::Extension`, prefer the combined
 /// `infer_extension_output_meta` helper when shape metadata is also needed.
 /// This function returns only the first output's dtype.
 pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> Result<DType> {
+    reject_complex_ordered_dtypes(op, input_dtypes)?;
+
     let dtype = match op {
         StdTensorOp::Constant { dtype, .. } => *dtype,
         StdTensorOp::Convert { to, .. } => *to,
@@ -84,9 +116,7 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> Result<DT
         | StdTensorOp::Maximum
         | StdTensorOp::Minimum
         | StdTensorOp::DotGeneral { .. }
-        | StdTensorOp::Concatenate { .. }
-        | StdTensorOp::PadToMatch { .. }
-        | StdTensorOp::DynamicTruncate { .. } => promote_dtype(
+        | StdTensorOp::Concatenate { .. } => promote_dtype(
             dtype_input(op, input_dtypes, 0)?,
             dtype_input(op, input_dtypes, 1)?,
         ),
@@ -129,6 +159,8 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> Result<DT
         | StdTensorOp::Gather(_)
         | StdTensorOp::GatherDynamicSliceSizes { .. }
         | StdTensorOp::DynamicSlice { .. }
+        | StdTensorOp::DynamicTruncate { .. }
+        | StdTensorOp::PadToMatch { .. }
         | StdTensorOp::Slice(_)
         | StdTensorOp::Pad(_)
         | StdTensorOp::Reverse { .. } => dtype_input(op, input_dtypes, 0)?,

--- a/crates/tenferro-runtime/src/shape_infer/tests.rs
+++ b/crates/tenferro-runtime/src/shape_infer/tests.rs
@@ -61,6 +61,32 @@ fn promote_dtypes_fold() {
 }
 
 #[test]
+fn ordered_ops_reject_complex_dtypes() {
+    let cases = [
+        (
+            StdTensorOp::Compare(tenferro_tensor::CompareDir::Eq),
+            vec![DType::C64, DType::C64],
+        ),
+        (
+            StdTensorOp::Compare(tenferro_tensor::CompareDir::Lt),
+            vec![DType::C64, DType::C64],
+        ),
+        (StdTensorOp::Maximum, vec![DType::C32, DType::C32]),
+        (StdTensorOp::Minimum, vec![DType::C64, DType::C64]),
+        (StdTensorOp::Clamp, vec![DType::C64, DType::C64, DType::C64]),
+        (StdTensorOp::ReduceMax { axes: vec![0] }, vec![DType::C64]),
+        (StdTensorOp::ReduceMin { axes: vec![0] }, vec![DType::C32]),
+    ];
+
+    for (op, dtypes) in cases {
+        let err = infer_output_dtype(&op, &dtypes).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("complex"), "{op:?}: {message}");
+        assert!(message.contains("total order"), "{op:?}: {message}");
+    }
+}
+
+#[test]
 fn invalid_shape_configs_return_errors_instead_of_panicking() {
     let shape = DimExpr::from_concrete(&[2, 3]);
 

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -1905,19 +1905,10 @@ impl TracedTensor {
                 message: "diagonal axes must be distinct".into(),
             });
         }
-        let out_shape_hint = self.shape_hint.as_ref().map(|shape| {
-            shape
-                .iter()
-                .enumerate()
-                .filter_map(|(axis, dim)| (axis != axis_b).then_some(dim.clone()))
-                .collect()
-        });
-        Ok(apply_unary(
-            StdTensorOp::ExtractDiag { axis_a, axis_b },
-            self,
-            self.rank - 1,
-            out_shape_hint,
-        ))
+        let op = StdTensorOp::ExtractDiag { axis_a, axis_b };
+        let (out_rank, out_shape_hint) =
+            infer_traced_single_output_shape("TracedTensor::extract_diag", &op, &[self])?;
+        Ok(apply_unary(op, self, out_rank, out_shape_hint))
     }
 
     /// Embed a vector or lower-rank tensor along a diagonal.
@@ -2017,12 +2008,13 @@ impl TracedTensor {
                 message: format!("size must be a scalar tensor, got rank {}", size.rank),
             });
         }
-        Ok(apply_binary(
+        Ok(apply_binary_preserve_input_dtypes(
             StdTensorOp::DynamicTruncate { axis },
             self,
             size,
             self.rank,
             None,
+            self.dtype,
         ))
     }
 
@@ -2052,12 +2044,19 @@ impl TracedTensor {
     pub fn pad_to_match(&self, reference: &TracedTensor, axis: usize) -> Result<TracedTensor> {
         validate_traced_axis(self, axis, "TracedTensor::pad_to_match")?;
         validate_traced_axis(reference, axis, "TracedTensor::pad_to_match")?;
-        Ok(apply_binary(
-            StdTensorOp::PadToMatch { axis },
+        let op = StdTensorOp::PadToMatch { axis };
+        let (out_rank, out_shape_hint) = infer_traced_single_output_shape(
+            "TracedTensor::pad_to_match",
+            &op,
+            &[self, reference],
+        )?;
+        Ok(apply_binary_preserve_input_dtypes(
+            op,
             self,
             reference,
-            self.rank,
-            reference.shape_hint.clone(),
+            out_rank,
+            out_shape_hint,
+            self.dtype,
         ))
     }
 }

--- a/crates/tenferro-runtime/tests/runtime_public_api.rs
+++ b/crates/tenferro-runtime/tests/runtime_public_api.rs
@@ -168,6 +168,12 @@ fn traced_tensor_methods_cover_structural_surface() {
         run(&matrix.triu(0)).as_slice::<f64>().unwrap(),
         &[1.0, 0.0, 3.0, 4.0]
     );
+    let rectangular =
+        TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let diag = rectangular.extract_diag(1, 0).unwrap();
+    assert_eq!(diag.try_concrete_shape(), Some(vec![2]));
+    assert_eq!(run(&diag).shape(), &[2]);
 
     let lhs = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
     let rhs = TracedTensor::from_vec_col_major(vec![3, 2], vec![1.0_f64; 6]).unwrap();

--- a/crates/tenferro-tensor-core/src/layout.rs
+++ b/crates/tenferro-tensor-core/src/layout.rs
@@ -104,6 +104,9 @@ fn normalize_slice(slice: SliceSpec, axis_len: usize) -> Result<(isize, usize)> 
     if slice.step == 0 {
         return Err(Error::InvalidSliceStep { step: slice.step });
     }
+    if axis_len == 0 {
+        return Ok((0, 0));
+    }
 
     let axis_len = isize::try_from(axis_len).map_err(|_| Error::IntegerOverflow)?;
     if slice.step > 0 {
@@ -287,6 +290,10 @@ impl<R: TensorRank> TensorLayout<R> {
     /// # Ok::<(), tenferro_tensor_core::Error>(())
     /// ```
     pub fn is_compact_col_major(&self) -> Result<bool> {
+        if self.shape().contains(&0) {
+            return Ok(true);
+        }
+
         col_major_strides(self.shape()).map(|strides| strides.as_slice() == self.strides())
     }
 

--- a/crates/tenferro-tensor-core/src/lib.rs
+++ b/crates/tenferro-tensor-core/src/lib.rs
@@ -457,6 +457,12 @@ fn validate_view_bounds<T>(
 }
 
 fn is_slice_contiguous(shape: &[usize], strides: &[isize]) -> Result<bool> {
+    if shape.contains(&0) {
+        // Empty logical views do not touch storage, so arbitrary strides are
+        // indistinguishable from compact strides for slice/reshape purposes.
+        return Ok(true);
+    }
+
     let mut expected = 1isize;
     for (&extent, &stride) in shape.iter().zip(strides) {
         if extent <= 1 {

--- a/crates/tenferro-tensor-core/tests/core.rs
+++ b/crates/tenferro-tensor-core/tests/core.rs
@@ -506,6 +506,45 @@ fn empty_view_offsets_may_point_one_past_the_borrowed_slice() {
 }
 
 #[test]
+fn empty_views_are_contiguous_even_with_degenerate_strides() {
+    let data = [1_i32, 2, 3];
+    let empty = HostTensorView::from_slice(vec![0, 3], vec![1, 0], 3, &data).unwrap();
+    assert!(empty.is_empty());
+    assert_eq!(empty.as_slice().unwrap(), &[]);
+    assert_eq!(empty.reshape_view(vec![0]).unwrap().shape(), &[0]);
+
+    let layout =
+        TensorLayout::<DynRank>::from_parts(vec![0, 3].into(), vec![99, -7].into(), 3, data.len())
+            .unwrap();
+    assert!(layout.is_compact_col_major().unwrap());
+    assert_eq!(
+        layout
+            .reshape_view_as::<DynRank>(vec![0].into(), data.len())
+            .unwrap()
+            .shape(),
+        &[0]
+    );
+}
+
+#[test]
+fn empty_axis_allows_negative_step_slices() {
+    let layout = TensorLayout::<DynRank>::from_parts(vec![0].into(), vec![1].into(), 0, 0).unwrap();
+    let reversed = layout
+        .slice_view(
+            [SliceSpec {
+                start: 0,
+                end: 0,
+                step: -1,
+            }],
+            0,
+        )
+        .unwrap();
+
+    assert_eq!(reversed.shape(), &[0]);
+    assert_eq!(reversed.offset(), 0);
+}
+
+#[test]
 fn as_slice_accepts_nonzero_offset_and_rejects_non_contiguous_views() {
     let data = [1_i32, 2, 3, 4, 5];
     let contiguous = HostTensorView::from_slice(vec![3], vec![1], 1, &data).unwrap();

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -1469,6 +1469,18 @@ fn strided_tensor_view_validation_covers_error_edges() {
             .unwrap(),
         &[] as &[i32]
     );
+    assert_eq!(empty.try_reshape(&[0]).unwrap().shape(), &[0]);
+    let reversed_empty = empty
+        .try_slice_axis(0, StridedSliceSpec::reverse())
+        .unwrap();
+    assert_eq!(reversed_empty.shape(), &[0, 3]);
+    assert_eq!(
+        materialize_typed_view_col_major(&reversed_empty, "test")
+            .unwrap()
+            .as_slice()
+            .unwrap(),
+        &[] as &[i32]
+    );
     assert_eq!(empty.get(&[0, 0]), None);
     assert!(matches!(
         TypedTensorView::<i32>::from_slice([0], [1], 4, &data),

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -3088,6 +3088,10 @@ fn relaxed_col_major_contiguous(
     strides: &[isize],
     op: &'static str,
 ) -> crate::Result<bool> {
+    if shape.contains(&0) {
+        return Ok(true);
+    }
+
     let mut expected = 1isize;
     for (&extent, &stride) in shape.iter().zip(strides) {
         if extent <= 1 {

--- a/crates/tenferro-xla/src/lowering/program.rs
+++ b/crates/tenferro-xla/src/lowering/program.rs
@@ -439,13 +439,13 @@ fn lower_constant(
             let bytes: [u8; 4] = bytes.try_into().map_err(|_| Error::InvalidProgram {
                 message: format!("F32 constant expected 4 bytes, got {}", bytes.len()),
             })?;
-            format_float(f32::from_le_bytes(bytes) as f64)
+            format_f32(f32::from_le_bytes(bytes))
         }
         DType::F64 => {
             let bytes: [u8; 8] = bytes.try_into().map_err(|_| Error::InvalidProgram {
                 message: format!("F64 constant expected 8 bytes, got {}", bytes.len()),
             })?;
-            format_float(f64::from_le_bytes(bytes))
+            format_f64(f64::from_le_bytes(bytes))
         }
         other => {
             return Err(Error::UnsupportedDType {
@@ -635,9 +635,6 @@ fn lower_dot_general(
         name: dot,
         ty: stable_ty,
     };
-    if dot_value.ty.shape == output_ty.shape {
-        return Ok(dot_value);
-    }
 
     let lhs_free = free_dims(
         lhs.ty.shape.len(),
@@ -654,6 +651,13 @@ fn lower_dot_general(
     perm.extend(batch_count..batch_count + lhs_free.len());
     perm.extend(batch_count + lhs_free.len()..batch_count + lhs_free.len() + rhs_free.len());
     perm.extend(0..batch_count);
+    let identity_perm = perm
+        .iter()
+        .enumerate()
+        .all(|(axis, &mapped)| axis == mapped);
+    if identity_perm && dot_value.ty.shape == output_ty.shape {
+        return Ok(dot_value);
+    }
     emit_transpose(&dot_value, &perm, output_ty, emitter)
 }
 
@@ -758,6 +762,30 @@ fn format_float(value: f64) -> String {
         format!("{value:.8e}")
     } else if value.is_nan() {
         "0x7ff8000000000000".to_string()
+    } else if value.is_sign_negative() {
+        "-0x7ff0000000000000".to_string()
+    } else {
+        "0x7ff0000000000000".to_string()
+    }
+}
+
+fn format_f32(value: f32) -> String {
+    if value.is_finite() {
+        format!("{value:.8e}")
+    } else if value.is_nan() {
+        format!("0x{:08x}", value.to_bits())
+    } else if value.is_sign_negative() {
+        "-0x7f800000".to_string()
+    } else {
+        "0x7f800000".to_string()
+    }
+}
+
+fn format_f64(value: f64) -> String {
+    if value.is_finite() {
+        format!("{value:.8e}")
+    } else if value.is_nan() {
+        format!("0x{:016x}", value.to_bits())
     } else if value.is_sign_negative() {
         "-0x7ff0000000000000".to_string()
     } else {

--- a/crates/tenferro-xla/src/lowering/program/tests.rs
+++ b/crates/tenferro-xla/src/lowering/program/tests.rs
@@ -101,6 +101,20 @@ fn constant_lowering_rejects_malformed_literal_bytes() {
 }
 
 #[test]
+fn special_float_literals_preserve_dtype_width_and_nan_payload() {
+    assert_eq!(format_f32(f32::from_bits(0x7fc0_1234)), "0x7fc01234");
+    assert_eq!(format_f32(f32::INFINITY), "0x7f800000");
+    assert_eq!(format_f32(f32::NEG_INFINITY), "-0x7f800000");
+
+    assert_eq!(
+        format_f64(f64::from_bits(0x7ff8_0000_0000_1234)),
+        "0x7ff8000000001234"
+    );
+    assert_eq!(format_f64(f64::INFINITY), "0x7ff0000000000000");
+    assert_eq!(format_f64(f64::NEG_INFINITY), "-0x7ff0000000000000");
+}
+
+#[test]
 fn dot_shape_rejects_invalid_dimension_config() {
     let err = stablehlo_dot_shape(
         &[2, 3],

--- a/crates/tenferro-xla/tests/stablehlo_lowering.rs
+++ b/crates/tenferro-xla/tests/stablehlo_lowering.rs
@@ -216,6 +216,40 @@ fn batched_dot_general_transposes_stablehlo_batch_first_result() {
 }
 
 #[test]
+fn equal_extent_batched_dot_general_still_transposes_batch_last_result() {
+    let lhs = TracedTensor::input_symbolic_shape(DType::F64, 3).unwrap();
+    let rhs = TracedTensor::input_symbolic_shape(DType::F64, 3).unwrap();
+    let product = lhs
+        .dot_general(
+            &rhs,
+            DotGeneralConfig {
+                lhs_contracting_dims: vec![2],
+                rhs_contracting_dims: vec![1],
+                lhs_batch_dims: vec![0],
+                rhs_batch_dims: vec![0],
+            },
+        )
+        .unwrap();
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(
+            &product,
+            &[
+                (&lhs, DType::F64, &[2, 2, 2]),
+                (&rhs, DType::F64, &[2, 2, 2]),
+            ],
+        )
+        .unwrap();
+
+    let module = lower_to_stablehlo(&program).unwrap();
+    let text = module.as_str();
+
+    assert!(text.contains("stablehlo.dot_general"));
+    assert!(text.contains("stablehlo.transpose"));
+    assert!(text.contains("dims = [1, 2, 0]"));
+}
+
+#[test]
 fn lowers_multi_output_program_and_special_scalar_constants() {
     let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let scaled_nan = x.scale_real(f64::NAN).unwrap();

--- a/docs/worklogs/2026-06-26-terasaki-bug-batch-4.md
+++ b/docs/worklogs/2026-06-26-terasaki-bug-batch-4.md
@@ -1,0 +1,78 @@
+# Terasaki Bug Batch 4
+
+## Summary
+
+This work log records the follow-up remediation for GitHub issues #1212 and
+#1222 through #1232. The batch focuses on user-visible numerical and shape
+semantics, shared helper extraction where repeated mistakes had the same root,
+and regression coverage for the issue reproducers plus same-class audit
+findings.
+
+Claude review was explicitly cancelled by the user before this implementation
+pass because earlier attempts were too slow, so no Claude review was run for
+this batch.
+
+## Context Read
+
+- `README.md`
+- `REPOSITORY_RULES.md`
+- Shared tensor4all rules: common repository, common performance,
+  common docs-and-tests, Rust performance, Rust numerical
+- GitHub issues #1212 and #1222 through #1232
+- Prior work log `docs/worklogs/2026-06-26-issue-1209-1220-remediation.md`
+
+## Classification Ledger
+
+| Issue/finding | Classification | Resolution |
+| --- | --- | --- |
+| #1212 degenerate `Clamp` AD | Maintainer decision | User chose permissive `lower > upper` semantics. CPU clamp was aligned with `min(max(x, lower), upper)`, and AD coverage now checks degenerate bounds. |
+| #1222 FFT `transpose_rule` ignores role | Auto fix / shared-helper parity | Added role-aware active-input helper usage and FFT coverage so `Primary` and inactive linearized paths do not emit invalid cotangents. |
+| #1223 `DynamicTruncate` / `PadToMatch` dtype promotion | Auto fix | Runtime dtype inference now preserves the data operand dtype instead of promoting with shape/control operands. |
+| #1224 `transpose_extract_diag` axis order | Auto fix | Diagonal transpose now maps rectangular reversed axes correctly. |
+| #1225 XLA dot-general transpose skip | Auto fix | StableHLO lowering skips output transpose only when the permutation is identity and the shape already matches. |
+| #1226 `TracedTensor::pad_to_match` shape hint | Auto fix | Traced metadata now uses the padded input shape rather than the reference tensor shape as the result hint. |
+| #1227 einsum repeated output labels | Auto fix / shared helper | Added occurrence-aware label mapping and reused it across traced/eager/extension paths. |
+| #1228 empty layout contiguity | Auto fix | Empty views are treated as contiguous even when degenerate strides appear before larger axes, with tensor-core and tensor-view coverage. |
+| #1229 FFT C2C VJP length mismatch | Auto fix | C2C adjoints restore input length using runtime shape, dynamic truncate, and pad-to-match instead of returning the transformed length. |
+| #1230 XLA F32 non-finite literals | Auto fix | StableHLO scalar formatting preserves f32 bit width and NaN payloads. |
+| #1231 complex ordered comparisons | Explicit rejection | Runtime and CPU ordered operations now reject complex dtypes with diagnostics; users should compute abs/norm explicitly before ordering. |
+| #1232 eager `svd`/`eigh` eps | Auto fix / shared constant | Eager and traced decomposition AD paths share `DEFAULT_DECOMPOSITION_AD_EPS = 1e-12`, preventing NaN gradients for vector-valued observables. |
+
+## Shared Helpers And Preventive Measures
+
+- `linear_transpose_input_active` centralizes the `OperationRole` /
+  `active_mask` policy for standard AD transpose rules. This avoids each rule
+  rediscovering how `Primary` direct-rule tests and inactive linearized inputs
+  should behave.
+- `map_label_occurrences` centralizes occurrence-sensitive einsum label
+  mapping so repeated labels cannot accidentally reuse the first matching axis.
+- `reject_complex_ordered_dtypes` in runtime shape inference and CPU dispatch
+  keeps the no-total-order decision at public operation boundaries instead of
+  relying on missing low-level trait impls.
+- `DEFAULT_DECOMPOSITION_AD_EPS` keeps eager and traced linalg decomposition AD
+  defaults in one place.
+
+## Verification
+
+Focused red/green and regression checks were run for each issue family,
+including dtype propagation, clamp AD, extract-diag AD, FFT inactive-mode and
+length-changing VJP paths, einsum repeated labels, XLA lowering, complex ordered
+operation rejection, empty-layout contiguity, and eager linalg finite-gradient
+coverage.
+
+Final pre-PR workspace verification:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo nextest run --release --workspace --no-fail-fast`
+- `cargo doc --workspace --no-deps`
+- `cargo test --doc --release --workspace`
+
+## Residual Risks
+
+- Complex equality remains exact equality where equality is not an ordered
+  operation; ordered comparisons and extrema are rejected instead of defining a
+  magnitude order.
+- The FFT C2C transpose path now handles runtime length restoration, but broader
+  real FFT length-changing variants should still be audited when those APIs are
+  extended.


### PR DESCRIPTION
## Summary

- harden tensor/runtime edge semantics for permissive clamp bounds, dtype-preserving dynamic shape ops, empty-view contiguity, and explicit complex ordered-op rejection
- centralize AD transpose active-mask handling, fix extract-diag transpose axes, and restore FFT C2C VJP input lengths
- fix occurrence-sensitive einsum label mapping, StableHLO edge-case lowering, and eager linalg decomposition AD eps defaults
- record design rationale and verification in `docs/worklogs/2026-06-26-terasaki-bug-batch-4.md`

## References

Fixes #1212
Fixes #1222
Fixes #1223
Fixes #1224
Fixes #1225
Fixes #1226
Fixes #1227
Fixes #1228
Fixes #1229
Fixes #1230
Fixes #1231
Fixes #1232

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --release --workspace --no-fail-fast` (`1789 passed, 0 skipped`)
- `cargo doc --workspace --no-deps`
- `cargo test --doc --release --workspace`
