### PR TITLE
[codex] Implement eager AD end-state APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "77527ecb647fecd4918ea2d06d0065ddce4e5b1c", version = "0.1.0" }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "998dbac4ca24442433ab9a52a182040dda2d8eea", version = "0.1.0" }
 strided-view = "0.3.0"
 strided-traits = "0.3.0"
 strided-perm = { version = "0.3.0", features = ["parallel"] }

--- a/crates/tenferro-ad/Cargo.toml
+++ b/crates/tenferro-ad/Cargo.toml
@@ -46,3 +46,10 @@ num-complex.workspace = true
 num-traits.workspace = true
 thiserror.workspace = true
 tidu.workspace = true
+
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "eager_ad_transform_cache"
+harness = false

--- a/crates/tenferro-ad/benches/eager_ad_transform_cache.rs
+++ b/crates/tenferro-ad/benches/eager_ad_transform_cache.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+use tenferro_cpu::CpuBackend;
+
+const LEN: usize = 1024;
+
+struct Fixture {
+    ctx: Arc<EagerRuntime>,
+    x: EagerTensor,
+    loss: EagerTensor,
+}
+
+fn fixture() -> Fixture {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let data = (0..LEN)
+        .map(|index| (index as f64 + 1.0) / LEN as f64)
+        .collect::<Vec<_>>();
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![LEN], data).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let x2 = x.mul(&x).unwrap();
+    let x3 = x2.mul(&x).unwrap();
+    let loss = x3.reduce_sum(&[0]).unwrap();
+    Fixture { ctx, x, loss }
+}
+
+fn run_backward(fixture: &Fixture) {
+    fixture.ctx.clear_grads().unwrap();
+    fixture.loss.backward().unwrap();
+    let grad = fixture.x.grad().unwrap().unwrap();
+    black_box(grad.as_slice::<f64>().unwrap()[0]);
+}
+
+fn bench_eager_ad_transform_cache(c: &mut Criterion) {
+    let cold = fixture();
+    let warm = fixture();
+    run_backward(&warm);
+    assert!(warm.ctx.cache_stats().unwrap().ad_transforms.entries > 0);
+
+    let mut group = c.benchmark_group("eager_ad_transform_cache/same_tape");
+    group.bench_function("cold_clear_cache_each_backward", |bench| {
+        bench.iter(|| {
+            cold.ctx.clear_caches().unwrap();
+            run_backward(black_box(&cold));
+        });
+    });
+    group.bench_function("warm_reuse_cached_linearization", |bench| {
+        bench.iter(|| run_backward(black_box(&warm)));
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_eager_ad_transform_cache);
+criterion_main!(benches);

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::env;
@@ -30,8 +30,11 @@ use tenferro_tensor::{
     TypedTensor,
 };
 use tidu::eager::{self, EagerInput, EagerOutput, KeySource, RecordedGraph, Recorder, Trace};
+use tidu::{ADRuleError, ADRuleKind, LinearizedGraph};
 
 use self::backward::TenferroBackwardCallbacks;
+use self::cache::{EagerAdTransformCache, EagerAdTransformCacheKey};
+use self::functional::{functional_jvp, functional_vjp_optional};
 use crate::eager_backend::EagerBackend;
 #[cfg(test)]
 use crate::eager_exec::exec_standard_op_on_tensor_reads_in_session;
@@ -50,6 +53,8 @@ use crate::traced::next_input_key;
 use crate::AdContext;
 
 mod backward;
+mod cache;
+mod functional;
 
 pub(crate) type GradSlot = Arc<Mutex<Option<Arc<Tensor>>>>;
 pub(crate) type WeakGradSlot = Weak<Mutex<Option<Arc<Tensor>>>>;
@@ -63,10 +68,55 @@ struct EagerOpProfileEntry {
 thread_local! {
     static EAGER_OP_PROFILE_STATE: RefCell<HashMap<&'static str, EagerOpProfileEntry>> =
         RefCell::new(HashMap::new());
+    static EAGER_NO_GRAD_DEPTH: Cell<usize> = const { Cell::new(0) };
     #[cfg(test)]
     static EAGER_OP_PROFILE_ENABLED_OVERRIDE: RefCell<Option<bool>> = const { RefCell::new(None) };
     #[cfg(test)]
     static EAGER_OP_PROFILE_PRINT_EVERY_OVERRIDE: RefCell<Option<Option<usize>>> = const { RefCell::new(None) };
+}
+
+pub(crate) fn eager_grad_recording_enabled() -> bool {
+    EAGER_NO_GRAD_DEPTH.with(|depth| depth.get() == 0)
+}
+
+/// Scope guard that temporarily disables eager operation recording.
+///
+/// Values computed while this guard is alive are concrete eager tensors, but
+/// they do not participate in reverse-mode gradient tracking.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+/// use tenferro_cpu::CpuBackend;
+///
+/// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+/// let x = EagerTensor::requires_grad_in(
+///     Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap(),
+///     ctx.clone(),
+/// )?;
+/// let y = {
+///     let _guard = ctx.no_grad();
+///     x.mul(&x)?
+/// };
+/// assert!(!y.tracks_grad());
+/// # Ok::<(), tenferro_ad::Error>(())
+/// ```
+#[derive(Debug)]
+pub struct EagerNoGradGuard {
+    active: bool,
+}
+
+impl Drop for EagerNoGradGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        EAGER_NO_GRAD_DEPTH.with(|depth| {
+            depth.set(depth.get().saturating_sub(1));
+        });
+        self.active = false;
+    }
 }
 
 pub(crate) fn eager_op_profile_enabled() -> bool {
@@ -171,6 +221,8 @@ fn eager_op_profile_per_call_us(entry: &EagerOpProfileEntry) -> Option<f64> {
 pub struct EagerRuntimeCacheStats {
     /// Generic extension runtime caches.
     pub extensions: CacheStats,
+    /// Eager AD transform memoization cache.
+    pub ad_transforms: CacheStats,
 }
 
 #[cfg(test)]
@@ -203,6 +255,9 @@ pub struct EagerRuntime {
     pub(crate) extension_executor: Mutex<ExtensionExecutor<EagerBackend>>,
     extension_rules: Option<ExtensionRuleSet>,
     grad_slots: Mutex<HashMap<ValueKey<StdTensorOp>, WeakGradSlot>>,
+    value_records: Mutex<HashMap<ValueKey<StdTensorOp>, Weak<EagerTensorRecord>>>,
+    value_ptr_records: Mutex<HashMap<usize, Weak<EagerTensorRecord>>>,
+    ad_transform_cache: Mutex<EagerAdTransformCache>,
 }
 
 impl fmt::Debug for EagerRuntime {
@@ -234,6 +289,30 @@ impl fmt::Debug for EagerRuntime {
                 debug.field("grad_slots_len", &"<locked>");
             }
         }
+        match self.value_records.try_lock() {
+            Ok(records) => {
+                debug.field("value_records_len", &records.len());
+            }
+            Err(_) => {
+                debug.field("value_records_len", &"<locked>");
+            }
+        }
+        match self.value_ptr_records.try_lock() {
+            Ok(records) => {
+                debug.field("value_ptr_records_len", &records.len());
+            }
+            Err(_) => {
+                debug.field("value_ptr_records_len", &"<locked>");
+            }
+        }
+        match self.ad_transform_cache.try_lock() {
+            Ok(cache) => {
+                debug.field("ad_transform_cache_stats", &cache.stats());
+            }
+            Err(_) => {
+                debug.field("ad_transform_cache_stats", &"<locked>");
+            }
+        }
         debug.finish_non_exhaustive()
     }
 }
@@ -259,6 +338,28 @@ impl EagerRuntime {
             .map_err(|_| Error::Internal("gradient slot registry lock poisoned".to_string()))
     }
 
+    fn lock_value_records(
+        &self,
+    ) -> Result<MutexGuard<'_, HashMap<ValueKey<StdTensorOp>, Weak<EagerTensorRecord>>>> {
+        self.value_records
+            .lock()
+            .map_err(|_| Error::Internal("eager value registry lock poisoned".to_string()))
+    }
+
+    fn lock_value_ptr_records(
+        &self,
+    ) -> Result<MutexGuard<'_, HashMap<usize, Weak<EagerTensorRecord>>>> {
+        self.value_ptr_records
+            .lock()
+            .map_err(|_| Error::Internal("eager value pointer registry lock poisoned".to_string()))
+    }
+
+    pub(crate) fn lock_ad_transform_cache(&self) -> Result<MutexGuard<'_, EagerAdTransformCache>> {
+        self.ad_transform_cache
+            .lock()
+            .map_err(|_| Error::Internal("eager AD transform cache lock poisoned".to_string()))
+    }
+
     fn from_backend(backend: EagerBackend) -> Self {
         Self::from_backend_with_extension_rules(backend, None)
     }
@@ -273,6 +374,9 @@ impl EagerRuntime {
             extension_executor: Mutex::new(ExtensionExecutor::new()),
             extension_rules,
             grad_slots: Mutex::new(HashMap::new()),
+            value_records: Mutex::new(HashMap::new()),
+            value_ptr_records: Mutex::new(HashMap::new()),
+            ad_transform_cache: Mutex::new(EagerAdTransformCache::new()),
         }
     }
 
@@ -409,6 +513,36 @@ impl EagerRuntime {
         self.id
     }
 
