### PR TITLE
Fix RunPod GPU test workflow

### DIFF
--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -1,13 +1,15 @@
 name: CI_gpu
 
-# Legacy larger-runner GPU workflow. PR GPU gating is owned by
-# `runpod-gpu-test.yml`, which emits the required `CI GPU gate` check through
-# trusted `workflow_run` / explicit maintainer `workflow_dispatch` execution.
-# Keep this workflow manual-only as a fallback for comparing the org larger GPU
-# runner with RunPod.
+# Build the CUDA test archive on a cheap non-GPU runner IN PARALLEL with the
+# repository-policy and non-GPU CI checks, then execute CUDA-feature GPU tests
+# on the org larger GPU runner `ubuntu-gpu` only after those checks pass, to
+# minimize GPU billing. Only the GPU runner (`cuda-run`) is gated behind
+# `pre-gpu-gate`; the archive build is not, so the GPU stage can start the
+# moment the gate clears instead of waiting for the archive to compile.
 
 on:
-  workflow_dispatch:
+  pull_request:
+    branches: [main]
 
 permissions:
   actions: read

--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -87,20 +87,15 @@ jobs:
                   return bTime - aTime;
                 });
 
-                // A cancelled or skipped check run can be a superseded attempt
-                // from before a label/approval update. Prefer any successful
-                // run for the same SHA, otherwise an active run, otherwise a
-                // real completed failure.
-                const successful = nameRuns.find(
-                  (run) => run.status === "completed" && run.conclusion === "success"
-                );
-                const active = nameRuns.find((run) => run.status !== "completed");
-                const failed = nameRuns.find(
+                // Cancelled or skipped runs can be superseded attempts from
+                // before a label/approval update. Use the newest current
+                // candidate instead of letting an older success mask a newer
+                // active or failed run.
+                const effective = nameRuns.find(
                   (run) =>
-                    run.status === "completed" &&
-                    !["cancelled", "skipped", "neutral", "success"].includes(run.conclusion)
+                    run.status !== "completed" ||
+                    !["cancelled", "skipped"].includes(run.conclusion)
                 );
-                const effective = successful || active || failed;
                 if (effective) {
                   latest.set(name, effective);
                 }

--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -421,7 +421,7 @@ jobs:
           cargo nextest run \
             --archive-file "${CUDA_ARCHIVE}" \
             --workspace-remap "${GITHUB_WORKSPACE}" \
-            --run-ignored all \
+            --run-ignored ignored-only \
             --no-fail-fast \
             -j 1
       - name: Run OpenXLA PJRT E2E tests

--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -1,15 +1,13 @@
 name: CI_gpu
 
-# Build the CUDA test archive on a cheap non-GPU runner IN PARALLEL with the
-# repository-policy and non-GPU CI checks, then execute CUDA-feature GPU tests
-# on the org larger GPU runner `ubuntu-gpu` only after those checks pass, to
-# minimize GPU billing. Only the GPU runner (`cuda-run`) is gated behind
-# `pre-gpu-gate`; the archive build is not, so the GPU stage can start the
-# moment the gate clears instead of waiting for the archive to compile.
+# Legacy larger-runner GPU workflow. PR GPU gating is owned by
+# `runpod-gpu-test.yml`, which emits the required `CI GPU gate` check through
+# trusted `workflow_run` / explicit maintainer `workflow_dispatch` execution.
+# Keep this workflow manual-only as a fallback for comparing the org larger GPU
+# runner with RunPod.
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   actions: read

--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -421,7 +421,7 @@ jobs:
           cargo nextest run \
             --archive-file "${CUDA_ARCHIVE}" \
             --workspace-remap "${GITHUB_WORKSPACE}" \
-            --run-ignored ignored-only \
+            --run-ignored all \
             --no-fail-fast \
             -j 1
       - name: Run OpenXLA PJRT E2E tests

--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -69,18 +69,40 @@ jobs:
                 per_page: 100,
               });
 
