### PR TITLE
Fix checked error paths and signed indexing edge cases

### DIFF
--- a/crates/tenferro-ad/tests/ad.rs
+++ b/crates/tenferro-ad/tests/ad.rs
@@ -1171,7 +1171,7 @@ fn jvp_elementwise_add_y_tangent() {
 fn grad_neg_sum() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, -2.0, 3.0]))
         .unwrap();
-    let loss = (-&x).reduce_sum(&[0]).unwrap();
+    let loss = (-&x).unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let result = eval_tensor(grad);
@@ -1185,7 +1185,7 @@ fn grad_conj_sum_complex() {
         vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
     ))
     .unwrap();
-    let loss = x.conj().reduce_sum(&[0]).unwrap();
+    let loss = x.conj().unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let result = eval_tensor(grad);
@@ -1263,12 +1263,12 @@ fn complex_abs_ad_matches_jax_real_output_convention() {
         TracedTensor::from_tensor_concrete_shape(c64_tensor(vec![2], input_data.clone())).unwrap();
     let dx = TracedTensor::from_tensor_concrete_shape(c64_tensor(vec![2], tangent_data.clone()))
         .unwrap();
-    let dy = x.abs().jvp(&x, &dx).unwrap();
+    let dy = x.abs().unwrap().jvp(&x, &dx).unwrap();
 
     let cotangent =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], cotangent_data.clone()))
             .unwrap();
-    let grad = x.abs().vjp(&x, &cotangent).unwrap();
+    let grad = x.abs().unwrap().vjp(&x, &cotangent).unwrap();
 
     let results =
         run_many_traced_with(&mut GraphExecutor::new(CpuBackend::new()), &[&dy, &grad]).unwrap();
@@ -1311,7 +1311,7 @@ fn complex_sign_ad_is_zero_like_jax() {
     ))
     .unwrap();
 
-    let signed = x.sign();
+    let signed = x.sign().unwrap();
     let tangent = signed.jvp(&x, &dx).unwrap();
     let grad = signed.vjp(&x, &cotangent).unwrap();
 
