### PR TITLE
Fix public-boundary validation bug batch

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -495,8 +495,10 @@ Tests follow implementation ownership.
   backend boundary. The diagnostic should say to download the tensor to host
   before CPU execution.
 - Direct host-inspection APIs such as `TypedTensor::host_data()` and
-  `TypedTensor::host_data_mut()` may panic with a diagnostic on backend
-  buffers because their signatures return slices, not `Result`.
+  `TypedTensor::host_data_mut()` return `Result` and must report backend
+  buffers as typed backend failures. Any infallible host-inspection API that
+  returns a borrowed slice instead of `Result` must document an explicit panic
+  boundary before it is exposed.
 - Execution pipeline internals may handle placement for documented cases:
   `Constant` ops may auto-upload through `upload_host_tensor()`, and
   host-dependent ops such as `ShapeOf` or `DynamicTruncate` may read metadata

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use computegraph::GraphOperation;
 use tenferro_ops::broadcast::{
     broadcast_input_plan, broadcast_shape, broadcast_shapes, BroadcastError,
 };
@@ -913,6 +914,10 @@ impl EagerTensor {
         let Some(first) = tensors.first() else {
             return Err(empty_nary_input_error(&op));
         };
+        let expected = op.input_count();
+        if tensors.len() != expected {
+            return Err(wrong_nary_input_count_error(&op, expected, tensors.len()));
+        }
 
         let ctx = Arc::clone(&first.ctx);
         profile_eager_op_section("nary_op.context_check", || -> Result<()> {
@@ -1017,6 +1022,13 @@ fn empty_nary_input_error(op: &StdTensorOp) -> Error {
     Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
         op: eager_validation_op_name(op),
         message: "operation requires at least one input tensor".to_string(),
+    })
+}
+
+fn wrong_nary_input_count_error(op: &StdTensorOp, expected: usize, actual: usize) -> Error {
+    Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
+        op: eager_validation_op_name(op),
+        message: format!("operation expects {expected} inputs, got {actual}"),
     })
 }
 

--- a/crates/tenferro-ad/tests/ad/reductions_and_indexing.rs
+++ b/crates/tenferro-ad/tests/ad/reductions_and_indexing.rs
@@ -234,7 +234,7 @@ fn grad_broadcast_add_singleton_lhs() {
 fn grad_reshape() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]))
         .unwrap();
-    let y = x.reshape(&[2, 2]);
+    let y = x.reshape(&[2, 2]).unwrap();
     let loss = y.reduce_sum(&[0, 1]).unwrap();
     let grad = loss.grad(&x).unwrap();
 

--- a/crates/tenferro-ad/tests/extension_op/api_and_registry.rs
+++ b/crates/tenferro-ad/tests/extension_op/api_and_registry.rs
@@ -46,6 +46,23 @@ fn apply_eager_rejects_wrong_input_count() {
 }
 
 #[test]
+fn apply_standard_op_rejects_wrong_input_count() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+        ctx,
+    )
+    .unwrap();
+
+    let err = match tenferro_ad::extension::apply_standard_op(StdTensorOp::Add, &[&x]) {
+        Ok(_) => panic!("wrong standard op input count unexpectedly succeeded"),
+        Err(err) => err,
+    };
+
+    assert!(err.to_string().contains("expects 2 inputs, got 1"));
+}
+
+#[test]
 fn apply_eager_rejects_cross_context_inputs() {
     let lhs_ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let rhs_ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());

