### PR TITLE
ci: launch RunPod helper as Python module

### DIFF
--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -789,7 +789,7 @@ jobs:
           ./run.sh --jitconfig "${RUNNER_JIT_CONFIG}"
           EOS
 
-          python3 scripts/ci/runpod_client.py create \
+          python3 -m scripts.ci.runpod_client create \
             --config scripts/ci/runpod_config.json \
             --startup-script /tmp/runpod-startup.sh \
             --image-name "${RUNPOD_IMAGE}" \

--- a/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
+++ b/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
@@ -98,6 +98,12 @@ control plane against schema drift and deterministic request failures.
   marker was emitted, and pod `37vcua0n4ayryn` was deleted successfully. This
   confirms the existing trusted execution path while the new tier behavior
   still awaits a post-merge run from `main`.
+- Pre-merge trusted run 29363682664 recovered on attempt 3 with an NVIDIA
+  GeForce RTX 4090; CUDA and OpenXLA passed and pod `dj8rm3kgcq21xw` was
+  deleted. Post-merge run 29373020352 then exposed that direct file execution
+  of `runpod_client.py` cannot resolve its `scripts.ci` package import. The
+  workflow now invokes the helper as a Python module and a source-contract test
+  prohibits the broken direct invocation.
 - Trusted PR recovery dry run targets only
   `runpod-gpu-test.yml --ref main -f pr_number=1379`.
 

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -85,7 +85,8 @@ class WorkflowContractTests(unittest.TestCase):
                 "      - name: Wait for org runner to come online"
             )
         ]
-        self.assertIn("python3 scripts/ci/runpod_client.py create", create)
+        self.assertIn("python3 -m scripts.ci.runpod_client create", create)
+        self.assertNotIn("python3 scripts/ci/runpod_client.py", create)
         self.assertNotIn("for attempt in $(seq 1 5)", create)
         self.assertNotIn("curl -sS", create)
 


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs #1379

## Summary

Post-merge trusted run 29373020352 showed that invoking `runpod_client.py` by file path sets Python's import root to `scripts/ci`, so its `scripts.ci.runpod_contract` import fails before any RunPod request. The workflow now launches the existing helper as a module from the checked-out repository root.

This is an existing-behavior bug fix: it adds no API, dependency, backend, or policy. A neighborhood scan found no other production helper with the same package-import/direct-execution mismatch.

## Work log

Updated `docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md` with the live failure and repair.

## Verification

- `python3 -m scripts.ci.runpod_client --help`
- `PATH="/tmp/actionlint-1.7.7:/tmp/shellcheck-v0.10.0:$PATH" python3 scripts/ci/run_profile.py ci-config` (59 tests + actionlint)
- `cargo fmt --all --check`
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- committed-head repository-rules review: pass, no findings
- independent code review: no findings, merge-ready

Full Rust release tests and coverage were not rerun because this follow-up changes only one workflow command, its source-contract test, and the work log; they passed on the immediately preceding PR #1380 head.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
