### PR TITLE
ci: add change-aware validation and trusted RunPod recovery

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-gpu

--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -8,6 +8,8 @@ name: CI_gpu
 # attach `CI GPU gate` to fork commits. It also remains a manual legacy fallback
 # for comparing the org larger GPU runner with RunPod while the migration
 # settles.
+# Maintainers should recover a same-repository PR through the trusted RunPod
+# workflow with `python3 scripts/ci/recover_runpod_pr.py PR_NUMBER --wait`.
 
 on:
   pull_request:
@@ -187,7 +189,6 @@ jobs:
           prefix-key: v0-rust-cuda
           shared-key: cuda-release
           cache-all-crates: true
-          cache-workspace-crates: true
       - uses: taiki-e/install-action@nextest
         if: steps.cuda_archive_cache.outputs.cache-hit != 'true'
       - name: Build CUDA test archive

--- a/.github/workflows/ci-pr-workspace-tests.yml
+++ b/.github/workflows/ci-pr-workspace-tests.yml
@@ -1,30 +1,5 @@
-# Workspace test suite (two-tier).
-#
-# This is the home of `cargo nextest run --workspace` + workspace doc tests.
-# `ci.yml` deliberately does NOT contain a workspace test job; it only runs the
-# fast checks (fmt, clippy, inject tests, coverage, docs) on push and PRs.
-#
-# Two tiers:
-#   * Pull requests (fast tier): cpu-faer always; cpu-blas ONLY when
-#     backend-relevant paths change (see the `changes` job). Most PRs skip the
-#     cpu-blas lane entirely, so they run one backend instead of two.
-#   * Push to main (comprehensive tier): the full cpu-faer + cpu-blas matrix
-#     always runs, so every backend is exercised on the merged result even when
-#     the PR that produced it skipped cpu-blas.
-#
-# The extension/sample tutorial tests (tropical, sparse, KdV) live in their own
-# `ext-samples` job. They are standalone workspaces that recompile tenferro from
-# scratch, so running them once here (instead of inside every backend leg) keeps
-# them off the per-backend critical path and avoids duplicate compilation.
-#
-# The `ci-gate` job below is the branch-protection check that proves the
-# workspace + extension tests passed. Its job name is the required check, so
-# renaming the workflow is safe. GPU tests are in `CI_gpu.yml`, gated behind
-# repository rules LLM review plus these non-GPU checks.
-#
-# Named for its PURPOSE, not its runner. The `ci-maintainer` job is intended to
-# run on a self-hosted pool but currently uses GitHub-hosted runners while that
-# pool is down — so a runner-derived name would be misleading.
+# Change-aware workspace and extension tests. Required gate names remain stable;
+# intentionally unnecessary lanes execute explicit successful no-ops.
 name: CI PR workspace tests
 
 on:
@@ -37,77 +12,77 @@ permissions:
   contents: read
 
 concurrency:
-  # Per-PR for pull_request events (new pushes cancel stale runs); per-commit for
-  # push-to-main so distinct main commits are each verified without cancelling.
   group: ci-pr-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:
-  # Decide which backends the same-repo matrix runs. cpu-blas is expensive, and
-  # only the CPU linalg backend selection distinguishes it from cpu-faer, so we
-  # run it only when backend-relevant paths change on a PR. On push to main we
-  # always run both (comprehensive tier).
   changes:
-    name: Select backend matrix
+    name: Select validation matrix
     runs-on: ubuntu-latest
     outputs:
       backends: ${{ steps.select.outputs.backends }}
+      run_workspace: ${{ steps.policy.outputs.run_rust }}
+      run_extensions: ${{ steps.policy.outputs.run_extensions }}
+      reason: ${{ steps.policy.outputs.reason }}
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Select backends
-        id: select
+      - name: Classify change
+        id: policy
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          python3 scripts/ci/change_policy.py
+          --event "${EVENT_NAME}"
+          --base "${BASE_SHA}"
+          --head "${HEAD_SHA}"
+      - name: Select backend profiles
+        id: select
+        env:
+          RUN_WORKSPACE: ${{ steps.policy.outputs.run_rust }}
+          RUN_BLAS: ${{ steps.policy.outputs.run_blas }}
         run: |
-          set -euo pipefail
-          faer='{"backend":"cpu-faer","feature_args":"","rustflags":""}'
-          blas='{"backend":"cpu-blas","feature_args":"--no-default-features --features cpu-blas","rustflags":"-l dylib=openblas -l dylib=lapack"}'
-          run_blas=false
-          if [ "${EVENT_NAME}" = "push" ]; then
-            # Comprehensive tier: always exercise both backends on main.
-            run_blas=true
-          else
-            changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}")"
-            if printf '%s\n' "${changed}" | grep -qE '^(crates/tenferro-cpu/|crates/tenferro-linalg/|crates/tenferro-tensor/|crates/tenferro-tensor-core/|Cargo\.lock|Cargo\.toml|\.github/workflows/ci-pr-workspace-tests\.yml)'; then
-              run_blas=true
-            fi
-          fi
-          if [ "${run_blas}" = "true" ]; then
+          faer='{"backend":"cpu-faer","profile":"workspace-faer","rustflags":""}'
+          blas='{"backend":"cpu-blas","profile":"workspace-blas","rustflags":"-l dylib=openblas -l dylib=lapack"}'
+          noop='{"backend":"not-required","profile":"","rustflags":""}'
+          if [ "${RUN_WORKSPACE}" != true ]; then
+            echo "backends=[${noop}]" >> "${GITHUB_OUTPUT}"
+          elif [ "${RUN_BLAS}" = true ]; then
             echo "backends=[${faer},${blas}]" >> "${GITHUB_OUTPUT}"
           else
             echo "backends=[${faer}]" >> "${GITHUB_OUTPUT}"
           fi
-          echo "Selected backends (run_blas=${run_blas}, event=${EVENT_NAME})."
 
-  # fork からの PR: GitHub-hosted runner で cpu-faer のみ。
   ci-fork:
     name: CI (fork PR / github-hosted)
+    needs: changes
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
+        if: needs.changes.outputs.run_workspace == 'true'
       - uses: dtolnay/rust-toolchain@stable
+        if: needs.changes.outputs.run_workspace == 'true'
       - uses: Swatinem/rust-cache@v2
+        if: needs.changes.outputs.run_workspace == 'true'
       - uses: taiki-e/install-action@nextest
-      - name: Run unit and integration tests
-        # `tenferro-tutorial-code` is a workspace test package, so the workspace
-        # nextest run already covers the runnable tutorials.
-        run: cargo nextest run --workspace --release --no-fail-fast
-      - name: Run doc tests
-        run: cargo test --doc --workspace --release
+        if: needs.changes.outputs.run_workspace == 'true'
+      - name: Run workspace faer profile
+        if: needs.changes.outputs.run_workspace == 'true'
+        run: python3 scripts/ci/run_profile.py workspace-faer
+      - name: Report workspace no-op
+        if: needs.changes.outputs.run_workspace != 'true'
+        env:
+          REASON: ${{ needs.changes.outputs.reason }}
+        run: echo "Workspace tests not required - ${REASON}"
 
-  # 同一リポジトリの PR と main への push: cpu-faer と（条件付きで）cpu-blas。
-  # Normally intended for a self-hosted runner; temporarily GitHub-hosted while
-  # that pool is down.
   ci-maintainer:
     name: CI (same-repo / heavy / ${{ matrix.cfg.backend }})
     needs: changes
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-    # runs-on: [self-hosted, linux, x64]
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -118,78 +93,82 @@ jobs:
       CARGO_PROFILE_RELEASE_DEBUG: 0
       RUSTFLAGS: ${{ matrix.cfg.rustflags }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
+        if: matrix.cfg.profile != ''
       - uses: dtolnay/rust-toolchain@stable
+        if: matrix.cfg.profile != ''
       - uses: Swatinem/rust-cache@v2
-      # Note: Disable this step when runs-on is self-hosted.
+        if: matrix.cfg.profile != ''
       - name: Install BLAS/LAPACK runtime libraries
         if: matrix.cfg.backend == 'cpu-blas'
         run: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapack-dev
       - uses: taiki-e/install-action@nextest
+        if: matrix.cfg.profile != ''
       - name: Verify BLAS/LAPACK runtime libraries
         if: matrix.cfg.backend == 'cpu-blas'
         run: |
-          set -euo pipefail
           ldconfig -p | grep -E 'libopenblas\.so' >/dev/null
           ldconfig -p | grep -E 'liblapack\.so' >/dev/null
-      - name: Run unit and integration tests
-        # `tenferro-tutorial-code` is a workspace test package, so the workspace
-        # nextest run already covers the runnable tutorials.
-        run: cargo nextest run --workspace --release ${{ matrix.cfg.feature_args }} --no-fail-fast
-      - name: Run doc tests
-        run: cargo test --doc --workspace --release ${{ matrix.cfg.feature_args }}
+      - name: Run workspace profile
+        if: matrix.cfg.profile != ''
+        run: python3 scripts/ci/run_profile.py "${{ matrix.cfg.profile }}"
+      - name: Report workspace no-op
+        if: matrix.cfg.profile == ''
+        env:
+          REASON: ${{ needs.changes.outputs.reason }}
+        run: echo "Workspace tests not required - ${REASON}"
 
-  # Extension and sample tutorials. These are standalone workspaces (each has its
-  # own `[workspace]`) that depend on tenferro via path, so they recompile the
-  # tenferro graph from scratch. They are backend-agnostic (they use the default
-  # cpu-faer backend), so we run them once here rather than inside every backend
-  # leg of ci-maintainer. `rust-cache` is pointed at each standalone workspace so
-  # their target dirs are cached across runs.
   ext-samples:
     name: Extension and sample tests
+    needs: changes
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
+        if: needs.changes.outputs.run_extensions == 'true'
       - uses: dtolnay/rust-toolchain@stable
+        if: needs.changes.outputs.run_extensions == 'true'
       - name: Cache extension/sample target dirs
+        if: needs.changes.outputs.run_extensions == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
             ext/tropical
             ext/sparse
             samples/kdv-pinn
-      - name: Run tropical extension tutorial tests
-        run: cargo test --manifest-path ext/tropical/Cargo.toml --release --features autodiff
-      - name: Run sparse extension tutorial tests
-        run: cargo test --manifest-path ext/sparse/Cargo.toml --release --features autodiff
-      - name: Compile-check KdV PINN sample
-        run: cargo check --manifest-path samples/kdv-pinn/Cargo.toml --release --all-targets
+      - name: Run extension profile
+        if: needs.changes.outputs.run_extensions == 'true'
+        run: python3 scripts/ci/run_profile.py extensions
+      - name: Report extension no-op
+        if: needs.changes.outputs.run_extensions != 'true'
+        env:
+          REASON: ${{ needs.changes.outputs.reason }}
+        run: echo "Extension tests not required - ${REASON}"
 
-  # Single check for branch protection. Requires the extension/sample tests plus
-  # the one runnable workspace path (fork = ci-fork, same-repo/push = ci-maintainer);
-  # the other is skipped. A cpu-blas leg that was intentionally not scheduled does
-  # not appear as a failure because ci-maintainer's matrix only contains the
-  # selected backends.
   ci-gate:
     name: CI gate (PR workspace tests)
-    needs: [ci-fork, ci-maintainer, ext-samples]
+    needs: [changes, ci-fork, ci-maintainer, ext-samples]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Require workspace and extension tests
+      - name: Require selected workspace and extension tests
         env:
+          CHANGE_RESULT: ${{ needs.changes.result }}
           FORK_RESULT: ${{ needs.ci-fork.result }}
           MAINTAINER_RESULT: ${{ needs.ci-maintainer.result }}
           EXT_RESULT: ${{ needs.ext-samples.result }}
+          RUN_WORKSPACE: ${{ needs.changes.outputs.run_workspace }}
+          RUN_EXTENSIONS: ${{ needs.changes.outputs.run_extensions }}
         run: |
-          set -euo pipefail
-          if [ "${EXT_RESULT}" != "success" ]; then
-            echo "Expected ext-samples to succeed; got ext-samples=${EXT_RESULT}"
+          if [ "${CHANGE_RESULT}" != success ]; then
+            echo "Change classification failed: ${CHANGE_RESULT}"
             exit 1
           fi
-          if [ "${FORK_RESULT}" = "success" ] || [ "${MAINTAINER_RESULT}" = "success" ]; then
-            exit 0
+          if [ "${EXT_RESULT}" != success ]; then
+            echo "Expected ext-samples to succeed or no-op; got ${EXT_RESULT}"
+            exit 1
           fi
-          echo "Expected ci-fork or ci-maintainer to succeed; got ci-fork=${FORK_RESULT} ci-maintainer=${MAINTAINER_RESULT}"
-          exit 1
+          if [ "${FORK_RESULT}" != success ] && [ "${MAINTAINER_RESULT}" != success ]; then
+            echo "Expected a workspace job to succeed or no-op; fork=${FORK_RESULT} maintainer=${MAINTAINER_RESULT}"
+            exit 1
+          fi
+          echo "Selected policy satisfied: workspace=${RUN_WORKSPACE} extensions=${RUN_EXTENSIONS}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,104 +16,221 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  policy:
+    name: Classify CI change
+    runs-on: ubuntu-latest
+    outputs:
+      run_rust: ${{ steps.policy.outputs.run_rust }}
+      run_blas: ${{ steps.policy.outputs.run_blas }}
+      run_docs: ${{ steps.policy.outputs.run_docs }}
+      run_ci_config: ${{ steps.policy.outputs.run_ci_config }}
+      classification: ${{ steps.policy.outputs.classification }}
+      reason: ${{ steps.policy.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Classify change
+        id: policy
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          python3 scripts/ci/change_policy.py
+          --event "${EVENT_NAME}"
+          --base "${BASE_SHA}"
+          --head "${HEAD_SHA}"
+
   fmt:
     name: rustfmt
+    needs: policy
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
       - uses: dtolnay/rust-toolchain@stable
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
         with:
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --all --check
+      - name: Run rustfmt
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+        run: cargo fmt --all --check
+      - name: Report rustfmt disposition
+        if: always()
+        env:
+          POLICY_RESULT: ${{ needs.policy.result }}
+          REQUIRED: ${{ needs.policy.outputs.run_rust }}
+          REASON: ${{ needs.policy.outputs.reason }}
+        run: |
+          if [ "${POLICY_RESULT}" != success ]; then echo "Change classification failed"; exit 1; fi
+          if [ "${REQUIRED}" != true ]; then echo "rustfmt not required: ${REASON}"; fi
 
   clippy:
     name: clippy
+    needs: policy
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
       - uses: dtolnay/rust-toolchain@stable
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
       - name: Run workspace clippy
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
         run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Run tropical extension clippy
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
         run: cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings
-
-  # NOTE: The full workspace test suite is NOT skipped — it has been MOVED, not
-  # disabled. `cargo nextest run --workspace` + workspace doc tests run on every
-  # pull request via the dedicated `ci-pr-workspace-tests.yml` workflow (the
-  # `ci-fork` and `ci-maintainer` jobs, across the cpu-faer and cpu-blas
-  # backends), and the `ci-gate` job there is the branch-protection check that
-  # requires them.
-  #
-  # This `ci.yml` workflow runs on both push-to-main and PRs, and intentionally
-  # keeps only the fast, always-cheap checks (fmt, clippy, focused inject tests,
-  # coverage, dependency-boundary, docs). The heavy workspace test matrix lives
-  # in `ci-pr-workspace-tests.yml` so it runs once per PR rather than also on
-  # every push to `main` (where the merged PR already gated it). GPU tests run in
-  # `CI_gpu.yml` only after the repository rules LLM review and cheap non-GPU CI
-  # checks pass. Do not re-add a workspace test job here without removing it from
-  # `ci-pr-workspace-tests.yml` first — otherwise the suite runs twice per PR.
+      - name: Report clippy disposition
+        if: always()
+        env:
+          POLICY_RESULT: ${{ needs.policy.result }}
+          REQUIRED: ${{ needs.policy.outputs.run_rust }}
+          REASON: ${{ needs.policy.outputs.reason }}
+        run: |
+          if [ "${POLICY_RESULT}" != success ]; then echo "Change classification failed"; exit 1; fi
+          if [ "${REQUIRED}" != true ]; then echo "clippy not required: ${REASON}"; fi
 
   test-inject-blas:
     name: cargo test (blas inject)
+    needs: policy
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_blas == 'true'
       - uses: dtolnay/rust-toolchain@stable
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_blas == 'true'
       - uses: Swatinem/rust-cache@v2
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_blas == 'true'
       - name: Run inject tests for tenferro-cpu
-        run: cargo test -p tenferro-cpu --test inject_tests --release --no-default-features --features "cpu-blas,provider-inject"
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_blas == 'true'
+        run: python3 scripts/ci/run_profile.py blas-inject
+      - name: Report BLAS inject disposition
+        if: always()
+        env:
+          POLICY_RESULT: ${{ needs.policy.result }}
+          REQUIRED: ${{ needs.policy.outputs.run_blas }}
+          REASON: ${{ needs.policy.outputs.reason }}
+        run: |
+          if [ "${POLICY_RESULT}" != success ]; then echo "Change classification failed"; exit 1; fi
+          if [ "${REQUIRED}" != true ]; then echo "BLAS inject tests not required: ${REASON}"; fi
 
   tensor-core-deps:
     name: tensor core dependency boundary
+    needs: policy
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
       - name: Check host-only tensor-core dependencies
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
         run: scripts/check-tensor-core-deps.sh
+      - name: Report dependency-check disposition
+        if: always()
+        env:
+          POLICY_RESULT: ${{ needs.policy.result }}
+          REQUIRED: ${{ needs.policy.outputs.run_rust }}
+          REASON: ${{ needs.policy.outputs.reason }}
+        run: |
+          if [ "${POLICY_RESULT}" != success ]; then echo "Change classification failed"; exit 1; fi
+          if [ "${REQUIRED}" != true ]; then echo "dependency check not required: ${REASON}"; fi
 
   coverage:
     name: coverage
+    needs: policy
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
       - uses: dtolnay/rust-toolchain@stable
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
       - uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Generate coverage JSON
-        run: cargo llvm-cov --workspace --release --json --output-path coverage.json
-      - name: Enforce per-file coverage thresholds
-        run: python3 scripts/check-coverage.py coverage.json
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+      - name: Generate and enforce coverage
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+        run: python3 scripts/ci/run_profile.py coverage
+      - name: Report coverage disposition
+        if: always()
+        env:
+          POLICY_RESULT: ${{ needs.policy.result }}
+          REQUIRED: ${{ needs.policy.outputs.run_rust }}
+          REASON: ${{ needs.policy.outputs.reason }}
+        run: |
+          if [ "${POLICY_RESULT}" != success ]; then echo "Change classification failed"; exit 1; fi
+          if [ "${REQUIRED}" != true ]; then echo "coverage not required: ${REASON}"; fi
 
   docs-site:
     name: docs-site
+    needs: policy
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_docs == 'true'
       - uses: dtolnay/rust-toolchain@stable
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_docs == 'true'
       - uses: Swatinem/rust-cache@v2
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_docs == 'true'
       - name: Install Quarto
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_docs == 'true'
         uses: quarto-dev/quarto-actions/setup@v2
       - name: Ensure graphviz
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_docs == 'true'
         run: |
-          set -euo pipefail
           if ! command -v dot >/dev/null 2>&1; then
             sudo DEBIAN_FRONTEND=noninteractive apt-get update
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends graphviz
           fi
-      - name: Run docs script tests
+      - name: Validate and build docs site
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_docs == 'true'
+        run: python3 scripts/ci/run_profile.py docs
+      - name: Report docs disposition
+        if: always()
+        env:
+          POLICY_RESULT: ${{ needs.policy.result }}
+          REQUIRED: ${{ needs.policy.outputs.run_docs }}
+          REASON: ${{ needs.policy.outputs.reason }}
         run: |
-          python3 scripts/test-check-docs-site.py
-          python3 scripts/test-doc-consistency.py
-          python3 scripts/test-repository-rules-review.py
-          python3 scripts/check-guide-dependency-snippets.py
-          python3 scripts/check-operation-categories.py --fail-on-findings
-      - name: Build docs site
-        run: bash scripts/build_docs_site.sh
+          if [ "${POLICY_RESULT}" != success ]; then echo "Change classification failed"; exit 1; fi
+          if [ "${REQUIRED}" != true ]; then echo "docs-site not required: ${REASON}"; fi
+
+  ci-config:
+    name: CI configuration checks
+    needs: policy
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_ci_config == 'true'
+      - uses: actions/setup-go@v5
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_ci_config == 'true'
+        with:
+          go-version: stable
+      - name: Install pinned actionlint
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_ci_config == 'true'
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+      - name: Validate CI configuration
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_ci_config == 'true'
+        run: python3 scripts/ci/run_profile.py ci-config
+      - name: Report CI configuration disposition
+        if: always()
+        env:
+          POLICY_RESULT: ${{ needs.policy.result }}
+          REQUIRED: ${{ needs.policy.outputs.run_ci_config }}
+          REASON: ${{ needs.policy.outputs.reason }}
+        run: |
+          if [ "${POLICY_RESULT}" != success ]; then echo "Change classification failed"; exit 1; fi
+          if [ "${REQUIRED}" != true ]; then echo "CI configuration checks not required: ${REASON}"; fi

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -206,8 +206,10 @@ jobs:
             fi
 
             echo "Pinned PR #${pr_number} merge ref to ${merge_sha}."
-            echo "tenferro_ref=${merge_sha}" >> "${GITHUB_OUTPUT}"
-            echo "target_head_sha=${pr_head_sha}" >> "${GITHUB_OUTPUT}"
+            {
+              echo "tenferro_ref=${merge_sha}"
+              echo "target_head_sha=${pr_head_sha}"
+            } >> "${GITHUB_OUTPUT}"
             classify_pr_paths "${pr_number}"
           else
             # Manual dispatch relies on the triggering actor check.
@@ -250,15 +252,19 @@ jobs:
                 echo "::error::PR #${MANUAL_PR_NUMBER} trust state changed during authorization; refusing recovery."
                 exit 1
               fi
-              echo "tenferro_ref=${pr_head_sha}" >> "${GITHUB_OUTPUT}"
-              echo "target_head_sha=${pr_head_sha}" >> "${GITHUB_OUTPUT}"
+              {
+                echo "tenferro_ref=${pr_head_sha}"
+                echo "target_head_sha=${pr_head_sha}"
+              } >> "${GITHUB_OUTPUT}"
               classify_pr_paths "${MANUAL_PR_NUMBER}"
             else
               manual_ref="${MANUAL_TENFERRO_REF:-main}"
-              echo "tenferro_ref=${manual_ref}" >> "${GITHUB_OUTPUT}"
-              echo "target_head_sha=${MANUAL_GATE_HEAD_SHA}" >> "${GITHUB_OUTPUT}"
-              echo "run_gpu=true" >> "${GITHUB_OUTPUT}"
-              echo "reason=trusted manual revision validation" >> "${GITHUB_OUTPUT}"
+              {
+                echo "tenferro_ref=${manual_ref}"
+                echo "target_head_sha=${MANUAL_GATE_HEAD_SHA}"
+                echo "run_gpu=true"
+                echo "reason=trusted manual revision validation"
+              } >> "${GITHUB_OUTPUT}"
             fi
           fi
 
@@ -703,7 +709,7 @@ jobs:
           echo "GitHub generate-jitconfig HTTP status: ${status}"
 
           if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
-            cat "$response_file" | jq . || cat "$response_file"
+            jq . "$response_file" || cat "$response_file"
             echo "Failed to generate JIT runner config" >&2
             exit 1
           fi
@@ -711,7 +717,7 @@ jobs:
           jit_config="$(jq -r .encoded_jit_config "$response_file")"
 
           if [ -z "$jit_config" ] || [ "$jit_config" = "null" ]; then
-            cat "$response_file" | jq 'del(.encoded_jit_config)' || cat "$response_file"
+            jq 'del(.encoded_jit_config)' "$response_file" || cat "$response_file"
             echo "Failed to generate JIT runner config: missing encoded_jit_config" >&2
             exit 1
           fi
@@ -812,7 +818,7 @@ jobs:
 
             if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
               echo "GitHub runners API HTTP status: ${status}"
-              cat "$response_file" | jq . || cat "$response_file"
+              jq . "$response_file" || cat "$response_file"
               sleep 10
               continue
             fi
@@ -860,7 +866,7 @@ jobs:
           )"
 
           echo "RunPod delete HTTP status: ${status}"
-          cat "$response_file" | jq . || cat "$response_file" || true
+          jq . "$response_file" || cat "$response_file" || true
 
           if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
             echo "Warning: failed to delete RunPod pod after startup failure" >&2
@@ -1261,7 +1267,7 @@ jobs:
           )"
 
           echo "RunPod delete HTTP status: ${status}"
-          cat "$response_file" | jq . || cat "$response_file" || true
+          jq . "$response_file" || cat "$response_file" || true
 
           if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
             echo "Warning: failed to delete RunPod pod" >&2

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -22,7 +22,7 @@ name: RunPod tenferro-rs GPU Test
 #     any paid pod is created.
 #   * `RUNPOD_API_KEY` (and the GitHub App credentials used to mint the JIT
 #     runner config) must only ever be read in trusted-base GitHub-hosted jobs
-#     (`start-runpod`, `cleanup-runpod`). Neither may ever be passed to, or
+#     (`runpod-contract`, `start-runpod`, `cleanup-runpod`). Neither may ever be passed to, or
 #     become readable from, the pod itself. Automatic PR runs are started only
 #     by `workflow_run`, after `authorize` gates the run to same-repo
 #     maintainer/admin PRs.
@@ -84,8 +84,15 @@ jobs:
 
     outputs:
       tenferro_ref: ${{ steps.resolve_ref.outputs.tenferro_ref }}
+      gpu_required: ${{ steps.resolve_ref.outputs.run_gpu }}
+      policy_reason: ${{ steps.resolve_ref.outputs.reason }}
 
     steps:
+      # workflow_run resolves this checkout to trusted default-branch content.
+      # Manual dispatch is rejected below unless the workflow ref is main.
+      - name: Checkout trusted CI policy
+        uses: actions/checkout@v5
+
       - name: Check actor and PR source are allowed
         id: resolve_ref
         env:
@@ -177,15 +184,49 @@ jobs:
 
             echo "Pinned PR #${pr_number} merge ref to ${merge_sha}."
             echo "tenferro_ref=${merge_sha}" >> "${GITHUB_OUTPUT}"
+
+            changed_paths=/tmp/runpod-pr-changed-paths.txt
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files?per_page=100" \
+              --jq '.[].filename' > "${changed_paths}"
+            policy_args=()
+            while IFS= read -r path; do
+              if [ -n "${path}" ]; then
+                policy_args+=(--path "${path}")
+              fi
+            done < "${changed_paths}"
+            python3 scripts/ci/change_policy.py "${policy_args[@]}"
           else
             # Manual dispatch relies on the triggering actor check.
+            if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+              echo "::error::Secret-bearing manual RunPod dispatch must use the trusted main workflow."
+              exit 1
+            fi
             check_permission "${GITHUB_ACTOR}" "Workflow actor"
             echo "tenferro_ref=${MANUAL_TENFERRO_REF}" >> "${GITHUB_OUTPUT}"
+            echo "run_gpu=true" >> "${GITHUB_OUTPUT}"
+            echo "reason=trusted manual revision validation" >> "${GITHUB_OUTPUT}"
           fi
+
+  runpod-contract:
+    name: Validate RunPod request contract
+    needs: authorize
+    if: needs.authorize.outputs.gpu_required == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout trusted RunPod helpers
+        uses: actions/checkout@v5
+      - name: Validate configured GPU IDs against live OpenAPI
+        env:
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+        run: python3 scripts/ci/runpod_contract.py
 
   pre-runpod-gate:
     name: Wait for review and non-GPU CI
     needs: authorize
+    if: needs.authorize.outputs.gpu_required == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -291,7 +332,10 @@ jobs:
 
   cuda-archive:
     name: CUDA test archive
-    needs: authorize
+    needs:
+      - authorize
+      - runpod-contract
+    if: needs.authorize.outputs.gpu_required == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 60
 
@@ -525,8 +569,10 @@ jobs:
     name: Start RunPod org runner
     needs:
       - authorize
+      - runpod-contract
       - pre-runpod-gate
       - cuda-archive
+    if: needs.authorize.outputs.gpu_required == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -903,6 +949,7 @@ jobs:
       - authorize
       - cuda-archive
       - start-runpod
+    if: needs.authorize.outputs.gpu_required == 'true'
 
     env:
       TENFERRO_REF: ${{ needs.authorize.outputs.tenferro_ref }}
@@ -1255,10 +1302,11 @@ jobs:
   cleanup-runpod:
     name: Delete RunPod pod
     needs:
+      - authorize
       - start-runpod
       - run-gpu-tests
 
-    if: always()
+    if: always() && needs.authorize.outputs.gpu_required == 'true'
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1302,6 +1350,7 @@ jobs:
     name: Publish CI GPU gate
     needs:
       - authorize
+      - runpod-contract
       - pre-runpod-gate
       - cuda-archive
       - start-runpod
@@ -1332,6 +1381,9 @@ jobs:
           WORKFLOW_RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           AUTHORIZE_RESULT: ${{ needs.authorize.result }}
+          GPU_REQUIRED: ${{ needs.authorize.outputs.gpu_required }}
+          POLICY_REASON: ${{ needs.authorize.outputs.policy_reason }}
+          CONTRACT_RESULT: ${{ needs.runpod-contract.result }}
           PRE_RUNPOD_RESULT: ${{ needs.pre-runpod-gate.result }}
           ARCHIVE_RESULT: ${{ needs.cuda-archive.result }}
           START_RUNPOD_RESULT: ${{ needs.start-runpod.result }}
@@ -1352,15 +1404,27 @@ jobs:
           }
 
           record_result "authorize" "${AUTHORIZE_RESULT}"