-              const latest = new Map();
+              const candidates = new Map();
               for (const run of runs) {
                 if (!required.includes(run.name)) {
                   continue;
                 }
-                const previous = latest.get(run.name);
-                const runTime = new Date(run.started_at || run.created_at || 0);
-                const previousTime = previous
-                  ? new Date(previous.started_at || previous.created_at || 0)
-                  : new Date(0);
-                if (!previous || runTime > previousTime) {
-                  latest.set(run.name, run);
+                const nameRuns = candidates.get(run.name) || [];
+                nameRuns.push(run);
+                candidates.set(run.name, nameRuns);
+              }
+
+              const latest = new Map();
+              for (const name of required) {
+                const nameRuns = (candidates.get(name) || []).sort((a, b) => {
+                  const aTime = new Date(a.started_at || a.created_at || 0);
+                  const bTime = new Date(b.started_at || b.created_at || 0);
+                  return bTime - aTime;
+                });
+
+                // A cancelled or skipped check run can be a superseded attempt
+                // from before a label/approval update. Prefer any successful
+                // run for the same SHA, otherwise an active run, otherwise a
+                // real completed failure.
+                const successful = nameRuns.find(
+                  (run) => run.status === "completed" && run.conclusion === "success"
+                );
+                const active = nameRuns.find((run) => run.status !== "completed");
+                const failed = nameRuns.find(
+                  (run) =>
+                    run.status === "completed" &&
+                    !["cancelled", "skipped", "neutral", "success"].includes(run.conclusion)
+                );
+                const effective = successful || active || failed;
+                if (effective) {
+                  latest.set(name, effective);
                 }
               }
 

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -26,6 +26,9 @@ name: RunPod tenferro-rs GPU Test
 #     become readable from, the pod itself. Automatic PR runs are started only
 #     by `workflow_run`, after `authorize` gates the run to same-repo
 #     maintainer/admin PRs.
+#   * This workflow owns the required `CI GPU gate` check. The legacy
+#     `.github/workflows/CI_gpu.yml` workflow is manual-only and must not also
+#     run automatically on PRs.
 # ---------------------------------------------------------------------------
 
 on:
@@ -1288,3 +1291,55 @@ jobs:
           fi
 
           echo "Deleted RunPod pod: ${POD_ID}"
+
+  ci-gpu-gate:
+    name: CI GPU gate
+    needs:
+      - authorize
+      - pre-runpod-gate
+      - cuda-archive
+      - start-runpod
+      - run-gpu-tests
+      - cleanup-runpod
+
+    if: always()
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check RunPod GPU workflow result
+        env:
+          AUTHORIZE_RESULT: ${{ needs.authorize.result }}
+          PRE_RUNPOD_GATE_RESULT: ${{ needs.pre-runpod-gate.result }}
+          CUDA_ARCHIVE_RESULT: ${{ needs.cuda-archive.result }}
+          START_RUNPOD_RESULT: ${{ needs.start-runpod.result }}
+          RUN_GPU_TESTS_RESULT: ${{ needs.run-gpu-tests.result }}
+          CLEANUP_RUNPOD_RESULT: ${{ needs.cleanup-runpod.result }}
+        run: |
+          set -euo pipefail
+
+          failed=0
+          check_result() {
+            local name="$1"
+            local result="$2"
+            if [ "${result}" != "success" ]; then
+              echo "::error::${name} concluded ${result}; RunPod GPU gate failed."
+              failed=1
+            else
+              echo "OK: ${name} succeeded."
+            fi
+          }
+
+          check_result "Authorize RunPod GPU run" "${AUTHORIZE_RESULT}"
+          check_result "Wait for review and non-GPU CI" "${PRE_RUNPOD_GATE_RESULT}"
+          check_result "CUDA test archive" "${CUDA_ARCHIVE_RESULT}"
+          check_result "Start RunPod org runner" "${START_RUNPOD_RESULT}"
+          check_result "CUDA GPU tests on RunPod" "${RUN_GPU_TESTS_RESULT}"
+          check_result "Delete RunPod pod" "${CLEANUP_RUNPOD_RESULT}"
+
+          if [ "${failed}" -ne 0 ]; then
+            exit 1
+          fi
+
+          echo "CI_GPU_GATE_OK"

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -54,7 +54,6 @@ env:
   CARGO_TERM_COLOR: always
   CUBECL_DEBUG_LOG: "0"
   CUDA_ARCHIVE: cuda-tests.tar.zst
-  TENFERRO_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tenferro_ref || format('refs/pull/{0}/merge', github.event.workflow_run.pull_requests[0].number) }}
   # cudarc 0.19.x needs 12080 bindings; install CUDA_RUNTIME_VERSION toolkit when
   # archiving so embedded PTX matches RunPod driver cap (nvidia-smi CUDA 12.4).
   CUDARC_CUDA_VERSION: "12080"
@@ -73,11 +72,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
+    outputs:
+      tenferro_ref: ${{ steps.resolve_ref.outputs.tenferro_ref }}
+
     steps:
       - name: Check actor and PR source are allowed
+        id: resolve_ref
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
+          MANUAL_TENFERRO_REF: ${{ inputs.tenferro_ref || 'main' }}
           WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event || '' }}
           WORKFLOW_RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
         run: |
@@ -108,6 +112,8 @@ jobs:
             fi
 
             pr_number="$(jq -r '.[0].number // empty' <<<"${WORKFLOW_RUN_PULL_REQUESTS}")"
+            trigger_head_sha="$(jq -r '.[0].head.sha // empty' <<<"${WORKFLOW_RUN_PULL_REQUESTS}")"
+            trigger_base_sha="$(jq -r '.[0].base.sha // empty' <<<"${WORKFLOW_RUN_PULL_REQUESTS}")"
             if [ -z "${pr_number}" ]; then
               echo "::error::workflow_run did not include an associated pull request."
               exit 1
@@ -116,16 +122,37 @@ jobs:
             pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}")"
             pr_author="$(jq -r '.user.login' <<<"${pr_json}")"
             pr_head_repo="$(jq -r '.head.repo.full_name' <<<"${pr_json}")"
+            pr_head_sha="$(jq -r '.head.sha' <<<"${pr_json}")"
+            pr_base_sha="$(jq -r '.base.sha' <<<"${pr_json}")"
 
             if [ "${pr_head_repo}" != "${GITHUB_REPOSITORY}" ]; then
               echo "::error::Fork PRs are not allowed to launch RunPod CI (${pr_head_repo} -> ${GITHUB_REPOSITORY})."
               exit 1
             fi
 
