### PR TITLE
Optimize CPU elementwise fusion via strided

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,11 +49,11 @@ proc-macro2 = "1"
 quote = "1"
 syn = "2"
 tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "77527ecb647fecd4918ea2d06d0065ddce4e5b1c", version = "0.1.0" }
-strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0", default-features = false }
+strided-view = "0.3.0"
+strided-traits = "0.3.0"
+strided-perm = { version = "0.3.0", features = ["parallel"] }
+strided-kernel = { version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = "0.24"
 cblas-sys = "0.1"

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -11,7 +11,9 @@ use crate::{
     Buffer, CacheStats, Tensor, TensorRank, TensorRead, TensorValue, TensorWrite, TypedTensor,
     TypedTensorView, TypedTensorViewMut,
 };
-use tenferro_tensor::backend::{dot_general_accum_via_temp, validate_dot_general_accumulation};
+use tenferro_tensor::backend::{
+    dot_general_accum_via_temp, validate_dot_general_accumulation, ElementwiseFusionPlan,
+};
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
     DotGeneralAccumulation, TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer,
@@ -1598,6 +1600,16 @@ where
 }
 
 impl TensorFusion for CpuBackend {
+    fn execute_elementwise_fusion(
+        &mut self,
+        inputs: &[&Tensor],
+        plan: &ElementwiseFusionPlan,
+    ) -> crate::Result<Option<Vec<Tensor>>> {
+        self.install_with_pool(|buffers| {
+            elementwise::elementwise_fusion_with_pool(buffers, inputs, plan)
+        })
+    }
+
     fn execute_broadcast_multiply(
         &mut self,
         lhs: TensorRead<'_>,

--- a/crates/tenferro-cpu/src/elementwise.rs
+++ b/crates/tenferro-cpu/src/elementwise.rs
@@ -4,12 +4,15 @@ use std::sync::Arc;
 use num_complex::Complex;
 use num_traits::{One, Zero};
 use strided_kernel::{
-    batched_outer_product_into, broadcast_mul_into, map_into, mul_into, zip_map2_into,
-    zip_map3_into,
+    batched_outer_product_into, broadcast_mul_into, fused_elementwise_into, map_into, mul_into,
+    zip_map2_into, zip_map3_into, FusedInst, FusedOp, FusedPlan, FusedScalar, StridedView,
 };
 
 use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::ConjElem;
+use tenferro_tensor::backend::{
+    ElementwiseFusionInputView, ElementwiseFusionOp, ElementwiseFusionPlan,
+};
 use tenferro_tensor::{
     col_major_strides, CompareDir, DType, Tensor, TensorOwnedView, TensorRank, TensorRead,
     TensorValue, TensorView, TypedTensor, TypedTensorView,
@@ -62,6 +65,105 @@ fn reject_complex_ordered_dtypes(op: &'static str, dtypes: &[DType]) -> crate::R
         return Err(ordered_complex_error(op));
     }
     Ok(())
+}
+
+const ELEMENTWISE_FUSION_OP: &str = "execute_elementwise_fusion";
+const ELEMENTWISE_FUSION_MIN_ELEMENTS: usize = 16 * 1024;
+
+fn validate_elementwise_fusion_inputs(
+    inputs: &[&Tensor],
+    plan: &ElementwiseFusionPlan,
+) -> crate::Result<bool> {
+    if inputs.len() != plan.input_count() {
+        return Err(crate::Error::backend_failure(
+            ELEMENTWISE_FUSION_OP,
+            format!(
+                "plan expects {} inputs but backend received {}",
+                plan.input_count(),
+                inputs.len()
+            ),
+        ));
+    }
+    if plan.input_views().len() != plan.input_count() {
+        return Err(crate::Error::backend_failure(
+            ELEMENTWISE_FUSION_OP,
+            format!(
+                "plan has {} input views for {} inputs",
+                plan.input_views().len(),
+                plan.input_count()
+            ),
+        ));
+    }
+    if plan.outputs().is_empty() {
+        return Ok(false);
+    }
+    for input in inputs {
+        if input.dtype() != plan.dtype() {
+            return Err(crate::Error::DTypeMismatch {
+                op: ELEMENTWISE_FUSION_OP,
+                lhs: input.dtype(),
+                rhs: plan.dtype(),
+            });
+        }
+    }
+    Ok(true)
+}
+
+fn strided_fused_op(op: ElementwiseFusionOp) -> FusedOp {
+    match op {
+        ElementwiseFusionOp::Add => FusedOp::Add,
+        ElementwiseFusionOp::Multiply => FusedOp::Multiply,
+        ElementwiseFusionOp::Negate => FusedOp::Negate,
+        ElementwiseFusionOp::Conj => FusedOp::Conj,
+        ElementwiseFusionOp::Divide => FusedOp::Divide,
+        ElementwiseFusionOp::Abs => FusedOp::Abs,
+        ElementwiseFusionOp::Maximum => FusedOp::Maximum,
+        ElementwiseFusionOp::Minimum => FusedOp::Minimum,
+        ElementwiseFusionOp::Clamp => FusedOp::Clamp,
+        ElementwiseFusionOp::Exp => FusedOp::Exp,
+        ElementwiseFusionOp::Log => FusedOp::Log,
+        ElementwiseFusionOp::Sin => FusedOp::Sin,
+        ElementwiseFusionOp::Cos => FusedOp::Cos,
+        ElementwiseFusionOp::Tanh => FusedOp::Tanh,
+        ElementwiseFusionOp::Sqrt => FusedOp::Sqrt,
+        ElementwiseFusionOp::Rsqrt => FusedOp::Rsqrt,
+        ElementwiseFusionOp::Pow => FusedOp::Pow,
+        ElementwiseFusionOp::Expm1 => FusedOp::Expm1,
+        ElementwiseFusionOp::Log1p => FusedOp::Log1p,
+    }
+}
+
+fn plan_uses_ordered_op(plan: &ElementwiseFusionPlan) -> bool {
+    plan.ops().iter().any(|inst| {
+        matches!(
+            inst.op(),
+            ElementwiseFusionOp::Maximum
+                | ElementwiseFusionOp::Minimum
+                | ElementwiseFusionOp::Clamp
+        )
+    })
+}
+
+fn should_defer_to_broadcast_multiply_special_case(plan: &ElementwiseFusionPlan) -> bool {
+    !plan.input_views().iter().all(|view| view.is_identity())
+        && plan.ops().len() == 1
+        && plan.outputs() == [plan.input_count()]
+        && plan.ops()[0].op() == ElementwiseFusionOp::Multiply
+}
+
+fn strided_fused_plan(plan: &ElementwiseFusionPlan) -> FusedPlan {
+    FusedPlan {
+        input_count: plan.input_count(),
+        outputs: plan.outputs().to_vec(),
+        ops: plan
+            .ops()
+            .iter()
+            .map(|inst| FusedInst {
+                op: strided_fused_op(inst.op()),
+                inputs: inst.inputs().to_vec(),
+            })
+            .collect(),
+    }
 }
 
 pub(crate) trait Tier2Elem: Copy + Clone + One + Zero + Send + Sync {
@@ -587,6 +689,291 @@ fn read_as_cpu_view(input: TensorRead<'_>) -> CpuReadView<'_> {
         TensorRead::View(TensorView::C32(view)) => CpuReadView::C32(view),
         TensorRead::View(TensorView::C64(view)) => CpuReadView::C64(view),
     }
+}
+
+pub(crate) fn elementwise_fusion_with_pool(
+    buffers: &mut BufferPool,
+    inputs: &[&Tensor],
+    plan: &ElementwiseFusionPlan,
+) -> crate::Result<Option<Vec<Tensor>>> {
+    if !validate_elementwise_fusion_inputs(inputs, plan)? {
+        return Ok(None);
+    }
+    if inputs.is_empty() {
+        return Ok(None);
+    }
+
+    match plan.dtype() {
+        DType::F32 => {
+            let typed_inputs = inputs
+                .iter()
+                .map(|input| match input {
+                    Tensor::F32(tensor) => Ok(tensor),
+                    _ => Err(crate::Error::DTypeMismatch {
+                        op: ELEMENTWISE_FUSION_OP,
+                        lhs: input.dtype(),
+                        rhs: plan.dtype(),
+                    }),
+                })
+                .collect::<crate::Result<Vec<_>>>()?;
+            typed_elementwise_fusion_with_pool(buffers, &typed_inputs, plan, Tensor::F32)
+        }
+        DType::F64 => {
+            let typed_inputs = inputs
+                .iter()
+                .map(|input| match input {
+                    Tensor::F64(tensor) => Ok(tensor),
+                    _ => Err(crate::Error::DTypeMismatch {
+                        op: ELEMENTWISE_FUSION_OP,
+                        lhs: input.dtype(),
+                        rhs: plan.dtype(),
+                    }),
+                })
+                .collect::<crate::Result<Vec<_>>>()?;
+            typed_elementwise_fusion_with_pool(buffers, &typed_inputs, plan, Tensor::F64)
+        }
+        DType::C32 => {
+            if plan_uses_ordered_op(plan) {
+                return Ok(None);
+            }
+            let typed_inputs = inputs
+                .iter()
+                .map(|input| match input {
+                    Tensor::C32(tensor) => Ok(tensor),
+                    _ => Err(crate::Error::DTypeMismatch {
+                        op: ELEMENTWISE_FUSION_OP,
+                        lhs: input.dtype(),
+                        rhs: plan.dtype(),
+                    }),
+                })
+                .collect::<crate::Result<Vec<_>>>()?;
+            typed_elementwise_fusion_with_pool(buffers, &typed_inputs, plan, Tensor::C32)
+        }
+        DType::C64 => {
+            if plan_uses_ordered_op(plan) {
+                return Ok(None);
+            }
+            let typed_inputs = inputs
+                .iter()
+                .map(|input| match input {
+                    Tensor::C64(tensor) => Ok(tensor),
+                    _ => Err(crate::Error::DTypeMismatch {
+                        op: ELEMENTWISE_FUSION_OP,
+                        lhs: input.dtype(),
+                        rhs: plan.dtype(),
+                    }),
+                })
+                .collect::<crate::Result<Vec<_>>>()?;
+            typed_elementwise_fusion_with_pool(buffers, &typed_inputs, plan, Tensor::C64)
+        }
+        DType::I32 | DType::I64 | DType::Bool => Ok(None),
+    }
+}
+
+fn typed_elementwise_fusion_with_pool<T>(
+    buffers: &mut BufferPool,
+    inputs: &[&TypedTensor<T>],
+    plan: &ElementwiseFusionPlan,
+    wrap: fn(TypedTensor<T>) -> Tensor,
+) -> crate::Result<Option<Vec<Tensor>>>
+where
+    T: Copy + Clone + FusedScalar + PoolScalar,
+{
+    if should_defer_to_broadcast_multiply_special_case(plan) {
+        return Ok(None);
+    }
+    if plan.input_views().iter().all(|view| view.is_identity()) {
+        return typed_elementwise_fusion_identity_with_pool(buffers, inputs, plan, wrap);
+    }
+
+    let input_views = inputs
+        .iter()
+        .zip(plan.input_views())
+        .map(|(input, view)| typed_fusion_input_view(input, view))
+        .collect::<crate::Result<Vec<_>>>()?;
+    let shape = input_views[0].dims().to_vec();
+    if input_views
+        .iter()
+        .skip(1)
+        .any(|input| input.dims() != shape.as_slice())
+    {
+        return Ok(None);
+    }
+    let element_count =
+        tenferro_tensor::validate::checked_shape_product(ELEMENTWISE_FUSION_OP, "shape", &shape)?;
+    if element_count < ELEMENTWISE_FUSION_MIN_ELEMENTS {
+        return Ok(None);
+    }
+
+    run_typed_elementwise_fusion_with_views(buffers, &input_views, &shape, plan, wrap)
+}
+
+fn typed_elementwise_fusion_identity_with_pool<T>(
+    buffers: &mut BufferPool,
+    inputs: &[&TypedTensor<T>],
+    plan: &ElementwiseFusionPlan,
+    wrap: fn(TypedTensor<T>) -> Tensor,
+) -> crate::Result<Option<Vec<Tensor>>>
+where
+    T: Copy + Clone + FusedScalar + PoolScalar,
+{
+    let shape = inputs[0].shape();
+    if inputs.iter().skip(1).any(|input| input.shape() != shape) {
+        return Ok(None);
+    }
+    let element_count =
+        tenferro_tensor::validate::checked_shape_product(ELEMENTWISE_FUSION_OP, "shape", shape)?;
+    if element_count < ELEMENTWISE_FUSION_MIN_ELEMENTS {
+        return Ok(None);
+    }
+
+    let input_views = inputs
+        .iter()
+        .map(|input| typed_view(ELEMENTWISE_FUSION_OP, input))
+        .collect::<crate::Result<Vec<_>>>()?;
+    run_typed_elementwise_fusion_with_views(buffers, &input_views, shape, plan, wrap)
+}
+
+fn run_typed_elementwise_fusion_with_views<T>(
+    buffers: &mut BufferPool,
+    input_views: &[StridedView<'_, T>],
+    shape: &[usize],
+    plan: &ElementwiseFusionPlan,
+    wrap: fn(TypedTensor<T>) -> Tensor,
+) -> crate::Result<Option<Vec<Tensor>>>
+where
+    T: Copy + Clone + FusedScalar + PoolScalar,
+{
+    if let Some(outputs) =
+        try_typed_mul_add_specialization(buffers, input_views, shape, plan, wrap)?
+    {
+        return Ok(Some(outputs));
+    }
+
+    let fused_plan = strided_fused_plan(plan);
+    let mut output_arrays = Vec::with_capacity(plan.outputs().len());
+    for _ in plan.outputs() {
+        // SAFETY: fused_elementwise_into writes every destination element.
+        output_arrays.push(unsafe { typed_array_uninit_from_pool(buffers, shape) }?);
+    }
+
+    {
+        let mut output_views = output_arrays
+            .iter_mut()
+            .map(|output| output.view_mut())
+            .collect::<Vec<_>>();
+        fused_elementwise_into(&mut output_views, input_views, &fused_plan)
+            .map_err(|err| crate::Error::backend_failure(ELEMENTWISE_FUSION_OP, err))?;
+    }
+
+    Ok(Some(
+        output_arrays
+            .into_iter()
+            .map(|output| wrap(tensor_from_array(output)))
+            .collect(),
+    ))
+}
+
+fn try_typed_mul_add_specialization<T>(
+    buffers: &mut BufferPool,
+    input_views: &[StridedView<'_, T>],
+    shape: &[usize],
+    plan: &ElementwiseFusionPlan,
+    wrap: fn(TypedTensor<T>) -> Tensor,
+) -> crate::Result<Option<Vec<Tensor>>>
+where
+    T: Copy + Clone + FusedScalar + PoolScalar,
+{
+    if plan.input_count() != 2
+        || input_views.len() != 2
+        || plan.outputs() != [3]
+        || plan.ops().len() != 2
+        || plan.ops()[0].op() != ElementwiseFusionOp::Multiply
+        || plan.ops()[0].inputs() != [0, 1]
+        || plan.ops()[1].op() != ElementwiseFusionOp::Add
+    {
+        return Ok(None);
+    }
+
+    // SAFETY: zip_map2_into overwrites every output element.
+    let mut out = unsafe { typed_array_uninit_from_pool(buffers, shape) }?;
+    match plan.ops()[1].inputs() {
+        [2, 0] | [0, 2] => zip_map2_into(
+            &mut out.view_mut(),
+            &input_views[0],
+            &input_views[1],
+            |a, b| a.fused_multiply(b).fused_add(a),
+        ),
+        [2, 1] | [1, 2] => zip_map2_into(
+            &mut out.view_mut(),
+            &input_views[0],
+            &input_views[1],
+            |a, b| a.fused_multiply(b).fused_add(b),
+        ),
+        _ => return Ok(None),
+    }
+    .map_err(|err| crate::Error::backend_failure(ELEMENTWISE_FUSION_OP, err))?;
+
+    Ok(Some(vec![wrap(tensor_from_array(out))]))
+}
+
+fn typed_fusion_input_view<'a, T>(
+    input: &'a TypedTensor<T>,
+    view: &ElementwiseFusionInputView,
+) -> crate::Result<StridedView<'a, T>>
+where
+    T: Copy,
+{
+    let base = typed_view(ELEMENTWISE_FUSION_OP, input)?;
+    let ElementwiseFusionInputView::BroadcastInDim { shape, dims } = view else {
+        return Ok(base);
+    };
+    if dims.len() != input.shape().len() {
+        return Err(crate::Error::InvalidConfig {
+            op: ELEMENTWISE_FUSION_OP,
+            message: format!(
+                "broadcast dims length {} does not match input rank {}",
+                dims.len(),
+                input.shape().len()
+            ),
+        });
+    }
+
+    let mut strides = vec![0; shape.len()];
+    let mut seen = Vec::with_capacity(shape.len());
+    seen.resize(shape.len(), false);
+    for (source_axis, &target_axis) in dims.iter().enumerate() {
+        if target_axis >= shape.len() {
+            return Err(crate::Error::AxisOutOfBounds {
+                op: ELEMENTWISE_FUSION_OP,
+                axis: target_axis,
+                rank: shape.len(),
+            });
+        }
+        if seen[target_axis] {
+            return Err(crate::Error::DuplicateAxis {
+                op: ELEMENTWISE_FUSION_OP,
+                axis: target_axis,
+                role: "broadcast dims",
+            });
+        }
+        seen[target_axis] = true;
+        let source_dim = input.shape()[source_axis];
+        let target_dim = shape[target_axis];
+        if source_dim != target_dim && source_dim != 1 {
+            return Err(crate::Error::ShapeMismatch {
+                op: ELEMENTWISE_FUSION_OP,
+                lhs: shape.to_vec(),
+                rhs: input.shape().to_vec(),
+            });
+        }
+        if source_dim == target_dim {
+            strides[target_axis] = base.strides()[source_axis];
+        }
+    }
+
+    StridedView::new(base.data(), shape, &strides, base.offset())
+        .map_err(|err| crate::Error::backend_failure(ELEMENTWISE_FUSION_OP, err))
 }
 
 fn typed_binary_view_with_pool<T, L, R>(

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -1,6 +1,8 @@
 use crate::buffer_pool::BufferPool;
 use crate::{Tensor, TensorRead, TensorValue, TensorWrite};
-use tenferro_tensor::backend::{dot_general_accum_via_temp, validate_dot_general_accumulation};
+use tenferro_tensor::backend::{
+    dot_general_accum_via_temp, validate_dot_general_accumulation, ElementwiseFusionPlan,
+};
 use tenferro_tensor::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
@@ -665,6 +667,14 @@ impl TensorBuffer for CpuExecSession<'_> {
 }
 
 impl TensorFusion for CpuExecSession<'_> {
+    fn execute_elementwise_fusion(
+        &mut self,
+        inputs: &[&Tensor],
+        plan: &ElementwiseFusionPlan,
+    ) -> crate::Result<Option<Vec<Tensor>>> {
+        elementwise::elementwise_fusion_with_pool(self.buffers, inputs, plan)
+    }
+
     fn execute_broadcast_multiply(
         &mut self,
         lhs: TensorRead<'_>,

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -61,6 +61,130 @@ fn test_broadcast_multiply_fusion_computes_outer_product_without_materialized_in
 }
 
 #[test]
+fn test_cpu_elementwise_fusion_executes_add_mul_plan() {
+    let mut backend = CpuBackend::new();
+    let n = 65_536usize;
+    let lhs_data = (0..n).map(|i| i as f64 + 1.0).collect::<Vec<_>>();
+    let rhs_data = (0..n).map(|i| (i as f64 + 1.0) * 10.0).collect::<Vec<_>>();
+    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![n], lhs_data).unwrap());
+    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![n], rhs_data).unwrap());
+    let fusion_plan = tenferro_tensor::backend::ElementwiseFusionPlan::new(
+        DType::F64,
+        2,
+        vec![3],
+        vec![
+            tenferro_tensor::backend::ElementwiseFusionInst::new(
+                tenferro_tensor::backend::ElementwiseFusionOp::Add,
+                vec![0, 1],
+            ),
+            tenferro_tensor::backend::ElementwiseFusionInst::new(
+                tenferro_tensor::backend::ElementwiseFusionOp::Multiply,
+                vec![2, 0],
+            ),
+        ],
+    );
+
+    let outputs = backend
+        .execute_elementwise_fusion(&[&lhs, &rhs], &fusion_plan)
+        .unwrap()
+        .expect("CPU backend should execute supported elementwise fusion plans");
+
+    assert_eq!(outputs.len(), 1);
+    assert_eq!(outputs[0].shape(), &[n]);
+    let actual = outputs[0].as_slice::<f64>().unwrap();
+    assert_eq!(actual[0], 11.0);
+    assert_eq!(actual[1], 44.0);
+    assert_eq!(actual[n - 1], 11.0 * (n as f64).powi(2));
+}
+
+#[test]
+fn test_cpu_elementwise_fusion_executes_broadcast_chain_plan() {
+    let mut backend = CpuBackend::new();
+    let n = 8_192usize;
+    let lhs_data = (0..n).map(|i| i as f64 + 1.0).collect::<Vec<_>>();
+    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![n], lhs_data).unwrap());
+    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![7.0, 11.0]).unwrap());
+    let output_shape = vec![n, 2];
+    let fusion_plan = tenferro_tensor::backend::ElementwiseFusionPlan::with_input_views(
+        DType::F64,
+        vec![
+            tenferro_tensor::backend::ElementwiseFusionInputView::broadcast_in_dim(
+                output_shape.clone(),
+                vec![0],
+            ),
+            tenferro_tensor::backend::ElementwiseFusionInputView::broadcast_in_dim(
+                output_shape,
+                vec![1],
+            ),
+        ],
+        vec![3],
+        vec![
+            tenferro_tensor::backend::ElementwiseFusionInst::new(
+                tenferro_tensor::backend::ElementwiseFusionOp::Multiply,
+                vec![0, 1],
+            ),
+            tenferro_tensor::backend::ElementwiseFusionInst::new(
+                tenferro_tensor::backend::ElementwiseFusionOp::Add,
+                vec![2, 0],
+            ),
+        ],
+    );
+
+    let outputs = backend
+        .execute_elementwise_fusion(&[&lhs, &rhs], &fusion_plan)
+        .unwrap()
+        .expect("CPU backend should execute broadcast input views in fusion plans");
+
+    assert_eq!(outputs.len(), 1);
+    assert_eq!(outputs[0].shape(), &[n, 2]);
+    let actual = outputs[0].as_slice::<f64>().unwrap();
+    assert_eq!(actual[0], 8.0);
+    assert_eq!(actual[n - 1], n as f64 * 8.0);
+    assert_eq!(actual[n], 12.0);
+    assert_eq!(actual[2 * n - 1], n as f64 * 12.0);
+}
+
+#[test]
+fn test_cpu_elementwise_fusion_broadcasts_mapped_unit_axes() {
+    let mut backend = CpuBackend::new();
+    let n = 16_384usize;
+    let lhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![3.0]).unwrap());
+    let rhs_data = (0..n).map(|i| i as f64 + 1.0).collect::<Vec<_>>();
+    let rhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![n], rhs_data).unwrap());
+    let fusion_plan = tenferro_tensor::backend::ElementwiseFusionPlan::with_input_views(
+        DType::F64,
+        vec![
+            tenferro_tensor::backend::ElementwiseFusionInputView::broadcast_in_dim(
+                vec![n],
+                vec![0],
+            ),
+            tenferro_tensor::backend::ElementwiseFusionInputView::Identity,
+        ],
+        vec![3],
+        vec![
+            tenferro_tensor::backend::ElementwiseFusionInst::new(
+                tenferro_tensor::backend::ElementwiseFusionOp::Multiply,
+                vec![0, 1],
+            ),
+            tenferro_tensor::backend::ElementwiseFusionInst::new(
+                tenferro_tensor::backend::ElementwiseFusionOp::Add,
+                vec![2, 0],
+            ),
+        ],
+    );
+
+    let outputs = backend
+        .execute_elementwise_fusion(&[&lhs, &rhs], &fusion_plan)
+        .unwrap()
+        .expect("CPU backend should broadcast mapped unit axes in fusion plans");
+
+    assert_eq!(outputs[0].shape(), &[n]);
+    let actual = outputs[0].as_slice::<f64>().unwrap();
+    assert_eq!(actual[0], 6.0);
+    assert_eq!(actual[n - 1], 3.0 * n as f64 + 3.0);
+}
+
+#[test]
 fn test_materialize_tensor_read_covers_host_tensor_and_view_variants() {
     let tensors = [
         Tensor::F32(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f32]).unwrap()),

