### PR TITLE
Broadcast CUDA scalar operands in binary elementwise ops

### DIFF
--- a/crates/tenferro-gpu/src/cubecl/dispatch.rs
+++ b/crates/tenferro-gpu/src/cubecl/dispatch.rs
@@ -920,21 +920,68 @@ pub(crate) fn compare_mode(dir: &CompareDir) -> usize {
 }
 
 macro_rules! launch_binary_elementwise_kernel {
-    ($backend:expr, $lhs:ident, $rhs:ident, $op:expr, $kernel:ident, $scalar:ty, $variant:ident) => {
-        launch_binary(
-            $backend.runtime(),
-            $lhs,
-            $rhs,
-            $lhs.shape(),
-            $op,
-            |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                crate::kernels::elementwise::$kernel::launch_unchecked::<$scalar, CubeclCudaRuntime>(
-                    client, count, dim, out, lhs_arg, rhs_arg,
-                );
-            },
-        )
-        .map(Tensor::$variant)
-    };
+    ($backend:expr, $lhs:ident, $rhs:ident, $op:expr, $kernel:ident, $scalar:ty, $variant:ident) => {{
+        let result = if $lhs.shape() == $rhs.shape() {
+            launch_binary(
+                $backend.runtime(),
+                $lhs,
+                $rhs,
+                $lhs.shape(),
+                $op,
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    crate::kernels::elementwise::$kernel::launch_unchecked::<
+                        $scalar,
+                        CubeclCudaRuntime,
+                    >(client, count, dim, out, lhs_arg, rhs_arg);
+                },
+            )
+        } else if $lhs.shape().is_empty() {
+            let lhs = $backend.broadcast_typed($lhs, $rhs.shape(), &[])?;
+            launch_binary(
+                $backend.runtime(),
+                &lhs,
+                $rhs,
+                $rhs.shape(),
+                $op,
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    crate::kernels::elementwise::$kernel::launch_unchecked::<
+                        $scalar,
+                        CubeclCudaRuntime,
+                    >(client, count, dim, out, lhs_arg, rhs_arg);
+                },
+            )
+        } else if $rhs.shape().is_empty() {
+            let rhs = $backend.broadcast_typed($rhs, $lhs.shape(), &[])?;
+            launch_binary(
+                $backend.runtime(),
+                $lhs,
+                &rhs,
+                $lhs.shape(),
+                $op,
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    crate::kernels::elementwise::$kernel::launch_unchecked::<
+                        $scalar,
+                        CubeclCudaRuntime,
+                    >(client, count, dim, out, lhs_arg, rhs_arg);
+                },
+            )
+        } else {
+            launch_binary(
+                $backend.runtime(),
+                $lhs,
+                $rhs,
+                $lhs.shape(),
+                $op,
+                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                    crate::kernels::elementwise::$kernel::launch_unchecked::<
+                        $scalar,
+                        CubeclCudaRuntime,
+                    >(client, count, dim, out, lhs_arg, rhs_arg);
+                },
+            )
+        };
+        result.map(Tensor::$variant)
+    }};
 }
 
 macro_rules! launch_unary_elementwise_kernel {

--- a/crates/tenferro-gpu/src/cubecl/dispatch.rs
+++ b/crates/tenferro-gpu/src/cubecl/dispatch.rs
@@ -920,68 +920,21 @@ pub(crate) fn compare_mode(dir: &CompareDir) -> usize {
 }
 
 macro_rules! launch_binary_elementwise_kernel {
-    ($backend:expr, $lhs:ident, $rhs:ident, $op:expr, $kernel:ident, $scalar:ty, $variant:ident) => {{
-        let result = if $lhs.shape() == $rhs.shape() {
-            launch_binary(
-                $backend.runtime(),
-                $lhs,
-                $rhs,
-                $lhs.shape(),
-                $op,
-                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                    crate::kernels::elementwise::$kernel::launch_unchecked::<
-                        $scalar,
-                        CubeclCudaRuntime,
-                    >(client, count, dim, out, lhs_arg, rhs_arg);
-                },
-            )
-        } else if $lhs.shape().is_empty() {
-            let lhs = $backend.broadcast_typed($lhs, $rhs.shape(), &[])?;
-            launch_binary(
-                $backend.runtime(),
-                &lhs,
-                $rhs,
-                $rhs.shape(),
-                $op,
-                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                    crate::kernels::elementwise::$kernel::launch_unchecked::<
-                        $scalar,
-                        CubeclCudaRuntime,
-                    >(client, count, dim, out, lhs_arg, rhs_arg);
-                },
-            )
-        } else if $rhs.shape().is_empty() {
-            let rhs = $backend.broadcast_typed($rhs, $lhs.shape(), &[])?;
-            launch_binary(
-                $backend.runtime(),
-                $lhs,
-                &rhs,
-                $lhs.shape(),
-                $op,
-                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                    crate::kernels::elementwise::$kernel::launch_unchecked::<
-                        $scalar,
-                        CubeclCudaRuntime,
-                    >(client, count, dim, out, lhs_arg, rhs_arg);
-                },
-            )
-        } else {
-            launch_binary(
-                $backend.runtime(),
-                $lhs,
-                $rhs,
-                $lhs.shape(),
-                $op,
-                |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
-                    crate::kernels::elementwise::$kernel::launch_unchecked::<
-                        $scalar,
-                        CubeclCudaRuntime,
-                    >(client, count, dim, out, lhs_arg, rhs_arg);
-                },
-            )
-        };
-        result.map(Tensor::$variant)
-    }};
+    ($backend:expr, $lhs:ident, $rhs:ident, $op:expr, $kernel:ident, $scalar:ty, $variant:ident) => {
+        launch_binary(
+            $backend.runtime(),
+            $lhs,
+            $rhs,
+            $lhs.shape(),
+            $op,
+            |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+                crate::kernels::elementwise::$kernel::launch_unchecked::<$scalar, CubeclCudaRuntime>(
+                    client, count, dim, out, lhs_arg, rhs_arg,
+                );
+            },
+        )
+        .map(Tensor::$variant)
+    };
 }
 
 macro_rules! launch_unary_elementwise_kernel {

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -3234,6 +3234,54 @@ impl TensorFusion for CudaBackend {
     ) -> crate::Result<Option<Vec<Tensor>>> {
         fusion::execute_elementwise_fusion(self, inputs, plan)
     }
+
+    fn execute_broadcast_multiply(
+        &mut self,
+        lhs: TensorRead<'_>,
+        lhs_shape: &[usize],
+        lhs_dims: &[usize],
+        rhs: TensorRead<'_>,
+        rhs_shape: &[usize],
+        rhs_dims: &[usize],
+    ) -> crate::Result<Option<Tensor>> {
+        let (TensorRead::Tensor(lhs), TensorRead::Tensor(rhs)) = (lhs, rhs) else {
+            return Ok(None);
+        };
+        match (lhs, rhs) {
+            (Tensor::F32(lhs), Tensor::F32(rhs)) => launch_broadcast_multiply_typed(
+                self, lhs, lhs_shape, lhs_dims, rhs, rhs_shape, rhs_dims,
+            )
+            .map(Tensor::F32)
+            .map(Some),
+            (Tensor::F64(lhs), Tensor::F64(rhs)) => launch_broadcast_multiply_typed(
+                self, lhs, lhs_shape, lhs_dims, rhs, rhs_shape, rhs_dims,
+            )
+            .map(Tensor::F64)
+            .map(Some),
+            (Tensor::I32(lhs), Tensor::I32(rhs)) => launch_broadcast_multiply_int_typed(
+                self, lhs, lhs_shape, lhs_dims, rhs, rhs_shape, rhs_dims,
+            )
+            .map(Tensor::I32)
+            .map(Some),
+            (Tensor::I64(lhs), Tensor::I64(rhs)) => launch_broadcast_multiply_int_typed(
+                self, lhs, lhs_shape, lhs_dims, rhs, rhs_shape, rhs_dims,
+            )
+            .map(Tensor::I64)
+            .map(Some),
+            (Tensor::C32(lhs), Tensor::C32(rhs)) => launch_broadcast_multiply_complex_typed(
+                self, lhs, lhs_shape, lhs_dims, rhs, rhs_shape, rhs_dims,
+            )
+            .map(Tensor::C32)
+            .map(Some),
+            (Tensor::C64(lhs), Tensor::C64(rhs)) => launch_broadcast_multiply_complex_typed(
+                self, lhs, lhs_shape, lhs_dims, rhs, rhs_shape, rhs_dims,
+            )
+            .map(Tensor::C64)
+            .map(Some),
+            (Tensor::Bool(_), Tensor::Bool(_)) => Ok(None),
+            _ => Err(dtype_mismatch("broadcast_multiply", lhs, rhs)),
+        }
+    }
 }
 
 impl BackendCachedDot for CudaBackend {}