+            if [ -n "${trigger_head_sha}" ] && [ "${pr_head_sha}" != "${trigger_head_sha}" ]; then
+              echo "::error::PR #${pr_number} head changed after the triggering CI run (${trigger_head_sha} -> ${pr_head_sha}); refusing to launch RunPod."
+              exit 1
+            fi
+            if [ -n "${trigger_base_sha}" ] && [ "${pr_base_sha}" != "${trigger_base_sha}" ]; then
+              echo "::error::PR #${pr_number} base changed after the triggering CI run (${trigger_base_sha} -> ${pr_base_sha}); refusing to launch RunPod."
+              exit 1
+            fi
+
             check_permission "${pr_author}" "PR author"
+
+            merge_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/pull/${pr_number}/merge" --jq .object.sha)"
+            if [ -z "${merge_sha}" ] || [ "${merge_sha}" = "null" ]; then
+              echo "::error::Failed to resolve refs/pull/${pr_number}/merge."
+              exit 1
+            fi
+
+            echo "Pinned PR #${pr_number} merge ref to ${merge_sha}."
+            echo "tenferro_ref=${merge_sha}" >> "${GITHUB_OUTPUT}"
           else
             # Manual dispatch relies on the triggering actor check.
             check_permission "${GITHUB_ACTOR}" "Workflow actor"
+            echo "tenferro_ref=${MANUAL_TENFERRO_REF}" >> "${GITHUB_OUTPUT}"
           fi
 
   pre-runpod-gate:
@@ -236,8 +263,12 @@ jobs:
 
   cuda-archive:
     name: CUDA test archive
+    needs: authorize
     runs-on: ubuntu-22.04
     timeout-minutes: 60
+
+    env:
+      TENFERRO_REF: ${{ needs.authorize.outputs.tenferro_ref }}
 
     outputs:
       archive_cache_key: ${{ steps.archive_key.outputs.key }}
@@ -842,8 +873,12 @@ jobs:
   run-gpu-tests:
     name: CUDA GPU tests on RunPod
     needs:
+      - authorize
       - cuda-archive
       - start-runpod
+
+    env:
+      TENFERRO_REF: ${{ needs.authorize.outputs.tenferro_ref }}
 
     runs-on:
       - self-hosted

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -51,7 +51,7 @@ env:
   CARGO_TERM_COLOR: always
   CUBECL_DEBUG_LOG: "0"
   CUDA_ARCHIVE: cuda-tests.tar.zst
-  TENFERRO_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tenferro_ref || github.event.pull_request.head.sha || github.sha }}
+  TENFERRO_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tenferro_ref || github.sha }}
   # cudarc 0.19.x needs 12080 bindings; install CUDA_RUNTIME_VERSION toolkit when
   # archiving so embedded PTX matches RunPod driver cap (nvidia-smi CUDA 12.4).
   CUDARC_CUDA_VERSION: "12080"

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -149,6 +149,22 @@ jobs:
               exit 1
             fi
 
+            # Re-read the PR after resolving the moving merge ref. Without
+            # this second check, a push between the first PR read and the merge
+            # ref lookup could make the pinned merge SHA belong to a newer
+            # head/base pair than the CI run that triggered this workflow.
+            refreshed_pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}")"
+            refreshed_head_sha="$(jq -r '.head.sha' <<<"${refreshed_pr_json}")"
+            refreshed_base_sha="$(jq -r '.base.sha' <<<"${refreshed_pr_json}")"
+            if [ -n "${trigger_head_sha}" ] && [ "${refreshed_head_sha}" != "${trigger_head_sha}" ]; then
+              echo "::error::PR #${pr_number} head changed while resolving the merge SHA (${trigger_head_sha} -> ${refreshed_head_sha}); refusing to launch RunPod."
+              exit 1
+            fi
+            if [ -n "${trigger_base_sha}" ] && [ "${refreshed_base_sha}" != "${trigger_base_sha}" ]; then
+              echo "::error::PR #${pr_number} base changed while resolving the merge SHA (${trigger_base_sha} -> ${refreshed_base_sha}); refusing to launch RunPod."
+              exit 1
+            fi
+
             echo "Pinned PR #${pr_number} merge ref to ${merge_sha}."
             echo "tenferro_ref=${merge_sha}" >> "${GITHUB_OUTPUT}"
           else

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -13,9 +13,11 @@ name: RunPod tenferro-rs GPU Test
 #     process, so fork code must never reach the self-hosted runner.
 #   * NEVER add `pull_request_target` to this workflow: that would combine base
 #     repository secrets with PR-controlled refs.
-#   * Top-level `permissions: contents: read` must never grow. In particular,
-#     never add `id-token: write` or any write scope to a job that runs on
-#     the self-hosted RunPod runner (`run-gpu-tests`).
+#   * Top-level permissions must stay read-only. In particular, never add
+#     `id-token: write` or any write scope to a job that runs on the
+#     self-hosted RunPod runner (`run-gpu-tests`). `checks: read` is present
+#     only so the GitHub-hosted pre-RunPod gate can wait for cheap CI before
+#     any paid pod is created.
 #   * `RUNPOD_API_KEY` (and the GitHub App credentials used to mint the JIT
 #     runner config) must only ever be read in GitHub-hosted jobs
 #     (`start-runpod`, `cleanup-runpod`). Neither may ever be passed to, or
