### PR TITLE
[codex] Add einsum into and strided view APIs

### DIFF
--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -8,9 +8,10 @@ use std::time::{Duration, Instant};
 
 use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
 use crate::{
-    Buffer, CacheStats, Tensor, TensorRank, TensorRead, TensorValue, TypedTensor, TypedTensorView,
-    TypedTensorViewMut,
+    Buffer, CacheStats, Tensor, TensorRank, TensorRead, TensorValue, TensorWrite, TypedTensor,
+    TypedTensorView, TypedTensorViewMut,
 };
+use tenferro_tensor::backend::validate_dot_general_read_into;
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, TensorAnalytic,
     TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
@@ -1062,6 +1063,60 @@ impl TensorDot for CpuBackend {
         let lhs = materialize_tensor_read("dot_general", lhs)?;
         let rhs = materialize_tensor_read("dot_general", rhs)?;
         BackendCachedDot::dot_general_cached(self, &mut cache, None, &lhs, &rhs, config)
+    }
+
+    fn dot_general_read_into(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        mut out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        validate_dot_general_read_into(&lhs, &rhs, config, &out, "dot_general")?;
+        let direct = match self.kind {
+            CpuBackendKind::Faer => {
+                #[cfg(feature = "cpu-faer")]
+                {
+                    gemm::dot_general_faer_read_into_cached(
+                        lhs.clone(),
+                        rhs.clone(),
+                        config,
+                        &mut out,
+                    )?
+                }
+                #[cfg(not(feature = "cpu-faer"))]
+                {
+                    return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
+                }
+            }
+            CpuBackendKind::Blas => {
+                #[cfg(feature = "cpu-blas")]
+                {
+                    let mut cache = gemm::GemmAnalysisCache::default();
+                    self.run_with_pool_and_gemm_cache(&mut cache, |buffers, cache| {
+                        gemm::dot_general_blas_read_into_cached(
+                            buffers,
+                            cache,
+                            None,
+                            lhs.clone(),
+                            rhs.clone(),
+                            config,
+                            &mut out,
+                        )
+                    })?
+                }
+                #[cfg(not(feature = "cpu-blas"))]
+                {
+                    return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
+                }
+            }
+        };
+        if direct {
+            return Ok(());
+        }
+
+        let result = self.dot_general_read(lhs, rhs, config)?;
+        out.copy_from_tensor(&result)
     }
 
     fn dot_general_with_conj(

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -1,5 +1,6 @@
 use crate::buffer_pool::BufferPool;
-use crate::{Tensor, TensorRead, TensorValue};
+use crate::{Tensor, TensorRead, TensorValue, TensorWrite};
+use tenferro_tensor::backend::validate_dot_general_read_into;
 use tenferro_tensor::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
@@ -233,6 +234,63 @@ impl TensorDot for CpuExecSession<'_> {
         let lhs = materialize_tensor_read("dot_general", lhs)?;
         let rhs = materialize_tensor_read("dot_general", rhs)?;
         self.dot_general_cached(None, &lhs, &rhs, config)
+    }
+
+    fn dot_general_read_into(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        mut out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        validate_dot_general_read_into(&lhs, &rhs, config, &out, "dot_general")?;
+        let direct = match self.kind {
+            CpuBackendKind::Faer => {
+                #[cfg(feature = "cpu-faer")]
+                {
+                    gemm::dot_general_faer_read_into_cached(
+                        lhs.clone(),
+                        rhs.clone(),
+                        config,
+                        &mut out,
+                    )?
+                }
+                #[cfg(not(feature = "cpu-faer"))]
+                {
+                    return Err(super::backend::unavailable_cpu_backend_kind(
+                        self.kind,
+                        "dot_general",
+                    ));
+                }
+            }
+            CpuBackendKind::Blas => {
+                #[cfg(feature = "cpu-blas")]
+                {
+                    gemm::dot_general_blas_read_into_cached(
+                        self.buffers,
+                        self.gemm_analysis_cache,
+                        None,
+                        lhs.clone(),
+                        rhs.clone(),
+                        config,
+                        &mut out,
+                    )?
+                }
+                #[cfg(not(feature = "cpu-blas"))]
+                {
+                    return Err(super::backend::unavailable_cpu_backend_kind(
+                        self.kind,
+                        "dot_general",
+                    ));
+                }
+            }
+        };
+        if direct {
+            return Ok(());
+        }
+
+        let result = self.dot_general_read(lhs, rhs, config)?;
+        out.copy_from_tensor(&result)
     }
 
     fn dot_general_with_conj(

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -13,9 +13,11 @@ use crate::ConjElem;
 use crate::{Error, Result};
 use tenferro_tensor::DotGeneralConfig;
 use tenferro_tensor::{
-    col_major_strides, Buffer, TensorRead, TensorView, TypedTensor, TypedTensorView,
+    col_major_strides, Buffer, TensorRead, TensorView, TensorWrite, TypedTensor, TypedTensorView,
 };
 use tenferro_tensor::{CacheStats, RuntimeCacheControl};
+#[cfg(feature = "cpu-faer")]
+use tenferro_tensor::{TensorViewMut, TypedTensorViewMut};
 
 #[cfg(feature = "cpu-blas")]
 mod blas_gemm;
@@ -977,6 +979,117 @@ pub(crate) fn dot_general_faer_read_cached(
 }
 
 #[cfg(feature = "cpu-faer")]
+pub(crate) fn dot_general_faer_read_into_cached(
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+    config: &DotGeneralConfig,
+    out: &mut TensorWrite<'_>,
+) -> crate::Result<bool> {
+    macro_rules! dispatch {
+        ($owned:ident, $view:ident) => {
+            match (&lhs, &rhs, &mut *out) {
+                (
+                    TensorRead::Tensor(crate::Tensor::$owned(a)),
+                    TensorRead::Tensor(crate::Tensor::$owned(b)),
+                    TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                ) => {
+                    let mut c = c.as_view_mut();
+                    dot_general_faer_into_typed(a, b, config, &mut c)?;
+                    return Ok(true);
+                }
+                (
+                    TensorRead::Tensor(crate::Tensor::$owned(a)),
+                    TensorRead::View(TensorView::$view(b)),
+                    TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                ) => {
+                    let mut c = c.as_view_mut();
+                    dot_general_faer_into_typed(a, b, config, &mut c)?;
+                    return Ok(true);
+                }
+                (
+                    TensorRead::View(TensorView::$view(a)),
+                    TensorRead::Tensor(crate::Tensor::$owned(b)),
+                    TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                ) => {
+                    let mut c = c.as_view_mut();
+                    dot_general_faer_into_typed(a, b, config, &mut c)?;
+                    return Ok(true);
+                }
+                (
+                    TensorRead::View(TensorView::$view(a)),
+                    TensorRead::View(TensorView::$view(b)),
+                    TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                ) => {
+                    let mut c = c.as_view_mut();
+                    dot_general_faer_into_typed(a, b, config, &mut c)?;
+                    return Ok(true);
+                }
+                (
+                    TensorRead::Tensor(crate::Tensor::$owned(a)),
+                    TensorRead::Tensor(crate::Tensor::$owned(b)),
+                    TensorWrite::View(TensorViewMut::$view(c)),
+                ) => {
+                    dot_general_faer_into_typed(a, b, config, c)?;
+                    return Ok(true);
+                }
+                (
+                    TensorRead::Tensor(crate::Tensor::$owned(a)),
+                    TensorRead::View(TensorView::$view(b)),
+                    TensorWrite::View(TensorViewMut::$view(c)),
+                ) => {
+                    dot_general_faer_into_typed(a, b, config, c)?;
+                    return Ok(true);
+                }
+                (
+                    TensorRead::View(TensorView::$view(a)),
+                    TensorRead::Tensor(crate::Tensor::$owned(b)),
+                    TensorWrite::View(TensorViewMut::$view(c)),
+                ) => {
+                    dot_general_faer_into_typed(a, b, config, c)?;
+                    return Ok(true);
+                }
+                (
+                    TensorRead::View(TensorView::$view(a)),
+                    TensorRead::View(TensorView::$view(b)),
+                    TensorWrite::View(TensorViewMut::$view(c)),
+                ) => {
+                    dot_general_faer_into_typed(a, b, config, c)?;
+                    return Ok(true);
+                }
+                _ => {}
+            }
+        };
+    }
+
+    dispatch!(F32, F32);
+    dispatch!(F64, F64);
+    dispatch!(C32, C32);
+    dispatch!(C64, C64);
+    Ok(false)
+}
+
+#[cfg(feature = "cpu-faer")]
+fn dot_general_faer_into_typed<L, R, T>(
+    lhs: &L,
+    rhs: &R,
+    config: &DotGeneralConfig,
+    out: &mut TypedTensorViewMut<'_, T>,
+) -> crate::Result<()>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+    T: PoolScalar + Copy + Clone + Zero + One + PartialEq + strided_einsum2::ScalarBase + 'static,
+    strided_einsum2::backend::FaerBackend: strided_einsum2::Backend<T>,
+{
+    strided_dot::dot_general_strided_with_backend_into::<
+        _,
+        _,
+        _,
+        strided_einsum2::backend::FaerBackend,
+    >(lhs, rhs, config, out)
+}
+
+#[cfg(feature = "cpu-faer")]
 // Internal GEMM fast path needs cache metadata, backend context, operands, and conjugation flags together.
 #[allow(clippy::too_many_arguments)]
 fn typed_faer_gemm<L, R, T>(
@@ -1294,6 +1407,19 @@ pub(crate) fn dot_general_blas_read_cached(
             rhs: rhs.dtype(),
         })
     }
+}
+
+#[cfg(feature = "cpu-blas")]
+pub(crate) fn dot_general_blas_read_into_cached(
+    _buffers: &mut BufferPool,
+    _cache: &mut GemmAnalysisCache,
+    _cache_slot: Option<usize>,
+    _lhs: TensorRead<'_>,
+    _rhs: TensorRead<'_>,
+    _config: &DotGeneralConfig,
+    _out: &mut TensorWrite<'_>,
+) -> crate::Result<bool> {
+    Ok(false)
 }
 
 #[cfg(feature = "cpu-blas")]

--- a/crates/tenferro-cpu/src/gemm/strided_dot.rs
+++ b/crates/tenferro-cpu/src/gemm/strided_dot.rs
@@ -1,7 +1,9 @@
 use num_traits::{One, Zero};
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
-use tenferro_tensor::{Buffer, DotGeneralConfig as TensorDotGeneralConfig, TypedTensor};
+use tenferro_tensor::{
+    Buffer, DotGeneralConfig as TensorDotGeneralConfig, TypedTensor, TypedTensorViewMut,
+};
 
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::{default_placement, Error};
@@ -95,4 +97,55 @@ where
     .map_err(map_strided_error)?;
 
     TypedTensor::from_buffer_col_major(out_shape, Buffer::Host(out_data), default_placement())
+}
+
+pub(crate) fn dot_general_strided_with_backend_into<L, R, T, B>(
+    lhs: &L,
+    rhs: &R,
+    config: &TensorDotGeneralConfig,
+    out: &mut TypedTensorViewMut<'_, T>,
+) -> crate::Result<()>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+    T: Copy + Clone + Zero + One + PartialEq + strided_einsum2::ScalarBase + 'static,
+    B: strided_einsum2::Backend<T>,
+{
+    #[cfg(test)]
+    DISPATCH_COUNT.fetch_add(1, Ordering::SeqCst);
+
+    super::validate_dot_general(lhs, rhs, config)?;
+
+    let lhs_view = as_strided_view(lhs)?;
+    let rhs_view = as_strided_view(rhs)?;
+
+    let strided_config = to_strided_config(config);
+    let out_shape = strided_config
+        .expected_output_shape(lhs.shape(), rhs.shape())
+        .map_err(map_strided_error)?;
+    if out.shape() != out_shape.as_slice() {
+        return Err(Error::ShapeMismatch {
+            op: "dot_general",
+            lhs: out.shape().to_vec(),
+            rhs: out_shape,
+        });
+    }
+
+    let out_shape = out.shape().to_vec();
+    let out_strides = out.strides().to_vec();
+    let out_offset = out.offset();
+    let out_data = out.host_storage_mut()?;
+    let out_view =
+        strided_einsum2::StridedViewMut::new(out_data, &out_shape, &out_strides, out_offset)
+            .map_err(map_strided_error)?;
+
+    strided_einsum2::dot_general_with_backend_into::<T, B>(
+        out_view,
+        &lhs_view,
+        &rhs_view,
+        &strided_config,
+        T::one(),
+        T::zero(),
+    )
+    .map_err(map_strided_error)
 }

--- a/crates/tenferro-cpu/src/gemm/tests.rs
+++ b/crates/tenferro-cpu/src/gemm/tests.rs
@@ -83,6 +83,24 @@ fn checked_product_rejects_product_overflow() {
 }
 
 #[test]
+fn strided_dot_into_does_not_acquire_output_buffer() {
+    let source = include_str!("strided_dot.rs");
+    let start = source
+        .find("pub(crate) fn dot_general_strided_with_backend_into")
+        .expect("missing strided dot into function");
+    let body = &source[start..];
+
+    assert!(
+        body.contains("StridedViewMut::new(out_data"),
+        "dot_general into should wrap caller-provided output storage"
+    );
+    assert!(
+        !body.contains("pool_acquire"),
+        "dot_general into must not acquire a pooled output Vec"
+    );
+}
+
+#[test]
 fn gemm_analysis_cache_keeps_direct_and_canonical_candidates_separate() {
     let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]).unwrap();
     let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![0.0; 6]).unwrap();

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -14,7 +14,7 @@ use crate::{
     abs, add, broadcast_in_dim, clamp, compare, conj, div, dynamic_slice, dynamic_update_slice,
     embed_diagonal, extract_diagonal, gather, maximum, minimum, mul, neg, pad, reduce_max,
     reduce_min, reduce_prod, reduce_sum, reshape, scatter, select, sign, transpose, tril, triu,
-    typed_array_uninit_from_pool, CpuBackend, CpuContext,
+    typed_array_uninit_from_pool, CpuBackend, CpuContext, Error,
 };
 #[cfg(feature = "cpu-blas")]
 use tenferro_tensor::StridedSliceSpec;
