### PR TITLE
[codex] Add concrete operation public APIs

### DIFF
--- a/crates/tenferro-einsum/Cargo.toml
+++ b/crates/tenferro-einsum/Cargo.toml
@@ -8,7 +8,7 @@ publish.workspace = true
 readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "Subscripts, contraction planning, traced/eager einsum APIs, extension runtime, and AD rule for tenferro."
+description = "Subscripts, contraction planning, concrete/traced/eager einsum APIs, extension runtime, and AD rule for tenferro."
 
 [features]
 default = ["cpu-faer"]

--- a/crates/tenferro-einsum/src/concrete.rs
+++ b/crates/tenferro-einsum/src/concrete.rs
@@ -370,7 +370,7 @@ impl ConcreteEinsumPlan {
             });
         }
 
-        for (index, (expected, actual)) in self.inputs.iter().zip(actual.iter()).enumerate() {
+        for (expected, actual) in self.inputs.iter().zip(actual.iter()) {
             if expected.dtype != actual.dtype {
                 return Err(Error::DTypeMismatch {
                     op,
@@ -385,19 +385,13 @@ impl ConcreteEinsumPlan {
                     rhs: actual.shape.clone(),
                 });
             }
-            if expected.shape.len() != actual.shape.len() {
-                return Err(Error::InvalidConfig {
-                    op,
-                    message: format!("input {index} rank changed during prepared einsum execution"),
-                });
-            }
         }
 
         Ok(())
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 struct ConcreteEinsumInputSpec {
     dtype: DType,
     shape: Vec<usize>,
@@ -451,7 +445,10 @@ fn typed_einsum_subscripts<T: TensorScalar>(
     into_typed_result(result, op)
 }
 
-fn into_typed_result<T: TensorScalar>(result: Tensor, op: &'static str) -> Result<TypedTensor<T>> {
+pub(crate) fn into_typed_result<T: TensorScalar>(
+    result: Tensor,
+    op: &'static str,
+) -> Result<TypedTensor<T>> {
     let actual = result.dtype();
     T::into_typed(result).map_err(|_| Error::DTypeMismatch {
         op,

--- a/crates/tenferro-einsum/src/concrete.rs
+++ b/crates/tenferro-einsum/src/concrete.rs
@@ -1,0 +1,461 @@
+//! Public concrete tensor einsum extension API.
+
+use tenferro_tensor::{
+    DType, Error, Result, Tensor, TensorBackend, TensorRead, TensorScalar, TypedTensor,
+};
+
+use crate::eager::{
+    eager_einsum_exec, eager_einsum_exec_read, eager_einsum_read_subscripts,
+    eager_einsum_subscripts, plan_subscripts,
+};
+use crate::{ContractionTree, EinsumSubscripts, Subscripts};
+
+const TENSOR_EINSUM_OP: &str = "TensorEinsumExt::einsum";
+const TENSOR_READ_EINSUM_OP: &str = "TensorReadEinsumExt::einsum_read";
+const TYPED_TENSOR_EINSUM_OP: &str = "TypedTensorEinsumExt::einsum";
+const PLAN_PREPARE_OP: &str = "ConcreteEinsumPlan::prepare";
+const PLAN_EXECUTE_OP: &str = "ConcreteEinsumPlan::execute";
+
+/// Backend-explicit einsum methods for dtype-erased concrete tensors.
+///
+/// Implementations are provided for slices and fixed-size arrays of
+/// [`Tensor`] references, so both `inputs.as_slice().einsum(...)` and
+/// `[&lhs, &rhs].einsum(...)` work.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_einsum::TensorEinsumExt;
+/// use tenferro_tensor::Tensor;
+///
+/// let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+/// let rhs = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
+/// let mut backend = CpuBackend::new();
+///
+/// let out = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend)?;
+/// assert_eq!(out.shape(), &[2, 4]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+pub trait TensorEinsumExt {
+    /// Execute an einsum from string notation.
+    fn einsum<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor>;
+
+    /// Execute an einsum from parsed integer-label subscripts.
+    fn einsum_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+    ) -> Result<Tensor>;
+}
+
+impl TensorEinsumExt for [&Tensor] {
+    fn einsum<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor> {
+        let subscripts = parse_subscripts(subscripts, TENSOR_EINSUM_OP)?;
+        eager_einsum_subscripts(backend, self, &subscripts)
+    }
+
+    fn einsum_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+    ) -> Result<Tensor> {
+        let subscripts = Subscripts::from(subscripts);
+        eager_einsum_subscripts(backend, self, &subscripts)
+    }
+}
+
+impl<const N: usize> TensorEinsumExt for [&Tensor; N] {
+    fn einsum<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor> {
+        self.as_slice().einsum(subscripts, backend)
+    }
+
+    fn einsum_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+    ) -> Result<Tensor> {
+        self.as_slice().einsum_subscripts(subscripts, backend)
+    }
+}
+
+/// Backend-explicit einsum methods for typed concrete tensors.
+///
+/// The result keeps the same scalar type as the inputs. Mixed dtypes should use
+/// [`TensorEinsumExt`] on dtype-erased [`Tensor`] values instead.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_einsum::TypedTensorEinsumExt;
+/// use tenferro_tensor::TypedTensor;
+///
+/// let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0; 6]).unwrap();
+/// let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 4], vec![1.0; 12]).unwrap();
+/// let mut backend = CpuBackend::new();
+///
+/// let out = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend)?;
+/// assert_eq!(out.shape(), &[2, 4]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+pub trait TypedTensorEinsumExt<T: TensorScalar> {
+    /// Execute an einsum from string notation.
+    fn einsum<B: TensorBackend>(&self, subscripts: &str, backend: &mut B)
+        -> Result<TypedTensor<T>>;
+
+    /// Execute an einsum from parsed integer-label subscripts.
+    fn einsum_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>>;
+}
+
+impl<T: TensorScalar> TypedTensorEinsumExt<T> for [&TypedTensor<T>] {
+    fn einsum<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>> {
+        let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_EINSUM_OP)?;
+        typed_einsum_subscripts(backend, self, &subscripts, TYPED_TENSOR_EINSUM_OP)
+    }
+
+    fn einsum_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>> {
+        let subscripts = Subscripts::from(subscripts);
+        typed_einsum_subscripts(backend, self, &subscripts, TYPED_TENSOR_EINSUM_OP)
+    }
+}
+
+impl<T: TensorScalar, const N: usize> TypedTensorEinsumExt<T> for [&TypedTensor<T>; N] {
+    fn einsum<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>> {
+        self.as_slice().einsum(subscripts, backend)
+    }
+
+    fn einsum_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>> {
+        self.as_slice().einsum_subscripts(subscripts, backend)
+    }
+}
+
+/// Backend-explicit einsum methods for [`TensorRead`] inputs.
+///
+/// Use this surface when an input is a borrowed tensor view rather than an
+/// owned compact [`Tensor`]. The `_read` suffix follows the repository-wide
+/// convention for APIs that explicitly accept read-oriented borrowed inputs.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_einsum::TensorReadEinsumExt;
+/// use tenferro_tensor::{Tensor, TensorRead, TensorView};
+///
+/// let shape = [2, 3];
+/// let data = [1.0_f64; 6];
+/// let rhs = Tensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
+/// let inputs = [
+///     TensorRead::from_view(TensorView::f64(&shape, &data)?),
+///     TensorRead::from_tensor(&rhs),
+/// ];
+/// let mut backend = CpuBackend::new();
+///
+/// let out = inputs.einsum_read("ij,j->i", &mut backend)?;
+/// assert_eq!(out.shape(), &[2]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+pub trait TensorReadEinsumExt {
+    /// Execute an einsum from string notation over read-only tensor inputs.
+    fn einsum_read<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor>;
+
+    /// Execute an einsum from parsed integer-label subscripts over read-only
+    /// tensor inputs.
+    fn einsum_read_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+    ) -> Result<Tensor>;
+}
+
+impl<'a> TensorReadEinsumExt for [TensorRead<'a>] {
+    fn einsum_read<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor> {
+        let subscripts = parse_subscripts(subscripts, TENSOR_READ_EINSUM_OP)?;
+        eager_einsum_read_subscripts(backend, self, &subscripts)
+    }
+
+    fn einsum_read_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+    ) -> Result<Tensor> {
+        let subscripts = Subscripts::from(subscripts);
+        eager_einsum_read_subscripts(backend, self, &subscripts)
+    }
+}
+
+impl<'a, const N: usize> TensorReadEinsumExt for [TensorRead<'a>; N] {
+    fn einsum_read<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor> {
+        self.as_slice().einsum_read(subscripts, backend)
+    }
+
+    fn einsum_read_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+    ) -> Result<Tensor> {
+        self.as_slice().einsum_read_subscripts(subscripts, backend)
+    }
+}
+
+/// Prepared concrete einsum plan for repeated executions with fixed input
+/// dtype and shape metadata.
+///
+/// Preparing a plan parses and optimizes the contraction tree once. Execution
+/// validates the later inputs against the prepared dtype and shape contract,
+/// then runs the stored tree without re-planning.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_einsum::ConcreteEinsumPlan;
+/// use tenferro_tensor::Tensor;
+///
+/// let lhs = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+/// let rhs = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
+/// let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik")?;
+///
+/// let mut backend = CpuBackend::new();
+/// let out = plan.execute([&lhs, &rhs], &mut backend)?;
+/// assert_eq!(out.shape(), &[2, 4]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+#[derive(Debug)]
+pub struct ConcreteEinsumPlan {
+    tree: ContractionTree,
+    inputs: Vec<ConcreteEinsumInputSpec>,
+}
+
+impl ConcreteEinsumPlan {
+    /// Prepare a plan from dtype-erased concrete tensor inputs and string
+    /// notation.
+    pub fn prepare<'a, I>(inputs: I, subscripts: &str) -> Result<Self>
+    where
+        I: AsRef<[&'a Tensor]>,
+    {
+        let subscripts = parse_subscripts(subscripts, PLAN_PREPARE_OP)?;
+        Self::prepare_subscripts_internal(input_specs(inputs.as_ref()), &subscripts)
+    }
+
+    /// Prepare a plan from dtype-erased concrete tensor inputs and parsed
+    /// integer-label subscripts.
+    pub fn prepare_subscripts<'a, I>(inputs: I, subscripts: &EinsumSubscripts) -> Result<Self>
+    where
+        I: AsRef<[&'a Tensor]>,
+    {
+        let subscripts = Subscripts::from(subscripts);
+        Self::prepare_subscripts_internal(input_specs(inputs.as_ref()), &subscripts)
+    }
+
+    /// Prepare a plan from typed concrete tensor inputs and string notation.
+    pub fn prepare_typed<'a, T, I>(inputs: I, subscripts: &str) -> Result<Self>
+    where
+        T: TensorScalar,
+        I: AsRef<[&'a TypedTensor<T>]>,
+    {
+        let subscripts = parse_subscripts(subscripts, PLAN_PREPARE_OP)?;
+        Self::prepare_subscripts_internal(typed_input_specs(inputs.as_ref()), &subscripts)
+    }
+
+    /// Prepare a plan from typed concrete tensor inputs and parsed integer-label
+    /// subscripts.
+    pub fn prepare_typed_subscripts<'a, T, I>(
+        inputs: I,
+        subscripts: &EinsumSubscripts,
+    ) -> Result<Self>
+    where
+        T: TensorScalar,
+        I: AsRef<[&'a TypedTensor<T>]>,
+    {
+        let subscripts = Subscripts::from(subscripts);
+        Self::prepare_subscripts_internal(typed_input_specs(inputs.as_ref()), &subscripts)
+    }
+
+    /// Prepare a plan from read-only tensor inputs and string notation.
+    pub fn prepare_read<'a, I>(inputs: I, subscripts: &str) -> Result<Self>
+    where
+        I: AsRef<[TensorRead<'a>]>,
+    {
+        let subscripts = parse_subscripts(subscripts, PLAN_PREPARE_OP)?;
+        Self::prepare_subscripts_internal(read_input_specs(inputs.as_ref()), &subscripts)
+    }
+
+    /// Prepare a plan from read-only tensor inputs and parsed integer-label
+    /// subscripts.
+    pub fn prepare_read_subscripts<'a, I>(inputs: I, subscripts: &EinsumSubscripts) -> Result<Self>
+    where
+        I: AsRef<[TensorRead<'a>]>,
+    {
+        let subscripts = Subscripts::from(subscripts);
+        Self::prepare_subscripts_internal(read_input_specs(inputs.as_ref()), &subscripts)
+    }
+
+    /// Execute this plan on dtype-erased concrete tensor inputs.
+    pub fn execute<'a, I, B>(&self, inputs: I, backend: &mut B) -> Result<Tensor>
+    where
+        I: AsRef<[&'a Tensor]>,
+        B: TensorBackend,
+    {
+        let inputs = inputs.as_ref();
+        self.validate_inputs(&input_specs(inputs), PLAN_EXECUTE_OP)?;
+        backend.with_backend_session(|exec| eager_einsum_exec(exec, inputs, &self.tree))
+    }
+
+    /// Execute this plan on typed concrete tensor inputs.
+    pub fn execute_typed<'a, T, I, B>(&self, inputs: I, backend: &mut B) -> Result<TypedTensor<T>>
+    where
+        T: TensorScalar,
+        I: AsRef<[&'a TypedTensor<T>]>,
+        B: TensorBackend,
+    {
+        let inputs = inputs.as_ref();
+        self.validate_inputs(&typed_input_specs(inputs), PLAN_EXECUTE_OP)?;
+        let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
+        let result = backend
+            .with_backend_session(|exec| eager_einsum_exec_read(exec, &reads, &self.tree))?;
+        into_typed_result(result, PLAN_EXECUTE_OP)
+    }
+
+    /// Execute this plan on read-only tensor inputs.
+    pub fn execute_read<'a, I, B>(&self, inputs: I, backend: &mut B) -> Result<Tensor>
+    where
+        I: AsRef<[TensorRead<'a>]>,
+        B: TensorBackend,
+    {
+        let inputs = inputs.as_ref();
+        self.validate_inputs(&read_input_specs(inputs), PLAN_EXECUTE_OP)?;
+        backend.with_backend_session(|exec| eager_einsum_exec_read(exec, inputs, &self.tree))
+    }
+
+    fn prepare_subscripts_internal(
+        inputs: Vec<ConcreteEinsumInputSpec>,
+        subscripts: &Subscripts,
+    ) -> Result<Self> {
+        let shapes: Vec<&[usize]> = inputs.iter().map(|input| input.shape.as_slice()).collect();
+        let tree = plan_subscripts(subscripts, &shapes)?;
+        Ok(Self { tree, inputs })
+    }
+
+    fn validate_inputs(&self, actual: &[ConcreteEinsumInputSpec], op: &'static str) -> Result<()> {
+        if actual.len() != self.inputs.len() {
+            return Err(Error::InvalidConfig {
+                op,
+                message: format!(
+                    "prepared einsum expects {} inputs, got {}",
+                    self.inputs.len(),
+                    actual.len()
+                ),
+            });
+        }
+
+        for (index, (expected, actual)) in self.inputs.iter().zip(actual.iter()).enumerate() {
+            if expected.dtype != actual.dtype {
+                return Err(Error::DTypeMismatch {
+                    op,
+                    lhs: expected.dtype,
+                    rhs: actual.dtype,
+                });
+            }
+            if expected.shape != actual.shape {
+                return Err(Error::ShapeMismatch {
+                    op,
+                    lhs: expected.shape.clone(),
+                    rhs: actual.shape.clone(),
+                });
+            }
+            if expected.shape.len() != actual.shape.len() {
+                return Err(Error::InvalidConfig {
+                    op,
+                    message: format!("input {index} rank changed during prepared einsum execution"),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConcreteEinsumInputSpec {
+    dtype: DType,
+    shape: Vec<usize>,
+}
+
+fn parse_subscripts(subscripts: &str, op: &'static str) -> Result<Subscripts> {
+    Subscripts::parse(subscripts).map_err(|err| Error::InvalidConfig {
+        op,
+        message: format!("invalid subscripts: {err}"),
+    })
+}
+
+fn input_specs(inputs: &[&Tensor]) -> Vec<ConcreteEinsumInputSpec> {
+    inputs
+        .iter()
+        .map(|tensor| ConcreteEinsumInputSpec {
+            dtype: tensor.dtype(),
+            shape: tensor.shape().to_vec(),
+        })
+        .collect()
+}
+
+fn typed_input_specs<T: TensorScalar>(inputs: &[&TypedTensor<T>]) -> Vec<ConcreteEinsumInputSpec> {
+    inputs
+        .iter()
+        .map(|tensor| ConcreteEinsumInputSpec {
+            dtype: T::dtype(),
+            shape: tensor.shape().to_vec(),
+        })
+        .collect()
+}
+
+fn read_input_specs(inputs: &[TensorRead<'_>]) -> Vec<ConcreteEinsumInputSpec> {
+    inputs
+        .iter()
+        .map(|tensor| ConcreteEinsumInputSpec {
+            dtype: tensor.dtype(),
+            shape: tensor.shape().to_vec(),
+        })
+        .collect()
+}
+
+fn typed_einsum_subscripts<T: TensorScalar>(
+    backend: &mut impl TensorBackend,
+    inputs: &[&TypedTensor<T>],
+    subscripts: &Subscripts,
+    op: &'static str,
+) -> Result<TypedTensor<T>> {
+    let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
+    let result = eager_einsum_read_subscripts(backend, &reads, subscripts)?;
+    into_typed_result(result, op)
+}
+
+fn into_typed_result<T: TensorScalar>(result: Tensor, op: &'static str) -> Result<TypedTensor<T>> {
+    let actual = result.dtype();
+    T::into_typed(result).map_err(|_| Error::DTypeMismatch {
+        op,
+        lhs: T::dtype(),
+        rhs: actual,
+    })
+}

--- a/crates/tenferro-einsum/src/concrete_tests.rs
+++ b/crates/tenferro-einsum/src/concrete_tests.rs
@@ -2,7 +2,10 @@ use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{DType, Tensor, TensorRead, TensorView, TypedTensor, TypedTensorView};
 
-use crate::{ConcreteEinsumPlan, TensorEinsumExt, TensorReadEinsumExt, TypedTensorEinsumExt};
+use crate::{
+    parse_einsum_subscripts, ConcreteEinsumPlan, TensorEinsumExt, TensorReadEinsumExt,
+    TypedTensorEinsumExt,
+};
 
 fn assert_f64_tensor(tensor: &Tensor, shape: &[usize], expected: &[f64]) {
     assert_eq!(tensor.shape(), shape);
@@ -20,6 +23,28 @@ fn public_tensor_einsum_ext_executes_dtype_erased_inputs() {
     let result = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend).unwrap();
 
     assert_f64_tensor(&result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn public_tensor_einsum_ext_accepts_slice_and_integer_subscripts() {
+    let mut backend = CpuBackend::new();
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let subscripts = parse_einsum_subscripts("ij,jk->ik").unwrap();
+    let inputs = vec![&lhs, &rhs];
+
+    let slice_result = inputs
+        .as_slice()
+        .einsum_subscripts(&subscripts, &mut backend)
+        .unwrap();
+    let array_result = [&lhs, &rhs]
+        .einsum_subscripts(&subscripts, &mut backend)
+        .unwrap();
+
+    assert_f64_tensor(&slice_result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+    assert_f64_tensor(&array_result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
 }
 
 #[test]
@@ -42,12 +67,50 @@ fn public_typed_tensor_einsum_ext_preserves_complex_dtype() {
     .unwrap();
 
     let result = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend).unwrap();
+    let subscripts = parse_einsum_subscripts("ij,jk->ik").unwrap();
+    let integer_result = [&lhs, &rhs]
+        .einsum_subscripts(&subscripts, &mut backend)
+        .unwrap();
+    let plan = ConcreteEinsumPlan::prepare_typed_subscripts([&lhs, &rhs], &subscripts).unwrap();
+    let planned_result = plan.execute_typed([&lhs, &rhs], &mut backend).unwrap();
 
     assert_eq!(result.shape(), &[2, 1]);
     assert_eq!(
         result.as_slice().unwrap(),
         &[Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)]
     );
+    assert_eq!(
+        integer_result.as_slice().unwrap(),
+        &[Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)]
+    );
+    assert_eq!(
+        planned_result.as_slice().unwrap(),
+        &[Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)]
+    );
+}
+
+#[test]
+fn public_typed_tensor_einsum_ext_accepts_slice_and_integer_subscripts() {
+    let mut backend = CpuBackend::new();
+    let lhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let rhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let subscripts = parse_einsum_subscripts("ij,jk->ik").unwrap();
+    let inputs = vec![&lhs, &rhs];
+
+    let slice_result = inputs
+        .as_slice()
+        .einsum_subscripts(&subscripts, &mut backend)
+        .unwrap();
+    let array_result = [&lhs, &rhs]
+        .einsum_subscripts(&subscripts, &mut backend)
+        .unwrap();
+
+    assert_eq!(slice_result.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+    assert_eq!(array_result.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
 }
 
 #[test]
@@ -67,6 +130,30 @@ fn public_tensor_read_einsum_ext_accepts_strided_views() {
 }
 
 #[test]
+fn public_tensor_read_einsum_ext_accepts_slice_and_integer_subscripts() {
+    let mut backend = CpuBackend::new();
+    let matrix_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let vector = Tensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]).unwrap();
+    let row_major_view = TypedTensorView::from_slice([2, 3], [3, 1], 0, &matrix_data).unwrap();
+    let inputs = [
+        TensorRead::from_view(TensorView::F64(row_major_view)),
+        TensorRead::from_tensor(&vector),
+    ];
+    let subscripts = parse_einsum_subscripts("ij,j->i").unwrap();
+
+    let slice_result = inputs
+        .as_slice()
+        .einsum_read_subscripts(&subscripts, &mut backend)
+        .unwrap();
+    let array_result = inputs
+        .einsum_read_subscripts(&subscripts, &mut backend)
+        .unwrap();
+
+    assert_f64_tensor(&slice_result, &[2], &[140.0, 320.0]);
+    assert_f64_tensor(&array_result, &[2], &[140.0, 320.0]);
+}
+
+#[test]
 fn concrete_einsum_plan_executes_without_replanning_contract() {
     let lhs =
         Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
@@ -82,6 +169,51 @@ fn concrete_einsum_plan_executes_without_replanning_contract() {
 
     assert_f64_tensor(&first, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
     assert_f64_tensor(&second, &[2, 2], &[7.0, 10.0, 40.0, 52.0]);
+}
+
+#[test]
+fn concrete_einsum_plan_prepares_integer_and_read_variants() {
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let typed_lhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let typed_rhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let read_inputs = [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)];
+    let subscripts = parse_einsum_subscripts("ij,jk->ik").unwrap();
+
+    let tensor_plan = ConcreteEinsumPlan::prepare_subscripts([&lhs, &rhs], &subscripts).unwrap();
+    let typed_plan =
+        ConcreteEinsumPlan::prepare_typed_subscripts([&typed_lhs, &typed_rhs], &subscripts)
+            .unwrap();
+    let read_string_plan =
+        ConcreteEinsumPlan::prepare_read(read_inputs.as_slice(), "ij,jk->ik").unwrap();
+    let read_integer_plan =
+        ConcreteEinsumPlan::prepare_read_subscripts(read_inputs.as_slice(), &subscripts).unwrap();
+    let debug = format!("{tensor_plan:?}");
+
+    let mut backend = CpuBackend::new();
+    let tensor_result = tensor_plan.execute([&lhs, &rhs], &mut backend).unwrap();
+    let typed_result = typed_plan
+        .execute_typed([&typed_lhs, &typed_rhs], &mut backend)
+        .unwrap();
+    let read_string_result = read_string_plan
+        .execute_read(read_inputs.as_slice(), &mut backend)
+        .unwrap();
+    let read_integer_result = read_integer_plan
+        .execute_read(read_inputs.as_slice(), &mut backend)
+        .unwrap();
+
+    assert!(debug.contains("ConcreteEinsumPlan"));
+    assert!(debug.contains("F64"));
+    assert_f64_tensor(&tensor_result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+    assert_eq!(typed_result.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+    assert_f64_tensor(&read_string_result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+    assert_f64_tensor(&read_integer_result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
 }
 
 #[test]
@@ -141,6 +273,52 @@ fn concrete_einsum_plan_rejects_shape_and_dtype_mismatches() {
         dtype_err,
         tenferro_tensor::Error::DTypeMismatch {
             op: "ConcreteEinsumPlan::execute",
+            lhs: DType::F64,
+            rhs: DType::F32,
+        }
+    ));
+}
+
+#[test]
+fn concrete_einsum_public_api_reports_parse_and_input_count_errors() {
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let mut backend = CpuBackend::new();
+
+    let parse_err = [&lhs, &rhs]
+        .einsum("ij,(jk)->ik", &mut backend)
+        .unwrap_err();
+    let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
+    let count_err = plan.execute([&lhs], &mut backend).unwrap_err();
+
+    assert!(matches!(
+        parse_err,
+        tenferro_tensor::Error::InvalidConfig {
+            op: "TensorEinsumExt::einsum",
+            ..
+        }
+    ));
+    assert!(matches!(
+        count_err,
+        tenferro_tensor::Error::InvalidConfig {
+            op: "ConcreteEinsumPlan::execute",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn concrete_einsum_typed_result_reports_defensive_dtype_mismatch() {
+    let tensor = Tensor::from_vec_col_major(vec![1], vec![1.0_f32]).unwrap();
+
+    let err = crate::concrete::into_typed_result::<f64>(tensor, "test typed result").unwrap_err();
+
+    assert!(matches!(
+        err,
+        tenferro_tensor::Error::DTypeMismatch {
+            op: "test typed result",
             lhs: DType::F64,
             rhs: DType::F32,
         }

--- a/crates/tenferro-einsum/src/concrete_tests.rs
+++ b/crates/tenferro-einsum/src/concrete_tests.rs
@@ -1,0 +1,148 @@
+use num_complex::Complex64;
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::{DType, Tensor, TensorRead, TensorView, TypedTensor, TypedTensorView};
+
+use crate::{ConcreteEinsumPlan, TensorEinsumExt, TensorReadEinsumExt, TypedTensorEinsumExt};
+
+fn assert_f64_tensor(tensor: &Tensor, shape: &[usize], expected: &[f64]) {
+    assert_eq!(tensor.shape(), shape);
+    assert_eq!(tensor.as_slice::<f64>().unwrap(), expected);
+}
+
+#[test]
+fn public_tensor_einsum_ext_executes_dtype_erased_inputs() {
+    let mut backend = CpuBackend::new();
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+
+    let result = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend).unwrap();
+
+    assert_f64_tensor(&result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn public_typed_tensor_einsum_ext_preserves_complex_dtype() {
+    let mut backend = CpuBackend::new();
+    let lhs = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(1.0, 1.0),
+            Complex64::new(2.0, -1.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 2.0),
+        ],
+    )
+    .unwrap();
+    let rhs = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 1],
+        vec![Complex64::new(5.0, 0.0), Complex64::new(6.0, -1.0)],
+    )
+    .unwrap();
+
+    let result = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend).unwrap();
+
+    assert_eq!(result.shape(), &[2, 1]);
+    assert_eq!(
+        result.as_slice().unwrap(),
+        &[Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)]
+    );
+}
+
+#[test]
+fn public_tensor_read_einsum_ext_accepts_strided_views() {
+    let mut backend = CpuBackend::new();
+    let matrix_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let vector = Tensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]).unwrap();
+    let row_major_view = TypedTensorView::from_slice([2, 3], [3, 1], 0, &matrix_data).unwrap();
+    let inputs = [
+        TensorRead::from_view(TensorView::F64(row_major_view)),
+        TensorRead::from_tensor(&vector),
+    ];
+
+    let result = inputs.einsum_read("ij,j->i", &mut backend).unwrap();
+
+    assert_f64_tensor(&result, &[2], &[140.0, 320.0]);
+}
+
+#[test]
+fn concrete_einsum_plan_executes_without_replanning_contract() {
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs2 =
+        Tensor::from_vec_col_major(vec![3, 2], vec![2.0_f64, 0.0, 1.0, 3.0, 4.0, 5.0]).unwrap();
+    let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
+
+    let mut backend = CpuBackend::new();
+    let first = plan.execute([&lhs, &rhs], &mut backend).unwrap();
+    let second = plan.execute([&lhs, &rhs2], &mut backend).unwrap();
+
+    assert_f64_tensor(&first, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+    assert_f64_tensor(&second, &[2, 2], &[7.0, 10.0, 40.0, 52.0]);
+}
+
+#[test]
+fn concrete_einsum_plan_executes_read_and_typed_inputs() {
+    let lhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let rhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let plan = ConcreteEinsumPlan::prepare_typed([&lhs, &rhs], "ij,jk->ik").unwrap();
+    let lhs_erased = Tensor::from(lhs.clone());
+    let rhs_erased = Tensor::from(rhs.clone());
+
+    let mut backend = CpuBackend::new();
+    let typed = plan.execute_typed([&lhs, &rhs], &mut backend).unwrap();
+    let read = plan
+        .execute_read(
+            [
+                TensorRead::from_tensor(&lhs_erased),
+                TensorRead::from_tensor(&rhs_erased),
+            ],
+            &mut backend,
+        )
+        .unwrap();
+
+    assert_eq!(typed.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+    assert_f64_tensor(&read, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn concrete_einsum_plan_rejects_shape_and_dtype_mismatches() {
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let wrong_shape = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+    let wrong_dtype = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f32; 6]).unwrap();
+    let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
+
+    let mut backend = CpuBackend::new();
+    let shape_err = plan
+        .execute([&lhs, &wrong_shape], &mut backend)
+        .unwrap_err();
+    let dtype_err = plan
+        .execute([&lhs, &wrong_dtype], &mut backend)
+        .unwrap_err();
+
+    assert!(matches!(
+        shape_err,
+        tenferro_tensor::Error::ShapeMismatch {
+            op: "ConcreteEinsumPlan::execute",
+            ..
+        }
+    ));
+    assert!(matches!(
+        dtype_err,
+        tenferro_tensor::Error::DTypeMismatch {
+            op: "ConcreteEinsumPlan::execute",
+            lhs: DType::F64,
+            rhs: DType::F32,
+        }
+    ));
+}

--- a/crates/tenferro-einsum/src/eager.rs
+++ b/crates/tenferro-einsum/src/eager.rs
@@ -267,7 +267,10 @@ fn eager_invalid_config(message: impl Into<String>) -> Error {
     }
 }
 
-fn plan_subscripts(subs: &Subscripts, input_shapes: &[&[usize]]) -> Result<ContractionTree> {
+pub(crate) fn plan_subscripts(
+    subs: &Subscripts,
+    input_shapes: &[&[usize]],
+) -> Result<ContractionTree> {
     if input_shapes.is_empty() {
         return Err(eager_invalid_config(
             "eager einsum requires at least one input tensor",
@@ -955,7 +958,6 @@ pub(crate) fn eager_einsum_subscripts(
 /// Owned tensors and borrowed host views share this entry point. Backends may
 /// consume views directly when their execution model supports it, or
 /// canonicalize them within the existing placement inside the execution session.
-#[cfg(test)]
 pub(crate) fn eager_einsum_read_subscripts(
     ctx: &mut impl TensorBackend,
     inputs: &[TensorRead<'_>],

--- a/crates/tenferro-einsum/src/lib.rs
+++ b/crates/tenferro-einsum/src/lib.rs
@@ -12,10 +12,14 @@
 //!   contraction order via [`ContractionTree`]
 //! - **Tensordot sugar**: NumPy-style axis-pair contraction extension methods,
 //!   implemented as contraction sugar rather than as linear algebra APIs.
+//! - **Concrete execution**: backend-explicit [`TensorEinsumExt`],
+//!   [`TypedTensorEinsumExt`], [`TensorReadEinsumExt`], and
+//!   [`ConcreteEinsumPlan`] APIs for non-AD tensor values.
 //! - **Extension runtime**: traced einsum lowers to a registered tenferro
 //!   extension runtime, keeping core op definitions small.
-//! - **Tensor extension traits**: graph-building helpers are available as
-//!   methods on `GraphCompiler`, eager input slices, and tensor receivers.
+//! - **Tensor extension traits**: graph-building and immediate-execution
+//!   helpers are available as methods on `GraphCompiler`, concrete input
+//!   slices/arrays, eager input slices/arrays, and tensor receivers.
 //!
 //! # Examples
 //!
@@ -25,6 +29,20 @@
 //! let subs = Subscripts::parse("ij,jk->ik").unwrap();
 //! let tree = ContractionTree::optimize(&subs, &[&[2, 3], &[3, 4]]).unwrap();
 //! assert_eq!(tree.step_count(), 1);
+//! ```
+//!
+//! ```
+//! use tenferro_cpu::CpuBackend;
+//! use tenferro_einsum::TensorEinsumExt;
+//! use tenferro_tensor::Tensor;
+//!
+//! let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+//! let b = Tensor::from_vec_col_major(vec![3, 4], vec![1.0_f64; 12]).unwrap();
+//! let mut backend = CpuBackend::new();
+//!
+//! let out = [&a, &b].einsum("ij,jk->ik", &mut backend)?;
+//! assert_eq!(out.shape(), &[2, 4]);
+//! # Ok::<(), tenferro_tensor::Error>(())
 //! ```
 //!
 //! ```
@@ -44,6 +62,7 @@
 mod binary_dot;
 mod builder;
 mod cache;
+mod concrete;
 mod eager;
 #[cfg(feature = "autodiff")]
 mod eager_ad;
@@ -61,6 +80,9 @@ mod typed_eager;
 pub(crate) mod util;
 
 pub use cache::EINSUM_EXTENSION_FAMILY_ID;
+pub use concrete::{
+    ConcreteEinsumPlan, TensorEinsumExt, TensorReadEinsumExt, TypedTensorEinsumExt,
+};
 #[cfg(feature = "autodiff")]
 pub use eager_ad::{EagerEinsumExt, EagerTensorEinsumExt};
 pub use error::{Error, Result};
@@ -75,6 +97,8 @@ pub use syntax::subscripts::Subscripts;
 pub use tensordot::TensorDotAxes;
 pub use traced::{GraphCompilerEinsumExt, TracedTensorEinsumExt};
 
+#[cfg(test)]
+mod concrete_tests;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -8,7 +8,7 @@ publish.workspace = true
 readme.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "FFT extension runtime and public FFT APIs for tenferro."
+description = "FFT extension runtime and public concrete/traced FFT APIs for tenferro."
 
 [features]
 default = ["cpu-faer"]

--- a/crates/tenferro-fft/src/concrete_tests.rs
+++ b/crates/tenferro-fft/src/concrete_tests.rs
@@ -1,0 +1,143 @@
+use num_complex::Complex64;
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::{Tensor, TensorRead, TensorView, TypedTensorView};
+
+use crate::{FftNorm, TensorFftExt, TensorReadFftExt};
+
+fn assert_complex_close(actual: &[Complex64], expected: &[Complex64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert!(
+            (*actual - *expected).norm() < 1.0e-12,
+            "actual {actual:?} expected {expected:?}"
+        );
+    }
+}
+
+fn assert_real_close(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert!(
+            (*actual - *expected).abs() < 1.0e-12,
+            "actual {actual:?} expected {expected:?}"
+        );
+    }
+}
+
+#[test]
+fn public_tensor_fft_ext_executes_real_and_complex_transforms() {
+    let mut backend = CpuBackend::new();
+    let real = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let full = real.fft(None, -1, FftNorm::Backward, &mut backend).unwrap();
+    let onesided = real
+        .rfft(None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+
+    assert_eq!(full.shape(), &[4]);
+    assert_complex_close(
+        full.as_slice::<Complex64>().unwrap(),
+        &[
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+            Complex64::new(-2.0, -2.0),
+        ],
+    );
+    assert_eq!(onesided.shape(), &[3]);
+    assert_complex_close(
+        onesided.as_slice::<Complex64>().unwrap(),
+        &[
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+        ],
+    );
+
+    let recovered = full
+        .ifft(None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    assert_complex_close(
+        recovered.as_slice::<Complex64>().unwrap(),
+        &[
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 0.0),
+        ],
+    );
+
+    let recovered_real = onesided
+        .irfft(Some(4), -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    assert_real_close(
+        recovered_real.as_slice::<f64>().unwrap(),
+        &[1.0, 2.0, 3.0, 4.0],
+    );
+}
+
+#[test]
+fn public_tensor_read_fft_ext_accepts_strided_host_views() {
+    let mut backend = CpuBackend::new();
+    let data = [1.0_f64, 99.0, 2.0, 99.0, 3.0, 99.0, 4.0];
+    let view = TypedTensorView::from_slice([4], [2], 0, &data).unwrap();
+    let input = TensorRead::from_view(TensorView::F64(view));
+
+    let full = input
+        .fft_read(None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    let onesided = input
+        .rfft_read(None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+
+    assert_complex_close(
+        full.as_slice::<Complex64>().unwrap(),
+        &[
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+            Complex64::new(-2.0, -2.0),
+        ],
+    );
+    assert_complex_close(
+        onesided.as_slice::<Complex64>().unwrap(),
+        &[
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+        ],
+    );
+}
+
+#[test]
+fn public_tensor_fft_ext_reports_invalid_dtype_and_shape_errors() {
+    let mut backend = CpuBackend::new();
+    let bools = Tensor::from_vec_col_major(vec![2], vec![true, false]).unwrap();
+    let spectrum = Tensor::from_vec_col_major(
+        vec![3],
+        vec![
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+        ],
+    )
+    .unwrap();
+
+    let dtype_err = bools
+        .fft(None, -1, FftNorm::Backward, &mut backend)
+        .unwrap_err();
+    let shape_err = spectrum
+        .irfft(Some(6), -1, FftNorm::Backward, &mut backend)
+        .unwrap_err();
+
+    assert!(matches!(
+        dtype_err,
+        tenferro_tensor::Error::InvalidConfig {
+            op: "TensorFftExt::fft",
+            ..
+        }
+    ));
+    assert!(matches!(
+        shape_err,
+        tenferro_tensor::Error::InvalidConfig { op: "irfft", .. }
+    ));
+}

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -2,7 +2,9 @@
 //!
 //! This crate is an out-of-tree `ExtensionOp` package. The initial
 //! implementation executes on host tensors through `rustfft`; it does not add
-//! FFT to the core `tenferro` backend trait surface.
+//! FFT to the core `tenferro` backend trait surface. Concrete non-AD execution
+//! uses [`TensorFftExt`] and [`TensorReadFftExt`]. Traced graph construction
+//! uses [`TracedTensorFftExt`].
 //!
 //! # Examples
 //!
@@ -30,6 +32,19 @@
 //! executor.register_extension(tenferro_fft::register_runtime).unwrap();
 //! let out = executor.run(&program).unwrap();
 //! assert_eq!(out.shape(), &[4]);
+//! assert_eq!(out.as_slice::<Complex64>().unwrap()[0], Complex64::new(10.0, 0.0));
+//! ```
+//!
+//! ```
+//! use num_complex::Complex64;
+//! use tenferro_cpu::CpuBackend;
+//! use tenferro_fft::{FftNorm, TensorFftExt};
+//! use tenferro_tensor::Tensor;
+//!
+//! let x = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+//! let mut backend = CpuBackend::new();
+//! let out = x.fft(None, -1, FftNorm::Backward, &mut backend).unwrap();
+//!
 //! assert_eq!(out.as_slice::<Complex64>().unwrap()[0], Complex64::new(10.0, 0.0));
 //! ```
 
@@ -96,6 +111,275 @@ impl TracedTensorFftExt for TracedTensor {
 
     fn irfft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<TracedTensor> {
         irfft(self, n, axis, norm)
+    }
+}
+
+/// Backend-explicit FFT methods for concrete [`Tensor`] values.
+///
+/// This is the non-AD immediate execution surface. It uses unsuffixed method
+/// names because the receiver is an owned compact tensor value. Use
+/// [`TensorReadFftExt`] when the input is a borrowed view or other
+/// [`TensorRead`] value.
+///
+/// # Examples
+///
+/// ```
+/// use num_complex::Complex64;
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_fft::{FftNorm, TensorFftExt};
+/// use tenferro_tensor::Tensor;
+///
+/// let input = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0])?;
+/// let mut backend = CpuBackend::new();
+///
+/// let spectrum = input.fft(None, -1, FftNorm::Backward, &mut backend)?;
+/// assert_eq!(spectrum.shape(), &[4]);
+/// assert_eq!(spectrum.as_slice::<Complex64>()?[0], Complex64::new(10.0, 0.0));
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+pub trait TensorFftExt {
+    /// Execute a one-dimensional FFT along `axis`.
+    fn fft<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+
+    /// Execute a one-dimensional inverse FFT along `axis`.
+    fn ifft<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+
+    /// Execute a one-dimensional real FFT along `axis`.
+    fn rfft<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+
+    /// Execute a one-dimensional inverse real FFT along `axis`.
+    fn irfft<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+}
+
+impl TensorFftExt for Tensor {
+    fn fft<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        let op = concrete_fft_op(
+            "TensorFftExt::fft",
+            concrete_fft_kind("TensorFftExt::fft", self.dtype())?,
+            self.shape(),
+            n,
+            axis,
+            norm,
+        )?;
+        execute_concrete_fft_op(self, &op, backend)
+    }
+
+    fn ifft<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        let op = concrete_fft_op(
+            "TensorFftExt::ifft",
+            concrete_ifft_kind("TensorFftExt::ifft", self.dtype())?,
+            self.shape(),
+            n,
+            axis,
+            norm,
+        )?;
+        execute_concrete_fft_op(self, &op, backend)
+    }
+
+    fn rfft<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        let op = concrete_fft_op(
+            "TensorFftExt::rfft",
+            concrete_rfft_kind("TensorFftExt::rfft", self.dtype())?,
+            self.shape(),
+            n,
+            axis,
+            norm,
+        )?;
+        execute_concrete_fft_op(self, &op, backend)
+    }
+
+    fn irfft<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        let op = concrete_fft_op(
+            "TensorFftExt::irfft",
+            concrete_irfft_kind("TensorFftExt::irfft", self.dtype())?,
+            self.shape(),
+            n,
+            axis,
+            norm,
+        )?;
+        execute_concrete_fft_op(self, &op, backend)
+    }
+}
+
+/// Backend-explicit FFT methods for read-only tensor inputs.
+///
+/// The `_read` suffix follows the repository convention for APIs that
+/// explicitly accept [`TensorRead`] values such as borrowed views.
+///
+/// # Examples
+///
+/// ```
+/// use num_complex::Complex64;
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_fft::{FftNorm, TensorReadFftExt};
+/// use tenferro_tensor::{TensorRead, TensorView};
+///
+/// let shape = [4usize];
+/// let data = [1.0_f64, 2.0, 3.0, 4.0];
+/// let input = TensorRead::from_view(TensorView::f64(&shape, &data)?);
+/// let mut backend = CpuBackend::new();
+///
+/// let spectrum = input.fft_read(None, -1, FftNorm::Backward, &mut backend)?;
+/// assert_eq!(spectrum.as_slice::<Complex64>()?[0], Complex64::new(10.0, 0.0));
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+pub trait TensorReadFftExt {
+    /// Execute a one-dimensional FFT along `axis`.
+    fn fft_read<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+
+    /// Execute a one-dimensional inverse FFT along `axis`.
+    fn ifft_read<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+
+    /// Execute a one-dimensional real FFT along `axis`.
+    fn rfft_read<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+
+    /// Execute a one-dimensional inverse real FFT along `axis`.
+    fn irfft_read<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+}
+
+impl TensorReadFftExt for TensorRead<'_> {
+    fn fft_read<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        execute_concrete_fft_read_op(
+            self,
+            concrete_fft_kind("TensorReadFftExt::fft_read", self.dtype())?,
+            "TensorReadFftExt::fft_read",
+            n,
+            axis,
+            norm,
+            backend,
+        )
+    }
+
+    fn ifft_read<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        execute_concrete_fft_read_op(
+            self,
+            concrete_ifft_kind("TensorReadFftExt::ifft_read", self.dtype())?,
+            "TensorReadFftExt::ifft_read",
+            n,
+            axis,
+            norm,
+            backend,
+        )
+    }
+
+    fn rfft_read<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        execute_concrete_fft_read_op(
+            self,
+            concrete_rfft_kind("TensorReadFftExt::rfft_read", self.dtype())?,
+            "TensorReadFftExt::rfft_read",
+            n,
+            axis,
+            norm,
+            backend,
+        )
+    }
+
+    fn irfft_read<B: TensorBackend>(
+        &self,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        execute_concrete_fft_read_op(
+            self,
+            concrete_irfft_kind("TensorReadFftExt::irfft_read", self.dtype())?,
+            "TensorReadFftExt::irfft_read",
+            n,
+            axis,
+            norm,
+            backend,
+        )
     }
 }
 
@@ -357,6 +641,159 @@ fn execute_host_fft_op(op: &FftOp, inputs: &[&Tensor]) -> tenferro_tensor::Resul
         }
     };
     Ok(vec![output])
+}
+
+fn execute_concrete_fft_op<B: TensorBackend>(
+    input: &Tensor,
+    op: &FftOp,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    backend.with_backend_session(|_exec| single_fft_output(execute_host_fft_op(op, &[input])?))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn execute_concrete_fft_read_op<B: TensorBackend>(
+    input: &TensorRead<'_>,
+    kind: FftKind,
+    op_name: &'static str,
+    n: Option<usize>,
+    axis: isize,
+    norm: FftNorm,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let op = concrete_fft_op(op_name, kind, input.shape(), n, axis, norm)?;
+    let materialized = input.to_tensor()?;
+    execute_concrete_fft_op(&materialized, &op, backend)
+}
+
+fn single_fft_output(mut outputs: Vec<Tensor>) -> tenferro_tensor::Result<Tensor> {
+    if outputs.len() != 1 {
+        return Err(tenferro_tensor::Error::InvalidConfig {
+            op: "tenferro-fft",
+            message: format!("expected 1 FFT output, got {}", outputs.len()),
+        });
+    }
+    Ok(outputs.remove(0))
+}
+
+fn concrete_fft_op(
+    op: &'static str,
+    kind: FftKind,
+    input_shape: &[usize],
+    n: Option<usize>,
+    axis: isize,
+    norm: FftNorm,
+) -> tenferro_tensor::Result<FftOp> {
+    validate_concrete_n(op, n)?;
+    let axis = normalize_concrete_axis(op, axis, input_shape.len())?;
+    validate_concrete_transform_len(op, input_shape, n, axis)?;
+    if matches!(kind, FftKind::C2R) {
+        output_shape_c2r(input_shape, axis, n)?;
+    }
+    Ok(FftOp::new(kind, axis, n, norm))
+}
+
+fn concrete_fft_kind(op: &'static str, dtype: DType) -> tenferro_tensor::Result<FftKind> {
+    match dtype {
+        DType::C32 | DType::C64 => Ok(FftKind::C2C { forward: true }),
+        DType::F32 | DType::F64 => Ok(FftKind::R2C { onesided: false }),
+        DType::I32 | DType::I64 | DType::Bool => Err(tensor_fft_config_error(
+            op,
+            format!("fft expects real or complex floating input, got {dtype:?}"),
+        )),
+    }
+}
+
+fn concrete_ifft_kind(op: &'static str, dtype: DType) -> tenferro_tensor::Result<FftKind> {
+    match dtype {
+        DType::C32 | DType::C64 => Ok(FftKind::C2C { forward: false }),
+        DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => Err(
+            tensor_fft_config_error(op, format!("ifft expects C32 or C64 input; got {dtype:?}")),
+        ),
+    }
+}
+
+fn concrete_rfft_kind(op: &'static str, dtype: DType) -> tenferro_tensor::Result<FftKind> {
+    match dtype {
+        DType::F32 | DType::F64 => Ok(FftKind::R2C { onesided: true }),
+        DType::C32 | DType::C64 | DType::I32 | DType::I64 | DType::Bool => Err(
+            tensor_fft_config_error(op, format!("rfft expects F32 or F64 input; got {dtype:?}")),
+        ),
+    }
+}
+
+fn concrete_irfft_kind(op: &'static str, dtype: DType) -> tenferro_tensor::Result<FftKind> {
+    match dtype {
+        DType::C32 | DType::C64 => Ok(FftKind::C2R),
+        DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => Err(
+            tensor_fft_config_error(op, format!("irfft expects C32 or C64 input; got {dtype:?}")),
+        ),
+    }
+}
+
+fn validate_concrete_n(op: &'static str, n: Option<usize>) -> tenferro_tensor::Result<()> {
+    if n == Some(0) {
+        return Err(tensor_fft_config_error(
+            op,
+            "tenferro-fft transform length n must be positive",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_concrete_transform_len(
+    op: &'static str,
+    input_shape: &[usize],
+    n: Option<usize>,
+    axis: usize,
+) -> tenferro_tensor::Result<()> {
+    if n.is_none() && input_shape.get(axis).copied() == Some(0) {
+        return Err(tensor_fft_config_error(
+            op,
+            "tenferro-fft transform length n must be positive",
+        ));
+    }
+    Ok(())
+}
+
+fn normalize_concrete_axis(
+    op: &'static str,
+    axis: isize,
+    rank: usize,
+) -> tenferro_tensor::Result<usize> {
+    if rank == 0 {
+        return Err(tensor_fft_config_error(
+            op,
+            "tenferro-fft requires rank >= 1",
+        ));
+    }
+    let normalized = if axis >= 0 {
+        axis as usize
+    } else {
+        rank.checked_sub(axis.unsigned_abs()).ok_or_else(|| {
+            tensor_fft_config_error(
+                op,
+                format!("tenferro-fft axis {axis} out of bounds for rank {rank}"),
+            )
+        })?
+    };
+    if normalized >= rank {
+        return Err(tensor_fft_config_error(
+            op,
+            format!("tenferro-fft axis {axis} out of bounds for rank {rank}"),
+        ));
+    }
+    Ok(normalized)
+}
+
+fn tensor_fft_config_error(
+    op: &'static str,
+    message: impl std::fmt::Display,
+) -> tenferro_tensor::Error {
+    tenferro_tensor::Error::InvalidConfig {
+        op,
+        message: message.to_string(),
+    }
 }
 
 fn tensor_placement(input: &Tensor) -> &Placement {
@@ -1259,6 +1696,9 @@ fn for_axis_lane(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod concrete_tests;
 
 #[cfg(test)]
 mod tests {

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -27,11 +27,12 @@ For contributors, internal crate APIs are also available in the
 - [tenferro-gpu](./tenferro_gpu/index.html): CubeCL/CUDA backend and GPU
   transfer helpers
 - [tenferro-einsum](./tenferro_einsum/index.html): subscripts,
-  contraction planning, traced/eager einsum APIs, extension runtime, and AD rule
+  contraction planning, concrete/traced/eager einsum APIs, extension runtime,
+  and AD rule
 - [tenferro-linalg](./tenferro_linalg/index.html): linear algebra traced APIs,
   eager helpers, extension runtime, and optional linalg AD rules
 - [tenferro-fft](./tenferro_fft/index.html): FFT extension runtime and
-  public FFT APIs
+  public concrete/traced FFT APIs
 
 ## Internal Implementation Crates
 

--- a/docs/architecture/tenferro-crates.md
+++ b/docs/architecture/tenferro-crates.md
@@ -42,9 +42,9 @@ stack. `tenferro-xla` is a peer executor over compiled static programs, not a
 | `tenferro-runtime` | Concrete tensor helpers, traced tensors, graph compilation/execution, extension runtime registration, and extension cache storage |
 | `tenferro-xla` | Experimental StableHLO lowering and runtime-loaded PJRT plugin support for static-shaped traced programs |
 | `tenferro-ad` | Eager runtime, eager tensors, and traced AD extension traits |
-| `tenferro-einsum` | Subscripts, contraction planning, traced/eager einsum APIs, extension runtime, and AD rule |
+| `tenferro-einsum` | Subscripts, contraction planning, concrete/traced/eager einsum APIs, extension runtime, and AD rule |
 | `tenferro-linalg` | Linear algebra traced APIs, eager helpers, extension runtime, and optional linalg AD rules |
-| `tenferro-fft` | FFT extension runtime and public FFT APIs |
+| `tenferro-fft` | FFT extension runtime and public concrete/traced FFT APIs |
 | `tenferro-core-ops` | Internal core primitive operation catalog used by graph, runtime, and backend dispatch |
 | `tenferro-internal-ops` | Graph op vocabulary and AD rule implementations |
 | `tenferro-internal-extension-macros` | Procedural macros for extension-op registration |

--- a/docs/design/api-and-convention-freeze.md
+++ b/docs/design/api-and-convention-freeze.md
@@ -79,9 +79,9 @@ The release API should make crate ownership obvious.
 | `tenferro-internal-ops` | Internal graph operation vocabulary and graph-level AD rule implementations. |
 | `tenferro-runtime` | Backend-agnostic runtime helpers, traced tensor construction, graph compilation and execution, extension registration, and extension cache storage. |
 | `tenferro-ad` | Eager AD surfaces, eager tensors, AD contexts, traced AD helper traits, and user-facing differentiation APIs. |
-| `tenferro-einsum` | Einsum public API, subscript parsing, contraction planning, extension runtime, extension-owned caches, eager/traced wrappers, and optional AD rule ownership. |
+| `tenferro-einsum` | Einsum public API, subscript parsing, contraction planning, concrete/traced/autodiff-eager wrappers, extension runtime, extension-owned caches, and optional AD rule ownership. |
 | `tenferro-linalg` | Linalg public API, extension payloads, linalg backend hooks, CPU linalg kernels, optional CUDA linalg bridge code, eager/traced wrappers, and optional AD rule ownership. |
-| `tenferro-fft` | FFT public API, extension runtime registration, eager/traced wrappers, and FFT-specific execution behavior. |
+| `tenferro-fft` | FFT public API, extension runtime registration, concrete/traced wrappers, optional AD rule ownership, and FFT-specific execution behavior. |
 
 If an implementation needs a cross-crate bridge, the bridge must be narrower
 than the internal subsystem it exposes. `#[doc(hidden)] pub` is not a substitute
@@ -128,8 +128,12 @@ Release APIs should follow these naming and shape rules.
 - Unary single-output traced ops are methods on `TracedTensor`.
 - Binary single-output ops use operator overloads when the operator is natural;
   otherwise they use methods.
-- Multi-output linalg and decomposition ops are free functions.
-- Einsum is a free function owned by `tenferro-einsum`.
+- Multi-output linalg and decomposition ops are tensor extension-trait methods.
+- Einsum is owned by `tenferro-einsum` through crate-root extension traits:
+  concrete input slices/arrays use `TensorEinsumExt`, `TypedTensorEinsumExt`,
+  and `TensorReadEinsumExt`; repeated concrete executions use
+  `ConcreteEinsumPlan`; traced graph construction uses
+  `GraphCompilerEinsumExt`; autodiff eager inputs use `EagerEinsumExt`.
 - Traced tensor methods do not use a `traced_` prefix.
 - User-facing backend features are named for concrete backend families, such as
   `cuda` and `rocm`. Public extension crates should not expose a vague `gpu`

--- a/docs/design/einsum.md
+++ b/docs/design/einsum.md
@@ -2,9 +2,13 @@
 
 Einsum is a standard extension crate, not part of a root facade.
 The public user-facing paths live under `tenferro_einsum` as crate-root
-extension traits: `GraphCompilerEinsumExt` for traced graph construction,
-`EagerEinsumExt` for immediate eager execution, and tensor extension traits for
-`tensordot` contraction sugar. `tensordot` is not a `tenferro-linalg` API.
+extension traits: `TensorEinsumExt`, `TypedTensorEinsumExt`, and
+`TensorReadEinsumExt` for concrete backend-explicit execution,
+`GraphCompilerEinsumExt` for traced graph construction, `EagerEinsumExt` for
+autodiff eager execution, and tensor extension traits for `tensordot`
+contraction sugar. `ConcreteEinsumPlan` owns repeated concrete executions with
+fixed input dtype and shape metadata. `tensordot` is not a `tenferro-linalg`
+API.
 
 The workspace intentionally has no root `tenferro` crate and no einsum facade
 paths. Programs that use traced einsum must explicitly register the extension
@@ -15,11 +19,15 @@ The implementation is split between:
 - `crates/tenferro-einsum/src/traced.rs` for the user-facing traced API,
   contraction strategy selection, symbolic-shape handling, and graph cache
   integration,
+- `crates/tenferro-einsum/src/concrete.rs` for the user-facing concrete tensor,
+  read, typed, and prepared-plan APIs,
 - `crates/tenferro-einsum/src/extension.rs` for runtime extension execution,
 - `crates/tenferro-einsum/src/syntax/` for subscript and nested-order parsing,
 - `crates/tenferro-einsum/src/planning/` for contraction tree planning and per-step
   lowering plans,
 - `crates/tenferro-einsum/src/builder.rs` for graph-fragment lowering,
+- `crates/tenferro-einsum/src/eager.rs` for the shared concrete executor used by
+  concrete wrappers and extension runtime execution,
 - `crates/tenferro-einsum/src/eager_ad.rs` for eager tensor execution.
 
 Historical design notes that refer to direct `CudaBackend`/`RocmBackend`,
@@ -47,6 +55,31 @@ executor.register_extension(tenferro_einsum::register_runtime).unwrap();
 let result = executor.run(&program).unwrap();
 assert_eq!(result.shape(), &[2, 2]);
 ```
+
+## Concrete Tensor API
+
+Concrete non-AD execution is exposed through crate-root extension traits on
+input slices and arrays, not through public module free functions:
+
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::TensorEinsumExt;
+use tenferro_tensor::Tensor;
+
+let a = Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+let b = Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+let mut backend = CpuBackend::new();
+let c = [&a, &b].einsum("ij,jk->ik", &mut backend).unwrap();
+
+assert_eq!(c.shape(), &[2, 2]);
+```
+
+`TensorEinsumExt` is the unsuffixed API for compact `Tensor` references.
+`TypedTensorEinsumExt` preserves a statically known scalar type.
+`TensorReadEinsumExt::einsum_read` accepts `TensorRead` values and therefore
+uses the repository-wide `_read` suffix convention. `ConcreteEinsumPlan`
+precomputes the contraction tree for fixed input metadata and validates later
+executions against the prepared input count, dtypes, and shapes.
 
 `einsum_with` accepts an explicit `EinsumOptimize` strategy:
 
@@ -83,8 +116,8 @@ let c = [&a, &b].einsum("ij,jk->ik").unwrap();
 assert_eq!(c.shape(), &[2, 2]);
 ```
 
-Runtime-owned concrete execution is internal to the extension runtime. It is
-not exposed through a facade crate.
+Autodiff eager execution remains separate from concrete `Tensor` execution:
+`EagerEinsumExt` is available only when the `autodiff` feature is enabled.
 
 ## Subscripts And Repeated Labels
 

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -87,7 +87,8 @@ operations.
 | Need | Without autodiff | Eager path | Traced path |
 | --- | --- | --- | --- |
 | Everyday tensor ops | `TensorOpsExt` / `TypedTensorOpsExt` backend-explicit methods | `EagerTensor` methods / associated functions | `TracedTensor` methods / associated functions |
-| Einsum | Internal to `tenferro-einsum` runtime execution | `[&a, &b].einsum(...)` via `EagerEinsumExt` | `compiler.einsum(...)` via `GraphCompilerEinsumExt` plus `register_runtime` |
+| Einsum | `[&a, &b].einsum(...)` via `TensorEinsumExt` / `TypedTensorEinsumExt`; `TensorReadEinsumExt` for views; `ConcreteEinsumPlan` for repeated fixed metadata | `[&a, &b].einsum(...)` via `EagerEinsumExt` | `compiler.einsum(...)` via `GraphCompilerEinsumExt` plus `register_runtime` |
+| FFT | `x.fft(...)` via `TensorFftExt`; `read.fft_read(...)` via `TensorReadFftExt` | Not exposed today | `x.fft(...)` via `TracedTensorFftExt` plus `register_runtime` |
 | Tensordot sugar | Use `matmul` or `dot_general` directly | `a.tensordot(&b, axes)` via `EagerTensorEinsumExt` | `a.tensordot(&b, axes)` via `TracedTensorEinsumExt` |
 | Linear algebra | `tenferro_linalg::LinalgBackend` methods on a backend | `EagerTensorLinalgExt` methods with `autodiff` | `TracedTensorLinalgExt` methods |
 | Automatic differentiation | Not applicable | `backward()` on tracked scalar losses | `grad`, `vjp`, `jvp`, HVP via composition |

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -1,11 +1,13 @@
 # Einsum
 
 `einsum` is a standard extension, not part of `tenferro` core. Add the
-`tenferro-einsum` crate and import its extension traits. Traced graph
-construction uses `GraphCompilerEinsumExt`; eager execution uses
-`EagerEinsumExt`; `tensordot` contraction sugar uses tensor extension traits.
-Compiled execution also requires explicit runtime registration for einsum
-extension ops.
+`tenferro-einsum` crate and import its extension traits. Concrete tensor
+execution uses `TensorEinsumExt`, `TypedTensorEinsumExt`, and
+`TensorReadEinsumExt`; repeated-shape concrete workloads can use
+`ConcreteEinsumPlan`. Traced graph construction uses `GraphCompilerEinsumExt`;
+autodiff eager execution uses `EagerEinsumExt`; `tensordot` contraction sugar
+uses tensor extension traits. Compiled traced execution also requires explicit
+runtime registration for einsum extension ops.
 
 When working from a local checkout, use paths that match your project layout.
 For a scratch crate created directly inside the `tenferro-rs` checkout, include
@@ -21,9 +23,13 @@ Then add the dependencies:
 ```toml
 [dependencies]
 tenferro-runtime = { path = "../crates/tenferro-runtime" }
+tenferro-tensor = { path = "../crates/tenferro-tensor" }
 tenferro-cpu = { path = "../crates/tenferro-cpu" }
-tenferro-ad = { path = "../crates/tenferro-ad" }
 tenferro-einsum = { path = "../crates/tenferro-einsum", features = ["autodiff"] }
+
+# Only needed for EagerTensor/autodiff examples.
+tenferro-ad = { path = "../crates/tenferro-ad" }
+num-complex = "0.4"
 ```
 
 For published crates, use the same crate set with version requirements:
@@ -31,14 +37,100 @@ For published crates, use the same crate set with version requirements:
 ```toml
 [dependencies]
 tenferro-runtime = "..."
+tenferro-tensor = "..."
 tenferro-cpu = "..."
-tenferro-ad = "..."
 tenferro-einsum = { version = "...", features = ["autodiff"] }
+
+# Only needed for EagerTensor/autodiff examples.
+tenferro-ad = "..."
+num-complex = "0.4"
 ```
 
-Graph-only users can omit `tenferro-ad` and the `autodiff` feature. The traced
-examples below are fragments; copy them into `fn main() -> Result<(), Box<dyn
-std::error::Error>>` when turning them into a standalone `src/main.rs`.
+Concrete and graph-only users can omit `tenferro-ad` and the `autodiff`
+feature. Enable `tenferro-einsum`'s `autodiff` feature when using
+`EagerEinsumExt` or einsum AD rules. The traced examples below are fragments;
+copy them into `fn main() -> Result<(), Box<dyn std::error::Error>>` when
+turning them into a standalone `src/main.rs`.
+
+## Concrete Tensor And TypedTensor
+
+Use the concrete route when you have `Tensor` or `TypedTensor` values and want
+to run the contraction immediately on an explicit backend without autodiff.
+Arrays such as `[&lhs, &rhs]` implement the extension traits directly; their
+receiver type is the fixed-size array of borrowed tensor references.
+
+```rust
+use num_complex::Complex64;
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::{TensorEinsumExt, TypedTensorEinsumExt};
+use tenferro_tensor::{Tensor, TypedTensor};
+
+let lhs = Tensor::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+)?;
+let rhs = Tensor::from_vec_col_major(
+    vec![3, 2],
+    vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0],
+)?;
+let mut backend = CpuBackend::new();
+let product = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend)?;
+assert_eq!(product.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
+
+let complex_lhs = TypedTensor::<Complex64>::from_vec_col_major(
+    vec![2, 2],
+    vec![
+        Complex64::new(1.0, 1.0),
+        Complex64::new(2.0, -1.0),
+        Complex64::new(3.0, 0.0),
+        Complex64::new(4.0, 2.0),
+    ],
+)?;
+let complex_rhs = TypedTensor::<Complex64>::from_vec_col_major(
+    vec![2, 1],
+    vec![Complex64::new(5.0, 0.0), Complex64::new(6.0, -1.0)],
+)?;
+let complex = [&complex_lhs, &complex_rhs].einsum("ij,jk->ik", &mut backend)?;
+assert_eq!(
+    complex.as_slice()?,
+    &[Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)],
+);
+# Ok::<(), tenferro_tensor::Error>(())
+```
+
+## TensorRead And Prepared Plans
+
+Use `TensorReadEinsumExt` when any input is a borrowed view. The `_read` suffix
+is reserved for this `TensorRead`-style API; compact owned `Tensor` inputs use
+the unsuffixed `einsum` method.
+
+Use `ConcreteEinsumPlan` when the same subscripts, dtypes, and shapes are
+executed repeatedly. Preparing the plan parses and optimizes the contraction
+tree once; each execution validates the input count, dtype, and shape before
+running the stored tree.
+
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_einsum::{ConcreteEinsumPlan, TensorReadEinsumExt};
+use tenferro_tensor::{Tensor, TensorRead, TensorView, TypedTensorView};
+
+let matrix_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+let matrix = TypedTensorView::from_slice([2, 3], [3, 1], 0, &matrix_data)?;
+let vector = Tensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0])?;
+let inputs = [
+    TensorRead::from_view(TensorView::F64(matrix)),
+    TensorRead::from_tensor(&vector),
+];
+
+let mut backend = CpuBackend::new();
+let result = inputs.einsum_read("ij,j->i", &mut backend)?;
+assert_eq!(result.as_slice::<f64>()?, &[140.0, 320.0]);
+
+let plan = ConcreteEinsumPlan::prepare_read(inputs.clone(), "ij,j->i")?;
+let planned = plan.execute_read(inputs, &mut backend)?;
+assert_eq!(planned.as_slice::<f64>()?, &[140.0, 320.0]);
+# Ok::<(), tenferro_tensor::Error>(())
+```
 
 ## Traced Matrix Multiply
 

--- a/docs/guides/tenferro-fft.md
+++ b/docs/guides/tenferro-fft.md
@@ -1,13 +1,14 @@
 # FFT (extension)
 
 `tenferro-fft` is the FFT extension package for tenferro. It is an extension
-crate imported directly alongside `tenferro-runtime`: users add the package,
-import `TracedTensorFftExt`, and use FFT methods with `TracedTensor` graphs.
+crate imported directly alongside `tenferro-runtime` or `tenferro-tensor`.
+Concrete non-AD execution uses `TensorFftExt` and `TensorReadFftExt`; traced
+graphs use `TracedTensorFftExt`.
 
 The current implementation provides one-dimensional CPU-host transforms backed
-by `rustfft` through tenferro extension operations. The public functions are
-ordinary Rust wrappers, so most users do not need to work with the lower-level
-extension machinery directly.
+by `rustfft` through tenferro extension operations. The public API is ordinary
+Rust extension-trait methods, so most users do not need to work with the
+lower-level extension machinery directly.
 
 ## Setup
 
@@ -25,6 +26,7 @@ Then add the dependencies:
 [dependencies]
 num-complex = "0.4"
 tenferro-runtime = { path = "../crates/tenferro-runtime" }
+tenferro-tensor = { path = "../crates/tenferro-tensor" }
 tenferro-cpu = { path = "../crates/tenferro-cpu" }
 tenferro-ad = { path = "../crates/tenferro-ad" }
 tenferro-fft = { path = "../crates/tenferro-fft", features = ["autodiff"] }
@@ -36,16 +38,16 @@ For published crates, use the same crate set with version requirements:
 [dependencies]
 num-complex = "0.4"
 tenferro-runtime = "..."
+tenferro-tensor = "..."
 tenferro-cpu = "..."
 tenferro-ad = "..."
 tenferro-fft = { version = "...", features = ["autodiff"] }
 ```
 
-Graph-only users can omit `tenferro-ad` and the `autodiff` feature. The
-`traced_tensor` module path in rustdoc contains the traced-graph FFT helpers
-implemented by `TracedTensorFftExt`. `rustfft` is pulled in automatically by
-`tenferro-fft`, and the first local build can take a few minutes on a fresh
-machine.
+Concrete and graph-only users can omit `tenferro-ad` and the `autodiff`
+feature. Enable `tenferro-fft`'s `autodiff` feature when registering FFT AD
+rules. `rustfft` is pulled in automatically by `tenferro-fft`, and the first
+local build can take a few minutes on a fresh machine.
 
 ## Current API
 
@@ -68,6 +70,41 @@ normalization modes are:
 | `FftNorm::Ortho` | forward and inverse scaled by `1 / sqrt(n)` |
 
 `Backward` is the default and matches NumPy, PyTorch, and JAX.
+
+### Concrete Tensor And TensorRead
+
+Use `TensorFftExt` when you have an owned compact `Tensor` and want immediate
+non-AD execution on an explicit backend. Use `TensorReadFftExt` when the input
+is a borrowed view or other read-oriented value. The `_read` suffix is reserved
+for that `TensorRead` surface; compact `Tensor` inputs use unsuffixed method
+names.
+
+```rust
+use num_complex::Complex64;
+use tenferro_cpu::CpuBackend;
+use tenferro_fft::{FftNorm, TensorFftExt, TensorReadFftExt};
+use tenferro_tensor::{Tensor, TensorRead, TensorView, TypedTensorView};
+
+let mut backend = CpuBackend::new();
+let x = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0])?;
+let full = x.fft(None, -1, FftNorm::Backward, &mut backend)?;
+let one_sided = x.rfft(None, -1, FftNorm::Backward, &mut backend)?;
+assert_eq!(full.as_slice::<Complex64>()?[0], Complex64::new(10.0, 0.0));
+assert_eq!(one_sided.shape(), &[3]);
+
+let data = [1.0_f64, 99.0, 2.0, 99.0, 3.0, 99.0, 4.0];
+let view = TypedTensorView::from_slice([4], [2], 0, &data)?;
+let read = TensorRead::from_view(TensorView::F64(view));
+let read_full = read.fft_read(None, -1, FftNorm::Backward, &mut backend)?;
+assert_eq!(read_full.as_slice::<Complex64>()?[0], Complex64::new(10.0, 0.0));
+# Ok::<(), tenferro_tensor::Error>(())
+```
+
+`TypedTensor<T>` wrappers are not part of the current API. FFT operations can
+change dtype (`rfft` real to complex, `irfft` complex to real), so typed return
+contracts need a separate design.
+
+### Traced Graphs
 
 <!-- snippet-source: crates/tenferro-fft/examples/traced_fft.rs -->
 ```rust

--- a/docs/spec/api-conventions.md
+++ b/docs/spec/api-conventions.md
@@ -65,8 +65,11 @@ The default stratum is internal.
    otherwise they use methods.
 3. Multi-output linalg and decomposition ops are tensor extension-trait methods.
 4. Einsum is exposed through extension traits owned by `tenferro-einsum`:
-   `GraphCompilerEinsumExt` for traced graph construction and
-   `EagerEinsumExt` for eager input slices/arrays.
+   `TensorEinsumExt`, `TypedTensorEinsumExt`, and `TensorReadEinsumExt` for
+   concrete input slices/arrays, `ConcreteEinsumPlan` for repeated concrete
+   executions with fixed input metadata, `GraphCompilerEinsumExt` for traced
+   graph construction, and `EagerEinsumExt` for autodiff eager input
+   slices/arrays.
 5. Standard operation families are first-class crates, not modules under a
    broad facade.
 

--- a/docs/spec/operation-categories.md
+++ b/docs/spec/operation-categories.md
@@ -145,10 +145,13 @@ and traced surfaces (subject to the same parity rule within each family):
   `triangular_solve`, `cholesky`, `lu`, `full_piv_lu` through
   `TracedTensorLinalgExt` / `EagerTensorLinalgExt`.
 - **Einsum** (`tenferro-einsum`): `einsum` + contraction planning.
-  Traced graph construction uses `GraphCompilerEinsumExt`; eager inputs use
-  `EagerEinsumExt`; `tensordot` sugar uses tensor extension traits.
-- **FFT** (`tenferro-fft`): `fft`, `rfft`, `irfft` through
-  `TracedTensorFftExt`.
+  Concrete inputs use `TensorEinsumExt`, `TypedTensorEinsumExt`,
+  `TensorReadEinsumExt`, and `ConcreteEinsumPlan`; traced graph construction
+  uses `GraphCompilerEinsumExt`; autodiff eager inputs use `EagerEinsumExt`;
+  `tensordot` sugar uses tensor extension traits.
+- **FFT** (`tenferro-fft`): `fft`, `ifft`, `rfft`, and `irfft`.
+  Concrete inputs use `TensorFftExt` and `TensorReadFftExt`; traced graph
+  construction uses `TracedTensorFftExt`.
 
 ## 9. AD transforms
 

--- a/docs/worklogs/2026-06-27-concrete-einsum-public-api.md
+++ b/docs/worklogs/2026-06-27-concrete-einsum-public-api.md
@@ -57,6 +57,11 @@ matching guide/spec/design documentation.
 - `cargo test -p tenferro-einsum -p tenferro-fft`
 - `cargo test -p tenferro-einsum -p tenferro-fft --features tenferro-einsum/autodiff,tenferro-fft/autodiff`
 - `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
 - `python3 scripts/check-doc-snippets.py --check`
 - `python3 scripts/check-guide-dependency-snippets.py`
 - `python3 scripts/check-api-consistency.py --fail-on-findings`

--- a/docs/worklogs/2026-06-27-concrete-einsum-public-api.md
+++ b/docs/worklogs/2026-06-27-concrete-einsum-public-api.md
@@ -1,0 +1,72 @@
+# Concrete Einsum Public API
+
+## Summary
+
+Implemented the accepted concrete einsum API stack for issues #1235-#1238:
+dtype-erased `Tensor` execution, typed `TypedTensor<T>` execution including
+complex tensors, `TensorRead` view execution, prepared concrete plans, and the
+matching guide/spec/design documentation.
+
+## Context Read
+
+- `AGENTS.md` and `REPOSITORY_RULES.md`
+- shared tensor4all common repository/docs rules
+- `docs/spec/api-conventions.md`
+- `docs/spec/operation-categories.md`
+- `docs/worklogs/2026-06-19-operation-surface.md`
+- `docs/design/einsum.md`
+- existing `tenferro-einsum` eager, typed eager, traced, and extension tests
+
+## Decisions
+
+- Exposed concrete einsum through crate-root extension traits:
+  `TensorEinsumExt`, `TypedTensorEinsumExt`, and `TensorReadEinsumExt`.
+- Kept public module free functions out of the release API. The implementation
+  uses a private `concrete` module and re-exports only the supported root
+  traits/type.
+- Used unsuffixed `einsum` for compact borrowed `Tensor` and `TypedTensor`
+  inputs. Used `einsum_read` only for the `TensorRead` surface.
+- Made `[&lhs, &rhs].einsum(...)` and `[lhs_read, rhs_read].einsum_read(...)`
+  the ergonomic receiver forms by implementing traits for both slices and
+  fixed-size arrays.
+- Added `ConcreteEinsumPlan` as the prepared-plan public contract. Preparation
+  captures input count, dtype, shape, and the optimized contraction tree;
+  execution validates later inputs against that metadata before running the
+  stored tree.
+- Reused the existing eager executor and read-capable execution path instead of
+  duplicating contraction logic or adding a new backend hook.
+
+## Alternatives Rejected
+
+- Public `tenferro_einsum::einsum(...)` and `einsum_read(...)` free functions:
+  rejected because the current operation-surface contract uses crate-root
+  extension traits for extension-family crates.
+- Public consuming `Vec<Tensor>` APIs: deferred because the accepted user-facing
+  contract centered on borrowed compact tensors, typed tensors, read views, and
+  prepared execution. The internal consuming path remains test-covered.
+- A separate cached execution function family: rejected in favor of
+  `ConcreteEinsumPlan`, which gives repeated execution a single owner and
+  validation boundary.
+
+## Verification
+
+- `cargo test -p tenferro-einsum concrete -- --nocapture` first failed on the
+  missing public API names, then passed after implementation.
+- `cargo test -p tenferro-einsum`
+- `cargo test -p tenferro-einsum --features autodiff`
+- `cargo test -p tenferro-einsum -p tenferro-fft`
+- `cargo test -p tenferro-einsum -p tenferro-fft --features tenferro-einsum/autodiff,tenferro-fft/autodiff`
+- `cargo fmt --all --check`
+- `python3 scripts/check-doc-snippets.py --check`
+- `python3 scripts/check-guide-dependency-snippets.py`
+- `python3 scripts/check-api-consistency.py --fail-on-findings`
+- `python3 scripts/check-operation-categories.py --fail-on-findings`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `git diff --check`
+
+## Remaining Risk
+
+GPU-specific concrete execution was not run locally. The API reuses the same
+backend-explicit tensor execution path as existing concrete/eager einsum
+helpers, so CUDA coverage remains tied to the existing GPU test lanes.

--- a/docs/worklogs/2026-06-27-fft-concrete-public-api.md
+++ b/docs/worklogs/2026-06-27-fft-concrete-public-api.md
@@ -46,6 +46,11 @@ Implemented #1239 by adding concrete non-AD FFT wrappers for `Tensor` and
 - `cargo test -p tenferro-einsum -p tenferro-fft`
 - `cargo test -p tenferro-einsum -p tenferro-fft --features tenferro-einsum/autodiff,tenferro-fft/autodiff`
 - `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
 - `python3 scripts/check-doc-snippets.py --check`
 - `python3 scripts/check-guide-dependency-snippets.py`
 - `python3 scripts/check-api-consistency.py --fail-on-findings`

--- a/docs/worklogs/2026-06-27-fft-concrete-public-api.md
+++ b/docs/worklogs/2026-06-27-fft-concrete-public-api.md
@@ -1,0 +1,60 @@
+# FFT Concrete Public API
+
+## Summary
+
+Implemented #1239 by adding concrete non-AD FFT wrappers for `Tensor` and
+`TensorRead` while keeping the existing traced FFT API unchanged.
+
+## Context Read
+
+- `CONTRIBUTING.md`
+- `REPOSITORY_RULES.md`
+- `docs/spec/api-conventions.md`
+- `docs/spec/operation-categories.md`
+- `docs/guides/tenferro-fft.md`
+- `crates/tenferro-fft/src/lib.rs`
+
+## Decisions
+
+- Added `TensorFftExt` for compact concrete `Tensor` values, with unsuffixed
+  `fft`, `ifft`, `rfft`, and `irfft` methods.
+- Added `TensorReadFftExt` for borrowed/read-oriented inputs, with
+  `fft_read`, `ifft_read`, `rfft_read`, and `irfft_read` methods.
+- Kept `TracedTensorFftExt` unchanged.
+- Did not add public module free functions. The public surface remains
+  crate-root extension traits.
+- Reused the existing host `rustfft` execution helper and validation path.
+  Backend-backed tensors or views continue to return explicit host/download
+  errors instead of transferring data implicitly.
+
+## Alternatives Rejected
+
+- `tenferro_fft::fft(...)` free functions: rejected because extension-family
+  operation surfaces are crate-root extension traits under the current API
+  convention.
+- `TypedTensor<T>` wrappers in the same change: deferred because FFT can change
+  dtype (`rfft` real to complex, `irfft` complex to real), so typed return
+  contracts need a separate design.
+
+## Verification
+
+- RED: `cargo test -p tenferro-fft concrete -- --nocapture` failed on missing
+  `TensorFftExt` and `TensorReadFftExt`.
+- GREEN: `cargo test -p tenferro-fft concrete -- --nocapture`
+- `cargo test -p tenferro-fft`
+- `cargo test -p tenferro-fft --features autodiff`
+- `cargo test -p tenferro-einsum -p tenferro-fft`
+- `cargo test -p tenferro-einsum -p tenferro-fft --features tenferro-einsum/autodiff,tenferro-fft/autodiff`
+- `cargo fmt --all --check`
+- `python3 scripts/check-doc-snippets.py --check`
+- `python3 scripts/check-guide-dependency-snippets.py`
+- `python3 scripts/check-api-consistency.py --fail-on-findings`
+- `python3 scripts/check-operation-categories.py --fail-on-findings`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `git diff --check`
+
+## Remaining Risk
+
+CUDA/cuFFT is still future work. These wrappers expose the current CPU-host FFT
+implementation and preserve the existing no-implicit-transfer behavior.


### PR DESCRIPTION
## Summary

- Add concrete `Tensor`, `TypedTensor<T>`, `TensorRead`, and prepared-plan public APIs for `tenferro-einsum`.
- Add concrete `TensorFftExt` and `TensorReadFftExt` wrappers for `tenferro-fft`, preserving the existing traced API.
- Update guides/spec/design/API index docs and add work logs for the API-surface decisions.

Closes #1235.
Closes #1236.
Closes #1237.
Closes #1238.
Closes #1239.

## Work Logs

- `docs/worklogs/2026-06-27-concrete-einsum-public-api.md`
- `docs/worklogs/2026-06-27-fft-concrete-public-api.md`

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test -p tenferro-einsum -p tenferro-fft`
- `cargo test -p tenferro-einsum -p tenferro-fft --features tenferro-einsum/autodiff,tenferro-fft/autodiff`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/check-doc-snippets.py --check`
- `python3 scripts/check-guide-dependency-snippets.py`
- `python3 scripts/check-api-consistency.py --fail-on-findings`
- `python3 scripts/check-operation-categories.py --fail-on-findings`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
- `git diff --check`
