### PR TITLE
[codex] Prefer linearized VJP generation

### DIFF
--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -16,7 +16,7 @@ use tenferro_runtime::ad_support::{
     linear_input_key, metadata_scopes as tensor_metadata_scopes, metadata_scopes_with_new,
     ones_tensor, push_metadata_scope, register_scoped_graph_metadata, registered_meta,
     resolve_roots as tensor_resolve_roots, shape_hint as tensor_shape_hint, tensor_from_parts,
-    tensor_meta_from_tensor, TracedTensorParts,
+    tensor_meta_from_tensor, GlobalMetadataScope, TracedTensorParts,
 };
 use tenferro_runtime::{Error, GraphCompiler, GraphExecutor, Result, TracedTensor};
 use tenferro_tensor::TensorBackend;
@@ -504,6 +504,12 @@ enum VjpTransposeGraph {
     Linear(tidu::LinearizedGraph<StdTensorOp>),
 }
 
+struct ActiveLinearVjp {
+    linear: tidu::LinearizedGraph<StdTensorOp>,
+    transposed: tidu::LinearizedGraph<StdTensorOp>,
+    metadata_scope: GlobalMetadataScope,
+}
+
 impl VjpTransposeGraph {
     fn as_graph(&self) -> &computegraph::graph::Graph<StdTensorOp> {
         match self {
@@ -555,59 +561,73 @@ fn vjp_optional_impl(
     let mut roots = tensor_resolve_roots(output);
     roots.extend(checkpoint_graphs.iter().cloned());
     let view = resolve(roots);
-    let mut ad_ctx = shape_guard_context(extension_rules, None);
-    ad_ctx.refresh_global_metadata();
 
-    let (transposed, linear_metadata_scope, linear_graph) = match try_primal_transpose(
+    let active_values =
+        linearize_active_value_keys(&view, std::slice::from_ref(&output_key), &aliases);
+    let mut linear_ad_ctx = shape_guard_context(extension_rules, Some(active_values));
+    let linear_attempt = match linearize(
         &view,
         std::slice::from_ref(&output_key),
         std::slice::from_ref(&wrt_input_key),
-        &aliases,
-        &mut ad_ctx,
         next_pass_id(),
+        &mut linear_ad_ctx,
+        &aliases,
     ) {
-        Ok(transposed)
-            if transposed
-                .tangent_outputs()
-                .first()
-                .and_then(|slot| *slot)
-                .is_some() =>
-        {
-            (VjpTransposeGraph::Primal(transposed), None, None)
+        Ok(linear) => {
+            if linear.tangent_outputs()[0].is_none() {
+                Ok(None)
+            } else {
+                let linear_seed_key =
+                    linear_input_key(linear.as_graph(), linear.tangent_inputs()[0].1)?;
+                let linear_metadata_scope = register_scoped_graph_metadata(
+                    linear.as_graph(),
+                    vec![(
+                        ValueKey::Input(linear_seed_key),
+                        registered_meta(&wrt.graph().values()[wrt.val].key)?,
+                    )],
+                )?;
+                linear_ad_ctx.refresh_global_metadata();
+                linear_transpose(&linear, &mut linear_ad_ctx).map(|transposed| {
+                    Some(ActiveLinearVjp {
+                        linear,
+                        transposed,
+                        metadata_scope: linear_metadata_scope,
+                    })
+                })
+            }
         }
-        _ => {
-            let active_values =
-                linearize_active_value_keys(&view, std::slice::from_ref(&output_key), &aliases);
-            let mut ad_ctx = shape_guard_context(extension_rules, Some(active_values));
-            let linear = linearize(
+        Err(err) => Err(err),
+    };
+
+    let (transposed, linear_metadata_scope, linear_graph) = match linear_attempt {
+        Ok(None) => return Ok(None),
+        Ok(Some(active)) => (
+            VjpTransposeGraph::Linear(active.transposed),
+            Some(active.metadata_scope),
+            Some(Arc::new(active.linear.into_graph())),
+        ),
+        Err(linear_err) => {
+            let mut primal_ad_ctx = shape_guard_context(extension_rules, None);
+            primal_ad_ctx.refresh_global_metadata();
+            match try_primal_transpose(
                 &view,
                 std::slice::from_ref(&output_key),
                 std::slice::from_ref(&wrt_input_key),
-                next_pass_id(),
-                &mut ad_ctx,
                 &aliases,
-            )
-            .map_err(|err| ad_rule_error(transform, err))?;
-            if linear.tangent_outputs()[0].is_none() {
-                return Ok(None);
+                &mut primal_ad_ctx,
+                next_pass_id(),
+            ) {
+                Ok(transposed)
+                    if transposed
+                        .tangent_outputs()
+                        .first()
+                        .and_then(|slot| *slot)
+                        .is_some() =>
+                {
+                    (VjpTransposeGraph::Primal(transposed), None, None)
+                }
+                _ => return Err(ad_rule_error(transform, linear_err)),
             }
-            let linear_seed_key =
-                linear_input_key(linear.as_graph(), linear.tangent_inputs()[0].1)?;
-            let linear_metadata_scope = Some(register_scoped_graph_metadata(
-                linear.as_graph(),
-                vec![(
-                    ValueKey::Input(linear_seed_key),
-                    registered_meta(&wrt.graph().values()[wrt.val].key)?,
-                )],
-            )?);
-            ad_ctx.refresh_global_metadata();
-            let transposed = linear_transpose(&linear, &mut ad_ctx)
-                .map_err(|err| ad_rule_error(transform, err))?;
-            (
-                VjpTransposeGraph::Linear(transposed),
-                linear_metadata_scope,
-                Some(Arc::new(linear.into_graph())),
-            )
         }
     };
 

--- a/crates/tenferro-ad/tests/extension_op.rs
+++ b/crates/tenferro-ad/tests/extension_op.rs
@@ -35,7 +35,7 @@ use tenferro_ops::{ShapeGuardContext, SymDim};
 use tenferro_runtime::extension::{apply, ExtensionExecutionContext, ExtensionRuntime};
 use tenferro_runtime::{Error as RuntimeError, GraphExecutor, Tensor, TracedTensor};
 use tenferro_tensor::{DType, TensorBackend, TensorRead, TypedTensor};
-use tidu::ADRuleResult;
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 // ----------------------------------------------------------------------
 // TestScaleBy2: single-input, single-output. y = x + x (= 2x).
@@ -275,6 +275,220 @@ fn swap_ad_context() -> AdContext {
         .with_extension_rules(swap_rules())
         .build()
         .expect("swap AD context")
+}
+
+// ----------------------------------------------------------------------
+// TestPreferLinearize: identity op with a deliberately distinguishable
+// primary transpose. This guards VJP path ordering: the generic
+// linearize -> linear_transpose path must be preferred when linearization is
+// available, while primary transpose remains an escape hatch.
+// ----------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq)]
+struct TestPreferLinearize;
+
+impl ExtensionOp for TestPreferLinearize {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.prefer_linearize.v1"
+    }
+
+    fn payload_hash(&self, _hasher: &mut dyn Hasher) {}
+
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<TestPreferLinearize>()
+            .is_some()
+    }
+
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+        Arc::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn input_count(&self) -> usize {
+        1
+    }
+
+    fn output_count(&self) -> usize {
+        1
+    }
+
+    fn infer_output_meta(
+        &self,
+        input_dtypes: &[DType],
+        input_shapes: &[&[SymDim]],
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
+    }
+
+    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Ok(vec![inputs[0].clone()])
+    }
+}
+
+#[derive(Debug)]
+struct TestPreferLinearizeRule;
+
+impl ExtensionAdRule for TestPreferLinearizeRule {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.prefer_linearize.v1"
+    }
+
+    fn linearize(
+        &self,
+        _op: &dyn ExtensionOp,
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        _primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
+        _ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+        Ok(vec![tangent_in[0]])
+    }
+
+    fn transpose_rule(
+        &self,
+        _op: &dyn ExtensionOp,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        _inputs: &[ValueRef<StdTensorOp>],
+        _mode: &OperationRole,
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+        let _ = ctx.transpose_primal_outputs();
+        match cotangent_out[0] {
+            Some(ct) => {
+                let doubled = builder.add_operation(
+                    StdTensorOp::Add,
+                    vec![ValueRef::Local(ct), ValueRef::Local(ct)],
+                    OperationRole::Linearized {
+                        active_mask: vec![true, true],
+                    },
+                );
+                Ok(vec![Some(doubled[0])])
+            }
+            None => Ok(vec![None]),
+        }
+    }
+}
+
+fn prefer_linearize_rules() -> ExtensionRuleSet {
+    ExtensionRuleSet::new()
+        .with_rule(Arc::new(TestPreferLinearizeRule))
+        .expect("prefer_linearize rule registration")
+}
+
+fn prefer_linearize_ad_context() -> AdContext {
+    AdContext::builder()
+        .with_extension_rules(prefer_linearize_rules())
+        .build()
+        .expect("prefer_linearize AD context")
+}
+
+// ----------------------------------------------------------------------
+// TestPrimaryTransposeOnly: identity op whose linearize deliberately fails.
+// This forces traced VJP to exercise the primary-transpose escape hatch.
+// ----------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq)]
+struct TestPrimaryTransposeOnly;
+
+impl ExtensionOp for TestPrimaryTransposeOnly {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.primary_transpose_only.v1"
+    }
+
+    fn payload_hash(&self, _hasher: &mut dyn Hasher) {}
+
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<TestPrimaryTransposeOnly>()
+            .is_some()
+    }
+
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+        Arc::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn input_count(&self) -> usize {
+        1
+    }
+
+    fn output_count(&self) -> usize {
+        1
+    }
+
+    fn infer_output_meta(
+        &self,
+        input_dtypes: &[DType],
+        input_shapes: &[&[SymDim]],
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
+    }
+
+    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Ok(vec![inputs[0].clone()])
+    }
+}
+
+#[derive(Debug)]
+struct TestPrimaryTransposeOnlyRule;
+
+impl ExtensionAdRule for TestPrimaryTransposeOnlyRule {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.primary_transpose_only.v1"
+    }
+
+    fn linearize(
+        &self,
+        _op: &dyn ExtensionOp,
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        _primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
+        _ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+        if tangent_in[0].is_none() {
+            return Ok(vec![None]);
+        }
+        Err(ADRuleError::unsupported(
+            "tenferro-tests.primary_transpose_only linearize is intentionally unsupported",
+            ADRuleKind::Jvp,
+        ))
+    }
+
+    fn transpose_rule(
+        &self,
+        _op: &dyn ExtensionOp,
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        _inputs: &[ValueRef<StdTensorOp>],
+        _mode: &OperationRole,
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+        let _ = ctx.transpose_primal_outputs();
+        Ok(vec![cotangent_out[0]])
+    }
+}
+
+fn primary_transpose_only_ad_context() -> AdContext {
+    AdContext::builder()
+        .with_extension_rules(
+            ExtensionRuleSet::new()
+                .with_rule(Arc::new(TestPrimaryTransposeOnlyRule))
+                .expect("primary_transpose_only rule registration"),
+        )
+        .build()
+        .expect("primary_transpose_only AD context")
 }
 
 // ----------------------------------------------------------------------
