### PR TITLE
Draft: add optional BLIS CPU provider feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ cblas-sys = "0.1"
 cblas-src = "0.1.3"
 cblas-inject = "0.1.1"
 blas-src = { version = "0.14", default-features = false }
+blis-src = { version = "0.2.2", default-features = false }
 lapack = "0.20"
 lapack-src = "0.13"
 lapack-inject = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,11 +49,11 @@ proc-macro2 = "1"
 quote = "1"
 syn = "2"
 tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "77527ecb647fecd4918ea2d06d0065ddce4e5b1c", version = "0.1.0" }
-strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs", rev = "71bdd913158a87437e51f4f9b69cba4cac6f5082", version = "0.1.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs", rev = "4ea9acbaa1422efa2662ff4b25b17cdae28f093d", version = "0.1.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs", rev = "4ea9acbaa1422efa2662ff4b25b17cdae28f093d", version = "0.1.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs", rev = "4ea9acbaa1422efa2662ff4b25b17cdae28f093d", version = "0.1.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs", rev = "4ea9acbaa1422efa2662ff4b25b17cdae28f093d", version = "0.1.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs", rev = "4ea9acbaa1422efa2662ff4b25b17cdae28f093d", version = "0.1.0", default-features = false }
 libloading = "0.8"
 faer = "0.24"
 cblas-sys = "0.1"

--- a/crates/tenferro-ad/Cargo.toml
+++ b/crates/tenferro-ad/Cargo.toml
@@ -30,6 +30,9 @@ blas-accelerate = [
 blas-mkl = [
     "tenferro-cpu/blas-mkl",
 ]
+blas-blis = [
+    "tenferro-cpu/blas-blis",
+]
 cuda = ["dep:tenferro-gpu", "tenferro-gpu/cuda"]
 webgpu = ["dep:tenferro-gpu", "tenferro-gpu/webgpu"]
 rocm = ["dep:tenferro-gpu", "tenferro-gpu/rocm"]

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -43,6 +43,18 @@ blas-mkl = [
     "strided-einsum2/blas-mkl",
     "strided-einsum2/parallel",
 ]
+blas-blis = [
+    "provider-src",
+    "dep:strided-einsum2",
+    "dep:blis-src",
+    "blas-src/blis",
+    "blis-src/cblas",
+    "blis-src/pthreads",
+    "blis-src/static",
+    "lapack-src/netlib",
+    "strided-einsum2/blas",
+    "strided-einsum2/parallel",
+]
 
 [dependencies]
 tenferro-tensor = { path = "../tenferro-tensor", version = "0.1.0" }
@@ -59,6 +71,7 @@ cblas-inject = { workspace = true, optional = true }
 lapack-inject = { workspace = true, optional = true }
 cblas-src = { workspace = true, optional = true }
 blas-src = { workspace = true, optional = true }
+blis-src = { workspace = true, optional = true }
 lapack = { workspace = true, optional = true }
 lapack-src = { workspace = true, optional = true }
 

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -25,10 +25,13 @@ compile_error!("provider-inject requires cpu-blas");
 #[cfg(any(
     all(feature = "blas-openblas", feature = "blas-accelerate"),
     all(feature = "blas-openblas", feature = "blas-mkl"),
+    all(feature = "blas-openblas", feature = "blas-blis"),
     all(feature = "blas-accelerate", feature = "blas-mkl"),
+    all(feature = "blas-accelerate", feature = "blas-blis"),
+    all(feature = "blas-mkl", feature = "blas-blis"),
 ))]
 compile_error!(
-    "enable at most one explicit BLAS provider feature: blas-openblas, blas-accelerate, or blas-mkl"
+    "enable at most one explicit BLAS provider feature: blas-openblas, blas-accelerate, blas-mkl, or blas-blis"
 );
 
 #[cfg(all(
@@ -36,7 +39,8 @@ compile_error!(
     any(
         feature = "blas-openblas",
         feature = "blas-accelerate",
-        feature = "blas-mkl"
+        feature = "blas-mkl",
+        feature = "blas-blis"
     )
 ))]
 compile_error!("provider-inject cannot be combined with explicit BLAS provider features");

--- a/crates/tenferro-cpu/tests/provider_feature_contract.rs
+++ b/crates/tenferro-cpu/tests/provider_feature_contract.rs
@@ -31,6 +31,18 @@ const PROVIDER_FEATURES: &[(&str, &[&str])] = &[
             "strided-einsum2/blas-mkl",
         ],
     ),