-          record_result "pre-runpod-gate" "${PRE_RUNPOD_RESULT}"
-          record_result "cuda-archive" "${ARCHIVE_RESULT}"
-          record_result "start-runpod" "${START_RUNPOD_RESULT}"
-          record_result "run-gpu-tests" "${RUN_GPU_TESTS_RESULT}"
-          record_result "cleanup-runpod" "${CLEANUP_RUNPOD_RESULT}"
+          if [ "${GPU_REQUIRED}" = true ]; then
+            record_result "runpod-contract" "${CONTRACT_RESULT}"
+            record_result "pre-runpod-gate" "${PRE_RUNPOD_RESULT}"
+            record_result "cuda-archive" "${ARCHIVE_RESULT}"
+            record_result "start-runpod" "${START_RUNPOD_RESULT}"
+            record_result "run-gpu-tests" "${RUN_GPU_TESTS_RESULT}"
+            record_result "cleanup-runpod" "${CLEANUP_RUNPOD_RESULT}"
+          elif [ "${GPU_REQUIRED}" = false ]; then
+            echo "GPU validation not required: ${POLICY_REASON}"
+          else
+            echo "::error::Authorize job did not publish a valid GPU policy."
+            echo "- authorize policy: ${GPU_REQUIRED:-missing}" >> "${failures_file}"
+          fi
 
           conclusion="success"
           title="RunPod CI GPU gate passed"
           summary="RunPod GPU validation completed successfully and owns CI GPU gate."
+          if [ "${GPU_REQUIRED}" = false ]; then
+            title="RunPod CI GPU gate not required"
+            summary="GPU validation not required for this change: ${POLICY_REASON}"
+          fi
           if [ -s "${failures_file}" ]; then
             conclusion="failure"
             title="RunPod CI GPU gate failed"

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -930,11 +930,14 @@ jobs:
           tool: nextest
 
       - name: Check machine
+        env:
+          RUNPOD_GPU_TIER: ${{ needs.start-runpod.outputs.gpu_tier }}
+          RUNPOD_GPU_TYPE_ID: ${{ needs.start-runpod.outputs.gpu_type_id }}
         run: |
           set -euxo pipefail
           echo "tenferro-rs ref: ${TENFERRO_REF}"
-          echo "RunPod price tier: ${{ needs.start-runpod.outputs.gpu_tier }}"
-          echo "RunPod gpu_type_id (from pod create): ${{ needs.start-runpod.outputs.gpu_type_id }}"
+          echo "RunPod price tier: ${RUNPOD_GPU_TIER}"
+          echo "RunPod gpu_type_id (from pod create): ${RUNPOD_GPU_TYPE_ID}"
           echo "=== GPU (nvidia-smi) ==="
           nvidia-smi --query-gpu=index,name,memory.total,driver_version --format=csv
           nvidia-smi

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -36,10 +36,15 @@ name: RunPod tenferro-rs GPU Test
 on:
   workflow_dispatch:
     inputs:
+      pr_number:
+        description: Open same-repository PR number to recover through trusted main
+        required: false
+        default: 0
+        type: number
       tenferro_ref:
         description: tenferro-rs git ref (branch, tag, or SHA)
         required: false
-        default: main
+        default: ""
         type: string
       ci_gpu_gate_head_sha:
         description: Optional PR head SHA to publish the CI GPU gate check to
@@ -86,6 +91,7 @@ jobs:
       tenferro_ref: ${{ steps.resolve_ref.outputs.tenferro_ref }}
       gpu_required: ${{ steps.resolve_ref.outputs.run_gpu }}
       policy_reason: ${{ steps.resolve_ref.outputs.reason }}
+      target_head_sha: ${{ steps.resolve_ref.outputs.target_head_sha }}
 
     steps:
       # workflow_run resolves this checkout to trusted default-branch content.
@@ -98,7 +104,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
-          MANUAL_TENFERRO_REF: ${{ inputs.tenferro_ref || 'main' }}
+          MANUAL_PR_NUMBER: ${{ inputs.pr_number || 0 }}
+          MANUAL_TENFERRO_REF: ${{ inputs.tenferro_ref || '' }}
+          MANUAL_GATE_HEAD_SHA: ${{ inputs.ci_gpu_gate_head_sha || '' }}
           WORKFLOW_RUN_ACTOR: ${{ github.event.workflow_run.actor.login || '' }}
           WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event || '' }}
           WORKFLOW_RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
@@ -121,6 +129,21 @@ jobs:
                 exit 1
               ;;
             esac
+          }
+
+          classify_pr_paths() {
+            local pr_number="$1"
+            local changed_paths=/tmp/runpod-pr-changed-paths.txt
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files?per_page=100" \
+              --jq '.[].filename' > "${changed_paths}"
+            local policy_args=()
+            while IFS= read -r path; do
+              if [ -n "${path}" ]; then
+                policy_args+=(--path "${path}")
+              fi
+            done < "${changed_paths}"
+            python3 scripts/ci/change_policy.py "${policy_args[@]}"
           }
 
           if [ "${EVENT_NAME}" = "workflow_run" ]; then
@@ -184,18 +207,8 @@ jobs:
 
             echo "Pinned PR #${pr_number} merge ref to ${merge_sha}."
             echo "tenferro_ref=${merge_sha}" >> "${GITHUB_OUTPUT}"
-
-            changed_paths=/tmp/runpod-pr-changed-paths.txt
-            gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files?per_page=100" \
-              --jq '.[].filename' > "${changed_paths}"
-            policy_args=()
-            while IFS= read -r path; do
-              if [ -n "${path}" ]; then
-                policy_args+=(--path "${path}")
-              fi
-            done < "${changed_paths}"
-            python3 scripts/ci/change_policy.py "${policy_args[@]}"
+            echo "target_head_sha=${pr_head_sha}" >> "${GITHUB_OUTPUT}"
+            classify_pr_paths "${pr_number}"
           else
             # Manual dispatch relies on the triggering actor check.
             if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
@@ -203,9 +216,50 @@ jobs:
               exit 1
             fi
             check_permission "${GITHUB_ACTOR}" "Workflow actor"
