### PR TITLE
Implement extension contract split

### DIFF
--- a/crates/tenferro-ad/src/context.rs
+++ b/crates/tenferro-ad/src/context.rs
@@ -13,7 +13,7 @@ use tenferro_runtime::{Result, TracedTensor};
 /// use tenferro_ad::AdContext;
 ///
 /// let ad = AdContext::builder().build().unwrap();
-/// assert!(ad.extension_rules().lookup_rule("example.missing.v1").is_none());
+/// assert!(ad.extension_rules().lookup_linearize("example.missing.v1").is_none());
 /// ```
 #[derive(Clone, Debug)]
 pub struct AdContext {
@@ -42,7 +42,7 @@ impl AdContext {
     /// use tenferro_ad::AdContext;
     ///
     /// let ad = AdContext::builder().build().unwrap();
-    /// assert!(!ad.extension_rules().is_rule_registered("example.missing.v1"));
+    /// assert!(!ad.extension_rules().is_linearize_registered("example.missing.v1"));
     /// ```
     pub fn extension_rules(&self) -> &ExtensionRuleSet {
         &self.extension_rules
@@ -204,7 +204,7 @@ impl AdContext {
 /// use tenferro_ad::AdContextBuilder;
 ///
 /// let ad = AdContextBuilder::new().build().unwrap();
-/// assert!(ad.extension_rules().lookup_rule("example.missing.v1").is_none());
+/// assert!(ad.extension_rules().lookup_linearize("example.missing.v1").is_none());
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct AdContextBuilder {
@@ -252,7 +252,7 @@ impl AdContextBuilder {
     /// use tenferro_ad::AdContext;
     ///
     /// let ad = AdContext::builder().build().unwrap();
-    /// assert!(ad.extension_rules().lookup_rule("example.missing.v1").is_none());
+    /// assert!(ad.extension_rules().lookup_linearize("example.missing.v1").is_none());
     /// ```
     pub fn build(self) -> std::result::Result<AdContext, ExtensionRegistryError> {
         let mut extension_rules = ExtensionRuleSet::new();

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -10,7 +10,7 @@ use computegraph::resolve::resolve;
 use computegraph::types::ValueKey;
 use computegraph::{OperationRole, ValueRef};
 use tenferro_cpu::CpuBackend;
-use tenferro_ops::ext_op::ExtensionOp;
+use tenferro_ops::ext_op::{ExtensionOp, HostReference};
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeExtent, ShapeGuardContext, SymDim, TensorMeta};
@@ -260,7 +260,13 @@ impl ExtensionOp for ReadPathFallbackProbe {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for ReadPathFallbackProbe {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         Ok(vec![inputs[0].clone()])
     }
 }
@@ -279,7 +285,11 @@ impl<B: TensorBackend + 'static> ExtensionRuntime<B> for ReadPathFallbackRuntime
         inputs: &[&Tensor],
         _ctx: &mut ExtensionExecutionContext<'_, B>,
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
-        op.eager_execute(inputs)
+        op.host_reference()
+            .ok_or(tenferro_tensor::Error::NoHostReference {
+                family_id: op.family_id(),
+            })?
+            .execute(inputs)
     }
 
     fn execute_reads(

--- a/crates/tenferro-ad/src/eager_exec/tests.rs
+++ b/crates/tenferro-ad/src/eager_exec/tests.rs
@@ -336,8 +336,4 @@ impl ExtensionOp for TestExtension {
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
-
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![inputs[0].clone()])
-    }
 }

--- a/crates/tenferro-ad/src/extension.rs
+++ b/crates/tenferro-ad/src/extension.rs
@@ -10,7 +10,10 @@ use tenferro_tensor::{Tensor, TensorValue};
 
 use crate::eager::{record_eager_outputs, EagerRuntime, EagerTensor};
 
-pub use tenferro_ops::ext_op::{ExtensionAdRule, ExtensionRegistryError, ExtensionRuleSet};
+pub use tenferro_ops::ext_op::{
+    ExtensionLinearTransposeRule, ExtensionLinearizeRule, ExtensionPrimalVjpRule,
+    ExtensionRegistryError, ExtensionRuleRole, ExtensionRuleSet, HostReference,
+};
 pub use tenferro_runtime::extension::{
     apply, ExtensionCacheKey, ExtensionCacheLimits, ExtensionCacheSelector, ExtensionCacheStore,
     ExtensionExecutionContext, ExtensionExecutor, ExtensionFamilyId, ExtensionOp,

--- a/crates/tenferro-ad/src/traced/primal_transpose.rs
+++ b/crates/tenferro-ad/src/traced/primal_transpose.rs
@@ -254,8 +254,12 @@ pub(super) fn try_primal_transpose(
             &wrt_value_key_set,
             &mut dependency_memo,
         );
-        let transpose_mode = OperationRole::Linearized {
-            active_mask: active_mask.clone(),
+        let transpose_mode = if matches!(op_key.operation(), StdTensorOp::Extension(_)) {
+            OperationRole::Primary
+        } else {
+            OperationRole::Linearized {
+                active_mask: active_mask.clone(),
+            }
         };
 
         ctx.set_transpose_primal_outputs(Some(output_keys.clone()));
@@ -267,13 +271,8 @@ pub(super) fn try_primal_transpose(
             &transpose_mode,
             ctx,
         );
-        let used_primal_outputs = ctx.transpose_primal_outputs_were_used();
         ctx.set_transpose_primal_outputs(None);
         let cotangent_in = cotangent_in?;
-
-        if matches!(op_key.operation(), StdTensorOp::Extension(_)) && !used_primal_outputs {
-            return Err(unsupported_primal_transpose(op_key.operation()));
-        }
 
         if cotangent_in.len() != rule_inputs.len() {
             return Err(ADRuleError::invalid_input(

--- a/crates/tenferro-ad/tests/extension_op.rs
+++ b/crates/tenferro-ad/tests/extension_op.rs
@@ -14,7 +14,7 @@
 //! hand-computed expected values.
 
 use tenferro_ad::TracedTensorAdExt;
-use tenferro_ad::{AdContext, AdContextBuilder, EagerRuntime, EagerTensor};
+use tenferro_ad::{AdContext, AdContextBuilder, EagerBackend, EagerRuntime, EagerTensor};
 #[path = "extension_op/api_and_registry.rs"]
 mod api_and_registry;
 mod support;
@@ -25,16 +25,19 @@ use support::RunTraced;
 
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use num_complex::{Complex32, Complex64};
-use tenferro_ad::extension::{apply_eager, ExtensionAdRule, ExtensionRuleSet};
+use tenferro_ad::extension::{
+    apply_eager, ExtensionLinearTransposeRule, ExtensionLinearizeRule, ExtensionPrimalVjpRule,
+    ExtensionRuleRole, ExtensionRuleSet, HostReference,
+};
 use tenferro_cpu::CpuBackend;
 use tenferro_ops::ad::PrimitiveRuleBuilder;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeGuardContext, SymDim};
-use tenferro_runtime::extension::{apply, ExtensionExecutionContext, ExtensionRuntime};
+use tenferro_runtime::extension::{apply, HostReferenceRuntime};
 use tenferro_runtime::{Error as RuntimeError, GraphExecutor, Tensor, TracedTensor};
-use tenferro_tensor::{DType, TensorBackend, TensorRead, TypedTensor};
+use tenferro_tensor::{DType, TensorBackend, TypedTensor};
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 // ----------------------------------------------------------------------
@@ -83,7 +86,13 @@ impl ExtensionOp for TestScaleBy2 {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for TestScaleBy2 {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         let input = inputs[0];
         // Reuse the same strategy the AD rules use: output = input + input.
         match input {
@@ -108,7 +117,7 @@ impl ExtensionOp for TestScaleBy2 {
 #[derive(Debug)]
 struct TestScaleBy2Rule;
 
-impl ExtensionAdRule for TestScaleBy2Rule {
+impl ExtensionLinearizeRule for TestScaleBy2Rule {
     fn family_id(&self) -> &'static str {
         "tenferro-tests.scale_by_2.v1"
     }
@@ -136,14 +145,20 @@ impl ExtensionAdRule for TestScaleBy2Rule {
             None => Ok(vec![None]),
         }
     }
+}
 
-    fn transpose_rule(
+impl ExtensionLinearTransposeRule for TestScaleBy2Rule {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.scale_by_2.v1"
+    }
+
+    fn linear_transpose(
         &self,
         _op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         _inputs: &[ValueRef<StdTensorOp>],
-        _mode: &OperationRole,
+        _active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         match cotangent_out[0] {
@@ -164,7 +179,9 @@ impl ExtensionAdRule for TestScaleBy2Rule {
 
 fn scale_by_2_rules() -> ExtensionRuleSet {
     ExtensionRuleSet::new()
-        .with_rule(Arc::new(TestScaleBy2Rule))
+        .with_linearize(Arc::new(TestScaleBy2Rule))
+        .expect("scale_by_2 linearize rule registration")
+        .with_linear_transpose(Arc::new(TestScaleBy2Rule))
         .expect("scale_by_2 rule registration")
 }
 
@@ -226,7 +243,13 @@ impl ExtensionOp for TestSwap {
         ])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for TestSwap {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         Ok(vec![inputs[1].clone(), inputs[0].clone()])
     }
 }
@@ -234,7 +257,7 @@ impl ExtensionOp for TestSwap {
 #[derive(Debug)]
 struct TestSwapRule;
 
-impl ExtensionAdRule for TestSwapRule {
+impl ExtensionLinearizeRule for TestSwapRule {
     fn family_id(&self) -> &'static str {
         "tenferro-tests.swap.v1"
     }
@@ -250,14 +273,20 @@ impl ExtensionAdRule for TestSwapRule {
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![tangent_in[1], tangent_in[0]])
     }
+}
 
-    fn transpose_rule(
+impl ExtensionLinearTransposeRule for TestSwapRule {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.swap.v1"
+    }
+
+    fn linear_transpose(
         &self,
         _op: &dyn ExtensionOp,
         _builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         _inputs: &[ValueRef<StdTensorOp>],
-        _mode: &OperationRole,
+        _active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![cotangent_out[1], cotangent_out[0]])
@@ -266,7 +295,9 @@ impl ExtensionAdRule for TestSwapRule {
 
 fn swap_rules() -> ExtensionRuleSet {
     ExtensionRuleSet::new()
-        .with_rule(Arc::new(TestSwapRule))
+        .with_linearize(Arc::new(TestSwapRule))
+        .expect("swap linearize rule registration")
+        .with_linear_transpose(Arc::new(TestSwapRule))
         .expect("swap rule registration")
 }
 
@@ -325,7 +356,13 @@ impl ExtensionOp for TestPreferLinearize {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for TestPreferLinearize {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         Ok(vec![inputs[0].clone()])
     }
 }
@@ -333,7 +370,7 @@ impl ExtensionOp for TestPreferLinearize {
 #[derive(Debug)]
 struct TestPreferLinearizeRule;
 
-impl ExtensionAdRule for TestPreferLinearizeRule {
+impl ExtensionLinearizeRule for TestPreferLinearizeRule {
     fn family_id(&self) -> &'static str {
         "tenferro-tests.prefer_linearize.v1"
     }
@@ -349,14 +386,19 @@ impl ExtensionAdRule for TestPreferLinearizeRule {
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![tangent_in[0]])
     }
+}
 
-    fn transpose_rule(
+impl ExtensionPrimalVjpRule for TestPreferLinearizeRule {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.prefer_linearize.v1"
+    }
+
+    fn primal_vjp(
         &self,
         _op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         _inputs: &[ValueRef<StdTensorOp>],
-        _mode: &OperationRole,
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let _ = ctx.transpose_primal_outputs();
@@ -378,7 +420,9 @@ impl ExtensionAdRule for TestPreferLinearizeRule {
 
 fn prefer_linearize_rules() -> ExtensionRuleSet {
     ExtensionRuleSet::new()
-        .with_rule(Arc::new(TestPreferLinearizeRule))
+        .with_linearize(Arc::new(TestPreferLinearizeRule))
+        .expect("prefer_linearize linearize rule registration")
+        .with_primal_vjp(Arc::new(TestPreferLinearizeRule))
         .expect("prefer_linearize rule registration")
 }
 
@@ -435,7 +479,13 @@ impl ExtensionOp for TestPrimaryTransposeOnly {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for TestPrimaryTransposeOnly {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         Ok(vec![inputs[0].clone()])
     }
 }
@@ -443,7 +493,7 @@ impl ExtensionOp for TestPrimaryTransposeOnly {
 #[derive(Debug)]
 struct TestPrimaryTransposeOnlyRule;
 
-impl ExtensionAdRule for TestPrimaryTransposeOnlyRule {
+impl ExtensionLinearizeRule for TestPrimaryTransposeOnlyRule {
     fn family_id(&self) -> &'static str {
         "tenferro-tests.primary_transpose_only.v1"
     }
@@ -465,14 +515,19 @@ impl ExtensionAdRule for TestPrimaryTransposeOnlyRule {
             ADRuleKind::Jvp,
         ))
     }
+}
 
-    fn transpose_rule(
+impl ExtensionPrimalVjpRule for TestPrimaryTransposeOnlyRule {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.primary_transpose_only.v1"
+    }
+
+    fn primal_vjp(
         &self,
         _op: &dyn ExtensionOp,
         _builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         _inputs: &[ValueRef<StdTensorOp>],
-        _mode: &OperationRole,
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let _ = ctx.transpose_primal_outputs();
@@ -484,7 +539,9 @@ fn primary_transpose_only_ad_context() -> AdContext {
     AdContext::builder()
         .with_extension_rules(
             ExtensionRuleSet::new()
-                .with_rule(Arc::new(TestPrimaryTransposeOnlyRule))
+                .with_linearize(Arc::new(TestPrimaryTransposeOnlyRule))
+                .expect("primary_transpose_only linearize registration")
+                .with_primal_vjp(Arc::new(TestPrimaryTransposeOnlyRule))
                 .expect("primary_transpose_only rule registration"),
         )
         .build()
@@ -533,7 +590,13 @@ impl ExtensionOp for TestNoAd {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for TestNoAd {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         Ok(vec![inputs[0].clone()])
     }
 }
@@ -585,7 +648,13 @@ impl ExtensionOp for TestProbeIdentity {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for TestProbeIdentity {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         Ok(vec![inputs[0].clone()])
     }
 }
@@ -632,7 +701,13 @@ impl ExtensionOp for TestProbeLinear {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for TestProbeLinear {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         Ok(vec![inputs[0].clone()])
     }
 }
@@ -640,7 +715,7 @@ impl ExtensionOp for TestProbeLinear {
 #[derive(Debug)]
 struct TestProbeIdentityRule;
 
-impl ExtensionAdRule for TestProbeIdentityRule {
+impl ExtensionLinearizeRule for TestProbeIdentityRule {
     fn family_id(&self) -> &'static str {
         "tenferro-tests.probe_identity.v1"
     }
@@ -676,47 +751,23 @@ impl ExtensionAdRule for TestProbeIdentityRule {
         );
         Ok(vec![Some(out[0])])
     }
-
-    fn transpose_rule(
-        &self,
-        _op: &dyn ExtensionOp,
-        _builder: &mut dyn PrimitiveRuleBuilder,
-        cotangent_out: &[Option<LocalValueId>],
-        _inputs: &[ValueRef<StdTensorOp>],
-        _mode: &OperationRole,
-        _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        Ok(vec![cotangent_out[0], None])
-    }
 }
 
 #[derive(Debug)]
 struct TestProbeLinearRule;
 
-impl ExtensionAdRule for TestProbeLinearRule {
+impl ExtensionLinearTransposeRule for TestProbeLinearRule {
     fn family_id(&self) -> &'static str {
         "tenferro-tests.probe_linear.v1"
     }
 
-    fn linearize(
-        &self,
-        _op: &dyn ExtensionOp,
-        _builder: &mut dyn PrimitiveRuleBuilder,
-        _primal_in: &[ValueKey<StdTensorOp>],
-        _primal_out: &[ValueKey<StdTensorOp>],
-        tangent_in: &[Option<LocalValueId>],
-        _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        Ok(vec![tangent_in[0]])
-    }
-
-    fn transpose_rule(
+    fn linear_transpose(
         &self,
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         inputs: &[ValueRef<StdTensorOp>],
-        _mode: &OperationRole,
+        _active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let Some(ct) = cotangent_out[0] else {
@@ -782,7 +833,13 @@ impl ExtensionOp for TestBadOutputCount {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for TestBadOutputCount {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         Ok(vec![inputs[0].clone()])
     }
 }
@@ -793,9 +850,9 @@ impl ExtensionOp for TestBadOutputCount {
 
 fn probe_rules() -> ExtensionRuleSet {
     ExtensionRuleSet::new()
-        .with_rule(Arc::new(TestProbeIdentityRule))
+        .with_linearize(Arc::new(TestProbeIdentityRule))
         .expect("probe identity rule registration")
-        .with_rule(Arc::new(TestProbeLinearRule))
+        .with_linear_transpose(Arc::new(TestProbeLinearRule))
         .expect("probe linear rule registration")
 }
 
@@ -820,40 +877,6 @@ fn f64_slice(tensor: &Tensor) -> &[f64] {
     }
 }
 
-#[derive(Debug)]
-struct TestRuntime {
-    family_id: &'static str,
-}
-
-impl<B: TensorBackend + 'static> ExtensionRuntime<B> for TestRuntime {
-    fn family_id(&self) -> &'static str {
-        self.family_id
-    }
-
-    fn execute(
-        &self,
-        op: &dyn ExtensionOp,
-        inputs: &[&Tensor],
-        _ctx: &mut ExtensionExecutionContext<'_, B>,
-    ) -> tenferro_tensor::Result<Vec<Tensor>> {
-        op.eager_execute(inputs)
-    }
-
-    fn execute_reads(
-        &self,
-        op: &dyn ExtensionOp,
-        inputs: &[TensorRead<'_>],
-        ctx: &mut ExtensionExecutionContext<'_, B>,
-    ) -> tenferro_tensor::Result<Vec<Tensor>> {
-        let materialized_inputs: Vec<Tensor> = inputs
-            .iter()
-            .map(TensorRead::to_tensor)
-            .collect::<tenferro_tensor::Result<_>>()?;
-        let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
-        self.execute(op, &input_refs, ctx)
-    }
-}
-
 fn register_test_runtime<B: TensorBackend + 'static>(
     executor: &mut GraphExecutor<B>,
     family_id: &'static str,
@@ -862,7 +885,7 @@ fn register_test_runtime<B: TensorBackend + 'static>(
         .register_extension(|extension_executor| {
             extension_executor
                 .registry_mut()
-                .register(Arc::new(TestRuntime { family_id }))
+                .register(Arc::new(HostReferenceRuntime::<B>::new(family_id)))
         })
         .expect("register test extension runtime");
 }
@@ -870,9 +893,9 @@ fn register_test_runtime<B: TensorBackend + 'static>(
 fn register_test_eager_runtime(runtime: &EagerRuntime, family_id: &'static str) {
     runtime
         .register_extension(|extension_executor| {
-            extension_executor
-                .registry_mut()
-                .register(Arc::new(TestRuntime { family_id }))
+            extension_executor.registry_mut().register(Arc::new(
+                HostReferenceRuntime::<EagerBackend>::new(family_id),
+            ))
         })
         .expect("register test eager extension runtime");
 }
@@ -957,16 +980,17 @@ fn ad_context_uses_owned_extension_rules_without_global_fallback() {
     };
     assert!(err.to_string().contains("tenferro-tests.scale_by_2.v1"));
 
-    let rules = ExtensionRuleSet::new()
-        .with_rule(Arc::new(TestScaleBy2Rule))
-        .expect("owned scale_by_2 rule registration");
+    let rules = scale_by_2_rules();
     let ad = AdContext::builder()
         .with_extension_rules(rules)
         .build()
         .unwrap();
     assert!(ad
         .extension_rules()
-        .is_rule_registered("tenferro-tests.scale_by_2.v1"));
+        .is_linearize_registered("tenferro-tests.scale_by_2.v1"));
+    assert!(ad
+        .extension_rules()
+        .is_linear_transpose_registered("tenferro-tests.scale_by_2.v1"));
 
     let grad = ad
         .grad_optional(&loss, &x)
@@ -1066,12 +1090,8 @@ fn traced_vjp_primary_transpose_fallback_reports_inactive_wrt() {
 
 #[test]
 fn ad_context_builder_rejects_duplicate_extension_rule_sets() {
-    let first = ExtensionRuleSet::new()
-        .with_rule(Arc::new(TestScaleBy2Rule))
-        .expect("first rule set");
-    let second = ExtensionRuleSet::new()
-        .with_rule(Arc::new(TestScaleBy2Rule))
-        .expect("second rule set");
+    let first = scale_by_2_rules();
+    let second = scale_by_2_rules();
 
     let err = AdContextBuilder::new()
         .with_extension_rules(first)
@@ -1081,7 +1101,8 @@ fn ad_context_builder_rejects_duplicate_extension_rule_sets() {
     assert!(matches!(
         err,
         tenferro_ad::extension::ExtensionRegistryError::DuplicateRule {
-            family_id: "tenferro-tests.scale_by_2.v1"
+            family_id: "tenferro-tests.scale_by_2.v1",
+            role: ExtensionRuleRole::Linearize
         }
     ));
 }
@@ -1107,9 +1128,7 @@ fn eager_runtime_ad_context_uses_owned_extension_rules_without_global_fallback()
         .expect_err("explicit empty rule set should not use global fallback");
     assert!(err.to_string().contains("tenferro-tests.scale_by_2.v1"));
 
-    let rules = ExtensionRuleSet::new()
-        .with_rule(Arc::new(TestScaleBy2Rule))
-        .expect("owned scale_by_2 rule registration");
+    let rules = scale_by_2_rules();
     let ad = AdContext::builder()
         .with_extension_rules(rules)
         .build()

--- a/crates/tenferro-ad/tests/extension_op/api_and_registry.rs
+++ b/crates/tenferro-ad/tests/extension_op/api_and_registry.rs
@@ -308,12 +308,13 @@ fn duplicate_rule_registration_is_rejected() {
 
     let mut rules = scale_by_2_rules();
     let err = rules
-        .register_rule(Arc::new(TestScaleBy2Rule))
+        .register_linearize(Arc::new(TestScaleBy2Rule))
         .expect_err("second rule registration must error");
     assert!(matches!(
         err,
         ExtensionRegistryError::DuplicateRule {
-            family_id: "tenferro-tests.scale_by_2.v1"
+            family_id: "tenferro-tests.scale_by_2.v1",
+            role: ExtensionRuleRole::Linearize
         }
     ));
 }
@@ -324,7 +325,7 @@ fn malformed_family_id_is_rejected() {
 
     #[derive(Debug)]
     struct BadRule;
-    impl ExtensionAdRule for BadRule {
+    impl ExtensionLinearizeRule for BadRule {
         fn family_id(&self) -> &'static str {
             "no-version-suffix"
         }
@@ -339,21 +340,10 @@ fn malformed_family_id_is_rejected() {
         ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
             Ok(vec![])
         }
-        fn transpose_rule(
-            &self,
-            _op: &dyn ExtensionOp,
-            _builder: &mut dyn PrimitiveRuleBuilder,
-            _cotangent_out: &[Option<LocalValueId>],
-            _inputs: &[ValueRef<StdTensorOp>],
-            _mode: &OperationRole,
-            _ctx: &mut ShapeGuardContext,
-        ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-            Ok(vec![])
-        }
     }
 
     let err = ExtensionRuleSet::new()
-        .with_rule(Arc::new(BadRule))
+        .with_linearize(Arc::new(BadRule))
         .expect_err("malformed family_id must error");
     assert!(matches!(
         err,

--- a/crates/tenferro-ad/tests/graph_compile.rs
+++ b/crates/tenferro-ad/tests/graph_compile.rs
@@ -2,9 +2,9 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use tenferro_runtime::extension::{apply, ExtensionOp};
+use tenferro_runtime::SymDim;
 use tenferro_runtime::{CompilerOptions, OptimizerConfig};
 use tenferro_runtime::{DType, GraphCompiler, TracedTensor};
-use tenferro_runtime::{SymDim, Tensor};
 
 #[derive(Clone)]
 struct ConstantDebugExtension {
@@ -55,10 +55,6 @@ impl ExtensionOp for ConstantDebugExtension {
         input_shapes: &[&[SymDim]],
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
-    }
-
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![inputs[0].clone()])
     }
 }
 

--- a/crates/tenferro-ad/tests/numpy_api.rs
+++ b/crates/tenferro-ad/tests/numpy_api.rs
@@ -47,10 +47,6 @@ impl ExtensionOp for TestExtensionOp {
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
-
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![inputs[0].clone()])
-    }
 }
 
 #[test]

--- a/crates/tenferro-einsum/src/extension.rs
+++ b/crates/tenferro-einsum/src/extension.rs
@@ -22,8 +22,10 @@ use tenferro_ops::ad::PrimitiveRuleBuilder;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::dim_expr::DimExpr;
 #[cfg(feature = "autodiff")]
-use tenferro_ops::ext_op::ExtensionAdRule;
-use tenferro_ops::ext_op::{ExtensionLoweringError, ExtensionLoweringResult, ExtensionOp};
+use tenferro_ops::ext_op::{ExtensionLinearTransposeRule, ExtensionLinearizeRule};
+use tenferro_ops::ext_op::{
+    ExtensionLoweringError, ExtensionLoweringResult, ExtensionOp, HostReference,
+};
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::sym_dim::SymDim;
@@ -60,9 +62,9 @@ type InputIndexVec = SmallVec<[usize; 8]>;
 /// Standard einsum extension payload.
 ///
 /// This mirrors the current `tenferro.einsum.v1` payload shape. Runtime-owned
-/// execution goes through [`EinsumRuntime`]; [`ExtensionOp::eager_execute`]
-/// remains only as a host reference implementation for direct context-free
-/// extension calls.
+/// execution goes through [`EinsumRuntime`]. The optional
+/// [`ExtensionOp::host_reference`] hook remains available for direct
+/// context-free reference execution.
 #[derive(Clone)]
 pub(crate) struct EinsumExtensionOp {
     subscripts: EinsumSubscripts,
@@ -289,11 +291,8 @@ impl ExtensionOp for EinsumExtensionOp {
         )])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        let mut backend = tenferro_cpu::CpuBackend::new();
-        let subscripts = Subscripts::from(&self.subscripts);
-        crate::eager::eager_einsum_subscripts(&mut backend, inputs, &subscripts)
-            .map(|output| vec![output])
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
     }
 
     fn lower_to_standard_ops(
@@ -329,6 +328,15 @@ impl ExtensionOp for EinsumExtensionOp {
     }
 }
 
+impl HostReference for EinsumExtensionOp {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let mut backend = tenferro_cpu::CpuBackend::new();
+        let subscripts = Subscripts::from(&self.subscripts);
+        crate::eager::eager_einsum_subscripts(&mut backend, inputs, &subscripts)
+            .map(|output| vec![output])
+    }
+}
+
 fn concrete_sym_shape_slices(input_shapes: &[&[SymDim]]) -> Option<Vec<Vec<usize>>> {
     input_shapes
         .iter()
@@ -344,7 +352,9 @@ fn concrete_sym_shape_slices(input_shapes: &[&[SymDim]]) -> Option<Vec<Vec<usize
 /// Return the explicit einsum extension AD rule set.
 #[cfg(feature = "autodiff")]
 pub fn ad_rules() -> Result<ExtensionRuleSet, ExtensionRegistryError> {
-    ExtensionRuleSet::new().with_rule(Arc::new(EinsumAdRule))
+    ExtensionRuleSet::new()
+        .with_linearize(Arc::new(EinsumAdRule))?
+        .with_linear_transpose(Arc::new(EinsumAdRule))
 }
 
 #[derive(Debug)]
@@ -352,7 +362,7 @@ pub fn ad_rules() -> Result<ExtensionRuleSet, ExtensionRegistryError> {
 struct EinsumAdRule;
 
 #[cfg(feature = "autodiff")]
-impl ExtensionAdRule for EinsumAdRule {
+impl ExtensionLinearizeRule for EinsumAdRule {
     fn family_id(&self) -> &'static str {
         EINSUM_EXTENSION_FAMILY_ID
     }
@@ -395,14 +405,21 @@ impl ExtensionAdRule for EinsumAdRule {
 
         Ok(vec![sum_terms(builder, terms)])
     }
+}
 
-    fn transpose_rule(
+#[cfg(feature = "autodiff")]
+impl ExtensionLinearTransposeRule for EinsumAdRule {
+    fn family_id(&self) -> &'static str {
+        EINSUM_EXTENSION_FAMILY_ID
+    }
+
+    fn linear_transpose(
         &self,
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         inputs: &[ValueRef<StdTensorOp>],
-        mode: &OperationRole,
+        active_mask: &[bool],
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_ad_op(op, ADRuleKind::Transpose)?;
@@ -412,10 +429,6 @@ impl ExtensionAdRule for EinsumAdRule {
 
         let Some(ct) = cotangent_out.first().copied().flatten() else {
             return Ok(vec![None; input_count]);
-        };
-        let active_mask = match mode {
-            OperationRole::Linearized { active_mask } => active_mask,
-            OperationRole::Primary => return Ok(vec![None; input_count]),
         };
         let primal_input_shapes: Vec<Vec<SymDim>> = inputs
             .iter()

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -60,7 +60,10 @@ use num_complex::Complex;
 use num_traits::{Float, FromPrimitive, Zero};
 use rustfft::{Fft, FftNum, FftPlanner};
 #[cfg(feature = "autodiff")]
-use tenferro_ad::extension::{ExtensionAdRule, ExtensionRegistryError, ExtensionRuleSet};
+use tenferro_ad::extension::{
+    ExtensionLinearTransposeRule, ExtensionLinearizeRule, ExtensionPrimalVjpRule,
+    ExtensionRegistryError, ExtensionRuleSet,
+};
 use tenferro_extension_macros::define_extension_runtime;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::ad::PrimitiveRuleBuilder;
@@ -69,7 +72,7 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::ShapeGuardContext;
 use tenferro_ops::SymDim;
-use tenferro_runtime::extension::{apply, ExtensionExecutionContext, ExtensionOp};
+use tenferro_runtime::extension::{apply, ExtensionExecutionContext, ExtensionOp, HostReference};
 use tenferro_runtime::{Error, Result, TracedTensor};
 use tenferro_tensor::{
     DType, DeviceKind, MemoryKind, Placement, Tensor, TensorBackend, TensorRead, TypedTensor,
@@ -582,7 +585,13 @@ impl ExtensionOp for FftOp {
         Ok(vec![(output_dtype, out_shape)])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for FftOp {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         execute_host_fft_op(self, inputs)
     }
 }
@@ -832,7 +841,7 @@ fn validate_host_fft_input(op: &'static str, input: &Tensor) -> tenferro_tensor:
 struct FftAdRule;
 
 #[cfg(feature = "autodiff")]
-impl ExtensionAdRule for FftAdRule {
+impl ExtensionLinearizeRule for FftAdRule {
     fn family_id(&self) -> &'static str {
         FFT_EXTENSION_FAMILY_ID
     }
@@ -868,58 +877,82 @@ impl ExtensionAdRule for FftAdRule {
             None => Ok(vec![None]),
         }
     }
+}
 
-    fn transpose_rule(
+#[cfg(feature = "autodiff")]
+impl ExtensionLinearTransposeRule for FftAdRule {
+    fn family_id(&self) -> &'static str {
+        FFT_EXTENSION_FAMILY_ID
+    }
+
+    fn linear_transpose(
         &self,
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         inputs: &[ValueRef<StdTensorOp>],
-        mode: &OperationRole,
+        active_mask: &[bool],
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        let fft_op = fft_payload(op, ADRuleKind::Transpose)?;
-        if !matches!(fft_op.kind, FftKind::C2C { .. }) {
-            return Err(ADRuleError::unsupported(
-                fft_ad_family_id(fft_op.kind),
-                ADRuleKind::Transpose,
-            ));
-        }
-        if !linear_transpose_input_active(mode, 0) {
-            return Ok(vec![None]);
-        }
-
-        match cotangent_out[0] {
-            Some(ct) => {
-                let adjoint_op = fft_op.c2c_adjoint().ok_or_else(|| {
-                    ADRuleError::unsupported(FFT_EXTENSION_FAMILY_ID, ADRuleKind::Transpose)
-                })?;
-                let outputs = builder.add_operation(
-                    StdTensorOp::Extension(Arc::new(adjoint_op)),
-                    vec![ValueRef::Local(ct)],
-                    OperationRole::Linearized {
-                        active_mask: vec![true],
-                    },
-                );
-                let restored =
-                    restore_c2c_adjoint_input_length(builder, outputs[0], inputs, fft_op, ctx)?;
-                Ok(vec![Some(restored)])
-            }
-            None => Ok(vec![None]),
-        }
+        transpose_fft_adjoint(op, builder, cotangent_out, inputs, Some(active_mask), ctx)
     }
 }
 
 #[cfg(feature = "autodiff")]
-fn linear_transpose_input_active(mode: &OperationRole, input_index: usize) -> bool {
-    match mode {
-        // Direct transpose-rule tests use `Primary` for globally linear
-        // extension ops. Only an explicit Linearized active mask suppresses an
-        // inactive cotangent path.
-        OperationRole::Primary => true,
-        OperationRole::Linearized { active_mask } => {
-            active_mask.get(input_index).copied().unwrap_or(false)
+impl ExtensionPrimalVjpRule for FftAdRule {
+    fn family_id(&self) -> &'static str {
+        FFT_EXTENSION_FAMILY_ID
+    }
+
+    fn primal_vjp(
+        &self,
+        op: &dyn ExtensionOp,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[ValueRef<StdTensorOp>],
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+        transpose_fft_adjoint(op, builder, cotangent_out, inputs, None, ctx)
+    }
+}
+
+#[cfg(feature = "autodiff")]
+fn transpose_fft_adjoint(
+    op: &dyn ExtensionOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[ValueRef<StdTensorOp>],
+    active_mask: Option<&[bool]>,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    let fft_op = fft_payload(op, ADRuleKind::Transpose)?;
+    if !matches!(fft_op.kind, FftKind::C2C { .. }) {
+        return Err(ADRuleError::unsupported(
+            fft_ad_family_id(fft_op.kind),
+            ADRuleKind::Transpose,
+        ));
+    }
+    if active_mask.is_some_and(|mask| !mask.get(0).copied().unwrap_or(false)) {
+        return Ok(vec![None]);
+    }
+
+    match cotangent_out[0] {
+        Some(ct) => {
+            let adjoint_op = fft_op.c2c_adjoint().ok_or_else(|| {
+                ADRuleError::unsupported(FFT_EXTENSION_FAMILY_ID, ADRuleKind::Transpose)
+            })?;
+            let outputs = builder.add_operation(
+                StdTensorOp::Extension(Arc::new(adjoint_op)),
+                vec![ValueRef::Local(ct)],
+                OperationRole::Linearized {
+                    active_mask: vec![true],
+                },
+            );
+            let restored =
+                restore_c2c_adjoint_input_length(builder, outputs[0], inputs, fft_op, ctx)?;
+            Ok(vec![Some(restored)])
         }
+        None => Ok(vec![None]),
     }
 }
 
@@ -977,7 +1010,10 @@ fn restore_c2c_adjoint_input_length(
 /// Return the explicit FFT extension AD rule set.
 #[cfg(feature = "autodiff")]
 pub fn ad_rules() -> std::result::Result<ExtensionRuleSet, ExtensionRegistryError> {
-    ExtensionRuleSet::new().with_rule(Arc::new(FftAdRule))
+    ExtensionRuleSet::new()
+        .with_linearize(Arc::new(FftAdRule))?
+        .with_linear_transpose(Arc::new(FftAdRule))?
+        .with_primal_vjp(Arc::new(FftAdRule))
 }
 
 fn execute_fft_extension<B: TensorBackend + 'static>(
@@ -1850,14 +1886,12 @@ mod tests {
         let mut builder = computegraph::graph::GraphBuilder::<StdTensorOp>::new();
         let cotangent = builder.add_input(tenferro_ops::input_key::TensorInputKey::User { id: 0 });
         let result = rule
-            .transpose_rule(
+            .linear_transpose(
                 &op,
                 &mut builder,
                 &[Some(cotangent)],
                 &[],
-                &OperationRole::Linearized {
-                    active_mask: vec![false],
-                },
+                &[false],
                 &mut ShapeGuardContext::default(),
             )
             .unwrap();

--- a/crates/tenferro-internal-ops/src/ad/context.rs
+++ b/crates/tenferro-internal-ops/src/ad/context.rs
@@ -18,7 +18,9 @@ use tenferro_tensor::DType;
 
 use crate::dim_expr::{DimExpr, DimExprEvalError};
 #[cfg(feature = "autodiff")]
-use crate::ext_op::{ExtensionAdRule, ExtensionRuleSet};
+use crate::ext_op::{
+    ExtensionLinearTransposeRule, ExtensionLinearizeRule, ExtensionPrimalVjpRule, ExtensionRuleSet,
+};
 use crate::shape_extent::ShapeExtent;
 use crate::std_tensor_op::StdTensorOp;
 use crate::sym_dim::SymDim;
@@ -373,15 +375,44 @@ impl ShapeGuardContext {
         self.transpose_primal_outputs_used
     }
 
-    /// Look up an extension AD rule using this context's ownership policy.
+    /// Look up an extension linearize rule using this context's ownership policy.
     ///
     /// Contexts without an explicit rule set have no extension AD rules.
     #[doc(hidden)]
     #[cfg(feature = "autodiff")]
-    pub(crate) fn extension_rule_for(&self, family_id: &str) -> Option<Arc<dyn ExtensionAdRule>> {
+    pub(crate) fn extension_linearize_rule_for(
+        &self,
+        family_id: &str,
+    ) -> Option<Arc<dyn ExtensionLinearizeRule>> {
         self.extension_rules
             .as_ref()
-            .and_then(|rules| rules.lookup_rule(family_id))
+            .and_then(|rules| rules.lookup_linearize(family_id))
+    }
+
+    /// Look up an extension linear-transpose rule using this context's
+    /// ownership policy.
+    #[doc(hidden)]
+    #[cfg(feature = "autodiff")]
+    pub(crate) fn extension_linear_transpose_rule_for(
+        &self,
+        family_id: &str,
+    ) -> Option<Arc<dyn ExtensionLinearTransposeRule>> {
+        self.extension_rules
+            .as_ref()
+            .and_then(|rules| rules.lookup_linear_transpose(family_id))
+    }
+
+    /// Look up an extension direct primal-VJP rule using this context's
+    /// ownership policy.
+    #[doc(hidden)]
+    #[cfg(feature = "autodiff")]
+    pub(crate) fn extension_primal_vjp_rule_for(
+        &self,
+        family_id: &str,
+    ) -> Option<Arc<dyn ExtensionPrimalVjpRule>> {
+        self.extension_rules
+            .as_ref()
+            .and_then(|rules| rules.lookup_primal_vjp(family_id))
     }
 
     /// Returns the guards recorded so far.

--- a/crates/tenferro-internal-ops/src/ext_op.rs
+++ b/crates/tenferro-internal-ops/src/ext_op.rs
@@ -79,6 +79,37 @@ impl ExtensionLoweringError {
 pub type ExtensionLoweringResult =
     std::result::Result<Option<Vec<ValueRef<StdTensorOp>>>, ExtensionLoweringError>;
 
+/// Host/reference implementation for an extension family.
+///
+/// This capability is optional. Backend-only extension families can omit it
+/// and still implement [`ExtensionOp`]; runtimes that specifically delegate to
+/// host reference execution must report a typed capability-missing error when
+/// this hook is absent.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_ops::ext_op::HostReference;
+/// use tenferro_tensor::Tensor;
+///
+/// #[derive(Debug)]
+/// struct IdentityHost;
+///
+/// impl HostReference for IdentityHost {
+///     fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+///         Ok(vec![inputs[0].clone()])
+///     }
+/// }
+///
+/// let input = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
+/// let output = IdentityHost.execute(&[&input]).unwrap();
+/// assert_eq!(output[0].as_slice::<f64>().unwrap(), &[3.0]);
+/// ```
+pub trait HostReference: Debug + Send + Sync + 'static {
+    /// Execute the extension op on host/reference tensors.
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>>;
+}
+
 /// The contract every out-of-tree extension primitive must satisfy.
 ///
 /// Implementations appear in the core graph as
@@ -89,13 +120,12 @@ pub type ExtensionLoweringResult =
 ///   + [`payload_eq`][Self::payload_eq];
 /// - fixed arity via [`input_count`][Self::input_count] / [`output_count`][Self::output_count];
 /// - shape / dtype inference via [`infer_output_meta`][Self::infer_output_meta];
-/// - host/reference forward execution via [`eager_execute`][Self::eager_execute];
-///   runtime-owned eager and compiled paths dispatch through registered
-///   extension runtimes instead of falling back to this method;
+/// - optional host/reference forward execution via
+///   [`host_reference`][Self::host_reference];
 /// - optional fixed-shape standard-op expansion via
 ///   [`lower_to_standard_ops`][Self::lower_to_standard_ops] for peer lowerers
 ///   such as XLA that cannot execute extension runtimes;
-/// - AD via a separately registered [`ExtensionAdRule`].
+/// - AD via separately registered role-specific extension rules.
 ///
 /// # Downcast convention
 ///
@@ -110,7 +140,7 @@ pub type ExtensionLoweringResult =
 /// ```
 /// # use std::any::Any;
 /// use std::sync::Arc;
-/// use tenferro_ops::ext_op::ExtensionOp;
+/// use tenferro_ops::ext_op::{ExtensionOp, HostReference};
 /// use tenferro_ops::SymDim;
 /// use tenferro_tensor::{DType, Tensor};
 ///
@@ -134,7 +164,13 @@ pub type ExtensionLoweringResult =
 ///     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
 ///         Ok(vec![(dtypes[0], shapes[0].to_vec())])
 ///     }
-///     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+///     fn host_reference(&self) -> Option<&dyn HostReference> {
+///         Some(self)
+///     }
+/// }
+///
+/// impl HostReference for IdentityExt {
+///     fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
 ///         Ok(vec![inputs[0].clone()])
 ///     }
 /// }
@@ -209,15 +245,17 @@ pub trait ExtensionOp: Debug + Send + Sync + 'static {
         input_shapes: &[&[SymDim]],
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>>;
 
-    // ----- Forward execution dispatch (spec Section 8) -----
+    // ----- Optional host/reference execution (spec Section 8) -----
 
-    /// Eager forward execution; called from the eager path and indirectly
-    /// from the compiled path.
+    /// Return the host/reference implementation for this payload, when the
+    /// family has one.
     ///
-    /// Input tensors are on the device the caller already arranged. Output
-    /// tensors MUST have shapes matching [`Self::infer_output_meta`] and MUST
-    /// be placed on a device the caller can consume.
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>>;
+    /// Backend-only extension families may leave the default `None`. Runtime
+    /// execution never silently falls back to this hook; a runtime must opt in
+    /// explicitly by using this capability.
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        None
+    }
 
     /// Optionally expand this extension into standard tensor graph operations.
     ///
@@ -242,18 +280,15 @@ pub trait ExtensionOp: Debug + Send + Sync + 'static {
         Ok(None)
     }
 
-    // AD rules are registered separately; see [`ExtensionAdRule`].
+    // AD rules are registered separately; see the role-specific rule traits.
 }
 
-/// AD rule provider for an extension family.
+/// Definitional JVP rule provider for an extension family.
 ///
-/// Rules are registered independently from the primal operation so an
-/// out-of-tree crate can provide forward execution without AD, or gate AD
-/// support behind an optional feature. Rule methods receive the concrete
-/// [`ExtensionOp`] payload as a trait object; implementations should downcast
-/// through [`ExtensionOp::as_any`] when they need payload-specific parameters.
+/// Required only for families that appear in primal graphs and must be
+/// differentiable.
 #[cfg(feature = "autodiff")]
-pub trait ExtensionAdRule: Debug + Send + Sync + 'static {
+pub trait ExtensionLinearizeRule: Debug + Send + Sync + 'static {
     /// The extension family this rule handles.
     fn family_id(&self) -> &'static str;
 
@@ -267,26 +302,72 @@ pub trait ExtensionAdRule: Debug + Send + Sync + 'static {
         tangent_in: &[Option<LocalValueId>],
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
+}
 
-    /// Emit the transpose (VJP) rule.
-    fn transpose_rule(
+/// Adjoint rule for an extension op viewed as a linear map in active inputs.
+///
+/// This rule is used only while `linear_transpose` walks a linearized graph.
+#[cfg(feature = "autodiff")]
+pub trait ExtensionLinearTransposeRule: Debug + Send + Sync + 'static {
+    /// The extension family this rule handles.
+    fn family_id(&self) -> &'static str;
+
+    /// Emit cotangents for active linear inputs.
+    fn linear_transpose(
         &self,
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         inputs: &[ValueRef<StdTensorOp>],
-        mode: &OperationRole,
+        active_mask: &[bool],
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
+}
+
+/// Optional direct primal VJP rule provider for an extension family.
+///
+/// This is an opt-in performance or compatibility escape hatch. The default
+/// reverse-mode path remains `linearize` followed by `linear_transpose`.
+#[cfg(feature = "autodiff")]
+pub trait ExtensionPrimalVjpRule: Debug + Send + Sync + 'static {
+    /// The extension family this rule handles.
+    fn family_id(&self) -> &'static str;
+
+    /// Emit a direct VJP from the primal op.
+    fn primal_vjp(
+        &self,
+        op: &dyn ExtensionOp,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[ValueRef<StdTensorOp>],
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
+}
+
+/// Extension AD rule role.
+#[cfg(feature = "autodiff")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ExtensionRuleRole {
+    /// Definitional JVP.
+    Linearize,
+    /// Transpose of an op as a linear map.
+    LinearTranspose,
+    /// Direct VJP from the primal graph.
+    PrimalVjp,
 }
 
 /// Errors returned from extension registries.
 #[cfg(feature = "autodiff")]
 #[derive(Debug, thiserror::Error)]
 pub enum ExtensionRegistryError {
-    /// An AD rule with the same `family_id` was already registered.
-    #[error("AD rule for family_id {family_id:?} already registered")]
-    DuplicateRule { family_id: &'static str },
+    /// An AD rule with the same `family_id` was already registered for one role.
+    #[error("extension AD {role:?} rule for family_id {family_id:?} already registered")]
+    DuplicateRule {
+        /// Duplicate extension family id.
+        family_id: &'static str,
+        /// Duplicate AD rule role.
+        role: ExtensionRuleRole,
+    },
     /// The `family_id` does not match the namespaced format
     /// `"<crate-name>.<op-name>.v<major>"`.
     #[error("family_id {family_id:?} does not match the namespaced format")]
@@ -294,7 +375,11 @@ pub enum ExtensionRegistryError {
 }
 
 #[cfg(feature = "autodiff")]
-type RuleMap = HashMap<&'static str, Arc<dyn ExtensionAdRule>>;
+type LinearizeRuleMap = HashMap<&'static str, Arc<dyn ExtensionLinearizeRule>>;
+#[cfg(feature = "autodiff")]
+type LinearTransposeRuleMap = HashMap<&'static str, Arc<dyn ExtensionLinearTransposeRule>>;
+#[cfg(feature = "autodiff")]
+type PrimalVjpRuleMap = HashMap<&'static str, Arc<dyn ExtensionPrimalVjpRule>>;
 
 /// Explicit, owned set of extension AD rules.
 ///
@@ -304,16 +389,24 @@ type RuleMap = HashMap<&'static str, Arc<dyn ExtensionAdRule>>;
 #[cfg(feature = "autodiff")]
 #[derive(Clone, Default)]
 pub struct ExtensionRuleSet {
-    rules: Arc<RuleMap>,
+    linearize_rules: Arc<LinearizeRuleMap>,
+    linear_transpose_rules: Arc<LinearTransposeRuleMap>,
+    primal_vjp_rules: Arc<PrimalVjpRuleMap>,
 }
 
 #[cfg(feature = "autodiff")]
 impl std::fmt::Debug for ExtensionRuleSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut families: Vec<_> = self.rules.keys().copied().collect();
-        families.sort_unstable();
+        let mut linearize: Vec<_> = self.linearize_rules.keys().copied().collect();
+        let mut linear_transpose: Vec<_> = self.linear_transpose_rules.keys().copied().collect();
+        let mut primal_vjp: Vec<_> = self.primal_vjp_rules.keys().copied().collect();
+        linearize.sort_unstable();
+        linear_transpose.sort_unstable();
+        primal_vjp.sort_unstable();
         f.debug_struct("ExtensionRuleSet")
-            .field("families", &families)
+            .field("linearize", &linearize)
+            .field("linear_transpose", &linear_transpose)
+            .field("primal_vjp", &primal_vjp)
             .finish()
     }
 }
@@ -328,30 +421,30 @@ impl ExtensionRuleSet {
     /// use tenferro_ops::ExtensionRuleSet;
     ///
     /// let rules = ExtensionRuleSet::new();
-    /// assert!(!rules.is_rule_registered("example.missing.v1"));
+    /// assert!(!rules.is_linearize_registered("example.missing.v1"));
     /// ```
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Add one rule to this owned set.
+    /// Add one linearize rule to this owned set.
     ///
     /// # Examples
     ///
     /// ```
     /// use std::sync::Arc;
     /// use tidu::ADRuleResult;
-    /// use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
+    /// use computegraph::types::{LocalValueId, ValueKey};
     /// use tenferro_ops::ad::PrimitiveRuleBuilder;
-    /// use tenferro_ops::ext_op::{ExtensionAdRule, ExtensionOp};
+    /// use tenferro_ops::ext_op::{ExtensionLinearizeRule, ExtensionOp};
     /// use tenferro_ops::{ExtensionRuleSet, ShapeGuardContext};
     /// use tenferro_ops::std_tensor_op::StdTensorOp;
     ///
     /// #[derive(Debug)]
     /// struct Rule;
     ///
-    /// impl ExtensionAdRule for Rule {
-    ///     fn family_id(&self) -> &'static str { "example.register_rule.v1" }
+    /// impl ExtensionLinearizeRule for Rule {
+    ///     fn family_id(&self) -> &'static str { "example.register_linearize.v1" }
     ///     fn linearize(
     ///         &self,
     ///         _op: &dyn ExtensionOp,
@@ -362,53 +455,66 @@ impl ExtensionRuleSet {
     ///         _ctx: &mut ShapeGuardContext,
     ///     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     ///         Ok(tangent_in.to_vec())
-    ///     }
-    ///     fn transpose_rule(
-    ///         &self,
-    ///         _op: &dyn ExtensionOp,
-    ///         _builder: &mut dyn PrimitiveRuleBuilder,
-    ///         cotangent_out: &[Option<LocalValueId>],
-    ///         _inputs: &[ValueRef<StdTensorOp>],
-    ///         _mode: &OperationRole,
-    ///         _ctx: &mut ShapeGuardContext,
-    ///     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    ///         Ok(cotangent_out.to_vec())
     ///     }
     /// }
     ///
     /// let mut rules = ExtensionRuleSet::new();
-    /// rules.register_rule(Arc::new(Rule)).unwrap();
-    /// assert!(rules.lookup_rule("example.register_rule.v1").is_some());
+    /// rules.register_linearize(Arc::new(Rule)).unwrap();
+    /// assert!(rules.lookup_linearize("example.register_linearize.v1").is_some());
     /// ```
-    pub fn register_rule(
+    pub fn register_linearize(
         &mut self,
-        rule: Arc<dyn ExtensionAdRule>,
+        rule: Arc<dyn ExtensionLinearizeRule>,
     ) -> Result<(), ExtensionRegistryError> {
         let family_id = rule.family_id();
-        validate_rule_insert(&self.rules, family_id)?;
-        let rules = Arc::make_mut(&mut self.rules);
+        validate_linearize_insert(&self.linearize_rules, family_id)?;
+        let rules = Arc::make_mut(&mut self.linearize_rules);
         rules.insert(family_id, rule);
         Ok(())
     }
 
-    /// Return a new rule set containing `rule`.
+    /// Add one linear-transpose rule to this owned set.
+    pub fn register_linear_transpose(
+        &mut self,
+        rule: Arc<dyn ExtensionLinearTransposeRule>,
+    ) -> Result<(), ExtensionRegistryError> {
+        let family_id = rule.family_id();
+        validate_linear_transpose_insert(&self.linear_transpose_rules, family_id)?;
+        let rules = Arc::make_mut(&mut self.linear_transpose_rules);
+        rules.insert(family_id, rule);
+        Ok(())
+    }
+
+    /// Add one primal-VJP rule to this owned set.
+    pub fn register_primal_vjp(
+        &mut self,
+        rule: Arc<dyn ExtensionPrimalVjpRule>,
+    ) -> Result<(), ExtensionRegistryError> {
+        let family_id = rule.family_id();
+        validate_primal_vjp_insert(&self.primal_vjp_rules, family_id)?;
+        let rules = Arc::make_mut(&mut self.primal_vjp_rules);
+        rules.insert(family_id, rule);
+        Ok(())
+    }
+
+    /// Return a new rule set containing a linearize rule.
     ///
     /// # Examples
     ///
     /// ```
     /// use std::sync::Arc;
     /// use tidu::ADRuleResult;
-    /// use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
+    /// use computegraph::types::{LocalValueId, ValueKey};
     /// use tenferro_ops::ad::PrimitiveRuleBuilder;
-    /// use tenferro_ops::ext_op::{ExtensionAdRule, ExtensionOp};
+    /// use tenferro_ops::ext_op::{ExtensionLinearizeRule, ExtensionOp};
     /// use tenferro_ops::{ExtensionRuleSet, ShapeGuardContext};
     /// use tenferro_ops::std_tensor_op::StdTensorOp;
     ///
     /// #[derive(Debug)]
     /// struct Rule;
     ///
-    /// impl ExtensionAdRule for Rule {
-    ///     fn family_id(&self) -> &'static str { "example.with_rule.v1" }
+    /// impl ExtensionLinearizeRule for Rule {
+    ///     fn family_id(&self) -> &'static str { "example.with_linearize.v1" }
     ///     fn linearize(
     ///         &self,
     ///         _op: &dyn ExtensionOp,
@@ -420,27 +526,34 @@ impl ExtensionRuleSet {
     ///     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     ///         Ok(tangent_in.to_vec())
     ///     }
-    ///     fn transpose_rule(
-    ///         &self,
-    ///         _op: &dyn ExtensionOp,
-    ///         _builder: &mut dyn PrimitiveRuleBuilder,
-    ///         cotangent_out: &[Option<LocalValueId>],
-    ///         _inputs: &[ValueRef<StdTensorOp>],
-    ///         _mode: &OperationRole,
-    ///         _ctx: &mut ShapeGuardContext,
-    ///     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    ///         Ok(cotangent_out.to_vec())
-    ///     }
     /// }
     ///
-    /// let rules = ExtensionRuleSet::new().with_rule(Arc::new(Rule)).unwrap();
-    /// assert!(rules.is_rule_registered("example.with_rule.v1"));
+    /// let rules = ExtensionRuleSet::new().with_linearize(Arc::new(Rule)).unwrap();
+    /// assert!(rules.is_linearize_registered("example.with_linearize.v1"));
     /// ```
-    pub fn with_rule(
+    pub fn with_linearize(
         mut self,
-        rule: Arc<dyn ExtensionAdRule>,
+        rule: Arc<dyn ExtensionLinearizeRule>,
     ) -> Result<Self, ExtensionRegistryError> {
-        self.register_rule(rule)?;
+        self.register_linearize(rule)?;
+        Ok(self)
+    }
+
+    /// Return a new rule set containing a linear-transpose rule.
+    pub fn with_linear_transpose(
+        mut self,
+        rule: Arc<dyn ExtensionLinearTransposeRule>,
+    ) -> Result<Self, ExtensionRegistryError> {
+        self.register_linear_transpose(rule)?;
+        Ok(self)
+    }
+
+    /// Return a new rule set containing a primal-VJP rule.
+    pub fn with_primal_vjp(
+        mut self,
+        rule: Arc<dyn ExtensionPrimalVjpRule>,
+    ) -> Result<Self, ExtensionRegistryError> {
+        self.register_primal_vjp(rule)?;
         Ok(self)
     }
 
@@ -456,18 +569,28 @@ impl ExtensionRuleSet {
     ///
     /// let mut rules = ExtensionRuleSet::new();
     /// rules.merge(ExtensionRuleSet::new()).unwrap();
-    /// assert!(!rules.is_rule_registered("example.missing.v1"));
+    /// assert!(!rules.is_linearize_registered("example.missing.v1"));
     /// ```
     pub fn merge(&mut self, other: ExtensionRuleSet) -> Result<(), ExtensionRegistryError> {
-        let mut rules = (*self.rules).clone();
-        for rule in other.rules.values() {
-            insert_rule(&mut rules, Arc::clone(rule))?;
+        let mut linearize_rules = (*self.linearize_rules).clone();
+        let mut linear_transpose_rules = (*self.linear_transpose_rules).clone();
+        let mut primal_vjp_rules = (*self.primal_vjp_rules).clone();
+        for rule in other.linearize_rules.values() {
+            insert_linearize_rule(&mut linearize_rules, Arc::clone(rule))?;
         }
-        self.rules = Arc::new(rules);
+        for rule in other.linear_transpose_rules.values() {
+            insert_linear_transpose_rule(&mut linear_transpose_rules, Arc::clone(rule))?;
+        }
+        for rule in other.primal_vjp_rules.values() {
+            insert_primal_vjp_rule(&mut primal_vjp_rules, Arc::clone(rule))?;
+        }
+        self.linearize_rules = Arc::new(linearize_rules);
+        self.linear_transpose_rules = Arc::new(linear_transpose_rules);
+        self.primal_vjp_rules = Arc::new(primal_vjp_rules);
         Ok(())
     }
 
-    /// Look up a rule in this set.
+    /// Look up a linearize rule in this set.
     ///
     /// # Examples
     ///
@@ -475,13 +598,26 @@ impl ExtensionRuleSet {
     /// use tenferro_ops::ExtensionRuleSet;
     ///
     /// let rules = ExtensionRuleSet::new();
-    /// assert!(rules.lookup_rule("example.missing.v1").is_none());
+    /// assert!(rules.lookup_linearize("example.missing.v1").is_none());
     /// ```
-    pub fn lookup_rule(&self, family_id: &str) -> Option<Arc<dyn ExtensionAdRule>> {
-        self.rules.get(family_id).cloned()
+    pub fn lookup_linearize(&self, family_id: &str) -> Option<Arc<dyn ExtensionLinearizeRule>> {
+        self.linearize_rules.get(family_id).cloned()
     }
 
-    /// Return whether `family_id` is present in this set.
+    /// Look up a linear-transpose rule in this set.
+    pub fn lookup_linear_transpose(
+        &self,
+        family_id: &str,
+    ) -> Option<Arc<dyn ExtensionLinearTransposeRule>> {
+        self.linear_transpose_rules.get(family_id).cloned()
+    }
+
+    /// Look up a primal-VJP rule in this set.
+    pub fn lookup_primal_vjp(&self, family_id: &str) -> Option<Arc<dyn ExtensionPrimalVjpRule>> {
+        self.primal_vjp_rules.get(family_id).cloned()
+    }
+
+    /// Return whether `family_id` has a linearize rule.
     ///
     /// # Examples
     ///
@@ -489,10 +625,20 @@ impl ExtensionRuleSet {
     /// use tenferro_ops::ExtensionRuleSet;
     ///
     /// let rules = ExtensionRuleSet::new();
-    /// assert!(!rules.is_rule_registered("example.missing.v1"));
+    /// assert!(!rules.is_linearize_registered("example.missing.v1"));
     /// ```
-    pub fn is_rule_registered(&self, family_id: &str) -> bool {
-        self.rules.contains_key(family_id)
+    pub fn is_linearize_registered(&self, family_id: &str) -> bool {
+        self.linearize_rules.contains_key(family_id)
+    }
+
+    /// Return whether `family_id` has a linear-transpose rule.
+    pub fn is_linear_transpose_registered(&self, family_id: &str) -> bool {
+        self.linear_transpose_rules.contains_key(family_id)
+    }
+
+    /// Return whether `family_id` has a primal-VJP rule.
+    pub fn is_primal_vjp_registered(&self, family_id: &str) -> bool {
+        self.primal_vjp_rules.contains_key(family_id)
     }
 }
 
@@ -530,28 +676,87 @@ fn is_valid_family_id(family_id: &str) -> bool {
 }
 
 #[cfg(feature = "autodiff")]
-fn insert_rule(
-    rules: &mut RuleMap,
-    rule: Arc<dyn ExtensionAdRule>,
+fn insert_linearize_rule(
+    rules: &mut LinearizeRuleMap,
+    rule: Arc<dyn ExtensionLinearizeRule>,
 ) -> Result<(), ExtensionRegistryError> {
     let family_id = rule.family_id();
-    validate_rule_insert(rules, family_id)?;
+    validate_linearize_insert(rules, family_id)?;
+    rules.insert(family_id, rule);
+    Ok(())
+}
+
+#[cfg(feature = "autodiff")]
+fn insert_linear_transpose_rule(
+    rules: &mut LinearTransposeRuleMap,
+    rule: Arc<dyn ExtensionLinearTransposeRule>,
+) -> Result<(), ExtensionRegistryError> {
+    let family_id = rule.family_id();
+    validate_linear_transpose_insert(rules, family_id)?;
+    rules.insert(family_id, rule);
+    Ok(())
+}
+
+#[cfg(feature = "autodiff")]
+fn insert_primal_vjp_rule(
+    rules: &mut PrimalVjpRuleMap,
+    rule: Arc<dyn ExtensionPrimalVjpRule>,
+) -> Result<(), ExtensionRegistryError> {
+    let family_id = rule.family_id();
+    validate_primal_vjp_insert(rules, family_id)?;
     rules.insert(family_id, rule);
     Ok(())
 }
 
 #[cfg(feature = "autodiff")]
 fn validate_rule_insert(
-    rules: &RuleMap,
+    contains_family: bool,
     family_id: &'static str,
+    role: ExtensionRuleRole,
 ) -> Result<(), ExtensionRegistryError> {
     if !is_valid_family_id(family_id) {
         return Err(ExtensionRegistryError::MalformedFamilyId { family_id });
     }
-    if rules.contains_key(family_id) {
-        return Err(ExtensionRegistryError::DuplicateRule { family_id });
+    if contains_family {
+        return Err(ExtensionRegistryError::DuplicateRule { family_id, role });
     }
     Ok(())
+}
+
+#[cfg(feature = "autodiff")]
+fn validate_linearize_insert(
+    rules: &LinearizeRuleMap,
+    family_id: &'static str,
+) -> Result<(), ExtensionRegistryError> {
+    validate_rule_insert(
+        rules.contains_key(family_id),
+        family_id,
+        ExtensionRuleRole::Linearize,
+    )
+}
+
+#[cfg(feature = "autodiff")]
+fn validate_linear_transpose_insert(
+    rules: &LinearTransposeRuleMap,
+    family_id: &'static str,
+) -> Result<(), ExtensionRegistryError> {
+    validate_rule_insert(
+        rules.contains_key(family_id),
+        family_id,
+        ExtensionRuleRole::LinearTranspose,
+    )
+}
+
+#[cfg(feature = "autodiff")]
+fn validate_primal_vjp_insert(
+    rules: &PrimalVjpRuleMap,
+    family_id: &'static str,
+) -> Result<(), ExtensionRegistryError> {
+    validate_rule_insert(
+        rules.contains_key(family_id),
+        family_id,
+        ExtensionRuleRole::PrimalVjp,
+    )
 }
 
 /// Emit a registered extension linearization rule.
@@ -564,7 +769,7 @@ pub fn linearize_extension_rule(
     tangent_in: &[Option<LocalValueId>],
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    match ctx.extension_rule_for(op.family_id()) {
+    match ctx.extension_linearize_rule_for(op.family_id()) {
         Some(rule) => rule.linearize(op, builder, primal_in, primal_out, tangent_in, ctx),
         None => Err(ADRuleError::unsupported(op.family_id(), ADRuleKind::Jvp)),
     }
@@ -580,12 +785,25 @@ pub fn transpose_extension_rule(
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    match ctx.extension_rule_for(op.family_id()) {
-        Some(rule) => rule.transpose_rule(op, builder, cotangent_out, inputs, mode, ctx),
-        None => Err(ADRuleError::unsupported(
-            op.family_id(),
-            ADRuleKind::Transpose,
-        )),
+    match mode {
+        OperationRole::Linearized { active_mask } => {
+            match ctx.extension_linear_transpose_rule_for(op.family_id()) {
+                Some(rule) => {
+                    rule.linear_transpose(op, builder, cotangent_out, inputs, active_mask, ctx)
+                }
+                None => Err(ADRuleError::unsupported(
+                    op.family_id(),
+                    ADRuleKind::Transpose,
+                )),
+            }
+        }
+        OperationRole::Primary => match ctx.extension_primal_vjp_rule_for(op.family_id()) {
+            Some(rule) => rule.primal_vjp(op, builder, cotangent_out, inputs, ctx),
+            None => Err(ADRuleError::unsupported(
+                op.family_id(),
+                ADRuleKind::Transpose,
+            )),
+        },
     }
 }
 

--- a/crates/tenferro-internal-ops/src/lib.rs
+++ b/crates/tenferro-internal-ops/src/lib.rs
@@ -29,13 +29,14 @@ pub mod std_tensor_op;
 pub mod sym_dim;
 
 pub use ad::context::{ShapeGuard, ShapeGuardContext, TensorMeta};
-#[cfg(not(feature = "autodiff"))]
-pub use ext_op::ExtensionOp;
 #[cfg(feature = "autodiff")]
 pub use ext_op::{
-    linearize_extension_rule, transpose_extension_rule, ExtensionAdRule, ExtensionOp,
-    ExtensionRegistryError, ExtensionRuleSet,
+    linearize_extension_rule, transpose_extension_rule, ExtensionLinearTransposeRule,
+    ExtensionLinearizeRule, ExtensionOp, ExtensionPrimalVjpRule, ExtensionRegistryError,
+    ExtensionRuleRole, ExtensionRuleSet, HostReference,
 };
+#[cfg(not(feature = "autodiff"))]
+pub use ext_op::{ExtensionOp, HostReference};
 pub use shape_extent::ShapeExtent;
 pub use sym_dim::SymDim;
 pub use tenferro_extension_macros::ExtensionFamilyId;

--- a/crates/tenferro-internal-ops/src/tests/catalog_kind_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/catalog_kind_tests.rs
@@ -3,7 +3,7 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 use tenferro_core_ops::{all_primitive_descriptors, PrimitiveOpKind};
-use tenferro_tensor::{CompareDir, DType, Tensor};
+use tenferro_tensor::{CompareDir, DType};
 
 use crate::ext_op::ExtensionOp;
 use crate::std_tensor_op::StdTensorOp;
@@ -45,10 +45,6 @@ impl ExtensionOp for CatalogExt {
         input_shapes: &[&[SymDim]],
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
-    }
-
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![inputs[0].clone()])
     }
 }
 

--- a/crates/tenferro-internal-ops/src/tests/ext_op_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/ext_op_tests.rs
@@ -13,13 +13,14 @@ use tidu::{ADRuleKind, ADRuleResult};
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::PrimitiveRuleBuilder;
 use crate::ext_op::{
-    linearize_extension_rule, transpose_extension_rule, ExtensionAdRule, ExtensionOp,
-    ExtensionRegistryError,
+    linearize_extension_rule, transpose_extension_rule, ExtensionLinearTransposeRule,
+    ExtensionLinearizeRule, ExtensionOp, ExtensionPrimalVjpRule, ExtensionRegistryError,
+    ExtensionRuleRole,
 };
 use crate::input_key::TensorInputKey;
 use crate::std_tensor_op::StdTensorOp;
 use crate::{ExtensionFamilyId, ExtensionRuleSet, SymDim};
-use tenferro_tensor::{DType, Tensor};
+use tenferro_tensor::DType;
 
 #[derive(Debug)]
 struct CoverageRule {
@@ -85,10 +86,6 @@ impl ExtensionOp for NoInlineRuleOp {
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
-
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![inputs[0].clone()])
-    }
 }
 
 impl ExtensionOp for FamilyOnlyOp {
@@ -129,10 +126,6 @@ impl ExtensionOp for FamilyOnlyOp {
         input_shapes: &[&[SymDim]],
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
-    }
-
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![inputs[0].clone()])
     }
 }
 
@@ -180,13 +173,9 @@ impl ExtensionOp for PayloadOp {
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
-
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![inputs[0].clone()])
-    }
 }
 
-impl ExtensionAdRule for CoverageRule {
+impl ExtensionLinearizeRule for CoverageRule {
     fn family_id(&self) -> &'static str {
         self.family
     }
@@ -202,14 +191,71 @@ impl ExtensionAdRule for CoverageRule {
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![tangent_in[0]])
     }
+}
 
-    fn transpose_rule(
+#[derive(Debug)]
+struct CoverageLinearizeRule {
+    family: &'static str,
+}
+
+#[derive(Debug)]
+struct CoverageLinearTransposeRule {
+    family: &'static str,
+}
+
+#[derive(Debug)]
+struct CoveragePrimalVjpRule {
+    family: &'static str,
+}
+
+impl ExtensionLinearizeRule for CoverageLinearizeRule {
+    fn family_id(&self) -> &'static str {
+        self.family
+    }
+
+    fn linearize(
+        &self,
+        _op: &dyn ExtensionOp,
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        _primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
+        _ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+        Ok(vec![tangent_in[0]])
+    }
+}
+
+impl ExtensionLinearTransposeRule for CoverageLinearTransposeRule {
+    fn family_id(&self) -> &'static str {
+        self.family
+    }
+
+    fn linear_transpose(
         &self,
         _op: &dyn ExtensionOp,
         _builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         _inputs: &[ValueRef<StdTensorOp>],
-        _mode: &OperationRole,
+        active_mask: &[bool],
+        _ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+        assert_eq!(active_mask, &[true]);
+        Ok(vec![cotangent_out[0]])
+    }
+}
+
+impl ExtensionPrimalVjpRule for CoveragePrimalVjpRule {
+    fn family_id(&self) -> &'static str {
+        self.family
+    }
+
+    fn primal_vjp(
+        &self,
+        _op: &dyn ExtensionOp,
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        _inputs: &[ValueRef<StdTensorOp>],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![cotangent_out[0]])
@@ -287,31 +333,120 @@ fn extension_payload_does_not_affect_tensor_input_arity() {
 #[test]
 fn register_and_lookup_rule_roundtrips() {
     let family = "covtest.register_rule.v1";
-    let rule: Arc<dyn ExtensionAdRule> = Arc::new(CoverageRule { family });
+    let rule: Arc<dyn ExtensionLinearizeRule> = Arc::new(CoverageRule { family });
     let mut rules = ExtensionRuleSet::new();
     rules
-        .register_rule(rule)
+        .register_linearize(rule)
         .expect("first rule registration should succeed");
 
-    assert!(rules.is_rule_registered(family));
+    assert!(rules.is_linearize_registered(family));
     let looked_up = rules
-        .lookup_rule(family)
+        .lookup_linearize(family)
         .expect("rule should be registered");
     assert_eq!(looked_up.family_id(), family);
 }
 
 #[test]
+fn role_split_rule_set_accepts_one_rule_per_role_for_same_family() {
+    let family = "covtest.role_split.v1";
+    let mut rules = ExtensionRuleSet::new();
+
+    rules
+        .register_linearize(Arc::new(CoverageLinearizeRule { family }))
+        .expect("linearize registration");
+    rules
+        .register_linear_transpose(Arc::new(CoverageLinearTransposeRule { family }))
+        .expect("linear transpose registration");
+    rules
+        .register_primal_vjp(Arc::new(CoveragePrimalVjpRule { family }))
+        .expect("primal VJP registration");
+
+    assert!(rules.lookup_linearize(family).is_some());
+    assert!(rules.lookup_linear_transpose(family).is_some());
+    assert!(rules.lookup_primal_vjp(family).is_some());
+}
+
+#[test]
+fn role_split_rule_set_rejects_duplicate_family_per_role() {
+    let family = "covtest.duplicate_linearize.v1";
+    let mut rules = ExtensionRuleSet::new()
+        .with_linearize(Arc::new(CoverageLinearizeRule { family }))
+        .expect("first linearize registration");
+
+    match rules.register_linearize(Arc::new(CoverageLinearizeRule { family })) {
+        Err(ExtensionRegistryError::DuplicateRule {
+            family_id,
+            role: ExtensionRuleRole::Linearize,
+        }) => assert_eq!(family_id, family),
+        other => panic!("expected duplicate linearize rule, got {other:?}"),
+    }
+}
+
+#[test]
+fn transpose_dispatch_uses_linear_transpose_for_linearized_role() {
+    let family = "covtest.linear-transpose-dispatch.v1";
+    let op = FamilyOnlyOp { family };
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let ct = builder.add_input(TensorInputKey::User { id: 10_301 });
+    let rules = ExtensionRuleSet::new()
+        .with_linear_transpose(Arc::new(CoverageLinearTransposeRule { family }))
+        .expect("linear transpose registration");
+    let mut ctx = ShapeGuardContext::default().with_extension_rules(rules);
+
+    let result = transpose_extension_rule(
+        &op,
+        &mut builder,
+        &[Some(ct)],
+        &[],
+        &OperationRole::Linearized {
+            active_mask: vec![true],
+        },
+        &mut ctx,
+    )
+    .expect("linearized transpose dispatch");
+
+    assert_eq!(result, vec![Some(ct)]);
+}
+
+#[test]
+fn transpose_dispatch_uses_primal_vjp_for_primary_role() {
+    let family = "covtest.primal-vjp-dispatch.v1";
+    let op = FamilyOnlyOp { family };
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let ct = builder.add_input(TensorInputKey::User { id: 10_302 });
+    let rules = ExtensionRuleSet::new()
+        .with_primal_vjp(Arc::new(CoveragePrimalVjpRule { family }))
+        .expect("primal VJP registration");
+    let mut ctx = ShapeGuardContext::default().with_extension_rules(rules);
+
+    let result = transpose_extension_rule(
+        &op,
+        &mut builder,
+        &[Some(ct)],
+        &[],
+        &OperationRole::Primary,
+        &mut ctx,
+    )
+    .expect("primary transpose dispatch");
+
+    assert_eq!(result, vec![Some(ct)]);
+}
+
+#[test]
 fn register_rule_rejects_duplicate_family_id() {
     let family = "covtest.duplicate_rule.v1";
-    let first: Arc<dyn ExtensionAdRule> = Arc::new(CoverageRule { family });
+    let first: Arc<dyn ExtensionLinearizeRule> = Arc::new(CoverageRule { family });
     let mut rules = ExtensionRuleSet::new();
     rules
-        .register_rule(first)
+        .register_linearize(first)
         .expect("first rule registration should succeed");
 
-    let second: Arc<dyn ExtensionAdRule> = Arc::new(CoverageRule { family });
-    match rules.register_rule(second) {
-        Err(ExtensionRegistryError::DuplicateRule { family_id }) => {
+    let second: Arc<dyn ExtensionLinearizeRule> = Arc::new(CoverageRule { family });
+    match rules.register_linearize(second) {
+        Err(ExtensionRegistryError::DuplicateRule {
+            family_id,
+            role: ExtensionRuleRole::Linearize,
+        }) => {
             assert_eq!(family_id, family);
         }
         other => panic!("expected DuplicateRule for {family:?}, got {other:?}"),
@@ -321,9 +456,9 @@ fn register_rule_rejects_duplicate_family_id() {
 #[test]
 fn register_rule_rejects_malformed_family_id() {
     let bad = "covtest.bad_rule";
-    let rule: Arc<dyn ExtensionAdRule> = Arc::new(CoverageRule { family: bad });
+    let rule: Arc<dyn ExtensionLinearizeRule> = Arc::new(CoverageRule { family: bad });
 
-    match ExtensionRuleSet::new().with_rule(rule) {
+    match ExtensionRuleSet::new().with_linearize(rule) {
         Err(ExtensionRegistryError::MalformedFamilyId { family_id }) => {
             assert_eq!(family_id, bad);
         }
@@ -349,12 +484,12 @@ fn owned_rule_set_merge_is_atomic_on_duplicate_family() {
     let family_a = "covtest.merge_a.v1";
     let family_b = "covtest.merge_b.v1";
     let mut base = ExtensionRuleSet::new()
-        .with_rule(Arc::new(CoverageRule { family: family_a }))
+        .with_linearize(Arc::new(CoverageRule { family: family_a }))
         .expect("base rule should register");
     let other = ExtensionRuleSet::new()
-        .with_rule(Arc::new(CoverageRule { family: family_b }))
+        .with_linearize(Arc::new(CoverageRule { family: family_b }))
         .expect("other rule should register")
-        .with_rule(Arc::new(CoverageRule { family: family_a }))
+        .with_linearize(Arc::new(CoverageRule { family: family_a }))
         .expect("duplicate is only relative to base");
 
     let err = base
@@ -363,33 +498,35 @@ fn owned_rule_set_merge_is_atomic_on_duplicate_family() {
     assert!(matches!(
         err,
         ExtensionRegistryError::DuplicateRule {
-            family_id: "covtest.merge_a.v1"
+            family_id: "covtest.merge_a.v1",
+            role: ExtensionRuleRole::Linearize
         }
     ));
-    assert!(base.is_rule_registered(family_a));
-    assert!(!base.is_rule_registered(family_b));
+    assert!(base.is_linearize_registered(family_a));
+    assert!(!base.is_linearize_registered(family_b));
 }
 
 #[test]
 fn owned_rule_set_rejects_duplicate_and_malformed_rules() {
     let family = "covtest.owned_duplicate.v1";
     let mut rules = ExtensionRuleSet::new()
-        .with_rule(Arc::new(CoverageRule { family }))
+        .with_linearize(Arc::new(CoverageRule { family }))
         .expect("first owned rule should register");
     let duplicate_err = rules
-        .register_rule(Arc::new(CoverageRule { family }))
+        .register_linearize(Arc::new(CoverageRule { family }))
         .expect_err("duplicate owned rule should be rejected");
     assert!(matches!(
         duplicate_err,
         ExtensionRegistryError::DuplicateRule {
-            family_id: "covtest.owned_duplicate.v1"
+            family_id: "covtest.owned_duplicate.v1",
+            role: ExtensionRuleRole::Linearize
         }
     ));
-    assert!(rules.is_rule_registered(family));
+    assert!(rules.is_linearize_registered(family));
 
     let malformed = "covtest.owned_malformed";
     let malformed_err = ExtensionRuleSet::new()
-        .with_rule(Arc::new(CoverageRule { family: malformed }))
+        .with_linearize(Arc::new(CoverageRule { family: malformed }))
         .expect_err("malformed owned rule should be rejected");
     assert!(matches!(
         malformed_err,
@@ -440,8 +577,8 @@ fn register_rule_rejects_malformed_family_ids() {
         "fooあ.operation.v1",   // non-ASCII in crate
     ];
     for bad in cases {
-        let rule: Arc<dyn ExtensionAdRule> = Arc::new(CoverageRule { family: bad });
-        match ExtensionRuleSet::new().with_rule(rule) {
+        let rule: Arc<dyn ExtensionLinearizeRule> = Arc::new(CoverageRule { family: bad });
+        match ExtensionRuleSet::new().with_linearize(rule) {
             Err(ExtensionRegistryError::MalformedFamilyId { family_id }) => {
                 assert_eq!(family_id, bad);
             }

--- a/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests.rs
@@ -1,6 +1,6 @@
 use crate::ad::context::ShapeGuardContext;
 use crate::dim_expr::DimExpr;
-use crate::ext_op::{ExtensionAdRule, ExtensionOp};
+use crate::ext_op::{ExtensionLinearTransposeRule, ExtensionLinearizeRule, ExtensionOp};
 use crate::std_tensor_op::StdTensorOp;
 use crate::{ExtensionRuleSet, SymDim, TensorMeta};
 use computegraph::graph::{Graph, GraphBuilder};

--- a/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
+++ b/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
@@ -545,13 +545,6 @@ impl ExtensionOp for RuleOnlyExt {
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
-
-    fn eager_execute(
-        &self,
-        inputs: &[&tenferro_tensor::Tensor],
-    ) -> tenferro_tensor::Result<Vec<tenferro_tensor::Tensor>> {
-        Ok(vec![inputs[0].clone()])
-    }
 }
 
 #[derive(Debug)]
@@ -559,7 +552,7 @@ struct RuleOnlyIdentityAd {
     family: &'static str,
 }
 
-impl ExtensionAdRule for RuleOnlyIdentityAd {
+impl ExtensionLinearizeRule for RuleOnlyIdentityAd {
     fn family_id(&self) -> &'static str {
         self.family
     }
@@ -575,14 +568,20 @@ impl ExtensionAdRule for RuleOnlyIdentityAd {
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![tangent_in[0]])
     }
+}
 
-    fn transpose_rule(
+impl ExtensionLinearTransposeRule for RuleOnlyIdentityAd {
+    fn family_id(&self) -> &'static str {
+        self.family
+    }
+
+    fn linear_transpose(
         &self,
         _op: &dyn ExtensionOp,
         _builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         _inputs: &[ValueRef<StdTensorOp>],
-        _mode: &OperationRole,
+        _active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         Ok(vec![cotangent_out[0]])
@@ -593,7 +592,7 @@ impl ExtensionAdRule for RuleOnlyIdentityAd {
 fn extension_linearize_uses_registered_rule() {
     let family = "stdtensor.rule_only_identity.v1";
     let rules = ExtensionRuleSet::new()
-        .with_rule(Arc::new(RuleOnlyIdentityAd { family }))
+        .with_linearize(Arc::new(RuleOnlyIdentityAd { family }))
         .expect("extension rule should register");
     let op = StdTensorOp::Extension(Arc::new(RuleOnlyExt { family }));
     let mut builder = GraphBuilder::<StdTensorOp>::new();
@@ -610,7 +609,7 @@ fn extension_linearize_uses_registered_rule() {
 fn extension_transpose_uses_registered_rule() {
     let family = "stdtensor.rule_only_transpose.v1";
     let rules = ExtensionRuleSet::new()
-        .with_rule(Arc::new(RuleOnlyIdentityAd { family }))
+        .with_linear_transpose(Arc::new(RuleOnlyIdentityAd { family }))
         .expect("extension rule should register");
     let op = StdTensorOp::Extension(Arc::new(RuleOnlyExt { family }));
     let mut builder = GraphBuilder::<StdTensorOp>::new();

--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -25,7 +25,8 @@ use std::sync::Arc;
 
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_ad::extension::{
-    ExtensionAdRule, ExtensionOp, ExtensionRegistryError, ExtensionRuleSet,
+    ExtensionLinearTransposeRule, ExtensionLinearizeRule, ExtensionOp, ExtensionRegistryError,
+    ExtensionRuleSet,
 };
 use tenferro_ops::ad::PrimitiveRuleBuilder;
 use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -44,16 +45,19 @@ pub mod support;
 ///
 /// ```rust
 /// let rules = tenferro_linalg::ad_rules().unwrap();
-/// assert!(rules.is_rule_registered(tenferro_linalg::LINALG_EXTENSION_FAMILY_ID));
+/// assert!(rules.is_linearize_registered(tenferro_linalg::LINALG_EXTENSION_FAMILY_ID));
+/// assert!(rules.is_linear_transpose_registered(tenferro_linalg::LINALG_EXTENSION_FAMILY_ID));
 /// ```
 pub fn ad_rules() -> Result<ExtensionRuleSet, ExtensionRegistryError> {
-    ExtensionRuleSet::new().with_rule(Arc::new(LinalgAdRule))
+    ExtensionRuleSet::new()
+        .with_linearize(Arc::new(LinalgAdRule))?
+        .with_linear_transpose(Arc::new(LinalgAdRule))
 }
 
 #[derive(Debug)]
 struct LinalgAdRule;
 
-impl ExtensionAdRule for LinalgAdRule {
+impl ExtensionLinearizeRule for LinalgAdRule {
     fn family_id(&self) -> &'static str {
         LINALG_EXTENSION_FAMILY_ID
     }
@@ -131,18 +135,27 @@ impl ExtensionAdRule for LinalgAdRule {
             }
         }
     }
+}
 
-    fn transpose_rule(
+impl ExtensionLinearTransposeRule for LinalgAdRule {
+    fn family_id(&self) -> &'static str {
+        LINALG_EXTENSION_FAMILY_ID
+    }
+
+    fn linear_transpose(
         &self,
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         inputs: &[ValueRef<StdTensorOp>],
-        mode: &OperationRole,
+        active_mask: &[bool],
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_ad_op(op, ADRuleKind::Transpose)?;
         let mut builder = DynBuilder(builder);
+        let mode = OperationRole::Linearized {
+            active_mask: active_mask.to_vec(),
+        };
         match op.op() {
             LinalgOp::TriangularSolve {
                 left_side,
@@ -153,7 +166,7 @@ impl ExtensionAdRule for LinalgAdRule {
                 &mut builder,
                 cotangent_out,
                 inputs,
-                mode,
+                &mode,
                 rules::TriangularSolveFlags::new(left_side, lower, transpose_a, unit_diagonal),
                 ctx,
             ),
@@ -164,7 +177,7 @@ impl ExtensionAdRule for LinalgAdRule {
                 &mut builder,
                 cotangent_out,
                 inputs,
-                mode,
+                &mode,
                 transpose_a,
                 conjugate_a,
                 ctx,
@@ -173,18 +186,18 @@ impl ExtensionAdRule for LinalgAdRule {
                 &mut builder,
                 cotangent_out,
                 inputs,
-                mode,
+                &mode,
                 transpose_a,
                 ctx,
             ),
             LinalgOp::Eigh { eps } => {
-                rules::transpose_eigh(&mut builder, cotangent_out, inputs, mode, eps, ctx)
+                rules::transpose_eigh(&mut builder, cotangent_out, inputs, &mode, eps, ctx)
             }
             LinalgOp::EighVals { eps } => {
-                rules::transpose_eigh_values(&mut builder, cotangent_out, inputs, mode, eps, ctx)
+                rules::transpose_eigh_values(&mut builder, cotangent_out, inputs, &mode, eps, ctx)
             }
-            LinalgOp::Lu => rules::transpose_lu(&mut builder, cotangent_out, inputs, mode, ctx),
-            LinalgOp::Qr => rules::transpose_qr(&mut builder, cotangent_out, inputs, mode, ctx),
+            LinalgOp::Lu => rules::transpose_lu(&mut builder, cotangent_out, inputs, &mode, ctx),
+            LinalgOp::Qr => rules::transpose_qr(&mut builder, cotangent_out, inputs, &mode, ctx),
             LinalgOp::Cholesky
             | LinalgOp::LuFactor
             | LinalgOp::FullPivLu
@@ -620,14 +633,12 @@ mod tests {
         });
 
         let result = LinalgAdRule
-            .transpose_rule(
+            .linear_transpose(
                 &op,
                 &mut builder,
                 &[Some(cotangent)],
                 &[ValueRef::External(lhs.clone()), ValueRef::External(rhs)],
-                &OperationRole::Linearized {
-                    active_mask: vec![false, true],
-                },
+                &[false, true],
                 &mut ctx,
             )
             .unwrap();
@@ -651,26 +662,24 @@ mod tests {
         ctx.set_transpose_primal_outputs(Some(primal_outputs));
 
         let inactive = LinalgAdRule
-            .transpose_rule(
+            .linear_transpose(
                 &op,
                 &mut builder,
                 &[Some(cotangent), None],
                 &[ValueRef::External(a.clone())],
-                &OperationRole::Linearized {
-                    active_mask: vec![false],
-                },
+                &[false],
                 &mut ctx,
             )
             .unwrap();
         assert_eq!(inactive, vec![None]);
 
         let zero_seed = LinalgAdRule
-            .transpose_rule(
+            .linear_transpose(
                 &op,
                 &mut builder,
                 &[None, None],
                 &[ValueRef::External(a)],
-                &OperationRole::Primary,
+                &[true],
                 &mut ctx,
             )
             .unwrap();
@@ -687,12 +696,12 @@ mod tests {
         });
 
         let err = LinalgAdRule
-            .transpose_rule(
+            .linear_transpose(
                 &op,
                 &mut builder,
                 &[Some(cotangent), None],
                 &[],
-                &OperationRole::Primary,
+                &[true],
                 &mut ctx,
             )
             .unwrap_err();
@@ -701,12 +710,12 @@ mod tests {
         let vector = input_key(71);
         insert_meta(&mut ctx, vector.clone(), &[2]);
         let inactive = LinalgAdRule
-            .transpose_rule(
+            .linear_transpose(
                 &op,
                 &mut builder,
                 &[Some(cotangent), None],
                 &[ValueRef::External(vector)],
-                &OperationRole::Primary,
+                &[true],
                 &mut ctx,
             )
             .unwrap();
@@ -724,12 +733,12 @@ mod tests {
         ctx.set_transpose_primal_outputs(Some(vec![primal_outputs[0].clone()]));
 
         let err = LinalgAdRule
-            .transpose_rule(
+            .linear_transpose(
                 &op,
                 &mut builder,
                 &[Some(cotangent), None],
                 &[ValueRef::External(a)],
-                &OperationRole::Primary,
+                &[true],
                 &mut ctx,
             )
             .unwrap_err();
@@ -757,12 +766,12 @@ mod tests {
             ctx.set_transpose_primal_outputs(Some(primal_outputs));
 
             let result = LinalgAdRule
-                .transpose_rule(
+                .linear_transpose(
                     &op,
                     &mut builder,
                     &[g_l, g_v],
                     &[ValueRef::External(a)],
-                    &OperationRole::Primary,
+                    &[true],
                     &mut ctx,
                 )
                 .unwrap();
@@ -782,12 +791,12 @@ mod tests {
             ctx.set_transpose_primal_outputs(Some(primal_outputs));
 
             let result = LinalgAdRule
-                .transpose_rule(
+                .linear_transpose(
                     &LinalgExtensionOp::new(LinalgOp::Lu),
                     &mut builder,
                     &[None, Some(g_l), Some(g_u), None],
                     &[ValueRef::External(a)],
-                    &OperationRole::Primary,
+                    &[true],
                     &mut ctx,
                 )
                 .unwrap();
@@ -811,12 +820,12 @@ mod tests {
             ctx.set_transpose_primal_outputs(Some(primal_outputs));
 
             let result = LinalgAdRule
-                .transpose_rule(
+                .linear_transpose(
                     &LinalgExtensionOp::new(LinalgOp::Qr),
                     &mut builder,
                     &[Some(g_q), Some(g_r)],
                     &[ValueRef::External(a)],
-                    &OperationRole::Primary,
+                    &[true],
                     &mut ctx,
                 )
                 .unwrap();

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use tenferro_extension_macros::define_extension_runtime;
 use tenferro_ops::SymDim;
-use tenferro_runtime::extension::{ExtensionExecutionContext, ExtensionOp};
+use tenferro_runtime::extension::{ExtensionExecutionContext, ExtensionOp, HostReference};
 use tenferro_tensor::{
     DType, DeviceKind, Error, GpuBackendKind, MemoryKind, Placement, Tensor, TensorRead,
 };
@@ -137,16 +137,16 @@ fn input_eager_device(input: &Tensor) -> tenferro_tensor::Result<EagerLinalgDevi
         (MemoryKind::Device, Some(device)) => match &device.kind {
             DeviceKind::Gpu(GpuBackendKind::Cuda) => Ok(EagerLinalgDevice::Cuda(device.ordinal)),
             DeviceKind::Gpu(kind) => Err(Error::backend_failure(
-                "linalg_eager_execute",
+                "linalg_host_reference",
                 format!("unsupported GPU backend {kind:?} for eager linalg"),
             )),
             kind => Err(Error::backend_failure(
-                "linalg_eager_execute",
+                "linalg_host_reference",
                 format!("unsupported device kind {kind:?} for eager linalg"),
             )),
         },
         (MemoryKind::Device, None) => Err(Error::backend_failure(
-            "linalg_eager_execute",
+            "linalg_host_reference",
             "device tensor is missing placement device metadata",
         )),
         _ => Ok(EagerLinalgDevice::Cpu),
@@ -163,7 +163,7 @@ fn eager_linalg_device(inputs: &[&Tensor]) -> tenferro_tensor::Result<EagerLinal
             (Some(EagerLinalgDevice::Cuda(lhs)), EagerLinalgDevice::Cuda(rhs)) if lhs == rhs => {}
             (Some(lhs), rhs) => {
                 return Err(Error::backend_failure(
-                    "linalg_eager_execute",
+                    "linalg_host_reference",
                     format!("all eager linalg inputs must be on the same device, got {lhs:?} and {rhs:?}"),
                 ));
             }
@@ -189,7 +189,7 @@ fn execute_cuda_eager_linalg(
     device_ordinal: usize,
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
     Err(Error::backend_failure(
-        "linalg_eager_execute",
+        "linalg_host_reference",
         format!(
             "received CUDA tensor on cuda:{device_ordinal}, but tenferro-linalg was built \
              without the cuda feature; enable the cuda feature or download the tensor to CPU \
@@ -322,11 +322,17 @@ impl ExtensionOp for LinalgExtensionOp {
         Ok(metas)
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for LinalgExtensionOp {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         let expected = self.input_count();
         if inputs.len() != expected {
             return Err(Error::InvalidConfig {
-                op: "linalg_eager_execute",
+                op: "linalg_host_reference",
                 message: format!(
                     "expected {expected} inputs for {:?}, got {}",
                     self.op,

--- a/crates/tenferro-linalg/src/extension/tests.rs
+++ b/crates/tenferro-linalg/src/extension/tests.rs
@@ -26,11 +26,15 @@ fn eager_linalg_rejects_cuda_tensor_when_cuda_feature_is_disabled() {
     );
     let op = LinalgExtensionOp::new(LinalgOp::Cholesky);
 
-    let err = op.eager_execute(&[&tensor]).unwrap_err();
+    let err = op
+        .host_reference()
+        .expect("linalg host reference")
+        .execute(&[&tensor])
+        .unwrap_err();
 
     match err {
         Error::BackendFailure { op, message } => {
-            assert_eq!(op, "linalg_eager_execute");
+            assert_eq!(op, "linalg_host_reference");
             assert!(message.contains("cuda feature"));
             assert!(message.contains("download"));
         }

--- a/crates/tenferro-runtime/src/exec/tests.rs
+++ b/crates/tenferro-runtime/src/exec/tests.rs
@@ -577,8 +577,4 @@ impl ExtensionOp for TestExtension {
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
-
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![inputs[0].clone()])
-    }
 }

--- a/crates/tenferro-runtime/src/extension.rs
+++ b/crates/tenferro-runtime/src/extension.rs
@@ -39,7 +39,7 @@ pub use crate::shape_infer::{
     infer_output_dtype, infer_output_extents, infer_output_shapes, promote_dtype,
     promote_dtype_div_like, promote_dtype_for_binary_op, promote_dtypes,
 };
-pub use tenferro_ops::ext_op::ExtensionOp;
+pub use tenferro_ops::ext_op::{ExtensionOp, HostReference};
 pub use tenferro_ops::ExtensionFamilyId;
 
 pub use crate::extension_cache::{
@@ -47,7 +47,7 @@ pub use crate::extension_cache::{
 };
 pub use crate::extension_runtime::{
     ExtensionExecutionContext, ExtensionExecutor, ExtensionRegistry, ExtensionRuntime,
-    ExtensionRuntimeRegistryError,
+    ExtensionRuntimeRegistryError, HostReferenceRuntime,
 };
 
 /// Execute a lowered core program with caller-owned backend runtime cache state.
@@ -88,7 +88,7 @@ pub fn execute_lowered_program_with_backend_cache<B: TensorBackend + 'static>(
 /// # use std::any::Any;
 /// use std::sync::Arc;
 /// use tenferro_runtime::extension::{apply, ExtensionOp};
-/// use tenferro_runtime::{DType, SymDim, Tensor, TracedTensor};
+/// use tenferro_runtime::{DType, SymDim, TracedTensor};
 ///
 /// # #[derive(Clone, Debug)]
 /// # struct IdentityExt;
@@ -108,9 +108,6 @@ pub fn execute_lowered_program_with_backend_cache<B: TensorBackend + 'static>(
 /// #         shapes: &[&[SymDim]],
 /// #     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
 /// #         Ok(vec![(dtypes[0], shapes[0].to_vec())])
-/// #     }
-/// #     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-/// #         Ok(vec![inputs[0].clone()])
 /// #     }
 /// # }
 /// let op: Arc<dyn ExtensionOp> = Arc::new(IdentityExt);

--- a/crates/tenferro-runtime/src/extension/tests.rs
+++ b/crates/tenferro-runtime/src/extension/tests.rs
@@ -47,10 +47,6 @@ impl ExtensionOp for TestExtension {
             .map(|_| (dtypes[0], shapes[0].to_vec()))
             .collect())
     }
-
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![inputs[0].clone()])
-    }
 }
 
 #[test]

--- a/crates/tenferro-runtime/src/extension_runtime.rs
+++ b/crates/tenferro-runtime/src/extension_runtime.rs
@@ -155,6 +155,80 @@ pub trait ExtensionRuntime<B: TensorBackend + 'static>: Debug + Send + Sync + 's
     ) -> tenferro_tensor::Result<Vec<Tensor>>;
 }
 
+/// Runtime adapter that delegates execution to an extension op's optional
+/// host/reference implementation.
+///
+/// Register one adapter per extension family. Backend-specific runtimes should
+/// implement [`ExtensionRuntime`] directly instead of using this adapter.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_runtime::{ExtensionRuntime, HostReferenceRuntime};
+///
+/// let runtime = HostReferenceRuntime::<CpuBackend>::new("example.identity.v1");
+/// assert_eq!(runtime.family_id(), "example.identity.v1");
+/// ```
+#[derive(Clone, Copy)]
+pub struct HostReferenceRuntime<B: TensorBackend + 'static> {
+    family_id: &'static str,
+    _backend: PhantomData<fn() -> B>,
+}
+
+impl<B: TensorBackend + 'static> HostReferenceRuntime<B> {
+    /// Create a host-reference runtime for one extension family.
+    pub fn new(family_id: &'static str) -> Self {
+        Self {
+            family_id,
+            _backend: PhantomData,
+        }
+    }
+}
+
+impl<B: TensorBackend + 'static> Debug for HostReferenceRuntime<B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HostReferenceRuntime")
+            .field("backend_type", &std::any::type_name::<B>())
+            .field("family_id", &self.family_id)
+            .finish()
+    }
+}
+
+impl<B: TensorBackend + 'static> ExtensionRuntime<B> for HostReferenceRuntime<B> {
+    fn family_id(&self) -> &'static str {
+        self.family_id
+    }
+
+    fn execute(
+        &self,
+        op: &dyn ExtensionOp,
+        inputs: &[&Tensor],
+        _ctx: &mut ExtensionExecutionContext<'_, B>,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let host = op
+            .host_reference()
+            .ok_or(tenferro_tensor::Error::NoHostReference {
+                family_id: op.family_id(),
+            })?;
+        host.execute(inputs)
+    }
+
+    fn execute_reads(
+        &self,
+        op: &dyn ExtensionOp,
+        inputs: &[TensorRead<'_>],
+        ctx: &mut ExtensionExecutionContext<'_, B>,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let materialized_inputs: Vec<Tensor> = inputs
+            .iter()
+            .map(TensorRead::to_tensor)
+            .collect::<tenferro_tensor::Result<_>>()?;
+        let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
+        self.execute(op, &input_refs, ctx)
+    }
+}
+
 fn validate_runtime_output_count(
     op: &dyn ExtensionOp,
     outputs: Vec<Tensor>,
@@ -368,14 +442,11 @@ impl<B: TensorBackend + 'static> ExtensionExecutor<B> {
     ///
     /// ```
     /// use std::any::Any;
-    /// use std::hash::Hasher;
     /// use std::sync::Arc;
     ///
     /// use tenferro_cpu::CpuBackend;
-    /// use tenferro_ops::{ext_op::ExtensionOp, SymDim};
-    /// use tenferro_runtime::{
-    ///     DType, ExtensionExecutionContext, ExtensionExecutor, ExtensionRuntime, Tensor,
-    /// };
+    /// use tenferro_ops::{ext_op::{ExtensionOp, HostReference}, SymDim};
+    /// use tenferro_runtime::{DType, ExtensionExecutor, HostReferenceRuntime, Tensor};
     /// use tenferro_tensor::TensorRead;
     ///
     /// #[derive(Clone, Debug)]
@@ -386,7 +457,7 @@ impl<B: TensorBackend + 'static> ExtensionExecutor<B> {
     ///         "example.identity.v1"
     ///     }
     ///
-    ///     fn payload_hash(&self, _hasher: &mut dyn Hasher) {}
+    ///     fn payload_hash(&self, _hasher: &mut dyn std::hash::Hasher) {}
     ///
     ///     fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
     ///         other.as_any().is::<IdentityOp>()
@@ -416,45 +487,23 @@ impl<B: TensorBackend + 'static> ExtensionExecutor<B> {
     ///         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     ///     }
     ///
-    ///     fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    ///     fn host_reference(&self) -> Option<&dyn HostReference> {
+    ///         Some(self)
+    ///     }
+    /// }
+    ///
+    /// impl HostReference for IdentityOp {
+    ///     fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
     ///         Ok(vec![inputs[0].clone()])
     ///     }
     /// }
     ///
-    /// #[derive(Debug)]
-    /// struct IdentityRuntime;
-    ///
-    /// impl ExtensionRuntime<CpuBackend> for IdentityRuntime {
-    ///     fn family_id(&self) -> &'static str {
-    ///         "example.identity.v1"
-    ///     }
-    ///
-    ///     fn execute(
-    ///         &self,
-    ///         op: &dyn ExtensionOp,
-    ///         inputs: &[&Tensor],
-    ///         _ctx: &mut ExtensionExecutionContext<'_, CpuBackend>,
-    ///     ) -> tenferro_tensor::Result<Vec<Tensor>> {
-    ///         op.eager_execute(inputs)
-    ///     }
-    ///
-    ///     fn execute_reads(
-    ///         &self,
-    ///         op: &dyn ExtensionOp,
-    ///         inputs: &[TensorRead<'_>],
-    ///         ctx: &mut ExtensionExecutionContext<'_, CpuBackend>,
-    ///     ) -> tenferro_tensor::Result<Vec<Tensor>> {
-    ///         let materialized_inputs: Vec<Tensor> = inputs
-    ///             .iter()
-    ///             .map(TensorRead::to_tensor)
-    ///             .collect::<tenferro_tensor::Result<_>>()?;
-    ///         let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
-    ///         self.execute(op, &input_refs, ctx)
-    ///     }
-    /// }
-    ///
     /// let mut executor = ExtensionExecutor::<CpuBackend>::new();
-    /// executor.registry_mut().register(Arc::new(IdentityRuntime))?;
+    /// executor
+    ///     .registry_mut()
+    ///     .register(Arc::new(HostReferenceRuntime::<CpuBackend>::new(
+    ///         "example.identity.v1",
+    ///     )))?;
     /// let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let read = TensorRead::from_tensor(&input);
     /// let mut backend = CpuBackend::new();

--- a/crates/tenferro-runtime/src/extension_runtime/tests.rs
+++ b/crates/tenferro-runtime/src/extension_runtime/tests.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use tenferro_cpu::CpuBackend;
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::SymDim;
-use tenferro_tensor::{DType, Tensor};
+use tenferro_tensor::DType;
 
 use super::{ExtensionCacheStore, ExtensionExecutionContext};
 use crate::exec::{ExecInstruction, ExecOp, ExecProgram};
@@ -77,11 +77,5 @@ impl ExtensionOp for TestExtension {
         _input_shapes: &[&[SymDim]],
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(DType::F64, vec![])])
-    }
-
-    fn eager_execute(&self, _inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![
-            Tensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap()
-        ])
     }
 }

--- a/crates/tenferro-runtime/src/graph/cache/tests.rs
+++ b/crates/tenferro-runtime/src/graph/cache/tests.rs
@@ -8,7 +8,6 @@ use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::{ShapeExtent, SymDim};
 use tenferro_tensor::{
     CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
-    Tensor,
 };
 
 use super::*;
@@ -314,9 +313,5 @@ impl ExtensionOp for CollidingExtension {
         input_shapes: &[&[SymDim]],
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
-    }
-
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![inputs[0].clone()])
     }
 }

--- a/crates/tenferro-runtime/src/graph/lowering_view/tests.rs
+++ b/crates/tenferro-runtime/src/graph/lowering_view/tests.rs
@@ -8,7 +8,6 @@ use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::{ShapeExtent, SymDim};
 use tenferro_tensor::{
     CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
-    Tensor,
 };
 
 #[derive(Clone, Debug)]
@@ -47,10 +46,6 @@ impl ExtensionOp for DummyExtension {
         input_shapes: &[&[SymDim]],
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
-    }
-
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![inputs[0].clone()])
     }
 }
 

--- a/crates/tenferro-runtime/src/lib.rs
+++ b/crates/tenferro-runtime/src/lib.rs
@@ -60,7 +60,7 @@ pub use extension_cache::{
 };
 pub use extension_runtime::{
     ExtensionExecutionContext, ExtensionExecutor, ExtensionRegistry, ExtensionRuntime,
-    ExtensionRuntimeRegistryError,
+    ExtensionRuntimeRegistryError, HostReferenceRuntime,
 };
 pub use graph::{
     GraphCompiler, GraphCompilerCacheStats, GraphExecutor, GraphExecutorCacheStats,

--- a/crates/tenferro-runtime/tests/extension_runtime.rs
+++ b/crates/tenferro-runtime/tests/extension_runtime.rs
@@ -5,11 +5,12 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 use tenferro_cpu::CpuBackend;
-use tenferro_ops::ext_op::ExtensionOp;
+use tenferro_ops::ext_op::{ExtensionOp, HostReference};
 use tenferro_ops::SymDim;
 use tenferro_runtime::{
     ExtensionCacheKey, ExtensionCacheLimits, ExtensionCacheSelector, ExtensionExecutionContext,
     ExtensionExecutor, ExtensionRegistry, ExtensionRuntime, ExtensionRuntimeRegistryError,
+    HostReferenceRuntime,
 };
 use tenferro_tensor::{
     Buffer, BufferHandle, DType, MemoryKind, Placement, Tensor, TensorOwnedView, TensorRead,
@@ -61,8 +62,60 @@ impl ExtensionOp for IdentityRuntimeOp {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for IdentityRuntimeOp {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         Ok(vec![inputs[0].clone()])
+    }
+}
+
+#[derive(Clone, Debug)]
+struct BackendOnlyRuntimeOp {
+    family: &'static str,
+}
+
+impl ExtensionOp for BackendOnlyRuntimeOp {
+    fn family_id(&self) -> &'static str {
+        self.family
+    }
+
+    fn payload_hash(&self, hasher: &mut dyn Hasher) {
+        hasher.write(self.family.as_bytes());
+    }
+
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<BackendOnlyRuntimeOp>()
+            .is_some_and(|op| op.family == self.family)
+    }
+
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+        Arc::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn input_count(&self) -> usize {
+        1
+    }
+
+    fn output_count(&self) -> usize {
+        1
+    }
+
+    fn infer_output_meta(
+        &self,
+        input_dtypes: &[DType],
+        input_shapes: &[&[SymDim]],
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
     }
 }
 
@@ -206,6 +259,47 @@ fn extension_executor_executes_registered_runtime_and_manages_caches() {
 
     executor.clear_caches();
     assert_eq!(executor.cache_stats().entries, 0);
+}
+
+#[test]
+fn host_reference_runtime_delegates_to_optional_host_reference() {
+    let family = "runtime.host-reference.v1";
+    let mut executor = ExtensionExecutor::<CpuBackend>::new();
+    executor
+        .registry_mut()
+        .register(Arc::new(HostReferenceRuntime::<CpuBackend>::new(family)))
+        .expect("host reference runtime registration");
+
+    let mut backend = CpuBackend::new();
+    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let output = executor
+        .execute(&mut backend, &IdentityRuntimeOp { family }, &[&input])
+        .expect("host reference execution");
+
+    assert_eq!(output[0].as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+}
+
+#[test]
+fn host_reference_runtime_reports_backend_only_family() {
+    let family = "runtime.backend-only.v1";
+    let mut executor = ExtensionExecutor::<CpuBackend>::new();
+    executor
+        .registry_mut()
+        .register(Arc::new(HostReferenceRuntime::<CpuBackend>::new(family)))
+        .expect("host reference runtime registration");
+
+    let mut backend = CpuBackend::new();
+    let input = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
+    let err = executor
+        .execute(&mut backend, &BackendOnlyRuntimeOp { family }, &[&input])
+        .expect_err("backend-only op should not fabricate a host reference");
+
+    assert!(matches!(
+        err,
+        tenferro_tensor::Error::NoHostReference {
+            family_id: "runtime.backend-only.v1"
+        }
+    ));
 }
 
 #[test]

--- a/crates/tenferro-tensor/src/error.rs
+++ b/crates/tenferro-tensor/src/error.rs
@@ -70,6 +70,8 @@ pub enum Error {
     },
     #[error("{op}: invalid config: {message}")]
     InvalidConfig { op: &'static str, message: String },
+    #[error("extension family {family_id:?} has no host reference implementation")]
+    NoHostReference { family_id: &'static str },
     #[error("{op}: backend failure: {message}")]
     BackendFailure { op: &'static str, message: String },
     #[error("missing runtime value for slot {slot}")]

--- a/crates/tenferro-xla/tests/unsupported.rs
+++ b/crates/tenferro-xla/tests/unsupported.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 use tenferro_runtime::extension::{apply, ExtensionOp};
-use tenferro_runtime::{DType, GraphCompiler, SymDim, Tensor, TracedTensor};
+use tenferro_runtime::{DType, GraphCompiler, SymDim, TracedTensor};
 use tenferro_xla::{lower_to_stablehlo, Error};
 
 #[derive(Clone, Debug)]
@@ -41,10 +41,6 @@ impl ExtensionOp for RuntimeOnlyExtension {
         input_shapes: &[&[SymDim]],
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
         Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
-    }
-
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Ok(vec![inputs[0].clone()])
     }
 }
 

--- a/docs/guides/custom-operations.md
+++ b/docs/guides/custom-operations.md
@@ -39,7 +39,10 @@ An extension crate is responsible for:
 - a stable operation descriptor, so graphs can compare and cache it,
 - output dtype and shape inference,
 - concrete execution for the supported backend and device combinations,
-- optional JVP/VJP rules for automatic differentiation,
+- optional host/reference execution for families that can run without a
+  backend-specific kernel,
+- optional linearize, linear-transpose, and direct primal-VJP rules for
+  automatic differentiation,
 - clear errors when a dtype, shape, backend, or AD path is not supported.
 
 ## Cache Ownership
@@ -84,13 +87,21 @@ Extension operation descriptors do not need process-global registration. Constru
 `Arc<dyn ExtensionOp>` and pass it to `tenferro_runtime::extension::apply` for
 traced tensors or `apply_eager` for eager tensors.
 
-For AD, implement `tenferro_ad::extension::ExtensionAdRule`, put the rule
-in a `tenferro_ad::extension::ExtensionRuleSet`, and attach that set with
-`tenferro_ad::AdContext::builder().with_extension_rules(...)`. Rule builders
-expose incoming tangents/cotangents and helper methods for emitting tensor
-operations, so extension authors do not need to handle graph IDs directly. The
-extension crate should expose a small `ad_rules()` helper that constructs the
-fresh rule set its operations need.
+Forward execution goes through a registered
+`tenferro_runtime::ExtensionRuntime`. If the operation has a simple
+host/reference implementation, expose it with `ExtensionOp::host_reference`
+and register `HostReferenceRuntime`; otherwise register a backend-specific
+runtime owned by the extension crate.
+
+For AD, implement the role-specific traits the operation needs:
+`tenferro_ad::extension::ExtensionLinearizeRule`,
+`ExtensionLinearTransposeRule`, and optionally `ExtensionPrimalVjpRule`. Put
+those rules in a `tenferro_ad::extension::ExtensionRuleSet`, and attach that
+set with `tenferro_ad::AdContext::builder().with_extension_rules(...)`. Rule
+builders expose incoming tangents/cotangents and helper methods for emitting
+tensor operations, so extension authors do not need to handle graph IDs
+directly. The extension crate should expose a small `ad_rules()` helper that
+constructs the fresh rule set its operations need.
 
 When porting Julia `frule` / `rrule` code:
 
@@ -102,7 +113,7 @@ When porting Julia `frule` / `rrule` code:
 
 The lower-level adapter API remains available for specialized extension
 authors who need direct graph-builder control. New extension authors should
-start with `ExtensionAdRule` plus an explicit `ExtensionRuleSet`.
+start with role-specific AD rule traits plus an explicit `ExtensionRuleSet`.
 The old `ExtensionFactory` / `register_extension` op-registration API has been
 removed; operation descriptors are carried directly in the graph.
 

--- a/docs/spec/backend-contract.md
+++ b/docs/spec/backend-contract.md
@@ -230,7 +230,7 @@ The unsegmented internal path evaluates one instruction at a time and is used
 for parity checks and narrow owner-scoped extension-runtime composition. It is
 not a general public execution surface. Extension instructions must run through
 a registered `ExtensionRuntime`; missing runtime registration is an error, not
-a fallback to `ExtensionOp::eager_execute()`.
+a fallback to optional host-reference execution.
 
 The engine uses `last_use` metadata to reclaim buffers via
 `BackendSession::reclaim_buffer()` or `TensorBackend::reclaim_buffer()`.

--- a/docs/spec/extension-op.md
+++ b/docs/spec/extension-op.md
@@ -105,9 +105,18 @@ pub enum StdTensorOp {
 ```
 
 The `ExtensionOp` trait itself is the following contract. All methods are
-required unless explicitly marked `provided`.
+required unless explicitly marked `provided`. Host/reference execution is a
+separate optional capability exposed through `HostReference`.
 
 ```rust
+/// Optional host/reference implementation for an extension family.
+pub trait HostReference: std::fmt::Debug + Send + Sync + 'static {
+    fn execute(
+        &self,
+        inputs: &[&tenferro_tensor::Tensor],
+    ) -> tenferro_tensor::Result<Vec<tenferro_tensor::Tensor>>;
+}
+
 /// An out-of-tree operation that participates in the `StdTensorOp` graph
 /// via the `StdTensorOp::Extension(Arc<dyn ExtensionOp>)` carrier.
 ///
@@ -180,6 +189,15 @@ pub trait ExtensionOp: std::fmt::Debug + Send + Sync + 'static {
         input_shapes: &[&[SymDim]],
     ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>>;
 
+    /// Optional host/reference execution capability.
+    ///
+    /// Backend-only extension families MAY return `None`. Runtime execution
+    /// never silently falls back to this hook; a runtime must opt in
+    /// explicitly, for example by registering `HostReferenceRuntime`.
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        None
+    }
+
     /// Optionally expand this extension into standard tensor graph operations.
     ///
     /// This is a provided method. Return `Ok(Some(outputs))` after adding only
@@ -196,21 +214,6 @@ pub trait ExtensionOp: std::fmt::Debug + Send + Sync + 'static {
     ) -> ExtensionLoweringResult {
         Ok(None)
     }
-
-    // ----- Forward execution dispatch (Section 8) -----
-
-    /// Eager forward execution.
-    ///
-    /// Called from the runtime extension dispatcher when the eager path
-    /// encounters an `Extension` variant. Input tensors are on the device
-    /// the caller already arranged. Returned tensors MUST have shapes that
-    /// match `infer_output_meta` and MUST be placed on a device the caller
-    /// can consume (per `backend-contract.md`'s device-transfer policy,
-    /// there is no implicit cross-device transfer).
-    fn eager_execute(
-        &self,
-        inputs: &[&tenferro_tensor::Tensor],
-    ) -> tenferro_tensor::Result<Vec<tenferro_tensor::Tensor>>;
 
     // AD rules are registered separately; see Section 10.
 }
@@ -513,8 +516,8 @@ The dispatcher integration in `crates/tenferro-internal-ops/src/ad/mod.rs` MUST 
 - The number of `primal_out` keys MUST equal `op.output_count()`.
 - The returned tangent-output vector from `linearize` MUST have length
   `op.output_count()`.
-- The returned cotangent-input vector from `transpose_rule` MUST have
-  length `op.input_count()`.
+- The returned cotangent-input vector from `linear_transpose` or
+  `primal_vjp` MUST have length `op.input_count()`.
 
 ### Variable-arity extensions (discouraged)
 
@@ -538,8 +541,8 @@ store the arity in their payload and are handled by the core enum directly.
 
 - `input_count` disagreeing with `linearize`'s `primal_in` length in the
   dispatcher causes `Error::InvalidConfig` (see Section 12).
-- `output_count` disagreeing with `eager_execute`'s returned vector
-  length causes `Error::InvalidConfig`.
+- `output_count` disagreeing with a registered runtime or host-reference
+  returned vector length causes `Error::InvalidConfig`.
 
 ---
 
@@ -623,11 +626,19 @@ StdTensorOp::Extension(ext) => extension_executor.execute(backend, ext, inputs)?
 The eager path MUST NOT open a backend execution session for extension
 ops before handing control to the extension runtime; the extension runtime owns
 its execution model and receives the backend plus its runtime-owned cache store.
-The context-free `ExtensionOp::eager_execute` method is a host/reference
-implementation for direct extension-op calls. Runtime-owned execution MUST NOT
-fall back to it when an extension family is unregistered; that is a missing
-runtime error. Built-in extensions with long-lived caches MUST register a
-runtime so `EagerRuntime`-attached execution uses the runtime-owned cache store.
+Runtime-owned execution MUST NOT fall back to host/reference execution when an
+extension family is unregistered; that is a missing-runtime error.
+
+Extension families that have a simple host/reference implementation MAY expose
+it through `ExtensionOp::host_reference`. That capability is optional and is
+not part of the mandatory `ExtensionOp` contract. Callers that want to use it
+MUST register a runtime that explicitly delegates to the capability, such as
+`HostReferenceRuntime<B>`. If such a runtime receives an op whose
+`host_reference()` is `None`, it MUST return a typed missing-capability error
+rather than panicking.
+
+Built-in extensions with long-lived caches MUST register a runtime so
+`EagerRuntime`-attached execution uses the runtime-owned cache store.
 
 ### Compiled path
 
@@ -658,12 +669,12 @@ standard tensor ops for those inputs, it adds those ops and returns their
 outputs.
 
 The hook MUST NOT call backend kernels, inspect tensor values, or fall back to
-`ExtensionOp::eager_execute`. It is a graph rewrite hook, not an execution
+`ExtensionOp::host_reference`. It is a graph rewrite hook, not an execution
 hook. Returning `Ok(None)` means "this extension cannot lower to standard ops
 for this metadata"; strict lowerers MUST report that as an error instead of
-silently switching to the native extension runtime. Returning
-`ExtensionLoweringError` is reserved for malformed payloads or invalid metadata
-detected while constructing the standard graph.
+silently switching to the native extension runtime or host-reference execution.
+Returning `ExtensionLoweringError` is reserved for malformed payloads or invalid
+metadata detected while constructing the standard graph.
 
 ### Responsibility split (normative)
 
@@ -682,6 +693,9 @@ detected while constructing the standard graph.
 - **Extension runtime (`ExtensionRuntime<B>`)** is responsible for: actual
   forward computation, backend use, runtime cache entries, and device placement
   of outputs. The core pipeline MUST NOT second-guess these choices.
+- **Host-reference runtime (`HostReferenceRuntime<B>`)** is responsible for:
+  adapting the optional `HostReference` capability into `ExtensionRuntime<B>`
+  when an owner deliberately chooses reference execution.
 
 ### Rationale
 
@@ -720,14 +734,16 @@ than overloading runtime graph construction.
 ### AD rule ownership
 
 AD rules are owned by an explicit `ExtensionRuleSet` attached to
-`tenferro_ad::AdContext`. New extension crates should expose a helper that
-constructs a fresh rule set and registers one `ExtensionAdRule` per supported
-family:
+`tenferro_ad::AdContext`. The rule surface is role-specific: linearization,
+linear-transpose, and optional direct primal VJP rules are registered
+independently. New extension crates should expose a helper that constructs a
+fresh rule set and registers the roles supported by each family:
 
 ```rust
 pub fn extension_rules() -> Result<ExtensionRuleSet, ExtensionRegistryError> {
     let mut rules = ExtensionRuleSet::new();
-    rules.register_rule(Arc::new(MyExtensionRule))?;
+    rules.register_linearize(Arc::new(MyLinearizeRule))?;
+    rules.register_linear_transpose(Arc::new(MyLinearTransposeRule))?;
     Ok(rules)
 }
 ```
@@ -736,16 +752,20 @@ Applications then pass that set through
 `tenferro_ad::AdContext::builder().with_extension_rules(...)`; eager runtimes
 that need extension AD should be built from the same `AdContext`.
 
-Double-registration under the same `family_id` in a rule set MUST be rejected
-with `ExtensionRegistryError::DuplicateRule { family_id }`.
+Double-registration under the same `(family_id, role)` in a rule set MUST be
+rejected with `ExtensionRegistryError::DuplicateRule { family_id, role }`.
+Registering different roles for the same `family_id` is valid.
 
 `ExtensionRegistryError`:
 
 ```rust
 #[derive(Debug, thiserror::Error)]
 pub enum ExtensionRegistryError {
-    #[error("AD rule for family_id {family_id:?} already registered")]
-    DuplicateRule { family_id: &'static str },
+    #[error("extension AD {role:?} rule for family_id {family_id:?} already registered")]
+    DuplicateRule {
+        family_id: &'static str,
+        role: ExtensionRuleRole,
+    },
     #[error("family_id {family_id:?} does not match the namespaced format")]
     MalformedFamilyId { family_id: &'static str },
 }
@@ -760,9 +780,9 @@ owner of extension AD rules for a transform.
 
 ### Failure signature
 
-- Registering two AD rules with the same `family_id` in one rule set returns
-  `ExtensionRegistryError::DuplicateRule`.
-- Looking up an unregistered AD rule `family_id` returns `None`.
+- Registering two AD rules with the same `(family_id, role)` in one rule set
+  returns `ExtensionRegistryError::DuplicateRule`.
+- Looking up an unregistered AD rule role for a `family_id` returns `None`.
 - Running a graph that references an extension op with no rule in the active
   `AdContext` is valid for forward execution. AD through that op returns
   `ADRuleError::Unsupported` with the `family_id` and rule kind.
@@ -772,32 +792,61 @@ owner of extension AD rules for a transform.
 ## 10. AD API surface
 
 Extension AD is registered independently from the primal op. Extension crates
-implement `ExtensionAdRule` and add it to an `ExtensionRuleSet`. Rule
-signatures mirror `Primitive::jvp_rule` and
-`Primitive::transpose_rule` and return `ADRuleResult<_>` so missing rules
-can propagate without panic:
+implement one or more role-specific rule traits and add them to an
+`ExtensionRuleSet`. Rules return `ADRuleResult<_>` so missing rules can
+propagate without panic.
+
+`ExtensionLinearizeRule` provides the definitional JVP used when an extension
+appears in a primal graph:
 
 ```rust
-pub trait ExtensionAdRule: Debug + Send + Sync + 'static {
+pub trait ExtensionLinearizeRule: Debug + Send + Sync + 'static {
     fn family_id(&self) -> &'static str;
 
     fn linearize(
         &self,
         op: &dyn ExtensionOp,
-        builder: &mut GraphBuilder<StdTensorOp>,
+        builder: &mut dyn PrimitiveRuleBuilder,
         primal_in: &[ValueKey<StdTensorOp>],
         primal_out: &[ValueKey<StdTensorOp>],
         tangent_in: &[Option<LocalValueId>],
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
+}
+```
 
-    fn transpose_rule(
+`ExtensionLinearTransposeRule` provides the transpose of an extension viewed as
+a linear map in the active linearized inputs:
+
+```rust
+pub trait ExtensionLinearTransposeRule: Debug + Send + Sync + 'static {
+    fn family_id(&self) -> &'static str;
+
+    fn linear_transpose(
         &self,
         op: &dyn ExtensionOp,
-        builder: &mut dyn PrimitiveBuilder<StdTensorOp>,
+        builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         inputs: &[ValueRef<StdTensorOp>],
-        mode: &OperationRole,
+        active_mask: &[bool],
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
+}
+```
+
+`ExtensionPrimalVjpRule` is an optional direct VJP hook for reverse-mode
+fallbacks from the primal graph:
+
+```rust
+pub trait ExtensionPrimalVjpRule: Debug + Send + Sync + 'static {
+    fn family_id(&self) -> &'static str;
+
+    fn primal_vjp(
+        &self,
+        op: &dyn ExtensionOp,
+        builder: &mut dyn PrimitiveRuleBuilder,
+        cotangent_out: &[Option<LocalValueId>],
+        inputs: &[ValueRef<StdTensorOp>],
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
 }
@@ -806,13 +855,20 @@ pub trait ExtensionAdRule: Debug + Send + Sync + 'static {
 The `op` argument is the concrete extension payload as a trait object. Rules
 that need payload parameters should downcast via `op.as_any()`.
 
+The AD engine dispatches by operation role:
+
+- `linearize` uses `ExtensionRuleSet::lookup_linearize`.
+- `linear_transpose` of a linearized extension op uses
+  `ExtensionRuleSet::lookup_linear_transpose` and passes the active input mask.
+- primal reverse-mode fallback uses `ExtensionRuleSet::lookup_primal_vjp`.
+
 ### AD closure
 
-`linearize` and `transpose_rule` may add core `StdTensorOp` values and
-`StdTensorOp::Extension` values. Emitted extension families MUST have their
-own `ExtensionAdRule` in the active `ExtensionRuleSet` before a subsequent AD
-pass reaches them. Terminal first-order helper families MAY omit a separate AD
-rule when the owning extension documents that higher-order AD through that
+`linearize`, `linear_transpose`, and `primal_vjp` may add core `StdTensorOp`
+values and `StdTensorOp::Extension` values. Emitted extension families MUST
+have the role-specific rules needed by any subsequent AD pass in the active
+`ExtensionRuleSet`. Terminal first-order helper families MAY omit separate
+rules when the owning extension documents that higher-order AD through that
 helper is unsupported. This keeps out-of-tree operations in the same compute
 graph while preserving the `Primitive` closure invariant at the
 `StdTensorOp` carrier level.
@@ -841,8 +897,8 @@ extension's AD rules.
 ### Failure signature
 
 - Dispatcher reaching a `StdTensorOp::Extension` variant for an
-  `family_id` with no `ExtensionAdRule` in the active rule set returns
-  `ADRuleError::Unsupported` with the family ID and rule kind.
+  `family_id` with no rule for the required role in the active rule set
+  returns `ADRuleError::Unsupported` with the family ID and rule kind.
 
 ---
 
@@ -907,10 +963,11 @@ these error types / behaviours in the listed scenarios.
 |---|---|
 | Extension runtime execution returns `Err` | Propagate to caller with `Error::backend_failure("extension", message)` and include `family_id` in `message`. MUST NOT retry, MUST NOT swallow. |
 | Backend lacks a capability the extension needs | The extension runtime SHOULD return `Error::backend_failure(...)` with a descriptive message that includes `family_id` and the missing capability name. The core pipeline MUST NOT fall back to a different backend. |
+| `HostReferenceRuntime` receives an op with no `host_reference()` capability | Return `Error::NoHostReference { family_id }`. MUST NOT panic or synthesize a fake result. |
 | Graph references an unregistered `family_id` at eager or graph runtime execution time | Return a backend/config error with `family_id` and registration guidance. |
 | Graph references an unregistered `family_id` at compile time | Return `Error::Unsupported` from `compile_std_to_exec`. |
-| AD rules (`linearize` / `transpose_rule`) encounter an `Extension` with no rule in the active `ExtensionRuleSet` | Return `ADRuleError::Unsupported` with `family_id` and rule kind; traced `grad` / eager `backward` propagate it through the public `Error` type re-exported by the owning surface crate. |
-| Duplicate AD rule `family_id` in one `ExtensionRuleSet` | Rule registration MUST reject with `ExtensionRegistryError::DuplicateRule`. |
+| AD dispatch (`linearize` / `linear_transpose` / primal VJP) encounters an `Extension` with no rule for the required role in the active `ExtensionRuleSet` | Return `ADRuleError::Unsupported` with `family_id` and rule kind; traced `grad` / eager `backward` propagate it through the public `Error` type re-exported by the owning surface crate. |
+| Duplicate AD rule `(family_id, role)` in one `ExtensionRuleSet` | Rule registration MUST reject with `ExtensionRegistryError::DuplicateRule { family_id, role }`. |
 | Arity mismatch: `input_count()` disagrees with the `primal_in.len()` the dispatcher passed | `Error::InvalidConfig { op: "extension", message: "family_id=<id>: expected N inputs, got M" }`. |
 | Output shape disagrees with `infer_output_meta` result length | `Error::InvalidConfig` with `family_id` and the mismatched counts. |
 | Extension runtime returns a tensor on the wrong device | Propagate to the caller as a backend failure (the core pipeline does not re-locate tensors). |
@@ -921,7 +978,7 @@ these error types / behaviours in the listed scenarios.
 
 Where the table specifies `op: "extension"`, that is the recommended
 constant. Implementations MAY refine it (e.g. `op: "ExtensionOp::linearize"` vs
-`op: "ExtensionOp::eager_execute"`) to give better error messages, as
+`op: "HostReference::execute"`) to give better error messages, as
 long as every `Error` value for an extension includes the `family_id`
 somewhere in its message or fields.
 
@@ -1046,10 +1103,10 @@ without revisiting this document.
    (e.g. for cross-thread isolation), the concrete semantics of that
    split are open.
 
-4. **Metrics / observability hooks.** Whether `eager_execute` should
-   add tracing spans (via `tracing` crate or similar) is deferred.
-   Extensions MAY add their own; the core pipeline does not
-   instrument extension calls today.
+4. **Metrics / observability hooks.** Whether extension runtimes or
+   host-reference adapters should add tracing spans (via `tracing` crate or
+   similar) is deferred. Extensions MAY add their own; the core pipeline does
+   not instrument extension calls today.
 
 ---
 

--- a/docs/worklogs/2026-07-04-issue-1301-extension-contract.md
+++ b/docs/worklogs/2026-07-04-issue-1301-extension-contract.md
@@ -1,0 +1,86 @@
+# Extension contract split work log
+
+Date: 2026-07-04
+
+## Session summary
+
+Issue #1301 changes the extension contract from a mandatory context-free
+execution hook and one combined AD rule trait to explicit capabilities:
+
+- `ExtensionOp::eager_execute` was removed from the required trait surface.
+- `HostReference` and `ExtensionOp::host_reference()` now model optional
+  host/reference execution.
+- `HostReferenceRuntime<B>` adapts that optional capability into a registered
+  runtime when an owner deliberately chooses reference execution.
+- `ExtensionAdRule` was split into `ExtensionLinearizeRule`,
+  `ExtensionLinearTransposeRule`, and `ExtensionPrimalVjpRule`.
+- `ExtensionRuleSet` now stores and checks duplicates per AD role.
+- Extension transpose dispatch uses linear-transpose rules for linearized
+  helper ops and primal-VJP rules only for primary primal fallback.
+
+## Context read
+
+| Source | Why it was read | Decision impact |
+| --- | --- | --- |
+| `REPOSITORY_RULES.md` | Confirm extension, docs, and test expectations. | Kept the change scoped to extension contracts and updated normative docs. |
+| Shared tensor4all rules | Confirm common Rust, performance, docs, and numerical rules. | Avoided new global state and kept host execution as an explicit runtime opt-in. |
+| Issue #1301 | Source of the requested breaking contract change. | Drove the required API names, role split, and dispatch behavior. |
+| `docs/spec/extension-op.md` and `docs/spec/backend-contract.md` | Locate normative extension dispatch wording. | Updated the contract to remove mandatory context-free execution and document role-specific AD dispatch. |
+| In-tree extensions under `crates/` and `ext/` | Find implementers of the old trait surface. | Migrated einsum, linalg, FFT, tropical, and sparse to host-reference/rule-role APIs. |
+
+## Decisions made
+
+- **Host/reference execution is an optional capability.** Backend-only
+  extension families can implement `ExtensionOp` without any host execution
+  hook. `HostReferenceRuntime` reports `NoHostReference` if it is registered
+  for such a family.
+- **Runtime registration remains mandatory for execution.** Removing
+  `eager_execute` does not reintroduce silent fallback. Owners must register
+  a concrete runtime or the host-reference adapter.
+- **AD rule roles are independent.** A family may register linearize,
+  linear-transpose, and primal-VJP rules separately. Duplicate checks are per
+  `(family_id, role)`.
+- **Primary fallback uses primal VJP for extensions.** Standard core ops still
+  receive the linearized role in the usual linear-transpose path; extension
+  primal fallback dispatches `OperationRole::Primary` so it reaches the
+  primal-VJP registry.
+- **Standalone examples should not require `tenferro-ad` only for rule types.**
+  The sparse extension now imports role traits from the internal ops surface,
+  matching tropical, so its `autodiff` feature does not accidentally compile
+  `tenferro-ad` without a CPU backend feature.
+
+## Verification performed
+
+- `cargo check -p tenferro-internal-ops --features autodiff`
+- `cargo check -p tenferro-runtime`
+- `cargo check -p tenferro-ad`
+- `cargo check -p tenferro-einsum --features autodiff`
+- `cargo check -p tenferro-linalg --features autodiff`
+- `cargo check -p tenferro-fft`
+- `cargo check --manifest-path ext/tropical/Cargo.toml --features autodiff`
+- `cargo check --manifest-path ext/sparse/Cargo.toml --features autodiff`
+- `cargo test -p tenferro-internal-ops --features autodiff ext_op -- --nocapture`
+- `cargo test -p tenferro-runtime --test extension_runtime -- --nocapture`
+- `cargo test -p tenferro-ad --test extension_op -- --nocapture`
+- `cargo test -p tenferro-einsum --features autodiff extension -- --nocapture`
+- `cargo test -p tenferro-linalg --features autodiff extension -- --nocapture`
+- `cargo test -p tenferro-linalg --features autodiff transpose --lib -- --nocapture`
+- `cargo test -p tenferro-fft -- --nocapture`
+- `cargo test -p tenferro-fft --features autodiff --lib fft_transpose_rule_respects_inactive_linearized_input -- --nocapture`
+- `cargo test --manifest-path ext/sparse/Cargo.toml --features autodiff -- --nocapture`
+- `cargo test --manifest-path ext/tropical/Cargo.toml --features autodiff -- --nocapture`
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `git diff --check`
+- `rg -n "ExtensionAdRule|register_rule\\(|with_rule\\(|lookup_rule\\(|is_rule_registered\\(|eager_execute|ExtensionOp::eager_execute|op\\.eager_execute" docs/guides docs/spec crates ext -g '*.md' -g '*.rs'`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+
+## Remaining risks
+
+- No known local implementation risks remain after the checks above. External
+  PR CI may still expose environment-specific failures.

--- a/ext/sparse/Cargo.toml
+++ b/ext/sparse/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/lib.rs"
 [features]
 default = []
 autodiff = [
-    "dep:tenferro-ad",
     "tenferro-internal-ops/autodiff",
 ]
 
@@ -24,10 +23,9 @@ autodiff = [
 tenferro-internal-ops = { path = "../../crates/tenferro-internal-ops", default-features = false }
 tenferro-runtime = { path = "../../crates/tenferro-runtime", default-features = false }
 tenferro-tensor = { path = "../../crates/tenferro-tensor", default-features = false }
-tenferro-ad = { path = "../../crates/tenferro-ad", default-features = false, optional = true }
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7" }
 tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "77527ecb647fecd4918ea2d06d0065ddce4e5b1c" }
 
 [dev-dependencies]
-tenferro-ad = { path = "../../crates/tenferro-ad", default-features = false }
+tenferro-ad = { path = "../../crates/tenferro-ad", default-features = false, features = ["cpu-faer"] }
 tenferro-cpu = { path = "../../crates/tenferro-cpu", default-features = false, features = ["cpu-faer"] }

--- a/ext/sparse/src/extension.rs
+++ b/ext/sparse/src/extension.rs
@@ -6,21 +6,23 @@ use std::sync::Arc;
 #[cfg(feature = "autodiff")]
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 #[cfg(feature = "autodiff")]
-use tenferro_ad::extension::{ExtensionAdRule, ExtensionRegistryError, ExtensionRuleSet};
-#[cfg(feature = "autodiff")]
 use tenferro_ops::ad::PrimitiveRuleBuilder;
-use tenferro_ops::ext_op::ExtensionOp;
+#[cfg(feature = "autodiff")]
+use tenferro_ops::{
+    ExtensionLinearTransposeRule, ExtensionLinearizeRule, ExtensionRegistryError,
+    ExtensionRuleSet,
+};
+use tenferro_ops::ext_op::{ExtensionOp, HostReference};
 #[cfg(feature = "autodiff")]
 use tenferro_ops::std_tensor_op::StdTensorOp;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::ShapeGuardContext;
 use tenferro_ops::SymDim;
 use tenferro_runtime::extension::{
-    apply, ExtensionExecutionContext, ExtensionExecutor, ExtensionRuntime,
-    ExtensionRuntimeRegistryError,
+    apply, ExtensionExecutor, ExtensionRuntimeRegistryError, HostReferenceRuntime,
 };
 use tenferro_runtime::{Error as RuntimeError, Result as RuntimeResult};
-use tenferro_tensor::{DType, Error, Result, Tensor, TensorBackend, TensorRead};
+use tenferro_tensor::{DType, Error, Result, Tensor, TensorBackend};
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
@@ -145,17 +147,17 @@ impl SparseMatmulPlan {
 pub fn register_runtime<B: TensorBackend + 'static>(
     executor: &mut ExtensionExecutor<B>,
 ) -> std::result::Result<(), ExtensionRuntimeRegistryError> {
-    executor.registry_mut().register(Arc::new(SparseRuntime {
-        family_id: FAMILY_ID,
-    }))?;
+    executor
+        .registry_mut()
+        .register(Arc::new(HostReferenceRuntime::<B>::new(FAMILY_ID)))?;
     #[cfg(feature = "autodiff")]
     {
-        executor.registry_mut().register(Arc::new(SparseRuntime {
-            family_id: JVP_FAMILY_ID,
-        }))?;
-        executor.registry_mut().register(Arc::new(SparseRuntime {
-            family_id: VJP_FAMILY_ID,
-        }))?;
+        executor
+            .registry_mut()
+            .register(Arc::new(HostReferenceRuntime::<B>::new(JVP_FAMILY_ID)))?;
+        executor
+            .registry_mut()
+            .register(Arc::new(HostReferenceRuntime::<B>::new(VJP_FAMILY_ID)))?;
     }
     Ok(())
 }
@@ -211,40 +213,6 @@ pub fn sparse_matmul(
     )
 }
 
-#[derive(Debug)]
-struct SparseRuntime {
-    family_id: &'static str,
-}
-
-impl<B: TensorBackend + 'static> ExtensionRuntime<B> for SparseRuntime {
-    fn family_id(&self) -> &'static str {
-        self.family_id
-    }
-
-    fn execute(
-        &self,
-        op: &dyn ExtensionOp,
-        inputs: &[&Tensor],
-        _ctx: &mut ExtensionExecutionContext<'_, B>,
-    ) -> Result<Vec<Tensor>> {
-        op.eager_execute(inputs)
-    }
-
-    fn execute_reads(
-        &self,
-        op: &dyn ExtensionOp,
-        inputs: &[TensorRead<'_>],
-        ctx: &mut ExtensionExecutionContext<'_, B>,
-    ) -> Result<Vec<Tensor>> {
-        let materialized_inputs: Vec<Tensor> = inputs
-            .iter()
-            .map(TensorRead::to_tensor)
-            .collect::<Result<_>>()?;
-        let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
-        self.execute(op, &input_refs, ctx)
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct SparseMatmulOp {
     plan: SparseMatmulPlan,
@@ -291,7 +259,13 @@ impl ExtensionOp for SparseMatmulOp {
         )])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for SparseMatmulOp {
+    fn execute(&self, inputs: &[&Tensor]) -> Result<Vec<Tensor>> {
         validate_primal_inputs(&self.plan, inputs)?;
         apply_sparse_matmul(&self.plan, inputs[0], inputs[1]).map(|tensor| vec![tensor])
     }
@@ -371,7 +345,14 @@ impl ExtensionOp for SparseMatmulJvpOp {
         )])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+#[cfg(feature = "autodiff")]
+impl HostReference for SparseMatmulJvpOp {
+    fn execute(&self, inputs: &[&Tensor]) -> Result<Vec<Tensor>> {
         validate_primal_inputs(&self.plan, &inputs[..2])?;
         execute_jvp(&self.plan, inputs, &self.active_inputs).map(|tensor| vec![tensor])
     }
@@ -438,7 +419,14 @@ impl ExtensionOp for SparseMatmulVjpOp {
         )])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+#[cfg(feature = "autodiff")]
+impl HostReference for SparseMatmulVjpOp {
+    fn execute(&self, inputs: &[&Tensor]) -> Result<Vec<Tensor>> {
         validate_primal_inputs(&self.plan, &inputs[..2])?;
         validate_value_tensor(inputs[2], self.plan.output_nnz())?;
         execute_vjp(&self.plan, inputs, self.active_input).map(|tensor| vec![tensor])
@@ -450,7 +438,7 @@ impl ExtensionOp for SparseMatmulVjpOp {
 struct SparseMatmulAdRule;
 
 #[cfg(feature = "autodiff")]
-impl ExtensionAdRule for SparseMatmulAdRule {
+impl ExtensionLinearizeRule for SparseMatmulAdRule {
     fn family_id(&self) -> &'static str {
         FAMILY_ID
     }
@@ -497,20 +485,6 @@ impl ExtensionAdRule for SparseMatmulAdRule {
         Ok(vec![Some(out[0])])
     }
 
-    fn transpose_rule(
-        &self,
-        _op: &dyn ExtensionOp,
-        _builder: &mut dyn PrimitiveRuleBuilder,
-        _cotangent_out: &[Option<LocalValueId>],
-        _inputs: &[ValueRef<StdTensorOp>],
-        _mode: &OperationRole,
-        _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        Err(ADRuleError::unsupported(
-            "sparse matmul transpose is supported through its JVP op",
-            ADRuleKind::Transpose,
-        ))
-    }
 }
 
 #[cfg(feature = "autodiff")]
@@ -518,39 +492,23 @@ impl ExtensionAdRule for SparseMatmulAdRule {
 struct SparseMatmulJvpAdRule;
 
 #[cfg(feature = "autodiff")]
-impl ExtensionAdRule for SparseMatmulJvpAdRule {
+impl ExtensionLinearTransposeRule for SparseMatmulJvpAdRule {
     fn family_id(&self) -> &'static str {
         JVP_FAMILY_ID
     }
 
-    fn linearize(
-        &self,
-        _op: &dyn ExtensionOp,
-        _builder: &mut dyn PrimitiveRuleBuilder,
-        _primal_in: &[ValueKey<StdTensorOp>],
-        _primal_out: &[ValueKey<StdTensorOp>],
-        _tangent_in: &[Option<LocalValueId>],
-        _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        Err(ADRuleError::unsupported(JVP_FAMILY_ID, ADRuleKind::Jvp))
-    }
-
-    fn transpose_rule(
+    fn linear_transpose(
         &self,
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         inputs: &[ValueRef<StdTensorOp>],
-        mode: &OperationRole,
+        active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_jvp_op(op, ADRuleKind::Transpose)?;
         let Some(ct) = cotangent_out.first().copied().flatten() else {
             return Ok(vec![None; op.input_count()]);
-        };
-        let active_mask = match mode {
-            OperationRole::Linearized { active_mask } => active_mask,
-            OperationRole::Primary => return Ok(vec![None; op.input_count()]),
         };
         let mut result = vec![None; op.input_count()];
         for (active_pos, &active_input) in op.active_inputs.iter().enumerate() {
@@ -584,14 +542,14 @@ impl ExtensionAdRule for SparseMatmulJvpAdRule {
 ///
 /// ```
 /// let rules = tenferro_ext_sparse::sparse_ad_rules().unwrap();
-/// assert!(rules.is_rule_registered("tenferro-ext-sparse.matmul.v1"));
-/// assert!(rules.is_rule_registered("tenferro-ext-sparse.matmul_jvp.v1"));
+/// assert!(rules.is_linearize_registered("tenferro-ext-sparse.matmul.v1"));
+/// assert!(rules.is_linear_transpose_registered("tenferro-ext-sparse.matmul_jvp.v1"));
 /// ```
 #[cfg(feature = "autodiff")]
 pub fn sparse_ad_rules() -> std::result::Result<ExtensionRuleSet, ExtensionRegistryError> {
     let mut rules = ExtensionRuleSet::new();
-    rules.register_rule(Arc::new(SparseMatmulAdRule))?;
-    rules.register_rule(Arc::new(SparseMatmulJvpAdRule))?;
+    rules.register_linearize(Arc::new(SparseMatmulAdRule))?;
+    rules.register_linear_transpose(Arc::new(SparseMatmulJvpAdRule))?;
     Ok(rules)
 }
 

--- a/ext/tropical/src/extension.rs
+++ b/ext/tropical/src/extension.rs
@@ -9,8 +9,8 @@ use tenferro_einsum::Subscripts;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::ad::PrimitiveRuleBuilder;
 #[cfg(feature = "autodiff")]
-use tenferro_ops::ext_op::ExtensionAdRule;
-use tenferro_ops::ext_op::ExtensionOp;
+use tenferro_ops::ext_op::{ExtensionLinearTransposeRule, ExtensionLinearizeRule};
+use tenferro_ops::ext_op::{ExtensionOp, HostReference};
 #[cfg(feature = "autodiff")]
 use tenferro_ops::std_tensor_op::StdTensorOp;
 #[cfg(feature = "autodiff")]
@@ -18,14 +18,10 @@ use tenferro_ops::ShapeGuardContext;
 use tenferro_ops::SymDim;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::{ExtensionRegistryError, ExtensionRuleSet};
-use tenferro_runtime::{
-    ExtensionExecutionContext, ExtensionExecutor, ExtensionRuntime, ExtensionRuntimeRegistryError,
-};
-#[cfg(not(feature = "autodiff"))]
-use tenferro_tensor::TensorBackend;
-use tenferro_tensor::{DType, Tensor, TensorRead};
+use tenferro_runtime::{ExtensionExecutor, ExtensionRuntimeRegistryError, HostReferenceRuntime};
+use tenferro_tensor::{DType, Tensor, TensorBackend};
 #[cfg(feature = "autodiff")]
-use tenferro_tensor::{TensorBackend, TensorScalar};
+use tenferro_tensor::TensorScalar;
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
@@ -47,46 +43,10 @@ fn invalid_config(op: &'static str, message: impl Into<String>) -> tenferro_tens
     }
 }
 
-#[derive(Debug)]
-struct TropicalRuntime {
-    family_id: &'static str,
-}
-
-impl<B: TensorBackend + 'static> ExtensionRuntime<B> for TropicalRuntime {
-    fn family_id(&self) -> &'static str {
-        self.family_id
-    }
-
-    fn execute(
-        &self,
-        op: &dyn ExtensionOp,
-        inputs: &[&Tensor],
-        _ctx: &mut ExtensionExecutionContext<'_, B>,
-    ) -> tenferro_tensor::Result<Vec<Tensor>> {
-        op.eager_execute(inputs)
-    }
-
-    fn execute_reads(
-        &self,
-        op: &dyn ExtensionOp,
-        inputs: &[TensorRead<'_>],
-        ctx: &mut ExtensionExecutionContext<'_, B>,
-    ) -> tenferro_tensor::Result<Vec<Tensor>> {
-        // Tropical CPU kernels consume compact host tensors, so view
-        // materialization is an explicit runtime choice.
-        let materialized_inputs: Vec<Tensor> = inputs
-            .iter()
-            .map(TensorRead::to_tensor)
-            .collect::<tenferro_tensor::Result<_>>()?;
-        let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
-        self.execute(op, &input_refs, ctx)
-    }
-}
-
 /// Register tropical extension runtimes on a graph or eager executor.
 ///
 /// The runtime executor is intentionally thin: it delegates to each tropical
-/// extension op's [`tenferro_runtime::extension::ExtensionOp::eager_execute`].
+/// extension op's optional host reference implementation.
 /// AD rules are registered separately through `tropical_ad_rules` when the
 /// `autodiff` feature is enabled.
 ///
@@ -113,17 +73,23 @@ impl<B: TensorBackend + 'static> ExtensionRuntime<B> for TropicalRuntime {
 pub fn register_runtime<B: TensorBackend + 'static>(
     executor: &mut ExtensionExecutor<B>,
 ) -> Result<(), ExtensionRuntimeRegistryError> {
-    executor.registry_mut().register(Arc::new(TropicalRuntime {
-        family_id: TROPICAL_EINSUM_FAMILY_ID,
-    }))?;
+    executor
+        .registry_mut()
+        .register(Arc::new(HostReferenceRuntime::<B>::new(
+            TROPICAL_EINSUM_FAMILY_ID,
+        )))?;
     #[cfg(feature = "autodiff")]
     {
-        executor.registry_mut().register(Arc::new(TropicalRuntime {
-            family_id: TROPICAL_EINSUM_JVP_FAMILY_ID,
-        }))?;
-        executor.registry_mut().register(Arc::new(TropicalRuntime {
-            family_id: TROPICAL_EINSUM_VJP_FAMILY_ID,
-        }))?;
+        executor
+            .registry_mut()
+            .register(Arc::new(HostReferenceRuntime::<B>::new(
+                TROPICAL_EINSUM_JVP_FAMILY_ID,
+            )))?;
+        executor
+            .registry_mut()
+            .register(Arc::new(HostReferenceRuntime::<B>::new(
+                TROPICAL_EINSUM_VJP_FAMILY_ID,
+            )))?;
     }
     Ok(())
 }
@@ -180,7 +146,13 @@ impl ExtensionOp for TropicalEinsumOp {
         Ok(vec![meta])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for TropicalEinsumOp {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         let result = tropical_einsum_subscripts_with_argmax(self.kind, inputs, &self.subscripts)?;
         Ok(vec![result.output])
     }
@@ -286,7 +258,14 @@ impl ExtensionOp for TropicalEinsumJvpOp {
         Ok(vec![primal])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+#[cfg(feature = "autodiff")]
+impl HostReference for TropicalEinsumJvpOp {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         if inputs.len() != self.input_count() {
             return Err(invalid_config(
                 "tropical_einsum_jvp",
@@ -407,7 +386,14 @@ impl ExtensionOp for TropicalEinsumVjpOp {
         )])
     }
 
-    fn eager_execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+#[cfg(feature = "autodiff")]
+impl HostReference for TropicalEinsumVjpOp {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         if inputs.len() != 3 {
             return Err(invalid_config(
                 "tropical_einsum_vjp",
@@ -442,7 +428,7 @@ impl ExtensionOp for TropicalEinsumVjpOp {
 struct TropicalEinsumAdRule;
 
 #[cfg(feature = "autodiff")]
-impl ExtensionAdRule for TropicalEinsumAdRule {
+impl ExtensionLinearizeRule for TropicalEinsumAdRule {
     fn family_id(&self) -> &'static str {
         TROPICAL_EINSUM_FAMILY_ID
     }
@@ -495,20 +481,6 @@ impl ExtensionAdRule for TropicalEinsumAdRule {
         Ok(vec![Some(out[0])])
     }
 
-    fn transpose_rule(
-        &self,
-        _op: &dyn ExtensionOp,
-        _builder: &mut dyn PrimitiveRuleBuilder,
-        _cotangent_out: &[Option<LocalValueId>],
-        _inputs: &[ValueRef<StdTensorOp>],
-        _mode: &OperationRole,
-        _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        Err(ADRuleError::unsupported(
-            "tropical einsum transpose is supported via its linearized JVP op",
-            ADRuleKind::Transpose,
-        ))
-    }
 }
 
 #[cfg(feature = "autodiff")]
@@ -516,43 +488,24 @@ impl ExtensionAdRule for TropicalEinsumAdRule {
 struct TropicalEinsumJvpAdRule;
 
 #[cfg(feature = "autodiff")]
-impl ExtensionAdRule for TropicalEinsumJvpAdRule {
+impl ExtensionLinearTransposeRule for TropicalEinsumJvpAdRule {
     fn family_id(&self) -> &'static str {
         TROPICAL_EINSUM_JVP_FAMILY_ID
     }
 
-    fn linearize(
-        &self,
-        _op: &dyn ExtensionOp,
-        _builder: &mut dyn PrimitiveRuleBuilder,
-        _primal_in: &[ValueKey<StdTensorOp>],
-        _primal_out: &[ValueKey<StdTensorOp>],
-        _tangent_in: &[Option<LocalValueId>],
-        _ctx: &mut ShapeGuardContext,
-    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        Err(ADRuleError::unsupported(
-            TROPICAL_EINSUM_JVP_FAMILY_ID,
-            ADRuleKind::Jvp,
-        ))
-    }
-
-    fn transpose_rule(
+    fn linear_transpose(
         &self,
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
         inputs: &[ValueRef<StdTensorOp>],
-        mode: &OperationRole,
+        active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_jvp_op(op, ADRuleKind::Transpose)?;
         validate_ad_supported(&op.subscripts, ADRuleKind::Transpose)?;
         let Some(ct) = cotangent_out.first().copied().flatten() else {
             return Ok(vec![None; op.input_count()]);
-        };
-        let active_mask = match mode {
-            OperationRole::Linearized { active_mask } => active_mask,
-            OperationRole::Primary => return Ok(vec![None; op.input_count()]),
         };
 
         let mut result = vec![None; op.input_count()];
@@ -594,14 +547,14 @@ impl ExtensionAdRule for TropicalEinsumJvpAdRule {
 /// ```
 /// let rules = tenferro_ext_tropical::tropical_ad_rules().unwrap();
 ///
-/// assert!(rules.is_rule_registered("tenferro-ext-tropical.einsum.v1"));
-/// assert!(rules.is_rule_registered("tenferro-ext-tropical.einsum_jvp.v1"));
+/// assert!(rules.is_linearize_registered("tenferro-ext-tropical.einsum.v1"));
+/// assert!(rules.is_linear_transpose_registered("tenferro-ext-tropical.einsum_jvp.v1"));
 /// ```
 #[cfg(feature = "autodiff")]
 pub fn tropical_ad_rules() -> Result<ExtensionRuleSet, ExtensionRegistryError> {
     let mut rules = ExtensionRuleSet::new();
-    rules.register_rule(Arc::new(TropicalEinsumAdRule))?;
-    rules.register_rule(Arc::new(TropicalEinsumJvpAdRule))?;
+    rules.register_linearize(Arc::new(TropicalEinsumAdRule))?;
+    rules.register_linear_transpose(Arc::new(TropicalEinsumJvpAdRule))?;
     Ok(rules)
 }
 


### PR DESCRIPTION
Closes #1301.

## Summary
- Remove mandatory `ExtensionOp::eager_execute` and add optional `HostReference` plus `HostReferenceRuntime`.
- Split extension AD registration into linearize, linear-transpose, and primal-VJP roles with duplicate checks per role.
- Migrate in-tree extensions, tests, and docs to the role-specific contract.

## Work log
- docs/worklogs/2026-07-04-issue-1301-extension-contract.md

## Verification
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`