### PR TITLE
Reuse managed CPU execution coordination

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -699,7 +699,9 @@ Tests follow implementation ownership.
 - For faer-backed CPU ops, `CpuContext` is the single source of truth for thread-pool policy.
 - Do not derive faer parallelism independently inside individual ops or helper functions.
 - Execute faer-backed work only inside `ctx.install(...)` so the owned rayon context is preserved.
-- Use `Par::Seq` for one-thread contexts and `Par::rayon(0)` for multi-thread contexts so faer follows the current `CpuContext`.
+- Use `Par::Seq` for one-thread contexts and explicit `Par::rayon(n)` from the
+  configured `CpuContext` degree for multi-thread contexts. Do not derive the
+  policy from an ambient Rayon pool during plan or session setup.
 - Tensor-sized strided CPU kernels that are not provider-owned must also run
   inside `CpuContext::install(...)`, so Rayon-backed `strided-kernel` work uses
   the backend's owned pool. BLAS/LAPACK provider-owned threading remains

--- a/crates/tenferro-cpu/benches/cpu_install_overhead.rs
+++ b/crates/tenferro-cpu/benches/cpu_install_overhead.rs
@@ -1,19 +1,30 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use tenferro_cpu::{linalg_interop::BufferPool, CpuBackend, CpuContext};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use tenferro_cpu::{linalg_interop::BufferPool, CpuBackend, CpuBackendKind, CpuContext};
 use tenferro_tensor::BackendRuntimeCache;
 
 fn bench_cpu_context_entry_overhead(c: &mut Criterion) {
-    let mut group = c.benchmark_group("cpu_context_entry_overhead/one_thread");
+    let mut group = c.benchmark_group("cpu_context_entry_overhead");
 
-    group.bench_function("ctx_install_inline_empty", |b| {
-        let ctx = CpuContext::with_threads(1).unwrap();
-        b.iter(|| ctx.install(|| black_box(1usize)));
-    });
+    for threads in [1, 2, 4] {
+        group.bench_with_input(
+            BenchmarkId::new("ctx_install_empty", threads),
+            &threads,
+            |b, &threads| {
+                let ctx = CpuContext::with_threads(threads).unwrap();
+                b.iter(|| ctx.install(|| black_box(1usize)));
+            },
+        );
 
-    group.bench_function("backend_install_inline_empty", |b| {
-        let backend = CpuBackend::with_threads(1).unwrap();
-        b.iter(|| backend.install(|| black_box(1usize)));
-    });
+        group.bench_with_input(
+            BenchmarkId::new("backend_install_empty", threads),
+            &threads,
+            |b, &threads| {
+                let backend =
+                    CpuBackend::with_threads_and_kind(threads, CpuBackendKind::Faer).unwrap();
+                b.iter(|| backend.install(|| black_box(1usize)));
+            },
+        );
+    }
 
     group.bench_function("buffer_pool_take_restore_only", |b| {
         let mut buffers = BufferPool::new();

--- a/crates/tenferro-cpu/src/arbiter.rs
+++ b/crates/tenferro-cpu/src/arbiter.rs
@@ -1,5 +1,5 @@
-use std::cell::Cell;
-use std::collections::{BTreeMap, VecDeque};
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
@@ -21,14 +21,19 @@ impl ResourceOwner {
 thread_local! {
     static THREAD_OWNER: ResourceOwner = ResourceOwner::fresh();
     static EXECUTION_OWNER: Cell<Option<ResourceOwner>> = const { Cell::new(None) };
-    static POOL_EXECUTION_OWNER: Cell<Option<ResourceOwner>> = const { Cell::new(None) };
+    static WORKER_EXECUTION_SCOPE: RefCell<Option<Arc<ExecutionScopeState>>> = const { RefCell::new(None) };
 }
 
 pub(crate) const BACKEND_REENTRY_PANIC: &str =
     "CpuBackend cannot be re-entered while another CPU backend execution is active on this thread or managed Rayon scope";
 
 pub(crate) fn inherited_or_new_execution_owner() -> ResourceOwner {
-    if POOL_EXECUTION_OWNER.with(Cell::get).is_some() {
+    if WORKER_EXECUTION_SCOPE.with(|scope| {
+        scope
+            .borrow()
+            .as_ref()
+            .is_some_and(|scope| scope.has_active_owner())
+    }) {
         panic!("{BACKEND_REENTRY_PANIC}");
     }
     if EXECUTION_OWNER.with(Cell::get).is_some() {
@@ -51,22 +56,78 @@ pub(crate) fn with_execution_owner<R>(owner: ResourceOwner, op: impl FnOnce() ->
     op()
 }
 
-pub(crate) fn set_pool_execution_owner(owner: Option<ResourceOwner>) {
-    POOL_EXECUTION_OWNER.set(owner);
+pub(crate) fn register_worker_execution_scope(scope: Arc<ExecutionScopeState>) {
+    WORKER_EXECUTION_SCOPE.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        // INVARIANT: each owned Rayon worker is a dedicated thread whose start
+        // hook runs once; replacing a live scope would mix context ownership.
+        debug_assert!(slot.is_none());
+        *slot = Some(scope);
+    });
 }
 
-pub(crate) fn with_pool_execution_owner<R>(owner: ResourceOwner, op: impl FnOnce() -> R) -> R {
-    struct RestoreOwner(Option<ResourceOwner>);
+#[cfg(test)]
+pub(crate) fn worker_execution_scope_registered() -> bool {
+    WORKER_EXECUTION_SCOPE.with(|scope| scope.borrow().is_some())
+}
 
-    impl Drop for RestoreOwner {
-        fn drop(&mut self) {
-            POOL_EXECUTION_OWNER.set(self.0);
+#[derive(Debug, Default)]
+pub(crate) struct ExecutionScopeState {
+    active: Mutex<ExecutionOwnerState>,
+}
+
+#[derive(Debug, Default)]
+struct ExecutionOwnerState {
+    owner: Option<ResourceOwner>,
+    depth: usize,
+}
+
+impl ExecutionScopeState {
+    pub(crate) fn enter(&self, owner: ResourceOwner) -> ExecutionScopeGuard<'_> {
+        let mut active = self
+            .active
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        match active.owner {
+            None => {
+                active.owner = Some(owner);
+                active.depth = 1;
+            }
+            Some(current) if current == owner => active.depth += 1,
+            Some(current) => panic!(
+                "CPU execution owner invariant violated: active {current:?}, requested {owner:?}"
+            ),
         }
+        ExecutionScopeGuard { scope: self, owner }
     }
 
-    let previous = POOL_EXECUTION_OWNER.replace(Some(owner));
-    let _restore = RestoreOwner(previous);
-    op()
+    fn has_active_owner(&self) -> bool {
+        self.active
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .owner
+            .is_some()
+    }
+}
+
+pub(crate) struct ExecutionScopeGuard<'a> {
+    scope: &'a ExecutionScopeState,
+    owner: ResourceOwner,
+}
+
+impl Drop for ExecutionScopeGuard<'_> {
+    fn drop(&mut self) {
+        let mut active = self
+            .scope
+            .active
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        debug_assert_eq!(active.owner, Some(self.owner));
+        active.depth -= 1;
+        if active.depth == 0 {
+            active.owner = None;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -108,6 +169,7 @@ struct Waiter {
 
 #[derive(Debug)]
 struct ActiveRequest {
+    id: u64,
     request: ResourceRequest,
     owner: ResourceOwner,
 }
@@ -116,7 +178,9 @@ struct ActiveRequest {
 struct ArbiterState {
     next_request_id: u64,
     waiters: VecDeque<Waiter>,
-    active: BTreeMap<u64, ActiveRequest>,
+    // INVARIANT: active admission only needs conflict scans and id removal. A
+    // retained Vec avoids the per-permit node allocation of a tree map.
+    active: Vec<ActiveRequest>,
 }
 
 #[derive(Debug, Default)]
@@ -231,10 +295,10 @@ impl ResourceArbiter {
                 return Err(ResourceArbiterError::StatePoisoned);
             };
             let request = &state.waiters[position].request;
-            let reentrant = state.active.values().any(|active| active.owner == owner);
+            let reentrant = state.active.iter().any(|active| active.owner == owner);
             let active_compatible = state
                 .active
-                .values()
+                .iter()
                 .all(|active| active.owner == owner || !active.request.conflicts_with(request));
             let older_compatible = reentrant
                 || state
@@ -246,13 +310,11 @@ impl ResourceArbiter {
                 let Some(waiter) = state.waiters.remove(position) else {
                     return Err(ResourceArbiterError::StatePoisoned);
                 };
-                state.active.insert(
+                state.active.push(ActiveRequest {
                     id,
-                    ActiveRequest {
-                        request: waiter.request,
-                        owner: waiter.owner,
-                    },
-                );
+                    request: waiter.request,
+                    owner: waiter.owner,
+                });
                 return Ok(ResourcePermit {
                     inner: Arc::clone(&self.inner),
                     id,
@@ -283,10 +345,10 @@ impl ResourceArbiter {
             .lock()
             .map_err(|_| ResourceArbiterError::StatePoisoned)?;
         let owner = request_owner();
-        let reentrant = state.active.values().any(|active| active.owner == owner);
+        let reentrant = state.active.iter().any(|active| active.owner == owner);
         let conflicts_with_active = state
             .active
-            .values()
+            .iter()
             .any(|active| active.owner != owner && active.request.conflicts_with(&request));
         let bypasses_waiter = !reentrant
             && state
@@ -301,7 +363,7 @@ impl ResourceArbiter {
             .next_request_id
             .checked_add(1)
             .ok_or(ResourceArbiterError::RequestIdExhausted)?;
-        state.active.insert(id, ActiveRequest { request, owner });
+        state.active.push(ActiveRequest { id, request, owner });
         Ok(Some(ResourcePermit {
             inner: Arc::clone(&self.inner),
             id,
@@ -371,7 +433,9 @@ impl Drop for ResourcePermit {
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        state.active.remove(&self.id);
+        if let Some(position) = state.active.iter().position(|active| active.id == self.id) {
+            state.active.swap_remove(position);
+        }
         self.inner.changed.notify_all();
     }
 }

--- a/crates/tenferro-cpu/src/arbiter/tests.rs
+++ b/crates/tenferro-cpu/src/arbiter/tests.rs
@@ -64,6 +64,21 @@ fn panic_releases_provider_exclusive_reservation() {
 }
 
 #[test]
+fn released_active_request_retains_reusable_storage() {
+    let arbiter = ResourceArbiter::new();
+    drop(arbiter.acquire(cpu_set([0, 1])).unwrap());
+    let warm_capacity = arbiter.inner.state.lock().unwrap().active.capacity();
+
+    for _ in 0..64 {
+        drop(arbiter.acquire(cpu_set([0, 1])).unwrap());
+    }
+
+    let state = arbiter.inner.state.lock().unwrap();
+    assert!(state.active.is_empty());
+    assert_eq!(state.active.capacity(), warm_capacity);
+}
+
+#[test]
 fn older_all_allowed_waiter_blocks_younger_disjoint_admission() {
     let arbiter = Arc::new(ResourceArbiter::new());
     let active = arbiter.acquire(cpu_set([0, 1])).unwrap();

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -651,6 +651,42 @@ pub struct CpuBackend {
     dot_general_provider: DotGeneralProvider,
 }
 
+/// Opaque binding token for operation-family prepared execution resources.
+///
+/// The token retains the coordinator and context allocations so identity cannot
+/// be recycled while a prepared plan is alive. Application code should not
+/// inspect or construct this interop type.
+///
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct CpuLinalgBinding {
+    shared: Arc<CpuBackendState>,
+    context: Arc<CpuContext>,
+    kind: CpuBackendKind,
+    threads: usize,
+}
+
+impl fmt::Debug for CpuLinalgBinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CpuLinalgBinding")
+            .field("kind", &self.kind)
+            .field("threads", &self.threads)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CpuLinalgBinding {
+    /// Return whether `backend` uses the exact retained provider resources.
+    ///
+    #[doc(hidden)]
+    pub fn matches(&self, backend: &CpuBackend) -> bool {
+        self.kind == backend.kind()
+            && self.threads == backend.num_threads()
+            && Arc::ptr_eq(&self.shared, &backend.shared)
+            && Arc::ptr_eq(&self.context, &backend.engine.context_arc())
+    }
+}
+
 fn resolve_discovered_topology(
     kind: CpuBackendKind,
     topology: Result<CpuTopology, CpuTopologyError>,
@@ -1506,6 +1542,23 @@ impl CpuBackend {
     #[doc(hidden)]
     pub fn linalg_context(&self) -> Arc<CpuContext> {
         self.engine.context_arc()
+    }
+
+    /// Retain the coordinator and execution-context identity used by
+    /// operation-family prepared plans.
+    ///
+    /// This is backend interop rather than application-facing identity. A
+    /// prepared plan uses both values so a clone sharing the same execution
+    /// resources is accepted while a separately constructed backend is not.
+    ///
+    #[doc(hidden)]
+    pub fn linalg_binding(&self) -> CpuLinalgBinding {
+        CpuLinalgBinding {
+            shared: Arc::clone(&self.shared),
+            context: self.engine.context_arc(),
+            kind: self.kind(),
+            threads: self.num_threads(),
+        }
     }
 
     // Selected when the Faer provider handles cached GEMM execution; some

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -204,8 +204,8 @@ fn direct_nested_independent_engine_is_rejected_in_a_managed_scope() {
 #[test]
 #[cfg(all(feature = "cpu-faer", any(target_os = "linux", target_os = "android")))]
 fn cross_pool_wait_cannot_misclassify_a_scheduled_sibling_as_direct_nesting() {
-    let outer = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
-    let middle = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let outer = CpuBackend::from_context(Arc::new(CpuContext::with_threads(2).unwrap()));
+    let middle = CpuBackend::from_context(Arc::new(CpuContext::with_threads(2).unwrap()));
     let sibling = outer.clone();
 
     let (_, sibling_outcome) = outer.install(move || {
@@ -325,7 +325,7 @@ fn shared_context_work_is_not_mistaken_for_backend_reentry() {
 
 #[test]
 #[cfg(all(feature = "cpu-faer", any(target_os = "linux", target_os = "android")))]
-fn execution_owner_broadcast_is_cleared_after_panic() {
+fn shared_execution_scope_is_cleared_after_panic() {
     let backend = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
 
     let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -202,7 +202,7 @@ fn direct_nested_independent_engine_is_rejected_in_a_managed_scope() {
 }
 
 #[test]
-#[cfg(all(feature = "cpu-faer", any(target_os = "linux", target_os = "android")))]
+#[cfg(feature = "cpu-faer")]
 fn cross_pool_wait_cannot_misclassify_a_scheduled_sibling_as_direct_nesting() {
     let outer = CpuBackend::from_context(Arc::new(CpuContext::with_threads(2).unwrap()));
     let middle = CpuBackend::from_context(Arc::new(CpuContext::with_threads(2).unwrap()));

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -1,19 +1,13 @@
 use std::env;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use thiserror::Error as ThisError;
 
 use crate::affinity::{SystemThreadAffinity, ThreadAffinity};
 use crate::arbiter::{
-    set_pool_execution_owner, with_execution_owner, with_pool_execution_owner, ResourceOwner,
+    register_worker_execution_scope, with_execution_owner, ExecutionScopeState, ResourceOwner,
 };
 use crate::{CpuId, CpuSet, Error, Result};
-
-#[derive(Debug, Default)]
-struct ExecutionOwnerState {
-    owner: Option<ResourceOwner>,
-    depth: usize,
-}
 
 /// Failure to construct a CPU context with pinned Rayon workers.
 ///
@@ -79,7 +73,7 @@ pub struct CpuContext {
     num_threads: usize,
     pool: Option<Arc<rayon::ThreadPool>>,
     pinned_cpus: Option<CpuSet>,
-    execution_owner: Arc<Mutex<ExecutionOwnerState>>,
+    execution_scope: Arc<ExecutionScopeState>,
 }
 
 impl CpuContext {
@@ -160,24 +154,36 @@ impl CpuContext {
                 message: "thread count must be at least 1".into(),
             });
         }
+        let execution_scope = Arc::new(ExecutionScopeState::default());
         let pool = if num_threads == 1 {
             None
         } else {
-            Some(Arc::new(
-                rayon::ThreadPoolBuilder::new()
-                    .num_threads(num_threads)
-                    .build()
-                    .map_err(|err| Error::InvalidConfig {
-                        op: "CpuContext::with_threads",
-                        message: format!("failed to build CPU thread pool: {err}"),
-                    })?,
-            ))
+            let (startup_tx, startup_rx) = std::sync::mpsc::channel();
+            let worker_scope = Arc::clone(&execution_scope);
+            let pool = rayon::ThreadPoolBuilder::new()
+                .num_threads(num_threads)
+                .start_handler(move |_| {
+                    register_worker_execution_scope(Arc::clone(&worker_scope));
+                    let _ = startup_tx.send(());
+                })
+                .build()
+                .map_err(|err| Error::InvalidConfig {
+                    op: "CpuContext::with_threads",
+                    message: format!("failed to build CPU thread pool: {err}"),
+                })?;
+            for _ in 0..num_threads {
+                startup_rx.recv().map_err(|_| Error::InvalidConfig {
+                    op: "CpuContext::with_threads",
+                    message: "CPU worker exited before execution-scope registration".into(),
+                })?;
+            }
+            Some(Arc::new(pool))
         };
         Ok(Self {
             num_threads,
             pool,
             pinned_cpus: None,
-            execution_owner: Arc::new(Mutex::new(ExecutionOwnerState::default())),
+            execution_scope,
         })
     }
 
@@ -220,9 +226,11 @@ impl CpuContext {
             });
         }
 
+        let execution_scope = Arc::new(ExecutionScopeState::default());
         let assigned_cpus = Arc::new(select_worker_cpus(&cpus, num_threads));
         let (startup_tx, startup_rx) = std::sync::mpsc::channel();
         let pool_assigned_cpus = Arc::clone(&assigned_cpus);
+        let worker_scope = Arc::clone(&execution_scope);
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(num_threads)
             .spawn_handler(move |thread| {
@@ -230,9 +238,11 @@ impl CpuContext {
                 let cpu = pool_assigned_cpus[worker];
                 let startup_tx = startup_tx.clone();
                 let affinity = affinity.clone();
+                let worker_scope = Arc::clone(&worker_scope);
                 std::thread::Builder::new()
                     .name(format!("tenferro-cpu-{cpu}"))
                     .spawn(move || {
+                        register_worker_execution_scope(Arc::clone(&worker_scope));
                         let result = affinity.pin_current(cpu).and_then(|observed| {
                             (observed.len() == 1 && observed.contains(cpu))
                                 .then_some(())
@@ -269,7 +279,7 @@ impl CpuContext {
             num_threads,
             pool: Some(pool),
             pinned_cpus: Some(cpus),
-            execution_owner: Arc::new(Mutex::new(ExecutionOwnerState::default())),
+            execution_scope,
         })
     }
 
@@ -278,7 +288,7 @@ impl CpuContext {
             num_threads: 1,
             pool: None,
             pinned_cpus: None,
-            execution_owner: Arc::new(Mutex::new(ExecutionOwnerState::default())),
+            execution_scope: Arc::new(ExecutionScopeState::default()),
         }
     }
 
@@ -336,69 +346,10 @@ impl CpuContext {
         owner: ResourceOwner,
         op: impl FnOnce() -> R + Send,
     ) -> R {
-        let should_broadcast = {
-            let mut state = self
-                .execution_owner
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            match state.owner {
-                None => {
-                    state.owner = Some(owner);
-                    state.depth = 1;
-                    true
-                }
-                Some(active) if active == owner => {
-                    state.depth += 1;
-                    false
-                }
-                Some(active) => panic!(
-                    "CPU execution owner invariant violated: active {active:?}, requested {owner:?}"
-                ),
-            }
-        };
-        if should_broadcast {
-            self.broadcast_execution_owner(Some(owner));
-        }
-
-        struct OwnerGuard<'a> {
-            context: &'a CpuContext,
-            owner: ResourceOwner,
-        }
-
-        impl Drop for OwnerGuard<'_> {
-            fn drop(&mut self) {
-                let should_clear = {
-                    let mut state = self
-                        .context
-                        .execution_owner
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    debug_assert_eq!(state.owner, Some(self.owner));
-                    state.depth -= 1;
-                    if state.depth == 0 {
-                        state.owner = None;
-                        true
-                    } else {
-                        false
-                    }
-                };
-                if should_clear {
-                    self.context.broadcast_execution_owner(None);
-                }
-            }
-        }
-
-        let _guard = OwnerGuard {
-            context: self,
-            owner,
-        };
-        self.install(|| with_pool_execution_owner(owner, || with_execution_owner(owner, op)))
-    }
-
-    fn broadcast_execution_owner(&self, owner: Option<ResourceOwner>) {
-        if let Some(pool) = &self.pool {
-            pool.broadcast(|_| set_pool_execution_owner(owner));
-        }
+        // Workers share this state from construction; broadcasting owner TLS
+        // here would only reintroduce per-entry scheduler work and allocation.
+        let _scope = self.execution_scope.enter(owner);
+        self.install(|| with_execution_owner(owner, op))
     }
 
     /// Return the faer parallelism policy for work run inside this context.

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -354,16 +354,17 @@ impl CpuContext {
 
     /// Return the faer parallelism policy for work run inside this context.
     ///
-    /// `Par::rayon(0)` is intentional for multi-threaded contexts: faer reads
-    /// `rayon::current_num_threads()`, so calls made under [`Self::install`]
-    /// inherit this context's Rayon pool size.
+    /// The explicit degree keeps policy construction independent of the
+    /// ambient Rayon pool, including plans prepared before [`Self::install`].
     #[cfg(feature = "cpu-faer")]
     #[doc(hidden)]
     pub fn faer_par(&self) -> faer::Par {
         if self.num_threads == 1 {
             faer::Par::Seq
         } else {
-            faer::Par::rayon(0)
+            // `rayon(0)` captures the ambient pool immediately, which may not
+            // be this context when a provider plan is prepared outside install.
+            faer::Par::rayon(self.num_threads)
         }
     }
 

--- a/crates/tenferro-cpu/src/context/tests.rs
+++ b/crates/tenferro-cpu/src/context/tests.rs
@@ -2,10 +2,10 @@ use super::{select_worker_cpus, CpuContext, CpuContextError};
 #[cfg(target_os = "linux")]
 use crate::affinity::current_cpu;
 use crate::affinity::ThreadAffinity;
+use crate::arbiter::worker_execution_scope_registered;
 #[cfg(target_os = "linux")]
 use crate::process_cpu_affinity;
 use crate::{CpuId, CpuSet};
-#[cfg(target_os = "linux")]
 use rayon::prelude::*;
 #[cfg(target_os = "linux")]
 use std::collections::BTreeSet;
@@ -13,6 +13,19 @@ use std::collections::BTreeSet;
 #[test]
 fn with_threads_rejects_zero() {
     assert!(CpuContext::with_threads(0).is_err());
+}
+
+#[test]
+fn context_constructor_registers_every_rayon_worker_execution_scope() {
+    for threads in [2, 4] {
+        let ctx = CpuContext::with_threads(threads).unwrap();
+        let registered = ctx
+            .pool
+            .as_ref()
+            .unwrap()
+            .broadcast(|_| worker_execution_scope_registered());
+        assert_eq!(registered, vec![true; threads]);
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/tenferro-cpu/src/context/tests.rs
+++ b/crates/tenferro-cpu/src/context/tests.rs
@@ -6,6 +6,7 @@ use crate::arbiter::worker_execution_scope_registered;
 #[cfg(target_os = "linux")]
 use crate::process_cpu_affinity;
 use crate::{CpuId, CpuSet};
+#[cfg(target_os = "linux")]
 use rayon::prelude::*;
 #[cfg(target_os = "linux")]
 use std::collections::BTreeSet;

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -94,7 +94,7 @@ pub use affinity::{available_parallelism, process_cpu_affinity, process_cpu_affi
 pub use analytic::pow;
 pub use backend::{
     CpuBackend, CpuBackendError, CpuBackendKind, CpuExecutionInfo, CpuExecutionMode,
-    DotGeneralProvider,
+    CpuLinalgBinding, DotGeneralProvider,
 };
 pub use buffer_pool::BufferPoolStats;
 pub use capability::cpu_capabilities;

--- a/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
@@ -194,9 +194,9 @@ fn performance_notes_match_current_cpu_threading_contract() {
     let notes = include_str!("../../../../../docs/performance/tt-inner-product-overhead.md");
     assert!(
         !notes.contains("The faer backend is therefore run without a tenferro-owned Rayon pool")
-            && !notes.contains("maps multi-threaded execution to `Par::rayon(n)`")
+            && notes.contains("maps multi-threaded execution to explicit `Par::rayon(n)`")
             && !notes.contains("The global-Rayon columns became the production policy"),
-        "performance notes must describe CpuContext::install plus Par::rayon(0), not the stale global-Rayon policy"
+        "performance notes must describe the explicit CpuContext thread budget, not ambient global-Rayon policy"
     );
 }
 

--- a/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
@@ -192,11 +192,18 @@ fn cpu_context_faer_policy_ignores_a_different_ambient_pool_size() {
 #[test]
 fn performance_notes_match_current_cpu_threading_contract() {
     let notes = include_str!("../../../../../docs/performance/tt-inner-product-overhead.md");
+    let repository_rules = include_str!("../../../../../REPOSITORY_RULES.md");
     assert!(
         !notes.contains("The faer backend is therefore run without a tenferro-owned Rayon pool")
             && notes.contains("maps multi-threaded execution to explicit `Par::rayon(n)`")
             && !notes.contains("The global-Rayon columns became the production policy"),
         "performance notes must describe the explicit CpuContext thread budget, not ambient global-Rayon policy"
+    );
+    assert!(
+        repository_rules.contains("explicit `Par::rayon(n)`")
+            && !repository_rules
+                .contains("Use `Par::Seq` for one-thread contexts and `Par::rayon(0)`"),
+        "repository rules must derive Faer parallelism from the configured CpuContext degree"
     );
 }
 

--- a/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
@@ -165,10 +165,28 @@ fn cpu_context_faer_policy_is_seq_for_one_thread() {
 
 #[cfg(feature = "cpu-faer")]
 #[test]
-fn cpu_context_faer_policy_uses_current_context_pool_for_multithreaded_context() {
+fn cpu_context_faer_policy_matches_configured_workers_outside_pool() {
+    let ctx = CpuContext::with_threads(2).unwrap();
+    assert_eq!(ctx.faer_par().degree(), 2);
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn cpu_context_faer_policy_matches_configured_workers_inside_context_pool() {
     let ctx = CpuContext::with_threads(2).unwrap();
     let par = ctx.install(|| ctx.faer_par());
     assert_eq!(par.degree(), 2);
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn cpu_context_faer_policy_ignores_a_different_ambient_pool_size() {
+    let ctx = CpuContext::with_threads(2).unwrap();
+    let ambient = rayon::ThreadPoolBuilder::new()
+        .num_threads(3)
+        .build()
+        .unwrap();
+    assert_eq!(ambient.install(|| ctx.faer_par().degree()), 2);
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/topology.rs
+++ b/crates/tenferro-cpu/src/topology.rs
@@ -1,6 +1,7 @@
 #[cfg(any(test, target_os = "linux"))]
 use std::collections::BTreeSet;
 use std::fmt;
+use std::sync::Arc;
 
 use thiserror::Error;
 
@@ -127,12 +128,14 @@ pub enum CpuSetError {
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CpuSet {
-    cpus: Vec<CpuId>,
+    cpus: Arc<[CpuId]>,
 }
 
 impl CpuSet {
     pub(crate) fn singleton(cpu: CpuId) -> Self {
-        Self { cpus: vec![cpu] }
+        Self {
+            cpus: Arc::from([cpu]),
+        }
     }
 
     /// Construct a sorted and deduplicated CPU set.
@@ -153,7 +156,7 @@ impl CpuSet {
         if cpus.is_empty() {
             return Err(CpuSetError::Empty);
         }
-        Ok(Self { cpus })
+        Ok(Self { cpus: cpus.into() })
     }
 
     /// Return the number of logical CPUs in this set.
@@ -258,7 +261,9 @@ impl CpuSet {
                 }
             }
         }
-        (!intersection.is_empty()).then_some(Self { cpus: intersection })
+        (!intersection.is_empty()).then_some(Self {
+            cpus: intersection.into(),
+        })
     }
 }
 

--- a/crates/tenferro-cpu/src/topology/tests.rs
+++ b/crates/tenferro-cpu/src/topology/tests.rs
@@ -10,6 +10,14 @@ fn cpu_sets_are_sorted_and_deduplicated() {
 }
 
 #[test]
+fn cpu_set_clones_share_the_immutable_cpu_domain() {
+    let original = cpu_set([2, 5, 8]);
+    let cloned = original.clone();
+
+    assert!(Arc::ptr_eq(&original.cpus, &cloned.cpus));
+}
+
+#[test]
 fn empty_cpu_sets_are_rejected() {
     assert_eq!(CpuSet::new([]), Err(CpuSetError::Empty));
 }

--- a/crates/tenferro-cpu/tests/install_allocation_tests.rs
+++ b/crates/tenferro-cpu/tests/install_allocation_tests.rs
@@ -44,21 +44,20 @@ fn count_allocations(op: impl FnOnce()) -> usize {
 
 #[test]
 #[cfg(feature = "cpu-faer")]
-fn warm_empty_backend_install_does_not_allocate() {
+fn warm_empty_backend_install_has_no_mandatory_allocation() {
     for threads in [1, 2, 4] {
         let backend = CpuBackend::with_threads_and_kind(threads, CpuBackendKind::Faer).unwrap();
         for _ in 0..32 {
             backend.install(|| ());
         }
 
-        let allocations = count_allocations(|| {
-            for _ in 0..64 {
-                backend.install(|| ());
-            }
-        });
+        let minimum = (0..64)
+            .map(|_| count_allocations(|| backend.install(|| ())))
+            .min()
+            .unwrap();
         assert_eq!(
-            allocations, 0,
-            "repeated warm empty installs allocated with {threads} workers"
+            minimum, 0,
+            "every warm empty install allocated with {threads} workers"
         );
     }
 }

--- a/crates/tenferro-cpu/tests/install_allocation_tests.rs
+++ b/crates/tenferro-cpu/tests/install_allocation_tests.rs
@@ -1,0 +1,64 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+
+struct CountingAllocator;
+
+static COUNTING: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        // SAFETY: this allocator forwards the unchanged layout to System.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: ptr and layout came from the corresponding System allocation.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if COUNTING.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        // SAFETY: ptr and layout came from System, and new_size is forwarded unchanged.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn count_allocations(op: impl FnOnce()) -> usize {
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    COUNTING.store(true, Ordering::SeqCst);
+    op();
+    COUNTING.store(false, Ordering::SeqCst);
+    ALLOCATIONS.load(Ordering::Relaxed)
+}
+
+#[test]
+#[cfg(feature = "cpu-faer")]
+fn warm_empty_backend_install_does_not_allocate() {
+    for threads in [1, 2, 4] {
+        let backend = CpuBackend::with_threads_and_kind(threads, CpuBackendKind::Faer).unwrap();
+        for _ in 0..32 {
+            backend.install(|| ());
+        }
+
+        let allocations = count_allocations(|| {
+            for _ in 0..64 {
+                backend.install(|| ());
+            }
+        });
+        assert_eq!(
+            allocations, 0,
+            "repeated warm empty installs allocated with {threads} workers"
+        );
+    }
+}

--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -99,3 +99,8 @@ criterion.workspace = true
 name = "lu_ad_breakdown"
 harness = false
 required-features = ["autodiff"]
+
+[[bench]]
+name = "prepared_svd"
+harness = false
+required-features = ["cpu-faer"]

--- a/crates/tenferro-linalg/benches/prepared_svd.rs
+++ b/crates/tenferro-linalg/benches/prepared_svd.rs
@@ -1,0 +1,155 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+use tenferro_linalg::{LinalgBackend, PreparedSvdBackendExt, SvdOptions, SvdOutputWrites};
+use tenferro_tensor::{
+    DType, Tensor, TensorRead, TensorView, TensorWrite, TypedTensor, TypedTensorView,
+};
+
+const SHAPES: &[[usize; 2]] = &[
+    [2, 2],
+    [4, 2],
+    [2, 4],
+    [4, 4],
+    [8, 4],
+    [4, 8],
+    [16, 16],
+    [32, 16],
+    [16, 32],
+    [64, 64],
+];
+const THREADS: &[usize] = &[1, 2];
+
+fn matrix([m, n]: [usize; 2]) -> TypedTensor<f64> {
+    let data = (0..n)
+        .flat_map(|col| {
+            (0..m).map(move |row| {
+                let diagonal = if row == col { 2.0 } else { 0.0 };
+                diagonal + ((row * 17 + col * 31 + 1) % 97) as f64 / 97.0
+            })
+        })
+        .collect();
+    TypedTensor::from_vec_col_major(vec![m, n], data).unwrap()
+}
+
+fn outputs([m, n]: [usize; 2]) -> (Tensor, Tensor, Tensor) {
+    let k = m.min(n);
+    (
+        Tensor::from_vec_col_major(vec![m, k], vec![0.0_f64; m * k]).unwrap(),
+        Tensor::from_vec_col_major(vec![k], vec![0.0_f64; k]).unwrap(),
+        Tensor::from_vec_col_major(vec![k, n], vec![0.0_f64; k * n]).unwrap(),
+    )
+}
+
+fn bench_prepared_svd(c: &mut Criterion) {
+    let mut group = c.benchmark_group("faer_f64_compact_svd");
+    for &threads in THREADS {
+        for &shape in SHAPES {
+            let input = matrix(shape);
+
+            let mut owned_backend =
+                CpuBackend::with_threads_and_kind(threads, CpuBackendKind::Faer).unwrap();
+            let owned_id = BenchmarkId::new(
+                "owned_svd_read",
+                format!("{}x{}/t{threads}", shape[0], shape[1]),
+            );
+            group.bench_with_input(owned_id, &shape, |b, _| {
+                b.iter(|| {
+                    let result = owned_backend
+                        .svd_read(TensorView::F64(input.as_view()))
+                        .unwrap();
+                    black_box(result);
+                });
+            });
+
+            let mut prepared_backend =
+                CpuBackend::with_threads_and_kind(threads, CpuBackendKind::Faer).unwrap();
+            let plan = prepared_backend
+                .prepare_svd(shape, DType::F64, SvdOptions::default())
+                .unwrap();
+            let mut workspace = plan.allocate_workspace(&mut prepared_backend).unwrap();
+            let (mut u, mut s, mut vt) = outputs(shape);
+            plan.execute_into(
+                &mut prepared_backend,
+                &mut workspace,
+                TensorRead::from_view(TensorView::F64(input.as_view())),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            let prepared_id = BenchmarkId::new(
+                "prepared_execute_into",
+                format!("{}x{}/t{threads}", shape[0], shape[1]),
+            );
+            group.bench_with_input(prepared_id, &shape, |b, _| {
+                b.iter(|| {
+                    plan.execute_into(
+                        &mut prepared_backend,
+                        &mut workspace,
+                        TensorRead::from_view(TensorView::F64(input.as_view())),
+                        SvdOutputWrites::new(
+                            TensorWrite::from_tensor(&mut u),
+                            TensorWrite::from_tensor(&mut s),
+                            TensorWrite::from_tensor(&mut vt),
+                        ),
+                    )
+                    .unwrap();
+                    black_box((&u, &s, &vt));
+                });
+            });
+        }
+    }
+    group.finish();
+
+    bench_strided_prepared_svd(c);
+}
+
+fn bench_strided_prepared_svd(c: &mut Criterion) {
+    let shape = [8, 4];
+    let input = matrix(shape);
+    let mut storage = vec![0.0_f64; 76];
+    let input_data = input.as_slice().unwrap();
+    for col in 0..shape[1] {
+        for row in 0..shape[0] {
+            storage[1 + 2 * row + 20 * col] = input_data[row + shape[0] * col];
+        }
+    }
+    let mut group = c.benchmark_group("faer_f64_compact_svd_positive_stride_t1");
+    let mut owned_backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    group.bench_function("owned_svd_read/8x4", |b| {
+        b.iter(|| {
+            let view = TypedTensorView::from_slice(shape, [2, 20], 1, &storage).unwrap();
+            black_box(owned_backend.svd_read(TensorView::F64(view)).unwrap());
+        });
+    });
+
+    let mut prepared_backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let plan = prepared_backend
+        .prepare_svd(shape, DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut prepared_backend).unwrap();
+    let (mut u, mut s, mut vt) = outputs(shape);
+    group.bench_function("prepared_execute_into/8x4", |b| {
+        b.iter(|| {
+            let view = TypedTensorView::from_slice(shape, [2, 20], 1, &storage).unwrap();
+            plan.execute_into(
+                &mut prepared_backend,
+                &mut workspace,
+                TensorRead::from_view(TensorView::F64(view)),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            black_box((&u, &s, &vt));
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_prepared_svd);
+criterion_main!(benches);

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -822,7 +822,7 @@ fn apply_canonical_pivot_svd_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::R
     }
 }
 
-fn canonicalize_svd_gauge_f64(
+pub(crate) fn canonicalize_svd_gauge_f64(
     u: &mut [f64],
     vt: &mut [f64],
     m: usize,
@@ -851,7 +851,7 @@ fn canonicalize_svd_gauge_f64(
     Ok(())
 }
 
-fn canonicalize_svd_gauge_f32(
+pub(crate) fn canonicalize_svd_gauge_f32(
     u: &mut [f32],
     vt: &mut [f32],
     m: usize,
@@ -880,7 +880,7 @@ fn canonicalize_svd_gauge_f32(
     Ok(())
 }
 
-fn canonicalize_svd_gauge_c64(
+pub(crate) fn canonicalize_svd_gauge_c64(
     u: &mut [Complex64],
     vt: &mut [Complex64],
     m: usize,
@@ -913,7 +913,7 @@ fn canonicalize_svd_gauge_c64(
     Ok(())
 }
 
-fn canonicalize_svd_gauge_c32(
+pub(crate) fn canonicalize_svd_gauge_c32(
     u: &mut [Complex32],
     vt: &mut [Complex32],
     m: usize,

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -37,6 +37,8 @@ mod eager_ext;
 mod extension;
 #[cfg(feature = "cuda")]
 mod gpu;
+mod prepared_factorization;
+mod prepared_svd;
 mod traced;
 
 #[cfg(feature = "autodiff")]
@@ -52,5 +54,10 @@ pub use eager_ext::EagerTensorLinalgExt;
 pub use extension::{
     register_runtime, EighGauge, EighOptions, QrGauge, QrOptions, SvdGauge, SvdOptions,
     DEFAULT_DECOMPOSITION_DERIVATIVE_EPS, LINALG_EXTENSION_FAMILY_ID,
+};
+pub use prepared_factorization::{PreparedFactorizationBackendExt, PreparedFactorizationSession};
+pub use prepared_svd::{
+    PreparedSvd, PreparedSvdBackendExt, SvdOutputSpec, SvdOutputSpecs, SvdOutputWrites,
+    SvdWorkspace,
 };
 pub use traced::TracedTensorLinalgExt;

--- a/crates/tenferro-linalg/src/prepared_factorization.rs
+++ b/crates/tenferro-linalg/src/prepared_factorization.rs
@@ -1,0 +1,140 @@
+use std::fmt;
+use std::marker::PhantomData;
+
+use tenferro_cpu::CpuBackend;
+
+/// Exclusive execution scope shared by prepared factorization operations.
+///
+/// A session enters the backend execution domain once. Prepared SVD, QR, and
+/// eigendecomposition plans can then reuse that entry without reacquiring CPU
+/// resources for each matrix. The session is intentionally neither `Clone`
+/// nor constructible outside [`PreparedFactorizationBackendExt`].
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_linalg::PreparedFactorizationBackendExt;
+///
+/// let mut backend = CpuBackend::new();
+/// let entered = backend.with_prepared_factorization_session(|session| {
+///     format!("{session:?}").contains("PreparedFactorizationSession")
+/// });
+/// assert!(entered);
+/// ```
+///
+/// The callback-scoped session cannot escape:
+///
+/// ```compile_fail
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_linalg::{
+///     PreparedFactorizationBackendExt, PreparedFactorizationSession,
+/// };
+///
+/// fn escape(
+///     backend: &mut CpuBackend,
+/// ) -> &mut PreparedFactorizationSession<'_> {
+///     backend.with_prepared_factorization_session(|session| session)
+/// }
+/// ```
+pub struct PreparedFactorizationSession<'scope> {
+    pub(crate) inner: PreparedFactorizationSessionInner,
+    // Invariance prevents a session borrowed from the callback from escaping it.
+    _scope: PhantomData<&'scope mut &'scope ()>,
+}
+
+impl fmt::Debug for PreparedFactorizationSession<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PreparedFactorizationSession")
+            .field("device", &"cpu")
+            .finish_non_exhaustive()
+    }
+}
+
+pub(crate) enum PreparedFactorizationSessionInner {
+    Cpu(CpuPreparedFactorizationSession),
+}
+
+pub(crate) struct CpuPreparedFactorizationSession {
+    pub(crate) backend: CpuBackend,
+    #[cfg(feature = "cpu-faer")]
+    pub(crate) par: faer::Par,
+}
+
+/// Backend capability for grouping prepared factorization leaf executions.
+///
+/// The callback cannot return the opaque session. Multiple independent calls
+/// may run concurrently when their backend execution domains do not conflict.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_linalg::PreparedFactorizationBackendExt;
+///
+/// let mut backend = CpuBackend::new();
+/// let value = backend.with_prepared_factorization_session(|_| 2 + 3);
+/// assert_eq!(value, 5);
+/// ```
+pub trait PreparedFactorizationBackendExt: private::PreparedFactorizationDispatch {
+    /// Enter one backend execution scope for one or more prepared factorizations.
+    ///
+    /// Panic unwinding and ordinary return both release backend execution
+    /// ownership before this method returns.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::PreparedFactorizationBackendExt;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// backend.with_prepared_factorization_session(|session| {
+    ///     let _ = format!("{session:?}");
+    /// });
+    /// ```
+    fn with_prepared_factorization_session<R: Send>(
+        &mut self,
+        f: impl for<'scope> FnOnce(&mut PreparedFactorizationSession<'scope>) -> R + Send,
+    ) -> R {
+        private::PreparedFactorizationDispatch::with_prepared_factorization_session_impl(self, f)
+    }
+}
+
+impl<T: private::PreparedFactorizationDispatch> PreparedFactorizationBackendExt for T {}
+
+pub(crate) mod private {
+    use super::*;
+
+    pub trait PreparedFactorizationDispatch {
+        fn with_prepared_factorization_session_impl<R: Send>(
+            &mut self,
+            f: impl for<'scope> FnOnce(&mut PreparedFactorizationSession<'scope>) -> R + Send,
+        ) -> R;
+    }
+}
+
+impl private::PreparedFactorizationDispatch for CpuBackend {
+    fn with_prepared_factorization_session_impl<R: Send>(
+        &mut self,
+        f: impl for<'scope> FnOnce(&mut PreparedFactorizationSession<'scope>) -> R + Send,
+    ) -> R {
+        let session_backend = self.clone();
+        #[cfg(feature = "cpu-faer")]
+        let par = self.linalg_context().faer_par();
+
+        // A factorization session does not borrow the tensor buffer pool, so
+        // CpuBackend::install avoids BackendSession's unrelated dynamic surface.
+        self.install(move || {
+            let mut session = PreparedFactorizationSession {
+                inner: PreparedFactorizationSessionInner::Cpu(CpuPreparedFactorizationSession {
+                    backend: session_backend,
+                    #[cfg(feature = "cpu-faer")]
+                    par,
+                }),
+                _scope: PhantomData,
+            };
+            f(&mut session)
+        })
+    }
+}

--- a/crates/tenferro-linalg/src/prepared_svd.rs
+++ b/crates/tenferro-linalg/src/prepared_svd.rs
@@ -1,0 +1,704 @@
+use std::fmt;
+#[cfg(feature = "cpu-faer")]
+use std::mem::size_of;
+#[cfg(feature = "cpu-faer")]
+use std::sync::Arc;
+
+#[cfg(feature = "cpu-faer")]
+use faer::dyn_stack::{MemBuffer, MemStack, StackReq};
+#[cfg(feature = "cpu-faer")]
+use faer::{diag::DiagMut, MatMut, MatRef};
+#[cfg(feature = "cpu-faer")]
+use num_complex::{Complex32, Complex64};
+#[cfg(feature = "cpu-faer")]
+use tenferro_cpu::CpuLinalgBinding;
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+#[cfg(feature = "cpu-faer")]
+use tenferro_tensor::{
+    validate::checked_shape_product, MemoryKind, Tensor, TensorView, TensorViewMut, TypedTensor,
+    TypedTensorView, TypedTensorViewMut,
+};
+use tenferro_tensor::{BackendId, DType, Error, Placement, TensorRead, TensorWrite};
+
+use crate::prepared_factorization::{
+    private::PreparedFactorizationDispatch, PreparedFactorizationBackendExt,
+    PreparedFactorizationSession, PreparedFactorizationSessionInner,
+};
+use crate::{backend::LinalgBackend, SvdOptions};
+#[cfg(feature = "cpu-faer")]
+use crate::{
+    extension::{
+        canonicalize_svd_gauge_c32, canonicalize_svd_gauge_c64, canonicalize_svd_gauge_f32,
+        canonicalize_svd_gauge_f64, validate_derivative_eps,
+    },
+    SvdGauge,
+};
+
+const PREPARE_OP: &str = "prepare_svd";
+const EXECUTE_OP: &str = "PreparedSvd::execute_into";
+const PREPARED_CAPABILITY: &str = "prepared compact SVD";
+#[cfg(feature = "cpu-faer")]
+const BINDING_CAPABILITY: &str = "prepared SVD backend/context binding";
+#[cfg(feature = "cpu-faer")]
+const DESTINATION_CAPABILITY: &str = "compact column-major prepared SVD destination";
+
+/// Exact metadata for one prepared SVD output.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::{CpuBackend, CpuBackendKind};
+/// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+/// use tenferro_tensor::DType;
+///
+/// let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer)?;
+/// let plan = backend.prepare_svd([3, 2], DType::F64, SvdOptions::default())?;
+/// assert_eq!(plan.output_specs().u().shape(), &[3, 2]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SvdOutputSpec {
+    shape: Vec<usize>,
+    dtype: DType,
+    placement: Placement,
+}
+
+impl SvdOutputSpec {
+    /// Return the exact output shape.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// # let mut backend = CpuBackend::new();
+    /// # let plan = backend.prepare_svd([3, 2], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().u().shape(), &[3, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    /// Return the exact output dtype.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// # let mut backend = CpuBackend::new();
+    /// # let plan = backend.prepare_svd([2, 2], DType::C64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().s().dtype(), DType::F64);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn dtype(&self) -> DType {
+        self.dtype
+    }
+
+    /// Return the default host placement expected for a newly allocated output.
+    ///
+    /// Pinned host destinations are also accepted by execution.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::{DType, MemoryKind};
+    /// # let mut backend = CpuBackend::new();
+    /// # let plan = backend.prepare_svd([2, 2], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().u().placement().memory_kind, MemoryKind::UnpinnedHost);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn placement(&self) -> &Placement {
+        &self.placement
+    }
+}
+
+/// Output metadata for prepared compact SVD.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::{CpuBackend, CpuBackendKind};
+/// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+/// use tenferro_tensor::DType;
+///
+/// let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer)?;
+/// let plan = backend.prepare_svd([2, 4], DType::C64, SvdOptions::default())?;
+/// let specs = plan.output_specs();
+/// assert_eq!(specs.s().dtype(), DType::F64);
+/// assert_eq!(specs.vt().shape(), &[2, 4]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SvdOutputSpecs {
+    u: SvdOutputSpec,
+    s: SvdOutputSpec,
+    vt: SvdOutputSpec,
+}
+
+impl SvdOutputSpecs {
+    /// Return the left-singular-vector output specification.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// # let mut backend = CpuBackend::new();
+    /// # let plan = backend.prepare_svd([4, 2], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().u().shape(), &[4, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn u(&self) -> &SvdOutputSpec {
+        &self.u
+    }
+
+    /// Return the singular-value output specification.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// # let mut backend = CpuBackend::new();
+    /// # let plan = backend.prepare_svd([4, 2], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().s().shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn s(&self) -> &SvdOutputSpec {
+        &self.s
+    }
+
+    /// Return the conjugate-transposed right-singular-vector output specification.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// # let mut backend = CpuBackend::new();
+    /// # let plan = backend.prepare_svd([2, 4], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().vt().shape(), &[2, 4]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn vt(&self) -> &SvdOutputSpec {
+        &self.vt
+    }
+}
+
+/// Caller-provided writable outputs for compact SVD.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::SvdOutputWrites;
+/// use tenferro_tensor::{Tensor, TensorWrite};
+///
+/// let mut u = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+/// let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+/// let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+/// let writes = SvdOutputWrites::new(
+///     TensorWrite::from_tensor(&mut u),
+///     TensorWrite::from_tensor(&mut s),
+///     TensorWrite::from_tensor(&mut vt),
+/// );
+/// assert_eq!(writes.u().shape(), &[1, 1]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+#[derive(Debug)]
+pub struct SvdOutputWrites<'a> {
+    pub(crate) u: TensorWrite<'a>,
+    pub(crate) s: TensorWrite<'a>,
+    pub(crate) vt: TensorWrite<'a>,
+}
+
+impl<'a> SvdOutputWrites<'a> {
+    /// Bundle caller-owned `U`, `S`, and `Vt` destinations.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::SvdOutputWrites;
+    /// use tenferro_tensor::{Tensor, TensorWrite};
+    /// let mut u = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+    /// let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// let writes = SvdOutputWrites::new(
+    ///     TensorWrite::from_tensor(&mut u),
+    ///     TensorWrite::from_tensor(&mut s),
+    ///     TensorWrite::from_tensor(&mut vt),
+    /// );
+    /// assert_eq!(writes.s().shape(), &[1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn new(u: TensorWrite<'a>, s: TensorWrite<'a>, vt: TensorWrite<'a>) -> Self {
+        Self { u, s, vt }
+    }
+
+    /// Inspect the `U` destination without mutating it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_linalg::SvdOutputWrites;
+    /// # use tenferro_tensor::{Tensor, TensorWrite};
+    /// # let mut u = Tensor::from_vec_col_major(vec![2, 1], vec![0.0_f64; 2])?;
+    /// # let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+    /// # let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// # let writes = SvdOutputWrites::new(TensorWrite::from_tensor(&mut u), TensorWrite::from_tensor(&mut s), TensorWrite::from_tensor(&mut vt));
+    /// assert_eq!(writes.u().shape(), &[2, 1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn u(&self) -> &TensorWrite<'a> {
+        &self.u
+    }
+
+    /// Inspect the `S` destination without mutating it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_linalg::SvdOutputWrites;
+    /// # use tenferro_tensor::{Tensor, TensorWrite};
+    /// # let mut u = Tensor::from_vec_col_major(vec![2, 1], vec![0.0_f64; 2])?;
+    /// # let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+    /// # let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// # let writes = SvdOutputWrites::new(TensorWrite::from_tensor(&mut u), TensorWrite::from_tensor(&mut s), TensorWrite::from_tensor(&mut vt));
+    /// assert_eq!(writes.s().shape(), &[1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn s(&self) -> &TensorWrite<'a> {
+        &self.s
+    }
+
+    /// Inspect the `Vt` destination without mutating it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_linalg::SvdOutputWrites;
+    /// # use tenferro_tensor::{Tensor, TensorWrite};
+    /// # let mut u = Tensor::from_vec_col_major(vec![2, 1], vec![0.0_f64; 2])?;
+    /// # let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+    /// # let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// # let writes = SvdOutputWrites::new(TensorWrite::from_tensor(&mut u), TensorWrite::from_tensor(&mut s), TensorWrite::from_tensor(&mut vt));
+    /// assert_eq!(writes.vt().shape(), &[1, 1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn vt(&self) -> &TensorWrite<'a> {
+        &self.vt
+    }
+}
+
+/// Immutable prepared compact-SVD plan.
+///
+/// A plan binds shape, dtype, provider, execution context, and options. Allocate
+/// one workspace per concurrent execution lane.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::{CpuBackend, CpuBackendKind};
+/// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions, SvdOutputWrites};
+/// use tenferro_tensor::{DType, Tensor, TensorRead, TensorWrite};
+///
+/// let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer)?;
+/// let plan = backend.prepare_svd([2, 2], DType::F64, SvdOptions::default())?;
+/// let mut workspace = plan.allocate_workspace(&mut backend)?;
+/// let input = Tensor::from_vec_col_major(
+///     vec![2, 2],
+///     vec![3.0_f64, 0.0, 0.0, 2.0],
+/// )?;
+/// let mut u = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4])?;
+/// let mut s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2])?;
+/// let mut vt = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4])?;
+/// for _ in 0..2 {
+///     plan.execute_into(
+///         &mut backend,
+///         &mut workspace,
+///         TensorRead::from_tensor(&input),
+///         SvdOutputWrites::new(
+///             TensorWrite::from_tensor(&mut u),
+///             TensorWrite::from_tensor(&mut s),
+///             TensorWrite::from_tensor(&mut vt),
+///         ),
+///     )?;
+/// }
+/// assert_eq!(s.as_slice::<f64>()?, &[3.0, 2.0]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub struct PreparedSvd {
+    shape: [usize; 2],
+    dtype: DType,
+    options: SvdOptions,
+    specs: SvdOutputSpecs,
+    #[cfg(feature = "cpu-faer")]
+    binding: CpuFaerBinding,
+    #[cfg(feature = "cpu-faer")]
+    plan_token: Arc<()>,
+    #[cfg(feature = "cpu-faer")]
+    provider: FaerPlan,
+}
+
+impl fmt::Debug for PreparedSvd {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("PreparedSvd");
+        debug
+            .field("operation", &"compact_svd")
+            .field("shape", &self.shape)
+            .field("dtype", &self.dtype)
+            .field("options", &self.options)
+            .field("provider", &"faer")
+            .field("device", &"cpu");
+        #[cfg(feature = "cpu-faer")]
+        debug
+            .field("context", &self.binding)
+            .field("plan_retained_bytes", &self.retained_bytes())
+            .field(
+                "workspace_required_bytes",
+                &self.provider.workspace_required_bytes(self.shape),
+            );
+        debug.finish_non_exhaustive()
+    }
+}
+
+impl PreparedSvd {
+    /// Return the exact provider-private heap bytes currently retained by this plan.
+    ///
+    /// This read-only snapshot does not allocate or mutate the plan. It excludes
+    /// inline Rust object size, backend binding and identity-token metadata,
+    /// shared backend context, workspaces, and outputs. Values are provider
+    /// representations, so no ordering is promised across shapes, dtypes,
+    /// options, or providers.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// use tenferro_tensor::DType;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([3, 2], DType::F64, SvdOptions::default())?;
+    /// let plan_bytes = plan.retained_bytes();
+    /// assert_eq!(plan_bytes, plan.retained_bytes());
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn retained_bytes(&self) -> usize {
+        #[cfg(feature = "cpu-faer")]
+        {
+            self.provider.retained_bytes()
+        }
+        #[cfg(not(feature = "cpu-faer"))]
+        {
+            0
+        }
+    }
+
+    /// Return exact `U`, `S`, and `Vt` output metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// # let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([5, 3], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().s().shape(), &[3]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn output_specs(&self) -> &SvdOutputSpecs {
+        &self.specs
+    }
+
+    /// Allocate one opaque workspace bound to this plan and backend context.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([2, 2], DType::F64, SvdOptions::default())?;
+    /// let workspace = plan.allocate_workspace(&mut backend)?;
+    /// assert!(format!("{workspace:?}").contains("SvdWorkspace"));
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn allocate_workspace<B: PreparedSvdBackendExt>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<SvdWorkspace> {
+        private::PreparedSvdDispatch::allocate_svd_workspace_impl(backend, self)
+    }
+
+    /// Execute into caller-owned outputs, reusing the supplied workspace.
+    ///
+    /// All metadata and overlap checks complete before the first output write.
+    /// Once the provider call starts, a numerical provider failure may leave
+    /// destinations partially overwritten.
+    ///
+    /// `TensorRead` and `TensorWrite` descriptor construction is caller-owned
+    /// setup evaluated before this method is entered. In particular, creating
+    /// dynamic-rank shape and stride metadata may allocate.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions, SvdOutputWrites};
+    /// use tenferro_tensor::{DType, Tensor, TensorRead, TensorWrite};
+    /// let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([1, 1], DType::F64, SvdOptions::default())?;
+    /// let mut workspace = plan.allocate_workspace(&mut backend)?;
+    /// let input = Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f64])?;
+    /// let mut u = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+    /// let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// plan.execute_into(
+    ///     &mut backend,
+    ///     &mut workspace,
+    ///     TensorRead::from_tensor(&input),
+    ///     SvdOutputWrites::new(
+    ///         TensorWrite::from_tensor(&mut u),
+    ///         TensorWrite::from_tensor(&mut s),
+    ///         TensorWrite::from_tensor(&mut vt),
+    ///     ),
+    /// )?;
+    /// assert_eq!(s.as_slice::<f64>()?, &[2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn execute_into<B: PreparedSvdBackendExt>(
+        &self,
+        backend: &mut B,
+        workspace: &mut SvdWorkspace,
+        input: TensorRead<'_>,
+        outputs: SvdOutputWrites<'_>,
+    ) -> tenferro_tensor::Result<()> {
+        backend.with_prepared_factorization_session(move |session| {
+            self.execute_into_session(session, workspace, input, outputs)
+        })
+    }
+
+    /// Execute inside an already-entered prepared factorization session.
+    ///
+    /// This leaf operation does not reacquire backend resources or re-enter a
+    /// backend worker pool. All metadata and overlap checks complete before
+    /// the first output write.
+    ///
+    /// The prepared-leaf allocation boundary begins with already-constructed
+    /// `TensorRead` and `TensorWrite` descriptors. Creating dynamic-rank view
+    /// descriptors is caller setup and may allocate before function entry.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{
+    ///     PreparedFactorizationBackendExt, PreparedSvdBackendExt, SvdOptions,
+    ///     SvdOutputWrites,
+    /// };
+    /// use tenferro_tensor::{DType, Tensor, TensorRead, TensorWrite};
+    /// let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([1, 1], DType::F64, SvdOptions::default())?;
+    /// let mut workspace = plan.allocate_workspace(&mut backend)?;
+    /// let input = Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f64])?;
+    /// let mut u = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+    /// let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// backend.with_prepared_factorization_session(|session| {
+    ///     plan.execute_into_session(
+    ///         session,
+    ///         &mut workspace,
+    ///         TensorRead::from_tensor(&input),
+    ///         SvdOutputWrites::new(
+    ///             TensorWrite::from_tensor(&mut u),
+    ///             TensorWrite::from_tensor(&mut s),
+    ///             TensorWrite::from_tensor(&mut vt),
+    ///         ),
+    ///     )
+    /// })?;
+    /// assert_eq!(s.as_slice::<f64>()?, &[2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn execute_into_session(
+        &self,
+        session: &mut PreparedFactorizationSession<'_>,
+        workspace: &mut SvdWorkspace,
+        input: TensorRead<'_>,
+        outputs: SvdOutputWrites<'_>,
+    ) -> tenferro_tensor::Result<()> {
+        match &mut session.inner {
+            PreparedFactorizationSessionInner::Cpu(cpu_session) => {
+                cpu::execute_prepared_svd_into_session(cpu_session, self, workspace, input, outputs)
+            }
+        }
+    }
+}
+
+/// Opaque caller-owned mutable workspace for a [`PreparedSvd`].
+///
+/// The workspace is intentionally not `Clone`; pass it as `&mut` to enforce
+/// exclusive use and allocate another workspace for another concurrency lane.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::{CpuBackend, CpuBackendKind};
+/// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+/// use tenferro_tensor::DType;
+///
+/// let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer)?;
+/// let plan = backend.prepare_svd([2, 2], DType::F64, SvdOptions::default())?;
+/// let workspace = plan.allocate_workspace(&mut backend)?;
+/// assert!(format!("{workspace:?}").contains("workspace_retained_bytes"));
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub struct SvdWorkspace {
+    #[cfg(feature = "cpu-faer")]
+    binding: CpuFaerBinding,
+    shape: [usize; 2],
+    dtype: DType,
+    #[cfg(feature = "cpu-faer")]
+    plan_token: Arc<()>,
+    #[cfg(feature = "cpu-faer")]
+    inner: FaerWorkspace,
+}
+
+impl fmt::Debug for SvdWorkspace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_struct("SvdWorkspace");
+        debug
+            .field("operation", &"compact_svd")
+            .field("shape", &self.shape)
+            .field("dtype", &self.dtype)
+            .field("provider", &"faer")
+            .field("device", &"cpu");
+        #[cfg(feature = "cpu-faer")]
+        debug
+            .field("context", &self.binding)
+            .field("workspace_required_bytes", &self.inner.required_bytes())
+            .field("workspace_retained_bytes", &self.retained_bytes());
+        debug.finish_non_exhaustive()
+    }
+}
+
+impl SvdWorkspace {
+    /// Return the exact provider-private heap bytes currently retained by this workspace.
+    ///
+    /// This read-only snapshot does not allocate or mutate the workspace. It
+    /// includes provider scratch and staging capacities, but excludes inline
+    /// Rust object size, backend binding and identity-token metadata, shared
+    /// backend context, plans, and outputs. Values are provider representations,
+    /// so no ordering is promised across shapes, dtypes, options, or providers.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// use tenferro_tensor::DType;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([3, 2], DType::F64, SvdOptions::default())?;
+    /// let workspace = plan.allocate_workspace(&mut backend)?;
+    /// let workspace_bytes = workspace.retained_bytes();
+    /// assert_eq!(workspace_bytes, workspace.retained_bytes());
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn retained_bytes(&self) -> usize {
+        #[cfg(feature = "cpu-faer")]
+        {
+            self.inner.retained_bytes()
+        }
+        #[cfg(not(feature = "cpu-faer"))]
+        {
+            0
+        }
+    }
+}
+
+/// Backend capability for explicit prepared compact SVD execution.
+///
+/// Provider dispatch is sealed and required for every backend implementation.
+/// Unsupported implementations return an explicit capability error rather than
+/// calling an owned SVD or allocating replacement outputs as a fallback.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::{CpuBackend, CpuBackendKind};
+/// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+/// use tenferro_tensor::DType;
+///
+/// let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer)?;
+/// let plan = backend.prepare_svd([3, 2], DType::F64, SvdOptions::default())?;
+/// assert_eq!(plan.output_specs().s().shape(), &[2]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub trait PreparedSvdBackendExt:
+    private::PreparedSvdDispatch + PreparedFactorizationBackendExt
+{
+    /// Prepare compact SVD for one fixed rank-2 shape and dtype.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// use tenferro_tensor::DType;
+    /// let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([3, 2], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().u().shape(), &[3, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    fn prepare_svd(
+        &mut self,
+        shape: [usize; 2],
+        dtype: DType,
+        options: SvdOptions,
+    ) -> tenferro_tensor::Result<PreparedSvd> {
+        private::PreparedSvdDispatch::prepare_svd_impl(self, shape, dtype, options)
+    }
+}
+
+impl<T> PreparedSvdBackendExt for T where
+    T: private::PreparedSvdDispatch + PreparedFactorizationBackendExt
+{
+}
+
+mod private {
+    use super::*;
+
+    pub trait PreparedSvdDispatch: LinalgBackend + PreparedFactorizationDispatch {
+        fn prepare_svd_impl(
+            &mut self,
+            shape: [usize; 2],
+            dtype: DType,
+            options: SvdOptions,
+        ) -> tenferro_tensor::Result<PreparedSvd>;
+
+        fn allocate_svd_workspace_impl(
+            &mut self,
+            plan: &PreparedSvd,
+        ) -> tenferro_tensor::Result<SvdWorkspace>;
+    }
+}
+
+mod cpu;
+#[cfg(feature = "cpu-faer")]
+use cpu::CpuFaerBinding;
+
+#[cfg(feature = "cpu-faer")]
+mod faer_impl;
+#[cfg(feature = "cpu-faer")]
+use faer_impl::{execute_faer, FaerPlan, FaerWorkspace};

--- a/crates/tenferro-linalg/src/prepared_svd/cpu.rs
+++ b/crates/tenferro-linalg/src/prepared_svd/cpu.rs
@@ -1,0 +1,500 @@
+use super::*;
+
+#[cfg(feature = "cpu-faer")]
+pub(super) struct CpuFaerBinding {
+    resources: CpuLinalgBinding,
+}
+
+#[cfg(feature = "cpu-faer")]
+impl Clone for CpuFaerBinding {
+    fn clone(&self) -> Self {
+        Self {
+            resources: self.resources.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+impl fmt::Debug for CpuFaerBinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.resources.fmt(f)
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+impl CpuFaerBinding {
+    fn capture(backend: &CpuBackend) -> Self {
+        Self {
+            resources: backend.linalg_binding(),
+        }
+    }
+
+    fn validate(&self, backend: &CpuBackend, dtype: DType) -> tenferro_tensor::Result<()> {
+        if !self.resources.matches(backend) || backend.kind() != CpuBackendKind::Faer {
+            return Err(Error::unsupported_capability(
+                EXECUTE_OP,
+                BackendId::Cpu,
+                cpu_provider_name(backend.kind()),
+                dtype,
+                BINDING_CAPABILITY,
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+impl private::PreparedSvdDispatch for CpuBackend {
+    fn prepare_svd_impl(
+        &mut self,
+        shape: [usize; 2],
+        dtype: DType,
+        options: SvdOptions,
+    ) -> tenferro_tensor::Result<PreparedSvd> {
+        validate_derivative_eps(PREPARE_OP, options.derivative_eps)?;
+        if self.kind() != CpuBackendKind::Faer {
+            return Err(Error::unsupported_capability(
+                PREPARE_OP,
+                BackendId::Cpu,
+                cpu_provider_name(self.kind()),
+                dtype,
+                PREPARED_CAPABILITY,
+            ));
+        }
+        checked_shape_product(PREPARE_OP, "matrix shape", &shape)?;
+        for &extent in &shape {
+            isize::try_from(extent).map_err(|_| Error::InvalidConfig {
+                op: PREPARE_OP,
+                message: format!("matrix extent {extent} does not fit in isize"),
+            })?;
+        }
+        let singular_dtype = real_dtype(dtype)?;
+        let provider = FaerPlan::new(dtype, shape, self.linalg_context().faer_par())?;
+        let k = shape[0].min(shape[1]);
+        let placement = Placement {
+            memory_kind: MemoryKind::UnpinnedHost,
+            device: None,
+        };
+        let specs = SvdOutputSpecs {
+            u: SvdOutputSpec {
+                shape: vec![shape[0], k],
+                dtype,
+                placement: placement.clone(),
+            },
+            s: SvdOutputSpec {
+                shape: vec![k],
+                dtype: singular_dtype,
+                placement: placement.clone(),
+            },
+            vt: SvdOutputSpec {
+                shape: vec![k, shape[1]],
+                dtype,
+                placement,
+            },
+        };
+        Ok(PreparedSvd {
+            shape,
+            dtype,
+            options,
+            specs,
+            binding: CpuFaerBinding::capture(self),
+            plan_token: Arc::new(()),
+            provider,
+        })
+    }
+
+    fn allocate_svd_workspace_impl(
+        &mut self,
+        plan: &PreparedSvd,
+    ) -> tenferro_tensor::Result<SvdWorkspace> {
+        plan.binding.validate(self, plan.dtype)?;
+        let inner = plan.provider.allocate(plan.shape)?;
+        Ok(SvdWorkspace {
+            binding: plan.binding.clone(),
+            shape: plan.shape,
+            dtype: plan.dtype,
+            plan_token: Arc::clone(&plan.plan_token),
+            inner,
+        })
+    }
+}
+
+#[cfg(not(feature = "cpu-faer"))]
+impl private::PreparedSvdDispatch for CpuBackend {
+    fn prepare_svd_impl(
+        &mut self,
+        _shape: [usize; 2],
+        dtype: DType,
+        _options: SvdOptions,
+    ) -> tenferro_tensor::Result<PreparedSvd> {
+        Err(Error::unsupported_capability(
+            PREPARE_OP,
+            BackendId::Cpu,
+            cpu_provider_name(self.kind()),
+            dtype,
+            PREPARED_CAPABILITY,
+        ))
+    }
+
+    fn allocate_svd_workspace_impl(
+        &mut self,
+        plan: &PreparedSvd,
+    ) -> tenferro_tensor::Result<SvdWorkspace> {
+        Err(Error::unsupported_capability(
+            PREPARE_OP,
+            BackendId::Cpu,
+            cpu_provider_name(self.kind()),
+            plan.dtype,
+            PREPARED_CAPABILITY,
+        ))
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+pub(super) fn execute_prepared_svd_into_session(
+    session: &mut crate::prepared_factorization::CpuPreparedFactorizationSession,
+    plan: &PreparedSvd,
+    workspace: &mut SvdWorkspace,
+    input: TensorRead<'_>,
+    outputs: SvdOutputWrites<'_>,
+) -> tenferro_tensor::Result<()> {
+    let backend = &session.backend;
+    plan.binding.validate(backend, plan.dtype)?;
+    workspace.binding.validate(backend, workspace.dtype)?;
+    if !workspace.binding.resources.matches(backend)
+        || !plan.binding.resources.matches(backend)
+        || workspace.shape != plan.shape
+        || workspace.dtype != plan.dtype
+        || !Arc::ptr_eq(&workspace.plan_token, &plan.plan_token)
+    {
+        return Err(Error::unsupported_capability(
+            EXECUTE_OP,
+            BackendId::Cpu,
+            cpu_provider_name(backend.kind()),
+            plan.dtype,
+            BINDING_CAPABILITY,
+        ));
+    }
+    validate_execution(plan, &input, &outputs)?;
+    if plan.shape[0] == 0 || plan.shape[1] == 0 {
+        return Ok(());
+    }
+    execute_faer(plan, &mut workspace.inner, session.par, input, outputs)
+}
+
+#[cfg(not(feature = "cpu-faer"))]
+pub(super) fn execute_prepared_svd_into_session(
+    session: &mut crate::prepared_factorization::CpuPreparedFactorizationSession,
+    plan: &PreparedSvd,
+    _workspace: &mut SvdWorkspace,
+    _input: TensorRead<'_>,
+    _outputs: SvdOutputWrites<'_>,
+) -> tenferro_tensor::Result<()> {
+    Err(Error::unsupported_capability(
+        EXECUTE_OP,
+        BackendId::Cpu,
+        cpu_provider_name(session.backend.kind()),
+        plan.dtype,
+        PREPARED_CAPABILITY,
+    ))
+}
+
+#[cfg(feature = "cpu-faer")]
+fn real_dtype(dtype: DType) -> tenferro_tensor::Result<DType> {
+    match dtype {
+        DType::F32 | DType::C32 => Ok(DType::F32),
+        DType::F64 | DType::C64 => Ok(DType::F64),
+        _ => Err(Error::unsupported_capability(
+            PREPARE_OP,
+            BackendId::Cpu,
+            "faer",
+            dtype,
+            PREPARED_CAPABILITY,
+        )),
+    }
+}
+
+const fn cpu_provider_name(kind: CpuBackendKind) -> &'static str {
+    match kind {
+        CpuBackendKind::Faer => "faer",
+        CpuBackendKind::Blas => "blas",
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+fn validate_execution(
+    plan: &PreparedSvd,
+    input: &TensorRead<'_>,
+    outputs: &SvdOutputWrites<'_>,
+) -> tenferro_tensor::Result<()> {
+    if input.shape() != plan.shape || input.dtype() != plan.dtype {
+        return Err(Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: format!(
+                "input must have shape {:?} and dtype {:?}, got {:?} and {:?}",
+                plan.shape,
+                plan.dtype,
+                input.shape(),
+                input.dtype()
+            ),
+        });
+    }
+    validate_host_read(input)?;
+    validate_output(&outputs.u, &plan.specs.u, "U")?;
+    validate_output(&outputs.s, &plan.specs.s, "S")?;
+    validate_output(&outputs.vt, &plan.specs.vt, "Vt")?;
+
+    let input_region = read_region(input)?;
+    let u_region = write_region(&outputs.u)?;
+    let s_region = write_region(&outputs.s)?;
+    let vt_region = write_region(&outputs.vt)?;
+    validate_non_aliasing(input_region, u_region, s_region, vt_region)
+}
+
+#[cfg(feature = "cpu-faer")]
+fn validate_non_aliasing(
+    input_region: Option<ByteRegion>,
+    u_region: Option<ByteRegion>,
+    s_region: Option<ByteRegion>,
+    vt_region: Option<ByteRegion>,
+) -> tenferro_tensor::Result<()> {
+    for (lhs_name, lhs, rhs_name, rhs) in [
+        ("input", input_region, "U", u_region),
+        ("input", input_region, "S", s_region),
+        ("input", input_region, "Vt", vt_region),
+        ("U", u_region, "S", s_region),
+        ("U", u_region, "Vt", vt_region),
+        ("S", s_region, "Vt", vt_region),
+    ] {
+        if regions_overlap(lhs, rhs) {
+            return Err(Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: format!("{lhs_name} and {rhs_name} may overlap"),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(test, feature = "cpu-faer"))]
+mod tests;
+
+#[cfg(feature = "cpu-faer")]
+fn validate_output(
+    output: &TensorWrite<'_>,
+    spec: &SvdOutputSpec,
+    name: &str,
+) -> tenferro_tensor::Result<()> {
+    if output.shape() != spec.shape || output.dtype() != spec.dtype {
+        return Err(Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: format!(
+                "{name} must have shape {:?} and dtype {:?}, got {:?} and {:?}",
+                spec.shape,
+                spec.dtype,
+                output.shape(),
+                output.dtype()
+            ),
+        });
+    }
+    if !output.is_col_major_contiguous()? {
+        let _ = name;
+        return Err(Error::unsupported_capability(
+            EXECUTE_OP,
+            BackendId::Cpu,
+            "faer",
+            spec.dtype,
+            DESTINATION_CAPABILITY,
+        ));
+    }
+    // Why not duplicate writable-placement validation: prepared outputs are
+    // rank <= 2, so the shared read descriptor stays inside ShapeVec inline storage.
+    validate_host_read(&output.as_read())
+}
+
+#[cfg(feature = "cpu-faer")]
+fn validate_host_read(read: &TensorRead<'_>) -> tenferro_tensor::Result<()> {
+    let placement = read_placement(read);
+    if placement.device.is_some()
+        || !matches!(
+            placement.memory_kind,
+            MemoryKind::PinnedHost | MemoryKind::UnpinnedHost
+        )
+    {
+        return Err(Error::unsupported_capability(
+            EXECUTE_OP,
+            BackendId::Cpu,
+            "faer",
+            read.dtype(),
+            "host-resident prepared SVD storage",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "cpu-faer")]
+fn read_placement<'a>(read: &'a TensorRead<'_>) -> &'a Placement {
+    match read {
+        TensorRead::Tensor(tensor) => tensor.placement(),
+        TensorRead::View(view) => match view {
+            TensorView::F32(v) => v.placement(),
+            TensorView::F64(v) => v.placement(),
+            TensorView::I32(v) => v.placement(),
+            TensorView::I64(v) => v.placement(),
+            TensorView::Bool(v) => v.placement(),
+            TensorView::C32(v) => v.placement(),
+            TensorView::C64(v) => v.placement(),
+        },
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+#[derive(Clone, Copy)]
+struct ByteRegion {
+    start: usize,
+    end: usize,
+}
+
+#[cfg(feature = "cpu-faer")]
+fn regions_overlap(lhs: Option<ByteRegion>, rhs: Option<ByteRegion>) -> bool {
+    match (lhs, rhs) {
+        (Some(lhs), Some(rhs)) => lhs.start < rhs.end && rhs.start < lhs.end,
+        _ => false,
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+fn read_region(read: &TensorRead<'_>) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    macro_rules! region {
+        ($value:expr, $ty:ty) => {
+            typed_read_region::<$ty>($value)
+        };
+    }
+    match read {
+        TensorRead::Tensor(Tensor::F32(t)) => region!(TypedReadRef::Tensor(t), f32),
+        TensorRead::Tensor(Tensor::F64(t)) => region!(TypedReadRef::Tensor(t), f64),
+        TensorRead::Tensor(Tensor::I32(t)) => region!(TypedReadRef::Tensor(t), i32),
+        TensorRead::Tensor(Tensor::I64(t)) => region!(TypedReadRef::Tensor(t), i64),
+        TensorRead::Tensor(Tensor::Bool(t)) => region!(TypedReadRef::Tensor(t), bool),
+        TensorRead::Tensor(Tensor::C32(t)) => region!(TypedReadRef::Tensor(t), Complex32),
+        TensorRead::Tensor(Tensor::C64(t)) => region!(TypedReadRef::Tensor(t), Complex64),
+        TensorRead::View(TensorView::F32(v)) => region!(TypedReadRef::View(v), f32),
+        TensorRead::View(TensorView::F64(v)) => region!(TypedReadRef::View(v), f64),
+        TensorRead::View(TensorView::I32(v)) => region!(TypedReadRef::View(v), i32),
+        TensorRead::View(TensorView::I64(v)) => region!(TypedReadRef::View(v), i64),
+        TensorRead::View(TensorView::Bool(v)) => region!(TypedReadRef::View(v), bool),
+        TensorRead::View(TensorView::C32(v)) => region!(TypedReadRef::View(v), Complex32),
+        TensorRead::View(TensorView::C64(v)) => region!(TypedReadRef::View(v), Complex64),
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+fn write_region(write: &TensorWrite<'_>) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    // Why not add a second writable-region walker: rank <= 2 descriptor clones
+    // stay inline, while this keeps one alias-analysis authority.
+    read_region(&write.as_read())
+}
+
+#[cfg(feature = "cpu-faer")]
+enum TypedReadRef<'a, T> {
+    Tensor(&'a TypedTensor<T>),
+    View(&'a TypedTensorView<'a, T>),
+}
+
+#[cfg(feature = "cpu-faer")]
+fn typed_read_region<T: Clone + 'static>(
+    read: TypedReadRef<'_, T>,
+) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    let (base, shape, strides, offset) = match read {
+        TypedReadRef::Tensor(tensor) => {
+            let data = tensor.host_data()?;
+            return byte_region(data.as_ptr(), 0, data.len(), size_of::<T>());
+        }
+        TypedReadRef::View(view) => (
+            view.host_storage()?.as_ptr(),
+            view.shape(),
+            view.strides(),
+            view.offset(),
+        ),
+    };
+    if shape.contains(&0) {
+        return Ok(None);
+    }
+    let mut min = offset;
+    let mut max = offset;
+    for (&extent, &stride) in shape.iter().zip(strides.iter()) {
+        let span = isize::try_from(extent - 1)
+            .ok()
+            .and_then(|extent| extent.checked_mul(stride))
+            .ok_or_else(|| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "input layout span overflows isize".to_owned(),
+            })?;
+        min = min
+            .checked_add(span.min(0))
+            .ok_or_else(|| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "input layout lower bound overflows isize".to_owned(),
+            })?;
+        max = max
+            .checked_add(span.max(0))
+            .ok_or_else(|| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "input layout upper bound overflows isize".to_owned(),
+            })?;
+    }
+    let start = usize::try_from(min).map_err(|_| Error::InvalidConfig {
+        op: EXECUTE_OP,
+        message: "input layout lower bound is negative".to_owned(),
+    })?;
+    let span = max
+        .checked_sub(min)
+        .and_then(|span| span.checked_add(1))
+        .ok_or_else(|| Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: "input layout range overflows isize".to_owned(),
+        })?;
+    let len = usize::try_from(span).map_err(|_| Error::InvalidConfig {
+        op: EXECUTE_OP,
+        message: "input layout range does not fit usize".to_owned(),
+    })?;
+    byte_region(base, start, len, size_of::<T>())
+}
+
+#[cfg(feature = "cpu-faer")]
+fn byte_region<T>(
+    base: *const T,
+    element_offset: usize,
+    element_len: usize,
+    element_size: usize,
+) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    if element_len == 0 {
+        return Ok(None);
+    }
+    let byte_offset =
+        element_offset
+            .checked_mul(element_size)
+            .ok_or_else(|| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "storage byte offset overflows usize".to_owned(),
+            })?;
+    let byte_len = element_len
+        .checked_mul(element_size)
+        .ok_or_else(|| Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: "storage byte length overflows usize".to_owned(),
+        })?;
+    let start = (base as usize)
+        .checked_add(byte_offset)
+        .ok_or_else(|| Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: "storage address range overflows usize".to_owned(),
+        })?;
+    let end = start
+        .checked_add(byte_len)
+        .ok_or_else(|| Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: "storage address range overflows usize".to_owned(),
+        })?;
+    Ok(Some(ByteRegion { start, end }))
+}

--- a/crates/tenferro-linalg/src/prepared_svd/cpu/tests.rs
+++ b/crates/tenferro-linalg/src/prepared_svd/cpu/tests.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+#[test]
+fn numeric_regions_reject_all_six_alias_pairs_without_touching_sentinels() {
+    let separate = [
+        ByteRegion { start: 0, end: 16 },
+        ByteRegion { start: 32, end: 48 },
+        ByteRegion { start: 64, end: 72 },
+        ByteRegion {
+            start: 96,
+            end: 104,
+        },
+    ];
+    for (expected, lhs, rhs) in [
+        ("input and U", 0, 1),
+        ("input and S", 0, 2),
+        ("input and Vt", 0, 3),
+        ("U and S", 1, 2),
+        ("U and Vt", 1, 3),
+        ("S and Vt", 2, 3),
+    ] {
+        let mut regions = separate;
+        regions[rhs] = regions[lhs];
+        let sentinels = [11_u8, 22, 33];
+        let error = validate_non_aliasing(
+            Some(regions[0]),
+            Some(regions[1]),
+            Some(regions[2]),
+            Some(regions[3]),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains(expected));
+        assert_eq!(sentinels, [11, 22, 33]);
+    }
+}

--- a/crates/tenferro-linalg/src/prepared_svd/faer_impl.rs
+++ b/crates/tenferro-linalg/src/prepared_svd/faer_impl.rs
@@ -1,0 +1,580 @@
+use super::*;
+
+pub(super) enum FaerPlan {
+    F32(StackReq),
+    F64(StackReq),
+    C32(StackReq),
+    C64(StackReq),
+}
+
+impl FaerPlan {
+    pub(super) fn new(
+        dtype: DType,
+        shape: [usize; 2],
+        par: faer::Par,
+    ) -> tenferro_tensor::Result<Self> {
+        let [m, n] = shape;
+        let req = match dtype {
+            DType::F32 => Self::F32(faer::linalg::svd::svd_scratch::<f32>(
+                m,
+                n,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                par,
+                Default::default(),
+            )),
+            DType::F64 => Self::F64(faer::linalg::svd::svd_scratch::<f64>(
+                m,
+                n,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                par,
+                Default::default(),
+            )),
+            DType::C32 => Self::C32(faer::linalg::svd::svd_scratch::<faer::c32>(
+                m,
+                n,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                par,
+                Default::default(),
+            )),
+            DType::C64 => Self::C64(faer::linalg::svd::svd_scratch::<faer::c64>(
+                m,
+                n,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                par,
+                Default::default(),
+            )),
+            _ => return Err(Error::backend_failure(PREPARE_OP, "unsupported SVD dtype")),
+        };
+        Ok(req)
+    }
+
+    pub(super) const fn retained_bytes(&self) -> usize {
+        // StackReq is inline metadata; tensor-sized storage belongs to SvdWorkspace.
+        0
+    }
+
+    pub(super) fn workspace_required_bytes(&self, shape: [usize; 2]) -> usize {
+        match self {
+            Self::F32(req) => required_bytes::<f32, f32>(*req, shape, false),
+            Self::F64(req) => required_bytes::<f64, f64>(*req, shape, false),
+            Self::C32(req) => required_bytes::<Complex32, faer::c32>(*req, shape, true),
+            Self::C64(req) => required_bytes::<Complex64, faer::c64>(*req, shape, true),
+        }
+    }
+
+    pub(super) fn allocate(&self, shape: [usize; 2]) -> tenferro_tensor::Result<FaerWorkspace> {
+        macro_rules! alloc {
+            ($variant:ident, $req:expr, $input:ty, $faer:ty, $stage_singular:expr) => {
+                Ok(FaerWorkspace::$variant(
+                    FaerTypedWorkspace::<$input, $faer>::new(*$req, shape, $stage_singular)?,
+                ))
+            };
+        }
+        match self {
+            Self::F32(req) => alloc!(F32, req, f32, f32, false),
+            Self::F64(req) => alloc!(F64, req, f64, f64, false),
+            Self::C32(req) => alloc!(C32, req, Complex32, faer::c32, true),
+            Self::C64(req) => alloc!(C64, req, Complex64, faer::c64, true),
+        }
+    }
+}
+
+pub(super) enum FaerWorkspace {
+    F32(FaerTypedWorkspace<f32, f32>),
+    F64(FaerTypedWorkspace<f64, f64>),
+    C32(FaerTypedWorkspace<Complex32, faer::c32>),
+    C64(FaerTypedWorkspace<Complex64, faer::c64>),
+}
+
+impl FaerWorkspace {
+    pub(super) fn required_bytes(&self) -> usize {
+        match self {
+            Self::F32(w) => w.required_bytes(),
+            Self::F64(w) => w.required_bytes(),
+            Self::C32(w) => w.required_bytes(),
+            Self::C64(w) => w.required_bytes(),
+        }
+    }
+
+    pub(super) fn retained_bytes(&self) -> usize {
+        match self {
+            Self::F32(w) => w.retained_bytes(),
+            Self::F64(w) => w.retained_bytes(),
+            Self::C32(w) => w.retained_bytes(),
+            Self::C64(w) => w.retained_bytes(),
+        }
+    }
+}
+
+pub(super) struct FaerTypedWorkspace<T, F> {
+    scratch: MemBuffer,
+    packed: Vec<T>,
+    singular: Vec<F>,
+    v: Vec<F>,
+}
+
+impl<T: Default + Clone, F: Default + Clone> FaerTypedWorkspace<T, F> {
+    fn new(
+        req: StackReq,
+        [m, n]: [usize; 2],
+        stage_singular: bool,
+    ) -> tenferro_tensor::Result<Self> {
+        let matrix_len = checked_shape_product(PREPARE_OP, "input pack", &[m, n])?;
+        let k = m.min(n);
+        let v_len = checked_shape_product(PREPARE_OP, "right singular vectors", &[n, k])?;
+        let scratch = MemBuffer::try_new(req).map_err(|err| {
+            Error::backend_failure(PREPARE_OP, format!("Faer scratch allocation failed: {err}"))
+        })?;
+        Ok(Self {
+            scratch,
+            packed: vec![T::default(); matrix_len],
+            singular: vec![F::default(); if stage_singular { k } else { 0 }],
+            v: vec![F::default(); v_len],
+        })
+    }
+
+    fn retained_bytes(&self) -> usize {
+        self.scratch.len()
+            + self.packed.capacity() * size_of::<T>()
+            + self.singular.capacity() * size_of::<F>()
+            + self.v.capacity() * size_of::<F>()
+    }
+
+    fn required_bytes(&self) -> usize {
+        self.scratch.len()
+            + self.packed.len() * size_of::<T>()
+            + self.singular.len() * size_of::<F>()
+            + self.v.len() * size_of::<F>()
+    }
+}
+
+fn required_bytes<T, F>(req: StackReq, [m, n]: [usize; 2], stage_singular: bool) -> usize {
+    let k = m.min(n);
+    req.size_bytes()
+        .saturating_add(m.saturating_mul(n).saturating_mul(size_of::<T>()))
+        .saturating_add(
+            usize::from(stage_singular)
+                .saturating_mul(k)
+                .saturating_mul(size_of::<F>()),
+        )
+        .saturating_add(n.saturating_mul(k).saturating_mul(size_of::<F>()))
+}
+
+pub(super) fn execute_faer(
+    plan: &PreparedSvd,
+    workspace: &mut FaerWorkspace,
+    par: faer::Par,
+    input: TensorRead<'_>,
+    outputs: SvdOutputWrites<'_>,
+) -> tenferro_tensor::Result<()> {
+    match plan.dtype {
+        DType::F32 => execute_f32(plan, workspace, par, input, outputs),
+        DType::F64 => execute_f64(plan, workspace, par, input, outputs),
+        DType::C32 => execute_c32(plan, workspace, par, input, outputs),
+        DType::C64 => execute_c64(plan, workspace, par, input, outputs),
+        _ => Err(Error::backend_failure(
+            EXECUTE_OP,
+            "unsupported prepared SVD dtype",
+        )),
+    }
+}
+
+// INVARIANT: variants stay inline because boxing a view would allocate on every warm call.
+#[allow(clippy::large_enum_variant)]
+enum PreparedRead<'a, T> {
+    Tensor(&'a TypedTensor<T>),
+    View(TypedTensorView<'a, T>),
+}
+
+// INVARIANT: output variants stay inline because boxing would violate allocation-free reuse.
+#[allow(clippy::large_enum_variant)]
+enum PreparedWrite<'a, T> {
+    Tensor(&'a mut TypedTensor<T>),
+    View(TypedTensorViewMut<'a, T>),
+}
+
+macro_rules! impl_dtype_dispatch {
+    (
+        $fn_name:ident,
+        $workspace_variant:ident,
+        $tensor_variant:ident,
+        $view_variant:ident,
+        $scalar:ty,
+        $real_tensor_variant:ident,
+        $real_view_variant:ident,
+        $real:ty
+    ) => {
+        fn $fn_name(
+            plan: &PreparedSvd,
+            workspace: &mut FaerWorkspace,
+            par: faer::Par,
+            input: TensorRead<'_>,
+            outputs: SvdOutputWrites<'_>,
+        ) -> tenferro_tensor::Result<()> {
+            let input = match input {
+                TensorRead::Tensor(Tensor::$tensor_variant(tensor)) => PreparedRead::Tensor(tensor),
+                TensorRead::View(TensorView::$view_variant(view)) => PreparedRead::View(view),
+                _ => {
+                    return Err(Error::backend_failure(
+                        EXECUTE_OP,
+                        "validated input dtype changed",
+                    ));
+                }
+            };
+            let SvdOutputWrites { u, s, vt } = outputs;
+            let u = match u {
+                TensorWrite::Tensor(Tensor::$tensor_variant(tensor)) => {
+                    PreparedWrite::Tensor(tensor)
+                }
+                TensorWrite::View(TensorViewMut::$view_variant(view)) => PreparedWrite::View(view),
+                _ => {
+                    return Err(Error::backend_failure(
+                        EXECUTE_OP,
+                        "validated U dtype changed",
+                    ));
+                }
+            };
+            let s = match s {
+                TensorWrite::Tensor(Tensor::$real_tensor_variant(tensor)) => {
+                    PreparedWrite::Tensor(tensor)
+                }
+                TensorWrite::View(TensorViewMut::$real_view_variant(view)) => {
+                    PreparedWrite::View(view)
+                }
+                _ => {
+                    return Err(Error::backend_failure(
+                        EXECUTE_OP,
+                        "validated S dtype changed",
+                    ));
+                }
+            };
+            let vt = match vt {
+                TensorWrite::Tensor(Tensor::$tensor_variant(tensor)) => {
+                    PreparedWrite::Tensor(tensor)
+                }
+                TensorWrite::View(TensorViewMut::$view_variant(view)) => PreparedWrite::View(view),
+                _ => {
+                    return Err(Error::backend_failure(
+                        EXECUTE_OP,
+                        "validated Vt dtype changed",
+                    ));
+                }
+            };
+            match workspace {
+                FaerWorkspace::$workspace_variant(workspace) => {
+                    execute_typed::<$scalar, $real>(plan, workspace, par, input, u, s, vt)
+                }
+                _ => Err(Error::backend_failure(
+                    EXECUTE_OP,
+                    "validated workspace dtype changed",
+                )),
+            }
+        }
+    };
+}
+
+impl_dtype_dispatch!(execute_f32, F32, F32, F32, f32, F32, F32, f32);
+impl_dtype_dispatch!(execute_f64, F64, F64, F64, f64, F64, F64, f64);
+impl_dtype_dispatch!(execute_c32, C32, C32, C32, Complex32, F32, F32, f32);
+impl_dtype_dispatch!(execute_c64, C64, C64, C64, Complex64, F64, F64, f64);
+
+trait PreparedSvdScalar<R>: Copy + Default + Send + Sync + 'static {
+    type Faer: Copy + Default;
+
+    fn copy_singular(staging: &[Self::Faer], output: &mut [R]);
+    fn conjugated_output(value: Self::Faer) -> Self;
+    fn apply_gauge(
+        gauge: SvdGauge,
+        u: &mut [Self],
+        vt: &mut [Self],
+        m: usize,
+        k: usize,
+        n: usize,
+    ) -> tenferro_tensor::Result<()>;
+    // INVARIANT: raw regions and dimensions stay explicit so alias and layout contracts remain
+    // reviewable at the backend boundary; bundling them would hide the unsafe preconditions.
+    #[allow(clippy::too_many_arguments)]
+    fn run_svd(
+        input: *const Self,
+        row_stride: isize,
+        col_stride: isize,
+        u: *mut Self,
+        singular_output: &mut [R],
+        singular_staging: &mut [Self::Faer],
+        v: &mut [Self::Faer],
+        m: usize,
+        n: usize,
+        k: usize,
+        par: faer::Par,
+        scratch: &mut MemBuffer,
+    ) -> tenferro_tensor::Result<()>;
+}
+
+macro_rules! impl_real_prepared_scalar {
+    ($ty:ty, $gauge_fn:ident) => {
+        impl PreparedSvdScalar<$ty> for $ty {
+            type Faer = $ty;
+
+            fn copy_singular(_staging: &[Self::Faer], _output: &mut [$ty]) {}
+
+            fn conjugated_output(value: Self::Faer) -> Self {
+                value
+            }
+
+            fn run_svd(
+                input: *const Self,
+                row_stride: isize,
+                col_stride: isize,
+                u: *mut Self,
+                singular_output: &mut [$ty],
+                _singular_staging: &mut [Self::Faer],
+                v: &mut [Self::Faer],
+                m: usize,
+                n: usize,
+                k: usize,
+                par: faer::Par,
+                scratch: &mut MemBuffer,
+            ) -> tenferro_tensor::Result<()> {
+                // INVARIANT: input pointer and signed strides describe the validated matrix span.
+                // SAFETY: prepared preflight validates all input/output layouts and aliasing.
+                let input = unsafe { MatRef::from_raw_parts(input, m, n, row_stride, col_stride) };
+                // INVARIANT: `u` is compact column-major and disjoint from every other region.
+                // SAFETY: `u` points to a compact, non-overlapping `m x k` destination.
+                let u = unsafe { MatMut::from_raw_parts_mut(u, m, k, 1, m as isize) };
+                let singular = DiagMut::from_slice_mut(singular_output);
+                let v = MatMut::from_column_major_slice_mut(v, n, k);
+                faer::linalg::svd::svd(
+                    input,
+                    singular,
+                    Some(u),
+                    Some(v),
+                    par,
+                    MemStack::new(scratch),
+                    Default::default(),
+                )
+                .map_err(|_| Error::backend_failure(EXECUTE_OP, "Faer SVD decomposition failed"))
+            }
+
+            fn apply_gauge(
+                gauge: SvdGauge,
+                u: &mut [Self],
+                vt: &mut [Self],
+                m: usize,
+                k: usize,
+                n: usize,
+            ) -> tenferro_tensor::Result<()> {
+                if gauge == SvdGauge::Raw {
+                    return Ok(());
+                }
+                $gauge_fn(u, vt, m, k, n, 1)
+            }
+        }
+    };
+}
+
+impl_real_prepared_scalar!(f32, canonicalize_svd_gauge_f32);
+impl_real_prepared_scalar!(f64, canonicalize_svd_gauge_f64);
+
+macro_rules! impl_complex_prepared_scalar {
+    ($complex:ty, $faer:ty, $real:ty, $gauge_fn:ident) => {
+        const _: () = {
+            assert!(size_of::<$complex>() == size_of::<$faer>());
+            assert!(std::mem::align_of::<$complex>() == std::mem::align_of::<$faer>());
+            assert!(std::mem::offset_of!($complex, re) == std::mem::offset_of!($faer, re));
+            assert!(std::mem::offset_of!($complex, im) == std::mem::offset_of!($faer, im));
+        };
+
+        impl PreparedSvdScalar<$real> for $complex {
+            type Faer = $faer;
+
+            fn copy_singular(staging: &[Self::Faer], output: &mut [$real]) {
+                for (dst, value) in output.iter_mut().zip(staging) {
+                    *dst = value.re;
+                }
+            }
+
+            fn conjugated_output(value: Self::Faer) -> Self {
+                Self::new(value.re, -value.im)
+            }
+
+            fn run_svd(
+                input: *const Self,
+                row_stride: isize,
+                col_stride: isize,
+                u: *mut Self,
+                _singular_output: &mut [$real],
+                singular_staging: &mut [Self::Faer],
+                v: &mut [Self::Faer],
+                m: usize,
+                n: usize,
+                k: usize,
+                par: faer::Par,
+                scratch: &mut MemBuffer,
+            ) -> tenferro_tensor::Result<()> {
+                // INVARIANT: the complex ABI assertions and validated strides remain fixed.
+                // SAFETY: compile-time layout assertions above prove compatible complex scalars;
+                // prepared preflight validates all input/output layouts and aliasing.
+                let input = unsafe {
+                    MatRef::from_raw_parts(input.cast::<$faer>(), m, n, row_stride, col_stride)
+                };
+                // INVARIANT: `u` is compact column-major and disjoint from every other region.
+                // SAFETY: `u` points to a compact, non-overlapping `m x k` destination.
+                let u =
+                    unsafe { MatMut::from_raw_parts_mut(u.cast::<$faer>(), m, k, 1, m as isize) };
+                let singular = DiagMut::from_slice_mut(singular_staging);
+                let v = MatMut::from_column_major_slice_mut(v, n, k);
+                faer::linalg::svd::svd(
+                    input,
+                    singular,
+                    Some(u),
+                    Some(v),
+                    par,
+                    MemStack::new(scratch),
+                    Default::default(),
+                )
+                .map_err(|_| Error::backend_failure(EXECUTE_OP, "Faer SVD decomposition failed"))
+            }
+
+            fn apply_gauge(
+                gauge: SvdGauge,
+                u: &mut [Self],
+                vt: &mut [Self],
+                m: usize,
+                k: usize,
+                n: usize,
+            ) -> tenferro_tensor::Result<()> {
+                if gauge == SvdGauge::Raw {
+                    return Ok(());
+                }
+                $gauge_fn(u, vt, m, k, n, 1)
+            }
+        }
+    };
+}
+
+impl_complex_prepared_scalar!(Complex32, faer::c32, f32, canonicalize_svd_gauge_c32);
+impl_complex_prepared_scalar!(Complex64, faer::c64, f64, canonicalize_svd_gauge_c64);
+
+fn execute_typed<T, R>(
+    plan: &PreparedSvd,
+    workspace: &mut FaerTypedWorkspace<T, T::Faer>,
+    par: faer::Par,
+    input: PreparedRead<'_, T>,
+    mut u: PreparedWrite<'_, T>,
+    mut s: PreparedWrite<'_, R>,
+    mut vt: PreparedWrite<'_, T>,
+) -> tenferro_tensor::Result<()>
+where
+    T: PreparedSvdScalar<R>,
+    R: Copy + Default + 'static,
+{
+    let [m, n] = plan.shape;
+    let k = m.min(n);
+    let (input_ptr, row_stride, col_stride) =
+        prepared_input_parts::<T, R>(&input, workspace, m, n)?;
+    let u_slice = prepared_write_slice(&mut u)?;
+    let s_slice = prepared_write_slice(&mut s)?;
+    let vt_slice = prepared_write_slice(&mut vt)?;
+    T::run_svd(
+        input_ptr,
+        row_stride,
+        col_stride,
+        u_slice.as_mut_ptr(),
+        s_slice,
+        workspace.singular.as_mut_slice(),
+        workspace.v.as_mut_slice(),
+        m,
+        n,
+        k,
+        par,
+        &mut workspace.scratch,
+    )?;
+
+    T::copy_singular(workspace.singular.as_slice(), s_slice);
+    for col in 0..n {
+        for row in 0..k {
+            vt_slice[row + k * col] = T::conjugated_output(workspace.v[col + n * row]);
+        }
+    }
+    T::apply_gauge(plan.options.gauge, u_slice, vt_slice, m, k, n)?;
+    Ok(())
+}
+
+fn prepared_input_parts<T, R>(
+    input: &PreparedRead<'_, T>,
+    workspace: &mut FaerTypedWorkspace<T, T::Faer>,
+    m: usize,
+    n: usize,
+) -> tenferro_tensor::Result<(*const T, isize, isize)>
+where
+    T: PreparedSvdScalar<R>,
+{
+    match input {
+        PreparedRead::Tensor(tensor) => Ok((tensor.host_data()?.as_ptr(), 1, m as isize)),
+        PreparedRead::View(view) if view.strides().iter().all(|&stride| stride > 0) => {
+            let storage = view.host_storage()?;
+            let offset = usize::try_from(view.offset()).map_err(|_| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "input view offset is negative".to_owned(),
+            })?;
+            Ok((
+                storage.as_ptr().wrapping_add(offset),
+                view.strides()[0],
+                view.strides()[1],
+            ))
+        }
+        PreparedRead::View(view) => {
+            let storage = view.host_storage()?;
+            let row_stride = view.strides()[0];
+            let col_stride = view.strides()[1];
+            let base = view.offset();
+            for col in 0..n {
+                for row in 0..m {
+                    let row_offset = isize::try_from(row)
+                        .ok()
+                        .and_then(|row| row.checked_mul(row_stride));
+                    let col_offset = isize::try_from(col)
+                        .ok()
+                        .and_then(|col| col.checked_mul(col_stride));
+                    let offset = row_offset
+                        .and_then(|row| col_offset.and_then(|col| row.checked_add(col)))
+                        .and_then(|delta| base.checked_add(delta))
+                        .and_then(|offset| usize::try_from(offset).ok())
+                        .ok_or_else(|| Error::InvalidConfig {
+                            op: EXECUTE_OP,
+                            message: "input view offset overflows during prepared packing"
+                                .to_owned(),
+                        })?;
+                    workspace.packed[row + m * col] = storage[offset];
+                }
+            }
+            Ok((workspace.packed.as_ptr(), 1, m as isize))
+        }
+    }
+}
+
+fn prepared_write_slice<'a, T: Clone + 'static>(
+    write: &'a mut PreparedWrite<'_, T>,
+) -> tenferro_tensor::Result<&'a mut [T]> {
+    match write {
+        PreparedWrite::Tensor(tensor) => tensor.host_data_mut(),
+        PreparedWrite::View(view) => {
+            let offset = usize::try_from(view.offset()).map_err(|_| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "output view offset is negative".to_owned(),
+            })?;
+            let len = checked_shape_product(EXECUTE_OP, "output shape", view.shape())?;
+            let end = offset
+                .checked_add(len)
+                .ok_or_else(|| Error::InvalidConfig {
+                    op: EXECUTE_OP,
+                    message: "output view range overflows usize".to_owned(),
+                })?;
+            Ok(&mut view.host_storage_mut()?[offset..end])
+        }
+    }
+}

--- a/crates/tenferro-linalg/tests/prepared_svd.rs
+++ b/crates/tenferro-linalg/tests/prepared_svd.rs
@@ -1,0 +1,1250 @@
+use num_complex::{Complex32, Complex64};
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+use tenferro_linalg::{
+    LinalgBackend, PreparedFactorizationBackendExt, PreparedSvdBackendExt, SvdGauge, SvdOptions,
+    SvdOutputWrites,
+};
+use tenferro_tensor::{
+    BackendId, DType, DeviceId, DeviceKind, Error, GpuBackendKind, MemoryKind, Placement, Tensor,
+    TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensorView, TypedTensorViewMut,
+};
+
+fn f64_outputs(m: usize, n: usize, fill: f64) -> (Tensor, Tensor, Tensor) {
+    let k = m.min(n);
+    (
+        Tensor::from_vec_col_major(vec![m, k], vec![fill; m * k]).unwrap(),
+        Tensor::from_vec_col_major(vec![k], vec![fill; k]).unwrap(),
+        Tensor::from_vec_col_major(vec![k, n], vec![fill; k * n]).unwrap(),
+    )
+}
+
+fn set_tensor_placement(tensor: &mut Tensor, placement: Placement) {
+    match tensor {
+        Tensor::F32(tensor) => tensor.set_placement(placement),
+        Tensor::F64(tensor) => tensor.set_placement(placement),
+        Tensor::I32(tensor) => tensor.set_placement(placement),
+        Tensor::I64(tensor) => tensor.set_placement(placement),
+        Tensor::Bool(tensor) => tensor.set_placement(placement),
+        Tensor::C32(tensor) => tensor.set_placement(placement),
+        Tensor::C64(tensor) => tensor.set_placement(placement),
+    }
+}
+
+fn prepared_execution_error(
+    backend: &mut CpuBackend,
+    plan: &tenferro_linalg::PreparedSvd,
+    workspace: &mut tenferro_linalg::SvdWorkspace,
+    input: &Tensor,
+    mut u: Tensor,
+    mut s: Tensor,
+    mut vt: Tensor,
+) -> Error {
+    let error = plan
+        .execute_into(
+            backend,
+            workspace,
+            TensorRead::from_tensor(input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap_err();
+    for output in [&u, &s, &vt] {
+        match output.dtype() {
+            DType::F64 => assert!(output.as_slice::<f64>().unwrap().iter().all(|&x| x == 41.0)),
+            DType::F32 => assert!(output.as_slice::<f32>().unwrap().iter().all(|&x| x == 41.0)),
+            dtype => panic!("unexpected validation-test dtype {dtype:?}"),
+        }
+    }
+    error
+}
+
+fn assert_f64_svd_residual(input: &[f64], u: &[f64], s: &[f64], vt: &[f64], m: usize, n: usize) {
+    let k = m.min(n);
+    let mut max_reconstruction = 0.0_f64;
+    for col in 0..n {
+        for row in 0..m {
+            let mut reconstructed = 0.0;
+            for inner in 0..k {
+                reconstructed += u[row + m * inner] * s[inner] * vt[inner + k * col];
+            }
+            max_reconstruction =
+                max_reconstruction.max((reconstructed - input[row + m * col]).abs());
+        }
+    }
+    let mut max_orthogonality = 0.0_f64;
+    for lhs in 0..k {
+        for rhs in 0..k {
+            let mut dot = 0.0;
+            for row in 0..m {
+                dot += u[row + m * lhs] * u[row + m * rhs];
+            }
+            let expected = if lhs == rhs { 1.0 } else { 0.0 };
+            max_orthogonality = max_orthogonality.max((dot - expected).abs());
+        }
+    }
+    let mut max_vt_orthogonality = 0.0_f64;
+    for lhs in 0..k {
+        for rhs in 0..k {
+            let mut dot = 0.0;
+            for col in 0..n {
+                dot += vt[lhs + k * col] * vt[rhs + k * col];
+            }
+            let expected = if lhs == rhs { 1.0 } else { 0.0 };
+            max_vt_orthogonality = max_vt_orthogonality.max((dot - expected).abs());
+        }
+    }
+    assert!(
+        max_reconstruction < 1.0e-10,
+        "reconstruction residual {max_reconstruction}"
+    );
+    assert!(
+        max_orthogonality < 1.0e-10,
+        "U orthogonality residual {max_orthogonality}"
+    );
+    assert!(
+        max_vt_orthogonality < 1.0e-10,
+        "Vt row orthogonality residual {max_vt_orthogonality}"
+    );
+}
+
+fn assert_c64_svd_residual(
+    input: &[Complex64],
+    u: &[Complex64],
+    s: &[f64],
+    vt: &[Complex64],
+    m: usize,
+    n: usize,
+    tolerance: f64,
+) {
+    let k = m.min(n);
+    let mut max_reconstruction = 0.0_f64;
+    for col in 0..n {
+        for row in 0..m {
+            let mut reconstructed = Complex64::new(0.0, 0.0);
+            for inner in 0..k {
+                reconstructed += u[row + m * inner] * s[inner] * vt[inner + k * col];
+            }
+            max_reconstruction =
+                max_reconstruction.max((reconstructed - input[row + m * col]).norm());
+        }
+    }
+    let mut max_orthogonality = 0.0_f64;
+    for lhs in 0..k {
+        for rhs in 0..k {
+            let mut dot = Complex64::new(0.0, 0.0);
+            for row in 0..m {
+                dot += u[row + m * lhs].conj() * u[row + m * rhs];
+            }
+            let expected = if lhs == rhs {
+                Complex64::new(1.0, 0.0)
+            } else {
+                Complex64::new(0.0, 0.0)
+            };
+            max_orthogonality = max_orthogonality.max((dot - expected).norm());
+        }
+    }
+    let mut max_vt_orthogonality = 0.0_f64;
+    for lhs in 0..k {
+        for rhs in 0..k {
+            let mut dot = Complex64::new(0.0, 0.0);
+            for col in 0..n {
+                dot += vt[lhs + k * col] * vt[rhs + k * col].conj();
+            }
+            let expected = if lhs == rhs {
+                Complex64::new(1.0, 0.0)
+            } else {
+                Complex64::new(0.0, 0.0)
+            };
+            max_vt_orthogonality = max_vt_orthogonality.max((dot - expected).norm());
+        }
+    }
+    assert!(
+        max_reconstruction < tolerance,
+        "reconstruction residual {max_reconstruction}"
+    );
+    assert!(
+        max_orthogonality < tolerance,
+        "U orthogonality residual {max_orthogonality}"
+    );
+    assert!(
+        max_vt_orthogonality < tolerance,
+        "Vt row orthogonality residual {max_vt_orthogonality}"
+    );
+}
+
+fn assert_f32_svd_residual(input: &[f32], u: &[f32], s: &[f32], vt: &[f32], m: usize, n: usize) {
+    let input = input.iter().map(|&x| f64::from(x)).collect::<Vec<_>>();
+    let u = u.iter().map(|&x| f64::from(x)).collect::<Vec<_>>();
+    let s = s.iter().map(|&x| f64::from(x)).collect::<Vec<_>>();
+    let vt = vt.iter().map(|&x| f64::from(x)).collect::<Vec<_>>();
+    let k = m.min(n);
+    let mut reconstruction = 0.0_f64;
+    for col in 0..n {
+        for row in 0..m {
+            let actual = (0..k)
+                .map(|inner| u[row + m * inner] * s[inner] * vt[inner + k * col])
+                .sum::<f64>();
+            reconstruction = reconstruction.max((actual - input[row + m * col]).abs());
+        }
+    }
+    let mut unitary = 0.0_f64;
+    for lhs in 0..k {
+        for rhs in 0..k {
+            let expected = f64::from(lhs == rhs);
+            let u_dot = (0..m)
+                .map(|row| u[row + m * lhs] * u[row + m * rhs])
+                .sum::<f64>();
+            let vt_dot = (0..n)
+                .map(|col| vt[lhs + k * col] * vt[rhs + k * col])
+                .sum::<f64>();
+            unitary = unitary.max((u_dot - expected).abs());
+            unitary = unitary.max((vt_dot - expected).abs());
+        }
+    }
+    assert!(
+        reconstruction < 2.0e-4,
+        "F32 reconstruction residual {reconstruction}"
+    );
+    assert!(unitary < 2.0e-4, "F32 unitarity residual {unitary}");
+}
+
+fn assert_c32_svd_residual(
+    input: &[Complex32],
+    u: &[Complex32],
+    s: &[f32],
+    vt: &[Complex32],
+    m: usize,
+    n: usize,
+) {
+    let lift = |value: &Complex32| Complex64::new(f64::from(value.re), f64::from(value.im));
+    let input = input.iter().map(lift).collect::<Vec<_>>();
+    let u = u.iter().map(lift).collect::<Vec<_>>();
+    let s = s.iter().map(|&x| f64::from(x)).collect::<Vec<_>>();
+    let vt = vt.iter().map(lift).collect::<Vec<_>>();
+    assert_c64_svd_residual(&input, &u, &s, &vt, m, n, 2.0e-4);
+}
+
+#[test]
+fn prepared_svd_all_dtypes_cover_shapes_repeated_values_and_gauges() {
+    let cases = [
+        (2, 2, vec![2.0_f64, 0.0, 0.0, 2.0]),
+        (3, 2, vec![3.0, 1.0, -2.0, 4.0, -1.0, 2.0]),
+        (2, 3, vec![3.0, 1.0, -2.0, 4.0, -1.0, 2.0]),
+    ];
+    for gauge in [SvdGauge::Raw, SvdGauge::CanonicalPivot] {
+        for (m, n, real_data) in &cases {
+            let (m, n) = (*m, *n);
+            let options = SvdOptions::default().gauge(gauge);
+
+            let f32_data = real_data.iter().map(|&x| x as f32).collect::<Vec<_>>();
+            let input = Tensor::from_vec_col_major(vec![m, n], f32_data.clone()).unwrap();
+            let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+            let plan = backend.prepare_svd([m, n], DType::F32, options).unwrap();
+            let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+            let k = m.min(n);
+            let mut u = Tensor::from_vec_col_major(vec![m, k], vec![0.0_f32; m * k]).unwrap();
+            let mut s = Tensor::from_vec_col_major(vec![k], vec![0.0_f32; k]).unwrap();
+            let mut vt = Tensor::from_vec_col_major(vec![k, n], vec![0.0_f32; k * n]).unwrap();
+            plan.execute_into(
+                &mut backend,
+                &mut workspace,
+                TensorRead::from_tensor(&input),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            assert_f32_svd_residual(
+                &f32_data,
+                u.as_slice().unwrap(),
+                s.as_slice().unwrap(),
+                vt.as_slice().unwrap(),
+                m,
+                n,
+            );
+
+            let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+            let input = Tensor::from_vec_col_major(vec![m, n], real_data.clone()).unwrap();
+            let plan = backend.prepare_svd([m, n], DType::F64, options).unwrap();
+            let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+            let (mut u, mut s, mut vt) = f64_outputs(m, n, 0.0);
+            plan.execute_into(
+                &mut backend,
+                &mut workspace,
+                TensorRead::from_tensor(&input),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            assert_f64_svd_residual(
+                real_data,
+                u.as_slice().unwrap(),
+                s.as_slice().unwrap(),
+                vt.as_slice().unwrap(),
+                m,
+                n,
+            );
+
+            let c32_data = real_data
+                .iter()
+                .enumerate()
+                .map(|(i, &x)| Complex32::new(x as f32, (i % 3) as f32 * 0.125))
+                .collect::<Vec<_>>();
+            let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+            let input = Tensor::from_vec_col_major(vec![m, n], c32_data.clone()).unwrap();
+            let plan = backend.prepare_svd([m, n], DType::C32, options).unwrap();
+            let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+            let mut u =
+                Tensor::from_vec_col_major(vec![m, k], vec![Complex32::default(); m * k]).unwrap();
+            let mut s = Tensor::from_vec_col_major(vec![k], vec![0.0_f32; k]).unwrap();
+            let mut vt =
+                Tensor::from_vec_col_major(vec![k, n], vec![Complex32::default(); k * n]).unwrap();
+            plan.execute_into(
+                &mut backend,
+                &mut workspace,
+                TensorRead::from_tensor(&input),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            assert_c32_svd_residual(
+                &c32_data,
+                u.as_slice().unwrap(),
+                s.as_slice().unwrap(),
+                vt.as_slice().unwrap(),
+                m,
+                n,
+            );
+
+            let c64_data = real_data
+                .iter()
+                .enumerate()
+                .map(|(i, &x)| Complex64::new(x, (i % 3) as f64 * 0.125))
+                .collect::<Vec<_>>();
+            let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+            let input = Tensor::from_vec_col_major(vec![m, n], c64_data.clone()).unwrap();
+            let plan = backend.prepare_svd([m, n], DType::C64, options).unwrap();
+            let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+            let mut u =
+                Tensor::from_vec_col_major(vec![m, k], vec![Complex64::default(); m * k]).unwrap();
+            let mut s = Tensor::from_vec_col_major(vec![k], vec![0.0_f64; k]).unwrap();
+            let mut vt =
+                Tensor::from_vec_col_major(vec![k, n], vec![Complex64::default(); k * n]).unwrap();
+            plan.execute_into(
+                &mut backend,
+                &mut workspace,
+                TensorRead::from_tensor(&input),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            assert_c64_svd_residual(
+                &c64_data,
+                u.as_slice().unwrap(),
+                s.as_slice().unwrap(),
+                vt.as_slice().unwrap(),
+                m,
+                n,
+                1.0e-10,
+            );
+        }
+    }
+}
+
+#[test]
+fn prepared_svd_supports_f32_c32_and_c64_with_owned_semantics() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+
+    let input_f32 =
+        Tensor::from_vec_col_major(vec![3, 2], vec![3.0_f32, 1.0, -2.0, 4.0, -1.0, 2.0]).unwrap();
+    let plan_f32 = backend
+        .prepare_svd([3, 2], DType::F32, SvdOptions::default())
+        .unwrap();
+    let mut workspace_f32 = plan_f32.allocate_workspace(&mut backend).unwrap();
+    let mut u_f32 = Tensor::from_vec_col_major(vec![3, 2], vec![0.0_f32; 6]).unwrap();
+    let mut s_f32 = Tensor::from_vec_col_major(vec![2], vec![0.0_f32; 2]).unwrap();
+    let mut vt_f32 = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f32; 4]).unwrap();
+    plan_f32
+        .execute_into(
+            &mut backend,
+            &mut workspace_f32,
+            TensorRead::from_tensor(&input_f32),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u_f32),
+                TensorWrite::from_tensor(&mut s_f32),
+                TensorWrite::from_tensor(&mut vt_f32),
+            ),
+        )
+        .unwrap();
+    let owned_f32 = backend.svd(&input_f32).unwrap();
+    for (prepared, owned) in [
+        (
+            u_f32.as_slice::<f32>().unwrap(),
+            owned_f32[0].as_slice::<f32>().unwrap(),
+        ),
+        (
+            s_f32.as_slice::<f32>().unwrap(),
+            owned_f32[1].as_slice::<f32>().unwrap(),
+        ),
+        (
+            vt_f32.as_slice::<f32>().unwrap(),
+            owned_f32[2].as_slice::<f32>().unwrap(),
+        ),
+    ] {
+        assert!(prepared
+            .iter()
+            .zip(owned)
+            .all(|(a, b)| (*a - *b).abs() < 2.0e-5));
+    }
+
+    let c32_data = vec![
+        Complex32::new(2.0, 1.0),
+        Complex32::new(-1.0, 0.5),
+        Complex32::new(3.0, -2.0),
+        Complex32::new(0.25, 1.5),
+    ];
+    let input_c32 = Tensor::from_vec_col_major(vec![2, 2], c32_data).unwrap();
+    let plan_c32 = backend
+        .prepare_svd([2, 2], DType::C32, SvdOptions::default())
+        .unwrap();
+    let mut workspace_c32 = plan_c32.allocate_workspace(&mut backend).unwrap();
+    let mut u_c32 = Tensor::from_vec_col_major(vec![2, 2], vec![Complex32::default(); 4]).unwrap();
+    let mut s_c32 = Tensor::from_vec_col_major(vec![2], vec![0.0_f32; 2]).unwrap();
+    let mut vt_c32 = Tensor::from_vec_col_major(vec![2, 2], vec![Complex32::default(); 4]).unwrap();
+    plan_c32
+        .execute_into(
+            &mut backend,
+            &mut workspace_c32,
+            TensorRead::from_tensor(&input_c32),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u_c32),
+                TensorWrite::from_tensor(&mut s_c32),
+                TensorWrite::from_tensor(&mut vt_c32),
+            ),
+        )
+        .unwrap();
+    let owned_c32 = backend.svd(&input_c32).unwrap();
+    for (prepared, owned) in [
+        (
+            u_c32.as_slice::<Complex32>().unwrap(),
+            owned_c32[0].as_slice::<Complex32>().unwrap(),
+        ),
+        (
+            vt_c32.as_slice::<Complex32>().unwrap(),
+            owned_c32[2].as_slice::<Complex32>().unwrap(),
+        ),
+    ] {
+        assert!(prepared
+            .iter()
+            .zip(owned)
+            .all(|(a, b)| (*a - *b).norm() < 2.0e-5));
+    }
+    assert!(s_c32
+        .as_slice::<f32>()
+        .unwrap()
+        .iter()
+        .zip(owned_c32[1].as_slice::<f32>().unwrap())
+        .all(|(a, b)| (*a - *b).abs() < 2.0e-5));
+
+    let c64_data = vec![
+        Complex64::new(2.0, 0.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(2.0, 0.0),
+    ];
+    let input_c64 = Tensor::from_vec_col_major(vec![2, 2], c64_data.clone()).unwrap();
+    let plan_c64 = backend
+        .prepare_svd([2, 2], DType::C64, SvdOptions::default())
+        .unwrap();
+    let mut workspace_c64 = plan_c64.allocate_workspace(&mut backend).unwrap();
+    let mut u_c64 = Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    let mut s_c64 = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut vt_c64 = Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    plan_c64
+        .execute_into(
+            &mut backend,
+            &mut workspace_c64,
+            TensorRead::from_tensor(&input_c64),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u_c64),
+                TensorWrite::from_tensor(&mut s_c64),
+                TensorWrite::from_tensor(&mut vt_c64),
+            ),
+        )
+        .unwrap();
+    assert_c64_svd_residual(
+        &c64_data,
+        u_c64.as_slice::<Complex64>().unwrap(),
+        s_c64.as_slice::<f64>().unwrap(),
+        vt_c64.as_slice::<Complex64>().unwrap(),
+        2,
+        2,
+        1.0e-10,
+    );
+}
+
+#[test]
+fn prepared_svd_canonical_complex_gauge_matches_owned_path() {
+    let options = SvdOptions::default().gauge(SvdGauge::CanonicalPivot);
+    let data = vec![
+        Complex64::new(2.0, 1.0),
+        Complex64::new(-1.0, 0.5),
+        Complex64::new(0.25, -1.0),
+        Complex64::new(3.0, 2.0),
+        Complex64::new(-2.0, 1.0),
+        Complex64::new(0.5, -0.25),
+    ];
+    let input = Tensor::from_vec_col_major(vec![3, 2], data.clone()).unwrap();
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend.prepare_svd([3, 2], DType::C64, options).unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let mut u = Tensor::from_vec_col_major(vec![3, 2], vec![Complex64::default(); 6]).unwrap();
+    let mut s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut vt = Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_tensor(&input),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    let owned = backend.svd_with_options(&input, options).unwrap();
+    assert_eq!(
+        u.as_slice::<Complex64>().unwrap(),
+        owned[0].as_slice::<Complex64>().unwrap()
+    );
+    assert_eq!(
+        s.as_slice::<f64>().unwrap(),
+        owned[1].as_slice::<f64>().unwrap()
+    );
+    assert_eq!(
+        vt.as_slice::<Complex64>().unwrap(),
+        owned[2].as_slice::<Complex64>().unwrap()
+    );
+    assert_c64_svd_residual(
+        &data,
+        u.as_slice::<Complex64>().unwrap(),
+        s.as_slice::<f64>().unwrap(),
+        vt.as_slice::<Complex64>().unwrap(),
+        3,
+        2,
+        1.0e-10,
+    );
+}
+
+#[test]
+fn prepared_svd_f64_raw_reconstructs_square_tall_and_wide_inputs() {
+    for (m, n, data) in [
+        (2, 2, vec![3.0, 1.0, -2.0, 4.0]),
+        (4, 2, vec![3.0, 1.0, -2.0, 0.5, 4.0, -1.0, 2.0, 5.0]),
+        (2, 4, vec![3.0, 1.0, -2.0, 4.0, 0.5, -3.0, 2.0, 1.5]),
+    ] {
+        let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+        let plan = backend
+            .prepare_svd([m, n], DType::F64, SvdOptions::default())
+            .unwrap();
+        let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+        let input = Tensor::from_vec_col_major(vec![m, n], data.clone()).unwrap();
+        let (mut u, mut s, mut vt) = f64_outputs(m, n, 0.0);
+        plan.execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+        assert_f64_svd_residual(
+            &data,
+            u.as_slice::<f64>().unwrap(),
+            s.as_slice::<f64>().unwrap(),
+            vt.as_slice::<f64>().unwrap(),
+            m,
+            n,
+        );
+    }
+}
+
+#[test]
+fn prepared_svd_f64_accepts_positive_negative_and_zero_stride_inputs() {
+    let cases = [
+        ([3, 2], [2, 7], 1_isize, 13_usize),
+        ([3, 2], [-2, 7], 5_isize, 13_usize),
+        ([1, 3], [0, 2], 1_isize, 6_usize),
+    ];
+    for (shape, strides, offset, storage_len) in cases {
+        let [m, n] = shape;
+        let mut storage = vec![97.0_f64; storage_len];
+        let mut expected = vec![0.0; m * n];
+        for col in 0..n {
+            for row in 0..m {
+                let value = 1.0 + row as f64 + 2.5 * col as f64;
+                let physical = offset + row as isize * strides[0] + col as isize * strides[1];
+                storage[usize::try_from(physical).unwrap()] = value;
+                expected[row + m * col] = value;
+            }
+        }
+        let view = TypedTensorView::from_slice(shape, strides, offset, &storage).unwrap();
+        let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+        let plan = backend
+            .prepare_svd(shape, DType::F64, SvdOptions::default())
+            .unwrap();
+        let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+        let (mut u, mut s, mut vt) = f64_outputs(m, n, 0.0);
+        plan.execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_view(TensorView::F64(view)),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+        assert_f64_svd_residual(
+            &expected,
+            u.as_slice::<f64>().unwrap(),
+            s.as_slice::<f64>().unwrap(),
+            vt.as_slice::<f64>().unwrap(),
+            m,
+            n,
+        );
+    }
+}
+
+#[test]
+fn prepared_svd_writes_compact_output_subviews_without_touching_guards() {
+    let (m, n, k) = (3, 2, 2);
+    let input_data = vec![3.0_f64, 1.0, -2.0, 4.0, -1.0, 2.0];
+    let input = Tensor::from_vec_col_major(vec![m, n], input_data.clone()).unwrap();
+    let mut u_storage = vec![41.0_f64; 2 + m * k + 2];
+    let mut s_storage = vec![42.0_f64; 2 + k + 2];
+    let mut vt_storage = vec![43.0_f64; 2 + k * n + 2];
+    let u_view =
+        TypedTensorViewMut::from_slice([m, k], [1, m as isize], 2, &mut u_storage).unwrap();
+    let s_view = TypedTensorViewMut::from_slice([k], [1], 2, &mut s_storage).unwrap();
+    let vt_view =
+        TypedTensorViewMut::from_slice([k, n], [1, k as isize], 2, &mut vt_storage).unwrap();
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([m, n], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_tensor(&input),
+        SvdOutputWrites::new(
+            TensorWrite::from_view(TensorViewMut::F64(u_view)),
+            TensorWrite::from_view(TensorViewMut::F64(s_view)),
+            TensorWrite::from_view(TensorViewMut::F64(vt_view)),
+        ),
+    )
+    .unwrap();
+    assert_eq!(&u_storage[..2], &[41.0; 2]);
+    assert_eq!(&u_storage[2 + m * k..], &[41.0; 2]);
+    assert_eq!(&s_storage[..2], &[42.0; 2]);
+    assert_eq!(&s_storage[2 + k..], &[42.0; 2]);
+    assert_eq!(&vt_storage[..2], &[43.0; 2]);
+    assert_eq!(&vt_storage[2 + k * n..], &[43.0; 2]);
+    assert_f64_svd_residual(
+        &input_data,
+        &u_storage[2..2 + m * k],
+        &s_storage[2..2 + k],
+        &vt_storage[2..2 + k * n],
+        m,
+        n,
+    );
+}
+
+#[test]
+fn prepared_svd_reports_compact_output_specs() {
+    fn debug_usize(debug: &str, field: &str) -> usize {
+        let marker = format!("{field}: ");
+        debug
+            .split_once(&marker)
+            .unwrap_or_else(|| panic!("missing {field}: {debug}"))
+            .1
+            .split([',', '}'])
+            .next()
+            .unwrap()
+            .parse()
+            .unwrap()
+    }
+
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([3, 2], DType::C64, SvdOptions::default())
+        .unwrap();
+    assert_eq!(plan.output_specs().u().shape(), &[3, 2]);
+    assert_eq!(plan.output_specs().u().dtype(), DType::C64);
+    assert_eq!(plan.output_specs().s().shape(), &[2]);
+    assert_eq!(plan.output_specs().s().dtype(), DType::F64);
+    assert_eq!(plan.output_specs().vt().shape(), &[2, 2]);
+    let plan_debug = format!("{plan:?}");
+    for field in [
+        "operation",
+        "shape",
+        "dtype",
+        "provider",
+        "device",
+        "context",
+        "plan_retained_bytes: 0",
+        "workspace_required_bytes",
+    ] {
+        assert!(plan_debug.contains(field), "missing {field}: {plan_debug}");
+    }
+    assert_eq!(plan.retained_bytes(), 0);
+    assert_eq!(
+        plan.retained_bytes(),
+        debug_usize(&plan_debug, "plan_retained_bytes")
+    );
+    let required_bytes = debug_usize(&plan_debug, "workspace_required_bytes");
+    let workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let workspace_debug = format!("{workspace:?}");
+    for field in [
+        "operation",
+        "shape",
+        "dtype",
+        "provider",
+        "device",
+        "context",
+        "workspace_required_bytes",
+        "workspace_retained_bytes",
+    ] {
+        assert!(
+            workspace_debug.contains(field),
+            "missing {field}: {workspace_debug}"
+        );
+    }
+    assert_eq!(
+        debug_usize(&workspace_debug, "workspace_required_bytes"),
+        required_bytes
+    );
+    assert!(
+        debug_usize(&workspace_debug, "workspace_retained_bytes") >= required_bytes,
+        "workspace retained fewer bytes than required: {workspace_debug}"
+    );
+    assert!(workspace.retained_bytes() > 0);
+    assert_eq!(
+        workspace.retained_bytes(),
+        debug_usize(&workspace_debug, "workspace_retained_bytes")
+    );
+}
+
+#[cfg(feature = "cpu-blas")]
+#[test]
+fn prepared_svd_rejects_unsupported_cpu_provider_without_fallback() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Blas).unwrap();
+    let error = backend
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::UnsupportedCapability {
+            op: "prepare_svd",
+            backend: BackendId::Cpu,
+            provider: "blas",
+            dtype: DType::F64,
+            capability: "prepared compact SVD",
+        }
+    ));
+}
+
+#[test]
+fn prepared_svd_reports_unsupported_dtype_as_typed_capability() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let error = backend
+        .prepare_svd([2, 2], DType::I32, SvdOptions::default())
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::UnsupportedCapability {
+            op: "prepare_svd",
+            backend: BackendId::Cpu,
+            provider: "faer",
+            dtype: DType::I32,
+            capability: "prepared compact SVD",
+        }
+    ));
+}
+
+#[test]
+fn prepared_svd_binding_accepts_clone_and_rejects_distinct_backend_before_writes() {
+    let mut creator = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = creator
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut creator).unwrap();
+    let mut clone = creator.clone();
+    drop(creator);
+
+    let input = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 2.0]).unwrap();
+    let (mut u, mut s, mut vt) = f64_outputs(2, 2, -7.0);
+    plan.execute_into(
+        &mut clone,
+        &mut workspace,
+        TensorRead::from_tensor(&input),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    assert_ne!(s.as_slice::<f64>().unwrap(), &[-7.0, -7.0]);
+
+    let mut distinct = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let before_u = vec![-11.0; 4];
+    let before_s = vec![-11.0; 2];
+    let before_vt = vec![-11.0; 4];
+    let mut u = Tensor::from_vec_col_major(vec![2, 2], before_u.clone()).unwrap();
+    let mut s = Tensor::from_vec_col_major(vec![2], before_s.clone()).unwrap();
+    let mut vt = Tensor::from_vec_col_major(vec![2, 2], before_vt.clone()).unwrap();
+    let error = plan
+        .execute_into(
+            &mut distinct,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::UnsupportedCapability {
+            op: "PreparedSvd::execute_into",
+            backend: BackendId::Cpu,
+            provider: "faer",
+            dtype: DType::F64,
+            capability: "prepared SVD backend/context binding",
+        }
+    ));
+    assert_eq!(u.as_slice::<f64>().unwrap(), before_u);
+    assert_eq!(s.as_slice::<f64>().unwrap(), before_s);
+    assert_eq!(vt.as_slice::<f64>().unwrap(), before_vt);
+}
+
+#[test]
+fn prepared_svd_session_rejects_distinct_binding_before_writes() {
+    let mut creator = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = creator
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut creator).unwrap();
+    let input = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 2.0]).unwrap();
+    let mut distinct = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let (mut u, mut s, mut vt) = f64_outputs(2, 2, 43.0);
+
+    let error = distinct.with_prepared_factorization_session(|session| {
+        plan.execute_into_session(
+            session,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+    });
+
+    assert!(matches!(
+        error,
+        Err(Error::UnsupportedCapability {
+            capability: "prepared SVD backend/context binding",
+            ..
+        })
+    ));
+    assert_eq!(u.as_slice::<f64>().unwrap(), &[43.0; 4]);
+    assert_eq!(s.as_slice::<f64>().unwrap(), &[43.0; 2]);
+    assert_eq!(vt.as_slice::<f64>().unwrap(), &[43.0; 4]);
+    assert_eq!(distinct.with_prepared_factorization_session(|_| 19_u32), 19);
+}
+
+#[test]
+fn prepared_factorization_session_releases_execution_after_panic() {
+    let mut backend = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.with_prepared_factorization_session(|_| panic!("forced session panic"));
+    }));
+    assert!(panic.is_err());
+    assert_eq!(backend.with_prepared_factorization_session(|_| 17_u32), 17);
+}
+
+#[test]
+fn prepared_svd_session_repeats_correctly_with_multiple_workers() {
+    let input = Tensor::from_vec_col_major(
+        vec![4, 3],
+        vec![
+            3.0_f64, 1.0, -2.0, 4.0, -1.0, 2.0, 0.5, 3.5, 2.0, -3.0, 1.5, 0.25,
+        ],
+    )
+    .unwrap();
+
+    for workers in [2, 4] {
+        let mut backend = CpuBackend::with_threads_and_kind(workers, CpuBackendKind::Faer).unwrap();
+        let plan = backend
+            .prepare_svd([4, 3], DType::F64, SvdOptions::default())
+            .unwrap();
+        let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+        let (mut u, mut s, mut vt) = f64_outputs(4, 3, -1.0);
+
+        backend.with_prepared_factorization_session(|session| {
+            for _ in 0..128 {
+                plan.execute_into_session(
+                    session,
+                    &mut workspace,
+                    TensorRead::from_tensor(&input),
+                    SvdOutputWrites::new(
+                        TensorWrite::from_tensor(&mut u),
+                        TensorWrite::from_tensor(&mut s),
+                        TensorWrite::from_tensor(&mut vt),
+                    ),
+                )
+                .unwrap();
+            }
+        });
+
+        assert_f64_svd_residual(
+            input.as_slice::<f64>().unwrap(),
+            u.as_slice::<f64>().unwrap(),
+            s.as_slice::<f64>().unwrap(),
+            vt.as_slice::<f64>().unwrap(),
+            4,
+            3,
+        );
+    }
+}
+
+#[test]
+fn prepared_svd_validation_failure_leaves_all_destinations_unchanged() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+    let mut u = Tensor::from_vec_col_major(vec![4], vec![19.0_f64; 4]).unwrap();
+    let mut s = Tensor::from_vec_col_major(vec![2], vec![19.0_f64; 2]).unwrap();
+    let mut vt = Tensor::from_vec_col_major(vec![2, 2], vec![19.0_f64; 4]).unwrap();
+    assert!(plan
+        .execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .is_err());
+    assert_eq!(u.as_slice::<f64>().unwrap(), &[19.0; 4]);
+    assert_eq!(s.as_slice::<f64>().unwrap(), &[19.0; 2]);
+    assert_eq!(vt.as_slice::<f64>().unwrap(), &[19.0; 4]);
+}
+
+#[test]
+fn prepared_svd_validates_every_field_metadata_and_order_before_writes() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let valid_input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+    let valid = || f64_outputs(2, 2, 41.0);
+
+    for input in [
+        Tensor::from_vec_col_major(vec![4], vec![1.0_f64; 4]).unwrap(),
+        Tensor::from_vec_col_major(vec![1, 4], vec![1.0_f64; 4]).unwrap(),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f32; 4]).unwrap(),
+    ] {
+        let (u, s, vt) = valid();
+        let error = prepared_execution_error(&mut backend, &plan, &mut workspace, &input, u, s, vt);
+        assert!(error.to_string().contains("input must have shape"));
+    }
+
+    let invalid_outputs = [
+        (
+            "U must have shape",
+            Tensor::from_vec_col_major(vec![4], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "U must have shape",
+            Tensor::from_vec_col_major(vec![1, 4], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "U must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f32; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "S must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![1, 2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "S must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![1], vec![41.0_f64]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "S must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f32; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "Vt must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![4], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "Vt must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![1, 4], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "Vt must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f32; 4]).unwrap(),
+        ),
+    ];
+    for (expected, u, s, vt) in invalid_outputs {
+        let error =
+            prepared_execution_error(&mut backend, &plan, &mut workspace, &valid_input, u, s, vt);
+        assert!(error.to_string().contains(expected), "{error}");
+    }
+
+    let wrong_input = Tensor::from_vec_col_major(vec![4], vec![1.0_f64; 4]).unwrap();
+    let wrong_u = Tensor::from_vec_col_major(vec![4], vec![41.0_f64; 4]).unwrap();
+    let wrong_s = Tensor::from_vec_col_major(vec![1], vec![41.0_f64]).unwrap();
+    let wrong_vt = Tensor::from_vec_col_major(vec![4], vec![41.0_f64; 4]).unwrap();
+    let error = prepared_execution_error(
+        &mut backend,
+        &plan,
+        &mut workspace,
+        &wrong_input,
+        wrong_u,
+        wrong_s,
+        wrong_vt,
+    );
+    assert!(error.to_string().contains("input must have shape"));
+}
+
+#[test]
+fn prepared_svd_validates_storage_placement_and_accepts_pinned_host() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let host = Placement {
+        memory_kind: MemoryKind::PinnedHost,
+        device: None,
+    };
+    let device = Placement {
+        memory_kind: MemoryKind::Device,
+        device: Some(DeviceId {
+            kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+            ordinal: 0,
+        }),
+    };
+    for field in 0..4 {
+        let mut input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+        let (mut u, mut s, mut vt) = f64_outputs(2, 2, 41.0);
+        match field {
+            0 => set_tensor_placement(&mut input, device.clone()),
+            1 => set_tensor_placement(&mut u, device.clone()),
+            2 => set_tensor_placement(&mut s, device.clone()),
+            3 => set_tensor_placement(&mut vt, device.clone()),
+            _ => unreachable!(),
+        }
+        let error = prepared_execution_error(&mut backend, &plan, &mut workspace, &input, u, s, vt);
+        assert!(matches!(error, Error::UnsupportedCapability { .. }));
+    }
+
+    let mut input = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 1.0]).unwrap();
+    let (mut u, mut s, mut vt) = f64_outputs(2, 2, 0.0);
+    for tensor in [&mut input, &mut u, &mut s, &mut vt] {
+        set_tensor_placement(tensor, host.clone());
+    }
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_tensor(&input),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    assert_eq!(s.as_slice::<f64>().unwrap(), &[2.0, 1.0]);
+}
+
+#[test]
+fn prepared_svd_rejects_unsupported_destination_stride_before_writes() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([2, 1], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let input = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f64, 1.0]).unwrap();
+    let mut u_storage = vec![31.0_f64; 3];
+    let before_u = u_storage.clone();
+    let u = TypedTensorViewMut::from_slice([2, 1], [2, 3], 0, &mut u_storage).unwrap();
+    let mut s = Tensor::from_vec_col_major(vec![1], vec![32.0_f64]).unwrap();
+    let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![33.0_f64]).unwrap();
+    let error = plan
+        .execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_view(TensorViewMut::F64(u)),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::UnsupportedCapability {
+            op: "PreparedSvd::execute_into",
+            backend: BackendId::Cpu,
+            provider: "faer",
+            dtype: DType::F64,
+            capability: "compact column-major prepared SVD destination",
+        }
+    ));
+    assert_eq!(u_storage, before_u);
+    assert_eq!(s.as_slice::<f64>().unwrap(), &[32.0]);
+    assert_eq!(vt.as_slice::<f64>().unwrap(), &[33.0]);
+}
+
+#[test]
+fn prepared_svd_supports_multiple_workspaces_and_rejects_cross_plan_workspace() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let other_plan = backend
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut first_workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let mut second_workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let input = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 2.0]).unwrap();
+
+    backend.with_prepared_factorization_session(|session| {
+        for workspace in [&mut first_workspace, &mut second_workspace] {
+            let (mut u, mut s, mut vt) = f64_outputs(2, 2, -1.0);
+            plan.execute_into_session(
+                session,
+                workspace,
+                TensorRead::from_tensor(&input),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            assert_f64_svd_residual(
+                input.as_slice::<f64>().unwrap(),
+                u.as_slice::<f64>().unwrap(),
+                s.as_slice::<f64>().unwrap(),
+                vt.as_slice::<f64>().unwrap(),
+                2,
+                2,
+            );
+        }
+    });
+
+    let (mut u, mut s, mut vt) = f64_outputs(2, 2, 37.0);
+    let error = other_plan
+        .execute_into(
+            &mut backend,
+            &mut first_workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::UnsupportedCapability {
+            capability: "prepared SVD backend/context binding",
+            ..
+        }
+    ));
+    assert_eq!(u.as_slice::<f64>().unwrap(), &[37.0; 4]);
+    assert_eq!(s.as_slice::<f64>().unwrap(), &[37.0; 2]);
+    assert_eq!(vt.as_slice::<f64>().unwrap(), &[37.0; 4]);
+}
+
+#[test]
+fn prepared_svd_zero_size_validates_and_skips_provider() {
+    for [m, n] in [[0, 3], [3, 0], [0, 0]] {
+        let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+        let plan = backend
+            .prepare_svd([m, n], DType::F64, SvdOptions::default())
+            .unwrap();
+        let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+        let input = Tensor::from_vec_col_major(vec![m, n], Vec::<f64>::new()).unwrap();
+        let (mut u, mut s, mut vt) = f64_outputs(m, n, 0.0);
+        plan.execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+        assert!(u.as_slice::<f64>().unwrap().is_empty());
+        assert!(s.as_slice::<f64>().unwrap().is_empty());
+        assert!(vt.as_slice::<f64>().unwrap().is_empty());
+    }
+}

