### PR TITLE
Use batched GEMM for MKL grouped GEMM

### DIFF
--- a/crates/tenferro-cpu/src/gemm/blas_gemm.rs
+++ b/crates/tenferro-cpu/src/gemm/blas_gemm.rs
@@ -18,16 +18,16 @@ pub(crate) struct BlasGemmBatch<T> {
     pub(crate) c_cs: isize,
 }
 
-#[cfg(feature = "blas-openblas")]
-const OPENBLAS_GEMM_BATCH_SMALL_DIM_LIMIT: usize = 16;
+#[cfg(any(feature = "blas-openblas", feature = "blas-mkl"))]
+const PROVIDER_GEMM_BATCH_SMALL_DIM_LIMIT: usize = 16;
 
-#[cfg(feature = "blas-openblas")]
-pub(super) fn openblas_should_use_gemm_batch<T>(batches: &[BlasGemmBatch<T>]) -> bool {
+#[cfg(any(feature = "blas-openblas", feature = "blas-mkl"))]
+pub(super) fn provider_should_use_gemm_batch<T>(batches: &[BlasGemmBatch<T>]) -> bool {
     batches.len() > 1
         && batches.iter().all(|batch| {
-            batch.m <= OPENBLAS_GEMM_BATCH_SMALL_DIM_LIMIT
-                && batch.n <= OPENBLAS_GEMM_BATCH_SMALL_DIM_LIMIT
-                && batch.k <= OPENBLAS_GEMM_BATCH_SMALL_DIM_LIMIT
+            batch.m <= PROVIDER_GEMM_BATCH_SMALL_DIM_LIMIT
+                && batch.n <= PROVIDER_GEMM_BATCH_SMALL_DIM_LIMIT
+                && batch.k <= PROVIDER_GEMM_BATCH_SMALL_DIM_LIMIT
         })
 }
 
@@ -274,8 +274,8 @@ fn apply_conj_transpose(trans: CBLAS_TRANSPOSE, conj: bool) -> Option<CBLAS_TRAN
     }
 }
 