@@ -26,7 +26,10 @@ use tenferro_tensor::{
 use tenferro_tensor::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use tenferro_tensor::{DType, Tensor, TensorRead, TensorView, TypedTensor};
+use tenferro_tensor::{
+    DType, Tensor, TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensor,
+    TypedTensorViewMut,
+};
 
 fn get_f64(t: &Tensor, idx: &[usize]) -> f64 {
     match t {

--- a/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
@@ -144,6 +144,106 @@ fn test_dot_general_read_accepts_transposed_host_view_input() {
     assert_eq!(out.as_slice::<f64>().unwrap(), &[50.0, 122.0, 68.0, 167.0]);
 }
 
+#[test]
+fn test_dot_general_read_into_writes_compact_and_strided_outputs() {
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs_shape = [3usize, 2];
+    let rhs_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let mut backend = CpuBackend::new();
+
+    let mut compact = Tensor::from_vec_col_major(vec![2, 2], vec![-1.0_f64; 4]).unwrap();
+    backend
+        .dot_general_read_into(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_view(TensorView::f64(&rhs_shape, &rhs_data).unwrap()),
+            &config,
+            TensorWrite::from_tensor(&mut compact),
+        )
+        .unwrap();
+    assert_eq!(
+        compact.as_slice::<f64>().unwrap(),
+        &[22.0, 28.0, 49.0, 64.0]
+    );
+
+    let mut strided_data = [-1.0_f64; 8];
+    {
+        let out_view = TensorViewMut::F64(
+            TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut strided_data).unwrap(),
+        );
+        backend
+            .with_backend_session(|exec| {
+                exec.dot_general_read_into(
+                    TensorRead::from_tensor(&lhs),
+                    TensorRead::from_view(TensorView::f64(&rhs_shape, &rhs_data).unwrap()),
+                    &config,
+                    TensorWrite::from_view(out_view),
+                )
+            })
+            .unwrap();
+    }
+    assert_eq!(
+        strided_data,
+        [-1.0, 22.0, 28.0, -1.0, 49.0, 64.0, -1.0, -1.0]
+    );
+}
+
+#[test]
+fn test_dot_general_read_into_rejects_output_shape_and_dtype_mismatch() {
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let mut backend = CpuBackend::new();
+
+    let mut wrong_shape = Tensor::from_vec_col_major(vec![4], vec![0.0_f64; 4]).unwrap();
+    let shape_err = backend
+        .dot_general_read_into(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config,
+            TensorWrite::from_tensor(&mut wrong_shape),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        shape_err,
+        Error::ShapeMismatch {
+            op: "dot_general",
+            ..
+        }
+    ));
+
+    let mut wrong_dtype = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f32; 4]).unwrap();
+    let dtype_err = backend
+        .dot_general_read_into(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config,
+            TensorWrite::from_tensor(&mut wrong_dtype),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        dtype_err,
+        Error::DTypeMismatch {
+            op: "dot_general",
+            lhs: DType::F32,
+            rhs: DType::F64,
+        }
+    ));
+}
+
 #[cfg(feature = "cpu-blas")]
 #[test]
 fn test_dot_general_read_blas_negative_stride_view_falls_back() {

--- a/crates/tenferro-einsum/src/concrete.rs
+++ b/crates/tenferro-einsum/src/concrete.rs
@@ -1,18 +1,22 @@
 //! Public concrete tensor einsum extension API.
 
 use tenferro_tensor::{
-    DType, Error, Result, Tensor, TensorBackend, TensorRead, TensorScalar, TypedTensor,
+    DType, Error, Result, Tensor, TensorBackend, TensorRead, TensorScalar, TensorWrite,
+    TypedTensor, TypedTensorView,
 };
 
 use crate::eager::{
-    eager_einsum_exec, eager_einsum_exec_read, eager_einsum_read_subscripts,
-    eager_einsum_subscripts, plan_subscripts,
+    eager_einsum_exec, eager_einsum_exec_read, eager_einsum_exec_read_into,
+    eager_einsum_read_subscripts, eager_einsum_subscripts, plan_subscripts,
 };
 use crate::{ContractionTree, EinsumSubscripts, Subscripts};
 
 const TENSOR_EINSUM_OP: &str = "TensorEinsumExt::einsum";
+const TENSOR_EINSUM_INTO_OP: &str = "TensorEinsumIntoExt::einsum_into";
 const TENSOR_READ_EINSUM_OP: &str = "TensorReadEinsumExt::einsum_read";
+const TENSOR_READ_EINSUM_INTO_OP: &str = "TensorReadEinsumIntoExt::einsum_read_into";
 const TYPED_TENSOR_EINSUM_OP: &str = "TypedTensorEinsumExt::einsum";
+const TYPED_TENSOR_EINSUM_INTO_OP: &str = "TypedTensorEinsumIntoExt::einsum_into";
 const PLAN_PREPARE_OP: &str = "ConcreteEinsumPlan::prepare";
 const PLAN_EXECUTE_OP: &str = "ConcreteEinsumPlan::execute";
 
@@ -76,6 +80,68 @@ impl<const N: usize> TensorEinsumExt for [&Tensor; N] {
         backend: &mut B,
     ) -> Result<Tensor> {
         self.as_slice().einsum_subscripts(subscripts, backend)
+    }
+}
+
+/// Backend-explicit preallocated-output einsum methods for dtype-erased tensors.
+pub trait TensorEinsumIntoExt {
+    /// Execute an einsum from string notation into caller-provided output.
+    fn einsum_into<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()>;
+
+    /// Execute an einsum from parsed integer-label subscripts into caller-provided output.
+    fn einsum_into_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()>;
+}
+
+impl TensorEinsumIntoExt for [&Tensor] {
+    fn einsum_into<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()> {
+        let subscripts = parse_subscripts(subscripts, TENSOR_EINSUM_INTO_OP)?;
+        tensor_einsum_into_subscripts(backend, self, &subscripts, out, TENSOR_EINSUM_INTO_OP)
+    }
+
+    fn einsum_into_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()> {
+        let subscripts = Subscripts::from(subscripts);
+        tensor_einsum_into_subscripts(backend, self, &subscripts, out, TENSOR_EINSUM_INTO_OP)
+    }
+}
+
+impl<const N: usize> TensorEinsumIntoExt for [&Tensor; N] {
+    fn einsum_into<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()> {
+        self.as_slice().einsum_into(subscripts, backend, out)
+    }
+
+    fn einsum_into_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()> {
+        self.as_slice()
+            .einsum_into_subscripts(subscripts, backend, out)
     }
 }
 
@@ -150,6 +216,163 @@ impl<T: TensorScalar, const N: usize> TypedTensorEinsumExt<T> for [&TypedTensor<
     }
 }
 
+impl<'a, T: TensorScalar> TypedTensorEinsumExt<T> for [TypedTensorView<'a, T>] {
+    fn einsum<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>> {
+        let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_EINSUM_OP)?;
+        typed_view_einsum_subscripts(backend, self, &subscripts, TYPED_TENSOR_EINSUM_OP)
+    }
+
+    fn einsum_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>> {
+        let subscripts = Subscripts::from(subscripts);
+        typed_view_einsum_subscripts(backend, self, &subscripts, TYPED_TENSOR_EINSUM_OP)
+    }
+}
+
+impl<'a, T: TensorScalar, const N: usize> TypedTensorEinsumExt<T> for [TypedTensorView<'a, T>; N] {
+    fn einsum<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>> {
+        self.as_slice().einsum(subscripts, backend)
+    }
+
+    fn einsum_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>> {
+        self.as_slice().einsum_subscripts(subscripts, backend)
+    }
+}
+
+/// Backend-explicit preallocated-output einsum methods for typed concrete tensors.
+pub trait TypedTensorEinsumIntoExt<T: TensorScalar> {
+    /// Execute an einsum from string notation into caller-provided typed output.
+    fn einsum_into<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+        out: &mut TypedTensor<T>,
+    ) -> Result<()>;
+
+    /// Execute an einsum from parsed integer-label subscripts into caller-provided typed output.
+    fn einsum_into_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+        out: &mut TypedTensor<T>,
+    ) -> Result<()>;
+}
+
+impl<T: TensorScalar> TypedTensorEinsumIntoExt<T> for [&TypedTensor<T>] {
+    fn einsum_into<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+        out: &mut TypedTensor<T>,
+    ) -> Result<()> {
+        let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_EINSUM_INTO_OP)?;
+        typed_einsum_into_subscripts(backend, self, &subscripts, out, TYPED_TENSOR_EINSUM_INTO_OP)
+    }
+
+    fn einsum_into_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+        out: &mut TypedTensor<T>,
+    ) -> Result<()> {
+        let subscripts = Subscripts::from(subscripts);
+        typed_einsum_into_subscripts(backend, self, &subscripts, out, TYPED_TENSOR_EINSUM_INTO_OP)
+    }
+}
+
+impl<T: TensorScalar, const N: usize> TypedTensorEinsumIntoExt<T> for [&TypedTensor<T>; N] {
+    fn einsum_into<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+        out: &mut TypedTensor<T>,
+    ) -> Result<()> {
+        self.as_slice().einsum_into(subscripts, backend, out)
+    }
+
+    fn einsum_into_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+        out: &mut TypedTensor<T>,
+    ) -> Result<()> {
+        self.as_slice()
+            .einsum_into_subscripts(subscripts, backend, out)
+    }
+}
+
+impl<'a, T: TensorScalar> TypedTensorEinsumIntoExt<T> for [TypedTensorView<'a, T>] {
+    fn einsum_into<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+        out: &mut TypedTensor<T>,
+    ) -> Result<()> {
+        let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_EINSUM_INTO_OP)?;
+        typed_view_einsum_into_subscripts(
+            backend,
+            self,
+            &subscripts,
+            out,
+            TYPED_TENSOR_EINSUM_INTO_OP,
+        )
+    }
+
+    fn einsum_into_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+        out: &mut TypedTensor<T>,
+    ) -> Result<()> {
+        let subscripts = Subscripts::from(subscripts);
+        typed_view_einsum_into_subscripts(
+            backend,
+            self,
+            &subscripts,
+            out,
+            TYPED_TENSOR_EINSUM_INTO_OP,
+        )
+    }
+}
+
+impl<'a, T: TensorScalar, const N: usize> TypedTensorEinsumIntoExt<T>
+    for [TypedTensorView<'a, T>; N]
+{
+    fn einsum_into<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+        out: &mut TypedTensor<T>,
+    ) -> Result<()> {
+        self.as_slice().einsum_into(subscripts, backend, out)
+    }
+
+    fn einsum_into_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+        out: &mut TypedTensor<T>,
+    ) -> Result<()> {
+        self.as_slice()
+            .einsum_into_subscripts(subscripts, backend, out)
+    }
+}
+
 /// Backend-explicit einsum methods for [`TensorRead`] inputs.
 ///
 /// Use this surface when an input is a borrowed tensor view rather than an
@@ -216,6 +439,80 @@ impl<'a, const N: usize> TensorReadEinsumExt for [TensorRead<'a>; N] {
         backend: &mut B,
     ) -> Result<Tensor> {
         self.as_slice().einsum_read_subscripts(subscripts, backend)
+    }
+}
+
+/// Backend-explicit preallocated-output einsum methods for [`TensorRead`] inputs.
+pub trait TensorReadEinsumIntoExt {
+    /// Execute an einsum from string notation over read-only inputs into caller-provided output.
+    fn einsum_read_into<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()>;
+
+    /// Execute an einsum from parsed integer-label subscripts over read-only inputs into output.
+    fn einsum_read_into_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()>;
+}
+
+impl<'a> TensorReadEinsumIntoExt for [TensorRead<'a>] {
+    fn einsum_read_into<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()> {
+        let subscripts = parse_subscripts(subscripts, TENSOR_READ_EINSUM_INTO_OP)?;
+        tensor_read_einsum_into_subscripts(
+            backend,
+            self,
+            &subscripts,
+            out,
+            TENSOR_READ_EINSUM_INTO_OP,
+        )
+    }
+
+    fn einsum_read_into_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()> {
+        let subscripts = Subscripts::from(subscripts);
+        tensor_read_einsum_into_subscripts(
+            backend,
+            self,
+            &subscripts,
+            out,
+            TENSOR_READ_EINSUM_INTO_OP,
+        )
+    }
+}
+
+impl<'a, const N: usize> TensorReadEinsumIntoExt for [TensorRead<'a>; N] {
+    fn einsum_read_into<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()> {
+        self.as_slice().einsum_read_into(subscripts, backend, out)
+    }
+
+    fn einsum_read_into_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()> {
+        self.as_slice()
+            .einsum_read_into_subscripts(subscripts, backend, out)
     }
 }
 
@@ -349,6 +646,70 @@ impl ConcreteEinsumPlan {
         backend.with_backend_session(|exec| eager_einsum_exec_read(exec, inputs, &self.tree))
     }
 