@@ -789,6 +1003,65 @@ fn ad_context_uses_owned_extension_rules_without_global_fallback() {
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let vjp_out = vjp.run_with(&mut engine).unwrap();
     assert_eq!(f64_slice(&vjp_out), &[14.0, 22.0]);
+}
+
+#[test]
+fn traced_vjp_prefers_linearize_transpose_over_primary_transpose() {
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0]).unwrap();
+    let y = apply(Arc::new(TestPreferLinearize), &[&x])
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("single prefer_linearize output");
+    let dy = TracedTensor::from_vec_col_major(vec![2], vec![7.0_f64, 11.0]).unwrap();
+
+    let vjp = prefer_linearize_ad_context()
+        .vjp(&y, &x, &dy)
+        .expect("vjp should build through linearize");
+    let mut engine = GraphExecutor::new(CpuBackend::new());
+    let vjp_out = vjp.run_with(&mut engine).unwrap();
+
+    assert_eq!(f64_slice(&vjp_out), &[7.0, 11.0]);
+}
+
+#[test]
+fn traced_vjp_falls_back_to_primary_transpose_when_linearize_fails() {
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap();
+    let y = apply(Arc::new(TestPrimaryTransposeOnly), &[&x])
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("single primary_transpose_only output");
+    let squared = (&y * &y).unwrap();
+    let observable = (&squared + &y).unwrap();
+    let loss = observable.reduce_sum(&[0]).unwrap();
+
+    let grad = primary_transpose_only_ad_context()
+        .grad(&loss, &x)
+        .expect("grad should fall back to primary transpose");
+    let mut engine = GraphExecutor::new(CpuBackend::new());
+    register_test_runtime(&mut engine, "tenferro-tests.primary_transpose_only.v1");
+    let grad_out = grad.run_with(&mut engine).unwrap();
+
+    assert_eq!(f64_slice(&grad_out), &[5.0, 7.0]);
+}
+
+#[test]
+fn traced_vjp_primary_transpose_fallback_reports_inactive_wrt() {
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap();
+    let z = TracedTensor::from_vec_col_major(vec![2], vec![5.0_f64, 7.0]).unwrap();
+    let y = apply(Arc::new(TestPrimaryTransposeOnly), &[&x])
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("single primary_transpose_only output");
+    let loss = y.reduce_sum(&[0]).unwrap();
+
+    let grad = primary_transpose_only_ad_context()
+        .grad_optional(&loss, &z)
+        .expect("inactive fallback should build");
+
+    assert!(grad.is_none());
 }
 
 #[test]

