### PR TITLE
Prefer linearize transpose optimize for VJP generation

### DIFF
--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -22,9 +22,12 @@ use tenferro_runtime::{Error, GraphCompiler, GraphExecutor, Result, TracedTensor
 use tenferro_tensor::TensorBackend;
 use tidu::{linear_transpose, linearize};
 
+#[path = "traced/optimizer.rs"]
+mod optimizer;
 #[path = "traced/primal_transpose.rs"]
 mod primal_transpose;
 
+use optimizer::OptimizedLinearGraph;
 use primal_transpose::{try_primal_transpose, PrimalTransposeGraph};
 
 static NEXT_DIFF_PASS_ID: AtomicU64 = AtomicU64::new(0);
@@ -448,6 +451,7 @@ fn jvp_optional_impl(
         &aliases,
     )
     .map_err(|err| ad_rule_error("jvp", err))?;
+    let linear = OptimizedLinearGraph::from_tidu(linear);
     let Some(tangent_output) = linear.tangent_outputs()[0] else {
         return Ok(None);
     };
@@ -501,12 +505,12 @@ fn jvp_optional_impl(
 
 enum VjpTransposeGraph {
     Primal(PrimalTransposeGraph),
-    Linear(tidu::LinearizedGraph<StdTensorOp>),
+    Linear(OptimizedLinearGraph),
 }
 
 struct ActiveLinearVjp {
     linear: tidu::LinearizedGraph<StdTensorOp>,
-    transposed: tidu::LinearizedGraph<StdTensorOp>,
+    transposed: OptimizedLinearGraph,
     metadata_scope: GlobalMetadataScope,
 }
 
@@ -588,6 +592,7 @@ fn vjp_optional_impl(
                 )?;
                 linear_ad_ctx.refresh_global_metadata();
                 linear_transpose(&linear, &mut linear_ad_ctx).map(|transposed| {
+                    let transposed = OptimizedLinearGraph::from_tidu(transposed);
                     Some(ActiveLinearVjp {
                         linear,
                         transposed,

--- a/crates/tenferro-ad/src/traced/optimizer.rs
+++ b/crates/tenferro-ad/src/traced/optimizer.rs
@@ -1,0 +1,438 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use computegraph::graph::{Graph, GraphBuilder};
+use computegraph::{LocalValueId, OperationRole, ValueKey, ValueRef};
+use tenferro_ops::input_key::TensorInputKey;
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_tensor::DType;
+
+pub(super) struct OptimizedLinearGraph {
+    graph: Graph<StdTensorOp>,
+    tangent_inputs: Vec<(TensorInputKey, LocalValueId)>,
+    tangent_outputs: Vec<Option<LocalValueId>>,
+}
+
+impl OptimizedLinearGraph {
+    pub(super) fn from_tidu(linear: tidu::LinearizedGraph<StdTensorOp>) -> Self {
+        let tangent_inputs = linear.tangent_inputs().to_vec();
+        let tangent_outputs = linear.tangent_outputs().to_vec();
+        optimize_graph(linear.into_graph(), tangent_inputs, tangent_outputs)
+    }
+
+    pub(super) fn as_graph(&self) -> &Graph<StdTensorOp> {
+        &self.graph
+    }
+
+    pub(super) fn into_graph(self) -> Graph<StdTensorOp> {
+        self.graph
+    }
+
+    pub(super) fn tangent_inputs(&self) -> &[(TensorInputKey, LocalValueId)] {
+        &self.tangent_inputs
+    }
+
+    pub(super) fn tangent_outputs(&self) -> &[Option<LocalValueId>] {
+        &self.tangent_outputs
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScalarConst {
+    Zero,
+    One,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LocalFact {
+    Neg(LocalValueId),
+    Conj(LocalValueId),
+    ScalarConst(ScalarConst),
+}
+
+fn optimize_graph(
+    graph: Graph<StdTensorOp>,
+    tangent_inputs: Vec<(TensorInputKey, LocalValueId)>,
+    tangent_outputs: Vec<Option<LocalValueId>>,
+) -> OptimizedLinearGraph {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    for parent in graph.parents() {
+        builder.add_parent(Arc::clone(parent));
+    }
+
+    let mut remap: Vec<Option<ValueRef<StdTensorOp>>> = vec![None; graph.values().len()];
+    let mut facts: HashMap<LocalValueId, LocalFact> = HashMap::new();
+
+    for &input in graph.inputs() {
+        let ValueKey::Input(key) = &graph.values()[input].key else {
+            continue;
+        };
+        let new_input = builder.add_input(key.clone());
+        remap[input] = Some(ValueRef::Local(new_input));
+    }
+
+    for op_node in graph.operations() {
+        let inputs: Vec<_> = op_node
+            .inputs
+            .iter()
+            .map(|input| remap_value(input, &remap))
+            .collect();
+
+        if op_node.outputs.len() == 1 {
+            if let Some(alias) =
+                canonical_alias(&op_node.operation, &inputs, op_node.role.clone(), &facts)
+            {
+                remap[op_node.outputs[0]] = Some(alias);
+                continue;
+            }
+        }
+
+        let outputs = builder.add_operation(
+            op_node.operation.clone(),
+            inputs.clone(),
+            op_node.role.clone(),
+        );
+        for (&old_output, &new_output) in op_node.outputs.iter().zip(outputs.iter()) {
+            remap[old_output] = Some(ValueRef::Local(new_output));
+        }
+        if op_node.outputs.len() == 1 {
+            if let Some(fact) = local_fact(&op_node.operation, &inputs) {
+                facts.insert(outputs[0], fact);
+            }
+        }
+    }
+
+    let tangent_inputs = tangent_inputs
+        .into_iter()
+        .filter_map(|(key, old_id)| remap_local(old_id, &remap).map(|new_id| (key, new_id)))
+        .collect();
+    let tangent_outputs: Vec<_> = tangent_outputs
+        .into_iter()
+        .map(|maybe_id| maybe_id.and_then(|old_id| remap_local(old_id, &remap)))
+        .collect();
+    let active_outputs: Vec<_> = tangent_outputs.iter().filter_map(|id| *id).collect();
+    if !active_outputs.is_empty() {
+        builder.set_outputs(active_outputs);
+    }
+
+    prune_unreachable_graph(builder.build(), tangent_inputs, tangent_outputs)
+}
+
+fn prune_unreachable_graph(
+    graph: Graph<StdTensorOp>,
+    tangent_inputs: Vec<(TensorInputKey, LocalValueId)>,
+    tangent_outputs: Vec<Option<LocalValueId>>,
+) -> OptimizedLinearGraph {
+    let mut needed_values = HashSet::new();
+    let mut needed_ops = HashSet::new();
+    let mut stack: Vec<_> = tangent_outputs.iter().filter_map(|id| *id).collect();
+
+    while let Some(value_id) = stack.pop() {
+        if !needed_values.insert(value_id) {
+            continue;
+        }
+        let Some((op_id, _slot)) = graph.values()[value_id].producer else {
+            continue;
+        };
+        if needed_ops.insert(op_id) {
+            for input in &graph.operations()[op_id].inputs {
+                if let ValueRef::Local(input_id) = input {
+                    stack.push(*input_id);
+                }
+            }
+        }
+    }
+
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    for parent in graph.parents() {
+        builder.add_parent(Arc::clone(parent));
+    }
+
+    let mut remap: Vec<Option<ValueRef<StdTensorOp>>> = vec![None; graph.values().len()];
+    for &input in graph.inputs() {
+        let ValueKey::Input(key) = &graph.values()[input].key else {
+            continue;
+        };
+        let new_input = builder.add_input(key.clone());
+        remap[input] = Some(ValueRef::Local(new_input));
+    }
+
+    for (op_id, op_node) in graph.operations().iter().enumerate() {
+        if !needed_ops.contains(&op_id) {
+            continue;
+        }
+        let inputs: Vec<_> = op_node
+            .inputs
+            .iter()
+            .map(|input| remap_value(input, &remap))
+            .collect();
+        let outputs =
+            builder.add_operation(op_node.operation.clone(), inputs, op_node.role.clone());
+        for (&old_output, &new_output) in op_node.outputs.iter().zip(outputs.iter()) {
+            remap[old_output] = Some(ValueRef::Local(new_output));
+        }
+    }
+
+    let tangent_inputs = tangent_inputs
+        .into_iter()
+        .filter_map(|(key, old_id)| remap_local(old_id, &remap).map(|new_id| (key, new_id)))
+        .collect();
+    let tangent_outputs: Vec<_> = tangent_outputs
+        .into_iter()
+        .map(|maybe_id| maybe_id.and_then(|old_id| remap_local(old_id, &remap)))
+        .collect();
+    let active_outputs: Vec<_> = tangent_outputs.iter().filter_map(|id| *id).collect();
+    if !active_outputs.is_empty() {
+        builder.set_outputs(active_outputs);
+    }
+
+    OptimizedLinearGraph {
+        graph: builder.build(),
+        tangent_inputs,
+        tangent_outputs,
+    }
+}
+
+fn remap_value(
+    input: &ValueRef<StdTensorOp>,
+    remap: &[Option<ValueRef<StdTensorOp>>],
+) -> ValueRef<StdTensorOp> {
+    match input {
+        ValueRef::Local(local_id) => remap
+            .get(*local_id)
+            .and_then(Clone::clone)
+            .unwrap_or(ValueRef::Local(*local_id)),
+        ValueRef::External(key) => ValueRef::External(key.clone()),
+    }
+}
+
+fn remap_local(
+    old_id: LocalValueId,
+    remap: &[Option<ValueRef<StdTensorOp>>],
+) -> Option<LocalValueId> {
+    match remap.get(old_id).and_then(Clone::clone)? {
+        ValueRef::Local(local_id) => Some(local_id),
+        ValueRef::External(_) => None,
+    }
+}
+
+fn canonical_alias(
+    operation: &StdTensorOp,
+    inputs: &[ValueRef<StdTensorOp>],
+    role: OperationRole,
+    facts: &HashMap<LocalValueId, LocalFact>,
+) -> Option<ValueRef<StdTensorOp>> {
+    match (operation, inputs) {
+        (StdTensorOp::Neg, [ValueRef::Local(input)]) => match facts.get(input).copied() {
+            Some(LocalFact::Neg(inner)) => Some(ValueRef::Local(inner)),
+            _ => None,
+        },
+        (StdTensorOp::Conj, [ValueRef::Local(input)]) => match facts.get(input).copied() {
+            Some(LocalFact::Conj(inner)) => Some(ValueRef::Local(inner)),
+            _ => None,
+        },
+        (StdTensorOp::Convert { from, to }, [input]) if from == to => Some(input.clone()),
+        (StdTensorOp::Transpose { perm }, [input]) if is_identity_perm(perm) => Some(input.clone()),
+        (StdTensorOp::Add, [lhs, rhs]) => {
+            match (scalar_const(lhs, facts), scalar_const(rhs, facts)) {
+                (Some(ScalarConst::Zero), _) if input_can_alias(&role, 1) => Some(rhs.clone()),
+                (_, Some(ScalarConst::Zero)) if input_can_alias(&role, 0) => Some(lhs.clone()),
+                _ => None,
+            }
+        }
+        (StdTensorOp::Mul, [lhs, rhs]) => {
+            match (scalar_const(lhs, facts), scalar_const(rhs, facts)) {
+                (Some(ScalarConst::One), _) if input_can_alias(&role, 1) => Some(rhs.clone()),
+                (_, Some(ScalarConst::One)) if input_can_alias(&role, 0) => Some(lhs.clone()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn local_fact(operation: &StdTensorOp, inputs: &[ValueRef<StdTensorOp>]) -> Option<LocalFact> {
+    match (operation, inputs) {
+        (StdTensorOp::Neg, [ValueRef::Local(input)]) => Some(LocalFact::Neg(*input)),
+        (StdTensorOp::Conj, [ValueRef::Local(input)]) => Some(LocalFact::Conj(*input)),
+        (StdTensorOp::Constant { dtype, bytes }, _) => {
+            scalar_const_bytes(*dtype, bytes).map(LocalFact::ScalarConst)
+        }
+        _ => None,
+    }
+}
+
+fn scalar_const(
+    input: &ValueRef<StdTensorOp>,
+    facts: &HashMap<LocalValueId, LocalFact>,
+) -> Option<ScalarConst> {
+    match input {
+        ValueRef::Local(local_id) => match facts.get(local_id).copied() {
+            Some(LocalFact::ScalarConst(value)) => Some(value),
+            _ => None,
+        },
+        ValueRef::External(_) => None,
+    }
+}
+
+fn scalar_const_bytes(dtype: DType, bytes: &[u8]) -> Option<ScalarConst> {
+    if bytes == zero_bytes(dtype).as_slice() {
+        Some(ScalarConst::Zero)
+    } else if bytes == one_bytes(dtype).as_slice() {
+        Some(ScalarConst::One)
+    } else {
+        None
+    }
+}
+
+fn zero_bytes(dtype: DType) -> Vec<u8> {
+    match dtype {
+        DType::F32 => 0.0_f32.to_le_bytes().to_vec(),
+        DType::F64 => 0.0_f64.to_le_bytes().to_vec(),
+        DType::I32 => 0_i32.to_le_bytes().to_vec(),
+        DType::I64 => 0_i64.to_le_bytes().to_vec(),
+        DType::Bool => vec![0],
+        DType::C32 => {
+            let mut bytes = Vec::with_capacity(8);
+            bytes.extend_from_slice(&0.0_f32.to_le_bytes());
+            bytes.extend_from_slice(&0.0_f32.to_le_bytes());
+            bytes
+        }
+        DType::C64 => {
+            let mut bytes = Vec::with_capacity(16);
+            bytes.extend_from_slice(&0.0_f64.to_le_bytes());
+            bytes.extend_from_slice(&0.0_f64.to_le_bytes());
+            bytes
+        }
+    }
+}
+
+fn one_bytes(dtype: DType) -> Vec<u8> {
+    match dtype {
+        DType::F32 => 1.0_f32.to_le_bytes().to_vec(),
+        DType::F64 => 1.0_f64.to_le_bytes().to_vec(),
+        DType::I32 => 1_i32.to_le_bytes().to_vec(),
+        DType::I64 => 1_i64.to_le_bytes().to_vec(),
+        DType::Bool => vec![1],
+        DType::C32 => {
+            let mut bytes = Vec::with_capacity(8);
+            bytes.extend_from_slice(&1.0_f32.to_le_bytes());
+            bytes.extend_from_slice(&0.0_f32.to_le_bytes());
+            bytes
+        }
+        DType::C64 => {
+            let mut bytes = Vec::with_capacity(16);
+            bytes.extend_from_slice(&1.0_f64.to_le_bytes());
+            bytes.extend_from_slice(&0.0_f64.to_le_bytes());
+            bytes
+        }
+    }
+}
+
+fn is_identity_perm(perm: &[usize]) -> bool {
+    perm.iter()
+        .enumerate()
+        .all(|(index, &value)| index == value)
+}
+
+fn input_can_alias(role: &OperationRole, input_index: usize) -> bool {
+    match role {
+        OperationRole::Primary => true,
+        OperationRole::Linearized { active_mask } => {
+            active_mask.get(input_index).copied().unwrap_or(false)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scalar_constant(dtype: DType, value: f64) -> StdTensorOp {
+        match dtype {
+            DType::F64 => StdTensorOp::Constant {
+                dtype,
+                bytes: value.to_le_bytes().to_vec(),
+            },
+            _ => unreachable!("test helper only needs f64"),
+        }
+    }
+
+    #[test]
+    fn optimizer_canonicalizes_ad_identity_chains() {
+        let mut builder = GraphBuilder::<StdTensorOp>::new();
+        let x = builder.add_input(TensorInputKey::User { id: 1 });
+
+        let neg = builder.add_operation(
+            StdTensorOp::Neg,
+            vec![ValueRef::Local(x)],
+            OperationRole::Linearized {
+                active_mask: vec![true],
+            },
+        )[0];
+        let double_neg = builder.add_operation(
+            StdTensorOp::Neg,
+            vec![ValueRef::Local(neg)],
+            OperationRole::Linearized {
+                active_mask: vec![true],
+            },
+        )[0];
+
+        let conj = builder.add_operation(
+            StdTensorOp::Conj,
+            vec![ValueRef::Local(double_neg)],
+            OperationRole::Linearized {
+                active_mask: vec![true],
+            },
+        )[0];
+        let double_conj = builder.add_operation(
+            StdTensorOp::Conj,
+            vec![ValueRef::Local(conj)],
+            OperationRole::Linearized {
+                active_mask: vec![true],
+            },
+        )[0];
+
+        let zero = builder.add_operation(
+            scalar_constant(DType::F64, 0.0),
+            vec![],
+            OperationRole::Primary,
+        )[0];
+        let added_zero = builder.add_operation(
+            StdTensorOp::Add,
+            vec![ValueRef::Local(double_conj), ValueRef::Local(zero)],
+            OperationRole::Linearized {
+                active_mask: vec![true, false],
+            },
+        )[0];
+
+        let one = builder.add_operation(
+            scalar_constant(DType::F64, 1.0),
+            vec![],
+            OperationRole::Primary,
+        )[0];
+        let mul_one = builder.add_operation(
+            StdTensorOp::Mul,
+            vec![ValueRef::Local(added_zero), ValueRef::Local(one)],
+            OperationRole::Linearized {
+                active_mask: vec![true, false],
+            },
+        )[0];
+
+        builder.set_outputs(vec![mul_one]);
+        let graph = builder.build();
+        let optimized = optimize_graph(
+            graph,
+            vec![(TensorInputKey::User { id: 1 }, x)],
+            vec![Some(mul_one)],
+        );
+
+        let operations = optimized.graph.operations();
+        assert!(
+            operations.is_empty(),
+            "all identity ops should fold away, got {} ops",
+            operations.len()
+        );
+        assert_eq!(optimized.tangent_outputs(), &[Some(0)]);
+    }
+}

--- a/crates/tenferro-ad/tests/ad_optimizer.rs
+++ b/crates/tenferro-ad/tests/ad_optimizer.rs
@@ -1,0 +1,81 @@
+use tenferro_ad::TracedTensorAdExt;
+use tenferro_cpu::CpuBackend;
+use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
+use tenferro_tensor::Tensor;
+
+fn f64_vec(data: Vec<f64>) -> TracedTensor {
+    TracedTensor::from_vec_col_major(vec![data.len()], data).unwrap()
+}
+
+fn eval_f64(tensor: &TracedTensor) -> Vec<f64> {
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(tensor).unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    match executor.run(&program).unwrap() {
+        Tensor::F64(tensor) => tensor.host_data().unwrap().to_vec(),
+        other => panic!("expected f64 result, got {other:?}"),
+    }
+}
+
+fn op_count(tensor: &TracedTensor, op: StdTensorOp) -> usize {
+    tensor
+        .graph()
+        .operations()
+        .iter()
+        .filter(|node| node.operation == op)
+        .count()
+}
+
+#[test]
+fn traced_jvp_zero_propagation_returns_none_without_dead_graph() {
+    let x = f64_vec(vec![1.0, 2.0]);
+    let y = f64_vec(vec![3.0, 4.0]);
+    let tangent = f64_vec(vec![1.0, 1.0]);
+    let output = y.neg();
+
+    assert!(output.jvp_optional(&x, &tangent).unwrap().is_none());
+}
+
+#[test]
+fn traced_jvp_optimizer_removes_identity_chain_before_compile() {
+    let x = f64_vec(vec![2.0, -3.0]);
+    let tangent = f64_vec(vec![0.25, -0.5]);
+    let y = x.neg().neg();
+
+    let dy = y.jvp(&x, &tangent).unwrap();
+    assert_eq!(
+        dy.graph().operations().len(),
+        0,
+        "double-neg JVP should alias the tangent input before compile"
+    );
+
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(&dy).unwrap();
+    assert_eq!(program.lowering_view().instructions().count(), 0);
+    assert_eq!(eval_f64(&dy), vec![0.25, -0.5]);
+}
+
+#[test]
+fn traced_vjp_cotangent_accumulation_stays_bounded_before_compile() {
+    let x = f64_vec(vec![2.0, -3.0]);
+    let cotangent = f64_vec(vec![1.0, 1.0]);
+    let pair = (&x + &x).unwrap();
+    let y = (&pair + &pair).unwrap();
+
+    let dx = y.vjp(&x, &cotangent).unwrap();
+    let add_count = op_count(&dx, StdTensorOp::Add);
+    assert!(
+        (1..=3).contains(&add_count),
+        "cotangent accumulation should stay linear for four x uses, got {add_count} Add ops"
+    );
+    assert_eq!(eval_f64(&dx), vec![4.0, 4.0]);
+
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(&dx).unwrap();
+    let instruction_count = program.lowering_view().instructions().count();
+    assert!(
+        instruction_count <= 3,
+        "compiled accumulation graph should remain bounded, got {instruction_count} instructions"
+    );
+}

--- a/crates/tenferro-internal-ops/src/ad/indexing.rs
+++ b/crates/tenferro-internal-ops/src/ad/indexing.rs
@@ -34,7 +34,7 @@ use tenferro_tensor::{GatherConfig, ScatterConfig};
 use tidu::ADRuleResult;
 
 use crate::ad::context::ShapeGuardContext;
-use crate::ad::zeros::build_zero_like;
+use crate::ad::zeros::{build_zero_like, SymbolicZero};
 use crate::ad::PrimitiveRuleBuilder;
 use crate::dim_expr::DimExpr;
 use crate::shape_extent::ShapeExtent;
@@ -161,14 +161,14 @@ pub fn linearize_dynamic_update_slice(
         Some(tangent) => tangent,
         None => {
             let meta = ctx.metadata_of(&operand)?;
-            build_zero_like(builder, meta.dtype, operand, meta.rank())
+            SymbolicZero::from_meta(operand, meta).instantiate(builder)
         }
     };
     let d_update = match tangent_in[1] {
         Some(tangent) => tangent,
         None => {
             let meta = ctx.metadata_of(&update)?;
-            build_zero_like(builder, meta.dtype, update, meta.rank())
+            SymbolicZero::from_meta(update, meta).instantiate(builder)
         }
     };
 
@@ -451,10 +451,8 @@ pub fn linearize_scatter(
         (None, Some(d_up)) => {
             let operand_key = ValueRef::External(primal_in[0].clone());
             let operand_meta = ctx.metadata_of(&operand_key)?;
-            let operand_rank = operand_meta.rank();
-            let operand_dtype = operand_meta.dtype;
             let zero_operand =
-                build_zero_like(builder, operand_dtype, operand_key.clone(), operand_rank);
+                SymbolicZero::from_meta(operand_key.clone(), operand_meta).instantiate(builder);
             let out = builder.add_operation(
                 StdTensorOp::Scatter(config.clone()),
                 vec![

--- a/crates/tenferro-internal-ops/src/ad/structural.rs
+++ b/crates/tenferro-internal-ops/src/ad/structural.rs
@@ -4,7 +4,7 @@ use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use crate::ad::context::{ShapeGuardContext, ShapeGuardError};
 use crate::ad::support::{is_differentiable_dtype, linear_transpose_input_active};
-use crate::ad::zeros::build_zero_like;
+use crate::ad::zeros::SymbolicZero;
 use crate::ad::PrimitiveRuleBuilder;
 use crate::dim_expr::DimExpr;
 use crate::shape_extent::ShapeExtent;
@@ -274,7 +274,7 @@ pub fn linearize_concatenate(
             None => {
                 let anchor = ValueRef::External(primal_in[input_index].clone());
                 let meta = ctx.metadata_of(&anchor)?;
-                let zero = build_zero_like(builder, meta.dtype, anchor, meta.rank());
+                let zero = SymbolicZero::from_meta(anchor, meta).instantiate(builder);
                 inputs.push(ValueRef::Local(zero));
                 active_mask.push(false);
             }

--- a/crates/tenferro-internal-ops/src/ad/tests/elementwise_tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/elementwise_tests.rs
@@ -4,9 +4,10 @@ use computegraph::graph::GraphBuilder;
 use computegraph::types::{OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::{CompareDir, DType};
 
-use crate::ad::context::ShapeGuardContext;
+use crate::ad::context::{ShapeGuardContext, TensorMeta};
 use crate::input_key::TensorInputKey;
 use crate::std_tensor_op::StdTensorOp;
+use crate::SymDim;
 
 fn tensor_input(id: u64) -> TensorInputKey {
     TensorInputKey::User { id }
@@ -75,6 +76,33 @@ fn zero_like_covers_scalar_and_broadcasted_dtype_paths() {
         }
     );
     assert_eq!(op.inputs[1], ValueRef::Local(anchor));
+}
+
+#[test]
+fn symbolic_zero_carries_aval_until_instantiated() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let anchor = builder.add_input(tensor_input(1));
+    let meta = TensorMeta::exact(DType::C64, vec![SymDim::from(2usize), SymDim::from(3usize)]);
+
+    let zero = super::super::zeros::SymbolicZero::from_meta(ValueRef::Local(anchor), &meta);
+    assert_eq!(zero.dtype(), DType::C64);
+    assert_eq!(zero.rank(), 2);
+    assert_eq!(zero.anchor(), &ValueRef::Local(anchor));
+    assert!(builder.build().operations().is_empty());
+
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let anchor = builder.add_input(tensor_input(2));
+    let zero = super::super::zeros::SymbolicZero::from_meta(ValueRef::Local(anchor), &meta);
+    let materialized = zero.instantiate(&mut builder);
+    let graph = builder.build();
+
+    let (op_id, _) = graph.values()[materialized]
+        .producer
+        .expect("ranked symbolic zero should materialize as broadcast");
+    assert!(matches!(
+        graph.operations()[op_id].operation,
+        StdTensorOp::BroadcastInDim { .. }
+    ));
 }
 
 #[test]

--- a/crates/tenferro-internal-ops/src/ad/zeros.rs
+++ b/crates/tenferro-internal-ops/src/ad/zeros.rs
@@ -2,8 +2,55 @@ use crate::ad::PrimitiveRuleBuilder;
 use computegraph::types::{LocalValueId, OperationRole, ValueRef};
 use tenferro_tensor::DType;
 
+use crate::ad::context::TensorMeta;
 use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct SymbolicZero {
+    dtype: DType,
+    anchor: ValueRef<StdTensorOp>,
+    anchor_rank: usize,
+}
+
+impl SymbolicZero {
+    pub(super) fn new(dtype: DType, anchor: ValueRef<StdTensorOp>, anchor_rank: usize) -> Self {
+        Self {
+            dtype,
+            anchor,
+            anchor_rank,
+        }
+    }
+
+    pub(super) fn from_meta(anchor: ValueRef<StdTensorOp>, meta: &TensorMeta) -> Self {
+        Self::new(meta.dtype, anchor, meta.rank())
+    }
+
+    #[cfg(test)]
+    pub(super) fn dtype(&self) -> DType {
+        self.dtype
+    }
+
+    #[cfg(test)]
+    pub(super) fn rank(&self) -> usize {
+        self.anchor_rank
+    }
+
+    #[cfg(test)]
+    pub(super) fn anchor(&self) -> &ValueRef<StdTensorOp> {
+        &self.anchor
+    }
+
+    pub(super) fn instantiate(&self, builder: &mut dyn PrimitiveRuleBuilder) -> LocalValueId {
+        build_scalar_like(
+            builder,
+            self.dtype,
+            zero_bytes(self.dtype),
+            self.anchor.clone(),
+            self.anchor_rank,
+        )
+    }
+}
 
 pub(super) fn build_zero_like(
     builder: &mut dyn PrimitiveRuleBuilder,
@@ -11,7 +58,7 @@ pub(super) fn build_zero_like(
     anchor: ValueRef<StdTensorOp>,
     anchor_rank: usize,
 ) -> LocalValueId {
-    build_scalar_like(builder, dtype, zero_bytes(dtype), anchor, anchor_rank)
+    SymbolicZero::new(dtype, anchor, anchor_rank).instantiate(builder)
 }
 
 pub(super) fn build_one_like(

--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -281,6 +281,21 @@ mod tests {
         (ctx, a, vec![w, v])
     }
 
+    fn eig_context() -> (
+        ShapeGuardContext,
+        ValueKey<StdTensorOp>,
+        Vec<ValueKey<StdTensorOp>>,
+    ) {
+        let mut ctx = ShapeGuardContext::default();
+        let a = input_key(114);
+        let w = input_key(115);
+        let v = input_key(116);
+        insert_typed_meta(&mut ctx, a.clone(), DType::F64, &[2, 2]);
+        insert_typed_meta(&mut ctx, w.clone(), DType::C64, &[2]);
+        insert_typed_meta(&mut ctx, v.clone(), DType::C64, &[2, 2]);
+        (ctx, a, vec![w, v])
+    }
+
     fn lu_context(
         shape: &[usize],
     ) -> (
@@ -453,6 +468,21 @@ mod tests {
                 svd_context(&[2, 2]),
                 vec![None, None, None],
             ),
+            (
+                LinalgOp::Eigh {
+                    eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                },
+                eigh_context(),
+                vec![None, None],
+            ),
+            (
+                LinalgOp::Eig {
+                    input_dtype: DType::F64,
+                },
+                eig_context(),
+                vec![None, None],
+            ),
+            (LinalgOp::Qr, qr_context(&[3, 2]), vec![None, None]),
         ];
 
         for (kind, (ctx, a, outputs), expected) in cases {
@@ -509,6 +539,120 @@ mod tests {
             builder.build().operations().len() <= 5,
             "singular-value-only SVD JVP should not emit the vector F-matrix chain"
         );
+    }
+
+    #[test]
+    fn eigh_linearize_prunes_inactive_eigenvalue_output() {
+        let (ctx, a, outputs) = eigh_context();
+        let mut ctx = with_active_values(ctx, [outputs[1].clone()]);
+        let mut builder = GraphBuilder::<StdTensorOp>::new();
+        let tangent = builder.add_input(TensorInputKey::User { id: 134 });
+        let op = LinalgExtensionOp::new(LinalgOp::Eigh {
+            eps: DEFAULT_DECOMPOSITION_AD_EPS,
+        });
+
+        let result = LinalgAdRule
+            .linearize(
+                &op,
+                &mut builder,
+                &[a],
+                &outputs,
+                &[Some(tangent)],
+                &mut ctx,
+            )
+            .unwrap();
+
+        assert_eq!(
+            result.iter().map(Option::is_some).collect::<Vec<_>>(),
+            vec![false, true]
+        );
+    }
+
+    #[test]
+    fn eig_linearize_prunes_unsupported_inactive_eigenvalue_output() {
+        let (ctx, a, outputs) = eig_context();
+        let mut ctx = with_active_values(ctx, [outputs[1].clone()]);
+        let mut builder = GraphBuilder::<StdTensorOp>::new();
+        let tangent = builder.add_input(TensorInputKey::User { id: 137 });
+        let op = LinalgExtensionOp::new(LinalgOp::Eig {
+            input_dtype: DType::F64,
+        });
+
+        let result = LinalgAdRule
+            .linearize(
+                &op,
+                &mut builder,
+                &[a],
+                &outputs,
+                &[Some(tangent)],
+                &mut ctx,
+            )
+            .unwrap();
+
+        assert_eq!(result, vec![None, None]);
+        assert!(
+            builder.build().operations().is_empty(),
+            "eigenvectors-only Eig JVP is unsupported and should not emit eigenvalue tangent work"
+        );
+    }
+
+    #[test]
+    fn qr_linearize_prunes_inactive_factor_outputs() {
+        let op = LinalgExtensionOp::new(LinalgOp::Qr);
+        for (case, active_slot, expected_active) in [
+            ("q only", 0_usize, vec![true, false]),
+            ("r only", 1_usize, vec![false, true]),
+        ] {
+            let (ctx, a, outputs) = qr_context(&[3, 2]);
+            let mut ctx = with_active_values(ctx, [outputs[active_slot].clone()]);
+            let mut builder = GraphBuilder::<StdTensorOp>::new();
+            let tangent = builder.add_input(TensorInputKey::User { id: 135 });
+
+            let result = LinalgAdRule
+                .linearize(
+                    &op,
+                    &mut builder,
+                    &[a],
+                    &outputs,
+                    &[Some(tangent)],
+                    &mut ctx,
+                )
+                .unwrap();
+
+            assert_eq!(
+                result.iter().map(Option::is_some).collect::<Vec<_>>(),
+                expected_active,
+                "{case}"
+            );
+            let pruned_count = builder.build().operations().len();
+
+            let (full_ctx, full_a, full_outputs) = qr_context(&[3, 2]);
+            let mut full_ctx =
+                with_active_values(full_ctx, [full_outputs[0].clone(), full_outputs[1].clone()]);
+            let mut full_builder = GraphBuilder::<StdTensorOp>::new();
+            let full_tangent = full_builder.add_input(TensorInputKey::User { id: 136 });
+            let full_result = LinalgAdRule
+                .linearize(
+                    &op,
+                    &mut full_builder,
+                    &[full_a],
+                    &full_outputs,
+                    &[Some(full_tangent)],
+                    &mut full_ctx,
+                )
+                .unwrap();
+
+            assert_eq!(
+                full_result.iter().map(Option::is_some).collect::<Vec<_>>(),
+                vec![true, true],
+                "{case}"
+            );
+            let full_count = full_builder.build().operations().len();
+            assert!(
+                pruned_count < full_count,
+                "{case} should not emit both QR factor tangent branches: {pruned_count} >= {full_count}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tenferro-linalg/src/ad/rules/mod.rs
+++ b/crates/tenferro-linalg/src/ad/rules/mod.rs
@@ -314,6 +314,10 @@ pub(crate) fn linearize_eig(
         return Ok(vec![None, None]);
     };
 
+    if !ctx.is_value_active_in_linearize(&primal_out[0]) {
+        return Ok(vec![None, None]);
+    }
+
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in)? else {
         return Ok(vec![None, None]);
     };
@@ -667,6 +671,12 @@ pub(crate) fn linearize_eigh(
         return Ok(vec![None, None]);
     };
 
+    let w_active = ctx.is_value_active_in_linearize(&primal_out[0]);
+    let v_active = ctx.is_value_active_in_linearize(&primal_out[1]);
+    if !w_active && !v_active {
+        return Ok(vec![None, None]);
+    }
+
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in)? else {
         return Ok(vec![None, None]);
     };
@@ -693,11 +703,15 @@ pub(crate) fn linearize_eigh(
         vec![true, false],
         matrix_rank,
     );
-    let dw = extract_diag_linear(builder, projected);
-    let dw = convert_linear_to_dtype(builder, dw, dtype, w_dtype);
+    let dw = if w_active {
+        let dw = extract_diag_linear(builder, projected);
+        Some(convert_linear_to_dtype(builder, dw, dtype, w_dtype))
+    } else {
+        None
+    };
 
-    if !ctx.is_value_active_in_linearize(&primal_out[1]) {
-        return Ok(vec![Some(dw), None]);
+    if !v_active {
+        return Ok(vec![dw, None]);
     }
 
     let diag_w = embed_diag_fixed(builder, w.clone());
@@ -729,7 +743,7 @@ pub(crate) fn linearize_eigh(
         matrix_rank,
     );
 
-    Ok(vec![Some(dw), Some(dv)])
+    Ok(vec![dw, Some(dv)])
 }
 
 pub(crate) fn linearize_eigh_values(
@@ -854,6 +868,12 @@ pub(crate) fn linearize_qr(
         return Ok(vec![None, None]);
     };
 
+    let q_active = ctx.is_value_active_in_linearize(&primal_out[0]);
+    let r_active = ctx.is_value_active_in_linearize(&primal_out[1]);
+    if !q_active && !r_active {
+        return Ok(vec![None, None]);
+    }
+
     let Some(input_shape) = primal_matrix_input_shape(ctx, primal_in)? else {
         return Ok(vec![None, None]);
     };
@@ -928,31 +948,40 @@ pub(crate) fn linearize_qr(
         let half_sym_diag_mat = embed_diag_linear(builder, half_sym_diag);
         let dr_leading_hat = linear_add(builder, upper, half_sym_diag_mat);
 
-        let q_dr_leading_hat = matmul_linear(
-            builder,
-            q.clone(),
-            ValueRef::Local(dr_leading_hat),
-            vec![false, true],
-            matrix_rank,
-        );
-        let dq = linear_sub(builder, dx_rinv, q_dr_leading_hat);
-        let dr_leading = matmul_linear(
-            builder,
-            ValueRef::Local(dr_leading_hat),
-            ValueRef::Local(r_leading),
-            vec![true, false],
-            matrix_rank,
-        );
-        let mut dr = matmul_linear(
-            builder,
-            ValueRef::Local(dr_leading),
-            ValueRef::Local(leading_selector),
-            vec![true, false],
-            matrix_rank,
-        );
+        let dq = if q_active {
+            let q_dr_leading_hat = matmul_linear(
+                builder,
+                q.clone(),
+                ValueRef::Local(dr_leading_hat),
+                vec![false, true],
+                matrix_rank,
+            );
+            Some(linear_sub(builder, dx_rinv, q_dr_leading_hat))
+        } else {
+            None
+        };
+
+        let mut dr = if r_active {
+            let dr_leading = matmul_linear(
+                builder,
+                ValueRef::Local(dr_leading_hat),
+                ValueRef::Local(r_leading),
+                vec![true, false],
+                matrix_rank,
+            );
+            Some(matmul_linear(
+                builder,
+                ValueRef::Local(dr_leading),
+                ValueRef::Local(leading_selector),
+                vec![true, false],
+                matrix_rank,
+            ))
+        } else {
+            None
+        };
 
         let trailing_cols = n_size - m_size;
-        if trailing_cols > 0 {
+        if r_active && trailing_cols > 0 {
             let trailing_selector = trailing_column_selector_fixed(
                 builder,
                 m_size,
@@ -999,10 +1028,12 @@ pub(crate) fn linearize_qr(
                 vec![true, false],
                 matrix_rank,
             );
-            dr = linear_add(builder, dr, dr_trailing_full);
+            if let Some(current_dr) = dr {
+                dr = Some(linear_add(builder, current_dr, dr_trailing_full));
+            }
         }
 
-        return Ok(vec![Some(dq), Some(dr)]);
+        return Ok(vec![dq, dr]);
     }
 
     let r_h = adjoint_matrix_fixed(builder, r.clone(), matrix_rank, dtype);
@@ -1042,21 +1073,29 @@ pub(crate) fn linearize_qr(
     let half_sym_diag_mat = embed_diag_linear(builder, half_sym_diag);
     let dr_hat = linear_add(builder, upper, half_sym_diag_mat);
 
-    let q_dr_hat = matmul_linear(
-        builder,
-        q.clone(),
-        ValueRef::Local(dr_hat),
-        vec![false, true],
-        matrix_rank,
-    );
-    let dq = linear_sub(builder, dx_rinv, q_dr_hat);
-    let dr = matmul_linear(
-        builder,
-        ValueRef::Local(dr_hat),
-        r,
-        vec![true, false],
-        matrix_rank,
-    );
+    let dq = if q_active {
+        let q_dr_hat = matmul_linear(
+            builder,
+            q.clone(),
+            ValueRef::Local(dr_hat),
+            vec![false, true],
+            matrix_rank,
+        );
+        Some(linear_sub(builder, dx_rinv, q_dr_hat))
+    } else {
+        None
+    };
+    let dr = if r_active {
+        Some(matmul_linear(
+            builder,
+            ValueRef::Local(dr_hat),
+            r,
+            vec![true, false],
+            matrix_rank,
+        ))
+    } else {
+        None
+    };
 
-    Ok(vec![Some(dq), Some(dr)])
+    Ok(vec![dq, dr])
 }

--- a/docs/architecture/ad-pipeline.md
+++ b/docs/architecture/ad-pipeline.md
@@ -55,10 +55,11 @@ Typical pipelines:
 
 ```text
 JVP:
-  build -> resolve -> linearize -> materialize_merge -> compile -> eval
+  build -> resolve -> linearize -> optimize AD graph -> materialize_merge -> compile -> eval
 
 VJP:
-  build -> resolve -> linearize -> linear_transpose -> materialize_merge -> compile -> eval
+  build -> resolve -> linearize -> linear_transpose -> optimize AD graph
+        -> materialize_merge -> compile -> eval
 
 2nd directional derivative:
   build -> resolve -> linearize -> resolve -> linearize -> materialize_merge -> compile -> eval
@@ -70,7 +71,8 @@ n-th derivative:
 Current tenferro traced VJP follows the generic VJP pipeline first:
 
 ```text
-build -> resolve -> linearize active outputs -> linear_transpose -> materialize_merge -> compile -> eval
+build -> resolve -> linearize active outputs -> linear_transpose
+      -> optimize AD graph -> materialize_merge -> compile -> eval
 ```
 
 Direct primary-graph transpose is an escape hatch. It is used only when the
@@ -88,6 +90,35 @@ F-matrix chain before `materialize_merge` ever runs. `materialize_merge` and
 the compiler still perform their own deduplication and backend-oriented
 optimization, but AD rules should not rely on late flattening to remove large,
 known-inactive derivative subgraphs.
+
+After traced `linearize` for JVP, and after `linear_transpose` for VJP, tenferro
+runs a small backend-independent AD graph optimizer before materialization. It
+is deliberately metadata-only: it rewrites graph topology and static operation
+payloads, and it never inspects or retains tensor buffers. The current pass set
+is:
+
+- reachable-output DCE on the transform graph;
+- algebraic identity canonicalization for AD-heavy patterns such as
+  `neg(neg(x))`, `conj(conj(x))`, identity `convert`, identity `transpose`,
+  scalar `add(x, 0)`, and scalar `mul(x, 1)`;
+- preservation of explicit cotangent accumulation `Add` nodes emitted by
+  `linear_transpose`, with DCE removing only unreachable accumulation work.
+
+This AD optimizer is separate from the runtime compiler optimizer documented in
+`docs/spec/optimizer-passes.md`. Runtime passes still own layout simplification,
+dot transpose/conjugation folding, dot decomposition, and execution-IR DCE. The
+duplication of simple algebraic identities is intentional: AD graph size and
+compile cost should stay bounded even if a backend compiler is swapped out or a
+runtime pass is disabled.
+
+Symbolic zero flow still uses `None` in tidu transform APIs to mean "no tangent
+or cotangent value is present". When a tenferro rule must instantiate such a
+zero, it carries the abstract value at the instantiation boundary as a
+`SymbolicZero`: dtype, rank, and an anchor value whose shape supplies broadcast
+metadata. Instantiation emits a scalar dtype-aware zero plus a metadata-only
+broadcast when the rank is nonzero. This keeps zero propagation symbolic until a
+primitive such as `Concatenate`, `DynamicUpdateSlice`, or `Scatter` needs a real
+zero input to express the correct linearized operation.
 
 Current tenferro eager AD uses the same primitive rule set through a different
 interpreter:
@@ -114,15 +145,30 @@ slots, so their derivative computations can be traced by later eager
 transforms.
 
 Traced AD transform outputs are not cached in a new persistent AD graph cache.
-The caller-owned traced result keeps the transformed graph and any required
-extra roots alive, while compile-time and runtime caches remain owned by the
-existing compiler, executor, and extension runtime contexts. Eager runtimes do
-own a bounded Tier-1 AD transform cache for `RecordedGraph` linearization,
-keyed by recorded graph structural fingerprint plus requested output slots.
-That cache is a same-tape per-node memoization layer; a future whole-program AD
-optimizer cache would need keys that include the resolved output keys, `wrt`
-inputs, extension rule set identity, shape/dtype guard inputs, and optimizer
-configuration version. Such keys must not live inside semantic op payloads.
+The AD graph optimizer is currently stateless and uses only per-invocation local
+maps for rewrite facts and reachability. The caller-owned traced result keeps
+the transformed graph and any required extra roots alive, while compile-time and
+runtime caches remain owned by the existing compiler, executor, and extension
+runtime contexts.
+
+Eager runtimes own a bounded Tier-1 AD transform cache for `RecordedGraph`
+linearization, keyed by recorded graph structural fingerprint plus requested
+output slots. That cache is a same-tape per-node memoization layer; it has one
+top-level owner (`EagerRuntime`), is cleared by `EagerRuntime::clear_caches()`,
+and reports retained-entry and retained-byte estimates through
+`EagerRuntime::cache_stats()`.
+
+No partial-result AD optimizer cache exists today. If traced or eager AD adds
+one, it must stay under a single long-lived top-level owner for that execution
+surface rather than under individual passes. Candidate entry kinds are local
+rewrite summaries, subgraph DCE summaries, multi-output pruning decisions,
+symbolic-zero instantiation summaries, residual-use summaries, and
+transpose/accumulation normalization summaries. Keys must be structural and
+metadata-only: resolved output keys, `wrt` inputs, active/usage masks, extension
+rule-set identity or fingerprint, symbolic shape/dtype metadata required for
+legality, and AD optimizer configuration version. Entries must not retain tensor
+buffers and must be bounded with explicit clear/configure/stats APIs. Per-pass
+memo tables remain ephemeral per optimizer invocation.
 
 Four crates, strictly layered:
 

--- a/docs/spec/ad-contract.md
+++ b/docs/spec/ad-contract.md
@@ -155,11 +155,30 @@ rule set. Rules must not read hidden runtime state or environment state to
 decide graph structure. That purity lets runtime owners safely memoize
 recorded-graph linearization through tidu's eager executor hook.
 
+Primitive-local `jvp_rule` / linearization is the required derivative contract.
+`transpose_rule` transposes already-linear graph flow. High-level direct primal
+VJP or primary-transpose rules are optional escape hatches for cases where the
+generic `linearize -> linear_transpose -> optimize` path is incomplete or too
+slow; they are not the default obligation for making a primitive
+reverse-differentiable.
+
+Symbolic zero propagation should remain symbolic until a rule must pass a real
+zero value to another primitive. At that forced-instantiation boundary, tenferro
+rules carry dtype, rank, and an anchor value as a `SymbolicZero` and instantiate
+it as a dtype-aware scalar zero plus shape-restoring broadcast when needed. Do
+not synthesize zeros through analytic operations or tensor buffers.
+
 tenferro's eager runtime owns a bounded Tier-1 AD transform cache keyed by the
 recorded graph structural fingerprint and requested output slots. This cache
 reuses linearization for repeated transforms on the same eager tape node. It is
 not a whole-program backward cache and it does not generalize across
 structurally similar but distinct tapes.
+
+The traced AD graph optimizer is currently stateless and has no persistent
+partial-result cache. Future partial AD optimizer caching must stay under one
+explicit long-lived owner for the relevant execution surface, expose bounded
+capacity/clear/stats controls, use structure and metadata keys, and never retain
+tensor buffers. Pass-local memo tables are per-invocation scratch state.
 
 ## Complex AD convention
 

--- a/docs/spec/optimizer-passes.md
+++ b/docs/spec/optimizer-passes.md
@@ -11,6 +11,13 @@
 This document specifies the optimization passes that run while lowering
 computegraph `CompiledProgram` values into tenferro's execution IR.
 
+This is the runtime compiler optimizer, not the AD graph optimizer. Traced AD
+also runs a smaller materialize-pre optimizer on graphs produced by
+`linearize`/`linear_transpose`; see `docs/architecture/ad-pipeline.md` for that
+pipeline. The AD optimizer owns backend-independent derivative graph cleanup
+such as transform-graph DCE and local algebraic identities. The runtime
+compiler still owns execution-IR layout, dot, backend, and last-use passes.
+
 The current compiler entry point is:
 
 - `compile_std_to_exec()`

--- a/docs/worklogs/2026-07-04-issue-1256-ad-vjp-default.md
+++ b/docs/worklogs/2026-07-04-issue-1256-ad-vjp-default.md
@@ -19,6 +19,14 @@ inactive, and all three rules return no tangent graph when all outputs are
 inactive. `Qr` now returns only the requested factor tangent and avoids the
 final inactive branch emission.
 
+The final slice added a traced AD transform optimizer, aval-carrying symbolic
+zero instantiation, and regression coverage for zero propagation,
+canonicalization, multi-output pruning, and cotangent accumulation. The
+optimizer runs before materialization on traced JVP outputs and traced generic
+VJP transpose outputs. It does reachable-output DCE plus local algebraic
+canonicalization for AD-heavy identity patterns, leaving backend/layout
+rewrites to the runtime compiler.
+
 ## Context Read
 
 - Issue #1256 and its acceptance criteria around VJP generation, active output
@@ -33,6 +41,10 @@ final inactive branch emission.
   primary transpose fallback in `traced/primal_transpose.rs`.
 - Existing linalg AD rules in `crates/tenferro-linalg/src/ad/rules/mod.rs`,
   including the prior `Eigh` active-output pruning pattern.
+- `crates/tenferro-ad/src/traced/optimizer.rs` for the materialize-pre traced
+  AD graph optimizer added in this work.
+- `crates/tenferro-internal-ops/src/ad/zeros.rs` for symbolic zero
+  instantiation helpers.
 
 ## Decisions
 
@@ -47,13 +59,22 @@ final inactive branch emission.
 - Use the existing `linearize_active_value_keys` analysis as the explicit
   used-output pruning pass for traced AD. Linalg multi-output rules now check
   `ctx.is_value_active_in_linearize` before emitting expensive tangent branches.
-- Keep the QR/Eigh/Eig follow-up at the rule-emission level rather than adding a
-  new whole-graph optimizer pass. The existing active-output metadata is enough
-  to avoid the known dead decomposition branches without changing the broader
-  AD transform contract.
-- Document cache ownership as unchanged: no persistent AD optimizer cache is
-  introduced here. Transformed graphs live with the returned traced tensor and
-  existing compiler/runtime/extension caches keep their current owners.
+- Keep QR/Eigh/Eig multi-output pruning at the rule-emission level. The
+  existing active-output metadata is enough to avoid the known dead
+  decomposition branches before any graph optimizer pass runs.
+- Add a small traced AD graph optimizer for backend-independent cleanup after
+  transform graph construction. It is intentionally stateless and
+  metadata-only: DCE, double-neg/conj cancellation, identity convert/transpose,
+  scalar add-zero, and scalar mul-one. Runtime compiler passes remain
+  responsible for layout, dot, backend, and execution-IR cleanup.
+- Carry zero abstract values at forced-instantiation boundaries with
+  `SymbolicZero { dtype, rank, anchor }`. The tidu API still uses `None` for
+  absent tangent/cotangent flow; tenferro instantiates zeros only when a
+  primitive needs an actual zero input.
+- Do not add a persistent traced AD optimizer cache. The optimizer has no
+  current partial-result cache, uses only per-invocation scratch maps, and is
+  covered by existing cache-owner documentation. The eager Tier-1 AD transform
+  cache remains owned by `EagerRuntime`.
 
 ## Verification
 
@@ -65,6 +86,12 @@ final inactive branch emission.
   `cargo test -p tenferro-linalg --features autodiff "linearize_prunes" -- --nocapture`
   `cargo test -p tenferro-linalg --features autodiff eig_linearize_prunes_unsupported_inactive_eigenvalue_output -- --nocapture`
   `cargo test -p tenferro-linalg --features autodiff one_input_linalg_jvps_prune_when_all_outputs_are_inactive -- --nocapture`
+- AD graph optimizer RED/GREEN tests:
+  `cargo test -p tenferro-ad optimizer_canonicalizes_ad_identity_chains -- --nocapture`
+  `cargo test -p tenferro-ad --test ad_optimizer -- --nocapture`
+- Symbolic zero RED/GREEN tests:
+  `cargo test -p tenferro-internal-ops symbolic_zero_carries_aval_until_instantiated -- --nocapture`
+  `cargo test -p tenferro-internal-ops ad::tests:: -- --nocapture`
 - Primary-transpose fallback coverage after generic VJP became the default:
   `cargo test -p tenferro-ad --test extension_op traced_vjp_ -- --nocapture`
 - Full touched-crate and linalg AD checks:
@@ -84,9 +111,13 @@ final inactive branch emission.
 
 ## Residual Risks
 
-- This is an initial #1256 slice. It makes generic VJP the default and prunes
-  high-impact decomposition linearizers, but it does not add a broad AD
-  algebraic canonicalizer, aval-carrying symbolic zero type, or persistent AD
-  graph optimizer cache.
+- The traced AD graph optimizer is intentionally conservative. It folds only
+  identities that do not need shape reasoning beyond scalar constant facts and
+  local unary provenance. Broader algebraic rewrites should be added with
+  explicit metadata legality checks.
 - The primary transpose fallback remains necessary for extension rules whose
   generic linearized path is incomplete.
+- No persistent traced partial-result AD optimizer cache is introduced because
+  the current pass is stateless and linear in the reachable transform graph.
+  Future cache work must stay under one explicit owner and use structure and
+  metadata keys only.

--- a/docs/worklogs/2026-07-04-issue-1256-ad-vjp-default.md
+++ b/docs/worklogs/2026-07-04-issue-1256-ad-vjp-default.md
@@ -12,6 +12,13 @@ decomposition linearizers where the active-output metadata already existed but
 was not fully used: `Svd` now skips the vector tangent chain when only singular
 values are consumed, and `Lu` now emits only requested factor tangent branches.
 
+Follow-up work extended that active-output pruning to `Eigh`, `Eig`, and `Qr`.
+`Eigh` now skips the eigenvalue tangent when only eigenvectors are consumed,
+`Eig` now skips eigenvalue-only tangent work when the eigenvalue output is
+inactive, and all three rules return no tangent graph when all outputs are
+inactive. `Qr` now returns only the requested factor tangent and avoids the
+final inactive branch emission.
+
 ## Context Read
 
 - Issue #1256 and its acceptance criteria around VJP generation, active output
@@ -40,6 +47,10 @@ values are consumed, and `Lu` now emits only requested factor tangent branches.
 - Use the existing `linearize_active_value_keys` analysis as the explicit
   used-output pruning pass for traced AD. Linalg multi-output rules now check
   `ctx.is_value_active_in_linearize` before emitting expensive tangent branches.
+- Keep the QR/Eigh/Eig follow-up at the rule-emission level rather than adding a
+  new whole-graph optimizer pass. The existing active-output metadata is enough
+  to avoid the known dead decomposition branches without changing the broader
+  AD transform contract.
 - Document cache ownership as unchanged: no persistent AD optimizer cache is
   introduced here. Transformed graphs live with the returned traced tensor and
   existing compiler/runtime/extension caches keep their current owners.
@@ -50,6 +61,10 @@ values are consumed, and `Lu` now emits only requested factor tangent branches.
   `cargo test -p tenferro-ad --test extension_op traced_vjp_prefers_linearize_transpose_over_primary_transpose -- --nocapture`
 - Red/green linalg active-output pruning tests:
   `cargo test -p tenferro-linalg --features autodiff prune -- --nocapture`
+- QR/Eigh/Eig follow-up RED/GREEN tests:
+  `cargo test -p tenferro-linalg --features autodiff "linearize_prunes" -- --nocapture`
+  `cargo test -p tenferro-linalg --features autodiff eig_linearize_prunes_unsupported_inactive_eigenvalue_output -- --nocapture`
+  `cargo test -p tenferro-linalg --features autodiff one_input_linalg_jvps_prune_when_all_outputs_are_inactive -- --nocapture`
 - Primary-transpose fallback coverage after generic VJP became the default:
   `cargo test -p tenferro-ad --test extension_op traced_vjp_ -- --nocapture`
 - Full touched-crate and linalg AD checks:
@@ -70,7 +85,8 @@ values are consumed, and `Lu` now emits only requested factor tangent branches.
 ## Residual Risks
 
 - This is an initial #1256 slice. It makes generic VJP the default and prunes
-  two high-impact decomposition linearizers, but it does not add a broad AD
-  algebraic canonicalizer or a persistent AD graph optimizer cache.
+  high-impact decomposition linearizers, but it does not add a broad AD
+  algebraic canonicalizer, aval-carrying symbolic zero type, or persistent AD
+  graph optimizer cache.
 - The primary transpose fallback remains necessary for extension rules whose
   generic linearized path is incomplete.


### PR DESCRIPTION
## Summary

- Prune inactive linalg AD outputs for Eigh/Eig/QR so unused decomposition outputs do not survive AD graph emission.
- Add a traced AD graph optimizer after JVP linearize and VJP linear_transpose to canonicalize local identity chains and drop unreachable tangent/cotangent work.
- Carry dtype/rank/anchor metadata for symbolic AD zeros until they are instantiated.
- Add graph-size/compile boundedness regressions, update AD/optimizer specs, and refresh the issue #1256 work log.

## Step commits

1. `Prune inactive linalg AD outputs`
2. `Canonicalize AD transform graphs`
3. `Carry aval metadata for symbolic AD zeros`
4. `Document and test the AD optimizer pipeline`

## Verification

- `cargo fmt --all --check`
- `cargo test -p tenferro-ad`
- `cargo test -p tenferro-linalg --features autodiff`
- `cargo test -p tenferro-internal-ops`
- `cargo clippy -p tenferro-ad -p tenferro-internal-ops -p tenferro-linalg --features tenferro-linalg/autodiff --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`

## Review notes

- Work log: `docs/worklogs/2026-07-04-issue-1256-ad-vjp-default.md`
- This branch intentionally keeps one commit per implementation step; please use a non-squash merge if that history should be preserved.

Closes #1256
