### PR TITLE
Retire CI_gpu PR gate in favor of RunPod

### DIFF
--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -2,10 +2,12 @@ name: CI_gpu
 
 # Retired from automatic same-repo PR gating by issue #1341. RunPod now owns the
 # branch-protection-required `CI GPU gate` check for eligible maintainer PRs.
-# Keep this workflow as the automatic fork-PR path because base-repo Checks API
-# writes cannot attach `CI GPU gate` to fork commits. It also remains a manual
-# legacy fallback for comparing the org larger GPU runner (`ubuntu-gpu`) with
-# RunPod while the migration settles.
+# Keep this workflow as the PR-attached `CI GPU gate` wrapper: same-repo PRs wait
+# for the trusted RunPod check published by `runpod-gpu-test.yml`, while fork PRs
+# use the legacy `ubuntu-gpu` path because base-repo Checks API writes cannot
+# attach `CI GPU gate` to fork commits. It also remains a manual legacy fallback
+# for comparing the org larger GPU runner with RunPod while the migration
+# settles.
 
 on:
   pull_request:
@@ -516,19 +518,94 @@ jobs:
             cargo test -p tenferro-xla --features pjrt --test pjrt_execution -- --nocapture
 
   cuda-gate:
-    name: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'CI GPU gate' || 'CI GPU legacy manual gate' }}
+    name: CI GPU gate
     needs: [cuda-archive, pre-gpu-gate, cuda-run]
     if: >-
       always() &&
       !cancelled() &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name != github.repository)
