### PR TITLE
Add dot-general accumulation backend hook

### DIFF
--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -11,11 +11,12 @@ use crate::{
     Buffer, CacheStats, Tensor, TensorRank, TensorRead, TensorValue, TensorWrite, TypedTensor,
     TypedTensorView, TypedTensorViewMut,
 };
-use tenferro_tensor::backend::validate_dot_general_read_into;
+use tenferro_tensor::backend::{dot_general_accum_via_temp, validate_dot_general_accumulation};
 use tenferro_tensor::{
-    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, TensorAnalytic,
-    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
-    TensorIndexing, TensorReduction, TensorStructural, TensorViewCanonicalization,
+    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
+    DotGeneralAccumulation, TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer,
+    TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
+    TensorViewCanonicalization,
 };
 use tenferro_tensor::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
@@ -1070,53 +1071,31 @@ impl TensorDot for CpuBackend {
         lhs: TensorRead<'_>,
         rhs: TensorRead<'_>,
         config: &DotGeneralConfig,
-        mut out: TensorWrite<'_>,
+        out: TensorWrite<'_>,
     ) -> crate::Result<()> {
-        validate_dot_general_read_into(&lhs, &rhs, config, &out, "dot_general")?;
-        let direct = match self.kind {
-            CpuBackendKind::Faer => {
-                #[cfg(feature = "cpu-faer")]
-                {
-                    gemm::dot_general_faer_read_into_cached(
-                        lhs.clone(),
-                        rhs.clone(),
-                        config,
-                        &mut out,
-                    )?
-                }
-                #[cfg(not(feature = "cpu-faer"))]
-                {
-                    return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
-                }
-            }
-            CpuBackendKind::Blas => {
-                #[cfg(feature = "cpu-blas")]
-                {
-                    let mut cache = gemm::GemmAnalysisCache::default();
-                    self.run_with_pool_and_gemm_cache(&mut cache, |buffers, cache| {
-                        gemm::dot_general_blas_read_into_cached(
-                            buffers,
-                            cache,
-                            None,
-                            lhs.clone(),
-                            rhs.clone(),
-                            config,
-                            &mut out,
-                        )
-                    })?
-                }
-                #[cfg(not(feature = "cpu-blas"))]
-                {
-                    return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
-                }
-            }
-        };
-        if direct {
-            return Ok(());
-        }
+        let accumulation = DotGeneralAccumulation::overwrite(lhs.dtype())?;
+        self.dot_general_read_into_accum(lhs, rhs, config, accumulation, out)
+    }
 
-        let result = self.dot_general_read(lhs, rhs, config)?;
-        out.copy_from_tensor(&result)
+    fn dot_general_read_into_accum(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        accumulation: DotGeneralAccumulation,
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        let mut cache = gemm::GemmAnalysisCache::default();
+        BackendCachedDot::dot_general_read_into_accum_cached(
+            self,
+            &mut cache,
+            None,
+            lhs,
+            rhs,
+            config,
+            accumulation,
+            out,
+        )
     }
 
     fn dot_general_with_conj(
@@ -1365,6 +1344,69 @@ impl BackendCachedDot for CpuBackend {
                 }
             }
         }
+    }
+
+    fn dot_general_read_into_accum_cached(
+        &mut self,
+        cache: &mut Self::RuntimeCache,
+        cache_slot: Option<usize>,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        accumulation: DotGeneralAccumulation,
+        mut out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        validate_dot_general_accumulation(&lhs, &rhs, config, accumulation, &out, "dot_general")?;
+        let direct = match self.kind {
+            CpuBackendKind::Faer => {
+                #[cfg(feature = "cpu-faer")]
+                {
+                    let ctx = Arc::clone(&self.ctx);
+                    self.install_with_pool_and_gemm_cache(cache, |_buffers, cache| {
+                        gemm::dot_general_faer_read_into_accum_cached(
+                            cache,
+                            cache_slot,
+                            ctx.as_ref(),
+                            lhs.clone(),
+                            rhs.clone(),
+                            config,
+                            accumulation,
+                            &mut out,
+                        )
+                    })?
+                }
+                #[cfg(not(feature = "cpu-faer"))]
+                {
+                    return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
+                }
+            }
+            CpuBackendKind::Blas => {
+                #[cfg(feature = "cpu-blas")]
+                {
+                    self.run_with_pool_and_gemm_cache(cache, |buffers, cache| {
+                        gemm::dot_general_blas_read_into_accum_cached(
+                            buffers,
+                            cache,
+                            cache_slot,
+                            lhs.clone(),
+                            rhs.clone(),
+                            config,
+                            accumulation,
+                            &mut out,
+                        )
+                    })?
+                }
+                #[cfg(not(feature = "cpu-blas"))]
+                {
+                    return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
+                }
+            }
+        };
+        if direct {
+            return Ok(());
+        }
+
+        dot_general_accum_via_temp(self, lhs, rhs, config, accumulation, out)
     }
 }
 

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -1,12 +1,12 @@
 use crate::buffer_pool::BufferPool;
 use crate::{Tensor, TensorRead, TensorValue, TensorWrite};
-use tenferro_tensor::backend::validate_dot_general_read_into;
+use tenferro_tensor::backend::{dot_general_accum_via_temp, validate_dot_general_accumulation};
 use tenferro_tensor::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
 use tenferro_tensor::{
-    SessionCachedDot, TensorAnalytic, TensorBuffer, TensorDot, TensorElementwise, TensorFusion,
-    TensorIndexing, TensorReduction, TensorStructural,
+    DotGeneralAccumulation, SessionCachedDot, TensorAnalytic, TensorBuffer, TensorDot,
+    TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
 };
 
 use super::backend::reclaim_typed;
@@ -241,56 +241,29 @@ impl TensorDot for CpuExecSession<'_> {
         lhs: TensorRead<'_>,
         rhs: TensorRead<'_>,
         config: &DotGeneralConfig,
-        mut out: TensorWrite<'_>,
+        out: TensorWrite<'_>,
     ) -> crate::Result<()> {
-        validate_dot_general_read_into(&lhs, &rhs, config, &out, "dot_general")?;
-        let direct = match self.kind {
-            CpuBackendKind::Faer => {
-                #[cfg(feature = "cpu-faer")]
-                {
-                    gemm::dot_general_faer_read_into_cached(
-                        lhs.clone(),
-                        rhs.clone(),
-                        config,
-                        &mut out,
-                    )?
-                }
-                #[cfg(not(feature = "cpu-faer"))]
-                {
-                    return Err(super::backend::unavailable_cpu_backend_kind(
-                        self.kind,
-                        "dot_general",
-                    ));
-                }
-            }
-            CpuBackendKind::Blas => {
-                #[cfg(feature = "cpu-blas")]
-                {
-                    gemm::dot_general_blas_read_into_cached(
-                        self.buffers,
-                        self.gemm_analysis_cache,
-                        None,
-                        lhs.clone(),
-                        rhs.clone(),
-                        config,
-                        &mut out,
-                    )?
-                }
-                #[cfg(not(feature = "cpu-blas"))]
-                {
-                    return Err(super::backend::unavailable_cpu_backend_kind(
-                        self.kind,
-                        "dot_general",
-                    ));
-                }
-            }
-        };
-        if direct {
-            return Ok(());
-        }
+        let accumulation = DotGeneralAccumulation::overwrite(lhs.dtype())?;
+        self.dot_general_read_into_accum(lhs, rhs, config, accumulation, out)
+    }
 
-        let result = self.dot_general_read(lhs, rhs, config)?;
-        out.copy_from_tensor(&result)
+    fn dot_general_read_into_accum(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        accumulation: DotGeneralAccumulation,
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        SessionCachedDot::dot_general_read_into_accum_cached(
+            self,
+            None,
+            lhs,
+            rhs,
+            config,
+            accumulation,
+            out,
+        )
     }
 
     fn dot_general_with_conj(
@@ -588,6 +561,69 @@ impl SessionCachedDot for CpuExecSession<'_> {
                 }
             }
         }