@@ -1920,7 +1920,7 @@ fn cast_eval_jvp_and_vjp_follow_real_complex_adjoint_rules() {
     .unwrap();
 
     let x_c64 = x.convert(DType::C64).unwrap();
-    let roundtrip = x_c64.cast(DType::F64);
+    let roundtrip = x_c64.cast(DType::F64).unwrap();
     let jvp = x_c64.jvp(&x, &dx).unwrap();
     let vjp = x_c64.vjp(&x, &cotangent).unwrap();
 
@@ -1952,6 +1952,7 @@ fn cast_ad_treats_integer_and_bool_boundaries_as_inactive_like_jax_float0() {
 
     assert!(
         real.cast(DType::I64)
+            .unwrap()
             .jvp_optional(&real, &real_tangent)
             .unwrap()
             .is_none(),
@@ -1959,6 +1960,7 @@ fn cast_ad_treats_integer_and_bool_boundaries_as_inactive_like_jax_float0() {
     );
     assert!(
         real.cast(DType::Bool)
+            .unwrap()
             .jvp_optional(&real, &real_tangent)
             .unwrap()
             .is_none(),
@@ -1985,6 +1987,7 @@ fn cast_ad_treats_integer_and_bool_boundaries_as_inactive_like_jax_float0() {
 
     assert!(
         real.cast(DType::I64)
+            .unwrap()
             .vjp_optional(
                 &real,
                 &TracedTensor::from_tensor_concrete_shape(i64_tensor(vec![2], vec![3, -4]))
@@ -1996,6 +1999,7 @@ fn cast_ad_treats_integer_and_bool_boundaries_as_inactive_like_jax_float0() {
     );
     assert!(
         real.cast(DType::Bool)
+            .unwrap()
             .vjp_optional(
                 &real,
                 &TracedTensor::from_tensor_concrete_shape(bool_tensor(vec![2], vec![true, false]))

--- a/crates/tenferro-ad/tests/ad/reductions_and_indexing.rs
+++ b/crates/tenferro-ad/tests/ad/reductions_and_indexing.rs
@@ -263,7 +263,7 @@ fn grad_transpose() {
 fn grad_exp() {
     let x_data = vec![0.2, -0.7, 1.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.exp().reduce_sum(&[0]).unwrap();
+    let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -273,7 +273,7 @@ fn grad_exp() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.exp().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.exp().unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -282,7 +282,7 @@ fn grad_exp() {
 fn grad_log() {
     let x_data = vec![0.8, 1.5, 2.4];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.log().reduce_sum(&[0]).unwrap();
+    let loss = x.log().unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -292,7 +292,7 @@ fn grad_log() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.log().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.log().unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -303,7 +303,7 @@ fn grad_sin_cos() {
 
     let x_sin =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let sin_loss = x_sin.sin().reduce_sum(&[0]).unwrap();
+    let sin_loss = x_sin.sin().unwrap().reduce_sum(&[0]).unwrap();
     let sin_grad = sin_loss.grad(&x_sin).unwrap();
     let sin_grad_tensor = eval_tensor(sin_grad);
     let sin_grad_data = get_f64_data(&sin_grad_tensor);
@@ -312,13 +312,13 @@ fn grad_sin_cos() {
 
     let f_sin = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.sin().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.sin().unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(sin_grad_data, &x_data, f_sin);
 
     let x_cos =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let cos_loss = x_cos.cos().reduce_sum(&[0]).unwrap();
+    let cos_loss = x_cos.cos().unwrap().reduce_sum(&[0]).unwrap();
     let cos_grad = cos_loss.grad(&x_cos).unwrap();
     let cos_grad_tensor = eval_tensor(cos_grad);
     let cos_grad_data = get_f64_data(&cos_grad_tensor);
@@ -327,7 +327,7 @@ fn grad_sin_cos() {
 
     let f_cos = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.cos().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.cos().unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(cos_grad_data, &x_data, f_cos);
 }
@@ -372,7 +372,7 @@ fn grad_div() {
 fn grad_sqrt() {
     let x_data = vec![0.8, 1.5, 3.2];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.sqrt().reduce_sum(&[0]).unwrap();
+    let loss = x.sqrt().unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -382,7 +382,7 @@ fn grad_sqrt() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.sqrt().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.sqrt().unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -391,7 +391,7 @@ fn grad_sqrt() {
 fn grad_tanh() {
     let x_data = vec![0.2, -0.7, 1.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.tanh().reduce_sum(&[0]).unwrap();
+    let loss = x.tanh().unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -401,7 +401,7 @@ fn grad_tanh() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.tanh().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.tanh().unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -486,7 +486,7 @@ fn grad_pow_wrt_exponent() {
 fn grad_abs() {
     let x_data = vec![-1.7, 0.8, 2.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.abs().reduce_sum(&[0]).unwrap();
+    let loss = x.abs().unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -496,7 +496,7 @@ fn grad_abs() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.abs().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.abs().unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -505,7 +505,7 @@ fn grad_abs() {
 fn grad_sign() {
     let x_data = vec![-1.7, 0.8, 2.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.sign().reduce_sum(&[0]).unwrap();
+    let loss = x.sign().unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -514,7 +514,7 @@ fn grad_sign() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.sign().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.sign().unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -523,7 +523,7 @@ fn grad_sign() {
 fn grad_rsqrt() {
     let x_data = vec![0.8, 1.5, 3.2];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.rsqrt().reduce_sum(&[0]).unwrap();
+    let loss = x.rsqrt().unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -533,7 +533,7 @@ fn grad_rsqrt() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.rsqrt().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.rsqrt().unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -542,7 +542,7 @@ fn grad_rsqrt() {
 fn grad_expm1() {
     let x_data = vec![0.2, -0.7, 1.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.expm1().reduce_sum(&[0]).unwrap();
+    let loss = x.expm1().unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -552,7 +552,7 @@ fn grad_expm1() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.expm1().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.expm1().unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -561,7 +561,7 @@ fn grad_expm1() {
 fn grad_log1p() {
     let x_data = vec![0.2, 0.7, 1.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.log1p().reduce_sum(&[0]).unwrap();
+    let loss = x.log1p().unwrap().reduce_sum(&[0]).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -571,7 +571,7 @@ fn grad_log1p() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.log1p().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.log1p().unwrap().reduce_sum(&[0]).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }

--- a/crates/tenferro-ad/tests/ad_optimizer.rs
+++ b/crates/tenferro-ad/tests/ad_optimizer.rs
@@ -32,7 +32,7 @@ fn traced_jvp_zero_propagation_returns_none_without_dead_graph() {
     let x = f64_vec(vec![1.0, 2.0]);
     let y = f64_vec(vec![3.0, 4.0]);
     let tangent = f64_vec(vec![1.0, 1.0]);
-    let output = y.neg();
+    let output = y.neg().unwrap();
 
     assert!(output.jvp_optional(&x, &tangent).unwrap().is_none());
 }
@@ -41,7 +41,7 @@ fn traced_jvp_zero_propagation_returns_none_without_dead_graph() {
 fn traced_jvp_optimizer_removes_identity_chain_before_compile() {
     let x = f64_vec(vec![2.0, -3.0]);
     let tangent = f64_vec(vec![0.25, -0.5]);
-    let y = x.neg().neg();
+    let y = x.neg().unwrap().neg().unwrap();
 
     let dy = y.jvp(&x, &tangent).unwrap();
     assert_eq!(

--- a/crates/tenferro-ad/tests/checkpoint.rs
+++ b/crates/tenferro-ad/tests/checkpoint.rs
@@ -124,7 +124,7 @@ fn checkpoint_loop_grad_correct() {
     let mut x = TracedTensor::from_tensor_concrete_shape(f64_scalar(x0_value)).unwrap();
 
     for _ in 0..steps {
-        x = (&a * &x.cos()).unwrap();
+        x = (&a * &x.cos().unwrap()).unwrap();
         x.checkpoint(&mut compiler, &mut executor).unwrap();
     }
 

--- a/crates/tenferro-ad/tests/exec_dispatch.rs
+++ b/crates/tenferro-ad/tests/exec_dispatch.rs
@@ -657,7 +657,7 @@ fn eval_exec_ir_reclaims_last_use_host_buffers() {
 #[test]
 fn graph_executor_does_not_reclaim_borrowed_input_slots() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
-    let y = (&x + &x).unwrap().neg();
+    let y = (&x + &x).unwrap().neg().unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])

--- a/crates/tenferro-ad/tests/graph_compile.rs
+++ b/crates/tenferro-ad/tests/graph_compile.rs
@@ -91,7 +91,7 @@ fn graph_compiler_validates_placeholder_specs() {
 
     let z = TracedTensor::input_concrete_shape(DType::F64, &[3]).unwrap();
     let err = compiler
-        .compile_with_input_specs(&z.neg(), &[(&z, DType::F64, &[2])])
+        .compile_with_input_specs(&z.neg().unwrap(), &[(&z, DType::F64, &[2])])
         .unwrap_err();
     assert!(format!("{err}").contains("shape"));
 }
@@ -99,7 +99,7 @@ fn graph_compiler_validates_placeholder_specs() {
 #[test]
 fn graph_program_input_accessors_report_compiled_contract() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
-    let y = x.neg();
+    let y = x.neg().unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler
@@ -122,7 +122,7 @@ fn graph_compiler_cache_is_bounded_and_reports_stats() {
     let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let y = (&x + &x).unwrap();
     let _ = compiler.compile(&y).unwrap();
-    let _ = compiler.compile(&x.neg()).unwrap();
+    let _ = compiler.compile(&x.neg().unwrap()).unwrap();
 
     let stats = compiler.cache_stats();
     assert_eq!(compiler.compile_cache_capacity().get(), 1);
@@ -134,7 +134,7 @@ fn graph_compiler_cache_is_bounded_and_reports_stats() {
 fn graph_compiler_compiler_options_setter_clears_compile_cache() {
     let mut compiler = GraphCompiler::new();
     let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    let _ = compiler.compile(&x.neg()).unwrap();
+    let _ = compiler.compile(&x.neg().unwrap()).unwrap();
     assert_eq!(compiler.compile_cache_len(), 1);
 
     let options = CompilerOptions {
@@ -206,7 +206,7 @@ fn graph_compiler_cache_distinguishes_extension_payload_eq_despite_hash_collisio
 fn graph_compiler_compile_many_returns_multi_output_program() {
     let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let y = (&x + &x).unwrap();
-    let z = x.neg();
+    let z = x.neg().unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile_many(&[&y, &z]).unwrap();

--- a/crates/tenferro-ad/tests/hvp.rs
+++ b/crates/tenferro-ad/tests/hvp.rs
@@ -110,7 +110,7 @@ fn hvp_for_scalar_exp_sin() {
     let x_val = 1.3_f64;
 
     let x = TracedTensor::from_tensor_concrete_shape(f64_scalar(x_val)).unwrap();
-    let y = x.sin().exp();
+    let y = x.sin().unwrap().exp().unwrap();
 
     let g = y.grad(&x).unwrap();
     let v = TracedTensor::from_tensor_concrete_shape(f64_scalar(1.0)).unwrap();
@@ -137,7 +137,7 @@ fn hvp_for_vector_exp_sum() {
     let n = x_data.len();
 
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![n], x_data.clone())).unwrap();
-    let y = x.exp().reduce_sum(&[0]).unwrap();
+    let y = x.exp().unwrap().reduce_sum(&[0]).unwrap();
 
     let g = y.grad(&x).unwrap(); // shape [n]
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![n], v_data.clone())).unwrap();

--- a/crates/tenferro-ad/tests/iterative_ad.rs
+++ b/crates/tenferro-ad/tests/iterative_ad.rs
@@ -91,7 +91,7 @@ fn fixed_point_traced(
 
     for iter in 1..=max_iter {
         // Build graph: x_new = a * cos(x)
-        let x_new = (a * &x.cos()).unwrap();
+        let x_new = (a * &x.cos().unwrap()).unwrap();
 
         // Convergence check — eval() must NOT break the graph
         let x_check = x_new.clone();
@@ -212,7 +212,7 @@ fn graph_size_grows_linearly() {
         let a = TracedTensor::from_tensor_concrete_shape(f64_scalar(0.8)).unwrap();
         let mut x = TracedTensor::from_tensor_concrete_shape(f64_scalar(0.5)).unwrap();
         for _ in 0..k {
-            x = (&a * &x.cos()).unwrap();
+            x = (&a * &x.cos().unwrap()).unwrap();
         }
         total_ops(x.graph())
     }

--- a/crates/tenferro-ad/tests/numpy_api.rs
+++ b/crates/tenferro-ad/tests/numpy_api.rs
@@ -107,20 +107,35 @@ fn traced_unary_methods_forward_to_distinct_primal_ops() {
     }
 
     let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap();
-    assert_eq!(run(&x.neg()).as_slice::<f64>().unwrap(), &[-1.0, -4.0]);
-    assert_eq!(run(&x.abs()).as_slice::<f64>().unwrap(), &[1.0, 4.0]);
-    assert_eq!(run(&x.sign()).as_slice::<f64>().unwrap(), &[1.0, 1.0]);
-    assert_eq!(run(&x.sqrt()).as_slice::<f64>().unwrap(), &[1.0, 2.0]);
-    assert_eq!(run(&x.rsqrt()).as_slice::<f64>().unwrap(), &[1.0, 0.5]);
+    assert_eq!(
+        run(&x.neg().unwrap()).as_slice::<f64>().unwrap(),
+        &[-1.0, -4.0]
+    );
+    assert_eq!(
+        run(&x.abs().unwrap()).as_slice::<f64>().unwrap(),
+        &[1.0, 4.0]
+    );
+    assert_eq!(
+        run(&x.sign().unwrap()).as_slice::<f64>().unwrap(),
+        &[1.0, 1.0]
+    );
+    assert_eq!(
+        run(&x.sqrt().unwrap()).as_slice::<f64>().unwrap(),
+        &[1.0, 2.0]
+    );
+    assert_eq!(
+        run(&x.rsqrt().unwrap()).as_slice::<f64>().unwrap(),
+        &[1.0, 0.5]
+    );
 
     let analytic = TracedTensor::from_vec_col_major(vec![2], vec![0.0_f64, 1.0]).unwrap();
-    let exp = run(&analytic.exp());
-    let log = run(&x.log());
-    let sin = run(&analytic.sin());
-    let cos = run(&analytic.cos());
-    let tanh = run(&analytic.tanh());
-    let expm1 = run(&analytic.expm1());
-    let log1p = run(&analytic.log1p());
+    let exp = run(&analytic.exp().unwrap());
+    let log = run(&x.log().unwrap());
+    let sin = run(&analytic.sin().unwrap());
+    let cos = run(&analytic.cos().unwrap());
+    let tanh = run(&analytic.tanh().unwrap());
+    let expm1 = run(&analytic.expm1().unwrap());
+    let log1p = run(&analytic.log1p().unwrap());
     assert_eq!(exp.as_slice::<f64>().unwrap(), &[1.0, std::f64::consts::E]);
     assert_eq!(log.as_slice::<f64>().unwrap(), &[0.0, 4.0_f64.ln()]);
     assert_eq!(sin.as_slice::<f64>().unwrap(), &[0.0, 1.0_f64.sin()]);
@@ -135,7 +150,7 @@ fn traced_unary_methods_forward_to_distinct_primal_ops() {
     )
     .unwrap();
     assert_eq!(
-        run(&z.conj()).as_slice::<Complex64>().unwrap(),
+        run(&z.conj().unwrap()).as_slice::<Complex64>().unwrap(),
         &[Complex64::new(1.0, -2.0), Complex64::new(3.0, 4.0)]
     );
 }

--- a/crates/tenferro-ad/tests/primitive_ops.rs
+++ b/crates/tenferro-ad/tests/primitive_ops.rs
@@ -138,7 +138,7 @@ fn test_pow_broadcast_vector_with_scalar_exponent() {
 fn test_neg() {
     let a = f64_tensor(vec![3], vec![1.0, -2.0, 3.0]);
     let ta = TracedTensor::from_tensor_concrete_shape(a).unwrap();
-    let tb = -&ta;
+    let tb = (-&ta).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tb.run_with(&mut engine).unwrap();
     assert_eq!(get_f64_data(&result), &[-1.0, 2.0, -3.0]);
@@ -156,7 +156,7 @@ fn traced_abs_of_complex_tensor_returns_real_tensor() {
         .unwrap(),
     )
     .unwrap();
-    let y = x.abs();
+    let y = x.abs().unwrap();
     assert_eq!(y.dtype, DType::F64);
 
     let mut engine = GraphExecutor::new(CpuBackend::new());

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -1395,12 +1395,6 @@ fn typed_pad_with_fill<T: Copy + Clone + PoolScalar>(
                 message: format!("interior padding must be non-negative on axis {axis}"),
             });
         }
-        if config.edge_padding_low[axis] < 0 || config.edge_padding_high[axis] < 0 {
-            return Err(crate::Error::InvalidConfig {
-                op: "pad",
-                message: format!("edge padding must be non-negative on axis {axis}"),
-            });
-        }
         let input_extent_i64 =
             i64::try_from(input_extent).map_err(|_| crate::Error::InvalidConfig {
                 op: "pad",

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -1440,9 +1440,9 @@ fn typed_pad_with_fill<T: Copy + Clone + PoolScalar>(
     for input_value in input.as_slice()? {
         let mut in_bounds = true;
         for axis in 0..input_shape.len() {
-            let out_pos = config.edge_padding_low[axis]
-                + input_idx[axis] as i64 * (config.interior_padding[axis] + 1);
-            if !(0..out_shape[axis] as i64).contains(&out_pos) {
+            let out_pos = i128::from(config.edge_padding_low[axis])
+                + input_idx[axis] as i128 * i128::from(config.interior_padding[axis] + 1);
+            if !(0..out_shape[axis] as i128).contains(&out_pos) {
                 in_bounds = false;
                 break;
             }

--- a/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
@@ -673,6 +673,23 @@ fn cpu_pad_supports_signed_edge_cropping() {
 }
 
 #[test]
+fn cpu_pad_skips_extreme_signed_positions_without_overflow() {
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
+    let output = pad(
+        &input,
+        &PadConfig {
+            edge_padding_low: vec![i64::MAX],
+            edge_padding_high: vec![i64::MIN],
+            interior_padding: vec![0],
+        },
+    )
+    .unwrap();
+
+    assert_eq!(output.shape(), &[1]);
+    assert_eq!(output.as_slice::<f64>().unwrap(), &[0.0]);
+}
+
+#[test]
 fn cpu_pad_does_not_reject_signed_edges_before_checked_shape_validation() {
     let indexing_source = include_str!("../indexing.rs");
     assert!(!indexing_source.contains("config.edge_padding_low[axis] < 0"));

--- a/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
@@ -441,8 +441,19 @@ fn cpu_indexing_validation_covers_error_branches() {
         backend.pad(
             &input,
             &PadConfig {
-                edge_padding_low: vec![-3],
+                edge_padding_low: vec![0],
                 edge_padding_high: vec![0],
+                interior_padding: vec![i64::MAX],
+            },
+        ),
+        "pad",
+    );
+    expect_invalid_config(
+        backend.pad(
+            &input,
+            &PadConfig {
+                edge_padding_low: vec![i64::MAX],
+                edge_padding_high: vec![1],
                 interior_padding: vec![0],
             },
         ),
@@ -452,8 +463,8 @@ fn cpu_indexing_validation_covers_error_branches() {
         backend.pad(
             &input,
             &PadConfig {
-                edge_padding_low: vec![-1],
-                edge_padding_high: vec![1],
+                edge_padding_low: vec![-3],
+                edge_padding_high: vec![0],
                 interior_padding: vec![0],
             },
         ),
@@ -635,6 +646,37 @@ fn cpu_indexing_validation_covers_error_branches() {
         scatter(&operand_2d, &idx2, &mismatched_updates, &scatter_cfg),
         "scatter",
     );
+}
+
+#[test]
+fn cpu_pad_supports_signed_edge_cropping() {
+    let input = Tensor::F64(
+        TypedTensor::from_vec_col_major(vec![5], vec![1.0, 2.0, 3.0, 4.0, 5.0]).unwrap(),
+    );
+
+    for (low, high, expected) in [
+        (-2, 0, vec![3.0, 4.0, 5.0]),
+        (0, -2, vec![1.0, 2.0, 3.0]),
+        (-1, -1, vec![2.0, 3.0, 4.0]),
+    ] {
+        let output = pad(
+            &input,
+            &PadConfig {
+                edge_padding_low: vec![low],
+                edge_padding_high: vec![high],
+                interior_padding: vec![0],
+            },
+        )
+        .unwrap();
+        assert_eq!(output.as_slice::<f64>().unwrap(), expected);
+    }
+}
+
+#[test]
+fn cpu_pad_does_not_reject_signed_edges_before_checked_shape_validation() {
+    let indexing_source = include_str!("../indexing.rs");
+    assert!(!indexing_source.contains("config.edge_padding_low[axis] < 0"));
+    assert!(!indexing_source.contains("config.edge_padding_high[axis] < 0"));
 }
 
 #[test]

--- a/crates/tenferro-einsum/benches/mps_inner_product.rs
+++ b/crates/tenferro-einsum/benches/mps_inner_product.rs
@@ -64,7 +64,7 @@ fn build_inner_product_graph(
     let mut env =
         TracedTensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 0.0)]).unwrap();
     for (bra_core, ket_core) in bra.iter().zip(ket) {
-        let bra_core = bra_core.conj();
+        let bra_core = bra_core.conj().unwrap();
         env = compiler
             .einsum(&[&env, &bra_core, ket_core], "ab,acr,bcs->rs")
             .expect("MPS inner-product contraction should build");

--- a/crates/tenferro-einsum/benches/mps_inner_product_compile.rs
+++ b/crates/tenferro-einsum/benches/mps_inner_product_compile.rs
@@ -32,7 +32,7 @@ fn build_inner_product_graph(
     let mut env =
         TracedTensor::from_vec_col_major(vec![1, 1], vec![Complex64::new(1.0, 0.0)]).unwrap();
     for (bra_core, ket_core) in bra.iter().zip(ket) {
-        let bra_core = bra_core.conj();
+        let bra_core = bra_core.conj().unwrap();
         env = compiler
             .einsum(&[&env, &bra_core, ket_core], "ab,acr,bcs->rs")
             .expect("MPS inner-product contraction should build");

--- a/crates/tenferro-einsum/tests/traced_graph_cache.rs
+++ b/crates/tenferro-einsum/tests/traced_graph_cache.rs
@@ -459,7 +459,8 @@ fn compiler_and_executor_clear_caches_clear_extension_einsum_entries() {
     run_static_matmul(&mut compiler, 2, 2, 3);
     let out = TracedTensor::from_vec_col_major(vec![1], vec![1.0_f64])
         .unwrap()
-        .neg();
+        .neg()
+        .unwrap();
     let _ = compiler.compile(&out).unwrap();
     assert!(compiler.cache_stats().compile.entries > 0);
     assert!(compiler.cache_stats().extensions.entries > 0);

--- a/crates/tenferro-fft/src/concrete_tests.rs
+++ b/crates/tenferro-fft/src/concrete_tests.rs
@@ -2,7 +2,7 @@ use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{Tensor, TensorRead, TensorView, TypedTensorView};
 
-use crate::{FftNorm, TensorFftExt, TensorReadFftExt};
+use crate::{cached_fft_plan_from_cache, FftNorm, FftPlanCache, TensorFftExt, TensorReadFftExt};
 
 fn assert_complex_close(actual: &[Complex64], expected: &[Complex64]) {
     assert_eq!(actual.len(), expected.len());
@@ -139,5 +139,27 @@ fn public_tensor_fft_ext_reports_invalid_dtype_and_shape_errors() {
     assert!(matches!(
         shape_err,
         tenferro_tensor::Error::InvalidConfig { op: "irfft", .. }
+    ));
+}
+
+#[test]
+fn poisoned_fft_plan_cache_returns_typed_error() {
+    let cache: &'static FftPlanCache<f64> = Box::leak(Box::new(Default::default()));
+    let mutex = cache.get_or_init(Default::default);
+    let _ = std::thread::spawn(move || {
+        let _guard = mutex.lock().unwrap();
+        panic!("poison FFT plan cache for regression test");
+    })
+    .join();
+
+    let Err(err) = cached_fft_plan_from_cache(cache, 4, true) else {
+        panic!("poisoned FFT plan cache must return an error");
+    };
+    assert!(matches!(
+        err,
+        tenferro_tensor::Error::BackendFailure {
+            op: "fft_plan_cache",
+            ..
+        }
     ));
 }

--- a/crates/tenferro-fft/src/concrete_tests.rs
+++ b/crates/tenferro-fft/src/concrete_tests.rs
@@ -144,7 +144,7 @@ fn public_tensor_fft_ext_reports_invalid_dtype_and_shape_errors() {
 
 #[test]
 fn poisoned_fft_plan_cache_returns_typed_error() {
-    let cache: &'static FftPlanCache<f64> = Box::leak(Box::new(Default::default()));
+    let cache: &'static FftPlanCache<f64> = Box::leak(Box::default());
     let mutex = cache.get_or_init(Default::default);
     let _ = std::thread::spawn(move || {
         let _guard = mutex.lock().unwrap();

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -1696,6 +1696,7 @@ where
     let input_data = input.host_data()?;
     let output_len = checked_shape_product("fft", "output", &out_shape)?;
     let mut output = uninit_output_vec(output_len);
+    // Propagate poisoned FFT plan-cache errors to the public caller.
     let fft_plan = cached_fft_plan::<T>(fft_len, forward)?;
     let scale: T = scale_for(norm, forward, fft_len)?;
     let mut lane = vec![Complex::zero(); fft_len];
@@ -1751,6 +1752,7 @@ where
     let input_data = input.host_data()?;
     let output_len = checked_shape_product("rfft", "output", &out_shape)?;
     let mut output = uninit_output_vec(output_len);
+    // Propagate poisoned FFT plan-cache errors to the public caller.
     let fft_plan = cached_fft_plan::<T>(fft_len, true)?;
     let scale: T = scale_for(norm, true, fft_len)?;
     let mut lane = vec![Complex::zero(); fft_len];
@@ -1805,6 +1807,7 @@ where
     let input_data = input.host_data()?;
     let output_len = checked_shape_product("irfft", "output", &out_shape)?;
     let mut output = uninit_output_vec(output_len);
+    // Propagate poisoned FFT plan-cache errors to the public caller.
     let fft_plan = cached_fft_plan::<T>(out_axis_len, false)?;
     let scale: T = scale_for(norm, false, out_axis_len)?;
     let mut lane = vec![Complex::zero(); out_axis_len];

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -1622,7 +1622,7 @@ struct FftPlanKey {
 }
 
 trait CachedFftPlanScalar: FftNum + Float + FromPrimitive + 'static {
-    fn cached_fft_plan(len: usize, forward: bool) -> Arc<dyn Fft<Self>>;
+    fn cached_fft_plan(len: usize, forward: bool) -> tenferro_tensor::Result<Arc<dyn Fft<Self>>>;
 }
 
 type FftPlanStore<T> = HashMap<FftPlanKey, Arc<dyn Fft<T>>>;
@@ -1632,18 +1632,21 @@ static F32_FFT_PLAN_CACHE: FftPlanCache<f32> = OnceLock::new();
 static F64_FFT_PLAN_CACHE: FftPlanCache<f64> = OnceLock::new();
 
 impl CachedFftPlanScalar for f32 {
-    fn cached_fft_plan(len: usize, forward: bool) -> Arc<dyn Fft<Self>> {
+    fn cached_fft_plan(len: usize, forward: bool) -> tenferro_tensor::Result<Arc<dyn Fft<Self>>> {
         cached_fft_plan_from_cache(&F32_FFT_PLAN_CACHE, len, forward)
     }
 }
 
 impl CachedFftPlanScalar for f64 {
-    fn cached_fft_plan(len: usize, forward: bool) -> Arc<dyn Fft<Self>> {
+    fn cached_fft_plan(len: usize, forward: bool) -> tenferro_tensor::Result<Arc<dyn Fft<Self>>> {
         cached_fft_plan_from_cache(&F64_FFT_PLAN_CACHE, len, forward)
     }
 }
 
-fn cached_fft_plan<T: CachedFftPlanScalar>(len: usize, forward: bool) -> Arc<dyn Fft<T>> {
+fn cached_fft_plan<T: CachedFftPlanScalar>(
+    len: usize,
+    forward: bool,
+) -> tenferro_tensor::Result<Arc<dyn Fft<T>>> {
     T::cached_fft_plan(len, forward)
 }
 
@@ -1651,14 +1654,19 @@ fn cached_fft_plan_from_cache<T: FftNum + 'static>(
     cache: &'static FftPlanCache<T>,
     len: usize,
     forward: bool,
-) -> Arc<dyn Fft<T>> {
+) -> tenferro_tensor::Result<Arc<dyn Fft<T>>> {
     let key = FftPlanKey { len, forward };
     let mut guard = cache
         .get_or_init(|| Mutex::new(HashMap::new()))
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+        .map_err(|_| {
+            tenferro_tensor::Error::backend_failure(
+                "fft_plan_cache",
+                "FFT plan cache lock is poisoned",
+            )
+        })?;
     if let Some(plan) = guard.get(&key) {
-        return Arc::clone(plan);
+        return Ok(Arc::clone(plan));
     }
 
     let mut planner = FftPlanner::<T>::new();
@@ -1668,7 +1676,7 @@ fn cached_fft_plan_from_cache<T: FftNum + 'static>(
         planner.plan_fft_inverse(len)
     };
     guard.insert(key, Arc::clone(&plan));
-    plan
+    Ok(plan)
 }
 
 fn execute_c2c<T>(
@@ -1688,7 +1696,7 @@ where
     let input_data = input.host_data()?;
     let output_len = checked_shape_product("fft", "output", &out_shape)?;
     let mut output = uninit_output_vec(output_len);
-    let fft_plan = cached_fft_plan::<T>(fft_len, forward);
+    let fft_plan = cached_fft_plan::<T>(fft_len, forward)?;
     let scale: T = scale_for(norm, forward, fft_len)?;
     let mut lane = vec![Complex::zero(); fft_len];
 
@@ -1743,7 +1751,7 @@ where
     let input_data = input.host_data()?;
     let output_len = checked_shape_product("rfft", "output", &out_shape)?;
     let mut output = uninit_output_vec(output_len);
-    let fft_plan = cached_fft_plan::<T>(fft_len, true);
+    let fft_plan = cached_fft_plan::<T>(fft_len, true)?;
     let scale: T = scale_for(norm, true, fft_len)?;
     let mut lane = vec![Complex::zero(); fft_len];
 
@@ -1797,7 +1805,7 @@ where
     let input_data = input.host_data()?;
     let output_len = checked_shape_product("irfft", "output", &out_shape)?;
     let mut output = uninit_output_vec(output_len);
-    let fft_plan = cached_fft_plan::<T>(out_axis_len, false);
+    let fft_plan = cached_fft_plan::<T>(out_axis_len, false)?;
     let scale: T = scale_for(norm, false, out_axis_len)?;
     let mut lane = vec![Complex::zero(); out_axis_len];
 

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -218,16 +218,27 @@ fn fft_cpu_execution_propagates_plan_cache_errors() {
     let r2c = source_section(source, "fn execute_r2c<T>(", "fn execute_c2r<T>(");
     let c2r = source_section(source, "fn execute_c2r<T>(", "fn scale_for<T>(");
 
-    for (name, section) in [
-        ("execute_c2c", c2c),
-        ("execute_r2c", r2c),
-        ("execute_c2r", c2r),
+    for (name, section, expected_statement) in [
+        (
+            "execute_c2c",
+            c2c,
+            "let fft_plan = cached_fft_plan::<T>(fft_len, forward)?;",
+        ),
+        (
+            "execute_r2c",
+            r2c,
+            "let fft_plan = cached_fft_plan::<T>(fft_len, true)?;",
+        ),
+        (
+            "execute_c2r",
+            c2r,
+            "let fft_plan = cached_fft_plan::<T>(out_axis_len, false)?;",
+        ),
     ] {
         assert!(
             section.contains("// Propagate poisoned FFT plan-cache errors to the public caller.")
-                && section.contains("cached_fft_plan::<T>")
-                && section.contains("?;"),
-            "{name} must propagate typed FFT plan-cache errors"
+                && section.contains(expected_statement),
+            "{name} must propagate typed FFT plan-cache errors with {expected_statement:?}"
         );
     }
 }

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -212,6 +212,27 @@ fn fft_cpu_execution_reuses_cached_rustfft_plans() {
 }
 
 #[test]
+fn fft_cpu_execution_propagates_plan_cache_errors() {
+    let source = include_str!("../src/lib.rs");
+    let c2c = source_section(source, "fn execute_c2c<T>(", "fn execute_r2c<T>(");
+    let r2c = source_section(source, "fn execute_r2c<T>(", "fn execute_c2r<T>(");
+    let c2r = source_section(source, "fn execute_c2r<T>(", "fn scale_for<T>(");
+
+    for (name, section) in [
+        ("execute_c2c", c2c),
+        ("execute_r2c", r2c),
+        ("execute_c2r", c2r),
+    ] {
+        assert!(
+            section.contains("// Propagate poisoned FFT plan-cache errors to the public caller.")
+                && section.contains("cached_fft_plan::<T>")
+                && section.contains("?;"),
+            "{name} must propagate typed FFT plan-cache errors"
+        );
+    }
+}
+
+#[test]
 fn fft_c64_matches_numpy_convention() {
     let x = TracedTensor::from_vec_col_major(
         vec![4],

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -218,27 +218,26 @@ fn fft_cpu_execution_propagates_plan_cache_errors() {
     let r2c = source_section(source, "fn execute_r2c<T>(", "fn execute_c2r<T>(");
     let c2r = source_section(source, "fn execute_c2r<T>(", "fn scale_for<T>(");
 
-    for (name, section, expected_statement) in [
-        (
-            "execute_c2c",
-            c2c,
-            "let fft_plan = cached_fft_plan::<T>(fft_len, forward)?;",
-        ),
-        (
-            "execute_r2c",
-            r2c,
-            "let fft_plan = cached_fft_plan::<T>(fft_len, true)?;",
-        ),
-        (
-            "execute_c2r",
-            c2r,
-            "let fft_plan = cached_fft_plan::<T>(out_axis_len, false)?;",
-        ),
+    for (name, section) in [
+        ("execute_c2c", c2c),
+        ("execute_r2c", r2c),
+        ("execute_c2r", c2r),
     ] {
+        let call_start = section
+            .find("cached_fft_plan::<T>")
+            .unwrap_or_else(|| panic!("{name} must call cached_fft_plan::<T>"));
+        let call_end = section[call_start..]
+            .find(';')
+            .map(|offset| call_start + offset + 1)
+            .unwrap_or_else(|| panic!("{name} cached_fft_plan call must end in a statement"));
+        let normalized_call = section[call_start..call_end]
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
         assert!(
-            section.contains("// Propagate poisoned FFT plan-cache errors to the public caller.")
-                && section.contains(expected_statement),
-            "{name} must propagate typed FFT plan-cache errors with {expected_statement:?}"
+            normalized_call.ends_with("?;"),
+            "{name} must propagate its cached_fft_plan error: {normalized_call}"
         );
     }
 }

--- a/crates/tenferro-gpu/src/cubecl/tests/indexing_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/indexing_tests.rs
@@ -51,6 +51,64 @@ fn test_cubecl_slice_dynamic_slice_and_pad_match_cpu() {
 }
 
 #[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn test_cubecl_signed_pad_cropping_matches_cpu_values() {
+    let cases = [
+        (
+            tensor_f64(vec![4], vec![1.0, 2.0, 3.0, 4.0]),
+            PadConfig {
+                edge_padding_low: vec![-1],
+                edge_padding_high: vec![0],
+                interior_padding: vec![0],
+            },
+            tensor_f64(vec![3], vec![2.0, 3.0, 4.0]),
+        ),
+        (
+            tensor_f64(vec![4], vec![1.0, 2.0, 3.0, 4.0]),
+            PadConfig {
+                edge_padding_low: vec![0],
+                edge_padding_high: vec![-1],
+                interior_padding: vec![0],
+            },
+            tensor_f64(vec![3], vec![1.0, 2.0, 3.0]),
+        ),
+        (
+            tensor_f64(vec![4], vec![1.0, 2.0, 3.0, 4.0]),
+            PadConfig {
+                edge_padding_low: vec![-1],
+                edge_padding_high: vec![0],
+                interior_padding: vec![1],
+            },
+            tensor_f64(vec![6], vec![0.0, 2.0, 0.0, 3.0, 0.0, 4.0]),
+        ),
+        (
+            tensor_f64(vec![2], vec![1.0, 2.0]),
+            PadConfig {
+                edge_padding_low: vec![i64::MIN],
+                edge_padding_high: vec![i64::MAX],
+                interior_padding: vec![0],
+            },
+            tensor_f64(vec![1], vec![0.0]),
+        ),
+    ];
+
+    let mut cpu = cpu_backend();
+    let mut gpu = gpu_backend();
+    for (input, config, expected_values) in cases {
+        let expected = cpu.pad(&input, &config).unwrap();
+        assert_eq!(expected.shape(), expected_values.shape());
+        assert_tensor_close(&expected, &expected_values, 0.0);
+
+        let gpu_input = upload(&gpu, &input);
+        let gpu_output = gpu.pad(&gpu_input, &config).unwrap();
+        let actual = download(&gpu, &gpu_output);
+        assert_eq!(actual.shape(), expected_values.shape());
+        assert_tensor_close(&actual, &expected_values, 0.0);
+        assert_tensor_close(&actual, &expected, 0.0);
+    }
+}
+
+#[test]
 #[ignore]
 fn test_cubecl_gather_and_scatter_match_cpu() {
     let operand = tensor_f64(vec![5], vec![10.0, 20.0, 30.0, 40.0, 50.0]);

--- a/crates/tenferro-gpu/src/kernels/indexing.rs
+++ b/crates/tenferro-gpu/src/kernels/indexing.rs
@@ -306,6 +306,8 @@ pub fn scatter_float_kernel<E: Float, I: Numeric + CubePrimitive>(
     #[comptime] updates_rank: usize,
     #[comptime] scatter_indices_rank: usize,
 ) {
+    // INVARIANT: `scatter_update_len` checked the batch and window products,
+    // checked their combined update-domain bound, and returned before launch when it was zero.
     let window_iters = update_window_len(updates, update_window_dims.clone());
     let update_iters = updates.len();
     if ABSOLUTE_POS < update_iters {
@@ -408,6 +410,8 @@ pub fn scatter_complex_kernel<E: ComplexCore, F: Float, I: Numeric + CubePrimiti
     #[comptime] updates_rank: usize,
     #[comptime] scatter_indices_rank: usize,
 ) {
+    // INVARIANT: `scatter_update_len` checked the batch and window products,
+    // checked their combined update-domain bound, and returned before launch when it was zero.
     let window_iters = update_window_len(updates, update_window_dims.clone());
     let update_iters = updates.len();
     if ABSOLUTE_POS < update_iters {

--- a/crates/tenferro-gpu/src/kernels/indexing.rs
+++ b/crates/tenferro-gpu/src/kernels/indexing.rs
@@ -187,11 +187,11 @@ pub fn pad_kernel<E: CubePrimitive>(
             if shifted % spacing != 0 {
                 in_bounds = false;
             } else {
-                let candidate = (shifted / spacing) as usize;
-                if candidate >= input.shape(axis) {
+                let candidate = shifted / spacing;
+                if candidate >= input.shape(axis) as u64 {
                     in_bounds = false;
                 } else {
-                    input_idx[axis] = candidate;
+                    input_idx[axis] = candidate as usize;
                 }
             }
         }

--- a/crates/tenferro-gpu/src/kernels/indexing.rs
+++ b/crates/tenferro-gpu/src/kernels/indexing.rs
@@ -173,9 +173,18 @@ pub fn pad_kernel<E: CubePrimitive>(
         #[unroll]
         for axis in 0..rank {
             let low = comptime! { *edge_padding_low.index(axis) };
-            let spacing = comptime! { *interior_padding.index(axis) } + 1;
-            let shifted = out_idx[axis] as i64 - low;
-            if shifted < 0 || shifted % spacing != 0 {
+            let low_magnitude = comptime! { low.unsigned_abs() };
+            let spacing = comptime! { (*interior_padding.index(axis) + 1) as u64 };
+            let out_pos = out_idx[axis] as u64;
+            let mut shifted = 0_u64;
+            if comptime! { low < 0 } {
+                shifted = out_pos + low_magnitude;
+            } else if out_pos < low_magnitude {
+                in_bounds = false;
+            } else {
+                shifted = out_pos - low_magnitude;
+            }
+            if shifted % spacing != 0 {
                 in_bounds = false;
             } else {
                 let candidate = (shifted / spacing) as usize;

--- a/crates/tenferro-gpu/src/kernels/indexing.rs
+++ b/crates/tenferro-gpu/src/kernels/indexing.rs
@@ -306,8 +306,8 @@ pub fn scatter_float_kernel<E: Float, I: Numeric + CubePrimitive>(
     #[comptime] updates_rank: usize,
     #[comptime] scatter_indices_rank: usize,
 ) {
-    // INVARIANT: `scatter_update_len` checked the batch and window products,
-    // checked their combined update-domain bound, and returned before launch when it was zero.
+    // INVARIANT: `scatter_update_len` returns the checked batch-window product, including zero;
+    // `scatter_float_typed` returns before launch when that checked length is zero.
     let window_iters = update_window_len(updates, update_window_dims.clone());
     let update_iters = updates.len();
     if ABSOLUTE_POS < update_iters {
@@ -410,8 +410,8 @@ pub fn scatter_complex_kernel<E: ComplexCore, F: Float, I: Numeric + CubePrimiti
     #[comptime] updates_rank: usize,
     #[comptime] scatter_indices_rank: usize,
 ) {
-    // INVARIANT: `scatter_update_len` checked the batch and window products,
-    // checked their combined update-domain bound, and returned before launch when it was zero.
+    // INVARIANT: `scatter_update_len` returns the checked batch-window product, including zero;
+    // `scatter_complex_typed` returns before launch when that checked length is zero.
     let window_iters = update_window_len(updates, update_window_dims.clone());
     let update_iters = updates.len();
     if ABSOLUTE_POS < update_iters {

--- a/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -1,4 +1,121 @@
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+fn rust_sources_under(dir: &Path, sources: &mut Vec<(PathBuf, String)>) {
+    for entry in fs::read_dir(dir).expect("source directory should be readable") {
+        let path = entry.expect("source entry should be readable").path();
+        if path.is_dir() {
+            rust_sources_under(&path, sources);
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            let source = fs::read_to_string(&path)
+                .unwrap_or_else(|err| panic!("source {path:?} should be readable: {err}"));
+            sources.push((path, source));
+        }
+    }
+}
+
+fn production_rust_sources() -> Vec<(PathBuf, String)> {
+    let mut sources = Vec::new();
+    rust_sources_under(
+        &Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
+        &mut sources,
+    );
+    sources
+}
+
+fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), String> {
+    let invariants = [
+        "    // INVARIANT: `scatter_update_len` returns the checked batch-window product, including zero;\n    // `scatter_float_typed` returns before launch when that checked length is zero.\n    let window_iters = update_window_len(updates, update_window_dims.clone());",
+        "    // INVARIANT: `scatter_update_len` returns the checked batch-window product, including zero;\n    // `scatter_complex_typed` returns before launch when that checked length is zero.\n    let window_iters = update_window_len(updates, update_window_dims.clone());",
+    ];
+    let mut product_calls = Vec::new();
+    let mut launches = Vec::new();
+    for (path, source) in sources {
+        let lines: Vec<_> = source.lines().collect();
+        for (line_index, line) in lines.iter().enumerate() {
+            if line.contains("update_window_len(") && !line.contains("fn update_window_len(") {
+                let context =
+                    (line_index >= 2).then(|| lines[line_index - 2..=line_index].join("\n"));
+                let adjacent = context
+                    .as_deref()
+                    .is_some_and(|context| invariants.contains(&context));
+                product_calls.push((path, line_index + 1, adjacent));
+            }
+            if line.contains("scatter_float_kernel::launch_unchecked")
+                || line.contains("scatter_complex_kernel::launch_unchecked")
+            {
+                launches.push((path, line_index + 1));
+            }
+        }
+    }
+
+    if product_calls.len() != 2 {
+        return Err(format!(
+            "expected exactly two update_window_len call sites, found {product_calls:?}"
+        ));
+    }
+    for (path, line, adjacent) in product_calls {
+        if !adjacent {
+            return Err(format!(
+                "{path:?}:{line} lacks the adjacent checked host invariant"
+            ));
+        }
+    }
+    let all_source = sources
+        .iter()
+        .map(|(_, source)| source.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    for invariant in invariants {
+        if all_source.matches(invariant.trim_start()).count() != 1 {
+            return Err(format!(
+                "expected exactly one concrete invariant {invariant:?}"
+            ));
+        }
+    }
+
+    if launches.len() != 2 {
+        return Err(format!(
+            "expected exactly two scatter update kernel launches, found {launches:?}"
+        ));
+    }
+    let mod_source = sources
+        .iter()
+        .find_map(|(path, source)| path.ends_with("cubecl/mod.rs").then_some(source.as_str()))
+        .ok_or_else(|| "cubecl/mod.rs was not inventoried".to_owned())?;
+    for (name, start, end, launch) in [
+        (
+            "scatter_float_typed",
+            "    fn scatter_float_typed<",
+            "    fn scatter_complex_typed<",
+            "indexing::scatter_float_kernel::launch_unchecked",
+        ),
+        (
+            "scatter_complex_typed",
+            "    fn scatter_complex_typed<",
+            "impl BackendRuntimeCache for CudaBackend",
+            "indexing::scatter_complex_kernel::launch_unchecked",
+        ),
+    ] {
+        let section = source_section(mod_source, start, end);
+        let required = [
+            "scatter_launch_meta(",
+            "let update_len = scatter_update_len(&meta)?;",
+            "if update_len == 0 {\n            return Ok(output);\n        }",
+            launch,
+        ];
+        let mut offset = 0;
+        for needle in required {
+            let Some(found) = section[offset..].find(needle) else {
+                return Err(format!("{name} lacks ordered launch proof {needle:?}"));
+            };
+            offset += found + needle.len();
+        }
+    }
+    Ok(())
+}
 
 fn cubecl_source(file: &str) -> String {
     fs::read_to_string(
@@ -78,7 +195,11 @@ fn cubecl_scatter_does_not_use_single_thread_launch_fallback() {
 
 #[test]
 fn cubecl_scatter_update_window_product_has_checked_host_invariant() {
-    let mod_source = cubecl_source("mod.rs");
+    let sources = production_rust_sources();
+    let mod_source = sources
+        .iter()
+        .find_map(|(path, source)| path.ends_with("cubecl/mod.rs").then_some(source.as_str()))
+        .expect("cubecl/mod.rs should be inventoried");
     let update_len = source_section(
         &mod_source,
         "fn scatter_update_len(",
@@ -94,56 +215,36 @@ fn cubecl_scatter_update_window_product_has_checked_host_invariant() {
         ],
     );
 
-    let launch_paths = [
-        (
-            "scatter_float_typed",
-            source_section(
-                &mod_source,
-                "    fn scatter_float_typed<",
-                "    fn scatter_complex_typed<",
-            ),
-            "indexing::scatter_float_kernel::launch_unchecked",
-        ),
-        (
-            "scatter_complex_typed",
-            source_section(
-                &mod_source,
-                "    fn scatter_complex_typed<",
-                "impl BackendRuntimeCache for CudaBackend",
-            ),
-            "indexing::scatter_complex_kernel::launch_unchecked",
-        ),
-    ];
-    assert_eq!(
-        mod_source
-            .matches("scatter_float_kernel::launch_unchecked")
-            .count()
-            + mod_source
-                .matches("scatter_complex_kernel::launch_unchecked")
-                .count(),
-        launch_paths.len(),
-        "every scatter update kernel launch path must be covered below"
-    );
-    for (name, source, launch) in launch_paths {
-        assert_ordered_needles(
-            name,
-            source,
-            &[
-                "scatter_launch_meta(",
-                "let update_len = scatter_update_len(&meta)?;",
-                "if update_len == 0 {\n            return Ok(output);\n        }",
-                launch,
-            ],
-        );
-    }
+    scatter_update_window_contract(&sources).unwrap_or_else(|err| panic!("{err}"));
+}
 
-    let indexing_source = gpu_source(&["kernels", "indexing.rs"]);
-    let invariant = "// INVARIANT: `scatter_update_len` checked the batch and window products,\n    // checked their combined update-domain bound, and returned before launch when it was zero.\n    let window_iters = update_window_len(updates, update_window_dims.clone());";
-    assert_eq!(
-        indexing_source.matches(invariant).count(),
-        2,
-        "both scatter kernels must keep the checked host-domain proof adjacent to update_window_len"
-    );
+#[test]
+fn scatter_update_window_inventory_rejects_unproved_new_paths() {
+    let sources = production_rust_sources();
+
+    let invariant = "// INVARIANT: `scatter_update_len` returns the checked batch-window product, including zero;\n    // `scatter_float_typed` returns before launch when that checked length is zero.\n    let window_iters = update_window_len(updates, update_window_dims.clone());";
+    let bare_call = "let window_iters = update_window_len(updates, update_window_dims.clone());";
+    let mut one_unmarked = sources.clone();
+    let indexing_source = one_unmarked
+        .iter_mut()
+        .find_map(|(path, source)| path.ends_with("kernels/indexing.rs").then_some(source))
+        .expect("indexing.rs should be inventoried");
+    *indexing_source = indexing_source.replacen(invariant, bare_call, 1);
+    assert!(scatter_update_window_contract(&one_unmarked).is_err());
+
+    let mut extra_product = sources.clone();
+    extra_product.push((
+        PathBuf::from("synthetic/unmarked.rs"),
+        "let third = update_window_len(updates, dims);".to_owned(),
+    ));
+    assert!(scatter_update_window_contract(&extra_product).is_err());
+
+    let mut extra_launch = sources;
+    extra_launch.push((
+        PathBuf::from("synthetic/launch.rs"),
+        "indexing::scatter_float_kernel::launch_unchecked();".to_owned(),
+    ));
+    assert!(scatter_update_window_contract(&extra_launch).is_err());
 }
 
 #[test]

--- a/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -164,6 +164,37 @@ fn contains_token_subsequence(tokens: &[RustToken], sequence: &[&str]) -> bool {
     false
 }
 
+fn forbidden_scatter_aliases(tokens: &[RustToken]) -> Vec<usize> {
+    let protected = [
+        "update_window_len",
+        "scatter_float_kernel",
+        "scatter_complex_kernel",
+        "indexing",
+    ];
+    let mut violations = Vec::new();
+    let mut index = 0;
+    while index < tokens.len() {
+        if tokens[index].text != "use" {
+            index += 1;
+            continue;
+        }
+        let end = tokens[index..]
+            .iter()
+            .position(|token| token.text == ";")
+            .map_or(tokens.len(), |offset| index + offset);
+        let statement = &tokens[index..end];
+        if statement.iter().any(|token| token.text == "as")
+            && statement
+                .iter()
+                .any(|token| protected.contains(&token.text.as_str()))
+        {
+            violations.push(tokens[index].offset);
+        }
+        index = end.saturating_add(1);
+    }
+    violations
+}
+
 fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), String> {
     let invariants = [
         "    // INVARIANT: `scatter_update_len` returns the checked batch-window product, including zero;\n    // `scatter_float_typed` returns before launch when that checked length is zero.\n    let window_iters = update_window_len(updates, update_window_dims.clone());",
@@ -172,8 +203,12 @@ fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), S
     let mut product_calls = Vec::new();
     let mut definitions = Vec::new();
     let mut launches = Vec::new();
+    let mut aliases = Vec::new();
     for (path, source) in sources {
         let tokens = rust_code_tokens(source);
+        for offset in forbidden_scatter_aliases(&tokens) {
+            aliases.push((path, offset));
+        }
         let local_definitions: Vec<_> = tokens
             .windows(2)
             .filter(|window| window[0].text == "fn" && window[1].text == "update_window_len")
@@ -210,6 +245,12 @@ fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), S
                 launches.push((path, offset));
             }
         }
+    }
+
+    if !aliases.is_empty() {
+        return Err(format!(
+            "scatter update-window proof symbols must not be imported or re-exported with aliases: {aliases:?}"
+        ));
     }
 
     if definitions.len() != 1 {
@@ -543,6 +584,24 @@ fn scatter_update_window_inventory_rejects_unproved_new_paths() {
         "let third = update_window_len(updates, dims);".to_owned(),
     ));
     assert!(scatter_update_window_contract(&extra_product).is_err());
+
+    let mut aliased_product = sources.clone();
+    aliased_product.push((
+        PathBuf::from("synthetic/aliased_product.rs"),
+        "use crate::kernels::indexing::update_window_len as checked_window;\n\
+         let third = checked_window(updates, dims);"
+            .to_owned(),
+    ));
+    assert!(scatter_update_window_contract(&aliased_product).is_err());
+
+    let mut aliased_scatter_module = sources.clone();
+    aliased_scatter_module.push((
+        PathBuf::from("synthetic/aliased_launch.rs"),
+        "use crate::kernels::indexing as scatter_kernels;\n\
+         scatter_kernels::scatter_float_kernel::launch_unchecked();"
+            .to_owned(),
+    ));
+    assert!(scatter_update_window_contract(&aliased_scatter_module).is_err());
 
     let mut extra_launch = sources;
     extra_launch.push((

--- a/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -25,30 +25,197 @@ fn production_rust_sources() -> Vec<(PathBuf, String)> {
     sources
 }
 
+#[derive(Debug)]
+struct RustToken {
+    text: String,
+    offset: usize,
+}
+
+fn rust_code_tokens(source: &str) -> Vec<RustToken> {
+    let bytes = source.as_bytes();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i..].starts_with(b"//") {
+            i += 2;
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        if bytes[i..].starts_with(b"/*") {
+            i += 2;
+            let mut depth = 1;
+            while i < bytes.len() && depth > 0 {
+                if bytes[i..].starts_with(b"/*") {
+                    depth += 1;
+                    i += 2;
+                } else if bytes[i..].starts_with(b"*/") {
+                    depth -= 1;
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            continue;
+        }
+        let raw = if bytes[i] == b'r' {
+            Some(i + 1)
+        } else if bytes[i..].starts_with(b"br") {
+            Some(i + 2)
+        } else {
+            None
+        };
+        if let Some(mut cursor) = raw {
+            let mut hashes = 0;
+            while cursor < bytes.len() && bytes[cursor] == b'#' {
+                hashes += 1;
+                cursor += 1;
+            }
+            if cursor < bytes.len() && bytes[cursor] == b'"' {
+                i = cursor + 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'"' && bytes[i + 1..].starts_with(&vec![b'#'; hashes]) {
+                        i += 1 + hashes;
+                        break;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
+        }
+        let quote = if bytes[i] == b'"' {
+            Some(i)
+        } else if bytes[i..].starts_with(b"b\"") {
+            Some(i + 1)
+        } else {
+            None
+        };
+        if let Some(quote) = quote {
+            i = quote + 1;
+            while i < bytes.len() {
+                if bytes[i] == b'\\' {
+                    i = (i + 2).min(bytes.len());
+                } else if bytes[i] == b'"' {
+                    i += 1;
+                    break;
+                } else {
+                    i += 1;
+                }
+            }
+            continue;
+        }
+        if bytes[i] == b'\'' {
+            let mut end = i + 1;
+            if end < bytes.len() && bytes[end] == b'\\' {
+                end += 2;
+            } else {
+                end += 1;
+            }
+            if end < bytes.len() && bytes[end] == b'\'' {
+                i = end + 1;
+                continue;
+            }
+        }
+        if bytes[i].is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        if bytes[i].is_ascii_alphabetic() || bytes[i] == b'_' {
+            i += 1;
+            while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_') {
+                i += 1;
+            }
+        } else {
+            i += if bytes[i..].starts_with(b"::") { 2 } else { 1 };
+        }
+        tokens.push(RustToken {
+            text: source[start..i].to_owned(),
+            offset: start,
+        });
+    }
+    tokens
+}
+
+fn token_positions(tokens: &[RustToken], sequence: &[&str]) -> Vec<usize> {
+    tokens
+        .windows(sequence.len())
+        .filter(|window| {
+            window
+                .iter()
+                .zip(sequence)
+                .all(|(token, expected)| token.text == *expected)
+        })
+        .map(|window| window[0].offset)
+        .collect()
+}
+
+fn contains_token_subsequence(tokens: &[RustToken], sequence: &[&str]) -> bool {
+    let mut next = 0;
+    for token in tokens {
+        if token.text == sequence[next] {
+            next += 1;
+            if next == sequence.len() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), String> {
     let invariants = [
         "    // INVARIANT: `scatter_update_len` returns the checked batch-window product, including zero;\n    // `scatter_float_typed` returns before launch when that checked length is zero.\n    let window_iters = update_window_len(updates, update_window_dims.clone());",
         "    // INVARIANT: `scatter_update_len` returns the checked batch-window product, including zero;\n    // `scatter_complex_typed` returns before launch when that checked length is zero.\n    let window_iters = update_window_len(updates, update_window_dims.clone());",
     ];
     let mut product_calls = Vec::new();
+    let mut definitions = Vec::new();
     let mut launches = Vec::new();
     for (path, source) in sources {
-        let lines: Vec<_> = source.lines().collect();
-        for (line_index, line) in lines.iter().enumerate() {
-            if line.contains("update_window_len(") && !line.contains("fn update_window_len(") {
-                let context =
-                    (line_index >= 2).then(|| lines[line_index - 2..=line_index].join("\n"));
-                let adjacent = context
-                    .as_deref()
-                    .is_some_and(|context| invariants.contains(&context));
-                product_calls.push((path, line_index + 1, adjacent));
+        let tokens = rust_code_tokens(source);
+        let local_definitions: Vec<_> = tokens
+            .windows(2)
+            .filter(|window| window[0].text == "fn" && window[1].text == "update_window_len")
+            .map(|window| window[1].offset)
+            .collect();
+        definitions.extend(local_definitions.iter().copied());
+        for offset in token_positions(&tokens, &["update_window_len", "("]) {
+            if local_definitions.contains(&offset) {
+                continue;
             }
-            if line.contains("scatter_float_kernel::launch_unchecked")
-                || line.contains("scatter_complex_kernel::launch_unchecked")
-            {
-                launches.push((path, line_index + 1));
+            let line_start = source[..offset]
+                .rfind('\n')
+                .map_or(0, |newline| newline + 1);
+            let before = source[..line_start].trim_end_matches('\n');
+            let context_start = before
+                .rmatch_indices('\n')
+                .nth(1)
+                .map_or(0, |(newline, _)| newline + 1);
+            let call_end = source[offset..]
+                .find(';')
+                .map_or(source.len(), |end| offset + end + 1);
+            let context = &source[context_start..call_end];
+            product_calls.push((
+                path,
+                offset,
+                invariants.iter().position(|item| context.contains(item)),
+            ));
+        }
+        for sequence in [
+            &["scatter_float_kernel", "::", "launch_unchecked"][..],
+            &["scatter_complex_kernel", "::", "launch_unchecked"][..],
+        ] {
+            for offset in token_positions(&tokens, sequence) {
+                launches.push((path, offset));
             }
         }
+    }
+
+    if definitions.len() != 1 {
+        return Err(format!(
+            "expected one update_window_len definition, found {definitions:?}"
+        ));
     }
 
     if product_calls.len() != 2 {
@@ -56,24 +223,20 @@ fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), S
             "expected exactly two update_window_len call sites, found {product_calls:?}"
         ));
     }
-    for (path, line, adjacent) in product_calls {
-        if !adjacent {
+    let mut seen_invariants = Vec::new();
+    for (path, line, invariant_index) in product_calls {
+        let Some(invariant_index) = invariant_index else {
             return Err(format!(
                 "{path:?}:{line} lacks the adjacent checked host invariant"
             ));
-        }
+        };
+        seen_invariants.push(invariant_index);
     }
-    let all_source = sources
-        .iter()
-        .map(|(_, source)| source.as_str())
-        .collect::<Vec<_>>()
-        .join("\n");
-    for invariant in invariants {
-        if all_source.matches(invariant.trim_start()).count() != 1 {
-            return Err(format!(
-                "expected exactly one concrete invariant {invariant:?}"
-            ));
-        }
+    seen_invariants.sort_unstable();
+    if seen_invariants != [0, 1] {
+        return Err(format!(
+            "expected one concrete invariant per kernel, found {seen_invariants:?}"
+        ));
     }
 
     if launches.len() != 2 {
@@ -85,6 +248,62 @@ fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), S
         .iter()
         .find_map(|(path, source)| path.ends_with("cubecl/mod.rs").then_some(source.as_str()))
         .ok_or_else(|| "cubecl/mod.rs was not inventoried".to_owned())?;
+    let meta_tokens = rust_code_tokens(source_section(
+        mod_source,
+        "fn scatter_launch_meta(",
+        "impl TensorIndexing for CudaBackend",
+    ));
+    for required in [
+        &[
+            "ensure_axes_unique",
+            "(",
+            ",",
+            ",",
+            "&",
+            "config",
+            ".",
+            "update_window_dims",
+            ",",
+            "updates_shape",
+            ".",
+            "len",
+            "(",
+            ")",
+        ][..],
+        &[
+            "window_shape_updates",
+            "=",
+            "config",
+            ".",
+            "update_window_dims",
+            ".",
+            "iter",
+            "(",
+            ")",
+            ".",
+            "map",
+            "(",
+            "|",
+            "&",
+            "axis",
+            "|",
+            "updates_shape",
+            "[",
+            "axis",
+            "]",
+            ")",
+            ".",
+            "collect",
+            "(",
+            ")",
+        ][..],
+    ] {
+        if token_positions(&meta_tokens, required).is_empty() {
+            return Err(format!(
+                "scatter_launch_meta lacks update-window derivation proof {required:?}"
+            ));
+        }
+    }
     for (name, start, end, launch) in [
         (
             "scatter_float_typed",
@@ -100,18 +319,45 @@ fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), S
         ),
     ] {
         let section = source_section(mod_source, start, end);
+        let section_tokens = rust_code_tokens(section);
+        let kernel = launch
+            .strip_prefix("indexing::")
+            .and_then(|launch| launch.strip_suffix("::launch_unchecked"))
+            .expect("launch descriptor should be qualified");
         let required = [
-            "scatter_launch_meta(",
-            "let update_len = scatter_update_len(&meta)?;",
-            "if update_len == 0 {\n            return Ok(output);\n        }",
-            launch,
+            "scatter_launch_meta",
+            "(",
+            "let",
+            "update_len",
+            "=",
+            "scatter_update_len",
+            "(",
+            "&",
+            "meta",
+            ")",
+            "?",
+            ";",
+            "if",
+            "update_len",
+            "=",
+            "=",
+            "0",
+            "{",
+            "return",
+            "Ok",
+            "(",
+            "output",
+            ")",
+            ";",
+            "}",
+            "indexing",
+            "::",
+            kernel,
+            "::",
+            "launch_unchecked",
         ];
-        let mut offset = 0;
-        for needle in required {
-            let Some(found) = section[offset..].find(needle) else {
-                return Err(format!("{name} lacks ordered launch proof {needle:?}"));
-            };
-            offset += found + needle.len();
+        if !contains_token_subsequence(&section_tokens, &required) {
+            return Err(format!("{name} lacks ordered checked launch proof"));
         }
     }
     Ok(())
@@ -219,6 +465,45 @@ fn cubecl_scatter_update_window_product_has_checked_host_invariant() {
 }
 
 #[test]
+fn rust_token_inventory_ignores_literals_and_accepts_multiline_calls() {
+    let source = r####"
+        // update_window_len(fake)
+        /* scatter_float_kernel::launch_unchecked(fake) */
+        let normal = "update_window_len(fake)";
+        let raw = r#"scatter_complex_kernel::launch_unchecked(fake)"#;
+        let byte = b"update_window_len(fake)";
+        let character = '(';
+        update_window_len
+            (
+                updates,
+                dims,
+            );
+        scatter_float_kernel
+            ::
+            launch_unchecked
+            ();
+    "####;
+    let tokens = rust_code_tokens(source);
+    assert_eq!(
+        token_positions(&tokens, &["update_window_len", "("]).len(),
+        1
+    );
+    assert_eq!(
+        token_positions(
+            &tokens,
+            &["scatter_float_kernel", "::", "launch_unchecked", "("]
+        )
+        .len(),
+        1
+    );
+    assert!(token_positions(
+        &tokens,
+        &["scatter_complex_kernel", "::", "launch_unchecked", "("]
+    )
+    .is_empty());
+}
+
+#[test]
 fn scatter_update_window_inventory_rejects_unproved_new_paths() {
     let sources = production_rust_sources();
 
@@ -231,6 +516,26 @@ fn scatter_update_window_inventory_rejects_unproved_new_paths() {
         .expect("indexing.rs should be inventoried");
     *indexing_source = indexing_source.replacen(invariant, bare_call, 1);
     assert!(scatter_update_window_contract(&one_unmarked).is_err());
+
+    let mut divergent_derivation = sources.clone();
+    let mod_source = divergent_derivation
+        .iter_mut()
+        .find_map(|(path, source)| path.ends_with("cubecl/mod.rs").then_some(source))
+        .expect("cubecl/mod.rs should be inventoried");
+    *mod_source = mod_source.replacen("updates_shape[axis]", "operand_shape[axis]", 1);
+    assert!(scatter_update_window_contract(&divergent_derivation).is_err());
+
+    let mut divergent_axes = sources.clone();
+    let mod_source = divergent_axes
+        .iter_mut()
+        .find_map(|(path, source)| path.ends_with("cubecl/mod.rs").then_some(source))
+        .expect("cubecl/mod.rs should be inventoried");
+    *mod_source = mod_source.replacen(
+        "&config.update_window_dims,\n        updates_shape.len(),",
+        "&config.inserted_window_dims,\n        updates_shape.len(),",
+        1,
+    );
+    assert!(scatter_update_window_contract(&divergent_axes).is_err());
 
     let mut extra_product = sources.clone();
     extra_product.push((

--- a/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -426,6 +426,18 @@ fn cubecl_gather_and_pad_validate_shape_bounds_before_launch() {
 }
 
 #[test]
+fn cubecl_pad_mapping_avoids_signed_edge_subtraction_overflow() {
+    let indexing_source = gpu_source(&["kernels", "indexing.rs"]);
+    let pad_kernel = source_section(
+        &indexing_source,
+        "pub fn pad_kernel",
+        "pub fn gather_kernel",
+    );
+    assert!(!pad_kernel.contains("out_idx[axis] as i64 - low"));
+    assert!(pad_kernel.contains("low.unsigned_abs()"));
+}
+
+#[test]
 fn cubecl_scatter_reports_unsupported_integer_operand_dtypes() {
     let mod_source = cubecl_source("mod.rs");
     let scatter_source = source_section(&mod_source, "    fn scatter(", "    fn slice(");

--- a/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -435,6 +435,15 @@ fn cubecl_pad_mapping_avoids_signed_edge_subtraction_overflow() {
     );
     assert!(!pad_kernel.contains("out_idx[axis] as i64 - low"));
     assert!(pad_kernel.contains("low.unsigned_abs()"));
+    assert_ordered_needles(
+        "pad_kernel candidate bounds check",
+        pad_kernel,
+        &[
+            "let candidate = shifted / spacing;",
+            "if candidate >= input.shape(axis) as u64",
+            "input_idx[axis] = candidate as usize;",
+        ],
+    );
 }
 
 #[test]

--- a/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -488,7 +488,7 @@ fn cubecl_scatter_update_window_product_has_checked_host_invariant() {
         .find_map(|(path, source)| path.ends_with("cubecl/mod.rs").then_some(source.as_str()))
         .expect("cubecl/mod.rs should be inventoried");
     let update_len = source_section(
-        &mod_source,
+        mod_source,
         "fn scatter_update_len(",
         "/// CubeCL-based GPU backend.",
     );

--- a/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -26,14 +26,14 @@ fn production_rust_sources() -> Vec<(PathBuf, String)> {
 }
 
 #[derive(Debug)]
-struct RustToken {
+struct Lexeme {
     text: String,
     offset: usize,
 }
 
-fn rust_code_tokens(source: &str) -> Vec<RustToken> {
+fn rust_code_lexemes(source: &str) -> Vec<Lexeme> {
     let bytes = source.as_bytes();
-    let mut tokens = Vec::new();
+    let mut lexemes = Vec::new();
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i..].starts_with(b"//") {
@@ -130,31 +130,31 @@ fn rust_code_tokens(source: &str) -> Vec<RustToken> {
         } else {
             i += if bytes[i..].starts_with(b"::") { 2 } else { 1 };
         }
-        tokens.push(RustToken {
+        lexemes.push(Lexeme {
             text: source[start..i].to_owned(),
             offset: start,
         });
     }
-    tokens
+    lexemes
 }
 
-fn token_positions(tokens: &[RustToken], sequence: &[&str]) -> Vec<usize> {
-    tokens
+fn lexeme_positions(lexemes: &[Lexeme], sequence: &[&str]) -> Vec<usize> {
+    lexemes
         .windows(sequence.len())
         .filter(|window| {
             window
                 .iter()
                 .zip(sequence)
-                .all(|(token, expected)| token.text == *expected)
+                .all(|(lexeme, expected)| lexeme.text == *expected)
         })
         .map(|window| window[0].offset)
         .collect()
 }
 
-fn contains_token_subsequence(tokens: &[RustToken], sequence: &[&str]) -> bool {
+fn contains_lexeme_subsequence(lexemes: &[Lexeme], sequence: &[&str]) -> bool {
     let mut next = 0;
-    for token in tokens {
-        if token.text == sequence[next] {
+    for lexeme in lexemes {
+        if lexeme.text == sequence[next] {
             next += 1;
             if next == sequence.len() {
                 return true;
@@ -164,7 +164,7 @@ fn contains_token_subsequence(tokens: &[RustToken], sequence: &[&str]) -> bool {
     false
 }
 
-fn forbidden_scatter_aliases(tokens: &[RustToken]) -> Vec<usize> {
+fn forbidden_scatter_aliases(lexemes: &[Lexeme]) -> Vec<usize> {
     let protected = [
         "update_window_len",
         "scatter_float_kernel",
@@ -173,22 +173,22 @@ fn forbidden_scatter_aliases(tokens: &[RustToken]) -> Vec<usize> {
     ];
     let mut violations = Vec::new();
     let mut index = 0;
-    while index < tokens.len() {
-        if tokens[index].text != "use" {
+    while index < lexemes.len() {
+        if lexemes[index].text != "use" {
             index += 1;
             continue;
         }
-        let end = tokens[index..]
+        let end = lexemes[index..]
             .iter()
-            .position(|token| token.text == ";")
-            .map_or(tokens.len(), |offset| index + offset);
-        let statement = &tokens[index..end];
-        if statement.iter().any(|token| token.text == "as")
+            .position(|lexeme| lexeme.text == ";")
+            .map_or(lexemes.len(), |offset| index + offset);
+        let statement = &lexemes[index..end];
+        if statement.iter().any(|lexeme| lexeme.text == "as")
             && statement
                 .iter()
-                .any(|token| protected.contains(&token.text.as_str()))
+                .any(|lexeme| protected.contains(&lexeme.text.as_str()))
         {
-            violations.push(tokens[index].offset);
+            violations.push(lexemes[index].offset);
         }
         index = end.saturating_add(1);
     }
@@ -205,17 +205,17 @@ fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), S
     let mut launches = Vec::new();
     let mut aliases = Vec::new();
     for (path, source) in sources {
-        let tokens = rust_code_tokens(source);
-        for offset in forbidden_scatter_aliases(&tokens) {
+        let lexemes = rust_code_lexemes(source);
+        for offset in forbidden_scatter_aliases(&lexemes) {
             aliases.push((path, offset));
         }
-        let local_definitions: Vec<_> = tokens
+        let local_definitions: Vec<_> = lexemes
             .windows(2)
             .filter(|window| window[0].text == "fn" && window[1].text == "update_window_len")
             .map(|window| window[1].offset)
             .collect();
         definitions.extend(local_definitions.iter().copied());
-        for offset in token_positions(&tokens, &["update_window_len", "("]) {
+        for offset in lexeme_positions(&lexemes, &["update_window_len", "("]) {
             if local_definitions.contains(&offset) {
                 continue;
             }
@@ -241,7 +241,7 @@ fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), S
             &["scatter_float_kernel", "::", "launch_unchecked"][..],
             &["scatter_complex_kernel", "::", "launch_unchecked"][..],
         ] {
-            for offset in token_positions(&tokens, sequence) {
+            for offset in lexeme_positions(&lexemes, sequence) {
                 launches.push((path, offset));
             }
         }
@@ -289,7 +289,7 @@ fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), S
         .iter()
         .find_map(|(path, source)| path.ends_with("cubecl/mod.rs").then_some(source.as_str()))
         .ok_or_else(|| "cubecl/mod.rs was not inventoried".to_owned())?;
-    let meta_tokens = rust_code_tokens(source_section(
+    let meta_lexemes = rust_code_lexemes(source_section(
         mod_source,
         "fn scatter_launch_meta(",
         "impl TensorIndexing for CudaBackend",
@@ -339,7 +339,7 @@ fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), S
             ")",
         ][..],
     ] {
-        if token_positions(&meta_tokens, required).is_empty() {
+        if lexeme_positions(&meta_lexemes, required).is_empty() {
             return Err(format!(
                 "scatter_launch_meta lacks update-window derivation proof {required:?}"
             ));
@@ -360,7 +360,7 @@ fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), S
         ),
     ] {
         let section = source_section(mod_source, start, end);
-        let section_tokens = rust_code_tokens(section);
+        let section_lexemes = rust_code_lexemes(section);
         let kernel = launch
             .strip_prefix("indexing::")
             .and_then(|launch| launch.strip_suffix("::launch_unchecked"))
@@ -397,7 +397,7 @@ fn scatter_update_window_contract(sources: &[(PathBuf, String)]) -> Result<(), S
             "::",
             "launch_unchecked",
         ];
-        if !contains_token_subsequence(&section_tokens, &required) {
+        if !contains_lexeme_subsequence(&section_lexemes, &required) {
             return Err(format!("{name} lacks ordered checked launch proof"));
         }
     }
@@ -506,7 +506,7 @@ fn cubecl_scatter_update_window_product_has_checked_host_invariant() {
 }
 
 #[test]
-fn rust_token_inventory_ignores_literals_and_accepts_multiline_calls() {
+fn rust_lexeme_inventory_ignores_literals_and_accepts_multiline_calls() {
     let source = r####"
         // update_window_len(fake)
         /* scatter_float_kernel::launch_unchecked(fake) */
@@ -524,21 +524,21 @@ fn rust_token_inventory_ignores_literals_and_accepts_multiline_calls() {
             launch_unchecked
             ();
     "####;
-    let tokens = rust_code_tokens(source);
+    let lexemes = rust_code_lexemes(source);
     assert_eq!(
-        token_positions(&tokens, &["update_window_len", "("]).len(),
+        lexeme_positions(&lexemes, &["update_window_len", "("]).len(),
         1
     );
     assert_eq!(
-        token_positions(
-            &tokens,
+        lexeme_positions(
+            &lexemes,
             &["scatter_float_kernel", "::", "launch_unchecked", "("]
         )
         .len(),
         1
     );
-    assert!(token_positions(
-        &tokens,
+    assert!(lexeme_positions(
+        &lexemes,
         &["scatter_complex_kernel", "::", "launch_unchecked", "("]
     )
     .is_empty());

--- a/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -77,6 +77,76 @@ fn cubecl_scatter_does_not_use_single_thread_launch_fallback() {
 }
 
 #[test]
+fn cubecl_scatter_update_window_product_has_checked_host_invariant() {
+    let mod_source = cubecl_source("mod.rs");
+    let update_len = source_section(
+        &mod_source,
+        "fn scatter_update_len(",
+        "/// CubeCL-based GPU backend.",
+    );
+    assert_ordered_needles(
+        "scatter_update_len",
+        update_len,
+        &[
+            "checked_dim_product(\"scatter\", \"batch shape\", &meta.batch_shape)?",
+            "checked_dim_product(\"scatter\", \"window update shape\", &meta.window_shape_updates)?",
+            "batch_len.checked_mul(window_len)",
+        ],
+    );
+
+    let launch_paths = [
+        (
+            "scatter_float_typed",
+            source_section(
+                &mod_source,
+                "    fn scatter_float_typed<",
+                "    fn scatter_complex_typed<",
+            ),
+            "indexing::scatter_float_kernel::launch_unchecked",
+        ),
+        (
+            "scatter_complex_typed",
+            source_section(
+                &mod_source,
+                "    fn scatter_complex_typed<",
+                "impl BackendRuntimeCache for CudaBackend",
+            ),
+            "indexing::scatter_complex_kernel::launch_unchecked",
+        ),
+    ];
+    assert_eq!(
+        mod_source
+            .matches("scatter_float_kernel::launch_unchecked")
+            .count()
+            + mod_source
+                .matches("scatter_complex_kernel::launch_unchecked")
+                .count(),
+        launch_paths.len(),
+        "every scatter update kernel launch path must be covered below"
+    );
+    for (name, source, launch) in launch_paths {
+        assert_ordered_needles(
+            name,
+            source,
+            &[
+                "scatter_launch_meta(",
+                "let update_len = scatter_update_len(&meta)?;",
+                "if update_len == 0 {\n            return Ok(output);\n        }",
+                launch,
+            ],
+        );
+    }
+
+    let indexing_source = gpu_source(&["kernels", "indexing.rs"]);
+    let invariant = "// INVARIANT: `scatter_update_len` checked the batch and window products,\n    // checked their combined update-domain bound, and returned before launch when it was zero.\n    let window_iters = update_window_len(updates, update_window_dims.clone());";
+    assert_eq!(
+        indexing_source.matches(invariant).count(),
+        2,
+        "both scatter kernels must keep the checked host-domain proof adjacent to update_window_len"
+    );
+}
+
+#[test]
 fn cubecl_zero_length_launches_validate_buffers_before_returning() {
     let dispatch_source = cubecl_source("dispatch.rs");
     let dispatch_contracts = [

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -708,11 +708,7 @@ where
         out_core_shape.ok_or_else(|| invalid_config(op_name, "missing output shape"))?;
     out_shape.extend_from_slice(batch_shape);
     let out_data = out_data.ok_or_else(|| invalid_config(op_name, "missing output data"))?;
-    Ok(tensor_from_vec_with_template(
-        out_shape,
-        out_data,
-        input.placement(),
-    )?)
+    tensor_from_vec_with_template(out_shape, out_data, input.placement())
 }
 
 fn batched_multi_result<T, F>(
@@ -994,11 +990,7 @@ where
         out_core_shape.ok_or_else(|| invalid_config(op_name, "missing output shape"))?;
     out_shape.extend_from_slice(a_batch_shape);
     let out_data = out_data.ok_or_else(|| invalid_config(op_name, "missing output data"))?;
-    Ok(tensor_from_vec_with_template(
-        out_shape,
-        out_data,
-        b.placement(),
-    )?)
+    tensor_from_vec_with_template(out_shape, out_data, b.placement())
 }
 
 macro_rules! impl_faer_linalg_for_real {
@@ -1045,11 +1037,11 @@ macro_rules! impl_faer_linalg_for_real {
             Default::default(),
         )
         .map_err(|_| tenferro_tensor::Error::backend_failure("cholesky", "matrix is not positive definite"))?;
-        Ok(tensor_from_vec_with_template(
+        tensor_from_vec_with_template(
             vec![n, n],
             lower_triangle_vec_from_mat(l.as_ref())?,
             placement,
-        )?)
+        )
     }
 
     fn lu_2d(
@@ -1313,7 +1305,7 @@ macro_rules! impl_faer_linalg_for_real {
                 stack,
             );
         }
-        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())?)
+        tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())
     }
 
     fn solve_2d(
@@ -1402,7 +1394,7 @@ macro_rules! impl_faer_linalg_for_real {
                 stack,
             );
         }
-        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())?)
+        tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())
     }
 
     fn triangular_solve_2d(
@@ -1603,7 +1595,7 @@ macro_rules! impl_faer_linalg_for_real {
         )
         .map_err(|_| decomposition_failed("svd_values"))?;
 
-        Ok(tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), input.placement())?)
+        tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), input.placement())
     }
 
     fn qr_2d(
@@ -1651,7 +1643,7 @@ macro_rules! impl_faer_linalg_for_real {
         )
         .map_err(|_| decomposition_failed("eigh_values"))?;
 
-        Ok(tensor_from_vec_with_template(vec![n], vec_from_diag(buffers, values.as_ref()), input.placement())?)
+        tensor_from_vec_with_template(vec![n], vec_from_diag(buffers, values.as_ref()), input.placement())
     }
 
     fn faer_mat_ref_compact<'a>(data: &'a [Self], m: usize, n: usize) -> MatRef<'a, Self> {
@@ -1893,11 +1885,11 @@ macro_rules! impl_faer_linalg_for_complex {
             Default::default(),
         )
         .map_err(|_| tenferro_tensor::Error::backend_failure("cholesky", "matrix is not positive definite"))?;
-        Ok(tensor_from_vec_with_template(
+        tensor_from_vec_with_template(
             vec![n, n],
             $matrix_from_predicate(l.as_ref(), n, n, |row, col| row >= col)?,
             placement,
-        )?)
+        )
     }
 
     fn lu_2d(
@@ -2200,7 +2192,7 @@ macro_rules! impl_faer_linalg_for_complex {
                 stack,
             );
         }
-        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())?)
+        tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())
     }
 
     fn solve_2d(
@@ -2298,7 +2290,7 @@ macro_rules! impl_faer_linalg_for_complex {
                 stack,
             );
         }
-        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())?)
+        tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())
     }
 
     fn triangular_solve_2d(
@@ -2512,7 +2504,7 @@ macro_rules! impl_faer_linalg_for_complex {
         for i in 0..col.nrows() {
             data.push(col[i].re);
         }
-        Ok(tensor_from_vec_with_template(vec![k], data, input.placement())?)
+        tensor_from_vec_with_template(vec![k], data, input.placement())
     }
 
     fn qr_2d(
@@ -2565,7 +2557,7 @@ macro_rules! impl_faer_linalg_for_complex {
         for i in 0..col.nrows() {
             data.push(col[i].re);
         }
-        Ok(tensor_from_vec_with_template(vec![n], data, input.placement())?)
+        tensor_from_vec_with_template(vec![n], data, input.placement())
     }
 
     fn faer_mat_ref_compact<'a>(data: &'a [Self], m: usize, n: usize) -> MatRef<'a, Self> {
@@ -2815,11 +2807,11 @@ pub(crate) fn cholesky<T: FaerLinalg>(
 ) -> tenferro_tensor::Result<TypedTensor<T>> {
     if has_zero_dim(input.shape()) {
         let (n, batch_shape) = square_core_and_batch(input, "cholesky")?;
-        return Ok(tensor_from_vec_with_template(
+        return tensor_from_vec_with_template(
             matrix_with_batch_shape(n, n, batch_shape),
             Vec::new(),
             input.placement(),
-        )?);
+        );
     }
     batched_single("cholesky", buffers, input, 2, |buffers, batch| {
         T::cholesky_2d(ctx, buffers, batch)
@@ -2996,11 +2988,7 @@ pub(crate) fn full_piv_lu_solve<T: FaerLinalg>(
                 rhs: b_batch_shape.to_vec(),
             });
         }
-        return Ok(tensor_from_vec_with_template(
-            b.shape().to_vec(),
-            Vec::new(),
-            b.placement(),
-        )?);
+        return tensor_from_vec_with_template(b.shape().to_vec(), Vec::new(), b.placement());
     }
     batched_binary_result("full_piv_lu_solve", buffers, a, b, 2, 2, |buffers, a, b| {
         T::full_piv_lu_solve_2d(ctx, buffers, a, b, transpose_a)
@@ -3031,11 +3019,7 @@ pub(crate) fn solve<T: FaerLinalg>(
                 rhs: b_batch_shape.to_vec(),
             });
         }
-        return Ok(tensor_from_vec_with_template(
-            b.shape().to_vec(),
-            Vec::new(),
-            b.placement(),
-        )?);
+        return tensor_from_vec_with_template(b.shape().to_vec(), Vec::new(), b.placement());
     }
     batched_binary_result("solve", buffers, a, b, 2, 2, |buffers, a, b| {
         T::solve_2d(ctx, buffers, a, b, transpose_a)
@@ -3072,11 +3056,7 @@ pub(crate) fn triangular_solve<T: FaerLinalg>(
                 rhs: b_batch_shape.to_vec(),
             });
         }
-        return Ok(tensor_from_vec_with_template(
-            b.shape().to_vec(),
-            Vec::new(),
-            b.placement(),
-        )?);
+        return tensor_from_vec_with_template(b.shape().to_vec(), Vec::new(), b.placement());
     }
     batched_binary_result("triangular_solve", buffers, a, b, 2, 2, |buffers, a, b| {
         T::triangular_solve_2d(
@@ -3131,11 +3111,11 @@ pub(crate) fn svd_values<T: FaerLinalg>(
     if has_zero_dim(input.shape()) {
         let (m, n, batch_shape) = matrix_core_and_batch(input, "svd_values")?;
         let k = m.min(n);
-        return Ok(tensor_from_vec_with_template(
+        return tensor_from_vec_with_template(
             vector_with_batch_shape(k, batch_shape),
             Vec::new(),
             input.placement(),
-        )?);
+        );
     }
     let mut outputs =
         batched_multi_convert_result("svd_values", buffers, input, 2, |buffers, batch| {
@@ -3202,11 +3182,11 @@ pub(crate) fn eigh_values<T: FaerLinalg>(
 ) -> tenferro_tensor::Result<TypedTensor<T::Real>> {
     if has_zero_dim(input.shape()) {
         let (n, batch_shape) = square_core_and_batch(input, "eigh_values")?;
-        return Ok(tensor_from_vec_with_template(
+        return tensor_from_vec_with_template(
             vector_with_batch_shape(n, batch_shape),
             Vec::new(),
             input.placement(),
-        )?);
+        );
     }
     let mut outputs =
         batched_multi_convert_result("eigh_values", buffers, input, 2, |buffers, batch| {
@@ -3432,11 +3412,7 @@ macro_rules! impl_eig_values_real_2d {
             .map_err(|_| decomposition_failed("eig_values"))?;
             let s = $real_eig_to_complex_values(buffers, s_re.as_ref(), s_im.as_ref());
 
-            Ok(tensor_from_vec_with_template(
-                vec![n],
-                s,
-                input.placement(),
-            )?)
+            tensor_from_vec_with_template(vec![n], s, input.placement())
         }
     };
 }
@@ -3529,11 +3505,11 @@ macro_rules! impl_eig_values_complex_2d {
             )
             .map_err(|_| decomposition_failed("eig_values"))?;
 
-            Ok(tensor_from_vec_with_template(
+            tensor_from_vec_with_template(
                 vec![n],
                 $vec_from_diag(buffers, s.as_ref()),
                 input.placement(),
-            )?)
+            )
         }
     };
 }

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -179,13 +179,10 @@ fn tensor_from_vec_with_template<T: Clone>(
     shape: Vec<usize>,
     data: Vec<T>,
     placement: &tenferro_tensor::Placement,
-) -> TypedTensor<T> {
-    // faer outputs are assembled from validated matrix dimensions and buffers
-    // sized by the same dimensions, so mismatch here is an internal backend bug.
-    let mut tensor =
-        TypedTensor::from_vec_col_major(shape, data).expect("faer output shape/data match");
+) -> tenferro_tensor::Result<TypedTensor<T>> {
+    let mut tensor = TypedTensor::from_vec_col_major(shape, data)?;
     tensor.set_placement(placement.clone());
-    tensor
+    Ok(tensor)
 }
 
 fn tensor_from_pooled_slice_with_template<T: Clone + PoolScalar>(
@@ -193,32 +190,33 @@ fn tensor_from_pooled_slice_with_template<T: Clone + PoolScalar>(
     shape: Vec<usize>,
     data: &[T],
     placement: &tenferro_tensor::Placement,
-) -> TypedTensor<T> {
+) -> tenferro_tensor::Result<TypedTensor<T>> {
     let mut owned = buffers.acquire_with_capacity::<T>(data.len());
     owned.extend_from_slice(data);
     tensor_from_vec_with_template(shape, owned, placement)
 }
 
-fn refill_tensor_from_slice<T: Copy>(tensor: &mut TypedTensor<T>, data: &[T]) {
-    // Batch scratch tensors are created as host tensors by this module.
-    tensor
-        .host_data_mut()
-        .expect("faer batch scratch tensor is host-backed")
-        .copy_from_slice(data);
+fn refill_tensor_from_slice<T: Copy>(
+    tensor: &mut TypedTensor<T>,
+    data: &[T],
+) -> tenferro_tensor::Result<()> {
+    tensor.host_data_mut()?.copy_from_slice(data);
+    Ok(())
 }
 
 fn col_major_vec_from_mat<T: Copy + PoolScalar>(
     buffers: &mut BufferPool,
     mat: MatRef<'_, T>,
-) -> Vec<T> {
+) -> tenferro_tensor::Result<Vec<T>> {
     let (rows, cols) = mat.shape();
-    let mut data = buffers.acquire_with_capacity::<T>(rows * cols);
+    let len = checked_product("faer_linalg", "matrix", &[rows, cols])?;
+    let mut data = buffers.acquire_with_capacity::<T>(len);
     for j in 0..cols {
         for i in 0..rows {
             data.push(mat[(i, j)]);
         }
     }
-    data
+    Ok(data)
 }
 
 fn vec_from_diag<T: Copy + PoolScalar>(buffers: &mut BufferPool, diag: DiagRef<'_, T>) -> Vec<T> {
@@ -393,16 +391,17 @@ macro_rules! impl_complex_vec_helpers {
         fn $vec_from_mat(
             buffers: &mut BufferPool,
             mat: MatRef<'_, $faer_complex>,
-        ) -> Vec<$complex> {
+        ) -> tenferro_tensor::Result<Vec<$complex>> {
             let (rows, cols) = mat.shape();
-            let mut data = buffers.acquire_with_capacity::<$complex>(rows * cols);
+            let len = checked_product("faer_linalg", "complex matrix", &[rows, cols])?;
+            let mut data = buffers.acquire_with_capacity::<$complex>(len);
             for j in 0..cols {
                 for i in 0..rows {
                     let value = mat[(i, j)];
                     data.push(<$complex>::new(value.re, value.im));
                 }
             }
-            data
+            Ok(data)
         }
 
         fn $matrix_from_predicate(
@@ -410,8 +409,9 @@ macro_rules! impl_complex_vec_helpers {
             rows: usize,
             cols: usize,
             predicate: impl Fn(usize, usize) -> bool,
-        ) -> Vec<$complex> {
-            let mut data = vec![<$complex>::new(0.0, 0.0); rows * cols];
+        ) -> tenferro_tensor::Result<Vec<$complex>> {
+            let len = checked_product("faer_linalg", "complex matrix", &[rows, cols])?;
+            let mut data = vec![<$complex>::new(0.0, 0.0); len];
             for j in 0..cols {
                 for i in 0..rows {
                     if predicate(i, j) {
@@ -420,7 +420,7 @@ macro_rules! impl_complex_vec_helpers {
                     }
                 }
             }
-            data
+            Ok(data)
         }
     };
 }
@@ -430,8 +430,9 @@ fn matrix_from_predicate<T: Copy + Default>(
     rows: usize,
     cols: usize,
     predicate: impl Fn(usize, usize) -> bool,
-) -> Vec<T> {
-    let mut data = vec![T::default(); rows * cols];
+) -> tenferro_tensor::Result<Vec<T>> {
+    let len = checked_product("faer_linalg", "matrix", &[rows, cols])?;
+    let mut data = vec![T::default(); len];
     for j in 0..cols {
         for i in 0..rows {
             if predicate(i, j) {
@@ -439,26 +440,34 @@ fn matrix_from_predicate<T: Copy + Default>(
             }
         }
     }
-    data
+    Ok(data)
 }
 
-fn lower_triangle_vec_from_mat<T: Copy + Default>(mat: MatRef<'_, T>) -> Vec<T> {
+fn lower_triangle_vec_from_mat<T: Copy + Default>(
+    mat: MatRef<'_, T>,
+) -> tenferro_tensor::Result<Vec<T>> {
     let (rows, cols) = mat.shape();
     matrix_from_predicate(mat, rows, cols, |row, col| row >= col)
 }
 
-fn upper_triangle_vec_from_mat<T: Copy + Default>(mat: MatRef<'_, T>) -> Vec<T> {
+fn upper_triangle_vec_from_mat<T: Copy + Default>(
+    mat: MatRef<'_, T>,
+) -> tenferro_tensor::Result<Vec<T>> {
     let (rows, cols) = mat.shape();
     matrix_from_predicate(mat, rows, cols, |row, col| row <= col)
 }
 
-fn permutation_matrix<T: Copy + Default>(perm: &[usize], one: T) -> Vec<T> {
+fn permutation_matrix<T: Copy + Default>(
+    perm: &[usize],
+    one: T,
+) -> tenferro_tensor::Result<Vec<T>> {
     let n = perm.len();
-    let mut data = vec![T::default(); n * n];
+    let len = checked_product("faer_linalg", "permutation matrix", &[n, n])?;
+    let mut data = vec![T::default(); len];
     for (row, &source) in perm.iter().enumerate() {
         data[row + source * n] = one;
     }
-    data
+    Ok(data)
 }
 
 fn swap_sequence_from_permutation(
@@ -505,10 +514,11 @@ macro_rules! impl_real_eig_to_complex_outputs {
             u_real: MatRef<'_, $real>,
             s_re: DiagRef<'_, $real>,
             s_im: DiagRef<'_, $real>,
-        ) -> (Vec<$complex>, Vec<$complex>) {
+        ) -> tenferro_tensor::Result<(Vec<$complex>, Vec<$complex>)> {
             let n = u_real.nrows();
+            let matrix_len = checked_product("eig", "eigenvector matrix", &[n, n])?;
             // SAFETY: the loop below writes every element of `u` and `s` before any read.
-            let mut u = unsafe { <$complex as PoolScalar>::pool_acquire(buffers, n * n) };
+            let mut u = unsafe { <$complex as PoolScalar>::pool_acquire(buffers, matrix_len) };
             // SAFETY: the loop below writes every element of `u` and `s` before any read.
             let mut s = unsafe { <$complex as PoolScalar>::pool_acquire(buffers, n) };
             let mut j = 0;
@@ -535,7 +545,7 @@ macro_rules! impl_real_eig_to_complex_outputs {
                     j += 2;
                 }
             }
-            (u, s)
+            Ok((u, s))
         }
     };
 }
@@ -657,12 +667,12 @@ where
         core_shape.to_vec(),
         &input.host_data()?[first_range],
         input.placement(),
-    );
+    )?;
 
     for batch_idx in 0..batch_count {
         if batch_idx > 0 {
             let range = checked_slice_range(op_name, batch_idx, slice_size)?;
-            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[range]);
+            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[range])?;
         }
         let batch_output = op(buffers, &batch_input)?;
 
@@ -702,7 +712,7 @@ where
         out_shape,
         out_data,
         input.placement(),
-    ))
+    )?)
 }
 
 fn batched_multi_result<T, F>(
@@ -739,12 +749,12 @@ where
         core_shape.to_vec(),
         &input.host_data()?[first_range],
         input.placement(),
-    );
+    )?;
 
     for batch_idx in 0..batch_count {
         if batch_idx > 0 {
             let range = checked_slice_range(op_name, batch_idx, slice_size)?;
-            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[range]);
+            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[range])?;
         }
         let batch_outputs = op(buffers, &batch_input)?;
 
@@ -784,14 +794,14 @@ where
         }
     }
 
-    Ok(out_shapes
+    out_shapes
         .into_iter()
         .zip(out_data)
         .map(|(mut out_shape, out_data)| {
             out_shape.extend_from_slice(batch_shape);
             tensor_from_vec_with_template(out_shape, out_data, input.placement())
         })
-        .collect())
+        .collect()
 }
 
 fn batched_multi_convert_result<InT, OutT, F>(
@@ -829,12 +839,12 @@ where
         core_shape.to_vec(),
         &input.host_data()?[first_range],
         input.placement(),
-    );
+    )?;
 
     for batch_idx in 0..batch_count {
         if batch_idx > 0 {
             let range = checked_slice_range(op_name, batch_idx, slice_size)?;
-            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[range]);
+            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[range])?;
         }
         let batch_outputs = op(buffers, &batch_input)?;
 
@@ -874,14 +884,14 @@ where
         }
     }
 
-    Ok(out_shapes
+    out_shapes
         .into_iter()
         .zip(out_data)
         .map(|(mut out_shape, out_data)| {
             out_shape.extend_from_slice(batch_shape);
             tensor_from_vec_with_template(out_shape, out_data, input.placement())
         })
-        .collect())
+        .collect()
 }
 
 fn batched_binary_result<T, F>(
@@ -935,20 +945,20 @@ where
         a_core_shape.to_vec(),
         &a.host_data()?[first_a_range],
         a.placement(),
-    );
+    )?;
     let mut batch_b = tensor_from_pooled_slice_with_template(
         buffers,
         b_core_shape.to_vec(),
         &b.host_data()?[first_b_range],
         b.placement(),
-    );
+    )?;
 
     for batch_idx in 0..batch_count {
         if batch_idx > 0 {
             let a_range = checked_slice_range(op_name, batch_idx, a_slice_size)?;
             let b_range = checked_slice_range(op_name, batch_idx, b_slice_size)?;
-            refill_tensor_from_slice(&mut batch_a, &a.host_data()?[a_range]);
-            refill_tensor_from_slice(&mut batch_b, &b.host_data()?[b_range]);
+            refill_tensor_from_slice(&mut batch_a, &a.host_data()?[a_range])?;
+            refill_tensor_from_slice(&mut batch_b, &b.host_data()?[b_range])?;
         }
         let batch_output = op(buffers, &batch_a, &batch_b)?;
 
@@ -988,7 +998,7 @@ where
         out_shape,
         out_data,
         b.placement(),
-    ))
+    )?)
 }
 
 macro_rules! impl_faer_linalg_for_real {
@@ -1037,9 +1047,9 @@ macro_rules! impl_faer_linalg_for_real {
         .map_err(|_| tenferro_tensor::Error::backend_failure("cholesky", "matrix is not positive definite"))?;
         Ok(tensor_from_vec_with_template(
             vec![n, n],
-            lower_triangle_vec_from_mat(l.as_ref()),
+            lower_triangle_vec_from_mat(l.as_ref())?,
             placement,
-        ))
+        )?)
     }
 
     fn lu_2d(
@@ -1084,7 +1094,8 @@ macro_rules! impl_faer_linalg_for_real {
         )
         .0;
 
-        let mut p_data = vec![0.0; m * m];
+        let p_len = checked_product("lu", "permutation matrix", &[m, m])?;
+        let mut p_data = vec![0.0; p_len];
         for (row, &col) in perm.iter().enumerate() {
             p_data[row + col * m] = 1.0;
         }
@@ -1094,17 +1105,17 @@ macro_rules! impl_faer_linalg_for_real {
             -1.0
         };
 
-        let mut l_data = matrix_from_predicate(lu.as_ref(), m, k, |row, col| row >= col);
+        let mut l_data = matrix_from_predicate(lu.as_ref(), m, k, |row, col| row >= col)?;
         for i in 0..k {
             l_data[i + i * m] = 1.0;
         }
-        let u_data = upper_triangle_vec_from_mat(lu.as_ref().get(..k, ..));
+        let u_data = upper_triangle_vec_from_mat(lu.as_ref().get(..k, ..))?;
 
         Ok(vec![
-            tensor_from_vec_with_template(vec![m, m], p_data, placement),
-            tensor_from_vec_with_template(vec![m, k], l_data, placement),
-            tensor_from_vec_with_template(vec![k, n], u_data, placement),
-            tensor_from_vec_with_template(vec![], vec![parity], placement),
+            tensor_from_vec_with_template(vec![m, m], p_data, placement)?,
+            tensor_from_vec_with_template(vec![m, k], l_data, placement)?,
+            tensor_from_vec_with_template(vec![k, n], u_data, placement)?,
+            tensor_from_vec_with_template(vec![], vec![parity], placement)?,
         ])
     }
 
@@ -1145,9 +1156,9 @@ macro_rules! impl_faer_linalg_for_real {
         let pivots = swap_sequence_from_permutation(&perm, k, "lu_factor")?;
 
         Ok((
-            tensor_from_vec_with_template(vec![m, n], col_major_vec_from_mat(buffers, lu.as_ref()), input.placement()),
-            tensor_from_vec_with_template(vec![k], pivots, input.placement()),
-            tensor_from_vec_with_template(vec![], vec![parity], input.placement()),
+            tensor_from_vec_with_template(vec![m, n], col_major_vec_from_mat(buffers, lu.as_ref())?, input.placement())?,
+            tensor_from_vec_with_template(vec![k], pivots, input.placement())?,
+            tensor_from_vec_with_template(vec![], vec![parity], input.placement())?,
         ))
     }
 
@@ -1195,11 +1206,11 @@ macro_rules! impl_faer_linalg_for_real {
         )
         .0;
 
-        let mut l_data = lower_triangle_vec_from_mat(lu.as_ref());
+        let mut l_data = lower_triangle_vec_from_mat(lu.as_ref())?;
         for i in 0..n {
             l_data[i + i * n] = 1.0;
         }
-        let u_data = upper_triangle_vec_from_mat(lu.as_ref());
+        let u_data = upper_triangle_vec_from_mat(lu.as_ref())?;
         let parity = if info.transposition_count % 2 == 0 {
             1.0
         } else {
@@ -1207,11 +1218,11 @@ macro_rules! impl_faer_linalg_for_real {
         };
 
         Ok(vec![
-            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, 1.0), placement),
-            tensor_from_vec_with_template(vec![n, n], l_data, placement),
-            tensor_from_vec_with_template(vec![n, n], u_data, placement),
-            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, 1.0), placement),
-            tensor_from_vec_with_template(vec![], vec![parity], placement),
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, 1.0)?, placement)?,
+            tensor_from_vec_with_template(vec![n, n], l_data, placement)?,
+            tensor_from_vec_with_template(vec![n, n], u_data, placement)?,
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, 1.0)?, placement)?,
+            tensor_from_vec_with_template(vec![], vec![parity], placement)?,
         ])
     }
 
@@ -1302,7 +1313,7 @@ macro_rules! impl_faer_linalg_for_real {
                 stack,
             );
         }
-        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement()))
+        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())?)
     }
 
     fn solve_2d(
@@ -1391,7 +1402,7 @@ macro_rules! impl_faer_linalg_for_real {
                 stack,
             );
         }
-        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement()))
+        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())?)
     }
 
     fn triangular_solve_2d(
@@ -1477,7 +1488,7 @@ macro_rules! impl_faer_linalg_for_real {
                     );
                 }
             }
-            Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement()))
+            Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())?)
         } else {
             if b_cols != n {
                 return Err(tenferro_tensor::Error::ShapeMismatch {
@@ -1549,7 +1560,7 @@ macro_rules! impl_faer_linalg_for_real {
             }
             let result = transpose_col_major_data(buffers, &rhs_transposed, n, nrhs);
             <Self as PoolScalar>::pool_release(buffers, rhs_transposed);
-            Ok(tensor_from_vec_with_template(vec![nrhs, n], result, b.placement()))
+            Ok(tensor_from_vec_with_template(vec![nrhs, n], result, b.placement())?)
         }
     }
 
@@ -1592,7 +1603,7 @@ macro_rules! impl_faer_linalg_for_real {
         )
         .map_err(|_| decomposition_failed("svd_values"))?;
 
-        Ok(tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), input.placement()))
+        Ok(tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), input.placement())?)
     }
 
     fn qr_2d(
@@ -1640,7 +1651,7 @@ macro_rules! impl_faer_linalg_for_real {
         )
         .map_err(|_| decomposition_failed("eigh_values"))?;
 
-        Ok(tensor_from_vec_with_template(vec![n], vec_from_diag(buffers, values.as_ref()), input.placement()))
+        Ok(tensor_from_vec_with_template(vec![n], vec_from_diag(buffers, values.as_ref()), input.placement())?)
     }
 
     fn faer_mat_ref_compact<'a>(data: &'a [Self], m: usize, n: usize) -> MatRef<'a, Self> {
@@ -1692,18 +1703,19 @@ macro_rules! impl_faer_linalg_for_real {
 
         let u = tensor_from_vec_with_template(
             vec![m, k],
-            col_major_vec_from_mat(buffers, u.as_ref()),
+            col_major_vec_from_mat(buffers, u.as_ref())?,
             placement,
-        );
+        )?;
         let s =
-            tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), placement);
-        let mut vt_data = buffers.acquire_with_capacity::<Self>(k * n);
+            tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), placement)?;
+        let vt_len = checked_product("svd", "right singular vectors", &[k, n])?;
+        let mut vt_data = buffers.acquire_with_capacity::<Self>(vt_len);
         for j in 0..n {
             for i in 0..k {
                 vt_data.push(v[(j, i)]);
             }
         }
-        let vt = tensor_from_vec_with_template(vec![k, n], vt_data, placement);
+        let vt = tensor_from_vec_with_template(vec![k, n], vt_data, placement)?;
 
         Ok(vec![u, s, vt])
     }
@@ -1758,14 +1770,14 @@ macro_rules! impl_faer_linalg_for_real {
         );
         let q = tensor_from_vec_with_template(
             vec![m, k],
-            col_major_vec_from_mat(buffers, q.as_ref()),
+            col_major_vec_from_mat(buffers, q.as_ref())?,
             placement,
-        );
+        )?;
         let r = tensor_from_vec_with_template(
             vec![k, n],
-            upper_triangle_vec_from_mat(qr.as_ref().get(..k, ..)),
+            upper_triangle_vec_from_mat(qr.as_ref().get(..k, ..))?,
             placement,
-        );
+        )?;
 
         Ok(vec![q, r])
     }
@@ -1800,12 +1812,12 @@ macro_rules! impl_faer_linalg_for_real {
             vec![n],
             vec_from_diag(buffers, values.as_ref()),
             placement,
-        );
+        )?;
         let vectors = tensor_from_vec_with_template(
             vec![n, n],
-            col_major_vec_from_mat(buffers, vectors.as_ref()),
+            col_major_vec_from_mat(buffers, vectors.as_ref())?,
             placement,
-        );
+        )?;
 
         Ok(vec![values, vectors])
     }
@@ -1883,9 +1895,9 @@ macro_rules! impl_faer_linalg_for_complex {
         .map_err(|_| tenferro_tensor::Error::backend_failure("cholesky", "matrix is not positive definite"))?;
         Ok(tensor_from_vec_with_template(
             vec![n, n],
-            $matrix_from_predicate(l.as_ref(), n, n, |row, col| row >= col),
+            $matrix_from_predicate(l.as_ref(), n, n, |row, col| row >= col)?,
             placement,
-        ))
+        )?)
     }
 
     fn lu_2d(
@@ -1941,7 +1953,8 @@ macro_rules! impl_faer_linalg_for_complex {
         )
         .0;
 
-        let mut p_data = vec![<$complex>::new(0.0, 0.0); m * m];
+        let p_len = checked_product("lu", "permutation matrix", &[m, m])?;
+        let mut p_data = vec![<$complex>::new(0.0, 0.0); p_len];
         for (row, &col) in perm.iter().enumerate() {
             p_data[row + col * m] = <$complex>::new(1.0, 0.0);
         }
@@ -1950,17 +1963,17 @@ macro_rules! impl_faer_linalg_for_complex {
         } else {
             <$complex>::new(-1.0, 0.0)
         };
-        let mut l_data = $matrix_from_predicate(lu.as_ref(), m, k, |row, col| row >= col);
+        let mut l_data = $matrix_from_predicate(lu.as_ref(), m, k, |row, col| row >= col)?;
         for i in 0..k {
             l_data[i + i * m] = <$complex>::new(1.0, 0.0);
         }
-        let u_data = $matrix_from_predicate(lu.as_ref(), k, n, |row, col| row <= col);
+        let u_data = $matrix_from_predicate(lu.as_ref(), k, n, |row, col| row <= col)?;
 
         Ok(vec![
-            tensor_from_vec_with_template(vec![m, m], p_data, placement),
-            tensor_from_vec_with_template(vec![m, k], l_data, placement),
-            tensor_from_vec_with_template(vec![k, n], u_data, placement),
-            tensor_from_vec_with_template(vec![], vec![parity], placement),
+            tensor_from_vec_with_template(vec![m, m], p_data, placement)?,
+            tensor_from_vec_with_template(vec![m, k], l_data, placement)?,
+            tensor_from_vec_with_template(vec![k, n], u_data, placement)?,
+            tensor_from_vec_with_template(vec![], vec![parity], placement)?,
         ])
     }
 
@@ -2005,9 +2018,9 @@ macro_rules! impl_faer_linalg_for_complex {
         let pivots = swap_sequence_from_permutation(&perm, k, "lu_factor")?;
 
         Ok((
-            tensor_from_vec_with_template(vec![m, n], $vec_from_mat(_buffers, lu.as_ref()), input.placement()),
-            tensor_from_vec_with_template(vec![k], pivots, input.placement()),
-            tensor_from_vec_with_template(vec![], vec![parity], input.placement()),
+            tensor_from_vec_with_template(vec![m, n], $vec_from_mat(_buffers, lu.as_ref())?, input.placement())?,
+            tensor_from_vec_with_template(vec![k], pivots, input.placement())?,
+            tensor_from_vec_with_template(vec![], vec![parity], input.placement())?,
         ))
     }
 
@@ -2066,11 +2079,11 @@ macro_rules! impl_faer_linalg_for_complex {
         )
         .0;
 
-        let mut l_data = $matrix_from_predicate(lu.as_ref(), n, n, |row, col| row >= col);
+        let mut l_data = $matrix_from_predicate(lu.as_ref(), n, n, |row, col| row >= col)?;
         for i in 0..n {
             l_data[i + i * n] = <$complex>::new(1.0, 0.0);
         }
-        let u_data = $matrix_from_predicate(lu.as_ref(), n, n, |row, col| row <= col);
+        let u_data = $matrix_from_predicate(lu.as_ref(), n, n, |row, col| row <= col)?;
         let one = <$complex>::new(1.0, 0.0);
         let parity = if info.transposition_count % 2 == 0 {
             one
@@ -2079,11 +2092,11 @@ macro_rules! impl_faer_linalg_for_complex {
         };
 
         Ok(vec![
-            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, one), placement),
-            tensor_from_vec_with_template(vec![n, n], l_data, placement),
-            tensor_from_vec_with_template(vec![n, n], u_data, placement),
-            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, one), placement),
-            tensor_from_vec_with_template(vec![], vec![parity], placement),
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&row_perm, one)?, placement)?,
+            tensor_from_vec_with_template(vec![n, n], l_data, placement)?,
+            tensor_from_vec_with_template(vec![n, n], u_data, placement)?,
+            tensor_from_vec_with_template(vec![n, n], permutation_matrix(&col_perm, one)?, placement)?,
+            tensor_from_vec_with_template(vec![], vec![parity], placement)?,
         ])
     }
 
@@ -2187,7 +2200,7 @@ macro_rules! impl_faer_linalg_for_complex {
                 stack,
             );
         }
-        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement()))
+        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())?)
     }
 
     fn solve_2d(
@@ -2285,7 +2298,7 @@ macro_rules! impl_faer_linalg_for_complex {
                 stack,
             );
         }
-        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement()))
+        Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())?)
     }
 
     fn triangular_solve_2d(
@@ -2375,7 +2388,7 @@ macro_rules! impl_faer_linalg_for_complex {
                     );
                 }
             }
-            Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement()))
+            Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())?)
         } else {
             if b_cols != n {
                 return Err(tenferro_tensor::Error::ShapeMismatch {
@@ -2451,7 +2464,7 @@ macro_rules! impl_faer_linalg_for_complex {
             }
             let result = transpose_col_major_data(buffers, &rhs_transposed, n, nrhs);
             <Self as PoolScalar>::pool_release(buffers, rhs_transposed);
-            Ok(tensor_from_vec_with_template(vec![nrhs, n], result, b.placement()))
+            Ok(tensor_from_vec_with_template(vec![nrhs, n], result, b.placement())?)
         }
     }
 
@@ -2499,7 +2512,7 @@ macro_rules! impl_faer_linalg_for_complex {
         for i in 0..col.nrows() {
             data.push(col[i].re);
         }
-        Ok(tensor_from_vec_with_template(vec![k], data, input.placement()))
+        Ok(tensor_from_vec_with_template(vec![k], data, input.placement())?)
     }
 
     fn qr_2d(
@@ -2552,7 +2565,7 @@ macro_rules! impl_faer_linalg_for_complex {
         for i in 0..col.nrows() {
             data.push(col[i].re);
         }
-        Ok(tensor_from_vec_with_template(vec![n], data, input.placement()))
+        Ok(tensor_from_vec_with_template(vec![n], data, input.placement())?)
     }
 
     fn faer_mat_ref_compact<'a>(data: &'a [Self], m: usize, n: usize) -> MatRef<'a, Self> {
@@ -2625,21 +2638,22 @@ macro_rules! impl_faer_linalg_for_complex {
 
         let u = tensor_from_vec_with_template(
             vec![m, k],
-            $vec_from_mat(buffers, u.as_ref()),
+            $vec_from_mat(buffers, u.as_ref())?,
             placement,
-        );
+        )?;
         let s = tensor_from_vec_with_template(
             vec![k],
             $vec_from_real_diag(buffers, s.as_ref()),
             placement,
-        );
-        let mut vt_data = buffers.acquire_with_capacity::<Self>(k * n);
+        )?;
+        let vt_len = checked_product("svd", "right singular vectors", &[k, n])?;
+        let mut vt_data = buffers.acquire_with_capacity::<Self>(vt_len);
         for j in 0..n {
             for i in 0..k {
                 vt_data.push(v[(j, i)].conj());
             }
         }
-        let vt = tensor_from_vec_with_template(vec![k, n], vt_data, placement);
+        let vt = tensor_from_vec_with_template(vec![k, n], vt_data, placement)?;
 
         Ok(vec![u, s, vt])
     }
@@ -2705,14 +2719,14 @@ macro_rules! impl_faer_linalg_for_complex {
         );
         let q = tensor_from_vec_with_template(
             vec![m, k],
-            $vec_from_mat(buffers, q.as_ref()),
+            $vec_from_mat(buffers, q.as_ref())?,
             placement,
-        );
+        )?;
         let r = tensor_from_vec_with_template(
             vec![k, n],
-            $matrix_from_predicate(qr.as_ref(), k, n, |row, col| row <= col),
+            $matrix_from_predicate(qr.as_ref(), k, n, |row, col| row <= col)?,
             placement,
-        );
+        )?;
 
         Ok(vec![q, r])
     }
@@ -2758,12 +2772,12 @@ macro_rules! impl_faer_linalg_for_complex {
             vec![n],
             $vec_from_real_diag(buffers, values.as_ref()),
             placement,
-        );
+        )?;
         let vectors = tensor_from_vec_with_template(
             vec![n, n],
-            $vec_from_mat(buffers, vectors.as_ref()),
+            $vec_from_mat(buffers, vectors.as_ref())?,
             placement,
-        );
+        )?;
 
         Ok(vec![values, vectors])
     }
@@ -2805,7 +2819,7 @@ pub(crate) fn cholesky<T: FaerLinalg>(
             matrix_with_batch_shape(n, n, batch_shape),
             Vec::new(),
             input.placement(),
-        ));
+        )?);
     }
     batched_single("cholesky", buffers, input, 2, |buffers, batch| {
         T::cholesky_2d(ctx, buffers, batch)
@@ -2826,22 +2840,22 @@ pub(crate) fn lu<T: FaerLinalg>(
                 matrix_with_batch_shape(m, m, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(k, n, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
             tensor_from_vec_with_template(
                 batch_shape.to_vec(),
                 vec![T::parity_one(); parity_elements],
                 input.placement(),
-            ),
+            )?,
         ]);
     }
     batched_multi_result("lu", buffers, input, 2, |buffers, batch| {
@@ -2859,17 +2873,17 @@ pub(crate) fn lu_factor<T: FaerLinalg>(
         let k = m.min(n);
         let parity_len = batch_count("lu_factor", batch_shape)?;
         return Ok((
-            tensor_from_vec_with_template(input.shape().to_vec(), Vec::new(), input.placement()),
+            tensor_from_vec_with_template(input.shape().to_vec(), Vec::new(), input.placement())?,
             tensor_from_vec_with_template(
                 vector_with_batch_shape(k, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
             tensor_from_vec_with_template(
                 batch_shape.to_vec(),
                 vec![T::parity_one(); parity_len],
                 input.placement(),
-            ),
+            )?,
         ));
     }
 
@@ -2893,12 +2907,12 @@ pub(crate) fn lu_factor<T: FaerLinalg>(
         vec![m, n],
         &input.host_data()?[first_range],
         input.placement(),
-    );
+    )?;
 
     for batch in 0..batch_total {
         if batch > 0 {
             let range = checked_slice_range("lu_factor", batch, matrix_len)?;
-            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[range]);
+            refill_tensor_from_slice(&mut batch_input, &input.host_data()?[range])?;
         }
         let (packed, pivots, parity) = T::lu_factor_2d(ctx, buffers, &batch_input)?;
         lu_data.extend_from_slice(packed.host_data()?);
@@ -2907,13 +2921,13 @@ pub(crate) fn lu_factor<T: FaerLinalg>(
     }
 
     Ok((
-        tensor_from_vec_with_template(input.shape().to_vec(), lu_data, input.placement()),
+        tensor_from_vec_with_template(input.shape().to_vec(), lu_data, input.placement())?,
         tensor_from_vec_with_template(
             vector_with_batch_shape(k, batch_shape),
             pivot_data,
             input.placement(),
-        ),
-        tensor_from_vec_with_template(batch_shape.to_vec(), parity_data, input.placement()),
+        )?,
+        tensor_from_vec_with_template(batch_shape.to_vec(), parity_data, input.placement())?,
     ))
 }
 
@@ -2930,27 +2944,27 @@ pub(crate) fn full_piv_lu<T: FaerLinalg>(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
             tensor_from_vec_with_template(
                 batch_shape.to_vec(),
                 vec![T::parity_one(); parity_elements],
                 input.placement(),
-            ),
+            )?,
         ]);
     }
     batched_multi_result("full_piv_lu", buffers, input, 2, |buffers, batch| {
@@ -2986,7 +3000,7 @@ pub(crate) fn full_piv_lu_solve<T: FaerLinalg>(
             b.shape().to_vec(),
             Vec::new(),
             b.placement(),
-        ));
+        )?);
     }
     batched_binary_result("full_piv_lu_solve", buffers, a, b, 2, 2, |buffers, a, b| {
         T::full_piv_lu_solve_2d(ctx, buffers, a, b, transpose_a)
@@ -3021,7 +3035,7 @@ pub(crate) fn solve<T: FaerLinalg>(
             b.shape().to_vec(),
             Vec::new(),
             b.placement(),
-        ));
+        )?);
     }
     batched_binary_result("solve", buffers, a, b, 2, 2, |buffers, a, b| {
         T::solve_2d(ctx, buffers, a, b, transpose_a)
@@ -3062,7 +3076,7 @@ pub(crate) fn triangular_solve<T: FaerLinalg>(
             b.shape().to_vec(),
             Vec::new(),
             b.placement(),
-        ));
+        )?);
     }
     batched_binary_result("triangular_solve", buffers, a, b, 2, 2, |buffers, a, b| {
         T::triangular_solve_2d(
@@ -3091,17 +3105,17 @@ pub(crate) fn svd<T: FaerLinalg>(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
             tensor_from_vec_with_template(
                 vector_with_batch_shape(k, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(k, n, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
         ]);
     }
     batched_multi_result("svd", buffers, input, 2, |buffers, batch| {
@@ -3121,7 +3135,7 @@ pub(crate) fn svd_values<T: FaerLinalg>(
             vector_with_batch_shape(k, batch_shape),
             Vec::new(),
             input.placement(),
-        ));
+        )?);
     }
     let mut outputs =
         batched_multi_convert_result("svd_values", buffers, input, 2, |buffers, batch| {
@@ -3143,12 +3157,12 @@ pub(crate) fn qr<T: FaerLinalg>(
                 matrix_with_batch_shape(m, k, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(k, n, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
         ]);
     }
     batched_multi_result("qr", buffers, input, 2, |buffers, batch| {
@@ -3168,12 +3182,12 @@ pub(crate) fn eigh<T: FaerLinalg>(
                 vector_with_batch_shape(n, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
             tensor_from_vec_with_template(
                 matrix_with_batch_shape(n, n, batch_shape),
                 Vec::new(),
                 input.placement(),
-            ),
+            )?,
         ]);
     }
     batched_multi_result("eigh", buffers, input, 2, |buffers, batch| {
@@ -3192,7 +3206,7 @@ pub(crate) fn eigh_values<T: FaerLinalg>(
             vector_with_batch_shape(n, batch_shape),
             Vec::new(),
             input.placement(),
-        ));
+        )?);
     }
     let mut outputs =
         batched_multi_convert_result("eigh_values", buffers, input, 2, |buffers, batch| {
@@ -3376,11 +3390,11 @@ macro_rules! impl_eig_real_2d {
                 u_real.as_ref(),
                 s_re.as_ref(),
                 s_im.as_ref(),
-            );
+            )?;
 
             Ok(vec![
-                tensor_from_vec_with_template(vec![n], s, input.placement()),
-                tensor_from_vec_with_template(vec![n, n], u, input.placement()),
+                tensor_from_vec_with_template(vec![n], s, input.placement())?,
+                tensor_from_vec_with_template(vec![n, n], u, input.placement())?,
             ])
         }
     };
@@ -3418,7 +3432,11 @@ macro_rules! impl_eig_values_real_2d {
             .map_err(|_| decomposition_failed("eig_values"))?;
             let s = $real_eig_to_complex_values(buffers, s_re.as_ref(), s_im.as_ref());
 
-            Ok(tensor_from_vec_with_template(vec![n], s, input.placement()))
+            Ok(tensor_from_vec_with_template(
+                vec![n],
+                s,
+                input.placement(),
+            )?)
         }
     };
 }