--- a/crates/tenferro-gpu/src/cubecl/fusion/classify.rs
+++ b/crates/tenferro-gpu/src/cubecl/fusion/classify.rs
@@ -21,6 +21,9 @@ where
     if plan.dtype() != T::DTYPE || plan.input_count() != inputs.len() || plan.outputs().is_empty() {
         return Ok(None);
     }
+    if !plan.input_views().iter().all(|view| view.is_identity()) {
+        return Ok(None);
+    }
     if !plan.ops().iter().all(|inst| T::supports_op(&inst.op())) {
         return Ok(None);
     }

--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -33,4 +33,9 @@ smallvec.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 tenferro-cpu = { path = "../tenferro-cpu", version = "0.1.0", default-features = false }
+
+[[bench]]
+name = "elementwise_fusion"
+harness = false

--- a/crates/tenferro-runtime/benches/elementwise_fusion.rs
+++ b/crates/tenferro-runtime/benches/elementwise_fusion.rs
@@ -1,0 +1,163 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TensorRead, TracedTensor};
+
+fn input_tensor(n: usize, scale: f64) -> Tensor {
+    let data = (0..n)
+        .map(|i| ((i % 97) as f64 + 1.0) * scale)
+        .collect::<Vec<_>>();
+    Tensor::from_vec_col_major(vec![n], data).expect("benchmark tensor")
+}
+
+fn compile_add_mul(n: usize) -> (TracedTensor, TracedTensor, tenferro_runtime::GraphProgram) {
+    let a = TracedTensor::input_concrete_shape(DType::F64, &[n]).expect("a placeholder");
+    let b = TracedTensor::input_concrete_shape(DType::F64, &[n]).expect("b placeholder");
+    let sum = (&a + &b).expect("sum graph");
+    let out = (&sum * &a).expect("multiply graph");
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(&out, &[(&a, DType::F64, &[n]), (&b, DType::F64, &[n])])
+        .expect("compiled add-mul graph");
+    (a, b, program)
+}
+
+fn compile_broadcast_mul(
+    rows: usize,
+    cols: usize,
+) -> (TracedTensor, TracedTensor, tenferro_runtime::GraphProgram) {
+    let a = TracedTensor::input_concrete_shape(DType::F64, &[rows]).expect("a placeholder");
+    let b = TracedTensor::input_concrete_shape(DType::F64, &[cols]).expect("b placeholder");
+    let a_bc = a
+        .broadcast_in_dim(&[rows, cols], &[0])
+        .expect("lhs broadcast graph");
+    let b_bc = b
+        .broadcast_in_dim(&[rows, cols], &[1])
+        .expect("rhs broadcast graph");
+    let out = (&a_bc * &b_bc).expect("multiply graph");
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(
+            &out,
+            &[(&a, DType::F64, &[rows]), (&b, DType::F64, &[cols])],
+        )
+        .expect("compiled broadcast-multiply graph");
+    (a, b, program)
+}
+
+fn compile_broadcast_mul_add(
+    rows: usize,
+    cols: usize,
+) -> (TracedTensor, TracedTensor, tenferro_runtime::GraphProgram) {
+    let a = TracedTensor::input_concrete_shape(DType::F64, &[rows]).expect("a placeholder");
+    let b = TracedTensor::input_concrete_shape(DType::F64, &[cols]).expect("b placeholder");
+    let a_bc = a
+        .broadcast_in_dim(&[rows, cols], &[0])
+        .expect("lhs broadcast graph");
+    let b_bc = b
+        .broadcast_in_dim(&[rows, cols], &[1])
+        .expect("rhs broadcast graph");
+    let product = (&a_bc * &b_bc).expect("multiply graph");
+    let out = (&product + &a_bc).expect("add graph");
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(
+            &out,
+            &[(&a, DType::F64, &[rows]), (&b, DType::F64, &[cols])],
+        )
+        .expect("compiled broadcast-multiply-add graph");
+    (a, b, program)
+}
+
+fn bench_runtime_add_mul(c: &mut Criterion) {
+    let mut group = c.benchmark_group("runtime_elementwise_chain/f64/add_mul");
+    for &n in &[4_096_usize, 65_536, 1_048_576] {
+        let (a_symbol, b_symbol, program) = compile_add_mul(n);
+        let a = input_tensor(n, 0.5);
+        let b = input_tensor(n, 1.25);
+        group.throughput(criterion::Throughput::Elements(n as u64));
+        group.bench_function(BenchmarkId::new("segmented_graph", n), |bench| {
+            let mut executor = GraphExecutor::new(CpuBackend::new());
+            bench.iter(|| {
+                let out = executor
+                    .run_with_input_reads(
+                        black_box(&program),
+                        &[
+                            (&a_symbol, TensorRead::from_tensor(black_box(&a))),
+                            (&b_symbol, TensorRead::from_tensor(black_box(&b))),
+                        ],
+                    )
+                    .expect("graph run");
+                black_box(out);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_runtime_broadcast_mul(c: &mut Criterion) {
+    let mut group = c.benchmark_group("runtime_elementwise_chain/f64/broadcast_mul");
+    for &(rows, cols) in &[(256_usize, 256_usize), (1024, 1024)] {
+        let (a_symbol, b_symbol, program) = compile_broadcast_mul(rows, cols);
+        let a = input_tensor(rows, 0.5);
+        let b = input_tensor(cols, 1.25);
+        let elements = rows * cols;
+        group.throughput(criterion::Throughput::Elements(elements as u64));
+        group.bench_function(
+            BenchmarkId::new("segmented_graph", format!("{rows}x{cols}")),
+            |bench| {
+                let mut executor = GraphExecutor::new(CpuBackend::new());
+                bench.iter(|| {
+                    let out = executor
+                        .run_with_input_reads(
+                            black_box(&program),
+                            &[
+                                (&a_symbol, TensorRead::from_tensor(black_box(&a))),
+                                (&b_symbol, TensorRead::from_tensor(black_box(&b))),
+                            ],
+                        )
+                        .expect("graph run");
+                    black_box(out);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_runtime_broadcast_mul_add(c: &mut Criterion) {
+    let mut group = c.benchmark_group("runtime_elementwise_chain/f64/broadcast_mul_add");
+    for &(rows, cols) in &[(256_usize, 256_usize), (1024, 1024)] {
+        let (a_symbol, b_symbol, program) = compile_broadcast_mul_add(rows, cols);
+        let a = input_tensor(rows, 0.5);
+        let b = input_tensor(cols, 1.25);
+        let elements = rows * cols;
+        group.throughput(criterion::Throughput::Elements(elements as u64));
+        group.bench_function(
+            BenchmarkId::new("segmented_graph", format!("{rows}x{cols}")),
+            |bench| {
+                let mut executor = GraphExecutor::new(CpuBackend::new());
+                bench.iter(|| {
+                    let out = executor
+                        .run_with_input_reads(
+                            black_box(&program),
+                            &[
+                                (&a_symbol, TensorRead::from_tensor(black_box(&a))),
+                                (&b_symbol, TensorRead::from_tensor(black_box(&b))),
+                            ],
+                        )
+                        .expect("graph run");
+                    black_box(out);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_runtime_add_mul,
+    bench_runtime_broadcast_mul,
+    bench_runtime_broadcast_mul_add
+);
+criterion_main!(benches);

--- a/crates/tenferro-runtime/src/segment.rs
+++ b/crates/tenferro-runtime/src/segment.rs
@@ -15,7 +15,10 @@ use crate::exec::{
     ExecOp, ExecProgram, ExecSlot,
 };
 use crate::extension_runtime::ExtensionExecutor;
-use tenferro_tensor::backend::{ElementwiseFusionInst, ElementwiseFusionPlan};
+use tenferro_ops::dim_expr::DimExpr;
+use tenferro_tensor::backend::{
+    ElementwiseFusionInputView, ElementwiseFusionInst, ElementwiseFusionPlan,
+};
 use tenferro_tensor::{Tensor, TensorBackend, TensorRead, TensorValue};
 
 /// A compiled execution segment.
@@ -64,7 +67,9 @@ pub(crate) fn segment_exec_program(program: &ExecProgram) -> Vec<Segment> {
             );
             segments.push(Segment::Ffi(inst.clone()));
             idx += 1;
-        } else if is_broadcast_multiply_triplet_at(program, idx) {
+        } else if is_broadcast_multiply_triplet_at(program, idx)
+            && !segment_outputs_have_future_uses(program, &future_uses, idx, idx + 3)
+        {
             flush_fused_segment(
                 program,
                 &future_uses,
@@ -74,7 +79,9 @@ pub(crate) fn segment_exec_program(program: &ExecProgram) -> Vec<Segment> {
             );
             segments.push(build_fused_segment(program, &future_uses, idx, idx + 3));
             idx += 3;
-        } else if is_single_broadcast_multiply_pair_at(program, idx) {
+        } else if is_single_broadcast_multiply_pair_at(program, idx)
+            && !segment_outputs_have_future_uses(program, &future_uses, idx, idx + 2)
+        {
             flush_fused_segment(
                 program,
                 &future_uses,
@@ -100,6 +107,18 @@ pub(crate) fn segment_exec_program(program: &ExecProgram) -> Vec<Segment> {
         program.instructions.len(),
     );
     segments
+}
+
+fn segment_outputs_have_future_uses(
+    program: &ExecProgram,
+    use_summary: &SegmentUseSummary,
+    start: usize,
+    end: usize,
+) -> bool {
+    program.instructions[start..end]
+        .iter()
+        .flat_map(|inst| inst.output_slots.iter().copied())
+        .any(|slot| use_summary.is_used_at_or_after(slot, end))
 }
 
 fn is_broadcast_multiply_triplet_at(program: &ExecProgram, idx: usize) -> bool {
@@ -954,15 +973,43 @@ fn build_elementwise_fusion_plan(
     let first = instructions.first()?;
     let dtype = first.dtype;
     let mut slot_to_value = HashMap::with_capacity(input_slots.len() + instructions.len());
+    // Keep this as Vec to match ElementwiseFusionPlan metadata; A/B
+    // benchmarks showed SmallVec made the broadcast metadata path slower.
+    let mut input_views = Vec::with_capacity(input_slots.len());
+    input_views.resize(input_slots.len(), ElementwiseFusionInputView::Identity);
     for (value, &slot) in input_slots.iter().enumerate() {
         slot_to_value.insert(slot, value);
     }
 
     let mut ops = Vec::with_capacity(instructions.len());
-    for (next_value, inst) in (input_slots.len()..).zip(instructions.iter()) {
+    let mut next_value = input_slots.len();
+    for inst in instructions {
         if inst.dtype != dtype || inst.output_slots.len() != 1 {
             return None;
         }
+        if let ExecOp::BroadcastInDim { shape, dims } = &inst.op {
+            let input_slot = *inst.input_slots.first()?;
+            if inst.input_slots.len() != 1
+                || source_slot_is_used_directly_by_elementwise(instructions, input_slot)
+            {
+                return None;
+            }
+            let input_value = *slot_to_value.get(&input_slot)?;
+            if input_value >= input_views.len()
+                || !matches!(
+                    input_views[input_value],
+                    ElementwiseFusionInputView::Identity
+                )
+            {
+                return None;
+            }
+            let shape = const_dim_expr_shape(shape)?;
+            input_views[input_value] =
+                ElementwiseFusionInputView::broadcast_in_dim(shape, dims.clone());
+            slot_to_value.insert(inst.output_slots[0], input_value);
+            continue;
+        }
+
         let op = inst.op.elementwise_fusion_op()?;
         let inputs = inst
             .input_slots
@@ -971,6 +1018,7 @@ fn build_elementwise_fusion_plan(
             .collect::<Option<Vec<_>>>()?;
         ops.push(ElementwiseFusionInst::new(op, inputs));
         slot_to_value.insert(inst.output_slots[0], next_value);
+        next_value += 1;
     }
 
     let outputs = output_slots
@@ -978,12 +1026,31 @@ fn build_elementwise_fusion_plan(
         .map(|slot| slot_to_value.get(slot).copied())
         .collect::<Option<Vec<_>>>()?;
 
-    Some(ElementwiseFusionPlan::new(
+    Some(ElementwiseFusionPlan::with_input_views(
         dtype,
-        input_slots.len(),
+        input_views,
         outputs,
         ops,
     ))
+}
+
+fn source_slot_is_used_directly_by_elementwise(
+    instructions: &[ExecInstruction],
+    source_slot: usize,
+) -> bool {
+    instructions.iter().any(|inst| {
+        !matches!(inst.op, ExecOp::BroadcastInDim { .. }) && inst.input_slots.contains(&source_slot)
+    })
+}
+
+fn const_dim_expr_shape(shape: &[DimExpr]) -> Option<Vec<usize>> {
+    shape
+        .iter()
+        .map(|dim| match dim {
+            DimExpr::Const(value) => Some(*value),
+            _ => None,
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/tenferro-runtime/src/segment/tests.rs
+++ b/crates/tenferro-runtime/src/segment/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::exec::{ExecInstruction, ExecOp, ExecProgram};
 use tenferro_cpu::CpuBackend;
 use tenferro_ops::{dim_expr::DimExpr, ShapeExtent};
+use tenferro_tensor::backend::{ElementwiseFusionInputView, ElementwiseFusionOp};
 use tenferro_tensor::{DType, Tensor};
 
 fn dim_shape(shape: &[usize]) -> Vec<DimExpr> {
@@ -47,6 +48,18 @@ fn multiply_with_shape(lhs: usize, rhs: usize, output: usize, shape: &[usize]) -
     }
 }
 
+fn add_with_shape(lhs: usize, rhs: usize, output: usize, shape: &[usize]) -> ExecInstruction {
+    ExecInstruction {
+        op: ExecOp::Add,
+        input_slots: vec![lhs, rhs],
+        output_slots: vec![output],
+        dtype: DType::F64,
+        output_shapes: vec![dim_shape(shape)].into(),
+        output_extents: vec![exact_extents(shape)].into(),
+        last_use: vec![true, true],
+    }
+}
+
 fn broadcast(input: usize, output: usize, dims: Vec<usize>) -> ExecInstruction {
     ExecInstruction {
         op: ExecOp::BroadcastInDim {
@@ -83,6 +96,53 @@ fn multiply(lhs: usize, rhs: usize, output: usize) -> ExecInstruction {
 }
 
 #[test]
+fn elementwise_fusion_plan_uses_dense_segment_value_ids() {
+    let instructions = vec![
+        add_with_shape(10, 20, 30, &[4]),
+        multiply_with_shape(30, 10, 40, &[4]),
+    ];
+
+    let plan = build_elementwise_fusion_plan(&instructions, &[10, 20], &[40])
+        .expect("add-multiply segment should build a fusion plan");
+
+    assert_eq!(plan.dtype(), DType::F64);
+    assert_eq!(plan.input_count(), 2);
+    assert!(plan.input_views().iter().all(|view| view.is_identity()));
+    assert_eq!(plan.outputs(), &[3]);
+    assert_eq!(plan.ops().len(), 2);
+    assert_eq!(plan.ops()[0].op(), ElementwiseFusionOp::Add);
+    assert_eq!(plan.ops()[0].inputs(), &[0, 1]);
+    assert_eq!(plan.ops()[1].op(), ElementwiseFusionOp::Multiply);
+    assert_eq!(plan.ops()[1].inputs(), &[2, 0]);
+}
+
+#[test]
+fn elementwise_fusion_plan_absorbs_broadcast_input_views() {
+    let instructions = vec![
+        broadcast_with_shape(0, 2, &[3, 2], vec![0]),
+        broadcast_with_shape(1, 3, &[3, 2], vec![1]),
+        multiply_with_shape(2, 3, 4, &[3, 2]),
+    ];
+
+    let plan = build_elementwise_fusion_plan(&instructions, &[0, 1], &[4])
+        .expect("broadcast-multiply segment should build a fusion plan");
+
+    assert_eq!(plan.input_count(), 2);
+    assert_eq!(plan.outputs(), &[2]);
+    assert_eq!(plan.ops().len(), 1);
+    assert_eq!(plan.ops()[0].op(), ElementwiseFusionOp::Multiply);
+    assert_eq!(plan.ops()[0].inputs(), &[0, 1]);
+    assert_eq!(
+        plan.input_views()[0],
+        ElementwiseFusionInputView::broadcast_in_dim(vec![3, 2], vec![0])
+    );
+    assert_eq!(
+        plan.input_views()[1],
+        ElementwiseFusionInputView::broadcast_in_dim(vec![3, 2], vec![1])
+    );
+}
+
+#[test]
 fn segmenter_isolates_consecutive_broadcast_multiply_triples() {
     let program = ExecProgram {
         instructions: vec![
@@ -107,6 +167,29 @@ fn segmenter_isolates_consecutive_broadcast_multiply_triples() {
             Segment::Fused { instructions, .. } if instructions.len() == 3
         ));
     }
+}
+
+#[test]
+fn segmenter_keeps_broadcast_multiply_chain_when_outputs_are_reused() {
+    let program = ExecProgram {
+        instructions: vec![
+            broadcast_with_shape(0, 2, &[3, 2], vec![0]),
+            broadcast_with_shape(1, 3, &[3, 2], vec![1]),
+            multiply_with_shape(2, 3, 4, &[3, 2]),
+            add_with_shape(4, 2, 5, &[3, 2]),
+        ],
+        input_slots: vec![0, 1],
+        output_slots: vec![5],
+        n_slots: 6,
+    };
+
+    let segments = segment_exec_program(&program);
+
+    assert_eq!(segments.len(), 1);
+    assert!(matches!(
+        &segments[0],
+        Segment::Fused { instructions, .. } if instructions.len() == 4
+    ));
 }
 
 #[test]

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -446,8 +446,23 @@ fn flat_to_multi_for_shape(shape: &[usize], mut linear: usize) -> Vec<usize> {
 pub struct ElementwiseFusionPlan {
     dtype: crate::DType,
     input_count: usize,
+    // Keep view metadata in Vecs. A/B benchmarking on the broadcast_mul
+    // path showed SmallVec made this metadata path about 6-7% slower.
+    input_views: Vec<ElementwiseFusionInputView>,
     outputs: Vec<usize>,
     ops: Vec<ElementwiseFusionInst>,
+}
+
+/// Metadata-only view applied to one backend fusion input.
+#[doc(hidden)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ElementwiseFusionInputView {
+    Identity,
+    BroadcastInDim {
+        // Vec is intentional here; see ElementwiseFusionPlan::input_views.
+        shape: Vec<usize>,
+        dims: Vec<usize>,
+    },
 }
 
 /// One node in a canonical elementwise fusion plan.
@@ -485,9 +500,45 @@ impl ElementwiseFusionPlan {
         outputs: Vec<usize>,
         ops: Vec<ElementwiseFusionInst>,
     ) -> Self {
+        Self::with_input_views(
+            dtype,
+            vec![ElementwiseFusionInputView::Identity; input_count],
+            outputs,
+            ops,
+        )
+    }
+
+    /// Build a backend elementwise fusion plan with input view metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::backend::{
+    ///     ElementwiseFusionInputView, ElementwiseFusionInst, ElementwiseFusionOp,
+    ///     ElementwiseFusionPlan,
+    /// };
+    /// use tenferro_tensor::DType;
+    ///
+    /// let plan = ElementwiseFusionPlan::with_input_views(
+    ///     DType::F64,
+    ///     vec![ElementwiseFusionInputView::broadcast_in_dim(vec![2, 3], vec![0])],
+    ///     vec![1],
+    ///     vec![ElementwiseFusionInst::new(ElementwiseFusionOp::Negate, vec![0])],
+    /// );
+    /// assert_eq!(plan.input_count(), 1);
+    /// ```
+    pub fn with_input_views(
+        dtype: crate::DType,
+        input_views: impl IntoIterator<Item = ElementwiseFusionInputView>,
+        outputs: Vec<usize>,
+        ops: Vec<ElementwiseFusionInst>,
+    ) -> Self {
+        let input_views = input_views.into_iter().collect::<Vec<_>>();
+        let input_count = input_views.len();
         Self {
             dtype,
             input_count,
+            input_views,
             outputs,
             ops,
         }
@@ -523,6 +574,21 @@ impl ElementwiseFusionPlan {
         self.input_count
     }
 
+    /// Return metadata views applied to fusion inputs before executing ops.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::backend::ElementwiseFusionPlan;
+    /// use tenferro_tensor::DType;
+    ///
+    /// let plan = ElementwiseFusionPlan::new(DType::F64, 2, Vec::new(), Vec::new());
+    /// assert_eq!(plan.input_views().len(), 2);
+    /// ```
+    pub fn input_views(&self) -> &[ElementwiseFusionInputView] {
+        &self.input_views
+    }
+
     /// Return the value ids selected as fusion outputs.
     ///
     /// # Examples
@@ -554,6 +620,41 @@ impl ElementwiseFusionPlan {
     /// ```
     pub fn ops(&self) -> &[ElementwiseFusionInst] {
         &self.ops
+    }
+}
+
+impl ElementwiseFusionInputView {
+    /// Build metadata for a `BroadcastInDim` fusion input view.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::backend::ElementwiseFusionInputView;
+    ///
+    /// let view = ElementwiseFusionInputView::broadcast_in_dim(vec![2, 3], vec![0]);
+    /// assert!(matches!(view, ElementwiseFusionInputView::BroadcastInDim { .. }));
+    /// ```
+    pub fn broadcast_in_dim(
+        shape: impl IntoIterator<Item = usize>,
+        dims: impl IntoIterator<Item = usize>,
+    ) -> Self {
+        Self::BroadcastInDim {
+            shape: shape.into_iter().collect(),
+            dims: dims.into_iter().collect(),
+        }
+    }
+
+    /// Return true when this fusion input is an identity view.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::backend::ElementwiseFusionInputView;
+    ///
+    /// assert!(ElementwiseFusionInputView::Identity.is_identity());
+    /// ```
+    pub fn is_identity(&self) -> bool {
+        matches!(self, Self::Identity)
     }
 }
 

--- a/docs/worklogs/2026-07-04-issue-1291-cpu-fusion-strided.md
+++ b/docs/worklogs/2026-07-04-issue-1291-cpu-fusion-strided.md
@@ -1,0 +1,131 @@
+# Issue 1291 CPU Elementwise Fusion Via Strided
+
+## Session Summary
+
+Implemented the first CPU-side #1291 slice after `strided-rs` 0.3.0 was
+published. The branch moves tenferro's strided dependencies from the old git
+revision to crates.io 0.3.0, adds a CPU `execute_elementwise_fusion` adapter,
+and extends segmented runtime planning so `BroadcastInDim` can be represented
+as fusion input metadata instead of forcing eager materialization.
+
+This is deliberately one PR with multiple measured phases. The final code keeps
+the existing hand-written broadcast-multiply fast paths for the pure multiply
+case because benchmarks showed they are still much faster than the generic
+fused plan. Broadcast metadata fusion is used for chained elementwise work such
+as `broadcast_mul_add`, where it removes a large materialization cost.
+
+## Context Read
+
+- Issue #1291 and its acceptance criteria around CPU elementwise fusion,
+  broadcast view absorption, strided fused plans, and benchmark verification.
+- Shared tensor4all common, Rust, performance, and docs/test rules.
+- `REPOSITORY_RULES.md`, especially hidden materialization, CPU kernel
+  ownership, benchmark, and worklog requirements.
+- `strided-kernel` 0.3.0 `FusedPlan`, `FusedInst`, `FusedOp`, and
+  `fused_elementwise_into`.
+- Existing segmented execution and broadcast-multiply special cases in
+  `crates/tenferro-runtime/src/segment.rs`.
+- Existing CPU elementwise and structural broadcast implementations in
+  `crates/tenferro-cpu/src/elementwise.rs` and `structural.rs`.
+
+## Decisions
+
+- Keep `ElementwiseFusionPlan` as the canonical hidden backend plan, but add
+  hidden `ElementwiseFusionInputView` metadata for input-side identity and
+  `BroadcastInDim` views.
+- Use `strided_kernel::fused_elementwise_into` for supported CPU F32/F64/C32/C64
+  plans, returning `None` for integer/bool and unsupported complex ordered ops
+  so existing per-op semantics remain authoritative.
+- Gate CPU fusion below 16K elements. The generic fused path has fixed overhead
+  that regressed 4K-element add-multiply chains, so small plans fall back to the
+  existing per-op path.
+- Defer pure broadcast multiply plans to the existing broadcast-multiply special
+  cases. Control benchmarks measured the special case at 15.8 us / 172.9 us for
+  256x256 and 1024x1024, versus 111.6 us / 1.65 ms for generic broadcast fusion.
+- Keep fusion input-view metadata in `Vec` rather than `SmallVec`. A/B
+  benchmarks on the broadcast metadata path measured `SmallVec` about 6-7%
+  slower than `Vec`, so the final code includes a source comment documenting
+  why `Vec` is intentional.
+- Add a local CPU fast path for the common `multiply -> add` fused chain. This
+  avoids strided's generic fused interpreter for the broadcast chain benchmark
+  and dispatches directly through `zip_map2_into`.
+
+## Benchmarks
+
+All benchmarks used:
+
+```bash
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 \
+VECLIB_MAXIMUM_THREADS=1 RAYON_NUM_THREADS=1 \
+CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target \
+cargo bench -p tenferro-runtime --bench elementwise_fusion -- \
+  --sample-size 10 --warm-up-time 0.2 --measurement-time 0.5
+```
+
+Baseline before dependency update, add-multiply chain:
+
+- 4,096 elements: 8.302 us
+- 65,536 elements: 92.241 us
+- 1,048,576 elements: 1.664 ms
+
+After updating strided dependencies to crates.io 0.3.0, before CPU fusion:
+
+- 4,096 elements: 8.425 us
+- 65,536 elements: 92.081 us
+- 1,048,576 elements: 1.666 ms
+
+Final add-multiply chain after CPU fusion and small-plan fallback:
+
+- 4,096 elements: 8.534 us
+- 65,536 elements: 26.314 us
+- 1,048,576 elements: 332.75 us
+
+Final simple broadcast multiply, which intentionally stays on the existing
+special-case path:
+
+- 256x256: 18.867 us
+- 1024x1024: 179.66 us
+
+Final broadcast multiply plus add chain, after keeping the segment intact and
+using the local `multiply -> add` fast path:
+
+- 256x256: 18.999 us
+- 1024x1024: 164.35 us
+
+Rejected alternatives measured during the session:
+
+- Generic broadcast fused interpreter before the local fast path:
+  938.47 us / 15.706 ms for 256x256 / 1024x1024 `broadcast_mul_add`.
+- `SmallVec` metadata on the broadcast metadata path:
+  118.54 us / 1.765 ms versus `Vec` control at 111.56 us / 1.655 ms.
+
+## Verification
+
+- Red test first confirmed CPU `execute_elementwise_fusion` returned `None` for
+  a supported add-multiply plan.
+- Targeted CPU fusion tests:
+  `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target cargo test -p tenferro-cpu test_cpu_elementwise_fusion -- --nocapture`
+- Runtime segment tests:
+  `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target cargo test -p tenferro-runtime segment -- --nocapture`
+- Benchmarks listed above.
+- `cargo fmt --all --check`
+- `git diff --check`
+- `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target cargo test --workspace --release`
+- `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target cargo clippy --workspace --all-targets -- -D warnings`
+- `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target/tropical cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-cov-target cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --worktree --output-json /tmp/repository-rules-review-worktree.json`
+
+## Residual Risks
+
+- The CPU fused adapter only covers F32/F64/C32/C64 and intentionally falls back
+  for integer and bool plans.
+- Broadcast metadata fusion currently handles metadata views on segment inputs.
+  More general reshape/permute metadata and GPU broadcast-aware codegen remain
+  follow-up work.
+- The strided generic fused interpreter is not yet a good fit for every
+  broadcast chain. This branch adds one high-value local specialization and
+  keeps existing broadcast-multiply special cases where they still win.


### PR DESCRIPTION
## Summary

Closes #1291.

This PR starts the post-materialization CPU optimization work now that `strided-rs` 0.3.0 is published:

- moves `strided-*` dependencies from the old git revision to crates.io `0.3.0`
- adds CPU `execute_elementwise_fusion` support through `strided_kernel::fused_elementwise_into`
- absorbs eligible `BroadcastInDim` ops into fusion input-view metadata so chained broadcast elementwise work does not materialize intermediate dense buffers
- keeps the existing pure broadcast-multiply special case because it remains faster than the generic fused interpreter
- adds Criterion benchmarks and a worklog: `docs/worklogs/2026-07-04-issue-1291-cpu-fusion-strided.md`

## Benchmarks

Bench command used after each phase:

```bash
OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 \
VECLIB_MAXIMUM_THREADS=1 RAYON_NUM_THREADS=1 \
CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target \
cargo bench -p tenferro-runtime --bench elementwise_fusion -- \
  --sample-size 10 --warm-up-time 0.2 --measurement-time 0.5
```

Key final numbers:

- add-mul, 65,536 elements: `92.081 us` after strided 0.3.0 update, `26.314 us` after CPU fusion
- add-mul, 1,048,576 elements: `1.666 ms` after strided 0.3.0 update, `332.75 us` after CPU fusion
- pure broadcast multiply remains on the old special case: `18.867 us` for 256x256, `179.66 us` for 1024x1024
- broadcast multiply plus add chain: `18.999 us` for 256x256, `164.35 us` for 1024x1024

SmallVec was also A/B tested for the new input-view metadata. It was slower on the broadcast metadata path (`118.54 us / 1.765 ms`) than the `Vec` control (`111.56 us / 1.655 ms`), so the code keeps `Vec` and documents why.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target cargo test -p tenferro-cpu test_cpu_elementwise_fusion -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target cargo test -p tenferro-runtime segment -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target cargo check -p tenferro-gpu`
- `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target cargo test --workspace --release`
- `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-target/tropical cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/tenferro-issue1291-cov-target cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