--- a/crates/tenferro-linalg/tests/prepared_svd_alloc.rs
+++ b/crates/tenferro-linalg/tests/prepared_svd_alloc.rs
@@ -1,0 +1,571 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use num_complex::Complex64;
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+use tenferro_linalg::{
+    PreparedFactorizationBackendExt, PreparedFactorizationSession, PreparedSvd,
+    PreparedSvdBackendExt, SvdOptions, SvdOutputWrites, SvdWorkspace,
+};
+use tenferro_tensor::{
+    DType, Tensor, TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensorView,
+    TypedTensorViewMut,
+};
+
+struct CountingAllocator;
+
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if ACTIVE.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        // SAFETY: forwarding the allocator contract unchanged to `System`.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr` and `layout` came from the forwarded `System` allocation.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if ACTIVE.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        // SAFETY: forwarding the allocator contract unchanged to `System`.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn measured_allocations(run: impl FnOnce()) -> usize {
+    ALLOCATIONS.store(0, Ordering::SeqCst);
+    ACTIVE.store(true, Ordering::SeqCst);
+    run();
+    ACTIVE.store(false, Ordering::SeqCst);
+    ALLOCATIONS.load(Ordering::SeqCst)
+}
+
+fn execute_leaf(
+    session: &mut PreparedFactorizationSession<'_>,
+    plan: &PreparedSvd,
+    workspace: &mut SvdWorkspace,
+    input: TensorRead<'_>,
+    u: &mut Tensor,
+    s: &mut Tensor,
+    vt: &mut Tensor,
+) {
+    plan.execute_into_session(
+        session,
+        workspace,
+        input,
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(u),
+            TensorWrite::from_tensor(s),
+            TensorWrite::from_tensor(vt),
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn prepared_svd_complete_warm_calls_allocate_zero() {
+    let _serial = TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+
+    let input =
+        Tensor::from_vec_col_major(vec![3, 2], vec![3.0_f64, 1.0, -2.0, 4.0, -1.0, 2.0]).unwrap();
+    let plan = backend
+        .prepare_svd([3, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let mut u = Tensor::from_vec_col_major(vec![3, 2], vec![0.0_f64; 6]).unwrap();
+    let mut s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut vt = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4]).unwrap();
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_tensor(&input),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    let contiguous = measured_allocations(|| {
+        plan.execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+    });
+    assert_eq!(contiguous, 0, "contiguous F64 warm allocations");
+
+    let mut positive_storage = vec![0.0_f64; 13];
+    let mut negative_storage = vec![0.0_f64; 13];
+    for col in 0..2 {
+        for row in 0..3 {
+            let value = 1.0 + row as f64 + 2.0 * col as f64;
+            positive_storage[1 + 2 * row + 7 * col] = value;
+            negative_storage[5 - 2 * row + 7 * col] = value;
+        }
+    }
+    let positive_prime = TypedTensorView::from_slice([3, 2], [2, 7], 1, &positive_storage).unwrap();
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_view(TensorView::F64(positive_prime)),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    let positive = TypedTensorView::from_slice([3, 2], [2, 7], 1, &positive_storage).unwrap();
+    let positive_allocations = measured_allocations(|| {
+        plan.execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_view(TensorView::F64(positive)),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+    });
+    assert_eq!(
+        positive_allocations, 0,
+        "positive-stride F64 warm allocations"
+    );
+
+    let negative_prime =
+        TypedTensorView::from_slice([3, 2], [-2, 7], 5, &negative_storage).unwrap();
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_view(TensorView::F64(negative_prime)),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    let negative = TypedTensorView::from_slice([3, 2], [-2, 7], 5, &negative_storage).unwrap();
+    let negative_allocations = measured_allocations(|| {
+        plan.execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_view(TensorView::F64(negative)),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+    });
+    assert_eq!(
+        negative_allocations, 0,
+        "negative-stride F64 warm allocations"
+    );
+
+    let complex_input = Tensor::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(2.0, 1.0),
+            Complex64::new(-1.0, 0.5),
+            Complex64::new(3.0, -2.0),
+            Complex64::new(0.25, 1.5),
+        ],
+    )
+    .unwrap();
+    let complex_plan = backend
+        .prepare_svd([2, 2], DType::C64, SvdOptions::default())
+        .unwrap();
+    let mut complex_workspace = complex_plan.allocate_workspace(&mut backend).unwrap();
+    let mut complex_u =
+        Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    let mut complex_s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut complex_vt =
+        Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    complex_plan
+        .execute_into(
+            &mut backend,
+            &mut complex_workspace,
+            TensorRead::from_tensor(&complex_input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut complex_u),
+                TensorWrite::from_tensor(&mut complex_s),
+                TensorWrite::from_tensor(&mut complex_vt),
+            ),
+        )
+        .unwrap();
+    let complex_allocations = measured_allocations(|| {
+        complex_plan
+            .execute_into(
+                &mut backend,
+                &mut complex_workspace,
+                TensorRead::from_tensor(&complex_input),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut complex_u),
+                    TensorWrite::from_tensor(&mut complex_s),
+                    TensorWrite::from_tensor(&mut complex_vt),
+                ),
+            )
+            .unwrap();
+    });
+    assert_eq!(complex_allocations, 0, "contiguous C64 warm allocations");
+}
+
+#[test]
+fn prepared_svd_resource_accounting_reads_allocate_zero() {
+    let _serial = TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([3, 2], DType::C64, SvdOptions::default())
+        .unwrap();
+    let workspace = plan.allocate_workspace(&mut backend).unwrap();
+
+    let expected_plan = std::hint::black_box(plan.retained_bytes());
+    let expected_workspace = std::hint::black_box(workspace.retained_bytes());
+    let allocations = measured_allocations(|| {
+        for _ in 0..128 {
+            assert_eq!(std::hint::black_box(plan.retained_bytes()), expected_plan);
+            assert_eq!(
+                std::hint::black_box(workspace.retained_bytes()),
+                expected_workspace
+            );
+        }
+    });
+
+    assert_eq!(expected_plan, 0);
+    assert!(expected_workspace > 0);
+    assert_eq!(allocations, 0, "resource accounting read allocations");
+}
+
+#[test]
+fn prepared_svd_session_repeated_single_worker_leaf_calls_allocate_zero() {
+    let _serial = TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_session_leaf_allocations();
+}
+
+#[test]
+fn prepared_svd_session_subview_destinations_allocate_zero_without_workspace_growth() {
+    let _serial = TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    for shape in [[4, 2], [2, 4]] {
+        assert_f64_subview_destination_allocations(shape);
+        assert_c64_subview_destination_allocations(shape);
+    }
+}
+
+fn assert_f64_subview_destination_allocations([m, n]: [usize; 2]) {
+    let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let input = Tensor::from_vec_col_major(
+        vec![m, n],
+        (0..m * n).map(|index| 1.0 + index as f64 / 3.0).collect(),
+    )
+    .unwrap();
+    let plan = backend
+        .prepare_svd([m, n], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let k = m.min(n);
+    let mut u_storage = vec![vec![0.0_f64; m * k + 4]; 65];
+    let mut s_storage = vec![vec![0.0_f64; k + 4]; 65];
+    let mut vt_storage = vec![vec![0.0_f64; k * n + 4]; 65];
+    let mut writes = u_storage
+        .iter_mut()
+        .zip(&mut s_storage)
+        .zip(&mut vt_storage)
+        .map(|((u, s), vt)| {
+            SvdOutputWrites::new(
+                TensorWrite::from_view(TensorViewMut::F64(
+                    TypedTensorViewMut::from_slice([m, k], [1, m as isize], 2, u).unwrap(),
+                )),
+                TensorWrite::from_view(TensorViewMut::F64(
+                    TypedTensorViewMut::from_slice([k], [1], 2, s).unwrap(),
+                )),
+                TensorWrite::from_view(TensorViewMut::F64(
+                    TypedTensorViewMut::from_slice([k, n], [1, k as isize], 2, vt).unwrap(),
+                )),
+            )
+        })
+        .collect::<Vec<_>>();
+    let retained_before = workspace.retained_bytes();
+
+    backend.with_prepared_factorization_session(|session| {
+        plan.execute_into_session(
+            session,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            writes.pop().unwrap(),
+        )
+        .unwrap();
+        let allocations = measured_allocations(|| {
+            for outputs in writes.drain(..) {
+                plan.execute_into_session(
+                    session,
+                    &mut workspace,
+                    TensorRead::from_tensor(&input),
+                    outputs,
+                )
+                .unwrap();
+            }
+        });
+        assert_eq!(
+            allocations, 0,
+            "F64 {m}x{n} caller-owned subview destination allocations"
+        );
+    });
+    assert_eq!(workspace.retained_bytes(), retained_before);
+}
+
+fn assert_c64_subview_destination_allocations([m, n]: [usize; 2]) {
+    let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let input = Tensor::from_vec_col_major(
+        vec![m, n],
+        (0..m * n)
+            .map(|index| Complex64::new(1.0 + index as f64 / 3.0, 0.25 + index as f64 / 7.0))
+            .collect(),
+    )
+    .unwrap();
+    let plan = backend
+        .prepare_svd([m, n], DType::C64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let k = m.min(n);
+    let mut u_storage = vec![vec![Complex64::default(); m * k + 4]; 65];
+    let mut s_storage = vec![vec![0.0_f64; k + 4]; 65];
+    let mut vt_storage = vec![vec![Complex64::default(); k * n + 4]; 65];
+    let mut writes = u_storage
+        .iter_mut()
+        .zip(&mut s_storage)
+        .zip(&mut vt_storage)
+        .map(|((u, s), vt)| {
+            SvdOutputWrites::new(
+                TensorWrite::from_view(TensorViewMut::C64(
+                    TypedTensorViewMut::from_slice([m, k], [1, m as isize], 2, u).unwrap(),
+                )),
+                TensorWrite::from_view(TensorViewMut::F64(
+                    TypedTensorViewMut::from_slice([k], [1], 2, s).unwrap(),
+                )),
+                TensorWrite::from_view(TensorViewMut::C64(
+                    TypedTensorViewMut::from_slice([k, n], [1, k as isize], 2, vt).unwrap(),
+                )),
+            )
+        })
+        .collect::<Vec<_>>();
+    let retained_before = workspace.retained_bytes();
+
+    backend.with_prepared_factorization_session(|session| {
+        plan.execute_into_session(
+            session,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            writes.pop().unwrap(),
+        )
+        .unwrap();
+        let allocations = measured_allocations(|| {
+            for outputs in writes.drain(..) {
+                plan.execute_into_session(
+                    session,
+                    &mut workspace,
+                    TensorRead::from_tensor(&input),
+                    outputs,
+                )
+                .unwrap();
+            }
+        });
+        assert_eq!(
+            allocations, 0,
+            "C64 {m}x{n} caller-owned subview destination allocations"
+        );
+    });
+    assert_eq!(workspace.retained_bytes(), retained_before);
+}
+
+fn assert_session_leaf_allocations() {
+    let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+
+    let f64_input =
+        Tensor::from_vec_col_major(vec![3, 2], vec![3.0_f64, 1.0, -2.0, 4.0, -1.0, 2.0]).unwrap();
+    let mut f64_strided_storage = vec![0.0_f64; 13];
+    for col in 0..2 {
+        for row in 0..3 {
+            f64_strided_storage[1 + 2 * row + 7 * col] = 1.0 + row as f64 + 2.0 * col as f64;
+        }
+    }
+    let f64_plan = backend
+        .prepare_svd([3, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut f64_workspace = f64_plan.allocate_workspace(&mut backend).unwrap();
+    let mut f64_u = Tensor::from_vec_col_major(vec![3, 2], vec![0.0_f64; 6]).unwrap();
+    let mut f64_s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut f64_vt = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4]).unwrap();
+
+    let c64_input = Tensor::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(2.0, 1.0),
+            Complex64::new(-1.0, 0.5),
+            Complex64::new(3.0, -2.0),
+            Complex64::new(0.25, 1.5),
+        ],
+    )
+    .unwrap();
+    let mut c64_strided_storage = vec![Complex64::default(); 9];
+    for col in 0..2 {
+        for row in 0..2 {
+            c64_strided_storage[1 + 2 * row + 5 * col] =
+                Complex64::new(1.0 + row as f64, 0.5 + col as f64);
+        }
+    }
+    let c64_plan = backend
+        .prepare_svd([2, 2], DType::C64, SvdOptions::default())
+        .unwrap();
+    let mut c64_workspace = c64_plan.allocate_workspace(&mut backend).unwrap();
+    let mut c64_u = Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    let mut c64_s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut c64_vt = Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+
+    // Dynamic-rank views own shape/stride metadata. Construct input handles
+    // before measurement so the counter covers factorization leaves only.
+    let mut f64_strided_reads = (0..129)
+        .map(|_| {
+            let view =
+                TypedTensorView::from_slice([3, 2], [2, 7], 1, &f64_strided_storage).unwrap();
+            TensorRead::from_view(TensorView::F64(view))
+        })
+        .collect::<Vec<_>>();
+    let mut c64_strided_reads = (0..129)
+        .map(|_| {
+            let view =
+                TypedTensorView::from_slice([2, 2], [2, 5], 1, &c64_strided_storage).unwrap();
+            TensorRead::from_view(TensorView::C64(view))
+        })
+        .collect::<Vec<_>>();
+
+    backend.with_prepared_factorization_session(|session| {
+        execute_leaf(
+            session,
+            &f64_plan,
+            &mut f64_workspace,
+            TensorRead::from_tensor(&f64_input),
+            &mut f64_u,
+            &mut f64_s,
+            &mut f64_vt,
+        );
+        execute_leaf(
+            session,
+            &f64_plan,
+            &mut f64_workspace,
+            f64_strided_reads.pop().unwrap(),
+            &mut f64_u,
+            &mut f64_s,
+            &mut f64_vt,
+        );
+        execute_leaf(
+            session,
+            &c64_plan,
+            &mut c64_workspace,
+            TensorRead::from_tensor(&c64_input),
+            &mut c64_u,
+            &mut c64_s,
+            &mut c64_vt,
+        );
+        execute_leaf(
+            session,
+            &c64_plan,
+            &mut c64_workspace,
+            c64_strided_reads.pop().unwrap(),
+            &mut c64_u,
+            &mut c64_s,
+            &mut c64_vt,
+        );
+
+        let f64_contiguous = measured_allocations(|| {
+            for _ in 0..128 {
+                execute_leaf(
+                    session,
+                    &f64_plan,
+                    &mut f64_workspace,
+                    TensorRead::from_tensor(&f64_input),
+                    &mut f64_u,
+                    &mut f64_s,
+                    &mut f64_vt,
+                );
+            }
+        });
+        let f64_strided = measured_allocations(|| {
+            for input in f64_strided_reads.drain(..) {
+                execute_leaf(
+                    session,
+                    &f64_plan,
+                    &mut f64_workspace,
+                    input,
+                    &mut f64_u,
+                    &mut f64_s,
+                    &mut f64_vt,
+                );
+            }
+        });
+        let c64_contiguous = measured_allocations(|| {
+            for _ in 0..128 {
+                execute_leaf(
+                    session,
+                    &c64_plan,
+                    &mut c64_workspace,
+                    TensorRead::from_tensor(&c64_input),
+                    &mut c64_u,
+                    &mut c64_s,
+                    &mut c64_vt,
+                );
+            }
+        });
+        let c64_strided = measured_allocations(|| {
+            for input in c64_strided_reads.drain(..) {
+                execute_leaf(
+                    session,
+                    &c64_plan,
+                    &mut c64_workspace,
+                    input,
+                    &mut c64_u,
+                    &mut c64_s,
+                    &mut c64_vt,
+                );
+            }
+        });
+        assert_eq!(
+            [f64_contiguous, f64_strided, c64_contiguous, c64_strided],
+            [0; 4],
+            "single-worker prepared factorization session leaf allocations: [F64 contiguous, F64 strided, C64 contiguous, C64 strided]"
+        );
+    });
+}

