### PR TITLE
Fix VJP residual graph retention

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "998dbac4ca24442433ab9a52a182040dda2d8eea", version = "0.1.0" }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "57a2e7ebe7738ca2f8b5c96f4c6ce4e467b20495", version = "0.1.0" }
 strided-view = "0.3.0"
 strided-traits = "0.3.0"
 strided-perm = { version = "0.3.0", features = ["parallel"] }

--- a/crates/tenferro-ad/src/eager/backward.rs
+++ b/crates/tenferro-ad/src/eager/backward.rs
@@ -62,6 +62,104 @@ impl<'a, B: TensorBackend + 'static> TenferroBackwardCallbacks<'a, B> {
             self.deferred_error = Some(err);
         }
     }
+
+    pub(super) fn execute_forward_graph(
+        &mut self,
+        graph: &Graph<StdTensorOp>,
+        initial_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
+    ) -> HashMap<ValueKey<StdTensorOp>, Arc<Tensor>> {
+        if self.deferred_error.is_some() {
+            return initial_data.clone();
+        }
+        let mut all_values = initial_data.clone();
+        let live_values = live_graph_values(graph);
+        let mut input_metadata = Vec::with_capacity(graph.inputs().len());
+        for &input_id in graph.inputs() {
+            let key = graph.values()[input_id].key.clone();
+            match eager_forward_input_metadata(&key, initial_data) {
+                Ok(meta) => input_metadata.push((key, meta)),
+                Err(err) => {
+                    self.record_error(err);
+                    return all_values;
+                }
+            }
+        }
+
+        for op_node in graph.operations() {
+            if linear_op_depends_on_tangents(&op_node.role) {
+                continue;
+            }
+            if !op_node
+                .outputs
+                .iter()
+                .any(|output_id| live_values.contains(output_id))
+            {
+                continue;
+            }
+
+            let mut resolved_values = Vec::with_capacity(op_node.inputs.len());
+            for input in &op_node.inputs {
+                let resolved = match input {
+                    ValueRef::Local(local_id) => {
+                        let key = &graph.values()[*local_id].key;
+                        eager_forward_value(&mut all_values, key, initial_data, self.backend)
+                    }
+                    ValueRef::External(key) => {
+                        eager_forward_value(&mut all_values, key, initial_data, self.backend)
+                    }
+                };
+                match resolved {
+                    Ok(value) => resolved_values.push(value),
+                    Err(err) => {
+                        self.record_error(err);
+                        return all_values;
+                    }
+                }
+            }
+            let resolved_inputs: Vec<&Tensor> =
+                resolved_values.iter().map(|value| value.as_ref()).collect();
+            let outputs_result =
+                if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
+                    exec_op_on_tensors_with_extension_executor(
+                        &op_node.operation,
+                        &resolved_inputs,
+                        self.backend,
+                        Some(extension_executor),
+                    )
+                } else {
+                    exec_op_on_tensors(&op_node.operation, &resolved_inputs, self.backend)
+                };
+            let outputs = match outputs_result {
+                Ok(outputs) => outputs,
+                Err(err) => {
+                    self.record_error(eager_ad_invalid_input(format!(
+                        "eager forward exec failed for {:?}: {err}",
+                        op_node.operation
+                    )));
+                    return all_values;
+                }
+            };
+
+            for (output_id, output) in op_node.outputs.iter().zip(outputs) {
+                let key = graph.values()[*output_id].key.clone();
+                all_values.insert(key, Arc::new(output));
+            }
+        }
+
+        let metadata_scope =
+            match register_scoped_live_graph_metadata(graph, &live_values, input_metadata) {
+                Ok(scope) => scope,
+                Err(err) => {
+                    self.record_error(eager_ad_invalid_input(format!(
+                        "eager replay metadata registration failed: {err}"
+                    )));
+                    return all_values;
+                }
+            };
+        push_metadata_scope(&mut self.metadata_scopes, Arc::new(metadata_scope));
+
+        all_values
+    }
 }
 
 pub(super) fn missing_tangent_base_key(
@@ -219,6 +317,109 @@ pub(super) fn prefill_missing_linear_zero_values<B: TensorBackend>(
     Ok(())
 }
 
+pub(super) fn prefill_linear_residual_values<B: TensorBackend + 'static>(
+    linear: &LinearizedGraph<StdTensorOp>,
+    external_data: &mut HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
+    backend: &mut B,
+    mut extension_executor: Option<&mut ExtensionExecutor<B>>,
+) -> ADRuleResult<()> {
+    let mut visited = HashSet::new();
+    prefill_residual_graph_values(
+        linear.residual_graph(),
+        external_data,
+        backend,
+        &mut extension_executor,
+        &mut visited,
+    )
+}
+
+fn prefill_residual_graph_values<B: TensorBackend + 'static>(
+    graph: &Graph<StdTensorOp>,
+    external_data: &mut HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
+    backend: &mut B,
+    extension_executor: &mut Option<&mut ExtensionExecutor<B>>,
+    visited: &mut HashSet<*const Graph<StdTensorOp>>,
+) -> ADRuleResult<()> {
+    let graph_ptr: *const Graph<StdTensorOp> = graph;
+    if !visited.insert(graph_ptr) {
+        return Ok(());
+    }
+
+    for parent in graph.parents() {
+        prefill_residual_graph_values(parent, external_data, backend, extension_executor, visited)?;
+    }
+
+    for op_node in graph.operations() {
+        if op_node
+            .outputs
+            .iter()
+            .all(|output_id| external_data.contains_key(&graph.values()[*output_id].key))
+        {
+            continue;
+        }
+
+        let mut resolved_values = Vec::with_capacity(op_node.inputs.len());
+        for input in &op_node.inputs {
+            let key = match input {
+                ValueRef::Local(local_id) => &graph.values()[*local_id].key,
+                ValueRef::External(key) => key,
+            };
+            resolved_values.push(eager_residual_value(external_data, key, backend)?);
+        }
+
+        let resolved_inputs: Vec<&Tensor> =
+            resolved_values.iter().map(|value| value.as_ref()).collect();
+        let outputs = match extension_executor.as_deref_mut() {
+            Some(executor) => exec_op_on_tensors_with_extension_executor(
+                &op_node.operation,
+                &resolved_inputs,
+                backend,
+                Some(executor),
+            ),
+            None => exec_op_on_tensors(&op_node.operation, &resolved_inputs, backend),
+        }
+        .map_err(|err| {
+            eager_ad_invalid_input(format!(
+                "eager residual exec failed for {:?}: {err}",
+                op_node.operation
+            ))
+        })?;
+
+        for (output_id, output) in op_node.outputs.iter().zip(outputs) {
+            let key = graph.values()[*output_id].key.clone();
+            external_data.insert(key, Arc::new(output));
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn eager_residual_value<B: TensorBackend>(
+    all_values: &mut HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
+    key: &ValueKey<StdTensorOp>,
+    backend: &mut B,
+) -> ADRuleResult<Arc<Tensor>> {
+    if let Some(value) = all_values.get(key) {
+        return Ok(Arc::clone(value));
+    }
+
+    let base_key = missing_tangent_base_key(key).ok_or_else(|| {
+        eager_ad_invalid_input(format!("missing concrete eager residual value for {key:?}"))
+    })?;
+    let base = all_values.get(&base_key).ok_or_else(|| {
+        eager_ad_invalid_input(format!(
+            "missing base eager residual value for {base_key:?}"
+        ))
+    })?;
+    let value = Arc::new(zero_like_tensor(base.as_ref(), backend).map_err(|err| {
+        eager_ad_invalid_input(format!(
+            "failed to create eager residual tangent zero: {err}"
+        ))
+    })?);
+    all_values.insert(key.clone(), Arc::clone(&value));
+    Ok(value)
+}
+
 fn checked_zero_element_count(shape: &[usize]) -> ADRuleResult<usize> {
     shape.iter().try_fold(1usize, |acc, &dim| {
         acc.checked_mul(dim).ok_or_else(|| {
@@ -253,98 +454,7 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
         graph: PrimitiveGraph<'_, StdTensorOp>,
         initial_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     ) -> HashMap<ValueKey<StdTensorOp>, Arc<Tensor>> {
-        if self.deferred_error.is_some() {
-            return initial_data.clone();
-        }
-        let graph = graph.as_graph();
-        let mut all_values = initial_data.clone();
-        let live_values = live_graph_values(graph);
-        let mut input_metadata = Vec::with_capacity(graph.inputs().len());
-        for &input_id in graph.inputs() {
-            let key = graph.values()[input_id].key.clone();
-            match eager_forward_input_metadata(&key, initial_data) {
-                Ok(meta) => input_metadata.push((key, meta)),
-                Err(err) => {
-                    self.record_error(err);
-                    return all_values;
-                }
-            }
-        }
-
-        for op_node in graph.operations() {
-            if linear_op_depends_on_tangents(&op_node.role) {
-                continue;
-            }
-            if !op_node
-                .outputs
-                .iter()
-                .any(|output_id| live_values.contains(output_id))
-            {
-                continue;
-            }
-
-            let mut resolved_values = Vec::with_capacity(op_node.inputs.len());
-            for input in &op_node.inputs {
-                let resolved = match input {
-                    ValueRef::Local(local_id) => {
-                        let key = &graph.values()[*local_id].key;
-                        eager_forward_value(&mut all_values, key, initial_data, self.backend)
-                    }
-                    ValueRef::External(key) => {
-                        eager_forward_value(&mut all_values, key, initial_data, self.backend)
-                    }
-                };
-                match resolved {
-                    Ok(value) => resolved_values.push(value),
-                    Err(err) => {
-                        self.record_error(err);
-                        return all_values;
-                    }
-                }
-            }
-            let resolved_inputs: Vec<&Tensor> =
-                resolved_values.iter().map(|value| value.as_ref()).collect();
-            let outputs_result =
-                if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
-                    exec_op_on_tensors_with_extension_executor(
-                        &op_node.operation,
-                        &resolved_inputs,
-                        self.backend,
-                        Some(extension_executor),
-                    )
-                } else {
-                    exec_op_on_tensors(&op_node.operation, &resolved_inputs, self.backend)
-                };
-            let outputs = match outputs_result {
-                Ok(outputs) => outputs,
-                Err(err) => {
-                    self.record_error(eager_ad_invalid_input(format!(
-                        "eager forward exec failed for {:?}: {err}",
-                        op_node.operation
-                    )));
-                    return all_values;
-                }
-            };
-
-            for (output_id, output) in op_node.outputs.iter().zip(outputs) {
-                let key = graph.values()[*output_id].key.clone();
-                all_values.insert(key, Arc::new(output));
-            }
-        }
-
-        let metadata_scope =
-            match register_scoped_live_graph_metadata(graph, &live_values, input_metadata) {
-                Ok(scope) => scope,
-                Err(err) => {
-                    self.record_error(eager_ad_invalid_input(format!(
-                        "eager replay metadata registration failed: {err}"
-                    )));
-                    return all_values;
-                }
-            };
-        push_metadata_scope(&mut self.metadata_scopes, Arc::new(metadata_scope));
-
-        all_values
+        self.execute_forward_graph(graph.as_graph(), initial_data)
     }
 
     fn run_transposed_linear(
@@ -358,6 +468,12 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
             return Err(err);
         }
         let mut external_data = external_data.clone();
+        prefill_linear_residual_values(
+            linear,
+            &mut external_data,
+            self.backend,
+            self.extension_executor.as_deref_mut(),
+        )?;
         ctx.refresh_global_metadata();
         prefill_missing_linear_zero_values(linear, &mut external_data, ctx, self.backend)?;
 

--- a/crates/tenferro-ad/src/eager/functional.rs
+++ b/crates/tenferro-ad/src/eager/functional.rs
@@ -20,7 +20,7 @@ use crate::extension_runtime::ExtensionExecutor;
 
 use super::backward::{
     eager_forward_input_metadata, eager_forward_value, live_graph_values, missing_tangent_base_key,
-    prefill_missing_linear_zero_values,
+    prefill_linear_residual_values, prefill_missing_linear_zero_values,
 };
 use super::{
     eager_val_key, record_eager_outputs, tensor_ptr, zero_like_tensor, EagerRuntime, EagerTensor,
@@ -352,6 +352,12 @@ impl BackwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
             return Err(err);
         }
         let mut external_data = external_data.clone();
+        prefill_linear_residual_values(
+            linear,
+            &mut external_data,
+            self.backend,
+            self.extension_executor.as_deref_mut(),
+        )?;
         ctx.refresh_global_metadata();
         prefill_missing_linear_zero_values(linear, &mut external_data, ctx, self.backend)?;
         let external_tensors = self.external_tensors(&external_data)?;

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -27,8 +27,9 @@ use crate::eager_exec::exec_op_on_tensor_reads_with_extension_executor;
 use crate::metadata::{register_scoped_metadata_batch, tensor_meta_from_tensor};
 
 use super::backward::{
-    eager_forward_input_metadata, eager_forward_value, missing_tangent_base_key,
-    zero_from_exact_metadata, TenferroBackwardCallbacks,
+    eager_forward_input_metadata, eager_forward_value, eager_residual_value,
+    missing_tangent_base_key, prefill_linear_residual_values, zero_from_exact_metadata,
+    TenferroBackwardCallbacks,
 };
 use super::{
     eager_op_profile_enabled, eager_op_profile_per_call_us, maybe_print_eager_op_profile,
@@ -559,6 +560,138 @@ fn eager_backward_transpose_runs_without_extension_executor() {
 
     let grad = gradients[0].as_ref().expect("active gradient");
     assert_eq!(grad.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+}
+
+#[test]
+fn eager_backward_prefills_split_linear_residual_graph_values() {
+    let base_key = TensorInputKey::User { id: 124 };
+    let exponent_key = TensorInputKey::User { id: 125 };
+    let mut graph_builder = GraphBuilder::<StdTensorOp>::new();
+    let x = graph_builder.add_input(base_key.clone());
+    let exponent = graph_builder.add_input(exponent_key.clone());
+    let y = graph_builder.add_operation(
+        StdTensorOp::Pow,
+        vec![ValueRef::Local(x), ValueRef::Local(exponent)],
+        OperationRole::Primary,
+    )[0];
+    graph_builder.set_outputs(vec![y]);
+    let graph = Arc::new(graph_builder.build());
+    let output_key = graph.values()[y].key.clone();
+    let x_tensor = Arc::new(Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap());
+    let exponent_tensor =
+        Arc::new(Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 2.0]).unwrap());
+    let output_tensor = Arc::new(Tensor::from_vec_col_major(vec![2], vec![8.0_f64, 9.0]).unwrap());
+    let _primal_scope = register_scoped_metadata_batch(vec![
+        (
+            ValueKey::Input(base_key.clone()),
+            tensor_meta_from_tensor(x_tensor.as_ref()),
+        ),
+        (
+            ValueKey::Input(exponent_key.clone()),
+            tensor_meta_from_tensor(exponent_tensor.as_ref()),
+        ),
+        (
+            output_key.clone(),
+            tensor_meta_from_tensor(output_tensor.as_ref()),
+        ),
+    ])
+    .unwrap();
+
+    let view = resolve(vec![Arc::clone(&graph)]);
+    let mut ad_ctx = ShapeGuardContext::with_global_metadata();
+    let linear = linearize(
+        &view,
+        std::slice::from_ref(&output_key),
+        &[base_key.clone(), exponent_key.clone()],
+        0,
+        &mut ad_ctx,
+        &HashMap::new(),
+    )
+    .unwrap();
+    assert!(
+        !linear.residual_graph().operations().is_empty(),
+        "Pow linearization should emit fixed residual operations"
+    );
+
+    let mut backend = CpuBackend::new();
+    let mut external_data = HashMap::from([
+        (ValueKey::Input(base_key), x_tensor),
+        (ValueKey::Input(exponent_key), exponent_tensor),
+        (output_key, output_tensor),
+    ]);
+    let before_len = external_data.len();
+    prefill_linear_residual_values(&linear, &mut external_data, &mut backend, None).unwrap();
+
+    assert!(
+        external_data.len() > before_len,
+        "residual prefill should add fixed linearization intermediates"
+    );
+}
+
+#[test]
+fn eager_backward_forward_replay_runs_only_live_fixed_linear_ops() {
+    let input_key = TensorInputKey::User { id: 126 };
+    let external_key = ValueKey::Input(input_key.clone());
+    let mut graph_builder = GraphBuilder::<StdTensorOp>::new();
+    let x = graph_builder.add_input(input_key.clone());
+    graph_builder.add_operation(
+        StdTensorOp::Neg,
+        vec![ValueRef::Local(x)],
+        OperationRole::Linearized {
+            active_mask: vec![true],
+        },
+    );
+    graph_builder.add_operation(
+        StdTensorOp::Neg,
+        vec![ValueRef::Local(x)],
+        OperationRole::Primary,
+    );
+    let sum = graph_builder.add_operation(
+        StdTensorOp::Add,
+        vec![ValueRef::Local(x), ValueRef::External(external_key.clone())],
+        OperationRole::Linearized {
+            active_mask: vec![false, false],
+        },
+    )[0];
+    graph_builder.set_outputs(vec![sum]);
+    let graph = graph_builder.build();
+
+    let x_tensor = Arc::new(Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap());
+    let initial_data = HashMap::from([(external_key, x_tensor)]);
+    let mut backend = CpuBackend::new();
+    let mut callbacks = TenferroBackwardCallbacks::new(&mut backend, None, Vec::new());
+
+    let all_values = callbacks.execute_forward_graph(&graph, &initial_data);
+
+    let out_key = &graph.values()[sum].key;
+    let out = all_values
+        .get(out_key)
+        .expect("live fixed op output should be replayed");
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
+    assert!(
+        callbacks.take_error().is_none(),
+        "forward replay should not record errors"
+    );
+}
+
+#[test]
+fn eager_backward_residual_value_synthesizes_missing_tangent_zero() {
+    let user = TensorInputKey::User { id: 127 };
+    let base_key = ValueKey::Input(user.clone());
+    let tangent_key = ValueKey::Input(user.tangent_of(128));
+    let base = Arc::new(Tensor::from_vec_col_major(vec![2], vec![5.0_f64, 6.0]).unwrap());
+    let mut all_values = HashMap::from([(base_key, base)]);
+    let mut backend = CpuBackend::new();
+
+    let tangent = eager_residual_value(&mut all_values, &tangent_key, &mut backend).unwrap();
+
+    assert_eq!(tangent.as_slice::<f64>().unwrap(), &[0.0, 0.0]);
+    assert!(Arc::ptr_eq(
+        &tangent,
+        all_values
+            .get(&tangent_key)
+            .expect("synthesized tangent should be cached")
+    ));
 }
 
 #[test]

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use crate::ad_rule_error::ad_rule_error;
+use computegraph::graph::Graph;
 use computegraph::resolve::resolve;
 use computegraph::resolve::{ResolvedView, ValueDef};
 use computegraph::types::ValueKey;
@@ -53,8 +54,10 @@ fn error_shape_hint(tensor: &TracedTensor) -> Vec<usize> {
 fn shape_guard_context(
     extension_rules: Option<&ExtensionRuleSet>,
     active_values: Option<Arc<HashSet<ValueKey<StdTensorOp>>>>,
+    roots: &[Arc<Graph<StdTensorOp>>],
 ) -> ShapeGuardContext {
-    let ctx = ShapeGuardContext::with_global_metadata();
+    let mut ctx = ShapeGuardContext::with_global_metadata();
+    register_shape_sources(&mut ctx, roots);
     let ctx = match extension_rules {
         Some(rules) => ctx.with_extension_rules(rules.clone()),
         None => ctx,
@@ -62,6 +65,41 @@ fn shape_guard_context(
     match active_values {
         Some(keys) => ctx.with_linearize_active_values(keys),
         None => ctx,
+    }
+}
+
+fn register_shape_sources(ctx: &mut ShapeGuardContext, roots: &[Arc<Graph<StdTensorOp>>]) {
+    let mut seen = HashSet::new();
+    for graph in roots {
+        register_graph_shape_sources(ctx, graph, &mut seen);
+    }
+}
+
+fn register_graph_shape_sources(
+    ctx: &mut ShapeGuardContext,
+    graph: &Arc<Graph<StdTensorOp>>,
+    seen: &mut HashSet<*const Graph<StdTensorOp>>,
+) {
+    if !seen.insert(Arc::as_ptr(graph)) {
+        return;
+    }
+    for parent in graph.parents() {
+        register_graph_shape_sources(ctx, parent, seen);
+    }
+    for &input_id in graph.inputs() {
+        let key = graph.values()[input_id].key.clone();
+        let Ok(meta) = registered_meta(&key) else {
+            continue;
+        };
+        let Some(shape) = meta.bound_shape() else {
+            continue;
+        };
+        for tensor_id in shape
+            .iter()
+            .flat_map(|dim| dim.referenced_tensor_ids().into_iter())
+        {
+            ctx.insert_shape_source(tensor_id, key.clone());
+        }
     }
 }
 
@@ -507,7 +545,8 @@ fn jvp_optional_impl(
             if let Some(linear) = cache.get_traced_linearized(&key)? {
                 linear
             } else {
-                let mut ad_ctx = shape_guard_context(extension_rules, Some(active_values));
+                let mut ad_ctx =
+                    shape_guard_context(extension_rules, Some(active_values), &view.roots);
                 let linear = linearize(
                     &view,
                     std::slice::from_ref(&output_key),
@@ -523,7 +562,7 @@ fn jvp_optional_impl(
             }
         }
         _ => {
-            let mut ad_ctx = shape_guard_context(extension_rules, Some(active_values));
+            let mut ad_ctx = shape_guard_context(extension_rules, Some(active_values), &view.roots);
             let linear = linearize(
                 &view,
                 std::slice::from_ref(&output_key),
@@ -636,7 +675,7 @@ fn compute_linear_vjp_transform(
     active_values: Arc<HashSet<ValueKey<StdTensorOp>>>,
     wrt: &TracedTensor,
 ) -> Result<tidu::ADRuleResult<Option<ActiveLinearVjp>>> {
-    let mut linear_ad_ctx = shape_guard_context(extension_rules, Some(active_values));
+    let mut linear_ad_ctx = shape_guard_context(extension_rules, Some(active_values), &view.roots);
     let linear = match linearize(
         view,
         std::slice::from_ref(output_key),
@@ -665,15 +704,13 @@ fn compute_linear_vjp_transform(
         Ok(transposed) => OptimizedLinearGraph::from_tidu(transposed).into_cached(),
         Err(err) => return Ok(Err(err)),
     };
-    let linear_tangent_inputs = linear.tangent_inputs().to_vec();
-    let linear_graph = Arc::new(linear.into_graph());
+    let (_linear_graph, residual_graph) = linear.into_graphs();
+    let residual_metadata_scope =
+        register_scoped_graph_metadata(residual_graph.as_ref(), std::iter::empty())?;
+    drop(linear_metadata_scope);
     Ok(Ok(Some(ActiveLinearVjp {
-        transposed: Arc::new(CachedTracedVjpTransform::new(
-            linear_graph,
-            linear_tangent_inputs,
-            transposed,
-        )),
-        metadata_scope: linear_metadata_scope,
+        transposed: Arc::new(CachedTracedVjpTransform::new(residual_graph, transposed)),
+        metadata_scope: residual_metadata_scope,
     })))
 }
 
@@ -714,20 +751,11 @@ fn vjp_optional_impl(
     let linear_attempt = match (ad_transform_cache, cache_key) {
         (Some(cache), Some(key)) => {
             if let Some(cached) = cache.get_traced_vjp(&key)? {
-                let linear_seed_key = linear_input_key(
-                    cached.linear_graph().as_ref(),
-                    cached.linear_tangent_inputs()[0].1,
-                )?;
-                let linear_metadata_scope = register_scoped_graph_metadata(
-                    cached.linear_graph().as_ref(),
-                    vec![(
-                        ValueKey::Input(linear_seed_key),
-                        registered_meta(&wrt.graph().values()[wrt.val].key)?,
-                    )],
-                )?;
+                let residual_metadata_scope =
+                    register_scoped_graph_metadata(cached.residual_graph(), std::iter::empty())?;
                 Ok(Some(ActiveLinearVjp {
                     transposed: cached,
-                    metadata_scope: linear_metadata_scope,
+                    metadata_scope: residual_metadata_scope,
                 }))
             } else {
                 let computed = compute_linear_vjp_transform(
@@ -756,15 +784,14 @@ fn vjp_optional_impl(
         )?,
     };
 
-    let (transposed, linear_metadata_scope, linear_graph) = match linear_attempt {
+    let (transposed, linear_metadata_scope) = match linear_attempt {
         Ok(None) => return Ok(None),
         Ok(Some(active)) => (
             VjpTransposeGraph::Linear(active.transposed),
             Some(active.metadata_scope),
-            None,
         ),
         Err(linear_err) => {
-            let mut primal_ad_ctx = shape_guard_context(extension_rules, None);
+            let mut primal_ad_ctx = shape_guard_context(extension_rules, None, &view.roots);
             primal_ad_ctx.refresh_global_metadata();
             match try_primal_transpose(
                 &view,
@@ -781,7 +808,7 @@ fn vjp_optional_impl(
                         .and_then(|slot| *slot)
                         .is_some() =>
                 {
-                    (VjpTransposeGraph::Primal(transposed), None, None)
+                    (VjpTransposeGraph::Primal(transposed), None)
                 }
                 _ => return Err(ad_rule_error(transform, linear_err)),
             }
@@ -816,11 +843,8 @@ fn vjp_optional_impl(
     inputs_map.insert(cotangent_input_key.clone(), cotangent_data);
 
     let mut extra_roots = vec![Arc::clone(output.graph())];
-    if let Some(linear_graph) = linear_graph {
-        extra_roots.push(linear_graph);
-    }
     if let VjpTransposeGraph::Linear(cached) = &transposed {
-        extra_roots.push(Arc::clone(cached.linear_graph()));
+        extra_roots.push(Arc::clone(cached.residual_graph()));
     }
     extra_roots.extend(checkpoint_graphs);
     extra_roots.extend(tensor_extra_roots(output));

--- a/crates/tenferro-ad/src/traced/primal_transpose.rs
+++ b/crates/tenferro-ad/src/traced/primal_transpose.rs
@@ -9,7 +9,7 @@ use tenferro_ops::ad::transpose_rule;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
-use tidu::{ADKey, ADRuleError, ADRuleKind, ADRuleResult, PrimitiveValue};
+use tidu::{ADKey, ADRuleError, ADRuleKind, ADRuleResult, PrimitiveTransposeInput};
 
 /// Reverse-mode graph built from primary transpose rules on the forward graph.
 pub(super) struct PrimalTransposeGraph {
@@ -232,19 +232,10 @@ pub(super) fn try_primal_transpose(
             continue;
         }
 
-        let rule_inputs: Vec<PrimitiveValue<StdTensorOp>> = op_key
+        let rule_inputs: Vec<PrimitiveTransposeInput<StdTensorOp>> = op_key
             .inputs()
             .iter()
-            .map(|key| PrimitiveValue::External(key.clone()))
-            .collect();
-        let inputs: Vec<ValueRef<StdTensorOp>> = rule_inputs
-            .iter()
-            .map(|value| match value {
-                PrimitiveValue::External(key) => ValueRef::External(key.clone()),
-                PrimitiveValue::Local(_) => {
-                    unreachable!("primal transpose rule inputs are external refs")
-                }
-            })
+            .map(|key| PrimitiveTransposeInput::Residual(key.clone()))
             .collect();
 
         let active_mask = transpose_active_mask(
@@ -267,7 +258,7 @@ pub(super) fn try_primal_transpose(
             op_key.operation(),
             &mut builder,
             &cotangent_out,
-            &inputs,
+            &rule_inputs,
             &transpose_mode,
             ctx,
         );
@@ -299,9 +290,7 @@ pub(super) fn try_primal_transpose(
             let Some(cotangent_id) = maybe_cotangent else {
                 continue;
             };
-            let PrimitiveValue::External(input_key) = input else {
-                continue;
-            };
+            let input_key = input.key();
 
             match cotangent_env.get(input_key).copied() {
                 Some(existing_id) => {

--- a/crates/tenferro-ad/src/transform_cache.rs
+++ b/crates/tenferro-ad/src/transform_cache.rs
@@ -201,30 +201,23 @@ impl fmt::Debug for CachedOptimizedLinearGraph {
 
 #[derive(Clone)]
 pub(crate) struct CachedTracedVjpTransform {
-    linear_graph: Arc<Graph<StdTensorOp>>,
-    linear_tangent_inputs: Vec<(TensorInputKey, LocalValueId)>,
+    residual_graph: Arc<Graph<StdTensorOp>>,
     transposed: Arc<CachedOptimizedLinearGraph>,
 }
 
 impl CachedTracedVjpTransform {
     pub(crate) fn new(
-        linear_graph: Arc<Graph<StdTensorOp>>,
-        linear_tangent_inputs: Vec<(TensorInputKey, LocalValueId)>,
+        residual_graph: Arc<Graph<StdTensorOp>>,
         transposed: CachedOptimizedLinearGraph,
     ) -> Self {
         Self {
-            linear_graph,
-            linear_tangent_inputs,
+            residual_graph,
             transposed: Arc::new(transposed),
         }
     }
 
-    pub(crate) fn linear_graph(&self) -> &Arc<Graph<StdTensorOp>> {
-        &self.linear_graph
-    }
-
-    pub(crate) fn linear_tangent_inputs(&self) -> &[(TensorInputKey, LocalValueId)] {
-        &self.linear_tangent_inputs
+    pub(crate) fn residual_graph(&self) -> &Arc<Graph<StdTensorOp>> {
+        &self.residual_graph
     }
 
     pub(crate) fn transposed(&self) -> &CachedOptimizedLinearGraph {
@@ -235,14 +228,10 @@ impl CachedTracedVjpTransform {
 impl fmt::Debug for CachedTracedVjpTransform {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CachedTracedVjpTransform")
-            .field("linear_values_len", &self.linear_graph.values().len())
+            .field("residual_values_len", &self.residual_graph.values().len())
             .field(
-                "linear_operations_len",
-                &self.linear_graph.operations().len(),
-            )
-            .field(
-                "linear_tangent_inputs_len",
-                &self.linear_tangent_inputs.len(),
+                "residual_operations_len",
+                &self.residual_graph.operations().len(),
             )
             .field("transposed", &self.transposed)
             .finish()
@@ -621,8 +610,7 @@ fn ad_transform_cache_value_retained_bytes(entry: &AdTransformCacheEntry) -> usi
 
 fn cached_traced_vjp_retained_bytes(vjp: &CachedTracedVjpTransform) -> usize {
     size_of::<CachedTracedVjpTransform>()
-        + graph_retained_bytes(vjp.linear_graph.as_ref())
-        + vjp.linear_tangent_inputs.capacity() * size_of::<(TensorInputKey, LocalValueId)>()
+        + graph_retained_bytes(vjp.residual_graph.as_ref())
         + cached_optimized_linear_graph_retained_bytes(vjp.transposed.as_ref())
 }
 

--- a/crates/tenferro-ad/tests/ad.rs
+++ b/crates/tenferro-ad/tests/ad.rs
@@ -2,7 +2,7 @@ use tenferro_ad::TracedTensorAdExt;
 #[path = "ad/reductions_and_indexing.rs"]
 mod reductions_and_indexing;
 mod support;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use support::{run_many_traced_with, RunTraced};
 
@@ -140,8 +140,29 @@ fn register_graph_metadata_for_test(
 ) -> GlobalMetadataScope {
     let seeded: Vec<_> = seeded.into_iter().collect();
     let mut known: HashMap<_, _> = seeded.iter().cloned().collect();
-
     let mut registrations = seeded;
+    let mut visited = HashSet::new();
+
+    append_graph_metadata_for_test(graph, &mut known, &mut registrations, &mut visited);
+
+    register_scoped_global_metadata_batch(registrations).unwrap()
+}
+
+fn append_graph_metadata_for_test(
+    graph: &Graph<StdTensorOp>,
+    known: &mut HashMap<ValueKey<StdTensorOp>, TensorMeta>,
+    registrations: &mut Vec<(ValueKey<StdTensorOp>, TensorMeta)>,
+    visited: &mut HashSet<*const Graph<StdTensorOp>>,
+) {
+    let graph_ptr: *const Graph<StdTensorOp> = graph;
+    if !visited.insert(graph_ptr) {
+        return;
+    }
+
+    for parent in graph.parents() {
+        append_graph_metadata_for_test(parent, known, registrations, visited);
+    }
+
     for op_node in graph.operations() {
         let input_metas: Vec<_> = op_node
             .inputs
@@ -194,8 +215,6 @@ fn register_graph_metadata_for_test(
             registrations.push((key, meta));
         }
     }
-
-    register_scoped_global_metadata_batch(registrations).unwrap()
 }
 
 fn eval_tensor(traced: TracedTensor) -> Tensor {

--- a/crates/tenferro-ad/tests/extension_op.rs
+++ b/crates/tenferro-ad/tests/extension_op.rs
@@ -38,7 +38,7 @@ use tenferro_ops::{ShapeGuardContext, SymDim};
 use tenferro_runtime::extension::{apply, HostReferenceRuntime};
 use tenferro_runtime::{Error as RuntimeError, GraphExecutor, Tensor, TracedTensor};
 use tenferro_tensor::{DType, TensorBackend, TypedTensor};
-use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult, PrimitiveTransposeInput};
 
 // ----------------------------------------------------------------------
 // TestScaleBy2: single-input, single-output. y = x + x (= 2x).
@@ -157,7 +157,7 @@ impl ExtensionLinearTransposeRule for TestScaleBy2Rule {
         _op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        _inputs: &[ValueRef<StdTensorOp>],
+        _inputs: &[PrimitiveTransposeInput<StdTensorOp>],
         _active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -285,7 +285,7 @@ impl ExtensionLinearTransposeRule for TestSwapRule {
         _op: &dyn ExtensionOp,
         _builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        _inputs: &[ValueRef<StdTensorOp>],
+        _inputs: &[PrimitiveTransposeInput<StdTensorOp>],
         _active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -766,7 +766,7 @@ impl ExtensionLinearTransposeRule for TestProbeLinearRule {
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        inputs: &[ValueRef<StdTensorOp>],
+        inputs: &[PrimitiveTransposeInput<StdTensorOp>],
         _active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -781,10 +781,29 @@ impl ExtensionLinearTransposeRule for TestProbeLinearRule {
             StdTensorOp::Reshape {
                 to_shape: DimExpr::from_concrete(&op.probe_shape),
             },
-            vec![inputs[1].clone()],
+            vec![transpose_input_value("probe_linear", 1, &inputs[1])?],
             OperationRole::Primary,
         );
         Ok(vec![Some(ct), None])
+    }
+}
+
+fn transpose_input_value(
+    op: &'static str,
+    index: usize,
+    input: &PrimitiveTransposeInput<StdTensorOp>,
+) -> ADRuleResult<ValueRef<StdTensorOp>> {
+    match input {
+        PrimitiveTransposeInput::Residual(key) => Ok(ValueRef::External(key.clone())),
+        PrimitiveTransposeInput::Linear {
+            primal: Some(primal),
+            ..
+        } => Ok(ValueRef::External(primal.clone())),
+        PrimitiveTransposeInput::Linear { key, primal: None } => Err(ADRuleError::invalid_input(
+            op,
+            ADRuleKind::Transpose,
+            format!("input {index} is linear-only and cannot be used as a test value: {key:?}"),
+        )),
     }
 }
 
@@ -900,6 +919,31 @@ fn register_test_eager_runtime(runtime: &EagerRuntime, family_id: &'static str) 
         .expect("register test eager extension runtime");
 }
 
+fn compiled_program_contains_extension(output: &TracedTensor) -> bool {
+    let mut compiler = tenferro_runtime::GraphCompiler::new();
+    let program = compiler.compile(output).expect("compile traced tensor");
+    let contains_extension = program
+        .lowering_view()
+        .instructions()
+        .any(|instruction| instruction.op_name() == "Extension");
+    contains_extension
+}
+
+fn compiled_program_contains_extension_with_specs(
+    output: &TracedTensor,
+    specs: &[(&TracedTensor, DType, &[usize])],
+) -> bool {
+    let mut compiler = tenferro_runtime::GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(output, specs)
+        .expect("compile traced tensor with specs");
+    let contains_extension = program
+        .lowering_view()
+        .instructions()
+        .any(|instruction| instruction.op_name() == "Extension");
+    contains_extension
+}
+
 // ----------------------------------------------------------------------
 // Tests
 // ----------------------------------------------------------------------
@@ -931,6 +975,10 @@ fn scale_by_2_grad_against_reduce_sum() {
     let loss = scaled.reduce_sum(&[0]).unwrap();
 
     let g = scale_by_2_ad_context().grad(&loss, &x).expect("grad build");
+    assert!(
+        !compiled_program_contains_extension(&g),
+        "sum(scale_by_2(x)) grad should not retain the forward extension as a shape-only dependency"
+    );
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let grad_out = g.run_with(&mut engine).unwrap();
 

--- a/crates/tenferro-ad/tests/extension_op/api_and_registry.rs
+++ b/crates/tenferro-ad/tests/extension_op/api_and_registry.rs
@@ -197,6 +197,10 @@ fn scale_by_2_grad_through_symbolic_placeholder() {
     let g = scale_by_2_ad_context().grad(&loss, &x).expect("grad build");
     let bound =
         Tensor::from_vec_col_major(vec![5], vec![10.0_f64, 20.0, 30.0, 40.0, 50.0]).unwrap();
+    assert!(
+        !compiled_program_contains_extension_with_specs(&g, &[(&x, bound.dtype(), bound.shape())]),
+        "symbolic sum(scale_by_2(x)) grad should not retain the forward extension as a shape-only dependency"
+    );
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let grad_out = g

--- a/crates/tenferro-ad/tests/graph_executor.rs
+++ b/crates/tenferro-ad/tests/graph_executor.rs
@@ -1,8 +1,18 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use computegraph::graph::GraphBuilder;
 use tenferro_ad::TracedTensorAdExt;
 use tenferro_cpu::CpuBackend;
+use tenferro_ops::input_key::TensorInputKey;
+use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_runtime::error::Error;
 use tenferro_runtime::extension::{ExecInstruction, ExecOp, ExecProgram};
-use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+use tenferro_runtime::{
+    ad_support::{tensor_from_parts, TracedTensorParts},
+    DType, GraphCompiler, GraphExecutor, SymDim, Tensor, TensorRead, TracedTensor,
+};
+use tidu::ADKey;
 
 #[test]
 fn graph_executor_runs_compiled_single_output_program() {
@@ -239,4 +249,55 @@ fn graph_executor_synthesizes_deferred_zero_tangents_from_primal_binding() {
 
     assert_eq!(out.shape(), &[4]);
     assert_eq!(out.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0, 8.0]);
+}
+
+#[test]
+fn graph_executor_synthesizes_deferred_zero_tangents_from_borrowed_primal_binding() {
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
+    let loss = (&x * &x).unwrap().reduce_sum(&[0]).unwrap();
+    let grad = loss.grad(&x).unwrap();
+
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(&grad, &[(&x, DType::F64, &[4])])
+        .unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+
+    let bound = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let out = executor
+        .run_with_input_reads(&program, &[(&x, TensorRead::from_tensor(&bound))])
+        .unwrap();
+
+    assert_eq!(out.shape(), &[4]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0, 8.0]);
+}
+
+#[test]
+fn graph_compiler_rejects_unbound_tangent_even_when_primal_has_default() {
+    let primal_key = TensorInputKey::User { id: 1234 };
+    let tangent_key = primal_key.tangent_of(7);
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let tangent_id = builder.add_input(tangent_key);
+    builder.set_outputs(vec![tangent_id]);
+    let graph = Arc::new(builder.build());
+
+    let primal = Arc::new(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap());
+    let output = tensor_from_parts(TracedTensorParts {
+        rank: 1,
+        dtype: DType::F64,
+        graph,
+        val: tangent_id,
+        data: None,
+        shape_hint: Some(vec![SymDim::from(2usize)]),
+        inputs_map: Arc::new(HashMap::from([(primal_key, primal)])),
+        extra_roots: Vec::new(),
+        checkpoint_chain: None,
+        metadata_scopes: Vec::new(),
+    });
+
+    let err = GraphCompiler::new().compile(&output).unwrap_err();
+    assert!(
+        matches!(err, Error::UnboundPlaceholder { ref input_key } if input_key.contains("Tangent")),
+        "dangling tangent inputs must not be silently bound from primal defaults: {err:?}"
+    );
 }

--- a/crates/tenferro-einsum/src/extension.rs
+++ b/crates/tenferro-einsum/src/extension.rs
@@ -18,6 +18,8 @@ use tenferro_extension_macros::define_extension_runtime;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::ad::context::ShapeGuardContext;
 #[cfg(feature = "autodiff")]
+use tenferro_ops::ad::transpose_input::TransposeInputRef;
+#[cfg(feature = "autodiff")]
 use tenferro_ops::ad::PrimitiveRuleBuilder;
 #[cfg(feature = "autodiff")]
 use tenferro_ops::dim_expr::DimExpr;
@@ -38,7 +40,7 @@ use tenferro_tensor::{
     DType, Error as TensorError, RuntimeCacheControl, Tensor, TensorBackend, TensorRead,
 };
 #[cfg(feature = "autodiff")]
-use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult, PrimitiveTransposeInput};
 
 use crate::builder::build_einsum_graph;
 use crate::cache::{
@@ -418,11 +420,12 @@ impl ExtensionLinearTransposeRule for EinsumAdRule {
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        inputs: &[ValueRef<StdTensorOp>],
+        inputs: &[PrimitiveTransposeInput<StdTensorOp>],
         active_mask: &[bool],
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_ad_op(op, ADRuleKind::Transpose)?;
+        let inputs: Vec<_> = inputs.iter().map(TransposeInputRef::new).collect();
         let input_labels = &op.subscripts.inputs;
         let output_labels = &op.subscripts.output;
         let input_count = input_labels.len();
@@ -432,7 +435,10 @@ impl ExtensionLinearTransposeRule for EinsumAdRule {
         };
         let primal_input_shapes: Vec<Vec<SymDim>> = inputs
             .iter()
-            .map(|input| ctx.shape_of(input).map(|shape| shape.to_vec()))
+            .map(|input| {
+                let metadata = input.metadata_value();
+                ctx.shape_of(&metadata).map(|shape| shape.to_vec())
+            })
             .collect::<Result<_, _>>()?;
         let cotangent_shape = op.output_shape_hint.clone().ok_or_else(|| {
             ADRuleError::unsupported(
@@ -472,11 +478,8 @@ impl ExtensionLinearTransposeRule for EinsumAdRule {
                 }
                 vjp_input_labels.push(input_labels[input_idx].clone());
                 vjp_input_shapes.push(primal_input_shapes[input_idx].clone());
-                vjp_inputs.push(conjugate_primal_if_complex(
-                    builder,
-                    inputs[input_idx].clone(),
-                    ctx,
-                )?);
+                let fixed_input = inputs[input_idx].fixed_value("einsum VJP", input_idx)?;
+                vjp_inputs.push(conjugate_primal_if_complex(builder, fixed_input, ctx)?);
             }
 
             let output_shape_hint = primal_input_shapes[active_idx].clone();
@@ -501,13 +504,15 @@ impl ExtensionLinearTransposeRule for EinsumAdRule {
             );
             let mut cotangent = out[0];
             if vjp_output_labels != input_labels[active_idx] {
+                let (shape, shape_sources) =
+                    inputs[active_idx].shape_operand(output_shape_hint.len(), 1, ctx)?;
                 let remapped = broadcast_einsum_vjp_to_input_shape(
                     builder,
                     cotangent,
                     &vjp_output_labels,
                     &input_labels[active_idx],
-                    inputs[active_idx].clone(),
-                    &output_shape_hint,
+                    shape,
+                    shape_sources,
                 )?;
                 cotangent = remapped;
             }
@@ -871,14 +876,9 @@ fn broadcast_einsum_vjp_to_input_shape(
     cotangent: LocalValueId,
     cotangent_labels: &[u32],
     input_labels: &[u32],
-    shape_source: ValueRef<StdTensorOp>,
-    input_shape: &[SymDim],
+    shape: Vec<DimExpr>,
+    shape_sources: Vec<ValueRef<StdTensorOp>>,
 ) -> ADRuleResult<LocalValueId> {
-    let shape: Vec<DimExpr> = input_shape
-        .iter()
-        .enumerate()
-        .map(|(axis, _)| DimExpr::InputDim { input_idx: 1, axis })
-        .collect();
     let dims = map_label_occurrences(cotangent_labels, input_labels).ok_or_else(|| {
         ADRuleError::unsupported(
             format!(
@@ -888,12 +888,12 @@ fn broadcast_einsum_vjp_to_input_shape(
             ADRuleKind::Transpose,
         )
     })?;
+    let source_count = shape_sources.len();
     let mut inputs = vec![ValueRef::Local(cotangent)];
-    let mut active_mask = vec![true];
-    if !shape.is_empty() {
-        inputs.push(shape_source);
-        active_mask.push(false);
-    }
+    inputs.extend(shape_sources);
+    let active_mask = std::iter::once(true)
+        .chain(std::iter::repeat_n(false, source_count))
+        .collect();
     let broadcast = builder.add_operation(
         StdTensorOp::BroadcastInDim { shape, dims },
         inputs,

--- a/crates/tenferro-einsum/src/extension/tests.rs
+++ b/crates/tenferro-einsum/src/extension/tests.rs
@@ -3,10 +3,22 @@ use std::hash::Hasher;
 
 use super::*;
 use crate::optimize::EinsumPlanSpec;
+#[cfg(feature = "autodiff")]
+use computegraph::graph::GraphBuilder;
+#[cfg(feature = "autodiff")]
+use computegraph::types::OperationRole;
 use tenferro_cpu::CpuBackend;
+#[cfg(feature = "autodiff")]
+use tenferro_ops::ext_op::ExtensionLinearTransposeRule;
 use tenferro_ops::ext_op::ExtensionOp;
+#[cfg(feature = "autodiff")]
+use tenferro_ops::input_key::TensorInputKey;
+#[cfg(feature = "autodiff")]
+use tenferro_ops::TensorMeta;
 use tenferro_runtime::ExtensionCacheStore;
 use tenferro_tensor::{TensorOwnedView, TensorRead};
+#[cfg(feature = "autodiff")]
+use tidu::PrimitiveTransposeInput;
 
 #[test]
 fn infer_output_meta_uses_output_labels_and_promotes_dtype() {
@@ -305,8 +317,17 @@ fn vjp_broadcast_remap_failure_returns_error() {
         0,
         &[0, 2],
         &[0, 1],
-        ValueRef::Local(1),
-        &[SymDim::from(2usize), SymDim::from(3usize)],
+        vec![
+            DimExpr::InputDim {
+                input_idx: 1,
+                axis: 0,
+            },
+            DimExpr::InputDim {
+                input_idx: 1,
+                axis: 1,
+            },
+        ],
+        vec![ValueRef::Local(1)],
     )
     .expect_err("unmappable VJP labels should be an AD rule error");
 
@@ -314,6 +335,120 @@ fn vjp_broadcast_remap_failure_returns_error() {
     assert!(message.contains("einsum VJP broadcast remap"));
     assert!(message.contains("cotangent"));
     assert!(builder.ops.is_empty());
+}
+
+#[cfg(feature = "autodiff")]
+fn ad_input_key(id: u64) -> TensorInputKey {
+    TensorInputKey::User { id }
+}
+
+#[cfg(feature = "autodiff")]
+fn ad_value_key(id: u64) -> ValueKey<StdTensorOp> {
+    ValueKey::Input(ad_input_key(id))
+}
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn linear_transpose_broadcasts_linear_only_active_input_from_metadata() {
+    let rule = EinsumAdRule;
+    let op = EinsumExtensionOp::with_output_shape_hint(
+        EinsumSubscripts {
+            inputs: vec![vec![b'i' as u32]],
+            output: vec![],
+        },
+        vec![],
+        EinsumPlanSpec::LeftToRight,
+    );
+    let active_key = ad_value_key(10);
+    let mut ctx = ShapeGuardContext::default();
+    ctx.insert_metadata(
+        active_key.clone(),
+        TensorMeta::exact(DType::F64, vec![SymDim::from(3usize)]),
+    );
+
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let cotangent = builder.add_input(ad_input_key(0));
+    let result = rule
+        .linear_transpose(
+            &op,
+            &mut builder,
+            &[Some(cotangent)],
+            &[PrimitiveTransposeInput::Linear {
+                key: active_key.clone(),
+                primal: None,
+            }],
+            &[true],
+            &mut ctx,
+        )
+        .unwrap();
+
+    assert_eq!(result.len(), 1);
+    assert!(result[0].is_some());
+    let active_ref = ValueRef::External(active_key);
+    let graph = builder.build();
+    assert!(graph
+        .operations()
+        .iter()
+        .all(|node| !node.inputs.iter().any(|input| input == &active_ref)));
+    assert!(graph.operations().iter().any(|node| {
+        matches!(
+            (&node.operation, &node.role, node.inputs.len()),
+            (
+                StdTensorOp::BroadcastInDim { shape, dims },
+                OperationRole::Linearized { active_mask },
+                1
+            ) if shape == &[DimExpr::Const(3)] && dims.is_empty() && active_mask == &[true]
+        )
+    }));
+}
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn linear_transpose_rejects_linear_only_coefficient_input() {
+    let rule = EinsumAdRule;
+    let op = EinsumExtensionOp::with_output_shape_hint(
+        EinsumSubscripts {
+            inputs: vec![vec![b'i' as u32], vec![b'i' as u32]],
+            output: vec![],
+        },
+        vec![],
+        EinsumPlanSpec::LeftToRight,
+    );
+    let active_key = ad_value_key(10);
+    let coefficient_key = ad_value_key(11);
+    let mut ctx = ShapeGuardContext::default();
+    for key in [&active_key, &coefficient_key] {
+        ctx.insert_metadata(
+            key.clone(),
+            TensorMeta::exact(DType::F64, vec![SymDim::from(3usize)]),
+        );
+    }
+
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let cotangent = builder.add_input(ad_input_key(0));
+    let err = rule
+        .linear_transpose(
+            &op,
+            &mut builder,
+            &[Some(cotangent)],
+            &[
+                PrimitiveTransposeInput::Linear {
+                    key: active_key,
+                    primal: None,
+                },
+                PrimitiveTransposeInput::Linear {
+                    key: coefficient_key,
+                    primal: None,
+                },
+            ],
+            &[true, false],
+            &mut ctx,
+        )
+        .unwrap_err();
+
+    let message = err.to_string();
+    assert!(message.contains("linear-only"), "{message}");
+    assert!(message.contains("einsum VJP"), "{message}");
 }
 
 #[cfg(feature = "autodiff")]

--- a/crates/tenferro-einsum/tests/public_surface_contract.rs
+++ b/crates/tenferro-einsum/tests/public_surface_contract.rs
@@ -27,7 +27,8 @@ fn einsum_vjp_broadcast_active_mask_matches_dynamic_inputs() {
         .expect("broadcast_einsum_vjp_to_input_shape source section should exist");
 
     assert!(
-        section.contains("let mut active_mask ="),
+        section.contains("let source_count = shape_sources.len();")
+            && section.contains("std::iter::repeat_n(false, source_count)"),
         "einsum VJP broadcast should build active_mask from the actual inputs"
     );
     assert!(

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -12,8 +12,8 @@ description = "FFT extension runtime and public concrete/traced FFT APIs for ten
 
 [features]
 default = ["cpu-faer"]
-cpu-faer = ["tenferro-cpu/cpu-faer"]
-cpu-blas = ["tenferro-cpu/cpu-blas"]
+cpu-faer = ["tenferro-ad?/cpu-faer", "tenferro-cpu/cpu-faer"]
+cpu-blas = ["tenferro-ad?/cpu-blas", "tenferro-cpu/cpu-blas"]
 blas-openblas = ["tenferro-ad?/blas-openblas", "tenferro-cpu/blas-openblas"]
 blas-accelerate = ["tenferro-ad?/blas-accelerate", "tenferro-cpu/blas-accelerate"]
 blas-mkl = ["tenferro-ad?/blas-mkl", "tenferro-cpu/blas-mkl"]

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -66,7 +66,7 @@ use tenferro_ad::extension::{
 };
 use tenferro_extension_macros::define_extension_runtime;
 #[cfg(feature = "autodiff")]
-use tenferro_ops::ad::PrimitiveRuleBuilder;
+use tenferro_ops::ad::{transpose_input::TransposeInputRef, PrimitiveRuleBuilder};
 #[cfg(feature = "autodiff")]
 use tenferro_ops::std_tensor_op::StdTensorOp;
 #[cfg(feature = "autodiff")]
@@ -890,11 +890,19 @@ impl ExtensionLinearTransposeRule for FftAdRule {
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        inputs: &[ValueRef<StdTensorOp>],
+        inputs: &[tidu::PrimitiveTransposeInput<StdTensorOp>],
         active_mask: &[bool],
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        transpose_fft_adjoint(op, builder, cotangent_out, inputs, Some(active_mask), ctx)
+        let inputs: Vec<_> = inputs.iter().map(TransposeInputRef::new).collect();
+        transpose_fft_adjoint_from_transpose_inputs(
+            op,
+            builder,
+            cotangent_out,
+            &inputs,
+            active_mask,
+            ctx,
+        )
     }
 }
 
@@ -925,6 +933,39 @@ fn transpose_fft_adjoint(
     active_mask: Option<&[bool]>,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    let Some((adjoint, fft_op)) = emit_c2c_adjoint(op, builder, cotangent_out, active_mask)? else {
+        return Ok(vec![None]);
+    };
+    let restored = restore_c2c_adjoint_input_length(builder, adjoint, inputs, fft_op, ctx)?;
+    Ok(vec![Some(restored)])
+}
+
+#[cfg(feature = "autodiff")]
+fn transpose_fft_adjoint_from_transpose_inputs(
+    op: &dyn ExtensionOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[TransposeInputRef<'_>],
+    active_mask: &[bool],
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    let Some((adjoint, fft_op)) = emit_c2c_adjoint(op, builder, cotangent_out, Some(active_mask))?
+    else {
+        return Ok(vec![None]);
+    };
+    let restored = restore_c2c_adjoint_input_length_from_transpose_input(
+        builder, adjoint, inputs, fft_op, ctx,
+    )?;
+    Ok(vec![Some(restored)])
+}
+
+#[cfg(feature = "autodiff")]
+fn emit_c2c_adjoint<'a>(
+    op: &'a dyn ExtensionOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    active_mask: Option<&[bool]>,
+) -> ADRuleResult<Option<(LocalValueId, &'a FftOp)>> {
     let fft_op = fft_payload(op, ADRuleKind::Transpose)?;
     if !matches!(fft_op.kind, FftKind::C2C { .. }) {
         return Err(ADRuleError::unsupported(
@@ -932,28 +973,24 @@ fn transpose_fft_adjoint(
             ADRuleKind::Transpose,
         ));
     }
-    if active_mask.is_some_and(|mask| !mask.get(0).copied().unwrap_or(false)) {
-        return Ok(vec![None]);
+    if active_mask.is_some_and(|mask| !mask.first().copied().unwrap_or(false)) {
+        return Ok(None);
     }
 
-    match cotangent_out[0] {
-        Some(ct) => {
-            let adjoint_op = fft_op.c2c_adjoint().ok_or_else(|| {
-                ADRuleError::unsupported(FFT_EXTENSION_FAMILY_ID, ADRuleKind::Transpose)
-            })?;
-            let outputs = builder.add_operation(
-                StdTensorOp::Extension(Arc::new(adjoint_op)),
-                vec![ValueRef::Local(ct)],
-                OperationRole::Linearized {
-                    active_mask: vec![true],
-                },
-            );
-            let restored =
-                restore_c2c_adjoint_input_length(builder, outputs[0], inputs, fft_op, ctx)?;
-            Ok(vec![Some(restored)])
-        }
-        None => Ok(vec![None]),
-    }
+    let Some(ct) = cotangent_out.first().copied().flatten() else {
+        return Ok(None);
+    };
+    let adjoint_op = fft_op
+        .c2c_adjoint()
+        .ok_or_else(|| ADRuleError::unsupported(FFT_EXTENSION_FAMILY_ID, ADRuleKind::Transpose))?;
+    let outputs = builder.add_operation(
+        StdTensorOp::Extension(Arc::new(adjoint_op)),
+        vec![ValueRef::Local(ct)],
+        OperationRole::Linearized {
+            active_mask: vec![true],
+        },
+    );
+    Ok(Some((outputs[0], fft_op)))
 }
 
 #[cfg(feature = "autodiff")]
@@ -1000,6 +1037,59 @@ fn restore_c2c_adjoint_input_length(
     let padded = builder.add_operation(
         StdTensorOp::PadToMatch { axis: fft_op.axis },
         vec![ValueRef::Local(truncated), input.clone()],
+        OperationRole::Linearized {
+            active_mask: vec![true, false],
+        },
+    )[0];
+    Ok(padded)
+}
+
+#[cfg(feature = "autodiff")]
+fn restore_c2c_adjoint_input_length_from_transpose_input(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    adjoint: LocalValueId,
+    inputs: &[TransposeInputRef<'_>],
+    fft_op: &FftOp,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<LocalValueId> {
+    let Some(transform_len) = fft_op.n else {
+        return Ok(adjoint);
+    };
+    let Some(input) = inputs.first() else {
+        return Err(ADRuleError::invalid_input(
+            FFT_EXTENSION_FAMILY_ID,
+            ADRuleKind::Transpose,
+            "FFT transpose rule expected one primal input",
+        ));
+    };
+    let metadata = input.metadata_value();
+    if ctx
+        .shape_of(&metadata)
+        .ok()
+        .and_then(|shape| shape.get(fft_op.axis).and_then(SymDim::constant_value))
+        == Some(transform_len)
+    {
+        return Ok(adjoint);
+    }
+
+    let shape_source = input.shape_source_value(FFT_EXTENSION_FAMILY_ID, 0)?;
+    let size = builder.add_operation(
+        StdTensorOp::ShapeOf { axis: fft_op.axis },
+        vec![shape_source.clone()],
+        OperationRole::Linearized {
+            active_mask: vec![false],
+        },
+    )[0];
+    let truncated = builder.add_operation(
+        StdTensorOp::DynamicTruncate { axis: fft_op.axis },
+        vec![ValueRef::Local(adjoint), ValueRef::Local(size)],
+        OperationRole::Linearized {
+            active_mask: vec![true, false],
+        },
+    )[0];
+    let padded = builder.add_operation(
+        StdTensorOp::PadToMatch { axis: fft_op.axis },
+        vec![ValueRef::Local(truncated), shape_source],
         OperationRole::Linearized {
             active_mask: vec![true, false],
         },
@@ -1898,5 +1988,56 @@ mod tests {
 
         assert_eq!(result, vec![None]);
         assert!(builder.build().operations().is_empty());
+    }
+
+    #[cfg(feature = "autodiff")]
+    #[test]
+    fn fft_transpose_rule_uses_metadata_for_linear_only_matching_length() {
+        let rule = FftAdRule;
+        let op = FftOp::new(
+            FftKind::C2C { forward: true },
+            0,
+            Some(4),
+            FftNorm::Backward,
+        );
+        let active_key = ValueKey::Input(tenferro_ops::input_key::TensorInputKey::User { id: 1 });
+        let mut ctx = ShapeGuardContext::default();
+        ctx.insert_metadata(
+            active_key.clone(),
+            tenferro_ops::TensorMeta::exact(DType::C64, vec![SymDim::from(4usize)]),
+        );
+
+        let mut builder = computegraph::graph::GraphBuilder::<StdTensorOp>::new();
+        let cotangent = builder.add_input(tenferro_ops::input_key::TensorInputKey::User { id: 0 });
+        let result = rule
+            .linear_transpose(
+                &op,
+                &mut builder,
+                &[Some(cotangent)],
+                &[tidu::PrimitiveTransposeInput::Linear {
+                    key: active_key.clone(),
+                    primal: None,
+                }],
+                &[true],
+                &mut ctx,
+            )
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert!(result[0].is_some());
+        let active_ref = ValueRef::External(active_key);
+        let graph = builder.build();
+        assert!(graph
+            .operations()
+            .iter()
+            .all(|node| !node.inputs.iter().any(|input| input == &active_ref)));
+        assert!(graph.operations().iter().all(|node| {
+            !matches!(
+                node.operation,
+                StdTensorOp::ShapeOf { .. }
+                    | StdTensorOp::DynamicTruncate { .. }
+                    | StdTensorOp::PadToMatch { .. }
+            )
+        }));
     }
 }

--- a/crates/tenferro-internal-ops/src/ad/context.rs
+++ b/crates/tenferro-internal-ops/src/ad/context.rs
@@ -269,6 +269,7 @@ pub struct ShapeGuard {
 pub struct ShapeGuardContext {
     guards: Vec<ShapeGuard>,
     metadata: MetadataMap,
+    shape_sources: HashMap<u64, ValueKey<StdTensorOp>>,
     use_global_registry: bool,
     local_keys: Option<Vec<ValueKey<StdTensorOp>>>,
     #[cfg(feature = "autodiff")]
@@ -311,6 +312,16 @@ impl ShapeGuardContext {
     /// also discard metadata inserted directly into this context.
     pub fn refresh_global_metadata(&mut self) {
         self.use_global_registry = true;
+    }
+
+    #[doc(hidden)]
+    pub fn insert_shape_source(&mut self, tensor_id: u64, key: ValueKey<StdTensorOp>) {
+        self.shape_sources.entry(tensor_id).or_insert(key);
+    }
+
+    #[doc(hidden)]
+    pub fn shape_source(&self, tensor_id: u64) -> Option<&ValueKey<StdTensorOp>> {
+        self.shape_sources.get(&tensor_id)
     }
 
     /// Use an explicit extension AD rule set for this context.

--- a/crates/tenferro-internal-ops/src/ad/contraction.rs
+++ b/crates/tenferro-internal-ops/src/ad/contraction.rs
@@ -7,9 +7,12 @@ use crate::ad::support::{
     conjugate_primal_if_complex, conjugate_primal_if_dtype_complex, convert_fixed_ref_to_dtype,
     convert_linear_to_dtype, dtype_of_or_real, project_linear_to_dtype, promote_dtype,
 };
+use crate::ad::transpose_input::{
+    linearized_inputs_with_inactive_shape_sources, metadata_value_refs,
+    shape_exprs_for_value_extent, TransposeInputRef,
+};
 use crate::ad::zeros::{build_one_like, build_zero_like};
 use crate::ad::PrimitiveRuleBuilder;
-use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
 
 pub fn linearize_dot_general(
@@ -130,16 +133,20 @@ pub fn linearize_reduce_prod(
         input.clone(),
         input_rank,
         &kept_dims,
+        ctx,
     );
     let input_dtype = ctx.dtype_of(&input)?;
     let coeff = reduce_prod_derivative_coeff(
         builder,
         input,
         ValueRef::Local(prod_broadcast),
-        input_rank,
-        &kept_dims,
-        axes,
+        ReductionShapeSpec {
+            input_rank,
+            kept_dims: &kept_dims,
+            axes,
+        },
         input_dtype,
+        ctx,
     );
     let scaled_tangent = builder.add_operation(
         StdTensorOp::Mul,
@@ -181,6 +188,7 @@ pub fn linearize_reduce_chooser(
         input.clone(),
         input_rank,
         &kept_dims,
+        ctx,
     );
     let indicators =
         reduction_location_indicators(builder, input.clone(), ValueRef::Local(answer_broadcast));
@@ -216,7 +224,7 @@ pub fn linearize_reduce_chooser(
 pub fn transpose_dot_general(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     config: &DotGeneralConfig,
     ctx: &mut ShapeGuardContext,
@@ -226,10 +234,11 @@ pub fn transpose_dot_general(
         None => return Ok(vec![None, None]),
     };
 
-    let lhs_rank = ctx.rank_of(&inputs[0])?;
-    let rhs_rank = ctx.rank_of(&inputs[1])?;
-    let lhs_dtype = dtype_of_or_real(ctx, &inputs[0]);
-    let rhs_dtype = dtype_of_or_real(ctx, &inputs[1]);
+    let metadata_inputs = metadata_value_refs(inputs);
+    let lhs_rank = ctx.rank_of(&metadata_inputs[0])?;
+    let rhs_rank = ctx.rank_of(&metadata_inputs[1])?;
+    let lhs_dtype = dtype_of_or_real(ctx, &metadata_inputs[0]);
+    let rhs_dtype = dtype_of_or_real(ctx, &metadata_inputs[1]);
     let output_dtype = promote_dtype(lhs_dtype, rhs_dtype);
 
     let active_mask = match mode {
@@ -259,7 +268,8 @@ pub fn transpose_dot_general(
     let mut result = vec![None, None];
 
     if active_mask[0] {
-        let rhs_conj = conjugate_primal_if_complex(builder, inputs[1].clone(), ctx)?;
+        let rhs = inputs[1].fixed_value("dot_general", 1)?;
+        let rhs_conj = conjugate_primal_if_complex(builder, rhs, ctx)?;
         let rhs_conj = convert_fixed_ref_to_dtype(builder, rhs_conj, rhs_dtype, output_dtype);
         let (transpose_config, new_lhs_rank, new_rhs_rank, perm) =
             transpose_plan_for_lhs(config, lhs_rank, rhs_rank, &lhs_free, &rhs_free)?;
@@ -283,7 +293,8 @@ pub fn transpose_dot_general(
     }
 
     if active_mask[1] {
-        let lhs_conj = conjugate_primal_if_complex(builder, inputs[0].clone(), ctx)?;
+        let lhs = inputs[0].fixed_value("dot_general", 0)?;
+        let lhs_conj = conjugate_primal_if_complex(builder, lhs, ctx)?;
         let lhs_conj = convert_fixed_ref_to_dtype(builder, lhs_conj, lhs_dtype, output_dtype);
         let (transpose_config, new_lhs_rank, new_rhs_rank, perm) =
             transpose_plan_for_rhs(config, lhs_rank, rhs_rank, &lhs_free, &rhs_free)?;
@@ -309,20 +320,21 @@ pub fn transpose_dot_general(
     Ok(result)
 }
 
-pub fn transpose_reduce_sum(
+pub fn transpose_reduce_sum_input(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     op: &StdTensorOp,
-    inputs: &[ValueRef<StdTensorOp>],
+    input: &TransposeInputRef<'_>,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::ReduceSum { axes } = op else {
-        unreachable!("transpose_reduce_sum expects ReduceSum");
+        unreachable!("transpose_reduce_sum_input expects ReduceSum");
     };
 
     match cotangent_out[0] {
         Some(ct) => {
-            let input_rank = ctx.rank_of(&inputs[0])?;
+            let input_key = ValueRef::External(input.key().clone());
+            let input_rank = ctx.rank_of(&input_key)?;
             let kept_dims = kept_dims(input_rank, axes);
             let cotangent = if kept_dims.is_empty() {
                 let scalar = builder.add_operation(
@@ -336,14 +348,9 @@ pub fn transpose_reduce_sum(
             } else {
                 ValueRef::Local(ct)
             };
-            let (shape, needs_shape_source) = runtime_shape_to_dim_expr(input_rank, 1);
-            let mut op_inputs = vec![cotangent];
-            let active_mask = if needs_shape_source {
-                op_inputs.push(inputs[0].clone());
-                vec![true, false]
-            } else {
-                vec![true]
-            };
+            let (shape, shape_sources) = input.shape_operand(input_rank, 1, ctx)?;
+            let (op_inputs, active_mask) =
+                linearized_inputs_with_inactive_shape_sources(cotangent, shape_sources);
             let out = builder.add_operation(
                 StdTensorOp::BroadcastInDim {
                     shape,
@@ -374,14 +381,10 @@ pub fn transpose_reduce_prod(
             let input_rank = ctx.rank_of(&inputs[0])?;
             let kept_dims = kept_dims(input_rank, axes);
             let cotangent = normalize_reduction_cotangent(builder, ct, &kept_dims);
-            let (shape, needs_shape_source) = runtime_shape_to_dim_expr(input_rank, 1);
-            let mut op_inputs = vec![cotangent];
-            let active_mask = if needs_shape_source {
-                op_inputs.push(inputs[0].clone());
-                vec![true, false]
-            } else {
-                vec![true]
-            };
+            let (shape, shape_sources) =
+                shape_exprs_for_value_extent(&inputs[0], input_rank, 1, ctx);
+            let (op_inputs, active_mask) =
+                linearized_inputs_with_inactive_shape_sources(cotangent, shape_sources);
             let cotangent = builder.add_operation(
                 StdTensorOp::BroadcastInDim {
                     shape,
@@ -399,16 +402,20 @@ pub fn transpose_reduce_prod(
                 inputs[0].clone(),
                 input_rank,
                 &kept_dims,
+                ctx,
             );
             let input_dtype = ctx.dtype_of(&inputs[0])?;
             let coeff = reduce_prod_derivative_coeff(
                 builder,
                 inputs[0].clone(),
                 ValueRef::Local(prod_broadcast),
-                input_rank,
-                &kept_dims,
-                axes,
+                ReductionShapeSpec {
+                    input_rank,
+                    kept_dims: &kept_dims,
+                    axes,
+                },
                 input_dtype,
+                ctx,
             );
             let coeff_conj =
                 conjugate_primal_if_dtype_complex(builder, ValueRef::Local(coeff), input_dtype);
@@ -442,14 +449,10 @@ pub fn transpose_reduce_chooser(
             let input_rank = ctx.rank_of(&inputs[0])?;
             let kept_dims = kept_dims(input_rank, axes);
             let cotangent = normalize_reduction_cotangent(builder, ct, &kept_dims);
-            let (shape, needs_shape_source) = runtime_shape_to_dim_expr(input_rank, 1);
-            let mut op_inputs = vec![cotangent];
-            let active_mask = if needs_shape_source {
-                op_inputs.push(inputs[0].clone());
-                vec![true, false]
-            } else {
-                vec![true]
-            };
+            let (shape, shape_sources) =
+                shape_exprs_for_value_extent(&inputs[0], input_rank, 1, ctx);
+            let (op_inputs, active_mask) =
+                linearized_inputs_with_inactive_shape_sources(cotangent, shape_sources);
             let cotangent = builder.add_operation(
                 StdTensorOp::BroadcastInDim {
                     shape,
@@ -467,6 +470,7 @@ pub fn transpose_reduce_chooser(
                 inputs[0].clone(),
                 input_rank,
                 &kept_dims,
+                ctx,
             );
             let indicators = reduction_location_indicators(
                 builder,
@@ -482,6 +486,7 @@ pub fn transpose_reduce_chooser(
                 inputs[0].clone(),
                 input_rank,
                 &kept_dims,
+                ctx,
             );
             let weights = builder.add_operation(
                 StdTensorOp::Div,
@@ -540,27 +545,6 @@ fn kept_dims(rank: usize, axes: &[usize]) -> Vec<usize> {
     (0..rank).filter(|dim| !axes.contains(dim)).collect()
 }
 
-/// Build a [`DimExpr`] shape that reads a value's runtime extents.
-///
-/// Each axis is resolved as a reference to `source_idx`'s axis so that the
-/// emitted op reads the *runtime* shape of the primal input. Exact metadata
-/// is intentionally not required: ops such as [`StdTensorOp::DynamicTruncate`]
-/// keep only an upper-bound static extent, and folding that bound to a
-/// constant would disagree with the runtime broadcast target.
-///
-/// Returns `(dim_exprs, needs_shape_source)`. When `rank` is zero the
-/// resulting `DimExpr` list is empty and no shape source is needed.
-fn runtime_shape_to_dim_expr(rank: usize, source_idx: usize) -> (Vec<DimExpr>, bool) {
-    let needs_shape_source = rank != 0;
-    let dim_exprs = (0..rank)
-        .map(|axis| DimExpr::InputDim {
-            input_idx: source_idx,
-            axis,
-        })
-        .collect();
-    (dim_exprs, needs_shape_source)
-}
-
 fn normalize_reduction_cotangent(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent: LocalValueId,
@@ -586,13 +570,12 @@ fn broadcast_reduction_output(
     shape_source: ValueRef<StdTensorOp>,
     input_rank: usize,
     kept_dims: &[usize],
+    ctx: &mut ShapeGuardContext,
 ) -> LocalValueId {
-    let (shape, needs_shape_source) = runtime_shape_to_dim_expr(input_rank, 1);
-    let inputs = if needs_shape_source {
-        vec![output, shape_source]
-    } else {
-        vec![output]
-    };
+    let (shape, shape_sources) = shape_exprs_for_value_extent(&shape_source, input_rank, 1, ctx);
+    let mut inputs = Vec::with_capacity(1 + shape_sources.len());
+    inputs.push(output);
+    inputs.extend(shape_sources);
     builder.add_operation(
         StdTensorOp::BroadcastInDim {
             shape,
@@ -603,17 +586,22 @@ fn broadcast_reduction_output(
     )[0]
 }
 
+struct ReductionShapeSpec<'a> {
+    input_rank: usize,
+    kept_dims: &'a [usize],
+    axes: &'a [usize],
+}
+
 fn reduce_prod_derivative_coeff(
     builder: &mut dyn PrimitiveRuleBuilder,
     input: ValueRef<StdTensorOp>,
     prod_broadcast: ValueRef<StdTensorOp>,
-    input_rank: usize,
-    kept_dims: &[usize],
-    axes: &[usize],
+    shape: ReductionShapeSpec<'_>,
     dtype: DType,
+    ctx: &mut ShapeGuardContext,
 ) -> LocalValueId {
-    let zero = build_zero_like(builder, dtype, input.clone(), input_rank);
-    let one = build_one_like(builder, dtype, input.clone(), input_rank);
+    let zero = build_zero_like(builder, dtype, input.clone(), shape.input_rank);
+    let one = build_one_like(builder, dtype, input.clone(), shape.input_rank);
     let zero_mask = builder.add_operation(
         StdTensorOp::Compare(CompareDir::Eq),
         vec![input.clone(), ValueRef::Local(zero)],
@@ -622,7 +610,7 @@ fn reduce_prod_derivative_coeff(
     let numeric_zero_mask = numeric_indicators(builder, zero_mask, dtype);
     let zero_count = builder.add_operation(
         StdTensorOp::ReduceSum {
-            axes: axes.to_vec(),
+            axes: shape.axes.to_vec(),
         },
         vec![ValueRef::Local(numeric_zero_mask)],
         OperationRole::Primary,
@@ -631,8 +619,9 @@ fn reduce_prod_derivative_coeff(
         builder,
         ValueRef::Local(zero_count),
         input.clone(),
-        input_rank,
-        kept_dims,
+        shape.input_rank,
+        shape.kept_dims,
+        ctx,
     );
     let safe_input = builder.add_operation(
         StdTensorOp::Select,
@@ -645,7 +634,7 @@ fn reduce_prod_derivative_coeff(
     )[0];
     let nonzero_prod = builder.add_operation(
         StdTensorOp::ReduceProd {
-            axes: axes.to_vec(),
+            axes: shape.axes.to_vec(),
         },
         vec![ValueRef::Local(safe_input)],
         OperationRole::Primary,
@@ -654,15 +643,16 @@ fn reduce_prod_derivative_coeff(
         builder,
         ValueRef::Local(nonzero_prod),
         input.clone(),
-        input_rank,
-        kept_dims,
+        shape.input_rank,
+        shape.kept_dims,
+        ctx,
     );
     let quotient = builder.add_operation(
         StdTensorOp::Div,
         vec![prod_broadcast, ValueRef::Local(safe_input)],
         OperationRole::Primary,
     )[0];
-    let zero_coeff = build_zero_like(builder, dtype, input.clone(), input_rank);
+    let zero_coeff = build_zero_like(builder, dtype, input.clone(), shape.input_rank);
     let single_zero_coeff = builder.add_operation(
         StdTensorOp::Select,
         vec![
@@ -672,7 +662,7 @@ fn reduce_prod_derivative_coeff(
         ],
         OperationRole::Primary,
     )[0];
-    let zero_count_zero = build_zero_like(builder, dtype, input.clone(), input_rank);
+    let zero_count_zero = build_zero_like(builder, dtype, input.clone(), shape.input_rank);
     let zero_count_is_zero = builder.add_operation(
         StdTensorOp::Compare(CompareDir::Eq),
         vec![
@@ -681,7 +671,7 @@ fn reduce_prod_derivative_coeff(
         ],
         OperationRole::Primary,
     )[0];
-    let zero_count_one = build_one_like(builder, dtype, input, input_rank);
+    let zero_count_one = build_one_like(builder, dtype, input, shape.input_rank);
     let zero_count_is_one = builder.add_operation(
         StdTensorOp::Compare(CompareDir::Eq),
         vec![
@@ -694,7 +684,7 @@ fn reduce_prod_derivative_coeff(
         builder,
         dtype,
         ValueRef::Local(single_zero_coeff),
-        input_rank,
+        shape.input_rank,
     );
     let zero_case_coeff = builder.add_operation(
         StdTensorOp::Select,

--- a/crates/tenferro-internal-ops/src/ad/diagonal.rs
+++ b/crates/tenferro-internal-ops/src/ad/diagonal.rs
@@ -1,10 +1,13 @@
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::support::linear_transpose_input_active;
+use crate::ad::transpose_input::TransposeInputRef;
 use crate::ad::PrimitiveRuleBuilder;
 use computegraph::types::{LocalValueId, OperationRole, ValueRef};
-use tidu::ADRuleResult;
+use tenferro_tensor::PadConfig;
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use crate::std_tensor_op::StdTensorOp;
+use crate::sym_dim::SymDim;
 
 pub fn linearize_extract_diag(
     builder: &mut dyn PrimitiveRuleBuilder,
@@ -53,11 +56,11 @@ pub fn linearize_embed_diag(
 pub fn transpose_extract_diag(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     axis_a: usize,
     axis_b: usize,
-    _ctx: &mut ShapeGuardContext,
+    ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     if !linear_transpose_input_active(mode, 0) {
         return Ok(vec![None]);
@@ -77,21 +80,9 @@ pub fn transpose_extract_diag(
                     active_mask: vec![true],
                 },
             );
-            let padded_axis_a = builder.add_operation(
-                StdTensorOp::PadToMatch { axis: axis_a },
-                vec![ValueRef::Local(out[0]), inputs[0].clone()],
-                OperationRole::Linearized {
-                    active_mask: vec![true, false],
-                },
-            );
-            let padded_axis_b = builder.add_operation(
-                StdTensorOp::PadToMatch { axis: axis_b },
-                vec![ValueRef::Local(padded_axis_a[0]), inputs[0].clone()],
-                OperationRole::Linearized {
-                    active_mask: vec![true, false],
-                },
-            );
-            Ok(vec![Some(padded_axis_b[0])])
+            let padded =
+                pad_embedded_diag_to_input(builder, out[0], &inputs[0], axis_a, axis_b, ctx)?;
+            Ok(vec![Some(padded)])
         }
         None => Ok(vec![None]),
     }
@@ -100,7 +91,7 @@ pub fn transpose_extract_diag(
 pub fn transpose_embed_diag(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     axis_a: usize,
     axis_b: usize,
@@ -125,7 +116,7 @@ pub fn transpose_embed_diag(
                 },
             );
             if axis_b < axis_a {
-                let rank = ctx.rank_of(&inputs[0])?;
+                let rank = ctx.rank_of(&inputs[0].metadata_value())?;
                 let mut perm: Vec<usize> = (0..rank).collect();
                 let diag_axis = perm.remove(axis_b);
                 perm.insert(axis_a, diag_axis);
@@ -142,4 +133,98 @@ pub fn transpose_embed_diag(
         }
         None => Ok(vec![None]),
     }
+}
+
+fn pad_embedded_diag_to_input(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    embedded: LocalValueId,
+    input: &TransposeInputRef<'_>,
+    axis_a: usize,
+    axis_b: usize,
+    ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<LocalValueId> {
+    let input_ref = input.metadata_value();
+    if let Some(input_shape) = ctx.shape_if_available(&input_ref) {
+        if let Some(padded) =
+            static_pad_embedded_diag_to_input(builder, embedded, &input_shape, axis_a, axis_b)?
+        {
+            return Ok(padded);
+        }
+    }
+
+    let shape_source = input.shape_source_value("ExtractDiag", 0)?;
+    let padded_axis_a = builder.add_operation(
+        StdTensorOp::PadToMatch { axis: axis_a },
+        vec![ValueRef::Local(embedded), shape_source.clone()],
+        OperationRole::Linearized {
+            active_mask: vec![true, false],
+        },
+    );
+    let padded_axis_b = builder.add_operation(
+        StdTensorOp::PadToMatch { axis: axis_b },
+        vec![ValueRef::Local(padded_axis_a[0]), shape_source],
+        OperationRole::Linearized {
+            active_mask: vec![true, false],
+        },
+    );
+    Ok(padded_axis_b[0])
+}
+
+fn static_pad_embedded_diag_to_input(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    embedded: LocalValueId,
+    input_shape: &[SymDim],
+    axis_a: usize,
+    axis_b: usize,
+) -> ADRuleResult<Option<LocalValueId>> {
+    if axis_a >= input_shape.len() || axis_b >= input_shape.len() || axis_a == axis_b {
+        return Err(ADRuleError::invalid_input(
+            "ExtractDiag",
+            ADRuleKind::Transpose,
+            format!(
+                "diagonal axes ({axis_a}, {axis_b}) out of bounds or not distinct for input rank {}",
+                input_shape.len()
+            ),
+        ));
+    }
+
+    let Some(size_a) = input_shape[axis_a].constant_value() else {
+        return Ok(None);
+    };
+    let Some(size_b) = input_shape[axis_b].constant_value() else {
+        return Ok(None);
+    };
+    let diag_size = size_a.min(size_b);
+    let mut high = vec![0_i64; input_shape.len()];
+    high[axis_a] = i64::try_from(size_a - diag_size).map_err(|_| {
+        ADRuleError::invalid_input(
+            "ExtractDiag",
+            ADRuleKind::Transpose,
+            "axis_a static diagonal padding does not fit in i64",
+        )
+    })?;
+    high[axis_b] = i64::try_from(size_b - diag_size).map_err(|_| {
+        ADRuleError::invalid_input(
+            "ExtractDiag",
+            ADRuleKind::Transpose,
+            "axis_b static diagonal padding does not fit in i64",
+        )
+    })?;
+
+    if high.iter().all(|&pad| pad == 0) {
+        return Ok(Some(embedded));
+    }
+    let rank = input_shape.len();
+    let out = builder.add_operation(
+        StdTensorOp::Pad(PadConfig {
+            edge_padding_low: vec![0_i64; rank],
+            edge_padding_high: high,
+            interior_padding: vec![0_i64; rank],
+        }),
+        vec![ValueRef::Local(embedded)],
+        OperationRole::Linearized {
+            active_mask: vec![true],
+        },
+    );
+    Ok(Some(out[0]))
 }

--- a/crates/tenferro-internal-ops/src/ad/elementwise.rs
+++ b/crates/tenferro-internal-ops/src/ad/elementwise.rs
@@ -3,9 +3,11 @@ use crate::ad::support::{
     conjugate_primal_if_any_dtype_complex, convert_fixed_ref_to_dtype, convert_linear_to_dtype,
     dtype_of_or_real, project_linear_to_dtype, promote_dtype_div_like,
 };
+use crate::ad::transpose_input::{metadata_value_refs, TransposeInputRef};
 use crate::ad::PrimitiveRuleBuilder;
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::{CompareDir, DType};
+use tidu::ADRuleResult;
 
 use crate::std_tensor_op::StdTensorOp;
 
@@ -561,27 +563,29 @@ pub fn linearize_clamp(
 pub fn transpose_div(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let ct = match cotangent_out[0] {
         Some(ct) => ct,
-        None => return vec![None, None],
+        None => return Ok(vec![None, None]),
     };
 
     let active_mask = match mode {
         OperationRole::Linearized { active_mask } => active_mask,
-        OperationRole::Primary => return vec![None, None],
+        OperationRole::Primary => return Ok(vec![None, None]),
     };
 
-    let lhs_dtype = dtype_of_or_real(ctx, &inputs[0]);
-    let rhs_dtype = dtype_of_or_real(ctx, &inputs[1]);
+    let metadata_inputs = metadata_value_refs(inputs);
+    let lhs_dtype = dtype_of_or_real(ctx, &metadata_inputs[0]);
+    let rhs_dtype = dtype_of_or_real(ctx, &metadata_inputs[1]);
     let output_dtype = promote_dtype_div_like(lhs_dtype, rhs_dtype);
     let mut result = vec![None, None];
 
     if active_mask[0] {
-        let denominator = conjugate_for_input_dtypes(builder, inputs[1].clone(), inputs, &[1], ctx);
+        let rhs = inputs[1].fixed_value("div", 1)?;
+        let denominator = conjugate_for_input_dtypes(builder, rhs, &metadata_inputs, &[1], ctx);
         let denominator = convert_fixed_ref_to_dtype(builder, denominator, rhs_dtype, output_dtype);
         let out = builder.add_operation(
             StdTensorOp::Div,
@@ -599,15 +603,20 @@ pub fn transpose_div(
     }
 
     if active_mask[1] {
-        let numerator =
-            convert_fixed_ref_to_dtype(builder, inputs[0].clone(), lhs_dtype, output_dtype);
-        let denominator =
-            convert_fixed_ref_to_dtype(builder, inputs[1].clone(), rhs_dtype, output_dtype);
+        let lhs = inputs[0].fixed_value("div", 0)?;
+        let rhs = inputs[1].fixed_value("div", 1)?;
+        let numerator = convert_fixed_ref_to_dtype(builder, lhs, lhs_dtype, output_dtype);
+        let denominator = convert_fixed_ref_to_dtype(builder, rhs, rhs_dtype, output_dtype);
         let quotient = emit_fixed_div(builder, numerator, denominator.clone());
         let neg_quotient = emit_fixed_neg(builder, ValueRef::Local(quotient));
         let coeff = emit_fixed_div(builder, ValueRef::Local(neg_quotient), denominator);
-        let coeff =
-            conjugate_for_input_dtypes(builder, ValueRef::Local(coeff), inputs, &[0, 1], ctx);
+        let coeff = conjugate_for_input_dtypes(
+            builder,
+            ValueRef::Local(coeff),
+            &metadata_inputs,
+            &[0, 1],
+            ctx,
+        );
         let cotangent = emit_linear_mul_fixed(builder, coeff, ct);
         result[1] = Some(project_linear_to_dtype(
             builder,
@@ -617,7 +626,7 @@ pub fn transpose_div(
         ));
     }
 
-    result
+    Ok(result)
 }
 
 pub fn transpose_abs(
@@ -747,21 +756,22 @@ pub fn transpose_minimum(
 pub fn transpose_select(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
-) -> Vec<Option<LocalValueId>> {
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let Some(ct) = cotangent_out[0] else {
-        return vec![None, None, None];
+        return Ok(vec![None, None, None]);
     };
     let active = active_mask(mode, 3);
     let true_active = active.get(1).copied().unwrap_or(false);
     let false_active = active.get(2).copied().unwrap_or(false);
     if !true_active && !false_active {
-        return vec![None, None, None];
+        return Ok(vec![None, None, None]);
     }
+    let condition = inputs[0].fixed_value("select", 0)?;
     let (on_true, on_false) =
-        split_cotangent_by_mask(builder, inputs[0].clone(), ct, true_active, false_active);
-    vec![None, on_true, on_false]
+        split_cotangent_by_mask(builder, condition, ct, true_active, false_active);
+    Ok(vec![None, on_true, on_false])
 }
 
 pub fn transpose_clamp(

--- a/crates/tenferro-internal-ops/src/ad/mod.rs
+++ b/crates/tenferro-internal-ops/src/ad/mod.rs
@@ -28,6 +28,9 @@ mod structural;
 #[doc(hidden)]
 pub mod support;
 #[cfg(feature = "autodiff")]
+#[doc(hidden)]
+pub mod transpose_input;
+#[cfg(feature = "autodiff")]
 mod zeros;
 
 #[cfg(feature = "autodiff")]
@@ -35,7 +38,10 @@ use computegraph::graph::GraphBuilder;
 #[cfg(feature = "autodiff")]
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 #[cfg(feature = "autodiff")]
-use tidu::{ADRuleError, ADRuleKind, ADRuleResult, PrimitiveBuilder, PrimitiveValue};
+use tidu::{
+    ADRuleError, ADRuleKind, ADRuleResult, PrimitiveBuilder, PrimitiveTransposeInput,
+    PrimitiveValue,
+};
 
 #[cfg(feature = "autodiff")]
 use crate::ext_op::{linearize_extension_rule, transpose_extension_rule};
@@ -157,7 +163,7 @@ pub fn transpose_rule(
     op: &StdTensorOp,
     builder: &mut impl PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[PrimitiveTransposeInput<StdTensorOp>],
     mode: &OperationRole,
     ctx: &mut context::ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -173,13 +179,17 @@ pub fn transpose_rule(
         );
     }
 
+    let transpose_inputs = inputs
+        .iter()
+        .map(transpose_input::TransposeInputRef::new)
+        .collect::<Vec<_>>();
     let kind = op
         .primitive_kind()
         .ok_or_else(|| missing_primitive_kind(op, ADRuleKind::Transpose))?;
     let rule = registry::primitive_ad_rule(kind)
         .ok_or_else(|| registry::missing_rule(kind, ADRuleKind::Transpose))?;
     let builder_dyn: &mut dyn PrimitiveRuleBuilder = builder;
-    rule.transpose_rule(op, builder_dyn, cotangent_out, inputs, mode, ctx)
+    rule.transpose_rule(op, builder_dyn, cotangent_out, &transpose_inputs, mode, ctx)
 }
 
 #[cfg(test)]

--- a/crates/tenferro-internal-ops/src/ad/registry.rs
+++ b/crates/tenferro-internal-ops/src/ad/registry.rs
@@ -1,9 +1,10 @@
 use crate::ad::PrimitiveRuleBuilder;
-use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
+use computegraph::types::{LocalValueId, OperationRole, ValueKey};
 use tenferro_core_ops::PrimitiveOpKind;
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use super::context::ShapeGuardContext;
+use super::transpose_input::{fixed_value_refs, metadata_value_refs, TransposeInputRef};
 use super::{
     analytic, contraction, diagonal, dynamic, elementwise, indexing, semiring, structural,
 };
@@ -22,7 +23,7 @@ pub(crate) type TransposeFn = fn(
     &StdTensorOp,
     &mut dyn PrimitiveRuleBuilder,
     &[Option<LocalValueId>],
-    &[ValueRef<StdTensorOp>],
+    &[TransposeInputRef<'_>],
     &OperationRole,
     &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
@@ -45,7 +46,7 @@ pub(crate) trait PrimitiveAdRule: Send + Sync {
         op: &StdTensorOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        inputs: &[ValueRef<StdTensorOp>],
+        inputs: &[TransposeInputRef<'_>],
         mode: &OperationRole,
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
@@ -79,7 +80,7 @@ impl PrimitiveAdRule for FunctionPrimitiveAdRule {
         op: &StdTensorOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        inputs: &[ValueRef<StdTensorOp>],
+        inputs: &[TransposeInputRef<'_>],
         mode: &OperationRole,
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -372,11 +373,12 @@ fn transpose_add(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    semiring::transpose_add(builder, cotangent_out, inputs, mode, ctx)
+    let inputs = metadata_value_refs(inputs);
+    semiring::transpose_add(builder, cotangent_out, &inputs, mode, ctx)
 }
 
 fn linearize_mul(
@@ -394,7 +396,7 @@ fn transpose_mul(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -416,7 +418,7 @@ fn transpose_neg(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    _inputs: &[ValueRef<StdTensorOp>],
+    _inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -438,11 +440,12 @@ fn transpose_conj(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    semiring::transpose_conj(builder, cotangent_out, inputs, mode, ctx)
+    let inputs = metadata_value_refs(inputs);
+    semiring::transpose_conj(builder, cotangent_out, &inputs, mode, ctx)
 }
 
 fn linearize_div(
@@ -549,11 +552,12 @@ macro_rules! transpose_elementwise {
             _op: &StdTensorOp,
             builder: &mut dyn PrimitiveRuleBuilder,
             cotangent_out: &[Option<LocalValueId>],
-            inputs: &[ValueRef<StdTensorOp>],
+            inputs: &[TransposeInputRef<'_>],
             mode: &OperationRole,
             _ctx: &mut ShapeGuardContext,
         ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-            Ok($callee(builder, cotangent_out, inputs, mode))
+            let inputs = fixed_value_refs(stringify!($name), inputs)?;
+            Ok($callee(builder, cotangent_out, &inputs, mode))
         }
     };
 }
@@ -562,30 +566,25 @@ fn transpose_div(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    Ok(elementwise::transpose_div(
-        builder,
-        cotangent_out,
-        inputs,
-        mode,
-        ctx,
-    ))
+    elementwise::transpose_div(builder, cotangent_out, inputs, mode, ctx)
 }
 fn transpose_abs(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    let inputs = fixed_value_refs("abs", inputs)?;
     Ok(elementwise::transpose_abs(
         builder,
         cotangent_out,
-        inputs,
+        &inputs,
         mode,
         ctx,
     ))
@@ -594,7 +593,7 @@ fn transpose_sign(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    _inputs: &[ValueRef<StdTensorOp>],
+    _inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -604,14 +603,15 @@ fn transpose_maximum(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    let inputs = fixed_value_refs("maximum", inputs)?;
     Ok(elementwise::transpose_maximum(
         builder,
         cotangent_out,
-        inputs,
+        &inputs,
         mode,
         ctx,
     ))
@@ -621,25 +621,35 @@ fn transpose_minimum(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    let inputs = fixed_value_refs("minimum", inputs)?;
     Ok(elementwise::transpose_minimum(
         builder,
         cotangent_out,
-        inputs,
+        &inputs,
         mode,
         ctx,
     ))
 }
-transpose_elementwise!(transpose_select, elementwise::transpose_select);
+fn transpose_select(
+    _op: &StdTensorOp,
+    builder: &mut dyn PrimitiveRuleBuilder,
+    cotangent_out: &[Option<LocalValueId>],
+    inputs: &[TransposeInputRef<'_>],
+    mode: &OperationRole,
+    _ctx: &mut ShapeGuardContext,
+) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+    elementwise::transpose_select(builder, cotangent_out, inputs, mode)
+}
 transpose_elementwise!(transpose_clamp, elementwise::transpose_clamp);
 fn transpose_compare(
     _op: &StdTensorOp,
     _builder: &mut dyn PrimitiveRuleBuilder,
     _cotangent_out: &[Option<LocalValueId>],
-    _inputs: &[ValueRef<StdTensorOp>],
+    _inputs: &[TransposeInputRef<'_>],
     _mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -737,11 +747,12 @@ macro_rules! analytic_transpose {
             _op: &StdTensorOp,
             builder: &mut dyn PrimitiveRuleBuilder,
             cotangent_out: &[Option<LocalValueId>],
-            inputs: &[ValueRef<StdTensorOp>],
+            inputs: &[TransposeInputRef<'_>],
             mode: &OperationRole,
             ctx: &mut ShapeGuardContext,
         ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-            Ok($callee(builder, cotangent_out, inputs, mode, ctx))
+            let inputs = fixed_value_refs(stringify!($name), inputs)?;
+            Ok($callee(builder, cotangent_out, &inputs, mode, ctx))
         }
     };
 }
@@ -754,11 +765,12 @@ fn transpose_tanh(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    analytic::transpose_tanh(builder, cotangent_out, inputs, mode, ctx)
+    let inputs = fixed_value_refs("tanh", inputs)?;
+    analytic::transpose_tanh(builder, cotangent_out, &inputs, mode, ctx)
 }
 analytic_transpose!(transpose_sqrt, analytic::transpose_sqrt);
 analytic_transpose!(transpose_rsqrt, analytic::transpose_rsqrt);
@@ -766,22 +778,24 @@ fn transpose_pow(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    analytic::transpose_pow(builder, cotangent_out, inputs, mode, ctx)
+    let inputs = fixed_value_refs("pow", inputs)?;
+    analytic::transpose_pow(builder, cotangent_out, &inputs, mode, ctx)
 }
 analytic_transpose!(transpose_expm1, analytic::transpose_expm1);
 fn transpose_log1p(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    analytic::transpose_log1p(builder, cotangent_out, inputs, mode, ctx)
+    let inputs = fixed_value_refs("log1p", inputs)?;
+    analytic::transpose_log1p(builder, cotangent_out, &inputs, mode, ctx)
 }
 
 fn linearize_dot_general(
@@ -801,7 +815,7 @@ fn transpose_dot_general(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -828,11 +842,11 @@ fn transpose_reduce_sum(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    contraction::transpose_reduce_sum(builder, cotangent_out, op, inputs, ctx)
+    contraction::transpose_reduce_sum_input(builder, cotangent_out, op, &inputs[0], ctx)
 }
 
 fn linearize_reduce_prod(
@@ -851,11 +865,12 @@ fn transpose_reduce_prod(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    contraction::transpose_reduce_prod(builder, cotangent_out, inputs, op, ctx)
+    let inputs = fixed_value_refs("reduce_prod", inputs)?;
+    contraction::transpose_reduce_prod(builder, cotangent_out, &inputs, op, ctx)
 }
 
 fn linearize_reduce_max(
@@ -886,22 +901,24 @@ fn transpose_reduce_max(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    contraction::transpose_reduce_chooser(builder, cotangent_out, inputs, op, ctx)
+    let inputs = fixed_value_refs("reduce_max", inputs)?;
+    contraction::transpose_reduce_chooser(builder, cotangent_out, &inputs, op, ctx)
 }
 
 fn transpose_reduce_min(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     _mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    contraction::transpose_reduce_chooser(builder, cotangent_out, inputs, op, ctx)
+    let inputs = fixed_value_refs("reduce_min", inputs)?;
+    contraction::transpose_reduce_chooser(builder, cotangent_out, &inputs, op, ctx)
 }
 
 fn linearize_transpose(
@@ -920,7 +937,7 @@ fn transpose_transpose(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    _inputs: &[ValueRef<StdTensorOp>],
+    _inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -945,11 +962,11 @@ fn transpose_reshape(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    structural::transpose_reshape(builder, cotangent_out, op, inputs, mode, ctx)
+    structural::transpose_reshape_input(builder, cotangent_out, op, inputs, mode, ctx)
 }
 
 fn linearize_broadcast_in_dim(
@@ -974,7 +991,7 @@ fn transpose_broadcast_in_dim(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -983,7 +1000,15 @@ fn transpose_broadcast_in_dim(
         ADRuleKind::Transpose,
         StdTensorOp::BroadcastInDim { shape, dims } => (shape, dims)
     );
-    structural::transpose_broadcast_in_dim(builder, cotangent_out, shape, dims, inputs, mode, ctx)
+    structural::transpose_broadcast_in_dim_input(
+        builder,
+        cotangent_out,
+        shape,
+        dims,
+        inputs,
+        mode,
+        ctx,
+    )
 }
 
 fn linearize_convert(
@@ -1005,7 +1030,7 @@ fn transpose_convert(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    _inputs: &[ValueRef<StdTensorOp>],
+    _inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -1045,7 +1070,7 @@ macro_rules! diagonal_rule {
             op: &StdTensorOp,
             builder: &mut dyn PrimitiveRuleBuilder,
             cotangent_out: &[Option<LocalValueId>],
-            inputs: &[ValueRef<StdTensorOp>],
+            inputs: &[TransposeInputRef<'_>],
             mode: &OperationRole,
             ctx: &mut ShapeGuardContext,
         ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -1092,7 +1117,7 @@ macro_rules! triangular_rule {
             op: &StdTensorOp,
             builder: &mut dyn PrimitiveRuleBuilder,
             cotangent_out: &[Option<LocalValueId>],
-            _inputs: &[ValueRef<StdTensorOp>],
+            _inputs: &[TransposeInputRef<'_>],
             mode: &OperationRole,
             _ctx: &mut ShapeGuardContext,
         ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -1135,12 +1160,13 @@ fn transpose_gather(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let config = catalog_payload!(op, ADRuleKind::Transpose, StdTensorOp::Gather(config) => config);
-    indexing::transpose_gather(builder, cotangent_out, inputs, mode, config, ctx)
+    let inputs = fixed_value_refs("gather", inputs)?;
+    indexing::transpose_gather(builder, cotangent_out, &inputs, mode, config, ctx)
 }
 
 fn linearize_gather_dynamic_slice_sizes(
@@ -1184,7 +1210,7 @@ fn transpose_gather_dynamic_slice_sizes(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -1199,10 +1225,11 @@ fn transpose_gather_dynamic_slice_sizes(
             ..
         } => (offset_dims, collapsed_slice_dims, start_index_map, index_vector_dim)
     );
+    let inputs = fixed_value_refs("gather_dynamic_slice_sizes", inputs)?;
     indexing::transpose_gather_dynamic_slice_sizes(
         builder,
         cotangent_out,
-        inputs,
+        &inputs,
         mode,
         offset_dims,
         collapsed_slice_dims,
@@ -1228,13 +1255,14 @@ fn transpose_scatter(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let config =
         catalog_payload!(op, ADRuleKind::Transpose, StdTensorOp::Scatter(config) => config);
-    indexing::transpose_scatter(builder, cotangent_out, inputs, mode, config, ctx)
+    let inputs = fixed_value_refs("scatter", inputs)?;
+    indexing::transpose_scatter(builder, cotangent_out, &inputs, mode, config, ctx)
 }
 
 fn linearize_slice(
@@ -1253,12 +1281,13 @@ fn transpose_slice(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let config = catalog_payload!(op, ADRuleKind::Transpose, StdTensorOp::Slice(config) => config);
-    structural::transpose_slice(builder, cotangent_out, inputs, mode, config, ctx)
+    let inputs = fixed_value_refs("slice", inputs)?;
+    structural::transpose_slice(builder, cotangent_out, &inputs, mode, config, ctx)
 }
 
 fn linearize_dynamic_slice(
@@ -1282,11 +1311,12 @@ fn transpose_dynamic_slice(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    indexing::transpose_dynamic_slice(builder, cotangent_out, inputs, mode, ctx)
+    let inputs = fixed_value_refs("dynamic_slice", inputs)?;
+    indexing::transpose_dynamic_slice(builder, cotangent_out, &inputs, mode, ctx)
 }
 
 fn linearize_dynamic_update_slice(
@@ -1304,11 +1334,12 @@ fn transpose_dynamic_update_slice(
     _op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-    indexing::transpose_dynamic_update_slice(builder, cotangent_out, inputs, mode, ctx)
+    let inputs = fixed_value_refs("dynamic_update_slice", inputs)?;
+    indexing::transpose_dynamic_update_slice(builder, cotangent_out, &inputs, mode, ctx)
 }
 
 fn linearize_pad(
@@ -1327,12 +1358,13 @@ fn transpose_pad(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let config = catalog_payload!(op, ADRuleKind::Transpose, StdTensorOp::Pad(config) => config);
-    structural::transpose_pad(builder, cotangent_out, inputs, mode, config, ctx)
+    let inputs = fixed_value_refs("pad", inputs)?;
+    structural::transpose_pad(builder, cotangent_out, &inputs, mode, config, ctx)
 }
 
 fn linearize_concatenate(
@@ -1355,7 +1387,7 @@ fn transpose_concatenate(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -1364,10 +1396,11 @@ fn transpose_concatenate(
         ADRuleKind::Transpose,
         StdTensorOp::Concatenate { axis, input_count } => (axis, input_count)
     );
+    let inputs = fixed_value_refs("concatenate", inputs)?;
     structural::transpose_concatenate(
         builder,
         cotangent_out,
-        inputs,
+        &inputs,
         mode,
         *axis,
         *input_count,
@@ -1391,7 +1424,7 @@ fn transpose_reverse(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    _inputs: &[ValueRef<StdTensorOp>],
+    _inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -1419,7 +1452,7 @@ fn transpose_shape_of(
     _op: &StdTensorOp,
     _builder: &mut dyn PrimitiveRuleBuilder,
     _cotangent_out: &[Option<LocalValueId>],
-    _inputs: &[ValueRef<StdTensorOp>],
+    _inputs: &[TransposeInputRef<'_>],
     _mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -1448,7 +1481,7 @@ fn transpose_dynamic_truncate(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -1457,10 +1490,11 @@ fn transpose_dynamic_truncate(
         ADRuleKind::Transpose,
         StdTensorOp::DynamicTruncate { axis } => axis
     );
+    let inputs = fixed_value_refs("dynamic_truncate", inputs)?;
     Ok(dynamic::transpose_dynamic_truncate(
         builder,
         cotangent_out,
-        inputs,
+        &inputs,
         mode,
         *axis,
     ))
@@ -1484,7 +1518,7 @@ fn transpose_pad_to_match(
     op: &StdTensorOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -1493,7 +1527,8 @@ fn transpose_pad_to_match(
         ADRuleKind::Transpose,
         StdTensorOp::PadToMatch { axis } => axis
     );
-    dynamic::transpose_pad_to_match(builder, cotangent_out, inputs, mode, *axis, ctx)
+    let inputs = fixed_value_refs("pad_to_match", inputs)?;
+    dynamic::transpose_pad_to_match(builder, cotangent_out, &inputs, mode, *axis, ctx)
 }
 
 fn linearize_constant(
@@ -1511,7 +1546,7 @@ fn transpose_constant(
     _op: &StdTensorOp,
     _builder: &mut dyn PrimitiveRuleBuilder,
     _cotangent_out: &[Option<LocalValueId>],
-    _inputs: &[ValueRef<StdTensorOp>],
+    _inputs: &[TransposeInputRef<'_>],
     _mode: &OperationRole,
     _ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {

--- a/crates/tenferro-internal-ops/src/ad/semiring.rs
+++ b/crates/tenferro-internal-ops/src/ad/semiring.rs
@@ -7,6 +7,7 @@ use crate::ad::support::{
     convert_linear_to_dtype, dtype_of_or_real, linear_transpose_input_active,
     project_linear_to_dtype, promote_dtype,
 };
+use crate::ad::transpose_input::{metadata_value_refs, TransposeInputRef};
 use crate::ad::PrimitiveRuleBuilder;
 use crate::std_tensor_op::StdTensorOp;
 
@@ -166,7 +167,7 @@ pub fn transpose_add(
 pub fn transpose_mul(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -180,13 +181,15 @@ pub fn transpose_mul(
         OperationRole::Primary => return Ok(vec![None, None]),
     };
 
-    let lhs_dtype = dtype_of_or_real(ctx, &inputs[0]);
-    let rhs_dtype = dtype_of_or_real(ctx, &inputs[1]);
+    let metadata_inputs = metadata_value_refs(inputs);
+    let lhs_dtype = dtype_of_or_real(ctx, &metadata_inputs[0]);
+    let rhs_dtype = dtype_of_or_real(ctx, &metadata_inputs[1]);
     let output_dtype = promote_dtype(lhs_dtype, rhs_dtype);
     let mut result = vec![None, None];
 
     if active_mask[0] {
-        let rhs_conj = conjugate_primal_if_complex(builder, inputs[1].clone(), ctx)?;
+        let rhs = inputs[1].fixed_value("mul", 1)?;
+        let rhs_conj = conjugate_primal_if_complex(builder, rhs, ctx)?;
         let rhs_conj = convert_fixed_ref_to_dtype(builder, rhs_conj, rhs_dtype, output_dtype);
         let out = builder.add_operation(
             StdTensorOp::Mul,
@@ -204,7 +207,8 @@ pub fn transpose_mul(
     }
 
     if active_mask[1] {
-        let lhs_conj = conjugate_primal_if_complex(builder, inputs[0].clone(), ctx)?;
+        let lhs = inputs[0].fixed_value("mul", 0)?;
+        let lhs_conj = conjugate_primal_if_complex(builder, lhs, ctx)?;
         let lhs_conj = convert_fixed_ref_to_dtype(builder, lhs_conj, lhs_dtype, output_dtype);
         let out = builder.add_operation(
             StdTensorOp::Mul,

--- a/crates/tenferro-internal-ops/src/ad/structural.rs
+++ b/crates/tenferro-internal-ops/src/ad/structural.rs
@@ -4,6 +4,9 @@ use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 
 use crate::ad::context::{ShapeGuardContext, ShapeGuardError};
 use crate::ad::support::{is_differentiable_dtype, linear_transpose_input_active};
+use crate::ad::transpose_input::{
+    linearized_inputs_with_inactive_shape_sources, TransposeInputRef,
+};
 use crate::ad::zeros::SymbolicZero;
 use crate::ad::PrimitiveRuleBuilder;
 use crate::dim_expr::DimExpr;
@@ -363,16 +366,16 @@ pub fn transpose_transpose(
     })
 }
 
-pub fn transpose_reshape(
+pub fn transpose_reshape_input(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     op: &StdTensorOp,
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
     let StdTensorOp::Reshape { to_shape: _ } = op else {
-        unreachable!("transpose_reshape expects Reshape");
+        unreachable!("transpose_reshape_input expects Reshape");
     };
 
     let mut result = Vec::with_capacity(inputs.len());
@@ -383,17 +386,11 @@ pub fn transpose_reshape(
 
     let primary = match cotangent_out[0] {
         Some(ct) => {
-            let input_rank = ctx.rank_of(&inputs[0])?;
-            let remapped_to_shape = DimExpr::input_shape(1, input_rank);
-            let needs_shape_source =
-                DimExpr::max_input_idx_all(&remapped_to_shape).is_some_and(|idx| idx > 0);
-            let mut op_inputs = vec![ValueRef::Local(ct)];
-            let active_mask = if needs_shape_source {
-                op_inputs.push(inputs[0].clone());
-                vec![true, false]
-            } else {
-                vec![true]
-            };
+            let input_key = ValueRef::External(inputs[0].key().clone());
+            let input_rank = ctx.rank_of(&input_key)?;
+            let (remapped_to_shape, shape_sources) = inputs[0].shape_operand(input_rank, 1, ctx)?;
+            let (op_inputs, active_mask) =
+                linearized_inputs_with_inactive_shape_sources(ValueRef::Local(ct), shape_sources);
             let out = builder.add_operation(
                 StdTensorOp::Reshape {
                     to_shape: remapped_to_shape,
@@ -412,12 +409,12 @@ pub fn transpose_reshape(
     Ok(result)
 }
 
-pub fn transpose_broadcast_in_dim(
+pub fn transpose_broadcast_in_dim_input(
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
     shape: &[DimExpr],
     dims: &[usize],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[TransposeInputRef<'_>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -427,8 +424,12 @@ pub fn transpose_broadcast_in_dim(
         return Ok(result);
     }
 
+    let value_inputs: Vec<_> = inputs
+        .iter()
+        .map(|input| ValueRef::External(input.key().clone()))
+        .collect();
     let (reduce_axes, needs_input_shape_restore) =
-        broadcast_transpose_reduce_axes(shape, dims, inputs, ctx)?;
+        broadcast_transpose_reduce_axes(shape, dims, &value_inputs, ctx)?;
 
     let primary = match cotangent_out[0] {
         Some(ct) => {
@@ -459,15 +460,16 @@ pub fn transpose_broadcast_in_dim(
                 reduced
             };
             if needs_input_shape_restore {
-                let input_rank = ctx.rank_of(&inputs[0])?;
+                let input_rank = ctx.rank_of(&value_inputs[0])?;
+                let (to_shape, shape_sources) = inputs[0].shape_operand(input_rank, 1, ctx)?;
+                let (op_inputs, active_mask) = linearized_inputs_with_inactive_shape_sources(
+                    ValueRef::Local(restored_order),
+                    shape_sources,
+                );
                 let reshaped = builder.add_operation(
-                    StdTensorOp::Reshape {
-                        to_shape: DimExpr::input_shape(1, input_rank),
-                    },
-                    vec![ValueRef::Local(restored_order), inputs[0].clone()],
-                    OperationRole::Linearized {
-                        active_mask: vec![true, false],
-                    },
+                    StdTensorOp::Reshape { to_shape },
+                    op_inputs,
+                    OperationRole::Linearized { active_mask },
                 );
                 Some(reshaped[0])
             } else {

--- a/crates/tenferro-internal-ops/src/ad/tests/structural_tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/structural_tests.rs
@@ -9,7 +9,7 @@ use crate::dim_expr::DimExpr;
 use crate::input_key::TensorInputKey;
 use crate::std_tensor_op::StdTensorOp;
 use crate::{ShapeExtent, SymDim, TensorMeta};
-use tidu::ADRuleError;
+use tidu::{ADRuleError, PrimitiveTransposeInput};
 
 fn tensor_input(id: u64) -> TensorInputKey {
     TensorInputKey::User { id }
@@ -116,17 +116,16 @@ fn transpose_reshape_returns_none_for_dynamic_shape_sources() {
     assert_eq!(graph.operations().len(), 1);
     let reshape = &graph.operations()[0];
     assert_eq!(reshape.inputs[0], ValueRef::Local(cotangent));
-    assert_eq!(reshape.inputs[1], inputs[0]);
     assert_eq!(
         reshape.operation,
         StdTensorOp::Reshape {
-            to_shape: DimExpr::input_shape(1, 2),
+            to_shape: vec![DimExpr::Const(2), DimExpr::Const(3)],
         }
     );
     assert_eq!(
         reshape.role,
         OperationRole::Linearized {
-            active_mask: vec![true, false],
+            active_mask: vec![true],
         }
     );
 }
@@ -293,13 +292,25 @@ fn transpose_broadcast_propagates_unresolved_local_shape_error() {
     let mut builder = GraphBuilder::<StdTensorOp>::new();
     let mut ctx = ShapeGuardContext::default();
     let cotangent = builder.add_input(tensor_input(35));
-    let inputs = vec![ValueRef::Local(999)];
+    let data_key = input_key(36);
+    ctx.insert_metadata(
+        data_key.clone(),
+        TensorMeta::with_extents(
+            DType::F64,
+            vec![ShapeExtent::upper_bound(SymDim::from(1usize))],
+        ),
+    );
+    let inputs = vec![PrimitiveTransposeInput::Linear {
+        key: data_key,
+        primal: None,
+    }];
 
-    let err = StdTensorOp::BroadcastInDim {
+    let op = StdTensorOp::BroadcastInDim {
         shape: vec![DimExpr::Const(3)],
         dims: vec![0],
-    }
-    .transpose_rule(
+    };
+    let err = crate::ad::transpose_rule(
+        &op,
         &mut builder,
         &[Some(cotangent)],
         &inputs,
@@ -308,8 +319,7 @@ fn transpose_broadcast_propagates_unresolved_local_shape_error() {
     )
     .unwrap_err();
 
-    assert!(err.to_string().contains("without an attached graph"));
-    assert!(builder.build().operations().is_empty());
+    assert!(err.to_string().contains("linear-only"));
 }
 
 #[test]
@@ -345,11 +355,10 @@ fn transpose_broadcast_reduces_singleton_input_axes() {
     assert_eq!(
         reshape.operation,
         StdTensorOp::Reshape {
-            to_shape: DimExpr::input_shape(1, 1),
+            to_shape: vec![DimExpr::Const(1)],
         }
     );
     assert_eq!(reshape.inputs[0], ValueRef::Local(reduce.outputs[0]));
-    assert_eq!(reshape.inputs[1], inputs[0]);
     assert!(reshape.outputs.contains(&cotangent_in));
 }
 
@@ -484,6 +493,101 @@ fn transpose_embed_diag_accepts_upper_bound_input_metadata_for_rank_only_perm() 
         graph.operations()[1].operation,
         StdTensorOp::Transpose { perm: vec![1, 0] }
     );
+}
+
+#[test]
+fn transpose_extract_diag_uses_runtime_shape_source_for_symbolic_padding() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let mut ctx = ShapeGuardContext::default();
+    let cotangent = builder.add_input(tensor_input(61));
+    let data_key = input_key(62);
+    ctx.insert_metadata(
+        data_key.clone(),
+        TensorMeta::exact(
+            DType::F64,
+            vec![SymDim::tensor_axis(900, 0), SymDim::from(5usize)],
+        ),
+    );
+    ctx.insert_shape_source(900, data_key.clone());
+
+    let result = StdTensorOp::ExtractDiag {
+        axis_a: 0,
+        axis_b: 1,
+    }
+    .transpose_rule(
+        &mut builder,
+        &[Some(cotangent)],
+        &[ValueRef::External(data_key.clone())],
+        &linear_mode(&[true]),
+        &mut ctx,
+    )
+    .unwrap();
+
+    assert_eq!(result.len(), 1);
+    let cotangent_in = result[0].expect("extract-diag input cotangent must be active");
+    let graph = builder.build();
+    assert_eq!(graph.operations().len(), 3);
+    assert_eq!(
+        graph.operations()[0].operation,
+        StdTensorOp::EmbedDiag {
+            axis_a: 0,
+            axis_b: 1,
+        }
+    );
+    assert_eq!(
+        graph.operations()[1].operation,
+        StdTensorOp::PadToMatch { axis: 0 }
+    );
+    assert_eq!(
+        graph.operations()[1].inputs,
+        vec![
+            ValueRef::Local(graph.operations()[0].outputs[0]),
+            ValueRef::External(data_key.clone())
+        ]
+    );
+    assert_eq!(
+        graph.operations()[2].operation,
+        StdTensorOp::PadToMatch { axis: 1 }
+    );
+    assert_eq!(
+        graph.operations()[2].inputs,
+        vec![
+            ValueRef::Local(graph.operations()[1].outputs[0]),
+            ValueRef::External(data_key)
+        ]
+    );
+    assert!(graph.operations()[2].outputs.contains(&cotangent_in));
+}
+
+#[test]
+fn transpose_extract_diag_reports_static_padding_axis_errors() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let mut ctx = ShapeGuardContext::default();
+    let cotangent = builder.add_input(tensor_input(63));
+    let data_key = input_key(64);
+    ctx.insert_metadata(data_key.clone(), meta(&[2, 2]));
+
+    let err = StdTensorOp::ExtractDiag {
+        axis_a: 2,
+        axis_b: 0,
+    }
+    .transpose_rule(
+        &mut builder,
+        &[Some(cotangent)],
+        &[ValueRef::External(data_key)],
+        &linear_mode(&[true]),
+        &mut ctx,
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ADRuleError::InvalidInput {
+            ref op,
+            ref message,
+            ..
+        } if op == "ExtractDiag" && message.contains("out of bounds")
+    ));
 }
 
 #[test]

--- a/crates/tenferro-internal-ops/src/ad/transpose_input.rs
+++ b/crates/tenferro-internal-ops/src/ad/transpose_input.rs
@@ -1,0 +1,250 @@
+use computegraph::types::{ValueKey, ValueRef};
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult, PrimitiveTransposeInput};
+
+use crate::ad::context::ShapeGuardContext;
+use crate::dim_expr::DimExpr;
+use crate::std_tensor_op::StdTensorOp;
+use crate::sym_dim::SymDim;
+
+pub struct TransposeInputRef<'a> {
+    input: &'a PrimitiveTransposeInput<StdTensorOp>,
+}
+
+impl<'a> TransposeInputRef<'a> {
+    pub fn new(input: &'a PrimitiveTransposeInput<StdTensorOp>) -> Self {
+        Self { input }
+    }
+
+    pub fn key(&self) -> &ValueKey<StdTensorOp> {
+        self.input.key()
+    }
+
+    pub fn metadata_value(&self) -> ValueRef<StdTensorOp> {
+        ValueRef::External(self.key().clone())
+    }
+
+    pub fn fixed_value(&self, op: &str, index: usize) -> ADRuleResult<ValueRef<StdTensorOp>> {
+        self.primal_or_residual_value(op, index, "retained as a tensor operand")
+    }
+
+    pub fn shape_source_value(
+        &self,
+        op: &str,
+        index: usize,
+    ) -> ADRuleResult<ValueRef<StdTensorOp>> {
+        self.primal_or_residual_value(op, index, "used as a runtime shape source")
+    }
+
+    fn primal_or_residual_value(
+        &self,
+        op: &str,
+        index: usize,
+        use_case: &str,
+    ) -> ADRuleResult<ValueRef<StdTensorOp>> {
+        match self.input {
+            PrimitiveTransposeInput::Residual(key) => Ok(ValueRef::External(key.clone())),
+            PrimitiveTransposeInput::Linear {
+                primal: Some(primal),
+                ..
+            } => Ok(ValueRef::External(primal.clone())),
+            PrimitiveTransposeInput::Linear { key, primal: None } => {
+                Err(ADRuleError::invalid_input(
+                    op,
+                    ADRuleKind::Transpose,
+                    format!(
+                        "transpose input {index} is linear-only and cannot be {use_case}: {key:?}"
+                    ),
+                ))
+            }
+        }
+    }
+
+    pub fn shape_operand(
+        &self,
+        rank: usize,
+        source_idx: usize,
+        ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<(Vec<DimExpr>, Vec<ValueRef<StdTensorOp>>)> {
+        let metadata_ref = ValueRef::External(self.key().clone());
+        if !self.requires_runtime_shape_source() {
+            if let Some(shape) = ctx.shape_if_available(&metadata_ref) {
+                if let Some(resolved) =
+                    shape_exprs_from_exact_metadata(&shape, rank, source_idx, ctx)
+                {
+                    return Ok(resolved);
+                }
+            }
+        }
+
+        self.runtime_shape_with_source(rank, source_idx)
+    }
+
+    fn requires_runtime_shape_source(&self) -> bool {
+        match self.input {
+            PrimitiveTransposeInput::Residual(key) => key_requires_runtime_shape_source(key),
+            PrimitiveTransposeInput::Linear { key, primal } => {
+                key_requires_runtime_shape_source(key)
+                    || primal
+                        .as_ref()
+                        .is_some_and(key_requires_runtime_shape_source)
+            }
+        }
+    }
+
+    fn runtime_shape_with_source(
+        &self,
+        rank: usize,
+        source_idx: usize,
+    ) -> ADRuleResult<(Vec<DimExpr>, Vec<ValueRef<StdTensorOp>>)> {
+        let shape = (0..rank)
+            .map(|axis| DimExpr::InputDim {
+                input_idx: source_idx,
+                axis,
+            })
+            .collect();
+        let shape_sources = if rank == 0 {
+            Vec::new()
+        } else {
+            vec![self.runtime_shape_source()?]
+        };
+        Ok((shape, shape_sources))
+    }
+
+    fn runtime_shape_source(&self) -> ADRuleResult<ValueRef<StdTensorOp>> {
+        match self.input {
+            PrimitiveTransposeInput::Residual(key) => Ok(ValueRef::External(key.clone())),
+            PrimitiveTransposeInput::Linear {
+                primal: Some(primal),
+                ..
+            } => Ok(ValueRef::External(primal.clone())),
+            PrimitiveTransposeInput::Linear { key, primal: None } => {
+                Err(ADRuleError::invalid_input(
+                    "transpose shape operand",
+                    ADRuleKind::Transpose,
+                    format!("linear-only value has no primal shape source: {key:?}"),
+                ))
+            }
+        }
+    }
+}
+
+pub(crate) fn metadata_value_refs(inputs: &[TransposeInputRef<'_>]) -> Vec<ValueRef<StdTensorOp>> {
+    inputs
+        .iter()
+        .map(TransposeInputRef::metadata_value)
+        .collect()
+}
+
+pub(crate) fn fixed_value_refs(
+    op: &str,
+    inputs: &[TransposeInputRef<'_>],
+) -> ADRuleResult<Vec<ValueRef<StdTensorOp>>> {
+    inputs
+        .iter()
+        .enumerate()
+        .map(|(index, input)| input.fixed_value(op, index))
+        .collect()
+}
+
+pub(crate) fn linearized_inputs_with_inactive_shape_sources(
+    data: ValueRef<StdTensorOp>,
+    shape_sources: Vec<ValueRef<StdTensorOp>>,
+) -> (Vec<ValueRef<StdTensorOp>>, Vec<bool>) {
+    let mut inputs = Vec::with_capacity(1 + shape_sources.len());
+    inputs.push(data);
+    inputs.extend(shape_sources);
+    let mut active_mask = vec![false; inputs.len()];
+    active_mask[0] = true;
+    (inputs, active_mask)
+}
+
+pub(crate) fn shape_exprs_for_value_extent(
+    input: &ValueRef<StdTensorOp>,
+    rank: usize,
+    source_idx: usize,
+    ctx: &mut ShapeGuardContext,
+) -> (Vec<DimExpr>, Vec<ValueRef<StdTensorOp>>) {
+    if !value_ref_requires_runtime_shape_source(input) {
+        if let Some(shape) = ctx.shape_if_available(input) {
+            if let Some(resolved) = shape_exprs_from_exact_metadata(&shape, rank, source_idx, ctx) {
+                return resolved;
+            }
+        }
+    }
+
+    runtime_shape_with_value_source(input, rank, source_idx)
+}
+
+fn shape_exprs_from_exact_metadata(
+    shape: &[SymDim],
+    rank: usize,
+    source_idx: usize,
+    ctx: &mut ShapeGuardContext,
+) -> Option<(Vec<DimExpr>, Vec<ValueRef<StdTensorOp>>)> {
+    let mut tensor_map = Vec::new();
+    let mut shape_sources = Vec::new();
+    for tensor_id in shape
+        .iter()
+        .flat_map(|dim| dim.referenced_tensor_ids().into_iter())
+    {
+        if tensor_map.iter().any(|(seen, _)| *seen == tensor_id) {
+            continue;
+        }
+        let source = ctx.shape_source(tensor_id).cloned()?;
+        let input_idx = source_idx + shape_sources.len();
+        tensor_map.push((tensor_id, input_idx));
+        shape_sources.push(ValueRef::External(source));
+    }
+
+    let converted = shape
+        .iter()
+        .map(|dim| dim.to_dim_expr(&tensor_map))
+        .collect::<Result<Vec<_>, _>>()
+        .ok()?;
+    if converted.len() == rank {
+        Some((converted, shape_sources))
+    } else {
+        None
+    }
+}
+
+fn value_ref_requires_runtime_shape_source(input: &ValueRef<StdTensorOp>) -> bool {
+    match input {
+        ValueRef::Local(_) => true,
+        ValueRef::External(key) => key_requires_runtime_shape_source(key),
+    }
+}
+
+fn runtime_shape_with_value_source(
+    input: &ValueRef<StdTensorOp>,
+    rank: usize,
+    source_idx: usize,
+) -> (Vec<DimExpr>, Vec<ValueRef<StdTensorOp>>) {
+    let shape = (0..rank)
+        .map(|axis| DimExpr::InputDim {
+            input_idx: source_idx,
+            axis,
+        })
+        .collect();
+    let shape_sources = if rank == 0 {
+        Vec::new()
+    } else {
+        vec![input.clone()]
+    };
+    (shape, shape_sources)
+}
+
+fn key_requires_runtime_shape_source(key: &ValueKey<StdTensorOp>) -> bool {
+    match key {
+        ValueKey::Input(_) => false,
+        ValueKey::Derived { operation, .. } => {
+            matches!(
+                operation.operation(),
+                StdTensorOp::DynamicTruncate { .. } | StdTensorOp::PadToMatch { .. }
+            ) || operation
+                .inputs()
+                .iter()
+                .any(key_requires_runtime_shape_source)
+        }
+    }
+}

--- a/crates/tenferro-internal-ops/src/ext_op.rs
+++ b/crates/tenferro-internal-ops/src/ext_op.rs
@@ -30,7 +30,7 @@ use computegraph::types::ValueRef;
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_tensor::{DType, Tensor};
 #[cfg(feature = "autodiff")]
-use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult, PrimitiveTransposeInput};
 
 #[cfg(feature = "autodiff")]
 use crate::ad::context::ShapeGuardContext;
@@ -329,7 +329,7 @@ pub trait ExtensionLinearTransposeRule: Debug + Send + Sync + 'static {
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        inputs: &[ValueRef<StdTensorOp>],
+        inputs: &[PrimitiveTransposeInput<StdTensorOp>],
         active_mask: &[bool],
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>>;
@@ -792,7 +792,7 @@ pub fn transpose_extension_rule(
     op: &dyn ExtensionOp,
     builder: &mut dyn PrimitiveRuleBuilder,
     cotangent_out: &[Option<LocalValueId>],
-    inputs: &[ValueRef<StdTensorOp>],
+    inputs: &[PrimitiveTransposeInput<StdTensorOp>],
     mode: &OperationRole,
     ctx: &mut ShapeGuardContext,
 ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -809,13 +809,42 @@ pub fn transpose_extension_rule(
             }
         }
         OperationRole::Primary => match ctx.extension_primal_vjp_rule_for(op.family_id()) {
-            Some(rule) => rule.primal_vjp(op, builder, cotangent_out, inputs, ctx),
+            Some(rule) => {
+                let value_inputs = primal_vjp_inputs(inputs)?;
+                rule.primal_vjp(op, builder, cotangent_out, &value_inputs, ctx)
+            }
             None => Err(ADRuleError::unsupported(
                 op.family_id(),
                 ADRuleKind::Transpose,
             )),
         },
     }
+}
+
+#[cfg(feature = "autodiff")]
+fn primal_vjp_inputs(
+    inputs: &[PrimitiveTransposeInput<StdTensorOp>],
+) -> ADRuleResult<Vec<ValueRef<StdTensorOp>>> {
+    inputs
+        .iter()
+        .enumerate()
+        .map(|(index, input)| match input {
+            PrimitiveTransposeInput::Residual(key) => Ok(ValueRef::External(key.clone())),
+            PrimitiveTransposeInput::Linear {
+                primal: Some(primal),
+                ..
+            } => Ok(ValueRef::External(primal.clone())),
+            PrimitiveTransposeInput::Linear { key, primal: None } => {
+                Err(ADRuleError::invalid_input(
+                    "extension transpose",
+                    ADRuleKind::Transpose,
+                    format!(
+                        "input {index} is linear-only and cannot be used as a primal VJP value: {key:?}"
+                    ),
+                ))
+            }
+        })
+        .collect()
 }
 
 /// Thin adapter that lets a generic `H: Hasher` satisfy the object-safe

--- a/crates/tenferro-internal-ops/src/std_tensor_op.rs
+++ b/crates/tenferro-internal-ops/src/std_tensor_op.rs
@@ -6,7 +6,7 @@ use computegraph::types::{LocalValueId, OperationRole, ValueKey};
 use computegraph::GraphOperation;
 use num_complex::{Complex32, Complex64};
 #[cfg(feature = "autodiff")]
-use tidu::{ADRuleResult, Primitive, PrimitiveBuilder, PrimitiveValue};
+use tidu::{ADRuleResult, Primitive, PrimitiveBuilder};
 
 use crate::dim_expr::DimExpr;
 use crate::ext_op::{ext_op_eq, hash_extension, ExtensionOp};
@@ -477,12 +477,11 @@ impl Primitive for StdTensorOp {
         &self,
         builder: &mut impl PrimitiveBuilder<Self>,
         cotangent_out: &[Option<LocalValueId>],
-        inputs: &[PrimitiveValue<Self>],
+        inputs: &[tidu::PrimitiveTransposeInput<Self>],
         mode: &OperationRole,
         ctx: &mut Self::ADContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        let inputs = inputs.iter().cloned().map(Into::into).collect::<Vec<_>>();
-        crate::ad::transpose_rule(self, builder, cotangent_out, &inputs, mode, ctx)
+        crate::ad::transpose_rule(self, builder, cotangent_out, inputs, mode, ctx)
     }
 }
 
@@ -501,12 +500,24 @@ impl StdTensorOp {
 
     pub(crate) fn transpose_rule(
         &self,
-        builder: &mut impl crate::ad::PrimitiveRuleBuilder,
+        builder: &mut computegraph::graph::GraphBuilder<Self>,
         cotangent_out: &[Option<LocalValueId>],
         inputs: &[computegraph::ValueRef<Self>],
         mode: &OperationRole,
         ctx: &mut crate::ad::context::ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
-        crate::ad::transpose_rule(self, builder, cotangent_out, inputs, mode, ctx)
+        let inputs = inputs
+            .iter()
+            .map(|input| match input {
+                computegraph::ValueRef::Local(local_id) => {
+                    let key = builder.global_key(*local_id).clone();
+                    tidu::PrimitiveTransposeInput::Residual(key)
+                }
+                computegraph::ValueRef::External(key) => {
+                    tidu::PrimitiveTransposeInput::Residual(key.clone())
+                }
+            })
+            .collect::<Vec<_>>();
+        crate::ad::transpose_rule(self, builder, cotangent_out, inputs.as_slice(), mode, ctx)
     }
 }

--- a/crates/tenferro-internal-ops/src/tests/ext_op_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/ext_op_tests.rs
@@ -236,7 +236,7 @@ impl ExtensionLinearTransposeRule for CoverageLinearTransposeRule {
         _op: &dyn ExtensionOp,
         _builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        _inputs: &[ValueRef<StdTensorOp>],
+        _inputs: &[tidu::PrimitiveTransposeInput<StdTensorOp>],
         active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {

--- a/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
+++ b/crates/tenferro-internal-ops/src/tests/std_tensor_op_tests/special_cases.rs
@@ -111,7 +111,7 @@ fn test_std_tensor_op_structural_special_cases_cover_identity_and_empty_axes() {
     assert_eq!(
         reshape_transpose_graph.operations()[0].operation,
         StdTensorOp::Reshape {
-            to_shape: DimExpr::input_shape(1, 1),
+            to_shape: shape![4],
         }
     );
 
@@ -411,22 +411,12 @@ fn test_std_tensor_op_contraction_special_cases_cover_none_and_scalar_paths() {
         run_transpose_case_with_input_shapes(reduce.clone(), 1, &[true], true, &[&[2, 3]]);
     assert!(reduce_transpose_result[0].is_some());
     assert_eq!(reduce_transpose_graph.operations().len(), 1);
-    // The transpose rule reads input shape via `ctx.shape_of` and emits
-    // `BroadcastInDim` with `InputDim` references into the primal input
-    // (which sits at op input index 1 after the cotangent at index 0).
+    // Exact metadata is enough here, so the transpose rule does not retain a
+    // runtime shape source input.
     assert_eq!(
         reduce_transpose_graph.operations()[0].operation,
         StdTensorOp::BroadcastInDim {
-            shape: vec![
-                DimExpr::InputDim {
-                    input_idx: 1,
-                    axis: 0,
-                },
-                DimExpr::InputDim {
-                    input_idx: 1,
-                    axis: 1,
-                },
-            ],
+            shape: shape![2, 3],
             dims: vec![0],
         }
     );
@@ -580,7 +570,7 @@ impl ExtensionLinearTransposeRule for RuleOnlyIdentityAd {
         _op: &dyn ExtensionOp,
         _builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        _inputs: &[ValueRef<StdTensorOp>],
+        _inputs: &[tidu::PrimitiveTransposeInput<StdTensorOp>],
         _active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {

--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -31,7 +31,7 @@ use tenferro_ad::extension::{
 use tenferro_ops::ad::PrimitiveRuleBuilder;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
-use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult, PrimitiveTransposeInput};
 
 use crate::extension::{LinalgExtensionOp, LinalgOp};
 use crate::LINALG_EXTENSION_FAMILY_ID;
@@ -147,7 +147,7 @@ impl ExtensionLinearTransposeRule for LinalgAdRule {
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        inputs: &[ValueRef<StdTensorOp>],
+        inputs: &[PrimitiveTransposeInput<StdTensorOp>],
         active_mask: &[bool],
         ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
@@ -162,34 +162,45 @@ impl ExtensionLinearTransposeRule for LinalgAdRule {
                 lower,
                 transpose_a,
                 unit_diagonal,
-            } => rules::transpose_triangular_solve(
-                &mut builder,
-                cotangent_out,
-                inputs,
-                &mode,
-                rules::TriangularSolveFlags::new(left_side, lower, transpose_a, unit_diagonal),
-                ctx,
-            ),
+            } => {
+                let value_inputs =
+                    linear_solve_transpose_inputs("triangular_solve", inputs, active_mask)?;
+                rules::transpose_triangular_solve(
+                    &mut builder,
+                    cotangent_out,
+                    &value_inputs,
+                    &mode,
+                    rules::TriangularSolveFlags::new(left_side, lower, transpose_a, unit_diagonal),
+                    ctx,
+                )
+            }
             LinalgOp::LuSolvePrepared {
                 transpose_a,
                 conjugate_a,
-            } => rules::transpose_lu_solve_prepared(
-                &mut builder,
-                cotangent_out,
-                inputs,
-                &mode,
-                transpose_a,
-                conjugate_a,
-                ctx,
-            ),
-            LinalgOp::FullPivLuSolve { transpose_a } => rules::transpose_full_piv_lu_solve(
-                &mut builder,
-                cotangent_out,
-                inputs,
-                &mode,
-                transpose_a,
-                ctx,
-            ),
+            } => {
+                let value_inputs = lu_solve_prepared_transpose_inputs(inputs, active_mask)?;
+                rules::transpose_lu_solve_prepared(
+                    &mut builder,
+                    cotangent_out,
+                    &value_inputs,
+                    &mode,
+                    transpose_a,
+                    conjugate_a,
+                    ctx,
+                )
+            }
+            LinalgOp::FullPivLuSolve { transpose_a } => {
+                let value_inputs =
+                    linear_solve_transpose_inputs("full_piv_lu_solve", inputs, active_mask)?;
+                rules::transpose_full_piv_lu_solve(
+                    &mut builder,
+                    cotangent_out,
+                    &value_inputs,
+                    &mode,
+                    transpose_a,
+                    ctx,
+                )
+            }
             LinalgOp::Cholesky
             | LinalgOp::Lu
             | LinalgOp::LuFactor
@@ -224,6 +235,70 @@ fn downcast_ad_op(op: &dyn ExtensionOp, kind: ADRuleKind) -> ADRuleResult<&Linal
         .ok_or_else(|| {
             ADRuleError::invalid_input("tenferro-linalg.linalg.v1", kind, "payload type mismatch")
         })
+}
+
+fn linear_solve_transpose_inputs(
+    op: &str,
+    inputs: &[PrimitiveTransposeInput<StdTensorOp>],
+    active_mask: &[bool],
+) -> ADRuleResult<Vec<ValueRef<StdTensorOp>>> {
+    let matrix_active = active_mask.first().copied().unwrap_or(false);
+    inputs
+        .iter()
+        .enumerate()
+        .map(|(index, input)| {
+            if index == 0 || matrix_active {
+                fixed_transpose_value(op, index, input)
+            } else {
+                Ok(metadata_transpose_value(input))
+            }
+        })
+        .collect()
+}
+
+fn lu_solve_prepared_transpose_inputs(
+    inputs: &[PrimitiveTransposeInput<StdTensorOp>],
+    active_mask: &[bool],
+) -> ADRuleResult<Vec<ValueRef<StdTensorOp>>> {
+    let matrix_active = active_mask.first().copied().unwrap_or(false);
+    inputs
+        .iter()
+        .enumerate()
+        .map(|(index, input)| {
+            if index <= 2 || matrix_active {
+                fixed_transpose_value("lu_solve_prepared", index, input)
+            } else {
+                Ok(metadata_transpose_value(input))
+            }
+        })
+        .collect()
+}
+
+fn metadata_transpose_value(input: &PrimitiveTransposeInput<StdTensorOp>) -> ValueRef<StdTensorOp> {
+    ValueRef::External(input.key().clone())
+}
+
+fn fixed_transpose_value(
+    op: &str,
+    index: usize,
+    input: &PrimitiveTransposeInput<StdTensorOp>,
+) -> ADRuleResult<ValueRef<StdTensorOp>> {
+    match input {
+        PrimitiveTransposeInput::Residual(key) => Ok(ValueRef::External(key.clone())),
+        PrimitiveTransposeInput::Linear {
+            primal: Some(primal),
+            ..
+        } => Ok(ValueRef::External(primal.clone())),
+        PrimitiveTransposeInput::Linear { key, primal: None } => {
+            Err(ADRuleError::invalid_input(
+                op,
+                ADRuleKind::Transpose,
+                format!(
+                    "transpose input {index} is linear-only and cannot be retained as a tensor operand: {key:?}"
+                ),
+            ))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -777,7 +852,10 @@ mod tests {
                 &op,
                 &mut builder,
                 &[Some(cotangent)],
-                &[ValueRef::External(lhs.clone()), ValueRef::External(rhs)],
+                &[
+                    PrimitiveTransposeInput::Residual(lhs.clone()),
+                    PrimitiveTransposeInput::Residual(rhs),
+                ],
                 &[false, true],
                 &mut ctx,
             )
@@ -805,7 +883,7 @@ mod tests {
                 &op,
                 &mut builder,
                 &[Some(cotangent)],
-                &[ValueRef::External(a)],
+                &[PrimitiveTransposeInput::Residual(a)],
                 &[true],
                 &mut ctx,
             )
@@ -833,7 +911,7 @@ mod tests {
                 &op,
                 &mut builder,
                 &[Some(g_w), Some(g_v)],
-                &[ValueRef::External(a)],
+                &[PrimitiveTransposeInput::Residual(a)],
                 &[true],
                 &mut ctx,
             )
@@ -858,7 +936,7 @@ mod tests {
                 &LinalgExtensionOp::new(LinalgOp::Qr),
                 &mut builder,
                 &[Some(g_q), Some(g_r)],
-                &[ValueRef::External(a)],
+                &[PrimitiveTransposeInput::Residual(a)],
                 &[true],
                 &mut ctx,
             )

--- a/crates/tenferro-linalg/tests/traced_ad_explicit.rs
+++ b/crates/tenferro-linalg/tests/traced_ad_explicit.rs
@@ -839,6 +839,29 @@ struct GraphOpSummary {
     multi_output_ops: usize,
 }
 
+#[derive(Debug)]
+struct CompiledProgramSummary {
+    input_count: usize,
+    instruction_count: usize,
+    counts: BTreeMap<&'static str, usize>,
+}
+
+fn compiled_program_summary(output: &TracedTensor) -> CompiledProgramSummary {
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(output).unwrap();
+    let view = program.lowering_view();
+    let mut counts = BTreeMap::new();
+    for instruction in view.instructions() {
+        *counts.entry(instruction.op_name()).or_insert(0) += 1;
+    }
+    let instruction_count = view.instructions().len();
+    CompiledProgramSummary {
+        input_count: program.input_count(),
+        instruction_count,
+        counts,
+    }
+}
+
 fn graph_op_summary(output: &TracedTensor) -> GraphOpSummary {
     let mut counts = BTreeMap::new();
     let mut multi_output_ops = 0;
@@ -935,6 +958,63 @@ fn assert_gradient_matches_finite_difference(
             actual_value
         );
     }
+}
+
+#[test]
+fn lu_sum_grad_compiled_program_does_not_retain_tangent_sweep() {
+    let ad = ad_context();
+    let matrix =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![2.0, 0.5, 0.25, 3.0]))
+            .unwrap();
+    let grad = ad.grad(&lu_sum_loss(&matrix), &matrix).unwrap();
+    let summary = compiled_program_summary(&grad);
+
+    assert_eq!(
+        summary.input_count, 2,
+        "compiled LU VJP should bind only the primal input and cotangent: {summary:?}"
+    );
+    assert_eq!(
+        summary.counts.get("DotGeneral").copied().unwrap_or(0),
+        3,
+        "compiled LU VJP should not retain the zero tangent matmul chain: {summary:?}"
+    );
+    assert_eq!(
+        summary.counts.get("Extension").copied().unwrap_or(0),
+        3,
+        "compiled LU VJP should contain primal LU plus two triangular-solve pullback ops: {summary:?}"
+    );
+    assert!(
+        summary.instruction_count <= 21,
+        "compiled LU VJP should stay near the direct transpose baseline: {summary:?}"
+    );
+}
+
+#[test]
+fn eigvalsh_sum_grad_compiled_program_does_not_retain_tangent_sweep() {
+    let ad = ad_context();
+    let matrix =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![2.0, 0.2, 0.2, 4.0]))
+            .unwrap();
+    let grad = ad.grad(&eigvalsh_sum_loss(&matrix), &matrix).unwrap();
+    let summary = compiled_program_summary(&grad);
+
+    assert_eq!(
+        summary.input_count, 2,
+        "compiled eigvalsh VJP should bind only the primal input and cotangent: {summary:?}"
+    );
+    assert_eq!(
+        summary.counts.get("DotGeneral").copied().unwrap_or(0),
+        2,
+        "compiled eigvalsh VJP should not retain the zero tangent matmul chain: {summary:?}"
+    );
+    assert!(
+        summary.counts.get("Extension").copied().unwrap_or(0) <= 2,
+        "compiled eigvalsh VJP should not retain extra extension ops from the zero tangent chain: {summary:?}"
+    );
+    assert!(
+        summary.instruction_count <= 16,
+        "compiled eigvalsh VJP should stay compact after linearize+transpose: {summary:?}"
+    );
 }
 
 #[test]
@@ -1050,13 +1130,12 @@ fn eigvalsh_sum_grad_optimized_graph_is_structurally_compact() {
             ("DotGeneral", 2),
             ("EmbedDiag", 2),
             ("ExtractDiag", 1),
-            ("PadToMatch", 4),
             ("Reshape", 1),
             ("Transpose", 1),
             ("Tril", 1),
         ])
     );
-    assert_eq!(summary.total_ops, 15);
+    assert_eq!(summary.total_ops, 11);
 }
 
 #[test]
@@ -1089,13 +1168,12 @@ fn full_eigh_sum_grad_optimized_graph_is_structurally_compact() {
             ("EmbedDiag", 2),
             ("ExtractDiag", 1),
             ("Mul", 1),
-            ("PadToMatch", 4),
             ("Reshape", 2),
             ("Transpose", 1),
             ("Tril", 1),
         ])
     );
-    assert_eq!(summary.total_ops, 20);
+    assert_eq!(summary.total_ops, 16);
 }
 
 #[test]
@@ -1115,7 +1193,6 @@ fn qr_sum_grad_optimized_graph_is_structurally_compact() {
                 ("ExtractDiag", 1),
                 ("Mul", 1),
                 ("Neg", 1),
-                ("PadToMatch", 2),
                 ("Reshape", 2),
                 ("Transpose", 3),
                 ("Triu", 1),
@@ -1134,7 +1211,6 @@ fn qr_sum_grad_optimized_graph_is_structurally_compact() {
                 ("ExtractDiag", 1),
                 ("Mul", 1),
                 ("Neg", 3),
-                ("PadToMatch", 2),
                 ("Reshape", 2),
                 ("Transpose", 3),
                 ("Triu", 1),
@@ -1153,7 +1229,6 @@ fn qr_sum_grad_optimized_graph_is_structurally_compact() {
                 ("ExtractDiag", 1),
                 ("Mul", 1),
                 ("Neg", 1),
-                ("PadToMatch", 2),
                 ("Reshape", 2),
                 ("Transpose", 3),
                 ("Triu", 1),

--- a/crates/tenferro-runtime/src/graph/compiler.rs
+++ b/crates/tenferro-runtime/src/graph/compiler.rs
@@ -509,34 +509,6 @@ fn descriptor_for_input(
     if let Some(spec) = binding_specs.get(key) {
         return Ok(spec.clone());
     }
-    if !matches!(key, TensorInputKey::User { .. }) {
-        let root = tangent_primal_root(key);
-        if let Some(tensor) = default_inputs.get(root) {
-            return Ok(InputDescriptor {
-                key: key.clone(),
-                dtype: tensor.dtype(),
-                shape: tensor.shape().to_vec(),
-                default_tensor: Some(Arc::new(zeros_tensor(
-                    tensor.dtype(),
-                    tensor.shape().to_vec(),
-                )?)),
-            });
-        }
-        if let Some(spec) = binding_specs.get(root) {
-            return Ok(InputDescriptor {
-                key: key.clone(),
-                dtype: spec.dtype,
-                shape: spec.shape.clone(),
-                default_tensor: spec
-                    .default_tensor
-                    .as_ref()
-                    .map(|tensor| {
-                        zeros_tensor(tensor.dtype(), tensor.shape().to_vec()).map(Arc::new)
-                    })
-                    .transpose()?,
-            });
-        }
-    }
     Err(Error::UnboundPlaceholder {
         input_key: format!("{:?}", key),
     })
@@ -567,38 +539,6 @@ fn default_slices_equivalent<T: TensorScalar + PartialEq>(lhs: &Tensor, rhs: &Te
         // Arc<Tensor> is considered equivalent by `default_tensors_equivalent`.
         _ => false,
     }
-}
-
-fn tangent_primal_root(key: &TensorInputKey) -> &TensorInputKey {
-    key.primal_root()
-}
-
-fn zeros_tensor(dtype: DType, shape: Vec<usize>) -> Result<Tensor> {
-    match dtype {
-        DType::F32 => Ok(Tensor::F32(tenferro_tensor::TypedTensor::zeros(shape)?)),
-        DType::F64 => Ok(Tensor::F64(tenferro_tensor::TypedTensor::zeros(shape)?)),
-        DType::I32 => Ok(Tensor::I32(tenferro_tensor::TypedTensor::zeros(shape)?)),
-        DType::I64 => Ok(Tensor::I64(tenferro_tensor::TypedTensor::zeros(shape)?)),
-        DType::Bool => {
-            let len = checked_default_element_count(&shape)?;
-            Ok(Tensor::Bool(
-                tenferro_tensor::TypedTensor::from_vec_col_major(shape, vec![false; len])?,
-            ))
-        }
-        DType::C32 => Ok(Tensor::C32(tenferro_tensor::TypedTensor::zeros(shape)?)),
-        DType::C64 => Ok(Tensor::C64(tenferro_tensor::TypedTensor::zeros(shape)?)),
-    }
-}
-
-fn checked_default_element_count(shape: &[usize]) -> Result<usize> {
-    shape.iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim)
-            .ok_or_else(|| Error::InvalidCompiledGraph {
-                message: format!(
-                    "default tensor shape product overflows usize for shape {shape:?}"
-                ),
-            })
-    })
 }
 
 #[cfg(test)]

--- a/crates/tenferro-runtime/src/graph/executor/tests.rs
+++ b/crates/tenferro-runtime/src/graph/executor/tests.rs
@@ -59,6 +59,67 @@ fn borrowed_input_value_execution_retains_workspace_and_lazy_output() {
 }
 
 #[test]
+fn single_value_wrappers_preserve_lazy_outputs_and_debug_state() {
+    let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let y = x.transpose(&[1, 0]).unwrap();
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(&y).unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+
+    let debug = format!("{executor:?}");
+    assert!(debug.contains("GraphExecutor"));
+    assert!(debug.contains("backend_type"));
+
+    let value = executor.run_value(&program).unwrap();
+    assert!(matches!(value, TensorValue::View(_)));
+    assert_eq!(value.shape(), &[2, 2]);
+
+    let placeholder = TracedTensor::input_symbolic_shape(DType::F64, 2).unwrap();
+    let transposed = placeholder.transpose(&[1, 0]).unwrap();
+    let program = compiler
+        .compile_with_input_specs(&transposed, &[(&placeholder, DType::F64, &[2, 2])])
+        .unwrap();
+    let bound =
+        Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
+
+    let value = executor
+        .run_value_with_inputs(&program, &[(&placeholder, &bound)])
+        .unwrap();
+    assert!(matches!(value, TensorValue::View(_)));
+    assert_eq!(value.shape(), &[2, 2]);
+
+    let value = executor
+        .run_value_with_input_reads(&program, &[(&placeholder, TensorRead::from_tensor(&bound))])
+        .unwrap();
+    assert!(matches!(value, TensorValue::View(_)));
+    assert_eq!(value.shape(), &[2, 2]);
+
+    executor.reclaim_value_outputs(vec![TensorValue::from_tensor(
+        Tensor::from_vec_col_major(vec![1], vec![9.0_f64]).unwrap(),
+    )]);
+}
+
+#[test]
+fn deferred_zero_tensor_covers_supported_dtypes_and_overflow() {
+    for dtype in [
+        DType::F32,
+        DType::F64,
+        DType::I32,
+        DType::I64,
+        DType::Bool,
+        DType::C32,
+        DType::C64,
+    ] {
+        let zero = super::zeros_tensor(dtype, vec![2]).unwrap();
+        assert_eq!(zero.dtype(), dtype);
+        assert_eq!(zero.shape(), &[2]);
+    }
+
+    let err = super::zeros_tensor(DType::Bool, vec![usize::MAX, 2]).unwrap_err();
+    assert!(matches!(err, Error::InvalidCompiledGraph { .. }));
+}
+
+#[test]
 fn borrowed_input_workspace_does_not_retype_static_slot_vec() {
     let source = include_str!("../executor.rs");
 

--- a/crates/tenferro-runtime/src/metadata.rs
+++ b/crates/tenferro-runtime/src/metadata.rs
@@ -230,6 +230,34 @@ fn graph_metadata_registrations(
     let mut known: HashMap<ValueKey<StdTensorOp>, TensorMeta> = seeded.iter().cloned().collect();
 
     let mut registrations = seeded;
+    let mut visited = HashSet::new();
+    append_graph_metadata_registrations(
+        graph,
+        live_values,
+        &mut known,
+        &mut registrations,
+        &mut visited,
+    )?;
+
+    Ok(registrations)
+}
+
+fn append_graph_metadata_registrations(
+    graph: &Graph<StdTensorOp>,
+    live_values: Option<&HashSet<LocalValueId>>,
+    known: &mut HashMap<ValueKey<StdTensorOp>, TensorMeta>,
+    registrations: &mut Vec<(ValueKey<StdTensorOp>, TensorMeta)>,
+    visited: &mut HashSet<*const Graph<StdTensorOp>>,
+) -> Result<()> {
+    let graph_ptr: *const Graph<StdTensorOp> = graph;
+    if !visited.insert(graph_ptr) {
+        return Ok(());
+    }
+
+    for parent in graph.parents() {
+        append_graph_metadata_registrations(parent, None, known, registrations, visited)?;
+    }
+
     for op_node in graph.operations() {
         if let Some(live_values) = live_values {
             if !op_node
@@ -269,7 +297,7 @@ fn graph_metadata_registrations(
         }
     }
 
-    Ok(registrations)
+    Ok(())
 }
 
 fn infer_output_metas(op: &StdTensorOp, input_metas: &[TensorMeta]) -> Result<Vec<TensorMeta>> {

--- a/docs/architecture/ad-pipeline.md
+++ b/docs/architecture/ad-pipeline.md
@@ -153,7 +153,12 @@ graph transform artifacts only:
 
 - eager `RecordedGraph` linearization;
 - traced JVP linearized/optimized graphs;
-- traced VJP linearized graphs plus optimized transposed graphs.
+- traced VJP residual graphs plus optimized transposed graphs.
+
+VJP cache entries deliberately do not retain the strictly-linear tangent sweep
+after `linear_transpose` has run. The optimized transposed graph may reference
+residual values, so the residual graph is the graph part that remains live as
+an `extra_roots` input to materialization.
 
 The default limit is 128 entries and 64 MiB of logical retained bytes. Users can
 query, configure, and clear it through
@@ -442,13 +447,17 @@ In practice:
 
 ### `linearize`
 
-`linearize` consumes a resolved view and returns a new linear graph.
+`linearize` consumes a resolved view and returns a split linearized graph.
 
 ```rust
+use std::sync::Arc;
+
 struct LinearizedGraph<Op> {
-    graph: Graph<Op>,
+    linear: Graph<Op>,
+    residual: Arc<Graph<Op>>,
     tangent_inputs: Vec<(InputKey, LocalValueId)>,
     tangent_outputs: Vec<Option<LocalValueId>>,
+    linear_primals: Vec<Option<ValueKey<Op>>>,
 }
 
 fn linearize<Op: Primitive>(
@@ -463,7 +472,8 @@ Important consequences:
 - callers specify **which primal inputs** they linearize with respect to
 - tangent inputs are created **inside the returned graph**
 - those tangent inputs receive fresh `InputKey`s and are returned to the caller
-- primal values are referenced by `External(ValueKey)`, not copied
+- primal and metadata values are held in the residual graph and referenced by
+  `External(ValueKey)`, not copied into the strictly-linear graph
 
 Algorithm sketch:
 
@@ -471,8 +481,9 @@ Algorithm sketch:
 1. Traverse the reachable logical DAG in topological order.
 2. Seed tangent inputs for the requested primal InputKeys.
 3. For each reachable primitive, call its linearization rule.
-4. Emit new local linear nodes into the new graph.
-5. Reference primal values through External(ValueKey).
+4. Emit tangent-flow nodes into the strictly-linear graph.
+5. Put residual values into the residual graph and reference them through
+   External(ValueKey).
 6. Skip unreachable tangent flow with zero propagation.
 ```
 
@@ -506,8 +517,8 @@ The design rule is:
 
 ### `linear_transpose`
 
-`linear_transpose` consumes a linear graph and produces another linear graph with
-active inputs and outputs reversed.
+`linear_transpose` consumes a linearized graph and produces another split
+linearized graph with active inputs and outputs reversed.
 
 ```rust
 fn linear_transpose<Op: Primitive>(
@@ -518,11 +529,17 @@ fn linear_transpose<Op: Primitive>(
 It does not linearize again. It reuses the same local linear rules with
 direction reversed.
 
-`tidu::linear_transpose` is generic. It traverses the linear graph in reverse
-topological order and, for each op node, calls `Op::transpose_rule` to obtain
-the local transposed contribution. `tidu` does not know which primitives
+`tidu::linear_transpose` is generic. It traverses the strictly-linear graph in
+reverse topological order and, for each op node, calls `Op::transpose_rule` to
+obtain the local transposed contribution. `tidu` does not know which primitives
 exist; it only requires that every op in the linear graph implements
 `Primitive::transpose_rule`.
+
+Transpose rules receive `PrimitiveTransposeInput` values. A residual input is
+an ordinary fixed operand. A linear input belongs to tangent flow; if tidu knows
+the primal counterpart, the rule may use that primal only for metadata, runtime
+shape sources, or fixed coefficients. A linear input without a primal must not
+be treated as an ordinary residual operand.
 
 Transpose accumulation must use global identity. When multiple reverse
 contributions flow back to the same original tangent node, bucket by the

--- a/docs/architecture/tidu.md
+++ b/docs/architecture/tidu.md
@@ -24,16 +24,21 @@ the same downstream primitive vocabulary.
 
 ### `linearize`
 
-Consumes a resolved view and returns a new linear graph (JVP).
+Consumes a resolved view and returns a new linearized graph (JVP). The returned
+value separates the strictly-linear tangent sweep from residual values
+referenced by that sweep.
 
 ```rust
 use computegraph::{ResolvedView, ValueKey, LocalValueId, Graph};
+use std::sync::Arc;
 use tidu::Primitive;
 
 struct LinearizedGraph<Op> {
-    graph: Graph<Op>,
+    linear: Graph<Op>,
+    residual: Arc<Graph<Op>>,
     tangent_inputs: Vec<(Op::InputKey, LocalValueId)>,
     tangent_outputs: Vec<Option<LocalValueId>>,
+    linear_primals: Vec<Option<ValueKey<Op>>>,
 }
 
 fn linearize<Op: Primitive>(
@@ -53,8 +58,9 @@ Algorithm:
 2. Seed tangent inputs for the requested primal `InputKey`s
    (keys generated via `ADKey::tangent_of`).
 3. For each reachable primitive, call `Op::linearize`.
-4. Emit new local linear nodes into the new graph.
-5. Reference primal values through `External(ValueKey)`.
+4. Emit tangent-flow nodes into the strictly-linear graph.
+5. Put residual values into the residual graph and reference them through
+   `External(ValueKey)`.
 6. Skip unreachable tangent flow with zero propagation.
 
 This is the graph-level analogue of JAX building a jaxpr whose linearized
@@ -62,8 +68,8 @@ body is itself a composition of primitives.
 
 ### `linear_transpose`
 
-Consumes a linear graph and produces another with active inputs and outputs
-reversed.
+Consumes a linearized graph and produces another with active inputs and
+outputs reversed.
 
 ```rust
 fn linear_transpose<Op: Primitive>(
@@ -71,8 +77,25 @@ fn linear_transpose<Op: Primitive>(
 ) -> LinearizedGraph<Op>;
 ```
 
-Traverses the linear graph in reverse topological order and, for each op
-node, calls `Op::transpose_rule` to obtain the local transposed contribution.
+Traverses the strictly-linear graph in reverse topological order and, for each
+op node, calls `Op::transpose_rule` to obtain the local transposed
+contribution.
+
+`transpose_rule` receives typed inputs:
+
+```rust
+enum PrimitiveTransposeInput<Op> {
+    Residual(ValueKey<Op>),
+    Linear { key: ValueKey<Op>, primal: Option<ValueKey<Op>> },
+}
+```
+
+Residual inputs are ordinary fixed operands. Linear inputs belong to tangent
+flow and must not be retained as tensor operands in the transposed graph. When
+`primal` is available, downstream primitive sets may use it for metadata,
+runtime shape sources, or fixed coefficients that are independent of the
+tangent flow. A `Linear { primal: None, .. }` input must not be collapsed into
+a residual `ValueRef`.
 
 Transpose accumulation must use global identity: when multiple reverse
 contributions flow back to the same original tangent node, bucket by the
@@ -90,7 +113,7 @@ primitive implementors do not need to implement `Dup`.
 
 ```rust
 fn linear_transpose<Op: Primitive>(linear: &LinearizedGraph<Op>) -> LinearizedGraph<Op> {
-    let mut builder = GraphBuilder::new();
+    let mut builder = SplitGraphBuilder::new();
     let mut ct_env: HashMap<ValueKey<Op>, LocalValueId> = HashMap::new();
 
     // 1. Seed cotangent outputs
@@ -105,15 +128,19 @@ fn linear_transpose<Op: Primitive>(linear: &LinearizedGraph<Op>) -> LinearizedGr
             .map(|out_id| ct_env.get(&global_key(out_id)).copied())
             .collect();
 
+        let rule_inputs = op_node.inputs.iter()
+            .map(|input| classify_transpose_input(linear, input))
+            .collect::<Vec<_>>();
+
         // Delegate to per-op linear_transpose rule
         let ct_ins = op_node.operation.transpose_rule(
-            &mut builder, &ct_outs, &op_node.inputs, &op_node.role,
+            &mut builder, &ct_outs, &rule_inputs, &op_node.role,
         );
 
         // 3. Accumulate cotangents by ValueKey
-        for (input, ct_in) in op_node.inputs.iter().zip(ct_ins) {
+        for (input, ct_in) in rule_inputs.iter().zip(ct_ins) {
             if let Some(ct) = ct_in {
-                let key = global_key_of(input);
+                let key = input.key();
                 match ct_env.entry(key) {
                     Vacant(e)  => { e.insert(ct); }
                     Occupied(e) => {
@@ -130,7 +157,7 @@ fn linear_transpose<Op: Primitive>(linear: &LinearizedGraph<Op>) -> LinearizedGr
             }
         }
     }
-    // Build transposed LinearizedGraph from builder + ct_env
+    // Build transposed LinearizedGraph from split builder + ct_env
 }
 ```
 
@@ -319,7 +346,7 @@ tidu-rs owns:
   - Primitive trait
   - linearize (JVP transform)
   - linear_transpose (reverse linear flow)
-  - LinearizedGraph data structure
+  - LinearizedGraph split between strictly-linear and residual graphs
 
 tidu-rs does NOT own:
   - graph infrastructure → computegraph-rs

--- a/docs/spec/ad-contract.md
+++ b/docs/spec/ad-contract.md
@@ -54,7 +54,7 @@ where
         &self,
         builder: &mut impl PrimitiveBuilder<Self>,
         cotangent_outputs: &[Option<LocalValueId>],
-        inputs: &[PrimitiveValue<Self>],
+        inputs: &[PrimitiveTransposeInput<Self>],
         role: &OperationRole,
         ctx: &mut Self::ADContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>>
@@ -81,6 +81,35 @@ pub trait ADKey: Clone + Debug + Hash + Eq + Send + Sync + 'static {
 
 `DiffPassId` is `u64`.
 
+## PrimitiveTransposeInput (canonical definition)
+
+Defined in `tidu-rs/src/rules/primitive_builder.rs`. `linear_transpose`
+passes these typed input references to primitive transpose rules so rules can
+distinguish residual operands from tangent-flow operands.
+
+```rust
+pub enum PrimitiveTransposeInput<Op: GraphOperation> {
+    Residual(ValueKey<Op>),
+    Linear {
+        key: ValueKey<Op>,
+        primal: Option<ValueKey<Op>>,
+    },
+}
+
+impl<Op: GraphOperation> PrimitiveTransposeInput<Op> {
+    pub fn key(&self) -> &ValueKey<Op>;
+    pub fn primal(&self) -> Option<&ValueKey<Op>>;
+    pub fn as_residual_value(&self) -> Option<PrimitiveValue<Op>>;
+}
+```
+
+`Residual` inputs are independent of the differentiated tangent flow and may be
+used as ordinary rule operands. `Linear` inputs belong to tangent flow; their
+`key` identifies the linearized value and `primal` identifies the corresponding
+primal value when tidu can recover one. Downstream primitive sets must not
+blindly convert a `Linear { primal: None, .. }` input into an ordinary residual
+operand, because doing so retains the tangent sweep in the transposed graph.
+
 ## LinearizedGraph (canonical definition)
 
 Defined in `tidu-rs/src/linearized_graph.rs`. Returned by
@@ -90,18 +119,35 @@ per operation node — note that `jvp_rule` itself returns
 assembled by `linearize`).
 
 ```rust
+use std::sync::Arc;
+
 pub struct LinearizedGraph<Op: GraphOperation> {
-    graph: Graph<Op>,
+    linear: Graph<Op>,
+    residual: Arc<Graph<Op>>,
     tangent_inputs: Vec<(Op::InputKey, LocalValueId)>,
     tangent_outputs: Vec<Option<LocalValueId>>,
+    linear_primals: Vec<Option<ValueKey<Op>>>,
 }
 
 impl<Op: GraphOperation> LinearizedGraph<Op> {
+    /// Borrow the strictly-linear graph representation.
     pub fn as_graph(&self) -> &Graph<Op>;
+    /// Borrow the residual graph referenced by the linear graph.
+    pub fn residual_graph(&self) -> &Graph<Op>;
+    /// Consume this value and return the strictly-linear graph representation.
+    pub fn into_graph(self) -> Graph<Op>;
+    /// Consume this value and return both graph parts.
+    pub fn into_graphs(self) -> (Graph<Op>, Arc<Graph<Op>>);
     pub fn tangent_inputs(&self) -> &[(Op::InputKey, LocalValueId)];
     pub fn tangent_outputs(&self) -> &[Option<LocalValueId>];
 }
 ```
+
+The strictly-linear graph is the only graph traversed by `linear_transpose`.
+The residual graph contains primal or metadata values referenced from that
+linear graph. Transform owners that cache VJP artifacts should retain the
+residual graph and optimized transposed graph, not the strictly-linear tangent
+sweep, unless they explicitly need to re-run `linear_transpose`.
 
 ## Rules
 
@@ -123,7 +169,15 @@ impl<Op: GraphOperation> LinearizedGraph<Op> {
    during `materialize_merge` so that shared primal computations are not
    duplicated.
 
-5. **Extension AD boundary**: built-in AD is defined for `StdTensorOp`.
+5. **Transpose input typing**: `transpose_rule` receives
+   `PrimitiveTransposeInput` values, not raw `ValueRef`s. Rules may use
+   residual inputs directly. Rules may use a linear input's `primal` only for
+   metadata, runtime shape sources, or fixed coefficients that are genuinely
+   independent of the tangent flow. A linear input without a primal counterpart
+   must be rejected at such a use site rather than smuggled into the residual
+   graph.
+
+6. **Extension AD boundary**: built-in AD is defined for `StdTensorOp`.
    `StdTensorOp::Extension` may participate in AD only when its operation
    family registers an extension AD rule. Missing extension rules must report
    unsupported AD; they must not silently drop or zero gradients.
@@ -176,11 +230,13 @@ runtimes created directly own a private cache. Direct `TracedTensorAdExt`
 methods remain stateless.
 
 The AD transform cache stores graph artifacts only: eager `RecordedGraph`
-linearization, traced JVP linearized/optimized graphs, and traced VJP
-linearized plus optimized transposed graphs. The default retention policy is
-bounded by both entry count and logical retained bytes. Owners expose limits,
-stats, and clear APIs through `AdContext` and `EagerRuntime`; retained-byte
-stats are logical estimates and do not report process RSS.
+linearization, traced JVP linearized/optimized graphs, and traced VJP residual
+graphs plus optimized transposed graphs. It must not keep the strictly-linear
+tangent sweep alive after a VJP transform has been transposed and optimized.
+The default retention policy is bounded by both entry count and logical
+retained bytes. Owners expose limits, stats, and clear APIs through `AdContext`
+and `EagerRuntime`; retained-byte stats are logical estimates and do not report
+process RSS.
 
 Cache keys must be deterministic, structural, and metadata-only. Eager keys
 cover the recorded graph fingerprint and requested output slots. Traced keys

--- a/docs/worklogs/2026-07-07-issue-1321-root-vjp-extra-roots.md
+++ b/docs/worklogs/2026-07-07-issue-1321-root-vjp-extra-roots.md
@@ -1,0 +1,131 @@
+# Issue 1321 Root VJP Extra Roots Fix
+
+## Summary
+
+This session fixed the traced VJP regression where the generic
+`linearize -> linear_transpose -> optimize` path could keep the original
+strictly-linear tangent sweep alive as a materialization root.
+
+The root cause had two parts:
+
+- tidu returned one `LinearizedGraph` graph that mixed strictly-linear tangent
+  values with residual values needed by later transposed graphs;
+- tenferro transpose rules received raw value references, so downstream rules
+  could accidentally treat a tangent-flow value as an ordinary fixed operand.
+
+The fix splits tidu linearized graphs into a strictly-linear graph and a
+residual graph, then changes tenferro to retain only the residual graph plus the
+optimized transposed graph for cached VJP execution. Transpose rules now receive
+typed inputs so residual, linear-with-primal, and linear-without-primal cases
+remain explicit at the operation-family boundary.
+
+## Context Read
+
+- GitHub issue #1321 and review comments
+- `HANDOFF.md`
+- `docs/worklogs/2026-07-06-lu-generic-vjp.md`
+- `docs/architecture/ad-pipeline.md`
+- `docs/architecture/tidu.md`
+- `docs/spec/ad-contract.md`
+- `crates/tenferro-ad/src/traced.rs`
+- `crates/tenferro-ad/src/transform_cache.rs`
+- `crates/tenferro-internal-ops/src/ad/`
+- `crates/tenferro-linalg/src/ad.rs`
+- `crates/tenferro-einsum/src/extension.rs`
+- `crates/tenferro-fft/src/lib.rs`
+
+## Decisions
+
+- Change tidu, not only tenferro call sites: `LinearizedGraph` now separates
+  `linear` and `residual`, and `PrimitiveTransposeInput` classifies each
+  transpose-rule input.
+- Register metadata for graph parent chains so cached residual graphs and
+  transposed graphs can recover symbolic shape sources without retaining the
+  tangent sweep.
+- Store traced VJP cache entries as residual graph plus optimized transposed
+  graph. Cache hits re-register residual metadata; final VJP materialization
+  pushes the residual graph as `extra_roots`, not the linear graph.
+- Remove production helpers that collapsed transpose inputs to raw `ValueRef`s.
+  Operation families must choose metadata-only, fixed-coefficient, or shape
+  source behavior explicitly for each input.
+- Keep primary extension VJP as an escape hatch for extension rules that still
+  intentionally consume primal values directly, but make linearized extension
+  transpose rules typed.
+
+## Rejected Alternatives
+
+- Do not reintroduce handwritten LU or Eigh VJP rules. The generic graph is
+  structurally compact once the tangent sweep is not retained.
+- Do not add LU- or Eigh-specific optimizer peepholes. The observed regression
+  was a transform ownership bug, not an algebraic simplification gap.
+- Do not patch `extra_roots` by filtering specific graph ids. The transform
+  artifact itself must expose which graph is residual and which graph is the
+  discardable tangent sweep.
+- Do not allow a `Linear { primal: None, .. }` input to become an external
+  tensor operand. Rules that need a fixed operand must have a residual value or
+  a known primal counterpart.
+
+## Benchmarks
+
+Benchmarks were run from the local tenferro-benchmark worktree using
+`PUBLICATION_GATE_FEATURES=cpu-faer`, trace mode, quick profile, and
+`CPU_OPS_BENCHMARK_FILTER=grad_sum_lu_vjp,grad_sum_eigh_vjp`. The local machine
+does not have the `/opt/openblas` setup used by the published Linux CPU report,
+so these are same-machine before/after checks rather than exact published
+report reproductions.
+
+Large suite, 1 thread, 5 runs, 2 warmups:
+
+- `grad_sum_eigh_vjp 256x256`: 10.487 ms -> 7.840 ms, 1.34x
+- `grad_sum_eigh_vjp 512x512`: 63.715 ms -> 47.664 ms, 1.34x
+- `grad_sum_lu_vjp 256x256`: 8.731 ms -> 5.395 ms, 1.62x
+- `grad_sum_lu_vjp 512x512`: 64.154 ms -> 37.052 ms, 1.73x
+
+Large suite, 4 threads, 5 runs, 2 warmups:
+
+- `grad_sum_eigh_vjp 256x256`: 13.784 ms -> 9.640 ms, 1.43x
+- `grad_sum_eigh_vjp 512x512`: 47.075 ms -> 32.738 ms, 1.44x
+- `grad_sum_lu_vjp 256x256`: 9.447 ms -> 6.590 ms, 1.43x
+- `grad_sum_lu_vjp 512x512`: 40.003 ms -> 26.311 ms, 1.52x
+
+Small suite, 1 thread, 30 runs, 5 warmups:
+
+- `grad_sum_eigh_vjp`: 1.40x to 2.30x faster across 2x2, 4x4, and 8x8
+- `grad_sum_lu_vjp`: 1.27x to 1.36x faster for 4x4 and 8x8; 2x2 was 0.062 ms
+  -> 0.069 ms with overlapping microbenchmark noise
+
+## Verification Performed
+
+- `cargo fmt --all --check`
+- `git diff --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo check -p tenferro-internal-ops --features autodiff`
+- `cargo check -p tenferro-einsum --features autodiff,cpu-faer`
+- `cargo check -p tenferro-fft --features autodiff,cpu-faer`
+- `cargo check -p tenferro-linalg --features autodiff,cpu-faer`
+- `cargo test -p tenferro-internal-ops --features autodiff -- --nocapture`
+- `cargo test -p tenferro-linalg --features autodiff,cpu-faer --test traced_ad_explicit sum_grad -- --nocapture`
+- `cargo test -p tenferro-linalg --features autodiff,cpu-faer --lib ad::tests -- --nocapture`
+- `cargo test -p tenferro-einsum --features autodiff,cpu-faer linear_transpose -- --nocapture`
+- `cargo test -p tenferro-einsum --features autodiff,cpu-faer --test traced_ad_migration -- --nocapture`
+- `cargo test -p tenferro-fft --features autodiff,cpu-faer -- --nocapture`
+- `cargo test -p tenferro-ad --test extension_op -- --nocapture`
+- `cargo test -p tenferro-ad --release --test ad`
+- `cargo test -p tenferro-ad --release --test ad_structural_primitives`
+- `cargo test -p tenferro-ad --release --test dynamic_truncate`
+- `cargo test -p tenferro-einsum --release --test public_surface_contract`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+
+## Residual Risks
+
+- Local benchmarks used `cpu-faer`, not the published `system-openblas` profile.
+  The same root fix should be remeasured in the publication environment before
+  regenerating public reports.
+- The typed transpose input boundary now covers core, linalg, einsum, FFT, and
+  extension tests touched by this change. New operation families must continue
+  the same pattern instead of reintroducing raw transpose input collapse.

--- a/ext/sparse/Cargo.toml
+++ b/ext/sparse/Cargo.toml
@@ -24,7 +24,7 @@ tenferro-internal-ops = { path = "../../crates/tenferro-internal-ops", default-f
 tenferro-runtime = { path = "../../crates/tenferro-runtime", default-features = false }
 tenferro-tensor = { path = "../../crates/tenferro-tensor", default-features = false }
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7" }
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "998dbac4ca24442433ab9a52a182040dda2d8eea" }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "57a2e7ebe7738ca2f8b5c96f4c6ce4e467b20495" }
 
 [dev-dependencies]
 tenferro-ad = { path = "../../crates/tenferro-ad", default-features = false, features = ["cpu-faer"] }

--- a/ext/sparse/src/extension.rs
+++ b/ext/sparse/src/extension.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 #[cfg(feature = "autodiff")]
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 #[cfg(feature = "autodiff")]
-use tenferro_ops::ad::PrimitiveRuleBuilder;
+use tenferro_ops::ad::{transpose_input::TransposeInputRef, PrimitiveRuleBuilder};
 #[cfg(feature = "autodiff")]
 use tenferro_ops::{
     ExtensionLinearTransposeRule, ExtensionLinearizeRule, ExtensionRegistryError,
@@ -24,7 +24,7 @@ use tenferro_runtime::extension::{
 use tenferro_runtime::{Error as RuntimeError, Result as RuntimeResult};
 use tenferro_tensor::{DType, Error, Result, Tensor, TensorBackend};
 #[cfg(feature = "autodiff")]
-use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult, PrimitiveTransposeInput};
 
 use crate::sparse::{
     coordinates_tensor, validate_traced_values, validate_value_tensor, SparseCooTracedTensor,
@@ -502,14 +502,17 @@ impl ExtensionLinearTransposeRule for SparseMatmulJvpAdRule {
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        inputs: &[ValueRef<StdTensorOp>],
+        inputs: &[PrimitiveTransposeInput<StdTensorOp>],
         active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_jvp_op(op, ADRuleKind::Transpose)?;
+        let inputs: Vec<_> = inputs.iter().map(TransposeInputRef::new).collect();
         let Some(ct) = cotangent_out.first().copied().flatten() else {
             return Ok(vec![None; op.input_count()]);
         };
+        let lhs = inputs[0].fixed_value("sparse matmul VJP", 0)?;
+        let rhs = inputs[1].fixed_value("sparse matmul VJP", 1)?;
         let mut result = vec![None; op.input_count()];
         for (active_pos, &active_input) in op.active_inputs.iter().enumerate() {
             let tangent_input_idx = 2 + active_pos;
@@ -521,7 +524,7 @@ impl ExtensionLinearTransposeRule for SparseMatmulJvpAdRule {
                     plan: op.plan.clone(),
                     active_input,
                 })),
-                vec![inputs[0].clone(), inputs[1].clone(), ValueRef::Local(ct)],
+                vec![lhs.clone(), rhs.clone(), ValueRef::Local(ct)],
                 OperationRole::Linearized {
                     active_mask: vec![false, false, true],
                 },
@@ -673,20 +676,20 @@ fn validate_primal_inputs(plan: &SparseMatmulPlan, inputs: &[&Tensor]) -> Result
 }
 
 #[cfg(feature = "autodiff")]
-fn downcast_matmul_op<'a>(
-    op: &'a dyn ExtensionOp,
+fn downcast_matmul_op(
+    op: &dyn ExtensionOp,
     rule: ADRuleKind,
-) -> ADRuleResult<&'a SparseMatmulOp> {
+) -> ADRuleResult<&SparseMatmulOp> {
     op.as_any()
         .downcast_ref::<SparseMatmulOp>()
         .ok_or_else(|| ADRuleError::unsupported(FAMILY_ID, rule))
 }
 
 #[cfg(feature = "autodiff")]
-fn downcast_jvp_op<'a>(
-    op: &'a dyn ExtensionOp,
+fn downcast_jvp_op(
+    op: &dyn ExtensionOp,
     rule: ADRuleKind,
-) -> ADRuleResult<&'a SparseMatmulJvpOp> {
+) -> ADRuleResult<&SparseMatmulJvpOp> {
     op.as_any()
         .downcast_ref::<SparseMatmulJvpOp>()
         .ok_or_else(|| ADRuleError::unsupported(JVP_FAMILY_ID, rule))

--- a/ext/tropical/Cargo.toml
+++ b/ext/tropical/Cargo.toml
@@ -31,7 +31,7 @@ tenferro-internal-ops = { path = "../../crates/tenferro-internal-ops", default-f
 tenferro-runtime = { path = "../../crates/tenferro-runtime" }
 tenferro-tensor = { path = "../../crates/tenferro-tensor" }
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7", optional = true }
-tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "998dbac4ca24442433ab9a52a182040dda2d8eea", optional = true }
+tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "57a2e7ebe7738ca2f8b5c96f4c6ce4e467b20495", optional = true }
 num-traits = "0.2"
 tropical-gemm = { version = "0.2", default-features = false, optional = true }
 

--- a/ext/tropical/src/extension.rs
+++ b/ext/tropical/src/extension.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_einsum::Subscripts;
 #[cfg(feature = "autodiff")]
-use tenferro_ops::ad::PrimitiveRuleBuilder;
+use tenferro_ops::ad::{transpose_input::TransposeInputRef, PrimitiveRuleBuilder};
 #[cfg(feature = "autodiff")]
 use tenferro_ops::ext_op::{ExtensionLinearTransposeRule, ExtensionLinearizeRule};
 use tenferro_ops::ext_op::{ExtensionOp, HostReference};
@@ -23,7 +23,7 @@ use tenferro_tensor::{DType, Tensor, TensorBackend};
 #[cfg(feature = "autodiff")]
 use tenferro_tensor::TensorScalar;
 #[cfg(feature = "autodiff")]
-use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
+use tidu::{ADRuleError, ADRuleKind, ADRuleResult, PrimitiveTransposeInput};
 
 use crate::einsum::tropical_einsum_subscripts_with_argmax;
 #[cfg(feature = "autodiff")]
@@ -498,15 +498,18 @@ impl ExtensionLinearTransposeRule for TropicalEinsumJvpAdRule {
         op: &dyn ExtensionOp,
         builder: &mut dyn PrimitiveRuleBuilder,
         cotangent_out: &[Option<LocalValueId>],
-        inputs: &[ValueRef<StdTensorOp>],
+        inputs: &[PrimitiveTransposeInput<StdTensorOp>],
         active_mask: &[bool],
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let op = downcast_jvp_op(op, ADRuleKind::Transpose)?;
         validate_ad_supported(&op.subscripts, ADRuleKind::Transpose)?;
+        let inputs: Vec<_> = inputs.iter().map(TransposeInputRef::new).collect();
         let Some(ct) = cotangent_out.first().copied().flatten() else {
             return Ok(vec![None; op.input_count()]);
         };
+        let lhs = inputs[0].fixed_value("tropical einsum VJP", 0)?;
+        let rhs = inputs[1].fixed_value("tropical einsum VJP", 1)?;
 
         let mut result = vec![None; op.input_count()];
         for (active_pos, &active_input) in op.active_inputs.iter().enumerate() {
@@ -520,7 +523,7 @@ impl ExtensionLinearTransposeRule for TropicalEinsumJvpAdRule {
                     op.subscripts.clone(),
                     active_input,
                 ))),
-                vec![inputs[0].clone(), inputs[1].clone(), ValueRef::Local(ct)],
+                vec![lhs.clone(), rhs.clone(), ValueRef::Local(ct)],
                 OperationRole::Linearized {
                     active_mask: vec![false, false, true],
                 },
@@ -678,7 +681,7 @@ where
             *out_value += *tangent_value;
         }
     }
-    Ok(Tensor::from_vec_col_major(output_shape, out)?)
+    Tensor::from_vec_col_major(output_shape, out)
 }
 
 #[cfg(feature = "autodiff")]
@@ -718,7 +721,7 @@ where
         })?;
         *slot += ct;
     }
-    Ok(Tensor::from_vec_col_major(active_shape, out)?)
+    Tensor::from_vec_col_major(active_shape, out)
 }
 
 #[cfg(feature = "autodiff")]


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1321

## Summary

This fixes the root cause behind the traced `grad_sum_lu_vjp` / `grad_sum_eigh_vjp` regression: the generic VJP path kept the whole linearized tangent graph alive through `extra_roots`, so final VJP graphs retained forward/JVP work that should have been residual-only.

The fix follows the split-linearization contract from tidu `57a2e7ebe7738ca2f8b5c96f4c6ce4e467b20495`:

- cache and attach only the residual graph as VJP `extra_roots`, while keeping the optimized transposed graph as the executable transpose body
- register metadata through parent graph chains so residual-only roots still resolve shape metadata
- replace flattened transpose inputs with typed `PrimitiveTransposeInput`/`TransposeInputRef`, preserving the distinction between linear, residual, and fixed operands instead of collapsing them back to `ValueRef`
- prefill eager backward residual graph values before building the transposed eager rule
- update linalg/einsum/fft extension transpose rules to use the typed boundary and add regression coverage for symbolic shape-source handling

Same-root-cause scan covered core AD rules, linalg, einsum, fft, traced VJP caching, eager backward replay, graph executor zero tangent synthesis, and extension transpose API tests.

## Work log

- `docs/worklogs/2026-07-07-issue-1321-root-vjp-extra-roots.md`

## Benchmarks

Local quick benchmarks were run with `PUBLICATION_GATE_FEATURES=cpu-faer` because this machine does not have the benchmark repo's `/opt/openblas` setup. Same-machine before/after results show the retained tangent graph work is removed from the traced VJP path:

| case | baseline | fixed | speedup |
| --- | ---: | ---: | ---: |
| `grad_sum_eigh_vjp`, 256, t1 | 10.487 ms | 7.840 ms | 1.34x |
| `grad_sum_eigh_vjp`, 512, t1 | 63.715 ms | 47.664 ms | 1.34x |
| `grad_sum_lu_vjp`, 256, t1 | 8.731 ms | 5.395 ms | 1.62x |
| `grad_sum_lu_vjp`, 512, t1 | 64.154 ms | 37.052 ms | 1.73x |
| `grad_sum_eigh_vjp`, 256, t4 | 13.784 ms | 9.640 ms | 1.43x |
| `grad_sum_eigh_vjp`, 512, t4 | 47.075 ms | 32.738 ms | 1.44x |
| `grad_sum_lu_vjp`, 256, t4 | 9.447 ms | 6.590 ms | 1.43x |
| `grad_sum_lu_vjp`, 512, t4 | 40.003 ms | 26.311 ms | 1.52x |

Small-shape `eigh` improved by 1.40x-2.30x; small-shape `lu` improved for 4x4/8x8, while 2x2 stayed in microbenchmark-noise territory.

## Verification

- [x] `cargo fmt --all --check`
- [x] `git diff --check HEAD`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- [x] `cargo test --workspace --release`
- [x] `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- [x] `python3 scripts/check-coverage.py coverage.json` (`146/146 files passed`)
- [x] `cargo doc --workspace --no-deps`
- [x] `python3 scripts/check-docs-site.py`
- [x] `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json` (`Verdict: pass`)

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. Not applicable: bug fix for existing AD behavior.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.