### PR TITLE
Add linalg AD route and decomposition APIs

### DIFF
--- a/crates/tenferro-ad/src/lib.rs
+++ b/crates/tenferro-ad/src/lib.rs
@@ -45,6 +45,7 @@ mod transform_cache;
 pub use context::{AdContext, AdContextBuilder, AdContextCacheStats};
 pub use eager::{EagerNoGradGuard, EagerRuntime, EagerRuntimeCacheStats, EagerTensor};
 pub use eager_backend::EagerBackend;
+pub use shape_packing::EagerSliceBuilder;
 pub(crate) use tenferro_runtime::{extension_cache, extension_runtime, scalar_semantics};
 pub use transform_cache::AdTransformCacheLimits;
 pub(crate) mod shape_infer {

--- a/crates/tenferro-ad/src/shape_packing.rs
+++ b/crates/tenferro-ad/src/shape_packing.rs
@@ -1,4 +1,6 @@
-use tenferro_tensor::{GatherConfig, Tensor, TensorDeviceTransfer, TypedTensor};
+use std::ops::Range;
+
+use tenferro_tensor::{GatherConfig, SliceConfig, Tensor, TensorDeviceTransfer, TypedTensor};
 
 use crate::eager::EagerTensor;
 use crate::error::{Error, Result};
@@ -124,7 +126,261 @@ fn validate_stack_shapes(op: &'static str, shapes: &[&[usize]]) -> Result<()> {
     Ok(())
 }
 
+#[derive(Clone, Debug)]
+enum AxisSelection {
+    Slice {
+        axis: usize,
+        range: Range<usize>,
+        step: usize,
+    },
+    Take {
+        axis: usize,
+        indices: Vec<usize>,
+    },
+}
+
+fn validate_axis_selection(
+    op: &'static str,
+    rank: usize,
+    seen: &mut [bool],
+    axis: usize,
+) -> Result<()> {
+    if axis >= rank {
+        return Err(tenferro_tensor::Error::AxisOutOfBounds { op, axis, rank }.into());
+    }
+    if seen[axis] {
+        return Err(tenferro_tensor::Error::DuplicateAxis {
+            op,
+            axis,
+            role: "selection",
+        }
+        .into());
+    }
+    seen[axis] = true;
+    Ok(())
+}
+
+fn apply_slice_axis_config(
+    op: &'static str,
+    shape: &[usize],
+    selections: &[AxisSelection],
+) -> Result<Option<SliceConfig>> {
+    let mut starts = vec![0; shape.len()];
+    let mut limits = shape.to_vec();
+    let mut strides = vec![1; shape.len()];
+    let mut has_slice = false;
+    for selection in selections {
+        let AxisSelection::Slice { axis, range, step } = selection else {
+            continue;
+        };
+        if *step == 0 {
+            return Err(tenferro_tensor::Error::InvalidConfig {
+                op,
+                message: format!("axis {axis} has zero step"),
+            }
+            .into());
+        }
+        let extent = shape[*axis];
+        if range.start > range.end || range.end > extent {
+            return Err(tenferro_tensor::Error::InvalidConfig {
+                op,
+                message: format!(
+                    "axis {axis} range {}..{} is out of bounds for extent {extent}",
+                    range.start, range.end
+                ),
+            }
+            .into());
+        }
+        starts[*axis] = range.start;
+        limits[*axis] = range.end;
+        strides[*axis] = *step;
+        has_slice = true;
+    }
+    Ok(has_slice.then_some(SliceConfig {
+        starts,
+        limits,
+        strides,
+    }))
+}
+
+/// Rank-preserving eager tensor slicing builder.
+///
+/// Unspecified axes are kept whole. Range selections become one `Slice`
+/// operation; host-known position selections become `Gather`/`index_select`
+/// operations.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+///
+/// let ctx = EagerRuntime::new();
+/// let x = EagerTensor::from_tensor_in(
+///     Tensor::from_vec_col_major(vec![3, 4], vec![0.0_f64; 12]).unwrap(),
+///     ctx,
+/// ).unwrap();
+/// let y = x.slice_builder().axis(0, 0..2).axis_step(1, 0..4, 2).apply().unwrap();
+/// assert_eq!(y.shape(), &[2, 2]);
+/// ```
+#[derive(Clone, Debug)]
+pub struct EagerSliceBuilder<'a> {
+    tensor: &'a EagerTensor,
+    selections: Vec<AxisSelection>,
+}
+
+impl<'a> EagerSliceBuilder<'a> {
+    fn new(tensor: &'a EagerTensor) -> Self {
+        Self {
+            tensor,
+            selections: Vec::new(),
+        }
+    }
+
+    /// Add an exclusive-end range selection for one axis.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerRuntime::new();
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
+    ///     ctx,
+    /// ).unwrap();
+    /// let y = x.slice_builder().axis(0, 1..3).apply().unwrap();
+    /// assert_eq!(y.shape(), &[2]);
+    /// ```
+    pub fn axis(mut self, axis: usize, range: Range<usize>) -> Self {
+        self.selections.push(AxisSelection::Slice {
+            axis,
+            range,
+            step: 1,
+        });
+        self
+    }
+
+    /// Add an exclusive-end strided range selection for one axis.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerRuntime::new();
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![5], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0]).unwrap(),
+    ///     ctx,
+    /// ).unwrap();
+    /// let y = x.slice_builder().axis_step(0, 0..5, 2).apply().unwrap();
+    /// assert_eq!(y.shape(), &[3]);
+    /// ```
+    pub fn axis_step(mut self, axis: usize, range: Range<usize>, step: usize) -> Self {
+        self.selections
+            .push(AxisSelection::Slice { axis, range, step });
+        self
+    }
+
+    /// Add a host-known position selection for one axis.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerRuntime::new();
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
+    ///     ctx,
+    /// ).unwrap();
+    /// let y = x.slice_builder().take_axis(0, &[2, 0]).apply().unwrap();
+    /// assert_eq!(y.shape(), &[2]);
+    /// ```
+    pub fn take_axis(mut self, axis: usize, indices: &[usize]) -> Self {
+        self.selections.push(AxisSelection::Take {
+            axis,
+            indices: indices.to_vec(),
+        });
+        self
+    }
+
+    /// Build and apply the requested slice/take operations.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerRuntime::new();
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
+    ///     ctx,
+    /// ).unwrap();
+    /// let y = x.slice_builder().axis(0, 1..4).apply().unwrap();
+    /// assert_eq!(y.shape(), &[3]);
+    /// ```
+    pub fn apply(self) -> Result<EagerTensor> {
+        let shape = self.tensor.shape().to_vec();
+        let mut seen = vec![false; shape.len()];
+        for selection in &self.selections {
+            let axis = match selection {
+                AxisSelection::Slice { axis, .. } | AxisSelection::Take { axis, .. } => *axis,
+            };
+            validate_axis_selection("slice_builder", shape.len(), &mut seen, axis)?;
+        }
+
+        let mut output = self.tensor.clone();
+        if let Some(config) = apply_slice_axis_config("slice_builder", &shape, &self.selections)? {
+            output = output.slice(config)?;
+        }
+        for selection in self.selections {
+            if let AxisSelection::Take { axis, indices } = selection {
+                output = output.take_axis(axis, &indices)?;
+            }
+        }
+        Ok(output)
+    }
+}
+
 impl EagerTensor {
+    /// Slice one axis with an exclusive-end range, keeping all other axes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerRuntime::new();
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
+    ///     ctx,
+    /// ).unwrap();
+    /// let y = x.slice_axis(0, 1..3).unwrap();
+    /// assert_eq!(y.shape(), &[2]);
+    /// ```
+    pub fn slice_axis(&self, axis: usize, range: Range<usize>) -> Result<Self> {
+        self.slice_builder().axis(axis, range).apply()
+    }
+
+    /// Start a rank-preserving slicing builder for this tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    ///
+    /// let ctx = EagerRuntime::new();
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(),
+    ///     ctx,
+    /// ).unwrap();
+    /// let y = x.slice_builder().axis(0, 0..2).apply().unwrap();
+    /// assert_eq!(y.shape(), &[2]);
+    /// ```
+    pub fn slice_builder(&self) -> EagerSliceBuilder<'_> {
+        EagerSliceBuilder::new(self)
+    }
+
     /// Select entries from one axis using host-known indices.
     ///
     /// The index list is primal metadata: gradients flow to `self`, including

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -21,7 +21,7 @@ use tenferro_runtime::ad_support::{
 };
 use tenferro_runtime::{Error, GraphCompiler, GraphExecutor, Result, TracedTensor};
 use tenferro_tensor::TensorBackend;
-use tidu::{linear_transpose, linearize};
+use tidu::{linear_transpose, linearize, ADRuleError};
 
 #[path = "traced/optimizer.rs"]
 mod optimizer;
@@ -131,6 +131,51 @@ fn linearize_active_value_keys(
         }
     }
     Arc::new(active)
+}
+
+fn graph_has_registered_primal_vjp(
+    view: &ResolvedView<StdTensorOp>,
+    outputs: &[ValueKey<StdTensorOp>],
+    aliases: &HashMap<TensorInputKey, ValueKey<StdTensorOp>>,
+    extension_rules: Option<&ExtensionRuleSet>,
+) -> bool {
+    let Some(extension_rules) = extension_rules else {
+        return false;
+    };
+    let mut seen = HashSet::new();
+    let mut stack = outputs.to_vec();
+    while let Some(key) = stack.pop() {
+        if !seen.insert(key.clone()) {
+            continue;
+        }
+        if let ValueKey::Derived { operation, .. } = &key {
+            if let StdTensorOp::Extension(ext) = operation.operation() {
+                if extension_rules.lookup_primal_vjp(ext.family_id()).is_some() {
+                    return true;
+                }
+            }
+        }
+        let Some(val_def) = view.resolve_value(&key) else {
+            continue;
+        };
+        match val_def {
+            ValueDef::Produced { input_keys, .. } => {
+                for input_key in input_keys {
+                    stack.push(input_key);
+                }
+            }
+            ValueDef::Input { key: input_key } => {
+                if let Some(aliased) = aliases.get(&input_key) {
+                    stack.push(aliased.clone());
+                }
+            }
+        }
+    }
+    false
+}
+
+fn is_not_applicable_custom_vjp(err: &ADRuleError) -> bool {
+    matches!(err, ADRuleError::Unsupported { .. })
 }
 
 pub(crate) fn grad_with_rules_and_cache(
@@ -748,6 +793,49 @@ fn vjp_optional_impl(
             &aliases,
         )
     });
