### PR TITLE
Add CPU grouped GEMM backend path

### DIFF
--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -81,3 +81,7 @@ harness = false
 name = "openblas_direct_overhead"
 harness = false
 required-features = ["cpu-blas"]
+
+[[bench]]
+name = "grouped_gemm"
+harness = false

--- a/crates/tenferro-cpu/benches/grouped_gemm.rs
+++ b/crates/tenferro-cpu/benches/grouped_gemm.rs
@@ -1,0 +1,156 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::backend::{GroupedGemmConfig, GroupedGemmJob};
+use tenferro_tensor::{
+    BackendCachedDot, BackendRuntimeCache, ContractionScalar, DotGeneralAccumulation,
+    DotGeneralConfig, Tensor, TensorDot, TensorRead, TensorWrite,
+};
+
+#[derive(Clone)]
+struct GroupedFixture {
+    lhs: Tensor,
+    rhs: Tensor,
+    out: Tensor,
+    jobs: Vec<GroupedGemmJob>,
+}
+
+fn deterministic_data(len: usize, seed: usize) -> Vec<f64> {
+    (0..len)
+        .map(|idx| ((idx * 17 + seed * 31 + 7) % 101) as f64 / 101.0 - 0.5)
+        .collect()
+}
+
+fn fixture_from_shapes(shapes: &[(usize, usize, usize)]) -> GroupedFixture {
+    let mut lhs_len = 0usize;
+    let mut rhs_len = 0usize;
+    let mut out_len = 0usize;
+    let mut jobs = Vec::with_capacity(shapes.len());
+    for &(rows, contracted, cols) in shapes {
+        jobs.push(GroupedGemmJob::new(
+            out_len, lhs_len, rhs_len, rows, contracted, cols,
+        ));
+        lhs_len += rows * contracted;
+        rhs_len += contracted * cols;
+        out_len += rows * cols;
+    }
+    GroupedFixture {
+        lhs: Tensor::from_vec_col_major(vec![lhs_len], deterministic_data(lhs_len, 1)).unwrap(),
+        rhs: Tensor::from_vec_col_major(vec![rhs_len], deterministic_data(rhs_len, 2)).unwrap(),
+        out: Tensor::from_vec_col_major(vec![out_len], deterministic_data(out_len, 3)).unwrap(),
+        jobs,
+    }
+}
+
+fn run_grouped(backend: &mut CpuBackend, fixture: &GroupedFixture) -> Tensor {
+    let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
+    let mut out = fixture.out.clone();
+    let config = GroupedGemmConfig::new(
+        &fixture.jobs,
+        DotGeneralAccumulation {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::F64(1.0),
+            beta: ContractionScalar::F64(1.0),
+        },
+    );
+    BackendCachedDot::grouped_gemm_cached(
+        backend,
+        &mut cache,
+        Some(0),
+        TensorRead::from_tensor(&fixture.lhs),
+        TensorRead::from_tensor(&fixture.rhs),
+        &config,
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+    out
+}
+
+fn run_sequential(backend: &mut CpuBackend, fixture: &GroupedFixture) -> Tensor {
+    let mut out = fixture.out.clone();
+    let dot_config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: Vec::new(),
+        rhs_batch_dims: Vec::new(),
+    };
+    let accumulation = DotGeneralAccumulation {
+        lhs_conj: false,
+        rhs_conj: false,
+        alpha: ContractionScalar::F64(1.0),
+        beta: ContractionScalar::F64(1.0),
+    };
+    let lhs = fixture.lhs.as_slice::<f64>().unwrap();
+    let rhs = fixture.rhs.as_slice::<f64>().unwrap();
+    for job in &fixture.jobs {
+        let lhs_view = tenferro_tensor::TypedTensorView::from_slice(
+            vec![job.rows(), job.contracted()],
+            vec![1, job.rows() as isize],
+            job.lhs_offset() as isize,
+            lhs,
+        )
+        .unwrap();
+        let rhs_view = tenferro_tensor::TypedTensorView::from_slice(
+            vec![job.contracted(), job.cols()],
+            vec![1, job.contracted() as isize],
+            job.rhs_offset() as isize,
+            rhs,
+        )
+        .unwrap();
+        let mut out_view = match &mut out {
+            Tensor::F64(tensor) => tensor.as_view_mut(),
+            _ => unreachable!("fixture output is F64"),
+        };
+        let out_storage = out_view.host_storage_mut().unwrap();
+        let out_matrix = tenferro_tensor::TypedTensorViewMut::from_slice(
+            vec![job.rows(), job.cols()],
+            vec![1, job.rows() as isize],
+            job.out_offset() as isize,
+            out_storage,
+        )
+        .unwrap();
+        backend
+            .dot_general_read_into_accum(
+                TensorRead::from_view(tenferro_tensor::TensorView::F64(lhs_view)),
+                TensorRead::from_view(tenferro_tensor::TensorView::F64(rhs_view)),
+                &dot_config,
+                accumulation,
+                TensorWrite::from_view(tenferro_tensor::TensorViewMut::F64(out_matrix)),
+            )
+            .unwrap();
+    }
+    out
+}
+
+fn bench_grouped_gemm(c: &mut Criterion) {
+    let cases = [
+        ("uniform_small", vec![(8, 8, 8); 64]),
+        (
+            "mixed_large_small",
+            std::iter::once((64, 64, 64))
+                .chain(std::iter::repeat_n((8, 8, 8), 31))
+                .collect(),
+        ),
+        ("medium_blocks", vec![(32, 32, 32); 16]),
+    ];
+    let mut group = c.benchmark_group("grouped_gemm");
+    for (name, shapes) in cases {
+        let fixture = fixture_from_shapes(&shapes);
+        group.bench_with_input(BenchmarkId::new("grouped", name), &fixture, |b, fixture| {
+            let mut backend = CpuBackend::new();
+            b.iter(|| black_box(run_grouped(&mut backend, fixture)));
+        });
+        group.bench_with_input(
+            BenchmarkId::new("sequential_n_call", name),
+            &fixture,
+            |b, fixture| {
+                let mut backend = CpuBackend::new();
+                b.iter(|| black_box(run_sequential(&mut backend, fixture)));
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_grouped_gemm);
+criterion_main!(benches);

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -12,7 +12,8 @@ use crate::{
     TypedTensorView, TypedTensorViewMut,
 };
 use tenferro_tensor::backend::{
-    dot_general_accum_via_temp, validate_dot_general_accumulation, ElementwiseFusionPlan,
+    dot_general_accum_via_temp, grouped_gemm_via_sequential, validate_dot_general_accumulation,
+    validate_grouped_gemm, ElementwiseFusionPlan, GroupedGemmConfig,
 };
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
@@ -1409,6 +1410,56 @@ impl BackendCachedDot for CpuBackend {
         }
 
         dot_general_accum_via_temp(self, lhs, rhs, config, accumulation, out)
+    }
+
+    fn grouped_gemm_cached(
+        &mut self,
+        _cache: &mut Self::RuntimeCache,
+        _cache_slot: Option<usize>,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &GroupedGemmConfig<'_>,
+        mut out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        validate_grouped_gemm(&lhs, &rhs, &out, config, "grouped_gemm")?;
+        let direct = match self.kind {
+            CpuBackendKind::Faer => {
+                #[cfg(feature = "cpu-faer")]
+                {
+                    let ctx = Arc::clone(&self.ctx);
+                    self.install_with_pool(|_buffers| {
+                        gemm::grouped_gemm_faer_cached(
+                            ctx.as_ref(),
+                            lhs.clone(),
+                            rhs.clone(),
+                            config,
+                            &mut out,
+                        )
+                    })?
+                }
+                #[cfg(not(feature = "cpu-faer"))]
+                {
+                    return Err(unavailable_cpu_backend_kind(self.kind, "grouped_gemm"));
+                }
+            }
+            CpuBackendKind::Blas => {
+                #[cfg(feature = "cpu-blas")]
+                {
+                    self.run_with_pool(|_buffers| {
+                        gemm::grouped_gemm_blas_cached(lhs.clone(), rhs.clone(), config, &mut out)
+                    })?
+                }
+                #[cfg(not(feature = "cpu-blas"))]
+                {
+                    return Err(unavailable_cpu_backend_kind(self.kind, "grouped_gemm"));
+                }
+            }
+        };
+        if direct {
+            return Ok(());
+        }
+
+        grouped_gemm_via_sequential(self, lhs, rhs, config, out)
     }
 }
 

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -171,6 +171,12 @@ impl CpuContext {
             faer::Par::rayon(0)
         }
     }
+
+    #[cfg(feature = "cpu-faer")]
+    #[doc(hidden)]
+    pub fn faer_seq(&self) -> faer::Par {
+        faer::Par::Seq
+    }
 }
 
 #[cfg(test)]

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -1,7 +1,8 @@
 use crate::buffer_pool::BufferPool;
 use crate::{Tensor, TensorRead, TensorValue, TensorWrite};
 use tenferro_tensor::backend::{
-    dot_general_accum_via_temp, validate_dot_general_accumulation, ElementwiseFusionPlan,
+    dot_general_accum_via_temp, grouped_gemm_via_sequential, validate_dot_general_accumulation,
+    validate_grouped_gemm, ElementwiseFusionPlan, GroupedGemmConfig,
 };
 use tenferro_tensor::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
@@ -626,6 +627,56 @@ impl SessionCachedDot for CpuExecSession<'_> {
         }
 
         dot_general_accum_via_temp(self, lhs, rhs, config, accumulation, out)
+    }
+
+    fn grouped_gemm_cached(
+        &mut self,
+        _cache_slot: Option<usize>,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &GroupedGemmConfig<'_>,
+        mut out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        validate_grouped_gemm(&lhs, &rhs, &out, config, "grouped_gemm")?;
+        let direct = match self.kind {
+            CpuBackendKind::Faer => {
+                #[cfg(feature = "cpu-faer")]
+                {
+                    gemm::grouped_gemm_faer_cached(
+                        self.ctx,
+                        lhs.clone(),
+                        rhs.clone(),
+                        config,
+                        &mut out,
+                    )?
+                }
+                #[cfg(not(feature = "cpu-faer"))]
+                {
+                    return Err(super::backend::unavailable_cpu_backend_kind(
+                        self.kind,
+                        "grouped_gemm",
+                    ));
+                }
+            }
+            CpuBackendKind::Blas => {
+                #[cfg(feature = "cpu-blas")]
+                {
+                    gemm::grouped_gemm_blas_cached(lhs.clone(), rhs.clone(), config, &mut out)?
+                }
+                #[cfg(not(feature = "cpu-blas"))]
+                {
+                    return Err(super::backend::unavailable_cpu_backend_kind(
+                        self.kind,
+                        "grouped_gemm",
+                    ));
+                }
+            }
+        };
+        if direct {
+            return Ok(());
+        }
+
+        grouped_gemm_via_sequential(self, lhs, rhs, config, out)
     }
 }
 

--- a/crates/tenferro-cpu/src/gemm/blas_gemm.rs
+++ b/crates/tenferro-cpu/src/gemm/blas_gemm.rs
@@ -3,7 +3,22 @@ use num_complex::{Complex32, Complex64};
 
 use crate::Error;
 
-pub(crate) trait BlasGemm: Sized {
+pub(crate) struct BlasGemmBatch<T> {
+    pub(crate) a_ptr: *const T,
+    pub(crate) b_ptr: *const T,
+    pub(crate) c_ptr: *mut T,
+    pub(crate) m: usize,
+    pub(crate) n: usize,
+    pub(crate) k: usize,
+    pub(crate) a_rs: isize,
+    pub(crate) a_cs: isize,
+    pub(crate) b_rs: isize,
+    pub(crate) b_cs: isize,
+    pub(crate) c_rs: isize,
+    pub(crate) c_cs: isize,
+}
+
+pub(crate) trait BlasGemm: Sized + Copy {
     // Kept as a provider-local contiguous BLAS entry point for direct BLAS
     // validation even when the optimized path uses explicit strides.
     #[allow(dead_code)]
@@ -78,6 +93,41 @@ pub(crate) trait BlasGemm: Sized {
             Self::strided_gemm(
                 alpha, a_ptr, m, k, a_rs, a_cs, b_ptr, n, b_rs, b_cs, beta, c_ptr, c_rs, c_cs,
             )?;
+        }
+        Ok(true)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    /// Run a group of raw strided GEMMs with shared alpha/beta.
+    ///
+    /// # Safety
+    ///
+    /// Each batch entry must satisfy [`BlasGemm::strided_gemm`]'s pointer
+    /// safety contract. Mutable output regions must be pairwise disjoint.
+    unsafe fn grouped_gemm(
+        alpha: Self,
+        beta: Self,
+        batches: &[BlasGemmBatch<Self>],
+    ) -> crate::Result<bool> {
+        for batch in batches {
+            unsafe {
+                Self::strided_gemm(
+                    alpha,
+                    batch.a_ptr,
+                    batch.m,
+                    batch.k,
+                    batch.a_rs,
+                    batch.a_cs,
+                    batch.b_ptr,
+                    batch.n,
+                    batch.b_rs,
+                    batch.b_cs,
+                    beta,
+                    batch.c_ptr,
+                    batch.c_rs,
+                    batch.c_cs,
+                )?;
+            }
         }
         Ok(true)
     }
@@ -199,8 +249,272 @@ fn apply_conj_transpose(trans: CBLAS_TRANSPOSE, conj: bool) -> Option<CBLAS_TRAN
     }
 }
 
