### PR TITLE
fix(ci): align RunPod runtime with CUDA 12.8

### DIFF
--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -69,10 +69,9 @@ env:
   CARGO_TERM_COLOR: always
   CUBECL_DEBUG_LOG: "0"
   CUDA_ARCHIVE: cuda-tests.tar.zst
-  # cudarc 0.19.x needs 12080 bindings; install CUDA_RUNTIME_VERSION toolkit when
-  # archiving so embedded PTX matches RunPod driver cap (nvidia-smi CUDA 12.4).
+  # Match the CUDA 12.8 cudarc bindings and CubeCL compiler API floor.
   CUDARC_CUDA_VERSION: "12080"
-  CUDA_RUNTIME_VERSION: "12.4"
+  CUDA_RUNTIME_VERSION: "12.8"
   ARCHIVE_WORKSPACE_ROOT: /home/runner/work/${{ github.event.repository.name }}/${{ github.event.repository.name }}
   CUTENSOR_VERSION: "2.6.0.4"
   JAX_CUDA12_PJRT_VERSION: "0.10.2"
@@ -1155,6 +1154,31 @@ jobs:
           echo "${cuda_path}/bin" >> "${GITHUB_PATH}"
           echo "LD_LIBRARY_PATH=${cuda_library_path}:$(dirname "${cutensor_path}"):${LD_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
           echo "TENFERRO_CUTENSOR_PATH=${cutensor_path}" >> "${GITHUB_ENV}"
+
+      - name: Verify loaded NVRTC version
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import ctypes
+          import os
+
+          nvrtc = ctypes.CDLL("libnvrtc.so")
+          major = ctypes.c_int()
+          minor = ctypes.c_int()
+          status = nvrtc.nvrtcVersion(ctypes.byref(major), ctypes.byref(minor))
+          if status != 0:
+              raise SystemExit(f"nvrtcVersion failed with status {status}")
+          loaded = (major.value, minor.value)
+          required = tuple(
+              int(part) for part in os.environ["CUDA_RUNTIME_VERSION"].split(".")
+          )
+          print(f"Loaded NVRTC version: {loaded[0]}.{loaded[1]}")
+          if loaded < required:
+              raise SystemExit(
+                  f"NVRTC {loaded[0]}.{loaded[1]} is older than required "
+                  f"CUDA {required[0]}.{required[1]}"
+              )
+          PY
 
       - name: Link archive build workspace path
         run: |

--- a/docs/design/change-aware-ci.md
+++ b/docs/design/change-aware-ci.md
@@ -79,6 +79,12 @@ and commit identity, allowing equivalent automatic and recovery runs to reuse
 the hosted cache while still uploading a per-run artifact for the external
 runner.
 
+The archive toolkit and external-runner CUDA runtime must match the workspace
+`cudarc` CUDA binding floor. The current floor is CUDA 12.8, which is required
+for NVRTC compilation of Blackwell `sm_120`/`sm_120a` kernels. Before running
+GPU tests, the external runner queries the dynamically loaded NVRTC library,
+logs its version, and rejects a version older than the configured floor.
+
 ## Recovery
 
 Maintainers recover a PR by number with:

--- a/docs/superpowers/specs/2026-07-15-runpod-cuda-12-8-design.md
+++ b/docs/superpowers/specs/2026-07-15-runpod-cuda-12-8-design.md
@@ -37,4 +37,3 @@ repository-required local checks. The final acceptance test is a trusted
 post-merge RunPod run that records CUDA/NVRTC 12.8 or newer, completes the CUDA
 archive tests and OpenXLA PJRT tests, emits `RUNPOD_TENFERRO_GPU_TEST_OK`, and
 deletes the selected pod.
-