-      )
+      github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Require CUDA GPU tests
+      - name: Require fork CUDA GPU tests or same-repo RunPod gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CURRENT_RUN_MARKER: /actions/runs/${{ github.run_id }}
+          ARCHIVE_RESULT: ${{ needs.cuda-archive.result }}
+          PRE_GPU_RESULT: ${{ needs.pre-gpu-gate.result }}
+          CUDA_RESULT: ${{ needs.cuda-run.result }}
+        run: |
+          set -euo pipefail
+
+          if [ "${HEAD_REPO}" != "${GITHUB_REPOSITORY}" ]; then
+            if [ "${PRE_GPU_RESULT}" != "success" ]; then
+              echo "Expected pre-gpu-gate to succeed; got pre-gpu-gate=${PRE_GPU_RESULT}"
+              exit 1
+            fi
+            if [ "${ARCHIVE_RESULT}" != "success" ]; then
+              echo "Expected cuda-archive to succeed; got cuda-archive=${ARCHIVE_RESULT}"
+              exit 1
+            fi
+            if [ "${CUDA_RESULT}" = "success" ]; then
+              exit 0
+            fi
+            echo "Expected cuda-run to succeed on ubuntu-gpu; got cuda-run=${CUDA_RESULT}"
+            exit 1
+          fi
+
+          deadline=$((SECONDS + 90 * 60))
+          while [ "${SECONDS}" -lt "${deadline}" ]; do
+            checks_file="$(mktemp)"
+            gh api \
+              --method GET \
+              "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs" \
+              -f check_name="CI GPU gate" \
+              --jq . > "${checks_file}"
+
+            run_json="$(
+              jq -c --arg current "${CURRENT_RUN_MARKER}" '
+                .check_runs
+                | map(select((((.details_url // "") | contains($current)) | not)))
+                | sort_by(.started_at // .created_at // "")
+                | reverse
+                | .[0] // empty
+              ' "${checks_file}"
+            )"
+
+            if [ -n "${run_json}" ]; then
+              status="$(jq -r '.status' <<<"${run_json}")"
+              conclusion="$(jq -r '.conclusion // ""' <<<"${run_json}")"
+              url="$(jq -r '.details_url // .html_url // ""' <<<"${run_json}")"
+              if [ "${status}" = "completed" ] && [ "${conclusion}" = "success" ]; then
+                echo "RunPod CI GPU gate passed: ${url}"
+                exit 0
+              fi
+              if [ "${status}" = "completed" ]; then
+                echo "RunPod CI GPU gate concluded ${conclusion}: ${url}"
+                exit 1
+              fi
+              echo "Waiting for RunPod CI GPU gate (${status}): ${url}"
+            else
+              echo "Waiting for RunPod CI GPU gate on ${HEAD_SHA}."
+            fi
+
+            sleep 30
+          done
+
+          echo "Timed out waiting for RunPod CI GPU gate on ${HEAD_SHA}."
+          exit 1
+
+  cuda-gate-manual:
+    name: CI GPU legacy manual gate
+    needs: [cuda-archive, pre-gpu-gate, cuda-run]
+    if: >-
+      always() &&
+      !cancelled() &&
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require manual CUDA GPU tests
         env:
           ARCHIVE_RESULT: ${{ needs.cuda-archive.result }}
           PRE_GPU_RESULT: ${{ needs.pre-gpu-gate.result }}

--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -1,15 +1,18 @@
 name: CI_gpu
 
-# Build the CUDA test archive on a cheap non-GPU runner IN PARALLEL with the
-# repository-policy and non-GPU CI checks, then execute CUDA-feature GPU tests
-# on the org larger GPU runner `ubuntu-gpu` only after those checks pass, to
-# minimize GPU billing. Only the GPU runner (`cuda-run`) is gated behind
-# `pre-gpu-gate`; the archive build is not, so the GPU stage can start the
-# moment the gate clears instead of waiting for the archive to compile.
+# Retired from automatic PR gating by issue #1341. RunPod now owns the
+# branch-protection-required `CI GPU gate` check for eligible maintainer PRs.
+# Keep this workflow as a manual legacy fallback for comparing the org larger
+# GPU runner (`ubuntu-gpu`) with RunPod while the migration settles.
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      tenferro_ref:
+        description: tenferro-rs git ref, branch, tag, or SHA to validate on ubuntu-gpu
+        required: false
+        default: main
+        type: string
 
 permissions:
   actions: read
@@ -33,11 +36,16 @@ env:
 jobs:
   pre-gpu-gate:
     name: Wait for review and non-GPU CI
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
+      - name: Manual fallback does not wait for PR checks
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "CI_gpu.yml is a manual legacy fallback; RunPod owns the PR CI GPU gate."
+
       - name: Wait for prerequisite checks
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -144,6 +152,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tenferro_ref }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Compute CUDA archive cache key
         id: archive_key
@@ -205,7 +215,6 @@ jobs:
   cuda-run:
     name: CUDA tests (${{ matrix.gpu_vendor }})
     needs: [pre-gpu-gate, cuda-archive]
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-gpu
     timeout-minutes: 45
     strategy:
@@ -489,7 +498,7 @@ jobs:
             cargo test -p tenferro-xla --features pjrt --test pjrt_execution -- --nocapture
 
   cuda-gate:
-    name: CI GPU gate
+    name: CI GPU legacy manual gate
     needs: [cuda-archive, pre-gpu-gate, cuda-run]
     if: always() && !cancelled()
     runs-on: ubuntu-latest
@@ -499,17 +508,8 @@ jobs:
           ARCHIVE_RESULT: ${{ needs.cuda-archive.result }}
           PRE_GPU_RESULT: ${{ needs.pre-gpu-gate.result }}
           CUDA_RESULT: ${{ needs.cuda-run.result }}
-          IS_FORK_PR: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           set -euo pipefail
-          if [ "${IS_FORK_PR}" = "true" ]; then
-            if [ "${ARCHIVE_RESULT}" != "success" ]; then
-              echo "Expected cuda-archive to succeed for fork PR; got cuda-archive=${ARCHIVE_RESULT}"
-              exit 1
-            fi
-            echo "Fork PR: GPU tests skipped on the org larger GPU runner; archive build passed."
-            exit 0
-          fi
           if [ "${PRE_GPU_RESULT}" != "success" ]; then
             echo "Expected pre-gpu-gate to succeed; got pre-gpu-gate=${PRE_GPU_RESULT}"
             exit 1

--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -1,11 +1,15 @@
 name: CI_gpu
 
-# Retired from automatic PR gating by issue #1341. RunPod now owns the
+# Retired from automatic same-repo PR gating by issue #1341. RunPod now owns the
 # branch-protection-required `CI GPU gate` check for eligible maintainer PRs.
-# Keep this workflow as a manual legacy fallback for comparing the org larger
-# GPU runner (`ubuntu-gpu`) with RunPod while the migration settles.
+# Keep this workflow as the automatic fork-PR path because base-repo Checks API
+# writes cannot attach `CI GPU gate` to fork commits. It also remains a manual
+# legacy fallback for comparing the org larger GPU runner (`ubuntu-gpu`) with
+# RunPod while the migration settles.
 
 on:
+  pull_request:
+    branches: [main]
   workflow_dispatch:
     inputs:
       tenferro_ref:
@@ -36,6 +40,10 @@ env:
 jobs:
   pre-gpu-gate:
     name: Wait for review and non-GPU CI
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -143,6 +151,10 @@ jobs:
 
   cuda-archive:
     name: CUDA test archive
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name != github.repository)
     # NOT gated on pre-gpu-gate: this build runs on a cheap non-GPU runner, so
     # it compiles in parallel with the non-GPU CI + repository review to keep it
     # off the critical path. The expensive GPU runner is still gated -- `cuda-run`
@@ -153,7 +165,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.tenferro_ref }}
+          ref: ${{ inputs.tenferro_ref || github.ref }}
       - uses: dtolnay/rust-toolchain@stable
       - name: Compute CUDA archive cache key
         id: archive_key
@@ -215,6 +227,10 @@ jobs:
   cuda-run:
     name: CUDA tests (${{ matrix.gpu_vendor }})
     needs: [pre-gpu-gate, cuda-archive]
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-gpu
     timeout-minutes: 45
     strategy:
@@ -228,7 +244,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.tenferro_ref }}
+          ref: ${{ inputs.tenferro_ref || github.ref }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/download-artifact@v4
         with:
@@ -500,9 +516,16 @@ jobs:
             cargo test -p tenferro-xla --features pjrt --test pjrt_execution -- --nocapture
 
   cuda-gate:
-    name: CI GPU legacy manual gate
+    name: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'CI GPU gate' || 'CI GPU legacy manual gate' }}
     needs: [cuda-archive, pre-gpu-gate, cuda-run]