+    /// Disable eager operation recording on the current thread until the guard is dropped.
+    ///
+    /// This is useful for optimizer updates, metric calculations, and other
+    /// eager computations that should not become part of the AD tape.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(
+    ///     Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let y = {
+    ///     let _guard = ctx.no_grad();
+    ///     x.mul(&x)?
+    /// };
+    /// assert!(!y.tracks_grad());
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    pub fn no_grad(&self) -> EagerNoGradGuard {
+        EAGER_NO_GRAD_DEPTH.with(|depth| {
+            depth.set(depth.get().saturating_add(1));
+        });
+        EagerNoGradGuard { active: true }
+    }
+
     /// Register one extension runtime on this eager context.
     pub fn register_extension(
         &self,
@@ -453,10 +587,13 @@ impl EagerRuntime {
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// ctx.clear_caches()?;
     /// assert_eq!(ctx.cache_stats()?.extensions.entries, 0);
+    /// assert_eq!(ctx.cache_stats()?.ad_transforms.entries, 0);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
     pub fn clear_caches(&self) -> Result<()> {
-        self.clear_extension_caches()
+        self.clear_extension_caches()?;
+        self.lock_ad_transform_cache()?.clear();
+        Ok(())
     }
 
     /// Return eager runtime cache-entry and retained-byte stats.
@@ -470,11 +607,13 @@ impl EagerRuntime {
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let stats = ctx.cache_stats()?;
     /// assert_eq!(stats.extensions.entries, 0);
+    /// assert_eq!(stats.ad_transforms.entries, 0);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
     pub fn cache_stats(&self) -> Result<EagerRuntimeCacheStats> {
         Ok(EagerRuntimeCacheStats {
             extensions: self.lock_extension_executor()?.cache_stats(),
+            ad_transforms: self.lock_ad_transform_cache()?.stats(),
         })
     }
 
@@ -707,6 +846,90 @@ impl EagerRuntime {
         Ok(())
     }
 
+    pub(crate) fn try_register_value_record(
+        &self,
+        key: &ValueKey<StdTensorOp>,
+        record: &Arc<EagerTensorRecord>,
+    ) -> Result<()> {
+        self.lock_value_records()?
+            .insert(key.clone(), Arc::downgrade(record));
+        self.try_register_value_record_ptr(record)?;
+        Ok(())
+    }
+
+    pub(crate) fn try_register_value_record_ptr(
+        &self,
+        record: &Arc<EagerTensorRecord>,
+    ) -> Result<()> {
+        let tensor = match record.value.as_tensor_arc() {
+            Some(tensor) => Some(Arc::clone(tensor)),
+            None => record.materialized_cache.get().cloned(),
+        };
+        let Some(tensor) = tensor else {
+            return Ok(());
+        };
+        self.lock_value_ptr_records()?
+            .insert(tensor_ptr(&tensor), Arc::downgrade(record));
+        Ok(())
+    }
+
+    pub(crate) fn value_record(
+        &self,
+        key: &ValueKey<StdTensorOp>,
+    ) -> Result<Option<Arc<EagerTensorRecord>>> {
+        let mut records = self.lock_value_records()?;
+        let Some(record) = records.get(key).cloned() else {
+            return Ok(None);
+        };
+        match record.upgrade() {
+            Some(record) => Ok(Some(record)),
+            None => {
+                records.remove(key);
+                Ok(None)
+            }
+        }
+    }
+
+    pub(crate) fn value_record_by_tensor(
+        &self,
+        tensor: &Arc<Tensor>,
+    ) -> Result<Option<Arc<EagerTensorRecord>>> {
+        let ptr = tensor_ptr(tensor);
+        let mut records = self.lock_value_ptr_records()?;
+        let Some(record) = records.get(&ptr).cloned() else {
+            return Ok(None);
+        };
+        match record.upgrade() {
+            Some(record) => Ok(Some(record)),
+            None => {
+                records.remove(&ptr);
+                Ok(None)
+            }
+        }
+    }
+
+    pub(crate) fn cached_linearize_recorded_graph(
+        &self,
+        graph: &RecordedGraph<StdTensorOp>,
+        output_slots: &[usize],
+        ctx: &mut ShapeGuardContext,
+    ) -> tidu::ADRuleResult<Arc<LinearizedGraph<StdTensorOp>>> {
+        let key = EagerAdTransformCacheKey::new(graph, output_slots);
+        if let Some(linear) = self
+            .lock_ad_transform_cache()
+            .map_err(eager_ad_transform_cache_error)?
+            .get(&key)
+        {
+            return Ok(linear);
+        }
+
+        let linear = Arc::new(graph.linearize(output_slots, ctx)?);
+        self.lock_ad_transform_cache()
+            .map_err(eager_ad_transform_cache_error)?
+            .put(key, Arc::clone(&linear));
+        Ok(linear)
+    }
+
     /// Clear all live gradient slots tracked by this context.
     ///
     /// This resets the stored gradients to `None` without unregistering the
@@ -809,6 +1032,221 @@ impl EagerRuntime {
         EagerTensor::new_leaf(Arc::clone(self), tensor, true)
     }
 
+    /// Gradient of a scalar eager output with respect to an eager tensor.
+    ///
+    /// Functional eager gradients return ordinary eager tensors and do not
+    /// write into `grad()` slots. The returned tensor keeps a trace when the
+    /// derivative computation depends on tracked eager values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(
+    ///     Tensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let loss = x.mul(&x)?;
+    /// let dx = ctx.grad(&loss, &x)?;
+    /// assert_eq!(dx.materialized()?.as_slice::<f64>().unwrap(), &[6.0]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    pub fn grad(self: &Arc<Self>, output: &EagerTensor, wrt: &EagerTensor) -> Result<EagerTensor> {
+        self.grad_optional(output, wrt)?
+            .ok_or_else(|| Error::Internal(format!("grad output is inactive for {:?}", wrt.key)))
+    }
+
+    /// Gradient that returns `None` when `wrt` is inactive.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(
+    ///     Tensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let y = EagerTensor::requires_grad_in(
+    ///     Tensor::from_vec_col_major(vec![], vec![4.0_f64]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let loss = y.mul(&y)?;
+    /// assert!(ctx.grad_optional(&loss, &x)?.is_none());
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    pub fn grad_optional(
+        self: &Arc<Self>,
+        output: &EagerTensor,
+        wrt: &EagerTensor,
+    ) -> Result<Option<EagerTensor>> {
+        if !output.shape().is_empty() {
+            return Err(Error::NonScalarGrad {
+                shape: output.shape().to_vec(),
+            });
+        }
+
+        let value = output.materialized_arc()?;
+        let seed = {
+            let mut backend = self.lock_backend()?;
+            one_like_tensor(value.as_ref(), &mut *backend)?
+        };
+        let seed = EagerTensor::new_result_arc(
+            Arc::clone(self),
+            eager_val_key(),
+            Arc::new(seed),
+            false,
+            None,
+            Vec::new(),
+        )?;
+        self.vjp_optional(output, wrt, &seed)
+    }
+
+    /// Reverse-mode vector-Jacobian product for eager tensors.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(
+    ///     Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let y = x.mul(&x)?;
+    /// let seed = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 1.0]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let dx = ctx.vjp(&y, &x, &seed)?;
+    /// assert_eq!(dx.materialized()?.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    pub fn vjp(
+        self: &Arc<Self>,
+        output: &EagerTensor,
+        wrt: &EagerTensor,
+        cotangent: &EagerTensor,
+    ) -> Result<EagerTensor> {
+        self.vjp_optional(output, wrt, cotangent)?
+            .ok_or_else(|| Error::Internal(format!("vjp output is inactive for {:?}", wrt.key)))
+    }
+
+    /// Reverse-mode vector-Jacobian product that returns `None` for inactive inputs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(
+    ///     Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let y = EagerTensor::requires_grad_in(
+    ///     Tensor::from_vec_col_major(vec![1], vec![4.0_f64]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let seed = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let loss = y.mul(&y)?;
+    /// assert!(ctx.vjp_optional(&loss, &x, &seed)?.is_none());
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    pub fn vjp_optional(
+        self: &Arc<Self>,
+        output: &EagerTensor,
+        wrt: &EagerTensor,
+        cotangent: &EagerTensor,
+    ) -> Result<Option<EagerTensor>> {
+        validate_same_runtime(self, output, "vjp output")?;
+        validate_same_runtime(self, wrt, "vjp wrt")?;
+        validate_same_runtime(self, cotangent, "vjp cotangent")?;
+        validate_seed_tensor("vjp", output, cotangent)?;
+        functional_vjp_optional(self, output, wrt, cotangent)
+    }
+
+    /// Forward-mode Jacobian-vector product for eager tensors.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(
+    ///     Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let tangent = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let y = x.mul(&x)?;
+    /// let dy = ctx.jvp(&y, &x, &tangent)?;
+    /// assert_eq!(dy.materialized()?.as_slice::<f64>().unwrap(), &[6.0]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    pub fn jvp(
+        self: &Arc<Self>,
+        output: &EagerTensor,
+        wrt: &EagerTensor,
+        tangent: &EagerTensor,
+    ) -> Result<EagerTensor> {
+        self.jvp_optional(output, wrt, tangent)?
+            .ok_or_else(|| Error::Internal(format!("jvp output is inactive for {:?}", wrt.key)))
+    }
+
+    /// Forward-mode Jacobian-vector product that returns `None` for inactive outputs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(
+    ///     Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let y = EagerTensor::requires_grad_in(
+    ///     Tensor::from_vec_col_major(vec![1], vec![4.0_f64]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let tangent = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let loss = y.mul(&y)?;
+    /// assert!(ctx.jvp_optional(&loss, &x, &tangent)?.is_none());
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    pub fn jvp_optional(
+        self: &Arc<Self>,
+        output: &EagerTensor,
+        wrt: &EagerTensor,
+        tangent: &EagerTensor,
+    ) -> Result<Option<EagerTensor>> {
+        validate_same_runtime(self, output, "jvp output")?;
+        validate_same_runtime(self, wrt, "jvp wrt")?;
+        validate_same_runtime(self, tangent, "jvp tangent")?;
+        validate_seed_tensor("jvp", wrt, tangent)?;
+        functional_jvp(self, output, wrt, tangent)
+    }
+
     fn store_grads(
         &self,
         cotangents: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
@@ -846,6 +1284,48 @@ impl EagerRuntime {
     }
 }
 
+fn validate_same_runtime(
+    runtime: &Arc<EagerRuntime>,
+    tensor: &EagerTensor,
+    role: &'static str,
+) -> Result<()> {
+    if tensor.ctx_id() != runtime.id() {
+        return Err(Error::ContextMismatch {
+            lhs: runtime.id(),
+            rhs: tensor.ctx_id(),
+        });
+    }
+    let _ = role;
+    Ok(())
+}
+
+pub(crate) fn tensor_ptr(tensor: &Arc<Tensor>) -> usize {
+    Arc::as_ptr(tensor) as usize
+}
+
+fn validate_seed_tensor(op: &'static str, primal: &EagerTensor, seed: &EagerTensor) -> Result<()> {
+    if primal.dtype() != seed.dtype() {
+        return Err(tenferro_tensor::Error::InvalidConfig {
+            op,
+            message: format!(
+                "{op} cotangent dtype must match primal dtype: {:?} vs {:?}",
+                seed.dtype(),
+                primal.dtype()
+            ),
+        }
+        .into());
+    }
+    if primal.shape() != seed.shape() {
+        return Err(tenferro_tensor::Error::ShapeMismatch {
+            op,
+            lhs: primal.shape().to_vec(),
+            rhs: seed.shape().to_vec(),
+        }
+        .into());
+    }
+    Ok(())
+}
+
 /// Eager tensor with reverse-mode autodiff over concrete tensor values.
 ///
 /// This executes each primitive immediately and records a lightweight reverse