+    /// Execute this plan on dtype-erased concrete tensor inputs into caller-provided output.
+    pub fn execute_into<'a, I, B>(
+        &self,
+        inputs: I,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()>
+    where
+        I: AsRef<[&'a Tensor]>,
+        B: TensorBackend,
+    {
+        let inputs = inputs.as_ref();
+        let specs = input_specs(inputs);
+        self.validate_inputs(&specs, PLAN_EXECUTE_OP)?;
+        validate_output(&self.inputs, &self.tree, &out, PLAN_EXECUTE_OP)?;
+        let reads: Vec<_> = inputs
+            .iter()
+            .map(|tensor| TensorRead::from_tensor(tensor))
+            .collect();
+        backend
+            .with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &self.tree, out))
+    }
+
+    /// Execute this plan on typed concrete tensor inputs into caller-provided output.
+    pub fn execute_typed_into<'a, T, I, B>(
+        &self,
+        inputs: I,
+        backend: &mut B,
+        out: &mut TypedTensor<T>,
+    ) -> Result<()>
+    where
+        T: TensorScalar,
+        I: AsRef<[&'a TypedTensor<T>]>,
+        B: TensorBackend,
+    {
+        let inputs = inputs.as_ref();
+        let specs = typed_input_specs(inputs);
+        self.validate_inputs(&specs, PLAN_EXECUTE_OP)?;
+        let out = T::tensor_write(out);
+        validate_output(&self.inputs, &self.tree, &out, PLAN_EXECUTE_OP)?;
+        let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
+        backend
+            .with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &self.tree, out))
+    }
+
+    /// Execute this plan on read-only tensor inputs into caller-provided output.
+    pub fn execute_read_into<'a, I, B>(
+        &self,
+        inputs: I,
+        backend: &mut B,
+        out: TensorWrite<'_>,
+    ) -> Result<()>
+    where
+        I: AsRef<[TensorRead<'a>]>,
+        B: TensorBackend,
+    {
+        let inputs = inputs.as_ref();
+        let specs = read_input_specs(inputs);
+        self.validate_inputs(&specs, PLAN_EXECUTE_OP)?;
+        validate_output(&self.inputs, &self.tree, &out, PLAN_EXECUTE_OP)?;
+        backend
+            .with_backend_session(|exec| eager_einsum_exec_read_into(exec, inputs, &self.tree, out))
+    }
+
     fn prepare_subscripts_internal(
         inputs: Vec<ConcreteEinsumInputSpec>,
         subscripts: &Subscripts,
@@ -391,7 +752,7 @@ impl ConcreteEinsumPlan {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct ConcreteEinsumInputSpec {
     dtype: DType,
     shape: Vec<usize>,
@@ -424,6 +785,18 @@ fn typed_input_specs<T: TensorScalar>(inputs: &[&TypedTensor<T>]) -> Vec<Concret
         .collect()
 }
 
+fn typed_view_input_specs<T: TensorScalar>(
+    inputs: &[TypedTensorView<'_, T>],
+) -> Vec<ConcreteEinsumInputSpec> {
+    inputs
+        .iter()
+        .map(|tensor| ConcreteEinsumInputSpec {
+            dtype: T::dtype(),
+            shape: tensor.shape().to_vec(),
+        })
+        .collect()
+}
+
 fn read_input_specs(inputs: &[TensorRead<'_>]) -> Vec<ConcreteEinsumInputSpec> {
     inputs
         .iter()
@@ -432,6 +805,161 @@ fn read_input_specs(inputs: &[TensorRead<'_>]) -> Vec<ConcreteEinsumInputSpec> {
             shape: tensor.shape().to_vec(),
         })
         .collect()
+}
+
+fn typed_view_einsum_subscripts<T: TensorScalar>(
+    backend: &mut impl TensorBackend,
+    inputs: &[TypedTensorView<'_, T>],
+    subscripts: &Subscripts,
+    op: &'static str,
+) -> Result<TypedTensor<T>> {
+    let reads: Vec<_> = inputs
+        .iter()
+        .cloned()
+        .map(|view| TensorRead::from_view(T::tensor_view(view)))
+        .collect();
+    let result = eager_einsum_read_subscripts(backend, &reads, subscripts)?;
+    into_typed_result(result, op)
+}
+
+fn tensor_einsum_into_subscripts(
+    backend: &mut impl TensorBackend,
+    inputs: &[&Tensor],
+    subscripts: &Subscripts,
+    out: TensorWrite<'_>,
+    op: &'static str,
+) -> Result<()> {
+    let specs = input_specs(inputs);
+    let plan = ConcreteEinsumPlan::prepare_subscripts_internal(specs.clone(), subscripts)?;
+    validate_output(&specs, &plan.tree, &out, op)?;
+    let reads: Vec<_> = inputs
+        .iter()
+        .map(|tensor| TensorRead::from_tensor(tensor))
+        .collect();
+    backend.with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))
+}
+
+fn typed_view_einsum_into_subscripts<T: TensorScalar>(
+    backend: &mut impl TensorBackend,
+    inputs: &[TypedTensorView<'_, T>],
+    subscripts: &Subscripts,
+    out: &mut TypedTensor<T>,
+    op: &'static str,
+) -> Result<()> {
+    let specs = typed_view_input_specs(inputs);
+    let plan = ConcreteEinsumPlan::prepare_subscripts_internal(specs.clone(), subscripts)?;
+    let out = T::tensor_write(out);
+    validate_output(&specs, &plan.tree, &out, op)?;
+    let reads: Vec<_> = inputs
+        .iter()
+        .cloned()
+        .map(|view| TensorRead::from_view(T::tensor_view(view)))
+        .collect();
+    backend.with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))
+}
+
+fn typed_einsum_into_subscripts<T: TensorScalar>(
+    backend: &mut impl TensorBackend,
+    inputs: &[&TypedTensor<T>],
+    subscripts: &Subscripts,
+    out: &mut TypedTensor<T>,
+    op: &'static str,
+) -> Result<()> {
+    let specs = typed_input_specs(inputs);
+    let plan = ConcreteEinsumPlan::prepare_subscripts_internal(specs.clone(), subscripts)?;
+    let out = T::tensor_write(out);
+    validate_output(&specs, &plan.tree, &out, op)?;
+    let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
+    backend.with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))
+}
+
+fn tensor_read_einsum_into_subscripts(
+    backend: &mut impl TensorBackend,
+    inputs: &[TensorRead<'_>],
+    subscripts: &Subscripts,
+    out: TensorWrite<'_>,
+    op: &'static str,
+) -> Result<()> {
+    let specs = read_input_specs(inputs);
+    let plan = ConcreteEinsumPlan::prepare_subscripts_internal(specs.clone(), subscripts)?;
+    validate_output(&specs, &plan.tree, &out, op)?;
+    backend.with_backend_session(|exec| eager_einsum_exec_read_into(exec, inputs, &plan.tree, out))
+}
+
+fn validate_output(
+    inputs: &[ConcreteEinsumInputSpec],
+    tree: &ContractionTree,
+    out: &TensorWrite<'_>,
+    op: &'static str,
+) -> Result<()> {
+    let expected = output_spec(inputs, tree, op)?;
+    if out.dtype() != expected.dtype {
+        return Err(Error::DTypeMismatch {
+            op,
+            lhs: out.dtype(),
+            rhs: expected.dtype,
+        });
+    }
+    if out.shape() != expected.shape.as_slice() {
+        return Err(Error::ShapeMismatch {
+            op,
+            lhs: out.shape().to_vec(),
+            rhs: expected.shape,
+        });
+    }
+    Ok(())
+}
+
+fn output_spec(
+    inputs: &[ConcreteEinsumInputSpec],
+    tree: &ContractionTree,
+    op: &'static str,
+) -> Result<ConcreteEinsumInputSpec> {
+    let dtype = inputs
+        .first()
+        .ok_or_else(|| Error::InvalidConfig {
+            op,
+            message: "einsum requires at least one input tensor".to_string(),
+        })?
+        .dtype;
+    for input in inputs {
+        if input.dtype != dtype {
+            return Err(Error::DTypeMismatch {
+                op,
+                lhs: dtype,
+                rhs: input.dtype,
+            });
+        }
+    }
+
+    let mut output_shape = Vec::with_capacity(tree.subscripts.output.len());
+    for &label in &tree.subscripts.output {
+        let mut found = None;
+        for (input, labels) in inputs.iter().zip(tree.subscripts.inputs.iter()) {
+            if labels.len() != input.shape.len() {
+                return Err(Error::RankMismatch {
+                    op,
+                    expected: labels.len(),
+                    actual: input.shape.len(),
+                });
+            }
+            if let Some(axis) = labels.iter().position(|candidate| *candidate == label) {
+                found = Some(input.shape[axis]);
+                break;
+            }
+        }
+        let Some(extent) = found else {
+            return Err(Error::InvalidConfig {
+                op,
+                message: format!("output label {label} is missing from inputs"),
+            });
+        };
+        output_shape.push(extent);
+    }
+    Ok(ConcreteEinsumInputSpec {
+        dtype,
+        shape: output_shape,
+    })
 }
 
 fn typed_einsum_subscripts<T: TensorScalar>(

--- a/crates/tenferro-einsum/src/concrete_tests.rs
+++ b/crates/tenferro-einsum/src/concrete_tests.rs
@@ -1,10 +1,13 @@
 use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
-use tenferro_tensor::{DType, Tensor, TensorRead, TensorView, TypedTensor, TypedTensorView};
+use tenferro_tensor::{
+    DType, Tensor, TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensor,
+    TypedTensorView, TypedTensorViewMut,
+};
 
 use crate::{
-    parse_einsum_subscripts, ConcreteEinsumPlan, TensorEinsumExt, TensorReadEinsumExt,
-    TypedTensorEinsumExt,
+    parse_einsum_subscripts, ConcreteEinsumPlan, TensorEinsumExt, TensorEinsumIntoExt,
+    TensorReadEinsumExt, TensorReadEinsumIntoExt, TypedTensorEinsumExt, TypedTensorEinsumIntoExt,
 };
 
 fn assert_f64_tensor(tensor: &Tensor, shape: &[usize], expected: &[f64]) {
@@ -114,6 +117,45 @@ fn public_typed_tensor_einsum_ext_accepts_slice_and_integer_subscripts() {
 }
 
 #[test]
+fn public_typed_tensor_einsum_ext_accepts_borrowed_strided_complex_views() {
+    let mut backend = CpuBackend::new();
+    let matrix_data = [
+        Complex64::new(1.0, 0.0),
+        Complex64::new(2.0, 0.0),
+        Complex64::new(3.0, 0.0),
+        Complex64::new(4.0, 0.0),
+        Complex64::new(5.0, 0.0),
+        Complex64::new(6.0, 0.0),
+    ];
+    let vector_data = [
+        Complex64::new(10.0, 0.0),
+        Complex64::new(20.0, 0.0),
+        Complex64::new(30.0, 0.0),
+    ];
+    let matrix_view = TypedTensorView::from_slice([2, 3], [3, 1], 0, &matrix_data).unwrap();
+    let vector_view = TypedTensorView::from_col_major(&[3], &vector_data).unwrap();
+    let mut out =
+        TypedTensor::<Complex64>::from_vec_col_major(vec![2], vec![Complex64::new(0.0, 0.0); 2])
+            .unwrap();
+
+    let result = [matrix_view.clone(), vector_view.clone()]
+        .einsum("ij,j->i", &mut backend)
+        .unwrap();
+    [matrix_view, vector_view]
+        .einsum_into("ij,j->i", &mut backend, &mut out)
+        .unwrap();
+
+    assert_eq!(
+        result.as_slice().unwrap(),
+        &[Complex64::new(140.0, 0.0), Complex64::new(320.0, 0.0)]
+    );
+    assert_eq!(
+        out.as_slice().unwrap(),
+        &[Complex64::new(140.0, 0.0), Complex64::new(320.0, 0.0)]
+    );
+}
+
+#[test]
 fn public_tensor_read_einsum_ext_accepts_strided_views() {
     let mut backend = CpuBackend::new();
     let matrix_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
@@ -154,6 +196,150 @@ fn public_tensor_read_einsum_ext_accepts_slice_and_integer_subscripts() {
 }
 
 #[test]
+fn public_einsum_into_writes_dynamic_typed_and_read_outputs() {
+    let mut backend = CpuBackend::new();
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+
+    let mut dynamic_out = Tensor::from_vec_col_major(vec![2, 2], vec![-1.0_f64; 4]).unwrap();
+    [&lhs, &rhs]
+        .einsum_into(
+            "ij,jk->ik",
+            &mut backend,
+            TensorWrite::from_tensor(&mut dynamic_out),
+        )
+        .unwrap();
+    assert_f64_tensor(&dynamic_out, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+
+    let typed_lhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let typed_rhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let mut typed_out = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![-1.0; 4]).unwrap();
+    [&typed_lhs, &typed_rhs]
+        .einsum_into("ij,jk->ik", &mut backend, &mut typed_out)
+        .unwrap();
+    assert_eq!(typed_out.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+
+    let mut strided_data = [-1.0_f64; 8];
+    {
+        let out_view = TensorViewMut::F64(
+            TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut strided_data).unwrap(),
+        );
+        let inputs = [TensorRead::from_tensor(&lhs), TensorRead::from_tensor(&rhs)];
+        inputs
+            .einsum_read_into("ij,jk->ik", &mut backend, TensorWrite::from_view(out_view))
+            .unwrap();
+    }
+    assert_eq!(
+        strided_data,
+        [-1.0, 22.0, 28.0, -1.0, 49.0, 64.0, -1.0, -1.0]
+    );
+}
+
+#[test]
+fn public_einsum_into_preserves_complex_dtype() {
+    let mut backend = CpuBackend::new();
+    let lhs = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(1.0, 1.0),
+            Complex64::new(2.0, -1.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 2.0),
+        ],
+    )
+    .unwrap();
+    let rhs = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 1],
+        vec![Complex64::new(5.0, 0.0), Complex64::new(6.0, -1.0)],
+    )
+    .unwrap();
+    let mut out =
+        TypedTensor::<Complex64>::from_vec_col_major(vec![2, 1], vec![Complex64::new(0.0, 0.0); 2])
+            .unwrap();
+
+    [&lhs, &rhs]
+        .einsum_into("ij,jk->ik", &mut backend, &mut out)
+        .unwrap();
+
+    assert_eq!(
+        out.as_slice().unwrap(),
+        &[Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)]
+    );
+}
+
+#[test]
+fn public_einsum_into_rejects_output_shape_and_dtype_mismatch() {
+    let mut backend = CpuBackend::new();
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let mut wrong_shape = Tensor::from_vec_col_major(vec![4], vec![0.0_f64; 4]).unwrap();
+    let shape_err = [&lhs, &rhs]
+        .einsum_into(
+            "ij,jk->ik",
+            &mut backend,
+            TensorWrite::from_tensor(&mut wrong_shape),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        shape_err,
+        tenferro_tensor::Error::ShapeMismatch {
+            op: "TensorEinsumIntoExt::einsum_into",
+            ..
+        }
+    ));
+
+    let mut wrong_dtype = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f32; 4]).unwrap();
+    let dtype_err = [&lhs, &rhs]
+        .einsum_into(
+            "ij,jk->ik",
+            &mut backend,
+            TensorWrite::from_tensor(&mut wrong_dtype),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        dtype_err,
+        tenferro_tensor::Error::DTypeMismatch {
+            op: "TensorEinsumIntoExt::einsum_into",
+            lhs: DType::F32,
+            rhs: DType::F64,
+        }
+    ));
+}
+
+#[test]
+fn einsum_into_gemm_fast_path_dispatches_to_backend_into_before_owned_fallback() {
+    let source = include_str!("eager.rs");
+    let start = source
+        .find("pub(crate) fn eager_einsum_exec_read_into")
+        .expect("missing eager_einsum_exec_read_into");
+    let tail = &source[start..];
+    let end = tail
+        .find("fn tensor_value_from_read")
+        .expect("missing following function");
+    let body = &tail[..end];
+
+    let into_call = body
+        .find("exec.dot_general_read_into")
+        .expect("GEMM-compatible einsum_into must call backend read-into");
+    let fallback = body
+        .find("eager_einsum_exec_read(exec, inputs, tree)")
+        .expect("general einsum_into fallback should keep using owned execution");
+
+    assert!(
+        into_call < fallback,
+        "GEMM-compatible einsum_into should try backend read-into before owned fallback"
+    );
+}
+
+#[test]
 fn concrete_einsum_plan_executes_without_replanning_contract() {
     let lhs =
         Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
@@ -169,6 +355,101 @@ fn concrete_einsum_plan_executes_without_replanning_contract() {
 
     assert_f64_tensor(&first, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
     assert_f64_tensor(&second, &[2, 2], &[7.0, 10.0, 40.0, 52.0]);
+}
+
+#[test]
+fn concrete_einsum_plan_execute_into_writes_reused_outputs() {
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs2 =
+        Tensor::from_vec_col_major(vec![3, 2], vec![2.0_f64, 0.0, 1.0, 3.0, 4.0, 5.0]).unwrap();
+    let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
+    let mut backend = CpuBackend::new();
+    let mut out = Tensor::from_vec_col_major(vec![2, 2], vec![-1.0_f64; 4]).unwrap();
+
+    plan.execute_into(
+        [&lhs, &rhs],
+        &mut backend,
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+    assert_f64_tensor(&out, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+
+    plan.execute_into(
+        [&lhs, &rhs2],
+        &mut backend,
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+    assert_f64_tensor(&out, &[2, 2], &[7.0, 10.0, 40.0, 52.0]);
+}
+
+#[test]
+fn concrete_einsum_plan_execute_typed_and_read_into_outputs() {
+    let lhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let rhs =
+        TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+            .unwrap();
+    let plan = ConcreteEinsumPlan::prepare_typed([&lhs, &rhs], "ij,jk->ik").unwrap();
+    let mut backend = CpuBackend::new();
+
+    let mut typed_out = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![-1.0; 4]).unwrap();
+    plan.execute_typed_into([&lhs, &rhs], &mut backend, &mut typed_out)
+        .unwrap();
+    assert_eq!(typed_out.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+
+    let lhs_erased = Tensor::from(lhs.clone());
+    let rhs_erased = Tensor::from(rhs.clone());
+    let mut strided_data = [-1.0_f64; 8];
+    {
+        let out_view = TensorViewMut::F64(
+            TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut strided_data).unwrap(),
+        );
+        plan.execute_read_into(
+            [
+                TensorRead::from_tensor(&lhs_erased),
+                TensorRead::from_tensor(&rhs_erased),
+            ],
+            &mut backend,
+            TensorWrite::from_view(out_view),
+        )
+        .unwrap();
+    }
+    assert_eq!(
+        strided_data,
+        [-1.0, 22.0, 28.0, -1.0, 49.0, 64.0, -1.0, -1.0]
+    );
+}
+
+#[test]
+fn concrete_einsum_plan_execute_into_rejects_incompatible_output() {
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
+    let mut backend = CpuBackend::new();
+    let mut wrong_shape = Tensor::from_vec_col_major(vec![4], vec![0.0_f64; 4]).unwrap();
+
+    let err = plan
+        .execute_into(
+            [&lhs, &rhs],
+            &mut backend,
+            TensorWrite::from_tensor(&mut wrong_shape),
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        tenferro_tensor::Error::ShapeMismatch {
+            op: "ConcreteEinsumPlan::execute",
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/crates/tenferro-einsum/src/eager.rs
+++ b/crates/tenferro-einsum/src/eager.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use tenferro_tensor::{
     BackendSession, DotGeneralConfig, Error, Result, Tensor, TensorBackend, TensorRank, TensorRead,
-    TensorView, TypedTensorView,
+    TensorView, TensorWrite, TypedTensorView,
 };
 
 use crate::binary_dot::{try_build_binary_dot_plan, BinaryDotPlan};
@@ -812,6 +812,41 @@ pub(crate) fn eager_einsum_exec_read(
         })
         .collect();
     eager_einsum_exec_values(exec, values, tree)
+}
+
+pub(crate) fn eager_einsum_exec_read_into(
+    exec: &mut dyn BackendSession,
+    inputs: &[TensorRead<'_>],
+    tree: &ContractionTree,
+    mut out: TensorWrite<'_>,
+) -> Result<()> {
+    record_eager_einsum_profile("exec_read_into.enter", Duration::ZERO);
+    let subscripts = &tree.subscripts;
+    if inputs.len() == 2
+        && subscripts.inputs.len() == 2
+        && inputs[0].shape().len() == subscripts.inputs[0].len()
+        && inputs[1].shape().len() == subscripts.inputs[1].len()
+    {
+        if let Some(plan) = try_build_binary_dot_plan(
+            &subscripts.inputs[0],
+            &subscripts.inputs[1],
+            &subscripts.output,
+        ) {
+            if plan.result_labels == plan.target_labels {
+                return profile_eager_einsum_section("binary.fast_dot_general_into", || {
+                    exec.dot_general_read_into(
+                        inputs[0].clone(),
+                        inputs[1].clone(),
+                        &plan.config,
+                        out,
+                    )
+                });
+            }
+        }
+    }
+
+    let result = eager_einsum_exec_read(exec, inputs, tree)?;
+    out.copy_from_tensor(&result)
 }
 
 fn tensor_value_from_read(input: TensorRead<'_>) -> TensorValue<'_> {

--- a/crates/tenferro-einsum/src/lib.rs
+++ b/crates/tenferro-einsum/src/lib.rs
@@ -81,7 +81,8 @@ pub(crate) mod util;
 
 pub use cache::EINSUM_EXTENSION_FAMILY_ID;
 pub use concrete::{
-    ConcreteEinsumPlan, TensorEinsumExt, TensorReadEinsumExt, TypedTensorEinsumExt,
+    ConcreteEinsumPlan, TensorEinsumExt, TensorEinsumIntoExt, TensorReadEinsumExt,
+    TensorReadEinsumIntoExt, TypedTensorEinsumExt, TypedTensorEinsumIntoExt,
 };
 #[cfg(feature = "autodiff")]
 pub use eager_ad::{EagerEinsumExt, EagerTensorEinsumExt};

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -3,7 +3,7 @@ use crate::config::{
 };
 use crate::types::{TensorRank, TypedTensor, TypedTensorView, TypedTensorViewMut};
 use crate::validate::validate_convert_dtype;
-use crate::{RuntimeCacheControl, Tensor, TensorRead, TensorValue};
+use crate::{RuntimeCacheControl, Tensor, TensorRead, TensorValue, TensorWrite};
 
 fn read_boundary_error(op: &'static str) -> crate::Error {
     crate::Error::backend_failure(
@@ -14,6 +14,169 @@ fn read_boundary_error(op: &'static str) -> crate::Error {
 
 fn read_tensor<'a>(op: &'static str, input: TensorRead<'a>) -> crate::Result<&'a Tensor> {
     input.as_tensor().ok_or_else(|| read_boundary_error(op))
+}
+
+fn validate_axis_list(
+    op: &'static str,
+    role: &'static str,
+    axes: &[usize],
+    rank: usize,
+) -> crate::Result<()> {
+    let mut seen = vec![false; rank];
+    for &axis in axes {
+        if axis >= rank {
+            return Err(crate::Error::AxisOutOfBounds { op, axis, rank });
+        }
+        if seen[axis] {
+            return Err(crate::Error::DuplicateAxis { op, axis, role });
+        }
+        seen[axis] = true;
+    }
+    Ok(())
+}
+
+fn validate_role_disjoint(
+    op: &'static str,
+    first_role: &'static str,
+    first_axes: &[usize],
+    second_role: &'static str,
+    second_axes: &[usize],
+) -> crate::Result<()> {
+    for &axis in first_axes {
+        if second_axes.contains(&axis) {
+            return Err(crate::Error::AxisRoleConflict {
+                op,
+                axis,
+                first_role,
+                second_role,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Infer the output shape for a validated dot-general operation.
+#[doc(hidden)]
+pub fn dot_general_output_shape(
+    lhs_shape: &[usize],
+    rhs_shape: &[usize],
+    config: &DotGeneralConfig,
+    op: &'static str,
+) -> crate::Result<Vec<usize>> {
+    if config.lhs_contracting_dims.len() != config.rhs_contracting_dims.len() {
+        return Err(crate::Error::InvalidConfig {
+            op,
+            message: "lhs/rhs contracting dim counts differ".into(),
+        });
+    }
+    if config.lhs_batch_dims.len() != config.rhs_batch_dims.len() {
+        return Err(crate::Error::InvalidConfig {
+            op,
+            message: "lhs/rhs batch dim counts differ".into(),
+        });
+    }
+
+    let lhs_rank = lhs_shape.len();
+    let rhs_rank = rhs_shape.len();
+    validate_axis_list(
+        op,
+        "lhs_contracting",
+        &config.lhs_contracting_dims,
+        lhs_rank,
+    )?;
+    validate_axis_list(
+        op,
+        "rhs_contracting",
+        &config.rhs_contracting_dims,
+        rhs_rank,
+    )?;
+    validate_axis_list(op, "lhs_batch", &config.lhs_batch_dims, lhs_rank)?;
+    validate_axis_list(op, "rhs_batch", &config.rhs_batch_dims, rhs_rank)?;
+    validate_role_disjoint(
+        op,
+        "lhs_contracting",
+        &config.lhs_contracting_dims,
+        "lhs_batch",
+        &config.lhs_batch_dims,
+    )?;
+    validate_role_disjoint(
+        op,
+        "rhs_contracting",
+        &config.rhs_contracting_dims,
+        "rhs_batch",
+        &config.rhs_batch_dims,
+    )?;
+
+    for (&lhs_axis, &rhs_axis) in config
+        .lhs_contracting_dims
+        .iter()
+        .zip(&config.rhs_contracting_dims)
+    {
+        if lhs_shape[lhs_axis] != rhs_shape[rhs_axis] {
+            return Err(crate::Error::ShapeMismatch {
+                op,
+                lhs: lhs_shape.to_vec(),
+                rhs: rhs_shape.to_vec(),
+            });
+        }
+    }
+    for (&lhs_axis, &rhs_axis) in config.lhs_batch_dims.iter().zip(&config.rhs_batch_dims) {
+        if lhs_shape[lhs_axis] != rhs_shape[rhs_axis] {
+            return Err(crate::Error::ShapeMismatch {
+                op,
+                lhs: lhs_shape.to_vec(),
+                rhs: rhs_shape.to_vec(),
+            });
+        }
+    }
+
+    let lhs_free = (0..lhs_rank)
+        .filter(|axis| {
+            !config.lhs_contracting_dims.contains(axis) && !config.lhs_batch_dims.contains(axis)
+        })
+        .map(|axis| lhs_shape[axis]);
+    let rhs_free = (0..rhs_rank)
+        .filter(|axis| {
+            !config.rhs_contracting_dims.contains(axis) && !config.rhs_batch_dims.contains(axis)
+        })
+        .map(|axis| rhs_shape[axis]);
+    let batch = config.lhs_batch_dims.iter().map(|&axis| lhs_shape[axis]);
+
+    Ok(lhs_free.chain(rhs_free).chain(batch).collect())
+}
+
+/// Validate output dtype and shape for dot-general read-into dispatch.
+#[doc(hidden)]
+pub fn validate_dot_general_read_into(
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
+    config: &DotGeneralConfig,
+    out: &TensorWrite<'_>,
+    op: &'static str,
+) -> crate::Result<Vec<usize>> {
+    if lhs.dtype() != rhs.dtype() {
+        return Err(crate::Error::DTypeMismatch {
+            op,
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        });
+    }
+    if out.dtype() != lhs.dtype() {
+        return Err(crate::Error::DTypeMismatch {
+            op,
+            lhs: out.dtype(),
+            rhs: lhs.dtype(),
+        });
+    }
+    let expected = dot_general_output_shape(lhs.shape(), rhs.shape(), config, op)?;
+    if out.shape() != expected.as_slice() {
+        return Err(crate::Error::ShapeMismatch {
+            op,
+            lhs: out.shape().to_vec(),
+            rhs: expected.clone(),
+        });
+    }
+    Ok(expected)
 }
 
 /// Canonical elementwise fusion plan shared between segmented execution and backends.
@@ -604,6 +767,19 @@ pub trait TensorDot: TensorElementwise {
                 self.dot_general(&lhs, &rhs, config)
             }
         }
+    }
+
+    #[doc(hidden)]
+    fn dot_general_read_into(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        mut out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        validate_dot_general_read_into(&lhs, &rhs, config, &out, "dot_general")?;
+        let result = self.dot_general_read(lhs, rhs, config)?;
+        out.copy_from_tensor(&result)
     }
 
     #[doc(hidden)]

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -6,8 +6,8 @@ use crate::types::{
     col_major_strides, flat_to_multi, materialize_typed_view_col_major, Buffer, BufferHandle,
     DType, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Rank, StridedSliceSpec,
     Tensor, TensorBufferRef, TensorBufferRefMut, TensorLayout, TensorOwnedView, TensorRank,
-    TensorRead, TensorScalar, TensorValue, TensorView, TypedTensor, TypedTensorView,
-    TypedTensorViewMut,
+    TensorRead, TensorScalar, TensorValue, TensorView, TensorViewMut, TensorWrite, TypedTensor,
+    TypedTensorView, TypedTensorViewMut,
 };
 use crate::{Error, SliceConfig};
 
@@ -1713,6 +1713,236 @@ fn tensor_read_wraps_owned_tensor_or_borrowed_view() {
         read_view.to_tensor().unwrap().as_slice::<f64>().unwrap(),
         &[5.0, 6.0]
     );
+}
+
+#[test]
+fn tensor_write_wraps_owned_tensor_or_borrowed_mutable_view() {
+    let mut tensor = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
+    {
+        let mut write_tensor = TensorWrite::from_tensor(&mut tensor);
+
+        assert_eq!(write_tensor.dtype(), DType::F64);
+        assert_eq!(write_tensor.shape(), &[2]);
+        assert_eq!(write_tensor.strides().unwrap().as_slice(), &[1]);
+        assert_eq!(write_tensor.offset(), 0);
+        assert!(write_tensor.is_col_major_contiguous().unwrap());
+
+        write_tensor
+            .copy_from_tensor(&Tensor::from_vec_col_major(vec![2], vec![7.0_f64, 8.0]).unwrap())
+            .unwrap();
+    }
+    assert_eq!(tensor.as_slice::<f64>().unwrap(), &[7.0, 8.0]);
+
+    let mut data = [0.0_f64, 10.0, 0.0, 20.0, 0.0];
+    {
+        let view =
+            TensorViewMut::F64(TypedTensorViewMut::from_slice([2], [2], 1, &mut data).unwrap());
+        let mut write_view = TensorWrite::from_view(view);
+
+        assert_eq!(write_view.dtype(), DType::F64);
+        assert_eq!(write_view.shape(), &[2]);
+        assert_eq!(write_view.strides().unwrap().as_slice(), &[2]);
+        assert_eq!(write_view.offset(), 1);
+        assert!(!write_view.is_col_major_contiguous().unwrap());
+
+        write_view
+            .copy_from_tensor(&Tensor::from_vec_col_major(vec![2], vec![30.0_f64, 40.0]).unwrap())
+            .unwrap();
+    }
+    assert_eq!(data, [0.0, 30.0, 0.0, 40.0, 0.0]);
+}
+
+#[test]
+fn layout_helpers_report_shape_strides_and_offset() {
+    let mut data = [1_i32, 2, 3, 4, 5];
+    let view = TypedTensorViewMut::from_slice([2], [2], 1, &mut data).unwrap();
+
+    assert_eq!(view.layout_linear_offset(&[1]).unwrap(), 3);
+    assert!(!view.is_col_major_contiguous().unwrap());
+
+    let summary = view.layout_summary();
+    assert!(summary.contains("shape=[2]"));
+    assert!(summary.contains("strides=[2]"));
+    assert!(summary.contains("offset=1"));
+
+    let err = view.assert_col_major_contiguous().unwrap_err();
+    let message = err.to_string();
+    assert!(message.contains("shape=[2]"));
+    assert!(message.contains("strides=[2]"));
+    assert!(message.contains("offset=1"));
+}
+
+#[test]
+fn tensor_view_layout_helpers_cover_all_dtype_variants() {
+    macro_rules! assert_view {
+        ($view:expr, $dtype:expr) => {{
+            let view = $view;
+            assert_eq!(view.dtype(), $dtype);
+            assert_eq!(view.shape(), &[2]);
+            assert_eq!(view.strides(), &[1]);
+            assert_eq!(view.offset(), 0);
+            assert_eq!(view.layout_linear_offset(&[1]).unwrap(), 1);
+            assert!(view.is_col_major_contiguous().unwrap());
+            assert!(view.layout_summary().contains("shape=[2]"));
+            view.assert_col_major_contiguous().unwrap();
+            assert_eq!(view.to_tensor().unwrap().dtype(), $dtype);
+        }};
+    }
+
+    let f32_data = [1.0_f32, 2.0];
+    assert_view!(TensorView::f32(&[2], &f32_data).unwrap(), DType::F32);
+
+    let f64_data = [1.0_f64, 2.0];
+    assert_view!(TensorView::f64(&[2], &f64_data).unwrap(), DType::F64);
+
+    let i32_data = [1_i32, 2];
+    assert_view!(TensorView::i32(&[2], &i32_data).unwrap(), DType::I32);
+
+    let i64_data = [1_i64, 2];
+    assert_view!(TensorView::i64(&[2], &i64_data).unwrap(), DType::I64);
+
+    let bool_data = [true, false];
+    assert_view!(TensorView::bool(&[2], &bool_data).unwrap(), DType::Bool);
+
+    let c32_data = [Complex32::new(1.0, 2.0), Complex32::new(3.0, 4.0)];
+    assert_view!(TensorView::c32(&[2], &c32_data).unwrap(), DType::C32);
+
+    let c64_data = [Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)];
+    assert_view!(TensorView::c64(&[2], &c64_data).unwrap(), DType::C64);
+}
+
+#[test]
+fn tensor_view_mut_layout_and_copy_cover_all_dtype_variants() {
+    macro_rules! assert_view_mut {
+        ($variant:ident, $ty:ty, $dtype:expr, $initial:expr, $replacement:expr) => {{
+            let mut data: [$ty; 2] = $initial;
+            {
+                let typed = TypedTensorViewMut::from_slice([2], [1], 0, &mut data).unwrap();
+                let mut view = TensorViewMut::$variant(typed);
+                assert_eq!(view.dtype(), $dtype);
+                assert_eq!(view.shape(), &[2]);
+                assert_eq!(view.strides(), &[1]);
+                assert_eq!(view.offset(), 0);
+                assert_eq!(view.layout_linear_offset(&[1]).unwrap(), 1);
+                assert!(view.is_col_major_contiguous().unwrap());
+                assert!(view.layout_summary().contains("shape=[2]"));
+                view.assert_col_major_contiguous().unwrap();
+
+                let read = view.as_read_only();
+                assert_eq!(read.dtype(), $dtype);
+                assert_eq!(read.shape(), &[2]);
+
+                let src =
+                    Tensor::from_vec_col_major(vec![2], Vec::<$ty>::from($replacement)).unwrap();
+                view.copy_from_tensor(&src).unwrap();
+            }
+            assert_eq!(data, $replacement);
+        }};
+    }
+
+    assert_view_mut!(F32, f32, DType::F32, [1.0, 2.0], [3.0, 4.0]);
+    assert_view_mut!(F64, f64, DType::F64, [1.0, 2.0], [3.0, 4.0]);
+    assert_view_mut!(I32, i32, DType::I32, [1, 2], [3, 4]);
+    assert_view_mut!(I64, i64, DType::I64, [1, 2], [3, 4]);
+    assert_view_mut!(Bool, bool, DType::Bool, [true, false], [false, true]);
+    assert_view_mut!(
+        C32,
+        Complex32,
+        DType::C32,
+        [Complex32::new(1.0, 2.0), Complex32::new(3.0, 4.0)],
+        [Complex32::new(5.0, 6.0), Complex32::new(7.0, 8.0)]
+    );
+    assert_view_mut!(
+        C64,
+        Complex64,
+        DType::C64,
+        [Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
+        [Complex64::new(5.0, 6.0), Complex64::new(7.0, 8.0)]
+    );
+}
+
+#[test]
+fn tensor_read_and_write_layout_helpers_cover_tensor_and_view_paths() {
+    let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let read_tensor = TensorRead::from_tensor(&tensor);
+    assert_eq!(read_tensor.strides().unwrap(), vec![1]);
+    assert_eq!(read_tensor.offset(), 0);
+    assert_eq!(read_tensor.layout_linear_offset(&[1]).unwrap(), 1);
+    assert!(read_tensor.is_col_major_contiguous().unwrap());
+    assert!(read_tensor.layout_summary().contains("offset=0"));
+    read_tensor.assert_col_major_contiguous().unwrap();
+
+    let view_data = [10.0_f64, 20.0, 30.0];
+    let read_view = TensorRead::from_view(TensorView::F64(
+        TypedTensorView::from_slice([2], [2], 0, &view_data).unwrap(),
+    ));
+    assert_eq!(read_view.strides().unwrap(), vec![2]);
+    assert_eq!(read_view.offset(), 0);
+    assert_eq!(read_view.layout_linear_offset(&[1]).unwrap(), 2);
+    assert!(!read_view.is_col_major_contiguous().unwrap());
+    assert!(read_view.assert_col_major_contiguous().is_err());
+
+    let mut write_tensor_dst = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 0.0]).unwrap();
+    {
+        let mut write_tensor = TensorWrite::from_tensor(&mut write_tensor_dst);
+        assert_eq!(write_tensor.strides().unwrap(), vec![1]);
+        assert_eq!(write_tensor.offset(), 0);
+        assert_eq!(write_tensor.layout_linear_offset(&[1]).unwrap(), 1);
+        assert!(write_tensor.is_col_major_contiguous().unwrap());
+        assert!(write_tensor.layout_summary().contains("shape=[2]"));
+        write_tensor.assert_col_major_contiguous().unwrap();
+        write_tensor.copy_from_tensor(&tensor).unwrap();
+    }
+    assert_eq!(write_tensor_dst.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+
+    let mut write_view_data = [0.0_f64, 10.0, 0.0, 20.0];
+    {
+        let mut write_view = TensorWrite::from_view(TensorViewMut::F64(
+            TypedTensorViewMut::from_slice([2], [2], 1, &mut write_view_data).unwrap(),
+        ));
+        assert_eq!(write_view.strides().unwrap(), vec![2]);
+        assert_eq!(write_view.offset(), 1);
+        assert_eq!(write_view.layout_linear_offset(&[1]).unwrap(), 3);
+        assert!(!write_view.is_col_major_contiguous().unwrap());
+        assert!(write_view.assert_col_major_contiguous().is_err());
+        write_view.copy_from_tensor(&tensor).unwrap();
+    }
+    assert_eq!(write_view_data, [0.0, 1.0, 0.0, 2.0]);
+}
+
+#[test]
+fn tensor_write_copy_rejects_dtype_and_shape_mismatch() {
+    let src_f64 = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let src_i32 = Tensor::from_vec_col_major(vec![2], vec![1_i32, 2]).unwrap();
+    let src_short = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
+
+    let mut dst = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 0.0]).unwrap();
+    {
+        let mut write = TensorWrite::from_tensor(&mut dst);
+        assert!(matches!(
+            write.copy_from_tensor(&src_i32),
+            Err(Error::DTypeMismatch { .. })
+        ));
+        assert!(matches!(
+            write.copy_from_tensor(&src_short),
+            Err(Error::ShapeMismatch { .. })
+        ));
+    }
+
+    let mut data = [0.0_f64, 0.0];
+    {
+        let mut write = TensorViewMut::f64(&[2], &mut data).unwrap();
+        assert!(matches!(
+            write.copy_from_tensor(&src_i32),
+            Err(Error::DTypeMismatch { .. })
+        ));
+        assert!(matches!(
+            write.copy_from_tensor(&src_short),
+            Err(Error::ShapeMismatch { .. })
+        ));
+        write.copy_from_tensor(&src_f64).unwrap();
+    }
+    assert_eq!(data, [1.0, 2.0]);
 }
 
 tensor_scalar_roundtrip_test!(

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -700,6 +700,84 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
         checked_view_offset(self.shape(), self.strides(), self.offset(), indices)
     }
 
+    /// Compute the physical element offset for a logical index, returning a typed error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensorView;
+    ///
+    /// let data = [1_i32, 2, 3];
+    /// let view = TypedTensorView::from_slice([3], [-1], 2, &data)?;
+    /// assert_eq!(view.layout_linear_offset(&[2])?, 0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
+        checked_view_offset_result(
+            self.shape(),
+            self.strides(),
+            self.offset(),
+            indices,
+            "TypedTensorView::layout_linear_offset",
+        )
+    }
+
+    /// Return whether this view is compact column-major.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensorView;
+    ///
+    /// let data = [1_i32, 2];
+    /// let view = TypedTensorView::from_slice([2], [1], 0, &data)?;
+    /// assert!(view.is_col_major_contiguous()?);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
+        self.layout
+            .is_compact_col_major()
+            .map_err(|err| tensor_layout_error("TypedTensorView::is_col_major_contiguous", err))
+    }
+
+    /// Return a compact string summary of this view's layout metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensorView;
+    ///
+    /// let data = [1_i32, 2];
+    /// let view = TypedTensorView::from_slice([2], [1], 0, &data)?;
+    /// assert!(view.layout_summary().contains("shape=[2]"));
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn layout_summary(&self) -> String {
+        layout_summary(self.shape(), self.strides(), self.offset())
+    }
+
+    /// Assert this view is compact column-major.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensorView;
+    ///
+    /// let data = [1_i32, 2];
+    /// let view = TypedTensorView::from_slice([2], [1], 0, &data)?;
+    /// view.assert_col_major_contiguous()?;
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
+        assert_layout_col_major_contiguous(
+            self.is_col_major_contiguous()?,
+            self.shape(),
+            self.strides(),
+            self.offset(),
+            "TypedTensorView::assert_col_major_contiguous",
+        )
+    }
+
     /// Borrow one host element by logical index.
     ///
     /// Returns `None` for out-of-bounds indices and backend buffers.
@@ -1211,6 +1289,84 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     pub fn linear_offset(&self, indices: &[usize]) -> Option<usize> {
         checked_view_offset(self.shape(), self.strides(), self.offset(), indices)
+    }
+
+    /// Compute the physical element offset for a logical index, returning a typed error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensorViewMut;
+    ///
+    /// let mut data = [1_i32, 2, 3];
+    /// let view = TypedTensorViewMut::from_slice([3], [-1], 2, &mut data)?;
+    /// assert_eq!(view.layout_linear_offset(&[2])?, 0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
+        checked_view_offset_result(
+            self.shape(),
+            self.strides(),
+            self.offset(),
+            indices,
+            "TypedTensorViewMut::layout_linear_offset",
+        )
+    }
+
+    /// Return whether this mutable view is compact column-major.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensorViewMut;
+    ///
+    /// let mut data = [1_i32, 2];
+    /// let view = TypedTensorViewMut::from_slice([2], [1], 0, &mut data)?;
+    /// assert!(view.is_col_major_contiguous()?);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
+        self.layout
+            .is_compact_col_major()
+            .map_err(|err| tensor_layout_error("TypedTensorViewMut::is_col_major_contiguous", err))
+    }
+
+    /// Return a compact string summary of this mutable view's layout metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensorViewMut;
+    ///
+    /// let mut data = [1_i32, 2];
+    /// let view = TypedTensorViewMut::from_slice([2], [1], 0, &mut data)?;
+    /// assert!(view.layout_summary().contains("shape=[2]"));
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn layout_summary(&self) -> String {
+        layout_summary(self.shape(), self.strides(), self.offset())
+    }
+
+    /// Assert this mutable view is compact column-major.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensorViewMut;
+    ///
+    /// let mut data = [1_i32, 2];
+    /// let view = TypedTensorViewMut::from_slice([2], [1], 0, &mut data)?;
+    /// view.assert_col_major_contiguous()?;
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
+        assert_layout_col_major_contiguous(
+            self.is_col_major_contiguous()?,
+            self.shape(),
+            self.strides(),
+            self.offset(),
+            "TypedTensorViewMut::assert_col_major_contiguous",
+        )
     }
 
     /// Borrow one host element by logical index.
@@ -1742,6 +1898,36 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// ```
     fn tensor_read(tensor: &TypedTensor<Self>) -> TensorRead<'_>;
 
+    /// Wrap a typed borrowed view as a dtype-erased [`TensorView`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{DType, TensorScalar, TypedTensorView};
+    ///
+    /// let data = [1.0_f64];
+    /// let view = TypedTensorView::from_col_major(&[1], &data)?;
+    /// assert_eq!(f64::tensor_view(view).dtype(), DType::F64);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn tensor_view<'a>(view: TypedTensorView<'a, Self>) -> TensorView<'a>;
+
+    /// Mutably borrow a typed tensor as a dtype-erased [`TensorWrite`] view.
+    ///
+    /// This keeps the typed output borrowed instead of wrapping it in a
+    /// temporary dynamic tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{DType, TensorScalar, TypedTensor};
+    ///
+    /// let mut tensor = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![0.0]).unwrap();
+    /// let write = f64::tensor_write(&mut tensor);
+    /// assert_eq!(write.dtype(), DType::F64);
+    /// ```
+    fn tensor_write(tensor: &mut TypedTensor<Self>) -> TensorWrite<'_>;
+
     /// Borrow the host data from a [`Tensor`].
     fn as_slice(tensor: &Tensor) -> crate::Result<&[Self]>;
 
@@ -1803,6 +1989,14 @@ macro_rules! impl_tensor_scalar {
 
             fn tensor_read(tensor: &TypedTensor<Self>) -> TensorRead<'_> {
                 TensorRead::from_view(TensorView::$variant(tensor.as_view()))
+            }
+
+            fn tensor_view<'a>(view: TypedTensorView<'a, Self>) -> TensorView<'a> {
+                TensorView::$variant(view)
+            }
+
+            fn tensor_write(tensor: &mut TypedTensor<Self>) -> TensorWrite<'_> {
+                TensorWrite::from_view(TensorViewMut::$variant(tensor.as_view_mut()))
             }
 
             fn as_slice(tensor: &Tensor) -> crate::Result<&[Self]> {
@@ -1910,6 +2104,34 @@ pub enum TensorView<'a> {
     C64(TypedTensorView<'a, Complex<f64>>),
 }
 
+/// Dynamic mutable borrowed tensor view.
+///
+/// `TensorViewMut` is the mutable counterpart to [`TensorView`]. It keeps the
+/// dtype erased while preserving the typed mutable view's shape, strides, and
+/// offset metadata.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::{DType, TensorViewMut, TypedTensorViewMut};
+///
+/// let mut data = [1.0_f64, 2.0];
+/// let view = TensorViewMut::F64(TypedTensorViewMut::from_slice([2], [1], 0, &mut data)?);
+/// assert_eq!(view.dtype(), DType::F64);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum TensorViewMut<'a> {
+    F32(TypedTensorViewMut<'a, f32>),
+    F64(TypedTensorViewMut<'a, f64>),
+    I32(TypedTensorViewMut<'a, i32>),
+    I64(TypedTensorViewMut<'a, i64>),
+    Bool(TypedTensorViewMut<'a, bool>),
+    C32(TypedTensorViewMut<'a, Complex<f32>>),
+    C64(TypedTensorViewMut<'a, Complex<f64>>),
+}
+
 /// Read-only tensor input accepted by synchronous eager kernels.
 ///
 /// `TensorRead` lets kernels accept either an owned tensor reference or a
@@ -1939,6 +2161,29 @@ pub enum TensorView<'a> {
 pub enum TensorRead<'a> {
     Tensor(&'a Tensor),
     View(TensorView<'a>),
+}
+
+/// Mutable tensor output accepted by synchronous eager kernels.
+///
+/// `TensorWrite` mirrors [`TensorRead`] for output dispatch: it can target an
+/// owned compact [`Tensor`] or a borrowed mutable [`TensorViewMut`]. The target
+/// is never resized.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::{Tensor, TensorWrite};
+///
+/// let mut tensor = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+/// let write = TensorWrite::from_tensor(&mut tensor);
+/// assert_eq!(write.shape(), &[1]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum TensorWrite<'a> {
+    Tensor(&'a mut Tensor),
+    View(TensorViewMut<'a>),
 }
 
 /// Owned lazy tensor view over a shared base tensor.
@@ -2557,6 +2802,74 @@ impl<'a> TensorView<'a> {
         }
     }
 
+    /// Return strides in element units.
+    pub fn strides(&self) -> &[isize] {
+        match self {
+            Self::F32(t) => t.strides(),
+            Self::F64(t) => t.strides(),
+            Self::I32(t) => t.strides(),
+            Self::I64(t) => t.strides(),
+            Self::Bool(t) => t.strides(),
+            Self::C32(t) => t.strides(),
+            Self::C64(t) => t.strides(),
+        }
+    }
+
+    /// Return the physical element offset.
+    pub fn offset(&self) -> isize {
+        match self {
+            Self::F32(t) => t.offset(),
+            Self::F64(t) => t.offset(),
+            Self::I32(t) => t.offset(),
+            Self::I64(t) => t.offset(),
+            Self::Bool(t) => t.offset(),
+            Self::C32(t) => t.offset(),
+            Self::C64(t) => t.offset(),
+        }
+    }
+
+    /// Compute the physical element offset for a logical index.
+    pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
+        match self {
+            Self::F32(t) => t.layout_linear_offset(indices),
+            Self::F64(t) => t.layout_linear_offset(indices),
+            Self::I32(t) => t.layout_linear_offset(indices),
+            Self::I64(t) => t.layout_linear_offset(indices),
+            Self::Bool(t) => t.layout_linear_offset(indices),
+            Self::C32(t) => t.layout_linear_offset(indices),
+            Self::C64(t) => t.layout_linear_offset(indices),
+        }
+    }
+
+    /// Return whether this view is compact column-major.
+    pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
+        match self {
+            Self::F32(t) => t.is_col_major_contiguous(),
+            Self::F64(t) => t.is_col_major_contiguous(),
+            Self::I32(t) => t.is_col_major_contiguous(),
+            Self::I64(t) => t.is_col_major_contiguous(),
+            Self::Bool(t) => t.is_col_major_contiguous(),
+            Self::C32(t) => t.is_col_major_contiguous(),
+            Self::C64(t) => t.is_col_major_contiguous(),
+        }
+    }
+
+    /// Return a compact string summary of this view's layout metadata.
+    pub fn layout_summary(&self) -> String {
+        layout_summary(self.shape(), self.strides(), self.offset())
+    }
+
+    /// Assert this view is compact column-major.
+    pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
+        assert_layout_col_major_contiguous(
+            self.is_col_major_contiguous()?,
+            self.shape(),
+            self.strides(),
+            self.offset(),
+            "TensorView::assert_col_major_contiguous",
+        )
+    }
+
     /// Materialize this host view into an owned tensor.
     ///
     /// This method has no backend context and does not download backend
@@ -2602,6 +2915,115 @@ impl<'a> TensorView<'a> {
     }
 }
 
+impl<'a> TensorViewMut<'a> {
+    /// Create a dynamic `f64` mutable view over compact column-major host data.
+    pub fn f64(shape: &'a [usize], data: &'a mut [f64]) -> crate::Result<Self> {
+        Ok(Self::F64(TypedTensorViewMut::from_col_major(shape, data)?))
+    }
+
+    pub fn dtype(&self) -> DType {
+        match self {
+            Self::F32(_) => DType::F32,
+            Self::F64(_) => DType::F64,
+            Self::I32(_) => DType::I32,
+            Self::I64(_) => DType::I64,
+            Self::Bool(_) => DType::Bool,
+            Self::C32(_) => DType::C32,
+            Self::C64(_) => DType::C64,
+        }
+    }
+
+    pub fn shape(&self) -> &[usize] {
+        match self {
+            Self::F32(t) => t.shape(),
+            Self::F64(t) => t.shape(),
+            Self::I32(t) => t.shape(),
+            Self::I64(t) => t.shape(),
+            Self::Bool(t) => t.shape(),
+            Self::C32(t) => t.shape(),
+            Self::C64(t) => t.shape(),
+        }
+    }
+
+    pub fn strides(&self) -> &[isize] {
+        match self {
+            Self::F32(t) => t.strides(),
+            Self::F64(t) => t.strides(),
+            Self::I32(t) => t.strides(),
+            Self::I64(t) => t.strides(),
+            Self::Bool(t) => t.strides(),
+            Self::C32(t) => t.strides(),
+            Self::C64(t) => t.strides(),
+        }
+    }
+
+    pub fn offset(&self) -> isize {
+        match self {
+            Self::F32(t) => t.offset(),
+            Self::F64(t) => t.offset(),
+            Self::I32(t) => t.offset(),
+            Self::I64(t) => t.offset(),
+            Self::Bool(t) => t.offset(),
+            Self::C32(t) => t.offset(),
+            Self::C64(t) => t.offset(),
+        }
+    }
+
+    pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
+        match self {
+            Self::F32(t) => t.layout_linear_offset(indices),
+            Self::F64(t) => t.layout_linear_offset(indices),
+            Self::I32(t) => t.layout_linear_offset(indices),
+            Self::I64(t) => t.layout_linear_offset(indices),
+            Self::Bool(t) => t.layout_linear_offset(indices),
+            Self::C32(t) => t.layout_linear_offset(indices),
+            Self::C64(t) => t.layout_linear_offset(indices),
+        }
+    }
+
+    pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
+        match self {
+            Self::F32(t) => t.is_col_major_contiguous(),
+            Self::F64(t) => t.is_col_major_contiguous(),
+            Self::I32(t) => t.is_col_major_contiguous(),
+            Self::I64(t) => t.is_col_major_contiguous(),
+            Self::Bool(t) => t.is_col_major_contiguous(),
+            Self::C32(t) => t.is_col_major_contiguous(),
+            Self::C64(t) => t.is_col_major_contiguous(),
+        }
+    }
+
+    pub fn layout_summary(&self) -> String {
+        layout_summary(self.shape(), self.strides(), self.offset())
+    }
+
+    pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
+        assert_layout_col_major_contiguous(
+            self.is_col_major_contiguous()?,
+            self.shape(),
+            self.strides(),
+            self.offset(),
+            "TensorViewMut::assert_col_major_contiguous",
+        )
+    }
+
+    pub fn as_read_only(&self) -> TensorView<'_> {
+        match self {
+            Self::F32(t) => TensorView::F32(t.as_read_only()),
+            Self::F64(t) => TensorView::F64(t.as_read_only()),
+            Self::I32(t) => TensorView::I32(t.as_read_only()),
+            Self::I64(t) => TensorView::I64(t.as_read_only()),
+            Self::Bool(t) => TensorView::Bool(t.as_read_only()),
+            Self::C32(t) => TensorView::C32(t.as_read_only()),
+            Self::C64(t) => TensorView::C64(t.as_read_only()),
+        }
+    }
+
+    pub fn copy_from_tensor(&mut self, src: &Tensor) -> crate::Result<()> {
+        copy_tensor_to_view_mut(self, src, "TensorViewMut::copy_from_tensor")
+    }
+}
+
 impl<'a> TensorRead<'a> {
     pub fn from_tensor(tensor: &'a Tensor) -> Self {
         Self::Tensor(tensor)
@@ -2623,6 +3045,53 @@ impl<'a> TensorRead<'a> {
             Self::Tensor(tensor) => tensor.shape(),
             Self::View(view) => view.shape(),
         }
+    }
+
+    pub fn strides(&self) -> crate::Result<Vec<isize>> {
+        match self {
+            Self::Tensor(tensor) => col_major_strides(tensor.shape()),
+            Self::View(view) => Ok(view.strides().to_vec()),
+        }
+    }
+
+    pub fn offset(&self) -> isize {
+        match self {
+            Self::Tensor(_) => 0,
+            Self::View(view) => view.offset(),
+        }
+    }
+
+    pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
+        match self {
+            Self::Tensor(tensor) => tensor.layout_linear_offset(indices),
+            Self::View(view) => view.layout_linear_offset(indices),
+        }
+    }
+
+    pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
+        match self {
+            Self::Tensor(tensor) => tensor.is_col_major_contiguous(),
+            Self::View(view) => view.is_col_major_contiguous(),
+        }
+    }
+
+    pub fn layout_summary(&self) -> String {
+        let strides = match self.strides() {
+            Ok(strides) => strides,
+            Err(err) => return format!("layout unavailable: {err}"),
+        };
+        layout_summary(self.shape(), &strides, self.offset())
+    }
+
+    pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
+        let strides = self.strides()?;
+        assert_layout_col_major_contiguous(
+            self.is_col_major_contiguous()?,
+            self.shape(),
+            &strides,
+            self.offset(),
+            "TensorRead::assert_col_major_contiguous",
+        )
     }
 
     pub fn as_tensor(&self) -> Option<&'a Tensor> {
