### PR TITLE
Add cholesky/lu/full_piv_lu/eig read-view linalg APIs + faer strided fast path

### DIFF
--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -1,5 +1,18 @@
 use tenferro_tensor::{Tensor, TensorBackend, TensorView};
 
+/// Build the shared "unsupported dtype" backend-failure error used by the
+/// linalg backends.
+///
+/// Both the CPU and GPU linalg backends reject integer and boolean dtypes for
+/// floating-point decompositions with an identical message; this helper keeps
+/// that error construction in one place.
+pub(crate) fn unsupported_dtype(
+    op: &'static str,
+    dtype: tenferro_tensor::DType,
+) -> tenferro_tensor::Error {
+    tenferro_tensor::Error::backend_failure(op, format!("unsupported dtype {dtype:?}"))
+}
+
 /// Backend surface required by the linalg extension runtime.
 ///
 /// # Examples

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -184,6 +184,114 @@ pub trait LinalgBackend: TensorBackend {
         ))
     }
 
+    /// Compute Cholesky factorization from a borrowed tensor view.
+    ///
+    /// Backends may canonicalize the view inside the same placement family, but
+    /// must not silently transfer between CPU and GPU memory.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::LinalgBackend;
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_tensor::{TensorView, TypedTensor};
+    ///
+    /// let input = TypedTensor::<f64>::from_vec_col_major(
+    ///     vec![2, 2],
+    ///     vec![4.0, 2.0, 2.0, 3.0],
+    /// )?;
+    /// let output = CpuBackend::new().cholesky_read(TensorView::F64(input.as_view()))?;
+    /// assert_eq!(output.shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn cholesky_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Tensor> {
+        Err(tenferro_tensor::Error::backend_failure(
+            "cholesky",
+            "backend does not accept borrowed tensor views at this execution boundary",
+        ))
+    }
+
+    /// Compute public LU outputs from a borrowed tensor view.
+    ///
+    /// Backends may canonicalize the view inside the same placement family, but
+    /// must not silently transfer between CPU and GPU memory.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::LinalgBackend;
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_tensor::{TensorView, TypedTensor};
+    ///
+    /// let input = TypedTensor::<f64>::from_vec_col_major(
+    ///     vec![2, 2],
+    ///     vec![1.0, 3.0, 2.0, 4.0],
+    /// )?;
+    /// let outputs = CpuBackend::new().lu_read(TensorView::F64(input.as_view()))?;
+    /// assert_eq!(outputs.len(), 4);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn lu_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Err(tenferro_tensor::Error::backend_failure(
+            "lu",
+            "backend does not accept borrowed tensor views at this execution boundary",
+        ))
+    }
+
+    /// Compute public full-pivoting LU outputs from a borrowed tensor view.
+    ///
+    /// Backends may canonicalize the view inside the same placement family, but
+    /// must not silently transfer between CPU and GPU memory.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::LinalgBackend;
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_tensor::{TensorView, TypedTensor};
+    ///
+    /// let input = TypedTensor::<f64>::from_vec_col_major(
+    ///     vec![2, 2],
+    ///     vec![1.0, 3.0, 2.0, 4.0],
+    /// )?;
+    /// let outputs = CpuBackend::new().full_piv_lu_read(TensorView::F64(input.as_view()))?;
+    /// assert_eq!(outputs.len(), 5);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn full_piv_lu_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Err(tenferro_tensor::Error::backend_failure(
+            "full_piv_lu",
+            "backend does not accept borrowed tensor views at this execution boundary",
+        ))
+    }
+
+    /// Compute general eigendecomposition outputs from a borrowed tensor view.
+    ///
+    /// Backends may canonicalize the view inside the same placement family, but
+    /// must not silently transfer between CPU and GPU memory.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::LinalgBackend;
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_tensor::{TensorView, TypedTensor};
+    ///
+    /// let input = TypedTensor::<f64>::from_vec_col_major(
+    ///     vec![2, 2],
+    ///     vec![2.0, 0.0, 0.0, 3.0],
+    /// )?;
+    /// let outputs = CpuBackend::new().eig_read(TensorView::F64(input.as_view()))?;
+    /// assert_eq!(outputs.len(), 2);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn eig_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Err(tenferro_tensor::Error::backend_failure(
+            "eig",
+            "backend does not accept borrowed tensor views at this execution boundary",
+        ))
+    }
+
     #[doc(hidden)]
     fn eigh_values(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         Err(tenferro_tensor::Error::backend_failure(

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -807,6 +807,203 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
+    fn cholesky_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Tensor> {
+        #[cfg(feature = "cpu-faer")]
+        if matches!(self.kind(), CpuBackendKind::Faer) {
+            let can_skip_materialize = match &input {
+                TensorView::F32(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::F64(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::C32(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::C64(view) => linalg::faer::faer_strided_ok(view),
+                _ => false,
+            };
+            if can_skip_materialize {
+                let ctx = self.linalg_context();
+                return self.with_linalg_pool(|buffers| match input {
+                    TensorView::F32(view) => {
+                        linalg::faer::cholesky_view(ctx.as_ref(), buffers, view).map(Tensor::F32)
+                    }
+                    TensorView::F64(view) => {
+                        linalg::faer::cholesky_view(ctx.as_ref(), buffers, view).map(Tensor::F64)
+                    }
+                    TensorView::C32(view) => {
+                        linalg::faer::cholesky_view(ctx.as_ref(), buffers, view).map(Tensor::C32)
+                    }
+                    TensorView::C64(view) => {
+                        linalg::faer::cholesky_view(ctx.as_ref(), buffers, view).map(Tensor::C64)
+                    }
+                    _ => unreachable!("can_skip_materialize only true for supported dtypes"),
+                });
+            }
+        }
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F32(compact);
+                self.cholesky(&input)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F64(compact);
+                self.cholesky(&input)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C32(compact);
+                self.cholesky(&input)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C64(compact);
+                self.cholesky(&input)
+            }
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("cholesky", input.dtype()))
+            }
+        }
+    }
+
+    fn lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        #[cfg(feature = "cpu-faer")]
+        if matches!(self.kind(), CpuBackendKind::Faer) {
+            let can_skip_materialize = match &input {
+                TensorView::F32(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::F64(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::C32(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::C64(view) => linalg::faer::faer_strided_ok(view),
+                _ => false,
+            };
+            if can_skip_materialize {
+                let ctx = self.linalg_context();
+                return self.with_linalg_pool(|buffers| match input {
+                    TensorView::F32(view) => linalg::faer::lu_view(ctx.as_ref(), buffers, view)
+                        .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
+                    TensorView::F64(view) => linalg::faer::lu_view(ctx.as_ref(), buffers, view)
+                        .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+                    TensorView::C32(view) => linalg::faer::lu_view(ctx.as_ref(), buffers, view)
+                        .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
+                    TensorView::C64(view) => linalg::faer::lu_view(ctx.as_ref(), buffers, view)
+                        .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+                    _ => unreachable!("can_skip_materialize only true for supported dtypes"),
+                });
+            }
+        }
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F32(compact);
+                self.lu(&input)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F64(compact);
+                self.lu(&input)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C32(compact);
+                self.lu(&input)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C64(compact);
+                self.lu(&input)
+            }
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("lu", input.dtype()))
+            }
+        }
+    }
+
+    fn full_piv_lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        #[cfg(feature = "cpu-faer")]
+        if matches!(self.kind(), CpuBackendKind::Faer) {
+            let can_skip_materialize = match &input {
+                TensorView::F32(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::F64(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::C32(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::C64(view) => linalg::faer::faer_strided_ok(view),
+                _ => false,
+            };
+            if can_skip_materialize {
+                let ctx = self.linalg_context();
+                return self.with_linalg_pool(|buffers| match input {
+                    TensorView::F32(view) => {
+                        linalg::faer::full_piv_lu_view(ctx.as_ref(), buffers, view)
+                            .map(|outputs| outputs.into_iter().map(Tensor::F32).collect())
+                    }
+                    TensorView::F64(view) => {
+                        linalg::faer::full_piv_lu_view(ctx.as_ref(), buffers, view)
+                            .map(|outputs| outputs.into_iter().map(Tensor::F64).collect())
+                    }
+                    TensorView::C32(view) => {
+                        linalg::faer::full_piv_lu_view(ctx.as_ref(), buffers, view)
+                            .map(|outputs| outputs.into_iter().map(Tensor::C32).collect())
+                    }
+                    TensorView::C64(view) => {
+                        linalg::faer::full_piv_lu_view(ctx.as_ref(), buffers, view)
+                            .map(|outputs| outputs.into_iter().map(Tensor::C64).collect())
+                    }
+                    _ => unreachable!("can_skip_materialize only true for supported dtypes"),
+                });
+            }
+        }
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F32(compact);
+                self.full_piv_lu(&input)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F64(compact);
+                self.full_piv_lu(&input)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C32(compact);
+                self.full_piv_lu(&input)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C64(compact);
+                self.full_piv_lu(&input)
+            }
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("full_piv_lu", input.dtype()))
+            }
+        }
+    }
+
+    fn eig_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        // eig has no faer fast-path; always materialize first.
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F32(compact);
+                self.eig(&input)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F64(compact);
+                self.eig(&input)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C32(compact);
+                self.eig(&input)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C64(compact);
+                self.eig(&input)
+            }
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("eig", input.dtype()))
+            }
+        }
+    }
+
     fn eigh_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         ensure_host_tensor("eigh_values", input)?;
         match self.kind() {

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -546,6 +546,34 @@ impl LinalgBackend for CpuBackend {
     }
 
     fn svd_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        #[cfg(feature = "cpu-faer")]
+        if matches!(self.kind(), CpuBackendKind::Faer) {
+            // Fast-path: if the view is already host-resident and 2D with non-negative strides,
+            // feed it directly to faer without materializing a contiguous copy.
+            let can_skip_materialize = match &input {
+                TensorView::F32(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::F64(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::C32(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::C64(view) => linalg::faer::faer_strided_ok(view),
+                _ => false,
+            };
+            if can_skip_materialize {
+                let ctx = self.linalg_context();
+                return self.with_linalg_pool(|buffers| match input {
+                    TensorView::F32(view) => linalg::faer::svd_view(ctx.as_ref(), buffers, view)
+                        .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
+                    TensorView::F64(view) => linalg::faer::svd_view(ctx.as_ref(), buffers, view)
+                        .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+                    TensorView::C32(view) => linalg::faer::svd_view(ctx.as_ref(), buffers, view)
+                        .and_then(svd_c32_outputs_to_public_tensors),
+                    TensorView::C64(view) => linalg::faer::svd_view(ctx.as_ref(), buffers, view)
+                        .and_then(svd_c64_outputs_to_public_tensors),
+                    _ => unreachable!("can_skip_materialize only true for supported dtypes"),
+                });
+            }
+        }
+        // Fall through: materialize the view first (handles non-faer backends, GPU tensors,
+        // negative strides, rank != 2, etc.).
         match input {
             TensorView::F32(view) => {
                 let compact = self.to_contiguous(&view)?;
@@ -621,6 +649,33 @@ impl LinalgBackend for CpuBackend {
     }
 
     fn qr_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        #[cfg(feature = "cpu-faer")]
+        if matches!(self.kind(), CpuBackendKind::Faer) {
+            // Fast-path: feed an already host-resident 2D non-negative-strided view directly to faer.
+            let can_skip_materialize = match &input {
+                TensorView::F32(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::F64(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::C32(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::C64(view) => linalg::faer::faer_strided_ok(view),
+                _ => false,
+            };
+            if can_skip_materialize {
+                let ctx = self.linalg_context();
+                return self.with_linalg_pool(|buffers| match input {
+                    TensorView::F32(view) => linalg::faer::qr_view(ctx.as_ref(), buffers, view)
+                        .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
+                    TensorView::F64(view) => linalg::faer::qr_view(ctx.as_ref(), buffers, view)
+                        .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+                    TensorView::C32(view) => linalg::faer::qr_view(ctx.as_ref(), buffers, view)
+                        .map(|outputs| outputs.into_iter().map(Tensor::C32).collect()),
+                    TensorView::C64(view) => linalg::faer::qr_view(ctx.as_ref(), buffers, view)
+                        .map(|outputs| outputs.into_iter().map(Tensor::C64).collect()),
+                    _ => unreachable!("can_skip_materialize only true for supported dtypes"),
+                });
+            }
+        }
+        // Fall through: materialize the view first (non-faer backends, GPU tensors,
+        // negative strides, rank != 2, etc.).
         match input {
             TensorView::F32(view) => {
                 let compact = self.to_contiguous(&view)?;
@@ -696,6 +751,35 @@ impl LinalgBackend for CpuBackend {
     }
 
     fn eigh_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        #[cfg(feature = "cpu-faer")]
+        if matches!(self.kind(), CpuBackendKind::Faer) {
+            // Fast-path: feed an already host-resident 2D non-negative-strided view directly to faer.
+            // Complex eigenvalues are real; mirror the materialized `eigh` path by converting the
+            // complex outputs (real eigenvalues, complex eigenvectors) to public tensors.
+            let can_skip_materialize = match &input {
+                TensorView::F32(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::F64(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::C32(view) => linalg::faer::faer_strided_ok(view),
+                TensorView::C64(view) => linalg::faer::faer_strided_ok(view),
+                _ => false,
+            };
+            if can_skip_materialize {
+                let ctx = self.linalg_context();
+                return self.with_linalg_pool(|buffers| match input {
+                    TensorView::F32(view) => linalg::faer::eigh_view(ctx.as_ref(), buffers, view)
+                        .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
+                    TensorView::F64(view) => linalg::faer::eigh_view(ctx.as_ref(), buffers, view)
+                        .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+                    TensorView::C32(view) => linalg::faer::eigh_view(ctx.as_ref(), buffers, view)
+                        .and_then(eigh_c32_outputs_to_public_tensors),
+                    TensorView::C64(view) => linalg::faer::eigh_view(ctx.as_ref(), buffers, view)
+                        .and_then(eigh_c64_outputs_to_public_tensors),
+                    _ => unreachable!("can_skip_materialize only true for supported dtypes"),
+                });
+            }
+        }
+        // Fall through: materialize the view first (non-faer backends, GPU tensors,
+        // negative strides, rank != 2, etc.).
         match input {
             TensorView::F32(view) => {
                 let compact = self.to_contiguous(&view)?;

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -1,4 +1,4 @@
-use crate::backend::LinalgBackend;
+use crate::backend::{unsupported_dtype, LinalgBackend};
 
 use super::linalg;
 
@@ -1423,8 +1423,4 @@ fn unsupported_pair(
     } else {
         Err(unsupported_dtype(op, lhs.dtype()))
     }
-}
-
-fn unsupported_dtype(op: &'static str, dtype: DType) -> Error {
-    Error::backend_failure(op, format!("unsupported dtype {dtype:?}"))
 }

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -85,6 +85,43 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<TypedTensor<Self::Real>>;
+
+    /// Wrap a compact column-major slice as a faer MatRef.
+    fn faer_mat_ref_compact<'a>(data: &'a [Self], m: usize, n: usize) -> MatRef<'a, Self>;
+    /// Wrap an arbitrarily-strided 2D host view as a faer MatRef (no copy).
+    /// # Safety
+    /// Caller must guarantee: host placement, exactly 2 dims, finite non-negative strides,
+    /// and that the backing data lives for at least `'a`.
+    unsafe fn faer_mat_ref_strided<'a>(
+        base: *const Self,
+        m: usize,
+        n: usize,
+        row_stride: isize,
+        col_stride: isize,
+    ) -> MatRef<'a, Self>;
+    fn svd_core(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        m: usize,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
+    fn qr_core(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        m: usize,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
+    fn eigh_core(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
 }
 
 fn matrix_dims<T>(
@@ -116,28 +153,28 @@ fn square_matrix_dim<T>(
     Ok(rows)
 }
 
-fn tensor_from_vec_with_template<T: Clone, U>(
+fn tensor_from_vec_with_template<T: Clone>(
     shape: Vec<usize>,
     data: Vec<T>,
-    template: &TypedTensor<U>,
+    placement: &tenferro_tensor::Placement,
 ) -> TypedTensor<T> {
     // faer outputs are assembled from validated matrix dimensions and buffers
     // sized by the same dimensions, so mismatch here is an internal backend bug.
     let mut tensor =
         TypedTensor::from_vec_col_major(shape, data).expect("faer output shape/data match");
-    tensor.set_placement(template.placement().clone());
+    tensor.set_placement(placement.clone());
     tensor
 }
 
-fn tensor_from_pooled_slice_with_template<T: Clone + PoolScalar, U>(
+fn tensor_from_pooled_slice_with_template<T: Clone + PoolScalar>(
     buffers: &mut BufferPool,
     shape: Vec<usize>,
     data: &[T],
-    template: &TypedTensor<U>,
+    placement: &tenferro_tensor::Placement,
 ) -> TypedTensor<T> {
     let mut owned = buffers.acquire_with_capacity::<T>(data.len());
     owned.extend_from_slice(data);
-    tensor_from_vec_with_template(shape, owned, template)
+    tensor_from_vec_with_template(shape, owned, placement)
 }
 
 fn refill_tensor_from_slice<T: Copy>(tensor: &mut TypedTensor<T>, data: &[T]) {
@@ -597,7 +634,7 @@ where
         buffers,
         core_shape.to_vec(),
         &input.host_data()?[first_range],
-        input,
+        input.placement(),
     );
 
     for batch_idx in 0..batch_count {
@@ -639,7 +676,11 @@ where
         out_core_shape.ok_or_else(|| invalid_config(op_name, "missing output shape"))?;
     out_shape.extend_from_slice(batch_shape);
     let out_data = out_data.ok_or_else(|| invalid_config(op_name, "missing output data"))?;
-    Ok(tensor_from_vec_with_template(out_shape, out_data, input))
+    Ok(tensor_from_vec_with_template(
+        out_shape,
+        out_data,
+        input.placement(),
+    ))
 }
 
 fn batched_multi_result<T, F>(
@@ -675,7 +716,7 @@ where
         buffers,
         core_shape.to_vec(),
         &input.host_data()?[first_range],
-        input,
+        input.placement(),
     );
 
     for batch_idx in 0..batch_count {
@@ -726,7 +767,7 @@ where
         .zip(out_data)
         .map(|(mut out_shape, out_data)| {
             out_shape.extend_from_slice(batch_shape);
-            tensor_from_vec_with_template(out_shape, out_data, input)
+            tensor_from_vec_with_template(out_shape, out_data, input.placement())
         })
         .collect())
 }
@@ -765,7 +806,7 @@ where
         buffers,
         core_shape.to_vec(),
         &input.host_data()?[first_range],
-        input,
+        input.placement(),
     );
 
     for batch_idx in 0..batch_count {
@@ -816,7 +857,7 @@ where
         .zip(out_data)
         .map(|(mut out_shape, out_data)| {
             out_shape.extend_from_slice(batch_shape);
-            tensor_from_vec_with_template(out_shape, out_data, input)
+            tensor_from_vec_with_template(out_shape, out_data, input.placement())
         })
         .collect())
 }
@@ -871,13 +912,13 @@ where
         buffers,
         a_core_shape.to_vec(),
         &a.host_data()?[first_a_range],
-        a,
+        a.placement(),
     );
     let mut batch_b = tensor_from_pooled_slice_with_template(
         buffers,
         b_core_shape.to_vec(),
         &b.host_data()?[first_b_range],
-        b,
+        b.placement(),
     );
 
     for batch_idx in 0..batch_count {
@@ -921,7 +962,11 @@ where
         out_core_shape.ok_or_else(|| invalid_config(op_name, "missing output shape"))?;
     out_shape.extend_from_slice(a_batch_shape);
     let out_data = out_data.ok_or_else(|| invalid_config(op_name, "missing output data"))?;
-    Ok(tensor_from_vec_with_template(out_shape, out_data, b))
+    Ok(tensor_from_vec_with_template(
+        out_shape,
+        out_data,
+        b.placement(),
+    ))
 }
 
 macro_rules! impl_faer_linalg_for_real {
@@ -960,7 +1005,7 @@ macro_rules! impl_faer_linalg_for_real {
         Ok(tensor_from_vec_with_template(
             vec![n, n],
             lower_triangle_vec_from_mat(l.as_ref()),
-            input,
+            input.placement(),
         ))
     }
 
@@ -1011,10 +1056,10 @@ macro_rules! impl_faer_linalg_for_real {
         let u_data = upper_triangle_vec_from_mat(lu.as_ref().get(..k, ..));
 
         Ok(vec![
-            tensor_from_vec_with_template(vec![m, m], p_data, input),
-            tensor_from_vec_with_template(vec![m, k], l_data, input),
-            tensor_from_vec_with_template(vec![k, n], u_data, input),
-            tensor_from_vec_with_template(vec![], vec![parity], input),
+            tensor_from_vec_with_template(vec![m, m], p_data, input.placement()),
+            tensor_from_vec_with_template(vec![m, k], l_data, input.placement()),
+            tensor_from_vec_with_template(vec![k, n], u_data, input.placement()),
+            tensor_from_vec_with_template(vec![], vec![parity], input.placement()),
         ])
     }
 
@@ -1055,9 +1100,9 @@ macro_rules! impl_faer_linalg_for_real {
         let pivots = swap_sequence_from_permutation(&perm, k, "lu_factor")?;
 
         Ok((
-            tensor_from_vec_with_template(vec![m, n], col_major_vec_from_mat(buffers, lu.as_ref()), input),
-            tensor_from_vec_with_template(vec![k], pivots, input),
-            tensor_from_vec_with_template(vec![], vec![parity], input),
+            tensor_from_vec_with_template(vec![m, n], col_major_vec_from_mat(buffers, lu.as_ref()), input.placement()),
+            tensor_from_vec_with_template(vec![k], pivots, input.placement()),
+            tensor_from_vec_with_template(vec![], vec![parity], input.placement()),
         ))
     }
 
@@ -1106,11 +1151,11 @@ macro_rules! impl_faer_linalg_for_real {
         };
 
         Ok(vec![
-            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, 1.0), input),
-            tensor_from_vec_with_template(vec![n, n], l_data, input),
-            tensor_from_vec_with_template(vec![n, n], u_data, input),
-            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, 1.0), input),
-            tensor_from_vec_with_template(vec![], vec![parity], input),
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, 1.0), input.placement()),
+            tensor_from_vec_with_template(vec![n, n], l_data, input.placement()),
+            tensor_from_vec_with_template(vec![n, n], u_data, input.placement()),
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, 1.0), input.placement()),
+            tensor_from_vec_with_template(vec![], vec![parity], input.placement()),
         ])
     }
 
@@ -1201,7 +1246,7 @@ macro_rules! impl_faer_linalg_for_real {
                 stack,
             );
         }
-        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
+        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement()))
     }
 
     fn solve_2d(
@@ -1290,7 +1335,7 @@ macro_rules! impl_faer_linalg_for_real {
                 stack,
             );
         }
-        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
+        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement()))
     }
 
     fn triangular_solve_2d(
@@ -1376,7 +1421,7 @@ macro_rules! impl_faer_linalg_for_real {
                     );
                 }
             }
