### PR TITLE
Add QR and Eigh read-view linalg APIs

### DIFF
--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -109,11 +109,67 @@ pub trait LinalgBackend: TensorBackend {
     /// `R` has shape `min(m, n) x n`.
     fn qr(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
 
+    /// Compute public QR outputs `(Q, R)` from a borrowed tensor view.
+    ///
+    /// Backends may canonicalize the view inside the same placement family, but
+    /// must not silently transfer between CPU and GPU memory.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::LinalgBackend;
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_tensor::{TensorView, TypedTensor};
+    ///
+    /// let input = TypedTensor::<f64>::from_vec_col_major(
+    ///     vec![2, 2],
+    ///     vec![1.0, 0.0, 0.0, 2.0],
+    /// )?;
+    /// let outputs = CpuBackend::new().qr_read(TensorView::F64(input.as_view()))?;
+    /// assert_eq!(outputs[0].shape(), &[2, 2]);
+    /// assert_eq!(outputs[1].shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn qr_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Err(tenferro_tensor::Error::backend_failure(
+            "qr",
+            "backend does not accept borrowed tensor views at this execution boundary",
+        ))
+    }
+
     /// Compute public Hermitian eigendecomposition outputs `(values, vectors)`.
     ///
     /// The returned vector order is `[values, vectors]`, where `values` has
     /// shape `[n]` and `vectors` has shape `[n, n]`.
     fn eigh(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+
+    /// Compute public Hermitian eigendecomposition outputs from a borrowed tensor view.
+    ///
+    /// Backends may canonicalize the view inside the same placement family, but
+    /// must not silently transfer between CPU and GPU memory.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::LinalgBackend;
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_tensor::{TensorView, TypedTensor};
+    ///
+    /// let input = TypedTensor::<f64>::from_vec_col_major(
+    ///     vec![2, 2],
+    ///     vec![1.0, 0.0, 0.0, 2.0],
+    /// )?;
+    /// let outputs = CpuBackend::new().eigh_read(TensorView::F64(input.as_view()))?;
+    /// assert_eq!(outputs[0].shape(), &[2]);
+    /// assert_eq!(outputs[1].shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn eigh_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Err(tenferro_tensor::Error::backend_failure(
+            "eigh",
+            "backend does not accept borrowed tensor views at this execution boundary",
+        ))
+    }
 
     #[doc(hidden)]
     fn eigh_values(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -620,6 +620,34 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
+    fn qr_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F32(compact);
+                self.qr(&input)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F64(compact);
+                self.qr(&input)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C32(compact);
+                self.qr(&input)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C64(compact);
+                self.qr(&input)
+            }
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("qr", input.dtype()))
+            }
+        }
+    }
+
     fn eigh(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         ensure_host_tensor("eigh", input)?;
         match self.kind() {
@@ -663,6 +691,34 @@ impl LinalgBackend for CpuBackend {
                 {
                     Err(unsupported_provider("eigh", self.kind()))
                 }
+            }
+        }
+    }
+
+    fn eigh_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F32(compact);
+                self.eigh(&input)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F64(compact);
+                self.eigh(&input)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C32(compact);
+                self.eigh(&input)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C64(compact);
+                self.eigh(&input)
+            }
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("eigh", input.dtype()))
             }
         }
     }

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -25,6 +25,289 @@ fn svd_canonicalizes_transposed_host_view_before_lapack() {
 }
 
 #[test]