@@ -40,6 +42,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  checks: read
   contents: read
 
 env:
@@ -71,6 +74,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login || '' }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
         run: |
           set -euo pipefail
@@ -80,17 +84,122 @@ jobs:
             exit 1
           fi
 
-          perm="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${GITHUB_ACTOR}/permission" --jq .permission)"
+          check_permission() {
+            local login="$1"
+            local role="$2"
+            local perm
 
-          case "${perm}" in
-            admin|maintain)
-              echo "OK: ${GITHUB_ACTOR} has '${perm}' permission and is allowed to launch RunPod CI."
-              ;;
-            *)
-              echo "::error::${GITHUB_ACTOR} has '${perm}' permission, which is not allowed to launch RunPod CI (requires admin or maintain)."
-              exit 1
-              ;;
-          esac
+            perm="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${login}/permission" --jq .permission)"
+
+            case "${perm}" in
+              admin|maintain)
+                echo "OK: ${role} ${login} has '${perm}' permission and is allowed to launch RunPod CI."
+                ;;
+              *)
+                echo "::error::${role} ${login} has '${perm}' permission, which is not allowed to launch RunPod CI (requires admin or maintain)."
+                exit 1
+                ;;
+            esac
+          }
+
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            check_permission "${PR_AUTHOR}" "PR author"
+          fi
+
+          # Keep checking the triggering actor too. Manual dispatch relies on
+          # this check, and PR reruns/synchronize events must not let a
+          # lower-trust actor trigger paid infrastructure for someone else's
+          # trusted branch.
+          check_permission "${GITHUB_ACTOR}" "Workflow actor"
+
+  pre-runpod-gate:
+    name: Wait for review and non-GPU CI
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Skip prerequisite gate for manual dispatch
+        if: github.event_name != 'pull_request'
+        run: echo "Manual dispatch is gated by the authorize job only."
+
+      - name: Wait for prerequisite checks
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Gate paid RunPod startup on checks that best predict a broken PR:
+            // repository policy, formatting, lint, coverage, and the full
+            // non-GPU workspace test aggregate. CUDA archive compilation still
+            // runs on a cheap hosted runner in parallel.
+            const required = [
+              "repository rules review",
+              "rustfmt",
+              "clippy",
+              "coverage",
+              "CI gate (PR workspace tests)",
+            ];
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const ref = context.payload.pull_request.head.sha;
+            const deadline = Date.now() + 85 * 60 * 1000;
+            const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            while (Date.now() < deadline) {
+              const runs = await github.paginate(github.rest.checks.listForRef, {
+                owner,
+                repo,
+                ref,
+                per_page: 100,
+              });
+
+              const latest = new Map();
+              for (const run of runs) {
+                if (!required.includes(run.name)) {
+                  continue;
+                }
+                const previous = latest.get(run.name);
+                const runTime = new Date(run.started_at || run.created_at || 0);
+                const previousTime = previous
+                  ? new Date(previous.started_at || previous.created_at || 0)
+                  : new Date(0);
+                if (!previous || runTime > previousTime) {
+                  latest.set(run.name, run);
+                }
+              }
+
+              const missing = required.filter((name) => !latest.has(name));
+              const pending = required.filter((name) => {
+                const run = latest.get(name);
+                return run && run.status !== "completed";
+              });
+              const failed = required.filter((name) => {
+                const run = latest.get(name);
+                return run && run.status === "completed" && run.conclusion !== "success";
+              });
+
+              if (failed.length > 0) {
+                for (const name of failed) {
+                  const run = latest.get(name);
+                  core.error(`${name} concluded ${run.conclusion}: ${run.html_url}`);
+                }
+                core.setFailed("A prerequisite review or non-GPU CI check failed.");
+                return;
+              }
+              if (missing.length === 0 && pending.length === 0) {
+                core.info(`All prerequisite checks passed: ${required.join(", ")}`);
+                return;
+              }
+
+              core.info(
+                `Waiting for prerequisite checks. Missing: ${missing.join(", ") || "none"}. ` +
+                  `Pending: ${pending.join(", ") || "none"}.`
+              );
+              await sleep(30_000);
+            }
+
+            core.setFailed(`Timed out waiting for prerequisite checks: ${required.join(", ")}`);
 
   cuda-archive:
     name: CUDA test archive
@@ -324,6 +433,7 @@ jobs:
     name: Start RunPod org runner
     needs:
       - authorize
+      - pre-runpod-gate
       - cuda-archive
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -154,18 +154,40 @@ jobs:
                 per_page: 100,
               });
 