-            Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
+            Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement()))
         } else {
             if b_cols != n {
                 return Err(tenferro_tensor::Error::ShapeMismatch {
@@ -1448,7 +1493,7 @@ macro_rules! impl_faer_linalg_for_real {
             }
             let result = transpose_col_major_data(buffers, &rhs_transposed, n, nrhs);
             <Self as PoolScalar>::pool_release(buffers, rhs_transposed);
-            Ok(tensor_from_vec_with_template(vec![nrhs, n], result, b))
+            Ok(tensor_from_vec_with_template(vec![nrhs, n], result, b.placement()))
         }
     }
 
@@ -1458,46 +1503,8 @@ macro_rules! impl_faer_linalg_for_real {
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "svd")?;
-        let k = m.min(n);
-        let mat = MatRef::from_column_major_slice(input.host_data()?, m, n);
-        let mut u = Mat::zeros(m, k);
-        let mut v = Mat::zeros(n, k);
-        let mut s = Diag::zeros(k);
-        let mut mem = MemBuffer::new(faer::linalg::svd::svd_scratch::<Self>(
-            m,
-            n,
-            faer::linalg::svd::ComputeSvdVectors::Thin,
-            faer::linalg::svd::ComputeSvdVectors::Thin,
-            ctx.faer_par(),
-            Default::default(),
-        ));
-        let stack = MemStack::new(&mut mem);
-        faer::linalg::svd::svd(
-            mat,
-            s.as_mut(),
-            Some(u.as_mut()),
-            Some(v.as_mut()),
-            ctx.faer_par(),
-            stack,
-            Default::default(),
-        )
-        .map_err(|_| decomposition_failed("svd"))?;
-
-        let u = tensor_from_vec_with_template(
-            vec![m, k],
-            col_major_vec_from_mat(buffers, u.as_ref()),
-            input,
-        );
-        let s = tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), input);
-        let mut vt_data = buffers.acquire_with_capacity::<Self>(k * n);
-        for j in 0..n {
-            for i in 0..k {
-                vt_data.push(v[(j, i)]);
-            }
-        }
-        let vt = tensor_from_vec_with_template(vec![k, n], vt_data, input);
-
-        Ok(vec![u, s, vt])
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, m, n);
+        Self::svd_core(ctx, buffers, mat, m, n, input.placement())
     }
 
     fn svd_values_2d(
@@ -1529,7 +1536,7 @@ macro_rules! impl_faer_linalg_for_real {
         )
         .map_err(|_| decomposition_failed("svd_values"))?;
 
-        Ok(tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), input))
+        Ok(tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), input.placement()))
     }
 
     fn qr_2d(
@@ -1538,8 +1545,122 @@ macro_rules! impl_faer_linalg_for_real {
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "qr")?;
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, m, n);
+        Self::qr_core(ctx, buffers, mat, m, n, input.placement())
+    }
+
+    fn eigh_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
+        let n = square_matrix_dim(input, "eigh")?;
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, n, n);
+        Self::eigh_core(ctx, buffers, mat, n, input.placement())
+    }
+
+    fn eigh_values_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
+        let n = square_matrix_dim(input, "eigh_values")?;
+        let mat = MatRef::from_column_major_slice(input.host_data()?, n, n);
+        let mut values = Diag::zeros(n);
+        let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<Self>(
+            n,
+            faer::linalg::evd::ComputeEigenvectors::No,
+            ctx.faer_par(),
+            Default::default(),
+        ));
+        let stack = MemStack::new(&mut mem);
+        faer::linalg::evd::self_adjoint_evd(
+            mat,
+            values.as_mut(),
+            None,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        )
+        .map_err(|_| decomposition_failed("eigh_values"))?;
+
+        Ok(tensor_from_vec_with_template(vec![n], vec_from_diag(buffers, values.as_ref()), input.placement()))
+    }
+
+    fn faer_mat_ref_compact<'a>(data: &'a [Self], m: usize, n: usize) -> MatRef<'a, Self> {
+        MatRef::from_column_major_slice(data, m, n)
+    }
+
+    unsafe fn faer_mat_ref_strided<'a>(
+        base: *const Self,
+        m: usize,
+        n: usize,
+        row_stride: isize,
+        col_stride: isize,
+    ) -> MatRef<'a, Self> {
+        // SAFETY: caller guarantees host placement, rank 2, non-negative strides, and 'a lifetime.
+        unsafe { MatRef::from_raw_parts(base, m, n, row_stride, col_stride) }
+    }
+
+    fn svd_core(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        m: usize,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let k = m.min(n);
-        let mat = MatRef::from_column_major_slice(input.host_data()?, m, n);
+        let mut u = Mat::zeros(m, k);
+        let mut v = Mat::zeros(n, k);
+        let mut s = Diag::zeros(k);
+        let mut mem = MemBuffer::new(faer::linalg::svd::svd_scratch::<Self>(
+            m,
+            n,
+            faer::linalg::svd::ComputeSvdVectors::Thin,
+            faer::linalg::svd::ComputeSvdVectors::Thin,
+            ctx.faer_par(),
+            Default::default(),
+        ));
+        let stack = MemStack::new(&mut mem);
+        faer::linalg::svd::svd(
+            mat,
+            s.as_mut(),
+            Some(u.as_mut()),
+            Some(v.as_mut()),
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        )
+        .map_err(|_| decomposition_failed("svd"))?;
+
+        let u = tensor_from_vec_with_template(
+            vec![m, k],
+            col_major_vec_from_mat(buffers, u.as_ref()),
+            placement,
+        );
+        let s =
+            tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), placement);
+        let mut vt_data = buffers.acquire_with_capacity::<Self>(k * n);
+        for j in 0..n {
+            for i in 0..k {
+                vt_data.push(v[(j, i)]);
+            }
+        }
+        let vt = tensor_from_vec_with_template(vec![k, n], vt_data, placement);
+
+        Ok(vec![u, s, vt])
+    }
+
+    fn qr_core(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        m: usize,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
+        let k = m.min(n);
         let block_size =
             faer::linalg::qr::no_pivoting::factor::recommended_block_size::<Self>(m, n);
         let mut qr = Mat::zeros(m, n);
@@ -1582,24 +1703,24 @@ macro_rules! impl_faer_linalg_for_real {
         let q = tensor_from_vec_with_template(
             vec![m, k],
             col_major_vec_from_mat(buffers, q.as_ref()),
-            input,
+            placement,
         );
         let r = tensor_from_vec_with_template(
             vec![k, n],
             upper_triangle_vec_from_mat(qr.as_ref().get(..k, ..)),
-            input,
+            placement,
         );
 
         Ok(vec![q, r])
     }
 
-    fn eigh_2d(
+    fn eigh_core(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
-        input: &TypedTensor<Self>,
+        mat: MatRef<'_, Self>,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
-        let n = square_matrix_dim(input, "eigh")?;
-        let mat = MatRef::from_column_major_slice(input.host_data()?, n, n);
         let mut values = Diag::zeros(n);
         let mut vectors = Mat::zeros(n, n);
         let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<Self>(
@@ -1619,43 +1740,18 @@ macro_rules! impl_faer_linalg_for_real {
         )
         .map_err(|_| decomposition_failed("eigh"))?;
 
-        let values =
-            tensor_from_vec_with_template(vec![n], vec_from_diag(buffers, values.as_ref()), input);
+        let values = tensor_from_vec_with_template(
+            vec![n],
+            vec_from_diag(buffers, values.as_ref()),
+            placement,
+        );
         let vectors = tensor_from_vec_with_template(
             vec![n, n],
             col_major_vec_from_mat(buffers, vectors.as_ref()),
-            input,
+            placement,
         );
 
         Ok(vec![values, vectors])
-    }
-
-    fn eigh_values_2d(
-        ctx: &CpuContext,
-        buffers: &mut BufferPool,
-        input: &TypedTensor<Self>,
-    ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
-        let n = square_matrix_dim(input, "eigh_values")?;
-        let mat = MatRef::from_column_major_slice(input.host_data()?, n, n);
-        let mut values = Diag::zeros(n);
-        let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<Self>(
-            n,
-            faer::linalg::evd::ComputeEigenvectors::No,
-            ctx.faer_par(),
-            Default::default(),
-        ));
-        let stack = MemStack::new(&mut mem);
-        faer::linalg::evd::self_adjoint_evd(
-            mat,
-            values.as_mut(),
-            None,
-            ctx.faer_par(),
-            stack,
-            Default::default(),
-        )
-        .map_err(|_| decomposition_failed("eigh_values"))?;
-
-        Ok(tensor_from_vec_with_template(vec![n], vec_from_diag(buffers, values.as_ref()), input))
     }
         }
     };
@@ -1714,7 +1810,7 @@ macro_rules! impl_faer_linalg_for_complex {
         Ok(tensor_from_vec_with_template(
             vec![n, n],
             $matrix_from_predicate(l.as_ref(), n, n, |row, col| row >= col),
-            input,
+            input.placement(),
         ))
     }
 
