### PR TITLE
Fix CUDA integer elementwise parity and backend reuse examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,9 @@ See `ai/README.md` for the repository-local AI workflow layout.
 CUDA GPU support is implemented through the feature-gated CubeCL backend across
 the concrete tensor, eager, and traced execution surfaces. Performance
 optimization is still active work. The remaining CUDA limitations are specific:
-`eig`, `full_piv_lu`, `full_piv_lu_solve`, `dynamic_update_slice`, `I64`
-numeric/linalg gaps, and selected complex analytic or ordering operations.
+`eig`, `full_piv_lu`, `full_piv_lu_solve`, `dynamic_update_slice`, integer
+numeric/linalg gaps beyond add/mul/compare/select and sum/prod reductions, and
+selected complex analytic or ordering operations.
 HIP/ROCm remains stubbed. Outside explicit GPU implementation tasks, check
 `docs/guides/devices-and-gpu.md` and the current CUDA/CubeCL backend tests
 before assuming a specific op/dtype/backend combination is supported.

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -673,6 +673,13 @@ Tests follow implementation ownership.
   clear and aggregate stats APIs in addition to cache-specific controls.
 - Backend resource pools such as buffer pools may live on the backend, but they
   still need explicit limit/clear controls, stats APIs, and documentation.
+- Backends that own resource pools or runtime contexts, including
+  `CpuBackend`'s buffer pool and `Arc<CpuContext>` and CUDA backends' runtime
+  client/context, are construct-once-and-reuse values. Examples should bind the
+  backend once and reuse it across related operations; they must not present
+  per-call `CpuBackend::new()` or GPU backend construction chained directly
+  into an operation as the normal idiom. A genuinely standalone single-op
+  example does not need to invent an unrelated long-lived backend variable.
 - Do not add a new cache without documenting its owner, lifetime, default
   capacity, memory behavior, entry/byte accounting, and
   clear/configuration/stats path.
@@ -768,6 +775,9 @@ Tests follow implementation ownership.
 - Every example must compile AND run as a doctest.
 - Use `compile_fail` only for examples that intentionally demonstrate compile errors.
 - If an example cannot run as a doctest, refactor it until it can.
+- Examples that call CPU or GPU backend operations should bind the backend to a
+  local variable and reuse it for related operations instead of chaining
+  `Backend::new().op(...)` beyond a single trivial construction example.
 
 ## Generic Over Scalar Type
 

--- a/crates/tenferro-gpu/src/cubecl/dispatch.rs
+++ b/crates/tenferro-gpu/src/cubecl/dispatch.rs
@@ -992,6 +992,85 @@ macro_rules! dispatch_binary_float_complex {
     }};
 }
 