@@ -2654,6 +3123,84 @@ impl<'a> TensorRead<'a> {
         match self {
             Self::Tensor(tensor) => Ok((*tensor).clone()),
             Self::View(view) => view.to_tensor(),
+        }
+    }
+}
+
+impl<'a> TensorWrite<'a> {
+    pub fn from_tensor(tensor: &'a mut Tensor) -> Self {
+        Self::Tensor(tensor)
+    }
+
+    pub fn from_view(view: TensorViewMut<'a>) -> Self {
+        Self::View(view)
+    }
+
+    pub fn dtype(&self) -> DType {
+        match self {
+            Self::Tensor(tensor) => tensor.dtype(),
+            Self::View(view) => view.dtype(),
+        }
+    }
+
+    pub fn shape(&self) -> &[usize] {
+        match self {
+            Self::Tensor(tensor) => tensor.shape(),
+            Self::View(view) => view.shape(),
+        }
+    }
+
+    pub fn strides(&self) -> crate::Result<Vec<isize>> {
+        match self {
+            Self::Tensor(tensor) => col_major_strides(tensor.shape()),
+            Self::View(view) => Ok(view.strides().to_vec()),
+        }
+    }
+
+    pub fn offset(&self) -> isize {
+        match self {
+            Self::Tensor(_) => 0,
+            Self::View(view) => view.offset(),
+        }
+    }
+
+    pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
+        match self {
+            Self::Tensor(tensor) => tensor.layout_linear_offset(indices),
+            Self::View(view) => view.layout_linear_offset(indices),
+        }
+    }
+
+    pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
+        match self {
+            Self::Tensor(tensor) => tensor.is_col_major_contiguous(),
+            Self::View(view) => view.is_col_major_contiguous(),
+        }
+    }
+
+    pub fn layout_summary(&self) -> String {
+        let strides = match self.strides() {
+            Ok(strides) => strides,
+            Err(err) => return format!("layout unavailable: {err}"),
+        };
+        layout_summary(self.shape(), &strides, self.offset())
+    }
+
+    pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
+        let strides = self.strides()?;
+        assert_layout_col_major_contiguous(
+            self.is_col_major_contiguous()?,
+            self.shape(),
+            &strides,
+            self.offset(),
+            "TensorWrite::assert_col_major_contiguous",
+        )
+    }
+
+    pub fn copy_from_tensor(&mut self, src: &Tensor) -> crate::Result<()> {
+        match self {
+            Self::Tensor(dst) => copy_tensor_to_tensor(dst, src, "TensorWrite::copy_from_tensor"),
+            Self::View(view) => copy_tensor_to_view_mut(view, src, "TensorWrite::copy_from_tensor"),
         }
     }
 }