-    if: always() && !cancelled()
+    if: >-
+      always() &&
+      !cancelled() &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository)
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Require CUDA GPU tests

--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -227,6 +227,8 @@ jobs:
           #   if: false
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tenferro_ref }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -40,6 +40,11 @@ on:
         required: false
         default: main
         type: string
+      ci_gpu_gate_head_sha:
+        description: Optional PR head SHA to publish the CI GPU gate check to
+        required: false
+        default: ""
+        type: string
   workflow_run:
     workflows: ["CI PR workspace tests"]
     types: [completed]
@@ -1317,6 +1322,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
+          MANUAL_GATE_HEAD_SHA: ${{ inputs.ci_gpu_gate_head_sha || '' }}
           WORKFLOW_RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           AUTHORIZE_RESULT: ${{ needs.authorize.result }}
@@ -1358,6 +1364,8 @@ jobs:
           target_sha=""
           if [ "${EVENT_NAME}" = "workflow_run" ]; then
             target_sha="$(jq -r '.[0].head.sha // empty' <<<"${WORKFLOW_RUN_PULL_REQUESTS}")"
+          elif [ -n "${MANUAL_GATE_HEAD_SHA}" ]; then
+            target_sha="${MANUAL_GATE_HEAD_SHA}"
           fi
 
           if [ -n "${target_sha}" ]; then

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -27,9 +27,10 @@ name: RunPod tenferro-rs GPU Test
 #     by `workflow_run`, after `authorize` gates the run to same-repo
 #     maintainer/admin PRs.
 #   * This workflow owns the branch-protection-required `CI GPU gate` check for
-#     eligible maintainer PRs by publishing that check to the PR head SHA from
-#     a GitHub-hosted final gate job. The legacy `CI_gpu.yml` workflow is
-#     manual-only.
+#     eligible same-repo maintainer PRs by publishing that check to the PR head
+#     SHA from a GitHub-hosted final gate job. Fork PRs keep using the legacy
+#     `CI_gpu.yml` pull_request path because base-repo Checks API writes cannot
+#     attach a check run to fork commits.
 # ---------------------------------------------------------------------------
 
 on:

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -27,7 +27,9 @@ name: RunPod tenferro-rs GPU Test
 #     by `workflow_run`, after `authorize` gates the run to same-repo
 #     maintainer/admin PRs.
 #   * This workflow owns the branch-protection-required `CI GPU gate` check for
-#     eligible maintainer PRs. The legacy `CI_gpu.yml` workflow is manual-only.
+#     eligible maintainer PRs by publishing that check to the PR head SHA from
+#     a GitHub-hosted final gate job. The legacy `CI_gpu.yml` workflow is
+#     manual-only.
 # ---------------------------------------------------------------------------
 
 on:
@@ -1292,7 +1294,7 @@ jobs:
           echo "Deleted RunPod pod: ${POD_ID}"
 
   ci-gpu-gate:
-    name: CI GPU gate
+    name: Publish CI GPU gate
     needs:
       - authorize
       - pre-runpod-gate
@@ -1306,9 +1308,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
+    permissions:
+      checks: write
+      contents: read
+
     steps:
-      - name: Require successful RunPod GPU validation and cleanup
+      - name: Publish required PR check
         env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           AUTHORIZE_RESULT: ${{ needs.authorize.result }}
           PRE_RUNPOD_RESULT: ${{ needs.pre-runpod-gate.result }}
           ARCHIVE_RESULT: ${{ needs.cuda-archive.result }}
@@ -1318,20 +1328,67 @@ jobs:
         run: |
           set -euo pipefail
 
-          require_success() {
+          failures_file="$(mktemp)"
+
+          record_result() {
             local job="$1"
             local result="$2"
             if [ "${result}" != "success" ]; then
               echo "::error::Expected ${job} to succeed; got ${result}."
-              exit 1
+              echo "- ${job}: ${result}" >> "${failures_file}"
             fi
           }
 
-          require_success "authorize" "${AUTHORIZE_RESULT}"
-          require_success "pre-runpod-gate" "${PRE_RUNPOD_RESULT}"
-          require_success "cuda-archive" "${ARCHIVE_RESULT}"
-          require_success "start-runpod" "${START_RUNPOD_RESULT}"
-          require_success "run-gpu-tests" "${RUN_GPU_TESTS_RESULT}"
-          require_success "cleanup-runpod" "${CLEANUP_RUNPOD_RESULT}"
+          record_result "authorize" "${AUTHORIZE_RESULT}"
+          record_result "pre-runpod-gate" "${PRE_RUNPOD_RESULT}"
+          record_result "cuda-archive" "${ARCHIVE_RESULT}"
+          record_result "start-runpod" "${START_RUNPOD_RESULT}"
+          record_result "run-gpu-tests" "${RUN_GPU_TESTS_RESULT}"
+          record_result "cleanup-runpod" "${CLEANUP_RUNPOD_RESULT}"
 
-          echo "RunPod GPU validation completed successfully and owns CI GPU gate."
+          conclusion="success"
+          title="RunPod CI GPU gate passed"
+          summary="RunPod GPU validation completed successfully and owns CI GPU gate."
+          if [ -s "${failures_file}" ]; then
+            conclusion="failure"
+            title="RunPod CI GPU gate failed"
+            summary="$(printf 'RunPod GPU validation did not complete successfully.\\n\\n%s' "$(cat "${failures_file}")")"
+          fi
+
+          target_sha=""
+          if [ "${EVENT_NAME}" = "workflow_run" ]; then
+            target_sha="$(jq -r '.[0].head.sha // empty' <<<"${WORKFLOW_RUN_PULL_REQUESTS}")"
+          fi
+
+          if [ -n "${target_sha}" ]; then
+            echo "Publishing CI GPU gate check to PR head SHA ${target_sha}."
+            jq -n \
+              --arg name "CI GPU gate" \
+              --arg head_sha "${target_sha}" \
+              --arg conclusion "${conclusion}" \
+              --arg details_url "${RUN_URL}" \
+              --arg title "${title}" \
+              --arg summary "${summary}" \
+              '{
+                name: $name,
+                head_sha: $head_sha,
+                status: "completed",
+                conclusion: $conclusion,
+                details_url: $details_url,
+                output: {
+                  title: $title,
+                  summary: $summary
+                }
+              }' > /tmp/ci-gpu-gate-check.json
+
+            gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/check-runs" \
+              --input /tmp/ci-gpu-gate-check.json
+          else
+            echo "No PR head SHA available; skipping PR-head CI GPU gate publication."
+          fi
+
+          if [ "${conclusion}" != "success" ]; then
+            exit 1
+          fi

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -1308,7 +1308,13 @@ jobs:
       - run-gpu-tests
       - cleanup-runpod
 
-    if: always() && !cancelled()
+    if: >-
+      always() &&
+      !cancelled() &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.event == 'pull_request'
+      )
 
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -26,6 +26,8 @@ name: RunPod tenferro-rs GPU Test
 #     become readable from, the pod itself. Automatic PR runs are started only
 #     by `workflow_run`, after `authorize` gates the run to same-repo
 #     maintainer/admin PRs.
