### PR TITLE
Enforce AD graph-emission invariants

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -319,6 +319,12 @@ rules from `tensor4all-agent-rules`.
   Exact-shape requirements are appropriate only when constructing a concrete
   op payload that cannot represent runtime dimensions; handle non-exact
   metadata conservatively instead of reinterpreting bounds as sizes.
+- AD graph-emission invariants must be enforced by API shape or structural
+  tests, not prose alone. Constant, zero, one, and identity construction in AD
+  rules should use the semantic helpers in `tenferro_ops::ad::support`; tests
+  such as `identity_matrix_helper_emits_semantic_constant_and_remaps_shape_source`
+  and `identity_matrix_fixed_uses_semantic_constant_not_analytic_shortcut`
+  guard against analytic constant shortcuts reappearing.
 - Reference JAX's implementations (`jax/_src/lax/lax.py`, `jax/_src/lax/linalg.py`)
   when implementing new AD rules.
 

--- a/ai/contribution-workflows/repository-remediation.md
+++ b/ai/contribution-workflows/repository-remediation.md
@@ -157,6 +157,10 @@ Search at least:
 - the same trait or generated wrapper family;
 - adjacent docs section or guide;
 - equivalent CPU/GPU/eager/traced wrappers when the pattern is shared.
+- when landing a canonical constructor, helper, backend capability, AD
+  transform contract, or other replacement path, grep for workaround patterns
+  it obsoletes and either remove them in the same PR or file a concrete
+  follow-up issue linked from the PR body.
 
 Fix nearby same-root-cause instances in the same batch when they have the same
 contract and verification path. Stop expanding when the search reaches another

--- a/crates/tenferro-internal-ops/src/ad/support.rs
+++ b/crates/tenferro-internal-ops/src/ad/support.rs
@@ -5,6 +5,7 @@ use tidu::ADRuleResult;
 
 use crate::ad::context::ShapeGuardContext;
 use crate::ad::PrimitiveRuleBuilder;
+use crate::dim_expr::DimExpr;
 use crate::std_tensor_op::StdTensorOp;
 
 /// AD rule support status for a core primitive operation.