@@ -2728,6 +3275,136 @@ fn try_linear_offset_for_shape(
             })?;
     }
     Ok(offset)
+}
+
+fn checked_view_offset_result(
+    shape: &[usize],
+    strides: &[isize],
+    base_offset: isize,
+    indices: &[usize],
+    op: &'static str,
+) -> crate::Result<usize> {
+    if indices.len() != shape.len() {
+        return Err(crate::Error::RankMismatch {
+            op,
+            expected: shape.len(),
+            actual: indices.len(),
+        });
+    }
+    for (axis, (&index, &extent)) in indices.iter().zip(shape).enumerate() {
+        if index >= extent {
+            return Err(crate::Error::InvalidConfig {
+                op,
+                message: format!("index {index} out of bounds for axis {axis} extent {extent}"),
+            });
+        }
+    }
+    checked_view_offset(shape, strides, base_offset, indices).ok_or_else(|| {
+        crate::Error::InvalidConfig {
+            op,
+            message: format!(
+                "layout offset overflow for shape={shape:?} strides={strides:?} offset={base_offset} indices={indices:?}"
+            ),
+        }
+    })
+}
+
+fn layout_summary(shape: &[usize], strides: &[isize], offset: isize) -> String {
+    format!("shape={shape:?} strides={strides:?} offset={offset}")
+}
+
+fn assert_layout_col_major_contiguous(
+    is_contiguous: bool,
+    shape: &[usize],
+    strides: &[isize],
+    offset: isize,
+    op: &'static str,
+) -> crate::Result<()> {
+    if is_contiguous {
+        Ok(())
+    } else {
+        Err(crate::Error::InvalidConfig {
+            op,
+            message: format!(
+                "expected compact column-major layout, got {}",
+                layout_summary(shape, strides, offset)
+            ),
+        })
+    }
+}
+
+fn validate_tensor_copy_target(
+    dst_dtype: DType,
+    dst_shape: &[usize],
+    src: &Tensor,
+    op: &'static str,
+) -> crate::Result<()> {
+    if dst_dtype != src.dtype() {
+        return Err(crate::Error::DTypeMismatch {
+            op,
+            lhs: dst_dtype,
+            rhs: src.dtype(),
+        });
+    }
+    if dst_shape != src.shape() {
+        return Err(crate::Error::ShapeMismatch {
+            op,
+            lhs: dst_shape.to_vec(),
+            rhs: src.shape().to_vec(),
+        });
+    }
+    Ok(())
+}
+
+fn copy_tensor_to_tensor(dst: &mut Tensor, src: &Tensor, op: &'static str) -> crate::Result<()> {
+    validate_tensor_copy_target(dst.dtype(), dst.shape(), src, op)?;
+    macro_rules! copy_variant {
+        ($variant:ident) => {
+            if let (Tensor::$variant(dst), Tensor::$variant(src)) = (&mut *dst, src) {
+                dst.host_data_mut()?.clone_from_slice(src.host_data()?);
+                return Ok(());
+            }
+        };
+    }
+    copy_variant!(F32);
+    copy_variant!(F64);
+    copy_variant!(I32);
+    copy_variant!(I64);
+    copy_variant!(Bool);
+    copy_variant!(C32);
+    copy_variant!(C64);
+    Err(crate::Error::DTypeMismatch {
+        op,
+        lhs: dst.dtype(),
+        rhs: src.dtype(),
+    })
+}
+
+fn copy_tensor_to_view_mut(
+    dst: &mut TensorViewMut<'_>,
+    src: &Tensor,
+    op: &'static str,
+) -> crate::Result<()> {
+    validate_tensor_copy_target(dst.dtype(), dst.shape(), src, op)?;
+    macro_rules! copy_variant {
+        ($variant:ident) => {
+            if let (TensorViewMut::$variant(dst), Tensor::$variant(src)) = (&mut *dst, src) {
+                return dst.copy_from_contiguous(src);
+            }
+        };
+    }
+    copy_variant!(F32);
+    copy_variant!(F64);
+    copy_variant!(I32);
+    copy_variant!(I64);
+    copy_variant!(Bool);
+    copy_variant!(C32);
+    copy_variant!(C64);
+    Err(crate::Error::DTypeMismatch {
+        op,
+        lhs: dst.dtype(),
+        rhs: src.dtype(),
+    })
 }
 
 fn try_shape_product(shape: &[usize], op: &'static str) -> crate::Result<usize> {
@@ -3776,6 +4453,74 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
         try_linear_offset_for_shape(self.shape(), indices, "TypedTensor::linear_offset")
     }
 