--- a/crates/tenferro-ad/tests/primitive_ops.rs
+++ b/crates/tenferro-ad/tests/primitive_ops.rs
@@ -209,7 +209,7 @@ fn test_transpose() {
 fn test_reshape() {
     let a = f64_tensor(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     let ta = TracedTensor::from_tensor_concrete_shape(a).unwrap();
-    let tb = ta.reshape(&[6]);
+    let tb = ta.reshape(&[6]).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tb.run_with(&mut engine).unwrap();
     assert_eq!(get_f64_data(&result), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);

--- a/crates/tenferro-einsum/benches/mps_inner_product.rs
+++ b/crates/tenferro-einsum/benches/mps_inner_product.rs
@@ -70,6 +70,7 @@ fn build_inner_product_graph(
             .expect("MPS inner-product contraction should build");
     }
     env.reshape(&[])
+        .expect("final MPS inner-product scalar reshape should preserve element count")
 }
 
 fn compile_mps_inner_product(fixture: &MpsFixture) -> GraphProgram {

--- a/crates/tenferro-einsum/benches/mps_inner_product_compile.rs
+++ b/crates/tenferro-einsum/benches/mps_inner_product_compile.rs
@@ -38,6 +38,7 @@ fn build_inner_product_graph(
             .expect("MPS inner-product contraction should build");
     }
     env.reshape(&[])
+        .expect("final MPS inner-product scalar reshape should preserve element count")
 }
 
 fn build_compile_case(sites: usize, chi: usize) -> CompileCase {

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -3023,6 +3023,7 @@ fn operand_window_dims(rank: usize, collapsed_or_inserted: &[usize]) -> Vec<usiz
         .collect()
 }
 
+#[derive(Debug)]
 struct GatherLaunchMeta {
     output_shape: Vec<usize>,
     window_dims: Vec<usize>,
@@ -3055,12 +3056,17 @@ fn gather_launch_meta(
         &config.collapsed_slice_dims,
         operand_shape.len(),
     )?;
-    ensure_axes_unique(
-        "gather",
-        "offset_dims",
-        &config.offset_dims,
-        operand_shape.len(),
-    )?;
+    for &dim in &config.collapsed_slice_dims {
+        if config.slice_sizes[dim] != 1 {
+            return Err(crate::Error::InvalidConfig {
+                op: "gather",
+                message: format!(
+                    "collapsed slice dimension {dim} must have slice_size == 1, got {}",
+                    config.slice_sizes[dim]
+                ),
+            });
+        }
+    }
     ensure_axes_unique(
         "gather",
         "start_index_map",
@@ -3076,6 +3082,7 @@ fn gather_launch_meta(
     }
     let batch_shape = index_batch_shape(start_indices_shape, config.index_vector_dim);
     let out_rank = batch_shape.len() + config.offset_dims.len();
+    ensure_axes_unique("gather", "offset_dims", &config.offset_dims, out_rank)?;
     let mut output_shape = vec![0usize; out_rank];
     let mut out_axis_to_operand_dim = vec![None; out_rank];
     for (offset_axis, &out_axis) in config.offset_dims.iter().enumerate() {
@@ -3096,6 +3103,7 @@ fn gather_launch_meta(
     })
 }
 
+#[derive(Debug)]
 struct ScatterLaunchMeta {
     batch_shape: Vec<usize>,
     window_dims: Vec<usize>,
@@ -3153,6 +3161,27 @@ fn scatter_launch_meta(
             op: "scatter",
             message: "updates batch rank mismatch".into(),
         });
+    }
+    let mut is_update_window_dim = vec![false; updates_shape.len()];
+    for &axis in &config.update_window_dims {
+        is_update_window_dim[axis] = true;
+    }
+    let mut batch_axis = 0usize;
+    for (axis, &actual) in updates_shape.iter().enumerate() {
+        if is_update_window_dim[axis] {
+            continue;
+        }
+        let expected = batch_shape[batch_axis];
+        if actual != expected {
+            return Err(crate::Error::InvalidConfig {
+                op: "scatter",
+                message: format!(
+                    "updates batch dim {batch_axis} extent {actual} does not match \
+                     scatter batch extent {expected}"
+                ),
+            });
+        }
+        batch_axis += 1;
     }
     let window_shape_updates = config
         .update_window_dims

--- a/crates/tenferro-gpu/src/cubecl/tests/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/mod.rs
@@ -2,7 +2,7 @@ use num_complex::{Complex32, Complex64};
 
 use crate::config::{GatherConfig, ScatterConfig};
 use crate::cubecl::{download_tensor, upload_tensor, CudaBackend};
-use crate::{Tensor, TypedTensor};
+use crate::{Error, Tensor, TypedTensor};
 use tenferro_cpu::CpuBackend;
 
 mod elementwise_tests;
@@ -56,6 +56,78 @@ fn tensor_c32(shape: Vec<usize>, data: Vec<Complex32>) -> Tensor {
 
 fn tensor_c64(shape: Vec<usize>, data: Vec<Complex64>) -> Tensor {
     Tensor::C64(TypedTensor::from_vec_col_major(shape, data).unwrap())
+}
+
+#[test]
+fn gather_launch_meta_rejects_offset_dim_outside_output_rank() {
+    let err = super::gather_launch_meta(
+        &[2, 3],
+        &[],
+        &GatherConfig {
+            offset_dims: vec![1],
+            collapsed_slice_dims: vec![0],
+            start_index_map: vec![0],
+            index_vector_dim: 0,
+            slice_sizes: vec![1, 3],
+        },
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::AxisOutOfBounds {
+            op: "gather",
+            axis: 1,
+            rank: 1
+        }
+    ));
+}
+
+#[test]
+fn gather_launch_meta_rejects_collapsed_non_unit_slice_sizes() {
+    let err = super::gather_launch_meta(
+        &[3],
+        &[],
+        &GatherConfig {
+            offset_dims: vec![],
+            collapsed_slice_dims: vec![0],
+            start_index_map: vec![0],
+            index_vector_dim: 0,
+            slice_sizes: vec![2],
+        },
+    )
+    .unwrap_err();
+
+    assert!(
+        matches!(err, Error::InvalidConfig { op: "gather", .. }),
+        "{err:?}"
+    );
+    assert!(err.to_string().contains("slice_size == 1"), "{err}");
+}
+
+#[test]
+fn scatter_launch_meta_rejects_mismatched_update_batch_extents() {
+    let err = super::scatter_launch_meta(
+        &[4],
+        &[2, 1],
+        &[3],
+        &ScatterConfig {
+            update_window_dims: vec![],
+            inserted_window_dims: vec![0],
+            scatter_dims_to_operand_dims: vec![0],
+            index_vector_dim: 1,
+        },
+    )
+    .unwrap_err();
+
+    assert!(
+        matches!(err, Error::InvalidConfig { op: "scatter", .. }),
+        "{err:?}"
+    );
+    assert!(
+        err.to_string().contains("updates batch dim 0 extent 3"),
+        "{err}"
+    );
 }
 
 fn assert_tensor_close(actual: &Tensor, expected: &Tensor, tol: f64) {

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -650,7 +650,7 @@ pub fn norm(
             }
         }
     };
-    Ok(restore_keepdim(out, &shape, &axes, keepdim))
+    restore_keepdim(out, &shape, &axes, keepdim)
 }
 
 fn unexpected_output_count(name: &str, expected: usize) -> Error {
@@ -951,7 +951,7 @@ fn scale_matrix_columns(matrix: &TracedTensor, scale: &TracedTensor) -> Result<T
     scale_shape.extend_from_slice(&matrix_shape[2..]);
     let dims: Vec<usize> = (0..matrix_shape.len()).collect();
     let scale = scale
-        .reshape(&scale_shape)
+        .reshape(&scale_shape)?
         .broadcast_in_dim(&matrix_shape, &dims)?;
     matrix * &scale
 }