@@ -1768,10 +1864,10 @@ macro_rules! impl_faer_linalg_for_complex {
         let u_data = $matrix_from_predicate(lu.as_ref(), k, n, |row, col| row <= col);
 
         Ok(vec![
-            tensor_from_vec_with_template(vec![m, m], p_data, input),
-            tensor_from_vec_with_template(vec![m, k], l_data, input),
-            tensor_from_vec_with_template(vec![k, n], u_data, input),
-            tensor_from_vec_with_template(vec![], vec![parity], input),
+            tensor_from_vec_with_template(vec![m, m], p_data, input.placement()),
+            tensor_from_vec_with_template(vec![m, k], l_data, input.placement()),
+            tensor_from_vec_with_template(vec![k, n], u_data, input.placement()),
+            tensor_from_vec_with_template(vec![], vec![parity], input.placement()),
         ])
     }
 
@@ -1816,9 +1912,9 @@ macro_rules! impl_faer_linalg_for_complex {
         let pivots = swap_sequence_from_permutation(&perm, k, "lu_factor")?;
 
         Ok((
-            tensor_from_vec_with_template(vec![m, n], $vec_from_mat(_buffers, lu.as_ref()), input),
-            tensor_from_vec_with_template(vec![k], pivots, input),
-            tensor_from_vec_with_template(vec![], vec![parity], input),
+            tensor_from_vec_with_template(vec![m, n], $vec_from_mat(_buffers, lu.as_ref()), input.placement()),
+            tensor_from_vec_with_template(vec![k], pivots, input.placement()),
+            tensor_from_vec_with_template(vec![], vec![parity], input.placement()),
         ))
     }
 
@@ -1872,11 +1968,11 @@ macro_rules! impl_faer_linalg_for_complex {
         };
 
         Ok(vec![
-            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, one), input),
-            tensor_from_vec_with_template(vec![n, n], l_data, input),
-            tensor_from_vec_with_template(vec![n, n], u_data, input),
-            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, one), input),
-            tensor_from_vec_with_template(vec![], vec![parity], input),
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, one), input.placement()),
+            tensor_from_vec_with_template(vec![n, n], l_data, input.placement()),
+            tensor_from_vec_with_template(vec![n, n], u_data, input.placement()),
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, one), input.placement()),
+            tensor_from_vec_with_template(vec![], vec![parity], input.placement()),
         ])
     }
 
@@ -1980,7 +2076,7 @@ macro_rules! impl_faer_linalg_for_complex {
                 stack,
             );
         }
-        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
+        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement()))
     }
 
     fn solve_2d(
@@ -2078,7 +2174,7 @@ macro_rules! impl_faer_linalg_for_complex {
                 stack,
             );
         }
-        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
+        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement()))
     }
 
     fn triangular_solve_2d(
@@ -2168,7 +2264,7 @@ macro_rules! impl_faer_linalg_for_complex {
                     );
                 }
             }
-            Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b))
+            Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement()))
         } else {
             if b_cols != n {
                 return Err(tenferro_tensor::Error::ShapeMismatch {
@@ -2244,7 +2340,7 @@ macro_rules! impl_faer_linalg_for_complex {
             }
             let result = transpose_col_major_data(buffers, &rhs_transposed, n, nrhs);
             <Self as PoolScalar>::pool_release(buffers, rhs_transposed);
-            Ok(tensor_from_vec_with_template(vec![nrhs, n], result, b))
+            Ok(tensor_from_vec_with_template(vec![nrhs, n], result, b.placement()))
         }
     }
 
@@ -2254,50 +2350,8 @@ macro_rules! impl_faer_linalg_for_complex {
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "svd")?;
-        let k = m.min(n);
-        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()?), m, n);
-        let mut u = Mat::zeros(m, k);
-        let mut v = Mat::zeros(n, k);
-        let mut s = Diag::zeros(k);
-        let mut mem = MemBuffer::new(faer::linalg::svd::svd_scratch::<$faer_complex>(
-            m,
-            n,
-            faer::linalg::svd::ComputeSvdVectors::Thin,
-            faer::linalg::svd::ComputeSvdVectors::Thin,
-            ctx.faer_par(),
-            Default::default(),
-        ));
-        let stack = MemStack::new(&mut mem);
-        faer::linalg::svd::svd(
-            mat,
-            s.as_mut(),
-            Some(u.as_mut()),
-            Some(v.as_mut()),
-            ctx.faer_par(),
-            stack,
-            Default::default(),
-        )
-        .map_err(|_| decomposition_failed("svd"))?;
-
-        let u = tensor_from_vec_with_template(
-            vec![m, k],
-            $vec_from_mat(buffers, u.as_ref()),
-            input,
-        );
-        let s = tensor_from_vec_with_template(
-            vec![k],
-            $vec_from_real_diag(buffers, s.as_ref()),
-            input,
-        );
-        let mut vt_data = buffers.acquire_with_capacity::<Self>(k * n);
-        for j in 0..n {
-            for i in 0..k {
-                vt_data.push(v[(j, i)].conj());
-            }
-        }
-        let vt = tensor_from_vec_with_template(vec![k, n], vt_data, input);
-
-        Ok(vec![u, s, vt])
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, m, n);
+        Self::svd_core(ctx, buffers, mat, m, n, input.placement())
     }
 
     fn svd_values_2d(
@@ -2334,7 +2388,7 @@ macro_rules! impl_faer_linalg_for_complex {
         for i in 0..col.nrows() {
             data.push(col[i].re);
         }
-        Ok(tensor_from_vec_with_template(vec![k], data, input))
+        Ok(tensor_from_vec_with_template(vec![k], data, input.placement()))
     }
 
     fn qr_2d(
@@ -2343,8 +2397,162 @@ macro_rules! impl_faer_linalg_for_complex {
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "qr")?;
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, m, n);
+        Self::qr_core(ctx, buffers, mat, m, n, input.placement())
+    }
+
+    fn eigh_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
+        let n = square_matrix_dim(input, "eigh")?;
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, n, n);
+        Self::eigh_core(ctx, buffers, mat, n, input.placement())
+    }
+
+    fn eigh_values_2d(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        input: &TypedTensor<Self>,
+    ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
+        let n = square_matrix_dim(input, "eigh_values")?;
+        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()?), n, n);
+        let mut values = Diag::zeros(n);
+        let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<$faer_complex>(
+            n,
+            faer::linalg::evd::ComputeEigenvectors::No,
+            ctx.faer_par(),
+            Default::default(),
+        ));
+        let stack = MemStack::new(&mut mem);
+        faer::linalg::evd::self_adjoint_evd(
+            mat,
+            values.as_mut(),
+            None,
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        )
+        .map_err(|_| decomposition_failed("eigh_values"))?;
+
+        let col = values.as_ref().column_vector();
+        let mut data = buffers.acquire_with_capacity::<$real>(col.nrows());
+        for i in 0..col.nrows() {
+            data.push(col[i].re);
+        }
+        Ok(tensor_from_vec_with_template(vec![n], data, input.placement()))
+    }
+
+    fn faer_mat_ref_compact<'a>(data: &'a [Self], m: usize, n: usize) -> MatRef<'a, Self> {
+        // SAFETY: layout identity guaranteed by impl_complex_faer_casts const asserts.
+        let faer_slice = $to_faer_slice(data);
+        unsafe {
+            MatRef::<Self>::from_raw_parts(
+                faer_slice.as_ptr() as *const Self,
+                m,
+                n,
+                1,
+                m as isize,
+            )
+        }
+    }
+
+    unsafe fn faer_mat_ref_strided<'a>(
+        base: *const Self,
+        m: usize,
+        n: usize,
+        row_stride: isize,
+        col_stride: isize,
+    ) -> MatRef<'a, Self> {
+        // SAFETY: caller guarantees host placement, rank 2, non-negative strides, and 'a lifetime.
+        unsafe { MatRef::<Self>::from_raw_parts(base, m, n, row_stride, col_stride) }
+    }
+
+    fn svd_core(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        m: usize,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
+        // Cast Self (Complex32/64) to $faer_complex (faer::c32/c64) for faer calls.
+        // SAFETY: layout identity guaranteed by impl_complex_faer_casts const asserts.
+        let mat: MatRef<'_, $faer_complex> = unsafe {
+            MatRef::from_raw_parts(
+                mat.as_ptr() as *const $faer_complex,
+                m,
+                n,
+                mat.row_stride(),
+                mat.col_stride(),
+            )
+        };
         let k = m.min(n);
-        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()?), m, n);
+        let mut u = Mat::zeros(m, k);
+        let mut v = Mat::zeros(n, k);
+        let mut s = Diag::zeros(k);
+        let mut mem = MemBuffer::new(faer::linalg::svd::svd_scratch::<$faer_complex>(
+            m,
+            n,
+            faer::linalg::svd::ComputeSvdVectors::Thin,
+            faer::linalg::svd::ComputeSvdVectors::Thin,
+            ctx.faer_par(),
+            Default::default(),
+        ));
+        let stack = MemStack::new(&mut mem);
+        faer::linalg::svd::svd(
+            mat,
+            s.as_mut(),
+            Some(u.as_mut()),
+            Some(v.as_mut()),
+            ctx.faer_par(),
+            stack,
+            Default::default(),
+        )
+        .map_err(|_| decomposition_failed("svd"))?;
+
+        let u = tensor_from_vec_with_template(
+            vec![m, k],
+            $vec_from_mat(buffers, u.as_ref()),
+            placement,
+        );
+        let s = tensor_from_vec_with_template(
+            vec![k],
+            $vec_from_real_diag(buffers, s.as_ref()),
+            placement,
+        );
+        let mut vt_data = buffers.acquire_with_capacity::<Self>(k * n);
+        for j in 0..n {
+            for i in 0..k {
+                vt_data.push(v[(j, i)].conj());
+            }
+        }
+        let vt = tensor_from_vec_with_template(vec![k, n], vt_data, placement);
+
+        Ok(vec![u, s, vt])
+    }
+
+    fn qr_core(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        m: usize,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
+        // Cast Self to $faer_complex for faer calls.
+        // SAFETY: layout identity guaranteed by impl_complex_faer_casts const asserts.
+        let mat: MatRef<'_, $faer_complex> = unsafe {
+            MatRef::from_raw_parts(
+                mat.as_ptr() as *const $faer_complex,
+                m,
+                n,
+                mat.row_stride(),
+                mat.col_stride(),
+            )
+        };
+        let k = m.min(n);
         let block_size =
             faer::linalg::qr::no_pivoting::factor::recommended_block_size::<$faer_complex>(m, n);
         let mut qr = Mat::zeros(m, n);
@@ -2387,24 +2595,35 @@ macro_rules! impl_faer_linalg_for_complex {
         let q = tensor_from_vec_with_template(
             vec![m, k],
             $vec_from_mat(buffers, q.as_ref()),
-            input,
+            placement,
         );
         let r = tensor_from_vec_with_template(
             vec![k, n],
             $matrix_from_predicate(qr.as_ref(), k, n, |row, col| row <= col),
-            input,
+            placement,
         );
 
         Ok(vec![q, r])
     }
 
-    fn eigh_2d(
+    fn eigh_core(
         ctx: &CpuContext,
         buffers: &mut BufferPool,
-        input: &TypedTensor<Self>,
+        mat: MatRef<'_, Self>,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
-        let n = square_matrix_dim(input, "eigh")?;
-        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()?), n, n);
+        // Cast Self to $faer_complex for faer calls.
+        // SAFETY: layout identity guaranteed by impl_complex_faer_casts const asserts.
+        let mat: MatRef<'_, $faer_complex> = unsafe {
+            MatRef::from_raw_parts(
+                mat.as_ptr() as *const $faer_complex,
+                n,
+                n,
+                mat.row_stride(),
+                mat.col_stride(),
+            )
+        };
         let mut values = Diag::zeros(n);
         let mut vectors = Mat::zeros(n, n);
         let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<$faer_complex>(
@@ -2427,48 +2646,15 @@ macro_rules! impl_faer_linalg_for_complex {
         let values = tensor_from_vec_with_template(
             vec![n],
             $vec_from_real_diag(buffers, values.as_ref()),
-            input,
+            placement,
         );
         let vectors = tensor_from_vec_with_template(
             vec![n, n],
             $vec_from_mat(buffers, vectors.as_ref()),
-            input,
+            placement,
         );
 
         Ok(vec![values, vectors])
-    }
-
-    fn eigh_values_2d(
-        ctx: &CpuContext,
-        buffers: &mut BufferPool,
-        input: &TypedTensor<Self>,
-    ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
-        let n = square_matrix_dim(input, "eigh_values")?;
-        let mat = MatRef::from_column_major_slice($to_faer_slice(input.host_data()?), n, n);
-        let mut values = Diag::zeros(n);
-        let mut mem = MemBuffer::new(faer::linalg::evd::self_adjoint_evd_scratch::<$faer_complex>(
-            n,
-            faer::linalg::evd::ComputeEigenvectors::No,
-            ctx.faer_par(),
-            Default::default(),
-        ));
-        let stack = MemStack::new(&mut mem);
-        faer::linalg::evd::self_adjoint_evd(
-            mat,
-            values.as_mut(),
-            None,
-            ctx.faer_par(),
-            stack,
-            Default::default(),
-        )
-        .map_err(|_| decomposition_failed("eigh_values"))?;
-
-        let col = values.as_ref().column_vector();
-        let mut data = buffers.acquire_with_capacity::<$real>(col.nrows());
-        for i in 0..col.nrows() {
-            data.push(col[i].re);
-        }
-        Ok(tensor_from_vec_with_template(vec![n], data, input))
     }
         }
     };
