### PR TITLE
docs: sync eager functional AD surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ tenferro-rs provides typed and dynamic dense tensors, explicit backend
 dispatch, linear algebra, einsum, FFT, and extensible automatic differentiation
 native to Rust. Use it as an ordinary tensor library first: direct
 `TypedTensor` and `Tensor` APIs run through a chosen CPU, CUDA, or experimental
-WebGPU backend, while `EagerTensor` and `TracedTensor` add PyTorch-style
-`backward()` or JAX-style graph transforms when a workflow needs AD.
+WebGPU backend, while `EagerTensor` and `TracedTensor` add automatic
+differentiation when a workflow needs it. Eager code can use PyTorch-style
+`backward()` on tracked losses or `EagerRuntime` functional `grad`, `vjp`, and
+`jvp`; traced code builds graph transforms for compile/run reuse.
 
 Positioning: tenferro-rs sits between low-level array crates and full
 deep-learning frameworks for Rust scientific code that needs column-major
@@ -132,7 +134,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 <!-- end-snippet-source -->
 
-For PyTorch-style eager autodiff with `backward()`, see the
+For PyTorch-style eager autodiff with `backward()` and functional
+`EagerRuntime` transforms, see the
 [eager autodiff tutorial](https://tensor4all.org/tenferro-rs/tutorials/eager-autodiff-pytorch-style.html).
 Setup notes, including local-checkout builds and BLAS provider selection, are
 in [Getting Started](https://tensor4all.org/tenferro-rs/getting-started/index.html).
@@ -146,9 +149,10 @@ tenferro-rs is a good fit when:
   counts resolve at execution time — the daily reality of tensor networks and
   much of adaptive scientific computing (see
   [dynamic and symbolic shapes](https://tensor4all.org/tenferro-rs/design/dynamic-symbolic-shapes.html)).
-- **You want autodiff in Rust without a Python runtime.** `backward()` on
-  eager tensors; `grad`, `vjp`, `jvp`, and HVP on traced graphs; shipped as a
-  single binary.
+- **You want autodiff in Rust without a Python runtime.** `backward()` plus
+  functional `grad`, `vjp`, `jvp`, and HVP composition on eager tensors;
+  compiled `grad`, `vjp`, `jvp`, and HVP workflows on traced graphs; shipped as
+  a single binary.
 - **Your data lives in the column-major world.** Storage matches Fortran,
   Julia, MATLAB, and LAPACK/BLAS conventions, and strided views bridge
   row-major data without eager copies (see
@@ -181,7 +185,7 @@ tenferro-rs is for projects that want this kind of stack natively in Rust.
 | --- | --- |
 | Fixed scalar type, ordinary tensor computation, no autodiff | `TypedTensor<T, R>` |
 | Runtime dtype selection or direct backend dispatch | `Tensor` with an explicit backend |
-| Immediate execution in one runtime, optionally with `backward()` on scalar losses | `EagerTensor` and `EagerRuntime` |
+| Immediate execution in one runtime, optionally with `backward()` or functional `grad`/`vjp`/`jvp` | `EagerTensor` and `EagerRuntime` |
 | `grad`, `vjp`, and `jvp` on traced graphs, graph reuse, or repeated compile/run execution | `TracedTensor`, `GraphCompiler`, and `GraphExecutor<B>` |
 | CUDA or experimental WebGPU execution | The same tensor API plus explicit GPU upload/download and supported provider backend features |
 | Static-shaped StableHLO and PJRT plugin experiments | `GraphCompiler` plus `tenferro-xla` |

--- a/docs/assets/tenferro-architecture.svg
+++ b/docs/assets/tenferro-architecture.svg
@@ -13,12 +13,12 @@
       .fam  { fill: #dbeafe; stroke: #2563eb; stroke-width: 1.5; }
       .xla  { fill: #fff7ed; stroke: #b45309; stroke-width: 1.5; }
       .ext  { fill: #ffffff; stroke: #94a3b8; stroke-width: 1.3; stroke-dasharray: 5 4; }
-      .name { font: 700 13px system-ui, sans-serif; fill: #0f172a; text-anchor: middle; }
-      .sub  { font: 11px system-ui, sans-serif; fill: #475569; text-anchor: middle; }
-      .tag  { font: 700 10px system-ui, sans-serif; fill: #94a3b8; }
-      .hdr  { font: 700 11px system-ui, sans-serif; fill: #475569; text-anchor: middle; letter-spacing: 0.4px; }
-      .cap  { font: italic 12px system-ui, sans-serif; fill: #334155; text-anchor: middle; }
-      .leg  { font: 11px system-ui, sans-serif; fill: #475569; }
+      .name { font-family: "DejaVu Sans"; font-size: 13px; font-weight: 700; fill: #0f172a; text-anchor: middle; }
+      .sub  { font-family: "DejaVu Sans"; font-size: 11px; fill: #475569; text-anchor: middle; }
+      .tag  { font-family: "DejaVu Sans"; font-size: 10px; font-weight: 700; fill: #94a3b8; }
+      .hdr  { font-family: "DejaVu Sans"; font-size: 11px; font-weight: 700; fill: #475569; text-anchor: middle; letter-spacing: 0.4px; }
+      .cap  { font-family: "DejaVu Sans"; font-size: 12px; font-style: italic; fill: #334155; text-anchor: middle; }
+      .leg  { font-family: "DejaVu Sans"; font-size: 11px; fill: #475569; }
       .dep  { stroke: #334155; stroke-width: 1.6; marker-end: url(#arr); fill: none; }
       .use  { stroke: #64748b; stroke-width: 1.2; stroke-dasharray: 4 4; marker-end: url(#arr); fill: none; }
       .gp   { stroke: #b45309; stroke-width: 1.4; stroke-dasharray: 5 3; marker-end: url(#arr-xla); fill: none; }
@@ -35,11 +35,13 @@
   <text x="324" y="52" class="name" style="font-size:12px">TypedTensor · Tensor</text>
   <text x="324" y="69" class="sub">no AD</text>
   <rect x="396" y="30" width="128" height="52" rx="6" class="box"/>
-  <text x="460" y="52" class="name" style="font-size:12px">EagerTensor</text>
-  <text x="460" y="69" class="sub">.backward()</text>
+  <text x="460" y="50" class="name" style="font-size:12px">EagerTensor</text>
+  <text x="460" y="65" class="sub" style="font-size:10px">backward · grad</text>
+  <text x="460" y="78" class="sub" style="font-size:10px">vjp · jvp</text>
   <rect x="532" y="30" width="128" height="52" rx="6" class="box"/>
-  <text x="596" y="52" class="name" style="font-size:12px">TracedTensor</text>
-  <text x="596" y="69" class="sub">grad · vjp · jvp</text>
+  <text x="596" y="50" class="name" style="font-size:12px">TracedTensor</text>
+  <text x="596" y="65" class="sub" style="font-size:10px">compile/run</text>
+  <text x="596" y="78" class="sub" style="font-size:10px">grad · vjp · jvp</text>
 
   <line x1="460" y1="84" x2="460" y2="106" class="dep"/>
 

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -3,9 +3,9 @@
 tenferro separates tensor data, execution timing, automatic differentiation,
 and device location. That separation is the main design point: users can stay
 in typed tensor code for ordinary numeric work without autodiff, move to eager
-execution for PyTorch-like forward-and-backward training loops, or move to
-traced graphs for JAX-like `grad`, `vjp`, and `jvp` workflows plus compile/run
-reuse.
+execution for PyTorch-like forward-and-backward training loops or functional
+`grad`, `vjp`, and `jvp` transforms, or move to traced graphs for compiled
+transform workflows plus compile/run reuse.
 
 ## The Three Axes
 
@@ -25,8 +25,8 @@ to a CUDA backend.
 | --- | --- | --- |
 | `TypedTensor<T>` | Concrete tensor with compile-time scalar type | Most typed numeric code, typed host data, typed linalg/einsum |
 | `Tensor` | Concrete tensor with runtime dtype | Dynamic dtype workflows, backend dispatch, CPU/CUDA values |
-| `EagerTensor` | Concrete tensor in an eager runtime, with optional gradient tracking | Immediate forward execution; reverse-mode AD on scalar losses when tracked |
-| `TracedTensor` | Graph-building tensor | `grad`, `vjp`, and `jvp` on traced graphs, graph optimization, repeated execution |
+| `EagerTensor` | Concrete tensor in an eager runtime, with optional gradient tracking | Immediate forward execution; `backward()` on scalar losses and `EagerRuntime` functional transforms when tracked |
+| `TracedTensor` | Graph-building tensor | Compiled `grad`, `vjp`, and `jvp` on traced graphs, graph optimization, repeated execution |
 
 Use the smallest layer that matches the job. AD is optional, and many projects
 should never leave the concrete tensor APIs.
@@ -98,7 +98,7 @@ Einsum is provided by the `tenferro-einsum` standard extension. Traced code
 uses `GraphCompilerEinsumExt` and registers `tenferro_einsum::register_runtime`
 on the executor.
 
-## Eager Execution And Backward
+## Eager Execution And Autodiff
 
 `EagerTensor` wraps concrete values in an `EagerRuntime`. Each operation
 computes or submits immediately and returns a concrete tensor handle. CPU
@@ -107,8 +107,11 @@ host inspection. If a tensor is a tracked variable, eager operations also
 record reverse-mode state so a scalar loss can call `backward()` and accumulate
 gradients.
 
-This is not the forward-mode AD/JVP API. Use `TracedTensor` for `grad`, `vjp`,
-`jvp`, and HVP via composition on traced graphs.
+When the derivative itself should be returned as an eager tensor instead of
+accumulated into a gradient slot, call `EagerRuntime::grad`,
+`EagerRuntime::vjp`, or `EagerRuntime::jvp`. These functional eager transforms
+can be composed for HVP-style workflows. Use `TracedTensor` when the derivative
+workflow should be compiled, optimized as a graph, or reused across runs.
 
 <!-- snippet-source: crates/tenferro-ad/examples/eager_backward.rs -->
 ```rust
@@ -159,8 +162,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 <!-- end-snippet-source -->
 
-Traced mode is the right API for `grad`, `vjp`, `jvp`, and HVP via composition
-on traced graphs, symbolic inputs, graph optimization, and repeated execution.
+Traced mode is the right API when `grad`, `vjp`, `jvp`, or HVP-style
+composition should run on traced graphs with symbolic inputs, graph
+optimization, and repeated execution.
 Core primitive AD rules are available by default. Extension operation families
 that provide AD rules, such as `tenferro-linalg`, require enabling that crate's
 `autodiff` feature and registering the extension rule set with

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,9 +1,9 @@
 # Getting Started
 
 tenferro supports tensor computation without autodiff, immediate execution with
-optional `backward()` on scalar losses, traced graph execution, `grad`, `vjp`,
-and `jvp` on traced graphs, einsum, linear algebra, and CUDA execution through
-the feature-gated CUDA backend.
+optional `backward()` on scalar losses, functional eager `grad`, `vjp`, and
+`jvp`, traced graph execution, einsum, linear algebra, and CUDA execution
+through the feature-gated CUDA backend.
 
 ## Mental Model
 
@@ -14,7 +14,7 @@ compiled traced program, then choose a CPU or CUDA backend explicitly.
 | Choice | Question | Common starting point |
 | --- | --- | --- |
 | Tensor layer | What kind of value do I pass around? | `TypedTensor<T>` for typed CPU values, `Tensor` for runtime dtype |
-| Execution model | When does computation run? | Direct/eager for ordinary code, traced for `grad`, `vjp`, `jvp`, or reuse |
+| Execution model | When does computation run? | Direct/eager for ordinary code and eager AD; traced for compiled graph reuse |
 | Backend/device | Where does computation run? | `CpuBackend`; upload/download explicitly for CUDA |
 
 CUDA, eager execution, and traced graphs are not competing APIs. They compose

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -11,8 +11,8 @@ This page is a translation guide for readers who already know `torch` or `jax.nu
 | Graph-building tensor handle | `torch.Tensor` under compiled/tracing tools | traced `jax.Array` values | `TracedTensor` |
 | Concrete result | `torch.Tensor` | `jax.Array` | `Tensor` returned by `GraphExecutor::run` |
 | Execution | Eager by default | Eager arrays, often staged with `jit` | Eager (`Tensor` / `EagerTensor`) or lazy traced (`TracedTensor` + `GraphCompiler` + `GraphExecutor`) |
-| Eager forward and gradients | eager ops plus `loss.backward()` | — | `EagerTensor` forward ops, with `backward()` for tracked scalar losses |
-| Transform AD | `torch.autograd.grad(...)` | `jax.grad`, `jax.vjp`, `jax.jvp`, `hvp` via composition | `loss.grad(&x)`, `.vjp()?`, `.jvp()?`; HVP via composition |
+| Eager forward and gradients | eager ops plus `loss.backward()` or `torch.autograd.grad(...)` | eager arrays with function transforms | `EagerTensor` forward ops, `backward()` for accumulated gradients, and `EagerRuntime` functional `grad`/`vjp`/`jvp` |
+| Transform AD | `torch.autograd.grad(...)`, `torch.func.jvp` | `jax.grad`, `jax.vjp`, `jax.jvp`, HVP via composition | `EagerRuntime::{grad,vjp,jvp}` or traced `.grad()?` / `.vjp()?` / `.jvp()?`; HVP via composition |
 | Device/runtime | Device is attached to tensors | Device is attached to arrays | Backend lives in direct tensor calls, `EagerRuntime`, or `GraphExecutor` |
 | CUDA execution | `x.to("cuda")` | `jax.device_put(x)` | `tenferro_gpu::upload_tensor(...)` and `download_tensor(...)` |
 | Matrix contraction | `torch.einsum` | `jnp.einsum` | `compiler.einsum(...)` via `GraphCompilerEinsumExt` |
@@ -34,9 +34,9 @@ This page is a translation guide for readers who already know `torch` or `jax.nu
 | Cholesky | `torch.linalg.cholesky(x)` | `jnp.linalg.cholesky(x)` | `tenferro_linalg::LinalgBackend::cholesky(&mut ctx, &x)?` | `x.cholesky()?` via `TracedTensorLinalgExt` |
 | Solve | `torch.linalg.solve(a, b)` | `jnp.linalg.solve(a, b)` | `tenferro_linalg::LinalgBackend::solve(&mut ctx, &a, &b)?` | `a.solve(&b)?` via `TracedTensorLinalgExt` |
 | Scalar-loss backward | `loss.backward()` | — | `loss.backward()` on `EagerTensor` | — |
-| Reverse-mode grad | `torch.autograd.grad(loss, x)` | `jax.grad(f)(x)` | — | `loss.grad(&x)` |
-| VJP | `torch.autograd.grad(..., grad_outputs=...)` | `jax.vjp` | — | `y.vjp(&x, &cotangent)?` |
-| JVP | `torch.func.jvp` | `jax.jvp` | — | `y.jvp(&x, &tangent)?` |
+| Reverse-mode grad | `torch.autograd.grad(loss, x)` | `jax.grad(f)(x)` | `ctx.grad(&loss, &x)?` | `loss.grad(&x)` |
+| VJP | `torch.autograd.grad(..., grad_outputs=...)` | `jax.vjp` | `ctx.vjp(&y, &x, &cotangent)?` | `y.vjp(&x, &cotangent)?` |
+| JVP | `torch.func.jvp` | `jax.jvp` | `ctx.jvp(&y, &x, &tangent)?` | `y.jvp(&x, &tangent)?` |
 
 ## Key differences
 
@@ -96,8 +96,10 @@ resulting `GraphProgram` with `GraphExecutor`.
 
 Eager tenferro matches PyTorch-style eager forward execution. When tensors are
 tracked, it also matches the scalar loss `loss.backward()` workflow with
-accumulation semantics. Traced tenferro is the API for `torch.autograd.grad`,
-`jax.grad`, `jax.vjp`, `jax.jvp`, and higher-order compositions such as HVPs.
+accumulation semantics, and `EagerRuntime` exposes functional `grad`, `vjp`,
+and `jvp` when the derivative should be returned as another eager tensor.
+Traced tenferro is the compiled-graph API for the same transform vocabulary and
+higher-order compositions such as HVPs.
 
 For complex reverse-mode AD, tenferro uses a Hermitian real-inner-product
 cotangent representation. When comparing scalar `grad` values to JAX, the

--- a/docs/guides/autodiff.md
+++ b/docs/guides/autodiff.md
@@ -2,12 +2,13 @@
 
 tenferro supports two autodiff workflows on top of the same dense tensor stack:
 
-- PyTorch-like eager execution with `EagerTensor::backward()` on scalar losses,
+- PyTorch-like eager execution with `EagerTensor::backward()` on scalar losses
+  and `EagerRuntime` functional `grad`, `vjp`, and `jvp`,
 - JAX-like `grad`, `vjp`, and `jvp` on `TracedTensor` graphs.
 
 This page focuses on traced graph workflows that you compile and execute
-explicitly. For eager forward execution and scalar loss accumulation semantics, see
-[Eager Operations](eager-operations.md).
+explicitly. For eager forward execution, scalar loss accumulation, and
+functional eager transforms, see [Eager Operations](eager-operations.md).
 
 ## Setup
 

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -10,9 +10,10 @@ backend or device executes the work.
 
 For most projects without autodiff, `TypedTensor<T, R>` or `Tensor` should
 come first. Move to `EagerTensor` when you want immediate execution under an
-`EagerRuntime`; make tensors tracked only when the workflow needs `backward()`
-on scalar losses. Move to `TracedTensor` when the workflow needs `grad`, `vjp`,
-or `jvp` on traced graphs.
+`EagerRuntime`; make tensors tracked when the workflow needs `backward()` on
+scalar losses or functional eager `grad`, `vjp`, `jvp`, and HVP composition.
+Move to `TracedTensor` when the workflow needs those transforms on compiled
+graphs.
 
 Quick reference:
 
@@ -20,7 +21,7 @@ Quick reference:
 | --- | --- |
 | No autodiff, scalar type known at compile time | `TypedTensor<T, R>` |
 | No autodiff, dtype selected at runtime | `Tensor` |
-| Immediate forward execution in one runtime, optionally `backward()` on scalar losses | `EagerTensor` + `EagerRuntime` |
+| Immediate forward execution in one runtime, optionally `backward()` or functional `grad`/`vjp`/`jvp` | `EagerTensor` + `EagerRuntime` |
 | `grad`, `vjp`, `jvp`, HVP via composition, graph reuse | `TracedTensor` + `GraphCompiler` + `GraphExecutor<B>` |
 
 ## Tensor Types
@@ -42,7 +43,8 @@ host-only adapters such as `HostTensor<T>`, not the backend-capable
 `EagerTensor` is concrete eager execution. It wraps `Tensor` values in an
 `EagerRuntime`, so each operation computes a concrete result immediately.
 Untracked eager tensors are forward-only. Tracked eager tensors additionally
-record reverse-mode state for `backward()` on scalar losses.
+record reverse-mode state for `backward()` on scalar losses and can feed
+`EagerRuntime` functional `grad`, `vjp`, and `jvp` transforms.
 
 `TracedTensor` is a graph-building handle. It is the graph and compilation API,
 not the default concrete tensor type.
@@ -52,7 +54,7 @@ not the default concrete tensor type.
 | Model | Similar to | What happens on each op |
 | --- | --- | --- |
 | Direct tensor execution | NumPy-style explicit backend calls | The backend runs the op immediately and returns a concrete `Tensor` |
-| Eager execution | PyTorch eager/autograd | The op runs immediately; tracked values record enough state for `backward()` |
+| Eager execution | PyTorch eager/autograd | The op runs immediately; tracked values record enough state for `backward()` and functional eager transforms |
 | Traced execution | JAX tracing/jit/grad | The op records graph structure; compute runs after compile/execute |
 
 See [Execution Models](execution-models.md) for the time-axis diagram,
@@ -91,7 +93,7 @@ operations.
 | FFT | `x.fft(...)` via `TensorFftExt`; `read.fft_read(...)` via `TensorReadFftExt` | Not exposed today | `x.fft(...)` via `TracedTensorFftExt` plus `register_runtime` |
 | Tensordot sugar | Use `matmul` or `dot_general` directly | `a.tensordot(&b, axes)` via `EagerTensorEinsumExt` | `a.tensordot(&b, axes)` via `TracedTensorEinsumExt` |
 | Linear algebra | `tenferro_linalg::LinalgBackend` methods on a backend | `EagerTensorLinalgExt` methods with `autodiff` | `TracedTensorLinalgExt` methods |
-| Automatic differentiation | Not applicable | `backward()` on tracked scalar losses | `grad`, `vjp`, `jvp`, HVP via composition |
+| Automatic differentiation | Not applicable | `backward()` plus `EagerRuntime` functional `grad`, `vjp`, `jvp`, HVP via composition | `grad`, `vjp`, `jvp`, HVP via composition |
 | External operations | Extension-defined concrete hooks | Extension-defined eager hooks and optional AD rules | Extension-defined graph hooks and optional AD rules |
 
 Use CPU or CUDA with these paths according to backend coverage. CUDA tensors

--- a/docs/guides/complex-ad.md
+++ b/docs/guides/complex-ad.md
@@ -127,8 +127,8 @@ Use this convention note when comparing:
 
 - `TracedTensorAdExt::grad` and `AdContext::grad` on complex scalar outputs,
 - `vjp` with complex cotangent seeds,
-- eager `EagerTensor::backward()` and stored `grad()` values for complex
-  scalar losses.
+- eager `EagerTensor::backward()` / `EagerRuntime::vjp` and stored `grad()`
+  values for complex scalar losses.
 
 For real-valued code, or for JVPs viewed as directional derivatives, there is
 no extra conjugation step to apply when comparing values.

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -1,11 +1,12 @@
 # Eager Operations
 
 This guide covers immediate execution: direct tensor computation without autodiff and
-`EagerTensor` forward execution with optional PyTorch-like reverse-mode
-autodiff on scalar losses. Start with `TypedTensor<T, R>` or `Tensor` for
-work without autodiff. Use `EagerTensor` when you want operations to run immediately
-inside an `EagerRuntime`, and create tracked variables when the workflow needs
-gradient accumulation and `backward()`.
+`EagerTensor` forward execution with optional eager autodiff. Start with
+`TypedTensor<T, R>` or `Tensor` for work without autodiff. Use `EagerTensor`
+when you want operations to run immediately inside an `EagerRuntime`, create
+tracked variables when the workflow needs stateful reverse-mode and functional
+`grad`/`vjp`/`jvp`, and use `backward()` when gradients should accumulate in
+leaf gradient slots.
 
 ## Setup
 

--- a/docs/guides/execution-models.md
+++ b/docs/guides/execution-models.md
@@ -1,9 +1,9 @@
 # Execution Models
 
 tenferro supports direct execution, PyTorch-like eager execution with optional
-reverse-mode AD, and JAX-like traced graph execution on the same dense tensor
-stack. The key distinction is when work is submitted and when the host waits
-for results.
+stateful and functional AD, and JAX-like traced graph execution on the same
+dense tensor stack. The key distinction is when work is submitted and when the
+host waits for results.
 
 ![Eager CPU, Eager GPU, and Traced execution timelines](../assets/execution-models.svg)
 

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -2,9 +2,10 @@
 
 tenferro exposes linear algebra through the `tenferro-linalg` operation crate.
 Use `LinalgBackend` for direct execution without autodiff, `EagerTensorLinalgExt`
-for immediate forward execution under an `EagerRuntime`, and `TracedTensorLinalgExt`
-when the operation should be part of a graph, `grad`/`vjp`/`jvp`, or repeated
-compile/run workflow.
+for immediate forward execution and eager `backward()` / functional transform
+workflows under an `EagerRuntime`, and `TracedTensorLinalgExt` when the
+operation should be part of a graph, `grad`/`vjp`/`jvp`, or repeated compile/run
+workflow.
 
 ## Setup
 
@@ -46,7 +47,7 @@ Box<dyn std::error::Error>>` for a standalone binary.
 | Layer | Linear algebra style |
 | --- | --- |
 | Concrete `Tensor` | `tenferro_linalg::LinalgBackend` methods on a backend |
-| `EagerTensor` | `EagerTensorLinalgExt` methods behind `autodiff`; tracked variables record gradients for scalar losses where AD rules support the operation |
+| `EagerTensor` | `EagerTensorLinalgExt` methods behind `autodiff`; tracked variables support `backward()` and `EagerRuntime` functional transforms where AD rules support the operation |
 | `TracedTensor` | `TracedTensorLinalgExt` methods for graph execution and `grad`/`vjp`/`jvp` workflows |
 
 CUDA is a backend/device choice for supported `Tensor`, `EagerTensor`, and
@@ -122,8 +123,9 @@ assert!(max_abs_diff(&reconstructed, &a) < 1.0e-12);
 The same operation families are available outside traced graphs. Use concrete
 or typed tensors for direct execution without autodiff, eager tensors when the result
 should be produced immediately under an `EagerRuntime`, and traced helpers when
-the operation belongs in a reusable graph. Use tracked eager tensors only when
-the result should remain connected to a scalar loss `backward()` pass.
+the operation belongs in a reusable graph. Use tracked eager tensors when the
+result should remain connected to a scalar loss `backward()` pass or to
+functional eager `grad`/`vjp`/`jvp` transforms.
 For linalg eager helpers or linalg AD rules, add the `tenferro-ad` dependency
 and enable `tenferro-linalg`'s `autodiff` feature.
 

--- a/docs/guides/tensor-operations.md
+++ b/docs/guides/tensor-operations.md
@@ -4,7 +4,7 @@ This guide covers everyday tensor operations: elementwise math, shape changes,
 broadcasting, reductions, and concrete backend execution. These operations are
 available through different tensor APIs depending on whether you need
 computation without autodiff, eager forward execution with optional
-`backward()` on scalar losses, or traced graph execution.
+`backward()` or functional `grad`/`vjp`/`jvp`, or traced graph execution.
 
 ## Setup
 
@@ -24,7 +24,7 @@ Choose the tensor API first, then choose the operation entry point.
 | --- | --- | --- | --- |
 | `TypedTensor<T, R>` | No autodiff, scalar type known at compile time | direct typed accessors; `TypedTensorOpsExt` backend-explicit methods for dynamic-rank `TypedTensor<T>` | No |
 | `Tensor` | No autodiff, dtype selected at runtime or passed through backend dispatch | `TensorOpsExt` backend-explicit methods | No |
-| `EagerTensor` | Immediate execution in an `EagerRuntime`, optionally with `backward()` on scalar losses | `EagerTensor` methods and associated functions | Yes, for tracked values |
+| `EagerTensor` | Immediate execution in an `EagerRuntime`, optionally with `backward()` or functional `grad`/`vjp`/`jvp` | `EagerTensor` methods and associated functions | Yes, for tracked values |
 | `TracedTensor` | Graph transforms, compilation, `grad`, `vjp`, `jvp`, or graph reuse | `TracedTensor` methods and associated functions | Yes, through graph transforms |
 
 For most code without autodiff, start with `TypedTensor<T, R>` when the scalar type is
@@ -54,7 +54,7 @@ in Rust's type system and when computation happens.
 | Host typed slice access | Direct `&[T]` on host tensors | Fallible `as_slice::<T>()` | Through concrete data | Only after graph execution |
 | Host iteration | Direct `iter()` and `iter_mut()` on host tensors | Fallible `iter::<T>()` and `iter_mut::<T>()` | Through concrete data | Not a concrete-data API |
 | Backend math | Selected typed wrappers | Broad concrete backend API | Eager runtime API | Graph-building API |
-| AD | No | No | Optional reverse-mode for tracked values | Transform AD and graph reuse |
+| AD | No | No | Stateful reverse mode plus functional transforms for tracked values | Transform AD and graph reuse |
 
 Use this distinction when reading operation examples:
 
@@ -219,11 +219,11 @@ assert_eq!(sum.as_slice::<f64>().unwrap(), &[5.0, 7.0, 9.0]);
 assert_eq!(product.as_slice::<f64>().unwrap(), &[4.0, 10.0, 18.0]);
 ```
 
-## Eager Forward And Backward Example
+## Eager Forward And Autodiff Example
 
 Use `EagerTensor` when the same immediate computation should stay in an
 `EagerRuntime`. Create tracked variables when a scalar loss should accumulate
-gradients.
+gradients or when a derivative transform should return another eager tensor.
 
 ```rust
 use tenferro_ad::{EagerRuntime, Tensor};

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,9 @@
 
 tenferro is a Rust-native tensor computation stack with opt-in autodiff for
 scientific workloads: typed tensors, dynamic tensors, PyTorch-style immediate
-execution with `backward()`, JAX-style traced graphs, einsum, linear algebra,
-FFT, and explicit CPU, CUDA, and experimental WebGPU backend control.
+execution with `backward()` and `EagerRuntime` functional `grad`, `vjp`, and
+`jvp`, JAX-style traced graphs, einsum, linear algebra, FFT, and explicit CPU,
+CUDA, and experimental WebGPU backend control.
 
 The project covers both ordinary tensor computation and autodiff workflows.
 Start with the smallest API that solves your problem, then add autodiff, graph
@@ -87,9 +88,10 @@ traced graphs are not competing APIs; they answer different questions.
 
 Most code without autodiff starts with `TypedTensor<T>` when the scalar type is
 known at compile time, or `Tensor` when dtype must be selected at runtime.
-`EagerTensor` adds immediate execution through an `EagerRuntime` and optional
-`backward()` on scalar losses. `TracedTensor` adds graph compilation, `grad`,
-`vjp`, and `jvp` on traced graphs, symbolic inputs, and reuse.
+`EagerTensor` adds immediate execution through an `EagerRuntime`, optional
+stateful `backward()` on scalar losses, and functional eager `grad`, `vjp`, and
+`jvp` transforms. `TracedTensor` adds graph compilation, `grad`, `vjp`, and
+`jvp` on traced graphs, symbolic inputs, and reuse.
 
 ## Get In Touch
 

--- a/docs/spec/extension-op.md
+++ b/docs/spec/extension-op.md
@@ -966,7 +966,7 @@ these error types / behaviours in the listed scenarios.
 | `HostReferenceRuntime` receives an op with no `host_reference()` capability | Return `Error::NoHostReference { family_id }`. MUST NOT panic or synthesize a fake result. |
 | Graph references an unregistered `family_id` at eager or graph runtime execution time | Return a backend/config error with `family_id` and registration guidance. |
 | Graph references an unregistered `family_id` at compile time | Return `Error::Unsupported` from `compile_std_to_exec`. |
-| AD dispatch (`linearize` / `linear_transpose` / primal VJP) encounters an `Extension` with no rule for the required role in the active `ExtensionRuleSet` | Return `ADRuleError::Unsupported` with `family_id` and rule kind; traced `grad` / eager `backward` propagate it through the public `Error` type re-exported by the owning surface crate. |
+| AD dispatch (`linearize` / `linear_transpose` / primal VJP) encounters an `Extension` with no rule for the required role in the active `ExtensionRuleSet` | Return `ADRuleError::Unsupported` with `family_id` and rule kind; traced transforms and eager `backward` / functional `grad` / `vjp` / `jvp` propagate it through the public `Error` type re-exported by the owning surface crate. |
 | Duplicate AD rule `(family_id, role)` in one `ExtensionRuleSet` | Rule registration MUST reject with `ExtensionRegistryError::DuplicateRule { family_id, role }`. |
 | Arity mismatch: `input_count()` disagrees with the `primal_in.len()` the dispatcher passed | `Error::InvalidConfig { op: "extension", message: "family_id=<id>: expected N inputs, got M" }`. |
 | Output shape disagrees with `infer_output_meta` result length | `Error::InvalidConfig` with `family_id` and the mismatched counts. |

--- a/docs/spec/operation-categories.md
+++ b/docs/spec/operation-categories.md
@@ -16,7 +16,7 @@ Related:
 |---|---|---|
 | **TypedTensor** | `TypedTensor<T, R>` (non-AD) | Static/dynamic-rank typed value; the "lightweight array" path |
 | **Tensor** | `Tensor` (runtime dtype) | Dynamic-dtype value with explicit backend |
-| **Eager** | `EagerTensor` | PyTorch-style immediate execution + `backward()` |
+| **Eager** | `EagerTensor` | PyTorch-style immediate execution + stateful `backward()` plus functional `grad`/`vjp`/`jvp` |
 | **Traced** | `TracedTensor` | JAX-style traced graph + `grad`/`vjp`/`jvp` |
 
 **Rank model.** `TypedTensor<T, R = DynRank>` offers `Rank<N>` (opt-in static rank)
@@ -155,8 +155,10 @@ and traced surfaces (subject to the same parity rule within each family):
 
 ## 9. AD transforms
 
-Not value operations; listed for completeness. `grad` / `vjp` / `jvp` / HVP on
-`Traced`; `backward` on `Eager` scalar losses.
+Not value operations; listed for completeness. `EagerRuntime` exposes stateful
+`backward()` / `backward_with(seed)` plus functional `grad` / `vjp` / `jvp` /
+HVP composition on eager tensors. `TracedTensor` and `AdContext` expose graph
+`grad` / `vjp` / `jvp` / HVP workflows for compiled execution and graph reuse.
 
 ## 10. Host iteration and closure map (non-AD surfaces only)
 

--- a/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
+++ b/docs/superpowers/specs/2026-04-13-eager-tensor-extensions-design.md
@@ -455,7 +455,7 @@ Split `eager.rs` (currently 631 lines) to keep files focused:
 
 | File | Responsibility |
 |------|---------------|
-| `eager.rs` | `EagerTensor` struct, `EagerRuntime` (pub), `new_leaf`, `new_result`, `backward()`, `detach()`, `data()`, `grad()`, internal helpers (`saved_forward_values`, `derived_output_key`, etc.) |
+| `eager.rs` | `EagerTensor` struct, `EagerRuntime` (pub), `new_leaf`, `new_result`, `backward()`, functional `grad`/`vjp`/`jvp`, `detach()`, `data()`, `grad()`, internal helpers (`saved_forward_values`, `derived_output_key`, etc.) |
 | `eager_ops.rs` | All op methods: `unary_op`, `binary_op`, `ternary_op`, `multi_output_unary_op`, `nary_op`, and every public method (`add`, `mul`, ..., `svd`, `transpose`, etc.) |
 | `eager_einsum.rs` | `eager_einsum_ad` free function |
 | `eager_exec.rs` | `exec_op_on_tensors` — add `NaryEinsum` branch (delegate to `eager_einsum`) |

--- a/docs/superpowers/specs/2026-06-15-kdv-pinn-design.md
+++ b/docs/superpowers/specs/2026-06-15-kdv-pinn-design.md
@@ -59,11 +59,11 @@ on the domain `x ∈ [-5, 5]`, `t ∈ [0, 1]`.
 
 **Approach A: `TracedTensor` + `AdContext` (JAX-style graph AD).**
 
-`EagerTensor` does not expose a `create_graph` equivalent, so higher-order automatic differentiation through `EagerTensor::backward()` is not supported. To compute the KdV term `u_xxx` exactly, we build a `TracedTensor` graph and use `TracedTensorAdExt::grad` repeatedly. Network parameters and collocation points are `TracedTensor::input_concrete_shape` placeholders, so the same compiled `GraphProgram` can be re-evaluated each epoch with `GraphExecutor::run_with_inputs`.
+`EagerTensor::backward()` does not expose a `create_graph`-style accumulation API. `EagerRuntime` functional transforms support returned `grad`/`vjp`/`jvp` tensors and HVP-style composition, but this sample needs repeated PDE derivative graph reuse. To compute the KdV term `u_xxx` exactly, we build a `TracedTensor` graph and use `TracedTensorAdExt::grad` repeatedly. Network parameters and collocation points are `TracedTensor::input_concrete_shape` placeholders, so the same compiled `GraphProgram` can be re-evaluated each epoch with `GraphExecutor::run_with_inputs`.
 
 ### Rejected Alternatives
 
-- **`EagerTensor` + `EagerRuntime`**: Familiar, but only first-order AD is available. Would require numerical differentiation for `u_xxx` and lose exact higher-order gradients.
+- **`EagerTensor` + `EagerRuntime`**: Familiar and useful for immediate `backward()` and functional `grad`/`vjp`/`jvp` workflows, but it does not provide the reusable compiled derivative graph needed for the training loop and PDE residual.
 - **Mixed Approach**: Adds complexity by switching between Eager and Traced tensors. Avoided for the first version.
 
 ---

--- a/docs/tutorials/eager-autodiff-pytorch-style.md
+++ b/docs/tutorials/eager-autodiff-pytorch-style.md
@@ -51,4 +51,5 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 <!-- end-snippet-source -->
 
-For the broader eager API, see the [eager operations guide](../guides/eager-operations.md).
+For the broader eager API, including `EagerRuntime` functional `grad`, `vjp`,
+and `jvp`, see the [eager operations guide](../guides/eager-operations.md).

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -16,7 +16,7 @@ would be too slow for every pull request.
 | Tutorial | Use it when |
 | --- | --- |
 | [TypedTensor for numeric computation without autodiff](typed-tensor-non-ad.md) | You know the scalar type in Rust and want ndarray-like CPU tensor computation without AD. |
-| [Eager autodiff, PyTorch style](eager-autodiff-pytorch-style.md) | You want immediate execution, scalar losses, `backward()`, and accumulated gradients. |
+| [Eager autodiff, PyTorch style](eager-autodiff-pytorch-style.md) | You want immediate execution, scalar losses, `backward()`, accumulated gradients, or the broader functional eager AD entry point. |
 | [Traced autodiff, JAX style](traced-autodiff-jax-style.md) | You want to build a graph, compile/run it, and use `grad` or `jvp` on the traced graph. |
 | [Einsum: subscripts to gradients](einsum-subscripts-to-gradients.md) | You contract more than two tensors and want planned contraction order plus AD. |
 | [XLA backend: einsum to StableHLO](xla-einsum-backend.md) | You want to lower a fixed-shape N-ary einsum path through the experimental XLA executor. |

--- a/docs/worklogs/2026-07-09-eager-functional-ad-doc-sync.md
+++ b/docs/worklogs/2026-07-09-eager-functional-ad-doc-sync.md
@@ -1,0 +1,53 @@
+# Eager Functional AD Documentation Sync
+
+## Summary
+
+Synchronized public documentation and the architecture SVG with the current
+eager AD implementation. `EagerRuntime` already exposes functional `grad`,
+`vjp`, and `jvp`; the stale docs made eager AD look like `backward()` only and
+made traced graphs look like the only transform surface.
+
+## Context Read
+
+- `AGENTS.md`, shared tensor4all rules, and `REPOSITORY_RULES.md`.
+- `EagerRuntime::{grad,vjp,jvp}` and the eager functional transform path in
+  `crates/tenferro-ad/src/eager.rs` and `crates/tenferro-ad/src/eager/functional.rs`.
+- Existing eager JVP and HVP tests in `crates/tenferro-ad/src/eager/tests.rs`.
+- Active user docs under `README.md`, `docs/getting-started/`, `docs/guides/`,
+  `docs/spec/`, `docs/tutorials/`, and `docs/assets/tenferro-architecture.svg`.
+
+## Decisions
+
+- Keep the API unchanged because the implementation already supports eager
+  functional JVP.
+- Update docs to distinguish stateful eager `backward()` from functional eager
+  transforms, and to describe traced transforms as the compiled graph reuse
+  surface rather than the only `grad`/`vjp`/`jvp` surface.
+- Add a source-contract check to `scripts/check-docs-site.py` so README,
+  getting-started docs, key guides/specs, and the architecture SVG cannot drift
+  back to the older wording unnoticed.
+- Keep historical `docs/plans/` and `docs/reference/` untouched, but update
+  active design/spec notes that asserted stale eager limitations.
+- Change the SVG font CSS from shorthand `system-ui` to explicit `DejaVu Sans`
+  properties so local SVG-to-PNG conversion renders the diagram reliably.
+
+## Verification
+
+- `git diff --check`
+- `cargo fmt --all --check`
+- `python3 scripts/check-docs-site.py --quiet`
+- `python3 scripts/check-docs-site.py`
+- `cargo test -p tenferro-ad jvp`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo doc --workspace --no-deps`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --worktree --output-json /tmp/repository-rules-review-worktree.json`
+- `convert -background white -alpha remove -alpha off docs/assets/tenferro-architecture.svg /tmp/tenferro-architecture-white.png`
+
+## Residual Risks
+
+- The docs still keep the traced tutorial focused on compiled graph AD. That is
+  intentional; eager functional examples live in the eager operations guide.

--- a/scripts/check-docs-site.py
+++ b/scripts/check-docs-site.py
@@ -92,6 +92,59 @@ def missing_rendered_html_links(site_root: pathlib.Path) -> list[tuple[pathlib.P
     return missing
 
 
+def check_eager_functional_ad_docs(root: pathlib.Path) -> list[str]:
+    required_snippets = [
+        (
+            root / "README.md",
+            "`EagerRuntime` functional `grad`, `vjp`, and `jvp`",
+        ),
+        (
+            root / "docs" / "index.md",
+            "`EagerRuntime` functional `grad`, `vjp`, and `jvp`",
+        ),
+        (
+            root / "docs" / "getting-started" / "index.md",
+            "functional eager `grad`, `vjp`, and `jvp`",
+        ),
+        (
+            root / "docs" / "getting-started" / "core-concepts.md",
+            "functional `grad`, `vjp`, and `jvp` transforms",
+        ),
+        (
+            root / "docs" / "getting-started" / "pytorch-jax-mapping.md",
+            "`EagerRuntime` functional `grad`/`vjp`/`jvp`",
+        ),
+        (
+            root / "docs" / "tutorials" / "index.md",
+            "functional eager AD entry point",
+        ),
+        (
+            root / "docs" / "spec" / "operation-categories.md",
+            "stateful `backward()` plus functional `grad`/`vjp`/`jvp`",
+        ),
+        (
+            root / "docs" / "guides" / "eager-operations.md",
+            "stateful reverse-mode and functional `grad`/`vjp`/`jvp`",
+        ),
+        (
+            root / "docs" / "assets" / "tenferro-architecture.svg",
+            "backward · grad",
+        ),
+        (
+            root / "docs" / "assets" / "tenferro-architecture.svg",
+            "vjp · jvp",
+        ),
+    ]
+    missing: list[str] = []
+    for path, snippet in required_snippets:
+        text = path.read_text(encoding="utf-8")
+        normalized_text = " ".join(text.split())
+        normalized_snippet = " ".join(snippet.split())
+        if normalized_snippet not in normalized_text:
+            missing.append(f"{path.relative_to(root)}: missing {snippet!r}")
+    return missing
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Verify docs-site completeness for workspace library crates.")
     parser.add_argument("--root-dir", default=".", help="Repository root (default: current directory)")
@@ -236,6 +289,13 @@ def main() -> int:
             source_rel = source.relative_to(docs_site_root)
             target_rel = target.relative_to(docs_site_root)
             print(f"- {source_rel}: {href} -> {target_rel}", file=sys.stderr)
+        return 1
+
+    eager_ad_doc_gaps = check_eager_functional_ad_docs(root)
+    if eager_ad_doc_gaps:
+        print("eager functional AD docs are stale:", file=sys.stderr)
+        for gap in eager_ad_doc_gaps:
+            print(f"- {gap}", file=sys.stderr)
         return 1
 
     if not args.quiet:


### PR DESCRIPTION
## Summary

- Sync README, getting-started docs, guides, specs, and the architecture SVG with the current eager functional AD surface.
- Clarify that eager supports stateful `backward()` plus `EagerRuntime` functional `grad`/`vjp`/`jvp`, while traced remains the compiled graph reuse surface.
- Add a docs-site source contract so the key eager functional AD wording and SVG labels do not drift again.
- Work log: `docs/worklogs/2026-07-09-eager-functional-ad-doc-sync.md`

## Implementation Check

- Confirmed the eager JVP path is implemented as `EagerRuntime::jvp -> jvp_optional -> functional_jvp -> tidu::eager::try_forward`.
- Confirmed existing eager tests cover direct JVP and `jvp(grad(f))` HVP-style composition.

## Verification

- `git diff --check`
- `cargo fmt --all --check`
- `python3 scripts/check-docs-site.py --quiet`
- `python3 scripts/check-docs-site.py`
- `cargo test -p tenferro-ad jvp`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo doc --workspace --no-deps`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
- `convert -background white -alpha remove -alpha off docs/assets/tenferro-architecture.svg /tmp/tenferro-architecture-white.png`