@@ -169,6 +170,99 @@ pub fn primitive_ad_support(kind: PrimitiveOpKind) -> &'static PrimitiveAdSuppor
 /// ```
 pub fn is_real_dtype(dtype: DType) -> bool {
     matches!(dtype, DType::F32 | DType::F64)
+}
+
+fn dim_expr_uses_only_input(expr: &DimExpr, expected_input_idx: usize) -> bool {
+    match expr {
+        DimExpr::Const(_) => true,
+        DimExpr::InputDim { input_idx, .. } => *input_idx == expected_input_idx,
+        DimExpr::Add(a, b)
+        | DimExpr::Sub(a, b)
+        | DimExpr::Mul(a, b)
+        | DimExpr::FloorDiv(a, b)
+        | DimExpr::Min(a, b)
+        | DimExpr::Max(a, b) => {
+            dim_expr_uses_only_input(a, expected_input_idx)
+                && dim_expr_uses_only_input(b, expected_input_idx)
+        }
+    }
+}
+
+#[doc(hidden)]
+pub fn constant_scalar(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    dtype: DType,
+    bytes: Vec<u8>,
+) -> LocalValueId {
+    builder.add_operation(
+        StdTensorOp::Constant { dtype, bytes },
+        vec![],
+        OperationRole::Primary,
+    )[0]
+}
+
+#[doc(hidden)]
+pub fn zero_like(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    dtype: DType,
+    anchor: ValueRef<StdTensorOp>,
+    anchor_rank: usize,
+) -> LocalValueId {
+    super::zeros::build_zero_like(builder, dtype, anchor, anchor_rank)
+}
+
+#[doc(hidden)]
+pub fn one_like(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    dtype: DType,
+    anchor: ValueRef<StdTensorOp>,
+    anchor_rank: usize,
+) -> LocalValueId {
+    super::zeros::build_one_like(builder, dtype, anchor, anchor_rank)
+}
+
+#[doc(hidden)]
+pub fn identity_matrix(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    dtype: DType,
+    size: usize,
+    batch_shape: &[DimExpr],
+    shape_source: ValueRef<StdTensorOp>,
+    shape_source_idx: usize,
+) -> LocalValueId {
+    let one = one_like(builder, dtype, shape_source.clone(), 0);
+    let mut shape = Vec::with_capacity(1 + batch_shape.len());
+    shape.push(DimExpr::Const(size));
+    shape.extend_from_slice(batch_shape);
+
+    let mut inputs = vec![ValueRef::Local(one)];
+    if DimExpr::max_input_idx_all(&shape).is_some() {
+        assert!(
+            shape
+                .iter()
+                .all(|expr| dim_expr_uses_only_input(expr, shape_source_idx)),
+            "identity_matrix shape expressions must reference only the provided shape_source_idx"
+        );
+        shape = DimExpr::remap_all(&shape, shape_source_idx, 1);
+        inputs.push(shape_source);
+    }
+
+    let ones = builder.add_operation(
+        StdTensorOp::BroadcastInDim {
+            shape,
+            dims: vec![],
+        },
+        inputs,
+        OperationRole::Primary,
+    )[0];
+    builder.add_operation(
+        StdTensorOp::EmbedDiag {
+            axis_a: 0,
+            axis_b: 1,
+        },
+        vec![ValueRef::Local(ones)],
+        OperationRole::Primary,
+    )[0]
 }
 
 pub(crate) fn is_differentiable_dtype(dtype: DType) -> bool {

--- a/crates/tenferro-internal-ops/src/ad/support/tests.rs
+++ b/crates/tenferro-internal-ops/src/ad/support/tests.rs
@@ -1,7 +1,65 @@
-use super::{all_primitive_ad_support, primitive_ad_support, promote_dtype, AdRuleSupport};
+use std::collections::BTreeMap;
+
+use computegraph::graph::{Graph, GraphBuilder};
+use computegraph::types::ValueRef;
+
+use super::{
+    all_primitive_ad_support, identity_matrix, one_like, primitive_ad_support, promote_dtype,
+    AdRuleSupport,
+};
 use crate::ad::registry;
+use crate::dim_expr::DimExpr;
+use crate::input_key::TensorInputKey;
+use crate::std_tensor_op::StdTensorOp;
 use tenferro_core_ops::{all_primitive_descriptors, PrimitiveOpKind};
 use tenferro_tensor::DType;
+
+fn op_kind_name(op: &StdTensorOp) -> &'static str {
+    match op {
+        StdTensorOp::Constant { .. } => "Constant",
+        StdTensorOp::BroadcastInDim { .. } => "BroadcastInDim",
+        StdTensorOp::EmbedDiag { .. } => "EmbedDiag",
+        StdTensorOp::Exp => "Exp",
+        StdTensorOp::Log => "Log",
+        StdTensorOp::Sin => "Sin",
+        StdTensorOp::Cos => "Cos",
+        StdTensorOp::Tanh => "Tanh",
+        StdTensorOp::Sqrt => "Sqrt",
+        StdTensorOp::Rsqrt => "Rsqrt",
+        StdTensorOp::Expm1 => "Expm1",
+        StdTensorOp::Log1p => "Log1p",
+        _ => "Other",
+    }
+}
+
+fn op_kind_histogram(graph: &Graph<StdTensorOp>) -> BTreeMap<&'static str, usize> {
+    let mut counts = BTreeMap::new();
+    for op in graph.operations() {
+        *counts.entry(op_kind_name(&op.operation)).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn assert_no_analytic_constant_shortcuts(graph: &Graph<StdTensorOp>) {
+    for op in graph.operations() {
+        assert!(
+            !matches!(
+                op.operation,
+                StdTensorOp::Exp
+                    | StdTensorOp::Log
+                    | StdTensorOp::Sin
+                    | StdTensorOp::Cos
+                    | StdTensorOp::Tanh
+                    | StdTensorOp::Sqrt
+                    | StdTensorOp::Rsqrt
+                    | StdTensorOp::Expm1
+                    | StdTensorOp::Log1p
+            ),
+            "AD semantic constant helpers must not use analytic shortcuts; saw {:?}",
+            op.operation
+        );
+    }
+}
 
 #[test]
 fn primitive_ad_support_manifest_covers_core_catalog_order() {
@@ -80,4 +138,96 @@ fn promote_dtype_delegates_to_canonical_tensor_validation_rules() {
             );
         }
     }