--- a/crates/tenferro-tensor/src/error.rs
+++ b/crates/tenferro-tensor/src/error.rs
@@ -74,6 +74,16 @@ pub enum Error {
         dtype: crate::DType,
         backend: crate::BackendId,
     },
+    #[error(
+        "{backend} backend provider {provider} does not support {capability} for {op} with dtype {dtype:?}"
+    )]
+    UnsupportedCapability {
+        op: &'static str,
+        backend: crate::BackendId,
+        provider: &'static str,
+        dtype: crate::DType,
+        capability: &'static str,
+    },
     #[error("{op}: division by zero for dtype {dtype:?}")]
     DivisionByZero {
         op: &'static str,
@@ -134,6 +144,41 @@ impl Error {
         backend: crate::BackendId,
     ) -> Self {
         Self::UnsupportedOpDType { op, dtype, backend }
+    }
+
+    /// Construct a structured backend/provider capability error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{BackendId, DType, Error};
+    ///
+    /// let err = Error::unsupported_capability(
+    ///     "prepare_svd",
+    ///     BackendId::Cpu,
+    ///     "blas",
+    ///     DType::F64,
+    ///     "prepared compact SVD",
+    /// );
+    /// assert!(matches!(
+    ///     err,
+    ///     Error::UnsupportedCapability { provider: "blas", .. }
+    /// ));
+    /// ```
+    pub fn unsupported_capability(
+        op: &'static str,
+        backend: crate::BackendId,
+        provider: &'static str,
+        dtype: crate::DType,
+        capability: &'static str,
+    ) -> Self {
+        Self::UnsupportedCapability {
+            op,
+            backend,
+            provider,
+            dtype,
+            capability,
+        }
     }
 
     /// Construct a structured division-by-zero domain error.

--- a/crates/tenferro-tensor/src/tests/error_tests.rs
+++ b/crates/tenferro-tensor/src/tests/error_tests.rs
@@ -1,0 +1,37 @@
+use crate::{BackendId, DType, Error};
+
+#[test]
+fn unsupported_capability_preserves_structured_context_and_display_contract() {
+    let error = Error::unsupported_capability(
+        "prepare_svd",
+        BackendId::Cpu,
+        "faer",
+        DType::C64,
+        "prepared compact SVD",
+    );
+
+    assert_eq!(
+        error,
+        Error::UnsupportedCapability {
+            op: "prepare_svd",
+            backend: BackendId::Cpu,
+            provider: "faer",
+            dtype: DType::C64,
+            capability: "prepared compact SVD",
+        }
+    );
+    assert!(matches!(
+        error,
+        Error::UnsupportedCapability {
+            op: "prepare_svd",
+            backend: BackendId::Cpu,
+            provider: "faer",
+            dtype: DType::C64,
+            capability: "prepared compact SVD",
+        }
+    ));
+    assert_eq!(
+        error.to_string(),
+        "cpu backend provider faer does not support prepared compact SVD for prepare_svd with dtype C64"
+    );
+}

--- a/crates/tenferro-tensor/src/tests/mod.rs
+++ b/crates/tenferro-tensor/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod backend_default_read_tests;
 mod capability_tests;
 mod config_tests;
 mod dispatch_tests;
+mod error_tests;
 mod op_vocabulary_contract_tests;
 mod public_surface_contract_tests;
 mod types_tests;

--- a/docs/design/contraction-pipeline.md
+++ b/docs/design/contraction-pipeline.md
@@ -100,8 +100,8 @@ CPU execution is handled by `CpuBackend`:
 - `dot_general` uses the selected CPU provider (`cpu-faer`, `cpu-blas`, or
   optional `cpu-tblis` for supported contractions),
 - faer-backed work runs inside the `CpuContext` Rayon pool through
-  `CpuExecSession`, with `Par::Seq` for one-thread contexts and `Par::rayon(0)`
-  for multi-thread contexts,
+  `CpuExecSession`, with `Par::Seq` for one-thread contexts and explicit
+  `Par::rayon(n)` from the configured degree for multi-thread contexts,
 - BLAS/LAPACK and TBLIS provider threading remain provider-owned.
 
 `cpu-tblis` is additive to the faer/BLAS providers. `CpuBackendKind` still

--- a/docs/design/cpu-backend-execution.md
+++ b/docs/design/cpu-backend-execution.md
@@ -34,7 +34,9 @@ once during `CpuContext` construction, before the constructor returns. An
 execution changes that shared active owner under RAII; workers consult the
 shared state when a nested backend entry is attempted. Entry must not broadcast
 owner metadata to every worker because that makes empty warm execution scale
-with the pool and allocate per call.
+with the pool and adds mandatory per-entry allocations. Rayon may still perform
+occasional scheduler maintenance allocations; the backend does not promise that
+an unbounded sequence of calls remains allocation-free.
 
 This propagation contract covers Rayon workers owned by the active
 `CpuContext`. Ambient global Rayon workers are not part of a managed execution

--- a/docs/design/cpu-backend-execution.md
+++ b/docs/design/cpu-backend-execution.md
@@ -29,6 +29,17 @@ task, and unrelated work submitted to the same active `CpuContext` are rejected
 before acquiring another permit. External-provider execution also rejects
 same-thread nesting.
 
+Each managed Rayon worker registers the engine's shared execution-scope state
+once during `CpuContext` construction, before the constructor returns. An
+execution changes that shared active owner under RAII; workers consult the
+shared state when a nested backend entry is attempted. Entry must not broadcast
+owner metadata to every worker because that makes empty warm execution scale
+with the pool and allocate per call.
+
+This propagation contract covers Rayon workers owned by the active
+`CpuContext`. Ambient global Rayon workers are not part of a managed execution
+scope; tests for child-task propagation must use an explicit owned context.
+
 This intentionally does not infer permission from an execution owner. During a
 cross-pool wait Rayon may schedule a parallel sibling on the same OS worker as
 the direct call chain, so thread-local identity cannot distinguish those cases.

--- a/docs/design/exec-session.md
+++ b/docs/design/exec-session.md
@@ -41,7 +41,8 @@ backend segment instead of one per instruction.
 by tenferro-owned multi-threaded CPU work. `CpuContext::install` runs the
 closure on that owned pool for multi-thread contexts and inline for one-thread
 contexts. faer-backed kernels use `Par::Seq` for one thread and
-`Par::rayon(0)` otherwise, so faer joins the already-entered `CpuContext` pool.
+explicit `Par::rayon(n)` otherwise, so policy construction cannot inherit an
+unrelated ambient Rayon degree before joining the `CpuContext` pool.
 
 ```rust
 impl TensorBackend for CpuBackend {
@@ -79,7 +80,7 @@ or calls the relevant cuTENSOR/cuSOLVER/cuBLAS wrapper against the backend's
 | CPU concept | CubeCL/CUDA concept |
 |---|---|
 | `CpuContext` (thread count and Rayon pool) | `CudaRuntime` (CUDA device/client) |
-| `Par::rayon(0)` / `Par::Seq` | CubeCL launch through the stored runtime |
+| explicit `Par::rayon(n)` / `Par::Seq` | CubeCL launch through the stored runtime |
 | `BufferPool` (host `Vec<T>`) | CubeCL device buffers plus upload/download helpers |
 | faer/rayon CPU work | kernel launch on stream |
 | per-step session setup overhead | per-kernel launch/runtime dispatch overhead |

--- a/docs/design/linalg-prims.md
+++ b/docs/design/linalg-prims.md
@@ -106,3 +106,90 @@ The scalar side is intentionally split:
 
 That separation keeps public/high-level linalg APIs backend-generic without
 leaking CPU-specific scalar trait names.
+
+## Prepared Factorization Contract
+
+Prepared factorization is a separate public expert path; it does not change
+the convenient owned-output methods on `LinalgBackend`. An immutable plan
+binds the operation, shape, dtype, options, provider, placement, and execution
+context. A caller explicitly allocates one opaque mutable workspace per
+concurrency lane and supplies caller-owned destinations to `execute_into`.
+
+Callers that factorize many independent matrices may enter an opaque
+`PreparedFactorizationSession` once and call operation-specific leaf methods
+such as `PreparedSvd::execute_into_session`. The session is operation-neutral
+so compact QR and EIGH can share the same lifecycle later. It is neither
+constructible nor cloneable, and its callback-scoped lifetime prevents it from
+escaping the backend execution domain. Standalone `execute_into` is defined as
+a one-leaf session adapter rather than a separate execution path.
+
+`TensorRead` and `TensorWrite` descriptors belong to caller setup and are
+evaluated before an execution method is entered. Dynamic-rank view descriptors
+own shape and stride metadata, so constructing or cloning them may allocate.
+The prepared-leaf contract begins with preconstructed descriptors; it does not
+hide descriptor construction inside execution. A separate rank-2 descriptor
+API is deliberately not introduced because it would duplicate the canonical
+tensor view contract.
+
+The first implementation is compact SVD through Faer. For an `m x n` input and
+`k = min(m, n)`, its exact outputs are `U: [m, k]`, `S: [k]`, and
+`Vt: [k, n]`. The workspace retains Faer scratch, signed-stride input packing,
+singular-value staging where required by the scalar ABI, and the `V` staging
+needed to produce public conjugate-transposed `Vt`.
+
+Execution follows these invariants:
+
+- validate backend/workspace identity, all metadata, layout, placement, and
+  conservative alias regions before the first output write;
+- return structured capability errors for unsupported provider, dtype,
+  placement, or layout instead of calling the owned API;
+- pass compatible borrowed inputs and compact destinations directly to the
+  provider, using only workspace-owned staging at documented boundaries;
+- apply gauge normalization in place; and
+- reuse all tenferro-controlled output, input-pack, and provider-workspace
+  storage without growing it after plan/workspace/output warm-up.
+
+Strict Rust global-allocator zero is evidence for the measured small sequential
+Faer regime, not a guarantee for every shape. Faer's numerical kernels may
+allocate their own internal metadata even with one worker, and its parallel
+Rayon/Spindle path may allocate scheduler storage. Those provider-internal
+allocations are explicitly outside the retained tenferro-storage contract and
+must be reported by shape and provider rather than hidden behind an unsupported
+fixed upper bound. The first implementation documents this distinction instead
+of adding a public capability enum before another provider needs one.
+
+On CPU, session entry acquires the resource permit and installs the managed
+execution owner exactly once. Leaves validate the retained backend, plan, and
+workspace bindings and invoke the provider directly; they do not call
+`CpuBackend::install`, broadcast worker state, or reacquire arbitration. The
+CPU implementation uses static session construction plus a private enum at the
+operation leaf. A tensor `BackendSession` trait object was rejected because
+factorization leaves neither need its buffer pool nor its dynamic operation
+surface.
+
+`CpuLinalgBinding` is a narrow opaque interop contract owned by
+`tenferro-cpu`. It retains coordinator and context allocations so backend
+identity cannot suffer pointer reuse, but application code must not inspect or
+construct it. Provider-specific resources remain private to the implementation
+and never appear in the backend-neutral prepared API.
+
+The workspace is deliberately not `Clone`. Multiple workspaces may be created
+from one plan, while Rust's exclusive `&mut SvdWorkspace` prevents ordinary
+concurrent reuse of a single workspace. Validation failures are atomic for all
+destinations; a provider numerical failure after writes begin may leave partial
+output and is reported without an allocating rollback.
+
+Prepared-resource `Debug` output distinguishes ownership from sizing. The plan's
+`plan_retained_bytes` counts provider-private heap buffers owned by the plan
+(zero for Faer's inline `StackReq` metadata), while `workspace_required_bytes`
+is the logical byte requirement computed at preparation. A workspace reports
+that logical requirement separately from `workspace_retained_bytes`, which
+counts its actual scratch length and vector capacities. Shared execution-context
+storage, backend binding and identity-token metadata, and inline Rust object
+size are outside these provider-resource counts.
+
+`PreparedSvd::retained_bytes` and `SvdWorkspace::retained_bytes` expose those
+currently retained provider-private heap bytes without parsing `Debug`. They are
+read-only, allocation-free snapshots, not estimates of total process memory.
+Provider representation determines the value; callers must not infer monotonic
+ordering across shapes, dtypes, options, or providers.

--- a/docs/design/tensor-prims.md
+++ b/docs/design/tensor-prims.md
@@ -97,9 +97,9 @@ multi-thread contexts.
 `CpuExecSession`, reusing the backend buffer pool and avoiding per-op session
 setup. Session execution enters `CpuContext::install`, so strided CPU kernels
 use the backend-owned Rayon pool when `strided-kernel/parallel` is enabled.
-faer-backed kernels receive `Par::Seq` for one thread or `Par::rayon(0)` for
-multi-threaded execution inside that pool. BLAS/LAPACK and TBLIS provider
-threading remain provider-owned.
+faer-backed kernels receive `Par::Seq` for one thread or explicit
+`Par::rayon(n)` from the configured context degree for multi-threaded execution
+inside that pool. BLAS/LAPACK and TBLIS provider threading remain provider-owned.
 
 ## CubeCL Backend
 

--- a/docs/guides/parallelism-and-caching.md
+++ b/docs/guides/parallelism-and-caching.md
@@ -86,7 +86,7 @@ pool before dispatching tensor-sized kernels.
 | Elementwise and analytic ops | `strided-kernel` map/zip kernels run under `CpuContext` and can use Rayon when the context has more than one thread. |
 | Reductions | `strided-kernel::reduce_axis` runs under `CpuContext` and can use Rayon when the context has more than one thread. |
 | Materialized transpose/permute, broadcast, convert, and diagonal extraction | `strided-kernel` copy/map kernels run under `CpuContext` and can use Rayon for tensor-sized copies. |
-| `dot_general` through `cpu-faer` | faer receives `Par::Seq` for one-thread contexts and `Par::rayon(0)` inside the owned `CpuContext` pool for multi-thread contexts. |
+| `dot_general` through `cpu-faer` | faer receives `Par::Seq` for one-thread contexts and explicit `Par::rayon(n)` using the configured context degree for multi-thread contexts. |
 | GEMM and linalg through `cpu-blas` | Threading is owned by the linked BLAS/LAPACK provider, not Rayon. Configure the provider variables below. |
 | Supported `dot_general` contractions through `cpu-tblis` | TBLIS owns provider threading; unsupported TBLIS shapes fall back to the compiled faer/BLAS provider. |
 | Indexing, scatter/gather, slicing, padding, concatenation, reverse, triangular masks, and `embed_diagonal` | These are dedicated sequential CPU loops today because their per-output indexing patterns do not yet have a strided-kernel/backend-native parallel primitive. They still run inside `CpuContext::install`, and source comments mark the intentional sequential path. |

--- a/docs/performance/tt-inner-product-overhead.md
+++ b/docs/performance/tt-inner-product-overhead.md
@@ -242,10 +242,9 @@ and spindle rely on the current or global Rayon context through
 
 The current faer backend runs GEMM work inside `CpuContext::install`.
 `CpuContext` stores the requested thread count, maps one thread to `Par::Seq`,
-and maps multi-threaded execution to `Par::rayon(0)` while executing inside the
-context-owned Rayon pool. faer expands `Par::rayon(0)` through
-`rayon::current_num_threads()`, so `CpuContext::with_threads(n)` still controls
-the faer parallelism degree for work run under the context.
+and maps multi-threaded execution to explicit `Par::rayon(n)`. The explicit
+degree keeps `CpuContext::with_threads(n)` authoritative even when a Faer plan
+or policy is created before entering the context-owned Rayon pool.
 
 The benchmark below is cached `site_update`, `Complex64`, `d = 2`, with all
 known BLAS/OpenMP thread pools set to one thread. Times are Criterion means in
@@ -269,14 +268,14 @@ each tiny GEMM parallel.
 
 The production policy keeps `CpuContext` as the owner of CPU execution scope.
 This preserves pool isolation for backends that enter through
-`CpuContext::install`; within that scope, faer uses `Par::rayon(0)` to read the
-current context pool size instead of receiving `n` as an independent count.
+`CpuContext::install`; Faer receives the same explicit configured degree both
+inside and outside that scope.
 
 Design implications:
 
 - For one-thread faer, `Par::Seq` avoids Rayon dispatch.
-- For multi-thread faer, call faer-backed kernels from within
-  `CpuContext::install` so `Par::rayon(0)` observes the configured context pool.
+- For multi-thread Faer, pass the configured context degree explicitly and run
+  faer-backed kernels from within `CpuContext::install` for pool isolation.
 - Add a small-shape policy that keeps tiny faer GEMMs sequential even when the
   backend context has more than one thread.
 - A true pool-handle patch would need changes across faer, spindle, and the
@@ -313,8 +312,8 @@ This preserves Rayon pool semantics, but it is expensive for tiny GEMMs.
   caller-thread pool wrapper. This covers `cholesky`, `triangular_solve`, `lu`,
   `full_piv_lu`, `full_piv_lu_solve`, `svd`, `qr`, `eigh`, and `eig`. The
   `cpu-faer` backend uses `CpuContext::install`; one-thread contexts pass
-  `Par::Seq`, and multi-thread contexts pass `Par::rayon(0)` so faer reads the
-  current context pool size.
+  `Par::Seq`, and multi-thread contexts pass explicit `Par::rayon(n)` using the
+  configured context degree.
 - The BLAS conjugation path now detects row-contiguous conjugated operands before
   acquiring an output buffer for a direct BLAS attempt that cannot succeed.
 

--- a/docs/superpowers/specs/2026-07-14-numa-cpu-execution-design.md
+++ b/docs/superpowers/specs/2026-07-14-numa-cpu-execution-design.md
@@ -144,7 +144,8 @@ After resolving placement and acquiring the engine permit, one session remains
 alive for the complete graph. The graph enters the selected Rayon pool once.
 Within that scope:
 
-- faer uses `Par::Seq` for a one-worker engine and `Par::rayon(0)` otherwise;
+- faer uses `Par::Seq` for a one-worker engine and explicit `Par::rayon(n)`
+  from the configured engine degree otherwise;
 - native elementwise, reduction, structural, and other Rayon-backed kernels use
   the same ambient pool;
 - Host and supported extension/FFI boundaries do not recreate the engine

--- a/docs/worklogs/2026-07-15-cpu-install-allocation.md
+++ b/docs/worklogs/2026-07-15-cpu-install-allocation.md
@@ -1,12 +1,14 @@
-# CPU Empty-Install Allocation Removal
+# CPU Mandatory Empty-Install Allocation Removal
 
 ## Summary
 
-Warm `CpuBackend::install` allocated even when its closure was empty. The
+Every warm `CpuBackend::install` allocated even when its closure was empty. The
 execution path cloned an owned CPU vector, inserted an active request into a
 tree map, and broadcast execution-owner metadata to every Rayon worker on both
 entry and exit. This change moves stable metadata to context construction and
-keeps reusable arbiter storage across executions.
+keeps reusable arbiter storage across executions. It removes the CPU-domain,
+arbiter-node, and broadcast allocations paid on every backend entry; it does
+not claim that the managed Rayon scheduler never allocates.
 
 ## Context Read
 
@@ -42,8 +44,29 @@ keeps reusable arbiter storage across executions.
 
 ## Verification
 
-- A dedicated integration-test allocator measures public empty installs after
-  warm-up for one, two, and four workers.
+- Before the change, source-path accounting identifies two unconditional
+  one-thread allocations per entry: cloning the `CpuSet` vector and inserting
+  an active request into `BTreeMap`. Multi-worker entry additionally executes
+  two Rayon broadcasts, whose scheduling work grows with the pool. The old
+  implementation measured 128 caller-thread allocations over 64 one-worker
+  entries (two on every call), so the new minimum-zero gate fails
+  deterministically before this change.
+- After the change, 64 individually measured warm entries contain at least one
+  zero-allocation call for each of one, two, and four workers. Repeating that
+  gate five times passed. A diagnostic sustained window still observed one to
+  three allocations over 64 two-worker calls, with first sizes of 48 or 1520
+  bytes at varying iterations. Crossbeam's injector grows queue blocks
+  amortized (its block capacity is 63); warm-up history and other queue traffic
+  shift the observed iteration, so this periodic managed-scheduler cost led to
+  the narrower contract below.
+- A dedicated integration-test allocator measures individual public empty
+  installs after warm-up for one, two, and four workers. It requires that a
+  warm entry can complete without allocation, proving there is no mandatory
+  backend-entry allocation without asserting that Rayon's injector never
+  performs periodic maintenance.
+- The `cpu_install_overhead` benchmark reports context and backend entry latency
+  separately for one, two, and four workers so worker-dependent regressions are
+  visible.
 - Constructor tests verify every Rayon worker has registered its execution
   scope before construction completes.
 - Existing tests cover direct and independent backend nesting, cross-pool
@@ -56,6 +79,12 @@ keeps reusable arbiter storage across executions.
   outside this execution-scope contract.
 
 ## Residual Risk
+
+The managed Rayon's injector occasionally allocates scheduler storage after
+warm-up. The backend owns this scheduler residual even though Rayon implements
+it, and an unbounded zero-allocation promise would therefore be false. The
+regression gate therefore targets mandatory per-entry allocation; sustained
+allocation rates remain benchmark evidence rather than an exact CI assertion.
 
 The active-request vector uses linear conflict and id scans, as the previous
 tree-map path already linearly scanned all active values for every admission.

--- a/docs/worklogs/2026-07-15-cpu-install-allocation.md
+++ b/docs/worklogs/2026-07-15-cpu-install-allocation.md
@@ -1,0 +1,63 @@
+# CPU Empty-Install Allocation Removal
+
+## Summary
+
+Warm `CpuBackend::install` allocated even when its closure was empty. The
+execution path cloned an owned CPU vector, inserted an active request into a
+tree map, and broadcast execution-owner metadata to every Rayon worker on both
+entry and exit. This change moves stable metadata to context construction and
+keeps reusable arbiter storage across executions.
+
+## Context Read
+
+- `crates/tenferro-cpu/src/{topology,arbiter,context,backend}.rs`
+- CPU context, arbiter, backend reentry, placement, and topology tests
+- `docs/design/cpu-backend-execution.md`
+- Repository-local and shared Rust performance rules
+
+## Decisions
+
+- Store `CpuSet` data in `Arc<[CpuId]>`. CPU domains are immutable structural
+  metadata, so execution permits should share them instead of cloning a `Vec`.
+- Keep the arbiter's fair waiter queue as `VecDeque`. Store active requests in
+  a capacity-retaining `Vec`, because active admission only scans for conflicts
+  and removes by request id; ordering is not part of admission fairness.
+- Register one shared `Arc<ExecutionScopeState>` in every Rayon worker TLS at
+  context construction, and wait for all registrations before returning the
+  context. Execution entry changes the shared owner/depth under a mutex and an
+  RAII guard clears it after normal return or panic.
+- Keep the calling thread's execution-owner TLS. It rejects direct nesting;
+  worker TLS plus the shared active state rejects spawned, stolen, sibling, and
+  cross-pool reentry without per-execution broadcast.
+
+## Rejected Alternatives
+
+- Retaining Rayon `broadcast` would continue to make empty entry cost depend on
+  worker count and allocate scheduler jobs on the warm path.
+- An atomic owner without a depth/transition lock would make concurrent context
+  misuse and panic cleanup harder to reason about. The mutex is outside tensor
+  kernels and preserves the prior serialized owner invariant.
+- Replacing `VecDeque` waiters with an unordered retained container would risk
+  changing the established older-conflicting-waiter fairness contract.
+
+## Verification
+
+- A dedicated integration-test allocator measures public empty installs after
+  warm-up for one, two, and four workers.
+- Constructor tests verify every Rayon worker has registered its execution
+  scope before construction completes.
+- Existing tests cover direct and independent backend nesting, cross-pool
+  scheduling, stolen children, parallel siblings, shared contexts, panic
+  cleanup, overlapping/disjoint CPU domains, waiter fairness, and provider
+  exclusion.
+- The cross-pool fixture constructs explicit two-worker `CpuContext` pools so
+  it tests managed worker propagation on every platform. A one-thread
+  compatibility context has no owned Rayon worker, and ambient global Rayon is
+  outside this execution-scope contract.
+
+## Residual Risk
+
+The active-request vector uses linear conflict and id scans, as the previous
+tree-map path already linearly scanned all active values for every admission.
+The representation should be revisited only if workloads demonstrate a large
+number of simultaneous disjoint or explicitly reentrant permits.

--- a/docs/worklogs/2026-07-15-issue-1378-prepared-svd.md
+++ b/docs/worklogs/2026-07-15-issue-1378-prepared-svd.md
@@ -1,0 +1,149 @@
+# Issue 1378: Prepared Compact SVD
+
+## Goal
+
+Implement the accepted backend-neutral prepared factorization lifecycle for
+compact SVD, with Faer as the first provider and no owned-output fallback.
+
+## Decisions
+
+- Keep `PreparedSvd`, `SvdWorkspace`, and `SvdOutputWrites` public while
+  sealing provider dispatch.
+- Bind plans and workspaces to retained CPU coordinator/context identity; raw
+  pointer identity was rejected because allocator address reuse creates an ABA
+  failure mode.
+- Validate every input/output byte region before writes and conservatively
+  reject all six possible overlap pairs.
+- Write compact `U` directly, stage Faer's `V`, and conjugate-transpose it into
+  caller-owned `Vt`. Signed-stride inputs use a workspace pack buffer when they
+  cannot be borrowed directly.
+- Reuse the existing owned-path gauge implementation in place so prepared and
+  owned semantics cannot drift.
+- Represent unsupported provider/dtype/layout/binding as structured capability
+  errors. String-only backend failures were rejected because callers cannot
+  reliably branch on diagnostic text.
+- Report provider-resource bytes without conflating the plan and workspace:
+  Faer's plan retains no heap buffer, workspace required bytes are logical
+  prepared sizes, and workspace retained bytes include actual vector capacity.
+  Shared context storage and inline object size are deliberately excluded.
+- Add an operation-neutral `PreparedFactorizationSession` rather than an
+  SVD-specific session. Standalone execution is a one-leaf adapter, while
+  repeated leaves reuse one CPU permit, execution owner, and pool entry.
+- Keep the leaf path statically dispatched. Reusing tensor `BackendSession`
+  would introduce an unrelated trait object and buffer-pool loan; the prepared
+  session instead uses `CpuBackend::install` once and a private operation enum.
+
+## Session Amendment
+
+The original complete-call allocation contract exposed a multi-worker CPU
+coordination cost before it exposed a provider allocation. The amendment keeps
+the backend arbitration and reentry semantics intact while moving that cost to
+one explicit, operation-neutral session entry. A prepared leaf validates the
+session/backend, plan, workspace, input, destinations, and alias regions before
+writes, then invokes Faer without another install. Ordinary errors remain
+inside the session and panic unwinding releases the outer execution guard.
+
+The session callback uses a higher-ranked lifetime, so the opaque non-`Clone`
+handle cannot escape. One workspace remains exclusive to one lane; independent
+sessions and workspaces are the concurrency mechanism. Provider-specific
+threading and bindings remain private and can be replaced without changing the
+public lifecycle.
+
+Input and destination descriptors are caller-owned setup. Dynamic-rank
+`TensorRead` and `TensorWrite` view construction retains shape and stride
+metadata and may allocate before the leaf is entered. The allocation gate
+therefore preconstructs those descriptors rather than adding a second rank-2
+descriptor API that would duplicate the tensor view contract.
+
+Directly counting one CPU entry and zero leaf reentries would require exposing
+or test-instrumenting private backend coordination. This change does not add a
+public counter solely for tests. CPU reentry tests and the leaf allocation gate
+provide indirect evidence; integration callers should retain a structural
+executor-entry counter when adopting sessions so this invariant is gated at the
+call site as well.
+
+## Verification Method
+
+Focused correctness tests compare prepared and owned output semantics and
+check reconstruction plus both `U` and `Vt` unitarity. Contract tests cover
+empty dimensions, signed strides, compact output subviews, unchanged sentinel
+outputs on validation failure, all alias pairs, backend/plan/workspace mismatch,
+and independent workspaces.
+
+The allocator test counts the complete release-mode warm call, including
+validation, packing, provider execution, `Vt` conversion, and gauge. Retaining
+`CpuSet` storage and active-request capacity removed the two one-thread
+coordination allocations: contiguous/strided F64 and contiguous C64 now measure
+zero. A two-thread probe still measured six allocations, exactly matching an
+empty `CpuBackend::install`, while `CpuContext::install` measured zero. That
+probe motivated amortizing backend entry through the session. It did not prove
+that provider scheduler activity inside later leaves would remain globally
+allocation-free.
+
+The session allocator amendment measures at least 128 F64 and C64 leaves for
+contiguous and non-compact strided inputs. Session construction and warm-up are
+excluded. The small one-worker cases retain strict global-zero gates as measured
+evidence, not as an all-shape provider guarantee. Two- and four-worker runs
+retain repeated-leaf correctness and benchmark coverage, but deliberately have
+no allocation upper-bound assertion.
+
+That distinction follows a release-mode repetition study: 23 of 30 multiworker
+runs failed the proposed global-zero assertion even after leaf warm-up. Splitting
+the four input cases showed the allocation bursts moving between measured
+windows; a representative two-worker failure reported `[25, 0, 0, 0]` for F64
+contiguous, F64 strided, C64 contiguous, and C64 strided. Re-running the same
+binary also alternated between zero and nonzero counts. A sequential-provider
+diagnostic made the attribution narrower: these moving bursts were dominated by
+managed Rayon activity from the outer session entry completing after the
+callback allocation counter became active. Separate Faer and Spindle internal
+allocation sources exist, but this experiment did not prove that they produced
+these particular moving counts.
+
+An independent 64x64 F64 source/root diagnostic primed and settled each path,
+then measured 47 provider allocations per call for one-worker sequential Faer.
+Its original two- and four-worker figures were discarded: `Par::rayon(0)` had
+captured the ambient global degree when the plan was prepared outside the
+managed pool, so those figures did not prove either configured worker count.
+After the CPU-context fix passed the configured degree explicitly, five release
+runs each confirmed actual degrees 1, 2, and 4. The allocation counts per call
+were 47 for one worker, 72 for two workers, and a median 112 for four workers;
+the four-worker totals over eight leaves were 896, 903, 896, 896, and 897. The
+sequential source includes the `did_pack_lhs` vectors in `gemm-common` 0.19.0
+`src/gemm.rs` (the sequential allocation at line 490 and per-worker storage at
+line 654). Faer 0.24.4 reaches Spindle 0.2.6 `for_each` through
+`src/utils/mod.rs::thread::join_raw`, including calls from
+`src/linalg/svd/bidiag.rs`; Spindle's `for_each_imp` reserves iterator-split
+storage at `src/lib.rs` line 660 and otherwise delegates work to Rayon when no
+Spindle root is installed. This evidence does not attribute Faer's calls to
+Spindle `with_lock` or its root-manager allocation.
+Consequently the accepted boundary is that
+tenferro-controlled output, pack, and prepared-workspace storage does not grow
+after warm-up. Provider-internal numerical and scheduler allocations remain
+allowed and are recorded by benchmark. No public capability enum is added until
+another provider demonstrates the abstraction it must express.
+
+External merge remains blocked until the accepted prepared-factorization issues
+approve this operation-neutral session amendment. The local implementation and
+verification do not change that issue-acceptance gate.
+
+The Criterion benchmark uses persistent one- and two-thread Faer backends per
+path. Preparation, workspace allocation, and destination allocation are outside
+the prepared timer. Owned `svd_read` includes result allocation and destruction;
+prepared timing includes destination overwrite. Shapes cover square, tall, and
+wide matrices from 2-wide through 64-square. A separate one-thread 8x4 case
+compares the same positive-stride borrowed view on both paths.
+
+On the local arm64 macOS host, a release `--quick` run at this branch's HEAD
+measured these two-worker ratios using the reported point estimates:
+
+| Shape / input | Threads | Owned | Prepared | Owned / prepared |
+| --- | ---: | ---: | ---: | ---: |
+| 2x2 compact | 2 | 6.339 us | 5.737 us | 1.10x |
+| 4x4 compact | 2 | 7.442 us | 6.880 us | 1.08x |
+| 16x16 compact | 2 | 25.944 us | 25.533 us | 1.02x |
+| 64x64 compact | 2 | 435.47 us | 429.45 us | 1.01x |
+
+The CPU execution-scope prerequisite removes the former roughly 18 us small
+matrix entry penalty. The standalone prepared adapter still enters one session
+per call; callers with multiple leaves use the explicit session API to amortize
+that remaining entry boundary.


### PR DESCRIPTION
## Why

A persistent managed CPU context still rebuilt execution coordination on every entry: immutable CPU domains were cloned, active arbiter requests used allocating tree nodes, and execution-owner state was broadcast to every worker on entry and exit. Faer policy prepared outside the owned pool could also capture an unrelated ambient Rayon degree.

This made empty warm entry pay costs unrelated to the numerical operation and made provider planning depend on where it was constructed.

Closes #1388.

Supersedes #1389, whose external-head repository-rules job was rejected by CI policy. This PR uses the identical reviewed commit and tree from a same-repository branch.

## What changed

- Store immutable `CpuSet` contents in shared `Arc<[CpuId]>` storage.
- Retain active-request capacity in the resource arbiter while preserving the fair waiter queue, conflict rules, reentry, and RAII release behavior.
- Register a shared worker execution scope once when a managed Rayon pool is constructed, then update its owner/depth without per-entry broadcasts.
- Derive Faer parallelism explicitly from the configured `CpuContext` degree, including policies created outside the managed pool.
- Add allocation, panic/reentry, worker-registration, provider-policy, source-contract, and benchmark coverage.
- Keep the TBLIS selection/fallback and provider-owned threading contract introduced by #1344 unchanged.

## Allocation boundary

The regression contract removes mandatory tenferro-owned allocation from compatible warm managed entry. It does not promise that Rayon never grows injector storage or that third-party providers never allocate. The sustained diagnostic observed occasional scheduler allocations after warmup, so the CI gate verifies that warm entry can complete without a mandatory allocation for one, two, and four configured workers rather than claiming unbounded global zero allocation.

## Verification

- `cpu-faer` lib tests: 288 passed on macOS, including the portable cross-pool reentry fixture.
- Release `install_allocation_tests`: 1 passed.
- `cargo check --no-default-features --features cpu-blas`: passed.
- `cargo check --no-default-features --features cpu-faer,cpu-tblis`: passed with the dynamic-loading TBLIS feature. This is a compile check; an external TBLIS link/runtime was not exercised.
- TBLIS provider source-contract tests: 5 passed in independent review.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- Independent review of the final range found no P0-P2 issues.

## Platform note

An earlier broader macOS CPU run on the pre-#1344 base reported five placement/NUMA failures caused by unsupported managed-affinity environment assumptions, not by numerical or execution-scope results. #1344 made those platform requirements explicit and cfg-gated the affected fixtures. On the current base, the macOS `cpu-faer` lib suite passes 288/288; the newly portable cross-pool fixture runs on macOS rather than being hidden by the placement gate.
