### PR TITLE
perf(linalg): reduce AD decomposition overhead

### DIFF
--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -23,6 +23,7 @@ cpu-faer = [
     "tenferro-cpu/cpu-faer",
 ]
 cpu-blas = [
+    "dep:cblas-sys",
     "tenferro-ad?/cpu-blas",
     "tenferro-cpu/cpu-blas",
 ]
@@ -68,6 +69,7 @@ tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-ma
 tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.2.0", default-features = false }
 tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0", default-features = false }
 tenferro-cpu = { path = "../tenferro-cpu", version = "0.2.0", default-features = false }
+cblas-sys = { workspace = true, optional = true }
 cblas-inject = { workspace = true, optional = true }
 computegraph = { workspace = true, optional = true }
 tidu = { workspace = true, optional = true }
@@ -81,3 +83,11 @@ lapack-inject = { workspace = true, optional = true }
 libloading = { workspace = true, optional = true }
 num-complex.workspace = true
 num-traits.workspace = true
+
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "lu_ad_breakdown"
+harness = false
+required-features = ["autodiff"]

--- a/crates/tenferro-linalg/benches/lu_ad_breakdown.rs
+++ b/crates/tenferro-linalg/benches/lu_ad_breakdown.rs
@@ -1,0 +1,250 @@
+use std::env;
+use std::sync::Arc;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use tenferro_ad::{AdContext, EagerRuntime, EagerTensor, Tensor};
+use tenferro_cpu::CpuBackend;
+use tenferro_linalg::EagerTensorLinalgExt;
+use tenferro_runtime::DotGeneralConfig;
+
+const DEFAULT_SIZES: &[usize] = &[256, 512];
+
+struct Fixture {
+    ctx: Arc<EagerRuntime>,
+    matrix: EagerTensor,
+    tangent: EagerTensor,
+    lu_loss: EagerTensor,
+    lower_unit: EagerTensor,
+    upper: EagerTensor,
+    rhs: EagerTensor,
+    scalar_one: EagerTensor,
+}
+
+fn bench_threads() -> usize {
+    env::var("TENFERRO_BENCH_THREADS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|&threads| threads > 0)
+        .unwrap_or(1)
+}
+
+fn bench_sizes() -> Vec<usize> {
+    env::var("TENFERRO_LINALG_BENCH_SIZES")
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .filter_map(|part| part.trim().parse::<usize>().ok())
+                .filter(|&size| size > 0)
+                .collect::<Vec<_>>()
+        })
+        .filter(|sizes| !sizes.is_empty())
+        .unwrap_or_else(|| DEFAULT_SIZES.to_vec())
+}
+
+fn ad_ctx(threads: usize) -> Arc<EagerRuntime> {
+    let ad = AdContext::builder()
+        .with_extension_rules(tenferro_linalg::ad_rules().unwrap())
+        .build()
+        .unwrap();
+    EagerRuntime::with_cpu_backend_and_ad_context(CpuBackend::with_threads(threads).unwrap(), &ad)
+}
+
+fn tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
+    Tensor::from_vec_col_major(shape, data).unwrap()
+}
+
+fn eager(ctx: &Arc<EagerRuntime>, shape: Vec<usize>, data: Vec<f64>) -> EagerTensor {
+    EagerTensor::from_tensor_in(tensor(shape, data), Arc::clone(ctx)).unwrap()
+}
+
+fn variable(ctx: &Arc<EagerRuntime>, shape: Vec<usize>, data: Vec<f64>) -> EagerTensor {
+    EagerTensor::requires_grad_in(tensor(shape, data), Arc::clone(ctx)).unwrap()
+}
+
+fn dense_matrix(n: usize, seed: u64) -> Vec<f64> {
+    let mut data = Vec::with_capacity(n * n);
+    for col in 0..n {
+        for row in 0..n {
+            let mixed = (row as u64)
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add((col as u64).wrapping_mul(1442695040888963407))
+                .wrapping_add(seed);
+            let mut value = (mixed % 2048) as f64 / 2048.0 - 0.5;
+            value *= 0.01;
+            if row == col {
+                value += 2.0 + row as f64 / n as f64;
+            }
+            data.push(value);
+        }
+    }
+    data
+}
+
+fn lower_unit_matrix(n: usize) -> Vec<f64> {
+    let mut data = vec![0.0; n * n];
+    for col in 0..n {
+        for row in col..n {
+            data[row + n * col] = if row == col {
+                1.0
+            } else {
+                ((row + col * 7 + 3) % 31) as f64 / 500.0
+            };
+        }
+    }
+    data
+}
+
+fn upper_matrix(n: usize) -> Vec<f64> {
+    let mut data = vec![0.0; n * n];
+    for col in 0..n {
+        for row in 0..=col {
+            data[row + n * col] = if row == col {
+                2.0 + row as f64 / n as f64
+            } else {
+                ((row * 11 + col + 5) % 37) as f64 / 400.0
+            };
+        }
+    }
+    data
+}
+
+fn reduce_all(tensor: &EagerTensor) -> EagerTensor {
+    let axes: Vec<usize> = (0..tensor.shape().len()).collect();
+    tensor.reduce_sum(&axes).unwrap()
+}
+
+fn fixture(n: usize, threads: usize) -> Fixture {
+    let ctx = ad_ctx(threads);
+    let matrix = variable(&ctx, vec![n, n], dense_matrix(n, 1));
+    let tangent = eager(&ctx, vec![n, n], dense_matrix(n, 2));
+    let lower_unit = eager(&ctx, vec![n, n], lower_unit_matrix(n));
+    let upper = eager(&ctx, vec![n, n], upper_matrix(n));
+    let rhs = eager(&ctx, vec![n, n], dense_matrix(n, 3));
+    let scalar_one = eager(&ctx, vec![], vec![1.0]);
+
+    let (_p, l, u, _parity) = matrix.lu().unwrap();
+    let lu_loss = reduce_all(&l).add(&reduce_all(&u)).unwrap();
+    let warm = ctx.jvp(&lu_loss, &matrix, &tangent).unwrap();
+    consume_f64(&warm);
+
+    Fixture {
+        ctx,
+        matrix,
+        tangent,
+        lu_loss,
+        lower_unit,
+        upper,
+        rhs,
+        scalar_one,
+    }
+}
+
+fn consume_f64(tensor: &EagerTensor) {
+    let materialized = tensor.materialized().unwrap();
+    black_box(materialized.shape());
+    black_box(materialized.as_slice::<f64>().unwrap()[0]);
+}
+
+fn consume_many(outputs: &[EagerTensor]) {
+    for output in outputs {
+        consume_f64(output);
+    }
+}
+
+fn bench_lu_ad_breakdown(c: &mut Criterion) {
+    let threads = bench_threads();
+    let mut group = c.benchmark_group(format!("tenferro_linalg/lu_ad_breakdown/threads_{threads}"));
+
+    for n in bench_sizes() {
+        let fixture = fixture(n, threads);
+
+        group.bench_function(BenchmarkId::new("lu_jvp_sum_lu_outputs", n), |bench| {
+            bench.iter(|| {
+                let out = fixture
+                    .ctx
+                    .jvp(
+                        black_box(&fixture.lu_loss),
+                        black_box(&fixture.matrix),
+                        black_box(&fixture.tangent),
+                    )
+                    .unwrap();
+                consume_f64(&out);
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("lu_forward_unpack", n), |bench| {
+            bench.iter(|| {
+                let (p, l, u, parity) = black_box(&fixture.matrix).lu().unwrap();
+                consume_many(&[p, l, u, parity]);
+            });
+        });
+
+        group.bench_function(
+            BenchmarkId::new("triangular_solve_left_unit_lower", n),
+            |bench| {
+                bench.iter(|| {
+                    let out = black_box(&fixture.lower_unit)
+                        .triangular_solve(black_box(&fixture.rhs), true, true, false, true)
+                        .unwrap();
+                    consume_f64(&out);
+                });
+            },
+        );
+
+        group.bench_function(
+            BenchmarkId::new("triangular_solve_right_upper", n),
+            |bench| {
+                bench.iter(|| {
+                    let out = black_box(&fixture.upper)
+                        .triangular_solve(black_box(&fixture.rhs), false, false, false, false)
+                        .unwrap();
+                    consume_f64(&out);
+                });
+            },
+        );
+
+        group.bench_function(
+            BenchmarkId::new("structural_lower_plus_identity", n),
+            |bench| {
+                bench.iter(|| {
+                    let strict_lower = black_box(&fixture.lower_unit).tril(-1).unwrap();
+                    let diagonal = fixture
+                        .scalar_one
+                        .broadcast_in_dim(black_box(&[n]), black_box(&[]))
+                        .unwrap();
+                    let eye = diagonal.embed_diag(0, 1).unwrap();
+                    let out = strict_lower.add(&eye).unwrap();
+                    consume_f64(&out);
+                });
+            },
+        );
+
+        group.bench_function(BenchmarkId::new("structural_upper_mask", n), |bench| {
+            bench.iter(|| {
+                let out = black_box(&fixture.upper).triu(0).unwrap();
+                consume_f64(&out);
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("dot_general_square", n), |bench| {
+            let config = DotGeneralConfig {
+                lhs_contracting_dims: vec![1],
+                rhs_contracting_dims: vec![0],
+                lhs_batch_dims: vec![],
+                rhs_batch_dims: vec![],
+            };
+            bench.iter(|| {
+                let out = black_box(&fixture.matrix)
+                    .dot_general(black_box(&fixture.rhs), black_box(config.clone()))
+                    .unwrap();
+                consume_f64(&out);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_lu_ad_breakdown);
+criterion_main!(benches);

--- a/crates/tenferro-linalg/src/ad/rules/mod.rs
+++ b/crates/tenferro-linalg/src/ad/rules/mod.rs
@@ -123,16 +123,24 @@ pub(crate) fn linearize_lu(
     let p = ValueRef::External(primal_out[0].clone());
     let l = ValueRef::External(primal_out[1].clone());
     let u = ValueRef::External(primal_out[2].clone());
-    let l_square = augment_unit_lower_to_square_fixed(
-        builder,
-        l.clone(),
-        SquareAugmentSpec::new(dtype, m_size, k_size, batch_shape, rank),
-    );
-    let u_square = augment_upper_to_square_fixed(
-        builder,
-        u.clone(),
-        SquareAugmentSpec::new(dtype, k_size, n_size, batch_shape, rank),
-    );
+    let l_square = if m_size == k_size {
+        l.clone()
+    } else {
+        ValueRef::Local(augment_unit_lower_to_square_fixed(
+            builder,
+            l.clone(),
+            SquareAugmentSpec::new(dtype, m_size, k_size, batch_shape, rank),
+        ))
+    };
+    let u_square = if k_size == n_size {
+        u.clone()
+    } else {
+        ValueRef::Local(augment_upper_to_square_fixed(
+            builder,
+            u.clone(),
+            SquareAugmentSpec::new(dtype, k_size, n_size, batch_shape, rank),
+        ))
+    };
 
     let pd_a = matmul_linear(builder, p, ValueRef::Local(da), vec![false, true], rank);
     let la = builder.add_operation(
@@ -142,7 +150,7 @@ pub(crate) fn linearize_lu(
             transpose_a: false,
             unit_diagonal: true,
         }),
-        vec![ValueRef::Local(l_square), ValueRef::Local(pd_a)],
+        vec![l_square.clone(), ValueRef::Local(pd_a)],
         OperationRole::Linearized {
             active_mask: vec![false, true],
         },
@@ -154,7 +162,7 @@ pub(crate) fn linearize_lu(
             transpose_a: false,
             unit_diagonal: false,
         }),
-        vec![ValueRef::Local(u_square), ValueRef::Local(la)],
+        vec![u_square.clone(), ValueRef::Local(la)],
         OperationRole::Linearized {
             active_mask: vec![false, true],
         },
@@ -164,7 +172,7 @@ pub(crate) fn linearize_lu(
         let x_lower = linear_unary(builder, StdTensorOp::Tril { k: -1 }, x);
         let dl_full = matmul_linear(
             builder,
-            ValueRef::Local(l_square),
+            l_square,
             ValueRef::Local(x_lower),
             vec![false, true],
             rank,
@@ -186,7 +194,7 @@ pub(crate) fn linearize_lu(
         let du_full = matmul_linear(
             builder,
             ValueRef::Local(x_upper),
-            ValueRef::Local(u_square),
+            u_square,
             vec![true, false],
             rank,
         );

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/triangular_solve.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/triangular_solve.rs
@@ -1,4 +1,6 @@
+use cblas_sys::{CBLAS_DIAG, CBLAS_LAYOUT, CBLAS_SIDE, CBLAS_TRANSPOSE, CBLAS_UPLO};
 use num_complex::{Complex32, Complex64};
+use num_traits::Zero;
 
 use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar};
 use tenferro_tensor::TypedTensor;
@@ -6,10 +8,11 @@ use tenferro_tensor::TypedTensor;
 use super::helpers::{
     batched_binary_result, check_lapack_info, dim_i32, has_zero_dim, matrix_core_and_batch_result,
     matrix_dims, square_core_and_batch_result, square_matrix_dim, tensor_from_vec_with_template,
-    transpose_col_major_data,
 };
 
-pub(crate) trait LapackTriangularSolve: Clone + Copy + PoolScalar {
+pub(crate) trait LapackTriangularSolve:
+    Clone + Copy + PartialEq + PoolScalar + Zero
+{
     fn trtrs(
         uplo: u8,
         trans: u8,
@@ -21,6 +24,19 @@ pub(crate) trait LapackTriangularSolve: Clone + Copy + PoolScalar {
         b: &mut [Self],
         ldb: i32,
         info: &mut i32,
+    );
+
+    fn trsm(
+        side: CBLAS_SIDE,
+        uplo: CBLAS_UPLO,
+        transa: CBLAS_TRANSPOSE,
+        diag: CBLAS_DIAG,
+        m: i32,
+        n: i32,
+        a: &[Self],
+        lda: i32,
+        b: &mut [Self],
+        ldb: i32,
     );
 }
 
@@ -41,6 +57,38 @@ impl LapackTriangularSolve for f64 {
         // provide column-major `a`/`b` buffers matching `lda`/`ldb`, and live `info`.
         unsafe {
             lapack::dtrtrs(uplo, trans, diag, n, nrhs, a, lda, b, ldb, info);
+        }
+    }
+
+    fn trsm(
+        side: CBLAS_SIDE,
+        uplo: CBLAS_UPLO,
+        transa: CBLAS_TRANSPOSE,
+        diag: CBLAS_DIAG,
+        m: i32,
+        n: i32,
+        a: &[Self],
+        lda: i32,
+        b: &mut [Self],
+        ldb: i32,
+    ) {
+        // SAFETY: callers validate dimensions and provide compact column-major
+        // `a` and writable `b` buffers with matching leading dimensions.
+        unsafe {
+            cblas_sys::cblas_dtrsm(
+                CBLAS_LAYOUT::CblasColMajor,
+                side,
+                uplo,
+                transa,
+                diag,
+                m,
+                n,
+                1.0,
+                a.as_ptr(),
+                lda,
+                b.as_mut_ptr(),
+                ldb,
+            );
         }
     }
 }
@@ -64,6 +112,38 @@ impl LapackTriangularSolve for f32 {
             lapack::strtrs(uplo, trans, diag, n, nrhs, a, lda, b, ldb, info);
         }
     }
+
+    fn trsm(
+        side: CBLAS_SIDE,
+        uplo: CBLAS_UPLO,
+        transa: CBLAS_TRANSPOSE,
+        diag: CBLAS_DIAG,
+        m: i32,
+        n: i32,
+        a: &[Self],
+        lda: i32,
+        b: &mut [Self],
+        ldb: i32,
+    ) {
+        // SAFETY: callers validate dimensions and provide compact column-major
+        // `a` and writable `b` buffers with matching leading dimensions.
+        unsafe {
+            cblas_sys::cblas_strsm(
+                CBLAS_LAYOUT::CblasColMajor,
+                side,
+                uplo,
+                transa,
+                diag,
+                m,
+                n,
+                1.0,
+                a.as_ptr(),
+                lda,
+                b.as_mut_ptr(),
+                ldb,
+            );
+        }
+    }
 }
 
 impl LapackTriangularSolve for Complex32 {
@@ -83,6 +163,39 @@ impl LapackTriangularSolve for Complex32 {
         // provide column-major `a`/`b` buffers matching `lda`/`ldb`, and live `info`.
         unsafe {
             lapack::ctrtrs(uplo, trans, diag, n, nrhs, a, lda, b, ldb, info);
+        }
+    }
+
+    fn trsm(
+        side: CBLAS_SIDE,
+        uplo: CBLAS_UPLO,
+        transa: CBLAS_TRANSPOSE,
+        diag: CBLAS_DIAG,
+        m: i32,
+        n: i32,
+        a: &[Self],
+        lda: i32,
+        b: &mut [Self],
+        ldb: i32,
+    ) {
+        let alpha = Complex32::new(1.0, 0.0);
+        // SAFETY: callers validate dimensions and provide compact column-major
+        // `a` and writable `b` buffers with matching leading dimensions.
+        unsafe {
+            cblas_sys::cblas_ctrsm(
+                CBLAS_LAYOUT::CblasColMajor,
+                side,
+                uplo,
+                transa,
+                diag,
+                m,
+                n,
+                (&alpha as *const Complex32).cast(),
+                a.as_ptr().cast(),
+                lda,
+                b.as_mut_ptr().cast(),
+                ldb,
+            );
         }
     }
 }
@@ -106,6 +219,84 @@ impl LapackTriangularSolve for Complex64 {
             lapack::ztrtrs(uplo, trans, diag, n, nrhs, a, lda, b, ldb, info);
         }
     }
+
+    fn trsm(
+        side: CBLAS_SIDE,
+        uplo: CBLAS_UPLO,
+        transa: CBLAS_TRANSPOSE,
+        diag: CBLAS_DIAG,
+        m: i32,
+        n: i32,
+        a: &[Self],
+        lda: i32,
+        b: &mut [Self],
+        ldb: i32,
+    ) {
+        let alpha = Complex64::new(1.0, 0.0);
+        // SAFETY: callers validate dimensions and provide compact column-major
+        // `a` and writable `b` buffers with matching leading dimensions.
+        unsafe {
+            cblas_sys::cblas_ztrsm(
+                CBLAS_LAYOUT::CblasColMajor,
+                side,
+                uplo,
+                transa,
+                diag,
+                m,
+                n,
+                (&alpha as *const Complex64).cast(),
+                a.as_ptr().cast(),
+                lda,
+                b.as_mut_ptr().cast(),
+                ldb,
+            );
+        }
+    }
+}
+
+fn cblas_uplo(lower: bool) -> CBLAS_UPLO {
+    if lower {
+        CBLAS_UPLO::CblasLower
+    } else {
+        CBLAS_UPLO::CblasUpper
+    }
+}
+
+fn cblas_transpose(transpose: bool) -> CBLAS_TRANSPOSE {
+    if transpose {
+        CBLAS_TRANSPOSE::CblasTrans
+    } else {
+        CBLAS_TRANSPOSE::CblasNoTrans
+    }
+}
+
+fn cblas_diag(unit_diagonal: bool) -> CBLAS_DIAG {
+    if unit_diagonal {
+        CBLAS_DIAG::CblasUnit
+    } else {
+        CBLAS_DIAG::CblasNonUnit
+    }
+}
+
+fn validate_non_unit_diagonal<T: LapackTriangularSolve>(
+    a: &TypedTensor<T>,
+    n: usize,
+    unit_diagonal: bool,
+) -> tenferro_tensor::Result<()> {
+    if unit_diagonal {
+        return Ok(());
+    }
+
+    let data = a.host_data()?;
+    for idx in 0..n {
+        if data[idx + idx * n] == T::zero() {
+            return Err(tenferro_tensor::Error::backend_failure(
+                "triangular_solve",
+                "matrix is singular",
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn solve_left<T: LapackTriangularSolve>(
@@ -160,23 +351,21 @@ fn solve_right<T: LapackTriangularSolve>(
         });
     }
 
-    let mut rhs_t = transpose_col_major_data(b.host_data()?, b_rows, n);
-    let mut info = 0;
-    T::trtrs(
-        if lower { b'L' } else { b'U' },
-        if transpose_a { b'N' } else { b'T' },
-        if unit_diagonal { b'U' } else { b'N' },
-        dim_i32(n, "triangular_solve")?,
+    validate_non_unit_diagonal(a, n, unit_diagonal)?;
+    let mut rhs = b.host_data()?.to_vec();
+    T::trsm(
+        CBLAS_SIDE::CblasRight,
+        cblas_uplo(lower),
+        cblas_transpose(transpose_a),
+        cblas_diag(unit_diagonal),
         dim_i32(b_rows, "triangular_solve")?,
+        dim_i32(n, "triangular_solve")?,
         a.host_data()?,
         dim_i32(n, "triangular_solve")?,
-        &mut rhs_t,
-        dim_i32(n, "triangular_solve")?,
-        &mut info,
+        &mut rhs,
+        dim_i32(b_rows, "triangular_solve")?,
     );
-    check_lapack_info("triangular_solve", "trtrs", info)?;
-    let result = transpose_col_major_data(&rhs_t, n, b_rows);
-    tensor_from_vec_with_template(vec![b_rows, n], result, b)
+    tensor_from_vec_with_template(vec![b_rows, n], rhs, b)
 }
 
 fn triangular_solve_2d<T: LapackTriangularSolve>(

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -265,6 +265,21 @@ impl ExtensionOp for LinalgExtensionOp {
         self.op.output_count()
     }
 
+    fn prune_outputs(&self, live_outputs: &[bool]) -> Option<Arc<dyn ExtensionOp>> {
+        match self.op {
+            LinalgOp::Svd { eps } if live_outputs == [false, true, false] => {
+                Some(Arc::new(Self::new(LinalgOp::SvdVals { eps })))
+            }
+            LinalgOp::Eigh { eps } if live_outputs == [true, false] => {
+                Some(Arc::new(Self::new(LinalgOp::EighVals { eps })))
+            }
+            LinalgOp::Eig { input_dtype } if live_outputs == [true, false] => {
+                Some(Arc::new(Self::new(LinalgOp::EigVals { input_dtype })))
+            }
+            _ => None,
+        }
+    }
+
     fn infer_output_meta(
         &self,
         input_dtypes: &[DType],

--- a/crates/tenferro-linalg/src/extension/tests.rs
+++ b/crates/tenferro-linalg/src/extension/tests.rs
@@ -84,3 +84,43 @@ fn extension_dtype_promotion_delegates_to_canonical_tensor_rules() {
         }
     }
 }
+
+#[test]
+fn decomposition_value_outputs_prune_to_values_only_ops() {
+    let svd = LinalgExtensionOp::new(LinalgOp::Svd { eps: 1.0e-12 });
+    let pruned_svd = svd
+        .prune_outputs(&[false, true, false])
+        .expect("S-only SVD should prune to SvdVals");
+    let pruned_svd = pruned_svd
+        .as_any()
+        .downcast_ref::<LinalgExtensionOp>()
+        .expect("pruned SVD op should stay in linalg family");
+    assert_eq!(pruned_svd.op(), LinalgOp::SvdVals { eps: 1.0e-12 });
+
+    let eigh = LinalgExtensionOp::new(LinalgOp::Eigh { eps: 1.0e-12 });
+    let pruned_eigh = eigh
+        .prune_outputs(&[true, false])
+        .expect("eigenvalue-only Hermitian eigendecomposition should prune to EighVals");
+    let pruned_eigh = pruned_eigh
+        .as_any()
+        .downcast_ref::<LinalgExtensionOp>()
+        .expect("pruned Eigh op should stay in linalg family");
+    assert_eq!(pruned_eigh.op(), LinalgOp::EighVals { eps: 1.0e-12 });
+
+    let eig = LinalgExtensionOp::new(LinalgOp::Eig {
+        input_dtype: DType::F64,
+    });
+    let pruned_eig = eig
+        .prune_outputs(&[true, false])
+        .expect("eigenvalue-only general eigendecomposition should prune to EigVals");
+    let pruned_eig = pruned_eig
+        .as_any()
+        .downcast_ref::<LinalgExtensionOp>()
+        .expect("pruned Eig op should stay in linalg family");
+    assert_eq!(
+        pruned_eig.op(),
+        LinalgOp::EigVals {
+            input_dtype: DType::F64
+        }
+    );
+}

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -909,39 +909,42 @@ fn matrix_norm(a: &TracedTensor, axes: &[usize], ord: Option<f64>) -> Result<Tra
 }
 
 fn svd_values(a: &TracedTensor) -> Result<TracedTensor> {
-    one_output(
+    let (_u, s, _vt) = three_outputs(
         apply(
-            Arc::new(LinalgExtensionOp::new(LinalgOp::SvdVals {
+            Arc::new(LinalgExtensionOp::new(LinalgOp::Svd {
                 eps: DEFAULT_DECOMPOSITION_AD_EPS,
             })),
             &[a],
         )?,
         "svd_values",
-    )
+    )?;
+    Ok(s)
 }
 
 fn eigh_values(a: &TracedTensor) -> Result<TracedTensor> {
-    one_output(
+    let (values, _vectors) = two_outputs(
         apply(
-            Arc::new(LinalgExtensionOp::new(LinalgOp::EighVals {
+            Arc::new(LinalgExtensionOp::new(LinalgOp::Eigh {
                 eps: DEFAULT_DECOMPOSITION_AD_EPS,
             })),
             &[a],
         )?,
         "eigh_values",
-    )
+    )?;
+    Ok(values)
 }
 
 fn eig_values(a: &TracedTensor) -> Result<TracedTensor> {
-    one_output(
+    let (values, _vectors) = two_outputs(
         apply(
-            Arc::new(LinalgExtensionOp::new(LinalgOp::EigVals {
+            Arc::new(LinalgExtensionOp::new(LinalgOp::Eig {
                 input_dtype: a.dtype,
             })),
             &[a],
         )?,
         "eig_values",
-    )
+    )?;
+    Ok(values)
 }
 
 fn scale_matrix_columns(matrix: &TracedTensor, scale: &TracedTensor) -> Result<TracedTensor> {

--- a/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
@@ -140,6 +140,33 @@ fn lapack_ffi_unsafe_blocks_document_safety_invariants() {
 }
 
 #[test]
+fn lapack_right_triangular_solve_uses_right_side_trsm_without_physical_transposes() {
+    let source = cpu_lapack_source("triangular_solve.rs");
+    let solve_right = source_section(&source, "fn solve_right", "fn triangular_solve_2d");
+
+    assert!(
+        solve_right.contains("T::trsm("),
+        "right-side triangular_solve should call BLAS TRSM directly"
+    );
+    assert!(
+        solve_right.contains("CblasRight"),
+        "right-side triangular_solve should use BLAS side=Right"
+    );
+    assert!(
+        !solve_right.contains("transpose_col_major_data("),
+        "right-side triangular_solve should not physically transpose RHS data"
+    );
+    assert!(
+        !solve_right.contains("T::trtrs("),
+        "right-side triangular_solve should not emulate side=Right through LAPACK TRTRS"
+    );
+    assert!(
+        solve_right.contains("validate_non_unit_diagonal"),
+        "right-side TRSM path should preserve non-unit singular checks before calling BLAS"
+    );
+}
+
+#[test]
 fn lapack_batched_helpers_reuse_input_scratch_instead_of_copying_per_batch() {
     let source = cpu_lapack_helpers_source();
     let batched_helpers = source_section(

--- a/crates/tenferro-linalg/tests/traced_ad_explicit.rs
+++ b/crates/tenferro-linalg/tests/traced_ad_explicit.rs
@@ -45,6 +45,24 @@ fn reduce_all(tensor: &TracedTensor) -> TracedTensor {
     tensor.reduce_sum(&axes).unwrap()
 }
 
+fn graph_op_debugs(tensor: &TracedTensor) -> Vec<String> {
+    let mut ops = Vec::new();
+    collect_graph_op_debugs(tensor.graph(), &mut ops);
+    ops
+}
+
+fn collect_graph_op_debugs(graph: &computegraph::graph::Graph<StdTensorOp>, ops: &mut Vec<String>) {
+    for parent in graph.parents() {
+        collect_graph_op_debugs(parent, ops);
+    }
+    ops.extend(
+        graph
+            .operations()
+            .iter()
+            .map(|node| format!("{:?}", node.operation)),
+    );
+}
+
 fn weighted_square_sum(
     tensor: &TracedTensor,
     shape: Vec<usize>,
@@ -264,6 +282,46 @@ fn triangular_solve_jvp_rejects_non_square_lhs_without_panic() {
     let result = catch_unwind(AssertUnwindSafe(|| ad.jvp(&loss, &a, &da)));
 
     assert_invalid_ad_graph_build(result, "jvp", "tenferro-linalg.triangular_solve", "square");
+}
+
+#[test]
+fn square_lu_jvp_does_not_materialize_solve_input_augmentations() {
+    let ad = ad_context();
+    let matrix =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![2.0, 0.5, 0.25, 3.0]))
+            .unwrap();
+    let tangent =
+        TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![0.2, 0.1, -0.1, 0.4]))
+            .unwrap();
+    let (_p, l, u, _parity) = matrix.lu().unwrap();
+    let loss = (&reduce_all(&l) + &reduce_all(&u)).unwrap();
+    let jvp = ad.jvp(&loss, &matrix, &tangent).unwrap();
+
+    let op_debugs = graph_op_debugs(&jvp);
+    assert!(
+        !op_debugs.iter().any(|op| op.contains("EmbedDiag")),
+        "square LU JVP should not build a dense identity for triangular solve inputs: {op_debugs:#?}"
+    );
+    assert!(
+        !op_debugs.iter().any(|op| op.contains("BroadcastInDim")),
+        "square LU JVP should not broadcast identity diagonals: {op_debugs:#?}"
+    );
+    assert_eq!(
+        op_debugs
+            .iter()
+            .filter(|op| op.contains("Tril { k: -1 }"))
+            .count(),
+        1,
+        "square LU JVP should keep only the output-forming strict-lower mask: {op_debugs:#?}"
+    );
+    assert_eq!(
+        op_debugs
+            .iter()
+            .filter(|op| op.contains("Triu { k: 0 }"))
+            .count(),
+        1,
+        "square LU JVP should keep only the output-forming upper mask: {op_debugs:#?}"
+    );
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/traced_ad_explicit.rs
+++ b/crates/tenferro-linalg/tests/traced_ad_explicit.rs
@@ -371,7 +371,26 @@ fn spectral_norm_jvp_matches_finite_diff_through_values_only_svd() {
             .unwrap();
 
     let norm = matrix.norm(Some(2.0), Some(&[0, 1]), false).unwrap();
-    let actual = eval(&ad.jvp(&norm, &matrix, &tangent).unwrap());
+    let primal_op_debugs = graph_op_debugs(&norm);
+    assert!(
+        primal_op_debugs.iter().any(|op| op.contains("Svd {")),
+        "spectral norm primal graph should carry full SVD residuals for AD: {primal_op_debugs:#?}"
+    );
+    assert!(
+        !primal_op_debugs.iter().any(|op| op.contains("SvdVals")),
+        "spectral norm primal graph should not use values-only SVD before compile-time pruning: {primal_op_debugs:#?}"
+    );
+    let jvp = ad.jvp(&norm, &matrix, &tangent).unwrap();
+    let op_debugs = graph_op_debugs(&jvp);
+    assert!(
+        !op_debugs.iter().any(|op| op.contains("SvdVals")),
+        "spectral norm JVP should reuse a full SVD residual instead of keeping a values-only primal op: {op_debugs:#?}"
+    );
+    assert!(
+        !op_debugs.iter().any(|op| op.contains("Svd {")),
+        "spectral norm JVP should not emit an extra full SVD after residual reuse: {op_debugs:#?}"
+    );
+    let actual = eval(&jvp);
 
     assert_close_scalar(
         "spectral norm directional JVP",

--- a/crates/tenferro-linalg/tests/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/traced_extension.rs
@@ -2,7 +2,7 @@ use num_complex::{Complex32, Complex64};
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::TracedTensorLinalgExt;
 use tenferro_runtime::{
-    DType, Error, GraphCompiler, GraphExecutor, Tensor, TracedTensor, TypedTensor,
+    DType, Error, GraphCompiler, GraphExecutor, GraphOpView, Tensor, TracedTensor, TypedTensor,
 };
 use tenferro_tensor::Error as TensorError;
 
@@ -94,6 +94,39 @@ fn complex_svd_runtime_singular_values_match_traced_real_dtype() {
     assert_eq!(outputs[1].dtype(), DType::F64);
     assert_eq!(outputs[0].shape(), &[2]);
     assert_eq!(outputs[1].shape(), &[2]);
+}
+
+#[test]
+fn spectral_norm_compile_prunes_residual_svd_to_values_only_op() {
+    let a = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![3, 2], vec![3.0_f64, 0.1, 0.2, 0.3, 2.0, 0.4]).unwrap(),
+    )
+    .unwrap();
+    let norm = a.norm(Some(2.0), Some(&[0, 1]), false).unwrap();
+
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(&norm).unwrap();
+    let extension_ops = program
+        .lowering_view()
+        .instructions()
+        .filter_map(|inst| match inst.op() {
+            GraphOpView::Extension { op }
+                if op.family_id() == tenferro_linalg::LINALG_EXTENSION_FAMILY_ID =>
+            {
+                Some(format!("{op:?}"))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        extension_ops.iter().any(|op| op.contains("SvdVals")),
+        "forward-only spectral norm should lower residual SVD to values-only op: {extension_ops:#?}"
+    );
+    assert!(
+        !extension_ops.iter().any(|op| op.contains("Svd {")),
+        "forward-only spectral norm should not execute full SVD after pruning: {extension_ops:#?}"
+    );
 }
 
 #[test]

--- a/crates/tenferro-runtime/src/graph/compiler.rs
+++ b/crates/tenferro-runtime/src/graph/compiler.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-use computegraph::compile::compile;
+use computegraph::compile::{compile, CompiledProgram};
 use computegraph::materialize::materialize_merge;
 use computegraph::resolve::resolve;
 use computegraph::types::ValueKey;
@@ -11,6 +11,7 @@ use lru::LruCache;
 use num_complex::{Complex32, Complex64};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::input_key::TensorInputKey;
+use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{DType, Tensor, TensorScalar};
 
 use super::cache::{
@@ -398,7 +399,8 @@ impl GraphCompiler {
 
         let view = resolve(roots);
         let graph = materialize_merge(&view, &output_keys);
-        let compiled = compile(&graph);
+        let mut compiled = compile(&graph);
+        prune_compiled_extension_outputs(&mut compiled)?;
 
         let mut descriptors = Vec::with_capacity(graph.inputs.len());
         let mut input_dtypes = Vec::with_capacity(graph.inputs.len());
@@ -514,6 +516,75 @@ fn descriptor_for_input(
     })
 }
 
+fn prune_compiled_extension_outputs(prog: &mut CompiledProgram<StdTensorOp>) -> Result<()> {
+    let mut live_slots = vec![false; prog.n_slots];
+    for &slot in &prog.output_slots {
+        let Some(live) = live_slots.get_mut(slot) else {
+            return Err(invalid_compiled_graph(format!(
+                "program output slot {slot} is outside slot table of length {}",
+                prog.n_slots
+            )));
+        };
+        *live = true;
+    }
+
+    for instr in prog.instructions.iter_mut().rev() {
+        let live_outputs = instr
+            .outputs
+            .iter()
+            .map(|&slot| {
+                live_slots.get(slot).copied().ok_or_else(|| {
+                    invalid_compiled_graph(format!(
+                        "instruction output slot {slot} is outside slot table of length {}",
+                        prog.n_slots
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        if let StdTensorOp::Extension(ext) = &instr.operation {
+            if let Some(pruned) = ext.prune_outputs(&live_outputs) {
+                let kept_outputs = instr
+                    .outputs
+                    .iter()
+                    .zip(live_outputs.iter())
+                    .filter_map(|(&slot, &live)| live.then_some(slot))
+                    .collect::<Vec<_>>();
+                if pruned.output_count() != kept_outputs.len() {
+                    return Err(invalid_compiled_graph(format!(
+                        "extension family_id={:?} pruned to {} outputs for {} live slots",
+                        ext.family_id(),
+                        pruned.output_count(),
+                        kept_outputs.len()
+                    )));
+                }
+                instr.operation = StdTensorOp::Extension(pruned);
+                instr.outputs = kept_outputs;
+            }
+        }
+
+        if live_outputs.iter().any(|&live| live) {
+            for &slot in &instr.inputs {
+                let Some(live) = live_slots.get_mut(slot) else {
+                    return Err(invalid_compiled_graph(format!(
+                        "instruction input slot {slot} is outside slot table of length {}",
+                        prog.n_slots
+                    )));
+                };
+                *live = true;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn invalid_compiled_graph(message: impl Into<String>) -> Error {
+    Error::InvalidCompiledGraph {
+        message: message.into(),
+    }
+}
+
 fn default_tensors_equivalent(lhs: &Arc<Tensor>, rhs: &Arc<Tensor>) -> bool {
     if Arc::ptr_eq(lhs, rhs) {
         return true;
@@ -544,7 +615,10 @@ fn default_slices_equivalent<T: TensorScalar + PartialEq>(lhs: &Tensor, rhs: &Te
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::any::Any;
+    use std::hash::Hasher;
     use std::sync::Arc;
+    use tenferro_ops::{ext_op::ExtensionOp, SymDim};
     use tenferro_tensor::{
         Buffer, BufferHandle, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement,
         TypedTensor,
@@ -600,5 +674,91 @@ mod tests {
             "distinct backend-resident default tensors must not compare equal just because both are unreadable on host"
         );
         assert!(default_tensors_equivalent(&lhs, &lhs));
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct PrunableTestOp {
+        pruned: bool,
+    }
+
+    impl ExtensionOp for PrunableTestOp {
+        fn family_id(&self) -> &'static str {
+            "tenferro-runtime.test-prunable.v1"
+        }
+
+        fn payload_hash(&self, hasher: &mut dyn Hasher) {
+            hasher.write_u8(u8::from(self.pruned));
+        }
+
+        fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+            other
+                .as_any()
+                .downcast_ref::<Self>()
+                .is_some_and(|that| self == that)
+        }
+
+        fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+            Arc::new(self.clone())
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn input_count(&self) -> usize {
+            1
+        }
+
+        fn output_count(&self) -> usize {
+            if self.pruned {
+                1
+            } else {
+                3
+            }
+        }
+
+        fn infer_output_meta(
+            &self,
+            input_dtypes: &[DType],
+            input_shapes: &[&[SymDim]],
+        ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+            Ok((0..self.output_count())
+                .map(|_| (input_dtypes[0], input_shapes[0].to_vec()))
+                .collect())
+        }
+
+        fn prune_outputs(&self, live_outputs: &[bool]) -> Option<Arc<dyn ExtensionOp>> {
+            (!self.pruned && live_outputs == [false, true, false])
+                .then(|| Arc::new(Self { pruned: true }) as Arc<dyn ExtensionOp>)
+        }
+    }
+
+    #[test]
+    fn compile_prunes_extension_outputs_with_replacement_op() {
+        let input = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+        let outputs =
+            crate::extension::apply(Arc::new(PrunableTestOp { pruned: false }), &[&input]).unwrap();
+
+        let program = GraphCompiler::new().compile(&outputs[1]).unwrap();
+        let pruned_instruction = program
+            .lowering_view()
+            .instructions()
+            .find_map(|inst| match inst.op() {
+                crate::GraphOpView::Extension { op }
+                    if op.family_id() == "tenferro-runtime.test-prunable.v1" =>
+                {
+                    Some((
+                        inst.output_slots().to_vec(),
+                        format!("{op:?}"),
+                        op.output_count(),
+                    ))
+                }
+                _ => None,
+            })
+            .expect("compiled program should contain the test extension");
+
+        assert_eq!(pruned_instruction.0.len(), 1);
+        assert!(pruned_instruction.1.contains("pruned: true"));
+        assert_eq!(pruned_instruction.2, 1);
     }
 }

--- a/docs/worklogs/2026-07-08-linalg-residual-pruning.md
+++ b/docs/worklogs/2026-07-08-linalg-residual-pruning.md
@@ -1,0 +1,51 @@
+# Linalg Residual-Aware Decomposition Pruning
+
+Date: 2026-07-08
+
+## Summary
+
+This work reduces traced AD overhead for values-only decomposition users such
+as spectral norm. Values-only traced helpers now build full decomposition
+graphs so AD can reuse residual outputs, while runtime compilation prunes
+forward-only full decompositions back to lighter values-only extension ops.
+
+## Context Read
+
+- `crates/tenferro-linalg/src/traced.rs`
+- `crates/tenferro-linalg/src/ad/rules/mod.rs`
+- `crates/tenferro-linalg/src/extension.rs`
+- `crates/tenferro-runtime/src/graph/compiler.rs`
+- `crates/tenferro-runtime/src/compiler/mod.rs`
+- `crates/tenferro-internal-ops/src/ext_op.rs`
+- `tidu::linear_transpose` in the pinned tidu checkout
+
+## Decisions
+
+- Runtime graph compilation now performs an extension-output pruning pass over
+  the compiled SSA program before lowering to `ExecProgram`.
+- The pruning pass uses `ExtensionOp::prune_outputs` as an operation-replacement
+  hook, not just as a dead-output filter.
+- `LinalgOp::Svd`, `Eigh`, and `Eig` prune to `SvdVals`, `EighVals`, and
+  `EigVals` when only the values output is live.
+- Traced `svd_values`, `eigh_values`, and `eig_values` helpers now construct the
+  full decomposition and return only the values output. This lets AD reuse U/VT
+  or eigenvectors from the primal graph instead of emitting another
+  decomposition inside the derivative graph.
+
+## Rejected Or Deferred
+
+- Eager values-only decomposition residual hooks are not added because the
+  current public eager linalg surface exposes full `svd`, `eigh`, and `eig`, not
+  values-only helpers.
+- Solve-transpose residual reuse is deferred. The relevant transpose rules need
+  the primal solution output, but the current pinned `tidu::linear_transpose`
+  does not pass operation-output primal keys through `ShapeGuardContext`. The
+  sibling `tidu-rs` checkout is dirty with conflicts, so this PR avoids mixing
+  an upstream tidu API change into the linalg pruning work.
+
+## Verification
+
+- `cargo test -p tenferro-runtime --lib`
+- `cargo test -p tenferro-linalg --lib --tests`
+- `cargo test -p tenferro-linalg --features autodiff --lib --tests`
+


### PR DESCRIPTION
## Summary

- reduce LU AD overhead by avoiding square-system augmentation and using BLAS `trsm` for right-side triangular solves
- make traced `svd_values`, `eigh_values`, and `eig_values` emit full decomposition ops so AD can reuse decomposition residuals
- add compiled extension-output pruning so forward-only value uses lower back to `SvdVals`, `EighVals`, or `EigVals`
- keep the LU AD breakdown benchmark for future profiling

## Design notes

The runtime compiler now lets extension ops replace themselves when only a subset of outputs remains live. Linalg uses that hook to keep values-only forward execution lightweight while preserving full decomposition residuals when AD needs vectors.

Work log: `docs/worklogs/2026-07-08-linalg-residual-pruning.md`

The solve-transpose primal-solution residual hook is intentionally deferred. It needs a `tidu` linear-transpose API cleanup so transpose rules can see primal output keys cleanly instead of using a tenferro-local workaround.

Refs #1328.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p tenferro-runtime --lib`
- `cargo test -p tenferro-linalg --features autodiff --lib --tests`
- `cargo test -p tenferro-linalg --lib --tests`
- `cargo test --workspace --release`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