+fn qr_read_canonicalizes_transposed_host_view_before_lapack() {
+    let data = vec![1.0, -2.0, 3.0, 0.5, -1.0, 4.0];
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], data.clone()).unwrap();
+    let view = a.as_view().transpose_view([1, 0]).unwrap();
+    let outputs = CpuBackend::new().qr_read(TensorView::F64(view)).unwrap();
+
+    assert_eq!(outputs.len(), 2);
+    assert_eq!(outputs[0].shape(), &[3, 2]);
+    assert_eq!(outputs[1].shape(), &[2, 2]);
+
+    let q = matrix_f64_from_tensor(&outputs[0], 3, 2);
+    let r = matrix_f64_from_tensor(&outputs[1], 2, 2);
+    let recon = matmul_f64(&q, &r, 3, 2, 2);
+    let expected = transpose_f64(&data, 2, 3);
+
+    for (actual, expected) in recon.iter().zip(expected.iter()) {
+        assert_f64_close_tol(*actual, *expected, 1.0e-9);
+    }
+}
+
+#[test]
+fn qr_read_canonicalizes_transposed_complex_host_view_before_lapack() {
+    let data = vec![
+        Complex64::new(1.0, 0.5),
+        Complex64::new(-2.0, 1.0),
+        Complex64::new(3.0, -0.25),
+        Complex64::new(0.5, -1.0),
+        Complex64::new(-1.0, 0.75),
+        Complex64::new(4.0, 1.5),
+    ];
+    let a = TypedTensor::<Complex64>::from_vec_col_major(vec![2, 3], data.clone()).unwrap();
+    let view = a.as_view().transpose_view([1, 0]).unwrap();
+    let outputs = CpuBackend::new().qr_read(TensorView::C64(view)).unwrap();
+
+    assert_eq!(outputs.len(), 2);
+    assert_eq!(outputs[0].shape(), &[3, 2]);
+    assert_eq!(outputs[1].shape(), &[2, 2]);
+
+    let q = matrix_c64_from_tensor(&outputs[0], 3, 2);
+    let r = matrix_c64_from_tensor(&outputs[1], 2, 2);
+    let recon = matmul_c64(&q, &r, 3, 2, 2);
+    let expected = transpose_c64(&data, 2, 3);
+
+    for (actual, expected) in recon.iter().zip(expected.iter()) {
+        assert_c64_close_tol(*actual, *expected, 1.0e-9);
+    }
+}
+
+#[test]
+fn eigh_read_canonicalizes_transposed_host_view_before_lapack() {
+    let data = vec![4.0, 1.0, 1.0, 3.0];
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data.clone()).unwrap();
+    let view = a.as_view().transpose_view([1, 0]).unwrap();
+    let outputs = CpuBackend::new().eigh_read(TensorView::F64(view)).unwrap();
+
+    assert_eq!(outputs.len(), 2);
+    assert_eq!(outputs[0].shape(), &[2]);
+    assert_eq!(outputs[1].shape(), &[2, 2]);
+
+    let values = match &outputs[0] {
+        Tensor::F64(inner) => inner.host_data().unwrap().to_vec(),
+        _ => panic!("expected f64 eigenvalues"),
+    };
+    let vectors = matrix_f64_from_tensor(&outputs[1], 2, 2);
+    let recon = matmul_f64(
+        &matmul_f64(&vectors, &diag_f64(&values), 2, 2, 2),
+        &transpose_f64(&vectors, 2, 2),
+        2,
+        2,
+        2,
+    );
+    let expected = transpose_f64(&data, 2, 2);
+
+    for (actual, expected) in recon.iter().zip(expected.iter()) {
+        assert_f64_close_tol(*actual, *expected, 1.0e-10);
+    }
+}
+
+#[test]
+fn eigh_read_canonicalizes_transposed_complex_host_view_before_lapack() {
+    let data = vec![
+        Complex64::new(4.0, 0.0),
+        Complex64::new(1.0, -0.5),
+        Complex64::new(1.0, 0.5),
+        Complex64::new(3.0, 0.0),
+    ];
+    let a = TypedTensor::<Complex64>::from_vec_col_major(vec![2, 2], data.clone()).unwrap();
+    let view = a.as_view().transpose_view([1, 0]).unwrap();
+    let outputs = CpuBackend::new().eigh_read(TensorView::C64(view)).unwrap();
+
+    assert_eq!(outputs.len(), 2);
+    assert_eq!(outputs[0].dtype(), DType::F64);
+    assert_eq!(outputs[1].dtype(), DType::C64);
+    assert_eq!(outputs[0].shape(), &[2]);
+    assert_eq!(outputs[1].shape(), &[2, 2]);
+
+    let values = vector_f64_from_tensor(&outputs[0], 2);
+    let vectors = matrix_c64_from_tensor(&outputs[1], 2, 2);
+    let recon = matmul_c64(
+        &matmul_c64(&vectors, &diag_c64_from_real(&values), 2, 2, 2),
+        &conjugate_transpose_c64(&vectors, 2, 2),
+        2,
+        2,
+        2,
+    );
+    let expected = transpose_c64(&data, 2, 2);
+
+    for (actual, expected) in recon.iter().zip(expected.iter()) {
+        assert_c64_close_tol(*actual, *expected, 1.0e-10);
+    }
+}
+
+#[test]
+fn qr_read_accepts_all_supported_linalg_view_dtypes() {
+    let f32_input =
+        TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![1.0, -2.0, 0.5, 4.0]).unwrap();
+    let f64_input =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, -2.0, 0.5, 4.0]).unwrap();
+    let c32_input = TypedTensor::<Complex32>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex32::new(1.0, 0.5),
+            Complex32::new(-2.0, 1.0),
+            Complex32::new(0.5, -0.25),
+            Complex32::new(4.0, 1.5),
+        ],
+    )
+    .unwrap();
+    let c64_input = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(1.0, 0.5),
+            Complex64::new(-2.0, 1.0),
+            Complex64::new(0.5, -0.25),
+            Complex64::new(4.0, 1.5),
+        ],
+    )
+    .unwrap();
+
+    let mut backend = CpuBackend::new();
+    for (view, dtype) in [
+        (
+            TensorView::F32(f32_input.as_view().transpose_view([1, 0]).unwrap()),
+            DType::F32,
+        ),
+        (
+            TensorView::F64(f64_input.as_view().transpose_view([1, 0]).unwrap()),
+            DType::F64,
+        ),
+        (
+            TensorView::C32(c32_input.as_view().transpose_view([1, 0]).unwrap()),
+            DType::C32,
+        ),
+        (
+            TensorView::C64(c64_input.as_view().transpose_view([1, 0]).unwrap()),
+            DType::C64,
+        ),
+    ] {
+        let outputs = backend.qr_read(view).unwrap();
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0].dtype(), dtype);
+        assert_eq!(outputs[1].dtype(), dtype);
+        assert_eq!(outputs[0].shape(), &[2, 2]);
+        assert_eq!(outputs[1].shape(), &[2, 2]);
+    }
+}
+
+#[test]
+fn eigh_read_accepts_all_supported_linalg_view_dtypes() {
+    let f32_input =
+        TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![4.0, 1.0, 1.0, 3.0]).unwrap();
+    let f64_input =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![4.0, 1.0, 1.0, 3.0]).unwrap();
+    let c32_input = TypedTensor::<Complex32>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex32::new(4.0, 0.0),
+            Complex32::new(1.0, -0.5),
+            Complex32::new(1.0, 0.5),
+            Complex32::new(3.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let c64_input = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(4.0, 0.0),
+            Complex64::new(1.0, -0.5),
+            Complex64::new(1.0, 0.5),
+            Complex64::new(3.0, 0.0),
+        ],
+    )
+    .unwrap();
+
+    let mut backend = CpuBackend::new();
+    for (view, value_dtype, vector_dtype) in [
+        (
+            TensorView::F32(f32_input.as_view().transpose_view([1, 0]).unwrap()),
+            DType::F32,
+            DType::F32,
+        ),
+        (
+            TensorView::F64(f64_input.as_view().transpose_view([1, 0]).unwrap()),
+            DType::F64,
+            DType::F64,
+        ),
+        (
+            TensorView::C32(c32_input.as_view().transpose_view([1, 0]).unwrap()),
+            DType::F32,
+            DType::C32,
+        ),
+        (
+            TensorView::C64(c64_input.as_view().transpose_view([1, 0]).unwrap()),
+            DType::F64,
+            DType::C64,
+        ),
+    ] {
+        let outputs = backend.eigh_read(view).unwrap();
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0].dtype(), value_dtype);
+        assert_eq!(outputs[1].dtype(), vector_dtype);
+        assert_eq!(outputs[0].shape(), &[2]);
+        assert_eq!(outputs[1].shape(), &[2, 2]);
+    }
+}
+
+#[test]
+fn linalg_read_rejects_non_float_view_dtypes() {
+    fn assert_unsupported_dtype(
+        result: tenferro_tensor::Result<Vec<Tensor>>,
+        expected_op: &'static str,
+    ) {
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            tenferro_tensor::Error::BackendFailure {
+                op,
+                ref message,
+            } if op == expected_op && message.contains("unsupported dtype")
+        ));
+    }
+
+    let i32_input = TypedTensor::<i32>::from_vec_col_major(vec![2, 2], vec![1, 0, 0, 1]).unwrap();
+    let i64_input =
+        TypedTensor::<i64>::from_vec_col_major(vec![2, 2], vec![1_i64, 0, 0, 1]).unwrap();
+    let bool_input =
+        TypedTensor::<bool>::from_vec_col_major(vec![2, 2], vec![true, false, false, true])
+            .unwrap();
+
+    let mut backend = CpuBackend::new();
+    assert_unsupported_dtype(
+        backend.svd_read(TensorView::I32(i32_input.as_view())),
+        "svd",
+    );
+    assert_unsupported_dtype(
+        backend.svd_read(TensorView::I64(i64_input.as_view())),
+        "svd",
+    );
+    assert_unsupported_dtype(
+        backend.svd_read(TensorView::Bool(bool_input.as_view())),
+        "svd",
+    );
+    assert_unsupported_dtype(backend.qr_read(TensorView::I32(i32_input.as_view())), "qr");
+    assert_unsupported_dtype(backend.qr_read(TensorView::I64(i64_input.as_view())), "qr");
+    assert_unsupported_dtype(
+        backend.qr_read(TensorView::Bool(bool_input.as_view())),
+        "qr",
+    );
+    assert_unsupported_dtype(
+        backend.eigh_read(TensorView::I32(i32_input.as_view())),
+        "eigh",
+    );
+    assert_unsupported_dtype(
+        backend.eigh_read(TensorView::I64(i64_input.as_view())),
+        "eigh",
+    );
+    assert_unsupported_dtype(
+        backend.eigh_read(TensorView::Bool(bool_input.as_view())),
+        "eigh",
+    );
+}
+
+#[test]
 fn test_batched_cholesky() {
     let l0 = vec![2.0, 1.0, 2.0, 0.0, 3.0, -1.0, 0.0, 0.0, 1.5];
     let l1 = vec![1.5, -0.5, 1.0, 0.0, 2.0, 0.75, 0.0, 0.0, 1.25];

--- a/crates/tenferro-linalg/src/eager_backend.rs
+++ b/crates/tenferro-linalg/src/eager_backend.rs
@@ -69,8 +69,16 @@ impl LinalgBackend for EagerBackend {
         dispatch_linalg!(self, qr(input))
     }
 
+    fn qr_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        dispatch_linalg!(self, qr_read(input))
+    }
+
     fn eigh(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         dispatch_linalg!(self, eigh(input))
+    }
+
+    fn eigh_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        dispatch_linalg!(self, eigh_read(input))
     }
 
     fn eigh_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {

--- a/crates/tenferro-linalg/src/gpu/mod.rs
+++ b/crates/tenferro-linalg/src/gpu/mod.rs
@@ -85,8 +85,64 @@ impl LinalgBackend for CudaBackend {
         linalg::qr(self, input)
     }
 
+    fn qr_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F32(compact);
+                self.qr(&input)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F64(compact);
+                self.qr(&input)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C32(compact);
+                self.qr(&input)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C64(compact);
+                self.qr(&input)
+            }
+            TensorView::I32(_) => Err(unsupported_view_dtype("qr", DType::I32)),
+            TensorView::I64(_) => Err(unsupported_view_dtype("qr", DType::I64)),
+            TensorView::Bool(_) => Err(unsupported_view_dtype("qr", DType::Bool)),
+        }
+    }
+
     fn eigh(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         linalg::eigh(self, input)
+    }
+
+    fn eigh_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F32(compact);
+                self.eigh(&input)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F64(compact);
+                self.eigh(&input)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C32(compact);
+                self.eigh(&input)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C64(compact);
+                self.eigh(&input)
+            }
+            TensorView::I32(_) => Err(unsupported_view_dtype("eigh", DType::I32)),
+            TensorView::I64(_) => Err(unsupported_view_dtype("eigh", DType::I64)),
+            TensorView::Bool(_) => Err(unsupported_view_dtype("eigh", DType::Bool)),
+        }
     }
 
     fn eigh_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {

--- a/crates/tenferro-linalg/tests/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/backend_errors.rs
@@ -242,6 +242,30 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
     ));
 
     let err = backend