@@ -3247,6 +3295,131 @@ impl TensorBackend for CudaBackend {}
 fn validate_permutation(op: &'static str, perm: &[usize], rank: usize) -> crate::Result<()> {
     ensure_rank(op, rank, perm.len())?;
     ensure_axes_unique(op, "perm", perm, rank)
+}
+
+fn ensure_same_shape_for_broadcast_multiply(
+    lhs_shape: &[usize],
+    rhs_shape: &[usize],
+) -> crate::Result<()> {
+    if lhs_shape != rhs_shape {
+        return Err(crate::Error::ShapeMismatch {
+            op: "broadcast_multiply",
+            lhs: lhs_shape.to_vec(),
+            rhs: rhs_shape.to_vec(),
+        });
+    }
+    Ok(())
+}
+
+fn launch_broadcast_multiply_typed<T>(
+    backend: &CudaBackend,
+    lhs: &TypedTensor<T>,
+    lhs_shape: &[usize],
+    lhs_dims: &[usize],
+    rhs: &TypedTensor<T>,
+    rhs_shape: &[usize],
+    rhs_dims: &[usize],
+) -> crate::Result<TypedTensor<T>>
+where
+    T: CubeElement + CubePrimitive + CubeFloat + Clone,
+{
+    ensure_same_shape_for_broadcast_multiply(lhs_shape, rhs_shape)?;
+    validate_broadcast_in_dim(lhs.shape(), lhs_shape, lhs_dims)?;
+    validate_broadcast_in_dim(rhs.shape(), rhs_shape, rhs_dims)?;
+    launch_binary_tensor(
+        backend.runtime(),
+        lhs,
+        rhs,
+        lhs_shape,
+        "broadcast_multiply",
+        |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+            elementwise::broadcast_multiply_float::launch_unchecked::<T, CubeclCudaRuntime>(
+                client,
+                count,
+                dim,
+                out.into_tensor_arg(),
+                lhs_arg.into_tensor_arg(),
+                rhs_arg.into_tensor_arg(),
+                comptime_sequence(lhs_dims),
+                comptime_sequence(rhs_dims),
+                lhs_shape.len(),
+            );
+        },
+    )
+}
+
+fn launch_broadcast_multiply_int_typed<T>(
+    backend: &CudaBackend,
+    lhs: &TypedTensor<T>,
+    lhs_shape: &[usize],
+    lhs_dims: &[usize],
+    rhs: &TypedTensor<T>,
+    rhs_shape: &[usize],
+    rhs_dims: &[usize],
+) -> crate::Result<TypedTensor<T>>
+where
+    T: CubeElement + CubePrimitive + CubeInt + Clone,
+{
+    ensure_same_shape_for_broadcast_multiply(lhs_shape, rhs_shape)?;
+    validate_broadcast_in_dim(lhs.shape(), lhs_shape, lhs_dims)?;
+    validate_broadcast_in_dim(rhs.shape(), rhs_shape, rhs_dims)?;
+    launch_binary_tensor(
+        backend.runtime(),
+        lhs,
+        rhs,
+        lhs_shape,
+        "broadcast_multiply",
+        |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+            elementwise::broadcast_multiply_int::launch_unchecked::<T, CubeclCudaRuntime>(
+                client,
+                count,
+                dim,
+                out.into_tensor_arg(),
+                lhs_arg.into_tensor_arg(),
+                rhs_arg.into_tensor_arg(),
+                comptime_sequence(lhs_dims),
+                comptime_sequence(rhs_dims),
+                lhs_shape.len(),
+            );
+        },
+    )
+}
+
+fn launch_broadcast_multiply_complex_typed<T>(
+    backend: &CudaBackend,
+    lhs: &TypedTensor<T>,
+    lhs_shape: &[usize],
+    lhs_dims: &[usize],
+    rhs: &TypedTensor<T>,
+    rhs_shape: &[usize],
+    rhs_dims: &[usize],
+) -> crate::Result<TypedTensor<T>>
+where
+    T: CubeElement + CubePrimitive + CubeComplex + Clone,
+{
+    ensure_same_shape_for_broadcast_multiply(lhs_shape, rhs_shape)?;
+    validate_broadcast_in_dim(lhs.shape(), lhs_shape, lhs_dims)?;
+    validate_broadcast_in_dim(rhs.shape(), rhs_shape, rhs_dims)?;
+    launch_binary_tensor(
+        backend.runtime(),
+        lhs,
+        rhs,
+        lhs_shape,
+        "broadcast_multiply",
+        |client, count, dim, out, lhs_arg, rhs_arg| unsafe {
+            elementwise::broadcast_multiply_complex::launch_unchecked::<T, CubeclCudaRuntime>(
+                client,
+                count,
+                dim,
+                out.into_tensor_arg(),
+                lhs_arg.into_tensor_arg(),
+                rhs_arg.into_tensor_arg(),
+                comptime_sequence(lhs_dims),
+                comptime_sequence(rhs_dims),
+                lhs_shape.len(),
+            );
+        },
+    )
 }
 
 fn validate_broadcast_in_dim(

--- a/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
@@ -3,12 +3,63 @@ use crate::config::CompareDir;
 use crate::cubecl::gpu_available;
 use crate::{DType, DeviceKind, GpuBackendKind, Tensor};
 use tenferro_tensor::BackendId;
-use tenferro_tensor::{TensorAnalytic, TensorElementwise, TensorStructural};
+use tenferro_tensor::{
+    TensorAnalytic, TensorElementwise, TensorFusion, TensorRead, TensorStructural,
+};
 
 use super::{
     assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c64, tensor_f64, tensor_i32,
     tensor_i64, upload,
 };
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn test_broadcast_multiply_scalar_operands_match_cpu() {
+    if !gpu_available() {
+        eprintln!(
+            "skipping test_broadcast_multiply_scalar_operands_match_cpu - no CUDA device found"
+        );
+        return;
+    }
+    let Ok(mut backend) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(gpu_backend))
+    else {
+        eprintln!(
+            "skipping test_broadcast_multiply_scalar_operands_match_cpu - CUDA runtime could not be initialized"
+        );
+        return;
+    };
+    let scalar = tensor_f64(vec![], vec![2.0]);
+    let vector = tensor_f64(vec![3], vec![3.0, -4.0, 5.0]);
+    let gpu_scalar = upload(&backend, &scalar);
+    let gpu_vector = upload(&backend, &vector);
+
+    let lhs_scalar = backend
+        .execute_broadcast_multiply(
+            TensorRead::from_tensor(&gpu_scalar),
+            &[3],
+            &[],
+            TensorRead::from_tensor(&gpu_vector),
+            &[3],
+            &[0],
+        )
+        .unwrap()
+        .expect("scalar lhs broadcast multiply should fuse");
+    let rhs_scalar = backend
+        .execute_broadcast_multiply(
+            TensorRead::from_tensor(&gpu_vector),
+            &[3],
+            &[0],
+            TensorRead::from_tensor(&gpu_scalar),
+            &[3],
+            &[],
+        )
+        .unwrap()
+        .expect("scalar rhs broadcast multiply should fuse");
+
+    let expected = tensor_f64(vec![3], vec![6.0, -8.0, 10.0]);
+    assert_tensor_close(&download(&backend, &lhs_scalar), &expected, 1e-12);
+    assert_tensor_close(&download(&backend, &rhs_scalar), &expected, 1e-12);
+}
 
 #[test]
 #[ignore = "requires CUDA 12.8+ GPU"]