+    if graph_has_registered_primal_vjp(
+        &view,
+        std::slice::from_ref(&output_key),
+        &aliases,
+        extension_rules,
+    ) {
+        let mut primal_ad_ctx = shape_guard_context(extension_rules, None, &view.roots);
+        primal_ad_ctx.refresh_global_metadata();
+        match try_primal_transpose(
+            &view,
+            std::slice::from_ref(&output_key),
+            std::slice::from_ref(&wrt_input_key),
+            &aliases,
+            &mut primal_ad_ctx,
+            next_pass_id(),
+        ) {
+            Ok(transposed) => {
+                if transposed
+                    .tangent_outputs()
+                    .first()
+                    .and_then(|slot| *slot)
+                    .is_some()
+                {
+                    let transposed = VjpTransposeGraph::Primal(transposed);
+                    return build_vjp_tensor(
+                        output,
+                        wrt,
+                        cotangent,
+                        transposed,
+                        None,
+                        checkpoint_chain,
+                        checkpoint_graphs,
+                    );
+                }
+                return Ok(None);
+            }
+            Err(err) if !is_not_applicable_custom_vjp(&err) => {
+                return Err(ad_rule_error(transform, err));
+            }
+            Err(_) => {}
+        }
+    }
+
     let linear_attempt = match (ad_transform_cache, cache_key) {
         (Some(cache), Some(key)) => {
             if let Some(cached) = cache.get_traced_vjp(&key)? {
@@ -790,31 +878,29 @@ fn vjp_optional_impl(
             VjpTransposeGraph::Linear(active.transposed),
             Some(active.metadata_scope),
         ),
-        Err(linear_err) => {
-            let mut primal_ad_ctx = shape_guard_context(extension_rules, None, &view.roots);
-            primal_ad_ctx.refresh_global_metadata();
-            match try_primal_transpose(
-                &view,
-                std::slice::from_ref(&output_key),
-                std::slice::from_ref(&wrt_input_key),
-                &aliases,
-                &mut primal_ad_ctx,
-                next_pass_id(),
-            ) {
-                Ok(transposed)
-                    if transposed
-                        .tangent_outputs()
-                        .first()
-                        .and_then(|slot| *slot)
-                        .is_some() =>
-                {
-                    (VjpTransposeGraph::Primal(transposed), None)
-                }
-                _ => return Err(ad_rule_error(transform, linear_err)),
-            }
-        }
+        Err(linear_err) => return Err(ad_rule_error(transform, linear_err)),
     };
 
+    build_vjp_tensor(
+        output,
+        wrt,
+        cotangent,
+        transposed,
+        linear_metadata_scope,
+        checkpoint_chain,
+        checkpoint_graphs,
+    )
+}
+
+fn build_vjp_tensor(
+    output: &TracedTensor,
+    wrt: &TracedTensor,
+    cotangent: &TracedTensor,
+    transposed: VjpTransposeGraph,
+    linear_metadata_scope: Option<GlobalMetadataScope>,
+    checkpoint_chain: Option<Arc<tenferro_runtime::ad_support::CheckpointNode>>,
+    checkpoint_graphs: Vec<Arc<Graph<StdTensorOp>>>,
+) -> Result<Option<TracedTensor>> {
     let cotangent_input_key =
         linear_input_key(transposed.as_graph(), transposed.tangent_inputs()[0].1)?;
     let cotangent_data =

--- a/crates/tenferro-ad/tests/eager_tensor.rs
+++ b/crates/tenferro-ad/tests/eager_tensor.rs
@@ -172,6 +172,52 @@ fn matrix_eager_input_uses_column_major_values() {
 }
 
 #[test]
+fn eager_slice_axis_and_builder_preserve_column_major_values() {
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(
+            vec![3, 4],
+            vec![
+                1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+            ],
+        )
+        .unwrap(),
+        test_ctx(),
+    )
+    .unwrap();
+
+    let rows = x.slice_axis(0, 1..3).unwrap();
+    assert_eq!(rows.shape(), &[2, 4]);
+    assert_eq!(
+        f64_data(rows.materialized().unwrap().as_ref()),
+        &[2.0, 3.0, 5.0, 6.0, 8.0, 9.0, 11.0, 12.0]
+    );
+
+    let strided = x
+        .slice_builder()
+        .axis(0, 1..3)
+        .axis_step(1, 0..4, 2)
+        .apply()
+        .unwrap();
+    assert_eq!(strided.shape(), &[2, 2]);
+    assert_eq!(
+        f64_data(strided.materialized().unwrap().as_ref()),
+        &[2.0, 3.0, 8.0, 9.0]
+    );
+
+    let mixed = x
+        .slice_builder()
+        .axis(0, 0..2)
+        .take_axis(1, &[3, 1, 3])
+        .apply()
+        .unwrap();
+    assert_eq!(mixed.shape(), &[2, 3]);
+    assert_eq!(
+        f64_data(mixed.materialized().unwrap().as_ref()),
+        &[10.0, 11.0, 4.0, 5.0, 10.0, 11.0]
+    );
+}
+
+#[test]
 fn eager_concatenate_empty_reports_typed_validation_error() {
     let err = EagerTensor::concatenate(&[], 0).unwrap_err();
 

--- a/crates/tenferro-ad/tests/extension_op.rs
+++ b/crates/tenferro-ad/tests/extension_op.rs
@@ -310,9 +310,8 @@ fn swap_ad_context() -> AdContext {
 
 // ----------------------------------------------------------------------
 // TestPreferLinearize: identity op with a deliberately distinguishable
-// primary transpose. This guards VJP path ordering: the generic
-// linearize -> linear_transpose path must be preferred when linearization is
-// available, while primary transpose remains an escape hatch.
+// primary transpose. This guards VJP path ordering: a registered custom VJP
+// must be preferred over the generic linearize -> linear_transpose path.
 // ----------------------------------------------------------------------
 
 #[derive(Clone, Debug, PartialEq)]
@@ -431,6 +430,119 @@ fn prefer_linearize_ad_context() -> AdContext {
         .with_extension_rules(prefer_linearize_rules())
         .build()
         .expect("prefer_linearize AD context")
+}
+
+// ----------------------------------------------------------------------
+// TestCustomVjpInvalid: identity op with both canonical and custom routes.
+// The custom route reports a real rule error; VJP dispatch must not hide it
+// behind the canonical linearize -> transpose fallback.
+// ----------------------------------------------------------------------
+
+#[derive(Clone, Debug, PartialEq)]
+struct TestCustomVjpInvalid;
+
+impl ExtensionOp for TestCustomVjpInvalid {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.custom_vjp_invalid.v1"
+    }
+
+    fn payload_hash(&self, _hasher: &mut dyn Hasher) {}
+
+    fn payload_eq(&self, other: &dyn ExtensionOp) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<TestCustomVjpInvalid>()
+            .is_some()
+    }
+
+    fn clone_arc(&self) -> Arc<dyn ExtensionOp> {
+        Arc::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn input_count(&self) -> usize {
+        1
+    }
+
+    fn output_count(&self) -> usize {
+        1
+    }
+
+    fn infer_output_meta(
+        &self,
+        input_dtypes: &[DType],
+        input_shapes: &[&[SymDim]],
+    ) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+        Ok(vec![(input_dtypes[0], input_shapes[0].to_vec())])
+    }
+
+    fn host_reference(&self) -> Option<&dyn HostReference> {
+        Some(self)
+    }
+}
+
+impl HostReference for TestCustomVjpInvalid {
+    fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Ok(vec![inputs[0].clone()])
+    }
+}
+
+#[derive(Debug)]
+struct TestCustomVjpInvalidRule;
+
+impl ExtensionLinearizeRule for TestCustomVjpInvalidRule {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.custom_vjp_invalid.v1"
+    }
+
+    fn linearize(
+        &self,
+        _op: &dyn ExtensionOp,
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        _primal_in: &[ValueKey<StdTensorOp>],
+        _primal_out: &[ValueKey<StdTensorOp>],
+        tangent_in: &[Option<LocalValueId>],
+        _ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+        Ok(vec![tangent_in[0]])
+    }
+}
+
+impl ExtensionPrimalVjpRule for TestCustomVjpInvalidRule {
+    fn family_id(&self) -> &'static str {
+        "tenferro-tests.custom_vjp_invalid.v1"
+    }
+
+    fn primal_vjp(
+        &self,
+        _op: &dyn ExtensionOp,
+        _builder: &mut dyn PrimitiveRuleBuilder,
+        _cotangent_out: &[Option<LocalValueId>],
+        _inputs: &[ValueRef<StdTensorOp>],
+        _ctx: &mut ShapeGuardContext,
+    ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
+        Err(ADRuleError::invalid_input(
+            "tenferro-tests.custom_vjp_invalid.v1",
+            ADRuleKind::Transpose,
+            "custom VJP validation failure",
+        ))
+    }
+}
+
+fn custom_vjp_invalid_ad_context() -> AdContext {
+    AdContext::builder()
+        .with_extension_rules(
+            ExtensionRuleSet::new()
+                .with_linearize(Arc::new(TestCustomVjpInvalidRule))
+                .expect("custom_vjp_invalid linearize registration")
+                .with_primal_vjp(Arc::new(TestCustomVjpInvalidRule))
+                .expect("custom_vjp_invalid VJP registration"),
+        )
+        .build()
+        .expect("custom_vjp_invalid AD context")
 }
 
 // ----------------------------------------------------------------------
@@ -1078,22 +1190,39 @@ fn ad_context_uses_owned_extension_rules_without_global_fallback() {
 }
 
 #[test]
-fn traced_vjp_prefers_linearize_transpose_over_primary_transpose() {
+fn traced_vjp_prefers_custom_primal_vjp_over_linearize_transpose() {
     let x = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0]).unwrap();
     let y = apply(Arc::new(TestPreferLinearize), &[&x])
         .unwrap()
         .into_iter()
         .next()
-        .expect("single prefer_linearize output");
+        .expect("single prefer_custom_vjp output");
     let dy = TracedTensor::from_vec_col_major(vec![2], vec![7.0_f64, 11.0]).unwrap();
 
     let vjp = prefer_linearize_ad_context()
         .vjp(&y, &x, &dy)
-        .expect("vjp should build through linearize");
+        .expect("vjp should build through custom primal VJP");
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let vjp_out = vjp.run_with(&mut engine).unwrap();
 
-    assert_eq!(f64_slice(&vjp_out), &[7.0, 11.0]);
+    assert_eq!(f64_slice(&vjp_out), &[14.0, 22.0]);
+}
+
+#[test]
+fn traced_vjp_does_not_fallback_when_custom_primal_vjp_reports_invalid_input() {
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 5.0]).unwrap();
+    let y = apply(Arc::new(TestCustomVjpInvalid), &[&x])
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("single custom_vjp_invalid output");
+    let dy = TracedTensor::from_vec_col_major(vec![2], vec![7.0_f64, 11.0]).unwrap();
+
+    let err = custom_vjp_invalid_ad_context()
+        .vjp(&y, &x, &dy)
+        .expect_err("custom VJP invalid-input failure must not fallback");
+
+    assert!(err.to_string().contains("custom VJP validation failure"));
 }
 
 #[test]

