### PR TITLE
docs: add maintainer release/publish workflow and skill adapters

### DIFF
--- a/.agents/skills/tenferro-release-publish/SKILL.md
+++ b/.agents/skills/tenferro-release-publish/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: tenferro-release-publish
+description: Release a new tenferro-rs version. Use for workspace version bumps, tagging, crates.io publication in dependency order, and post-publish provenance verification. Publishing is irreversible and requires maintainer crates.io ownership. Do not use for ordinary feature or bug-fix PRs, and never publish from an unpushed or untagged commit.
+---
+
+# Tenferro Release And Publish
+
+Follow `ai/contribution-workflows/release-publish.md` as the canonical
+workflow. Read it fully before acting.
+
+Hard invariants (abort the release if any would be violated):
+
+1. Publish only from a pushed, tagged, main-lineage commit.
+2. The version bump merges to `main` before anything is published.
+3. No manifest edits at publish time; fix on `main` and re-tag instead.
+4. Git-pinned workspace dependencies must pin revs whose declared versions
+   exist on crates.io.
+
+Keep the interaction incremental:
+
+1. Confirm the target version and that `origin/main` is green and clean.
+2. Phase 1: version-bump PR (workspace version plus every internal
+   cross-crate `version = "..."` requirement) and the full pre-push
+   checklist.
+3. Phase 2: tag the merged commit and push the tag.
+4. Phase 3: publish crates in dependency order from a worktree of the tag,
+   waiting for the registry index between crates. Confirm with the user
+   immediately before the first `cargo publish`.
+5. Phase 4: verify crates.io versions and `.cargo_vcs_info.json`
+   provenance, then clean up.

--- a/.claude/skills/tenferro-release-publish/SKILL.md
+++ b/.claude/skills/tenferro-release-publish/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: tenferro-release-publish
+description: Release a new tenferro-rs version. Use for workspace version bumps, tagging, crates.io publication in dependency order, and post-publish provenance verification. Publishing is irreversible and requires maintainer crates.io ownership. Do not use for ordinary feature or bug-fix PRs, and never publish from an unpushed or untagged commit.
+---
+
+# Tenferro Release And Publish
+
+Follow `ai/contribution-workflows/release-publish.md` as the canonical
+workflow. Read it fully before acting.
+
+Hard invariants (abort the release if any would be violated):
+
+1. Publish only from a pushed, tagged, main-lineage commit.
+2. The version bump merges to `main` before anything is published.
+3. No manifest edits at publish time; fix on `main` and re-tag instead.
+4. Git-pinned workspace dependencies must pin revs whose declared versions
+   exist on crates.io.
+
+Keep the interaction incremental:
+
+1. Confirm the target version and that `origin/main` is green and clean.
+2. Phase 1: version-bump PR (workspace version plus every internal
+   cross-crate `version = "..."` requirement) and the full pre-push
+   checklist.
+3. Phase 2: tag the merged commit and push the tag.
+4. Phase 3: publish crates in dependency order from a worktree of the tag,
+   waiting for the registry index between crates. Confirm with the user
+   immediately before the first `cargo publish`.
+5. Phase 4: verify crates.io versions and `.cargo_vcs_info.json`
+   provenance, then clean up.