+}
+
+#[test]
+fn one_like_helper_emits_semantic_constant_not_analytic_shortcut() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let anchor = builder.add_input(TensorInputKey::User { id: 901 });
+
+    let one = one_like(&mut builder, DType::F64, ValueRef::Local(anchor), 2);
+    let graph = builder.build();
+
+    assert!(graph.values()[one].producer.is_some());
+    assert_no_analytic_constant_shortcuts(&graph);
+    assert_eq!(
+        op_kind_histogram(&graph),
+        BTreeMap::from([("BroadcastInDim", 1), ("Constant", 1)])
+    );
+}
+
+#[test]
+fn identity_matrix_helper_emits_semantic_constant_and_remaps_shape_source() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let anchor = builder.add_input(TensorInputKey::User { id: 900 });
+
+    let identity = identity_matrix(
+        &mut builder,
+        DType::F64,
+        3,
+        &[DimExpr::InputDim {
+            input_idx: 0,
+            axis: 2,
+        }],
+        ValueRef::Local(anchor),
+        0,
+    );
+    let graph = builder.build();
+
+    assert_no_analytic_constant_shortcuts(&graph);
+    assert_eq!(
+        op_kind_histogram(&graph),
+        BTreeMap::from([("BroadcastInDim", 1), ("Constant", 1), ("EmbedDiag", 1)])
+    );
+
+    let (embed_diag_id, _) = graph.values()[identity]
+        .producer
+        .expect("identity output must be produced by embed diag");
+    assert!(matches!(
+        graph.operations()[embed_diag_id].operation,
+        StdTensorOp::EmbedDiag { .. }
+    ));
+    let broadcast_id = match graph.operations()[embed_diag_id].inputs[0] {
+        ValueRef::Local(id) => id,
+        ref other => panic!("embed diag should consume broadcast output, got {other:?}"),
+    };
+    let (broadcast_op_id, _) = graph.values()[broadcast_id]
+        .producer
+        .expect("identity diagonal must be produced by broadcast");
+    let broadcast = &graph.operations()[broadcast_op_id];
+    assert_eq!(
+        broadcast.operation,
+        StdTensorOp::BroadcastInDim {
+            shape: vec![
+                DimExpr::Const(3),
+                DimExpr::InputDim {
+                    input_idx: 1,
+                    axis: 2,
+                },
+            ],
+            dims: vec![],
+        }
+    );
+    assert_eq!(broadcast.inputs[1], ValueRef::Local(anchor));
+}
+
+#[test]
+#[should_panic(
+    expected = "identity_matrix shape expressions must reference only the provided shape_source_idx"
+)]
+fn identity_matrix_helper_rejects_unbound_shape_sources() {
+    let mut builder = GraphBuilder::<StdTensorOp>::new();
+    let anchor = builder.add_input(TensorInputKey::User { id: 902 });
+
+    let _ = identity_matrix(
+        &mut builder,
+        DType::F64,
+        3,
+        &[DimExpr::InputDim {
+            input_idx: 1,
+            axis: 0,
+        }],
+        ValueRef::Local(anchor),
+        0,
+    );
 }

