### PR TITLE
Add optional TBLIS CPU contraction provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/tenferro-einsum",
     "crates/tenferro-linalg",
     "crates/tenferro-fft",
+    "crates/tenferro-tblis-src",
     "docs/tutorial-code",
 ]
 default-members = [
@@ -63,6 +64,8 @@ blas-src = { version = "0.14", default-features = false }
 lapack = "0.20"
 lapack-src = "0.13"
 lapack-inject = "0.1.2"
+tblis-ffi = "0.2.6"
+tenferro-tblis-src = { path = "crates/tenferro-tblis-src", version = "0.1.0" }
 # Match CubeCL's CUDA API floor. CUDA 12.8 is the oldest cudarc binding set
 # that exposes the driver symbols used by the current cubecl-cuda revision.
 cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "dynamic-loading", "cuda-12080"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,11 +49,11 @@ proc-macro2 = "1"
 quote = "1"
 syn = "2"
 tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "77527ecb647fecd4918ea2d06d0065ddce4e5b1c", version = "0.1.0" }
-strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "4ea9acbaa1422efa2662ff4b25b17cdae28f093d", version = "0.1.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "4ea9acbaa1422efa2662ff4b25b17cdae28f093d", version = "0.1.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "4ea9acbaa1422efa2662ff4b25b17cdae28f093d", version = "0.1.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs", rev = "4ea9acbaa1422efa2662ff4b25b17cdae28f093d", version = "0.1.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs", rev = "4ea9acbaa1422efa2662ff4b25b17cdae28f093d", version = "0.1.0", default-features = false }
 libloading = "0.8"
 faer = "0.24"
 cblas-sys = "0.1"