--- a/.kimi/skills/tenferro-release-publish/SKILL.md
+++ b/.kimi/skills/tenferro-release-publish/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: tenferro-release-publish
+description: Release a new tenferro-rs version. Use for workspace version bumps, tagging, crates.io publication in dependency order, and post-publish provenance verification. Publishing is irreversible and requires maintainer crates.io ownership. Do not use for ordinary feature or bug-fix PRs, and never publish from an unpushed or untagged commit.
+---
+
+# Tenferro Release And Publish
+
+Follow `ai/contribution-workflows/release-publish.md` as the canonical
+workflow. Read it fully before acting.
+
+Hard invariants (abort the release if any would be violated):
+
+1. Publish only from a pushed, tagged, main-lineage commit.
+2. The version bump merges to `main` before anything is published.
+3. No manifest edits at publish time; fix on `main` and re-tag instead.
+4. Git-pinned workspace dependencies must pin revs whose declared versions
+   exist on crates.io.
+
+Keep the interaction incremental:
+
+1. Confirm the target version and that `origin/main` is green and clean.
+2. Phase 1: version-bump PR (workspace version plus every internal
+   cross-crate `version = "..."` requirement) and the full pre-push
+   checklist.
+3. Phase 2: tag the merged commit and push the tag.
+4. Phase 3: publish crates in dependency order from a worktree of the tag,
+   waiting for the registry index between crates. Confirm with the user
+   immediately before the first `cargo publish`.
+5. Phase 4: verify crates.io versions and `.cargo_vcs_info.json`
+   provenance, then clean up.

--- a/.opencode/commands/tenferro-release-publish.md
+++ b/.opencode/commands/tenferro-release-publish.md
@@ -1,0 +1,18 @@
+---
+description: Release a new tenferro-rs version - bump the workspace version on main, tag the merged commit, publish crates to crates.io in dependency order, and verify provenance. Maintainer-only; publishing is irreversible.
+---
+
+Use `$ARGUMENTS` as the target version or initial request if present.
+
+Follow `ai/contribution-workflows/release-publish.md` as the canonical
+workflow. Read it fully before acting.
+
+Hard invariants (abort the release if any would be violated): publish only
+from a pushed, tagged, main-lineage commit; land the version bump on `main`
+before publishing; never edit manifests at publish time (fix on `main` and
+re-tag instead); git-pinned workspace dependencies must pin revs whose
+declared versions exist on crates.io.
+
+Proceed phase by phase — version-bump PR, tag, dependency-order publish from
+a worktree of the tag, post-publish verification — and confirm with the user
+immediately before the first `cargo publish`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,9 @@ issues or bug-fix PRs:
 - `ai/contribution-workflows/repository-remediation.md` for batched,
   agent-assisted remediation of repository-rule violations across multiple
   related issues or findings.
+- `ai/contribution-workflows/release-publish.md` for maintainer releases:
+  workspace version bumps, tagging, dependency-order crates.io publication,
+  and post-publish provenance verification.
 
 Do not open a new-feature implementation PR before maintainers accept the
 corresponding issue. If a proposed bug-fix PR needs a new public API, operation

--- a/ai/README.md
+++ b/ai/README.md
@@ -10,7 +10,8 @@ optional sibling checkout fallback documented in `AGENTS.md`.
 ## Contents
 
 - `contribution-workflows/`: reusable repository-local workflows for issue
-  intake and bug-fix pull requests.
+  intake, bug-fix pull requests, batched repository-rule remediation, and
+  maintainer release/publish.
 - `repo-settings.json`: the expected GitHub repository settings and required
   branch protection checks for this repository.
 - `run-codex-solve-bug.sh`, `run-claude-solve-bug.sh`, and