-            echo "tenferro_ref=${MANUAL_TENFERRO_REF}" >> "${GITHUB_OUTPUT}"
-            echo "run_gpu=true" >> "${GITHUB_OUTPUT}"
-            echo "reason=trusted manual revision validation" >> "${GITHUB_OUTPUT}"
+            if ! [[ "${MANUAL_PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+              echo "::error::pr_number must be a non-negative integer."
+              exit 1
+            fi
+            if [ "${MANUAL_PR_NUMBER}" -gt 0 ]; then
+              if [ -n "${MANUAL_TENFERRO_REF}" ] || [ -n "${MANUAL_GATE_HEAD_SHA}" ]; then
+                echo "::error::pr_number cannot be combined with tenferro_ref or ci_gpu_gate_head_sha."
+                exit 1
+              fi
+              pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${MANUAL_PR_NUMBER}")"
+              if [ "$(jq -r .state <<<"${pr_json}")" != open ]; then
+                echo "::error::PR #${MANUAL_PR_NUMBER} is not open; refusing recovery."
+                exit 1
+              fi
+              pr_head_repo="$(jq -r '.head.repo.full_name' <<<"${pr_json}")"
+              if [ "${pr_head_repo}" != "${GITHUB_REPOSITORY}" ]; then
+                echo "::error::PR #${MANUAL_PR_NUMBER} is not from this repository; refusing recovery."
+                exit 1
+              fi
+              pr_author="$(jq -r '.user.login' <<<"${pr_json}")"
+              check_permission "${pr_author}" "PR author"
+              pr_head_sha="$(jq -r '.head.sha' <<<"${pr_json}")"
+              refreshed_pr_json="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${MANUAL_PR_NUMBER}")"
+              refreshed_head_sha="$(jq -r '.head.sha' <<<"${refreshed_pr_json}")"
+              refreshed_state="$(jq -r .state <<<"${refreshed_pr_json}")"
+              refreshed_head_repo="$(jq -r '.head.repo.full_name' <<<"${refreshed_pr_json}")"
+              if [ "${refreshed_head_sha}" != "${pr_head_sha}" ]; then
+                echo "::error::PR #${MANUAL_PR_NUMBER} head moved during authorization; refusing recovery."
+                exit 1
+              fi
+              if [ "${refreshed_state}" != open ] || [ "${refreshed_head_repo}" != "${GITHUB_REPOSITORY}" ]; then
+                echo "::error::PR #${MANUAL_PR_NUMBER} trust state changed during authorization; refusing recovery."
+                exit 1
+              fi
+              echo "tenferro_ref=${pr_head_sha}" >> "${GITHUB_OUTPUT}"
+              echo "target_head_sha=${pr_head_sha}" >> "${GITHUB_OUTPUT}"
+              classify_pr_paths "${MANUAL_PR_NUMBER}"
+            else
+              manual_ref="${MANUAL_TENFERRO_REF:-main}"
+              echo "tenferro_ref=${manual_ref}" >> "${GITHUB_OUTPUT}"
+              echo "target_head_sha=${MANUAL_GATE_HEAD_SHA}" >> "${GITHUB_OUTPUT}"
+              echo "run_gpu=true" >> "${GITHUB_OUTPUT}"
+              echo "reason=trusted manual revision validation" >> "${GITHUB_OUTPUT}"
+            fi
           fi
 
   runpod-contract:
@@ -489,7 +543,7 @@ jobs:
         id: archive_key
         run: |
           set -euo pipefail
-          key="cuda-archive-v8-ubuntu22.04-cuda${CUDARC_CUDA_VERSION}-ptx${CUDA_RUNTIME_VERSION}-${TENFERRO_REF}-${{ hashFiles('tenferro-rs/Cargo.lock', 'tenferro-rs/**/Cargo.toml', 'tenferro-rs/**/src/**', 'tenferro-rs/**/tests/**') }}"
+          key="cuda-archive-v9-ubuntu22.04-cuda${CUDARC_CUDA_VERSION}-ptx${CUDA_RUNTIME_VERSION}-${{ hashFiles('tenferro-rs/Cargo.lock', 'tenferro-rs/**/Cargo.toml', 'tenferro-rs/**/src/**', 'tenferro-rs/**/tests/**', 'tenferro-rs/scripts/ci/runpod_config.json', 'tenferro-rs/.github/workflows/runpod-gpu-test.yml') }}"
           echo "key=${key}" >> "${GITHUB_OUTPUT}"
           echo "CUDA archive cache key: ${key}"
 
@@ -1247,8 +1301,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
-          MANUAL_GATE_HEAD_SHA: ${{ inputs.ci_gpu_gate_head_sha || '' }}
-          WORKFLOW_RUN_PULL_REQUESTS: ${{ toJson(github.event.workflow_run.pull_requests) }}
+          TARGET_HEAD_SHA: ${{ needs.authorize.outputs.target_head_sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           AUTHORIZE_RESULT: ${{ needs.authorize.result }}
           GPU_REQUIRED: ${{ needs.authorize.outputs.gpu_required }}
@@ -1301,12 +1354,7 @@ jobs:
             summary="$(printf 'RunPod GPU validation did not complete successfully.\\n\\n%s' "$(cat "${failures_file}")")"
           fi
 
-          target_sha=""
-          if [ "${EVENT_NAME}" = "workflow_run" ]; then
-            target_sha="$(jq -r '.[0].head.sha // empty' <<<"${WORKFLOW_RUN_PULL_REQUESTS}")"
-          elif [ -n "${MANUAL_GATE_HEAD_SHA}" ]; then
-            target_sha="${MANUAL_GATE_HEAD_SHA}"
-          fi
+          target_sha="${TARGET_HEAD_SHA}"
 
           if [ -n "${target_sha}" ]; then
             echo "Publishing CI GPU gate check to PR head SHA ${target_sha}."

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -640,6 +640,7 @@ jobs:
       pod_id: ${{ steps.create_pod.outputs.pod_id }}
       runner_label: ${{ steps.vars.outputs.runner_label }}
       gpu_type_id: ${{ steps.create_pod.outputs.gpu_type_id }}
+      gpu_tier: ${{ steps.create_pod.outputs.gpu_tier }}
 
     steps:
       - name: Checkout trusted RunPod client
@@ -932,6 +933,7 @@ jobs:
         run: |
           set -euxo pipefail
           echo "tenferro-rs ref: ${TENFERRO_REF}"
+          echo "RunPod price tier: ${{ needs.start-runpod.outputs.gpu_tier }}"
           echo "RunPod gpu_type_id (from pod create): ${{ needs.start-runpod.outputs.gpu_type_id }}"
           echo "=== GPU (nvidia-smi) ==="
           nvidia-smi --query-gpu=index,name,memory.total,driver_version --format=csv

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -582,6 +582,9 @@ jobs:
       gpu_type_id: ${{ steps.create_pod.outputs.gpu_type_id }}
 
     steps:
+      - name: Checkout trusted RunPod client
+        uses: actions/checkout@v5
+
       - name: Define runner label
         id: vars
         run: |
@@ -672,39 +675,6 @@ jobs:
           set -euo pipefail
 
           echo "::add-mask::${RUNNER_JIT_CONFIG}"
-          redact_secrets() {
-            jq '
-              def redact_item:
-                (if has("env") then
-                   .env.RUNNER_JIT_CONFIG = "***redacted***"
-                   | .env.PUBLIC_KEY = "***redacted***"
-                 else
-                   .
-                 end)
-                | (if has("dockerStartCmd") then
-                     (if (.dockerStartCmd | type) == "array" then
-                       .dockerStartCmd = ["***redacted-startup-script***"]
-                     else
-                       .dockerStartCmd = "***redacted-startup-script***"
-                     end)
-                   else
-                     .
-                   end);
-
-              if type == "array" then
-                map(redact_item)
-              elif has("pods") then
-                .pods |= map(redact_item)
-              elif has("data") then
-                .data |= map(redact_item)
-              elif has("items") then
-                .items |= map(redact_item)
-              else
-                redact_item
-              end
-            ' "$1"
-          }
-
           cat > /tmp/runpod-startup.sh <<'EOS'
           set -euo pipefail
 
@@ -758,111 +728,11 @@ jobs:
           ./run.sh --jitconfig "${RUNNER_JIT_CONFIG}"
           EOS
 
-          startup_script="$(cat /tmp/runpod-startup.sh)"
-
-          jq -n \
-            --arg script "$startup_script" \
-            --arg jit_config "$RUNNER_JIT_CONFIG" \
-            --arg image_name "$RUNPOD_IMAGE" \
-            '{
-              cloudType: "SECURE",
-              computeType: "GPU",
-              name: ("tenferro-rs-gpu-ci-" + env.GITHUB_RUN_ID),
-              imageName: $image_name,
-
-              gpuTypeIds: [
-                "NVIDIA RTX A2000",
-                "NVIDIA GeForce RTX 3070",
-                "NVIDIA GeForce RTX 3080",
-                "NVIDIA GeForce RTX 3080 Ti",
-                "Tesla V100-PCIE-16GB",
-                "NVIDIA RTX A4000",
-                "NVIDIA RTX 2000 Ada Generation",
-                "NVIDIA RTX A4500",
-                "NVIDIA RTX A5000",
-                "NVIDIA A40",
-                "NVIDIA GeForce RTX 4090"
-              ],
-              gpuTypePriority: "availability",
-              gpuCount: 1,
-
-              containerDiskInGb: 100,
-              volumeInGb: 20,
-              volumeMountPath: "/workspace",
-
-              interruptible: false,
-              ports: [],
-
-              dockerEntrypoint: ["bash", "-lc"],
-              dockerStartCmd: [$script],
-
-              env: {
-                RUNNER_JIT_CONFIG: $jit_config,
-                RUNNER_ALLOW_RUNASROOT: "1"
-              }
-            }' > /tmp/pod.json
-
-          echo "RunPod request payload, secrets redacted:"
-          redact_secrets /tmp/pod.json
-
-          response_file=/tmp/runpod-response.json
-          status=""
-
-          for attempt in $(seq 1 5); do
-            echo "Creating RunPod pod (attempt ${attempt}/5)"
-            status="$(
-              curl -sS \
-                --request POST \
-                --url https://rest.runpod.io/v1/pods \
-                --header "Authorization: Bearer ${RUNPOD_API_KEY}" \
-                --header "Content-Type: application/json" \
-                --data @/tmp/pod.json \
-                --output "$response_file" \
-                --write-out "%{http_code}"
-            )"
-
-            echo "RunPod HTTP status: ${status}"
-            redact_secrets "$response_file" || cat "$response_file"
-
-            if [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
-              break
-            fi
-
-            if [ "$attempt" -lt 5 ]; then
-              echo "RunPod pod creation failed; retrying in 20 seconds" >&2
-              sleep 20
-            fi
-          done
-
-          if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
-            echo "Failed to create RunPod pod after 5 attempts" >&2
-            exit 1
-          fi
-
-          pod_id="$(jq -r .id "$response_file")"
-
-          if [ -z "$pod_id" ] || [ "$pod_id" = "null" ]; then
-            echo "Failed to create RunPod pod: missing pod id" >&2
-            exit 1
-          fi
-
-          gpu_type_id="$(
-            jq -r '
-              .machine.gpuTypeId
-              // .machine.gpuType.id
-              // empty
-            ' "$response_file"
-          )"
-
-          echo "pod_id=${pod_id}" >> "$GITHUB_OUTPUT"
-          echo "Created RunPod pod: ${pod_id}"
-
-          if [ -n "$gpu_type_id" ]; then
-            echo "gpu_type_id=${gpu_type_id}" >> "$GITHUB_OUTPUT"
-            echo "RunPod assigned GPU type: ${gpu_type_id}"
-          else
-            echo "RunPod assigned GPU type: unknown (not present in create response)"
-          fi
+          python3 scripts/ci/runpod_client.py create \
+            --config scripts/ci/runpod_config.json \
+            --startup-script /tmp/runpod-startup.sh \
+            --image-name "${RUNPOD_IMAGE}" \
+            --response-file /tmp/runpod-response.json
 
       - name: Wait for org runner to come online
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,43 @@ Implementation PRs for new features or substantial changes that are opened
 before an accepted issue may be closed with a request to continue the
 discussion in an issue first.
 
+## Local and hosted CI profiles
+
+The exact command groups used by hosted CI are available locally:
+
+```bash
+python3 scripts/ci/run_profile.py --list
+python3 scripts/ci/run_profile.py workspace-faer
+python3 scripts/ci/run_profile.py workspace-blas
+python3 scripts/ci/run_profile.py docs
+```
+
+`full` expands every profile once. Use `--dry-run` to inspect commands without
+executing them. `scripts/check-pr-fast.sh` also accepts repeatable
+`--ci-profile NAME` options; prefer these profiles over copying hosted-CI
+commands into local scripts.
+
+Pull-request CI classifies a diff conservatively as code, docs-only, or
+CI-only. Docs-only changes run documentation validation. CI-only changes run
+CI helper tests and actionlint; changes to the RunPod control plane also keep
+the GPU gate. Mixed docs and CI changes run both lightweight suites. Empty
+diffs, unknown paths, and compiled-code changes use full validation. Pushes to
+`main` always run the comprehensive non-GPU matrix. Required check names remain
+present and succeed with an explicit “not required” result when a lane is
+irrelevant.
+
+Maintainers can recover a same-repository PR GPU gate from its PR number:
+
+```bash
+python3 scripts/ci/recover_runpod_pr.py 1379 --wait
+```
+
+The command always dispatches the secret-bearing workflow from trusted
+`main`. The workflow resolves and rechecks the open PR head itself; do not run
+a PR-branch copy of that workflow with repository secrets. See
+[Change-aware CI and trusted RunPod recovery](docs/design/change-aware-ci.md)
+for the durable design and trust boundaries.
+
 ## Prototype code and provenance
 
 By submitting code directly to this repository, you represent that you have the

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -108,6 +108,7 @@ website:
               - design/capi-error-handling.md
               - design/testing.md
               - design/review-decision-records.md
+              - design/change-aware-ci.md
           - section: "Specification"
             contents:
               - spec/index.md

--- a/docs/design/change-aware-ci.md
+++ b/docs/design/change-aware-ci.md
@@ -69,7 +69,9 @@ configuration and startup command. The `Start RunPod org runner` job summary
 records the selected price tier and provider GPU ID, and the GPU job prints the
 same values next to `nvidia-smi` so the assigned machine remains auditable. A
 successful response without an assigned GPU ID, or with an ID outside the
-requested tier, is rejected before the external runner starts.
+requested tier, is rejected before the external runner starts. The created pod
+ID is still forwarded to the trusted startup-failure cleanup path so rejection
+cannot leave a paid pod running.
 
 The CUDA test archive key is content-addressed across source, manifests,
 tests, lockfile, workflow, and RunPod configuration. It excludes branch, ref,

--- a/docs/design/change-aware-ci.md
+++ b/docs/design/change-aware-ci.md
@@ -67,7 +67,9 @@ requests and sleeps share a 60-second deadline, honor numeric `Retry-After`,
 and use bounded jittered backoff. Request diagnostics redact the JIT
 configuration and startup command. The `Start RunPod org runner` job summary
 records the selected price tier and provider GPU ID, and the GPU job prints the
-same values next to `nvidia-smi` so the assigned machine remains auditable.
+same values next to `nvidia-smi` so the assigned machine remains auditable. A
+successful response without an assigned GPU ID, or with an ID outside the
+requested tier, is rejected before the external runner starts.
 
 The CUDA test archive key is content-addressed across source, manifests,
 tests, lockfile, workflow, and RunPod configuration. It excludes branch, ref,

--- a/docs/design/change-aware-ci.md
+++ b/docs/design/change-aware-ci.md
@@ -1,0 +1,83 @@
+# Change-aware CI and trusted RunPod recovery
+
+This document defines how tenferro selects validation work without weakening
+required checks, and how paid RunPod validation stays behind a trusted control
+plane. The executable sources of truth are `scripts/ci/` and the workflows
+under `.github/workflows/`.
+
+## Change policy
+
+Pull requests have one primary class and independent lane flags:
+
+- **code** includes Rust, manifests, build configuration, unknown paths, and
+  empty diffs. It uses the full CPU, extension, docs, CI-configuration, and GPU
+  policy.
+- **docs-only** contains only rendered documentation or repository prose. It
+  runs documentation validation and skips compiled-code lanes.
+- **CI-only** contains only known workflow and CI-helper paths. It runs helper
+  tests and actionlint. RunPod workflow, request, recovery, or classification
+  changes additionally require the GPU gate.
+
+Mixed docs and CI changes are CI-only with both lightweight flags enabled.
+Unknown paths always fall back to code. Pushes to `main` force the
+comprehensive non-GPU matrix; they do not add a second paid GPU run after the
+pull-request gate.
+
+Required job names do not disappear when work is unnecessary. Each required
+job either runs its selected profile or publishes an explicit successful
+no-op. A classification failure is a validation failure, never a cheap
+fallback.
+
+## Shared command profiles
+
+`scripts/ci/run_profile.py` owns immutable profiles for workspace-faer,
+workspace-blas, provider injection, extensions, documentation, coverage, and
+CI configuration. Local and hosted execution call the same profile names.
+`full` is composition rather than another command list, so repeated profiles
+execute once.
+
+## RunPod trust boundary
+
+The RunPod workflow is triggered from trusted `main`, never from
+`pull_request_target`. Before any archive build or pod allocation it:
+
+1. authorizes the actor and rejects fork PRs;
+2. resolves an immutable same-repository PR revision and rechecks head
+   stability;
+3. obtains the complete changed-file list through the GitHub API and classifies
+   it with the helper from trusted `main`;
+4. validates configured GPU IDs against RunPod's live `POST /pods` OpenAPI
+   request schema.
+
+Only trusted GitHub-hosted jobs receive the RunPod API key or GitHub App
+credentials. The self-hosted pod never receives those credentials. The final
+GitHub-hosted job publishes `CI GPU gate` to the authorized PR head SHA. A
+docs-only or unrelated CI-only skip is successful only when the trusted
+classifier says GPU validation is unnecessary.
+
+Pod creation treats HTTP 408, 429, 5xx responses, and transport failures as
+retryable. Other 4xx responses are permanent. Retries are limited by both an
+attempt count and a wall-clock deadline, honor numeric `Retry-After`, and use
+bounded jittered backoff. Request diagnostics redact the JIT configuration and
+startup command.
+
+The CUDA test archive key is content-addressed across source, manifests,
+tests, lockfile, workflow, and RunPod configuration. It excludes branch, ref,
+and commit identity, allowing equivalent automatic and recovery runs to reuse
+the hosted cache while still uploading a per-run artifact for the external
+runner.
+
+## Recovery
+
+Maintainers recover a PR by number with:
+
+```bash
+python3 scripts/ci/recover_runpod_pr.py PR_NUMBER --wait
+```
+
+The command has no workflow-ref option and always dispatches
+`runpod-gpu-test.yml` at `main`. The trusted workflow verifies that the PR is
+open, same-repository, authorized, and head-stable; it derives both the tested
+revision and required-check target rather than accepting them from the caller.
+Raw revision dispatch remains available for trusted post-merge validation, but
+cannot be combined with PR-number recovery.

--- a/docs/design/change-aware-ci.md
+++ b/docs/design/change-aware-ci.md
@@ -56,10 +56,18 @@ docs-only or unrelated CI-only skip is successful only when the trusted
 classifier says GPU validation is unnecessary.
 
 Pod creation treats HTTP 408, 429, 5xx responses, and transport failures as
-retryable. Other 4xx responses are permanent. Retries are limited by both an
-attempt count and a wall-clock deadline, honor numeric `Retry-After`, and use
-bounded jittered backoff. Request diagnostics redact the JIT configuration and
-startup command.
+retryable. Other 4xx responses are permanent. An explicit RunPod machine
+capacity error does not retry the same candidate set: the client moves without
+sleeping from the cost-preferred tier to the premium tier and finally the A100
+tier. Automatic selection excludes H100-class GPUs; the reviewed ceiling is
+A100 SXM (listed at USD 1.49/hour when the tiers were reviewed on 2026-07-15).
+
+Unrelated transient failures receive one short retry in the current tier. All
+requests and sleeps share a 60-second deadline, honor numeric `Retry-After`,
+and use bounded jittered backoff. Request diagnostics redact the JIT
+configuration and startup command. The `Start RunPod org runner` job summary
+records the selected price tier and provider GPU ID, and the GPU job prints the
+same values next to `nvidia-smi` so the assigned machine remains auditable.
 
 The CUDA test archive key is content-addressed across source, manifests,
 tests, lockfile, workflow, and RunPod configuration. It excludes branch, ref,

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -30,6 +30,7 @@ migration notes live under [Plans](../plans/), not this active design index.
 | [capi-error-handling.md](./capi-error-handling.md) | C-API error handling policy |
 | [testing.md](./testing.md) | Testing and performance verification strategy |
 | [review-decision-records.md](./review-decision-records.md) | Relationship between historical plans, reviewer-facing work logs, and durable design records |
+| [change-aware-ci.md](./change-aware-ci.md) | Conservative pull-request classification, shared command profiles, stable required checks, and trusted RunPod recovery |
 
 ## Reference
 

--- a/docs/superpowers/plans/2026-07-14-change-aware-ci-runpod-recovery.md
+++ b/docs/superpowers/plans/2026-07-14-change-aware-ci-runpod-recovery.md
@@ -502,11 +502,11 @@ def resolve_local_ref(document: Mapping[str, object], ref: str) -> Mapping[str, 
     if not ref.startswith("#/"):
         raise ContractError(f"unsupported non-local OpenAPI reference: {ref}")
     value: object = document
-    for token in ref[2:].split("/"):
-        token = token.replace("~1", "/").replace("~0", "~")
-        if not isinstance(value, Mapping) or token not in value:
+    for segment in ref[2:].split("/"):
+        segment = segment.replace("~1", "/").replace("~0", "~")
+        if not isinstance(value, Mapping) or segment not in value:
             raise ContractError(f"unresolved OpenAPI reference: {ref}")
-        value = value[token]
+        value = value[segment]
     if not isinstance(value, Mapping):
         raise ContractError(f"OpenAPI reference is not an object schema: {ref}")
     return value

--- a/docs/superpowers/plans/2026-07-14-change-aware-ci-runpod-recovery.md
+++ b/docs/superpowers/plans/2026-07-14-change-aware-ci-runpod-recovery.md
@@ -1,0 +1,877 @@
+# Change-aware CI and RunPod Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #1379 so docs-only and CI-only pull requests avoid irrelevant expensive work, local and hosted CI share exact command profiles, and trusted RunPod validation/recovery handles schema drift, retries, caching, and PR-number dispatch safely.
+
+**Architecture:** Put policy in standard-library-only Python modules under `scripts/ci/` and keep workflow YAML as orchestration. A conservative classifier emits lane flags, a profile runner owns exact commands, and trusted RunPod helpers own live-schema validation plus retry behavior. Required job names remain stable and report explicit successful no-ops; pushes to `main` force the comprehensive non-GPU matrix.
+
+**Tech Stack:** Python 3 standard library and `unittest`, Bash entry points, GitHub Actions YAML, `gh`, RunPod REST/OpenAPI, Rust/Cargo/nextest/llvm-cov, actionlint.
+
+---
+
+## File map
+
+Create:
+
+- `scripts/ci/__init__.py`: marks the CI policy package.
+- `scripts/ci/change_policy.py`: classifies changed paths and emits GitHub outputs.
+- `scripts/ci/run_profile.py`: owns exact local/hosted CI command profiles.
+- `scripts/ci/runpod_config.json`: single RunPod GPU allowlist and retry configuration.
+- `scripts/ci/runpod_contract.py`: resolves the live OpenAPI pod schema and validates configured GPU IDs.
+- `scripts/ci/runpod_client.py`: builds the redacted pod request and performs status-aware creation retries.
+- `scripts/ci/recover_runpod_pr.py`: PR-number-oriented trusted manual-dispatch CLI.
+- `scripts/ci/tests/__init__.py`: test package marker.
+- `scripts/ci/tests/test_change_policy.py`: table-driven classification and lane tests.
+- `scripts/ci/tests/test_run_profile.py`: profile composition and dry-run tests.
+- `scripts/ci/tests/test_runpod_contract.py`: OpenAPI fixture and invalid-ID tests.
+- `scripts/ci/tests/test_runpod_client.py`: retry/status/payload tests.
+- `scripts/ci/tests/test_recover_runpod_pr.py`: trusted dispatch command tests.
+- `scripts/ci/tests/test_workflow_contracts.py`: required-name, no-op, trust, and cache-key source contracts.
+- `docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md`: curated implementation record.
+
+Modify:
+
+- `scripts/check-pr-fast.sh`: delegate optional exact CI profiles.
+- `.github/workflows/ci.yml`: consume shared policy/profile helpers and add CI configuration checks.
+- `.github/workflows/ci-pr-workspace-tests.yml`: replace path regexes and keep aggregate checks successful for explicit no-ops.
+- `.github/workflows/runpod-gpu-test.yml`: trusted classification, OpenAPI preflight, helper-based pod creation, content cache key, and PR-number recovery.
+- `.github/workflows/CI_gpu.yml`: document and preserve wrapper behavior for classifier-backed external success.
+- `CONTRIBUTING.md`: document local profiles and docs/CI-only policy at contributor level.
+
+## Task 1: Conservative change classifier
+
+**Files:**
+
+- Create: `scripts/ci/__init__.py`
+- Create: `scripts/ci/change_policy.py`
+- Create: `scripts/ci/tests/__init__.py`
+- Create: `scripts/ci/tests/test_change_policy.py`
+
+- [ ] **Step 1: Write failing table-driven classifier tests**
+
+Define expected behavior explicitly:
+
+```python
+from scripts.ci.change_policy import ChangeClass, classify_paths
+
+
+def test_docs_only_runs_docs_without_rust_or_gpu() -> None:
+    policy = classify_paths(["docs/guides/cpu.md", "README.md"])
+    assert policy.change_class is ChangeClass.DOCS_ONLY
+    assert policy.run_docs
+    assert not policy.run_rust
+    assert not policy.run_extensions
+    assert not policy.run_gpu
+
+
+def test_ci_and_docs_runs_both_lightweight_suites() -> None:
+    policy = classify_paths([
+        ".github/workflows/ci.yml",
+        "docs/worklogs/ci.md",
+    ])
+    assert policy.change_class is ChangeClass.CI_ONLY
+    assert policy.run_ci_config
+    assert policy.run_docs
+    assert not policy.run_rust
+
+
+def test_runpod_control_plane_requires_gpu() -> None:
+    policy = classify_paths(["scripts/ci/runpod_client.py"])
+    assert policy.change_class is ChangeClass.CI_ONLY
+    assert policy.run_ci_config
+    assert policy.run_gpu
+
+
+def test_unknown_and_empty_diffs_fall_back_to_code() -> None:
+    for paths in ([], ["new-top-level-policy.toml"]):
+        policy = classify_paths(paths)
+        assert policy.change_class is ChangeClass.CODE
+        assert policy.run_rust
+        assert policy.run_extensions
+        assert policy.run_gpu
+
+
+def test_push_to_main_forces_comprehensive_non_gpu_lanes() -> None:
+    policy = classify_paths(["README.md"], event="push")
+    assert policy.change_class is ChangeClass.CODE
+    assert policy.run_rust
+    assert policy.run_extensions
+    assert policy.run_docs
+    assert policy.run_ci_config
+```
+
+- [ ] **Step 2: Run the tests and confirm the red state**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_change_policy -v
+```
+
+Expected: import failure because `scripts.ci.change_policy` does not exist.
+
+- [ ] **Step 3: Implement the classifier and GitHub-output CLI**
+
+Use immutable output with explicit path allowlists:
+
+```python
+class ChangeClass(enum.StrEnum):
+    CODE = "code"
+    DOCS_ONLY = "docs-only"
+    CI_ONLY = "ci-only"
+
+
+@dataclasses.dataclass(frozen=True)
+class ChangePolicy:
+    change_class: ChangeClass
+    run_rust: bool
+    run_blas: bool
+    run_extensions: bool
+    run_docs: bool
+    run_ci_config: bool
+    run_gpu: bool
+    reasons: tuple[str, ...]
+
+
+def classify_paths(paths: Sequence[str], event: str = "pull_request") -> ChangePolicy:
+    normalized = tuple(sorted({path.strip().removeprefix("./") for path in paths if path.strip()}))
+    if event == "push" or not normalized:
+        return full_policy("push-to-main override" if event == "push" else "empty diff fallback")
+
+    docs = tuple(path for path in normalized if is_docs_path(path))
+    ci = tuple(path for path in normalized if is_ci_path(path))
+    unknown = tuple(path for path in normalized if path not in docs and path not in ci)
+    if unknown:
+        return full_policy("code or unknown paths: " + ", ".join(unknown))
+
+    has_ci = bool(ci)
+    return ChangePolicy(
+        change_class=ChangeClass.CI_ONLY if has_ci else ChangeClass.DOCS_ONLY,
+        run_rust=False,
+        run_blas=False,
+        run_extensions=False,
+        run_docs=bool(docs),
+        run_ci_config=has_ci,
+        run_gpu=any(is_gpu_control_plane_path(path) for path in ci),
+        reasons=("docs: " + ", ".join(docs), "ci: " + ", ".join(ci)),
+    )
+```
+
+The CLI must accept `--event`, either repeated `--path` or `--base/--head`, print JSON to stdout, and append stable lowercase booleans plus `classification` and `reason` to `$GITHUB_OUTPUT` when present. `git diff` failures return nonzero rather than falling back cheap.
+
+- [ ] **Step 4: Run classifier tests and CLI smoke checks**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_change_policy -v
+python3 scripts/ci/change_policy.py --path README.md --path docs/index.md
+python3 scripts/ci/change_policy.py --path crates/tenferro-cpu/src/lib.rs
+```
+
+Expected: tests pass; first JSON is `docs-only`, second is `code`.
+
+- [ ] **Step 5: Commit the classifier**
+
+```bash
+git add scripts/ci
+git commit -m "ci: add conservative change classification"
+```
+
+## Task 2: Shared local and hosted command profiles
+
+**Files:**
+
+- Create: `scripts/ci/run_profile.py`
+- Create: `scripts/ci/tests/test_run_profile.py`
+- Modify: `scripts/check-pr-fast.sh`
+
+- [ ] **Step 1: Write failing profile routing tests**
+
+```python
+from scripts.ci.run_profile import commands_for, expand_profiles
+
+
+def test_workspace_blas_matches_ci_feature_contract() -> None:
+    commands = commands_for("workspace-blas")
+    assert commands == (
+        "cargo nextest run --workspace --release --no-default-features --features cpu-blas --no-fail-fast",
+        "cargo test --doc --workspace --release --no-default-features --features cpu-blas",
+    )
+
+
+def test_full_profile_expands_named_profiles_once() -> None:
+    expanded = expand_profiles(["full"])
+    assert expanded == (
+        "workspace-faer",
+        "workspace-blas",
+        "blas-inject",
+        "extensions",
+        "docs",
+        "coverage",
+        "ci-config",
+    )
+    assert len(expanded) == len(set(expanded))
+
+
+def test_duplicate_profile_composition_is_deduplicated() -> None:
+    assert expand_profiles(["workspace-faer", "full"])[0] == "workspace-faer"
+    assert expand_profiles(["workspace-faer", "full"]).count("workspace-faer") == 1
+```
+
+- [ ] **Step 2: Confirm tests fail before implementation**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_run_profile -v
+```
+
+Expected: import failure for `scripts.ci.run_profile`.
+
+- [ ] **Step 3: Implement exact profiles, composition, and dry run**
+
+Represent commands as immutable static tuples. Execute with `subprocess.run(command, shell=True, check=True, env=...)`; commands are repository constants, never user-provided shell text. Set `RUSTFLAGS=-l dylib=openblas -l dylib=lapack` only for `workspace-blas`.
+
+The profile map must contain the exact existing commands, including:
+
+```python
+PROFILE_COMMANDS = {
+    "workspace-faer": (
+        "cargo nextest run --workspace --release --no-fail-fast",
+        "cargo test --doc --workspace --release",
+    ),
+    "workspace-blas": (
+        "cargo nextest run --workspace --release --no-default-features --features cpu-blas --no-fail-fast",
+        "cargo test --doc --workspace --release --no-default-features --features cpu-blas",
+    ),
+    "blas-inject": (
+        'cargo test -p tenferro-cpu --test inject_tests --release --no-default-features --features "cpu-blas,provider-inject"',
+    ),
+    "extensions": (
+        "cargo test --manifest-path ext/tropical/Cargo.toml --release --features autodiff",
+        "cargo test --manifest-path ext/sparse/Cargo.toml --release --features autodiff",
+        "cargo check --manifest-path samples/kdv-pinn/Cargo.toml --release --all-targets",
+    ),
+    "docs": (
+        "python3 scripts/test-check-docs-site.py",
+        "python3 scripts/test-doc-consistency.py",
+        "python3 scripts/test-repository-rules-review.py",
+        "python3 scripts/check-guide-dependency-snippets.py",
+        "python3 scripts/check-operation-categories.py --fail-on-findings",
+        "bash scripts/build_docs_site.sh",
+    ),
+    "coverage": (
+        "cargo llvm-cov --workspace --release --json --output-path coverage.json",
+        "python3 scripts/check-coverage.py coverage.json",
+    ),
+    "ci-config": (
+        "python3 -m unittest discover -s scripts/ci/tests -v",
+        "actionlint",
+    ),
+}
+```
+
+Support `--list`, `--dry-run`, and one or more profile names. Print `+ <command>` before each execution and include the profile in failures.
+
+- [ ] **Step 4: Extend fast preflight without duplicating commands**
+
+Add repeatable `--ci-profile NAME` and `--ci-profile-dry-run` options to `scripts/check-pr-fast.sh`. The execution must be exactly:
+
+```bash
+python3 scripts/ci/run_profile.py "${profile_args[@]}"
+```
+
+The existing `--test` behavior remains available, but documentation tells contributors to prefer profiles for commands owned by CI.
+
+- [ ] **Step 5: Verify profile tests and dry-run parity**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_run_profile -v
+python3 scripts/ci/run_profile.py --list
+python3 scripts/ci/run_profile.py --dry-run full
+bash scripts/check-pr-fast.sh --no-fetch --coverage-reviewed --skip-doc-snippets --ci-profile workspace-blas --ci-profile-dry-run
+```
+
+Expected: all tests pass; dry runs print each concrete command once and execute no Cargo command.
+
+- [ ] **Step 6: Commit the profile runner**
+
+```bash
+git add scripts/ci/run_profile.py scripts/ci/tests/test_run_profile.py scripts/check-pr-fast.sh
+git commit -m "ci: share local and hosted command profiles"
+```
+
+## Task 3: Integrate classifier-backed no-ops into non-GPU workflows
+
+**Files:**
+
+- Create: `scripts/ci/tests/test_workflow_contracts.py`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/workflows/ci-pr-workspace-tests.yml`
+
+- [ ] **Step 1: Write failing workflow source-contract tests**
+
+Read workflows as text and assert stable required names and shared helpers:
+
+```python
+def test_fast_ci_uses_shared_policy_and_profiles() -> None:
+    text = read(".github/workflows/ci.yml")
+    assert "python3 scripts/ci/change_policy.py" in text
+    assert "python3 scripts/ci/run_profile.py blas-inject" in text
+    assert "python3 scripts/ci/run_profile.py coverage" in text
+    assert "python3 scripts/ci/run_profile.py docs" in text
+    assert "name: CI configuration checks" in text
+
+
+def test_required_names_remain_stable() -> None:
+    fast = read(".github/workflows/ci.yml")
+    heavy = read(".github/workflows/ci-pr-workspace-tests.yml")
+    for name in ("rustfmt", "clippy", "coverage", "docs-site", "cargo test (blas inject)"):
+        assert f"name: {name}" in fast
+    assert "name: CI gate (PR workspace tests)" in heavy
+
+
+def test_heavy_workflow_has_explicit_noop_matrix_and_gate_contract() -> None:
+    text = read(".github/workflows/ci-pr-workspace-tests.yml")
+    assert '"backend":"not-required"' in text
+    assert "RUN_WORKSPACE" in text
+    assert "RUN_EXTENSIONS" in text
+    assert "Workspace tests not required" in text
+```
+
+- [ ] **Step 2: Run the contracts and verify failure**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_workflow_contracts -v
+```
+
+Expected: failures because workflows still contain inline regexes and commands.
+
+- [ ] **Step 3: Add a policy job and conditional expensive steps to `ci.yml`**
+
+Add a first job that checks out full history and runs:
+
+```yaml
+- name: Classify change
+  id: policy
+  env:
+    EVENT_NAME: ${{ github.event_name }}
+    BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  run: >-
+    python3 scripts/ci/change_policy.py
+    --event "${EVENT_NAME}"
+    --base "${BASE_SHA}"
+    --head "${HEAD_SHA}"
+```
+
+Expose every policy flag as an output. Make each existing required job depend on the policy job, condition only expensive setup/execution steps, and add an unconditional summary step. The job itself must succeed when work is intentionally unnecessary.
+
+Add `CI configuration checks`; it runs `python3 scripts/ci/run_profile.py ci-config` only when `run_ci_config == 'true'`, otherwise reports a no-op. Use a pinned actionlint installer/version in workflow setup.
+
+- [ ] **Step 4: Replace backend regexes with policy output in the heavy workflow**
+
+The selector uses the shared classifier. For `run_workspace=false`, emit one matrix entry:
+
+```json
+{"backend":"not-required","profile":"","rustflags":""}
+```
+
+For code changes emit faer and, when `run_blas=true`, BLAS entries with profile names. The matrix job invokes:
+
+```yaml
+python3 scripts/ci/run_profile.py "${{ matrix.cfg.profile }}"
+```
+
+only when the profile is nonempty; otherwise it prints `Workspace tests not required: <reason>`.
+
+Make extension steps call `run_profile.py extensions` only when `run_extensions=true`. The aggregate gate receives both policy booleans and accepts successful no-op jobs only when the corresponding boolean is false.
+
+- [ ] **Step 5: Run workflow contracts, policy tests, and profile dry runs**
+
+Run:
+
+```bash
+python3 -m unittest discover -s scripts/ci/tests -v
+python3 scripts/ci/run_profile.py --dry-run workspace-faer workspace-blas extensions coverage docs
+git diff --check
+```
+
+Expected: all tests pass; no inline backend path regex remains.
+
+- [ ] **Step 6: Run actionlint and focused real profiles**
+
+Install the pinned actionlint release used in CI if absent, then run:
+
+```bash
+actionlint .github/workflows/ci.yml .github/workflows/ci-pr-workspace-tests.yml
+python3 scripts/ci/run_profile.py blas-inject
+```
+
+Expected: actionlint passes and provider injection tests pass.
+
+- [ ] **Step 7: Commit non-GPU workflow integration**
+
+```bash
+git add .github/workflows/ci.yml .github/workflows/ci-pr-workspace-tests.yml scripts/ci/tests/test_workflow_contracts.py
+git commit -m "ci: skip irrelevant PR lanes conservatively"
+```
+
+## Task 4: Validate the live RunPod schema before archive work
+
+**Files:**
+
+- Create: `scripts/ci/runpod_config.json`
+- Create: `scripts/ci/runpod_contract.py`
+- Create: `scripts/ci/tests/test_runpod_contract.py`
+- Modify: `.github/workflows/runpod-gpu-test.yml`
+
+- [ ] **Step 1: Write failing OpenAPI contract tests**
+
+Use in-memory fixtures with a `$ref` from the POST request body to a component schema:
+
+```python
+SCHEMA = {
+    "paths": {
+        "/pods": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/CreatePod"}
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "CreatePod": {
+                "type": "object",
+                "properties": {
+                    "gpuTypeIds": {
+                        "type": "array",
+                        "items": {"enum": ["NVIDIA A40", "NVIDIA GeForce RTX 4090"]},
+                    }
+                },
+            }
+        }
+    },
+}
+
+
+def test_extract_gpu_enum_follows_local_ref() -> None:
+    assert extract_gpu_type_ids(SCHEMA) == frozenset({"NVIDIA A40", "NVIDIA GeForce RTX 4090"})
+
+
+def test_validate_reports_every_invalid_configured_id() -> None:
+    with assertRaisesRegex(ContractError, "Tesla T4.*Unknown GPU"):
+        validate_gpu_type_ids(SCHEMA, ["Tesla T4", "Unknown GPU"])
+
+
+def test_missing_post_schema_is_a_hard_error() -> None:
+    with assertRaisesRegex(ContractError, "POST /pods"):
+        extract_gpu_type_ids({"paths": {}})
+```
+
+- [ ] **Step 2: Confirm contract tests fail**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_runpod_contract -v
+```
+
+Expected: import failure for `runpod_contract`.
+
+- [ ] **Step 3: Implement configuration and local `$ref` resolution**
+
+The JSON configuration contains `cloud_type`, `gpu_type_ids`, retry limits, and disk settings. Keep the current reviewed valid GPU list and no secret values.
+
+Implement:
+
+```python
+def resolve_local_ref(document: Mapping[str, object], ref: str) -> Mapping[str, object]:
+    if not ref.startswith("#/"):
+        raise ContractError(f"unsupported non-local OpenAPI reference: {ref}")
+    value: object = document
+    for token in ref[2:].split("/"):
+        token = token.replace("~1", "/").replace("~0", "~")
+        if not isinstance(value, Mapping) or token not in value:
+            raise ContractError(f"unresolved OpenAPI reference: {ref}")
+        value = value[token]
+    if not isinstance(value, Mapping):
+        raise ContractError(f"OpenAPI reference is not an object schema: {ref}")
+    return value
+```
+
+Fetch with `urllib.request` and bearer authentication, parse JSON, validate all configured IDs, and print a concise success message. Never log the API key.
+
+- [ ] **Step 4: Insert trusted change classification and contract validation before CUDA archive creation**
+
+Extend the hosted `authorize` job with a `gpu_required` output. For PR runs, it
+fetches the changed-file list through the GitHub API and passes that list to the
+classifier checked out from trusted `main`; for push-to-main and explicit
+revision validation it sets `gpu_required=true`. Only RunPod control-plane CI
+paths, code paths, or unknown paths require GPU. Docs-only and unrelated
+CI-only changes publish an explicit successful no-op.
+
+Add a `runpod-contract` job after authorization, guarded by
+`gpu_required == 'true'`. It checks out the same trusted workflow revision,
+loads `runpod_config.json`, fetches `openapi.json`, and runs the validator. Make
+`cuda-archive`, pod creation, and GPU tests depend on the same trusted output so
+an invalid request cannot compile/upload an archive and an untrusted PR cannot
+choose its own classification.
+
+Add source-contract assertions that `RUNPOD_API_KEY` appears only in trusted
+hosted jobs and never in `run-gpu-tests`, and that the final required gate
+reports success for a skip only when the trusted `gpu_required` output is
+`false`.
+
+- [ ] **Step 5: Run fixtures, config validation against a saved live schema, and actionlint**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_runpod_contract scripts.ci.tests.test_workflow_contracts -v
+RUNPOD_OPENAPI_FILE=/tmp/runpod-openapi.json python3 scripts/ci/runpod_contract.py --schema-file "$RUNPOD_OPENAPI_FILE"
+actionlint .github/workflows/runpod-gpu-test.yml
+```
+
+Expected: fixtures pass; the live-schema fixture accepts every configured ID; actionlint passes. The authenticated live fetch remains CI-only if no local key is available.
+
+- [ ] **Step 6: Commit schema preflight**
+
+```bash
+git add scripts/ci/runpod_config.json scripts/ci/runpod_contract.py scripts/ci/tests/test_runpod_contract.py .github/workflows/runpod-gpu-test.yml scripts/ci/tests/test_workflow_contracts.py
+git commit -m "ci: validate RunPod requests before GPU setup"
+```
+
+## Task 5: Status-aware RunPod pod creation
+
+**Files:**
+
+- Create: `scripts/ci/runpod_client.py`
+- Create: `scripts/ci/tests/test_runpod_client.py`
+- Modify: `.github/workflows/runpod-gpu-test.yml`
+
+- [ ] **Step 1: Write failing status, delay, payload, and protocol tests**
+
+```python
+def test_retry_classification() -> None:
+    for status in (408, 429, 500, 502, 503):
+        assert classify_http_status(status) is RetryClass.RETRYABLE
+    for status in (400, 401, 403, 404, 422):
+        assert classify_http_status(status) is RetryClass.PERMANENT
+
+
+def test_backoff_is_bounded_and_jittered() -> None:
+    delays = [backoff_seconds(i, base=5, cap=60, jitter=lambda: 0.5) for i in range(1, 8)]
+    assert delays == [2.5, 5.0, 10.0, 20.0, 30.0, 30.0, 30.0]
+
+
+def test_payload_preserves_secure_trust_boundary(config: Mapping[str, object]) -> None:
+    payload = build_pod_payload(config, "image", "startup", "jit")
+    assert payload["cloudType"] == "SECURE"
+    assert payload["interruptible"] is False
+    assert payload["gpuTypeIds"] == config["gpu_type_ids"]
+
+
+def test_success_without_pod_id_is_protocol_error() -> None:
+    with assertRaisesRegex(PermanentRunPodError, "missing pod id"):
+        parse_create_response(201, b"{}")
+```
+
+Use a fake transport and fake sleeper to assert permanent errors make one call, while two 500 responses followed by 201 make three calls and two bounded sleeps.
+
+- [ ] **Step 2: Confirm the client tests fail**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_runpod_client -v
+```
+
+Expected: import failure for `runpod_client`.
+
+- [ ] **Step 3: Implement request construction and retry loop**
+
+Use `urllib.request`, inject transport/sleep/random functions for tests, and define typed internal exceptions. The loop must stop at both `max_attempts` and `deadline_seconds`:
+
+```python
+for attempt in range(1, max_attempts + 1):
+    try:
+        status, headers, body = transport(payload)
+    except OSError as error:
+        failure = RetryableRunPodError(f"transport failure: {error}")
+    else:
+        retry_class = classify_http_status(status)
+        if 200 <= status < 300:
+            return parse_create_response(status, body)
+        message = redacted_error_message(body)
+        if retry_class is RetryClass.PERMANENT:
+            raise PermanentRunPodError(f"RunPod HTTP {status}: {message}")
+        failure = RetryableRunPodError(f"RunPod HTTP {status}: {message}")
+
+    if attempt == max_attempts or monotonic() >= deadline:
+        raise failure
+    delay = retry_after_or_backoff(headers, attempt, config, random_fn)
+    sleep(min(delay, max(0.0, deadline - monotonic())))
+```
+
+Redact JIT configuration and configured secret field names from all payload and response logging.
+
+- [ ] **Step 4: Replace the inline five-attempt curl loop**
+
+Keep creation of the startup script in the trusted workflow. Check out the trusted helper revision and call:
+
+```bash
+python3 scripts/ci/runpod_client.py create \
+  --config scripts/ci/runpod_config.json \
+  --startup-script /tmp/runpod-startup.sh \
+  --image-name "${RUNPOD_IMAGE}" \
+  --response-file /tmp/runpod-response.json
+```
+
+The helper appends `pod_id` and `gpu_type_id` to `$GITHUB_OUTPUT`. The subsequent runner-registration wait and unconditional cleanup retain their existing trust and permission boundaries.
+
+- [ ] **Step 5: Run client tests and workflow contracts**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_runpod_client scripts.ci.tests.test_workflow_contracts -v
+actionlint .github/workflows/runpod-gpu-test.yml
+```
+
+Expected: tests and actionlint pass; workflow source contains no `for attempt in $(seq 1 5)` pod-creation loop.
+
+- [ ] **Step 6: Commit status-aware creation**
+
+```bash
+git add scripts/ci/runpod_client.py scripts/ci/tests/test_runpod_client.py .github/workflows/runpod-gpu-test.yml scripts/ci/tests/test_workflow_contracts.py
+git commit -m "ci: classify and retry RunPod failures"
+```
+
+## Task 6: Content-addressed cache and trusted PR-number recovery
+
+**Files:**
+
+- Create: `scripts/ci/recover_runpod_pr.py`
+- Create: `scripts/ci/tests/test_recover_runpod_pr.py`
+- Modify: `.github/workflows/runpod-gpu-test.yml`
+- Modify: `.github/workflows/CI_gpu.yml`
+
+- [ ] **Step 1: Write failing cache and recovery tests**
+
+```python
+def test_cache_key_does_not_include_ref_identity() -> None:
+    text = read(".github/workflows/runpod-gpu-test.yml")
+    key_line = next(line for line in text.splitlines() if 'key="cuda-archive-' in line)
+    assert "TENFERRO_REF" not in key_line
+    assert "hashFiles(" in key_line
+
+
+def test_dispatch_always_uses_trusted_main() -> None:
+    command = build_dispatch_command(1379, wait=False)
+    assert command == [
+        "gh", "workflow", "run", "runpod-gpu-test.yml",
+        "--ref", "main", "-f", "pr_number=1379",
+    ]
+
+
+def test_invalid_pr_numbers_are_rejected() -> None:
+    for value in (0, -1):
+        with assertRaisesRegex(ValueError, "positive"):
+            build_dispatch_command(value, wait=False)
+```
+
+Workflow contracts must assert the manual `pr_number` input, same-repository check, open-state check, head-stability recheck, trusted changed-file classification, and final publication through the authorized target output.
+
+- [ ] **Step 2: Confirm tests fail before changes**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_recover_runpod_pr scripts.ci.tests.test_workflow_contracts -v
+```
+
+Expected: missing helper and missing workflow input failures.
+
+- [ ] **Step 3: Make the archive key content/configuration based**
+
+Remove `TENFERRO_REF` from the key. Keep a bumped format version, OS, CUDA binding/runtime versions, and `hashFiles` over lockfile, manifests, sources, and tests. Preserve per-run artifact upload on both cache hit and miss.
+
+- [ ] **Step 4: Add trusted `pr_number` authorization**
+
+Add optional numeric `pr_number` input. In manual PR mode, the hosted authorize job uses GitHub API to fetch the PR, verifies:
+
+```bash
+test "$(jq -r .state <<<"${pr_json}")" = open
+test "$(jq -r .head.repo.full_name <<<"${pr_json}")" = "${GITHUB_REPOSITORY}"
+```
+
+It records `tenferro_ref` and `target_head_sha` from `.head.sha`, fetches the PR a second time, and rejects head movement. Conflicting `pr_number`, `tenferro_ref`, or `ci_gpu_gate_head_sha` combinations fail explicitly.
+
+For automatic mode, expose the already validated PR head as the same
+`target_head_sha` output. In either PR mode, fetch the complete changed-file
+list with pagination and classify it using the helper from trusted `main`;
+publish `gpu_required` from that result. Final gate publication consumes only
+`needs.authorize.outputs.target_head_sha` and
+`needs.authorize.outputs.gpu_required`.
+
+- [ ] **Step 5: Implement the maintainer CLI**
+
+`recover_runpod_pr.py PR_NUMBER [--wait]` validates `gh auth status`, dispatches exactly at `--ref main`, prints the URL returned by `gh workflow run`, and optionally watches that run. It never accepts a workflow ref override and never reads a secret.
+
+Use `subprocess.run(..., check=True, text=True, capture_output=True)` with an injectable runner for unit tests.
+
+- [ ] **Step 6: Verify recovery contracts and dry-run command**
+
+Run:
+
+```bash
+python3 -m unittest scripts.ci.tests.test_recover_runpod_pr scripts.ci.tests.test_workflow_contracts -v
+python3 scripts/ci/recover_runpod_pr.py --dry-run 1379
+actionlint .github/workflows/runpod-gpu-test.yml .github/workflows/CI_gpu.yml
+```
+
+Expected: command shows `--ref main -f pr_number=1379`; tests and actionlint pass.
+
+- [ ] **Step 7: Commit cache and recovery changes**
+
+```bash
+git add scripts/ci/recover_runpod_pr.py scripts/ci/tests/test_recover_runpod_pr.py .github/workflows/runpod-gpu-test.yml .github/workflows/CI_gpu.yml scripts/ci/tests/test_workflow_contracts.py
+git commit -m "ci: add trusted PR GPU recovery"
+```
+
+## Task 7: Documentation, work log, and full verification
+
+**Files:**
+
+- Modify: `CONTRIBUTING.md`
+- Create: `docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md`
+- Modify: `docs/superpowers/specs/2026-07-14-change-aware-ci-runpod-recovery-design.md` (record the trusted post-merge live-validation boundary)
+
+- [ ] **Step 1: Add contributor-facing command and classification docs**
+
+Document:
+
+```bash
+python3 scripts/ci/run_profile.py --list
+python3 scripts/ci/run_profile.py workspace-faer
+python3 scripts/ci/run_profile.py workspace-blas
+python3 scripts/ci/recover_runpod_pr.py 1379 --wait
+```
+
+Explain docs-only, CI-only, unknown-path fallback, comprehensive `main` behavior, and that PR-number recovery executes the trusted workflow from `main`.
+
+- [ ] **Step 2: Write the curated work log**
+
+Record issue #1379, PR #1376 evidence, files/rules read, central-helper design, docs/CI classification, required-check no-op decision, SECURE trust boundary, OpenAPI validation, retry semantics, content cache key, rejected inline/external-service alternatives, verification, live GPU result, and residual risks.
+
+- [ ] **Step 3: Run all CI helper and source-contract tests**
+
+```bash
+python3 -m unittest discover -s scripts/ci/tests -v
+python3 scripts/ci/run_profile.py --dry-run full
+actionlint
+```
+
+Expected: all helper tests and all workflows pass.
+
+- [ ] **Step 4: Run exact non-GPU profiles**
+
+```bash
+python3 scripts/ci/run_profile.py workspace-faer
+python3 scripts/ci/run_profile.py workspace-blas
+python3 scripts/ci/run_profile.py blas-inject
+python3 scripts/ci/run_profile.py extensions
+python3 scripts/ci/run_profile.py docs
+python3 scripts/ci/run_profile.py coverage
+```
+
+Expected: every profile passes; coverage thresholds pass for all tracked files.
+
+- [ ] **Step 5: Run repository-required quality gates**
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings
+cargo test --workspace --release
+cargo doc --workspace --no-deps
+python3 scripts/check-docs-site.py
+python3 scripts/repository-rules-review.py \
+  --base origin/main \
+  --head HEAD \
+  --output-json /tmp/repository-rules-review-1379.json
+```
+
+Expected: every command passes and repository review reports no findings.
+
+- [ ] **Step 6: Validate change classes end to end**
+
+For checked-in fixture path lists, invoke the classifier CLI and assert:
+
+- docs-only selects docs and skips Rust/extensions/GPU;
+- unrelated CI-only selects CI config and skips Rust/docs/GPU;
+- RunPod CI-only selects CI config plus GPU;
+- mixed docs/CI selects docs plus CI config;
+- Rust and unknown paths select full validation;
+- push mode selects the comprehensive non-GPU matrix.
+
+- [ ] **Step 7: Perform the trusted recovery dry run before merge**
+
+After pushing the branch and opening the PR, run:
+
+```bash
+python3 scripts/ci/recover_runpod_pr.py --dry-run <PR_NUMBER>
+```
+
+Expected: the command targets `runpod-gpu-test.yml --ref main` and passes only
+the PR number. Do not dispatch the PR branch workflow with repository secrets.
+
+- [ ] **Step 8: Re-read repository rules and update the work log with pre-merge evidence**
+
+Read `REPOSITORY_RULES.md` again. Add final local command outcomes, PR CI
+evidence, the pending trusted post-merge live-validation requirement, and
+residual risks to the work log.
+
+- [ ] **Step 9: Commit documentation and pre-merge verification record**
+
+```bash
+git add CONTRIBUTING.md docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md docs/superpowers/specs/2026-07-14-change-aware-ci-runpod-recovery-design.md
+git commit -m "docs: record change-aware CI operations"
+```
+
+- [ ] **Step 10: Prepare and land the implementation PR**
+
+Create a PR that links (but does not yet close) #1379, links the work log and design spec,
+lists exact local verification, and calls out that required check names and the
+SECURE RunPod trust boundary are unchanged. Enable auto-merge after all
+pre-merge required checks succeed and land the PR; keep issue #1379 open until
+the trusted post-merge live GPU validation succeeds.
+
+- [ ] **Step 11: Run trusted post-merge live validation and close the issue**
+
+After the implementation lands on `main`, dispatch the now-trusted workflow
+against the landed revision:
+
+```bash
+gh workflow run runpod-gpu-test.yml --ref main -f tenferro_ref=main
+```
+
+Expected: schema validation passes before archive work, CUDA archive cache
+behavior is reported, a SECURE pod is created, CUDA and OpenXLA PJRT GPU tests
+pass, cleanup succeeds, and the workflow concludes successfully. Comment on
+#1379 with the run URL, cache hit/miss, assigned GPU, test result, and cleanup
+result, then close the issue. If it fails, keep the issue open and prepare a
+corrective follow-up.

--- a/docs/superpowers/plans/2026-07-15-runpod-price-tier-fallback.md
+++ b/docs/superpowers/plans/2026-07-15-runpod-price-tier-fallback.md
@@ -1,0 +1,403 @@
+# RunPod price-tier fallback implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move trusted RunPod CI immediately through reviewed GPU price tiers when capacity is unavailable, bound creation to 60 seconds, and record the assigned GPU.
+
+**Architecture:** `runpod_config.json` owns three ordered SECURE Cloud tiers. `runpod_client.py` distinguishes capacity exhaustion from generic transient failures: capacity changes tier without sleeping, while network/rate-limit/service failures get one short same-tier retry. Workflow YAML only forwards and displays the selected tier and GPU.
+
+**Tech Stack:** Python 3 standard library, `unittest`, JSON, GitHub Actions YAML, actionlint.
+
+---
+
+### Task 1: Capacity-aware tier failover
+
+**Files:**
+- Modify: `scripts/ci/tests/test_runpod_client.py`
+- Modify: `scripts/ci/runpod_client.py`
+
+- [ ] **Step 1: Write the failing capacity tests**
+
+Add imports for `CreateRequest` and `is_capacity_failure`, then add:
+
+```python
+def test_capacity_failure_requires_server_error_and_known_message(self) -> None:
+    body = b'{"error":"This machine does not have the resources to deploy your pod"}'
+    self.assertTrue(is_capacity_failure(500, body))
+    self.assertFalse(is_capacity_failure(400, body))
+    self.assertFalse(is_capacity_failure(500, b'{"error":"internal failure"}'))
+
+def test_capacity_failure_moves_tier_without_sleep(self) -> None:
+    requests = [
+        CreateRequest("cost-preferred", b"cheap"),
+        CreateRequest("premium", b"premium"),
+    ]
+    responses = iter([
+        (500, {}, b'{"error":"This machine does not have the resources to deploy your pod"}'),
+        (201, {}, b'{"id":"pod-1","machine":{"gpuTypeId":"NVIDIA L40S"}}'),
+    ])
+    seen: list[bytes] = []
+    result = create_pod(
+        CONFIG,
+        requests,
+        transport=lambda payload: (seen.append(payload), next(responses))[1],
+        sleep=lambda _delay: self.fail("capacity failover must not sleep"),
+    )
+    self.assertEqual(seen, [b"cheap", b"premium"])
+    self.assertEqual(result.gpu_tier, "premium")
+    self.assertEqual(result.gpu_type_id, "NVIDIA L40S")
+```
+
+- [ ] **Step 2: Run the named tests and verify RED**
+
+```bash
+python3 -m unittest \
+  scripts.ci.tests.test_runpod_client.RunPodClientTests.test_capacity_failure_requires_server_error_and_known_message \
+  scripts.ci.tests.test_runpod_client.RunPodClientTests.test_capacity_failure_moves_tier_without_sleep
+```
+
+Expected: missing-symbol import errors.
+
+- [ ] **Step 3: Implement the minimal tier request/result types and capacity recognizer**
+
+```python
+@dataclasses.dataclass(frozen=True)
+class CreateRequest:
+    tier_name: str
+    payload: bytes
+
+@dataclasses.dataclass(frozen=True)
+class CreateResult:
+    pod_id: str
+    gpu_type_id: str
+    gpu_tier: str
+    body: bytes
+
+_CAPACITY_MESSAGES = (
+    "does not have the resources to deploy your pod",
+    "no available machine",
+)
+
+def is_capacity_failure(status: int, body: bytes) -> bool:
+    if not 500 <= status < 600:
+        return False
+    message = body.decode("utf-8", errors="replace").lower()
+    return any(marker in message for marker in _CAPACITY_MESSAGES)
+```
+
+Change `parse_create_response` to accept `gpu_tier`. Change `create_pod` to accept `Sequence[CreateRequest]`; on a recognized capacity response, print the current and next tier and break immediately to the next request. On the last tier, raise `RetryableRunPodError`.
+
+- [ ] **Step 4: Update old tests to wrap byte payloads and verify GREEN**
+
+Wrap old payloads as `[CreateRequest("cost-preferred", b"{}")]`.
+
+```bash
+python3 -m unittest scripts.ci.tests.test_runpod_client -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Add RED tests for one same-tier retry and the global deadline**
+
+```python
+def test_generic_service_failure_retries_same_tier_once(self) -> None:
+    responses = iter([
+        (503, {"Retry-After": "2"}, b'{"error":"busy"}'),
+        (201, {}, b'{"id":"pod-1","machine":{"gpuTypeId":"NVIDIA L40S"}}'),
+    ])
+    seen: list[bytes] = []
+    sleeps: list[float] = []
+    result = create_pod(
+        CONFIG | {"same_tier_retries": 1},
+        [CreateRequest("premium", b"premium")],
+        transport=lambda payload: (seen.append(payload), next(responses))[1],
+        sleep=sleeps.append,
+    )
+    self.assertEqual(seen, [b"premium", b"premium"])
+    self.assertEqual(sleeps, [2.0])
+    self.assertEqual(result.gpu_tier, "premium")
+
+def test_creation_deadline_caps_retry_sleep(self) -> None:
+    ticks = iter([0.0, 59.0])
+    sleeps: list[float] = []
+    with self.assertRaises(RetryableRunPodError):
+        create_pod(
+            CONFIG | {"same_tier_retries": 1, "create_deadline_seconds": 60},
+            [CreateRequest("cost-preferred", b"cheap")],
+            transport=lambda _payload: (503, {"Retry-After": "30"}, b"{}"),
+            sleep=sleeps.append,
+            monotonic=lambda: next(ticks),
+        )
+    self.assertEqual(sleeps, [1.0])
+```
+
+- [ ] **Step 6: Verify RED, replace the old attempt budget, and verify GREEN**
+
+Remove `max_create_attempts` use. Read `same_tier_retries`, retain one global monotonic deadline, and cap every sleep by remaining time.
+
+```bash
+python3 -m unittest scripts.ci.tests.test_runpod_client -v
+git add scripts/ci/runpod_client.py scripts/ci/tests/test_runpod_client.py
+git commit -m "ci: fail over RunPod capacity by GPU tier"
+```
+
+### Task 2: Reviewed price tiers and OpenAPI validation
+
+**Files:**
+- Modify: `scripts/ci/runpod_config.json`
+- Modify: `scripts/ci/runpod_contract.py`
+- Modify: `scripts/ci/tests/test_runpod_contract.py`
+- Modify: `scripts/ci/tests/test_runpod_client.py`
+- Modify: `scripts/ci/runpod_client.py`
+
+- [ ] **Step 1: Write RED tests for ordered tier parsing**
+
+Add `configured_gpu_tiers` tests:
+
+```python
+def test_configured_gpu_tiers_preserve_order(self) -> None:
+    tiers = configured_gpu_tiers({"gpu_tiers": [
+        {"name": "cheap", "gpu_type_ids": ["NVIDIA A40"]},
+        {"name": "premium", "gpu_type_ids": ["NVIDIA L40S"]},
+    ]})
+    self.assertEqual(tiers, [
+        ("cheap", ("NVIDIA A40",)),
+        ("premium", ("NVIDIA L40S",)),
+    ])
+
+def test_configured_gpu_tiers_reject_duplicates(self) -> None:
+    with self.assertRaisesRegex(ContractError, "duplicate GPU ID"):
+        configured_gpu_tiers({"gpu_tiers": [
+            {"name": "cheap", "gpu_type_ids": ["NVIDIA A40"]},
+            {"name": "premium", "gpu_type_ids": ["NVIDIA A40"]},
+        ]})
+```
+
+Run `python3 -m unittest scripts.ci.tests.test_runpod_contract -v`.
+Expected: missing-symbol import failure.
+
+- [ ] **Step 2: Implement strict tier parsing**
+
+Implement:
+
+```python
+def configured_gpu_tiers(
+    config: Mapping[str, object],
+) -> list[tuple[str, tuple[str, ...]]]:
+    value = config.get("gpu_tiers")
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)) or not value:
+        raise ContractError("runpod_config.json gpu_tiers must be a nonempty array")
+    tiers: list[tuple[str, tuple[str, ...]]] = []
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise ContractError("each GPU tier must be an object")
+        name, ids = item.get("name"), item.get("gpu_type_ids")
+        if not isinstance(name, str) or not name:
+            raise ContractError("each GPU tier requires a nonempty name")
+        if not isinstance(ids, Sequence) or isinstance(ids, (str, bytes)) or not ids:
+            raise ContractError(f"GPU tier {name} requires nonempty gpu_type_ids")
+        if any(not isinstance(gpu_id, str) or not gpu_id for gpu_id in ids):
+            raise ContractError(f"GPU tier {name} IDs must be nonempty strings")
+        duplicate = seen.intersection(ids)
+        if duplicate:
+            raise ContractError(f"duplicate GPU ID across tiers: {sorted(duplicate)}")
+        seen.update(ids)
+        tiers.append((name, tuple(ids)))
+    return tiers
+```
+
+Flatten all tiers before `validate_gpu_type_ids`.
+
+- [ ] **Step 3: Replace the flat configuration with three reviewed tiers**
+
+Use:
+- `cost-preferred`: all current IDs plus `NVIDIA L4` and `NVIDIA RTX A6000`.
+- `premium`: `NVIDIA RTX 6000 Ada Generation`, `NVIDIA L40`, `NVIDIA L40S`, `NVIDIA GeForce RTX 5090`.
+- `a100`: `NVIDIA A100 80GB PCIe`, `NVIDIA A100-SXM4-80GB`.
+
+Set `"same_tier_retries": 1` and `"create_deadline_seconds": 60`; remove `max_create_attempts`. Keep SECURE Cloud, one non-interruptible GPU, and existing storage settings.
+
+- [ ] **Step 4: Build one payload per tier**
+
+Change `build_pod_payload` to accept `gpu_type_ids: Sequence[str]`. In `main`, build:
+
+```python
+requests = [
+    CreateRequest(
+        tier_name,
+        json.dumps(build_pod_payload(
+            config,
+            args.image_name,
+            args.startup_script.read_text(encoding="utf-8"),
+            jit_config,
+            gpu_type_ids,
+        )).encode(),
+    )
+    for tier_name, gpu_type_ids in configured_gpu_tiers(config)
+]
+```
+
+Pass `requests` to `create_pod`.
+
+- [ ] **Step 5: Run unit and live-contract tests, then commit**
+
+```bash
+python3 -m unittest \
+  scripts.ci.tests.test_runpod_contract \
+  scripts.ci.tests.test_runpod_client -v
+python3 scripts/ci/runpod_contract.py
+git add scripts/ci/runpod_config.json scripts/ci/runpod_contract.py \
+  scripts/ci/runpod_client.py scripts/ci/tests/test_runpod_contract.py \
+  scripts/ci/tests/test_runpod_client.py
+git commit -m "ci: add cost-bounded RunPod GPU tiers"
+```
+
+Expected: the live OpenAPI accepts every configured ID. Never weaken validation to make an invalid ID pass.
+
+### Task 3: Selected GPU observability
+
+**Files:**
+- Modify: `scripts/ci/tests/test_runpod_client.py`
+- Modify: `scripts/ci/tests/test_workflow_contracts.py`
+- Modify: `scripts/ci/runpod_client.py`
+- Modify: `.github/workflows/runpod-gpu-test.yml`
+
+- [ ] **Step 1: Write RED output and workflow contract tests**
+
+Add:
+
+```python
+def test_publish_github_result_records_tier_and_gpu(self) -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        output = Path(directory) / "output"
+        summary = Path(directory) / "summary"
+        result = CreateResult(
+            pod_id="pod-1",
+            gpu_type_id="NVIDIA L40S",
+            gpu_tier="premium",
+            body=b"{}",
+        )
+        publish_github_result(result, output_path=output, summary_path=summary)
+        self.assertEqual(
+            output.read_text(),
+            "pod_id=pod-1\ngpu_type_id=NVIDIA L40S\ngpu_tier=premium\n",
+        )
+        self.assertIn("Selected GPU: `NVIDIA L40S`", summary.read_text())
+        self.assertIn("Price tier: `premium`", summary.read_text())
+```
+
+Add to workflow contracts:
+
+```python
+def test_runpod_selected_gpu_is_forwarded_and_logged(self) -> None:
+    text = read(".github/workflows/runpod-gpu-test.yml")
+    self.assertIn("gpu_tier: ${{ steps.create_pod.outputs.gpu_tier }}", text)
+    self.assertIn("needs.start-runpod.outputs.gpu_type_id", text)
+    self.assertIn("needs.start-runpod.outputs.gpu_tier", text)
+    self.assertIn("nvidia-smi --query-gpu=index,name", text)
+```
+
+Run the two named tests. Expected: missing helper and missing workflow output.
+
+- [ ] **Step 2: Implement GitHub output and summary publication**
+
+```python
+def publish_github_result(
+    result: CreateResult,
+    *,
+    output_path: Path | None,
+    summary_path: Path | None,
+) -> None:
+    if output_path is not None:
+        with output_path.open("a", encoding="utf-8") as output:
+            output.write(f"pod_id={result.pod_id}\n")
+            output.write(f"gpu_type_id={result.gpu_type_id}\n")
+            output.write(f"gpu_tier={result.gpu_tier}\n")
+    if summary_path is not None:
+        with summary_path.open("a", encoding="utf-8") as summary:
+            summary.write("### RunPod GPU selection\n\n")
+            summary.write(f"- Price tier: `{result.gpu_tier}`\n")
+            summary.write(f"- Selected GPU: `{result.gpu_type_id or 'unknown'}`\n")
+```
+
+Call it from `main` with `GITHUB_OUTPUT` and `GITHUB_STEP_SUMMARY` paths when present. Keep ordinary log lines for tier and GPU.
+
+- [ ] **Step 3: Forward the tier in workflow YAML**
+
+Add:
+
+```yaml
+gpu_tier: ${{ steps.create_pod.outputs.gpu_tier }}
+```
+
+to `start-runpod.outputs`. In `Check machine`, print the tier and provider GPU ID immediately before the existing `nvidia-smi --query-gpu=index,name,...` command.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+python3 -m unittest \
+  scripts.ci.tests.test_runpod_client \
+  scripts.ci.tests.test_workflow_contracts -v
+actionlint .github/workflows/runpod-gpu-test.yml
+git add scripts/ci/runpod_client.py scripts/ci/tests/test_runpod_client.py \
+  scripts/ci/tests/test_workflow_contracts.py \
+  .github/workflows/runpod-gpu-test.yml
+git commit -m "ci: log the selected RunPod GPU"
+```
+
+### Task 4: Docs, full verification, and PR completion
+
+**Files:**
+- Modify: `docs/design/change-aware-ci.md`
+- Modify: `docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md`
+
+- [ ] **Step 1: Update durable docs and the work log**
+
+Document: immediate capacity tier changes, one same-tier transient retry, 60-second global deadline, H100 exclusion, A100 price cap, and selected GPU logs/job summary. Record failed run `29334073902`, its five capacity errors, successful cleanup, operational retry, and accepted follow-up design.
+
+- [ ] **Step 2: Run focused verification**
+
+```bash
+python3 scripts/ci/run_profile.py ci-config
+python3 scripts/check-docs-site.py
+git diff --check
+```
+
+Expected: helper tests, actionlint, docs checks, and whitespace checks pass.
+
+- [ ] **Step 3: Run the repository-required checks**
+
+```bash
+cargo fmt --all --check
+cargo test --workspace --release
+cargo llvm-cov --workspace --release --json --output-path coverage.json
+python3 scripts/check-coverage.py coverage.json
+cargo doc --workspace --no-deps
+python3 scripts/check-docs-site.py
+python3 scripts/repository-rules-review.py \
+  --base origin/main --head HEAD \
+  --output-json /tmp/repository-rules-review-1380.json
+```
+
+Also run clippy exactly as defined by the CI `clippy` job. Expected: every command passes.
+
+- [ ] **Step 4: Commit docs**
+
+```bash
+git add docs/design/change-aware-ci.md \
+  docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
+git commit -m "docs: explain RunPod GPU tier fallback"
+```
+
+- [ ] **Step 5: Push and restore auto-merge**
+
+```bash
+git push origin codex/issue-1379-ci-resilience
+gh pr merge 1380 --repo tensor4all/tenferro-rs \
+  --auto --squash --delete-branch
+gh pr checks 1380 --repo tensor4all/tenferro-rs --watch
+```
+
+Expected: the live RunPod log and summary name the selected tier/GPU, cleanup passes, and PR #1380 merges. After merge, dispatch the trusted `main` workflow once and record its URL on issue #1379 before closing it.
+