+    (
+        "blas-blis",
+        &[
+            "provider-src",
+            "dep:strided-einsum2",
+            "dep:blis-src",
+            "blas-src/blis",
+            "blis-src/static",
+            "lapack-src/netlib",
+            "strided-einsum2/blas",
+        ],
+    ),
 ];
 
 const PASSTHROUGH_CRATES: &[&str] = &[
@@ -129,13 +141,29 @@ fn public_cpu_user_crates_expose_provider_passthrough_features() {
 }
 
 #[test]
+fn linalg_explicit_provider_features_enable_local_blas_backend() {
+    let manifest = manifest("tenferro-linalg");
+
+    for (feature, _) in PROVIDER_FEATURES {
+        let values = feature_values(&manifest, feature);
+        assert!(
+            values.contains("\"cpu-blas\""),
+            "`tenferro-linalg` feature `{feature}` should enable its local cpu-blas cfg, got:\n{values}"
+        );
+    }
+}
+
+#[test]
 fn cpu_crate_rejects_ambiguous_explicit_provider_features() {
     let lib = source("crates/tenferro-cpu/src/lib.rs");
 
     for pair in [
         r#"all(feature = "blas-openblas", feature = "blas-accelerate")"#,
         r#"all(feature = "blas-openblas", feature = "blas-mkl")"#,
+        r#"all(feature = "blas-openblas", feature = "blas-blis")"#,
         r#"all(feature = "blas-accelerate", feature = "blas-mkl")"#,
+        r#"all(feature = "blas-accelerate", feature = "blas-blis")"#,
+        r#"all(feature = "blas-mkl", feature = "blas-blis")"#,
     ] {
         assert!(
             lib.contains(pair),

--- a/crates/tenferro-einsum/Cargo.toml
+++ b/crates/tenferro-einsum/Cargo.toml
@@ -37,6 +37,10 @@ blas-mkl = [
     "tenferro-ad?/blas-mkl",
     "tenferro-cpu/blas-mkl",
 ]
+blas-blis = [
+    "tenferro-ad?/blas-blis",
+    "tenferro-cpu/blas-blis",
+]
 cuda = ["tenferro-ad?/cuda", "tenferro-internal-ops/cuda"]
 webgpu = ["tenferro-ad?/webgpu", "tenferro-internal-ops/webgpu"]
 rocm = ["tenferro-ad?/rocm", "tenferro-internal-ops/rocm"]

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -17,6 +17,7 @@ cpu-blas = ["tenferro-cpu/cpu-blas"]
 blas-openblas = ["tenferro-ad?/blas-openblas", "tenferro-cpu/blas-openblas"]
 blas-accelerate = ["tenferro-ad?/blas-accelerate", "tenferro-cpu/blas-accelerate"]
 blas-mkl = ["tenferro-ad?/blas-mkl", "tenferro-cpu/blas-mkl"]
+blas-blis = ["tenferro-ad?/blas-blis", "tenferro-cpu/blas-blis"]
 autodiff = [
     "dep:tidu",
     "dep:tenferro-ad",

--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -20,6 +20,7 @@ cpu-blas = ["tenferro-cpu/cpu-blas"]
 blas-openblas = ["tenferro-cpu/blas-openblas"]
 blas-accelerate = ["tenferro-cpu/blas-accelerate"]
 blas-mkl = ["tenferro-cpu/blas-mkl"]
+blas-blis = ["tenferro-cpu/blas-blis"]
 cpu-reference = []
 cuda = [
     "dep:cubecl",

--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -27,19 +27,28 @@ cpu-blas = [
     "tenferro-cpu/cpu-blas",
 ]
 blas-openblas = [
+    "cpu-blas",
     "tenferro-ad?/blas-openblas",
     "tenferro-cpu/blas-openblas",
     "tenferro-gpu?/blas-openblas",
 ]
 blas-accelerate = [
+    "cpu-blas",
     "tenferro-ad?/blas-accelerate",
     "tenferro-cpu/blas-accelerate",
     "tenferro-gpu?/blas-accelerate",
 ]
 blas-mkl = [
+    "cpu-blas",
     "tenferro-ad?/blas-mkl",
     "tenferro-cpu/blas-mkl",
     "tenferro-gpu?/blas-mkl",
+]
+blas-blis = [
+    "cpu-blas",
+    "tenferro-ad?/blas-blis",
+    "tenferro-cpu/blas-blis",
+    "tenferro-gpu?/blas-blis",
 ]
 provider-inject = [
     "cpu-blas",

--- a/crates/tenferro-runtime/Cargo.toml
+++ b/crates/tenferro-runtime/Cargo.toml
@@ -20,6 +20,7 @@ cpu-blas = ["tenferro-cpu/cpu-blas"]
 blas-openblas = ["tenferro-cpu/blas-openblas"]
 blas-accelerate = ["tenferro-cpu/blas-accelerate"]
 blas-mkl = ["tenferro-cpu/blas-mkl"]
+blas-blis = ["tenferro-cpu/blas-blis"]
 
 [dependencies]
 tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.1.0" }


### PR DESCRIPTION
Not ready to merge yet.

This is a draft PR for #1334 to make the BLIS direction reviewable. The intent is to validate the feature wiring and source-provider contract before deciding whether this should become the final public BLIS provider interface.

## Summary

- Adds an opt-in `blas-blis` feature for the CPU provider stack.
- Wires BLIS through `blas-src/blis` and direct `blis-src` with `cblas`, `pthreads`, and `static`.
- Pairs BLIS with `lapack-src/netlib`, because BLIS provides BLAS/CBLAS but not LAPACK symbols required by `tenferro-linalg`.
- Adds `blas-blis` passthrough features for runtime/ad/einsum/linalg/fft/gpu crates.
- Extends provider conflict guards so `blas-blis` cannot be combined with another explicit BLAS provider or `provider-inject`.
- Fixes `tenferro-linalg` explicit `blas-*` features to enable its local `cpu-blas` cfg gate.

## Current Contract

`blas-blis` should be read as:

- BLIS-backed BLAS/CBLAS for dense contraction paths using the existing BLAS provider surface.
- Netlib-backed LAPACK source provider for LAPACK symbols used by linalg routines.
- Opt-in only; not a default provider.

This should not be described as a native BLIS object-API integration, and it is separate from the TBLIS rank-N contraction provider.

## Verification

Ran locally on macOS arm64:

```text
cargo check -p tenferro-cpu --no-default-features --features blas-blis
cargo check -p tenferro-runtime --no-default-features --features blas-blis
cargo test -p tenferro-cpu --test provider_feature_contract --no-default-features --features blas-blis
cargo test -p tenferro-cpu --no-default-features --features blas-blis dot_general -- --nocapture
OPENBLAS_FC=/opt/homebrew/bin/gfortran \
LIBRARY_PATH=/opt/homebrew/lib/gcc/current:/opt/homebrew/lib/gcc/15:/opt/homebrew/opt/openblas/lib \
DYLD_LIBRARY_PATH=/opt/homebrew/lib/gcc/current:/opt/homebrew/lib/gcc/15:/opt/homebrew/opt/openblas/lib \
CARGO_TARGET_DIR=/private/tmp/tenferro-blis-linalg-netlib-test \
cargo test -p tenferro-linalg --no-default-features --features blas-blis solve -- --nocapture
```

Important failure found before adding `lapack-src/netlib`:

- `tenferro-linalg --features blas-blis solve` linked BLIS but failed with unresolved LAPACK symbols such as `dgesdd_`, `dgetrf_`, `zheev_`.
- After adding `lapack-src/netlib`, the remaining local issue was `ld: library 'gfortran' not found`; setting the Homebrew gfortran library path made the linalg test pass.

## Benchmark Notes

Command shape:

```text
RAYON_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 BLIS_NUM_THREADS=1 TENFERRO_PAIRWISE_THREADS=1 \
cargo bench -p tenferro-cpu [provider features] --bench pairwise_contraction -- \
  --warm-up-time 0.2 --measurement-time 0.5 --sample-size 10
```

Benchmark variables:

- dtype: `c64`
- threads: `1`
- physical dimension: `d = 2`
- bond dimension: `chi`
- `first_site`: one first-site contraction
- `env_bra`: environment times bra contraction
- `tmp_ket`: temporary tensor times ket contraction
- `site_update`: two contractions, `env_bra` followed by `tmp_ket`
- values below are approximate mean wall times from `normal_per_call`

| case | chi | faer | BLIS | OpenBLAS |
|---|---:|---:|---:|---:|
| first_site | 32 | 1.06 us | 2.66 us | 1.44 us |
| env_bra | 32 | 12.2 us | 17.5 us | 90.1 us |
| tmp_ket | 32 | 13.9 us | 14.1 us | 70.7 us |
| site_update | 32 | 38.3 us | 31.4 us | 167.5 us |

Interpretation: BLIS is not uniformly faster. It looks worse than faer/OpenBLAS for several small and mid-sized cases, close to faer for `tmp_ket chi=32`, and better for the larger composite `site_update chi=32` case. OpenBLAS is competitive in small/mid cases but regresses sharply in this benchmark at `chi=32`.

## Remaining Work Before Merge

- Decide whether `blas-blis` should permanently expose BLIS + Netlib LAPACK as one bundled feature, or whether the project wants separate BLAS/LAPACK provider features.
- Document the macOS/Homebrew `gfortran` runtime requirement for Netlib LAPACK source builds.
- Run CI and review repository rule feedback.
- Add or update user-facing provider docs once the contract is accepted.