--- a/ai/contribution-workflows/release-publish.md
+++ b/ai/contribution-workflows/release-publish.md
@@ -1,0 +1,117 @@
+# Release And Publish Workflow
+
+Maintainer workflow for releasing a new tenferro-rs version to crates.io.
+Publishing is irreversible: published versions cannot be replaced, only
+yanked. Only maintainers with crates.io ownership run Phase 3.
+
+## Why This Workflow Exists
+
+The v0.2.0 release (2026-06-28) was published from a local-only branch
+(`release/v0.2.0`) with post-hoc dependency rewrites. The branch was not
+pushed, not tagged, and not merged, so `main` kept version 0.1.0 and the
+published source had no corresponding commit on GitHub until cleanup a week
+later. The invariants below make that failure mode structurally impossible.
+
+## Invariants
+
+Violating any of these aborts the release.
+
+1. Publish only from a commit that is pushed to `origin`, tagged `vX.Y.Z`,
+   and reachable from `main`.
+2. The version bump lands on `main` before anything is published.
+3. No manifest edits at publish time. The tagged tree must be publishable
+   as-is; if a crate needs an edit to publish, abort, fix on `main`, and
+   re-tag as a new patch version.
+4. Every git-pinned dependency in `[workspace.dependencies]` must pin a rev
+   whose declared `version` exists on crates.io, because `cargo publish`
+   strips the `git` source and keeps only `version`.
+
+## Phase 0 — Preconditions
+
+- Fresh worktree of the latest `origin/main`; clean tree; CI green on
+  `origin/main`.
+- Pick the new version `X.Y.Z`. Pre-1.0 convention: breaking changes bump
+  the minor version; compatible fixes bump the patch version.
+- Run `python3 scripts/check-publish-layout.py` and fix findings first.
+
+## Phase 1 — Version-Bump PR To Main
+
+1. Branch `release/vX.Y.Z-prep` from `origin/main`.
+2. Bump `[workspace.package] version` in the root `Cargo.toml`.
+3. Bump every internal cross-crate requirement in `crates/*/Cargo.toml` to
+   the same version. These look like
+   `tenferro-foo = { path = "../tenferro-foo", version = "X.Y.Z", ... }`
+   and MUST match the new workspace version, or dependency resolution
+   fails. Find them with:
+
+   ```bash
+   grep -rn 'tenferro-.*path = "\.\./' crates/*/Cargo.toml
+   ```
+
+   (With `cargo-edit` installed, `cargo set-version --workspace X.Y.Z`
+   performs steps 2-3 in one command.)
+4. Verify locally:
+
+   ```bash
+   cargo metadata --format-version 1 > /dev/null   # resolution sanity
+   python3 scripts/check-publish-layout.py
+   ```
+
+   then run the full pre-push checklist from `AGENTS.md`. Note:
+   `cargo publish --dry-run` works only for crates whose internal
+   dependencies are already on the registry at the new version, so deep
+   crates are verified live in Phase 3; that is expected.
+5. Open the PR to `main` and merge it through the normal auto-merge flow.
+
+## Phase 2 — Tag
+
+1. `git fetch origin main` and identify the merged bump commit.
+2. `git tag vX.Y.Z <merged-commit> && git push origin vX.Y.Z`.
+3. Recommended: `gh release create vX.Y.Z --generate-notes`.
+
+## Phase 3 — Publish From The Tag
+
+1. `git worktree add <fresh-path> vX.Y.Z`; confirm the tree is clean and
+   `python3 scripts/check-publish-layout.py` passes unchanged.
+2. Publish publishable crates in dependency order. As of 2026-07 the order
+   is:
+
+   ```text
+   tenferro-core-ops
+   tenferro-internal-extension-macros
+   tenferro-tensor-core
+   tenferro-tensor
+   tenferro-cpu
+   tenferro-gpu
+   tenferro-internal-ops
+   tenferro-runtime
+   tenferro-xla
+   tenferro-ad
+   tenferro-einsum
+   tenferro-fft
+   tenferro-linalg
+   ```
+
+   Crates with `publish = false` (currently `tenferro-tutorial-code`) are
+   skipped. When workspace membership or dependencies change, recompute the
+   order from `cargo metadata` (topological sort of workspace members over
+   their `tenferro-*` dependencies) instead of trusting this list.
+3. For each crate run `cargo publish -p <crate>`. A dependent crate fails
+   until the registry index has its dependencies; wait roughly 30 seconds
+   and retry before treating a failure as real.
+4. If any crate cannot publish without a manifest change: stop publishing,
+   fix the manifest on `main` through Phase 1, and restart at Phase 2 with
+   the next patch version. Crates already published stay published; the
+   remaining crates ship only at the new version, so prefer aborting before
+   any crate has been published when possible.
+
+## Phase 4 — Verify And Close
+
+1. For every published crate, confirm crates.io reports
+   `max_version == X.Y.Z`.
+2. Fetch one published crate's source (registry cache under
+   `~/.cargo/registry/src/` after any consumer build, or the `.crate` file)
+   and confirm `.cargo_vcs_info.json` records the tagged commit, and that
+   the commit is on `origin` and reachable from `main`.
+3. Remove the release worktree. Update downstream pins and announcements
+   (Matrix, blog for major releases) as appropriate.