+    /// Compute the physical element offset for a logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::zeros(vec![2, 3]).unwrap();
+    /// assert_eq!(t.layout_linear_offset(&[1, 2])?, 5);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
+        try_linear_offset_for_shape(self.shape(), indices, "TypedTensor::layout_linear_offset")
+    }
+
+    /// Return whether this owned tensor is compact column-major.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::zeros(vec![2]).unwrap();
+    /// assert!(t.is_col_major_contiguous()?);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
+        self.layout
+            .is_compact_col_major()
+            .map_err(|err| tensor_layout_error("TypedTensor::is_col_major_contiguous", err))
+    }
+
+    /// Return a compact string summary of this tensor's layout metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::zeros(vec![2]).unwrap();
+    /// assert!(t.layout_summary().contains("shape=[2]"));
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn layout_summary(&self) -> String {
+        layout_summary(self.shape(), self.layout.strides(), self.layout.offset())
+    }
+
+    /// Assert this tensor is compact column-major.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let t = TypedTensor::<f64>::zeros(vec![2]).unwrap();
+    /// t.assert_col_major_contiguous()?;
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
+        assert_layout_col_major_contiguous(
+            self.is_col_major_contiguous()?,
+            self.shape(),
+            self.layout.strides(),
+            self.layout.offset(),
+            "TypedTensor::assert_col_major_contiguous",
+        )
+    }
+
     /// Borrow a single element by multi-index.
     ///
     /// # Examples
