### PR TITLE
CUDA dot-general accumulation over borrowed device views (#1287 stage 2)

### DIFF
--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -6,8 +6,10 @@ use num_complex::{Complex32, Complex64};
 use num_traits::{One, Zero};
 
 use super::dispatch::{
-    alloc_output, cube_count_for_len, cube_dim_1d, cubecl_buffer, dtype_mismatch,
-    ensure_resident_on_runtime, launch_nullary_into, typed_tensor_array_arg,
+    alloc_output, cube_count_for_len, cube_dim_1d, cubecl_buffer, cubecl_view_buffer,
+    cubecl_view_mut_buffer, dtype_mismatch, ensure_resident_on_runtime,
+    ensure_view_mut_resident_on_runtime, ensure_view_resident_on_runtime, launch_nullary_into,
+    typed_tensor_array_arg,
 };
 use super::ffi::cutensor::{
     CudaDataType, CutensorComputeDescriptor, CutensorCudaStream, CutensorHandle, CutensorOperator,
@@ -18,8 +20,11 @@ use super::memory::upload_tensor;
 use super::{CudaBackend, CudaRuntime};
 use crate::config::DotGeneralConfig;
 use crate::kernels::structural;
-use crate::{col_major_strides, Error, Tensor, TypedTensor};
-use tenferro_tensor::{ContractionScalar, DotGeneralAccumulation};
+use crate::{col_major_strides, CubeclBuffer, Error, Tensor, TypedTensor};
+use tenferro_tensor::{
+    ContractionScalar, DType, DotGeneralAccumulation, TensorRead, TensorView, TensorViewMut,
+    TensorWrite, TypedTensorView, TypedTensorViewMut,
+};
 
 const OP: &str = "dot_general";
 const CUDA_ALLOCATION_ALIGNMENT: u32 = 256;
@@ -35,6 +40,13 @@ trait CutensorScalar: CubeElement + CubePrimitive + Clone + One + Zero {
     fn wrap_tensor(tensor: TypedTensor<Self>) -> Tensor;
     fn unwrap_tensor(tensor: &Tensor) -> Option<&TypedTensor<Self>>;
 
+    /// Unwrap the matching dtype variant from dtype-erased borrowed views.
+    fn unwrap_view<'a, 'b>(view: &'a TensorView<'b>) -> Option<&'a TypedTensorView<'b, Self>>;
+    fn unwrap_view_mut<'a, 'b>(
+        view: &'a mut TensorViewMut<'b>,
+    ) -> Option<&'a mut TypedTensorViewMut<'b, Self>>;
+    fn unwrap_tensor_mut(tensor: &mut Tensor) -> Option<&mut TypedTensor<Self>>;
+
     /// Launch the in-place scale kernel for this scalar type.
     fn launch_scale_in_place(
         client: &cubecl::prelude::ComputeClient<CubeclCudaRuntime>,
@@ -45,7 +57,37 @@ trait CutensorScalar: CubeElement + CubePrimitive + Clone + One + Zero {
     );
 }
 
+/// Implement the dtype-erased variant accessors for one scalar type.
+macro_rules! cutensor_variant_accessors {
+    ($variant:ident) => {
+        fn unwrap_view<'a, 'b>(view: &'a TensorView<'b>) -> Option<&'a TypedTensorView<'b, Self>> {
+            match view {
+                TensorView::$variant(view) => Some(view),
+                _ => None,
+            }
+        }
+
+        fn unwrap_view_mut<'a, 'b>(
+            view: &'a mut TensorViewMut<'b>,
+        ) -> Option<&'a mut TypedTensorViewMut<'b, Self>> {
+            match view {
+                TensorViewMut::$variant(view) => Some(view),
+                _ => None,
+            }
+        }
+
+        fn unwrap_tensor_mut(tensor: &mut Tensor) -> Option<&mut TypedTensor<Self>> {
+            match tensor {
+                Tensor::$variant(tensor) => Some(tensor),
+                _ => None,
+            }
+        }
+    };
+}
+
 impl CutensorScalar for f32 {
+    cutensor_variant_accessors!(F32);
+
     const DATA_TYPE: CudaDataType = CudaDataType::R32F;
     const IS_COMPLEX: bool = false;
 
@@ -80,6 +122,8 @@ impl CutensorScalar for f32 {
 }
 
 impl CutensorScalar for f64 {
+    cutensor_variant_accessors!(F64);
+
     const DATA_TYPE: CudaDataType = CudaDataType::R64F;
     const IS_COMPLEX: bool = false;
 
@@ -114,6 +158,8 @@ impl CutensorScalar for f64 {
 }
 
 impl CutensorScalar for Complex32 {
+    cutensor_variant_accessors!(C32);
+
     const DATA_TYPE: CudaDataType = CudaDataType::C32F;
     const IS_COMPLEX: bool = true;
 
@@ -149,6 +195,8 @@ impl CutensorScalar for Complex32 {
 }
 
 impl CutensorScalar for Complex64 {
+    cutensor_variant_accessors!(C64);
+
     const DATA_TYPE: CudaDataType = CudaDataType::C64F;
     const IS_COMPLEX: bool = true;
 
@@ -293,96 +341,153 @@ impl_from_contraction_scalar!(f64, F64);
 impl_from_contraction_scalar!(Complex32, C32);
 impl_from_contraction_scalar!(Complex64, C64);
 
+/// Read-slot operand for the accumulate path: an owned compact tensor or a
+/// borrowed strided view over a device buffer.
+enum ReadOperand<'a, 'b, T> {
+    Owned(&'a TypedTensor<T>),
+    View(&'a TypedTensorView<'b, T>),
+}
+
+impl<T: 'static> ReadOperand<'_, '_, T> {
+    fn shape(&self) -> &[usize] {
+        match self {
+            Self::Owned(tensor) => tensor.shape(),
+            Self::View(view) => view.shape(),
+        }
+    }
+}
+
+/// Write-slot operand for the accumulate path.
+enum WriteOperand<'a, 'b, T> {
+    Owned(&'a mut TypedTensor<T>),
+    View(&'a mut TypedTensorViewMut<'b, T>),
+}
+
+impl<T: 'static> WriteOperand<'_, '_, T> {
+    fn shape(&self) -> &[usize] {
+        match self {
+            Self::Owned(tensor) => tensor.shape(),
+            Self::View(view) => view.shape(),
+        }
+    }
+
+    fn n_elements(&self) -> usize {
+        match self {
+            Self::Owned(tensor) => tensor.n_elements(),
+            Self::View(view) => view.n_elements(),
+        }
+    }
+}
+
+/// Device pointer plus cuTENSOR descriptor metadata for one operand.
+struct ResolvedOperand {
+    ptr: *mut c_void,
+    strides: Vec<i64>,
+    alignment: u32,
+}
+
+fn read_operand<'a, 'b, T: CutensorScalar>(
+    read: &'a TensorRead<'b>,
+) -> Option<ReadOperand<'a, 'b, T>> {
+    match read {
+        TensorRead::Tensor(tensor) => T::unwrap_tensor(tensor).map(ReadOperand::Owned),
+        TensorRead::View(view) => T::unwrap_view(view).map(ReadOperand::View),
+    }
+}
+
+fn write_operand<'a, 'b, T: CutensorScalar>(
+    write: &'a mut TensorWrite<'b>,
+) -> Option<WriteOperand<'a, 'b, T>> {
+    match write {
+        TensorWrite::Tensor(tensor) => T::unwrap_tensor_mut(tensor).map(WriteOperand::Owned),
+        TensorWrite::View(view) => T::unwrap_view_mut(view).map(WriteOperand::View),
+    }
+}
+
 /// CUDA-native accumulate-form contraction:
 /// `out = alpha * op(lhs) * op(rhs) + beta * out` executed by a single
 /// cuTENSOR contraction with `C = D = out` (no temporary result tensor).
 ///
-/// Stage-1 scope (tensor4all/tenferro-rs#1287): compact GPU-resident owned
-/// tensors on all three slots; anything else is an explicit error — no hidden
-/// host transfer and no silent fallback.
-pub(super) fn dot_general_with_conj_into_accum(
+/// Stage-2 scope (tensor4all/tenferro-rs#1287): every slot accepts either a
+/// compact GPU-resident owned tensor or a borrowed strided view over a
+/// GPU-resident device buffer. Host-backed views, negative view strides, and
+/// out-of-bounds regions are explicit errors — no hidden host transfer and no
+/// silent fallback.
+pub(super) fn dot_general_read_into_accum(
     backend: &CudaBackend,
-    lhs: &Tensor,
-    rhs: &Tensor,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
     config: &DotGeneralConfig,
     accumulation: DotGeneralAccumulation,
-    out: &mut Tensor,
+    out: &mut TensorWrite<'_>,
 ) -> crate::Result<()> {
-    match (lhs, rhs, out) {
-        (Tensor::F32(lhs), Tensor::F32(rhs), Tensor::F32(out)) => dot_general_typed_into_accum(
-            backend,
-            lhs,
-            rhs,
-            config,
-            accumulation.lhs_conj,
-            accumulation.rhs_conj,
-            f32::from_contraction_scalar(accumulation.alpha)?,
-            f32::from_contraction_scalar(accumulation.beta)?,
-            out,
-        ),
-        (Tensor::F64(lhs), Tensor::F64(rhs), Tensor::F64(out)) => dot_general_typed_into_accum(
-            backend,
-            lhs,
-            rhs,
-            config,
-            accumulation.lhs_conj,
-            accumulation.rhs_conj,
-            f64::from_contraction_scalar(accumulation.alpha)?,
-            f64::from_contraction_scalar(accumulation.beta)?,
-            out,
-        ),
-        (Tensor::C32(lhs), Tensor::C32(rhs), Tensor::C32(out)) => dot_general_typed_into_accum(
-            backend,
-            lhs,
-            rhs,
-            config,
-            accumulation.lhs_conj,
-            accumulation.rhs_conj,
-            Complex32::from_contraction_scalar(accumulation.alpha)?,
-            Complex32::from_contraction_scalar(accumulation.beta)?,
-            out,
-        ),
-        (Tensor::C64(lhs), Tensor::C64(rhs), Tensor::C64(out)) => dot_general_typed_into_accum(
-            backend,
-            lhs,
-            rhs,
-            config,
-            accumulation.lhs_conj,
-            accumulation.rhs_conj,
-            Complex64::from_contraction_scalar(accumulation.alpha)?,
-            Complex64::from_contraction_scalar(accumulation.beta)?,
-            out,
-        ),
-        (lhs, rhs, out) => {
-            if lhs.dtype() != rhs.dtype() || lhs.dtype() != out.dtype() {
-                return Err(dtype_mismatch(OP, lhs, rhs));
-            }
-            Err(Error::backend_failure(
-                OP,
-                "CUDA dot-general accumulation supports f32/f64/c32/c64 operands",
-            ))
-        }
+    match lhs.dtype() {
+        DType::F32 => accum_erased::<f32>(backend, lhs, rhs, config, accumulation, out),
+        DType::F64 => accum_erased::<f64>(backend, lhs, rhs, config, accumulation, out),
+        DType::C32 => accum_erased::<Complex32>(backend, lhs, rhs, config, accumulation, out),
+        DType::C64 => accum_erased::<Complex64>(backend, lhs, rhs, config, accumulation, out),
+        dtype => Err(Error::backend_failure(
+            OP,
+            format!(
+                "CUDA dot-general accumulation supports f32/f64/c32/c64 operands, got {dtype:?}"
+            ),
+        )),
     }
+}
+
+fn accum_erased<T>(
+    backend: &CudaBackend,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
+    config: &DotGeneralConfig,
+    accumulation: DotGeneralAccumulation,
+    out: &mut TensorWrite<'_>,
+) -> crate::Result<()>
+where
+    T: CutensorScalar + FromContractionScalar + PartialEq + tenferro_tensor::TensorScalar,
+{
+    let (lhs_dtype, rhs_dtype, out_dtype) = (lhs.dtype(), rhs.dtype(), out.dtype());
+    let (Some(lhs), Some(rhs), Some(out)) = (
+        read_operand::<T>(lhs),
+        read_operand::<T>(rhs),
+        write_operand::<T>(out),
+    ) else {
+        return Err(Error::backend_failure(
+            OP,
+            format!("dtype mismatch lhs={lhs_dtype:?} rhs={rhs_dtype:?} out={out_dtype:?}"),
+        ));
+    };
+    dot_general_typed_into_accum(
+        backend,
+        lhs,
+        rhs,
+        config,
+        accumulation.lhs_conj,
+        accumulation.rhs_conj,
+        T::from_contraction_scalar(accumulation.alpha)?,
+        T::from_contraction_scalar(accumulation.beta)?,
+        out,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
 fn dot_general_typed_into_accum<T>(
     backend: &CudaBackend,
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
+    lhs: ReadOperand<'_, '_, T>,
+    rhs: ReadOperand<'_, '_, T>,
     config: &DotGeneralConfig,
     lhs_conj: bool,
     rhs_conj: bool,
     alpha: T,
     beta: T,
-    out: &mut TypedTensor<T>,
+    mut out: WriteOperand<'_, '_, T>,
 ) -> crate::Result<()>
 where
     T: CutensorScalar + PartialEq + tenferro_tensor::TensorScalar,
 {
     backend.runtime().set_current_cuda_context(OP)?;
-    validate_dot_general(lhs, rhs, config)?;
-    let layout = build_layout(lhs, rhs, config)?;
+    validate_dot_general(lhs.shape(), rhs.shape(), config)?;
+    let layout = build_layout(lhs.shape(), rhs.shape(), config)?;
     if out.shape() != layout.output_shape.as_slice() {
         return Err(Error::ShapeMismatch {
             op: OP,
@@ -390,40 +495,58 @@ where
             rhs: layout.output_shape.clone(),
         });
     }
-    ensure_resident_on_runtime(backend.runtime(), lhs, OP)?;
-    ensure_resident_on_runtime(backend.runtime(), rhs, OP)?;
-    ensure_resident_on_runtime(backend.runtime(), out, OP)?;
+    // Residency, buffer-family, stride-sign, and bounds validation for all
+    // three slots happens here, before any degenerate-case early return.
+    let lhs_res = resolve_read_operand(backend.runtime(), &lhs, &layout.lhs_strides)?;
+    let rhs_res = resolve_read_operand(backend.runtime(), &rhs, &layout.rhs_strides)?;
+    let out_res = resolve_write_operand(backend.runtime(), &mut out, &layout.output_strides)?;
     if out.n_elements() == 0 {
         return Ok(());
     }
     if layout.contracting_elements == 0 {
         // The contraction sum is empty: out = beta * out.
-        return scale_in_place(backend.runtime(), out, beta);
+        return match out {
+            WriteOperand::Owned(tensor) => scale_in_place(backend.runtime(), tensor, beta),
+            WriteOperand::View(_) => {
+                if beta == T::one() {
+                    Ok(())
+                } else {
+                    // No strided in-place scale kernel exists yet; an explicit
+                    // error is required instead of a silent wrong result.
+                    Err(Error::backend_failure(
+                        OP,
+                        "zero-sized contraction with beta != 1 is not supported for \
+                         borrowed view outputs on CUDA; use an owned output tensor \
+                         or scale the region explicitly",
+                    ))
+                }
+            }
+        };
     }
 
     let cutensor = backend.cutensor_handle()?;
     let desc_a = TensorDescriptor::new(
         cutensor,
         &layout.lhs_extents,
-        &layout.lhs_strides,
+        &lhs_res.strides,
         T::DATA_TYPE,
-        CUDA_ALLOCATION_ALIGNMENT,
+        lhs_res.alignment,
         OP,
     )?;
     let desc_b = TensorDescriptor::new(
         cutensor,
         &layout.rhs_extents,
-        &layout.rhs_strides,
+        &rhs_res.strides,
         T::DATA_TYPE,
-        CUDA_ALLOCATION_ALIGNMENT,
+        rhs_res.alignment,
         OP,
     )?;
     let desc_out = TensorDescriptor::new(
         cutensor,
         &layout.output_extents,
-        &layout.output_strides,
+        &out_res.strides,
         T::DATA_TYPE,
-        CUDA_ALLOCATION_ALIGNMENT,
+        out_res.alignment,
         OP,
     )?;
     let op_desc = OperationDescriptor::new_contraction_with_ops(
@@ -451,22 +574,20 @@ where
     let plan = Plan::new(cutensor, &op_desc, &pref, workspace_size, OP)?;
     let workspace = alloc_workspace(backend.runtime(), workspace_size)?;
 
-    let lhs_ptr = typed_device_ptr(backend.runtime(), lhs)?;
-    let rhs_ptr = typed_device_ptr(backend.runtime(), rhs)?;
-    let out_ptr = typed_device_ptr(backend.runtime(), out)?;
-
     let stream = raw_stream(backend.runtime())?;
     // C = D = out: cuTENSOR reads the destination as the accumulator (skipped
     // by cuTENSOR itself when beta == 0) and writes the result in place.
+    // Overlap between the out region and the lhs/rhs regions is the caller's
+    // responsibility, as with BLAS-style in-place update APIs.
     unsafe {
         cutensor.contract(
             &plan,
             &alpha as *const T as *const c_void,
-            lhs_ptr as *const c_void,
-            rhs_ptr as *const c_void,
+            lhs_res.ptr as *const c_void,
+            rhs_res.ptr as *const c_void,
             &beta as *const T as *const c_void,
-            out_ptr as *const c_void,
-            out_ptr,
+            out_res.ptr as *const c_void,
+            out_res.ptr,
             workspace.ptr,
             workspace.size,
             stream,
@@ -474,6 +595,132 @@ where
         )?;
     }
     Ok(())
+}
+
+fn resolve_read_operand<T>(
+    rt: &CudaRuntime,
+    operand: &ReadOperand<'_, '_, T>,
+    compact_strides: &[i64],
+) -> crate::Result<ResolvedOperand>
+where
+    T: CutensorScalar + 'static,
+{
+    match operand {
+        ReadOperand::Owned(tensor) => Ok(ResolvedOperand {
+            ptr: typed_device_ptr(rt, tensor)?,
+            strides: compact_strides.to_vec(),
+            alignment: CUDA_ALLOCATION_ALIGNMENT,
+        }),
+        ReadOperand::View(view) => {
+            ensure_view_resident_on_runtime(rt, view, OP)?;
+            let buffer = cubecl_view_buffer(view, OP)?;
+            resolve_device_region(rt, buffer, view.shape(), view.strides(), view.offset())
+        }
+    }
+}
+
+fn resolve_write_operand<T>(
+    rt: &CudaRuntime,
+    operand: &mut WriteOperand<'_, '_, T>,
+    compact_strides: &[i64],
+) -> crate::Result<ResolvedOperand>
+where
+    T: CutensorScalar + 'static,
+{
+    match operand {
+        WriteOperand::Owned(tensor) => Ok(ResolvedOperand {
+            ptr: typed_device_ptr(rt, tensor)?,
+            strides: compact_strides.to_vec(),
+            alignment: CUDA_ALLOCATION_ALIGNMENT,
+        }),
+        WriteOperand::View(view) => {
+            ensure_view_mut_resident_on_runtime(rt, view, OP)?;
+            let buffer = cubecl_view_mut_buffer(view, OP)?;
+            resolve_device_region(rt, buffer, view.shape(), view.strides(), view.offset())
+        }
+    }
+}
+
+/// Resolve a strided view region over a device buffer into an effective
+/// cuTENSOR operand: `ptr = base + offset * size_of::<T>()`, the view's own
+/// element strides, and the alignment actually guaranteed by the effective
+/// byte address.
+fn resolve_device_region<T: 'static>(
+    rt: &CudaRuntime,
+    buffer: &CubeclBuffer<T>,
+    shape: &[usize],
+    strides: &[isize],
+    offset: isize,
+) -> crate::Result<ResolvedOperand> {
+    let mut strides_i64 = Vec::with_capacity(strides.len());
+    for &stride in strides {
+        if stride < 0 {
+            return Err(Error::backend_failure(
+                OP,
+                format!(
+                    "cuTENSOR dot-general accumulation requires nonnegative view \
+                     strides, got {strides:?}; canonicalize the view on device first"
+                ),
+            ));
+        }
+        strides_i64.push(stride as i64);
+    }
+    let offset = usize::try_from(offset).map_err(|_| {
+        Error::backend_failure(
+            OP,
+            format!(
+                "view offset {offset} must be nonnegative for cuTENSOR dot-general accumulation"
+            ),
+        )
+    })?;
+    // Reachable-span validation against the physical device buffer length.
+    if !shape.contains(&0) {
+        let mut max_offset = offset;
+        for (&dim, &stride) in shape.iter().zip(strides) {
+            max_offset = (dim - 1)
+                .checked_mul(stride as usize)
+                .and_then(|span| max_offset.checked_add(span))
+                .ok_or_else(|| Error::backend_failure(OP, "view element span overflows usize"))?;
+        }
+        if max_offset >= buffer.element_len() {
+            return Err(Error::backend_failure(
+                OP,
+                format!(
+                    "view region reaches element offset {max_offset} but the device \
+                     buffer holds only {} elements",
+                    buffer.element_len()
+                ),
+            ));
+        }
+    }
+    let resource = rt
+        .client()
+        .get_resource(buffer.handle().clone())
+        .map_err(|err| {
+            Error::backend_failure(OP, format!("failed to obtain CubeCL resource: {err:?}"))
+        })?;
+    let offset_bytes = (offset as u64)
+        .checked_mul(std::mem::size_of::<T>() as u64)
+        .ok_or_else(|| Error::backend_failure(OP, "view byte offset overflows u64"))?;
+    let addr = resource
+        .resource()
+        .ptr
+        .checked_add(offset_bytes)
+        .ok_or_else(|| Error::backend_failure(OP, "view device address overflows u64"))?;
+    Ok(ResolvedOperand {
+        ptr: cuda_device_ptr_from_addr(addr, OP)?,
+        strides: strides_i64,
+        alignment: address_alignment(addr),
+    })
+}
+
+/// Largest power of two dividing the byte address, capped at the CUDA
+/// allocation alignment cuTENSOR descriptors assume for whole allocations.
+fn address_alignment(addr: u64) -> u32 {
+    if addr == 0 {
+        return CUDA_ALLOCATION_ALIGNMENT;
+    }
+    1u32 << addr.trailing_zeros().min(8)
 }
 
 /// Device-side `out *= beta` for the degenerate zero-contraction case. The
@@ -542,8 +789,8 @@ where
     T: CutensorScalar,
 {
     backend.runtime().set_current_cuda_context(OP)?;
-    validate_dot_general(lhs, rhs, config)?;
-    let layout = build_layout(lhs, rhs, config)?;
+    validate_dot_general(lhs.shape(), rhs.shape(), config)?;
+    let layout = build_layout(lhs.shape(), rhs.shape(), config)?;
     let output = alloc_output::<T>(backend.runtime(), &layout.output_shape)?;
     if output.n_elements() == 0 {
         return Ok(output);
@@ -700,24 +947,24 @@ where
     Ok(output)
 }
 
-fn build_layout<T>(
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
+fn build_layout(
+    lhs_shape: &[usize],
+    rhs_shape: &[usize],
     config: &DotGeneralConfig,
 ) -> crate::Result<DotGeneralLayout> {
     let lhs_free = free_axes(
-        lhs.shape().len(),
+        lhs_shape.len(),
         &config.lhs_contracting_dims,
         &config.lhs_batch_dims,
     );
     let rhs_free = free_axes(
-        rhs.shape().len(),
+        rhs_shape.len(),
         &config.rhs_contracting_dims,
         &config.rhs_batch_dims,
     );
 
-    let mut lhs_modes = vec![-1i32; lhs.shape().len()];
-    let mut rhs_modes = vec![-1i32; rhs.shape().len()];
+    let mut lhs_modes = vec![-1i32; lhs_shape.len()];
+    let mut rhs_modes = vec![-1i32; rhs_shape.len()];
     let mut output_modes =
         Vec::with_capacity(lhs_free.len() + rhs_free.len() + config.lhs_batch_dims.len());
     let mut output_shape = Vec::with_capacity(output_modes.capacity());
@@ -736,12 +983,11 @@ fn build_layout<T>(
         lhs_modes[lhs_axis] = mode;
         rhs_modes[rhs_axis] = mode;
         contracting_elements = contracting_elements
-            .checked_mul(lhs.shape()[lhs_axis])
+            .checked_mul(lhs_shape[lhs_axis])
             .ok_or_else(|| Error::InvalidConfig {
                 op: OP,
                 message: format!(
-                    "contracting dimension product overflows usize for lhs shape {:?}",
-                    lhs.shape()
+                    "contracting dimension product overflows usize for lhs shape {lhs_shape:?}"
                 ),
             })?;
     }
@@ -752,7 +998,7 @@ fn build_layout<T>(
         lhs_modes[lhs_axis] = mode;
         rhs_modes[rhs_axis] = mode;
         batch_modes.push(mode);
-        batch_shape.push(lhs.shape()[lhs_axis]);
+        batch_shape.push(lhs_shape[lhs_axis]);
     }
 
     for &lhs_axis in &lhs_free {
@@ -760,7 +1006,7 @@ fn build_layout<T>(
         next_mode += 1;
         lhs_modes[lhs_axis] = mode;
         output_modes.push(mode);
-        output_shape.push(lhs.shape()[lhs_axis]);
+        output_shape.push(lhs_shape[lhs_axis]);
     }
 
     for &rhs_axis in &rhs_free {
@@ -768,17 +1014,17 @@ fn build_layout<T>(
         next_mode += 1;
         rhs_modes[rhs_axis] = mode;
         output_modes.push(mode);
-        output_shape.push(rhs.shape()[rhs_axis]);
+        output_shape.push(rhs_shape[rhs_axis]);
     }
 
     output_modes.extend_from_slice(&batch_modes);
     output_shape.extend_from_slice(&batch_shape);
 
-    let lhs_extents = dims_to_i64(lhs.shape())?;
-    let rhs_extents = dims_to_i64(rhs.shape())?;
+    let lhs_extents = dims_to_i64(lhs_shape)?;
+    let rhs_extents = dims_to_i64(rhs_shape)?;
     let output_extents = dims_to_i64(&output_shape)?;
-    let lhs_strides = strides_to_i64(&col_major_strides(lhs.shape())?)?;
-    let rhs_strides = strides_to_i64(&col_major_strides(rhs.shape())?)?;
+    let lhs_strides = strides_to_i64(&col_major_strides(lhs_shape)?)?;
+    let rhs_strides = strides_to_i64(&col_major_strides(rhs_shape)?)?;
     let output_strides = strides_to_i64(&col_major_strides(&output_shape)?)?;
 
     Ok(DotGeneralLayout {
@@ -864,9 +1110,9 @@ fn validate_role_disjoint(
     Ok(())
 }
 
-fn validate_dot_general<T>(
-    lhs: &TypedTensor<T>,
-    rhs: &TypedTensor<T>,
+fn validate_dot_general(
+    lhs_shape: &[usize],
+    rhs_shape: &[usize],
     config: &DotGeneralConfig,
 ) -> crate::Result<()> {
     if config.lhs_contracting_dims.len() != config.rhs_contracting_dims.len() {
@@ -882,8 +1128,8 @@ fn validate_dot_general<T>(
         });
     }
 
-    let lhs_rank = lhs.shape().len();
-    let rhs_rank = rhs.shape().len();
+    let lhs_rank = lhs_shape.len();
+    let rhs_rank = rhs_shape.len();
 
     validate_axis_list(
         OP,
@@ -919,26 +1165,24 @@ fn validate_dot_general<T>(
         .iter()
         .zip(&config.rhs_contracting_dims)
     {
-        if lhs.shape()[lhs_axis] != rhs.shape()[rhs_axis] {
+        if lhs_shape[lhs_axis] != rhs_shape[rhs_axis] {
             return Err(Error::InvalidConfig {
                 op: OP,
                 message: format!(
                     "contracting dim size mismatch: lhs axis {lhs_axis}={} rhs axis {rhs_axis}={}",
-                    lhs.shape()[lhs_axis],
-                    rhs.shape()[rhs_axis]
+                    lhs_shape[lhs_axis], rhs_shape[rhs_axis]
                 ),
             });
         }
     }
 
     for (&lhs_axis, &rhs_axis) in config.lhs_batch_dims.iter().zip(&config.rhs_batch_dims) {
-        if lhs.shape()[lhs_axis] != rhs.shape()[rhs_axis] {
+        if lhs_shape[lhs_axis] != rhs_shape[rhs_axis] {
             return Err(Error::InvalidConfig {
                 op: OP,
                 message: format!(
                     "batch dim size mismatch: lhs axis {lhs_axis}={} rhs axis {rhs_axis}={}",
-                    lhs.shape()[lhs_axis],
-                    rhs.shape()[rhs_axis]
+                    lhs_shape[lhs_axis], rhs_shape[rhs_axis]
                 ),
             });
         }

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -2331,9 +2331,9 @@ impl TensorDot for CudaBackend {
 
     // CUDA-native accumulation (tensor4all/tenferro-rs#1287): one cuTENSOR
     // contraction with C = D = out; no temporary result tensor, no host
-    // transfer. Stage 1 accepts compact owned tensors on all three slots;
-    // views are an explicit backend limitation until cuTENSOR
-    // extent/stride/offset view mapping lands.
+    // transfer. Stage 2 accepts compact owned tensors and borrowed strided
+    // views over device buffers on all three slots; host-backed views are an
+    // explicit backend error.
     fn dot_general_read_into_accum(
         &mut self,
         lhs: TensorRead<'_>,
@@ -2350,19 +2350,7 @@ impl TensorDot for CudaBackend {
             &out,
             "dot_general",
         )?;
-        let (TensorRead::Tensor(lhs), TensorRead::Tensor(rhs)) = (&lhs, &rhs) else {
-            return Err(crate::Error::backend_failure(
-                "dot_general",
-                "CUDA dot-general accumulation requires compact owned operand tensors; borrowed views are not yet supported",
-            ));
-        };
-        let TensorWrite::Tensor(out) = &mut out else {
-            return Err(crate::Error::backend_failure(
-                "dot_general",
-                "CUDA dot-general accumulation requires a compact owned output tensor; borrowed views are not yet supported",
-            ));
-        };
-        gemm::dot_general_with_conj_into_accum(self, lhs, rhs, config, accumulation, out)
+        gemm::dot_general_read_into_accum(self, &lhs, &rhs, config, accumulation, &mut out)
     }
 }
 

--- a/crates/tenferro-gpu/src/cubecl/tests/gemm_accum_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/gemm_accum_tests.rs
@@ -5,7 +5,8 @@ use num_complex::Complex64;
 use crate::DotGeneralConfig;
 use crate::Tensor;
 use tenferro_tensor::{
-    ContractionScalar, DotGeneralAccumulation, TensorDot, TensorRead, TensorWrite,
+    ContractionScalar, DotGeneralAccumulation, TensorDot, TensorRead, TensorView, TensorViewMut,
+    TensorWrite, TypedTensorView,
 };
 
 use super::{
@@ -171,8 +172,8 @@ fn test_accum_dtype_mismatch_rejected() {
 #[test]
 #[ignore]
 fn test_accum_view_output_is_explicit_error() {
-    // Stage 1 supports compact owned tensors only; a borrowed view output
-    // must produce an explicit backend error, never a silent fallback.
+    // A borrowed view output over HOST memory must produce an explicit
+    // backend error, never a silent fallback or hidden upload.
     let mut gpu = gpu_backend();
     let lhs = upload(&gpu, &tensor_f64(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
     let rhs = upload(&gpu, &tensor_f64(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
@@ -233,4 +234,311 @@ fn test_accum_zero_contraction_rejects_cpu_tensors() {
         TensorWrite::from_tensor(&mut cpu_out),
     );
     assert!(result.is_err(), "CPU output must be rejected");
+}
+
+// --- Stage 2 (tensor4all/tenferro-rs#1287): borrowed views over device
+// buffers on all three slots. Region layout metadata comes from
+// `TypedTensor::backend_region_view{,_mut}`.
+
+/// Read an element of a strided f64 region embedded in a flat host vector.
+fn region_get(flat: &[f64], offset: usize, strides: &[usize], indices: &[usize]) -> f64 {
+    let linear = offset
+        + indices
+            .iter()
+            .zip(strides)
+            .map(|(&index, &stride)| index * stride)
+            .sum::<usize>();
+    flat[linear]
+}
+
+/// Host reference for `out = alpha * lhs * rhs + beta * out` on strided
+/// matrix regions of flat col-major buffers; updates `out_flat` in place.
+#[allow(clippy::too_many_arguments)]
+fn host_region_gemm_accum(
+    lhs_flat: &[f64],
+    lhs_off: usize,
+    lhs_strides: &[usize],
+    rhs_flat: &[f64],
+    rhs_off: usize,
+    rhs_strides: &[usize],
+    out_flat: &mut [f64],
+    out_off: usize,
+    out_strides: &[usize],
+    (rows, k, cols): (usize, usize, usize),
+    alpha: f64,
+    beta: f64,
+) {
+    for row in 0..rows {
+        for col in 0..cols {
+            let mut acc = 0.0;
+            for inner in 0..k {
+                acc += region_get(lhs_flat, lhs_off, lhs_strides, &[row, inner])
+                    * region_get(rhs_flat, rhs_off, rhs_strides, &[inner, col]);
+            }
+            let linear = out_off + row * out_strides[0] + col * out_strides[1];
+            out_flat[linear] = alpha * acc + beta * out_flat[linear];
+        }
+    }
+}
+
+fn flat_f64(len: usize, seed: f64) -> Vec<f64> {
+    (0..len).map(|i| seed + 0.25 * i as f64).collect()
+}
+
+fn download_f64(gpu: &crate::cubecl::CudaBackend, tensor: &Tensor) -> Vec<f64> {
+    match download(gpu, tensor) {
+        Tensor::F64(host) => host.as_slice().unwrap().to_vec(),
+        other => panic!("expected f64 tensor, got {:?}", other.dtype()),
+    }
+}
+
+#[test]
+#[ignore]
+fn test_accum_view_operands_offset_regions_f64() {
+    // lhs: [2,3] region at offset 5 with leading dimension 4 in a flat len-32
+    // device buffer; rhs: [3,2] region at offset 7, ld 3 (contiguous);
+    // out: [2,2] region at offset 3, ld 4, in a flat len-20 device buffer.
+    let mut gpu = gpu_backend();
+    let lhs_host = flat_f64(32, -3.0);
+    let rhs_host = flat_f64(32, 1.5);
+    let out_host = flat_f64(20, -0.5);
+    let (alpha, beta) = (2.0, -0.5);
+
+    let mut expected = out_host.clone();
+    host_region_gemm_accum(
+        &lhs_host,
+        5,
+        &[1, 4],
+        &rhs_host,
+        7,
+        &[1, 3],
+        &mut expected,
+        3,
+        &[1, 4],
+        (2, 3, 2),
+        alpha,
+        beta,
+    );
+
+    let lhs_gpu = upload(&gpu, &tensor_f64(vec![32], lhs_host));
+    let rhs_gpu = upload(&gpu, &tensor_f64(vec![32], rhs_host));
+    let mut out_gpu = upload(&gpu, &tensor_f64(vec![20], out_host));
+    let (Tensor::F64(lhs_t), Tensor::F64(rhs_t)) = (&lhs_gpu, &rhs_gpu) else {
+        unreachable!()
+    };
+    let Tensor::F64(out_t) = &mut out_gpu else {
+        unreachable!()
+    };
+    let lhs_view = lhs_t
+        .backend_region_view(vec![2, 3], vec![1, 4], 5)
+        .unwrap();
+    let rhs_view = rhs_t
+        .backend_region_view(vec![3, 2], vec![1, 3], 7)
+        .unwrap();
+    let out_view = out_t
+        .backend_region_view_mut(vec![2, 2], vec![1, 4], 3)
+        .unwrap();
+    gpu.dot_general_read_into_accum(
+        TensorRead::from_view(TensorView::F64(lhs_view)),
+        TensorRead::from_view(TensorView::F64(rhs_view)),
+        &matmul_config(),
+        DotGeneralAccumulation {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::F64(alpha),
+            beta: ContractionScalar::F64(beta),
+        },
+        TensorWrite::from_view(TensorViewMut::F64(out_view)),
+    )
+    .unwrap();
+
+    // The updated region matches the host reference and every element outside
+    // the region is preserved bit-for-bit.
+    let actual = download_f64(&gpu, &out_gpu);
+    for (index, (actual, expected)) in actual.iter().zip(&expected).enumerate() {
+        assert!(
+            (actual - expected).abs() < 1e-10,
+            "flat index {index}: {actual} != {expected}"
+        );
+    }
+}
+
+#[test]
+#[ignore]
+fn test_accum_block_diagonal_regions_of_one_buffer_f64() {
+    // Two successive accumulations into disjoint diagonal blocks of ONE flat
+    // device buffer holding a col-major [4,4] matrix; off-block elements and
+    // the beta-scaled block contents must both be exact.
+    let mut gpu = gpu_backend();
+    let out_host = flat_f64(16, 10.0);
+    let lhs_a = flat_f64(4, -1.0);
+    let rhs_a = flat_f64(4, 0.5);
+    let lhs_b = flat_f64(4, 2.0);
+    let rhs_b = flat_f64(4, -0.75);
+    let (alpha, beta) = (1.5, 1.0);
+
+    let mut expected = out_host.clone();
+    // Block (0..2)x(0..2): offset 0. Block (2..4)x(2..4): offset 2 + 2*4 = 10.
+    host_region_gemm_accum(
+        &lhs_a,
+        0,
+        &[1, 2],
+        &rhs_a,
+        0,
+        &[1, 2],
+        &mut expected,
+        0,
+        &[1, 4],
+        (2, 2, 2),
+        alpha,
+        beta,
+    );
+    host_region_gemm_accum(
+        &lhs_b,
+        0,
+        &[1, 2],
+        &rhs_b,
+        0,
+        &[1, 2],
+        &mut expected,
+        10,
+        &[1, 4],
+        (2, 2, 2),
+        alpha,
+        beta,
+    );
+
+    let lhs_a_gpu = upload(&gpu, &tensor_f64(vec![2, 2], lhs_a));
+    let rhs_a_gpu = upload(&gpu, &tensor_f64(vec![2, 2], rhs_a));
+    let lhs_b_gpu = upload(&gpu, &tensor_f64(vec![2, 2], lhs_b));
+    let rhs_b_gpu = upload(&gpu, &tensor_f64(vec![2, 2], rhs_b));
+    let mut out_gpu = upload(&gpu, &tensor_f64(vec![16], out_host));
+
+    for (lhs, rhs, offset) in [(&lhs_a_gpu, &rhs_a_gpu, 0), (&lhs_b_gpu, &rhs_b_gpu, 10)] {
+        let Tensor::F64(out_t) = &mut out_gpu else {
+            unreachable!()
+        };
+        let out_view = out_t
+            .backend_region_view_mut(vec![2, 2], vec![1, 4], offset)
+            .unwrap();
+        gpu.dot_general_read_into_accum(
+            TensorRead::from_tensor(lhs),
+            TensorRead::from_tensor(rhs),
+            &matmul_config(),
+            DotGeneralAccumulation {
+                lhs_conj: false,
+                rhs_conj: false,
+                alpha: ContractionScalar::F64(alpha),
+                beta: ContractionScalar::F64(beta),
+            },
+            TensorWrite::from_view(TensorViewMut::F64(out_view)),
+        )
+        .unwrap();
+    }
+
+    let actual = download_f64(&gpu, &out_gpu);
+    for (index, (actual, expected)) in actual.iter().zip(&expected).enumerate() {
+        assert!(
+            (actual - expected).abs() < 1e-10,
+            "flat index {index}: {actual} != {expected}"
+        );
+    }
+}
+
+#[test]
+#[ignore]
+fn test_accum_host_view_operand_rejected() {
+    // A borrowed view over HOST memory must be an explicit backend error on
+    // the CUDA accumulation path (no hidden upload).
+    let mut gpu = gpu_backend();
+    let lhs_host = [1.0_f64, 2.0, 3.0, 4.0];
+    let lhs_view = TypedTensorView::from_col_major(&[2, 2], &lhs_host).unwrap();
+    let rhs = upload(&gpu, &tensor_f64(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
+    let mut out = upload(&gpu, &tensor_f64(vec![2, 2], vec![0.0; 4]));
+    let result = gpu.dot_general_read_into_accum(
+        TensorRead::from_view(TensorView::F64(lhs_view)),
+        TensorRead::from_tensor(&rhs),
+        &matmul_config(),
+        DotGeneralAccumulation {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::F64(1.0),
+            beta: ContractionScalar::F64(0.0),
+        },
+        TensorWrite::from_tensor(&mut out),
+    );
+    assert!(result.is_err(), "host view operand must be rejected");
+}
+
+#[test]
+#[ignore]
+fn test_accum_negative_stride_view_rejected() {
+    // Reversed device regions are valid tensor views but outside the cuTENSOR
+    // nonnegative-stride contract: explicit error, no silent canonicalization.
+    let mut gpu = gpu_backend();
+    let lhs_gpu = upload(&gpu, &tensor_f64(vec![8], flat_f64(8, 0.0)));
+    let Tensor::F64(lhs_t) = &lhs_gpu else {
+        unreachable!()
+    };
+    let lhs_view = lhs_t
+        .backend_region_view(vec![2, 2], vec![1, -2], 2)
+        .unwrap();
+    let rhs = upload(&gpu, &tensor_f64(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]));
+    let mut out = upload(&gpu, &tensor_f64(vec![2, 2], vec![0.0; 4]));
+    let result = gpu.dot_general_read_into_accum(
+        TensorRead::from_view(TensorView::F64(lhs_view)),
+        TensorRead::from_tensor(&rhs),
+        &matmul_config(),
+        DotGeneralAccumulation {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::F64(1.0),
+            beta: ContractionScalar::F64(0.0),
+        },
+        TensorWrite::from_tensor(&mut out),
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("stride"),
+        "negative view stride must be an explicit stride error, got: {err}"
+    );
+}
+
+#[test]
+#[ignore]
+fn test_accum_zero_contraction_view_output_beta_error() {
+    // k = 0 with a view output: beta == 1 is a validated no-op; any other
+    // beta needs a strided scale kernel that does not exist yet, so it must
+    // be an explicit error (documented stage-2 limitation).
+    let mut gpu = gpu_backend();
+    let lhs = upload(&gpu, &tensor_f64(vec![2, 0], vec![]));
+    let rhs = upload(&gpu, &tensor_f64(vec![0, 2], vec![]));
+    let out_host = flat_f64(8, 1.0);
+    let mut out_gpu = upload(&gpu, &tensor_f64(vec![8], out_host.clone()));
+
+    for (beta, expect_ok) in [(1.0, true), (-2.0, false)] {
+        let Tensor::F64(out_t) = &mut out_gpu else {
+            unreachable!()
+        };
+        let out_view = out_t
+            .backend_region_view_mut(vec![2, 2], vec![1, 4], 1)
+            .unwrap();
+        let result = gpu.dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &matmul_config(),
+            DotGeneralAccumulation {
+                lhs_conj: false,
+                rhs_conj: false,
+                alpha: ContractionScalar::F64(1.0),
+                beta: ContractionScalar::F64(beta),
+            },
+            TensorWrite::from_view(TensorViewMut::F64(out_view)),
+        );
+        assert_eq!(result.is_ok(), expect_ok, "beta = {beta}: {result:?}");
+    }
+
+    // Both calls must leave the buffer untouched (no-op or rejected).
+    let actual = download_f64(&gpu, &out_gpu);
+    assert_eq!(actual, out_host);
 }

--- a/crates/tenferro-gpu/tests/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/public_surface_contract.rs
@@ -279,11 +279,11 @@ fn cubecl_structural_shape_arithmetic_is_checked() {
 fn cubecl_gemm_contracting_element_product_is_checked() {
     let gemm = repo_file("crates/tenferro-gpu/src/cubecl/gemm.rs");
     assert!(
-        gemm.contains("checked_mul(lhs.shape()[lhs_axis])"),
+        gemm.contains("checked_mul(lhs_shape[lhs_axis])"),
         "CubeCL GEMM must reject contracting dimension product overflow"
     );
     assert!(
-        !gemm.contains("contracting_elements *= lhs.shape()[lhs_axis];"),
+        !gemm.contains("contracting_elements *= lhs_shape[lhs_axis];"),
         "CubeCL GEMM must not use unchecked contracting dimension multiplication"
     );
 }

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -2064,3 +2064,90 @@ fn n_elements_invariant_checks_do_not_use_unsafe_unreachable() {
         "n_elements panic path should document the constructor-validation invariant"
     );
 }
+
+fn backend_tensor_f64(id: u64, len: usize) -> TypedTensor<f64> {
+    TypedTensor::<f64>::from_buffer_col_major(
+        vec![len],
+        Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(id, len))),
+        Placement {
+            memory_kind: MemoryKind::Device,
+            device: Some(DeviceId {
+                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+                ordinal: 0,
+            }),
+        },
+    )
+    .unwrap()
+}
+
+#[test]
+fn backend_region_view_exposes_layout_and_shared_buffer() {
+    let tensor = backend_tensor_f64(90, 16);
+    let view = tensor
+        .backend_region_view(vec![2, 3], vec![1, 4], 5)
+        .unwrap();
+
+    assert_eq!(view.shape(), &[2, 3]);
+    assert_eq!(view.strides(), &[1, 4]);
+    assert_eq!(view.offset(), 5);
+    assert_eq!(view.placement(), tensor.placement());
+    let buffer = view.backend_buffer().expect("backend buffer");
+    assert_eq!(buffer.len(), 16);
+}
+
+#[test]
+fn backend_region_view_mut_exposes_layout_and_shared_buffer() {
+    let mut tensor = backend_tensor_f64(91, 16);
+    let placement = tensor.placement().clone();
+    let view = tensor
+        .backend_region_view_mut(vec![2, 2], vec![1, 4], 10)
+        .unwrap();
+
+    assert_eq!(view.shape(), &[2, 2]);
+    assert_eq!(view.strides(), &[1, 4]);
+    assert_eq!(view.offset(), 10);
+    assert_eq!(view.placement(), &placement);
+    let buffer = view.backend_buffer().expect("backend buffer");
+    assert_eq!(buffer.len(), 16);
+}
+
+#[test]
+fn backend_region_view_rejects_host_buffer() {
+    let tensor = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![0.0; 4]).unwrap();
+    let err = tensor
+        .backend_region_view(vec![2, 2], vec![1, 2], 0)
+        .unwrap_err();
+    assert!(err.to_string().contains("backend"));
+
+    let mut tensor = tensor;
+    let err = tensor
+        .backend_region_view_mut(vec![2, 2], vec![1, 2], 0)
+        .unwrap_err();
+    assert!(err.to_string().contains("backend"));
+}
+
+#[test]
+fn backend_region_view_rejects_out_of_bounds_span() {
+    let tensor = backend_tensor_f64(92, 8);
+    // Max reachable element offset 7 + 1*1 + 4*1 = 12 exceeds len 8.
+    assert!(tensor
+        .backend_region_view(vec![2, 2], vec![1, 4], 7)
+        .is_err());
+    let mut tensor = tensor;
+    assert!(tensor
+        .backend_region_view_mut(vec![2, 2], vec![1, 4], 7)
+        .is_err());
+}
+
+#[test]
+fn backend_region_view_mut_rejects_aliasing_layout() {
+    let mut tensor = backend_tensor_f64(93, 8);
+    // Zero stride on a non-singleton axis aliases physical elements.
+    assert!(tensor
+        .backend_region_view_mut(vec![2, 2], vec![0, 1], 0)
+        .is_err());
+    // The read-only variant accepts the same broadcast-style layout.
+    assert!(tensor
+        .backend_region_view(vec![2, 2], vec![0, 1], 0)
+        .is_ok());
+}

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -4330,6 +4330,106 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
         }
     }
 
+    /// Borrow a read-only strided region view over this tensor's backend
+    /// (device) buffer from explicit layout metadata.
+    ///
+    /// This is a metadata-only view: no data is copied or transferred. The
+    /// layout's reachable element span is validated against the backend
+    /// buffer's physical length. Host-backed tensors are rejected with an
+    /// explicit backend error; host regions are expressed with
+    /// [`TypedTensorView::from_slice`] over host storage instead.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// // Host tensors are rejected: this constructor is for backend buffers.
+    /// let host = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![0.0; 4]).unwrap();
+    /// let err = host.backend_region_view(vec![2, 2], vec![1, 2], 0).unwrap_err();
+    /// assert!(err.to_string().contains("backend"));
+    /// ```
+    pub fn backend_region_view(
+        &self,
+        shape: Vec<usize>,
+        strides: Vec<isize>,
+        offset: isize,
+    ) -> crate::Result<TypedTensorView<'_, T, DynRank>>
+    where
+        T: 'static,
+    {
+        let op = "TypedTensor::backend_region_view";
+        let Buffer::Backend(buffer) = &self.buffer else {
+            return Err(crate::Error::backend_failure(
+                op,
+                "expected a backend (device) buffer; host tensors use \
+                 TypedTensorView::from_slice over host storage",
+            ));
+        };
+        let layout = TensorLayout::from_parts(shape.into(), strides.into(), offset, buffer.len())
+            .map_err(|err| tensor_layout_error(op, err))?;
+        Ok(TypedTensorView {
+            buffer: TensorBufferRef::Backend(Arc::clone(buffer)),
+            layout,
+            placement: self.placement.clone(),
+        })
+    }
+
+    /// Borrow a mutable strided region view over this tensor's backend
+    /// (device) buffer from explicit layout metadata.
+    ///
+    /// This is the mutable counterpart of
+    /// [`TypedTensor::backend_region_view`]. The layout's reachable element
+    /// span is validated against the backend buffer's physical length, and
+    /// layouts whose logical elements alias the same physical element are
+    /// rejected. Host-backed tensors are rejected with an explicit backend
+    /// error; mutable host regions must go through
+    /// [`TypedTensorViewMut::try_multi_slice_mut`] or host constructors.
+    ///
+    /// Backend buffers are shared handles, so distinct region views over one
+    /// buffer can coexist; disjointness between regions used concurrently by
+    /// backend operations is the caller's contract (as with BLAS-style
+    /// in-place update APIs).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// // Host tensors are rejected: this constructor is for backend buffers.
+    /// let mut host = TypedTensor::<f64>::from_vec_col_major(vec![4], vec![0.0; 4]).unwrap();
+    /// let err = host.backend_region_view_mut(vec![2, 2], vec![1, 2], 0).unwrap_err();
+    /// assert!(err.to_string().contains("backend"));
+    /// ```
+    pub fn backend_region_view_mut(
+        &mut self,
+        shape: Vec<usize>,
+        strides: Vec<isize>,
+        offset: isize,
+    ) -> crate::Result<TypedTensorViewMut<'_, T, DynRank>>
+    where
+        T: 'static,
+    {
+        let op = "TypedTensor::backend_region_view_mut";
+        let Buffer::Backend(buffer) = &self.buffer else {
+            return Err(crate::Error::backend_failure(
+                op,
+                "expected a backend (device) buffer; mutable host regions use \
+                 TypedTensorViewMut host constructors or try_multi_slice_mut",
+            ));
+        };
+        let layout = TensorLayout::from_parts(shape.into(), strides.into(), offset, buffer.len())
+            .map_err(|err| tensor_layout_error(op, err))?;
+        layout
+            .validate_mutable_no_overlap()
+            .map_err(|err| tensor_layout_error(op, err))?;
+        Ok(TypedTensorViewMut {
+            buffer: TensorBufferRefMut::Backend(Arc::clone(buffer)),
+            layout,
+            placement: self.placement.clone(),
+        })
+    }
+
     /// Consume this tensor and return its layout metadata.
     ///
     /// # Examples

--- a/docs/worklogs/2026-07-04-issue-1287-stage2-view-operands.md
+++ b/docs/worklogs/2026-07-04-issue-1287-stage2-view-operands.md
@@ -1,0 +1,125 @@
+# Issue 1287 Stage 2: CUDA Dot-General Accumulation Over Borrowed Views
+
+## Session Summary
+
+Extended `CudaBackend::dot_general_read_into_accum` (stage 1, #1289) to accept
+borrowed strided views (`TensorRead::View` / `TensorWrite::View`) over
+GPU-resident device buffers on all three slots. A view contributes its own
+shape / strides / element offset to the cuTENSOR descriptors; the effective
+device pointer is `base + offset * size_of::<T>()`, and the descriptor
+alignment is the alignment actually guaranteed by that byte address. Added the
+missing public constructors `TypedTensor::backend_region_view` /
+`backend_region_view_mut` in `tenferro-tensor` so callers can express matrix
+regions of a flat device buffer at all (previously no public API could build a
+mutable sub-region view over a backend buffer).
+
+## Context Read
+
+- Issue #1287 staged plan and the stage-1 work log
+  (`2026-07-04-issue-1287-cuda-dot-accum.md`); stage-1 code in
+  `crates/tenferro-gpu/src/cubecl/{mod.rs,gemm.rs}` and its ignored CUDA tests
+  (`cubecl/tests/gemm_accum_tests.rs`).
+- View data model in `crates/tenferro-tensor/src/types.rs`:
+  `TypedTensorView{,Mut}` = `TensorBufferRef{,Mut}` (Host slice | shared
+  `Arc<dyn BackendBuffer<T>>`) + `TensorLayout` (shape, isize strides, element
+  offset) + `Placement`; `TensorLayout::from_parts` already proves the
+  reachable span fits the backing buffer, and `validate_mutable_no_overlap`
+  rejects self-aliasing mutable layouts.
+- Existing view plumbing in `cubecl/dispatch.rs`
+  (`cubecl_view_buffer`, `cubecl_view_mut_buffer`,
+  `ensure_view{, _mut}_resident_on_runtime`) as the residency/downcast
+  precedent, and `REPOSITORY_RULES.md` device-transfer, backend-buffer error,
+  and negative-stride policy sections.
+
+## Decisions Made
+
+- **One generalized typed path**: `dot_general_typed_into_accum` now consumes
+  `ReadOperand` / `WriteOperand` (owned compact tensor | borrowed view) and a
+  per-operand `ResolvedOperand { ptr, strides, alignment }`. Owned operands
+  keep the stage-1 behavior exactly (compact col-major strides, base pointer,
+  256-byte descriptor alignment). The overwrite (non-accum) path is untouched.
+- **Erased dispatch via variant accessors**: `CutensorScalar` gained
+  `unwrap_view` / `unwrap_view_mut` / `unwrap_tensor_mut` (macro-implemented
+  per dtype), so the `TensorRead`/`TensorWrite` enums dispatch through one
+  generic `accum_erased::<T>` for f32/f64/c32/c64 instead of a 4x(2x2x2)
+  match. Everything stays private to the `cubecl` module.
+- **View constraints as explicit typed errors** (no silent fallback,
+  validated before any degenerate-case early return):
+  - host-backed views: explicit backend error via the existing
+    `cubecl_view{_mut}_buffer` diagnostics (no hidden upload);
+  - negative view strides: explicit error naming the cuTENSOR nonnegative
+    stride contract (repo policy allows narrower adapter limits when stated
+    at the boundary); zero strides on read views are passed through;
+  - offset/extent bounds: defensive re-check that
+    `offset + sum((dim-1)*stride)` fits the physical device buffer length,
+    with overflow-checked arithmetic.
+- **Per-descriptor alignment**: view descriptors pass the largest power of
+  two dividing the effective byte address, capped at 256
+  (`address_alignment`). Owned operands keep the stage-1 constant 256 rather
+  than churning behavior.
+- **New public region-view constructors** (`tenferro-tensor`):
+  `TypedTensor::backend_region_view{,_mut}(shape, strides, offset)` build
+  metadata-only views over the tensor's `Buffer::Backend` handle, reusing
+  `TensorLayout::from_parts` bounds validation plus
+  `validate_mutable_no_overlap` for the mutable variant; host buffers are
+  rejected with explicit errors (host users keep the existing host
+  constructors and `try_multi_slice_mut`). Backend buffers are `Arc`-shared,
+  so distinct mutable regions can coexist; disjointness of regions used
+  concurrently is the caller's contract, as with BLAS-style in-place APIs.
+  This was required because no public API could construct a mutable
+  sub-region view over a device buffer (host-only constructors, and
+  `try_multi_slice_mut` returns `Ok(None)` for backend buffers).
+- **Zero-sized contraction with a view output** (`out = beta * out`):
+  `beta == 1` is a validated no-op; any other beta returns an explicit
+  backend error because no strided in-place scale kernel exists yet. Owned
+  outputs keep the stage-1 fill/scale kernels. This corner is unreachable for
+  the intended matrix-region accumulation use.
+- **Overlap semantics**: `C = D = out` unchanged; overlap between the out
+  region and lhs/rhs regions is the caller's responsibility (BLAS
+  convention), noted at the contraction call site.
+
+## Rejected Alternatives
+
+- Canonicalizing negative-stride or host views on the fly: hidden
+  materialization/upload violates the device-transfer contract; explicit
+  errors keep the caller in control.
+- Computing descriptor alignment from the actual address for owned operands
+  too: strictly more precise, but changes stage-1 descriptor inputs for no
+  functional gain; left as-is to keep the stage-1 surface stable.
+- Expressing the view-output `beta * out` degenerate case as a dummy
+  cuTENSOR contraction or a fresh strided scale kernel: out of scope for the
+  unreachable corner; documented limitation instead.
+- Adding dtype-erased `Tensor::backend_region_view` wrappers: not needed by
+  the backend path or tests; the typed constructors plus the existing
+  `TensorView::F64(...)`-style wrapping suffice.
+
+## Verification
+
+- `cargo check -p tenferro-gpu` and `cargo check -p tenferro-gpu --features
+  cuda` clean on the macOS dev host; `cargo test -p tenferro-gpu --features
+  cuda --no-run` builds the CUDA test binaries.
+- `cargo fmt --all` and CI-parity `cargo clippy --workspace --all-targets --
+  -D warnings` clean; full `cargo test --workspace --release` green,
+  including the new `backend_region_view` doctests and unit tests
+  (layout/buffer sharing, host rejection, out-of-bounds span rejection,
+  mutable aliasing rejection).
+- New ignored CUDA tests in `cubecl/tests/gemm_accum_tests.rs`: offset
+  strided regions on all three slots vs a host reference with untouched
+  elements preserved bit-for-bit, two disjoint diagonal blocks of one flat
+  buffer updated by successive calls, host-view operand rejection,
+  negative-stride rejection, and the zero-contraction view-output beta
+  contract. GPU execution of the ignored lane is pending on an A100 machine.
+
+## Residual Risks
+
+- The ignored CUDA lane has not run yet on real hardware (no CUDA on the dev
+  host); cuTENSOR's acceptance of zero strides on read views and of
+  sub-256-byte descriptor alignments is per documentation and must be
+  confirmed on the A100 runner.
+- The runtime out-of-bounds region check in `resolve_device_region` is
+  defensive: public constructors already reject such layouts, so the error
+  branch is not reachable through safe public API and is covered at the
+  constructor level instead of by a CUDA runtime test.
+- `out = beta * out` with `beta != 1` for view outputs remains an explicit
+  backend error until a strided in-place scale kernel exists.
+- WebGPU accumulation and further #1287 stages remain out of scope.


### PR DESCRIPTION
Stage 2 of #1287: accept borrowed views over device-resident buffers in the CUDA dot-general accumulation path, per the staged plan in the issue.

## What this adds

- `dot_general_read_into_accum` on `CudaBackend` now accepts `TensorRead::View` / `TensorWrite::View` whose buffers are backend (device) buffers. Views resolve to `(base_ptr + offset * size_of::<T>(), view strides)`, with the cuTENSOR descriptor alignment computed from the effective byte address (largest power of two, capped at the stage-1 constant 256). Owned compact operands keep stage-1 behavior and descriptor inputs exactly.
- New public constructors `TypedTensor::backend_region_view` / `backend_region_view_mut` (tenferro-tensor): metadata-only sub-region views over a backend buffer with explicit layout. These are required for callers to express "matrix region at an offset inside a flat device buffer" — no existing public API could construct a mutable backend-buffer sub-view (`try_multi_slice_mut` intentionally returns `None` for backend buffers). Host-buffer tensors get an explicit error; reachable spans are validated against the buffer length; the mut variant additionally rejects self-overlapping layouts.

## Explicit limitations (typed errors, no silent fallback)

- Host-buffer views are rejected (no hidden upload), preserving the device-transfer contract.
- Negative strides are rejected (cuTENSOR boundary).
- Zero-sized contraction (`out = beta * out`) on a view output with `beta != 1` is an explicit error until a strided in-place scale kernel exists; `beta == 1` is a no-op.

## Verification

- A100 (CUDA 12.6, cuTENSOR 2.5): `cargo test -p tenferro-gpu --features cuda -- --ignored accum` — 14/14 pass, including the new `test_accum_view_operands_offset_regions_f64`, `test_accum_block_diagonal_regions_of_one_buffer_f64`, and the rejection tests (host view, negative stride, zero-contraction view beta).
- `cargo fmt --all --check`, CI-parity `cargo clippy --workspace --all-targets -- -D warnings`, and full `cargo test --workspace --release` clean on the development host; `cargo check -p tenferro-gpu --features cuda` and `--no-run` test builds clean.
- Doctests for the new public constructors run without a GPU (host-error path).

Work log: `docs/worklogs/2026-07-04-issue-1287-stage2-view-operands.md`

## Residual risks

- Overlap between the output region and input regions is the caller's contract (BLAS-style), documented on the constructors.
- Pre-existing on main and unchanged by this PR: 4 cuda-feature doctest compile failures in `cubecl/mod.rs` module docs and 24 cuda-feature clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