--- a/crates/tenferro-gpu/src/kernels/elementwise.rs
+++ b/crates/tenferro-gpu/src/kernels/elementwise.rs
@@ -1,5 +1,7 @@
 use cubecl::prelude::*;
 
+use crate::kernels::helpers::{flat_to_tensor_index, multi_to_tensor_index};
+
 pub(crate) const COMPARE_EQ: usize = 0;
 pub(crate) const COMPARE_LT: usize = 1;
 pub(crate) const COMPARE_LE: usize = 2;
@@ -40,6 +42,53 @@ macro_rules! binary_float_int_complex_kernel {
         }
     };
 }
+
+#[cube]
+fn broadcast_source_index<E: CubePrimitive>(
+    out_flat: usize,
+    out: &Tensor<E>,
+    input: &Tensor<E>,
+    #[comptime] dims: Sequence<usize>,
+    #[comptime] output_rank: usize,
+) -> usize {
+    let input_rank = dims.len();
+    let out_idx = flat_to_tensor_index(out_flat, out, output_rank);
+    let mut input_idx = Array::<usize>::new(input_rank);
+    #[unroll]
+    for src_axis in 0..input_rank {
+        let dst_axis = comptime! { *dims.index(src_axis) };
+        let src_dim = input.shape(src_axis);
+        input_idx[src_axis] = out_idx[dst_axis];
+        if src_dim == 1 {
+            input_idx[src_axis] = 0;
+        }
+    }
+    multi_to_tensor_index(&input_idx, input, input_rank)
+}
+
+macro_rules! broadcast_multiply_kernel {
+    ($name:ident, $bound:path) => {
+        #[cube(launch_unchecked)]
+        pub fn $name<E: $bound>(
+            out: &mut Tensor<E>,
+            lhs: &Tensor<E>,
+            rhs: &Tensor<E>,
+            #[comptime] lhs_dims: Sequence<usize>,
+            #[comptime] rhs_dims: Sequence<usize>,
+            #[comptime] output_rank: usize,
+        ) {
+            if ABSOLUTE_POS < out.len() {
+                let lhs_idx = broadcast_source_index(ABSOLUTE_POS, out, lhs, lhs_dims, output_rank);
+                let rhs_idx = broadcast_source_index(ABSOLUTE_POS, out, rhs, rhs_dims, output_rank);
+                out[ABSOLUTE_POS] = lhs[lhs_idx] * rhs[rhs_idx];
+            }
+        }
+    };
+}
+
+broadcast_multiply_kernel!(broadcast_multiply_float, Float);
+broadcast_multiply_kernel!(broadcast_multiply_int, Int);
+broadcast_multiply_kernel!(broadcast_multiply_complex, ComplexCore);
 
 macro_rules! unary_float_kernel {
     ($name:ident, $method:ident) => {

--- a/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -206,7 +206,7 @@ fn cubecl_zero_length_launches_validate_buffers_before_returning() {
 }
 
 #[test]
-fn cubecl_binary_elementwise_kernels_broadcast_zero_dim_scalars() {
+fn cubecl_binary_elementwise_kernels_do_not_materialize_scalar_broadcasts() {
     let dispatch_source = cubecl_source("dispatch.rs");
     let binary_macro = source_section(
         &dispatch_source,
@@ -214,22 +214,29 @@ fn cubecl_binary_elementwise_kernels_broadcast_zero_dim_scalars() {
         "macro_rules! dispatch_binary_float_complex_int",
     );
 
-    assert_ordered_needles(
-        "launch_binary_elementwise_kernel scalar lhs broadcast",
-        binary_macro,
-        &[
-            "$lhs.shape().is_empty()",
-            "let lhs = $backend.broadcast_typed($lhs, $rhs.shape(), &[])?;",
-            "launch_binary(",
-        ],
+    assert!(
+        !binary_macro.contains("broadcast_typed"),
+        "raw binary elementwise launchers must not allocate dense scalar-broadcast temporaries"
+    );
+    assert!(
+        !binary_macro.contains("shape().is_empty()"),
+        "scalar broadcast should be represented as BroadcastInDim and fused by backend hooks"
+    );
+
+    let mod_source = cubecl_source("mod.rs");
+    let fusion_impl = source_section(
+        &mod_source,
+        "impl TensorFusion for CudaBackend",
+        "impl BackendCachedDot for CudaBackend",
     );
     assert_ordered_needles(
-        "launch_binary_elementwise_kernel scalar rhs broadcast",
-        binary_macro,
+        "CudaBackend broadcast multiply hook",
+        fusion_impl,
         &[
-            "$rhs.shape().is_empty()",
-            "let rhs = $backend.broadcast_typed($rhs, $lhs.shape(), &[])?;",
-            "launch_binary(",
+            "fn execute_broadcast_multiply(",
+            "launch_broadcast_multiply_typed",
+            "launch_broadcast_multiply_int_typed",
+            "launch_broadcast_multiply_complex_typed",
         ],
     );
 }

--- a/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -206,6 +206,35 @@ fn cubecl_zero_length_launches_validate_buffers_before_returning() {
 }
 
 #[test]
+fn cubecl_binary_elementwise_kernels_broadcast_zero_dim_scalars() {
+    let dispatch_source = cubecl_source("dispatch.rs");
+    let binary_macro = source_section(
+        &dispatch_source,
+        "macro_rules! launch_binary_elementwise_kernel",
+        "macro_rules! dispatch_binary_float_complex_int",
+    );
+
+    assert_ordered_needles(
+        "launch_binary_elementwise_kernel scalar lhs broadcast",
+        binary_macro,
+        &[
+            "$lhs.shape().is_empty()",
+            "let lhs = $backend.broadcast_typed($lhs, $rhs.shape(), &[])?;",
+            "launch_binary(",
+        ],
+    );
+    assert_ordered_needles(
+        "launch_binary_elementwise_kernel scalar rhs broadcast",
+        binary_macro,
+        &[
+            "$rhs.shape().is_empty()",
+            "let rhs = $backend.broadcast_typed($rhs, $lhs.shape(), &[])?;",
+            "launch_binary(",
+        ],
+    );
+}
+
+#[test]
 fn cubecl_interop_download_validates_buffer_before_empty_fast_path() {
     let interop_source = cubecl_source("interop.rs");
     let download_source = source_section(

--- a/crates/tenferro-linalg/src/ad/rules/mod.rs
+++ b/crates/tenferro-linalg/src/ad/rules/mod.rs
@@ -488,14 +488,24 @@ pub(crate) fn linearize_svd(
     let s_diff = fixed_sub(builder, ValueRef::Local(s_dim), ValueRef::Local(s_dim_t));
     let s_gap = fixed_mul(builder, ValueRef::Local(s_sum), ValueRef::Local(s_diff));
     let s_gap_sq = fixed_mul(builder, ValueRef::Local(s_gap), ValueRef::Local(s_gap));
-    let eps_sq = fixed_scale(builder, ValueRef::Local(ones_mat), eps * eps);
+    let eps_sq = fixed_scale(
+        builder,
+        ValueRef::Local(ones_mat),
+        eps * eps,
+        matrix_shape(k.clone(), k.clone(), batch_shape),
+    );
     let safe_gap = fixed_add(builder, ValueRef::Local(s_gap_sq), ValueRef::Local(eps_sq));
     let f = fixed_div(builder, ValueRef::Local(s_gap), ValueRef::Local(safe_gap));
 
     let du = if u_active {
         let s_ones = one_like_fixed(builder, s_dtype, s.clone(), matrix_rank - 1);
         let s_sq = fixed_mul(builder, s.clone(), s.clone());
-        let s_eps_sq = fixed_scale(builder, ValueRef::Local(s_ones), eps * eps);
+        let s_eps_sq = fixed_scale(
+            builder,
+            ValueRef::Local(s_ones),
+            eps * eps,
+            vector_shape(k.clone(), batch_shape),
+        );
         let safe_s_sq = fixed_add(builder, ValueRef::Local(s_sq), ValueRef::Local(s_eps_sq));
         let s_inv = fixed_div(builder, s.clone(), ValueRef::Local(safe_s_sq));
         let s_inv_mat = embed_diag_fixed(builder, ValueRef::Local(s_inv));
@@ -504,7 +514,12 @@ pub(crate) fn linearize_svd(
         let anti_hermitian = linear_sub(builder, ds_mat, ds_h);
         // Matches JAX's complex gauge correction: 0.5 * (dS - dS^H) * diag(1 / s).
         let d_udv_diag = hadamard_fixed_linear(builder, ValueRef::Local(s_inv_mat), anti_hermitian);
-        let d_udv_diag = linear_scale(builder, d_udv_diag, 0.5);
+        let d_udv_diag = linear_scale(
+            builder,
+            d_udv_diag,
+            0.5,
+            matrix_shape(k.clone(), k.clone(), batch_shape),
+        );
 
         let dss = hadamard_fixed_linear(builder, ValueRef::Local(s_dim), ds_mat);
         let dss_h = adjoint_matrix_linear(builder, dss, matrix_rank, dtype);
@@ -679,12 +694,19 @@ pub(crate) fn linearize_eigh(
         return Ok(vec![None, None]);
     };
     let input_shape = input_shape.as_slice();
+    let (n, _, batch_shape) = matrix_shape_parts(input_shape, "linearize_eigh");
     let matrix_rank = input_shape.len();
     let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let w = ValueRef::External(primal_out[0].clone());
     let w_dtype = ctx.dtype_of(&w)?;
     let v = ValueRef::External(primal_out[1].clone());
-    let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank, dtype);
+    let da_self_adjoint = self_adjoint_from_lower_linear(
+        builder,
+        da,
+        matrix_rank,
+        dtype,
+        vector_shape(n.clone(), batch_shape),
+    );
 
     let vh = adjoint_matrix_fixed(builder, v.clone(), matrix_rank, dtype);
     let tmp = matmul_linear(
@@ -728,7 +750,12 @@ pub(crate) fn linearize_eigh(
     );
     let diff = fixed_sub(builder, ValueRef::Local(w_row), ValueRef::Local(w_col));
     let diff_sq = fixed_mul(builder, ValueRef::Local(diff), ValueRef::Local(diff));
-    let eps_sq = fixed_scale(builder, ValueRef::Local(ones_mat), eps * eps);
+    let eps_sq = fixed_scale(
+        builder,
+        ValueRef::Local(ones_mat),
+        eps * eps,
+        matrix_shape(n.clone(), n.clone(), batch_shape),
+    );
     let safe_diff = fixed_add(builder, ValueRef::Local(diff_sq), ValueRef::Local(eps_sq));
     let f = fixed_div(builder, ValueRef::Local(diff), ValueRef::Local(safe_diff));
     let f = convert_fixed_ref_to_dtype(builder, ValueRef::Local(f), w_dtype, dtype);
@@ -760,6 +787,7 @@ pub(crate) fn linearize_eigh_values(
     };
     let input_shape = input_shape.as_slice();
     let matrix_rank = input_shape.len();
+    let (n, _, batch_shape) = matrix_shape_parts(input_shape, "linearize_eigh_values");
     let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let eigh_outputs = builder.add_operation(
         linalg_std_op(LinalgOp::Eigh {
@@ -770,7 +798,13 @@ pub(crate) fn linearize_eigh_values(
         OperationRole::Primary,
     );
     let v = ValueRef::Local(eigh_outputs[1]);
-    let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank, dtype);
+    let da_self_adjoint = self_adjoint_from_lower_linear(
+        builder,
+        da,
+        matrix_rank,
+        dtype,
+        vector_shape(n.clone(), batch_shape),
+    );
     let vh = adjoint_matrix_fixed(builder, v.clone(), matrix_rank, dtype);
     let tmp = matmul_linear(
         builder,
@@ -806,9 +840,16 @@ pub(crate) fn linearize_cholesky(
     };
     let input_shape = input_shape.as_slice();
     let matrix_rank = input_shape.len();
+    let (n, _, batch_shape) = matrix_shape_parts(input_shape, "linearize_cholesky");
     let dtype = ctx.dtype_of(&ValueRef::External(primal_in[0].clone()))?;
     let l = ValueRef::External(primal_out[0].clone());
-    let da_self_adjoint = self_adjoint_from_lower_linear(builder, da, matrix_rank, dtype);
+    let da_self_adjoint = self_adjoint_from_lower_linear(
+        builder,
+        da,
+        matrix_rank,
+        dtype,
+        vector_shape(n.clone(), batch_shape),
+    );
     let l_conj = conjugate_primal_if_dtype_complex(builder, l.clone(), dtype);
 
     let tmp = builder.add_operation(
@@ -844,7 +885,7 @@ pub(crate) fn linearize_cholesky(
         },
     )[0];
     let diag_s = extract_diag_linear(builder, s);
-    let half_diag = linear_scale(builder, diag_s, 0.5);
+    let half_diag = linear_scale(builder, diag_s, 0.5, vector_shape(n.clone(), batch_shape));
     let half_diag_mat = embed_diag_linear(builder, half_diag);
     let phi_s = linear_add(builder, strict_lower, half_diag_mat);
     let dl = matmul_linear(
@@ -939,7 +980,8 @@ pub(crate) fn linearize_qr(
             },
         )[0];
         let sym_diag = extract_diag_linear(builder, sym);
-        let half_sym_diag = linear_scale(builder, sym_diag, 0.5);
+        let half_sym_diag =
+            linear_scale(builder, sym_diag, 0.5, vector_shape(m.clone(), batch_shape));
         let half_sym_diag_mat = embed_diag_linear(builder, half_sym_diag);
         let dr_leading_hat = linear_add(builder, upper, half_sym_diag_mat);
 
@@ -1064,7 +1106,7 @@ pub(crate) fn linearize_qr(
         },
     )[0];
     let sym_diag = extract_diag_linear(builder, sym);
-    let half_sym_diag = linear_scale(builder, sym_diag, 0.5);
+    let half_sym_diag = linear_scale(builder, sym_diag, 0.5, vector_shape(n.clone(), batch_shape));
     let half_sym_diag_mat = embed_diag_linear(builder, half_sym_diag);
     let dr_hat = linear_add(builder, upper, half_sym_diag_mat);
 

--- a/crates/tenferro-linalg/src/ad/rules/support.rs
+++ b/crates/tenferro-linalg/src/ad/rules/support.rs
@@ -165,15 +165,35 @@ pub(super) fn fixed_scale(
     builder: &mut dyn PrimitiveRuleBuilder,
     input: ValueRef<StdTensorOp>,
     factor: f64,
+    shape: Vec<DimExpr>,
+) -> LocalValueId {
+    let constant = broadcast_scalar_constant(builder, factor, shape);
+    builder.add_operation(
+        StdTensorOp::Mul,
+        vec![ValueRef::Local(constant), input],
+        OperationRole::Primary,
+    )[0]
+}
+
+fn broadcast_scalar_constant(
+    builder: &mut dyn PrimitiveRuleBuilder,
+    factor: f64,
+    shape: Vec<DimExpr>,
 ) -> LocalValueId {
     let constant = builder.add_operation(
         StdTensorOp::constant(factor),
         vec![],
         OperationRole::Primary,
-    );
+    )[0];
+    if shape.is_empty() {
+        return constant;
+    }
     builder.add_operation(
-        StdTensorOp::Mul,
-        vec![ValueRef::Local(constant[0]), input],
+        StdTensorOp::BroadcastInDim {
+            shape,
+            dims: vec![],
+        },
+        vec![ValueRef::Local(constant)],
         OperationRole::Primary,
     )[0]
 }
@@ -233,15 +253,12 @@ pub(super) fn linear_scale(
     builder: &mut dyn PrimitiveRuleBuilder,
     input: LocalValueId,
     factor: f64,
+    shape: Vec<DimExpr>,
 ) -> LocalValueId {
-    let constant = builder.add_operation(
-        StdTensorOp::constant(factor),
-        vec![],
-        OperationRole::Primary,
-    );
+    let constant = broadcast_scalar_constant(builder, factor, shape);
     builder.add_operation(
         StdTensorOp::Mul,
-        vec![ValueRef::Local(constant[0]), ValueRef::Local(input)],
+        vec![ValueRef::Local(constant), ValueRef::Local(input)],
         OperationRole::Linearized {
             active_mask: vec![false, true],
         },
@@ -439,6 +456,7 @@ pub(super) fn self_adjoint_from_lower_linear(
     input: LocalValueId,
     rank: usize,
     dtype: DType,
+    diag_shape: Vec<DimExpr>,
 ) -> LocalValueId {
     let strict_lower = builder.add_operation(
         StdTensorOp::Tril { k: -1 },
@@ -456,7 +474,7 @@ pub(super) fn self_adjoint_from_lower_linear(
     } else {
         let diag_h = conjugate_linear_if_dtype_complex(builder, diag, dtype);
         let diag_sum = linear_add(builder, diag, diag_h);
-        linear_scale(builder, diag_sum, 0.5)
+        linear_scale(builder, diag_sum, 0.5, diag_shape)
     };
     let diag_mat = embed_diag_linear(builder, diag);
     linear_add(builder, offdiag, diag_mat)
@@ -531,6 +549,12 @@ pub(super) fn matrix_shape(
     batch_shape: &[DimExpr],
 ) -> Vec<DimExpr> {
     let mut shape = vec![rows.into(), cols.into()];
+    shape.extend_from_slice(batch_shape);
+    shape
+}
+
+pub(super) fn vector_shape(dim: impl Into<DimExpr>, batch_shape: &[DimExpr]) -> Vec<DimExpr> {
+    let mut shape = vec![dim.into()];
     shape.extend_from_slice(batch_shape);
     shape
 }


### PR DESCRIPTION
## Summary

- Remove scalar broadcast materialization in CUDA elementwise paths and keep explicit broadcast IR.
- In CUDA dispatch, remove scalar `broadcast_typed` branches from raw binary elementwise launchers so launch contract remains equal-shape.
- Add CUDA `TensorFusion::execute_broadcast_multiply` with a fused, index-mapped multiply kernel for scalar-like broadcasts.
- Update linalg AD scale helpers (`fixed_scale`, `linear_scale`) to emit `BroadcastInDim -> Mul` for rank-0 constants.
- Replace source-contract coverage to forbid dense scalar broadcast materialization and verify the CUDA broadcast-multiply hook is present.
- Add a GPU ignored test for scalar-lhs and scalar-rhs multiply correctness against CPU.

## Why

A prior implementation materialized zero-dimension operands via `broadcast_typed` before launching binary elementwise kernels, which could allocate an extra full-size temporary and add extra kernel work. This patch follows JAX/PyTorch-style behavior: broadcast is explicit in IR and consumed in one kernel via source-index mapping.

## Validation

- `cargo test -p tenferro-gpu --test cubecl_launch_contract cubecl_binary_elementwise_kernels_do_not_materialize_scalar_broadcasts --features cuda`
- `cargo test -p tenferro-gpu --features cuda test_broadcast_multiply_scalar_operands_match_cpu -- --ignored`
- `cargo test -p tenferro-linalg --test traced_ad_explicit --features autodiff`
- `cargo test -p tenferro-linalg --lib --features autodiff`
- `git diff --check`

## Commit

- `8c267c63`