-#[cfg(feature = "blas-openblas")]
-mod openblas_batch {
+#[cfg(any(feature = "blas-openblas", feature = "blas-mkl"))]
+mod provider_batch {
     use super::*;
     use std::ffi::c_void;
 
@@ -399,14 +399,14 @@ mod openblas_batch {
                     let Some(last_size) = self.group_size.last_mut() else {
                         return Err(Error::InvalidConfig {
                             op: "grouped_gemm",
-                            message: "OpenBLAS grouped GEMM metadata is inconsistent".into(),
+                            message: "BLAS grouped GEMM metadata is inconsistent".into(),
                         });
                     };
                     *last_size = last_size
                         .checked_add(1)
                         .ok_or_else(|| Error::InvalidConfig {
                             op: "grouped_gemm",
-                            message: "OpenBLAS grouped GEMM group_size overflows i32".into(),
+                            message: "BLAS grouped GEMM group_size overflows i32".into(),
                         })?;
                 }
                 _ => {
@@ -460,7 +460,7 @@ mod openblas_batch {
         }
         let prepared = prepare(batches)?;
         let group_count = dim_to_i32("group_count", prepared.group_count())?;
-        // alpha/beta are per OpenBLAS group, not per job. Keep them in Vecs so
+        // alpha/beta are per BLAS group, not per job. Keep them in Vecs so
         // the C call receives stable contiguous descriptor slices.
         let alpha = vec![alpha; prepared.group_count()];
         let beta = vec![beta; prepared.group_count()];
@@ -505,7 +505,7 @@ mod openblas_batch {
         }
         let prepared = prepare(batches)?;
         let group_count = dim_to_i32("group_count", prepared.group_count())?;
-        // See sgemm_batch: scalar and metadata arrays are per OpenBLAS group.
+        // See sgemm_batch: scalar and metadata arrays are per BLAS group.
         let alpha = vec![alpha; prepared.group_count()];
         let beta = vec![beta; prepared.group_count()];
         let trans_a: Vec<_> = prepared.groups.iter().map(|group| group.trans_a).collect();
@@ -549,7 +549,7 @@ mod openblas_batch {
         }
         let prepared = prepare(batches)?;
         let group_count = dim_to_i32("group_count", prepared.group_count())?;
-        // See sgemm_batch: scalar and metadata arrays are per OpenBLAS group.
+        // See sgemm_batch: scalar and metadata arrays are per BLAS group.
         let alpha = vec![alpha; prepared.group_count()];
         let beta = vec![beta; prepared.group_count()];
         let trans_a: Vec<_> = prepared.groups.iter().map(|group| group.trans_a).collect();
@@ -598,7 +598,7 @@ mod openblas_batch {
         }
         let prepared = prepare(batches)?;
         let group_count = dim_to_i32("group_count", prepared.group_count())?;
-        // See sgemm_batch: scalar and metadata arrays are per OpenBLAS group.
+        // See sgemm_batch: scalar and metadata arrays are per BLAS group.
         let alpha = vec![alpha; prepared.group_count()];
         let beta = vec![beta; prepared.group_count()];
         let trans_a: Vec<_> = prepared.groups.iter().map(|group| group.trans_a).collect();
@@ -723,7 +723,7 @@ macro_rules! impl_real_blas_gemm {
                 Ok(())
             }
 
-            #[cfg(feature = "blas-openblas")]
+            #[cfg(any(feature = "blas-openblas", feature = "blas-mkl"))]
             unsafe fn grouped_gemm(
                 alpha: Self,
                 beta: Self,
@@ -732,9 +732,9 @@ macro_rules! impl_real_blas_gemm {
                 if batches.is_empty() {
                     return Ok(true);
                 }
-                if openblas_should_use_gemm_batch(batches) {
+                if provider_should_use_gemm_batch(batches) {
                     // SAFETY: callers validate job pointers, dimensions, and
-                    // disjoint outputs. The heuristic keeps OpenBLAS
+                    // disjoint outputs. The heuristic keeps provider
                     // gemm_batch on the small-job regime measured to win.
                     unsafe { $batch(alpha, beta, batches) }
                 } else {
@@ -893,7 +893,7 @@ macro_rules! impl_complex_blas_gemm {
                 Ok(true)
             }
 
-            #[cfg(feature = "blas-openblas")]
+            #[cfg(any(feature = "blas-openblas", feature = "blas-mkl"))]
             unsafe fn grouped_gemm(
                 alpha: Self,
                 beta: Self,
@@ -902,9 +902,9 @@ macro_rules! impl_complex_blas_gemm {
                 if batches.is_empty() {
                     return Ok(true);
                 }
-                if openblas_should_use_gemm_batch(batches) {
+                if provider_should_use_gemm_batch(batches) {
                     // SAFETY: callers validate job pointers, dimensions, and
-                    // disjoint outputs. The heuristic keeps OpenBLAS
+                    // disjoint outputs. The heuristic keeps provider
                     // gemm_batch on the small-job regime measured to win.
                     unsafe { $batch(alpha, beta, batches) }
                 } else {
@@ -917,15 +917,15 @@ macro_rules! impl_complex_blas_gemm {
     };
 }
 
-impl_real_blas_gemm!(f64, cblas_sys::cblas_dgemm, openblas_batch::dgemm_batch);
-impl_real_blas_gemm!(f32, cblas_sys::cblas_sgemm, openblas_batch::sgemm_batch);
+impl_real_blas_gemm!(f64, cblas_sys::cblas_dgemm, provider_batch::dgemm_batch);
+impl_real_blas_gemm!(f32, cblas_sys::cblas_sgemm, provider_batch::sgemm_batch);
 impl_complex_blas_gemm!(
     Complex64,
     cblas_sys::cblas_zgemm,
-    openblas_batch::zgemm_batch
+    provider_batch::zgemm_batch
 );
 impl_complex_blas_gemm!(
     Complex32,
     cblas_sys::cblas_cgemm,
-    openblas_batch::cgemm_batch
+    provider_batch::cgemm_batch
 );

--- a/crates/tenferro-cpu/src/gemm/tests.rs
+++ b/crates/tenferro-cpu/src/gemm/tests.rs
@@ -3,8 +3,8 @@ use super::{
     try_fuse_dims, GemmAnalysisCache, GemmAnalysisCacheKind,
 };
 
-#[cfg(feature = "blas-openblas")]
-use super::blas_gemm::openblas_should_use_gemm_batch;
+#[cfg(any(feature = "blas-openblas", feature = "blas-mkl"))]
+use super::blas_gemm::provider_should_use_gemm_batch;
 #[cfg(feature = "cpu-blas")]
 use super::blas_gemm::{BlasGemm, BlasGemmBatch};
 #[cfg(feature = "cpu-blas")]
@@ -416,9 +416,9 @@ fn blas_complex_conj_no_trans_reports_materialization_needed() {
     assert_eq!(c, [Complex64::new(0.0, 0.0); 4]);
 }
 
-#[cfg(feature = "blas-openblas")]
+#[cfg(any(feature = "blas-openblas", feature = "blas-mkl"))]
 #[test]
-fn openblas_gemm_batch_heuristic_keeps_medium_jobs_on_sequential_path() {
+fn provider_gemm_batch_heuristic_keeps_medium_jobs_on_sequential_path() {
     fn batch(m: usize, n: usize, k: usize) -> BlasGemmBatch<f64> {
         BlasGemmBatch {
             a_ptr: std::ptr::null(),
@@ -436,12 +436,12 @@ fn openblas_gemm_batch_heuristic_keeps_medium_jobs_on_sequential_path() {
         }
     }
 
-    assert!(openblas_should_use_gemm_batch(&[
+    assert!(provider_should_use_gemm_batch(&[
         batch(8, 8, 8),
         batch(8, 8, 8)
     ]));
-    assert!(!openblas_should_use_gemm_batch(&[batch(8, 8, 8)]));
-    assert!(!openblas_should_use_gemm_batch(&[
+    assert!(!provider_should_use_gemm_batch(&[batch(8, 8, 8)]));
+    assert!(!provider_should_use_gemm_batch(&[
         batch(8, 8, 8),
         batch(32, 32, 32)
     ]));


### PR DESCRIPTION
## Summary

- enable the provider `cblas_*gemm_batch` path for `blas-mkl` grouped GEMM
- rename the OpenBLAS-specific batch helper/heuristic names to provider-generic names
- run the existing small-job batch heuristic test under both `blas-openblas` and `blas-mkl`

Fixes #1305.

## Verification

- `cargo fmt -p tenferro-cpu --check`
- `cargo check -p tenferro-cpu --no-default-features --features blas-mkl`
- `cargo check -p tenferro-cpu --no-default-features --features cpu-blas`
- `cargo check -p tenferro-cpu --no-default-features --features blas-openblas`
- `cargo test -p tenferro-cpu --no-default-features --features blas-openblas provider_gemm_batch_heuristic_keeps_medium_jobs_on_sequential_path`

## Not fully verified locally

- `blas-mkl` runtime/link tests are blocked on this machine by the local MKL/BLAS link setup. The `blas-mkl` feature type-checks with `cargo check`, but the actual `cblas_*gemm_batch` symbols should be link/runtime verified on a working MKL environment.