@@ -2507,7 +2693,7 @@ pub(crate) fn cholesky<T: FaerLinalg>(
         return Ok(tensor_from_vec_with_template(
             matrix_with_batch_shape(n, n, batch_shape),
             Vec::new(),
-            input,
+            input.placement(),
         ));
     }
     batched_single("cholesky", buffers, input, 2, |buffers, batch| {
@@ -2528,22 +2714,22 @@ pub(crate) fn lu<T: FaerLinalg>(
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(m, m, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(k, n, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
             tensor_from_vec_with_template(
                 batch_shape.to_vec(),
                 vec![T::parity_one(); parity_elements],
-                input,
+                input.placement(),
             ),
         ]);
     }
@@ -2562,16 +2748,16 @@ pub(crate) fn lu_factor<T: FaerLinalg>(
         let k = m.min(n);
         let parity_len = batch_count("lu_factor", batch_shape)?;
         return Ok((
-            tensor_from_vec_with_template(input.shape().to_vec(), Vec::new(), input),
+            tensor_from_vec_with_template(input.shape().to_vec(), Vec::new(), input.placement()),
             tensor_from_vec_with_template(
                 vector_with_batch_shape(k, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
             tensor_from_vec_with_template(
                 batch_shape.to_vec(),
                 vec![T::parity_one(); parity_len],
-                input,
+                input.placement(),
             ),
         ));
     }
@@ -2595,7 +2781,7 @@ pub(crate) fn lu_factor<T: FaerLinalg>(
         buffers,
         vec![m, n],
         &input.host_data()?[first_range],
-        input,
+        input.placement(),
     );
 
     for batch in 0..batch_total {
@@ -2610,9 +2796,13 @@ pub(crate) fn lu_factor<T: FaerLinalg>(
     }
 
     Ok((
-        tensor_from_vec_with_template(input.shape().to_vec(), lu_data, input),
-        tensor_from_vec_with_template(vector_with_batch_shape(k, batch_shape), pivot_data, input),
-        tensor_from_vec_with_template(batch_shape.to_vec(), parity_data, input),
+        tensor_from_vec_with_template(input.shape().to_vec(), lu_data, input.placement()),
+        tensor_from_vec_with_template(
+            vector_with_batch_shape(k, batch_shape),
+            pivot_data,
+            input.placement(),
+        ),
+        tensor_from_vec_with_template(batch_shape.to_vec(), parity_data, input.placement()),
     ))
 }
 
@@ -2628,27 +2818,27 @@ pub(crate) fn full_piv_lu<T: FaerLinalg>(
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
             tensor_from_vec_with_template(
                 batch_shape.to_vec(),
                 vec![T::parity_one(); parity_elements],
-                input,
+                input.placement(),
             ),
         ]);
     }
@@ -2684,7 +2874,7 @@ pub(crate) fn full_piv_lu_solve<T: FaerLinalg>(
         return Ok(tensor_from_vec_with_template(
             b.shape().to_vec(),
             Vec::new(),
-            b,
+            b.placement(),
         ));
     }
     batched_binary_result("full_piv_lu_solve", buffers, a, b, 2, 2, |buffers, a, b| {
@@ -2719,7 +2909,7 @@ pub(crate) fn solve<T: FaerLinalg>(
         return Ok(tensor_from_vec_with_template(
             b.shape().to_vec(),
             Vec::new(),
-            b,
+            b.placement(),
         ));
     }
     batched_binary_result("solve", buffers, a, b, 2, 2, |buffers, a, b| {
@@ -2760,7 +2950,7 @@ pub(crate) fn triangular_solve<T: FaerLinalg>(
         return Ok(tensor_from_vec_with_template(
             b.shape().to_vec(),
             Vec::new(),
-            b,
+            b.placement(),
         ));
     }
     batched_binary_result("triangular_solve", buffers, a, b, 2, 2, |buffers, a, b| {
@@ -2789,17 +2979,17 @@ pub(crate) fn svd<T: FaerLinalg>(
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
             tensor_from_vec_with_template(
                 vector_with_batch_shape(k, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(k, n, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
         ]);
     }
@@ -2819,7 +3009,7 @@ pub(crate) fn svd_values<T: FaerLinalg>(
         return Ok(tensor_from_vec_with_template(
             vector_with_batch_shape(k, batch_shape),
             Vec::new(),
-            input,
+            input.placement(),
         ));
     }
     let mut outputs =
@@ -2841,12 +3031,12 @@ pub(crate) fn qr<T: FaerLinalg>(
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(k, n, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
         ]);
     }
@@ -2866,12 +3056,12 @@ pub(crate) fn eigh<T: FaerLinalg>(
             tensor_from_vec_with_template(
                 vector_with_batch_shape(n, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
-                input,
+                input.placement(),
             ),
         ]);
     }
@@ -2890,7 +3080,7 @@ pub(crate) fn eigh_values<T: FaerLinalg>(
         return Ok(tensor_from_vec_with_template(
             vector_with_batch_shape(n, batch_shape),
             Vec::new(),
-            input,
+            input.placement(),
         ));
     }
     let mut outputs =
@@ -2939,8 +3129,8 @@ macro_rules! impl_eig_real_2d {
             );
 
             Ok(vec![
-                tensor_from_vec_with_template(vec![n], s, input),
-                tensor_from_vec_with_template(vec![n, n], u, input),
+                tensor_from_vec_with_template(vec![n], s, input.placement()),
+                tensor_from_vec_with_template(vec![n, n], u, input.placement()),
             ])
         }
     };
@@ -2978,7 +3168,7 @@ macro_rules! impl_eig_values_real_2d {
             .map_err(|_| decomposition_failed("eig_values"))?;
             let s = $real_eig_to_complex_values(buffers, s_re.as_ref(), s_im.as_ref());
 
-            Ok(tensor_from_vec_with_template(vec![n], s, input))
+            Ok(tensor_from_vec_with_template(vec![n], s, input.placement()))
         }
     };
 }
@@ -3021,11 +3211,15 @@ macro_rules! impl_eig_complex_2d {
             .map_err(|_| decomposition_failed("eig"))?;
 
             Ok(vec![
-                tensor_from_vec_with_template(vec![n], $vec_from_diag(buffers, s.as_ref()), input),
+                tensor_from_vec_with_template(
+                    vec![n],
+                    $vec_from_diag(buffers, s.as_ref()),
+                    input.placement(),
+                ),
                 tensor_from_vec_with_template(
                     vec![n, n],
                     $vec_from_mat(buffers, u.as_ref()),
-                    input,
+                    input.placement(),
                 ),
             ])
         }
@@ -3070,7 +3264,7 @@ macro_rules! impl_eig_values_complex_2d {
             Ok(tensor_from_vec_with_template(
                 vec![n],
                 $vec_from_diag(buffers, s.as_ref()),
-                input,
+                input.placement(),
             ))
         }
     };

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -122,6 +122,28 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         n: usize,
         placement: &tenferro_tensor::Placement,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
+    fn cholesky_core(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<TypedTensor<Self>>;
+    fn lu_core(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        m: usize,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
+    fn full_piv_lu_core(
+        ctx: &CpuContext,
+        buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
 }
 
 fn matrix_dims<T>(
@@ -980,12 +1002,23 @@ macro_rules! impl_faer_linalg_for_real {
 
     fn cholesky_2d(
         ctx: &CpuContext,
-        _buffers: &mut BufferPool,
+        buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<TypedTensor<Self>> {
         let n = square_matrix_dim(input, "cholesky")?;
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, n, n);
+        Self::cholesky_core(ctx, buffers, mat, n, input.placement())
+    }
+
+    fn cholesky_core(
+        ctx: &CpuContext,
+        _buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<TypedTensor<Self>> {
         let mut l = Mat::zeros(n, n);
-        l.copy_from(MatRef::from_column_major_slice(input.host_data()?, n, n));
+        l.copy_from(mat);
         let mut mem = MemBuffer::new(
             faer::linalg::cholesky::llt::factor::cholesky_in_place_scratch::<Self>(
                 n,
@@ -1005,19 +1038,31 @@ macro_rules! impl_faer_linalg_for_real {
         Ok(tensor_from_vec_with_template(
             vec![n, n],
             lower_triangle_vec_from_mat(l.as_ref()),
-            input.placement(),
+            placement,
         ))
     }
 
     fn lu_2d(
         ctx: &CpuContext,
-        _buffers: &mut BufferPool,
+        buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "lu")?;
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, m, n);
+        Self::lu_core(ctx, buffers, mat, m, n, input.placement())
+    }
+
+    fn lu_core(
+        ctx: &CpuContext,
+        _buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        m: usize,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let k = m.min(n);
         let mut lu = Mat::zeros(m, n);
-        lu.copy_from(MatRef::from_column_major_slice(input.host_data()?, m, n));
+        lu.copy_from(mat);
         let mut perm = vec![0usize; m];
         let mut perm_inv = vec![0usize; m];
         let mut mem = MemBuffer::new(
@@ -1056,10 +1101,10 @@ macro_rules! impl_faer_linalg_for_real {
         let u_data = upper_triangle_vec_from_mat(lu.as_ref().get(..k, ..));
 
         Ok(vec![
-            tensor_from_vec_with_template(vec![m, m], p_data, input.placement()),
-            tensor_from_vec_with_template(vec![m, k], l_data, input.placement()),
-            tensor_from_vec_with_template(vec![k, n], u_data, input.placement()),
-            tensor_from_vec_with_template(vec![], vec![parity], input.placement()),
+            tensor_from_vec_with_template(vec![m, m], p_data, placement),
+            tensor_from_vec_with_template(vec![m, k], l_data, placement),
+            tensor_from_vec_with_template(vec![k, n], u_data, placement),
+            tensor_from_vec_with_template(vec![], vec![parity], placement),
         ])
     }
 
@@ -1108,12 +1153,23 @@ macro_rules! impl_faer_linalg_for_real {
 
     fn full_piv_lu_2d(
         ctx: &CpuContext,
-        _buffers: &mut BufferPool,
+        buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let n = square_matrix_dim(input, "full_piv_lu")?;
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, n, n);
+        Self::full_piv_lu_core(ctx, buffers, mat, n, input.placement())
+    }
+
+    fn full_piv_lu_core(
+        ctx: &CpuContext,
+        _buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let mut lu = Mat::zeros(n, n);
-        lu.copy_from(MatRef::from_column_major_slice(input.host_data()?, n, n));
+        lu.copy_from(mat);
         let mut row_perm = vec![0usize; n];
         let mut row_perm_inv = vec![0usize; n];
         let mut col_perm = vec![0usize; n];
@@ -1151,11 +1207,11 @@ macro_rules! impl_faer_linalg_for_real {
         };
 
         Ok(vec![
-            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, 1.0), input.placement()),
-            tensor_from_vec_with_template(vec![n, n], l_data, input.placement()),
-            tensor_from_vec_with_template(vec![n, n], u_data, input.placement()),
-            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, 1.0), input.placement()),
-            tensor_from_vec_with_template(vec![], vec![parity], input.placement()),
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, 1.0), placement),
+            tensor_from_vec_with_template(vec![n, n], l_data, placement),
+            tensor_from_vec_with_template(vec![n, n], u_data, placement),
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, 1.0), placement),
+            tensor_from_vec_with_template(vec![], vec![parity], placement),
         ])
     }
 
@@ -1781,16 +1837,34 @@ macro_rules! impl_faer_linalg_for_complex {
 
     fn cholesky_2d(
         ctx: &CpuContext,
-        _buffers: &mut BufferPool,
+        buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<TypedTensor<Self>> {
         let n = square_matrix_dim(input, "cholesky")?;
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, n, n);
+        Self::cholesky_core(ctx, buffers, mat, n, input.placement())
+    }
+
+    fn cholesky_core(
+        ctx: &CpuContext,
+        _buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<TypedTensor<Self>> {
+        // Cast Self (Complex32/64) to $faer_complex (faer::c32/c64) for faer calls.
+        // SAFETY: layout identity guaranteed by impl_complex_faer_casts const asserts.
+        let mat: MatRef<'_, $faer_complex> = unsafe {
+            MatRef::from_raw_parts(
+                mat.as_ptr() as *const $faer_complex,
+                n,
+                n,
+                mat.row_stride(),
+                mat.col_stride(),
+            )
+        };
         let mut l = Mat::zeros(n, n);
-        l.copy_from(MatRef::from_column_major_slice(
-            $to_faer_slice(input.host_data()?),
-            n,
-            n,
-        ));
+        l.copy_from(mat);
         let mut mem = MemBuffer::new(
             faer::linalg::cholesky::llt::factor::cholesky_in_place_scratch::<$faer_complex>(
                 n,
@@ -1810,23 +1884,42 @@ macro_rules! impl_faer_linalg_for_complex {
         Ok(tensor_from_vec_with_template(
             vec![n, n],
             $matrix_from_predicate(l.as_ref(), n, n, |row, col| row >= col),
-            input.placement(),
+            placement,
         ))
     }
 
     fn lu_2d(
         ctx: &CpuContext,
-        _buffers: &mut BufferPool,
+        buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "lu")?;
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, m, n);
+        Self::lu_core(ctx, buffers, mat, m, n, input.placement())
+    }
+
+    fn lu_core(
+        ctx: &CpuContext,
+        _buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        m: usize,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
+        // Cast Self (Complex32/64) to $faer_complex (faer::c32/c64) for faer calls.
+        // SAFETY: layout identity guaranteed by impl_complex_faer_casts const asserts.
+        let mat: MatRef<'_, $faer_complex> = unsafe {
+            MatRef::from_raw_parts(
+                mat.as_ptr() as *const $faer_complex,
+                m,
+                n,
+                mat.row_stride(),
+                mat.col_stride(),
+            )
+        };
         let k = m.min(n);
         let mut lu = Mat::zeros(m, n);
-        lu.copy_from(MatRef::from_column_major_slice(
-            $to_faer_slice(input.host_data()?),
-            m,
-            n,
-        ));
+        lu.copy_from(mat);
         let mut perm = vec![0usize; m];
         let mut perm_inv = vec![0usize; m];
         let mut mem = MemBuffer::new(
@@ -1864,10 +1957,10 @@ macro_rules! impl_faer_linalg_for_complex {
         let u_data = $matrix_from_predicate(lu.as_ref(), k, n, |row, col| row <= col);
 
         Ok(vec![
-            tensor_from_vec_with_template(vec![m, m], p_data, input.placement()),
-            tensor_from_vec_with_template(vec![m, k], l_data, input.placement()),
-            tensor_from_vec_with_template(vec![k, n], u_data, input.placement()),
-            tensor_from_vec_with_template(vec![], vec![parity], input.placement()),
+            tensor_from_vec_with_template(vec![m, m], p_data, placement),
+            tensor_from_vec_with_template(vec![m, k], l_data, placement),
+            tensor_from_vec_with_template(vec![k, n], u_data, placement),
+            tensor_from_vec_with_template(vec![], vec![parity], placement),
         ])
     }
 
@@ -1920,16 +2013,34 @@ macro_rules! impl_faer_linalg_for_complex {
 
     fn full_piv_lu_2d(
         ctx: &CpuContext,
-        _buffers: &mut BufferPool,
+        buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let n = square_matrix_dim(input, "full_piv_lu")?;
+        let mat = Self::faer_mat_ref_compact(input.host_data()?, n, n);
+        Self::full_piv_lu_core(ctx, buffers, mat, n, input.placement())
+    }
+
+    fn full_piv_lu_core(
+        ctx: &CpuContext,
+        _buffers: &mut BufferPool,
+        mat: MatRef<'_, Self>,
+        n: usize,
+        placement: &tenferro_tensor::Placement,
+    ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
+        // Cast Self (Complex32/64) to $faer_complex (faer::c32/c64) for faer calls.
+        // SAFETY: layout identity guaranteed by impl_complex_faer_casts const asserts.
+        let mat: MatRef<'_, $faer_complex> = unsafe {
+            MatRef::from_raw_parts(
+                mat.as_ptr() as *const $faer_complex,
+                n,
+                n,
+                mat.row_stride(),
+                mat.col_stride(),
+            )
+        };
         let mut lu = Mat::zeros(n, n);
-        lu.copy_from(MatRef::from_column_major_slice(
-            $to_faer_slice(input.host_data()?),
-            n,
-            n,
-        ));
+        lu.copy_from(mat);
         let mut row_perm = vec![0usize; n];
         let mut row_perm_inv = vec![0usize; n];
         let mut col_perm = vec![0usize; n];
@@ -1968,11 +2079,11 @@ macro_rules! impl_faer_linalg_for_complex {
         };
 
         Ok(vec![
-            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, one), input.placement()),
-            tensor_from_vec_with_template(vec![n, n], l_data, input.placement()),
-            tensor_from_vec_with_template(vec![n, n], u_data, input.placement()),
-            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, one), input.placement()),
-            tensor_from_vec_with_template(vec![], vec![parity], input.placement()),
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, one), placement),
+            tensor_from_vec_with_template(vec![n, n], l_data, placement),
+            tensor_from_vec_with_template(vec![n, n], u_data, placement),
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, one), placement),
+            tensor_from_vec_with_template(vec![], vec![parity], placement),
         ])
     }
 
@@ -3171,8 +3282,62 @@ pub(crate) fn eigh_view<T: FaerLinalg + 'static>(
     }
     let placement = view.placement().clone();
     let base = host_base_ptr(&view)?;
+    // SAFETY: faer_strided_ok guarantees host placement, rank 2, non-negative strides.
     let mat = unsafe { T::faer_mat_ref_strided(base, m, n, view.strides()[0], view.strides()[1]) };
     T::eigh_core(ctx, buffers, mat, m, &placement)
+}
+
+pub(crate) fn cholesky_view<T: FaerLinalg + 'static>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    view: TypedTensorView<'_, T>,
+) -> tenferro_tensor::Result<TypedTensor<T>> {
+    let (m, n) = matrix_dims_view(&view, "cholesky")?;
+    if m != n {
+        return Err(tenferro_tensor::Error::ShapeMismatch {
+            op: "cholesky",
+            lhs: vec![m],
+            rhs: vec![n],
+        });
+    }
+    let placement = view.placement().clone();
+    let base = host_base_ptr(&view)?;
+    // SAFETY: faer_strided_ok guarantees host placement, rank 2, non-negative strides.
+    let mat = unsafe { T::faer_mat_ref_strided(base, m, n, view.strides()[0], view.strides()[1]) };
+    T::cholesky_core(ctx, buffers, mat, m, &placement)
+}
+
+pub(crate) fn lu_view<T: FaerLinalg + 'static>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    view: TypedTensorView<'_, T>,
+) -> tenferro_tensor::Result<Vec<TypedTensor<T>>> {
+    let (m, n) = matrix_dims_view(&view, "lu")?;
+    let placement = view.placement().clone();
+    let base = host_base_ptr(&view)?;
+    // SAFETY: faer_strided_ok guarantees host placement, rank 2, non-negative strides.
+    let mat = unsafe { T::faer_mat_ref_strided(base, m, n, view.strides()[0], view.strides()[1]) };
+    T::lu_core(ctx, buffers, mat, m, n, &placement)
+}
+
+pub(crate) fn full_piv_lu_view<T: FaerLinalg + 'static>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    view: TypedTensorView<'_, T>,
+) -> tenferro_tensor::Result<Vec<TypedTensor<T>>> {
+    let (m, n) = matrix_dims_view(&view, "full_piv_lu")?;
+    if m != n {
+        return Err(tenferro_tensor::Error::ShapeMismatch {
+            op: "full_piv_lu",
+            lhs: vec![m],
+            rhs: vec![n],
+        });
+    }
+    let placement = view.placement().clone();
+    let base = host_base_ptr(&view)?;
+    // SAFETY: faer_strided_ok guarantees host placement, rank 2, non-negative strides.
+    let mat = unsafe { T::faer_mat_ref_strided(base, m, n, view.strides()[0], view.strides()[1]) };
+    T::full_piv_lu_core(ctx, buffers, mat, m, &placement)
 }
 
 macro_rules! impl_eig_real_2d {

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -8,7 +8,7 @@ use std::ops::Range;
 
 use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar};
 use tenferro_cpu::CpuContext;