+        .qr_read(TensorView::F64(input.as_view()))
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "qr",
+            ref message,
+        } if message.contains("borrowed tensor views")
+    ));
+
+    let err = backend
+        .eigh_read(TensorView::F64(input.as_view()))
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "eigh",
+            ref message,
+        } if message.contains("borrowed tensor views")
+    ));
+
+    let err = backend
         .eigh_values(&Tensor::F64(input.clone()))
         .unwrap_err();
     assert!(matches!(

--- a/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
@@ -294,6 +294,40 @@ fn cubecl_linalg_overrides_svd_read_with_backend_canonicalization() {
 }
 
 #[test]
+fn cubecl_linalg_overrides_qr_read_with_backend_canonicalization() {
+    let source = gpu_mod_source();
+    let qr_read_source = source_section(&source, "fn qr_read", "fn eigh");
+
+    for needle in [
+        "self.to_contiguous(&view)?",
+        "let input = Tensor::F64(compact);",
+        "self.qr(&input)",
+    ] {
+        assert!(
+            qr_read_source.contains(needle),
+            "CubeCL qr_read should canonicalize borrowed GPU views on the backend: missing {needle}"
+        );
+    }
+}
+
+#[test]
+fn cubecl_linalg_overrides_eigh_read_with_backend_canonicalization() {
+    let source = gpu_mod_source();
+    let eigh_read_source = source_section(&source, "fn eigh_read", "fn eigh_values");
+
+    for needle in [
+        "self.to_contiguous(&view)?",
+        "let input = Tensor::F64(compact);",
+        "self.eigh(&input)",
+    ] {
+        assert!(
+            eigh_read_source.contains(needle),
+            "CubeCL eigh_read should canonicalize borrowed GPU views on the backend: missing {needle}"
+        );
+    }
+}
+
+#[test]
 fn gpu_solver_info_checks_are_batched_outside_kernel_loops() {
     let source = linalg_source();
 


### PR DESCRIPTION
Summary: Adds qr_read and eigh_read to LinalgBackend, mirroring the existing svd_read borrowed-view execution boundary. CPU and CUDA backends canonicalize borrowed views within the same placement family and then reuse existing qr/eigh implementations. EagerBackend dispatches the new methods. Tests cover transposed CPU views, real/complex supported linalg dtypes, unsupported integer/bool view dtypes, default backend errors, GPU source contracts, and doc examples. Tests: cargo test -p tenferro-linalg.