### PR TITLE
feat(cpu): add NUMA-aware execution placement

### DIFF
--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -726,7 +726,6 @@ jobs:
 
               gpuTypeIds: [
                 "NVIDIA RTX A2000",
-                "Tesla T4",
                 "NVIDIA GeForce RTX 3070",
                 "NVIDIA GeForce RTX 3080",
                 "NVIDIA GeForce RTX 3080 Ti",

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -86,3 +86,8 @@ required-features = ["cpu-blas"]
 [[bench]]
 name = "grouped_gemm"
 harness = false
+
+[[bench]]
+name = "numa_execution"
+harness = false
+required-features = ["cpu-faer"]

--- a/crates/tenferro-cpu/benches/numa_execution.rs
+++ b/crates/tenferro-cpu/benches/numa_execution.rs
@@ -1,0 +1,116 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use tenferro_cpu::{CpuBackend, CpuBackendKind, CpuPlacement};
+use tenferro_tensor::{BackendSessionHost, DotGeneralConfig, Tensor};
+
+const MATRIX_SHAPE: [usize; 2] = [512, 512];
+
+fn matrix() -> Tensor {
+    let len = MATRIX_SHAPE.iter().product();
+    Tensor::from_vec_col_major(MATRIX_SHAPE.to_vec(), vec![1.0_f64; len])
+        .expect("NUMA benchmark matrix should be valid")
+}
+
+fn run_session_workload(backend: &mut CpuBackend, input: &Tensor) -> Tensor {
+    backend
+        .with_backend_session(|exec| {
+            let squared = exec.mul(input, input)?;
+            exec.dot_general(
+                &squared,
+                input,
+                &DotGeneralConfig {
+                    lhs_contracting_dims: vec![1],
+                    rhs_contracting_dims: vec![0],
+                    lhs_batch_dims: vec![],
+                    rhs_batch_dims: vec![],
+                },
+            )
+        })
+        .expect("NUMA benchmark session workload should succeed")
+}
+
+fn print_metadata(label: &str, backend: &CpuBackend) {
+    let info = backend.execution_info();
+    eprintln!(
+        "numa_execution case={label} allowed={:?} topology={:?} requested={:?} resolved={:?} kind={:?} provider={} workers={} shape={:?}",
+        backend.topology().allowed_cpus().as_usize_vec(),
+        backend.topology(),
+        info.requested_placement(),
+        info.resolved_placement(),
+        info.backend_kind(),
+        info.provider_diagnostic(),
+        backend.num_threads(),
+        MATRIX_SHAPE,
+    );
+}
+
+fn bench_numa_execution(c: &mut Criterion) {
+    let coordinator = CpuBackend::with_kind(CpuBackendKind::Faer)
+        .expect("NUMA benchmark requires the cpu-faer feature");
+    let nodes = coordinator.topology().nodes();
+    if nodes.len() < 2 {
+        eprintln!(
+            "numa_execution skipped: need at least two process-visible NUMA nodes; allowed={:?} topology={:?}",
+            coordinator.topology().allowed_cpus().as_usize_vec(),
+            coordinator.topology(),
+        );
+        return;
+    }
+
+    let node0 = coordinator
+        .for_placement(CpuPlacement::NumaNode(nodes[0].id()))
+        .expect("first reported NUMA node should resolve");
+    let node1 = coordinator
+        .for_placement(CpuPlacement::NumaNode(nodes[1].id()))
+        .expect("second reported NUMA node should resolve");
+    let all_allowed = coordinator
+        .for_placement(CpuPlacement::AllAllowed)
+        .expect("faer AllAllowed placement should resolve");
+    let input = matrix();
+
+    print_metadata("disjoint_nodes_concurrent/first", &node0);
+    print_metadata("disjoint_nodes_concurrent/second", &node1);
+    print_metadata("all_allowed", &all_allowed);
+
+    let mut node0_backend = node0;
+    let mut node1_backend = node1;
+    c.bench_function("numa_execution/disjoint_nodes_concurrent", |b| {
+        b.iter(|| {
+            std::thread::scope(|scope| {
+                let first = scope.spawn(|| run_session_workload(&mut node0_backend, &input));
+                let second = scope.spawn(|| run_session_workload(&mut node1_backend, &input));
+                black_box(first.join().expect("first NUMA benchmark worker panicked"));
+                black_box(
+                    second
+                        .join()
+                        .expect("second NUMA benchmark worker panicked"),
+                );
+            });
+        });
+    });
+
+    let mut all_backend = all_allowed;
+    c.bench_function("numa_execution/all_allowed", |b| {
+        b.iter(|| black_box(run_session_workload(&mut all_backend, &input)));
+    });
+
+    #[cfg(feature = "cpu-blas")]
+    {
+        let provider = CpuBackend::with_kind(CpuBackendKind::Blas)
+            .expect("compiled BLAS provider should construct");
+        print_metadata("provider_default_exclusive", &provider);
+        let mut provider_backend = provider;
+        c.bench_function("numa_execution/provider_default_exclusive", |b| {
+            b.iter(|| black_box(run_session_workload(&mut provider_backend, &input)));
+        });
+    }
+
+    #[cfg(not(feature = "cpu-blas"))]
+    eprintln!(
+        "numa_execution provider_default_exclusive skipped: compile cpu-blas with a linked provider"
+    );
+}
+
+criterion_group!(benches, bench_numa_execution);
+criterion_main!(benches);

--- a/crates/tenferro-cpu/benches/numa_execution.rs
+++ b/crates/tenferro-cpu/benches/numa_execution.rs
@@ -1,14 +1,15 @@
 use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use tenferro_cpu::{CpuBackend, CpuBackendKind, CpuPlacement};
+use tenferro_cpu::{available_parallelism, CpuBackend, CpuBackendKind, CpuPlacement};
 use tenferro_tensor::{BackendSessionHost, DotGeneralConfig, Tensor};
 
-const MATRIX_SHAPE: [usize; 2] = [512, 512];
+const MATRIX_SIZES: [usize; 3] = [64, 256, 512];
 
-fn matrix() -> Tensor {
-    let len = MATRIX_SHAPE.iter().product();
-    Tensor::from_vec_col_major(MATRIX_SHAPE.to_vec(), vec![1.0_f64; len])
+fn matrix(size: usize) -> Tensor {
+    let shape = [size, size];
+    let len = shape.iter().product();
+    Tensor::from_vec_col_major(shape.to_vec(), vec![1.0_f64; len])
         .expect("NUMA benchmark matrix should be valid")
 }
 
@@ -30,28 +31,59 @@ fn run_session_workload(backend: &mut CpuBackend, input: &Tensor) -> Tensor {
         .expect("NUMA benchmark session workload should succeed")
 }
 
-fn print_metadata(label: &str, backend: &CpuBackend) {
+fn print_metadata(label: &str, backend: &CpuBackend, size: usize) {
     let info = backend.execution_info();
     eprintln!(
-        "numa_execution case={label} allowed={:?} topology={:?} requested={:?} resolved={:?} kind={:?} provider={} workers={} shape={:?}",
-        backend.topology().allowed_cpus().as_usize_vec(),
-        backend.topology(),
+        "numa_execution case={label} allowed={:?} topology={:?} requested={:?} resolved={:?} mode={:?} kind={:?} provider={} workers={} shape={:?}",
+        info.topology().allowed_cpus().as_usize_vec(),
+        info.topology(),
         info.requested_placement(),
         info.resolved_placement(),
+        info.execution_mode(),
         info.backend_kind(),
         info.provider_diagnostic(),
-        backend.num_threads(),
-        MATRIX_SHAPE,
+        info.worker_count(),
+        [size, size],
     );
 }
 
-fn bench_numa_execution(c: &mut Criterion) {
-    let coordinator = CpuBackend::with_kind(CpuBackendKind::Faer)
+fn bench_configuration(c: &mut Criterion, size: usize, threads: usize) {
+    let coordinator = CpuBackend::with_threads_and_kind(threads, CpuBackendKind::Faer)
         .expect("NUMA benchmark requires the cpu-faer feature");
+    let all_allowed = coordinator
+        .for_placement(CpuPlacement::AllAllowed)
+        .expect("faer AllAllowed placement should resolve");
+    let input = matrix(size);
+    let case = format!("numa_execution/{size}x{size}/threads_{threads}");
+    print_metadata(&format!("{case}/all_allowed"), &all_allowed, size);
+
+    let mut all_backend = all_allowed;
+    c.bench_function(&format!("{case}/all_allowed"), |b| {
+        b.iter(|| black_box(run_session_workload(&mut all_backend, &input)));
+    });
+
+    #[cfg(feature = "cpu-blas")]
+    {
+        let provider = CpuBackend::with_threads_and_kind(threads, CpuBackendKind::Blas)
+            .expect("compiled BLAS provider should construct");
+        print_metadata(
+            &format!("{case}/provider_default_exclusive"),
+            &provider,
+            size,
+        );
+        let mut provider_backend = provider;
+        c.bench_function(&format!("{case}/provider_default_exclusive"), |b| {
+            b.iter(|| black_box(run_session_workload(&mut provider_backend, &input)));
+        });
+    }
+
+    #[cfg(not(feature = "cpu-blas"))]
+    eprintln!("{case}/provider_default_exclusive skipped: compile cpu-blas with a linked provider");
+
     let nodes = coordinator.topology().nodes();
     if nodes.len() < 2 {
         eprintln!(
-            "numa_execution skipped: need at least two process-visible NUMA nodes; allowed={:?} topology={:?}",
+            "{case}/disjoint_nodes_concurrent skipped: need at least two process-visible NUMA nodes; allowed={:?} topology={:?}",
             coordinator.topology().allowed_cpus().as_usize_vec(),
             coordinator.topology(),
         );
@@ -64,18 +96,20 @@ fn bench_numa_execution(c: &mut Criterion) {
     let node1 = coordinator
         .for_placement(CpuPlacement::NumaNode(nodes[1].id()))
         .expect("second reported NUMA node should resolve");
-    let all_allowed = coordinator
-        .for_placement(CpuPlacement::AllAllowed)
-        .expect("faer AllAllowed placement should resolve");
-    let input = matrix();
-
-    print_metadata("disjoint_nodes_concurrent/first", &node0);
-    print_metadata("disjoint_nodes_concurrent/second", &node1);
-    print_metadata("all_allowed", &all_allowed);
+    print_metadata(
+        &format!("{case}/disjoint_nodes_concurrent/first"),
+        &node0,
+        size,
+    );
+    print_metadata(
+        &format!("{case}/disjoint_nodes_concurrent/second"),
+        &node1,
+        size,
+    );
 
     let mut node0_backend = node0;
     let mut node1_backend = node1;
-    c.bench_function("numa_execution/disjoint_nodes_concurrent", |b| {
+    c.bench_function(&format!("{case}/disjoint_nodes_concurrent"), |b| {
         b.iter(|| {
             std::thread::scope(|scope| {
                 let first = scope.spawn(|| run_session_workload(&mut node0_backend, &input));
@@ -89,27 +123,19 @@ fn bench_numa_execution(c: &mut Criterion) {
             });
         });
     });
+}
 
-    let mut all_backend = all_allowed;
-    c.bench_function("numa_execution/all_allowed", |b| {
-        b.iter(|| black_box(run_session_workload(&mut all_backend, &input)));
-    });
+fn bench_numa_execution(c: &mut Criterion) {
+    let default_threads = available_parallelism();
+    let mut thread_budgets = vec![1, default_threads];
+    thread_budgets.sort_unstable();
+    thread_budgets.dedup();
 
-    #[cfg(feature = "cpu-blas")]
-    {
-        let provider = CpuBackend::with_kind(CpuBackendKind::Blas)
-            .expect("compiled BLAS provider should construct");
-        print_metadata("provider_default_exclusive", &provider);
-        let mut provider_backend = provider;
-        c.bench_function("numa_execution/provider_default_exclusive", |b| {
-            b.iter(|| black_box(run_session_workload(&mut provider_backend, &input)));
-        });
+    for size in MATRIX_SIZES {
+        for &threads in &thread_budgets {
+            bench_configuration(c, size, threads);
+        }
     }
-
-    #[cfg(not(feature = "cpu-blas"))]
-    eprintln!(
-        "numa_execution provider_default_exclusive skipped: compile cpu-blas with a linked provider"
-    );
 }
 
 criterion_group!(benches, bench_numa_execution);

--- a/crates/tenferro-cpu/src/affinity.rs
+++ b/crates/tenferro-cpu/src/affinity.rs
@@ -1,5 +1,7 @@
 use std::num::NonZeroUsize;
 
+use crate::{CpuId, CpuSet};
+
 /// Return a best-effort CPU count available to the current process.
 ///
 /// This first tries an OS-standard process-affinity query when supported, then
@@ -34,16 +36,41 @@ pub fn process_cpu_affinity_count() -> Option<usize> {
     platform_process_cpu_affinity_count()
 }
 
+/// Return the process affinity mask as logical CPU identifiers when supported.
+///
+/// The returned set preserves sparse operating-system CPU IDs. Platforms where
+/// the standard affinity API exposes only a count return `None`.
+///
+/// # Examples
+///
+/// ```
+/// if let Some(cpus) = tenferro_cpu::process_cpu_affinity() {
+///     assert!(!cpus.is_empty());
+/// }
+/// ```
+pub fn process_cpu_affinity() -> Option<CpuSet> {
+    platform_process_cpu_affinity()
+}
+
 pub(crate) fn standard_available_parallelism() -> Option<usize> {
     std::thread::available_parallelism()
         .ok()
         .map(NonZeroUsize::get)
 }
 
-#[cfg(any(target_os = "linux", target_os = "android", test))]
+#[cfg(test)]
 fn count_affinity_mask_bits(mask: &[u8]) -> Option<usize> {
-    let count = mask.iter().map(|byte| byte.count_ones() as usize).sum();
-    (count > 0).then_some(count)
+    cpu_set_from_affinity_mask(mask).map(|cpus| cpus.len())
+}
+
+#[cfg(any(target_os = "linux", target_os = "android", test))]
+fn cpu_set_from_affinity_mask(mask: &[u8]) -> Option<CpuSet> {
+    let cpus = mask.iter().enumerate().flat_map(|(byte_index, byte)| {
+        (0..u8::BITS as usize)
+            .filter(move |bit| byte & (1 << bit) != 0)
+            .map(move |bit| CpuId::new(byte_index * u8::BITS as usize + bit))
+    });
+    CpuSet::new(cpus).ok()
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -58,6 +85,11 @@ fn linux_next_affinity_mask_bytes(mask_bytes: usize, errno: Option<i32>) -> Opti
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 fn platform_process_cpu_affinity_count() -> Option<usize> {
+    platform_process_cpu_affinity().map(|cpus| cpus.len())
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn platform_process_cpu_affinity() -> Option<CpuSet> {
     unsafe extern "C" {
         fn sched_getaffinity(pid: i32, cpusetsize: usize, mask: *mut core::ffi::c_void) -> i32;
     }
@@ -73,7 +105,7 @@ fn platform_process_cpu_affinity_count() -> Option<usize> {
             sched_getaffinity(0, mask_bytes, mask.as_mut_ptr().cast::<core::ffi::c_void>())
         };
         if rc == 0 {
-            return count_affinity_mask_bits(&mask);
+            return cpu_set_from_affinity_mask(&mask);
         }
 
         mask_bytes = linux_next_affinity_mask_bytes(
@@ -81,6 +113,11 @@ fn platform_process_cpu_affinity_count() -> Option<usize> {
             std::io::Error::last_os_error().raw_os_error(),
         )?;
     }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn platform_process_cpu_affinity() -> Option<CpuSet> {
+    None
 }
 
 #[cfg(target_os = "windows")]

--- a/crates/tenferro-cpu/src/affinity.rs
+++ b/crates/tenferro-cpu/src/affinity.rs
@@ -26,9 +26,9 @@ pub(crate) fn current_cpu() -> Result<CpuId, String> {
         // SAFETY: `sched_getcpu` takes no arguments and returns the calling
         // thread's current logical CPU or a negative error sentinel.
         let cpu = unsafe { sched_getcpu() };
-        return usize::try_from(cpu)
+        usize::try_from(cpu)
             .map(CpuId::new)
-            .map_err(|_| std::io::Error::last_os_error().to_string());
+            .map_err(|_| std::io::Error::last_os_error().to_string())
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -67,9 +67,9 @@ fn set_current_thread_affinity(cpus: &CpuSet) -> Result<(), String> {
         // matches its byte length, and pid 0 selects the calling thread.
         let rc =
             unsafe { sched_setaffinity(0, mask.len(), mask.as_ptr().cast::<core::ffi::c_void>()) };
-        return (rc == 0)
+        (rc == 0)
             .then_some(())
-            .ok_or_else(|| std::io::Error::last_os_error().to_string());
+            .ok_or_else(|| std::io::Error::last_os_error().to_string())
     }
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {

--- a/crates/tenferro-cpu/src/affinity.rs
+++ b/crates/tenferro-cpu/src/affinity.rs
@@ -2,6 +2,82 @@ use std::num::NonZeroUsize;
 
 use crate::{CpuId, CpuSet};
 
+pub(crate) trait ThreadAffinity: Clone + Send + Sync + 'static {
+    fn pin_current(&self, cpu: CpuId) -> Result<CpuSet, String>;
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SystemThreadAffinity;
+
+impl ThreadAffinity for SystemThreadAffinity {
+    fn pin_current(&self, cpu: CpuId) -> Result<CpuSet, String> {
+        set_current_thread_affinity(&CpuSet::new([cpu]).map_err(|err| err.to_string())?)?;
+        process_cpu_affinity().ok_or_else(|| "failed to verify worker affinity".to_owned())
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn current_cpu() -> Result<CpuId, String> {
+    #[cfg(target_os = "linux")]
+    {
+        unsafe extern "C" {
+            fn sched_getcpu() -> i32;
+        }
+        // SAFETY: `sched_getcpu` takes no arguments and returns the calling
+        // thread's current logical CPU or a negative error sentinel.
+        let cpu = unsafe { sched_getcpu() };
+        return usize::try_from(cpu)
+            .map(CpuId::new)
+            .map_err(|_| std::io::Error::last_os_error().to_string());
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        Err("current logical CPU discovery is unsupported on this platform".to_owned())
+    }
+}
+
+fn set_current_thread_affinity(cpus: &CpuSet) -> Result<(), String> {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        unsafe extern "C" {
+            fn sched_setaffinity(
+                pid: i32,
+                cpusetsize: usize,
+                mask: *const core::ffi::c_void,
+            ) -> i32;
+        }
+
+        let highest_cpu = cpus
+            .as_slice()
+            .last()
+            .copied()
+            .ok_or_else(|| "cannot set an empty affinity mask".to_owned())?;
+        let required_bytes = highest_cpu
+            .as_usize()
+            .checked_div(u8::BITS as usize)
+            .and_then(|index| index.checked_add(1))
+            .ok_or_else(|| "affinity mask size overflow".to_owned())?;
+        let mut mask = vec![0u8; required_bytes.max(128)];
+        for cpu in cpus.as_slice() {
+            let byte = cpu.as_usize() / u8::BITS as usize;
+            let bit = cpu.as_usize() % u8::BITS as usize;
+            mask[byte] |= 1 << bit;
+        }
+        // SAFETY: `mask` remains allocated for the call, `cpusetsize` exactly
+        // matches its byte length, and pid 0 selects the calling thread.
+        let rc =
+            unsafe { sched_setaffinity(0, mask.len(), mask.as_ptr().cast::<core::ffi::c_void>()) };
+        return (rc == 0)
+            .then_some(())
+            .ok_or_else(|| std::io::Error::last_os_error().to_string());
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        let _ = cpus;
+        Err("setting thread affinity is unsupported on this platform".to_owned())
+    }
+}
+
 /// Return a best-effort CPU count available to the current process.
 ///
 /// This first tries an OS-standard process-affinity query when supported, then

--- a/crates/tenferro-cpu/src/affinity.rs
+++ b/crates/tenferro-cpu/src/affinity.rs
@@ -47,22 +47,7 @@ fn set_current_thread_affinity(cpus: &CpuSet) -> Result<(), String> {
             ) -> i32;
         }
 
-        let highest_cpu = cpus
-            .as_slice()
-            .last()
-            .copied()
-            .ok_or_else(|| "cannot set an empty affinity mask".to_owned())?;
-        let required_bytes = highest_cpu
-            .as_usize()
-            .checked_div(u8::BITS as usize)
-            .and_then(|index| index.checked_add(1))
-            .ok_or_else(|| "affinity mask size overflow".to_owned())?;
-        let mut mask = vec![0u8; required_bytes.max(128)];
-        for cpu in cpus.as_slice() {
-            let byte = cpu.as_usize() / u8::BITS as usize;
-            let bit = cpu.as_usize() % u8::BITS as usize;
-            mask[byte] |= 1 << bit;
-        }
+        let mask = build_affinity_mask(cpus)?;
         // SAFETY: `mask` remains allocated for the call, `cpusetsize` exactly
         // matches its byte length, and pid 0 selects the calling thread.
         let rc =
@@ -76,6 +61,40 @@ fn set_current_thread_affinity(cpus: &CpuSet) -> Result<(), String> {
         let _ = cpus;
         Err("setting thread affinity is unsupported on this platform".to_owned())
     }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android", test))]
+fn build_affinity_mask(cpus: &CpuSet) -> Result<Vec<u8>, String> {
+    const MIN_MASK_BYTES: usize = 128;
+    const MAX_MASK_BYTES: usize = 1 << 20;
+
+    let highest_cpu = cpus
+        .as_slice()
+        .last()
+        .copied()
+        .ok_or_else(|| "cannot set an empty affinity mask".to_owned())?;
+    let required_bytes = highest_cpu
+        .as_usize()
+        .checked_div(u8::BITS as usize)
+        .and_then(|index| index.checked_add(1))
+        .ok_or_else(|| "affinity mask size overflow".to_owned())?
+        .max(MIN_MASK_BYTES);
+    if required_bytes > MAX_MASK_BYTES {
+        return Err(format!(
+            "CPU {highest_cpu} exceeds supported affinity mask size of {MAX_MASK_BYTES} bytes"
+        ));
+    }
+
+    let mut mask = Vec::new();
+    mask.try_reserve_exact(required_bytes)
+        .map_err(|error| format!("failed to allocate affinity mask: {error}"))?;
+    mask.resize(required_bytes, 0u8);
+    for cpu in cpus.as_slice() {
+        let byte = cpu.as_usize() / u8::BITS as usize;
+        let bit = cpu.as_usize() % u8::BITS as usize;
+        mask[byte] |= 1 << bit;
+    }
+    Ok(mask)
 }
 
 /// Return a best-effort CPU count available to the current process.

--- a/crates/tenferro-cpu/src/affinity/tests.rs
+++ b/crates/tenferro-cpu/src/affinity/tests.rs
@@ -15,6 +15,12 @@ fn count_affinity_mask_bits_sums_all_set_bits() {
     );
 }
 
+#[test]
+fn affinity_mask_preserves_sparse_logical_cpu_ids() {
+    let cpus = cpu_set_from_affinity_mask(&[0b1000_0010, 0b0000_0101]).unwrap();
+    assert_eq!(cpus.as_usize_vec(), vec![1, 7, 8, 10]);
+}
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[test]
 fn linux_next_affinity_mask_bytes_retries_only_on_einval() {
@@ -38,6 +44,10 @@ fn available_parallelism_helpers_report_positive_counts() {
     }
     if let Some(count) = process_cpu_affinity_count() {
         assert!(count >= 1);
+    }
+    if let Some(cpus) = process_cpu_affinity() {
+        assert!(!cpus.is_empty());
+        assert_eq!(process_cpu_affinity_count(), Some(cpus.len()));
     }
 }
 

--- a/crates/tenferro-cpu/src/affinity/tests.rs
+++ b/crates/tenferro-cpu/src/affinity/tests.rs
@@ -21,6 +21,13 @@ fn affinity_mask_preserves_sparse_logical_cpu_ids() {
     assert_eq!(cpus.as_usize_vec(), vec![1, 7, 8, 10]);
 }
 
+#[test]
+fn affinity_mask_rejects_extreme_cpu_ids_before_allocation() {
+    let cpus = CpuSet::new([CpuId::new(usize::MAX)]).unwrap();
+    let error = build_affinity_mask(&cpus).unwrap_err();
+    assert!(error.contains("exceeds supported affinity mask"));
+}
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[test]
 fn linux_next_affinity_mask_bytes_retries_only_on_einval() {

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -21,12 +21,20 @@ impl ResourceOwner {
 thread_local! {
     static THREAD_OWNER: ResourceOwner = ResourceOwner::fresh();
     static EXECUTION_OWNER: Cell<Option<ResourceOwner>> = const { Cell::new(None) };
+    static POOL_EXECUTION_OWNER: Cell<Option<ResourceOwner>> = const { Cell::new(None) };
 }
 
+pub(crate) const PARALLEL_REENTRY_PANIC: &str =
+    "CpuBackend cannot be re-entered from a parallel Rayon child task while its CPU execution pool is active";
+
 pub(crate) fn inherited_or_new_execution_owner() -> ResourceOwner {
-    EXECUTION_OWNER
-        .with(Cell::get)
-        .unwrap_or_else(ResourceOwner::fresh)
+    if let Some(owner) = EXECUTION_OWNER.with(Cell::get) {
+        return owner;
+    }
+    if POOL_EXECUTION_OWNER.with(Cell::get).is_some() {
+        panic!("{PARALLEL_REENTRY_PANIC}");
+    }
+    ResourceOwner::fresh()
 }
 
 pub(crate) fn with_execution_owner<R>(owner: ResourceOwner, op: impl FnOnce() -> R) -> R {
@@ -43,8 +51,8 @@ pub(crate) fn with_execution_owner<R>(owner: ResourceOwner, op: impl FnOnce() ->
     op()
 }
 
-pub(crate) fn set_execution_owner(owner: Option<ResourceOwner>) {
-    EXECUTION_OWNER.set(owner);
+pub(crate) fn set_pool_execution_owner(owner: Option<ResourceOwner>) {
+    POOL_EXECUTION_OWNER.set(owner);
 }
 
 #[cfg(test)]

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
 
 use thiserror::Error;
 
@@ -56,6 +56,11 @@ pub(crate) struct ResourceArbiter {
 impl ResourceArbiter {
     pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    pub(crate) fn global() -> Self {
+        static GLOBAL: OnceLock<ResourceArbiter> = OnceLock::new();
+        GLOBAL.get_or_init(Self::new).clone()
     }
 
     #[cfg(test)]

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -33,13 +33,20 @@ impl ResourceRequest {
 struct Waiter {
     id: u64,
     request: ResourceRequest,
+    owner: std::thread::ThreadId,
+}
+
+#[derive(Debug)]
+struct ActiveRequest {
+    request: ResourceRequest,
+    owner: std::thread::ThreadId,
 }
 
 #[derive(Debug, Default)]
 struct ArbiterState {
     next_request_id: u64,
     waiters: VecDeque<Waiter>,
-    active: BTreeMap<u64, ResourceRequest>,
+    active: BTreeMap<u64, ActiveRequest>,
 }
 
 #[derive(Debug, Default)]
@@ -134,11 +141,12 @@ impl ResourceArbiter {
             .lock()
             .map_err(|_| ResourceArbiterError::StatePoisoned)?;
         let id = state.next_request_id;
+        let owner = std::thread::current().id();
         state.next_request_id = state
             .next_request_id
             .checked_add(1)
             .ok_or(ResourceArbiterError::RequestIdExhausted)?;
-        state.waiters.push_back(Waiter { id, request });
+        state.waiters.push_back(Waiter { id, request, owner });
         self.inner.changed.notify_all();
 
         loop {
@@ -146,20 +154,28 @@ impl ResourceArbiter {
                 return Err(ResourceArbiterError::StatePoisoned);
             };
             let request = &state.waiters[position].request;
+            let reentrant = state.active.values().any(|active| active.owner == owner);
             let active_compatible = state
                 .active
                 .values()
-                .all(|active| !active.conflicts_with(request));
-            let older_compatible = state
-                .waiters
-                .iter()
-                .take(position)
-                .all(|older| !older.request.conflicts_with(request));
+                .all(|active| active.owner == owner || !active.request.conflicts_with(request));
+            let older_compatible = reentrant
+                || state
+                    .waiters
+                    .iter()
+                    .take(position)
+                    .all(|older| !older.request.conflicts_with(request));
             if active_compatible && older_compatible {
                 let Some(waiter) = state.waiters.remove(position) else {
                     return Err(ResourceArbiterError::StatePoisoned);
                 };
-                state.active.insert(id, waiter.request);
+                state.active.insert(
+                    id,
+                    ActiveRequest {
+                        request: waiter.request,
+                        owner: waiter.owner,
+                    },
+                );
                 return Ok(ResourcePermit {
                     inner: Arc::clone(&self.inner),
                     id,
@@ -188,14 +204,17 @@ impl ResourceArbiter {
             .state
             .lock()
             .map_err(|_| ResourceArbiterError::StatePoisoned)?;
+        let owner = std::thread::current().id();
+        let reentrant = state.active.values().any(|active| active.owner == owner);
         let conflicts_with_active = state
             .active
             .values()
-            .any(|active| active.conflicts_with(&request));
-        let bypasses_waiter = state
-            .waiters
-            .iter()
-            .any(|waiter| waiter.request.conflicts_with(&request));
+            .any(|active| active.owner != owner && active.request.conflicts_with(&request));
+        let bypasses_waiter = !reentrant
+            && state
+                .waiters
+                .iter()
+                .any(|waiter| waiter.request.conflicts_with(&request));
         if conflicts_with_active || bypasses_waiter {
             return Ok(None);
         }
@@ -204,7 +223,7 @@ impl ResourceArbiter {
             .next_request_id
             .checked_add(1)
             .ok_or(ResourceArbiterError::RequestIdExhausted)?;
-        state.active.insert(id, request);
+        state.active.insert(id, ActiveRequest { request, owner });
         Ok(Some(ResourcePermit {
             inner: Arc::clone(&self.inner),
             id,

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -58,10 +58,12 @@ impl ResourceArbiter {
         Self::default()
     }
 
+    #[cfg(test)]
     pub(crate) fn acquire(&self, cpus: CpuSet) -> Result<ResourcePermit, ResourceArbiterError> {
         self.acquire_request(ResourceRequest::CpuSet(cpus))
     }
 
+    #[cfg(test)]
     pub(crate) fn try_acquire(
         &self,
         cpus: CpuSet,
@@ -69,16 +71,52 @@ impl ResourceArbiter {
         self.try_acquire_request(ResourceRequest::CpuSet(cpus))
     }
 
+    #[cfg(test)]
     pub(crate) fn acquire_provider_exclusive(
         &self,
     ) -> Result<ResourcePermit, ResourceArbiterError> {
         self.acquire_request(ResourceRequest::ProviderExclusive)
     }
 
+    #[cfg(test)]
     pub(crate) fn try_acquire_provider_exclusive(
         &self,
     ) -> Result<Option<ResourcePermit>, ResourceArbiterError> {
         self.try_acquire_request(ResourceRequest::ProviderExclusive)
+    }
+
+    pub(crate) fn acquire_recovering(&self, cpus: CpuSet) -> ResourcePermit {
+        self.acquire_request_recovering(ResourceRequest::CpuSet(cpus))
+    }
+
+    pub(crate) fn acquire_provider_exclusive_recovering(&self) -> ResourcePermit {
+        self.acquire_request_recovering(ResourceRequest::ProviderExclusive)
+    }
+
+    fn acquire_request_recovering(&self, request: ResourceRequest) -> ResourcePermit {
+        loop {
+            match self.acquire_request(request.clone()) {
+                Ok(permit) => return permit,
+                Err(ResourceArbiterError::StatePoisoned) => {
+                    self.inner.state.clear_poison();
+                }
+                Err(ResourceArbiterError::RequestIdExhausted) => {
+                    let mut state = self
+                        .inner
+                        .state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    while !state.active.is_empty() || !state.waiters.is_empty() {
+                        state = self
+                            .inner
+                            .changed
+                            .wait(state)
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    }
+                    state.next_request_id = 0;
+                }
+            }
+        }
     }
 
     fn acquire_request(
@@ -135,6 +173,7 @@ impl ResourceArbiter {
         }
     }
 
+    #[cfg(test)]
     fn try_acquire_request(
         &self,
         request: ResourceRequest,

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -43,6 +43,11 @@ pub(crate) fn with_execution_owner<R>(owner: ResourceOwner, op: impl FnOnce() ->
     op()
 }
 
+pub(crate) fn set_execution_owner(owner: Option<ResourceOwner>) {
+    EXECUTION_OWNER.set(owner);
+}
+
+#[cfg(test)]
 fn request_owner() -> ResourceOwner {
     EXECUTION_OWNER
         .with(Cell::get)
@@ -115,7 +120,7 @@ impl ResourceArbiter {
 
     #[cfg(test)]
     pub(crate) fn acquire(&self, cpus: CpuSet) -> Result<ResourcePermit, ResourceArbiterError> {
-        self.acquire_request(ResourceRequest::CpuSet(cpus))
+        self.acquire_request(ResourceRequest::CpuSet(cpus), request_owner())
     }
 
     #[cfg(test)]
@@ -130,7 +135,7 @@ impl ResourceArbiter {
     pub(crate) fn acquire_provider_exclusive(
         &self,
     ) -> Result<ResourcePermit, ResourceArbiterError> {
-        self.acquire_request(ResourceRequest::ProviderExclusive)
+        self.acquire_request(ResourceRequest::ProviderExclusive, request_owner())
     }
 
     #[cfg(test)]
@@ -140,17 +145,24 @@ impl ResourceArbiter {
         self.try_acquire_request(ResourceRequest::ProviderExclusive)
     }
 
-    pub(crate) fn acquire_recovering(&self, cpus: CpuSet) -> ResourcePermit {
-        self.acquire_request_recovering(ResourceRequest::CpuSet(cpus))
+    pub(crate) fn acquire_recovering(&self, cpus: CpuSet, owner: ResourceOwner) -> ResourcePermit {
+        self.acquire_request_recovering(ResourceRequest::CpuSet(cpus), owner)
     }
 
-    pub(crate) fn acquire_provider_exclusive_recovering(&self) -> ResourcePermit {
-        self.acquire_request_recovering(ResourceRequest::ProviderExclusive)
+    pub(crate) fn acquire_provider_exclusive_recovering(
+        &self,
+        owner: ResourceOwner,
+    ) -> ResourcePermit {
+        self.acquire_request_recovering(ResourceRequest::ProviderExclusive, owner)
     }
 
-    fn acquire_request_recovering(&self, request: ResourceRequest) -> ResourcePermit {
+    fn acquire_request_recovering(
+        &self,
+        request: ResourceRequest,
+        owner: ResourceOwner,
+    ) -> ResourcePermit {
         loop {
-            match self.acquire_request(request.clone()) {
+            match self.acquire_request(request.clone(), owner) {
                 Ok(permit) => return permit,
                 Err(ResourceArbiterError::StatePoisoned) => {
                     self.inner.state.clear_poison();
@@ -177,6 +189,7 @@ impl ResourceArbiter {
     fn acquire_request(
         &self,
         request: ResourceRequest,
+        owner: ResourceOwner,
     ) -> Result<ResourcePermit, ResourceArbiterError> {
         let mut state = self
             .inner
@@ -184,7 +197,6 @@ impl ResourceArbiter {
             .lock()
             .map_err(|_| ResourceArbiterError::StatePoisoned)?;
         let id = state.next_request_id;
-        let owner = request_owner();
         state.next_request_id = state
             .next_request_id
             .checked_add(1)

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -1,10 +1,53 @@
+use std::cell::Cell;
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 
 use thiserror::Error;
 
 use crate::CpuSet;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ResourceOwner(u64);
+
+impl ResourceOwner {
+    fn fresh() -> Self {
+        static NEXT_OWNER: AtomicU64 = AtomicU64::new(1);
+        Self(NEXT_OWNER.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+thread_local! {
+    static THREAD_OWNER: ResourceOwner = ResourceOwner::fresh();
+    static EXECUTION_OWNER: Cell<Option<ResourceOwner>> = const { Cell::new(None) };
+}
+
+pub(crate) fn inherited_or_new_execution_owner() -> ResourceOwner {
+    EXECUTION_OWNER
+        .with(Cell::get)
+        .unwrap_or_else(ResourceOwner::fresh)
+}
+
+pub(crate) fn with_execution_owner<R>(owner: ResourceOwner, op: impl FnOnce() -> R) -> R {
+    struct RestoreOwner(Option<ResourceOwner>);
+
+    impl Drop for RestoreOwner {
+        fn drop(&mut self) {
+            EXECUTION_OWNER.set(self.0);
+        }
+    }
+
+    let previous = EXECUTION_OWNER.replace(Some(owner));
+    let _restore = RestoreOwner(previous);
+    op()
+}
+
+fn request_owner() -> ResourceOwner {
+    EXECUTION_OWNER
+        .with(Cell::get)
+        .unwrap_or_else(|| THREAD_OWNER.with(|owner| *owner))
+}
 
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 pub(crate) enum ResourceArbiterError {
@@ -33,13 +76,13 @@ impl ResourceRequest {
 struct Waiter {
     id: u64,
     request: ResourceRequest,
-    owner: std::thread::ThreadId,
+    owner: ResourceOwner,
 }
 
 #[derive(Debug)]
 struct ActiveRequest {
     request: ResourceRequest,
-    owner: std::thread::ThreadId,
+    owner: ResourceOwner,
 }
 
 #[derive(Debug, Default)]
@@ -141,7 +184,7 @@ impl ResourceArbiter {
             .lock()
             .map_err(|_| ResourceArbiterError::StatePoisoned)?;
         let id = state.next_request_id;
-        let owner = std::thread::current().id();
+        let owner = request_owner();
         state.next_request_id = state
             .next_request_id
             .checked_add(1)
@@ -179,6 +222,7 @@ impl ResourceArbiter {
                 return Ok(ResourcePermit {
                     inner: Arc::clone(&self.inner),
                     id,
+                    reentrant,
                 });
             }
 
@@ -204,7 +248,7 @@ impl ResourceArbiter {
             .state
             .lock()
             .map_err(|_| ResourceArbiterError::StatePoisoned)?;
-        let owner = std::thread::current().id();
+        let owner = request_owner();
         let reentrant = state.active.values().any(|active| active.owner == owner);
         let conflicts_with_active = state
             .active
@@ -227,6 +271,7 @@ impl ResourceArbiter {
         Ok(Some(ResourcePermit {
             inner: Arc::clone(&self.inner),
             id,
+            reentrant,
         }))
     }
 
@@ -268,6 +313,13 @@ impl ResourceArbiter {
 pub(crate) struct ResourcePermit {
     inner: Arc<ArbiterInner>,
     id: u64,
+    reentrant: bool,
+}
+
+impl ResourcePermit {
+    pub(crate) fn is_reentrant(&self) -> bool {
+        self.reentrant
+    }
 }
 
 impl fmt::Debug for ResourcePermit {

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -24,15 +24,15 @@ thread_local! {
     static POOL_EXECUTION_OWNER: Cell<Option<ResourceOwner>> = const { Cell::new(None) };
 }
 
-pub(crate) const PARALLEL_REENTRY_PANIC: &str =
-    "CpuBackend cannot be re-entered from a parallel Rayon child task while its CPU execution pool is active";
+pub(crate) const BACKEND_REENTRY_PANIC: &str =
+    "CpuBackend cannot be re-entered while another CPU backend execution is active on this thread or managed Rayon scope";
 
 pub(crate) fn inherited_or_new_execution_owner() -> ResourceOwner {
-    if let Some(owner) = EXECUTION_OWNER.with(Cell::get) {
-        return owner;
-    }
     if POOL_EXECUTION_OWNER.with(Cell::get).is_some() {
-        panic!("{PARALLEL_REENTRY_PANIC}");
+        panic!("{BACKEND_REENTRY_PANIC}");
+    }
+    if EXECUTION_OWNER.with(Cell::get).is_some() {
+        panic!("{BACKEND_REENTRY_PANIC}");
     }
     ResourceOwner::fresh()
 }
@@ -53,6 +53,20 @@ pub(crate) fn with_execution_owner<R>(owner: ResourceOwner, op: impl FnOnce() ->
 
 pub(crate) fn set_pool_execution_owner(owner: Option<ResourceOwner>) {
     POOL_EXECUTION_OWNER.set(owner);
+}
+
+pub(crate) fn with_pool_execution_owner<R>(owner: ResourceOwner, op: impl FnOnce() -> R) -> R {
+    struct RestoreOwner(Option<ResourceOwner>);
+
+    impl Drop for RestoreOwner {
+        fn drop(&mut self) {
+            POOL_EXECUTION_OWNER.set(self.0);
+        }
+    }
+
+    let previous = POOL_EXECUTION_OWNER.replace(Some(owner));
+    let _restore = RestoreOwner(previous);
+    op()
 }
 
 #[cfg(test)]

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -1,0 +1,231 @@
+use std::collections::{BTreeMap, VecDeque};
+use std::fmt;
+use std::sync::{Arc, Condvar, Mutex};
+
+use thiserror::Error;
+
+use crate::CpuSet;
+
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub(crate) enum ResourceArbiterError {
+    #[error("CPU resource arbiter state is poisoned")]
+    StatePoisoned,
+    #[error("CPU resource arbiter request IDs are exhausted")]
+    RequestIdExhausted,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ResourceRequest {
+    CpuSet(CpuSet),
+    ProviderExclusive,
+}
+
+impl ResourceRequest {
+    fn conflicts_with(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::ProviderExclusive, _) | (_, Self::ProviderExclusive) => true,
+            (Self::CpuSet(left), Self::CpuSet(right)) => left.overlaps(right),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Waiter {
+    id: u64,
+    request: ResourceRequest,
+}
+
+#[derive(Debug, Default)]
+struct ArbiterState {
+    next_request_id: u64,
+    waiters: VecDeque<Waiter>,
+    active: BTreeMap<u64, ResourceRequest>,
+}
+
+#[derive(Debug, Default)]
+struct ArbiterInner {
+    state: Mutex<ArbiterState>,
+    changed: Condvar,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ResourceArbiter {
+    inner: Arc<ArbiterInner>,
+}
+
+impl ResourceArbiter {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn acquire(&self, cpus: CpuSet) -> Result<ResourcePermit, ResourceArbiterError> {
+        self.acquire_request(ResourceRequest::CpuSet(cpus))
+    }
+
+    pub(crate) fn try_acquire(
+        &self,
+        cpus: CpuSet,
+    ) -> Result<Option<ResourcePermit>, ResourceArbiterError> {
+        self.try_acquire_request(ResourceRequest::CpuSet(cpus))
+    }
+
+    pub(crate) fn acquire_provider_exclusive(
+        &self,
+    ) -> Result<ResourcePermit, ResourceArbiterError> {
+        self.acquire_request(ResourceRequest::ProviderExclusive)
+    }
+
+    pub(crate) fn try_acquire_provider_exclusive(
+        &self,
+    ) -> Result<Option<ResourcePermit>, ResourceArbiterError> {
+        self.try_acquire_request(ResourceRequest::ProviderExclusive)
+    }
+
+    fn acquire_request(
+        &self,
+        request: ResourceRequest,
+    ) -> Result<ResourcePermit, ResourceArbiterError> {
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| ResourceArbiterError::StatePoisoned)?;
+        let id = state.next_request_id;
+        state.next_request_id = state
+            .next_request_id
+            .checked_add(1)
+            .ok_or(ResourceArbiterError::RequestIdExhausted)?;
+        state.waiters.push_back(Waiter { id, request });
+        self.inner.changed.notify_all();
+
+        loop {
+            let Some(position) = state.waiters.iter().position(|waiter| waiter.id == id) else {
+                return Err(ResourceArbiterError::StatePoisoned);
+            };
+            let request = &state.waiters[position].request;
+            let active_compatible = state
+                .active
+                .values()
+                .all(|active| !active.conflicts_with(request));
+            let older_compatible = state
+                .waiters
+                .iter()
+                .take(position)
+                .all(|older| !older.request.conflicts_with(request));
+            if active_compatible && older_compatible {
+                let Some(waiter) = state.waiters.remove(position) else {
+                    return Err(ResourceArbiterError::StatePoisoned);
+                };
+                state.active.insert(id, waiter.request);
+                return Ok(ResourcePermit {
+                    inner: Arc::clone(&self.inner),
+                    id,
+                });
+            }
+
+            state = match self.inner.changed.wait(state) {
+                Ok(state) => state,
+                Err(poisoned) => {
+                    let mut state = poisoned.into_inner();
+                    state.waiters.retain(|waiter| waiter.id != id);
+                    self.inner.changed.notify_all();
+                    return Err(ResourceArbiterError::StatePoisoned);
+                }
+            };
+        }
+    }
+
+    fn try_acquire_request(
+        &self,
+        request: ResourceRequest,
+    ) -> Result<Option<ResourcePermit>, ResourceArbiterError> {
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .map_err(|_| ResourceArbiterError::StatePoisoned)?;
+        let conflicts_with_active = state
+            .active
+            .values()
+            .any(|active| active.conflicts_with(&request));
+        let bypasses_waiter = state
+            .waiters
+            .iter()
+            .any(|waiter| waiter.request.conflicts_with(&request));
+        if conflicts_with_active || bypasses_waiter {
+            return Ok(None);
+        }
+        let id = state.next_request_id;
+        state.next_request_id = state
+            .next_request_id
+            .checked_add(1)
+            .ok_or(ResourceArbiterError::RequestIdExhausted)?;
+        state.active.insert(id, request);
+        Ok(Some(ResourcePermit {
+            inner: Arc::clone(&self.inner),
+            id,
+        }))
+    }
+
+    #[cfg(test)]
+    fn wait_for_waiter_count_for_test(
+        &self,
+        expected: usize,
+        timeout: std::time::Duration,
+    ) -> bool {
+        let Ok(mut state) = self.inner.state.lock() else {
+            return false;
+        };
+        let deadline = std::time::Instant::now() + timeout;
+        while state.waiters.len() < expected {
+            let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
+                return false;
+            };
+            let Ok((next, wait)) = self.inner.changed.wait_timeout(state, remaining) else {
+                return false;
+            };
+            state = next;
+            if wait.timed_out() && state.waiters.len() < expected {
+                return false;
+            }
+        }
+        true
+    }
+
+    #[cfg(test)]
+    fn poison_for_test(&self) {
+        let inner = Arc::clone(&self.inner);
+        let _ = std::panic::catch_unwind(move || {
+            let _state = inner.state.lock().unwrap();
+            panic!("forced arbiter poisoning");
+        });
+    }
+}
+
+pub(crate) struct ResourcePermit {
+    inner: Arc<ArbiterInner>,
+    id: u64,
+}
+
+impl fmt::Debug for ResourcePermit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ResourcePermit")
+            .field("id", &self.id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for ResourcePermit {
+    fn drop(&mut self) {
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.active.remove(&self.id);
+        self.inner.changed.notify_all();
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tenferro-cpu/src/arbiter/tests.rs
+++ b/crates/tenferro-cpu/src/arbiter/tests.rs
@@ -1,0 +1,81 @@
+use super::*;
+use crate::{CpuId, CpuSet};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::Arc;
+use std::time::Duration;
+
+#[test]
+fn disjoint_domains_run_together_but_all_allowed_waits() {
+    let arbiter = ResourceArbiter::new();
+    let node0 = arbiter.acquire(cpu_set([0, 1])).unwrap();
+    let node1 = arbiter.try_acquire(cpu_set([2, 3])).unwrap().unwrap();
+    assert!(arbiter
+        .try_acquire(cpu_set([0, 1, 2, 3]))
+        .unwrap()
+        .is_none());
+    drop((node0, node1));
+    assert!(arbiter
+        .try_acquire(cpu_set([0, 1, 2, 3]))
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn provider_exclusive_conflicts_with_every_cpu_domain() {
+    let arbiter = ResourceArbiter::new();
+    let _node = arbiter.acquire(cpu_set([4, 5])).unwrap();
+    assert!(arbiter.try_acquire_provider_exclusive().unwrap().is_none());
+}
+
+#[test]
+fn panic_releases_provider_exclusive_reservation() {
+    let arbiter = ResourceArbiter::new();
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        let _permit = arbiter.acquire_provider_exclusive().unwrap();
+        panic!("forced");
+    }));
+    assert!(arbiter.try_acquire_provider_exclusive().unwrap().is_some());
+}
+
+#[test]
+fn older_all_allowed_waiter_blocks_younger_disjoint_admission() {
+    let arbiter = Arc::new(ResourceArbiter::new());
+    let active = arbiter.acquire(cpu_set([0, 1])).unwrap();
+    let waiter_arbiter = Arc::clone(&arbiter);
+    let waiter = std::thread::spawn(move || waiter_arbiter.acquire(cpu_set([0, 1, 2, 3])).unwrap());
+    assert!(arbiter.wait_for_waiter_count_for_test(1, Duration::from_secs(2)));
+
+    assert!(arbiter.try_acquire(cpu_set([2, 3])).unwrap().is_none());
+    drop(active);
+    drop(waiter.join().unwrap());
+}
+
+#[test]
+fn older_blocked_node_waiter_does_not_serialize_a_disjoint_node() {
+    let arbiter = Arc::new(ResourceArbiter::new());
+    let active = arbiter.acquire(cpu_set([0, 1])).unwrap();
+    let waiter_arbiter = Arc::clone(&arbiter);
+    let waiter = std::thread::spawn(move || waiter_arbiter.acquire(cpu_set([0, 1])).unwrap());
+    assert!(arbiter.wait_for_waiter_count_for_test(1, Duration::from_secs(2)));
+
+    let disjoint = arbiter.try_acquire(cpu_set([2, 3])).unwrap();
+    assert!(disjoint.is_some());
+    drop(disjoint);
+    drop(active);
+    drop(waiter.join().unwrap());
+}
+
+#[test]
+fn poisoned_state_returns_a_typed_error() {
+    let arbiter = ResourceArbiter::new();
+    arbiter.poison_for_test();
+
+    assert!(matches!(
+        arbiter.try_acquire(cpu_set([0])),
+        Err(ResourceArbiterError::StatePoisoned)
+    ));
+}
+
+fn cpu_set<const N: usize>(cpus: [usize; N]) -> CpuSet {
+    CpuSet::new(cpus.map(CpuId::new)).unwrap()
+}

--- a/crates/tenferro-cpu/src/arbiter/tests.rs
+++ b/crates/tenferro-cpu/src/arbiter/tests.rs
@@ -8,11 +8,8 @@ use std::time::Duration;
 fn disjoint_domains_run_together_but_all_allowed_waits() {
     let arbiter = ResourceArbiter::new();
     let node0 = arbiter.acquire(cpu_set([0, 1])).unwrap();
-    let node1 = arbiter.try_acquire(cpu_set([2, 3])).unwrap().unwrap();
-    assert!(arbiter
-        .try_acquire(cpu_set([0, 1, 2, 3]))
-        .unwrap()
-        .is_none());
+    let node1 = try_cpu_on_other_thread(&arbiter, cpu_set([2, 3])).unwrap();
+    assert!(try_cpu_on_other_thread(&arbiter, cpu_set([0, 1, 2, 3])).is_none());
     drop((node0, node1));
     assert!(arbiter
         .try_acquire(cpu_set([0, 1, 2, 3]))
@@ -24,7 +21,36 @@ fn disjoint_domains_run_together_but_all_allowed_waits() {
 fn provider_exclusive_conflicts_with_every_cpu_domain() {
     let arbiter = ResourceArbiter::new();
     let _node = arbiter.acquire(cpu_set([4, 5])).unwrap();
-    assert!(arbiter.try_acquire_provider_exclusive().unwrap().is_none());
+    let other = arbiter.clone();
+    assert!(
+        std::thread::spawn(move || other.try_acquire_provider_exclusive().unwrap())
+            .join()
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn same_thread_reentrant_request_does_not_wait_on_its_own_permit() {
+    let arbiter = ResourceArbiter::new();
+    let _outer = arbiter.acquire_provider_exclusive().unwrap();
+
+    assert!(arbiter.try_acquire(cpu_set([0])).unwrap().is_some());
+}
+
+#[test]
+fn blocking_same_thread_reentrant_request_completes() {
+    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let arbiter = ResourceArbiter::new();
+        let _outer = arbiter.acquire_provider_exclusive().unwrap();
+        let _inner = arbiter.acquire(cpu_set([0])).unwrap();
+        completed_tx.send(()).unwrap();
+    });
+
+    assert!(completed_rx
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .is_ok());
 }
 
 #[test]
@@ -45,7 +71,7 @@ fn older_all_allowed_waiter_blocks_younger_disjoint_admission() {
     let waiter = std::thread::spawn(move || waiter_arbiter.acquire(cpu_set([0, 1, 2, 3])).unwrap());
     assert!(arbiter.wait_for_waiter_count_for_test(1, Duration::from_secs(2)));
 
-    assert!(arbiter.try_acquire(cpu_set([2, 3])).unwrap().is_none());
+    assert!(try_cpu_on_other_thread(&arbiter, cpu_set([2, 3])).is_none());
     drop(active);
     drop(waiter.join().unwrap());
 }
@@ -58,7 +84,7 @@ fn older_blocked_node_waiter_does_not_serialize_a_disjoint_node() {
     let waiter = std::thread::spawn(move || waiter_arbiter.acquire(cpu_set([0, 1])).unwrap());
     assert!(arbiter.wait_for_waiter_count_for_test(1, Duration::from_secs(2)));
 
-    let disjoint = arbiter.try_acquire(cpu_set([2, 3])).unwrap();
+    let disjoint = try_cpu_on_other_thread(&arbiter, cpu_set([2, 3]));
     assert!(disjoint.is_some());
     drop(disjoint);
     drop(active);
@@ -78,4 +104,11 @@ fn poisoned_state_returns_a_typed_error() {
 
 fn cpu_set<const N: usize>(cpus: [usize; N]) -> CpuSet {
     CpuSet::new(cpus.map(CpuId::new)).unwrap()
+}
+
+fn try_cpu_on_other_thread(arbiter: &ResourceArbiter, cpus: CpuSet) -> Option<ResourcePermit> {
+    let other = arbiter.clone();
+    std::thread::spawn(move || other.try_acquire(cpus).unwrap())
+        .join()
+        .unwrap()
 }

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use crate::arbiter::{ResourceArbiter, ResourcePermit};
 use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
 use crate::engine::CpuEngine;
-use crate::placement::{resolve_placement, ResolvedCpuExecution};
+use crate::placement::{resolve_placement, resolve_placement_with_affinity, ResolvedCpuExecution};
 use crate::{
     discover_cpu_topology, CpuId, CpuPlacement, CpuPlacementError, CpuSet, CpuTopology,
     CpuTopologyError, NumaNodeId, ResolvedCpuPlacement,
@@ -242,6 +242,70 @@ pub enum CpuExecutionMode {
     Compatibility,
 }
 
+/// Errors returned while constructing a [`CpuBackend`].
+///
+/// Placement failures remain typed so callers can distinguish topology
+/// discovery failures from unsupported placement requests. Configuration and
+/// provider-selection failures retain the existing tensor error contract.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{CpuBackend, CpuBackendError};
+///
+/// let error = CpuBackend::with_threads(0).unwrap_err();
+/// assert!(matches!(error, CpuBackendError::Tensor(_)));
+/// ```
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum CpuBackendError {
+    /// CPU context configuration or provider selection failed.
+    #[error(transparent)]
+    Tensor(#[from] crate::Error),
+    /// CPU placement resolution or engine construction failed.
+    #[error("{op}: {source}")]
+    Placement {
+        /// Constructor that observed the placement failure.
+        op: &'static str,
+        /// Typed placement failure.
+        #[source]
+        source: CpuPlacementError,
+    },
+}
+
+impl CpuBackendError {
+    fn placement(op: &'static str, source: CpuPlacementError) -> Self {
+        Self::Placement { op, source }
+    }
+
+    /// Return the typed placement failure, when construction reached placement resolution.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuBackend, CpuBackendError};
+    ///
+    /// let result: Result<CpuBackend, CpuBackendError> = CpuBackend::with_threads(1);
+    /// if let Err(error) = result {
+    ///     let _placement_failure = error.placement_error();
+    /// }
+    /// ```
+    pub fn placement_error(&self) -> Option<&CpuPlacementError> {
+        match self {
+            Self::Tensor(_) => None,
+            Self::Placement { source, .. } => Some(source),
+        }
+    }
+}
+
+impl From<CpuBackendError> for crate::Error {
+    fn from(error: CpuBackendError) -> Self {
+        match error {
+            CpuBackendError::Tensor(error) => error,
+            CpuBackendError::Placement { op, source } => Self::backend_failure(op, source),
+        }
+    }
+}
+
 /// Snapshot of the stable CPU execution contract and non-contractual provider diagnostics.
 ///
 /// [`CpuBackendKind`] is the stable provider identity. The diagnostic string is
@@ -412,6 +476,14 @@ fn ensure_cpu_backend_kind_available(kind: CpuBackendKind, op: &'static str) -> 
             }
         }
     }
+}
+
+fn constructor_tensor_error(op: &'static str, error: crate::Error) -> CpuBackendError {
+    CpuBackendError::Tensor(match error {
+        crate::Error::InvalidConfig { message, .. } => crate::Error::InvalidConfig { op, message },
+        crate::Error::BackendFailure { message, .. } => crate::Error::backend_failure(op, message),
+        error => error,
+    })
 }
 
 // Used by feature-disabled backend paths; a given feature build may compile no
@@ -660,10 +732,6 @@ impl CpuBackend {
         }
     }
 
-    fn placement_failure(op: &'static str, error: CpuPlacementError) -> crate::Error {
-        crate::Error::backend_failure(op, error)
-    }
-
     /// Create a CPU backend using the environment-driven CPU context.
     ///
     /// # Examples
@@ -698,15 +766,22 @@ impl CpuBackend {
     /// let backend = CpuBackend::with_kind(CpuBackendKind::default_compiled()).unwrap();
     /// assert_eq!(backend.kind(), CpuBackendKind::default_compiled());
     /// ```
-    pub fn with_kind(kind: CpuBackendKind) -> crate::Result<Self> {
-        ensure_cpu_backend_kind_available(kind, "CpuBackend::with_kind")?;
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the provider is unavailable or CPU topology and
+    /// placement initialization fails.
+    pub fn with_kind(kind: CpuBackendKind) -> Result<Self, CpuBackendError> {
+        let op = "CpuBackend::with_kind";
+        ensure_cpu_backend_kind_available(kind, op)
+            .map_err(|error| constructor_tensor_error(op, error))?;
         let context = CpuContext::from_env();
         Self::from_thread_budget_and_kind(
             context.num_threads(),
             kind,
             crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
         )
-        .map_err(|error| Self::placement_failure("CpuBackend::with_kind", error))
+        .map_err(|error| CpuBackendError::placement(op, error))
     }
 
     /// Try to create a CPU backend using `RAYON_NUM_THREADS`.
@@ -720,14 +795,21 @@ impl CpuBackend {
     ///     .unwrap_or_else(|_| CpuBackend::with_threads(1).unwrap());
     /// let _ = backend.num_threads();
     /// ```
-    pub fn try_new() -> crate::Result<Self> {
-        let context = CpuContext::try_from_env()?;
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the environment-driven thread configuration is
+    /// invalid or CPU topology and placement initialization fails.
+    pub fn try_new() -> Result<Self, CpuBackendError> {
+        let op = "CpuBackend::try_new";
+        let context =
+            CpuContext::try_from_env().map_err(|error| constructor_tensor_error(op, error))?;
         Self::from_thread_budget_and_kind(
             context.num_threads(),
             CpuBackendKind::default_compiled(),
             crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
         )
-        .map_err(|error| Self::placement_failure("CpuBackend::try_new", error))
+        .map_err(|error| CpuBackendError::placement(op, error))
     }
 
     /// Create a CPU backend from an existing context.
@@ -797,27 +879,18 @@ impl CpuBackend {
     ///
     /// # Errors
     ///
-    /// Returns an error when `num_threads` is zero or Rayon rejects the pool.
-    pub fn with_threads(num_threads: usize) -> crate::Result<Self> {
-        CpuContext::with_threads(num_threads)
-            .and_then(|context| {
-                Self::from_thread_budget_and_kind(
-                    context.num_threads(),
-                    CpuBackendKind::default_compiled(),
-                    crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
-                )
-                .map_err(|error| Self::placement_failure("CpuBackend::with_threads", error))
-            })
-            .map_err(|err| match err {
-                crate::Error::InvalidConfig { message, .. } => crate::Error::InvalidConfig {
-                    op: "CpuBackend::with_threads",
-                    message,
-                },
-                crate::Error::BackendFailure { message, .. } => {
-                    crate::Error::backend_failure("CpuBackend::with_threads", message)
-                }
-                err => err,
-            })
+    /// Returns an error when `num_threads` is zero, Rayon rejects the pool, or
+    /// CPU topology and placement initialization fails.
+    pub fn with_threads(num_threads: usize) -> Result<Self, CpuBackendError> {
+        let op = "CpuBackend::with_threads";
+        let context = CpuContext::with_threads(num_threads)
+            .map_err(|error| constructor_tensor_error(op, error))?;
+        Self::from_thread_budget_and_kind(
+            context.num_threads(),
+            CpuBackendKind::default_compiled(),
+            crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
+        )
+        .map_err(|error| CpuBackendError::placement(op, error))
     }
 
     /// Create a CPU backend with a custom thread count and provider.
@@ -838,30 +911,23 @@ impl CpuBackend {
     /// # Errors
     ///
     /// Returns an error when `num_threads` is zero, Rayon rejects the pool, or
-    /// the selected provider is unavailable.
-    pub fn with_threads_and_kind(num_threads: usize, kind: CpuBackendKind) -> crate::Result<Self> {
-        ensure_cpu_backend_kind_available(kind, "CpuBackend::with_threads_and_kind")?;
-        CpuContext::with_threads(num_threads)
-            .and_then(|context| {
-                Self::from_thread_budget_and_kind(
-                    context.num_threads(),
-                    kind,
-                    crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
-                )
-                .map_err(|error| {
-                    Self::placement_failure("CpuBackend::with_threads_and_kind", error)
-                })
-            })
-            .map_err(|err| match err {
-                crate::Error::InvalidConfig { message, .. } => crate::Error::InvalidConfig {
-                    op: "CpuBackend::with_threads_and_kind",
-                    message,
-                },
-                crate::Error::BackendFailure { message, .. } => {
-                    crate::Error::backend_failure("CpuBackend::with_threads_and_kind", message)
-                }
-                err => err,
-            })
+    /// the selected provider is unavailable, or CPU topology and placement
+    /// initialization fails.
+    pub fn with_threads_and_kind(
+        num_threads: usize,
+        kind: CpuBackendKind,
+    ) -> Result<Self, CpuBackendError> {
+        let op = "CpuBackend::with_threads_and_kind";
+        ensure_cpu_backend_kind_available(kind, op)
+            .map_err(|error| constructor_tensor_error(op, error))?;
+        let context = CpuContext::with_threads(num_threads)
+            .map_err(|error| constructor_tensor_error(op, error))?;
+        Self::from_thread_budget_and_kind(
+            context.num_threads(),
+            kind,
+            crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
+        )
+        .map_err(|error| CpuBackendError::placement(op, error))
     }
 
     /// Clone this backend coordinator with a specific CPU placement request.
@@ -883,7 +949,31 @@ impl CpuBackend {
     /// # Ok::<(), tenferro_cpu::CpuPlacementError>(())
     /// ```
     pub fn for_placement(&self, requested: CpuPlacement) -> Result<Self, CpuPlacementError> {
-        let resolved = resolve_placement(self.kind(), requested, &self.shared.topology)?;
+        self.for_placement_with_affinity(
+            requested,
+            cfg!(any(target_os = "linux", target_os = "android")),
+        )
+    }
+
+    fn for_placement_with_affinity(
+        &self,
+        requested: CpuPlacement,
+        managed_affinity_available: bool,
+    ) -> Result<Self, CpuPlacementError> {
+        let resolved = resolve_placement_with_affinity(
+            self.kind(),
+            requested,
+            &self.shared.topology,
+            managed_affinity_available,
+        )?;
+        if requested == CpuPlacement::Auto && !managed_affinity_available {
+            return Ok(Self {
+                shared: Arc::clone(&self.shared),
+                requested,
+                resolved,
+                engine: Arc::clone(&self.shared.base_engine),
+            });
+        }
         let engine_placement = match &resolved {
             ResolvedCpuExecution::Managed(placement) => placement.clone(),
             ResolvedCpuExecution::ProviderDefaultExclusive => ResolvedCpuPlacement::AllAllowed {

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -7,9 +7,11 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::arbiter::{ResourceArbiter, ResourcePermit};
+use crate::arbiter::{
+    inherited_or_new_execution_owner, with_execution_owner, ResourceArbiter, ResourcePermit,
+};
 use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
-use crate::engine::CpuEngine;
+use crate::engine::{CpuEngine, EngineResources};
 use crate::placement::{resolve_placement, resolve_placement_with_affinity, ResolvedCpuExecution};
 use crate::{
     discover_cpu_topology, CpuId, CpuPlacement, CpuPlacementError, CpuSet, CpuTopology,
@@ -1291,34 +1293,41 @@ impl CpuBackend {
     /// assert_eq!(value, 2);
     /// ```
     pub fn install<R: Send>(&self, op: impl FnOnce() -> R + Send) -> R {
-        let _permit = self.acquire_execution_permit();
-        self.engine.context().install(op)
+        let owner = inherited_or_new_execution_owner();
+        self.engine.context().install(|| {
+            with_execution_owner(owner, || {
+                let _permit = self.acquire_execution_permit();
+                op()
+            })
+        })
     }
 
     fn install_with_pool<R: Send>(&mut self, op: impl FnOnce(&mut BufferPool) -> R + Send) -> R {
-        let _permit = self.acquire_execution_permit();
         let ctx = self.engine.context_arc();
-        let mut resources = self
-            .engine
-            .resources
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
-        ctx.install(|| op(buffers.get_mut()))
+        let owner = inherited_or_new_execution_owner();
+        ctx.install(|| {
+            with_execution_owner(owner, || {
+                let permit = self.acquire_execution_permit();
+                self.with_execution_resources(&permit, |resources| {
+                    let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
+                    op(buffers.get_mut())
+                })
+            })
+        })
     }
 
     // Selected when the BLAS provider is active; default Faer-only builds keep
     // it dormant.
     #[allow(dead_code)]
     fn run_with_pool<R>(&mut self, op: impl FnOnce(&mut BufferPool) -> R) -> R {
-        let _permit = self.acquire_execution_permit();
-        let mut resources = self
-            .engine
-            .resources
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
-        op(buffers.get_mut())
+        let owner = inherited_or_new_execution_owner();
+        with_execution_owner(owner, || {
+            let permit = self.acquire_execution_permit();
+            self.with_execution_resources(&permit, |resources| {
+                let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
+                op(buffers.get_mut())
+            })
+        })
     }
 
     fn linalg_with_pool<R: Send>(&mut self, op: impl FnOnce(&mut BufferPool) -> R + Send) -> R {
@@ -1352,15 +1361,17 @@ impl CpuBackend {
         gemm_analysis_cache: &mut gemm::GemmAnalysisCache,
         op: impl FnOnce(&mut BufferPool, &mut gemm::GemmAnalysisCache) -> R + Send,
     ) -> R {
-        let _permit = self.acquire_execution_permit();
-        let mut resources = self
-            .engine
-            .resources
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
         let ctx = self.engine.context_arc();
-        ctx.install(|| op(buffers.get_mut(), gemm_analysis_cache))
+        let owner = inherited_or_new_execution_owner();
+        ctx.install(|| {
+            with_execution_owner(owner, || {
+                let permit = self.acquire_execution_permit();
+                self.with_execution_resources(&permit, |resources| {
+                    let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
+                    op(buffers.get_mut(), gemm_analysis_cache)
+                })
+            })
+        })
     }
 
     // Selected when the BLAS provider handles cached GEMM execution; default
@@ -1371,14 +1382,32 @@ impl CpuBackend {
         gemm_analysis_cache: &mut gemm::GemmAnalysisCache,
         op: impl FnOnce(&mut BufferPool, &mut gemm::GemmAnalysisCache) -> R,
     ) -> R {
-        let _permit = self.acquire_execution_permit();
+        let owner = inherited_or_new_execution_owner();
+        with_execution_owner(owner, || {
+            let permit = self.acquire_execution_permit();
+            self.with_execution_resources(&permit, |resources| {
+                let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
+                op(buffers.get_mut(), gemm_analysis_cache)
+            })
+        })
+    }
+
+    fn with_execution_resources<R>(
+        &self,
+        permit: &ResourcePermit,
+        op: impl FnOnce(&mut EngineResources) -> R,
+    ) -> R {
+        if permit.is_reentrant() {
+            let mut resources =
+                EngineResources::new(self.shared.buffer_limit.load(Ordering::Relaxed));
+            return op(&mut resources);
+        }
         let mut resources = self
             .engine
             .resources
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
-        op(buffers.get_mut(), gemm_analysis_cache)
+        op(&mut resources)
     }
 
     fn acquire_execution_permit(&self) -> ResourcePermit {
@@ -2279,36 +2308,35 @@ impl CpuBackend {
         cache: Option<&mut gemm::GemmAnalysisCache>,
         f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
     ) -> R {
-        let _permit = self.acquire_execution_permit();
         let ctx = self.engine.context_arc();
         let kind = self.kind();
-        let mut resources = self
-            .engine
-            .resources
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let resources = &mut *resources;
-        let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
-        let cache = cache.unwrap_or(&mut resources.gemm_analysis_cache);
+        let owner = inherited_or_new_execution_owner();
         let run = || {
-            let session_started = Instant::now();
-            let mut session = CpuExecSession {
-                ctx: ctx.as_ref(),
-                buffers: buffers.get_mut(),
-                gemm_analysis_cache: cache,
-                kind,
-            };
-            record_cpu_session_profile(
-                "with_backend_session_cached.session_construct",
-                session_started.elapsed(),
-            );
-            let exec_started = Instant::now();
-            let result = f(&mut session);
-            record_cpu_session_profile(
-                "with_backend_session_cached.exec_body",
-                exec_started.elapsed(),
-            );
-            result
+            with_execution_owner(owner, || {
+                let permit = self.acquire_execution_permit();
+                self.with_execution_resources(&permit, |resources| {
+                    let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
+                    let cache = cache.unwrap_or(&mut resources.gemm_analysis_cache);
+                    let session_started = Instant::now();
+                    let mut session = CpuExecSession {
+                        ctx: ctx.as_ref(),
+                        buffers: buffers.get_mut(),
+                        gemm_analysis_cache: cache,
+                        kind,
+                    };
+                    record_cpu_session_profile(
+                        "with_backend_session_cached.session_construct",
+                        session_started.elapsed(),
+                    );
+                    let exec_started = Instant::now();
+                    let result = f(&mut session);
+                    record_cpu_session_profile(
+                        "with_backend_session_cached.exec_body",
+                        exec_started.elapsed(),
+                    );
+                    result
+                })
+            })
         };
         match kind {
             CpuBackendKind::Faer => ctx.install(run),
@@ -2346,22 +2374,22 @@ impl BackendSessionHost for CpuBackend {
 
 impl TensorBuffer for CpuBackend {
     fn reclaim_buffer(&mut self, tensor: Tensor) {
-        let _permit = self.acquire_execution_permit();
-        let mut resources = self
-            .engine
-            .resources
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let buffers = &mut resources.buffers;
-        match tensor {
-            Tensor::F32(t) => reclaim_typed(buffers, t),
-            Tensor::F64(t) => reclaim_typed(buffers, t),
-            Tensor::I32(t) => reclaim_typed(buffers, t),
-            Tensor::I64(t) => reclaim_typed(buffers, t),
-            Tensor::Bool(t) => reclaim_typed(buffers, t),
-            Tensor::C32(t) => reclaim_typed(buffers, t),
-            Tensor::C64(t) => reclaim_typed(buffers, t),
-        }
+        let owner = inherited_or_new_execution_owner();
+        with_execution_owner(owner, || {
+            let permit = self.acquire_execution_permit();
+            self.with_execution_resources(&permit, |resources| {
+                let buffers = &mut resources.buffers;
+                match tensor {
+                    Tensor::F32(t) => reclaim_typed(buffers, t),
+                    Tensor::F64(t) => reclaim_typed(buffers, t),
+                    Tensor::I32(t) => reclaim_typed(buffers, t),
+                    Tensor::I64(t) => reclaim_typed(buffers, t),
+                    Tensor::Bool(t) => reclaim_typed(buffers, t),
+                    Tensor::C32(t) => reclaim_typed(buffers, t),
+                    Tensor::C64(t) => reclaim_typed(buffers, t),
+                }
+            })
+        })
     }
 }
 

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -8,7 +8,8 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::arbiter::{
-    inherited_or_new_execution_owner, with_execution_owner, ResourceArbiter, ResourcePermit,
+    inherited_or_new_execution_owner, with_execution_owner, ResourceArbiter, ResourceOwner,
+    ResourcePermit,
 };
 use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
 use crate::engine::{CpuEngine, EngineResources};
@@ -1294,24 +1295,20 @@ impl CpuBackend {
     /// ```
     pub fn install<R: Send>(&self, op: impl FnOnce() -> R + Send) -> R {
         let owner = inherited_or_new_execution_owner();
-        self.engine.context().install(|| {
-            with_execution_owner(owner, || {
-                let _permit = self.acquire_execution_permit();
-                op()
-            })
-        })
+        let _permit = self.acquire_execution_permit(owner);
+        self.engine
+            .context()
+            .install_with_execution_owner(owner, op)
     }
 
     fn install_with_pool<R: Send>(&mut self, op: impl FnOnce(&mut BufferPool) -> R + Send) -> R {
         let ctx = self.engine.context_arc();
         let owner = inherited_or_new_execution_owner();
-        ctx.install(|| {
-            with_execution_owner(owner, || {
-                let permit = self.acquire_execution_permit();
-                self.with_execution_resources(&permit, |resources| {
-                    let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
-                    op(buffers.get_mut())
-                })
+        let permit = self.acquire_execution_permit(owner);
+        ctx.install_with_execution_owner(owner, || {
+            self.with_execution_resources(&permit, |resources| {
+                let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
+                op(buffers.get_mut())
             })
         })
     }
@@ -1322,7 +1319,7 @@ impl CpuBackend {
     fn run_with_pool<R>(&mut self, op: impl FnOnce(&mut BufferPool) -> R) -> R {
         let owner = inherited_or_new_execution_owner();
         with_execution_owner(owner, || {
-            let permit = self.acquire_execution_permit();
+            let permit = self.acquire_execution_permit(owner);
             self.with_execution_resources(&permit, |resources| {
                 let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
                 op(buffers.get_mut())
@@ -1363,13 +1360,11 @@ impl CpuBackend {
     ) -> R {
         let ctx = self.engine.context_arc();
         let owner = inherited_or_new_execution_owner();
-        ctx.install(|| {
-            with_execution_owner(owner, || {
-                let permit = self.acquire_execution_permit();
-                self.with_execution_resources(&permit, |resources| {
-                    let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
-                    op(buffers.get_mut(), gemm_analysis_cache)
-                })
+        let permit = self.acquire_execution_permit(owner);
+        ctx.install_with_execution_owner(owner, || {
+            self.with_execution_resources(&permit, |resources| {
+                let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
+                op(buffers.get_mut(), gemm_analysis_cache)
             })
         })
     }
@@ -1384,7 +1379,7 @@ impl CpuBackend {
     ) -> R {
         let owner = inherited_or_new_execution_owner();
         with_execution_owner(owner, || {
-            let permit = self.acquire_execution_permit();
+            let permit = self.acquire_execution_permit(owner);
             self.with_execution_resources(&permit, |resources| {
                 let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
                 op(buffers.get_mut(), gemm_analysis_cache)
@@ -1410,19 +1405,20 @@ impl CpuBackend {
         op(&mut resources)
     }
 
-    fn acquire_execution_permit(&self) -> ResourcePermit {
+    fn acquire_execution_permit(&self, owner: ResourceOwner) -> ResourcePermit {
         match &self.resolved {
             ResolvedCpuExecution::Managed(placement) => self
                 .shared
                 .arbiter
-                .acquire_recovering(placement.cpus().clone()),
+                .acquire_recovering(placement.cpus().clone(), owner),
             ResolvedCpuExecution::Compatibility => self
                 .shared
                 .arbiter
-                .acquire_recovering(self.shared.topology.allowed_cpus().clone()),
-            ResolvedCpuExecution::ProviderDefaultExclusive => {
-                self.shared.arbiter.acquire_provider_exclusive_recovering()
-            }
+                .acquire_recovering(self.shared.topology.allowed_cpus().clone(), owner),
+            ResolvedCpuExecution::ProviderDefaultExclusive => self
+                .shared
+                .arbiter
+                .acquire_provider_exclusive_recovering(owner),
         }
     }
 }
@@ -2311,36 +2307,34 @@ impl CpuBackend {
         let ctx = self.engine.context_arc();
         let kind = self.kind();
         let owner = inherited_or_new_execution_owner();
+        let permit = self.acquire_execution_permit(owner);
         let run = || {
-            with_execution_owner(owner, || {
-                let permit = self.acquire_execution_permit();
-                self.with_execution_resources(&permit, |resources| {
-                    let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
-                    let cache = cache.unwrap_or(&mut resources.gemm_analysis_cache);
-                    let session_started = Instant::now();
-                    let mut session = CpuExecSession {
-                        ctx: ctx.as_ref(),
-                        buffers: buffers.get_mut(),
-                        gemm_analysis_cache: cache,
-                        kind,
-                    };
-                    record_cpu_session_profile(
-                        "with_backend_session_cached.session_construct",
-                        session_started.elapsed(),
-                    );
-                    let exec_started = Instant::now();
-                    let result = f(&mut session);
-                    record_cpu_session_profile(
-                        "with_backend_session_cached.exec_body",
-                        exec_started.elapsed(),
-                    );
-                    result
-                })
+            self.with_execution_resources(&permit, |resources| {
+                let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
+                let cache = cache.unwrap_or(&mut resources.gemm_analysis_cache);
+                let session_started = Instant::now();
+                let mut session = CpuExecSession {
+                    ctx: ctx.as_ref(),
+                    buffers: buffers.get_mut(),
+                    gemm_analysis_cache: cache,
+                    kind,
+                };
+                record_cpu_session_profile(
+                    "with_backend_session_cached.session_construct",
+                    session_started.elapsed(),
+                );
+                let exec_started = Instant::now();
+                let result = f(&mut session);
+                record_cpu_session_profile(
+                    "with_backend_session_cached.exec_body",
+                    exec_started.elapsed(),
+                );
+                result
             })
         };
         match kind {
-            CpuBackendKind::Faer => ctx.install(run),
-            CpuBackendKind::Blas => run(),
+            CpuBackendKind::Faer => ctx.install_with_execution_owner(owner, run),
+            CpuBackendKind::Blas => with_execution_owner(owner, run),
         }
     }
 }
@@ -2376,7 +2370,7 @@ impl TensorBuffer for CpuBackend {
     fn reclaim_buffer(&mut self, tensor: Tensor) {
         let owner = inherited_or_new_execution_owner();
         with_execution_owner(owner, || {
-            let permit = self.acquire_execution_permit();
+            let permit = self.acquire_execution_permit(owner);
             self.with_execution_resources(&permit, |resources| {
                 let buffers = &mut resources.buffers;
                 match tensor {

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -1958,7 +1958,7 @@ impl TensorIndexing for CpuBackend {
 impl CpuBackend {
     fn run_backend_session_cached<R: Send>(
         &mut self,
-        cache: &mut gemm::GemmAnalysisCache,
+        cache: Option<&mut gemm::GemmAnalysisCache>,
         f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
     ) -> R {
         let _permit = self.acquire_execution_permit();
@@ -1969,7 +1969,9 @@ impl CpuBackend {
             .resources
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let resources = &mut *resources;
         let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
+        let cache = cache.unwrap_or(&mut resources.gemm_analysis_cache);
         let run = || {
             let session_started = Instant::now();
             let mut session = CpuExecSession {
@@ -2002,10 +2004,7 @@ impl BackendSessionHost for CpuBackend {
         &mut self,
         f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
     ) -> R {
-        let mut cache = profile_cpu_session_section("with_backend_session.cache_default", || {
-            gemm::GemmAnalysisCache::default()
-        });
-        self.with_backend_session_cached(&mut cache, f)
+        self.run_backend_session_cached(None, f)
     }
 
     fn with_backend_session_cached<R: Send>(
@@ -2014,12 +2013,12 @@ impl BackendSessionHost for CpuBackend {
         f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
     ) -> R {
         if !cpu_session_profile_enabled() {
-            return self.run_backend_session_cached(cache, f);
+            return self.run_backend_session_cached(Some(cache), f);
         }
         let total_started = Instant::now();
         let result =
             profile_cpu_session_section("with_backend_session_cached.exec_session", || {
-                self.run_backend_session_cached(cache, f)
+                self.run_backend_session_cached(Some(cache), f)
             });
         record_cpu_session_profile("with_backend_session_cached.total", total_started.elapsed());
         maybe_print_cpu_session_profile();

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -1296,10 +1296,10 @@ impl CpuBackend {
     ///
     /// # Panics
     ///
-    /// Panics when called from a parallel Rayon child task while another CPU
-    /// backend execution owns that task's pool. Direct synchronous nesting is
-    /// supported, but parallel backend re-entry would violate CPU and provider
-    /// exclusivity.
+    /// Panics when re-entered while another CPU backend execution is active on
+    /// the current thread or managed Rayon scope. This includes direct nesting
+    /// and backend calls from parallel child tasks; either could violate CPU or
+    /// provider exclusivity.
     pub fn install<R: Send>(&self, op: impl FnOnce() -> R + Send) -> R {
         let owner = inherited_or_new_execution_owner();
         let _permit = self.acquire_execution_permit(owner);

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -1,12 +1,20 @@
 use std::cmp::Reverse;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::env;
 use std::fmt;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use crate::arbiter::{ResourceArbiter, ResourcePermit};
 use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
+use crate::engine::CpuEngine;
+use crate::placement::{resolve_placement, ResolvedCpuExecution};
+use crate::{
+    discover_cpu_topology, CpuId, CpuPlacement, CpuPlacementError, CpuSet, CpuTopology, NumaNodeId,
+    ResolvedCpuPlacement,
+};
 use crate::{
     Buffer, CacheStats, Tensor, TensorRank, TensorRead, TensorValue, TensorWrite, TypedTensor,
     TypedTensorView, TypedTensorViewMut,
@@ -251,7 +259,84 @@ pub(super) fn unavailable_cpu_backend_kind(kind: CpuBackendKind, op: &'static st
     }
 }
 
-/// CPU execution backend.
+struct CpuBackendState {
+    topology: CpuTopology,
+    node_engines: Mutex<BTreeMap<NumaNodeId, Arc<CpuEngine>>>,
+    all_allowed: OnceLock<Arc<CpuEngine>>,
+    all_allowed_build: Mutex<()>,
+    base_engine: Arc<CpuEngine>,
+    arbiter: ResourceArbiter,
+    kind: CpuBackendKind,
+    thread_budget: usize,
+    buffer_limit: AtomicUsize,
+}
+
+impl CpuBackendState {
+    fn engine_for(
+        &self,
+        placement: &ResolvedCpuPlacement,
+    ) -> Result<Arc<CpuEngine>, crate::CpuContextError> {
+        match placement {
+            ResolvedCpuPlacement::NumaNode { id, .. } => {
+                let mut engines = self
+                    .node_engines
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if let Some(engine) = engines.get(id) {
+                    return Ok(Arc::clone(engine));
+                }
+                let engine = Arc::new(CpuEngine::new(
+                    placement.clone(),
+                    self.thread_budget,
+                    self.buffer_limit.load(Ordering::Relaxed),
+                )?);
+                engines.insert(*id, Arc::clone(&engine));
+                Ok(engine)
+            }
+            ResolvedCpuPlacement::AllAllowed { .. } => {
+                if let Some(engine) = self.all_allowed.get() {
+                    return Ok(Arc::clone(engine));
+                }
+                let _build = self
+                    .all_allowed_build
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if let Some(engine) = self.all_allowed.get() {
+                    return Ok(Arc::clone(engine));
+                }
+                let engine = Arc::new(CpuEngine::new(
+                    placement.clone(),
+                    self.thread_budget,
+                    self.buffer_limit.load(Ordering::Relaxed),
+                )?);
+                let _ = self.all_allowed.set(Arc::clone(&engine));
+                Ok(engine)
+            }
+        }
+    }
+
+    fn initialized_engines(&self) -> Vec<Arc<CpuEngine>> {
+        let mut engines = vec![Arc::clone(&self.base_engine)];
+        if let Some(engine) = self.all_allowed.get() {
+            engines.push(Arc::clone(engine));
+        }
+        engines.extend(
+            self.node_engines
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .values()
+                .cloned(),
+        );
+        engines.sort_unstable_by_key(|engine| Arc::as_ptr(engine) as usize);
+        engines.dedup_by(|left, right| Arc::ptr_eq(left, right));
+        engines
+    }
+}
+
+/// A cheap cloneable handle to shared CPU execution coordination.
+///
+/// Clones share topology, execution engines, arbitration, and engine-owned
+/// buffer resources.
 ///
 /// # Examples
 ///
@@ -259,17 +344,24 @@ pub(super) fn unavailable_cpu_backend_kind(kind: CpuBackendKind, op: &'static st
 /// use tenferro_cpu::CpuBackend;
 ///
 /// let backend = CpuBackend::new();
+/// let clone = backend.clone();
+/// assert_eq!(backend.kind(), clone.kind());
 /// ```
+#[derive(Clone)]
 pub struct CpuBackend {
-    pub(crate) ctx: Arc<CpuContext>,
-    pub(crate) buffers: BufferPool,
-    kind: CpuBackendKind,
+    shared: Arc<CpuBackendState>,
+    requested: CpuPlacement,
+    resolved: ResolvedCpuExecution,
+    engine: Arc<CpuEngine>,
 }
 
 impl fmt::Debug for CpuBackend {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CpuBackend")
-            .field("kind", &self.kind)
+            .field("kind", &self.kind())
+            .field("requested_placement", &self.requested)
+            .field("resolved_execution", &self.resolved)
+            .field("engine_placement", &self.engine.placement())
             .field("num_threads", &self.num_threads())
             .field("buffer_pool_cache_stats", &self.buffer_pool_cache_stats())
             .field("buffer_pool_limit_bytes", &self.buffer_pool_limit_bytes())
@@ -278,6 +370,98 @@ impl fmt::Debug for CpuBackend {
 }
 
 impl CpuBackend {
+    fn from_thread_budget_and_kind(
+        thread_budget: usize,
+        kind: CpuBackendKind,
+        max_retained_capacity_bytes: usize,
+    ) -> Result<Self, CpuPlacementError> {
+        let topology = discover_cpu_topology().unwrap_or_else(|_| {
+            let allowed = crate::process_cpu_affinity().unwrap_or_else(|| {
+                CpuSet::new((0..crate::available_parallelism()).map(CpuId::new))
+                    .unwrap_or_else(|_| CpuSet::singleton(CpuId::new(0)))
+            });
+            CpuTopology::all_allowed(allowed)
+        });
+        let resolved = resolve_placement(kind, CpuPlacement::Auto, &topology)?;
+        let engine_placement = ResolvedCpuPlacement::AllAllowed {
+            cpus: topology.allowed_cpus().clone(),
+        };
+        let engine = Arc::new(
+            CpuEngine::new(engine_placement, thread_budget, max_retained_capacity_bytes).map_err(
+                |error| CpuPlacementError::EngineConstruction {
+                    requested: CpuPlacement::Auto,
+                    backend: kind,
+                    message: error.to_string(),
+                },
+            )?,
+        );
+        let all_allowed = OnceLock::new();
+        let _ = all_allowed.set(Arc::clone(&engine));
+        Ok(Self {
+            shared: Arc::new(CpuBackendState {
+                topology,
+                node_engines: Mutex::new(BTreeMap::new()),
+                all_allowed,
+                all_allowed_build: Mutex::new(()),
+                base_engine: Arc::clone(&engine),
+                arbiter: ResourceArbiter::new(),
+                kind,
+                thread_budget,
+                buffer_limit: AtomicUsize::new(max_retained_capacity_bytes),
+            }),
+            requested: CpuPlacement::Auto,
+            resolved,
+            engine,
+        })
+    }
+
+    fn compatibility(
+        ctx: Arc<CpuContext>,
+        max_retained_capacity_bytes: usize,
+        kind: CpuBackendKind,
+    ) -> Self {
+        let topology = discover_cpu_topology().unwrap_or_else(|_| {
+            let allowed = crate::process_cpu_affinity().unwrap_or_else(|| {
+                CpuSet::new((0..crate::available_parallelism()).map(CpuId::new))
+                    .unwrap_or_else(|_| CpuSet::singleton(CpuId::new(0)))
+            });
+            CpuTopology::all_allowed(allowed)
+        });
+        let placement = ResolvedCpuPlacement::AllAllowed {
+            cpus: topology.allowed_cpus().clone(),
+        };
+        let base_engine = Arc::new(CpuEngine::from_context(
+            placement,
+            ctx,
+            max_retained_capacity_bytes,
+        ));
+        let resolved = if kind == CpuBackendKind::Blas {
+            ResolvedCpuExecution::ProviderDefaultExclusive
+        } else {
+            ResolvedCpuExecution::Compatibility
+        };
+        Self {
+            shared: Arc::new(CpuBackendState {
+                topology,
+                node_engines: Mutex::new(BTreeMap::new()),
+                all_allowed: OnceLock::new(),
+                all_allowed_build: Mutex::new(()),
+                base_engine: Arc::clone(&base_engine),
+                arbiter: ResourceArbiter::new(),
+                kind,
+                thread_budget: base_engine.context().num_threads(),
+                buffer_limit: AtomicUsize::new(max_retained_capacity_bytes),
+            }),
+            requested: CpuPlacement::Auto,
+            resolved,
+            engine: base_engine,
+        }
+    }
+
+    fn placement_failure(op: &'static str, error: CpuPlacementError) -> crate::Error {
+        crate::Error::backend_failure(op, error)
+    }
+
     /// Create a CPU backend using the environment-driven CPU context.
     ///
     /// # Examples
@@ -288,7 +472,18 @@ impl CpuBackend {
     /// let backend = CpuBackend::new();
     /// ```
     pub fn new() -> Self {
-        Self::from_context(Arc::new(CpuContext::from_env()))
+        let context = Arc::new(CpuContext::from_env());
+        Self::from_thread_budget_and_kind(
+            context.num_threads(),
+            CpuBackendKind::default_compiled(),
+            crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
+        )
+        .unwrap_or_else(|error| {
+            eprintln!(
+                "tenferro_cpu: using the unpinned compatibility context after placement error: {error}"
+            );
+            Self::from_context(context)
+        })
     }
 
     /// Create a CPU backend using the selected compiled provider.
@@ -302,7 +497,14 @@ impl CpuBackend {
     /// assert_eq!(backend.kind(), CpuBackendKind::default_compiled());
     /// ```
     pub fn with_kind(kind: CpuBackendKind) -> crate::Result<Self> {
-        Self::try_from_context_with_kind(Arc::new(CpuContext::from_env()), kind)
+        ensure_cpu_backend_kind_available(kind, "CpuBackend::with_kind")?;
+        let context = CpuContext::from_env();
+        Self::from_thread_budget_and_kind(
+            context.num_threads(),
+            kind,
+            crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
+        )
+        .map_err(|error| Self::placement_failure("CpuBackend::with_kind", error))
     }
 
     /// Try to create a CPU backend using `RAYON_NUM_THREADS`.
@@ -317,7 +519,13 @@ impl CpuBackend {
     /// let _ = backend.num_threads();
     /// ```
     pub fn try_new() -> crate::Result<Self> {
-        CpuContext::try_from_env().map(|ctx| Self::from_context(Arc::new(ctx)))
+        let context = CpuContext::try_from_env()?;
+        Self::from_thread_budget_and_kind(
+            context.num_threads(),
+            CpuBackendKind::default_compiled(),
+            crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
+        )
+        .map_err(|error| Self::placement_failure("CpuBackend::try_new", error))
     }
 
     /// Create a CPU backend from an existing context.
@@ -333,23 +541,11 @@ impl CpuBackend {
     /// assert_eq!(backend.num_threads(), 2);
     /// ```
     pub fn from_context(ctx: Arc<CpuContext>) -> Self {
-        Self {
+        Self::compatibility(
             ctx,
-            buffers: BufferPool::new(),
-            kind: CpuBackendKind::default_compiled(),
-        }
-    }
-
-    fn try_from_context_with_kind(
-        ctx: Arc<CpuContext>,
-        kind: CpuBackendKind,
-    ) -> crate::Result<Self> {
-        ensure_cpu_backend_kind_available(kind, "CpuBackend::with_kind")?;
-        Ok(Self {
-            ctx,
-            buffers: BufferPool::new(),
-            kind,
-        })
+            crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
+            CpuBackendKind::default_compiled(),
+        )
     }
 
     /// Create a CPU backend from an existing context and buffer-pool retention cap.
@@ -383,11 +579,7 @@ impl CpuBackend {
         max_retained_capacity_bytes: usize,
         kind: CpuBackendKind,
     ) -> Self {
-        Self {
-            ctx,
-            buffers: BufferPool::with_max_retained_capacity_bytes(max_retained_capacity_bytes),
-            kind,
-        }
+        Self::compatibility(ctx, max_retained_capacity_bytes, kind)
     }
 
     /// Create a CPU backend with a custom thread count.
@@ -406,7 +598,14 @@ impl CpuBackend {
     /// Returns an error when `num_threads` is zero or Rayon rejects the pool.
     pub fn with_threads(num_threads: usize) -> crate::Result<Self> {
         CpuContext::with_threads(num_threads)
-            .map(|ctx| Self::from_context(Arc::new(ctx)))
+            .and_then(|context| {
+                Self::from_thread_budget_and_kind(
+                    context.num_threads(),
+                    CpuBackendKind::default_compiled(),
+                    crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
+                )
+                .map_err(|error| Self::placement_failure("CpuBackend::with_threads", error))
+            })
             .map_err(|err| match err {
                 crate::Error::InvalidConfig { message, .. } => crate::Error::InvalidConfig {
                     op: "CpuBackend::with_threads",
@@ -441,10 +640,15 @@ impl CpuBackend {
     pub fn with_threads_and_kind(num_threads: usize, kind: CpuBackendKind) -> crate::Result<Self> {
         ensure_cpu_backend_kind_available(kind, "CpuBackend::with_threads_and_kind")?;
         CpuContext::with_threads(num_threads)
-            .map(|ctx| Self {
-                ctx: Arc::new(ctx),
-                buffers: BufferPool::new(),
-                kind,
+            .and_then(|context| {
+                Self::from_thread_budget_and_kind(
+                    context.num_threads(),
+                    kind,
+                    crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
+                )
+                .map_err(|error| {
+                    Self::placement_failure("CpuBackend::with_threads_and_kind", error)
+                })
             })
             .map_err(|err| match err {
                 crate::Error::InvalidConfig { message, .. } => crate::Error::InvalidConfig {
@@ -458,6 +662,130 @@ impl CpuBackend {
             })
     }
 
+    /// Clone this backend coordinator with a specific CPU placement request.
+    ///
+    /// Explicit placement is supported for faer/native execution. External
+    /// BLAS providers accept only [`CpuPlacement::Auto`] because tenferro does
+    /// not control their worker affinity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuBackend, CpuPlacement};
+    ///
+    /// let backend = CpuBackend::new();
+    /// if backend.supports_placement(CpuPlacement::AllAllowed) {
+    ///     let placed = backend.for_placement(CpuPlacement::AllAllowed)?;
+    ///     assert_eq!(placed.placement(), CpuPlacement::AllAllowed);
+    /// }
+    /// # Ok::<(), tenferro_cpu::CpuPlacementError>(())
+    /// ```
+    pub fn for_placement(&self, requested: CpuPlacement) -> Result<Self, CpuPlacementError> {
+        let resolved = resolve_placement(self.kind(), requested, &self.shared.topology)?;
+        let engine_placement = match &resolved {
+            ResolvedCpuExecution::Managed(placement) => placement.clone(),
+            ResolvedCpuExecution::ProviderDefaultExclusive => ResolvedCpuPlacement::AllAllowed {
+                cpus: self.shared.topology.allowed_cpus().clone(),
+            },
+            ResolvedCpuExecution::Compatibility => {
+                return Err(CpuPlacementError::EngineConstruction {
+                    requested,
+                    backend: self.kind(),
+                    message: "placement resolution returned an internal compatibility mode"
+                        .to_owned(),
+                });
+            }
+        };
+        let engine = self.shared.engine_for(&engine_placement).map_err(|error| {
+            CpuPlacementError::EngineConstruction {
+                requested,
+                backend: self.kind(),
+                message: error.to_string(),
+            }
+        })?;
+        Ok(Self {
+            shared: Arc::clone(&self.shared),
+            requested,
+            resolved,
+            engine,
+        })
+    }
+
+    /// Return the placement requested by this handle.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuBackend, CpuPlacement};
+    ///
+    /// assert_eq!(CpuBackend::new().placement(), CpuPlacement::Auto);
+    /// ```
+    pub fn placement(&self) -> CpuPlacement {
+        self.requested
+    }
+
+    /// Return the concrete managed placement, if tenferro owns worker affinity.
+    ///
+    /// External-provider and compatibility contexts return `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuBackend, CpuPlacement};
+    ///
+    /// let backend = CpuBackend::new();
+    /// if backend.supports_placement(CpuPlacement::AllAllowed) {
+    ///     assert!(backend
+    ///         .for_placement(CpuPlacement::AllAllowed)?
+    ///         .resolved_placement()
+    ///         .is_some());
+    /// }
+    /// # Ok::<(), tenferro_cpu::CpuPlacementError>(())
+    /// ```
+    pub fn resolved_placement(&self) -> Option<&ResolvedCpuPlacement> {
+        match &self.resolved {
+            ResolvedCpuExecution::Managed(placement) => Some(placement),
+            ResolvedCpuExecution::Compatibility
+            | ResolvedCpuExecution::ProviderDefaultExclusive => None,
+        }
+    }
+
+    /// Return the process-visible topology shared by all coordinator clones.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    ///
+    /// assert!(!CpuBackend::new().topology().allowed_cpus().is_empty());
+    /// ```
+    pub fn topology(&self) -> &CpuTopology {
+        &self.shared.topology
+    }
+
+    /// Report whether this public provider kind accepts a placement request.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuBackend, CpuPlacement};
+    ///
+    /// assert!(CpuBackend::new().supports_placement(CpuPlacement::Auto));
+    /// ```
+    pub fn supports_placement(&self, placement: CpuPlacement) -> bool {
+        resolve_placement(self.kind(), placement, &self.shared.topology).is_ok()
+    }
+
+    #[cfg(all(test, feature = "cpu-faer"))]
+    fn coordinator_id_for_test(&self) -> usize {
+        Arc::as_ptr(&self.shared) as usize
+    }
+
+    #[cfg(test)]
+    pub(crate) fn context_id_for_test(&self) -> usize {
+        Arc::as_ptr(&self.engine.context_arc()) as usize
+    }
+
     /// Return the runtime CPU provider selected by this backend.
     ///
     /// # Examples
@@ -469,7 +797,7 @@ impl CpuBackend {
     /// assert_eq!(backend.kind(), CpuBackendKind::default_compiled());
     /// ```
     pub fn kind(&self) -> CpuBackendKind {
-        self.kind
+        self.shared.kind
     }
 
     /// Return the number of threads in this backend's CPU context.
@@ -483,7 +811,7 @@ impl CpuBackend {
     /// assert_eq!(backend.num_threads(), 2);
     /// ```
     pub fn num_threads(&self) -> usize {
-        self.ctx.num_threads()
+        self.engine.context().num_threads()
     }
 
     /// Number of retained typed host buffers currently held by this backend.
@@ -497,7 +825,18 @@ impl CpuBackend {
     /// assert_eq!(backend.buffer_pool_len(), 0);
     /// ```
     pub fn buffer_pool_len(&self) -> usize {
-        self.buffers.len()
+        self.shared
+            .initialized_engines()
+            .into_iter()
+            .map(|engine| {
+                engine
+                    .resources
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .buffers
+                    .len()
+            })
+            .sum()
     }
 
     /// Snapshot reusable typed host buffers currently retained by this backend.
@@ -513,7 +852,20 @@ impl CpuBackend {
     /// assert_eq!(stats.capacity_bytes, 0);
     /// ```
     pub fn buffer_pool_stats(&self) -> BufferPoolStats {
-        self.buffers.stats()
+        self.shared.initialized_engines().into_iter().fold(
+            BufferPoolStats::default(),
+            |mut total, engine| {
+                let stats = engine
+                    .resources
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .buffers
+                    .stats();
+                total.buffers += stats.buffers;
+                total.capacity_bytes += stats.capacity_bytes;
+                total
+            },
+        )
     }
 
     /// Return cache-style stats for the CPU buffer pool.
@@ -529,7 +881,11 @@ impl CpuBackend {
     /// assert_eq!(stats.retained_bytes, 0);
     /// ```
     pub fn buffer_pool_cache_stats(&self) -> CacheStats {
-        self.buffers.cache_stats()
+        let stats = self.buffer_pool_stats();
+        CacheStats {
+            entries: stats.buffers,
+            retained_bytes: stats.capacity_bytes,
+        }
     }
 
     /// Current CPU buffer-pool retention limit in bytes.
@@ -547,7 +903,7 @@ impl CpuBackend {
     /// assert_eq!(backend.buffer_pool_limit_bytes(), 4096);
     /// ```
     pub fn buffer_pool_limit_bytes(&self) -> usize {
-        self.buffers.max_retained_capacity_bytes()
+        self.shared.buffer_limit.load(Ordering::Relaxed)
     }
 
     /// Update the CPU buffer-pool retention limit in bytes.
@@ -566,8 +922,17 @@ impl CpuBackend {
     /// assert_eq!(backend.buffer_pool_len(), 0);
     /// ```
     pub fn set_buffer_pool_limit_bytes(&mut self, max_retained_capacity_bytes: usize) {
-        self.buffers
-            .set_max_retained_capacity_bytes(max_retained_capacity_bytes);
+        self.shared
+            .buffer_limit
+            .store(max_retained_capacity_bytes, Ordering::Relaxed);
+        for engine in self.shared.initialized_engines() {
+            engine
+                .resources
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .buffers
+                .set_max_retained_capacity_bytes(max_retained_capacity_bytes);
+        }
     }
 
     /// Reset reusable typed host buffers currently retained by this backend.
@@ -586,7 +951,14 @@ impl CpuBackend {
     /// assert_eq!(backend.buffer_pool_len(), 0);
     /// ```
     pub fn reset_buffer_pool(&mut self) {
-        self.buffers.clear();
+        for engine in self.shared.initialized_engines() {
+            engine
+                .resources
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .buffers
+                .clear();
+        }
     }
 
     /// Run a closure in this backend's CPU execution scope.
@@ -601,12 +973,19 @@ impl CpuBackend {
     /// assert_eq!(value, 2);
     /// ```
     pub fn install<R: Send>(&self, op: impl FnOnce() -> R + Send) -> R {
-        self.ctx.install(op)
+        let _permit = self.acquire_execution_permit();
+        self.engine.context().install(op)
     }
 
     fn install_with_pool<R: Send>(&mut self, op: impl FnOnce(&mut BufferPool) -> R + Send) -> R {
-        let mut buffers = BufferPoolLoan::new(&mut self.buffers);
-        let ctx = Arc::clone(&self.ctx);
+        let _permit = self.acquire_execution_permit();
+        let ctx = self.engine.context_arc();
+        let mut resources = self
+            .engine
+            .resources
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
         ctx.install(|| op(buffers.get_mut()))
     }
 
@@ -614,12 +993,18 @@ impl CpuBackend {
     // it dormant.
     #[allow(dead_code)]
     fn run_with_pool<R>(&mut self, op: impl FnOnce(&mut BufferPool) -> R) -> R {
-        let mut buffers = BufferPoolLoan::new(&mut self.buffers);
+        let _permit = self.acquire_execution_permit();
+        let mut resources = self
+            .engine
+            .resources
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
         op(buffers.get_mut())
     }
 
     fn linalg_with_pool<R: Send>(&mut self, op: impl FnOnce(&mut BufferPool) -> R + Send) -> R {
-        match self.kind {
+        match self.kind() {
             CpuBackendKind::Faer => self.install_with_pool(op),
             CpuBackendKind::Blas => self.run_with_pool(op),
         }
@@ -638,7 +1023,7 @@ impl CpuBackend {
     #[cfg(feature = "cpu-faer")]
     #[doc(hidden)]
     pub fn linalg_context(&self) -> Arc<CpuContext> {
-        Arc::clone(&self.ctx)
+        self.engine.context_arc()
     }
 
     // Selected when the Faer provider handles cached GEMM execution; some
@@ -649,8 +1034,14 @@ impl CpuBackend {
         gemm_analysis_cache: &mut gemm::GemmAnalysisCache,
         op: impl FnOnce(&mut BufferPool, &mut gemm::GemmAnalysisCache) -> R + Send,
     ) -> R {
-        let mut buffers = BufferPoolLoan::new(&mut self.buffers);
-        let ctx = Arc::clone(&self.ctx);
+        let _permit = self.acquire_execution_permit();
+        let mut resources = self
+            .engine
+            .resources
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
+        let ctx = self.engine.context_arc();
         ctx.install(|| op(buffers.get_mut(), gemm_analysis_cache))
     }
 
@@ -662,8 +1053,30 @@ impl CpuBackend {
         gemm_analysis_cache: &mut gemm::GemmAnalysisCache,
         op: impl FnOnce(&mut BufferPool, &mut gemm::GemmAnalysisCache) -> R,
     ) -> R {
-        let mut buffers = BufferPoolLoan::new(&mut self.buffers);
+        let _permit = self.acquire_execution_permit();
+        let mut resources = self
+            .engine
+            .resources
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
         op(buffers.get_mut(), gemm_analysis_cache)
+    }
+
+    fn acquire_execution_permit(&self) -> ResourcePermit {
+        match &self.resolved {
+            ResolvedCpuExecution::Managed(placement) => self
+                .shared
+                .arbiter
+                .acquire_recovering(placement.cpus().clone()),
+            ResolvedCpuExecution::Compatibility => self
+                .shared
+                .arbiter
+                .acquire_recovering(self.shared.topology.allowed_cpus().clone()),
+            ResolvedCpuExecution::ProviderDefaultExclusive => {
+                self.shared.arbiter.acquire_provider_exclusive_recovering()
+            }
+        }
     }
 }
 
@@ -1034,11 +1447,11 @@ impl TensorDot for CpuBackend {
         config: &DotGeneralConfig,
     ) -> crate::Result<Tensor> {
         let mut cache = gemm::GemmAnalysisCache::default();
-        let direct = match self.kind {
+        let direct = match self.kind() {
             CpuBackendKind::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
-                    let ctx = Arc::clone(&self.ctx);
+                    let ctx = self.engine.context_arc();
                     self.install_with_pool_and_gemm_cache(&mut cache, |buffers, cache| {
                         gemm::dot_general_faer_read_cached(
                             buffers,
@@ -1053,7 +1466,7 @@ impl TensorDot for CpuBackend {
                 }
                 #[cfg(not(feature = "cpu-faer"))]
                 {
-                    return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
+                    return Err(unavailable_cpu_backend_kind(self.kind(), "dot_general"));
                 }
             }
             CpuBackendKind::Blas => {
@@ -1072,7 +1485,7 @@ impl TensorDot for CpuBackend {
                 }
                 #[cfg(not(feature = "cpu-blas"))]
                 {
-                    return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
+                    return Err(unavailable_cpu_backend_kind(self.kind(), "dot_general"));
                 }
             }
         };
@@ -1141,11 +1554,11 @@ impl BackendCachedDot for CpuBackend {
         rhs: &Tensor,
         config: &DotGeneralConfig,
     ) -> crate::Result<Tensor> {
-        match self.kind {
+        match self.kind() {
             CpuBackendKind::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
-                    let ctx = Arc::clone(&self.ctx);
+                    let ctx = self.engine.context_arc();
                     self.install_with_pool_and_gemm_cache(cache, |buffers, cache| {
                         match (lhs, rhs) {
                             (Tensor::F32(a), Tensor::F32(b)) => gemm::dot_general_faer_cached(
@@ -1198,7 +1611,7 @@ impl BackendCachedDot for CpuBackend {
                 }
                 #[cfg(not(feature = "cpu-faer"))]
                 {
-                    Err(unavailable_cpu_backend_kind(self.kind, "dot_general"))
+                    Err(unavailable_cpu_backend_kind(self.kind(), "dot_general"))
                 }
             }
             CpuBackendKind::Blas => {
@@ -1230,7 +1643,7 @@ impl BackendCachedDot for CpuBackend {
                 }
                 #[cfg(not(feature = "cpu-blas"))]
                 {
-                    Err(unavailable_cpu_backend_kind(self.kind, "dot_general"))
+                    Err(unavailable_cpu_backend_kind(self.kind(), "dot_general"))
                 }
             }
         }
@@ -1246,11 +1659,11 @@ impl BackendCachedDot for CpuBackend {
         lhs_conj: bool,
         rhs_conj: bool,
     ) -> crate::Result<Tensor> {
-        match self.kind {
+        match self.kind() {
             CpuBackendKind::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
-                    let ctx = Arc::clone(&self.ctx);
+                    let ctx = self.engine.context_arc();
                     self.install_with_pool_and_gemm_cache(cache, |buffers, cache| {
                         match (lhs, rhs) {
                             (Tensor::F32(a), Tensor::F32(b)) => {
@@ -1319,7 +1732,7 @@ impl BackendCachedDot for CpuBackend {
                 }
                 #[cfg(not(feature = "cpu-faer"))]
                 {
-                    Err(unavailable_cpu_backend_kind(self.kind, "dot_general"))
+                    Err(unavailable_cpu_backend_kind(self.kind(), "dot_general"))
                 }
             }
             CpuBackendKind::Blas => {
@@ -1359,7 +1772,7 @@ impl BackendCachedDot for CpuBackend {
                 }
                 #[cfg(not(feature = "cpu-blas"))]
                 {
-                    Err(unavailable_cpu_backend_kind(self.kind, "dot_general"))
+                    Err(unavailable_cpu_backend_kind(self.kind(), "dot_general"))
                 }
             }
         }
@@ -1376,11 +1789,11 @@ impl BackendCachedDot for CpuBackend {
         mut out: TensorWrite<'_>,
     ) -> crate::Result<()> {
         validate_dot_general_accumulation(&lhs, &rhs, config, accumulation, &out, "dot_general")?;
-        let direct = match self.kind {
+        let direct = match self.kind() {
             CpuBackendKind::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
-                    let ctx = Arc::clone(&self.ctx);
+                    let ctx = self.engine.context_arc();
                     self.install_with_pool_and_gemm_cache(cache, |_buffers, cache| {
                         gemm::dot_general_faer_read_into_accum_cached(
                             cache,
@@ -1396,7 +1809,7 @@ impl BackendCachedDot for CpuBackend {
                 }
                 #[cfg(not(feature = "cpu-faer"))]
                 {
-                    return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
+                    return Err(unavailable_cpu_backend_kind(self.kind(), "dot_general"));
                 }
             }
             CpuBackendKind::Blas => {
@@ -1417,7 +1830,7 @@ impl BackendCachedDot for CpuBackend {
                 }
                 #[cfg(not(feature = "cpu-blas"))]
                 {
-                    return Err(unavailable_cpu_backend_kind(self.kind, "dot_general"));
+                    return Err(unavailable_cpu_backend_kind(self.kind(), "dot_general"));
                 }
             }
         };
@@ -1438,11 +1851,11 @@ impl BackendCachedDot for CpuBackend {
         mut out: TensorWrite<'_>,
     ) -> crate::Result<()> {
         validate_grouped_gemm(&lhs, &rhs, &out, config, "grouped_gemm")?;
-        let direct = match self.kind {
+        let direct = match self.kind() {
             CpuBackendKind::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
-                    let ctx = Arc::clone(&self.ctx);
+                    let ctx = self.engine.context_arc();
                     self.install_with_pool(|_buffers| {
                         gemm::grouped_gemm_faer_cached(
                             ctx.as_ref(),
@@ -1455,7 +1868,7 @@ impl BackendCachedDot for CpuBackend {
                 }
                 #[cfg(not(feature = "cpu-faer"))]
                 {
-                    return Err(unavailable_cpu_backend_kind(self.kind, "grouped_gemm"));
+                    return Err(unavailable_cpu_backend_kind(self.kind(), "grouped_gemm"));
                 }
             }
             CpuBackendKind::Blas => {
@@ -1467,7 +1880,7 @@ impl BackendCachedDot for CpuBackend {
                 }
                 #[cfg(not(feature = "cpu-blas"))]
                 {
-                    return Err(unavailable_cpu_backend_kind(self.kind, "grouped_gemm"));
+                    return Err(unavailable_cpu_backend_kind(self.kind(), "grouped_gemm"));
                 }
             }
         };
@@ -1542,6 +1955,48 @@ impl TensorIndexing for CpuBackend {
     }
 }
 
+impl CpuBackend {
+    fn run_backend_session_cached<R: Send>(
+        &mut self,
+        cache: &mut gemm::GemmAnalysisCache,
+        f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
+    ) -> R {
+        let _permit = self.acquire_execution_permit();
+        let ctx = self.engine.context_arc();
+        let kind = self.kind();
+        let mut resources = self
+            .engine
+            .resources
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
+        let run = || {
+            let session_started = Instant::now();
+            let mut session = CpuExecSession {
+                ctx: ctx.as_ref(),
+                buffers: buffers.get_mut(),
+                gemm_analysis_cache: cache,
+                kind,
+            };
+            record_cpu_session_profile(
+                "with_backend_session_cached.session_construct",
+                session_started.elapsed(),
+            );
+            let exec_started = Instant::now();
+            let result = f(&mut session);
+            record_cpu_session_profile(
+                "with_backend_session_cached.exec_body",
+                exec_started.elapsed(),
+            );
+            result
+        };
+        match kind {
+            CpuBackendKind::Faer => ctx.install(run),
+            CpuBackendKind::Blas => run(),
+        }
+    }
+}
+
 impl BackendSessionHost for CpuBackend {
     fn with_backend_session<R: Send>(
         &mut self,
@@ -1559,54 +2014,13 @@ impl BackendSessionHost for CpuBackend {
         f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
     ) -> R {
         if !cpu_session_profile_enabled() {
-            let mut buffers = BufferPoolLoan::new(&mut self.buffers);
-            let ctx = Arc::clone(&self.ctx);
-            let kind = self.kind;
-            return ctx.install(|| {
-                let mut session = CpuExecSession {
-                    ctx: ctx.as_ref(),
-                    buffers: buffers.get_mut(),
-                    gemm_analysis_cache: cache,
-                    kind,
-                };
-                f(&mut session)
-            });
+            return self.run_backend_session_cached(cache, f);
         }
-
         let total_started = Instant::now();
-        let mut buffers =
-            profile_cpu_session_section("with_backend_session_cached.take_buffers", || {
-                BufferPoolLoan::new(&mut self.buffers)
-            });
-        let ctx = Arc::clone(&self.ctx);
-        let kind = self.kind;
         let result =
             profile_cpu_session_section("with_backend_session_cached.exec_session", || {
-                ctx.install(|| {
-                    let session_started = Instant::now();
-                    let mut session = CpuExecSession {
-                        ctx: ctx.as_ref(),
-                        buffers: buffers.get_mut(),
-                        gemm_analysis_cache: cache,
-                        kind,
-                    };
-                    record_cpu_session_profile(
-                        "with_backend_session_cached.session_construct",
-                        session_started.elapsed(),
-                    );
-
-                    let exec_started = Instant::now();
-                    let result = f(&mut session);
-                    record_cpu_session_profile(
-                        "with_backend_session_cached.exec_body",
-                        exec_started.elapsed(),
-                    );
-                    result
-                })
+                self.run_backend_session_cached(cache, f)
             });
-        profile_cpu_session_section("with_backend_session_cached.restore_buffers", || {
-            drop(buffers);
-        });
         record_cpu_session_profile("with_backend_session_cached.total", total_started.elapsed());
         maybe_print_cpu_session_profile();
         result
@@ -1615,14 +2029,21 @@ impl BackendSessionHost for CpuBackend {
 
 impl TensorBuffer for CpuBackend {
     fn reclaim_buffer(&mut self, tensor: Tensor) {
+        let _permit = self.acquire_execution_permit();
+        let mut resources = self
+            .engine
+            .resources
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let buffers = &mut resources.buffers;
         match tensor {
-            Tensor::F32(t) => reclaim_typed(&mut self.buffers, t),
-            Tensor::F64(t) => reclaim_typed(&mut self.buffers, t),
-            Tensor::I32(t) => reclaim_typed(&mut self.buffers, t),
-            Tensor::I64(t) => reclaim_typed(&mut self.buffers, t),
-            Tensor::Bool(t) => reclaim_typed(&mut self.buffers, t),
-            Tensor::C32(t) => reclaim_typed(&mut self.buffers, t),
-            Tensor::C64(t) => reclaim_typed(&mut self.buffers, t),
+            Tensor::F32(t) => reclaim_typed(buffers, t),
+            Tensor::F64(t) => reclaim_typed(buffers, t),
+            Tensor::I32(t) => reclaim_typed(buffers, t),
+            Tensor::I64(t) => reclaim_typed(buffers, t),
+            Tensor::Bool(t) => reclaim_typed(buffers, t),
+            Tensor::C32(t) => reclaim_typed(buffers, t),
+            Tensor::C64(t) => reclaim_typed(buffers, t),
         }
     }
 }

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -1293,6 +1293,13 @@ impl CpuBackend {
     /// let value = backend.install(|| 1 + 1);
     /// assert_eq!(value, 2);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics when called from a parallel Rayon child task while another CPU
+    /// backend execution owns that task's pool. Direct synchronous nesting is
+    /// supported, but parallel backend re-entry would violate CPU and provider
+    /// exclusivity.
     pub fn install<R: Send>(&self, op: impl FnOnce() -> R + Send) -> R {
         let owner = inherited_or_new_execution_owner();
         let _permit = self.acquire_execution_permit(owner);

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -12,8 +12,8 @@ use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
 use crate::engine::CpuEngine;
 use crate::placement::{resolve_placement, ResolvedCpuExecution};
 use crate::{
-    discover_cpu_topology, CpuId, CpuPlacement, CpuPlacementError, CpuSet, CpuTopology, NumaNodeId,
-    ResolvedCpuPlacement,
+    discover_cpu_topology, CpuId, CpuPlacement, CpuPlacementError, CpuSet, CpuTopology,
+    CpuTopologyError, NumaNodeId, ResolvedCpuPlacement,
 };
 use crate::{
     Buffer, CacheStats, Tensor, TensorRank, TensorRead, TensorValue, TensorWrite, TypedTensor,
@@ -217,6 +217,31 @@ impl CpuBackendKind {
     }
 }
 
+/// Stable execution-ownership mode selected for a CPU backend handle.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{CpuBackend, CpuExecutionMode};
+///
+/// let mode = CpuBackend::new().execution_info().execution_mode();
+/// assert!(matches!(
+///     mode,
+///     CpuExecutionMode::Managed
+///         | CpuExecutionMode::ProviderDefaultExclusive
+///         | CpuExecutionMode::Compatibility
+/// ));
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum CpuExecutionMode {
+    /// tenferro owns a pinned Rayon engine for the resolved CPU placement.
+    Managed,
+    /// An external provider owns worker placement under a process-wide permit.
+    ProviderDefaultExclusive,
+    /// A legacy unpinned Rayon context is used because managed affinity is unavailable.
+    Compatibility,
+}
+
 /// Snapshot of the stable CPU execution contract and non-contractual provider diagnostics.
 ///
 /// [`CpuBackendKind`] is the stable provider identity. The diagnostic string is
@@ -234,8 +259,11 @@ impl CpuBackendKind {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CpuExecutionInfo {
     backend_kind: CpuBackendKind,
+    execution_mode: CpuExecutionMode,
     requested_placement: CpuPlacement,
     resolved_placement: Option<ResolvedCpuPlacement>,
+    topology: CpuTopology,
+    worker_count: usize,
     provider_diagnostic: &'static str,
 }
 
@@ -250,6 +278,20 @@ impl CpuExecutionInfo {
     /// ```
     pub fn backend_kind(&self) -> CpuBackendKind {
         self.backend_kind
+    }
+
+    /// Return the stable execution-ownership mode.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let mode = tenferro_cpu::CpuBackend::new()
+    ///     .execution_info()
+    ///     .execution_mode();
+    /// let _ = format!("{mode:?}");
+    /// ```
+    pub fn execution_mode(&self) -> CpuExecutionMode {
+        self.execution_mode
     }
 
     /// Return the placement requested by this backend handle.
@@ -274,6 +316,30 @@ impl CpuExecutionInfo {
     /// ```
     pub fn resolved_placement(&self) -> Option<&ResolvedCpuPlacement> {
         self.resolved_placement.as_ref()
+    }
+
+    /// Return the process-visible topology used for placement resolution.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let info = tenferro_cpu::CpuBackend::new().execution_info();
+    /// assert!(!info.topology().allowed_cpus().is_empty());
+    /// ```
+    pub fn topology(&self) -> &CpuTopology {
+        &self.topology
+    }
+
+    /// Return the worker count of the selected native execution context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let info = tenferro_cpu::CpuBackend::new().execution_info();
+    /// assert!(info.worker_count() >= 1);
+    /// ```
+    pub fn worker_count(&self) -> usize {
+        self.worker_count
     }
 
     /// Return a human-readable provider description for logs.
@@ -454,6 +520,17 @@ pub struct CpuBackend {
     engine: Arc<CpuEngine>,
 }
 
+fn resolve_discovered_topology(
+    kind: CpuBackendKind,
+    topology: Result<CpuTopology, CpuTopologyError>,
+) -> Result<CpuTopology, CpuPlacementError> {
+    topology.map_err(|source| CpuPlacementError::TopologyDiscovery {
+        requested: CpuPlacement::Auto,
+        backend: kind,
+        source,
+    })
+}
+
 impl fmt::Debug for CpuBackend {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CpuBackend")
@@ -474,14 +551,24 @@ impl CpuBackend {
         kind: CpuBackendKind,
         max_retained_capacity_bytes: usize,
     ) -> Result<Self, CpuPlacementError> {
-        let topology = discover_cpu_topology().unwrap_or_else(|_| {
-            let allowed = crate::process_cpu_affinity().unwrap_or_else(|| {
-                CpuSet::new((0..crate::available_parallelism()).map(CpuId::new))
-                    .unwrap_or_else(|_| CpuSet::singleton(CpuId::new(0)))
-            });
-            CpuTopology::all_allowed(allowed)
-        });
+        let topology = resolve_discovered_topology(kind, discover_cpu_topology())?;
         let resolved = resolve_placement(kind, CpuPlacement::Auto, &topology)?;
+        if !cfg!(any(target_os = "linux", target_os = "android")) {
+            let context = CpuContext::with_threads(thread_budget).map_err(|error| {
+                CpuPlacementError::EngineConstruction {
+                    requested: CpuPlacement::Auto,
+                    backend: kind,
+                    message: error.to_string(),
+                }
+            })?;
+            return Ok(Self::compatibility_with_topology(
+                Arc::new(context),
+                max_retained_capacity_bytes,
+                kind,
+                topology,
+                resolved,
+            ));
+        }
         let engine_placement = ResolvedCpuPlacement::AllAllowed {
             cpus: topology.allowed_cpus().clone(),
         };
@@ -503,7 +590,7 @@ impl CpuBackend {
                 all_allowed,
                 all_allowed_build: Mutex::new(()),
                 base_engine: Arc::clone(&engine),
-                arbiter: ResourceArbiter::new(),
+                arbiter: ResourceArbiter::global(),
                 kind,
                 thread_budget,
                 buffer_limit: AtomicUsize::new(max_retained_capacity_bytes),
@@ -526,6 +613,27 @@ impl CpuBackend {
             });
             CpuTopology::all_allowed(allowed)
         });
+        let resolved = if kind == CpuBackendKind::Blas {
+            ResolvedCpuExecution::ProviderDefaultExclusive
+        } else {
+            ResolvedCpuExecution::Compatibility
+        };
+        Self::compatibility_with_topology(
+            ctx,
+            max_retained_capacity_bytes,
+            kind,
+            topology,
+            resolved,
+        )
+    }
+
+    fn compatibility_with_topology(
+        ctx: Arc<CpuContext>,
+        max_retained_capacity_bytes: usize,
+        kind: CpuBackendKind,
+        topology: CpuTopology,
+        resolved: ResolvedCpuExecution,
+    ) -> Self {
         let placement = ResolvedCpuPlacement::AllAllowed {
             cpus: topology.allowed_cpus().clone(),
         };
@@ -534,11 +642,6 @@ impl CpuBackend {
             ctx,
             max_retained_capacity_bytes,
         ));
-        let resolved = if kind == CpuBackendKind::Blas {
-            ResolvedCpuExecution::ProviderDefaultExclusive
-        } else {
-            ResolvedCpuExecution::Compatibility
-        };
         Self {
             shared: Arc::new(CpuBackendState {
                 topology,
@@ -546,7 +649,7 @@ impl CpuBackend {
                 all_allowed: OnceLock::new(),
                 all_allowed_build: Mutex::new(()),
                 base_engine: Arc::clone(&base_engine),
-                arbiter: ResourceArbiter::new(),
+                arbiter: ResourceArbiter::global(),
                 kind,
                 thread_budget: base_engine.context().num_threads(),
                 buffer_limit: AtomicUsize::new(max_retained_capacity_bytes),
@@ -886,8 +989,17 @@ impl CpuBackend {
     pub fn execution_info(&self) -> CpuExecutionInfo {
         CpuExecutionInfo {
             backend_kind: self.kind(),
+            execution_mode: match &self.resolved {
+                ResolvedCpuExecution::Managed(_) => CpuExecutionMode::Managed,
+                ResolvedCpuExecution::ProviderDefaultExclusive => {
+                    CpuExecutionMode::ProviderDefaultExclusive
+                }
+                ResolvedCpuExecution::Compatibility => CpuExecutionMode::Compatibility,
+            },
             requested_placement: self.requested,
             resolved_placement: self.resolved_placement().cloned(),
+            topology: self.shared.topology.clone(),
+            worker_count: self.num_threads(),
             provider_diagnostic: provider_diagnostic(self.kind()),
         }
     }

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -217,6 +217,105 @@ impl CpuBackendKind {
     }
 }
 
+/// Snapshot of the stable CPU execution contract and non-contractual provider diagnostics.
+///
+/// [`CpuBackendKind`] is the stable provider identity. The diagnostic string is
+/// intended for logs and may change between builds or releases.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{CpuBackend, CpuPlacement};
+///
+/// let info = CpuBackend::new().execution_info();
+/// assert_eq!(info.requested_placement(), CpuPlacement::Auto);
+/// assert!(!info.provider_diagnostic().is_empty());
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CpuExecutionInfo {
+    backend_kind: CpuBackendKind,
+    requested_placement: CpuPlacement,
+    resolved_placement: Option<ResolvedCpuPlacement>,
+    provider_diagnostic: &'static str,
+}
+
+impl CpuExecutionInfo {
+    /// Return the stable public provider identity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let info = tenferro_cpu::CpuBackend::new().execution_info();
+    /// assert_eq!(info.backend_kind(), tenferro_cpu::CpuBackend::new().kind());
+    /// ```
+    pub fn backend_kind(&self) -> CpuBackendKind {
+        self.backend_kind
+    }
+
+    /// Return the placement requested by this backend handle.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let info = tenferro_cpu::CpuBackend::new().execution_info();
+    /// assert_eq!(info.requested_placement(), tenferro_cpu::CpuPlacement::Auto);
+    /// ```
+    pub fn requested_placement(&self) -> CpuPlacement {
+        self.requested_placement
+    }
+
+    /// Return the concrete CPU placement when tenferro owns worker affinity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let backend = tenferro_cpu::CpuBackend::new();
+    /// let _managed = backend.execution_info().resolved_placement();
+    /// ```
+    pub fn resolved_placement(&self) -> Option<&ResolvedCpuPlacement> {
+        self.resolved_placement.as_ref()
+    }
+
+    /// Return a human-readable provider description for logs.
+    ///
+    /// This string is diagnostic only and is not a provider identity contract.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let diagnostic = tenferro_cpu::CpuBackend::new()
+    ///     .execution_info()
+    ///     .provider_diagnostic();
+    /// assert!(!diagnostic.is_empty());
+    /// ```
+    pub fn provider_diagnostic(&self) -> &'static str {
+        self.provider_diagnostic
+    }
+}
+
+fn provider_diagnostic(kind: CpuBackendKind) -> &'static str {
+    match kind {
+        CpuBackendKind::Faer => "faer (tenferro-managed Rayon affinity)",
+        CpuBackendKind::Blas => {
+            #[cfg(feature = "blas-openblas")]
+            return "OpenBLAS (external worker affinity)";
+            #[cfg(feature = "blas-mkl")]
+            return "Intel MKL (external worker affinity)";
+            #[cfg(feature = "blas-accelerate")]
+            return "Apple Accelerate (external worker affinity)";
+            #[cfg(feature = "provider-inject")]
+            return "runtime-injected BLAS/LAPACK (external worker affinity)";
+            #[cfg(not(any(
+                feature = "blas-openblas",
+                feature = "blas-mkl",
+                feature = "blas-accelerate",
+                feature = "provider-inject"
+            )))]
+            return "linked BLAS/LAPACK provider (identity unknown; external worker affinity)";
+        }
+    }
+}
+
 fn ensure_cpu_backend_kind_available(kind: CpuBackendKind, op: &'static str) -> crate::Result<()> {
     let _ = op;
     match kind {
@@ -774,6 +873,23 @@ impl CpuBackend {
     /// ```
     pub fn supports_placement(&self, placement: CpuPlacement) -> bool {
         resolve_placement(self.kind(), placement, &self.shared.topology).is_ok()
+    }
+
+    /// Return a snapshot suitable for diagnostics and placement reporting.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let backend = tenferro_cpu::CpuBackend::new();
+    /// assert_eq!(backend.execution_info().backend_kind(), backend.kind());
+    /// ```
+    pub fn execution_info(&self) -> CpuExecutionInfo {
+        CpuExecutionInfo {
+            backend_kind: self.kind(),
+            requested_placement: self.requested,
+            resolved_placement: self.resolved_placement().cloned(),
+            provider_diagnostic: provider_diagnostic(self.kind()),
+        }
     }
 
     #[cfg(all(test, feature = "cpu-faer"))]

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -160,33 +160,70 @@ fn independently_constructed_backends_share_global_provider_exclusion() {
 
 #[test]
 #[cfg(feature = "cpu-faer")]
-fn nested_clone_install_crosses_the_rayon_boundary_without_waiting() {
+fn direct_nested_clone_install_is_rejected_in_a_managed_scope() {
     let backend = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
     let nested = backend.clone();
-    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
 
-    std::thread::spawn(move || {
-        let value = backend.install(|| nested.install(|| 7_u32));
-        completed_tx.send(value).unwrap();
-    });
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.install(|| nested.install(|| 7_u32))
+    }));
 
-    assert_eq!(completed_rx.recv_timeout(Duration::from_secs(2)), Ok(7));
+    let message = outcome
+        .err()
+        .map(panic_message)
+        .expect("nesting should panic");
+    assert!(
+        message.contains("another CPU backend execution"),
+        "{message}"
+    );
 }
 
 #[test]
 #[cfg(feature = "cpu-faer")]
-fn nested_independent_engines_propagate_reentrancy_across_rayon_pools() {
+fn direct_nested_independent_engine_is_rejected_in_a_managed_scope() {
     let outer = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
     let middle = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
-    let inner = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
-    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
 
-    std::thread::spawn(move || {
-        let value = outer.install(|| middle.install(|| inner.install(|| 11_u32)));
-        completed_tx.send(value).unwrap();
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        outer.install(|| middle.install(|| 11_u32))
+    }));
+
+    let message = outcome
+        .err()
+        .map(panic_message)
+        .expect("nesting should panic");
+    assert!(
+        message.contains("another CPU backend execution"),
+        "{message}"
+    );
+}
+
+#[test]
+#[cfg(feature = "cpu-faer")]
+fn cross_pool_wait_cannot_misclassify_a_scheduled_sibling_as_direct_nesting() {
+    let outer = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let middle = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let sibling = outer.clone();
+
+    let (_, sibling_outcome) = outer.install(move || {
+        rayon::join(
+            || {
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    middle.install(|| std::thread::sleep(Duration::from_millis(50)))
+                }))
+            },
+            || std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| sibling.install(|| ()))),
+        )
     });
 
-    assert_eq!(completed_rx.recv_timeout(Duration::from_secs(2)), Ok(11));
+    let message = sibling_outcome
+        .err()
+        .map(panic_message)
+        .expect("scheduled sibling reentry should panic");
+    assert!(
+        message.contains("another CPU backend execution"),
+        "{message}"
+    );
 }
 
 #[test]
@@ -215,7 +252,10 @@ fn stolen_rayon_child_task_backend_reentry_is_rejected() {
         .recv_timeout(Duration::from_secs(2))
         .expect("parallel child reentry should fail without deadlocking")
         .expect("parallel child reentry should panic");
-    assert!(message.contains("parallel Rayon child task"), "{message}");
+    assert!(
+        message.contains("another CPU backend execution"),
+        "{message}"
+    );
 }
 
 #[test]
@@ -246,7 +286,10 @@ fn parallel_rayon_sibling_backend_reentry_is_rejected() {
             .recv_timeout(Duration::from_secs(2))
             .expect("parallel sibling reentry should fail without deadlocking")
             .expect("parallel sibling reentry should panic");
-        assert!(message.contains("parallel Rayon child task"), "{message}");
+        assert!(
+            message.contains("another CPU backend execution"),
+            "{message}"
+        );
     }
 }
 
@@ -271,7 +314,10 @@ fn shared_context_work_is_not_mistaken_for_backend_reentry() {
             .expect("shared-context work should not bypass backend exclusion")
     });
 
-    assert!(message.contains("parallel Rayon child task"), "{message}");
+    assert!(
+        message.contains("another CPU backend execution"),
+        "{message}"
+    );
 }
 
 #[test]
@@ -289,44 +335,45 @@ fn execution_owner_broadcast_is_cleared_after_panic() {
 
 #[test]
 #[cfg(feature = "cpu-faer")]
-fn nested_clone_tensor_operation_does_not_relock_engine_resources() {
+fn nested_clone_tensor_operation_is_rejected_in_a_managed_scope() {
     let mut backend = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
     let mut nested = backend.clone();
     let lhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     let rhs = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
-    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
 
-    std::thread::spawn(move || {
-        let result = backend.with_backend_session(|_| nested.add(&lhs, &rhs));
-        completed_tx.send(result).unwrap();
-    });
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.with_backend_session(|_| nested.add(&lhs, &rhs))
+    }));
 
-    let result = completed_rx
-        .recv_timeout(Duration::from_secs(2))
-        .expect("nested tensor operation should not deadlock")
-        .unwrap();
-    assert_eq!(result.as_slice::<f64>().unwrap(), &[5.0]);
+    let message = outcome
+        .err()
+        .map(panic_message)
+        .expect("nesting should panic");
+    assert!(
+        message.contains("another CPU backend execution"),
+        "{message}"
+    );
 }
 
 #[test]
 #[cfg(feature = "cpu-blas")]
-fn nested_provider_session_uses_reentrant_transient_resources() {
+fn nested_provider_session_is_rejected() {
     let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Blas).unwrap();
     let mut nested = backend.clone();
     let lhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     let rhs = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
-    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.with_backend_session(|_| nested.add(&lhs, &rhs))
+    }));
 
-    std::thread::spawn(move || {
-        let result = backend.with_backend_session(|_| nested.add(&lhs, &rhs));
-        completed_tx.send(result).unwrap();
-    });
-
-    let result = completed_rx
-        .recv_timeout(Duration::from_secs(2))
-        .expect("nested provider operation should not deadlock")
-        .unwrap();
-    assert_eq!(result.as_slice::<f64>().unwrap(), &[5.0]);
+    let message = outcome
+        .err()
+        .map(panic_message)
+        .expect("nesting should panic");
+    assert!(
+        message.contains("another CPU backend execution"),
+        "{message}"
+    );
 }
 
 #[test]
@@ -358,7 +405,10 @@ fn parallel_rayon_siblings_cannot_bypass_provider_exclusion() {
             .recv_timeout(Duration::from_secs(2))
             .expect("provider sibling reentry should fail without deadlocking")
             .expect("provider sibling reentry should panic");
-        assert!(message.contains("parallel Rayon child task"), "{message}");
+        assert!(
+            message.contains("another CPU backend execution"),
+            "{message}"
+        );
     }
 }
 

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -79,6 +79,17 @@ fn placement_capabilities_follow_public_backend_kind() {
 }
 
 #[test]
+fn execution_info_exposes_stable_kind_and_placement_contract() {
+    let backend = CpuBackend::new();
+    let info = backend.execution_info();
+
+    assert_eq!(info.backend_kind(), backend.kind());
+    assert_eq!(info.requested_placement(), CpuPlacement::Auto);
+    assert_eq!(info.resolved_placement(), backend.resolved_placement());
+    assert!(!info.provider_diagnostic().is_empty());
+}
+
+#[test]
 #[cfg(feature = "cpu-blas")]
 fn blas_provider_session_body_stays_outside_the_rayon_engine() {
     use tenferro_tensor::BackendSessionHost;

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -80,6 +80,17 @@ fn placement_capabilities_follow_public_backend_kind() {
 
 #[test]
 #[cfg(feature = "cpu-blas")]
+fn blas_provider_session_body_stays_outside_the_rayon_engine() {
+    use tenferro_tensor::BackendSessionHost;
+
+    let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Blas).unwrap();
+    backend.with_backend_session(|_| {
+        assert!(rayon::current_thread_index().is_none());
+    });
+}
+
+#[test]
+#[cfg(feature = "cpu-blas")]
 fn blas_auto_is_provider_exclusive_and_explicit_placement_is_rejected() {
     let backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Blas).unwrap();
 

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -45,6 +45,50 @@ fn explicit_backend_kind_constructor_records_selection() {
 }
 
 #[test]
+#[cfg(feature = "cpu-faer")]
+fn placement_handle_clones_share_coordinator_engine_and_resources() {
+    let backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let mut placed = backend.for_placement(CpuPlacement::AllAllowed).unwrap();
+    let clone = placed.clone();
+
+    assert_eq!(
+        placed.coordinator_id_for_test(),
+        clone.coordinator_id_for_test()
+    );
+    assert_eq!(placed.placement(), CpuPlacement::AllAllowed);
+    assert!(matches!(
+        placed.resolved_placement(),
+        Some(ResolvedCpuPlacement::AllAllowed { .. })
+    ));
+    placed.with_linalg_pool(|pool| {
+        <f64 as PoolScalar>::pool_release(pool, vec![1.0, 2.0]);
+    });
+    assert_eq!(clone.buffer_pool_len(), 1);
+}
+
+#[test]
+#[cfg(feature = "cpu-faer")]
+fn placement_capabilities_follow_public_backend_kind() {
+    let backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    assert!(backend.supports_placement(CpuPlacement::Auto));
+    assert!(backend.supports_placement(CpuPlacement::AllAllowed));
+    assert_eq!(
+        backend.topology().allowed_cpus(),
+        crate::process_cpu_affinity().as_ref().unwrap()
+    );
+}
+
+#[test]
+#[cfg(feature = "cpu-blas")]
+fn blas_auto_is_provider_exclusive_and_explicit_placement_is_rejected() {
+    let backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Blas).unwrap();
+
+    assert!(backend.for_placement(CpuPlacement::AllAllowed).is_err());
+    assert!(!backend.supports_placement(CpuPlacement::AllAllowed));
+    assert!(backend.resolved_placement().is_none());
+}
+
+#[test]
 #[cfg(feature = "cpu-blas")]
 fn explicit_blas_backend_kind_constructor_records_selection() {
     let backend = CpuBackend::with_kind(CpuBackendKind::Blas).unwrap();
@@ -86,11 +130,11 @@ fn unavailable_blas_backend_kind_reports_config_errors() {
         }
     ));
 
-    let mut backend = CpuBackend {
-        ctx: Arc::new(CpuContext::with_threads(1).unwrap()),
-        buffers: BufferPool::new(),
-        kind: CpuBackendKind::Blas,
-    };
+    let mut backend = CpuBackend::compatibility(
+        Arc::new(CpuContext::with_threads(1).unwrap()),
+        crate::buffer_pool::DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
+        CpuBackendKind::Blas,
+    );
     let retained = backend.with_linalg_pool(|pool| {
         <f64 as PoolScalar>::pool_release(pool, vec![1.0, 2.0]);
         pool.len()
@@ -175,10 +219,12 @@ fn with_linalg_pool_restores_backend_pool_and_context() {
 #[test]
 fn linalg_pool_acquire_then_panic_replenishes_retained_buffer() {
     let mut backend = CpuBackend::with_threads(1).unwrap();
-    <f64 as PoolScalar>::pool_release(&mut backend.buffers, Vec::with_capacity(1024));
+    backend.with_linalg_pool(|pool| {
+        <f64 as PoolScalar>::pool_release(pool, Vec::with_capacity(1024));
+    });
     assert_eq!(backend.buffer_pool_len(), 1);
     assert_eq!(
-        backend.buffers.retained_capacity_bytes(),
+        backend.buffer_pool_stats().capacity_bytes,
         1024 * std::mem::size_of::<f64>()
     );
 
@@ -193,7 +239,7 @@ fn linalg_pool_acquire_then_panic_replenishes_retained_buffer() {
     assert!(result.is_err());
     assert_eq!(backend.buffer_pool_len(), 1);
     assert_eq!(
-        backend.buffers.retained_capacity_bytes(),
+        backend.buffer_pool_stats().capacity_bytes,
         1024 * std::mem::size_of::<f64>()
     );
 }

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -86,6 +86,25 @@ fn execution_info_exposes_stable_kind_and_placement_contract() {
     assert_eq!(info.backend_kind(), backend.kind());
     assert_eq!(info.requested_placement(), CpuPlacement::Auto);
     assert_eq!(info.resolved_placement(), backend.resolved_placement());
+    assert_eq!(info.topology(), backend.topology());
+    assert_eq!(info.worker_count(), backend.num_threads());
+    #[cfg(feature = "cpu-blas")]
+    assert_eq!(
+        info.execution_mode(),
+        CpuExecutionMode::ProviderDefaultExclusive
+    );
+    #[cfg(all(
+        not(feature = "cpu-blas"),
+        feature = "cpu-faer",
+        any(target_os = "linux", target_os = "android")
+    ))]
+    assert_eq!(info.execution_mode(), CpuExecutionMode::Managed);
+    #[cfg(all(
+        not(feature = "cpu-blas"),
+        feature = "cpu-faer",
+        not(any(target_os = "linux", target_os = "android"))
+    ))]
+    assert_eq!(info.execution_mode(), CpuExecutionMode::Compatibility);
     assert!(!info.provider_diagnostic().is_empty());
 }
 
@@ -108,6 +127,21 @@ fn blas_auto_is_provider_exclusive_and_explicit_placement_is_rejected() {
     assert!(backend.for_placement(CpuPlacement::AllAllowed).is_err());
     assert!(!backend.supports_placement(CpuPlacement::AllAllowed));
     assert!(backend.resolved_placement().is_none());
+}
+
+#[test]
+#[cfg(feature = "cpu-blas")]
+fn independently_constructed_backends_share_global_provider_exclusion() {
+    let first = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Blas).unwrap();
+    let second = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Blas).unwrap();
+
+    let _permit = first.shared.arbiter.acquire_provider_exclusive().unwrap();
+    assert!(second
+        .shared
+        .arbiter
+        .try_acquire_provider_exclusive()
+        .unwrap()
+        .is_none());
 }
 
 #[test]
@@ -317,4 +351,22 @@ fn cached_dot_dispatch_reports_dtype_mismatches() {
 #[test]
 fn with_threads_rejects_invalid_thread_count() {
     assert!(CpuBackend::with_threads(0).is_err());
+}
+
+#[test]
+fn fallible_backend_construction_preserves_topology_error_category() {
+    let source = CpuTopologyError::InvalidCpuList {
+        list: "not-a-cpu".to_owned(),
+        reason: "component is not a CPU number",
+    };
+
+    let error = resolve_discovered_topology(CpuBackendKind::Faer, Err(source.clone())).unwrap_err();
+    assert_eq!(
+        error,
+        CpuPlacementError::TopologyDiscovery {
+            requested: CpuPlacement::Auto,
+            backend: CpuBackendKind::Faer,
+            source,
+        }
+    );
 }

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -149,6 +149,73 @@ fn independently_constructed_backends_share_global_provider_exclusion() {
 }
 
 #[test]
+#[cfg(feature = "cpu-faer")]
+fn nested_clone_install_crosses_the_rayon_boundary_without_waiting() {
+    let backend = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
+    let nested = backend.clone();
+    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+
+    std::thread::spawn(move || {
+        let value = backend.install(|| nested.install(|| 7_u32));
+        completed_tx.send(value).unwrap();
+    });
+
+    assert_eq!(completed_rx.recv_timeout(Duration::from_secs(2)), Ok(7));
+}
+
+#[test]
+#[cfg(feature = "cpu-faer")]
+fn nested_independent_engines_propagate_reentrancy_across_rayon_pools() {
+    let outer = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
+    let middle = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
+    let inner = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
+    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+
+    std::thread::spawn(move || {
+        let value = outer.install(|| middle.install(|| inner.install(|| 11_u32)));
+        completed_tx.send(value).unwrap();
+    });
+
+    assert_eq!(completed_rx.recv_timeout(Duration::from_secs(2)), Ok(11));
+}
+
+#[test]
+#[cfg(feature = "cpu-faer")]
+fn nested_clone_tensor_operation_does_not_relock_engine_resources() {
+    let mut backend = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
+    let mut nested = backend.clone();
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
+    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+
+    std::thread::spawn(move || {
+        let result = backend.with_backend_session(|_| nested.add(&lhs, &rhs));
+        completed_tx.send(result).unwrap();
+    });
+
+    let result = completed_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("nested tensor operation should not deadlock")
+        .unwrap();
+    assert_eq!(result.as_slice::<f64>().unwrap(), &[5.0]);
+}
+
+#[test]
+#[cfg(feature = "cpu-blas")]
+fn nested_provider_session_uses_reentrant_transient_resources() {
+    let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Blas).unwrap();
+    let mut nested = backend.clone();
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
+
+    let result = backend
+        .with_backend_session(|_| nested.add(&lhs, &rhs))
+        .unwrap();
+
+    assert_eq!(result.as_slice::<f64>().unwrap(), &[5.0]);
+}
+
+#[test]
 #[cfg(feature = "cpu-blas")]
 fn explicit_blas_backend_kind_constructor_records_selection() {
     let backend = CpuBackend::with_kind(CpuBackendKind::Blas).unwrap();

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -2,6 +2,16 @@ use std::time::Duration;
 
 use super::*;
 
+fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<String>() {
+        return message.clone();
+    }
+    if let Some(message) = payload.downcast_ref::<&'static str>() {
+        return (*message).to_owned();
+    }
+    "<non-string panic payload>".to_owned()
+}
+
 #[test]
 fn cpu_tensor_kernel_parallel_features_are_wired() {
     let workspace_manifest = include_str!("../../../../Cargo.toml");
@@ -181,7 +191,7 @@ fn nested_independent_engines_propagate_reentrancy_across_rayon_pools() {
 
 #[test]
 #[cfg(feature = "cpu-faer")]
-fn stolen_rayon_child_task_inherits_the_outer_execution_owner() {
+fn stolen_rayon_child_task_backend_reentry_is_rejected() {
     let outer = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
     let nested = outer.clone();
     let (completed_tx, completed_rx) = std::sync::mpsc::channel();
@@ -191,15 +201,77 @@ fn stolen_rayon_child_task_inherits_the_outer_execution_owner() {
             rayon::scope(|scope| {
                 let completed_tx = completed_tx.clone();
                 scope.spawn(move |_| {
-                    let value = nested.install(|| 13_u32);
-                    completed_tx.send(value).unwrap();
+                    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        nested.install(|| 13_u32)
+                    }));
+                    completed_tx.send(outcome.err().map(panic_message)).unwrap();
                 });
                 std::thread::sleep(Duration::from_millis(100));
             });
         });
     });
 
-    assert_eq!(completed_rx.recv_timeout(Duration::from_secs(2)), Ok(13));
+    let message = completed_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("parallel child reentry should fail without deadlocking")
+        .expect("parallel child reentry should panic");
+    assert!(message.contains("parallel Rayon child task"), "{message}");
+}
+
+#[test]
+#[cfg(feature = "cpu-faer")]
+fn parallel_rayon_sibling_backend_reentry_is_rejected() {
+    let outer = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
+    let first = outer.clone();
+    let second = outer.clone();
+    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+
+    outer.install(|| {
+        rayon::scope(|scope| {
+            for nested in [first, second] {
+                let completed_tx = completed_tx.clone();
+                scope.spawn(move |_| {
+                    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        nested.install(|| ())
+                    }));
+                    completed_tx.send(outcome.err().map(panic_message)).unwrap();
+                });
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        });
+    });
+
+    for _ in 0..2 {
+        let message = completed_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("parallel sibling reentry should fail without deadlocking")
+            .expect("parallel sibling reentry should panic");
+        assert!(message.contains("parallel Rayon child task"), "{message}");
+    }
+}
+
+#[test]
+#[cfg(feature = "cpu-faer")]
+fn shared_context_work_is_not_mistaken_for_backend_reentry() {
+    let context = Arc::new(CpuContext::with_threads(2).unwrap());
+    let backend = CpuBackend::from_context(Arc::clone(&context));
+    let nested = backend.clone();
+
+    let message = backend.install(|| {
+        let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                context.install(|| nested.install(|| ()))
+            }));
+            completed_tx.send(outcome.err().map(panic_message)).unwrap();
+        });
+        completed_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("shared-context work should fail without deadlocking")
+            .expect("shared-context work should not bypass backend exclusion")
+    });
+
+    assert!(message.contains("parallel Rayon child task"), "{message}");
 }
 
 #[test]
@@ -255,6 +327,39 @@ fn nested_provider_session_uses_reentrant_transient_resources() {
         .expect("nested provider operation should not deadlock")
         .unwrap();
     assert_eq!(result.as_slice::<f64>().unwrap(), &[5.0]);
+}
+
+#[test]
+#[cfg(all(feature = "cpu-faer", feature = "cpu-blas"))]
+fn parallel_rayon_siblings_cannot_bypass_provider_exclusion() {
+    let outer = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
+    let provider = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Blas).unwrap();
+    let first = provider.clone();
+    let second = provider;
+    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+
+    outer.install(|| {
+        rayon::scope(|scope| {
+            for nested in [first, second] {
+                let completed_tx = completed_tx.clone();
+                scope.spawn(move |_| {
+                    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        nested.install(|| ())
+                    }));
+                    completed_tx.send(outcome.err().map(panic_message)).unwrap();
+                });
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        });
+    });
+
+    for _ in 0..2 {
+        let message = completed_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("provider sibling reentry should fail without deadlocking")
+            .expect("provider sibling reentry should panic");
+        assert!(message.contains("parallel Rayon child task"), "{message}");
+    }
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -181,6 +181,42 @@ fn nested_independent_engines_propagate_reentrancy_across_rayon_pools() {
 
 #[test]
 #[cfg(feature = "cpu-faer")]
+fn stolen_rayon_child_task_inherits_the_outer_execution_owner() {
+    let outer = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
+    let nested = outer.clone();
+    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+
+    std::thread::spawn(move || {
+        outer.install(|| {
+            rayon::scope(|scope| {
+                let completed_tx = completed_tx.clone();
+                scope.spawn(move |_| {
+                    let value = nested.install(|| 13_u32);
+                    completed_tx.send(value).unwrap();
+                });
+                std::thread::sleep(Duration::from_millis(100));
+            });
+        });
+    });
+
+    assert_eq!(completed_rx.recv_timeout(Duration::from_secs(2)), Ok(13));
+}
+
+#[test]
+#[cfg(feature = "cpu-faer")]
+fn execution_owner_broadcast_is_cleared_after_panic() {
+    let backend = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
+
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.install(|| panic!("forced nested execution panic"));
+    }));
+
+    assert!(panic.is_err());
+    assert_eq!(backend.install(|| 17_u32), 17);
+}
+
+#[test]
+#[cfg(feature = "cpu-faer")]
 fn nested_clone_tensor_operation_does_not_relock_engine_resources() {
     let mut backend = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
     let mut nested = backend.clone();
@@ -207,11 +243,17 @@ fn nested_provider_session_uses_reentrant_transient_resources() {
     let mut nested = backend.clone();
     let lhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     let rhs = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
+    let (completed_tx, completed_rx) = std::sync::mpsc::channel();
 
-    let result = backend
-        .with_backend_session(|_| nested.add(&lhs, &rhs))
+    std::thread::spawn(move || {
+        let result = backend.with_backend_session(|_| nested.add(&lhs, &rhs));
+        completed_tx.send(result).unwrap();
+    });
+
+    let result = completed_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("nested provider operation should not deadlock")
         .unwrap();
-
     assert_eq!(result.as_slice::<f64>().unwrap(), &[5.0]);
 }
 

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -136,12 +136,16 @@ fn independently_constructed_backends_share_global_provider_exclusion() {
     let second = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Blas).unwrap();
 
     let _permit = first.shared.arbiter.acquire_provider_exclusive().unwrap();
-    assert!(second
-        .shared
-        .arbiter
-        .try_acquire_provider_exclusive()
-        .unwrap()
-        .is_none());
+    let second_arbiter = second.shared.arbiter.clone();
+    let blocked = std::thread::spawn(move || {
+        second_arbiter
+            .try_acquire_provider_exclusive()
+            .unwrap()
+            .is_none()
+    })
+    .join()
+    .unwrap();
+    assert!(blocked);
 }
 
 #[test]
@@ -164,10 +168,10 @@ fn with_threads_and_kind_records_selection_and_validates_threads() {
     };
     assert!(matches!(
         err,
-        crate::Error::InvalidConfig {
+        CpuBackendError::Tensor(crate::Error::InvalidConfig {
             op: "CpuBackend::with_threads_and_kind",
             ..
-        }
+        })
     ));
 }
 
@@ -180,10 +184,10 @@ fn unavailable_blas_backend_kind_reports_config_errors() {
     };
     assert!(matches!(
         err,
-        crate::Error::InvalidConfig {
+        CpuBackendError::Tensor(crate::Error::InvalidConfig {
             op: "CpuBackend::with_kind",
             ..
-        }
+        })
     ));
 
     let mut backend = CpuBackend::compatibility(
@@ -350,7 +354,30 @@ fn cached_dot_dispatch_reports_dtype_mismatches() {
 
 #[test]
 fn with_threads_rejects_invalid_thread_count() {
-    assert!(CpuBackend::with_threads(0).is_err());
+    let result: Result<CpuBackend, CpuBackendError> = CpuBackend::with_threads(0);
+    let error = result.unwrap_err();
+    assert!(matches!(
+        error,
+        CpuBackendError::Tensor(crate::Error::InvalidConfig {
+            op: "CpuBackend::with_threads",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn backend_error_keeps_placement_failure_typed() {
+    let placement = CpuPlacementError::TopologyDiscovery {
+        requested: CpuPlacement::Auto,
+        backend: CpuBackendKind::Faer,
+        source: CpuTopologyError::InvalidCpuList {
+            list: "bad".to_owned(),
+            reason: "test failure",
+        },
+    };
+
+    let error = CpuBackendError::placement("CpuBackend::try_new", placement.clone());
+    assert_eq!(error.placement_error(), Some(&placement));
 }
 
 #[test]
@@ -369,4 +396,20 @@ fn fallible_backend_construction_preserves_topology_error_category() {
             source,
         }
     );
+}
+
+#[test]
+#[cfg(feature = "cpu-faer")]
+fn unavailable_affinity_auto_placement_reuses_compatibility_engine() {
+    let backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+
+    let placed = backend
+        .for_placement_with_affinity(CpuPlacement::Auto, false)
+        .unwrap();
+
+    assert_eq!(
+        placed.execution_info().execution_mode(),
+        CpuExecutionMode::Compatibility
+    );
+    assert_eq!(placed.context_id_for_test(), backend.context_id_for_test());
 }

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -1,7 +1,54 @@
 use std::env;
 use std::sync::Arc;
 
-use crate::{Error, Result};
+use thiserror::Error as ThisError;
+
+use crate::affinity::{SystemThreadAffinity, ThreadAffinity};
+use crate::{CpuId, CpuSet, Error, Result};
+
+/// Failure to construct a CPU context with pinned Rayon workers.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::CpuContextError;
+///
+/// let error = CpuContextError::InvalidThreadCount;
+/// assert!(error.to_string().contains("thread count"));
+/// ```
+#[derive(Clone, Debug, ThisError, PartialEq, Eq)]
+pub enum CpuContextError {
+    /// A context must contain at least one worker.
+    #[error("thread count must be at least 1")]
+    InvalidThreadCount,
+    /// A pinned engine cannot create more workers than assigned CPUs.
+    #[error("requested {workers} workers for only {cpus} assigned CPUs")]
+    TooManyWorkers {
+        /// Requested Rayon worker count.
+        workers: usize,
+        /// Number of logical CPUs in the execution domain.
+        cpus: usize,
+    },
+    /// Rayon could not construct the custom thread pool.
+    #[error("failed to build pinned CPU thread pool: {message}")]
+    PoolBuild {
+        /// Rayon or OS thread-spawn error detail.
+        message: String,
+    },
+    /// A worker could not set or verify its assigned CPU affinity.
+    #[error("failed to pin worker {worker} to CPU {cpu}: {message}")]
+    WorkerPinning {
+        /// Stable Rayon worker index.
+        worker: usize,
+        /// Assigned operating-system logical CPU.
+        cpu: CpuId,
+        /// OS or verification failure detail.
+        message: String,
+    },
+    /// A worker terminated before reporting startup affinity.
+    #[error("worker startup channel closed before all workers reported")]
+    WorkerStartupClosed,
+}
 
 /// Reusable CPU execution context carrying CPU parallelism policy.
 ///
@@ -22,6 +69,7 @@ use crate::{Error, Result};
 pub struct CpuContext {
     num_threads: usize,
     pool: Option<Arc<rayon::ThreadPool>>,
+    pinned_cpus: Option<CpuSet>,
 }
 
 impl CpuContext {
@@ -115,13 +163,109 @@ impl CpuContext {
                     })?,
             ))
         };
-        Ok(Self { num_threads, pool })
+        Ok(Self {
+            num_threads,
+            pool,
+            pinned_cpus: None,
+        })
+    }
+
+    /// Create a Rayon context whose workers are pinned to assigned logical CPUs.
+    ///
+    /// A real Rayon pool is constructed even when `num_threads` is one. The
+    /// worker count cannot exceed the assigned CPU count.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{process_cpu_affinity, CpuContext};
+    ///
+    /// if let Some(allowed) = process_cpu_affinity() {
+    ///     let one_cpu = tenferro_cpu::CpuSet::new([allowed.as_slice()[0]])?;
+    ///     let context = CpuContext::with_pinned_cpus(one_cpu.clone(), 1)?;
+    ///     assert_eq!(context.pinned_cpus(), Some(&one_cpu));
+    /// }
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn with_pinned_cpus(
+        cpus: CpuSet,
+        num_threads: usize,
+    ) -> std::result::Result<Self, CpuContextError> {
+        Self::with_pinned_cpus_using(cpus, num_threads, SystemThreadAffinity)
+    }
+
+    pub(crate) fn with_pinned_cpus_using<A: ThreadAffinity>(
+        cpus: CpuSet,
+        num_threads: usize,
+        affinity: A,
+    ) -> std::result::Result<Self, CpuContextError> {
+        if num_threads == 0 {
+            return Err(CpuContextError::InvalidThreadCount);
+        }
+        if num_threads > cpus.len() {
+            return Err(CpuContextError::TooManyWorkers {
+                workers: num_threads,
+                cpus: cpus.len(),
+            });
+        }
+
+        let assigned_cpus = Arc::new(cpus.as_slice()[..num_threads].to_vec());
+        let (startup_tx, startup_rx) = std::sync::mpsc::channel();
+        let pool_assigned_cpus = Arc::clone(&assigned_cpus);
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .spawn_handler(move |thread| {
+                let worker = thread.index();
+                let cpu = pool_assigned_cpus[worker];
+                let startup_tx = startup_tx.clone();
+                let affinity = affinity.clone();
+                std::thread::Builder::new()
+                    .name(format!("tenferro-cpu-{cpu}"))
+                    .spawn(move || {
+                        let result = affinity.pin_current(cpu).and_then(|observed| {
+                            (observed.len() == 1 && observed.contains(cpu))
+                                .then_some(())
+                                .ok_or_else(|| {
+                                    format!(
+                                        "verification returned affinity {:?}",
+                                        observed.as_usize_vec()
+                                    )
+                                })
+                        });
+                        let _ = startup_tx.send((worker, cpu, result));
+                        thread.run();
+                    })
+                    .map(|_| ())
+            })
+            .build()
+            .map_err(|err| CpuContextError::PoolBuild {
+                message: err.to_string(),
+            })?;
+        let pool = Arc::new(pool);
+        for _ in 0..num_threads {
+            let (worker, cpu, result) = startup_rx
+                .recv()
+                .map_err(|_| CpuContextError::WorkerStartupClosed)?;
+            if let Err(message) = result {
+                return Err(CpuContextError::WorkerPinning {
+                    worker,
+                    cpu,
+                    message,
+                });
+            }
+        }
+        Ok(Self {
+            num_threads,
+            pool: Some(pool),
+            pinned_cpus: Some(cpus),
+        })
     }
 
     fn single_threaded() -> Self {
         Self {
             num_threads: 1,
             pool: None,
+            pinned_cpus: None,
         }
     }
 
@@ -137,6 +281,23 @@ impl CpuContext {
     /// ```
     pub fn num_threads(&self) -> usize {
         self.num_threads
+    }
+
+    /// Return the worker CPU domain for a pinned context.
+    ///
+    /// Legacy thread-count-only contexts return `None` because they do not own
+    /// worker affinity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuContext;
+    ///
+    /// assert_eq!(CpuContext::with_threads(1)?.pinned_cpus(), None);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn pinned_cpus(&self) -> Option<&CpuSet> {
+        self.pinned_cpus.as_ref()
     }
 
     /// Run a closure inside this context's CPU execution scope.

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -4,7 +4,9 @@ use std::sync::{Arc, Mutex};
 use thiserror::Error as ThisError;
 
 use crate::affinity::{SystemThreadAffinity, ThreadAffinity};
-use crate::arbiter::{set_pool_execution_owner, with_execution_owner, ResourceOwner};
+use crate::arbiter::{
+    set_pool_execution_owner, with_execution_owner, with_pool_execution_owner, ResourceOwner,
+};
 use crate::{CpuId, CpuSet, Error, Result};
 
 #[derive(Debug, Default)]
@@ -390,7 +392,7 @@ impl CpuContext {
             context: self,
             owner,
         };
-        self.install(|| with_execution_owner(owner, op))
+        self.install(|| with_pool_execution_owner(owner, || with_execution_owner(owner, op)))
     }
 
     fn broadcast_execution_owner(&self, owner: Option<ResourceOwner>) {

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -209,7 +209,7 @@ impl CpuContext {
             });
         }
 
-        let assigned_cpus = Arc::new(cpus.as_slice()[..num_threads].to_vec());
+        let assigned_cpus = Arc::new(select_worker_cpus(&cpus, num_threads));
         let (startup_tx, startup_rx) = std::sync::mpsc::channel();
         let pool_assigned_cpus = Arc::clone(&assigned_cpus);
         let pool = rayon::ThreadPoolBuilder::new()
@@ -338,6 +338,19 @@ impl CpuContext {
     pub fn faer_seq(&self) -> faer::Par {
         faer::Par::Seq
     }
+}
+
+fn select_worker_cpus(cpus: &CpuSet, num_threads: usize) -> Vec<CpuId> {
+    if num_threads == 1 {
+        return vec![cpus.as_slice()[cpus.len() / 2]];
+    }
+    (0..num_threads)
+        .map(|worker| {
+            let index = ((worker as u128) * ((cpus.len() - 1) as u128)
+                / ((num_threads - 1) as u128)) as usize;
+            cpus.as_slice()[index]
+        })
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use thiserror::Error as ThisError;
 
 use crate::affinity::{SystemThreadAffinity, ThreadAffinity};
-use crate::arbiter::{set_execution_owner, with_execution_owner, ResourceOwner};
+use crate::arbiter::{set_pool_execution_owner, with_execution_owner, ResourceOwner};
 use crate::{CpuId, CpuSet, Error, Result};
 
 #[derive(Debug, Default)]
@@ -395,7 +395,7 @@ impl CpuContext {
 
     fn broadcast_execution_owner(&self, owner: Option<ResourceOwner>) {
         if let Some(pool) = &self.pool {
-            pool.broadcast(|_| set_execution_owner(owner));
+            pool.broadcast(|_| set_pool_execution_owner(owner));
         }
     }
 

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -1,10 +1,17 @@
 use std::env;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use thiserror::Error as ThisError;
 
 use crate::affinity::{SystemThreadAffinity, ThreadAffinity};
+use crate::arbiter::{set_execution_owner, with_execution_owner, ResourceOwner};
 use crate::{CpuId, CpuSet, Error, Result};
+
+#[derive(Debug, Default)]
+struct ExecutionOwnerState {
+    owner: Option<ResourceOwner>,
+    depth: usize,
+}
 
 /// Failure to construct a CPU context with pinned Rayon workers.
 ///
@@ -70,6 +77,7 @@ pub struct CpuContext {
     num_threads: usize,
     pool: Option<Arc<rayon::ThreadPool>>,
     pinned_cpus: Option<CpuSet>,
+    execution_owner: Arc<Mutex<ExecutionOwnerState>>,
 }
 
 impl CpuContext {
@@ -167,6 +175,7 @@ impl CpuContext {
             num_threads,
             pool,
             pinned_cpus: None,
+            execution_owner: Arc::new(Mutex::new(ExecutionOwnerState::default())),
         })
     }
 
@@ -258,6 +267,7 @@ impl CpuContext {
             num_threads,
             pool: Some(pool),
             pinned_cpus: Some(cpus),
+            execution_owner: Arc::new(Mutex::new(ExecutionOwnerState::default())),
         })
     }
 
@@ -266,6 +276,7 @@ impl CpuContext {
             num_threads: 1,
             pool: None,
             pinned_cpus: None,
+            execution_owner: Arc::new(Mutex::new(ExecutionOwnerState::default())),
         }
     }
 
@@ -315,6 +326,76 @@ impl CpuContext {
         match &self.pool {
             Some(pool) => pool.install(op),
             None => op(),
+        }
+    }
+
+    pub(crate) fn install_with_execution_owner<R: Send>(
+        &self,
+        owner: ResourceOwner,
+        op: impl FnOnce() -> R + Send,
+    ) -> R {
+        let should_broadcast = {
+            let mut state = self
+                .execution_owner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            match state.owner {
+                None => {
+                    state.owner = Some(owner);
+                    state.depth = 1;
+                    true
+                }
+                Some(active) if active == owner => {
+                    state.depth += 1;
+                    false
+                }
+                Some(active) => panic!(
+                    "CPU execution owner invariant violated: active {active:?}, requested {owner:?}"
+                ),
+            }
+        };
+        if should_broadcast {
+            self.broadcast_execution_owner(Some(owner));
+        }
+
+        struct OwnerGuard<'a> {
+            context: &'a CpuContext,
+            owner: ResourceOwner,
+        }
+
+        impl Drop for OwnerGuard<'_> {
+            fn drop(&mut self) {
+                let should_clear = {
+                    let mut state = self
+                        .context
+                        .execution_owner
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner);
+                    debug_assert_eq!(state.owner, Some(self.owner));
+                    state.depth -= 1;
+                    if state.depth == 0 {
+                        state.owner = None;
+                        true
+                    } else {
+                        false
+                    }
+                };
+                if should_clear {
+                    self.context.broadcast_execution_owner(None);
+                }
+            }
+        }
+
+        let _guard = OwnerGuard {
+            context: self,
+            owner,
+        };
+        self.install(|| with_execution_owner(owner, op))
+    }
+
+    fn broadcast_execution_owner(&self, owner: Option<ResourceOwner>) {
+        if let Some(pool) = &self.pool {
+            pool.broadcast(|_| set_execution_owner(owner));
         }
     }
 

--- a/crates/tenferro-cpu/src/context/tests.rs
+++ b/crates/tenferro-cpu/src/context/tests.rs
@@ -1,4 +1,4 @@
-use super::{CpuContext, CpuContextError};
+use super::{select_worker_cpus, CpuContext, CpuContextError};
 use crate::affinity::{current_cpu, ThreadAffinity};
 use crate::{process_cpu_affinity, CpuId, CpuSet};
 use rayon::prelude::*;
@@ -64,6 +64,17 @@ fn pinned_context_rejects_invalid_worker_counts() {
             cpus: 1
         })
     ));
+}
+
+#[test]
+fn worker_assignment_spreads_a_reduced_budget_across_the_domain() {
+    let cpus = CpuSet::new((0..8).map(CpuId::new)).unwrap();
+
+    assert_eq!(
+        select_worker_cpus(&cpus, 4),
+        vec![CpuId::new(0), CpuId::new(2), CpuId::new(4), CpuId::new(7)]
+    );
+    assert_eq!(select_worker_cpus(&cpus, 1), vec![CpuId::new(4)]);
 }
 
 #[derive(Clone)]

--- a/crates/tenferro-cpu/src/context/tests.rs
+++ b/crates/tenferro-cpu/src/context/tests.rs
@@ -1,6 +1,76 @@
-use super::CpuContext;
+use super::{CpuContext, CpuContextError};
+use crate::affinity::{current_cpu, ThreadAffinity};
+use crate::{process_cpu_affinity, CpuId, CpuSet};
+use rayon::prelude::*;
+use std::collections::BTreeSet;
 
 #[test]
 fn with_threads_rejects_zero() {
     assert!(CpuContext::with_threads(0).is_err());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn pinned_context_reports_only_assigned_cpus() {
+    let allowed = process_cpu_affinity().unwrap();
+    let selected = CpuSet::new(allowed.as_slice().iter().take(2).copied()).unwrap();
+    let ctx = CpuContext::with_pinned_cpus(selected.clone(), selected.len()).unwrap();
+    let observed = ctx.install(|| {
+        (0..4096usize)
+            .into_par_iter()
+            .map(|_| current_cpu().unwrap())
+            .collect::<BTreeSet<_>>()
+    });
+
+    assert!(observed.iter().all(|cpu| selected.contains(*cpu)));
+    assert_eq!(ctx.pinned_cpus(), Some(&selected));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn pinned_single_worker_context_still_enters_a_real_rayon_pool() {
+    let allowed = process_cpu_affinity().unwrap();
+    let selected = CpuSet::new(allowed.as_slice().iter().take(1).copied()).unwrap();
+    let ctx = CpuContext::with_pinned_cpus(selected, 1).unwrap();
+
+    assert!(ctx.install(|| rayon::current_thread_index().is_some()));
+}
+
+#[test]
+fn pin_failure_aborts_context_construction() {
+    let result = CpuContext::with_pinned_cpus_using(
+        CpuSet::new([CpuId::new(0)]).unwrap(),
+        1,
+        FailingAffinitySetter,
+    );
+
+    assert!(matches!(
+        result,
+        Err(CpuContextError::WorkerPinning { worker: 0, .. })
+    ));
+}
+
+#[test]
+fn pinned_context_rejects_invalid_worker_counts() {
+    let cpus = CpuSet::new([CpuId::new(0)]).unwrap();
+    assert!(matches!(
+        CpuContext::with_pinned_cpus_using(cpus.clone(), 0, FailingAffinitySetter),
+        Err(CpuContextError::InvalidThreadCount)
+    ));
+    assert!(matches!(
+        CpuContext::with_pinned_cpus_using(cpus, 2, FailingAffinitySetter),
+        Err(CpuContextError::TooManyWorkers {
+            workers: 2,
+            cpus: 1
+        })
+    ));
+}
+
+#[derive(Clone)]
+struct FailingAffinitySetter;
+
+impl ThreadAffinity for FailingAffinitySetter {
+    fn pin_current(&self, _cpu: CpuId) -> Result<CpuSet, String> {
+        Err("forced test failure".to_owned())
+    }
 }

--- a/crates/tenferro-cpu/src/engine.rs
+++ b/crates/tenferro-cpu/src/engine.rs
@@ -1,0 +1,48 @@
+use std::sync::{Arc, Mutex};
+
+use crate::buffer_pool::BufferPool;
+use crate::gemm::GemmAnalysisCache;
+use crate::{CpuContext, CpuContextError, ResolvedCpuPlacement};
+
+#[derive(Debug)]
+pub(crate) struct EngineResources {
+    pub(crate) buffers: BufferPool,
+    pub(crate) gemm_analysis_cache: GemmAnalysisCache,
+}
+
+#[derive(Debug)]
+pub(crate) struct CpuEngine {
+    placement: ResolvedCpuPlacement,
+    context: Arc<CpuContext>,
+    pub(crate) resources: Mutex<EngineResources>,
+}
+
+impl CpuEngine {
+    pub(crate) fn new(
+        placement: ResolvedCpuPlacement,
+        thread_budget: usize,
+        buffer_limit: usize,
+    ) -> Result<Self, CpuContextError> {
+        let worker_count = thread_budget.min(placement.cpus().len());
+        let context = CpuContext::with_pinned_cpus(placement.cpus().clone(), worker_count)?;
+        Ok(Self {
+            placement,
+            context: Arc::new(context),
+            resources: Mutex::new(EngineResources {
+                buffers: BufferPool::with_max_retained_capacity_bytes(buffer_limit),
+                gemm_analysis_cache: GemmAnalysisCache::default(),
+            }),
+        })
+    }
+
+    pub(crate) fn placement(&self) -> &ResolvedCpuPlacement {
+        &self.placement
+    }
+
+    pub(crate) fn context(&self) -> &CpuContext {
+        self.context.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tenferro-cpu/src/engine.rs
+++ b/crates/tenferro-cpu/src/engine.rs
@@ -7,6 +7,8 @@ use crate::{CpuContext, CpuContextError, ResolvedCpuPlacement};
 #[derive(Debug)]
 pub(crate) struct EngineResources {
     pub(crate) buffers: BufferPool,
+    // Session-cache ownership migrates here in the graph-session stage.
+    #[allow(dead_code)]
     pub(crate) gemm_analysis_cache: GemmAnalysisCache,
 }
 
@@ -35,12 +37,31 @@ impl CpuEngine {
         })
     }
 
+    pub(crate) fn from_context(
+        placement: ResolvedCpuPlacement,
+        context: Arc<CpuContext>,
+        buffer_limit: usize,
+    ) -> Self {
+        Self {
+            placement,
+            context,
+            resources: Mutex::new(EngineResources {
+                buffers: BufferPool::with_max_retained_capacity_bytes(buffer_limit),
+                gemm_analysis_cache: GemmAnalysisCache::default(),
+            }),
+        }
+    }
+
     pub(crate) fn placement(&self) -> &ResolvedCpuPlacement {
         &self.placement
     }
 
     pub(crate) fn context(&self) -> &CpuContext {
         self.context.as_ref()
+    }
+
+    pub(crate) fn context_arc(&self) -> Arc<CpuContext> {
+        Arc::clone(&self.context)
     }
 }
 

--- a/crates/tenferro-cpu/src/engine.rs
+++ b/crates/tenferro-cpu/src/engine.rs
@@ -7,8 +7,6 @@ use crate::{CpuContext, CpuContextError, ResolvedCpuPlacement};
 #[derive(Debug)]
 pub(crate) struct EngineResources {
     pub(crate) buffers: BufferPool,
-    // Session-cache ownership migrates here in the graph-session stage.
-    #[allow(dead_code)]
     pub(crate) gemm_analysis_cache: GemmAnalysisCache,
 }
 

--- a/crates/tenferro-cpu/src/engine.rs
+++ b/crates/tenferro-cpu/src/engine.rs
@@ -10,6 +10,15 @@ pub(crate) struct EngineResources {
     pub(crate) gemm_analysis_cache: GemmAnalysisCache,
 }
 
+impl EngineResources {
+    pub(crate) fn new(buffer_limit: usize) -> Self {
+        Self {
+            buffers: BufferPool::with_max_retained_capacity_bytes(buffer_limit),
+            gemm_analysis_cache: GemmAnalysisCache::default(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct CpuEngine {
     placement: ResolvedCpuPlacement,
@@ -28,10 +37,7 @@ impl CpuEngine {
         Ok(Self {
             placement,
             context: Arc::new(context),
-            resources: Mutex::new(EngineResources {
-                buffers: BufferPool::with_max_retained_capacity_bytes(buffer_limit),
-                gemm_analysis_cache: GemmAnalysisCache::default(),
-            }),
+            resources: Mutex::new(EngineResources::new(buffer_limit)),
         })
     }
 
@@ -43,10 +49,7 @@ impl CpuEngine {
         Self {
             placement,
             context,
-            resources: Mutex::new(EngineResources {
-                buffers: BufferPool::with_max_retained_capacity_bytes(buffer_limit),
-                gemm_analysis_cache: GemmAnalysisCache::default(),
-            }),
+            resources: Mutex::new(EngineResources::new(buffer_limit)),
         }
     }
 

--- a/crates/tenferro-cpu/src/engine/tests.rs
+++ b/crates/tenferro-cpu/src/engine/tests.rs
@@ -1,0 +1,19 @@
+use super::*;
+use crate::{process_cpu_affinity, CpuSet, ResolvedCpuPlacement};
+
+#[cfg(target_os = "linux")]
+#[test]
+fn engine_caps_workers_to_its_cpu_domain_and_owns_resources() {
+    let allowed = process_cpu_affinity().unwrap();
+    let selected = CpuSet::new(allowed.as_slice().iter().take(2).copied()).unwrap();
+    let placement = ResolvedCpuPlacement::AllAllowed {
+        cpus: selected.clone(),
+    };
+    let engine = CpuEngine::new(placement.clone(), usize::MAX, 0).unwrap();
+
+    assert_eq!(engine.context().num_threads(), selected.len());
+    assert_eq!(engine.placement(), &placement);
+    let resources = engine.resources.lock().unwrap();
+    assert_eq!(resources.buffers.max_retained_capacity_bytes(), 0);
+    assert_eq!(resources.gemm_analysis_cache.capacity(), 1024);
+}

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -41,8 +41,8 @@ impl TensorDeviceTransfer for CpuExecSession<'_> {
     fn download_to_host(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
         if tensor.is_backend_buffer() {
             return Err(crate::Error::backend_failure(
-                "CpuExecSession::download_to_host",
-                "CPU session received a backend buffer owned by another backend",
+                "CpuBackend::download_to_host",
+                "CPU backend received a backend buffer; download the tensor to host with its owning backend before CPU execution",
             ));
         }
         Ok(tensor.clone())
@@ -51,8 +51,8 @@ impl TensorDeviceTransfer for CpuExecSession<'_> {
     fn upload_host_tensor(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
         if tensor.is_backend_buffer() {
             return Err(crate::Error::backend_failure(
-                "CpuExecSession::upload_host_tensor",
-                "CPU session upload expects a host tensor",
+                "CpuBackend::upload_host_tensor",
+                "CPU backend upload_host_tensor expects a host tensor; download backend buffers to host before CPU execution",
             ));
         }
         Ok(tensor.clone())

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -8,8 +8,8 @@ use tenferro_tensor::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
 use tenferro_tensor::{
-    DotGeneralAccumulation, SessionCachedDot, TensorAnalytic, TensorBuffer, TensorDot,
-    TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
+    DotGeneralAccumulation, SessionCachedDot, TensorAnalytic, TensorBuffer, TensorDeviceTransfer,
+    TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
 };
 
 use super::backend::reclaim_typed;
@@ -27,10 +27,44 @@ pub(crate) struct CpuExecSession<'a> {
     pub(crate) kind: CpuBackendKind,
 }
 
+impl CpuExecSession<'_> {
+    fn run_native<R: Send>(&mut self, op: impl FnOnce(&mut BufferPool) -> R + Send) -> R {
+        let buffers = &mut *self.buffers;
+        match self.kind {
+            CpuBackendKind::Faer => op(buffers),
+            CpuBackendKind::Blas => self.ctx.install(|| op(buffers)),
+        }
+    }
+}
+
+impl TensorDeviceTransfer for CpuExecSession<'_> {
+    fn download_to_host(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
+        if tensor.is_backend_buffer() {
+            return Err(crate::Error::backend_failure(
+                "CpuExecSession::download_to_host",
+                "CPU session received a backend buffer owned by another backend",
+            ));
+        }
+        Ok(tensor.clone())
+    }
+
+    fn upload_host_tensor(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
+        if tensor.is_backend_buffer() {
+            return Err(crate::Error::backend_failure(
+                "CpuExecSession::upload_host_tensor",
+                "CPU session upload expects a host tensor",
+            ));
+        }
+        Ok(tensor.clone())
+    }
+}
+
 /// Simple delegation: no dtype dispatch, no install.
 macro_rules! delegate {
     ($name:ident($($arg:ident : $ty:ty),*) => $body:expr) => {
-        fn $name(&mut self, $($arg: $ty),*) -> crate::Result<Tensor> { $body }
+        fn $name(&mut self, $($arg: $ty),*) -> crate::Result<Tensor> {
+            self.run_native(|_| $body)
+        }
     };
 }
 
@@ -38,7 +72,7 @@ macro_rules! delegate {
 macro_rules! delegate_with_pool {
     ($name:ident($($arg:ident : $ty:ty),*) => $callee:path) => {
         fn $name(&mut self, $($arg: $ty),*) -> crate::Result<Tensor> {
-            $callee(self.buffers, $($arg),*)
+            self.run_native(|buffers| $callee(buffers, $($arg),*))
         }
     };
 }
@@ -48,7 +82,7 @@ impl TensorElementwise for CpuExecSession<'_> {
     delegate_with_pool!(add(lhs: &Tensor, rhs: &Tensor) => elementwise::add_with_pool);
 
     fn add_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
-        elementwise::add_read_with_pool(self.buffers, lhs, rhs)
+        self.run_native(|buffers| elementwise::add_read_with_pool(buffers, lhs, rhs))
     }
 
     delegate_with_pool!(sub(lhs: &Tensor, rhs: &Tensor) => elementwise::sub_with_pool);
@@ -107,22 +141,24 @@ impl TensorStructural for CpuExecSession<'_> {
     // Structural
     delegate_with_pool!(transpose(input: &Tensor, perm: &[usize]) => structural::transpose_with_pool);
     fn transpose_read(&mut self, input: TensorRead<'_>, perm: &[usize]) -> crate::Result<Tensor> {
-        if let Some(input) = input.as_tensor() {
-            return structural::transpose_with_pool(self.buffers, input, perm);
-        }
-
-        let input = materialize_tensor_read("transpose", input)?;
-        structural::transpose_with_pool(self.buffers, &input, perm)
+        self.run_native(|buffers| {
+            if let Some(input) = input.as_tensor() {
+                return structural::transpose_with_pool(buffers, input, perm);
+            }
+            let input = materialize_tensor_read("transpose", input)?;
+            structural::transpose_with_pool(buffers, &input, perm)
+        })
     }
 
     delegate!(reshape(input: &Tensor, shape: &[usize]) => structural::reshape(input, shape));
     fn reshape_read(&mut self, input: TensorRead<'_>, shape: &[usize]) -> crate::Result<Tensor> {
-        if let Some(input) = input.as_tensor() {
-            return structural::reshape(input, shape);
-        }
-
-        let input = materialize_tensor_read("reshape", input)?;
-        structural::reshape(&input, shape)
+        self.run_native(|_| {
+            if let Some(input) = input.as_tensor() {
+                return structural::reshape(input, shape);
+            }
+            let input = materialize_tensor_read("reshape", input)?;
+            structural::reshape(&input, shape)
+        })
     }
 
     delegate_with_pool!(broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) => structural::broadcast_in_dim_with_pool);
@@ -132,12 +168,13 @@ impl TensorStructural for CpuExecSession<'_> {
         shape: &[usize],
         dims: &[usize],
     ) -> crate::Result<Tensor> {
-        if let Some(input) = input.as_tensor() {
-            return structural::broadcast_in_dim_with_pool(self.buffers, input, shape, dims);
-        }
-
-        let input = materialize_tensor_read("broadcast_in_dim", input)?;
-        structural::broadcast_in_dim_with_pool(self.buffers, &input, shape, dims)
+        self.run_native(|buffers| {
+            if let Some(input) = input.as_tensor() {
+                return structural::broadcast_in_dim_with_pool(buffers, input, shape, dims);
+            }
+            let input = materialize_tensor_read("broadcast_in_dim", input)?;
+            structural::broadcast_in_dim_with_pool(buffers, &input, shape, dims)
+        })
     }
 
     delegate_with_pool!(cast(input: &Tensor, to: crate::DType) => structural::cast_with_pool);
@@ -152,25 +189,25 @@ impl TensorReduction for CpuExecSession<'_> {
     delegate!(reduce_sum(input: &Tensor, axes: &[usize]) => reduction::reduce_sum(input, axes));
 
     fn reduce_sum_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        reduction::reduce_sum_read(input, axes)
+        self.run_native(|_| reduction::reduce_sum_read(input, axes))
     }
 
     delegate!(reduce_prod(input: &Tensor, axes: &[usize]) => reduction::reduce_prod(input, axes));
 
     fn reduce_prod_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        reduction::reduce_prod_read(input, axes)
+        self.run_native(|_| reduction::reduce_prod_read(input, axes))
     }
 
     delegate!(reduce_max(input: &Tensor, axes: &[usize]) => reduction::reduce_max(input, axes));
 
     fn reduce_max_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        reduction::reduce_max_read(input, axes)
+        self.run_native(|_| reduction::reduce_max_read(input, axes))
     }
 
     delegate!(reduce_min(input: &Tensor, axes: &[usize]) => reduction::reduce_min(input, axes));
 
     fn reduce_min_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        reduction::reduce_min_read(input, axes)
+        self.run_native(|_| reduction::reduce_min_read(input, axes))
     }
 }
 
@@ -692,7 +729,9 @@ impl TensorIndexing for CpuExecSession<'_> {
         start_indices: &Tensor,
         config: &GatherConfig,
     ) -> crate::Result<Tensor> {
-        indexing::gather_with_pool(self.buffers, operand, start_indices, config)
+        self.run_native(|buffers| {
+            indexing::gather_with_pool(buffers, operand, start_indices, config)
+        })
     }
     delegate_with_pool!(scatter(operand: &Tensor, indices: &Tensor, updates: &Tensor, config: &ScatterConfig) => indexing::scatter_with_pool);
     delegate_with_pool!(slice(input: &Tensor, config: &SliceConfig) => indexing::try_slice_with_pool);
@@ -700,10 +739,10 @@ impl TensorIndexing for CpuExecSession<'_> {
     delegate_with_pool!(dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) => indexing::dynamic_update_slice_with_pool);
     delegate_with_pool!(pad(input: &Tensor, config: &PadConfig) => indexing::try_pad_with_pool);
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
-        indexing::try_concatenate_with_pool(self.buffers, inputs, axis)
+        self.run_native(|buffers| indexing::try_concatenate_with_pool(buffers, inputs, axis))
     }
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-        indexing::reverse_with_pool(self.buffers, input, axes)
+        self.run_native(|buffers| indexing::reverse_with_pool(buffers, input, axes))
     }
 }
 
@@ -727,7 +766,7 @@ impl TensorFusion for CpuExecSession<'_> {
         inputs: &[&Tensor],
         plan: &ElementwiseFusionPlan,
     ) -> crate::Result<Option<Vec<Tensor>>> {
-        elementwise::elementwise_fusion_with_pool(self.buffers, inputs, plan)
+        self.run_native(|buffers| elementwise::elementwise_fusion_with_pool(buffers, inputs, plan))
     }
 
     fn execute_broadcast_multiply(
@@ -739,15 +778,11 @@ impl TensorFusion for CpuExecSession<'_> {
         rhs_shape: &[usize],
         rhs_dims: &[usize],
     ) -> crate::Result<Option<Tensor>> {
-        elementwise::broadcast_multiply_read_with_pool(
-            self.buffers,
-            lhs,
-            lhs_shape,
-            lhs_dims,
-            rhs,
-            rhs_shape,
-            rhs_dims,
-        )
+        self.run_native(|buffers| {
+            elementwise::broadcast_multiply_read_with_pool(
+                buffers, lhs, lhs_shape, lhs_dims, rhs, rhs_shape, rhs_dims,
+            )
+        })
     }
 
     fn execute_broadcast_multiply_value(
@@ -759,14 +794,38 @@ impl TensorFusion for CpuExecSession<'_> {
         rhs_shape: &[usize],
         rhs_dims: &[usize],
     ) -> crate::Result<Option<TensorValue>> {
-        elementwise::broadcast_multiply_value_with_pool(
-            self.buffers,
-            lhs,
-            lhs_shape,
-            lhs_dims,
-            rhs,
-            rhs_shape,
-            rhs_dims,
-        )
+        self.run_native(|buffers| {
+            elementwise::broadcast_multiply_value_with_pool(
+                buffers, lhs, lhs_shape, lhs_dims, rhs, rhs_shape, rhs_dims,
+            )
+        })
+    }
+}
+
+#[cfg(all(test, feature = "cpu-blas"))]
+mod tests {
+    use super::*;
+    use crate::{process_cpu_affinity, CpuSet};
+
+    #[test]
+    fn blas_session_native_scope_enters_the_pinned_rayon_engine() {
+        let allowed = process_cpu_affinity().expect("Linux test requires process affinity");
+        let cpus = CpuSet::new([allowed.as_slice()[0]]).unwrap();
+        let context = CpuContext::with_pinned_cpus(cpus, 1).unwrap();
+        let mut buffers = BufferPool::new();
+        let mut gemm_analysis_cache = gemm::GemmAnalysisCache::default();
+        let mut session = CpuExecSession {
+            ctx: &context,
+            buffers: &mut buffers,
+            gemm_analysis_cache: &mut gemm_analysis_cache,
+            kind: CpuBackendKind::Blas,
+        };
+
+        assert!(rayon::current_thread_index().is_none());
+        assert_eq!(
+            session.run_native(|_| rayon::current_thread_index()),
+            Some(0)
+        );
+        assert!(rayon::current_thread_index().is_none());
     }
 }

--- a/crates/tenferro-cpu/src/gemm/tests.rs
+++ b/crates/tenferro-cpu/src/gemm/tests.rs
@@ -6,7 +6,9 @@ use super::{
 #[cfg(any(feature = "blas-openblas", feature = "blas-mkl"))]
 use super::blas_gemm::provider_should_use_gemm_batch;
 #[cfg(feature = "cpu-blas")]
-use super::blas_gemm::{BlasGemm, BlasGemmBatch};
+use super::blas_gemm::BlasGemm;
+#[cfg(any(feature = "blas-openblas", feature = "blas-mkl"))]
+use super::blas_gemm::BlasGemmBatch;
 #[cfg(feature = "cpu-blas")]
 use super::dot_general_blas_cached;
 #[cfg(feature = "cpu-faer")]

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -43,6 +43,7 @@ compile_error!("provider-inject cannot be combined with explicit BLAS provider f
 
 pub mod affinity;
 mod analytic;
+mod arbiter;
 pub mod backend;
 mod buffer_pool;
 mod capability;

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -79,7 +79,9 @@ extern crate lapack_src as _;
 
 pub use affinity::{available_parallelism, process_cpu_affinity, process_cpu_affinity_count};
 pub use analytic::pow;
-pub use backend::{CpuBackend, CpuBackendKind, CpuExecutionInfo, CpuExecutionMode};
+pub use backend::{
+    CpuBackend, CpuBackendError, CpuBackendKind, CpuExecutionInfo, CpuExecutionMode,
+};
 pub use buffer_pool::BufferPoolStats;
 pub use capability::cpu_capabilities;
 pub use context::{CpuContext, CpuContextError};

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -79,7 +79,7 @@ extern crate lapack_src as _;
 
 pub use affinity::{available_parallelism, process_cpu_affinity, process_cpu_affinity_count};
 pub use analytic::pow;
-pub use backend::{CpuBackend, CpuBackendKind};
+pub use backend::{CpuBackend, CpuBackendKind, CpuExecutionInfo};
 pub use buffer_pool::BufferPoolStats;
 pub use capability::cpu_capabilities;
 pub use context::{CpuContext, CpuContextError};

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -48,6 +48,7 @@ mod buffer_pool;
 mod capability;
 pub mod context;
 mod elementwise;
+mod engine;
 mod exec_session;
 mod gemm;
 mod indexing;
@@ -80,7 +81,7 @@ pub use analytic::pow;
 pub use backend::{CpuBackend, CpuBackendKind};
 pub use buffer_pool::BufferPoolStats;
 pub use capability::cpu_capabilities;
-pub use context::CpuContext;
+pub use context::{CpuContext, CpuContextError};
 pub use elementwise::{
     abs, add, clamp, compare, conj, div, maximum, minimum, mul, neg, rem, select, sign, sub,
 };

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -79,7 +79,7 @@ extern crate lapack_src as _;
 
 pub use affinity::{available_parallelism, process_cpu_affinity, process_cpu_affinity_count};
 pub use analytic::pow;
-pub use backend::{CpuBackend, CpuBackendKind, CpuExecutionInfo};
+pub use backend::{CpuBackend, CpuBackendKind, CpuExecutionInfo, CpuExecutionMode};
 pub use buffer_pool::BufferPoolStats;
 pub use capability::cpu_capabilities;
 pub use context::{CpuContext, CpuContextError};

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -75,7 +75,7 @@ extern crate lapack_inject as _;
 #[cfg(feature = "provider-src")]
 extern crate lapack_src as _;
 
-pub use affinity::{available_parallelism, process_cpu_affinity_count};
+pub use affinity::{available_parallelism, process_cpu_affinity, process_cpu_affinity_count};
 pub use analytic::pow;
 pub use backend::{CpuBackend, CpuBackendKind};
 pub use buffer_pool::BufferPoolStats;
@@ -91,7 +91,8 @@ pub use structural::{
     broadcast_in_dim, convert, embed_diagonal, extract_diagonal, reshape, transpose, tril, triu,
 };
 pub use topology::{
-    CpuId, CpuNode, CpuSet, CpuSetError, CpuTopology, CpuTopologyError, NumaNodeId,
+    discover_cpu_topology, CpuId, CpuNode, CpuSet, CpuSetError, CpuTopology, CpuTopologyError,
+    NumaNodeId,
 };
 
 /// Owner-scoped CPU scratch-pool API for operation-family crates.

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -54,8 +54,10 @@ mod indexing;
 mod indexing_alloc;
 #[cfg(feature = "provider-inject")]
 pub mod inject;
+mod placement;
 mod reduction;
 mod structural;
+mod topology;
 
 use strided_kernel::{col_major_strides as kernel_col_major_strides, StridedArray, StridedView};
 
@@ -83,9 +85,13 @@ pub use elementwise::{
     abs, add, clamp, compare, conj, div, maximum, minimum, mul, neg, rem, select, sign, sub,
 };
 pub use indexing::{dynamic_slice, dynamic_update_slice, gather, pad, scatter};
+pub use placement::{CpuPlacement, CpuPlacementError, ResolvedCpuPlacement};
 pub use reduction::{reduce_max, reduce_min, reduce_prod, reduce_sum};
 pub use structural::{
     broadcast_in_dim, convert, embed_diagonal, extract_diagonal, reshape, transpose, tril, triu,
+};
+pub use topology::{
+    CpuId, CpuNode, CpuSet, CpuSetError, CpuTopology, CpuTopologyError, NumaNodeId,
 };
 
 /// Owner-scoped CPU scratch-pool API for operation-family crates.

--- a/crates/tenferro-cpu/src/placement.rs
+++ b/crates/tenferro-cpu/src/placement.rs
@@ -193,7 +193,7 @@ pub(crate) fn resolve_placement(
     )
 }
 
-fn resolve_placement_with_affinity(
+pub(crate) fn resolve_placement_with_affinity(
     backend: CpuBackendKind,
     requested: CpuPlacement,
     topology: &CpuTopology,

--- a/crates/tenferro-cpu/src/placement.rs
+++ b/crates/tenferro-cpu/src/placement.rs
@@ -140,10 +140,21 @@ pub enum CpuPlacementError {
         /// The selected public backend kind.
         backend: CpuBackendKind,
     },
+    /// A pinned engine could not be built for an otherwise valid placement.
+    #[error("cannot resolve {requested:?} for {backend:?}: engine construction failed: {message}")]
+    EngineConstruction {
+        /// The placement requested by the caller.
+        requested: CpuPlacement,
+        /// The selected public backend kind.
+        backend: CpuBackendKind,
+        /// Worker-pool construction or affinity verification detail.
+        message: String,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ResolvedCpuExecution {
+    Compatibility,
     Managed(ResolvedCpuPlacement),
     ProviderDefaultExclusive,
 }

--- a/crates/tenferro-cpu/src/placement.rs
+++ b/crates/tenferro-cpu/src/placement.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::{CpuBackendKind, CpuSet, CpuTopology, NumaNodeId};
+use crate::{CpuBackendKind, CpuSet, CpuTopology, CpuTopologyError, NumaNodeId};
 
 /// Requested CPU execution placement.
 ///
@@ -112,6 +112,27 @@ impl ResolvedCpuPlacement {
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum CpuPlacementError {
+    /// Process-visible topology discovery failed before placement resolution.
+    #[error("cannot resolve {requested:?} for {backend:?}: topology discovery failed: {source}")]
+    TopologyDiscovery {
+        /// The placement requested by the caller.
+        requested: CpuPlacement,
+        /// The selected public backend kind.
+        backend: CpuBackendKind,
+        /// The preserved topology failure category.
+        #[source]
+        source: CpuTopologyError,
+    },
+    /// The current platform cannot construct verified pinned worker pools.
+    #[error(
+        "cannot resolve {requested:?} for {backend:?}: managed worker affinity is unavailable"
+    )]
+    ManagedAffinityUnavailable {
+        /// The explicit placement requested by the caller.
+        requested: CpuPlacement,
+        /// The selected public backend kind.
+        backend: CpuBackendKind,
+    },
     /// NUMA-node placement was requested but OS NUMA discovery was unavailable.
     #[error("cannot resolve {requested:?} for {backend:?}: NUMA discovery is unavailable")]
     NumaDiscoveryUnavailable {
@@ -164,11 +185,34 @@ pub(crate) fn resolve_placement(
     requested: CpuPlacement,
     topology: &CpuTopology,
 ) -> Result<ResolvedCpuExecution, CpuPlacementError> {
+    resolve_placement_with_affinity(
+        backend,
+        requested,
+        topology,
+        cfg!(any(target_os = "linux", target_os = "android")),
+    )
+}
+
+fn resolve_placement_with_affinity(
+    backend: CpuBackendKind,
+    requested: CpuPlacement,
+    topology: &CpuTopology,
+    managed_affinity_available: bool,
+) -> Result<ResolvedCpuExecution, CpuPlacementError> {
     if backend == CpuBackendKind::Blas {
         return match requested {
             CpuPlacement::Auto => Ok(ResolvedCpuExecution::ProviderDefaultExclusive),
             CpuPlacement::NumaNode(_) | CpuPlacement::AllAllowed => {
                 Err(CpuPlacementError::ExternalProviderAffinityUnmanaged { requested, backend })
+            }
+        };
+    }
+
+    if !managed_affinity_available {
+        return match requested {
+            CpuPlacement::Auto => Ok(ResolvedCpuExecution::Compatibility),
+            CpuPlacement::NumaNode(_) | CpuPlacement::AllAllowed => {
+                Err(CpuPlacementError::ManagedAffinityUnavailable { requested, backend })
             }
         };
     }

--- a/crates/tenferro-cpu/src/placement.rs
+++ b/crates/tenferro-cpu/src/placement.rs
@@ -1,0 +1,190 @@
+use thiserror::Error;
+
+use crate::{CpuBackendKind, CpuSet, CpuTopology, NumaNodeId};
+
+/// Requested CPU execution placement.
+///
+/// `AllAllowed` means all logical CPUs permitted by the process affinity mask,
+/// not every CPU installed in the host.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{CpuPlacement, NumaNodeId};
+///
+/// let placement = CpuPlacement::NumaNode(NumaNodeId::new(2));
+/// assert!(matches!(placement, CpuPlacement::NumaNode(_)));
+/// ```
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum CpuPlacement {
+    /// Let the selected provider choose its compatible default policy.
+    #[default]
+    Auto,
+    /// Restrict managed tenferro/faer execution to one usable OS NUMA node.
+    NumaNode(NumaNodeId),
+    /// Use the complete CPU set permitted to the process.
+    AllAllowed,
+}
+
+/// Concrete managed placement after topology resolution.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{CpuId, CpuSet, ResolvedCpuPlacement};
+///
+/// let placement = ResolvedCpuPlacement::AllAllowed {
+///     cpus: CpuSet::new([CpuId::new(0)])?,
+/// };
+/// assert_eq!(placement.cpus().len(), 1);
+/// # Ok::<(), tenferro_cpu::CpuSetError>(())
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResolvedCpuPlacement {
+    /// A selected usable OS NUMA node.
+    NumaNode {
+        /// The sparse OS NUMA node ID.
+        id: NumaNodeId,
+        /// The node CPUs permitted by the process affinity mask.
+        cpus: CpuSet,
+    },
+    /// The complete process affinity CPU set.
+    AllAllowed {
+        /// Logical CPUs permitted by the process affinity mask.
+        cpus: CpuSet,
+    },
+}
+
+impl ResolvedCpuPlacement {
+    /// Return the concrete logical CPU set used for pinning and arbitration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet, ResolvedCpuPlacement};
+    ///
+    /// let placement = ResolvedCpuPlacement::AllAllowed {
+    ///     cpus: CpuSet::new([CpuId::new(1), CpuId::new(2)])?,
+    /// };
+    /// assert_eq!(placement.cpus().as_usize_vec(), vec![1, 2]);
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn cpus(&self) -> &CpuSet {
+        match self {
+            Self::NumaNode { cpus, .. } | Self::AllAllowed { cpus } => cpus,
+        }
+    }
+
+    /// Return the OS NUMA node ID for a node placement.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet, NumaNodeId, ResolvedCpuPlacement};
+    ///
+    /// let placement = ResolvedCpuPlacement::NumaNode {
+    ///     id: NumaNodeId::new(7),
+    ///     cpus: CpuSet::new([CpuId::new(3)])?,
+    /// };
+    /// assert_eq!(placement.node_id(), Some(NumaNodeId::new(7)));
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn node_id(&self) -> Option<NumaNodeId> {
+        match self {
+            Self::NumaNode { id, .. } => Some(*id),
+            Self::AllAllowed { .. } => None,
+        }
+    }
+}
+
+/// Failure to resolve a CPU placement for the selected public provider kind.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{CpuBackendKind, CpuPlacement, CpuPlacementError};
+///
+/// let error = CpuPlacementError::ExternalProviderAffinityUnmanaged {
+///     requested: CpuPlacement::AllAllowed,
+///     backend: CpuBackendKind::Blas,
+/// };
+/// assert!(error.to_string().contains("affinity"));
+/// ```
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum CpuPlacementError {
+    /// NUMA-node placement was requested but OS NUMA discovery was unavailable.
+    #[error("cannot resolve {requested:?} for {backend:?}: NUMA discovery is unavailable")]
+    NumaDiscoveryUnavailable {
+        /// The placement requested by the caller.
+        requested: CpuPlacement,
+        /// The selected public backend kind.
+        backend: CpuBackendKind,
+    },
+    /// The requested OS NUMA node has no usable CPUs in this process.
+    #[error("cannot resolve {requested:?} for {backend:?}: NUMA node {node} is unavailable")]
+    UnknownNumaNode {
+        /// The placement requested by the caller.
+        requested: CpuPlacement,
+        /// The selected public backend kind.
+        backend: CpuBackendKind,
+        /// The unknown or process-unavailable OS node ID.
+        node: NumaNodeId,
+    },
+    /// An external provider owns worker affinity, so explicit placement is unsafe.
+    #[error(
+        "cannot resolve {requested:?} for {backend:?}: external provider worker affinity is unmanaged"
+    )]
+    ExternalProviderAffinityUnmanaged {
+        /// The explicit placement requested by the caller.
+        requested: CpuPlacement,
+        /// The selected public backend kind.
+        backend: CpuBackendKind,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ResolvedCpuExecution {
+    Managed(ResolvedCpuPlacement),
+    ProviderDefaultExclusive,
+}
+
+pub(crate) fn resolve_placement(
+    backend: CpuBackendKind,
+    requested: CpuPlacement,
+    topology: &CpuTopology,
+) -> Result<ResolvedCpuExecution, CpuPlacementError> {
+    if backend == CpuBackendKind::Blas {
+        return match requested {
+            CpuPlacement::Auto => Ok(ResolvedCpuExecution::ProviderDefaultExclusive),
+            CpuPlacement::NumaNode(_) | CpuPlacement::AllAllowed => {
+                Err(CpuPlacementError::ExternalProviderAffinityUnmanaged { requested, backend })
+            }
+        };
+    }
+
+    let placement = match requested {
+        CpuPlacement::Auto | CpuPlacement::AllAllowed => ResolvedCpuPlacement::AllAllowed {
+            cpus: topology.allowed_cpus().clone(),
+        },
+        CpuPlacement::NumaNode(node) => {
+            if !topology.has_numa_nodes() {
+                return Err(CpuPlacementError::NumaDiscoveryUnavailable { requested, backend });
+            }
+            let cpus = topology
+                .node(node)
+                .ok_or(CpuPlacementError::UnknownNumaNode {
+                    requested,
+                    backend,
+                    node,
+                })?;
+            ResolvedCpuPlacement::NumaNode {
+                id: node,
+                cpus: cpus.cpus().clone(),
+            }
+        }
+    };
+    Ok(ResolvedCpuExecution::Managed(placement))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tenferro-cpu/src/placement/tests.rs
+++ b/crates/tenferro-cpu/src/placement/tests.rs
@@ -69,6 +69,31 @@ fn explicit_node_requires_discovered_numa_domains() {
     ));
 }
 
+#[test]
+fn unavailable_managed_affinity_keeps_auto_compatible_and_rejects_explicit_placement() {
+    let topology = two_node_fixture();
+
+    assert_eq!(
+        resolve_placement_with_affinity(
+            CpuBackendKind::Faer,
+            CpuPlacement::Auto,
+            &topology,
+            false,
+        )
+        .unwrap(),
+        ResolvedCpuExecution::Compatibility
+    );
+    assert!(matches!(
+        resolve_placement_with_affinity(
+            CpuBackendKind::Faer,
+            CpuPlacement::AllAllowed,
+            &topology,
+            false,
+        ),
+        Err(CpuPlacementError::ManagedAffinityUnavailable { .. })
+    ));
+}
+
 fn two_node_fixture() -> CpuTopology {
     CpuTopology::from_discovered(
         cpu_set([8, 9, 12, 13]),

--- a/crates/tenferro-cpu/src/placement/tests.rs
+++ b/crates/tenferro-cpu/src/placement/tests.rs
@@ -1,0 +1,85 @@
+use super::*;
+use crate::{CpuBackendKind, CpuId, CpuSet, CpuTopology, NumaNodeId};
+
+#[test]
+fn faer_resolves_auto_and_explicit_managed_placements() {
+    let topology = two_node_fixture();
+
+    assert!(matches!(
+        resolve_placement(CpuBackendKind::Faer, CpuPlacement::Auto, &topology).unwrap(),
+        ResolvedCpuExecution::Managed(ResolvedCpuPlacement::AllAllowed { .. })
+    ));
+    assert!(matches!(
+        resolve_placement(
+            CpuBackendKind::Faer,
+            CpuPlacement::NumaNode(NumaNodeId::new(7)),
+            &topology,
+        )
+        .unwrap(),
+        ResolvedCpuExecution::Managed(ResolvedCpuPlacement::NumaNode { id, .. })
+            if id == NumaNodeId::new(7)
+    ));
+}
+
+#[test]
+fn explicit_external_provider_placement_never_falls_back() {
+    let topology = two_node_fixture();
+    assert!(matches!(
+        resolve_placement(
+            CpuBackendKind::Blas,
+            CpuPlacement::NumaNode(NumaNodeId::new(2)),
+            &topology,
+        ),
+        Err(CpuPlacementError::ExternalProviderAffinityUnmanaged { .. })
+    ));
+    assert!(matches!(
+        resolve_placement(CpuBackendKind::Blas, CpuPlacement::AllAllowed, &topology),
+        Err(CpuPlacementError::ExternalProviderAffinityUnmanaged { .. })
+    ));
+    assert_eq!(
+        resolve_placement(CpuBackendKind::Blas, CpuPlacement::Auto, &topology).unwrap(),
+        ResolvedCpuExecution::ProviderDefaultExclusive,
+    );
+}
+
+#[test]
+fn explicit_unknown_node_is_an_error_without_fallback() {
+    let topology = two_node_fixture();
+    assert!(matches!(
+        resolve_placement(
+            CpuBackendKind::Faer,
+            CpuPlacement::NumaNode(NumaNodeId::new(9)),
+            &topology,
+        ),
+        Err(CpuPlacementError::UnknownNumaNode { node, .. })
+            if node == NumaNodeId::new(9)
+    ));
+}
+
+#[test]
+fn explicit_node_requires_discovered_numa_domains() {
+    let topology = CpuTopology::from_discovered(cpu_set([4, 5]), []).unwrap();
+    assert!(matches!(
+        resolve_placement(
+            CpuBackendKind::Faer,
+            CpuPlacement::NumaNode(NumaNodeId::new(0)),
+            &topology,
+        ),
+        Err(CpuPlacementError::NumaDiscoveryUnavailable { .. })
+    ));
+}
+
+fn two_node_fixture() -> CpuTopology {
+    CpuTopology::from_discovered(
+        cpu_set([8, 9, 12, 13]),
+        [
+            (NumaNodeId::new(2), cpu_set([8, 9])),
+            (NumaNodeId::new(7), cpu_set([12, 13])),
+        ],
+    )
+    .unwrap()
+}
+
+fn cpu_set<const N: usize>(cpus: [usize; N]) -> CpuSet {
+    CpuSet::new(cpus.map(CpuId::new)).unwrap()
+}

--- a/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
@@ -134,7 +134,7 @@ fn cpu_backend_shared_context() {
     let ctx = Arc::new(CpuContext::with_threads(3).unwrap());
     let b1 = CpuBackend::from_context(ctx.clone());
     let b2 = CpuBackend::from_context(ctx);
-    assert!(Arc::ptr_eq(&b1.ctx, &b2.ctx));
+    assert_eq!(b1.context_id_for_test(), b2.context_id_for_test());
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
@@ -123,10 +123,15 @@ fn cpu_install_accepts_send_state() {
 }
 
 #[test]
-fn cpu_backend_exec_session_enters_owned_pool() {
+fn cpu_backend_exec_session_uses_default_provider_scope() {
     let mut backend = CpuBackend::with_threads(2).unwrap();
-    let seen_threads = backend.with_backend_session(|_| rayon::current_num_threads());
-    assert_eq!(seen_threads, 2);
+    backend.with_backend_session(|_| {
+        #[cfg(feature = "cpu-blas")]
+        assert!(rayon::current_thread_index().is_none());
+
+        #[cfg(all(not(feature = "cpu-blas"), feature = "cpu-faer"))]
+        assert_eq!(rayon::current_num_threads(), 2);
+    });
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/topology.rs
+++ b/crates/tenferro-cpu/src/topology.rs
@@ -225,6 +225,18 @@ impl CpuSet {
         self.cpus.binary_search(&cpu).is_ok()
     }
 
+    pub(crate) fn overlaps(&self, other: &Self) -> bool {
+        let (mut left, mut right) = (0, 0);
+        while left < self.len() && right < other.len() {
+            match self.cpus[left].cmp(&other.cpus[right]) {
+                std::cmp::Ordering::Less => left += 1,
+                std::cmp::Ordering::Greater => right += 1,
+                std::cmp::Ordering::Equal => return true,
+            }
+        }
+        false
+    }
+
     fn intersection(&self, other: &Self) -> Option<Self> {
         let mut intersection = Vec::with_capacity(self.len().min(other.len()));
         let (mut left, mut right) = (0, 0);

--- a/crates/tenferro-cpu/src/topology.rs
+++ b/crates/tenferro-cpu/src/topology.rs
@@ -449,13 +449,13 @@ pub(crate) fn parse_linux_cpu_list(input: &str) -> Result<CpuSet, CpuTopologyErr
 pub fn discover_cpu_topology() -> Result<CpuTopology, CpuTopologyError> {
     #[cfg(target_os = "linux")]
     {
-        return discover_from(&LinuxTopologySource);
+        discover_from(&LinuxTopologySource)
     }
     #[cfg(not(target_os = "linux"))]
     {
         let allowed = crate::process_cpu_affinity().unwrap_or_else(|| {
             CpuSet::new((0..crate::available_parallelism()).map(CpuId::new))
-                .expect("available_parallelism always returns at least one CPU")
+                .unwrap_or_else(|_| CpuSet::singleton(CpuId::new(0)))
         });
         Ok(CpuTopology::all_allowed(allowed))
     }

--- a/crates/tenferro-cpu/src/topology.rs
+++ b/crates/tenferro-cpu/src/topology.rs
@@ -1,0 +1,499 @@
+use std::fmt;
+
+use thiserror::Error;
+
+/// An operating-system logical CPU identifier.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::CpuId;
+///
+/// assert_eq!(CpuId::new(3).as_usize(), 3);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CpuId(usize);
+
+impl CpuId {
+    /// Create an identifier from the operating-system logical CPU number.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuId;
+    ///
+    /// assert_eq!(CpuId::new(5).as_usize(), 5);
+    /// ```
+    pub const fn new(id: usize) -> Self {
+        Self(id)
+    }
+
+    /// Return the operating-system logical CPU number.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuId;
+    ///
+    /// assert_eq!(CpuId::new(7).as_usize(), 7);
+    /// ```
+    pub const fn as_usize(self) -> usize {
+        self.0
+    }
+}
+
+impl fmt::Display for CpuId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// An operating-system NUMA node identifier.
+///
+/// Node IDs are preserved as reported by the OS and may be sparse.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::NumaNodeId;
+///
+/// assert_eq!(NumaNodeId::new(4).as_usize(), 4);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NumaNodeId(usize);
+
+impl NumaNodeId {
+    /// Create an identifier from the operating-system NUMA node number.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::NumaNodeId;
+    ///
+    /// assert_eq!(NumaNodeId::new(2).as_usize(), 2);
+    /// ```
+    pub const fn new(id: usize) -> Self {
+        Self(id)
+    }
+
+    /// Return the operating-system NUMA node number.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::NumaNodeId;
+    ///
+    /// assert_eq!(NumaNodeId::new(9).as_usize(), 9);
+    /// ```
+    pub const fn as_usize(self) -> usize {
+        self.0
+    }
+}
+
+impl fmt::Display for NumaNodeId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Failure to construct a non-empty CPU set.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{CpuId, CpuSet, CpuSetError};
+///
+/// assert_eq!(CpuSet::new(Vec::<CpuId>::new()), Err(CpuSetError::Empty));
+/// ```
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum CpuSetError {
+    /// A CPU execution domain cannot be empty.
+    #[error("CPU set is empty")]
+    Empty,
+}
+
+/// A sorted, deduplicated, non-empty set of logical CPUs.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{CpuId, CpuSet};
+///
+/// let cpus = CpuSet::new([CpuId::new(3), CpuId::new(1), CpuId::new(3)])?;
+/// assert_eq!(cpus.as_usize_vec(), vec![1, 3]);
+/// # Ok::<(), tenferro_cpu::CpuSetError>(())
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CpuSet {
+    cpus: Vec<CpuId>,
+}
+
+impl CpuSet {
+    /// Construct a sorted and deduplicated CPU set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet};
+    ///
+    /// let cpus = CpuSet::new([CpuId::new(2), CpuId::new(0)])?;
+    /// assert_eq!(cpus.as_usize_vec(), vec![0, 2]);
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn new(cpus: impl IntoIterator<Item = CpuId>) -> Result<Self, CpuSetError> {
+        let mut cpus: Vec<_> = cpus.into_iter().collect();
+        cpus.sort_unstable();
+        cpus.dedup();
+        if cpus.is_empty() {
+            return Err(CpuSetError::Empty);
+        }
+        Ok(Self { cpus })
+    }
+
+    /// Return the number of logical CPUs in this set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet};
+    ///
+    /// assert_eq!(CpuSet::new([CpuId::new(0), CpuId::new(1)])?.len(), 2);
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn len(&self) -> usize {
+        self.cpus.len()
+    }
+
+    /// Report whether this set is empty.
+    ///
+    /// A successfully constructed `CpuSet` is never empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet};
+    ///
+    /// assert!(!CpuSet::new([CpuId::new(0)])?.is_empty());
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.cpus.is_empty()
+    }
+
+    /// Return the sorted logical CPU identifiers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet};
+    ///
+    /// let cpus = CpuSet::new([CpuId::new(4), CpuId::new(2)])?;
+    /// assert_eq!(cpus.as_slice(), &[CpuId::new(2), CpuId::new(4)]);
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn as_slice(&self) -> &[CpuId] {
+        &self.cpus
+    }
+
+    /// Copy the sorted logical CPU numbers into a vector.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet};
+    ///
+    /// let cpus = CpuSet::new([CpuId::new(6), CpuId::new(5)])?;
+    /// assert_eq!(cpus.as_usize_vec(), vec![5, 6]);
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn as_usize_vec(&self) -> Vec<usize> {
+        self.cpus.iter().map(|cpu| cpu.as_usize()).collect()
+    }
+
+    /// Report whether the logical CPU belongs to this set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet};
+    ///
+    /// let cpus = CpuSet::new([CpuId::new(1), CpuId::new(3)])?;
+    /// assert!(cpus.contains(CpuId::new(3)));
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn contains(&self, cpu: CpuId) -> bool {
+        self.cpus.binary_search(&cpu).is_ok()
+    }
+
+    fn intersection(&self, other: &Self) -> Option<Self> {
+        let mut intersection = Vec::with_capacity(self.len().min(other.len()));
+        let (mut left, mut right) = (0, 0);
+        while left < self.len() && right < other.len() {
+            match self.cpus[left].cmp(&other.cpus[right]) {
+                std::cmp::Ordering::Less => left += 1,
+                std::cmp::Ordering::Greater => right += 1,
+                std::cmp::Ordering::Equal => {
+                    intersection.push(self.cpus[left]);
+                    left += 1;
+                    right += 1;
+                }
+            }
+        }
+        (!intersection.is_empty()).then_some(Self { cpus: intersection })
+    }
+}
+
+/// One usable OS NUMA node and its process-allowed logical CPUs.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{CpuId, CpuNode, CpuSet, NumaNodeId};
+///
+/// let node = CpuNode::new(NumaNodeId::new(2), CpuSet::new([CpuId::new(8)])?);
+/// assert_eq!(node.id(), NumaNodeId::new(2));
+/// # Ok::<(), tenferro_cpu::CpuSetError>(())
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CpuNode {
+    id: NumaNodeId,
+    cpus: CpuSet,
+}
+
+impl CpuNode {
+    /// Construct a usable NUMA node description.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuNode, CpuSet, NumaNodeId};
+    ///
+    /// let node = CpuNode::new(NumaNodeId::new(7), CpuSet::new([CpuId::new(12)])?);
+    /// assert_eq!(node.id(), NumaNodeId::new(7));
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn new(id: NumaNodeId, cpus: CpuSet) -> Self {
+        Self { id, cpus }
+    }
+
+    /// Return the sparse operating-system NUMA node ID.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuNode, CpuSet, NumaNodeId};
+    ///
+    /// let node = CpuNode::new(NumaNodeId::new(3), CpuSet::new([CpuId::new(0)])?);
+    /// assert_eq!(node.id().as_usize(), 3);
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn id(&self) -> NumaNodeId {
+        self.id
+    }
+
+    /// Return this node's process-allowed logical CPUs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuNode, CpuSet, NumaNodeId};
+    ///
+    /// let node = CpuNode::new(NumaNodeId::new(0), CpuSet::new([CpuId::new(4)])?);
+    /// assert!(node.cpus().contains(CpuId::new(4)));
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn cpus(&self) -> &CpuSet {
+        &self.cpus
+    }
+}
+
+/// Failure to canonicalize discovered NUMA topology.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{CpuTopologyError, NumaNodeId};
+///
+/// let error = CpuTopologyError::DuplicateNode { node: NumaNodeId::new(2) };
+/// assert!(error.to_string().contains("2"));
+/// ```
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum CpuTopologyError {
+    /// The process affinity mask contained no logical CPU.
+    #[error("the process-allowed CPU set is empty")]
+    EmptyAllowedCpuSet,
+    /// Discovery reported the same OS NUMA node more than once.
+    #[error("NUMA node {node} was discovered more than once")]
+    DuplicateNode {
+        /// The duplicated OS NUMA node ID.
+        node: NumaNodeId,
+    },
+    /// Two usable NUMA nodes contained at least one common logical CPU.
+    #[error("NUMA nodes {first} and {second} overlap on CPUs {cpus:?}")]
+    OverlappingNodes {
+        /// The first overlapping OS node ID.
+        first: NumaNodeId,
+        /// The second overlapping OS node ID.
+        second: NumaNodeId,
+        /// Logical CPUs present in both usable node sets.
+        cpus: CpuSet,
+    },
+}
+
+/// Process-visible CPU topology used for execution placement.
+///
+/// Each usable NUMA node contains only CPUs also present in the process affinity
+/// mask. Empty nodes are omitted and OS node IDs are not renumbered.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{CpuId, CpuSet, CpuTopology};
+///
+/// let topology = CpuTopology::all_allowed(CpuSet::new([CpuId::new(0)])?);
+/// assert_eq!(topology.allowed_cpus().len(), 1);
+/// assert!(!topology.has_numa_nodes());
+/// # Ok::<(), tenferro_cpu::CpuSetError>(())
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CpuTopology {
+    allowed_cpus: CpuSet,
+    nodes: Vec<CpuNode>,
+}
+
+impl CpuTopology {
+    /// Construct a topology with only the all-allowed execution domain.
+    ///
+    /// This is the portable fallback when NUMA discovery is unavailable.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet, CpuTopology};
+    ///
+    /// let topology = CpuTopology::all_allowed(CpuSet::new([CpuId::new(2)])?);
+    /// assert!(topology.nodes().is_empty());
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn all_allowed(allowed_cpus: CpuSet) -> Self {
+        Self {
+            allowed_cpus,
+            nodes: Vec::new(),
+        }
+    }
+
+    pub(crate) fn from_discovered(
+        allowed_cpus: CpuSet,
+        nodes: impl IntoIterator<Item = (NumaNodeId, CpuSet)>,
+    ) -> Result<Self, CpuTopologyError> {
+        if allowed_cpus.is_empty() {
+            return Err(CpuTopologyError::EmptyAllowedCpuSet);
+        }
+        let mut usable = Vec::new();
+        for (id, discovered_cpus) in nodes {
+            if usable.iter().any(|node: &CpuNode| node.id == id) {
+                return Err(CpuTopologyError::DuplicateNode { node: id });
+            }
+            if let Some(cpus) = discovered_cpus.intersection(&allowed_cpus) {
+                usable.push(CpuNode::new(id, cpus));
+            }
+        }
+        usable.sort_unstable_by_key(CpuNode::id);
+        for (index, left) in usable.iter().enumerate() {
+            for right in usable.iter().skip(index + 1) {
+                if let Some(cpus) = left.cpus.intersection(&right.cpus) {
+                    return Err(CpuTopologyError::OverlappingNodes {
+                        first: left.id,
+                        second: right.id,
+                        cpus,
+                    });
+                }
+            }
+        }
+        Ok(Self {
+            allowed_cpus,
+            nodes: usable,
+        })
+    }
+
+    /// Return the complete process affinity CPU set.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet, CpuTopology};
+    ///
+    /// let topology = CpuTopology::all_allowed(CpuSet::new([CpuId::new(1)])?);
+    /// assert!(topology.allowed_cpus().contains(CpuId::new(1)));
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn allowed_cpus(&self) -> &CpuSet {
+        &self.allowed_cpus
+    }
+
+    /// Return usable NUMA nodes ordered by their sparse OS node IDs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet, CpuTopology};
+    ///
+    /// let topology = CpuTopology::all_allowed(CpuSet::new([CpuId::new(0)])?);
+    /// assert!(topology.nodes().is_empty());
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn nodes(&self) -> &[CpuNode] {
+        &self.nodes
+    }
+
+    /// Copy the usable sparse operating-system NUMA node IDs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet, CpuTopology};
+    ///
+    /// let topology = CpuTopology::all_allowed(CpuSet::new([CpuId::new(0)])?);
+    /// assert!(topology.node_ids().is_empty());
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn node_ids(&self) -> Vec<NumaNodeId> {
+        self.nodes.iter().map(CpuNode::id).collect()
+    }
+
+    /// Look up a usable node by its original OS node ID.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet, CpuTopology, NumaNodeId};
+    ///
+    /// let topology = CpuTopology::all_allowed(CpuSet::new([CpuId::new(0)])?);
+    /// assert!(topology.node(NumaNodeId::new(0)).is_none());
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn node(&self, id: NumaNodeId) -> Option<&CpuNode> {
+        self.nodes
+            .binary_search_by_key(&id, CpuNode::id)
+            .ok()
+            .map(|index| &self.nodes[index])
+    }
+
+    /// Report whether NUMA discovery produced any usable node domains.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::{CpuId, CpuSet, CpuTopology};
+    ///
+    /// let topology = CpuTopology::all_allowed(CpuSet::new([CpuId::new(0)])?);
+    /// assert!(!topology.has_numa_nodes());
+    /// # Ok::<(), tenferro_cpu::CpuSetError>(())
+    /// ```
+    pub fn has_numa_nodes(&self) -> bool {
+        !self.nodes.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/tenferro-cpu/src/topology.rs
+++ b/crates/tenferro-cpu/src/topology.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{collections::BTreeSet, fmt};
 
 use thiserror::Error;
 
@@ -322,6 +322,17 @@ pub enum CpuTopologyError {
     /// The process affinity mask contained no logical CPU.
     #[error("the process-allowed CPU set is empty")]
     EmptyAllowedCpuSet,
+    /// The process CPU affinity mask could not be obtained.
+    #[error("the process CPU affinity mask is unavailable")]
+    AffinityUnavailable,
+    /// A Linux sysfs CPU-list value was malformed or unreasonably large.
+    #[error("invalid Linux CPU list {list:?}: {reason}")]
+    InvalidCpuList {
+        /// The original sysfs CPU-list text.
+        list: String,
+        /// A stable human-readable parsing reason.
+        reason: &'static str,
+    },
     /// Discovery reported the same OS NUMA node more than once.
     #[error("NUMA node {node} was discovered more than once")]
     DuplicateNode {
@@ -338,6 +349,148 @@ pub enum CpuTopologyError {
         /// Logical CPUs present in both usable node sets.
         cpus: CpuSet,
     },
+}
+
+pub(crate) trait TopologySource {
+    fn allowed_cpus(&self) -> Result<CpuSet, CpuTopologyError>;
+
+    fn numa_node_cpu_lists(&self) -> Result<Option<Vec<(NumaNodeId, String)>>, CpuTopologyError>;
+}
+
+pub(crate) fn discover_from(source: &impl TopologySource) -> Result<CpuTopology, CpuTopologyError> {
+    let allowed_cpus = source.allowed_cpus()?;
+    let Some(node_cpu_lists) = source.numa_node_cpu_lists()? else {
+        return Ok(CpuTopology::all_allowed(allowed_cpus));
+    };
+    let nodes = node_cpu_lists
+        .into_iter()
+        .map(|(id, cpus)| parse_linux_cpu_list(&cpus).map(|cpus| (id, cpus)))
+        .collect::<Result<Vec<_>, _>>()?;
+    CpuTopology::from_discovered(allowed_cpus, nodes)
+}
+
+pub(crate) fn parse_linux_cpu_list(input: &str) -> Result<CpuSet, CpuTopologyError> {
+    const MAX_PARSED_CPUS: usize = 1 << 20;
+
+    let invalid = |reason| CpuTopologyError::InvalidCpuList {
+        list: input.to_owned(),
+        reason,
+    };
+    let input = input.trim();
+    if input.is_empty() {
+        return Err(invalid("list is empty"));
+    }
+    let mut cpus = Vec::new();
+    for component in input.split(',') {
+        let component = component.trim();
+        if component.is_empty() {
+            return Err(invalid("empty list component"));
+        }
+        if let Some((start, end)) = component.split_once('-') {
+            if end.contains('-') {
+                return Err(invalid("range contains more than one separator"));
+            }
+            let start = start
+                .parse::<usize>()
+                .map_err(|_| invalid("range start is not a CPU number"))?;
+            let end = end
+                .parse::<usize>()
+                .map_err(|_| invalid("range end is not a CPU number"))?;
+            let span = end
+                .checked_sub(start)
+                .and_then(|distance| distance.checked_add(1))
+                .ok_or_else(|| invalid("range is reversed or overflows"))?;
+            if span > MAX_PARSED_CPUS || cpus.len().saturating_add(span) > MAX_PARSED_CPUS {
+                return Err(invalid("list contains too many CPUs"));
+            }
+            cpus.extend((start..=end).map(CpuId::new));
+        } else {
+            let cpu = component
+                .parse::<usize>()
+                .map_err(|_| invalid("component is not a CPU number"))?;
+            cpus.push(CpuId::new(cpu));
+            if cpus.len() > MAX_PARSED_CPUS {
+                return Err(invalid("list contains too many CPUs"));
+            }
+        }
+    }
+    CpuSet::new(cpus).map_err(|_| invalid("list is empty"))
+}
+
+/// Discover the process-visible CPU and NUMA topology.
+///
+/// Linux uses `/sys/devices/system/node` intersected with the process affinity
+/// mask. Other platforms, and Linux systems without readable NUMA node files,
+/// expose only the all-allowed execution domain.
+///
+/// # Examples
+///
+/// ```
+/// let topology = tenferro_cpu::discover_cpu_topology()?;
+/// assert!(!topology.allowed_cpus().is_empty());
+/// # Ok::<(), tenferro_cpu::CpuTopologyError>(())
+/// ```
+pub fn discover_cpu_topology() -> Result<CpuTopology, CpuTopologyError> {
+    #[cfg(target_os = "linux")]
+    {
+        return discover_from(&LinuxTopologySource);
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let allowed = crate::process_cpu_affinity().unwrap_or_else(|| {
+            CpuSet::new((0..crate::available_parallelism()).map(CpuId::new))
+                .expect("available_parallelism always returns at least one CPU")
+        });
+        Ok(CpuTopology::all_allowed(allowed))
+    }
+}
+
+#[cfg(target_os = "linux")]
+struct LinuxTopologySource;
+
+#[cfg(target_os = "linux")]
+impl TopologySource for LinuxTopologySource {
+    fn allowed_cpus(&self) -> Result<CpuSet, CpuTopologyError> {
+        crate::process_cpu_affinity().ok_or(CpuTopologyError::AffinityUnavailable)
+    }
+
+    fn numa_node_cpu_lists(&self) -> Result<Option<Vec<(NumaNodeId, String)>>, CpuTopologyError> {
+        let entries = match std::fs::read_dir("/sys/devices/system/node") {
+            Ok(entries) => entries,
+            Err(_) => return Ok(None),
+        };
+        let mut nodes = Vec::new();
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => return Ok(None),
+            };
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            let Some(id) = name.strip_prefix("node") else {
+                continue;
+            };
+            if id.is_empty() || !id.bytes().all(|byte| byte.is_ascii_digit()) {
+                continue;
+            }
+            let Ok(id) = id.parse::<usize>() else {
+                continue;
+            };
+            let cpus = match std::fs::read_to_string(entry.path().join("cpulist")) {
+                Ok(cpus) => cpus,
+                Err(_) => return Ok(None),
+            };
+            nodes.push((NumaNodeId::new(id), cpus));
+        }
+        if nodes.is_empty() {
+            Ok(None)
+        } else {
+            nodes.sort_unstable_by_key(|(id, _)| *id);
+            Ok(Some(nodes))
+        }
+    }
 }
 
 /// Process-visible CPU topology used for execution placement.
@@ -390,8 +543,9 @@ impl CpuTopology {
             return Err(CpuTopologyError::EmptyAllowedCpuSet);
         }
         let mut usable = Vec::new();
+        let mut seen_node_ids = BTreeSet::new();
         for (id, discovered_cpus) in nodes {
-            if usable.iter().any(|node: &CpuNode| node.id == id) {
+            if !seen_node_ids.insert(id) {
                 return Err(CpuTopologyError::DuplicateNode { node: id });
             }
             if let Some(cpus) = discovered_cpus.intersection(&allowed_cpus) {

--- a/crates/tenferro-cpu/src/topology.rs
+++ b/crates/tenferro-cpu/src/topology.rs
@@ -129,6 +129,10 @@ pub struct CpuSet {
 }
 
 impl CpuSet {
+    pub(crate) fn singleton(cpu: CpuId) -> Self {
+        Self { cpus: vec![cpu] }
+    }
+
     /// Construct a sorted and deduplicated CPU set.
     ///
     /// # Examples

--- a/crates/tenferro-cpu/src/topology/tests.rs
+++ b/crates/tenferro-cpu/src/topology/tests.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+#[test]
+fn cpu_sets_are_sorted_and_deduplicated() {
+    let cpus = CpuSet::new([CpuId::new(11), CpuId::new(8), CpuId::new(11), CpuId::new(9)]).unwrap();
+
+    assert_eq!(cpus.as_usize_vec(), vec![8, 9, 11]);
+    assert!(cpus.contains(CpuId::new(9)));
+    assert!(!cpus.contains(CpuId::new(10)));
+}
+
+#[test]
+fn empty_cpu_sets_are_rejected() {
+    assert_eq!(CpuSet::new([]), Err(CpuSetError::Empty));
+}
+
+#[test]
+fn topology_intersects_nodes_with_allowed_cpus_without_renumbering() {
+    let allowed = cpu_set([8, 9, 10, 11, 12, 13, 14, 15]);
+    let topology = CpuTopology::from_discovered(
+        allowed.clone(),
+        [
+            (NumaNodeId::new(2), cpu_set([0, 8, 9, 10, 11])),
+            (NumaNodeId::new(7), cpu_set([12, 13, 14, 15, 16])),
+            (NumaNodeId::new(9), cpu_set([20, 21, 22, 23, 24])),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(topology.allowed_cpus(), &allowed);
+    assert_eq!(
+        topology.node_ids(),
+        vec![NumaNodeId::new(2), NumaNodeId::new(7)]
+    );
+    assert_eq!(
+        topology
+            .node(NumaNodeId::new(2))
+            .unwrap()
+            .cpus()
+            .as_usize_vec(),
+        vec![8, 9, 10, 11]
+    );
+}
+
+#[test]
+fn topology_rejects_overlapping_usable_nodes() {
+    let result = CpuTopology::from_discovered(
+        cpu_set([0, 1, 2]),
+        [
+            (NumaNodeId::new(2), cpu_set([0, 1])),
+            (NumaNodeId::new(7), cpu_set([1, 2])),
+        ],
+    );
+
+    assert!(matches!(
+        result,
+        Err(CpuTopologyError::OverlappingNodes {
+            first,
+            second,
+            ..
+        }) if first == NumaNodeId::new(2) && second == NumaNodeId::new(7)
+    ));
+}
+
+fn cpu_set<const N: usize>(cpus: [usize; N]) -> CpuSet {
+    CpuSet::new(cpus.map(CpuId::new)).unwrap()
+}

--- a/crates/tenferro-cpu/src/topology/tests.rs
+++ b/crates/tenferro-cpu/src/topology/tests.rs
@@ -62,6 +62,109 @@ fn topology_rejects_overlapping_usable_nodes() {
     ));
 }
 
+#[test]
+fn topology_rejects_duplicate_node_ids_even_when_one_copy_is_unusable() {
+    let result = CpuTopology::from_discovered(
+        cpu_set([0, 1]),
+        [
+            (NumaNodeId::new(2), cpu_set([8, 9])),
+            (NumaNodeId::new(2), cpu_set([0, 1])),
+        ],
+    );
+
+    assert_eq!(
+        result,
+        Err(CpuTopologyError::DuplicateNode {
+            node: NumaNodeId::new(2)
+        })
+    );
+}
+
+#[test]
+fn linux_cpu_list_parser_handles_ranges_gaps_and_whitespace() {
+    assert_eq!(
+        parse_linux_cpu_list("0-3,8,10-11\n")
+            .unwrap()
+            .as_usize_vec(),
+        vec![0, 1, 2, 3, 8, 10, 11],
+    );
+}
+
+#[test]
+fn linux_cpu_list_parser_rejects_reversed_or_malformed_ranges() {
+    assert!(parse_linux_cpu_list("4-2").is_err());
+    assert!(parse_linux_cpu_list("0,word,2").is_err());
+    assert!(parse_linux_cpu_list("0-").is_err());
+}
+
+#[test]
+fn discovery_falls_back_to_all_allowed_when_node_files_are_unavailable() {
+    let source = FixtureTopologySource {
+        allowed: cpu_set([4, 5]),
+        nodes: None,
+    };
+    let topology = discover_from(&source).unwrap();
+
+    assert!(topology.nodes().is_empty());
+    assert_eq!(topology.allowed_cpus().as_usize_vec(), vec![4, 5]);
+}
+
+#[test]
+fn discovery_parses_sparse_nodes_then_applies_process_affinity() {
+    let source = FixtureTopologySource {
+        allowed: cpu_set([8, 9, 12, 13]),
+        nodes: Some(vec![
+            (NumaNodeId::new(2), "0-9".to_owned()),
+            (NumaNodeId::new(7), "12-15".to_owned()),
+            (NumaNodeId::new(9), "20-23".to_owned()),
+        ]),
+    };
+    let topology = discover_from(&source).unwrap();
+
+    assert_eq!(
+        topology.node_ids(),
+        vec![NumaNodeId::new(2), NumaNodeId::new(7)]
+    );
+    assert_eq!(
+        topology
+            .node(NumaNodeId::new(2))
+            .unwrap()
+            .cpus()
+            .as_usize_vec(),
+        vec![8, 9]
+    );
+}
+
+#[test]
+fn live_discovery_stays_within_the_process_affinity_mask() {
+    let topology = discover_cpu_topology().unwrap();
+    if let Some(process_cpus) = crate::process_cpu_affinity() {
+        assert_eq!(topology.allowed_cpus(), &process_cpus);
+    }
+    for node in topology.nodes() {
+        assert!(node
+            .cpus()
+            .as_slice()
+            .iter()
+            .all(|cpu| topology.allowed_cpus().contains(*cpu)));
+    }
+}
+
+struct FixtureTopologySource {
+    allowed: CpuSet,
+    nodes: Option<Vec<(NumaNodeId, String)>>,
+}
+
+impl TopologySource for FixtureTopologySource {
+    fn allowed_cpus(&self) -> Result<CpuSet, CpuTopologyError> {
+        Ok(self.allowed.clone())
+    }
+
+    fn numa_node_cpu_lists(&self) -> Result<Option<Vec<(NumaNodeId, String)>>, CpuTopologyError> {
+        Ok(self.nodes.clone())
+    }
+}
+
 fn cpu_set<const N: usize>(cpus: [usize; N]) -> CpuSet {
     CpuSet::new(cpus.map(CpuId::new)).unwrap()
 }

--- a/crates/tenferro-cpu/tests/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/runtime_error_tests.rs
@@ -335,10 +335,10 @@ fn cpu_backend_with_threads_rejects_zero_without_panicking() {
 
     assert!(matches!(
         err,
-        Error::InvalidConfig {
+        tenferro_cpu::CpuBackendError::Tensor(Error::InvalidConfig {
             op: "CpuBackend::with_threads",
             ..
-        }
+        })
     ));
 }
 

--- a/crates/tenferro-einsum/src/eager/tests.rs
+++ b/crates/tenferro-einsum/src/eager/tests.rs
@@ -1,9 +1,9 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{
     BackendSessionHost, CompareDir, DotGeneralConfig, Error, GatherConfig, PadConfig, Result,
-    ScatterConfig, SessionCachedDot, SliceConfig, Tensor, TensorAnalytic, TensorBuffer, TensorDot,
-    TensorElementwise, TensorFusion, TensorIndexing, TensorRead, TensorReduction, TensorStructural,
-    TensorView,
+    ScatterConfig, SessionCachedDot, SliceConfig, Tensor, TensorAnalytic, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
+    TensorReduction, TensorStructural, TensorView,
 };
 
 use super::{
@@ -412,6 +412,7 @@ impl TensorDot for NoBroadcastMaterializationBackend {
 impl TensorFusion for NoBroadcastMaterializationBackend {}
 impl TensorBuffer for NoBroadcastMaterializationBackend {}
 impl SessionCachedDot for NoBroadcastMaterializationBackend {}
+impl TensorDeviceTransfer for NoBroadcastMaterializationBackend {}
 
 #[test]
 fn generic_read_exec_reduces_single_view_input() {

--- a/crates/tenferro-runtime/src/exec.rs
+++ b/crates/tenferro-runtime/src/exec.rs
@@ -744,10 +744,10 @@ pub(crate) fn eval_exec_ir_unsegmented_slot_values_with_cache_and_workspace<
 }
 
 pub(crate) fn can_run_in_single_exec_session(program: &ExecProgram) -> bool {
-    program.instructions.iter().all(|inst| {
-        !is_host_instruction(inst)
-            && (!is_ffi_instruction(inst) || is_exec_session_ffi_instruction(inst))
-    })
+    program
+        .instructions
+        .iter()
+        .all(|inst| !is_ffi_instruction(inst) || is_exec_session_ffi_instruction(inst))
 }
 
 pub(crate) fn eval_exec_ir_single_session_slots_with_workspace<'input, B: TensorBackend>(
@@ -764,9 +764,7 @@ pub(crate) fn eval_exec_ir_single_session_slots_with_workspace<'input, B: Tensor
         backend.with_backend_session_cached(backend_cache, |exec| -> Result<()> {
             for (inst_idx, inst) in program.instructions.iter().enumerate() {
                 if is_host_instruction(inst) {
-                    return Err(Error::Internal(
-                        "host instruction reached single-session executor".into(),
-                    ));
+                    execute_host_instruction_exec(exec, slots, inst)?;
                 } else if is_ffi_instruction(inst) {
                     execute_ffi_instruction_exec(exec, slots, inst, Some(inst_idx))?;
                 } else {
@@ -798,6 +796,14 @@ pub(crate) fn execute_host_instruction<B: TensorBackend>(
     inst: &ExecInstruction,
 ) -> Result<()> {
     dispatch::execute_host_dispatch(backend, slots, inst)
+}
+
+pub(crate) fn execute_host_instruction_exec(
+    exec: &mut dyn BackendSession,
+    slots: &mut [Option<ExecSlot<'_>>],
+    inst: &ExecInstruction,
+) -> Result<()> {
+    dispatch::execute_host_dispatch(exec, slots, inst)
 }
 
 pub(crate) fn execute_ffi_instruction<B: TensorBackend + 'static>(

--- a/crates/tenferro-runtime/src/exec/dispatch.rs
+++ b/crates/tenferro-runtime/src/exec/dispatch.rs
@@ -1,7 +1,8 @@
 use crate::error::{Error, Result};
 use tenferro_core_ops::PrimitiveOpKind;
 use tenferro_tensor::{
-    BackendSession, GatherConfig, PadConfig, SliceConfig, Tensor, TensorBackend,
+    BackendSession, GatherConfig, PadConfig, SliceConfig, Tensor, TensorBackend, TensorBackendOps,
+    TensorDeviceTransfer,
 };
 
 use super::{
@@ -24,6 +25,10 @@ type FfiDispatchFn<B> = fn(
     DispatchMode,
     Option<&mut ExtensionExecutor<B>>,
 ) -> Result<()>;
+
+pub(super) trait HostExecution: TensorBackendOps + TensorDeviceTransfer {}
+
+impl<T> HostExecution for T where T: TensorBackendOps + TensorDeviceTransfer + ?Sized {}
 
 type HostDispatchFn<B> = fn(&mut B, &mut [Option<ExecSlot<'_>>], &ExecInstruction) -> Result<()>;
 
@@ -99,7 +104,7 @@ macro_rules! define_host_dispatch {
             }
         }
 
-        fn host_dispatch_table<B: TensorBackend>() -> [HostDispatchEntry<B>; HostDispatchKey::COUNT_FOR_TABLE] {
+        fn host_dispatch_table<B: HostExecution + ?Sized>() -> [HostDispatchEntry<B>; HostDispatchKey::COUNT_FOR_TABLE] {
             [
                 $(
                     HostDispatchEntry {
@@ -122,7 +127,7 @@ pub(super) struct FfiDispatchEntry<B: TensorBackend + 'static> {
     execute: FfiDispatchFn<B>,
 }
 
-pub(super) struct HostDispatchEntry<B: TensorBackend> {
+pub(super) struct HostDispatchEntry<B: HostExecution + ?Sized> {
     pub(super) key: HostDispatchKey,
     execute: HostDispatchFn<B>,
 }
@@ -135,9 +140,9 @@ impl<B: TensorBackend + 'static> Clone for FfiDispatchEntry<B> {
     }
 }
 
-impl<B: TensorBackend> Copy for HostDispatchEntry<B> {}
+impl<B: HostExecution + ?Sized> Copy for HostDispatchEntry<B> {}
 
-impl<B: TensorBackend> Clone for HostDispatchEntry<B> {
+impl<B: HostExecution + ?Sized> Clone for HostDispatchEntry<B> {
     fn clone(&self) -> Self {
         *self
     }
@@ -237,7 +242,9 @@ pub(super) fn is_exec_session_ffi_op(op: &ExecOp) -> bool {
     )
 }
 
-pub(super) fn host_dispatch_entry<B: TensorBackend>(op: &ExecOp) -> Option<HostDispatchEntry<B>> {
+pub(super) fn host_dispatch_entry<B: HostExecution + ?Sized>(
+    op: &ExecOp,
+) -> Option<HostDispatchEntry<B>> {
     let key = HostDispatchKey::for_op(op)?;
     // INVARIANT: the host dispatch table is macro-generated and fixed at
     // compile time, so this lookup is constant-bounded.
@@ -260,7 +267,7 @@ pub(super) fn execute_backend_dispatch(
     (entry.execute)(exec, slots, inst)
 }
 
-pub(super) fn execute_host_dispatch<B: TensorBackend>(
+pub(super) fn execute_host_dispatch<B: HostExecution + ?Sized>(
     backend: &mut B,
     slots: &mut [Option<ExecSlot<'_>>],
     inst: &ExecInstruction,
@@ -308,7 +315,7 @@ fn host_dispatch_mismatch(expected: HostDispatchKey, op: &ExecOp) -> Error {
     ))
 }
 
-fn execute_shape_of_host<B: TensorBackend>(
+fn execute_shape_of_host<B: HostExecution + ?Sized>(
     backend: &mut B,
     slots: &mut [Option<ExecSlot<'_>>],
     inst: &ExecInstruction,
@@ -332,7 +339,7 @@ fn execute_shape_of_host<B: TensorBackend>(
     Ok(())
 }
 
-fn execute_dynamic_truncate_host<B: TensorBackend>(
+fn execute_dynamic_truncate_host<B: HostExecution + ?Sized>(
     backend: &mut B,
     slots: &mut [Option<ExecSlot<'_>>],
     inst: &ExecInstruction,
@@ -366,7 +373,7 @@ fn execute_dynamic_truncate_host<B: TensorBackend>(
     Ok(())
 }
 
-fn execute_pad_to_match_host<B: TensorBackend>(
+fn execute_pad_to_match_host<B: HostExecution + ?Sized>(
     backend: &mut B,
     slots: &mut [Option<ExecSlot<'_>>],
     inst: &ExecInstruction,
@@ -404,7 +411,7 @@ fn execute_pad_to_match_host<B: TensorBackend>(
     Ok(())
 }
 
-fn execute_constant_host<B: TensorBackend>(
+fn execute_constant_host<B: HostExecution + ?Sized>(
     backend: &mut B,
     slots: &mut [Option<ExecSlot<'_>>],
     inst: &ExecInstruction,

--- a/crates/tenferro-runtime/src/graph/executor/tests/preflight.rs
+++ b/crates/tenferro-runtime/src/graph/executor/tests/preflight.rs
@@ -22,8 +22,10 @@ use crate::{Error, GraphCompiler, TracedTensor};
 #[derive(Debug)]
 struct CountingBackend {
     uploads: Arc<AtomicUsize>,
+    uploads_in_session: Arc<AtomicUsize>,
     dispatches: Arc<AtomicUsize>,
     session_entries: Arc<AtomicUsize>,
+    session_depth: Arc<AtomicUsize>,
 }
 
 macro_rules! unreachable_backend_methods {
@@ -40,6 +42,9 @@ macro_rules! unreachable_backend_methods {
 impl TensorDeviceTransfer for CountingBackend {
     fn upload_host_tensor(&mut self, tensor: &Tensor) -> tenferro_tensor::Result<Tensor> {
         self.uploads.fetch_add(1, Ordering::Relaxed);
+        if self.session_depth.load(Ordering::Relaxed) != 0 {
+            self.uploads_in_session.fetch_add(1, Ordering::Relaxed);
+        }
         Ok(tensor.clone())
     }
 }
@@ -121,8 +126,14 @@ impl TensorIndexing for CountingBackend {
 }
 
 impl TensorDot for CountingBackend {
-    unreachable_backend_methods! {
-        dot_general(lhs: &Tensor, rhs: &Tensor, config: &DotGeneralConfig) -> tenferro_tensor::Result<Tensor>;
+    fn dot_general(
+        &mut self,
+        lhs: &Tensor,
+        _rhs: &Tensor,
+        _config: &DotGeneralConfig,
+    ) -> tenferro_tensor::Result<Tensor> {
+        self.dispatches.fetch_add(1, Ordering::Relaxed);
+        Ok(lhs.clone())
     }
 }
 
@@ -135,7 +146,10 @@ impl BackendSessionHost for CountingBackend {
         f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
     ) -> R {
         self.session_entries.fetch_add(1, Ordering::Relaxed);
-        f(self)
+        self.session_depth.fetch_add(1, Ordering::Relaxed);
+        let result = f(self);
+        self.session_depth.fetch_sub(1, Ordering::Relaxed);
+        result
     }
 }
 impl TensorBackend for CountingBackend {}
@@ -147,18 +161,97 @@ fn counting_backend() -> (
     Arc<AtomicUsize>,
 ) {
     let uploads = Arc::new(AtomicUsize::new(0));
+    let uploads_in_session = Arc::new(AtomicUsize::new(0));
     let dispatches = Arc::new(AtomicUsize::new(0));
     let session_entries = Arc::new(AtomicUsize::new(0));
+    let session_depth = Arc::new(AtomicUsize::new(0));
     (
         CountingBackend {
             uploads: uploads.clone(),
+            uploads_in_session,
             dispatches: dispatches.clone(),
             session_entries: session_entries.clone(),
+            session_depth,
         },
         uploads,
         dispatches,
         session_entries,
     )
+}
+
+#[test]
+fn host_native_and_session_ffi_share_one_backend_session() {
+    let uploads = Arc::new(AtomicUsize::new(0));
+    let uploads_in_session = Arc::new(AtomicUsize::new(0));
+    let dispatches = Arc::new(AtomicUsize::new(0));
+    let session_entries = Arc::new(AtomicUsize::new(0));
+    let session_depth = Arc::new(AtomicUsize::new(0));
+    let mut backend = CountingBackend {
+        uploads: uploads.clone(),
+        uploads_in_session: uploads_in_session.clone(),
+        dispatches: dispatches.clone(),
+        session_entries: session_entries.clone(),
+        session_depth,
+    };
+    let program = ExecProgram {
+        instructions: vec![
+            ExecInstruction {
+                op: ExecOp::ShapeOf { axis: 0 },
+                input_slots: vec![0],
+                output_slots: vec![1],
+                dtype: DType::F64,
+                output_shapes: vec![vec![]].into(),
+                output_extents: vec![vec![]].into(),
+                last_use: vec![false],
+            },
+            ExecInstruction {
+                op: ExecOp::Negate,
+                input_slots: vec![1],
+                output_slots: vec![2],
+                dtype: DType::F64,
+                output_shapes: vec![vec![]].into(),
+                output_extents: vec![vec![]].into(),
+                last_use: vec![false],
+            },
+            ExecInstruction {
+                op: ExecOp::DotGeneral(DotGeneralConfig {
+                    lhs_contracting_dims: vec![],
+                    rhs_contracting_dims: vec![],
+                    lhs_batch_dims: vec![],
+                    rhs_batch_dims: vec![],
+                }),
+                input_slots: vec![2, 1],
+                output_slots: vec![3],
+                dtype: DType::F64,
+                output_shapes: vec![vec![]].into(),
+                output_extents: vec![vec![]].into(),
+                last_use: vec![true, true],
+            },
+        ],
+        input_slots: vec![0],
+        output_slots: vec![3],
+        n_slots: 4,
+        shape_guards: vec![],
+    };
+    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let mut slots = Vec::new();
+    let mut cache = ();
+
+    let outputs = crate::segment::eval_exec_segmented_slots_with_cache_and_workspace(
+        &mut backend,
+        &program,
+        vec![ExecSlot::Owned(input)],
+        &mut slots,
+        &mut cache,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(outputs.len(), 1);
+    assert_eq!(uploads.load(Ordering::Relaxed), 1);
+    assert_eq!(uploads_in_session.load(Ordering::Relaxed), 1);
+    assert_eq!(dispatches.load(Ordering::Relaxed), 2);
+    assert_eq!(session_entries.load(Ordering::Relaxed), 1);
 }
 
 fn constant_guard(lhs: usize, rhs: usize, family_id: &'static str) -> ShapeGuard {

--- a/crates/tenferro-runtime/src/graph/executor/tests/preflight.rs
+++ b/crates/tenferro-runtime/src/graph/executor/tests/preflight.rs
@@ -254,6 +254,134 @@ fn host_native_and_session_ffi_share_one_backend_session() {
     assert_eq!(session_entries.load(Ordering::Relaxed), 1);
 }
 
+fn fused_host_program() -> ExecProgram {
+    let scalar_metadata = || (vec![vec![]].into(), vec![vec![]].into());
+    let vector_metadata = || {
+        (
+            vec![vec![DimExpr::Const(2)]].into(),
+            vec![vec![tenferro_ops::ShapeExtent::exact(DimExpr::Const(2))]].into(),
+        )
+    };
+    let (output_shapes, output_extents) = vector_metadata();
+    let first = ExecInstruction {
+        op: ExecOp::Negate,
+        input_slots: vec![0],
+        output_slots: vec![1],
+        dtype: DType::F64,
+        output_shapes,
+        output_extents,
+        last_use: vec![false],
+    };
+    let (output_shapes, output_extents) = vector_metadata();
+    let second = ExecInstruction {
+        op: ExecOp::Negate,
+        input_slots: vec![1],
+        output_slots: vec![2],
+        dtype: DType::F64,
+        output_shapes,
+        output_extents,
+        last_use: vec![true],
+    };
+    let (output_shapes, output_extents) = vector_metadata();
+    let ffi = ExecInstruction {
+        op: ExecOp::DotGeneral(DotGeneralConfig {
+            lhs_contracting_dims: vec![],
+            rhs_contracting_dims: vec![],
+            lhs_batch_dims: vec![],
+            rhs_batch_dims: vec![],
+        }),
+        input_slots: vec![2, 0],
+        output_slots: vec![3],
+        dtype: DType::F64,
+        output_shapes,
+        output_extents,
+        last_use: vec![false, false],
+    };
+    let (output_shapes, output_extents) = scalar_metadata();
+    let host = ExecInstruction {
+        op: ExecOp::ShapeOf { axis: 0 },
+        input_slots: vec![0],
+        output_slots: vec![4],
+        dtype: DType::F64,
+        output_shapes,
+        output_extents,
+        last_use: vec![false],
+    };
+    let (output_shapes, output_extents) = scalar_metadata();
+    let third = ExecInstruction {
+        op: ExecOp::Negate,
+        input_slots: vec![4],
+        output_slots: vec![5],
+        dtype: DType::F64,
+        output_shapes,
+        output_extents,
+        last_use: vec![false],
+    };
+    let (output_shapes, output_extents) = scalar_metadata();
+    let fourth = ExecInstruction {
+        op: ExecOp::Negate,
+        input_slots: vec![5],
+        output_slots: vec![6],
+        dtype: DType::F64,
+        output_shapes,
+        output_extents,
+        last_use: vec![true],
+    };
+    ExecProgram {
+        instructions: vec![first, second, ffi, host, third, fourth],
+        input_slots: vec![0],
+        output_slots: vec![3, 6],
+        n_slots: 7,
+        shape_guards: vec![],
+    }
+}
+
+#[test]
+fn fused_and_host_segments_share_one_backend_session_for_owned_outputs() {
+    let (mut backend, _, dispatches, sessions) = counting_backend();
+    let mut slots = Vec::new();
+    let mut cache = ();
+
+    let outputs = crate::segment::eval_exec_segmented_slots_with_cache_and_workspace(
+        &mut backend,
+        &fused_host_program(),
+        vec![ExecSlot::Owned(
+            Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+        )],
+        &mut slots,
+        &mut cache,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(outputs.len(), 2);
+    assert_eq!(dispatches.load(Ordering::Relaxed), 5);
+    assert_eq!(sessions.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn fused_and_host_segments_share_one_backend_session_for_value_outputs() {
+    let (mut backend, _, dispatches, sessions) = counting_backend();
+    let mut slots = Vec::new();
+    let mut cache = ();
+
+    let outputs = crate::segment::eval_exec_segmented_slot_values_with_cache_and_workspace(
+        &mut backend,
+        &fused_host_program(),
+        vec![ExecSlot::Owned(
+            Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+        )],
+        &mut slots,
+        &mut cache,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(outputs.len(), 2);
+    assert_eq!(dispatches.load(Ordering::Relaxed), 5);
+    assert_eq!(sessions.load(Ordering::Relaxed), 1);
+}
+
 fn constant_guard(lhs: usize, rhs: usize, family_id: &'static str) -> ShapeGuard {
     ShapeGuard {
         source: ConstraintSource {

--- a/crates/tenferro-runtime/src/segment.rs
+++ b/crates/tenferro-runtime/src/segment.rs
@@ -8,18 +8,18 @@ use crate::exec::{
     eval_exec_ir_single_session_slots_with_workspace,
     eval_exec_ir_unsegmented_slot_values_with_cache_and_workspace,
     eval_exec_ir_unsegmented_slots_with_cache_and_workspace, execute_backend_op,
-    execute_ffi_instruction_cached, execute_host_instruction, get_read, initialize_exec_slots_in,
-    is_ffi_instruction, is_host_instruction, reclaim_last_use_inputs_backend,
-    reclaim_last_use_inputs_exec, resolve_tensor_shape_exprs, terminal_output_slots,
-    try_execute_terminal_value_instruction, validate_exec_program, DispatchMode, ExecInstruction,
-    ExecOp, ExecProgram, ExecSlot,
+    execute_ffi_instruction_cached, execute_ffi_instruction_exec, execute_host_instruction,
+    execute_host_instruction_exec, get_read, initialize_exec_slots_in, is_ffi_instruction,
+    is_host_instruction, reclaim_last_use_inputs_backend, reclaim_last_use_inputs_exec,
+    resolve_tensor_shape_exprs, terminal_output_slots, try_execute_terminal_value_instruction,
+    validate_exec_program, DispatchMode, ExecInstruction, ExecOp, ExecProgram, ExecSlot,
 };
 use crate::extension_runtime::ExtensionExecutor;
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_tensor::backend::{
     ElementwiseFusionInputView, ElementwiseFusionInst, ElementwiseFusionPlan,
 };
-use tenferro_tensor::{Tensor, TensorBackend, TensorRead, TensorValue};
+use tenferro_tensor::{BackendSession, Tensor, TensorBackend, TensorRead, TensorValue};
 
 /// A compiled execution segment.
 ///
@@ -212,6 +212,15 @@ pub(crate) fn eval_exec_segmented_slots_with_cache_and_workspace<
 ) -> Result<Vec<Tensor>> {
     validate_exec_program(program, "segmented executor")?;
     let has_fused_segment = has_multi_instruction_fused_segment(program);
+    if has_fused_segment && can_run_in_single_exec_session(program) {
+        return eval_exec_segmented_single_session_slots_with_workspace(
+            backend,
+            program,
+            inputs,
+            slots,
+            backend_cache,
+        );
+    }
     if !has_fused_segment && can_run_in_single_exec_session(program) {
         return eval_exec_ir_single_session_slots_with_workspace(
             backend,
@@ -245,55 +254,15 @@ pub(crate) fn eval_exec_segmented_slots_with_cache_and_workspace<
                     output_slots,
                     last_use,
                 } => {
-                    backend.with_backend_session(|exec| -> Result<()> {
-                        if let Some(plan) =
-                            build_elementwise_fusion_plan(instructions, input_slots, output_slots)
-                        {
-                            let inputs = collect_segment_inputs(slots, input_slots)?;
-                            if let Some(outputs) =
-                                exec.execute_elementwise_fusion(&inputs, &plan)?
-                            {
-                                if outputs.len() != output_slots.len() {
-                                    return Err(crate::error::Error::Internal(format!(
-                                        "fused elementwise kernel produced {} outputs for {} slots",
-                                        outputs.len(),
-                                        output_slots.len()
-                                    )));
-                                }
-                                for (slot, tensor) in output_slots.iter().copied().zip(outputs) {
-                                    slots[slot] = Some(ExecSlot::Owned(tensor));
-                                }
-                                reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
-                                return Ok(());
-                            }
-                        }
-                        if let Some(output) = try_execute_broadcast_multiply_segment(
+                    backend.with_backend_session(|exec| {
+                        execute_fused_segment(
                             exec,
                             slots,
                             instructions,
+                            input_slots,
                             output_slots,
-                        )? {
-                            slots[output_slots[0]] = Some(ExecSlot::Owned(output));
-                            reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
-                            return Ok(());
-                        }
-                        if let Some(output) = try_execute_single_broadcast_multiply_segment(
-                            exec,
-                            slots,
-                            instructions,
-                            output_slots,
-                        )? {
-                            slots[output_slots[0]] = Some(ExecSlot::Owned(output));
-                            reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
-                            return Ok(());
-                        }
-
-                        for inst in instructions {
-                            let result = execute_backend_op(exec, slots, inst)?;
-                            slots[inst.output_slots[0]] = Some(ExecSlot::Owned(result));
-                            reclaim_last_use_inputs_exec(slots, inst, exec);
-                        }
-                        Ok(())
+                            last_use,
+                        )
                     })?;
                     inst_idx += instructions.len();
                 }
@@ -337,6 +306,15 @@ pub(crate) fn eval_exec_segmented_slot_values_with_cache_and_workspace<
 ) -> Result<Vec<TensorValue>> {
     validate_exec_program(program, "segmented value executor")?;
     let has_fused_segment = has_multi_instruction_fused_segment(program);
+    if can_run_in_single_exec_session(program) {
+        return eval_exec_segmented_single_session_slot_values_with_workspace(
+            backend,
+            program,
+            inputs,
+            slots,
+            backend_cache,
+        );
+    }
     if !has_fused_segment {
         return eval_exec_ir_unsegmented_slot_values_with_cache_and_workspace(
             backend,
@@ -362,84 +340,16 @@ pub(crate) fn eval_exec_segmented_slot_values_with_cache_and_workspace<
                     output_slots,
                     last_use,
                 } => {
-                    backend.with_backend_session(|exec| -> Result<()> {
-                        if let Some(plan) =
-                            build_elementwise_fusion_plan(instructions, input_slots, output_slots)
-                        {
-                            let inputs = collect_segment_inputs(slots, input_slots)?;
-                            if let Some(outputs) =
-                                exec.execute_elementwise_fusion(&inputs, &plan)?
-                            {
-                                if outputs.len() != output_slots.len() {
-                                    return Err(crate::error::Error::Internal(format!(
-                                        "fused elementwise kernel produced {} outputs for {} slots",
-                                        outputs.len(),
-                                        output_slots.len()
-                                    )));
-                                }
-                                for (slot, tensor) in output_slots.iter().copied().zip(outputs) {
-                                    slots[slot] = Some(ExecSlot::Owned(tensor));
-                                }
-                                reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
-                                return Ok(());
-                            }
-                        }
-                        if let Some(output) = try_execute_terminal_broadcast_multiply_value_segment(
+                    backend.with_backend_session(|exec| {
+                        execute_fused_value_segment(
                             exec,
                             slots,
                             instructions,
+                            input_slots,
                             output_slots,
+                            last_use,
                             &terminal_slots,
-                        )? {
-                            slots[output_slots[0]] = Some(ExecSlot::Value(output));
-                            reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
-                            return Ok(());
-                        }
-                        if let Some(output) =
-                            try_execute_terminal_single_broadcast_multiply_value_segment(
-                                exec,
-                                slots,
-                                instructions,
-                                output_slots,
-                                &terminal_slots,
-                            )?
-                        {
-                            slots[output_slots[0]] = Some(ExecSlot::Value(output));
-                            reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
-                            return Ok(());
-                        }
-                        if let Some(output) = try_execute_broadcast_multiply_segment(
-                            exec,
-                            slots,
-                            instructions,
-                            output_slots,
-                        )? {
-                            slots[output_slots[0]] = Some(ExecSlot::Owned(output));
-                            reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
-                            return Ok(());
-                        }
-                        if let Some(output) = try_execute_single_broadcast_multiply_segment(
-                            exec,
-                            slots,
-                            instructions,
-                            output_slots,
-                        )? {
-                            slots[output_slots[0]] = Some(ExecSlot::Owned(output));
-                            reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
-                            return Ok(());
-                        }
-
-                        for inst in instructions {
-                            if try_execute_terminal_value_instruction(slots, inst, &terminal_slots)?
-                            {
-                                // Already handled as a metadata-only TensorValue.
-                            } else {
-                                let result = execute_backend_op(exec, slots, inst)?;
-                                slots[inst.output_slots[0]] = Some(ExecSlot::Owned(result));
-                            }
-                            reclaim_last_use_inputs_exec(slots, inst, exec);
-                        }
-                        Ok(())
+                        )
                     })?;
                     inst_idx += instructions.len();
                 }
@@ -476,6 +386,235 @@ pub(crate) fn eval_exec_segmented_slot_values_with_cache_and_workspace<
     })();
     slots.clear();
     result
+}
+
+fn eval_exec_segmented_single_session_slots_with_workspace<'input, B: TensorBackend>(
+    backend: &mut B,
+    program: &ExecProgram,
+    inputs: Vec<ExecSlot<'input>>,
+    slots: &mut Vec<Option<ExecSlot<'input>>>,
+    backend_cache: &mut B::RuntimeCache,
+) -> Result<Vec<Tensor>> {
+    let result = (|| {
+        initialize_exec_slots_in(program, inputs, slots)?;
+        let segments = segment_exec_program(program);
+
+        backend.with_backend_session_cached(backend_cache, |exec| -> Result<()> {
+            let mut inst_idx = 0usize;
+            for segment in &segments {
+                match segment {
+                    Segment::Fused {
+                        instructions,
+                        input_slots,
+                        output_slots,
+                        last_use,
+                    } => execute_fused_segment(
+                        exec,
+                        slots,
+                        instructions,
+                        input_slots,
+                        output_slots,
+                        last_use,
+                    )?,
+                    Segment::Ffi(inst) => {
+                        execute_ffi_instruction_exec(exec, slots, inst, Some(inst_idx))?;
+                        reclaim_last_use_inputs_exec(slots, inst, exec);
+                    }
+                    Segment::Host(inst) => {
+                        execute_host_instruction_exec(exec, slots, inst)?;
+                        reclaim_last_use_inputs_exec(slots, inst, exec);
+                    }
+                }
+                inst_idx += match segment {
+                    Segment::Fused { instructions, .. } => instructions.len(),
+                    Segment::Ffi(_) | Segment::Host(_) => 1,
+                };
+            }
+            Ok(())
+        })?;
+
+        collect_outputs_from(program, slots)
+    })();
+    slots.clear();
+    result
+}
+
+fn eval_exec_segmented_single_session_slot_values_with_workspace<'input, B: TensorBackend>(
+    backend: &mut B,
+    program: &ExecProgram,
+    inputs: Vec<ExecSlot<'input>>,
+    slots: &mut Vec<Option<ExecSlot<'input>>>,
+    backend_cache: &mut B::RuntimeCache,
+) -> Result<Vec<TensorValue>> {
+    let result = (|| {
+        initialize_exec_slots_in(program, inputs, slots)?;
+        let terminal_slots = terminal_output_slots(program);
+        let segments = segment_exec_program(program);
+
+        backend.with_backend_session_cached(backend_cache, |exec| -> Result<()> {
+            let mut inst_idx = 0usize;
+            for segment in &segments {
+                match segment {
+                    Segment::Fused {
+                        instructions,
+                        input_slots,
+                        output_slots,
+                        last_use,
+                    } => execute_fused_value_segment(
+                        exec,
+                        slots,
+                        instructions,
+                        input_slots,
+                        output_slots,
+                        last_use,
+                        &terminal_slots,
+                    )?,
+                    Segment::Ffi(inst) => {
+                        if !try_execute_terminal_value_instruction(slots, inst, &terminal_slots)? {
+                            execute_ffi_instruction_exec(exec, slots, inst, Some(inst_idx))?;
+                        }
+                        reclaim_last_use_inputs_exec(slots, inst, exec);
+                    }
+                    Segment::Host(inst) => {
+                        if !try_execute_terminal_value_instruction(slots, inst, &terminal_slots)? {
+                            execute_host_instruction_exec(exec, slots, inst)?;
+                        }
+                        reclaim_last_use_inputs_exec(slots, inst, exec);
+                    }
+                }
+                inst_idx += match segment {
+                    Segment::Fused { instructions, .. } => instructions.len(),
+                    Segment::Ffi(_) | Segment::Host(_) => 1,
+                };
+            }
+            Ok(())
+        })?;
+
+        collect_output_values_from(program, slots)
+    })();
+    slots.clear();
+    result
+}
+
+fn execute_fused_segment(
+    exec: &mut dyn BackendSession,
+    slots: &mut [Option<ExecSlot<'_>>],
+    instructions: &[ExecInstruction],
+    input_slots: &[usize],
+    output_slots: &[usize],
+    last_use: &[bool],
+) -> Result<()> {
+    if let Some(plan) = build_elementwise_fusion_plan(instructions, input_slots, output_slots) {
+        let inputs = collect_segment_inputs(slots, input_slots)?;
+        if let Some(outputs) = exec.execute_elementwise_fusion(&inputs, &plan)? {
+            if outputs.len() != output_slots.len() {
+                return Err(crate::error::Error::Internal(format!(
+                    "fused elementwise kernel produced {} outputs for {} slots",
+                    outputs.len(),
+                    output_slots.len()
+                )));
+            }
+            for (slot, tensor) in output_slots.iter().copied().zip(outputs) {
+                slots[slot] = Some(ExecSlot::Owned(tensor));
+            }
+            reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
+            return Ok(());
+        }
+    }
+    if let Some(output) =
+        try_execute_broadcast_multiply_segment(exec, slots, instructions, output_slots)?
+    {
+        slots[output_slots[0]] = Some(ExecSlot::Owned(output));
+        reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
+        return Ok(());
+    }
+    if let Some(output) =
+        try_execute_single_broadcast_multiply_segment(exec, slots, instructions, output_slots)?
+    {
+        slots[output_slots[0]] = Some(ExecSlot::Owned(output));
+        reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
+        return Ok(());
+    }
+
+    for inst in instructions {
+        let result = execute_backend_op(exec, slots, inst)?;
+        slots[inst.output_slots[0]] = Some(ExecSlot::Owned(result));
+        reclaim_last_use_inputs_exec(slots, inst, exec);
+    }
+    Ok(())
+}
+
+fn execute_fused_value_segment(
+    exec: &mut dyn BackendSession,
+    slots: &mut [Option<ExecSlot<'_>>],
+    instructions: &[ExecInstruction],
+    input_slots: &[usize],
+    output_slots: &[usize],
+    last_use: &[bool],
+    terminal_slots: &[bool],
+) -> Result<()> {
+    if let Some(plan) = build_elementwise_fusion_plan(instructions, input_slots, output_slots) {
+        let inputs = collect_segment_inputs(slots, input_slots)?;
+        if let Some(outputs) = exec.execute_elementwise_fusion(&inputs, &plan)? {
+            if outputs.len() != output_slots.len() {
+                return Err(crate::error::Error::Internal(format!(
+                    "fused elementwise kernel produced {} outputs for {} slots",
+                    outputs.len(),
+                    output_slots.len()
+                )));
+            }
+            for (slot, tensor) in output_slots.iter().copied().zip(outputs) {
+                slots[slot] = Some(ExecSlot::Owned(tensor));
+            }
+            reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
+            return Ok(());
+        }
+    }
+    if let Some(output) = try_execute_terminal_broadcast_multiply_value_segment(
+        exec,
+        slots,
+        instructions,
+        output_slots,
+        terminal_slots,
+    )? {
+        slots[output_slots[0]] = Some(ExecSlot::Value(output));
+        reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
+        return Ok(());
+    }
+    if let Some(output) = try_execute_terminal_single_broadcast_multiply_value_segment(
+        exec,
+        slots,
+        instructions,
+        output_slots,
+        terminal_slots,
+    )? {
+        slots[output_slots[0]] = Some(ExecSlot::Value(output));
+        reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
+        return Ok(());
+    }
+    if let Some(output) =
+        try_execute_broadcast_multiply_segment(exec, slots, instructions, output_slots)?
+    {
+        slots[output_slots[0]] = Some(ExecSlot::Owned(output));
+        reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
+        return Ok(());
+    }
+    if let Some(output) =
+        try_execute_single_broadcast_multiply_segment(exec, slots, instructions, output_slots)?
+    {
+        slots[output_slots[0]] = Some(ExecSlot::Owned(output));
+        reclaim_segment_inputs_exec(slots, input_slots, last_use, exec);
+        return Ok(());
+    }
+
+    for inst in instructions {
+        if !try_execute_terminal_value_instruction(slots, inst, terminal_slots)? {
+            let result = execute_backend_op(exec, slots, inst)?;
+            slots[inst.output_slots[0]] = Some(ExecSlot::Owned(result));
+        }
+        reclaim_last_use_inputs_exec(slots, inst, exec);
+    }
+    Ok(())
 }
 
 fn has_multi_instruction_fused_segment(program: &ExecProgram) -> bool {

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -2613,9 +2613,12 @@ impl<T> TensorBackendOps for T where
 ///     backend.with_backend_session(|exec| exec.add(a, b))
 /// }
 /// ```
-pub trait BackendSession: TensorBackendOps + SessionCachedDot {}
+pub trait BackendSession: TensorBackendOps + SessionCachedDot + TensorDeviceTransfer {}
 
-impl<T> BackendSession for T where T: TensorBackendOps + SessionCachedDot + ?Sized {}
+impl<T> BackendSession for T where
+    T: TensorBackendOps + SessionCachedDot + TensorDeviceTransfer + ?Sized
+{
+}
 
 /// Standard runtime backend over dynamic [`Tensor`] values.
 ///

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -61,6 +61,8 @@ website:
           - guides/devices-and-gpu.md
           - guides/xla.md
           - guides/memory-order.md
+          - text: "CPU Execution and NUMA"
+            href: guides/cpu-execution.md
           - text: "Parallelism and Caching"
             href: guides/parallelism-and-caching.md
           - guides/troubleshooting.md

--- a/docs/design/cpu-backend-execution.md
+++ b/docs/design/cpu-backend-execution.md
@@ -1,0 +1,27 @@
+# CPU Backend Execution Contract
+
+`CpuBackend` is a cloneable handle to a shared coordinator. The coordinator
+owns process-visible topology, lazily constructed fixed engines, overlap-aware
+execution arbitration, and engine-local buffer and GEMM-analysis caches.
+
+Topology uses sparse OS CPU and NUMA node IDs. A usable node CPU set is
+`OS node cpuset ∩ process affinity`; `AllAllowed` is the process affinity set.
+No code may reinterpret node IDs as dense indexes or widen process affinity.
+
+For `CpuBackendKind::Faer`, `Auto` resolves to managed `AllAllowed`, and
+explicit node/all-allowed placement is supported. Each managed engine has a
+fixed Rayon pool whose workers are pinned and verified at construction.
+Overlapping CPU sets cannot hold permits concurrently; disjoint sets can.
+
+For `CpuBackendKind::Blas`, only `Auto` is valid. It resolves to a
+provider-default exclusive permit because tenferro cannot establish the CPU
+affinity of provider-owned OpenMP or native workers. Native graph segments enter
+the fixed all-allowed Rayon engine; provider calls remain outside that pool.
+
+A supported graph execution holds one permit and one backend session across
+Host operations, native operations, and session-capable FFI operations.
+Non-session extension runtimes are boundaries. Cache ownership follows engine
+ownership so clone handles do not duplicate retained execution state.
+
+The stable public identity is `CpuBackendKind::{Faer, Blas}`. Concrete provider
+names are diagnostic strings, not dispatch or compatibility keys.

--- a/docs/design/cpu-backend-execution.md
+++ b/docs/design/cpu-backend-execution.md
@@ -23,19 +23,18 @@ Host operations, native operations, and session-capable FFI operations.
 Non-session extension runtimes are boundaries. Cache ownership follows engine
 ownership so clone handles do not duplicate retained execution state.
 
-Synchronous nested execution propagates one logical owner across nested pools.
-Direct clone and independent-backend calls can therefore reenter permits
-already held by that call chain. Reentrant operations use transient scratch
-buffers and analysis caches rather than re-locking an outer session's engine
-resources.
+Backend execution is non-reentrant. An active managed Rayon scope marks both
+the root call and every owned worker; direct nesting, a spawned or stolen child
+task, and unrelated work submitted to the same active `CpuContext` are rejected
+before acquiring another permit. External-provider execution also rejects
+same-thread nesting.
 
-That owner is deliberately not inherited as permission by parallel Rayon child
-tasks. A backend call from a spawned or stolen child task, or from unrelated
-work submitted to the same active `CpuContext`, is rejected immediately. If
-parallel siblings shared the owner's permission, they could enter the same
-engine resources or an external BLAS provider concurrently and defeat the
-process-wide exclusion contract. Separate logical executions remain governed
-by process-wide overlap and provider exclusion.
+This intentionally does not infer permission from an execution owner. During a
+cross-pool wait Rayon may schedule a parallel sibling on the same OS worker as
+the direct call chain, so thread-local identity cannot distinguish those cases.
+Treating that sibling as reentrant could enter overlapping engine resources or
+an external BLAS provider concurrently. Separate top-level executions remain
+governed by process-wide overlap and provider exclusion.
 
 The stable public identity is `CpuBackendKind::{Faer, Blas}`. Concrete provider
 names are diagnostic strings, not dispatch or compatibility keys.

--- a/docs/design/cpu-backend-execution.md
+++ b/docs/design/cpu-backend-execution.md
@@ -23,5 +23,12 @@ Host operations, native operations, and session-capable FFI operations.
 Non-session extension runtimes are boundaries. Cache ownership follows engine
 ownership so clone handles do not duplicate retained execution state.
 
+Synchronous nested execution propagates one logical owner across Rayon pools,
+so clone and independent-backend work can reenter permits already held by that
+execution. Reentrant operations use transient scratch buffers and analysis
+caches rather than re-locking an outer session's engine resources. Separate
+logical executions remain governed by process-wide overlap and provider
+exclusion.
+
 The stable public identity is `CpuBackendKind::{Faer, Blas}`. Concrete provider
 names are diagnostic strings, not dispatch or compatibility keys.

--- a/docs/design/cpu-backend-execution.md
+++ b/docs/design/cpu-backend-execution.md
@@ -23,13 +23,19 @@ Host operations, native operations, and session-capable FFI operations.
 Non-session extension runtimes are boundaries. Cache ownership follows engine
 ownership so clone handles do not duplicate retained execution state.
 
-Synchronous nested execution broadcasts one logical owner to every worker in
-the active Rayon pool and propagates it across nested pools. Clone and
-independent-backend work, including work in stolen child tasks, can therefore
-reenter permits already held by that execution. Reentrant operations use
-transient scratch buffers and analysis caches rather than re-locking an outer
-session's engine resources. Separate logical executions remain governed by
-process-wide overlap and provider exclusion.
+Synchronous nested execution propagates one logical owner across nested pools.
+Direct clone and independent-backend calls can therefore reenter permits
+already held by that call chain. Reentrant operations use transient scratch
+buffers and analysis caches rather than re-locking an outer session's engine
+resources.
+
+That owner is deliberately not inherited as permission by parallel Rayon child
+tasks. A backend call from a spawned or stolen child task, or from unrelated
+work submitted to the same active `CpuContext`, is rejected immediately. If
+parallel siblings shared the owner's permission, they could enter the same
+engine resources or an external BLAS provider concurrently and defeat the
+process-wide exclusion contract. Separate logical executions remain governed
+by process-wide overlap and provider exclusion.
 
 The stable public identity is `CpuBackendKind::{Faer, Blas}`. Concrete provider
 names are diagnostic strings, not dispatch or compatibility keys.

--- a/docs/design/cpu-backend-execution.md
+++ b/docs/design/cpu-backend-execution.md
@@ -23,12 +23,13 @@ Host operations, native operations, and session-capable FFI operations.
 Non-session extension runtimes are boundaries. Cache ownership follows engine
 ownership so clone handles do not duplicate retained execution state.
 
-Synchronous nested execution propagates one logical owner across Rayon pools,
-so clone and independent-backend work can reenter permits already held by that
-execution. Reentrant operations use transient scratch buffers and analysis
-caches rather than re-locking an outer session's engine resources. Separate
-logical executions remain governed by process-wide overlap and provider
-exclusion.
+Synchronous nested execution broadcasts one logical owner to every worker in
+the active Rayon pool and propagates it across nested pools. Clone and
+independent-backend work, including work in stolen child tasks, can therefore
+reenter permits already held by that execution. Reentrant operations use
+transient scratch buffers and analysis caches rather than re-locking an outer
+session's engine resources. Separate logical executions remain governed by
+process-wide overlap and provider exclusion.
 
 The stable public identity is `CpuBackendKind::{Faer, Blas}`. Concrete provider
 names are diagnostic strings, not dispatch or compatibility keys.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,5 +1,9 @@
 # Getting Started
 
+For multi-socket hosts, containers, or schedulers with restricted cpusets, read
+[CPU Execution and NUMA Placement](../guides/cpu-execution.md) before choosing
+between managed faer placement and an external BLAS provider.
+
 tenferro supports tensor computation without autodiff, immediate execution with
 optional `backward()` on scalar losses, functional eager `grad`, `vjp`, and
 `jvp`, traced graph execution, einsum, linear algebra, and CUDA execution

--- a/docs/guides/cpu-execution.md
+++ b/docs/guides/cpu-execution.md
@@ -1,0 +1,113 @@
+# CPU Execution and NUMA Placement
+
+tenferro distinguishes a CPU thread count from CPU affinity. A thread count
+limits parallelism; affinity determines which logical CPUs may execute those
+threads. On NUMA machines, setting only the count does not keep work in one
+memory-locality domain.
+
+## What a NUMA Node Means
+
+For this API, a NUMA node is an operating-system topology domain identified by
+its sparse OS node ID and its set of logical CPUs. A node is usable only through
+the intersection of that OS CPU set with the process affinity mask. Therefore:
+
+- `NumaNodeId(2)` means OS node 2, not the third entry in a dense array;
+- CPUs excluded by a container, scheduler, cpuset, or `taskset` are never added
+  back by tenferro;
+- an OS node with an empty process-visible intersection is unavailable; and
+- `AllAllowed` means the complete process affinity mask, not every CPU installed
+  in the host.
+
+Inspect the process-visible topology before selecting a node:
+
+```rust
+use tenferro_cpu::{CpuBackend, CpuPlacement};
+
+let backend = CpuBackend::new();
+for node in backend.topology().nodes() {
+    println!("OS node {}: {:?}", node.id(), node.cpus().as_usize_vec());
+}
+
+let all = backend.for_placement(CpuPlacement::AllAllowed)?;
+println!("{:?}", all.execution_info());
+# Ok::<(), tenferro_cpu::CpuPlacementError>(())
+```
+
+## Managed Placement Is a faer Contract
+
+`CpuPlacement::NumaNode` and `CpuPlacement::AllAllowed` are supported by
+`CpuBackendKind::Faer`. tenferro creates a fixed Rayon engine for the resolved
+CPU set and pins every worker when the engine is constructed. `CpuBackend`
+clones are cheap handles: they share topology, engines, arbitration, and
+engine-owned caches.
+
+```rust
+use tenferro_cpu::{CpuBackend, CpuBackendKind, CpuPlacement};
+
+let coordinator = CpuBackend::with_threads_and_kind(4, CpuBackendKind::Faer)?;
+if let Some(node) = coordinator.topology().nodes().first() {
+    let local = coordinator.for_placement(CpuPlacement::NumaNode(node.id()))?;
+    let another_handle = local.clone();
+    assert_eq!(local.resolved_placement(), another_handle.resolved_placement());
+}
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+`Auto` resolves to `AllAllowed` for faer. An all-allowed engine can use all CPUs
+granted to the process, so splitting work by NUMA node does not prevent a
+separate all-node computation. Overlapping placements are serialized by the
+shared coordinator; disjoint node placements may execute concurrently.
+
+## External BLAS Providers
+
+OpenBLAS, Intel MKL, Apple Accelerate, and OpenMP-backed BLAS implementations
+own their worker creation and affinity. Their thread-count settings do not prove
+that workers stay inside a requested tenferro CPU set. Consequently external
+BLAS backends accept only `CpuPlacement::Auto`; explicit `NumaNode` and
+`AllAllowed` requests return `CpuPlacementError`.
+
+`Auto` for `CpuBackendKind::Blas` uses provider-default execution under an
+exclusive coordinator permit. This prevents tenferro-managed CPU work from
+overlapping a provider call whose worker CPU set is unknown. Provider variables
+such as `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, and `OMP_NUM_THREADS` still
+control counts where supported, but they do not upgrade the provider to a
+tenferro-managed affinity contract.
+
+If strict NUMA placement is required, select `CpuBackendKind::Faer`. If an
+application configures and pins a BLAS provider independently, that remains an
+application/provider responsibility outside the tenferro placement guarantee.
+
+## Where Elementwise Rayon Runs
+
+For a faer backend, elementwise, analytic, reduction, structural, indexing, and
+faer GEMM work execute inside the selected fixed Rayon engine. With the default
+`Auto` placement this is the all-allowed process CPU set; with `NumaNode(id)` it
+is that node's process-visible CPU set.
+
+For a BLAS backend, a graph keeps one exclusive coordinator permit. Native
+tenferro segments enter the pinned all-allowed Rayon engine, while BLAS/LAPACK
+provider calls execute outside that Rayon pool. Thus an elementwise operation
+adjacent to BLAS does not run on an unconstrained global Rayon pool, and the
+provider is not nested inside tenferro's Rayon workers.
+
+Supported Host instructions, native instructions, and session-capable GEMM FFI
+instructions share one backend session. Extension runtimes that cannot execute
+through `BackendSession` remain explicit session boundaries.
+
+## Diagnostics
+
+Use `CpuBackend::execution_info()` for logs. `CpuBackendKind::{Faer, Blas}` is
+the stable public provider identity. `provider_diagnostic()` may mention a
+compiled provider such as OpenBLAS or a runtime-injected provider, but that
+string is diagnostic only and may change.
+
+```rust
+let backend = tenferro_cpu::CpuBackend::new();
+let info = backend.execution_info();
+println!("kind={:?} provider={}", info.backend_kind(), info.provider_diagnostic());
+println!("requested={:?} resolved={:?}",
+    info.requested_placement(), info.resolved_placement());
+```
+
+See [Parallelism and Caching](parallelism-and-caching.md) for thread budgets,
+cache limits, and oversubscription guidance.

--- a/docs/guides/cpu-execution.md
+++ b/docs/guides/cpu-execution.md
@@ -68,12 +68,20 @@ if let Some(node) = coordinator.topology().nodes().first() {
 granted to the process, so splitting work by NUMA node does not prevent a
 separate all-node computation. Overlapping placements are serialized by the
 process-wide arbiter, including placements created by independently constructed
-backends; disjoint node placements may execute concurrently. Synchronous nested
-execution carries one logical owner across Rayon pools, so nested clone or
-independent-backend work, including a backend call from a stolen Rayon child
-task, cannot wait on its own permit. Reentrant operations use transient scratch
-buffers and analysis caches instead of re-locking an outer engine session's
-resources. Other logical executions remain subject to the overlap rules.
+backends; disjoint node placements may execute concurrently. Synchronous direct
+nesting carries one logical owner across Rayon pools, so nested clone or
+independent-backend work cannot wait on its own permit. Reentrant operations use
+transient scratch buffers and analysis caches instead of re-locking an outer
+engine session's resources. Other logical executions remain subject to the
+overlap rules.
+
+Do not call a CPU backend from a parallel Rayon child task spawned inside
+`CpuBackend::install`, or from unrelated work submitted to the same active
+`CpuContext`. tenferro rejects that re-entry with a panic instead of allowing a
+deadlock or concurrent access to one engine or external provider. Finish the
+outer backend execution before launching those backend calls, or give each
+concurrent top-level operation a disjoint managed placement. Ordinary Rayon
+work that does not re-enter a CPU backend remains supported.
 
 ## External BLAS Providers
 

--- a/docs/guides/cpu-execution.md
+++ b/docs/guides/cpu-execution.md
@@ -35,6 +35,17 @@ println!("{:?}", all.execution_info());
 
 ## Managed Placement Is a faer Contract
 
+The initial capability matrix is deliberately conservative:
+
+| Runtime CPU provider | `Auto` | `NumaNode(id)` | `AllAllowed` |
+| --- | --- | --- | --- |
+| faer and tenferro-native kernels | managed all-allowed engine | managed pinned node engine | managed pinned all-allowed engine |
+| OpenBLAS, MKL, Accelerate, or another external BLAS | provider-default, process-wide exclusive | unsupported | unsupported |
+
+On platforms where tenferro cannot set and verify worker affinity, faer's
+`Auto` mode uses an unpinned compatibility context. Explicit managed placement
+still returns an error instead of silently weakening the request.
+
 `CpuPlacement::NumaNode` and `CpuPlacement::AllAllowed` are supported by
 `CpuBackendKind::Faer`. tenferro creates a fixed Rayon engine for the resolved
 CPU set and pins every worker when the engine is constructed. `CpuBackend`
@@ -66,8 +77,8 @@ that workers stay inside a requested tenferro CPU set. Consequently external
 BLAS backends accept only `CpuPlacement::Auto`; explicit `NumaNode` and
 `AllAllowed` requests return `CpuPlacementError`.
 
-`Auto` for `CpuBackendKind::Blas` uses provider-default execution under an
-exclusive coordinator permit. This prevents tenferro-managed CPU work from
+`Auto` for `CpuBackendKind::Blas` uses provider-default execution under a
+process-wide exclusive permit. This prevents tenferro-managed CPU work from
 overlapping a provider call whose worker CPU set is unknown. Provider variables
 such as `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, and `OMP_NUM_THREADS` still
 control counts where supported, but they do not upgrade the provider to a
@@ -76,6 +87,19 @@ tenferro-managed affinity contract.
 If strict NUMA placement is required, select `CpuBackendKind::Faer`. If an
 application configures and pins a BLAS provider independently, that remains an
 application/provider responsibility outside the tenferro placement guarantee.
+
+## CPU Affinity Is Not NUMA Memory Placement
+
+Pinned workers restrict where computation may run. They do not make tensor
+allocation NUMA-local, choose a first-touch policy, migrate existing pages, or
+configure page interleaving. Input and output pages may therefore remain remote
+from the selected node. Applications that require memory locality must arrange
+allocation/first-touch or OS memory policy separately and measure the result on
+their deployment topology.
+
+The reduced worker budget is spread deterministically over the logical CPU IDs
+in a domain. This is not a promise to prefer physical cores over SMT siblings;
+tenferro does not currently infer core/sibling topology for that selection.
 
 ## Where Elementwise Rayon Runs
 
@@ -105,7 +129,8 @@ string is diagnostic only and may change.
 let backend = tenferro_cpu::CpuBackend::new();
 let info = backend.execution_info();
 println!("kind={:?} provider={}", info.backend_kind(), info.provider_diagnostic());
-println!("requested={:?} resolved={:?}",
+println!("mode={:?} workers={}", info.execution_mode(), info.worker_count());
+println!("topology={:?} requested={:?} resolved={:?}", info.topology(),
     info.requested_placement(), info.resolved_placement());
 ```
 

--- a/docs/guides/cpu-execution.md
+++ b/docs/guides/cpu-execution.md
@@ -67,7 +67,10 @@ if let Some(node) = coordinator.topology().nodes().first() {
 `Auto` resolves to `AllAllowed` for faer. An all-allowed engine can use all CPUs
 granted to the process, so splitting work by NUMA node does not prevent a
 separate all-node computation. Overlapping placements are serialized by the
-shared coordinator; disjoint node placements may execute concurrently.
+process-wide arbiter, including placements created by independently constructed
+backends; disjoint node placements may execute concurrently. Synchronous nested
+work on the same thread is treated as reentrant so a backend call cannot wait on
+its own permit. Other threads remain subject to the overlap rules.
 
 ## External BLAS Providers
 
@@ -87,6 +90,10 @@ tenferro-managed affinity contract.
 If strict NUMA placement is required, select `CpuBackendKind::Faer`. If an
 application configures and pins a BLAS provider independently, that remains an
 application/provider responsibility outside the tenferro placement guarantee.
+
+Fallible backend constructors return `CpuBackendError`. Configuration failures
+appear as `CpuBackendError::Tensor`, while topology discovery and engine
+placement failures remain inspectable through `CpuBackendError::placement_error`.
 
 ## CPU Affinity Is Not NUMA Memory Placement
 

--- a/docs/guides/cpu-execution.md
+++ b/docs/guides/cpu-execution.md
@@ -69,8 +69,11 @@ granted to the process, so splitting work by NUMA node does not prevent a
 separate all-node computation. Overlapping placements are serialized by the
 process-wide arbiter, including placements created by independently constructed
 backends; disjoint node placements may execute concurrently. Synchronous nested
-work on the same thread is treated as reentrant so a backend call cannot wait on
-its own permit. Other threads remain subject to the overlap rules.
+execution carries one logical owner across Rayon pools, so nested clone or
+independent-backend work cannot wait on its own permit. Reentrant operations use
+transient scratch buffers and analysis caches instead of re-locking an outer
+engine session's resources. Other logical executions remain subject to the
+overlap rules.
 
 ## External BLAS Providers
 

--- a/docs/guides/cpu-execution.md
+++ b/docs/guides/cpu-execution.md
@@ -68,20 +68,18 @@ if let Some(node) = coordinator.topology().nodes().first() {
 granted to the process, so splitting work by NUMA node does not prevent a
 separate all-node computation. Overlapping placements are serialized by the
 process-wide arbiter, including placements created by independently constructed
-backends; disjoint node placements may execute concurrently. Synchronous direct
-nesting carries one logical owner across Rayon pools, so nested clone or
-independent-backend work cannot wait on its own permit. Reentrant operations use
-transient scratch buffers and analysis caches instead of re-locking an outer
-engine session's resources. Other logical executions remain subject to the
-overlap rules.
+backends; disjoint node placements may execute concurrently. Other top-level
+executions remain subject to these overlap rules.
 
-Do not call a CPU backend from a parallel Rayon child task spawned inside
-`CpuBackend::install`, or from unrelated work submitted to the same active
-`CpuContext`. tenferro rejects that re-entry with a panic instead of allowing a
-deadlock or concurrent access to one engine or external provider. Finish the
-outer backend execution before launching those backend calls, or give each
-concurrent top-level operation a disjoint managed placement. Ordinary Rayon
-work that does not re-enter a CPU backend remains supported.
+CPU backend execution is not reentrant. Do not call a backend clone or another
+CPU backend directly from `CpuBackend::install` or a backend session, and do not
+make backend calls from Rayon tasks spawned inside one. A managed scope rejects
+same-thread, spawned, stolen, and shared-context re-entry with a panic before a
+second permit is acquired. Work moved to an unrelated executor cannot always
+inherit that diagnostic marker and may instead wait for the outer permit, so
+waiting for it from the outer execution can deadlock. Finish the outer backend
+execution before launching new top-level backend calls. Ordinary Rayon work
+that does not re-enter a CPU backend remains supported.
 
 ## External BLAS Providers
 

--- a/docs/guides/cpu-execution.md
+++ b/docs/guides/cpu-execution.md
@@ -70,10 +70,10 @@ separate all-node computation. Overlapping placements are serialized by the
 process-wide arbiter, including placements created by independently constructed
 backends; disjoint node placements may execute concurrently. Synchronous nested
 execution carries one logical owner across Rayon pools, so nested clone or
-independent-backend work cannot wait on its own permit. Reentrant operations use
-transient scratch buffers and analysis caches instead of re-locking an outer
-engine session's resources. Other logical executions remain subject to the
-overlap rules.
+independent-backend work, including a backend call from a stolen Rayon child
+task, cannot wait on its own permit. Reentrant operations use transient scratch
+buffers and analysis caches instead of re-locking an outer engine session's
+resources. Other logical executions remain subject to the overlap rules.
 
 ## External BLAS Providers
 

--- a/docs/guides/parallelism-and-caching.md
+++ b/docs/guides/parallelism-and-caching.md
@@ -4,6 +4,10 @@ tenferro keeps CPU parallelism and execution caches explicit. Use this page to
 control CPU thread counts, avoid provider oversubscription, and release cached
 memory in long-running processes.
 
+Thread count is not CPU affinity. For NUMA-node definitions, pinned engines,
+external BLAS safety, and the location of elementwise Rayon work, see
+[CPU Execution and NUMA Placement](cpu-execution.md).
+
 For tensor memory layout and column-major buffers, see
 [Memory Order](memory-order.md). That is part of the tensor data model, not the
 parallelism contract.
@@ -80,9 +84,9 @@ pool before dispatching tensor-sized kernels.
 
 ## BLAS And LAPACK Threads
 
-For `cpu-blas`, `CpuBackend::with_threads(n)` controls tenferro's CPU context,
-but the linked BLAS/LAPACK provider has its own thread controls. Set provider
-thread variables before process start:
+For `cpu-blas`, `CpuBackend::with_threads(n)` controls tenferro-native work, but
+the linked BLAS/LAPACK provider has its own thread controls. Set provider thread
+variables before process start when appropriate:
 
 ```bash
 RAYON_NUM_THREADS=4 \
@@ -99,6 +103,11 @@ uses `OPENBLAS_NUM_THREADS`; Intel MKL uses `MKL_NUM_THREADS`; Accelerate uses
 `OMP_NUM_THREADS`. For provider discovery at build time, non-standard OpenBLAS
 installs commonly need `OPENBLAS_LIB_DIR`; non-standard MKL installs commonly
 need `MKLROOT` or `MKL_LIB_DIR`.
+
+These variables limit thread counts; they do not let tenferro verify or enforce
+provider worker affinity. External BLAS therefore supports only
+`CpuPlacement::Auto` and executes under an exclusive coordinator permit. Use
+the faer backend when tenferro-managed NUMA placement is required.
 
 ## Avoid Oversubscription
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ compilation, CUDA, or experimental WebGPU only when the workflow needs them.
 | Understanding direct, eager, and traced execution | [Execution Models](guides/execution-models.md) |
 | Column-major storage and row-major import/export | [Memory Order](guides/memory-order.md) |
 | CPU, CUDA, and experimental WebGPU backend behavior | [Devices and GPU](guides/devices-and-gpu.md) |
+| CPU affinity, NUMA placement, faer, and external BLAS behavior | [CPU Execution and NUMA Placement](guides/cpu-execution.md) |
 | Static-shaped StableHLO and PJRT plugin loading | [XLA and PJRT](guides/xla.md) |
 | Runtime-dependent dimensions in traced graphs | [Dynamic and symbolic shapes](design/dynamic-symbolic-shapes.md) |
 | API documentation for every crate | [API Reference](api/index.md) |

--- a/docs/superpowers/plans/2026-07-14-numa-cpu-execution.md
+++ b/docs/superpowers/plans/2026-07-14-numa-cpu-execution.md
@@ -1,0 +1,636 @@
+# NUMA-Aware CPU Execution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add managed NUMA placement for faer/native CPU graphs, shared cloneable CPU engine coordination, exclusive unmanaged BLAS execution, and rendered user documentation.
+
+**Architecture:** `CpuBackend` becomes a cloneable handle over shared topology, engine, and arbitration state. A placement-bound handle selects a pinned NUMA or lazy all-allowed Rayon engine for faer/native execution; BLAS-backed handles reject explicit placement and run under one exclusive provider reservation, entering the all-allowed native pool only for native segments. Runtime execution keeps one backend session across supported backend, Host, and FFI instructions.
+
+**Tech Stack:** Rust, Rayon custom worker spawning, Linux `sched_getaffinity`/`sched_setaffinity`, Linux sysfs NUMA topology, `thiserror`, fixture-based unit tests, Cargo doctests, MkDocs user guides, Criterion benchmarks.
+
+**Design:** `docs/superpowers/specs/2026-07-14-numa-cpu-execution-design.md`
+
+---
+
+## File map
+
+New CPU modules:
+
+- `crates/tenferro-cpu/src/topology.rs`: CPU/node IDs, canonical CPU sets, topology resolution, Linux discovery, and public diagnostics.
+- `crates/tenferro-cpu/src/topology/tests.rs`: parser and injected-topology fixtures.
+- `crates/tenferro-cpu/src/placement.rs`: placement requests, resolved/provider-exclusive modes, capability checks, and typed errors.
+- `crates/tenferro-cpu/src/placement/tests.rs`: provider matrix and non-fallback tests.
+- `crates/tenferro-cpu/src/engine.rs`: pinned Rayon engine, engine-owned buffers/cache, and execution instrumentation.
+- `crates/tenferro-cpu/src/engine/tests.rs`: worker affinity and engine resource tests.
+- `crates/tenferro-cpu/src/arbiter.rs`: overlap-aware permits and provider-exclusive reservation.
+- `crates/tenferro-cpu/src/arbiter/tests.rs`: concurrency, ordering, and unwind release tests.
+- `crates/tenferro-cpu/benches/numa_execution.rs`: opt-in placement/concurrency benchmark and metadata.
+
+Primary modified CPU files:
+
+- `crates/tenferro-cpu/src/affinity.rs`: expose CPU masks and current-thread set/restore helpers instead of count-only discovery.
+- `crates/tenferro-cpu/src/context.rs`: add pinned-pool construction while retaining existing unpinned compatibility construction.
+- `crates/tenferro-cpu/src/backend.rs`: shared backend state, placement-bound handles, aggregate resource APIs, and session routing.
+- `crates/tenferro-cpu/src/exec_session.rs`: engine-owned state and provider/native context transitions.
+- `crates/tenferro-cpu/src/lib.rs`: modules and public exports.
+- `crates/tenferro-cpu/Cargo.toml`: NUMA benchmark target if explicit registration is required.
+
+Runtime/session files:
+
+- `crates/tenferro-tensor/src/backend.rs`: extend backend-session capabilities needed by Host execution without exposing sessions to users.
+- `crates/tenferro-runtime/src/exec.rs`: one session loop for supported backend/Host/FFI instructions.
+- `crates/tenferro-runtime/src/segment.rs`: run fused and boundary segments inside the graph session when supported.
+- `crates/tenferro-runtime/src/graph/executor/tests.rs`: whole-graph session/pool-entry instrumentation.
+
+Documentation:
+
+- `docs/guides/cpu-execution.md`: rendered placement and mixed-provider guide.
+- `docs/getting-started/index.md` and `docs/index.md`: discovery links and concise provider warning.
+- `docs/design/cpu-backend-execution.md`: durable ownership/session architecture.
+- `docs/worklogs/2026-07-14-numa-cpu-execution.md`: implementation record, evidence, and residual risks.
+
+## Task 1: Add canonical topology and placement contracts
+
+**Files:**
+
+- Create: `crates/tenferro-cpu/src/topology.rs`
+- Create: `crates/tenferro-cpu/src/topology/tests.rs`
+- Create: `crates/tenferro-cpu/src/placement.rs`
+- Create: `crates/tenferro-cpu/src/placement/tests.rs`
+- Modify: `crates/tenferro-cpu/src/lib.rs:44-82`
+
+- [ ] **Step 1: Write failing topology and capability tests**
+
+Cover sorted/deduplicated CPU sets, sparse OS node IDs, affinity intersection,
+empty-node removal, overlap rejection, provider capability, and non-fallback:
+
+```rust
+#[test]
+fn topology_intersects_nodes_with_allowed_cpus_without_renumbering() {
+    let allowed = CpuSet::new([8, 9, 10, 11, 12, 13, 14, 15]).unwrap();
+    let topology = CpuTopology::from_discovered(
+        allowed.clone(),
+        [
+            (NumaNodeId::new(2), CpuSet::new([0, 8, 9, 10, 11]).unwrap()),
+            (NumaNodeId::new(7), CpuSet::new([12, 13, 14, 15, 16]).unwrap()),
+            (NumaNodeId::new(9), CpuSet::new([20, 21]).unwrap()),
+        ],
+    ).unwrap();
+
+    assert_eq!(topology.allowed_cpus(), &allowed);
+    assert_eq!(topology.node_ids(), vec![NumaNodeId::new(2), NumaNodeId::new(7)]);
+    assert_eq!(topology.node(NumaNodeId::new(2)).unwrap().cpus().as_slice(), &[8, 9, 10, 11]);
+}
+
+#[test]
+fn explicit_external_provider_placement_never_falls_back() {
+    let topology = two_node_fixture();
+    assert!(matches!(
+        resolve_placement(CpuBackendKind::Blas, CpuPlacement::NumaNode(NumaNodeId::new(0)), &topology),
+        Err(CpuPlacementError::ExternalProviderAffinityUnmanaged { .. })
+    ));
+    assert!(matches!(
+        resolve_placement(CpuBackendKind::Blas, CpuPlacement::AllAllowed, &topology),
+        Err(CpuPlacementError::ExternalProviderAffinityUnmanaged { .. })
+    ));
+    assert_eq!(
+        resolve_placement(CpuBackendKind::Blas, CpuPlacement::Auto, &topology).unwrap(),
+        ResolvedCpuExecution::ProviderDefaultExclusive,
+    );
+}
+```
+
+- [ ] **Step 2: Run the focused tests and confirm missing APIs fail**
+
+Run: `cargo test -p tenferro-cpu topology placement --release`
+
+Expected: FAIL because the modules and types do not exist.
+
+- [ ] **Step 3: Implement minimal public value types and pure resolution**
+
+Define `CpuId`, `NumaNodeId`, `CpuSet`, `CpuNode`, `CpuTopology`,
+`CpuPlacement`, `ResolvedCpuPlacement`, internal `ResolvedCpuExecution`, and
+`CpuPlacementError`. Use sorted `Vec<CpuId>` storage, checked non-empty sets,
+binary-search membership, linear merge intersection/overlap, and public
+`# Examples` for every public item. Do not put provider details below
+`CpuBackendKind::{Faer, Blas}` into the public enum surface.
+
+- [ ] **Step 4: Run focused tests and doctests**
+
+Run: `cargo test -p tenferro-cpu topology placement --release && cargo test -p tenferro-cpu --doc --release`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the contract**
+
+```bash
+git add crates/tenferro-cpu/src/{topology.rs,topology/tests.rs,placement.rs,placement/tests.rs,lib.rs}
+git commit -m "feat(cpu): define NUMA placement contracts"
+```
+
+## Task 2: Discover process CPU sets and Linux NUMA topology
+
+**Files:**
+
+- Modify: `crates/tenferro-cpu/src/affinity.rs`
+- Modify: `crates/tenferro-cpu/src/affinity/tests.rs`
+- Modify: `crates/tenferro-cpu/src/topology.rs`
+- Modify: `crates/tenferro-cpu/src/topology/tests.rs`
+
+- [ ] **Step 1: Add failing parsers and injected discovery tests**
+
+```rust
+#[test]
+fn linux_cpu_list_parser_handles_ranges_gaps_and_whitespace() {
+    assert_eq!(
+        parse_linux_cpu_list("0-3,8,10-11\n").unwrap().as_usize_vec(),
+        vec![0, 1, 2, 3, 8, 10, 11],
+    );
+}
+
+#[test]
+fn discovery_falls_back_to_all_allowed_when_node_files_are_unavailable() {
+    let source = FixtureTopologySource::unavailable(CpuSet::new([4, 5]).unwrap());
+    let topology = discover_from(&source).unwrap();
+    assert!(topology.nodes().is_empty());
+    assert_eq!(topology.allowed_cpus().as_usize_vec(), vec![4, 5]);
+}
+```
+
+- [ ] **Step 2: Confirm the tests fail**
+
+Run: `cargo test -p tenferro-cpu affinity topology --release`
+
+Expected: FAIL for missing mask/parser/discovery functions.
+
+- [ ] **Step 3: Implement mask discovery and the narrow OS source**
+
+Refactor the Linux `sched_getaffinity` loop to return `CpuSet`; retain
+`process_cpu_affinity_count()` as `.len()`. Parse
+`/sys/devices/system/node/node*/cpulist` through a private `TopologySource`
+boundary and pure fixture path. Unsupported OSes return one all-allowed domain.
+Reject malformed lists, empty allowed masks, arithmetic overflow, and overlapping
+usable nodes with typed construction errors.
+
+- [ ] **Step 4: Verify platform-neutral and live invariants**
+
+Run: `cargo test -p tenferro-cpu affinity topology --release`
+
+Expected: PASS on single-node and multi-node hosts.
+
+- [ ] **Step 5: Commit discovery**
+
+```bash
+git add crates/tenferro-cpu/src/{affinity.rs,affinity/tests.rs,topology.rs,topology/tests.rs}
+git commit -m "feat(cpu): discover allowed NUMA domains"
+```
+
+## Task 3: Build verified pinned Rayon contexts
+
+**Files:**
+
+- Modify: `crates/tenferro-cpu/src/affinity.rs`
+- Modify: `crates/tenferro-cpu/src/context.rs`
+- Modify: `crates/tenferro-cpu/src/context/tests.rs`
+- Create: `crates/tenferro-cpu/src/engine.rs`
+- Create: `crates/tenferro-cpu/src/engine/tests.rs`
+- Modify: `crates/tenferro-cpu/src/lib.rs`
+
+- [ ] **Step 1: Write failing construction and observation tests**
+
+```rust
+#[test]
+fn pinned_context_reports_only_assigned_cpus() {
+    let allowed = process_cpu_affinity().unwrap();
+    let selected = CpuSet::new(allowed.as_slice().iter().take(2).copied()).unwrap();
+    let ctx = CpuContext::with_pinned_cpus(selected.clone(), selected.len()).unwrap();
+    let observed = ctx.install(|| {
+        (0..4096usize)
+            .into_par_iter()
+            .map(|_| current_cpu().unwrap())
+            .collect::<BTreeSet<_>>()
+    });
+    assert!(observed.iter().all(|cpu| selected.contains(*cpu)));
+}
+
+#[test]
+fn pin_failure_aborts_engine_construction() {
+    let source = FailingAffinitySetter::new();
+    assert!(matches!(
+        CpuContext::with_pinned_cpus_using(CpuSet::new([0]).unwrap(), 1, source),
+        Err(CpuContextError::WorkerPinning { .. })
+    ));
+}
+```
+
+- [ ] **Step 2: Confirm tests fail**
+
+Run: `cargo test -p tenferro-cpu pinned worker_affinity --release`
+
+Expected: FAIL for missing pinned construction.
+
+- [ ] **Step 3: Implement worker pinning and verification**
+
+Use Rayon's custom `spawn_handler`. Each OS worker sets its affinity before
+`ThreadBuilder::run`, verifies the resulting mask contains only its assigned
+logical CPU, and reports startup through a channel. Constructor success requires
+one successful report per worker. Always use a real one-worker pool for pinned
+engines; retain the direct-call one-thread behavior only for legacy unpinned
+`CpuContext::with_threads(1)`.
+
+Implement `CpuEngine` with immutable placement/context and a mutex-protected
+`EngineResources { buffers, gemm_analysis_cache }`. Default workers equal CPU
+set length; an explicit budget uses `min(budget, cpus.len())`.
+
+- [ ] **Step 4: Run focused tests repeatedly**
+
+Run: `cargo test -p tenferro-cpu context engine --release -- --test-threads=1`
+
+Expected: PASS with every live observation inside the selected CPU set.
+
+- [ ] **Step 5: Commit pinned engines**
+
+```bash
+git add crates/tenferro-cpu/src/{affinity.rs,context.rs,context/tests.rs,engine.rs,engine/tests.rs,lib.rs}
+git commit -m "feat(cpu): build pinned execution engines"
+```
+
+## Task 4: Add overlap-aware resource arbitration
+
+**Files:**
+
+- Create: `crates/tenferro-cpu/src/arbiter.rs`
+- Create: `crates/tenferro-cpu/src/arbiter/tests.rs`
+- Modify: `crates/tenferro-cpu/src/lib.rs`
+
+- [ ] **Step 1: Write failing concurrency and unwind tests**
+
+```rust
+#[test]
+fn disjoint_domains_run_together_but_all_allowed_waits() {
+    let arbiter = Arc::new(ResourceArbiter::new());
+    let node0 = arbiter.acquire(CpuSet::new([0, 1]).unwrap()).unwrap();
+    let node1 = arbiter.try_acquire(CpuSet::new([2, 3]).unwrap()).unwrap();
+    assert!(arbiter.try_acquire(CpuSet::new([0, 1, 2, 3]).unwrap()).is_none());
+    drop((node0, node1));
+    assert!(arbiter.try_acquire(CpuSet::new([0, 1, 2, 3]).unwrap()).is_some());
+}
+
+#[test]
+fn panic_releases_provider_exclusive_reservation() {
+    let arbiter = ResourceArbiter::new();
+    let _ = catch_unwind(AssertUnwindSafe(|| {
+        let _permit = arbiter.acquire_provider_exclusive().unwrap();
+        panic!("forced");
+    }));
+    assert!(arbiter.try_acquire_provider_exclusive().is_some());
+}
+```
+
+- [ ] **Step 2: Confirm tests fail**
+
+Run: `cargo test -p tenferro-cpu arbiter --release`
+
+Expected: FAIL for missing arbiter.
+
+- [ ] **Step 3: Implement fair stable arbitration**
+
+Use one `Mutex<ArbiterState>` plus `Condvar`. Track monotonically increasing
+request IDs, active CPU sets, and the provider-exclusive flag. Grant a request
+only when it is the oldest compatible waiter; this stable ordering prevents
+starvation and multi-resource deadlock. Permit `Drop` removes active state and
+notifies all waiters. Poisoning maps to a typed backend failure, never unwraps.
+
+- [ ] **Step 4: Run concurrency tests under repetition**
+
+Run: `for i in $(seq 1 20); do cargo test -p tenferro-cpu arbiter --release || exit 1; done`
+
+Expected: all 20 runs PASS without hangs.
+
+- [ ] **Step 5: Commit arbitration**
+
+```bash
+git add crates/tenferro-cpu/src/{arbiter.rs,arbiter/tests.rs,lib.rs}
+git commit -m "feat(cpu): arbitrate overlapping CPU domains"
+```
+
+## Task 5: Refactor `CpuBackend` into a cloneable placement handle
+
+**Files:**
+
+- Modify: `crates/tenferro-cpu/src/backend.rs`
+- Modify: `crates/tenferro-cpu/src/backend/tests.rs`
+- Modify: `crates/tenferro-cpu/src/exec_session.rs`
+- Modify: `crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs`
+- Modify: `crates/tenferro-cpu/src/tests/cpu_tests/context.rs`
+
+- [ ] **Step 1: Write failing handle-sharing and capability tests**
+
+```rust
+#[test]
+fn clones_share_registry_arbiter_and_aggregate_resources() {
+    let backend = CpuBackend::from_topology_for_test(two_node_topology(), CpuBackendKind::Faer).unwrap();
+    let node0 = backend.for_placement(CpuPlacement::NumaNode(NumaNodeId::new(0))).unwrap();
+    let clone = node0.clone();
+    assert_eq!(node0.coordinator_id(), clone.coordinator_id());
+    assert_eq!(node0.resolved_placement(), clone.resolved_placement());
+}
+
+#[test]
+fn blas_rejects_explicit_placement_but_auto_is_exclusive() {
+    let backend = CpuBackend::from_topology_for_test(two_node_topology(), CpuBackendKind::Blas).unwrap();
+    assert!(backend.for_placement(CpuPlacement::AllAllowed).is_err());
+    assert_eq!(backend.resolved_execution(), ResolvedCpuExecution::ProviderDefaultExclusive);
+}
+```
+
+- [ ] **Step 2: Confirm tests fail**
+
+Run: `cargo test -p tenferro-cpu backend::tests::clone placement --release`
+
+Expected: FAIL because `CpuBackend` is not cloneable or placement-aware.
+
+- [ ] **Step 3: Introduce shared state and migrate constructors**
+
+Replace direct `ctx`/`buffers` ownership with
+`Arc<CpuBackendState> { topology, engines, all_allowed: OnceLock<_>, arbiter,
+kind, thread_budget, buffer_limit }` plus a per-handle requested/resolved
+execution field. Add:
+
+```rust
+pub fn for_placement(&self, placement: CpuPlacement) -> Result<Self, CpuPlacementError>;
+pub fn placement(&self) -> CpuPlacement;
+pub fn resolved_placement(&self) -> Option<&ResolvedCpuPlacement>;
+pub fn topology(&self) -> &CpuTopology;
+pub fn supports_placement(&self, placement: CpuPlacement) -> bool;
+```
+
+Keep existing constructors and `kind()` behavior. Aggregate buffer stats and
+clear/limit operations across initialized engines without holding more than one
+engine lock at a time. `linalg_context()` resolves the current managed engine
+and is available only while a session owns it; remove any helper that could
+bypass placement arbitration.
+
+- [ ] **Step 4: Route direct operations through one engine permit/session**
+
+Make `with_backend_session_cached` resolve once, acquire one permit, lock one
+engine resource owner, enter the selected pool, and construct `CpuExecSession`.
+Provider-default execution acquires the exclusive reservation and uses the lazy
+all-allowed engine for native delegated methods while provider methods execute
+outside Rayon.
+
+- [ ] **Step 5: Run CPU tests for faer and BLAS feature shapes**
+
+Run:
+
+```bash
+cargo test -p tenferro-cpu --features cpu-faer --release
+cargo test -p tenferro-cpu --no-default-features --features cpu-blas --release
+cargo check -p tenferro-cpu --no-default-features --features cpu-faer,cpu-blas
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the backend handle migration**
+
+```bash
+git add crates/tenferro-cpu/src/{backend.rs,backend/tests.rs,exec_session.rs,tests/cpu_tests/backend_misc.rs,tests/cpu_tests/context.rs}
+git commit -m "refactor(cpu): share NUMA engine coordination"
+```
+
+## Task 6: Keep one managed session across graph boundaries
+
+**Files:**
+
+- Modify: `crates/tenferro-tensor/src/backend.rs`
+- Modify: `crates/tenferro-runtime/src/exec.rs`
+- Modify: `crates/tenferro-runtime/src/segment.rs`
+- Modify: `crates/tenferro-runtime/src/graph/executor/tests.rs`
+- Modify: `crates/tenferro-cpu/src/exec_session.rs`
+- Modify: `crates/tenferro-cpu/src/backend.rs`
+
+- [ ] **Step 1: Add failing whole-graph instrumentation tests**
+
+Create a counting backend/session test proving one session wraps a program with
+ordinary backend operations plus supported Host and exec-session FFI boundaries:
+
+```rust
+#[test]
+fn managed_graph_enters_one_session_across_supported_boundaries() {
+    let (mut executor, counters) = counted_executor();
+    let program = backend_host_exec_ffi_fixture();
+    executor.run(&program).unwrap();
+    assert_eq!(counters.session_entries.load(Ordering::SeqCst), 1);
+    assert_eq!(counters.pool_entries.load(Ordering::SeqCst), 1);
+}
+```
+
+Add a provider-mode test with a native/provider/native fixture and assert one
+exclusive reservation, two native pool entries, and one provider call outside
+Rayon.
+
+- [ ] **Step 2: Confirm current multiple-session behavior fails**
+
+Run: `cargo test -p tenferro-runtime session_entries provider_native_transition --release`
+
+Expected: FAIL with session/pool counts greater than the contract.
+
+- [ ] **Step 3: Extend the internal session surface**
+
+Add the minimum hidden session capabilities needed for Host transfer and
+reclamation. Keep the public user surface unchanged. Implement them for
+`CpuExecSession`, CUDA, WebGPU, and default backend sessions without exposing a
+user-constructed lifetime.
+
+- [ ] **Step 4: Move the program/segment loop inside one session**
+
+Refactor `eval_exec_ir_unsegmented_*` and `eval_exec_segmented_*` so supported
+Host and FFI instructions dispatch through the live session. Fused segments use
+the same session. Unsupported extension runtimes return a clear internal
+capability error or use the documented provider-default transition; they must
+not silently recreate a managed CPU session.
+
+- [ ] **Step 5: Verify runtime and backend suites**
+
+Run:
+
+```bash
+cargo test -p tenferro-runtime --release
+cargo test -p tenferro-cpu --release
+cargo test -p tenferro-ad --release
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit session lifetime changes**
+
+```bash
+git add crates/tenferro-tensor/src/backend.rs crates/tenferro-runtime/src/{exec.rs,segment.rs,graph/executor/tests.rs} crates/tenferro-cpu/src/{exec_session.rs,backend.rs}
+git commit -m "refactor(runtime): keep CPU graph sessions engine-scoped"
+```
+
+## Task 7: Add diagnostics and rendered documentation
+
+**Files:**
+
+- Create: `docs/guides/cpu-execution.md`
+- Modify: `docs/getting-started/index.md`
+- Modify: `docs/index.md`
+- Create: `docs/design/cpu-backend-execution.md`
+- Modify: `crates/tenferro-cpu/src/lib.rs`
+- Modify: `crates/tenferro-cpu/src/backend.rs`
+- Create: `docs/worklogs/2026-07-14-numa-cpu-execution.md`
+
+- [ ] **Step 1: Add public diagnostic contract tests**
+
+Test that formatted topology includes allowed CPUs, sparse node IDs, resolved
+placement/provider-default mode, backend kind, and worker count without relying
+on debug formatting as a machine-readable API.
+
+- [ ] **Step 2: Implement typed diagnostics**
+
+Expose an immutable `CpuExecutionInfo` snapshot from `CpuBackend` with public
+documented fields/accessors for topology, requested/resolved placement,
+backend kind, and worker count. Concrete linked provider identity remains an
+optional diagnostic string, not a stable enum.
+
+- [ ] **Step 3: Write the online guide and durable design document**
+
+The guide must contain the agreed matrix and this mixed-provider flow:
+
+```text
+provider-default exclusive session
+    native segment -> pinned AllAllowed Rayon engine
+    BLAS call      -> outside Rayon, provider-owned workers
+    native segment -> pinned AllAllowed Rayon engine
+```
+
+State explicitly that thread count is not CPU affinity, external providers have
+no explicit placement support, and CPU affinity does not imply NUMA-local
+allocation. Add a runnable faer placement example backed by a doctest or checked
+tutorial source.
+
+- [ ] **Step 4: Verify rendered docs inputs**
+
+Run:
+
+```bash
+cargo doc --workspace --no-deps
+python3 scripts/check-docs-site.py
+python3 scripts/check-doc-snippets.py --check
+python3 scripts/check-api-consistency.py
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 5: Commit docs and diagnostics**
+
+```bash
+git add crates/tenferro-cpu/src/{lib.rs,backend.rs} docs/guides/cpu-execution.md docs/getting-started/index.md docs/index.md docs/design/cpu-backend-execution.md docs/worklogs/2026-07-14-numa-cpu-execution.md
+git commit -m "docs: explain NUMA CPU execution ownership"
+```
+
+## Task 8: Add opt-in NUMA benchmarks and complete local verification
+
+**Files:**
+
+- Create: `crates/tenferro-cpu/benches/numa_execution.rs`
+- Modify: `crates/tenferro-cpu/Cargo.toml`
+- Modify: `docs/worklogs/2026-07-14-numa-cpu-execution.md`
+
+- [ ] **Step 1: Add benchmark metadata and fixture smoke test**
+
+The benchmark must print process allowed CPUs, topology, requested/resolved
+placement, backend kind, worker count, and matrix shape before measuring. It
+must skip with an explanatory message when fewer than two usable nodes exist.
+
+- [ ] **Step 2: Compile the benchmark and run a short smoke sample**
+
+Run:
+
+```bash
+cargo bench -p tenferro-cpu --bench numa_execution --no-run
+cargo bench -p tenferro-cpu --bench numa_execution -- --sample-size 10
+```
+
+Expected: compile succeeds; run either records the three configured cases or
+reports that multi-NUMA hardware is unavailable without failing.
+
+- [ ] **Step 3: Run the repository pre-push checklist**
+
+Run exactly:
+
+```bash
+cargo fmt --all --check
+cargo test --workspace --release
+cargo llvm-cov --workspace --release --json --output-path coverage.json
+python3 scripts/check-coverage.py coverage.json
+cargo doc --workspace --no-deps
+python3 scripts/check-docs-site.py
+python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json
+```
+
+Also run the exact clippy command from the current `.github/workflows` clippy
+job. Fix every finding or document a verified residual hardware limitation in
+the work log.
+
+- [ ] **Step 4: Re-read rules and update the work log evidence**
+
+Re-read `REPOSITORY_RULES.md`; compare every changed file to the CPU threading,
+cache ownership, docs, test organization, and performance rules. Record exact
+commands/results and any unavailable multi-NUMA live evidence.
+
+- [ ] **Step 5: Commit benchmark and verification record**
+
+```bash
+git add crates/tenferro-cpu/benches/numa_execution.rs crates/tenferro-cpu/Cargo.toml docs/worklogs/2026-07-14-numa-cpu-execution.md
+git commit -m "bench(cpu): measure NUMA execution modes"
+```
+
+## Task 9: Review, publish, and merge the PR
+
+**Files:**
+
+- Review: all files changed from `origin/main...HEAD`
+
+- [ ] **Step 1: Run verification again on committed HEAD**
+
+Repeat formatting, workspace release tests, coverage, docs, exact CI clippy,
+and repository rules review on committed `HEAD`. Do not rely on pre-commit
+worktree results.
+
+- [ ] **Step 2: Request code review and address findings**
+
+Use `superpowers:requesting-code-review`, inspect the complete diff against the
+spec and Issue #1345, and fix verified findings with focused commits. Re-run
+affected tests after each fix and the full gate after the last fix.
+
+- [ ] **Step 3: Push and create the PR**
+
+Push `codex/issue-1345-numa-design` and create the PR to `main` with
+`gh pr create`. The body links Issue #1345, the design spec, durable design doc,
+work log, provider-placement limitation, and exact verification evidence.
+
+- [ ] **Step 4: Enable and verify auto-merge**
+
+Run:
+
+```bash
+gh pr merge --auto --squash --delete-branch
+gh pr view --json autoMergeRequest,mergeStateStatus,statusCheckRollup
+```
+
+Expected: auto-merge is enabled and required checks are present.
+
+- [ ] **Step 5: Monitor CI and review state until merge**
+
+Poll PR checks and unresolved review threads. Use `github:gh-fix-ci` for Actions
+failures and `github:gh-address-comments` for actionable review feedback. Make
+focused fixes, push, re-run local affected checks, and restore auto-merge if a
+push disables it.
+
+- [ ] **Step 6: Verify the merged state**
+
+Run `gh pr view --json state,mergedAt,mergeCommit,url` and verify `state` is
+`MERGED`, `mergedAt` is non-null, and the merge commit is reachable from
+`origin/main`. Only then is the requested objective complete.

--- a/docs/superpowers/specs/2026-07-14-numa-cpu-execution-design.md
+++ b/docs/superpowers/specs/2026-07-14-numa-cpu-execution-design.md
@@ -1,0 +1,318 @@
+# NUMA-Aware CPU Execution Design
+
+## Status
+
+This design refines GitHub issue #1345. It defines the initial NUMA-aware
+execution contract for `tenferro-cpu` and deliberately limits explicit CPU
+placement to execution whose parallelism tenferro controls.
+
+## Goals
+
+- Run independent faer/native graphs concurrently on disjoint NUMA nodes.
+- Preserve an execution mode spanning the full CPU set allowed to the process.
+- Pin every tenferro-owned Rayon worker to a known logical CPU.
+- Keep `CpuBackend` as the public coordinator and make clones share one resource
+  registry and arbiter.
+- Keep faer and tenferro-native kernels in the same selected Rayon engine.
+- Preserve existing BLAS execution while making clear that tenferro does not
+  control external-provider worker affinity.
+- Document the execution ownership model in the rendered online docs.
+
+## Non-goals
+
+- NUMA-aware allocation, first-touch placement, page migration, or memory
+  interleaving.
+- Explicit NUMA placement for MKL, OpenBLAS, Accelerate, TBLIS, or another
+  external provider in the initial implementation.
+- Reaching into OpenMP or provider internals to construct per-node worker teams.
+- A fixed mapping from a Rayon task to one worker or core. Workers are pinned;
+  Rayon may still move tasks among workers in the selected engine.
+- Topology hot-plug handling after backend construction.
+
+## NUMA Topology Definition
+
+The OS NUMA node ID remains the public diagnostic identity. IDs are not
+renumbered and may be sparse.
+
+For each discovered OS node, tenferro computes:
+
+```text
+usable_node(id).cpus = os_node(id).cpus ∩ process_allowed_cpus
+```
+
+Empty intersections are discarded. Usable node CPU sets must be pairwise
+disjoint. A topology with overlapping usable node sets is invalid.
+
+CPU IDs identify logical CPUs, including SMT siblings when those logical CPUs
+are allowed. Containers and virtual machines use the topology and affinity
+visible inside that environment, not the host's hidden physical topology.
+
+When NUMA topology discovery is unavailable, tenferro exposes only the
+all-allowed domain. An explicit unknown or unavailable NUMA node request returns
+a typed error and never falls back.
+
+## Placement Model
+
+The public request type distinguishes automatic policy from explicit placement:
+
+```rust
+pub enum CpuPlacement {
+    Auto,
+    NumaNode(NumaNodeId),
+    AllAllowed,
+}
+```
+
+`AllAllowed` means the complete logical-CPU set permitted to the process, not
+all installed CPUs and not a promise that every CPU will be busy. A resolved
+placement carries the concrete CPU set used for pinning and arbitration.
+
+The initial capability matrix is:
+
+| Runtime provider | `Auto` | `NumaNode(id)` | `AllAllowed` |
+| --- | --- | --- | --- |
+| faer plus tenferro-native kernels | supported | supported | supported |
+| BLAS/LAPACK external provider | provider-default exclusive execution | unsupported | unsupported |
+| TBLIS or another external provider | provider-default exclusive execution | unsupported | unsupported |
+
+Only `Auto` may resolve to provider-default execution. Explicit `NumaNode` and
+`AllAllowed` requests must not silently become an unmanaged provider call.
+
+## Backend And Engine Ownership
+
+`CpuBackend` becomes a cheap cloneable handle:
+
+```rust
+pub struct CpuBackend {
+    shared: Arc<CpuBackendState>,
+}
+```
+
+All clones share topology, the engine registry, the resource arbiter, external
+provider synchronization, and engine-owned resource statistics. Cloning does
+not create a Rayon pool or duplicate a buffer/cache owner.
+
+`CpuBackendState` owns:
+
+- the topology snapshot and process-allowed CPU set;
+- one fixed `CpuEngine` for each usable NUMA node;
+- one lazily constructed `AllAllowed` engine;
+- an overlap-aware resource arbiter;
+- synchronization for provider-default exclusive execution.
+
+Each `CpuEngine` owns:
+
+- an immutable execution-domain CPU set;
+- a Rayon pool with every worker pinned and verified;
+- the engine's thread count and faer `Par` policy;
+- a `BufferPool`;
+- a `GemmAnalysisCache`;
+- other placement- or thread-count-dependent tuning state.
+
+Default engine construction uses one worker per logical CPU in the engine CPU
+set. Compatibility constructors with an explicit thread budget cap each
+engine's worker count at that budget and spread the workers deterministically
+over the engine CPU set. They do not create more workers than CPUs in a pinned
+engine. Existing thread-count-only construction continues to work for default
+execution while the placement-aware APIs expose resolved per-engine counts.
+
+The all-allowed engine is lazy so NUMA-local workloads do not create a second
+set of parked workers unless all-allowed native execution is requested.
+
+## Resource Arbitration
+
+The arbiter reasons about CPU-set overlap, not NUMA node numbers:
+
+- disjoint NUMA engines may execute concurrently;
+- one engine initially runs at most one graph at a time;
+- the all-allowed engine conflicts with every NUMA engine;
+- provider-default exclusive execution conflicts with every tenferro CPU
+  engine, even though the provider's exact worker CPU set is unmanaged;
+- acquisition of multiple resources uses stable ordering;
+- errors and panics release every acquired permit.
+
+External-provider synchronization must cover all handles sharing the backend
+state. Synchronization state required solely because an external library owns
+process-wide mutable configuration may be process-wide; engine caches and
+buffers must not become globals.
+
+## Execution Contexts
+
+### Faer/native graph
+
+After resolving placement and acquiring the engine permit, one session remains
+alive for the complete graph. The graph enters the selected Rayon pool once.
+Within that scope:
+
+- faer uses `Par::Seq` for a one-worker engine and `Par::rayon(0)` otherwise;
+- native elementwise, reduction, structural, and other Rayon-backed kernels use
+  the same ambient pool;
+- Host and supported extension/FFI boundaries do not recreate the engine
+  session or re-enter the pool.
+
+### External-provider graph
+
+An external-provider graph uses provider-default exclusive execution and holds
+that permit for the complete graph. It does not claim a public NUMA placement.
+
+Native segments run in the pinned all-allowed Rayon engine. Provider operations
+run outside the Rayon pool so provider-created OpenMP or native workers do not
+inherit a single pinned Rayon worker as their execution context and do not
+create nested parallelism under an active Rayon operation.
+
+The provider-default exclusive permit already reserves the complete tenferro
+CPU domain. Native segments borrow the all-allowed engine's pool and mutable
+resources under that reservation; they do not acquire a second overlapping
+all-allowed permit. This avoids self-conflict while retaining one serialization
+boundary for the graph.
+
+```text
+provider-default exclusive session
+    native segment   -> enter pinned AllAllowed Rayon engine
+    provider call    -> leave Rayon; call provider exclusively
+    native segment   -> enter pinned AllAllowed Rayon engine
+```
+
+The graph owns one permit and one execution session, but may enter the native
+pool once per native segment. The one-pool-entry acceptance criterion applies
+only to faer/native graphs with managed placement.
+
+## Provider Identity
+
+The existing public provider-selection boundary remains:
+
+```rust
+pub enum CpuBackendKind {
+    Faer,
+    Blas,
+}
+```
+
+This NUMA work does not add a public `CpuProvider::{Mkl, OpenBlas, ...}` enum.
+Concrete provider identity may be unavailable with injected symbols and is not
+needed for the initial placement decision.
+
+Internally, execution is classified by capability:
+
+```text
+TenferroRayon    -> managed explicit placement
+ExternalProvider -> provider-default exclusive execution
+```
+
+Public callers may query placement capabilities and topology. Concrete provider
+details may appear as diagnostic text or benchmark metadata, but are not a
+stable enum used for control flow.
+
+## Errors
+
+Unsupported or invalid placement fails before graph execution. Errors distinguish
+at least:
+
+- unknown NUMA node ID;
+- NUMA discovery unavailable;
+- invalid/overlapping topology;
+- worker pinning failure;
+- external provider does not support managed placement;
+- engine construction failure.
+
+An error should include the requested placement, public backend kind, and a
+stable reason category. It must not retry with a different placement unless the
+original request was `Auto`.
+
+## Public Documentation
+
+The implementation PR must add a rendered user guide at
+`docs/guides/cpu-execution.md` and link it from `docs/getting-started/index.md`
+and the docs index/navigation.
+
+The guide must explain:
+
+- OS NUMA node IDs and intersection with process-allowed CPUs;
+- `Auto`, `NumaNode`, `AllAllowed`, and provider-default exclusive execution;
+- the provider/placement capability matrix;
+- where native elementwise kernels execute in a BLAS-backed graph;
+- that thread-count control is not CPU-affinity control;
+- cloneable `CpuBackend` handle semantics;
+- affinity versus NUMA memory placement;
+- typed errors and non-fallback behavior;
+- topology and resolved-placement diagnostics.
+
+Rustdoc for the new public placement, topology, capability, and execution APIs
+must contain compiling, runnable examples. User-facing examples must use public
+direct crates and should verify a deterministic property rather than only print
+diagnostics.
+
+Durable internal architecture belongs in a CPU backend design document under
+`docs/design/`; the implementation PR also requires a work log recording the
+staged migration, verification, and residual provider risks.
+
+## Testing
+
+Topology and arbitration tests use injected fixtures and do not require a
+multi-socket CI host. They cover:
+
+- affinity intersection, empty nodes, sparse IDs, and overlap rejection;
+- disjoint permit coexistence and overlapping permit exclusion;
+- lazy all-allowed construction;
+- clone handles sharing the same arbiter and engines;
+- worker pinning success and failure;
+- release after errors and panics;
+- explicit external-provider placement rejection;
+- `Auto` provider-default resolution;
+- one pool entry for a managed faer/native graph across Host/FFI boundaries;
+- native/provider/native context transitions for an external-provider graph.
+
+Linux-only diagnostics may verify observed worker CPUs remain within their
+engine CPU set. Tests must still pass on single-node and topology-unavailable
+hosts.
+
+## Benchmarks
+
+An opt-in multi-NUMA benchmark compares:
+
+- two concurrent faer/native graphs on disjoint nodes;
+- one faer/native graph on the all-allowed engine;
+- the existing external-provider path under provider-default exclusive
+  execution.
+
+Output reports the process-allowed CPU set, resolved topology, provider kind,
+placement or unmanaged-provider mode, worker/thread count, and problem shape.
+No benchmark may describe external-provider execution as NUMA-pinned without
+verifying every provider worker's affinity.
+
+## Staged Delivery
+
+The work should be split into reviewable PRs or clearly separated commits:
+
+1. placement/topology value types, capability checks, fixture tests, and docs
+   contract without changing execution behavior;
+2. topology discovery and diagnostics;
+3. cloneable backend state, engine registry, and overlap arbiter;
+4. pinned faer/native Rayon engines;
+5. one managed engine session across complete graph execution;
+6. provider-default exclusive mixed-graph execution;
+7. rendered docs, durable design documentation, diagnostics, and benchmarks.
+
+The first behavior-changing PR must preserve existing constructors and ordinary
+BLAS execution. No PR may advertise external-provider NUMA placement merely
+because it can set a provider thread count.
+
+## Acceptance Criteria
+
+- Two managed faer/native graphs execute concurrently on disjoint fixture or
+  hardware NUMA nodes.
+- Every managed Rayon worker is pinned to its engine CPU set.
+- The lazy all-allowed engine supports full-domain faer/native execution and
+  conflicts with every node engine.
+- `CpuBackend` clones share engines and arbitration.
+- Explicit placement for external providers returns a typed error without
+  fallback.
+- External-provider graphs hold a global exclusive permit; native segments use
+  the pinned all-allowed Rayon engine and provider calls occur outside Rayon.
+- Engine-local buffers and analysis caches are not concurrently shared.
+- Managed faer/native graphs create one engine session and enter one pool once,
+  including supported Host/FFI boundaries.
+- Single-node and topology-unavailable hosts retain working default execution.
+- Rendered online docs describe the mixed BLAS/native execution model and the
+  distinction between thread count, affinity, and NUMA memory placement.
+- Required tests, docs checks, coverage checks, and multi-NUMA diagnostics pass.

--- a/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
+++ b/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
@@ -64,12 +64,12 @@ The same review tightened the remaining safety contracts:
 
 - arbitration is process-wide, so independently constructed backends cannot
   overlap an unmanaged external-provider call with any tenferro CPU domain;
-- process-wide arbitration propagates a logical execution owner across Rayon
-  pools for direct synchronous nesting, while backend calls from parallel
-  Rayon child tasks or unrelated work on the active context are rejected so
-  siblings cannot bypass engine or provider exclusion;
-- reentrant operations use transient engine resources so a nested tensor or
-  provider session does not re-lock the outer session's scratch/cache mutex;
+- backend execution is non-reentrant: direct nesting and backend calls from
+  parallel Rayon child tasks or unrelated work on the active context are
+  rejected so scheduler siblings cannot bypass engine or provider exclusion;
+- the managed-scope marker covers both the root call and every owned worker,
+  including the cross-pool wait case where Rayon schedules a sibling on the
+  same OS worker as the apparent direct call chain;
 - fallible constructors expose `CpuBackendError` and preserve typed placement
   and `CpuTopologyError` detail, while only infallible construction may use the
   documented compatibility fallback;
@@ -81,7 +81,7 @@ The same review tightened the remaining safety contracts:
 - typed diagnostics now report topology, worker count, and managed,
   provider-exclusive, or compatibility execution mode.
 
-Focused post-review verification passed for 287 CPU unit tests, fused runtime
+Focused post-review verification passed for 288 CPU unit tests, fused runtime
 owned/value session tests, the provider-inject integration suite, and benchmark
 compilation. A `wasm32-unknown-unknown` portability check stopped in the
 third-party `atomic-wait` crate before compiling tenferro; the unavailable

--- a/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
+++ b/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
@@ -64,9 +64,11 @@ The same review tightened the remaining safety contracts:
 
 - arbitration is process-wide, so independently constructed backends cannot
   overlap an unmanaged external-provider call with any tenferro CPU domain;
-- process-wide arbitration is same-thread reentrant, preventing synchronous
-  nested backend calls from waiting on their own permit while preserving
-  exclusion across threads;
+- process-wide arbitration propagates a logical execution owner across Rayon
+  pools, preventing synchronous nested clone and independent-backend calls from
+  waiting on their own permit while preserving exclusion across executions;
+- reentrant operations use transient engine resources so a nested tensor or
+  provider session does not re-lock the outer session's scratch/cache mutex;
 - fallible constructors expose `CpuBackendError` and preserve typed placement
   and `CpuTopologyError` detail, while only infallible construction may use the
   documented compatibility fallback;
@@ -78,7 +80,7 @@ The same review tightened the remaining safety contracts:
 - typed diagnostics now report topology, worker count, and managed,
   provider-exclusive, or compatibility execution mode.
 
-Focused post-review verification passed for 280 CPU unit tests, fused runtime
+Focused post-review verification passed for 283 CPU unit tests, fused runtime
 owned/value session tests, the provider-inject integration suite, and benchmark
 compilation. A `wasm32-unknown-unknown` portability check stopped in the
 third-party `atomic-wait` crate before compiling tenferro; the unavailable

--- a/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
+++ b/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
@@ -65,9 +65,9 @@ The same review tightened the remaining safety contracts:
 - arbitration is process-wide, so independently constructed backends cannot
   overlap an unmanaged external-provider call with any tenferro CPU domain;
 - process-wide arbitration propagates a logical execution owner across Rayon
-  pools and broadcasts it to every worker, preventing synchronous nested clone,
-  independent-backend, and stolen-child-task calls from waiting on their own
-  permit while preserving exclusion across executions;
+  pools for direct synchronous nesting, while backend calls from parallel
+  Rayon child tasks or unrelated work on the active context are rejected so
+  siblings cannot bypass engine or provider exclusion;
 - reentrant operations use transient engine resources so a nested tensor or
   provider session does not re-lock the outer session's scratch/cache mutex;
 - fallible constructors expose `CpuBackendError` and preserve typed placement
@@ -81,7 +81,7 @@ The same review tightened the remaining safety contracts:
 - typed diagnostics now report topology, worker count, and managed,
   provider-exclusive, or compatibility execution mode.
 
-Focused post-review verification passed for 285 CPU unit tests, fused runtime
+Focused post-review verification passed for 287 CPU unit tests, fused runtime
 owned/value session tests, the provider-inject integration suite, and benchmark
 compilation. A `wasm32-unknown-unknown` portability check stopped in the
 third-party `atomic-wait` crate before compiling tenferro; the unavailable

--- a/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
+++ b/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
@@ -64,8 +64,12 @@ The same review tightened the remaining safety contracts:
 
 - arbitration is process-wide, so independently constructed backends cannot
   overlap an unmanaged external-provider call with any tenferro CPU domain;
-- fallible constructors preserve `CpuTopologyError`, while only infallible
-  construction may use the documented compatibility fallback;
+- process-wide arbitration is same-thread reentrant, preventing synchronous
+  nested backend calls from waiting on their own permit while preserving
+  exclusion across threads;
+- fallible constructors expose `CpuBackendError` and preserve typed placement
+  and `CpuTopologyError` detail, while only infallible construction may use the
+  documented compatibility fallback;
 - unsupported-affinity platforms resolve faer `Auto` to compatibility mode and
   reject explicit managed placement;
 - affinity-mask allocation rejects extreme public CPU IDs using checked,
@@ -74,7 +78,7 @@ The same review tightened the remaining safety contracts:
 - typed diagnostics now report topology, worker count, and managed,
   provider-exclusive, or compatibility execution mode.
 
-Focused post-review verification passed for 276 CPU unit tests, fused runtime
+Focused post-review verification passed for 280 CPU unit tests, fused runtime
 owned/value session tests, the provider-inject integration suite, and benchmark
 compilation. A `wasm32-unknown-unknown` portability check stopped in the
 third-party `atomic-wait` crate before compiling tenferro; the unavailable

--- a/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
+++ b/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
@@ -18,3 +18,21 @@ Verification covers sparse topology parsing, affinity pinning, overlapping and
 disjoint permits, clone sharing, graph session count, Host work inside the
 session, and the BLAS Rayon/provider transition. The online guide is
 `docs/guides/cpu-execution.md`.
+
+The opt-in `numa_execution` benchmark reports allowed CPUs, topology,
+requested/resolved placement, stable backend kind, diagnostic provider text,
+worker count, and problem shape. It compares concurrent disjoint-node managed
+sessions, an all-allowed session, and (when compiled and linked)
+provider-default exclusive execution; it exits successfully with an
+explanation on single-node hosts. The CPU crate benchmark uses the same
+multi-op `BackendSession` boundary as compiled graph execution without adding a
+reverse dev-dependency from `tenferro-cpu` to `tenferro-runtime`.
+
+Local benchmark verification on 2026-07-14:
+
+- `cargo bench -p tenferro-cpu --bench numa_execution --no-run` passed.
+- `cargo bench -p tenferro-cpu --bench numa_execution -- --sample-size 10`
+  passed and reported a skip because the process-visible topology contained one
+  usable node (64 allowed logical CPUs). Live two-node timing evidence is
+  therefore unavailable in this environment; fixture/unit tests cover sparse
+  multi-node resolution and disjoint arbitration.

--- a/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
+++ b/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
@@ -21,10 +21,11 @@ session, and the BLAS Rayon/provider transition. The online guide is
 
 The opt-in `numa_execution` benchmark reports allowed CPUs, topology,
 requested/resolved placement, stable backend kind, diagnostic provider text,
-worker count, and problem shape. It compares concurrent disjoint-node managed
+worker count, and problem shape. It covers 64, 256, and 512 square matrices at
+one worker and the process-default worker budget. It compares concurrent disjoint-node managed
 sessions, an all-allowed session, and (when compiled and linked)
-provider-default exclusive execution; it exits successfully with an
-explanation on single-node hosts. The CPU crate benchmark uses the same
+provider-default exclusive execution. On single-node hosts it still measures
+the portable cases and skips only the disjoint-node comparison. The CPU crate benchmark uses the same
 multi-op `BackendSession` boundary as compiled graph execution without adding a
 reverse dev-dependency from `tenferro-cpu` to `tenferro-runtime`.
 
@@ -51,3 +52,30 @@ Repository verification evidence:
   including guide dependency snippets and 13 workspace API crates.
 - CI-equivalent workspace and tropical-extension clippy commands passed with
   `-D warnings`.
+
+Pre-PR review found that the fused segmented executor still opened one backend
+session per fused segment. The revised executor keeps elementwise fusion and
+terminal lazy values while running every session-capable fused, Host, and FFI
+segment inside one cached session. Regression tests first failed with two
+session entries, then passed with one for both owned and value outputs; the
+fixture includes native/FFI/Host/native transitions.
+
+The same review tightened the remaining safety contracts:
+
+- arbitration is process-wide, so independently constructed backends cannot
+  overlap an unmanaged external-provider call with any tenferro CPU domain;
+- fallible constructors preserve `CpuTopologyError`, while only infallible
+  construction may use the documented compatibility fallback;
+- unsupported-affinity platforms resolve faer `Auto` to compatibility mode and
+  reject explicit managed placement;
+- affinity-mask allocation rejects extreme public CPU IDs using checked,
+  fallible allocation;
+- reduced worker budgets are spread over the logical CPU domain; and
+- typed diagnostics now report topology, worker count, and managed,
+  provider-exclusive, or compatibility execution mode.
+
+Focused post-review verification passed for 276 CPU unit tests, fused runtime
+owned/value session tests, the provider-inject integration suite, and benchmark
+compilation. A `wasm32-unknown-unknown` portability check stopped in the
+third-party `atomic-wait` crate before compiling tenferro; the unavailable
+affinity branch is covered by an injected capability contract test.

--- a/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
+++ b/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
@@ -65,8 +65,9 @@ The same review tightened the remaining safety contracts:
 - arbitration is process-wide, so independently constructed backends cannot
   overlap an unmanaged external-provider call with any tenferro CPU domain;
 - process-wide arbitration propagates a logical execution owner across Rayon
-  pools, preventing synchronous nested clone and independent-backend calls from
-  waiting on their own permit while preserving exclusion across executions;
+  pools and broadcasts it to every worker, preventing synchronous nested clone,
+  independent-backend, and stolen-child-task calls from waiting on their own
+  permit while preserving exclusion across executions;
 - reentrant operations use transient engine resources so a nested tensor or
   provider session does not re-lock the outer session's scratch/cache mutex;
 - fallible constructors expose `CpuBackendError` and preserve typed placement
@@ -80,7 +81,7 @@ The same review tightened the remaining safety contracts:
 - typed diagnostics now report topology, worker count, and managed,
   provider-exclusive, or compatibility execution mode.
 
-Focused post-review verification passed for 283 CPU unit tests, fused runtime
+Focused post-review verification passed for 285 CPU unit tests, fused runtime
 owned/value session tests, the provider-inject integration suite, and benchmark
 compilation. A `wasm32-unknown-unknown` portability check stopped in the
 third-party `atomic-wait` crate before compiling tenferro; the unavailable

--- a/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
+++ b/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
@@ -36,3 +36,18 @@ Local benchmark verification on 2026-07-14:
   usable node (64 allowed logical CPUs). Live two-node timing evidence is
   therefore unavailable in this environment; fixture/unit tests cover sparse
   multi-node resolution and disjoint arbitration.
+
+Repository verification evidence:
+
+- `cargo test --workspace --release` passed, including workspace doctests.
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json --
+  --test-threads=1` passed; `scripts/check-coverage.py` reported 159/159 files
+  meeting thresholds (3 excluded).
+- The first parallel coverage run exposed a pre-existing graph-metadata registry
+  race in one linalg test. The same instrumented test passed alone; serializing
+  the coverage harness made the full run deterministic. Normal parallel release
+  tests passed.
+- `cargo doc --workspace --no-deps` and `scripts/check-docs-site.py` passed,
+  including guide dependency snippets and 13 workspace API crates.
+- CI-equivalent workspace and tropical-extension clippy commands passed with
+  `-D warnings`.

--- a/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
+++ b/docs/worklogs/2026-07-14-numa-aware-cpu-execution.md
@@ -1,0 +1,20 @@
+# NUMA-aware CPU execution
+
+Issue #1345 adds process-affinity-aware NUMA topology, pinned fixed CPU engines,
+shared arbitration, and a documented provider boundary.
+
+The implementation treats OS node IDs as sparse and intersects node cpusets
+with the process mask. `CpuBackend` clones share engines and caches. faer owns
+managed placement; external BLAS accepts only `Auto` and runs exclusively
+because its worker affinity is not controlled by tenferro. Graph execution
+keeps a permit across supported Host/native/FFI instructions, entering Rayon
+for native BLAS-backend segments and leaving it for provider calls.
+
+Rejected alternatives were thread-count-only placement, exposing concrete BLAS
+provider names as stable identities, and allowing explicit BLAS node placement
+without a verifiable worker-affinity contract.
+
+Verification covers sparse topology parsing, affinity pinning, overlapping and
+disjoint permits, clone sharing, graph session count, Host work inside the
+session, and the BLAS Rayon/provider transition. The online guide is
+`docs/guides/cpu-execution.md`.


### PR DESCRIPTION
## Summary

- add process-affinity-aware NUMA topology discovery, public CPU placement contracts, and pinned faer execution engines
- make CpuBackend a cloneable shared coordinator handle with process-wide overlap/provider arbitration and graph-wide CPU sessions
- restrict external BLAS to Auto/provider-exclusive execution and make backend execution non-reentrant so Rayon scheduler siblings cannot bypass engine or provider exclusion
- document NUMA definitions, faer/BLAS behavior, Rayon elementwise placement, diagnostics, and residual executor constraints; add benchmarks and coverage-backed tests

## Verification

- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings
- cargo test --workspace --release --quiet
- cargo llvm-cov --workspace --release --json (159/159 files passed)
- cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py
- python3 scripts/repository-rules-review.py --base origin/main --head HEAD (pass)
- provider-inject release integration tests
- NUMA benchmark compile

Closes #1345