+    }
+
+    fn dot_general_read_into_accum_cached(
+        &mut self,
+        cache_slot: Option<usize>,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        accumulation: DotGeneralAccumulation,
+        mut out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        validate_dot_general_accumulation(&lhs, &rhs, config, accumulation, &out, "dot_general")?;
+        let direct = match self.kind {
+            CpuBackendKind::Faer => {
+                #[cfg(feature = "cpu-faer")]
+                {
+                    gemm::dot_general_faer_read_into_accum_cached(
+                        self.gemm_analysis_cache,
+                        cache_slot,
+                        self.ctx,
+                        lhs.clone(),
+                        rhs.clone(),
+                        config,
+                        accumulation,
+                        &mut out,
+                    )?
+                }
+                #[cfg(not(feature = "cpu-faer"))]
+                {
+                    return Err(super::backend::unavailable_cpu_backend_kind(
+                        self.kind,
+                        "dot_general",
+                    ));
+                }
+            }
+            CpuBackendKind::Blas => {
+                #[cfg(feature = "cpu-blas")]
+                {
+                    gemm::dot_general_blas_read_into_accum_cached(
+                        self.buffers,
+                        self.gemm_analysis_cache,
+                        cache_slot,
+                        lhs.clone(),
+                        rhs.clone(),
+                        config,
+                        accumulation,
+                        &mut out,
+                    )?
+                }
+                #[cfg(not(feature = "cpu-blas"))]
+                {
+                    return Err(super::backend::unavailable_cpu_backend_kind(
+                        self.kind,
+                        "dot_general",
+                    ));
+                }
+            }
+        };
+        if direct {
+            return Ok(());
+        }
+
+        dot_general_accum_via_temp(self, lhs, rhs, config, accumulation, out)
     }
 }
 

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -11,13 +11,12 @@ use crate::structural::typed_transpose_with_pool;
 #[cfg(feature = "cpu-blas")]
 use crate::ConjElem;
 use crate::{Error, Result};
-use tenferro_tensor::DotGeneralConfig;
 use tenferro_tensor::{
-    col_major_strides, Buffer, TensorRead, TensorView, TensorWrite, TypedTensor, TypedTensorView,
+    col_major_strides, Buffer, TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensor,
+    TypedTensorView, TypedTensorViewMut,
 };
 use tenferro_tensor::{CacheStats, RuntimeCacheControl};
-#[cfg(feature = "cpu-faer")]
-use tenferro_tensor::{TensorViewMut, TypedTensorViewMut};
+use tenferro_tensor::{ContractionScalar, DotGeneralAccumulation, DotGeneralConfig};
 
 #[cfg(feature = "cpu-blas")]
 mod blas_gemm;
@@ -533,6 +532,91 @@ fn checked_view_batch_offset(base: isize, batch: usize, stride: isize) -> Result
                 "view batch offset overflows isize: base={base} batch={batch} stride={stride}"
             ),
         })