--- a/crates/tenferro-linalg/src/ad/rules/mod.rs
+++ b/crates/tenferro-linalg/src/ad/rules/mod.rs
@@ -117,31 +117,21 @@ pub(crate) fn linearize_lu(
     let (m, n, batch_shape) = matrix_shape_parts(input_shape, "linearize_lu");
     let (m_size, n_size) =
         resolve_and_guard(m, n, ctx).map_err(|err| invalid_dim_expr("linearize_lu", err))?;
-    let k = DimExpr::min(m.clone(), n.clone());
     let k_size = m_size.min(n_size);
     let rank = input_shape.len();
-    let l_shape = matrix_shape(m, &k, batch_shape);
-    let u_shape = matrix_shape(&k, n, batch_shape);
+    let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let p = ValueRef::External(primal_out[0].clone());
     let l = ValueRef::External(primal_out[1].clone());
     let u = ValueRef::External(primal_out[2].clone());
     let l_square = augment_unit_lower_to_square_fixed(
         builder,
         l.clone(),
-        m_size,
-        k_size,
-        batch_shape,
-        &l_shape,
-        rank,
+        SquareAugmentSpec::new(dtype, m_size, k_size, batch_shape, rank),
     );
     let u_square = augment_upper_to_square_fixed(
         builder,
         u.clone(),
-        k_size,
-        n_size,
-        batch_shape,
-        &u_shape,
-        rank,
+        SquareAugmentSpec::new(dtype, k_size, n_size, batch_shape, rank),
     );
 
     let pd_a = matmul_linear(builder, p, ValueRef::Local(da), vec![false, true], rank);
@@ -183,7 +173,7 @@ pub(crate) fn linearize_lu(
             take_leading_cols_linear(
                 builder,
                 dl_full,
-                LeadingMatrixSlice::new(k_size, n_size, batch_shape, l.clone(), &l_shape, rank),
+                LeadingMatrixSlice::new(k_size, n_size, dtype, batch_shape, l.clone(), rank),
             )
         } else {
             dl_full
@@ -204,7 +194,7 @@ pub(crate) fn linearize_lu(
             take_leading_rows_linear(
                 builder,
                 du_full,
-                LeadingMatrixSlice::new(k_size, m_size, batch_shape, u.clone(), &u_shape, rank),
+                LeadingMatrixSlice::new(k_size, m_size, dtype, batch_shape, u.clone(), rank),
             )
         } else {
             du_full
@@ -448,6 +438,7 @@ pub(crate) fn linearize_svd(
     let u = ValueRef::External(primal_out[0].clone());
     let s = ValueRef::External(primal_out[1].clone());
     let vt = ValueRef::External(primal_out[2].clone());
+    let s_dtype = ctx.dtype_of(&s)?;
 
     let uh = adjoint_matrix_fixed(builder, u.clone(), matrix_rank, dtype);
     let v = adjoint_matrix_fixed(builder, vt.clone(), matrix_rank, dtype);
@@ -472,7 +463,7 @@ pub(crate) fn linearize_svd(
     }
 
     let diag_s = embed_diag_fixed(builder, s.clone());
-    let ones_mat = one_like_fixed(builder, ValueRef::Local(diag_s));
+    let ones_mat = one_like_fixed(builder, s_dtype, ValueRef::Local(diag_s), matrix_rank);
     let s_dim = matmul_fixed(
         builder,
         ValueRef::Local(ones_mat),
@@ -494,7 +485,7 @@ pub(crate) fn linearize_svd(
     let f = fixed_div(builder, ValueRef::Local(s_gap), ValueRef::Local(safe_gap));
 
     let du = if u_active {
-        let s_ones = one_like_fixed(builder, s.clone());
+        let s_ones = one_like_fixed(builder, s_dtype, s.clone(), matrix_rank - 1);
         let s_sq = fixed_mul(builder, s.clone(), s.clone());
         let s_eps_sq = fixed_scale(builder, ValueRef::Local(s_ones), eps * eps);
         let safe_s_sq = fixed_add(builder, ValueRef::Local(s_sq), ValueRef::Local(s_eps_sq));
@@ -711,7 +702,7 @@ pub(crate) fn linearize_eigh(
     }
 
     let diag_w = embed_diag_fixed(builder, w.clone());
-    let ones_mat = one_like_fixed(builder, ValueRef::Local(diag_w));
+    let ones_mat = one_like_fixed(builder, w_dtype, ValueRef::Local(diag_w), matrix_rank);
     let w_col = matmul_fixed(
         builder,
         ValueRef::Local(diag_w),
@@ -884,14 +875,8 @@ pub(crate) fn linearize_qr(
 
     if n_size > m_size {
         let qh = adjoint_matrix_fixed(builder, q.clone(), matrix_rank, dtype);
-        let leading_selector = leading_column_selector_fixed(
-            builder,
-            m_size,
-            n_size,
-            batch_shape,
-            r.clone(),
-            input_shape,
-        );
+        let leading_selector =
+            leading_column_selector_fixed(builder, dtype, m_size, n_size, batch_shape, r.clone());
         let leading_selector_t =
             transpose_matrix_fixed(builder, ValueRef::Local(leading_selector), matrix_rank);
         let da_leading = matmul_linear(
@@ -980,11 +965,11 @@ pub(crate) fn linearize_qr(
         if r_active && trailing_cols > 0 {
             let trailing_selector = trailing_column_selector_fixed(
                 builder,
+                dtype,
                 m_size,
                 trailing_cols,
                 batch_shape,
                 r.clone(),
-                input_shape,
             );
             let trailing_selector_t =
                 transpose_matrix_fixed(builder, ValueRef::Local(trailing_selector), matrix_rank);

--- a/crates/tenferro-linalg/src/ad/rules/support.rs
+++ b/crates/tenferro-linalg/src/ad/rules/support.rs
@@ -1,5 +1,5 @@
 use computegraph::types::{LocalValueId, OperationRole, ValueRef};
-use tenferro_ops::ad::PrimitiveRuleBuilder;
+use tenferro_ops::ad::{support as ad_support, PrimitiveRuleBuilder};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{DType, DotGeneralConfig, PadConfig};
@@ -187,14 +187,6 @@ pub(super) fn broadcast_in_dim_fixed(
     fixed_unary(builder, StdTensorOp::BroadcastInDim { shape, dims }, input)
 }
 
-pub(super) fn reduce_sum_fixed(
-    builder: &mut dyn PrimitiveRuleBuilder,
-    input: ValueRef<StdTensorOp>,
-    axes: Vec<usize>,
-) -> LocalValueId {
-    fixed_unary(builder, StdTensorOp::ReduceSum { axes }, input)
-}
-
 pub(super) fn pad_fixed(
     builder: &mut dyn PrimitiveRuleBuilder,
     input: ValueRef<StdTensorOp>,
@@ -313,10 +305,11 @@ pub(super) fn hadamard_fixed_linear(
 
 pub(super) fn one_like_fixed(
     builder: &mut dyn PrimitiveRuleBuilder,
+    dtype: DType,
     anchor: ValueRef<StdTensorOp>,
+    anchor_rank: usize,
 ) -> LocalValueId {
-    let zero = fixed_sub(builder, anchor.clone(), anchor);
-    fixed_unary(builder, StdTensorOp::Exp, ValueRef::Local(zero))
+    ad_support::one_like(builder, dtype, anchor, anchor_rank)
 }
 
 pub(super) fn extract_diag_linear(
@@ -542,12 +535,6 @@ pub(super) fn matrix_shape(
     shape
 }
 
-pub(super) fn vector_shape(len: impl Into<DimExpr>, batch_shape: &[DimExpr]) -> Vec<DimExpr> {
-    let mut shape = vec![len.into()];
-    shape.extend_from_slice(batch_shape);
-    shape
-}
-
 pub(super) fn vector_to_matrix_broadcast_dims(batch_ndim: usize) -> Vec<usize> {
     let mut dims = Vec::with_capacity(1 + batch_ndim);
     dims.push(1);
@@ -557,13 +544,13 @@ pub(super) fn vector_to_matrix_broadcast_dims(batch_ndim: usize) -> Vec<usize> {
 
 pub(super) fn leading_column_selector_fixed(
     builder: &mut dyn PrimitiveRuleBuilder,
+    dtype: DType,
     leading_cols: usize,
     total_cols: usize,
     batch_shape: &[DimExpr],
     anchor: ValueRef<StdTensorOp>,
-    anchor_shape: &[DimExpr],
 ) -> LocalValueId {
-    let eye = identity_matrix_fixed(builder, leading_cols, batch_shape, anchor, anchor_shape);
+    let eye = identity_matrix_fixed(builder, dtype, leading_cols, batch_shape, anchor);
     let rank = 2 + batch_shape.len();
     pad_fixed(
         builder,
@@ -576,13 +563,13 @@ pub(super) fn leading_column_selector_fixed(
 
 pub(super) fn trailing_column_selector_fixed(
     builder: &mut dyn PrimitiveRuleBuilder,
+    dtype: DType,
     leading_cols: usize,
     trailing_cols: usize,
     batch_shape: &[DimExpr],
     anchor: ValueRef<StdTensorOp>,
-    anchor_shape: &[DimExpr],
 ) -> LocalValueId {
-    let eye = identity_matrix_fixed(builder, trailing_cols, batch_shape, anchor, anchor_shape);
+    let eye = identity_matrix_fixed(builder, dtype, trailing_cols, batch_shape, anchor);
     let rank = 2 + batch_shape.len();
     pad_fixed(
         builder,
@@ -595,37 +582,12 @@ pub(super) fn trailing_column_selector_fixed(
 
 pub(super) fn identity_matrix_fixed(
     builder: &mut dyn PrimitiveRuleBuilder,
+    dtype: DType,
     size: usize,
     batch_shape: &[DimExpr],
     anchor: ValueRef<StdTensorOp>,
-    anchor_shape: &[DimExpr],
 ) -> LocalValueId {
-    let one_scalar = scalar_one_fixed(builder, anchor, anchor_shape);
-    let ones = broadcast_in_dim_fixed(
-        builder,
-        ValueRef::Local(one_scalar),
-        vector_shape(size, batch_shape),
-        vec![],
-    );
-    embed_diag_fixed(builder, ValueRef::Local(ones))
-}
-
-pub(super) fn scalar_one_fixed(
-    builder: &mut dyn PrimitiveRuleBuilder,
-    anchor: ValueRef<StdTensorOp>,
-    anchor_shape: &[DimExpr],
-) -> LocalValueId {
-    let zero = fixed_sub(builder, anchor.clone(), anchor);
-    let zero_scalar = if anchor_shape.is_empty() {
-        zero
-    } else {
-        reduce_sum_fixed(
-            builder,
-            ValueRef::Local(zero),
-            (0..anchor_shape.len()).collect(),
-        )
-    };
-    fixed_unary(builder, StdTensorOp::Exp, ValueRef::Local(zero_scalar))
+    ad_support::identity_matrix(builder, dtype, size, batch_shape, anchor, 0)
 }
 
 pub(super) fn pad_vec(rank: usize, axis: usize, amount: i64) -> Vec<i64> {
@@ -641,28 +603,50 @@ pub(super) fn pad_matrix_low(rank: usize, row_amount: i64, col_amount: i64) -> V
     padding
 }
 
+pub(super) struct SquareAugmentSpec<'a> {
+    dtype: DType,
+    rows: usize,
+    cols: usize,
+    batch_shape: &'a [DimExpr],
+    rank: usize,
+}
+
+impl<'a> SquareAugmentSpec<'a> {
+    pub(super) fn new(
+        dtype: DType,
+        rows: usize,
+        cols: usize,
+        batch_shape: &'a [DimExpr],
+        rank: usize,
+    ) -> Self {
+        Self {
+            dtype,
+            rows,
+            cols,
+            batch_shape,
+            rank,
+        }
+    }
+}
+
 pub(super) fn augment_unit_lower_to_square_fixed(
     builder: &mut dyn PrimitiveRuleBuilder,
     l: ValueRef<StdTensorOp>,
-    rows: usize,
-    cols: usize,
-    batch_shape: &[DimExpr],
-    l_shape: &[DimExpr],
-    rank: usize,
+    spec: SquareAugmentSpec<'_>,
 ) -> LocalValueId {
     let strict_lower = fixed_unary(builder, StdTensorOp::Tril { k: -1 }, l.clone());
-    let strict_lower_square = if cols < rows {
+    let strict_lower_square = if spec.cols < spec.rows {
         pad_fixed(
             builder,
             ValueRef::Local(strict_lower),
-            rank,
-            vec![0; rank],
-            pad_vec(rank, 1, (rows - cols) as i64),
+            spec.rank,
+            vec![0; spec.rank],
+            pad_vec(spec.rank, 1, (spec.rows - spec.cols) as i64),
         )
     } else {
         strict_lower
     };
-    let identity = identity_matrix_fixed(builder, rows, batch_shape, l, l_shape);
+    let identity = identity_matrix_fixed(builder, spec.dtype, spec.rows, spec.batch_shape, l);
     fixed_add(
         builder,
         ValueRef::Local(strict_lower_square),
@@ -673,31 +657,33 @@ pub(super) fn augment_unit_lower_to_square_fixed(
 pub(super) fn augment_upper_to_square_fixed(
     builder: &mut dyn PrimitiveRuleBuilder,
     u: ValueRef<StdTensorOp>,
-    rows: usize,
-    cols: usize,
-    batch_shape: &[DimExpr],
-    u_shape: &[DimExpr],
-    rank: usize,
+    spec: SquareAugmentSpec<'_>,
 ) -> LocalValueId {
     let upper = fixed_unary(builder, StdTensorOp::Triu { k: 0 }, u.clone());
-    if rows == cols {
+    if spec.rows == spec.cols {
         return upper;
     }
 
     let upper_square = pad_fixed(
         builder,
         ValueRef::Local(upper),
-        rank,
-        vec![0; rank],
-        pad_vec(rank, 0, (cols - rows) as i64),
+        spec.rank,
+        vec![0; spec.rank],
+        pad_vec(spec.rank, 0, (spec.cols - spec.rows) as i64),
     );
-    let trailing_eye = identity_matrix_fixed(builder, cols - rows, batch_shape, u, u_shape);
+    let trailing_eye = identity_matrix_fixed(
+        builder,
+        spec.dtype,
+        spec.cols - spec.rows,
+        spec.batch_shape,
+        u,
+    );
     let trailing_eye = pad_fixed(
         builder,
         ValueRef::Local(trailing_eye),
-        rank,
-        pad_matrix_low(rank, rows as i64, rows as i64),
-        vec![0; rank],
+        spec.rank,
+        pad_matrix_low(spec.rank, spec.rows as i64, spec.rows as i64),
+        vec![0; spec.rank],
     );
     fixed_add(
         builder,
@@ -709,9 +695,9 @@ pub(super) fn augment_upper_to_square_fixed(
 pub(super) struct LeadingMatrixSlice<'a> {
     leading: usize,
     total: usize,
+    dtype: DType,
     batch_shape: &'a [DimExpr],
     anchor: ValueRef<StdTensorOp>,
-    anchor_shape: &'a [DimExpr],
     rank: usize,
 }
 
@@ -719,17 +705,17 @@ impl<'a> LeadingMatrixSlice<'a> {
     pub(super) fn new(
         leading: usize,
         total: usize,
+        dtype: DType,
         batch_shape: &'a [DimExpr],
         anchor: ValueRef<StdTensorOp>,
-        anchor_shape: &'a [DimExpr],
         rank: usize,
     ) -> Self {
         Self {
             leading,
             total,
+            dtype,
             batch_shape,
             anchor,
-            anchor_shape,
             rank,
         }
     }
@@ -742,11 +728,11 @@ pub(super) fn take_leading_cols_linear(
 ) -> LocalValueId {
     let selector = leading_column_selector_fixed(
         builder,
+        spec.dtype,
         spec.leading,
         spec.total,
         spec.batch_shape,
         spec.anchor,
-        spec.anchor_shape,
     );
     let selector_t = transpose_matrix_fixed(builder, ValueRef::Local(selector), spec.rank);
     matmul_linear(
@@ -765,11 +751,11 @@ pub(super) fn take_leading_rows_linear(
 ) -> LocalValueId {
     let selector = leading_column_selector_fixed(
         builder,
+        spec.dtype,
         spec.leading,
         spec.total,
         spec.batch_shape,
         spec.anchor,
-        spec.anchor_shape,
     );
     matmul_linear(
         builder,
@@ -778,4 +764,97 @@ pub(super) fn take_leading_rows_linear(
         vec![false, true],
         spec.rank,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use computegraph::graph::{Graph, GraphBuilder};
+    use computegraph::types::ValueRef;
+    use tenferro_ops::input_key::TensorInputKey;
+    use tenferro_ops::std_tensor_op::StdTensorOp;
+    use tenferro_tensor::DType;
+
+    use super::{identity_matrix_fixed, one_like_fixed};
+
+    fn op_kind_name(op: &StdTensorOp) -> &'static str {
+        match op {
+            StdTensorOp::Constant { .. } => "Constant",
+            StdTensorOp::BroadcastInDim { .. } => "BroadcastInDim",
+            StdTensorOp::EmbedDiag { .. } => "EmbedDiag",
+            StdTensorOp::Exp => "Exp",
+            StdTensorOp::Log => "Log",
+            StdTensorOp::Sin => "Sin",
+            StdTensorOp::Cos => "Cos",
+            StdTensorOp::Tanh => "Tanh",
+            StdTensorOp::Sqrt => "Sqrt",
+            StdTensorOp::Rsqrt => "Rsqrt",
+            StdTensorOp::Expm1 => "Expm1",
+            StdTensorOp::Log1p => "Log1p",
+            _ => "Other",
+        }
+    }
+
+    fn op_kind_histogram(graph: &Graph<StdTensorOp>) -> BTreeMap<&'static str, usize> {
+        let mut counts = BTreeMap::new();
+        for op in graph.operations() {
+            *counts.entry(op_kind_name(&op.operation)).or_insert(0) += 1;
+        }
+        counts
+    }
+
+    fn assert_no_analytic_constant_shortcuts(graph: &computegraph::graph::Graph<StdTensorOp>) {
+        for op in graph.operations() {
+            assert!(
+                !matches!(
+                    op.operation,
+                    StdTensorOp::Exp
+                        | StdTensorOp::Log
+                        | StdTensorOp::Sin
+                        | StdTensorOp::Cos
+                        | StdTensorOp::Tanh
+                        | StdTensorOp::Sqrt
+                        | StdTensorOp::Rsqrt
+                        | StdTensorOp::Expm1
+                        | StdTensorOp::Log1p
+                ),
+                "constant and identity rule helpers must use semantic constant emission, not analytic shortcuts; saw {:?}",
+                op.operation
+            );
+        }
+    }
+
+    #[test]
+    fn one_like_fixed_uses_semantic_constant_not_analytic_shortcut() {
+        let mut builder = GraphBuilder::<StdTensorOp>::new();
+        let anchor = builder.add_input(TensorInputKey::User { id: 2 });
+
+        let one = one_like_fixed(&mut builder, DType::F64, ValueRef::Local(anchor), 2);
+        let graph = builder.build();
+
+        assert!(graph.values()[one].producer.is_some());
+        assert_no_analytic_constant_shortcuts(&graph);
+        assert_eq!(
+            op_kind_histogram(&graph),
+            BTreeMap::from([("BroadcastInDim", 1), ("Constant", 1)])
+        );
+    }
+
+    #[test]
+    fn identity_matrix_fixed_uses_semantic_constant_not_analytic_shortcut() {
+        let mut builder = GraphBuilder::<StdTensorOp>::new();
+        let anchor = builder.add_input(TensorInputKey::User { id: 1 });
+
+        let identity =
+            identity_matrix_fixed(&mut builder, DType::F64, 2, &[], ValueRef::Local(anchor));
+        let graph = builder.build();
+
+        assert!(graph.values()[identity].producer.is_some());
+        assert_no_analytic_constant_shortcuts(&graph);
+        assert_eq!(
+            op_kind_histogram(&graph),
+            BTreeMap::from([("BroadcastInDim", 1), ("Constant", 1), ("EmbedDiag", 1)])
+        );
+    }
 }

--- a/docs/architecture/ad-pipeline.md
+++ b/docs/architecture/ad-pipeline.md
@@ -121,6 +121,14 @@ broadcast when the rank is nonzero. This keeps zero propagation symbolic until a
 primitive such as `Concatenate`, `DynamicUpdateSlice`, or `Scatter` needs a real
 zero input to express the correct linearized operation.
 
+The same semantic-emission rule applies to constants, ones, and identity
+matrices inside AD rules. Rule code should call the helper surface in
+`tenferro_ops::ad::support` so it emits `Constant` plus structural ops directly
+instead of reconstructing constants through analytic identities such as
+`exp(sum(x - x))`. Each discovered graph-emission invariant must become either
+unrepresentable through that helper API or covered by a structural test; prose
+rules alone are not treated as sufficient protection.
+
 Current tenferro eager AD uses the same primitive rule set through a different
 interpreter:
 

--- a/docs/spec/ad-contract.md
+++ b/docs/spec/ad-contract.md
@@ -222,6 +222,14 @@ rules carry dtype, rank, and an anchor value as a `SymbolicZero` and instantiate
 it as a dtype-aware scalar zero plus shape-restoring broadcast when needed. Do
 not synthesize zeros through analytic operations or tensor buffers.
 
+The same rule applies to AD-emitted scalar constants, one-like tensors, and
+identity matrices. Rule implementations must use semantic graph-emission
+helpers such as `tenferro_ops::ad::support::{constant_scalar, zero_like,
+one_like, identity_matrix}` rather than analytic identities. Graph-shape
+invariants discovered during AD-rule work must be guarded by CI-checkable
+structural tests, for example tests that reject analytic ops in constant or
+identity helper emission.
+
 `AdContext` is the explicit owner for shared AD transform memoization. It owns
 the extension AD rules and a bounded AD transform cache used by
 context-driven traced transforms. Eager runtimes created with

--- a/docs/worklogs/2026-07-07-graph-emission-invariants.md
+++ b/docs/worklogs/2026-07-07-graph-emission-invariants.md
@@ -1,0 +1,51 @@
+# Graph Emission Invariants Work Log
+
+## Summary
+
+This session implemented the HANDOFF v2 structural-prevention item for AD graph
+emission. The immediate bug class was dtype-polymorphic constants written as
+analytic identities, especially linalg identity construction through
+`Exp(anchor - anchor)`.
+
+## Context Read
+
+- `HANDOFF.md` v2 section F from the issue #1321 handoff
+- `REPOSITORY_RULES.md` AD rule-source and work-log sections
+- `ai/contribution-workflows/bugfix-pr.md`
+- `ai/contribution-workflows/repository-remediation.md`
+- `docs/architecture/ad-pipeline.md`
+- `docs/spec/ad-contract.md`
+- `crates/tenferro-internal-ops/src/ad/{support.rs,zeros.rs}`
+- `crates/tenferro-linalg/src/ad/rules/support.rs`
+
+## Decisions
+
+- Expose semantic AD rule helpers through `tenferro_ops::ad::support` instead
+  of adding required methods to `PrimitiveRuleBuilder`. This keeps existing
+  builder implementations stable while giving extension and operation-family
+  rules a public rule-support path for constants, zero-like, one-like, and
+  identity-matrix emission.
+- Rewrite linalg one-like and identity helpers to use semantic constants
+  instead of analytic `Exp` shortcuts.
+- Add structural tests that fail when identity helper emission uses analytic
+  operations for constants.
+- Record the durable policy in active architecture/spec docs and point
+  repository rules at machine-checkable gates.
+- Add the capability-landing sweep step to the remediation workflow so new
+  canonical helpers trigger a search for obsolete workaround patterns.
+
+## Verification
+
+Verification performed during implementation:
+
+- `cargo test -p tenferro-linalg --features autodiff,cpu-faer identity_matrix_fixed_uses_semantic_constant_not_analytic_shortcut -- --nocapture`
+- `cargo test -p tenferro-internal-ops --features autodiff identity_matrix_helper_emits_semantic_constant_and_remaps_shape_source -- --nocapture`
+
+Broader verification is recorded in the PR body.
+
+## Residual Risks
+
+The structural tests cover the helper path and the linalg identity construction
+that regressed. They do not yet enumerate every possible extension rule fixture.
+Future AD-rule capability landings should add or reuse structural gates for the
+specific invariant they introduce.


### PR DESCRIPTION
> [!IMPORTANT]
> New features must start as a feature request issue.
> Please do not open a new-feature implementation PR before maintainers accept
> the issue and agree that implementation should start.
>
> If you already have prototype code, link to a fork branch, gist, or
> repository from the feature request issue instead of opening a PR.
>
> New-feature PRs opened before an accepted issue may be closed and redirected
> to an issue.
>
> If you are using an AI agent for a bug-fix PR, use or follow the
> repository-local `tenferro-bugfix-pr` workflow before editing code.

## Type

- [x] Bug fix
- [x] Documentation
- [x] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs #1321

## Summary

This implements the HANDOFF v2 structural-prevention item: graph-emission invariants must be machine-enforced.

- Adds semantic AD rule-support helpers for scalar constants, zero-like, one-like, and identity-matrix emission under `tenferro_ops::ad::support`.
- Rewrites linalg one/identity helper emission away from analytic shortcuts such as `Exp(anchor - anchor)` and carries dtype through LU/SVD/Eigh/QR helper paths.
- Adds structural tests with op-kind histograms and analytic-op rejection for the internal helper path and linalg helper path, plus a negative shape-source invariant test for identity emission.
- Records the invariant in `REPOSITORY_RULES.md`, `docs/architecture/ad-pipeline.md`, `docs/spec/ad-contract.md`, and adds the capability-landing sweep to the remediation workflow.

## Work log

`docs/worklogs/2026-07-07-graph-emission-invariants.md`

## Verification

- `cargo fmt --all --check`
- `cargo test -p tenferro-internal-ops --features autodiff ad::support::tests -- --nocapture`
- `cargo test -p tenferro-linalg --features autodiff,cpu-faer ad::rules::support::tests -- --nocapture`
- `cargo test -p tenferro-linalg --features autodiff,cpu-faer --test traced_ad_explicit -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-graph-emission.json`
- `git diff --check`

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