--- a/docs/superpowers/plans/2026-07-15-runpod-price-tier-fallback.md
+++ b/docs/superpowers/plans/2026-07-15-runpod-price-tier-fallback.md
@@ -400,4 +400,3 @@ gh pr checks 1380 --repo tensor4all/tenferro-rs --watch
 ```
 
 Expected: the live RunPod log and summary name the selected tier/GPU, cleanup passes, and PR #1380 merges. After merge, dispatch the trusted `main` workflow once and record its URL on issue #1379 before closing it.
-

--- a/docs/superpowers/specs/2026-07-14-change-aware-ci-runpod-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-14-change-aware-ci-runpod-recovery-design.md
@@ -187,9 +187,33 @@ The policy is:
 - transient transport failures: retryable;
 - malformed success responses or missing pod IDs: permanent protocol errors.
 
-Retryable failures use bounded exponential backoff with jitter and a total
-deadline. Logs state the attempt, status class, next delay, and redacted
-provider error. Deterministic failures do not sleep or consume all attempts.
+Capacity exhaustion uses price-tier failover instead of repeatedly submitting
+the same candidate set. The reviewed SECURE Cloud GPU allowlist is split into
+three tiers:
+
+1. the existing cost-preferred GPUs;
+2. premium GPUs whose published Pod price is at most USD 0.99/hour;
+3. A100 PCIe and A100 SXM, capped at a published USD 1.49/hour.
+
+H100 and more expensive models are outside the automatic CI allowlist. Prices
+are reference values checked against RunPod's public Pod pricing on 2026-07-15;
+the durable control is the explicit reviewed GPU IDs in each tier, not an
+assumption that a provider price will remain unchanged.
+
+An error response that explicitly reports unavailable machine resources moves
+immediately to the next tier without backoff. Each tier receives one capacity
+attempt. HTTP 408, 429, an unrelated 5xx response, and transient transport
+failures receive at most one short retry in the current tier. A global
+60-second creation deadline bounds all requests and sleeps. This typically
+checks all capacity tiers in about ten seconds while preserving one recovery
+attempt for service or network instability.
+
+Every request log states the attempt, tier, candidate GPU IDs, status class,
+next action, and redacted provider error. On success, the helper records the
+RunPod-assigned GPU ID in ordinary workflow logs and appends the selected tier
+and GPU ID to the GitHub Actions job summary. The GPU test job also prints the
+reported ID next to `nvidia-smi` output so a provider response mismatch is
+visible. Deterministic failures do not sleep or consume all tiers.
 
 The request remains `cloudType: SECURE`, non-interruptible, and limited to the
 reviewed allowlist. Cleanup remains unconditional and idempotent whenever a pod
@@ -278,6 +302,11 @@ Use Python standard-library tests for:
 - profile listing, composition, and dry-run command parity;
 - OpenAPI enum extraction and invalid-ID reporting;
 - HTTP/transport retry classification and bounded delay calculation;
+- immediate capacity failover from the cost-preferred tier through the premium
+  and A100 tiers;
+- same-tier short retry for transport, rate-limit, and non-capacity service
+  failures;
+- selected GPU logging and job-summary output without request secrets;
 - PR-number recovery validation and conflicting input rejection;
 - required workflow names and their classifier-backed no-op contracts.
 
@@ -338,9 +367,11 @@ requires a corrective follow-up before issue #1379 is closed.
   stable job names and test aggregate-gate behavior for every class.
 - **Live OpenAPI changes could block GPU CI.** This is intentional when the
   configured request is invalid; the error must be early and actionable.
-- **Broader retries could increase queue time or cost.** Retries end before pod
-  creation when capacity is absent, use a bounded deadline, and retain the
-  reviewed allowlist and SECURE Cloud.
+- **Broader retries could increase queue time or cost.** Capacity errors switch
+  tiers immediately, all requests share a 60-second deadline, and automatic
+  selection is capped at the reviewed A100 tier (published USD 1.49/hour on
+  2026-07-15). The workflow logs the assigned GPU so actual selections remain
+  auditable.
 - **Cache reuse could restore an incompatible archive.** Include every CUDA,
   runner, archive-format, manifest, and source input in the content key and
   bump the format version when packaging changes.

--- a/docs/superpowers/specs/2026-07-14-change-aware-ci-runpod-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-14-change-aware-ci-runpod-recovery-design.md
@@ -313,9 +313,13 @@ Exercise classifier fixtures representing:
 - an unknown new top-level path;
 - push-to-main override.
 
-Perform one trusted manual dry-run of PR resolution without starting a pod. A
-live RunPod run is required before merge because the request and recovery
-control plane changes. It must use SECURE Cloud and complete cleanup.
+Perform one trusted manual dry-run of PR resolution without starting a pod.
+Because the new secret-bearing workflow and helpers are not trusted `main`
+content until they land, pre-merge validation is limited to fixtures,
+actionlint, source contracts, and dry runs. Immediately after landing, run the
+workflow from `main` against the landed revision. That live validation must use
+SECURE Cloud, complete CUDA and OpenXLA tests, and complete cleanup. A failure
+requires a corrective follow-up before issue #1379 is closed.
 
 ## Documentation and records
 

--- a/docs/superpowers/specs/2026-07-14-change-aware-ci-runpod-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-14-change-aware-ci-runpod-recovery-design.md
@@ -1,0 +1,362 @@
+# Change-aware CI and trusted RunPod recovery
+
+**Date:** 2026-07-14
+**Status:** Approved design, pending implementation plan
+**Issue:** [#1379](https://github.com/tensor4all/tenferro-rs/issues/1379)
+
+## Problem
+
+The current pull-request workflows apply most Rust-heavy validation to every
+change. A documentation-only change still runs workspace tests, coverage,
+provider tests, extension samples, and the GPU gate. A CI-only follow-up also
+reruns those lanes even when no Rust source, manifest, or generated artifact
+has changed.
+
+The NUMA implementation in PR #1376 exposed related feedback and recovery
+problems:
+
+- The CPU-BLAS-only workspace command caught a provider-scope test assumption
+  only after push because local preflight and GitHub Actions do not share one
+  command definition.
+- A one-line RunPod workflow correction restarted the complete non-GPU matrix.
+- The RunPod pod-creation loop retried a deterministic HTTP 400 schema error
+  five times, then treated temporary HTTP 500 capacity failures the same way.
+- Automatic and manual GPU runs rebuilt equivalent CUDA archives because the
+  cache key included ref identity in addition to content.
+- Recovering the required GPU check needed raw ref and SHA inputs and a manual
+  wrapper rerun. That path is correctable, but too easy to invoke incorrectly.
+
+The workflows must reduce latency without weakening branch protection,
+comprehensive main-branch validation, or the trusted RunPod boundary.
+
+## Goals
+
+- Give local contributors exact entry points for the command profiles used by
+  GitHub Actions.
+- Skip irrelevant expensive work for docs-only and CI-only pull requests while
+  preserving successful required check names.
+- Validate RunPod request configuration before building a CUDA archive or
+  requesting paid hardware.
+- Distinguish permanent request failures from retryable service and capacity
+  failures.
+- Reuse equivalent CUDA archives across automatic and manual recovery runs.
+- Provide a PR-number-oriented recovery path that always executes the workflow
+  and secret-bearing helpers from trusted `main`.
+
+## Non-goals
+
+- Do not change tenferro's public Rust API, crate graph, backends, feature
+  flags, numerical behavior, or AD semantics.
+- Do not weaken required checks for changes that can affect compiled code.
+- Do not skip comprehensive validation on pushes to `main`.
+- Do not use RunPod Community Cloud or source a secret-bearing workflow/helper
+  from a pull-request branch.
+- Do not turn an infrastructure failure into a successful GPU result without
+  an actual successful GPU validation.
+- Do not introduce a third-party CI service or a repository dependency for
+  workflow classification.
+
+## Chosen approach
+
+Use repository-owned, standard-library-only Python helpers as the testable
+policy layer and keep GitHub workflow YAML as thin orchestration adapters.
+
+Two alternatives were rejected:
+
+- Keeping all logic inline in YAML is initially smaller, but it would preserve
+  the command drift and make classification, schema parsing, and retry policy
+  difficult to test locally.
+- Moving the policy into an external reusable action or service would create a
+  new trust and versioning boundary for a repository-local problem.
+
+## Change classification
+
+### Classifier contract
+
+Add a single classifier under `scripts/ci/` that consumes changed paths and
+returns:
+
+- a primary class: `code`, `docs-only`, or `ci-only`;
+- independent booleans for documentation, CI configuration, CPU/Rust-heavy,
+  extension, and GPU validation needs;
+- a human-readable explanation listing the paths that selected each flag.
+
+Classification precedence is conservative:
+
+1. Any code, manifest, build input, generated artifact source, or unknown path
+   selects `code`.
+2. If every path belongs to the explicit documentation or CI allowlists and at
+   least one CI path changed, select `ci-only`.
+3. If every path belongs to the documentation allowlist, select `docs-only`.
+
+A mixed docs-and-CI change is therefore `ci-only`, with both the docs and CI
+validation flags enabled. An empty or unrecognized diff is `code`; the
+classifier never guesses that an unknown path is cheap.
+
+Documentation paths include the repository documentation trees and selected
+top-level prose files. CI paths are an explicit list covering workflow files,
+the shared CI helper directory, and the existing PR-check entry points. The
+implementation must not classify all of `scripts/` as CI-only because many
+scripts validate source or generated project content.
+
+### Event policy
+
+Pull requests consume the classifier result. Pushes to `main` override it and
+run the comprehensive non-GPU matrix. This preserves the current post-merge
+backend coverage even when a pull request legitimately took a cheap path. Live
+GPU validation remains a pull-request gate for changes that can affect GPU
+behavior or its control plane; this design does not add a second paid GPU run
+after merge.
+
+The classifier also emits more specific safety decisions:
+
+- A docs-only pull request runs docs/site/snippet/link/consistency validation.
+- A CI-only pull request runs actionlint and CI helper/contract tests.
+- A change to the RunPod control-plane workflow or its request helpers still
+  requires a live GPU gate; unrelated CI-only changes do not.
+- A mixed docs-and-CI pull request runs both relevant lightweight suites.
+
+### Required check behavior
+
+Required job names remain stable. Jobs that have no relevant expensive work
+still start, report the classifier decision, and finish successfully. They are
+not omitted in a way that leaves branch protection waiting for a missing or
+skipped check.
+
+The workspace aggregate gate accepts a successful explicit no-op only when the
+classifier proves the pull request contains no code-affecting path. Code
+changes retain the existing faer lane, conditional BLAS lane, extension
+samples, and their aggregate requirements.
+
+## Shared command profiles
+
+Add a profile runner under `scripts/ci/` and make both local preflight and
+GitHub Actions call it. The initial profiles are:
+
+- `workspace-faer`
+- `workspace-blas`
+- `blas-inject`
+- `extensions`
+- `docs`
+- `coverage`
+- `ci-config`
+- `full`
+
+Profiles own exact Cargo feature flags, release mode, nextest arguments, and
+the repository script sequence. Runner provisioning such as apt installation,
+Rust component installation, and GitHub cache setup remains in YAML.
+
+The runner supports a dry-run/list mode so unit tests can verify command
+routing without compiling the workspace. `scripts/check-pr-fast.sh` may select
+profiles, but it must delegate rather than duplicate the commands.
+
+`full` composes the named profiles rather than maintaining a second command
+list. Profile composition must detect duplicate execution where one profile
+already subsumes another.
+
+## RunPod request validation
+
+### Trusted configuration
+
+Store the cost-bounded GPU allowlist and request policy in one repository-owned
+configuration file. The automatic and manual paths read the same file.
+
+Before CUDA archive construction, a trusted GitHub-hosted job:
+
+1. checks out the helper at the same trusted revision as the workflow;
+2. fetches the authenticated RunPod OpenAPI document from
+   `https://rest.runpod.io/v1/openapi.json`;
+3. resolves the request schema used by `POST /pods`, including local `$ref`
+   references;
+4. compares the configured `gpuTypeIds` with the live enum;
+5. fails with the invalid IDs before archive construction or pod creation.
+
+The validator uses fixture-based tests for direct schemas, referenced schemas,
+missing paths, missing enums, and invalid configured IDs. A missing or
+structurally unexpected live schema is a hard failure, not permission to skip
+validation.
+
+### Retry policy
+
+Move request construction and retry classification into a testable helper.
+The policy is:
+
+- 2xx: success;
+- HTTP 408, 429, and 5xx: retryable;
+- other 4xx: permanent and reported immediately;
+- transient transport failures: retryable;
+- malformed success responses or missing pod IDs: permanent protocol errors.
+
+Retryable failures use bounded exponential backoff with jitter and a total
+deadline. Logs state the attempt, status class, next delay, and redacted
+provider error. Deterministic failures do not sleep or consume all attempts.
+
+The request remains `cloudType: SECURE`, non-interruptible, and limited to the
+reviewed allowlist. Cleanup remains unconditional and idempotent whenever a pod
+ID was created.
+
+## CUDA archive reuse
+
+The archive cache key contains:
+
+- an explicit cache-format version;
+- hosted runner OS;
+- CUDA/PTX/runtime configuration;
+- relevant manifests, lockfile, source, and tests content hashes.
+
+It does not contain the PR head SHA, merge SHA, branch, or dispatch identity.
+Equivalent source trees therefore share a key. The trusted automatic and
+manual workflows both run from `main`, keeping cache scope compatible while
+checking out the requested tenferro ref only for archive/test content.
+
+The workflow continues to upload a per-run artifact because the self-hosted
+RunPod runner cannot directly restore the hosted-runner Actions cache. A cache
+hit skips archive compilation but still uploads the archive for that run.
+
+## Trusted manual recovery
+
+Extend the existing `workflow_dispatch` path with a PR-number input. The
+trusted `main` workflow resolves the pull request through GitHub API and checks:
+
+- the actor has the required repository permission;
+- the pull request belongs to this repository rather than a fork;
+- the pull request is open;
+- the resolved head SHA has not changed during authorization;
+- the published required check targets that exact head SHA.
+
+Raw ref/SHA inputs may remain for non-PR maintainer diagnostics, but PR-number
+mode is the documented recovery path and rejects conflicting inputs.
+
+Provide a small maintainer command that dispatches the workflow explicitly at
+`--ref main`, passes the PR number, prints the run URL, waits for completion
+when requested, and never reads or forwards repository secrets locally.
+
+After a successful external GPU check, the command documents how the
+pull-request wrapper gate observes the newest result. If GitHub requires a
+wrapper rerun, the helper performs or clearly reports that repository-scoped
+action; it never manufactures a success check.
+
+## Workflow data flow
+
+For pull requests:
+
+1. A cheap classification job computes policy flags from the base/head diff.
+2. Required jobs start and either run their shared profiles or report an
+   intentional classifier-backed no-op.
+3. The non-GPU aggregate gate verifies executed or explicitly unnecessary
+   lanes.
+4. The GPU wrapper either records that GPU validation is unnecessary for this
+   diff or waits for the trusted RunPod result.
+5. For a required live GPU run, the trusted workflow validates the RunPod
+   schema before creating the CUDA archive, restores/builds the
+   content-addressed archive, creates a SECURE pod with status-aware retries,
+   runs GPU tests, cleans up, and publishes the result to the PR head.
+
+For pushes to `main`, every non-GPU validation flag is forced on.
+
+## Error handling and observability
+
+- Classifier output includes the class, flags, and matching reason.
+- Every no-op job says which class made its expensive steps unnecessary.
+- Profile failures include the profile and exact command.
+- OpenAPI failures distinguish fetch, parse, schema resolution, and invalid ID
+  errors.
+- RunPod failures distinguish permanent request errors, rate limiting,
+  provider/service failures, transport failures, malformed responses, runner
+  registration timeout, test failure, and cleanup failure.
+- The final GPU check summary identifies the failing phase without treating
+  skipped downstream work as an independent root cause.
+
+## Testing strategy
+
+### Unit and contract tests
+
+Use Python standard-library tests for:
+
+- documentation, CI, mixed, code, empty, and unknown-path classification;
+- per-lane flags, including GPU-control-plane changes;
+- profile listing, composition, and dry-run command parity;
+- OpenAPI enum extraction and invalid-ID reporting;
+- HTTP/transport retry classification and bounded delay calculation;
+- PR-number recovery validation and conflicting input rejection;
+- required workflow names and their classifier-backed no-op contracts.
+
+Use checked-in redacted fixtures derived from public API shapes, not responses
+containing tokens, account IDs, pod IDs, or runner configuration.
+
+### Local validation
+
+At minimum:
+
+```bash
+python3 -m unittest discover -s scripts/ci/tests
+actionlint
+python3 scripts/ci/run_profile.py ci-config
+python3 scripts/ci/run_profile.py workspace-faer
+python3 scripts/ci/run_profile.py workspace-blas
+```
+
+Run profile dry runs for every named profile and source-contract tests against
+all modified workflow files. Repository-wide formatting, clippy, tests,
+coverage, docs, and rule review remain required before PR creation because the
+implementation changes the policy that decides when future PRs may skip them.
+
+### End-to-end validation
+
+Exercise classifier fixtures representing:
+
+- docs-only;
+- CI-only without GPU-control-plane changes;
+- CI-only with RunPod control-plane changes;
+- mixed docs and CI;
+- ordinary Rust code;
+- an unknown new top-level path;
+- push-to-main override.
+
+Perform one trusted manual dry-run of PR resolution without starting a pod. A
+live RunPod run is required before merge because the request and recovery
+control plane changes. It must use SECURE Cloud and complete cleanup.
+
+## Documentation and records
+
+- Document the local profile commands and which PR classes run each lane.
+- Document the PR-number RunPod recovery command and its trust boundary.
+- Add a curated work log covering issue #1379, PR #1376 evidence, decisions,
+  rejected alternatives, validation, and residual risks.
+- Keep detailed implementation mechanics in the helpers and workflow comments;
+  do not duplicate them across contributor documentation.
+
+## Risks and mitigations
+
+- **Misclassification could skip necessary tests.** Explicit allowlists,
+  unknown-path fallback, main override, and table-driven tests mitigate this.
+- **A required job could disappear instead of succeeding as a no-op.** Keep
+  stable job names and test aggregate-gate behavior for every class.
+- **Live OpenAPI changes could block GPU CI.** This is intentional when the
+  configured request is invalid; the error must be early and actionable.
+- **Broader retries could increase queue time or cost.** Retries end before pod
+  creation when capacity is absent, use a bounded deadline, and retain the
+  reviewed allowlist and SECURE Cloud.
+- **Cache reuse could restore an incompatible archive.** Include every CUDA,
+  runner, archive-format, manifest, and source input in the content key and
+  bump the format version when packaging changes.
+- **Manual dispatch could test the wrong commit.** Resolve PR number in the
+  trusted workflow, recheck head stability, and publish only to the resolved
+  SHA.
+
+## Success criteria
+
+- Docs-only pull requests run documentation validation without Rust-heavy,
+  coverage, provider, extension, or live GPU work.
+- CI-only pull requests run actionlint and CI helper tests; RunPod control-plane
+  changes additionally run the live GPU gate.
+- Code pull requests retain required GPU validation, and all pushes to `main`
+  retain the comprehensive non-GPU matrix.
+- Local and hosted CI use the same named profiles and command definitions.
+- Invalid RunPod GPU IDs fail before CUDA archive construction.
+- Permanent 4xx errors are not retried; retryable capacity/service failures use
+  bounded jittered backoff.
+- Equivalent automatic/manual source trees reuse the CUDA archive cache.
+- Maintainers can recover a PR GPU gate safely from a PR number through the
+  trusted `main` workflow.
+- Required check names and branch-protection behavior remain stable.