+}
+
+fn output_gemm_strides(
+    out_shape: &[usize],
+    out_strides: &[isize],
+    lhs_rank: usize,
+    rhs_rank: usize,
+    config: &DotGeneralConfig,
+) -> crate::Result<Option<(isize, isize, isize)>> {
+    let nm = lhs_rank
+        .checked_sub(config.lhs_contracting_dims.len() + config.lhs_batch_dims.len())
+        .ok_or_else(|| Error::InvalidConfig {
+            op: OP,
+            message: "lhs free rank underflow while analyzing output strides".into(),
+        })?;
+    let nn = rhs_rank
+        .checked_sub(config.rhs_contracting_dims.len() + config.rhs_batch_dims.len())
+        .ok_or_else(|| Error::InvalidConfig {
+            op: OP,
+            message: "rhs free rank underflow while analyzing output strides".into(),
+        })?;
+    let nb = config.lhs_batch_dims.len();
+    if out_shape.len() != nm + nn + nb || out_strides.len() != out_shape.len() {
+        return Ok(None);
+    }
+
+    let out_m_shapes = &out_shape[..nm];
+    let out_m_strides = &out_strides[..nm];
+    let out_n_shapes = &out_shape[nm..nm + nn];
+    let out_n_strides = &out_strides[nm..nm + nn];
+    let out_b_shapes = &out_shape[nm + nn..];
+    let out_b_strides = &out_strides[nm + nn..];
+
+    let Some((_, c_rs)) = try_fuse_dims(out_m_shapes, out_m_strides)? else {
+        return Ok(None);
+    };
+    let Some((_, c_cs)) = try_fuse_dims(out_n_shapes, out_n_strides)? else {
+        return Ok(None);
+    };
+    let Some((_, c_bs)) = try_fuse_dims(out_b_shapes, out_b_strides)? else {
+        return Ok(None);
+    };
+    Ok(Some((c_rs, c_cs, c_bs)))
+}
+
+fn scale_empty_contract_output<T>(out: &mut TypedTensorViewMut<'_, T>, beta: T) -> crate::Result<()>
+where
+    T: Copy + Zero + PartialEq + std::ops::Mul<Output = T> + 'static,
+{
+    let beta_is_zero = beta == T::zero();
+    let shape = out.shape().to_vec();
+    let element_count = checked_product(&shape).ok_or_else(|| {
+        Error::backend_failure(
+            OP,
+            "output element count overflow while scaling empty contraction output",
+        )
+    })?;
+    for linear in 0..element_count {
+        let indices = flat_to_multi_for_shape(&shape, linear);
+        let output = out.get_mut(&indices).ok_or_else(|| Error::InvalidConfig {
+            op: OP,
+            message: format!("output index {indices:?} is outside accumulation target"),
+        })?;
+        // INVARIANT: beta == 0 follows GEMM semantics and overwrites the
+        // destination with zero without reading its previous value.
+        *output = if beta_is_zero {
+            T::zero()
+        } else {
+            beta * *output
+        };
+    }
+    Ok(())
+}
+
+fn flat_to_multi_for_shape(shape: &[usize], mut linear: usize) -> SmallVec<[usize; 8]> {
+    let mut indices = SmallVec::<[usize; 8]>::with_capacity(shape.len());
+    for &dim in shape {
+        if dim == 0 {
+            indices.push(0);
+        } else {
+            indices.push(linear % dim);
+            linear /= dim;
+        }
+    }
+    indices
 }
 
 fn dim_to_isize(dim: usize, context: &'static str) -> Result<isize> {
@@ -1069,6 +1153,195 @@ pub(crate) fn dot_general_faer_read_into_cached(
 }
 
 #[cfg(feature = "cpu-faer")]
+// INVARIANT: this fast path mirrors dot-general read inputs plus cache,
+// context, accumulation, and output-write metadata for one backend dispatch.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn dot_general_faer_read_into_accum_cached(
+    cache: &mut GemmAnalysisCache,
+    cache_slot: Option<usize>,
+    ctx: &crate::CpuContext,
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+    config: &DotGeneralConfig,
+    accumulation: DotGeneralAccumulation,
+    out: &mut TensorWrite<'_>,
+) -> crate::Result<bool> {
+    if !accumulation.lhs_conj
+        && !accumulation.rhs_conj
+        && accumulation.alpha == ContractionScalar::one(lhs.dtype())?
+        && accumulation.beta == ContractionScalar::zero(lhs.dtype())?
+    {
+        return dot_general_faer_read_into_cached(lhs, rhs, config, out);
+    }
+
+    macro_rules! dispatch {
+        ($owned:ident, $view:ident) => {
+            if let (ContractionScalar::$owned(alpha), ContractionScalar::$owned(beta)) =
+                (accumulation.alpha, accumulation.beta)
+            {
+                match (&lhs, &rhs, &mut *out) {
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return dot_general_faer_accum_typed(
+                            cache,
+                            cache_slot,
+                            ctx,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            &mut c,
+                        );
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return dot_general_faer_accum_typed(
+                            cache,
+                            cache_slot,
+                            ctx,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            &mut c,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return dot_general_faer_accum_typed(
+                            cache,
+                            cache_slot,
+                            ctx,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            &mut c,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return dot_general_faer_accum_typed(
+                            cache,
+                            cache_slot,
+                            ctx,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            &mut c,
+                        );
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => {
+                        return dot_general_faer_accum_typed(
+                            cache,
+                            cache_slot,
+                            ctx,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            c,
+                        );
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => {
+                        return dot_general_faer_accum_typed(
+                            cache,
+                            cache_slot,
+                            ctx,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            c,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => {
+                        return dot_general_faer_accum_typed(
+                            cache,
+                            cache_slot,
+                            ctx,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            c,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => {
+                        return dot_general_faer_accum_typed(
+                            cache,
+                            cache_slot,
+                            ctx,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            c,
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        };
+    }
+
+    dispatch!(F32, F32);
+    dispatch!(F64, F64);
+    dispatch!(C32, C32);
+    dispatch!(C64, C64);
+    Ok(false)
+}
+
+#[cfg(feature = "cpu-faer")]
 fn dot_general_faer_into_typed<L, R, T>(
     lhs: &L,
     rhs: &R,
@@ -1087,6 +1360,94 @@ where
         _,
         strided_einsum2::backend::FaerBackend,
     >(lhs, rhs, config, out)
+}
+
+#[cfg(feature = "cpu-faer")]
+// INVARIANT: typed accumulation needs the validated operand views, cache
+// metadata, provider context, scalar coefficients, and output view together.
+#[allow(clippy::too_many_arguments)]
+fn dot_general_faer_accum_typed<L, R, T>(
+    cache: &mut GemmAnalysisCache,
+    cache_slot: Option<usize>,
+    ctx: &crate::CpuContext,
+    lhs: &L,
+    rhs: &R,
+    config: &DotGeneralConfig,
+    accumulation: DotGeneralAccumulation,
+    alpha: T,
+    beta: T,
+    out: &mut TypedTensorViewMut<'_, T>,
+) -> crate::Result<bool>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+    T: FaerGemm + Copy + Clone + Zero + PartialEq + std::ops::Mul<Output = T> + 'static,
+{
+    let Some(dims) = analyse_gemm_cached(
+        cache,
+        cache_slot,
+        GemmAnalysisCacheKind::Direct,
+        lhs,
+        rhs,
+        config,
+    )?
+    else {
+        return Ok(false);
+    };
+    let Some((c_rs, c_cs, c_bs)) = output_gemm_strides(
+        out.shape(),
+        out.strides(),
+        lhs.shape().len(),
+        rhs.shape().len(),
+        config,
+    )?
+    else {
+        return Ok(false);
+    };
+
+    if dims.k == 0 || dims.m == 0 || dims.n == 0 || dims.batch_total == 0 {
+        scale_empty_contract_output(out, beta)?;
+        return Ok(true);
+    }
+
+    let Some(a_data) = lhs.host_data_opt()?.map(<[T]>::as_ptr) else {
+        return Ok(false);
+    };
+    let Some(b_data) = rhs.host_data_opt()?.map(<[T]>::as_ptr) else {
+        return Ok(false);
+    };
+    let a_base = lhs.offset();
+    let b_base = rhs.offset();
+    let c_base = out.offset();
+    let c_data = out.host_storage_mut()?.as_mut_ptr();
+
+    for batch in 0..dims.batch_total {
+        let a_off = checked_view_batch_offset(a_base, batch, dims.a_bs)?;
+        let b_off = checked_view_batch_offset(b_base, batch, dims.b_bs)?;
+        let c_off = checked_view_batch_offset(c_base, batch, c_bs)?;
+        unsafe {
+            T::strided_gemm_with_conj(
+                ctx,
+                alpha,
+                a_data.offset(a_off),
+                dims.m,
+                dims.k,
+                dims.a_rs,
+                dims.a_cs,
+                accumulation.lhs_conj,
+                b_data.offset(b_off),
+                dims.n,
+                dims.b_rs,
+                dims.b_cs,
+                accumulation.rhs_conj,
+                beta,
+                c_data.offset(c_off),
+                c_rs,
+                c_cs,
+            );
+        }
+    }
+    Ok(true)
 }
 
 #[cfg(feature = "cpu-faer")]
@@ -1410,16 +1771,283 @@ pub(crate) fn dot_general_blas_read_cached(
 }
 
 #[cfg(feature = "cpu-blas")]
-pub(crate) fn dot_general_blas_read_into_cached(
+// INVARIANT: this fast path mirrors dot-general read inputs plus cache,
+// accumulation, and output-write metadata for one BLAS dispatch.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn dot_general_blas_read_into_accum_cached(
     _buffers: &mut BufferPool,
-    _cache: &mut GemmAnalysisCache,
-    _cache_slot: Option<usize>,
-    _lhs: TensorRead<'_>,
-    _rhs: TensorRead<'_>,
-    _config: &DotGeneralConfig,
-    _out: &mut TensorWrite<'_>,
+    cache: &mut GemmAnalysisCache,
+    cache_slot: Option<usize>,
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+    config: &DotGeneralConfig,
+    accumulation: DotGeneralAccumulation,
+    out: &mut TensorWrite<'_>,
 ) -> crate::Result<bool> {
+    macro_rules! dispatch {
+        ($owned:ident, $view:ident) => {
+            if let (ContractionScalar::$owned(alpha), ContractionScalar::$owned(beta)) =
+                (accumulation.alpha, accumulation.beta)
+            {
+                match (&lhs, &rhs, &mut *out) {
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return dot_general_blas_accum_typed(
+                            cache,
+                            cache_slot,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            &mut c,
+                        );
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return dot_general_blas_accum_typed(
+                            cache,
+                            cache_slot,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            &mut c,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return dot_general_blas_accum_typed(
+                            cache,
+                            cache_slot,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            &mut c,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return dot_general_blas_accum_typed(
+                            cache,
+                            cache_slot,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            &mut c,
+                        );
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => {
+                        return dot_general_blas_accum_typed(
+                            cache,
+                            cache_slot,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            c,
+                        );
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => {
+                        return dot_general_blas_accum_typed(
+                            cache,
+                            cache_slot,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            c,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => {
+                        return dot_general_blas_accum_typed(
+                            cache,
+                            cache_slot,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            c,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => {
+                        return dot_general_blas_accum_typed(
+                            cache,
+                            cache_slot,
+                            a,
+                            b,
+                            config,
+                            accumulation,
+                            alpha,
+                            beta,
+                            c,
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        };
+    }
+
+    dispatch!(F32, F32);
+    dispatch!(F64, F64);
+    dispatch!(C32, C32);
+    dispatch!(C64, C64);
     Ok(false)
+}
+
+#[cfg(feature = "cpu-blas")]
+// INVARIANT: typed BLAS accumulation needs the validated operand views, cache
+// metadata, scalar coefficients, and output view together.
+#[allow(clippy::too_many_arguments)]
+fn dot_general_blas_accum_typed<L, R, T>(
+    cache: &mut GemmAnalysisCache,
+    cache_slot: Option<usize>,
+    lhs: &L,
+    rhs: &R,
+    config: &DotGeneralConfig,
+    accumulation: DotGeneralAccumulation,
+    alpha: T,
+    beta: T,
+    out: &mut TypedTensorViewMut<'_, T>,
+) -> crate::Result<bool>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+    T: BlasGemm + Copy + Clone + Zero + PartialEq + std::ops::Mul<Output = T> + 'static,
+{
+    let Some(dims) = analyse_gemm_cached(
+        cache,
+        cache_slot,
+        GemmAnalysisCacheKind::Direct,
+        lhs,
+        rhs,
+        config,
+    )?
+    else {
+        return Ok(false);
+    };
+    let Some((c_rs, c_cs, c_bs)) = output_gemm_strides(
+        out.shape(),
+        out.strides(),
+        lhs.shape().len(),
+        rhs.shape().len(),
+        config,
+    )?
+    else {
+        return Ok(false);
+    };
+
+    if dims.k == 0 || dims.m == 0 || dims.n == 0 || dims.batch_total == 0 {
+        scale_empty_contract_output(out, beta)?;
+        return Ok(true);
+    }
+
+    let a_rs = normalize_singleton_stride(dims.a_rs, dims.m, dims.k);
+    let a_cs = normalize_singleton_stride(dims.a_cs, dims.k, dims.m);
+    let b_rs = normalize_singleton_stride(dims.b_rs, dims.k, dims.n);
+    let b_cs = normalize_singleton_stride(dims.b_cs, dims.n, dims.k);
+    let c_rs = normalize_singleton_stride(c_rs, dims.m, 1);
+    let c_cs = normalize_singleton_stride(c_cs, dims.n, dims.m);
+
+    if !blas_lhs_layout_supported(dims.m, dims.k, a_rs, a_cs)
+        || !blas_rhs_layout_supported(dims.k, dims.n, b_rs, b_cs)
+        || !blas_output_layout_supported(dims.m, c_rs, c_cs)
+    {
+        return Ok(false);
+    }
+    if (accumulation.lhs_conj && a_rs == 1) || (accumulation.rhs_conj && b_rs == 1) {
+        return Ok(false);
+    }
+
+    let Some(a_data) = lhs.host_data_opt()?.map(<[T]>::as_ptr) else {
+        return Ok(false);
+    };
+    let Some(b_data) = rhs.host_data_opt()?.map(<[T]>::as_ptr) else {
+        return Ok(false);
+    };
+    let a_base = lhs.offset();
+    let b_base = rhs.offset();
+    let c_base = out.offset();
+    let c_data = out.host_storage_mut()?.as_mut_ptr();
+
+    for batch in 0..dims.batch_total {
+        let a_off = checked_view_batch_offset(a_base, batch, dims.a_bs)?;
+        let b_off = checked_view_batch_offset(b_base, batch, dims.b_bs)?;
+        let c_off = checked_view_batch_offset(c_base, batch, c_bs)?;
+        let executed = unsafe {
+            T::strided_gemm_with_conj(
+                alpha,
+                a_data.offset(a_off),
+                dims.m,
+                dims.k,
+                a_rs,
+                a_cs,
+                accumulation.lhs_conj,
+                b_data.offset(b_off),
+                dims.n,
+                b_rs,
+                b_cs,
+                accumulation.rhs_conj,
+                beta,
+                c_data.offset(c_off),
+                c_rs,
+                c_cs,
+            )?
+        };
+        if !executed {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
 }
 
 #[cfg(feature = "cpu-blas")]

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -19,9 +19,10 @@ use crate::{
 #[cfg(feature = "cpu-blas")]
 use tenferro_tensor::StridedSliceSpec;
 use tenferro_tensor::{
-    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, SessionCachedDot, TensorAnalytic,
-    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
-    TensorIndexing, TensorReduction, TensorStructural,
+    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, ContractionScalar,
+    DotGeneralAccumulation, SessionCachedDot, TensorAnalytic, TensorBackend, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorReduction, TensorStructural,
 };
 use tenferro_tensor::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,

--- a/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
@@ -244,6 +244,258 @@ fn test_dot_general_read_into_rejects_output_shape_and_dtype_mismatch() {
     ));
 }
 
+#[test]
+fn test_dot_general_read_into_accum_updates_existing_output() {
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let initial = [10.0_f64, 20.0, 30.0, 40.0];
+    let mut out = Tensor::from_vec_col_major(vec![2, 2], initial.to_vec()).unwrap();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let accum = DotGeneralAccumulation {
+        lhs_conj: false,
+        rhs_conj: false,
+        alpha: ContractionScalar::F64(2.0),
+        beta: ContractionScalar::F64(-0.5),
+    };
+    let mut backend = CpuBackend::new();
+
+    backend
+        .dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config,
+            accum,
+            TensorWrite::from_tensor(&mut out),
+        )
+        .unwrap();
+
+    let expected_dot = [22.0, 28.0, 49.0, 64.0];
+    for (actual, expected) in out
+        .as_slice::<f64>()
+        .unwrap()
+        .iter()
+        .zip(expected_dot.iter().zip(initial))
+    {
+        let (dot, previous) = expected;
+        assert_f64_close(*actual, 2.0 * *dot - 0.5 * previous);
+    }
+
+    let mut strided_data = [-1.0_f64, 10.0, 20.0, -1.0, 30.0, 40.0, -1.0, -1.0];
+    {
+        let out_view = TensorViewMut::F64(
+            TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut strided_data).unwrap(),
+        );
+        backend
+            .with_backend_session(|exec| {
+                exec.dot_general_read_into_accum_cached(
+                    Some(7),
+                    TensorRead::from_tensor(&lhs),
+                    TensorRead::from_tensor(&rhs),
+                    &config,
+                    accum,
+                    TensorWrite::from_view(out_view),
+                )
+            })
+            .unwrap();
+    }
+    assert_eq!(strided_data[0], -1.0);
+    assert_eq!(strided_data[3], -1.0);
+    assert_eq!(strided_data[6], -1.0);
+    assert_eq!(strided_data[7], -1.0);
+    for (actual, expected) in [
+        strided_data[1],
+        strided_data[2],
+        strided_data[4],
+        strided_data[5],
+    ]
+    .into_iter()
+    .zip(expected_dot.iter().zip(initial))
+    {
+        let (dot, previous) = expected;
+        assert_f64_close(actual, 2.0 * *dot - 0.5 * previous);
+    }
+}
+
+#[test]
+fn test_dot_general_read_into_accum_applies_complex_conj_and_scalars() {
+    let lhs_data = vec![
+        Complex64::new(1.0, 2.0),
+        Complex64::new(-3.0, 0.5),
+        Complex64::new(2.0, -1.0),
+        Complex64::new(0.25, 4.0),
+    ];
+    let rhs_data = vec![
+        Complex64::new(-2.0, 1.0),
+        Complex64::new(1.5, -0.25),
+        Complex64::new(0.5, 3.0),
+        Complex64::new(-1.0, -2.0),
+    ];
+    let initial = vec![
+        Complex64::new(1.0, -1.0),
+        Complex64::new(2.0, 0.5),
+        Complex64::new(-3.0, 2.0),
+        Complex64::new(0.25, -4.0),
+    ];
+    let lhs = Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], lhs_data.clone()).unwrap());
+    let rhs = Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], rhs_data.clone()).unwrap());
+    let mut out =
+        Tensor::C64(TypedTensor::from_vec_col_major(vec![2, 2], initial.clone()).unwrap());
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let alpha = Complex64::new(0.5, -1.0);
+    let beta = Complex64::new(-0.25, 0.75);
+    let accum = DotGeneralAccumulation {
+        lhs_conj: true,
+        rhs_conj: true,
+        alpha: ContractionScalar::C64(alpha),
+        beta: ContractionScalar::C64(beta),
+    };
+    let mut backend = CpuBackend::new();
+
+    backend
+        .dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config,
+            accum,
+            TensorWrite::from_tensor(&mut out),
+        )
+        .unwrap();
+
+    let lhs_conj: Vec<Complex64> = lhs_data.iter().map(|value| value.conj()).collect();
+    let rhs_conj: Vec<Complex64> = rhs_data.iter().map(|value| value.conj()).collect();
+    let dot = matmul_c64(&lhs_conj, &rhs_conj, 2, 2, 2);
+    for index in 0..4 {
+        assert_c64_close(
+            out.as_slice::<Complex64>().unwrap()[index],
+            alpha * dot[index] + beta * initial[index],
+        );
+    }
+}
+
+#[test]
+fn test_dot_general_read_into_accum_rejects_scalar_dtype_mismatch() {
+    let lhs = Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f64]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1, 1], vec![3.0_f64]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![1, 1], vec![4.0_f64]).unwrap();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let accum = DotGeneralAccumulation {
+        lhs_conj: false,
+        rhs_conj: false,
+        alpha: ContractionScalar::F32(1.0),
+        beta: ContractionScalar::F64(0.0),
+    };
+    let mut backend = CpuBackend::new();
+
+    let err = backend
+        .dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config,
+            accum,
+            TensorWrite::from_tensor(&mut out),
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::DTypeMismatch {
+            op: "dot_general",
+            lhs: DType::F32,
+            rhs: DType::F64,
+        }
+    ));
+}
+
+#[test]
+fn test_dot_general_read_into_accum_covers_supported_scalar_dtypes() {
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+
+    let lhs_f32 = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f32, 2.0, 3.0, 4.0]).unwrap();
+    let rhs_f32 = Tensor::from_vec_col_major(vec![2, 1], vec![5.0_f32, 6.0]).unwrap();
+    let mut out_f32 = Tensor::from_vec_col_major(vec![2, 1], vec![7.0_f32, 8.0]).unwrap();
+    CpuBackend::new()
+        .dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs_f32),
+            TensorRead::from_tensor(&rhs_f32),
+            &config,
+            DotGeneralAccumulation {
+                lhs_conj: false,
+                rhs_conj: false,
+                alpha: ContractionScalar::F32(2.0),
+                beta: ContractionScalar::F32(-0.5),
+            },
+            TensorWrite::from_tensor(&mut out_f32),
+        )
+        .unwrap();
+    let out_f32 = out_f32.as_slice::<f32>().unwrap();
+    assert!((out_f32[0] - 42.5).abs() < 1.0e-5);
+    assert!((out_f32[1] - 64.0).abs() < 1.0e-5);
+
+    let lhs_c32 = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![1, 2],
+            vec![Complex32::new(1.0, 1.0), Complex32::new(2.0, -1.0)],
+        )
+        .unwrap(),
+    );
+    let rhs_c32 = Tensor::C32(
+        TypedTensor::from_vec_col_major(
+            vec![2, 1],
+            vec![Complex32::new(0.5, -1.0), Complex32::new(3.0, 0.25)],
+        )
+        .unwrap(),
+    );
+    let mut out_c32 = Tensor::C32(
+        TypedTensor::from_vec_col_major(vec![1, 1], vec![Complex32::new(-2.0, 0.5)]).unwrap(),
+    );
+    let alpha = Complex32::new(1.5, -0.25);
+    let beta = Complex32::new(0.25, 0.5);
+    CpuBackend::new()
+        .dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs_c32),
+            TensorRead::from_tensor(&rhs_c32),
+            &config,
+            DotGeneralAccumulation {
+                lhs_conj: true,
+                rhs_conj: false,
+                alpha: ContractionScalar::C32(alpha),
+                beta: ContractionScalar::C32(beta),
+            },
+            TensorWrite::from_tensor(&mut out_c32),
+        )
+        .unwrap();
+    let dot = lhs_c32.as_slice::<Complex32>().unwrap()[0].conj()
+        * rhs_c32.as_slice::<Complex32>().unwrap()[0]
+        + lhs_c32.as_slice::<Complex32>().unwrap()[1].conj()
+            * rhs_c32.as_slice::<Complex32>().unwrap()[1];
+    let expected = alpha * dot + beta * Complex32::new(-2.0, 0.5);
+    let actual = out_c32.as_slice::<Complex32>().unwrap()[0];
+    assert!((actual.re - expected.re).abs() < 1.0e-5);
+    assert!((actual.im - expected.im).abs() < 1.0e-5);
+}
+
 #[cfg(feature = "cpu-blas")]
 #[test]
 fn test_dot_general_read_blas_negative_stride_view_falls_back() {

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -3,7 +3,8 @@ use crate::config::{
 };
 use crate::types::{TensorRank, TypedTensor, TypedTensorView, TypedTensorViewMut};
 use crate::validate::validate_convert_dtype;
-use crate::{RuntimeCacheControl, Tensor, TensorRead, TensorValue, TensorWrite};
+use crate::{DType, RuntimeCacheControl, Tensor, TensorRead, TensorValue, TensorWrite};
+use num_complex::{Complex32, Complex64};
 
 fn read_boundary_error(op: &'static str) -> crate::Error {
     crate::Error::backend_failure(
@@ -177,6 +178,266 @@ pub fn validate_dot_general_read_into(
         });
     }
     Ok(expected)
+}
+
+/// Scalar coefficient accepted by contraction accumulation backends.
+///
+/// `ContractionScalar` is intentionally narrower than [`crate::TensorScalar`]:
+/// dot-general accumulation is only defined for floating and complex tensor
+/// dtypes.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{ContractionScalar, DType};
+///
+/// let alpha = ContractionScalar::F64(2.0);
+/// assert_eq!(alpha.dtype(), DType::F64);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ContractionScalar {
+    F32(f32),
+    F64(f64),
+    C32(Complex32),
+    C64(Complex64),
+}
+
+impl ContractionScalar {
+    /// Return this scalar's tensor dtype.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{ContractionScalar, DType};
+    ///
+    /// assert_eq!(ContractionScalar::F32(1.0).dtype(), DType::F32);
+    /// ```
+    pub fn dtype(self) -> DType {
+        match self {
+            Self::F32(_) => DType::F32,
+            Self::F64(_) => DType::F64,
+            Self::C32(_) => DType::C32,
+            Self::C64(_) => DType::C64,
+        }
+    }
+
+    /// Return the multiplicative identity for a supported contraction dtype.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{ContractionScalar, DType};
+    ///
+    /// assert_eq!(ContractionScalar::one(DType::F64).unwrap(), ContractionScalar::F64(1.0));
+    /// assert!(ContractionScalar::one(DType::I32).is_err());
+    /// ```
+    pub fn one(dtype: DType) -> crate::Result<Self> {
+        match dtype {
+            DType::F32 => Ok(Self::F32(1.0)),
+            DType::F64 => Ok(Self::F64(1.0)),
+            DType::C32 => Ok(Self::C32(Complex32::new(1.0, 0.0))),
+            DType::C64 => Ok(Self::C64(Complex64::new(1.0, 0.0))),
+            DType::I32 | DType::I64 | DType::Bool => Err(crate::Error::DTypeMismatch {
+                op: "dot_general",
+                lhs: dtype,
+                rhs: DType::F32,
+            }),
+        }
+    }
+
+    /// Return the additive identity for a supported contraction dtype.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{ContractionScalar, DType};
+    ///
+    /// assert_eq!(ContractionScalar::zero(DType::F64).unwrap(), ContractionScalar::F64(0.0));
+    /// ```
+    pub fn zero(dtype: DType) -> crate::Result<Self> {
+        match dtype {
+            DType::F32 => Ok(Self::F32(0.0)),
+            DType::F64 => Ok(Self::F64(0.0)),
+            DType::C32 => Ok(Self::C32(Complex32::new(0.0, 0.0))),
+            DType::C64 => Ok(Self::C64(Complex64::new(0.0, 0.0))),
+            DType::I32 | DType::I64 | DType::Bool => Err(crate::Error::DTypeMismatch {
+                op: "dot_general",
+                lhs: dtype,
+                rhs: DType::F32,
+            }),
+        }
+    }
+}
+
+/// Output-update semantics for dot-general accumulation.
+///
+/// This keeps contraction axes in [`DotGeneralConfig`] and output update
+/// semantics here, so cached and non-cached backend traits can share the same
+/// accumulation contract.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::{ContractionScalar, DotGeneralAccumulation, DType};
+///
+/// let accum = DotGeneralAccumulation::overwrite(DType::F64).unwrap();
+/// assert_eq!(accum.alpha, ContractionScalar::F64(1.0));
+/// assert_eq!(accum.beta, ContractionScalar::F64(0.0));
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DotGeneralAccumulation {
+    pub lhs_conj: bool,
+    pub rhs_conj: bool,
+    pub alpha: ContractionScalar,
+    pub beta: ContractionScalar,
+}
+
+impl DotGeneralAccumulation {
+    /// Return overwrite semantics, `out = lhs dot rhs`, for `dtype`.
+    pub fn overwrite(dtype: DType) -> crate::Result<Self> {
+        Ok(Self {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::one(dtype)?,
+            beta: ContractionScalar::zero(dtype)?,
+        })
+    }
+
+    fn validate_for_dtype(self, dtype: DType) -> crate::Result<()> {
+        for scalar in [self.alpha, self.beta] {
+            if scalar.dtype() != dtype {
+                return Err(crate::Error::DTypeMismatch {
+                    op: "dot_general",
+                    lhs: scalar.dtype(),
+                    rhs: dtype,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[doc(hidden)]
+pub fn validate_dot_general_accumulation(
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
+    config: &DotGeneralConfig,
+    accumulation: DotGeneralAccumulation,
+    out: &TensorWrite<'_>,
+    op: &'static str,
+) -> crate::Result<Vec<usize>> {
+    let shape = validate_dot_general_read_into(lhs, rhs, config, out, op)?;
+    accumulation.validate_for_dtype(lhs.dtype())?;
+    Ok(shape)
+}
+
+#[doc(hidden)]
+pub fn dot_general_accum_via_temp<B: TensorDot + ?Sized>(
+    backend: &mut B,
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+    config: &DotGeneralConfig,
+    accumulation: DotGeneralAccumulation,
+    mut out: TensorWrite<'_>,
+) -> crate::Result<()> {
+    validate_dot_general_accumulation(&lhs, &rhs, config, accumulation, &out, "dot_general")?;
+    let dot = backend.dot_general_with_conj_read(
+        lhs,
+        rhs,
+        config,
+        accumulation.lhs_conj,
+        accumulation.rhs_conj,
+    )?;
+    accumulate_dot_result_into(&dot, accumulation, &mut out)
+}
+
+fn accumulate_dot_result_into(
+    dot: &Tensor,
+    accumulation: DotGeneralAccumulation,
+    out: &mut TensorWrite<'_>,
+) -> crate::Result<()> {
+    macro_rules! dispatch {
+        ($variant:ident, $ty:ty) => {
+            if let (
+                Tensor::$variant(dot),
+                ContractionScalar::$variant(alpha),
+                ContractionScalar::$variant(beta),
+            ) = (dot, accumulation.alpha, accumulation.beta)
+            {
+                match out {
+                    TensorWrite::Tensor(Tensor::$variant(out)) => {
+                        let mut out = out.as_view_mut();
+                        accumulate_typed(dot.as_slice()?, alpha, beta, &mut out)?;
+                        return Ok(());
+                    }
+                    TensorWrite::View(crate::TensorViewMut::$variant(out)) => {
+                        accumulate_typed(dot.as_slice()?, alpha, beta, out)?;
+                        return Ok(());
+                    }
+                    _ => {}
+                }
+            }
+        };
+    }
+
+    dispatch!(F32, f32);
+    dispatch!(F64, f64);
+    dispatch!(C32, Complex32);
+    dispatch!(C64, Complex64);
+
+    Err(crate::Error::DTypeMismatch {
+        op: "dot_general",
+        lhs: accumulation.alpha.dtype(),
+        rhs: dot.dtype(),
+    })
+}
+
+fn accumulate_typed<T>(
+    dot: &[T],
+    alpha: T,
+    beta: T,
+    out: &mut TypedTensorViewMut<'_, T>,
+) -> crate::Result<()>
+where
+    T: Copy
+        + PartialEq
+        + std::ops::Add<Output = T>
+        + std::ops::Mul<Output = T>
+        + num_traits::Zero
+        + 'static,
+{
+    let beta_is_zero = beta == T::zero();
+    for (linear, dot_value) in dot.iter().copied().enumerate() {
+        let indices = flat_to_multi_for_shape(out.shape(), linear);
+        let output = out
+            .get_mut(&indices)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op: "dot_general",
+                message: format!("output index {indices:?} is outside accumulation target"),
+            })?;
+        // INVARIANT: beta == 0 follows BLAS GEMM semantics and does not read
+        // the existing output element; beta != 0 requires an initialized
+        // TensorWrite target and performs a read-modify-write update.
+        *output = if beta_is_zero {
+            alpha * dot_value
+        } else {
+            alpha * dot_value + beta * *output
+        };
+    }
+    Ok(())
+}
+
+fn flat_to_multi_for_shape(shape: &[usize], mut linear: usize) -> Vec<usize> {
+    let mut indices = Vec::with_capacity(shape.len());
+    for &dim in shape {
+        if dim == 0 {
+            indices.push(0);
+        } else {
+            indices.push(linear % dim);
+            linear /= dim;
+        }
+    }
+    indices
 }
 
 /// Canonical elementwise fusion plan shared between segmented execution and backends.
@@ -775,11 +1036,10 @@ pub trait TensorDot: TensorElementwise {
         lhs: TensorRead<'_>,
         rhs: TensorRead<'_>,
         config: &DotGeneralConfig,
-        mut out: TensorWrite<'_>,
+        out: TensorWrite<'_>,
     ) -> crate::Result<()> {
-        validate_dot_general_read_into(&lhs, &rhs, config, &out, "dot_general")?;
-        let result = self.dot_general_read(lhs, rhs, config)?;
-        out.copy_from_tensor(&result)
+        let accumulation = DotGeneralAccumulation::overwrite(lhs.dtype())?;
+        self.dot_general_read_into_accum(lhs, rhs, config, accumulation, out)
     }
 
     #[doc(hidden)]
@@ -841,6 +1101,18 @@ pub trait TensorDot: TensorElementwise {
             &rhs_tmp
         };
         self.dot_general_with_conj(lhs_ref, rhs_ref, config, lhs_conj, rhs_conj)
+    }
+
+    #[doc(hidden)]
+    fn dot_general_read_into_accum(
+        &mut self,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        accumulation: DotGeneralAccumulation,
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        dot_general_accum_via_temp(self, lhs, rhs, config, accumulation, out)
     }
 }
 
@@ -929,6 +1201,19 @@ pub trait SessionCachedDot: TensorDot {
             &rhs_tmp
         };
         self.dot_general_with_conj_cached(cache_slot, lhs_ref, rhs_ref, config, lhs_conj, rhs_conj)
+    }
+
+    #[doc(hidden)]
+    fn dot_general_read_into_accum_cached(
+        &mut self,
+        _cache_slot: Option<usize>,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        accumulation: DotGeneralAccumulation,
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        self.dot_general_read_into_accum(lhs, rhs, config, accumulation, out)
     }
 }
 
@@ -1195,6 +1480,23 @@ pub trait BackendCachedDot: BackendRuntimeCache + TensorDot {
         self.dot_general_with_conj_cached(
             cache, cache_slot, lhs_ref, rhs_ref, config, lhs_conj, rhs_conj,
         )
+    }
+
+    // INVARIANT: cached backend accumulation must carry cache owner metadata
+    // and the full dot-general output-update contract in one dispatch call.
+    #[allow(clippy::too_many_arguments)]
+    #[doc(hidden)]
+    fn dot_general_read_into_accum_cached(
+        &mut self,
+        _cache: &mut Self::RuntimeCache,
+        _cache_slot: Option<usize>,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        accumulation: DotGeneralAccumulation,
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        self.dot_general_read_into_accum(lhs, rhs, config, accumulation, out)
     }
 }
 

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -53,9 +53,10 @@ pub mod validate;
 
 pub use backend::{
     default_backend_session, BackendCachedDot, BackendRuntimeCache, BackendSession,
-    BackendSessionHost, SessionCachedDot, TensorAnalytic, TensorBackend, TensorBackendOps,
-    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
-    TensorReduction, TensorStructural, TensorViewCanonicalization,
+    BackendSessionHost, ContractionScalar, DotGeneralAccumulation, SessionCachedDot,
+    TensorAnalytic, TensorBackend, TensorBackendOps, TensorBuffer, TensorDeviceTransfer, TensorDot,
+    TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
+    TensorViewCanonicalization,
 };
 pub use cache::{CacheStats, RuntimeCacheControl};
 pub use config::*;

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -1,13 +1,16 @@
 use crate::{
-    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, CompareDir, DType, DotGeneralConfig,
-    GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend,
-    TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
-    TensorRead, TensorReduction, TensorStructural, TensorView, TypedTensor,
+    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, CompareDir, ContractionScalar,
+    DType, DotGeneralAccumulation, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,
+    SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer,
+    TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead, TensorReduction,
+    TensorStructural, TensorView, TensorViewMut, TensorWrite, TypedTensor,
 };