-use tenferro_tensor::{Tensor, TypedTensor};
+use tenferro_tensor::{Tensor, TypedTensor, TypedTensorView};
 
 pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
     type Real: Copy + Clone + PoolScalar;
@@ -3088,6 +3088,91 @@ pub(crate) fn eigh_values<T: FaerLinalg>(
             T::eigh_values_2d(ctx, buffers, batch).map(|values| vec![values])
         })?;
     Ok(outputs.remove(0))
+}
+
+/// Predicate: can this view be fed to faer as a strided MatRef?
+pub(crate) fn faer_strided_ok<T: 'static>(view: &TypedTensorView<'_, T>) -> bool {
+    view.backend_buffer().is_none()
+        && view.shape().len() == 2
+        && view.strides().iter().all(|&s| s >= 0)
+}
+
+/// Get the host base pointer at the view's offset.
+fn host_base_ptr<T: 'static>(view: &TypedTensorView<'_, T>) -> tenferro_tensor::Result<*const T> {
+    let storage = view.host_storage()?;
+    let offset = view.offset();
+    if offset < 0 {
+        return Err(tenferro_tensor::Error::backend_failure(
+            "faer_view",
+            "view offset is negative",
+        ));
+    }
+    let offset_usize = offset as usize;
+    if !storage.is_empty() && offset_usize >= storage.len() {
+        return Err(tenferro_tensor::Error::backend_failure(
+            "faer_view",
+            "view offset is outside host buffer",
+        ));
+    }
+    // SAFETY: offset is validated above.
+    Ok(unsafe { storage.as_ptr().offset(offset) })
+}
+
+fn matrix_dims_view<T: 'static>(
+    view: &TypedTensorView<'_, T>,
+    op: &'static str,
+) -> tenferro_tensor::Result<(usize, usize)> {
+    if view.shape().len() != 2 {
+        return Err(tenferro_tensor::Error::RankMismatch {
+            op,
+            expected: 2,
+            actual: view.shape().len(),
+        });
+    }
+    Ok((view.shape()[0], view.shape()[1]))
+}
+
+pub(crate) fn svd_view<T: FaerLinalg + 'static>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    view: TypedTensorView<'_, T>,
+) -> tenferro_tensor::Result<Vec<TypedTensor<T>>> {
+    let (m, n) = matrix_dims_view(&view, "svd")?;
+    let placement = view.placement().clone();
+    let base = host_base_ptr(&view)?;
+    let mat = unsafe { T::faer_mat_ref_strided(base, m, n, view.strides()[0], view.strides()[1]) };
+    T::svd_core(ctx, buffers, mat, m, n, &placement)
+}
+
+pub(crate) fn qr_view<T: FaerLinalg + 'static>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    view: TypedTensorView<'_, T>,
+) -> tenferro_tensor::Result<Vec<TypedTensor<T>>> {
+    let (m, n) = matrix_dims_view(&view, "qr")?;
+    let placement = view.placement().clone();
+    let base = host_base_ptr(&view)?;
+    let mat = unsafe { T::faer_mat_ref_strided(base, m, n, view.strides()[0], view.strides()[1]) };
+    T::qr_core(ctx, buffers, mat, m, n, &placement)
+}
+
+pub(crate) fn eigh_view<T: FaerLinalg + 'static>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    view: TypedTensorView<'_, T>,
+) -> tenferro_tensor::Result<Vec<TypedTensor<T>>> {
+    let (m, n) = matrix_dims_view(&view, "eigh")?;
+    if m != n {
+        return Err(tenferro_tensor::Error::ShapeMismatch {
+            op: "eigh",
+            lhs: vec![m],
+            rhs: vec![n],
+        });
+    }
+    let placement = view.placement().clone();
+    let base = host_base_ptr(&view)?;
+    let mat = unsafe { T::faer_mat_ref_strided(base, m, n, view.strides()[0], view.strides()[1]) };
+    T::eigh_core(ctx, buffers, mat, m, &placement)
 }
 
 macro_rules! impl_eig_real_2d {

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -976,3 +976,101 @@ fn test_complex_solve_returns_error_for_singular_matrix() {
         tenferro_tensor::Error::BackendFailure { op: "solve", .. }
     ));
 }