--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -222,6 +222,7 @@ mod tests {
     use super::*;
     use crate::extension::DEFAULT_DECOMPOSITION_AD_EPS;
     use computegraph::graph::GraphBuilder;
+    use std::collections::HashSet;
     use tenferro_ops::input_key::TensorInputKey;
     use tenferro_ops::{ShapeExtent, SymDim, TensorMeta};
     use tenferro_tensor::DType;
@@ -289,6 +290,26 @@ mod tests {
         (ctx, a, vec![p, l, u, parity])
     }
 
+    fn svd_context(
+        shape: &[usize],
+    ) -> (
+        ShapeGuardContext,
+        ValueKey<StdTensorOp>,
+        Vec<ValueKey<StdTensorOp>>,
+    ) {
+        let mut ctx = ShapeGuardContext::default();
+        let a = input_key(120);
+        let u = input_key(121);
+        let s = input_key(122);
+        let vt = input_key(123);
+        let k = shape[0].min(shape[1]);
+        insert_typed_meta(&mut ctx, a.clone(), DType::F64, shape);
+        insert_typed_meta(&mut ctx, u.clone(), DType::F64, &[shape[0], k]);
+        insert_typed_meta(&mut ctx, s.clone(), DType::F64, &[k]);
+        insert_typed_meta(&mut ctx, vt.clone(), DType::F64, &[k, shape[1]]);
+        (ctx, a, vec![u, s, vt])
+    }
+
     fn qr_context(
         shape: &[usize],
     ) -> (
@@ -305,6 +326,13 @@ mod tests {
         insert_typed_meta(&mut ctx, q.clone(), DType::F64, &[shape[0], k]);
         insert_typed_meta(&mut ctx, r.clone(), DType::F64, &[k, shape[1]]);
         (ctx, a, vec![q, r])
+    }
+
+    fn with_active_values(
+        ctx: ShapeGuardContext,
+        values: impl IntoIterator<Item = ValueKey<StdTensorOp>>,
+    ) -> ShapeGuardContext {
+        ctx.with_linearize_active_values(Arc::new(values.into_iter().collect::<HashSet<_>>()))
     }
 
     #[test]
@@ -336,6 +364,138 @@ mod tests {
 
         assert_eq!(result, vec![None, None, None, None, None]);
         assert!(builder.build().operations().is_empty());
+    }
+
+    #[test]
+    fn lu_linearize_prunes_inactive_factor_outputs() {
+        let op = LinalgExtensionOp::new(LinalgOp::Lu);
+        for (case, active_slot, expected_active) in [
+            ("l only", 1_usize, vec![false, true, false, false]),
+            ("u only", 2_usize, vec![false, false, true, false]),
+        ] {
+            let (ctx, a, outputs) = lu_context(&[2, 2]);
+            let mut ctx = with_active_values(ctx, [outputs[active_slot].clone()]);
+            let mut builder = GraphBuilder::<StdTensorOp>::new();
+            let tangent = builder.add_input(TensorInputKey::User { id: 130 });
+
+            let result = LinalgAdRule
+                .linearize(
+                    &op,
+                    &mut builder,
+                    &[a],
+                    &outputs,
+                    &[Some(tangent)],
+                    &mut ctx,
+                )
+                .unwrap();
+
+            assert_eq!(
+                result.iter().map(Option::is_some).collect::<Vec<_>>(),
+                expected_active,
+                "{case}"
+            );
+            let pruned_count = builder.build().operations().len();
+
+            let (full_ctx, full_a, full_outputs) = lu_context(&[2, 2]);
+            let mut full_ctx =
+                with_active_values(full_ctx, [full_outputs[1].clone(), full_outputs[2].clone()]);
+            let mut full_builder = GraphBuilder::<StdTensorOp>::new();
+            let full_tangent = full_builder.add_input(TensorInputKey::User { id: 131 });
+            let full_result = LinalgAdRule
+                .linearize(
+                    &op,
+                    &mut full_builder,
+                    &[full_a],
+                    &full_outputs,
+                    &[Some(full_tangent)],
+                    &mut full_ctx,
+                )
+                .unwrap();
+
+            assert_eq!(
+                full_result.iter().map(Option::is_some).collect::<Vec<_>>(),
+                vec![false, true, true, false],
+                "{case}"
+            );
+            let full_count = full_builder.build().operations().len();
+            assert!(
+                pruned_count < full_count,
+                "{case} should not emit both LU factor tangent branches: {pruned_count} >= {full_count}"
+            );
+        }
+    }
+
+    #[test]
+    fn one_input_linalg_jvps_prune_when_all_outputs_are_inactive() {
+        let cases = [
+            (
+                LinalgOp::Lu,
+                lu_context(&[2, 2]),
+                vec![None, None, None, None],
+            ),
+            (
+                LinalgOp::Svd {
+                    eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                },
+                svd_context(&[2, 2]),
+                vec![None, None, None],
+            ),
+        ];
+
+        for (kind, (ctx, a, outputs), expected) in cases {
+            let mut ctx = with_active_values(ctx, []);
+            let mut builder = GraphBuilder::<StdTensorOp>::new();
+            let tangent = builder.add_input(TensorInputKey::User { id: 132 });
+            let op = LinalgExtensionOp::new(kind);
+
+            let result = LinalgAdRule
+                .linearize(
+                    &op,
+                    &mut builder,
+                    &[a],
+                    &outputs,
+                    &[Some(tangent)],
+                    &mut ctx,
+                )
+                .unwrap();
+
+            assert_eq!(result, expected, "{kind:?}");
+            assert!(
+                builder.build().operations().is_empty(),
+                "{kind:?} should not emit AD graph operations for inactive outputs"
+            );
+        }
+    }
+
+    #[test]
+    fn svd_linearize_prunes_inactive_vector_outputs() {
+        let (ctx, a, outputs) = svd_context(&[2, 2]);
+        let mut ctx = with_active_values(ctx, [outputs[1].clone()]);
+        let mut builder = GraphBuilder::<StdTensorOp>::new();
+        let tangent = builder.add_input(TensorInputKey::User { id: 133 });
+        let op = LinalgExtensionOp::new(LinalgOp::Svd {
+            eps: DEFAULT_DECOMPOSITION_AD_EPS,
+        });
+
+        let result = LinalgAdRule
+            .linearize(
+                &op,
+                &mut builder,
+                &[a],
+                &outputs,
+                &[Some(tangent)],
+                &mut ctx,
+            )
+            .unwrap();
+
+        assert_eq!(
+            result.iter().map(Option::is_some).collect::<Vec<_>>(),
+            vec![false, true, false]
+        );
+        assert!(
+            builder.build().operations().len() <= 5,
+            "singular-value-only SVD JVP should not emit the vector F-matrix chain"
+        );
     }
 
     #[test]

--- a/crates/tenferro-linalg/src/ad/rules/mod.rs
+++ b/crates/tenferro-linalg/src/ad/rules/mod.rs
@@ -108,6 +108,12 @@ pub(crate) fn linearize_lu(
         return Ok(vec![None, None, None, None]);
     };
 
+    let l_active = ctx.is_value_active_in_linearize(&primal_out[1]);
+    let u_active = ctx.is_value_active_in_linearize(&primal_out[2]);
+    if !l_active && !u_active {
+        return Ok(vec![None, None, None, None]);
+    }
+
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in)? else {
         return Ok(vec![None, None, None, None]);
     };
@@ -168,42 +174,50 @@ pub(crate) fn linearize_lu(
         },
     )[0];
 
