### PR TITLE
Add opt-in linalg gauge conventions

### DIFF
--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -125,8 +125,10 @@ impl ExtensionLinearizeRule for LinalgAdRule {
             LinalgOp::SvdVals { derivative_eps } => {
                 rules::linearize_svd_values(builder, primal_in, tangent_in, derivative_eps, ctx)
             }
-            LinalgOp::Qr => rules::linearize_qr(builder, primal_in, primal_out, tangent_in, ctx),
-            LinalgOp::Eigh { derivative_eps } => rules::linearize_eigh(
+            LinalgOp::Qr { .. } => {
+                rules::linearize_qr(builder, primal_in, primal_out, tangent_in, ctx)
+            }
+            LinalgOp::Eigh { derivative_eps, .. } => rules::linearize_eigh(
                 builder,
                 primal_in,
                 primal_out,
@@ -217,7 +219,7 @@ impl ExtensionLinearTransposeRule for LinalgAdRule {
             | LinalgOp::FullPivLu
             | LinalgOp::Svd { .. }
             | LinalgOp::SvdVals { .. }
-            | LinalgOp::Qr
+            | LinalgOp::Qr { .. }
             | LinalgOp::Eigh { .. }
             | LinalgOp::EighVals { .. }
             | LinalgOp::Eig { .. }
@@ -314,7 +316,7 @@ fn fixed_transpose_value(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::extension::{SvdGauge, DEFAULT_DECOMPOSITION_DERIVATIVE_EPS};
+    use crate::extension::{EighGauge, QrGauge, SvdGauge, DEFAULT_DECOMPOSITION_DERIVATIVE_EPS};
     use computegraph::graph::GraphBuilder;
     use std::collections::HashSet;
     use tenferro_ops::input_key::TensorInputKey;
@@ -553,6 +555,7 @@ mod tests {
             (
                 LinalgOp::Eigh {
                     derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
+                    gauge: EighGauge::Raw,
                 },
                 eigh_context(),
                 vec![None, None],
@@ -564,7 +567,13 @@ mod tests {
                 eig_context(),
                 vec![None, None],
             ),
-            (LinalgOp::Qr, qr_context(&[3, 2]), vec![None, None]),
+            (
+                LinalgOp::Qr {
+                    gauge: QrGauge::Raw,
+                },
+                qr_context(&[3, 2]),
+                vec![None, None],
+            ),
         ];
 
         for (kind, (ctx, a, outputs), expected) in cases {
@@ -632,6 +641,7 @@ mod tests {
         let tangent = builder.add_input(TensorInputKey::User { id: 134 });
         let op = LinalgExtensionOp::new(LinalgOp::Eigh {
             derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
+            gauge: EighGauge::Raw,
         });
 
         let result = LinalgAdRule
@@ -681,7 +691,9 @@ mod tests {
 
     #[test]
     fn qr_linearize_prunes_inactive_factor_outputs() {
-        let op = LinalgExtensionOp::new(LinalgOp::Qr);
+        let op = LinalgExtensionOp::new(LinalgOp::Qr {
+            gauge: QrGauge::Raw,
+        });
         for (case, active_slot, expected_active) in [
             ("q only", 0_usize, vec![true, false]),
             ("r only", 1_usize, vec![false, true]),
@@ -916,6 +928,7 @@ mod tests {
         let g_v = builder.add_input(TensorInputKey::User { id: 87 });
         let op = LinalgExtensionOp::new(LinalgOp::Eigh {
             derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
+            gauge: EighGauge::Raw,
         });
 
         let result = LinalgAdRule
@@ -945,7 +958,9 @@ mod tests {
 
         let result = LinalgAdRule
             .linear_transpose(
-                &LinalgExtensionOp::new(LinalgOp::Qr),
+                &LinalgExtensionOp::new(LinalgOp::Qr {
+                    gauge: QrGauge::Raw,
+                }),
                 &mut builder,
                 &[Some(g_q), Some(g_r)],
                 &[PrimitiveTransposeInput::Residual(a)],
@@ -1031,9 +1046,12 @@ mod tests {
             LinalgOp::SvdVals {
                 derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
             },
-            LinalgOp::Qr,
+            LinalgOp::Qr {
+                gauge: QrGauge::Raw,
+            },
             LinalgOp::Eigh {
                 derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
+                gauge: EighGauge::Raw,
             },
             LinalgOp::EighVals {
                 derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,

--- a/crates/tenferro-linalg/src/ad/rules/mod.rs
+++ b/crates/tenferro-linalg/src/ad/rules/mod.rs
@@ -22,7 +22,7 @@ use tenferro_ops::ad::PrimitiveRuleBuilder;
 
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
 
-use crate::extension::{LinalgExtensionOp, LinalgOp, SvdGauge};
+use crate::extension::{EighGauge, LinalgExtensionOp, LinalgOp, SvdGauge};
 use tenferro_ops::ad::context::{resolve_and_guard, ShapeGuardContext};
 pub(crate) use tenferro_ops::ad::support::{
     conjugate_linear_if_dtype_complex, conjugate_primal_if_dtype_complex,
@@ -764,6 +764,7 @@ pub(crate) fn linearize_eigh_values(
     let eigh_outputs = builder.add_operation(
         linalg_std_op(LinalgOp::Eigh {
             derivative_eps: eps,
+            gauge: EighGauge::Raw,
         }),
         vec![ValueRef::External(primal_in[0].clone())],
         OperationRole::Primary,

--- a/crates/tenferro-linalg/src/ad/support.rs
+++ b/crates/tenferro-linalg/src/ad/support.rs
@@ -137,7 +137,7 @@ impl LinalgAdOpKind {
             LinalgOp::FullPivLuSolve { .. } => Self::FullPivLuSolve,
             LinalgOp::Svd { .. } => Self::Svd,
             LinalgOp::SvdVals { .. } => Self::SvdVals,
-            LinalgOp::Qr => Self::Qr,
+            LinalgOp::Qr { .. } => Self::Qr,
             LinalgOp::Eigh { .. } => Self::Eigh,
             LinalgOp::EighVals { .. } => Self::EighVals,
             LinalgOp::Eig { .. } => Self::Eig,

--- a/crates/tenferro-linalg/src/ad/support/tests.rs
+++ b/crates/tenferro-linalg/src/ad/support/tests.rs
@@ -1,6 +1,6 @@
 use tenferro_tensor::DType;
 
-use crate::extension::{SvdGauge, DEFAULT_DECOMPOSITION_DERIVATIVE_EPS};
+use crate::extension::{EighGauge, QrGauge, SvdGauge, DEFAULT_DECOMPOSITION_DERIVATIVE_EPS};
 
 use super::*;
 
@@ -35,10 +35,16 @@ fn manifest_internal_mapping_covers_linalg_op_variants() {
             },
             LinalgAdOpKind::SvdVals,
         ),
-        (LinalgOp::Qr, LinalgAdOpKind::Qr),
+        (
+            LinalgOp::Qr {
+                gauge: QrGauge::Raw,
+            },
+            LinalgAdOpKind::Qr,
+        ),
         (
             LinalgOp::Eigh {
                 derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
+                gauge: EighGauge::Raw,
             },
             LinalgAdOpKind::Eigh,
         ),

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -1,6 +1,9 @@
 use tenferro_tensor::{Tensor, TensorBackend, TensorView};
 
-use crate::extension::{apply_svd_gauge, validate_derivative_eps, EighOptions, SvdOptions};
+use crate::extension::{
+    apply_eigh_gauge, apply_qr_gauge, apply_svd_gauge, validate_derivative_eps, EighOptions,
+    QrOptions, SvdOptions,
+};
 
 /// Build the shared "unsupported dtype" backend-failure error used by the
 /// linalg backends.
@@ -158,6 +161,36 @@ pub trait LinalgBackend: TensorBackend {
     /// `R` has shape `min(m, n) x n`.
     fn qr(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
 
+    /// Compute public QR outputs `(Q, R)` with explicit options.
+    ///
+    /// `gauge` controls optional sign or phase post-processing.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{LinalgBackend, QrGauge, QrOptions};
+    /// use tenferro_tensor::Tensor;
+    ///
+    /// let input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
+    /// let mut backend = CpuBackend::new();
+    /// let outputs = backend.qr_with_options(
+    ///     &input,
+    ///     QrOptions::default().gauge(QrGauge::PositiveDiagonal),
+    /// )?;
+    /// assert_eq!(outputs[0].shape(), &[2, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn qr_with_options(
+        &mut self,
+        input: &Tensor,
+        options: QrOptions,
+    ) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let mut outputs = self.qr(input)?;
+        apply_qr_gauge(options.gauge, &mut outputs)?;
+        Ok(outputs)
+    }
+
     /// Compute public QR outputs `(Q, R)` from a borrowed tensor view.
     ///
     /// Backends may canonicalize the view inside the same placement family, but
@@ -196,20 +229,23 @@ pub trait LinalgBackend: TensorBackend {
     /// Compute public Hermitian eigendecomposition outputs with explicit options.
     ///
     /// `derivative_eps` is validated for API consistency, but concrete backend
-    /// execution does not perform AD.
+    /// execution does not perform AD. `gauge` controls optional eigenvector
+    /// post-processing.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use tenferro_cpu::CpuBackend;
-    /// use tenferro_linalg::{EighOptions, LinalgBackend};
+    /// use tenferro_linalg::{EighGauge, EighOptions, LinalgBackend};
     /// use tenferro_tensor::Tensor;
     ///
     /// let input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0])?;
     /// let mut backend = CpuBackend::new();
     /// let outputs = backend.eigh_with_options(
     ///     &input,
-    ///     EighOptions::default().derivative_eps(1.0e-10),
+    ///     EighOptions::default()
+    ///         .gauge(EighGauge::CanonicalPivot)
+    ///         .derivative_eps(1.0e-10),
     /// )?;
     /// assert_eq!(outputs[0].shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
@@ -220,7 +256,9 @@ pub trait LinalgBackend: TensorBackend {
         options: EighOptions,
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
         validate_derivative_eps("eigh_with_options", options.derivative_eps)?;
-        self.eigh(input)
+        let mut outputs = self.eigh(input)?;
+        apply_eigh_gauge(options.gauge, &mut outputs)?;
+        Ok(outputs)
     }
 
     /// Compute public Hermitian eigendecomposition outputs from a borrowed tensor view.

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -5,7 +5,7 @@ use tenferro_ad::extension::apply_eager;
 use tenferro_ad::EagerTensor;
 
 use crate::extension::{
-    validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, SvdOptions,
+    validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, QrOptions, SvdOptions,
 };
 use crate::register_runtime;
 
@@ -17,6 +17,7 @@ pub trait EagerTensorLinalgExt {
         options: SvdOptions,
     ) -> Result<(EagerTensor, EagerTensor, EagerTensor)>;
     fn qr(&self) -> Result<(EagerTensor, EagerTensor)>;
+    fn qr_with_options(&self, options: QrOptions) -> Result<(EagerTensor, EagerTensor)>;
     fn lu(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor, EagerTensor)>;
     fn full_piv_lu(
         &self,
@@ -57,6 +58,10 @@ impl EagerTensorLinalgExt for EagerTensor {
 
     fn qr(&self) -> Result<(EagerTensor, EagerTensor)> {
         qr(self)
+    }
+
+    fn qr_with_options(&self, options: QrOptions) -> Result<(EagerTensor, EagerTensor)> {
+        qr_with_options(self, options)
     }
 
     fn lu(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor, EagerTensor)> {
@@ -210,7 +215,39 @@ pub fn svd_with_options(
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
 pub fn qr(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
-    two_outputs(apply_linalg_eager(LinalgOp::Qr, &[a])?, "qr")
+    qr_with_options(a, QrOptions::default())
+}
+
+/// QR decomposition for eager tensors with explicit options.
+///
+/// `gauge` controls optional sign or phase post-processing.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+/// use tenferro_linalg::{EagerTensorLinalgExt, QrGauge, QrOptions};
+///
+/// let ctx = EagerRuntime::new();
+/// let a = EagerTensor::from_tensor_in(
+///     Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap(),
+///     ctx,
+/// ).unwrap();
+/// let (q, r) = a.qr_with_options(QrOptions::default().gauge(QrGauge::PositiveDiagonal))?;
+/// assert_eq!(q.shape(), &[2, 2]);
+/// assert_eq!(r.shape(), &[2, 2]);
+/// # Ok::<(), tenferro_ad::Error>(())
+/// ```
+pub fn qr_with_options(a: &EagerTensor, options: QrOptions) -> Result<(EagerTensor, EagerTensor)> {
+    two_outputs(
+        apply_linalg_eager(
+            LinalgOp::Qr {
+                gauge: options.gauge,
+            },
+            &[a],
+        )?,
+        "qr",
+    )
 }
 
 /// LU factorization for eager tensors.
@@ -425,7 +462,7 @@ pub fn eigh(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
 ///
 /// ```rust
 /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
-/// use tenferro_linalg::{EagerTensorLinalgExt, EighOptions};
+/// use tenferro_linalg::{EagerTensorLinalgExt, EighGauge, EighOptions};
 ///
 /// let ctx = EagerRuntime::new();
 /// let a = EagerTensor::from_tensor_in(
@@ -433,7 +470,11 @@ pub fn eigh(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
 ///     ctx,
 /// ).unwrap();
 /// let (values, vectors) = a
-///     .eigh_with_options(EighOptions::default().derivative_eps(1.0e-10))?;
+///     .eigh_with_options(
+///         EighOptions::default()
+///             .gauge(EighGauge::CanonicalPivot)
+///             .derivative_eps(1.0e-10),
+///     )?;
 /// assert_eq!(values.shape(), &[2]);
 /// assert_eq!(vectors.shape(), &[2, 2]);
 /// # Ok::<(), tenferro_ad::Error>(())
@@ -447,6 +488,7 @@ pub fn eigh_with_options(
         apply_linalg_eager(
             LinalgOp::Eigh {
                 derivative_eps: options.derivative_eps,
+                gauge: options.gauge,
             },
             &[a],
         )?,

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -12,8 +12,11 @@ use tenferro_tensor::{
 
 use crate::backend::LinalgBackend;
 
+mod gauge;
 #[cfg(all(test, not(feature = "cuda")))]
 mod tests;
+
+pub(crate) use gauge::{apply_eigh_gauge, apply_qr_gauge};
 
 pub const LINALG_EXTENSION_FAMILY_ID: &str = "tenferro-linalg.linalg.v1";
 
@@ -49,6 +52,42 @@ pub enum SvdGauge {
     /// Make each left singular vector's max-absolute pivot entry positive-real
     /// and adjust the matching `VT` row so reconstruction is preserved.
     CanonicalPivot,
+}
+
+/// Eigenvector gauge convention used by [`EighOptions`].
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::{EighGauge, EighOptions};
+///
+/// let options = EighOptions::default().gauge(EighGauge::CanonicalPivot);
+/// assert_eq!(options.gauge, EighGauge::CanonicalPivot);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EighGauge {
+    /// Leave the backend's raw eigenvector signs or phases unchanged.
+    Raw,
+    /// Make each eigenvector's max-absolute pivot entry positive-real.
+    CanonicalPivot,
+}
+
+/// QR factor gauge convention used by [`QrOptions`].
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::{QrGauge, QrOptions};
+///
+/// let options = QrOptions::default().gauge(QrGauge::PositiveDiagonal);
+/// assert_eq!(options.gauge, QrGauge::PositiveDiagonal);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QrGauge {
+    /// Leave the backend's raw QR signs or phases unchanged.
+    Raw,
+    /// Make each `R` diagonal entry positive-real, compensating `Q`.
+    PositiveDiagonal,
 }
 
 /// Options for singular value decomposition.
@@ -125,6 +164,8 @@ impl SvdOptions {
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct EighOptions {
+    /// Eigenvector gauge convention.
+    pub gauge: EighGauge,
     /// AD derivative regularization for repeated or nearly repeated eigenvalues.
     pub derivative_eps: f64,
 }
@@ -132,12 +173,28 @@ pub struct EighOptions {
 impl Default for EighOptions {
     fn default() -> Self {
         Self {
+            gauge: EighGauge::Raw,
             derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
         }
     }
 }
 
 impl EighOptions {
+    /// Return options with the requested eigenvector gauge.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::{EighGauge, EighOptions};
+    ///
+    /// let options = EighOptions::default().gauge(EighGauge::CanonicalPivot);
+    /// assert_eq!(options.gauge, EighGauge::CanonicalPivot);
+    /// ```
+    pub fn gauge(mut self, gauge: EighGauge) -> Self {
+        self.gauge = gauge;
+        self
+    }
+
     /// Return options with an explicit derivative epsilon.
     ///
     /// # Examples
@@ -150,6 +207,47 @@ impl EighOptions {
     /// ```
     pub fn derivative_eps(mut self, derivative_eps: f64) -> Self {
         self.derivative_eps = derivative_eps;
+        self
+    }
+}
+
+/// Options for QR decomposition.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::{QrGauge, QrOptions};
+///
+/// let options = QrOptions::default().gauge(QrGauge::PositiveDiagonal);
+/// assert_eq!(options.gauge, QrGauge::PositiveDiagonal);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct QrOptions {
+    /// QR sign or phase convention.
+    pub gauge: QrGauge,
+}
+
+impl Default for QrOptions {
+    fn default() -> Self {
+        Self {
+            gauge: QrGauge::Raw,
+        }
+    }
+}
+
+impl QrOptions {
+    /// Return options with the requested QR gauge.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::{QrGauge, QrOptions};
+    ///
+    /// let options = QrOptions::default().gauge(QrGauge::PositiveDiagonal);
+    /// assert_eq!(options.gauge, QrGauge::PositiveDiagonal);
+    /// ```
+    pub fn gauge(mut self, gauge: QrGauge) -> Self {
+        self.gauge = gauge;
         self
     }
 }
@@ -189,9 +287,12 @@ pub(crate) enum LinalgOp {
     SvdVals {
         derivative_eps: f64,
     },
-    Qr,
+    Qr {
+        gauge: QrGauge,
+    },
     Eigh {
         derivative_eps: f64,
+        gauge: EighGauge,
     },
     EighVals {
         derivative_eps: f64,
@@ -221,7 +322,7 @@ impl LinalgOp {
             | Self::SvdVals { .. }
             | Self::TriangularSolve { .. } => 1,
             Self::Svd { .. } => 3,
-            Self::Qr | Self::Eigh { .. } | Self::Eig { .. } => 2,
+            Self::Qr { .. } | Self::Eigh { .. } | Self::Eig { .. } => 2,
             Self::LuFactor => 3,
             Self::Lu => 4,
             Self::FullPivLu => 5,
@@ -243,7 +344,7 @@ impl LinalgOp {
             Self::FullPivLu => 2,
             Self::FullPivLuSolve { .. } => 3,
             Self::Svd { .. } => 4,
-            Self::Qr => 5,
+            Self::Qr { .. } => 5,
             Self::Eigh { .. } => 6,
             Self::Eig { .. } => 7,
             Self::TriangularSolve { .. } => 9,
@@ -364,10 +465,18 @@ impl ExtensionOp for LinalgExtensionOp {
                 hasher.write_u64(derivative_eps.to_bits());
                 hash_svd_gauge(hasher, gauge);
             }
-            LinalgOp::SvdVals { derivative_eps }
-            | LinalgOp::Eigh { derivative_eps }
-            | LinalgOp::EighVals { derivative_eps } => {
+            LinalgOp::SvdVals { derivative_eps } | LinalgOp::EighVals { derivative_eps } => {
                 hasher.write_u64(derivative_eps.to_bits());
+            }
+            LinalgOp::Qr { gauge } => {
+                hash_qr_gauge(hasher, gauge);
+            }
+            LinalgOp::Eigh {
+                derivative_eps,
+                gauge,
+            } => {
+                hasher.write_u64(derivative_eps.to_bits());
+                hash_eigh_gauge(hasher, gauge);
             }
             LinalgOp::Eig { input_dtype } | LinalgOp::EigVals { input_dtype } => {
                 hash_dtype(hasher, input_dtype);
@@ -393,11 +502,7 @@ impl ExtensionOp for LinalgExtensionOp {
                 hasher.write_u8(u8::from(transpose_a));
                 hasher.write_u8(u8::from(unit_diagonal));
             }
-            LinalgOp::Cholesky
-            | LinalgOp::Lu
-            | LinalgOp::LuFactor
-            | LinalgOp::FullPivLu
-            | LinalgOp::Qr => {}
+            LinalgOp::Cholesky | LinalgOp::Lu | LinalgOp::LuFactor | LinalgOp::FullPivLu => {}
         }
     }
 
@@ -429,7 +534,7 @@ impl ExtensionOp for LinalgExtensionOp {
             LinalgOp::Svd { derivative_eps, .. } if live_outputs == [false, true, false] => {
                 Some(Arc::new(Self::new(LinalgOp::SvdVals { derivative_eps })))
             }
-            LinalgOp::Eigh { derivative_eps } if live_outputs == [true, false] => {
+            LinalgOp::Eigh { derivative_eps, .. } if live_outputs == [true, false] => {
                 Some(Arc::new(Self::new(LinalgOp::EighVals { derivative_eps })))
             }
             LinalgOp::Eig { input_dtype } if live_outputs == [true, false] => {
@@ -485,7 +590,7 @@ impl ExtensionOp for LinalgExtensionOp {
             LinalgOp::SvdVals { .. } => {
                 vec![svd_values_meta(input_dtypes[0], input_shapes[0])?]
             }
-            LinalgOp::Qr => qr_meta(input_dtypes[0], input_shapes[0])?,
+            LinalgOp::Qr { .. } => qr_meta(input_dtypes[0], input_shapes[0])?,
             LinalgOp::Eigh { .. } => eigh_meta(input_dtypes[0], input_shapes[0])?,
             LinalgOp::EighVals { .. } => vec![eigh_values_meta(input_dtypes[0], input_shapes[0])?],
             LinalgOp::Eig { input_dtype } => eig_meta(input_dtype, input_shapes[0])?,
@@ -597,10 +702,17 @@ fn execute_linalg<B: LinalgBackend>(
             },
         ),
         LinalgOp::SvdVals { .. } => Ok(vec![backend.svd_values(inputs[0])?]),
-        LinalgOp::Qr => backend.qr(inputs[0]),
-        LinalgOp::Eigh { derivative_eps } => {
-            backend.eigh_with_options(inputs[0], EighOptions { derivative_eps })
-        }
+        LinalgOp::Qr { gauge } => backend.qr_with_options(inputs[0], QrOptions { gauge }),
+        LinalgOp::Eigh {
+            derivative_eps,
+            gauge,
+        } => backend.eigh_with_options(
+            inputs[0],
+            EighOptions {
+                derivative_eps,
+                gauge,
+            },
+        ),
         LinalgOp::EighVals { .. } => Ok(vec![backend.eigh_values(inputs[0])?]),
         LinalgOp::Eig { .. } => backend.eig(inputs[0]),
         LinalgOp::EigVals { .. } => Ok(vec![backend.eig_values(inputs[0])?]),
@@ -1067,6 +1179,22 @@ fn hash_svd_gauge(hasher: &mut dyn Hasher, gauge: SvdGauge) {
     let tag = match gauge {
         SvdGauge::Raw => 0,
         SvdGauge::CanonicalPivot => 1,
+    };
+    hasher.write_u8(tag);
+}
+
+fn hash_eigh_gauge(hasher: &mut dyn Hasher, gauge: EighGauge) {
+    let tag = match gauge {
+        EighGauge::Raw => 0,
+        EighGauge::CanonicalPivot => 1,
+    };
+    hasher.write_u8(tag);
+}
+
+fn hash_qr_gauge(hasher: &mut dyn Hasher, gauge: QrGauge) {
+    let tag = match gauge {
+        QrGauge::Raw => 0,
+        QrGauge::PositiveDiagonal => 1,
     };
     hasher.write_u8(tag);
 }

--- a/crates/tenferro-linalg/src/extension/gauge.rs
+++ b/crates/tenferro-linalg/src/extension/gauge.rs
@@ -1,0 +1,481 @@
+use num_complex::{Complex32, Complex64};
+use tenferro_tensor::{Error, Tensor};
+
+use super::{EighGauge, QrGauge};
+
+pub(crate) fn apply_eigh_gauge(
+    gauge: EighGauge,
+    outputs: &mut [Tensor],
+) -> tenferro_tensor::Result<()> {
+    match gauge {
+        EighGauge::Raw => Ok(()),
+        EighGauge::CanonicalPivot => apply_canonical_pivot_eigh_gauge(outputs),
+    }
+}
+
+pub(crate) fn apply_qr_gauge(
+    gauge: QrGauge,
+    outputs: &mut [Tensor],
+) -> tenferro_tensor::Result<()> {
+    match gauge {
+        QrGauge::Raw => Ok(()),
+        QrGauge::PositiveDiagonal => apply_positive_diagonal_qr_gauge(outputs),
+    }
+}
+
+fn apply_canonical_pivot_eigh_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::Result<()> {
+    if outputs.len() != 2 {
+        return Err(Error::InvalidConfig {
+            op: "tenferro-linalg.eigh",
+            message: format!(
+                "canonical eigh gauge expected two outputs, got {}",
+                outputs.len()
+            ),
+        });
+    }
+
+    let (values_slice, vectors_slice) = outputs.split_at_mut(1);
+    let values_shape = values_slice[0].shape().to_vec();
+    let vectors = &mut vectors_slice[0];
+    let vectors_shape = vectors.shape().to_vec();
+    if values_shape.is_empty() || vectors_shape.len() < 2 {
+        return Err(Error::InvalidConfig {
+            op: "tenferro-linalg.eigh",
+            message: format!(
+                "canonical eigh gauge expected values rank >= 1 and vectors rank >= 2; got values={values_shape:?}, vectors={vectors_shape:?}"
+            ),
+        });
+    }
+
+    let n = vectors_shape[0];
+    if vectors_shape[1] != n || values_shape[0] != n || values_shape[1..] != vectors_shape[2..] {
+        return Err(Error::InvalidConfig {
+            op: "tenferro-linalg.eigh",
+            message: format!(
+                "canonical eigh gauge expected compatible eigendecomposition shapes, got values={values_shape:?}, vectors={vectors_shape:?}"
+            ),
+        });
+    }
+    let batch_count = checked_batch_count("tenferro-linalg.eigh", &vectors_shape[2..])?;
+
+    match vectors {
+        Tensor::F64(vectors) => canonicalize_eigh_gauge_f64(
+            vectors.host_data_mut()?,
+            n,
+            batch_count,
+            "tenferro-linalg.eigh",
+        ),
+        Tensor::F32(vectors) => canonicalize_eigh_gauge_f32(
+            vectors.host_data_mut()?,
+            n,
+            batch_count,
+            "tenferro-linalg.eigh",
+        ),
+        Tensor::C64(vectors) => canonicalize_eigh_gauge_c64(
+            vectors.host_data_mut()?,
+            n,
+            batch_count,
+            "tenferro-linalg.eigh",
+        ),
+        Tensor::C32(vectors) => canonicalize_eigh_gauge_c32(
+            vectors.host_data_mut()?,
+            n,
+            batch_count,
+            "tenferro-linalg.eigh",
+        ),
+        vectors => Err(Error::backend_failure(
+            "tenferro-linalg.eigh",
+            format!("unsupported eigenvector dtype {:?}", vectors.dtype()),
+        )),
+    }
+}
+
+fn apply_positive_diagonal_qr_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::Result<()> {
+    if outputs.len() != 2 {
+        return Err(Error::InvalidConfig {
+            op: "tenferro-linalg.qr",
+            message: format!(
+                "positive-diagonal QR gauge expected two outputs, got {}",
+                outputs.len()
+            ),
+        });
+    }
+
+    let (q_slice, r_slice) = outputs.split_at_mut(1);
+    let q = &mut q_slice[0];
+    let r = &mut r_slice[0];
+    let q_shape = q.shape().to_vec();
+    let r_shape = r.shape().to_vec();
+    if q_shape.len() < 2 || r_shape.len() < 2 {
+        return Err(Error::InvalidConfig {
+            op: "tenferro-linalg.qr",
+            message: format!(
+                "positive-diagonal QR gauge expected Q and R rank >= 2; got Q={q_shape:?}, R={r_shape:?}"
+            ),
+        });
+    }
+
+    let m = q_shape[0];
+    let k = q_shape[1];
+    let n = r_shape[1];
+    if r_shape[0] != k || q_shape[2..] != r_shape[2..] {
+        return Err(Error::InvalidConfig {
+            op: "tenferro-linalg.qr",
+            message: format!(
+                "positive-diagonal QR gauge expected compatible QR shapes, got Q={q_shape:?}, R={r_shape:?}"
+            ),
+        });
+    }
+    let batch_count = checked_batch_count("tenferro-linalg.qr", &q_shape[2..])?;
+
+    match (q, r) {
+        (Tensor::F64(q), Tensor::F64(r)) => canonicalize_qr_gauge_f64(
+            q.host_data_mut()?,
+            r.host_data_mut()?,
+            m,
+            k,
+            n,
+            batch_count,
+            "tenferro-linalg.qr",
+        ),
+        (Tensor::F32(q), Tensor::F32(r)) => canonicalize_qr_gauge_f32(
+            q.host_data_mut()?,
+            r.host_data_mut()?,
+            m,
+            k,
+            n,
+            batch_count,
+            "tenferro-linalg.qr",
+        ),
+        (Tensor::C64(q), Tensor::C64(r)) => canonicalize_qr_gauge_c64(
+            q.host_data_mut()?,
+            r.host_data_mut()?,
+            m,
+            k,
+            n,
+            batch_count,
+            "tenferro-linalg.qr",
+        ),
+        (Tensor::C32(q), Tensor::C32(r)) => canonicalize_qr_gauge_c32(
+            q.host_data_mut()?,
+            r.host_data_mut()?,
+            m,
+            k,
+            n,
+            batch_count,
+            "tenferro-linalg.qr",
+        ),
+        (q, r) => Err(Error::DTypeMismatch {
+            op: "tenferro-linalg.qr",
+            lhs: q.dtype(),
+            rhs: r.dtype(),
+        }),
+    }
+}
+
+fn canonicalize_eigh_gauge_f64(
+    vectors: &mut [f64],
+    n: usize,
+    batch_count: usize,
+    op: &'static str,
+) -> tenferro_tensor::Result<()> {
+    let batch_stride = checked_square_len(op, n)?;
+    for batch in 0..batch_count {
+        let base = checked_batch_offset(op, batch, batch_stride)?;
+        for col in 0..n {
+            let pivot = max_abs_pivot_f64(vectors, base, n, col);
+            if vectors[base + pivot + n * col] < 0.0 {
+                for row in 0..n {
+                    let offset = base + row + n * col;
+                    vectors[offset] = -vectors[offset];
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn canonicalize_eigh_gauge_f32(
+    vectors: &mut [f32],
+    n: usize,
+    batch_count: usize,
+    op: &'static str,
+) -> tenferro_tensor::Result<()> {
+    let batch_stride = checked_square_len(op, n)?;
+    for batch in 0..batch_count {
+        let base = checked_batch_offset(op, batch, batch_stride)?;
+        for col in 0..n {
+            let pivot = max_abs_pivot_f32(vectors, base, n, col);
+            if vectors[base + pivot + n * col] < 0.0 {
+                for row in 0..n {
+                    let offset = base + row + n * col;
+                    vectors[offset] = -vectors[offset];
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn canonicalize_eigh_gauge_c64(
+    vectors: &mut [Complex64],
+    n: usize,
+    batch_count: usize,
+    op: &'static str,
+) -> tenferro_tensor::Result<()> {
+    let batch_stride = checked_square_len(op, n)?;
+    for batch in 0..batch_count {
+        let base = checked_batch_offset(op, batch, batch_stride)?;
+        for col in 0..n {
+            let pivot = max_abs_pivot_c64(vectors, base, n, col);
+            let pivot_value = vectors[base + pivot + n * col];
+            let pivot_norm = pivot_value.norm();
+            if pivot_norm == 0.0 {
+                continue;
+            }
+            let phase = pivot_value.conj() / pivot_norm;
+            for row in 0..n {
+                let offset = base + row + n * col;
+                vectors[offset] *= phase;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn canonicalize_eigh_gauge_c32(
+    vectors: &mut [Complex32],
+    n: usize,
+    batch_count: usize,
+    op: &'static str,
+) -> tenferro_tensor::Result<()> {
+    let batch_stride = checked_square_len(op, n)?;
+    for batch in 0..batch_count {
+        let base = checked_batch_offset(op, batch, batch_stride)?;
+        for col in 0..n {
+            let pivot = max_abs_pivot_c32(vectors, base, n, col);
+            let pivot_value = vectors[base + pivot + n * col];
+            let pivot_norm = pivot_value.norm();
+            if pivot_norm == 0.0 {
+                continue;
+            }
+            let phase = pivot_value.conj() / pivot_norm;
+            for row in 0..n {
+                let offset = base + row + n * col;
+                vectors[offset] *= phase;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn canonicalize_qr_gauge_f64(
+    q: &mut [f64],
+    r: &mut [f64],
+    m: usize,
+    k: usize,
+    n: usize,
+    batch_count: usize,
+    op: &'static str,
+) -> tenferro_tensor::Result<()> {
+    let q_stride = checked_matrix_len(op, m, k)?;
+    let r_stride = checked_matrix_len(op, k, n)?;
+    for batch in 0..batch_count {
+        let q_base = checked_batch_offset(op, batch, q_stride)?;
+        let r_base = checked_batch_offset(op, batch, r_stride)?;
+        for diag in 0..k {
+            if r[r_base + diag + k * diag] < 0.0 {
+                for row in 0..m {
+                    q[q_base + row + m * diag] = -q[q_base + row + m * diag];
+                }
+                for col in 0..n {
+                    r[r_base + diag + k * col] = -r[r_base + diag + k * col];
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn canonicalize_qr_gauge_f32(
+    q: &mut [f32],
+    r: &mut [f32],
+    m: usize,
+    k: usize,
+    n: usize,
+    batch_count: usize,
+    op: &'static str,
+) -> tenferro_tensor::Result<()> {
+    let q_stride = checked_matrix_len(op, m, k)?;
+    let r_stride = checked_matrix_len(op, k, n)?;
+    for batch in 0..batch_count {
+        let q_base = checked_batch_offset(op, batch, q_stride)?;
+        let r_base = checked_batch_offset(op, batch, r_stride)?;
+        for diag in 0..k {
+            if r[r_base + diag + k * diag] < 0.0 {
+                for row in 0..m {
+                    q[q_base + row + m * diag] = -q[q_base + row + m * diag];
+                }
+                for col in 0..n {
+                    r[r_base + diag + k * col] = -r[r_base + diag + k * col];
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn canonicalize_qr_gauge_c64(
+    q: &mut [Complex64],
+    r: &mut [Complex64],
+    m: usize,
+    k: usize,
+    n: usize,
+    batch_count: usize,
+    op: &'static str,
+) -> tenferro_tensor::Result<()> {
+    let q_stride = checked_matrix_len(op, m, k)?;
+    let r_stride = checked_matrix_len(op, k, n)?;
+    for batch in 0..batch_count {
+        let q_base = checked_batch_offset(op, batch, q_stride)?;
+        let r_base = checked_batch_offset(op, batch, r_stride)?;
+        for diag in 0..k {
+            let diagonal = r[r_base + diag + k * diag];
+            let norm = diagonal.norm();
+            if norm == 0.0 {
+                continue;
+            }
+            let q_phase = diagonal / norm;
+            let r_phase = diagonal.conj() / norm;
+            for row in 0..m {
+                q[q_base + row + m * diag] *= q_phase;
+            }
+            for col in 0..n {
+                r[r_base + diag + k * col] *= r_phase;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn canonicalize_qr_gauge_c32(
+    q: &mut [Complex32],
+    r: &mut [Complex32],
+    m: usize,
+    k: usize,
+    n: usize,
+    batch_count: usize,
+    op: &'static str,
+) -> tenferro_tensor::Result<()> {
+    let q_stride = checked_matrix_len(op, m, k)?;
+    let r_stride = checked_matrix_len(op, k, n)?;
+    for batch in 0..batch_count {
+        let q_base = checked_batch_offset(op, batch, q_stride)?;
+        let r_base = checked_batch_offset(op, batch, r_stride)?;
+        for diag in 0..k {
+            let diagonal = r[r_base + diag + k * diag];
+            let norm = diagonal.norm();
+            if norm == 0.0 {
+                continue;
+            }
+            let q_phase = diagonal / norm;
+            let r_phase = diagonal.conj() / norm;
+            for row in 0..m {
+                q[q_base + row + m * diag] *= q_phase;
+            }
+            for col in 0..n {
+                r[r_base + diag + k * col] *= r_phase;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn max_abs_pivot_f64(values: &[f64], base: usize, rows: usize, col: usize) -> usize {
+    let mut pivot = 0;
+    let mut pivot_abs = values[base + rows * col].abs();
+    for row in 1..rows {
+        let candidate_abs = values[base + row + rows * col].abs();
+        if candidate_abs > pivot_abs {
+            pivot = row;
+            pivot_abs = candidate_abs;
+        }
+    }
+    pivot
+}
+
+fn max_abs_pivot_f32(values: &[f32], base: usize, rows: usize, col: usize) -> usize {
+    let mut pivot = 0;
+    let mut pivot_abs = values[base + rows * col].abs();
+    for row in 1..rows {
+        let candidate_abs = values[base + row + rows * col].abs();
+        if candidate_abs > pivot_abs {
+            pivot = row;
+            pivot_abs = candidate_abs;
+        }
+    }
+    pivot
+}
+
+fn max_abs_pivot_c64(values: &[Complex64], base: usize, rows: usize, col: usize) -> usize {
+    let mut pivot = 0;
+    let mut pivot_abs = values[base + rows * col].norm_sqr();
+    for row in 1..rows {
+        let candidate_abs = values[base + row + rows * col].norm_sqr();
+        if candidate_abs > pivot_abs {
+            pivot = row;
+            pivot_abs = candidate_abs;
+        }
+    }
+    pivot
+}
+
+fn max_abs_pivot_c32(values: &[Complex32], base: usize, rows: usize, col: usize) -> usize {
+    let mut pivot = 0;
+    let mut pivot_abs = values[base + rows * col].norm_sqr();
+    for row in 1..rows {
+        let candidate_abs = values[base + row + rows * col].norm_sqr();
+        if candidate_abs > pivot_abs {
+            pivot = row;
+            pivot_abs = candidate_abs;
+        }
+    }
+    pivot
+}
+
+fn checked_batch_count(op: &'static str, batch_shape: &[usize]) -> tenferro_tensor::Result<usize> {
+    batch_shape.iter().try_fold(1usize, |acc, &dim| {
+        acc.checked_mul(dim)
+            .ok_or_else(|| invalid_config(op, "batch element count overflow"))
+    })
+}
+
+fn checked_square_len(op: &'static str, n: usize) -> tenferro_tensor::Result<usize> {
+    checked_matrix_len(op, n, n)
+}
+
+fn checked_matrix_len(
+    op: &'static str,
+    rows: usize,
+    cols: usize,
+) -> tenferro_tensor::Result<usize> {
+    rows.checked_mul(cols)
+        .ok_or_else(|| invalid_config(op, "matrix element count overflow"))
+}
+
+fn checked_batch_offset(
+    op: &'static str,
+    batch: usize,
+    stride: usize,
+) -> tenferro_tensor::Result<usize> {
+    batch
+        .checked_mul(stride)
+        .ok_or_else(|| invalid_config(op, "batch offset overflow"))
+}
+
+fn invalid_config(op: &'static str, message: &'static str) -> Error {
+    Error::InvalidConfig {
+        op,
+        message: message.to_string(),
+    }
+}

--- a/crates/tenferro-linalg/src/extension/tests.rs
+++ b/crates/tenferro-linalg/src/extension/tests.rs
@@ -1,13 +1,16 @@
 use std::sync::Arc;
 
-use num_complex::Complex64;
+use num_complex::{Complex32, Complex64};
 use tenferro_runtime::extension::ExtensionOp;
 use tenferro_tensor::{
     Buffer, BufferHandle, DType, DeviceId, DeviceKind, Error, GpuBackendKind, MemoryKind,
     Placement, Tensor, TypedTensor,
 };
 
-use super::{apply_svd_gauge, promote_dtypes, LinalgExtensionOp, LinalgOp, SvdGauge};
+use super::{
+    apply_eigh_gauge, apply_qr_gauge, apply_svd_gauge, promote_dtypes, EighGauge,
+    LinalgExtensionOp, LinalgOp, QrGauge, SvdGauge,
+};
 
 #[test]
 fn eager_linalg_rejects_cuda_tensor_when_cuda_feature_is_disabled() {
@@ -108,6 +111,7 @@ fn decomposition_value_outputs_prune_to_values_only_ops() {
 
     let eigh = LinalgExtensionOp::new(LinalgOp::Eigh {
         derivative_eps: 1.0e-12,
+        gauge: EighGauge::Raw,
     });
     let pruned_eigh = eigh
         .prune_outputs(&[true, false])
@@ -195,4 +199,456 @@ fn canonical_pivot_svd_gauge_removes_complex_pivot_phase() {
     assert!((vt[0].im - scale).abs() < 1.0e-12);
     assert!((vt[1].re + 1.0 / scale).abs() < 1.0e-12);
     assert!((vt[1].im - 7.0 / scale).abs() < 1.0e-12);
+}
+
+#[test]
+fn canonical_pivot_eigh_gauge_flips_real_eigenvector_columns() {
+    let mut outputs = vec![
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 3.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![2, 2], vec![-0.9_f64, 0.2, -0.8, 0.1]).unwrap(),
+    ];
+    let before_reconstruction = reconstruct_eigh_f64(
+        outputs[0].as_slice::<f64>().unwrap(),
+        outputs[1].as_slice::<f64>().unwrap(),
+        2,
+    );
+
+    apply_eigh_gauge(EighGauge::CanonicalPivot, &mut outputs).unwrap();
+
+    assert_eq!(
+        outputs[1].as_slice::<f64>().unwrap(),
+        &[0.9, -0.2, 0.8, -0.1]
+    );
+    let after_reconstruction = reconstruct_eigh_f64(
+        outputs[0].as_slice::<f64>().unwrap(),
+        outputs[1].as_slice::<f64>().unwrap(),
+        2,
+    );
+    assert_slice_close_f64(&after_reconstruction, &before_reconstruction, 1.0e-12);
+}
+
+#[test]
+fn canonical_pivot_eigh_gauge_removes_complex_eigenvector_phase() {
+    let mut outputs = vec![
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+        Tensor::C64(
+            TypedTensor::from_vec_col_major(
+                vec![2, 2],
+                vec![
+                    Complex64::new(1.0, 1.0),
+                    Complex64::new(0.1, 0.0),
+                    Complex64::new(0.0, 0.0),
+                    Complex64::new(1.0, 0.0),
+                ],
+            )
+            .unwrap(),
+        ),
+    ];
+    let before_reconstruction = reconstruct_eigh_c64(
+        outputs[0].as_slice::<f64>().unwrap(),
+        outputs[1].as_slice::<Complex64>().unwrap(),
+        2,
+    );
+
+    apply_eigh_gauge(EighGauge::CanonicalPivot, &mut outputs).unwrap();
+
+    let scale = 2.0_f64.sqrt();
+    let vectors = outputs[1].as_slice::<Complex64>().unwrap();
+    assert!((vectors[0].re - scale).abs() < 1.0e-12);
+    assert!(vectors[0].im.abs() < 1.0e-12);
+    assert!((vectors[1].re - 0.1 / scale).abs() < 1.0e-12);
+    assert!((vectors[1].im + 0.1 / scale).abs() < 1.0e-12);
+    let after_reconstruction = reconstruct_eigh_c64(
+        outputs[0].as_slice::<f64>().unwrap(),
+        outputs[1].as_slice::<Complex64>().unwrap(),
+        2,
+    );
+    assert_slice_close_c64(&after_reconstruction, &before_reconstruction, 1.0e-12);
+}
+
+#[test]
+fn eigh_gauge_covers_f32_and_c32_paths() {
+    let mut real_outputs = vec![
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 3.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![2, 2], vec![-0.7_f32, 0.2, 0.5, -0.8]).unwrap(),
+    ];
+    let before_real = reconstruct_eigh_f64(
+        &real_outputs[0]
+            .as_slice::<f32>()
+            .unwrap()
+            .iter()
+            .map(|&value| f64::from(value))
+            .collect::<Vec<_>>(),
+        &real_outputs[1]
+            .as_slice::<f32>()
+            .unwrap()
+            .iter()
+            .map(|&value| f64::from(value))
+            .collect::<Vec<_>>(),
+        2,
+    );
+
+    apply_eigh_gauge(EighGauge::CanonicalPivot, &mut real_outputs).unwrap();
+
+    assert_eq!(
+        real_outputs[1].as_slice::<f32>().unwrap(),
+        &[0.7, -0.2, -0.5, 0.8]
+    );
+    let after_real = reconstruct_eigh_f64(
+        &real_outputs[0]
+            .as_slice::<f32>()
+            .unwrap()
+            .iter()
+            .map(|&value| f64::from(value))
+            .collect::<Vec<_>>(),
+        &real_outputs[1]
+            .as_slice::<f32>()
+            .unwrap()
+            .iter()
+            .map(|&value| f64::from(value))
+            .collect::<Vec<_>>(),
+        2,
+    );
+    assert_slice_close_f64(&after_real, &before_real, 1.0e-6);
+
+    let mut complex_outputs = vec![
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f32, 3.0]).unwrap(),
+        Tensor::C32(
+            TypedTensor::from_vec_col_major(
+                vec![2, 2],
+                vec![
+                    Complex32::new(1.0, 1.0),
+                    Complex32::new(0.1, 0.0),
+                    Complex32::new(0.0, 0.0),
+                    Complex32::new(0.0, 0.0),
+                ],
+            )
+            .unwrap(),
+        ),
+    ];
+
+    apply_eigh_gauge(EighGauge::CanonicalPivot, &mut complex_outputs).unwrap();
+
+    let scale = 2.0_f32.sqrt();
+    let vectors = complex_outputs[1].as_slice::<Complex32>().unwrap();
+    assert!((vectors[0].re - scale).abs() < 1.0e-6);
+    assert!(vectors[0].im.abs() < 1.0e-6);
+    assert!((vectors[1].re - 0.1 / scale).abs() < 1.0e-6);
+    assert!((vectors[1].im + 0.1 / scale).abs() < 1.0e-6);
+    assert_eq!(vectors[2], Complex32::new(0.0, 0.0));
+    assert_eq!(vectors[3], Complex32::new(0.0, 0.0));
+}
+
+#[test]
+fn positive_diagonal_qr_gauge_flips_real_q_columns_and_r_rows() {
+    let mut outputs = vec![
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![2, 2], vec![-5.0_f64, 0.0, 6.0, -7.0]).unwrap(),
+    ];
+    let before_product = matmul_f64(
+        outputs[0].as_slice::<f64>().unwrap(),
+        outputs[1].as_slice::<f64>().unwrap(),
+        2,
+        2,
+        2,
+    );
+
+    apply_qr_gauge(QrGauge::PositiveDiagonal, &mut outputs).unwrap();
+
+    assert_eq!(
+        outputs[0].as_slice::<f64>().unwrap(),
+        &[-1.0, -2.0, -3.0, -4.0]
+    );
+    assert_eq!(
+        outputs[1].as_slice::<f64>().unwrap(),
+        &[5.0, -0.0, -6.0, 7.0]
+    );
+    let after_product = matmul_f64(
+        outputs[0].as_slice::<f64>().unwrap(),
+        outputs[1].as_slice::<f64>().unwrap(),
+        2,
+        2,
+        2,
+    );
+    assert_slice_close_f64(&after_product, &before_product, 1.0e-12);
+}
+
+#[test]
+fn positive_diagonal_qr_gauge_removes_complex_diagonal_phase() {
+    let mut outputs = vec![
+        Tensor::C64(
+            TypedTensor::from_vec_col_major(
+                vec![2, 1],
+                vec![Complex64::new(2.0, 0.0), Complex64::new(0.0, 1.0)],
+            )
+            .unwrap(),
+        ),
+        Tensor::C64(
+            TypedTensor::from_vec_col_major(
+                vec![1, 2],
+                vec![Complex64::new(1.0, 1.0), Complex64::new(3.0, 4.0)],
+            )
+            .unwrap(),
+        ),
+    ];
+    let before_product = matmul_c64(
+        outputs[0].as_slice::<Complex64>().unwrap(),
+        outputs[1].as_slice::<Complex64>().unwrap(),
+        2,
+        1,
+        2,
+    );
+
+    apply_qr_gauge(QrGauge::PositiveDiagonal, &mut outputs).unwrap();
+
+    let scale = 2.0_f64.sqrt();
+    let q = outputs[0].as_slice::<Complex64>().unwrap();
+    assert!((q[0].re - scale).abs() < 1.0e-12);
+    assert!((q[0].im - scale).abs() < 1.0e-12);
+    assert!((q[1].re + 1.0 / scale).abs() < 1.0e-12);
+    assert!((q[1].im - 1.0 / scale).abs() < 1.0e-12);
+
+    let r = outputs[1].as_slice::<Complex64>().unwrap();
+    assert!((r[0].re - scale).abs() < 1.0e-12);
+    assert!(r[0].im.abs() < 1.0e-12);
+    assert!((r[1].re - 7.0 / scale).abs() < 1.0e-12);
+    assert!((r[1].im - 1.0 / scale).abs() < 1.0e-12);
+    let after_product = matmul_c64(
+        outputs[0].as_slice::<Complex64>().unwrap(),
+        outputs[1].as_slice::<Complex64>().unwrap(),
+        2,
+        1,
+        2,
+    );
+    assert_slice_close_c64(&after_product, &before_product, 1.0e-12);
+}
+
+#[test]
+fn qr_gauge_covers_f32_and_c32_paths() {
+    let mut real_outputs = vec![
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f32, 2.0, 3.0, 4.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![2, 2], vec![-5.0_f32, 0.0, 6.0, -7.0]).unwrap(),
+    ];
+
+    apply_qr_gauge(QrGauge::PositiveDiagonal, &mut real_outputs).unwrap();
+
+    assert_eq!(
+        real_outputs[0].as_slice::<f32>().unwrap(),
+        &[-1.0, -2.0, -3.0, -4.0]
+    );
+    assert_eq!(
+        real_outputs[1].as_slice::<f32>().unwrap(),
+        &[5.0, -0.0, -6.0, 7.0]
+    );
+
+    let mut complex_outputs = vec![
+        Tensor::C32(
+            TypedTensor::from_vec_col_major(
+                vec![2, 2],
+                vec![
+                    Complex32::new(2.0, 0.0),
+                    Complex32::new(0.0, 1.0),
+                    Complex32::new(0.5, 0.0),
+                    Complex32::new(1.0, 0.0),
+                ],
+            )
+            .unwrap(),
+        ),
+        Tensor::C32(
+            TypedTensor::from_vec_col_major(
+                vec![2, 2],
+                vec![
+                    Complex32::new(1.0, 1.0),
+                    Complex32::new(0.0, 0.0),
+                    Complex32::new(3.0, 4.0),
+                    Complex32::new(0.0, 0.0),
+                ],
+            )
+            .unwrap(),
+        ),
+    ];
+
+    apply_qr_gauge(QrGauge::PositiveDiagonal, &mut complex_outputs).unwrap();
+
+    let scale = 2.0_f32.sqrt();
+    let q = complex_outputs[0].as_slice::<Complex32>().unwrap();
+    assert!((q[0].re - scale).abs() < 1.0e-6);
+    assert!((q[0].im - scale).abs() < 1.0e-6);
+    assert!((q[1].re + 1.0 / scale).abs() < 1.0e-6);
+    assert!((q[1].im - 1.0 / scale).abs() < 1.0e-6);
+    assert_eq!(q[2], Complex32::new(0.5, 0.0));
+    assert_eq!(q[3], Complex32::new(1.0, 0.0));
+
+    let r = complex_outputs[1].as_slice::<Complex32>().unwrap();
+    assert!((r[0].re - scale).abs() < 1.0e-6);
+    assert!(r[0].im.abs() < 1.0e-6);
+    assert!((r[2].re - 7.0 / scale).abs() < 1.0e-6);
+    assert!((r[2].im - 1.0 / scale).abs() < 1.0e-6);
+    assert_eq!(r[3], Complex32::new(0.0, 0.0));
+}
+
+#[test]
+fn raw_gauges_leave_outputs_unchanged() {
+    let mut eigh_outputs = vec![
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![2, 2], vec![-1.0_f64, 0.0, 0.0, -1.0]).unwrap(),
+    ];
+    let original_vectors = eigh_outputs[1].as_slice::<f64>().unwrap().to_vec();
+
+    apply_eigh_gauge(EighGauge::Raw, &mut eigh_outputs).unwrap();
+
+    assert_eq!(eigh_outputs[1].as_slice::<f64>().unwrap(), original_vectors);
+
+    let mut qr_outputs = vec![
+        Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![1, 2], vec![-3.0_f64, 4.0]).unwrap(),
+    ];
+    let original_q = qr_outputs[0].as_slice::<f64>().unwrap().to_vec();
+    let original_r = qr_outputs[1].as_slice::<f64>().unwrap().to_vec();
+
+    apply_qr_gauge(QrGauge::Raw, &mut qr_outputs).unwrap();
+
+    assert_eq!(qr_outputs[0].as_slice::<f64>().unwrap(), original_q);
+    assert_eq!(qr_outputs[1].as_slice::<f64>().unwrap(), original_r);
+}
+
+#[test]
+fn gauge_validation_errors_cover_malformed_outputs() {
+    assert_invalid_config(apply_eigh_gauge(EighGauge::CanonicalPivot, &mut []));
+
+    let mut bad_eigh_rank = vec![
+        Tensor::from_vec_col_major(vec![], vec![1.0_f64]).unwrap(),
+        Tensor::from_vec_col_major(vec![1, 1], vec![1.0_f64]).unwrap(),
+    ];
+    assert_invalid_config(apply_eigh_gauge(
+        EighGauge::CanonicalPivot,
+        &mut bad_eigh_rank,
+    ));
+
+    let mut bad_eigh_shape = vec![
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 0.0]).unwrap(),
+    ];
+    assert_invalid_config(apply_eigh_gauge(
+        EighGauge::CanonicalPivot,
+        &mut bad_eigh_shape,
+    ));
+
+    let mut bad_eigh_dtype = vec![
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+        Tensor::from_vec_col_major(vec![1, 1], vec![1_i32]).unwrap(),
+    ];
+    assert!(matches!(
+        apply_eigh_gauge(EighGauge::CanonicalPivot, &mut bad_eigh_dtype),
+        Err(Error::BackendFailure { .. })
+    ));
+
+    assert_invalid_config(apply_qr_gauge(QrGauge::PositiveDiagonal, &mut []));
+
+    let mut bad_qr_rank = vec![
+        Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
+        Tensor::from_vec_col_major(vec![1, 1], vec![1.0_f64]).unwrap(),
+    ];
+    assert_invalid_config(apply_qr_gauge(QrGauge::PositiveDiagonal, &mut bad_qr_rank));
+
+    let mut bad_qr_shape = vec![
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 0.0]).unwrap(),
+    ];
+    assert_invalid_config(apply_qr_gauge(QrGauge::PositiveDiagonal, &mut bad_qr_shape));
+
+    let mut bad_qr_dtype = vec![
+        Tensor::from_vec_col_major(vec![1, 1], vec![1.0_f64]).unwrap(),
+        Tensor::from_vec_col_major(vec![1, 1], vec![1.0_f32]).unwrap(),
+    ];
+    assert!(matches!(
+        apply_qr_gauge(QrGauge::PositiveDiagonal, &mut bad_qr_dtype),
+        Err(Error::DTypeMismatch { .. })
+    ));
+}
+
+fn reconstruct_eigh_f64(values: &[f64], vectors: &[f64], n: usize) -> Vec<f64> {
+    let mut output = vec![0.0; n * n];
+    for col in 0..n {
+        for row in 0..n {
+            let mut sum = 0.0;
+            for eig in 0..n {
+                sum += vectors[row + n * eig] * values[eig] * vectors[col + n * eig];
+            }
+            output[row + n * col] = sum;
+        }
+    }
+    output
+}
+
+fn reconstruct_eigh_c64(values: &[f64], vectors: &[Complex64], n: usize) -> Vec<Complex64> {
+    let mut output = vec![Complex64::new(0.0, 0.0); n * n];
+    for col in 0..n {
+        for row in 0..n {
+            let mut sum = Complex64::new(0.0, 0.0);
+            for eig in 0..n {
+                sum += vectors[row + n * eig] * values[eig] * vectors[col + n * eig].conj();
+            }
+            output[row + n * col] = sum;
+        }
+    }
+    output
+}
+
+fn matmul_f64(lhs: &[f64], rhs: &[f64], m: usize, k: usize, n: usize) -> Vec<f64> {
+    let mut output = vec![0.0; m * n];
+    for col in 0..n {
+        for row in 0..m {
+            let mut sum = 0.0;
+            for inner in 0..k {
+                sum += lhs[row + m * inner] * rhs[inner + k * col];
+            }
+            output[row + m * col] = sum;
+        }
+    }
+    output
+}
+
+fn matmul_c64(
+    lhs: &[Complex64],
+    rhs: &[Complex64],
+    m: usize,
+    k: usize,
+    n: usize,
+) -> Vec<Complex64> {
+    let mut output = vec![Complex64::new(0.0, 0.0); m * n];
+    for col in 0..n {
+        for row in 0..m {
+            let mut sum = Complex64::new(0.0, 0.0);
+            for inner in 0..k {
+                sum += lhs[row + m * inner] * rhs[inner + k * col];
+            }
+            output[row + m * col] = sum;
+        }
+    }
+    output
+}
+
+fn assert_slice_close_f64(actual: &[f64], expected: &[f64], tol: f64) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (actual - expected).abs() <= tol,
+            "index {index}: actual={actual}, expected={expected}, tol={tol}"
+        );
+    }
+}
+
+fn assert_slice_close_c64(actual: &[Complex64], expected: &[Complex64], tol: f64) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (actual - expected).norm() <= tol,
+            "index {index}: actual={actual:?}, expected={expected:?}, tol={tol}"
+        );
+    }
+}
+
+fn assert_invalid_config(result: tenferro_tensor::Result<()>) {
+    assert!(matches!(result, Err(Error::InvalidConfig { .. })));
 }

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -50,7 +50,7 @@ pub use backend::LinalgBackend;
 #[cfg(feature = "autodiff")]
 pub use eager_ext::EagerTensorLinalgExt;
 pub use extension::{
-    register_runtime, EighOptions, SvdGauge, SvdOptions, DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
-    LINALG_EXTENSION_FAMILY_ID,
+    register_runtime, EighGauge, EighOptions, QrGauge, QrOptions, SvdGauge, SvdOptions,
+    DEFAULT_DECOMPOSITION_DERIVATIVE_EPS, LINALG_EXTENSION_FAMILY_ID,
 };
 pub use traced::TracedTensorLinalgExt;

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -5,7 +5,7 @@ use tenferro_runtime::extension::apply;
 use tenferro_runtime::{CompareDir, DType, DotGeneralConfig, Error, Result, TracedTensor};
 
 use crate::extension::{
-    validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, SvdOptions,
+    validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, QrOptions, SvdOptions,
 };
 
 /// Linear algebra extension methods for [`TracedTensor`].
@@ -16,6 +16,7 @@ pub trait TracedTensorLinalgExt {
         options: SvdOptions,
     ) -> Result<(TracedTensor, TracedTensor, TracedTensor)>;
     fn qr(&self) -> Result<(TracedTensor, TracedTensor)>;
+    fn qr_with_options(&self, options: QrOptions) -> Result<(TracedTensor, TracedTensor)>;
     fn eigh(&self) -> Result<(TracedTensor, TracedTensor)>;
     fn eigh_with_options(&self, options: EighOptions) -> Result<(TracedTensor, TracedTensor)>;
     fn cholesky(&self) -> Result<TracedTensor>;
@@ -64,6 +65,10 @@ impl TracedTensorLinalgExt for TracedTensor {
 
     fn qr(&self) -> Result<(TracedTensor, TracedTensor)> {
         qr(self)
+    }
+
+    fn qr_with_options(&self, options: QrOptions) -> Result<(TracedTensor, TracedTensor)> {
+        qr_with_options(self, options)
     }
 
     fn eigh(&self) -> Result<(TracedTensor, TracedTensor)> {
@@ -217,8 +222,35 @@ pub fn svd_with_options(
 /// assert_eq!(r.rank, 2);
 /// ```
 pub fn qr(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
+    qr_with_options(a, QrOptions::default())
+}
+
+/// Build a traced QR decomposition op with explicit options.
+///
+/// `gauge` controls optional sign or phase post-processing.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_linalg::{QrGauge, QrOptions, TracedTensorLinalgExt};
+/// use tenferro_runtime::TracedTensor;
+///
+/// let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap();
+/// let (q, r) = a.qr_with_options(QrOptions::default().gauge(QrGauge::PositiveDiagonal)).unwrap();
+/// assert_eq!(q.rank, 2);
+/// assert_eq!(r.rank, 2);
+/// ```
+pub fn qr_with_options(
+    a: &TracedTensor,
+    options: QrOptions,
+) -> Result<(TracedTensor, TracedTensor)> {
     two_outputs(
-        apply(Arc::new(LinalgExtensionOp::new(LinalgOp::Qr)), &[a])?,
+        apply(
+            Arc::new(LinalgExtensionOp::new(LinalgOp::Qr {
+                gauge: options.gauge,
+            })),
+            &[a],
+        )?,
         "qr",
     )
 }
@@ -248,12 +280,16 @@ pub fn eigh(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
 /// # Examples
 ///
 /// ```
-/// use tenferro_linalg::{EighOptions, TracedTensorLinalgExt};
+/// use tenferro_linalg::{EighGauge, EighOptions, TracedTensorLinalgExt};
 /// use tenferro_runtime::TracedTensor;
 ///
 /// let a = TracedTensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 3.0]).unwrap();
 /// let (values, _vectors) = a
-///     .eigh_with_options(EighOptions::default().derivative_eps(1e-10))
+///     .eigh_with_options(
+///         EighOptions::default()
+///             .gauge(EighGauge::CanonicalPivot)
+///             .derivative_eps(1e-10),
+///     )
 ///     .unwrap();
 /// assert_eq!(values.rank, 1);
 /// ```
@@ -266,6 +302,7 @@ pub fn eigh_with_options(
         apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::Eigh {
                 derivative_eps: options.derivative_eps,
+                gauge: options.gauge,
             })),
             &[a],
         )?,
@@ -956,6 +993,7 @@ fn eigh_values(a: &TracedTensor) -> Result<TracedTensor> {
         apply(
             Arc::new(LinalgExtensionOp::new(LinalgOp::Eigh {
                 derivative_eps: EighOptions::default().derivative_eps,
+                gauge: EighOptions::default().gauge,
             })),
             &[a],
         )?,

--- a/crates/tenferro-linalg/tests/eager_tensor.rs
+++ b/crates/tenferro-linalg/tests/eager_tensor.rs
@@ -6,7 +6,9 @@ use tenferro_ad::{AdContext, EagerRuntime, EagerTensor, Tensor};
 use tenferro_cpu::CpuBackend;
 #[cfg(feature = "cuda")]
 use tenferro_gpu::{download_tensor, gpu_available, upload_tensor, CudaBackend};
-use tenferro_linalg::{EagerTensorLinalgExt, EighOptions, SvdGauge, SvdOptions};
+use tenferro_linalg::{
+    EagerTensorLinalgExt, EighGauge, EighOptions, QrGauge, QrOptions, SvdGauge, SvdOptions,
+};
 
 fn test_ctx() -> Arc<EagerRuntime> {
     static CTX: OnceLock<Arc<EagerRuntime>> = OnceLock::new();
@@ -124,7 +126,14 @@ fn eager_decomposition_options_execute_and_return_expected_shapes() {
         )
         .unwrap();
     let (eigh_values, eigh_vectors) = a
-        .eigh_with_options(EighOptions::default().derivative_eps(1.0e-10))
+        .eigh_with_options(
+            EighOptions::default()
+                .gauge(EighGauge::CanonicalPivot)
+                .derivative_eps(1.0e-10),
+        )
+        .unwrap();
+    let (q, r) = a
+        .qr_with_options(QrOptions::default().gauge(QrGauge::PositiveDiagonal))
         .unwrap();
 
     assert_eq!(u.shape(), &[2, 2]);
@@ -132,6 +141,8 @@ fn eager_decomposition_options_execute_and_return_expected_shapes() {
     assert_eq!(vt.shape(), &[2, 2]);
     assert_eq!(eigh_values.shape(), &[2]);
     assert_eq!(eigh_vectors.shape(), &[2, 2]);
+    assert_eq!(q.shape(), &[2, 2]);
+    assert_eq!(r.shape(), &[2, 2]);
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/traced_extension.rs
@@ -1,6 +1,9 @@
 use num_complex::{Complex32, Complex64};
 use tenferro_cpu::CpuBackend;
-use tenferro_linalg::{EighOptions, LinalgBackend, SvdGauge, SvdOptions, TracedTensorLinalgExt};
+use tenferro_linalg::{
+    EighGauge, EighOptions, LinalgBackend, QrGauge, QrOptions, SvdGauge, SvdOptions,
+    TracedTensorLinalgExt,
+};
 use tenferro_runtime::{
     DType, Error, GraphCompiler, GraphExecutor, GraphOpView, Tensor, TracedTensor, TypedTensor,
 };
@@ -72,7 +75,15 @@ fn concrete_decomposition_options_execute_through_backend_defaults() {
         )
         .unwrap();
     let eigh_outputs = backend
-        .eigh_with_options(&a, EighOptions::default().derivative_eps(1.0e-10))
+        .eigh_with_options(
+            &a,
+            EighOptions::default()
+                .gauge(EighGauge::CanonicalPivot)
+                .derivative_eps(1.0e-10),
+        )
+        .unwrap();
+    let qr_outputs = backend
+        .qr_with_options(&a, QrOptions::default().gauge(QrGauge::PositiveDiagonal))
         .unwrap();
 
     assert_eq!(svd_outputs[0].shape(), &[2, 2]);
@@ -80,6 +91,8 @@ fn concrete_decomposition_options_execute_through_backend_defaults() {
     assert_eq!(svd_outputs[2].shape(), &[2, 2]);
     assert_eq!(eigh_outputs[0].shape(), &[2]);
     assert_eq!(eigh_outputs[1].shape(), &[2, 2]);
+    assert_eq!(qr_outputs[0].shape(), &[2, 2]);
+    assert_eq!(qr_outputs[1].shape(), &[2, 2]);
 }
 
 #[test]
@@ -96,12 +109,19 @@ fn traced_decomposition_options_execute_through_registered_runtime() {
         )
         .unwrap();
     let (eigh_values, eigh_vectors) = a
-        .eigh_with_options(EighOptions::default().derivative_eps(1.0e-10))
+        .eigh_with_options(
+            EighOptions::default()
+                .gauge(EighGauge::CanonicalPivot)
+                .derivative_eps(1.0e-10),
+        )
+        .unwrap();
+    let (q, r) = a
+        .qr_with_options(QrOptions::default().gauge(QrGauge::PositiveDiagonal))
         .unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler
-        .compile_many(&[&u, &s, &vt, &eigh_values, &eigh_vectors])
+        .compile_many(&[&u, &s, &vt, &eigh_values, &eigh_vectors, &q, &r])
         .unwrap();
     let mut executor = GraphExecutor::new(CpuBackend::new());
     executor
@@ -114,6 +134,8 @@ fn traced_decomposition_options_execute_through_registered_runtime() {
     assert_eq!(outputs[2].shape(), &[2, 2]);
     assert_eq!(outputs[3].shape(), &[2]);
     assert_eq!(outputs[4].shape(), &[2, 2]);
+    assert_eq!(outputs[5].shape(), &[2, 2]);
+    assert_eq!(outputs[6].shape(), &[2, 2]);
 }
 
 #[test]

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -62,7 +62,7 @@ CUDA is a backend/device choice for supported `Tensor`, `EagerTensor`, and
 | Triangular solve | `triangular_solve` | `triangular_solve` | `triangular_solve` |
 | Cholesky | `cholesky` | `cholesky` | `cholesky` |
 | SVD | `svd`, `svd_with_options` | `svd`, `svd_with_options` | `svd`, `svd_with_options` |
-| QR | `qr` | `qr` | `qr` |
+| QR | `qr`, `qr_with_options` | `qr`, `qr_with_options` | `qr`, `qr_with_options` |
 | Hermitian eigen | `eigh`, `eigh_with_options` | `eigh`, `eigh_with_options` | `eigh`, `eigh_with_options`, `eigvalsh` |
 | General eigen | `eig` | `eig` | `eig`, `eigvals` |
 | LU | `lu` | `lu` | `lu` |
@@ -94,8 +94,8 @@ assert_eq!(x.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
 ## Concrete Cholesky
 
 ```rust
-use tenferro_linalg::LinalgBackend;
 use tenferro_cpu::CpuBackend;
+use tenferro_linalg::LinalgBackend;
 use tenferro_runtime::{Tensor, TensorOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
@@ -144,8 +144,8 @@ let ad = AdContext::builder()
 ## Singular value decomposition
 
 ```rust
-use tenferro_linalg::LinalgBackend;
 use tenferro_cpu::CpuBackend;
+use tenferro_linalg::{LinalgBackend, QrGauge, QrOptions};
 use tenferro_runtime::{Tensor, TensorOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
@@ -180,11 +180,12 @@ assert!(max_abs_diff(&reconstructed, &a) < 1.0e-12);
 
 ## Decomposition Options And SVD Truncation
 
-Eager and traced SVD expose options when you need a deterministic singular-vector
-gauge or a non-default derivative regularization epsilon. `derivative_eps`
-regularizes AD formulas for repeated or nearly repeated singular values or
-eigenvalues. It is not a backend solver tolerance and does not change the
-forward decomposition algorithm.
+SVD, QR, and Hermitian eigen decomposition expose options when you need an
+opt-in deterministic sign or phase convention. The default remains the
+backend's raw gauge. SVD and Hermitian eigen options also expose
+`derivative_eps`, which regularizes AD formulas for repeated or nearly repeated
+singular values or eigenvalues. It is not a backend solver tolerance and does
+not change the forward decomposition algorithm.
 
 ```rust
 use tenferro_linalg::{SvdGauge, SvdOptions, TracedTensorLinalgExt};
@@ -264,7 +265,12 @@ let a = Tensor::from_vec_col_major(
         3.0, 6.0, 10.0, 5.0,
     ],
 );
-let outputs = LinalgBackend::qr(&mut backend, &a).unwrap();
+let outputs = LinalgBackend::qr_with_options(
+    &mut backend,
+    &a,
+    QrOptions::default().gauge(QrGauge::PositiveDiagonal),
+)
+.unwrap();
 let q = &outputs[0];
 let r = &outputs[1];
 

--- a/docs/worklogs/2026-07-09-issue-1333-gauge-options.md
+++ b/docs/worklogs/2026-07-09-issue-1333-gauge-options.md
@@ -1,0 +1,72 @@
+# Issue 1333 Gauge Options
+
+## Session Summary
+
+GitHub issue #1333 was narrowed after #1338 had already landed SVD canonical
+gauge support and the linalg AD route cleanup. This session kept the default
+decomposition behavior as backend raw gauge and implemented only the remaining
+opt-in forward gauge conventions:
+
+- `EighGauge::CanonicalPivot` for Hermitian eigenvectors.
+- `QrGauge::PositiveDiagonal` for QR factors.
+- Public `QrOptions` and `qr_with_options` on backend, eager, and traced
+  surfaces.
+- `EighOptions::gauge`, with raw gauge as the default.
+
+## Context Read
+
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+- `REPOSITORY_RULES.md`
+- shared tensor4all common, Rust, performance, numerical, and docs/tests rules
+- GitHub issue #1333
+- recently merged PR #1338 context via issue and branch state
+- linalg backend, eager, traced, extension-op, and AD route code
+- linalg guide and existing linalg public-surface tests
+
+## Decisions Made
+
+- Kept gauge fixing opt-in. `svd`, `eigh`, and `qr` still use backend raw
+  signs/phases by default.
+- Treated gauge fixing as forward-output post-processing at the linalg
+  extension/backend boundary. CPU and CUDA decomposition kernels remain
+  unchanged.
+- Did not add new gauge-aware AD rules. The existing AD formulas still operate
+  on the chosen forward outputs; repeated or nearly repeated singular/eigen
+  subspaces remain governed by the existing `derivative_eps` regularization.
+- When AD internally reconstructs a full `Eigh` carrier for eigenvalue-only
+  linearization, it uses `EighGauge::Raw` because that carrier is a derivative
+  implementation detail rather than a public forward-output request.
+
+## Rejected Or Deferred Alternatives
+
+- No default gauge fixing.
+- No broad gauge-aware AD policy or custom VJP/JVP rules solely for gauge
+  conventions.
+- No SVD truncation policy; users continue to slice returned factors.
+- General non-Hermitian `eig` gauge handling remains separate from this issue.
+- LQ remains out of scope because there is no current public LQ operation.
+
+## Verification Performed
+
+- `cargo fmt --all`
+- `cargo test -p tenferro-linalg --features autodiff decomposition_options`
+- `cargo test -p tenferro-linalg --features autodiff gauge`
+- `cargo test -p tenferro-linalg --features autodiff`
+- `cargo fmt --all --check`
+- `git diff --check`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
+- `cargo test --workspace --release`
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+- `python3 scripts/check-coverage.py coverage.json`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-docs-site.py`
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
+
+## Remaining Risks
+
+- Gauge post-processing currently covers host tensors returned by the backend
+  boundary. A future backend that returns non-host-resident decomposition
+  outputs would need either placement-aware gauge handling or an explicit
+  backend override.


### PR DESCRIPTION
## Summary

Closes #1333.

This PR finishes the remaining opt-in decomposition gauge-convention work after #1338:

- adds `EighGauge::{Raw, CanonicalPivot}` and `EighOptions::gauge`
- adds `QrGauge::{Raw, PositiveDiagonal}`, `QrOptions`, and `qr_with_options` on concrete backend, eager, and traced surfaces
- keeps default decomposition behavior as raw backend gauge output
- applies gauge fixing as forward-output post-processing without changing CPU/CUDA decomposition kernels
- leaves AD route semantics unchanged: no broad gauge-aware AD policy and no custom VJP/JVP solely for gauge conventions

The worklog records the design tradeoffs: `docs/worklogs/2026-07-09-issue-1333-gauge-options.md`.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test -p tenferro-linalg --features autodiff gauge`
- `cargo test -p tenferro-linalg --features autodiff decomposition_options`
- `cargo test -p tenferro-linalg --features autodiff`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`