+
+#[test]
+fn svd_read_faer_strided_view_matches_contiguous() {
+    // 2x3 matrix stored col-major, then transposed to give a 3x2 strided view.
+    let data = vec![1.0_f64, -2.0, 3.0, 0.5, -1.0, 4.0]; // 2x3 col-major
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], data.clone()).unwrap();
+    let view = a.as_view().transpose_view([1, 0]).unwrap(); // 3x2 strided
+    let out = CpuBackend::new().svd_read(TensorView::F64(view)).unwrap();
+    // For 3x2 input (m=3, n=2), thin SVD gives U:[3,2], S:[2], Vt:[2,2].
+    assert_eq!(out[0].shape(), &[3, 2]);
+    assert_eq!(out[1].shape(), &[2]);
+    assert_eq!(out[2].shape(), &[2, 2]);
+
+    let u = matrix_f64_from_tensor(&out[0], 3, 2);
+    let s = (0..2).map(|i| get_f64(&out[1], &[i])).collect::<Vec<_>>();
+    let vt = matrix_f64_from_tensor(&out[2], 2, 2);
+    let recon = matmul_f64(&matmul_f64(&u, &diag_f64(&s), 3, 2, 2), &vt, 3, 2, 2);
+    let expected = transpose_f64(&data, 2, 3); // A^T is 3x2 col-major
+    for (actual, expected) in recon.iter().zip(expected.iter()) {
+        assert_f64_close_tol(*actual, *expected, 1.0e-9);
+    }
+}
+
+#[test]
+fn svd_read_faer_strided_c64_view() {
+    let data = vec![
+        Complex64::new(1.0, 0.5),
+        Complex64::new(-2.0, 1.0),
+        Complex64::new(3.0, -0.25),
+        Complex64::new(0.5, -1.0),
+        Complex64::new(-1.0, 0.75),
+        Complex64::new(4.0, 1.5),
+    ];
+    let a = TypedTensor::<Complex64>::from_vec_col_major(vec![2, 3], data.clone()).unwrap();
+    let view = a.as_view().transpose_view([1, 0]).unwrap(); // 3x2 strided
+    let out = CpuBackend::new().svd_read(TensorView::C64(view)).unwrap();
+    assert_eq!(out[0].shape(), &[3, 2]); // U (thin, complex)
+    assert_eq!(out[1].shape(), &[2]); // S (real singular values)
+    assert_eq!(out[2].shape(), &[2, 2]); // Vt (thin, complex)
+
+    // Singular values are returned as a real tensor, mirroring the materialized path.
+    let s_vals = match &out[1] {
+        Tensor::F64(t) => t.host_data().unwrap().to_vec(),
+        Tensor::C64(t) => t.host_data().unwrap().iter().map(|c| c.re).collect(),
+        _ => panic!("unexpected type for singular values"),
+    };
+    assert!(s_vals.iter().all(|&v| v.is_finite() && v >= 0.0));
+    assert!(s_vals[0] >= s_vals[1]); // singular values descending
+}
+
+#[test]
+fn qr_read_faer_strided_view_matches_contiguous() {
+    let data = vec![1.0_f64, -2.0, 3.0, 0.5, -1.0, 4.0];
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], data.clone()).unwrap();
+    let view = a.as_view().transpose_view([1, 0]).unwrap(); // 3x2 strided
+    let out = CpuBackend::new().qr_read(TensorView::F64(view)).unwrap();
+    assert_eq!(out.len(), 2);
+    assert_eq!(out[0].shape(), &[3, 2]);
+    assert_eq!(out[1].shape(), &[2, 2]);
+
+    let q = matrix_f64_from_tensor(&out[0], 3, 2);
+    let r = matrix_f64_from_tensor(&out[1], 2, 2);
+    let recon = matmul_f64(&q, &r, 3, 2, 2);
+    let expected = transpose_f64(&data, 2, 3);
+    for (actual, expected) in recon.iter().zip(expected.iter()) {
+        assert_f64_close_tol(*actual, *expected, 1.0e-9);
+    }
+}
+
+#[test]
+fn eigh_read_faer_strided_view_matches_contiguous() {
+    // Symmetric 2x2 stored col-major, then transposed to a strided view (still symmetric).
+    let data = vec![4.0_f64, 1.0, 1.0, 3.0]; // 2x2 symmetric
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data.clone()).unwrap();
+    let view = a.as_view().transpose_view([1, 0]).unwrap(); // 2x2 strided (still symmetric)
+    let out = CpuBackend::new().eigh_read(TensorView::F64(view)).unwrap();
+    assert_eq!(out.len(), 2);
+    assert_eq!(out[0].shape(), &[2]); // eigenvalues
+    assert_eq!(out[1].shape(), &[2, 2]); // eigenvectors
+
+    let eigenvalues = (0..2).map(|i| get_f64(&out[0], &[i])).collect::<Vec<_>>();
+    assert!(eigenvalues[0].is_finite());
+    assert!(eigenvalues[1].is_finite());
+
+    // Reconstruct A = V diag(lambda) V^T and compare against the (symmetric) input view.
+    let vectors = matrix_f64_from_tensor(&out[1], 2, 2);
+    let recon = matmul_f64(
+        &matmul_f64(&vectors, &diag_f64(&eigenvalues), 2, 2, 2),
+        &transpose_f64(&vectors, 2, 2),
+        2,
+        2,
+        2,
+    );
+    let expected = transpose_f64(&data, 2, 2);
+    for (actual, expected) in recon.iter().zip(expected.iter()) {
+        assert_f64_close_tol(*actual, *expected, 1.0e-10);
+    }
+}

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -1438,3 +1438,371 @@ fn eigh_read_faer_strided_view_matches_contiguous() {
         assert_f64_close_tol(*actual, *expected, 1.0e-10);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Fallback-path tests: rank-3 views force `faer_strided_ok` to return false
+// (rank != 2), so each `*_read` method takes the `to_contiguous` fallback
+// branch for every supported dtype (F32, F64, C32, C64).
+// ---------------------------------------------------------------------------
+
+/// Shared column-major data for a batch of two 2x2 matrices.
+/// Layout: [2, 2, 2] with the batch dimension last, column-major for the
+/// matrix core. Each matrix is independently well-conditioned.
+///
+/// batch 0: [[1, 2], [3, 4]]   (col-major: [1, 3, 2, 4])
+/// batch 1: [[2, 0], [0, 3]]   (col-major: [2, 0, 0, 3])
+fn rank3_batched_2x2_f32() -> TypedTensor<f32> {
+    TypedTensor::<f32>::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![1.0_f32, 3.0, 2.0, 4.0, 2.0, 0.0, 0.0, 3.0],
+    )
+    .unwrap()
+}
+
+fn rank3_batched_2x2_f64() -> TypedTensor<f64> {
+    TypedTensor::<f64>::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![1.0_f64, 3.0, 2.0, 4.0, 2.0, 0.0, 0.0, 3.0],
+    )
+    .unwrap()
+}
+
+fn rank3_batched_2x2_c32() -> TypedTensor<Complex32> {
+    // batch 0: [[1+0i, 2+0i], [3+0i, 4+0i]]  col-major: [(1,0),(3,0),(2,0),(4,0)]
+    // batch 1: [[2+0i, 0+0i], [0+0i, 3+0i]]  col-major: [(2,0),(0,0),(0,0),(3,0)]
+    TypedTensor::<Complex32>::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![
+            Complex32::new(1.0, 0.0),
+            Complex32::new(3.0, 0.0),
+            Complex32::new(2.0, 0.0),
+            Complex32::new(4.0, 0.0),
+            Complex32::new(2.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(3.0, 0.0),
+        ],
+    )
+    .unwrap()
+}
+
+fn rank3_batched_2x2_c64() -> TypedTensor<Complex64> {
+    TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(4.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(3.0, 0.0),
+        ],
+    )
+    .unwrap()
+}
+
+/// SPD 2x2 matrices packed into a rank-3 [2, 2, 2] tensor for cholesky tests.
+/// batch 0: A = L*L^T where L = [[2, 0], [1, 3]]  => A = [[4, 2], [2, 10]]
+/// batch 1: A = L*L^T where L = [[1, 0], [0, 2]]  => A = [[1, 0], [0, 4]]
+fn rank3_batched_spd_2x2_f32() -> TypedTensor<f32> {
+    // col-major batch 0: [4, 2, 2, 10]
+    // col-major batch 1: [1, 0, 0, 4]
+    TypedTensor::<f32>::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![4.0_f32, 2.0, 2.0, 10.0, 1.0, 0.0, 0.0, 4.0],
+    )
+    .unwrap()
+}
+
+fn rank3_batched_spd_2x2_f64() -> TypedTensor<f64> {
+    TypedTensor::<f64>::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![4.0_f64, 2.0, 2.0, 10.0, 1.0, 0.0, 0.0, 4.0],
+    )
+    .unwrap()
+}
+
+fn rank3_batched_spd_2x2_c32() -> TypedTensor<Complex32> {
+    TypedTensor::<Complex32>::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![
+            Complex32::new(4.0, 0.0),
+            Complex32::new(2.0, 0.0),
+            Complex32::new(2.0, 0.0),
+            Complex32::new(10.0, 0.0),
+            Complex32::new(1.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(4.0, 0.0),
+        ],
+    )
+    .unwrap()
+}
+
+fn rank3_batched_spd_2x2_c64() -> TypedTensor<Complex64> {
+    TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![
+            Complex64::new(4.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(10.0, 0.0),
+            Complex64::new(1.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(4.0, 0.0),
+        ],
+    )
+    .unwrap()
+}
+
+/// `svd_read` fallback: rank-3 view forces `to_contiguous` path for all dtypes.
+#[test]
+fn svd_read_to_contiguous_fallback_rank3_all_dtypes() {
+    let f32_t = rank3_batched_2x2_f32();
+    let f64_t = rank3_batched_2x2_f64();
+    let c32_t = rank3_batched_2x2_c32();
+    let c64_t = rank3_batched_2x2_c64();
+
+    let mut backend = CpuBackend::new();
+    // F32: view is rank-3 so faer_strided_ok returns false; fallback is taken.
+    let outs = backend.svd_read(TensorView::F32(f32_t.as_view())).unwrap();
+    assert_eq!(outs.len(), 3);
+    assert_eq!(outs[0].dtype(), DType::F32);
+    assert_eq!(outs[0].shape(), &[2, 2, 2]);
+    assert_eq!(outs[1].shape(), &[2, 2]);
+    assert_eq!(outs[2].shape(), &[2, 2, 2]);
+
+    // F64
+    let outs = backend.svd_read(TensorView::F64(f64_t.as_view())).unwrap();
+    assert_eq!(outs.len(), 3);
+    assert_eq!(outs[0].dtype(), DType::F64);
+    assert_eq!(outs[0].shape(), &[2, 2, 2]);
+    assert_eq!(outs[1].shape(), &[2, 2]);
+    assert_eq!(outs[2].shape(), &[2, 2, 2]);
+
+    // C32: SVD of complex inputs returns U (C32), S (F32), Vt (C32).
+    let outs = backend.svd_read(TensorView::C32(c32_t.as_view())).unwrap();
+    assert_eq!(outs.len(), 3);
+    assert_eq!(outs[0].dtype(), DType::C32);
+    assert_eq!(outs[0].shape(), &[2, 2, 2]);
+    assert_eq!(outs[1].shape(), &[2, 2]);
+    assert_eq!(outs[2].shape(), &[2, 2, 2]);
+
+    // C64: SVD of complex inputs returns U (C64), S (F64), Vt (C64).
+    let outs = backend.svd_read(TensorView::C64(c64_t.as_view())).unwrap();
+    assert_eq!(outs.len(), 3);
+    assert_eq!(outs[0].dtype(), DType::C64);
+    assert_eq!(outs[0].shape(), &[2, 2, 2]);
+    assert_eq!(outs[1].shape(), &[2, 2]);
+    assert_eq!(outs[2].shape(), &[2, 2, 2]);
+}
+
+/// `qr_read` fallback: rank-3 view forces `to_contiguous` path for all dtypes.
+#[test]
+fn qr_read_to_contiguous_fallback_rank3_all_dtypes() {
+    let f32_t = rank3_batched_2x2_f32();
+    let f64_t = rank3_batched_2x2_f64();
+    let c32_t = rank3_batched_2x2_c32();
+    let c64_t = rank3_batched_2x2_c64();
+
+    let mut backend = CpuBackend::new();
+    for (view, dtype) in [
+        (TensorView::F32(f32_t.as_view()), DType::F32),
+        (TensorView::F64(f64_t.as_view()), DType::F64),
+        (TensorView::C32(c32_t.as_view()), DType::C32),
+        (TensorView::C64(c64_t.as_view()), DType::C64),
+    ] {
+        let outs = backend.qr_read(view).unwrap();
+        assert_eq!(
+            outs.len(),
+            2,
+            "qr_read expected 2 outputs for dtype {dtype:?}"
+        );
+        assert_eq!(outs[0].dtype(), dtype);
+        assert_eq!(outs[0].shape(), &[2, 2, 2]);
+        assert_eq!(outs[1].shape(), &[2, 2, 2]);
+    }
+}
+
+/// `eigh_read` fallback: rank-3 view forces `to_contiguous` path for all dtypes.
+#[test]
+fn eigh_read_to_contiguous_fallback_rank3_all_dtypes() {
+    // Use symmetric/Hermitian rank-3 inputs (batch of symmetric 2x2 matrices).
+    let sym_f32 = TypedTensor::<f32>::from_vec_col_major(
+        vec![2, 2, 2],
+        // batch 0: [[4,1],[1,3]] col-major: [4,1,1,3]
+        // batch 1: [[2,0],[0,5]] col-major: [2,0,0,5]
+        vec![4.0_f32, 1.0, 1.0, 3.0, 2.0, 0.0, 0.0, 5.0],
+    )
+    .unwrap();
+    let sym_f64 = TypedTensor::<f64>::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![4.0_f64, 1.0, 1.0, 3.0, 2.0, 0.0, 0.0, 5.0],
+    )
+    .unwrap();
+    let sym_c32 = TypedTensor::<Complex32>::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![
+            Complex32::new(4.0, 0.0),
+            Complex32::new(1.0, 0.0),
+            Complex32::new(1.0, 0.0),
+            Complex32::new(3.0, 0.0),
+            Complex32::new(2.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(5.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let sym_c64 = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![
+            Complex64::new(4.0, 0.0),
+            Complex64::new(1.0, 0.0),
+            Complex64::new(1.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(5.0, 0.0),
+        ],
+    )
+    .unwrap();
+
+    let mut backend = CpuBackend::new();
+
+    // Real dtypes: eigenvalues are same dtype, eigenvectors same dtype.
+    let outs = backend
+        .eigh_read(TensorView::F32(sym_f32.as_view()))
+        .unwrap();
+    assert_eq!(outs.len(), 2);
+    assert_eq!(outs[0].dtype(), DType::F32);
+    assert_eq!(outs[1].dtype(), DType::F32);
+    assert_eq!(outs[0].shape(), &[2, 2]);
+    assert_eq!(outs[1].shape(), &[2, 2, 2]);
+
+    let outs = backend
+        .eigh_read(TensorView::F64(sym_f64.as_view()))
+        .unwrap();
+    assert_eq!(outs.len(), 2);
+    assert_eq!(outs[0].dtype(), DType::F64);
+    assert_eq!(outs[1].dtype(), DType::F64);
+    assert_eq!(outs[0].shape(), &[2, 2]);
+    assert_eq!(outs[1].shape(), &[2, 2, 2]);
+
+    // Complex dtypes: eigenvalues are real, eigenvectors are complex.
+    let outs = backend
+        .eigh_read(TensorView::C32(sym_c32.as_view()))
+        .unwrap();
+    assert_eq!(outs.len(), 2);
+    assert_eq!(outs[0].dtype(), DType::F32);
+    assert_eq!(outs[1].dtype(), DType::C32);
+    assert_eq!(outs[0].shape(), &[2, 2]);
+    assert_eq!(outs[1].shape(), &[2, 2, 2]);
+
+    let outs = backend
+        .eigh_read(TensorView::C64(sym_c64.as_view()))
+        .unwrap();
+    assert_eq!(outs.len(), 2);
+    assert_eq!(outs[0].dtype(), DType::F64);
+    assert_eq!(outs[1].dtype(), DType::C64);
+    assert_eq!(outs[0].shape(), &[2, 2]);
+    assert_eq!(outs[1].shape(), &[2, 2, 2]);
+}
+
+/// `cholesky_read` fallback: rank-3 SPD view forces `to_contiguous` path for all dtypes.
+#[test]
+fn cholesky_read_to_contiguous_fallback_rank3_all_dtypes() {
+    let f32_t = rank3_batched_spd_2x2_f32();
+    let f64_t = rank3_batched_spd_2x2_f64();
+    let c32_t = rank3_batched_spd_2x2_c32();
+    let c64_t = rank3_batched_spd_2x2_c64();
+
+    let mut backend = CpuBackend::new();
+    let out = backend
+        .cholesky_read(TensorView::F32(f32_t.as_view()))
+        .unwrap();
+    assert!(matches!(out, Tensor::F32(_)));
+    assert_eq!(out.shape(), &[2, 2, 2]);
+
+    let out = backend
+        .cholesky_read(TensorView::F64(f64_t.as_view()))
+        .unwrap();
+    assert!(matches!(out, Tensor::F64(_)));
+    assert_eq!(out.shape(), &[2, 2, 2]);
+
+    let out = backend
+        .cholesky_read(TensorView::C32(c32_t.as_view()))
+        .unwrap();
+    assert!(matches!(out, Tensor::C32(_)));
+    assert_eq!(out.shape(), &[2, 2, 2]);
+
+    let out = backend
+        .cholesky_read(TensorView::C64(c64_t.as_view()))
+        .unwrap();
+    assert!(matches!(out, Tensor::C64(_)));
+    assert_eq!(out.shape(), &[2, 2, 2]);
+}
+
+/// `lu_read` fallback: rank-3 view forces `to_contiguous` path for all dtypes.
+#[test]
+fn lu_read_to_contiguous_fallback_rank3_all_dtypes() {
+    let f32_t = rank3_batched_2x2_f32();
+    let f64_t = rank3_batched_2x2_f64();
+    let c32_t = rank3_batched_2x2_c32();
+    let c64_t = rank3_batched_2x2_c64();
+
+    let mut backend = CpuBackend::new();
+    for (view, dtype) in [
+        (TensorView::F32(f32_t.as_view()), DType::F32),
+        (TensorView::F64(f64_t.as_view()), DType::F64),
+        (TensorView::C32(c32_t.as_view()), DType::C32),
+        (TensorView::C64(c64_t.as_view()), DType::C64),
+    ] {
+        let outs = backend.lu_read(view).unwrap();
+        assert_eq!(
+            outs.len(),
+            4,
+            "lu_read expected 4 outputs for dtype {dtype:?}"
+        );
+        assert_eq!(outs[0].dtype(), dtype);
+        // P, L, U have shape [2, 2, 2]; parity is [2] (one scalar per batch element).
+        assert_eq!(outs[0].shape(), &[2, 2, 2]);
+        assert_eq!(outs[1].shape(), &[2, 2, 2]);
+        assert_eq!(outs[2].shape(), &[2, 2, 2]);
+        assert_eq!(outs[3].shape(), &[2]);
+    }
+}
+
+/// `full_piv_lu_read` fallback: rank-3 view forces `to_contiguous` path for all dtypes.
+#[test]
+fn full_piv_lu_read_to_contiguous_fallback_rank3_all_dtypes() {
+    let f32_t = rank3_batched_2x2_f32();
+    let f64_t = rank3_batched_2x2_f64();
+    let c32_t = rank3_batched_2x2_c32();
+    let c64_t = rank3_batched_2x2_c64();
+
+    let mut backend = CpuBackend::new();
+    for (view, dtype) in [
+        (TensorView::F32(f32_t.as_view()), DType::F32),
+        (TensorView::F64(f64_t.as_view()), DType::F64),
+        (TensorView::C32(c32_t.as_view()), DType::C32),
+        (TensorView::C64(c64_t.as_view()), DType::C64),
+    ] {
+        let outs = backend.full_piv_lu_read(view).unwrap();
+        assert_eq!(
+            outs.len(),
+            5,
+            "full_piv_lu_read expected 5 outputs for dtype {dtype:?}"
+        );
+        // P_row, L, U, P_col each [2, 2, 2]; parity is [2].
+        assert_eq!(outs[0].shape(), &[2, 2, 2]);
+        assert_eq!(outs[1].shape(), &[2, 2, 2]);
+        assert_eq!(outs[2].shape(), &[2, 2, 2]);
+        assert_eq!(outs[3].shape(), &[2, 2, 2]);
+        assert_eq!(outs[4].shape(), &[2]);
+    }
+}

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -386,7 +386,8 @@ fn cholesky_read_canonicalizes_transposed_host_view_before_factorization() {
 
 #[test]
 fn lu_read_canonicalizes_transposed_host_view_before_factorization() {
-    // col-major [1, 2, 3, 4] => matrix [[1, 3], [2, 4]]
+    // col-major [1, 2, 3, 4] => matrix [[1, 3], [2, 4]]; the transposed view is
+    // [[1, 2], [3, 4]] (col-major [1, 3, 2, 4]), which is what the fast path must factor.
     let data = vec![1.0_f64, 2.0, 3.0, 4.0];
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap();
@@ -397,11 +398,22 @@ fn lu_read_canonicalizes_transposed_host_view_before_factorization() {
     assert_eq!(outputs[1].shape(), &[2, 2]);
     assert_eq!(outputs[2].shape(), &[2, 2]);
     assert_eq!(outputs[3].shape(), &[] as &[usize]);
+
+    // Reconstruct P * A_view == L * U (the canonical LU convention).
+    let a_view = vec![1.0_f64, 3.0, 2.0, 4.0];
+    let p = matrix_f64_from_tensor(&outputs[0], 2, 2);
+    let l = matrix_f64_from_tensor(&outputs[1], 2, 2);
+    let u = matrix_f64_from_tensor(&outputs[2], 2, 2);
+    let pa = matmul_f64(&p, &a_view, 2, 2, 2);
+    let lu = matmul_f64(&l, &u, 2, 2, 2);
+    for (actual, expected) in lu.iter().zip(pa.iter()) {
+        assert_f64_close_tol(*actual, *expected, 1.0e-9);
+    }
 }
 
 #[test]
 fn full_piv_lu_read_canonicalizes_transposed_host_view_before_factorization() {
-    // col-major [1, 2, 3, 4] => matrix [[1, 3], [2, 4]]
+    // col-major [1, 2, 3, 4] => matrix [[1, 3], [2, 4]]; transposed view is col-major [1, 3, 2, 4].
     let data = vec![1.0_f64, 2.0, 3.0, 4.0];
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap();
@@ -415,6 +427,19 @@ fn full_piv_lu_read_canonicalizes_transposed_host_view_before_factorization() {
     assert_eq!(outputs[2].shape(), &[2, 2]);
     assert_eq!(outputs[3].shape(), &[2, 2]);
     assert_eq!(outputs[4].shape(), &[] as &[usize]);
+
+    // Reconstruct P * A_view * Q^T == L * U (the complete-pivot convention).
+    let a_view = vec![1.0_f64, 3.0, 2.0, 4.0];
+    let p = matrix_f64_from_tensor(&outputs[0], 2, 2);
+    let l = matrix_f64_from_tensor(&outputs[1], 2, 2);
+    let u = matrix_f64_from_tensor(&outputs[2], 2, 2);
+    let q = matrix_f64_from_tensor(&outputs[3], 2, 2);
+    let pa = matmul_f64(&p, &a_view, 2, 2, 2);
+    let paqt = matmul_f64(&pa, &transpose_f64(&q, 2, 2), 2, 2, 2);
+    let lu = matmul_f64(&l, &u, 2, 2, 2);
+    for (actual, expected) in lu.iter().zip(paqt.iter()) {
+        assert_f64_close_tol(*actual, *expected, 1.0e-9);
+    }
 }
 
 #[test]

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -305,6 +305,345 @@ fn linalg_read_rejects_non_float_view_dtypes() {
         backend.eigh_read(TensorView::Bool(bool_input.as_view())),
         "eigh",
     );
+
+    fn assert_unsupported_dtype_single(
+        result: tenferro_tensor::Result<Tensor>,
+        expected_op: &'static str,
+    ) {
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            tenferro_tensor::Error::BackendFailure {
+                op,
+                ref message,
+            } if op == expected_op && message.contains("unsupported dtype")
+        ));
+    }
+
+    assert_unsupported_dtype_single(
+        backend.cholesky_read(TensorView::I32(i32_input.as_view())),
+        "cholesky",
+    );
+    assert_unsupported_dtype_single(
+        backend.cholesky_read(TensorView::I64(i64_input.as_view())),
+        "cholesky",
+    );
+    assert_unsupported_dtype_single(
+        backend.cholesky_read(TensorView::Bool(bool_input.as_view())),
+        "cholesky",
+    );
+    assert_unsupported_dtype(backend.lu_read(TensorView::I32(i32_input.as_view())), "lu");
+    assert_unsupported_dtype(backend.lu_read(TensorView::I64(i64_input.as_view())), "lu");
+    assert_unsupported_dtype(
+        backend.lu_read(TensorView::Bool(bool_input.as_view())),
+        "lu",
+    );
+    assert_unsupported_dtype(
+        backend.full_piv_lu_read(TensorView::I32(i32_input.as_view())),
+        "full_piv_lu",
+    );
+    assert_unsupported_dtype(
+        backend.full_piv_lu_read(TensorView::I64(i64_input.as_view())),
+        "full_piv_lu",
+    );
+    assert_unsupported_dtype(
+        backend.full_piv_lu_read(TensorView::Bool(bool_input.as_view())),
+        "full_piv_lu",
+    );
+    assert_unsupported_dtype(
+        backend.eig_read(TensorView::I32(i32_input.as_view())),
+        "eig",
+    );
+    assert_unsupported_dtype(
+        backend.eig_read(TensorView::I64(i64_input.as_view())),
+        "eig",
+    );
+    assert_unsupported_dtype(
+        backend.eig_read(TensorView::Bool(bool_input.as_view())),
+        "eig",
+    );
+}
+
+#[test]
+fn cholesky_read_canonicalizes_transposed_host_view_before_factorization() {
+    // A = L * L^T where L = [[2, 0], [1, 3]] => A = [[4, 2], [2, 10]]
+    // column-major storage: [4, 2, 2, 10]
+    let data = vec![4.0_f64, 2.0, 2.0, 10.0];
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data.clone()).unwrap();
+    // Transposed view of a symmetric matrix is still the same matrix, so cholesky should succeed.
+    let view = a.as_view().transpose_view([1, 0]).unwrap();
+    let output = CpuBackend::new()
+        .cholesky_read(TensorView::F64(view))
+        .unwrap();
+    assert_eq!(output.shape(), &[2, 2]);
+    // Verify L * L^T ≈ A
+    let l = matrix_f64_from_tensor(&output, 2, 2);
+    let recon = matmul_f64(&l, &transpose_f64(&l, 2, 2), 2, 2, 2);
+    for (actual, expected) in recon.iter().zip(data.iter()) {
+        assert_f64_close_tol(*actual, *expected, 1.0e-9);
+    }
+}
+
+#[test]
+fn lu_read_canonicalizes_transposed_host_view_before_factorization() {
+    // col-major [1, 2, 3, 4] => matrix [[1, 3], [2, 4]]
+    let data = vec![1.0_f64, 2.0, 3.0, 4.0];
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data).unwrap();
+    let view = a.as_view().transpose_view([1, 0]).unwrap();
+    let outputs = CpuBackend::new().lu_read(TensorView::F64(view)).unwrap();
+    assert_eq!(outputs.len(), 4);
+    // P has shape [2, 2], L has shape [2, 2], U has shape [2, 2], parity is scalar []
+    assert_eq!(outputs[0].shape(), &[2, 2]);
+    assert_eq!(outputs[1].shape(), &[2, 2]);
+    assert_eq!(outputs[2].shape(), &[2, 2]);
+    assert_eq!(outputs[3].shape(), &[] as &[usize]);
+}
+
+#[test]
+fn full_piv_lu_read_canonicalizes_transposed_host_view_before_factorization() {
+    // col-major [1, 2, 3, 4] => matrix [[1, 3], [2, 4]]
+    let data = vec![1.0_f64, 2.0, 3.0, 4.0];
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data).unwrap();
+    let view = a.as_view().transpose_view([1, 0]).unwrap();
+    let outputs = CpuBackend::new()
+        .full_piv_lu_read(TensorView::F64(view))
+        .unwrap();
+    assert_eq!(outputs.len(), 5);
+    // P_row, L, U, P_col, parity
+    assert_eq!(outputs[0].shape(), &[2, 2]);
+    assert_eq!(outputs[1].shape(), &[2, 2]);
+    assert_eq!(outputs[2].shape(), &[2, 2]);
+    assert_eq!(outputs[3].shape(), &[2, 2]);
+    assert_eq!(outputs[4].shape(), &[] as &[usize]);
+}
+
+#[test]
+fn eig_read_returns_correct_outputs_for_diagonal_matrix() {
+    // diagonal matrix [[2, 0], [0, 3]] col-major: [2, 0, 0, 3]
+    let data = vec![2.0_f64, 0.0, 0.0, 3.0];
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data).unwrap();
+    let outputs = CpuBackend::new()
+        .eig_read(TensorView::F64(a.as_view()))
+        .unwrap();
+    assert_eq!(outputs.len(), 2);
+    // eig on real returns complex outputs
+    assert!(matches!(outputs[0], Tensor::C64(_)));
+    assert!(matches!(outputs[1], Tensor::C64(_)));
+    assert_eq!(outputs[0].shape(), &[2]);
+    assert_eq!(outputs[1].shape(), &[2, 2]);
+}
+
+#[test]
+fn cholesky_read_accepts_all_supported_linalg_view_dtypes() {
+    let mut backend = CpuBackend::new();
+    let spd_f32 =
+        TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![4.0_f32, 2.0, 2.0, 3.0]).unwrap();
+    let spd_f64 =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![4.0_f64, 2.0, 2.0, 3.0]).unwrap();
+    let spd_c32 = TypedTensor::<Complex32>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex32::new(4.0, 0.0),
+            Complex32::new(2.0, 0.0),
+            Complex32::new(2.0, 0.0),
+            Complex32::new(3.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let spd_c64 = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(4.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+        ],
+    )
+    .unwrap();
+
+    let out = backend
+        .cholesky_read(TensorView::F32(spd_f32.as_view()))
+        .unwrap();
+    assert!(matches!(out, Tensor::F32(_)));
+    assert_eq!(out.shape(), &[2, 2]);
+
+    let out = backend
+        .cholesky_read(TensorView::F64(spd_f64.as_view()))
+        .unwrap();
+    assert!(matches!(out, Tensor::F64(_)));
+    assert_eq!(out.shape(), &[2, 2]);
+
+    let out = backend
+        .cholesky_read(TensorView::C32(spd_c32.as_view()))
+        .unwrap();
+    assert!(matches!(out, Tensor::C32(_)));
+    assert_eq!(out.shape(), &[2, 2]);
+
+    let out = backend
+        .cholesky_read(TensorView::C64(spd_c64.as_view()))
+        .unwrap();
+    assert!(matches!(out, Tensor::C64(_)));
+    assert_eq!(out.shape(), &[2, 2]);
+}
+
+#[test]
+fn lu_read_accepts_all_supported_linalg_view_dtypes() {
+    let mut backend = CpuBackend::new();
+    let mat_f32 =
+        TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![1.0_f32, 2.0, 3.0, 4.0]).unwrap();
+    let mat_f64 =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let mat_c32 = TypedTensor::<Complex32>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex32::new(1.0, 0.0),
+            Complex32::new(2.0, 0.0),
+            Complex32::new(3.0, 0.0),
+            Complex32::new(4.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let mat_c64 = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 0.0),
+        ],
+    )
+    .unwrap();
+
+    let outs = backend.lu_read(TensorView::F32(mat_f32.as_view())).unwrap();
+    assert_eq!(outs.len(), 4);
+    assert!(matches!(outs[0], Tensor::F32(_)));
+
+    let outs = backend.lu_read(TensorView::F64(mat_f64.as_view())).unwrap();
+    assert_eq!(outs.len(), 4);
+    assert!(matches!(outs[0], Tensor::F64(_)));
+
+    let outs = backend.lu_read(TensorView::C32(mat_c32.as_view())).unwrap();
+    assert_eq!(outs.len(), 4);
+    assert!(matches!(outs[0], Tensor::C32(_)));
+
+    let outs = backend.lu_read(TensorView::C64(mat_c64.as_view())).unwrap();
+    assert_eq!(outs.len(), 4);
+    assert!(matches!(outs[0], Tensor::C64(_)));
+}
+
+#[test]
+fn full_piv_lu_read_accepts_all_supported_linalg_view_dtypes() {
+    let mut backend = CpuBackend::new();
+    let mat_f32 =
+        TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![1.0_f32, 2.0, 3.0, 4.0]).unwrap();
+    let mat_f64 =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let mat_c32 = TypedTensor::<Complex32>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex32::new(1.0, 0.0),
+            Complex32::new(2.0, 0.0),
+            Complex32::new(3.0, 0.0),
+            Complex32::new(4.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let mat_c64 = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 0.0),
+        ],
+    )
+    .unwrap();
+
+    let outs = backend
+        .full_piv_lu_read(TensorView::F32(mat_f32.as_view()))
+        .unwrap();
+    assert_eq!(outs.len(), 5);
+    assert!(matches!(outs[0], Tensor::F32(_)));
+
+    let outs = backend
+        .full_piv_lu_read(TensorView::F64(mat_f64.as_view()))
+        .unwrap();
+    assert_eq!(outs.len(), 5);
+    assert!(matches!(outs[0], Tensor::F64(_)));
+
+    let outs = backend
+        .full_piv_lu_read(TensorView::C32(mat_c32.as_view()))
+        .unwrap();
+    assert_eq!(outs.len(), 5);
+    assert!(matches!(outs[0], Tensor::C32(_)));
+
+    let outs = backend
+        .full_piv_lu_read(TensorView::C64(mat_c64.as_view()))
+        .unwrap();
+    assert_eq!(outs.len(), 5);
+    assert!(matches!(outs[0], Tensor::C64(_)));
+}
+
+#[test]
+fn eig_read_accepts_all_supported_linalg_view_dtypes() {
+    let mut backend = CpuBackend::new();
+    // Use diagonal matrices so eig is well-conditioned
+    let mat_f32 =
+        TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![2.0_f32, 0.0, 0.0, 3.0]).unwrap();
+    let mat_f64 =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 3.0]).unwrap();
+    let mat_c32 = TypedTensor::<Complex32>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex32::new(2.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(3.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let mat_c64 = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(2.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(3.0, 0.0),
+        ],
+    )
+    .unwrap();
+
+    // f32 -> C32 outputs
+    let outs = backend
+        .eig_read(TensorView::F32(mat_f32.as_view()))
+        .unwrap();
+    assert_eq!(outs.len(), 2);
+    assert!(matches!(outs[0], Tensor::C32(_)));
+    assert!(matches!(outs[1], Tensor::C32(_)));
+
+    // f64 -> C64 outputs
+    let outs = backend
+        .eig_read(TensorView::F64(mat_f64.as_view()))
+        .unwrap();
+    assert_eq!(outs.len(), 2);
+    assert!(matches!(outs[0], Tensor::C64(_)));
+    assert!(matches!(outs[1], Tensor::C64(_)));
+
+    // C32 -> C32 outputs
+    let outs = backend
+        .eig_read(TensorView::C32(mat_c32.as_view()))
+        .unwrap();
+    assert_eq!(outs.len(), 2);
+    assert!(matches!(outs[0], Tensor::C32(_)));
+    assert!(matches!(outs[1], Tensor::C32(_)));
+
+    // C64 -> C64 outputs
+    let outs = backend
+        .eig_read(TensorView::C64(mat_c64.as_view()))
+        .unwrap();
+    assert_eq!(outs.len(), 2);
+    assert!(matches!(outs[0], Tensor::C64(_)));
+    assert!(matches!(outs[1], Tensor::C64(_)));
 }
 
 #[test]

