### PR TITLE
docs: retarget README and entry docs at the primary audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,162 +1,32 @@
 # tenferro-rs
 
-tenferro-rs is a modular Rust tensor stack for scientific computing and
-general-purpose tensor workflows.
+**A Rust-native tensor & autodiff stack for scientific computing.**
+
+[![CI](https://github.com/tensor4all/tenferro-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/tensor4all/tenferro-rs/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/tenferro-runtime.svg)](https://crates.io/crates/tenferro-runtime)
+[![docs](https://img.shields.io/badge/docs-tensor4all.org-blue)](https://tensor4all.org/tenferro-rs/)
+[![license](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue)](LICENSE-MIT)
+
+tenferro-rs provides dense tensors, linear algebra, einsum, FFT, and
+extensible automatic differentiation — eager like PyTorch, traced like JAX —
+natively in Rust, with explicit CPU, CUDA, and experimental WebGPU backend
+control. It is built for scientific workloads rather than deep learning:
+storage is column-major, aligned with LAPACK, Fortran, and Julia conventions;
+traced programs compile once and are reused while concrete sizes resolve at
+runtime; and operation families and AD rules can be extended from external
+crates.
 
 ![tenferro-rs architecture overview](docs/assets/tenferro-architecture.svg)
 
-## Why tenferro-rs Exists
+## Quick Example
 
-`tenferro` means tensor computation with an iron/Rust flavor: `tensor` +
-`ferro`.
+Add the runtime and CPU backend crates:
 
-The project aims to provide a Rust-native tensor stack for typed tensor
-computation, immediate execution with optional `backward()`, traced graph
-execution, automatic differentiation, linear algebra, einsum, FFT, and explicit
-CPU, CUDA, and experimental WebGPU backend control.
-
-tenferro-rs is influenced by JAX and PyTorch in its split between immediate
-execution, traced graphs, and AD. It is also influenced by the Julia numerical
-computing ecosystem, where operation semantics and AD rules can live outside a
-single all-in-one tensor type.
-
-tenferro-rs is Rust-native, but it should fit established numerical computing
-conventions rather than replacing them with project-specific rules. It uses
-Rust's type system, ownership model, and crate boundaries where those choices
-help.
-
-We also see Rust's package system — fine-grained crates, feature flags, and
-semver-aware dependency composition — as a strong place for **cross-ecosystem
-collaboration**. tenferro-rs prefers to build on and contribute back to existing
-crates (GPU kernels, linear algebra, autodiff, contraction ordering) rather than
-reinvent them, and to bridge cleanly to the Fortran/LAPACK, Julia, and JAX/PyTorch
-worlds. The modular crate layout is meant to make tenferro components reusable as
-shared infrastructure, not just as an internal stack.
-
-## Design Principles
-
-- Keep tensor types and operation crates modular, rather than building one
-  all-in-one tensor type.
-- Let users choose the lowest API that solves their problem. Autodiff, traced
-  graphs, CUDA, experimental WebGPU, linalg, einsum, and FFT are opt-in
-  capabilities.
-- Stay aligned with established numerical computing conventions where they
-  fit: Rust's crate ecosystem, column-major conventions from Fortran, Julia,
-  MATLAB, and LAPACK-oriented workflows, and Rust numerics crates such as
-  `faer`, `num-traits`, and `num-complex`.
-- Make dependencies, feature flags, backends, and devices explicit. tenferro
-  does not silently move tensor data between CPU and GPU.
-- Support both Rust-typed tensors and tensors whose dtype is selected at
-  runtime.
-- Treat extension operations and AD rules as part of the design, so external
-  crates can add operations without growing the core tensor crates.
-- Manage engineering quality through three pillars — reference **oracles**
-  (finite-difference and Torch reference data), a comprehensive **unit-test**
-  suite with enforced per-file coverage thresholds, and a reproducible
-  **benchmark suite** — backed by invariants, residual checks, and provenance
-  checks. This engineering discipline is what lets the project iterate quickly
-  (see [Stability Policy](#stability-policy)) without sacrificing correctness.
-
-## When tenferro Is a Good Fit
-
-tenferro-rs is designed for workloads where tensor shapes are not always fixed
-before execution. If your computation involves runtime-dependent ranks,
-threshold-based filtering, data-dependent iteration counts, or shape-parametric
-models, tenferro's traced execution can reuse a compiled program while resolving
-the concrete sizes at runtime.
-
-It also fits small-to-medium batched linear algebra with autodiff,
-`grad`/`vjp`/`jvp`/HVP workflows in Rust, Rust-native tensor applications, and
-extension points for custom algebra or operation families.
-
-The experimental `tenferro-xla` crate lowers static-shaped traced graph
-programs to StableHLO and can load PJRT plugins at runtime through environment
-variables. Dynamic-shape graphs remain the native runtime's core use case. See
-the [XLA and PJRT guide](https://tensor4all.org/tenferro-rs/guides/xla.html).
-
-## Why Build On tenferro-rs
-
-tenferro-rs aims to be a pure-Rust tensor stack for scientific and numerical
-computing — one you can build on, extend, and ship as a single binary, rather
-than a wrapper around a C++ or Python engine. What that gives you:
-
-- **A complete stack, natively in Rust.** Typed tensors, eager execution with
-  `backward()`, traced graphs with reuse, `grad`/`vjp`/`jvp`/HVP autodiff, linear
-  algebra, einsum, and FFT — all carried by Rust's type system, ownership model,
-  and tooling, with no Python runtime.
-- **Extensible operations and AD rules.** Operations and their AD rules live
-  *outside* the core tensor crates. An external crate can introduce a new
-  operation family — even a different algebra — register its
-  `linearize`/`transpose_rule`, and have it flow through the same eager and
-  traced autodiff as the built-in ops. The `ext/tropical` semiring extension is a
-  worked example; see
-  [`docs/guides/custom-operations.md`](docs/guides/custom-operations.md).
-- **Fits the numerical-computing world.** Column-major storage lines up with
-  Fortran, Julia, MATLAB, Eigen3, and LAPACK/BLAS, and strided views bridge to
-  row-major data without eager copies (see
-  [`docs/guides/memory-order.md`](docs/guides/memory-order.md)). tenferro-rs
-  builds on `faer` for dense linear algebra and on
-  [CubeCL](https://github.com/tracel-ai/cubecl) for GPU kernels, contributing to
-  the Rust ecosystem rather than reinventing it.
-- **Built for shapes you only know at runtime.** A traced program is compiled
-  once and reused while concrete sizes — ranks, truncation thresholds,
-  data-dependent iteration counts — resolve at execution time.
-
-If your host language is Python, JAX and PyTorch are the natural choice.
-tenferro-rs is for the projects that want this kind of stack natively in Rust.
-
-## Which API Should I Use?
-
-| If your workflow needs | Start with |
-| --- | --- |
-| Fixed scalar type, ordinary tensor computation, no autodiff | `TypedTensor<T, R>` |
-| Runtime dtype selection or direct backend dispatch | `Tensor` with an explicit backend |
-| Immediate execution in one runtime, optionally with `backward()` on scalar losses | `EagerTensor` and `EagerRuntime` |
-| `grad`, `vjp`, and `jvp` on traced graphs, graph reuse, or repeated compile/run execution | `TracedTensor`, `GraphCompiler`, and `GraphExecutor<B>` |
-| CUDA or experimental WebGPU execution | The same tensor API plus explicit GPU upload/download and supported provider backend features |
-| Static-shaped StableHLO and PJRT plugin experiments | `GraphCompiler` plus `tenferro-xla` |
-
-## Crates
-
-tenferro-rs is a multi-crate workspace. There is intentionally no `tenferro` facade crate; users depend on the crates they need directly.
-
-### Core User Crates
-
-| Crate | Use when you need |
-| --- | --- |
-| `tenferro-tensor` | Tensor values, typed tensors, views, dtype/runtime tensor contracts, and backend traits |
-| `tenferro-cpu` | CPU backend execution |
-| `tenferro-gpu` | CUDA backend support, experimental WebGPU support, future ROCm substrate, and explicit device transfers |
-| `tenferro-runtime` | Eager/traced execution, graph compilation, and extension runtime support |
-| `tenferro-ad` | Automatic differentiation |
-| `tenferro-xla` | Experimental StableHLO lowering and runtime-loaded PJRT plugin support for static-shaped traced graphs |
-
-### Standard Operation Extensions
-
-| Crate | Use when you need |
-| --- | --- |
-| `tenferro-linalg` | Linear algebra operations |
-| `tenferro-einsum` | Einsum and contraction planning |
-| `tenferro-fft` | FFT operations |
-
-### Implementation Crates
-
-| Crate | Use when you need |
-| --- | --- |
-| `tenferro-tensor-core` | Host tensor storage, dtype tags, and metadata-only layouts |
-| `tenferro-core-ops` | Core primitive operation metadata shared by runtimes and backends |
-| `tenferro-internal-ops` | Published implementation crate for internal graph op vocabulary and AD rule implementations used by tenferro crates |
-| `tenferro-internal-extension-macros` | Procedural macros for registering internal extension operation descriptors |
-
-## Minimal CPU Example
-
-Create a binary crate that depends on `tenferro-runtime` and `tenferro-cpu`.
-The same runnable example lives at
-`crates/tenferro-runtime/examples/cpu_quickstart.rs`.
-For a local checkout, the full setup notes are in
-[`docs/getting-started/index.md`](docs/getting-started/index.md), including the
-empty `[workspace]` table needed by scratch crates created inside this
-repository.
+```toml
+[dependencies]
+tenferro-runtime = "0.2"
+tenferro-cpu = "0.2"
+```
 
 <!-- snippet-source: crates/tenferro-runtime/examples/cpu_quickstart.rs -->
 ```rust
@@ -179,150 +49,197 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 <!-- end-snippet-source -->
 
+The same stack scales up to PyTorch-style eager autodiff with `backward()`
+([tutorial](https://tensor4all.org/tenferro-rs/tutorials/eager-autodiff-pytorch-style.html))
+and JAX-style traced `grad`/`vjp`/`jvp`
+([tutorial](https://tensor4all.org/tenferro-rs/tutorials/traced-autodiff-jax-style.html)).
+Setup notes, including local-checkout builds and BLAS provider selection, are
+in [Getting Started](https://tensor4all.org/tenferro-rs/getting-started/index.html).
+
+## Is tenferro for You?
+
+tenferro-rs is a good fit when:
+
+- **Shapes are only known at runtime.** A traced program is compiled once and
+  reused while ranks, truncation thresholds, and data-dependent iteration
+  counts resolve at execution time — the daily reality of tensor networks and
+  much of adaptive scientific computing (see
+  [dynamic and symbolic shapes](https://tensor4all.org/tenferro-rs/design/dynamic-symbolic-shapes.html)).
+- **You want autodiff in Rust without a Python runtime.** `backward()` on
+  eager tensors; `grad`, `vjp`, `jvp`, and HVP on traced graphs; shipped as a
+  single binary.
+- **Your data lives in the column-major world.** Storage matches Fortran,
+  Julia, MATLAB, and LAPACK/BLAS conventions, and strided views bridge
+  row-major data without eager copies (see
+  [memory order](https://tensor4all.org/tenferro-rs/guides/memory-order.html)).
+- **You need operations the core does not ship.** Operations and their AD
+  rules live outside the core tensor type, so an external crate can add an
+  operation family — even a different algebra, such as the tropical-semiring
+  example — and it flows through the same eager and traced autodiff (see
+  [custom operations](https://tensor4all.org/tenferro-rs/guides/custom-operations.html)).
+
+tenferro-rs deliberately builds on the Rust numerics ecosystem instead of
+replacing it: [`faer`](https://github.com/sarah-quinones/faer-rs) for dense
+linear algebra, [CubeCL](https://github.com/tracel-ai/cubecl) for GPU
+kernels, [`omeco`](https://crates.io/crates/omeco) for contraction ordering,
+and [`num-traits`](https://github.com/rust-num/num-traits) /
+[`num-complex`](https://github.com/rust-num/num-complex) for generic
+numerics.
+
+Where else to look: [ndarray](https://github.com/rust-ndarray/ndarray) for
+general N-dimensional arrays without autodiff or traced graphs;
+[faer](https://github.com/sarah-quinones/faer-rs) directly for pure dense
+linear algebra; [Burn](https://github.com/tracel-ai/burn) and
+[candle](https://github.com/huggingface/candle) for deep-learning workloads.
+If your host language is Python, JAX and PyTorch are the natural choice —
+tenferro-rs is for projects that want this kind of stack natively in Rust.
+
+## Which API Should I Use?
+
+| If your workflow needs | Start with |
+| --- | --- |
+| Fixed scalar type, ordinary tensor computation, no autodiff | `TypedTensor<T, R>` |
+| Runtime dtype selection or direct backend dispatch | `Tensor` with an explicit backend |
+| Immediate execution in one runtime, optionally with `backward()` on scalar losses | `EagerTensor` and `EagerRuntime` |
+| `grad`, `vjp`, and `jvp` on traced graphs, graph reuse, or repeated compile/run execution | `TracedTensor`, `GraphCompiler`, and `GraphExecutor<B>` |
+| CUDA or experimental WebGPU execution | The same tensor API plus explicit GPU upload/download and supported provider backend features |
+| Static-shaped StableHLO and PJRT plugin experiments | `GraphCompiler` plus `tenferro-xla` |
+
+## Crates
+
+tenferro-rs is a multi-crate workspace. There is intentionally no `tenferro`
+facade crate; depend directly on the crates you need, starting with the
+smallest API that solves your problem.
+
+### Core User Crates
+
+| Crate | Use when you need |
+| --- | --- |
+| `tenferro-tensor` | Tensor values, typed tensors, views, dtype/runtime tensor contracts, and backend traits |
+| `tenferro-cpu` | CPU backend execution |
+| `tenferro-gpu` | CUDA backend support, experimental WebGPU support, future ROCm substrate, and explicit device transfers |
+| `tenferro-runtime` | Eager/traced execution, graph compilation, and extension runtime support |
+| `tenferro-ad` | Automatic differentiation |
+| `tenferro-xla` | Experimental StableHLO lowering and runtime-loaded PJRT plugin support for static-shaped traced graphs |
+
+### Standard Operation Extensions
+
+| Crate | Use when you need |
+| --- | --- |
+| `tenferro-linalg` | Linear algebra operations |
+| `tenferro-einsum` | Einsum and contraction planning |
+| `tenferro-fft` | FFT operations |
+
+The implementation crates `tenferro-tensor-core`, `tenferro-core-ops`,
+`tenferro-internal-ops`, and `tenferro-internal-extension-macros` are
+published building blocks for the crates above; most users never depend on
+them directly.
+
 ## Documentation
 
 The full guides, tutorials, API reference, architecture notes, and
 specifications live at <https://tensor4all.org/tenferro-rs/>. Start with
-Getting Started if you are using tenferro-rs for the first time.
+[Getting Started](https://tensor4all.org/tenferro-rs/getting-started/index.html);
+PyTorch/JAX users can also jump in through the
+[PyTorch and JAX mapping](https://tensor4all.org/tenferro-rs/getting-started/pytorch-jax-mapping.html).
 
-- [Design: dynamic and symbolic shapes](https://tensor4all.org/tenferro-rs/design/dynamic-symbolic-shapes.html)
-  explains how tenferro represents runtime-dependent dimensions in traced
-  programs.
+Selected deep dives:
+
+- [Devices and GPU](https://tensor4all.org/tenferro-rs/guides/devices-and-gpu.html)
+  — explicit CPU, CUDA, and experimental WebGPU control; tensors never move
+  between devices silently.
+- [Dynamic and symbolic shapes](https://tensor4all.org/tenferro-rs/design/dynamic-symbolic-shapes.html)
+  — how runtime-dependent dimensions work in traced programs.
 - [XLA and PJRT](https://tensor4all.org/tenferro-rs/guides/xla.html)
-  documents the experimental StableHLO lowering path and the CUDA, cuTENSOR,
-  and PJRT environment variables used for local verification.
-- [XLA backend: einsum to StableHLO](https://tensor4all.org/tenferro-rs/tutorials/xla-einsum-backend.html)
-  shows a runnable fixed-shape N-ary einsum lowering path through
-  `tenferro-xla`.
-- [Oracle-based AD validation](https://tensor4all.org/tenferro-rs/oracle/tensor-ad-oracles-support.html)
-  documents how AD rules are validated against finite-difference and Torch
-  reference oracles, and which operation/output gradients are covered. The
-  oracle datasets live in
-  [`tensor4all/tensor-ad-oracles`](https://github.com/tensor4all/tensor-ad-oracles).
+  — experimental StableHLO lowering and PJRT plugin loading for static-shaped
+  graphs via `tenferro-xla`.
+- [Custom operations](https://tensor4all.org/tenferro-rs/guides/custom-operations.html)
+  — extension operations and AD rules from external crates.
 
-## Benchmarks And Numerical Validation
+## Project
 
-Official benchmark suites and result tooling live in
-[`tensor4all/tenferro-benchmark`](https://github.com/tensor4all/tenferro-benchmark).
-Run them there for reproducible cross-backend performance numbers rather than
-relying on ad hoc local timings.
+**Why tenferro-rs exists.** Moving tensor-network engines from Julia to Rust
+exposed a missing layer: a scientific-computing tensor stack between ndarray,
+faer, and the deep-learning frameworks — column-major, dynamic-shape,
+autodiff-capable, and extensible. tenferro-rs fills that layer and bridges to
+the Fortran/LAPACK, Julia, and JAX/PyTorch worlds. The background story is in
+the introduction post:
+[From Julia to Rust: a differentiable tensor stack for scientific computing in the agentic AI era](https://tensor4all.org/blog/introducing-tenferro-rs/).
 
-Numerical correctness — especially automatic differentiation — is validated
-against reference *oracles* (finite-difference checks and Torch reference data)
-rather than line coverage alone. See the
-[oracle support table](https://tensor4all.org/tenferro-rs/oracle/tensor-ad-oracles-support.html)
-for the per-operation AD coverage status and the
-[`tensor4all/tensor-ad-oracles`](https://github.com/tensor4all/tensor-ad-oracles)
-dataset repository.
+**Stability.** tenferro-rs is a pre-1.0 experimental research platform;
+public APIs may change substantially, including across 0.x releases. Pin
+exact versions or commits, and follow the current documentation as the
+primary reference — migration notes accompany major breaking changes. The
+stack is dogfooded in
+[tensor4all-rs](https://github.com/tensor4all/tensor4all-rs) and related
+tensor4all projects.
 
-## Get In Touch
+**Engineering discipline.** Numerical correctness — especially automatic
+differentiation — is validated against reference oracles (finite-difference
+and Torch reference data in
+[tensor-ad-oracles](https://github.com/tensor4all/tensor-ad-oracles); see the
+[oracle support table](https://tensor4all.org/tenferro-rs/oracle/tensor-ad-oracles-support.html)),
+enforced per-file coverage thresholds, and the reproducible
+[tenferro-benchmark](https://github.com/tensor4all/tenferro-benchmark) suite.
+Every documentation example compiles and runs in CI.
 
-Questions, design discussions, and contributor coordination for tenferro happen
-in the tenferro Matrix room:
+**AI-assisted development.** tenferro-rs assumes AI-assisted and agentic
+coding for development, migration, and review. AI output is never accepted as
+authority by itself: changes are validated against repository rules
+([REPOSITORY_RULES.md](REPOSITORY_RULES.md)), oracle checks, CI, reproducible
+benchmarks, and maintainer review, with design records under
+[docs/design/](docs/design/) and [docs/worklogs/](docs/worklogs/) keeping the
+process coherent. Why we work this way is part of the
+[introduction post](https://tensor4all.org/blog/introducing-tenferro-rs/).
+
+## Community
+
+Questions, design discussions, and contributor coordination happen in the
+tenferro Matrix room:
 
 - [#tenferro-tensor4all:matrix.org](https://matrix.to/#/#tenferro-tensor4all:matrix.org)
 
-Matrix is an open, federated chat protocol. You can join from a Matrix client
-such as Element, or through the browser flow opened by the link above.
-
 Use GitHub issues for bug reports, feature requests, and decisions that need
 tracking; use Matrix for lightweight discussion before filing or implementing
-changes. The broader tensor4all community also uses the
+changes. The broader tensor4all community uses the
 [tensor4all mailing list](https://groups.google.com/g/tensor4all) for
 announcements, and the community entry point is <https://tensor4all.org/>.
 
 ## Acknowledgments
 
 tenferro-rs stands on excellent work across several ecosystems, and aims to
-integrate with and contribute back to them rather than wall itself off — even as
-it iterates quickly.
+integrate with and contribute back to them.
 
-- **GPU.** The GPU backend is built on
+- **GPU.** The GPU backend builds on
   [CubeCL](https://github.com/tracel-ai/cubecl) by the
-  [tracel-ai](https://github.com/tracel-ai) team (also the foundation of the
-  [Burn](https://github.com/tracel-ai/burn) deep learning framework). The
-  temporary `t4a-*` CubeCL/CubeK crates stage tensor4all fork patches until
-  those changes are upstream, with the intent to converge back rather than fork
-  the ecosystem.
+  [tracel-ai](https://github.com/tracel-ai) team (also the foundation of
+  [Burn](https://github.com/tracel-ai/burn)). The temporary `t4a-*` crates
+  stage tensor4all patches until they land upstream.
 - **CPU / numerics.** Dense CPU linear algebra builds on
-  [`faer`](https://github.com/sarah-quinones/faer-rs), with numeric foundations
-  from [`num-traits`](https://github.com/rust-num/num-traits) and
+  [`faer`](https://github.com/sarah-quinones/faer-rs), with numeric
+  foundations from [`num-traits`](https://github.com/rust-num/num-traits) and
   [`num-complex`](https://github.com/rust-num/num-complex).
 - **Contraction ordering.** Einsum contraction-order optimization uses
-  [`omeco`](https://crates.io/crates/omeco), carrying over ideas from the Julia
-  tensor-network ecosystem (OMEinsum/contraction-order tooling).
-- **Design heritage.** The modular structure — operation semantics and AD rules
-  living *outside* an all-in-one tensor type — is influenced by the **Julia
-  numerical-computing community** (e.g. the ChainRules and OMEinsum/tensor-network
-  ecosystems), and by JAX/PyTorch for the eager/traced/AD split.
-- **Generic autodiff.** Autodiff is built on `tidu`, a tensor4all crate providing
-  `Primitive`-generic graph transforms (`linearize` / `linear_transpose`) that are
-  **not tied to tensors** and can drive autodiff for other domains.
+  [`omeco`](https://crates.io/crates/omeco), carrying over ideas from the
+  Julia tensor-network ecosystem.
+- **Design heritage.** Operation semantics and AD rules living outside an
+  all-in-one tensor type follow the Julia numerical-computing community
+  (ChainRules, OMEinsum); the eager/traced/AD split follows JAX and PyTorch.
+  Autodiff builds on [`tidu`](https://github.com/tensor4all/tidu-rs), a
+  tensor4all crate for `Primitive`-generic graph transforms that are not tied
+  to tensors.
 
 Thanks to these projects, communities, and their maintainers.
 
-## Stability Policy
-
-tenferro-rs is a **pre-1.0 experimental research platform**. Before v1.0, public
-APIs may change substantially, including across 0.1.x releases: at this stage we
-prioritize rapid iteration, backend exploration, and AI-assisted development over
-API stability.
-
-This does **not** mean correctness or engineering discipline is relaxed. We keep
-tests, runnable examples, documentation, and migration notes for major changes up
-to date, and changes are accepted only after the checks described in
-[Development And Trust Model](#development-and-trust-model) — repository rules, CI,
-oracle-based validation, reproducible benchmarks, provenance checks, and maintainer
-review. The detailed, current API documentation is the primary reference for
-following the library as it evolves; we write migration notes for major breaking
-changes rather than maintaining exhaustive compatibility tables.
-
-For downstream projects, **pin exact versions or commits**, and when upgrading use
-AI-assisted refactoring against the current docs to follow breaking changes. The
-stack is dogfooded in
-[tensor4all-rs](https://github.com/tensor4all/tensor4all-rs) and related tensor4all
-projects.
-
-## AI-Assisted Development
-
-tenferro-rs assumes AI-assisted and agentic coding for development, migration,
-and review. AI output is not accepted as authority by itself: changes are
-validated against repository rules, source-of-truth code and doc comments, CI,
-oracle-based numerical checks, reproducible benchmarks when relevant,
-provenance checks, and maintainer review.
-
-Correctness and consistency are also kept by a retained knowledge base that the
-project builds on rather than rediscovers each time: durable **repository and
-engineering rules** ([`REPOSITORY_RULES.md`](REPOSITORY_RULES.md) and the shared
-[`tensor4all-agent-rules`](https://github.com/tensor4all/tensor4all-agent-rules)),
-**design documents** ([`docs/design/`](docs/design/), [`docs/spec/`](docs/spec/)),
-and the **history of past development decisions** (work logs in
-[`docs/worklogs/`](docs/worklogs/) and review-decision records). This institutional
-memory is what keeps a fast, AI-assisted workflow coherent: rules and recorded
-decisions constrain new changes — including AI-generated ones — toward the
-established design.
-
-Documentation–implementation consistency is itself audited regularly by agents,
-on top of the automated doc-snippet and docs-site checks in CI (every doc example
-must compile and run). Because the current API documentation is the primary
-reference for following the library as it evolves, keeping the docs aligned with
-the code is treated as a correctness concern, not an afterthought.
-
 ## Contributing
 
-Bug reports, minimal reproducers, proposed regression tests, feature requests,
-design discussions, documentation improvements, benchmark reports, and
-prototype branches are welcome in issues. Pull request creation is currently
-restricted to collaborators.
+Bug reports, minimal reproducers, proposed regression tests, feature
+requests, design discussions, documentation improvements, benchmark reports,
+and prototype branches are welcome in issues. Pull request creation is
+currently restricted to collaborators, and collaborator feature PRs must
+start from accepted feature-request issues.
 
-Collaborator implementation PRs for new features must start from accepted
-feature request issues so API, backend, AD, dependency, and testing
-implications can be reviewed first.
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the external contribution policy and
-the supported AI-assisted issue-intake and collaborator bug-fix PR workflows
-across Codex CLI, Claude Code, OpenCode, and Kimi CLI.
-
-See [GOVERNANCE.md](GOVERNANCE.md) for maintainer roles, merge authority, and
-the project-direction decision model. Maintainers are listed in
-[CONTRIBUTORS.md](CONTRIBUTORS.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the contribution policy and the
+supported AI-assisted workflows, and [GOVERNANCE.md](GOVERNANCE.md) for
+maintainer roles, merge authority, and the project-direction decision model.
+Maintainers are listed in [CONTRIBUTORS.md](CONTRIBUTORS.md).

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -23,8 +23,16 @@ runtime crate and CPU backend.
 
 ## Setup
 
-Start with the runtime crate and CPU backend crate. Use a local checkout while
-the crates are still evolving:
+Start with the runtime crate and CPU backend crate from crates.io:
+
+```toml
+[dependencies]
+tenferro-runtime = "0.2"
+tenferro-cpu = "0.2"
+```
+
+For development against a local checkout of this repository, use path
+dependencies instead:
 
 ```toml
 [dependencies]
@@ -106,13 +114,6 @@ support:
 tenferro-ad = { path = "/path/to/tenferro-rs/crates/tenferro-ad", features = ["cuda"] }
 tenferro-gpu = { path = "/path/to/tenferro-rs/crates/tenferro-gpu", features = ["cuda"] }
 tenferro-linalg = { path = "/path/to/tenferro-rs/crates/tenferro-linalg", features = ["autodiff", "cuda"] }
-```
-
-Switch to crates.io once published:
-
-```toml
-[dependencies]
-tenferro-runtime = "..."
 ```
 
 ## First CPU Program

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -1,6 +1,6 @@
 # PyTorch and JAX Mapping
 
-This page is for readers who already know either `torch` or `jax.numpy` and want to find the tenferro equivalent quickly.
+This page is a translation guide for readers who already know `torch` or `jax.numpy`: find the tenferro equivalent quickly, then read [Core Concepts](./core-concepts.md) for tenferro's own mental model.
 
 ## Concept mapping
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # tenferro
 
-tenferro is a dense tensor computation stack for Rust users who want typed
-tensor computation, PyTorch-like immediate execution with `backward()`,
-JAX-like traced graphs, einsum, linear algebra, and explicit CPU, CUDA, and
+tenferro is a Rust-native tensor & autodiff stack for scientific computing:
+typed tensors, PyTorch-style immediate execution with `backward()`, JAX-style
+traced graphs, einsum, linear algebra, FFT, and explicit CPU, CUDA, and
 experimental WebGPU backend control.
 
 The project covers both ordinary tensor computation and autodiff workflows.

--- a/docs/superpowers/specs/2026-07-04-readme-docs-blog-audience-design.md
+++ b/docs/superpowers/specs/2026-07-04-readme-docs-blog-audience-design.md
@@ -1,0 +1,165 @@
+# README / Docs / Blog Audience Redesign — Design
+
+- Date: 2026-07-04
+- Status: approved in discussion; pending maintainer spec review
+- Scope: `README.md`, `docs/index.md`, `docs/getting-started/` (3 pages),
+  the "Introducing tenferro-rs" blog post (separate website repository),
+  and the GitHub repository description.
+
+## Goal
+
+Make each documentation surface serve a clearly chosen audience with one
+consistent project identity, so that a first-time visitor can answer
+"what is this, is it for me, how is it different, how do I start" within
+the first screen of the README.
+
+## Decisions
+
+### 1. Primary audience
+
+**Rust developers and researchers doing numerical / scientific
+computing.** They know NumPy/JAX/PyTorch concepts, are not tensor-network
+specialists, and arrive cold from crates.io, web search, or GitHub.
+Optimizing the front door for this group also serves the secondary
+audiences in deeper sections.
+
+Secondary audiences and their treatment:
+
+| Audience | Treatment |
+| --- | --- |
+| JAX/PyTorch migrants | Served by `getting-started/pytorch-jax-mapping.md`, framed as a translation guide, not as the project identity |
+| Library authors building on tenferro | Served by extension/custom-operations content and design docs, linked from README |
+| tensor4all researchers | Reached mostly through tensor4all-rs / Tensor4all.jl; README provides ecosystem context |
+| Contributors and AI coding agents | Served by CONTRIBUTING, REPOSITORY_RULES, and docs internals; moved off the README front door |
+| Evaluators (papers, talks, reviewers) | Served by compressed Project section (stability, engineering discipline) plus the blog narrative |
+
+### 2. Positioning (unified one-liner)
+
+> A Rust-native tensor & autodiff stack for scientific computing.
+
+- PyTorch/JAX appear as **explanatory anchors** ("eager like PyTorch,
+  traced like JAX"), never as the identity.
+- Explicitly not a deep-learning framework; the README says so and points
+  to candle/burn for that use case, and to JAX/PyTorch when the host
+  language is Python.
+- Differentiators to lead with: column-major / LAPACK-Fortran-Julia
+  alignment, dynamic shapes in compiled graphs, extensible operations and
+  AD rules, explicit backend/device control.
+
+### 3. Surface roles
+
+| | README | docs site | blog post |
+| --- | --- | --- | --- |
+| Role | Front door: 30-second fit decision | Workspace: task completion | Narrative: why the project exists |
+| Main reader | Cold-arriving Rust numerical-computing user | Someone who decided to try tenferro | Community, physics audience, social/aggregator readers, evaluators |
+| Temporality | Evergreen, always matches current state | Evergreen, synced with code (CI-verified examples) | Dated snapshot; may describe its moment |
+| Voice | Project voice, facts only | Neutral, task-oriented | Author's first person; opinions and story welcome |
+| Update policy | Continuous edits | Continuous edits | Append-oriented: major changes become new posts |
+
+The one-line identity is the only text shared verbatim across surfaces:
+README opening, docs landing opening, blog opening, and the GitHub
+repository description. Everything else varies by surface.
+
+### 4. Story moves to the blog
+
+The blog post becomes the canonical home of the project narrative
+(Julia-to-Rust background, AI-era development philosophy, verification
+philosophy, cross-ecosystem collaboration stance). The README compresses
+each of these to one paragraph plus a link to the blog post. Content that
+functions as durable policy (how changes are validated, contribution
+rules) stays in CONTRIBUTING / REPOSITORY_RULES / docs, not in the blog.
+
+## README redesign (329 lines → target ≈170)
+
+New section order, following the reader's decision sequence:
+
+| # | Section | Content |
+| --- | --- | --- |
+| 1 | Title + one-liner + badges | Unified one-liner, 2–3 sentence capability summary, crates.io/docs/CI/license badges (new) |
+| 2 | Quick Example | Current `cpu_quickstart` snippet moved up (~line 30); snippet-source markers preserved |
+| 3 | Is tenferro for you? | Rework of "When tenferro Is a Good Fit" + "Why Build On tenferro-rs": dynamic shapes, Rust-native AD, column-major alignment; one-line respectful positioning vs ndarray, candle/burn, faer; "if Python, use JAX/PyTorch" |
+| 4 | Which API Should I Use? | Current table kept as-is |
+| 5 | Crates | Core + extension tables kept; implementation crates compressed to one note line |
+| 6 | Documentation | Docs-site links, Getting Started first |
+| 7 | Project | One paragraph each: why it exists (+blog link), stability policy, engineering discipline (oracles, coverage, benchmarks), AI-assisted development (+blog link) |
+| 8 | Community | Matrix, issues, mailing list (kept) |
+| 9 | Acknowledgments | Kept, tightened by ~20–30% |
+| 10 | Contributing | Key points + CONTRIBUTING/GOVERNANCE links |
+
+Disposition of current sections: "Design Principles" bullets are absorbed
+into §3 and §7; "Why Build On tenferro-rs" merges into §3; "Benchmarks And
+Numerical Validation" merges into §7. No information is deleted outright;
+everything is compressed, relocated, or delegated to the blog.
+
+## docs/index.md
+
+Rewrite the opening paragraph only: unified one-liner + capability
+summary, with PyTorch/JAX demoted to explanatory anchors. Keep the
+"Where To Start" table, "First CPU Example", "Mental Model", and
+"Get In Touch" sections unchanged.
+
+## getting-started/
+
+Alignment edits only; no structural or content reorganization.
+
+- `index.md`, `core-concepts.md`: align opening framing with the
+  one-liner.
+- `pytorch-jax-mapping.md`: add an intro positioning it as a translation
+  guide for PyTorch/JAX users.
+
+## Blog post (separate repository)
+
+1. Align the opening line with the unified one-liner (currently a feature
+   list).
+2. Fix any drift against the current project state (post published
+   2026-06-23; expected minor).
+3. Absorb narrative elements compressed out of the README that the post
+   does not already cover (e.g., the cross-ecosystem collaboration
+   stance). The post already covers the Julia-to-Rust background,
+   AI-development model, and verification philosophy, so no major
+   additions are expected.
+4. Confirm/strengthen the closing pointer to docs Getting Started.
+
+Dependency: the website repository is not checked out locally under
+`~/tensor4all`; the maintainer will provide its location at
+implementation time. Blog changes ship as a separate PR in that
+repository.
+
+## Success criteria
+
+1. The first README screen answers "what / for whom / how is it
+   different".
+2. A runnable example appears near line 30 of the README.
+3. The one-liner matches across README, docs landing, blog opening, and
+   the GitHub repository description.
+4. snippet-source sync and CI doc checks (`check-docs-site.py`, doc
+   snippet tests) keep passing; `docs/_quarto.yml` is unchanged.
+
+## Constraints
+
+- README example stays snippet-source-synced with
+  `crates/tenferro-runtime/examples/cpu_quickstart.rs`.
+- tenferro-rs changes go through the normal PR flow (auto-merge, squash);
+  the implementation PR links a work log under `docs/worklogs/`.
+- References to other projects (ndarray, candle, burn, faer) are factual
+  and respectful.
+- crates.io per-crate `description` fields are out of scope for this
+  round.
+
+## Rejected alternatives
+
+- **"JAX/PyTorch in Rust" positioning** — invites head-on comparison with
+  candle/burn and sets deep-learning expectations (NN layers, optimizers)
+  the project deliberately does not serve.
+- **Dynamic-shape-first positioning** — strongest differentiator but too
+  abstract as a cold opening; readers must already understand traced
+  execution.
+- **Full docs-site restructure** — the existing Getting
+  Started/Tutorials/Guides/API/Internals structure is sound; cost and
+  risk outweigh the entry-page misalignment actually observed.
+- **Keeping full-length philosophy sections in the README** — blocks the
+  30-second fit decision for the primary audience; the narrative now has
+  a canonical home in the blog.
+- **New "Project" section on the docs site for the philosophy** — adds a
+  third surface to keep in sync; the blog post already exists, is fresh,
+  and fits the narrative role.

--- a/docs/superpowers/specs/2026-07-04-readme-docs-blog-audience-design.md
+++ b/docs/superpowers/specs/2026-07-04-readme-docs-blog-audience-design.md
@@ -100,10 +100,14 @@ summary, with PyTorch/JAX demoted to explanatory anchors. Keep the
 
 ## getting-started/
 
-Alignment edits only; no structural or content reorganization.
+Alignment edits only; no structural reorganization.
 
-- `index.md`, `core-concepts.md`: align opening framing with the
-  one-liner.
+- `index.md`: make Setup crates.io-first — the crates are published as of
+  2026-06-23, so the local-checkout-first text and the "Switch to crates.io
+  once published" block are factual drift. Keep the rest.
+- `core-concepts.md`: unchanged. Refined during planning: the page is
+  already task-oriented with no stale positioning, and repeating the
+  identity line on a sub-page adds nothing.
 - `pytorch-jax-mapping.md`: add an intro positioning it as a translation
   guide for PyTorch/JAX users.
 

--- a/docs/superpowers/specs/2026-07-04-readme-docs-blog-audience-design.md
+++ b/docs/superpowers/specs/2026-07-04-readme-docs-blog-audience-design.md
@@ -109,8 +109,15 @@ Alignment edits only; no structural or content reorganization.
 
 ## Blog post (separate repository)
 
-1. Align the opening line with the unified one-liner (currently a feature
-   list).
+Source: `tensor4all/tensor4all.github.io` (Jekyll site), checked out at
+`~/tensor4all/tensor4all.github.io`. The post exists in three language
+versions — `blog/introducing-tenferro-rs`, `…-rs-ja`, `…-rs-zh` — and
+every change below must be applied to all three in sync. Blog changes
+ship as a separate PR in that repository.
+
+1. Align the opening italic line with the unified one-liner (currently a
+   feature list). The H1 ("… a differentiable tensor stack for
+   scientific computing …") is already close and stays.
 2. Fix any drift against the current project state (post published
    2026-06-23; expected minor).
 3. Absorb narrative elements compressed out of the README that the post
@@ -119,11 +126,6 @@ Alignment edits only; no structural or content reorganization.
    AI-development model, and verification philosophy, so no major
    additions are expected.
 4. Confirm/strengthen the closing pointer to docs Getting Started.
-
-Dependency: the website repository is not checked out locally under
-`~/tensor4all`; the maintainer will provide its location at
-implementation time. Blog changes ship as a separate PR in that
-repository.
 
 ## Success criteria
 

--- a/docs/worklogs/2026-07-04-readme-docs-blog-audience-redesign.md
+++ b/docs/worklogs/2026-07-04-readme-docs-blog-audience-redesign.md
@@ -1,0 +1,48 @@
+# 2026-07-04 README / entry docs / blog audience redesign
+
+## Summary
+
+Retargeted the README, docs landing (`docs/index.md`), and getting-started
+entry pages at the primary audience settled in the design spec: Rust
+developers and researchers doing numerical / scientific computing, arriving
+cold from crates.io, search, or GitHub. Unified the project identity line
+across surfaces and compressed README narrative sections in favor of the
+introduction blog post, which becomes the canonical home of the project
+story. A companion PR in `tensor4all/tensor4all.github.io` aligns the blog
+post opening (en/ja/zh) with the same one-liner.
+
+## Context read
+
+- `docs/superpowers/specs/2026-07-04-readme-docs-blog-audience-design.md`
+  (design spec; decisions and rejected alternatives recorded there)
+- `README.md`, `docs/index.md`, `docs/getting-started/*.md`, `docs/_quarto.yml`
+- Blog post sources (en/ja/zh) in `tensor4all/tensor4all.github.io`
+- `scripts/check-doc-snippets.py`, `.github/workflows/ci.yml`
+- crates.io: verified `tenferro-runtime` / `tenferro-cpu` max version 0.2.0
+
+## Chosen design
+
+- One-liner everywhere: "A Rust-native tensor & autodiff stack for
+  scientific computing." (README, docs landing, blog opening, GitHub repo
+  description). PyTorch/JAX demoted to explanatory anchors.
+- README restructured to the reader's decision sequence: identity → quick
+  example → "Is tenferro for You?" (including respectful positioning vs
+  ndarray, Burn/candle, faer) → API/crate maps → docs links → compressed
+  Project section (why / stability / engineering discipline / AI-assisted
+  development, each one paragraph with links).
+- Getting Started setup switched to crates.io-first: the crates were
+  published on 2026-06-23, so the previous local-checkout-first text and the
+  "Switch to crates.io once published" block were factual drift.
+- `docs/getting-started/core-concepts.md` intentionally unchanged (already
+  task-oriented; no stale positioning).
+
+## Residual risks
+
+- `cargo llvm-cov` was not rerun for this diff: it changes Markdown only, no
+  Rust source or tests, so coverage is identical to `origin/main`.
+- The docs site rebuilds from `main`; until the companion website PR merges,
+  the blog opening briefly lags the README one-liner. Both PRs are tracked
+  to merge in the same session.
+- README line target (≈170) is approximate; the delivered README is 245
+  lines (down from 329). The acceptance criterion is the first-screen
+  decision flow — the quick example starts at line 21 — not the exact count.


### PR DESCRIPTION
## Summary

- Rewrites `README.md` around the audience decision in
  `docs/superpowers/specs/2026-07-04-readme-docs-blog-audience-design.md`:
  unified one-liner ("A Rust-native tensor & autodiff stack for scientific
  computing."), quick example moved to the top, new "Is tenferro for You?"
  section with respectful positioning vs ndarray/Burn/candle/faer, and the
  narrative sections compressed into a Project section that links the
  introduction blog post as the canonical story.
- Aligns the `docs/index.md` opening with the same one-liner.
- Getting Started setup becomes crates.io-first (`tenferro-runtime = "0.2"`,
  published 2026-06-23) and drops the stale "Switch to crates.io once
  published" block; the PyTorch/JAX mapping page is framed as a translation
  guide.
- Adds the design spec and work log
  (`docs/worklogs/2026-07-04-readme-docs-blog-audience-redesign.md`).

Companion PR: tensor4all/tensor4all.github.io PR aligning the blog post
opening (en/ja/zh) with the same one-liner.

## Verification

- `python3 scripts/check-doc-snippets.py --check`
- `cargo run -p tenferro-runtime --example cpu_quickstart --release`
- `cargo fmt --all --check`, `cargo test --workspace --release`
- `cargo doc --workspace --no-deps` + `python3 scripts/check-docs-site.py`
  (13 workspace library crates verified)
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD`
  → pass, no findings
- `cargo llvm-cov` intentionally skipped: Markdown-only diff, no Rust source
  changes (see work log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)