--- a/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
+++ b/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
@@ -43,6 +43,9 @@ control plane against schema drift and deterministic request failures.
   work at 60 seconds, and exclude GPUs above the reviewed A100 SXM tier.
 - Publish the selected tier and provider GPU ID to both ordinary logs and the
   GitHub job summary, then show them next to the machine's `nvidia-smi` output.
+- Bound every HTTP request by the remaining global deadline, reject a missing
+  or out-of-tier assigned GPU, and pass provider output to shell through the
+  step environment rather than interpolating it into shell source.
 - Exclude ref/SHA identity from the CUDA archive cache key and include all
   content/configuration inputs that affect the archive.
 - Replace raw PR ref/SHA recovery with a PR-number command that dispatches only

--- a/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
+++ b/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
@@ -46,6 +46,8 @@ control plane against schema drift and deterministic request failures.
 - Bound every HTTP request by the remaining global deadline, reject a missing
   or out-of-tier assigned GPU, and pass provider output to shell through the
   step environment rather than interpolating it into shell source.
+- Preserve the pod ID for trusted cleanup even when assigned-GPU validation
+  rejects an otherwise successful create response.
 - Exclude ref/SHA identity from the CUDA archive cache key and include all
   content/configuration inputs that affect the archive.
 - Replace raw PR ref/SHA recovery with a PR-number command that dispatches only

--- a/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
+++ b/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
@@ -1,0 +1,94 @@
+# Issue #1379 change-aware CI and RunPod recovery
+
+## Summary
+
+Issue #1379 consolidates CI latency and RunPod recovery improvements observed
+during the NUMA implementation and its documentation follow-up. This change
+centralizes local/hosted command profiles, makes pull-request lanes
+change-aware with conservative fallbacks, and hardens the trusted RunPod
+control plane against schema drift and deterministic request failures.
+
+## Context read
+
+- Issue #1379 and the timing/recovery evidence from PR #1376.
+- Shared tensor4all repository and docs/tests rules.
+- `AGENTS.md`, `CONTRIBUTING.md`, and `REPOSITORY_RULES.md`, especially CI cost
+  discipline, documentation, design-record, and PR verification requirements.
+- `.github/workflows/ci.yml`, `ci-pr-workspace-tests.yml`, `CI_gpu.yml`, and
+  `runpod-gpu-test.yml`.
+- `scripts/check-pr-fast.sh` and existing docs-site, coverage, and repository
+  review commands.
+- RunPod's live `POST /pods` OpenAPI schema on 2026-07-14.
+- The prior RunPod retirement work log, including its now-superseded raw
+  workflow-branch recovery path.
+
+## Decisions
+
+- Keep one standard-library Python policy layer under `scripts/ci/`; workflows
+  orchestrate it rather than reproducing path regexes or command lists.
+- Treat empty and unknown diffs as code. Docs-only and CI-only are explicit
+  allowlists, and required check names complete as auditable no-ops.
+- Force the comprehensive non-GPU matrix on pushes to `main`. Keep paid GPU
+  work on code PRs and RunPod control-plane changes, after cheaper gates.
+- Validate repository GPU IDs against the live request schema before archive
+  setup. The checked live fixture accepted all 11 configured IDs.
+- Retry only 408, 429, 5xx, and transport failures. Bound retries by count and
+  deadline; treat other 4xx responses and malformed success responses as
+  permanent.
+- Exclude ref/SHA identity from the CUDA archive cache key and include all
+  content/configuration inputs that affect the archive.
+- Replace raw PR ref/SHA recovery with a PR-number command that dispatches only
+  trusted `main`. The hosted authorization job owns state, repository,
+  permission, changed-file, and head-stability checks.
+- Keep secrets on trusted GitHub-hosted jobs. The external RunPod runner stays
+  read-only and never receives RunPod or GitHub App credentials.
+- Publish the durable policy in `docs/design/change-aware-ci.md`; keep the
+  detailed accepted design and execution plan as development records.
+
+## Alternatives rejected
+
+- Inline workflow regexes and duplicated Cargo commands drift between local
+  and hosted execution.
+- A permissive “non-Rust means docs” rule can skip validation for unknown new
+  paths.
+- Retrying every non-2xx response repeats deterministic schema/auth failures
+  and wastes paid-runner latency.
+- A cache key containing a branch or SHA prevents reuse of identical content.
+- Dispatching a secret-bearing workflow from a PR branch makes untrusted
+  workflow/helper content part of the control plane.
+- An external classification service adds availability and ownership without
+  improving the repository-local trust model.
+
+## Verification so far
+
+- Baseline `cargo test --workspace --release --quiet` passed before changes.
+- CI helper unit/source-contract tests passed through each TDD cycle.
+- actionlint 1.7.7 passed all workflows after registering the organization
+  `ubuntu-gpu` label and removing an obsolete `rust-cache` input.
+- The shared faer and BLAS workspace profiles each passed 2,150 nextest tests
+  plus workspace doctests.
+- Provider-injection release tests passed: 3 tests in 5m11s for the cold build.
+- The extension profile passed tropical and sparse release tests and doctests,
+  plus the KdV sample all-target release check.
+- The docs profile passed its source-contract checks, all four executable guide
+  dependency snippets, the 78-page Quarto render, and rendered-site validation.
+- The coverage profile passed all 159 included source files at their configured
+  thresholds.
+- The saved live RunPod OpenAPI schema accepted all 11 configured GPU IDs.
+- Trusted PR recovery dry run targets only
+  `runpod-gpu-test.yml --ref main -f pr_number=1379`.
+
+The committed-head repository review and trusted post-merge SECURE GPU run are
+recorded before closing issue #1379. The live run must happen after the new
+secret-bearing workflow has landed on `main`; pre-merge execution of the PR
+branch workflow is intentionally prohibited.
+
+## Residual risks
+
+- RunPod may change its live schema or capacity between preflight and pod
+  creation; schema mismatch fails early, while transient capacity remains a
+  bounded retry.
+- actionlint validates workflow structure and shell contracts but cannot model
+  GitHub/RunPod external state.
+- The first cache population still pays full CUDA archive cost; content reuse
+  improves subsequent equivalent runs.

--- a/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
+++ b/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
@@ -74,6 +74,7 @@ control plane against schema drift and deterministic request failures.
   dependency snippets, the 78-page Quarto render, and rendered-site validation.
 - The coverage profile passed all 159 included source files at their configured
   thresholds.
+- The committed-head repository-rules review passed with no findings.
 - The saved live RunPod OpenAPI schema accepted all 11 configured GPU IDs.
 - Trusted PR recovery dry run targets only
   `runpod-gpu-test.yml --ref main -f pr_number=1379`.

--- a/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
+++ b/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
@@ -18,7 +18,8 @@ control plane against schema drift and deterministic request failures.
   `runpod-gpu-test.yml`.
 - `scripts/check-pr-fast.sh` and existing docs-site, coverage, and repository
   review commands.
-- RunPod's live `POST /pods` OpenAPI schema on 2026-07-14.
+- RunPod's live `POST /pods` OpenAPI schema on 2026-07-14 and 2026-07-15.
+- RunPod's published Pod prices on 2026-07-15.
 - The prior RunPod retirement work log, including its now-superseded raw
   workflow-branch recovery path.
 
@@ -31,10 +32,17 @@ control plane against schema drift and deterministic request failures.
 - Force the comprehensive non-GPU matrix on pushes to `main`. Keep paid GPU
   work on code PRs and RunPod control-plane changes, after cheaper gates.
 - Validate repository GPU IDs against the live request schema before archive
-  setup. The checked live fixture accepted all 11 configured IDs.
+  setup. The 2026-07-15 live schema accepted all 19 configured IDs across the
+  cost-preferred, premium, and A100 tiers.
 - Retry only 408, 429, 5xx, and transport failures. Bound retries by count and
   deadline; treat other 4xx responses and malformed success responses as
   permanent.
+- Treat an explicit machine-capacity error separately: move immediately to the
+  next price tier rather than sleeping and resubmitting the same candidates.
+  Allow one same-tier retry for unrelated transient failures, cap all creation
+  work at 60 seconds, and exclude GPUs above the reviewed A100 SXM tier.
+- Publish the selected tier and provider GPU ID to both ordinary logs and the
+  GitHub job summary, then show them next to the machine's `nvidia-smi` output.
 - Exclude ref/SHA identity from the CUDA archive cache key and include all
   content/configuration inputs that affect the archive.
 - Replace raw PR ref/SHA recovery with a PR-number command that dispatches only
@@ -75,7 +83,16 @@ control plane against schema drift and deterministic request failures.
 - The coverage profile passed all 159 included source files at their configured
   thresholds.
 - The committed-head repository-rules review passed with no findings.
-- The saved live RunPod OpenAPI schema accepted all 11 configured GPU IDs.
+- The live RunPod OpenAPI schema accepted all 19 configured GPU IDs.
+- Automatic run 29334073902 failed after five submissions of the same request:
+  RunPod returned HTTP 500 with “This machine does not have the resources to
+  deploy your pod” each time. Archive creation and cleanup behaved correctly;
+  this evidence motivated immediate price-tier failover.
+- Attempt 2 of run 29334073902 then recovered with an NVIDIA GeForce RTX 4090.
+  The CUDA archive tests and OpenXLA PJRT end-to-end tests passed, the success
+  marker was emitted, and pod `37vcua0n4ayryn` was deleted successfully. This
+  confirms the existing trusted execution path while the new tier behavior
+  still awaits a post-merge run from `main`.
 - Trusted PR recovery dry run targets only
   `runpod-gpu-test.yml --ref main -f pr_number=1379`.
 

--- a/scripts/check-pr-fast.sh
+++ b/scripts/check-pr-fast.sh
@@ -6,6 +6,8 @@ FETCH=1
 DOC_SNIPPETS="auto"
 COVERAGE_REVIEWED=0
 FOCUSED_TESTS=()