@@ -3465,12 +3483,12 @@ macro_rules! impl_eig_complex_2d {
                     vec![n],
                     $vec_from_diag(buffers, s.as_ref()),
                     input.placement(),
-                ),
+                )?,
                 tensor_from_vec_with_template(
                     vec![n, n],
-                    $vec_from_mat(buffers, u.as_ref()),
+                    $vec_from_mat(buffers, u.as_ref())?,
                     input.placement(),
-                ),
+                )?,
             ])
         }
     };
@@ -3515,7 +3533,7 @@ macro_rules! impl_eig_values_complex_2d {
                 vec![n],
                 $vec_from_diag(buffers, s.as_ref()),
                 input.placement(),
-            ))
+            )?)
         }
     };
 }
@@ -3730,3 +3748,7 @@ fn vector_with_batch_shape(len: usize, batch_shape: &[usize]) -> Vec<usize> {
     shape.extend_from_slice(batch_shape);
     shape
 }
+
+#[cfg(test)]
+#[path = "faer_linalg/tests.rs"]
+mod tests;

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg/tests.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg/tests.rs
@@ -1,0 +1,15 @@
+use super::checked_product;
+
+#[test]
+fn checked_matrix_element_count_reports_typed_overflow() {
+    let err = checked_product("test_faer_allocation", "matrix", &[usize::MAX, 2])
+        .expect_err("overflowing matrix dimensions must fail");
+
+    assert!(matches!(
+        err,
+        tenferro_tensor::Error::InvalidConfig {
+            op: "test_faer_allocation",
+            ..
+        }
+    ));
+}

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/cholesky.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/cholesky.rs
@@ -69,7 +69,11 @@ fn cholesky_2d<T: LapackCholesky>(
         ));
     }
     check_lapack_info("cholesky", "dpotrf", info)?;