+macro_rules! dispatch_binary_float_complex_int {
+    ($backend:expr, $lhs:expr, $rhs:expr, $kind:expr, $float_kernel:ident, $int_kernel:ident, $complex_kernel:ident) => {{
+        let descriptor = $crate::cubecl::op_descriptor::require_gpu_descriptor(
+            $kind,
+            $crate::cubecl::op_descriptor::GpuLaunchKind::BinaryFloatComplexInt,
+        )?;
+        let op = descriptor.name;
+        match ($lhs, $rhs) {
+            (Tensor::F32(lhs), Tensor::F32(rhs)) => {
+                $crate::cubecl::dispatch::launch_binary_elementwise_kernel!(
+                    $backend,
+                    lhs,
+                    rhs,
+                    op,
+                    $float_kernel,
+                    f32,
+                    F32
+                )
+            }
+            (Tensor::F64(lhs), Tensor::F64(rhs)) => {
+                $crate::cubecl::dispatch::launch_binary_elementwise_kernel!(
+                    $backend,
+                    lhs,
+                    rhs,
+                    op,
+                    $float_kernel,
+                    f64,
+                    F64
+                )
+            }
+            (Tensor::I32(lhs), Tensor::I32(rhs)) => {
+                $crate::cubecl::dispatch::launch_binary_elementwise_kernel!(
+                    $backend,
+                    lhs,
+                    rhs,
+                    op,
+                    $int_kernel,
+                    i32,
+                    I32
+                )
+            }
+            (Tensor::I64(lhs), Tensor::I64(rhs)) => {
+                $crate::cubecl::dispatch::launch_binary_elementwise_kernel!(
+                    $backend,
+                    lhs,
+                    rhs,
+                    op,
+                    $int_kernel,
+                    i64,
+                    I64
+                )
+            }
+            (Tensor::C32(lhs), Tensor::C32(rhs)) => {
+                $crate::cubecl::dispatch::launch_binary_elementwise_kernel!(
+                    $backend,
+                    lhs,
+                    rhs,
+                    op,
+                    $complex_kernel,
+                    num_complex::Complex32,
+                    C32
+                )
+            }
+            (Tensor::C64(lhs), Tensor::C64(rhs)) => {
+                $crate::cubecl::dispatch::launch_binary_elementwise_kernel!(
+                    $backend,
+                    lhs,
+                    rhs,
+                    op,
+                    $complex_kernel,
+                    num_complex::Complex64,
+                    C64
+                )
+            }
+            _ => Err(dtype_mismatch(op, $lhs, $rhs)),
+        }
+    }};
+}
+
 macro_rules! dispatch_binary_float_only {
     ($backend:expr, $lhs:expr, $rhs:expr, $kind:expr, $float_kernel:ident) => {{
         let descriptor = $crate::cubecl::op_descriptor::require_gpu_descriptor(
@@ -1121,6 +1200,7 @@ macro_rules! dispatch_unary_float_only {
 }
 
 pub(crate) use dispatch_binary_float_complex;
+pub(crate) use dispatch_binary_float_complex_int;
 pub(crate) use dispatch_binary_float_only;
 pub(crate) use dispatch_unary_float_complex;
 pub(crate) use dispatch_unary_float_only;

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -48,8 +48,8 @@
 //! let mut backend = CudaBackend::new(0)?;
 //!
 //! // 2. Create tensors on the CPU
-//! let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]));
-//! let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0]));
+//! let a = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0])?);
+//! let b = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![3.0, 4.0])?);
 //!
 //! // 3. Upload to GPU
 //! let gpu_a = upload_tensor(backend.runtime(), &a)?;
@@ -333,7 +333,8 @@ impl CudaExtensionCache {
     /// use tenferro_gpu::CudaExtensionCache;
     ///
     /// let cache = CudaExtensionCache::new();
-    /// assert!(cache.is_empty());
+    /// assert!(cache.is_empty()?);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     pub fn new() -> Self {
         let max_entries = NonZeroUsize::new(DEFAULT_CUDA_EXTENSION_CACHE_MAX_ENTRIES)
@@ -356,7 +357,7 @@ impl CudaExtensionCache {
     /// use tenferro_gpu::CudaExtensionCache;
     ///
     /// assert!(CudaExtensionCache::new().is_empty()?);
-    /// # Ok::<(), tenferro_gpu::Error>(())
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
     pub fn is_empty(&self) -> crate::Result<bool> {
         Ok(self.lock_inner()?.entries.is_empty())
@@ -1726,23 +1727,25 @@ impl BackendRuntimeCache for CudaBackend {
 
 impl TensorElementwise for CudaBackend {
     fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-        dispatch::dispatch_binary_float_complex!(
+        dispatch::dispatch_binary_float_complex_int!(
             self,
             lhs,
             rhs,
             PrimitiveOpKind::Add,
             add_float,
+            add_int,
             add_complex
         )
     }
 
     fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-        dispatch::dispatch_binary_float_complex!(
+        dispatch::dispatch_binary_float_complex_int!(
             self,
             lhs,
             rhs,
             PrimitiveOpKind::Mul,
             mul_float,
+            mul_int,
             mul_complex
         )
     }
@@ -1843,7 +1846,7 @@ impl TensorElementwise for CudaBackend {
     fn compare(&mut self, lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor> {
         let op = op_name(
             PrimitiveOpKind::Compare,
-            op_descriptor::GpuLaunchKind::CompareFloatToBool,
+            op_descriptor::GpuLaunchKind::CompareFloatIntToBool,
         )?;
         match (lhs, rhs) {
             (Tensor::F32(lhs), Tensor::F32(rhs)) => launch_compare_bool(
@@ -1884,6 +1887,44 @@ impl TensorElementwise for CudaBackend {
                 },
             )
             .map(Tensor::Bool),
+            (Tensor::I32(lhs), Tensor::I32(rhs)) => launch_compare_bool(
+                self.runtime(),
+                lhs,
+                rhs,
+                lhs.shape(),
+                op,
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::compare_int_bool::launch_unchecked::<i32, CubeclCudaRuntime>(
+                        client,
+                        count,
+                        dim,
+                        out,
+                        lhs_arg,
+                        rhs_arg,
+                        dispatch::compare_mode(dir),
+                    );
+                },
+            )
+            .map(Tensor::Bool),
+            (Tensor::I64(lhs), Tensor::I64(rhs)) => launch_compare_bool(
+                self.runtime(),
+                lhs,
+                rhs,
+                lhs.shape(),
+                op,
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    elementwise::compare_int_bool::launch_unchecked::<i64, CubeclCudaRuntime>(
+                        client,
+                        count,
+                        dim,
+                        out,
+                        lhs_arg,
+                        rhs_arg,
+                        dispatch::compare_mode(dir),
+                    );
+                },
+            )
+            .map(Tensor::Bool),
             (Tensor::C32(_), Tensor::C32(_)) | (Tensor::C64(_), Tensor::C64(_)) => Err(
                 crate::Error::backend_failure(op, format!("unsupported dtype {:?}", lhs.dtype())),
             ),
@@ -1899,7 +1940,7 @@ impl TensorElementwise for CudaBackend {
     ) -> crate::Result<Tensor> {
         let op = op_name(
             PrimitiveOpKind::Select,
-            op_descriptor::GpuLaunchKind::SelectBoolFloat,
+            op_descriptor::GpuLaunchKind::SelectBoolFloatInt,
         )?;
         match (pred, on_true, on_false) {
             (Tensor::Bool(pred), Tensor::F32(on_true), Tensor::F32(on_false)) => {
@@ -1933,6 +1974,38 @@ impl TensorElementwise for CudaBackend {
                     },
                 )
                 .map(Tensor::F64)
+            }
+            (Tensor::Bool(pred), Tensor::I32(on_true), Tensor::I32(on_false)) => {
+                launch_select_bool(
+                    self.runtime(),
+                    pred,
+                    on_true,
+                    on_false,
+                    pred.shape(),
+                    op,
+                    |client, count, dim, out, pred_arg, true_arg, false_arg| unsafe {
+                        elementwise::select_bool_int::launch_unchecked::<i32, CubeclCudaRuntime>(
+                            client, count, dim, out, pred_arg, true_arg, false_arg,
+                        );
+                    },
+                )
+                .map(Tensor::I32)
+            }
+            (Tensor::Bool(pred), Tensor::I64(on_true), Tensor::I64(on_false)) => {
+                launch_select_bool(
+                    self.runtime(),
+                    pred,
+                    on_true,
+                    on_false,
+                    pred.shape(),
+                    op,
+                    |client, count, dim, out, pred_arg, true_arg, false_arg| unsafe {
+                        elementwise::select_bool_int::launch_unchecked::<i64, CubeclCudaRuntime>(
+                            client, count, dim, out, pred_arg, true_arg, false_arg,
+                        );
+                    },
+                )
+                .map(Tensor::I64)
             }
             (Tensor::C32(_), Tensor::C32(_), Tensor::C32(_))
             | (Tensor::C64(_), Tensor::C64(_), Tensor::C64(_)) => Err(

--- a/crates/tenferro-gpu/src/cubecl/op_descriptor.rs
+++ b/crates/tenferro-gpu/src/cubecl/op_descriptor.rs
@@ -4,11 +4,12 @@ use tenferro_core_ops::{descriptor as primitive_descriptor, DTypePolicy, Primiti
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum GpuLaunchKind {
     BinaryFloatComplex,
+    BinaryFloatComplexInt,
     BinaryFloatOnly,
     UnaryFloatComplex,
     UnaryFloatOnly,
-    CompareFloatToBool,
-    SelectBoolFloat,
+    CompareFloatIntToBool,
+    SelectBoolFloatInt,
     ClampFloat,
     Reduction,
 }
@@ -24,9 +25,8 @@ pub(crate) struct GpuOpDescriptor {
 
 pub(crate) fn gpu_descriptor(kind: PrimitiveOpKind) -> Option<GpuOpDescriptor> {
     let launch = match kind {
-        PrimitiveOpKind::Add | PrimitiveOpKind::Mul | PrimitiveOpKind::Div => {
-            GpuLaunchKind::BinaryFloatComplex
-        }
+        PrimitiveOpKind::Add | PrimitiveOpKind::Mul => GpuLaunchKind::BinaryFloatComplexInt,
+        PrimitiveOpKind::Div => GpuLaunchKind::BinaryFloatComplex,
         PrimitiveOpKind::Maximum | PrimitiveOpKind::Minimum | PrimitiveOpKind::Pow => {
             GpuLaunchKind::BinaryFloatOnly
         }
@@ -42,8 +42,8 @@ pub(crate) fn gpu_descriptor(kind: PrimitiveOpKind) -> Option<GpuOpDescriptor> {
         | PrimitiveOpKind::Rsqrt
         | PrimitiveOpKind::Expm1
         | PrimitiveOpKind::Log1p => GpuLaunchKind::UnaryFloatOnly,
-        PrimitiveOpKind::Compare => GpuLaunchKind::CompareFloatToBool,
-        PrimitiveOpKind::Select => GpuLaunchKind::SelectBoolFloat,
+        PrimitiveOpKind::Compare => GpuLaunchKind::CompareFloatIntToBool,
+        PrimitiveOpKind::Select => GpuLaunchKind::SelectBoolFloatInt,
         PrimitiveOpKind::Clamp => GpuLaunchKind::ClampFloat,
         PrimitiveOpKind::ReduceSum
         | PrimitiveOpKind::ReduceProd

--- a/crates/tenferro-gpu/src/cubecl/op_descriptor/tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/op_descriptor/tests.rs
@@ -4,9 +4,17 @@ use super::*;
 fn gpu_descriptors_have_catalog_dtype_policy() {
     let add = gpu_descriptor(PrimitiveOpKind::Add).unwrap();
     assert_eq!(add.dtype_policy, DTypePolicy::SameNumeric);
+    assert_eq!(add.launch, GpuLaunchKind::BinaryFloatComplexInt);
+
+    let div = gpu_descriptor(PrimitiveOpKind::Div).unwrap();
+    assert_eq!(div.launch, GpuLaunchKind::BinaryFloatComplex);
 
     let compare = gpu_descriptor(PrimitiveOpKind::Compare).unwrap();
     assert_eq!(compare.dtype_policy, DTypePolicy::CompareToBool);
+    assert_eq!(compare.launch, GpuLaunchKind::CompareFloatIntToBool);
+
+    let select = gpu_descriptor(PrimitiveOpKind::Select).unwrap();
+    assert_eq!(select.launch, GpuLaunchKind::SelectBoolFloatInt);
 }
 
 #[test]

--- a/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
@@ -5,7 +5,8 @@ use crate::{DType, DeviceKind, GpuBackendKind, Tensor};
 use tenferro_tensor::{TensorAnalytic, TensorElementwise, TensorStructural};
 
 use super::{
-    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c64, tensor_f64, upload,
+    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c64, tensor_f64, tensor_i32,
+    tensor_i64, upload,
 };
 
 #[test]
@@ -217,6 +218,52 @@ fn test_cubecl_float_compare_select_and_clamp_match_cpu() {
     let gpu_out = gpu.clamp(&gpu_lhs, &gpu_lower, &gpu_upper).unwrap();
     let actual = download(&gpu, &gpu_out);
     assert_tensor_close(&actual, &expected, 1e-12);
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn test_cubecl_integer_add_mul_compare_select_match_cpu() {
+    if !gpu_available() {
+        eprintln!(
+            "skipping test_cubecl_integer_add_mul_compare_select_match_cpu — no CUDA device found"
+        );
+        return;
+    }
+
+    let i32_lhs = tensor_i32(vec![2, 3], vec![1, -2, 3, 4, -5, 6]);
+    let i32_rhs = tensor_i32(vec![2, 3], vec![6, 5, -4, 3, 2, -1]);
+    assert_integer_binary_and_select_matches_cpu(&i32_lhs, &i32_rhs);
+
+    let i64_lhs = tensor_i64(vec![2, 3], vec![10, -20, 30, 40, -50, 60]);
+    let i64_rhs = tensor_i64(vec![2, 3], vec![7, 6, -5, 4, 3, -2]);
+    assert_integer_binary_and_select_matches_cpu(&i64_lhs, &i64_rhs);
+}
+
+fn assert_integer_binary_and_select_matches_cpu(lhs: &Tensor, rhs: &Tensor) {
+    let mut cpu = cpu_backend();
+    let mut gpu = gpu_backend();
+    let gpu_lhs = upload(&gpu, lhs);
+    let gpu_rhs = upload(&gpu, rhs);
+
+    let expected = cpu.add(lhs, rhs).unwrap();
+    let gpu_out = gpu.add(&gpu_lhs, &gpu_rhs).unwrap();
+    let actual = download(&gpu, &gpu_out);
+    assert_tensor_close(&actual, &expected, 0.0);
+
+    let expected = cpu.mul(lhs, rhs).unwrap();
+    let gpu_out = gpu.mul(&gpu_lhs, &gpu_rhs).unwrap();
+    let actual = download(&gpu, &gpu_out);
+    assert_tensor_close(&actual, &expected, 0.0);
+
+    let expected_pred = cpu.compare(lhs, rhs, &CompareDir::Ge).unwrap();
+    let gpu_pred = gpu.compare(&gpu_lhs, &gpu_rhs, &CompareDir::Ge).unwrap();
+    let actual_pred = download(&gpu, &gpu_pred);
+    assert_tensor_close(&actual_pred, &expected_pred, 0.0);
+
+    let expected = cpu.select(&expected_pred, lhs, rhs).unwrap();
+    let gpu_out = gpu.select(&gpu_pred, &gpu_lhs, &gpu_rhs).unwrap();
+    let actual = download(&gpu, &gpu_out);
+    assert_tensor_close(&actual, &expected, 0.0);
 }
 
 #[test]

--- a/crates/tenferro-gpu/src/kernels/elementwise.rs
+++ b/crates/tenferro-gpu/src/kernels/elementwise.rs
@@ -6,7 +6,7 @@ pub(crate) const COMPARE_LE: usize = 2;
 pub(crate) const COMPARE_GT: usize = 3;
 pub(crate) const COMPARE_GE: usize = 4;
 
-macro_rules! binary_kernel {
+macro_rules! binary_float_complex_kernel {
     ($float_name:ident, $complex_name:ident, $op:tt) => {
         #[cube(launch_unchecked)]
         pub fn $float_name<F: Float>(out: &mut Array<F>, lhs: &Array<F>, rhs: &Array<F>) {
@@ -21,6 +21,19 @@ macro_rules! binary_kernel {
             lhs: &Array<C>,
             rhs: &Array<C>,
         ) {
+            if ABSOLUTE_POS < out.len() {
+                out[ABSOLUTE_POS] = lhs[ABSOLUTE_POS] $op rhs[ABSOLUTE_POS];
+            }
+        }
+    };
+}
+
+macro_rules! binary_float_int_complex_kernel {
+    ($float_name:ident, $int_name:ident, $complex_name:ident, $op:tt) => {
+        binary_float_complex_kernel!($float_name, $complex_name, $op);
+
+        #[cube(launch_unchecked)]
+        pub fn $int_name<I: Int>(out: &mut Array<I>, lhs: &Array<I>, rhs: &Array<I>) {
             if ABSOLUTE_POS < out.len() {
                 out[ABSOLUTE_POS] = lhs[ABSOLUTE_POS] $op rhs[ABSOLUTE_POS];
             }
@@ -59,9 +72,9 @@ macro_rules! unary_both_kernel {
     };
 }
 
-binary_kernel!(add_float, add_complex, +);
-binary_kernel!(mul_float, mul_complex, *);
-binary_kernel!(div_float, div_complex, /);
+binary_float_int_complex_kernel!(add_float, add_int, add_complex, +);
+binary_float_int_complex_kernel!(mul_float, mul_int, mul_complex, *);
+binary_float_complex_kernel!(div_float, div_complex, /);
 unary_both_kernel!(neg_float, neg_complex, |value| -value);
 unary_float_kernel!(exp_float, exp);
 unary_float_kernel!(log_float, ln);
@@ -159,11 +172,49 @@ pub fn compare_float_bool<F: Float>(
 }
 
 #[cube(launch_unchecked)]
+pub fn compare_int_bool<I: Int>(
+    out: &mut Array<bool>,
+    lhs: &Array<I>,
+    rhs: &Array<I>,
+    #[comptime] mode: usize,
+) {
+    if ABSOLUTE_POS < out.len() {
+        let x = lhs[ABSOLUTE_POS];
+        let y = rhs[ABSOLUTE_POS];
+        let pred = match mode {
+            COMPARE_EQ => x == y,
+            COMPARE_LT => x < y,
+            COMPARE_LE => x <= y,
+            COMPARE_GT => x > y,
+            COMPARE_GE => x >= y,
+            _ => false,
+        };
+        out[ABSOLUTE_POS] = pred;
+    }
+}
+
+#[cube(launch_unchecked)]
 pub fn select_bool_float<F: Float>(
     out: &mut Array<F>,
     pred: &Array<bool>,
     on_true: &Array<F>,
     on_false: &Array<F>,
+) {
+    if ABSOLUTE_POS < out.len() {
+        out[ABSOLUTE_POS] = if pred[ABSOLUTE_POS] {
+            on_true[ABSOLUTE_POS]
+        } else {
+            on_false[ABSOLUTE_POS]
+        };
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn select_bool_int<I: Int>(
+    out: &mut Array<I>,
+    pred: &Array<bool>,
+    on_true: &Array<I>,
+    on_false: &Array<I>,
 ) {
     if ABSOLUTE_POS < out.len() {
         out[ABSOLUTE_POS] = if pred[ABSOLUTE_POS] {

--- a/crates/tenferro-gpu/src/lib.rs
+++ b/crates/tenferro-gpu/src/lib.rs
@@ -3,6 +3,7 @@
 //! # Examples
 //!
 //! ```rust
+//! # fn main() -> tenferro_tensor::Result<()> {
 //! #[cfg(feature = "cuda")]
 //! {
 //!     use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CudaBackend};
@@ -10,8 +11,8 @@
 //!
 //!     if gpu_available() {
 //!         let mut backend = CudaBackend::new(0).unwrap();
-//!         let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]);
-//!         let b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]);
+//!         let a = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
+//!         let b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0])?;
 //!         let gpu_a = upload_tensor(backend.runtime(), &a).unwrap();
 //!         let gpu_b = upload_tensor(backend.runtime(), &b).unwrap();
 //!         let gpu_sum = backend.add(&gpu_a, &gpu_b).unwrap();
@@ -19,6 +20,8 @@
 //!         assert_eq!(sum.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
 //!     }
 //! }
+//! # Ok(())
+//! # }
 //! ```
 
 #[cfg(feature = "cuda")]

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -105,7 +105,8 @@ pub trait LinalgBackend: TensorBackend {
     ///     vec![2, 2],
     ///     vec![1.0, 0.0, 0.0, 2.0],
     /// )?;
-    /// let outputs = CpuBackend::new().svd_read(TensorView::F64(input.as_view()))?;
+    /// let mut backend = CpuBackend::new();
+    /// let outputs = backend.svd_read(TensorView::F64(input.as_view()))?;
     /// assert_eq!(outputs[1].shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
@@ -138,7 +139,8 @@ pub trait LinalgBackend: TensorBackend {
     ///     vec![2, 2],
     ///     vec![1.0, 0.0, 0.0, 2.0],
     /// )?;
-    /// let outputs = CpuBackend::new().qr_read(TensorView::F64(input.as_view()))?;
+    /// let mut backend = CpuBackend::new();
+    /// let outputs = backend.qr_read(TensorView::F64(input.as_view()))?;
     /// assert_eq!(outputs[0].shape(), &[2, 2]);
     /// assert_eq!(outputs[1].shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
@@ -172,7 +174,8 @@ pub trait LinalgBackend: TensorBackend {
     ///     vec![2, 2],
     ///     vec![1.0, 0.0, 0.0, 2.0],
     /// )?;
-    /// let outputs = CpuBackend::new().eigh_read(TensorView::F64(input.as_view()))?;
+    /// let mut backend = CpuBackend::new();
+    /// let outputs = backend.eigh_read(TensorView::F64(input.as_view()))?;
     /// assert_eq!(outputs[0].shape(), &[2]);
     /// assert_eq!(outputs[1].shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
@@ -200,7 +203,8 @@ pub trait LinalgBackend: TensorBackend {
     ///     vec![2, 2],
     ///     vec![4.0, 2.0, 2.0, 3.0],
     /// )?;
-    /// let output = CpuBackend::new().cholesky_read(TensorView::F64(input.as_view()))?;
+    /// let mut backend = CpuBackend::new();
+    /// let output = backend.cholesky_read(TensorView::F64(input.as_view()))?;
     /// assert_eq!(output.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
@@ -227,7 +231,8 @@ pub trait LinalgBackend: TensorBackend {
     ///     vec![2, 2],
     ///     vec![1.0, 3.0, 2.0, 4.0],
     /// )?;
-    /// let outputs = CpuBackend::new().lu_read(TensorView::F64(input.as_view()))?;
+    /// let mut backend = CpuBackend::new();
+    /// let outputs = backend.lu_read(TensorView::F64(input.as_view()))?;
     /// assert_eq!(outputs.len(), 4);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
@@ -254,7 +259,8 @@ pub trait LinalgBackend: TensorBackend {
     ///     vec![2, 2],
     ///     vec![1.0, 3.0, 2.0, 4.0],
     /// )?;
-    /// let outputs = CpuBackend::new().full_piv_lu_read(TensorView::F64(input.as_view()))?;
+    /// let mut backend = CpuBackend::new();
+    /// let outputs = backend.full_piv_lu_read(TensorView::F64(input.as_view()))?;
     /// assert_eq!(outputs.len(), 5);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
@@ -281,7 +287,8 @@ pub trait LinalgBackend: TensorBackend {
     ///     vec![2, 2],
     ///     vec![2.0, 0.0, 0.0, 3.0],
     /// )?;
-    /// let outputs = CpuBackend::new().eig_read(TensorView::F64(input.as_view()))?;
+    /// let mut backend = CpuBackend::new();
+    /// let outputs = backend.eig_read(TensorView::F64(input.as_view()))?;
     /// assert_eq!(outputs.len(), 2);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```

--- a/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
@@ -69,6 +69,15 @@ fn cpu_backend_source() -> String {
     .unwrap_or_else(|err| panic!("CPU linalg backend source should be readable: {err}"))
 }
 
+fn linalg_backend_trait_source() -> String {
+    fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("backend.rs"),
+    )
+    .unwrap_or_else(|err| panic!("linalg backend trait source should be readable: {err}"))
+}
+
 fn assert_unsafe_blocks_have_safety_comments(path: &str, source: &str) {
     let lines: Vec<_> = source.lines().collect();
     let mut missing = Vec::new();
@@ -101,6 +110,16 @@ fn source_section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
         .map(|offset| start_idx + offset)
         .unwrap_or(source.len());
     &source[start_idx..end_idx]
+}
+
+#[test]
+fn linalg_rustdoc_reuses_backend_in_read_examples() {
+    let source = linalg_backend_trait_source();
+
+    assert!(
+        !source.contains("CpuBackend::new()."),
+        "LinalgBackend rustdoc examples should bind and reuse CpuBackend instead of constructing it inline"
+    );
 }
 
 #[test]

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -22,8 +22,9 @@ allocation, explicit CPU/GPU transfer, broad structural/elementwise/reduction
 kernels, cuTENSOR contractions, and cuSOLVER/cuBLAS linear algebra paths.
 Performance optimization is still active work. The remaining unsupported CUDA
 cases are operation-specific: `eig`, `full_piv_lu`, `full_piv_lu_solve`,
-`dynamic_update_slice`, integer numeric/linalg gaps, `Bool` kernel gaps beyond
-transfer and reshape, and selected complex analytic or ordering operations.
+`dynamic_update_slice`, integer numeric/linalg gaps beyond add/mul/compare/select
+and sum/prod reductions, `Bool` kernel gaps beyond transfer and reshape, and
+selected complex analytic or ordering operations.
 WebGPU is being introduced incrementally. The implemented path covers explicit
 transfer plus `F32` `dot_general` through a CubeK BGEMM planner. `C32` GEMM is
 implemented through a CubeK-owned complex GEMM launch API that lowers to real
@@ -362,7 +363,7 @@ CUDA library calls:
 | Category | Current status |
 | --- | --- |
 | Allocation/transfer | CUDA allocation, upload, download, raw pointer bridge for all public tensor dtypes |
-| Elementwise | `F32`/`F64` arithmetic, comparison, selection, clamp, and analytic unary ops; `C32`/`C64` add/mul/div/neg/conj |
+| Elementwise | `F32`/`F64` arithmetic, comparison, selection, clamp, and analytic unary ops; `I32`/`I64` add/mul/compare/select; `C32`/`C64` add/mul/div/neg/conj |
 | Reductions | sum/prod for `F32`, `F64`, `I32`, `I64`, `C32`, and `C64`; min/max for `F32`/`F64` |
 | Structural | reshape for all public tensor dtypes; transpose, broadcast, reverse, concatenate, diagonal extraction/embedding, and triangular masks for non-`Bool` dtypes with CubeCL element storage |
 | Indexing | slice/pad/concatenate/reverse for `F32`, `F64`, `I32`, `I64`, `C32`, and `C64`; gather/dynamic_slice for `F32`, `F64`, `I32`, `C32`, and `C64` data with `F32`, `F64`, `I32`, or `I64` start/index tensors; scatter for floating and complex data with those numeric index tensors |
@@ -405,7 +406,8 @@ The following are intentionally outside the current batch:
 - selected complex analytic kernels and ordering operations,
 - CUDA implementations for `full_piv_lu`, `full_piv_lu_solve`, and
   `dynamic_update_slice`,
-- integer numeric/linalg CUDA kernels beyond structural and reduction paths,
+- integer numeric/linalg CUDA kernels beyond add/mul/compare/select,
+  structural paths, and sum/prod reductions,
 - `Bool` CUDA kernels beyond allocation, upload/download, and metadata-only
   reshape,
 - changing the public placement contract,

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -217,11 +217,13 @@ Legend:
 | Operation or family | CUDA dtype support | Notes |
 | --- | --- | --- |
 | Allocation, upload, download | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Explicit CPU/GPU transfer only |
-| `add`, `mul`, `div` | `F32`, `F64`, `C32`, `C64` | Same dtype inputs only; integer and `Bool` arithmetic are not implemented |
+| `add`, `mul` | `F32`, `F64`, `I32`, `I64`, `C32`, `C64` | Same dtype inputs only; `Bool` arithmetic is not implemented |
+| `div` | `F32`, `F64`, `C32`, `C64` | Same dtype inputs only; integer and `Bool` division are not implemented |
 | `neg` | `F32`, `F64`, `C32`, `C64` | Integer and `Bool` negation are not implemented |
 | `conj` | `F32`, `F64`, `C32`, `C64` | Real floating dtypes are identity; integer and `Bool` inputs are not implemented |
 | `abs`, `sign` | `F32`, `F64` | Complex, integer, and `Bool` inputs are not implemented |
-| `maximum`, `minimum`, `compare`, `select`, `clamp` | `F32`, `F64` | Complex ordering is not defined; `compare` returns a `Bool` tensor and `select` takes a `Bool` predicate |
+| `maximum`, `minimum`, `clamp` | `F32`, `F64` | Complex ordering is not defined; integer and `Bool` min/max/clamp are not implemented |
+| `compare`, `select` | `F32`, `F64`, `I32`, `I64` | Same dtype data inputs only; `compare` returns a `Bool` tensor and `select` takes a `Bool` predicate |
 | `exp`, `log`, `sin`, `cos`, `tanh`, `sqrt`, `rsqrt`, `expm1`, `log1p` | `F32`, `F64` | Complex analytic kernels are not implemented |
 | `pow` | `F32`, `F64` | Same dtype inputs only |
 | `reshape` | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Metadata-only shape change |

--- a/docs/worklogs/2026-07-08-issue-1314-1319-gpu-int-docs.md
+++ b/docs/worklogs/2026-07-08-issue-1314-1319-gpu-int-docs.md
@@ -1,0 +1,100 @@
+# Issue 1314 And 1319 CUDA Integer Parity Batch
+
+## Summary
+
+This session fixes two related, reviewable findings in one branch:
+
+- #1319: linalg rustdoc examples now bind and reuse `CpuBackend` instead of
+  presenting per-call backend construction as the normal style.
+- #1314: CUDA/CubeCL now supports the integer operation subset already
+  supported by the CPU backend for `I32` and `I64`: `add`, `mul`, `compare`,
+  and `select`. Existing CUDA integer sum/prod reduction coverage remains
+  unchanged.
+- Verification also surfaced stale `tenferro-gpu` doctest snippets for
+  `Tensor::from_vec_col_major` and `CudaExtensionCache::is_empty`; those
+  examples were updated to the current `Result`-returning APIs.
+
+The batch deliberately does not implement #1320 semantics-gated integer ops
+such as integer `neg`, `abs`, `sign`, `maximum`, `minimum`, `reduce_max`,
+`reduce_min`, `div`, `rem`, `pow`, or a new `sub` operation.
+
+## Context Read
+
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+- `REPOSITORY_RULES.md`
+- shared tensor4all common, Rust, performance, numerical, docs/test rules
+- `ai/contribution-workflows/bugfix-pr.md`
+- `ai/contribution-workflows/repository-remediation.md`
+- `docs/design/gpu-backend-design.md`
+- GitHub issues and comments for #1314, #1315, #1316, #1317, #1318, #1319,
+  and #1320
+- `crates/tenferro-linalg/src/backend.rs`
+- `crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs`
+- `crates/tenferro-gpu/src/kernels/elementwise.rs`
+- `crates/tenferro-gpu/src/cubecl/dispatch.rs`
+- `crates/tenferro-gpu/src/cubecl/mod.rs`
+- `crates/tenferro-gpu/src/cubecl/op_descriptor.rs`
+- `crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs`
+
+## Classification
+
+- #1319: Auto Fix. The examples were already valid but taught a backend
+  lifetime pattern that discards `CpuBackend`'s buffer pool and context.
+- #1314: Auto Fix for the phase-1 parity subset. CPU already supports
+  integer `add`, `mul`, `compare -> Bool`, `select`, `reduce_sum`, and
+  `reduce_prod`; CUDA already had integer sum/prod wiring, so the missing
+  piece was the elementwise dispatch/kernels.
+- #1315/#1316/#1317/#1318: Design Gate. These define future capability,
+  dispatch, output-mode, and docs-positioning architecture. They were read to
+  keep this PR scoped, not implemented here.
+- #1320: Design Gate. Integer ops that need overflow/division/rounding/API
+  decisions stay deferred.
+
+## Decisions
+
+- Keep #1314 within existing `TensorBackend` operations and existing dtypes.
+  No public API, operation family, feature flag, dependency, or backend is
+  added.
+- Split `Add`/`Mul` from `Div` in `GpuLaunchKind`: `Add` and `Mul` use a
+  float/complex/int launch family, while `Div` remains float/complex only.
+- Extend `compare` and `select` to float/int data dtypes only. Complex and
+  `Bool` support remain explicit unsupported/mismatch paths.
+- Reuse the existing raw Array elementwise launch helpers. The kernels launch
+  over the full output element domain and keep shape/device validation at the
+  host dispatch boundary.
+- Update the CUDA support matrix and GPU backend design note to reflect the
+  newly supported integer subset without implying #1320 coverage.
+
+## Verification Performed
+
+- RED:
+  `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.6 LD_LIBRARY_PATH=/usr/local/cuda-12.6/targets/x86_64-linux/lib:/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH cargo test -p tenferro-gpu --features cuda test_cubecl_integer_add_mul_compare_select_match_cpu -- --ignored`
+  failed with `DTypeMismatch { op: "add", lhs: I32, rhs: I32 }`.
+- GREEN:
+  the same command passed after adding integer CUDA dispatch and kernels.
+- `cargo fmt --all`
+- `cargo test -p tenferro-gpu --features cuda gpu_descriptors_have_catalog_dtype_policy`
+- `cargo test -p tenferro-linalg --test cpu_linalg_source_contract linalg_rustdoc_reuses_backend_in_read_examples -- --exact`
+- `cargo test --doc -p tenferro-linalg`
+- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.6 LD_LIBRARY_PATH=/usr/local/cuda-12.6/targets/x86_64-linux/lib:/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH cargo test -p tenferro-gpu --features cuda cubecl::tests::elementwise_tests -- --ignored`
+- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.6 LD_LIBRARY_PATH=/usr/local/cuda-12.6/targets/x86_64-linux/lib:/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH cargo test -p tenferro-gpu --features cuda cubecl::tests::reduction_tests::test_cubecl_i -- --ignored`
+- `cargo test -p tenferro-gpu --features cuda`
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --worktree --output-json /tmp/repository-rules-review-worktree.json`
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
+
+## Residual Risks
+
+- The local machine provides CUDA 12.6 rather than the documented CUDA 12.8
+  root. The targeted CUDA test ran successfully with the installed toolkit and
+  NVIDIA driver.
+- The broader capability descriptor work from #1315 remains future work, so
+  the support matrix is still hand-maintained in this PR.


### PR DESCRIPTION
> [!IMPORTANT]
> New features must start as a feature request issue.
> Please do not open a new-feature implementation PR before maintainers accept
> the issue and agree that implementation should start.
>
> If you already have prototype code, link to a fork branch, gist, or
> repository from the feature request issue instead of opening a PR.
>
> New-feature PRs opened before an accepted issue may be closed and redirected
> to an issue.
>
> If you are using an AI agent for a bug-fix PR, use or follow the
> repository-local `tenferro-bugfix-pr` workflow before editing code.

## Type

- [x] Bug fix
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1314
Fixes #1319
Refs #1315
Refs #1316
Refs #1317
Refs #1318
Refs #1320

## Summary

- Reuses a bound `CpuBackend` in linalg rustdoc examples and adds a source-contract test so `LinalgBackend` docs do not reintroduce per-call backend construction as the normal idiom.
- Adds CUDA/CubeCL `I32`/`I64` support for the #1314 phase-1 parity set: `add`, `mul`, `compare -> Bool`, and `select` with a `Bool` predicate.
- Keeps #1320 integer semantics-gated ops out of scope: integer `neg`, `abs`, `sign`, min/max, `reduce_min/max`, `div`, `rem`, `pow`, and new `sub` remain unsupported/deferred.
- Updates CUDA support docs, GPU backend design notes, and stale GPU doctests surfaced by verification.

## Work log

- `docs/worklogs/2026-07-08-issue-1314-1319-gpu-int-docs.md`

## Bug-fix scope gate

This PR stays within existing intended behavior and existing public APIs. It does not add a public API, operation family, backend, dependency, feature flag, architectural layer, or AD semantics. The issue discussion for #1314 identifies CPU-supported integer paths that CUDA rejected; #1320 remains the design gate for integer ops whose semantics are not yet accepted.

## Same-root-cause scan

- Verified #1314 issue comments and sibling Design Gate issues #1315/#1316/#1317/#1318/#1320 before implementing.
- Confirmed existing CUDA integer reduction tests already cover `I32`/`I64` sum/prod and reran them on GPU.
- Split `Add`/`Mul` launch metadata from `Div`, so integer arithmetic support does not accidentally imply integer division.
- Updated docs and AGENTS GPU status so the support matrix matches the new CUDA dispatch coverage.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test -p tenferro-linalg --test cpu_linalg_source_contract linalg_rustdoc_reuses_backend_in_read_examples -- --exact`
- `cargo test --doc -p tenferro-linalg`
- `cargo test -p tenferro-gpu --features cuda gpu_descriptors_have_catalog_dtype_policy`
- `cargo test -p tenferro-gpu --features cuda`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.6 LD_LIBRARY_PATH=/usr/local/cuda-12.6/targets/x86_64-linux/lib:/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH cargo test -p tenferro-gpu --features cuda cubecl::tests::elementwise_tests -- --ignored`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.6 LD_LIBRARY_PATH=/usr/local/cuda-12.6/targets/x86_64-linux/lib:/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH cargo test -p tenferro-gpu --features cuda cubecl::tests::reduction_tests::test_cubecl_i -- --ignored`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.