--- a/crates/tenferro-ad/Cargo.toml
+++ b/crates/tenferro-ad/Cargo.toml
@@ -21,6 +21,9 @@ cpu-faer = [
 cpu-blas = [
     "tenferro-cpu/cpu-blas",
 ]
+cpu-tblis = [
+    "tenferro-cpu/cpu-tblis",
+]
 blas-openblas = [
     "tenferro-cpu/blas-openblas",
 ]

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -17,6 +17,12 @@ name = "tenferro_cpu"
 default = ["cpu-faer"]
 cpu-faer = ["dep:faer", "dep:strided-einsum2", "strided-einsum2/faer", "strided-einsum2/parallel"]
 cpu-blas = ["dep:cblas-sys", "dep:lapack"]
+cpu-tblis = [
+    "dep:tblis-ffi",
+    "dep:tenferro-tblis-src",
+    "tenferro-tblis-src/build_from_source",
+    "tenferro-tblis-src/static",
+]
 provider-src = ["cpu-blas", "dep:blas-src", "dep:cblas-src", "dep:lapack-src"]
 provider-inject = ["cpu-blas", "dep:cblas-inject", "dep:lapack-inject"]
 blas-openblas = [
@@ -61,6 +67,8 @@ cblas-src = { workspace = true, optional = true }
 blas-src = { workspace = true, optional = true }
 lapack = { workspace = true, optional = true }
 lapack-src = { workspace = true, optional = true }
+tblis-ffi = { workspace = true, optional = true }
+tenferro-tblis-src = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion.workspace = true
@@ -81,3 +89,8 @@ harness = false
 name = "openblas_direct_overhead"
 harness = false
 required-features = ["cpu-blas"]
+
+[[bench]]
+name = "tblis_dot_general_provider"
+harness = false
+required-features = ["cpu-tblis"]

--- a/crates/tenferro-cpu/benches/tblis_dot_general_provider.rs
+++ b/crates/tenferro-cpu/benches/tblis_dot_general_provider.rs
@@ -1,0 +1,442 @@
+use criterion::{
+    black_box, criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, BenchmarkId,
+    Criterion,
+};
+#[cfg(feature = "cpu-tblis")]
+use std::env;
+
+#[cfg(feature = "cpu-tblis")]
+use num_complex::Complex64;
+#[cfg(feature = "cpu-tblis")]
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+#[cfg(feature = "cpu-tblis")]
+use tenferro_tensor::{
+    DotGeneralConfig, Tensor, TensorDot, TensorRead, TensorView, TypedTensorView,
+};
+
+#[cfg(feature = "cpu-tblis")]
+const SIZES: &[usize] = &[32, 64, 128];
+#[cfg(feature = "cpu-tblis")]
+const HIGHER_RANK_NS: &[usize] = &[4, 8];
+
+#[cfg(feature = "cpu-tblis")]
+fn matmul_config() -> DotGeneralConfig {
+    DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    }
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn rank4_contract_config() -> DotGeneralConfig {
+    DotGeneralConfig {
+        lhs_contracting_dims: vec![2, 3],
+        rhs_contracting_dims: vec![0, 1],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    }
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn interleaved_rank4_contract_config() -> DotGeneralConfig {
+    DotGeneralConfig {
+        lhs_contracting_dims: vec![1, 3],
+        rhs_contracting_dims: vec![2, 1],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    }
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn batched_interleaved_rank5_contract_config() -> DotGeneralConfig {
+    DotGeneralConfig {
+        lhs_contracting_dims: vec![2, 4],
+        rhs_contracting_dims: vec![3, 2],
+        lhs_batch_dims: vec![0],
+        rhs_batch_dims: vec![0],
+    }
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn parse_size_list_env(var: &str, default: &[usize]) -> Vec<usize> {
+    env::var(var)
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .filter_map(|item| item.trim().parse::<usize>().ok())
+                .filter(|&n| n > 0)
+                .collect::<Vec<_>>()
+        })
+        .filter(|values| !values.is_empty())
+        .unwrap_or_else(|| default.to_vec())
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn real_tensor(shape: &[usize], seed: usize) -> Tensor {
+    let len = shape.iter().product();
+    let data = (0..len)
+        .map(|idx| ((idx * 17 + seed * 11 + 5) % 101) as f64 / 101.0 - 0.5)
+        .collect();
+    Tensor::from_vec_col_major(shape.to_vec(), data).unwrap()
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn real_data(shape: &[usize], seed: usize) -> Vec<f64> {
+    let len = shape.iter().product();
+    (0..len)
+        .map(|idx| ((idx * 17 + seed * 11 + 5) % 101) as f64 / 101.0 - 0.5)
+        .collect()
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn real_matrix(rows: usize, cols: usize, seed: usize) -> Tensor {
+    real_tensor(&[rows, cols], seed)
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn complex_matrix(rows: usize, cols: usize, seed: usize) -> Tensor {
+    let data = (0..rows * cols)
+        .map(|idx| {
+            let real = ((idx * 17 + seed * 11 + 5) % 101) as f64 / 101.0 - 0.5;
+            let imag = ((idx * 29 + seed * 7 + 13) % 103) as f64 / 103.0 - 0.5;
+            Complex64::new(real, imag)
+        })
+        .collect();
+    Tensor::from_vec_col_major(vec![rows, cols], data).unwrap()
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn tblis_runtime_available(config: &DotGeneralConfig) -> bool {
+    let lhs = real_matrix(2, 2, 1);
+    let rhs = real_matrix(2, 2, 2);
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Tblis).unwrap();
+    match backend.dot_general(&lhs, &rhs, config) {
+        Ok(_) => true,
+        Err(err) => {
+            eprintln!("skipping tblis_dot_general_provider: {err}");
+            false
+        }
+    }
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn bench_owned_dot(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    provider: &str,
+    kind: CpuBackendKind,
+    case: &str,
+    params: impl std::fmt::Display,
+    lhs: &Tensor,
+    rhs: &Tensor,
+    config: &DotGeneralConfig,
+) {
+    group.bench_function(
+        BenchmarkId::new(format!("{provider}_{case}"), params),
+        |b| {
+            let mut backend = CpuBackend::with_kind(kind).unwrap();
+            b.iter(|| {
+                let out = backend
+                    .dot_general(black_box(lhs), black_box(rhs), black_box(config))
+                    .unwrap();
+                black_box(out.shape().to_vec());
+            });
+        },
+    );
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn bench_owned_conj_dot(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    provider: &str,
+    kind: CpuBackendKind,
+    case: &str,
+    params: impl std::fmt::Display,
+    lhs: &Tensor,
+    rhs: &Tensor,
+    config: &DotGeneralConfig,
+) {
+    group.bench_function(
+        BenchmarkId::new(format!("{provider}_{case}"), params),
+        |b| {
+            let mut backend = CpuBackend::with_kind(kind).unwrap();
+            b.iter(|| {
+                let out = backend
+                    .dot_general_with_conj(
+                        black_box(lhs),
+                        black_box(rhs),
+                        black_box(config),
+                        true,
+                        false,
+                    )
+                    .unwrap();
+                black_box(out.shape().to_vec());
+            });
+        },
+    );
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn bench_read_view_dot(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    provider: &str,
+    kind: CpuBackendKind,
+    case: &str,
+    params: impl std::fmt::Display,
+    lhs: StridedData<'_>,
+    rhs: StridedData<'_>,
+    config: &DotGeneralConfig,
+) {
+    group.bench_function(
+        BenchmarkId::new(format!("{provider}_{case}"), params),
+        |b| {
+            let mut backend = CpuBackend::with_kind(kind).unwrap();
+            b.iter(|| {
+                let lhs_view =
+                    TypedTensorView::from_slice(lhs.shape, lhs.strides, 0, black_box(lhs.data))
+                        .unwrap();
+                let rhs_view =
+                    TypedTensorView::from_slice(rhs.shape, rhs.strides, 0, black_box(rhs.data))
+                        .unwrap();
+                let out = backend
+                    .dot_general_read(
+                        TensorRead::from_view(TensorView::F64(lhs_view)),
+                        TensorRead::from_view(TensorView::F64(rhs_view)),
+                        black_box(config),
+                    )
+                    .unwrap();
+                black_box(out.shape().to_vec());
+            });
+        },
+    );
+}
+
+#[cfg(feature = "cpu-tblis")]
+#[derive(Clone, Copy)]
+struct StridedData<'a> {
+    shape: &'a [usize],
+    strides: &'a [isize],
+    data: &'a [f64],
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn bench_owned_all_providers(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    case: &str,
+    params: impl std::fmt::Display + Clone,
+    lhs: &Tensor,
+    rhs: &Tensor,
+    config: &DotGeneralConfig,
+) {
+    #[cfg(feature = "cpu-faer")]
+    bench_owned_dot(
+        group,
+        "faer",
+        CpuBackendKind::Faer,
+        case,
+        params.clone(),
+        lhs,
+        rhs,
+        config,
+    );
+    #[cfg(feature = "cpu-blas")]
+    bench_owned_dot(
+        group,
+        "blas",
+        CpuBackendKind::Blas,
+        case,
+        params.clone(),
+        lhs,
+        rhs,
+        config,
+    );
+    bench_owned_dot(
+        group,
+        "tblis",
+        CpuBackendKind::Tblis,
+        case,
+        params,
+        lhs,
+        rhs,
+        config,
+    );
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn bench_read_view_all_providers(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    case: &str,
+    params: impl std::fmt::Display + Clone,
+    lhs: StridedData<'_>,
+    rhs: StridedData<'_>,
+    config: &DotGeneralConfig,
+) {
+    #[cfg(feature = "cpu-faer")]
+    bench_read_view_dot(
+        group,
+        "faer",
+        CpuBackendKind::Faer,
+        case,
+        params.clone(),
+        lhs,
+        rhs,
+        config,
+    );
+    #[cfg(feature = "cpu-blas")]
+    bench_read_view_dot(
+        group,
+        "blas",
+        CpuBackendKind::Blas,
+        case,
+        params.clone(),
+        lhs,
+        rhs,
+        config,
+    );
+    bench_read_view_dot(
+        group,
+        "tblis",
+        CpuBackendKind::Tblis,
+        case,
+        params,
+        lhs,
+        rhs,
+        config,
+    );
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn bench_tblis_dot_general_provider(c: &mut Criterion) {
+    let matmul_config = matmul_config();
+    if !tblis_runtime_available(&matmul_config) {
+        return;
+    }
+
+    let mut group = c.benchmark_group("tblis_dot_general_provider");
+    let matmul_sizes = parse_size_list_env("TENFERRO_TBLIS_BENCH_MATMUL_SIZES", SIZES);
+    let higher_rank_sizes =
+        parse_size_list_env("TENFERRO_TBLIS_BENCH_HIGHER_RANK_NS", HIGHER_RANK_NS);
+
+    for &n in &matmul_sizes {
+        let real_lhs = real_matrix(n, n, 1);
+        let real_rhs = real_matrix(n, n, 2);
+        let complex_lhs = complex_matrix(n, n, 3);
+        let complex_rhs = complex_matrix(n, n, 4);
+
+        bench_owned_all_providers(
+            &mut group,
+            "f64_matmul",
+            n,
+            &real_lhs,
+            &real_rhs,
+            &matmul_config,
+        );
+        #[cfg(feature = "cpu-faer")]
+        bench_owned_conj_dot(
+            &mut group,
+            "faer",
+            CpuBackendKind::Faer,
+            "c64_lhs_conj_matmul",
+            n,
+            &complex_lhs,
+            &complex_rhs,
+            &matmul_config,
+        );
+        #[cfg(feature = "cpu-blas")]
+        bench_owned_conj_dot(
+            &mut group,
+            "blas",
+            CpuBackendKind::Blas,
+            "c64_lhs_conj_matmul",
+            n,
+            &complex_lhs,
+            &complex_rhs,
+            &matmul_config,
+        );
+        bench_owned_conj_dot(
+            &mut group,
+            "tblis",
+            CpuBackendKind::Tblis,
+            "c64_lhs_conj_matmul",
+            n,
+            &complex_lhs,
+            &complex_rhs,
+            &matmul_config,
+        );
+    }
+
+    let rank4_config = rank4_contract_config();
+    let interleaved_rank4_config = interleaved_rank4_contract_config();
+    let batched_config = batched_interleaved_rank5_contract_config();
+
+    for &n in &higher_rank_sizes {
+        let rank4_lhs = real_tensor(&[n, n, n, n], 11);
+        let rank4_rhs = real_tensor(&[n, n, n, n], 12);
+        bench_owned_all_providers(
+            &mut group,
+            "f64_rank4_two_contract",
+            format!("n_{n}"),
+            &rank4_lhs,
+            &rank4_rhs,
+            &rank4_config,
+        );
+
+        let interleaved_lhs = real_tensor(&[n, n, n, n], 21);
+        let interleaved_rhs = real_tensor(&[n, n, n, n], 22);
+        bench_owned_all_providers(
+            &mut group,
+            "f64_rank4_interleaved_two_contract",
+            format!("n_{n}"),
+            &interleaved_lhs,
+            &interleaved_rhs,
+            &interleaved_rank4_config,
+        );
+
+        let batch = 4;
+        let batched_lhs = real_tensor(&[batch, n, n, n, n], 31);
+        let batched_rhs = real_tensor(&[batch, n, n, n, n], 32);
+        bench_owned_all_providers(
+            &mut group,
+            "f64_rank5_batched_interleaved_two_contract",
+            format!("batch_{batch}_n_{n}"),
+            &batched_lhs,
+            &batched_rhs,
+            &batched_config,
+        );
+    }
+
+    for &n in &higher_rank_sizes {
+        let lhs_shape = [n, n, n, n];
+        let rhs_shape = [n, n, n, n];
+        let lhs_row_major_strides = [(n * n * n) as isize, (n * n) as isize, n as isize, 1];
+        let rhs_row_major_strides = [(n * n * n) as isize, (n * n) as isize, n as isize, 1];
+        let lhs_data = real_data(&lhs_shape, 41);
+        let rhs_data = real_data(&rhs_shape, 42);
+        bench_read_view_all_providers(
+            &mut group,
+            "f64_rank4_interleaved_row_major_view",
+            format!("n_{n}"),
+            StridedData {
+                shape: &lhs_shape,
+                strides: &lhs_row_major_strides,
+                data: &lhs_data,
+            },
+            StridedData {
+                shape: &rhs_shape,
+                strides: &rhs_row_major_strides,
+                data: &rhs_data,
+            },
+            &interleaved_rank4_config,
+        );
+    }
+
+    group.finish();
+}
+
+#[cfg(not(feature = "cpu-tblis"))]
+fn bench_tblis_dot_general_provider(_c: &mut Criterion) {}
+
+criterion_group!(benches, bench_tblis_dot_general_provider);
+criterion_main!(benches);

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -168,6 +168,8 @@ pub enum CpuBackendKind {
     Faer,
     /// BLAS/LAPACK-backed CPU kernels.
     Blas,
+    /// TBLIS-backed CPU contraction kernels.
+    Tblis,
 }
 
 impl CpuBackendKind {
@@ -202,6 +204,7 @@ impl CpuBackendKind {
         match self {
             Self::Faer => "faer",
             Self::Blas => "blas",
+            Self::Tblis => "tblis",
         }
     }
 }
@@ -232,6 +235,19 @@ fn ensure_cpu_backend_kind_available(kind: CpuBackendKind, op: &'static str) -> 
                 Err(crate::Error::InvalidConfig {
                     op,
                     message: "CpuBackendKind::Blas requires the cpu-blas feature".to_string(),
+                })
+            }
+        }
+        CpuBackendKind::Tblis => {
+            #[cfg(feature = "cpu-tblis")]
+            {
+                Ok(())
+            }
+            #[cfg(not(feature = "cpu-tblis"))]
+            {
+                Err(crate::Error::InvalidConfig {
+                    op,
+                    message: "CpuBackendKind::Tblis requires the cpu-tblis feature".to_string(),
                 })
             }
         }
@@ -619,6 +635,7 @@ impl CpuBackend {
         match self.kind {
             CpuBackendKind::Faer => self.install_with_pool(op),
             CpuBackendKind::Blas => self.run_with_pool(op),
+            CpuBackendKind::Tblis => self.run_with_pool(op),
         }
     }
 
@@ -997,6 +1014,207 @@ impl TensorReduction for CpuBackend {
     }
 }
 
+#[cfg(feature = "cpu-tblis")]
+impl CpuBackend {
+    fn dot_general_existing_provider_cached(
+        &mut self,
+        cache: &mut gemm::GemmAnalysisCache,
+        cache_slot: Option<usize>,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        #[cfg(feature = "cpu-blas")]
+        {
+            return self.run_with_pool_and_gemm_cache(cache, |buffers, cache| match (lhs, rhs) {
+                (Tensor::F32(a), Tensor::F32(b)) => {
+                    gemm::dot_general_blas_cached(buffers, cache, cache_slot, a, b, config)
+                        .map(Tensor::F32)
+                }
+                (Tensor::F64(a), Tensor::F64(b)) => {
+                    gemm::dot_general_blas_cached(buffers, cache, cache_slot, a, b, config)
+                        .map(Tensor::F64)
+                }
+                (Tensor::C32(a), Tensor::C32(b)) => {
+                    gemm::dot_general_blas_cached(buffers, cache, cache_slot, a, b, config)
+                        .map(Tensor::C32)
+                }
+                (Tensor::C64(a), Tensor::C64(b)) => {
+                    gemm::dot_general_blas_cached(buffers, cache, cache_slot, a, b, config)
+                        .map(Tensor::C64)
+                }
+                _ => Err(crate::Error::DTypeMismatch {
+                    op: "dot_general",
+                    lhs: lhs.dtype(),
+                    rhs: rhs.dtype(),
+                }),
+            });
+        }
+        #[cfg(all(not(feature = "cpu-blas"), feature = "cpu-faer"))]
+        {
+            let ctx = Arc::clone(&self.ctx);
+            return self.install_with_pool_and_gemm_cache(cache, |buffers, cache| {
+                match (lhs, rhs) {
+                    (Tensor::F32(a), Tensor::F32(b)) => gemm::dot_general_faer_cached(
+                        buffers,
+                        cache,
+                        cache_slot,
+                        ctx.as_ref(),
+                        a,
+                        b,
+                        config,
+                    )
+                    .map(Tensor::F32),
+                    (Tensor::F64(a), Tensor::F64(b)) => gemm::dot_general_faer_cached(
+                        buffers,
+                        cache,
+                        cache_slot,
+                        ctx.as_ref(),
+                        a,
+                        b,
+                        config,
+                    )
+                    .map(Tensor::F64),
+                    (Tensor::C32(a), Tensor::C32(b)) => gemm::dot_general_faer_cached(
+                        buffers,
+                        cache,
+                        cache_slot,
+                        ctx.as_ref(),
+                        a,
+                        b,
+                        config,
+                    )
+                    .map(Tensor::C32),
+                    (Tensor::C64(a), Tensor::C64(b)) => gemm::dot_general_faer_cached(
+                        buffers,
+                        cache,
+                        cache_slot,
+                        ctx.as_ref(),
+                        a,
+                        b,
+                        config,
+                    )
+                    .map(Tensor::C64),
+                    _ => Err(crate::Error::DTypeMismatch {
+                        op: "dot_general",
+                        lhs: lhs.dtype(),
+                        rhs: rhs.dtype(),
+                    }),
+                }
+            });
+        }
+        #[cfg(not(any(feature = "cpu-blas", feature = "cpu-faer")))]
+        {
+            let _ = (cache, cache_slot, lhs, rhs, config);
+            Err(crate::Error::InvalidConfig {
+                op: "dot_general",
+                message: "CpuBackendKind::Tblis fallback requires cpu-blas or cpu-faer".into(),
+            })
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(any(feature = "cpu-blas", feature = "cpu-faer"))]
+    fn dot_general_existing_provider_with_conj_cached(
+        &mut self,
+        cache: &mut gemm::GemmAnalysisCache,
+        cache_slot: Option<usize>,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+        lhs_conj: bool,
+        rhs_conj: bool,
+    ) -> crate::Result<Tensor> {
+        let saved_kind = self.kind;
+        #[cfg(feature = "cpu-blas")]
+        {
+            self.kind = CpuBackendKind::Blas;
+        }
+        #[cfg(all(not(feature = "cpu-blas"), feature = "cpu-faer"))]
+        {
+            self.kind = CpuBackendKind::Faer;
+        }
+        let result = BackendCachedDot::dot_general_with_conj_cached(
+            self, cache, cache_slot, lhs, rhs, config, lhs_conj, rhs_conj,
+        );
+        self.kind = saved_kind;
+        result
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(not(any(feature = "cpu-blas", feature = "cpu-faer")))]
+    fn dot_general_existing_provider_with_conj_cached(
+        &mut self,
+        cache: &mut gemm::GemmAnalysisCache,
+        cache_slot: Option<usize>,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+        lhs_conj: bool,
+        rhs_conj: bool,
+    ) -> crate::Result<Tensor> {
+        let _ = (cache, cache_slot, lhs, rhs, config, lhs_conj, rhs_conj);
+        Err(crate::Error::InvalidConfig {
+            op: "dot_general",
+            message: "CpuBackendKind::Tblis fallback requires cpu-blas or cpu-faer".into(),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(any(feature = "cpu-blas", feature = "cpu-faer"))]
+    fn dot_general_existing_provider_read_into_accum_cached(
+        &mut self,
+        cache: &mut gemm::GemmAnalysisCache,
+        cache_slot: Option<usize>,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        accumulation: DotGeneralAccumulation,
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        let saved_kind = self.kind;
+        #[cfg(feature = "cpu-blas")]
+        {
+            self.kind = CpuBackendKind::Blas;
+        }
+        #[cfg(all(not(feature = "cpu-blas"), feature = "cpu-faer"))]
+        {
+            self.kind = CpuBackendKind::Faer;
+        }
+        let result = BackendCachedDot::dot_general_read_into_accum_cached(
+            self,
+            cache,
+            cache_slot,
+            lhs,
+            rhs,
+            config,
+            accumulation,
+            out,
+        );
+        self.kind = saved_kind;
+        result
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(not(any(feature = "cpu-blas", feature = "cpu-faer")))]
+    fn dot_general_existing_provider_read_into_accum_cached(
+        &mut self,
+        cache: &mut gemm::GemmAnalysisCache,
+        cache_slot: Option<usize>,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        accumulation: DotGeneralAccumulation,
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        let _ = (cache, cache_slot, lhs, rhs, config, accumulation, out);
+        Err(crate::Error::InvalidConfig {
+            op: "dot_general",
+            message: "CpuBackendKind::Tblis fallback requires cpu-blas or cpu-faer".into(),
+        })
+    }
+}
+
 impl TensorDot for CpuBackend {
     fn dot_general(
         &mut self,
@@ -1052,6 +1270,23 @@ impl TensorDot for CpuBackend {
                     })?
                 }
                 #[cfg(not(feature = "cpu-blas"))]
+                {
+                    return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
+                }
+            }
+            CpuBackendKind::Tblis => {
+                #[cfg(feature = "cpu-tblis")]
+                {
+                    self.run_with_pool_and_gemm_cache(&mut cache, |buffers, _cache| {
+                        gemm::dot_general_tblis_read_cached(
+                            buffers,
+                            lhs.clone(),
+                            rhs.clone(),
+                            config,
+                        )
+                    })?
+                }
+                #[cfg(not(feature = "cpu-tblis"))]
                 {
                     return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
                 }
@@ -1214,6 +1449,46 @@ impl BackendCachedDot for CpuBackend {
                     Err(unavailable_cpu_backend_kind(self.kind, "dot_general"))
                 }
             }
+            CpuBackendKind::Tblis => {
+                #[cfg(feature = "cpu-tblis")]
+                {
+                    let direct = self.run_with_pool(|buffers| match (lhs, rhs) {
+                        (Tensor::F32(a), Tensor::F32(b)) => {
+                            gemm::dot_general_tblis_cached(buffers, a, b, config)
+                                .map(|result| result.map(Tensor::F32))
+                        }
+                        (Tensor::F64(a), Tensor::F64(b)) => {
+                            gemm::dot_general_tblis_cached(buffers, a, b, config)
+                                .map(|result| result.map(Tensor::F64))
+                        }
+                        (Tensor::C32(a), Tensor::C32(b)) => {
+                            gemm::dot_general_tblis_cached(buffers, a, b, config)
+                                .map(|result| result.map(Tensor::C32))
+                        }
+                        (Tensor::C64(a), Tensor::C64(b)) => {
+                            gemm::dot_general_tblis_cached(buffers, a, b, config)
+                                .map(|result| result.map(Tensor::C64))
+                        }
+                        _ if lhs.dtype() == rhs.dtype() => Ok(None),
+                        _ => Err(crate::Error::DTypeMismatch {
+                            op: "dot_general",
+                            lhs: lhs.dtype(),
+                            rhs: rhs.dtype(),
+                        }),
+                    })?;
+                    if let Some(result) = direct {
+                        Ok(result)
+                    } else {
+                        self.dot_general_existing_provider_cached(
+                            cache, cache_slot, lhs, rhs, config,
+                        )
+                    }
+                }
+                #[cfg(not(feature = "cpu-tblis"))]
+                {
+                    Err(unavailable_cpu_backend_kind(self.kind, "dot_general"))
+                }
+            }
         }
     }
 
@@ -1343,6 +1618,54 @@ impl BackendCachedDot for CpuBackend {
                     Err(unavailable_cpu_backend_kind(self.kind, "dot_general"))
                 }
             }
+            CpuBackendKind::Tblis => {
+                #[cfg(feature = "cpu-tblis")]
+                {
+                    let direct = self.run_with_pool(|buffers| match (lhs, rhs) {
+                        (Tensor::F32(a), Tensor::F32(b)) => {
+                            gemm::dot_general_tblis_with_conj_cached(
+                                buffers, a, b, config, lhs_conj, rhs_conj,
+                            )
+                            .map(|result| result.map(Tensor::F32))
+                        }
+                        (Tensor::F64(a), Tensor::F64(b)) => {
+                            gemm::dot_general_tblis_with_conj_cached(
+                                buffers, a, b, config, lhs_conj, rhs_conj,
+                            )
+                            .map(|result| result.map(Tensor::F64))
+                        }
+                        (Tensor::C32(a), Tensor::C32(b)) => {
+                            gemm::dot_general_tblis_with_conj_cached(
+                                buffers, a, b, config, lhs_conj, rhs_conj,
+                            )
+                            .map(|result| result.map(Tensor::C32))
+                        }
+                        (Tensor::C64(a), Tensor::C64(b)) => {
+                            gemm::dot_general_tblis_with_conj_cached(
+                                buffers, a, b, config, lhs_conj, rhs_conj,
+                            )
+                            .map(|result| result.map(Tensor::C64))
+                        }
+                        _ if lhs.dtype() == rhs.dtype() => Ok(None),
+                        _ => Err(crate::Error::DTypeMismatch {
+                            op: "dot_general",
+                            lhs: lhs.dtype(),
+                            rhs: rhs.dtype(),
+                        }),
+                    })?;
+                    if let Some(result) = direct {
+                        Ok(result)
+                    } else {
+                        self.dot_general_existing_provider_with_conj_cached(
+                            cache, cache_slot, lhs, rhs, config, lhs_conj, rhs_conj,
+                        )
+                    }
+                }
+                #[cfg(not(feature = "cpu-tblis"))]
+                {
+                    Err(unavailable_cpu_backend_kind(self.kind, "dot_general"))
+                }
+            }
         }
     }
 
@@ -1401,9 +1724,40 @@ impl BackendCachedDot for CpuBackend {
                     return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
                 }
             }
+            CpuBackendKind::Tblis => {
+                #[cfg(feature = "cpu-tblis")]
+                {
+                    self.run_with_pool_and_gemm_cache(cache, |_buffers, _cache| {
+                        gemm::dot_general_tblis_read_into_accum_cached(
+                            lhs.clone(),
+                            rhs.clone(),
+                            config,
+                            accumulation,
+                            &mut out,
+                        )
+                    })?
+                }
+                #[cfg(not(feature = "cpu-tblis"))]
+                {
+                    return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
+                }
+            }
         };
         if direct {
             return Ok(());
+        }
+
+        #[cfg(feature = "cpu-tblis")]
+        if self.kind == CpuBackendKind::Tblis {
+            return self.dot_general_existing_provider_read_into_accum_cached(
+                cache,
+                cache_slot,
+                lhs,
+                rhs,
+                config,
+                accumulation,
+                out,
+            );
         }
 
         dot_general_accum_via_temp(self, lhs, rhs, config, accumulation, out)

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -1,5 +1,8 @@
 use std::time::Duration;
 
+#[cfg(feature = "cpu-tblis")]
+use num_complex::{Complex32, Complex64};
+
 use super::*;
 
 #[test]
@@ -50,6 +53,240 @@ fn explicit_blas_backend_kind_constructor_records_selection() {
     let backend = CpuBackend::with_kind(CpuBackendKind::Blas).unwrap();
 
     assert_eq!(backend.kind(), CpuBackendKind::Blas);
+}
+
+#[test]
+#[cfg(feature = "cpu-tblis")]
+fn explicit_tblis_backend_kind_constructor_records_selection() {
+    let backend = CpuBackend::with_kind(CpuBackendKind::Tblis).unwrap();
+
+    assert_eq!(backend.kind(), CpuBackendKind::Tblis);
+}
+
+#[test]
+#[cfg(feature = "cpu-tblis")]
+fn tblis_dot_general_matches_column_major_matmul() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Tblis).unwrap();
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0]).unwrap();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+
+    let out = backend.dot_general(&lhs, &rhs, &config).unwrap();
+
+    assert_eq!(out.shape(), &[2, 2]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[76.0, 100.0, 103.0, 136.0]);
+}
+
+#[test]
+#[cfg(feature = "cpu-tblis")]
+fn tblis_dot_general_read_into_accum_applies_alpha_beta() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Tblis).unwrap();
+    let lhs =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let rhs =
+        Tensor::from_vec_col_major(vec![3, 2], vec![7.0_f64, 8.0, 9.0, 10.0, 11.0, 12.0]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let accumulation = DotGeneralAccumulation {
+        lhs_conj: false,
+        rhs_conj: false,
+        alpha: tenferro_tensor::ContractionScalar::F64(2.0),
+        beta: tenferro_tensor::ContractionScalar::F64(3.0),
+    };
+
+    backend
+        .dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config,
+            accumulation,
+            TensorWrite::from_tensor(&mut out),
+        )
+        .unwrap();
+
+    assert_eq!(
+        out.as_slice::<f64>().unwrap(),
+        &[155.0, 203.0, 209.0, 275.0]
+    );
+}
+
+#[test]
+#[cfg(feature = "cpu-tblis")]
+fn tblis_dot_general_supports_c64() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Tblis).unwrap();
+    let lhs = Tensor::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(1.0, 1.0),
+            Complex64::new(2.0, -1.0),
+            Complex64::new(3.0, 0.5),
+            Complex64::new(-1.0, 2.0),
+        ],
+    )
+    .unwrap();
+    let rhs = Tensor::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(0.5, -1.0),
+            Complex64::new(4.0, 1.0),
+            Complex64::new(-2.0, 0.25),
+            Complex64::new(1.5, -3.0),
+        ],
+    )
+    .unwrap();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+
+    let out = backend.dot_general(&lhs, &rhs, &config).unwrap();
+
+    assert_eq!(out.shape(), &[2, 2]);
+    assert_complex64_close(
+        out.as_slice::<Complex64>().unwrap(),
+        &[
+            Complex64::new(13.0, 4.5),
+            Complex64::new(-6.0, 4.5),
+            Complex64::new(3.75, -10.0),
+            Complex64::new(0.75, 8.5),
+        ],
+        1.0e-12,
+    );
+}
+
+#[test]
+#[cfg(feature = "cpu-tblis")]
+fn tblis_dot_general_c32_conj_accum() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Tblis).unwrap();
+    let lhs = Tensor::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex32::new(1.0, 2.0),
+            Complex32::new(2.0, 0.5),
+            Complex32::new(3.0, -1.0),
+            Complex32::new(-1.0, 1.0),
+        ],
+    )
+    .unwrap();
+    let rhs = Tensor::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex32::new(0.5, 1.0),
+            Complex32::new(4.0, -1.0),
+            Complex32::new(-2.0, 0.25),
+            Complex32::new(1.5, 3.0),
+        ],
+    )
+    .unwrap();
+    let mut out =
+        Tensor::from_vec_col_major(vec![2, 2], vec![Complex32::new(1.0, -2.0); 4]).unwrap();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let accumulation = DotGeneralAccumulation {
+        lhs_conj: true,
+        rhs_conj: false,
+        alpha: tenferro_tensor::ContractionScalar::C32(Complex32::new(2.0, -1.0)),
+        beta: tenferro_tensor::ContractionScalar::C32(Complex32::new(-1.0, 0.5)),
+    };
+
+    backend
+        .dot_general_read_into_accum(
+            TensorRead::from_tensor(&lhs),
+            TensorRead::from_tensor(&rhs),
+            &config,
+            accumulation,
+            TensorWrite::from_tensor(&mut out),
+        )
+        .unwrap();
+
+    assert_complex32_close(
+        out.as_slice::<Complex32>().unwrap(),
+        &[
+            Complex32::new(32.0, -11.0),
+            Complex32::new(-8.25, 3.5),
+            Complex32::new(14.75, 32.0),
+            Complex32::new(-7.75, -1.125),
+        ],
+        1.0e-5,
+    );
+}
+
+#[test]
+#[cfg(feature = "cpu-tblis")]
+fn tblis_dot_general_falls_back_for_scalar_output_inner_product() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Tblis).unwrap();
+    let lhs = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]).unwrap();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![0],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+
+    let out = backend.dot_general(&lhs, &rhs, &config).unwrap();
+
+    assert_eq!(out.shape(), &[] as &[usize]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[32.0]);
+}
+
+#[test]
+#[cfg(feature = "cpu-tblis")]
+fn tblis_dot_general_falls_back_for_zero_size_matmul() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Tblis).unwrap();
+    let lhs = Tensor::from_vec_col_major(vec![2, 0], Vec::<f64>::new()).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![0, 3], Vec::<f64>::new()).unwrap();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+
+    let out = backend.dot_general(&lhs, &rhs, &config).unwrap();
+
+    assert_eq!(out.shape(), &[2, 3]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[0.0; 6]);
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn assert_complex64_close(actual: &[Complex64], expected: &[Complex64], tol: f64) {
+    assert_eq!(actual.len(), expected.len());
+    for (idx, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (actual - expected).norm() <= tol,
+            "complex64 mismatch at {idx}: actual={actual:?} expected={expected:?}"
+        );
+    }
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn assert_complex32_close(actual: &[Complex32], expected: &[Complex32], tol: f32) {
+    assert_eq!(actual.len(), expected.len());
+    for (idx, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            (actual - expected).norm() <= tol,
+            "complex32 mismatch at {idx}: actual={actual:?} expected={expected:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -40,6 +40,142 @@ macro_rules! delegate_with_pool {
     };
 }
 