-    let x_lower = linear_unary(builder, StdTensorOp::Tril { k: -1 }, x);
-    let x_upper = linear_unary(builder, StdTensorOp::Triu { k: 0 }, x);
-    let dl_full = matmul_linear(
-        builder,
-        ValueRef::Local(l_square),
-        ValueRef::Local(x_lower),
-        vec![false, true],
-        rank,
-    );
-    let du_full = matmul_linear(
-        builder,
-        ValueRef::Local(x_upper),
-        ValueRef::Local(u_square),
-        vec![true, false],
-        rank,
-    );
-    let dl = if n_size > k_size {
-        take_leading_cols_linear(
+    let dl = if l_active {
+        let x_lower = linear_unary(builder, StdTensorOp::Tril { k: -1 }, x);
+        let dl_full = matmul_linear(
             builder,
-            dl_full,
-            LeadingMatrixSlice::new(k_size, n_size, batch_shape, l.clone(), &l_shape, rank),
-        )
+            ValueRef::Local(l_square),
+            ValueRef::Local(x_lower),
+            vec![false, true],
+            rank,
+        );
+        Some(if n_size > k_size {
+            take_leading_cols_linear(
+                builder,
+                dl_full,
+                LeadingMatrixSlice::new(k_size, n_size, batch_shape, l.clone(), &l_shape, rank),
+            )
+        } else {
+            dl_full
+        })
     } else {
-        dl_full
+        None
     };
-    let du = if m_size > k_size {
-        take_leading_rows_linear(
+    let du = if u_active {
+        let x_upper = linear_unary(builder, StdTensorOp::Triu { k: 0 }, x);
+        let du_full = matmul_linear(
             builder,
-            du_full,
-            LeadingMatrixSlice::new(k_size, m_size, batch_shape, u.clone(), &u_shape, rank),
-        )
+            ValueRef::Local(x_upper),
+            ValueRef::Local(u_square),
+            vec![true, false],
+            rank,
+        );
+        Some(if m_size > k_size {
+            take_leading_rows_linear(
+                builder,
+                du_full,
+                LeadingMatrixSlice::new(k_size, m_size, batch_shape, u.clone(), &u_shape, rank),
+            )
+        } else {
+            du_full
+        })
     } else {
-        du_full
+        None
     };
 
-    Ok(vec![None, Some(dl), Some(du), None])
+    Ok(vec![None, dl, du, None])
 }
 
 pub(crate) fn linearize_full_piv_lu(
@@ -414,6 +428,13 @@ pub(crate) fn linearize_svd(
         return Ok(vec![None, None, None]);
     };
 
+    let u_active = ctx.is_value_active_in_linearize(&primal_out[0]);
+    let s_active = ctx.is_value_active_in_linearize(&primal_out[1]);
+    let vt_active = ctx.is_value_active_in_linearize(&primal_out[2]);
+    if !u_active && !s_active && !vt_active {
+        return Ok(vec![None, None, None]);
+    }
+
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in)? else {
         return Ok(vec![None, None, None]);
     };
@@ -444,7 +465,11 @@ pub(crate) fn linearize_svd(
         vec![true, false],
         matrix_rank,
     );
-    let ds = extract_diag_linear(builder, ds_mat);
+    let ds = s_active.then(|| extract_diag_linear(builder, ds_mat));
+
+    if !u_active && !vt_active {
+        return Ok(vec![None, ds, None]);
+    }
 
     let diag_s = embed_diag_fixed(builder, s.clone());
     let ones_mat = one_like_fixed(builder, ValueRef::Local(diag_s));
@@ -468,114 +493,123 @@ pub(crate) fn linearize_svd(
     let safe_gap = fixed_add(builder, ValueRef::Local(s_gap_sq), ValueRef::Local(eps_sq));
     let f = fixed_div(builder, ValueRef::Local(s_gap), ValueRef::Local(safe_gap));
 
-    let s_ones = one_like_fixed(builder, s.clone());
-    let s_sq = fixed_mul(builder, s.clone(), s.clone());
-    let s_eps_sq = fixed_scale(builder, ValueRef::Local(s_ones), eps * eps);
-    let safe_s_sq = fixed_add(builder, ValueRef::Local(s_sq), ValueRef::Local(s_eps_sq));
-    let s_inv = fixed_div(builder, s.clone(), ValueRef::Local(safe_s_sq));
-    let s_inv_mat = embed_diag_fixed(builder, ValueRef::Local(s_inv));
+    let du = if u_active {
+        let s_ones = one_like_fixed(builder, s.clone());
+        let s_sq = fixed_mul(builder, s.clone(), s.clone());
+        let s_eps_sq = fixed_scale(builder, ValueRef::Local(s_ones), eps * eps);
+        let safe_s_sq = fixed_add(builder, ValueRef::Local(s_sq), ValueRef::Local(s_eps_sq));
+        let s_inv = fixed_div(builder, s.clone(), ValueRef::Local(safe_s_sq));
+        let s_inv_mat = embed_diag_fixed(builder, ValueRef::Local(s_inv));
 
-    let ds_h = adjoint_matrix_linear(builder, ds_mat, matrix_rank, dtype);
-    let anti_hermitian = linear_sub(builder, ds_mat, ds_h);
-    // Matches JAX's complex gauge correction: 0.5 * (dS - dS^H) * diag(1 / s).
-    let d_udv_diag = hadamard_fixed_linear(builder, ValueRef::Local(s_inv_mat), anti_hermitian);
-    let d_udv_diag = linear_scale(builder, d_udv_diag, 0.5);
+        let ds_h = adjoint_matrix_linear(builder, ds_mat, matrix_rank, dtype);
+        let anti_hermitian = linear_sub(builder, ds_mat, ds_h);
+        // Matches JAX's complex gauge correction: 0.5 * (dS - dS^H) * diag(1 / s).
+        let d_udv_diag = hadamard_fixed_linear(builder, ValueRef::Local(s_inv_mat), anti_hermitian);
+        let d_udv_diag = linear_scale(builder, d_udv_diag, 0.5);
 
-    let dss = hadamard_fixed_linear(builder, ValueRef::Local(s_dim), ds_mat);
-    let dss_h = adjoint_matrix_linear(builder, dss, matrix_rank, dtype);
-    let du_inner_sum = linear_add(builder, dss, dss_h);
-    let du_inner = hadamard_fixed_linear(builder, ValueRef::Local(f), du_inner_sum);
-    let du_inner = linear_add(builder, du_inner, d_udv_diag);
-    let mut du = matmul_linear(
-        builder,
-        u.clone(),
-        ValueRef::Local(du_inner),
-        vec![false, true],
-        matrix_rank,
-    );
-
-    let sds = hadamard_fixed_linear(builder, ValueRef::Local(s_dim_t), ds_mat);
-    let sds_h = adjoint_matrix_linear(builder, sds, matrix_rank, dtype);
-    let dv_inner_sum = linear_add(builder, sds, sds_h);
-    let dv_inner = hadamard_fixed_linear(builder, ValueRef::Local(f), dv_inner_sum);
-    let mut dv = matmul_linear(
-        builder,
-        ValueRef::Local(v),
-        ValueRef::Local(dv_inner),
-        vec![false, true],
-        matrix_rank,
-    );
-
-    if m_size > n_size {
-        let d_av = matmul_linear(
-            builder,
-            ValueRef::Local(da),
-            ValueRef::Local(v),
-            vec![true, false],
-            matrix_rank,
-        );
-        let ut_d_av = matmul_linear(
-            builder,
-            ValueRef::Local(uh),
-            ValueRef::Local(d_av),
-            vec![false, true],
-            matrix_rank,
-        );
-        let u_ut_d_av = matmul_linear(
+        let dss = hadamard_fixed_linear(builder, ValueRef::Local(s_dim), ds_mat);
+        let dss_h = adjoint_matrix_linear(builder, dss, matrix_rank, dtype);
+        let du_inner_sum = linear_add(builder, dss, dss_h);
+        let du_inner = hadamard_fixed_linear(builder, ValueRef::Local(f), du_inner_sum);
+        let du_inner = linear_add(builder, du_inner, d_udv_diag);
+        let mut du = matmul_linear(
             builder,
             u.clone(),
-            ValueRef::Local(ut_d_av),
+            ValueRef::Local(du_inner),
             vec![false, true],
             matrix_rank,
         );
-        let proj = linear_sub(builder, d_av, u_ut_d_av);
-        let s_broadcast = broadcast_in_dim_fixed(
-            builder,
-            s.clone(),
-            matrix_shape(m, &k, batch_shape),
-            vector_to_matrix_broadcast_dims(batch_shape.len()),
-        );
-        let correction = linear_div_fixed(builder, proj, ValueRef::Local(s_broadcast));
-        du = linear_add(builder, du, correction);
-    }
 
-    if n_size > m_size {
-        let da_h = adjoint_matrix_linear(builder, da, matrix_rank, dtype);
-        let d_ahu = matmul_linear(
-            builder,
-            ValueRef::Local(da_h),
-            u.clone(),
-            vec![true, false],
-            matrix_rank,
-        );
-        let vt_d_ahu = matmul_linear(
-            builder,
-            vt.clone(),
-            ValueRef::Local(d_ahu),
-            vec![false, true],
-            matrix_rank,
-        );
-        let v_vt_d_ahu = matmul_linear(
+        if m_size > n_size {
+            let d_av = matmul_linear(
+                builder,
+                ValueRef::Local(da),
+                ValueRef::Local(v),
+                vec![true, false],
+                matrix_rank,
+            );
+            let ut_d_av = matmul_linear(
+                builder,
+                ValueRef::Local(uh),
+                ValueRef::Local(d_av),
+                vec![false, true],
+                matrix_rank,
+            );
+            let u_ut_d_av = matmul_linear(
+                builder,
+                u.clone(),
+                ValueRef::Local(ut_d_av),
+                vec![false, true],
+                matrix_rank,
+            );
+            let proj = linear_sub(builder, d_av, u_ut_d_av);
+            let s_broadcast = broadcast_in_dim_fixed(
+                builder,
+                s.clone(),
+                matrix_shape(m, &k, batch_shape),
+                vector_to_matrix_broadcast_dims(batch_shape.len()),
+            );
+            let correction = linear_div_fixed(builder, proj, ValueRef::Local(s_broadcast));
+            du = linear_add(builder, du, correction);
+        }
+        Some(du)
+    } else {
+        None
+    };
+
+    let dvt = if vt_active {
+        let sds = hadamard_fixed_linear(builder, ValueRef::Local(s_dim_t), ds_mat);
+        let sds_h = adjoint_matrix_linear(builder, sds, matrix_rank, dtype);
+        let dv_inner_sum = linear_add(builder, sds, sds_h);
+        let dv_inner = hadamard_fixed_linear(builder, ValueRef::Local(f), dv_inner_sum);
+        let mut dv = matmul_linear(
             builder,
             ValueRef::Local(v),
-            ValueRef::Local(vt_d_ahu),
+            ValueRef::Local(dv_inner),
             vec![false, true],
             matrix_rank,
         );
-        let proj = linear_sub(builder, d_ahu, v_vt_d_ahu);
-        let s_broadcast = broadcast_in_dim_fixed(
-            builder,
-            s.clone(),
-            matrix_shape(n, &k, batch_shape),
-            vector_to_matrix_broadcast_dims(batch_shape.len()),
-        );
-        let correction = linear_div_fixed(builder, proj, ValueRef::Local(s_broadcast));
-        dv = linear_add(builder, dv, correction);
-    }
 
-    let dvt = adjoint_matrix_linear(builder, dv, matrix_rank, dtype);
+        if n_size > m_size {
+            let da_h = adjoint_matrix_linear(builder, da, matrix_rank, dtype);
+            let d_ahu = matmul_linear(
+                builder,
+                ValueRef::Local(da_h),
+                u.clone(),
+                vec![true, false],
+                matrix_rank,
+            );
+            let vt_d_ahu = matmul_linear(
+                builder,
+                vt.clone(),
+                ValueRef::Local(d_ahu),
+                vec![false, true],
+                matrix_rank,
+            );
+            let v_vt_d_ahu = matmul_linear(
+                builder,
+                ValueRef::Local(v),
+                ValueRef::Local(vt_d_ahu),
+                vec![false, true],
+                matrix_rank,
+            );
+            let proj = linear_sub(builder, d_ahu, v_vt_d_ahu);
+            let s_broadcast = broadcast_in_dim_fixed(
+                builder,
+                s.clone(),
+                matrix_shape(n, &k, batch_shape),
+                vector_to_matrix_broadcast_dims(batch_shape.len()),
+            );
+            let correction = linear_div_fixed(builder, proj, ValueRef::Local(s_broadcast));
+            dv = linear_add(builder, dv, correction);
+        }
 
-    Ok(vec![Some(du), Some(ds), Some(dvt)])
+        Some(adjoint_matrix_linear(builder, dv, matrix_rank, dtype))
+    } else {
+        None
+    };
+
+    Ok(vec![du, ds, dvt])
 }
 
 pub(crate) fn linearize_svd_values(

--- a/docs/architecture/ad-pipeline.md
+++ b/docs/architecture/ad-pipeline.md
@@ -67,6 +67,36 @@ n-th derivative:
   build -> (resolve -> linearize) x n -> [linear_transpose] -> materialize_merge -> compile -> eval
 ```
 
+Current tenferro traced VJP follows the generic VJP pipeline first:
+
+```text
+build -> resolve -> linearize active outputs -> linear_transpose -> materialize_merge -> compile -> eval
+```
+
+Direct primary-graph transpose is an escape hatch. It is used only when the
+generic `linearize + linear_transpose` path cannot build a usable reverse graph.
+This keeps forward and reverse AD behavior anchored on the same linearization
+rules while preserving support for extension rules that still need primal
+outputs directly.
+
+Before `linearize`, traced AD computes the set of primal `ValueKey`s reachable
+from the requested output. That active-output set is attached to the
+`ShapeGuardContext` so multi-output rules can avoid emitting tangent branches
+for unused outputs. For example, an SVD whose caller only consumes singular
+values can emit just the `dS = diag(U^H dA V)` path and skip the vector
+F-matrix chain before `materialize_merge` ever runs. `materialize_merge` and
+the compiler still perform their own deduplication and backend-oriented
+optimization, but AD rules should not rely on late flattening to remove large,
+known-inactive derivative subgraphs.
+
+AD transform outputs are not cached in a new persistent AD graph cache. The
+caller-owned traced result keeps the transformed graph and any required extra
+roots alive, while compile-time and runtime caches remain owned by the existing
+compiler, executor, and extension runtime contexts. If a future AD optimizer
+cache is introduced, its key must include the resolved output keys, `wrt`
+inputs, extension rule set identity, shape/dtype guard inputs, and optimizer
+configuration version; it must not live inside semantic op payloads.
+
 Four crates, strictly layered:
 
 ```text

--- a/docs/worklogs/2026-07-04-issue-1256-ad-vjp-default.md
+++ b/docs/worklogs/2026-07-04-issue-1256-ad-vjp-default.md
@@ -1,0 +1,76 @@
+# Issue 1256 AD VJP Default Pipeline
+
+## Session Summary
+
+Started the #1256 implementation by making traced VJP prefer
+`linearize + linear_transpose` over direct primary-graph transpose, while
+retaining the primary transpose walker as the fallback for rules that cannot
+yet flow through the generic linear graph path.
+
+The same branch also added targeted active-output pruning for linalg
+decomposition linearizers where the active-output metadata already existed but
+was not fully used: `Svd` now skips the vector tangent chain when only singular
+values are consumed, and `Lu` now emits only requested factor tangent branches.
+
+## Context Read
+
+- Issue #1256 and its acceptance criteria around VJP generation, active output
+  pruning, graph-size regression checks, cache ownership, and linalg-heavy AD
+  cases.
+- Shared tensor4all common, Rust, performance, numerical, docs, and test rules.
+- `REPOSITORY_RULES.md`, especially the AD source-of-truth and oracle coverage
+  requirements.
+- `docs/architecture/ad-pipeline.md` for the intended
+  `linearize -> linear_transpose -> materialize_merge` model.
+- Existing traced AD implementation in `crates/tenferro-ad/src/traced.rs` and
+  primary transpose fallback in `traced/primal_transpose.rs`.
+- Existing linalg AD rules in `crates/tenferro-linalg/src/ad/rules/mod.rs`,
+  including the prior `Eigh` active-output pruning pattern.
+
+## Decisions
+
+- Prefer the generic linearized VJP path first. If `linearize` reports the
+  target as inactive, return `None`; if either `linearize` or
+  `linear_transpose` fails, try the primary transpose fallback and report the
+  original generic-path error only when the fallback cannot produce a usable
+  cotangent graph.
+- Keep direct primary transpose rules as an escape hatch rather than deleting
+  them. Several extension rules use primal outputs directly and this preserves
+  compatibility while the generic path becomes the default.
+- Use the existing `linearize_active_value_keys` analysis as the explicit
+  used-output pruning pass for traced AD. Linalg multi-output rules now check
+  `ctx.is_value_active_in_linearize` before emitting expensive tangent branches.
+- Document cache ownership as unchanged: no persistent AD optimizer cache is
+  introduced here. Transformed graphs live with the returned traced tensor and
+  existing compiler/runtime/extension caches keep their current owners.
+
+## Verification
+
+- Red/green test for VJP path ordering:
+  `cargo test -p tenferro-ad --test extension_op traced_vjp_prefers_linearize_transpose_over_primary_transpose -- --nocapture`
+- Red/green linalg active-output pruning tests:
+  `cargo test -p tenferro-linalg --features autodiff prune -- --nocapture`
+- Primary-transpose fallback coverage after generic VJP became the default:
+  `cargo test -p tenferro-ad --test extension_op traced_vjp_ -- --nocapture`
+- Full touched-crate and linalg AD checks:
+  `cargo test -p tenferro-ad`
+  `cargo test -p tenferro-linalg --features autodiff`
+- Repository checklist checks:
+  `cargo fmt --all --check`
+  `git diff --check`
+  `cargo clippy --workspace --all-targets -- -D warnings`
+  `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+  `cargo test --workspace --release`
+  `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+  `python3 scripts/check-coverage.py coverage.json`
+  `cargo doc --workspace --no-deps`
+  `python3 scripts/check-docs-site.py`
+  `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --worktree --output-json /tmp/repository-rules-review-worktree.json`
+
+## Residual Risks
+
+- This is an initial #1256 slice. It makes generic VJP the default and prunes
+  two high-impact decomposition linearizers, but it does not add a broad AD
+  algebraic canonicalizer or a persistent AD graph optimizer cache.
+- The primary transpose fallback remains necessary for extension rules whose
+  generic linearized path is incomplete.


### PR DESCRIPTION
## Summary
- Prefer traced VJP generation through `linearize + linear_transpose`, while keeping primary-graph transpose as the compatibility fallback.
- Use active-output metadata in LU and SVD linearizers so inactive decomposition outputs do not emit derivative branches.
- Document the current AD pipeline/cache ownership model and add a worklog for this #1256 slice.

## Issue
Refs #1256.

This addresses the VJP-default and targeted used-output pruning parts of the issue. Broader AD algebraic canonicalization, symbolic `Zero`, and any persistent AD optimizer cache remain follow-up work.

## Validation
- `cargo test -p tenferro-ad --test extension_op traced_vjp_prefers_linearize_transpose_over_primary_transpose -- --nocapture`
- `cargo test -p tenferro-linalg --features autodiff prune -- --nocapture`
- `cargo test -p tenferro-ad --test extension_op traced_vjp_ -- --nocapture`
- `cargo test -p tenferro-ad`
- `cargo test -p tenferro-linalg --features autodiff`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --worktree --output-json /tmp/repository-rules-review-worktree.json`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`