--- a/docs/worklogs/2026-07-04-release-publish-workflow.md
+++ b/docs/worklogs/2026-07-04-release-publish-workflow.md
@@ -1,0 +1,40 @@
+# 2026-07-04 Release/publish workflow and adapters
+
+## Summary
+
+Added `ai/contribution-workflows/release-publish.md` as the canonical
+maintainer release workflow, with thin adapters
+(`tenferro-release-publish`) under `.claude/skills/`, `.agents/skills/`,
+`.kimi/skills/`, and `.opencode/commands/`, and registered the workflow in
+`AGENTS.md` and `ai/README.md`.
+
+## Context
+
+Investigation of the crates.io v0.2.0 release found it was published
+(2026-06-28) from a local-only branch `release/v0.2.0` with publish-time
+dependency rewrites; the branch was neither pushed, tagged, nor merged, so
+`main` stayed at 0.1.0 and the published source had no commit on GitHub. As
+cleanup, the branch was pushed, `v0.2.0` was tagged on the publish commit
+(`cee2a6d4`), and a companion PR reflects version 0.2.0 on `main` via an
+`-s ours` lineage merge.
+
+## Chosen design
+
+- Four-phase flow: version-bump PR to `main` → tag the merged commit →
+  publish from a worktree of the tag in dependency order → provenance
+  verification against `.cargo_vcs_info.json`.
+- Invariants forbid publishing from unpushed/untagged commits and forbid
+  publish-time manifest edits (fix on `main`, re-tag a patch version).
+- The version bump must update both `[workspace.package] version` and every
+  internal cross-crate `version = "..."` requirement; missing the latter
+  breaks dependency resolution (hit during the companion cleanup PR).
+
+## Residual risks
+
+- The publish order list is a snapshot; the workflow instructs recomputing
+  it from `cargo metadata` when workspace membership changes.
+- `cargo publish --dry-run` cannot fully verify deep crates before their
+  dependencies exist on the registry at the new version; deep crates are
+  verified live during Phase 3.
+- Test suite not rerun locally for this docs-only branch (code tree
+  identical to `origin/main`); PR CI gates the merge.


### PR DESCRIPTION
## Summary

- Adds `ai/contribution-workflows/release-publish.md`: the canonical
  maintainer workflow for releasing to crates.io (version-bump PR → tag the
  merged commit → dependency-order publish from a worktree of the tag →
  `.cargo_vcs_info.json` provenance verification).
- Adds `tenferro-release-publish` thin adapters for Claude Code
  (`.claude/skills/`), Codex (`.agents/skills/`), Kimi (`.kimi/skills/`),
  and OpenCode (`.opencode/commands/`), mirroring the existing
  `tenferro-bugfix-pr` adapter pattern.
- Registers the workflow in `AGENTS.md` and `ai/README.md`; adds a work log.

## Background

The v0.2.0 crates.io release was published from a local-only branch with
publish-time dependency rewrites and never reached `main` (no push, no tag,
no merge). The workflow's invariants make that failure mode structurally
impossible. Companion cleanup PR reflects 0.2.0 on `main` and records the
release lineage.

## Verification

- `cargo fmt --all --check`, `python3 scripts/check-doc-snippets.py --check`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD`
  → pass, no findings
- Markdown/workflow-assets-only diff; the code tree is identical to
  `origin/main`, so the test/coverage state matches main's green CI (PR CI
  gates the merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)