+use num_complex::{Complex32, Complex64};
 
 #[derive(Default)]
 struct DefaultReadBackend {
     calls: Vec<&'static str>,
+    dot_result: Option<Tensor>,
     gather_indices: Option<Tensor>,
     gather_config: Option<GatherConfig>,
     reshape_shapes: Vec<Vec<usize>>,
@@ -296,7 +299,7 @@ impl TensorDot for DefaultReadBackend {
         _config: &DotGeneralConfig,
     ) -> crate::Result<Tensor> {
         self.calls.push("dot_general");
-        Ok(marker())
+        Ok(self.dot_result.clone().unwrap_or_else(marker))
     }
 }
 
@@ -461,6 +464,208 @@ fn default_read_methods_delegate_owned_tensors_and_reject_views() {
 
     assert!(backend.calls.contains(&"add"));
     assert!(backend.calls.contains(&"dot_general"));
+}
+
+#[test]
+fn contraction_scalar_helpers_cover_supported_and_rejected_dtypes() {
+    assert_eq!(ContractionScalar::F32(1.0).dtype(), DType::F32);
+    assert_eq!(ContractionScalar::F64(1.0).dtype(), DType::F64);
+    assert_eq!(
+        ContractionScalar::C32(Complex32::new(1.0, 0.0)).dtype(),
+        DType::C32
+    );
+    assert_eq!(
+        ContractionScalar::C64(Complex64::new(1.0, 0.0)).dtype(),
+        DType::C64
+    );
+
+    assert_eq!(
+        ContractionScalar::one(DType::C32).unwrap(),
+        ContractionScalar::C32(Complex32::new(1.0, 0.0))
+    );
+    assert_eq!(
+        ContractionScalar::zero(DType::C64).unwrap(),
+        ContractionScalar::C64(Complex64::new(0.0, 0.0))
+    );
+    assert!(ContractionScalar::one(DType::I64).is_err());
+    assert!(ContractionScalar::zero(DType::Bool).is_err());
+
+    let overwrite = DotGeneralAccumulation::overwrite(DType::F32).unwrap();
+    assert_eq!(overwrite.alpha, ContractionScalar::F32(1.0));
+    assert_eq!(overwrite.beta, ContractionScalar::F32(0.0));
+    assert!(DotGeneralAccumulation::overwrite(DType::I32).is_err());
+}
+
+fn vector_contract_config() -> DotGeneralConfig {
+    DotGeneralConfig {
+        lhs_contracting_dims: vec![0],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    }
+}
+
+#[test]
+fn dot_general_accum_default_fallback_updates_tensor_and_view_outputs() {
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
+    let config = vector_contract_config();
+    let mut backend = DefaultReadBackend {
+        dot_result: Some(Tensor::from_vec_col_major(vec![], vec![42.0_f64]).unwrap()),
+        ..Default::default()
+    };
+    let accumulation = DotGeneralAccumulation {
+        lhs_conj: true,
+        rhs_conj: false,
+        alpha: ContractionScalar::F64(2.0),
+        beta: ContractionScalar::F64(0.5),
+    };
+    let mut out = Tensor::from_vec_col_major(vec![], vec![10.0_f64]).unwrap();
+
+    backend
+        .dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config,
+            accumulation,
+            TensorWrite::from_tensor(&mut out),
+        )
+        .unwrap();
+
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[89.0]);
+    assert!(backend.calls.contains(&"conj"));
+    assert!(backend.calls.contains(&"dot_general"));
+
+    let mut cache = ();
+    let mut out_view = TypedTensor::<f64>::from_vec_col_major(vec![], vec![1.0]).unwrap();
+    BackendCachedDot::dot_general_read_into_accum_cached(
+        &mut backend,
+        &mut cache,
+        Some(7),
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &config,
+        DotGeneralAccumulation {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::F64(1.0),
+            beta: ContractionScalar::F64(1.0),
+        },
+        TensorWrite::from_view(TensorViewMut::F64(out_view.as_view_mut())),
+    )
+    .unwrap();
+
+    assert_eq!(out_view.as_slice().unwrap(), &[43.0]);
+}
+
+#[test]
+fn dot_general_accum_default_fallback_covers_supported_scalar_dtypes() {
+    let config = vector_contract_config();
+
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![1.0_f32]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f32]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![], vec![10.0_f32]).unwrap();
+    let mut backend = DefaultReadBackend {
+        dot_result: Some(Tensor::from_vec_col_major(vec![], vec![4.0_f32]).unwrap()),
+        ..Default::default()
+    };
+    backend
+        .dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config,
+            DotGeneralAccumulation {
+                lhs_conj: false,
+                rhs_conj: false,
+                alpha: ContractionScalar::F32(2.0),
+                beta: ContractionScalar::F32(0.5),
+            },
+            TensorWrite::from_tensor(&mut out),
+        )
+        .unwrap();
+    assert_eq!(out.as_slice::<f32>().unwrap(), &[13.0]);
+
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![Complex32::new(1.0, 0.0)]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![Complex32::new(2.0, 0.0)]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![], vec![Complex32::new(3.0, -1.0)]).unwrap();
+    let mut backend = DefaultReadBackend {
+        dot_result: Some(
+            Tensor::from_vec_col_major(vec![], vec![Complex32::new(1.0, 2.0)]).unwrap(),
+        ),
+        ..Default::default()
+    };
+    backend
+        .dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config,
+            DotGeneralAccumulation {
+                lhs_conj: false,
+                rhs_conj: false,
+                alpha: ContractionScalar::C32(Complex32::new(2.0, 0.0)),
+                beta: ContractionScalar::C32(Complex32::new(0.0, 1.0)),
+            },
+            TensorWrite::from_tensor(&mut out),
+        )
+        .unwrap();
+    assert_eq!(
+        out.as_slice::<Complex32>().unwrap(),
+        &[Complex32::new(3.0, 7.0)]
+    );
+
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 0.0)]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![Complex64::new(2.0, 0.0)]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![], vec![Complex64::new(5.0, 0.0)]).unwrap();
+    let mut backend = DefaultReadBackend {
+        dot_result: Some(
+            Tensor::from_vec_col_major(vec![], vec![Complex64::new(4.0, -2.0)]).unwrap(),
+        ),
+        ..Default::default()
+    };
+    backend
+        .dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config,
+            DotGeneralAccumulation {
+                lhs_conj: false,
+                rhs_conj: false,
+                alpha: ContractionScalar::C64(Complex64::new(1.0, 0.0)),
+                beta: ContractionScalar::C64(Complex64::new(0.0, 0.0)),
+            },
+            TensorWrite::from_tensor(&mut out),
+        )
+        .unwrap();
+    assert_eq!(
+        out.as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(4.0, -2.0)]
+    );
+}
+
+#[test]
+fn dot_general_accum_default_fallback_rejects_scalar_dtype_mismatch() {
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![], vec![0.0_f64]).unwrap();
+    let config = vector_contract_config();
+    let mut backend = DefaultReadBackend::default();
+
+    let err = backend
+        .dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config,
+            DotGeneralAccumulation {
+                lhs_conj: false,
+                rhs_conj: false,
+                alpha: ContractionScalar::F32(1.0),
+                beta: ContractionScalar::F64(0.0),
+            },
+            TensorWrite::from_tensor(&mut out),
+        )
+        .unwrap_err();
+
+    assert!(err.to_string().contains("dtype mismatch"));
 }
 
 #[test]

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -2002,6 +2002,30 @@ fn tensor_as_slice_returns_none_for_dtype_mismatch() {
 }
 
 #[test]