+#[cfg(feature = "cpu-tblis")]
+impl CpuExecSession<'_> {
+    #[cfg(any(feature = "cpu-blas", feature = "cpu-faer"))]
+    fn dot_general_existing_provider_cached(
+        &mut self,
+        cache_slot: Option<usize>,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        let saved_kind = self.kind;
+        #[cfg(feature = "cpu-blas")]
+        {
+            self.kind = CpuBackendKind::Blas;
+        }
+        #[cfg(all(not(feature = "cpu-blas"), feature = "cpu-faer"))]
+        {
+            self.kind = CpuBackendKind::Faer;
+        }
+        let result = SessionCachedDot::dot_general_cached(self, cache_slot, lhs, rhs, config);
+        self.kind = saved_kind;
+        result
+    }
+
+    #[cfg(not(any(feature = "cpu-blas", feature = "cpu-faer")))]
+    fn dot_general_existing_provider_cached(
+        &mut self,
+        cache_slot: Option<usize>,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+    ) -> crate::Result<Tensor> {
+        let _ = (cache_slot, lhs, rhs, config);
+        Err(crate::Error::InvalidConfig {
+            op: "dot_general",
+            message: "CpuBackendKind::Tblis fallback requires cpu-blas or cpu-faer".into(),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(any(feature = "cpu-blas", feature = "cpu-faer"))]
+    fn dot_general_existing_provider_with_conj_cached(
+        &mut self,
+        cache_slot: Option<usize>,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+        lhs_conj: bool,
+        rhs_conj: bool,
+    ) -> crate::Result<Tensor> {
+        let saved_kind = self.kind;
+        #[cfg(feature = "cpu-blas")]
+        {
+            self.kind = CpuBackendKind::Blas;
+        }
+        #[cfg(all(not(feature = "cpu-blas"), feature = "cpu-faer"))]
+        {
+            self.kind = CpuBackendKind::Faer;
+        }
+        let result = SessionCachedDot::dot_general_with_conj_cached(
+            self, cache_slot, lhs, rhs, config, lhs_conj, rhs_conj,
+        );
+        self.kind = saved_kind;
+        result
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(not(any(feature = "cpu-blas", feature = "cpu-faer")))]
+    fn dot_general_existing_provider_with_conj_cached(
+        &mut self,
+        cache_slot: Option<usize>,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+        lhs_conj: bool,
+        rhs_conj: bool,
+    ) -> crate::Result<Tensor> {
+        let _ = (cache_slot, lhs, rhs, config, lhs_conj, rhs_conj);
+        Err(crate::Error::InvalidConfig {
+            op: "dot_general",
+            message: "CpuBackendKind::Tblis fallback requires cpu-blas or cpu-faer".into(),
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(any(feature = "cpu-blas", feature = "cpu-faer"))]
+    fn dot_general_existing_provider_read_into_accum_cached(
+        &mut self,
+        cache_slot: Option<usize>,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        accumulation: DotGeneralAccumulation,
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        let saved_kind = self.kind;
+        #[cfg(feature = "cpu-blas")]
+        {
+            self.kind = CpuBackendKind::Blas;
+        }
+        #[cfg(all(not(feature = "cpu-blas"), feature = "cpu-faer"))]
+        {
+            self.kind = CpuBackendKind::Faer;
+        }
+        let result = SessionCachedDot::dot_general_read_into_accum_cached(
+            self,
+            cache_slot,
+            lhs,
+            rhs,
+            config,
+            accumulation,
+            out,
+        );
+        self.kind = saved_kind;
+        result
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    #[cfg(not(any(feature = "cpu-blas", feature = "cpu-faer")))]
+    fn dot_general_existing_provider_read_into_accum_cached(
+        &mut self,
+        cache_slot: Option<usize>,
+        lhs: TensorRead<'_>,
+        rhs: TensorRead<'_>,
+        config: &DotGeneralConfig,
+        accumulation: DotGeneralAccumulation,
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        let _ = (cache_slot, lhs, rhs, config, accumulation, out);
+        Err(crate::Error::InvalidConfig {
+            op: "dot_general",
+            message: "CpuBackendKind::Tblis fallback requires cpu-blas or cpu-faer".into(),
+        })
+    }
+}
+
 impl TensorElementwise for CpuExecSession<'_> {
     // Elementwise — direct delegation, no install
     delegate_with_pool!(add(lhs: &Tensor, rhs: &Tensor) => elementwise::add_with_pool);
@@ -226,6 +362,24 @@ impl TensorDot for CpuExecSession<'_> {
                     ));
                 }
             }
+            CpuBackendKind::Tblis => {
+                #[cfg(feature = "cpu-tblis")]
+                {
+                    gemm::dot_general_tblis_read_cached(
+                        self.buffers,
+                        lhs.clone(),
+                        rhs.clone(),
+                        config,
+                    )?
+                }
+                #[cfg(not(feature = "cpu-tblis"))]
+                {
+                    return Err(super::backend::unavailable_cpu_backend_kind(
+                        self.kind,
+                        "dot_general",
+                    ));
+                }
+            }
         };
         if let Some(result) = direct {
             return Ok(result);
@@ -401,6 +555,47 @@ impl SessionCachedDot for CpuExecSession<'_> {
                     ))
                 }
             }
+            CpuBackendKind::Tblis => {
+                #[cfg(feature = "cpu-tblis")]
+                {
+                    let direct = match (lhs, rhs) {
+                        (Tensor::F32(a), Tensor::F32(b)) => {
+                            gemm::dot_general_tblis_cached(self.buffers, a, b, config)
+                                .map(|result| result.map(Tensor::F32))
+                        }
+                        (Tensor::F64(a), Tensor::F64(b)) => {
+                            gemm::dot_general_tblis_cached(self.buffers, a, b, config)
+                                .map(|result| result.map(Tensor::F64))
+                        }
+                        (Tensor::C32(a), Tensor::C32(b)) => {
+                            gemm::dot_general_tblis_cached(self.buffers, a, b, config)
+                                .map(|result| result.map(Tensor::C32))
+                        }
+                        (Tensor::C64(a), Tensor::C64(b)) => {
+                            gemm::dot_general_tblis_cached(self.buffers, a, b, config)
+                                .map(|result| result.map(Tensor::C64))
+                        }
+                        _ if lhs.dtype() == rhs.dtype() => Ok(None),
+                        _ => Err(crate::Error::DTypeMismatch {
+                            op: "dot_general",
+                            lhs: lhs.dtype(),
+                            rhs: rhs.dtype(),
+                        }),
+                    }?;
+                    if let Some(result) = direct {
+                        Ok(result)
+                    } else {
+                        self.dot_general_existing_provider_cached(cache_slot, lhs, rhs, config)
+                    }
+                }
+                #[cfg(not(feature = "cpu-tblis"))]
+                {
+                    Err(super::backend::unavailable_cpu_backend_kind(
+                        self.kind,
+                        "dot_general",
+                    ))
+                }
+            }
         }
     }
 
@@ -560,6 +755,77 @@ impl SessionCachedDot for CpuExecSession<'_> {
                     ))
                 }
             }
+            CpuBackendKind::Tblis => {
+                #[cfg(feature = "cpu-tblis")]
+                {
+                    let direct = match (lhs, rhs) {
+                        (Tensor::F32(a), Tensor::F32(b)) => {
+                            gemm::dot_general_tblis_with_conj_cached(
+                                self.buffers,
+                                a,
+                                b,
+                                config,
+                                lhs_conj,
+                                rhs_conj,
+                            )
+                            .map(|result| result.map(Tensor::F32))
+                        }
+                        (Tensor::F64(a), Tensor::F64(b)) => {
+                            gemm::dot_general_tblis_with_conj_cached(
+                                self.buffers,
+                                a,
+                                b,
+                                config,
+                                lhs_conj,
+                                rhs_conj,
+                            )
+                            .map(|result| result.map(Tensor::F64))
+                        }
+                        (Tensor::C32(a), Tensor::C32(b)) => {
+                            gemm::dot_general_tblis_with_conj_cached(
+                                self.buffers,
+                                a,
+                                b,
+                                config,
+                                lhs_conj,
+                                rhs_conj,
+                            )
+                            .map(|result| result.map(Tensor::C32))
+                        }
+                        (Tensor::C64(a), Tensor::C64(b)) => {
+                            gemm::dot_general_tblis_with_conj_cached(
+                                self.buffers,
+                                a,
+                                b,
+                                config,
+                                lhs_conj,
+                                rhs_conj,
+                            )
+                            .map(|result| result.map(Tensor::C64))
+                        }
+                        _ if lhs.dtype() == rhs.dtype() => Ok(None),
+                        _ => Err(crate::Error::DTypeMismatch {
+                            op: "dot_general",
+                            lhs: lhs.dtype(),
+                            rhs: rhs.dtype(),
+                        }),
+                    }?;
+                    if let Some(result) = direct {
+                        Ok(result)
+                    } else {
+                        self.dot_general_existing_provider_with_conj_cached(
+                            cache_slot, lhs, rhs, config, lhs_conj, rhs_conj,
+                        )
+                    }
+                }
+                #[cfg(not(feature = "cpu-tblis"))]
+                {
+                    Err(super::backend::unavailable_cpu_backend_kind(
+                        self.kind,
+                        "dot_general",
+                    ))
+                }
+            }
         }
     }
 
@@ -618,9 +884,40 @@ impl SessionCachedDot for CpuExecSession<'_> {
                     ));
                 }
             }
+            CpuBackendKind::Tblis => {
+                #[cfg(feature = "cpu-tblis")]
+                {
+                    gemm::dot_general_tblis_read_into_accum_cached(
+                        lhs.clone(),
+                        rhs.clone(),
+                        config,
+                        accumulation,
+                        &mut out,
+                    )?
+                }
+                #[cfg(not(feature = "cpu-tblis"))]
+                {
+                    return Err(super::backend::unavailable_cpu_backend_kind(
+                        self.kind,
+                        "dot_general",
+                    ));
+                }
+            }
         };
         if direct {
             return Ok(());
+        }
+
+        #[cfg(feature = "cpu-tblis")]
+        if self.kind == CpuBackendKind::Tblis {
+            return self.dot_general_existing_provider_read_into_accum_cached(
+                cache_slot,
+                lhs,
+                rhs,
+                config,
+                accumulation,
+                out,
+            );
         }
 
         dot_general_accum_via_temp(self, lhs, rhs, config, accumulation, out)

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -7,6 +7,7 @@ use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::default_placement;
 #[cfg(feature = "cpu-blas")]
 use crate::elementwise::typed_conj_with_pool;
+#[cfg(any(feature = "cpu-blas", feature = "cpu-faer"))]
 use crate::structural::typed_transpose_with_pool;
 #[cfg(feature = "cpu-blas")]
 use crate::ConjElem;
@@ -24,11 +25,15 @@ mod blas_gemm;
 mod faer_gemm;
 #[cfg(feature = "cpu-faer")]
 mod strided_dot;
+#[cfg(feature = "cpu-tblis")]
+mod tblis_gemm;
 
 #[cfg(feature = "cpu-blas")]
 use blas_gemm::BlasGemm;
 #[cfg(feature = "cpu-faer")]
 use faer_gemm::FaerGemm;
+#[cfg(feature = "cpu-tblis")]
+use tblis_gemm::TblisGemm;
 
 const OP: &str = "dot_general";
 
@@ -2238,6 +2243,362 @@ where
         Buffer::Host(out),
         default_placement(),
     )?))