@@ -3928,6 +4673,90 @@ impl Tensor {
             Tensor::C32(t) => t.buffer().is_backend(),
             Tensor::C64(t) => t.buffer().is_backend(),
         }
+    }
+
+    /// Compute the physical element offset for a logical index.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
+    /// assert_eq!(t.layout_linear_offset(&[1])?, 1);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
+        match self {
+            Tensor::F32(t) => t.layout_linear_offset(indices),
+            Tensor::F64(t) => t.layout_linear_offset(indices),
+            Tensor::I32(t) => t.layout_linear_offset(indices),
+            Tensor::I64(t) => t.layout_linear_offset(indices),
+            Tensor::Bool(t) => t.layout_linear_offset(indices),
+            Tensor::C32(t) => t.layout_linear_offset(indices),
+            Tensor::C64(t) => t.layout_linear_offset(indices),
+        }
+    }
+
+    /// Return whether this tensor is compact column-major.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
+    /// assert!(t.is_col_major_contiguous()?);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
+        match self {
+            Tensor::F32(t) => t.is_col_major_contiguous(),
+            Tensor::F64(t) => t.is_col_major_contiguous(),
+            Tensor::I32(t) => t.is_col_major_contiguous(),
+            Tensor::I64(t) => t.is_col_major_contiguous(),
+            Tensor::Bool(t) => t.is_col_major_contiguous(),
+            Tensor::C32(t) => t.is_col_major_contiguous(),
+            Tensor::C64(t) => t.is_col_major_contiguous(),
+        }
+    }
+
+    /// Return a compact string summary of this tensor's layout metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
+    /// assert!(t.layout_summary().contains("shape=[2]"));
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn layout_summary(&self) -> String {
+        let layout = tensor_layout(self);
+        layout_summary(layout.shape(), layout.strides(), layout.offset())
+    }
+
+    /// Assert this tensor is compact column-major.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let t = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
+    /// t.assert_col_major_contiguous()?;
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
+        let layout = tensor_layout(self);
+        assert_layout_col_major_contiguous(
+            self.is_col_major_contiguous()?,
+            layout.shape(),
+            layout.strides(),
+            layout.offset(),
+            "Tensor::assert_col_major_contiguous",
+        )
     }
 
     /// Try to borrow the host data as a typed slice.

--- a/docs/design/einsum.md
+++ b/docs/design/einsum.md
@@ -3,7 +3,8 @@
 Einsum is a standard extension crate, not part of a root facade.
 The public user-facing paths live under `tenferro_einsum` as crate-root
 extension traits: `TensorEinsumExt`, `TypedTensorEinsumExt`, and
-`TensorReadEinsumExt` for concrete backend-explicit execution,
+`TensorReadEinsumExt` for concrete backend-explicit execution, their
+`*IntoExt` counterparts for preallocated output execution,
 `GraphCompilerEinsumExt` for traced graph construction, `EagerEinsumExt` for
 autodiff eager execution, and tensor extension traits for `tensordot`
 contraction sugar. `ConcreteEinsumPlan` owns repeated concrete executions with
@@ -75,11 +76,18 @@ assert_eq!(c.shape(), &[2, 2]);
 ```
 
 `TensorEinsumExt` is the unsuffixed API for compact `Tensor` references.
-`TypedTensorEinsumExt` preserves a statically known scalar type.
+`TypedTensorEinsumExt` preserves a statically known scalar type and also
+accepts borrowed typed strided views.
 `TensorReadEinsumExt::einsum_read` accepts `TensorRead` values and therefore
-uses the repository-wide `_read` suffix convention. `ConcreteEinsumPlan`
-precomputes the contraction tree for fixed input metadata and validates later
-executions against the prepared input count, dtypes, and shapes.
+uses the repository-wide `_read` suffix convention. `TensorEinsumIntoExt`,
+`TypedTensorEinsumIntoExt`, and `TensorReadEinsumIntoExt` write into caller
+provided `TensorWrite` or typed tensor outputs; they validate output dtype and
+shape before any writes and never resize the destination.
+
+`ConcreteEinsumPlan` precomputes the contraction tree for fixed input metadata
+and validates later executions against the prepared input count, dtypes, and
+shapes. Plan execution exposes both owned-output methods and `execute_into`,
+`execute_typed_into`, and `execute_read_into`.
 
 `einsum_with` accepts an explicit `EinsumOptimize` strategy:
 
@@ -200,6 +208,15 @@ general path of diagonalization, reductions, broadcast/outer product, and
 Column-major ordering matters. For GEMM-like steps, compute dimensions stay on
 the left and batch dimensions stay on the right so each batch slice remains a
 contiguous block for the underlying tensor backend.
+
+For a whole-expression binary GEMM-compatible contraction such as
+`ij,jk->ik`, `einsum_into` and `ConcreteEinsumPlan::execute_into` dispatch to
+the backend `dot_general_read_into` hook before the owned-output fallback. The
+CPU faer path writes directly into caller-provided output storage through
+`strided_einsum2` and does not allocate the final output tensor. General
+multi-step einsums may still allocate intermediates; their `*_into` contract is
+that the final result is copied into the preallocated destination after output
+validation.
 
 ## GPU Interaction
 

--- a/docs/design/tensor.md
+++ b/docs/design/tensor.md
@@ -22,6 +22,9 @@ buffers, CUDA, BLAS/LAPACK providers, execution traits, runtime caches, or AD.
 - dtype-erased dynamic-rank `Tensor`,
 - `TypedTensorView<'a, T, R>` and `TypedTensorViewMut<'a, T, R>` for borrowed
   strided views,
+- `TensorView<'a>` and `TensorViewMut<'a>` for dtype-erased borrowed views,
+- `TensorRead<'a>` and `TensorWrite<'a>` for read/write kernel dispatch over
+  either owned tensors or borrowed views,
 - placement metadata, backend buffer handles, `TensorBackend`, and backend
   session traits.
 
@@ -39,6 +42,12 @@ Arbitrary strides, non-zero offsets, transposes, slices, and reverse layouts
 belong to views or `TensorLayout` metadata. Metadata-only transformations use
 the `_view` suffix, such as `transpose_view` and `slice_view`.
 
+Owned tensors and views expose layout inspection helpers for migration and
+assertion code: compact column-major checks, logical-index to physical-offset
+calculation, and layout summaries that include shape, strides, and offset.
+Mutable views validate that distinct logical elements do not alias the same
+physical element at construction.
+
 When a compact-only operation receives a view, it may canonicalize that view
 inside the same placement. Host views can copy to host compact tensors; CUDA
 views can copy to CUDA compact tensors. Canonicalization is not a CPU/GPU
@@ -49,6 +58,10 @@ transfer mechanism.
 Unsuffixed operation names take owned compact tensor inputs. APIs that accept
 borrowed view inputs or `TensorRead` inputs use a `_read` suffix. Examples
 include `add_read`, `reduce_sum_read`, and `dot_general_read`.
+
+Preallocated-output APIs use `TensorWrite` when the output may be either an
+owned tensor or a mutable view. These APIs validate output dtype and shape
+before writing and do not resize the destination.
 
 Metadata-only APIs that produce views use `_view`. APIs that allocate,
 execute kernels, canonicalize buffers, or move data must not use `_view`.

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -3,7 +3,9 @@
 `einsum` is a standard extension, not part of `tenferro` core. Add the
 `tenferro-einsum` crate and import its extension traits. Concrete tensor
 execution uses `TensorEinsumExt`, `TypedTensorEinsumExt`, and
-`TensorReadEinsumExt`; repeated-shape concrete workloads can use
+`TensorReadEinsumExt`; preallocated-output execution uses the matching
+`TensorEinsumIntoExt`, `TypedTensorEinsumIntoExt`, and
+`TensorReadEinsumIntoExt` traits; repeated-shape concrete workloads can use
 `ConcreteEinsumPlan`. Traced graph construction uses `GraphCompilerEinsumExt`;
 autodiff eager execution uses `EagerEinsumExt`; `tensordot` contraction sugar
 uses tensor extension traits. Compiled traced execution also requires explicit
@@ -62,8 +64,11 @@ receiver type is the fixed-size array of borrowed tensor references.
 ```rust
 use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