--- a/crates/tenferro-linalg/src/eager_backend.rs
+++ b/crates/tenferro-linalg/src/eager_backend.rs
@@ -81,6 +81,22 @@ impl LinalgBackend for EagerBackend {
         dispatch_linalg!(self, eigh_read(input))
     }
 
+    fn cholesky_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Tensor> {
+        dispatch_linalg!(self, cholesky_read(input))
+    }
+
+    fn lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        dispatch_linalg!(self, lu_read(input))
+    }
+
+    fn full_piv_lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        dispatch_linalg!(self, full_piv_lu_read(input))
+    }
+
+    fn eig_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        dispatch_linalg!(self, eig_read(input))
+    }
+
     fn eigh_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         dispatch_linalg!(self, eigh_values(input))
     }

--- a/crates/tenferro-linalg/src/gpu/mod.rs
+++ b/crates/tenferro-linalg/src/gpu/mod.rs
@@ -145,6 +145,118 @@ impl LinalgBackend for CudaBackend {
         }
     }
 
+    fn cholesky_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Tensor> {
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F32(compact);
+                self.cholesky(&input)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F64(compact);
+                self.cholesky(&input)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C32(compact);
+                self.cholesky(&input)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C64(compact);
+                self.cholesky(&input)
+            }
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("cholesky", input.dtype()))
+            }
+        }
+    }
+
+    fn lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F32(compact);
+                self.lu(&input)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F64(compact);
+                self.lu(&input)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C32(compact);
+                self.lu(&input)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C64(compact);
+                self.lu(&input)
+            }
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("lu", input.dtype()))
+            }
+        }
+    }
+
+    fn full_piv_lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F32(compact);
+                self.full_piv_lu(&input)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F64(compact);
+                self.full_piv_lu(&input)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C32(compact);
+                self.full_piv_lu(&input)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C64(compact);
+                self.full_piv_lu(&input)
+            }
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("full_piv_lu", input.dtype()))
+            }
+        }
+    }
+
+    fn eig_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        match input {
+            TensorView::F32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F32(compact);
+                self.eig(&input)
+            }
+            TensorView::F64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::F64(compact);
+                self.eig(&input)
+            }
+            TensorView::C32(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C32(compact);
+                self.eig(&input)
+            }
+            TensorView::C64(view) => {
+                let compact = self.to_contiguous(&view)?;
+                let input = Tensor::C64(compact);
+                self.eig(&input)
+            }
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("eig", input.dtype()))
+            }
+        }
+    }
+
     fn eigh_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         linalg::eigh_values(self, input)
     }

--- a/crates/tenferro-linalg/src/gpu/mod.rs
+++ b/crates/tenferro-linalg/src/gpu/mod.rs
@@ -3,9 +3,9 @@ mod kernels;
 mod linalg;
 
 use tenferro_gpu::CudaBackend;
-use tenferro_tensor::{DType, Error, Tensor, TensorView, TensorViewCanonicalization};
+use tenferro_tensor::{Tensor, TensorView, TensorViewCanonicalization};
 
-use crate::backend::LinalgBackend;
+use crate::backend::{unsupported_dtype, LinalgBackend};
 
 impl LinalgBackend for CudaBackend {
     fn cholesky(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
@@ -75,9 +75,9 @@ impl LinalgBackend for CudaBackend {
                 let input = Tensor::C64(compact);
                 self.svd(&input)
             }
-            TensorView::I32(_) => Err(unsupported_view_dtype("svd", DType::I32)),
-            TensorView::I64(_) => Err(unsupported_view_dtype("svd", DType::I64)),
-            TensorView::Bool(_) => Err(unsupported_view_dtype("svd", DType::Bool)),
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("svd", input.dtype()))
+            }
         }
     }
 
@@ -107,9 +107,9 @@ impl LinalgBackend for CudaBackend {
                 let input = Tensor::C64(compact);
                 self.qr(&input)
             }
-            TensorView::I32(_) => Err(unsupported_view_dtype("qr", DType::I32)),
-            TensorView::I64(_) => Err(unsupported_view_dtype("qr", DType::I64)),
-            TensorView::Bool(_) => Err(unsupported_view_dtype("qr", DType::Bool)),
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("qr", input.dtype()))
+            }
         }
     }
 
@@ -139,9 +139,9 @@ impl LinalgBackend for CudaBackend {
                 let input = Tensor::C64(compact);
                 self.eigh(&input)
             }
-            TensorView::I32(_) => Err(unsupported_view_dtype("eigh", DType::I32)),
-            TensorView::I64(_) => Err(unsupported_view_dtype("eigh", DType::I64)),
-            TensorView::Bool(_) => Err(unsupported_view_dtype("eigh", DType::Bool)),
+            TensorView::I32(_) | TensorView::I64(_) | TensorView::Bool(_) => {
+                Err(unsupported_dtype("eigh", input.dtype()))
+            }
         }
     }
 
@@ -168,8 +168,4 @@ impl LinalgBackend for CudaBackend {
     ) -> tenferro_tensor::Result<Tensor> {
         linalg::lu_solve_prepared(self, a, packed_lu, pivots, b, transpose_a, conjugate_a)
     }
-}
-
-fn unsupported_view_dtype(op: &'static str, dtype: DType) -> Error {
-    Error::backend_failure(op, format!("unsupported dtype {dtype:?}"))
 }

--- a/crates/tenferro-linalg/tests/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/backend_errors.rs
@@ -282,7 +282,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
             &Tensor::F64(input.clone()),
             &Tensor::F64(input.clone()),
             &pivots,
-            &Tensor::F64(input),
+            &Tensor::F64(input.clone()),
             false,
             false,
         )
@@ -293,6 +293,50 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
             op: "lu_solve_prepared",
             ref message,
         } if message.contains("does not implement")
+    ));
+
+    let err = backend
+        .cholesky_read(TensorView::F64(input.as_view()))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "cholesky",
+            ref message,
+        } if message.contains("borrowed tensor views")
+    ));
+
+    let err = backend
+        .lu_read(TensorView::F64(input.as_view()))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "lu",
+            ref message,
+        } if message.contains("borrowed tensor views")
+    ));
+
+    let err = backend
+        .full_piv_lu_read(TensorView::F64(input.as_view()))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "full_piv_lu",
+            ref message,
+        } if message.contains("borrowed tensor views")
+    ));
+
+    let err = backend
+        .eig_read(TensorView::F64(input.as_view()))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "eig",
+            ref message,
+        } if message.contains("borrowed tensor views")
     ));
 }
 

--- a/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
@@ -748,3 +748,59 @@ fn gpu_lu_shape_extent_k_is_runtime_not_compile_time_specialized() {
         );
     }
 }