+fn tensor_write_as_read_borrows_tensor_and_view_outputs() {
+    let mut tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let write = TensorWrite::from_tensor(&mut tensor);
+    let read = write.as_read();
+    assert_eq!(read.dtype(), DType::F64);
+    assert_eq!(read.shape(), &[2]);
+    assert_eq!(
+        read.as_tensor().unwrap().as_slice::<f64>().unwrap(),
+        &[1.0, 2.0]
+    );
+
+    let mut data = [0.0_f64, 3.0, 4.0, 0.0];
+    let view = TensorViewMut::F64(TypedTensorViewMut::from_slice([2], [1], 1, &mut data).unwrap());
+    let write = TensorWrite::from_view(view);
+    let read = write.as_read();
+    assert_eq!(read.dtype(), DType::F64);
+    assert_eq!(read.shape(), &[2]);
+    assert_eq!(
+        read.to_tensor().unwrap().as_slice::<f64>().unwrap(),
+        &[3.0, 4.0]
+    );
+}
+
+#[test]
 fn memory_kind_variants_are_constructible() {
     let kinds = [
         MemoryKind::Device,

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -3136,6 +3136,30 @@ impl<'a> TensorWrite<'a> {
         Self::View(view)
     }
 
+    /// Borrow this writable target as a read-only tensor input.
+    ///
+    /// This is useful for explicit read-modify-write kernels such as
+    /// accumulation updates. The returned view borrows through `&self`, so it
+    /// cannot outlive the current read-only borrow of the writable target.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{DType, Tensor, TensorWrite};
+    ///
+    /// let mut tensor = Tensor::from_vec_col_major(vec![1], vec![2.0_f64])?;
+    /// let write = TensorWrite::from_tensor(&mut tensor);
+    /// let read = write.as_read();
+    /// assert_eq!(read.dtype(), DType::F64);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn as_read(&self) -> TensorRead<'_> {
+        match self {
+            Self::Tensor(tensor) => TensorRead::from_tensor(tensor),
+            Self::View(view) => TensorRead::from_view(view.as_read_only()),
+        }
+    }
+
     pub fn dtype(&self) -> DType {
         match self {
             Self::Tensor(tensor) => tensor.dtype(),

--- a/docs/design/tensor.md
+++ b/docs/design/tensor.md
@@ -63,6 +63,13 @@ Preallocated-output APIs use `TensorWrite` when the output may be either an
 owned tensor or a mutable view. These APIs validate output dtype and shape
 before writing and do not resize the destination.
 
+Dot-general accumulation keeps contraction axes and output-update semantics in
+separate contracts. `DotGeneralConfig` describes only dimension roles. Output
+updates such as `out = alpha * op(lhs) * op(rhs) + beta * out` use
+`DotGeneralAccumulation`, including conjugation flags and the floating/complex
+`ContractionScalar` coefficients. Cache ownership stays on `SessionCachedDot`
+and `BackendCachedDot`; non-cached `TensorDot` methods do not take cache slots.
+
 Metadata-only APIs that produce views use `_view`. APIs that allocate,
 execute kernels, canonicalize buffers, or move data must not use `_view`.
 

--- a/docs/worklogs/2026-07-03-issue-1285-dot-accumulation.md
+++ b/docs/worklogs/2026-07-03-issue-1285-dot-accumulation.md
@@ -1,0 +1,90 @@
+# Issue 1285 Dot-General Accumulation
+
+## Session Summary
+
+Implemented the first pass of issue #1285: a dot-general accumulation backend
+contract for `out = alpha * op(lhs) * op(rhs) + beta * out`, with CPU faer/BLAS
+native wiring and fallback composition for backends that do not override the
+new hook.
+
+## Context Read
+
+- Shared tensor4all rules: common repository, performance, docs/tests, Rust
+  performance, and Rust numerical rules.
+- Repository rules in `REPOSITORY_RULES.md`, especially public-surface
+  discipline, hidden backend hook behavior, materialization boundaries, CPU
+  GEMM ownership, cache ownership, and work-log requirements.
+- Issue #1285 and the existing `TensorDot`, `SessionCachedDot`, and
+  `BackendCachedDot` separation.
+- Claude side review of the issue proposal. It agreed the feature was valid,
+  but that putting `cache_slot` directly on the non-cached `TensorDot` API would
+  be inconsistent and that a separate config-style accumulation contract was
+  cleaner.
+- CPU GEMM helpers in `crates/tenferro-cpu/src/gemm/`, including the faer and
+  BLAS raw strided GEMM traits that already accepted `alpha`, `beta`, and
+  conjugation flags.
+
+The private `tensor4all-agent-knowledge` checkout was unavailable in this
+workspace, so no private knowledge rules were loaded.
+
+## Decisions Made
+
+- Added `DotGeneralAccumulation` instead of extending `DotGeneralConfig`.
+  `DotGeneralConfig` remains the dimension-role contract; accumulation carries
+  conjugation flags and output update coefficients.
+- Added `ContractionScalar` instead of a broad scalar enum. It intentionally
+  covers only `F32`, `F64`, `C32`, and `C64`, matching GEMM-style contraction
+  accumulation.
+- Preserved the cached/non-cached trait split. `TensorDot` has the non-cached
+  accumulation method; `SessionCachedDot` and `BackendCachedDot` own the cached
+  variants and `cache_slot`/runtime-cache plumbing.
+- Kept `dot_general_read_into` as overwrite shorthand by delegating to
+  accumulation with `alpha = 1`, `beta = 0`, and no conjugation.
+- Added `TensorWrite::as_read()` for explicit read-modify-write callers.
+- Wired CPU faer and BLAS accumulation through existing `GemmAnalysisCache` and
+  provider GEMM traits. Output views can use native paths when their output
+  dimensions fuse to GEMM row, column, and batch strides; otherwise the explicit
+  temp fallback remains available.
+- Preserved BLAS/faer `beta = 0` semantics: the output element is not read when
+  beta is zero.
+
+## Rejected Or Deferred Alternatives
+
+- Rejected placing `cache_slot` directly on `TensorDot`; that would mix cache
+  ownership into the non-cached backend trait.
+- Rejected placing `alpha`, `beta`, and conj flags directly into
+  `DotGeneralConfig`; that would mix contraction shape semantics with output
+  update semantics.
+- Deferred CUDA/cuTENSOR native accumulation. The current CUDA path mainly
+  handles owned compact tensors and needs separate pointer/offset work for full
+  `TensorRead`/`TensorWrite` parity.
+- Deferred WebGPU native accumulation. It can continue through the explicit
+  fallback unless and until the backend grows native alpha/beta support.
+
+## Verification Performed
+
+- `cargo test -p tenferro-tensor`
+- `cargo test -p tenferro-cpu`
+- `cargo check --workspace`
+- `cargo check -p tenferro-cpu --features cpu-blas`
+- `cargo fmt --all --check`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
+
+Focused tests cover `TensorWrite::as_read()`, accumulation dtype validation,
+`F32`/`F64`/`C32`/`C64` coefficients, complex conjugation, cached session
+dispatch, and strided output accumulation.
+
+## Remaining Risks
+
+- CUDA native accumulation is still a follow-up. GPU backends compile through
+  the fallback trait path but do not yet wire cuTENSOR alpha/beta.
+- BLAS execution with an actual linked provider was compile-checked through
+  `cpu-blas`; provider-backed runtime execution remains covered by the normal
+  provider-specific CI lanes.


### PR DESCRIPTION
## Summary

Resolves #1285.

- Add `DotGeneralAccumulation` and `ContractionScalar` so dot-general output updates can model `out = alpha * op(lhs) * op(rhs) + beta * out` without mixing cache slots into `TensorDot`.
- Add cached accumulation variants on `SessionCachedDot` and `BackendCachedDot`, plus `TensorWrite::as_read()` for explicit read-modify-write flows.
- Wire CPU faer and BLAS native accumulation paths, including strided output views when output dimensions fuse to GEMM row/column/batch strides, with fallback composition for unsupported layouts/backends.
- Update tensor design notes and add worklog: `docs/worklogs/2026-07-03-issue-1285-dot-accumulation.md`.

## API Notes

The issue proposal is implemented with a separate accumulation config struct rather than adding `alpha`, `beta`, conjugation flags, or `cache_slot` directly to `DotGeneralConfig`/`TensorDot`. This keeps `DotGeneralConfig` focused on dimension roles and keeps cache ownership on the cached traits.

## Verification

- `cargo fmt --all --check`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo check -p tenferro-cpu --features cpu-blas`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