+#   * This workflow owns the branch-protection-required `CI GPU gate` check for
+#     eligible maintainer PRs. The legacy `CI_gpu.yml` workflow is manual-only.
 # ---------------------------------------------------------------------------
 
 on:
@@ -1288,3 +1290,48 @@ jobs:
           fi
 
           echo "Deleted RunPod pod: ${POD_ID}"
+
+  ci-gpu-gate:
+    name: CI GPU gate
+    needs:
+      - authorize
+      - pre-runpod-gate
+      - cuda-archive
+      - start-runpod
+      - run-gpu-tests
+      - cleanup-runpod
+
+    if: always() && !cancelled()
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Require successful RunPod GPU validation and cleanup
+        env:
+          AUTHORIZE_RESULT: ${{ needs.authorize.result }}
+          PRE_RUNPOD_RESULT: ${{ needs.pre-runpod-gate.result }}
+          ARCHIVE_RESULT: ${{ needs.cuda-archive.result }}
+          START_RUNPOD_RESULT: ${{ needs.start-runpod.result }}
+          RUN_GPU_TESTS_RESULT: ${{ needs.run-gpu-tests.result }}
+          CLEANUP_RUNPOD_RESULT: ${{ needs.cleanup-runpod.result }}
+        run: |
+          set -euo pipefail
+
+          require_success() {
+            local job="$1"
+            local result="$2"
+            if [ "${result}" != "success" ]; then
+              echo "::error::Expected ${job} to succeed; got ${result}."
+              exit 1
+            fi
+          }
+
+          require_success "authorize" "${AUTHORIZE_RESULT}"
+          require_success "pre-runpod-gate" "${PRE_RUNPOD_RESULT}"
+          require_success "cuda-archive" "${ARCHIVE_RESULT}"
+          require_success "start-runpod" "${START_RUNPOD_RESULT}"
+          require_success "run-gpu-tests" "${RUN_GPU_TESTS_RESULT}"
+          require_success "cleanup-runpod" "${CLEANUP_RUNPOD_RESULT}"
+
+          echo "RunPod GPU validation completed successfully and owns CI GPU gate."

--- a/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
+++ b/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
@@ -29,6 +29,10 @@ execution and makes the trusted RunPod workflow own the PR GPU gate.
 - Keep a manual `ci_gpu_gate_head_sha` input so workflow-change PRs can run the
   PR branch workflow against a pinned test ref and still publish the required
   gate to the PR head before the trusted workflow has landed on `main`.
+- Restrict the final gate job to manual dispatch and PR-sourced
+  `workflow_run` events. Push-sourced `CI PR workspace tests` runs on `main`
+  should not create a failing RunPod workflow result when there is no PR gate to
+  publish.
 - Make the legacy `CI_gpu.yml` manual fallback check out the requested
   `tenferro_ref` in both archive and GPU-runner jobs so PJRT validation uses
   the same ref as the archived CUDA tests.

--- a/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
+++ b/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
@@ -1,0 +1,40 @@
+# RunPod GPU gate retirement
+
+## Summary
+
+Issue #1341 retires the legacy `CI_gpu.yml` workflow from automatic PR
+execution and makes the trusted RunPod workflow own the PR GPU gate.
+
+## Context read
+
+- Issue #1341 acceptance criteria.
+- Shared tensor4all common repository and docs/tests rules.
+- `REPOSITORY_RULES.md`, especially CI cost discipline.
+- `.github/workflows/CI_gpu.yml`.
+- `.github/workflows/runpod-gpu-test.yml`.
+
+## Decisions
+
+- Keep `CI_gpu.yml` as a manual fallback instead of deleting it immediately, so
+  maintainers can still compare the org larger GPU runner with RunPod.
+- Rename the legacy workflow's final check to `CI GPU legacy manual gate` so it
+  no longer owns the branch-protection-required `CI GPU gate` name.
+- Add the required `CI GPU gate` check to the RunPod workflow after
+  authorization, non-GPU pre-gating, archive build, pod startup, GPU tests, and
+  cleanup all succeed.
+- Preserve the existing trusted-base `workflow_run` model and pinned merge-SHA
+  checkout behavior from PR #1340.
+
+## Deferred
+
+- Deleting `CI_gpu.yml` entirely remains a maintainer decision after RunPod has
+  enough production history.
+- Branch protection should continue requiring the same check name,
+  `CI GPU gate`, now emitted by the RunPod workflow.
+
+## Verification
+
+No local CI was run in this editing pass. The intended verification is a manual
+dispatch of `runpod-gpu-test.yml` against a pinned PR merge SHA, followed by a
+maintainer same-repo PR update confirming that only RunPod automatically emits
+`CI GPU gate`.