+}
+
+#[cfg(feature = "cpu-tblis")]
+pub(crate) fn dot_general_tblis_cached<T>(
+    buffers: &mut BufferPool,
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+    config: &DotGeneralConfig,
+) -> crate::Result<Option<TypedTensor<T>>>
+where
+    T: TblisGemm + PoolScalar + Copy + Clone + Zero + One + 'static,
+{
+    typed_tblis_gemm(buffers, lhs, rhs, config, false, false)
+}
+
+#[cfg(feature = "cpu-tblis")]
+pub(crate) fn dot_general_tblis_with_conj_cached<T>(
+    buffers: &mut BufferPool,
+    lhs: &TypedTensor<T>,
+    rhs: &TypedTensor<T>,
+    config: &DotGeneralConfig,
+    lhs_conj: bool,
+    rhs_conj: bool,
+) -> crate::Result<Option<TypedTensor<T>>>
+where
+    T: TblisGemm + PoolScalar + Copy + Clone + Zero + One + 'static,
+{
+    typed_tblis_gemm(buffers, lhs, rhs, config, lhs_conj, rhs_conj)
+}
+
+#[cfg(feature = "cpu-tblis")]
+pub(crate) fn dot_general_tblis_read_cached(
+    buffers: &mut BufferPool,
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+    config: &DotGeneralConfig,
+) -> crate::Result<Option<crate::Tensor>> {
+    macro_rules! dispatch {
+        ($owned:ident, $view:ident, $wrap:ident) => {
+            match (&lhs, &rhs) {
+                (
+                    TensorRead::Tensor(crate::Tensor::$owned(a)),
+                    TensorRead::Tensor(crate::Tensor::$owned(b)),
+                ) => {
+                    return typed_tblis_gemm(buffers, a, b, config, false, false)
+                        .map(|result| result.map(crate::Tensor::$wrap));
+                }
+                (
+                    TensorRead::Tensor(crate::Tensor::$owned(a)),
+                    TensorRead::View(TensorView::$view(b)),
+                ) => {
+                    return typed_tblis_gemm(buffers, a, b, config, false, false)
+                        .map(|result| result.map(crate::Tensor::$wrap));
+                }
+                (
+                    TensorRead::View(TensorView::$view(a)),
+                    TensorRead::Tensor(crate::Tensor::$owned(b)),
+                ) => {
+                    return typed_tblis_gemm(buffers, a, b, config, false, false)
+                        .map(|result| result.map(crate::Tensor::$wrap));
+                }
+                (
+                    TensorRead::View(TensorView::$view(a)),
+                    TensorRead::View(TensorView::$view(b)),
+                ) => {
+                    return typed_tblis_gemm(buffers, a, b, config, false, false)
+                        .map(|result| result.map(crate::Tensor::$wrap));
+                }
+                _ => {}
+            }
+        };
+    }
+
+    dispatch!(F32, F32, F32);
+    dispatch!(F64, F64, F64);
+    dispatch!(C32, C32, C32);
+    dispatch!(C64, C64, C64);
+
+    if lhs.dtype() == rhs.dtype() {
+        Ok(None)
+    } else {
+        Err(Error::DTypeMismatch {
+            op: "dot_general",
+            lhs: lhs.dtype(),
+            rhs: rhs.dtype(),
+        })
+    }
+}
+
+#[cfg(feature = "cpu-tblis")]
+// INVARIANT: this fast path mirrors dot-general read inputs plus accumulation
+// and output-write metadata for one TBLIS dispatch.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn dot_general_tblis_read_into_accum_cached(
+    lhs: TensorRead<'_>,
+    rhs: TensorRead<'_>,
+    config: &DotGeneralConfig,
+    accumulation: DotGeneralAccumulation,
+    out: &mut TensorWrite<'_>,
+) -> crate::Result<bool> {
+    macro_rules! dispatch {
+        ($owned:ident, $view:ident) => {
+            if let (ContractionScalar::$owned(alpha), ContractionScalar::$owned(beta)) =
+                (accumulation.alpha, accumulation.beta)
+            {
+                match (&lhs, &rhs, &mut *out) {
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return dot_general_tblis_accum_typed(
+                            a,
+                            b,
+                            config,
+                            alpha,
+                            beta,
+                            &mut c,
+                            accumulation.lhs_conj,
+                            accumulation.rhs_conj,
+                        );
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return dot_general_tblis_accum_typed(
+                            a,
+                            b,
+                            config,
+                            alpha,
+                            beta,
+                            &mut c,
+                            accumulation.lhs_conj,
+                            accumulation.rhs_conj,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return dot_general_tblis_accum_typed(
+                            a,
+                            b,
+                            config,
+                            alpha,
+                            beta,
+                            &mut c,
+                            accumulation.lhs_conj,
+                            accumulation.rhs_conj,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::Tensor(crate::Tensor::$owned(c)),
+                    ) => {
+                        let mut c = c.as_view_mut();
+                        return dot_general_tblis_accum_typed(
+                            a,
+                            b,
+                            config,
+                            alpha,
+                            beta,
+                            &mut c,
+                            accumulation.lhs_conj,
+                            accumulation.rhs_conj,
+                        );
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => {
+                        return dot_general_tblis_accum_typed(
+                            a,
+                            b,
+                            config,
+                            alpha,
+                            beta,
+                            c,
+                            accumulation.lhs_conj,
+                            accumulation.rhs_conj,
+                        );
+                    }
+                    (
+                        TensorRead::Tensor(crate::Tensor::$owned(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => {
+                        return dot_general_tblis_accum_typed(
+                            a,
+                            b,
+                            config,
+                            alpha,
+                            beta,
+                            c,
+                            accumulation.lhs_conj,
+                            accumulation.rhs_conj,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::Tensor(crate::Tensor::$owned(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => {
+                        return dot_general_tblis_accum_typed(
+                            a,
+                            b,
+                            config,
+                            alpha,
+                            beta,
+                            c,
+                            accumulation.lhs_conj,
+                            accumulation.rhs_conj,
+                        );
+                    }
+                    (
+                        TensorRead::View(TensorView::$view(a)),
+                        TensorRead::View(TensorView::$view(b)),
+                        TensorWrite::View(TensorViewMut::$view(c)),
+                    ) => {
+                        return dot_general_tblis_accum_typed(
+                            a,
+                            b,
+                            config,
+                            alpha,
+                            beta,
+                            c,
+                            accumulation.lhs_conj,
+                            accumulation.rhs_conj,
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        };
+    }
+
+    dispatch!(F32, F32);
+    dispatch!(F64, F64);
+    dispatch!(C32, C32);
+    dispatch!(C64, C64);
+    Ok(false)
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn dot_general_tblis_accum_typed<L, R, T>(
+    lhs: &L,
+    rhs: &R,
+    config: &DotGeneralConfig,
+    alpha: T,
+    beta: T,
+    out: &mut TypedTensorViewMut<'_, T>,
+    lhs_conj: bool,
+    rhs_conj: bool,
+) -> crate::Result<bool>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+    T: TblisGemm + Copy + Clone + Zero + One + PartialEq + std::ops::Mul<Output = T> + 'static,
+{
+    let Some(plan) = tblis_gemm::plan(lhs, rhs, config, out.shape(), out.strides())? else {
+        return Ok(false);
+    };
+
+    let out_n = tblis_gemm::output_element_count(out.shape())?;
+    if out_n == 0 {
+        scale_empty_contract_output(out, beta)?;
+        return Ok(true);
+    }
+
+    let Some(a_data) = lhs.host_data_opt()?.map(<[T]>::as_ptr) else {
+        return Ok(false);
+    };
+    let Some(b_data) = rhs.host_data_opt()?.map(<[T]>::as_ptr) else {
+        return Ok(false);
+    };
+    let a_base = lhs.offset();
+    let b_base = rhs.offset();
+    if a_base < 0 || b_base < 0 {
+        return Ok(false);
+    }
+
+    // SAFETY: offsets are non-negative and the validated tensor layouts prove
+    // the logical positive-stride regions are addressable in their host buffers.
+    let a_ptr = unsafe { a_data.offset(a_base) };
+    // SAFETY: same proof as `a_ptr` for the rhs input.
+    let b_ptr = unsafe { b_data.offset(b_base) };
+    tblis_gemm::execute(plan, alpha, a_ptr, b_ptr, beta, out, lhs_conj, rhs_conj)?;
+    Ok(true)
+}
+
+#[cfg(feature = "cpu-tblis")]
+fn typed_tblis_gemm<L, R, T>(
+    buffers: &mut BufferPool,
+    lhs: &L,
+    rhs: &R,
+    config: &DotGeneralConfig,
+    lhs_conj: bool,
+    rhs_conj: bool,
+) -> crate::Result<Option<TypedTensor<T>>>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+    T: TblisGemm + PoolScalar + Copy + Clone + Zero + One + 'static,
+{
+    let out_shape = tblis_gemm::output_shape(lhs, rhs, config)?;
+    let out_strides: SmallVec<[isize; 8]> = col_major_strides(&out_shape)?.into_iter().collect();
+    let Some(plan) = tblis_gemm::plan(lhs, rhs, config, &out_shape, &out_strides)? else {
+        return Ok(None);
+    };
+
+    let out_n = tblis_gemm::output_element_count(&out_shape)?;
+    let out = T::pool_acquire_zeroed(buffers, out_n);
+    let mut tensor = TypedTensor::from_buffer_col_major(
+        out_shape.into_vec(),
+        Buffer::Host(out),
+        default_placement(),
+    )?;
+    let mut out_view = tensor.as_view_mut();
+
+    let Some(a_data) = lhs.host_data_opt()?.map(<[T]>::as_ptr) else {
+        return Ok(None);
+    };
+    let Some(b_data) = rhs.host_data_opt()?.map(<[T]>::as_ptr) else {
+        return Ok(None);
+    };
+    let a_base = lhs.offset();
+    let b_base = rhs.offset();
+    if a_base < 0 || b_base < 0 {
+        return Ok(None);
+    }
+
+    // SAFETY: offsets are non-negative and the validated tensor layouts prove
+    // the logical positive-stride regions are addressable in their host buffers.
+    let a_ptr = unsafe { a_data.offset(a_base) };
+    // SAFETY: same proof as `a_ptr` for the rhs input.
+    let b_ptr = unsafe { b_data.offset(b_base) };
+    tblis_gemm::execute(
+        plan,
+        T::one(),
+        a_ptr,
+        b_ptr,
+        T::zero(),
+        &mut out_view,
+        lhs_conj,
+        rhs_conj,
+    )?;
+
+    Ok(Some(tensor))
 }
 
 fn normalize_singleton_stride(stride: isize, extent: usize, fallback: usize) -> isize {

--- a/crates/tenferro-cpu/src/gemm/tblis_gemm.rs
+++ b/crates/tenferro-cpu/src/gemm/tblis_gemm.rs
@@ -1,0 +1,387 @@
+use core::ffi::{c_char, c_int, c_void};
+
+use num_traits::{One, Zero};
+use smallvec::SmallVec;
+use tblis_ffi::tblis::{
+    label_type, len_type, stride_type, tblis_scalar, tblis_scalar_scalar, tblis_tensor,
+    tblis_tensor_mult, type_t, TYPE_DCOMPLEX, TYPE_DOUBLE, TYPE_SCOMPLEX, TYPE_SINGLE,
+};
+
+use super::{checked_product, validate_dot_general, TypedTensorRead, OP};
+use crate::{Error, Result};
+use tenferro_tensor::{DotGeneralConfig, TypedTensorViewMut};
+
+use num_complex::{Complex32, Complex64};
+
+pub(crate) trait TblisGemm: Copy + One + Zero + 'static {
+    const TYPE: type_t;
+
+    fn scalar(value: Self) -> tblis_scalar;
+}
+
+impl TblisGemm for f32 {
+    const TYPE: type_t = TYPE_SINGLE;
+
+    fn scalar(value: Self) -> tblis_scalar {
+        tblis_scalar {
+            data: tblis_scalar_scalar { s: value },
+            type_: Self::TYPE,
+        }
+    }
+}
+
+impl TblisGemm for f64 {
+    const TYPE: type_t = TYPE_DOUBLE;
+
+    fn scalar(value: Self) -> tblis_scalar {
+        tblis_scalar {
+            data: tblis_scalar_scalar { d: value },
+            type_: Self::TYPE,
+        }
+    }
+}
+
+impl TblisGemm for Complex32 {
+    const TYPE: type_t = TYPE_SCOMPLEX;
+
+    fn scalar(value: Self) -> tblis_scalar {
+        tblis_scalar {
+            data: tblis_scalar_scalar { c: value },
+            type_: Self::TYPE,
+        }
+    }
+}
+
+impl TblisGemm for Complex64 {
+    const TYPE: type_t = TYPE_DCOMPLEX;
+
+    fn scalar(value: Self) -> tblis_scalar {
+        tblis_scalar {
+            data: tblis_scalar_scalar { z: value },
+            type_: Self::TYPE,
+        }
+    }
+}
+
+pub(crate) struct TblisPlan {
+    lhs_len: SmallVec<[len_type; 8]>,
+    rhs_len: SmallVec<[len_type; 8]>,
+    out_len: SmallVec<[len_type; 8]>,
+    lhs_stride: SmallVec<[stride_type; 8]>,
+    rhs_stride: SmallVec<[stride_type; 8]>,
+    out_stride: SmallVec<[stride_type; 8]>,
+    lhs_labels: SmallVec<[label_type; 8]>,
+    rhs_labels: SmallVec<[label_type; 8]>,
+    out_labels: SmallVec<[label_type; 8]>,
+}
+
+pub(crate) fn output_shape<L, R, T>(
+    lhs: &L,
+    rhs: &R,
+    config: &DotGeneralConfig,
+) -> Result<SmallVec<[usize; 8]>>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+{
+    validate_dot_general(lhs, rhs, config)?;
+
+    let lhs_shape = lhs.shape();
+    let rhs_shape = rhs.shape();
+    let lhs_free = free_dims(
+        lhs_shape.len(),
+        &config.lhs_contracting_dims,
+        &config.lhs_batch_dims,
+    );
+    let rhs_free = free_dims(
+        rhs_shape.len(),
+        &config.rhs_contracting_dims,
+        &config.rhs_batch_dims,
+    );
+
+    let mut out = SmallVec::<[usize; 8]>::new();
+    out.extend(lhs_free.iter().map(|&axis| lhs_shape[axis]));
+    out.extend(rhs_free.iter().map(|&axis| rhs_shape[axis]));
+    out.extend(config.lhs_batch_dims.iter().map(|&axis| lhs_shape[axis]));
+    Ok(out)
+}
+
+pub(crate) fn plan<L, R, T>(
+    lhs: &L,
+    rhs: &R,
+    config: &DotGeneralConfig,
+    out_shape: &[usize],
+    out_strides: &[isize],
+) -> Result<Option<TblisPlan>>
+where
+    L: TypedTensorRead<T>,
+    R: TypedTensorRead<T>,
+{
+    let expected_out_shape = output_shape(lhs, rhs, config)?;
+    if expected_out_shape.as_slice() != out_shape {
+        return Ok(None);
+    }
+
+    let lhs_shape = lhs.shape();
+    let rhs_shape = rhs.shape();
+    let lhs_rank = lhs_shape.len();
+    let rhs_rank = rhs_shape.len();
+    if lhs_rank == 0 || rhs_rank == 0 || out_shape.is_empty() {
+        return Ok(None);
+    }
+    if lhs_shape
+        .iter()
+        .chain(rhs_shape)
+        .chain(out_shape)
+        .any(|&dim| dim == 0)
+    {
+        return Ok(None);
+    }
+    if lhs.offset() < 0 || rhs.offset() < 0 {
+        return Ok(None);
+    }
+
+    let lhs_strides = lhs.strides()?;
+    let rhs_strides = rhs.strides()?;
+    if lhs_strides
+        .iter()
+        .chain(rhs_strides.iter())
+        .chain(out_strides.iter())
+        .any(|&stride| stride <= 0)
+    {
+        return Ok(None);
+    }
+
+    let out_rank = out_shape.len();
+    if lhs_rank > c_int::MAX as usize
+        || rhs_rank > c_int::MAX as usize
+        || out_rank > c_int::MAX as usize
+    {
+        return Ok(None);
+    }
+
+    let mut labels = TblisLabelAllocator::new();
+    let mut lhs_labels = SmallVec::<[label_type; 8]>::from_elem(0, lhs_rank);
+    let mut rhs_labels = SmallVec::<[label_type; 8]>::from_elem(0, rhs_rank);
+    let mut out_labels = SmallVec::<[label_type; 8]>::new();
+
+    let lhs_free = free_dims(
+        lhs_rank,
+        &config.lhs_contracting_dims,
+        &config.lhs_batch_dims,
+    );
+    let rhs_free = free_dims(
+        rhs_rank,
+        &config.rhs_contracting_dims,
+        &config.rhs_batch_dims,
+    );
+
+    for &axis in &lhs_free {
+        let label = match labels.next() {
+            Some(label) => label,
+            None => return Ok(None),
+        };
+        lhs_labels[axis] = label;
+        out_labels.push(label);
+    }
+    for &axis in &rhs_free {
+        let label = match labels.next() {
+            Some(label) => label,
+            None => return Ok(None),
+        };
+        rhs_labels[axis] = label;
+        out_labels.push(label);
+    }
+    for (&lhs_axis, &rhs_axis) in config
+        .lhs_batch_dims
+        .iter()
+        .zip(config.rhs_batch_dims.iter())
+    {
+        let label = match labels.next() {
+            Some(label) => label,
+            None => return Ok(None),
+        };
+        lhs_labels[lhs_axis] = label;
+        rhs_labels[rhs_axis] = label;
+        out_labels.push(label);
+    }
+    for (&lhs_axis, &rhs_axis) in config
+        .lhs_contracting_dims
+        .iter()
+        .zip(config.rhs_contracting_dims.iter())
+    {
+        let label = match labels.next() {
+            Some(label) => label,
+            None => return Ok(None),
+        };
+        lhs_labels[lhs_axis] = label;
+        rhs_labels[rhs_axis] = label;
+    }
+
+    if lhs_labels.iter().any(|&label| label == 0) || rhs_labels.iter().any(|&label| label == 0) {
+        return Ok(None);
+    }
+
+    lhs_labels.push(0);
+    rhs_labels.push(0);
+    out_labels.push(0);
+
+    Ok(Some(TblisPlan {
+        lhs_len: dims_to_tblis(lhs_shape)?,
+        rhs_len: dims_to_tblis(rhs_shape)?,
+        out_len: dims_to_tblis(out_shape)?,
+        lhs_stride: strides_to_tblis(lhs_strides.as_slice())?,
+        rhs_stride: strides_to_tblis(rhs_strides.as_slice())?,
+        out_stride: strides_to_tblis(out_strides)?,
+        lhs_labels,
+        rhs_labels,
+        out_labels,
+    }))
+}
+
+pub(crate) fn execute<T>(
+    mut plan: TblisPlan,
+    alpha: T,
+    lhs_ptr: *const T,
+    rhs_ptr: *const T,
+    beta: T,
+    out: &mut TypedTensorViewMut<'_, T>,
+    lhs_conj: bool,
+    rhs_conj: bool,
+) -> Result<()>
+where
+    T: TblisGemm,
+{
+    ensure_runtime_available()?;
+    if out.offset() < 0 {
+        return Err(Error::InvalidConfig {
+            op: OP,
+            message: "TBLIS output offset must be non-negative".into(),
+        });
+    }
+    let out_offset = usize::try_from(out.offset()).map_err(|_| Error::InvalidConfig {
+        op: OP,
+        message: "TBLIS output offset does not fit in usize".into(),
+    })?;
+    let out_storage = out.host_storage_mut()?;
+    if out_offset > out_storage.len() {
+        return Err(Error::InvalidConfig {
+            op: OP,
+            message: "TBLIS output offset is outside host storage".into(),
+        });
+    }
+    let out_ptr = out_storage.as_mut_ptr();
+
+    let mut lhs_tensor = tblis_tensor {
+        type_: T::TYPE,
+        conj: c_int::from(lhs_conj),
+        scalar: T::scalar(alpha),
+        data: lhs_ptr.cast_mut() as *mut c_void,
+        ndim: c_int::try_from(plan.lhs_len.len()).map_err(|_| Error::InvalidConfig {
+            op: OP,
+            message: "TBLIS lhs rank exceeds c_int range".into(),
+        })?,
+        len: plan.lhs_len.as_mut_ptr(),
+        stride: plan.lhs_stride.as_mut_ptr(),
+    };
+    let mut rhs_tensor = tblis_tensor {
+        type_: T::TYPE,
+        conj: c_int::from(rhs_conj),
+        scalar: T::scalar(T::one()),
+        data: rhs_ptr.cast_mut() as *mut c_void,
+        ndim: c_int::try_from(plan.rhs_len.len()).map_err(|_| Error::InvalidConfig {
+            op: OP,
+            message: "TBLIS rhs rank exceeds c_int range".into(),
+        })?,
+        len: plan.rhs_len.as_mut_ptr(),
+        stride: plan.rhs_stride.as_mut_ptr(),
+    };
+    let mut out_tensor = tblis_tensor {
+        type_: T::TYPE,
+        conj: 0,
+        scalar: T::scalar(beta),
+        data: out_ptr.wrapping_add(out_offset) as *mut c_void,
+        ndim: c_int::try_from(plan.out_len.len()).map_err(|_| Error::InvalidConfig {
+            op: OP,
+            message: "TBLIS output rank exceeds c_int range".into(),
+        })?,
+        len: plan.out_len.as_mut_ptr(),
+        stride: plan.out_stride.as_mut_ptr(),
+    };
+
+    // SAFETY: all tensors are host-backed for the duration of the call; ranks,
+    // shapes, positive strides, non-negative offsets, dtype, and label counts
+    // are validated before construction. TBLIS owns execution only and receives
+    // null comm/context for its default runtime behavior.
+    unsafe {
+        tblis_tensor_mult(
+            std::ptr::null(),
+            std::ptr::null(),
+            &lhs_tensor,
+            plan.lhs_labels.as_ptr(),
+            &rhs_tensor,
+            plan.rhs_labels.as_ptr(),
+            &mut out_tensor,
+            plan.out_labels.as_ptr(),
+        );
+    }
+    // Keep variables visibly live across the FFI call.
+    let _ = (&mut lhs_tensor, &mut rhs_tensor);
+    Ok(())
+}
+
+fn ensure_runtime_available() -> Result<()> {
+    Ok(())
+}
+
+pub(crate) fn output_element_count(shape: &[usize]) -> Result<usize> {
+    checked_product(shape).ok_or_else(|| {
+        Error::backend_failure(OP, "TBLIS output element count overflow while allocating")
+    })
+}
+
+fn free_dims(rank: usize, contracting: &[usize], batch: &[usize]) -> SmallVec<[usize; 8]> {
+    (0..rank)
+        .filter(|axis| !contracting.contains(axis) && !batch.contains(axis))
+        .collect()
+}
+
+fn dims_to_tblis(dims: &[usize]) -> Result<SmallVec<[len_type; 8]>> {
+    dims.iter()
+        .map(|&dim| {
+            len_type::try_from(dim).map_err(|_| Error::InvalidConfig {
+                op: OP,
+                message: format!("TBLIS dimension {dim} exceeds len_type range"),
+            })
+        })
+        .collect()
+}
+
+fn strides_to_tblis(strides: &[isize]) -> Result<SmallVec<[stride_type; 8]>> {
+    strides
+        .iter()
+        .map(|&stride| {
+            stride_type::try_from(stride).map_err(|_| Error::InvalidConfig {
+                op: OP,
+                message: format!("TBLIS stride {stride} exceeds stride_type range"),
+            })
+        })
+        .collect()
+}
+
+struct TblisLabelAllocator {
+    next: usize,
+}
+
+impl TblisLabelAllocator {
+    fn new() -> Self {
+        Self { next: 0 }
+    }
+
+    fn next(&mut self) -> Option<label_type> {
+        const LABELS: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        let byte = *LABELS.get(self.next)?;
+        self.next += 1;
+        Some(byte as c_char)
+    }
+}

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -17,7 +17,9 @@
 //! ```
 
 #[cfg(not(any(feature = "cpu-faer", feature = "cpu-blas")))]
-compile_error!("enable at least one CPU backend: cpu-faer or cpu-blas");
+compile_error!(
+    "enable at least one fallback CPU backend: cpu-faer or cpu-blas; cpu-tblis is an optional contraction provider"
+);
 
 #[cfg(all(feature = "provider-inject", not(feature = "cpu-blas")))]
 compile_error!("provider-inject requires cpu-blas");
@@ -71,6 +73,8 @@ extern crate cblas_src as _;
 extern crate lapack_inject as _;
 #[cfg(feature = "provider-src")]
 extern crate lapack_src as _;
+#[cfg(feature = "cpu-tblis")]
+extern crate tenferro_tblis_src as _;
 
 pub use affinity::{available_parallelism, process_cpu_affinity_count};
 pub use backend::{CpuBackend, CpuBackendKind};

--- a/crates/tenferro-cpu/tests/provider_feature_contract.rs
+++ b/crates/tenferro-cpu/tests/provider_feature_contract.rs
@@ -2,6 +2,15 @@ use std::path::{Path, PathBuf};
 
 const PROVIDER_FEATURES: &[(&str, &[&str])] = &[
     (
+        "cpu-tblis",
+        &[
+            "dep:tblis-ffi",
+            "dep:tenferro-tblis-src",
+            "tenferro-tblis-src/build_from_source",
+            "tenferro-tblis-src/static",
+        ],
+    ),
+    (
         "blas-openblas",
         &[
             "provider-src",

--- a/crates/tenferro-einsum/Cargo.toml
+++ b/crates/tenferro-einsum/Cargo.toml
@@ -25,6 +25,10 @@ cpu-blas = [
     "tenferro-ad?/cpu-blas",
     "tenferro-cpu/cpu-blas",
 ]
+cpu-tblis = [
+    "tenferro-ad?/cpu-tblis",
+    "tenferro-cpu/cpu-tblis",
+]
 blas-openblas = [
     "tenferro-ad?/blas-openblas",
     "tenferro-cpu/blas-openblas",

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -14,6 +14,7 @@ description = "FFT extension runtime and public concrete/traced FFT APIs for ten
 default = ["cpu-faer"]
 cpu-faer = ["tenferro-cpu/cpu-faer"]
 cpu-blas = ["tenferro-cpu/cpu-blas"]
+cpu-tblis = ["tenferro-ad?/cpu-tblis", "tenferro-cpu/cpu-tblis"]
 blas-openblas = ["tenferro-ad?/blas-openblas", "tenferro-cpu/blas-openblas"]
 blas-accelerate = ["tenferro-ad?/blas-accelerate", "tenferro-cpu/blas-accelerate"]
 blas-mkl = ["tenferro-ad?/blas-mkl", "tenferro-cpu/blas-mkl"]

--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -17,6 +17,7 @@ name = "tenferro_gpu"
 default = ["cpu-faer"]
 cpu-faer = ["tenferro-cpu/cpu-faer"]
 cpu-blas = ["tenferro-cpu/cpu-blas"]
+cpu-tblis = ["tenferro-cpu/cpu-tblis"]
 blas-openblas = ["tenferro-cpu/blas-openblas"]
 blas-accelerate = ["tenferro-cpu/blas-accelerate"]
 blas-mkl = ["tenferro-cpu/blas-mkl"]

--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -26,6 +26,10 @@ cpu-blas = [
     "tenferro-ad?/cpu-blas",
     "tenferro-cpu/cpu-blas",
 ]
+cpu-tblis = [
+    "tenferro-ad?/cpu-tblis",
+    "tenferro-cpu/cpu-tblis",
+]
 blas-openblas = [
     "tenferro-ad?/blas-openblas",
     "tenferro-cpu/blas-openblas",

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -12,8 +12,8 @@ use tenferro_tensor::{
 impl LinalgBackend for CpuBackend {
     fn cholesky(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         ensure_host_tensor("cholesky", input)?;
-        match self.kind() {
-            CpuBackendKind::Faer => {
+        match linalg_provider_kind(self.kind(), "cholesky")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -38,7 +38,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("cholesky", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| match input {
@@ -68,8 +68,8 @@ impl LinalgBackend for CpuBackend {
     ) -> tenferro_tensor::Result<Tensor> {
         ensure_host_tensor("triangular_solve", a)?;
         ensure_host_tensor("triangular_solve", b)?;
-        match self.kind() {
-            CpuBackendKind::Faer => {
+        match linalg_provider_kind(self.kind(), "triangular_solve")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -126,7 +126,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("triangular_solve", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| match (a, b) {
@@ -183,8 +183,8 @@ impl LinalgBackend for CpuBackend {
 
     fn lu(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         ensure_host_tensor("lu", input)?;
-        match self.kind() {
-            CpuBackendKind::Faer => {
+        match linalg_provider_kind(self.kind(), "lu")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -205,7 +205,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("lu", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| match input {
@@ -230,8 +230,8 @@ impl LinalgBackend for CpuBackend {
 
     fn lu_factor(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         ensure_host_tensor("lu_factor", input)?;
-        match self.kind() {
-            CpuBackendKind::Faer => {
+        match linalg_provider_kind(self.kind(), "lu_factor")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -264,7 +264,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("lu_factor", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| match input {
@@ -301,8 +301,8 @@ impl LinalgBackend for CpuBackend {
 
     fn full_piv_lu(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         ensure_host_tensor("full_piv_lu", input)?;
-        match self.kind() {
-            CpuBackendKind::Faer => {
+        match linalg_provider_kind(self.kind(), "full_piv_lu")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -323,7 +323,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("full_piv_lu", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| match input {
@@ -368,8 +368,8 @@ impl LinalgBackend for CpuBackend {
             (b.clone(), None)
         };
 
-        let result = match self.kind() {
-            CpuBackendKind::Faer => {
+        let result = match linalg_provider_kind(self.kind(), "full_piv_lu_solve")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -414,7 +414,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("full_piv_lu_solve", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| match (a, &rhs) {
@@ -453,8 +453,8 @@ impl LinalgBackend for CpuBackend {
 
     fn svd(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         ensure_host_tensor("svd", input)?;
-        match self.kind() {
-            CpuBackendKind::Faer => {
+        match linalg_provider_kind(self.kind(), "svd")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -475,7 +475,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("svd", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| match input {
@@ -500,8 +500,8 @@ impl LinalgBackend for CpuBackend {
 
     fn svd_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         ensure_host_tensor("svd_values", input)?;
-        match self.kind() {
-            CpuBackendKind::Faer => {
+        match linalg_provider_kind(self.kind(), "svd_values")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -526,7 +526,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("svd_values", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| match input {
@@ -547,7 +547,10 @@ impl LinalgBackend for CpuBackend {
 
     fn svd_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         #[cfg(feature = "cpu-faer")]
-        if matches!(self.kind(), CpuBackendKind::Faer) {
+        if matches!(
+            linalg_provider_kind(self.kind(), "svd")?,
+            CpuLinalgProvider::Faer
+        ) {
             // Fast-path: if the view is already host-resident and 2D with non-negative strides,
             // feed it directly to faer without materializing a contiguous copy.
             let can_skip_materialize = match &input {
@@ -603,8 +606,8 @@ impl LinalgBackend for CpuBackend {
 
     fn qr(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         ensure_host_tensor("qr", input)?;
-        match self.kind() {
-            CpuBackendKind::Faer => {
+        match linalg_provider_kind(self.kind(), "qr")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -625,7 +628,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("qr", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| match input {
@@ -650,7 +653,10 @@ impl LinalgBackend for CpuBackend {
 
     fn qr_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         #[cfg(feature = "cpu-faer")]
-        if matches!(self.kind(), CpuBackendKind::Faer) {
+        if matches!(
+            linalg_provider_kind(self.kind(), "qr")?,
+            CpuLinalgProvider::Faer
+        ) {
             // Fast-path: feed an already host-resident 2D non-negative-strided view directly to faer.
             let can_skip_materialize = match &input {
                 TensorView::F32(view) => linalg::faer::faer_strided_ok(view),
@@ -705,8 +711,8 @@ impl LinalgBackend for CpuBackend {
 
     fn eigh(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         ensure_host_tensor("eigh", input)?;
-        match self.kind() {
-            CpuBackendKind::Faer => {
+        match linalg_provider_kind(self.kind(), "eigh")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -727,7 +733,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("eigh", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| match input {
@@ -752,7 +758,10 @@ impl LinalgBackend for CpuBackend {
 
     fn eigh_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         #[cfg(feature = "cpu-faer")]
-        if matches!(self.kind(), CpuBackendKind::Faer) {
+        if matches!(
+            linalg_provider_kind(self.kind(), "eigh")?,
+            CpuLinalgProvider::Faer
+        ) {
             // Fast-path: feed an already host-resident 2D non-negative-strided view directly to faer.
             // Complex eigenvalues are real; mirror the materialized `eigh` path by converting the
             // complex outputs (real eigenvalues, complex eigenvectors) to public tensors.
@@ -809,7 +818,10 @@ impl LinalgBackend for CpuBackend {
 
     fn cholesky_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Tensor> {
         #[cfg(feature = "cpu-faer")]
-        if matches!(self.kind(), CpuBackendKind::Faer) {
+        if matches!(
+            linalg_provider_kind(self.kind(), "cholesky")?,
+            CpuLinalgProvider::Faer
+        ) {
             let can_skip_materialize = match &input {
                 TensorView::F32(view) => linalg::faer::faer_strided_ok(view),
                 TensorView::F64(view) => linalg::faer::faer_strided_ok(view),
@@ -865,7 +877,10 @@ impl LinalgBackend for CpuBackend {
 
     fn lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         #[cfg(feature = "cpu-faer")]
-        if matches!(self.kind(), CpuBackendKind::Faer) {
+        if matches!(
+            linalg_provider_kind(self.kind(), "lu")?,
+            CpuLinalgProvider::Faer
+        ) {
             let can_skip_materialize = match &input {
                 TensorView::F32(view) => linalg::faer::faer_strided_ok(view),
                 TensorView::F64(view) => linalg::faer::faer_strided_ok(view),
@@ -917,7 +932,10 @@ impl LinalgBackend for CpuBackend {
 
     fn full_piv_lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         #[cfg(feature = "cpu-faer")]
-        if matches!(self.kind(), CpuBackendKind::Faer) {
+        if matches!(
+            linalg_provider_kind(self.kind(), "full_piv_lu")?,
+            CpuLinalgProvider::Faer
+        ) {
             let can_skip_materialize = match &input {
                 TensorView::F32(view) => linalg::faer::faer_strided_ok(view),
                 TensorView::F64(view) => linalg::faer::faer_strided_ok(view),
@@ -1006,8 +1024,8 @@ impl LinalgBackend for CpuBackend {
 
     fn eigh_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         ensure_host_tensor("eigh_values", input)?;
-        match self.kind() {
-            CpuBackendKind::Faer => {
+        match linalg_provider_kind(self.kind(), "eigh_values")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -1032,7 +1050,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("eigh_values", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| match input {
@@ -1059,8 +1077,8 @@ impl LinalgBackend for CpuBackend {
         ) {
             return Err(unsupported_dtype("eig", input.dtype()));
         }
-        match self.kind() {
-            CpuBackendKind::Faer => {
+        match linalg_provider_kind(self.kind(), "eig")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -1071,7 +1089,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("eig", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| linalg::blas::eig(buffers, input))
@@ -1092,8 +1110,8 @@ impl LinalgBackend for CpuBackend {
         ) {
             return Err(unsupported_dtype("eig_values", input.dtype()));
         }
-        match self.kind() {
-            CpuBackendKind::Faer => {
+        match linalg_provider_kind(self.kind(), "eig_values")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -1106,7 +1124,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("eig_values", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| linalg::blas::eig_values(buffers, input))
@@ -1197,8 +1215,8 @@ impl LinalgBackend for CpuBackend {
             (b.clone(), None)
         };
 
-        let result = match self.kind() {
-            CpuBackendKind::Faer => {
+        let result = match linalg_provider_kind(self.kind(), "solve")? {
+            CpuLinalgProvider::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
                     let ctx = self.linalg_context();
@@ -1223,7 +1241,7 @@ impl LinalgBackend for CpuBackend {
                     Err(unsupported_provider("solve", self.kind()))
                 }
             }
-            CpuBackendKind::Blas => {
+            CpuLinalgProvider::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.with_linalg_pool(|buffers| match (a, &rhs) {
@@ -1253,6 +1271,42 @@ impl LinalgBackend for CpuBackend {
             self.reshape(&result, &shape)
         } else {
             Ok(result)
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CpuLinalgProvider {
+    Faer,
+    Blas,
+}
+
+fn linalg_provider_kind(
+    kind: CpuBackendKind,
+    op: &'static str,
+) -> tenferro_tensor::Result<CpuLinalgProvider> {
+    match kind {
+        CpuBackendKind::Faer => Ok(CpuLinalgProvider::Faer),
+        CpuBackendKind::Blas => Ok(CpuLinalgProvider::Blas),
+        CpuBackendKind::Tblis => {
+            #[cfg(feature = "cpu-blas")]
+            {
+                let _ = op;
+                Ok(CpuLinalgProvider::Blas)
+            }
+            #[cfg(all(not(feature = "cpu-blas"), feature = "cpu-faer"))]
+            {
+                let _ = op;
+                Ok(CpuLinalgProvider::Faer)
+            }
+            #[cfg(all(not(feature = "cpu-blas"), not(feature = "cpu-faer")))]
+            {
+                Err(Error::InvalidConfig {
+                    op,
+                    message: "CpuBackendKind::Tblis linalg fallback requires cpu-blas or cpu-faer"
+                        .into(),
+                })
+            }
         }
     }
 }

--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -17,6 +17,7 @@ name = "tenferro_runtime"
 default = ["cpu-faer"]
 cpu-faer = ["tenferro-cpu/cpu-faer"]
 cpu-blas = ["tenferro-cpu/cpu-blas"]
+cpu-tblis = ["tenferro-cpu/cpu-tblis"]
 blas-openblas = ["tenferro-cpu/blas-openblas"]
 blas-accelerate = ["tenferro-cpu/blas-accelerate"]
 blas-mkl = ["tenferro-cpu/blas-mkl"]

--- a/crates/tenferro-tblis-src/Cargo.toml
+++ b/crates/tenferro-tblis-src/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tenferro-tblis-src"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish.workspace = true
+readme.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "Source-build link crate for the TBLIS native library used by tenferro."
+links = "tblis"
+build = "build.rs"
+
+[lib]
+name = "tenferro_tblis_src"
+
+[features]
+default = []
+build_from_source = []
+static = []
+
+[build-dependencies]
+cmake = "0.1"

--- a/crates/tenferro-tblis-src/build.rs
+++ b/crates/tenferro-tblis-src/build.rs
@@ -1,0 +1,110 @@
+use std::path::{Path, PathBuf};
+
+const DEFAULT_TBLIS_VER: &str = "eb719e718976572e0ab53975f4e0c799faeb35f2";
+
+fn build_tblis() {
+    if !cfg!(feature = "build_from_source") {
+        return;
+    }
+
+    let tblis_src = std::env::var("TBLIS_SRC")
+        .unwrap_or_else(|_| "https://github.com/MatthewsResearchGroup/tblis.git".to_string());
+    let tblis_ver = std::env::var("TBLIS_VER").unwrap_or_else(|_| DEFAULT_TBLIS_VER.to_string());
+
+    println!("cargo:rerun-if-env-changed=TBLIS_SRC");
+    println!("cargo:rerun-if-env-changed=TBLIS_VER");
+
+    let mut cfg = cmake::Config::new("cmake");
+    cfg.define("TBLIS_SRC", &tblis_src)
+        .define("TBLIS_VER", tblis_ver)
+        .define("CMAKE_BUILD_TYPE", "Release")
+        .define("CMAKE_DISABLE_FIND_PACKAGE_BLIS", "ON")
+        .define("CMAKE_FIND_USE_PACKAGE_REGISTRY", "FALSE")
+        .define("CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY", "FALSE");
+
+    if Path::new(&tblis_src).is_dir() {
+        cfg.define("TBLIS_SRC_IS_LOCAL_DIR", "ON");
+    } else {
+        cfg.define("TBLIS_FORCE_BUNDLED_BLIS", "ON");
+    }
+
+    let dst = cfg.build();
+    println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    println!("cargo:rustc-link-search=native={}/lib64", dst.display());
+    println!("cargo:rustc-link-search=native={}/lib/tblis", dst.display());
+}
+
+fn generate_link_search_paths(paths: &str) -> Vec<String> {
+    let split_char = if cfg!(windows) { ";" } else { ":" };
+    paths.split(split_char).map(str::to_string).collect()
+}
+
+fn root_candidates(env_candidates: &[&str]) -> Vec<PathBuf> {
+    let root_candidates = ["/usr", "/usr/local", "/usr/local/share", "/opt"];
+
+    env_candidates
+        .iter()
+        .map(std::env::var)
+        .filter_map(Result::ok)
+        .flat_map(|path| generate_link_search_paths(&path))
+        .filter(|path| !path.is_empty())
+        .chain(root_candidates.into_iter().map(str::to_string))
+        .map(PathBuf::from)
+        .collect()
+}
+
+fn lib_candidates() -> impl Iterator<Item = PathBuf> {
+    [
+        "",
+        "lib",
+        "lib/stubs",
+        "lib/x64",
+        "lib/Win32",
+        "lib/x86_64",
+        "lib/x86_64-linux-gnu",
+        "lib64",
+        "lib64/stubs",
+        "targets/x86_64-linux",
+        "targets/x86_64-linux/lib",
+        "targets/x86_64-linux/lib/stubs",
+    ]
+    .into_iter()
+    .map(PathBuf::from)
+}
+
+fn path_candidates(env_candidates: &[&str]) -> impl Iterator<Item = PathBuf> {
+    root_candidates(env_candidates)
+        .into_iter()
+        .flat_map(|root| lib_candidates().map(move |lib| root.join(lib)))
+        .filter(|path| path.exists())
+        .filter_map(|path| std::fs::canonicalize(path).ok())
+}
+
+fn link_tblis() {
+    let env_candidates = [
+        "TBLIS_DIR",
+        "REST_EXT_DIR",
+        "LD_LIBRARY_PATH",
+        "DYLD_LIBRARY_PATH",
+        "PATH",
+    ];
+
+    println!("cargo:rerun-if-env-changed=TBLIS_DIR");
+    for path in path_candidates(&env_candidates) {
+        println!("cargo:rustc-link-search=native={}", path.display());
+    }
+
+    if cfg!(feature = "static") {
+        println!("cargo:rustc-link-lib=static=tblis");
+        println!("cargo:rustc-link-lib=static=tci");
+        println!("cargo:rustc-link-lib=static=blis_tblis");
+        println!("cargo:rustc-link-lib=static=blis_core");
+    } else {
+        println!("cargo:rustc-link-lib=tblis");
+    }
+}
+
+fn main() {
+    build_tblis();
+    link_tblis();
+}

--- a/crates/tenferro-tblis-src/cmake/CMakeLists.txt
+++ b/crates/tenferro-tblis-src/cmake/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 3.15)
+project(tenferro-dep-tblis)
+
+include(ExternalProject)
+include(GNUInstallDirs)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+if(NOT TBLIS_SRC)
+    set(TBLIS_SRC https://github.com/MatthewsResearchGroup/tblis.git)
+endif()
+
+if(NOT TBLIS_VER)
+    set(TBLIS_VER eb719e718976572e0ab53975f4e0c799faeb35f2)
+endif()
+
+set(TBLIS_SOURCE_ARGS
+    GIT_REPOSITORY ${TBLIS_SRC}
+    GIT_TAG ${TBLIS_VER}
+    GIT_PROGRESS TRUE
+)
+
+if(TBLIS_SRC_IS_LOCAL_DIR)
+    set(TBLIS_SOURCE_ARGS SOURCE_DIR ${TBLIS_SRC})
+endif()
+
+set(TBLIS_PATCH_COMMAND "")
+if(TBLIS_FORCE_BUNDLED_BLIS)
+    set(TBLIS_PATCH_COMMAND
+        ${CMAKE_COMMAND}
+            -DTBLIS_SOURCE_DIR=<SOURCE_DIR>
+            -P ${CMAKE_CURRENT_LIST_DIR}/PatchBundledBlis.cmake
+    )
+endif()
+
+ExternalProject_Add(tblis
+    ${TBLIS_SOURCE_ARGS}
+    PREFIX ${PROJECT_BINARY_DIR}/deps
+    PATCH_COMMAND ${TBLIS_PATCH_COMMAND}
+    CMAKE_ARGS
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+        -DCMAKE_INSTALL_PREFIX:PATH=${PROJECT_BINARY_DIR}/deps
+        -DCMAKE_DISABLE_FIND_PACKAGE_BLIS=ON
+        -DCMAKE_FIND_USE_PACKAGE_REGISTRY=FALSE
+        -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=FALSE
+)
+
+install(DIRECTORY ${PROJECT_BINARY_DIR}/deps/${CMAKE_INSTALL_LIBDIR}/ DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/crates/tenferro-tblis-src/cmake/PatchBundledBlis.cmake
+++ b/crates/tenferro-tblis-src/cmake/PatchBundledBlis.cmake
@@ -1,0 +1,32 @@
+set(TBLIS_CMAKE "${TBLIS_SOURCE_DIR}/CMakeLists.txt")
+file(READ "${TBLIS_CMAKE}" TBLIS_CMAKE_CONTENTS)
+
+set(BLIS_DISCOVERY_BLOCK "find_package(BLIS QUIET)
+
+if(BLIS_FOUND)
+    set(BLIS_TARGET BLIS::BLIS)
+    message(CHECK_PASS \"found via cmake\")
+    #not sure what to do here
+    #set(BLIS_BINARY_DIR ...)
+    add_custom_target(blis-install)
+else()
+    find_package(PkgConfig)
+    set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH ON)
+    pkg_check_modules(BLIS IMPORTED_TARGET blis>=2.0)
+endif()")
+
+set(BUNDLED_BLIS_BLOCK "set(BLIS_FOUND FALSE)")
+
+string(REPLACE
+    "${BLIS_DISCOVERY_BLOCK}"
+    "${BUNDLED_BLIS_BLOCK}"
+    TBLIS_PATCHED_CMAKE_CONTENTS
+    "${TBLIS_CMAKE_CONTENTS}"
+)
+
+if(TBLIS_PATCHED_CMAKE_CONTENTS STREQUAL TBLIS_CMAKE_CONTENTS
+   AND NOT TBLIS_CMAKE_CONTENTS MATCHES "set\\(BLIS_FOUND FALSE\\)")
+    message(FATAL_ERROR "failed to patch TBLIS BLIS discovery block")
+endif()
+
+file(WRITE "${TBLIS_CMAKE}" "${TBLIS_PATCHED_CMAKE_CONTENTS}")

--- a/crates/tenferro-tblis-src/src/lib.rs
+++ b/crates/tenferro-tblis-src/src/lib.rs
@@ -1,0 +1,1 @@
+//! Native TBLIS build and link directives for tenferro.

--- a/docs/design/contraction-pipeline.md
+++ b/docs/design/contraction-pipeline.md
@@ -97,10 +97,16 @@ CPU execution is handled by `CpuBackend`:
 
 - elementwise/reduction/structural work uses strided-kernel and dedicated CPU
   implementations,
-- `dot_general` uses the selected CPU GEMM backend (`cpu-faer` or `cpu-blas`),
+- `dot_general` uses the selected CPU provider (`cpu-faer`, `cpu-blas`, or
+  optional `cpu-tblis` for supported contractions),
 - faer-backed work runs inside the `CpuContext` Rayon pool through
   `CpuExecSession`, with `Par::Seq` for one-thread contexts and `Par::rayon(0)`
-  for multi-thread contexts.
+  for multi-thread contexts,
+- BLAS/LAPACK and TBLIS provider threading remain provider-owned.
+
+`cpu-tblis` is additive to the faer/BLAS providers. `CpuBackendKind::Tblis`
+falls back to the compiled faer/BLAS provider when a valid `dot_general` shape
+is outside the current TBLIS path.
 
 ## CubeCL/CUDA Execution
 

--- a/docs/design/supported-ops.md
+++ b/docs/design/supported-ops.md
@@ -48,15 +48,17 @@ CPU execution, and backend-parametric concrete tensor kernels.
 
 ### CPU Status
 
-The CPU backend is the main complete backend. Exactly one CPU feature must be
-enabled:
+The CPU backend is the main complete backend. At least one fallback/linalg CPU
+feature must be enabled:
 
 - `cpu-faer` for faer-backed GEMM,
-- `cpu-blas` for BLAS-backed GEMM.
+- `cpu-blas` for BLAS-backed GEMM,
+- optional `cpu-tblis` for supported TBLIS-backed `dot_general` contractions.
 
 Elementwise, reductions, structural operations, indexing, `dot_general`, and
 the standard linalg extension are implemented on CPU for the supported dtype
-subset of each op.
+subset of each op. `cpu-tblis` does not replace `cpu-faer` or `cpu-blas`; a
+compiled faer/BLAS provider remains required for fallback and linalg coverage.
 
 ### CUDA/CubeCL Status
 

--- a/docs/design/tensor-prims.md
+++ b/docs/design/tensor-prims.md
@@ -76,25 +76,29 @@ does not support. Higher layers must not silently fall back across devices.
 CPU provider features are additive:
 
 - `cpu-faer` for faer-backed GEMM/linalg,
-- `cpu-blas` for BLAS/LAPACK-backed GEMM/linalg.
+- `cpu-blas` for BLAS/LAPACK-backed GEMM/linalg,
+- `cpu-tblis` for supported TBLIS-backed `dot_general` contractions.
 
 CPU execution uses strided-kernel for elementwise/reduction/structural work and
-faer or BLAS/LAPACK for GEMM and linalg. `CpuBackend` stores the runtime
-provider selection for an individual backend instance. `CpuBackend::new()`
-chooses the compiled default provider: BLAS if `cpu-blas` is compiled,
-otherwise faer. Explicit constructors such as `CpuBackend::with_kind` and
-`CpuBackend::with_threads_and_kind` can select any provider compiled into
-the binary. `CpuContext` stores the CPU thread count as the single source of
-truth for tenferro-owned CPU parallelism and owns the Rayon thread pool used by
-multi-thread contexts.
+faer or BLAS/LAPACK for GEMM and linalg. At least one of `cpu-faer` or
+`cpu-blas` remains required as the fallback/linalg provider when `cpu-tblis` is
+enabled. `CpuBackend` stores the runtime provider selection for an individual
+backend instance. `CpuBackend::new()` chooses the compiled default provider:
+BLAS if `cpu-blas` is compiled, otherwise faer. Explicit constructors such as
+`CpuBackend::with_kind` and `CpuBackend::with_threads_and_kind` can select any
+provider compiled into the binary. `CpuBackendKind::Tblis` attempts supported
+TBLIS contractions first and falls back to the compiled faer/BLAS provider for
+other valid `dot_general` shapes. `CpuContext` stores the CPU thread count as
+the single source of truth for tenferro-owned CPU parallelism and owns the Rayon
+thread pool used by multi-thread contexts.
 
 `CpuBackend::with_backend_session` runs the whole compiled program through
 `CpuExecSession`, reusing the backend buffer pool and avoiding per-op session
 setup. Session execution enters `CpuContext::install`, so strided CPU kernels
 use the backend-owned Rayon pool when `strided-kernel/parallel` is enabled.
 faer-backed kernels receive `Par::Seq` for one thread or `Par::rayon(0)` for
-multi-threaded execution inside that pool. BLAS/LAPACK provider threading
-remains provider-owned.
+multi-threaded execution inside that pool. BLAS/LAPACK and TBLIS provider
+threading remain provider-owned.
 
 ## CubeCL Backend
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -68,10 +68,12 @@ CPU backend features are additive. At least one of `cpu-faer` or `cpu-blas`
 must be enabled, and builds may enable both. `CpuBackend::new()` selects the
 compiled default provider: BLAS when `cpu-blas` is compiled, otherwise faer.
 Use `CpuBackend::with_kind` when a program needs explicit provider selection
-within a build that has multiple providers. The `cpu-blas` backend needs a
-BLAS/LAPACK provider. Link one from the system toolchain with `cpu-blas`, or
-enable exactly one explicit provider feature to select a source provider for
-BLAS, LAPACK, and strided einsum:
+within a build that has multiple providers. `cpu-tblis` may be enabled as an
+optional `dot_general` contraction provider, but it does not replace `cpu-faer`
+or `cpu-blas`; one of those providers is still required for fallback and linalg
+coverage. The `cpu-blas` backend needs a BLAS/LAPACK provider. Link one from
+the system toolchain with `cpu-blas`, or enable exactly one explicit provider
+feature to select a source provider for BLAS, LAPACK, and strided einsum:
 
 ```toml
 [dependencies]

--- a/docs/guides/parallelism-and-caching.md
+++ b/docs/guides/parallelism-and-caching.md
@@ -11,7 +11,10 @@ parallelism contract.
 ## CPU Backend Provider
 
 At least one CPU provider feature must be compiled. `cpu-faer` is the default.
-`cpu-blas` can be compiled by itself or together with `cpu-faer`.
+`cpu-blas` can be compiled by itself or together with `cpu-faer`. `cpu-tblis`
+is an optional `dot_general` contraction provider; it is additive and still
+requires at least one of `cpu-faer` or `cpu-blas` for fallback and linalg
+coverage.
 `blas-openblas`, `blas-accelerate`, and `blas-mkl` are explicit BLAS/LAPACK
 source-provider features that also enable `cpu-blas`; enable at most one of
 them in a single resolved Cargo feature graph.
@@ -25,9 +28,11 @@ current binary:
 | `cpu-blas` only | BLAS/LAPACK |
 | `cpu-faer` and `cpu-blas` | BLAS/LAPACK |
 
-This is the default provider for that backend instance, not a dynamic fallback
-chain. If both providers are compiled, select a provider explicitly when a
-specific call path should use faer or BLAS. Explicit selection returns a
+This is the default provider for that backend instance. If multiple providers
+are compiled, select a provider explicitly when a specific call path should use
+faer, BLAS, or TBLIS. `CpuBackendKind::Tblis` first attempts supported TBLIS
+`dot_general` contractions and then falls back to the compiled faer/BLAS
+provider for shapes outside the TBLIS path. Explicit selection returns a
 configuration error if the requested provider was not compiled into the binary:
 
 ```rust
@@ -62,6 +67,8 @@ RAYON_NUM_THREADS=4 cargo run --release
 For `cpu-faer`, tenferro passes the `CpuContext` thread count to faer-backed
 kernels. A one-thread context uses sequential faer execution; a multi-thread
 context uses faer's Rayon parallelism with the requested thread count.
+For `cpu-tblis`, TBLIS owns its internal threading policy; `CpuBackend` thread
+counts still apply to tenferro-owned CPU kernels and fallback paths.
 
 ## CPU Operation Parallelism
 
@@ -76,6 +83,7 @@ pool before dispatching tensor-sized kernels.
 | Materialized transpose/permute, broadcast, convert, and diagonal extraction | `strided-kernel` copy/map kernels run under `CpuContext` and can use Rayon for tensor-sized copies. |
 | `dot_general` through `cpu-faer` | faer receives `Par::Seq` for one-thread contexts and `Par::rayon(0)` inside the owned `CpuContext` pool for multi-thread contexts. |
 | GEMM and linalg through `cpu-blas` | Threading is owned by the linked BLAS/LAPACK provider, not Rayon. Configure the provider variables below. |
+| Supported `dot_general` contractions through `cpu-tblis` | TBLIS owns provider threading; unsupported TBLIS shapes fall back to the compiled faer/BLAS provider. |
 | Indexing, scatter/gather, slicing, padding, concatenation, reverse, triangular masks, and `embed_diagonal` | These are dedicated sequential CPU loops today because their per-output indexing patterns do not yet have a strided-kernel/backend-native parallel primitive. They still run inside `CpuContext::install`, and source comments mark the intentional sequential path. |
 
 ## BLAS And LAPACK Threads
@@ -112,8 +120,9 @@ use tenferro_cpu::CpuBackend;
 let backend = CpuBackend::with_threads(1);
 ```
 
-For BLAS/LAPACK providers, apply the same rule to provider thread variables.
-For benchmarks, pin all relevant thread counts and report them with the result.
+For BLAS/LAPACK and TBLIS providers, apply the same rule to provider thread
+variables. For benchmarks, pin all relevant thread counts and report them with
+the result.
 
 ## Reuse Runtime State
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -70,8 +70,9 @@ See [Memory Order](memory-order.md).
 
 ## CPU Backend Feature Selection
 
-At least one CPU backend feature must be enabled. `cpu-faer` is the default,
-and `cpu-blas` can be enabled by itself or together with `cpu-faer`:
+At least one CPU fallback/linalg backend feature must be enabled. `cpu-faer`
+is the default, and `cpu-blas` can be enabled by itself or together with
+`cpu-faer`:
 
 ```toml
 [dependencies]
@@ -93,6 +94,10 @@ different dependencies, tenferro stops at compile time instead of linking an
 ambiguous BLAS/LAPACK provider set. Use `OPENBLAS_LIB_DIR` for non-standard
 OpenBLAS installs, and `MKLROOT` or `MKL_LIB_DIR` for non-standard MKL installs
 when the provider build scripts need a library path.
+
+`cpu-tblis` is an optional `dot_general` contraction provider. It is additive
+to `cpu-faer`/`cpu-blas`, and `CpuBackendKind::Tblis` falls back to the
+compiled faer/BLAS provider for valid contraction shapes outside the TBLIS path.
 
 `CpuBackend::new()` selects the compiled default provider: BLAS when `cpu-blas`
 is compiled, otherwise faer. Use `CpuBackend::with_kind(CpuBackendKind::Faer)`

--- a/docs/worklogs/2026-07-10-issue-1332-tblis-provider.md
+++ b/docs/worklogs/2026-07-10-issue-1332-tblis-provider.md
@@ -1,0 +1,276 @@
+# Issue #1332 TBLIS CPU Provider
+
+## Summary
+
+Added an initial optional `cpu-tblis` provider path for dense CPU
+`dot_general` contractions. The patch is intentionally narrow: feature wiring,
+`CpuBackendKind::Tblis`, a private TBLIS FFI leaf, and dispatch from
+`TensorDot`/cached session dot-general paths.
+
+## Context Read
+
+- `AGENTS.md`
+- `REPOSITORY_RULES.md`
+- `crates/tenferro-cpu/src/backend.rs`
+- `crates/tenferro-cpu/src/exec_session.rs`
+- `crates/tenferro-cpu/src/gemm/mod.rs`
+- `crates/tenferro-cpu/src/gemm/{faer_gemm.rs,blas_gemm.rs}`
+- `crates/tenferro-cpu/tests/provider_feature_contract.rs`
+- shared `tensor4all-agent-rules` common/Rust rules from the upstream repository
+- local cargo registry sources for `tblis-ffi 0.2.6`
+
+## Decisions
+
+- Kept `tblis-ffi = 0.2.6` optional behind `cpu-tblis`; default features are
+  unchanged.
+- Added tenferro-owned `tenferro-tblis-src` source-build link glue behind
+  `cpu-tblis`, so the user-facing feature is source-backed rather than
+  requiring a manual `libtblis` install or caller environment workaround.
+- Kept `cpu-tblis` additive to an existing CPU provider: `tenferro-cpu` still
+  requires `cpu-faer` or `cpu-blas`, and `CpuBackendKind::default_compiled()`
+  remains unchanged. This preserves current defaults and guarantees unsupported
+  TBLIS cases have a compiled fallback path.
+- Added `CpuBackendKind::Tblis`, but kept low-level TBLIS helpers `pub(crate)`.
+- Supports `f32`, `f64`, `c32`, and `c64` TBLIS contractions. Conjugated
+  `dot_general_with_conj` and accumulated writes use TBLIS tensor conjugation
+  flags when a TBLIS plan is valid.
+- Passed full tensor labels directly to `tblis_tensor_mult`; no
+  `tblis_einsum`, no eager-einsum path, no reductions, no copy/transpose
+  replacement, and no grouped GEMM replacement.
+- Required host-backed inputs, positive strides, non-negative offsets,
+  nonzero rank, nonempty dimensions, representable FFI ranks/dimensions, and
+  a small ASCII label set before calling TBLIS.
+- Used zero-initialized pooled owned output for the first TBLIS path even with
+  `beta = 0`, avoiding assumptions about whether TBLIS reads `C`.
+
+## Deferred
+
+- Negative strides, zero-rank scalar contractions, and zero-size tensors.
+- Upstreaming the source-build fixes to `tblis-src` remains desirable, but the
+  tenferro PR no longer depends on a new upstream release.
+- A richer TBLIS thread-count policy. The initial path avoids tenferro-owned
+  outer Rayon installation for `CpuBackendKind::Tblis` and leaves native TBLIS
+  scheduling provider-owned.
+- Broader TBLIS benchmark coverage beyond the quick local release-mode run with
+  pinned provider thread counts.
+
+## Provider-source integration review
+
+- Current feature shape is the right user-facing direction:
+  `tenferro-cpu/cpu-tblis` enables `dep:tblis-ffi`,
+  `dep:tenferro-tblis-src`, and
+  `tenferro-tblis-src/build_from_source` plus
+  `tenferro-tblis-src/static`. Public passthrough crates forward `cpu-tblis`,
+  and the provider feature contract covers this.
+- `tblis-ffi` has no source-build feature of its own. Tenferro must keep both
+  dependencies directly: `tenferro-tblis-src` supplies Cargo link directives,
+  and `tblis-ffi` supplies extern declarations.
+- Do not enable `tblis-ffi/dynamic_loading` for the source-backed feature. With
+  `tenferro-tblis-src`, the FFI should use the non-dynamic extern path, and
+  runtime availability should be treated as compile/link availability.
+- The source-backed TBLIS path treats runtime availability as compile/link
+  availability. The FFI leaf keeps `ensure_runtime_available()` as a no-op and
+  does not call `tblis_ffi::tblis::dyload_lib()`, which only exists with
+  `tblis-ffi/dynamic_loading`.
+- Blocking check:
+  `cargo check -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis`
+  fails inside `tblis-src v0.2.6` before tenferro compiles. The `tblis-src`
+  build script passes the packaged
+  `.../tblis-src-0.2.6/external_deps/tblis` path as `TBLIS_SRC`, but
+  `external_deps/CMakeLists.txt` uses it as `GIT_REPOSITORY`. The unpacked
+  crates.io source directory is not a Git repository, so CMake fails with
+  `fatal: repository '.../external_deps/tblis' does not exist`.
+- `tblis-src/static` does not help this blocker. It only changes the final
+  Cargo link directive to `cargo:rustc-link-lib=static=tblis`; CMake still
+  attempts to clone the local unpacked source path as a Git repository.
+- Fresh-source workaround that does build on this machine:
+  `CARGO_TARGET_DIR=/private/tmp/tenferro-tblis-envcheck PKG_CONFIG_LIBDIR=/private/tmp/empty-pkgconfig PKG_CONFIG_PATH=/private/tmp/empty-pkgconfig CMAKE_FIND_USE_PACKAGE_REGISTRY=FALSE CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=FALSE TBLIS_SRC=https://github.com/MatthewsResearchGroup/tblis.git cargo check -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis`.
+  This completed successfully.
+- The successful workaround really used bundled BLIS. The generated
+  `/private/tmp/tenferro-tblis-envcheck/.../tblis-build/CMakeCache.txt`
+  recorded empty `BLIS_FOUND`, empty `BLIS_PREFIX`, and a populated
+  `_deps/blis-src` directory; the install output included `lib/libtblis.a` and
+  `lib/libtblis.dylib`.
+- The same command without a fresh build directory can keep stale CMake cache
+  state. A previous run still used `/opt/homebrew/bin/pkg-config` and Homebrew
+  BLIS 2.0 despite `PKG_CONFIG=/usr/bin/false`, then failed in the TBLIS plugin
+  build with `typedef redefinition with different types ('struct auxinfo_t' vs
+  'struct auxinfo_s')`.
+- Passing check:
+  `cargo test -p tenferro-cpu --test provider_feature_contract` succeeds.
+
+## Source-backed link blocker fix
+
+- Reproduced the current test link failure with the previously successful
+  source-build target:
+  `CARGO_TARGET_DIR=/private/tmp/tenferro-tblis-envcheck PKG_CONFIG_LIBDIR=/private/tmp/empty-pkgconfig PKG_CONFIG_PATH=/private/tmp/empty-pkgconfig CMAKE_FIND_USE_PACKAGE_REGISTRY=FALSE CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=FALSE TBLIS_SRC=https://github.com/MatthewsResearchGroup/tblis.git cargo test -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis`.
+  The link line had `-L .../tblis-src-.../out/lib` but no `-ltblis`, then
+  failed with undefined `_tblis_tensor_mult`.
+- Fixed the link retention in the initial `tblis-src` experiment by adding an
+  explicit provider-source crate anchor in `tenferro-cpu`, matching the
+  existing provider-source pattern for BLAS/LAPACK crates. The final patch uses
+  `#[cfg(feature = "cpu-tblis")] extern crate tenferro_tblis_src as _;`, so
+  Cargo keeps the tenferro-owned source/link crate in the Rust crate graph and
+  propagates its native `cargo:rustc-link-lib=static=tblis` directive.
+- Verified the cached source-build target after the fix with:
+  `CARGO_TARGET_DIR=/private/tmp/tenferro-tblis-envcheck PKG_CONFIG_LIBDIR=/private/tmp/empty-pkgconfig PKG_CONFIG_PATH=/private/tmp/empty-pkgconfig CMAKE_FIND_USE_PACKAGE_REGISTRY=FALSE CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=FALSE TBLIS_SRC=https://github.com/MatthewsResearchGroup/tblis.git cargo test -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis`.
+  This passed: 218 unit tests, 7 backend capability contract tests, 3 provider
+  feature contract tests, 25 runtime error tests, and 61 doc-tests.
+- Verified a fresh source-build target after the fix with:
+  `CARGO_TARGET_DIR=/private/tmp/tenferro-tblis-fresh-after PKG_CONFIG_LIBDIR=/private/tmp/empty-pkgconfig PKG_CONFIG_PATH=/private/tmp/empty-pkgconfig CMAKE_FIND_USE_PACKAGE_REGISTRY=FALSE CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=FALSE TBLIS_SRC=https://github.com/MatthewsResearchGroup/tblis.git cargo test -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis`.
+  This also passed: 218 unit tests, 7 backend capability contract tests, 3
+  provider feature contract tests, 25 runtime error tests, and 61 doc-tests.
+- Verified the focused provider contract independently:
+  `cargo test -p tenferro-cpu --test provider_feature_contract` passed.
+- Ran `cargo fmt --all`; the follow-up `cargo fmt --all --check` passed.
+
+## Follow-up fallback tests and docs
+
+- Added two `cpu-tblis` fallback behavior tests in
+  `crates/tenferro-cpu/src/backend/tests.rs`:
+  - scalar-output vector inner product, which TBLIS declines because the output
+    rank is zero,
+  - zero-size matmul, which TBLIS declines because one logical dimension is
+    zero.
+  Both use `CpuBackendKind::Tblis` and assert successful results through the
+  compiled faer/BLAS fallback provider.
+- Updated public-facing provider docs in:
+  `docs/guides/parallelism-and-caching.md`,
+  `docs/guides/troubleshooting.md`, `docs/getting-started/index.md`,
+  `docs/design/tensor-prims.md`, `docs/design/contraction-pipeline.md`, and
+  `docs/design/supported-ops.md`.
+- The docs now describe `cpu-tblis` as an optional additive `dot_general`
+  contraction provider, keep `cpu-faer`/`cpu-blas` as the required
+  fallback/linalg providers, and note that TBLIS threading is provider-owned.
+  The current `tblis-src 0.2.6` source-build workaround remains documented only
+  in this worklog.
+- Follow-up verification:
+  `CARGO_TARGET_DIR=/private/tmp/tenferro-tblis-fresh-after PKG_CONFIG_LIBDIR=/private/tmp/empty-pkgconfig PKG_CONFIG_PATH=/private/tmp/empty-pkgconfig CMAKE_FIND_USE_PACKAGE_REGISTRY=FALSE CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=FALSE TBLIS_SRC=https://github.com/MatthewsResearchGroup/tblis.git cargo test -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis`
+  passed with 220 unit tests, including the two new fallback tests, plus 7
+  backend capability contract tests, 3 provider feature contract tests, 25
+  runtime error tests, and 61 doc-tests.
+- `cargo fmt --all --check` passed after the follow-up edits.
+
+## Quick local benchmark
+
+- Supervisor-run quick local release benchmark, not a broad performance claim.
+  Threads were pinned with `TBLIS_NUM_THREADS=1`, `RAYON_NUM_THREADS=1`, and
+  `OMP_NUM_THREADS=1`.
+- Command:
+  `CARGO_TARGET_DIR=/private/tmp/tenferro-tblis-owned-fresh TBLIS_NUM_THREADS=1 RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 cargo bench -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis --bench tblis_dot_general_provider -- --quick`
+- Results:
+  - f64 32: baseline 3.08 us, TBLIS 5.70 us
+  - c64 conj 32: baseline 6.38 us, TBLIS 10.54 us
+  - f64 64: baseline 12.57 us, TBLIS 19.19 us
+  - c64 conj 64: baseline 48.94 us, TBLIS 52.35 us
+  - f64 128: baseline 83.49 us, TBLIS 99.34 us
+  - c64 conj 128: baseline 386.16 us, TBLIS 330.41 us
+
+## Source-build UX fix
+
+- Checked upstream `RESTGroup/tblis-rs` main before changing tenferro. The
+  `tblis-src` `build.rs` and `external_deps/CMakeLists.txt` are still identical
+  to crates.io `0.2.6` for this blocker, so switching to upstream main would not
+  fix the PR risk.
+- Rejected a local `[patch.crates-io]` as the main fix: it would make this
+  workspace pass, but downstream users would still resolve crates.io
+  `tblis-src` unless an upstream release happened first.
+- Added `crates/tenferro-tblis-src`, a small tenferro-owned link crate. It does
+  not vendor a TBLIS source tree. By default it clones
+  `https://github.com/MatthewsResearchGroup/tblis.git` at
+  `eb719e718976572e0ab53975f4e0c799faeb35f2`, still honors
+  `TBLIS_SRC`/`TBLIS_VER`, uses `SOURCE_DIR` for local `TBLIS_SRC` directories,
+  and passes Cargo native link directives for `libtblis`.
+- For cloned TBLIS sources, the build glue patches only the downloaded TBLIS
+  `CMakeLists.txt` BLIS discovery block so bundled BLIS is used. This avoids the
+  Homebrew/pkg-config header mismatch without requiring users to empty
+  `PKG_CONFIG_PATH` or CMake package registries.
+- Updated `cpu-tblis` feature wiring to:
+  `["dep:tblis-ffi", "dep:tenferro-tblis-src", "tenferro-tblis-src/build_from_source", "tenferro-tblis-src/static"]`,
+  so the source-backed provider links `libtblis.a` by default.
+- Static source-provider linking also emits link directives for bundled
+  `libtci.a`, `libblis_tblis.a`, and `libblis_core.a`; `otool -L` on the
+  resulting test binary shows no `libtblis.dylib` dependency.
+- The bundled-BLIS CMake patch is idempotent so repeated Cargo rebuilds in the
+  same target directory do not fail after the first patch application.
+- Bare verification now passes without `TBLIS_SRC`, `PKG_CONFIG_*`, or
+  `CMAKE_FIND_*` environment workarounds:
+  `cargo check -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis`
+- Full bare test verification also passes:
+  `cargo test -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis`
+  passed with 220 unit tests, 7 backend capability contract tests, 3 provider
+  feature contract tests, 25 runtime error tests, and 61 doc-tests.
+- Remaining release hygiene: add a CI/build job for the bare `cpu-faer,cpu-tblis`
+  feature set on a platform with the native build prerequisites. The provider
+  feature contract validates manifest wiring, but CI should also prove native
+  TBLIS can be built and linked.
+
+## TBLIS benchmark expansion
+
+- Expanded `crates/tenferro-cpu/benches/tblis_dot_general_provider.rs` beyond
+  square GEMM while keeping the existing f64 and c64 conjugated matmul cases.
+- Benchmark names now use explicit provider prefixes: `faer_*`, optional
+  `blas_*` under `cpu-blas`, and `tblis_*`.
+- The matmul and higher-rank sizes can be overridden with
+  `TENFERRO_TBLIS_BENCH_MATMUL_SIZES` and
+  `TENFERRO_TBLIS_BENCH_HIGHER_RANK_NS` so large cases can be sampled without
+  making the default bench heavy.
+- Added optional BLAS baselines gated with `#[cfg(feature = "cpu-blas")]`, so
+  the bench compiles both for `cpu-faer,cpu-tblis` and for
+  `cpu-faer,cpu-tblis,blas-openblas`.
+- Added owned higher-rank f64 contractions:
+  - rank-4 x rank-4 with two contracting dimensions and no batch,
+  - interleaved rank-4 x rank-4 with two contracting dimensions,
+  - rank-5 x rank-5 with one batch dimension and two contracting dimensions.
+- Added a non-canonical positive-stride view case through `TensorRead` using
+  row-major rank-4 host views. This exercises TBLIS's direct strided tensor
+  contraction path without materializing a compact col-major tensor first.
+- Verification:
+  `cargo fmt --all --check` passed.
+- Verification:
+  `CARGO_TARGET_DIR=/private/tmp/tenferro-tblis-fresh-after PKG_CONFIG_LIBDIR=/private/tmp/empty-pkgconfig PKG_CONFIG_PATH=/private/tmp/empty-pkgconfig CMAKE_FIND_USE_PACKAGE_REGISTRY=FALSE CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=FALSE TBLIS_SRC=https://github.com/MatthewsResearchGroup/tblis.git cargo check -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis --bench tblis_dot_general_provider`
+  passed after allowing the TBLIS source clone.
+- Verification:
+  `CARGO_TARGET_DIR=/private/tmp/tenferro-tblis-fresh-after PKG_CONFIG_LIBDIR=/private/tmp/empty-pkgconfig PKG_CONFIG_PATH=/private/tmp/empty-pkgconfig CMAKE_FIND_USE_PACKAGE_REGISTRY=FALSE CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=FALSE TBLIS_SRC=https://github.com/MatthewsResearchGroup/tblis.git OPENBLAS_FC=/opt/homebrew/bin/gfortran LIBRARY_PATH=/opt/homebrew/lib/gcc/current:/opt/homebrew/lib/gcc/15 DYLD_LIBRARY_PATH=/opt/homebrew/lib/gcc/current:/opt/homebrew/lib/gcc/15 cargo check -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis,blas-openblas --bench tblis_dot_general_provider`
+  passed after allowing OpenBLAS/cblas and TBLIS source downloads.
+- Supervisor-run quick local release benchmark with BLAS baseline enabled.
+  Threads were pinned with `TBLIS_NUM_THREADS=1`, `RAYON_NUM_THREADS=1`,
+  `OMP_NUM_THREADS=1`, and `OPENBLAS_NUM_THREADS=1`.
+- Command:
+  `CARGO_TARGET_DIR=/private/tmp/tenferro-tblis-blas-bench OPENBLAS_FC=/opt/homebrew/bin/gfortran LIBRARY_PATH=/opt/homebrew/lib/gcc/current:/opt/homebrew/lib/gcc/15 DYLD_LIBRARY_PATH=/opt/homebrew/lib/gcc/current:/opt/homebrew/lib/gcc/15 TBLIS_NUM_THREADS=1 RAYON_NUM_THREADS=1 OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 cargo bench -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis,blas-openblas --bench tblis_dot_general_provider -- --quick`
+- Selected results:
+  - f64 matmul 32: faer 3.42 us, BLAS 1.98 us, TBLIS 5.66 us
+  - f64 matmul 64: faer 12.71 us, BLAS 19.77 us, TBLIS 19.52 us
+  - f64 matmul 128: faer 86.88 us, BLAS 99.27 us, TBLIS 101.31 us
+  - c64 lhs-conj matmul 32: faer 6.38 us, BLAS 12.10 us, TBLIS 10.92 us
+  - c64 lhs-conj matmul 64: faer 53.72 us, BLAS 60.93 us, TBLIS 53.35 us
+  - c64 lhs-conj matmul 128: faer 385.69 us, BLAS 406.12 us, TBLIS 333.33 us
+  - rank-4 two-contract n=4: faer 2.02 us, BLAS 0.88 us, TBLIS 3.40 us
+  - rank-4 two-contract n=8: faer 12.82 us, BLAS 20.60 us, TBLIS 19.44 us
+  - rank-4 interleaved n=4: faer 3.37 us, BLAS 4.05 us, TBLIS 3.72 us
+  - rank-4 interleaved n=8: faer 16.79 us, BLAS 29.64 us, TBLIS 19.08 us
+  - rank-5 batched interleaved n=4: faer 5.67 us, BLAS 6.42 us, TBLIS 10.38 us
+  - rank-5 batched interleaved n=8: faer 62.11 us, BLAS 108.55 us, TBLIS 74.58 us
+  - rank-4 row-major view n=4: faer 3.49 us, BLAS 5.49 us, TBLIS 3.88 us
+  - rank-4 row-major view n=8: faer 17.90 us, BLAS 42.66 us, TBLIS 20.13 us
+- The expanded benchmark does not show a broad TBLIS win on this machine.
+  TBLIS is competitive with or faster than BLAS on several complex/interleaved
+  cases, but faer remains faster for most measured f64 higher-rank cases at
+  these sizes. PR messaging should present this as an optional provider and
+  source-build/correctness integration, not a demonstrated performance win.
+- Large-size quick local release sample:
+  `TENFERRO_TBLIS_BENCH_MATMUL_SIZES=256,512 TENFERRO_TBLIS_BENCH_HIGHER_RANK_NS=16`
+  with the same pinned single-thread settings and `blas-openblas`.
+- Large-size selected results:
+  - f64 matmul 256: faer 617.38 us, BLAS 748.55 us, TBLIS 645.64 us
+  - f64 matmul 512: faer 5.04 ms, BLAS 4.91 ms, TBLIS 4.78 ms
+  - c64 lhs-conj matmul 256: faer 2.93 ms, BLAS 2.77 ms, TBLIS 2.39 ms
+  - c64 lhs-conj matmul 512: faer 23.37 ms, BLAS 22.08 ms, TBLIS 18.32 ms
+  - rank-4 two-contract n=16: faer 621.53 us, BLAS 621.47 us, TBLIS 646.96 us
+  - rank-4 interleaved n=16: faer 672.51 us, BLAS 676.83 us, TBLIS 646.17 us
+  - rank-5 batched interleaved n=16: faer 3.03 ms, BLAS 3.10 ms, TBLIS 2.67 ms
+  - rank-4 row-major view n=16: faer 935.45 us, BLAS 954.64 us, TBLIS 651.67 us
+- Larger cases are more favorable to TBLIS than the default small quick bench,
+  especially complex GEMM, batched/interleaved higher-rank contraction, and
+  direct row-major positive-stride views. The broad claim should still remain
+  measured and size-dependent.


### PR DESCRIPTION
Summary:
- optional `cpu-tblis` provider on the CPU backend, with fallback to the existing CPU path when TBLIS is unavailable or not selected
- complex contraction support is wired through the same route
- provider resolution now goes through `tenferro-tblis-src`, with a pinned TBLIS commit and static linking so the runtime/test/bench binaries do not depend on `libtblis.dylib`
- docs and the worklog were updated to match the new provider flow

Tests run:
- `cargo test -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis` passed: 220 unit tests, 7 backend capability tests, 3 provider feature tests, 25 runtime error tests, 61 doctests
- `cargo check -p tenferro-runtime --no-default-features --features cpu-faer,cpu-tblis` passed
- `cargo check -p tenferro-linalg --no-default-features --features cpu-faer,cpu-tblis` passed
- `cargo check -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis --benches` passed
- `cargo check -p tenferro-cpu --no-default-features --features cpu-faer,cpu-tblis,blas-openblas --benches` passed after source-provider downloads
- `cargo package -p tenferro-tblis-src --allow-dirty --offline` passed
- `cargo fmt --all --check` passed
- `git diff --check` passed
- `otool -L` on the test/bench binaries showed no `libtblis.dylib` dependency

Benchmarks:
- Quick local release benchmarks with threads pinned: `TBLIS_NUM_THREADS=1`, `RAYON_NUM_THREADS=1`, `OMP_NUM_THREADS=1`, and for the BLAS runs `OPENBLAS_NUM_THREADS=1`
- Small/default BLAS run:
  - f64 matmul 32: faer 3.42 us, BLAS 1.98 us, TBLIS 5.66 us
  - f64 matmul 64: faer 12.71 us, BLAS 19.77 us, TBLIS 19.52 us
  - f64 matmul 128: faer 86.88 us, BLAS 99.27 us, TBLIS 101.31 us
  - c64 lhs-conj matmul 128: faer 385.69 us, BLAS 406.12 us, TBLIS 333.33 us
  - rank-4 interleaved n=8: faer 16.79 us, BLAS 29.64 us, TBLIS 19.08 us
  - rank-5 batched interleaved n=8: faer 62.11 us, BLAS 108.55 us, TBLIS 74.58 us
  - rank-4 row-major view n=8: faer 17.90 us, BLAS 42.66 us, TBLIS 20.13 us
- Large sample:
  - f64 matmul 256: faer 617.38 us, BLAS 748.55 us, TBLIS 645.64 us
  - f64 matmul 512: faer 5.04 ms, BLAS 4.91 ms, TBLIS 4.78 ms
  - c64 lhs-conj matmul 256: faer 2.93 ms, BLAS 2.77 ms, TBLIS 2.39 ms
  - c64 lhs-conj matmul 512: faer 23.37 ms, BLAS 22.08 ms, TBLIS 18.32 ms
  - rank-4 interleaved n=16: faer 672.51 us, BLAS 676.83 us, TBLIS 646.17 us
  - rank-5 batched interleaved n=16: faer 3.03 ms, BLAS 3.10 ms, TBLIS 2.67 ms
  - rank-4 row-major view n=16: faer 935.45 us, BLAS 954.64 us, TBLIS 651.67 us
- Interpretation: TBLIS is not a broad small-size win; it is more favorable on larger complex, interleaved, and view-heavy cases, so this PR does not overstate it as a universal replacement