+
+#[test]
+fn gpu_mod_implements_cholesky_read_with_to_contiguous_fallback() {
+    let source = gpu_mod_source();
+    assert!(
+        source.contains("fn cholesky_read"),
+        "gpu mod should implement cholesky_read"
+    );
+    let section = source_section(&source, "fn cholesky_read", "fn lu_read");
+    assert!(
+        section.contains("to_contiguous"),
+        "gpu cholesky_read should fall through to to_contiguous"
+    );
+}
+
+#[test]
+fn gpu_mod_implements_lu_read_with_to_contiguous_fallback() {
+    let source = gpu_mod_source();
+    assert!(
+        source.contains("fn lu_read"),
+        "gpu mod should implement lu_read"
+    );
+    let section = source_section(&source, "fn lu_read", "fn full_piv_lu_read");
+    assert!(
+        section.contains("to_contiguous"),
+        "gpu lu_read should fall through to to_contiguous"
+    );
+}
+
+#[test]
+fn gpu_mod_implements_full_piv_lu_read_with_to_contiguous_fallback() {
+    let source = gpu_mod_source();
+    assert!(
+        source.contains("fn full_piv_lu_read"),
+        "gpu mod should implement full_piv_lu_read"
+    );
+    let section = source_section(&source, "fn full_piv_lu_read", "fn eig_read");
+    assert!(
+        section.contains("to_contiguous"),
+        "gpu full_piv_lu_read should fall through to to_contiguous"
+    );
+}
+
+#[test]
+fn gpu_mod_implements_eig_read_with_to_contiguous_fallback() {
+    let source = gpu_mod_source();
+    assert!(
+        source.contains("fn eig_read"),
+        "gpu mod should implement eig_read"
+    );
+    let section = source_section(&source, "fn eig_read", "fn eigh_values");
+    assert!(
+        section.contains("to_contiguous"),
+        "gpu eig_read should fall through to to_contiguous"
+    );
+}

--- a/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/gpu_linalg_source_contract.rs
@@ -750,57 +750,69 @@ fn gpu_lu_shape_extent_k_is_runtime_not_compile_time_specialized() {
 }
 
 #[test]
-fn gpu_mod_implements_cholesky_read_with_to_contiguous_fallback() {
+fn cubecl_linalg_overrides_cholesky_read_with_backend_canonicalization() {
     let source = gpu_mod_source();
-    assert!(
-        source.contains("fn cholesky_read"),
-        "gpu mod should implement cholesky_read"
-    );
-    let section = source_section(&source, "fn cholesky_read", "fn lu_read");
-    assert!(
-        section.contains("to_contiguous"),
-        "gpu cholesky_read should fall through to to_contiguous"
-    );
+    let cholesky_read_source = source_section(&source, "fn cholesky_read", "fn lu_read");
+
+    for needle in [
+        "self.to_contiguous(&view)?",
+        "let input = Tensor::F64(compact);",
+        "self.cholesky(&input)",
+    ] {
+        assert!(
+            cholesky_read_source.contains(needle),
+            "CubeCL cholesky_read should canonicalize borrowed GPU views on the backend: missing {needle}"
+        );
+    }
 }
 
 #[test]
-fn gpu_mod_implements_lu_read_with_to_contiguous_fallback() {
+fn cubecl_linalg_overrides_lu_read_with_backend_canonicalization() {
     let source = gpu_mod_source();
-    assert!(
-        source.contains("fn lu_read"),
-        "gpu mod should implement lu_read"
-    );
-    let section = source_section(&source, "fn lu_read", "fn full_piv_lu_read");
-    assert!(
-        section.contains("to_contiguous"),
-        "gpu lu_read should fall through to to_contiguous"
-    );
+    let lu_read_source = source_section(&source, "fn lu_read", "fn full_piv_lu_read");
+
+    for needle in [
+        "self.to_contiguous(&view)?",
+        "let input = Tensor::F64(compact);",
+        "self.lu(&input)",
+    ] {
+        assert!(
+            lu_read_source.contains(needle),
+            "CubeCL lu_read should canonicalize borrowed GPU views on the backend: missing {needle}"
+        );
+    }
 }
 
 #[test]
-fn gpu_mod_implements_full_piv_lu_read_with_to_contiguous_fallback() {
+fn cubecl_linalg_overrides_full_piv_lu_read_with_backend_canonicalization() {
     let source = gpu_mod_source();
-    assert!(
-        source.contains("fn full_piv_lu_read"),
-        "gpu mod should implement full_piv_lu_read"
-    );
-    let section = source_section(&source, "fn full_piv_lu_read", "fn eig_read");
-    assert!(
-        section.contains("to_contiguous"),
-        "gpu full_piv_lu_read should fall through to to_contiguous"
-    );
+    let full_piv_lu_read_source = source_section(&source, "fn full_piv_lu_read", "fn eig_read");
+
+    for needle in [
+        "self.to_contiguous(&view)?",
+        "let input = Tensor::F64(compact);",
+        "self.full_piv_lu(&input)",
+    ] {
+        assert!(
+            full_piv_lu_read_source.contains(needle),
+            "CubeCL full_piv_lu_read should canonicalize borrowed GPU views on the backend: missing {needle}"
+        );
+    }
 }
 
 #[test]
-fn gpu_mod_implements_eig_read_with_to_contiguous_fallback() {
+fn cubecl_linalg_overrides_eig_read_with_backend_canonicalization() {
     let source = gpu_mod_source();
-    assert!(
-        source.contains("fn eig_read"),
-        "gpu mod should implement eig_read"
-    );
-    let section = source_section(&source, "fn eig_read", "fn eigh_values");
-    assert!(
-        section.contains("to_contiguous"),
-        "gpu eig_read should fall through to to_contiguous"
-    );
+    let eig_read_source = source_section(&source, "fn eig_read", "fn eigh_values");
+
+    for needle in [
+        "self.to_contiguous(&view)?",
+        "let input = Tensor::F64(compact);",
+        "self.eig(&input)",
+    ] {
+        assert!(
+            eig_read_source.contains(needle),
+            "CubeCL eig_read should canonicalize borrowed GPU views on the backend: missing {needle}"
+        );
+    }
 }

--- a/docs/worklogs/2026-06-30-linalg-read-decomposition-faer-strided.md
+++ b/docs/worklogs/2026-06-30-linalg-read-decomposition-faer-strided.md
@@ -1,0 +1,105 @@
+# 2026-06-30 Linalg read-view decomposition family + faer strided fast path
+
+## Summary
+
+Completes the borrowed-view `_read` execution-boundary API for the linalg
+decomposition family and makes the faer CPU path consume strided 2-D views
+directly instead of materializing a contiguous copy. Direct continuation of the
+merged #1248 (`svd_read`/`qr_read`/`eigh_read`); maintainer-directed, AI-assisted
+implementation.
+
+Three coordinated changes:
+
+1. Unify the dtype-error helper (`unsupported_view_dtype` in `gpu/mod.rs` was a
+   byte-identical duplicate of `unsupported_dtype`); GPU `_read` methods adopt the
+   CPU grouped match arm.
+2. faer buffer-avoidance: on `CpuBackend` with the faer provider, a 2-D host view
+   with non-negative strides is wrapped as a strided `faer::MatRef` and fed to the
+   same decomposition core. faer copies its input into a packed workspace anyway,
+   so the strided→packed gather is absorbed there — one copy instead of two
+   (`to_contiguous` gather + faer workspace copy).
+3. Add `cholesky_read`/`lu_read`/`full_piv_lu_read`/`eig_read` across trait
+   default, `CpuBackend`, `CudaBackend`, and `EagerBackend`, matching the merged
+   `svd_read`/`qr_read`/`eigh_read` conventions.
+
+Out of scope by design: the solve family (`solve`/`triangular_solve`/
+`full_piv_lu_solve`, multi-input signature) and internal `#[doc(hidden)]` ops.
+
+## Context read
+
+- The merged #1248 `svd_read`/`qr_read`/`eigh_read` (the pattern this mirrors):
+  trait default impl, `CpuBackend`/`CudaBackend` overrides, `EagerBackend`
+  dispatch, and their tests.
+- `cpu/linalg/faer_linalg.rs`: the `*_2d` cores and the
+  `impl_faer_linalg_for_real!` / `impl_faer_linalg_for_complex!` macros; the
+  `MatRef::from_column_major_slice` + workspace `copy_from` pattern.
+- `tenferro-tensor` `TypedTensorView` accessors (`strides`/`offset`/
+  `host_storage`/`backend_buffer`) and `CpuBackend::to_contiguous` (host-placement
+  rejection).
+- `REPOSITORY_RULES.md`: Faer Integration (prefer zero-copy `MatRef`),
+  Materialization And Copies (avoid dense copy-in around strided-capable ops),
+  Unsafe Code Boundary (backend-leaf only, `// SAFETY:` notes), Public Surface
+  Discipline (`_read` suffix for borrowed-view inputs), AD Rule Coverage (this
+  change touches no AD rule, so the Oracle Gate does not apply).
+
+## Design decisions
+
+- **MatRef-in refactor over additive `*_view` duplication.** Faer output helpers
+  are templated on `&Placement`, and each `*_2d` was split into a `*_core` taking
+  a `faer::MatRef`. Both the compact path (`faer_mat_ref_compact`) and the strided
+  path (`faer_mat_ref_strided`) feed the same core, so there is no duplicated
+  decomposition logic. Bodies live once per real/complex macro.
+- **Strided fast path is strictly additive.** Gated by
+  `#[cfg(feature = "cpu-faer")]` + `matches!(self.kind(), CpuBackendKind::Faer)` +
+  `faer_strided_ok(view)` (host buffer, rank 2, all strides ≥ 0). Any other case
+  (BLAS, GPU, batched/rank≠2, negative strides, feature off) falls through to the
+  unchanged `to_contiguous` → owned-`Tensor` path. The documented "no silent
+  CPU↔GPU transfer" contract holds: GPU-buffer views fail the predicate and are
+  rejected by `to_contiguous` as before.
+- **eig has no fast path (fallback only).** `eig` is non-Hermitian and real input
+  yields complex output (`Vec<TypedTensor<Complex>>` from a real `TypedTensor`),
+  so a generic `eig_core` over `FaerLinalg<T>` is not type-expressible. `eig_read`
+  materializes and calls `self.eig`, producing the same complex public tensors as
+  the slow path. Documented in code.
+- **cholesky is single-output** (`Result<Tensor>`); its fast path returns the
+  `Tensor` directly.
+
+## Alternatives rejected / deferred
+
+- Additive `*_2d_view` siblings beside the existing `*_2d`: rejected — duplicates
+  each decomposition body.
+- Batched (rank > 2) strided fast path: deferred — the batch stride adds
+  complexity for uncertain benefit; batched views still work correctly via the
+  `to_contiguous` fallback. The 2-D matrix case is the documented contract.
+- Lowering `coverage-thresholds.json` for the touched files: not done; prefer real
+  fallback-path tests if CI coverage flags the additive arms.
+
+## Verification
+
+- `cargo test -p tenferro-linalg` (default faer build): lib 62, doctests 29,
+  integration suites (backend_errors, gpu_linalg_source_contract incl. 7 `_read`
+  contract tests, full_piv_lu, traced_correctness, …) all pass, 0 failures.
+- `cargo clippy -p tenferro-linalg --all-targets -- -D warnings`: clean.
+- `cargo fmt --all --check`: clean.
+- The pre-existing `*_canonicalizes_transposed_*` reconstruction tests now route
+  through the strided fast path (transposed view → positive strides →
+  `faer_strided_ok`), so the optimization is covered by already-trusted numerical
+  reconstruction, plus new `*_faer_strided_*` regressions for svd/qr/eigh and
+  factor-reconstruction tests for lu/full_piv_lu.
+
+## Residual risks
+
+- **Coverage**: depending on the coverage build's CPU provider features, either
+  the fast-path arms or the float `to_contiguous` fallback arms in
+  `cpu/backend.rs` may be unexercised, possibly dropping the file below the 90%
+  default. Fix by adding fallback-forcing tests (e.g. a rank-3 view) rather than
+  padding — pending the CI coverage report.
+- **faer generic-stride input**: a transposed view has row stride ≠ 1, which is
+  not faer's preferred contiguous layout. Justified: faer copies the input into a
+  packed workspace before factoring, so the non-unit stride only affects that
+  one unavoidable pack read, not the decomposition itself; the alternative is a
+  full `to_contiguous` allocation + gather.
+- **eig** gets no buffer-avoidance win (fallback only); acceptable and documented.
+- Full-workspace `--release` tests, `llvm-cov` coverage, `cargo doc`,
+  `check-docs-site.py`, repository-rules review, and the GPU lane are verified in
+  CI rather than locally for this crate-scoped change.


### PR DESCRIPTION
## Type

- [x] Refactor / cleanup
- [x] Implementation of accepted issue <!-- continuation of the merged #1248 read-view family; maintainer-directed -->

## Related issue

Refs #1248 (continues the borrowed-view `_read` linalg execution-boundary family).

## Summary

Completes the decomposition-family `_read` (borrowed `TensorView`) API and makes the
faer CPU path canonicalize strided 2-D views without materializing a contiguous copy.

Three parts:

1. **Unify the dtype-error helper.** `gpu/mod.rs`'s `unsupported_view_dtype` was a
   byte-identical duplicate of `cpu/backend.rs`'s `unsupported_dtype`. Both now use a
   single `pub(crate) fn unsupported_dtype` in `backend.rs`, and the GPU `_read`
   methods adopt the CPU grouped match arm (`I32 | I64 | Bool => unsupported_dtype(op, input.dtype())`).

2. **faer buffer-avoidance (perf).** `_read` previously did `to_contiguous(view)` →
   owned `Tensor` → op, i.e. **two** copies (our gather + faer's mandatory workspace
   copy). On `CpuBackend` with the faer provider, a 2-D host view with non-negative
   strides is now wrapped directly as a strided `faer::MatRef` and fed to the same
   decomposition core, so faer's workspace copy absorbs the strided→packed gather —
   **one** copy. All other cases (BLAS, GPU, batched/rank≠2, negative strides) fall
   through to the unchanged `to_contiguous` path, so the change is strictly additive.

3. **Complete the family.** Adds `cholesky_read` / `lu_read` / `full_piv_lu_read` /
   `eig_read` to `LinalgBackend` (default impl + CpuBackend + CudaBackend + EagerBackend),
   matching the existing `svd_read` / `qr_read` / `eigh_read` exactly. (`cholesky_read`
   returns a single `Tensor`.)

Out of scope (by design): the solve family (`solve` / `triangular_solve` /
`full_piv_lu_solve`, different multi-input signature) and internal `#[doc(hidden)]`
ops (`*_values`, `lu_factor`, `lu_solve_prepared`).

### `_read` coverage after this PR

| op | `_read` | faer 2-D fast path |
|---|---|---|
| svd, qr, eigh | ✅ (merged in #1248) | ✅ |
| cholesky, lu, full_piv_lu | ✅ (this PR) | ✅ |
| eig | ✅ (this PR) | — (fallback only: real→complex output isn't type-expressible as a generic core; uses `to_contiguous` → `self.eig`, same result) |

### Fast-path / fallback matrix

| case | path | copies |
|---|---|---|
| CpuBackend·faer · 2-D · non-negative strides | strided `MatRef` → faer | 1 |
| CpuBackend·faer · batched / negative-stride | `to_contiguous` → existing batched path | 2 |
| CpuBackend·BLAS | `to_contiguous` → LAPACK | 2 |
| CudaBackend | `to_contiguous` → cuSOLVER | 2 |

The documented "must not silently transfer between CPU and GPU memory" contract is
preserved: GPU-buffer views fail `faer_strided_ok` and fall through to
`to_contiguous`, which rejects backend buffers as before.

## Work log

See [`docs/worklogs/2026-06-30-linalg-read-decomposition-faer-strided.md`](docs/worklogs/2026-06-30-linalg-read-decomposition-faer-strided.md)
for the decision record (faer MatRef-in refactor, additive fast-path predicate,
eig fallback rationale, residual coverage risk).

- Unify `unsupported_dtype` across cpu/gpu.
- Template faer outputs on `&Placement`; extract `*_core(MatRef, …)` from `*_2d`.
- Add `*_view` faer entries + CpuBackend faer fast path (svd/qr/eigh, then cholesky/lu/full_piv_lu/eig).
- Add `cholesky/lu/full_piv_lu/eig` `_read` to trait/cpu/gpu/eager.
- Tests: transposed/symmetric strided-view reconstruction (real+complex), all supported dtypes, int/bool rejection, default-backend boundary errors, GPU source contracts.

Tests: `cargo test -p tenferro-linalg` (+ `cargo fmt --all`, `cargo clippy -p tenferro-linalg --all-targets -- -D warnings`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