-use tenferro_einsum::{TensorEinsumExt, TypedTensorEinsumExt};
-use tenferro_tensor::{Tensor, TypedTensor};
+use tenferro_einsum::{
+    TensorEinsumExt, TensorEinsumIntoExt, TypedTensorEinsumExt,
+    TypedTensorEinsumIntoExt,
+};
+use tenferro_tensor::{Tensor, TensorWrite, TypedTensor, TypedTensorView};
 
 let lhs = Tensor::from_vec_col_major(
     vec![2, 3],
@@ -76,6 +81,14 @@ let rhs = Tensor::from_vec_col_major(
 let mut backend = CpuBackend::new();
 let product = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend)?;
 assert_eq!(product.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
+
+let mut product_out = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4])?;
+[&lhs, &rhs].einsum_into(
+    "ij,jk->ik",
+    &mut backend,
+    TensorWrite::from_tensor(&mut product_out),
+)?;
+assert_eq!(product_out.as_slice::<f64>()?, &[22.0, 28.0, 49.0, 64.0]);
 
 let complex_lhs = TypedTensor::<Complex64>::from_vec_col_major(
     vec![2, 2],
@@ -95,6 +108,18 @@ assert_eq!(
     complex.as_slice()?,
     &[Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)],
 );
+
+let borrowed = TypedTensorView::from_slice([2, 2], [1, 2], 0, complex_lhs.as_slice()?)?;
+let borrowed_rhs = complex_rhs.as_view();
+let mut borrowed_out = TypedTensor::<Complex64>::from_vec_col_major(
+    vec![2, 1],
+    vec![Complex64::new(0.0, 0.0); 2],
+)?;
+[borrowed, borrowed_rhs].einsum_into("ij,jk->ik", &mut backend, &mut borrowed_out)?;
+assert_eq!(
+    borrowed_out.as_slice()?,
+    &[Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)],
+);
 # Ok::<(), tenferro_tensor::Error>(())
 ```
 
@@ -111,8 +136,8 @@ running the stored tree.
 
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_einsum::{ConcreteEinsumPlan, TensorReadEinsumExt};
-use tenferro_tensor::{Tensor, TensorRead, TensorView, TypedTensorView};
+use tenferro_einsum::{ConcreteEinsumPlan, TensorReadEinsumExt, TensorReadEinsumIntoExt};
+use tenferro_tensor::{Tensor, TensorRead, TensorView, TensorWrite, TypedTensorView};
 
 let matrix_data = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
 let matrix = TypedTensorView::from_slice([2, 3], [3, 1], 0, &matrix_data)?;
@@ -129,6 +154,18 @@ assert_eq!(result.as_slice::<f64>()?, &[140.0, 320.0]);
 let plan = ConcreteEinsumPlan::prepare_read(inputs.clone(), "ij,j->i")?;
 let planned = plan.execute_read(inputs, &mut backend)?;
 assert_eq!(planned.as_slice::<f64>()?, &[140.0, 320.0]);
+
+let mut planned_out = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2])?;
+let inputs = [
+    TensorRead::from_view(TensorView::F64(matrix)),
+    TensorRead::from_tensor(&vector),
+];
+plan.execute_read_into(
+    inputs,
+    &mut backend,
+    TensorWrite::from_tensor(&mut planned_out),
+)?;
+assert_eq!(planned_out.as_slice::<f64>()?, &[140.0, 320.0]);
 # Ok::<(), tenferro_tensor::Error>(())
 ```
 

--- a/docs/spec/api-conventions.md
+++ b/docs/spec/api-conventions.md
@@ -66,9 +66,11 @@ The default stratum is internal.
 3. Multi-output linalg and decomposition ops are tensor extension-trait methods.
 4. Einsum is exposed through extension traits owned by `tenferro-einsum`:
    `TensorEinsumExt`, `TypedTensorEinsumExt`, and `TensorReadEinsumExt` for
-   concrete input slices/arrays, `ConcreteEinsumPlan` for repeated concrete
-   executions with fixed input metadata, `GraphCompilerEinsumExt` for traced
-   graph construction, and `EagerEinsumExt` for autodiff eager input
+   concrete input slices/arrays; `TensorEinsumIntoExt`,
+   `TypedTensorEinsumIntoExt`, and `TensorReadEinsumIntoExt` for
+   preallocated-output concrete execution; `ConcreteEinsumPlan` for repeated
+   concrete executions with fixed input metadata; `GraphCompilerEinsumExt` for
+   traced graph construction; and `EagerEinsumExt` for autodiff eager input
    slices/arrays.
 5. Standard operation families are first-class crates, not modules under a
    broad facade.

--- a/docs/worklogs/2026-06-28-einsum-views-into.md
+++ b/docs/worklogs/2026-06-28-einsum-views-into.md
@@ -1,0 +1,105 @@
+# Einsum Views, Into Outputs, And Layout Helpers
+
+## Summary
+
+Implemented the concrete tensor API extensions for issues #1241-#1244:
+borrowed typed strided view inputs for typed einsum, preallocated output
+execution, reusable concrete plan `execute_into` entry points, and tensor
+layout inspection helpers.
+
+## Issue Ledger
+
+- #1241: `TypedTensorEinsumExt` now accepts borrowed `TypedTensorView` inputs,
+  including strided complex views.
+- #1242: concrete einsum exposes `einsum_into`/`einsum_read_into` entry points
+  that write into caller-provided output storage.
+- #1243: `ConcreteEinsumPlan` exposes `execute_into`,
+  `execute_typed_into`, and `execute_read_into` for repeated fixed-expression
+  workloads.
+- #1244: tensor read/write/view surfaces expose layout inspection and
+  column-major assertion helpers.
+
+## Context Read
+
+- `AGENTS.md` and `REPOSITORY_RULES.md`
+- shared tensor4all common, Rust, performance, numerical, and docs/test rules
+- `docs/spec/api-conventions.md`
+- `docs/design/tensor.md`
+- `docs/design/einsum.md`
+- `docs/worklogs/2026-06-27-concrete-einsum-public-api.md`
+- existing tensor, CPU dot-general, and concrete einsum tests
+
+## Design Review
+
+An external Claude plan review was run before implementation. The usable
+review feedback was design-level because Claude's own file tools could not
+read the workspace in the first attempts. The incorporated points were:
+
+- validate output dtype and shape before allocation or writes;
+- make aliasing and output-layout behavior explicit;
+- require evidence that the GEMM-compatible path reaches a direct backend
+  `*_into` call before owned-result fallback;
+- justify the dtype-erased mutable view boundary rather than adding only a
+  typed-only output API.
+
+## Decisions
+
+- Added `TensorViewMut<'a>` and `TensorWrite<'a>` as the dtype-erased mutable
+  output surface. This mirrors the existing `TensorView<'a>` and
+  `TensorRead<'a>` read-side design while keeping typed callers on
+  `&mut TypedTensor<T>` where static dtype information is already available.
+- Kept `einsum_into` as a validating write API, not a resizing API. If the
+  destination dtype or shape differs from the expression result, the call
+  returns an error before writing.
+- Added layout helpers to owned tensors, read views, mutable views, and
+  read/write erased wrappers. The helpers report shape, strides, offset, and
+  column-major compactness without materializing data.
+- Routed GEMM-compatible binary contractions such as `ij,jk->ik` through
+  `TensorDot::dot_general_read_into`. On the CPU faer provider this constructs
+  a mutable strided output view over caller storage and writes the final result
+  directly.
+- Kept the general einsum fallback simple: it may allocate intermediates and,
+  for non-direct cases, may allocate an owned final result before copying into
+  the caller's output. The public guarantee is preallocated destination support,
+  with allocation-free final output targeted at direct GEMM-compatible paths.
+- Left the CPU BLAS direct-into provider as a fallback path for this branch.
+  The default CPU faer provider has the direct output path; BLAS-specific
+  direct output can be added behind the same backend hook later.
+
+## Alternatives Rejected
+
+- A typed-only `einsum_into(&mut TypedTensor<T>)` surface for all callers:
+  rejected because it would leave dtype-erased `Tensor` users without a
+  symmetric preallocated-output API.
+- Resizing the destination tensor on mismatch: rejected because it hides
+  allocation in an API whose purpose is caller-owned output storage and makes
+  view destinations impossible to reason about.
+- A separate public "compiled typed einsum" type: rejected in favor of adding
+  `execute_into` methods to the existing `ConcreteEinsumPlan` contract.
+
+## Verification
+
+Incremental TDD checks were run while implementing the branch:
+
+- `cargo test -p tenferro-tensor types_tests -- --nocapture`
+- `cargo test -p tenferro-cpu dot_general_read_into -- --nocapture`
+- `cargo test -p tenferro-cpu strided_dot_into_does_not_acquire_output_buffer -- --nocapture`
+- `cargo test -p tenferro-einsum einsum_into -- --nocapture`
+- `cargo test -p tenferro-einsum concrete_einsum_plan_execute -- --nocapture`
+- `cargo test -p tenferro-einsum concrete`
+- `cargo test -p tenferro-einsum borrowed_strided_complex_views -- --nocapture`
+- `cargo test -p tenferro-einsum gemm_fast_path_dispatches -- --nocapture`
+
+Final branch verification is recorded in the PR once the full checklist has
+passed.
+
+## Remaining Risks
+
+- The no-final-allocation evidence for GEMM-compatible `einsum_into` is based
+  on the faer direct path and source contracts. It is not a global allocator
+  count for every contraction expression.
+- CPU BLAS currently falls back to owned-result execution before copying into
+  the output destination.
+- Safe Rust borrowing prevents ordinary owned tensor input/output aliasing at
+  the public API boundary, but backend-shared storage aliasing is not
+  exhaustively detected at runtime.


### PR DESCRIPTION
## Summary
- Add dtype-erased mutable output views (`TensorViewMut`/`TensorWrite`) plus layout inspection/assertion helpers.
- Add concrete `einsum_into` and plan `execute_into` APIs, including typed borrowed strided view inputs.
- Route GEMM-compatible `ij,jk->ik` into the CPU faer direct-output path and document the remaining BLAS/general-einsum fallback limits.

## Issues
Closes #1241
Closes #1242
Closes #1243
Closes #1244

## Worklog
- docs/worklogs/2026-06-28-einsum-views-into.md

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings
- cargo test -p tenferro-tensor types_tests -- --nocapture
- cargo test -p tenferro-cpu dot_general_read_into -- --nocapture
- cargo test -p tenferro-cpu strided_dot_into_does_not_acquire_output_buffer -- --nocapture
- cargo test -p tenferro-einsum concrete -- --nocapture
- cargo check -p tenferro-cpu --no-default-features --features cpu-blas
- cargo check -p tenferro-einsum --no-default-features --features cpu-blas
- cargo check -p tenferro-einsum --no-default-features --features cpu-faer,autodiff
- cargo test --workspace --release
- cargo llvm-cov --workspace --release --json --output-path coverage.json --no-clean
- python3 scripts/check-coverage.py coverage.json
- cargo doc --workspace --no-deps
- python3 scripts/check-doc-snippets.py --check
- python3 scripts/check-guide-dependency-snippets.py
- python3 scripts/check-api-consistency.py --fail-on-findings
- python3 scripts/check-operation-categories.py --fail-on-findings
- python3 scripts/check-docs-site.py
- python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json
- git diff --check

## Notes
- `cargo test/check --all-features` is not a valid local check for these crates because `strided-einsum2` rejects multiple explicit BLAS provider features at once; supported feature combinations were checked separately.
- CPU BLAS direct-output dispatch intentionally falls back in this branch; the direct no-final-output-allocation path is the CPU faer provider path.