--- a/docs/superpowers/specs/2026-07-15-runpod-cuda-12-8-design.md
+++ b/docs/superpowers/specs/2026-07-15-runpod-cuda-12-8-design.md
@@ -1,0 +1,40 @@
+# RunPod CUDA 12.8 alignment
+
+## Problem
+
+The trusted post-merge RunPod run selected an NVIDIA GeForce RTX 5090 and
+failed 62 CUDA tests because CubeCL passed `sm_120a` to a CUDA 12.4 NVRTC,
+which rejected the Blackwell architecture. The workspace already pins cudarc
+to the CUDA 12.8 binding set and documents CUDA 12.8 as the current CubeCL API
+floor, so the CI runtime is below the repository contract.
+
+## Design
+
+- Set the shared RunPod workflow CUDA toolkit/runtime version to 12.8 for both
+  the GitHub-hosted test archive build and the external RunPod test runner.
+- Keep the existing CubeCL, cudarc, cuTENSOR, and OpenXLA dependency versions.
+  cuTENSOR remains on its CUDA 12 redistributable, while OpenXLA continues to
+  use its separately pinned CUDA 12.9 `ptxas` package.
+- Preserve the existing GPU price tiers, including the RTX 5090. CUDA 12.8 is
+  the first toolkit release with compiler support for `sm_120`/`sm_120a`.
+- Log the loaded NVRTC version before tests so future runtime/toolkit drift is
+  visible in the trusted run.
+- Add source-contract coverage that requires the workflow runtime version to
+  match the workspace cudarc CUDA binding floor.
+
+The existing content-addressed keys include the CUDA runtime version and the
+workflow content, so this change intentionally creates fresh archive and
+runtime caches without a cache schema migration.
+
+## Failure handling and verification
+
+The workflow continues to fail before CUDA tests if exact CUDA 12.8 packages
+cannot be installed. The trusted cleanup job remains unconditional and must
+delete the pod after either success or failure.
+
+Verification proceeds from the narrow CI contract tests and actionlint to the
+repository-required local checks. The final acceptance test is a trusted
+post-merge RunPod run that records CUDA/NVRTC 12.8 or newer, completes the CUDA
+archive tests and OpenXLA PJRT tests, emits `RUNPOD_TENFERRO_GPU_TEST_OK`, and
+deletes the selected pod.
+

--- a/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
+++ b/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
@@ -114,6 +114,10 @@ control plane against schema drift and deterministic request failures.
   12.8 bindings and documents CUDA 12.8 as the current CubeCL API floor, so the
   workflow now aligns both the archive toolkit and RunPod runtime with CUDA
   12.8 and verifies the dynamically loaded NVRTC version before tests.
+- The CUDA 12.8 repair passed all 60 CI helper/source-contract tests,
+  actionlint 1.7.7, workspace rustdoc, rendered-site validation, formatting,
+  diff checks, and the committed-head repository-rules review. Independent
+  review found no remaining Critical, Important, or Minor findings.
 - Trusted PR recovery dry run targets only
   `runpod-gpu-test.yml --ref main -f pr_number=1379`.
 

--- a/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
+++ b/docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md
@@ -104,6 +104,16 @@ control plane against schema drift and deterministic request failures.
   of `runpod_client.py` cannot resolve its `scripts.ci` package import. The
   workflow now invokes the helper as a Python module and a source-contract test
   prohibits the broken direct invocation.