@@ -1004,9 +1004,9 @@ fn restore_keepdim(
     original_shape: &[usize],
     axes: &[usize],
     keepdim: bool,
-) -> TracedTensor {
+) -> Result<TracedTensor> {
     if !keepdim {
-        return reduced;
+        return Ok(reduced);
     }
     let mut kept_shape = original_shape.to_vec();
     for &axis in axes {

--- a/crates/tenferro-runtime/src/shape_packing.rs
+++ b/crates/tenferro-runtime/src/shape_packing.rs
@@ -234,7 +234,7 @@ impl TracedTensor {
         let expanded = tensors
             .iter()
             .map(|tensor| tensor.reshape(&expanded_shape))
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>>>()?;
         let refs = expanded.iter().collect::<Vec<_>>();
         Ok(apply_nary_concatenate(
             &refs,

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -118,7 +118,7 @@ pub(crate) fn broadcast_to(tensor: &TracedTensor, target_shape: &[usize]) -> Res
     let source = if plan.source_shape == tensor_shape {
         tensor.clone()
     } else {
-        tensor.reshape(&plan.source_shape)
+        tensor.reshape(&plan.source_shape)?
     };
     source.broadcast_in_dim(target_shape, &plan.dims)
 }
@@ -174,6 +174,22 @@ fn scale_with_constant(input: &TracedTensor, op: StdTensorOp) -> TracedTensor {
     )
 }
 
+fn dtype_inference_error(op: &StdTensorOp, context: &'static str, err: String) -> Error {
+    Error::InvalidGraphBuild {
+        op: context,
+        message: format!("built-in traced dtype inference failed for {op:?}: {err}"),
+    }
+}
+
+fn try_inferred_output_dtype(
+    op: &StdTensorOp,
+    inputs: &[DType],
+    context: &'static str,
+) -> Result<DType> {
+    crate::shape_infer::infer_output_dtype(op, inputs)
+        .map_err(|err| dtype_inference_error(op, context, err.to_string()))
+}
+
 fn inferred_output_dtype(op: &StdTensorOp, inputs: &[DType], context: &'static str) -> DType {
     match crate::shape_infer::infer_output_dtype(op, inputs) {
         Ok(dtype) => dtype,
@@ -181,6 +197,36 @@ fn inferred_output_dtype(op: &StdTensorOp, inputs: &[DType], context: &'static s
             panic!("{context}: built-in traced dtype inference failed for {op:?}: {err}");
         }
     }
+}
+
+fn checked_shape_product_for_graph_build(
+    shape: &[usize],
+    context: &'static str,
+    role: &'static str,
+) -> Result<usize> {
+    shape.iter().copied().try_fold(1usize, |acc, dim| {
+        acc.checked_mul(dim)
+            .ok_or_else(|| Error::InvalidGraphBuild {
+                op: context,
+                message: format!("{role} shape element count overflows usize"),
+            })
+    })
+}
+
+fn validate_concrete_reshape_shape(input: &TracedTensor, shape: &[usize]) -> Result<()> {
+    let to = checked_shape_product_for_graph_build(shape, "TracedTensor::reshape", "target")?;
+    let Some(input_shape) = try_concrete_shape(input) else {
+        return Ok(());
+    };
+    let from =
+        checked_shape_product_for_graph_build(&input_shape, "TracedTensor::reshape", "input")?;
+    if from != to {
+        return Err(Error::InvalidGraphBuild {
+            op: "TracedTensor::reshape",
+            message: format!("reshape element-count mismatch: from {from} to {to}"),
+        });
+    }
+    Ok(())
 }
 
 fn traced_input_shape_exprs(input_idx: usize, tensor: &TracedTensor) -> Vec<DimExpr> {
@@ -876,14 +922,7 @@ impl TracedTensor {
 
     /// Elementwise comparison with NumPy-style broadcasting.
     pub fn compare(&self, other: &TracedTensor, dir: CompareDir) -> Result<TracedTensor> {
-        let (lhs, rhs) = broadcast_binary(self, other)?;
-        Ok(apply_binary(
-            StdTensorOp::Compare(dir),
-            &lhs,
-            &rhs,
-            lhs.rank,
-            lhs.shape_hint.clone(),
-        ))
+        apply_broadcast_binary_op(StdTensorOp::Compare(dir), self, other)
     }
 
     /// Elementwise maximum with NumPy-style broadcasting.
@@ -1393,14 +1432,15 @@ impl TracedTensor {
     pub fn reduce_max(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_max")?;
-        Ok(apply_unary(
+        try_apply_unary(
             StdTensorOp::ReduceMax {
                 axes: axes.to_vec(),
             },
             self,
             out_rank,
             out_shape_hint,
-        ))
+            "TracedTensor::reduce_max",
+        )
     }
 
     /// Reduce by taking the minimum along the given axes.
@@ -1423,14 +1463,15 @@ impl TracedTensor {
     pub fn reduce_min(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_min")?;
-        Ok(apply_unary(
+        try_apply_unary(
             StdTensorOp::ReduceMin {
                 axes: axes.to_vec(),
             },
             self,
             out_rank,
             out_shape_hint,
-        ))
+            "TracedTensor::reduce_min",
+        )
     }
 
     /// Reduce by taking the product along the given axes.
@@ -1467,17 +1508,26 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f64; 4]).unwrap();
-    /// let y = x.reshape(&[2, 2]);
+    /// let y = x.reshape(&[2, 2])?;
+    /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
-    pub fn reshape(&self, shape: &[usize]) -> TracedTensor {
-        apply_unary(
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the input has a concrete shape and the target
+    /// shape has a different element count, or when the target shape product
+    /// overflows `usize`.
+    pub fn reshape(&self, shape: &[usize]) -> Result<TracedTensor> {
+        validate_concrete_reshape_shape(self, shape)?;
+        Ok(apply_unary_with_dtype(
             StdTensorOp::Reshape {
                 to_shape: DimExpr::from_concrete(shape),
             },
             self,
             shape.len(),
             Some(shape.iter().copied().map(SymDim::from).collect()),
-        )
+            self.dtype,
+        ))
     }
 
     /// Return a symbolic expression for the size of one axis, suitable as
@@ -2071,6 +2121,23 @@ pub(crate) fn apply_unary(
     apply_unary_with_dtype(op, input, out_rank, out_shape_hint, out_dtype)
 }
 
+fn try_apply_unary(
+    op: StdTensorOp,
+    input: &TracedTensor,
+    out_rank: usize,
+    out_shape_hint: Option<Vec<SymDim>>,
+    context: &'static str,
+) -> Result<TracedTensor> {
+    let out_dtype = try_inferred_output_dtype(&op, &[input.dtype], context)?;
+    Ok(apply_unary_with_dtype(
+        op,
+        input,
+        out_rank,
+        out_shape_hint,
+        out_dtype,
+    ))
+}
+
 pub(crate) fn apply_unary_with_dtype(
     op: StdTensorOp,
     input: &TracedTensor,
@@ -2231,6 +2298,38 @@ pub(crate) fn apply_binary(
     apply_binary_with_output_dtype(op, &lhs, &rhs, out_rank, out_shape_hint, out_dtype)
 }
 
+fn try_apply_binary(
+    op: StdTensorOp,
+    lhs: &TracedTensor,
+    rhs: &TracedTensor,
+    out_rank: usize,
+    out_shape_hint: Option<Vec<SymDim>>,
+    context: &'static str,
+) -> Result<TracedTensor> {
+    let input_dtype = crate::shape_infer::promote_dtype_for_binary_op(&op, lhs.dtype, rhs.dtype);
+    let out_dtype = try_inferred_output_dtype(&op, &[lhs.dtype, rhs.dtype], context)?;
+
+    let lhs = if lhs.dtype != input_dtype {
+        lhs.cast(input_dtype)
+    } else {
+        lhs.clone()
+    };
+    let rhs = if rhs.dtype != input_dtype {
+        rhs.cast(input_dtype)
+    } else {
+        rhs.clone()
+    };
+
+    Ok(apply_binary_with_output_dtype(
+        op,
+        &lhs,
+        &rhs,
+        out_rank,
+        out_shape_hint,
+        out_dtype,
+    ))
+}
+
 pub(crate) fn apply_binary_preserve_input_dtypes(
     op: StdTensorOp,
     lhs: &TracedTensor,
@@ -2248,13 +2347,14 @@ pub(crate) fn apply_broadcast_binary_op(
     rhs: &TracedTensor,
 ) -> Result<TracedTensor> {
     let (lhs, rhs) = broadcast_binary(lhs, rhs)?;
-    Ok(apply_binary(
+    try_apply_binary(
         op,
         &lhs,
         &rhs,
         lhs.rank,
         lhs.shape_hint.clone(),
-    ))
+        "broadcast_binary",
+    )
 }
 
 pub(crate) fn apply_broadcast_ternary_op(
@@ -2264,29 +2364,28 @@ pub(crate) fn apply_broadcast_ternary_op(
     third: &TracedTensor,
 ) -> Result<TracedTensor> {
     let (first, second, third) = broadcast_ternary(first, second, third)?;
-    Ok(apply_ternary(
+    try_apply_ternary(
         op,
         &first,
         &second,
         &third,
         first.rank,
         first.shape_hint.clone(),
-    ))
+        "broadcast_ternary",
+    )
 }
 
-pub(crate) fn apply_ternary(
+fn try_apply_ternary(
     op: StdTensorOp,
     first: &TracedTensor,
     second: &TracedTensor,
     third: &TracedTensor,
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
-) -> TracedTensor {
-    let out_dtype = inferred_output_dtype(
-        &op,
-        &[first.dtype, second.dtype, third.dtype],
-        "apply_ternary",
-    );
+    context: &'static str,
+) -> Result<TracedTensor> {
+    let out_dtype =
+        try_inferred_output_dtype(&op, &[first.dtype, second.dtype, third.dtype], context)?;
     let (first, second, third) = match op {
         StdTensorOp::Select => {
             let value_dtype = crate::shape_infer::promote_dtype(second.dtype, third.dtype);
@@ -2323,7 +2422,7 @@ pub(crate) fn apply_ternary(
             (first, second, third)
         }
     };
-    apply_ternary_with_output_dtype(
+    Ok(apply_ternary_with_output_dtype(
         op,
         &first,
         &second,
@@ -2331,7 +2430,7 @@ pub(crate) fn apply_ternary(
         out_rank,
         out_shape_hint,
         out_dtype,
-    )
+    ))
 }
 
 fn apply_binary_with_output_dtype(

--- a/crates/tenferro-runtime/src/traced/tests.rs
+++ b/crates/tenferro-runtime/src/traced/tests.rs
@@ -1,4 +1,6 @@
-use crate::{DType, DotGeneralConfig, TracedTensor};
+use num_complex::Complex64;
+
+use crate::{DType, DotGeneralConfig, Error, TracedTensor};
 
 #[test]
 fn dot_general_returns_error_for_invalid_config() {
@@ -148,4 +150,61 @@ fn broadcast_in_dim_rejects_invalid_dimension_mappings() {
     let valid = x.broadcast_in_dim(&[2, 3, 4], &[0, 1]).unwrap();
     assert_eq!(valid.rank, 3);
     assert_eq!(valid.try_concrete_shape().unwrap(), &[2, 3, 4]);
+}
+
+#[test]
+fn reshape_rejects_concrete_element_count_mismatch_at_graph_build() {
+    let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+
+    let err = x.reshape(&[3]).unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::InvalidGraphBuild {
+            op: "TracedTensor::reshape",
+            ..
+        }
+    ));
+    assert!(err.to_string().contains("element-count mismatch"), "{err}");
+}
+
+#[test]
+fn reshape_allows_symbolic_input_when_element_count_cannot_be_proven() {
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 2).unwrap();
+
+    let y = x.reshape(&[3]).unwrap();
+
+    assert_eq!(y.rank, 1);
+    assert_eq!(y.try_concrete_shape(), Some(vec![3]));
+}
+
+#[test]
+fn ordered_binary_ops_reject_complex_dtype_without_panicking() {
+    let lhs = TracedTensor::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 2.0)]).unwrap();
+    let rhs = TracedTensor::from_vec_col_major(vec![1], vec![Complex64::new(3.0, 4.0)]).unwrap();
+
+    let err = lhs.maximum(&rhs).unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("complex numbers have no total order"),
+        "{err}"
+    );
+}
+
+#[test]
+fn ordered_reductions_reject_complex_dtype_without_panicking() {
+    let x = TracedTensor::from_vec_col_major(
+        vec![2],
+        vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
+    )
+    .unwrap();
+
+    let err = x.reduce_max(&[0]).unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("complex numbers have no total order"),
+        "{err}"
+    );
 }

--- a/crates/tenferro-tensor-core/src/layout.rs
+++ b/crates/tenferro-tensor-core/src/layout.rs
@@ -147,7 +147,14 @@ fn normalize_slice(slice: SliceSpec, axis_len: usize) -> Result<(isize, usize)> 
     } else {
         slice.start
     };
-    let end = slice.end;
+    let end = if slice.end < -1 {
+        slice
+            .end
+            .checked_add(axis_len)
+            .ok_or(Error::IntegerOverflow)?
+    } else {
+        slice.end
+    };
     if start < 0 || start >= axis_len || end < -1 || end >= axis_len {
         return Err(Error::InvalidSliceBounds {
             start: slice.start,

--- a/crates/tenferro-tensor-core/src/lib.rs
+++ b/crates/tenferro-tensor-core/src/lib.rs
@@ -165,7 +165,18 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// ```
     fn dtype() -> DType;
 
-    fn into_tensor(shape: ShapeVec, data: Vec<Self>) -> Tensor;
+    /// Build a dynamic tensor from validated column-major data.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor_core::{DType, ShapeVec, TensorScalar};
+    ///
+    /// let tensor = <f64 as TensorScalar>::into_tensor(ShapeVec::from_slice(&[1]), vec![2.0])?;
+    /// assert_eq!(tensor.dtype(), DType::F64);
+    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// ```
+    fn into_tensor(shape: ShapeVec, data: Vec<Self>) -> Result<Tensor>;
     fn tensor_slice(tensor: &Tensor) -> Option<&[Self]>;
     fn tensor_mut_slice(tensor: &mut Tensor) -> Option<&mut [Self]>;
     fn into_typed(tensor: Tensor) -> Option<HostTensor<Self>>;
@@ -192,8 +203,8 @@ macro_rules! impl_scalar {
                 $dtype
             }
 
-            fn into_tensor(shape: ShapeVec, data: Vec<Self>) -> Tensor {
-                Tensor::$variant(HostTensor { data, shape })
+            fn into_tensor(shape: ShapeVec, data: Vec<Self>) -> Result<Tensor> {
+                HostTensor::from_vec_col_major(shape, data).map(Tensor::$variant)
             }
 
             fn tensor_slice(tensor: &Tensor) -> Option<&[Self]> {
@@ -932,9 +943,7 @@ impl Tensor {
         shape: impl Into<ShapeVec>,
         data: Vec<T>,
     ) -> Result<Self> {
-        let shape = shape.into();
-        checked_shape_len(&shape, data.len())?;
-        Ok(T::into_tensor(shape, data))
+        T::into_tensor(shape.into(), data)
     }
 
     /// Return the tensor dtype tag.

--- a/crates/tenferro-tensor-core/tests/core.rs
+++ b/crates/tenferro-tensor-core/tests/core.rs
@@ -1,7 +1,7 @@
 use num_complex::{Complex32, Complex64};
 use tenferro_tensor_core::{
     col_major_strides, DType, DynRank, Error, HostTensor, HostTensorView, Rank, SliceSpec, Tensor,
-    TensorLayout, TensorRank, TensorRef,
+    TensorLayout, TensorRank, TensorRef, TensorScalar,
 };
 
 #[test]
@@ -120,6 +120,25 @@ fn slice_view_supports_negative_step() {
 }
 
 #[test]
+fn slice_view_normalizes_negative_end_for_negative_step() {
+    let layout = TensorLayout::<Rank<1>>::compact([5]).unwrap();
+    let sliced = layout
+        .slice_view(
+            [SliceSpec {
+                start: 3,
+                end: -3,
+                step: -1,
+            }],
+            5,
+        )
+        .unwrap();
+
+    assert_eq!(sliced.shape(), &[1]);
+    assert_eq!(sliced.strides(), &[-1]);
+    assert_eq!(sliced.offset(), 3);
+}
+
+#[test]
 fn reshape_view_as_requires_compact_layout() {
     let layout = TensorLayout::<Rank<2>>::compact([2, 3]).unwrap();
     let reshaped = layout.reshape_view_as::<Rank<1>>([6], 6).unwrap();
@@ -154,7 +173,7 @@ fn slice_view_rejects_invalid_normalized_bounds_with_exact_error() {
         .slice_view(
             [SliceSpec {
                 start: 3,
-                end: -2,
+                end: -6,
                 step: -1,
             }],
             4,
@@ -164,7 +183,7 @@ fn slice_view_rejects_invalid_normalized_bounds_with_exact_error() {
         err,
         Error::InvalidSliceBounds {
             start: 3,
-            end: -2,
+            end: -6,
             axis_len: 4
         }
     ));
@@ -573,6 +592,19 @@ fn dynamic_tensor_and_view_report_dtype_mismatch() {
         tensor.as_view().reshape_view(vec![1, 2]).unwrap().shape(),
         &[1, 2]
     );
+}
+
+#[test]
+fn tensor_scalar_into_tensor_rejects_shape_data_length_mismatch() {
+    let err = <f64 as TensorScalar>::into_tensor(vec![2, 3].into(), vec![1.0, 2.0]).unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::ShapeDataLengthMismatch {
+            expected: 6,
+            actual: 2
+        }
+    ));
 }
 
 #[test]

--- a/crates/tenferro-xla/tests/stablehlo_lowering.rs
+++ b/crates/tenferro-xla/tests/stablehlo_lowering.rs
@@ -69,6 +69,7 @@ fn lowers_structural_ops_and_convert() {
         .transpose(&[1, 0])
         .unwrap()
         .reshape(&[6])
+        .unwrap()
         .convert(DType::F64)
         .unwrap();
     let mut compiler = GraphCompiler::new();

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -24,7 +24,7 @@ This page is for readers who already know either `torch` or `jax.numpy` and want
 | Create typed tensor | `torch.tensor(data, dtype=...)` | `jnp.array(data, dtype=...)` | `TypedTensor::<T>::from_vec_col_major(shape, data)` | — |
 | Create dynamic tensor | `torch.tensor(data)` | `jnp.array(data)` | `Tensor::from_vec_col_major(shape, data)` | `TracedTensor::from_vec_col_major(shape, data)` |
 | Matrix multiply | `torch.matmul(a, b)` | `jnp.matmul(a, b)` | `a.matmul(&b, &mut ctx)` via `TensorOpsExt` | `a.matmul(&b)` |
-| Reshape | `x.reshape(shape)` | `jnp.reshape(x, shape)` | `x.reshape(&shape, &mut ctx)` via `TensorOpsExt` | `x.reshape(&shape)` |
+| Reshape | `x.reshape(shape)` | `jnp.reshape(x, shape)` | `x.reshape(&shape, &mut ctx)` via `TensorOpsExt` | `x.reshape(&shape)?` |
 | Transpose | `x.transpose(0, 1)` | `jnp.transpose(x, axes)` | `x.transpose(&perm, &mut ctx)` via `TensorOpsExt` | `x.transpose(&perm)` |
 | Broadcast | `x.expand(...)` / implicit broadcast | implicit broadcast in many ops | backend-level op | `x.broadcast_in_dim(&shape, &dims)` |
 | Reduce sum | `x.sum(dim=...)` | `jnp.sum(x, axis=...)` | `x.reduce_sum(&axes, &mut ctx)` via `TensorOpsExt` | `x.reduce_sum(&axes)` |

--- a/docs/worklogs/2026-07-02-public-boundary-minor-bugs.md
+++ b/docs/worklogs/2026-07-02-public-boundary-minor-bugs.md
@@ -1,0 +1,55 @@
+# 2026-07-02 Public Boundary Minor Bugs
+
+## Summary
+
+Addressed a small batch of validation and public-boundary issues from the
+July 2 audit set plus older minor issues that shared the same typed-error
+contract. The branch keeps behavior changes local to graph-build, tensor-core,
+eager standard-op, and CUDA launch-metadata validation paths.
+
+## Issue Ledger
+
+- #1257: fixed negative-step slice normalization for negative `end` values
+  below `-1`.
+- #1277: changed `TensorScalar::into_tensor` to return `Result<Tensor>` and
+  validate shape/data length through `HostTensor::from_vec_col_major`.
+- #1245: changed `TracedTensor::reshape` to return `Result<TracedTensor>` and
+  reject concrete element-count mismatches at graph build time.
+- #1273: converted traced ordered op dtype inference failures for complex
+  dtypes into typed graph-build errors instead of panics.
+- #1274: added eager standard-op input-count validation before dispatch.
+- #1251: aligned CUDA gather/scatter launch-metadata validation with CPU
+  indexing contracts for offset dims, collapsed slice sizes, and update batch
+  extents.
+- #1278: updated stale repository-rule text for `host_data()` and
+  `host_data_mut()` returning `Result`.
+
+## Decisions
+
+- Accepted the public trait/API return-value changes because this batch is not
+  preserving backward compatibility.
+- Kept symbolic traced reshape permissive when the input element count cannot
+  be proven at graph build time; runtime compilation/execution still validates
+  concrete bindings.
+- Added CUDA validation tests against private launch metadata helpers so the
+  invalid-config behavior is covered without requiring local GPU execution.
+
+## Verification
+
+- `cargo fmt --all --check`
+- `cargo test -p tenferro-tensor-core --test core`
+- `cargo test -p tenferro-runtime --lib`
+- `cargo test -p tenferro-linalg --lib`
+- `cargo test -p tenferro-ad --test extension_op`
+- `cargo test -p tenferro-gpu --features cuda launch_meta_rejects`
+- `cargo test -p tenferro-xla lowers_structural_ops_and_convert`
+- `cargo check --workspace --all-targets`
+- `git diff --check`
+
+## Residual Risks
+
+- Full CUDA kernel execution for gather/scatter still depends on GPU CI; the
+  local coverage here is launch-metadata validation.
+- Larger performance/design reports from the same umbrella, including cache,
+  FFT, einsum, and API design proposals, remain deferred for separate design
+  or measurement work.

--- a/samples/kdv-pinn/src/main.rs
+++ b/samples/kdv-pinn/src/main.rs
@@ -70,23 +70,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let u_ic_true = TracedTensor::input_concrete_shape(DType::F64, &[N_IC, 1])?;
 
     let t_zero = TracedTensor::from_vec_col_major(vec![N_IC, 1], vec![0.0_f64; N_IC])?;
-    let xt_ic = TracedTensor::stack(&[&x_ic, &t_zero], 1)?.reshape(&[N_IC, 2]);
+    let xt_ic = TracedTensor::stack(&[&x_ic, &t_zero], 1)?.reshape(&[N_IC, 2])?;
     let u_ic = net.forward(&xt_ic)?;
 
     let x_col = TracedTensor::input_concrete_shape(DType::F64, &[N_COL, 1])?;
     let t_col = TracedTensor::input_concrete_shape(DType::F64, &[N_COL, 1])?;
-    let xt_col = TracedTensor::stack(
-        &[&x_col.reshape(&[N_COL, 1]), &t_col.reshape(&[N_COL, 1])],
-        1,
-    )?
-    .reshape(&[N_COL, 2]);
+    let xt_col = TracedTensor::stack(&[&x_col, &t_col], 1)?.reshape(&[N_COL, 2])?;
     let u_col = net.forward(&xt_col)?;
 
     let x_bc = TracedTensor::input_concrete_shape(DType::F64, &[N_BC, 1])?;
     let t_bc = TracedTensor::input_concrete_shape(DType::F64, &[N_BC, 1])?;
     let u_bc_true = TracedTensor::input_concrete_shape(DType::F64, &[N_BC, 1])?;
-    let xt_bc = TracedTensor::stack(&[&x_bc.reshape(&[N_BC, 1]), &t_bc.reshape(&[N_BC, 1])], 1)?
-        .reshape(&[N_BC, 2]);
+    let xt_bc = TracedTensor::stack(&[&x_bc, &t_bc], 1)?.reshape(&[N_BC, 2])?;
     let u_bc = net.forward(&xt_bc)?;
 
     let residual = pde::kdv_residual(&u_col, &x_col, &t_col)?;
@@ -174,11 +169,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Evaluation grid at t = 0.5.
     let x_eval = TracedTensor::input_concrete_shape(DType::F64, &[N_EVAL, 1])?;
     let t_eval = TracedTensor::input_concrete_shape(DType::F64, &[N_EVAL, 1])?;
-    let xt_eval = TracedTensor::stack(
-        &[&x_eval.reshape(&[N_EVAL, 1]), &t_eval.reshape(&[N_EVAL, 1])],
-        1,
-    )?
-    .reshape(&[N_EVAL, 2]);
+    let xt_eval = TracedTensor::stack(&[&x_eval, &t_eval], 1)?.reshape(&[N_EVAL, 2])?;
     let u_eval = net.forward(&xt_eval)?;
 
     let mut eval_specs: Vec<(&TracedTensor, DType, &[usize])> = param_specs

--- a/samples/kdv-pinn/src/network.rs
+++ b/samples/kdv-pinn/src/network.rs
@@ -37,7 +37,7 @@ impl Linear {
             self.bias
                 .try_concrete_shape()
                 .expect("placeholder shape is concrete")[0],
-        ]);
+        ])?;
         y.add(&bias_broadcast)
     }
 }


### PR DESCRIPTION
## Summary

- fix tensor-core negative-step slice normalization and make `TensorScalar::into_tensor` return typed validation errors
- make traced `reshape` fallible for concrete element-count mismatches and convert complex ordered-op graph-build failures into typed errors
- validate eager standard-op arity and CUDA gather/scatter launch metadata before indexing/dispatch
- update stale host-data repository-rule text and add a work log for the batch
- update the KdV PINN sample for the fallible traced reshape API

## Issue Ledger

Closes #1245
Closes #1251
Closes #1257
Closes #1273
Closes #1274
Closes #1277
Closes #1278

Does not close umbrella #1271; larger design/performance/cache/FFT/einsum/API findings from the same audit remain deferred. See `docs/worklogs/2026-07-02-public-boundary-minor-bugs.md`.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path /tmp/tenferro-public-boundary-coverage.json`
- `python3 scripts/check-coverage.py /tmp/tenferro-public-boundary-coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/tenferro-public-boundary-rules-review.json`

Focused checks also run during development and CI babysitting:

- `cargo test -p tenferro-tensor-core --test core`
- `cargo test -p tenferro-runtime --lib`
- `cargo test -p tenferro-linalg --lib`
- `cargo test -p tenferro-ad --test extension_op`
- `cargo test -p tenferro-gpu --features cuda launch_meta_rejects`
- `cargo test -p tenferro-xla lowers_structural_ops_and_convert`
- `cargo check --workspace --all-targets`
- `cargo fmt --manifest-path samples/kdv-pinn/Cargo.toml --all --check`
- `cargo check --manifest-path samples/kdv-pinn/Cargo.toml --release --all-targets`