### PR TITLE
[codex] Use gesdd for OpenBLAS SVD

### DIFF
--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
@@ -22,10 +22,12 @@ pub(crate) trait LapackSvd: Clone + Copy + Default + PoolScalar {
     ) -> tenferro_tensor::Result<TypedTensor<Self::Real>>;
 }
 
+#[cfg(not(feature = "provider-inject"))]
 fn gesdd_iwork_len(k: usize) -> usize {
     8 * k.max(1)
 }
 
+#[cfg(not(feature = "provider-inject"))]
 fn complex_gesdd_rwork_len(jobz: u8, m: usize, n: usize) -> usize {
     let mn = m.min(n);
     let mx = m.max(n);
@@ -38,6 +40,121 @@ fn complex_gesdd_rwork_len(jobz: u8, m: usize, n: usize) -> usize {
     (5 * mn * mn + 5 * mn).max(2 * mx * mn + 2 * mn * mn + mn)
 }
 
+#[cfg(feature = "provider-inject")]
+macro_rules! impl_real_svd {
+    ($scalar:ty, $gesvd:path, $routine:literal) => {
+        impl LapackSvd for $scalar {
+            type Real = $scalar;
+
+            fn svd_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
+                let (m, n) = matrix_dims(input, "svd")?;
+                let k = m.min(n);
+                let m_i32 = dim_i32(m, "svd")?;
+                let n_i32 = dim_i32(n, "svd")?;
+                let k_i32 = dim_i32(k, "svd")?;
+
+                let mut a = input.host_data()?.to_vec();
+                let mut s = vec![0.0 as $scalar; k];
+                let mut u = vec![0.0 as $scalar; m * k];
+                let mut vt = vec![0.0 as $scalar; k * n];
+                let mut query = vec![0.0 as $scalar; 1];
+                let mut info = 0;
+                // SAFETY: `a`, `s`, `u`, and `vt` match the validated SVD
+                // dimensions, and `lwork = -1` makes `query` the workspace output.
+                unsafe {
+                    $gesvd(
+                        b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
+                        k_i32, &mut query, -1, &mut info,
+                    );
+                }
+                check_lapack_info("svd", concat!($routine, "(work query)"), info)?;
+                let lwork = work_len(query[0] as f64, "svd", $routine)?;
+                let mut work = vec![0.0 as $scalar; lwork as usize];
+                // SAFETY: buffers and leading dimensions match the validated
+                // SVD problem, and `work` uses the queried workspace length.
+                unsafe {
+                    $gesvd(
+                        b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
+                        k_i32, &mut work, lwork, &mut info,
+                    );
+                }
+                check_lapack_info("svd", $routine, info)?;
+
+                Ok(vec![
+                    tensor_from_vec_with_template(vec![m, k], u, input)?,
+                    tensor_from_vec_with_template(vec![k], s, input)?,
+                    tensor_from_vec_with_template(vec![k, n], vt, input)?,
+                ])
+            }
+
+            fn svd_values_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
+                let (m, n) = matrix_dims(input, "svd_values")?;
+                let k = m.min(n);
+                let m_i32 = dim_i32(m, "svd_values")?;
+                let n_i32 = dim_i32(n, "svd_values")?;
+
+                let mut a = input.host_data()?.to_vec();
+                let mut s = vec![0.0 as $scalar; k];
+                let mut query = vec![0.0 as $scalar; 1];
+                let mut info = 0;
+                // SAFETY: `a` and `s` match the validated SVD dimensions;
+                // no-vector mode ignores the dummy U/VT buffers, and `lwork = -1` queries workspace.
+                unsafe {
+                    $gesvd(
+                        b'N',
+                        b'N',
+                        m_i32,
+                        n_i32,
+                        &mut a,
+                        m_i32,
+                        &mut s,
+                        &mut [],
+                        1,
+                        &mut [],
+                        1,
+                        &mut query,
+                        -1,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("svd_values", concat!($routine, "(work query)"), info)?;
+                let lwork = work_len(query[0] as f64, "svd_values", $routine)?;
+                let mut work = vec![0.0 as $scalar; lwork as usize];
+                // SAFETY: `a`, `s`, dummy no-vector buffers, and `work`
+                // satisfy the validated SVD dimensions and queried workspace length.
+                unsafe {
+                    $gesvd(
+                        b'N',
+                        b'N',
+                        m_i32,
+                        n_i32,
+                        &mut a,
+                        m_i32,
+                        &mut s,
+                        &mut [],
+                        1,
+                        &mut [],
+                        1,
+                        &mut work,
+                        lwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("svd_values", $routine, info)?;
+
+                tensor_from_vec_with_template(vec![k], s, input)
+            }
+        }
+    };
+}
+
+#[cfg(not(feature = "provider-inject"))]
 macro_rules! impl_real_svd {
     ($scalar:ty, $gesdd:path, $routine:literal) => {
         impl LapackSvd for $scalar {
@@ -153,6 +270,131 @@ macro_rules! impl_real_svd {
     };
 }
 
+#[cfg(feature = "provider-inject")]
+macro_rules! impl_complex_svd {
+    ($complex:ty, $real:ty, $gesvd:path, $routine:literal) => {
+        impl LapackSvd for $complex {
+            type Real = $real;
+
+            fn svd_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
+                let (m, n) = matrix_dims(input, "svd")?;
+                let k = m.min(n);
+                let m_i32 = dim_i32(m, "svd")?;
+                let n_i32 = dim_i32(n, "svd")?;
+                let k_i32 = dim_i32(k, "svd")?;
+
+                let mut a = input.host_data()?.to_vec();
+                let mut s = vec![0.0 as $real; k];
+                let mut u = vec![<$complex>::new(0.0, 0.0); m * k];
+                let mut vt = vec![<$complex>::new(0.0, 0.0); k * n];
+                let mut query = vec![<$complex>::new(0.0, 0.0); 1];
+                let mut rwork = vec![0.0 as $real; 5 * k.max(1)];
+                let mut info = 0;
+                // SAFETY: `a`, `s`, `u`, `vt`, and `rwork` match the
+                // validated complex SVD dimensions; `lwork = -1` queries workspace.
+                unsafe {
+                    $gesvd(
+                        b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
+                        k_i32, &mut query, -1, &mut rwork, &mut info,
+                    );
+                }
+                check_lapack_info("svd", concat!($routine, "(work query)"), info)?;
+                let lwork = work_len(query[0].re as f64, "svd", $routine)?;
+                let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                // SAFETY: buffers, real workspace, and leading dimensions
+                // match the validated complex SVD problem and queried workspace length.
+                unsafe {
+                    $gesvd(
+                        b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
+                        k_i32, &mut work, lwork, &mut rwork, &mut info,
+                    );
+                }
+                check_lapack_info("svd", $routine, info)?;
+
+                Ok(vec![
+                    tensor_from_vec_with_template(vec![m, k], u, input)?,
+                    tensor_from_vec_with_template(
+                        vec![k],
+                        s.into_iter()
+                            .map(|value| <$complex>::new(value, 0.0))
+                            .collect(),
+                        input,
+                    )?,
+                    tensor_from_vec_with_template(vec![k, n], vt, input)?,
+                ])
+            }
+
+            fn svd_values_2d(
+                _buffers: &mut BufferPool,
+                input: &TypedTensor<Self>,
+            ) -> tenferro_tensor::Result<TypedTensor<Self::Real>> {
+                let (m, n) = matrix_dims(input, "svd_values")?;
+                let k = m.min(n);
+                let m_i32 = dim_i32(m, "svd_values")?;
+                let n_i32 = dim_i32(n, "svd_values")?;
+
+                let mut a = input.host_data()?.to_vec();
+                let mut s = vec![0.0 as $real; k];
+                let mut query = vec![<$complex>::new(0.0, 0.0); 1];
+                let mut rwork = vec![0.0 as $real; 5 * k.max(1)];
+                let mut info = 0;
+                // SAFETY: `a`, `s`, and `rwork` match the validated complex
+                // SVD dimensions; no-vector mode ignores dummy U/VT buffers, and `lwork = -1` queries workspace.
+                unsafe {
+                    $gesvd(
+                        b'N',
+                        b'N',
+                        m_i32,
+                        n_i32,
+                        &mut a,
+                        m_i32,
+                        &mut s,
+                        &mut [],
+                        1,
+                        &mut [],
+                        1,
+                        &mut query,
+                        -1,
+                        &mut rwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("svd_values", concat!($routine, "(work query)"), info)?;
+                let lwork = work_len(query[0].re as f64, "svd_values", $routine)?;
+                let mut work = vec![<$complex>::new(0.0, 0.0); lwork as usize];
+                // SAFETY: `a`, `s`, dummy no-vector buffers, `work`, and
+                // `rwork` satisfy the validated complex SVD dimensions and queried workspace length.
+                unsafe {
+                    $gesvd(
+                        b'N',
+                        b'N',
+                        m_i32,
+                        n_i32,
+                        &mut a,
+                        m_i32,
+                        &mut s,
+                        &mut [],
+                        1,
+                        &mut [],
+                        1,
+                        &mut work,
+                        lwork,
+                        &mut rwork,
+                        &mut info,
+                    );
+                }
+                check_lapack_info("svd_values", $routine, info)?;
+
+                tensor_from_vec_with_template(vec![k], s, input)
+            }
+        }
+    };
+}
+
+#[cfg(not(feature = "provider-inject"))]
 macro_rules! impl_complex_svd {
     ($complex:ty, $real:ty, $gesdd:path, $routine:literal) => {
         impl LapackSvd for $complex {
@@ -278,10 +520,23 @@ macro_rules! impl_complex_svd {
     };
 }
 
+#[cfg(not(feature = "provider-inject"))]
 impl_real_svd!(f32, lapack::sgesdd, "sgesdd");
+#[cfg(not(feature = "provider-inject"))]
 impl_real_svd!(f64, lapack::dgesdd, "dgesdd");
+#[cfg(not(feature = "provider-inject"))]
 impl_complex_svd!(Complex32, f32, lapack::cgesdd, "cgesdd");
+#[cfg(not(feature = "provider-inject"))]
 impl_complex_svd!(Complex64, f64, lapack::zgesdd, "zgesdd");
+
+#[cfg(feature = "provider-inject")]
+impl_real_svd!(f32, lapack::sgesvd, "sgesvd");
+#[cfg(feature = "provider-inject")]
+impl_real_svd!(f64, lapack::dgesvd, "dgesvd");
+#[cfg(feature = "provider-inject")]
+impl_complex_svd!(Complex32, f32, lapack::cgesvd, "cgesvd");
+#[cfg(feature = "provider-inject")]
+impl_complex_svd!(Complex64, f64, lapack::zgesvd, "zgesvd");
 
 fn svd_2d<T: LapackSvd>(
     buffers: &mut BufferPool,

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
@@ -22,8 +22,24 @@ pub(crate) trait LapackSvd: Clone + Copy + Default + PoolScalar {
     ) -> tenferro_tensor::Result<TypedTensor<Self::Real>>;
 }
 
+fn gesdd_iwork_len(k: usize) -> usize {
+    8 * k.max(1)
+}
+
+fn complex_gesdd_rwork_len(jobz: u8, m: usize, n: usize) -> usize {
+    let mn = m.min(n);
+    let mx = m.max(n);
+    if jobz == b'N' {
+        return 5 * mn.max(1);
+    }
+    if mx > 10 * mn {
+        return 5 * mn * mn + 5 * mn;
+    }
+    (5 * mn * mn + 5 * mn).max(2 * mx * mn + 2 * mn * mn + mn)
+}
+
 macro_rules! impl_real_svd {
-    ($scalar:ty, $gesvd:path, $routine:literal) => {
+    ($scalar:ty, $gesdd:path, $routine:literal) => {
         impl LapackSvd for $scalar {
             type Real = $scalar;
 
@@ -42,13 +58,14 @@ macro_rules! impl_real_svd {
                 let mut u = vec![0.0 as $scalar; m * k];
                 let mut vt = vec![0.0 as $scalar; k * n];
                 let mut query = vec![0.0 as $scalar; 1];
+                let mut iwork = vec![0; gesdd_iwork_len(k)];
                 let mut info = 0;
                 // SAFETY: `a`, `s`, `u`, and `vt` match the validated SVD
                 // dimensions, and `lwork = -1` makes `query` the workspace output.
                 unsafe {
-                    $gesvd(
-                        b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
-                        k_i32, &mut query, -1, &mut info,
+                    $gesdd(
+                        b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt, k_i32,
+                        &mut query, -1, &mut iwork, &mut info,
                     );
                 }
                 check_lapack_info("svd", concat!($routine, "(work query)"), info)?;
@@ -57,9 +74,9 @@ macro_rules! impl_real_svd {
                 // SAFETY: buffers and leading dimensions match the validated
                 // SVD problem, and `work` uses the queried workspace length.
                 unsafe {
-                    $gesvd(
-                        b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
-                        k_i32, &mut work, lwork, &mut info,
+                    $gesdd(
+                        b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt, k_i32,
+                        &mut work, lwork, &mut iwork, &mut info,
                     );
                 }
                 check_lapack_info("svd", $routine, info)?;
@@ -83,12 +100,12 @@ macro_rules! impl_real_svd {
                 let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $scalar; k];
                 let mut query = vec![0.0 as $scalar; 1];
+                let mut iwork = vec![0; gesdd_iwork_len(k)];
                 let mut info = 0;
                 // SAFETY: `a` and `s` match the validated SVD dimensions;
                 // no-vector mode ignores the dummy U/VT buffers, and `lwork = -1` queries workspace.
                 unsafe {
-                    $gesvd(
-                        b'N',
+                    $gesdd(
                         b'N',
                         m_i32,
                         n_i32,
@@ -101,6 +118,7 @@ macro_rules! impl_real_svd {
                         1,
                         &mut query,
                         -1,
+                        &mut iwork,
                         &mut info,
                     );
                 }
@@ -110,8 +128,7 @@ macro_rules! impl_real_svd {
                 // SAFETY: `a`, `s`, dummy no-vector buffers, and `work`
                 // satisfy the validated SVD dimensions and queried workspace length.
                 unsafe {
-                    $gesvd(
-                        b'N',
+                    $gesdd(
                         b'N',
                         m_i32,
                         n_i32,
@@ -124,6 +141,7 @@ macro_rules! impl_real_svd {
                         1,
                         &mut work,
                         lwork,
+                        &mut iwork,
                         &mut info,
                     );
                 }
@@ -136,7 +154,7 @@ macro_rules! impl_real_svd {
 }
 
 macro_rules! impl_complex_svd {
-    ($complex:ty, $real:ty, $gesvd:path, $routine:literal) => {
+    ($complex:ty, $real:ty, $gesdd:path, $routine:literal) => {
         impl LapackSvd for $complex {
             type Real = $real;
 
@@ -155,14 +173,15 @@ macro_rules! impl_complex_svd {
                 let mut u = vec![<$complex>::new(0.0, 0.0); m * k];
                 let mut vt = vec![<$complex>::new(0.0, 0.0); k * n];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
-                let mut rwork = vec![0.0 as $real; 5 * k.max(1)];
+                let mut rwork = vec![0.0 as $real; complex_gesdd_rwork_len(b'S', m, n)];
+                let mut iwork = vec![0; gesdd_iwork_len(k)];
                 let mut info = 0;
                 // SAFETY: `a`, `s`, `u`, `vt`, and `rwork` match the
                 // validated complex SVD dimensions; `lwork = -1` queries workspace.
                 unsafe {
-                    $gesvd(
-                        b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
-                        k_i32, &mut query, -1, &mut rwork, &mut info,
+                    $gesdd(
+                        b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt, k_i32,
+                        &mut query, -1, &mut rwork, &mut iwork, &mut info,
                     );
                 }
                 check_lapack_info("svd", concat!($routine, "(work query)"), info)?;
@@ -171,9 +190,9 @@ macro_rules! impl_complex_svd {
                 // SAFETY: buffers, real workspace, and leading dimensions
                 // match the validated complex SVD problem and queried workspace length.
                 unsafe {
-                    $gesvd(
-                        b'S', b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt,
-                        k_i32, &mut work, lwork, &mut rwork, &mut info,
+                    $gesdd(
+                        b'S', m_i32, n_i32, &mut a, m_i32, &mut s, &mut u, m_i32, &mut vt, k_i32,
+                        &mut work, lwork, &mut rwork, &mut iwork, &mut info,
                     );
                 }
                 check_lapack_info("svd", $routine, info)?;
@@ -203,13 +222,13 @@ macro_rules! impl_complex_svd {
                 let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $real; k];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
-                let mut rwork = vec![0.0 as $real; 5 * k.max(1)];
+                let mut rwork = vec![0.0 as $real; complex_gesdd_rwork_len(b'N', m, n)];
+                let mut iwork = vec![0; gesdd_iwork_len(k)];
                 let mut info = 0;
                 // SAFETY: `a`, `s`, and `rwork` match the validated complex
                 // SVD dimensions; no-vector mode ignores dummy U/VT buffers, and `lwork = -1` queries workspace.
                 unsafe {
-                    $gesvd(
-                        b'N',
+                    $gesdd(
                         b'N',
                         m_i32,
                         n_i32,
@@ -223,6 +242,7 @@ macro_rules! impl_complex_svd {
                         &mut query,
                         -1,
                         &mut rwork,
+                        &mut iwork,
                         &mut info,
                     );
                 }
@@ -232,8 +252,7 @@ macro_rules! impl_complex_svd {
                 // SAFETY: `a`, `s`, dummy no-vector buffers, `work`, and
                 // `rwork` satisfy the validated complex SVD dimensions and queried workspace length.
                 unsafe {
-                    $gesvd(
-                        b'N',
+                    $gesdd(
                         b'N',
                         m_i32,
                         n_i32,
@@ -247,6 +266,7 @@ macro_rules! impl_complex_svd {
                         &mut work,
                         lwork,
                         &mut rwork,
+                        &mut iwork,
                         &mut info,
                     );
                 }
@@ -258,10 +278,10 @@ macro_rules! impl_complex_svd {
     };
 }
 
-impl_real_svd!(f32, lapack::sgesvd, "sgesvd");
-impl_real_svd!(f64, lapack::dgesvd, "dgesvd");
-impl_complex_svd!(Complex32, f32, lapack::cgesvd, "cgesvd");
-impl_complex_svd!(Complex64, f64, lapack::zgesvd, "zgesvd");
+impl_real_svd!(f32, lapack::sgesdd, "sgesdd");
+impl_real_svd!(f64, lapack::dgesdd, "dgesdd");
+impl_complex_svd!(Complex32, f32, lapack::cgesdd, "cgesdd");
+impl_complex_svd!(Complex64, f64, lapack::zgesdd, "zgesdd");
 
 fn svd_2d<T: LapackSvd>(
     buffers: &mut BufferPool,

--- a/crates/tenferro-linalg/tests/inject_tests.rs
+++ b/crates/tenferro-linalg/tests/inject_tests.rs
@@ -8,7 +8,7 @@ use tenferro_cpu::inject::{
     register_blas_gemm_provider_ptrs, register_lapack_provider_ptrs, BlasGemmProviderPtrSet,
     LapackProviderPtrSet, ProviderAbi,
 };
-use tenferro_cpu::CpuBackend;
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
 use tenferro_linalg::LinalgBackend;
 use tenferro_tensor::{DotGeneralConfig, Tensor, TensorDot, TypedTensor};
 
@@ -19,6 +19,7 @@ static DGETC2_CALLS: AtomicUsize = AtomicUsize::new(0);
 static DGESC2_CALLS: AtomicUsize = AtomicUsize::new(0);
 static DGETRF_CALLS: AtomicUsize = AtomicUsize::new(0);
 static DGETRS_CALLS: AtomicUsize = AtomicUsize::new(0);
+static DGESVD_CALLS: AtomicUsize = AtomicUsize::new(0);
 
 fn register_test_ptrs_once() {
     REGISTER_ONCE.call_once(|| unsafe {
@@ -37,6 +38,7 @@ fn register_test_ptrs_once() {
                 dgesc2: Some(test_dgesc2 as *const c_void),
                 dgetrf: Some(test_dgetrf as *const c_void),
                 dgetrs: Some(test_dgetrs as *const c_void),
+                dgesvd: Some(test_dgesvd as *const c_void),
                 ..LapackProviderPtrSet::new()
             },
         )
@@ -164,6 +166,63 @@ unsafe extern "C" fn test_dgetrs(
     info: *mut lapack_inject::lapackint,
 ) {
     DGETRS_CALLS.fetch_add(1, Ordering::SeqCst);
+    unsafe {
+        *info = 0;
+    }
+}
+
+unsafe extern "C" fn test_dgesvd(
+    _jobu: *const c_char,
+    _jobvt: *const c_char,
+    m: *const lapack_inject::lapackint,
+    n: *const lapack_inject::lapackint,
+    _a: *mut f64,
+    _lda: *const lapack_inject::lapackint,
+    s: *mut f64,
+    u: *mut f64,
+    ldu: *const lapack_inject::lapackint,
+    vt: *mut f64,
+    ldvt: *const lapack_inject::lapackint,
+    work: *mut f64,
+    lwork: *const lapack_inject::lapackint,
+    info: *mut lapack_inject::lapackint,
+) {
+    DGESVD_CALLS.fetch_add(1, Ordering::SeqCst);
+    if unsafe { *lwork } == -1 {
+        unsafe {
+            *work = 16.0;
+            *info = 0;
+        }
+        return;
+    }
+
+    let m = unsafe { *m as usize };
+    let n = unsafe { *n as usize };
+    let k = m.min(n);
+    for index in 0..k {
+        unsafe {
+            *s.add(index) = if index == 0 { 3.0 } else { 2.0 };
+        }
+    }
+
+    let ldu = unsafe { *ldu as usize };
+    for col in 0..k {
+        for row in 0..m {
+            unsafe {
+                *u.add(row + col * ldu) = if row == col { 1.0 } else { 0.0 };
+            }
+        }
+    }
+
+    let ldvt = unsafe { *ldvt as usize };
+    for col in 0..n {
+        for row in 0..k {
+            unsafe {
+                *vt.add(row + col * ldvt) = if row == col { 1.0 } else { 0.0 };
+            }
+        }
+    }
+
     unsafe {
         *info = 0;
     }
@@ -308,5 +367,27 @@ fn provider_inject_solve_uses_registered_lapack_getrf_getrs() {
     match x {
         Ok(Tensor::F64(inner)) => assert_eq!(inner.host_data().unwrap(), &[4.0, 8.0]),
         _ => panic!("expected f64 tensor"),
+    }
+}
+
+#[test]
+fn provider_inject_svd_uses_registered_lapack_gesvd() {
+    let _guard = TEST_LOCK
+        .lock()
+        .expect("provider-inject test lock poisoned");
+    register_test_ptrs_once();
+    DGESVD_CALLS.store(0, Ordering::SeqCst);
+
+    let a =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![3.0, 0.0, 0.0, 2.0]).unwrap());
+
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Blas).unwrap();
+    let outputs = backend.svd(&a).expect("provider-inject SVD should run");
+
+    assert_eq!(DGESVD_CALLS.load(Ordering::SeqCst), 2);
+    assert_eq!(outputs.len(), 3);
+    match &outputs[1] {
+        Tensor::F64(inner) => assert_eq!(inner.host_data().unwrap(), &[3.0, 2.0]),
+        _ => panic!("expected f64 singular values"),
     }
 }


### PR DESCRIPTION
## Summary

- Switch the CPU LAPACK SVD path from `gesvd` to divide-and-conquer `gesdd`.
- Add the `gesdd` integer workspace and complex real-workspace sizing for full SVD and singular-value-only calls.
- Keep the existing reduced SVD shape contract (`U: m x k`, `VT: k x n`).

## Why

The OpenBLAS-backed `gesvd` path made `grad_sum_svd_s_jvp` and `grad_sum_svd_s_vjp` unusually slow in the benchmark suite. PyTorch uses the faster divide-and-conquer SVD path for the comparable CPU workload, so this brings tenferro's OpenBLAS path closer to that behavior.

## Validation

- `cargo fmt --manifest-path extern/tenferro-rs/Cargo.toml --all`
- devcontainer: `cargo test -p tenferro-linalg --no-default-features --features "cpu-blas blas-openblas" svd -- --nocapture`
- devcontainer benchmark rerun through `./scripts/reproduce_linux_cpu_linalg_jvp_jvp.sh 1 4` from the benchmark repository
- OpenBLAS runtime check: `OpenBLAS 0.3.26 ... MAX_THREADS=64`, `openblas_get_parallel=1`