--- a/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
+++ b/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
@@ -26,6 +26,9 @@ execution and makes the trusted RunPod workflow own the PR GPU gate.
   the PR head SHA instead of relying on the workflow job's own check run.
 - Keep `checks: write` scoped to the final GitHub-hosted gate job only; the
   self-hosted RunPod job remains read-only.
+- Keep a manual `ci_gpu_gate_head_sha` input so workflow-change PRs can run the
+  PR branch workflow against a pinned test ref and still publish the required
+  gate to the PR head before the trusted workflow has landed on `main`.
 - Preserve the existing trusted-base `workflow_run` model and pinned merge-SHA
   checkout behavior from PR #1340.
 

--- a/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
+++ b/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
@@ -2,8 +2,10 @@
 
 ## Summary
 
-Issue #1341 retires the legacy `CI_gpu.yml` workflow from automatic PR
-execution and makes the trusted RunPod workflow own the PR GPU gate.
+Issue #1341 retires the legacy `CI_gpu.yml` workflow from automatic same-repo
+PR execution and makes the trusted RunPod workflow own the maintainer PR GPU
+gate. Fork PRs keep the legacy pull_request path because base-repo Checks API
+writes cannot attach a required check to fork commits.
 
 ## Context read
 
@@ -15,10 +17,14 @@ execution and makes the trusted RunPod workflow own the PR GPU gate.
 
 ## Decisions
 
-- Keep `CI_gpu.yml` as a manual fallback instead of deleting it immediately, so
-  maintainers can still compare the org larger GPU runner with RunPod.
-- Rename the legacy workflow's final check to `CI GPU legacy manual gate` so it
-  no longer owns the branch-protection-required `CI GPU gate` name.
+- Keep `CI_gpu.yml` as a fork-PR fallback instead of deleting it immediately,
+  so fork PRs still have a branch-protection-compatible `CI GPU gate` check.
+  It also remains available as a manual fallback for maintainers comparing the
+  org larger GPU runner with RunPod.
+- Rename the legacy workflow's final check to `CI GPU legacy manual gate` for
+  same-repo/manual paths, but keep the exact `CI GPU gate` name on fork PRs.
+  This avoids a skipped same-repo legacy job satisfying branch protection while
+  preserving the required check path for forks.
 - Add the required `CI GPU gate` check to the RunPod workflow after
   authorization, non-GPU pre-gating, archive build, pod startup, GPU tests, and
   cleanup all succeed. Because `workflow_run` jobs are attached to the default
@@ -35,20 +41,26 @@ execution and makes the trusted RunPod workflow own the PR GPU gate.
   publish.
 - Make the legacy `CI_gpu.yml` manual fallback check out the requested
   `tenferro_ref` in both archive and GPU-runner jobs so PJRT validation uses
-  the same ref as the archived CUDA tests.
+  the same ref as the archived CUDA tests. Pull request runs use the PR event
+  ref.
+- Keep `CI_gpu.yml` automatic only for fork PRs. Same-repo PRs must use RunPod,
+  while fork PRs cannot receive the RunPod-published base-repo check on the
+  fork head SHA.
 - Preserve the existing trusted-base `workflow_run` model and pinned merge-SHA
   checkout behavior from PR #1340.
 
 ## Deferred
 
-- Deleting `CI_gpu.yml` entirely remains a maintainer decision after RunPod has
-  enough production history.
+- Deleting `CI_gpu.yml` entirely requires a separate fork-PR gate design, not
+  just more RunPod production history.
 - Branch protection should continue requiring the same check name,
-  `CI GPU gate`, now emitted by the RunPod workflow.
+  `CI GPU gate`, emitted by RunPod for same-repo maintainer PRs and by
+  `CI_gpu.yml` for fork PRs.
 
 ## Verification
 
 No local CI was run in this editing pass. The intended verification is a manual
 dispatch of `runpod-gpu-test.yml` against a pinned PR merge SHA, followed by a
 maintainer same-repo PR update confirming that only RunPod automatically emits
