### PR TITLE
[codex] Add LU and QR transpose AD rules

### DIFF
--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -183,13 +183,13 @@ impl ExtensionAdRule for LinalgAdRule {
             LinalgOp::EighVals { eps } => {
                 rules::transpose_eigh_values(&mut builder, cotangent_out, inputs, mode, eps, ctx)
             }
+            LinalgOp::Lu => rules::transpose_lu(&mut builder, cotangent_out, inputs, mode, ctx),
+            LinalgOp::Qr => rules::transpose_qr(&mut builder, cotangent_out, inputs, mode, ctx),
             LinalgOp::Cholesky
-            | LinalgOp::Lu
             | LinalgOp::LuFactor
             | LinalgOp::FullPivLu
             | LinalgOp::Svd { .. }
             | LinalgOp::SvdVals { .. }
-            | LinalgOp::Qr
             | LinalgOp::Eig { .. }
             | LinalgOp::EigVals { .. } => Ok(vec![None; op.input_count()]),
         }
@@ -265,6 +265,46 @@ mod tests {
         insert_typed_meta(&mut ctx, w.clone(), DType::F64, &[2]);
         insert_typed_meta(&mut ctx, v.clone(), DType::F64, &[2, 2]);
         (ctx, a, vec![w, v])
+    }
+
+    fn lu_context(
+        shape: &[usize],
+    ) -> (
+        ShapeGuardContext,
+        ValueKey<StdTensorOp>,
+        Vec<ValueKey<StdTensorOp>>,
+    ) {
+        let mut ctx = ShapeGuardContext::default();
+        let a = input_key(4);
+        let p = input_key(5);
+        let l = input_key(6);
+        let u = input_key(7);
+        let parity = input_key(8);
+        let k = shape[0].min(shape[1]);
+        insert_typed_meta(&mut ctx, a.clone(), DType::F64, shape);
+        insert_typed_meta(&mut ctx, p.clone(), DType::F64, &[shape[0], shape[0]]);
+        insert_typed_meta(&mut ctx, l.clone(), DType::F64, &[shape[0], k]);
+        insert_typed_meta(&mut ctx, u.clone(), DType::F64, &[k, shape[1]]);
+        insert_typed_meta(&mut ctx, parity.clone(), DType::F64, &[]);
+        (ctx, a, vec![p, l, u, parity])
+    }
+
+    fn qr_context(
+        shape: &[usize],
+    ) -> (
+        ShapeGuardContext,
+        ValueKey<StdTensorOp>,
+        Vec<ValueKey<StdTensorOp>>,
+    ) {
+        let mut ctx = ShapeGuardContext::default();
+        let a = input_key(9);
+        let q = input_key(10);
+        let r = input_key(11);
+        let k = shape[0].min(shape[1]);
+        insert_typed_meta(&mut ctx, a.clone(), DType::F64, shape);
+        insert_typed_meta(&mut ctx, q.clone(), DType::F64, &[shape[0], k]);
+        insert_typed_meta(&mut ctx, r.clone(), DType::F64, &[k, shape[1]]);
+        (ctx, a, vec![q, r])
     }
 
     #[test]
