### PR TITLE
Support scalar pow operands on CPU and CUDA

### DIFF
--- a/crates/tenferro-cpu/src/analytic.rs
+++ b/crates/tenferro-cpu/src/analytic.rs
@@ -319,22 +319,42 @@ where
     L: TensorRank,
     R: TensorRank,
 {
-    if lhs.shape() != rhs.shape() {
+    let output_shape = if lhs.shape() == rhs.shape() {
+        lhs.shape()
+    } else if lhs.shape().is_empty() {
+        rhs.shape()
+    } else if rhs.shape().is_empty() {
+        lhs.shape()
+    } else {
         return Err(crate::Error::ShapeMismatch {
             op,
             lhs: lhs.shape().to_vec(),
             rhs: rhs.shape().to_vec(),
         });
+    };
+    // SAFETY: the selected map kernel overwrites every output element.
+    let mut out = unsafe { typed_array_uninit_from_pool(buffers, output_shape) }?;
+    if lhs.shape() == rhs.shape() {
+        zip_map2_into(
+            &mut out.view_mut(),
+            &typed_view_from_view(op, lhs)?,
+            &typed_view_from_view(op, rhs)?,
+            |x, y| x.pow_elem(y),
+        )
+        .map_err(|err| crate::Error::backend_failure(op, err))?;
+    } else if lhs.shape().is_empty() {
+        let scalar = typed_view_from_view(op, lhs)?.get(&[]);
+        map_into(&mut out.view_mut(), &typed_view_from_view(op, rhs)?, |x| {
+            scalar.pow_elem(x)
+        })
+        .map_err(|err| crate::Error::backend_failure(op, err))?;
+    } else {
+        let scalar = typed_view_from_view(op, rhs)?.get(&[]);
+        map_into(&mut out.view_mut(), &typed_view_from_view(op, lhs)?, |x| {
+            x.pow_elem(scalar)
+        })
+        .map_err(|err| crate::Error::backend_failure(op, err))?;
     }
-    // SAFETY: the following kernel overwrites every output element before any read.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
-    zip_map2_into(
-        &mut out.view_mut(),
-        &typed_view_from_view(op, lhs)?,
-        &typed_view_from_view(op, rhs)?,
-        |x, y| x.pow_elem(y),
-    )
-    .map_err(|err| crate::Error::backend_failure(op, err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -495,22 +515,42 @@ fn typed_pow_with_pool<T>(
 where
     T: PowElem + PoolScalar,
 {
-    if lhs.shape() != rhs.shape() {
+    let output_shape = if lhs.shape() == rhs.shape() {
+        lhs.shape()
+    } else if lhs.shape().is_empty() {
+        rhs.shape()
+    } else if rhs.shape().is_empty() {
+        lhs.shape()
+    } else {
         return Err(crate::Error::ShapeMismatch {
             op: "pow",
             lhs: lhs.shape().to_vec(),
             rhs: rhs.shape().to_vec(),
         });
+    };
+    // SAFETY: the selected map kernel overwrites every output element.
+    let mut out = unsafe { typed_array_uninit_from_pool(buffers, output_shape) }?;
+    if lhs.shape() == rhs.shape() {
+        zip_map2_into(
+            &mut out.view_mut(),
+            &typed_view("pow", lhs)?,
+            &typed_view("pow", rhs)?,
+            |x, y| x.pow_elem(y),
+        )
+        .map_err(|err| crate::Error::backend_failure("pow", err))?;
+    } else if lhs.shape().is_empty() {
+        let scalar = typed_view("pow", lhs)?.get(&[]);
+        map_into(&mut out.view_mut(), &typed_view("pow", rhs)?, |x| {
+            scalar.pow_elem(x)
+        })
+        .map_err(|err| crate::Error::backend_failure("pow", err))?;
+    } else {
+        let scalar = typed_view("pow", rhs)?.get(&[]);
+        map_into(&mut out.view_mut(), &typed_view("pow", lhs)?, |x| {
+            x.pow_elem(scalar)
+        })
+        .map_err(|err| crate::Error::backend_failure("pow", err))?;
     }
-    // SAFETY: the following kernel overwrites every output element before any read.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
-    zip_map2_into(
-        &mut out.view_mut(),
-        &typed_view("pow", lhs)?,
-        &typed_view("pow", rhs)?,
-        |x, y| x.pow_elem(y),
-    )
-    .map_err(|err| crate::Error::backend_failure("pow", err))?;
     Ok(tensor_from_array(out))
 }
 

--- a/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
@@ -307,8 +307,7 @@ fn test_integer_div_rem_pow_contract() {
 
 #[test]
 fn test_pow_accepts_rank_zero_operands() {
-    let f64_tensor =
-        Tensor::from_vec_col_major(vec![3], vec![2.0_f64, 3.0, 4.0]).unwrap();
+    let f64_tensor = Tensor::from_vec_col_major(vec![3], vec![2.0_f64, 3.0, 4.0]).unwrap();
     let f64_exponent = Tensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
     let f64_base = Tensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
 
@@ -331,6 +330,57 @@ fn test_pow_accepts_rank_zero_operands() {
     let scalar_base = pow(&i32_base, &i32_tensor).unwrap();
     assert_eq!(scalar_base.shape(), &[3]);
     assert_eq!(scalar_base.as_slice::<i32>().unwrap(), &[4, 8, 16]);
+}
+
+#[test]
+fn test_pow_rank_zero_read_views_and_domain_contracts() {
+    let tensor = TypedTensor::<f32>::from_vec_col_major(vec![3], vec![2.0, 3.0, 4.0]).unwrap();
+    let exponent = TypedTensor::<f32>::from_vec_col_major(vec![], vec![2.0]).unwrap();
+    let base = TypedTensor::<f32>::from_vec_col_major(vec![], vec![2.0]).unwrap();
+    let mut backend = CpuBackend::new();
+
+    let tensor_base = backend
+        .pow_read(
+            TensorRead::from_view(TensorView::F32(tensor.as_view())),
+            TensorRead::from_view(TensorView::F32(exponent.as_view())),
+        )
+        .unwrap();
+    assert_eq!(tensor_base.shape(), &[3]);
+    assert_eq!(tensor_base.as_slice::<f32>().unwrap(), &[4.0, 9.0, 16.0]);
+
+    let scalar_base = backend
+        .pow_read(
+            TensorRead::from_view(TensorView::F32(base.as_view())),
+            TensorRead::from_view(TensorView::F32(tensor.as_view())),
+        )
+        .unwrap();
+    assert_eq!(scalar_base.shape(), &[3]);
+    assert_eq!(scalar_base.as_slice::<f32>().unwrap(), &[4.0, 8.0, 16.0]);
+
+    let empty = Tensor::from_vec_col_major(vec![0, 2], Vec::<f64>::new()).unwrap();
+    let scalar = Tensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
+    let empty_out = pow(&empty, &scalar).unwrap();
+    assert_eq!(empty_out.shape(), &[0, 2]);
+    assert!(empty_out.as_slice::<f64>().unwrap().is_empty());
+
+    for (base, exponent) in [
+        (
+            Tensor::from_vec_col_major(vec![2], vec![2_i64, 3]).unwrap(),
+            Tensor::from_vec_col_major(vec![], vec![-1_i64]).unwrap(),
+        ),
+        (
+            Tensor::from_vec_col_major(vec![], vec![2_i64]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![2_i64, -1]).unwrap(),
+        ),
+    ] {
+        assert!(matches!(
+            pow(&base, &exponent),
+            Err(Error::NegativeIntegerExponent {
+                op: "pow",
+                dtype: DType::I64
+            })
+        ));
+    }
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
@@ -306,6 +306,34 @@ fn test_integer_div_rem_pow_contract() {
 }
 
 #[test]
+fn test_pow_accepts_rank_zero_operands() {
+    let f64_tensor =
+        Tensor::from_vec_col_major(vec![3], vec![2.0_f64, 3.0, 4.0]).unwrap();
+    let f64_exponent = Tensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
+    let f64_base = Tensor::from_vec_col_major(vec![], vec![2.0_f64]).unwrap();
+
+    let tensor_base = pow(&f64_tensor, &f64_exponent).unwrap();
+    assert_eq!(tensor_base.shape(), &[3]);
+    assert_eq!(tensor_base.as_slice::<f64>().unwrap(), &[4.0, 9.0, 16.0]);
+
+    let scalar_base = pow(&f64_base, &f64_tensor).unwrap();
+    assert_eq!(scalar_base.shape(), &[3]);
+    assert_eq!(scalar_base.as_slice::<f64>().unwrap(), &[4.0, 8.0, 16.0]);
+
+    let i32_tensor = Tensor::from_vec_col_major(vec![3], vec![2_i32, 3, 4]).unwrap();
+    let i32_exponent = Tensor::from_vec_col_major(vec![], vec![3_i32]).unwrap();
+    let i32_base = Tensor::from_vec_col_major(vec![], vec![2_i32]).unwrap();
+
+    let tensor_base = pow(&i32_tensor, &i32_exponent).unwrap();
+    assert_eq!(tensor_base.shape(), &[3]);
+    assert_eq!(tensor_base.as_slice::<i32>().unwrap(), &[8, 27, 64]);
+
+    let scalar_base = pow(&i32_base, &i32_tensor).unwrap();
+    assert_eq!(scalar_base.shape(), &[3]);
+    assert_eq!(scalar_base.as_slice::<i32>().unwrap(), &[4, 8, 16]);
+}
+
+#[test]
 fn test_integer_div_rem_pow_read_views_contract() {
     let lhs =
         TypedTensor::<i32>::from_vec_col_major(vec![6], vec![7_i32, -7, 7, -7, i32::MIN, i32::MAX])

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -3853,8 +3853,21 @@ impl TensorAnalytic for CudaBackend {
         if lhs.dtype() != rhs.dtype() {
             return Err(dtype_mismatch(op, lhs, rhs));
         }
-        dispatch::ensure_same_shape(op, lhs.shape(), rhs.shape())?;
         match (lhs, rhs) {
+            (Tensor::F32(lhs), Tensor::F32(rhs)) if lhs.shape() != rhs.shape() => {
+                launch_scalar_binary(
+                    self,
+                    lhs,
+                    rhs,
+                    op,
+                    |client, count, dim, out, lhs_arg, rhs_arg, lhs_scalar| unsafe {
+                        elementwise::scalar_pow_float::launch_unchecked::<f32, CubeclCudaRuntime>(
+                            client, count, dim, out, lhs_arg, rhs_arg, lhs_scalar,
+                        );
+                    },
+                )
+                .map(Tensor::F32)
+            }
             (Tensor::F32(lhs), Tensor::F32(rhs)) => launch_binary(
                 self.runtime(),
                 lhs,
@@ -3868,6 +3881,20 @@ impl TensorAnalytic for CudaBackend {
                 },
             )
             .map(Tensor::F32),
+            (Tensor::F64(lhs), Tensor::F64(rhs)) if lhs.shape() != rhs.shape() => {
+                launch_scalar_binary(
+                    self,
+                    lhs,
+                    rhs,
+                    op,
+                    |client, count, dim, out, lhs_arg, rhs_arg, lhs_scalar| unsafe {
+                        elementwise::scalar_pow_float::launch_unchecked::<f64, CubeclCudaRuntime>(
+                            client, count, dim, out, lhs_arg, rhs_arg, lhs_scalar,
+                        );
+                    },
+                )
+                .map(Tensor::F64)
+            }
             (Tensor::F64(lhs), Tensor::F64(rhs)) => launch_binary(
                 self.runtime(),
                 lhs,
@@ -3881,6 +3908,25 @@ impl TensorAnalytic for CudaBackend {
                 },
             )
             .map(Tensor::F64),
+            (Tensor::I32(lhs), Tensor::I32(rhs)) if lhs.shape() != rhs.shape() => {
+                launch_checked_integer_scalar_binary(
+                    self,
+                    lhs,
+                    rhs,
+                    op,
+                    crate::DType::I32,
+                    CheckedIntegerDomain::NegativeExponent,
+                    |client, count, dim, out, lhs_arg, rhs_arg, err_arg, lhs_scalar| unsafe {
+                        elementwise::scalar_pow_int_checked::launch_unchecked::<
+                            i32,
+                            CubeclCudaRuntime,
+                        >(
+                            client, count, dim, out, lhs_arg, rhs_arg, err_arg, lhs_scalar,
+                        );
+                    },
+                )
+                .map(Tensor::I32)
+            }
             (Tensor::I32(lhs), Tensor::I32(rhs)) => launch_checked_integer_binary(
                 self,
                 lhs,
@@ -3895,6 +3941,25 @@ impl TensorAnalytic for CudaBackend {
                 },
             )
             .map(Tensor::I32),
+            (Tensor::I64(lhs), Tensor::I64(rhs)) if lhs.shape() != rhs.shape() => {
+                launch_checked_integer_scalar_binary(
+                    self,
+                    lhs,
+                    rhs,
+                    op,
+                    crate::DType::I64,
+                    CheckedIntegerDomain::NegativeExponent,
+                    |client, count, dim, out, lhs_arg, rhs_arg, err_arg, lhs_scalar| unsafe {
+                        elementwise::scalar_pow_int_checked::launch_unchecked::<
+                            i64,
+                            CubeclCudaRuntime,
+                        >(
+                            client, count, dim, out, lhs_arg, rhs_arg, err_arg, lhs_scalar,
+                        );
+                    },
+                )
+                .map(Tensor::I64)
+            }
             (Tensor::I64(lhs), Tensor::I64(rhs)) => launch_checked_integer_binary(
                 self,
                 lhs,
@@ -3909,14 +3974,26 @@ impl TensorAnalytic for CudaBackend {
                 },
             )
             .map(Tensor::I64),
-            (Tensor::C32(_), Tensor::C32(_)) | (Tensor::C64(_), Tensor::C64(_)) => {
+            (Tensor::C32(lhs), Tensor::C32(rhs)) => {
+                dispatch::ensure_same_shape(op, lhs.shape(), rhs.shape())?;
                 Err(crate::Error::unsupported_op_dtype(
                     op,
-                    lhs.dtype(),
+                    crate::DType::C32,
                     tenferro_tensor::BackendId::Cuda,
                 ))
             }
-            _ => Err(dtype_mismatch(op, lhs, rhs)),
+            (Tensor::C64(lhs), Tensor::C64(rhs)) => {
+                dispatch::ensure_same_shape(op, lhs.shape(), rhs.shape())?;
+                Err(crate::Error::unsupported_op_dtype(
+                    op,
+                    crate::DType::C64,
+                    tenferro_tensor::BackendId::Cuda,
+                ))
+            }
+            _ => {
+                dispatch::ensure_same_shape(op, lhs.shape(), rhs.shape())?;
+                Err(dtype_mismatch(op, lhs, rhs))
+            }
         }
     }
 

--- a/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
@@ -537,6 +537,99 @@ fn test_scalar_div_rem_pow_match_cpu() {
             assert_tensor_close(&actual.unwrap(), &expected, 0.0);
         }
     }
+
+    for (empty, scalar) in [
+        (tensor_f32(vec![0], vec![]), tensor_f32(vec![], vec![2.0])),
+        (tensor_f64(vec![0], vec![]), tensor_f64(vec![], vec![2.0])),
+        (tensor_i32(vec![0], vec![]), tensor_i32(vec![], vec![2])),
+        (tensor_i64(vec![0], vec![]), tensor_i64(vec![], vec![2])),
+    ] {
+        let gpu_empty = upload(&gpu, &empty);
+        let gpu_scalar = upload(&gpu, &scalar);
+        for (expected, actual) in [
+            (
+                cpu.pow(&scalar, &empty).unwrap(),
+                gpu.pow(&gpu_scalar, &gpu_empty).unwrap(),
+            ),
+            (
+                cpu.pow(&empty, &scalar).unwrap(),
+                gpu.pow(&gpu_empty, &gpu_scalar).unwrap(),
+            ),
+        ] {
+            assert_tensor_close(&download(&gpu, &actual), &expected, 0.0);
+            assert_eq!(actual.shape(), &[0]);
+        }
+    }
+
+    for (base, exponent) in [
+        (
+            tensor_i32(vec![2], vec![2, 3]),
+            tensor_i32(vec![], vec![-1]),
+        ),
+        (
+            tensor_i64(vec![2], vec![2, 3]),
+            tensor_i64(vec![], vec![-1]),
+        ),
+        (
+            tensor_i32(vec![], vec![2]),
+            tensor_i32(vec![2], vec![2, -1]),
+        ),
+        (
+            tensor_i64(vec![], vec![2]),
+            tensor_i64(vec![2], vec![2, -1]),
+        ),
+    ] {
+        let dtype = base.dtype();
+        let gpu_base = upload(&gpu, &base);
+        let gpu_exponent = upload(&gpu, &exponent);
+        assert!(matches!(
+            gpu.pow(&gpu_base, &gpu_exponent),
+            Err(crate::Error::NegativeIntegerExponent { op: "pow", dtype: actual })
+                if actual == dtype
+        ));
+    }
+
+    let unequal_lhs = upload(&gpu, &tensor_f32(vec![2], vec![2.0, 3.0]));
+    let unequal_rhs = upload(&gpu, &tensor_f32(vec![3], vec![2.0, 3.0, 4.0]));
+    assert!(matches!(
+        gpu.pow(&unequal_lhs, &unequal_rhs),
+        Err(crate::Error::ShapeMismatch { op: "pow", lhs, rhs })
+            if lhs == vec![2] && rhs == vec![3]
+    ));
+
+    for (tensor, scalar) in [
+        (
+            tensor_f32(
+                vec![6],
+                vec![-0.0, 0.0, f32::INFINITY, f32::NEG_INFINITY, f32::NAN, -1.0],
+            ),
+            tensor_f32(vec![], vec![0.5]),
+        ),
+        (
+            tensor_f64(
+                vec![6],
+                vec![-0.0, 0.0, f64::INFINITY, f64::NEG_INFINITY, f64::NAN, -1.0],
+            ),
+            tensor_f64(vec![], vec![0.5]),
+        ),
+    ] {
+        let gpu_tensor = upload(&gpu, &tensor);
+        let gpu_scalar = upload(&gpu, &scalar);
+        for (label, expected, actual) in [
+            (
+                "scalar exponent pow",
+                cpu.pow(&tensor, &scalar).unwrap(),
+                gpu.pow(&gpu_tensor, &gpu_scalar).unwrap(),
+            ),
+            (
+                "scalar base pow",
+                cpu.pow(&scalar, &tensor).unwrap(),
+                gpu.pow(&gpu_scalar, &gpu_tensor).unwrap(),
+            ),
+        ] {
+            assert_float_classes_and_zero_signs_match(label, &download(&gpu, &actual), &expected);
+        }
+    }
 }
 
 #[test]

--- a/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
@@ -342,7 +342,7 @@ fn test_real_scalar_complex_binary_ops_match_cpu() {
 
 #[test]
 #[ignore = "requires CUDA 12.8+ GPU"]
-fn test_scalar_div_rem_match_cpu_and_pow_rejects_shape_mismatch() {
+fn test_scalar_div_rem_pow_match_cpu() {
     if !gpu_available() {
         eprintln!("skipping scalar div/rem/pow parity test - no CUDA device found");
         return;
@@ -522,30 +522,19 @@ fn test_scalar_div_rem_match_cpu_and_pow_rejects_shape_mismatch() {
     ] {
         let gpu_tensor = upload(&gpu, &tensor);
         let gpu_scalar = upload(&gpu, &scalar);
-        for (cpu_result, gpu_result, lhs_shape, rhs_shape) in [
+        for (expected, actual) in [
             (
-                cpu.pow(&scalar, &tensor),
-                gpu.pow(&gpu_scalar, &gpu_tensor),
-                vec![],
-                vec![2],
+                cpu.pow(&scalar, &tensor).unwrap(),
+                gpu.pow(&gpu_scalar, &gpu_tensor)
+                    .map(|value| download(&gpu, &value)),
             ),
             (
-                cpu.pow(&tensor, &scalar),
-                gpu.pow(&gpu_tensor, &gpu_scalar),
-                vec![2],
-                vec![],
+                cpu.pow(&tensor, &scalar).unwrap(),
+                gpu.pow(&gpu_tensor, &gpu_scalar)
+                    .map(|value| download(&gpu, &value)),
             ),
         ] {
-            for result in [cpu_result, gpu_result] {
-                match result {
-                    Err(crate::Error::ShapeMismatch { op, lhs, rhs }) => {
-                        assert_eq!(op, "pow");
-                        assert_eq!(lhs, lhs_shape);
-                        assert_eq!(rhs, rhs_shape);
-                    }
-                    other => panic!("unexpected scalar pow result: {other:?}"),
-                }
-            }
+            assert_tensor_close(&actual.unwrap(), &expected, 0.0);
         }
     }
 }

--- a/crates/tenferro-gpu/src/kernels/elementwise.rs
+++ b/crates/tenferro-gpu/src/kernels/elementwise.rs
@@ -151,6 +151,7 @@ macro_rules! scalar_binary_float_kernel {
 }
 
 scalar_binary_float_kernel!(scalar_div_float, |x, y| x / y);
+scalar_binary_float_kernel!(scalar_pow_float, |x, y| x.powf(y));
 scalar_binary_float_kernel!(scalar_rem_float, |x, y| {
     let remainder = x - (x / y).trunc() * y;
     if remainder == F::new(0.0f32) {
@@ -481,6 +482,43 @@ pub fn pow_int_checked<I: Int>(
             out[ABSOLUTE_POS] = zero;
         } else {
             let mut base = lhs[ABSOLUTE_POS];
+            let mut acc = one;
+            while exp > zero {
+                let quotient = exp / two;
+                let remainder = exp - quotient * two;
+                if remainder != zero {
+                    acc = acc * base;
+                }
+                exp = quotient;
+                if exp > zero {
+                    base = base * base;
+                }
+            }
+            out[ABSOLUTE_POS] = acc;
+        }
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn scalar_pow_int_checked<I: Int>(
+    out: &mut Array<I>,
+    lhs: &Array<I>,
+    rhs: &Array<I>,
+    err: &mut Array<i32>,
+    #[comptime] lhs_scalar: bool,
+) {
+    if ABSOLUTE_POS < out.len() {
+        let lhs_idx = if lhs_scalar { 0 } else { ABSOLUTE_POS };
+        let rhs_idx = if lhs_scalar { ABSOLUTE_POS } else { 0 };
+        let zero = I::new(0);
+        let one = I::new(1);
+        let two = I::new(2);
+        let mut exp = rhs[rhs_idx];
+        if exp < zero {
+            err[0] = 1;
+            out[ABSOLUTE_POS] = zero;
+        } else {
+            let mut base = lhs[lhs_idx];
             let mut acc = one;
             while exp > zero {
                 let quotient = exp / two;

--- a/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/cubecl_launch_contract.rs
@@ -962,7 +962,7 @@ fn cubecl_binary_elementwise_kernels_do_not_materialize_scalar_broadcasts() {
 }
 
 #[test]
-fn cubecl_scalar_div_rem_is_narrow_and_pow_remains_equal_shape() {
+fn cubecl_scalar_div_rem_pow_launches_are_narrow() {
     let mod_source = cubecl_source("mod.rs");
     let helper = source_section(
         &mod_source,
@@ -1024,14 +1024,16 @@ fn cubecl_scalar_div_rem_is_narrow_and_pow_remains_equal_shape() {
         );
     }
     let pow = source_section(&mod_source, "fn pow(", "fn transpose(");
-    assert!(!pow.contains("launch_scalar_binary"));
+    assert!(pow.contains("launch_scalar_binary"));
+    assert!(pow.contains("launch_checked_integer_scalar_binary"));
+    assert!(!pow.contains("broadcast_typed"));
     assert_ordered_needles(
-        "pow dtype and shape validation",
+        "pow dtype validation before scalar shape dispatch",
         pow,
         &[
             "if lhs.dtype() != rhs.dtype()",
             "return Err(dtype_mismatch(op, lhs, rhs))",
-            "ensure_same_shape(op, lhs.shape(), rhs.shape())?",
+            "match (lhs, rhs)",
         ],
     );
     assert!(pow.contains("launch_binary("));

--- a/docs/superpowers/plans/2026-07-13-backend-scalar-pow.md
+++ b/docs/superpowers/plans/2026-07-13-backend-scalar-pow.md
@@ -1,0 +1,88 @@
+# Backend Scalar `pow` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add native rank-0 operand support to direct CPU and CUDA `pow` execution without dense scalar materialization.
+
+**Architecture:** General broadcasting remains in runtime/eager/traced layers. CPU gains a scalar-aware mapping helper for owned and read-view paths; CUDA reuses its scalar launch boundary with pow-specific float and checked-integer kernels. Existing equal-shape behavior remains unchanged.
+
+**Tech Stack:** Rust, strided-kernel views, CubeCL CUDA kernels, cargo tests, A100 ignored tests.
+
+---
+
+### Task 1: Establish CPU RED coverage
+
+**Files:**
+- Modify: `crates/tenferro-cpu/src/tests/analytic_tests.rs`
+- Modify: `crates/tenferro-cpu/src/analytic.rs` only after RED
+
+- [ ] Add direct `CpuBackend::pow` tests for F32/F64/I32/I64 with tensor-base/scalar-exponent and scalar-base/tensor-exponent inputs. Assert output shape and exact representative values.
+- [ ] Add negative integer scalar and tensor exponent cases asserting the existing typed error.
+- [ ] Add unequal non-scalar shape rejection and empty non-scalar output cases.
+- [ ] Run the exact new test target and confirm failure is `ShapeMismatch` for a scalar case, not a test setup error.
+- [ ] Commit the RED tests separately.
+
+### Task 2: Implement CPU scalar mapping
+
+**Files:**
+- Modify: `crates/tenferro-cpu/src/analytic.rs`
+- Test: `crates/tenferro-cpu/src/tests/analytic_tests.rs`
+
+- [ ] Add a private helper that accepts two typed views, permits exact shape or exactly one rank-0 operand, selects the non-scalar output shape, reads the scalar once, and writes one pooled output in operand order.
+- [ ] Route owned `typed_pow_with_pool` and view-based `typed_pow_view_with_pool` through the helper without allocating a broadcast tensor.
+- [ ] Keep integer exponent validation before mapping and retain exact error fields.
+- [ ] Run the new CPU tests and relevant analytic crate tests; confirm GREEN.
+- [ ] Run formatting and commit the CPU implementation.
+
+### Task 3: Establish CUDA RED and source contracts
+
+**Files:**
+- Modify: `crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs`
+- Modify: `crates/tenferro-gpu/tests/cubecl_launch_contract.rs`
+
+- [ ] Replace the scalar-pow rejection assertions with CPU-oracle parity for both operand positions and F32/F64/I32/I64.
+- [ ] Include empty tensors, unequal non-scalar rejection, negative integer exponents, and floating exceptional-class checks.
+- [ ] Change the source contract to require a scalar launch branch for `pow`, forbid `broadcast_typed`, and preserve dtype-before-shape validation.
+- [ ] Run the source contract and confirm RED because `pow` lacks the scalar launcher.
+- [ ] On A100, run the focused ignored test and confirm RED with current `ShapeMismatch`.
+- [ ] Commit the RED CUDA tests separately.
+
+### Task 4: Implement CUDA scalar pow kernels
+
+**Files:**
+- Modify: `crates/tenferro-gpu/src/cubecl/kernels/elementwise.rs`
+- Modify: `crates/tenferro-gpu/src/cubecl/mod.rs`
+- Test: `crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs`
+- Test: `crates/tenferro-gpu/tests/cubecl_launch_contract.rs`
+
+- [ ] Add `scalar_pow_float`, reading index zero from the rank-0 operand and the output index from the tensor operand.
+- [ ] Add `scalar_pow_int_checked` with the existing negative-exponent device flag contract.
+- [ ] Route only unequal-shape, exactly-one-rank-0 pow inputs through existing scalar launch helpers; leave equal-shape kernels untouched.
+- [ ] Preserve residency validation and empty-output ordering in the shared launch helpers.
+- [ ] Run source contracts, CUDA feature no-run compilation, and the focused A100 test; confirm GREEN.
+- [ ] Run `cargo fmt --all --check` and commit the CUDA implementation.
+
+### Task 5: Neighborhood scan and documentation
+
+**Files:**
+- Modify if needed: `docs/guides/devices-and-gpu.md`
+- Create: `docs/worklogs/2026-07-13-backend-scalar-pow.md`
+
+- [ ] Search current active docs and capability tables for claims that scalar `pow` is rejected; update only active statements.
+- [ ] Confirm public/runtime/eager/traced pow already broadcast explicitly and require no production changes.
+- [ ] Record issue context, external semantic references, RED/GREEN evidence, design choice, rejected backend-general broadcasting, and residual risks in the worklog.
+- [ ] Run docs/source contract checks and commit documentation.
+
+### Task 6: Full verification, review, and PR
+
+**Files:**
+- Modify if findings require: files already in scope
+
+- [ ] Run full ignored CUDA suite on A100 with the supported CUDA environment.
+- [ ] Run `cargo fmt --all --check` and CI-exact workspace/tropical clippy.
+- [ ] Run `cargo test --workspace --release`.
+- [ ] Run release llvm-cov plus `scripts/check-coverage.py`.
+- [ ] Run workspace docs plus `scripts/check-docs-site.py`.
+- [ ] Run committed-head `scripts/repository-rules-review.py` and resolve findings.
+- [ ] Perform a final specification and code-quality review against issue #1371 and this plan.
+- [ ] Push, create one PR with `Closes #1371`, monitor review and all CI including RunPod GPU gate, resolve actionable feedback, enable normal squash auto-merge, and verify the merged commit and closed issue.

--- a/docs/superpowers/specs/2026-07-13-backend-scalar-pow-design.md
+++ b/docs/superpowers/specs/2026-07-13-backend-scalar-pow-design.md
@@ -1,0 +1,94 @@
+# Backend Scalar `pow` Design
+
+## Context
+
+Issue #1371 concerns rank-0 operands passed directly to CPU and CUDA backend
+`pow`. The public `TensorOpsExt`, typed, eager, and traced APIs already own
+general NumPy-style broadcasting and emit explicit broadcast operations before
+backend execution. Direct backend `pow` currently requires exact shape equality.
+
+JAX, PyTorch, and NumPy establish scalar/tensor power as expected user-facing
+semantics. This design adds the corresponding narrow backend capability to both
+CPU and CUDA without moving general broadcasting into the backend layer.
+
+## Contract
+
+Exactly one same-dtype rank-0 operand may pair with a non-scalar tensor:
+
+- tensor base, scalar exponent: `[N, ...] ** [] -> [N, ...]`
+- scalar base, tensor exponent: `[] ** [N, ...] -> [N, ...]`
+
+Two scalars continue through the existing equal-shape path and return shape
+`[]`. Two unequal non-scalar shapes continue to return `ShapeMismatch`.
+
+Supported dtypes are the existing backend `pow` dtypes: `F32`, `F64`, `I32`,
+and `I64` on CUDA, plus the CPU dtypes it already supports. This change does not
+add CUDA complex power or mixed-dtype power.
+
+Integer exponent validation remains global over the logical exponent operand.
+A negative scalar exponent fails before output production, and a tensor
+exponent containing any negative value produces the same typed
+`NegativeIntegerExponent` error as the equal-shape path.
+
+## CPU Design
+
+The CPU implementation gains a scalar-aware internal mapping path shared by
+owned tensors and `TensorRead` views. It selects the non-scalar operand shape,
+reads the rank-0 value once, allocates one output, and applies `PowElem` in the
+original operand order. It must not allocate a dense broadcast of the scalar.
+
+Integer validation runs against the original exponent view before scalar-aware
+mapping. Exact-shape behavior and complex CPU behavior remain unchanged.
+
+## CUDA Design
+
+CUDA reuses the existing scalar-binary launch boundary introduced for `div`
+and `rem`. New scalar-indexed float and checked-integer pow kernels map the
+rank-0 operand to index zero and the tensor operand to the output index. The
+checked integer kernel retains the device error flag and reports the existing
+negative-exponent error after synchronization.
+
+The ordinary equal-shape kernels remain unchanged. Source-contract tests must
+forbid `broadcast_typed` and require the scalar launch only in the one-scalar
+branch.
+
+## Public, Traced, And AD Surfaces
+
+No public, traced, or AD implementation changes are required. Those layers
+already broadcast inputs explicitly and reduce broadcast cotangents to original
+input shapes. Existing tests remain regression coverage; focused tests will
+confirm that this change does not alter their graph representation.
+
+## Error And Edge Semantics
+
+- Dtype mismatch remains checked before shape dispatch.
+- Unequal non-scalar shapes remain `ShapeMismatch` with original operand shapes.
+- Empty non-scalar tensors produce an empty output after residency and shape
+  validation, without launching a kernel.
+- Floating results follow the existing CPU `pow` oracle for finite values,
+  NaN, infinity, and signed zero.
+- Device residency is validated before CUDA early returns.
+
+## Verification
+
+Testing follows RED/GREEN discipline:
+
+1. Replace the CPU/CUDA scalar-pow rejection regression with expected parity
+   and observe it fail on both direct backends.
+2. Add CPU owned/read-view tests for both operand orders, dtypes, empty output,
+   negative integer exponents, and incompatible non-scalar shapes.
+3. Add CUDA A100 parity tests for `F32`, `F64`, `I32`, and `I64`, including
+   floating exceptional classes and exact integer errors.
+4. Update launch/source contracts and prove they fail before the CUDA dispatch
+   change.
+5. Run focused crates, CUDA no-run compilation, the ignored A100 suite, and the
+   complete repository pre-PR checklist.
+
+## Non-goals
+
+- General backend-level broadcasting
+- Dense scalar materialization
+- New dtype promotion
+- Complex CUDA `pow`
+- Mixed-dtype `pow`
+- New public APIs, dependencies, feature flags, or AD conventions

--- a/docs/worklogs/2026-07-13-backend-scalar-pow.md
+++ b/docs/worklogs/2026-07-13-backend-scalar-pow.md
@@ -1,0 +1,47 @@
+# Backend scalar `pow` support
+
+## Summary
+
+Issue #1371 adds rank-0 operand support to direct CPU and CUDA `pow`
+execution. General broadcasting remains owned by the runtime/eager/traced
+layers; the backend path accepts only equal shapes or exactly one rank-0
+operand and never materializes a dense broadcasted scalar.
+
+## Context and corrected scope
+
+The investigation began from the earlier #1358 report that CUDA rejected a
+case accepted by CPU. At that revision, both direct backends rejected it.
+Public `TensorOpsExt::pow`, typed, eager-AD, and traced APIs already performed
+explicit NumPy-style broadcasting and needed no production change. The accepted
+#1371 contract therefore deliberately extends both direct backends together.
+
+The user-facing precedent was checked against the official JAX `jnp.power`,
+PyTorch `torch.pow`, and NumPy `power` documentation: each supports scalar and
+broadcast-compatible operands. This change adopts only the rank-0 backend
+subset needed to avoid CPU/CUDA divergence.
+
+## Implementation
+
+- CPU owned-buffer and read-view paths read the scalar once and map directly
+  over the non-scalar operand using the existing pooled kernels.
+- CUDA float paths use a scalar-indexed `powf` kernel through the existing
+  scalar binary launch boundary.
+- CUDA integer paths use a scalar-indexed checked kernel, retaining the device
+  error flag and `NegativeIntegerExponent` contract.
+- Equal-shape behavior and error precedence are unchanged. Unequal non-scalar
+  shapes still return `ShapeMismatch`.
+
+## Verification evidence
+
+The CPU regression first failed with `ShapeMismatch { op: "pow", lhs: [3],
+rhs: [] }`; after implementation, all 243 CPU library tests passed. The CUDA
+source contract first failed because `pow` lacked a scalar launcher. The
+focused A100 test then passed for F32, F64, I32, and I64 in both operand
+positions, including empty outputs, integer negative-exponent errors,
+non-scalar shape rejection, and floating NaN/infinity/signed-zero classes.
+The CUDA feature build also completed with `--no-run`.
+
+## Residual scope
+
+This does not add general raw-backend broadcasting, mixed-dtype power, or CUDA
+complex power. Public broadcasting remains an upper-layer responsibility.


### PR DESCRIPTION
Closes #1371

## Summary

- accept exactly one rank-0 operand in direct CPU and CUDA `pow` execution
- preserve equal-shape behavior, integer negative-exponent errors, and unequal non-scalar shape rejection
- avoid dense scalar materialization on both backends
- cover F32/F64/I32/I64, read views, empty outputs, IEEE special values, and A100 parity

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json` (150/150 files)
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD ...` (pass, no findings)
- CUDA A100: `cargo test -p tenferro-gpu --features cuda -- --ignored --test-threads=1` (93 passed)