-              const latest = new Map();
+              const candidates = new Map();
               for (const run of runs) {
                 if (!required.includes(run.name)) {
                   continue;
                 }
-                const previous = latest.get(run.name);
-                const runTime = new Date(run.started_at || run.created_at || 0);
-                const previousTime = previous
-                  ? new Date(previous.started_at || previous.created_at || 0)
-                  : new Date(0);
-                if (!previous || runTime > previousTime) {
-                  latest.set(run.name, run);
+                const nameRuns = candidates.get(run.name) || [];
+                nameRuns.push(run);
+                candidates.set(run.name, nameRuns);
+              }
+
+              const latest = new Map();
+              for (const name of required) {
+                const nameRuns = (candidates.get(name) || []).sort((a, b) => {
+                  const aTime = new Date(a.started_at || a.created_at || 0);
+                  const bTime = new Date(b.started_at || b.created_at || 0);
+                  return bTime - aTime;
+                });
+
+                // A cancelled or skipped check run can be a superseded attempt
+                // from before a label/approval update. Prefer any successful
+                // run for the same SHA, otherwise an active run, otherwise a
+                // real completed failure.
+                const successful = nameRuns.find(
+                  (run) => run.status === "completed" && run.conclusion === "success"
+                );
+                const active = nameRuns.find((run) => run.status !== "completed");
+                const failed = nameRuns.find(
+                  (run) =>
+                    run.status === "completed" &&
+                    !["cancelled", "skipped", "neutral", "success"].includes(run.conclusion)
+                );
+                const effective = successful || active || failed;
+                if (effective) {
+                  latest.set(name, effective);
                 }
               }
 

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -991,7 +991,7 @@ jobs:
           cargo nextest run \
             --archive-file "${CUDA_ARCHIVE}" \
             --workspace-remap "${GITHUB_WORKSPACE}/tenferro-rs" \
-            --run-ignored ignored-only \
+            --run-ignored all \
             --no-fail-fast \
             -j 1
 

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -19,7 +19,9 @@ name: RunPod tenferro-rs GPU Test
 #   * `RUNPOD_API_KEY` (and the GitHub App credentials used to mint the JIT
 #     runner config) must only ever be read in GitHub-hosted jobs
 #     (`start-runpod`, `cleanup-runpod`). Neither may ever be passed to, or
-#     become readable from, the pod itself.
+#     become readable from, the pod itself. PR-triggered runs are gated by the
+#     `authorize` job instead of the `runpod-gpu` environment because GitHub
+#     environment branch rules reject `refs/pull/*/merge`.
 # ---------------------------------------------------------------------------
 
 on:
@@ -324,7 +326,6 @@ jobs:
     needs:
       - authorize
       - cuda-archive
-    environment: runpod-gpu
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -1055,7 +1056,6 @@ jobs:
 
     if: always()
 
-    environment: runpod-gpu
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -8,7 +8,9 @@ name: RunPod tenferro-rs GPU Test
 #     self-hosted GitHub Actions runner. Self-hosted runners on a repo that
 #     accepts external contributions are a well-known escalation path
 #     (see GitHub's "Security hardening for GitHub Actions" guide).
-#   * PR-triggered runs MUST reject fork PRs before RunPod startup. The pod
+#   * PR-triggered runs enter through `workflow_run` from the trusted default
+#     branch workflow file, not through a PR-controlled `pull_request` copy of
+#     this workflow. They MUST reject fork PRs before RunPod startup. The pod
 #     executes the checked-out ref as root, in the same container as the runner
 #     process, so fork code must never reach the self-hosted runner.
 #   * NEVER add `pull_request_target` to this workflow: that would combine base
@@ -19,10 +21,11 @@ name: RunPod tenferro-rs GPU Test
 #     only so the GitHub-hosted pre-RunPod gate can wait for cheap CI before
 #     any paid pod is created.
 #   * `RUNPOD_API_KEY` (and the GitHub App credentials used to mint the JIT
-#     runner config) must only ever be read in GitHub-hosted jobs
+#     runner config) must only ever be read in trusted-base GitHub-hosted jobs
 #     (`start-runpod`, `cleanup-runpod`). Neither may ever be passed to, or
-#     become readable from, the pod itself. PR runs use repository secrets
-#     after `authorize` gates the run to same-repo maintainer/admin PRs.
+#     become readable from, the pod itself. Automatic PR runs are started only
+#     by `workflow_run`, after `authorize` gates the run to same-repo
+#     maintainer/admin PRs.
 # ---------------------------------------------------------------------------
 
 on:
@@ -33,9 +36,9 @@ on:
         required: false
         default: main
         type: string
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["CI PR workspace tests"]
+    types: [completed]
 
 concurrency:
   group: runpod-tenferro-gpu-${{ github.ref }}
@@ -51,7 +54,7 @@ env:
   CARGO_TERM_COLOR: always
   CUBECL_DEBUG_LOG: "0"
   CUDA_ARCHIVE: cuda-tests.tar.zst
-  TENFERRO_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tenferro_ref || github.sha }}
+  TENFERRO_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tenferro_ref || format('refs/pull/{0}/merge', github.event.workflow_run.pull_requests[0].number) }}
   # cudarc 0.19.x needs 12080 bindings; install CUDA_RUNTIME_VERSION toolkit when
   # archiving so embedded PTX matches RunPod driver cap (nvidia-smi CUDA 12.4).
   CUDARC_CUDA_VERSION: "12080"
@@ -66,6 +69,7 @@ env:
 jobs:
   authorize:
     name: Authorize RunPod GPU run
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -74,15 +78,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login || '' }}
-          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event || '' }}
+          WORKFLOW_RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
         run: |
           set -euo pipefail