--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -114,18 +114,28 @@ impl ExtensionLinearizeRule for LinalgAdRule {
             LinalgOp::Cholesky => {
                 rules::linearize_cholesky(builder, primal_in, primal_out, tangent_in, ctx)
             }
-            LinalgOp::Svd { eps } => {
-                rules::linearize_svd(builder, primal_in, primal_out, tangent_in, eps, ctx)
-            }
-            LinalgOp::SvdVals { eps } => {
-                rules::linearize_svd_values(builder, primal_in, tangent_in, eps, ctx)
+            LinalgOp::Svd { derivative_eps, .. } => rules::linearize_svd(
+                builder,
+                primal_in,
+                primal_out,
+                tangent_in,
+                derivative_eps,
+                ctx,
+            ),
+            LinalgOp::SvdVals { derivative_eps } => {
+                rules::linearize_svd_values(builder, primal_in, tangent_in, derivative_eps, ctx)
             }
             LinalgOp::Qr => rules::linearize_qr(builder, primal_in, primal_out, tangent_in, ctx),
-            LinalgOp::Eigh { eps } => {
-                rules::linearize_eigh(builder, primal_in, primal_out, tangent_in, eps, ctx)
-            }
-            LinalgOp::EighVals { eps } => {
-                rules::linearize_eigh_values(builder, primal_in, tangent_in, eps, ctx)
+            LinalgOp::Eigh { derivative_eps } => rules::linearize_eigh(
+                builder,
+                primal_in,
+                primal_out,
+                tangent_in,
+                derivative_eps,
+                ctx,
+            ),
+            LinalgOp::EighVals { derivative_eps } => {
+                rules::linearize_eigh_values(builder, primal_in, tangent_in, derivative_eps, ctx)
             }
             LinalgOp::Eig { input_dtype } => {
                 rules::linearize_eig(builder, primal_in, primal_out, tangent_in, input_dtype, ctx)
@@ -304,7 +314,7 @@ fn fixed_transpose_value(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::DEFAULT_DECOMPOSITION_AD_EPS;
+    use crate::extension::{SvdGauge, DEFAULT_DECOMPOSITION_DERIVATIVE_EPS};
     use computegraph::graph::GraphBuilder;
     use std::collections::HashSet;
     use tenferro_ops::input_key::TensorInputKey;
@@ -534,14 +544,15 @@ mod tests {
             ),
             (
                 LinalgOp::Svd {
-                    eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                    derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
+                    gauge: SvdGauge::Raw,
                 },
                 svd_context(&[2, 2]),
                 vec![None, None, None],
             ),
             (
                 LinalgOp::Eigh {
-                    eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                    derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
                 },
                 eigh_context(),
                 vec![None, None],
@@ -588,7 +599,8 @@ mod tests {
         let mut builder = GraphBuilder::<StdTensorOp>::new();
         let tangent = builder.add_input(TensorInputKey::User { id: 133 });
         let op = LinalgExtensionOp::new(LinalgOp::Svd {
-            eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
+            gauge: SvdGauge::Raw,
         });
 
         let result = LinalgAdRule
@@ -619,7 +631,7 @@ mod tests {
         let mut builder = GraphBuilder::<StdTensorOp>::new();
         let tangent = builder.add_input(TensorInputKey::User { id: 134 });
         let op = LinalgExtensionOp::new(LinalgOp::Eigh {
-            eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
         });
 
         let result = LinalgAdRule
@@ -875,7 +887,7 @@ mod tests {
         let mut builder = GraphBuilder::<StdTensorOp>::new();
         let cotangent = builder.add_input(TensorInputKey::User { id: 85 });
         let op = LinalgExtensionOp::new(LinalgOp::EighVals {
-            eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
         });
 
         let result = LinalgAdRule
@@ -903,7 +915,7 @@ mod tests {
         let g_w = builder.add_input(TensorInputKey::User { id: 86 });
         let g_v = builder.add_input(TensorInputKey::User { id: 87 });
         let op = LinalgExtensionOp::new(LinalgOp::Eigh {
-            eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
         });
 
         let result = LinalgAdRule
@@ -1013,17 +1025,18 @@ mod tests {
             LinalgOp::Lu,
             LinalgOp::FullPivLu,
             LinalgOp::Svd {
-                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
+                gauge: SvdGauge::Raw,
             },
             LinalgOp::SvdVals {
-                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
             },
             LinalgOp::Qr,
             LinalgOp::Eigh {
-                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
             },
             LinalgOp::EighVals {
-                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
             },
             LinalgOp::Eig {
                 input_dtype: DType::F64,

--- a/crates/tenferro-linalg/src/ad/rules/mod.rs
+++ b/crates/tenferro-linalg/src/ad/rules/mod.rs
@@ -22,7 +22,7 @@ use tenferro_ops::ad::PrimitiveRuleBuilder;
 
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 
-use crate::extension::{LinalgExtensionOp, LinalgOp};
+use crate::extension::{LinalgExtensionOp, LinalgOp, SvdGauge};
 use tenferro_ops::ad::context::{resolve_and_guard, ShapeGuardContext};
 pub(crate) use tenferro_ops::ad::support::{
     conjugate_linear_if_dtype_complex, conjugate_primal_if_dtype_complex,
@@ -629,7 +629,10 @@ pub(crate) fn linearize_svd_values(
     let matrix_rank = input_shape.len();
     let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let svd_outputs = builder.add_operation(
-        linalg_std_op(LinalgOp::Svd { eps }),
+        linalg_std_op(LinalgOp::Svd {
+            derivative_eps: eps,
+            gauge: SvdGauge::Raw,
+        }),
         vec![ValueRef::External(primal_in[0].clone())],
         OperationRole::Primary,
     );
@@ -759,7 +762,9 @@ pub(crate) fn linearize_eigh_values(
     let matrix_rank = input_shape.len();
     let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let eigh_outputs = builder.add_operation(
-        linalg_std_op(LinalgOp::Eigh { eps }),
+        linalg_std_op(LinalgOp::Eigh {
+            derivative_eps: eps,
+        }),
         vec![ValueRef::External(primal_in[0].clone())],
         OperationRole::Primary,
     );

--- a/crates/tenferro-linalg/src/ad/support.rs
+++ b/crates/tenferro-linalg/src/ad/support.rs
@@ -21,6 +21,53 @@ pub enum LinalgAdRuleSupport {
     PendingOracle,
 }
 
+/// Implementation route used for a user-visible AD mode.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::{linalg_ad_support, LinalgAdOpKind, LinalgAdRoute};
+///
+/// let svd = linalg_ad_support(LinalgAdOpKind::Svd);
+/// assert_eq!(svd.vjp.route, LinalgAdRoute::LinearizeThenTranspose);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LinalgAdRoute {
+    /// No supported route exists.
+    Unsupported,
+    /// The mode is emitted directly by the operation's linearize rule.
+    Linearize,
+    /// Reverse mode is supported by linearizing the primal graph and then
+    /// transposing that linear graph.
+    LinearizeThenTranspose,
+    /// Reverse mode is supported by linearizing the primal graph and using a
+    /// custom transposed-linear rule for the emitted linear operation.
+    LinearizeThenCustomLinearTranspose,
+    /// Reverse mode is emitted by a direct operation-specific primal VJP rule.
+    CustomVjp,
+    /// A custom VJP is preferred, with the canonical linearize-then-transpose
+    /// route retained as an intentional not-applicable fallback.
+    CustomPreferredWithLinearizeFallback,
+}
+
+/// User-visible AD support for one mode.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::{linalg_ad_support, LinalgAdOpKind, LinalgAdRoute};
+///
+/// let solve = linalg_ad_support(LinalgAdOpKind::TriangularSolve);
+/// assert_eq!(solve.vjp.route, LinalgAdRoute::LinearizeThenCustomLinearTranspose);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LinalgAdModeSupport {
+    /// Whether the user-visible mode is supported.
+    pub status: LinalgAdRuleSupport,
+    /// How the mode is implemented.
+    pub route: LinalgAdRoute,
+}
+
 /// Operation keys covered by the linalg AD support manifest.
 ///
 /// # Examples
@@ -129,18 +176,68 @@ pub struct LinalgAdOutputSupport {
 /// use tenferro_linalg::{linalg_ad_support, LinalgAdOpKind, LinalgAdRuleSupport};
 ///
 /// let solve = linalg_ad_support(LinalgAdOpKind::TriangularSolve);
-/// assert_eq!(solve.transpose, LinalgAdRuleSupport::Supported);
+/// assert_eq!(solve.vjp.route, tenferro_linalg::LinalgAdRoute::LinearizeThenCustomLinearTranspose);
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct LinalgAdSupport {
     /// Operation kind described by this manifest entry.
     pub kind: LinalgAdOpKind,
+    /// User-visible JVP support and route.
+    pub jvp: LinalgAdModeSupport,
+    /// User-visible VJP support and route.
+    pub vjp: LinalgAdModeSupport,
+    /// Definitional linearize rule implementation status.
+    pub linearize_rule: LinalgAdRuleSupport,
+    /// Direct primal VJP rule implementation status.
+    pub custom_vjp_rule: LinalgAdRuleSupport,
+    /// Custom transposed-linear rule implementation status.
+    pub custom_linear_transpose_rule: LinalgAdRuleSupport,
     /// Forward-mode graph emission support.
     pub linearize: LinalgAdRuleSupport,
     /// Transposed-linear graph emission support.
     pub transpose: LinalgAdRuleSupport,
     /// Per-output support status for multi-output operations.
     pub outputs: &'static [LinalgAdOutputSupport],
+    /// Numerical or semantic caveats for this operation family.
+    pub caveats: &'static [&'static str],
+}
+
+const fn mode(status: LinalgAdRuleSupport, route: LinalgAdRoute) -> LinalgAdModeSupport {
+    LinalgAdModeSupport { status, route }
+}
+
+const fn jvp_route(status: LinalgAdRuleSupport) -> LinalgAdRoute {
+    match status {
+        LinalgAdRuleSupport::Unsupported
+        | LinalgAdRuleSupport::NonDifferentiable
+        | LinalgAdRuleSupport::PendingOracle => LinalgAdRoute::Unsupported,
+        LinalgAdRuleSupport::Supported
+        | LinalgAdRuleSupport::SupportedViaLinearize
+        | LinalgAdRuleSupport::PartiallySupported => LinalgAdRoute::Linearize,
+    }
+}
+
+const fn support_entry(
+    kind: LinalgAdOpKind,
+    linearize: LinalgAdRuleSupport,
+    transpose: LinalgAdRuleSupport,
+    vjp: LinalgAdModeSupport,
+    custom_linear_transpose_rule: LinalgAdRuleSupport,
+    outputs: &'static [LinalgAdOutputSupport],
+    caveats: &'static [&'static str],
+) -> LinalgAdSupport {
+    LinalgAdSupport {
+        kind,
+        jvp: mode(linearize, jvp_route(linearize)),
+        vjp,
+        linearize_rule: linearize,
+        custom_vjp_rule: LinalgAdRuleSupport::Unsupported,
+        custom_linear_transpose_rule,
+        linearize,
+        transpose,
+        outputs,
+        caveats,
+    }
 }
 
 const fn output(
@@ -229,91 +326,176 @@ static EIG_VALS_OUTPUTS: [LinalgAdOutputSupport; 1] = [output(
     LinalgAdRuleSupport::SupportedViaLinearize,
 )];
 
+static DECOMPOSITION_CAVEATS: [&str; 1] = [
+    "Derivative regularization handles near-degenerate spectra but does not make exact degeneracies smoothly differentiable.",
+];
+
 static LINALG_AD_SUPPORT: [LinalgAdSupport; LinalgAdOpKind::COUNT] = [
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::Cholesky,
-        linearize: LinalgAdRuleSupport::SupportedViaLinearize,
-        transpose: LinalgAdRuleSupport::Unsupported,
-        outputs: &CHOLESKY_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::Lu,
-        linearize: LinalgAdRuleSupport::PartiallySupported,
-        transpose: LinalgAdRuleSupport::Unsupported,
-        outputs: &LU_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::LuFactor,
-        linearize: LinalgAdRuleSupport::Unsupported,
-        transpose: LinalgAdRuleSupport::Unsupported,
-        outputs: &LU_FACTOR_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::LuSolvePrepared,
-        linearize: LinalgAdRuleSupport::SupportedViaLinearize,
-        transpose: LinalgAdRuleSupport::PartiallySupported,
-        outputs: &SOLUTION_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::FullPivLu,
-        linearize: LinalgAdRuleSupport::SupportedViaLinearize,
-        transpose: LinalgAdRuleSupport::Unsupported,
-        outputs: &FULL_PIV_LU_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::FullPivLuSolve,
-        linearize: LinalgAdRuleSupport::SupportedViaLinearize,
-        transpose: LinalgAdRuleSupport::Supported,
-        outputs: &FULL_PIV_LU_SOLVE_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::Svd,
-        linearize: LinalgAdRuleSupport::SupportedViaLinearize,
-        transpose: LinalgAdRuleSupport::Unsupported,
-        outputs: &SVD_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::SvdVals,
-        linearize: LinalgAdRuleSupport::SupportedViaLinearize,
-        transpose: LinalgAdRuleSupport::Unsupported,
-        outputs: &SVD_VALS_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::Qr,
-        linearize: LinalgAdRuleSupport::SupportedViaLinearize,
-        transpose: LinalgAdRuleSupport::Unsupported,
-        outputs: &QR_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::Eigh,
-        linearize: LinalgAdRuleSupport::SupportedViaLinearize,
-        transpose: LinalgAdRuleSupport::Unsupported,
-        outputs: &EIGH_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::EighVals,
-        linearize: LinalgAdRuleSupport::SupportedViaLinearize,
-        transpose: LinalgAdRuleSupport::Unsupported,
-        outputs: &EIGH_VALS_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::Eig,
-        linearize: LinalgAdRuleSupport::PartiallySupported,
-        transpose: LinalgAdRuleSupport::Unsupported,
-        outputs: &EIG_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::EigVals,
-        linearize: LinalgAdRuleSupport::SupportedViaLinearize,
-        transpose: LinalgAdRuleSupport::Unsupported,
-        outputs: &EIG_VALS_OUTPUTS,
-    },
-    LinalgAdSupport {
-        kind: LinalgAdOpKind::TriangularSolve,
-        linearize: LinalgAdRuleSupport::SupportedViaLinearize,
-        transpose: LinalgAdRuleSupport::Supported,
-        outputs: &SOLUTION_OUTPUTS,
-    },
+    support_entry(
+        LinalgAdOpKind::Cholesky,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::Unsupported,
+        mode(
+            LinalgAdRuleSupport::SupportedViaLinearize,
+            LinalgAdRoute::LinearizeThenTranspose,
+        ),
+        LinalgAdRuleSupport::Unsupported,
+        &CHOLESKY_OUTPUTS,
+        &DECOMPOSITION_CAVEATS,
+    ),
+    support_entry(
+        LinalgAdOpKind::Lu,
+        LinalgAdRuleSupport::PartiallySupported,
+        LinalgAdRuleSupport::Unsupported,
+        mode(
+            LinalgAdRuleSupport::PartiallySupported,
+            LinalgAdRoute::LinearizeThenTranspose,
+        ),
+        LinalgAdRuleSupport::Unsupported,
+        &LU_OUTPUTS,
+        &DECOMPOSITION_CAVEATS,
+    ),
+    support_entry(
+        LinalgAdOpKind::LuFactor,
+        LinalgAdRuleSupport::Unsupported,
+        LinalgAdRuleSupport::Unsupported,
+        mode(LinalgAdRuleSupport::Unsupported, LinalgAdRoute::Unsupported),
+        LinalgAdRuleSupport::Unsupported,
+        &LU_FACTOR_OUTPUTS,
+        &[],
+    ),
+    support_entry(
+        LinalgAdOpKind::LuSolvePrepared,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::PartiallySupported,
+        mode(
+            LinalgAdRuleSupport::SupportedViaLinearize,
+            LinalgAdRoute::LinearizeThenCustomLinearTranspose,
+        ),
+        LinalgAdRuleSupport::PartiallySupported,
+        &SOLUTION_OUTPUTS,
+        &[],
+    ),
+    support_entry(
+        LinalgAdOpKind::FullPivLu,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::Unsupported,
+        mode(
+            LinalgAdRuleSupport::SupportedViaLinearize,
+            LinalgAdRoute::LinearizeThenTranspose,
+        ),
+        LinalgAdRuleSupport::Unsupported,
+        &FULL_PIV_LU_OUTPUTS,
+        &DECOMPOSITION_CAVEATS,
+    ),
+    support_entry(
+        LinalgAdOpKind::FullPivLuSolve,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::Supported,
+        mode(
+            LinalgAdRuleSupport::SupportedViaLinearize,
+            LinalgAdRoute::LinearizeThenCustomLinearTranspose,
+        ),
+        LinalgAdRuleSupport::Supported,
+        &FULL_PIV_LU_SOLVE_OUTPUTS,
+        &[],
+    ),
+    support_entry(
+        LinalgAdOpKind::Svd,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::Unsupported,
+        mode(
+            LinalgAdRuleSupport::SupportedViaLinearize,
+            LinalgAdRoute::LinearizeThenTranspose,
+        ),
+        LinalgAdRuleSupport::Unsupported,
+        &SVD_OUTPUTS,
+        &DECOMPOSITION_CAVEATS,
+    ),
+    support_entry(
+        LinalgAdOpKind::SvdVals,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::Unsupported,
+        mode(
+            LinalgAdRuleSupport::SupportedViaLinearize,
+            LinalgAdRoute::LinearizeThenTranspose,
+        ),
+        LinalgAdRuleSupport::Unsupported,
+        &SVD_VALS_OUTPUTS,
+        &DECOMPOSITION_CAVEATS,
+    ),
+    support_entry(
+        LinalgAdOpKind::Qr,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::Unsupported,
+        mode(
+            LinalgAdRuleSupport::SupportedViaLinearize,
+            LinalgAdRoute::LinearizeThenTranspose,
+        ),
+        LinalgAdRuleSupport::Unsupported,
+        &QR_OUTPUTS,
+        &DECOMPOSITION_CAVEATS,
+    ),
+    support_entry(
+        LinalgAdOpKind::Eigh,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::Unsupported,
+        mode(
+            LinalgAdRuleSupport::SupportedViaLinearize,
+            LinalgAdRoute::LinearizeThenTranspose,
+        ),
+        LinalgAdRuleSupport::Unsupported,
+        &EIGH_OUTPUTS,
+        &DECOMPOSITION_CAVEATS,
+    ),
+    support_entry(
+        LinalgAdOpKind::EighVals,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::Unsupported,
+        mode(
+            LinalgAdRuleSupport::SupportedViaLinearize,
+            LinalgAdRoute::LinearizeThenTranspose,
+        ),
+        LinalgAdRuleSupport::Unsupported,
+        &EIGH_VALS_OUTPUTS,
+        &DECOMPOSITION_CAVEATS,
+    ),
+    support_entry(
+        LinalgAdOpKind::Eig,
+        LinalgAdRuleSupport::PartiallySupported,
+        LinalgAdRuleSupport::Unsupported,
+        mode(
+            LinalgAdRuleSupport::PartiallySupported,
+            LinalgAdRoute::LinearizeThenTranspose,
+        ),
+        LinalgAdRuleSupport::Unsupported,
+        &EIG_OUTPUTS,
+        &DECOMPOSITION_CAVEATS,
+    ),
+    support_entry(
+        LinalgAdOpKind::EigVals,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::Unsupported,
+        mode(
+            LinalgAdRuleSupport::SupportedViaLinearize,
+            LinalgAdRoute::LinearizeThenTranspose,
+        ),
+        LinalgAdRuleSupport::Unsupported,
+        &EIG_VALS_OUTPUTS,
+        &DECOMPOSITION_CAVEATS,
+    ),
+    support_entry(
+        LinalgAdOpKind::TriangularSolve,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::Supported,
+        mode(
+            LinalgAdRuleSupport::SupportedViaLinearize,
+            LinalgAdRoute::LinearizeThenCustomLinearTranspose,
+        ),
+        LinalgAdRuleSupport::Supported,
+        &SOLUTION_OUTPUTS,
+        &[],
+    ),
 ];
 
 /// Return the complete linalg AD support manifest.

--- a/crates/tenferro-linalg/src/ad/support/tests.rs
+++ b/crates/tenferro-linalg/src/ad/support/tests.rs
@@ -1,6 +1,6 @@
 use tenferro_tensor::DType;
 
-use crate::extension::DEFAULT_DECOMPOSITION_AD_EPS;
+use crate::extension::{SvdGauge, DEFAULT_DECOMPOSITION_DERIVATIVE_EPS};
 
 use super::*;
 
@@ -24,26 +24,27 @@ fn manifest_internal_mapping_covers_linalg_op_variants() {
         ),
         (
             LinalgOp::Svd {
-                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
+                gauge: SvdGauge::Raw,
             },
             LinalgAdOpKind::Svd,
         ),
         (
             LinalgOp::SvdVals {
-                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
             },
             LinalgAdOpKind::SvdVals,
         ),
         (LinalgOp::Qr, LinalgAdOpKind::Qr),
         (
             LinalgOp::Eigh {
-                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
             },
             LinalgAdOpKind::Eigh,
         ),
         (
             LinalgOp::EighVals {
-                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
             },
             LinalgAdOpKind::EighVals,
         ),
@@ -73,4 +74,72 @@ fn manifest_internal_mapping_covers_linalg_op_variants() {
     for (op, kind) in samples {
         assert_eq!(linalg_ad_support_for_op(op).kind, kind);
     }
+}
+
+#[test]
+fn helper_routes_cover_all_rule_statuses() {
+    let supported_statuses = [
+        LinalgAdRuleSupport::Supported,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::PartiallySupported,
+    ];
+    for status in supported_statuses {
+        assert_eq!(jvp_route(status), LinalgAdRoute::Linearize);
+        assert_eq!(mode(status, jvp_route(status)).status, status);
+    }
+
+    let inactive_statuses = [
+        LinalgAdRuleSupport::Unsupported,
+        LinalgAdRuleSupport::NonDifferentiable,
+        LinalgAdRuleSupport::PendingOracle,
+    ];
+    for status in inactive_statuses {
+        assert_eq!(jvp_route(status), LinalgAdRoute::Unsupported);
+        assert_eq!(
+            mode(status, jvp_route(status)).route,
+            LinalgAdRoute::Unsupported
+        );
+    }
+}
+
+#[test]
+fn support_entry_helper_preserves_manifest_fields() {
+    static OUTPUTS: [LinalgAdOutputSupport; 1] = [output(
+        0,
+        "solution",
+        LinalgAdRuleSupport::SupportedViaLinearize,
+    )];
+    static CAVEATS: [&str; 1] = ["test caveat"];
+
+    let vjp = mode(
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRoute::LinearizeThenCustomLinearTranspose,
+    );
+    let entry = support_entry(
+        LinalgAdOpKind::TriangularSolve,
+        LinalgAdRuleSupport::SupportedViaLinearize,
+        LinalgAdRuleSupport::Supported,
+        vjp,
+        LinalgAdRuleSupport::Supported,
+        &OUTPUTS,
+        &CAVEATS,
+    );
+
+    assert_eq!(entry.kind, LinalgAdOpKind::TriangularSolve);
+    assert_eq!(entry.jvp.status, LinalgAdRuleSupport::SupportedViaLinearize);
+    assert_eq!(entry.jvp.route, LinalgAdRoute::Linearize);
+    assert_eq!(entry.vjp, vjp);
+    assert_eq!(
+        entry.linearize_rule,
+        LinalgAdRuleSupport::SupportedViaLinearize
+    );
+    assert_eq!(entry.custom_vjp_rule, LinalgAdRuleSupport::Unsupported);
+    assert_eq!(
+        entry.custom_linear_transpose_rule,
+        LinalgAdRuleSupport::Supported
+    );
+    assert_eq!(entry.linearize, LinalgAdRuleSupport::SupportedViaLinearize);
+    assert_eq!(entry.transpose, LinalgAdRuleSupport::Supported);
+    assert_eq!(entry.outputs, &OUTPUTS);
+    assert_eq!(entry.caveats, &CAVEATS);
 }

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -1,5 +1,7 @@
 use tenferro_tensor::{Tensor, TensorBackend, TensorView};
 
+use crate::extension::{apply_svd_gauge, validate_derivative_eps, EighOptions, SvdOptions};
+
 /// Build the shared "unsupported dtype" backend-failure error used by the
 /// linalg backends.
 ///
@@ -77,6 +79,39 @@ pub trait LinalgBackend: TensorBackend {
 
     /// Compute public SVD outputs `(U, S, Vt)`.
     fn svd(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+
+    /// Compute public SVD outputs `(U, S, Vt)` with explicit options.
+    ///
+    /// `derivative_eps` is validated for API consistency, but concrete backend
+    /// execution does not perform AD. `gauge` controls optional singular-vector
+    /// post-processing.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{LinalgBackend, SvdGauge, SvdOptions};
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
+    /// let mut backend = CpuBackend::new();
+    /// let outputs = backend.svd_with_options(
+    ///     &input,
+    ///     SvdOptions::default().gauge(SvdGauge::CanonicalPivot),
+    /// )?;
+    /// assert_eq!(outputs[1].shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn svd_with_options(
+        &mut self,
+        input: &Tensor,
+        options: SvdOptions,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        validate_derivative_eps("svd_with_options", options.derivative_eps)?;
+        let mut outputs = self.svd(input)?;
+        apply_svd_gauge(options.gauge, &mut outputs)?;
+        Ok(outputs)
+    }
 
     #[doc(hidden)]
     fn svd_values(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
@@ -157,6 +192,36 @@ pub trait LinalgBackend: TensorBackend {
     /// The returned vector order is `[values, vectors]`, where `values` has
     /// shape `[n]` and `vectors` has shape `[n, n]`.
     fn eigh(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
+
+    /// Compute public Hermitian eigendecomposition outputs with explicit options.
+    ///
+    /// `derivative_eps` is validated for API consistency, but concrete backend
+    /// execution does not perform AD.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{EighOptions, LinalgBackend};
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
+    /// let mut backend = CpuBackend::new();
+    /// let outputs = backend.eigh_with_options(
+    ///     &input,
+    ///     EighOptions::default().derivative_eps(1.0e-10),
+    /// )?;
+    /// assert_eq!(outputs[0].shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn eigh_with_options(
+        &mut self,
+        input: &Tensor,
+        options: EighOptions,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        validate_derivative_eps("eigh_with_options", options.derivative_eps)?;
+        self.eigh(input)
+    }
 
     /// Compute public Hermitian eigendecomposition outputs from a borrowed tensor view.
     ///

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -4,12 +4,18 @@ use tenferro_ad::error::{Error, Result};
 use tenferro_ad::extension::apply_eager;
 use tenferro_ad::EagerTensor;
 
-use crate::extension::{LinalgExtensionOp, LinalgOp, DEFAULT_DECOMPOSITION_AD_EPS};
+use crate::extension::{
+    validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, SvdOptions,
+};
 use crate::register_runtime;
 
 /// Linear algebra extension methods for [`EagerTensor`].
 pub trait EagerTensorLinalgExt {
     fn svd(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor)>;
+    fn svd_with_options(
+        &self,
+        options: SvdOptions,
+    ) -> Result<(EagerTensor, EagerTensor, EagerTensor)>;
     fn qr(&self) -> Result<(EagerTensor, EagerTensor)>;
     fn lu(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor, EagerTensor)>;
     fn full_piv_lu(
@@ -25,6 +31,7 @@ pub trait EagerTensorLinalgExt {
     fn solve(&self, b: &EagerTensor) -> Result<EagerTensor>;
     fn cholesky(&self) -> Result<EagerTensor>;
     fn eigh(&self) -> Result<(EagerTensor, EagerTensor)>;
+    fn eigh_with_options(&self, options: EighOptions) -> Result<(EagerTensor, EagerTensor)>;
     fn eig(&self) -> Result<(EagerTensor, EagerTensor)>;
     fn triangular_solve(
         &self,
@@ -39,6 +46,13 @@ pub trait EagerTensorLinalgExt {
 impl EagerTensorLinalgExt for EagerTensor {
     fn svd(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor)> {
         svd(self)
+    }
+
+    fn svd_with_options(
+        &self,
+        options: SvdOptions,
+    ) -> Result<(EagerTensor, EagerTensor, EagerTensor)> {
+        svd_with_options(self, options)
     }
 
     fn qr(&self) -> Result<(EagerTensor, EagerTensor)> {
@@ -75,6 +89,10 @@ impl EagerTensorLinalgExt for EagerTensor {
 
     fn eigh(&self) -> Result<(EagerTensor, EagerTensor)> {
         eigh(self)
+    }
+
+    fn eigh_with_options(&self, options: EighOptions) -> Result<(EagerTensor, EagerTensor)> {
+        eigh_with_options(self, options)
     }
 
     fn eig(&self) -> Result<(EagerTensor, EagerTensor)> {
@@ -121,9 +139,41 @@ fn apply_linalg_eager(op: LinalgOp, inputs: &[&EagerTensor]) -> Result<Vec<Eager
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
 pub fn svd(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor, EagerTensor)> {
+    svd_with_options(a, SvdOptions::default())
+}
+
+/// Singular value decomposition for eager tensors with explicit options.
+///
+/// `derivative_eps` regularizes decomposition derivative formulas. It is not a
+/// backend SVD solver tolerance.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+/// use tenferro_linalg::{EagerTensorLinalgExt, SvdGauge, SvdOptions};
+///
+/// let ctx = EagerRuntime::new();
+/// let a = EagerTensor::from_tensor_in(
+///     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]).unwrap(),
+///     ctx,
+/// ).unwrap();
+/// let options = SvdOptions::default()
+///     .gauge(SvdGauge::CanonicalPivot)
+///     .derivative_eps(1.0e-10);
+/// let (_u, s, _vt) = a.svd_with_options(options)?;
+/// assert_eq!(s.shape(), &[2]);
+/// # Ok::<(), tenferro_ad::Error>(())
+/// ```
+pub fn svd_with_options(
+    a: &EagerTensor,
+    options: SvdOptions,
+) -> Result<(EagerTensor, EagerTensor, EagerTensor)> {
+    validate_derivative_eps("svd_with_options", options.derivative_eps)?;
     let mut outputs = apply_linalg_eager(
         LinalgOp::Svd {
-            eps: DEFAULT_DECOMPOSITION_AD_EPS,
+            derivative_eps: options.derivative_eps,
+            gauge: options.gauge,
         },
         &[a],
     )?
@@ -363,10 +413,40 @@ pub fn cholesky(a: &EagerTensor) -> Result<EagerTensor> {
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
 pub fn eigh(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
+    eigh_with_options(a, EighOptions::default())
+}
+
+/// Hermitian eigenvalue decomposition for eager tensors with explicit options.
+///
+/// `derivative_eps` regularizes derivative formulas for repeated or nearly
+/// repeated eigenvalues. It is not a backend eigensolver tolerance.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+/// use tenferro_linalg::{EagerTensorLinalgExt, EighOptions};
+///
+/// let ctx = EagerRuntime::new();
+/// let a = EagerTensor::from_tensor_in(
+///     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 3.0]).unwrap(),
+///     ctx,
+/// ).unwrap();
+/// let (values, vectors) = a
+///     .eigh_with_options(EighOptions::default().derivative_eps(1.0e-10))?;
+/// assert_eq!(values.shape(), &[2]);
+/// assert_eq!(vectors.shape(), &[2, 2]);
+/// # Ok::<(), tenferro_ad::Error>(())
+/// ```
+pub fn eigh_with_options(
+    a: &EagerTensor,
+    options: EighOptions,
+) -> Result<(EagerTensor, EagerTensor)> {
+    validate_derivative_eps("eigh_with_options", options.derivative_eps)?;
     two_outputs(
         apply_linalg_eager(
             LinalgOp::Eigh {
-                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                derivative_eps: options.derivative_eps,
             },
             &[a],
         )?,

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::hash::Hasher;
 use std::sync::Arc;
 
+use num_complex::{Complex32, Complex64};
 use tenferro_extension_macros::define_extension_runtime;
 use tenferro_ops::SymDim;
 use tenferro_runtime::extension::{ExtensionExecutionContext, ExtensionOp, HostReference};
@@ -16,7 +17,156 @@ mod tests;
 
 pub const LINALG_EXTENSION_FAMILY_ID: &str = "tenferro-linalg.linalg.v1";
 
-pub(crate) const DEFAULT_DECOMPOSITION_AD_EPS: f64 = 1e-12;
+/// Default derivative regularization used by decomposition AD rules.
+///
+/// This epsilon is used only when differentiating decomposition formulas with
+/// repeated or nearly repeated spectral values. It is not a solver tolerance.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::{SvdOptions, DEFAULT_DECOMPOSITION_DERIVATIVE_EPS};
+///
+/// let options = SvdOptions::default();
+/// assert_eq!(options.derivative_eps, DEFAULT_DECOMPOSITION_DERIVATIVE_EPS);
+/// ```
+pub const DEFAULT_DECOMPOSITION_DERIVATIVE_EPS: f64 = 1e-12;
+
+/// Singular-vector gauge convention used by [`SvdOptions`].
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::{SvdGauge, SvdOptions};
+///
+/// let options = SvdOptions::default().gauge(SvdGauge::CanonicalPivot);
+/// assert_eq!(options.gauge, SvdGauge::CanonicalPivot);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SvdGauge {
+    /// Leave the backend's raw singular vector signs or phases unchanged.
+    Raw,
+    /// Make each left singular vector's max-absolute pivot entry positive-real
+    /// and adjust the matching `VT` row so reconstruction is preserved.
+    CanonicalPivot,
+}
+
+/// Options for singular value decomposition.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::{SvdGauge, SvdOptions};
+///
+/// let options = SvdOptions::default()
+///     .gauge(SvdGauge::CanonicalPivot)
+///     .derivative_eps(1.0e-10);
+/// assert_eq!(options.gauge, SvdGauge::CanonicalPivot);
+/// assert_eq!(options.derivative_eps, 1.0e-10);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SvdOptions {
+    /// Singular-vector gauge convention.
+    pub gauge: SvdGauge,
+    /// AD derivative regularization for repeated or nearly repeated singular values.
+    pub derivative_eps: f64,
+}
+
+impl Default for SvdOptions {
+    fn default() -> Self {
+        Self {
+            gauge: SvdGauge::Raw,
+            derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
+        }
+    }
+}
+
+impl SvdOptions {
+    /// Return options with the requested singular-vector gauge.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::{SvdGauge, SvdOptions};
+    ///
+    /// let options = SvdOptions::default().gauge(SvdGauge::CanonicalPivot);
+    /// assert_eq!(options.gauge, SvdGauge::CanonicalPivot);
+    /// ```
+    pub fn gauge(mut self, gauge: SvdGauge) -> Self {
+        self.gauge = gauge;
+        self
+    }
+
+    /// Return options with an explicit derivative epsilon.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::SvdOptions;
+    ///
+    /// let options = SvdOptions::default().derivative_eps(1.0e-9);
+    /// assert_eq!(options.derivative_eps, 1.0e-9);
+    /// ```
+    pub fn derivative_eps(mut self, derivative_eps: f64) -> Self {
+        self.derivative_eps = derivative_eps;
+        self
+    }
+}
+
+/// Options for Hermitian eigenvalue decomposition.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::EighOptions;
+///
+/// let options = EighOptions::default().derivative_eps(1.0e-10);
+/// assert_eq!(options.derivative_eps, 1.0e-10);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EighOptions {
+    /// AD derivative regularization for repeated or nearly repeated eigenvalues.
+    pub derivative_eps: f64,
+}
+
+impl Default for EighOptions {
+    fn default() -> Self {
+        Self {
+            derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
+        }
+    }
+}
+
+impl EighOptions {
+    /// Return options with an explicit derivative epsilon.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::EighOptions;
+    ///
+    /// let options = EighOptions::default().derivative_eps(1.0e-9);
+    /// assert_eq!(options.derivative_eps, 1.0e-9);
+    /// ```
+    pub fn derivative_eps(mut self, derivative_eps: f64) -> Self {
+        self.derivative_eps = derivative_eps;
+        self
+    }
+}
+
+pub(crate) fn validate_derivative_eps(
+    op: &'static str,
+    derivative_eps: f64,
+) -> tenferro_tensor::Result<()> {
+    if derivative_eps.is_finite() && derivative_eps > 0.0 {
+        Ok(())
+    } else {
+        Err(Error::InvalidConfig {
+            op,
+            message: format!("derivative_eps must be positive and finite, got {derivative_eps}"),
+        })
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[doc(hidden)]
@@ -33,17 +183,18 @@ pub(crate) enum LinalgOp {
         transpose_a: bool,
     },
     Svd {
-        eps: f64,
+        derivative_eps: f64,
+        gauge: SvdGauge,
     },
     SvdVals {
-        eps: f64,
+        derivative_eps: f64,
     },
     Qr,
     Eigh {
-        eps: f64,
+        derivative_eps: f64,
     },
     EighVals {
-        eps: f64,
+        derivative_eps: f64,
     },
     Eig {
         input_dtype: DType,
@@ -206,10 +357,18 @@ impl ExtensionOp for LinalgExtensionOp {
     fn payload_hash(&self, hasher: &mut dyn Hasher) {
         hasher.write_u8(self.op.tag());
         match self.op {
-            LinalgOp::Svd { eps }
-            | LinalgOp::SvdVals { eps }
-            | LinalgOp::Eigh { eps }
-            | LinalgOp::EighVals { eps } => hasher.write_u64(eps.to_bits()),
+            LinalgOp::Svd {
+                derivative_eps,
+                gauge,
+            } => {
+                hasher.write_u64(derivative_eps.to_bits());
+                hash_svd_gauge(hasher, gauge);
+            }
+            LinalgOp::SvdVals { derivative_eps }
+            | LinalgOp::Eigh { derivative_eps }
+            | LinalgOp::EighVals { derivative_eps } => {
+                hasher.write_u64(derivative_eps.to_bits());
+            }
             LinalgOp::Eig { input_dtype } | LinalgOp::EigVals { input_dtype } => {
                 hash_dtype(hasher, input_dtype);
             }
@@ -267,11 +426,11 @@ impl ExtensionOp for LinalgExtensionOp {
 
     fn prune_outputs(&self, live_outputs: &[bool]) -> Option<Arc<dyn ExtensionOp>> {
         match self.op {
-            LinalgOp::Svd { eps } if live_outputs == [false, true, false] => {
-                Some(Arc::new(Self::new(LinalgOp::SvdVals { eps })))
+            LinalgOp::Svd { derivative_eps, .. } if live_outputs == [false, true, false] => {
+                Some(Arc::new(Self::new(LinalgOp::SvdVals { derivative_eps })))
             }
-            LinalgOp::Eigh { eps } if live_outputs == [true, false] => {
-                Some(Arc::new(Self::new(LinalgOp::EighVals { eps })))
+            LinalgOp::Eigh { derivative_eps } if live_outputs == [true, false] => {
+                Some(Arc::new(Self::new(LinalgOp::EighVals { derivative_eps })))
             }
             LinalgOp::Eig { input_dtype } if live_outputs == [true, false] => {
                 Some(Arc::new(Self::new(LinalgOp::EigVals { input_dtype })))
@@ -427,10 +586,21 @@ fn execute_linalg<B: LinalgBackend>(
             inputs[1],
             transpose_a,
         )?]),
-        LinalgOp::Svd { .. } => backend.svd(inputs[0]),
+        LinalgOp::Svd {
+            derivative_eps,
+            gauge,
+        } => backend.svd_with_options(
+            inputs[0],
+            SvdOptions {
+                derivative_eps,
+                gauge,
+            },
+        ),
         LinalgOp::SvdVals { .. } => Ok(vec![backend.svd_values(inputs[0])?]),
         LinalgOp::Qr => backend.qr(inputs[0]),
-        LinalgOp::Eigh { .. } => backend.eigh(inputs[0]),
+        LinalgOp::Eigh { derivative_eps } => {
+            backend.eigh_with_options(inputs[0], EighOptions { derivative_eps })
+        }
         LinalgOp::EighVals { .. } => Ok(vec![backend.eigh_values(inputs[0])?]),
         LinalgOp::Eig { .. } => backend.eig(inputs[0]),
         LinalgOp::EigVals { .. } => Ok(vec![backend.eig_values(inputs[0])?]),
@@ -448,6 +618,278 @@ fn execute_linalg<B: LinalgBackend>(
             unit_diagonal,
         )?]),
     }
+}
+
+pub(crate) fn apply_svd_gauge(
+    gauge: SvdGauge,
+    outputs: &mut [Tensor],
+) -> tenferro_tensor::Result<()> {
+    match gauge {
+        SvdGauge::Raw => Ok(()),
+        SvdGauge::CanonicalPivot => apply_canonical_pivot_svd_gauge(outputs),
+    }
+}
+
+fn apply_canonical_pivot_svd_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::Result<()> {
+    if outputs.len() != 3 {
+        return Err(Error::InvalidConfig {
+            op: "tenferro-linalg.svd",
+            message: format!(
+                "canonical SVD gauge expected three outputs, got {}",
+                outputs.len()
+            ),
+        });
+    }
+
+    let (u_slice, rest) = outputs.split_at_mut(1);
+    let (singular_slice, vt_slice) = rest.split_at_mut(1);
+    let u = &mut u_slice[0];
+    let singular_values = &singular_slice[0];
+    let vt = &mut vt_slice[0];
+    let u_shape = u.shape().to_vec();
+    let s_shape = singular_values.shape().to_vec();
+    let vt_shape = vt.shape().to_vec();
+    if u_shape.len() < 2 || vt_shape.len() < 2 || s_shape.is_empty() {
+        return Err(Error::InvalidConfig {
+            op: "tenferro-linalg.svd",
+            message: format!(
+                "canonical SVD gauge expected U rank >= 2, S rank >= 1, VT rank >= 2; got U={u_shape:?}, S={s_shape:?}, VT={vt_shape:?}"
+            ),
+        });
+    }
+
+    let m = u_shape[0];
+    let k = u_shape[1];
+    let n = vt_shape[1];
+    if s_shape[0] != k
+        || vt_shape[0] != k
+        || u_shape[2..] != vt_shape[2..]
+        || s_shape[1..] != u_shape[2..]
+    {
+        return Err(Error::InvalidConfig {
+            op: "tenferro-linalg.svd",
+            message: format!(
+                "canonical SVD gauge expected compatible compact SVD shapes, got U={u_shape:?}, S={s_shape:?}, VT={vt_shape:?}"
+            ),
+        });
+    }
+    let batch_count = u_shape[2..].iter().product::<usize>();
+
+    match (u, vt) {
+        (Tensor::F64(u), Tensor::F64(vt)) => canonicalize_svd_gauge_f64(
+            u.host_data_mut()?,
+            vt.host_data_mut()?,
+            m,
+            k,
+            n,
+            batch_count,
+        ),
+        (Tensor::F32(u), Tensor::F32(vt)) => canonicalize_svd_gauge_f32(
+            u.host_data_mut()?,
+            vt.host_data_mut()?,
+            m,
+            k,
+            n,
+            batch_count,
+        ),
+        (Tensor::C64(u), Tensor::C64(vt)) => canonicalize_svd_gauge_c64(
+            u.host_data_mut()?,
+            vt.host_data_mut()?,
+            m,
+            k,
+            n,
+            batch_count,
+        ),
+        (Tensor::C32(u), Tensor::C32(vt)) => canonicalize_svd_gauge_c32(
+            u.host_data_mut()?,
+            vt.host_data_mut()?,
+            m,
+            k,
+            n,
+            batch_count,
+        ),
+        (u, vt) => Err(Error::DTypeMismatch {
+            op: "tenferro-linalg.svd",
+            lhs: u.dtype(),
+            rhs: vt.dtype(),
+        }),
+    }
+}
+
+fn canonicalize_svd_gauge_f64(
+    u: &mut [f64],
+    vt: &mut [f64],
+    m: usize,
+    k: usize,
+    n: usize,
+    batch_count: usize,
+) -> tenferro_tensor::Result<()> {
+    for batch in 0..batch_count {
+        let u_batch = batch * m * k;
+        let vt_batch = batch * k * n;
+        for col in 0..k {
+            let pivot = max_abs_pivot_f64(u, u_batch, m, col);
+            let pivot_value = u[u_batch + pivot + m * col];
+            if pivot_value < 0.0 {
+                for row in 0..m {
+                    let offset = u_batch + row + m * col;
+                    u[offset] = -u[offset];
+                }
+                for vt_col in 0..n {
+                    let offset = vt_batch + col + k * vt_col;
+                    vt[offset] = -vt[offset];
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn canonicalize_svd_gauge_f32(
+    u: &mut [f32],
+    vt: &mut [f32],
+    m: usize,
+    k: usize,
+    n: usize,
+    batch_count: usize,
+) -> tenferro_tensor::Result<()> {
+    for batch in 0..batch_count {
+        let u_batch = batch * m * k;
+        let vt_batch = batch * k * n;
+        for col in 0..k {
+            let pivot = max_abs_pivot_f32(u, u_batch, m, col);
+            let pivot_value = u[u_batch + pivot + m * col];
+            if pivot_value < 0.0 {
+                for row in 0..m {
+                    let offset = u_batch + row + m * col;
+                    u[offset] = -u[offset];
+                }
+                for vt_col in 0..n {
+                    let offset = vt_batch + col + k * vt_col;
+                    vt[offset] = -vt[offset];
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn canonicalize_svd_gauge_c64(
+    u: &mut [Complex64],
+    vt: &mut [Complex64],
+    m: usize,
+    k: usize,
+    n: usize,
+    batch_count: usize,
+) -> tenferro_tensor::Result<()> {
+    for batch in 0..batch_count {
+        let u_batch = batch * m * k;
+        let vt_batch = batch * k * n;
+        for col in 0..k {
+            let pivot = max_abs_pivot_c64(u, u_batch, m, col);
+            let pivot_value = u[u_batch + pivot + m * col];
+            let pivot_norm = pivot_value.norm();
+            if pivot_norm == 0.0 {
+                continue;
+            }
+            let phase = pivot_value.conj() / pivot_norm;
+            let vt_phase = phase.conj();
+            for row in 0..m {
+                let offset = u_batch + row + m * col;
+                u[offset] *= phase;
+            }
+            for vt_col in 0..n {
+                let offset = vt_batch + col + k * vt_col;
+                vt[offset] *= vt_phase;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn canonicalize_svd_gauge_c32(
+    u: &mut [Complex32],
+    vt: &mut [Complex32],
+    m: usize,
+    k: usize,
+    n: usize,
+    batch_count: usize,
+) -> tenferro_tensor::Result<()> {
+    for batch in 0..batch_count {
+        let u_batch = batch * m * k;
+        let vt_batch = batch * k * n;
+        for col in 0..k {
+            let pivot = max_abs_pivot_c32(u, u_batch, m, col);
+            let pivot_value = u[u_batch + pivot + m * col];
+            let pivot_norm = pivot_value.norm();
+            if pivot_norm == 0.0 {
+                continue;
+            }
+            let phase = pivot_value.conj() / pivot_norm;
+            let vt_phase = phase.conj();
+            for row in 0..m {
+                let offset = u_batch + row + m * col;
+                u[offset] *= phase;
+            }
+            for vt_col in 0..n {
+                let offset = vt_batch + col + k * vt_col;
+                vt[offset] *= vt_phase;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn max_abs_pivot_f64(u: &[f64], u_batch: usize, m: usize, col: usize) -> usize {
+    let mut pivot = 0;
+    let mut pivot_abs = u[u_batch + m * col].abs();
+    for row in 1..m {
+        let candidate_abs = u[u_batch + row + m * col].abs();
+        if candidate_abs > pivot_abs {
+            pivot = row;
+            pivot_abs = candidate_abs;
+        }
+    }
+    pivot
+}
+
+fn max_abs_pivot_f32(u: &[f32], u_batch: usize, m: usize, col: usize) -> usize {
+    let mut pivot = 0;
+    let mut pivot_abs = u[u_batch + m * col].abs();
+    for row in 1..m {
+        let candidate_abs = u[u_batch + row + m * col].abs();
+        if candidate_abs > pivot_abs {
+            pivot = row;
+            pivot_abs = candidate_abs;
+        }
+    }
+    pivot
+}
+
+fn max_abs_pivot_c64(u: &[Complex64], u_batch: usize, m: usize, col: usize) -> usize {
+    let mut pivot = 0;
+    let mut pivot_abs = u[u_batch + m * col].norm_sqr();
+    for row in 1..m {
+        let candidate_abs = u[u_batch + row + m * col].norm_sqr();
+        if candidate_abs > pivot_abs {
+            pivot = row;
+            pivot_abs = candidate_abs;
+        }
+    }
+    pivot
+}
+
+fn max_abs_pivot_c32(u: &[Complex32], u_batch: usize, m: usize, col: usize) -> usize {
+    let mut pivot = 0;
+    let mut pivot_abs = u[u_batch + m * col].norm_sqr();
+    for row in 1..m {
+        let candidate_abs = u[u_batch + row + m * col].norm_sqr();
+        if candidate_abs > pivot_abs {
+            pivot = row;
+            pivot_abs = candidate_abs;
+        }
+    }
+    pivot
 }
 
 fn require_matrix_meta(op: &'static str, shape: &[SymDim]) -> tenferro_tensor::Result<()> {
@@ -617,6 +1059,14 @@ fn hash_dtype(hasher: &mut dyn Hasher, dtype: DType) {
         DType::C32 => 4,
         DType::I32 => 5,
         DType::Bool => 6,
+    };
+    hasher.write_u8(tag);
+}
+
+fn hash_svd_gauge(hasher: &mut dyn Hasher, gauge: SvdGauge) {
+    let tag = match gauge {
+        SvdGauge::Raw => 0,
+        SvdGauge::CanonicalPivot => 1,
     };
     hasher.write_u8(tag);
 }

--- a/crates/tenferro-linalg/src/extension/tests.rs
+++ b/crates/tenferro-linalg/src/extension/tests.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
+use num_complex::Complex64;
 use tenferro_runtime::extension::ExtensionOp;
 use tenferro_tensor::{
     Buffer, BufferHandle, DType, DeviceId, DeviceKind, Error, GpuBackendKind, MemoryKind,
     Placement, Tensor, TypedTensor,
 };
 
-use super::{promote_dtypes, LinalgExtensionOp, LinalgOp};
+use super::{apply_svd_gauge, promote_dtypes, LinalgExtensionOp, LinalgOp, SvdGauge};
 
 #[test]
 fn eager_linalg_rejects_cuda_tensor_when_cuda_feature_is_disabled() {
@@ -87,7 +88,10 @@ fn extension_dtype_promotion_delegates_to_canonical_tensor_rules() {
 
 #[test]
 fn decomposition_value_outputs_prune_to_values_only_ops() {
-    let svd = LinalgExtensionOp::new(LinalgOp::Svd { eps: 1.0e-12 });
+    let svd = LinalgExtensionOp::new(LinalgOp::Svd {
+        derivative_eps: 1.0e-12,
+        gauge: SvdGauge::CanonicalPivot,
+    });
     let pruned_svd = svd
         .prune_outputs(&[false, true, false])
         .expect("S-only SVD should prune to SvdVals");
@@ -95,9 +99,16 @@ fn decomposition_value_outputs_prune_to_values_only_ops() {
         .as_any()
         .downcast_ref::<LinalgExtensionOp>()
         .expect("pruned SVD op should stay in linalg family");
-    assert_eq!(pruned_svd.op(), LinalgOp::SvdVals { eps: 1.0e-12 });
+    assert_eq!(
+        pruned_svd.op(),
+        LinalgOp::SvdVals {
+            derivative_eps: 1.0e-12
+        }
+    );
 
-    let eigh = LinalgExtensionOp::new(LinalgOp::Eigh { eps: 1.0e-12 });
+    let eigh = LinalgExtensionOp::new(LinalgOp::Eigh {
+        derivative_eps: 1.0e-12,
+    });
     let pruned_eigh = eigh
         .prune_outputs(&[true, false])
         .expect("eigenvalue-only Hermitian eigendecomposition should prune to EighVals");
@@ -105,7 +116,12 @@ fn decomposition_value_outputs_prune_to_values_only_ops() {
         .as_any()
         .downcast_ref::<LinalgExtensionOp>()
         .expect("pruned Eigh op should stay in linalg family");
-    assert_eq!(pruned_eigh.op(), LinalgOp::EighVals { eps: 1.0e-12 });
+    assert_eq!(
+        pruned_eigh.op(),
+        LinalgOp::EighVals {
+            derivative_eps: 1.0e-12
+        }
+    );
 
     let eig = LinalgExtensionOp::new(LinalgOp::Eig {
         input_dtype: DType::F64,
@@ -123,4 +139,60 @@ fn decomposition_value_outputs_prune_to_values_only_ops() {
             input_dtype: DType::F64
         }
     );
+}
+
+#[test]
+fn canonical_pivot_svd_gauge_flips_real_vectors_and_vt_rows_together() {
+    let mut outputs = vec![
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, -2.0, -3.0, 0.5]).unwrap(),
+        Tensor::from_vec_col_major(vec![2], vec![4.0_f64, 1.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![2, 2], vec![10.0_f64, 20.0, 30.0, 40.0]).unwrap(),
+    ];
+
+    apply_svd_gauge(SvdGauge::CanonicalPivot, &mut outputs).unwrap();
+
+    assert_eq!(
+        outputs[0].as_slice::<f64>().unwrap(),
+        &[-1.0, 2.0, 3.0, -0.5]
+    );
+    assert_eq!(
+        outputs[2].as_slice::<f64>().unwrap(),
+        &[-10.0, -20.0, -30.0, -40.0]
+    );
+}
+
+#[test]
+fn canonical_pivot_svd_gauge_removes_complex_pivot_phase() {
+    let mut outputs = vec![
+        Tensor::C64(
+            TypedTensor::from_vec_col_major(
+                vec![2, 1],
+                vec![Complex64::new(1.0, 1.0), Complex64::new(0.1, 0.0)],
+            )
+            .unwrap(),
+        ),
+        Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap(),
+        Tensor::C64(
+            TypedTensor::from_vec_col_major(
+                vec![1, 2],
+                vec![Complex64::new(2.0, 0.0), Complex64::new(3.0, 4.0)],
+            )
+            .unwrap(),
+        ),
+    ];
+
+    apply_svd_gauge(SvdGauge::CanonicalPivot, &mut outputs).unwrap();
+
+    let scale = 2.0_f64.sqrt();
+    let u = outputs[0].as_slice::<Complex64>().unwrap();
+    assert!((u[0].re - scale).abs() < 1.0e-12);
+    assert!(u[0].im.abs() < 1.0e-12);
+    assert!((u[1].re - 0.1 / scale).abs() < 1.0e-12);
+    assert!((u[1].im + 0.1 / scale).abs() < 1.0e-12);
+
+    let vt = outputs[2].as_slice::<Complex64>().unwrap();
+    assert!((vt[0].re - scale).abs() < 1.0e-12);
+    assert!((vt[0].im - scale).abs() < 1.0e-12);
+    assert!((vt[1].re + 1.0 / scale).abs() < 1.0e-12);
+    assert!((vt[1].im - 7.0 / scale).abs() < 1.0e-12);
 }

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -43,11 +43,14 @@ mod traced;
 pub use ad::ad_rules;
 #[cfg(feature = "autodiff")]
 pub use ad::support::{
-    all_linalg_ad_support, linalg_ad_support, LinalgAdOpKind, LinalgAdOutputSupport,
-    LinalgAdRuleSupport, LinalgAdSupport,
+    all_linalg_ad_support, linalg_ad_support, LinalgAdModeSupport, LinalgAdOpKind,
+    LinalgAdOutputSupport, LinalgAdRoute, LinalgAdRuleSupport, LinalgAdSupport,
 };
 pub use backend::LinalgBackend;
 #[cfg(feature = "autodiff")]
 pub use eager_ext::EagerTensorLinalgExt;
-pub use extension::{register_runtime, LINALG_EXTENSION_FAMILY_ID};
+pub use extension::{
+    register_runtime, EighOptions, SvdGauge, SvdOptions, DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
+    LINALG_EXTENSION_FAMILY_ID,
+};
 pub use traced::TracedTensorLinalgExt;

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -4,15 +4,20 @@ use num_complex::{Complex32, Complex64};
 use tenferro_runtime::extension::apply;
 use tenferro_runtime::{CompareDir, DType, DotGeneralConfig, Error, Result, TracedTensor};
 
-use crate::extension::{LinalgExtensionOp, LinalgOp, DEFAULT_DECOMPOSITION_AD_EPS};
+use crate::extension::{
+    validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, SvdOptions,
+};
 
 /// Linear algebra extension methods for [`TracedTensor`].
 pub trait TracedTensorLinalgExt {
     fn svd(&self) -> Result<(TracedTensor, TracedTensor, TracedTensor)>;
-    fn svd_with_eps(&self, eps: f64) -> Result<(TracedTensor, TracedTensor, TracedTensor)>;
+    fn svd_with_options(
+        &self,
+        options: SvdOptions,
+    ) -> Result<(TracedTensor, TracedTensor, TracedTensor)>;
     fn qr(&self) -> Result<(TracedTensor, TracedTensor)>;
     fn eigh(&self) -> Result<(TracedTensor, TracedTensor)>;
-    fn eigh_with_eps(&self, eps: f64) -> Result<(TracedTensor, TracedTensor)>;
+    fn eigh_with_options(&self, options: EighOptions) -> Result<(TracedTensor, TracedTensor)>;
     fn cholesky(&self) -> Result<TracedTensor>;
     fn lu(&self) -> Result<(TracedTensor, TracedTensor, TracedTensor, TracedTensor)>;
     fn full_piv_lu(
@@ -50,8 +55,11 @@ impl TracedTensorLinalgExt for TracedTensor {
         svd(self)
     }
 
-    fn svd_with_eps(&self, eps: f64) -> Result<(TracedTensor, TracedTensor, TracedTensor)> {
-        svd_with_eps(self, eps)
+    fn svd_with_options(
+        &self,
+        options: SvdOptions,
+    ) -> Result<(TracedTensor, TracedTensor, TracedTensor)> {
+        svd_with_options(self, options)
     }
 
     fn qr(&self) -> Result<(TracedTensor, TracedTensor)> {
@@ -62,8 +70,8 @@ impl TracedTensorLinalgExt for TracedTensor {
         eigh(self)
     }
 
-    fn eigh_with_eps(&self, eps: f64) -> Result<(TracedTensor, TracedTensor)> {
-        eigh_with_eps(self, eps)
+    fn eigh_with_options(&self, options: EighOptions) -> Result<(TracedTensor, TracedTensor)> {
+        eigh_with_options(self, options)
     }
 
     fn cholesky(&self) -> Result<TracedTensor> {
@@ -142,7 +150,7 @@ impl TracedTensorLinalgExt for TracedTensor {
     }
 }
 
-/// Build a traced singular value decomposition op using the default epsilon.
+/// Build a traced singular value decomposition op using default options.
 ///
 /// # Examples
 ///
@@ -157,28 +165,38 @@ impl TracedTensorLinalgExt for TracedTensor {
 /// assert_eq!(vt.rank, 2);
 /// ```
 pub fn svd(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor, TracedTensor)> {
-    svd_with_eps(a, DEFAULT_DECOMPOSITION_AD_EPS)
+    svd_with_options(a, SvdOptions::default())
 }
 
-/// Build a traced singular value decomposition op with an explicit epsilon.
+/// Build a traced singular value decomposition op with explicit options.
+///
+/// `derivative_eps` regularizes decomposition derivative formulas. It is not a
+/// backend SVD solver tolerance.
 ///
 /// # Examples
 ///
 /// ```
-/// use tenferro_linalg::TracedTensorLinalgExt;
+/// use tenferro_linalg::{SvdGauge, SvdOptions, TracedTensorLinalgExt};
 /// use tenferro_runtime::TracedTensor;
 ///
 /// let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap();
-/// let (_u, s, _vt) = a.svd_with_eps(1e-10).unwrap();
+/// let options = SvdOptions::default()
+///     .gauge(SvdGauge::CanonicalPivot)
+///     .derivative_eps(1e-10);
+/// let (_u, s, _vt) = a.svd_with_options(options).unwrap();
 /// assert_eq!(s.rank, 1);
 /// ```
-pub fn svd_with_eps(
+pub fn svd_with_options(
     a: &TracedTensor,
-    eps: f64,
+    options: SvdOptions,
 ) -> Result<(TracedTensor, TracedTensor, TracedTensor)> {
+    validate_derivative_eps("svd_with_options", options.derivative_eps)?;
     three_outputs(
         apply(
-            Arc::new(LinalgExtensionOp::new(LinalgOp::Svd { eps })),
+            Arc::new(LinalgExtensionOp::new(LinalgOp::Svd {
+                derivative_eps: options.derivative_eps,
+                gauge: options.gauge,
+            })),
             &[a],
         )?,
         "svd",
@@ -205,7 +223,7 @@ pub fn qr(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
     )
 }
 
-/// Build a traced Hermitian eigenvalue decomposition op using the default epsilon.
+/// Build a traced Hermitian eigenvalue decomposition op using default options.
 ///
 /// # Examples
 ///
@@ -219,25 +237,36 @@ pub fn qr(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
 /// assert_eq!(vectors.rank, 2);
 /// ```
 pub fn eigh(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
-    eigh_with_eps(a, DEFAULT_DECOMPOSITION_AD_EPS)
+    eigh_with_options(a, EighOptions::default())
 }
 
-/// Build a traced Hermitian eigenvalue decomposition op with an explicit epsilon.
+/// Build a traced Hermitian eigenvalue decomposition op with explicit options.
+///
+/// `derivative_eps` regularizes derivative formulas for repeated or nearly
+/// repeated eigenvalues. It is not a backend eigensolver tolerance.
 ///
 /// # Examples
 ///
 /// ```
-/// use tenferro_linalg::TracedTensorLinalgExt;
+/// use tenferro_linalg::{EighOptions, TracedTensorLinalgExt};
 /// use tenferro_runtime::TracedTensor;
 ///
 /// let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 3.0]).unwrap();
-/// let (values, _vectors) = a.eigh_with_eps(1e-10).unwrap();
+/// let (values, _vectors) = a
+///     .eigh_with_options(EighOptions::default().derivative_eps(1e-10))
+///     .unwrap();
 /// assert_eq!(values.rank, 1);
 /// ```
-pub fn eigh_with_eps(a: &TracedTensor, eps: f64) -> Result<(TracedTensor, TracedTensor)> {
+pub fn eigh_with_options(
+    a: &TracedTensor,
+    options: EighOptions,
+) -> Result<(TracedTensor, TracedTensor)> {
+    validate_derivative_eps("eigh_with_options", options.derivative_eps)?;
     two_outputs(
         apply(
-            Arc::new(LinalgExtensionOp::new(LinalgOp::Eigh { eps })),
+            Arc::new(LinalgExtensionOp::new(LinalgOp::Eigh {
+                derivative_eps: options.derivative_eps,
+            })),
             &[a],
         )?,
         "eigh",
@@ -912,7 +941,8 @@ fn svd_values(a: &TracedTensor) -> Result<TracedTensor> {
     let (_u, s, _vt) = three_outputs(
         apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::Svd {
-                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                derivative_eps: SvdOptions::default().derivative_eps,
+                gauge: SvdOptions::default().gauge,
             })),
             &[a],
         )?,
@@ -925,7 +955,7 @@ fn eigh_values(a: &TracedTensor) -> Result<TracedTensor> {
     let (values, _vectors) = two_outputs(
         apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::Eigh {
-                eps: DEFAULT_DECOMPOSITION_AD_EPS,
+                derivative_eps: EighOptions::default().derivative_eps,
             })),
             &[a],
         )?,

--- a/crates/tenferro-linalg/tests/ad_support_manifest.rs
+++ b/crates/tenferro-linalg/tests/ad_support_manifest.rs
@@ -3,7 +3,7 @@
 use std::{fs, path::Path};
 
 use tenferro_linalg::{
-    all_linalg_ad_support, linalg_ad_support, LinalgAdOpKind, LinalgAdRuleSupport,
+    all_linalg_ad_support, linalg_ad_support, LinalgAdOpKind, LinalgAdRoute, LinalgAdRuleSupport,
 };
 
 fn workspace_root() -> &'static Path {
@@ -140,6 +140,46 @@ fn linalg_ad_support_manifest_marks_values_only_rules_finite_diff_backed() {
         "eigenvalues",
         LinalgAdRuleSupport::SupportedViaLinearize,
     );
+}
+
+#[test]
+fn linalg_ad_support_manifest_separates_user_modes_from_rule_routes() {
+    let svd = linalg_ad_support(LinalgAdOpKind::Svd);
+    assert_eq!(svd.jvp.status, LinalgAdRuleSupport::SupportedViaLinearize);
+    assert_eq!(svd.jvp.route, LinalgAdRoute::Linearize);
+    assert_eq!(svd.vjp.status, LinalgAdRuleSupport::SupportedViaLinearize);
+    assert_eq!(svd.vjp.route, LinalgAdRoute::LinearizeThenTranspose);
+    assert_eq!(svd.custom_vjp_rule, LinalgAdRuleSupport::Unsupported);
+    assert_eq!(
+        svd.custom_linear_transpose_rule,
+        LinalgAdRuleSupport::Unsupported
+    );
+
+    let svd_vals = linalg_ad_support(LinalgAdOpKind::SvdVals);
+    assert_eq!(svd_vals.vjp.route, LinalgAdRoute::LinearizeThenTranspose);
+
+    let triangular_solve = linalg_ad_support(LinalgAdOpKind::TriangularSolve);
+    assert_eq!(
+        triangular_solve.vjp.route,
+        LinalgAdRoute::LinearizeThenCustomLinearTranspose
+    );
+    assert_eq!(
+        triangular_solve.custom_linear_transpose_rule,
+        LinalgAdRuleSupport::Supported
+    );
+
+    let lu_solve = linalg_ad_support(LinalgAdOpKind::LuSolvePrepared);
+    assert_eq!(
+        lu_solve.vjp.route,
+        LinalgAdRoute::LinearizeThenCustomLinearTranspose
+    );
+    assert_eq!(
+        lu_solve.custom_linear_transpose_rule,
+        LinalgAdRuleSupport::PartiallySupported
+    );
+
+    let lu_factor = linalg_ad_support(LinalgAdOpKind::LuFactor);
+    assert_eq!(lu_factor.vjp.route, LinalgAdRoute::Unsupported);
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/eager_tensor.rs
+++ b/crates/tenferro-linalg/tests/eager_tensor.rs
@@ -6,7 +6,7 @@ use tenferro_ad::{AdContext, EagerRuntime, EagerTensor, Tensor};
 use tenferro_cpu::CpuBackend;
 #[cfg(feature = "cuda")]
 use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CudaBackend};
-use tenferro_linalg::EagerTensorLinalgExt;
+use tenferro_linalg::{EagerTensorLinalgExt, EighOptions, SvdGauge, SvdOptions};
 
 fn test_ctx() -> Arc<EagerRuntime> {
     static CTX: OnceLock<Arc<EagerRuntime>> = OnceLock::new();
@@ -106,6 +106,32 @@ fn svd_returns_correct_shapes() {
     assert_eq!(u.shape(), &[2, 2]);
     assert_eq!(s.shape(), &[2]);
     assert_eq!(vt.shape(), &[2, 2]);
+}
+
+#[test]
+fn eager_decomposition_options_execute_and_return_expected_shapes() {
+    let a = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]).unwrap(),
+        test_ctx(),
+    )
+    .unwrap();
+
+    let (u, s, vt) = a
+        .svd_with_options(
+            SvdOptions::default()
+                .gauge(SvdGauge::CanonicalPivot)
+                .derivative_eps(1.0e-10),
+        )
+        .unwrap();
+    let (eigh_values, eigh_vectors) = a
+        .eigh_with_options(EighOptions::default().derivative_eps(1.0e-10))
+        .unwrap();
+
+    assert_eq!(u.shape(), &[2, 2]);
+    assert_eq!(s.shape(), &[2]);
+    assert_eq!(vt.shape(), &[2, 2]);
+    assert_eq!(eigh_values.shape(), &[2]);
+    assert_eq!(eigh_vectors.shape(), &[2, 2]);
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/traced_extension.rs
@@ -1,6 +1,6 @@
 use num_complex::{Complex32, Complex64};
 use tenferro_cpu::CpuBackend;
-use tenferro_linalg::TracedTensorLinalgExt;
+use tenferro_linalg::{EighOptions, LinalgBackend, SvdGauge, SvdOptions, TracedTensorLinalgExt};
 use tenferro_runtime::{
     DType, Error, GraphCompiler, GraphExecutor, GraphOpView, Tensor, TracedTensor, TypedTensor,
 };
@@ -56,6 +56,64 @@ fn svd_executes_after_runtime_registration() {
     assert_eq!(outputs[0].shape(), &[2, 2]);
     assert_eq!(outputs[1].shape(), &[2]);
     assert_eq!(outputs[2].shape(), &[2, 2]);
+}
+
+#[test]
+fn concrete_decomposition_options_execute_through_backend_defaults() {
+    let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]).unwrap();
+    let mut backend = CpuBackend::new();
+
+    let svd_outputs = backend
+        .svd_with_options(
+            &a,
+            SvdOptions::default()
+                .gauge(SvdGauge::CanonicalPivot)
+                .derivative_eps(1.0e-10),
+        )
+        .unwrap();
+    let eigh_outputs = backend
+        .eigh_with_options(&a, EighOptions::default().derivative_eps(1.0e-10))
+        .unwrap();
+
+    assert_eq!(svd_outputs[0].shape(), &[2, 2]);
+    assert_eq!(svd_outputs[1].shape(), &[2]);
+    assert_eq!(svd_outputs[2].shape(), &[2, 2]);
+    assert_eq!(eigh_outputs[0].shape(), &[2]);
+    assert_eq!(eigh_outputs[1].shape(), &[2, 2]);
+}
+
+#[test]
+fn traced_decomposition_options_execute_through_registered_runtime() {
+    let a = TracedTensor::from_tensor_concrete_shape(
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]).unwrap(),
+    )
+    .unwrap();
+    let (u, s, vt) = a
+        .svd_with_options(
+            SvdOptions::default()
+                .gauge(SvdGauge::CanonicalPivot)
+                .derivative_eps(1.0e-10),
+        )
+        .unwrap();
+    let (eigh_values, eigh_vectors) = a
+        .eigh_with_options(EighOptions::default().derivative_eps(1.0e-10))
+        .unwrap();
+
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_many(&[&u, &s, &vt, &eigh_values, &eigh_vectors])
+        .unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    executor
+        .register_extension(tenferro_linalg::register_runtime)
+        .unwrap();
+    let outputs = executor.run_many(&program).unwrap();
+
+    assert_eq!(outputs[0].shape(), &[2, 2]);
+    assert_eq!(outputs[1].shape(), &[2]);
+    assert_eq!(outputs[2].shape(), &[2, 2]);
+    assert_eq!(outputs[3].shape(), &[2]);
+    assert_eq!(outputs[4].shape(), &[2, 2]);
 }
 
 #[test]

--- a/crates/tenferro-runtime/src/lib.rs
+++ b/crates/tenferro-runtime/src/lib.rs
@@ -67,6 +67,7 @@ pub use graph::{
     GraphInstructionView, GraphOpView, GraphProgram, GraphProgramInput,
     GraphProgramLoweringShapeError, GraphProgramLoweringView,
 };
+pub use shape_packing::TracedSliceBuilder;
 pub use sym_dim::SymDim;
 pub use tenferro_tensor::{
     CacheStats, CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,

--- a/crates/tenferro-runtime/src/shape_packing.rs
+++ b/crates/tenferro-runtime/src/shape_packing.rs
@@ -1,9 +1,10 @@
+use std::ops::Range;
 use std::sync::Arc;
 
 use computegraph::graph::GraphBuilder;
 use computegraph::types::{OperationRole, ValueRef};
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_tensor::{GatherConfig, Tensor, TypedTensor};
+use tenferro_tensor::{GatherConfig, SliceConfig, Tensor, TypedTensor};
 
 use crate::checkpoint::CheckpointNode;
 use crate::error::{Error, Result};
@@ -140,7 +141,261 @@ fn validate_stack_shapes(op: &'static str, shapes: &[&[usize]]) -> Result<()> {
     Ok(())
 }
 
+#[derive(Clone, Debug)]
+enum AxisSelection {
+    Slice {
+        axis: usize,
+        range: Range<usize>,
+        step: usize,
+    },
+    Take {
+        axis: usize,
+        indices: Vec<usize>,
+    },
+}
+
+fn concrete_shape_for_axis_slice(tensor: &TracedTensor, op: &'static str) -> Result<Vec<usize>> {
+    try_concrete_shape(tensor).ok_or_else(|| Error::InvalidGraphBuild {
+        op,
+        message: format!("{op} requires a concrete shape hint"),
+    })
+}
+
+fn validate_axis_selection(
+    op: &'static str,
+    rank: usize,
+    seen: &mut [bool],
+    axis: usize,
+) -> Result<()> {
+    if axis >= rank {
+        return Err(tenferro_tensor::Error::AxisOutOfBounds { op, axis, rank }.into());
+    }
+    if seen[axis] {
+        return Err(tenferro_tensor::Error::DuplicateAxis {
+            op,
+            axis,
+            role: "selection",
+        }
+        .into());
+    }
+    seen[axis] = true;
+    Ok(())
+}
+
+fn apply_slice_axis_config(
+    op: &'static str,
+    shape: &[usize],
+    selections: &[AxisSelection],
+) -> Result<Option<SliceConfig>> {
+    let mut starts = vec![0; shape.len()];
+    let mut limits = shape.to_vec();
+    let mut strides = vec![1; shape.len()];
+    let mut has_slice = false;
+    for selection in selections {
+        let AxisSelection::Slice { axis, range, step } = selection else {
+            continue;
+        };
+        if *step == 0 {
+            return Err(tenferro_tensor::Error::InvalidConfig {
+                op,
+                message: format!("axis {axis} has zero step"),
+            }
+            .into());
+        }
+        let extent = shape[*axis];
+        if range.start > range.end || range.end > extent {
+            return Err(tenferro_tensor::Error::InvalidConfig {
+                op,
+                message: format!(
+                    "axis {axis} range {}..{} is out of bounds for extent {extent}",
+                    range.start, range.end
+                ),
+            }
+            .into());
+        }
+        starts[*axis] = range.start;
+        limits[*axis] = range.end;
+        strides[*axis] = *step;
+        has_slice = true;
+    }
+    Ok(has_slice.then_some(SliceConfig {
+        starts,
+        limits,
+        strides,
+    }))
+}
+
+/// Rank-preserving traced tensor slicing builder.
+///
+/// Unspecified axes are kept whole. Range selections become one `Slice`
+/// operation; host-known position selections become `Gather`/`index_select`
+/// operations.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_runtime::TracedTensor;
+///
+/// let x = TracedTensor::from_vec_col_major(vec![3, 4], vec![0.0_f64; 12]).unwrap();
+/// let y = x.slice_builder().axis(0, 0..2).axis_step(1, 0..4, 2).apply().unwrap();
+/// assert_eq!(y.try_concrete_shape(), Some(vec![2, 2]));
+/// ```
+#[derive(Clone, Debug)]
+pub struct TracedSliceBuilder<'a> {
+    tensor: &'a TracedTensor,
+    selections: Vec<AxisSelection>,
+}
+
+impl<'a> TracedSliceBuilder<'a> {
+    fn new(tensor: &'a TracedTensor) -> Self {
+        Self {
+            tensor,
+            selections: Vec::new(),
+        }
+    }
+
+    /// Add an exclusive-end range selection for one axis.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::TracedTensor;
+    ///
+    /// let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    /// let y = x.slice_builder().axis(0, 1..3).apply().unwrap();
+    /// assert_eq!(y.try_concrete_shape(), Some(vec![2]));
+    /// ```
+    pub fn axis(mut self, axis: usize, range: Range<usize>) -> Self {
+        self.selections.push(AxisSelection::Slice {
+            axis,
+            range,
+            step: 1,
+        });
+        self
+    }
+
+    /// Add an exclusive-end strided range selection for one axis.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::TracedTensor;
+    ///
+    /// let x = TracedTensor::from_vec_col_major(vec![5], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0]).unwrap();
+    /// let y = x.slice_builder().axis_step(0, 0..5, 2).apply().unwrap();
+    /// assert_eq!(y.try_concrete_shape(), Some(vec![3]));
+    /// ```
+    pub fn axis_step(mut self, axis: usize, range: Range<usize>, step: usize) -> Self {
+        self.selections
+            .push(AxisSelection::Slice { axis, range, step });
+        self
+    }
+
+    /// Add a host-known position selection for one axis.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::TracedTensor;
+    ///
+    /// let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    /// let y = x.slice_builder().take_axis(0, &[2, 0]).apply().unwrap();
+    /// assert_eq!(y.try_concrete_shape(), Some(vec![2]));
+    /// ```
+    pub fn take_axis(mut self, axis: usize, indices: &[usize]) -> Self {
+        self.selections.push(AxisSelection::Take {
+            axis,
+            indices: indices.to_vec(),
+        });
+        self
+    }
+
+    /// Build and apply the requested slice/take operations.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::TracedTensor;
+    ///
+    /// let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    /// let y = x.slice_builder().axis(0, 1..4).apply().unwrap();
+    /// assert_eq!(y.try_concrete_shape(), Some(vec![3]));
+    /// ```
+    pub fn apply(self) -> Result<TracedTensor> {
+        let shape = concrete_shape_for_axis_slice(self.tensor, "slice_builder")?;
+        let mut seen = vec![false; shape.len()];
+        for selection in &self.selections {
+            let axis = match selection {
+                AxisSelection::Slice { axis, .. } | AxisSelection::Take { axis, .. } => *axis,
+            };
+            validate_axis_selection("slice_builder", shape.len(), &mut seen, axis)?;
+        }
+
+        let mut output = self.tensor.clone();
+        if let Some(config) = apply_slice_axis_config("slice_builder", &shape, &self.selections)? {
+            output = output.slice(config)?;
+        }
+        for selection in self.selections {
+            if let AxisSelection::Take { axis, indices } = selection {
+                output = output.take_axis(axis, &indices)?;
+            }
+        }
+        Ok(output)
+    }
+}
+
 impl TracedTensor {
+    /// Slice one axis with an exclusive-end range, keeping all other axes.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::TracedTensor;
+    ///
+    /// let x = TracedTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    /// let y = x.slice_axis(0, 1..3).unwrap();
+    /// assert_eq!(y.try_concrete_shape(), Some(vec![2]));
+    /// ```
+    pub fn slice_axis(&self, axis: usize, range: Range<usize>) -> Result<Self> {
+        self.slice_builder().axis(axis, range).apply()
+    }
+
+    /// Start a rank-preserving slicing builder for this tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::TracedTensor;
+    ///
+    /// let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    /// let y = x.slice_builder().axis(0, 0..2).apply().unwrap();
+    /// assert_eq!(y.try_concrete_shape(), Some(vec![2]));
+    /// ```
+    pub fn slice_builder(&self) -> TracedSliceBuilder<'_> {
+        TracedSliceBuilder::new(self)
+    }
+
+    /// Select entries from one axis using host-known indices.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::TracedTensor;
+    ///
+    /// let x = TracedTensor::from_vec_col_major(vec![3], vec![10.0_f64, 20.0, 30.0]).unwrap();
+    /// let y = x.take_axis(0, &[2, 0]).unwrap();
+    /// assert_eq!(y.try_concrete_shape(), Some(vec![2]));
+    /// ```
+    pub fn take_axis(&self, axis: usize, indices: &[usize]) -> Result<Self> {
+        let axis = isize::try_from(axis).map_err(|_| {
+            Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
+                op: "take_axis",
+                message: format!("axis {axis} cannot be represented as isize"),
+            })
+        })?;
+        self.index_select(axis, indices)
+    }
+
     /// Select entries from one axis using host-known positions.
     ///
     /// # Examples

--- a/crates/tenferro-runtime/tests/runtime_public_api.rs
+++ b/crates/tenferro-runtime/tests/runtime_public_api.rs
@@ -103,6 +103,51 @@ fn traced_tensor_methods_cover_structural_surface() {
         .unwrap();
     assert_eq!(run(&sliced).as_slice::<f64>().unwrap(), &[2.0, 3.0]);
 
+    let matrix_3x4 = TracedTensor::from_vec_col_major(
+        vec![3, 4],
+        vec![
+            1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+        ],
+    )
+    .unwrap();
+    let row_slice = matrix_3x4.slice_axis(0, 1..3).unwrap();
+    assert_eq!(row_slice.try_concrete_shape(), Some(vec![2, 4]));
+    assert_eq!(
+        run(&row_slice).as_slice::<f64>().unwrap(),
+        &[2.0, 3.0, 5.0, 6.0, 8.0, 9.0, 11.0, 12.0]
+    );
+
+    let builder_slice = matrix_3x4
+        .slice_builder()
+        .axis(0, 1..3)
+        .axis_step(1, 0..4, 2)
+        .apply()
+        .unwrap();
+    assert_eq!(builder_slice.try_concrete_shape(), Some(vec![2, 2]));
+    assert_eq!(
+        run(&builder_slice).as_slice::<f64>().unwrap(),
+        &[2.0, 3.0, 8.0, 9.0]
+    );
+
+    let selected = matrix_3x4.take_axis(1, &[3, 1, 3]).unwrap();
+    assert_eq!(selected.try_concrete_shape(), Some(vec![3, 3]));
+    assert_eq!(
+        run(&selected).as_slice::<f64>().unwrap(),
+        &[10.0, 11.0, 12.0, 4.0, 5.0, 6.0, 10.0, 11.0, 12.0]
+    );
+
+    let mixed = matrix_3x4
+        .slice_builder()
+        .axis(0, 0..2)
+        .take_axis(1, &[3, 1, 3])
+        .apply()
+        .unwrap();
+    assert_eq!(mixed.try_concrete_shape(), Some(vec![2, 3]));
+    assert_eq!(
+        run(&mixed).as_slice::<f64>().unwrap(),
+        &[10.0, 11.0, 4.0, 5.0, 10.0, 11.0]
+    );
+
     let padded = sliced
         .pad(PadConfig {
             edge_padding_low: vec![1],

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -61,9 +61,9 @@ CUDA is a backend/device choice for supported `Tensor`, `EagerTensor`, and
 | Dense solve | `solve` | `solve` | `solve` |
 | Triangular solve | `triangular_solve` | `triangular_solve` | `triangular_solve` |
 | Cholesky | `cholesky` | `cholesky` | `cholesky` |
-| SVD | `svd` | `svd` | `svd` |
+| SVD | `svd`, `svd_with_options` | `svd`, `svd_with_options` | `svd`, `svd_with_options` |
 | QR | `qr` | `qr` | `qr` |
-| Hermitian eigen | `eigh` | `eigh` | `eigh`, `eigvalsh` |
+| Hermitian eigen | `eigh`, `eigh_with_options` | `eigh`, `eigh_with_options` | `eigh`, `eigh_with_options`, `eigvalsh` |
 | General eigen | `eig` | `eig` | `eig`, `eigvals` |
 | LU | `lu` | `lu` | `lu` |
 | Complete-pivot LU | `full_piv_lu`, `full_piv_lu_solve` | `full_piv_lu`, `full_piv_lu_solve` | `full_piv_lu`, `full_piv_lu_solve` |
@@ -176,6 +176,67 @@ let us = u.matmul(&sigma, &mut backend).unwrap();
 let reconstructed = us.matmul(vt, &mut backend).unwrap();
 
 assert!(max_abs_diff(&reconstructed, &a) < 1.0e-12);
+```
+
+## Decomposition Options And SVD Truncation
+
+Eager and traced SVD expose options when you need a deterministic singular-vector
+gauge or a non-default derivative regularization epsilon. `derivative_eps`
+regularizes AD formulas for repeated or nearly repeated singular values or
+eigenvalues. It is not a backend solver tolerance and does not change the
+forward decomposition algorithm.
+
+```rust
+use tenferro_linalg::{SvdGauge, SvdOptions, TracedTensorLinalgExt};
+use tenferro_runtime::TracedTensor;
+
+let a = TracedTensor::from_vec_col_major(
+    vec![3, 3],
+    vec![
+        3.0_f64, 0.0, 0.0,
+        0.0, 2.0, 0.0,
+        0.0, 0.0, 1.0,
+    ],
+)
+.unwrap();
+let (u, s, vt) = a
+    .svd_with_options(
+        SvdOptions::default()
+            .gauge(SvdGauge::CanonicalPivot)
+            .derivative_eps(1.0e-10),
+    )
+    .unwrap();
+
+let rank = 2;
+let u_rank2 = u.slice_axis(1, 0..rank).unwrap();
+let s_rank2 = s.slice_axis(0, 0..rank).unwrap();
+let vt_rank2 = vt.slice_axis(0, 0..rank).unwrap();
+
+assert_eq!(u_rank2.concrete_shape().unwrap(), vec![3, 2]);
+assert_eq!(s_rank2.concrete_shape().unwrap(), vec![2]);
+assert_eq!(vt_rank2.concrete_shape().unwrap(), vec![2, 3]);
+```
+
+Use `slice_axis` for rank-preserving contiguous ranges and `take_axis` when the
+selected axis needs repeated or reordered indices:
+
+```rust
+use tenferro_linalg::TracedTensorLinalgExt;
+use tenferro_runtime::TracedTensor;
+
+let a = TracedTensor::from_vec_col_major(
+    vec![3, 3],
+    vec![
+        3.0_f64, 0.0, 0.0,
+        0.0, 2.0, 0.0,
+        0.0, 0.0, 1.0,
+    ],
+)
+.unwrap();
+let (_u, s, _vt) = a.svd().unwrap();
+let repeated = s.take_axis(0, &[0, 1, 0]).unwrap();
+
+assert_eq!(repeated.concrete_shape().unwrap(), vec![3]);
 ```
 
 ## QR decomposition

--- a/docs/tutorial-code/src/bin/dynamic_shape_truncated_svd.rs
+++ b/docs/tutorial-code/src/bin/dynamic_shape_truncated_svd.rs
@@ -1,6 +1,6 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::GraphCompilerEinsumExt;
-use tenferro_linalg::TracedTensorLinalgExt;
+use tenferro_linalg::{SvdOptions, TracedTensorLinalgExt};
 use tenferro_runtime::{
     CompareDir, DType, GraphCompiler, GraphExecutor, GraphProgram, Tensor, TracedTensor,
 };
@@ -60,7 +60,7 @@ fn run_case(
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let x = TracedTensor::input_concrete_shape(DType::F64, &[4, 4])?;
-    let (u, s, vt) = x.svd_with_eps(1.0e-12)?;
+    let (u, s, vt) = x.svd_with_options(SvdOptions::default().derivative_eps(1.0e-12))?;
 
     let threshold = TracedTensor::from_vec_col_major(vec![], vec![0.5_f64])?;
     let keep_count = s

--- a/docs/tutorials/dynamic-shape-truncated-svd.md
+++ b/docs/tutorials/dynamic-shape-truncated-svd.md
@@ -13,7 +13,7 @@ once with three. No re-trace or recompile is needed between the two executions.
 ```rust
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::GraphCompilerEinsumExt;
-use tenferro_linalg::TracedTensorLinalgExt;
+use tenferro_linalg::{SvdOptions, TracedTensorLinalgExt};
 use tenferro_runtime::{
     CompareDir, DType, GraphCompiler, GraphExecutor, GraphProgram, Tensor, TracedTensor,
 };
@@ -73,7 +73,7 @@ fn run_case(
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let x = TracedTensor::input_concrete_shape(DType::F64, &[4, 4])?;
-    let (u, s, vt) = x.svd_with_eps(1.0e-12)?;
+    let (u, s, vt) = x.svd_with_options(SvdOptions::default().derivative_eps(1.0e-12))?;
 
     let threshold = TracedTensor::from_vec_col_major(vec![], vec![0.5_f64])?;
     let keep_count = s

--- a/docs/worklogs/2026-07-09-issues-1335-1337-linalg-ad-api.md
+++ b/docs/worklogs/2026-07-09-issues-1335-1337-linalg-ad-api.md
@@ -1,0 +1,76 @@
+# Issues 1335-1337 Linalg AD API
+
+## Summary
+
+This work log records the single-PR implementation for GitHub issues #1335,
+#1336, and #1337. The changes clarify linalg AD support routes, make traced
+VJP prefer registered custom primal VJP rules, add rank-preserving axis slicing
+builders, and replace decomposition epsilon helper methods with options-based
+SVD/Eigh APIs.
+
+## Context Read
+
+- `AGENTS.md`
+- `REPOSITORY_RULES.md`
+- Shared tensor4all rules: common docs/tests, Rust performance, Rust numerical
+- GitHub issues #1335, #1336, #1337
+- Existing linalg AD manifest, traced/eager linalg APIs, runtime/eager shape
+  packing helpers, and linalg extension op pruning
+
+## Classification Ledger
+
+| Issue/finding | Classification | Resolution |
+| --- | --- | --- |
+| #1335 AD support manifest routes | API clarification / behavior fix | Added user-visible JVP/VJP mode support with explicit implementation routes. Linalg SVD/Eigh remain supported via `linearize -> linear_transpose`; solve-like paths are marked as `LinearizeThenCustomLinearTranspose`. |
+| #1335 custom VJP precedence | AD dispatch fix | Traced VJP now attempts registered custom primal VJP rules before canonical linearize-transpose. It falls back only on `Unsupported`; malformed/internal rule errors are surfaced directly. |
+| #1336 axis slicing builder | Public API addition | Added traced and eager `slice_axis`, `slice_builder`, and builder range/step/take operations. Added traced `take_axis` as a `usize` wrapper over `index_select`. |
+| #1336 SVD truncation examples | Documentation | Documented fixed-rank truncation as `svd()` plus `slice_axis`/`take_axis`; dynamic-shape tutorial remains based on `dynamic_truncate`. |
+| #1337 decomposition options | Public API replacement | Added `SvdOptions`, `SvdGauge`, `EighOptions`, and `DEFAULT_DECOMPOSITION_DERIVATIVE_EPS`. Removed `svd_with_eps`/`eigh_with_eps` from the traced API in favor of `*_with_options`. |
+| #1337 SVD canonical gauge | Numerical API option | `SvdGauge::CanonicalPivot` makes each U column's max-absolute pivot positive-real and applies the inverse sign/phase to the matching VT row, preserving reconstruction. |
+
+## Design Notes
+
+- `derivative_eps` is API-level AD regularization for repeated or nearly
+  repeated spectral values. It is validated as positive and finite, but it is
+  not a backend solver tolerance.
+- Full SVD pruning to `SvdVals` deliberately drops SVD vector gauge options,
+  because values-only execution should not retain vector policy.
+- Concrete `LinalgBackend` gained default `svd_with_options` and
+  `eigh_with_options` methods so options are available across concrete, eager,
+  and traced surfaces.
+- Canonical SVD gauge mutates only compact host outputs from the backend. It
+  does not introduce implicit GPU-to-CPU transfers.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo fmt --all --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `RUSTFLAGS='-C link-arg=-fuse-ld=bfd' cargo test --workspace --release`
+- `cargo test -p tenferro-linalg --features autodiff --lib --tests`
+- `cargo test -p tenferro-linalg --features autodiff ad::support::tests`
+- `cargo test -p tenferro-ad --test extension_op traced_vjp_`
+- `cargo test -p tenferro-runtime --test runtime_public_api traced_tensor_methods_cover_structural_surface`
+- `cargo test -p tenferro-ad --test eager_tensor eager_slice_axis_and_builder_preserve_column_major_values`
+- `RUSTFLAGS='-C link-arg=-fuse-ld=bfd' cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
+- `RUSTFLAGS='-C link-arg=-fuse-ld=bfd' cargo test -p tenferro-linalg --features autodiff --doc --jobs 1`
+
+The first coverage check showed `crates/tenferro-linalg/src/ad/support.rs`
+below its per-file threshold because private const helper functions used to
+build the manifest were not executed at runtime. Module-local tests now call
+those helpers directly; the rerun passed all 149 checked files.
+
+## Residual Risks
+
+- Plain `cargo test -p tenferro-linalg --features autodiff --doc --jobs 1`
+  failed locally in `rust-lld` with Bus error before the bfd retry. The bfd
+  retry passed all linalg doctests, so this is treated as a local linker
+  environment issue rather than a doctest/API failure.
+- `SvdGauge::CanonicalPivot` is a post-processing policy on full SVD outputs.
+  Values-only SVD and pruned graphs intentionally do not apply vector gauge
+  behavior.


### PR DESCRIPTION
## Summary
- Closes #1335 by making traced VJP prefer registered custom primal VJP rules, falling back only when the custom rule reports Unsupported, and by exposing explicit linalg AD manifest routes.
- Closes #1336 by adding eager/traced axis slicing builders plus traced take_axis, and documenting SVD truncation examples.
- Closes #1337 by adding SvdOptions/SvdGauge/EighOptions, derivative_eps documentation, and options-based SVD/Eigh APIs across concrete/eager/traced linalg surfaces.

## Work Log
- docs/worklogs/2026-07-09-issues-1335-1337-linalg-ad-api.md

## Verification
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings
- RUSTFLAGS='-C link-arg=-fuse-ld=bfd' cargo test --workspace --release
- cargo test -p tenferro-linalg --features autodiff --lib --tests
- cargo test -p tenferro-linalg --features autodiff ad::support::tests
- cargo test -p tenferro-ad --test extension_op traced_vjp_
- cargo test -p tenferro-runtime --test runtime_public_api traced_tensor_methods_cover_structural_surface
- cargo test -p tenferro-ad --test eager_tensor eager_slice_axis_and_builder_preserve_column_major_values
- RUSTFLAGS='-C link-arg=-fuse-ld=bfd' cargo llvm-cov --workspace --release --json --output-path coverage.json
- python3 scripts/check-coverage.py coverage.json
- cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py
- python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json
- RUSTFLAGS='-C link-arg=-fuse-ld=bfd' cargo test -p tenferro-linalg --features autodiff --doc --jobs 1

## Notes
- Plain linalg doctests with the default rust-lld failed locally with a Bus error; the same doctests passed with bfd. This is recorded as a local linker environment issue in the work log.