-    tensor_from_vec_with_template(vec![n, n], lower_triangle_from_lapack(&factor, n, n), input)
+    tensor_from_vec_with_template(
+        vec![n, n],
+        lower_triangle_from_lapack(&factor, n, n)?,
+        input,
+    )
 }
 
 pub(crate) fn cholesky<T: LapackCholesky>(

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eig.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eig.rs
@@ -4,8 +4,9 @@ use tenferro_cpu::linalg_interop::BufferPool;
 use tenferro_tensor::{Tensor, TypedTensor};
 
 use super::helpers::{
-    batched_multi_convert, check_lapack_info, dim_i32, has_zero_dim, square_matrix_dim,
-    tensor_from_vec_with_template, vector_with_batch_shape, work_len, zero_dim_eig_outputs,
+    batched_multi_convert, check_lapack_info, checked_product, dim_i32, has_zero_dim,
+    square_matrix_dim, tensor_from_vec_with_template, vector_with_batch_shape, work_len,
+    zero_dim_eig_outputs,
 };
 
 fn eig_imag_is_effectively_zero(real: f64, imag: f64, eps: f64) -> bool {
@@ -19,8 +20,9 @@ macro_rules! impl_real_eig_to_complex_outputs {
             s_re: &[$real],
             s_im: &[$real],
             n: usize,
-        ) -> (Vec<$complex>, Vec<$complex>) {
-            let mut vectors = vec![<$complex>::new(0.0, 0.0); n * n];
+        ) -> tenferro_tensor::Result<(Vec<$complex>, Vec<$complex>)> {
+            let vector_len = checked_product("eig", "eigenvector matrix", &[n, n])?;
+            let mut vectors = vec![<$complex>::new(0.0, 0.0); vector_len];
             let mut values = vec![<$complex>::new(0.0, 0.0); n];
             let mut col = 0;
             while col < n {
@@ -48,7 +50,7 @@ macro_rules! impl_real_eig_to_complex_outputs {
                     col += 2;
                 }
             }
-            (vectors, values)
+            Ok((vectors, values))
         }
     };
 }