@@ -569,6 +609,67 @@ mod tests {
 
             assert!(result[0].is_some(), "{case}");
             assert!(!builder.build().operations().is_empty(), "{case}");
+        }
+    }
+
+    #[test]
+    fn lu_qr_transpose_reuses_primal_outputs_for_factor_cotangents() {
+        for shape in [&[2, 2][..], &[2, 3][..], &[3, 2][..]] {
+            let (mut ctx, a, primal_outputs) = lu_context(shape);
+            let mut builder = GraphBuilder::<StdTensorOp>::new();
+            let g_l = builder.add_input(TensorInputKey::User { id: 100 });
+            let g_u = builder.add_input(TensorInputKey::User { id: 101 });
+            ctx.set_transpose_primal_outputs(Some(primal_outputs));
+
+            let result = LinalgAdRule
+                .transpose_rule(
+                    &LinalgExtensionOp::new(LinalgOp::Lu),
+                    &mut builder,
+                    &[None, Some(g_l), Some(g_u), None],
+                    &[ValueRef::External(a)],
+                    &OperationRole::Primary,
+                    &mut ctx,
+                )
+                .unwrap();
+
+            assert!(result[0].is_some(), "lu shape {shape:?}");
+            assert!(
+                ctx.transpose_primal_outputs_were_used(),
+                "lu shape {shape:?}"
+            );
+            assert!(
+                !builder.build().operations().is_empty(),
+                "lu shape {shape:?}"
+            );
+        }
+
+        for shape in [&[3, 2][..], &[2, 3][..]] {
+            let (mut ctx, a, primal_outputs) = qr_context(shape);
+            let mut builder = GraphBuilder::<StdTensorOp>::new();
+            let g_q = builder.add_input(TensorInputKey::User { id: 102 });
+            let g_r = builder.add_input(TensorInputKey::User { id: 103 });
+            ctx.set_transpose_primal_outputs(Some(primal_outputs));
+
+            let result = LinalgAdRule
+                .transpose_rule(
+                    &LinalgExtensionOp::new(LinalgOp::Qr),
+                    &mut builder,
+                    &[Some(g_q), Some(g_r)],
+                    &[ValueRef::External(a)],
+                    &OperationRole::Primary,
+                    &mut ctx,
+                )
+                .unwrap();
+
+            assert!(result[0].is_some(), "qr shape {shape:?}");
+            assert!(
+                ctx.transpose_primal_outputs_were_used(),
+                "qr shape {shape:?}"
+            );
+            assert!(
+                !builder.build().operations().is_empty(),
+                "qr shape {shape:?}"
+            );
         }
     }
 