+CI_PROFILES=()
+CI_PROFILE_DRY_RUN=0
 
 usage() {
   cat <<'EOF'
@@ -19,6 +21,8 @@ Options:
   --no-fetch                 Do not fetch origin before checking BASE_REF
   --coverage-reviewed        Confirm changed code was manually/agent reviewed for test coverage
   --test COMMAND             Run one focused verification command; repeatable
+  --ci-profile NAME          Run one shared CI profile; repeatable
+  --ci-profile-dry-run       Print selected CI profile commands without running them
   --doc-snippets             Always run docs snippet sync checks
   --skip-doc-snippets        Never run docs snippet sync checks
   --help                     Show this help text
@@ -63,6 +67,15 @@ while [[ $# -gt 0 ]]; do
       [[ $# -ge 2 ]] || die "--test requires a command"
       FOCUSED_TESTS+=("$2")
       shift 2
+      ;;
+    --ci-profile)
+      [[ $# -ge 2 ]] || die "--ci-profile requires a name"
+      CI_PROFILES+=("$2")
+      shift 2
+      ;;
+    --ci-profile-dry-run)
+      CI_PROFILE_DRY_RUN=1
+      shift
       ;;
     --doc-snippets)
       DOC_SNIPPETS="always"
@@ -168,6 +181,16 @@ for command in "${FOCUSED_TESTS[@]}"; do
   log "+ ${command}"
   bash -lc "$command"
 done
+
+if [[ "${#CI_PROFILES[@]}" -gt 0 ]]; then
+  profile_args=("${CI_PROFILES[@]}")
+  if [[ "$CI_PROFILE_DRY_RUN" -eq 1 ]]; then
+    profile_args=(--dry-run "${profile_args[@]}")
+  fi
+  python3 scripts/ci/run_profile.py "${profile_args[@]}"
+elif [[ "$CI_PROFILE_DRY_RUN" -eq 1 ]]; then
+  die "--ci-profile-dry-run requires at least one --ci-profile"
+fi
 
 if [[ "$COVERAGE_REVIEWED" -ne 1 ]]; then
   cat >&2 <<'EOF'

--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,1 @@
+"""Shared local and hosted CI policy helpers."""

--- a/scripts/ci/change_policy.py
+++ b/scripts/ci/change_policy.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Classify a diff into conservative CI lanes."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import enum
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+
+class ChangeClass(enum.StrEnum):
+    """Primary change class used by local and hosted CI."""
+
+    CODE = "code"
+    DOCS_ONLY = "docs-only"
+    CI_ONLY = "ci-only"
+
+
+@dataclasses.dataclass(frozen=True)
+class ChangePolicy:
+    """Exact CI lanes selected for a set of changed paths."""
+
+    change_class: ChangeClass
+    run_rust: bool
+    run_blas: bool
+    run_extensions: bool
+    run_docs: bool
+    run_ci_config: bool
+    run_gpu: bool
+    reasons: tuple[str, ...]
+
+    def as_output(self) -> dict[str, str | bool]:
+        """Return stable names consumed by GitHub Actions."""
+
+        return {
+            "classification": self.change_class.value,
+            "run_rust": self.run_rust,
+            "run_blas": self.run_blas,
+            "run_extensions": self.run_extensions,
+            "run_docs": self.run_docs,
+            "run_ci_config": self.run_ci_config,
+            "run_gpu": self.run_gpu,
+            "reason": "; ".join(self.reasons),
+        }
+
+
+_DOC_FILES = frozenset(
+    {
+        "CHANGELOG.md",
+        "CONTRIBUTING.md",
+        "LICENSE-APACHE",
+        "LICENSE-MIT",
+        "README.md",
+    }
+)
+_DOC_PREFIXES = ("docs/",)
+_CI_FILES = frozenset(
+    {
+        ".github/dependabot.yml",
+        "scripts/check-pr-fast.sh",
+    }
+)
+_CI_PREFIXES = (".github/workflows/", "scripts/ci/")
+_GPU_CONTROL_FILES = frozenset(
+    {
+        ".github/workflows/CI_gpu.yml",
+        ".github/workflows/runpod-gpu-test.yml",
+        "scripts/ci/change_policy.py",
+        "scripts/ci/runpod_client.py",
+        "scripts/ci/runpod_config.json",
+        "scripts/ci/runpod_contract.py",
+        "scripts/ci/recover_runpod_pr.py",
+    }
+)
+
+
+def _is_docs_path(path: str) -> bool:
+    return path in _DOC_FILES or path.startswith(_DOC_PREFIXES)
+
+
+def _is_ci_path(path: str) -> bool:
+    return path in _CI_FILES or path.startswith(_CI_PREFIXES)
+
+
+def _is_gpu_control_plane_path(path: str) -> bool:
+    return path in _GPU_CONTROL_FILES
+
+
+def _full_policy(reason: str, *, run_gpu: bool = True) -> ChangePolicy:
+    return ChangePolicy(
+        change_class=ChangeClass.CODE,
+        run_rust=True,
+        run_blas=True,
+        run_extensions=True,
+        run_docs=True,
+        run_ci_config=True,
+        run_gpu=run_gpu,
+        reasons=(reason,),
+    )
+
+
+def classify_paths(
+    paths: Sequence[str], event: str = "pull_request"
+) -> ChangePolicy:
+    """Classify paths, defaulting empty and unknown diffs to full validation."""
+
+    normalized = tuple(
+        sorted(
+            {
+                path.strip().removeprefix("./")
+                for path in paths
+                if path.strip()
+            }
+        )
+    )
+    if event == "push":
+        return _full_policy("push-to-main override", run_gpu=False)
+    if not normalized:
+        return _full_policy("empty diff fallback")
+
+    docs = tuple(path for path in normalized if _is_docs_path(path))
+    ci = tuple(path for path in normalized if _is_ci_path(path))
+    known = frozenset((*docs, *ci))
+    unknown = tuple(path for path in normalized if path not in known)
+    if unknown:
+        return _full_policy("code or unknown paths: " + ", ".join(unknown))
+
+    reasons = tuple(
+        reason
+        for reason in (
+            "docs: " + ", ".join(docs) if docs else "",
+            "ci: " + ", ".join(ci) if ci else "",
+        )
+        if reason
+    )
+    has_ci = bool(ci)
+    return ChangePolicy(
+        change_class=ChangeClass.CI_ONLY if has_ci else ChangeClass.DOCS_ONLY,
+        run_rust=False,
+        run_blas=False,
+        run_extensions=False,
+        run_docs=bool(docs),
+        run_ci_config=has_ci,
+        run_gpu=any(_is_gpu_control_plane_path(path) for path in ci),
+        reasons=reasons,
+    )
+
+
+def _changed_paths(base: str, head: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", base, head, "--"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.splitlines()
+
+
+def _write_github_output(policy: ChangePolicy, output_path: str) -> None:
+    output = policy.as_output()
+    with Path(output_path).open("a", encoding="utf-8") as stream:
+        for key, value in output.items():
+            rendered = str(value).lower() if isinstance(value, bool) else value
+            if "\n" in rendered or "\r" in rendered:
+                raise ValueError(f"multiline GitHub output is not supported: {key}")
+            stream.write(f"{key}={rendered}\n")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--event", choices=("pull_request", "push"), default="pull_request"
+    )
+    parser.add_argument("--path", action="append", default=[])
+    parser.add_argument("--base")
+    parser.add_argument("--head")
+    args = parser.parse_args()
+    if bool(args.base) != bool(args.head):
+        parser.error("--base and --head must be provided together")
+    if args.path and args.base:
+        parser.error("use either --path or --base/--head")
+    return args
+
+
+def main() -> int:
+    args = _parse_args()
+    paths = _changed_paths(args.base, args.head) if args.base else args.path
+    policy = classify_paths(paths, event=args.event)
+    print(json.dumps(policy.as_output(), sort_keys=True))
+    if output_path := os.environ.get("GITHUB_OUTPUT"):
+        _write_github_output(policy, output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/recover_runpod_pr.py
+++ b/scripts/ci/recover_runpod_pr.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Recover one PR's GPU gate through the trusted main RunPod workflow."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from collections.abc import Callable
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def build_dispatch_command(pr_number: int, wait: bool = False) -> list[str]:
+    """Build the invariant main-ref dispatch command for a positive PR number."""
+
+    del wait  # Waiting is a post-dispatch action and never changes trust inputs.
+    if pr_number <= 0:
+        raise ValueError("PR number must be positive")
+    return [
+        "gh",
+        "workflow",
+        "run",
+        "runpod-gpu-test.yml",
+        "--ref",
+        "main",
+        "-f",
+        f"pr_number={pr_number}",
+    ]
+
+
+def recover_pr(
+    pr_number: int, *, wait: bool, runner: Runner = subprocess.run
+) -> str:
+    """Authenticate, dispatch, return the run URL, and optionally watch it."""
+
+    common = {"check": True, "text": True, "capture_output": True}
+    runner(["gh", "auth", "status"], **common)
+    result = runner(build_dispatch_command(pr_number, wait), **common)
+    url = next(
+        (
+            token
+            for token in result.stdout.split()
+            if token.startswith("https://") and "/actions/runs/" in token
+        ),
+        "",
+    )
+    if not url:
+        raise RuntimeError("gh workflow run did not return a run URL")
+    if wait:
+        run_id = url.rstrip("/").rsplit("/", 1)[-1]
+        runner(
+            ["gh", "run", "watch", run_id, "--exit-status"],
+            **common,
+        )
+    return url
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pr_number", type=int)
+    parser.add_argument("--wait", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        command = build_dispatch_command(args.pr_number, args.wait)
+        if args.dry_run:
+            print(shlex.join(command))
+            return 0
+        url = recover_pr(args.pr_number, wait=args.wait)
+        print(url)
+    except (ValueError, RuntimeError, subprocess.CalledProcessError) as error:
+        print(f"RunPod PR recovery failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Run exact command profiles shared by contributors and hosted CI."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from collections.abc import Sequence
+from typing import TextIO
+
+
+PROFILE_COMMANDS: dict[str, tuple[str, ...]] = {
+    "workspace-faer": (
+        "cargo nextest run --workspace --release --no-fail-fast",
+        "cargo test --doc --workspace --release",
+    ),
+    "workspace-blas": (
+        "cargo nextest run --workspace --release --no-default-features "
+        "--features cpu-blas --no-fail-fast",
+        "cargo test --doc --workspace --release --no-default-features "
+        "--features cpu-blas",
+    ),
+    "blas-inject": (
+        "cargo test -p tenferro-cpu --test inject_tests --release "
+        '--no-default-features --features "cpu-blas,provider-inject"',
+    ),
+    "extensions": (
+        "cargo test --manifest-path ext/tropical/Cargo.toml --release "
+        "--features autodiff",
+        "cargo test --manifest-path ext/sparse/Cargo.toml --release "
+        "--features autodiff",
+        "cargo check --manifest-path samples/kdv-pinn/Cargo.toml --release "
+        "--all-targets",
+    ),
+    "docs": (
+        "python3 scripts/test-check-docs-site.py",
+        "python3 scripts/test-doc-consistency.py",
+        "python3 scripts/test-repository-rules-review.py",
+        "python3 scripts/check-guide-dependency-snippets.py",
+        "python3 scripts/check-operation-categories.py --fail-on-findings",
+        "bash scripts/build_docs_site.sh",
+    ),
+    "coverage": (
+        "cargo llvm-cov --workspace --release --json --output-path coverage.json",
+        "python3 scripts/check-coverage.py coverage.json",
+    ),
+    "ci-config": (
+        "python3 -m unittest discover -s scripts/ci/tests -v",
+        "actionlint",
+    ),
+}
+
+FULL_PROFILE = (
+    "workspace-faer",
+    "workspace-blas",
+    "blas-inject",
+    "extensions",
+    "docs",
+    "coverage",
+    "ci-config",
+)
+
+
+def commands_for(profile: str) -> tuple[str, ...]:
+    """Return immutable commands for one concrete profile."""
+
+    try:
+        return PROFILE_COMMANDS[profile]
+    except KeyError as error:
+        raise ValueError(f"unknown CI profile: {profile}") from error
+
+
+def expand_profiles(profiles: Sequence[str]) -> tuple[str, ...]:
+    """Expand composites and preserve the first occurrence of each profile."""
+
+    expanded: list[str] = []
+    for profile in profiles:
+        names = FULL_PROFILE if profile == "full" else (profile,)
+        for name in names:
+            commands_for(name)
+            if name not in expanded:
+                expanded.append(name)
+    return tuple(expanded)
+
+
+def run_profiles(
+    profiles: Sequence[str], *, dry_run: bool, output: TextIO = sys.stdout
+) -> None:
+    """Run selected profiles in order, or print their commands in dry-run mode."""
+
+    for profile in expand_profiles(profiles):
+        for command in commands_for(profile):
+            print(f"+ {command}", file=output, flush=True)
+            if dry_run:
+                continue
+            environment = os.environ.copy()
+            if profile == "workspace-blas":
+                environment["RUSTFLAGS"] = "-l dylib=openblas -l dylib=lapack"
+            try:
+                # Commands are repository constants, not caller-provided shell text.
+                subprocess.run(
+                    command, shell=True, check=True, env=environment
+                )
+            except subprocess.CalledProcessError as error:
+                raise RuntimeError(
+                    f"CI profile {profile!r} failed: {command}"
+                ) from error
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profiles", nargs="*")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--list", action="store_true")
+    args = parser.parse_args()
+    if not args.list and not args.profiles:
+        parser.error("provide at least one profile or --list")
+    return args
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.list:
+        print("full: " + ", ".join(FULL_PROFILE))
+        for name in PROFILE_COMMANDS:
+            print(name)
+        if not args.profiles:
+            return 0
+    try:
+        run_profiles(args.profiles, dry_run=args.dry_run)
+    except (RuntimeError, ValueError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/runpod_client.py
+++ b/scripts/ci/runpod_client.py
@@ -38,15 +38,29 @@ class PermanentRunPodError(RunPodError):
 
 
 @dataclasses.dataclass(frozen=True)
+class CreateRequest:
+    """One reviewed GPU tier and its encoded RunPod request."""
+
+    tier_name: str
+    payload: bytes
+
+
+@dataclasses.dataclass(frozen=True)
 class CreateResult:
     """Validated result of a successful pod creation request."""
 
     pod_id: str
     gpu_type_id: str
+    gpu_tier: str
     body: bytes
 
 
 Transport = Callable[[bytes], tuple[int, Mapping[str, str], bytes]]
+
+_CAPACITY_MESSAGES = (
+    "does not have the resources to deploy your pod",
+    "no available machine",
+)
 
 
 def classify_http_status(status: int) -> RetryClass:
@@ -55,6 +69,15 @@ def classify_http_status(status: int) -> RetryClass:
     if status in (408, 429) or 500 <= status < 600:
         return RetryClass.RETRYABLE
     return RetryClass.PERMANENT
+
+
+def is_capacity_failure(status: int, body: bytes) -> bool:
+    """Return whether RunPod reported exhausted machine capacity."""
+
+    if not 500 <= status < 600:
+        return False
+    message = body.decode("utf-8", errors="replace").lower()
+    return any(marker in message for marker in _CAPACITY_MESSAGES)
 
 
 def backoff_seconds(
@@ -129,7 +152,9 @@ def redacted_error_message(
     return message[:4000]
 
 
-def parse_create_response(status: int, body: bytes) -> CreateResult:
+def parse_create_response(
+    status: int, body: bytes, *, gpu_tier: str = ""
+) -> CreateResult:
     """Validate a successful create response and extract stable fields."""
 
     try:
@@ -159,7 +184,12 @@ def parse_create_response(status: int, body: bytes) -> CreateResult:
                 gpu_type.get("id"), str
             ):
                 gpu_type_id = gpu_type["id"]
-    return CreateResult(pod_id=pod_id, gpu_type_id=gpu_type_id, body=body)
+    return CreateResult(
+        pod_id=pod_id,
+        gpu_type_id=gpu_type_id,
+        gpu_tier=gpu_tier,
+        body=body,
+    )
 
 
 def _retry_after(headers: Mapping[str, str]) -> float | None:
@@ -178,7 +208,7 @@ def _retry_after(headers: Mapping[str, str]) -> float | None:
 
 def create_pod(
     config: Mapping[str, object],
-    payload: bytes,
+    requests: Sequence[CreateRequest],
     *,
     transport: Transport,
     sleep: Callable[[float], None] = time.sleep,
@@ -188,33 +218,58 @@ def create_pod(
 ) -> CreateResult:
     """Create a pod within both an attempt budget and a wall-clock deadline."""
 
-    max_attempts = int(config["max_create_attempts"])
+    attempts_per_tier = int(config.get("same_tier_retries", 1)) + 1
     base = float(config["retry_base_seconds"])
     cap = float(config["retry_max_seconds"])
     deadline = monotonic() + float(config["create_deadline_seconds"])
-    for attempt in range(1, max_attempts + 1):
-        headers: Mapping[str, str] = {}
-        try:
-            status, headers, body = transport(payload)
-        except OSError as error:
-            failure: RunPodError = RetryableRunPodError(
-                f"transport failure: {error}"
+    for tier_index, request in enumerate(requests):
+        for attempt in range(1, attempts_per_tier + 1):
+            print(
+                f"RunPod create tier={request.tier_name} "
+                f"tier_attempt={attempt}/{attempts_per_tier}"
             )
-        else:
-            if 200 <= status < 300:
-                return parse_create_response(status, body)
-            message = redacted_error_message(body, secrets=secrets)
-            if classify_http_status(status) is RetryClass.PERMANENT:
-                raise PermanentRunPodError(f"RunPod HTTP {status}: {message}")
-            failure = RetryableRunPodError(f"RunPod HTTP {status}: {message}")
+            headers: Mapping[str, str] = {}
+            try:
+                status, headers, body = transport(request.payload)
+            except OSError as error:
+                failure: RunPodError = RetryableRunPodError(
+                    f"transport failure: {error}"
+                )
+            else:
+                if 200 <= status < 300:
+                    return parse_create_response(
+                        status, body, gpu_tier=request.tier_name
+                    )
+                message = redacted_error_message(body, secrets=secrets)
+                if is_capacity_failure(status, body):
+                    failure = RetryableRunPodError(
+                        f"RunPod capacity unavailable: {message}"
+                    )
+                    if tier_index + 1 < len(requests):
+                        print(
+                            "RunPod capacity unavailable in tier "
+                            f"{request.tier_name}; trying "
+                            f"{requests[tier_index + 1].tier_name}"
+                        )
+                        break
+                    raise failure
+                if classify_http_status(status) is RetryClass.PERMANENT:
+                    raise PermanentRunPodError(
+                        f"RunPod HTTP {status}: {message}"
+                    )
+                failure = RetryableRunPodError(
+                    f"RunPod HTTP {status}: {message}"
+                )
 
-        now = monotonic()
-        if attempt == max_attempts or now >= deadline:
-            raise failure
-        delay = _retry_after(headers)
-        if delay is None:
-            delay = backoff_seconds(attempt, base=base, cap=cap, jitter=jitter)
-        sleep(min(delay, max(0.0, deadline - now)))
+            now = monotonic()
+            if attempt == attempts_per_tier or now >= deadline:
+                raise failure
+            delay = _retry_after(headers)
+            if delay is None:
+                delay = backoff_seconds(
+                    attempt, base=base, cap=cap, jitter=jitter
+                )
+            sleep(min(delay, max(0.0, deadline - now)))
     raise AssertionError("unreachable retry loop")
 
 
@@ -281,7 +336,7 @@ def main() -> int:
         encoded = json.dumps(payload).encode()
         result = create_pod(
             config,
-            encoded,
+            [CreateRequest("cost-preferred", encoded)],
             transport=_http_transport(str(config["api_url"]), api_key),
             secrets=(api_key, jit_config),
         )

--- a/scripts/ci/runpod_client.py
+++ b/scripts/ci/runpod_client.py
@@ -276,6 +276,37 @@ def create_pod(
     raise AssertionError("unreachable retry loop")
 
 
+def publish_github_result(
+    result: CreateResult,
+    *,
+    output_path: Path | None,
+    summary_path: Path | None,
+) -> None:
+    """Publish the selected pod, GPU, and tier to GitHub Actions."""
+
+    for name, value in (
+        ("pod_id", result.pod_id),
+        ("gpu_type_id", result.gpu_type_id),
+        ("gpu_tier", result.gpu_tier),
+    ):
+        if "\n" in value or "\r" in value:
+            raise PermanentRunPodError(
+                f"unsafe GitHub output value for {name}"
+            )
+    if output_path is not None:
+        with output_path.open("a", encoding="utf-8") as output:
+            output.write(f"pod_id={result.pod_id}\n")
+            output.write(f"gpu_type_id={result.gpu_type_id}\n")
+            output.write(f"gpu_tier={result.gpu_tier}\n")
+    if summary_path is not None:
+        with summary_path.open("a", encoding="utf-8") as summary:
+            summary.write("### RunPod GPU selection\n\n")
+            summary.write(f"- Price tier: `{result.gpu_tier}`\n")
+            summary.write(
+                f"- Selected GPU: `{result.gpu_type_id or 'unknown'}`\n"
+            )
+
+
 def _http_transport(url: str, api_key: str) -> Transport:
     def send(payload: bytes) -> tuple[int, Mapping[str, str], bytes]:
         request = urllib.request.Request(
@@ -350,11 +381,15 @@ def main() -> int:
             secrets=(api_key, jit_config),
         )
         args.response_file.write_bytes(result.body)
-        if output_path := os.environ.get("GITHUB_OUTPUT"):
-            with Path(output_path).open("a", encoding="utf-8") as output:
-                output.write(f"pod_id={result.pod_id}\n")
-                output.write(f"gpu_type_id={result.gpu_type_id}\n")
+        output_path = os.environ.get("GITHUB_OUTPUT")
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        publish_github_result(
+            result,
+            output_path=Path(output_path) if output_path else None,
+            summary_path=Path(summary_path) if summary_path else None,
+        )
         print(f"Created RunPod pod: {result.pod_id}")
+        print(f"RunPod selected price tier: {result.gpu_tier}")
         print(f"RunPod assigned GPU type: {result.gpu_type_id or 'unknown'}")
     except (
         OSError,

--- a/scripts/ci/runpod_client.py
+++ b/scripts/ci/runpod_client.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Create RunPod pods with bounded, status-aware retries and redacted output."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import enum
+import json
+import os
+import random
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+class RetryClass(enum.Enum):
+    """Whether an HTTP failure may be retried safely."""
+
+    RETRYABLE = enum.auto()
+    PERMANENT = enum.auto()
+
+
+class RunPodError(RuntimeError):
+    """Base error for pod creation."""
+
+
+class RetryableRunPodError(RunPodError):
+    """A transient failure exhausted the configured retry budget."""
+
+
+class PermanentRunPodError(RunPodError):
+    """A request or protocol failure that must not be retried."""
+
+
+@dataclasses.dataclass(frozen=True)
+class CreateResult:
+    """Validated result of a successful pod creation request."""
+
+    pod_id: str
+    gpu_type_id: str
+    body: bytes
+
+
+Transport = Callable[[bytes], tuple[int, Mapping[str, str], bytes]]
+
+
+def classify_http_status(status: int) -> RetryClass:
+    """Classify only timeout, rate-limit, and server failures as retryable."""
+
+    if status in (408, 429) or 500 <= status < 600:
+        return RetryClass.RETRYABLE
+    return RetryClass.PERMANENT
+
+
+def backoff_seconds(
+    attempt: int, *, base: float, cap: float, jitter: Callable[[], float]
+) -> float:
+    """Return full-jitter exponential backoff bounded before jitter."""
+
+    if attempt < 1:
+        raise ValueError("attempt must be positive")
+    return min(cap, base * (2 ** (attempt - 1))) * jitter()
+
+
+def build_pod_payload(
+    config: Mapping[str, object],
+    image_name: str,
+    startup_script: str,
+    jit_config: str,
+) -> dict[str, object]:
+    """Build the reviewed SECURE Cloud request from repository configuration."""
+
+    return {
+        "cloudType": config["cloud_type"],
+        "computeType": config["compute_type"],
+        "name": f"tenferro-rs-gpu-ci-{os.environ.get('GITHUB_RUN_ID', 'local')}",
+        "imageName": image_name,
+        "gpuTypeIds": config["gpu_type_ids"],
+        "gpuTypePriority": config["gpu_type_priority"],
+        "gpuCount": config["gpu_count"],
+        "containerDiskInGb": config["container_disk_gb"],
+        "volumeInGb": config["volume_gb"],
+        "volumeMountPath": config["volume_mount_path"],
+        "interruptible": False,
+        "ports": [],
+        "dockerEntrypoint": ["bash", "-lc"],
+        "dockerStartCmd": [startup_script],
+        "env": {
+            "RUNNER_JIT_CONFIG": jit_config,
+            "RUNNER_ALLOW_RUNASROOT": "1",
+        },
+    }
+
+
+def _redact(value: object) -> object:
+    if isinstance(value, list):
+        return [_redact(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    redacted: dict[str, object] = {}
+    for key, item in value.items():
+        if key in {"RUNNER_JIT_CONFIG", "PUBLIC_KEY"}:
+            redacted[key] = "***redacted***"
+        elif key == "dockerStartCmd":
+            redacted[key] = ["***redacted-startup-script***"]
+        else:
+            redacted[key] = _redact(item)
+    return redacted
+
+
+def redacted_error_message(
+    body: bytes, *, secrets: Sequence[str] = ()
+) -> str:
+    """Render a bounded response diagnostic without request secrets."""
+
+    try:
+        parsed: object = json.loads(body)
+        message = json.dumps(_redact(parsed), sort_keys=True)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        message = body.decode("utf-8", errors="replace")
+    for secret in secrets:
+        if secret:
+            message = message.replace(secret, "***redacted***")
+    return message[:4000]
+
+
+def parse_create_response(status: int, body: bytes) -> CreateResult:
+    """Validate a successful create response and extract stable fields."""
+
+    try:
+        value: Any = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise PermanentRunPodError(
+            f"RunPod HTTP {status} returned invalid JSON"
+        ) from error
+    if not isinstance(value, Mapping):
+        raise PermanentRunPodError(
+            f"RunPod HTTP {status} response must be an object"
+        )
+    pod_id = value.get("id")
+    if not isinstance(pod_id, str) or not pod_id:
+        raise PermanentRunPodError(
+            f"RunPod HTTP {status} response is missing pod id"
+        )
+    gpu_type_id = ""
+    machine = value.get("machine")
+    if isinstance(machine, Mapping):
+        direct = machine.get("gpuTypeId")
+        if isinstance(direct, str):
+            gpu_type_id = direct
+        else:
+            gpu_type = machine.get("gpuType")
+            if isinstance(gpu_type, Mapping) and isinstance(
+                gpu_type.get("id"), str
+            ):
+                gpu_type_id = gpu_type["id"]
+    return CreateResult(pod_id=pod_id, gpu_type_id=gpu_type_id, body=body)
+
+
+def _retry_after(headers: Mapping[str, str]) -> float | None:
+    value = next(
+        (item for key, item in headers.items() if key.lower() == "retry-after"),
+        None,
+    )
+    if value is None:
+        return None
+    try:
+        delay = float(value)
+    except ValueError:
+        return None
+    return max(0.0, delay)
+
+
+def create_pod(
+    config: Mapping[str, object],
+    payload: bytes,
+    *,
+    transport: Transport,
+    sleep: Callable[[float], None] = time.sleep,
+    jitter: Callable[[], float] = random.random,
+    monotonic: Callable[[], float] = time.monotonic,
+    secrets: Sequence[str] = (),
+) -> CreateResult:
+    """Create a pod within both an attempt budget and a wall-clock deadline."""
+
+    max_attempts = int(config["max_create_attempts"])
+    base = float(config["retry_base_seconds"])
+    cap = float(config["retry_max_seconds"])
+    deadline = monotonic() + float(config["create_deadline_seconds"])
+    for attempt in range(1, max_attempts + 1):
+        headers: Mapping[str, str] = {}
+        try:
+            status, headers, body = transport(payload)
+        except OSError as error:
+            failure: RunPodError = RetryableRunPodError(
+                f"transport failure: {error}"
+            )
+        else:
+            if 200 <= status < 300:
+                return parse_create_response(status, body)
+            message = redacted_error_message(body, secrets=secrets)
+            if classify_http_status(status) is RetryClass.PERMANENT:
+                raise PermanentRunPodError(f"RunPod HTTP {status}: {message}")
+            failure = RetryableRunPodError(f"RunPod HTTP {status}: {message}")
+
+        now = monotonic()
+        if attempt == max_attempts or now >= deadline:
+            raise failure
+        delay = _retry_after(headers)
+        if delay is None:
+            delay = backoff_seconds(attempt, base=base, cap=cap, jitter=jitter)
+        sleep(min(delay, max(0.0, deadline - now)))
+    raise AssertionError("unreachable retry loop")
+
+
+def _http_transport(url: str, api_key: str) -> Transport:
+    def send(payload: bytes) -> tuple[int, Mapping[str, str], bytes]:
+        request = urllib.request.Request(
+            url,
+            data=payload,
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "User-Agent": "tenferro-ci-runpod/1",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                return response.status, dict(response.headers.items()), response.read()
+        except urllib.error.HTTPError as error:
+            return error.code, dict(error.headers.items()), error.read()
+
+    return send
+
+
+def _load_config(path: Path) -> Mapping[str, object]:
+    value: Any = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, Mapping):
+        raise PermanentRunPodError("RunPod configuration root must be an object")
+    return value
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    create = subparsers.add_parser("create")
+    create.add_argument("--config", type=Path, required=True)
+    create.add_argument("--startup-script", type=Path, required=True)
+    create.add_argument("--image-name", required=True)
+    create.add_argument("--response-file", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        config = _load_config(args.config)
+        api_key = os.environ.get("RUNPOD_API_KEY")
+        jit_config = os.environ.get("RUNNER_JIT_CONFIG")
+        if not api_key or not jit_config:
+            raise PermanentRunPodError(
+                "RUNPOD_API_KEY and RUNNER_JIT_CONFIG are required"
+            )
+        payload = build_pod_payload(
+            config,
+            args.image_name,
+            args.startup_script.read_text(encoding="utf-8"),
+            jit_config,
+        )
+        print(
+            "RunPod request payload, secrets redacted: "
+            + json.dumps(_redact(payload), sort_keys=True)
+        )
+        encoded = json.dumps(payload).encode()
+        result = create_pod(
+            config,
+            encoded,
+            transport=_http_transport(str(config["api_url"]), api_key),
+            secrets=(api_key, jit_config),
+        )
+        args.response_file.write_bytes(result.body)
+        if output_path := os.environ.get("GITHUB_OUTPUT"):
+            with Path(output_path).open("a", encoding="utf-8") as output:
+                output.write(f"pod_id={result.pod_id}\n")
+                output.write(f"gpu_type_id={result.gpu_type_id}\n")
+        print(f"Created RunPod pod: {result.pod_id}")
+        print(f"RunPod assigned GPU type: {result.gpu_type_id or 'unknown'}")
+    except (OSError, KeyError, ValueError, json.JSONDecodeError, RunPodError) as error:
+        print(f"RunPod create failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/runpod_client.py
+++ b/scripts/ci/runpod_client.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import dataclasses
 import enum
+import html
 import json
 import os
 import random
@@ -45,6 +46,7 @@ class CreateRequest:
 
     tier_name: str
     payload: bytes
+    gpu_type_ids: tuple[str, ...] = ()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -57,7 +59,9 @@ class CreateResult:
     body: bytes
 
 
-Transport = Callable[[bytes], tuple[int, Mapping[str, str], bytes]]
+Transport = Callable[
+    [bytes, float], tuple[int, Mapping[str, str], bytes]
+]
 
 _CAPACITY_MESSAGES = (
     "does not have the resources to deploy your pod",
@@ -227,27 +231,51 @@ def create_pod(
     deadline = monotonic() + float(config["create_deadline_seconds"])
     for tier_index, request in enumerate(requests):
         for attempt in range(1, attempts_per_tier + 1):
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                raise RetryableRunPodError(
+                    "RunPod create deadline expired"
+                )
             print(
                 f"RunPod create tier={request.tier_name} "
                 f"tier_attempt={attempt}/{attempts_per_tier}"
             )
             headers: Mapping[str, str] = {}
             try:
-                status, headers, body = transport(request.payload)
+                status, headers, body = transport(
+                    request.payload, remaining
+                )
             except OSError as error:
                 failure: RunPodError = RetryableRunPodError(
                     f"transport failure: {error}"
                 )
             else:
                 if 200 <= status < 300:
-                    return parse_create_response(
+                    result = parse_create_response(
                         status, body, gpu_tier=request.tier_name
                     )
+                    if request.gpu_type_ids and not result.gpu_type_id:
+                        raise PermanentRunPodError(
+                            "RunPod response is missing assigned GPU for "
+                            f"selected tier {request.tier_name}"
+                        )
+                    if (
+                        result.gpu_type_id
+                        and request.gpu_type_ids
+                        and result.gpu_type_id not in request.gpu_type_ids
+                    ):
+                        raise PermanentRunPodError(
+                            "RunPod assigned GPU outside selected tier: "
+                            f"{result.gpu_type_id}"
+                        )
+                    return result
                 message = redacted_error_message(body, secrets=secrets)
                 if is_capacity_failure(status, body):
                     failure = RetryableRunPodError(
                         f"RunPod capacity unavailable: {message}"
                     )
+                    if monotonic() >= deadline:
+                        raise failure
                     if tier_index + 1 < len(requests):
                         print(
                             "RunPod capacity unavailable in tier "
@@ -272,7 +300,12 @@ def create_pod(
                 delay = backoff_seconds(
                     attempt, base=base, cap=cap, jitter=jitter
                 )
-            sleep(min(delay, max(0.0, deadline - now)))
+            bounded_delay = min(delay, max(0.0, deadline - now))
+            print(
+                f"RunPod transient failure in tier {request.tier_name}; "
+                f"retrying after {bounded_delay:.1f}s: {failure}"
+            )
+            sleep(bounded_delay)
     raise AssertionError("unreachable retry loop")
 
 
@@ -299,16 +332,20 @@ def publish_github_result(
             output.write(f"gpu_type_id={result.gpu_type_id}\n")
             output.write(f"gpu_tier={result.gpu_tier}\n")
     if summary_path is not None:
+        gpu_tier = html.escape(result.gpu_tier).replace("`", "&#96;")
+        gpu_type_id = html.escape(
+            result.gpu_type_id or "unknown"
+        ).replace("`", "&#96;")
         with summary_path.open("a", encoding="utf-8") as summary:
             summary.write("### RunPod GPU selection\n\n")
-            summary.write(f"- Price tier: `{result.gpu_tier}`\n")
-            summary.write(
-                f"- Selected GPU: `{result.gpu_type_id or 'unknown'}`\n"
-            )
+            summary.write(f"- Price tier: {gpu_tier}\n")
+            summary.write(f"- Selected GPU: {gpu_type_id}\n")
 
 
 def _http_transport(url: str, api_key: str) -> Transport:
-    def send(payload: bytes) -> tuple[int, Mapping[str, str], bytes]:
+    def send(
+        payload: bytes, timeout: float
+    ) -> tuple[int, Mapping[str, str], bytes]:
         request = urllib.request.Request(
             url,
             data=payload,
@@ -321,7 +358,7 @@ def _http_transport(url: str, api_key: str) -> Transport:
             },
         )
         try:
-            with urllib.request.urlopen(request, timeout=60) as response:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
                 return response.status, dict(response.headers.items()), response.read()
         except urllib.error.HTTPError as error:
             return error.code, dict(error.headers.items()), error.read()
@@ -372,7 +409,11 @@ def main() -> int:
                 + json.dumps(_redact(payload), sort_keys=True)
             )
             requests.append(
-                CreateRequest(tier_name, json.dumps(payload).encode())
+                CreateRequest(
+                    tier_name,
+                    json.dumps(payload).encode(),
+                    gpu_type_ids,
+                )
             )
         result = create_pod(
             config,

--- a/scripts/ci/runpod_client.py
+++ b/scripts/ci/runpod_client.py
@@ -59,6 +59,14 @@ class CreateResult:
     body: bytes
 
 
+class AssignedGpuError(PermanentRunPodError):
+    """A created pod reported an unsafe or unverifiable assigned GPU."""
+
+    def __init__(self, message: str, result: CreateResult) -> None:
+        super().__init__(message)
+        self.result = result
+
+
 Transport = Callable[
     [bytes, float], tuple[int, Mapping[str, str], bytes]
 ]
@@ -255,18 +263,19 @@ def create_pod(
                         status, body, gpu_tier=request.tier_name
                     )
                     if request.gpu_type_ids and not result.gpu_type_id:
-                        raise PermanentRunPodError(
+                        raise AssignedGpuError(
                             "RunPod response is missing assigned GPU for "
-                            f"selected tier {request.tier_name}"
+                            f"selected tier {request.tier_name}",
+                            result,
                         )
                     if (
                         result.gpu_type_id
                         and request.gpu_type_ids
                         and result.gpu_type_id not in request.gpu_type_ids
                     ):
-                        raise PermanentRunPodError(
-                            "RunPod assigned GPU outside selected tier: "
-                            f"{result.gpu_type_id}"
+                        raise AssignedGpuError(
+                            "RunPod assigned GPU outside selected tier",
+                            result,
                         )
                     return result
                 message = redacted_error_message(body, secrets=secrets)
@@ -280,7 +289,8 @@ def create_pod(
                         print(
                             "RunPod capacity unavailable in tier "
                             f"{request.tier_name}; trying "
-                            f"{requests[tier_index + 1].tier_name}"
+                            f"{requests[tier_index + 1].tier_name}; "
+                            f"error={str(failure)!r}"
                         )
                         break
                     raise failure
@@ -303,7 +313,7 @@ def create_pod(
             bounded_delay = min(delay, max(0.0, deadline - now))
             print(
                 f"RunPod transient failure in tier {request.tier_name}; "
-                f"retrying after {bounded_delay:.1f}s: {failure}"
+                f"retrying after {bounded_delay:.1f}s: {str(failure)!r}"
             )
             sleep(bounded_delay)
     raise AssertionError("unreachable retry loop")
@@ -340,6 +350,18 @@ def publish_github_result(
             summary.write("### RunPod GPU selection\n\n")
             summary.write(f"- Price tier: {gpu_tier}\n")
             summary.write(f"- Selected GPU: {gpu_type_id}\n")
+
+
+def publish_cleanup_pod_id(
+    result: CreateResult, output_path: Path | None
+) -> None:
+    """Publish only a validated pod ID so a rejected pod can be deleted."""
+
+    if "\n" in result.pod_id or "\r" in result.pod_id:
+        raise PermanentRunPodError("unsafe GitHub output value for pod_id")
+    if output_path is not None:
+        with output_path.open("a", encoding="utf-8") as output:
+            output.write(f"pod_id={result.pod_id}\n")
 
 
 def _http_transport(url: str, api_key: str) -> Transport:
@@ -415,12 +437,21 @@ def main() -> int:
                     gpu_type_ids,
                 )
             )
-        result = create_pod(
-            config,
-            requests,
-            transport=_http_transport(str(config["api_url"]), api_key),
-            secrets=(api_key, jit_config),
-        )
+        try:
+            result = create_pod(
+                config,
+                requests,
+                transport=_http_transport(str(config["api_url"]), api_key),
+                secrets=(api_key, jit_config),
+            )
+        except AssignedGpuError as error:
+            args.response_file.write_bytes(error.result.body)
+            output_path = os.environ.get("GITHUB_OUTPUT")
+            publish_cleanup_pod_id(
+                error.result,
+                Path(output_path) if output_path else None,
+            )
+            raise
         args.response_file.write_bytes(result.body)
         output_path = os.environ.get("GITHUB_OUTPUT")
         summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
@@ -440,7 +471,7 @@ def main() -> int:
         ContractError,
         RunPodError,
     ) as error:
-        print(f"RunPod create failed: {error}", file=sys.stderr)
+        print(f"RunPod create failed: {str(error)!r}", file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/ci/runpod_client.py
+++ b/scripts/ci/runpod_client.py
@@ -17,6 +17,8 @@ from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from scripts.ci.runpod_contract import ContractError, configured_gpu_tiers
+
 
 class RetryClass(enum.Enum):
     """Whether an HTTP failure may be retried safely."""
@@ -95,6 +97,7 @@ def build_pod_payload(
     image_name: str,
     startup_script: str,
     jit_config: str,
+    gpu_type_ids: Sequence[str],
 ) -> dict[str, object]:
     """Build the reviewed SECURE Cloud request from repository configuration."""
 
@@ -103,7 +106,7 @@ def build_pod_payload(
         "computeType": config["compute_type"],
         "name": f"tenferro-rs-gpu-ci-{os.environ.get('GITHUB_RUN_ID', 'local')}",
         "imageName": image_name,
-        "gpuTypeIds": config["gpu_type_ids"],
+        "gpuTypeIds": list(gpu_type_ids),
         "gpuTypePriority": config["gpu_type_priority"],
         "gpuCount": config["gpu_count"],
         "containerDiskInGb": config["container_disk_gb"],
@@ -323,20 +326,26 @@ def main() -> int:
             raise PermanentRunPodError(
                 "RUNPOD_API_KEY and RUNNER_JIT_CONFIG are required"
             )
-        payload = build_pod_payload(
-            config,
-            args.image_name,
-            args.startup_script.read_text(encoding="utf-8"),
-            jit_config,
-        )
-        print(
-            "RunPod request payload, secrets redacted: "
-            + json.dumps(_redact(payload), sort_keys=True)
-        )
-        encoded = json.dumps(payload).encode()
+        startup_script = args.startup_script.read_text(encoding="utf-8")
+        requests: list[CreateRequest] = []
+        for tier_name, gpu_type_ids in configured_gpu_tiers(config):
+            payload = build_pod_payload(
+                config,
+                args.image_name,
+                startup_script,
+                jit_config,
+                gpu_type_ids,
+            )
+            print(
+                f"RunPod request tier={tier_name}, secrets redacted: "
+                + json.dumps(_redact(payload), sort_keys=True)
+            )
+            requests.append(
+                CreateRequest(tier_name, json.dumps(payload).encode())
+            )
         result = create_pod(
             config,
-            [CreateRequest("cost-preferred", encoded)],
+            requests,
             transport=_http_transport(str(config["api_url"]), api_key),
             secrets=(api_key, jit_config),
         )
@@ -347,7 +356,14 @@ def main() -> int:
                 output.write(f"gpu_type_id={result.gpu_type_id}\n")
         print(f"Created RunPod pod: {result.pod_id}")
         print(f"RunPod assigned GPU type: {result.gpu_type_id or 'unknown'}")
-    except (OSError, KeyError, ValueError, json.JSONDecodeError, RunPodError) as error:
+    except (
+        OSError,
+        KeyError,
+        ValueError,
+        json.JSONDecodeError,
+        ContractError,
+        RunPodError,
+    ) as error:
         print(f"RunPod create failed: {error}", file=sys.stderr)
         return 1
     return 0

--- a/scripts/ci/runpod_config.json
+++ b/scripts/ci/runpod_config.json
@@ -1,0 +1,27 @@
+{
+  "api_url": "https://rest.runpod.io/v1/pods",
+  "openapi_url": "https://rest.runpod.io/v1/openapi.json",
+  "cloud_type": "SECURE",
+  "compute_type": "GPU",
+  "gpu_type_ids": [
+    "NVIDIA RTX A2000",
+    "NVIDIA GeForce RTX 3070",
+    "NVIDIA GeForce RTX 3080",
+    "NVIDIA GeForce RTX 3080 Ti",
+    "Tesla V100-PCIE-16GB",
+    "NVIDIA RTX A4000",
+    "NVIDIA RTX 2000 Ada Generation",
+    "NVIDIA RTX A4500",
+    "NVIDIA RTX A5000",
+    "NVIDIA A40",
+    "NVIDIA GeForce RTX 4090"
+  ],
+  "gpu_type_priority": "availability",
+  "gpu_count": 1,
+  "container_disk_gb": 100,
+  "volume_gb": 20,
+  "volume_mount_path": "/workspace",
+  "max_create_attempts": 5,
+  "retry_base_seconds": 10,
+  "retry_max_seconds": 60
+}

--- a/scripts/ci/runpod_config.json
+++ b/scripts/ci/runpod_config.json
@@ -3,26 +3,49 @@
   "openapi_url": "https://rest.runpod.io/v1/openapi.json",
   "cloud_type": "SECURE",
   "compute_type": "GPU",
-  "gpu_type_ids": [
-    "NVIDIA RTX A2000",
-    "NVIDIA GeForce RTX 3070",
-    "NVIDIA GeForce RTX 3080",
-    "NVIDIA GeForce RTX 3080 Ti",
-    "Tesla V100-PCIE-16GB",
-    "NVIDIA RTX A4000",
-    "NVIDIA RTX 2000 Ada Generation",
-    "NVIDIA RTX A4500",
-    "NVIDIA RTX A5000",
-    "NVIDIA A40",
-    "NVIDIA GeForce RTX 4090"
+  "gpu_tiers": [
+    {
+      "name": "cost-preferred",
+      "gpu_type_ids": [
+        "NVIDIA RTX A2000",
+        "NVIDIA GeForce RTX 3070",
+        "NVIDIA GeForce RTX 3080",
+        "NVIDIA GeForce RTX 3080 Ti",
+        "Tesla V100-PCIE-16GB",
+        "NVIDIA RTX A4000",
+        "NVIDIA RTX 2000 Ada Generation",
+        "NVIDIA RTX A4500",
+        "NVIDIA RTX A5000",
+        "NVIDIA A40",
+        "NVIDIA L4",
+        "NVIDIA RTX A6000",
+        "NVIDIA GeForce RTX 4090"
+      ]
+    },
+    {
+      "name": "premium",
+      "gpu_type_ids": [
+        "NVIDIA RTX 6000 Ada Generation",
+        "NVIDIA L40",
+        "NVIDIA L40S",
+        "NVIDIA GeForce RTX 5090"
+      ]
+    },
+    {
+      "name": "a100",
+      "gpu_type_ids": [
+        "NVIDIA A100 80GB PCIe",
+        "NVIDIA A100-SXM4-80GB"
+      ]
+    }
   ],
   "gpu_type_priority": "availability",
   "gpu_count": 1,
   "container_disk_gb": 100,
   "volume_gb": 20,
   "volume_mount_path": "/workspace",
-  "max_create_attempts": 5,
-  "create_deadline_seconds": 180,
+  "same_tier_retries": 1,
+  "create_deadline_seconds": 60,
   "retry_base_seconds": 10,
   "retry_max_seconds": 60
 }

--- a/scripts/ci/runpod_config.json
+++ b/scripts/ci/runpod_config.json
@@ -22,6 +22,7 @@
   "volume_gb": 20,
   "volume_mount_path": "/workspace",
   "max_create_attempts": 5,
+  "create_deadline_seconds": 180,
   "retry_base_seconds": 10,
   "retry_max_seconds": 60
 }

--- a/scripts/ci/runpod_contract.py
+++ b/scripts/ci/runpod_contract.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Validate repository RunPod configuration against the live OpenAPI schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_CONFIG = Path(__file__).with_name("runpod_config.json")
+
+
+class ContractError(RuntimeError):
+    """The RunPod schema or repository configuration violates the contract."""
+
+
+def resolve_local_ref(
+    document: Mapping[str, object], ref: str
+) -> Mapping[str, object]:
+    """Resolve one RFC 6901 local JSON pointer to an object."""
+
+    if not ref.startswith("#/"):
+        raise ContractError(f"unsupported non-local OpenAPI reference: {ref}")
+    value: object = document
+    for token in ref[2:].split("/"):
+        token = token.replace("~1", "/").replace("~0", "~")
+        if not isinstance(value, Mapping) or token not in value:
+            raise ContractError(f"unresolved OpenAPI reference: {ref}")
+        value = value[token]
+    if not isinstance(value, Mapping):
+        raise ContractError(f"OpenAPI reference is not an object schema: {ref}")
+    return value
+
+
+def _mapping(value: object, context: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ContractError(f"OpenAPI {context} must be an object")
+    return value
+
+
+def _property(value: Mapping[str, object], name: str, context: str) -> object:
+    if name not in value:
+        raise ContractError(f"OpenAPI {context} is missing {name!r}")
+    return value[name]
+
+
+def extract_gpu_type_ids(document: Mapping[str, object]) -> frozenset[str]:
+    """Extract the accepted ``gpuTypeIds`` enum from ``POST /pods``."""
+
+    try:
+        paths = _mapping(_property(document, "paths", "document"), "paths")
+        pods = _mapping(_property(paths, "/pods", "paths"), "POST /pods")
+        post = _mapping(_property(pods, "post", "POST /pods"), "POST /pods")
+        request_body = _mapping(
+            _property(post, "requestBody", "POST /pods"),
+            "POST /pods requestBody",
+        )
+        content = _mapping(
+            _property(request_body, "content", "POST /pods requestBody"),
+            "POST /pods requestBody content",
+        )
+        json_content = _mapping(
+            _property(content, "application/json", "POST /pods content"),
+            "POST /pods application/json",
+        )
+        schema = _mapping(
+            _property(json_content, "schema", "POST /pods application/json"),
+            "POST /pods request schema",
+        )
+    except ContractError as error:
+        if "POST /pods" in str(error):
+            raise
+        raise ContractError(f"invalid POST /pods OpenAPI schema: {error}") from error
+
+    if ref := schema.get("$ref"):
+        if not isinstance(ref, str):
+            raise ContractError("POST /pods schema $ref must be a string")
+        schema = resolve_local_ref(document, ref)
+
+    properties = _mapping(
+        _property(schema, "properties", "POST /pods schema"),
+        "POST /pods properties",
+    )
+    gpu_types = _mapping(
+        _property(properties, "gpuTypeIds", "POST /pods properties"),
+        "POST /pods gpuTypeIds",
+    )
+    items = _mapping(
+        _property(gpu_types, "items", "POST /pods gpuTypeIds"),
+        "POST /pods gpuTypeIds items",
+    )
+    enum_values = _property(items, "enum", "POST /pods gpuTypeIds items")
+    if (
+        not isinstance(enum_values, Sequence)
+        or isinstance(enum_values, (str, bytes))
+        or not enum_values
+        or any(not isinstance(value, str) for value in enum_values)
+    ):
+        raise ContractError("POST /pods gpuTypeIds enum must contain string GPU IDs")
+    return frozenset(enum_values)
+
+
+def validate_gpu_type_ids(
+    document: Mapping[str, object], configured_ids: Sequence[str]
+) -> None:
+    """Require every configured GPU ID to occur in the current schema."""
+
+    accepted = extract_gpu_type_ids(document)
+    invalid = sorted(set(configured_ids) - accepted)
+    if invalid:
+        raise ContractError(
+            "configured RunPod GPU IDs absent from POST /pods schema: "
+            + ", ".join(invalid)
+        )
+
+
+def _load_json(path: Path) -> Mapping[str, object]:
+    try:
+        value: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ContractError(f"failed to read JSON from {path}: {error}") from error
+    if not isinstance(value, Mapping):
+        raise ContractError(f"JSON root in {path} must be an object")
+    return value
+
+
+def fetch_openapi(url: str, api_key: str) -> Mapping[str, object]:
+    """Fetch and decode the authenticated OpenAPI document without logging secrets."""
+
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Accept": "application/json",
+            "User-Agent": "tenferro-ci-contract/1",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            value: Any = json.load(response)
+    except (OSError, urllib.error.HTTPError, json.JSONDecodeError) as error:
+        raise ContractError(f"failed to fetch RunPod OpenAPI document: {error}") from error
+    if not isinstance(value, Mapping):
+        raise ContractError("RunPod OpenAPI document root must be an object")
+    return value
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--schema-file", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        config = _load_json(args.config)
+        configured_ids = config.get("gpu_type_ids")
+        if (
+            not isinstance(configured_ids, Sequence)
+            or isinstance(configured_ids, (str, bytes))
+            or not configured_ids
+            or any(not isinstance(value, str) for value in configured_ids)
+        ):
+            raise ContractError("runpod_config.json gpu_type_ids must be nonempty strings")
+        if args.schema_file:
+            schema = _load_json(args.schema_file)
+        else:
+            api_key = os.environ.get("RUNPOD_API_KEY")
+            if not api_key:
+                raise ContractError(
+                    "RUNPOD_API_KEY is required for live OpenAPI validation"
+                )
+            openapi_url = config.get("openapi_url")
+            if not isinstance(openapi_url, str) or not openapi_url:
+                raise ContractError("runpod_config.json openapi_url must be a string")
+            schema = fetch_openapi(openapi_url, api_key)
+        validate_gpu_type_ids(schema, configured_ids)
+        print(
+            f"RunPod OpenAPI accepts all {len(configured_ids)} configured GPU IDs."
+        )
+    except ContractError as error:
+        print(f"RunPod contract error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/runpod_contract.py
+++ b/scripts/ci/runpod_contract.py
@@ -21,6 +21,51 @@ class ContractError(RuntimeError):
     """The RunPod schema or repository configuration violates the contract."""
 
 
+def configured_gpu_tiers(
+    config: Mapping[str, object],
+) -> list[tuple[str, tuple[str, ...]]]:
+    """Validate and return ordered, disjoint GPU tiers."""
+
+    value = config.get("gpu_tiers")
+    if (
+        not isinstance(value, Sequence)
+        or isinstance(value, (str, bytes))
+        or not value
+    ):
+        raise ContractError(
+            "runpod_config.json gpu_tiers must be a nonempty array"
+        )
+    tiers: list[tuple[str, tuple[str, ...]]] = []
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise ContractError("each GPU tier must be an object")
+        name = item.get("name")
+        ids = item.get("gpu_type_ids")
+        if not isinstance(name, str) or not name:
+            raise ContractError("each GPU tier requires a nonempty name")
+        if (
+            not isinstance(ids, Sequence)
+            or isinstance(ids, (str, bytes))
+            or not ids
+        ):
+            raise ContractError(
+                f"GPU tier {name} requires nonempty gpu_type_ids"
+            )
+        if any(not isinstance(gpu_id, str) or not gpu_id for gpu_id in ids):
+            raise ContractError(
+                f"GPU tier {name} IDs must be nonempty strings"
+            )
+        duplicate = seen.intersection(ids)
+        if duplicate:
+            raise ContractError(
+                f"duplicate GPU ID across tiers: {sorted(duplicate)}"
+            )
+        seen.update(ids)
+        tiers.append((name, tuple(ids)))
+    return tiers
+
+
 def resolve_local_ref(
     document: Mapping[str, object], ref: str
 ) -> Mapping[str, object]:
@@ -163,14 +208,10 @@ def main() -> int:
     args = _parse_args()
     try:
         config = _load_json(args.config)
-        configured_ids = config.get("gpu_type_ids")
-        if (
-            not isinstance(configured_ids, Sequence)
-            or isinstance(configured_ids, (str, bytes))
-            or not configured_ids
-            or any(not isinstance(value, str) for value in configured_ids)
-        ):
-            raise ContractError("runpod_config.json gpu_type_ids must be nonempty strings")
+        tiers = configured_gpu_tiers(config)
+        configured_ids = [
+            gpu_id for _name, gpu_ids in tiers for gpu_id in gpu_ids
+        ]
         if args.schema_file:
             schema = _load_json(args.schema_file)
         else:

--- a/scripts/ci/runpod_contract.py
+++ b/scripts/ci/runpod_contract.py
@@ -29,11 +29,11 @@ def resolve_local_ref(
     if not ref.startswith("#/"):
         raise ContractError(f"unsupported non-local OpenAPI reference: {ref}")
     value: object = document
-    for token in ref[2:].split("/"):
-        token = token.replace("~1", "/").replace("~0", "~")
-        if not isinstance(value, Mapping) or token not in value:
+    for segment in ref[2:].split("/"):
+        segment = segment.replace("~1", "/").replace("~0", "~")
+        if not isinstance(value, Mapping) or segment not in value:
             raise ContractError(f"unresolved OpenAPI reference: {ref}")
-        value = value[token]
+        value = value[segment]
     if not isinstance(value, Mapping):
         raise ContractError(f"OpenAPI reference is not an object schema: {ref}")
     return value

--- a/scripts/ci/tests/__init__.py
+++ b/scripts/ci/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for shared CI policy helpers."""

--- a/scripts/ci/tests/test_change_policy.py
+++ b/scripts/ci/tests/test_change_policy.py
@@ -1,0 +1,99 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.ci.change_policy import ChangeClass, classify_paths
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "ci" / "change_policy.py"
+
+
+class ChangePolicyTests(unittest.TestCase):
+    def test_docs_only_runs_docs_without_rust_or_gpu(self) -> None:
+        policy = classify_paths(["docs/guides/cpu.md", "README.md"])
+        self.assertIs(policy.change_class, ChangeClass.DOCS_ONLY)
+        self.assertTrue(policy.run_docs)
+        self.assertFalse(policy.run_rust)
+        self.assertFalse(policy.run_extensions)
+        self.assertFalse(policy.run_gpu)
+
+    def test_ci_and_docs_runs_both_lightweight_suites(self) -> None:
+        policy = classify_paths(
+            [".github/workflows/ci.yml", "docs/worklogs/ci.md"]
+        )
+        self.assertIs(policy.change_class, ChangeClass.CI_ONLY)
+        self.assertTrue(policy.run_ci_config)
+        self.assertTrue(policy.run_docs)
+        self.assertFalse(policy.run_rust)
+
+    def test_runpod_control_plane_requires_gpu(self) -> None:
+        for path in (
+            "scripts/ci/runpod_client.py",
+            "scripts/ci/runpod_config.json",
+            ".github/workflows/runpod-gpu-test.yml",
+            ".github/workflows/CI_gpu.yml",
+        ):
+            with self.subTest(path=path):
+                policy = classify_paths([path])
+                self.assertIs(policy.change_class, ChangeClass.CI_ONLY)
+                self.assertTrue(policy.run_ci_config)
+                self.assertTrue(policy.run_gpu)
+
+    def test_unrelated_ci_change_does_not_require_gpu(self) -> None:
+        policy = classify_paths([".github/workflows/docs.yml"])
+        self.assertIs(policy.change_class, ChangeClass.CI_ONLY)
+        self.assertTrue(policy.run_ci_config)
+        self.assertFalse(policy.run_gpu)
+
+    def test_unknown_and_empty_diffs_fall_back_to_code(self) -> None:
+        for paths in ([], ["new-top-level-policy.toml"]):
+            with self.subTest(paths=paths):
+                policy = classify_paths(paths)
+                self.assertIs(policy.change_class, ChangeClass.CODE)
+                self.assertTrue(policy.run_rust)
+                self.assertTrue(policy.run_extensions)
+                self.assertTrue(policy.run_gpu)
+
+    def test_push_to_main_forces_comprehensive_non_gpu_lanes(self) -> None:
+        policy = classify_paths(["README.md"], event="push")
+        self.assertIs(policy.change_class, ChangeClass.CODE)
+        self.assertTrue(policy.run_rust)
+        self.assertTrue(policy.run_extensions)
+        self.assertTrue(policy.run_docs)
+        self.assertTrue(policy.run_ci_config)
+
+    def test_paths_are_normalized_and_deduplicated(self) -> None:
+        policy = classify_paths([" ./README.md ", "README.md", ""])
+        self.assertIs(policy.change_class, ChangeClass.DOCS_ONLY)
+        self.assertEqual(policy.reasons, ("docs: README.md",))
+
+    def test_cli_writes_stable_github_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "github-output"
+            env = os.environ | {"GITHUB_OUTPUT": str(output)}
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--path", "README.md"],
+                cwd=ROOT,
+                env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["classification"], "docs-only")
+            values = dict(
+                line.split("=", 1) for line in output.read_text().splitlines()
+            )
+            self.assertEqual(values["classification"], "docs-only")
+            self.assertEqual(values["run_docs"], "true")
+            self.assertEqual(values["run_rust"], "false")
+            self.assertIn("README.md", values["reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_recover_runpod_pr.py
+++ b/scripts/ci/tests/test_recover_runpod_pr.py
@@ -1,0 +1,66 @@
+import subprocess
+import unittest
+
+from scripts.ci.recover_runpod_pr import (
+    build_dispatch_command,
+    recover_pr,
+)
+
+
+class RecoverRunPodPrTests(unittest.TestCase):
+    def test_dispatch_always_uses_trusted_main(self) -> None:
+        self.assertEqual(
+            build_dispatch_command(1379, wait=False),
+            [
+                "gh",
+                "workflow",
+                "run",
+                "runpod-gpu-test.yml",
+                "--ref",
+                "main",
+                "-f",
+                "pr_number=1379",
+            ],
+        )
+
+    def test_invalid_pr_numbers_are_rejected(self) -> None:
+        for value in (0, -1):
+            with self.subTest(value=value), self.assertRaisesRegex(
+                ValueError, "positive"
+            ):
+                build_dispatch_command(value, wait=False)
+
+    def test_recovery_authenticates_dispatches_and_watches_returned_run(self) -> None:
+        commands: list[list[str]] = []
+
+        def runner(
+            command: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            commands.append(command)
+            stdout = (
+                "https://github.com/tensor4all/tenferro-rs/actions/runs/12345\n"
+                if command[1:3] == ["workflow", "run"]
+                else ""
+            )
+            return subprocess.CompletedProcess(command, 0, stdout, "")
+
+        url = recover_pr(1379, wait=True, runner=runner)
+        self.assertEqual(
+            url,
+            "https://github.com/tensor4all/tenferro-rs/actions/runs/12345",
+        )
+        self.assertEqual(commands[0], ["gh", "auth", "status"])
+        self.assertEqual(commands[-1], ["gh", "run", "watch", "12345", "--exit-status"])
+
+    def test_missing_run_url_is_an_error(self) -> None:
+        def runner(
+            command: list[str], **_kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(command, 0, "dispatched\n", "")
+
+        with self.assertRaisesRegex(RuntimeError, "run URL"):
+            recover_pr(1379, wait=False, runner=runner)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -1,0 +1,83 @@
+import io
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.ci.run_profile import commands_for, expand_profiles, run_profiles
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class RunProfileTests(unittest.TestCase):
+    def test_workspace_blas_matches_ci_feature_contract(self) -> None:
+        self.assertEqual(
+            commands_for("workspace-blas"),
+            (
+                "cargo nextest run --workspace --release --no-default-features "
+                "--features cpu-blas --no-fail-fast",
+                "cargo test --doc --workspace --release --no-default-features "
+                "--features cpu-blas",
+            ),
+        )
+
+    def test_full_profile_expands_named_profiles_once(self) -> None:
+        expanded = expand_profiles(["full"])
+        self.assertEqual(
+            expanded,
+            (
+                "workspace-faer",
+                "workspace-blas",
+                "blas-inject",
+                "extensions",
+                "docs",
+                "coverage",
+                "ci-config",
+            ),
+        )
+        self.assertEqual(len(expanded), len(set(expanded)))
+
+    def test_duplicate_profile_composition_is_deduplicated(self) -> None:
+        expanded = expand_profiles(["workspace-faer", "full"])
+        self.assertEqual(expanded[0], "workspace-faer")
+        self.assertEqual(expanded.count("workspace-faer"), 1)
+
+    def test_unknown_profile_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unknown CI profile"):
+            expand_profiles(["expensive-typo"])
+
+    def test_dry_run_prints_commands_without_executing(self) -> None:
+        output = io.StringIO()
+        with patch("scripts.ci.run_profile.subprocess.run") as run:
+            run_profiles(["blas-inject"], dry_run=True, output=output)
+        run.assert_not_called()
+        self.assertIn("+ cargo test -p tenferro-cpu", output.getvalue())
+
+    def test_workspace_blas_uses_linker_flags_only_for_that_profile(self) -> None:
+        calls: list[dict[str, str]] = []
+
+        def record_run(*_args: object, **kwargs: object) -> None:
+            calls.append(kwargs["env"])  # type: ignore[arg-type]
+
+        with patch.dict("os.environ", {}, clear=True), patch(
+            "scripts.ci.run_profile.subprocess.run", side_effect=record_run
+        ):
+            run_profiles(
+                ["workspace-faer", "workspace-blas"],
+                dry_run=False,
+                output=io.StringIO(),
+            )
+        self.assertNotIn("RUSTFLAGS", calls[0])
+        self.assertEqual(
+            calls[2]["RUSTFLAGS"], "-l dylib=openblas -l dylib=lapack"
+        )
+
+    def test_fast_preflight_delegates_profiles_without_redefining_them(self) -> None:
+        source = (ROOT / "scripts" / "check-pr-fast.sh").read_text()
+        self.assertIn("--ci-profile", source)
+        self.assertIn('python3 scripts/ci/run_profile.py "${profile_args[@]}"', source)
+        self.assertNotIn("cargo nextest run --workspace", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_runpod_client.py
+++ b/scripts/ci/tests/test_runpod_client.py
@@ -98,10 +98,17 @@ class RunPodClientTests(unittest.TestCase):
         self.assertEqual(delays, [2.5, 5.0, 10.0, 20.0, 30.0, 30.0, 30.0])
 
     def test_payload_preserves_secure_trust_boundary(self) -> None:
-        payload = build_pod_payload(CONFIG, "image", "startup", "jit")
+        gpu_type_ids = CONFIG["gpu_tiers"][0]["gpu_type_ids"]
+        payload = build_pod_payload(
+            CONFIG,
+            "image",
+            "startup",
+            "jit",
+            gpu_type_ids,
+        )
         self.assertEqual(payload["cloudType"], "SECURE")
         self.assertIs(payload["interruptible"], False)
-        self.assertEqual(payload["gpuTypeIds"], CONFIG["gpu_type_ids"])
+        self.assertEqual(payload["gpuTypeIds"], gpu_type_ids)
         self.assertEqual(payload["env"]["RUNNER_JIT_CONFIG"], "jit")
         self.assertEqual(payload["dockerStartCmd"], ["startup"])
 

--- a/scripts/ci/tests/test_runpod_client.py
+++ b/scripts/ci/tests/test_runpod_client.py
@@ -52,9 +52,9 @@ class RunPodClientTests(unittest.TestCase):
                 "gpu_tier=premium\n",
             )
             self.assertIn(
-                "Selected GPU: `NVIDIA L40S`", summary.read_text()
+                "Selected GPU: NVIDIA L40S", summary.read_text()
             )
-            self.assertIn("Price tier: `premium`", summary.read_text())
+            self.assertIn("Price tier: premium", summary.read_text())
 
     def test_publish_github_result_rejects_multiline_provider_values(
         self,
@@ -73,6 +73,62 @@ class RunPodClientTests(unittest.TestCase):
                 output_path=Path("unused-output"),
                 summary_path=None,
             )
+
+    def test_create_rejects_gpu_outside_selected_tier(self) -> None:
+        with self.assertRaisesRegex(
+            PermanentRunPodError, "outside selected tier"
+        ):
+            create_pod(
+                CONFIG,
+                [
+                    CreateRequest(
+                        "premium",
+                        b"premium",
+                        ("NVIDIA L40S",),
+                    )
+                ],
+                transport=lambda _payload, _timeout: (
+                    201,
+                    {},
+                    b'{"id":"pod-1","machine":'
+                    b'{"gpuTypeId":"NVIDIA H100 80GB HBM3"}}',
+                ),
+            )
+
+    def test_create_requires_assigned_gpu_for_selected_tier(self) -> None:
+        with self.assertRaisesRegex(
+            PermanentRunPodError, "missing assigned GPU"
+        ):
+            create_pod(
+                CONFIG,
+                [
+                    CreateRequest(
+                        "premium",
+                        b"premium",
+                        ("NVIDIA L40S",),
+                    )
+                ],
+                transport=lambda _payload, _timeout: (
+                    201,
+                    {},
+                    b'{"id":"pod-1"}',
+                ),
+            )
+
+    def test_summary_escapes_markdown_from_provider_values(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            summary = Path(directory) / "summary"
+            publish_github_result(
+                CreateResult(
+                    pod_id="pod-1",
+                    gpu_type_id="GPU `spoof`",
+                    gpu_tier="premium",
+                    body=b"{}",
+                ),
+                output_path=None,
+                summary_path=summary,
+            )
+            self.assertIn("GPU &#96;spoof&#96;", summary.read_text())
 
     def test_capacity_failure_requires_server_error_and_known_message(
         self,
@@ -110,7 +166,9 @@ class RunPodClientTests(unittest.TestCase):
         )
         seen: list[bytes] = []
 
-        def transport(payload: bytes) -> tuple[int, dict[str, str], bytes]:
+        def transport(
+            payload: bytes, _timeout: float
+        ) -> tuple[int, dict[str, str], bytes]:
             seen.append(payload)
             return next(responses)
 
@@ -168,7 +226,9 @@ class RunPodClientTests(unittest.TestCase):
     def test_permanent_error_is_not_retried(self) -> None:
         calls = 0
 
-        def transport(_payload: bytes) -> tuple[int, dict[str, str], bytes]:
+        def transport(
+            _payload: bytes, _timeout: float
+        ) -> tuple[int, dict[str, str], bytes]:
             nonlocal calls
             calls += 1
             return 400, {}, b'{"error":"bad gpu id"}'
@@ -194,7 +254,7 @@ class RunPodClientTests(unittest.TestCase):
         result = create_pod(
             CONFIG,
             [CreateRequest("cost-preferred", b"{}")],
-            transport=lambda _payload: next(responses),
+            transport=lambda _payload, _timeout: next(responses),
             sleep=sleeps.append,
             jitter=lambda: 0.5,
         )
@@ -218,7 +278,9 @@ class RunPodClientTests(unittest.TestCase):
         seen: list[bytes] = []
         sleeps: list[float] = []
 
-        def transport(payload: bytes) -> tuple[int, dict[str, str], bytes]:
+        def transport(
+            payload: bytes, _timeout: float
+        ) -> tuple[int, dict[str, str], bytes]:
             seen.append(payload)
             return next(responses)
 
@@ -236,7 +298,9 @@ class RunPodClientTests(unittest.TestCase):
     def test_generic_service_failure_stops_after_one_retry(self) -> None:
         calls = 0
 
-        def transport(_payload: bytes) -> tuple[int, dict[str, str], bytes]:
+        def transport(
+            _payload: bytes, _timeout: float
+        ) -> tuple[int, dict[str, str], bytes]:
             nonlocal calls
             calls += 1
             if calls == 3:
@@ -254,7 +318,7 @@ class RunPodClientTests(unittest.TestCase):
         self.assertEqual(calls, 2)
 
     def test_creation_deadline_caps_retry_sleep(self) -> None:
-        ticks = iter([0.0, 59.0, 60.0])
+        ticks = iter([0.0, 0.0, 59.0, 60.0])
         sleeps: list[float] = []
         with self.assertRaises(RetryableRunPodError):
             create_pod(
@@ -264,7 +328,7 @@ class RunPodClientTests(unittest.TestCase):
                     "create_deadline_seconds": 60,
                 },
                 [CreateRequest("cost-preferred", b"cheap")],
-                transport=lambda _payload: (
+                transport=lambda _payload, _timeout: (
                     503,
                     {"Retry-After": "30"},
                     b"{}",
@@ -274,15 +338,44 @@ class RunPodClientTests(unittest.TestCase):
             )
         self.assertEqual(sleeps, [1.0])
 
+    def test_creation_deadline_caps_each_transport_timeout(self) -> None:
+        ticks = iter([0.0, 0.0, 59.0, 59.0])
+        timeouts: list[float] = []
+        responses = iter(
+            [
+                (503, {}, b'{"error":"busy"}'),
+                (201, {}, b'{"id":"pod-1"}'),
+            ]
+        )
+
+        def transport(
+            _payload: bytes, timeout: float
+        ) -> tuple[int, dict[str, str], bytes]:
+            timeouts.append(timeout)
+            return next(responses)
+
+        result = create_pod(
+            CONFIG,
+            [CreateRequest("cost-preferred", b"cheap")],
+            transport=transport,
+            sleep=lambda _delay: None,
+            monotonic=lambda: next(ticks),
+        )
+
+        self.assertEqual(result.pod_id, "pod-1")
+        self.assertEqual(timeouts, [60.0, 1.0])
+
     def test_transport_failure_is_retryable_but_bounded(self) -> None:
         calls = 0
 
-        def transport(_payload: bytes) -> tuple[int, dict[str, str], bytes]:
+        def transport(
+            _payload: bytes, _timeout: float
+        ) -> tuple[int, dict[str, str], bytes]:
             nonlocal calls
             calls += 1
             raise OSError("connection reset")
 
-        config: dict[str, Any] = CONFIG | {"max_create_attempts": 2}
+        config: dict[str, Any] = CONFIG | {"same_tier_retries": 1}
         with self.assertRaisesRegex(RetryableRunPodError, "transport failure"):
             create_pod(
                 config,

--- a/scripts/ci/tests/test_runpod_client.py
+++ b/scripts/ci/tests/test_runpod_client.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.ci.runpod_client import (
+    CreateRequest,
     PermanentRunPodError,
     RetryClass,
     RetryableRunPodError,
@@ -11,6 +12,7 @@ from scripts.ci.runpod_client import (
     build_pod_payload,
     classify_http_status,
     create_pod,
+    is_capacity_failure,
     parse_create_response,
     redacted_error_message,
 )
@@ -23,6 +25,59 @@ CONFIG = json.loads(
 
 
 class RunPodClientTests(unittest.TestCase):
+    def test_capacity_failure_requires_server_error_and_known_message(
+        self,
+    ) -> None:
+        body = (
+            b'{"error":"This machine does not have the resources to deploy '
+            b'your pod"}'
+        )
+        self.assertTrue(is_capacity_failure(500, body))
+        self.assertFalse(is_capacity_failure(400, body))
+        self.assertFalse(
+            is_capacity_failure(500, b'{"error":"internal failure"}')
+        )
+
+    def test_capacity_failure_moves_tier_without_sleep(self) -> None:
+        requests = [
+            CreateRequest("cost-preferred", b"cheap"),
+            CreateRequest("premium", b"premium"),
+        ]
+        responses = iter(
+            [
+                (
+                    500,
+                    {},
+                    b'{"error":"This machine does not have the resources '
+                    b'to deploy your pod"}',
+                ),
+                (
+                    201,
+                    {},
+                    b'{"id":"pod-1","machine":'
+                    b'{"gpuTypeId":"NVIDIA L40S"}}',
+                ),
+            ]
+        )
+        seen: list[bytes] = []
+
+        def transport(payload: bytes) -> tuple[int, dict[str, str], bytes]:
+            seen.append(payload)
+            return next(responses)
+
+        result = create_pod(
+            CONFIG,
+            requests,
+            transport=transport,
+            sleep=lambda _delay: self.fail(
+                "capacity failover must not sleep"
+            ),
+        )
+
+        self.assertEqual(seen, [b"cheap", b"premium"])
+        self.assertEqual(result.gpu_tier, "premium")
+        self.assertEqual(result.gpu_type_id, "NVIDIA L40S")
+
     def test_retry_classification(self) -> None:
         for status in (408, 429, 500, 502, 503):
             with self.subTest(status=status):
@@ -65,7 +120,7 @@ class RunPodClientTests(unittest.TestCase):
         with self.assertRaisesRegex(PermanentRunPodError, "HTTP 400"):
             create_pod(
                 CONFIG,
-                b"{}",
+                [CreateRequest("cost-preferred", b"{}")],
                 transport=transport,
                 sleep=lambda _delay: self.fail("must not sleep"),
             )
@@ -75,7 +130,6 @@ class RunPodClientTests(unittest.TestCase):
         responses = iter(
             [
                 (500, {}, b'{"error":"busy"}'),
-                (503, {"Retry-After": "7"}, b'{"error":"busy"}'),
                 (201, {}, b'{"id":"pod-1","machine":{"gpuTypeId":"NVIDIA A40"}}'),
             ]
         )
@@ -83,7 +137,7 @@ class RunPodClientTests(unittest.TestCase):
 
         result = create_pod(
             CONFIG,
-            b"{}",
+            [CreateRequest("cost-preferred", b"{}")],
             transport=lambda _payload: next(responses),
             sleep=sleeps.append,
             jitter=lambda: 0.5,
@@ -91,7 +145,78 @@ class RunPodClientTests(unittest.TestCase):
 
         self.assertEqual(result.pod_id, "pod-1")
         self.assertEqual(result.gpu_type_id, "NVIDIA A40")
-        self.assertEqual(sleeps, [5.0, 7.0])
+        self.assertEqual(sleeps, [5.0])
+
+    def test_generic_service_failure_retries_same_tier_once(self) -> None:
+        responses = iter(
+            [
+                (503, {"Retry-After": "2"}, b'{"error":"busy"}'),
+                (
+                    201,
+                    {},
+                    b'{"id":"pod-1","machine":'
+                    b'{"gpuTypeId":"NVIDIA L40S"}}',
+                ),
+            ]
+        )
+        seen: list[bytes] = []
+        sleeps: list[float] = []
+
+        def transport(payload: bytes) -> tuple[int, dict[str, str], bytes]:
+            seen.append(payload)
+            return next(responses)
+
+        result = create_pod(
+            CONFIG | {"same_tier_retries": 1},
+            [CreateRequest("premium", b"premium")],
+            transport=transport,
+            sleep=sleeps.append,
+        )
+
+        self.assertEqual(seen, [b"premium", b"premium"])
+        self.assertEqual(sleeps, [2.0])
+        self.assertEqual(result.gpu_tier, "premium")
+
+    def test_generic_service_failure_stops_after_one_retry(self) -> None:
+        calls = 0
+
+        def transport(_payload: bytes) -> tuple[int, dict[str, str], bytes]:
+            nonlocal calls
+            calls += 1
+            if calls == 3:
+                return 201, {}, b'{"id":"too-late"}'
+            return 503, {}, b'{"error":"busy"}'
+
+        with self.assertRaises(RetryableRunPodError):
+            create_pod(
+                CONFIG | {"same_tier_retries": 1},
+                [CreateRequest("premium", b"premium")],
+                transport=transport,
+                sleep=lambda _delay: None,
+                monotonic=lambda: 0.0,
+            )
+        self.assertEqual(calls, 2)
+
+    def test_creation_deadline_caps_retry_sleep(self) -> None:
+        ticks = iter([0.0, 59.0, 60.0])
+        sleeps: list[float] = []
+        with self.assertRaises(RetryableRunPodError):
+            create_pod(
+                CONFIG
+                | {
+                    "same_tier_retries": 1,
+                    "create_deadline_seconds": 60,
+                },
+                [CreateRequest("cost-preferred", b"cheap")],
+                transport=lambda _payload: (
+                    503,
+                    {"Retry-After": "30"},
+                    b"{}",
+                ),
+                sleep=sleeps.append,
+                monotonic=lambda: next(ticks),
+            )
+        self.assertEqual(sleeps, [1.0])
 
     def test_transport_failure_is_retryable_but_bounded(self) -> None:
         calls = 0
@@ -105,7 +230,7 @@ class RunPodClientTests(unittest.TestCase):
         with self.assertRaisesRegex(RetryableRunPodError, "transport failure"):
             create_pod(
                 config,
-                b"{}",
+                [CreateRequest("cost-preferred", b"{}")],
                 transport=transport,
                 sleep=lambda _delay: None,
                 jitter=lambda: 0.5,

--- a/scripts/ci/tests/test_runpod_client.py
+++ b/scripts/ci/tests/test_runpod_client.py
@@ -1,0 +1,130 @@
+import json
+import unittest
+from pathlib import Path
+from typing import Any
+
+from scripts.ci.runpod_client import (
+    PermanentRunPodError,
+    RetryClass,
+    RetryableRunPodError,
+    backoff_seconds,
+    build_pod_payload,
+    classify_http_status,
+    create_pod,
+    parse_create_response,
+    redacted_error_message,
+)
+
+
+ROOT = Path(__file__).resolve().parents[3]
+CONFIG = json.loads(
+    (ROOT / "scripts" / "ci" / "runpod_config.json").read_text()
+)
+
+
+class RunPodClientTests(unittest.TestCase):
+    def test_retry_classification(self) -> None:
+        for status in (408, 429, 500, 502, 503):
+            with self.subTest(status=status):
+                self.assertIs(
+                    classify_http_status(status), RetryClass.RETRYABLE
+                )
+        for status in (400, 401, 403, 404, 422):
+            with self.subTest(status=status):
+                self.assertIs(
+                    classify_http_status(status), RetryClass.PERMANENT
+                )
+
+    def test_backoff_is_bounded_and_jittered(self) -> None:
+        delays = [
+            backoff_seconds(index, base=5, cap=60, jitter=lambda: 0.5)
+            for index in range(1, 8)
+        ]
+        self.assertEqual(delays, [2.5, 5.0, 10.0, 20.0, 30.0, 30.0, 30.0])
+
+    def test_payload_preserves_secure_trust_boundary(self) -> None:
+        payload = build_pod_payload(CONFIG, "image", "startup", "jit")
+        self.assertEqual(payload["cloudType"], "SECURE")
+        self.assertIs(payload["interruptible"], False)
+        self.assertEqual(payload["gpuTypeIds"], CONFIG["gpu_type_ids"])
+        self.assertEqual(payload["env"]["RUNNER_JIT_CONFIG"], "jit")
+        self.assertEqual(payload["dockerStartCmd"], ["startup"])
+
+    def test_success_without_pod_id_is_protocol_error(self) -> None:
+        with self.assertRaisesRegex(PermanentRunPodError, "missing pod id"):
+            parse_create_response(201, b"{}")
+
+    def test_permanent_error_is_not_retried(self) -> None:
+        calls = 0
+
+        def transport(_payload: bytes) -> tuple[int, dict[str, str], bytes]:
+            nonlocal calls
+            calls += 1
+            return 400, {}, b'{"error":"bad gpu id"}'
+
+        with self.assertRaisesRegex(PermanentRunPodError, "HTTP 400"):
+            create_pod(
+                CONFIG,
+                b"{}",
+                transport=transport,
+                sleep=lambda _delay: self.fail("must not sleep"),
+            )
+        self.assertEqual(calls, 1)
+
+    def test_retryable_responses_sleep_then_succeed(self) -> None:
+        responses = iter(
+            [
+                (500, {}, b'{"error":"busy"}'),
+                (503, {"Retry-After": "7"}, b'{"error":"busy"}'),
+                (201, {}, b'{"id":"pod-1","machine":{"gpuTypeId":"NVIDIA A40"}}'),
+            ]
+        )
+        sleeps: list[float] = []
+
+        result = create_pod(
+            CONFIG,
+            b"{}",
+            transport=lambda _payload: next(responses),
+            sleep=sleeps.append,
+            jitter=lambda: 0.5,
+        )
+
+        self.assertEqual(result.pod_id, "pod-1")
+        self.assertEqual(result.gpu_type_id, "NVIDIA A40")
+        self.assertEqual(sleeps, [5.0, 7.0])
+
+    def test_transport_failure_is_retryable_but_bounded(self) -> None:
+        calls = 0
+
+        def transport(_payload: bytes) -> tuple[int, dict[str, str], bytes]:
+            nonlocal calls
+            calls += 1
+            raise OSError("connection reset")
+
+        config: dict[str, Any] = CONFIG | {"max_create_attempts": 2}
+        with self.assertRaisesRegex(RetryableRunPodError, "transport failure"):
+            create_pod(
+                config,
+                b"{}",
+                transport=transport,
+                sleep=lambda _delay: None,
+                jitter=lambda: 0.5,
+            )
+        self.assertEqual(calls, 2)
+
+    def test_error_redaction_removes_secret_values_and_fields(self) -> None:
+        body = json.dumps(
+            {
+                "env": {"RUNNER_JIT_CONFIG": "jit-secret"},
+                "dockerStartCmd": ["startup-secret"],
+                "message": "request echoed jit-secret",
+            }
+        ).encode()
+        message = redacted_error_message(body, secrets=("jit-secret",))
+        self.assertNotIn("jit-secret", message)
+        self.assertNotIn("startup-secret", message)
+        self.assertIn("***redacted***", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_runpod_client.py
+++ b/scripts/ci/tests/test_runpod_client.py
@@ -1,10 +1,12 @@
 import json
+import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
 
 from scripts.ci.runpod_client import (
     CreateRequest,
+    CreateResult,
     PermanentRunPodError,
     RetryClass,
     RetryableRunPodError,
@@ -14,6 +16,7 @@ from scripts.ci.runpod_client import (
     create_pod,
     is_capacity_failure,
     parse_create_response,
+    publish_github_result,
     redacted_error_message,
 )
 
@@ -25,6 +28,52 @@ CONFIG = json.loads(
 
 
 class RunPodClientTests(unittest.TestCase):
+    def test_publish_github_result_records_tier_and_gpu(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "output"
+            summary = Path(directory) / "summary"
+            result = CreateResult(
+                pod_id="pod-1",
+                gpu_type_id="NVIDIA L40S",
+                gpu_tier="premium",
+                body=b"{}",
+            )
+
+            publish_github_result(
+                result,
+                output_path=output,
+                summary_path=summary,
+            )
+
+            self.assertEqual(
+                output.read_text(),
+                "pod_id=pod-1\n"
+                "gpu_type_id=NVIDIA L40S\n"
+                "gpu_tier=premium\n",
+            )
+            self.assertIn(
+                "Selected GPU: `NVIDIA L40S`", summary.read_text()
+            )
+            self.assertIn("Price tier: `premium`", summary.read_text())
+
+    def test_publish_github_result_rejects_multiline_provider_values(
+        self,
+    ) -> None:
+        result = CreateResult(
+            pod_id="pod-1",
+            gpu_type_id="NVIDIA L40S\ngpu_tier=forged",
+            gpu_tier="premium",
+            body=b"{}",
+        )
+        with self.assertRaisesRegex(
+            PermanentRunPodError, "unsafe GitHub output"
+        ):
+            publish_github_result(
+                result,
+                output_path=Path("unused-output"),
+                summary_path=None,
+            )
+
     def test_capacity_failure_requires_server_error_and_known_message(
         self,
     ) -> None:

--- a/scripts/ci/tests/test_runpod_client.py
+++ b/scripts/ci/tests/test_runpod_client.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from scripts.ci.runpod_client import (
+    AssignedGpuError,
     CreateRequest,
     CreateResult,
     PermanentRunPodError,
@@ -16,6 +17,7 @@ from scripts.ci.runpod_client import (
     create_pod,
     is_capacity_failure,
     parse_create_response,
+    publish_cleanup_pod_id,
     publish_github_result,
     redacted_error_message,
 )
@@ -76,8 +78,8 @@ class RunPodClientTests(unittest.TestCase):
 
     def test_create_rejects_gpu_outside_selected_tier(self) -> None:
         with self.assertRaisesRegex(
-            PermanentRunPodError, "outside selected tier"
-        ):
+            AssignedGpuError, "outside selected tier"
+        ) as caught:
             create_pod(
                 CONFIG,
                 [
@@ -94,6 +96,10 @@ class RunPodClientTests(unittest.TestCase):
                     b'{"gpuTypeId":"NVIDIA H100 80GB HBM3"}}',
                 ),
             )
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "output"
+            publish_cleanup_pod_id(caught.exception.result, output)
+            self.assertEqual(output.read_text(), "pod_id=pod-1\n")
 
     def test_create_requires_assigned_gpu_for_selected_tier(self) -> None:
         with self.assertRaisesRegex(

--- a/scripts/ci/tests/test_runpod_contract.py
+++ b/scripts/ci/tests/test_runpod_contract.py
@@ -2,6 +2,7 @@ import unittest
 
 from scripts.ci.runpod_contract import (
     ContractError,
+    configured_gpu_tiers,
     extract_gpu_type_ids,
     resolve_local_ref,
     validate_gpu_type_ids,
@@ -46,6 +47,46 @@ SCHEMA = {
 
 
 class RunPodContractTests(unittest.TestCase):
+    def test_configured_gpu_tiers_preserve_order(self) -> None:
+        tiers = configured_gpu_tiers(
+            {
+                "gpu_tiers": [
+                    {
+                        "name": "cheap",
+                        "gpu_type_ids": ["NVIDIA A40"],
+                    },
+                    {
+                        "name": "premium",
+                        "gpu_type_ids": ["NVIDIA L40S"],
+                    },
+                ]
+            }
+        )
+        self.assertEqual(
+            tiers,
+            [
+                ("cheap", ("NVIDIA A40",)),
+                ("premium", ("NVIDIA L40S",)),
+            ],
+        )
+
+    def test_configured_gpu_tiers_reject_duplicates(self) -> None:
+        with self.assertRaisesRegex(ContractError, "duplicate GPU ID"):
+            configured_gpu_tiers(
+                {
+                    "gpu_tiers": [
+                        {
+                            "name": "cheap",
+                            "gpu_type_ids": ["NVIDIA A40"],
+                        },
+                        {
+                            "name": "premium",
+                            "gpu_type_ids": ["NVIDIA A40"],
+                        },
+                    ]
+                }
+            )
+
     def test_extract_gpu_enum_follows_local_ref(self) -> None:
         self.assertEqual(
             extract_gpu_type_ids(SCHEMA),

--- a/scripts/ci/tests/test_runpod_contract.py
+++ b/scripts/ci/tests/test_runpod_contract.py
@@ -1,0 +1,89 @@
+import unittest
+
+from scripts.ci.runpod_contract import (
+    ContractError,
+    extract_gpu_type_ids,
+    resolve_local_ref,
+    validate_gpu_type_ids,
+)
+
+
+SCHEMA = {
+    "paths": {
+        "/pods": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreatePod"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "CreatePod": {
+                "type": "object",
+                "properties": {
+                    "gpuTypeIds": {
+                        "type": "array",
+                        "items": {
+                            "enum": [
+                                "NVIDIA A40",
+                                "NVIDIA GeForce RTX 4090",
+                            ]
+                        },
+                    }
+                },
+            }
+        }
+    },
+}
+
+
+class RunPodContractTests(unittest.TestCase):
+    def test_extract_gpu_enum_follows_local_ref(self) -> None:
+        self.assertEqual(
+            extract_gpu_type_ids(SCHEMA),
+            frozenset({"NVIDIA A40", "NVIDIA GeForce RTX 4090"}),
+        )
+
+    def test_validate_reports_every_invalid_configured_id(self) -> None:
+        with self.assertRaisesRegex(
+            ContractError, "Tesla T4.*Unknown GPU"
+        ):
+            validate_gpu_type_ids(SCHEMA, ["Tesla T4", "Unknown GPU"])
+
+    def test_missing_post_schema_is_a_hard_error(self) -> None:
+        with self.assertRaisesRegex(ContractError, "POST /pods"):
+            extract_gpu_type_ids({"paths": {}})
+
+    def test_non_local_reference_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ContractError, "non-local"):
+            resolve_local_ref(SCHEMA, "https://example.test/CreatePod")
+
+    def test_non_string_enum_member_is_rejected(self) -> None:
+        schema = {
+            **SCHEMA,
+            "components": {
+                "schemas": {
+                    "CreatePod": {
+                        "properties": {
+                            "gpuTypeIds": {
+                                "items": {"enum": ["NVIDIA A40", 7]}
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        with self.assertRaisesRegex(ContractError, "string GPU IDs"):
+            extract_gpu_type_ids(schema)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -78,6 +78,17 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertNotIn("RUNPOD_API_KEY", run_gpu)
         self.assertIn("RUNPOD_API_KEY", text[text.index("  runpod-contract:") :])
 
+    def test_runpod_creation_uses_status_aware_helper(self) -> None:
+        text = read(".github/workflows/runpod-gpu-test.yml")
+        create = text[
+            text.index("      - name: Create RunPod pod") : text.index(
+                "      - name: Wait for org runner to come online"
+            )
+        ]
+        self.assertIn("python3 scripts/ci/runpod_client.py create", create)
+        self.assertNotIn("for attempt in $(seq 1 5)", create)
+        self.assertNotIn("curl -sS", create)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -89,6 +89,41 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertNotIn("for attempt in $(seq 1 5)", create)
         self.assertNotIn("curl -sS", create)
 
+    def test_runpod_cache_key_uses_content_not_ref_identity(self) -> None:
+        text = read(".github/workflows/runpod-gpu-test.yml")
+        key_line = next(
+            line for line in text.splitlines() if 'key="cuda-archive-' in line
+        )
+        self.assertNotIn("TENFERRO_REF", key_line)
+        self.assertIn("hashFiles(", key_line)
+        self.assertIn("runpod_config.json", key_line)
+
+    def test_manual_pr_recovery_is_authorized_and_head_stable(self) -> None:
+        text = read(".github/workflows/runpod-gpu-test.yml")
+        self.assertIn("pr_number:", text)
+        self.assertIn("MANUAL_PR_NUMBER", text)
+        self.assertIn(".state", text)
+        self.assertIn(".head.repo.full_name", text)
+        self.assertIn("refusing recovery", text)
+        self.assertIn(
+            "target_head_sha: ${{ steps.resolve_ref.outputs.target_head_sha }}",
+            text,
+        )
+        gate = text[text.index("  ci-gpu-gate:") :]
+        self.assertIn(
+            "TARGET_HEAD_SHA: ${{ needs.authorize.outputs.target_head_sha }}",
+            gate,
+        )
+        self.assertNotIn("WORKFLOW_RUN_PULL_REQUESTS", gate)
+
+    def test_actionlint_knows_the_organization_gpu_runner(self) -> None:
+        config = read(".github/actionlint.yaml")
+        self.assertIn("self-hosted-runner:", config)
+        self.assertIn("- ubuntu-gpu", config)
+        self.assertNotIn(
+            "cache-workspace-crates", read(".github/workflows/CI_gpu.yml")
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -107,6 +107,19 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("${RUNPOD_GPU_TYPE_ID}", run_script)
         self.assertIn("${RUNPOD_GPU_TIER}", run_script)
 
+    def test_runpod_rejected_gpu_still_reaches_cleanup(self) -> None:
+        text = read(".github/workflows/runpod-gpu-test.yml")
+        client = read("scripts/ci/runpod_client.py")
+        main = client[client.index("def main()") :]
+        self.assertIn("except AssignedGpuError as error:", main)
+        self.assertIn("publish_cleanup_pod_id(", main)
+        startup_cleanup = text[
+            text.index("      - name: Delete pod if runner startup failed") :
+            text.index("  run-gpu-tests:")
+        ]
+        self.assertIn("steps.create_pod.outputs.pod_id != ''", startup_cleanup)
+        self.assertIn("POD_ID: ${{ steps.create_pod.outputs.pod_id }}", startup_cleanup)
+
     def test_runpod_cache_key_uses_content_not_ref_identity(self) -> None:
         text = read(".github/workflows/runpod-gpu-test.yml")
         key_line = next(

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -89,6 +89,15 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertNotIn("for attempt in $(seq 1 5)", create)
         self.assertNotIn("curl -sS", create)
 
+    def test_runpod_selected_gpu_is_forwarded_and_logged(self) -> None:
+        text = read(".github/workflows/runpod-gpu-test.yml")
+        self.assertIn(
+            "gpu_tier: ${{ steps.create_pod.outputs.gpu_tier }}", text
+        )
+        self.assertIn("needs.start-runpod.outputs.gpu_type_id", text)
+        self.assertIn("needs.start-runpod.outputs.gpu_tier", text)
+        self.assertIn("nvidia-smi --query-gpu=index,name", text)
+
     def test_runpod_cache_key_uses_content_not_ref_identity(self) -> None:
         text = read(".github/workflows/runpod-gpu-test.yml")
         key_line = next(

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -52,6 +52,32 @@ class WorkflowContractTests(unittest.TestCase):
             "github.com/rhysd/actionlint/cmd/actionlint@v1.7.7", text
         )
 
+    def test_runpod_schema_preflight_precedes_archive(self) -> None:
+        text = read(".github/workflows/runpod-gpu-test.yml")
+        self.assertIn("runpod-contract:", text)
+        self.assertIn("python3 scripts/ci/runpod_contract.py", text)
+        archive = text.index("  cuda-archive:")
+        preflight = text.index("  runpod-contract:")
+        self.assertLess(preflight, archive)
+        archive_block = text[archive : text.index("  start-runpod:")]
+        self.assertIn("- runpod-contract", archive_block)
+
+    def test_runpod_gpu_skip_uses_trusted_authorize_output(self) -> None:
+        text = read(".github/workflows/runpod-gpu-test.yml")
+        self.assertIn("gpu_required: ${{ steps.resolve_ref.outputs.run_gpu }}", text)
+        self.assertIn("gh api --paginate", text)
+        self.assertIn("python3 scripts/ci/change_policy.py", text)
+        self.assertIn("GPU validation not required", text)
+        self.assertIn("GPU_REQUIRED: ${{ needs.authorize.outputs.gpu_required }}", text)
+
+    def test_runpod_secret_stays_on_trusted_hosted_jobs(self) -> None:
+        text = read(".github/workflows/runpod-gpu-test.yml")
+        run_gpu = text[
+            text.index("  run-gpu-tests:") : text.index("  cleanup-runpod:")
+        ]
+        self.assertNotIn("RUNPOD_API_KEY", run_gpu)
+        self.assertIn("RUNPOD_API_KEY", text[text.index("  runpod-contract:") :])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -97,6 +97,15 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("needs.start-runpod.outputs.gpu_type_id", text)
         self.assertIn("needs.start-runpod.outputs.gpu_tier", text)
         self.assertIn("nvidia-smi --query-gpu=index,name", text)
+        check_machine = text[
+            text.index("      - name: Check machine") : text.index(
+                "      - name: Cache cuTENSOR redistributable"
+            )
+        ]
+        run_script = check_machine[check_machine.index("        run: |") :]
+        self.assertNotIn("${{ needs.start-runpod.outputs", run_script)
+        self.assertIn("${RUNPOD_GPU_TYPE_ID}", run_script)
+        self.assertIn("${RUNPOD_GPU_TIER}", run_script)
 
     def test_runpod_cache_key_uses_content_not_ref_identity(self) -> None:
         text = read(".github/workflows/runpod-gpu-test.yml")

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -1,0 +1,57 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text()
+
+
+class WorkflowContractTests(unittest.TestCase):
+    def test_fast_ci_uses_shared_policy_and_profiles(self) -> None:
+        text = read(".github/workflows/ci.yml")
+        self.assertIn("python3 scripts/ci/change_policy.py", text)
+        self.assertIn("python3 scripts/ci/run_profile.py blas-inject", text)
+        self.assertIn("python3 scripts/ci/run_profile.py coverage", text)
+        self.assertIn("python3 scripts/ci/run_profile.py docs", text)
+        self.assertIn("name: CI configuration checks", text)
+
+    def test_required_names_remain_stable(self) -> None:
+        fast = read(".github/workflows/ci.yml")
+        heavy = read(".github/workflows/ci-pr-workspace-tests.yml")
+        for name in (
+            "rustfmt",
+            "clippy",
+            "coverage",
+            "docs-site",
+            "cargo test (blas inject)",
+        ):
+            with self.subTest(name=name):
+                self.assertIn(f"name: {name}", fast)
+        self.assertIn("name: CI gate (PR workspace tests)", heavy)
+
+    def test_fast_required_jobs_fail_if_policy_fails(self) -> None:
+        text = read(".github/workflows/ci.yml")
+        self.assertGreaterEqual(text.count("needs.policy.result"), 6)
+        self.assertIn("Change classification failed", text)
+
+    def test_heavy_workflow_has_explicit_noop_matrix_and_gate_contract(self) -> None:
+        text = read(".github/workflows/ci-pr-workspace-tests.yml")
+        self.assertIn('"backend":"not-required"', text)
+        self.assertIn("RUN_WORKSPACE", text)
+        self.assertIn("RUN_EXTENSIONS", text)
+        self.assertIn("Workspace tests not required", text)
+        self.assertIn("python3 scripts/ci/run_profile.py", text)
+        self.assertNotIn("grep -qE", text)
+
+    def test_ci_config_installs_a_pinned_actionlint(self) -> None:
+        text = read(".github/workflows/ci.yml")
+        self.assertIn(
+            "github.com/rhysd/actionlint/cmd/actionlint@v1.7.7", text
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-doc-consistency.py
+++ b/scripts/test-doc-consistency.py
@@ -69,13 +69,15 @@ def test_agents_layer_diagram_lists_cpu_crate() -> None:
 
 def test_docs_ci_runs_docs_script_tests() -> None:
     text = read(".github/workflows/ci.yml")
+    profiles = read("scripts/ci/run_profile.py")
     build_docs_site = read("scripts/build_docs_site.sh")
 
-    assert "python3 scripts/test-check-docs-site.py" in text
-    assert "python3 scripts/test-doc-consistency.py" in text
-    assert "python3 scripts/test-repository-rules-review.py" in text
-    assert "python3 scripts/check-guide-dependency-snippets.py" in text
-    assert "python3 scripts/check-operation-categories.py --fail-on-findings" in text
+    assert "python3 scripts/ci/run_profile.py docs" in text
+    assert "python3 scripts/test-check-docs-site.py" in profiles
+    assert "python3 scripts/test-doc-consistency.py" in profiles
+    assert "python3 scripts/test-repository-rules-review.py" in profiles
+    assert "python3 scripts/check-guide-dependency-snippets.py" in profiles
+    assert "python3 scripts/check-operation-categories.py --fail-on-findings" in profiles
     assert (
         "python3 \"$ROOT_DIR/scripts/check-operation-categories.py\" --fail-on-findings --include-rendered"
         in build_docs_site


### PR DESCRIPTION
## Summary

- centralize local and hosted CI command profiles and conservatively classify PR changes as code, docs-only, or CI-only while preserving stable required check names
- validate RunPod GPU configuration against the live OpenAPI contract, classify retryable failures, and use content-addressed CUDA archive caching
- add trusted `main`-only PR-number recovery with same-repository authorization and head-stability checks
- publish contributor guidance, durable design intent, and the reviewer-facing work log

## Why

Issue #1379 consolidates the CI latency and recovery problems observed during the NUMA implementation and its documentation follow-up. Duplicated command lists, unconditional expensive lanes, branch-bound cache keys, and raw-ref recovery made ordinary and docs-only PRs slower and failure recovery riskier than necessary.

## Validation

- `cargo fmt --all --check`
- CI-parity workspace and tropical clippy with `-D warnings`
- `cargo test --workspace --release`
- faer and BLAS shared profiles: 2,150 nextest tests each plus doctests
- provider-injection, tropical, sparse, and KdV sample profiles
- coverage: 159/159 included files passed thresholds
- rustdoc and full 78-page docs-site render; 13 workspace library crates verified
- 44 CI helper tests and actionlint 1.7.7
- live RunPod schema fixture accepted all 11 configured GPU IDs
- committed-head repository-rules review: pass, no findings

## Review context

- [Work log](docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md)
- [Durable design](docs/design/change-aware-ci.md)

Part of #1379. The issue remains open until the new trusted workflow lands on `main` and a post-merge SECURE RunPod run succeeds.