+#[cfg(feature = "blas-openblas")]
+mod openblas_batch {
+    use super::*;
+    use std::ffi::c_void;
+
+    unsafe extern "C" {
+        fn cblas_sgemm_batch(
+            order: CBLAS_LAYOUT,
+            trans_a: *const CBLAS_TRANSPOSE,
+            trans_b: *const CBLAS_TRANSPOSE,
+            m: *const i32,
+            n: *const i32,
+            k: *const i32,
+            alpha: *const f32,
+            a: *const *const f32,
+            lda: *const i32,
+            b: *const *const f32,
+            ldb: *const i32,
+            beta: *const f32,
+            c: *const *mut f32,
+            ldc: *const i32,
+            group_count: i32,
+            group_size: *const i32,
+        );
+
+        fn cblas_dgemm_batch(
+            order: CBLAS_LAYOUT,
+            trans_a: *const CBLAS_TRANSPOSE,
+            trans_b: *const CBLAS_TRANSPOSE,
+            m: *const i32,
+            n: *const i32,
+            k: *const i32,
+            alpha: *const f64,
+            a: *const *const f64,
+            lda: *const i32,
+            b: *const *const f64,
+            ldb: *const i32,
+            beta: *const f64,
+            c: *const *mut f64,
+            ldc: *const i32,
+            group_count: i32,
+            group_size: *const i32,
+        );
+
+        fn cblas_cgemm_batch(
+            order: CBLAS_LAYOUT,
+            trans_a: *const CBLAS_TRANSPOSE,
+            trans_b: *const CBLAS_TRANSPOSE,
+            m: *const i32,
+            n: *const i32,
+            k: *const i32,
+            alpha: *const c_void,
+            a: *const *const c_void,
+            lda: *const i32,
+            b: *const *const c_void,
+            ldb: *const i32,
+            beta: *const c_void,
+            c: *const *mut c_void,
+            ldc: *const i32,
+            group_count: i32,
+            group_size: *const i32,
+        );
+
+        fn cblas_zgemm_batch(
+            order: CBLAS_LAYOUT,
+            trans_a: *const CBLAS_TRANSPOSE,
+            trans_b: *const CBLAS_TRANSPOSE,
+            m: *const i32,
+            n: *const i32,
+            k: *const i32,
+            alpha: *const c_void,
+            a: *const *const c_void,
+            lda: *const i32,
+            b: *const *const c_void,
+            ldb: *const i32,
+            beta: *const c_void,
+            c: *const *mut c_void,
+            ldc: *const i32,
+            group_count: i32,
+            group_size: *const i32,
+        );
+    }
+
+    struct PreparedBatch<T> {
+        trans_a: Vec<CBLAS_TRANSPOSE>,
+        trans_b: Vec<CBLAS_TRANSPOSE>,
+        m: Vec<i32>,
+        n: Vec<i32>,
+        k: Vec<i32>,
+        a: Vec<*const T>,
+        b: Vec<*const T>,
+        c: Vec<*mut T>,
+        lda: Vec<i32>,
+        ldb: Vec<i32>,
+        ldc: Vec<i32>,
+        group_size: Vec<i32>,
+    }
+
+    fn prepare<T>(batches: &[BlasGemmBatch<T>]) -> crate::Result<PreparedBatch<T>> {
+        let mut prepared = PreparedBatch {
+            trans_a: Vec::with_capacity(batches.len()),
+            trans_b: Vec::with_capacity(batches.len()),
+            m: Vec::with_capacity(batches.len()),
+            n: Vec::with_capacity(batches.len()),
+            k: Vec::with_capacity(batches.len()),
+            a: Vec::with_capacity(batches.len()),
+            b: Vec::with_capacity(batches.len()),
+            c: Vec::with_capacity(batches.len()),
+            lda: Vec::with_capacity(batches.len()),
+            ldb: Vec::with_capacity(batches.len()),
+            ldc: Vec::with_capacity(batches.len()),
+            group_size: Vec::with_capacity(batches.len()),
+        };
+        for batch in batches {
+            let (trans_a, lda) = infer_a_layout(batch.m, batch.k, batch.a_rs, batch.a_cs)?;
+            let (trans_b, ldb) = infer_b_layout(batch.k, batch.n, batch.b_rs, batch.b_cs)?;
+            let ldc = infer_c_layout(batch.m, batch.c_rs, batch.c_cs)?;
+            prepared.trans_a.push(trans_a);
+            prepared.trans_b.push(trans_b);
+            prepared.m.push(dim_to_i32("m", batch.m)?);
+            prepared.n.push(dim_to_i32("n", batch.n)?);
+            prepared.k.push(dim_to_i32("k", batch.k)?);
+            prepared.a.push(batch.a_ptr);
+            prepared.b.push(batch.b_ptr);
+            prepared.c.push(batch.c_ptr);
+            prepared.lda.push(lda);
+            prepared.ldb.push(ldb);
+            prepared.ldc.push(ldc);
+            prepared.group_size.push(1);
+        }
+        Ok(prepared)
+    }
+
+    pub(crate) unsafe fn sgemm_batch(
+        alpha: f32,
+        beta: f32,
+        batches: &[BlasGemmBatch<f32>],
+    ) -> crate::Result<bool> {
+        let prepared = prepare(batches)?;
+        let group_count = dim_to_i32("group_count", batches.len())?;
+        unsafe {
+            cblas_sgemm_batch(
+                CBLAS_LAYOUT::CblasColMajor,
+                prepared.trans_a.as_ptr(),
+                prepared.trans_b.as_ptr(),
+                prepared.m.as_ptr(),
+                prepared.n.as_ptr(),
+                prepared.k.as_ptr(),
+                vec![alpha; batches.len()].as_ptr(),
+                prepared.a.as_ptr(),
+                prepared.lda.as_ptr(),
+                prepared.b.as_ptr(),
+                prepared.ldb.as_ptr(),
+                vec![beta; batches.len()].as_ptr(),
+                prepared.c.as_ptr(),
+                prepared.ldc.as_ptr(),
+                group_count,
+                prepared.group_size.as_ptr(),
+            );
+        }
+        Ok(true)
+    }
+
+    pub(crate) unsafe fn dgemm_batch(
+        alpha: f64,
+        beta: f64,
+        batches: &[BlasGemmBatch<f64>],
+    ) -> crate::Result<bool> {
+        let prepared = prepare(batches)?;
+        let group_count = dim_to_i32("group_count", batches.len())?;
+        unsafe {
+            cblas_dgemm_batch(
+                CBLAS_LAYOUT::CblasColMajor,
+                prepared.trans_a.as_ptr(),
+                prepared.trans_b.as_ptr(),
+                prepared.m.as_ptr(),
+                prepared.n.as_ptr(),
+                prepared.k.as_ptr(),
+                vec![alpha; batches.len()].as_ptr(),
+                prepared.a.as_ptr(),
+                prepared.lda.as_ptr(),
+                prepared.b.as_ptr(),
+                prepared.ldb.as_ptr(),
+                vec![beta; batches.len()].as_ptr(),
+                prepared.c.as_ptr(),
+                prepared.ldc.as_ptr(),
+                group_count,
+                prepared.group_size.as_ptr(),
+            );
+        }
+        Ok(true)
+    }
+
+    pub(crate) unsafe fn cgemm_batch(
+        alpha: Complex32,
+        beta: Complex32,
+        batches: &[BlasGemmBatch<Complex32>],
+    ) -> crate::Result<bool> {
+        let prepared = prepare(batches)?;
+        let group_count = dim_to_i32("group_count", batches.len())?;
+        let alpha = vec![alpha; batches.len()];
+        let beta = vec![beta; batches.len()];
+        let a: Vec<*const c_void> = prepared.a.iter().map(|&ptr| ptr as *const c_void).collect();
+        let b: Vec<*const c_void> = prepared.b.iter().map(|&ptr| ptr as *const c_void).collect();
+        let c: Vec<*mut c_void> = prepared.c.iter().map(|&ptr| ptr as *mut c_void).collect();
+        unsafe {
+            cblas_cgemm_batch(
+                CBLAS_LAYOUT::CblasColMajor,
+                prepared.trans_a.as_ptr(),
+                prepared.trans_b.as_ptr(),
+                prepared.m.as_ptr(),
+                prepared.n.as_ptr(),
+                prepared.k.as_ptr(),
+                alpha.as_ptr() as *const c_void,
+                a.as_ptr(),
+                prepared.lda.as_ptr(),
+                b.as_ptr(),
+                prepared.ldb.as_ptr(),
+                beta.as_ptr() as *const c_void,
+                c.as_ptr(),
+                prepared.ldc.as_ptr(),
+                group_count,
+                prepared.group_size.as_ptr(),
+            );
+        }
+        Ok(true)
+    }
+
+    pub(crate) unsafe fn zgemm_batch(
+        alpha: Complex64,
+        beta: Complex64,
+        batches: &[BlasGemmBatch<Complex64>],
+    ) -> crate::Result<bool> {
+        let prepared = prepare(batches)?;
+        let group_count = dim_to_i32("group_count", batches.len())?;
+        let alpha = vec![alpha; batches.len()];
+        let beta = vec![beta; batches.len()];
+        let a: Vec<*const c_void> = prepared.a.iter().map(|&ptr| ptr as *const c_void).collect();
+        let b: Vec<*const c_void> = prepared.b.iter().map(|&ptr| ptr as *const c_void).collect();
+        let c: Vec<*mut c_void> = prepared.c.iter().map(|&ptr| ptr as *mut c_void).collect();
+        unsafe {
+            cblas_zgemm_batch(
+                CBLAS_LAYOUT::CblasColMajor,
+                prepared.trans_a.as_ptr(),
+                prepared.trans_b.as_ptr(),
+                prepared.m.as_ptr(),
+                prepared.n.as_ptr(),
+                prepared.k.as_ptr(),
+                alpha.as_ptr() as *const c_void,
+                a.as_ptr(),
+                prepared.lda.as_ptr(),
+                b.as_ptr(),
+                prepared.ldb.as_ptr(),
+                beta.as_ptr() as *const c_void,
+                c.as_ptr(),
+                prepared.ldc.as_ptr(),
+                group_count,
+                prepared.group_size.as_ptr(),
+            );
+        }
+        Ok(true)
+    }
+}
+
 macro_rules! impl_real_blas_gemm {
-    ($ty:ty, $gemm:path) => {
+    ($ty:ty, $gemm:path, $batch:path) => {
         impl BlasGemm for $ty {
             fn contiguous_gemm(
                 alpha: Self,
@@ -283,12 +597,24 @@ macro_rules! impl_real_blas_gemm {
                 );
                 Ok(())
             }
+
+            #[cfg(feature = "blas-openblas")]
+            unsafe fn grouped_gemm(
+                alpha: Self,
+                beta: Self,
+                batches: &[BlasGemmBatch<Self>],
+            ) -> crate::Result<bool> {
+                if batches.is_empty() {
+                    return Ok(true);
+                }
+                unsafe { $batch(alpha, beta, batches) }
+            }
         }
     };
 }
 
 macro_rules! impl_complex_blas_gemm {
-    ($ty:ty, $gemm:path) => {
+    ($ty:ty, $gemm:path, $batch:path) => {
         impl BlasGemm for $ty {
             fn contiguous_gemm(
                 alpha: Self,
@@ -432,11 +758,31 @@ macro_rules! impl_complex_blas_gemm {
                 );
                 Ok(true)
             }
+
+            #[cfg(feature = "blas-openblas")]
+            unsafe fn grouped_gemm(
+                alpha: Self,
+                beta: Self,
+                batches: &[BlasGemmBatch<Self>],
+            ) -> crate::Result<bool> {
+                if batches.is_empty() {
+                    return Ok(true);
+                }
+                unsafe { $batch(alpha, beta, batches) }
+            }
         }
     };
 }
 
-impl_real_blas_gemm!(f64, cblas_sys::cblas_dgemm);
-impl_real_blas_gemm!(f32, cblas_sys::cblas_sgemm);
-impl_complex_blas_gemm!(Complex64, cblas_sys::cblas_zgemm);
-impl_complex_blas_gemm!(Complex32, cblas_sys::cblas_cgemm);
+impl_real_blas_gemm!(f64, cblas_sys::cblas_dgemm, openblas_batch::dgemm_batch);
+impl_real_blas_gemm!(f32, cblas_sys::cblas_sgemm, openblas_batch::sgemm_batch);
+impl_complex_blas_gemm!(
+    Complex64,
+    cblas_sys::cblas_zgemm,
+    openblas_batch::zgemm_batch
+);
+impl_complex_blas_gemm!(
+    Complex32,
+    cblas_sys::cblas_cgemm,
+    openblas_batch::cgemm_batch
+);

--- a/crates/tenferro-cpu/src/gemm/blas_gemm.rs
+++ b/crates/tenferro-cpu/src/gemm/blas_gemm.rs
@@ -18,6 +18,49 @@ pub(crate) struct BlasGemmBatch<T> {
     pub(crate) c_cs: isize,
 }
 
+#[cfg(feature = "blas-openblas")]
+const OPENBLAS_GEMM_BATCH_SMALL_DIM_LIMIT: usize = 16;
+
+#[cfg(feature = "blas-openblas")]
+pub(super) fn openblas_should_use_gemm_batch<T>(batches: &[BlasGemmBatch<T>]) -> bool {
+    batches.len() > 1
+        && batches.iter().all(|batch| {
+            batch.m <= OPENBLAS_GEMM_BATCH_SMALL_DIM_LIMIT
+                && batch.n <= OPENBLAS_GEMM_BATCH_SMALL_DIM_LIMIT
+                && batch.k <= OPENBLAS_GEMM_BATCH_SMALL_DIM_LIMIT
+        })
+}
+
+unsafe fn grouped_gemm_sequential<T: BlasGemm>(
+    alpha: T,
+    beta: T,
+    batches: &[BlasGemmBatch<T>],
+) -> crate::Result<bool> {
+    for batch in batches {
+        // SAFETY: this fallback preserves the caller's grouped-GEMM contract by
+        // executing each already-validated job sequentially.
+        unsafe {
+            T::strided_gemm(
+                alpha,
+                batch.a_ptr,
+                batch.m,
+                batch.k,
+                batch.a_rs,
+                batch.a_cs,
+                batch.b_ptr,
+                batch.n,
+                batch.b_rs,
+                batch.b_cs,
+                beta,
+                batch.c_ptr,
+                batch.c_rs,
+                batch.c_cs,
+            )?;
+        }
+    }
+    Ok(true)
+}
+
 pub(crate) trait BlasGemm: Sized + Copy {
     // Kept as a provider-local contiguous BLAS entry point for direct BLAS
     // validation even when the optimized path uses explicit strides.
@@ -109,27 +152,9 @@ pub(crate) trait BlasGemm: Sized + Copy {
         beta: Self,
         batches: &[BlasGemmBatch<Self>],
     ) -> crate::Result<bool> {
-        for batch in batches {
-            unsafe {
-                Self::strided_gemm(
-                    alpha,
-                    batch.a_ptr,
-                    batch.m,
-                    batch.k,
-                    batch.a_rs,
-                    batch.a_cs,
-                    batch.b_ptr,
-                    batch.n,
-                    batch.b_rs,
-                    batch.b_cs,
-                    beta,
-                    batch.c_ptr,
-                    batch.c_rs,
-                    batch.c_cs,
-                )?;
-            }
-        }
-        Ok(true)
+        // SAFETY: this default provider preserves the caller's grouped-GEMM
+        // contract by executing each already-validated job sequentially.
+        unsafe { grouped_gemm_sequential(alpha, beta, batches) }
     }
 }
 
@@ -332,52 +357,95 @@ mod openblas_batch {
         );
     }
 
+    #[derive(Clone, Copy)]
+    struct PreparedGroup {
+        trans_a: CBLAS_TRANSPOSE,
+        trans_b: CBLAS_TRANSPOSE,
+        m: i32,
+        n: i32,
+        k: i32,
+        lda: i32,
+        ldb: i32,
+        ldc: i32,
+    }
+
+    fn same_group(lhs: PreparedGroup, rhs: PreparedGroup) -> bool {
+        lhs.trans_a as i32 == rhs.trans_a as i32
+            && lhs.trans_b as i32 == rhs.trans_b as i32
+            && lhs.m == rhs.m
+            && lhs.n == rhs.n
+            && lhs.k == rhs.k
+            && lhs.lda == rhs.lda
+            && lhs.ldb == rhs.ldb
+            && lhs.ldc == rhs.ldc
+    }
+
     struct PreparedBatch<T> {
-        trans_a: Vec<CBLAS_TRANSPOSE>,
-        trans_b: Vec<CBLAS_TRANSPOSE>,
-        m: Vec<i32>,
-        n: Vec<i32>,
-        k: Vec<i32>,
+        groups: Vec<PreparedGroup>,
         a: Vec<*const T>,
         b: Vec<*const T>,
         c: Vec<*mut T>,
-        lda: Vec<i32>,
-        ldb: Vec<i32>,
-        ldc: Vec<i32>,
         group_size: Vec<i32>,
     }
 
+    impl<T> PreparedBatch<T> {
+        fn group_count(&self) -> usize {
+            self.groups.len()
+        }
+
+        fn push_group(&mut self, group: PreparedGroup) -> crate::Result<()> {
+            match self.groups.last().copied() {
+                Some(last) if same_group(last, group) => {
+                    let Some(last_size) = self.group_size.last_mut() else {
+                        return Err(Error::InvalidConfig {
+                            op: "grouped_gemm",
+                            message: "OpenBLAS grouped GEMM metadata is inconsistent".into(),
+                        });
+                    };
+                    *last_size = last_size
+                        .checked_add(1)
+                        .ok_or_else(|| Error::InvalidConfig {
+                            op: "grouped_gemm",
+                            message: "OpenBLAS grouped GEMM group_size overflows i32".into(),
+                        })?;
+                }
+                _ => {
+                    self.groups.push(group);
+                    self.group_size.push(1);
+                }
+            }
+            Ok(())
+        }
+    }
+
     fn prepare<T>(batches: &[BlasGemmBatch<T>]) -> crate::Result<PreparedBatch<T>> {
+        // OpenBLAS consumes C-contiguous descriptor arrays for one immediate
+        // call. These Vecs are deliberately not SmallVec-backed: job count is
+        // runtime-dependent, and capacity reservation plus a stable slice keeps
+        // the FFI boundary simple without a second inline/spill path.
         let mut prepared = PreparedBatch {
-            trans_a: Vec::with_capacity(batches.len()),
-            trans_b: Vec::with_capacity(batches.len()),
-            m: Vec::with_capacity(batches.len()),
-            n: Vec::with_capacity(batches.len()),
-            k: Vec::with_capacity(batches.len()),
+            groups: Vec::with_capacity(batches.len()),
             a: Vec::with_capacity(batches.len()),
             b: Vec::with_capacity(batches.len()),
             c: Vec::with_capacity(batches.len()),
-            lda: Vec::with_capacity(batches.len()),
-            ldb: Vec::with_capacity(batches.len()),
-            ldc: Vec::with_capacity(batches.len()),
             group_size: Vec::with_capacity(batches.len()),
         };
         for batch in batches {
             let (trans_a, lda) = infer_a_layout(batch.m, batch.k, batch.a_rs, batch.a_cs)?;
             let (trans_b, ldb) = infer_b_layout(batch.k, batch.n, batch.b_rs, batch.b_cs)?;
-            let ldc = infer_c_layout(batch.m, batch.c_rs, batch.c_cs)?;
-            prepared.trans_a.push(trans_a);
-            prepared.trans_b.push(trans_b);
-            prepared.m.push(dim_to_i32("m", batch.m)?);
-            prepared.n.push(dim_to_i32("n", batch.n)?);
-            prepared.k.push(dim_to_i32("k", batch.k)?);
+            prepared.push_group(PreparedGroup {
+                trans_a,
+                trans_b,
+                m: dim_to_i32("m", batch.m)?,
+                n: dim_to_i32("n", batch.n)?,
+                k: dim_to_i32("k", batch.k)?,
+                lda,
+                ldb,
+                ldc: infer_c_layout(batch.m, batch.c_rs, batch.c_cs)?,
+            })?;
             prepared.a.push(batch.a_ptr);
             prepared.b.push(batch.b_ptr);
             prepared.c.push(batch.c_ptr);
-            prepared.lda.push(lda);
-            prepared.ldb.push(ldb);
-            prepared.ldc.push(ldc);
-            prepared.group_size.push(1);
         }
         Ok(prepared)
     }
@@ -387,24 +455,39 @@ mod openblas_batch {
         beta: f32,
         batches: &[BlasGemmBatch<f32>],
     ) -> crate::Result<bool> {
+        if batches.is_empty() {
+            return Ok(true);
+        }
         let prepared = prepare(batches)?;
-        let group_count = dim_to_i32("group_count", batches.len())?;
+        let group_count = dim_to_i32("group_count", prepared.group_count())?;
+        // alpha/beta are per OpenBLAS group, not per job. Keep them in Vecs so
+        // the C call receives stable contiguous descriptor slices.
+        let alpha = vec![alpha; prepared.group_count()];
+        let beta = vec![beta; prepared.group_count()];
+        let trans_a: Vec<_> = prepared.groups.iter().map(|group| group.trans_a).collect();
+        let trans_b: Vec<_> = prepared.groups.iter().map(|group| group.trans_b).collect();
+        let m: Vec<_> = prepared.groups.iter().map(|group| group.m).collect();
+        let n: Vec<_> = prepared.groups.iter().map(|group| group.n).collect();
+        let k: Vec<_> = prepared.groups.iter().map(|group| group.k).collect();
+        let lda: Vec<_> = prepared.groups.iter().map(|group| group.lda).collect();
+        let ldb: Vec<_> = prepared.groups.iter().map(|group| group.ldb).collect();
+        let ldc: Vec<_> = prepared.groups.iter().map(|group| group.ldc).collect();
         unsafe {
             cblas_sgemm_batch(
                 CBLAS_LAYOUT::CblasColMajor,
-                prepared.trans_a.as_ptr(),
-                prepared.trans_b.as_ptr(),
-                prepared.m.as_ptr(),
-                prepared.n.as_ptr(),
-                prepared.k.as_ptr(),
-                vec![alpha; batches.len()].as_ptr(),
+                trans_a.as_ptr(),
+                trans_b.as_ptr(),
+                m.as_ptr(),
+                n.as_ptr(),
+                k.as_ptr(),
+                alpha.as_ptr(),
                 prepared.a.as_ptr(),
-                prepared.lda.as_ptr(),
+                lda.as_ptr(),
                 prepared.b.as_ptr(),
-                prepared.ldb.as_ptr(),
-                vec![beta; batches.len()].as_ptr(),
+                ldb.as_ptr(),
+                beta.as_ptr(),
                 prepared.c.as_ptr(),
-                prepared.ldc.as_ptr(),
+                ldc.as_ptr(),
                 group_count,
                 prepared.group_size.as_ptr(),
             );
@@ -417,24 +500,38 @@ mod openblas_batch {
         beta: f64,
         batches: &[BlasGemmBatch<f64>],
     ) -> crate::Result<bool> {
+        if batches.is_empty() {
+            return Ok(true);
+        }
         let prepared = prepare(batches)?;
-        let group_count = dim_to_i32("group_count", batches.len())?;
+        let group_count = dim_to_i32("group_count", prepared.group_count())?;
+        // See sgemm_batch: scalar and metadata arrays are per OpenBLAS group.
+        let alpha = vec![alpha; prepared.group_count()];
+        let beta = vec![beta; prepared.group_count()];
+        let trans_a: Vec<_> = prepared.groups.iter().map(|group| group.trans_a).collect();
+        let trans_b: Vec<_> = prepared.groups.iter().map(|group| group.trans_b).collect();
+        let m: Vec<_> = prepared.groups.iter().map(|group| group.m).collect();
+        let n: Vec<_> = prepared.groups.iter().map(|group| group.n).collect();
+        let k: Vec<_> = prepared.groups.iter().map(|group| group.k).collect();
+        let lda: Vec<_> = prepared.groups.iter().map(|group| group.lda).collect();
+        let ldb: Vec<_> = prepared.groups.iter().map(|group| group.ldb).collect();
+        let ldc: Vec<_> = prepared.groups.iter().map(|group| group.ldc).collect();
         unsafe {
             cblas_dgemm_batch(
                 CBLAS_LAYOUT::CblasColMajor,
-                prepared.trans_a.as_ptr(),
-                prepared.trans_b.as_ptr(),
-                prepared.m.as_ptr(),
-                prepared.n.as_ptr(),
-                prepared.k.as_ptr(),
-                vec![alpha; batches.len()].as_ptr(),
+                trans_a.as_ptr(),
+                trans_b.as_ptr(),
+                m.as_ptr(),
+                n.as_ptr(),
+                k.as_ptr(),
+                alpha.as_ptr(),
                 prepared.a.as_ptr(),
-                prepared.lda.as_ptr(),
+                lda.as_ptr(),
                 prepared.b.as_ptr(),
-                prepared.ldb.as_ptr(),
-                vec![beta; batches.len()].as_ptr(),
+                ldb.as_ptr(),
+                beta.as_ptr(),
                 prepared.c.as_ptr(),
-                prepared.ldc.as_ptr(),
+                ldc.as_ptr(),
                 group_count,
                 prepared.group_size.as_ptr(),
             );
@@ -447,29 +544,43 @@ mod openblas_batch {
         beta: Complex32,
         batches: &[BlasGemmBatch<Complex32>],
     ) -> crate::Result<bool> {
+        if batches.is_empty() {
+            return Ok(true);
+        }
         let prepared = prepare(batches)?;
-        let group_count = dim_to_i32("group_count", batches.len())?;
-        let alpha = vec![alpha; batches.len()];
-        let beta = vec![beta; batches.len()];
+        let group_count = dim_to_i32("group_count", prepared.group_count())?;
+        // See sgemm_batch: scalar and metadata arrays are per OpenBLAS group.
+        let alpha = vec![alpha; prepared.group_count()];
+        let beta = vec![beta; prepared.group_count()];
+        let trans_a: Vec<_> = prepared.groups.iter().map(|group| group.trans_a).collect();
+        let trans_b: Vec<_> = prepared.groups.iter().map(|group| group.trans_b).collect();
+        let m: Vec<_> = prepared.groups.iter().map(|group| group.m).collect();
+        let n: Vec<_> = prepared.groups.iter().map(|group| group.n).collect();
+        let k: Vec<_> = prepared.groups.iter().map(|group| group.k).collect();
+        let lda: Vec<_> = prepared.groups.iter().map(|group| group.lda).collect();
+        let ldb: Vec<_> = prepared.groups.iter().map(|group| group.ldb).collect();
+        let ldc: Vec<_> = prepared.groups.iter().map(|group| group.ldc).collect();
+        // Complex OpenBLAS ABI uses c_void pointer arrays, so these Vecs mirror
+        // the provider descriptor arrays instead of SmallVec rank metadata.
         let a: Vec<*const c_void> = prepared.a.iter().map(|&ptr| ptr as *const c_void).collect();
         let b: Vec<*const c_void> = prepared.b.iter().map(|&ptr| ptr as *const c_void).collect();
         let c: Vec<*mut c_void> = prepared.c.iter().map(|&ptr| ptr as *mut c_void).collect();
         unsafe {
             cblas_cgemm_batch(
                 CBLAS_LAYOUT::CblasColMajor,
-                prepared.trans_a.as_ptr(),
-                prepared.trans_b.as_ptr(),
-                prepared.m.as_ptr(),
-                prepared.n.as_ptr(),
-                prepared.k.as_ptr(),
+                trans_a.as_ptr(),
+                trans_b.as_ptr(),
+                m.as_ptr(),
+                n.as_ptr(),
+                k.as_ptr(),
                 alpha.as_ptr() as *const c_void,
                 a.as_ptr(),
-                prepared.lda.as_ptr(),
+                lda.as_ptr(),
                 b.as_ptr(),
-                prepared.ldb.as_ptr(),
+                ldb.as_ptr(),
                 beta.as_ptr() as *const c_void,
                 c.as_ptr(),
-                prepared.ldc.as_ptr(),
+                ldc.as_ptr(),
                 group_count,
                 prepared.group_size.as_ptr(),
             );
@@ -482,29 +593,43 @@ mod openblas_batch {
         beta: Complex64,
         batches: &[BlasGemmBatch<Complex64>],
     ) -> crate::Result<bool> {
+        if batches.is_empty() {
+            return Ok(true);
+        }
         let prepared = prepare(batches)?;
-        let group_count = dim_to_i32("group_count", batches.len())?;
-        let alpha = vec![alpha; batches.len()];
-        let beta = vec![beta; batches.len()];
+        let group_count = dim_to_i32("group_count", prepared.group_count())?;
+        // See sgemm_batch: scalar and metadata arrays are per OpenBLAS group.
+        let alpha = vec![alpha; prepared.group_count()];
+        let beta = vec![beta; prepared.group_count()];
+        let trans_a: Vec<_> = prepared.groups.iter().map(|group| group.trans_a).collect();
+        let trans_b: Vec<_> = prepared.groups.iter().map(|group| group.trans_b).collect();
+        let m: Vec<_> = prepared.groups.iter().map(|group| group.m).collect();
+        let n: Vec<_> = prepared.groups.iter().map(|group| group.n).collect();
+        let k: Vec<_> = prepared.groups.iter().map(|group| group.k).collect();
+        let lda: Vec<_> = prepared.groups.iter().map(|group| group.lda).collect();
+        let ldb: Vec<_> = prepared.groups.iter().map(|group| group.ldb).collect();
+        let ldc: Vec<_> = prepared.groups.iter().map(|group| group.ldc).collect();
+        // Complex OpenBLAS ABI uses c_void pointer arrays, so these Vecs mirror
+        // the provider descriptor arrays instead of SmallVec rank metadata.
         let a: Vec<*const c_void> = prepared.a.iter().map(|&ptr| ptr as *const c_void).collect();
         let b: Vec<*const c_void> = prepared.b.iter().map(|&ptr| ptr as *const c_void).collect();
         let c: Vec<*mut c_void> = prepared.c.iter().map(|&ptr| ptr as *mut c_void).collect();
         unsafe {
             cblas_zgemm_batch(
                 CBLAS_LAYOUT::CblasColMajor,
-                prepared.trans_a.as_ptr(),
-                prepared.trans_b.as_ptr(),
-                prepared.m.as_ptr(),
-                prepared.n.as_ptr(),
-                prepared.k.as_ptr(),
+                trans_a.as_ptr(),
+                trans_b.as_ptr(),
+                m.as_ptr(),
+                n.as_ptr(),
+                k.as_ptr(),
                 alpha.as_ptr() as *const c_void,
                 a.as_ptr(),
-                prepared.lda.as_ptr(),
+                lda.as_ptr(),
                 b.as_ptr(),
-                prepared.ldb.as_ptr(),
+                ldb.as_ptr(),
                 beta.as_ptr() as *const c_void,
                 c.as_ptr(),
-                prepared.ldc.as_ptr(),
+                ldc.as_ptr(),
                 group_count,
                 prepared.group_size.as_ptr(),
             );
@@ -607,7 +732,16 @@ macro_rules! impl_real_blas_gemm {
                 if batches.is_empty() {
                     return Ok(true);
                 }
-                unsafe { $batch(alpha, beta, batches) }
+                if openblas_should_use_gemm_batch(batches) {
+                    // SAFETY: callers validate job pointers, dimensions, and
+                    // disjoint outputs. The heuristic keeps OpenBLAS
+                    // gemm_batch on the small-job regime measured to win.
+                    unsafe { $batch(alpha, beta, batches) }
+                } else {
+                    // SAFETY: same grouped-GEMM contract, executed through the
+                    // existing per-job BLAS path for larger jobs.
+                    unsafe { grouped_gemm_sequential(alpha, beta, batches) }
+                }
             }
         }
     };
@@ -768,7 +902,16 @@ macro_rules! impl_complex_blas_gemm {
                 if batches.is_empty() {
                     return Ok(true);
                 }
-                unsafe { $batch(alpha, beta, batches) }
+                if openblas_should_use_gemm_batch(batches) {
+                    // SAFETY: callers validate job pointers, dimensions, and
+                    // disjoint outputs. The heuristic keeps OpenBLAS
+                    // gemm_batch on the small-job regime measured to win.
+                    unsafe { $batch(alpha, beta, batches) }
+                } else {
+                    // SAFETY: same grouped-GEMM contract, executed through the
+                    // existing per-job BLAS path for larger jobs.
+                    unsafe { grouped_gemm_sequential(alpha, beta, batches) }
+                }
             }
         }
     };

--- a/crates/tenferro-cpu/src/gemm/faer_gemm.rs
+++ b/crates/tenferro-cpu/src/gemm/faer_gemm.rs
@@ -48,14 +48,60 @@ pub(crate) trait FaerGemm: Sized {
         c_ptr: *mut Self,
         c_rs: isize,
         c_cs: isize,
+    ) {
+        unsafe {
+            Self::strided_gemm_with_conj_par(
+                ctx,
+                ctx.faer_par(),
+                alpha,
+                a_ptr,
+                m,
+                k,
+                a_rs,
+                a_cs,
+                conj_a,
+                b_ptr,
+                n,
+                b_rs,
+                b_cs,
+                conj_b,
+                beta,
+                c_ptr,
+                c_rs,
+                c_cs,
+            )
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn strided_gemm_with_conj_par(
+        ctx: &CpuContext,
+        par: faer::Par,
+        alpha: Self,
+        a_ptr: *const Self,
+        m: usize,
+        k: usize,
+        a_rs: isize,
+        a_cs: isize,
+        conj_a: bool,
+        b_ptr: *const Self,
+        n: usize,
+        b_rs: isize,
+        b_cs: isize,
+        conj_b: bool,
+        beta: Self,
+        c_ptr: *mut Self,
+        c_rs: isize,
+        c_cs: isize,
     );
 }
 
 macro_rules! impl_faer_gemm {
     ($ty:ty) => {
         impl FaerGemm for $ty {
-            unsafe fn strided_gemm_with_conj(
+            unsafe fn strided_gemm_with_conj_par(
                 ctx: &CpuContext,
+                par: faer::Par,
                 alpha: $ty,
                 a_ptr: *const $ty,
                 m: usize,
@@ -73,6 +119,7 @@ macro_rules! impl_faer_gemm {
                 c_rs: isize,
                 c_cs: isize,
             ) {
+                let _ = ctx;
                 use faer::{Accum, Conj, MatMut, MatRef};
                 let a_rs = super::normalize_singleton_stride(a_rs, m, k);
                 let a_cs = super::normalize_singleton_stride(a_cs, k, m);
@@ -110,14 +157,7 @@ macro_rules! impl_faer_gemm {
                 let conj_a = if conj_a { Conj::Yes } else { Conj::No };
                 let conj_b = if conj_b { Conj::Yes } else { Conj::No };
                 faer::linalg::matmul::matmul_with_conj(
-                    &mut c_mat,
-                    accum,
-                    &a_mat,
-                    conj_a,
-                    &b_mat,
-                    conj_b,
-                    alpha,
-                    ctx.faer_par(),
+                    &mut c_mat, accum, &a_mat, conj_a, &b_mat, conj_b, alpha, par,
                 );
             }
         }

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -11,6 +11,9 @@ use crate::structural::typed_transpose_with_pool;
 #[cfg(feature = "cpu-blas")]
 use crate::ConjElem;
 use crate::{Error, Result};
+#[cfg(feature = "cpu-faer")]
+use rayon::prelude::*;
+use tenferro_tensor::backend::GroupedGemmConfig;
 use tenferro_tensor::{
     col_major_strides, Buffer, TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensor,
     TypedTensorView, TypedTensorViewMut,
@@ -27,6 +30,8 @@ mod strided_dot;
 
 #[cfg(feature = "cpu-blas")]
 use blas_gemm::BlasGemm;
+#[cfg(feature = "cpu-blas")]
+use blas_gemm::BlasGemmBatch;
 #[cfg(feature = "cpu-faer")]
 use faer_gemm::FaerGemm;
 
@@ -624,6 +629,47 @@ fn dim_to_isize(dim: usize, context: &'static str) -> Result<isize> {
         op: OP,
         message: format!("{context}: dimension {dim} does not fit in isize"),
     })
+}
+
+fn add_job_offset(base: isize, offset: usize, role: &'static str) -> Result<isize> {
+    let offset = isize::try_from(offset).map_err(|_| Error::InvalidConfig {
+        op: "grouped_gemm",
+        message: format!("{role} offset {offset} does not fit in isize"),
+    })?;
+    base.checked_add(offset)
+        .ok_or_else(|| Error::InvalidConfig {
+            op: "grouped_gemm",
+            message: format!("{role} offset overflows isize: base={base} offset={offset}"),
+        })
+}
+
+fn scale_grouped_empty_output<T>(
+    c_ptr: *mut T,
+    rows: usize,
+    cols: usize,
+    beta: T,
+) -> crate::Result<()>
+where
+    T: Copy + Zero + PartialEq + std::ops::Mul<Output = T>,
+{
+    if rows == 0 || cols == 0 {
+        return Ok(());
+    }
+    let beta_is_zero = beta == T::zero();
+    for col in 0..cols {
+        let col_offset = col.checked_mul(rows).ok_or_else(|| Error::InvalidConfig {
+            op: "grouped_gemm",
+            message: format!("output column offset overflows usize: col={col} rows={rows}"),
+        })?;
+        for row in 0..rows {
+            let offset = col_offset + row;
+            unsafe {
+                let dst = c_ptr.add(offset);
+                *dst = if beta_is_zero { T::zero() } else { beta * *dst };
+            }
+        }
+    }
+    Ok(())
 }
 
 fn stride_sort_order(strides: &[isize]) -> SmallVec<[usize; 8]> {
@@ -1342,6 +1388,168 @@ pub(crate) fn dot_general_faer_read_into_accum_cached(
 }
 
 #[cfg(feature = "cpu-faer")]
+pub(crate) fn grouped_gemm_faer_cached(
+    ctx: &crate::CpuContext,
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+    config: &GroupedGemmConfig<'_>,
+    out: &mut TensorWrite<'_>,
+) -> crate::Result<bool> {
+    macro_rules! dispatch {
+        ($owned:ident, $view:ident) => {
+            if let (ContractionScalar::$owned(alpha), ContractionScalar::$owned(beta)) =
+                (config.accumulation().alpha, config.accumulation().beta)
+            {
+                match (&lhs, &rhs, &mut *out) {
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return grouped_gemm_faer_typed(ctx, a, b, config, alpha, beta, &mut c);
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return grouped_gemm_faer_typed(ctx, a, b, config, alpha, beta, &mut c);
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return grouped_gemm_faer_typed(ctx, a, b, config, alpha, beta, &mut c);
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return grouped_gemm_faer_typed(ctx, a, b, config, alpha, beta, &mut c);
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => return grouped_gemm_faer_typed(ctx, a, b, config, alpha, beta, c),
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => return grouped_gemm_faer_typed(ctx, a, b, config, alpha, beta, c),
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => return grouped_gemm_faer_typed(ctx, a, b, config, alpha, beta, c),
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => return grouped_gemm_faer_typed(ctx, a, b, config, alpha, beta, c),
+                    _ => {}
+                }
+            }
+        };
+    }
+
+    dispatch!(F32, F32);
+    dispatch!(F64, F64);
+    dispatch!(C32, C32);
+    dispatch!(C64, C64);
+    Ok(false)
+}
+
+#[cfg(feature = "cpu-faer")]
+fn grouped_gemm_faer_typed<L, R, T>(
+    ctx: &crate::CpuContext,
+    lhs: &L,
+    rhs: &R,
+    config: &GroupedGemmConfig<'_>,
+    alpha: T,
+    beta: T,
+    out: &mut TypedTensorViewMut<'_, T>,
+) -> crate::Result<bool>
+where
+    L: TypedTensorRead<T> + Sync,
+    R: TypedTensorRead<T> + Sync,
+    T: FaerGemm
+        + Copy
+        + Clone
+        + Zero
+        + PartialEq
+        + std::ops::Mul<Output = T>
+        + Send
+        + Sync
+        + 'static,
+{
+    let Some(a_data) = lhs.host_data_opt()?.map(<[T]>::as_ptr) else {
+        return Ok(false);
+    };
+    let Some(b_data) = rhs.host_data_opt()?.map(<[T]>::as_ptr) else {
+        return Ok(false);
+    };
+    let a_base = lhs.offset();
+    let b_base = rhs.offset();
+    let c_base = out.offset();
+    let c_data = out.host_storage_mut()?.as_mut_ptr();
+    let a_addr = a_data as usize;
+    let b_addr = b_data as usize;
+    let c_addr = c_data as usize;
+    let run_job = |job: &tenferro_tensor::backend::GroupedGemmJob| -> crate::Result<()> {
+        let a_ptr =
+            (a_addr as *const T).wrapping_offset(add_job_offset(a_base, job.lhs_offset(), "lhs")?);
+        let b_ptr =
+            (b_addr as *const T).wrapping_offset(add_job_offset(b_base, job.rhs_offset(), "rhs")?);
+        let c_ptr =
+            (c_addr as *mut T).wrapping_offset(add_job_offset(c_base, job.out_offset(), "out")?);
+        if job.rows() == 0 || job.cols() == 0 || job.contracted() == 0 {
+            return scale_grouped_empty_output(c_ptr, job.rows(), job.cols(), beta);
+        }
+        let rows = dim_to_isize(job.rows(), "grouped_gemm rows")?;
+        let contracted = dim_to_isize(job.contracted(), "grouped_gemm contracted")?;
+        unsafe {
+            T::strided_gemm_with_conj_par(
+                ctx,
+                ctx.faer_seq(),
+                alpha,
+                a_ptr,
+                job.rows(),
+                job.contracted(),
+                1,
+                rows,
+                config.accumulation().lhs_conj,
+                b_ptr,
+                job.cols(),
+                1,
+                contracted,
+                config.accumulation().rhs_conj,
+                beta,
+                c_ptr,
+                1,
+                rows,
+            );
+        }
+        Ok(())
+    };
+
+    if ctx.num_threads() > 1 && config.jobs().len() > 1 {
+        config.jobs().par_iter().try_for_each(run_job)?;
+    } else {
+        for job in config.jobs() {
+            run_job(job)?;
+        }
+    }
+    Ok(true)
+}
+
+#[cfg(feature = "cpu-faer")]
 fn dot_general_faer_into_typed<L, R, T>(
     lhs: &L,
     rhs: &R,
@@ -1941,6 +2149,144 @@ pub(crate) fn dot_general_blas_read_into_accum_cached(
     dispatch!(C32, C32);
     dispatch!(C64, C64);
     Ok(false)
+}
+
+#[cfg(feature = "cpu-blas")]
+pub(crate) fn grouped_gemm_blas_cached(
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+    config: &GroupedGemmConfig<'_>,
+    out: &mut TensorWrite<'_>,
+) -> crate::Result<bool> {
+    macro_rules! dispatch {
+        ($owned:ident, $view:ident) => {
+            if let (ContractionScalar::$owned(alpha), ContractionScalar::$owned(beta)) =
+                (config.accumulation().alpha, config.accumulation().beta)
+            {
+                match (&lhs, &rhs, &mut *out) {
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return grouped_gemm_blas_typed(a, b, config, alpha, beta, &mut c);
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return grouped_gemm_blas_typed(a, b, config, alpha, beta, &mut c);
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return grouped_gemm_blas_typed(a, b, config, alpha, beta, &mut c);
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return grouped_gemm_blas_typed(a, b, config, alpha, beta, &mut c);
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => return grouped_gemm_blas_typed(a, b, config, alpha, beta, c),
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => return grouped_gemm_blas_typed(a, b, config, alpha, beta, c),
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => return grouped_gemm_blas_typed(a, b, config, alpha, beta, c),
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => return grouped_gemm_blas_typed(a, b, config, alpha, beta, c),
+                    _ => {}
+                }
+            }
+        };
+    }
+
+    dispatch!(F32, F32);
+    dispatch!(F64, F64);
+    dispatch!(C32, C32);
+    dispatch!(C64, C64);
+    Ok(false)
+}
+
+#[cfg(feature = "cpu-blas")]
+fn grouped_gemm_blas_typed<L, R, T>(
+    lhs: &L,
+    rhs: &R,
+    config: &GroupedGemmConfig<'_>,
+    alpha: T,
+    beta: T,
+    out: &mut TypedTensorViewMut<'_, T>,
+) -> crate::Result<bool>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+    T: BlasGemm + Copy + Clone + Zero + PartialEq + std::ops::Mul<Output = T> + 'static,
+{
+    if config.accumulation().lhs_conj || config.accumulation().rhs_conj {
+        return Ok(false);
+    }
+    let Some(a_data) = lhs.host_data_opt()?.map(<[T]>::as_ptr) else {
+        return Ok(false);
+    };
+    let Some(b_data) = rhs.host_data_opt()?.map(<[T]>::as_ptr) else {
+        return Ok(false);
+    };
+    let a_base = lhs.offset();
+    let b_base = rhs.offset();
+    let c_base = out.offset();
+    let c_data = out.host_storage_mut()?.as_mut_ptr();
+
+    let mut batches = Vec::with_capacity(config.jobs().len());
+    for job in config.jobs() {
+        let a_ptr = unsafe { a_data.offset(add_job_offset(a_base, job.lhs_offset(), "lhs")?) };
+        let b_ptr = unsafe { b_data.offset(add_job_offset(b_base, job.rhs_offset(), "rhs")?) };
+        let c_ptr = unsafe { c_data.offset(add_job_offset(c_base, job.out_offset(), "out")?) };
+        if job.rows() == 0 || job.cols() == 0 || job.contracted() == 0 {
+            scale_grouped_empty_output(c_ptr, job.rows(), job.cols(), beta)?;
+            continue;
+        }
+        let rows = dim_to_isize(job.rows(), "grouped_gemm rows")?;
+        let contracted = dim_to_isize(job.contracted(), "grouped_gemm contracted")?;
+        batches.push(BlasGemmBatch {
+            a_ptr,
+            b_ptr,
+            c_ptr,
+            m: job.rows(),
+            n: job.cols(),
+            k: job.contracted(),
+            a_rs: 1,
+            a_cs: rows,
+            b_rs: 1,
+            b_cs: contracted,
+            c_rs: 1,
+            c_cs: rows,
+        });
+    }
+    unsafe {
+        T::grouped_gemm(alpha, beta, &batches)?;
+    }
+    Ok(true)
 }
 
 #[cfg(feature = "cpu-blas")]

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -1502,6 +1502,9 @@ where
     let a_addr = a_data as usize;
     let b_addr = b_data as usize;
     let c_addr = c_data as usize;
+    // Rayon closures cannot capture raw pointers as Sync. Keep only integer
+    // base addresses outside the closure and reconstruct execution-local
+    // pointers after validate_grouped_gemm has checked each job range.
     let run_job = |job: &tenferro_tensor::backend::GroupedGemmJob| -> crate::Result<()> {
         let a_ptr =
             (a_addr as *const T).wrapping_offset(add_job_offset(a_base, job.lhs_offset(), "lhs")?);
@@ -1514,6 +1517,9 @@ where
         }
         let rows = dim_to_isize(job.rows(), "grouped_gemm rows")?;
         let contracted = dim_to_isize(job.contracted(), "grouped_gemm contracted")?;
+        // SAFETY: validate_grouped_gemm checked input/output ranges and output
+        // disjointness before this provider path; child faer calls run
+        // sequentially to avoid nested Rayon fan-out.
         unsafe {
             T::strided_gemm_with_conj_par(
                 ctx,
@@ -1812,6 +1818,9 @@ where
 }
 
 #[cfg(feature = "cpu-blas")]
+// INVARIANT: BLAS conjugation dispatch needs buffer/cache state, operands,
+// dot_general config, and two conjugation flags at the backend boundary.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn dot_general_blas_with_conj_cached<T>(
     buffers: &mut BufferPool,
     cache: &mut GemmAnalysisCache,
@@ -2257,11 +2266,21 @@ where
     let c_base = out.offset();
     let c_data = out.host_storage_mut()?.as_mut_ptr();
 
+    // Raw pointers are execution-local and must not be cached. The job count is
+    // runtime-dependent, so use a reserved Vec rather than a SmallVec threshold
+    // for the contiguous provider descriptor slice.
     let mut batches = Vec::with_capacity(config.jobs().len());
     for job in config.jobs() {
-        let a_ptr = unsafe { a_data.offset(add_job_offset(a_base, job.lhs_offset(), "lhs")?) };
-        let b_ptr = unsafe { b_data.offset(add_job_offset(b_base, job.rhs_offset(), "rhs")?) };
-        let c_ptr = unsafe { c_data.offset(add_job_offset(c_base, job.out_offset(), "out")?) };
+        // SAFETY: validate_grouped_gemm checked each job's range before this
+        // provider path; add_job_offset only combines the checked view base
+        // with the checked element offset.
+        let (a_ptr, b_ptr, c_ptr) = unsafe {
+            (
+                a_data.offset(add_job_offset(a_base, job.lhs_offset(), "lhs")?),
+                b_data.offset(add_job_offset(b_base, job.rhs_offset(), "rhs")?),
+                c_data.offset(add_job_offset(c_base, job.out_offset(), "out")?),
+            )
+        };
         if job.rows() == 0 || job.cols() == 0 || job.contracted() == 0 {
             scale_grouped_empty_output(c_ptr, job.rows(), job.cols(), beta)?;
             continue;
@@ -2283,6 +2302,9 @@ where
             c_cs: rows,
         });
     }
+    // SAFETY: every descriptor uses validated dimensions and output regions are
+    // pairwise-disjoint, so the BLAS provider may run jobs in batch order or as
+    // a native grouped call.
     unsafe {
         T::grouped_gemm(alpha, beta, &batches)?;
     }
@@ -2397,6 +2419,9 @@ where
 }
 
 #[cfg(feature = "cpu-blas")]
+// INVARIANT: typed BLAS conjugation needs the cache slot/kind, validated
+// operand views, dot_general config, and conjugation flags together.
+#[allow(clippy::too_many_arguments)]
 fn typed_blas_gemm_with_conj<L, R, T>(
     buffers: &mut BufferPool,
     cache: &mut GemmAnalysisCache,

--- a/crates/tenferro-cpu/src/gemm/tests.rs
+++ b/crates/tenferro-cpu/src/gemm/tests.rs
@@ -3,8 +3,10 @@ use super::{
     try_fuse_dims, GemmAnalysisCache, GemmAnalysisCacheKind,
 };
 
+#[cfg(feature = "blas-openblas")]
+use super::blas_gemm::openblas_should_use_gemm_batch;
 #[cfg(feature = "cpu-blas")]
-use super::blas_gemm::BlasGemm;
+use super::blas_gemm::{BlasGemm, BlasGemmBatch};
 #[cfg(feature = "cpu-blas")]
 use super::dot_general_blas_cached;
 #[cfg(feature = "cpu-faer")]
@@ -412,6 +414,37 @@ fn blas_complex_conj_no_trans_reports_materialization_needed() {
 
     assert!(!executed);
     assert_eq!(c, [Complex64::new(0.0, 0.0); 4]);
+}
+
+#[cfg(feature = "blas-openblas")]
+#[test]
+fn openblas_gemm_batch_heuristic_keeps_medium_jobs_on_sequential_path() {
+    fn batch(m: usize, n: usize, k: usize) -> BlasGemmBatch<f64> {
+        BlasGemmBatch {
+            a_ptr: std::ptr::null(),
+            b_ptr: std::ptr::null(),
+            c_ptr: std::ptr::null_mut(),
+            m,
+            n,
+            k,
+            a_rs: 1,
+            a_cs: m as isize,
+            b_rs: 1,
+            b_cs: k as isize,
+            c_rs: 1,
+            c_cs: m as isize,
+        }
+    }
+
+    assert!(openblas_should_use_gemm_batch(&[
+        batch(8, 8, 8),
+        batch(8, 8, 8)
+    ]));
+    assert!(!openblas_should_use_gemm_batch(&[batch(8, 8, 8)]));
+    assert!(!openblas_should_use_gemm_batch(&[
+        batch(8, 8, 8),
+        batch(32, 32, 32)
+    ]));
 }
 
 #[cfg(feature = "cpu-faer")]

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -16,6 +16,7 @@ use crate::{
     reduce_min, reduce_prod, reduce_sum, reshape, scatter, select, sign, transpose, tril, triu,
     typed_array_uninit_from_pool, CpuBackend, CpuContext, Error,
 };
+use tenferro_tensor::backend::{GroupedGemmConfig, GroupedGemmJob};
 #[cfg(feature = "cpu-blas")]
 use tenferro_tensor::StridedSliceSpec;
 use tenferro_tensor::{
@@ -137,6 +138,346 @@ fn conjugate_transpose_c64(mat: &[Complex64], rows: usize, cols: usize) -> Vec<C
         }
     }
     out
+}
+
+fn grouped_gemm_reference_f64(
+    lhs: &[f64],
+    rhs: &[f64],
+    out: &mut [f64],
+    job: GroupedGemmJob,
+    alpha: f64,
+    beta: f64,
+) {
+    for col in 0..job.cols() {
+        for row in 0..job.rows() {
+            let mut acc = 0.0;
+            for kk in 0..job.contracted() {
+                let a = lhs[job.lhs_offset() + row + kk * job.rows()];
+                let b = rhs[job.rhs_offset() + kk + col * job.contracted()];
+                acc += a * b;
+            }
+            let out_idx = job.out_offset() + row + col * job.rows();
+            out[out_idx] = alpha * acc + beta * out[out_idx];
+        }
+    }
+}
+
+fn grouped_gemm_reference_c64(
+    lhs: &[Complex64],
+    rhs: &[Complex64],
+    out: &mut [Complex64],
+    job: GroupedGemmJob,
+    alpha: Complex64,
+    beta: Complex64,
+) {
+    for col in 0..job.cols() {
+        for row in 0..job.rows() {
+            let mut acc = Complex64::new(0.0, 0.0);
+            for kk in 0..job.contracted() {
+                let a = lhs[job.lhs_offset() + row + kk * job.rows()];
+                let b = rhs[job.rhs_offset() + kk + col * job.contracted()];
+                acc += a * b;
+            }
+            let out_idx = job.out_offset() + row + col * job.rows();
+            out[out_idx] = alpha * acc + beta * out[out_idx];
+        }
+    }
+}
+
+fn grouped_gemm_reference_f32(
+    lhs: &[f32],
+    rhs: &[f32],
+    out: &mut [f32],
+    job: GroupedGemmJob,
+    alpha: f32,
+    beta: f32,
+) {
+    for col in 0..job.cols() {
+        for row in 0..job.rows() {
+            let mut acc = 0.0;
+            for kk in 0..job.contracted() {
+                let a = lhs[job.lhs_offset() + row + kk * job.rows()];
+                let b = rhs[job.rhs_offset() + kk + col * job.contracted()];
+                acc += a * b;
+            }
+            let out_idx = job.out_offset() + row + col * job.rows();
+            out[out_idx] = alpha * acc + beta * out[out_idx];
+        }
+    }
+}
+
+fn grouped_gemm_reference_c32(
+    lhs: &[Complex32],
+    rhs: &[Complex32],
+    out: &mut [Complex32],
+    job: GroupedGemmJob,
+    alpha: Complex32,
+    beta: Complex32,
+) {
+    for col in 0..job.cols() {
+        for row in 0..job.rows() {
+            let mut acc = Complex32::new(0.0, 0.0);
+            for kk in 0..job.contracted() {
+                let a = lhs[job.lhs_offset() + row + kk * job.rows()];
+                let b = rhs[job.rhs_offset() + kk + col * job.contracted()];
+                acc += a * b;
+            }
+            let out_idx = job.out_offset() + row + col * job.rows();
+            out[out_idx] = alpha * acc + beta * out[out_idx];
+        }
+    }
+}
+
+#[test]
+fn grouped_gemm_shared_buffers_f64_matches_sequential_reference() {
+    let lhs_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+    let rhs_data = vec![1.0, -1.0, 2.0, 3.0, 0.5, 4.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
+    let out_initial = vec![10.0; 7];
+    let jobs = [
+        GroupedGemmJob::new(0, 0, 0, 2, 3, 2),
+        GroupedGemmJob::new(4, 6, 6, 1, 2, 3),
+    ];
+    let mut expected = out_initial.clone();
+    for job in jobs {
+        grouped_gemm_reference_f64(&lhs_data, &rhs_data, &mut expected, job, 2.0, 3.0);
+    }
+
+    let lhs = Tensor::from_vec_col_major(vec![lhs_data.len()], lhs_data).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![rhs_data.len()], rhs_data).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![out_initial.len()], out_initial).unwrap();
+    let accumulation = DotGeneralAccumulation {
+        lhs_conj: false,
+        rhs_conj: false,
+        alpha: ContractionScalar::F64(2.0),
+        beta: ContractionScalar::F64(3.0),
+    };
+    let config = GroupedGemmConfig::new(&jobs, accumulation);
+    let mut backend = CpuBackend::new();
+    let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
+
+    BackendCachedDot::grouped_gemm_cached(
+        &mut backend,
+        &mut cache,
+        Some(0),
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &config,
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+
+    assert_eq!(out.as_slice::<f64>().unwrap(), expected.as_slice());
+}
+
+#[test]
+fn grouped_gemm_shared_buffers_c64_matches_sequential_reference() {
+    let lhs_data = vec![
+        Complex64::new(1.0, 1.0),
+        Complex64::new(2.0, -1.0),
+        Complex64::new(3.0, 0.5),
+        Complex64::new(4.0, -0.5),
+    ];
+    let rhs_data = vec![
+        Complex64::new(1.0, 0.0),
+        Complex64::new(0.0, 1.0),
+        Complex64::new(2.0, -1.0),
+        Complex64::new(-1.0, 2.0),
+    ];
+    let out_initial = vec![Complex64::new(1.0, -1.0); 4];
+    let jobs = [GroupedGemmJob::new(0, 0, 0, 2, 2, 2)];
+    let alpha = Complex64::new(0.5, 1.0);
+    let beta = Complex64::new(-1.0, 0.25);
+    let mut expected = out_initial.clone();
+    grouped_gemm_reference_c64(&lhs_data, &rhs_data, &mut expected, jobs[0], alpha, beta);
+
+    let lhs = Tensor::from_vec_col_major(vec![lhs_data.len()], lhs_data).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![rhs_data.len()], rhs_data).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![out_initial.len()], out_initial).unwrap();
+    let config = GroupedGemmConfig::new(
+        &jobs,
+        DotGeneralAccumulation {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::C64(alpha),
+            beta: ContractionScalar::C64(beta),
+        },
+    );
+    let mut backend = CpuBackend::new();
+    let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
+
+    BackendCachedDot::grouped_gemm_cached(
+        &mut backend,
+        &mut cache,
+        None,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &config,
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+
+    for (actual, expected) in out.as_slice::<Complex64>().unwrap().iter().zip(expected) {
+        assert_c64_close_tol(*actual, expected, 1.0e-10);
+    }
+}
+
+#[test]
+fn grouped_gemm_covers_f32_and_c32() {
+    let f32_job = GroupedGemmJob::new(0, 0, 0, 2, 2, 2);
+    let f32_lhs = vec![1.0_f32, 2.0, 3.0, 4.0];
+    let f32_rhs = vec![5.0_f32, 6.0, 7.0, 8.0];
+    let f32_initial = vec![1.0_f32; 4];
+    let mut f32_expected = f32_initial.clone();
+    grouped_gemm_reference_f32(&f32_lhs, &f32_rhs, &mut f32_expected, f32_job, 0.5, 2.0);
+    let lhs = Tensor::from_vec_col_major(vec![4], f32_lhs).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![4], f32_rhs).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![4], f32_initial).unwrap();
+    let f32_jobs = [f32_job];
+    let config = GroupedGemmConfig::new(
+        &f32_jobs,
+        DotGeneralAccumulation {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::F32(0.5),
+            beta: ContractionScalar::F32(2.0),
+        },
+    );
+    let mut backend = CpuBackend::new();
+    let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
+    BackendCachedDot::grouped_gemm_cached(
+        &mut backend,
+        &mut cache,
+        None,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &config,
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+    for (actual, expected) in out.as_slice::<f32>().unwrap().iter().zip(f32_expected) {
+        assert!((*actual - expected).abs() < 1.0e-5);
+    }
+
+    let c32_job = GroupedGemmJob::new(0, 0, 0, 1, 2, 2);
+    let c32_lhs = vec![Complex32::new(1.0, 1.0), Complex32::new(2.0, -1.0)];
+    let c32_rhs = vec![
+        Complex32::new(0.0, 1.0),
+        Complex32::new(1.0, 0.0),
+        Complex32::new(2.0, 1.0),
+        Complex32::new(-1.0, 0.5),
+    ];
+    let c32_initial = vec![Complex32::new(0.5, -0.5); 2];
+    let alpha = Complex32::new(1.0, -0.25);
+    let beta = Complex32::new(0.25, 0.5);
+    let mut c32_expected = c32_initial.clone();
+    grouped_gemm_reference_c32(&c32_lhs, &c32_rhs, &mut c32_expected, c32_job, alpha, beta);
+    let lhs = Tensor::from_vec_col_major(vec![2], c32_lhs).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![4], c32_rhs).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![2], c32_initial).unwrap();
+    let c32_jobs = [c32_job];
+    let config = GroupedGemmConfig::new(
+        &c32_jobs,
+        DotGeneralAccumulation {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::C32(alpha),
+            beta: ContractionScalar::C32(beta),
+        },
+    );
+    BackendCachedDot::grouped_gemm_cached(
+        &mut backend,
+        &mut cache,
+        None,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &config,
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+    for (actual, expected) in out
+        .as_slice::<Complex32>()
+        .unwrap()
+        .iter()
+        .zip(c32_expected)
+    {
+        assert!((actual.re - expected.re).abs() < 1.0e-5);
+        assert!((actual.im - expected.im).abs() < 1.0e-5);
+    }
+}
+
+#[test]
+fn grouped_gemm_rejects_overlapping_output_ranges() {
+    let lhs = Tensor::from_vec_col_major(vec![8], vec![1.0_f64; 8]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![8], vec![1.0_f64; 8]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![8], vec![0.0_f64; 8]).unwrap();
+    let jobs = [
+        GroupedGemmJob::new(0, 0, 0, 2, 2, 2),
+        GroupedGemmJob::new(2, 4, 4, 2, 2, 2),
+    ];
+    let config = GroupedGemmConfig::new(
+        &jobs,
+        DotGeneralAccumulation::overwrite(DType::F64).unwrap(),
+    );
+    let mut backend = CpuBackend::new();
+    let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
+    let err = BackendCachedDot::grouped_gemm_cached(
+        &mut backend,
+        &mut cache,
+        None,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &config,
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap_err();
+    assert!(format!("{err}").contains("overlaps"));
+}
+
+#[test]
+fn grouped_gemm_zero_jobs_is_noop_and_empty_contract_scales_output() {
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![4], vec![2.0_f64, 3.0, 4.0, 5.0]).unwrap();
+    let mut backend = CpuBackend::new();
+    let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
+    let no_jobs: [GroupedGemmJob; 0] = [];
+    let noop = GroupedGemmConfig::new(
+        &no_jobs,
+        DotGeneralAccumulation::overwrite(DType::F64).unwrap(),
+    );
+    BackendCachedDot::grouped_gemm_cached(
+        &mut backend,
+        &mut cache,
+        None,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &noop,
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[2.0, 3.0, 4.0, 5.0]);
+
+    let empty_jobs = [GroupedGemmJob::new(0, 0, 0, 2, 0, 2)];
+    let scale = GroupedGemmConfig::new(
+        &empty_jobs,
+        DotGeneralAccumulation {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::F64(1.0),
+            beta: ContractionScalar::F64(3.0),
+        },
+    );
+    BackendCachedDot::grouped_gemm_cached(
+        &mut backend,
+        &mut cache,
+        None,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &scale,
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[6.0, 9.0, 12.0, 15.0]);
 }
 
 #[test]

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -1,7 +1,9 @@
 use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use crate::types::{TensorRank, TypedTensor, TypedTensorView, TypedTensorViewMut};
+use crate::types::{
+    Buffer, TensorRank, TensorView, TensorViewMut, TypedTensor, TypedTensorView, TypedTensorViewMut,
+};
 use crate::validate::validate_convert_dtype;
 use crate::{DType, RuntimeCacheControl, Tensor, TensorRead, TensorValue, TensorWrite};
 use num_complex::{Complex32, Complex64};
@@ -292,6 +294,90 @@ pub struct DotGeneralAccumulation {
     pub beta: ContractionScalar,
 }
 
+/// One matrix multiply in a grouped GEMM over shared flat buffers.
+///
+/// Offsets are element offsets into the corresponding shared lhs, rhs, and
+/// output buffers. Each job computes a column-major `rows x cols` output block
+/// from a column-major `rows x contracted` lhs block and a column-major
+/// `contracted x cols` rhs block.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct GroupedGemmJob {
+    out_offset: usize,
+    lhs_offset: usize,
+    rhs_offset: usize,
+    rows: usize,
+    contracted: usize,
+    cols: usize,
+}
+
+impl GroupedGemmJob {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        out_offset: usize,
+        lhs_offset: usize,
+        rhs_offset: usize,
+        rows: usize,
+        contracted: usize,
+        cols: usize,
+    ) -> Self {
+        Self {
+            out_offset,
+            lhs_offset,
+            rhs_offset,
+            rows,
+            contracted,
+            cols,
+        }
+    }
+
+    pub fn out_offset(&self) -> usize {
+        self.out_offset
+    }
+
+    pub fn lhs_offset(&self) -> usize {
+        self.lhs_offset
+    }
+
+    pub fn rhs_offset(&self) -> usize {
+        self.rhs_offset
+    }
+
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    pub fn contracted(&self) -> usize {
+        self.contracted
+    }
+
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+}
+
+/// Shared scalar/update metadata for grouped GEMM execution.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct GroupedGemmConfig<'a> {
+    jobs: &'a [GroupedGemmJob],
+    accumulation: DotGeneralAccumulation,
+}
+
+impl<'a> GroupedGemmConfig<'a> {
+    pub fn new(jobs: &'a [GroupedGemmJob], accumulation: DotGeneralAccumulation) -> Self {
+        Self { jobs, accumulation }
+    }
+
+    pub fn jobs(&self) -> &'a [GroupedGemmJob] {
+        self.jobs
+    }
+
+    pub fn accumulation(&self) -> DotGeneralAccumulation {
+        self.accumulation
+    }
+}
+
 impl DotGeneralAccumulation {
     /// Return overwrite semantics, `out = lhs dot rhs`, for `dtype`.
     pub fn overwrite(dtype: DType) -> crate::Result<Self> {
@@ -349,6 +435,449 @@ pub fn dot_general_accum_via_temp<B: TensorDot + ?Sized>(
         accumulation.rhs_conj,
     )?;
     accumulate_dot_result_into(&dot, accumulation, &mut out)
+}
+
+fn grouped_checked_product(
+    op: &'static str,
+    role: &'static str,
+    dims: &[usize],
+) -> crate::Result<usize> {
+    dims.iter().try_fold(1usize, |acc, &dim| {
+        acc.checked_mul(dim)
+            .ok_or_else(|| crate::Error::InvalidConfig {
+                op,
+                message: format!("{role} logical element count overflows usize for shape {dims:?}"),
+            })
+    })
+}
+
+fn checked_gemm_span(
+    op: &'static str,
+    role: &'static str,
+    offset: usize,
+    rows: usize,
+    cols: usize,
+) -> crate::Result<Option<std::ops::Range<usize>>> {
+    let len = rows
+        .checked_mul(cols)
+        .ok_or_else(|| crate::Error::InvalidConfig {
+            op,
+            message: format!(
+                "{role} matrix element count overflows usize: rows={rows} cols={cols}"
+            ),
+        })?;
+    if len == 0 {
+        return Ok(None);
+    }
+    let end = offset
+        .checked_add(len)
+        .ok_or_else(|| crate::Error::InvalidConfig {
+            op,
+            message: format!("{role} matrix range overflows usize: offset={offset} len={len}"),
+        })?;
+    Ok(Some(offset..end))
+}
+
+fn validate_grouped_gemm_range(
+    op: &'static str,
+    role: &'static str,
+    len: usize,
+    range: Option<std::ops::Range<usize>>,
+) -> crate::Result<()> {
+    let Some(range) = range else {
+        return Ok(());
+    };
+    if range.end > len {
+        return Err(crate::Error::InvalidConfig {
+            op,
+            message: format!(
+                "{role} matrix range {}..{} exceeds shared buffer logical length {len}",
+                range.start, range.end
+            ),
+        });
+    }
+    Ok(())
+}
+
+#[doc(hidden)]
+pub fn validate_grouped_gemm(
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
+    out: &TensorWrite<'_>,
+    config: &GroupedGemmConfig<'_>,
+    op: &'static str,
+) -> crate::Result<()> {
+    if lhs.dtype() != rhs.dtype() {
+        return Err(crate::Error::DTypeMismatch {
+            op,
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        });
+    }
+    if lhs.dtype() != out.dtype() {
+        return Err(crate::Error::DTypeMismatch {
+            op,
+            lhs: lhs.dtype(),
+            rhs: out.dtype(),
+        });
+    }
+    config.accumulation.validate_for_dtype(lhs.dtype())?;
+
+    let lhs_len = grouped_checked_product(op, "lhs", lhs.shape())?;
+    let rhs_len = grouped_checked_product(op, "rhs", rhs.shape())?;
+    let out_len = grouped_checked_product(op, "out", out.shape())?;
+    let mut out_ranges = Vec::<std::ops::Range<usize>>::new();
+    for (idx, job) in config.jobs.iter().enumerate() {
+        validate_grouped_gemm_range(
+            op,
+            "lhs",
+            lhs_len,
+            checked_gemm_span(op, "lhs", job.lhs_offset, job.rows, job.contracted)?,
+        )?;
+        validate_grouped_gemm_range(
+            op,
+            "rhs",
+            rhs_len,
+            checked_gemm_span(op, "rhs", job.rhs_offset, job.contracted, job.cols)?,
+        )?;
+        let out_range = checked_gemm_span(op, "out", job.out_offset, job.rows, job.cols)?;
+        validate_grouped_gemm_range(op, "out", out_len, out_range.clone())?;
+        if let Some(out_range) = out_range {
+            for previous in &out_ranges {
+                if previous.start < out_range.end && out_range.start < previous.end {
+                    return Err(crate::Error::InvalidConfig {
+                        op,
+                        message: format!(
+                            "grouped GEMM output range for job {idx} overlaps previous range {}..{}",
+                            previous.start, previous.end
+                        ),
+                    });
+                }
+            }
+            out_ranges.push(out_range);
+        }
+    }
+    Ok(())
+}
+
+fn add_element_offsets(
+    op: &'static str,
+    base: isize,
+    offset: usize,
+    role: &'static str,
+) -> crate::Result<isize> {
+    let offset = isize::try_from(offset).map_err(|_| crate::Error::InvalidConfig {
+        op,
+        message: format!("{role} offset {offset} does not fit in isize"),
+    })?;
+    base.checked_add(offset)
+        .ok_or_else(|| crate::Error::InvalidConfig {
+            op,
+            message: format!("{role} offset overflows isize: base={base} offset={offset}"),
+        })
+}
+
+fn dim_stride(op: &'static str, dim: usize, role: &'static str) -> crate::Result<isize> {
+    isize::try_from(dim).map_err(|_| crate::Error::InvalidConfig {
+        op,
+        message: format!("{role} leading dimension {dim} does not fit in isize"),
+    })
+}
+
+fn typed_read_storage<'a, T>(
+    tensor: &'a TypedTensor<T>,
+    op: &'static str,
+) -> crate::Result<(&'a [T], isize)> {
+    match tensor.buffer() {
+        Buffer::Host(data) => Ok((data, 0)),
+        Buffer::Backend(_) => Err(crate::Error::backend_failure(
+            op,
+            "grouped GEMM default path requires host-backed tensor storage",
+        )),
+    }
+}
+
+fn grouped_gemm_default_config() -> DotGeneralConfig {
+    DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: Vec::new(),
+        rhs_batch_dims: Vec::new(),
+    }
+}
+
+trait GroupedGemmDType<T> {
+    fn wrap_read(view: TypedTensorView<'_, T>) -> TensorView<'_>;
+    fn wrap_write(view: TypedTensorViewMut<'_, T>) -> TensorViewMut<'_>;
+}
+
+struct GroupedF32;
+struct GroupedF64;
+struct GroupedC32;
+struct GroupedC64;
+
+impl GroupedGemmDType<f32> for GroupedF32 {
+    fn wrap_read(view: TypedTensorView<'_, f32>) -> TensorView<'_> {
+        TensorView::F32(view)
+    }
+
+    fn wrap_write(view: TypedTensorViewMut<'_, f32>) -> TensorViewMut<'_> {
+        TensorViewMut::F32(view)
+    }
+}
+
+impl GroupedGemmDType<f64> for GroupedF64 {
+    fn wrap_read(view: TypedTensorView<'_, f64>) -> TensorView<'_> {
+        TensorView::F64(view)
+    }
+
+    fn wrap_write(view: TypedTensorViewMut<'_, f64>) -> TensorViewMut<'_> {
+        TensorViewMut::F64(view)
+    }
+}
+
+impl GroupedGemmDType<Complex32> for GroupedC32 {
+    fn wrap_read(view: TypedTensorView<'_, Complex32>) -> TensorView<'_> {
+        TensorView::C32(view)
+    }
+
+    fn wrap_write(view: TypedTensorViewMut<'_, Complex32>) -> TensorViewMut<'_> {
+        TensorViewMut::C32(view)
+    }
+}
+
+impl GroupedGemmDType<Complex64> for GroupedC64 {
+    fn wrap_read(view: TypedTensorView<'_, Complex64>) -> TensorView<'_> {
+        TensorView::C64(view)
+    }
+
+    fn wrap_write(view: TypedTensorViewMut<'_, Complex64>) -> TensorViewMut<'_> {
+        TensorViewMut::C64(view)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn grouped_gemm_default_loop<B, T, V>(
+    backend: &mut B,
+    lhs_data: &[T],
+    lhs_base: isize,
+    rhs_data: &[T],
+    rhs_base: isize,
+    out_view: &mut TypedTensorViewMut<'_, T>,
+    config: &GroupedGemmConfig<'_>,
+) -> crate::Result<()>
+where
+    B: TensorDot + ?Sized,
+    T: 'static,
+    V: GroupedGemmDType<T>,
+{
+    let op = "grouped_gemm";
+    let dot_config = grouped_gemm_default_config();
+    for job in config.jobs {
+        let lhs_offset = add_element_offsets(op, lhs_base, job.lhs_offset, "lhs")?;
+        let rhs_offset = add_element_offsets(op, rhs_base, job.rhs_offset, "rhs")?;
+        let out_offset = add_element_offsets(op, out_view.offset(), job.out_offset, "out")?;
+        let lhs_rows = dim_stride(op, job.rows, "lhs")?;
+        let rhs_rows = dim_stride(op, job.contracted, "rhs")?;
+        let out_rows = dim_stride(op, job.rows, "out")?;
+        let lhs_matrix = TypedTensorView::from_slice(
+            vec![job.rows, job.contracted],
+            vec![1, lhs_rows],
+            lhs_offset,
+            lhs_data,
+        )?;
+        let rhs_matrix = TypedTensorView::from_slice(
+            vec![job.contracted, job.cols],
+            vec![1, rhs_rows],
+            rhs_offset,
+            rhs_data,
+        )?;
+        let out_storage = out_view.host_storage_mut()?;
+        let out_matrix = TypedTensorViewMut::from_slice(
+            vec![job.rows, job.cols],
+            vec![1, out_rows],
+            out_offset,
+            out_storage,
+        )?;
+        backend.dot_general_read_into_accum(
+            TensorRead::from_view(V::wrap_read(lhs_matrix)),
+            TensorRead::from_view(V::wrap_read(rhs_matrix)),
+            &dot_config,
+            config.accumulation,
+            TensorWrite::from_view(V::wrap_write(out_matrix)),
+        )?;
+    }
+    Ok(())
+}
+
+#[doc(hidden)]
+pub fn grouped_gemm_via_sequential<B>(
+    backend: &mut B,
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+    config: &GroupedGemmConfig<'_>,
+    mut out: TensorWrite<'_>,
+) -> crate::Result<()>
+where
+    B: TensorDot + ?Sized,
+{
+    validate_grouped_gemm(&lhs, &rhs, &out, config, "grouped_gemm")?;
+    macro_rules! dispatch {
+        ($variant:ident, $wrapper:ty) => {
+            match (&lhs, &rhs, &mut out) {
+                (
+                    TensorRead::Tensor(Tensor::$variant(a)),
+                    TensorRead::Tensor(Tensor::$variant(b)),
+                    TensorWrite::Tensor(Tensor::$variant(c)),
+                ) => {
+                    let (a_data, a_base) = typed_read_storage(a, "grouped_gemm")?;
+                    let (b_data, b_base) = typed_read_storage(b, "grouped_gemm")?;
+                    let mut c_view = c.as_view_mut();
+                    return grouped_gemm_default_loop::<_, _, $wrapper>(
+                        backend,
+                        a_data,
+                        a_base,
+                        b_data,
+                        b_base,
+                        &mut c_view,
+                        config,
+                    );
+                }
+                (
+                    TensorRead::Tensor(Tensor::$variant(a)),
+                    TensorRead::View(TensorView::$variant(b)),
+                    TensorWrite::Tensor(Tensor::$variant(c)),
+                ) => {
+                    let (a_data, a_base) = typed_read_storage(a, "grouped_gemm")?;
+                    let mut c_view = c.as_view_mut();
+                    return grouped_gemm_default_loop::<_, _, $wrapper>(
+                        backend,
+                        a_data,
+                        a_base,
+                        b.host_storage()?,
+                        b.offset(),
+                        &mut c_view,
+                        config,
+                    );
+                }
+                (
+                    TensorRead::View(TensorView::$variant(a)),
+                    TensorRead::Tensor(Tensor::$variant(b)),
+                    TensorWrite::Tensor(Tensor::$variant(c)),
+                ) => {
+                    let (b_data, b_base) = typed_read_storage(b, "grouped_gemm")?;
+                    let mut c_view = c.as_view_mut();
+                    return grouped_gemm_default_loop::<_, _, $wrapper>(
+                        backend,
+                        a.host_storage()?,
+                        a.offset(),
+                        b_data,
+                        b_base,
+                        &mut c_view,
+                        config,
+                    );
+                }
+                (
+                    TensorRead::View(TensorView::$variant(a)),
+                    TensorRead::View(TensorView::$variant(b)),
+                    TensorWrite::Tensor(Tensor::$variant(c)),
+                ) => {
+                    let mut c_view = c.as_view_mut();
+                    return grouped_gemm_default_loop::<_, _, $wrapper>(
+                        backend,
+                        a.host_storage()?,
+                        a.offset(),
+                        b.host_storage()?,
+                        b.offset(),
+                        &mut c_view,
+                        config,
+                    );
+                }
+                (
+                    TensorRead::Tensor(Tensor::$variant(a)),
+                    TensorRead::Tensor(Tensor::$variant(b)),
+                    TensorWrite::View(TensorViewMut::$variant(c)),
+                ) => {
+                    let (a_data, a_base) = typed_read_storage(a, "grouped_gemm")?;
+                    let (b_data, b_base) = typed_read_storage(b, "grouped_gemm")?;
+                    return grouped_gemm_default_loop::<_, _, $wrapper>(
+                        backend, a_data, a_base, b_data, b_base, c, config,
+                    );
+                }
+                (
+                    TensorRead::Tensor(Tensor::$variant(a)),
+                    TensorRead::View(TensorView::$variant(b)),
+                    TensorWrite::View(TensorViewMut::$variant(c)),
+                ) => {
+                    let (a_data, a_base) = typed_read_storage(a, "grouped_gemm")?;
+                    return grouped_gemm_default_loop::<_, _, $wrapper>(
+                        backend,
+                        a_data,
+                        a_base,
+                        b.host_storage()?,
+                        b.offset(),
+                        c,
+                        config,
+                    );
+                }
+                (
+                    TensorRead::View(TensorView::$variant(a)),
+                    TensorRead::Tensor(Tensor::$variant(b)),
+                    TensorWrite::View(TensorViewMut::$variant(c)),
+                ) => {
+                    let (b_data, b_base) = typed_read_storage(b, "grouped_gemm")?;
+                    return grouped_gemm_default_loop::<_, _, $wrapper>(
+                        backend,
+                        a.host_storage()?,
+                        a.offset(),
+                        b_data,
+                        b_base,
+                        c,
+                        config,
+                    );
+                }
+                (
+                    TensorRead::View(TensorView::$variant(a)),
+                    TensorRead::View(TensorView::$variant(b)),
+                    TensorWrite::View(TensorViewMut::$variant(c)),
+                ) => {
+                    return grouped_gemm_default_loop::<_, _, $wrapper>(
+                        backend,
+                        a.host_storage()?,
+                        a.offset(),
+                        b.host_storage()?,
+                        b.offset(),
+                        c,
+                        config,
+                    );
+                }
+                _ => {}
+            }
+        };
+    }
+
+    dispatch!(F32, GroupedF32);
+    dispatch!(F64, GroupedF64);
+    dispatch!(C32, GroupedC32);
+    dispatch!(C64, GroupedC64);
+    Err(crate::Error::DTypeMismatch {
+        op: "grouped_gemm",
+        lhs: lhs.dtype(),
+        rhs: out.dtype(),
+    })
+}
+
+fn grouped_gemm_default<B>(
+    backend: &mut B,
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+    config: &GroupedGemmConfig<'_>,
+    out: TensorWrite<'_>,
+) -> crate::Result<()>
+where
+    B: TensorDot + ?Sized,
+{
+    grouped_gemm_via_sequential(backend, lhs, rhs, config, out)
 }
 
 fn accumulate_dot_result_into(
@@ -1316,6 +1845,18 @@ pub trait SessionCachedDot: TensorDot {
     ) -> crate::Result<()> {
         self.dot_general_read_into_accum(lhs, rhs, config, accumulation, out)
     }
+
+    #[doc(hidden)]
+    fn grouped_gemm_cached(
+        &mut self,
+        _cache_slot: Option<usize>,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &GroupedGemmConfig<'_>,
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        grouped_gemm_default(self, lhs, rhs, config, out)
+    }
 }
 
 /// Indexing, slicing, and padding operations.
@@ -1598,6 +2139,19 @@ pub trait BackendCachedDot: BackendRuntimeCache + TensorDot {
         out: TensorWrite<'_>,
     ) -> crate::Result<()> {
         self.dot_general_read_into_accum(lhs, rhs, config, accumulation, out)
+    }
+
+    #[doc(hidden)]
+    fn grouped_gemm_cached(
+        &mut self,
+        _cache: &mut Self::RuntimeCache,
+        _cache_slot: Option<usize>,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &GroupedGemmConfig<'_>,
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        grouped_gemm_default(self, lhs, rhs, config, out)
     }
 }
 

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -526,7 +526,11 @@ pub fn validate_grouped_gemm(
     let lhs_len = grouped_checked_product(op, "lhs", lhs.shape())?;
     let rhs_len = grouped_checked_product(op, "rhs", rhs.shape())?;
     let out_len = grouped_checked_product(op, "out", out.shape())?;
-    let mut out_ranges = Vec::<std::ops::Range<usize>>::new();
+    // Grouped GEMM job count is runtime-controlled and can be large. Keep the
+    // validation ranges in a reserved Vec, not SmallVec, so arbitrary batches
+    // avoid inline-capacity tuning and can be sorted for O(n log n) overlap
+    // validation.
+    let mut out_ranges = Vec::<(usize, std::ops::Range<usize>)>::with_capacity(config.jobs.len());
     for (idx, job) in config.jobs.iter().enumerate() {
         validate_grouped_gemm_range(
             op,
@@ -543,18 +547,21 @@ pub fn validate_grouped_gemm(
         let out_range = checked_gemm_span(op, "out", job.out_offset, job.rows, job.cols)?;
         validate_grouped_gemm_range(op, "out", out_len, out_range.clone())?;
         if let Some(out_range) = out_range {
-            for previous in &out_ranges {
-                if previous.start < out_range.end && out_range.start < previous.end {
-                    return Err(crate::Error::InvalidConfig {
-                        op,
-                        message: format!(
-                            "grouped GEMM output range for job {idx} overlaps previous range {}..{}",
-                            previous.start, previous.end
-                        ),
-                    });
-                }
-            }
-            out_ranges.push(out_range);
+            out_ranges.push((idx, out_range));
+        }
+    }
+    out_ranges.sort_unstable_by_key(|(_, range)| range.start);
+    for pair in out_ranges.windows(2) {
+        let (prev_idx, previous) = &pair[0];
+        let (idx, current) = &pair[1];
+        if previous.end > current.start {
+            return Err(crate::Error::InvalidConfig {
+                op,
+                message: format!(
+                    "grouped GEMM output range for job {idx} overlaps job {prev_idx} range {}..{}",
+                    previous.start, previous.end
+                ),
+            });
         }
     }
     Ok(())
@@ -598,6 +605,8 @@ fn typed_read_storage<'a, T>(
 }
 
 fn grouped_gemm_default_config() -> DotGeneralConfig {
+    // DotGeneralConfig owns Vec fields, so this rank-2 fallback config follows
+    // that API boundary rather than introducing SmallVec locally.
     DotGeneralConfig {
         lhs_contracting_dims: vec![1],
         rhs_contracting_dims: vec![0],
@@ -680,6 +689,9 @@ where
         let lhs_rows = dim_stride(op, job.rows, "lhs")?;
         let rhs_rows = dim_stride(op, job.contracted, "rhs")?;
         let out_rows = dim_stride(op, job.rows, "out")?;
+        // TypedTensorView constructors own Vec shape/stride metadata. These
+        // fallback rank-2 views are short-lived, but SmallVec is not usable
+        // without changing the view API.
         let lhs_matrix = TypedTensorView::from_slice(
             vec![job.rows, job.contracted],
             vec![1, lhs_rows],

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -1017,7 +1017,7 @@ fn grouped_gemm_validation_rejects_invalid_metadata() {
         "test_grouped_gemm",
     )
     .unwrap_err();
-    assert!(err.to_string().contains("overlaps previous range"));
+    assert!(err.to_string().contains("overlaps job"));
 
     let overflow_jobs = [GroupedGemmJob::new(0, 0, 0, usize::MAX, 0, 2)];
     let err = validate_grouped_gemm(

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -1,9 +1,11 @@
 use crate::{
+    backend::{validate_grouped_gemm, GroupedGemmConfig, GroupedGemmJob},
     BackendCachedDot, BackendRuntimeCache, BackendSessionHost, CompareDir, ContractionScalar,
     DType, DotGeneralAccumulation, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,
     SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer,
     TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead, TensorReduction,
-    TensorStructural, TensorView, TensorViewMut, TensorWrite, TypedTensor,
+    TensorStructural, TensorView, TensorViewMut, TensorWrite, TypedTensor, TypedTensorView,
+    TypedTensorViewMut,
 };
 use num_complex::{Complex32, Complex64};
 
@@ -666,6 +668,411 @@ fn dot_general_accum_default_fallback_rejects_scalar_dtype_mismatch() {
         .unwrap_err();
 
     assert!(err.to_string().contains("dtype mismatch"));
+}
+
+fn scalar_grouped_config<'a>(jobs: &'a [GroupedGemmJob], dtype: DType) -> GroupedGemmConfig<'a> {
+    GroupedGemmConfig::new(jobs, DotGeneralAccumulation::overwrite(dtype).unwrap())
+}
+
+#[test]
+fn grouped_gemm_job_and_config_metadata_are_preserved() {
+    let job = GroupedGemmJob::new(1, 2, 3, 4, 5, 6);
+
+    assert_eq!(job.out_offset(), 1);
+    assert_eq!(job.lhs_offset(), 2);
+    assert_eq!(job.rhs_offset(), 3);
+    assert_eq!(job.rows(), 4);
+    assert_eq!(job.contracted(), 5);
+    assert_eq!(job.cols(), 6);
+
+    let jobs = [job];
+    let accumulation = DotGeneralAccumulation {
+        lhs_conj: false,
+        rhs_conj: true,
+        alpha: ContractionScalar::F64(2.0),
+        beta: ContractionScalar::F64(3.0),
+    };
+    let config = GroupedGemmConfig::new(&jobs, accumulation);
+
+    assert_eq!(config.jobs(), &jobs);
+    assert_eq!(config.accumulation(), accumulation);
+}
+
+fn run_grouped_f64_default_combo(
+    lhs_as_view: bool,
+    rhs_as_view: bool,
+    out_as_view: bool,
+) -> Vec<f64> {
+    let lhs_tensor = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
+    let rhs_tensor = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
+    let lhs_storage = [0.0_f64, 1.0];
+    let rhs_storage = [0.0_f64, 2.0];
+    let lhs_view =
+        TypedTensorView::from_slice(vec![1], vec![1], 1, lhs_storage.as_slice()).unwrap();
+    let rhs_view =
+        TypedTensorView::from_slice(vec![1], vec![1], 1, rhs_storage.as_slice()).unwrap();
+
+    let lhs_read = if lhs_as_view {
+        TensorRead::from_view(TensorView::F64(lhs_view))
+    } else {
+        TensorRead::from_tensor(&lhs_tensor)
+    };
+    let rhs_read = if rhs_as_view {
+        TensorRead::from_view(TensorView::F64(rhs_view))
+    } else {
+        TensorRead::from_tensor(&rhs_tensor)
+    };
+
+    let jobs = [GroupedGemmJob::new(0, 0, 0, 1, 1, 1)];
+    let config = scalar_grouped_config(&jobs, DType::F64);
+    let mut cache = ();
+    let mut backend = DefaultReadBackend {
+        dot_result: Some(Tensor::from_vec_col_major(vec![1, 1], vec![4.0_f64]).unwrap()),
+        ..Default::default()
+    };
+
+    if out_as_view {
+        let mut out_storage = vec![100.0_f64, 9.0];
+        {
+            let out_view =
+                TypedTensorViewMut::from_slice(vec![1], vec![1], 1, out_storage.as_mut_slice())
+                    .unwrap();
+            BackendCachedDot::grouped_gemm_cached(
+                &mut backend,
+                &mut cache,
+                Some(3),
+                lhs_read,
+                rhs_read,
+                &config,
+                TensorWrite::from_view(TensorViewMut::F64(out_view)),
+            )
+            .unwrap();
+        }
+        out_storage
+    } else {
+        let mut out = Tensor::from_vec_col_major(vec![1], vec![9.0_f64]).unwrap();
+        BackendCachedDot::grouped_gemm_cached(
+            &mut backend,
+            &mut cache,
+            Some(3),
+            lhs_read,
+            rhs_read,
+            &config,
+            TensorWrite::from_tensor(&mut out),
+        )
+        .unwrap();
+        out.as_slice::<f64>().unwrap().to_vec()
+    }
+}
+
+#[test]
+fn grouped_gemm_default_fallback_covers_tensor_and_view_dispatch() {
+    for lhs_as_view in [false, true] {
+        for rhs_as_view in [false, true] {
+            for out_as_view in [false, true] {
+                let values = run_grouped_f64_default_combo(lhs_as_view, rhs_as_view, out_as_view);
+                if out_as_view {
+                    assert_eq!(values, vec![100.0, 4.0]);
+                } else {
+                    assert_eq!(values, vec![4.0]);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn grouped_gemm_default_fallback_updates_shared_buffer_offsets() {
+    let lhs = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![4], vec![10.0_f64, 20.0, 30.0, 40.0]).unwrap();
+    let jobs = [
+        GroupedGemmJob::new(0, 0, 0, 1, 1, 1),
+        GroupedGemmJob::new(2, 2, 2, 1, 1, 1),
+    ];
+    let config = GroupedGemmConfig::new(
+        &jobs,
+        DotGeneralAccumulation {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::F64(2.0),
+            beta: ContractionScalar::F64(0.5),
+        },
+    );
+    let mut cache = ();
+    let mut backend = DefaultReadBackend {
+        dot_result: Some(Tensor::from_vec_col_major(vec![1, 1], vec![4.0_f64]).unwrap()),
+        ..Default::default()
+    };
+
+    BackendCachedDot::grouped_gemm_cached(
+        &mut backend,
+        &mut cache,
+        Some(9),
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &config,
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[13.0, 20.0, 23.0, 40.0]);
+    assert_eq!(
+        backend
+            .calls
+            .iter()
+            .filter(|&&call| call == "dot_general")
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn grouped_gemm_default_fallback_covers_supported_dtypes() {
+    let jobs = [GroupedGemmJob::new(0, 0, 0, 1, 1, 1)];
+    let mut cache = ();
+
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![1.0_f32]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f32]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![1], vec![5.0_f32]).unwrap();
+    let mut backend = DefaultReadBackend {
+        dot_result: Some(Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f32]).unwrap()),
+        ..Default::default()
+    };
+    BackendCachedDot::grouped_gemm_cached(
+        &mut backend,
+        &mut cache,
+        None,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &GroupedGemmConfig::new(
+            &jobs,
+            DotGeneralAccumulation {
+                lhs_conj: false,
+                rhs_conj: false,
+                alpha: ContractionScalar::F32(3.0),
+                beta: ContractionScalar::F32(1.0),
+            },
+        ),
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+    assert_eq!(out.as_slice::<f32>().unwrap(), &[11.0]);
+
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![Complex32::new(1.0, 0.0)]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![Complex32::new(2.0, 0.0)]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![1], vec![Complex32::new(3.0, -1.0)]).unwrap();
+    let mut backend = DefaultReadBackend {
+        dot_result: Some(
+            Tensor::from_vec_col_major(vec![1, 1], vec![Complex32::new(1.0, 1.0)]).unwrap(),
+        ),
+        ..Default::default()
+    };
+    BackendCachedDot::grouped_gemm_cached(
+        &mut backend,
+        &mut cache,
+        None,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &GroupedGemmConfig::new(
+            &jobs,
+            DotGeneralAccumulation {
+                lhs_conj: false,
+                rhs_conj: false,
+                alpha: ContractionScalar::C32(Complex32::new(2.0, 0.0)),
+                beta: ContractionScalar::C32(Complex32::new(0.0, 1.0)),
+            },
+        ),
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+    assert_eq!(
+        out.as_slice::<Complex32>().unwrap(),
+        &[Complex32::new(3.0, 5.0)]
+    );
+
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 0.0)]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![Complex64::new(2.0, 0.0)]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![1], vec![Complex64::new(0.0, 0.0)]).unwrap();
+    let mut backend = DefaultReadBackend {
+        dot_result: Some(
+            Tensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(4.0, -2.0)]).unwrap(),
+        ),
+        ..Default::default()
+    };
+    BackendCachedDot::grouped_gemm_cached(
+        &mut backend,
+        &mut cache,
+        None,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &GroupedGemmConfig::new(
+            &jobs,
+            DotGeneralAccumulation {
+                lhs_conj: false,
+                rhs_conj: false,
+                alpha: ContractionScalar::C64(Complex64::new(1.0, 0.0)),
+                beta: ContractionScalar::C64(Complex64::new(0.0, 0.0)),
+            },
+        ),
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap();
+    assert_eq!(
+        out.as_slice::<Complex64>().unwrap(),
+        &[Complex64::new(4.0, -2.0)]
+    );
+}
+
+#[test]
+fn grouped_gemm_validation_rejects_invalid_metadata() {
+    let lhs = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
+    let out = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 0.0]).unwrap();
+    let mut out_mut = out.clone();
+    let jobs = [GroupedGemmJob::new(0, 0, 0, 1, 1, 1)];
+
+    let rhs_f32 = Tensor::from_vec_col_major(vec![2], vec![3.0_f32, 4.0]).unwrap();
+    let err = validate_grouped_gemm(
+        &TensorRead::from_tensor(&lhs),
+        &TensorRead::from_tensor(&rhs_f32),
+        &TensorWrite::from_tensor(&mut out_mut),
+        &scalar_grouped_config(&jobs, DType::F64),
+        "test_grouped_gemm",
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("dtype mismatch"));
+
+    let mut out_f32 = Tensor::from_vec_col_major(vec![2], vec![0.0_f32, 0.0]).unwrap();
+    let err = validate_grouped_gemm(
+        &TensorRead::from_tensor(&lhs),
+        &TensorRead::from_tensor(&rhs),
+        &TensorWrite::from_tensor(&mut out_f32),
+        &scalar_grouped_config(&jobs, DType::F64),
+        "test_grouped_gemm",
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("dtype mismatch"));
+
+    let err = validate_grouped_gemm(
+        &TensorRead::from_tensor(&lhs),
+        &TensorRead::from_tensor(&rhs),
+        &TensorWrite::from_tensor(&mut out_mut),
+        &GroupedGemmConfig::new(
+            &jobs,
+            DotGeneralAccumulation {
+                lhs_conj: false,
+                rhs_conj: false,
+                alpha: ContractionScalar::F32(1.0),
+                beta: ContractionScalar::F64(0.0),
+            },
+        ),
+        "test_grouped_gemm",
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("dtype mismatch"));
+
+    let lhs_range_jobs = [GroupedGemmJob::new(0, 1, 0, 2, 1, 1)];
+    let err = validate_grouped_gemm(
+        &TensorRead::from_tensor(&lhs),
+        &TensorRead::from_tensor(&rhs),
+        &TensorWrite::from_tensor(&mut out_mut),
+        &scalar_grouped_config(&lhs_range_jobs, DType::F64),
+        "test_grouped_gemm",
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("lhs matrix range"));
+
+    let rhs_range_jobs = [GroupedGemmJob::new(0, 0, 1, 1, 1, 2)];
+    let err = validate_grouped_gemm(
+        &TensorRead::from_tensor(&lhs),
+        &TensorRead::from_tensor(&rhs),
+        &TensorWrite::from_tensor(&mut out_mut),
+        &scalar_grouped_config(&rhs_range_jobs, DType::F64),
+        "test_grouped_gemm",
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("rhs matrix range"));
+
+    let out_range_jobs = [GroupedGemmJob::new(1, 0, 0, 1, 1, 2)];
+    let err = validate_grouped_gemm(
+        &TensorRead::from_tensor(&lhs),
+        &TensorRead::from_tensor(&rhs),
+        &TensorWrite::from_tensor(&mut out_mut),
+        &scalar_grouped_config(&out_range_jobs, DType::F64),
+        "test_grouped_gemm",
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("out matrix range"));
+
+    let overlapping_jobs = [
+        GroupedGemmJob::new(0, 0, 0, 1, 1, 1),
+        GroupedGemmJob::new(0, 1, 1, 1, 1, 1),
+    ];
+    let err = validate_grouped_gemm(
+        &TensorRead::from_tensor(&lhs),
+        &TensorRead::from_tensor(&rhs),
+        &TensorWrite::from_tensor(&mut out_mut),
+        &scalar_grouped_config(&overlapping_jobs, DType::F64),
+        "test_grouped_gemm",
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("overlaps previous range"));
+
+    let overflow_jobs = [GroupedGemmJob::new(0, 0, 0, usize::MAX, 0, 2)];
+    let err = validate_grouped_gemm(
+        &TensorRead::from_tensor(&lhs),
+        &TensorRead::from_tensor(&rhs),
+        &TensorWrite::from_tensor(&mut out_mut),
+        &scalar_grouped_config(&overflow_jobs, DType::F64),
+        "test_grouped_gemm",
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("element count overflows"));
+
+    let empty_jobs = [GroupedGemmJob::new(
+        usize::MAX,
+        usize::MAX,
+        usize::MAX,
+        0,
+        0,
+        2,
+    )];
+    validate_grouped_gemm(
+        &TensorRead::from_tensor(&lhs),
+        &TensorRead::from_tensor(&rhs),
+        &TensorWrite::from_tensor(&mut out_mut),
+        &scalar_grouped_config(&empty_jobs, DType::F64),
+        "test_grouped_gemm",
+    )
+    .unwrap();
+}
+
+#[test]
+fn grouped_gemm_default_fallback_rejects_offsets_that_do_not_fit_isize() {
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![1], vec![0.0_f64]).unwrap();
+    let jobs = [GroupedGemmJob::new(0, usize::MAX, 0, 0, 0, 0)];
+    let config = scalar_grouped_config(&jobs, DType::F64);
+    let mut cache = ();
+    let mut backend = DefaultReadBackend {
+        dot_result: Some(Tensor::from_vec_col_major(vec![0, 0], Vec::<f64>::new()).unwrap()),
+        ..Default::default()
+    };
+
+    let err = BackendCachedDot::grouped_gemm_cached(
+        &mut backend,
+        &mut cache,
+        None,
+        TensorRead::from_tensor(&lhs),
+        TensorRead::from_tensor(&rhs),
+        &config,
+        TensorWrite::from_tensor(&mut out),
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("offset"));
 }
 
 #[test]

--- a/docs/worklogs/2026-07-04-issue-1293-grouped-gemm.md
+++ b/docs/worklogs/2026-07-04-issue-1293-grouped-gemm.md
@@ -1,0 +1,118 @@
+# Issue 1293 Grouped GEMM
+
+## Session Summary
+
+PR #1297 implements a backend-internal grouped GEMM path for CPU execution.
+The public tensor API is unchanged; the new hook lives behind
+`BackendCachedDot`/`SessionCachedDot` and accepts validated matrix jobs over
+shared flat buffers.
+
+After comparing an independent batched-`dot_general` prototype with #1297, the
+PR keeps #1297's broader backend-hook design and folds in the prototype's
+reviewed details: OpenBLAS group coalescing, explicit `Vec`/`SmallVec`
+rationale, execution-local raw pointer descriptors, and a sorted output-overlap
+validation pass.
+
+## Context Read
+
+- Issue #1293 discussion, including Rayon/faer behavior, OpenBLAS
+  `gemm_batch`, descriptor caching, and BLAS thread-count concerns.
+- PR #1295 merge state before implementation.
+- PR #1297 implementation branch and local prototype diff.
+- Shared tensor4all repository, performance, docs/test, and Rust performance
+  rules.
+- `AGENTS.md` and `REPOSITORY_RULES.md`, especially CPU provider features,
+  faer/Rayon policy, BLAS provider threading policy, public-surface discipline,
+  FFI safety, work-log requirements, and benchmark rules.
+
+## Decisions
+
+- Keep the grouped operation as hidden backend/session plumbing instead of a
+  user-facing tensor API. The hook can serve batched `dot_general` lowering and
+  future compiler/runtime dispatch without exposing raw offsets publicly.
+- Validate dtype, scalar compatibility, buffer ranges, and pairwise-disjoint
+  output ranges before provider execution. Output overlap is rejected; input
+  reuse is allowed.
+- Use faer with outer Rayon job parallelism under the owning `CpuContext`; each
+  child GEMM receives `faer::Par::Seq` to avoid nested parallel fan-out.
+- Use OpenBLAS `cblas_*gemm_batch` as the first BLAS provider candidate for
+  small grouped jobs. The short benchmark showed OpenBLAS batch overhead can
+  lose on medium or mixed-size jobs, so the provider falls back to the existing
+  per-job BLAS path outside the measured small-job regime. The OpenBLAS path
+  supports real and complex dtypes when `blas-openblas` is enabled; generic
+  BLAS keeps the sequential provider fallback.
+- Cache only structural metadata. Raw pointers are rebuilt per execution because
+  tensor views and buffer-pool allocations can change between calls.
+- Keep runtime job descriptors and OpenBLAS descriptor arrays in reserved
+  `Vec`s, not `SmallVec`s. Group/job count is runtime-dependent and can exceed
+  any inline threshold; OpenBLAS also requires stable contiguous C arrays for
+  the immediate FFI call.
+
+## Benchmarks
+
+The PR adds:
+
+```bash
+cargo bench -p tenferro-cpu --bench grouped_gemm --features cpu-faer
+cargo bench -p tenferro-cpu --bench grouped_gemm --no-default-features --features blas-openblas
+```
+
+Benchmark cases compare grouped execution with the existing N-call
+`dot_general_read_into_accum` loop over:
+
+- `uniform_small`: 64 jobs of 8x8x8
+- `mixed_large_small`: one 64x64x64 job plus 31 jobs of 8x8x8
+- `medium_blocks`: 16 jobs of 32x32x32
+
+For OpenBLAS runs, provider thread variables should be pinned explicitly by the
+caller, for example `OPENBLAS_NUM_THREADS=4`. There is no stable portable API
+for reading the active OpenMP/OpenBLAS thread count, so benchmark commands must
+record the environment used for the run.
+
+Short local faer run with `--sample-size 10 --warm-up-time 0.1
+--measurement-time 0.2`:
+
+| Case | Grouped hook | Sequential N-call |
+| ---- | ------------ | ----------------- |
+| uniform_small | 111.99 us | 954.56 us |
+| mixed_large_small | 161.47 us | 5.3152 ms |
+| medium_blocks | 270.23 us | 80.764 ms |
+
+Short local OpenBLAS run with `OPENBLAS_NUM_THREADS=4 --sample-size 10
+--warm-up-time 0.1 --measurement-time 0.2` after the small-job `gemm_batch`
+heuristic:
+
+| Case | Grouped hook | Sequential N-call |
+| ---- | ------------ | ----------------- |
+| uniform_small | 40.706 us | 130.23 us |
+| mixed_large_small | 21.267 us | 79.706 us |
+| medium_blocks | 82.261 us | 98.769 us |
+
+Before the heuristic, OpenBLAS `gemm_batch` was still faster for
+`uniform_small` but lost on `mixed_large_small` and `medium_blocks`. The final
+provider keeps `gemm_batch` for small jobs and uses the existing per-job BLAS
+path for larger jobs.
+
+## Verification
+
+- `cargo fmt --all --check`
+- `git diff --check`
+- `cargo test -p tenferro-tensor grouped_gemm`
+- `cargo test -p tenferro-cpu grouped --features cpu-faer`
+- `OPENBLAS_NUM_THREADS=4 cargo test -p tenferro-cpu --no-default-features --features blas-openblas grouped`
+- `OPENBLAS_NUM_THREADS=4 cargo test -p tenferro-cpu --no-default-features --features blas-openblas openblas_gemm_batch_heuristic_keeps_medium_jobs_on_sequential_path --lib`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `OPENBLAS_NUM_THREADS=4 cargo clippy -p tenferro-cpu --no-default-features --features blas-openblas --all-targets -- -D warnings`
+- Short faer and OpenBLAS benchmark runs listed above.
+
+## Residual Risks
+
+- The OpenBLAS `gemm_batch` FFI uses OpenBLAS extension symbols that are not
+  exposed by `cblas-sys`.
+- Group coalescing currently preserves input job order and combines consecutive
+  jobs with identical BLAS metadata. This improves uniform small batches without
+  adding a reorder table; non-consecutive equal-shape jobs remain a possible
+  future optimization.
+- The hidden grouped hook uses flat-buffer offsets and assumes column-major
+  matrix blocks. Callers should continue to build those jobs from validated
+  layout/planning metadata rather than ad hoc public inputs.


### PR DESCRIPTION
Closes #1293.

## Summary

This PR adds an internal grouped GEMM path for independent matrix products whose input and output matrices live at element offsets inside shared flat buffers. The public Tensor API is unchanged: the new surface is hidden backend/session plumbing for `BackendCachedDot` and `SessionCachedDot`.

A grouped job describes one column-major GEMM region:

```text
out[out_offset] = alpha * lhs[lhs_offset] @ rhs[rhs_offset] + beta * out[out_offset]
shape: rows x contracted  @  contracted x cols  ->  rows x cols
```

The runtime validates dtype/scalar compatibility, buffer-region bounds, and pairwise-disjoint output regions before provider execution.

## CPU Provider Behavior

- **Default hook**: sequential fallback that lowers each job to the existing `dot_general_read_into_accum` behavior, preserving AD/execution semantics for backends that do not override grouped GEMM.
- **faer**: executes job-level parallelism under `CpuContext::install`; every child GEMM uses `Par::Seq` to avoid nested parallelism.
- **generic BLAS**: builds grouped metadata but executes sequentially through the existing BLAS GEMM path.
- **blas-openblas**: uses a minimal internal FFI for `cblas_{s,d,c,z}gemm_batch` because `cblas-sys` does not expose these OpenBLAS extension symbols.

## Scope And Non-Goals

- CPU only. CUDA/NCCL/MPI grouped GEMM remains follow-up work.
- No new user-facing Tensor API.
- No cached raw pointers. Cached/backend descriptors carry dimensions, offsets, and scalar/update metadata; execution forms pointers from the current buffer base plus element offsets.
- Output overlap is rejected. Input regions may be shared/reused.

## Tests And Benchmarks

- Adds correctness coverage for `F32`, `F64`, `C32`, and `C64`.
- Covers nontrivial `alpha`/`beta` accumulation, shared input/output buffers with offsets, zero jobs, empty-contraction beta scaling, and output-overlap rejection.
- Adds focused `tenferro-tensor` tests for the default grouped hook, validation failures, and tensor/view dispatch combinations so the backend-internal fallback is covered independently from CPU provider overrides.
- Adds `crates/tenferro-cpu/benches/grouped_gemm.rs` to compare grouped dispatch with the current N-call `dot_general_read_into_accum` loop across uniform-small, mixed large+small, and medium block cases.

## Follow-up Reconciliation

After comparing this PR with an independent batched-`dot_general` prototype, this branch keeps the broader backend/session hook design from #1297 and folds in the useful pieces from the prototype:

- OpenBLAS descriptor group coalescing for consecutive jobs with identical BLAS metadata.
- A conservative OpenBLAS `gemm_batch` heuristic: use batched FFI only for small grouped jobs (`m`, `n`, `k` <= 16, at least two jobs), and fall back to the existing per-job BLAS path for medium or mixed-size jobs.
- Sorted output-overlap validation instead of an O(n^2) nested scan.
- Comments explaining why runtime job descriptors and OpenBLAS descriptor arrays stay in `Vec` rather than `SmallVec`.
- FFI/raw-pointer safety comments around execution-local descriptor construction.

Work log: `docs/worklogs/2026-07-04-issue-1293-grouped-gemm.md`.

Short local OpenBLAS benchmark after the heuristic, with `OPENBLAS_NUM_THREADS=4` and `--sample-size 10 --warm-up-time 0.1 --measurement-time 0.2`:

| Case | Grouped hook | Sequential N-call |
| ---- | ------------ | ----------------- |
| uniform_small | 40.706 us | 130.23 us |
| mixed_large_small | 21.267 us | 79.706 us |
| medium_blocks | 82.261 us | 98.769 us |

Before the heuristic, unconditional OpenBLAS `gemm_batch` won on `uniform_small` but lost on the mixed and medium cases, so this PR keeps `gemm_batch` as the first OpenBLAS path only in the measured small-job regime.

## Verification

- `cargo fmt --all --check`
- `cargo check -p tenferro-tensor`
- `cargo check -p tenferro-cpu --features cpu-faer`
- `cargo check -p tenferro-cpu --no-default-features --features cpu-blas`
- `cargo check -p tenferro-cpu --features cpu-faer,cpu-blas`
- `cargo check -p tenferro-cpu --benches --features cpu-faer`
- `cargo check -p tenferro-cpu --no-default-features --features blas-openblas`
- `cargo test -p tenferro-tensor grouped_gemm` — 6 passed
- `cargo test -p tenferro-tensor` — 182 unit tests and 237 doctests passed
- `cargo clippy -p tenferro-tensor --all-targets -- -D warnings`
- `cargo test -p tenferro-cpu grouped --features cpu-faer` — 5 passed
- `OPENBLAS_FC=/opt/homebrew/bin/gfortran LIBRARY_PATH=/opt/homebrew/lib/gcc/current:/opt/homebrew/lib/gcc/15 DYLD_LIBRARY_PATH=/opt/homebrew/lib/gcc/current:/opt/homebrew/lib/gcc/15 cargo test -p tenferro-cpu --no-default-features --features blas-openblas grouped` — 5 passed

Latest verification on commit `e6d7d048` used `CARGO_BUILD_JOBS=32`:

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p tenferro-tensor grouped_gemm` — 6 passed
- `cargo test -p tenferro-cpu grouped --features cpu-faer` — 5 passed
- `OPENBLAS_NUM_THREADS=4 cargo test -p tenferro-cpu --no-default-features --features blas-openblas grouped` — 5 passed
- `OPENBLAS_NUM_THREADS=4 cargo test -p tenferro-cpu --no-default-features --features blas-openblas openblas_gemm_batch_heuristic_keeps_medium_jobs_on_sequential_path --lib` — 1 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `OPENBLAS_NUM_THREADS=4 cargo clippy -p tenferro-cpu --no-default-features --features blas-openblas --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json` — 144/144 files passed
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py` — 13 workspace library crates verified
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1297.json` — pass, no findings

## Notes

`cpu-blas` by itself only enables BLAS calls and does not select/link a provider, so it is checked with `cargo check`. The OpenBLAS provider path was run with Homebrew GCC library paths explicitly set so `openblas-src` can find `libgfortran` on macOS.