--- a/crates/tenferro-linalg/src/ad/rules/decomposition_transpose.rs
+++ b/crates/tenferro-linalg/src/ad/rules/decomposition_transpose.rs
@@ -1,0 +1,445 @@
+use computegraph::types::{LocalValueId, OperationRole, ValueRef};
+use tenferro_ops::ad::context::{resolve_and_guard, ShapeGuardContext};
+use tenferro_ops::ad::PrimitiveRuleBuilder;
+use tenferro_ops::dim_expr::DimExpr;
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_tensor::DType;
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
+
+use crate::extension::LinalgOp;
+
+use super::support::*;
+use super::{conjugate_primal_if_dtype_complex, linalg_std_op};
+
+fn transpose_input_active(mode: &OperationRole, input_index: usize) -> bool {
+    match mode {
+        OperationRole::Primary => true,
+        OperationRole::Linearized { active_mask } => {
+            active_mask.get(input_index).copied().unwrap_or(false)
+        }
+    }
+}
+
+fn matrix_shape_from_input(
+    ctx: &mut ShapeGuardContext,
+    input: &ValueRef<StdTensorOp>,
+) -> ADRuleResult<Option<Vec<DimExpr>>> {
+    if let Some(exact_shape) = ctx.shape_if_available(input) {
+        return if let Some(concrete) = exact_shape
+            .iter()
+            .map(|dim| dim.constant_value())
+            .collect::<Option<Vec<_>>>()
+        {
+            Ok((concrete.len() >= 2).then(|| DimExpr::from_concrete(&concrete)))
+        } else {
+            Ok((exact_shape.len() >= 2).then(|| DimExpr::input_shape(0, exact_shape.len())))
+        };
+    }
+
+    let rank = ctx.rank_of(input)?;
+    Ok((rank >= 2).then(|| DimExpr::input_shape(0, rank)))
+}
+
+fn invalid_transpose_dim_expr(op: &'static str, err: impl std::fmt::Display) -> ADRuleError {
+    ADRuleError::invalid_input(
+        format!("tenferro-linalg.{op}"),
+        ADRuleKind::Transpose,
+        format!("invalid matrix dimension expression: {err}"),
+    )
+}
+
+fn expected_primal_outputs_error(op: &'static str, expected: usize) -> ADRuleError {
+    ADRuleError::invalid_input(
+        format!("tenferro-linalg.{op}"),
+        ADRuleKind::Transpose,
+        format!("expected {expected} primal outputs for primary transpose"),
+    )
+}
+
+fn lu_primal_outputs(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<(
+    ValueRef<StdTensorOp>,
+    ValueRef<StdTensorOp>,
+    ValueRef<StdTensorOp>,
+)> {
+    if let Some(primal_outputs) = ctx.transpose_primal_outputs() {
+        if primal_outputs.len() < 4 {
+            return Err(expected_primal_outputs_error("lu", 4));
+        }
+        return Ok((
+            ValueRef::External(primal_outputs[0].clone()),
+            ValueRef::External(primal_outputs[1].clone()),
+            ValueRef::External(primal_outputs[2].clone()),
+        ));
+    }
+
+    let outputs = builder.add_operation(
+        linalg_std_op(LinalgOp::Lu),
+        vec![input],
+        OperationRole::Primary,
+    );
+    Ok((
+        ValueRef::Local(outputs[0]),
+        ValueRef::Local(outputs[1]),
+        ValueRef::Local(outputs[2]),
+    ))
+}
+
+fn qr_primal_outputs(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: ValueRef<StdTensorOp>,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<(ValueRef<StdTensorOp>, ValueRef<StdTensorOp>)> {
+    if let Some(primal_outputs) = ctx.transpose_primal_outputs() {
+        if primal_outputs.len() < 2 {
+            return Err(expected_primal_outputs_error("qr", 2));
+        }
+        return Ok((
+            ValueRef::External(primal_outputs[0].clone()),
+            ValueRef::External(primal_outputs[1].clone()),
+        ));
+    }
+
+    let outputs = builder.add_operation(
+        linalg_std_op(LinalgOp::Qr),
+        vec![input],
+        OperationRole::Primary,
+    );
+    Ok((ValueRef::Local(outputs[0]), ValueRef::Local(outputs[1])))
+}
+
+fn add_optional_linear(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lhs: Option<LocalValueId>,
+    rhs: LocalValueId,
+) -> LocalValueId {
+    match lhs {
+        Some(lhs) => linear_add(builder, lhs, rhs),
+        None => rhs,
+    }
+}
+
+fn left_solve_lower_adjoint(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    lower: ValueRef<StdTensorOp>,
+    rhs: LocalValueId,
+    unit_diagonal: bool,
+    dtype: DType,
+) -> LocalValueId {
+    let lower = conjugate_primal_if_dtype_complex(builder, lower, dtype);
+    builder.add_operation(
+        linalg_std_op(LinalgOp::TriangularSolve {
+            left_side: true,
+            lower: true,
+            transpose_a: true,
+            unit_diagonal,
+        }),
+        vec![lower, ValueRef::Local(rhs)],
+        OperationRole::Linearized {
+            active_mask: vec![false, true],
+        },
+    )[0]
+}
+
+fn right_solve_upper_adjoint(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    upper: ValueRef<StdTensorOp>,
+    rhs: LocalValueId,
+    dtype: DType,
+) -> LocalValueId {
+    let upper = conjugate_primal_if_dtype_complex(builder, upper, dtype);
+    builder.add_operation(
+        linalg_std_op(LinalgOp::TriangularSolve {
+            left_side: false,
+            lower: false,
+            transpose_a: true,
+            unit_diagonal: false,
+        }),
+        vec![upper, ValueRef::Local(rhs)],
+        OperationRole::Linearized {
+            active_mask: vec![false, true],
+        },
+    )[0]
+}
+
+fn tril_im_inv_adj_skew_linear(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
+    rank: usize,
+    dtype: DType,
+) -> LocalValueId {
+    let input_h = adjoint_matrix_linear(builder, input, rank, dtype);
+    let skew = linear_sub(builder, input, input_h);
+    let strict_lower = linear_unary(builder, StdTensorOp::Tril { k: -1 }, skew);
+    let diag = extract_diag_linear(builder, skew);
+    let half_diag = linear_scale(builder, diag, 0.5);
+    let half_diag_mat = embed_diag_linear(builder, half_diag);
+    linear_add(builder, strict_lower, half_diag_mat)
+}
+
+pub(crate) fn transpose_lu(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    if !transpose_input_active(mode, 0) {
+        return Ok(vec![None]);
+    }
+
+    let g_l = cotangent_out.get(1).copied().flatten();
+    let g_u = cotangent_out.get(2).copied().flatten();
+    if g_l.is_none() && g_u.is_none() {
+        return Ok(vec![None]);
+    }
+
+    let input = inputs.first().ok_or_else(|| {
+        ADRuleError::invalid_input(
+            "tenferro-linalg.lu",
+            ADRuleKind::Transpose,
+            "expected one matrix input",
+        )
+    })?;
+    let Some(input_shape) = matrix_shape_from_input(ctx, input)? else {
+        return Ok(vec![None]);
+    };
+    let input_shape = input_shape.as_slice();
+    let (m, n, batch_shape) = matrix_shape_parts(input_shape, "transpose_lu");
+    let (m_size, n_size) =
+        resolve_and_guard(m, n, ctx).map_err(|err| invalid_transpose_dim_expr("lu", err))?;
+    let k = DimExpr::min(m.clone(), n.clone());
+    let k_size = m_size.min(n_size);
+    let rank = input_shape.len();
+    let dtype = ctx.dtype_of(input)?;
+    let (p, l, u) = lu_primal_outputs(builder, input.clone(), ctx)?;
+    let l_shape = matrix_shape(m, &k, batch_shape);
+    let u_shape = matrix_shape(&k, n, batch_shape);
+    let l_square = augment_unit_lower_to_square_fixed(
+        builder,
+        l.clone(),
+        m_size,
+        k_size,
+        batch_shape,
+        &l_shape,
+        rank,
+    );
+    let u_square = augment_upper_to_square_fixed(
+        builder,
+        u.clone(),
+        k_size,
+        n_size,
+        batch_shape,
+        &u_shape,
+        rank,
+    );
+
+    let mut f_sum = None;
+    if let Some(g_l) = g_l {
+        let g_l = if n_size > k_size {
+            pad_linear(
+                builder,
+                g_l,
+                rank,
+                vec![0; rank],
+                pad_vec(rank, 1, (n_size - k_size) as i64),
+            )
+        } else {
+            g_l
+        };
+        let l_h = adjoint_matrix_fixed(builder, ValueRef::Local(l_square), rank, dtype);
+        let term = matmul_linear(
+            builder,
+            ValueRef::Local(l_h),
+            ValueRef::Local(g_l),
+            vec![false, true],
+            rank,
+        );
+        let term = linear_unary(builder, StdTensorOp::Tril { k: -1 }, term);
+        f_sum = Some(add_optional_linear(builder, f_sum, term));
+    }
+    if let Some(g_u) = g_u {
+        let g_u = if m_size > k_size {
+            pad_linear(
+                builder,
+                g_u,
+                rank,
+                vec![0; rank],
+                pad_vec(rank, 0, (m_size - k_size) as i64),
+            )
+        } else {
+            g_u
+        };
+        let u_h = adjoint_matrix_fixed(builder, ValueRef::Local(u_square), rank, dtype);
+        let term = matmul_linear(
+            builder,
+            ValueRef::Local(g_u),
+            ValueRef::Local(u_h),
+            vec![true, false],
+            rank,
+        );
+        let term = linear_unary(builder, StdTensorOp::Triu { k: 0 }, term);
+        f_sum = Some(add_optional_linear(builder, f_sum, term));
+    }
+
+    let Some(f_sum) = f_sum else {
+        return Ok(vec![None]);
+    };
+    let y = left_solve_lower_adjoint(builder, ValueRef::Local(l_square), f_sum, true, dtype);
+    let z = right_solve_upper_adjoint(builder, ValueRef::Local(u_square), y, dtype);
+    let p_t = transpose_matrix_fixed(builder, p, rank);
+    let da = matmul_linear(
+        builder,
+        ValueRef::Local(p_t),
+        ValueRef::Local(z),
+        vec![false, true],
+        rank,
+    );
+    Ok(vec![Some(da)])
+}
+
+pub(crate) fn transpose_qr(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    mode: &OperationRole,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    if !transpose_input_active(mode, 0) {
+        return Ok(vec![None]);
+    }
+
+    let g_q = cotangent_out.first().copied().flatten();
+    let g_r = cotangent_out.get(1).copied().flatten();
+    if g_q.is_none() && g_r.is_none() {
+        return Ok(vec![None]);
+    }
+
+    let input = inputs.first().ok_or_else(|| {
+        ADRuleError::invalid_input(
+            "tenferro-linalg.qr",
+            ADRuleKind::Transpose,
+            "expected one matrix input",
+        )
+    })?;
+    let Some(input_shape) = matrix_shape_from_input(ctx, input)? else {
+        return Ok(vec![None]);
+    };
+    let input_shape = input_shape.as_slice();
+    let (m, n, batch_shape) = matrix_shape_parts(input_shape, "transpose_qr");
+    let (m_size, n_size) =
+        resolve_and_guard(m, n, ctx).map_err(|err| invalid_transpose_dim_expr("qr", err))?;
+    let rank = input_shape.len();
+    let dtype = ctx.dtype_of(input)?;
+    let (q, r) = qr_primal_outputs(builder, input.clone(), ctx)?;
+
+    if m_size >= n_size {
+        let mut w_sum = None;
+        if let Some(g_r) = g_r {
+            let g_r_h = adjoint_matrix_linear(builder, g_r, rank, dtype);
+            let term = matmul_linear(
+                builder,
+                r.clone(),
+                ValueRef::Local(g_r_h),
+                vec![false, true],
+                rank,
+            );
+            w_sum = Some(add_optional_linear(builder, w_sum, term));
+        }
+        if let Some(g_q) = g_q {
+            let g_q_h = adjoint_matrix_linear(builder, g_q, rank, dtype);
+            let term = matmul_linear(
+                builder,
+                ValueRef::Local(g_q_h),
+                q.clone(),
+                vec![true, false],
+                rank,
+            );
+            let term = linear_neg(builder, term);
+            w_sum = Some(add_optional_linear(builder, w_sum, term));
+        }
+        let Some(w_sum) = w_sum else {
+            return Ok(vec![None]);
+        };
+        let h_sum = self_adjoint_from_lower_linear(builder, w_sum, rank, dtype);
+        let q_h_sum = matmul_linear(
+            builder,
+            q.clone(),
+            ValueRef::Local(h_sum),
+            vec![false, true],
+            rank,
+        );
+        let rhs = match g_q {
+            Some(g_q) => linear_add(builder, g_q, q_h_sum),
+            None => q_h_sum,
+        };
+        let da = right_solve_upper_adjoint(builder, r, rhs, dtype);
+        return Ok(vec![Some(da)]);
+    }
+
+    let mut result = None;
+    if let Some(g_r) = g_r {
+        let direct = matmul_linear(
+            builder,
+            q.clone(),
+            ValueRef::Local(g_r),
+            vec![false, true],
+            rank,
+        );
+        result = Some(add_optional_linear(builder, result, direct));
+    }
+
+    let mut x = None;
+    if let Some(g_q) = g_q {
+        let q_h = adjoint_matrix_fixed(builder, q.clone(), rank, dtype);
+        let term = matmul_linear(
+            builder,
+            ValueRef::Local(q_h),
+            ValueRef::Local(g_q),
+            vec![false, true],
+            rank,
+        );
+        x = Some(add_optional_linear(builder, x, term));
+    }
+    if let Some(g_r) = g_r {
+        let r_h = adjoint_matrix_fixed(builder, r.clone(), rank, dtype);
+        let term = matmul_linear(
+            builder,
+            ValueRef::Local(g_r),
+            ValueRef::Local(r_h),
+            vec![true, false],
+            rank,
+        );
+        let term = linear_neg(builder, term);
+        x = Some(add_optional_linear(builder, x, term));
+    }
+    if let Some(x) = x {
+        let helper = tril_im_inv_adj_skew_linear(builder, x, rank, dtype);
+        let q_helper = matmul_linear(builder, q, ValueRef::Local(helper), vec![false, true], rank);
+        let leading_selector = leading_column_selector_fixed(
+            builder,
+            m_size,
+            n_size,
+            batch_shape,
+            r.clone(),
+            input_shape,
+        );
+        let leading_selector_t =
+            transpose_matrix_fixed(builder, ValueRef::Local(leading_selector), rank);
+        let r_leading = matmul_fixed(builder, r, ValueRef::Local(leading_selector_t), rank);
+        let lead = right_solve_upper_adjoint(builder, ValueRef::Local(r_leading), q_helper, dtype);
+        let padded = pad_linear(
+            builder,
+            lead,
+            rank,
+            vec![0; rank],
+            pad_vec(rank, 1, (n_size - m_size) as i64),
+        );
+        result = Some(add_optional_linear(builder, result, padded));
+    }
+
+    Ok(vec![result])
+}

--- a/crates/tenferro-linalg/src/ad/rules/mod.rs
+++ b/crates/tenferro-linalg/src/ad/rules/mod.rs
@@ -32,10 +32,12 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::DType;
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
+mod decomposition_transpose;
 mod eigh;
 mod solve;
 mod support;
 
+pub(crate) use decomposition_transpose::{transpose_lu, transpose_qr};
 pub(crate) use eigh::{transpose_eigh, transpose_eigh_values};
 pub(crate) use solve::{
     linearize_full_piv_lu_solve, linearize_lu_solve_prepared, linearize_triangular_solve,

--- a/crates/tenferro-linalg/src/ad/rules/support.rs
+++ b/crates/tenferro-linalg/src/ad/rules/support.rs
@@ -213,6 +213,26 @@ pub(super) fn pad_fixed(
     )
 }
 
+pub(super) fn pad_linear(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    input: LocalValueId,
+    rank: usize,
+    edge_padding_low: Vec<i64>,
+    edge_padding_high: Vec<i64>,
+) -> LocalValueId {
+    builder.add_operation(
+        StdTensorOp::Pad(PadConfig {
+            edge_padding_low,
+            edge_padding_high,
+            interior_padding: vec![0; rank],
+        }),
+        vec![ValueRef::Local(input)],
+        OperationRole::Linearized {
+            active_mask: vec![true],
+        },
+    )[0]
+}
+
 pub(super) fn fixed_sub(
     builder: &mut dyn PrimitiveRuleBuilder,
     lhs: ValueRef<StdTensorOp>,

--- a/crates/tenferro-linalg/src/ad/support.rs
+++ b/crates/tenferro-linalg/src/ad/support.rs
@@ -239,7 +239,7 @@ static LINALG_AD_SUPPORT: [LinalgAdSupport; LinalgAdOpKind::COUNT] = [
     LinalgAdSupport {
         kind: LinalgAdOpKind::Lu,
         linearize: LinalgAdRuleSupport::PartiallySupported,
-        transpose: LinalgAdRuleSupport::Unsupported,
+        transpose: LinalgAdRuleSupport::Supported,
         outputs: &LU_OUTPUTS,
     },
     LinalgAdSupport {
@@ -281,7 +281,7 @@ static LINALG_AD_SUPPORT: [LinalgAdSupport; LinalgAdOpKind::COUNT] = [
     LinalgAdSupport {
         kind: LinalgAdOpKind::Qr,
         linearize: LinalgAdRuleSupport::SupportedViaLinearize,
-        transpose: LinalgAdRuleSupport::Unsupported,
+        transpose: LinalgAdRuleSupport::Supported,
         outputs: &QR_OUTPUTS,
     },
     LinalgAdSupport {

--- a/crates/tenferro-linalg/tests/ad_support_manifest.rs
+++ b/crates/tenferro-linalg/tests/ad_support_manifest.rs
@@ -50,6 +50,7 @@ fn linalg_ad_support_manifest_covers_all_dispatch_arms_in_order() {
 fn linalg_ad_support_manifest_marks_partial_decomposition_outputs() {
     let lu = linalg_ad_support(LinalgAdOpKind::Lu);
     assert_eq!(lu.linearize, LinalgAdRuleSupport::PartiallySupported);
+    assert_eq!(lu.transpose, LinalgAdRuleSupport::Supported);
     assert_output_status(lu, "p", LinalgAdRuleSupport::NonDifferentiable);
     assert_output_status(lu, "l", LinalgAdRuleSupport::SupportedViaLinearize);
     assert_output_status(lu, "u", LinalgAdRuleSupport::SupportedViaLinearize);
@@ -73,6 +74,12 @@ fn linalg_ad_support_manifest_marks_partial_decomposition_outputs() {
 
 #[test]
 fn linalg_ad_support_manifest_marks_vector_outputs_explicitly() {
+    let qr = linalg_ad_support(LinalgAdOpKind::Qr);
+    assert_eq!(qr.linearize, LinalgAdRuleSupport::SupportedViaLinearize);
+    assert_eq!(qr.transpose, LinalgAdRuleSupport::Supported);
+    assert_output_status(qr, "q", LinalgAdRuleSupport::SupportedViaLinearize);
+    assert_output_status(qr, "r", LinalgAdRuleSupport::SupportedViaLinearize);
+
     let svd = linalg_ad_support(LinalgAdOpKind::Svd);
     assert_eq!(svd.linearize, LinalgAdRuleSupport::SupportedViaLinearize);
     assert_output_status(svd, "u", LinalgAdRuleSupport::SupportedViaLinearize);
@@ -144,6 +151,8 @@ fn linalg_values_only_finite_diff_support_is_documented_next_to_oracle_snapshot(
     .expect("oracle support docs should be readable");
 
     for needle in [
+        "| Lu | finite-difference | `grad(sum(l) + sum(u))` |",
+        "| Qr | finite-difference | `grad(sum(q) + sum(r))` |",
         "| SvdVals | finite-difference | `norm(..., ord=2)` |",
         "| EighVals | finite-difference | `eigvalsh` |",
         "| EigVals | finite-difference | `eigvals` |",

--- a/crates/tenferro-linalg/tests/traced_ad_explicit.rs
+++ b/crates/tenferro-linalg/tests/traced_ad_explicit.rs
@@ -811,6 +811,88 @@ fn solve_and_triangular_solve_grad_use_extension_transpose_rules() {
     }
 }
 
+fn lu_sum_loss(input: &TracedTensor) -> TracedTensor {
+    let (_p, l, u, _parity) = input.lu().unwrap();
+    (&reduce_all(&l) + &reduce_all(&u)).unwrap()
+}
+
+fn qr_sum_loss(input: &TracedTensor) -> TracedTensor {
+    let (q, r) = input.qr().unwrap();
+    (&reduce_all(&q) + &reduce_all(&r)).unwrap()
+}
+
+fn assert_gradient_matches_finite_difference(
+    name: &str,
+    shape: Vec<usize>,
+    data: Vec<f64>,
+    loss: fn(&TracedTensor) -> TracedTensor,
+) {
+    let ad = ad_context();
+    let matrix =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(shape.clone(), data.clone())).unwrap();
+    let grad = ad.grad(&loss(&matrix), &matrix).unwrap();
+    let result = eval(&grad);
+    let actual = get_f64_data(&result);
+
+    assert_eq!(result.shape(), shape.as_slice(), "{name} gradient shape");
+    assert_eq!(actual.len(), data.len(), "{name} gradient length");
+    for (idx, actual_value) in actual.iter().enumerate() {
+        let expected = finite_diff_scalar(
+            |xs| {
+                let input = TracedTensor::from_tensor_concrete_shape(f64_tensor(
+                    shape.clone(),
+                    xs.to_vec(),
+                ))
+                .unwrap();
+                get_f64_data(&eval(&loss(&input)))[0]
+            },
+            &data,
+            idx,
+            1.0e-6,
+        );
+        let diff = (*actual_value - expected).abs();
+        assert!(
+            diff <= 1.0e-4,
+            "{name} idx {idx}: expected {expected}, got {}, diff {diff}",
+            actual_value
+        );
+    }
+}
+
+#[test]
+fn lu_qr_sum_grads_match_finite_diff_using_direct_transpose_rules() {
+    assert_gradient_matches_finite_difference(
+        "lu square sum gradient",
+        vec![2, 2],
+        vec![2.0, 0.5, 0.25, 3.0],
+        lu_sum_loss,
+    );
+    assert_gradient_matches_finite_difference(
+        "lu wide sum gradient",
+        vec![2, 3],
+        vec![2.0, 0.5, 0.25, 3.0, 1.0, -0.4],
+        lu_sum_loss,
+    );
+    assert_gradient_matches_finite_difference(
+        "lu tall sum gradient",
+        vec![3, 2],
+        vec![2.0, 0.5, 0.1, 0.25, 3.0, -0.4],
+        lu_sum_loss,
+    );
+    assert_gradient_matches_finite_difference(
+        "qr full-rank sum gradient",
+        vec![3, 2],
+        vec![2.0, 0.5, 0.1, 0.25, 3.0, -0.4],
+        qr_sum_loss,
+    );
+    assert_gradient_matches_finite_difference(
+        "qr wide sum gradient",
+        vec![2, 3],
+        vec![2.0, 0.5, 0.25, 3.0, 1.0, -0.4],
+        qr_sum_loss,
+    );
+}
+
 #[test]
 fn complex_eigh_values_grad_executes_with_complex_input_dtype() {
     let ad = ad_context();

--- a/docs/oracle/tensor-ad-oracles-support.md
+++ b/docs/oracle/tensor-ad-oracles-support.md
@@ -22,6 +22,8 @@ finite-difference tests until a crate-local replay harness is restored.
 | --- | --- | --- | --- |
 | Einsum extension | finite-difference | `einsum_with(..., "ij,jk->ik", ...)` | `cargo test -p tenferro-einsum --features autodiff --test traced_ad_migration grad_einsum_matmul_real_matches_finite_diff_for_both_inputs` |
 | FFT C2C extension | finite-difference | `fft(...).jvp(...)` | `cargo test -p tenferro-fft --features autodiff --test fft_ops fft_c64_jvp_matches_finite_diff` |
+| Lu | finite-difference | `grad(sum(l) + sum(u))` | `cargo test -p tenferro-linalg --features autodiff --test traced_ad_explicit lu_qr_sum_grads_match_finite_diff_using_direct_transpose_rules` |
+| Qr | finite-difference | `grad(sum(q) + sum(r))` | `cargo test -p tenferro-linalg --features autodiff --test traced_ad_explicit lu_qr_sum_grads_match_finite_diff_using_direct_transpose_rules` |
 | SvdVals | finite-difference | `norm(..., ord=2)` | `cargo test -p tenferro-linalg --features autodiff --test traced_ad_explicit spectral_norm_jvp_matches_finite_diff_through_values_only_svd` |
 | EighVals | finite-difference | `eigvalsh` | `cargo test -p tenferro-linalg --features autodiff --test traced_ad_explicit eigvalsh_jvp_matches_finite_diff_through_values_only_eigh` |
 | EigVals | finite-difference | `eigvals` | `cargo test -p tenferro-linalg --features autodiff --test traced_ad_explicit eigvals_jvp_matches_finite_diff` |


### PR DESCRIPTION
## Summary

Adds direct transpose AD rules for LU and QR in `tenferro-linalg`.

- Implements LU transpose from factor cotangents for square, wide, and tall inputs.
- Implements QR transpose for full-rank tall/square and wide cases.
- Reuses primal outputs when available in the transpose context, avoiding the previous fallback through linearize-and-transpose.
- Marks LU and QR transpose support as available in the linalg AD support manifest.
- Adds finite-difference coverage for `grad(sum(L) + sum(U))` and `grad(sum(Q) + sum(R))`.

## Motivation

`grad_sum_lu_vjp` and `grad_sum_qr_vjp` previously had to go through the generic linearize + transpose path because the linalg extension did not provide direct transpose rules for LU or QR. That path added avoidable AD graph construction and transpose overhead for scalarized VJP workloads.

The formulas are mirrored from the tensor-ad-oracles LU/QR scalarized-rule work in tensor4all/tensor-ad-oracles#24 and were validated against finite differences in this crate.

## Validation

- `cargo fmt --all --check`
- `cargo check -p tenferro-linalg --features autodiff`
- `cargo test -p tenferro-linalg --features autodiff ad::tests:: -- --nocapture`
- `cargo test -p tenferro-linalg --features autodiff --test traced_ad_explicit -- --nocapture`
- `cargo test -p tenferro-linalg --features autodiff --test ad_support_manifest -- --nocapture`
- `cargo test -p tenferro-linalg --features autodiff --test traced_ad_explicit lu_qr_sum_grads_match_finite_diff_using_direct_transpose_rules -- --nocapture`

## Benchmark Note

Linux CPU devcontainer benchmarks with OpenBLAS show improved large VJP medians for LU/QR after the direct transpose rules, especially for `grad_sum_lu_vjp` and `grad_sum_qr_vjp`. PyTorch remains faster for several 4-thread large cases, so this closes only the AD-rule fallback overhead, not all remaining backend/runtime gap.