@@ -82,7 +84,8 @@ macro_rules! impl_eig_real_2d {
             let mut values_re = vec![0.0 as $real; n];
             let mut values_im = vec![0.0 as $real; n];
             let mut vl = vec![0.0 as $real; 1];
-            let mut vectors_real = vec![0.0 as $real; n * n];
+            let vector_len = checked_product("eig", "eigenvector matrix", &[n, n])?;
+            let mut vectors_real = vec![0.0 as $real; vector_len];
             let mut query = vec![0.0 as $real; 1];
             let mut info = 0;
             // SAFETY: all matrix/vector buffers match the validated `n x n`
@@ -129,7 +132,7 @@ macro_rules! impl_eig_real_2d {
                 );
             }
             check_lapack_info("eig", $routine, info)?;
-            let (vectors, values) = $convert(&vectors_real, &values_re, &values_im, n);
+            let (vectors, values) = $convert(&vectors_real, &values_re, &values_im, n)?;
 
             Ok(vec![
                 tensor_from_vec_with_template(vec![n], values, input)?,
@@ -216,9 +219,11 @@ macro_rules! impl_eig_complex_2d {
             let mut a = input.host_data()?.to_vec();
             let mut values = vec![<$complex>::new(0.0, 0.0); n];
             let mut vl = vec![<$complex>::new(0.0, 0.0); 1];
-            let mut vectors = vec![<$complex>::new(0.0, 0.0); n * n];
+            let vector_len = checked_product("eig", "eigenvector matrix", &[n, n])?;
+            let mut vectors = vec![<$complex>::new(0.0, 0.0); vector_len];
             let mut query = vec![<$complex>::new(0.0, 0.0); 1];
-            let mut rwork = vec![0.0 as $real; 2 * n.max(1)];
+            let rwork_len = checked_product("eig", "real workspace", &[2, n.max(1)])?;
+            let mut rwork = vec![0.0 as $real; rwork_len];
             let mut info = 0;
             // SAFETY: all complex matrix/vector buffers and real workspace
             // match the validated `n x n` problem; `lwork = -1` queries workspace.
@@ -286,7 +291,8 @@ macro_rules! impl_eig_values_complex_2d {
             let mut vl = vec![<$complex>::new(0.0, 0.0); 1];
             let mut vr = vec![<$complex>::new(0.0, 0.0); 1];
             let mut query = vec![<$complex>::new(0.0, 0.0); 1];
-            let mut rwork = vec![0.0 as $real; 2 * n.max(1)];
+            let rwork_len = checked_product("eig_values", "real workspace", &[2, n.max(1)])?;
+            let mut rwork = vec![0.0 as $real; rwork_len];
             let mut info = 0;
             // SAFETY: all complex matrix/vector buffers and real workspace
             // match the validated `n x n` problem; `lwork = -1` queries workspace.

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eigh.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eigh.rs
@@ -4,8 +4,8 @@ use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar};
 use tenferro_tensor::TypedTensor;
 
 use super::helpers::{
-    batched_multi, batched_multi_convert, check_lapack_info, dim_i32, has_zero_dim,
-    matrix_with_batch_shape, square_core_and_batch_result, square_matrix_dim,
+    batched_multi, batched_multi_convert, check_lapack_info, checked_product, dim_i32,
+    has_zero_dim, matrix_with_batch_shape, square_core_and_batch_result, square_matrix_dim,
     tensor_from_vec_with_template, vector_with_batch_shape, work_len,
 };
 
@@ -198,7 +198,11 @@ macro_rules! impl_complex_eigh {
                 let mut vectors = input.host_data()?.to_vec();
                 let mut values = vec![0.0 as $real; n];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
-                let mut rwork = vec![0.0 as $real; (3 * n).saturating_sub(2).max(1)];
+                let rwork_len = checked_product("eigh", "real workspace", &[3, n])?
+                    .checked_sub(2)
+                    .unwrap_or(1)
+                    .max(1);
+                let mut rwork = vec![0.0 as $real; rwork_len];
                 let mut info = 0;
                 // SAFETY: `vectors`, `values`, and `rwork` satisfy LAPACK's
                 // Hermitian eigensolver dimensions; `lwork = -1` writes only `query`.
@@ -259,7 +263,11 @@ macro_rules! impl_complex_eigh {
                 let mut work_matrix = input.host_data()?.to_vec();
                 let mut values = vec![0.0 as $real; n];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
-                let mut rwork = vec![0.0 as $real; (3 * n).saturating_sub(2).max(1)];
+                let rwork_len = checked_product("eigh_values", "real workspace", &[3, n])?
+                    .checked_sub(2)
+                    .unwrap_or(1)
+                    .max(1);
+                let mut rwork = vec![0.0 as $real; rwork_len];
                 let mut info = 0;
                 // SAFETY: `work_matrix`, `values`, and `rwork` satisfy LAPACK's
                 // Hermitian eigensolver dimensions; `lwork = -1` writes only `query`.

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
@@ -473,11 +473,11 @@ fn full_piv_lu_2d<T: LapackFullPivLu>(
     let col_perm = permutation_from_lapack_pivots(&jpiv, "full_piv_lu")?;
     let p_data = permutation_matrix::<T>(&row_perm);
     let q_data = permutation_matrix::<T>(&col_perm);
-    let mut l_data = lower_triangle_from_lapack(&lu, n, n);
+    let mut l_data = lower_triangle_from_lapack(&lu, n, n)?;
     for index in 0..n {
         l_data[index + index * n] = T::one();
     }
-    let u_data = leading_upper_triangle_from_lapack(&lu, n, n, n);
+    let u_data = leading_upper_triangle_from_lapack(&lu, n, n, n)?;
     let row_swap_count = ipiv
         .iter()
         .enumerate()

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
@@ -4,10 +4,11 @@ use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar};
 use tenferro_tensor::TypedTensor;
 
 use super::helpers::{
-    batch_element_count, batched_binary_result, check_lapack_info, dim_i32, has_zero_dim,
-    leading_upper_triangle_from_lapack, lower_triangle_from_lapack, matrix_core_and_batch_result,
-    matrix_dims, matrix_with_batch_shape, square_core_and_batch_result, square_matrix_dim,
-    tensor_from_vec_with_template, transpose_col_major_data,
+    batch_element_count, batched_binary_result, check_lapack_info, checked_product, dim_i32,
+    has_zero_dim, leading_upper_triangle_from_lapack, lower_triangle_from_lapack,
+    matrix_core_and_batch_result, matrix_dims, matrix_with_batch_shape,
+    square_core_and_batch_result, square_matrix_dim, tensor_from_vec_with_template,
+    transpose_col_major_data,
 };
 
 extern "C" {
@@ -432,13 +433,16 @@ fn permutation_from_lapack_pivots(
     Ok(permutation)
 }
 
-fn permutation_matrix<T: LapackFullPivLu>(permutation: &[usize]) -> Vec<T> {
+fn permutation_matrix<T: LapackFullPivLu>(
+    permutation: &[usize],
+) -> tenferro_tensor::Result<Vec<T>> {
     let n = permutation.len();
-    let mut data = vec![T::default(); n * n];
+    let len = checked_product("full_piv_lu", "permutation matrix", &[n, n])?;
+    let mut data = vec![T::default(); len];
     for (row, &source) in permutation.iter().enumerate() {
         data[row + source * n] = T::one();
     }
-    data
+    Ok(data)
 }
 
 fn factor_getc2<T: LapackFullPivLu>(
@@ -471,8 +475,8 @@ fn full_piv_lu_2d<T: LapackFullPivLu>(
 
     let row_perm = permutation_from_lapack_pivots(&ipiv, "full_piv_lu")?;
     let col_perm = permutation_from_lapack_pivots(&jpiv, "full_piv_lu")?;
-    let p_data = permutation_matrix::<T>(&row_perm);
-    let q_data = permutation_matrix::<T>(&col_perm);
+    let p_data = permutation_matrix::<T>(&row_perm)?;
+    let q_data = permutation_matrix::<T>(&col_perm)?;
     let mut l_data = lower_triangle_from_lapack(&lu, n, n)?;
     for index in 0..n {
         l_data[index + index * n] = T::one();

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/helpers.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/helpers.rs
@@ -3,6 +3,10 @@ use std::ops::Range;
 use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar};
 use tenferro_tensor::{Tensor, TypedTensor};
 
+#[cfg(test)]
+#[path = "helpers/tests.rs"]
+mod tests;
+
 pub(crate) fn matrix_dims<T>(
     input: &TypedTensor<T>,
     op: &'static str,
@@ -230,14 +234,15 @@ pub(crate) fn lower_triangle_from_lapack<T: Copy + Default>(
     data: &[T],
     rows: usize,
     cols: usize,
-) -> Vec<T> {
-    let mut out = vec![T::default(); rows * cols];
+) -> tenferro_tensor::Result<Vec<T>> {
+    let len = checked_product("lapack_linalg", "lower triangle", &[rows, cols])?;
+    let mut out = vec![T::default(); len];
     for col in 0..cols {
         for row in col..rows {
             out[row + col * rows] = data[row + col * rows];
         }
     }
-    out
+    Ok(out)
 }
 
 pub(crate) fn leading_upper_triangle_from_lapack<T: Copy + Default>(
@@ -245,14 +250,15 @@ pub(crate) fn leading_upper_triangle_from_lapack<T: Copy + Default>(
     source_rows: usize,
     rows: usize,
     cols: usize,
-) -> Vec<T> {
-    let mut out = vec![T::default(); rows * cols];
+) -> tenferro_tensor::Result<Vec<T>> {
+    let len = checked_product("lapack_linalg", "upper triangle", &[rows, cols])?;
+    let mut out = vec![T::default(); len];
     for col in 0..cols {
         for row in 0..rows.min(col + 1) {
             out[row + col * rows] = data[row + col * source_rows];
         }
     }
-    out
+    Ok(out)
 }
 
 pub(crate) fn transpose_col_major_data<T: Copy>(data: &[T], rows: usize, cols: usize) -> Vec<T> {

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/helpers/tests.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/helpers/tests.rs
@@ -1,0 +1,15 @@
+use super::checked_product;
+
+#[test]
+fn checked_matrix_element_count_reports_typed_overflow() {
+    let err = checked_product("test_lapack_allocation", "matrix", &[usize::MAX, 2])
+        .expect_err("overflowing matrix dimensions must fail");
+
+    assert!(matches!(
+        err,
+        tenferro_tensor::Error::InvalidConfig {
+            op: "test_lapack_allocation",
+            ..
+        }
+    ));
+}

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs
@@ -143,7 +143,7 @@ fn lu_2d<T: LapackLu>(
         }
         l_data[col + col * m] = T::one();
     }
-    let u_data = leading_upper_triangle_from_lapack(&lu, m, k, n);
+    let u_data = leading_upper_triangle_from_lapack(&lu, m, k, n)?;
 
     Ok(vec![
         tensor_from_vec_with_template(vec![m, m], p_data, input)?,

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs
@@ -126,7 +126,8 @@ fn lu_2d<T: LapackLu>(
         }
     }
 
-    let mut p_data = vec![T::default(); m * m];
+    let p_len = checked_product("lu", "permutation matrix", &[m, m])?;
+    let mut p_data = vec![T::default(); p_len];
     for (row, &source_row) in permutation.iter().enumerate() {
         p_data[row + source_row * m] = T::one();
     }
@@ -136,7 +137,8 @@ fn lu_2d<T: LapackLu>(
         T::negative_one()
     };
 
-    let mut l_data = vec![T::default(); m * k];
+    let l_len = checked_product("lu", "lower factor", &[m, k])?;
+    let mut l_data = vec![T::default(); l_len];
     for col in 0..k {
         for row in col..m {
             l_data[row + col * m] = lu[row + col * m];

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr.rs
@@ -4,9 +4,9 @@ use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar};
 use tenferro_tensor::TypedTensor;
 
 use super::helpers::{
-    batched_multi, check_lapack_info, dim_i32, has_zero_dim, leading_upper_triangle_from_lapack,
-    matrix_dims, matrix_with_batch_shape, split_core_and_batch_result,
-    tensor_from_vec_with_template, work_len,
+    batched_multi, check_lapack_info, checked_product, dim_i32, has_zero_dim,
+    leading_upper_triangle_from_lapack, matrix_dims, matrix_with_batch_shape,
+    split_core_and_batch_result, tensor_from_vec_with_template, work_len,
 };
 
 pub(crate) trait LapackQr: Clone + Copy + Default + PoolScalar {
@@ -53,7 +53,8 @@ macro_rules! impl_real_qr {
                 check_lapack_info("qr", $geqrf_name, info)?;
 
                 let r = leading_upper_triangle_from_lapack(&qr, m, k, n)?;
-                let mut q = Vec::with_capacity(m * k);
+                let q_len = checked_product("qr", "Q matrix", &[m, k])?;
+                let mut q = Vec::with_capacity(q_len);
                 for col in 0..k {
                     let start = col * m;
                     q.extend_from_slice(&qr[start..start + m]);
@@ -125,7 +126,8 @@ macro_rules! impl_complex_qr {
                 check_lapack_info("qr", $geqrf_name, info)?;
 
                 let r = leading_upper_triangle_from_lapack(&qr, m, k, n)?;
-                let mut q = Vec::with_capacity(m * k);
+                let q_len = checked_product("qr", "Q matrix", &[m, k])?;
+                let mut q = Vec::with_capacity(q_len);
                 for col in 0..k {
                     let start = col * m;
                     q.extend_from_slice(&qr[start..start + m]);

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/qr.rs
@@ -52,7 +52,7 @@ macro_rules! impl_real_qr {
                 }
                 check_lapack_info("qr", $geqrf_name, info)?;
 
-                let r = leading_upper_triangle_from_lapack(&qr, m, k, n);
+                let r = leading_upper_triangle_from_lapack(&qr, m, k, n)?;
                 let mut q = Vec::with_capacity(m * k);
                 for col in 0..k {
                     let start = col * m;
@@ -124,7 +124,7 @@ macro_rules! impl_complex_qr {
                 }
                 check_lapack_info("qr", $geqrf_name, info)?;
 
-                let r = leading_upper_triangle_from_lapack(&qr, m, k, n);
+                let r = leading_upper_triangle_from_lapack(&qr, m, k, n)?;
                 let mut q = Vec::with_capacity(m * k);
                 for col in 0..k {
                     let start = col * m;

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
@@ -4,9 +4,9 @@ use tenferro_cpu::linalg_interop::{BufferPool, PoolScalar};
 use tenferro_tensor::TypedTensor;
 
 use super::helpers::{
-    batched_multi, batched_multi_convert, check_lapack_info, dim_i32, has_zero_dim, matrix_dims,
-    matrix_with_batch_shape, split_core_and_batch_result, tensor_from_vec_with_template,
-    vector_with_batch_shape, work_len,
+    batched_multi, batched_multi_convert, check_lapack_info, checked_product, dim_i32,
+    has_zero_dim, matrix_dims, matrix_with_batch_shape, split_core_and_batch_result,
+    tensor_from_vec_with_template, vector_with_batch_shape, work_len,
 };
 
 pub(crate) trait LapackSvd: Clone + Copy + Default + PoolScalar {
@@ -23,21 +23,40 @@ pub(crate) trait LapackSvd: Clone + Copy + Default + PoolScalar {
 }
 
 #[cfg(not(feature = "provider-inject"))]
-fn gesdd_iwork_len(k: usize) -> usize {
-    8 * k.max(1)
+fn gesdd_iwork_len(k: usize) -> tenferro_tensor::Result<usize> {
+    checked_product("svd", "integer workspace", &[8, k.max(1)])
 }
 
 #[cfg(not(feature = "provider-inject"))]
-fn complex_gesdd_rwork_len(jobz: u8, m: usize, n: usize) -> usize {
+fn complex_gesdd_rwork_len(jobz: u8, m: usize, n: usize) -> tenferro_tensor::Result<usize> {
     let mn = m.min(n);
     let mx = m.max(n);
     if jobz == b'N' {
-        return 5 * mn.max(1);
+        return checked_product("svd", "real workspace", &[5, mn.max(1)]);
     }
-    if mx > 10 * mn {
-        return 5 * mn * mn + 5 * mn;
+    let threshold = checked_product("svd", "workspace crossover", &[10, mn])?;
+    let square_term = checked_product("svd", "real workspace square term", &[5, mn, mn])?;
+    let linear_term = checked_product("svd", "real workspace linear term", &[5, mn])?;
+    let small_shape_len = square_term.checked_add(linear_term).ok_or_else(|| {
+        tenferro_tensor::Error::InvalidConfig {
+            op: "svd",
+            message: "real workspace length overflow".into(),
+        }
+    })?;
+    if mx > threshold {
+        return Ok(small_shape_len);
     }
-    (5 * mn * mn + 5 * mn).max(2 * mx * mn + 2 * mn * mn + mn)
+    let rectangular_term = checked_product("svd", "real workspace rectangular term", &[2, mx, mn])?;
+    let second_square_term =
+        checked_product("svd", "real workspace secondary square term", &[2, mn, mn])?;
+    let large_shape_len = rectangular_term
+        .checked_add(second_square_term)
+        .and_then(|len| len.checked_add(mn))
+        .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
+            op: "svd",
+            message: "real workspace length overflow".into(),
+        })?;
+    Ok(small_shape_len.max(large_shape_len))
 }
 
 #[cfg(feature = "provider-inject")]
@@ -58,8 +77,10 @@ macro_rules! impl_real_svd {
 
                 let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $scalar; k];
-                let mut u = vec![0.0 as $scalar; m * k];
-                let mut vt = vec![0.0 as $scalar; k * n];
+                let u_len = checked_product("svd", "left singular vectors", &[m, k])?;
+                let mut u = vec![0.0 as $scalar; u_len];
+                let vt_len = checked_product("svd", "right singular vectors", &[k, n])?;
+                let mut vt = vec![0.0 as $scalar; vt_len];
                 let mut query = vec![0.0 as $scalar; 1];
                 let mut info = 0;
                 // SAFETY: `a`, `s`, `u`, and `vt` match the validated SVD
@@ -172,10 +193,12 @@ macro_rules! impl_real_svd {
 
                 let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $scalar; k];
-                let mut u = vec![0.0 as $scalar; m * k];
-                let mut vt = vec![0.0 as $scalar; k * n];
+                let u_len = checked_product("svd", "left singular vectors", &[m, k])?;
+                let mut u = vec![0.0 as $scalar; u_len];
+                let vt_len = checked_product("svd", "right singular vectors", &[k, n])?;
+                let mut vt = vec![0.0 as $scalar; vt_len];
                 let mut query = vec![0.0 as $scalar; 1];
-                let mut iwork = vec![0; gesdd_iwork_len(k)];
+                let mut iwork = vec![0; gesdd_iwork_len(k)?];
                 let mut info = 0;
                 // SAFETY: `a`, `s`, `u`, and `vt` match the validated SVD
                 // dimensions, and `lwork = -1` makes `query` the workspace output.
@@ -217,7 +240,7 @@ macro_rules! impl_real_svd {
                 let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $scalar; k];
                 let mut query = vec![0.0 as $scalar; 1];
-                let mut iwork = vec![0; gesdd_iwork_len(k)];
+                let mut iwork = vec![0; gesdd_iwork_len(k)?];
                 let mut info = 0;
                 // SAFETY: `a` and `s` match the validated SVD dimensions;
                 // no-vector mode ignores the dummy U/VT buffers, and `lwork = -1` queries workspace.
@@ -288,10 +311,13 @@ macro_rules! impl_complex_svd {
 
                 let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $real; k];
-                let mut u = vec![<$complex>::new(0.0, 0.0); m * k];
-                let mut vt = vec![<$complex>::new(0.0, 0.0); k * n];
+                let u_len = checked_product("svd", "left singular vectors", &[m, k])?;
+                let mut u = vec![<$complex>::new(0.0, 0.0); u_len];
+                let vt_len = checked_product("svd", "right singular vectors", &[k, n])?;
+                let mut vt = vec![<$complex>::new(0.0, 0.0); vt_len];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
-                let mut rwork = vec![0.0 as $real; 5 * k.max(1)];
+                let rwork_len = checked_product("svd", "real workspace", &[5, k.max(1)])?;
+                let mut rwork = vec![0.0 as $real; rwork_len];
                 let mut info = 0;
                 // SAFETY: `a`, `s`, `u`, `vt`, and `rwork` match the
                 // validated complex SVD dimensions; `lwork = -1` queries workspace.
@@ -339,7 +365,8 @@ macro_rules! impl_complex_svd {
                 let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $real; k];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
-                let mut rwork = vec![0.0 as $real; 5 * k.max(1)];
+                let rwork_len = checked_product("svd", "real workspace", &[5, k.max(1)])?;
+                let mut rwork = vec![0.0 as $real; rwork_len];
                 let mut info = 0;
                 // SAFETY: `a`, `s`, and `rwork` match the validated complex
                 // SVD dimensions; no-vector mode ignores dummy U/VT buffers, and `lwork = -1` queries workspace.
@@ -412,11 +439,13 @@ macro_rules! impl_complex_svd {
 
                 let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $real; k];
-                let mut u = vec![<$complex>::new(0.0, 0.0); m * k];
-                let mut vt = vec![<$complex>::new(0.0, 0.0); k * n];
+                let u_len = checked_product("svd", "left singular vectors", &[m, k])?;
+                let mut u = vec![<$complex>::new(0.0, 0.0); u_len];
+                let vt_len = checked_product("svd", "right singular vectors", &[k, n])?;
+                let mut vt = vec![<$complex>::new(0.0, 0.0); vt_len];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
-                let mut rwork = vec![0.0 as $real; complex_gesdd_rwork_len(b'S', m, n)];
-                let mut iwork = vec![0; gesdd_iwork_len(k)];
+                let mut rwork = vec![0.0 as $real; complex_gesdd_rwork_len(b'S', m, n)?];
+                let mut iwork = vec![0; gesdd_iwork_len(k)?];
                 let mut info = 0;
                 // SAFETY: `a`, `s`, `u`, `vt`, and `rwork` match the
                 // validated complex SVD dimensions; `lwork = -1` queries workspace.
@@ -464,8 +493,8 @@ macro_rules! impl_complex_svd {
                 let mut a = input.host_data()?.to_vec();
                 let mut s = vec![0.0 as $real; k];
                 let mut query = vec![<$complex>::new(0.0, 0.0); 1];
-                let mut rwork = vec![0.0 as $real; complex_gesdd_rwork_len(b'N', m, n)];
-                let mut iwork = vec![0; gesdd_iwork_len(k)];
+                let mut rwork = vec![0.0 as $real; complex_gesdd_rwork_len(b'N', m, n)?];
+                let mut iwork = vec![0; gesdd_iwork_len(k)?];
                 let mut info = 0;
                 // SAFETY: `a`, `s`, and `rwork` match the validated complex
                 // SVD dimensions; no-vector mode ignores dummy U/VT buffers, and `lwork = -1` queries workspace.

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -535,9 +535,9 @@ pub fn slogdet(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
         _ => return Err(unexpected_output_count("lu_factor", 3)),
     };
     let diag_u = packed_lu.extract_diag(0, 1)?;
-    let sign_u = diag_u.sign().reduce_prod(&[0])?;
+    let sign_u = diag_u.sign()?.reduce_prod(&[0])?;
     let sign = (&parity * &sign_u)?;
-    let logabsdet = diag_u.abs().log().reduce_sum(&[0])?;
+    let logabsdet = diag_u.abs()?.log()?.reduce_sum(&[0])?;
     Ok((sign, logabsdet))
 }
 
@@ -555,7 +555,7 @@ pub fn slogdet(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
 /// ```
 pub fn det(a: &TracedTensor) -> Result<TracedTensor> {
     let (sign, logabsdet) = slogdet(a)?;
-    &sign * &logabsdet.exp()
+    &sign * &logabsdet.exp()?
 }
 
 /// Build a traced matrix inverse op.
@@ -654,7 +654,7 @@ pub fn pinv_with_rtol(a: &TracedTensor, rtol: f64) -> Result<TracedTensor> {
     ensure_float_or_complex("pinv_with_rtol", a.dtype)?;
     require_concrete_shape("pinv_with_rtol", a)?;
     let (u, s, vt) = svd(a)?;
-    let abs_s = s.abs();
+    let abs_s = s.abs()?;
     let s_max = abs_s.reduce_max(&[0])?;
     let s_max_shape = s_max.concrete_shape()?;
     let threshold_scalar = broadcast_scalar(scalar_real(s.dtype, rtol.max(0.0))?, &s_max_shape)?;
@@ -664,11 +664,12 @@ pub fn pinv_with_rtol(a: &TracedTensor, rtol: f64) -> Result<TracedTensor> {
     let mask = abs_s.compare(&threshold, CompareDir::Gt)?;
     let mask = mask.convert(s.dtype)?;
     let ones = ones_like(&s)?;
-    let denom = (&s + &(&ones + &(-&mask))?)?;
+    let neg_mask = (-&mask)?;
+    let denom = (&s + &(&ones + &neg_mask)?)?;
     let s_inv = (&mask / &denom)?;
 
-    let v = vt.conj().transpose(&matrix_transpose_perm(vt.rank))?;
-    let uh = u.conj().transpose(&matrix_transpose_perm(u.rank))?;
+    let v = vt.conj()?.transpose(&matrix_transpose_perm(vt.rank))?;
+    let uh = u.conj()?.transpose(&matrix_transpose_perm(u.rank))?;
     let vs = scale_matrix_columns(&v, &s_inv)?;
     matmul_preserve_trailing_batch(&vs, &uh)
 }
@@ -706,7 +707,7 @@ pub fn norm(
         1 => vector_norm(a, axes[0], ord)?,
         2 => matrix_norm(a, &axes, ord)?,
         _ => {
-            let abs = a.abs();
+            let abs = a.abs()?;
             match ord {
                 None => frobenius_norm(&abs, &axes)?,
                 Some(p) if p == f64::INFINITY => abs.reduce_max(&axes)?,
@@ -917,7 +918,7 @@ fn matrix_transpose_perm(rank: usize) -> Vec<usize> {
 
 fn frobenius_norm(abs: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
     let squared = abs.pow(&scalar_real(abs.dtype, 2.0)?)?;
-    Ok(squared.reduce_sum(axes)?.sqrt())
+    Ok(squared.reduce_sum(axes)?.sqrt()?)
 }
 
 fn p_norm(abs: &TracedTensor, axes: &[usize], p: f64) -> Result<TracedTensor> {
@@ -942,7 +943,7 @@ fn default_pinv_rtol(dtype: DType, max_dim: usize) -> f64 {
 }
 
 fn vector_norm(a: &TracedTensor, axis: usize, ord: Option<f64>) -> Result<TracedTensor> {
-    let abs = a.abs();
+    let abs = a.abs()?;
     match ord {
         None => frobenius_norm(&abs, &[axis]),
         Some(0.0) => count_nonzero(&abs, &[axis]),
@@ -954,7 +955,7 @@ fn vector_norm(a: &TracedTensor, axis: usize, ord: Option<f64>) -> Result<Traced
 
 fn matrix_norm(a: &TracedTensor, axes: &[usize], ord: Option<f64>) -> Result<TracedTensor> {
     let matrix = move_axes_to_front(a, axes)?;
-    let abs = matrix.abs();
+    let abs = matrix.abs()?;
     match ord {
         None => frobenius_norm(&abs, &[0, 1]),
         Some(p) if p == f64::INFINITY => matrix_row_sum_norm(&abs, true),
@@ -962,11 +963,11 @@ fn matrix_norm(a: &TracedTensor, axes: &[usize], ord: Option<f64>) -> Result<Tra
         Some(1.0) => matrix_col_sum_norm(&abs, true),
         Some(-1.0) => matrix_col_sum_norm(&abs, false),
         Some(2.0) => {
-            let singular_values = svd_values(&matrix)?.abs();
+            let singular_values = svd_values(&matrix)?.abs()?;
             singular_values.reduce_max(&[0])
         }
         Some(-2.0) => {
-            let singular_values = svd_values(&matrix)?.abs();
+            let singular_values = svd_values(&matrix)?.abs()?;
             singular_values.reduce_min(&[0])
         }
         Some(0.0) => count_nonzero(&abs, &[0, 1]),
@@ -1094,7 +1095,7 @@ mod tests {
     #[test]
     fn p_norm_rejects_zero_and_non_finite_orders() {
         let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-        let abs = x.abs();
+        let abs = x.abs().unwrap();
 
         for p in [0.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
             let err = p_norm(&abs, &[0], p).unwrap_err();

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -918,7 +918,7 @@ fn matrix_transpose_perm(rank: usize) -> Vec<usize> {
 
 fn frobenius_norm(abs: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
     let squared = abs.pow(&scalar_real(abs.dtype, 2.0)?)?;
-    Ok(squared.reduce_sum(axes)?.sqrt()?)
+    squared.reduce_sum(axes)?.sqrt()
 }
 
 fn p_norm(abs: &TracedTensor, axes: &[usize], p: f64) -> Result<TracedTensor> {

--- a/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
@@ -1,5 +1,33 @@
 use std::{fs, path::Path};
 
+fn lapack_production_sources() -> Vec<(String, String)> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("cpu")
+        .join("linalg")
+        .join("lapack_linalg");
+    let mut sources = Vec::new();
+    for entry in fs::read_dir(&root)
+        .unwrap_or_else(|err| panic!("LAPACK source directory should be readable: {err}"))
+    {
+        let path = entry
+            .unwrap_or_else(|err| panic!("LAPACK source entry should be readable: {err}"))
+            .path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_else(|| panic!("LAPACK source path should have a UTF-8 file name"))
+            .to_owned();
+        let source = fs::read_to_string(&path)
+            .unwrap_or_else(|err| panic!("LAPACK source {name} should be readable: {err}"));
+        sources.push((name, source));
+    }
+    sources
+}
+
 fn cpu_lapack_helpers_source() -> String {
     fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -76,6 +104,36 @@ fn cpu_linalg_allocation_helpers_remain_fallible_and_checked() {
             }
         }
     }
+}
+
+#[test]
+fn lapack_shape_derived_allocation_lengths_remain_checked() {
+    let mut violations = Vec::new();
+    for (name, source) in lapack_production_sources() {
+        let lines: Vec<_> = source.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            let allocation_product = (line.contains("vec![")
+                || line.contains("with_capacity(")
+                || line.contains("pool_acquire("))
+                && line.contains(" * ");
+            let unchecked_workspace_formula = line.contains("return 5 * mn * mn")
+                || line.contains("(5 * mn * mn")
+                || line.contains("8 * min_dim")
+                || line.contains("2 * min_dim * min_dim")
+                || line.contains("5 * min_dim * min_dim");
+            if allocation_product || unchecked_workspace_formula {
+                let invariant = index > 0 && lines[index - 1].contains("// INVARIANT:");
+                if !invariant {
+                    violations.push(format!("{name}:{}: {}", index + 1, line.trim()));
+                }
+            }
+        }
+    }
+    assert!(
+        violations.is_empty(),
+        "LAPACK allocation lengths require checked arithmetic:\n{}",
+        violations.join("\n")
+    );
 }
 
 fn cpu_backend_source() -> String {

--- a/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
@@ -59,6 +59,25 @@ fn cpu_faer_linalg_source() -> String {
     .unwrap_or_else(|err| panic!("faer linalg source should be readable: {err}"))
 }
 
+#[test]
+fn cpu_linalg_allocation_helpers_remain_fallible_and_checked() {
+    let faer = cpu_faer_linalg_source();
+    let lapack = cpu_lapack_helpers_source();
+
+    for source in [&faer, &lapack] {
+        let lines: Vec<_> = source.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            if line.contains("rows * cols") || line.contains(".expect(") {
+                let invariant = index > 0 && lines[index - 1].contains("// INVARIANT:");
+                assert!(
+                    invariant,
+                    "linalg helpers must propagate errors and use checked allocation sizes unless the immediately preceding line documents an INVARIANT"
+                );
+            }
+        }
+    }
+}
+
 fn cpu_backend_source() -> String {
     fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/tenferro-runtime/src/graph/compiler.rs
+++ b/crates/tenferro-runtime/src/graph/compiler.rs
@@ -122,7 +122,8 @@ impl GraphCompiler {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// assert_eq!(program.input_count(), 1);
     /// ```
     pub fn compile(&mut self, output: &TracedTensor) -> Result<GraphProgram> {
@@ -137,7 +138,7 @@ impl GraphCompiler {
     /// use tenferro_runtime::{GraphCompiler, TracedTensor};
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
-    /// let y = x.neg();
+    /// let y = x.neg().unwrap();
     /// let mut compiler = GraphCompiler::new();
     /// let program = compiler.compile_many(&[&x, &y]).unwrap();
     /// assert_eq!(program.output_count(), 2);
@@ -169,8 +170,9 @@ impl GraphCompiler {
     ///
     /// let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
     /// let mut compiler = GraphCompiler::new();
+    /// let y = x.neg().unwrap();
     /// let program = compiler
-    ///     .compile_with_input_specs(&x.neg(), &[(&x, DType::F64, &[3])])
+    ///     .compile_with_input_specs(&y, &[(&x, DType::F64, &[3])])
     ///     .unwrap();
     /// assert_eq!(program.input_specs()[0].shape(), &[3]);
     /// ```

--- a/crates/tenferro-runtime/src/graph/compiler.rs
+++ b/crates/tenferro-runtime/src/graph/compiler.rs
@@ -627,8 +627,8 @@ mod tests {
     #[test]
     fn compile_many_rejects_conflicting_default_inputs_for_same_key() {
         let x = TracedTensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
-        let y1 = x.neg();
-        let mut y2 = x.neg();
+        let y1 = x.neg().unwrap();
+        let mut y2 = x.neg().unwrap();
         let key = x.input_key().expect("concrete traced tensor has input key");
         let replacement = Arc::new(Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap());
         let mut inputs = (*y2.inputs_map).clone();

--- a/crates/tenferro-runtime/src/graph/executor.rs
+++ b/crates/tenferro-runtime/src/graph/executor.rs
@@ -108,7 +108,8 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let mut executor = GraphExecutor::new(CpuBackend::new());
     ///
     /// let out = executor.run(&program).unwrap();
@@ -206,7 +207,8 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let mut executor = GraphExecutor::new(CpuBackend::new());
     /// let out = executor.run(&program).unwrap();
     /// assert_eq!(out.as_slice::<f64>().unwrap(), &[-3.0]);
@@ -256,7 +258,7 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
-    /// let y = x.neg();
+    /// let y = x.neg().unwrap();
     /// let mut compiler = GraphCompiler::new();
     /// let program = compiler.compile_many(&[&x, &y]).unwrap();
     /// let mut executor = GraphExecutor::new(CpuBackend::new());
@@ -573,7 +575,8 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let mut executor = GraphExecutor::new(CpuBackend::new());
     /// let out = executor.run(&program).unwrap();
     /// assert_eq!(out.as_slice::<f64>().unwrap(), &[-2.0]);
@@ -639,7 +642,8 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let mut executor = GraphExecutor::new(CpuBackend::new());
     /// let out = executor.run(&program).unwrap();
     /// assert_eq!(out.shape(), &[1]);

--- a/crates/tenferro-runtime/src/graph/lowering_view.rs
+++ b/crates/tenferro-runtime/src/graph/lowering_view.rs
@@ -19,7 +19,8 @@ use crate::exec::{ExecInstruction, ExecOp, ExecProgram};
 ///
 /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
 /// let mut compiler = GraphCompiler::new();
-/// let program = compiler.compile(&x.neg()).unwrap();
+/// let y = x.neg().unwrap();
+/// let program = compiler.compile(&y).unwrap();
 /// let view = program.lowering_view();
 /// assert_eq!(view.output_slots().len(), 1);
 /// ```
@@ -53,7 +54,8 @@ impl<'a> GraphProgramLoweringView<'a> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// assert!(program.lowering_view().slot_count() >= 1);
     /// ```
     pub fn slot_count(&self) -> usize {
@@ -69,7 +71,8 @@ impl<'a> GraphProgramLoweringView<'a> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// assert_eq!(program.lowering_view().input_slots().len(), 1);
     /// ```
     pub fn input_slots(&self) -> &'a [usize] {
@@ -85,7 +88,8 @@ impl<'a> GraphProgramLoweringView<'a> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// assert_eq!(program.lowering_view().output_slots().len(), 1);
     /// ```
     pub fn output_slots(&self) -> &'a [usize] {
@@ -101,7 +105,8 @@ impl<'a> GraphProgramLoweringView<'a> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// assert!(program.lowering_view().instructions().count() >= 1);
     /// ```
     pub fn instructions(&self) -> impl ExactSizeIterator<Item = GraphInstructionView<'a>> + '_ {
@@ -118,7 +123,8 @@ impl<'a> GraphProgramLoweringView<'a> {
 ///
 /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
 /// let mut compiler = GraphCompiler::new();
-/// let program = compiler.compile(&x.neg()).unwrap();
+/// let y = x.neg().unwrap();
+/// let program = compiler.compile(&y).unwrap();
 /// let inst = program.lowering_view().instructions().next().unwrap();
 /// assert_eq!(inst.output_slots().len(), 1);
 /// ```
@@ -152,7 +158,8 @@ impl<'a> GraphInstructionView<'a> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let inst = program.lowering_view().instructions().next().unwrap();
     /// assert!(matches!(inst.op(), GraphOpView::Negate));
     /// ```
@@ -199,7 +206,8 @@ impl<'a> GraphInstructionView<'a> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let inst = program.lowering_view().instructions().next().unwrap();
     /// assert_eq!(inst.op_name(), "Negate");
     /// ```
@@ -234,7 +242,8 @@ impl<'a> GraphInstructionView<'a> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let inst = program.lowering_view().instructions().next().unwrap();
     /// assert_eq!(inst.output_slots().len(), 1);
     /// ```
@@ -251,7 +260,8 @@ impl<'a> GraphInstructionView<'a> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let inst = program.lowering_view().instructions().next().unwrap();
     /// assert_eq!(inst.dtype(), DType::F64);
     /// ```
@@ -270,7 +280,8 @@ impl<'a> GraphInstructionView<'a> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let inst = program.lowering_view().instructions().next().unwrap();
     /// assert_eq!(inst.static_output_shape(0, &[&[1]]).unwrap(), vec![1]);
     /// ```
@@ -331,7 +342,8 @@ impl<'a> GraphInstructionView<'a> {
 ///
 /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
 /// let mut compiler = GraphCompiler::new();
-/// let program = compiler.compile(&x.neg()).unwrap();
+/// let y = x.neg().unwrap();
+/// let program = compiler.compile(&y).unwrap();
 /// let op = program.lowering_view().instructions().next().unwrap().op();
 /// assert!(matches!(op, GraphOpView::Negate));
 /// ```
@@ -443,7 +455,8 @@ impl GraphOpView<'_> {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let op = program.lowering_view().instructions().next().unwrap().op();
     /// assert_eq!(op.name(), "Negate");
     /// ```

--- a/crates/tenferro-runtime/src/graph/program.rs
+++ b/crates/tenferro-runtime/src/graph/program.rs
@@ -40,7 +40,8 @@ impl GraphProgram {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// assert_eq!(program.input_count(), 1);
     /// ```
     #[inline(never)]
@@ -57,7 +58,8 @@ impl GraphProgram {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// assert_eq!(program.output_count(), 1);
     /// ```
     #[inline(never)]
@@ -74,8 +76,9 @@ impl GraphProgram {
     ///
     /// let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
     /// let mut compiler = GraphCompiler::new();
+    /// let y = x.neg().unwrap();
     /// let program = compiler
-    ///     .compile_with_input_specs(&x.neg(), &[(&x, DType::F64, &[4])])
+    ///     .compile_with_input_specs(&y, &[(&x, DType::F64, &[4])])
     ///     .unwrap();
     /// assert_eq!(program.input_specs()[0].shape(), &[4]);
     /// ```
@@ -96,7 +99,8 @@ impl GraphProgram {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// assert_eq!(program.lowering_view().output_slots().len(), 1);
     /// ```
     #[inline(never)]
@@ -114,7 +118,8 @@ impl GraphProgram {
 ///
 /// let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
 /// let mut compiler = GraphCompiler::new();
-/// let program = compiler.compile(&x.neg()).unwrap();
+/// let y = x.neg().unwrap();
+/// let program = compiler.compile(&y).unwrap();
 /// let input = &program.input_specs()[0];
 /// assert_eq!(input.shape(), &[2]);
 /// ```

--- a/crates/tenferro-runtime/src/scalar_semantics.rs
+++ b/crates/tenferro-runtime/src/scalar_semantics.rs
@@ -40,9 +40,26 @@ pub(crate) fn bool_from_real_for_op(op: &'static str, value: f64) -> Result<bool
 }
 
 pub fn dynamic_truncate_size(size_tensor: &Tensor, axis_extent: usize) -> Result<usize> {
+    if !size_tensor.shape().is_empty() {
+        return Err(Error::Internal(format!(
+            "DynamicTruncate size must be an f32, f64, or i64 scalar, got shape {:?}",
+            size_tensor.shape()
+        )));
+    }
+    if let Tensor::I64(inner) = size_tensor {
+        let value = scalar_host_value(inner.host_data()?, DType::I64)?;
+        return Ok(truncate_i64_size(value, axis_extent));
+    }
     let value = scalar_size_value(size_tensor)?;
     let rounded = finite_real_scalar("DynamicTruncate", value)?.round();
     Ok(rounded.max(0.0).min(axis_extent as f64) as usize)
+}
+
+fn truncate_i64_size(value: i64, axis_extent: usize) -> usize {
+    if value <= 0 {
+        return 0;
+    }
+    usize::try_from(value).map_or(axis_extent, |value| value.min(axis_extent))
 }
 
 fn scalar_size_value(size_tensor: &Tensor) -> Result<f64> {
@@ -56,7 +73,6 @@ fn scalar_size_value(size_tensor: &Tensor) -> Result<f64> {
     match size_tensor {
         Tensor::F64(inner) => scalar_host_value(inner.host_data()?, DType::F64),
         Tensor::F32(inner) => Ok(scalar_host_value(inner.host_data()?, DType::F32)? as f64),
-        Tensor::I64(inner) => Ok(scalar_host_value(inner.host_data()?, DType::I64)? as f64),
         _ => Err(Error::Internal(
             "DynamicTruncate size must be an f32, f64, or i64 scalar".into(),
         )),
@@ -75,7 +91,7 @@ fn scalar_host_value<T: Copy>(data: &[T], dtype: DType) -> Result<T> {
 mod tests {
     use super::{
         bool_from_real_for_op, dynamic_truncate_size, round_real_to_i32_for_op, round_real_to_i64,
-        round_real_to_i64_for_op, scalar_host_value,
+        round_real_to_i64_for_op, scalar_host_value, truncate_i64_size,
     };
     use tenferro_tensor::{DType, Tensor, TypedTensor};
 
@@ -123,6 +139,22 @@ mod tests {
         assert_eq!(dynamic_truncate_size(&f64_scalar(2.6), 4).unwrap(), 3);
         assert_eq!(dynamic_truncate_size(&f32_scalar(-2.0), 4).unwrap(), 0);
         assert_eq!(dynamic_truncate_size(&i64_scalar(9), 4).unwrap(), 4);
+    }
+
+    #[test]
+    fn dynamic_truncate_i64_size_clamps_without_lossy_float_conversion() {
+        assert_eq!(truncate_i64_size(-1, 4), 0);
+        assert_eq!(truncate_i64_size(9, 4), 4);
+
+        #[cfg(target_pointer_width = "64")]
+        {
+            const ABOVE_F64_INTEGER_PRECISION: i64 = (1_i64 << 53) + 1;
+            let axis_extent = usize::try_from(ABOVE_F64_INTEGER_PRECISION + 1).unwrap();
+            assert_eq!(
+                truncate_i64_size(ABOVE_F64_INTEGER_PRECISION, axis_extent),
+                usize::try_from(ABOVE_F64_INTEGER_PRECISION).unwrap()
+            );
+        }
     }
 
     #[test]

--- a/crates/tenferro-runtime/src/scalar_semantics.rs
+++ b/crates/tenferro-runtime/src/scalar_semantics.rs
@@ -91,7 +91,7 @@ fn scalar_host_value<T: Copy>(data: &[T], dtype: DType) -> Result<T> {
 mod tests {
     use super::{
         bool_from_real_for_op, dynamic_truncate_size, round_real_to_i32_for_op, round_real_to_i64,
-        round_real_to_i64_for_op, scalar_host_value, truncate_i64_size,
+        round_real_to_i64_for_op, scalar_host_value,
     };
     use tenferro_tensor::{DType, Tensor, TypedTensor};
 
@@ -142,16 +142,17 @@ mod tests {
     }
 
     #[test]
-    fn dynamic_truncate_i64_size_clamps_without_lossy_float_conversion() {
-        assert_eq!(truncate_i64_size(-1, 4), 0);
-        assert_eq!(truncate_i64_size(9, 4), 4);
+    fn dynamic_truncate_i64_routing_clamps_without_lossy_float_conversion() {
+        assert_eq!(dynamic_truncate_size(&i64_scalar(-1), 4).unwrap(), 0);
+        assert_eq!(dynamic_truncate_size(&i64_scalar(9), 4).unwrap(), 4);
 
         #[cfg(target_pointer_width = "64")]
         {
             const ABOVE_F64_INTEGER_PRECISION: i64 = (1_i64 << 53) + 1;
             let axis_extent = usize::try_from(ABOVE_F64_INTEGER_PRECISION + 1).unwrap();
             assert_eq!(
-                truncate_i64_size(ABOVE_F64_INTEGER_PRECISION, axis_extent),
+                dynamic_truncate_size(&i64_scalar(ABOVE_F64_INTEGER_PRECISION), axis_extent)
+                    .unwrap(),
                 usize::try_from(ABOVE_F64_INTEGER_PRECISION).unwrap()
             );
         }

--- a/crates/tenferro-runtime/src/shape_packing.rs
+++ b/crates/tenferro-runtime/src/shape_packing.rs
@@ -425,14 +425,14 @@ impl TracedTensor {
         })?;
         let (indices_tensor, config, out_shape) = index_select_config(&shape, axis, positions)?;
         let indices = TracedTensor::from_tensor_concrete_shape(indices_tensor)?;
-        Ok(apply_binary_preserve_input_dtypes(
+        apply_binary_preserve_input_dtypes(
             StdTensorOp::Gather(config),
             self,
             &indices,
             out_shape.len(),
             Some(out_shape.into_iter().map(SymDim::from).collect()),
             self.dtype,
-        ))
+        )
     }
 
     /// Stack tensors along a newly inserted axis.
@@ -490,11 +490,11 @@ impl TracedTensor {
             .map(|tensor| tensor.reshape(&expanded_shape))
             .collect::<Result<Vec<_>>>()?;
         let refs = expanded.iter().collect::<Vec<_>>();
-        Ok(apply_nary_concatenate(
+        apply_nary_concatenate(
             &refs,
             axis,
             out_shape.into_iter().map(SymDim::from).collect(),
-        ))
+        )
     }
 
     /// Concatenate tensors along one existing axis.
@@ -533,7 +533,7 @@ impl TracedTensor {
         let out_shape = out_shape_hint.ok_or_else(|| {
             Error::Internal("concatenate shape inference returned no shape hint".into())
         })?;
-        Ok(apply_nary_concatenate(tensors, axis, out_shape))
+        apply_nary_concatenate(tensors, axis, out_shape)
     }
 }
 
@@ -541,7 +541,7 @@ fn apply_nary_concatenate(
     tensors: &[&TracedTensor],
     axis: usize,
     out_shape: Vec<SymDim>,
-) -> TracedTensor {
+) -> Result<TracedTensor> {
     let out_dtype = promote_dtypes(tensors.iter().map(|tensor| tensor.dtype));
     let tensors = tensors
         .iter()
@@ -549,10 +549,10 @@ fn apply_nary_concatenate(
             if tensor.dtype != out_dtype {
                 tensor.cast(out_dtype)
             } else {
-                (*tensor).clone()
+                Ok((*tensor).clone())
             }
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>>>()?;
 
     let mut builder = GraphBuilder::new();
     for tensor in &tensors {
@@ -573,11 +573,11 @@ fn apply_nary_concatenate(
     builder.set_outputs(outputs.clone());
     let graph = Arc::new(builder.build());
     // Callers route through shape inference before graph construction.
-    let metadata_scope = register_scoped_value_metadata(
-        graph.values()[outputs[0]].key.clone(),
-        tensor_meta(out_dtype, out_shape.clone()),
-    )
-    .expect("fresh concatenate output metadata registration failed");
+    let metadata_scope =
+        super::traced::register_metadata_or_internal(register_scoped_value_metadata(
+            graph.values()[outputs[0]].key.clone(),
+            tensor_meta(out_dtype, out_shape.clone()),
+        ))?;
 
     let inputs_map = merge_traced_inputs_map(tensors.iter());
     let mut extra_roots = Vec::new();
@@ -587,7 +587,7 @@ fn apply_nary_concatenate(
         checkpoint_chain =
             CheckpointNode::merge_chains(checkpoint_chain, tensor.checkpoint_chain.clone());
     }
-    TracedTensor {
+    Ok(TracedTensor {
         id: next_traced_id(),
         rank: out_shape.len(),
         dtype: out_dtype,
@@ -602,7 +602,7 @@ fn apply_nary_concatenate(
             metadata_scope,
             tensors.iter().map(|tensor| &tensor.metadata_scopes),
         ),
-    }
+    })
 }
 
 #[cfg(test)]

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -1043,8 +1043,8 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    /// let y = x.neg();
-    /// let y2 = -&x;
+    /// let y = x.neg().unwrap();
+    /// let y2 = (-&x).unwrap();
     /// ```
     pub fn neg(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Neg)
@@ -1062,7 +1062,7 @@ impl TracedTensor {
     /// #     vec![Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)],
     /// # )
     /// # .unwrap();
-    /// let y = x.conj();
+    /// let y = x.conj().unwrap();
     /// ```
     pub fn conj(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Conj)
@@ -1077,7 +1077,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![-1.0_f64, 2.0]).unwrap();
-    /// let y = x.abs();
+    /// let y = x.abs().unwrap();
     /// ```
     pub fn abs(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Abs)
@@ -1090,7 +1090,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![-1.0_f64, 2.0]).unwrap();
-    /// let y = x.sign();
+    /// let y = x.sign().unwrap();
     /// ```
     pub fn sign(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Sign)
@@ -1159,7 +1159,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    /// let y = x.exp();
+    /// let y = x.exp().unwrap();
     /// ```
     pub fn exp(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Exp)
@@ -1172,7 +1172,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    /// let y = x.log();
+    /// let y = x.log().unwrap();
     /// ```
     pub fn log(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Log)
@@ -1185,7 +1185,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    /// let y = x.sin();
+    /// let y = x.sin().unwrap();
     /// ```
     pub fn sin(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Sin)
@@ -1198,7 +1198,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    /// let y = x.cos();
+    /// let y = x.cos().unwrap();
     /// ```
     pub fn cos(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Cos)
@@ -1211,7 +1211,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    /// let y = x.tanh();
+    /// let y = x.tanh().unwrap();
     /// ```
     pub fn tanh(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Tanh)
@@ -1224,7 +1224,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap();
-    /// let y = x.sqrt();
+    /// let y = x.sqrt().unwrap();
     /// ```
     pub fn sqrt(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Sqrt)
@@ -1237,7 +1237,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap();
-    /// let y = x.rsqrt();
+    /// let y = x.rsqrt().unwrap();
     /// ```
     pub fn rsqrt(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Rsqrt)
@@ -1271,7 +1271,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    /// let y = x.expm1();
+    /// let y = x.expm1().unwrap();
     /// ```
     pub fn expm1(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Expm1)
@@ -1284,7 +1284,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    /// let y = x.log1p();
+    /// let y = x.log1p().unwrap();
     /// ```
     pub fn log1p(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Log1p)
@@ -1328,7 +1328,7 @@ impl TracedTensor {
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.2_f64, -2.8]).unwrap();
     ///
-    /// let y = x.cast(DType::I32);
+    /// let y = x.cast(DType::I32).unwrap();
     /// ```
     pub fn cast(&self, to: DType) -> Result<TracedTensor> {
         if self.dtype == to {

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -214,8 +214,8 @@ pub(crate) fn broadcast_ternary(
     ))
 }
 
-fn scale_with_constant(input: &TracedTensor, op: StdTensorOp) -> TracedTensor {
-    let scalar = apply_nullary(op, 0, input.dtype, Some(vec![]));
+fn scale_with_constant(input: &TracedTensor, op: StdTensorOp) -> Result<TracedTensor> {
+    let scalar = apply_nullary(op, 0, input.dtype, Some(vec![]))?;
     apply_binary(
         StdTensorOp::Mul,
         input,
@@ -350,7 +350,7 @@ pub(crate) fn infer_traced_single_output_shape(
     Ok((output_shape.len(), Some(out_shape_hint)))
 }
 
-fn register_metadata_or_internal(
+pub(crate) fn register_metadata_or_internal(
     result: std::result::Result<GlobalMetadataScope, impl std::fmt::Display>,
 ) -> Result<GlobalMetadataScope> {
     result.map_err(|err| Error::Internal(format!("metadata registration failed: {err}")))
@@ -553,9 +553,9 @@ impl std::ops::Mul<&TracedTensor> for f64 {
 }
 
 impl std::ops::Neg for &TracedTensor {
-    type Output = TracedTensor;
+    type Output = Result<TracedTensor>;
 
-    fn neg(self) -> TracedTensor {
+    fn neg(self) -> Self::Output {
         TracedTensor::neg(self)
     }
 }
@@ -907,13 +907,13 @@ impl TracedTensor {
     /// ```
     pub fn add(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
-        Ok(apply_binary(
+        apply_binary(
             StdTensorOp::Add,
             &lhs,
             &rhs,
             lhs.rank,
             lhs.shape_hint.clone(),
-        ))
+        )
     }
 
     /// Elementwise subtraction with NumPy-style broadcasting.
@@ -921,13 +921,13 @@ impl TracedTensor {
     /// Prefer using the `-` operator when it reads naturally.
     pub fn sub(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
-        Ok(apply_binary(
+        apply_binary(
             StdTensorOp::Sub,
             &lhs,
             &rhs,
             lhs.rank,
             lhs.shape_hint.clone(),
-        ))
+        )
     }
 
     /// Elementwise multiplication with NumPy-style broadcasting.
@@ -945,13 +945,13 @@ impl TracedTensor {
     /// ```
     pub fn mul(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
-        Ok(apply_binary(
+        apply_binary(
             StdTensorOp::Mul,
             &lhs,
             &rhs,
             lhs.rank,
             lhs.shape_hint.clone(),
-        ))
+        )
     }
 
     /// Elementwise division with NumPy-style broadcasting.
@@ -969,13 +969,13 @@ impl TracedTensor {
     /// ```
     pub fn div(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
-        Ok(apply_binary(
+        apply_binary(
             StdTensorOp::Div,
             &lhs,
             &rhs,
             lhs.rank,
             lhs.shape_hint.clone(),
-        ))
+        )
     }
 
     /// Elementwise remainder with NumPy-style broadcasting.
@@ -983,13 +983,13 @@ impl TracedTensor {
     /// Prefer using the `%` operator when it reads naturally.
     pub fn rem(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
-        Ok(apply_binary(
+        apply_binary(
             StdTensorOp::Rem,
             &lhs,
             &rhs,
             lhs.rank,
             lhs.shape_hint.clone(),
-        ))
+        )
     }
 
     /// Elementwise comparison with NumPy-style broadcasting.
@@ -1030,7 +1030,7 @@ impl TracedTensor {
         apply_broadcast_ternary_op(StdTensorOp::Clamp, self, lower, upper)
     }
 
-    fn apply_same_shape_unary(&self, op: StdTensorOp) -> TracedTensor {
+    fn apply_same_shape_unary(&self, op: StdTensorOp) -> Result<TracedTensor> {
         apply_unary(op, self, self.rank, self.shape_hint.clone())
     }
 
@@ -1046,7 +1046,7 @@ impl TracedTensor {
     /// let y = x.neg();
     /// let y2 = -&x;
     /// ```
-    pub fn neg(&self) -> TracedTensor {
+    pub fn neg(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Neg)
     }
 
@@ -1064,7 +1064,7 @@ impl TracedTensor {
     /// # .unwrap();
     /// let y = x.conj();
     /// ```
-    pub fn conj(&self) -> TracedTensor {
+    pub fn conj(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Conj)
     }
 
@@ -1079,7 +1079,7 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![-1.0_f64, 2.0]).unwrap();
     /// let y = x.abs();
     /// ```
-    pub fn abs(&self) -> TracedTensor {
+    pub fn abs(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Abs)
     }
 
@@ -1092,7 +1092,7 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![-1.0_f64, 2.0]).unwrap();
     /// let y = x.sign();
     /// ```
-    pub fn sign(&self) -> TracedTensor {
+    pub fn sign(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Sign)
     }
 
@@ -1116,7 +1116,7 @@ impl TracedTensor {
             DType::C64 => StdTensorOp::constant(Complex64::new(factor, 0.0)),
             DType::C32 => StdTensorOp::constant(Complex32::new(factor as f32, 0.0)),
         };
-        Ok(scale_with_constant(self, op))
+        scale_with_constant(self, op)
     }
 
     /// Scale by a complex scalar: `y = factor * x`.
@@ -1138,11 +1138,11 @@ impl TracedTensor {
     /// ```
     pub fn scale_complex(&self, factor: Complex64) -> Result<TracedTensor> {
         match self.dtype {
-            DType::C64 => Ok(scale_with_constant(self, StdTensorOp::constant(factor))),
-            DType::C32 => Ok(scale_with_constant(
+            DType::C64 => scale_with_constant(self, StdTensorOp::constant(factor)),
+            DType::C32 => scale_with_constant(
                 self,
                 StdTensorOp::constant(Complex32::new(factor.re as f32, factor.im as f32)),
-            )),
+            ),
             DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => {
                 Err(Error::InvalidGraphBuild {
                     op: "scale_complex",
@@ -1161,7 +1161,7 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.exp();
     /// ```
-    pub fn exp(&self) -> TracedTensor {
+    pub fn exp(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Exp)
     }
 
@@ -1174,7 +1174,7 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.log();
     /// ```
-    pub fn log(&self) -> TracedTensor {
+    pub fn log(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Log)
     }
 
@@ -1187,7 +1187,7 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.sin();
     /// ```
-    pub fn sin(&self) -> TracedTensor {
+    pub fn sin(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Sin)
     }
 
@@ -1200,7 +1200,7 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.cos();
     /// ```
-    pub fn cos(&self) -> TracedTensor {
+    pub fn cos(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Cos)
     }
 
@@ -1213,7 +1213,7 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.tanh();
     /// ```
-    pub fn tanh(&self) -> TracedTensor {
+    pub fn tanh(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Tanh)
     }
 
@@ -1226,7 +1226,7 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap();
     /// let y = x.sqrt();
     /// ```
-    pub fn sqrt(&self) -> TracedTensor {
+    pub fn sqrt(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Sqrt)
     }
 
@@ -1239,7 +1239,7 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap();
     /// let y = x.rsqrt();
     /// ```
-    pub fn rsqrt(&self) -> TracedTensor {
+    pub fn rsqrt(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Rsqrt)
     }
 
@@ -1255,13 +1255,13 @@ impl TracedTensor {
     /// ```
     pub fn pow(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
-        Ok(apply_binary(
+        apply_binary(
             StdTensorOp::Pow,
             &lhs,
             &rhs,
             lhs.rank,
             lhs.shape_hint.clone(),
-        ))
+        )
     }
 
     /// Elementwise `exp(x) - 1`.
@@ -1273,7 +1273,7 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.expm1();
     /// ```
-    pub fn expm1(&self) -> TracedTensor {
+    pub fn expm1(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Expm1)
     }
 
@@ -1286,7 +1286,7 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.log1p();
     /// ```
-    pub fn log1p(&self) -> TracedTensor {
+    pub fn log1p(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Log1p)
     }
 
@@ -1312,7 +1312,7 @@ impl TracedTensor {
     /// lossy dtype projection.
     pub fn convert(&self, to: DType) -> Result<TracedTensor> {
         tenferro_tensor::validate::validate_convert_dtype("TracedTensor::convert", self.dtype, to)?;
-        Ok(self.cast(to))
+        self.cast(to)
     }
 
     /// Cast the tensor to a different dtype using explicit dtype projection.
@@ -1330,9 +1330,9 @@ impl TracedTensor {
     ///
     /// let y = x.cast(DType::I32);
     /// ```
-    pub fn cast(&self, to: DType) -> TracedTensor {
+    pub fn cast(&self, to: DType) -> Result<TracedTensor> {
         if self.dtype == to {
-            return self.clone();
+            return Ok(self.clone());
         }
 
         apply_unary_with_dtype(
@@ -1408,13 +1408,13 @@ impl TracedTensor {
             _ => None,
         };
 
-        Ok(apply_binary(
+        apply_binary(
             StdTensorOp::DotGeneral { config },
             self,
             other,
             out_rank,
             out_shape_hint,
-        ))
+        )
     }
 
     /// Matrix multiplication for rank-2 tensors.
@@ -1474,14 +1474,14 @@ impl TracedTensor {
     pub fn reduce_sum(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_sum")?;
-        Ok(apply_unary(
+        apply_unary(
             StdTensorOp::ReduceSum {
                 axes: axes.to_vec(),
             },
             self,
             out_rank,
             out_shape_hint,
-        ))
+        )
     }
 
     /// Reduce by taking the maximum along the given axes.
@@ -1563,14 +1563,14 @@ impl TracedTensor {
     pub fn reduce_prod(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_prod")?;
-        Ok(apply_unary(
+        apply_unary(
             StdTensorOp::ReduceProd {
                 axes: axes.to_vec(),
             },
             self,
             out_rank,
             out_shape_hint,
-        ))
+        )
     }
 
     /// Reshape without changing element order.
@@ -1591,7 +1591,7 @@ impl TracedTensor {
     /// overflows `usize`.
     pub fn reshape(&self, shape: &[usize]) -> Result<TracedTensor> {
         validate_concrete_reshape_shape(self, shape)?;
-        Ok(apply_unary_with_dtype(
+        apply_unary_with_dtype(
             StdTensorOp::Reshape {
                 to_shape: DimExpr::from_concrete(shape),
             },
@@ -1599,7 +1599,7 @@ impl TracedTensor {
             shape.len(),
             Some(shape.iter().copied().map(SymDim::from).collect()),
             self.dtype,
-        ))
+        )
     }
 
     /// Return a symbolic expression for the size of one axis, suitable as
@@ -1723,12 +1723,12 @@ impl TracedTensor {
             .map(|dim| dim.to_dim_expr(&tensor_map).map_err(Error::Internal))
             .collect::<Result<Vec<_>>>()?;
         let out_shape_hint = Some(shape.to_vec());
-        Ok(apply_unary(
+        apply_unary(
             StdTensorOp::Reshape { to_shape },
             self,
             shape.len(),
             out_shape_hint,
-        ))
+        )
     }
 
     /// Broadcast into a larger shape with explicit dimension placement.
@@ -1755,7 +1755,7 @@ impl TracedTensor {
             dims,
             "TracedTensor::broadcast_in_dim",
         )?;
-        Ok(apply_unary(
+        apply_unary(
             StdTensorOp::BroadcastInDim {
                 shape: DimExpr::from_concrete(shape),
                 dims: dims.to_vec(),
@@ -1763,7 +1763,7 @@ impl TracedTensor {
             self,
             shape.len(),
             Some(out_shape_hint),
-        ))
+        )
     }
 
     /// Broadcast into a symbolic target shape with explicit dimension
@@ -1844,7 +1844,7 @@ impl TracedTensor {
         let used_refs: Vec<&TracedTensor> = dedup_refs.into_iter().take(max_used_idx).collect();
 
         let out_shape_hint = Some(shape.to_vec());
-        Ok(apply_unary_with_shape_refs(
+        apply_unary_with_shape_refs(
             StdTensorOp::BroadcastInDim {
                 shape: to_shape,
                 dims: dims.to_vec(),
@@ -1853,7 +1853,7 @@ impl TracedTensor {
             &used_refs,
             shape.len(),
             out_shape_hint,
-        ))
+        )
     }
 
     /// Slice with explicit start, limit, and stride per axis.
@@ -1861,7 +1861,7 @@ impl TracedTensor {
         let op = StdTensorOp::Slice(config);
         let (out_rank, out_shape_hint) =
             infer_traced_single_output_shape("TracedTensor::slice", &op, &[self])?;
-        Ok(apply_unary(op, self, out_rank, out_shape_hint))
+        apply_unary(op, self, out_rank, out_shape_hint)
     }
 
     /// Pad with zeros using StableHLO-style edge and interior padding.
@@ -1869,20 +1869,20 @@ impl TracedTensor {
         let op = StdTensorOp::Pad(config);
         let (out_rank, out_shape_hint) =
             infer_traced_single_output_shape("TracedTensor::pad", &op, &[self])?;
-        Ok(apply_unary(op, self, out_rank, out_shape_hint))
+        apply_unary(op, self, out_rank, out_shape_hint)
     }
 
     /// Reverse the order of elements along the requested axes.
     pub fn reverse(&self, axes: &[usize]) -> Result<TracedTensor> {
         validate_traced_axes(self.rank, axes, "TracedTensor::reverse")?;
-        Ok(apply_unary(
+        apply_unary(
             StdTensorOp::Reverse {
                 axes: axes.to_vec(),
             },
             self,
             self.rank,
             self.shape_hint.clone(),
-        ))
+        )
     }
 
     /// Gather slices from `self` using integer start indices.
@@ -1890,14 +1890,7 @@ impl TracedTensor {
         let op = StdTensorOp::Gather(config);
         let (out_rank, out_shape_hint) =
             infer_traced_single_output_shape("TracedTensor::gather", &op, &[self, indices])?;
-        Ok(apply_binary_preserve_input_dtypes(
-            op,
-            self,
-            indices,
-            out_rank,
-            out_shape_hint,
-            self.dtype,
-        ))
+        apply_binary_preserve_input_dtypes(op, self, indices, out_rank, out_shape_hint, self.dtype)
     }
 
     /// Scatter updates into `self` using StableHLO scatter semantics.
@@ -1915,16 +1908,16 @@ impl TracedTensor {
         )?;
         let out_dtype = crate::shape_infer::promote_dtype(self.dtype, updates.dtype);
         let operand = if self.dtype != out_dtype {
-            self.cast(out_dtype)
+            self.cast(out_dtype)?
         } else {
             self.clone()
         };
         let updates = if updates.dtype != out_dtype {
-            updates.cast(out_dtype)
+            updates.cast(out_dtype)?
         } else {
             updates.clone()
         };
-        Ok(apply_ternary_with_output_dtype(
+        apply_ternary_with_output_dtype(
             op,
             &operand,
             indices,
@@ -1932,7 +1925,7 @@ impl TracedTensor {
             out_rank,
             out_shape_hint,
             out_dtype,
-        ))
+        )
     }
 
     /// Slice using runtime start indices.
@@ -1942,18 +1935,11 @@ impl TracedTensor {
         };
         let (out_rank, out_shape_hint) =
             infer_traced_single_output_shape("TracedTensor::dynamic_slice", &op, &[self, starts])?;
-        Ok(apply_binary_preserve_input_dtypes(
-            op,
-            self,
-            starts,
-            out_rank,
-            out_shape_hint,
-            self.dtype,
-        ))
+        apply_binary_preserve_input_dtypes(op, self, starts, out_rank, out_shape_hint, self.dtype)
     }
 
     /// Keep the lower triangle and zero the rest.
-    pub fn tril(&self, k: i64) -> TracedTensor {
+    pub fn tril(&self, k: i64) -> Result<TracedTensor> {
         apply_unary(
             StdTensorOp::Tril { k },
             self,
@@ -1963,7 +1949,7 @@ impl TracedTensor {
     }
 
     /// Keep the upper triangle and zero the rest.
-    pub fn triu(&self, k: i64) -> TracedTensor {
+    pub fn triu(&self, k: i64) -> Result<TracedTensor> {
         apply_unary(
             StdTensorOp::Triu { k },
             self,
@@ -1993,14 +1979,14 @@ impl TracedTensor {
             .shape_hint
             .as_ref()
             .map(|shape| perm.iter().map(|&p| shape[p].clone()).collect());
-        Ok(apply_unary(
+        apply_unary(
             StdTensorOp::Transpose {
                 perm: perm.to_vec(),
             },
             self,
             self.rank,
             out_shape_hint,
-        ))
+        )
     }
 
     /// Extract the diagonal along two axes.
@@ -2030,7 +2016,7 @@ impl TracedTensor {
         let op = StdTensorOp::ExtractDiag { axis_a, axis_b };
         let (out_rank, out_shape_hint) =
             infer_traced_single_output_shape("TracedTensor::extract_diag", &op, &[self])?;
-        Ok(apply_unary(op, self, out_rank, out_shape_hint))
+        apply_unary(op, self, out_rank, out_shape_hint)
     }
 
     /// Embed a vector or lower-rank tensor along a diagonal.
@@ -2056,12 +2042,12 @@ impl TracedTensor {
             out_shape.insert(axis_b, shape[axis_a].clone());
             out_shape
         });
-        Ok(apply_unary(
+        apply_unary(
             StdTensorOp::EmbedDiag { axis_a, axis_b },
             self,
             self.rank + 1,
             out_shape_hint,
-        ))
+        )
     }
 
     /// Return the runtime size of one axis as a scalar `f64` tensor.
@@ -2088,13 +2074,13 @@ impl TracedTensor {
     /// Returns an error when `axis` is out of bounds.
     pub fn shape_of(&self, axis: usize) -> Result<TracedTensor> {
         validate_traced_axis(self, axis, "TracedTensor::shape_of")?;
-        Ok(apply_unary_with_dtype(
+        apply_unary_with_dtype(
             StdTensorOp::ShapeOf { axis },
             self,
             0,
             Some(vec![]),
             DType::F64,
-        ))
+        )
     }
 
     /// Truncate this tensor along `axis` to the first `size` elements.
@@ -2130,14 +2116,14 @@ impl TracedTensor {
                 message: format!("size must be a scalar tensor, got rank {}", size.rank),
             });
         }
-        Ok(apply_binary_preserve_input_dtypes(
+        apply_binary_preserve_input_dtypes(
             StdTensorOp::DynamicTruncate { axis },
             self,
             size,
             self.rank,
             None,
             self.dtype,
-        ))
+        )
     }
 
     /// Pad this tensor with zeros along `axis` to match `reference.shape[axis]`.
@@ -2172,14 +2158,14 @@ impl TracedTensor {
             &op,
             &[self, reference],
         )?;
-        Ok(apply_binary_preserve_input_dtypes(
+        apply_binary_preserve_input_dtypes(
             op,
             self,
             reference,
             out_rank,
             out_shape_hint,
             self.dtype,
-        ))
+        )
     }
 }
 
@@ -2188,7 +2174,7 @@ pub(crate) fn apply_unary(
     input: &TracedTensor,
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
-) -> TracedTensor {
+) -> Result<TracedTensor> {
     let out_dtype = inferred_output_dtype(&op, &[input.dtype], "apply_unary");
     apply_unary_with_dtype(op, input, out_rank, out_shape_hint, out_dtype)
 }
@@ -2201,13 +2187,7 @@ fn try_apply_unary(
     context: &'static str,
 ) -> Result<TracedTensor> {
     let out_dtype = try_inferred_output_dtype(&op, &[input.dtype], context)?;
-    Ok(apply_unary_with_dtype(
-        op,
-        input,
-        out_rank,
-        out_shape_hint,
-        out_dtype,
-    ))
+    apply_unary_with_dtype(op, input, out_rank, out_shape_hint, out_dtype)
 }
 
 pub(crate) fn apply_unary_with_dtype(
@@ -2216,7 +2196,7 @@ pub(crate) fn apply_unary_with_dtype(
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
     out_dtype: DType,
-) -> TracedTensor {
+) -> Result<TracedTensor> {
     let mut builder = GraphBuilder::new();
     builder.add_parent(input.graph.clone());
     let input_ref = ValueRef::External(input.graph.values()[input.val].key.clone());
@@ -2224,9 +2204,9 @@ pub(crate) fn apply_unary_with_dtype(
     builder.set_outputs(outputs.clone());
     let graph = Arc::new(builder.build());
     let metadata_scope =
-        register_single_output_metadata(graph.as_ref(), outputs[0], out_dtype, &out_shape_hint);
+        register_single_output_metadata(graph.as_ref(), outputs[0], out_dtype, &out_shape_hint)?;
 
-    TracedTensor {
+    Ok(TracedTensor {
         id: next_traced_id(),
         rank: out_rank,
         dtype: out_dtype,
@@ -2238,7 +2218,7 @@ pub(crate) fn apply_unary_with_dtype(
         extra_roots: input.extra_roots.clone(),
         checkpoint_chain: input.checkpoint_chain.clone(),
         metadata_scopes: MetadataScopeChain::with_new(metadata_scope, [&input.metadata_scopes]),
-    }
+    })
 }
 
 /// Apply a unary-primary op that additionally references one or more
@@ -2255,7 +2235,7 @@ pub(crate) fn apply_unary_with_shape_refs(
     shape_refs: &[&TracedTensor],
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
-) -> TracedTensor {
+) -> Result<TracedTensor> {
     let mut builder = GraphBuilder::new();
     builder.add_parent(input.graph.clone());
     for t in shape_refs {
@@ -2272,7 +2252,7 @@ pub(crate) fn apply_unary_with_shape_refs(
     builder.set_outputs(outputs.clone());
     let graph = Arc::new(builder.build());
     let metadata_scope =
-        register_single_output_metadata(graph.as_ref(), outputs[0], input.dtype, &out_shape_hint);
+        register_single_output_metadata(graph.as_ref(), outputs[0], input.dtype, &out_shape_hint)?;
 
     let inputs_map =
         merge_traced_inputs_map(std::iter::once(input).chain(shape_refs.iter().copied()));
@@ -2288,7 +2268,7 @@ pub(crate) fn apply_unary_with_shape_refs(
             CheckpointNode::merge_chains(checkpoint_chain, t.checkpoint_chain.clone());
     }
 
-    TracedTensor {
+    Ok(TracedTensor {
         id: next_traced_id(),
         rank: out_rank,
         dtype: input.dtype,
@@ -2304,7 +2284,7 @@ pub(crate) fn apply_unary_with_shape_refs(
             std::iter::once(&input.metadata_scopes)
                 .chain(shape_refs.iter().map(|tensor| &tensor.metadata_scopes)),
         ),
-    }
+    })
 }
 
 pub(crate) fn apply_nullary(
@@ -2312,15 +2292,15 @@ pub(crate) fn apply_nullary(
     rank: usize,
     dtype: DType,
     shape_hint: Option<Vec<SymDim>>,
-) -> TracedTensor {
+) -> Result<TracedTensor> {
     let mut builder = GraphBuilder::new();
     let outputs = builder.add_operation(op, vec![], OperationRole::Primary);
     builder.set_outputs(outputs.clone());
     let graph = Arc::new(builder.build());
     let metadata_scope =
-        register_single_output_metadata(graph.as_ref(), outputs[0], dtype, &shape_hint);
+        register_single_output_metadata(graph.as_ref(), outputs[0], dtype, &shape_hint)?;
 
-    TracedTensor {
+    Ok(TracedTensor {
         id: next_traced_id(),
         rank,
         dtype,
@@ -2332,7 +2312,7 @@ pub(crate) fn apply_nullary(
         extra_roots: Vec::new(),
         checkpoint_chain: None,
         metadata_scopes: MetadataScopeChain::from_scope(metadata_scope),
-    }
+    })
 }
 
 pub(crate) fn apply_binary(
@@ -2341,18 +2321,18 @@ pub(crate) fn apply_binary(
     rhs: &TracedTensor,
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
-) -> TracedTensor {
+) -> Result<TracedTensor> {
     let input_dtype = crate::shape_infer::promote_dtype_for_binary_op(&op, lhs.dtype, rhs.dtype);
     let out_dtype = inferred_output_dtype(&op, &[lhs.dtype, rhs.dtype], "apply_binary");
 
     // Insert Convert ops when an input dtype differs from the primitive input dtype.
     let lhs = if lhs.dtype != input_dtype {
-        lhs.cast(input_dtype)
+        lhs.cast(input_dtype)?
     } else {
         lhs.clone()
     };
     let rhs = if rhs.dtype != input_dtype {
-        rhs.cast(input_dtype)
+        rhs.cast(input_dtype)?
     } else {
         rhs.clone()
     };
@@ -2372,24 +2352,17 @@ fn try_apply_binary(
     let out_dtype = try_inferred_output_dtype(&op, &[lhs.dtype, rhs.dtype], context)?;
 
     let lhs = if lhs.dtype != input_dtype {
-        lhs.cast(input_dtype)
+        lhs.cast(input_dtype)?
     } else {
         lhs.clone()
     };
     let rhs = if rhs.dtype != input_dtype {
-        rhs.cast(input_dtype)
+        rhs.cast(input_dtype)?
     } else {
         rhs.clone()
     };
 
-    Ok(apply_binary_with_output_dtype(
-        op,
-        &lhs,
-        &rhs,
-        out_rank,
-        out_shape_hint,
-        out_dtype,
-    ))
+    apply_binary_with_output_dtype(op, &lhs, &rhs, out_rank, out_shape_hint, out_dtype)
 }
 
 pub(crate) fn apply_binary_preserve_input_dtypes(
@@ -2399,7 +2372,7 @@ pub(crate) fn apply_binary_preserve_input_dtypes(
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
     out_dtype: DType,
-) -> TracedTensor {
+) -> Result<TracedTensor> {
     apply_binary_with_output_dtype(op, lhs, rhs, out_rank, out_shape_hint, out_dtype)
 }
 
@@ -2452,12 +2425,12 @@ fn try_apply_ternary(
         StdTensorOp::Select => {
             let value_dtype = crate::shape_infer::promote_dtype(second.dtype, third.dtype);
             let second = if second.dtype != value_dtype {
-                second.cast(value_dtype)
+                second.cast(value_dtype)?
             } else {
                 second.clone()
             };
             let third = if third.dtype != value_dtype {
-                third.cast(value_dtype)
+                third.cast(value_dtype)?
             } else {
                 third.clone()
             };
@@ -2467,24 +2440,24 @@ fn try_apply_ternary(
             let input_dtype =
                 crate::shape_infer::promote_dtypes([first.dtype, second.dtype, third.dtype]);
             let first = if first.dtype != input_dtype {
-                first.cast(input_dtype)
+                first.cast(input_dtype)?
             } else {
                 first.clone()
             };
             let second = if second.dtype != input_dtype {
-                second.cast(input_dtype)
+                second.cast(input_dtype)?
             } else {
                 second.clone()
             };
             let third = if third.dtype != input_dtype {
-                third.cast(input_dtype)
+                third.cast(input_dtype)?
             } else {
                 third.clone()
             };
             (first, second, third)
         }
     };
-    Ok(apply_ternary_with_output_dtype(
+    apply_ternary_with_output_dtype(
         op,
         &first,
         &second,
@@ -2492,7 +2465,7 @@ fn try_apply_ternary(
         out_rank,
         out_shape_hint,
         out_dtype,
-    ))
+    )
 }
 
 fn apply_binary_with_output_dtype(
@@ -2502,7 +2475,7 @@ fn apply_binary_with_output_dtype(
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
     out_dtype: DType,
-) -> TracedTensor {
+) -> Result<TracedTensor> {
     let lhs_ref = ValueRef::External(lhs.graph.values()[lhs.val].key.clone());
     let rhs_ref = ValueRef::External(rhs.graph.values()[rhs.val].key.clone());
 
@@ -2513,12 +2486,12 @@ fn apply_binary_with_output_dtype(
     builder.set_outputs(outputs.clone());
     let graph = Arc::new(builder.build());
     let metadata_scope =
-        register_single_output_metadata(graph.as_ref(), outputs[0], out_dtype, &out_shape_hint);
+        register_single_output_metadata(graph.as_ref(), outputs[0], out_dtype, &out_shape_hint)?;
 
     let mut extra_roots = lhs.extra_roots.clone();
     extra_roots.extend(rhs.extra_roots.iter().cloned());
 
-    TracedTensor {
+    Ok(TracedTensor {
         id: next_traced_id(),
         rank: out_rank,
         dtype: out_dtype,
@@ -2536,7 +2509,7 @@ fn apply_binary_with_output_dtype(
             metadata_scope,
             [&lhs.metadata_scopes, &rhs.metadata_scopes],
         ),
-    }
+    })
 }
 
 fn apply_ternary_with_output_dtype(
@@ -2547,7 +2520,7 @@ fn apply_ternary_with_output_dtype(
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
     out_dtype: DType,
-) -> TracedTensor {
+) -> Result<TracedTensor> {
     let first_ref = ValueRef::External(first.graph.values()[first.val].key.clone());
     let second_ref = ValueRef::External(second.graph.values()[second.val].key.clone());
     let third_ref = ValueRef::External(third.graph.values()[third.val].key.clone());
@@ -2564,7 +2537,7 @@ fn apply_ternary_with_output_dtype(
     builder.set_outputs(outputs.clone());
     let graph = Arc::new(builder.build());
     let metadata_scope =
-        register_single_output_metadata(graph.as_ref(), outputs[0], out_dtype, &out_shape_hint);
+        register_single_output_metadata(graph.as_ref(), outputs[0], out_dtype, &out_shape_hint)?;
 
     let mut extra_roots = first.extra_roots.clone();
     extra_roots.extend(second.extra_roots.iter().cloned());
@@ -2578,7 +2551,7 @@ fn apply_ternary_with_output_dtype(
         third.checkpoint_chain.clone(),
     );
 
-    TracedTensor {
+    Ok(TracedTensor {
         id: next_traced_id(),
         rank: out_rank,
         dtype: out_dtype,
@@ -2597,7 +2570,7 @@ fn apply_ternary_with_output_dtype(
                 &third.metadata_scopes,
             ],
         ),
-    }
+    })
 }
 
 fn register_single_output_metadata(
@@ -2605,20 +2578,18 @@ fn register_single_output_metadata(
     output: LocalValueId,
     dtype: DType,
     shape_hint: &Option<Vec<SymDim>>,
-) -> GlobalMetadataScope {
+) -> Result<GlobalMetadataScope> {
     if let Some(shape) = shape_hint {
         // Fresh graph output keys are generated in this builder, so metadata
         // registration failure would indicate a global metadata invariant bug.
-        register_scoped_value_metadata(
+        register_metadata_or_internal(register_scoped_value_metadata(
             graph.values()[output].key.clone(),
             tensor_meta(dtype, shape.clone()),
-        )
-        .expect("fresh traced graph output metadata registration failed")
+        ))
     } else {
         // Fresh graph output keys are generated in this builder, so metadata
         // registration failure would indicate a global metadata invariant bug.
-        register_scoped_graph_metadata(graph, std::iter::empty())
-            .expect("fresh traced graph metadata registration failed")
+        register_metadata_or_internal(register_scoped_graph_metadata(graph, std::iter::empty()))
     }
 }
 

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -1939,6 +1939,20 @@ impl TracedTensor {
     }
 
     /// Keep the lower triangle and zero the rest.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_runtime::TracedTensor;
+    /// let matrix = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4])?;
+    /// let lower = matrix.tril(0)?;
+    /// assert_eq!(lower.rank, 2);
+    /// # Ok::<(), tenferro_runtime::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if traced output metadata registration fails.
     pub fn tril(&self, k: i64) -> Result<TracedTensor> {
         apply_unary(
             StdTensorOp::Tril { k },
@@ -1949,6 +1963,20 @@ impl TracedTensor {
     }
 
     /// Keep the upper triangle and zero the rest.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_runtime::TracedTensor;
+    /// let matrix = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4])?;
+    /// let upper = matrix.triu(0)?;
+    /// assert_eq!(upper.rank, 2);
+    /// # Ok::<(), tenferro_runtime::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if traced output metadata registration fails.
     pub fn triu(&self, k: i64) -> Result<TracedTensor> {
         apply_unary(
             StdTensorOp::Triu { k },

--- a/crates/tenferro-runtime/tests/public_surface_contract.rs
+++ b/crates/tenferro-runtime/tests/public_surface_contract.rs
@@ -145,3 +145,28 @@ fn traced_dtype_inference_must_not_fall_back_in_release_builds() {
         "traced dtype inference must not silently return a fallback dtype"
     );
 }
+
+#[test]
+fn traced_metadata_registration_is_fallible_without_panic_helpers() {
+    let traced = repo_file("crates/tenferro-runtime/src/traced.rs");
+    let registration = traced
+        .split_once("fn register_single_output_metadata(")
+        .and_then(|(_, rest)| rest.split_once("impl TracedTensor").map(|(body, _)| body))
+        .expect("single-output metadata helper should exist");
+    assert!(registration.contains(") -> Result<GlobalMetadataScope>"));
+    assert!(!registration.contains(".expect("));
+
+    let packing = repo_file("crates/tenferro-runtime/src/shape_packing.rs");
+    let concatenate = packing
+        .split_once("fn apply_nary_concatenate(")
+        .and_then(|(_, rest)| rest.split_once("#[cfg(test)]").map(|(body, _)| body))
+        .expect("concatenate graph helper should exist");
+    assert!(
+        concatenate.contains(") -> Result<TracedTensor>"),
+        "concatenate graph construction must preserve metadata errors"
+    );
+    assert!(
+        !concatenate.contains(".expect("),
+        "concatenate metadata registration must not panic"
+    );
+}

--- a/crates/tenferro-runtime/tests/runtime_public_api.rs
+++ b/crates/tenferro-runtime/tests/runtime_public_api.rs
@@ -72,7 +72,7 @@ fn traced_tensor_methods_cover_conversion_and_rank_errors() {
     let converted = vector.convert(DType::C64).unwrap();
     assert_eq!(converted.dtype, DType::C64);
 
-    let casted = vector.cast(DType::I32);
+    let casted = vector.cast(DType::I32).unwrap();
     assert_eq!(casted.dtype, DType::I32);
 
     let err = scalar.matmul(&vector).unwrap_err();
@@ -206,11 +206,11 @@ fn traced_tensor_methods_cover_structural_surface() {
     let matrix =
         TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     assert_eq!(
-        run(&matrix.tril(0)).as_slice::<f64>().unwrap(),
+        run(&matrix.tril(0).unwrap()).as_slice::<f64>().unwrap(),
         &[1.0, 2.0, 0.0, 4.0]
     );
     assert_eq!(
-        run(&matrix.triu(0)).as_slice::<f64>().unwrap(),
+        run(&matrix.triu(0).unwrap()).as_slice::<f64>().unwrap(),
         &[1.0, 0.0, 3.0, 4.0]
     );
     let rectangular =
@@ -435,7 +435,7 @@ fn graph_executor_public_helpers_and_borrowed_input_errors_are_covered() {
     assert!(matches!(shape, Error::PlaceholderShapeMismatch { .. }));
 
     let multi = compiler
-        .compile_many(&[&concrete, &concrete.neg()])
+        .compile_many(&[&concrete, &concrete.neg().unwrap()])
         .unwrap();
     let output_count = executor.run(&multi).unwrap_err();
     assert!(output_count.to_string().contains("expected 1 output"));

--- a/crates/tenferro-xla/src/error.rs
+++ b/crates/tenferro-xla/src/error.rs
@@ -12,8 +12,9 @@ use tenferro_tensor::DType;
 ///
 /// let x = TracedTensor::input_symbolic_shape(DType::I64, 1).unwrap();
 /// let mut compiler = GraphCompiler::new();
+/// let y = x.neg().unwrap();
 /// let program = compiler
-///     .compile_with_input_specs(&x.neg(), &[(&x, DType::I64, &[2])])
+///     .compile_with_input_specs(&y, &[(&x, DType::I64, &[2])])
 ///     .unwrap();
 /// let err = lower_to_stablehlo(&program).unwrap_err();
 /// assert!(matches!(err, Error::UnsupportedDType { .. }));

--- a/crates/tenferro-xla/src/executor.rs
+++ b/crates/tenferro-xla/src/executor.rs
@@ -38,7 +38,8 @@ impl fmt::Debug for XlaExecutorOptions {
 ///
 /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
 /// let mut compiler = GraphCompiler::new();
-/// let program = compiler.compile(&x.neg()).unwrap();
+/// let y = x.neg().unwrap();
+/// let program = compiler.compile(&y).unwrap();
 /// let module = XlaExecutor::default().lower_to_stablehlo(&program).unwrap();
 /// assert!(module.as_str().contains("stablehlo.negate"));
 /// ```
@@ -170,7 +171,8 @@ impl XlaExecutor {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let module = XlaExecutor::default().lower_to_stablehlo(&program).unwrap();
     /// assert!(module.as_str().contains("stablehlo.negate"));
     /// ```
@@ -193,7 +195,8 @@ impl XlaExecutor {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let input = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let err = XlaExecutor::default()
     ///     .run_many_with_inputs(&program, &[&input])
@@ -230,7 +233,8 @@ impl XlaExecutor {
     ///
     /// let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let mut compiler = GraphCompiler::new();
-    /// let program = compiler.compile(&x.neg()).unwrap();
+    /// let y = x.neg().unwrap();
+    /// let program = compiler.compile(&y).unwrap();
     /// let input = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// let err = XlaExecutor::default().run_with_inputs(&program, &[&input]).unwrap_err();
     /// assert!(matches!(err, Error::PjrtFeatureDisabled | Error::PjrtPluginNotLoaded));

--- a/crates/tenferro-xla/src/executor.rs
+++ b/crates/tenferro-xla/src/executor.rs
@@ -280,7 +280,7 @@ mod tests {
     fn default_executor_reports_missing_pjrt_before_dispatch() {
         let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
         let mut compiler = GraphCompiler::new();
-        let program = compiler.compile(&x.neg()).unwrap();
+        let program = compiler.compile(&x.neg().unwrap()).unwrap();
         let input = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
 
         let err = XlaExecutor::default()

--- a/crates/tenferro-xla/src/lib.rs
+++ b/crates/tenferro-xla/src/lib.rs
@@ -66,7 +66,8 @@ pub const TENFERRO_PJRT_GPU_PLUGIN_ENV: &str = "TENFERRO_PJRT_GPU_PLUGIN";
 ///
 /// let x = TracedTensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
 /// let mut compiler = GraphCompiler::new();
-/// let program = compiler.compile(&x.neg()).unwrap();
+/// let y = x.neg().unwrap();
+/// let program = compiler.compile(&y).unwrap();
 /// let module = lower_to_stablehlo(&program).unwrap();
 /// assert!(module.as_str().contains("stablehlo.negate"));
 /// ```

--- a/crates/tenferro-xla/src/lowering/shape/tests.rs
+++ b/crates/tenferro-xla/src/lowering/shape/tests.rs
@@ -7,7 +7,7 @@ use tenferro_runtime::{GraphCompiler, GraphProgramLoweringShapeError, TracedTens
 fn missing_output_shape_metadata_maps_to_invalid_program() {
     let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     let mut compiler = GraphCompiler::new();
-    let program = compiler.compile(&x.neg()).unwrap();
+    let program = compiler.compile(&x.neg().unwrap()).unwrap();
     let inst = program.lowering_view().instructions().next().unwrap();
 
     let err = static_output_shape(inst, 1, &[&[1]]).unwrap_err();

--- a/crates/tenferro-xla/tests/pjrt_execution.rs
+++ b/crates/tenferro-xla/tests/pjrt_execution.rs
@@ -14,12 +14,22 @@ fn pjrt_executes_phase_one_elementwise_from_rust_when_configured() {
     };
 
     let x = TracedTensor::input_symbolic_shape(DType::F32, 1).unwrap();
-    let positive = x.abs().exp();
-    let analytic = positive.log().sqrt().rsqrt().expm1().log1p();
-    let trig = positive.sin().cos().tanh();
+    let positive = x.abs().unwrap().exp().unwrap();
+    let analytic = positive
+        .log()
+        .unwrap()
+        .sqrt()
+        .unwrap()
+        .rsqrt()
+        .unwrap()
+        .expm1()
+        .unwrap()
+        .log1p()
+        .unwrap();
+    let trig = positive.sin().unwrap().cos().unwrap().tanh().unwrap();
     let combined = (&analytic + &trig).unwrap();
     let divided = combined.div(&positive).unwrap();
-    let y = divided.abs().pow(&positive).unwrap();
+    let y = divided.abs().unwrap().pow(&positive).unwrap();
 
     let mut compiler = GraphCompiler::new();
     let program = compiler
@@ -95,7 +105,15 @@ fn pjrt_executes_nary_einsum_plus_elementwise_from_rust_when_configured() {
     let product = compiler
         .einsum(&[&lhs, &mid, &rhs], "ij,jk,kl->il")
         .unwrap();
-    let y = product.abs().sqrt().log1p().exp();
+    let y = product
+        .abs()
+        .unwrap()
+        .sqrt()
+        .unwrap()
+        .log1p()
+        .unwrap()
+        .exp()
+        .unwrap();
     let program = compiler
         .compile_with_input_specs(
             &y,

--- a/crates/tenferro-xla/tests/public_api.rs
+++ b/crates/tenferro-xla/tests/public_api.rs
@@ -43,7 +43,7 @@ fn xla_executor_options_debug_and_lowering_are_stable() {
 
     let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     let mut compiler = GraphCompiler::new();
-    let program = compiler.compile(&x.neg()).unwrap();
+    let program = compiler.compile(&x.neg().unwrap()).unwrap();
     let module = executor.lower_to_stablehlo(&program).unwrap();
     assert!(module.as_str().contains("stablehlo.negate"));
 }
@@ -52,7 +52,7 @@ fn xla_executor_options_debug_and_lowering_are_stable() {
 fn xla_executor_run_with_inputs_requires_pjrt_plugin_boundary() {
     let x = TracedTensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     let mut compiler = GraphCompiler::new();
-    let program = compiler.compile(&x.neg()).unwrap();
+    let program = compiler.compile(&x.neg().unwrap()).unwrap();
     let input = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
 
     let err = XlaExecutor::default()

--- a/crates/tenferro-xla/tests/stablehlo_lowering.rs
+++ b/crates/tenferro-xla/tests/stablehlo_lowering.rs
@@ -26,15 +26,25 @@ fn lowers_phase_one_real_elementwise_ops() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
     let unary = x
         .abs()
+        .unwrap()
         .exp()
+        .unwrap()
         .log()
+        .unwrap()
         .sin()
+        .unwrap()
         .cos()
+        .unwrap()
         .tanh()
+        .unwrap()
         .sqrt()
+        .unwrap()
         .rsqrt()
+        .unwrap()
         .expm1()
-        .log1p();
+        .unwrap()
+        .log1p()
+        .unwrap();
     let divided = unary.div(&x).unwrap();
     let powered = divided.pow(&x).unwrap();
     let mut compiler = GraphCompiler::new();

--- a/crates/tenferro-xla/tests/xla_tool_execution.rs
+++ b/crates/tenferro-xla/tests/xla_tool_execution.rs
@@ -153,12 +153,22 @@ fn stablehlo_nary_einsum_module() -> tenferro_xla::StableHloModule {
 
 fn stablehlo_phase_one_elementwise_module() -> tenferro_xla::StableHloModule {
     let x = TracedTensor::input_symbolic_shape(DType::F32, 1).unwrap();
-    let positive = x.abs().exp();
-    let analytic = positive.log().sqrt().rsqrt().expm1().log1p();
-    let trig = positive.sin().cos().tanh();
+    let positive = x.abs().unwrap().exp().unwrap();
+    let analytic = positive
+        .log()
+        .unwrap()
+        .sqrt()
+        .unwrap()
+        .rsqrt()
+        .unwrap()
+        .expm1()
+        .unwrap()
+        .log1p()
+        .unwrap();
+    let trig = positive.sin().unwrap().cos().unwrap().tanh().unwrap();
     let combined = (&analytic + &trig).unwrap();
     let divided = combined.div(&positive).unwrap();
-    let powered = divided.abs().pow(&positive).unwrap();
+    let powered = divided.abs().unwrap().pow(&positive).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&powered, &[(&x, DType::F32, &[4])])

--- a/docs/guides/complex-ad.md
+++ b/docs/guides/complex-ad.md
@@ -76,8 +76,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
     let z = TracedTensor::from_vec_col_major(vec![2], z_data.clone())?;
 
-    let holomorphic_loss = z.exp().reduce_sum(&[0]);
-    let tenferro_grad = holomorphic_loss?.grad(&z)?;
+    let holomorphic_loss = z.exp()?.reduce_sum(&[0])?;
+    let tenferro_grad = holomorphic_loss.grad(&z)?;
     let tenferro_grad_value = run(&tenferro_grad)?;
     let expected_grad: Vec<_> = z_data.iter().map(|z| z.exp().conj()).collect();
     assert_complex_slice_close(
@@ -85,7 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &expected_grad,
     );
 
-    let magnitude = z.abs();
+    let magnitude = z.abs()?;
     let real_loss = (&magnitude * &magnitude)?.reduce_sum(&[0]);
     let real_loss_grad = real_loss?.grad(&z)?;
     let real_loss_grad_value = run(&real_loss_grad)?;
@@ -99,7 +99,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         vec![1],
         vec![Complex64::new(0.0, std::f64::consts::FRAC_PI_2)],
     )?;
-    let y = scalar_z.exp();
+    let y = scalar_z.exp()?;
     let seed = Complex64::new(2.0, -3.0);
     let cotangent = TracedTensor::from_vec_col_major(vec![1], vec![seed])?;
     let vjp = y.vjp(&scalar_z, &cotangent)?;

--- a/docs/guides/xla.md
+++ b/docs/guides/xla.md
@@ -146,7 +146,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut compiler = GraphCompiler::new();
     let product = compiler.einsum(&[&lhs, &mid, &rhs], "ij,jk,kl->il")?;
-    let y = product.abs().sqrt().log1p().exp();
+    let y = product.abs()?.sqrt()?.log1p()?.exp()?;
     let program = compiler.compile_with_input_specs(
         &y,
         &[

--- a/docs/tutorial-code/src/bin/complex_ad_convention.rs
+++ b/docs/tutorial-code/src/bin/complex_ad_convention.rs
@@ -34,8 +34,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
     let z = TracedTensor::from_vec_col_major(vec![2], z_data.clone())?;
 
-    let holomorphic_loss = z.exp().reduce_sum(&[0]);
-    let tenferro_grad = holomorphic_loss?.grad(&z)?;
+    let holomorphic_loss = z.exp()?.reduce_sum(&[0])?;
+    let tenferro_grad = holomorphic_loss.grad(&z)?;
     let tenferro_grad_value = run(&tenferro_grad)?;
     let expected_grad: Vec<_> = z_data.iter().map(|z| z.exp().conj()).collect();
     assert_complex_slice_close(
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &expected_grad,
     );
 
-    let magnitude = z.abs();
+    let magnitude = z.abs()?;
     let real_loss = (&magnitude * &magnitude)?.reduce_sum(&[0]);
     let real_loss_grad = real_loss?.grad(&z)?;
     let real_loss_grad_value = run(&real_loss_grad)?;
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         vec![1],
         vec![Complex64::new(0.0, std::f64::consts::FRAC_PI_2)],
     )?;
-    let y = scalar_z.exp();
+    let y = scalar_z.exp()?;
     let seed = Complex64::new(2.0, -3.0);
     let cotangent = TracedTensor::from_vec_col_major(vec![1], vec![seed])?;
     let vjp = y.vjp(&scalar_z, &cotangent)?;

--- a/docs/tutorial-code/src/bin/xla_pjrt_execution.rs
+++ b/docs/tutorial-code/src/bin/xla_pjrt_execution.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut compiler = GraphCompiler::new();
     let product = compiler.einsum(&[&lhs, &mid, &rhs], "ij,jk,kl->il")?;
-    let y = product.abs().sqrt().log1p().exp();
+    let y = product.abs()?.sqrt()?.log1p()?.exp()?;
     let program = compiler.compile_with_input_specs(
         &y,
         &[

--- a/docs/worklogs/2026-07-11-small-bugfix-remediation.md
+++ b/docs/worklogs/2026-07-11-small-bugfix-remediation.md
@@ -1,0 +1,127 @@
+# Small Bug-Fix Remediation
+
+## Session Summary
+
+This batch triaged eight small repository-rule findings against the current
+source, then grouped the confirmed repairs by owning subsystem. Seven findings
+remain `Auto Fix` items implemented on `codex/batch-small-bugfixes`; one GPU
+finding is a false positive whose host-side proof is now explicit and guarded;
+and one additional issue was found stale because an earlier change on `main`
+already removed the reported pattern. No GitHub issue was closed or otherwise
+mutated during this session.
+
+This is an in-progress ledger. The implementation commits are present, but the
+full PR checklist, issue closure, PR creation, and merge are still pending.
+
+## Context And Rules Read
+
+- Online `tensor4all-agent-rules`: `rules/index.md`,
+  `rules/common/repository.md`, `rules/common/docs-and-tests.md`, and
+  `rules/rust/index.md`.
+- Repository `AGENTS.md`, `CONTRIBUTING.md`, and `REPOSITORY_RULES.md`, with
+  emphasis on public-boundary safety, checked allocation arithmetic, lock
+  poison propagation, invariant markers, parallel backend semantics, work
+  logs, and the pre-PR checklist.
+- `ai/contribution-workflows/bugfix-pr.md` and
+  `ai/contribution-workflows/repository-remediation.md`.
+- The issue reports for #1325, #1351, #1290, #1350, #1349, #1330, #1352, and
+  #1309; design-gated exclusions #1353, #1275, and #1276.
+- `git log` and `git diff` for `origin/main..HEAD`, plus the current source and
+  history relevant to #1309.
+
+## Classification Ledger
+
+| Issue | Classification | Current evidence | Close criterion and current result | Recurrence prevention |
+| --- | --- | --- | --- | --- |
+| #1325 | Auto Fix | Commits `0570bad9` and `3525c61e` make faer/LAPACK tensor assembly and scratch refill helpers fallible and propagate errors through their callers. | No production `.expect()` remains in the reported helpers; focused linalg tests and the full PR checklist must pass before closure. **Implemented; final verification pending.** | Unit tests exercise overflow helpers, and `cpu_linalg_source_contract.rs` guards the fallible helper boundary. |
+| #1351 | Auto Fix | Commits `0570bad9` and `3525c61e` replace reported allocation products across faer and LAPACK assembly/workspace paths with checked element/byte calculations and typed errors. | Every reported `rows * cols` or equivalent allocation length is checked before allocation or FFI use. **Implemented; final verification pending.** | Helper unit tests cover overflow, while source-contract tests inventory the LAPACK allocation sites that are impractical to execute at extreme dimensions. |
+| #1290 | Auto Fix | Commits `9ae171dd`, `2f103426`, and `c36c2c08` make single-output metadata registration and concatenate graph construction return `Result`, migrate workspace callers, and document fallible triangular traced methods. | Metadata registration failures reach callers without `.expect()` or a fallback value, with all affected callers and docs migrated. **Implemented; final verification pending.** | `runtime/tests/public_surface_contract.rs` requires fallible helpers and forbids `.expect()` in the reported registration bodies. |
+| #1350 | Auto Fix | Commits `87c0979e`, `966ab814`, and `cd1a3b14` replace FFT cache poison recovery through `into_inner()` with an exact typed cache error and propagate it through FFT plan resolution. | A deliberately poisoned cache must produce the expected error through the public FFT path, and silent recovery must be absent. **Implemented; final verification pending.** | Concrete poison coverage plus public FFT source-contract/error-propagation tests require the exact failure path. |
+| #1349 | Auto Fix | Commit `9f593ecd` routes `I64` DynamicTruncate sizes through integer clamping, keeping only floating dtypes on the finite/rounding path. | `2^53 + 1` remains exact on 64-bit hosts, negative values clamp to zero, and oversized values clamp to the axis extent. **Implemented; final verification pending.** | A focused unit test covers the value immediately above binary64 integer precision and the ordinary clamp boundaries. |
+| #1330 | Auto Fix | Commits `7961fb8e`, `09b3b9d3`, `b1b834be`, and `2d2ef5ec` remove the CPU sign-only rejection, harden signed position calculations before narrowing, and align CPU/CUDA cropping behavior. | Valid negative edge padding crops on CPU and CUDA while invalid dimensions and index conversions remain checked. **Implemented; CUDA hardware verification pending.** | CPU value tests cover low/high cropping and overflow edges; GPU source contracts and ignored CubeCL value tests cover signed mapping and parity. |
+| #1352 | False Positive | The kernel-local `update_window_len` product is bounded by host launch validation. Commits `81bcf014`, `5fb5e5bb`, `579a138d`, and `8c003f5e` add concrete `// INVARIANT:` markers and lexically prove every scatter launch reaches the checked window/batch calculation without proof aliases. | Each launch path must preserve a checked host product before the kernel's unchecked multiplication, and the marker must remain adjacent and re-verifiable. **Evidence recorded and guarded; final suite pending.** | `cubecl_launch_contract.rs` inventories launch sites, rejects unchecked or aliased proofs, and ties the kernel marker to host validation. |
+| #1309 | Stale / Out Of Scope | This was already resolved on `main` by `9ad0fb1a` (`Enforce AD graph emission invariants (#1324)`). Current `one_like_fixed` at `crates/tenferro-linalg/src/ad/rules/support.rs:306` calls `ad_support::one_like`; the former `scalar_one_fixed` no longer exists, and `identity_matrix_fixed` calls `ad_support::identity_matrix`. | Neither reported helper emits `StdTensorOp::Exp` for a constant. Tests at `support.rs:829` and `support.rs:844` assert `Constant`/`BroadcastInDim` structure and reject analytic constant shortcuts. **Close as already fixed by #1324 after maintainer review; no batch code change needed.** | Shared semantic constant builders centralize dtype-aware emission, and graph-structure tests reject `Exp`, `Log`, `Sin`, `Cos`, `Tanh`, `Sqrt`, `Rsqrt`, `Expm1`, or `Log1p` as constant shortcuts. |
+
+## Issue #1309 Evidence
+
+The current source is stronger than the issue's proposed local visibility
+change. `tenferro-internal-ops` exposes semantic builders through its supported
+AD helper surface, and linalg delegates to that surface instead of reaching
+into `zeros.rs`:
+
+- `one_like_fixed` delegates to `ad_support::one_like(builder, dtype, anchor,
+  anchor_rank)`.
+- `scalar_one_fixed` and its `exp(anchor - anchor)` implementation were
+  removed.
+- `identity_matrix_fixed` delegates to `ad_support::identity_matrix`, which
+  supplies the scalar one through semantic constant construction.
+- `one_like_fixed_uses_semantic_constant_not_analytic_shortcut` expects exactly
+  one `Constant` and one `BroadcastInDim` operation.
+- `identity_matrix_fixed_uses_semantic_constant_not_analytic_shortcut` uses the
+  same analytic-shortcut rejection helper.
+
+This supports closing #1309 as stale/already fixed, citing commit
+`9ad0fb1a96112bd1e0ee33a3c581198745923635` and its regression tests. This work
+log does not perform that GitHub mutation.
+
+## Scope And Design Exclusions
+
+- #1353 is design-gated: choosing IEEE floating remainder semantics versus a
+  new typed zero-divisor policy requires a binding cross-dtype specification.
+- #1275 is design-gated: removing public CPU free functions or introducing a
+  shared default backend changes public API and runtime/thread-pool ownership.
+- #1276 is design-gated: renaming typed einsum view methods and adding a typed
+  mutable-write abstraction changes the public API surface.
+
+The batch does not change those policies or APIs. It also does not introduce a
+new backend, operation family, dependency, feature flag, AD convention, or
+coverage policy.
+
+## Verification Status
+
+The implementation commits contain focused unit, source-contract, and ignored
+CUDA regression coverage described in the ledger. During work-log preparation,
+the #1309 source and commit history were inspected directly, and the following
+narrow checks were run:
+
+- `cargo test -p tenferro-linalg --features autodiff
+  one_like_fixed_uses_semantic_constant_not_analytic_shortcut --lib`: passed,
+  one test.
+- `git diff --check`: passed.
+- `python3 scripts/check-docs-site.py`: snippet and guide dependency checks
+  passed, but the overall command stopped because workspace rustdoc output had
+  not yet been generated. It must be rerun after `cargo doc --workspace
+  --no-deps` during final verification.
+
+The following repository-required checks are **pending** and must not be
+inferred from this ledger: release workspace tests, CI-parity clippy, LLVM
+coverage plus the per-file threshold check, workspace rustdoc, the committed
+repository-rules review, and CUDA ignored tests on supported NVIDIA hardware.
+Issue closure, PR creation, branch-protection confirmation, non-squash
+auto-merge configuration, and merge are also pending.
+
+## Environment Notes
+
+The linalg changes cover faer and LAPACK allocation/error paths. Full release
+tests may depend on the host BLAS/LAPACK linker configuration; no result is
+claimed here until that command is run. Coverage generation can require
+substantial target-directory and JSON disk space, so available disk should be
+checked before the final coverage run. CUDA value tests require the documented
+CUDA toolkit and runtime libraries; source-contract coverage does not replace
+that hardware run.
+
+## Residual Risks
+
+- The broad fallible traced-API migration touched runtime, AD, einsum, XLA,
+  tutorials, and tests; only the full release workspace test can establish
+  cross-crate completeness.
+- GPU signed-padding tests are ignored without CUDA, so runtime parity remains
+  hardware-gated even though CPU tests and source contracts cover the mapping.
+- #1352 remains correct only while every scatter launch preserves the checked
+  host proof; the lexical contract tests intentionally fail when a new launch
+  path or proof alias is introduced.
+- Extreme allocation failures are validated mainly through checked helpers and
+  source contracts because constructing near-`usize::MAX` matrices is not a
+  practical runtime test.
+- The three excluded issues remain open design questions and must not be
+  silently folded into this remediation PR.

--- a/docs/worklogs/2026-07-11-small-bugfix-remediation.md
+++ b/docs/worklogs/2026-07-11-small-bugfix-remediation.md
@@ -7,11 +7,12 @@ source, then grouped the confirmed repairs by owning subsystem. Seven findings
 remain `Auto Fix` items implemented on `codex/batch-small-bugfixes`; one GPU
 finding is a false positive whose host-side proof is now explicit and guarded;
 and one additional issue was found stale because an earlier change on `main`
-already removed the reported pattern. No GitHub issue was closed or otherwise
-mutated during this session.
+already removed the reported pattern. Issue #1309 was closed after that source
+and test evidence was verified.
 
-This is an in-progress ledger. The implementation commits are present, but the
-full PR checklist, issue closure, PR creation, and merge are still pending.
+The implementation and required verification are complete. PR creation, merge,
+and closure of #1325, #1351, #1290, #1350, #1349, #1330, and #1352 remain
+pending.
 
 ## Context And Rules Read
 
@@ -33,14 +34,14 @@ full PR checklist, issue closure, PR creation, and merge are still pending.
 
 | Issue | Classification | Current evidence | Close criterion and current result | Recurrence prevention |
 | --- | --- | --- | --- | --- |
-| #1325 | Auto Fix | Commits `0570bad9` and `3525c61e` make faer/LAPACK tensor assembly and scratch refill helpers fallible and propagate errors through their callers. | No production `.expect()` remains in the reported helpers; focused linalg tests and the full PR checklist must pass before closure. **Implemented; final verification pending.** | Unit tests exercise overflow helpers, and `cpu_linalg_source_contract.rs` guards the fallible helper boundary. |
-| #1351 | Auto Fix | Commits `0570bad9` and `3525c61e` replace reported allocation products across faer and LAPACK assembly/workspace paths with checked element/byte calculations and typed errors. | Every reported `rows * cols` or equivalent allocation length is checked before allocation or FFI use. **Implemented; final verification pending.** | Helper unit tests cover overflow, while source-contract tests inventory the LAPACK allocation sites that are impractical to execute at extreme dimensions. |
-| #1290 | Auto Fix | Commits `9ae171dd`, `2f103426`, and `c36c2c08` make single-output metadata registration and concatenate graph construction return `Result`, migrate workspace callers, and document fallible triangular traced methods. | Metadata registration failures reach callers without `.expect()` or a fallback value, with all affected callers and docs migrated. **Implemented; final verification pending.** | `runtime/tests/public_surface_contract.rs` requires fallible helpers and forbids `.expect()` in the reported registration bodies. |
-| #1350 | Auto Fix | Commits `87c0979e`, `966ab814`, and `cd1a3b14` replace FFT cache poison recovery through `into_inner()` with an exact typed cache error and propagate it through FFT plan resolution. | A deliberately poisoned cache must produce the expected error through the public FFT path, and silent recovery must be absent. **Implemented; final verification pending.** | Concrete poison coverage plus public FFT source-contract/error-propagation tests require the exact failure path. |
-| #1349 | Auto Fix | Commit `9f593ecd` routes `I64` DynamicTruncate sizes through integer clamping, keeping only floating dtypes on the finite/rounding path. | `2^53 + 1` remains exact on 64-bit hosts, negative values clamp to zero, and oversized values clamp to the axis extent. **Implemented; final verification pending.** | A focused unit test covers the value immediately above binary64 integer precision and the ordinary clamp boundaries. |
-| #1330 | Auto Fix | Commits `7961fb8e`, `09b3b9d3`, `b1b834be`, and `2d2ef5ec` remove the CPU sign-only rejection, harden signed position calculations before narrowing, and align CPU/CUDA cropping behavior. | Valid negative edge padding crops on CPU and CUDA while invalid dimensions and index conversions remain checked. **Implemented; CUDA hardware verification pending.** | CPU value tests cover low/high cropping and overflow edges; GPU source contracts and ignored CubeCL value tests cover signed mapping and parity. |
-| #1352 | False Positive | The kernel-local `update_window_len` product is bounded by host launch validation. Commits `81bcf014`, `5fb5e5bb`, `579a138d`, and `8c003f5e` add concrete `// INVARIANT:` markers and lexically prove every scatter launch reaches the checked window/batch calculation without proof aliases. | Each launch path must preserve a checked host product before the kernel's unchecked multiplication, and the marker must remain adjacent and re-verifiable. **Evidence recorded and guarded; final suite pending.** | `cubecl_launch_contract.rs` inventories launch sites, rejects unchecked or aliased proofs, and ties the kernel marker to host validation. |
-| #1309 | Stale / Out Of Scope | This was already resolved on `main` by `9ad0fb1a` (`Enforce AD graph emission invariants (#1324)`). Current `one_like_fixed` at `crates/tenferro-linalg/src/ad/rules/support.rs:306` calls `ad_support::one_like`; the former `scalar_one_fixed` no longer exists, and `identity_matrix_fixed` calls `ad_support::identity_matrix`. | Neither reported helper emits `StdTensorOp::Exp` for a constant. Tests at `support.rs:829` and `support.rs:844` assert `Constant`/`BroadcastInDim` structure and reject analytic constant shortcuts. **Close as already fixed by #1324 after maintainer review; no batch code change needed.** | Shared semantic constant builders centralize dtype-aware emission, and graph-structure tests reject `Exp`, `Log`, `Sin`, `Cos`, `Tanh`, `Sqrt`, `Rsqrt`, `Expm1`, or `Log1p` as constant shortcuts. |
+| #1325 | Auto Fix | Commits `0570bad9` and `3525c61e` make faer/LAPACK tensor assembly and scratch refill helpers fallible and propagate errors through their callers. | No production `.expect()` remains in the reported helpers, and the full verification suite passes. **Ready to close when the remediation PR merges.** | Unit tests exercise overflow helpers, and `cpu_linalg_source_contract.rs` guards the fallible helper boundary. |
+| #1351 | Auto Fix | Commits `0570bad9` and `3525c61e` replace reported allocation products across faer and LAPACK assembly/workspace paths with checked element/byte calculations and typed errors. | Every reported `rows * cols` or equivalent allocation length is checked before allocation or FFI use, and the full verification suite passes. **Ready to close when the remediation PR merges.** | Helper unit tests cover overflow, while source-contract tests inventory the LAPACK allocation sites that are impractical to execute at extreme dimensions. |
+| #1290 | Auto Fix | Commits `9ae171dd`, `2f103426`, and `c36c2c08` make single-output metadata registration and concatenate graph construction return `Result`, migrate workspace callers, and document fallible triangular traced methods. | Metadata registration failures reach callers without `.expect()` or a fallback value; affected callers, runtime/XLA doctests, and docs are migrated. **Ready to close when the remediation PR merges.** | `runtime/tests/public_surface_contract.rs` requires fallible helpers and forbids `.expect()` in the reported registration bodies. |
+| #1350 | Auto Fix | Commits `87c0979e`, `966ab814`, and `cd1a3b14` replace FFT cache poison recovery through `into_inner()` with an exact typed cache error and propagate it through FFT plan resolution. | A deliberately poisoned cache produces the expected error through the public FFT path, silent recovery is absent, and the full verification suite passes. **Ready to close when the remediation PR merges.** | Concrete poison coverage plus public FFT source-contract/error-propagation tests require the exact failure path. |
+| #1349 | Auto Fix | Commit `9f593ecd` routes `I64` DynamicTruncate sizes through integer clamping, keeping only floating dtypes on the finite/rounding path. | `2^53 + 1` remains exact on 64-bit hosts, negative values clamp to zero, oversized values clamp to the axis extent, and the full verification suite passes. **Ready to close when the remediation PR merges.** | A focused unit test covers the value immediately above binary64 integer precision and the ordinary clamp boundaries. |
+| #1330 | Auto Fix | Commits `7961fb8e`, `09b3b9d3`, `b1b834be`, and `2d2ef5ec` remove the CPU sign-only rejection, harden signed position calculations before narrowing, and align CPU/CUDA cropping behavior. | Valid negative edge padding crops on CPU and CUDA while invalid dimensions and index conversions remain checked; the A100 ignored test passed after RED/GREEN mutation. **Ready to close when the remediation PR merges.** | CPU value tests cover low/high cropping and overflow edges; GPU source contracts and ignored CubeCL value tests cover signed mapping and parity. |
+| #1352 | False Positive | The kernel-local `update_window_len` product is bounded by host launch validation. Commits `81bcf014`, `5fb5e5bb`, `579a138d`, and `8c003f5e` add concrete `// INVARIANT:` markers and lexically prove every scatter launch reaches the checked window/batch calculation without proof aliases. | Each launch path preserves a checked host product before the kernel's unchecked multiplication; CUDA checks and the full verification suite pass. **Ready to close with the remediation PR as a guarded false positive.** | `cubecl_launch_contract.rs` inventories launch sites, rejects unchecked or aliased proofs, and ties the kernel marker to host validation. |
+| #1309 | Stale / Out Of Scope | This was already resolved on `main` by `9ad0fb1a` (`Enforce AD graph emission invariants (#1324)`). Current `one_like_fixed` at `crates/tenferro-linalg/src/ad/rules/support.rs:306` calls `ad_support::one_like`; the former `scalar_one_fixed` no longer exists, and `identity_matrix_fixed` calls `ad_support::identity_matrix`. | Neither reported helper emits `StdTensorOp::Exp` for a constant. Tests at `support.rs:829` and `support.rs:844` assert `Constant`/`BroadcastInDim` structure and reject analytic constant shortcuts. **Closed as already fixed by #1324 after source and test verification.** | Shared semantic constant builders centralize dtype-aware emission, and graph-structure tests reject `Exp`, `Log`, `Sin`, `Cos`, `Tanh`, `Sqrt`, `Rsqrt`, `Expm1`, or `Log1p` as constant shortcuts. |
 
 ## Issue #1309 Evidence
 
@@ -60,9 +61,8 @@ into `zeros.rs`:
 - `identity_matrix_fixed_uses_semantic_constant_not_analytic_shortcut` uses the
   same analytic-shortcut rejection helper.
 
-This supports closing #1309 as stale/already fixed, citing commit
-`9ad0fb1a96112bd1e0ee33a3c581198745923635` and its regression tests. This work
-log does not perform that GitHub mutation.
+Issue #1309 was closed as stale/already fixed, citing commit
+`9ad0fb1a96112bd1e0ee33a3c581198745923635` and its regression tests.
 
 ## Scope And Design Exclusions
 
@@ -77,46 +77,51 @@ The batch does not change those policies or APIs. It also does not introduce a
 new backend, operation family, dependency, feature flag, AD convention, or
 coverage policy.
 
-## Verification Status
+## Verification Performed
 
-The implementation commits contain focused unit, source-contract, and ignored
-CUDA regression coverage described in the ledger. During work-log preparation,
-the #1309 source and commit history were inspected directly, and the following
-narrow checks were run:
+- `cargo fmt --all --check`: passed.
+- The CI-parity workspace and tropical clippy commands passed with warnings
+  denied.
+- `cargo test --workspace --release`: passed after migrating the remaining
+  runtime and XLA doctest call sites to the fallible traced API.
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+  followed by `python3 scripts/check-coverage.py coverage.json`: passed for all
+  150 measured files; three configured files were excluded.
+- `cargo doc --workspace --no-deps` followed by
+  `python3 scripts/check-docs-site.py`: passed, including four guide dependency
+  checks and rustdoc output for all 13 workspace crates checked by the script.
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD
+  --output-json /tmp/repository-rules-review.json` on the committed head:
+  passed with zero findings and no waiver.
+- The sensitive-detector finding in the GPU source-contract test was a lexical
+  false positive. Renaming the incidental lexeme resolved it; no detector
+  suppression, baseline entry, or waiver was added.
+- On an NVIDIA A100, the signed-padding ignored regression test was mutation
+  checked RED/GREEN and passed with the fix restored. The associated CUDA
+  checks also passed.
+- The focused #1309 semantic-constant regression test passed, and the issue was
+  closed as already fixed by #1324.
+- `git diff --check`: passed for the implementation state before this final
+  work-log update and is rerun for the documentation commit.
 
-- `cargo test -p tenferro-linalg --features autodiff
-  one_like_fixed_uses_semantic_constant_not_analytic_shortcut --lib`: passed,
-  one test.
-- `git diff --check`: passed.
-- `python3 scripts/check-docs-site.py`: snippet and guide dependency checks
-  passed, but the overall command stopped because workspace rustdoc output had
-  not yet been generated. It must be rerun after `cargo doc --workspace
-  --no-deps` during final verification.
-
-The following repository-required checks are **pending** and must not be
-inferred from this ledger: release workspace tests, CI-parity clippy, LLVM
-coverage plus the per-file threshold check, workspace rustdoc, the committed
-repository-rules review, and CUDA ignored tests on supported NVIDIA hardware.
-Issue closure, PR creation, branch-protection confirmation, non-squash
-auto-merge configuration, and merge are also pending.
+PR creation, merge, and closure of #1325, #1351, #1290, #1350, #1349, #1330,
+and #1352 remain pending until the remediation branch is merged.
 
 ## Environment Notes
 
-The linalg changes cover faer and LAPACK allocation/error paths. Full release
-tests may depend on the host BLAS/LAPACK linker configuration; no result is
-claimed here until that command is run. Coverage generation can require
-substantial target-directory and JSON disk space, so available disk should be
-checked before the final coverage run. CUDA value tests require the documented
-CUDA toolkit and runtime libraries; source-contract coverage does not replace
-that hardware run.
+The linalg changes cover faer and LAPACK allocation/error paths. The final
+release test and coverage runs completed with the available BLAS/LAPACK linker
+configuration. Coverage generation required substantial target-directory and
+JSON disk space but completed successfully. CUDA value verification used an
+NVIDIA A100 with the documented CUDA runtime setup.
 
 ## Residual Risks
 
 - The broad fallible traced-API migration touched runtime, AD, einsum, XLA,
-  tutorials, and tests; only the full release workspace test can establish
-  cross-crate completeness.
-- GPU signed-padding tests are ignored without CUDA, so runtime parity remains
-  hardware-gated even though CPU tests and source contracts cover the mapping.
+  tutorials, and tests. The release workspace test passed, but downstream code
+  outside this workspace may still require the same source migration.
+- GPU signed-padding runtime parity was verified on an A100; other CUDA device
+  generations remain covered by the same CubeCL path but were not sampled.
 - #1352 remains correct only while every scatter launch preserves the checked
   host proof; the lexical contract tests intentionally fail when a new launch
   path or proof alias is introduced.

--- a/samples/kdv-pinn/src/loss.rs
+++ b/samples/kdv-pinn/src/loss.rs
@@ -11,7 +11,8 @@ pub(crate) fn mean_square(
     n: usize,
 ) -> Result<TracedTensor> {
     assert!(n > 0, "mean_square count must be positive");
-    let diff = pred.add(&target.neg())?;
+    let neg_target = target.neg()?;
+    let diff = pred.add(&neg_target)?;
     let sq = diff.mul(&diff)?;
     let sum = sq.reduce_sum(&[0, 1])?;
     sum.scale_real(1.0 / n as f64)

--- a/samples/kdv-pinn/src/network.rs
+++ b/samples/kdv-pinn/src/network.rs
@@ -67,7 +67,7 @@ impl Mlp {
         for (i, layer) in self.layers.iter().enumerate() {
             y = layer.forward(&y)?;
             if i < self.layers.len() - 1 {
-                y = y.tanh();
+                y = y.tanh()?;
             }
         }
         Ok(y)

--- a/samples/kdv-pinn/src/pde/tests.rs
+++ b/samples/kdv-pinn/src/pde/tests.rs
@@ -80,7 +80,7 @@ fn jvp_mixed_variable_second_derivative() -> TestResult {
     let x = TracedTensor::input_concrete_shape(DType::F64, &[3, 1])?;
     let t = TracedTensor::input_concrete_shape(DType::F64, &[3, 1])?;
     let z = x.add(&t.scale_real(-4.0)?)?;
-    let u = z.exp();
+    let u = z.exp()?;
     let ones = TracedTensor::from_vec_col_major(vec![3, 1], vec![1.0_f64; 3])?;
     let u_x = u.jvp(&x, &ones)?;
     let u_xx = u_x.jvp(&x, &ones)?;
@@ -196,7 +196,10 @@ fn kdv_residual_of_exact_solution_is_small() -> TestResult {
     let z = x.add(&t.scale_real(-4.0)?)?;
     let one = TracedTensor::from_vec_col_major(vec![3, 1], vec![1.0_f64; 3])?;
     let two = TracedTensor::from_vec_col_major(vec![3, 1], vec![2.0_f64; 3])?;
-    let cosh = z.exp().add(&z.neg().exp())?.div(&two)?;
+    let exp_z = z.exp()?;
+    let neg_z = z.neg()?;
+    let exp_neg_z = neg_z.exp()?;
+    let cosh = exp_z.add(&exp_neg_z)?.div(&two)?;
     let sech2 = one.div(&cosh.pow(&two)?)?;
     let u = sech2.scale_real(2.0)?;
     let r = kdv_residual(&u, &x, &t)?;


### PR DESCRIPTION
## Summary

- propagate linalg allocation, tensor-construction, traced metadata, and FFT cache failures as typed errors
- preserve exact `I64` DynamicTruncate sizes and align CPU/CUDA signed pad cropping, including extreme index arithmetic
- document and mechanically guard the checked host invariant for GPU scatter update-window products
- migrate affected workspace callers, doctests, guides, and tutorial sources to the canonical fallible traced API

## Classification ledger

The reviewed issue classification, implementation decisions, verification evidence, and residual risks are recorded in [`docs/worklogs/2026-07-11-small-bugfix-remediation.md`](docs/worklogs/2026-07-11-small-bugfix-remediation.md).

Issue #1352 was verified as a false positive caused by a missing local invariant marker: host launch metadata already checks the batch/window products and zero domains return before launch. This PR adds the explicit invariant and a lexer-based source-contract inventory that rejects unproved new callers, launches, or aliases.

Issue #1309 was already fixed by #1324. Current evidence was posted to the issue and it has been closed separately.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json` (`150/150` files passed; 3 excluded)
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json` (pass, 0 findings, no waiver)
- CUDA signed-pad CPU/GPU parity test on A100, including mutation RED and restored GREEN
- `CUDA_PATH=/usr/local/cuda-12.8 cargo check -p tenferro-gpu --features cuda`

This is a batched remediation PR. Preserve its coherent commits and merge with a non-squash merge commit.

Closes #1325
Closes #1351
Closes #1290
Closes #1350
Closes #1349
Closes #1330
Closes #1352