-`CI GPU gate`.
+`CI GPU gate` for same-repo PRs. A future fork PR should confirm the legacy
+`CI_gpu.yml` path still emits `CI GPU gate`.

--- a/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
+++ b/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
@@ -29,6 +29,9 @@ execution and makes the trusted RunPod workflow own the PR GPU gate.
 - Keep a manual `ci_gpu_gate_head_sha` input so workflow-change PRs can run the
   PR branch workflow against a pinned test ref and still publish the required
   gate to the PR head before the trusted workflow has landed on `main`.
+- Make the legacy `CI_gpu.yml` manual fallback check out the requested
+  `tenferro_ref` in both archive and GPU-runner jobs so PJRT validation uses
+  the same ref as the archived CUDA tests.
 - Preserve the existing trusted-base `workflow_run` model and pinned merge-SHA
   checkout behavior from PR #1340.
 

--- a/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
+++ b/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
@@ -21,7 +21,11 @@ execution and makes the trusted RunPod workflow own the PR GPU gate.
   no longer owns the branch-protection-required `CI GPU gate` name.
 - Add the required `CI GPU gate` check to the RunPod workflow after
   authorization, non-GPU pre-gating, archive build, pod startup, GPU tests, and
-  cleanup all succeed.
+  cleanup all succeed. Because `workflow_run` jobs are attached to the default
+  branch commit, the final GitHub-hosted gate publishes a Checks API result to
+  the PR head SHA instead of relying on the workflow job's own check run.
+- Keep `checks: write` scoped to the final GitHub-hosted gate job only; the
+  self-hosted RunPod job remains read-only.
 - Preserve the existing trusted-base `workflow_run` model and pinned merge-SHA
   checkout behavior from PR #1340.
 

--- a/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
+++ b/docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md
@@ -17,14 +17,11 @@ writes cannot attach a required check to fork commits.
 
 ## Decisions
 
-- Keep `CI_gpu.yml` as a fork-PR fallback instead of deleting it immediately,
-  so fork PRs still have a branch-protection-compatible `CI GPU gate` check.
-  It also remains available as a manual fallback for maintainers comparing the
-  org larger GPU runner with RunPod.
-- Rename the legacy workflow's final check to `CI GPU legacy manual gate` for
-  same-repo/manual paths, but keep the exact `CI GPU gate` name on fork PRs.
-  This avoids a skipped same-repo legacy job satisfying branch protection while
-  preserving the required check path for forks.
+- Keep `CI_gpu.yml` as the PR-attached `CI GPU gate` wrapper. Same-repo PRs do
+  not run legacy GPU work there; they wait for the trusted RunPod check. Fork
+  PRs still use the legacy `ubuntu-gpu` path because the RunPod workflow cannot
+  attach a base-repo Checks API result to fork commits.
+- Keep a separate `CI GPU legacy manual gate` for manual fallback runs.
 - Add the required `CI GPU gate` check to the RunPod workflow after
   authorization, non-GPU pre-gating, archive build, pod startup, GPU tests, and
   cleanup all succeed. Because `workflow_run` jobs are attached to the default


### PR DESCRIPTION
Closes #1341.

## Summary

- retire `.github/workflows/CI_gpu.yml` from automatic PR execution
- keep `CI_gpu.yml` as a manual legacy fallback under `workflow_dispatch`
- move the branch-protection check name `CI GPU gate` to the trusted RunPod workflow
- require RunPod authorization, non-GPU pre-gating, archive build, pod startup, GPU tests, and cleanup to succeed before the RunPod `CI GPU gate` passes
- add a work log documenting the migration decision

## Notes

This keeps the existing trusted-base RunPod model from PR #1340: PR-triggered GPU validation enters through `workflow_run`, rejects fork PRs, checks maintainer/admin permissions, and uses the pinned merge SHA resolved by the trusted workflow.

The legacy ubuntu-gpu workflow remains available for explicit maintainer comparison runs, but it no longer emits the required `CI GPU gate` check.

Work log: `docs/worklogs/2026-07-10-runpod-gpu-gate-retirement.md`

## Validation

Not run locally. This change is workflow-only and needs GitHub Actions validation after PR creation, plus a manual RunPod dispatch before merge if maintainers want to verify the new gate path on this workflow-change PR.
