### PR TITLE
Reuse managed CPU execution coordination

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -699,7 +699,9 @@ Tests follow implementation ownership.
 - For faer-backed CPU ops, `CpuContext` is the single source of truth for thread-pool policy.
 - Do not derive faer parallelism independently inside individual ops or helper functions.
 - Execute faer-backed work only inside `ctx.install(...)` so the owned rayon context is preserved.
-- Use `Par::Seq` for one-thread contexts and `Par::rayon(0)` for multi-thread contexts so faer follows the current `CpuContext`.
+- Use `Par::Seq` for one-thread contexts and explicit `Par::rayon(n)` from the
+  configured `CpuContext` degree for multi-thread contexts. Do not derive the
+  policy from an ambient Rayon pool during plan or session setup.
 - Tensor-sized strided CPU kernels that are not provider-owned must also run
   inside `CpuContext::install(...)`, so Rayon-backed `strided-kernel` work uses
   the backend's owned pool. BLAS/LAPACK provider-owned threading remains

--- a/crates/tenferro-cpu/benches/cpu_install_overhead.rs
+++ b/crates/tenferro-cpu/benches/cpu_install_overhead.rs
@@ -1,19 +1,30 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use tenferro_cpu::{linalg_interop::BufferPool, CpuBackend, CpuContext};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use tenferro_cpu::{linalg_interop::BufferPool, CpuBackend, CpuBackendKind, CpuContext};
 use tenferro_tensor::BackendRuntimeCache;
 
 fn bench_cpu_context_entry_overhead(c: &mut Criterion) {
-    let mut group = c.benchmark_group("cpu_context_entry_overhead/one_thread");
+    let mut group = c.benchmark_group("cpu_context_entry_overhead");
 
-    group.bench_function("ctx_install_inline_empty", |b| {
-        let ctx = CpuContext::with_threads(1).unwrap();
-        b.iter(|| ctx.install(|| black_box(1usize)));
-    });
+    for threads in [1, 2, 4] {
+        group.bench_with_input(
+            BenchmarkId::new("ctx_install_empty", threads),
+            &threads,
+            |b, &threads| {
+                let ctx = CpuContext::with_threads(threads).unwrap();
+                b.iter(|| ctx.install(|| black_box(1usize)));
+            },
+        );
 
-    group.bench_function("backend_install_inline_empty", |b| {
-        let backend = CpuBackend::with_threads(1).unwrap();
-        b.iter(|| backend.install(|| black_box(1usize)));
-    });
+        group.bench_with_input(
+            BenchmarkId::new("backend_install_empty", threads),
+            &threads,
+            |b, &threads| {
+                let backend =
+                    CpuBackend::with_threads_and_kind(threads, CpuBackendKind::Faer).unwrap();
+                b.iter(|| backend.install(|| black_box(1usize)));
+            },
+        );
+    }
 
     group.bench_function("buffer_pool_take_restore_only", |b| {
         let mut buffers = BufferPool::new();

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -1,5 +1,5 @@
-use std::cell::Cell;
-use std::collections::{BTreeMap, VecDeque};
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
@@ -21,14 +21,19 @@ impl ResourceOwner {
 thread_local! {
     static THREAD_OWNER: ResourceOwner = ResourceOwner::fresh();
     static EXECUTION_OWNER: Cell<Option<ResourceOwner>> = const { Cell::new(None) };
-    static POOL_EXECUTION_OWNER: Cell<Option<ResourceOwner>> = const { Cell::new(None) };
+    static WORKER_EXECUTION_SCOPE: RefCell<Option<Arc<ExecutionScopeState>>> = const { RefCell::new(None) };
 }
 
 pub(crate) const BACKEND_REENTRY_PANIC: &str =
     "CpuBackend cannot be re-entered while another CPU backend execution is active on this thread or managed Rayon scope";
 
 pub(crate) fn inherited_or_new_execution_owner() -> ResourceOwner {
-    if POOL_EXECUTION_OWNER.with(Cell::get).is_some() {
+    if WORKER_EXECUTION_SCOPE.with(|scope| {
+        scope
+            .borrow()
+            .as_ref()
+            .is_some_and(|scope| scope.has_active_owner())
+    }) {
         panic!("{BACKEND_REENTRY_PANIC}");
     }
     if EXECUTION_OWNER.with(Cell::get).is_some() {
@@ -51,22 +56,78 @@ pub(crate) fn with_execution_owner<R>(owner: ResourceOwner, op: impl FnOnce() ->
     op()
 }
 
-pub(crate) fn set_pool_execution_owner(owner: Option<ResourceOwner>) {
-    POOL_EXECUTION_OWNER.set(owner);
+pub(crate) fn register_worker_execution_scope(scope: Arc<ExecutionScopeState>) {
+    WORKER_EXECUTION_SCOPE.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        // INVARIANT: each owned Rayon worker is a dedicated thread whose start
+        // hook runs once; replacing a live scope would mix context ownership.
+        debug_assert!(slot.is_none());
+        *slot = Some(scope);
+    });
 }
 
-pub(crate) fn with_pool_execution_owner<R>(owner: ResourceOwner, op: impl FnOnce() -> R) -> R {
-    struct RestoreOwner(Option<ResourceOwner>);
+#[cfg(test)]
+pub(crate) fn worker_execution_scope_registered() -> bool {
+    WORKER_EXECUTION_SCOPE.with(|scope| scope.borrow().is_some())
+}
 
-    impl Drop for RestoreOwner {
-        fn drop(&mut self) {
-            POOL_EXECUTION_OWNER.set(self.0);
+#[derive(Debug, Default)]
+pub(crate) struct ExecutionScopeState {
+    active: Mutex<ExecutionOwnerState>,
+}
+
+#[derive(Debug, Default)]
+struct ExecutionOwnerState {
+    owner: Option<ResourceOwner>,
+    depth: usize,
+}
+
+impl ExecutionScopeState {
+    pub(crate) fn enter(&self, owner: ResourceOwner) -> ExecutionScopeGuard<'_> {
+        let mut active = self
+            .active
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match active.owner {
+            None => {
+                active.owner = Some(owner);
+                active.depth = 1;
+            }
+            Some(current) if current == owner => active.depth += 1,
+            Some(current) => panic!(
+                "CPU execution owner invariant violated: active {current:?}, requested {owner:?}"
+            ),
         }
+        ExecutionScopeGuard { scope: self, owner }
     }
 
-    let previous = POOL_EXECUTION_OWNER.replace(Some(owner));
-    let _restore = RestoreOwner(previous);
-    op()
+    fn has_active_owner(&self) -> bool {
+        self.active
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .owner
+            .is_some()
+    }
+}
+
+pub(crate) struct ExecutionScopeGuard<'a> {
+    scope: &'a ExecutionScopeState,
+    owner: ResourceOwner,
+}
+
+impl Drop for ExecutionScopeGuard<'_> {
+    fn drop(&mut self) {
+        let mut active = self
+            .scope
+            .active
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        debug_assert_eq!(active.owner, Some(self.owner));
+        active.depth -= 1;
+        if active.depth == 0 {
+            active.owner = None;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -108,6 +169,7 @@ struct Waiter {
 
 #[derive(Debug)]
 struct ActiveRequest {
+    id: u64,
     request: ResourceRequest,
     owner: ResourceOwner,
 }
@@ -116,7 +178,9 @@ struct ActiveRequest {
 struct ArbiterState {
     next_request_id: u64,
     waiters: VecDeque<Waiter>,
-    active: BTreeMap<u64, ActiveRequest>,
+    // INVARIANT: active admission only needs conflict scans and id removal. A
+    // retained Vec avoids the per-permit node allocation of a tree map.
+    active: Vec<ActiveRequest>,
 }
 
 #[derive(Debug, Default)]
@@ -231,10 +295,10 @@ impl ResourceArbiter {
                 return Err(ResourceArbiterError::StatePoisoned);
             };
             let request = &state.waiters[position].request;
-            let reentrant = state.active.values().any(|active| active.owner == owner);
+            let reentrant = state.active.iter().any(|active| active.owner == owner);
             let active_compatible = state
                 .active
-                .values()
+                .iter()
                 .all(|active| active.owner == owner || !active.request.conflicts_with(request));
             let older_compatible = reentrant
                 || state
@@ -246,13 +310,11 @@ impl ResourceArbiter {
                 let Some(waiter) = state.waiters.remove(position) else {
                     return Err(ResourceArbiterError::StatePoisoned);
                 };
-                state.active.insert(
+                state.active.push(ActiveRequest {
                     id,
-                    ActiveRequest {
-                        request: waiter.request,
-                        owner: waiter.owner,
-                    },
-                );
+                    request: waiter.request,
+                    owner: waiter.owner,
+                });
                 return Ok(ResourcePermit {
                     inner: Arc::clone(&self.inner),
                     id,
@@ -283,10 +345,10 @@ impl ResourceArbiter {
             .lock()
             .map_err(|_| ResourceArbiterError::StatePoisoned)?;
         let owner = request_owner();
-        let reentrant = state.active.values().any(|active| active.owner == owner);
+        let reentrant = state.active.iter().any(|active| active.owner == owner);
         let conflicts_with_active = state
             .active
-            .values()
+            .iter()
             .any(|active| active.owner != owner && active.request.conflicts_with(&request));
         let bypasses_waiter = !reentrant
             && state
@@ -301,7 +363,7 @@ impl ResourceArbiter {
             .next_request_id
             .checked_add(1)
             .ok_or(ResourceArbiterError::RequestIdExhausted)?;
-        state.active.insert(id, ActiveRequest { request, owner });
+        state.active.push(ActiveRequest { id, request, owner });
         Ok(Some(ResourcePermit {
             inner: Arc::clone(&self.inner),
             id,
@@ -371,7 +433,9 @@ impl Drop for ResourcePermit {
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        state.active.remove(&self.id);
+        if let Some(position) = state.active.iter().position(|active| active.id == self.id) {
+            state.active.swap_remove(position);
+        }
         self.inner.changed.notify_all();
     }
 }

--- a/crates/tenferro-cpu/src/arbiter/tests.rs
+++ b/crates/tenferro-cpu/src/arbiter/tests.rs
@@ -64,6 +64,21 @@ fn panic_releases_provider_exclusive_reservation() {
 }
 
 #[test]
+fn released_active_request_retains_reusable_storage() {
+    let arbiter = ResourceArbiter::new();
+    drop(arbiter.acquire(cpu_set([0, 1])).unwrap());
+    let warm_capacity = arbiter.inner.state.lock().unwrap().active.capacity();
+
+    for _ in 0..64 {
+        drop(arbiter.acquire(cpu_set([0, 1])).unwrap());
+    }
+
+    let state = arbiter.inner.state.lock().unwrap();
+    assert!(state.active.is_empty());
+    assert_eq!(state.active.capacity(), warm_capacity);
+}
+
+#[test]
 fn older_all_allowed_waiter_blocks_younger_disjoint_admission() {
     let arbiter = Arc::new(ResourceArbiter::new());
     let active = arbiter.acquire(cpu_set([0, 1])).unwrap();

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -204,8 +204,8 @@ fn direct_nested_independent_engine_is_rejected_in_a_managed_scope() {
 #[test]
 #[cfg(all(feature = "cpu-faer", any(target_os = "linux", target_os = "android")))]
 fn cross_pool_wait_cannot_misclassify_a_scheduled_sibling_as_direct_nesting() {
-    let outer = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
-    let middle = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let outer = CpuBackend::from_context(Arc::new(CpuContext::with_threads(2).unwrap()));
+    let middle = CpuBackend::from_context(Arc::new(CpuContext::with_threads(2).unwrap()));
     let sibling = outer.clone();
 
     let (_, sibling_outcome) = outer.install(move || {
@@ -325,7 +325,7 @@ fn shared_context_work_is_not_mistaken_for_backend_reentry() {
 
 #[test]
 #[cfg(all(feature = "cpu-faer", any(target_os = "linux", target_os = "android")))]
-fn execution_owner_broadcast_is_cleared_after_panic() {
+fn shared_execution_scope_is_cleared_after_panic() {
     let backend = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
 
     let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -202,7 +202,7 @@ fn direct_nested_independent_engine_is_rejected_in_a_managed_scope() {
 }
 
 #[test]
-#[cfg(all(feature = "cpu-faer", any(target_os = "linux", target_os = "android")))]
+#[cfg(feature = "cpu-faer")]
 fn cross_pool_wait_cannot_misclassify_a_scheduled_sibling_as_direct_nesting() {
     let outer = CpuBackend::from_context(Arc::new(CpuContext::with_threads(2).unwrap()));
     let middle = CpuBackend::from_context(Arc::new(CpuContext::with_threads(2).unwrap()));

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -1,19 +1,13 @@
 use std::env;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use thiserror::Error as ThisError;
 
 use crate::affinity::{SystemThreadAffinity, ThreadAffinity};
 use crate::arbiter::{
-    set_pool_execution_owner, with_execution_owner, with_pool_execution_owner, ResourceOwner,
+    register_worker_execution_scope, with_execution_owner, ExecutionScopeState, ResourceOwner,
 };
 use crate::{CpuId, CpuSet, Error, Result};
-
-#[derive(Debug, Default)]
-struct ExecutionOwnerState {
-    owner: Option<ResourceOwner>,
-    depth: usize,
-}
 
 /// Failure to construct a CPU context with pinned Rayon workers.
 ///
@@ -79,7 +73,7 @@ pub struct CpuContext {
     num_threads: usize,
     pool: Option<Arc<rayon::ThreadPool>>,
     pinned_cpus: Option<CpuSet>,
-    execution_owner: Arc<Mutex<ExecutionOwnerState>>,
+    execution_scope: Arc<ExecutionScopeState>,
 }
 
 impl CpuContext {
@@ -160,24 +154,36 @@ impl CpuContext {
                 message: "thread count must be at least 1".into(),
             });
         }
+        let execution_scope = Arc::new(ExecutionScopeState::default());
         let pool = if num_threads == 1 {
             None
         } else {
-            Some(Arc::new(
-                rayon::ThreadPoolBuilder::new()
-                    .num_threads(num_threads)
-                    .build()
-                    .map_err(|err| Error::InvalidConfig {
-                        op: "CpuContext::with_threads",
-                        message: format!("failed to build CPU thread pool: {err}"),
-                    })?,
-            ))
+            let (startup_tx, startup_rx) = std::sync::mpsc::channel();
+            let worker_scope = Arc::clone(&execution_scope);
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(num_threads)
+                .start_handler(move |_| {
+                    register_worker_execution_scope(Arc::clone(&worker_scope));
+                    let _ = startup_tx.send(());
+                })
+                .build()
+                .map_err(|err| Error::InvalidConfig {
+                    op: "CpuContext::with_threads",
+                    message: format!("failed to build CPU thread pool: {err}"),
+                })?;
+            for _ in 0..num_threads {
+                startup_rx.recv().map_err(|_| Error::InvalidConfig {
+                    op: "CpuContext::with_threads",
+                    message: "CPU worker exited before execution-scope registration".into(),
+                })?;
+            }
+            Some(Arc::new(pool))
         };
         Ok(Self {
             num_threads,
             pool,
             pinned_cpus: None,
-            execution_owner: Arc::new(Mutex::new(ExecutionOwnerState::default())),
+            execution_scope,
         })
     }
 
@@ -220,9 +226,11 @@ impl CpuContext {
             });
         }
 
+        let execution_scope = Arc::new(ExecutionScopeState::default());
         let assigned_cpus = Arc::new(select_worker_cpus(&cpus, num_threads));
         let (startup_tx, startup_rx) = std::sync::mpsc::channel();
         let pool_assigned_cpus = Arc::clone(&assigned_cpus);
+        let worker_scope = Arc::clone(&execution_scope);
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(num_threads)
             .spawn_handler(move |thread| {
@@ -230,9 +238,11 @@ impl CpuContext {
                 let cpu = pool_assigned_cpus[worker];
                 let startup_tx = startup_tx.clone();
                 let affinity = affinity.clone();
+                let worker_scope = Arc::clone(&worker_scope);
                 std::thread::Builder::new()
                     .name(format!("tenferro-cpu-{cpu}"))
                     .spawn(move || {
+                        register_worker_execution_scope(Arc::clone(&worker_scope));
                         let result = affinity.pin_current(cpu).and_then(|observed| {
                             (observed.len() == 1 && observed.contains(cpu))
                                 .then_some(())
@@ -269,7 +279,7 @@ impl CpuContext {
             num_threads,
             pool: Some(pool),
             pinned_cpus: Some(cpus),
-            execution_owner: Arc::new(Mutex::new(ExecutionOwnerState::default())),
+            execution_scope,
         })
     }
 
@@ -278,7 +288,7 @@ impl CpuContext {
             num_threads: 1,
             pool: None,
             pinned_cpus: None,
-            execution_owner: Arc::new(Mutex::new(ExecutionOwnerState::default())),
+            execution_scope: Arc::new(ExecutionScopeState::default()),
         }
     }
 
@@ -336,69 +346,10 @@ impl CpuContext {
         owner: ResourceOwner,
         op: impl FnOnce() -> R + Send,
     ) -> R {
-        let should_broadcast = {
-            let mut state = self
-                .execution_owner
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            match state.owner {
-                None => {
-                    state.owner = Some(owner);
-                    state.depth = 1;
-                    true
-                }
-                Some(active) if active == owner => {
-                    state.depth += 1;
-                    false
-                }
-                Some(active) => panic!(
-                    "CPU execution owner invariant violated: active {active:?}, requested {owner:?}"
-                ),
-            }
-        };
-        if should_broadcast {
-            self.broadcast_execution_owner(Some(owner));
-        }
-
-        struct OwnerGuard<'a> {
-            context: &'a CpuContext,
-            owner: ResourceOwner,
-        }
-
-        impl Drop for OwnerGuard<'_> {
-            fn drop(&mut self) {
-                let should_clear = {
-                    let mut state = self
-                        .context
-                        .execution_owner
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    debug_assert_eq!(state.owner, Some(self.owner));
-                    state.depth -= 1;
-                    if state.depth == 0 {
-                        state.owner = None;
-                        true
-                    } else {
-                        false
-                    }
-                };
-                if should_clear {
-                    self.context.broadcast_execution_owner(None);
-                }
-            }
-        }
-
-        let _guard = OwnerGuard {
-            context: self,
-            owner,
-        };
-        self.install(|| with_pool_execution_owner(owner, || with_execution_owner(owner, op)))
-    }
-
-    fn broadcast_execution_owner(&self, owner: Option<ResourceOwner>) {
-        if let Some(pool) = &self.pool {
-            pool.broadcast(|_| set_pool_execution_owner(owner));
-        }
+        // Workers share this state from construction; broadcasting owner TLS
+        // here would only reintroduce per-entry scheduler work and allocation.
+        let _scope = self.execution_scope.enter(owner);
+        self.install(|| with_execution_owner(owner, op))
     }
 
     /// Return the faer parallelism policy for work run inside this context.

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -354,16 +354,17 @@ impl CpuContext {
 
     /// Return the faer parallelism policy for work run inside this context.
     ///
-    /// `Par::rayon(0)` is intentional for multi-threaded contexts: faer reads
-    /// `rayon::current_num_threads()`, so calls made under [`Self::install`]
-    /// inherit this context's Rayon pool size.
+    /// The explicit degree keeps policy construction independent of the
+    /// ambient Rayon pool, including plans prepared before [`Self::install`].
     #[cfg(feature = "cpu-faer")]
     #[doc(hidden)]
     pub fn faer_par(&self) -> faer::Par {
         if self.num_threads == 1 {
             faer::Par::Seq
         } else {
-            faer::Par::rayon(0)
+            // `rayon(0)` captures the ambient pool immediately, which may not
+            // be this context when a provider plan is prepared outside install.
+            faer::Par::rayon(self.num_threads)
         }
     }
 

--- a/crates/tenferro-cpu/src/context/tests.rs
+++ b/crates/tenferro-cpu/src/context/tests.rs
@@ -2,10 +2,10 @@ use super::{select_worker_cpus, CpuContext, CpuContextError};
 #[cfg(target_os = "linux")]
 use crate::affinity::current_cpu;
 use crate::affinity::ThreadAffinity;
+use crate::arbiter::worker_execution_scope_registered;
 #[cfg(target_os = "linux")]
 use crate::process_cpu_affinity;
 use crate::{CpuId, CpuSet};
-#[cfg(target_os = "linux")]
 use rayon::prelude::*;
 #[cfg(target_os = "linux")]
 use std::collections::BTreeSet;
@@ -13,6 +13,19 @@ use std::collections::BTreeSet;
 #[test]
 fn with_threads_rejects_zero() {
     assert!(CpuContext::with_threads(0).is_err());
+}
+
+#[test]
+fn context_constructor_registers_every_rayon_worker_execution_scope() {
+    for threads in [2, 4] {
+        let ctx = CpuContext::with_threads(threads).unwrap();
+        let registered = ctx
+            .pool
+            .as_ref()
+            .unwrap()
+            .broadcast(|_| worker_execution_scope_registered());
+        assert_eq!(registered, vec![true; threads]);
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/tenferro-cpu/src/context/tests.rs
+++ b/crates/tenferro-cpu/src/context/tests.rs
@@ -6,6 +6,7 @@ use crate::arbiter::worker_execution_scope_registered;
 #[cfg(target_os = "linux")]
 use crate::process_cpu_affinity;
 use crate::{CpuId, CpuSet};
+#[cfg(target_os = "linux")]
 use rayon::prelude::*;
 #[cfg(target_os = "linux")]
 use std::collections::BTreeSet;

--- a/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
@@ -194,9 +194,9 @@ fn performance_notes_match_current_cpu_threading_contract() {
     let notes = include_str!("../../../../../docs/performance/tt-inner-product-overhead.md");
     assert!(
         !notes.contains("The faer backend is therefore run without a tenferro-owned Rayon pool")
-            && !notes.contains("maps multi-threaded execution to `Par::rayon(n)`")
+            && notes.contains("maps multi-threaded execution to explicit `Par::rayon(n)`")
             && !notes.contains("The global-Rayon columns became the production policy"),
-        "performance notes must describe CpuContext::install plus Par::rayon(0), not the stale global-Rayon policy"
+        "performance notes must describe the explicit CpuContext thread budget, not ambient global-Rayon policy"
     );
 }
 

--- a/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
@@ -192,11 +192,18 @@ fn cpu_context_faer_policy_ignores_a_different_ambient_pool_size() {
 #[test]
 fn performance_notes_match_current_cpu_threading_contract() {
     let notes = include_str!("../../../../../docs/performance/tt-inner-product-overhead.md");
+    let repository_rules = include_str!("../../../../../REPOSITORY_RULES.md");
     assert!(
         !notes.contains("The faer backend is therefore run without a tenferro-owned Rayon pool")
             && notes.contains("maps multi-threaded execution to explicit `Par::rayon(n)`")
             && !notes.contains("The global-Rayon columns became the production policy"),
         "performance notes must describe the explicit CpuContext thread budget, not ambient global-Rayon policy"
+    );
+    assert!(
+        repository_rules.contains("explicit `Par::rayon(n)`")
+            && !repository_rules
+                .contains("Use `Par::Seq` for one-thread contexts and `Par::rayon(0)`"),
+        "repository rules must derive Faer parallelism from the configured CpuContext degree"
     );
 }
 

--- a/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
@@ -165,10 +165,28 @@ fn cpu_context_faer_policy_is_seq_for_one_thread() {
 
 #[cfg(feature = "cpu-faer")]
 #[test]
-fn cpu_context_faer_policy_uses_current_context_pool_for_multithreaded_context() {
+fn cpu_context_faer_policy_matches_configured_workers_outside_pool() {
+    let ctx = CpuContext::with_threads(2).unwrap();
+    assert_eq!(ctx.faer_par().degree(), 2);
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn cpu_context_faer_policy_matches_configured_workers_inside_context_pool() {
     let ctx = CpuContext::with_threads(2).unwrap();
     let par = ctx.install(|| ctx.faer_par());
     assert_eq!(par.degree(), 2);
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn cpu_context_faer_policy_ignores_a_different_ambient_pool_size() {
+    let ctx = CpuContext::with_threads(2).unwrap();
+    let ambient = rayon::ThreadPoolBuilder::new()
+        .num_threads(3)
+        .build()
+        .unwrap();
+    assert_eq!(ambient.install(|| ctx.faer_par().degree()), 2);
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/topology.rs
+++ b/crates/tenferro-cpu/src/topology.rs
@@ -1,6 +1,7 @@
 #[cfg(any(test, target_os = "linux"))]
 use std::collections::BTreeSet;
 use std::fmt;
+use std::sync::Arc;
 
 use thiserror::Error;
 
@@ -127,12 +128,14 @@ pub enum CpuSetError {
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CpuSet {
-    cpus: Vec<CpuId>,
+    cpus: Arc<[CpuId]>,
 }
 
 impl CpuSet {
     pub(crate) fn singleton(cpu: CpuId) -> Self {
-        Self { cpus: vec![cpu] }
+        Self {
+            cpus: Arc::from([cpu]),
+        }
     }
 
     /// Construct a sorted and deduplicated CPU set.
@@ -153,7 +156,7 @@ impl CpuSet {
         if cpus.is_empty() {
             return Err(CpuSetError::Empty);
         }
-        Ok(Self { cpus })
+        Ok(Self { cpus: cpus.into() })
     }
 
     /// Return the number of logical CPUs in this set.
@@ -258,7 +261,9 @@ impl CpuSet {
                 }
             }
         }
-        (!intersection.is_empty()).then_some(Self { cpus: intersection })
+        (!intersection.is_empty()).then_some(Self {
+            cpus: intersection.into(),
+        })
     }
 }
 

--- a/crates/tenferro-cpu/src/topology/tests.rs
+++ b/crates/tenferro-cpu/src/topology/tests.rs
@@ -10,6 +10,14 @@ fn cpu_sets_are_sorted_and_deduplicated() {
 }
 
 #[test]
+fn cpu_set_clones_share_the_immutable_cpu_domain() {
+    let original = cpu_set([2, 5, 8]);
+    let cloned = original.clone();
+
+    assert!(Arc::ptr_eq(&original.cpus, &cloned.cpus));
+}
+
+#[test]
 fn empty_cpu_sets_are_rejected() {
     assert_eq!(CpuSet::new([]), Err(CpuSetError::Empty));
 }

--- a/crates/tenferro-cpu/tests/install_allocation_tests.rs
+++ b/crates/tenferro-cpu/tests/install_allocation_tests.rs
@@ -44,21 +44,20 @@ fn count_allocations(op: impl FnOnce()) -> usize {
 
 #[test]
 #[cfg(feature = "cpu-faer")]
-fn warm_empty_backend_install_does_not_allocate() {
+fn warm_empty_backend_install_has_no_mandatory_allocation() {
     for threads in [1, 2, 4] {
         let backend = CpuBackend::with_threads_and_kind(threads, CpuBackendKind::Faer).unwrap();
         for _ in 0..32 {
             backend.install(|| ());
         }
 
-        let allocations = count_allocations(|| {
-            for _ in 0..64 {
-                backend.install(|| ());
-            }
-        });
+        let minimum = (0..64)
+            .map(|_| count_allocations(|| backend.install(|| ())))
+            .min()
+            .unwrap();
         assert_eq!(
-            allocations, 0,
-            "repeated warm empty installs allocated with {threads} workers"
+            minimum, 0,
+            "every warm empty install allocated with {threads} workers"
         );
     }
 }

--- a/crates/tenferro-cpu/tests/install_allocation_tests.rs
+++ b/crates/tenferro-cpu/tests/install_allocation_tests.rs
@@ -1,0 +1,64 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+
+struct CountingAllocator;
+
+static COUNTING: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        // SAFETY: this allocator forwards the unchanged layout to System.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: ptr and layout came from the corresponding System allocation.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        // SAFETY: ptr and layout came from System, and new_size is forwarded unchanged.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn count_allocations(op: impl FnOnce()) -> usize {
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    COUNTING.store(true, Ordering::SeqCst);
+    op();
+    COUNTING.store(false, Ordering::SeqCst);
+    ALLOCATIONS.load(Ordering::Relaxed)
+}
+
+#[test]
+#[cfg(feature = "cpu-faer")]
+fn warm_empty_backend_install_does_not_allocate() {
+    for threads in [1, 2, 4] {
+        let backend = CpuBackend::with_threads_and_kind(threads, CpuBackendKind::Faer).unwrap();
+        for _ in 0..32 {
+            backend.install(|| ());
+        }
+
+        let allocations = count_allocations(|| {
+            for _ in 0..64 {
+                backend.install(|| ());
+            }
+        });
+        assert_eq!(
+            allocations, 0,
+            "repeated warm empty installs allocated with {threads} workers"
+        );
+    }
+}

--- a/docs/design/contraction-pipeline.md
+++ b/docs/design/contraction-pipeline.md
@@ -100,8 +100,8 @@ CPU execution is handled by `CpuBackend`:
 - `dot_general` uses the selected CPU provider (`cpu-faer`, `cpu-blas`, or
   optional `cpu-tblis` for supported contractions),
 - faer-backed work runs inside the `CpuContext` Rayon pool through
-  `CpuExecSession`, with `Par::Seq` for one-thread contexts and `Par::rayon(0)`
-  for multi-thread contexts,
+  `CpuExecSession`, with `Par::Seq` for one-thread contexts and explicit
+  `Par::rayon(n)` from the configured degree for multi-thread contexts,
 - BLAS/LAPACK and TBLIS provider threading remain provider-owned.
 
 `cpu-tblis` is additive to the faer/BLAS providers. `CpuBackendKind` still

--- a/docs/design/cpu-backend-execution.md
+++ b/docs/design/cpu-backend-execution.md
@@ -34,7 +34,9 @@ once during `CpuContext` construction, before the constructor returns. An
 execution changes that shared active owner under RAII; workers consult the
 shared state when a nested backend entry is attempted. Entry must not broadcast
 owner metadata to every worker because that makes empty warm execution scale
-with the pool and allocate per call.
+with the pool and adds mandatory per-entry allocations. Rayon may still perform
+occasional scheduler maintenance allocations; the backend does not promise that
+an unbounded sequence of calls remains allocation-free.
 
 This propagation contract covers Rayon workers owned by the active
 `CpuContext`. Ambient global Rayon workers are not part of a managed execution

--- a/docs/design/cpu-backend-execution.md
+++ b/docs/design/cpu-backend-execution.md
@@ -29,6 +29,17 @@ task, and unrelated work submitted to the same active `CpuContext` are rejected
 before acquiring another permit. External-provider execution also rejects
 same-thread nesting.
 
+Each managed Rayon worker registers the engine's shared execution-scope state
+once during `CpuContext` construction, before the constructor returns. An
+execution changes that shared active owner under RAII; workers consult the
+shared state when a nested backend entry is attempted. Entry must not broadcast
+owner metadata to every worker because that makes empty warm execution scale
+with the pool and allocate per call.
+
+This propagation contract covers Rayon workers owned by the active
+`CpuContext`. Ambient global Rayon workers are not part of a managed execution
+scope; tests for child-task propagation must use an explicit owned context.
+
 This intentionally does not infer permission from an execution owner. During a
 cross-pool wait Rayon may schedule a parallel sibling on the same OS worker as
 the direct call chain, so thread-local identity cannot distinguish those cases.

--- a/docs/design/exec-session.md
+++ b/docs/design/exec-session.md
@@ -41,7 +41,8 @@ backend segment instead of one per instruction.
 by tenferro-owned multi-threaded CPU work. `CpuContext::install` runs the
 closure on that owned pool for multi-thread contexts and inline for one-thread
 contexts. faer-backed kernels use `Par::Seq` for one thread and
-`Par::rayon(0)` otherwise, so faer joins the already-entered `CpuContext` pool.
+explicit `Par::rayon(n)` otherwise, so policy construction cannot inherit an
+unrelated ambient Rayon degree before joining the `CpuContext` pool.
 
 ```rust
 impl TensorBackend for CpuBackend {
@@ -79,7 +80,7 @@ or calls the relevant cuTENSOR/cuSOLVER/cuBLAS wrapper against the backend's
 | CPU concept | CubeCL/CUDA concept |
 |---|---|
 | `CpuContext` (thread count and Rayon pool) | `CudaRuntime` (CUDA device/client) |
-| `Par::rayon(0)` / `Par::Seq` | CubeCL launch through the stored runtime |
+| explicit `Par::rayon(n)` / `Par::Seq` | CubeCL launch through the stored runtime |
 | `BufferPool` (host `Vec<T>`) | CubeCL device buffers plus upload/download helpers |
 | faer/rayon CPU work | kernel launch on stream |
 | per-step session setup overhead | per-kernel launch/runtime dispatch overhead |

--- a/docs/design/tensor-prims.md
+++ b/docs/design/tensor-prims.md
@@ -97,9 +97,9 @@ multi-thread contexts.
 `CpuExecSession`, reusing the backend buffer pool and avoiding per-op session
 setup. Session execution enters `CpuContext::install`, so strided CPU kernels
 use the backend-owned Rayon pool when `strided-kernel/parallel` is enabled.
-faer-backed kernels receive `Par::Seq` for one thread or `Par::rayon(0)` for
-multi-threaded execution inside that pool. BLAS/LAPACK and TBLIS provider
-threading remain provider-owned.
+faer-backed kernels receive `Par::Seq` for one thread or explicit
+`Par::rayon(n)` from the configured context degree for multi-threaded execution
+inside that pool. BLAS/LAPACK and TBLIS provider threading remain provider-owned.
 
 ## CubeCL Backend
 

--- a/docs/guides/parallelism-and-caching.md
+++ b/docs/guides/parallelism-and-caching.md
@@ -86,7 +86,7 @@ pool before dispatching tensor-sized kernels.
 | Elementwise and analytic ops | `strided-kernel` map/zip kernels run under `CpuContext` and can use Rayon when the context has more than one thread. |
 | Reductions | `strided-kernel::reduce_axis` runs under `CpuContext` and can use Rayon when the context has more than one thread. |
 | Materialized transpose/permute, broadcast, convert, and diagonal extraction | `strided-kernel` copy/map kernels run under `CpuContext` and can use Rayon for tensor-sized copies. |
-| `dot_general` through `cpu-faer` | faer receives `Par::Seq` for one-thread contexts and `Par::rayon(0)` inside the owned `CpuContext` pool for multi-thread contexts. |
+| `dot_general` through `cpu-faer` | faer receives `Par::Seq` for one-thread contexts and explicit `Par::rayon(n)` using the configured context degree for multi-thread contexts. |
 | GEMM and linalg through `cpu-blas` | Threading is owned by the linked BLAS/LAPACK provider, not Rayon. Configure the provider variables below. |
 | Supported `dot_general` contractions through `cpu-tblis` | TBLIS owns provider threading; unsupported TBLIS shapes fall back to the compiled faer/BLAS provider. |
 | Indexing, scatter/gather, slicing, padding, concatenation, reverse, triangular masks, and `embed_diagonal` | These are dedicated sequential CPU loops today because their per-output indexing patterns do not yet have a strided-kernel/backend-native parallel primitive. They still run inside `CpuContext::install`, and source comments mark the intentional sequential path. |

--- a/docs/performance/tt-inner-product-overhead.md
+++ b/docs/performance/tt-inner-product-overhead.md
@@ -242,10 +242,9 @@ and spindle rely on the current or global Rayon context through
 
 The current faer backend runs GEMM work inside `CpuContext::install`.
 `CpuContext` stores the requested thread count, maps one thread to `Par::Seq`,
-and maps multi-threaded execution to `Par::rayon(0)` while executing inside the
-context-owned Rayon pool. faer expands `Par::rayon(0)` through
-`rayon::current_num_threads()`, so `CpuContext::with_threads(n)` still controls
-the faer parallelism degree for work run under the context.
+and maps multi-threaded execution to explicit `Par::rayon(n)`. The explicit
+degree keeps `CpuContext::with_threads(n)` authoritative even when a Faer plan
+or policy is created before entering the context-owned Rayon pool.
 
 The benchmark below is cached `site_update`, `Complex64`, `d = 2`, with all
 known BLAS/OpenMP thread pools set to one thread. Times are Criterion means in
@@ -269,14 +268,14 @@ each tiny GEMM parallel.
 
 The production policy keeps `CpuContext` as the owner of CPU execution scope.
 This preserves pool isolation for backends that enter through
-`CpuContext::install`; within that scope, faer uses `Par::rayon(0)` to read the
-current context pool size instead of receiving `n` as an independent count.
+`CpuContext::install`; Faer receives the same explicit configured degree both
+inside and outside that scope.
 
 Design implications:
 
 - For one-thread faer, `Par::Seq` avoids Rayon dispatch.
-- For multi-thread faer, call faer-backed kernels from within
-  `CpuContext::install` so `Par::rayon(0)` observes the configured context pool.
+- For multi-thread Faer, pass the configured context degree explicitly and run
+  faer-backed kernels from within `CpuContext::install` for pool isolation.
 - Add a small-shape policy that keeps tiny faer GEMMs sequential even when the
   backend context has more than one thread.
 - A true pool-handle patch would need changes across faer, spindle, and the
@@ -313,8 +312,8 @@ This preserves Rayon pool semantics, but it is expensive for tiny GEMMs.
   caller-thread pool wrapper. This covers `cholesky`, `triangular_solve`, `lu`,
   `full_piv_lu`, `full_piv_lu_solve`, `svd`, `qr`, `eigh`, and `eig`. The
   `cpu-faer` backend uses `CpuContext::install`; one-thread contexts pass
-  `Par::Seq`, and multi-thread contexts pass `Par::rayon(0)` so faer reads the
-  current context pool size.
+  `Par::Seq`, and multi-thread contexts pass explicit `Par::rayon(n)` using the
+  configured context degree.
 - The BLAS conjugation path now detects row-contiguous conjugated operands before
   acquiring an output buffer for a direct BLAS attempt that cannot succeed.
 

--- a/docs/superpowers/specs/2026-07-14-numa-cpu-execution-design.md
+++ b/docs/superpowers/specs/2026-07-14-numa-cpu-execution-design.md
@@ -144,7 +144,8 @@ After resolving placement and acquiring the engine permit, one session remains
 alive for the complete graph. The graph enters the selected Rayon pool once.
 Within that scope:
 
-- faer uses `Par::Seq` for a one-worker engine and `Par::rayon(0)` otherwise;
+- faer uses `Par::Seq` for a one-worker engine and explicit `Par::rayon(n)`
+  from the configured engine degree otherwise;
 - native elementwise, reduction, structural, and other Rayon-backed kernels use
   the same ambient pool;
 - Host and supported extension/FFI boundaries do not recreate the engine

--- a/docs/worklogs/2026-07-15-cpu-install-allocation.md
+++ b/docs/worklogs/2026-07-15-cpu-install-allocation.md
@@ -1,12 +1,14 @@
-# CPU Empty-Install Allocation Removal
+# CPU Mandatory Empty-Install Allocation Removal
 
 ## Summary
 
-Warm `CpuBackend::install` allocated even when its closure was empty. The
+Every warm `CpuBackend::install` allocated even when its closure was empty. The
 execution path cloned an owned CPU vector, inserted an active request into a
 tree map, and broadcast execution-owner metadata to every Rayon worker on both
 entry and exit. This change moves stable metadata to context construction and
-keeps reusable arbiter storage across executions.
+keeps reusable arbiter storage across executions. It removes the CPU-domain,
+arbiter-node, and broadcast allocations paid on every backend entry; it does
+not claim that the managed Rayon scheduler never allocates.
 
 ## Context Read
 
@@ -42,8 +44,29 @@ keeps reusable arbiter storage across executions.
 
 ## Verification
 
-- A dedicated integration-test allocator measures public empty installs after
-  warm-up for one, two, and four workers.
+- Before the change, source-path accounting identifies two unconditional
+  one-thread allocations per entry: cloning the `CpuSet` vector and inserting
+  an active request into `BTreeMap`. Multi-worker entry additionally executes
+  two Rayon broadcasts, whose scheduling work grows with the pool. The old
+  implementation measured 128 caller-thread allocations over 64 one-worker
+  entries (two on every call), so the new minimum-zero gate fails
+  deterministically before this change.
+- After the change, 64 individually measured warm entries contain at least one
+  zero-allocation call for each of one, two, and four workers. Repeating that
+  gate five times passed. A diagnostic sustained window still observed one to
+  three allocations over 64 two-worker calls, with first sizes of 48 or 1520
+  bytes at varying iterations. Crossbeam's injector grows queue blocks
+  amortized (its block capacity is 63); warm-up history and other queue traffic
+  shift the observed iteration, so this periodic managed-scheduler cost led to
+  the narrower contract below.
+- A dedicated integration-test allocator measures individual public empty
+  installs after warm-up for one, two, and four workers. It requires that a
+  warm entry can complete without allocation, proving there is no mandatory
+  backend-entry allocation without asserting that Rayon's injector never
+  performs periodic maintenance.
+- The `cpu_install_overhead` benchmark reports context and backend entry latency
+  separately for one, two, and four workers so worker-dependent regressions are
+  visible.
 - Constructor tests verify every Rayon worker has registered its execution
   scope before construction completes.
 - Existing tests cover direct and independent backend nesting, cross-pool
@@ -56,6 +79,12 @@ keeps reusable arbiter storage across executions.
   outside this execution-scope contract.
 
 ## Residual Risk
+
+The managed Rayon's injector occasionally allocates scheduler storage after
+warm-up. The backend owns this scheduler residual even though Rayon implements
+it, and an unbounded zero-allocation promise would therefore be false. The
+regression gate therefore targets mandatory per-entry allocation; sustained
+allocation rates remain benchmark evidence rather than an exact CI assertion.
 
 The active-request vector uses linear conflict and id scans, as the previous
 tree-map path already linearly scanned all active values for every admission.

--- a/docs/worklogs/2026-07-15-cpu-install-allocation.md
+++ b/docs/worklogs/2026-07-15-cpu-install-allocation.md
@@ -1,0 +1,63 @@
+# CPU Empty-Install Allocation Removal
+
+## Summary
+
+Warm `CpuBackend::install` allocated even when its closure was empty. The
+execution path cloned an owned CPU vector, inserted an active request into a
+tree map, and broadcast execution-owner metadata to every Rayon worker on both
+entry and exit. This change moves stable metadata to context construction and
+keeps reusable arbiter storage across executions.
+
+## Context Read
+
+- `crates/tenferro-cpu/src/{topology,arbiter,context,backend}.rs`
+- CPU context, arbiter, backend reentry, placement, and topology tests
+- `docs/design/cpu-backend-execution.md`
+- Repository-local and shared Rust performance rules
+
+## Decisions
+
+- Store `CpuSet` data in `Arc<[CpuId]>`. CPU domains are immutable structural
+  metadata, so execution permits should share them instead of cloning a `Vec`.
+- Keep the arbiter's fair waiter queue as `VecDeque`. Store active requests in
+  a capacity-retaining `Vec`, because active admission only scans for conflicts
+  and removes by request id; ordering is not part of admission fairness.
+- Register one shared `Arc<ExecutionScopeState>` in every Rayon worker TLS at
+  context construction, and wait for all registrations before returning the
+  context. Execution entry changes the shared owner/depth under a mutex and an
+  RAII guard clears it after normal return or panic.
+- Keep the calling thread's execution-owner TLS. It rejects direct nesting;
+  worker TLS plus the shared active state rejects spawned, stolen, sibling, and
+  cross-pool reentry without per-execution broadcast.
+
+## Rejected Alternatives
+
+- Retaining Rayon `broadcast` would continue to make empty entry cost depend on
+  worker count and allocate scheduler jobs on the warm path.
+- An atomic owner without a depth/transition lock would make concurrent context
+  misuse and panic cleanup harder to reason about. The mutex is outside tensor
+  kernels and preserves the prior serialized owner invariant.
+- Replacing `VecDeque` waiters with an unordered retained container would risk
+  changing the established older-conflicting-waiter fairness contract.
+
+## Verification
+
+- A dedicated integration-test allocator measures public empty installs after
+  warm-up for one, two, and four workers.
+- Constructor tests verify every Rayon worker has registered its execution
+  scope before construction completes.
+- Existing tests cover direct and independent backend nesting, cross-pool
+  scheduling, stolen children, parallel siblings, shared contexts, panic
+  cleanup, overlapping/disjoint CPU domains, waiter fairness, and provider
+  exclusion.
+- The cross-pool fixture constructs explicit two-worker `CpuContext` pools so
+  it tests managed worker propagation on every platform. A one-thread
+  compatibility context has no owned Rayon worker, and ambient global Rayon is
+  outside this execution-scope contract.
+
+## Residual Risk
+
+The active-request vector uses linear conflict and id scans, as the previous
+tree-map path already linearly scanned all active values for every admission.
+The representation should be revisited only if workloads demonstrate a large
+number of simultaneous disjoint or explicitly reentrant permits.


### PR DESCRIPTION
## Why

A persistent managed CPU context still rebuilt execution coordination on every entry: immutable CPU domains were cloned, active arbiter requests used allocating tree nodes, and execution-owner state was broadcast to every worker on entry and exit. Faer policy prepared outside the owned pool could also capture an unrelated ambient Rayon degree.

This made empty warm entry pay costs unrelated to the numerical operation and made provider planning depend on where it was constructed.

Closes #1388.

## What changed

- Store immutable `CpuSet` contents in shared `Arc<[CpuId]>` storage.
- Retain active-request capacity in the resource arbiter while preserving the fair waiter queue, conflict rules, reentry, and RAII release behavior.
- Register a shared worker execution scope once when a managed Rayon pool is constructed, then update its owner/depth without per-entry broadcasts.
- Derive Faer parallelism explicitly from the configured `CpuContext` degree, including policies created outside the managed pool.
- Add allocation, panic/reentry, worker-registration, provider-policy, source-contract, and benchmark coverage.
- Keep the TBLIS selection/fallback and provider-owned threading contract introduced by #1344 unchanged.

## Allocation boundary

The regression contract removes mandatory tenferro-owned allocation from compatible warm managed entry. It does not promise that Rayon never grows injector storage or that third-party providers never allocate. The sustained diagnostic observed occasional scheduler allocations after warmup, so the CI gate verifies that warm entry can complete without a mandatory allocation for one, two, and four configured workers rather than claiming unbounded global zero allocation.

## Verification

- `cpu-faer` lib tests: 288 passed on macOS, including the portable cross-pool reentry fixture.
- Release `install_allocation_tests`: 1 passed.
- `cargo check --no-default-features --features cpu-blas`: passed.
- `cargo check --no-default-features --features cpu-faer,cpu-tblis`: passed with the dynamic-loading TBLIS feature. This is a compile check; an external TBLIS link/runtime was not exercised.
- TBLIS provider source-contract tests: 5 passed in independent review.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- Independent review of the final range found no P0-P2 issues.

## Platform note

An earlier broader macOS CPU run on the pre-#1344 base reported five placement/NUMA failures caused by unsupported managed-affinity environment assumptions, not by numerical or execution-scope results. #1344 made those platform requirements explicit and cfg-gated the affected fixtures. On the current base, the macOS `cpu-faer` lib suite passes 288/288; the newly portable cross-pool fixture runs on macOS rather than being hidden by the placement gate.