-
-          if [ "${EVENT_NAME}" = "pull_request" ] && [ "${PR_HEAD_REPO}" != "${GITHUB_REPOSITORY}" ]; then
-            echo "::error::Fork PRs are not allowed to launch RunPod CI (${PR_HEAD_REPO} -> ${GITHUB_REPOSITORY})."
-            exit 1
-          fi
 
           check_permission() {
             local login="$1"
@@ -98,19 +97,36 @@ jobs:
               *)
                 echo "::error::${role} ${login} has '${perm}' permission, which is not allowed to launch RunPod CI (requires admin or maintain)."
                 exit 1
-                ;;
+              ;;
             esac
           }
 
-          if [ "${EVENT_NAME}" = "pull_request" ]; then
-            check_permission "${PR_AUTHOR}" "PR author"
-          fi
+          if [ "${EVENT_NAME}" = "workflow_run" ]; then
+            if [ "${WORKFLOW_RUN_EVENT}" != "pull_request" ]; then
+              echo "::error::RunPod CI workflow_run events must come from pull_request workflows, got '${WORKFLOW_RUN_EVENT}'."
+              exit 1
+            fi
 
-          # Keep checking the triggering actor too. Manual dispatch relies on
-          # this check, and PR reruns/synchronize events must not let a
-          # lower-trust actor trigger paid infrastructure for someone else's
-          # trusted branch.
-          check_permission "${GITHUB_ACTOR}" "Workflow actor"
+            pr_number="$(jq -r '.[0].number // empty' <<<"${WORKFLOW_RUN_PULL_REQUESTS}")"
+            if [ -z "${pr_number}" ]; then
+              echo "::error::workflow_run did not include an associated pull request."
+              exit 1
+            fi
+
+            pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}")"
+            pr_author="$(jq -r '.user.login' <<<"${pr_json}")"
+            pr_head_repo="$(jq -r '.head.repo.full_name' <<<"${pr_json}")"
+
+            if [ "${pr_head_repo}" != "${GITHUB_REPOSITORY}" ]; then
+              echo "::error::Fork PRs are not allowed to launch RunPod CI (${pr_head_repo} -> ${GITHUB_REPOSITORY})."
+              exit 1
+            fi
+
+            check_permission "${pr_author}" "PR author"
+          else
+            # Manual dispatch relies on the triggering actor check.
+            check_permission "${GITHUB_ACTOR}" "Workflow actor"
+          fi
 
   pre-runpod-gate:
     name: Wait for review and non-GPU CI
@@ -120,11 +136,11 @@ jobs:
 
     steps:
       - name: Skip prerequisite gate for manual dispatch
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'workflow_run'
         run: echo "Manual dispatch is gated by the authorize job only."
 
       - name: Wait for prerequisite checks
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'workflow_run'
         uses: actions/github-script@v7
         with:
           script: |
@@ -142,7 +158,7 @@ jobs:
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const ref = context.payload.pull_request.head.sha;
+            const ref = context.payload.workflow_run.head_sha;
             const deadline = Date.now() + 85 * 60 * 1000;
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -172,20 +188,15 @@ jobs:
                   return bTime - aTime;
                 });
 
-                // A cancelled or skipped check run can be a superseded attempt
-                // from before a label/approval update. Prefer any successful
-                // run for the same SHA, otherwise an active run, otherwise a
-                // real completed failure.
-                const successful = nameRuns.find(
-                  (run) => run.status === "completed" && run.conclusion === "success"
-                );
-                const active = nameRuns.find((run) => run.status !== "completed");
-                const failed = nameRuns.find(
+                // Cancelled or skipped runs can be superseded attempts from
+                // before a label/approval update. Use the newest current
+                // candidate instead of letting an older success mask a newer
+                // active or failed run.
+                const effective = nameRuns.find(
                   (run) =>
-                    run.status === "completed" &&
-                    !["cancelled", "skipped", "neutral", "success"].includes(run.conclusion)
+                    run.status !== "completed" ||
+                    !["cancelled", "skipped"].includes(run.conclusion)
                 );
-                const effective = successful || active || failed;
                 if (effective) {
                   latest.set(name, effective);
                 }

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -19,7 +19,8 @@ name: RunPod tenferro-rs GPU Test
 #   * `RUNPOD_API_KEY` (and the GitHub App credentials used to mint the JIT
 #     runner config) must only ever be read in GitHub-hosted jobs
 #     (`start-runpod`, `cleanup-runpod`). Neither may ever be passed to, or
-#     become readable from, the pod itself.
+#     become readable from, the pod itself. PR runs use repository secrets
+#     after `authorize` gates the run to same-repo maintainer/admin PRs.
 # ---------------------------------------------------------------------------
 
 on:
@@ -324,7 +325,6 @@ jobs:
     needs:
       - authorize
       - cuda-archive
-    environment: runpod-gpu
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -1055,7 +1055,6 @@ jobs:
 
     if: always()
 
-    environment: runpod-gpu
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -68,7 +68,7 @@ env:
 jobs:
   authorize:
     name: Authorize RunPod GPU run
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request')
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -82,6 +82,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           MANUAL_TENFERRO_REF: ${{ inputs.tenferro_ref || 'main' }}
+          WORKFLOW_RUN_ACTOR: ${{ github.event.workflow_run.actor.login || '' }}
           WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event || '' }}
           WORKFLOW_RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
         run: |