+- Post-fix trusted run 29375027798 exercised the new price-tier fallback. The
+  cost-preferred tier reported no capacity, the premium tier selected an NVIDIA
+  GeForce RTX 5090, and the runner started successfully. The CUDA archive then
+  ran 833 tests: 771 passed and 62 failed because the CUDA 12.4 NVRTC rejected
+  CubeCL's Blackwell `sm_120a` architecture with `invalid value for
+  --gpu-architecture`. Cleanup still succeeded and deleted pod
+  `i92a7kiz76t521` with HTTP 204. The workspace already pins cudarc to its CUDA
+  12.8 bindings and documents CUDA 12.8 as the current CubeCL API floor, so the
+  workflow now aligns both the archive toolkit and RunPod runtime with CUDA
+  12.8 and verifies the dynamically loaded NVRTC version before tests.
 - Trusted PR recovery dry run targets only
   `runpod-gpu-test.yml --ref main -f pr_number=1379`.
 
@@ -117,6 +127,9 @@ branch workflow is intentionally prohibited.
 - RunPod may change its live schema or capacity between preflight and pod
   creation; schema mismatch fails early, while transient capacity remains a
   bounded retry.
+- RTX 5090 functional coverage remains contingent on a successful trusted CUDA
+  12.8 rerun. This CI control-plane repair does not by itself establish that
+  CubeCL's Blackwell-specific performance paths are fully optimized.
 - actionlint validates workflow structure and shell contracts but cannot model
   GitHub/RunPod external state.
 - The first cache population still pays full CUDA archive cost; content reuse

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -133,7 +133,8 @@ class WorkflowContractTests(unittest.TestCase):
 
     def test_runpod_cuda_runtime_matches_cudarc_floor(self) -> None:
         text = read(".github/workflows/runpod-gpu-test.yml")
-        cudarc = re.search(
+        cargo = read("Cargo.toml")
+        workflow_cudarc = re.search(
             r'^  CUDARC_CUDA_VERSION: "(\d+)"$', text, re.MULTILINE
         )
         runtime = re.search(
@@ -141,16 +142,26 @@ class WorkflowContractTests(unittest.TestCase):
             text,
             re.MULTILINE,
         )
-        self.assertIsNotNone(cudarc)
+        cargo_cudarc = re.search(
+            r'^cudarc = \{[^\n]*features = \[[^\n]*"cuda-(\d+)"',
+            cargo,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(workflow_cudarc)
         self.assertIsNotNone(runtime)
-        assert cudarc is not None
+        self.assertIsNotNone(cargo_cudarc)
+        assert workflow_cudarc is not None
         assert runtime is not None
+        assert cargo_cudarc is not None
         encoded_runtime = (
             int(runtime.group(1)) * 1000 + int(runtime.group(2)) * 10
         )
-        self.assertEqual(int(cudarc.group(1)), encoded_runtime)
+        self.assertEqual(int(workflow_cudarc.group(1)), encoded_runtime)
+        self.assertEqual(workflow_cudarc.group(1), cargo_cudarc.group(1))
         self.assertIn("nvrtc.nvrtcVersion", text)
         self.assertIn("Loaded NVRTC version:", text)
+        self.assertIn("if loaded < required:", text)
+        self.assertIn("is older than required", text)
 
     def test_manual_pr_recovery_is_authorized_and_head_stable(self) -> None:
         text = read(".github/workflows/runpod-gpu-test.yml")

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from pathlib import Path
 
@@ -129,6 +130,27 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertNotIn("TENFERRO_REF", key_line)
         self.assertIn("hashFiles(", key_line)
         self.assertIn("runpod_config.json", key_line)
+
+    def test_runpod_cuda_runtime_matches_cudarc_floor(self) -> None:
+        text = read(".github/workflows/runpod-gpu-test.yml")
+        cudarc = re.search(
+            r'^  CUDARC_CUDA_VERSION: "(\d+)"$', text, re.MULTILINE
+        )
+        runtime = re.search(
+            r'^  CUDA_RUNTIME_VERSION: "(\d+)\.(\d+)"$',
+            text,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(cudarc)
+        self.assertIsNotNone(runtime)
+        assert cudarc is not None
+        assert runtime is not None
+        encoded_runtime = (
+            int(runtime.group(1)) * 1000 + int(runtime.group(2)) * 10
+        )
+        self.assertEqual(int(cudarc.group(1)), encoded_runtime)
+        self.assertIn("nvrtc.nvrtcVersion", text)
+        self.assertIn("Loaded NVRTC version:", text)
 
     def test_manual_pr_recovery_is_authorized_and_head_stable(self) -> None:
         text = read(".github/workflows/runpod-gpu-test.yml")


### PR DESCRIPTION
> [!IMPORTANT]
> This is a trusted-workflow bootstrap change. The modified RunPod workflow can only be validated with repository secrets after it reaches trusted main.

## Type

- [x] Bug fix
- [x] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs #1379

## Summary

- Align the RunPod archive image and runtime NVRTC with the workspace cudarc CUDA 12.8 floor.
- Query and log the loaded NVRTC version before GPU tests, rejecting runtimes below the configured floor.
- Bind the workflow CUDA encoding, runtime version, and workspace cudarc feature in a contract test.
- Keep the existing price tiers (including RTX 5090), trust boundary, retry policy, and unconditional pod cleanup unchanged.

Trusted run 29375027798 reproduced the failure on an RTX 5090: 771 CUDA tests passed and 62 failed because CUDA 12.4 NVRTC rejected CubeCL sm_120a. Final GPU acceptance will run from trusted main after merge.

## Work log

[Issue #1379 change-aware CI work log](docs/worklogs/2026-07-14-issue-1379-change-aware-ci.md)

## Verification

- cargo test --workspace --release
- cargo fmt --all --check
- cargo doc --workspace --no-deps
- python3 scripts/check-docs-site.py
- python3 -m unittest discover -s scripts/ci/tests -v (60 passed)
- actionlint v1.7.7
- python3 scripts/repository-rules-review.py --base origin/main --head HEAD (pass, no findings)
- git diff --check origin/main...HEAD
- Independent review: merge-ready, no remaining findings

## Checklist

- [x] I read CONTRIBUTING.md.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from ai/contribution-workflows/bugfix-pr.md.
- [x] If this PR needs a work log, I added one under docs/worklogs/ and linked it above.