### PR TITLE
ci: cut PR wall-clock via two-tier tests and parallel CUDA archive

### DIFF
--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -1,8 +1,11 @@
 name: CI_gpu
 
-# Wait for repository-policy and non-GPU CI checks before building CUDA test
-# archives, then execute CUDA-feature GPU tests on the org larger GPU runner
-# `ubuntu-gpu` to minimize GPU billing.
+# Build the CUDA test archive on a cheap non-GPU runner IN PARALLEL with the
+# repository-policy and non-GPU CI checks, then execute CUDA-feature GPU tests
+# on the org larger GPU runner `ubuntu-gpu` only after those checks pass, to
+# minimize GPU billing. Only the GPU runner (`cuda-run`) is gated behind
+# `pre-gpu-gate`; the archive build is not, so the GPU stage can start the
+# moment the gate clears instead of waiting for the archive to compile.
 
 on:
   pull_request:
@@ -38,14 +41,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Gate GPU billing on the checks that best predict a broken PR:
+            // formatting, lint, coverage (frequently the failing check here),
+            // and the full non-GPU workspace test aggregate, plus repository
+            // policy. Other merge-required checks (docs-site, blas inject,
+            // tensor core dependency boundary) still block merge via branch
+            // protection, but do not need to hold up the GPU runner.
             const required = [
               "repository rules review",
               "rustfmt",
               "clippy",
-              "cargo test (blas inject)",
-              "tensor core dependency boundary",
               "coverage",
-              "docs-site",
               "CI gate (PR workspace tests)",
             ];
 
@@ -112,13 +118,12 @@ jobs:
 
   cuda-archive:
     name: CUDA test archive
-    needs: [pre-gpu-gate]
-    if: |
-      always() &&
-      (
-        github.event.pull_request.head.repo.full_name != github.repository ||
-        needs.pre-gpu-gate.result == 'success'
-      )
+    # NOT gated on pre-gpu-gate: this build runs on a cheap non-GPU runner, so
+    # it compiles in parallel with the non-GPU CI + repository review to keep it
+    # off the critical path. The expensive GPU runner is still gated -- `cuda-run`
+    # needs [pre-gpu-gate, cuda-archive]. Runs for both fork and same-repo PRs;
+    # the build result (and its cache) is reused even if a prerequisite check
+    # later fails, so the only cost is cheap-runner minutes on doomed PRs.
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci-pr-workspace-tests.yml
+++ b/.github/workflows/ci-pr-workspace-tests.yml
@@ -1,37 +1,92 @@
-# Full workspace test suite for pull requests.
+# Workspace test suite (two-tier).
 #
 # This is the home of `cargo nextest run --workspace` + workspace doc tests.
 # `ci.yml` deliberately does NOT contain a workspace test job; it only runs the
-# fast checks (fmt, clippy, inject tests, coverage, docs) on push and PRs. The
-# heavy suite lives here so it runs once per PR instead of also on every push to
-# `main`. The `ci-gate` job below is the branch-protection check that proves the
-# workspace tests passed (via either the fork or same-repo path). GPU tests are
-# in `CI_gpu.yml` and are gated behind repository rules LLM review plus these
-# non-GPU checks.
+# fast checks (fmt, clippy, inject tests, coverage, docs) on push and PRs.
 #
-# Named for its PURPOSE (PR workspace tests), not its runner. The `ci-maintainer`
-# job is intended to run on a self-hosted pool but currently uses GitHub-hosted
-# runners while that pool is down — so a runner-derived name would be misleading.
-# The branch-protection required check is the job name `CI gate (PR workspace
-# tests)`, not this workflow name, so renaming the workflow is safe.
+# Two tiers:
+#   * Pull requests (fast tier): cpu-faer always; cpu-blas ONLY when
+#     backend-relevant paths change (see the `changes` job). Most PRs skip the
+#     cpu-blas lane entirely, so they run one backend instead of two.
+#   * Push to main (comprehensive tier): the full cpu-faer + cpu-blas matrix
+#     always runs, so every backend is exercised on the merged result even when
+#     the PR that produced it skipped cpu-blas.
+#
+# The extension/sample tutorial tests (tropical, sparse, KdV) live in their own
+# `ext-samples` job. They are standalone workspaces that recompile tenferro from
+# scratch, so running them once here (instead of inside every backend leg) keeps
+# them off the per-backend critical path and avoids duplicate compilation.
+#
+# The `ci-gate` job below is the branch-protection check that proves the
+# workspace + extension tests passed. Its job name is the required check, so
+# renaming the workflow is safe. GPU tests are in `CI_gpu.yml`, gated behind
+# repository rules LLM review plus these non-GPU checks.
+#
+# Named for its PURPOSE, not its runner. The `ci-maintainer` job is intended to
+# run on a self-hosted pool but currently uses GitHub-hosted runners while that
+# pool is down — so a runner-derived name would be misleading.
 name: CI PR workspace tests
 
 on:
   pull_request:
+    branches: [main]
+  push:
     branches: [main]
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-pr-${{ github.event.pull_request.number }}
+  # Per-PR for pull_request events (new pushes cancel stale runs); per-commit for
+  # push-to-main so distinct main commits are each verified without cancelling.
+  group: ci-pr-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  # fork からの PR: GitHub-hosted runner で通常 CI
+  # Decide which backends the same-repo matrix runs. cpu-blas is expensive, and
+  # only the CPU linalg backend selection distinguishes it from cpu-faer, so we
+  # run it only when backend-relevant paths change on a PR. On push to main we
+  # always run both (comprehensive tier).
+  changes:
+    name: Select backend matrix
+    runs-on: ubuntu-latest
+    outputs:
+      backends: ${{ steps.select.outputs.backends }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Select backends
+        id: select
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          faer='{"backend":"cpu-faer","feature_args":"","rustflags":""}'
+          blas='{"backend":"cpu-blas","feature_args":"--no-default-features --features cpu-blas","rustflags":"-l dylib=openblas -l dylib=lapack"}'
+          run_blas=false
+          if [ "${EVENT_NAME}" = "push" ]; then
+            # Comprehensive tier: always exercise both backends on main.
+            run_blas=true
+          else
+            changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"
+            if printf '%s\n' "${changed}" | grep -qE '^(crates/tenferro-cpu/|crates/tenferro-linalg/|crates/tenferro-tensor/|crates/tenferro-tensor-core/|Cargo\.lock|Cargo\.toml|\.github/workflows/ci-pr-workspace-tests\.yml)'; then
+              run_blas=true
+            fi
+          fi
+          if [ "${run_blas}" = "true" ]; then
+            echo "backends=[${faer},${blas}]" >> "${GITHUB_OUTPUT}"
+          else
+            echo "backends=[${faer}]" >> "${GITHUB_OUTPUT}"
+          fi
+          echo "Selected backends (run_blas=${run_blas}, event=${EVENT_NAME})."
+
+  # fork からの PR: GitHub-hosted runner で cpu-faer のみ。
   ci-fork:
     name: CI (fork PR / github-hosted)
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
@@ -39,40 +94,29 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - name: Run unit and integration tests
-        # `tenferro-tutorial-code` is a workspace test package. Keep runnable
-        # tutorials in this command so CI reuses the unit-test target dir
-        # instead of recompiling tenferro in a separate tutorial job.
+        # `tenferro-tutorial-code` is a workspace test package, so the workspace
+        # nextest run already covers the runnable tutorials.
         run: cargo nextest run --workspace --release --no-fail-fast
       - name: Run doc tests
         run: cargo test --doc --workspace --release
-      - name: Compile-check KdV PINN sample
-        run: cargo check --manifest-path samples/kdv-pinn/Cargo.toml --release --all-targets
-      - name: Run tropical extension tutorial tests
-        run: cargo test --manifest-path ext/tropical/Cargo.toml --release --features autodiff
-      - name: Run sparse extension tutorial tests
-        run: cargo test --manifest-path ext/sparse/Cargo.toml --release --features autodiff
 
-  # PRs from the same repository: normally run heavy CI on self-hosted runner.
-  # Temporarily use GitHub-hosted runners while the self-hosted pool is down.
+  # 同一リポジトリの PR と main への push: cpu-faer と（条件付きで）cpu-blas。
+  # Normally intended for a self-hosted runner; temporarily GitHub-hosted while
+  # that pool is down.
   ci-maintainer:
-    name: CI (same-repo PR / self-hosted heavy / ${{ matrix.backend }})
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    name: CI (same-repo / heavy / ${{ matrix.cfg.backend }})
+    needs: changes
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     # runs-on: [self-hosted, linux, x64]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - backend: cpu-faer
-            feature_args: ""
-            rustflags: ""
-          - backend: cpu-blas
-            feature_args: "--no-default-features --features cpu-blas"
-            rustflags: "-l dylib=openblas -l dylib=lapack"
+        cfg: ${{ fromJSON(needs.changes.outputs.backends) }}
     env:
-      CARGO_TARGET_DIR: ${{ github.workspace }}/../target-${{ matrix.backend }}
+      CARGO_TARGET_DIR: ${{ github.workspace }}/../target-${{ matrix.cfg.backend }}
       CARGO_PROFILE_RELEASE_DEBUG: 0
-      RUSTFLAGS: ${{ matrix.rustflags }}
+      RUSTFLAGS: ${{ matrix.cfg.rustflags }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -80,45 +124,72 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       # Note: Disable this step when runs-on is self-hosted.
       - name: Install BLAS/LAPACK runtime libraries
-        if: matrix.backend == 'cpu-blas'
+        if: matrix.cfg.backend == 'cpu-blas'
         run: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapack-dev
       - uses: taiki-e/install-action@nextest
       - name: Verify BLAS/LAPACK runtime libraries
-        if: matrix.backend == 'cpu-blas'
+        if: matrix.cfg.backend == 'cpu-blas'
         run: |
           set -euo pipefail
           ldconfig -p | grep -E 'libopenblas\.so' >/dev/null
           ldconfig -p | grep -E 'liblapack\.so' >/dev/null
       - name: Run unit and integration tests
-        # `tenferro-tutorial-code` is a workspace test package. Keep runnable
-        # tutorials in this command so CI reuses the unit-test target dir
-        # instead of recompiling tenferro in a separate tutorial job.
-        run: cargo nextest run --workspace --release ${{ matrix.feature_args }} --no-fail-fast
+        # `tenferro-tutorial-code` is a workspace test package, so the workspace
+        # nextest run already covers the runnable tutorials.
+        run: cargo nextest run --workspace --release ${{ matrix.cfg.feature_args }} --no-fail-fast
       - name: Run doc tests
-        run: cargo test --doc --workspace --release ${{ matrix.feature_args }}
-      - name: Compile-check KdV PINN sample
-        run: cargo check --manifest-path samples/kdv-pinn/Cargo.toml --release --all-targets
+        run: cargo test --doc --workspace --release ${{ matrix.cfg.feature_args }}
+
+  # Extension and sample tutorials. These are standalone workspaces (each has its
+  # own `[workspace]`) that depend on tenferro via path, so they recompile the
+  # tenferro graph from scratch. They are backend-agnostic (they use the default
+  # cpu-faer backend), so we run them once here rather than inside every backend
+  # leg of ci-maintainer. `rust-cache` is pointed at each standalone workspace so
+  # their target dirs are cached across runs.
+  ext-samples:
+    name: Extension and sample tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache extension/sample target dirs
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            ext/tropical
+            ext/sparse
+            samples/kdv-pinn
       - name: Run tropical extension tutorial tests
         run: cargo test --manifest-path ext/tropical/Cargo.toml --release --features autodiff
       - name: Run sparse extension tutorial tests
         run: cargo test --manifest-path ext/sparse/Cargo.toml --release --features autodiff
+      - name: Compile-check KdV PINN sample
+        run: cargo check --manifest-path samples/kdv-pinn/Cargo.toml --release --all-targets
 
-  # Single check for branch protection: passes when the one runnable path
-  # (fork = ci-fork, same-repo = ci-maintainer) succeeds; the other is skipped.
+  # Single check for branch protection. Requires the extension/sample tests plus
+  # the one runnable workspace path (fork = ci-fork, same-repo/push = ci-maintainer);
+  # the other is skipped. A cpu-blas leg that was intentionally not scheduled does
+  # not appear as a failure because ci-maintainer's matrix only contains the
+  # selected backends.
   ci-gate:
     name: CI gate (PR workspace tests)
-    needs: [ci-fork, ci-maintainer]
+    needs: [ci-fork, ci-maintainer, ext-samples]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Require fork or same-repo workspace CI
+      - name: Require workspace and extension tests
         env:
           FORK_RESULT: ${{ needs.ci-fork.result }}
           MAINTAINER_RESULT: ${{ needs.ci-maintainer.result }}
+          EXT_RESULT: ${{ needs.ext-samples.result }}
         run: |
           set -euo pipefail
-          if [ "$FORK_RESULT" = "success" ] || [ "$MAINTAINER_RESULT" = "success" ]; then
+          if [ "${EXT_RESULT}" != "success" ]; then
+            echo "Expected ext-samples to succeed; got ext-samples=${EXT_RESULT}"
+            exit 1
+          fi
+          if [ "${FORK_RESULT}" = "success" ] || [ "${MAINTAINER_RESULT}" = "success" ]; then
             exit 0
           fi
-          echo "Expected ci-fork or ci-maintainer to succeed; got ci-fork=$FORK_RESULT ci-maintainer=$MAINTAINER_RESULT"
+          echo "Expected ci-fork or ci-maintainer to succeed; got ci-fork=${FORK_RESULT} ci-maintainer=${MAINTAINER_RESULT}"
           exit 1

--- a/docs/worklogs/2026-07-04-ci-time-two-tier.md
+++ b/docs/worklogs/2026-07-04-ci-time-two-tier.md
@@ -1,0 +1,127 @@
+# CI Time Reduction: Two-Tier PR/main Workflow
+
+## Session Summary
+
+Reduced pull-request CI wall-clock time without increasing GPU-runner billing.
+The GPU runner was already gated behind the non-GPU checks, so the constraint
+"only use the GPU runner after other tests pass" was preserved throughout. The
+work restructures three areas:
+
+1. **Parallelize the CUDA test archive build.** `cuda-archive` runs on a cheap
+   non-GPU runner but was gated behind `pre-gpu-gate`, putting its ~9 min
+   compile serially on the critical path. It now builds in parallel with the
+   non-GPU CI. Only the expensive GPU runner (`cuda-run`) stays gated.
+2. **Two-tier workspace tests.** Pull requests run `cpu-faer` always and
+   `cpu-blas` only when backend-relevant paths change (dynamic matrix). Push to
+   `main` runs the full `cpu-faer` + `cpu-blas` matrix (comprehensive tier), so
+   every backend is exercised on the merged result.
+3. **Extract extension/sample tutorial tests into one job.** `tropical`,
+   `sparse`, and the KdV sample are standalone workspaces that recompile the
+   tenferro graph from scratch (~11 min combined). They previously ran inside
+   *both* backend legs of the matrix; they now run once in a dedicated
+   `ext-samples` job (backend-agnostic), with `rust-cache` pointed at their
+   target dirs.
+
+The GPU gate's prerequisite list was also trimmed from 8 checks to 5, keeping
+the checks that best predict a broken PR (fmt, clippy, coverage, the workspace
+test aggregate, repository policy) and dropping three that still block merge via
+branch protection but need not hold up the GPU runner (docs-site, blas inject,
+tensor core dependency boundary).
+
+## Context Read
+
+- `.github/workflows/{ci.yml,ci-pr-workspace-tests.yml,CI_gpu.yml,review_bot.yml}`.
+- `scripts/check-coverage.py` and `coverage-thresholds.json` (per-file absolute
+  thresholds, default 80, 32 overrides, 11 exclusions; supports `--report-only`).
+- Branch-protection required checks (via API): `rustfmt`, `coverage`,
+  `docs-site`, `cargo test (blas inject)`, `CI gate (PR workspace tests)`,
+  `CI GPU gate`.
+- Actual check-run names on a recent PR head (to confirm gate name matching and
+  that renamed matrix legs are not required checks).
+
+## Measured Baseline (single-run samples, not rigorous benchmarks)
+
+Per PR, the three workflows:
+
+| Workflow | Wall time | Notes |
+|---|---|---|
+| CI (`ci.yml`) | ~11 min | slowest job = coverage (11.4 min) |
+| CI PR workspace tests | ~25 min | cpu-faer / cpu-blas matrix (parallel) |
+| CI_gpu | ~39 min | **critical path** |
+
+CI_gpu breakdown (run 28688363421):
+
+```
+0..25min   pre-gpu-gate (waits for the non-GPU checks)
+25..34min  cuda-archive (9 min compile, cheap runner, serial after the gate)
+34..39min  cuda-run (5 min, ubuntu-gpu)
+39min      cuda-gate
+```
+
+Per-backend workspace-test breakdown: `nextest --workspace` ~12 min, tropical
+ext ~5.5 min, sparse ext ~5.3 min, doc/kdv/setup ~2 min. The ext tutorial steps
+used the same command in both legs (they ignore `matrix.feature_args`), so they
+were duplicated across backends and their target dirs were not covered by
+`rust-cache`.
+
+## Chosen Design
+
+- **`CI_gpu.yml`**: remove `needs: [pre-gpu-gate]` and the archive `if:` gate so
+  `cuda-archive` runs in parallel; `cuda-run` keeps `needs: [pre-gpu-gate,
+  cuda-archive]`. Trim `pre-gpu-gate.required` to `repository rules review`,
+  `rustfmt`, `clippy`, `coverage`, `CI gate (PR workspace tests)`.
+- **`ci-pr-workspace-tests.yml`**: add `push: [main]`; add a `changes` job that
+  emits the backend matrix as JSON (`[faer]` or `[faer, blas]`); `ci-maintainer`
+  consumes it via `fromJSON`; new `ext-samples` job; `ci-gate` now also requires
+  `ext-samples`. Concurrency group keyed per-PR for PRs, per-commit for pushes.
+
+Projected critical path after the change: `pre-gpu-gate` waits on
+`max(CI ~11, workspace ~14) ≈ 14 min` (cpu-blas usually skipped, ext extracted),
+archive is already built in parallel, `cuda-run` +5 min ⇒ **CI_gpu ≈ 20 min**
+(from ~39). Numbers are estimates pending post-merge confirmation.
+
+## Decisions And Rejected Alternatives
+
+Explicit maintainer decisions this session:
+
+- **Coverage stays a hard, blocking, per-PR check.** Rejected switching PRs to
+  `--report-only` (with strict enforcement moved to main) and rejected switching
+  to diff/patch coverage. Coverage friction is accepted as the cost of the
+  quality bar. Coverage is not the time bottleneck, so no coverage change was
+  needed for the time goal.
+- **Comprehensive tier lives on `push: main` only** (no nightly schedule).
+- **`cpu-blas` runs full when triggered**, not a backend-sensitive subset.
+  Rejected the subset because compile time dominates test-execution time in
+  these jobs, so subsetting saves little while adding a fragile "which tests are
+  backend-sensitive" boundary. The savings come from skipping the lane entirely
+  when no backend path changed.
+- **GPU gate keeps `coverage`** even though it is not the timing bottleneck,
+  because coverage fails frequently for this repo and gating on it avoids
+  spending GPU minutes on PRs that will fail coverage anyway.
+
+## Residual Risks
+
+- **Opt3 (ext target-dir caching) benefit is unconfirmed.** `rust-cache` may
+  clean the tenferro path-dependency artifacts from the standalone-workspace
+  caches; if so the ext build stays cold. Worst case is no speedup (harmless),
+  and wall-clock is already bounded by the cpu-faer leg. Confirm from CI timing.
+- **`main` may go red post-merge** if a merged change breaks the `cpu-blas` lane
+  that its PR skipped. This is the accepted trade-off of running the full matrix
+  only on `main` push. The full matrix still runs on any PR that touches backend
+  paths, so backend-affecting changes are caught pre-merge.
+- **Path-based `cpu-blas` selection** depends on the backend path list in the
+  `changes` job (tenferro-cpu, tenferro-linalg, tenferro-tensor,
+  tenferro-tensor-core, Cargo.lock/toml, the workflow file). If a future backend
+  crate is added, extend this list.
+- Renamed matrix leg check names (`CI (same-repo / heavy / …)`) are **not**
+  branch-protection required checks; only `CI gate (PR workspace tests)` and
+  `CI GPU gate` are, and both job names are preserved verbatim.
+
+## Verification
+
+- `actionlint 1.7.12` on both changed workflows: clean except the pre-existing
+  `ubuntu-gpu` custom self-hosted label warning (unchanged line, false positive).
+- Confirmed all 5 trimmed GPU-gate names and all 6 branch-protection required
+  check names still map to real reported checks.
+- Rust build/test/coverage/doc checklist items are N/A: this change touches only
+  `.github/workflows/` and this worklog, with no Rust source changes.

--- a/scripts/test-doc-consistency.py
+++ b/scripts/test-doc-consistency.py
@@ -104,8 +104,15 @@ def test_gpu_ci_waits_for_review_bot_gate_before_cuda_work() -> None:
     assert "repository rules review (LLM)" not in text
     assert text.index("pre-gpu-gate:") < text.index("cuda-archive:")
     assert text.index("pre-gpu-gate:") < text.index("runs-on: ubuntu-gpu")
-    assert "needs: [pre-gpu-gate]" in text
+    # The expensive GPU runner (cuda-run) stays gated behind the review +
+    # non-GPU checks: it needs both pre-gpu-gate and the archive.
     assert "needs: [pre-gpu-gate, cuda-archive]" in text
+    # The cheap non-GPU archive build must NOT be gated on pre-gpu-gate: it
+    # compiles in parallel with the non-GPU CI so the GPU stage can start the
+    # moment the gate clears. Guard against re-adding a bare `needs:
+    # [pre-gpu-gate]`, which would serialize the archive back onto the critical
+    # path (only cuda-run carries the gate).
+    assert "needs: [pre-gpu-gate]" not in text
 
 
 def test_pre_pr_checklist_requires_local_llm_review() -> None:


### PR DESCRIPTION
## Goal

Reduce pull-request CI wall-clock time **without increasing GPU-runner billing**. The expensive GPU runner (`ubuntu-gpu`) stays gated behind the non-GPU checks throughout — the "only use the GPU runner after other tests pass" constraint is preserved.

## Measured baseline (single-run samples)

| Workflow | Wall time |
|---|---|
| CI (`ci.yml`) | ~11 min |
| CI PR workspace tests | ~25 min |
| **CI_gpu** | **~39 min** (critical path) |

CI_gpu breakdown: `pre-gpu-gate` waits ~25 min → `cuda-archive` compiles ~9 min **serially after the gate** (on a cheap non-GPU runner) → `cuda-run` ~5 min on GPU. Within workspace tests, the `tropical`+`sparse` tutorial tests (~11 min) were duplicated across both backend legs and recompiled tenferro cold each run.

## Changes

**`CI_gpu.yml`**
- `cuda-archive` no longer `needs: [pre-gpu-gate]` — it builds in **parallel** with the non-GPU CI (cheap runner). `cuda-run` keeps `needs: [pre-gpu-gate, cuda-archive]`, so the GPU runner is still fully gated.
- `pre-gpu-gate` prerequisite list trimmed **8 → 5** (keep `rustfmt`, `clippy`, `coverage`, `CI gate (PR workspace tests)`, `repository rules review`). Dropped `docs-site` / `cargo test (blas inject)` / `tensor core dependency boundary` from the GPU gate only — they still block merge via branch protection.

**`ci-pr-workspace-tests.yml`** (now triggers on `pull_request` **and** `push: main`)
- Two-tier: PRs run **cpu-faer always**, **cpu-blas only when backend paths change** (dynamic matrix via a `changes` job + `fromJSON`). `push: main` runs the **full matrix** (comprehensive tier).
- New `ext-samples` job runs `tropical`/`sparse`/`kdv` **once** (backend-agnostic) with `rust-cache` on their standalone target dirs, instead of inside both backend legs.
- `ci-gate` (the required check) now also requires `ext-samples`.

## Projected result

`pre-gpu-gate` waits `max(CI ~11, workspace ~14) ≈ 14 min` (cpu-blas usually skipped, ext extracted), archive already built in parallel, `cuda-run` +5 ⇒ **CI_gpu ≈ 20 min** (from ~39). Estimates pending post-merge confirmation.

## Safety notes

- Branch-protection required checks (`rustfmt`, `coverage`, `docs-site`, `cargo test (blas inject)`, `CI gate (PR workspace tests)`, `CI GPU gate`) all still report; the required job names are preserved verbatim. Renamed matrix legs are **not** required checks.
- This PR edits `ci-pr-workspace-tests.yml` (a backend-path trigger), so its own CI exercises **both** backend legs live.
- Coverage stays a hard, blocking, per-PR check (maintainer decision). Comprehensive matrix lives on `push: main` only (no nightly). See the worklog for rejected alternatives and residual risks: `docs/worklogs/2026-07-04-ci-time-two-tier.md`.

Validated with `actionlint 1.7.12` (clean except the pre-existing `ubuntu-gpu` custom-label warning). No Rust source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)