@@ -140,6 +141,7 @@ jobs:
             fi
 
             check_permission "${pr_author}" "PR author"
+            check_permission "${WORKFLOW_RUN_ACTOR}" "Source workflow actor"
 
             merge_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/pull/${pr_number}/merge" --jq .object.sha)"
             if [ -z "${merge_sha}" ] || [ "${merge_sha}" = "null" ]; then

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -26,9 +26,6 @@ name: RunPod tenferro-rs GPU Test
 #     become readable from, the pod itself. Automatic PR runs are started only
 #     by `workflow_run`, after `authorize` gates the run to same-repo
 #     maintainer/admin PRs.
-#   * This workflow owns the required `CI GPU gate` check. The legacy
-#     `.github/workflows/CI_gpu.yml` workflow is manual-only and must not also
-#     run automatically on PRs.
 # ---------------------------------------------------------------------------
 
 on:
@@ -1291,55 +1288,3 @@ jobs:
           fi
 
           echo "Deleted RunPod pod: ${POD_ID}"
-
-  ci-gpu-gate:
-    name: CI GPU gate
-    needs:
-      - authorize
-      - pre-runpod-gate
-      - cuda-archive
-      - start-runpod
-      - run-gpu-tests
-      - cleanup-runpod
-
-    if: always()
-
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: Check RunPod GPU workflow result
-        env:
-          AUTHORIZE_RESULT: ${{ needs.authorize.result }}
-          PRE_RUNPOD_GATE_RESULT: ${{ needs.pre-runpod-gate.result }}
-          CUDA_ARCHIVE_RESULT: ${{ needs.cuda-archive.result }}
-          START_RUNPOD_RESULT: ${{ needs.start-runpod.result }}
-          RUN_GPU_TESTS_RESULT: ${{ needs.run-gpu-tests.result }}
-          CLEANUP_RUNPOD_RESULT: ${{ needs.cleanup-runpod.result }}
-        run: |
-          set -euo pipefail
-
-          failed=0
-          check_result() {
-            local name="$1"
-            local result="$2"
-            if [ "${result}" != "success" ]; then
-              echo "::error::${name} concluded ${result}; RunPod GPU gate failed."
-              failed=1
-            else
-              echo "OK: ${name} succeeded."
-            fi
-          }
-
-          check_result "Authorize RunPod GPU run" "${AUTHORIZE_RESULT}"
-          check_result "Wait for review and non-GPU CI" "${PRE_RUNPOD_GATE_RESULT}"
-          check_result "CUDA test archive" "${CUDA_ARCHIVE_RESULT}"
-          check_result "Start RunPod org runner" "${START_RUNPOD_RESULT}"
-          check_result "CUDA GPU tests on RunPod" "${RUN_GPU_TESTS_RESULT}"
-          check_result "Delete RunPod pod" "${CLEANUP_RUNPOD_RESULT}"
-
-          if [ "${failed}" -ne 0 ]; then
-            exit 1
-          fi
-
-          echo "CI_GPU_GATE_OK"

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -19,9 +19,7 @@ name: RunPod tenferro-rs GPU Test
 #   * `RUNPOD_API_KEY` (and the GitHub App credentials used to mint the JIT
 #     runner config) must only ever be read in GitHub-hosted jobs
 #     (`start-runpod`, `cleanup-runpod`). Neither may ever be passed to, or
-#     become readable from, the pod itself. PR-triggered runs are gated by the
-#     `authorize` job instead of the `runpod-gpu` environment because GitHub
-#     environment branch rules reject `refs/pull/*/merge`.
+#     become readable from, the pod itself.
 # ---------------------------------------------------------------------------
 
 on:
@@ -326,6 +324,7 @@ jobs:
     needs:
       - authorize
       - cuda-archive
+    environment: runpod-gpu
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -1056,6 +1055,7 @@ jobs:
 
     if: always()
 
+    environment: runpod-gpu
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -48,7 +48,7 @@ env:
   # archiving so embedded PTX matches RunPod driver cap (nvidia-smi CUDA 12.4).
   CUDARC_CUDA_VERSION: "12080"
   CUDA_RUNTIME_VERSION: "12.4"
-  ARCHIVE_WORKSPACE_ROOT: /home/runner/work/hello-world-runpod/hello-world-runpod
+  ARCHIVE_WORKSPACE_ROOT: /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}
   CUTENSOR_VERSION: "2.6.0.4"
   JAX_CUDA12_PJRT_VERSION: "0.10.2"
   NVIDIA_CUDNN_CU12_VERSION: "9.23.2.1"
@@ -984,7 +984,7 @@ jobs:
           cargo nextest run \
             --archive-file "${CUDA_ARCHIVE}" \
             --workspace-remap "${GITHUB_WORKSPACE}/tenferro-rs" \