@@ -881,6 +1361,18 @@ pub struct EagerTensor {
     grad_slot: GradSlot,
     pub(crate) metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
     pub(crate) ctx: Arc<EagerRuntime>,
+    _record: Arc<EagerTensorRecord>,
+}
+
+pub(crate) struct EagerTensorRecord {
+    value: Arc<TensorValue>,
+    materialized_cache: Arc<OnceLock<Arc<Tensor>>>,
+    key: ValueKey<StdTensorOp>,
+    trace: Option<Trace<StdTensorOp>>,
+    requires_grad: bool,
+    grad_slot: GradSlot,
+    metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
+    ctx: Arc<EagerRuntime>,
 }
 
 impl fmt::Debug for EagerTensor {
@@ -943,22 +1435,15 @@ impl EagerTensor {
             register_scoped_value_metadata(key.clone(), tensor_meta_from_tensor(&tensor)).map_err(
                 |err| Error::Internal(format!("eager leaf metadata registration failed: {err}")),
             )?;
-        let tensor = Arc::new(tensor);
-        let grad_slot = Arc::new(Mutex::new(None));
-        if requires_grad {
-            ctx.try_register_grad_slot(&key, &grad_slot)?;
-        }
-
-        Ok(Self {
-            value: Arc::new(TensorValue::from_tensor_arc(tensor)),
-            materialized_cache: Arc::new(OnceLock::new()),
-            key,
-            trace: None,
-            requires_grad,
-            grad_slot,
-            metadata_scopes: metadata_scopes_for_scope(metadata_scope),
+        Self::from_parts(
             ctx,
-        })
+            key,
+            requires_grad,
+            None,
+            Arc::new(TensorValue::from_tensor_arc(Arc::new(tensor))),
+            metadata_scopes_for_scope(metadata_scope),
+            true,
+        )
     }
 
     pub(crate) fn new_result(
@@ -987,21 +1472,15 @@ impl EagerTensor {
         trace: Option<Trace<StdTensorOp>>,
         metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
     ) -> Result<Self> {
-        let grad_slot = Arc::new(Mutex::new(None));
-        if requires_grad {
-            ctx.try_register_grad_slot(&key, &grad_slot)?;
-        }
-
-        Ok(Self {
-            value: Arc::new(TensorValue::from_tensor_arc(tensor)),
-            materialized_cache: Arc::new(OnceLock::new()),
-            key,
-            trace,
-            requires_grad,
-            grad_slot,
-            metadata_scopes,
+        Self::from_parts(
             ctx,
-        })
+            key,
+            requires_grad,
+            trace,
+            Arc::new(TensorValue::from_tensor_arc(tensor)),
+            metadata_scopes,
+            true,
+        )
     }
 
     pub(crate) fn new_result_value(
@@ -1012,20 +1491,55 @@ impl EagerTensor {
         trace: Option<Trace<StdTensorOp>>,
         metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
     ) -> Result<Self> {
+        Self::from_parts(
+            ctx,
+            key,
+            requires_grad,
+            trace,
+            Arc::new(value),
+            metadata_scopes,
+            true,
+        )
+    }
+
+    fn from_parts(
+        ctx: Arc<EagerRuntime>,
+        key: ValueKey<StdTensorOp>,
+        requires_grad: bool,
+        trace: Option<Trace<StdTensorOp>>,
+        value: Arc<TensorValue>,
+        metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
+        register_value: bool,
+    ) -> Result<Self> {
         let grad_slot = Arc::new(Mutex::new(None));
         if requires_grad {
             ctx.try_register_grad_slot(&key, &grad_slot)?;
         }
+        let materialized_cache = Arc::new(OnceLock::new());
+        let record = Arc::new(EagerTensorRecord {
+            value: Arc::clone(&value),
+            materialized_cache: Arc::clone(&materialized_cache),
+            key: key.clone(),
+            trace: trace.clone(),
+            requires_grad,
+            grad_slot: Arc::clone(&grad_slot),
+            metadata_scopes: metadata_scopes.clone(),
+            ctx: Arc::clone(&ctx),
+        });
+        if register_value {
+            ctx.try_register_value_record(&key, &record)?;
+        }
 
         Ok(Self {
-            value: Arc::new(value),
-            materialized_cache: Arc::new(OnceLock::new()),
+            value,
+            materialized_cache,
             key,
             trace,
             requires_grad,
             grad_slot,
             metadata_scopes,
             ctx,
+            _record: record,
         })
     }
 
@@ -1034,15 +1548,44 @@ impl EagerTensor {
     }
 
     pub(crate) fn new_untracked_value_result(ctx: Arc<EagerRuntime>, value: TensorValue) -> Self {
-        Self {
-            value: Arc::new(value),
-            materialized_cache: Arc::new(OnceLock::new()),
-            key: eager_val_key(),
+        let value = Arc::new(value);
+        let materialized_cache = Arc::new(OnceLock::new());
+        let key = eager_val_key();
+        let grad_slot = Arc::new(Mutex::new(None));
+        let record = Arc::new(EagerTensorRecord {
+            value: Arc::clone(&value),
+            materialized_cache: Arc::clone(&materialized_cache),
+            key: key.clone(),
             trace: None,
             requires_grad: false,
-            grad_slot: Arc::new(Mutex::new(None)),
+            grad_slot: Arc::clone(&grad_slot),
+            metadata_scopes: Vec::new(),
+            ctx: Arc::clone(&ctx),
+        });
+        Self {
+            value,
+            materialized_cache,
+            key,
+            trace: None,
+            requires_grad: false,
+            grad_slot,
             metadata_scopes: Vec::new(),
             ctx,
+            _record: record,
+        }
+    }
+
+    pub(crate) fn from_record(record: Arc<EagerTensorRecord>) -> Self {
+        Self {
+            value: Arc::clone(&record.value),
+            materialized_cache: Arc::clone(&record.materialized_cache),
+            key: record.key.clone(),
+            trace: record.trace.clone(),
+            requires_grad: record.requires_grad,
+            grad_slot: Arc::clone(&record.grad_slot),
+            metadata_scopes: record.metadata_scopes.clone(),
+            ctx: Arc::clone(&record.ctx),
+            _record: record,
         }
     }
 
@@ -1140,14 +1683,17 @@ impl EagerTensor {
 
     pub(crate) fn materialized_arc(&self) -> Result<Arc<Tensor>> {
         if let Some(tensor) = self.value.as_tensor_arc() {
+            self.ctx.try_register_value_record_ptr(&self._record)?;
             return Ok(Arc::clone(tensor));
         }
         if let Some(tensor) = self.materialized_cache.get() {
+            self.ctx.try_register_value_record_ptr(&self._record)?;
             return Ok(Arc::clone(tensor));
         }
 
         let materialized = Arc::new(self.value.to_tensor().map_err(Error::from)?);
         let _ = self.materialized_cache.set(Arc::clone(&materialized));
+        self.ctx.try_register_value_record_ptr(&self._record)?;
         Ok(self
             .materialized_cache
             .get()
@@ -1329,7 +1875,7 @@ impl EagerTensor {
             )));
         }
 
-        if !inputs.iter().any(|input| input.requires_grad) {
+        if !eager_grad_recording_enabled() || !inputs.iter().any(|input| input.requires_grad) {
             return execution
                 .outputs
                 .into_iter()
@@ -1425,12 +1971,64 @@ impl EagerTensor {
         }
 
         let value = self.materialized_arc()?;
+        let seed = {
+            let mut backend = self.ctx.lock_backend()?;
+            Arc::new(one_like_tensor(value.as_ref(), &mut *backend)?)
+        };
+        self.backward_from_seed(seed)
+    }
+
+    /// Run reverse-mode AD from this output with an explicit cotangent seed.
+    ///
+    /// This is the stateful eager VJP sugar: it returns the cotangent map and
+    /// accumulates reachable tracked leaves into their `grad()` slots. Use
+    /// [`EagerRuntime::vjp`] when the VJP result should be returned as a
+    /// composable eager tensor without touching grad slots.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    /// let x = EagerTensor::requires_grad_in(
+    ///     Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+    ///     ctx.clone(),
+    /// )?;
+    /// let seed = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
+    ///     ctx,
+    /// )?;
+    /// let y = x.mul(&x)?;
+    /// y.backward_with(&seed)?;
+    /// assert_eq!(x.grad()?.unwrap().as_slice::<f64>().unwrap(), &[4.0, 12.0]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    pub fn backward_with(
+        &self,
+        cotangent: &EagerTensor,
+    ) -> Result<HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>> {
+        if !self.same_context(cotangent) {
+            return Err(Error::ContextMismatch {
+                lhs: self.ctx_id(),
+                rhs: cotangent.ctx_id(),
+            });
+        }
+        validate_seed_tensor("backward", self, cotangent)?;
+        self.backward_from_seed(cotangent.materialized_arc()?)
+    }
+
+    fn backward_from_seed(
+        &self,
+        seed: Arc<Tensor>,
+    ) -> Result<HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>> {
         let mut backend = self.ctx.lock_backend()?;
         let mut extension_executor = self.ctx.lock_extension_executor()?;
-        let seed = Arc::new(one_like_tensor(value.as_ref(), &mut *backend)?);
-        let mut callbacks = TenferroBackwardCallbacks::new(
+        let mut callbacks = TenferroBackwardCallbacks::with_runtime(
             &mut *backend,
             Some(&mut *extension_executor),
+            Some(self.ctx.as_ref()),
             self.metadata_scopes.clone(),
         );
         let mut ad_ctx = ShapeGuardContext::with_global_metadata();
@@ -1536,6 +2134,14 @@ pub(crate) fn record_eager_recorded_graph_outputs(
 
 fn eager_record_error(err: tidu::eager::EagerRecordError) -> Error {
     Error::Internal(format!("invalid eager recording metadata: {err}"))
+}
+
+fn eager_ad_transform_cache_error(message: impl ToString) -> ADRuleError {
+    ADRuleError::invalid_input(
+        "tenferro-ad.eager.transform-cache",
+        ADRuleKind::Jvp,
+        message.to_string(),
+    )
 }
 
 pub(crate) fn exec_single_output(

--- a/crates/tenferro-ad/src/eager/backward.rs
+++ b/crates/tenferro-ad/src/eager/backward.rs
@@ -7,7 +7,7 @@ use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeGuardContext, TensorMeta};
 use tenferro_tensor::{DType, Tensor, TensorBackend, TypedTensor};
-use tidu::eager::BackwardExecutor;
+use tidu::eager::{BackwardExecutor, RecordedGraph};
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult, LinearizedGraph, PrimitiveGraph};
 
 use crate::eager_builder::EagerPrimitiveBuilder;
@@ -18,24 +18,36 @@ use crate::metadata::{
     GlobalMetadataScope,
 };
 
-use super::zero_like_tensor;
+use super::{zero_like_tensor, EagerRuntime};
 
 pub(crate) struct TenferroBackwardCallbacks<'a, B: TensorBackend + 'static> {
     backend: &'a mut B,
     extension_executor: Option<&'a mut ExtensionExecutor<B>>,
+    runtime: Option<&'a EagerRuntime>,
     metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
     deferred_error: Option<ADRuleError>,
 }
 
 impl<'a, B: TensorBackend + 'static> TenferroBackwardCallbacks<'a, B> {
+    #[cfg(test)]
     pub(crate) fn new(
         backend: &'a mut B,
         extension_executor: Option<&'a mut ExtensionExecutor<B>>,
         metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
     ) -> Self {
+        Self::with_runtime(backend, extension_executor, None, metadata_scopes)
+    }
+
+    pub(crate) fn with_runtime(
+        backend: &'a mut B,
+        extension_executor: Option<&'a mut ExtensionExecutor<B>>,
+        runtime: Option<&'a EagerRuntime>,
+        metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
+    ) -> Self {
         Self {
             backend,
             extension_executor,
+            runtime,
             metadata_scopes,
             deferred_error: None,
         }
@@ -104,7 +116,7 @@ pub(super) fn eager_forward_value<B: TensorBackend>(
     Ok(value)
 }
 
-fn live_graph_values(graph: &Graph<StdTensorOp>) -> HashSet<LocalValueId> {
+pub(super) fn live_graph_values(graph: &Graph<StdTensorOp>) -> HashSet<LocalValueId> {
     let mut producers = HashMap::new();
     for (op_index, op_node) in graph.operations().iter().enumerate() {
         for &output_id in &op_node.outputs {
@@ -183,7 +195,7 @@ pub(super) fn zero_from_exact_metadata<B: TensorBackend>(
     })?))
 }
 
-fn prefill_missing_linear_zero_values<B: TensorBackend>(
+pub(super) fn prefill_missing_linear_zero_values<B: TensorBackend>(
     linear: &LinearizedGraph<StdTensorOp>,
     external_data: &mut HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     ctx: &mut ShapeGuardContext,
@@ -224,6 +236,18 @@ fn eager_ad_invalid_input(message: impl Into<String>) -> ADRuleError {
 impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
     for TenferroBackwardCallbacks<'_, B>
 {
+    fn linearize_recorded_graph(
+        &mut self,
+        graph: &RecordedGraph<StdTensorOp>,
+        output_slots: &[usize],
+        ctx: &mut ShapeGuardContext,
+    ) -> tidu::ADRuleResult<Arc<LinearizedGraph<StdTensorOp>>> {
+        match self.runtime {
+            Some(runtime) => runtime.cached_linearize_recorded_graph(graph, output_slots, ctx),
+            None => graph.linearize(output_slots, ctx).map(Arc::new),
+        }
+    }
+
     fn execute_forward(
         &mut self,
         graph: PrimitiveGraph<'_, StdTensorOp>,

--- a/crates/tenferro-ad/src/eager/cache.rs
+++ b/crates/tenferro-ad/src/eager/cache.rs
@@ -1,0 +1,107 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::mem::{size_of, size_of_val};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use lru::LruCache;
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_tensor::CacheStats;
+use tidu::eager::RecordedGraph;
+use tidu::LinearizedGraph;
+
+const DEFAULT_EAGER_AD_TRANSFORM_CACHE_CAPACITY: usize = 256;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct EagerAdTransformCacheKey {
+    recorded_graph_fingerprint: u64,
+    output_slots: Vec<usize>,
+}
+
+impl EagerAdTransformCacheKey {
+    pub(crate) fn new(graph: &RecordedGraph<StdTensorOp>, output_slots: &[usize]) -> Self {
+        Self {
+            recorded_graph_fingerprint: eager_recorded_graph_fingerprint(graph),
+            output_slots: output_slots.to_vec(),
+        }
+    }
+}
+
+fn eager_recorded_graph_fingerprint(graph: &RecordedGraph<StdTensorOp>) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    graph.input_keys().hash(&mut hasher);
+    graph.output_keys().hash(&mut hasher);
+    graph.as_graph().inputs().hash(&mut hasher);
+    graph.as_graph().outputs().hash(&mut hasher);
+    for value in graph.as_graph().values() {
+        value.key.hash(&mut hasher);
+        value.producer.hash(&mut hasher);
+    }
+    for op in graph.as_graph().operations() {
+        op.operation.hash(&mut hasher);
+        op.inputs.hash(&mut hasher);
+        op.outputs.hash(&mut hasher);
+        op.role.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+#[derive(Debug)]
+pub(crate) struct EagerAdTransformCache {
+    entries: LruCache<EagerAdTransformCacheKey, Arc<LinearizedGraph<StdTensorOp>>>,
+}
+
+impl EagerAdTransformCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: LruCache::new(
+                NonZeroUsize::new(DEFAULT_EAGER_AD_TRANSFORM_CACHE_CAPACITY)
+                    .unwrap_or(NonZeroUsize::MIN),
+            ),
+        }
+    }
+
+    pub(crate) fn get(
+        &mut self,
+        key: &EagerAdTransformCacheKey,
+    ) -> Option<Arc<LinearizedGraph<StdTensorOp>>> {
+        self.entries.get(key).cloned()
+    }
+
+    pub(crate) fn put(
+        &mut self,
+        key: EagerAdTransformCacheKey,
+        value: Arc<LinearizedGraph<StdTensorOp>>,
+    ) {
+        self.entries.put(key, value);
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    pub(crate) fn stats(&self) -> CacheStats {
+        CacheStats {
+            entries: self.entries.len(),
+            retained_bytes: self
+                .entries
+                .iter()
+                .map(|(key, linear)| eager_ad_transform_cache_entry_retained_bytes(key, linear))
+                .sum(),
+        }
+    }
+}
+
+fn eager_ad_transform_cache_entry_retained_bytes(
+    key: &EagerAdTransformCacheKey,
+    linear: &Arc<LinearizedGraph<StdTensorOp>>,
+) -> usize {
+    size_of::<EagerAdTransformCacheKey>()
+        + key.output_slots.capacity() * size_of::<usize>()
+        + size_of::<Arc<LinearizedGraph<StdTensorOp>>>()
+        + size_of::<LinearizedGraph<StdTensorOp>>()
+        + size_of_val(linear.as_graph().values())
+        + size_of_val(linear.as_graph().operations())
+        + size_of_val(linear.tangent_inputs())
+        + size_of_val(linear.tangent_outputs())
+}

--- a/crates/tenferro-ad/src/eager/functional.rs
+++ b/crates/tenferro-ad/src/eager/functional.rs
@@ -1,0 +1,731 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use computegraph::{GraphOperation, LocalValueId, OperationRole, ValueKey, ValueRef};
+use tenferro_ops::input_key::TensorInputKey;
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_ops::ShapeGuardContext;
+use tenferro_runtime::ad_support::push_metadata_scope;
+use tenferro_tensor::Tensor;
+use tidu::eager::{BackwardExecutor, ForwardExecutor, ForwardTangentInput, RecordedGraph};
+use tidu::{
+    ADRuleError, ADRuleKind, ADRuleResult, LinearizedGraph, PrimitiveBuilder, PrimitiveGraph,
+    PrimitiveValue,
+};
+
+use crate::ad_rule_error::ad_rule_error;
+use crate::eager_exec::exec_op_on_tensors_with_extension_executor;
+use crate::error::Result;
+use crate::extension_runtime::ExtensionExecutor;
+
+use super::backward::{
+    eager_forward_input_metadata, eager_forward_value, live_graph_values, missing_tangent_base_key,
+    prefill_missing_linear_zero_values,
+};
+use super::{
+    eager_val_key, record_eager_outputs, tensor_ptr, zero_like_tensor, EagerRuntime, EagerTensor,
+};
+use crate::metadata::{
+    push_metadata_scope as push_ad_metadata_scope, register_scoped_live_graph_metadata,
+    GlobalMetadataScope,
+};
+
+pub(super) fn functional_vjp_optional(
+    ctx: &Arc<EagerRuntime>,
+    output: &EagerTensor,
+    wrt: &EagerTensor,
+    cotangent: &EagerTensor,
+) -> Result<Option<EagerTensor>> {
+    let seed = cotangent.materialized_arc()?;
+    let mut backend = ctx.lock_backend()?;
+    let mut extension_executor = ctx.lock_extension_executor()?;
+    let mut callbacks = RecordingCallbacks::new(
+        Arc::clone(ctx),
+        &mut backend,
+        Some(&mut *extension_executor),
+        output.metadata_scopes.clone(),
+    );
+    callbacks.remember_tensor(output)?;
+    callbacks.remember_tensor(wrt)?;
+    callbacks.remember_tensor(cotangent)?;
+    let mut ad_ctx = ShapeGuardContext::with_global_metadata();
+    if let Some(extension_rules) = &ctx.extension_rules {
+        ad_ctx = ad_ctx.with_extension_rules(extension_rules.clone());
+    }
+
+    let cotangents_result = tidu::eager::backward(
+        &output.key,
+        output.trace.as_ref(),
+        seed,
+        &mut callbacks,
+        &mut ad_ctx,
+    );
+    let callback_error = callbacks.take_error();
+    let cotangents = match (cotangents_result, callback_error) {
+        (_, Some(err)) => return Err(ad_rule_error("vjp", err)),
+        (Err(err), None) => return Err(ad_rule_error("vjp", err)),
+        (Ok(cotangents), None) => cotangents,
+    };
+
+    cotangents
+        .get(&wrt.key)
+        .map(|cotangent| callbacks.tensor_for_arc(cotangent))
+        .transpose()
+}
+
+pub(super) fn functional_jvp(
+    ctx: &Arc<EagerRuntime>,
+    output: &EagerTensor,
+    wrt: &EagerTensor,
+    tangent: &EagerTensor,
+) -> Result<Option<EagerTensor>> {
+    let tangent_value = tangent.materialized_arc()?;
+    let mut backend = ctx.lock_backend()?;
+    let mut extension_executor = ctx.lock_extension_executor()?;
+    let mut callbacks = RecordingCallbacks::new(
+        Arc::clone(ctx),
+        &mut backend,
+        Some(&mut *extension_executor),
+        output.metadata_scopes.clone(),
+    );
+    callbacks.remember_tensor(output)?;
+    callbacks.remember_tensor(wrt)?;
+    callbacks.remember_tensor(tangent)?;
+    let tangent_seeds = HashMap::from([(wrt.key.clone(), tangent_value)]);
+    let mut ad_ctx = ShapeGuardContext::with_global_metadata();
+    if let Some(extension_rules) = &ctx.extension_rules {
+        ad_ctx = ad_ctx.with_extension_rules(extension_rules.clone());
+    }
+
+    let tangent_result = tidu::eager::try_forward(
+        &output.key,
+        output.trace.as_ref(),
+        &tangent_seeds,
+        &mut callbacks,
+        &mut ad_ctx,
+    );
+    let callback_error = callbacks.take_error();
+    let tangent = match (tangent_result, callback_error) {
+        (_, Some(err)) => return Err(ad_rule_error("jvp", err)),
+        (Err(err), None) => return Err(ad_rule_error("jvp", err)),
+        (Ok(tangent), None) => tangent,
+    };
+
+    tangent
+        .as_ref()
+        .map(|tangent| callbacks.tensor_for_arc(tangent))
+        .transpose()
+}
+
+struct RecordingCallbacks<'a> {
+    ctx: Arc<EagerRuntime>,
+    backend: &'a mut super::EagerBackend,
+    extension_executor: Option<&'a mut ExtensionExecutor<super::EagerBackend>>,
+    metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
+    tensors_by_ptr: HashMap<usize, EagerTensor>,
+    deferred_error: Option<ADRuleError>,
+}
+
+impl<'a> RecordingCallbacks<'a> {
+    fn new(
+        ctx: Arc<EagerRuntime>,
+        backend: &'a mut super::EagerBackend,
+        extension_executor: Option<&'a mut ExtensionExecutor<super::EagerBackend>>,
+        metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
+    ) -> Self {
+        Self {
+            ctx,
+            backend,
+            extension_executor,
+            metadata_scopes,
+            tensors_by_ptr: HashMap::new(),
+            deferred_error: None,
+        }
+    }
+
+    fn take_error(&mut self) -> Option<ADRuleError> {
+        self.deferred_error.take()
+    }
+
+    fn record_error(&mut self, err: ADRuleError) {
+        if self.deferred_error.is_none() {
+            self.deferred_error = Some(err);
+        }
+    }
+
+    fn ptr(tensor: &Arc<Tensor>) -> usize {
+        tensor_ptr(tensor)
+    }
+
+    fn remember_tensor(&mut self, tensor: &EagerTensor) -> Result<Arc<Tensor>> {
+        let value = tensor.materialized_arc()?;
+        self.tensors_by_ptr
+            .insert(Self::ptr(&value), tensor.clone());
+        Ok(value)
+    }
+
+    fn remember_result(&mut self, tensor: EagerTensor) -> ADRuleResult<Arc<Tensor>> {
+        let value = tensor.materialized_arc().map_err(recording_error)?;
+        self.tensors_by_ptr.insert(Self::ptr(&value), tensor);
+        Ok(value)
+    }
+
+    fn tensor_for_arc(&mut self, value: &Arc<Tensor>) -> Result<EagerTensor> {
+        if let Some(tensor) = self.tensors_by_ptr.get(&Self::ptr(value)) {
+            return Ok(tensor.clone());
+        }
+        let tensor = EagerTensor::new_result_arc(
+            Arc::clone(&self.ctx),
+            eager_val_key(),
+            Arc::clone(value),
+            false,
+            None,
+            Vec::new(),
+        )?;
+        self.tensors_by_ptr.insert(Self::ptr(value), tensor.clone());
+        Ok(tensor)
+    }
+
+    fn tensor_for_key_or_value(
+        &mut self,
+        key: &ValueKey<StdTensorOp>,
+        value: &Arc<Tensor>,
+    ) -> ADRuleResult<EagerTensor> {
+        if let Some(tensor) = self.tensors_by_ptr.get(&Self::ptr(value)) {
+            return Ok(tensor.clone());
+        }
+        if let Some(record) = self
+            .ctx
+            .value_record_by_tensor(value)
+            .map_err(recording_error)?
+        {
+            let tensor = EagerTensor::from_record(record);
+            self.tensors_by_ptr.insert(Self::ptr(value), tensor.clone());
+            return Ok(tensor);
+        }
+        if let Some(record) = self.ctx.value_record(key).map_err(recording_error)? {
+            let tensor = EagerTensor::from_record(record);
+            self.tensors_by_ptr.insert(Self::ptr(value), tensor.clone());
+            return Ok(tensor);
+        }
+        let tensor = EagerTensor::new_result_arc(
+            Arc::clone(&self.ctx),
+            key.clone(),
+            Arc::clone(value),
+            false,
+            None,
+            Vec::new(),
+        )
+        .map_err(recording_error)?;
+        self.tensors_by_ptr.insert(Self::ptr(value), tensor.clone());
+        Ok(tensor)
+    }
+
+    fn external_tensors(
+        &mut self,
+        external_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
+    ) -> ADRuleResult<HashMap<ValueKey<StdTensorOp>, EagerTensor>> {
+        external_data
+            .iter()
+            .map(|(key, value)| {
+                self.tensor_for_key_or_value(key, value)
+                    .map(|tensor| (key.clone(), tensor))
+            })
+            .collect()
+    }
+
+    fn add_recorded(&mut self, a: &Arc<Tensor>, b: &Arc<Tensor>) -> ADRuleResult<Arc<Tensor>> {
+        let lhs = self.tensor_for_arc(a).map_err(recording_error)?;
+        let rhs = self.tensor_for_arc(b).map_err(recording_error)?;
+        let mut builder = RecordingPrimitiveBuilder::new(
+            Arc::clone(&self.ctx),
+            self.backend,
+            self.extension_executor.as_deref_mut(),
+            HashMap::new(),
+        );
+        let outputs = builder.execute_operation(&StdTensorOp::Add, vec![lhs, rhs])?;
+        let output = outputs
+            .into_iter()
+            .next()
+            .ok_or_else(|| recording_error("eager AD add produced no outputs"))?;
+        drop(builder);
+        self.remember_result(output)
+    }
+}
+
+impl BackwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
+    fn linearize_recorded_graph(
+        &mut self,
+        graph: &RecordedGraph<StdTensorOp>,
+        output_slots: &[usize],
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Arc<LinearizedGraph<StdTensorOp>>> {
+        self.ctx
+            .cached_linearize_recorded_graph(graph, output_slots, ctx)
+    }
+
+    fn execute_forward(
+        &mut self,
+        graph: PrimitiveGraph<'_, StdTensorOp>,
+        initial_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
+    ) -> HashMap<ValueKey<StdTensorOp>, Arc<Tensor>> {
+        if self.deferred_error.is_some() {
+            return initial_data.clone();
+        }
+        let graph = graph.as_graph();
+        let mut all_values = initial_data.clone();
+        let mut input_metadata = Vec::with_capacity(graph.inputs().len());
+        for &input_id in graph.inputs() {
+            let key = graph.values()[input_id].key.clone();
+            match eager_forward_input_metadata(&key, initial_data) {
+                Ok(meta) => input_metadata.push((key, meta)),
+                Err(err) => {
+                    self.record_error(err);
+                    return all_values;
+                }
+            }
+        }
+
+        for op_node in graph.operations() {
+            let mut resolved_values = Vec::with_capacity(op_node.inputs.len());
+            for input in &op_node.inputs {
+                let resolved = match input {
+                    ValueRef::Local(local_id) => {
+                        let key = &graph.values()[*local_id].key;
+                        eager_forward_value(&mut all_values, key, initial_data, self.backend)
+                    }
+                    ValueRef::External(key) => {
+                        eager_forward_value(&mut all_values, key, initial_data, self.backend)
+                    }
+                };
+                match resolved {
+                    Ok(value) => resolved_values.push(value),
+                    Err(err) => {
+                        self.record_error(err);
+                        return all_values;
+                    }
+                }
+            }
+            let resolved_inputs: Vec<&Tensor> =
+                resolved_values.iter().map(|value| value.as_ref()).collect();
+            let outputs = match exec_op_on_tensors_with_extension_executor(
+                &op_node.operation,
+                &resolved_inputs,
+                self.backend,
+                self.extension_executor.as_deref_mut(),
+            ) {
+                Ok(outputs) => outputs,
+                Err(err) => {
+                    self.record_error(recording_error(format!(
+                        "eager forward exec failed for {:?}: {err}",
+                        op_node.operation
+                    )));
+                    return all_values;
+                }
+            };
+
+            for (output_id, output) in op_node.outputs.iter().zip(outputs) {
+                let key = graph.values()[*output_id].key.clone();
+                all_values.insert(key, Arc::new(output));
+            }
+        }
+
+        let live_values = live_graph_values(graph);
+        match register_scoped_live_graph_metadata(graph, &live_values, input_metadata) {
+            Ok(scope) => push_ad_metadata_scope(&mut self.metadata_scopes, Arc::new(scope)),
+            Err(err) => self.record_error(recording_error(format!(
+                "eager replay metadata registration failed: {err}"
+            ))),
+        }
+
+        all_values
+    }
+
+    fn run_transposed_linear(
+        &mut self,
+        linear: &LinearizedGraph<StdTensorOp>,
+        cotangent_out: &[Option<Arc<Tensor>>],
+        external_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<Arc<Tensor>>>> {
+        if let Some(err) = self.take_error() {
+            return Err(err);
+        }
+        let mut external_data = external_data.clone();
+        ctx.refresh_global_metadata();
+        prefill_missing_linear_zero_values(linear, &mut external_data, ctx, self.backend)?;
+        let external_tensors = self.external_tensors(&external_data)?;
+        let seed_tensors = cotangent_out
+            .iter()
+            .map(|maybe_seed| {
+                maybe_seed
+                    .as_ref()
+                    .map(|seed| self.tensor_for_arc(seed).map_err(recording_error))
+                    .transpose()
+            })
+            .collect::<ADRuleResult<Vec<_>>>()?;
+        let mut builder = RecordingPrimitiveBuilder::new(
+            Arc::clone(&self.ctx),
+            self.backend,
+            self.extension_executor.as_deref_mut(),
+            external_tensors,
+        );
+        let cotangent_seed_ids = seed_tensors
+            .into_iter()
+            .map(|maybe_tensor| maybe_tensor.map(|tensor| builder.push_tensor(tensor)))
+            .collect::<Vec<_>>();
+
+        let transpose_result =
+            tidu::linear_transpose_with_builder(linear, &mut builder, &cotangent_seed_ids, ctx);
+        if let Some(err) = builder.take_error() {
+            return Err(err);
+        }
+        let cotangent_ids = transpose_result?;
+        let cotangent_tensors = cotangent_ids
+            .into_iter()
+            .map(|maybe_id| maybe_id.map(|id| builder.tensor(id)).transpose())
+            .collect::<ADRuleResult<Vec<_>>>()?;
+        drop(builder);
+        cotangent_tensors
+            .into_iter()
+            .map(|maybe_tensor| {
+                maybe_tensor
+                    .map(|tensor| self.remember_result(tensor))
+                    .transpose()
+            })
+            .collect()
+    }
+
+    fn add_operands(&mut self, a: &Arc<Tensor>, b: &Arc<Tensor>) -> Arc<Tensor> {
+        if self.deferred_error.is_some() {
+            return Arc::clone(a);
+        }
+        match self.add_recorded(a, b) {
+            Ok(sum) => sum,
+            Err(err) => {
+                self.record_error(err);
+                Arc::clone(a)
+            }
+        }
+    }
+}
+
+impl ForwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
+    fn linearize_recorded_graph(
+        &mut self,
+        graph: &RecordedGraph<StdTensorOp>,
+        output_slots: &[usize],
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Arc<LinearizedGraph<StdTensorOp>>> {
+        self.ctx
+            .cached_linearize_recorded_graph(graph, output_slots, ctx)
+    }
+
+    fn run_linearized_forward(
+        &mut self,
+        linear: &LinearizedGraph<StdTensorOp>,
+        tangent_in: &[ForwardTangentInput<StdTensorOp>],
+        external_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<Arc<Tensor>>>> {
+        if let Some(err) = self.take_error() {
+            return Err(err);
+        }
+        let mut external_data = external_data.clone();
+        ctx.refresh_global_metadata();
+        prefill_missing_linear_zero_values(linear, &mut external_data, ctx, self.backend)?;
+        let tangent_by_key: HashMap<_, _> = tangent_in
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        let tangent_tensors = linear
+            .tangent_inputs()
+            .iter()
+            .map(
+                |(key, _)| match tangent_by_key.get(key).cloned().flatten() {
+                    Some(tangent) => self.tensor_for_arc(&tangent).map_err(recording_error),
+                    None => self.zero_tangent_for_key(key, &external_data),
+                },
+            )
+            .collect::<ADRuleResult<Vec<_>>>()?;
+        let external_tensors = self.external_tensors(&external_data)?;
+        let mut builder = RecordingPrimitiveBuilder::new(
+            Arc::clone(&self.ctx),
+            self.backend,
+            self.extension_executor.as_deref_mut(),
+            external_tensors,
+        );
+        for ((_, expected_id), tangent) in linear.tangent_inputs().iter().zip(tangent_tensors) {
+            let id = builder.push_tensor(tangent);
+            if id != *expected_id {
+                return Err(recording_error(format!(
+                    "linearized forward expected tangent local {expected_id}, got {id}"
+                )));
+            }
+        }
+
+        for op_node in linear.as_graph().operations() {
+            let inputs = op_node
+                .inputs
+                .iter()
+                .map(|input| match input {
+                    ValueRef::Local(local_id) => PrimitiveValue::Local(*local_id),
+                    ValueRef::External(key) => PrimitiveValue::External(key.clone()),
+                })
+                .collect();
+            let output_ids =
+                builder.add_primitive(op_node.operation.clone(), inputs, op_node.role.clone());
+            if let Some(err) = builder.take_error() {
+                return Err(err);
+            }
+            if output_ids != op_node.outputs {
+                return Err(recording_error(format!(
+                    "linearized forward expected outputs {:?}, got {:?}",
+                    op_node.outputs, output_ids
+                )));
+            }
+        }
+
+        let tangent_tensors = linear
+            .tangent_outputs()
+            .iter()
+            .map(|maybe_id| maybe_id.map(|id| builder.tensor(id)).transpose())
+            .collect::<ADRuleResult<Vec<_>>>()?;
+        drop(builder);
+        tangent_tensors
+            .into_iter()
+            .map(|maybe_tensor| {
+                maybe_tensor
+                    .map(|tensor| self.remember_result(tensor))
+                    .transpose()
+            })
+            .collect()
+    }
+
+    fn add_operands(&mut self, a: &Arc<Tensor>, b: &Arc<Tensor>) -> Arc<Tensor> {
+        <Self as BackwardExecutor<StdTensorOp>>::add_operands(self, a, b)
+    }
+}
+
+impl RecordingCallbacks<'_> {
+    fn zero_tangent_for_key(
+        &mut self,
+        key: &TensorInputKey,
+        external_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
+    ) -> ADRuleResult<EagerTensor> {
+        let tangent_key = ValueKey::Input(key.clone());
+        let base_key =
+            missing_tangent_base_key(&tangent_key).unwrap_or_else(|| tangent_key.clone());
+        let base = external_data.get(&base_key).ok_or_else(|| {
+            recording_error(format!("missing tangent base eager value for {base_key:?}"))
+        })?;
+        let zero = zero_like_tensor(base.as_ref(), self.backend).map_err(recording_error)?;
+        EagerTensor::new_result_arc(
+            Arc::clone(&self.ctx),
+            eager_val_key(),
+            Arc::new(zero),
+            false,
+            None,
+            Vec::new(),
+        )
+        .map_err(recording_error)
+    }
+}
+
+struct RecordingPrimitiveBuilder<'a> {
+    ctx: Arc<EagerRuntime>,
+    backend: &'a mut super::EagerBackend,
+    extension_executor: Option<&'a mut ExtensionExecutor<super::EagerBackend>>,
+    external_data: HashMap<ValueKey<StdTensorOp>, EagerTensor>,
+    results: Vec<EagerTensor>,
+    error: Option<ADRuleError>,
+}
+
+impl<'a> RecordingPrimitiveBuilder<'a> {
+    fn new(
+        ctx: Arc<EagerRuntime>,
+        backend: &'a mut super::EagerBackend,
+        extension_executor: Option<&'a mut ExtensionExecutor<super::EagerBackend>>,
+        external_data: HashMap<ValueKey<StdTensorOp>, EagerTensor>,
+    ) -> Self {
+        Self {
+            ctx,
+            backend,
+            extension_executor,
+            external_data,
+            results: Vec::new(),
+            error: None,
+        }
+    }
+
+    fn push_tensor(&mut self, tensor: EagerTensor) -> LocalValueId {
+        let id = self.results.len();
+        self.results.push(tensor);
+        id
+    }
+
+    fn tensor(&self, id: LocalValueId) -> ADRuleResult<EagerTensor> {
+        self.results
+            .get(id)
+            .cloned()
+            .ok_or_else(|| recording_error(format!("missing eager AD local {id}")))
+    }
+
+    fn take_error(&mut self) -> Option<ADRuleError> {
+        self.error.take()
+    }
+
+    fn record_error(&mut self, err: ADRuleError) {
+        if self.error.is_none() {
+            self.error = Some(err);
+        }
+    }
+
+    fn dummy_output_ids(&self, operation: &StdTensorOp) -> Vec<LocalValueId> {
+        (0..operation.output_count()).collect()
+    }
+
+    fn external_tensor(&mut self, key: &ValueKey<StdTensorOp>) -> ADRuleResult<EagerTensor> {
+        if let Some(tensor) = self.external_data.get(key) {
+            return Ok(tensor.clone());
+        }
+        let base_key = missing_tangent_base_key(key).ok_or_else(|| {
+            recording_error(format!("missing external eager AD value for {key:?}"))
+        })?;
+        let base = self.external_data.get(&base_key).cloned().ok_or_else(|| {
+            recording_error(format!(
+                "missing tangent base eager AD value for {base_key:?}"
+            ))
+        })?;
+        let zero = zero_like_tensor(
+            base.materialized_arc().map_err(recording_error)?.as_ref(),
+            self.backend,
+        )
+        .map_err(recording_error)?;
+        let tensor = EagerTensor::new_result_arc(
+            Arc::clone(&self.ctx),
+            eager_val_key(),
+            Arc::new(zero),
+            false,
+            None,
+            Vec::new(),
+        )
+        .map_err(recording_error)?;
+        self.external_data.insert(key.clone(), tensor.clone());
+        Ok(tensor)
+    }
+
+    fn resolve_primitive_input(
+        &mut self,
+        input: PrimitiveValue<StdTensorOp>,
+    ) -> ADRuleResult<EagerTensor> {
+        match input {
+            PrimitiveValue::Local(id) => self.tensor(id),
+            PrimitiveValue::External(key) => self.external_tensor(&key),
+        }
+    }
+
+    fn execute_operation(
+        &mut self,
+        operation: &StdTensorOp,
+        inputs: Vec<EagerTensor>,
+    ) -> ADRuleResult<Vec<EagerTensor>> {
+        let input_values = inputs
+            .iter()
+            .map(|tensor| tensor.materialized_arc().map_err(recording_error))
+            .collect::<ADRuleResult<Vec<_>>>()?;
+        let input_refs: Vec<_> = input_values.iter().map(|tensor| tensor.as_ref()).collect();
+        let outputs = exec_op_on_tensors_with_extension_executor(
+            operation,
+            &input_refs,
+            self.backend,
+            self.extension_executor.as_deref_mut(),
+        )
+        .map_err(|err| recording_error(format!("eager AD exec failed for {operation:?}: {err}")))?;
+        let output_arcs: Vec<_> = outputs.into_iter().map(Arc::new).collect();
+
+        if !inputs.iter().any(|tensor| tensor.requires_grad) {
+            return output_arcs
+                .into_iter()
+                .map(|output| {
+                    EagerTensor::new_result_arc(
+                        Arc::clone(&self.ctx),
+                        eager_val_key(),
+                        output,
+                        false,
+                        None,
+                        Vec::new(),
+                    )
+                    .map_err(recording_error)
+                })
+                .collect();
+        }
+
+        let input_refs: Vec<_> = inputs.iter().collect();
+        let recorded =
+            record_eager_outputs(operation, &output_arcs, &input_refs).map_err(recording_error)?;
+        if recorded.traces.len() != output_arcs.len() {
+            return Err(recording_error(format!(
+                "expected {} eager AD traces for {:?}, got {}",
+                output_arcs.len(),
+                operation,
+                recorded.traces.len()
+            )));
+        }
+        let mut metadata_scopes = vec![Arc::clone(&recorded.metadata_scope)];
+        for input in &inputs {
+            for scope in &input.metadata_scopes {
+                push_metadata_scope(&mut metadata_scopes, Arc::clone(scope));
+            }
+        }
+
+        recorded
+            .traces
+            .into_iter()
+            .zip(output_arcs)
+            .map(|(trace, output)| {
+                EagerTensor::new_result_arc(
+                    Arc::clone(&self.ctx),
+                    trace.key,
+                    output,
+                    trace.requires_grad,
+                    trace.trace,
+                    metadata_scopes.clone(),
+                )
+                .map_err(recording_error)
+            })
+            .collect()
+    }
+}
+
+impl PrimitiveBuilder<StdTensorOp> for RecordingPrimitiveBuilder<'_> {
+    fn add_primitive(
+        &mut self,
+        operation: StdTensorOp,
+        inputs: Vec<PrimitiveValue<StdTensorOp>>,
+        _role: OperationRole,
+    ) -> Vec<LocalValueId> {
+        let resolved = inputs
+            .into_iter()
+            .map(|input| self.resolve_primitive_input(input))
+            .collect::<ADRuleResult<Vec<_>>>();
+        let outputs = match resolved.and_then(|inputs| self.execute_operation(&operation, inputs)) {
+            Ok(outputs) => outputs,
+            Err(err) => {
+                self.record_error(err);
+                return self.dummy_output_ids(&operation);
+            }
+        };
+        let start = self.results.len();
+        self.results.extend(outputs);
+        (start..self.results.len()).collect()
+    }
+}
+
+fn recording_error(message: impl ToString) -> ADRuleError {
+    ADRuleError::invalid_input(
+        "tenferro-ad.eager.functional",
+        ADRuleKind::Transpose,
+        message.to_string(),
+    )
+}

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -631,6 +631,229 @@ fn standard_graph_op_records_one_tracked_graph_and_backpropagates() {
 }
 
 #[test]
+fn eager_backward_with_accepts_vector_cotangent_seed() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let seed = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let y = x.mul(&x).unwrap();
+
+    y.backward_with(&seed).unwrap();
+
+    assert_eq!(
+        x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(),
+        &[4.0, 12.0]
+    );
+}
+
+#[test]
+fn eager_backward_with_rejects_mismatched_seed_shape() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let seed = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let y = x.mul(&x).unwrap();
+
+    let err = y.backward_with(&seed).unwrap_err();
+
+    assert!(
+        err.to_string().contains("shape mismatch"),
+        "unexpected error: {err}"
+    );
+    assert!(x.grad().unwrap().is_none());
+}
+
+#[test]
+fn eager_runtime_vjp_returns_composable_tensor_without_touching_grad_slot() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let seed = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let y = x.mul(&x).unwrap();
+
+    let dx = ctx.vjp(&y, &x, &seed).unwrap();
+
+    assert!(dx.tracks_grad());
+    assert_eq!(
+        dx.materialized().unwrap().as_slice::<f64>().unwrap(),
+        &[4.0, 12.0]
+    );
+    assert!(x.grad().unwrap().is_none());
+}
+
+#[test]
+fn eager_runtime_jvp_uses_forward_walker() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let tangent = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 1.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let y = x.mul(&x).unwrap();
+
+    let dy = ctx.jvp(&y, &x, &tangent).unwrap();
+
+    assert!(dy.tracks_grad());
+    assert_eq!(
+        dy.materialized().unwrap().as_slice::<f64>().unwrap(),
+        &[4.0, 6.0]
+    );
+}
+
+#[test]
+fn eager_runtime_ad_transform_cache_reuses_recorded_graph_linearization() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let seed = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 1.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let y = x.mul(&x).unwrap();
+
+    assert_eq!(ctx.cache_stats().unwrap().ad_transforms.entries, 0);
+
+    let first = ctx.vjp(&y, &x, &seed).unwrap();
+    assert_eq!(
+        first.materialized().unwrap().as_slice::<f64>().unwrap(),
+        &[4.0, 6.0]
+    );
+    let after_first = ctx.cache_stats().unwrap().ad_transforms;
+    assert!(after_first.entries > 0);
+
+    let second = ctx.vjp(&y, &x, &seed).unwrap();
+    assert_eq!(
+        second.materialized().unwrap().as_slice::<f64>().unwrap(),
+        &[4.0, 6.0]
+    );
+    let after_second = ctx.cache_stats().unwrap().ad_transforms;
+    assert_eq!(after_second.entries, after_first.entries);
+    assert_eq!(after_second.retained_bytes, after_first.retained_bytes);
+
+    ctx.clear_caches().unwrap();
+    assert_eq!(ctx.cache_stats().unwrap().ad_transforms.entries, 0);
+
+    let tangent = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 1.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let dy = ctx.jvp(&y, &x, &tangent).unwrap();
+    assert_eq!(
+        dy.materialized().unwrap().as_slice::<f64>().unwrap(),
+        &[4.0, 6.0]
+    );
+    assert!(ctx.cache_stats().unwrap().ad_transforms.entries > 0);
+}
+
+#[test]
+fn eager_functional_grad_can_feed_jvp() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let tangent = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let loss = x.mul(&x).unwrap();
+
+    let grad = ctx.grad(&loss, &x).unwrap();
+    let hvp = ctx.jvp(&grad, &x, &tangent).unwrap();
+
+    assert!(grad.tracks_grad());
+    assert_eq!(
+        grad.materialized().unwrap().as_slice::<f64>().unwrap(),
+        &[6.0]
+    );
+    assert_eq!(
+        hvp.materialized().unwrap().as_slice::<f64>().unwrap(),
+        &[2.0]
+    );
+}
+
+#[test]
+fn eager_jvp_of_functional_grad_matches_cubic_hvp() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let tangent = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let x2 = x.mul(&x).unwrap();
+    let loss = x2.mul(&x).unwrap();
+
+    let grad = ctx.grad(&loss, &x).unwrap();
+    let hvp = ctx.jvp(&grad, &x, &tangent).unwrap();
+
+    assert_eq!(
+        grad.materialized().unwrap().as_slice::<f64>().unwrap(),
+        &[27.0]
+    );
+    assert_eq!(
+        hvp.materialized().unwrap().as_slice::<f64>().unwrap(),
+        &[18.0]
+    );
+}
+
+#[test]
+fn eager_no_grad_scope_suppresses_operation_recording() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+
+    let y = {
+        let _guard = ctx.no_grad();
+        x.mul(&x).unwrap()
+    };
+    let z = x.mul(&x).unwrap();
+
+    assert!(!y.tracks_grad());
+    assert!(z.tracks_grad());
+}
+
+#[test]
 fn standard_graph_op_rejects_empty_and_cross_context_inputs() {
     let err = match EagerTensor::standard_graph_op(&[], |_| {
         panic!("empty inputs should fail before graph construction")

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -12,8 +12,9 @@ use tenferro_tensor::{
 };
 
 use crate::eager::{
-    exec_single_output, exec_single_output_read, maybe_print_eager_op_profile,
-    profile_eager_op_section, record_eager_op_profile, record_eager_outputs, EagerTensor,
+    eager_grad_recording_enabled, exec_single_output, exec_single_output_read,
+    maybe_print_eager_op_profile, profile_eager_op_section, record_eager_op_profile,
+    record_eager_outputs, EagerTensor,
 };
 use crate::eager_exec::exec_dot_general_with_conj_on_tensor_reads;
 use crate::error::{Error, Result};
@@ -882,7 +883,7 @@ impl EagerTensor {
             }
         }
 
-        if !tensors.iter().any(|tensor| tensor.requires_grad) {
+        if !eager_grad_recording_enabled() || !tensors.iter().any(|tensor| tensor.requires_grad) {
             return Ok(Self::new_untracked_value_result(ctx, value));
         }
 
@@ -933,7 +934,7 @@ impl EagerTensor {
         })?;
 
         let any_requires_grad = profile_eager_op_section("nary_op.requires_grad_scan", || {
-            tensors.iter().any(|tensor| tensor.requires_grad)
+            eager_grad_recording_enabled() && tensors.iter().any(|tensor| tensor.requires_grad)
         });
         if !any_requires_grad {
             let input_reads = profile_eager_op_section("nary_op.collect_input_reads", || {

--- a/crates/tenferro-ad/src/extension.rs
+++ b/crates/tenferro-ad/src/extension.rs
@@ -8,7 +8,7 @@ use tenferro_runtime::ad_support::push_metadata_scope;
 use tenferro_runtime::{Error, Result};
 use tenferro_tensor::{Tensor, TensorValue};
 
-use crate::eager::{record_eager_outputs, EagerRuntime, EagerTensor};
+use crate::eager::{eager_grad_recording_enabled, record_eager_outputs, EagerRuntime, EagerTensor};
 
 pub use tenferro_ops::ext_op::{
     ExtensionLinearTransposeRule, ExtensionLinearizeRule, ExtensionPrimalVjpRule,
@@ -104,7 +104,7 @@ pub fn apply_eager(op: Arc<dyn ExtensionOp>, inputs: &[&EagerTensor]) -> Result<
         )));
     }
 
-    if !inputs.iter().any(|input| input.requires_grad) {
+    if !eager_grad_recording_enabled() || !inputs.iter().any(|input| input.requires_grad) {
         return outputs
             .into_iter()
             .map(|output| EagerTensor::new_untracked_result(Arc::clone(&ctx), output))

--- a/crates/tenferro-ad/src/lib.rs
+++ b/crates/tenferro-ad/src/lib.rs
@@ -42,7 +42,7 @@ mod shape_packing;
 pub mod traced;
 
 pub use context::{AdContext, AdContextBuilder};
-pub use eager::{EagerRuntime, EagerRuntimeCacheStats, EagerTensor};
+pub use eager::{EagerNoGradGuard, EagerRuntime, EagerRuntimeCacheStats, EagerTensor};
 pub use eager_backend::EagerBackend;
 pub(crate) use tenferro_runtime::{extension_cache, extension_runtime, scalar_semantics};
 pub(crate) mod shape_infer {

--- a/crates/tenferro-ad/tests/gpu_ad_tests.rs
+++ b/crates/tenferro-ad/tests/gpu_ad_tests.rs
@@ -1,12 +1,12 @@
 #![cfg(feature = "cuda")]
 
-use tenferro_ad::TracedTensorAdExt;
+use tenferro_ad::{EagerRuntime, EagerTensor, TracedTensorAdExt};
 mod support;
 use support::RunTraced;
 use tenferro_cpu::CpuBackend;
-use tenferro_gpu::{download_tensor, upload_tensor, CudaBackend};
+use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CudaBackend};
 use tenferro_runtime::{DotGeneralConfig, GraphExecutor, Tensor, TracedTensor, TypedTensor};
-use tenferro_tensor::Buffer;
+use tenferro_tensor::{Buffer, TensorDeviceTransfer};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
@@ -79,7 +79,48 @@ fn matmul(lhs: &TracedTensor, rhs: &TracedTensor) -> TracedTensor {
 }
 
 #[test]
+fn test_gpu_eager_backward_smoke() {
+    if !gpu_available() {
+        return;
+    }
+
+    let upload_backend = CudaBackend::new(0).unwrap();
+    let x_gpu = upload_tensor(
+        upload_backend.runtime(),
+        &f64_tensor(vec![2], vec![2.0_f64, 3.0]),
+    )
+    .unwrap();
+    let seed_gpu = upload_tensor(
+        upload_backend.runtime(),
+        &f64_tensor(vec![2], vec![1.0_f64, 1.0]),
+    )
+    .unwrap();
+    let ctx = EagerRuntime::with_cuda_backend(upload_backend);
+    let x = EagerTensor::requires_grad_in(x_gpu, ctx.clone()).unwrap();
+    let seed = EagerTensor::from_tensor_in(seed_gpu, ctx.clone()).unwrap();
+    let y = x.mul(&x).unwrap();
+
+    y.backward_with(&seed).unwrap();
+    let grad = x.grad().unwrap().unwrap();
+    let grad_host = ctx
+        .with_backend_mut(|backend| backend.download_to_host(grad.as_ref()))
+        .unwrap()
+        .unwrap();
+
+    assert_f64_tensor_close(
+        &grad_host,
+        &f64_tensor(vec![2], vec![4.0_f64, 6.0]),
+        1.0e-10,
+        1.0e-10,
+    );
+}
+
+#[test]
 fn test_gpu_matmul_vjp() {
+    if !gpu_available() {
+        return;
+    }
+
     let a_host = f64_tensor(
         vec![3, 4],
         vec![

--- a/docs/architecture/ad-pipeline.md
+++ b/docs/architecture/ad-pipeline.md
@@ -89,13 +89,40 @@ the compiler still perform their own deduplication and backend-oriented
 optimization, but AD rules should not rely on late flattening to remove large,
 known-inactive derivative subgraphs.
 
-AD transform outputs are not cached in a new persistent AD graph cache. The
-caller-owned traced result keeps the transformed graph and any required extra
-roots alive, while compile-time and runtime caches remain owned by the existing
-compiler, executor, and extension runtime contexts. If a future AD optimizer
-cache is introduced, its key must include the resolved output keys, `wrt`
+Current tenferro eager AD uses the same primitive rule set through a different
+interpreter:
+
+```text
+forward eager op:
+  execute concrete op -> record a small RecordedGraph node
+
+stateful eager backward:
+  tidu backward walker -> per-node linearize -> linear_transpose -> execute cotangents
+
+functional eager jvp:
+  tidu forward walker -> per-node linearize -> execute tangents
+
+functional eager grad/vjp:
+  tidu backward walker -> execute emitted derivative primitives through eager recording
+```
+
+tidu owns the eager trace traversal and determines which recorded graph nodes
+are visited. tenferro owns concrete tensor execution, public eager APIs,
+gradient slots, extension-rule context, and runtime caches. Functional eager
+transforms return ordinary eager tensors rather than writing into gradient
+slots, so their derivative computations can be traced by later eager
+transforms.
+
+Traced AD transform outputs are not cached in a new persistent AD graph cache.
+The caller-owned traced result keeps the transformed graph and any required
+extra roots alive, while compile-time and runtime caches remain owned by the
+existing compiler, executor, and extension runtime contexts. Eager runtimes do
+own a bounded Tier-1 AD transform cache for `RecordedGraph` linearization,
+keyed by recorded graph structural fingerprint plus requested output slots.
+That cache is a same-tape per-node memoization layer; a future whole-program AD
+optimizer cache would need keys that include the resolved output keys, `wrt`
 inputs, extension rule set identity, shape/dtype guard inputs, and optimizer
-configuration version; it must not live inside semantic op payloads.
+configuration version. Such keys must not live inside semantic op payloads.
 
 Four crates, strictly layered:
 
@@ -105,7 +132,8 @@ computegraph   GraphOperation + Operand traits, Graph, resolve,
                compilation cache
     ↓
 tidu           Primitive: GraphOperation (adds add + JVP + transpose_rule),
-               linearize, linear_transpose; no graph infrastructure of its own
+               linearize, linear_transpose, eager forward/backward walkers;
+               no graph infrastructure of its own
     ↓
 tenferro       Concrete tensor primitives + execution lowering
 ```
@@ -821,6 +849,8 @@ details (execution lowering, GPU dispatch) remain in `../spec/backend-contract.m
 The important contract is:
 
 - AD transforms (tidu) are graph-based and resolver-backed
+- eager AD traversal (tidu) is separate from concrete execution and cache
+  ownership (tenferro)
 - graph infrastructure (computegraph) is AD-agnostic
 - backends only see the materialized or compiled result
 
@@ -900,7 +930,9 @@ Expected second-order result for `exp(a*x)` with unit seeds:
 ## X. Implementation Status
 
 Phases 1–3 (scalar graph AD, tensor primitives, backend compilation) are
-implemented and tested. Current work focuses on:
+implemented and tested. Eager reverse mode, eager JVP, functional eager
+`grad`/`vjp`/`jvp`, and per-recorded-graph eager linearization caching are
+implemented on the same primitive rule set. Current work focuses on:
 
 - Logical-DAG-aware checkpoint scheduling
 - Partial linear_transpose / cross-country mode

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -239,7 +239,15 @@ row-major order.
 ## Eager Forward And Reverse-Mode Gradients
 
 Eager tensors always compute the forward value immediately. Tracked eager
-tensors also support reverse-mode autodiff on scalar losses with accumulation.
+tensors support two AD styles:
+
+- `backward()` and `backward_with(seed)` are stateful reverse-mode APIs. They
+  return the cotangent map and accumulate reachable tracked leaves into
+  `grad()` slots.
+- `EagerRuntime::grad`, `EagerRuntime::vjp`, and `EagerRuntime::jvp` are
+  functional APIs. They return ordinary eager tensors and do not mutate
+  `grad()` slots, so their results can feed later eager transforms.
+
 Repeated `backward()` calls add to the existing gradients, and you clear them
 explicitly when you want a fresh pass.
 
@@ -269,6 +277,100 @@ assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
 ctx.clear_grads().unwrap();
 assert!(x.grad().unwrap().is_none());
 assert!(y.grad().unwrap().is_none());
+```
+
+Use `backward_with` when the output is not scalar or when reverse mode should
+start from an explicit cotangent seed:
+
+```rust
+use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+use tenferro_cpu::CpuBackend;
+
+let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+let x = EagerTensor::requires_grad_in(
+    Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+    ctx.clone(),
+).unwrap();
+let seed = EagerTensor::from_tensor_in(
+    Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
+    ctx,
+).unwrap();
+
+let y = x.mul(&x).unwrap();
+y.backward_with(&seed).unwrap();
+assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[4.0, 12.0]);
+```
+
+Functional eager transforms return tensors instead of updating gradient slots:
+
+```rust
+use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+use tenferro_cpu::CpuBackend;
+
+let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+let x = EagerTensor::requires_grad_in(
+    Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+    ctx.clone(),
+).unwrap();
+let y = x.mul(&x).unwrap();
+let seed = EagerTensor::from_tensor_in(
+    Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 1.0]).unwrap(),
+    ctx.clone(),
+).unwrap();
+let tangent = EagerTensor::from_tensor_in(
+    Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 1.0]).unwrap(),
+    ctx.clone(),
+).unwrap();
+
+let vjp = ctx.vjp(&y, &x, &seed).unwrap();
+let jvp = ctx.jvp(&y, &x, &tangent).unwrap();
+assert_eq!(vjp.materialized().unwrap().as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+assert_eq!(jvp.materialized().unwrap().as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+assert!(x.grad().unwrap().is_none());
+```
+
+Because functional derivatives are eager tensors, Hessian-vector products can
+be written as `jvp(grad(f))`:
+
+```rust
+use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+use tenferro_cpu::CpuBackend;
+
+let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+let x = EagerTensor::requires_grad_in(
+    Tensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap(),
+    ctx.clone(),
+).unwrap();
+let tangent = EagerTensor::from_tensor_in(
+    Tensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap(),
+    ctx,
+).unwrap();
+
+let loss = x.mul(&x).unwrap().mul(&x).unwrap();
+let grad = ctx.grad(&loss, &x).unwrap();
+let hvp = ctx.jvp(&grad, &x, &tangent).unwrap();
+
+assert_eq!(grad.materialized().unwrap().as_slice::<f64>().unwrap(), &[27.0]);
+assert_eq!(hvp.materialized().unwrap().as_slice::<f64>().unwrap(), &[18.0]);
+```
+
+Wrap updates, metric computations, and other non-differentiated eager work in
+`no_grad` when they should not be recorded:
+
+```rust
+use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+use tenferro_cpu::CpuBackend;
+
+let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+let x = EagerTensor::requires_grad_in(
+    Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap(),
+    ctx.clone(),
+).unwrap();
+let y = {
+    let _guard = ctx.no_grad();
+    x.mul(&x).unwrap()
+};
+assert!(!y.tracks_grad());
 ```
 
 `matmul` participates in the same eager reverse-mode workflow:
@@ -307,6 +409,7 @@ assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[182.0, 410.0
 | Tight inner loops | Direct/eager execution |
 | Exploratory computation | Direct/eager execution |
 | Immediate forward execution through one runtime | `EagerTensor` |
-| Need reverse-mode gradients on scalar losses | tracked `EagerTensor` variables + `backward()` |
-| Need `grad` / `vjp` / `jvp` / HVP via composition on traced graphs | Lazy traced (`TracedTensor` + `GraphCompiler` + `GraphExecutor<B>`) |
+| Need reverse-mode gradients with gradient slots | tracked `EagerTensor` variables + `backward()` / `backward_with(seed)` |
+| Need functional eager `grad` / `vjp` / `jvp` / HVP composition | `EagerRuntime` functional APIs |
+| Need compiled `grad` / `vjp` / `jvp` / HVP composition | Lazy traced (`TracedTensor` + `GraphCompiler` + `GraphExecutor<B>`) |
 | CUDA execution for supported operations | Eager (`Tensor` / `EagerTensor`) or lazy traced (`TracedTensor` + `GraphExecutor<B>`) with explicit upload/download |

--- a/docs/guides/execution-models.md
+++ b/docs/guides/execution-models.md
@@ -18,8 +18,9 @@ autodiff.
 Use `TypedTensor<T, R>` or `Tensor` when no gradient state is needed.
 `TypedTensor<T, R>` carries the scalar type in Rust; `Tensor` stores dtype at
 runtime. Use `EagerTensor` when you want immediate forward execution through an
-`EagerRuntime`, and make tensors tracked when you want PyTorch-style
-`backward()` on scalar losses.
+`EagerRuntime`. Make tensors tracked for PyTorch-style `backward()` on scalar
+losses, or call the runtime functional APIs (`grad`, `vjp`, `jvp`) when the
+derivative should be returned as another eager tensor.
 
 ## Eager GPU
 
@@ -39,10 +40,10 @@ Traced mode records operations into a graph first. It is similar to JAX's
 tracing and `jit` workflow: build the expression, compile it, then run the
 compiled program through a `GraphExecutor<B>`.
 
-Use traced mode for `grad`, `vjp`, `jvp`, and HVP via composition on traced
-graphs, symbolic inputs, graph optimization, and repeated execution. The
-executor backend decides whether the compiled program runs on CPU or CUDA for
-supported operations.
+Use traced mode for symbolic inputs, graph optimization, repeated execution,
+and compiled `grad`, `vjp`, `jvp`, and HVP workflows. The executor backend
+decides whether the compiled program runs on CPU or CUDA for supported
+operations.
 
 ### Dynamic Shapes in Traced Mode
 
@@ -66,7 +67,8 @@ Eager and traced serve different workflows on the same tensor stack.
 | --- | --- |
 | Inspect intermediate values while developing | Eager CPU or eager GPU with explicit download |
 | Immediate forward execution through one runtime | `EagerTensor` |
-| Reverse-mode AD on scalar losses with gradient accumulation | tracked `EagerTensor` variables |
-| `grad`, `vjp`, `jvp`, and higher-order AD on traced graphs | `TracedTensor` |
+| Reverse-mode AD on scalar losses with gradient accumulation | tracked `EagerTensor` variables + `backward()` |
+| Functional eager `grad`, `vjp`, `jvp`, or HVP composition | `EagerRuntime` functional APIs |
+| Compiled `grad`, `vjp`, `jvp`, and higher-order AD | `TracedTensor` |
 | Reuse the same computation many times | `GraphCompiler` + `GraphExecutor<B>` |
 | Keep code without autodiff simple | `TypedTensor<T, R>` or `Tensor` |

--- a/docs/spec/ad-contract.md
+++ b/docs/spec/ad-contract.md
@@ -45,7 +45,7 @@ where
         primal_outputs: &[ValueKey<Self>],
         tangent_inputs: &[Option<LocalValueId>],
         ctx: &mut Self::ADContext,
-    ) -> Vec<Option<LocalValueId>>
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>>
     where
         Self: Sized;
 
@@ -57,11 +57,14 @@ where
         inputs: &[PrimitiveValue<Self>],
         role: &OperationRole,
         ctx: &mut Self::ADContext,
-    ) -> Vec<Option<LocalValueId>>
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>>
     where
         Self: Sized;
 }
 ```
+
+`ADRuleResult<T>` is tidu's rule-emission result type. Rule failures must be
+reported through it instead of panicking or silently dropping derivative flow.
 
 ## ADKey trait (canonical signature)
 
@@ -83,7 +86,7 @@ pub trait ADKey: Clone + Debug + Hash + Eq + Send + Sync + 'static {
 Defined in `tidu-rs/src/linearized_graph.rs`. Returned by
 `tidu::linearize` (which internally calls `Primitive::jvp_rule`
 per operation node — note that `jvp_rule` itself returns
-`Vec<Option<LocalValueId>>`, not `LinearizedGraph`; the graph is
+`ADRuleResult<Vec<Option<LocalValueId>>>`, not `LinearizedGraph`; the graph is
 assembled by `linearize`).
 
 ```rust
@@ -124,6 +127,39 @@ impl<Op: GraphOperation> LinearizedGraph<Op> {
    `StdTensorOp::Extension` may participate in AD only when its operation
    family registers an extension AD rule. Missing extension rules must report
    unsupported AD; they must not silently drop or zero gradients.
+
+## Mode Interpreters And Cacheability
+
+The AD trait contract has one derivative rule set. `jvp_rule` is the only
+primitive-local derivative producer. `transpose_rule` applies only to linear
+flow that was already produced by linearization; it is not a separate primal
+reverse-mode derivative rule. Eager and traced execution choose different
+interpreters for the same rule set:
+
+- **Traced transforms** operate on recorded graphs, then compile and execute a
+  materialized graph.
+- **Eager transforms** record each eager op as a small `RecordedGraph`.
+  tidu owns the eager forward and backward graph traversal. tenferro owns
+  concrete graph execution, public eager APIs, runtime state, extension rules,
+  and cache storage.
+- **Stateful eager reverse mode** (`backward()` and `backward_with(seed)`)
+  accumulates reachable tracked leaves into gradient slots.
+- **Functional eager transforms** (`grad`, `vjp`, `jvp`) return ordinary eager
+  tensors and do not mutate gradient slots. When their derivative computation
+  depends on tracked eager values, the returned tensor remains traceable, so
+  transforms such as `jvp(grad(f))` can be expressed by composing eager calls.
+
+Rule emission must be deterministic for a fixed primitive payload, input and
+output metadata, active mask, requested output slots, AD context, and extension
+rule set. Rules must not read hidden runtime state or environment state to
+decide graph structure. That purity lets runtime owners safely memoize
+recorded-graph linearization through tidu's eager executor hook.
+
+tenferro's eager runtime owns a bounded Tier-1 AD transform cache keyed by the
+recorded graph structural fingerprint and requested output slots. This cache
+reuses linearization for repeated transforms on the same eager tape node. It is
+not a whole-program backward cache and it does not generalize across
+structurally similar but distinct tapes.
 
 ## Complex AD convention
 
@@ -221,6 +257,8 @@ difference requirements for AD at those discontinuous boundaries.
 - Cotangent accumulation rule
 - Linear op rule
 - Primal reuse rule
+- Eager/traced interpreter split
+- Rule-emission cacheability contract
 - Complex AD convention
 - Convert dtype-boundary AD convention
 - Elementwise nondifferentiable boundary AD convention

--- a/docs/worklogs/2026-07-05-issue-1303-ad-end-state.md
+++ b/docs/worklogs/2026-07-05-issue-1303-ad-end-state.md
@@ -1,0 +1,92 @@
+# Issue 1303 AD end-state work log
+
+Date: 2026-07-05
+
+## Session summary
+
+Issue #1303 moves tenferro eager AD to the same rule-set architecture as
+traced AD:
+
+- tidu now provides eager forward and backward trace walkers plus an executor
+  hook for recorded-graph linearization caching.
+- tenferro eager tensors support `backward_with(seed)`, functional
+  `grad`/`vjp`/`jvp`, and `no_grad`.
+- Functional eager transforms return ordinary eager tensors and can compose,
+  including Hessian-vector products written as `jvp(grad(f))`.
+- Eager runtime cache stats now include a bounded Tier-1 AD transform cache for
+  repeated linearization of the same recorded eager graph node.
+- `tenferro-ad` has a Criterion microbenchmark for the same-tape Tier-1 cache
+  hit path, comparing cold cache-cleared backward against warm repeated
+  backward.
+- CUDA eager reverse-mode smoke coverage was added for supported GPU builds.
+
+## Context read
+
+| Source | Why it was read | Decision impact |
+| --- | --- | --- |
+| Issue #1303 | Source of the requested AD architecture end state. | Drove the eager `{JVP,VJP,grad}` work, composability tests, cache hook, and docs updates. |
+| `AGENTS.md` and `REPOSITORY_RULES.md` | Confirm repository rules for public APIs, docs, coverage, work logs, and tidu updates. | Added API examples, updated architecture/spec/guides, and made the needed tidu change upstream instead of shimming in tenferro. |
+| Shared tensor4all rules | Confirm Rust, performance, docs, numerical, benchmark, and workflow expectations. | Kept cache ownership explicit and documented residual cache scope. |
+| tidu eager AD code | Locate traversal ownership boundaries. | Added the linearization-cache hook to tidu executors while leaving traversal in tidu. |
+| Existing tenferro eager reverse-mode implementation | Find how tensors, gradient slots, metadata, and extension executors are owned. | Reused existing runtime ownership and callback execution instead of adding a second eager AD engine. |
+| `docs/spec/ad-contract.md` and `docs/architecture/ad-pipeline.md` | Locate normative AD wording that would become stale. | Updated the one-rule-set contract and eager/traced interpreter split. |
+
+## Decisions made
+
+- **tidu keeps traversal ownership.** Eager forward and backward walkers decide
+  trace order and active slots. tenferro supplies concrete execution hooks and
+  cache storage.
+- **Functional eager transforms record derivative execution.** `grad`, `vjp`,
+  and `jvp` do not mutate gradient slots; they return eager tensors that remain
+  traceable when the derivative depends on tracked eager values.
+- **Stateful backward stays explicit.** `backward()` and `backward_with(seed)`
+  are the APIs that accumulate into `grad()` slots.
+- **Eager value records bridge saved concrete tensors back to eager tensors.**
+  The runtime keeps weak registries by `ValueKey` and materialized tensor
+  pointer so derivative execution can recover the original eager trace when
+  tidu saved a concrete `Arc<Tensor>`.
+- **Synthetic tangent zeros use fresh eager keys.** Reusing the primal input
+  key for a missing tangent zero caused later derivative execution to recover
+  the zero instead of the saved primal tensor. Fresh keys avoid that collision.
+- **Tier-1 cache scope is same-tape recorded graph reuse.** The cache key is a
+  recorded graph structural fingerprint plus requested output slots.
+  Generalized shape-template caching and whole-program backward caching are
+  left as future work.
+- **`no_grad` is a thread-local nesting guard.** It suppresses eager operation
+  recording while still computing concrete eager values.
+
+## Verification performed
+
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test -p tenferro-ad eager_ --release -- --nocapture`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --worktree --output-json /tmp/repository-rules-review-worktree.json`
+- `cargo bench -p tenferro-ad --bench eager_ad_transform_cache --no-run`
+- `cargo bench -p tenferro-ad --bench eager_ad_transform_cache -- --sample-size 10 --warm-up-time 0.2 --measurement-time 0.2`
+  - cold clear-cache backward: 213.79-218.58 us
+  - warm cached-linearization backward: 196.66-200.24 us
+- `cargo test -p tenferro-ad --features cuda test_gpu_eager_backward_smoke --release --no-run`
+- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.6 LD_LIBRARY_PATH=/usr/local/cuda-12.6/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-ad --features cuda test_gpu_eager_backward_smoke --release -- --nocapture`
+- tidu PR #44 CI passed before merging into the tidu AD-rule branch:
+  - coverage
+  - docs-site
+  - nextest on macOS and Ubuntu
+  - rustfmt
+- tidu PR #33 merged the AD-rule branch to `main`; tenferro now pins tidu
+  `998dbac4ca24442433ab9a52a182040dda2d8eea`.
+
+## Remaining risks
+
+- The eager AD transform cache is intentionally a per-recorded-graph Tier-1
+  cache. It does not yet provide whole-program backward caching or reuse across
+  structurally equivalent tapes.
+- CUDA eager AD coverage is a smoke test, not an exhaustive GPU AD oracle.
+- `cargo clippy -p tenferro-ad --features cuda --all-targets -- -D warnings`
+  currently reaches existing `tenferro-gpu` CUDA-feature lint findings outside
+  this change. The CUDA feature test build and smoke execution pass.

--- a/ext/sparse/Cargo.toml
+++ b/ext/sparse/Cargo.toml
@@ -24,7 +24,7 @@ tenferro-internal-ops = { path = "../../crates/tenferro-internal-ops", default-f
 tenferro-runtime = { path = "../../crates/tenferro-runtime", default-features = false }
 tenferro-tensor = { path = "../../crates/tenferro-tensor", default-features = false }
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7" }
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "77527ecb647fecd4918ea2d06d0065ddce4e5b1c" }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "998dbac4ca24442433ab9a52a182040dda2d8eea" }
 
 [dev-dependencies]
 tenferro-ad = { path = "../../crates/tenferro-ad", default-features = false, features = ["cpu-faer"] }

--- a/ext/tropical/Cargo.toml
+++ b/ext/tropical/Cargo.toml
@@ -31,7 +31,7 @@ tenferro-internal-ops = { path = "../../crates/tenferro-internal-ops", default-f
 tenferro-runtime = { path = "../../crates/tenferro-runtime" }
 tenferro-tensor = { path = "../../crates/tenferro-tensor" }
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7", optional = true }
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "77527ecb647fecd4918ea2d06d0065ddce4e5b1c", optional = true }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "998dbac4ca24442433ab9a52a182040dda2d8eea", optional = true }
 num-traits = "0.2"
 tropical-gemm = { version = "0.2", default-features = false, optional = true }
 


### PR DESCRIPTION
## Summary

Closes #1303.
Refs #1280 as the eager-AD gap issue subsumed by the new end-state work.

This PR implements the eager side of the AD architecture end-state:

- adds eager `backward_with(seed)`, functional `grad`/`vjp`/`jvp`, and `no_grad`
- routes functional eager transforms through recording so `grad` can compose with `jvp`, including HVP as `jvp(grad(f))`
- adds a runtime-owned bounded Tier-1 eager AD transform cache and a Criterion same-tape cache benchmark
- updates the AD contract/spec/guides and records the design decisions in `docs/worklogs/2026-07-05-issue-1303-ad-end-state.md`
- updates the tidu pin to merged main commit `998dbac4ca24442433ab9a52a182040dda2d8eea`
- adds CUDA eager backward smoke coverage

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
- `cargo bench -p tenferro-ad --bench eager_ad_transform_cache --no-run`
- `cargo bench -p tenferro-ad --bench eager_ad_transform_cache -- --sample-size 10 --warm-up-time 0.2 --measurement-time 0.2`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.6 LD_LIBRARY_PATH=/usr/local/cuda-12.6/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-ad --features cuda test_gpu_eager_backward_smoke --release -- --nocapture`