-            --run-ignored all \
+            --run-ignored ignored-only \
             --no-fail-fast \
             -j 1
 

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -8,11 +8,11 @@ name: RunPod tenferro-rs GPU Test
 #     self-hosted GitHub Actions runner. Self-hosted runners on a repo that
 #     accepts external contributions are a well-known escalation path
 #     (see GitHub's "Security hardening for GitHub Actions" guide).
-#   * Triggers MUST remain `workflow_dispatch` (optionally also `schedule`).
-#     NEVER add `pull_request` or `pull_request_target` to this workflow: the
-#     pod executes the checked-out ref as root, in the same container as the
-#     runner process, so a PR-triggered run (especially from a fork) would
-#     hand arbitrary code a path to the runner's credentials.
+#   * PR-triggered runs MUST reject fork PRs before RunPod startup. The pod
+#     executes the checked-out ref as root, in the same container as the runner
+#     process, so fork code must never reach the self-hosted runner.
+#   * NEVER add `pull_request_target` to this workflow: that would combine base
+#     repository secrets with PR-controlled refs.
 #   * Top-level `permissions: contents: read` must never grow. In particular,
 #     never add `id-token: write` or any write scope to a job that runs on
 #     the self-hosted RunPod runner (`run-gpu-tests`).
@@ -30,6 +30,9 @@ on:
         required: false
         default: main
         type: string
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: runpod-tenferro-gpu-${{ github.ref }}
@@ -44,6 +47,7 @@ env:
   CARGO_TERM_COLOR: always
   CUBECL_DEBUG_LOG: "0"
   CUDA_ARCHIVE: cuda-tests.tar.zst
+  TENFERRO_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.tenferro_ref || github.event.pull_request.head.sha || github.sha }}
   # cudarc 0.19.x needs 12080 bindings; install CUDA_RUNTIME_VERSION toolkit when
   # archiving so embedded PTX matches RunPod driver cap (nvidia-smi CUDA 12.4).
   CUDARC_CUDA_VERSION: "12080"
@@ -57,22 +61,29 @@ env:
 
 jobs:
   authorize:
-    name: Authorize dispatch actor
+    name: Authorize RunPod GPU run
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-      - name: Check dispatching actor is a maintainer
+      - name: Check actor and PR source are allowed
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
         run: |
           set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "pull_request" ] && [ "${PR_HEAD_REPO}" != "${GITHUB_REPOSITORY}" ]; then
+            echo "::error::Fork PRs are not allowed to launch RunPod CI (${PR_HEAD_REPO} -> ${GITHUB_REPOSITORY})."
+            exit 1
+          fi
 
           perm="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${GITHUB_ACTOR}/permission" --jq .permission)"
 
           case "${perm}" in
             admin|maintain)
-              echo "OK: ${GITHUB_ACTOR} has '${perm}' permission; allowed to launch RunPod CI."
+              echo "OK: ${GITHUB_ACTOR} has '${perm}' permission and is allowed to launch RunPod CI."
               ;;
             *)
               echo "::error::${GITHUB_ACTOR} has '${perm}' permission, which is not allowed to launch RunPod CI (requires admin or maintain)."
@@ -93,7 +104,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ env.TENFERRO_REPO }}
-          ref: ${{ inputs.tenferro_ref }}
+          ref: ${{ env.TENFERRO_REF }}
           path: tenferro-rs
 
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master (2026-07-07)
@@ -230,8 +241,6 @@ jobs:
 
       - name: Compute CUDA archive cache key
         id: archive_key
-        env:
-          TENFERRO_REF: ${{ inputs.tenferro_ref }}
         run: |
           set -euo pipefail
           key="cuda-archive-v8-ubuntu22.04-cuda${CUDARC_CUDA_VERSION}-ptx${CUDA_RUNTIME_VERSION}-${TENFERRO_REF}-${{ hashFiles('tenferro-rs/Cargo.lock', 'tenferro-rs/**/Cargo.toml', 'tenferro-rs/**/src/**', 'tenferro-rs/**/tests/**') }}"
@@ -704,7 +713,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ env.TENFERRO_REPO }}
-          ref: ${{ inputs.tenferro_ref }}
+          ref: ${{ env.TENFERRO_REF }}
           path: tenferro-rs
 
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master (2026-07-07)
@@ -738,8 +747,6 @@ jobs:
           tool: nextest
 
       - name: Check machine
-        env:
-          TENFERRO_REF: ${{ inputs.tenferro_ref }}
         run: |
           set -euxo pipefail
           echo "tenferro-rs ref: ${TENFERRO_REF}"


### PR DESCRIPTION
## Summary

- run archived CUDA nextest tests with `--run-ignored ignored-only` so the GPU lane executes only ignored GPU tests instead of rerunning normal tests too
- derive the RunPod archive workspace path from `github.event.repository.name` instead of the local `hello-world-runpod` checkout name

## Context

The failing RunPod job was https://github.com/tensor4all/tenferro-rs/actions/runs/29031259017/job/86165137261. The public job metadata shows `Run CUDA tests from archive` failed with exit code 100. The raw job log endpoint requires repository admin rights, so the exact failing test output was not available locally.

## Verification

- Reviewed `REPOSITORY_RULES.md` before PR creation
- Inspected the workflow diff
- Did not run the GPU workflow locally
