### PR TITLE
Add prepared factorization sessions and compact SVD

### DIFF
--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -651,6 +651,42 @@ pub struct CpuBackend {
     dot_general_provider: DotGeneralProvider,
 }
 
+/// Opaque binding token for operation-family prepared execution resources.
+///
+/// The token retains the coordinator and context allocations so identity cannot
+/// be recycled while a prepared plan is alive. Application code should not
+/// inspect or construct this interop type.
+///
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct CpuLinalgBinding {
+    shared: Arc<CpuBackendState>,
+    context: Arc<CpuContext>,
+    kind: CpuBackendKind,
+    threads: usize,
+}
+
+impl fmt::Debug for CpuLinalgBinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CpuLinalgBinding")
+            .field("kind", &self.kind)
+            .field("threads", &self.threads)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CpuLinalgBinding {
+    /// Return whether `backend` uses the exact retained provider resources.
+    ///
+    #[doc(hidden)]
+    pub fn matches(&self, backend: &CpuBackend) -> bool {
+        self.kind == backend.kind()
+            && self.threads == backend.num_threads()
+            && Arc::ptr_eq(&self.shared, &backend.shared)
+            && Arc::ptr_eq(&self.context, &backend.engine.context_arc())
+    }
+}
+
 fn resolve_discovered_topology(
     kind: CpuBackendKind,
     topology: Result<CpuTopology, CpuTopologyError>,
@@ -1506,6 +1542,23 @@ impl CpuBackend {
     #[doc(hidden)]
     pub fn linalg_context(&self) -> Arc<CpuContext> {
         self.engine.context_arc()
+    }
+
+    /// Retain the coordinator and execution-context identity used by
+    /// operation-family prepared plans.
+    ///
+    /// This is backend interop rather than application-facing identity. A
+    /// prepared plan uses both values so a clone sharing the same execution
+    /// resources is accepted while a separately constructed backend is not.
+    ///
+    #[doc(hidden)]
+    pub fn linalg_binding(&self) -> CpuLinalgBinding {
+        CpuLinalgBinding {
+            shared: Arc::clone(&self.shared),
+            context: self.engine.context_arc(),
+            kind: self.kind(),
+            threads: self.num_threads(),
+        }
     }
 
     // Selected when the Faer provider handles cached GEMM execution; some

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -94,7 +94,7 @@ pub use affinity::{available_parallelism, process_cpu_affinity, process_cpu_affi
 pub use analytic::pow;
 pub use backend::{
     CpuBackend, CpuBackendError, CpuBackendKind, CpuExecutionInfo, CpuExecutionMode,
-    DotGeneralProvider,
+    CpuLinalgBinding, DotGeneralProvider,
 };
 pub use buffer_pool::BufferPoolStats;
 pub use capability::cpu_capabilities;

--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -99,3 +99,8 @@ criterion.workspace = true
 name = "lu_ad_breakdown"
 harness = false
 required-features = ["autodiff"]
+
+[[bench]]
+name = "prepared_svd"
+harness = false
+required-features = ["cpu-faer"]

--- a/crates/tenferro-linalg/benches/prepared_svd.rs
+++ b/crates/tenferro-linalg/benches/prepared_svd.rs
@@ -1,0 +1,96 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+use tenferro_linalg::{LinalgBackend, PreparedSvdBackendExt, SvdOptions, SvdOutputWrites};
+use tenferro_tensor::{DType, Tensor, TensorRead, TensorView, TensorWrite, TypedTensor};
+
+const SHAPES: &[[usize; 2]] = &[
+    [4, 4],
+    [8, 4],
+    [4, 8],
+    [16, 16],
+    [32, 16],
+    [16, 32],
+    [64, 64],
+];
+
+fn matrix([m, n]: [usize; 2]) -> TypedTensor<f64> {
+    let data = (0..n)
+        .flat_map(|col| {
+            (0..m).map(move |row| {
+                let diagonal = if row == col { 2.0 } else { 0.0 };
+                diagonal + ((row * 17 + col * 31 + 1) % 97) as f64 / 97.0
+            })
+        })
+        .collect();
+    TypedTensor::from_vec_col_major(vec![m, n], data).unwrap()
+}
+
+fn outputs([m, n]: [usize; 2]) -> (Tensor, Tensor, Tensor) {
+    let k = m.min(n);
+    (
+        Tensor::from_vec_col_major(vec![m, k], vec![0.0_f64; m * k]).unwrap(),
+        Tensor::from_vec_col_major(vec![k], vec![0.0_f64; k]).unwrap(),
+        Tensor::from_vec_col_major(vec![k, n], vec![0.0_f64; k * n]).unwrap(),
+    )
+}
+
+fn bench_prepared_svd(c: &mut Criterion) {
+    let mut group = c.benchmark_group("faer_f64_compact_svd");
+    for &shape in SHAPES {
+        let input = matrix(shape);
+
+        let mut owned_backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+        let owned_id = BenchmarkId::new("owned_svd_read", format!("{}x{}", shape[0], shape[1]));
+        group.bench_with_input(owned_id, &shape, |b, _| {
+            b.iter(|| {
+                let result = owned_backend
+                    .svd_read(TensorView::F64(input.as_view()))
+                    .unwrap();
+                black_box(result);
+            });
+        });
+
+        let mut prepared_backend =
+            CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+        let plan = prepared_backend
+            .prepare_svd(shape, DType::F64, SvdOptions::default())
+            .unwrap();
+        let mut workspace = plan.allocate_workspace(&mut prepared_backend).unwrap();
+        let (mut u, mut s, mut vt) = outputs(shape);
+        plan.execute_into(
+            &mut prepared_backend,
+            &mut workspace,
+            TensorRead::from_view(TensorView::F64(input.as_view())),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+        let prepared_id = BenchmarkId::new(
+            "prepared_execute_into",
+            format!("{}x{}", shape[0], shape[1]),
+        );
+        group.bench_with_input(prepared_id, &shape, |b, _| {
+            b.iter(|| {
+                plan.execute_into(
+                    &mut prepared_backend,
+                    &mut workspace,
+                    TensorRead::from_view(TensorView::F64(input.as_view())),
+                    SvdOutputWrites::new(
+                        TensorWrite::from_tensor(&mut u),
+                        TensorWrite::from_tensor(&mut s),
+                        TensorWrite::from_tensor(&mut vt),
+                    ),
+                )
+                .unwrap();
+                black_box((&u, &s, &vt));
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_prepared_svd);
+criterion_main!(benches);

--- a/crates/tenferro-linalg/benches/prepared_svd.rs
+++ b/crates/tenferro-linalg/benches/prepared_svd.rs
@@ -1,9 +1,14 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use tenferro_cpu::{CpuBackend, CpuBackendKind};
 use tenferro_linalg::{LinalgBackend, PreparedSvdBackendExt, SvdOptions, SvdOutputWrites};
-use tenferro_tensor::{DType, Tensor, TensorRead, TensorView, TensorWrite, TypedTensor};
+use tenferro_tensor::{
+    DType, Tensor, TensorRead, TensorView, TensorWrite, TypedTensor, TypedTensorView,
+};
 
 const SHAPES: &[[usize; 2]] = &[
+    [2, 2],
+    [4, 2],
+    [2, 4],
     [4, 4],
     [8, 4],
     [4, 8],
@@ -12,6 +17,7 @@ const SHAPES: &[[usize; 2]] = &[
     [16, 32],
     [64, 64],
 ];
+const THREADS: &[usize] = &[1, 2];
 
 fn matrix([m, n]: [usize; 2]) -> TypedTensor<f64> {
     let data = (0..n)
@@ -36,59 +42,112 @@ fn outputs([m, n]: [usize; 2]) -> (Tensor, Tensor, Tensor) {
 
 fn bench_prepared_svd(c: &mut Criterion) {
     let mut group = c.benchmark_group("faer_f64_compact_svd");
-    for &shape in SHAPES {
-        let input = matrix(shape);
+    for &threads in THREADS {
+        for &shape in SHAPES {
+            let input = matrix(shape);
 
-        let mut owned_backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
-        let owned_id = BenchmarkId::new("owned_svd_read", format!("{}x{}", shape[0], shape[1]));
-        group.bench_with_input(owned_id, &shape, |b, _| {
-            b.iter(|| {
-                let result = owned_backend
-                    .svd_read(TensorView::F64(input.as_view()))
-                    .unwrap();
-                black_box(result);
+            let mut owned_backend =
+                CpuBackend::with_threads_and_kind(threads, CpuBackendKind::Faer).unwrap();
+            let owned_id = BenchmarkId::new(
+                "owned_svd_read",
+                format!("{}x{}/t{threads}", shape[0], shape[1]),
+            );
+            group.bench_with_input(owned_id, &shape, |b, _| {
+                b.iter(|| {
+                    let result = owned_backend
+                        .svd_read(TensorView::F64(input.as_view()))
+                        .unwrap();
+                    black_box(result);
+                });
             });
-        });
 
-        let mut prepared_backend =
-            CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
-        let plan = prepared_backend
-            .prepare_svd(shape, DType::F64, SvdOptions::default())
-            .unwrap();
-        let mut workspace = plan.allocate_workspace(&mut prepared_backend).unwrap();
-        let (mut u, mut s, mut vt) = outputs(shape);
-        plan.execute_into(
-            &mut prepared_backend,
-            &mut workspace,
-            TensorRead::from_view(TensorView::F64(input.as_view())),
-            SvdOutputWrites::new(
-                TensorWrite::from_tensor(&mut u),
-                TensorWrite::from_tensor(&mut s),
-                TensorWrite::from_tensor(&mut vt),
-            ),
-        )
-        .unwrap();
-        let prepared_id = BenchmarkId::new(
-            "prepared_execute_into",
-            format!("{}x{}", shape[0], shape[1]),
-        );
-        group.bench_with_input(prepared_id, &shape, |b, _| {
-            b.iter(|| {
-                plan.execute_into(
-                    &mut prepared_backend,
-                    &mut workspace,
-                    TensorRead::from_view(TensorView::F64(input.as_view())),
-                    SvdOutputWrites::new(
-                        TensorWrite::from_tensor(&mut u),
-                        TensorWrite::from_tensor(&mut s),
-                        TensorWrite::from_tensor(&mut vt),
-                    ),
-                )
+            let mut prepared_backend =
+                CpuBackend::with_threads_and_kind(threads, CpuBackendKind::Faer).unwrap();
+            let plan = prepared_backend
+                .prepare_svd(shape, DType::F64, SvdOptions::default())
                 .unwrap();
-                black_box((&u, &s, &vt));
+            let mut workspace = plan.allocate_workspace(&mut prepared_backend).unwrap();
+            let (mut u, mut s, mut vt) = outputs(shape);
+            plan.execute_into(
+                &mut prepared_backend,
+                &mut workspace,
+                TensorRead::from_view(TensorView::F64(input.as_view())),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            let prepared_id = BenchmarkId::new(
+                "prepared_execute_into",
+                format!("{}x{}/t{threads}", shape[0], shape[1]),
+            );
+            group.bench_with_input(prepared_id, &shape, |b, _| {
+                b.iter(|| {
+                    plan.execute_into(
+                        &mut prepared_backend,
+                        &mut workspace,
+                        TensorRead::from_view(TensorView::F64(input.as_view())),
+                        SvdOutputWrites::new(
+                            TensorWrite::from_tensor(&mut u),
+                            TensorWrite::from_tensor(&mut s),
+                            TensorWrite::from_tensor(&mut vt),
+                        ),
+                    )
+                    .unwrap();
+                    black_box((&u, &s, &vt));
+                });
             });
-        });
+        }
     }
+    group.finish();
+
+    bench_strided_prepared_svd(c);
+}
+
+fn bench_strided_prepared_svd(c: &mut Criterion) {
+    let shape = [8, 4];
+    let input = matrix(shape);
+    let mut storage = vec![0.0_f64; 76];
+    let input_data = input.as_slice().unwrap();
+    for col in 0..shape[1] {
+        for row in 0..shape[0] {
+            storage[1 + 2 * row + 20 * col] = input_data[row + shape[0] * col];
+        }
+    }
+    let mut group = c.benchmark_group("faer_f64_compact_svd_positive_stride_t1");
+    let mut owned_backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    group.bench_function("owned_svd_read/8x4", |b| {
+        b.iter(|| {
+            let view = TypedTensorView::from_slice(shape, [2, 20], 1, &storage).unwrap();
+            black_box(owned_backend.svd_read(TensorView::F64(view)).unwrap());
+        });
+    });
+
+    let mut prepared_backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let plan = prepared_backend
+        .prepare_svd(shape, DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut prepared_backend).unwrap();
+    let (mut u, mut s, mut vt) = outputs(shape);
+    group.bench_function("prepared_execute_into/8x4", |b| {
+        b.iter(|| {
+            let view = TypedTensorView::from_slice(shape, [2, 20], 1, &storage).unwrap();
+            plan.execute_into(
+                &mut prepared_backend,
+                &mut workspace,
+                TensorRead::from_view(TensorView::F64(view)),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            black_box((&u, &s, &vt));
+        });
+    });
     group.finish();
 }
 

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -822,7 +822,7 @@ fn apply_canonical_pivot_svd_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::R
     }
 }
 
-fn canonicalize_svd_gauge_f64(
+pub(crate) fn canonicalize_svd_gauge_f64(
     u: &mut [f64],
     vt: &mut [f64],
     m: usize,
@@ -851,7 +851,7 @@ fn canonicalize_svd_gauge_f64(
     Ok(())
 }
 
-fn canonicalize_svd_gauge_f32(
+pub(crate) fn canonicalize_svd_gauge_f32(
     u: &mut [f32],
     vt: &mut [f32],
     m: usize,
@@ -880,7 +880,7 @@ fn canonicalize_svd_gauge_f32(
     Ok(())
 }
 
-fn canonicalize_svd_gauge_c64(
+pub(crate) fn canonicalize_svd_gauge_c64(
     u: &mut [Complex64],
     vt: &mut [Complex64],
     m: usize,
@@ -913,7 +913,7 @@ fn canonicalize_svd_gauge_c64(
     Ok(())
 }
 
-fn canonicalize_svd_gauge_c32(
+pub(crate) fn canonicalize_svd_gauge_c32(
     u: &mut [Complex32],
     vt: &mut [Complex32],
     m: usize,

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -37,6 +37,7 @@ mod eager_ext;
 mod extension;
 #[cfg(feature = "cuda")]
 mod gpu;
+mod prepared_svd;
 mod traced;
 
 #[cfg(feature = "autodiff")]
@@ -52,5 +53,9 @@ pub use eager_ext::EagerTensorLinalgExt;
 pub use extension::{
     register_runtime, EighGauge, EighOptions, QrGauge, QrOptions, SvdGauge, SvdOptions,
     DEFAULT_DECOMPOSITION_DERIVATIVE_EPS, LINALG_EXTENSION_FAMILY_ID,
+};
+pub use prepared_svd::{
+    PreparedSvd, PreparedSvdBackendExt, SvdOutputSpec, SvdOutputSpecs, SvdOutputWrites,
+    SvdWorkspace,
 };
 pub use traced::TracedTensorLinalgExt;

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -37,6 +37,7 @@ mod eager_ext;
 mod extension;
 #[cfg(feature = "cuda")]
 mod gpu;
+mod prepared_factorization;
 mod prepared_svd;
 mod traced;
 
@@ -54,6 +55,7 @@ pub use extension::{
     register_runtime, EighGauge, EighOptions, QrGauge, QrOptions, SvdGauge, SvdOptions,
     DEFAULT_DECOMPOSITION_DERIVATIVE_EPS, LINALG_EXTENSION_FAMILY_ID,
 };
+pub use prepared_factorization::{PreparedFactorizationBackendExt, PreparedFactorizationSession};
 pub use prepared_svd::{
     PreparedSvd, PreparedSvdBackendExt, SvdOutputSpec, SvdOutputSpecs, SvdOutputWrites,
     SvdWorkspace,

--- a/crates/tenferro-linalg/src/prepared_factorization.rs
+++ b/crates/tenferro-linalg/src/prepared_factorization.rs
@@ -1,0 +1,140 @@
+use std::fmt;
+use std::marker::PhantomData;
+
+use tenferro_cpu::CpuBackend;
+
+/// Exclusive execution scope shared by prepared factorization operations.
+///
+/// A session enters the backend execution domain once. Prepared SVD, QR, and
+/// eigendecomposition plans can then reuse that entry without reacquiring CPU
+/// resources for each matrix. The session is intentionally neither `Clone`
+/// nor constructible outside [`PreparedFactorizationBackendExt`].
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_linalg::PreparedFactorizationBackendExt;
+///
+/// let mut backend = CpuBackend::new();
+/// let entered = backend.with_prepared_factorization_session(|session| {
+///     format!("{session:?}").contains("PreparedFactorizationSession")
+/// });
+/// assert!(entered);
+/// ```
+///
+/// The callback-scoped session cannot escape:
+///
+/// ```compile_fail
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_linalg::{
+///     PreparedFactorizationBackendExt, PreparedFactorizationSession,
+/// };
+///
+/// fn escape(
+///     backend: &mut CpuBackend,
+/// ) -> &mut PreparedFactorizationSession<'_> {
+///     backend.with_prepared_factorization_session(|session| session)
+/// }
+/// ```
+pub struct PreparedFactorizationSession<'scope> {
+    pub(crate) inner: PreparedFactorizationSessionInner,
+    // Invariance prevents a session borrowed from the callback from escaping it.
+    _scope: PhantomData<&'scope mut &'scope ()>,
+}
+
+impl fmt::Debug for PreparedFactorizationSession<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PreparedFactorizationSession")
+            .field("device", &"cpu")
+            .finish_non_exhaustive()
+    }
+}
+
+pub(crate) enum PreparedFactorizationSessionInner {
+    Cpu(CpuPreparedFactorizationSession),
+}
+
+pub(crate) struct CpuPreparedFactorizationSession {
+    pub(crate) backend: CpuBackend,
+    #[cfg(feature = "cpu-faer")]
+    pub(crate) par: faer::Par,
+}
+
+/// Backend capability for grouping prepared factorization leaf executions.
+///
+/// The callback cannot return the opaque session. Multiple independent calls
+/// may run concurrently when their backend execution domains do not conflict.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_linalg::PreparedFactorizationBackendExt;
+///
+/// let mut backend = CpuBackend::new();
+/// let value = backend.with_prepared_factorization_session(|_| 2 + 3);
+/// assert_eq!(value, 5);
+/// ```
+pub trait PreparedFactorizationBackendExt: private::PreparedFactorizationDispatch {
+    /// Enter one backend execution scope for one or more prepared factorizations.
+    ///
+    /// Panic unwinding and ordinary return both release backend execution
+    /// ownership before this method returns.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::PreparedFactorizationBackendExt;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// backend.with_prepared_factorization_session(|session| {
+    ///     let _ = format!("{session:?}");
+    /// });
+    /// ```
+    fn with_prepared_factorization_session<R: Send>(
+        &mut self,
+        f: impl for<'scope> FnOnce(&mut PreparedFactorizationSession<'scope>) -> R + Send,
+    ) -> R {
+        private::PreparedFactorizationDispatch::with_prepared_factorization_session_impl(self, f)
+    }
+}
+
+impl<T: private::PreparedFactorizationDispatch> PreparedFactorizationBackendExt for T {}
+
+pub(crate) mod private {
+    use super::*;
+
+    pub trait PreparedFactorizationDispatch {
+        fn with_prepared_factorization_session_impl<R: Send>(
+            &mut self,
+            f: impl for<'scope> FnOnce(&mut PreparedFactorizationSession<'scope>) -> R + Send,
+        ) -> R;
+    }
+}
+
+impl private::PreparedFactorizationDispatch for CpuBackend {
+    fn with_prepared_factorization_session_impl<R: Send>(
+        &mut self,
+        f: impl for<'scope> FnOnce(&mut PreparedFactorizationSession<'scope>) -> R + Send,
+    ) -> R {
+        let session_backend = self.clone();
+        #[cfg(feature = "cpu-faer")]
+        let par = self.linalg_context().faer_par();
+
+        // A factorization session does not borrow the tensor buffer pool, so
+        // CpuBackend::install avoids BackendSession's unrelated dynamic surface.
+        self.install(move || {
+            let mut session = PreparedFactorizationSession {
+                inner: PreparedFactorizationSessionInner::Cpu(CpuPreparedFactorizationSession {
+                    backend: session_backend,
+                    #[cfg(feature = "cpu-faer")]
+                    par,
+                }),
+                _scope: PhantomData,
+            };
+            f(&mut session)
+        })
+    }
+}

--- a/crates/tenferro-linalg/src/prepared_svd.rs
+++ b/crates/tenferro-linalg/src/prepared_svd.rs
@@ -1,30 +1,41 @@
 use std::fmt;
+#[cfg(feature = "cpu-faer")]
 use std::mem::size_of;
+#[cfg(feature = "cpu-faer")]
 use std::sync::Arc;
 
+#[cfg(feature = "cpu-faer")]
 use faer::dyn_stack::{MemBuffer, MemStack, StackReq};
+#[cfg(feature = "cpu-faer")]
 use faer::{diag::DiagMut, MatMut, MatRef};
+#[cfg(feature = "cpu-faer")]
 use num_complex::{Complex32, Complex64};
-use tenferro_cpu::{CpuBackend, CpuBackendKind, CpuLinalgBinding};
+#[cfg(feature = "cpu-faer")]
+use tenferro_cpu::CpuLinalgBinding;
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+#[cfg(feature = "cpu-faer")]
 use tenferro_tensor::{
-    validate::checked_shape_product, BackendId, DType, Error, MemoryKind, Placement, Tensor,
-    TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensor, TypedTensorView,
-    TypedTensorViewMut,
+    validate::checked_shape_product, MemoryKind, Tensor, TensorView, TensorViewMut, TypedTensor,
+    TypedTensorView, TypedTensorViewMut,
 };
+use tenferro_tensor::{BackendId, DType, Error, Placement, TensorRead, TensorWrite};
 
+use crate::{backend::LinalgBackend, SvdOptions};
+#[cfg(feature = "cpu-faer")]
 use crate::{
-    backend::LinalgBackend,
     extension::{
         canonicalize_svd_gauge_c32, canonicalize_svd_gauge_c64, canonicalize_svd_gauge_f32,
         canonicalize_svd_gauge_f64, validate_derivative_eps,
     },
-    SvdGauge, SvdOptions,
+    SvdGauge,
 };
 
 const PREPARE_OP: &str = "prepare_svd";
 const EXECUTE_OP: &str = "PreparedSvd::execute_into";
 const PREPARED_CAPABILITY: &str = "prepared compact SVD";
+#[cfg(feature = "cpu-faer")]
 const BINDING_CAPABILITY: &str = "prepared SVD backend/context binding";
+#[cfg(feature = "cpu-faer")]
 const DESTINATION_CAPABILITY: &str = "compact column-major prepared SVD destination";
 
 /// Exact metadata for one prepared SVD output.
@@ -50,11 +61,35 @@ pub struct SvdOutputSpec {
 
 impl SvdOutputSpec {
     /// Return the exact output shape.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// # let mut backend = CpuBackend::new();
+    /// # let plan = backend.prepare_svd([3, 2], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().u().shape(), &[3, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn shape(&self) -> &[usize] {
         &self.shape
     }
 
     /// Return the exact output dtype.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// # let mut backend = CpuBackend::new();
+    /// # let plan = backend.prepare_svd([2, 2], DType::C64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().s().dtype(), DType::F64);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn dtype(&self) -> DType {
         self.dtype
     }
@@ -62,6 +97,18 @@ impl SvdOutputSpec {
     /// Return the default host placement expected for a newly allocated output.
     ///
     /// Pinned host destinations are also accepted by execution.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::{DType, MemoryKind};
+    /// # let mut backend = CpuBackend::new();
+    /// # let plan = backend.prepare_svd([2, 2], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().u().placement().memory_kind, MemoryKind::UnpinnedHost);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn placement(&self) -> &Placement {
         &self.placement
     }
@@ -92,16 +139,52 @@ pub struct SvdOutputSpecs {
 
 impl SvdOutputSpecs {
     /// Return the left-singular-vector output specification.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// # let mut backend = CpuBackend::new();
+    /// # let plan = backend.prepare_svd([4, 2], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().u().shape(), &[4, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn u(&self) -> &SvdOutputSpec {
         &self.u
     }
 
     /// Return the singular-value output specification.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// # let mut backend = CpuBackend::new();
+    /// # let plan = backend.prepare_svd([4, 2], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().s().shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn s(&self) -> &SvdOutputSpec {
         &self.s
     }
 
     /// Return the conjugate-transposed right-singular-vector output specification.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// # let mut backend = CpuBackend::new();
+    /// # let plan = backend.prepare_svd([2, 4], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().vt().shape(), &[2, 4]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn vt(&self) -> &SvdOutputSpec {
         &self.vt
     }
@@ -135,21 +218,77 @@ pub struct SvdOutputWrites<'a> {
 
 impl<'a> SvdOutputWrites<'a> {
     /// Bundle caller-owned `U`, `S`, and `Vt` destinations.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::SvdOutputWrites;
+    /// use tenferro_tensor::{Tensor, TensorWrite};
+    /// let mut u = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+    /// let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// let writes = SvdOutputWrites::new(
+    ///     TensorWrite::from_tensor(&mut u),
+    ///     TensorWrite::from_tensor(&mut s),
+    ///     TensorWrite::from_tensor(&mut vt),
+    /// );
+    /// assert_eq!(writes.s().shape(), &[1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn new(u: TensorWrite<'a>, s: TensorWrite<'a>, vt: TensorWrite<'a>) -> Self {
         Self { u, s, vt }
     }
 
     /// Inspect the `U` destination without mutating it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_linalg::SvdOutputWrites;
+    /// # use tenferro_tensor::{Tensor, TensorWrite};
+    /// # let mut u = Tensor::from_vec_col_major(vec![2, 1], vec![0.0_f64; 2])?;
+    /// # let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+    /// # let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// # let writes = SvdOutputWrites::new(TensorWrite::from_tensor(&mut u), TensorWrite::from_tensor(&mut s), TensorWrite::from_tensor(&mut vt));
+    /// assert_eq!(writes.u().shape(), &[2, 1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn u(&self) -> &TensorWrite<'a> {
         &self.u
     }
 
     /// Inspect the `S` destination without mutating it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_linalg::SvdOutputWrites;
+    /// # use tenferro_tensor::{Tensor, TensorWrite};
+    /// # let mut u = Tensor::from_vec_col_major(vec![2, 1], vec![0.0_f64; 2])?;
+    /// # let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+    /// # let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// # let writes = SvdOutputWrites::new(TensorWrite::from_tensor(&mut u), TensorWrite::from_tensor(&mut s), TensorWrite::from_tensor(&mut vt));
+    /// assert_eq!(writes.s().shape(), &[1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn s(&self) -> &TensorWrite<'a> {
         &self.s
     }
 
     /// Inspect the `Vt` destination without mutating it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_linalg::SvdOutputWrites;
+    /// # use tenferro_tensor::{Tensor, TensorWrite};
+    /// # let mut u = Tensor::from_vec_col_major(vec![2, 1], vec![0.0_f64; 2])?;
+    /// # let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+    /// # let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// # let writes = SvdOutputWrites::new(TensorWrite::from_tensor(&mut u), TensorWrite::from_tensor(&mut s), TensorWrite::from_tensor(&mut vt));
+    /// assert_eq!(writes.vt().shape(), &[1, 1]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn vt(&self) -> &TensorWrite<'a> {
         &self.vt
     }
@@ -197,30 +336,64 @@ pub struct PreparedSvd {
     dtype: DType,
     options: SvdOptions,
     specs: SvdOutputSpecs,
+    #[cfg(feature = "cpu-faer")]
     binding: CpuFaerBinding,
+    #[cfg(feature = "cpu-faer")]
     plan_token: Arc<()>,
+    #[cfg(feature = "cpu-faer")]
     provider: FaerPlan,
 }
 
 impl fmt::Debug for PreparedSvd {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PreparedSvd")
+        let mut debug = f.debug_struct("PreparedSvd");
+        debug
+            .field("operation", &"compact_svd")
             .field("shape", &self.shape)
             .field("dtype", &self.dtype)
             .field("options", &self.options)
             .field("provider", &"faer")
-            .field("scratch_bytes", &self.provider.scratch_bytes())
-            .finish_non_exhaustive()
+            .field("device", &"cpu");
+        #[cfg(feature = "cpu-faer")]
+        debug
+            .field("context", &self.binding)
+            .field("scratch_bytes", &self.provider.scratch_bytes());
+        debug.finish_non_exhaustive()
     }
 }
 
 impl PreparedSvd {
     /// Return exact `U`, `S`, and `Vt` output metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// # let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([5, 3], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().s().shape(), &[3]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn output_specs(&self) -> &SvdOutputSpecs {
         &self.specs
     }
 
     /// Allocate one opaque workspace bound to this plan and backend context.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use tenferro_cpu::CpuBackend;
+    /// # use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// # use tenferro_tensor::DType;
+    /// let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([2, 2], DType::F64, SvdOptions::default())?;
+    /// let workspace = plan.allocate_workspace(&mut backend)?;
+    /// assert!(format!("{workspace:?}").contains("SvdWorkspace"));
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn allocate_workspace<B: PreparedSvdBackendExt>(
         &self,
         backend: &mut B,
@@ -233,6 +406,33 @@ impl PreparedSvd {
     /// All metadata and overlap checks complete before the first output write.
     /// Once the provider call starts, a numerical provider failure may leave
     /// destinations partially overwritten.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions, SvdOutputWrites};
+    /// use tenferro_tensor::{DType, Tensor, TensorRead, TensorWrite};
+    /// let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([1, 1], DType::F64, SvdOptions::default())?;
+    /// let mut workspace = plan.allocate_workspace(&mut backend)?;
+    /// let input = Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f64])?;
+    /// let mut u = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+    /// let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// plan.execute_into(
+    ///     &mut backend,
+    ///     &mut workspace,
+    ///     TensorRead::from_tensor(&input),
+    ///     SvdOutputWrites::new(
+    ///         TensorWrite::from_tensor(&mut u),
+    ///         TensorWrite::from_tensor(&mut s),
+    ///         TensorWrite::from_tensor(&mut vt),
+    ///     ),
+    /// )?;
+    /// assert_eq!(s.as_slice::<f64>()?, &[2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn execute_into<B: PreparedSvdBackendExt>(
         &self,
         backend: &mut B,
@@ -265,21 +465,30 @@ impl PreparedSvd {
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct SvdWorkspace {
+    #[cfg(feature = "cpu-faer")]
     binding: CpuFaerBinding,
     shape: [usize; 2],
     dtype: DType,
+    #[cfg(feature = "cpu-faer")]
     plan_token: Arc<()>,
+    #[cfg(feature = "cpu-faer")]
     inner: FaerWorkspace,
 }
 
 impl fmt::Debug for SvdWorkspace {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SvdWorkspace")
+        let mut debug = f.debug_struct("SvdWorkspace");
+        debug
+            .field("operation", &"compact_svd")
             .field("shape", &self.shape)
             .field("dtype", &self.dtype)
             .field("provider", &"faer")
-            .field("retained_bytes", &self.inner.retained_bytes())
-            .finish_non_exhaustive()
+            .field("device", &"cpu");
+        #[cfg(feature = "cpu-faer")]
+        debug
+            .field("context", &self.binding)
+            .field("retained_bytes", &self.inner.retained_bytes());
+        debug.finish_non_exhaustive()
     }
 }
 
@@ -302,6 +511,18 @@ impl fmt::Debug for SvdWorkspace {
 /// ```
 pub trait PreparedSvdBackendExt: private::PreparedSvdDispatch {
     /// Prepare compact SVD for one fixed rank-2 shape and dtype.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// use tenferro_tensor::DType;
+    /// let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([3, 2], DType::F64, SvdOptions::default())?;
+    /// assert_eq!(plan.output_specs().u().shape(), &[3, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn prepare_svd(
         &mut self,
         shape: [usize; 2],
@@ -340,469 +561,11 @@ mod private {
     }
 }
 
-struct CpuFaerBinding {
-    resources: CpuLinalgBinding,
-}
-
-impl Clone for CpuFaerBinding {
-    fn clone(&self) -> Self {
-        Self {
-            resources: self.resources.clone(),
-        }
-    }
-}
-
-impl fmt::Debug for CpuFaerBinding {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.resources.fmt(f)
-    }
-}
-
-impl CpuFaerBinding {
-    fn capture(backend: &CpuBackend) -> Self {
-        Self {
-            resources: backend.linalg_binding(),
-        }
-    }
-
-    fn validate(&self, backend: &CpuBackend, dtype: DType) -> tenferro_tensor::Result<()> {
-        if !self.resources.matches(backend) || backend.kind() != CpuBackendKind::Faer {
-            return Err(Error::unsupported_capability(
-                EXECUTE_OP,
-                BackendId::Cpu,
-                cpu_provider_name(backend.kind()),
-                dtype,
-                BINDING_CAPABILITY,
-            ));
-        }
-        Ok(())
-    }
-}
+mod cpu;
+#[cfg(feature = "cpu-faer")]
+use cpu::CpuFaerBinding;
 
 #[cfg(feature = "cpu-faer")]
-impl private::PreparedSvdDispatch for CpuBackend {
-    fn prepare_svd_impl(
-        &mut self,
-        shape: [usize; 2],
-        dtype: DType,
-        options: SvdOptions,
-    ) -> tenferro_tensor::Result<PreparedSvd> {
-        validate_derivative_eps(PREPARE_OP, options.derivative_eps)?;
-        if self.kind() != CpuBackendKind::Faer {
-            return Err(Error::unsupported_capability(
-                PREPARE_OP,
-                BackendId::Cpu,
-                cpu_provider_name(self.kind()),
-                dtype,
-                PREPARED_CAPABILITY,
-            ));
-        }
-        checked_shape_product(PREPARE_OP, "matrix shape", &shape)?;
-        for &extent in &shape {
-            isize::try_from(extent).map_err(|_| Error::InvalidConfig {
-                op: PREPARE_OP,
-                message: format!("matrix extent {extent} does not fit in isize"),
-            })?;
-        }
-        let singular_dtype = real_dtype(dtype)?;
-        let provider = FaerPlan::new(dtype, shape, self.linalg_context().faer_par())?;
-        let k = shape[0].min(shape[1]);
-        let placement = Placement {
-            memory_kind: MemoryKind::UnpinnedHost,
-            device: None,
-        };
-        let specs = SvdOutputSpecs {
-            u: SvdOutputSpec {
-                shape: vec![shape[0], k],
-                dtype,
-                placement: placement.clone(),
-            },
-            s: SvdOutputSpec {
-                shape: vec![k],
-                dtype: singular_dtype,
-                placement: placement.clone(),
-            },
-            vt: SvdOutputSpec {
-                shape: vec![k, shape[1]],
-                dtype,
-                placement,
-            },
-        };
-        Ok(PreparedSvd {
-            shape,
-            dtype,
-            options,
-            specs,
-            binding: CpuFaerBinding::capture(self),
-            plan_token: Arc::new(()),
-            provider,
-        })
-    }
-
-    fn allocate_svd_workspace_impl(
-        &mut self,
-        plan: &PreparedSvd,
-    ) -> tenferro_tensor::Result<SvdWorkspace> {
-        plan.binding.validate(self, plan.dtype)?;
-        let inner = plan.provider.allocate(plan.shape)?;
-        Ok(SvdWorkspace {
-            binding: plan.binding.clone(),
-            shape: plan.shape,
-            dtype: plan.dtype,
-            plan_token: Arc::clone(&plan.plan_token),
-            inner,
-        })
-    }
-
-    fn execute_prepared_svd_into_impl(
-        &mut self,
-        plan: &PreparedSvd,
-        workspace: &mut SvdWorkspace,
-        input: TensorRead<'_>,
-        outputs: SvdOutputWrites<'_>,
-    ) -> tenferro_tensor::Result<()> {
-        plan.binding.validate(self, plan.dtype)?;
-        workspace.binding.validate(self, workspace.dtype)?;
-        if !workspace.binding.resources.matches(self)
-            || !plan.binding.resources.matches(self)
-            || workspace.shape != plan.shape
-            || workspace.dtype != plan.dtype
-            || !Arc::ptr_eq(&workspace.plan_token, &plan.plan_token)
-        {
-            return Err(Error::unsupported_capability(
-                EXECUTE_OP,
-                BackendId::Cpu,
-                cpu_provider_name(self.kind()),
-                plan.dtype,
-                BINDING_CAPABILITY,
-            ));
-        }
-        validate_execution(plan, &input, &outputs)?;
-        if plan.shape[0] == 0 || plan.shape[1] == 0 {
-            return Ok(());
-        }
-        let par = self.linalg_context().faer_par();
-        self.install(move || execute_faer(plan, &mut workspace.inner, par, input, outputs))
-    }
-}
-
-#[cfg(not(feature = "cpu-faer"))]
-impl private::PreparedSvdDispatch for CpuBackend {
-    fn prepare_svd_impl(
-        &mut self,
-        _shape: [usize; 2],
-        dtype: DType,
-        _options: SvdOptions,
-    ) -> tenferro_tensor::Result<PreparedSvd> {
-        Err(Error::unsupported_capability(
-            PREPARE_OP,
-            BackendId::Cpu,
-            cpu_provider_name(self.kind()),
-            dtype,
-            PREPARED_CAPABILITY,
-        ))
-    }
-
-    fn allocate_svd_workspace_impl(
-        &mut self,
-        plan: &PreparedSvd,
-    ) -> tenferro_tensor::Result<SvdWorkspace> {
-        Err(Error::unsupported_capability(
-            PREPARE_OP,
-            BackendId::Cpu,
-            cpu_provider_name(self.kind()),
-            plan.dtype,
-            PREPARED_CAPABILITY,
-        ))
-    }
-
-    fn execute_prepared_svd_into_impl(
-        &mut self,
-        plan: &PreparedSvd,
-        _workspace: &mut SvdWorkspace,
-        _input: TensorRead<'_>,
-        _outputs: SvdOutputWrites<'_>,
-    ) -> tenferro_tensor::Result<()> {
-        Err(Error::unsupported_capability(
-            EXECUTE_OP,
-            BackendId::Cpu,
-            cpu_provider_name(self.kind()),
-            plan.dtype,
-            PREPARED_CAPABILITY,
-        ))
-    }
-}
-
-fn real_dtype(dtype: DType) -> tenferro_tensor::Result<DType> {
-    match dtype {
-        DType::F32 | DType::C32 => Ok(DType::F32),
-        DType::F64 | DType::C64 => Ok(DType::F64),
-        _ => Err(Error::unsupported_capability(
-            PREPARE_OP,
-            BackendId::Cpu,
-            "faer",
-            dtype,
-            PREPARED_CAPABILITY,
-        )),
-    }
-}
-
-const fn cpu_provider_name(kind: CpuBackendKind) -> &'static str {
-    match kind {
-        CpuBackendKind::Faer => "faer",
-        CpuBackendKind::Blas => "blas",
-    }
-}
-
-fn validate_execution(
-    plan: &PreparedSvd,
-    input: &TensorRead<'_>,
-    outputs: &SvdOutputWrites<'_>,
-) -> tenferro_tensor::Result<()> {
-    if input.shape() != plan.shape || input.dtype() != plan.dtype {
-        return Err(Error::InvalidConfig {
-            op: EXECUTE_OP,
-            message: format!(
-                "input must have shape {:?} and dtype {:?}, got {:?} and {:?}",
-                plan.shape,
-                plan.dtype,
-                input.shape(),
-                input.dtype()
-            ),
-        });
-    }
-    validate_host_read(input)?;
-    validate_output(&outputs.u, &plan.specs.u, "U")?;
-    validate_output(&outputs.s, &plan.specs.s, "S")?;
-    validate_output(&outputs.vt, &plan.specs.vt, "Vt")?;
-
-    let input_region = read_region(input)?;
-    let u_region = write_region(&outputs.u)?;
-    let s_region = write_region(&outputs.s)?;
-    let vt_region = write_region(&outputs.vt)?;
-    for (lhs_name, lhs, rhs_name, rhs) in [
-        ("input", input_region, "U", u_region),
-        ("input", input_region, "S", s_region),
-        ("input", input_region, "Vt", vt_region),
-        ("U", u_region, "S", s_region),
-        ("U", u_region, "Vt", vt_region),
-        ("S", s_region, "Vt", vt_region),
-    ] {
-        if regions_overlap(lhs, rhs) {
-            return Err(Error::InvalidConfig {
-                op: EXECUTE_OP,
-                message: format!("{lhs_name} and {rhs_name} may overlap"),
-            });
-        }
-    }
-    Ok(())
-}
-
-fn validate_output(
-    output: &TensorWrite<'_>,
-    spec: &SvdOutputSpec,
-    name: &str,
-) -> tenferro_tensor::Result<()> {
-    if output.shape() != spec.shape || output.dtype() != spec.dtype {
-        return Err(Error::InvalidConfig {
-            op: EXECUTE_OP,
-            message: format!(
-                "{name} must have shape {:?} and dtype {:?}, got {:?} and {:?}",
-                spec.shape,
-                spec.dtype,
-                output.shape(),
-                output.dtype()
-            ),
-        });
-    }
-    if !output.is_col_major_contiguous()? {
-        let _ = name;
-        return Err(Error::unsupported_capability(
-            EXECUTE_OP,
-            BackendId::Cpu,
-            "faer",
-            spec.dtype,
-            DESTINATION_CAPABILITY,
-        ));
-    }
-    validate_host_read(&output.as_read())
-}
-
-fn validate_host_read(read: &TensorRead<'_>) -> tenferro_tensor::Result<()> {
-    let placement = read_placement(read);
-    if placement.device.is_some()
-        || !matches!(
-            placement.memory_kind,
-            MemoryKind::PinnedHost | MemoryKind::UnpinnedHost
-        )
-    {
-        return Err(Error::unsupported_capability(
-            EXECUTE_OP,
-            BackendId::Cpu,
-            "faer",
-            read.dtype(),
-            "host-resident prepared SVD storage",
-        ));
-    }
-    Ok(())
-}
-
-fn read_placement<'a>(read: &'a TensorRead<'_>) -> &'a Placement {
-    match read {
-        TensorRead::Tensor(tensor) => tensor.placement(),
-        TensorRead::View(view) => match view {
-            TensorView::F32(v) => v.placement(),
-            TensorView::F64(v) => v.placement(),
-            TensorView::I32(v) => v.placement(),
-            TensorView::I64(v) => v.placement(),
-            TensorView::Bool(v) => v.placement(),
-            TensorView::C32(v) => v.placement(),
-            TensorView::C64(v) => v.placement(),
-        },
-    }
-}
-
-#[derive(Clone, Copy)]
-struct ByteRegion {
-    start: usize,
-    end: usize,
-}
-
-fn regions_overlap(lhs: Option<ByteRegion>, rhs: Option<ByteRegion>) -> bool {
-    match (lhs, rhs) {
-        (Some(lhs), Some(rhs)) => lhs.start < rhs.end && rhs.start < lhs.end,
-        _ => false,
-    }
-}
-
-fn read_region(read: &TensorRead<'_>) -> tenferro_tensor::Result<Option<ByteRegion>> {
-    macro_rules! region {
-        ($value:expr, $ty:ty) => {
-            typed_read_region::<$ty>($value)
-        };
-    }
-    match read {
-        TensorRead::Tensor(Tensor::F32(t)) => region!(TypedReadRef::Tensor(t), f32),
-        TensorRead::Tensor(Tensor::F64(t)) => region!(TypedReadRef::Tensor(t), f64),
-        TensorRead::Tensor(Tensor::I32(t)) => region!(TypedReadRef::Tensor(t), i32),
-        TensorRead::Tensor(Tensor::I64(t)) => region!(TypedReadRef::Tensor(t), i64),
-        TensorRead::Tensor(Tensor::Bool(t)) => region!(TypedReadRef::Tensor(t), bool),
-        TensorRead::Tensor(Tensor::C32(t)) => region!(TypedReadRef::Tensor(t), Complex32),
-        TensorRead::Tensor(Tensor::C64(t)) => region!(TypedReadRef::Tensor(t), Complex64),
-        TensorRead::View(TensorView::F32(v)) => region!(TypedReadRef::View(v), f32),
-        TensorRead::View(TensorView::F64(v)) => region!(TypedReadRef::View(v), f64),
-        TensorRead::View(TensorView::I32(v)) => region!(TypedReadRef::View(v), i32),
-        TensorRead::View(TensorView::I64(v)) => region!(TypedReadRef::View(v), i64),
-        TensorRead::View(TensorView::Bool(v)) => region!(TypedReadRef::View(v), bool),
-        TensorRead::View(TensorView::C32(v)) => region!(TypedReadRef::View(v), Complex32),
-        TensorRead::View(TensorView::C64(v)) => region!(TypedReadRef::View(v), Complex64),
-    }
-}
-
-fn write_region(write: &TensorWrite<'_>) -> tenferro_tensor::Result<Option<ByteRegion>> {
-    read_region(&write.as_read())
-}
-
-enum TypedReadRef<'a, T> {
-    Tensor(&'a TypedTensor<T>),
-    View(&'a TypedTensorView<'a, T>),
-}
-
-fn typed_read_region<T: Clone + 'static>(
-    read: TypedReadRef<'_, T>,
-) -> tenferro_tensor::Result<Option<ByteRegion>> {
-    let (base, shape, strides, offset) = match read {
-        TypedReadRef::Tensor(tensor) => {
-            let data = tensor.host_data()?;
-            return byte_region(data.as_ptr(), 0, data.len(), size_of::<T>());
-        }
-        TypedReadRef::View(view) => (
-            view.host_storage()?.as_ptr(),
-            view.shape(),
-            view.strides(),
-            view.offset(),
-        ),
-    };
-    if shape.contains(&0) {
-        return Ok(None);
-    }
-    let mut min = offset;
-    let mut max = offset;
-    for (&extent, &stride) in shape.iter().zip(strides.iter()) {
-        let span = isize::try_from(extent - 1)
-            .ok()
-            .and_then(|extent| extent.checked_mul(stride))
-            .ok_or_else(|| Error::InvalidConfig {
-                op: EXECUTE_OP,
-                message: "input layout span overflows isize".to_owned(),
-            })?;
-        min = min
-            .checked_add(span.min(0))
-            .ok_or_else(|| Error::InvalidConfig {
-                op: EXECUTE_OP,
-                message: "input layout lower bound overflows isize".to_owned(),
-            })?;
-        max = max
-            .checked_add(span.max(0))
-            .ok_or_else(|| Error::InvalidConfig {
-                op: EXECUTE_OP,
-                message: "input layout upper bound overflows isize".to_owned(),
-            })?;
-    }
-    let start = usize::try_from(min).map_err(|_| Error::InvalidConfig {
-        op: EXECUTE_OP,
-        message: "input layout lower bound is negative".to_owned(),
-    })?;
-    let span = max
-        .checked_sub(min)
-        .and_then(|span| span.checked_add(1))
-        .ok_or_else(|| Error::InvalidConfig {
-            op: EXECUTE_OP,
-            message: "input layout range overflows isize".to_owned(),
-        })?;
-    let len = usize::try_from(span).map_err(|_| Error::InvalidConfig {
-        op: EXECUTE_OP,
-        message: "input layout range does not fit usize".to_owned(),
-    })?;
-    byte_region(base, start, len, size_of::<T>())
-}
-
-fn byte_region<T>(
-    base: *const T,
-    element_offset: usize,
-    element_len: usize,
-    element_size: usize,
-) -> tenferro_tensor::Result<Option<ByteRegion>> {
-    if element_len == 0 {
-        return Ok(None);
-    }
-    let byte_offset =
-        element_offset
-            .checked_mul(element_size)
-            .ok_or_else(|| Error::InvalidConfig {
-                op: EXECUTE_OP,
-                message: "storage byte offset overflows usize".to_owned(),
-            })?;
-    let byte_len = element_len
-        .checked_mul(element_size)
-        .ok_or_else(|| Error::InvalidConfig {
-            op: EXECUTE_OP,
-            message: "storage byte length overflows usize".to_owned(),
-        })?;
-    let start = (base as usize)
-        .checked_add(byte_offset)
-        .ok_or_else(|| Error::InvalidConfig {
-            op: EXECUTE_OP,
-            message: "storage address range overflows usize".to_owned(),
-        })?;
-    let end = start
-        .checked_add(byte_len)
-        .ok_or_else(|| Error::InvalidConfig {
-            op: EXECUTE_OP,
-            message: "storage address range overflows usize".to_owned(),
-        })?;
-    Ok(Some(ByteRegion { start, end }))
-}
-
 mod faer_impl;
+#[cfg(feature = "cpu-faer")]
 use faer_impl::{execute_faer, FaerPlan, FaerWorkspace};

--- a/crates/tenferro-linalg/src/prepared_svd.rs
+++ b/crates/tenferro-linalg/src/prepared_svd.rs
@@ -357,7 +357,11 @@ impl fmt::Debug for PreparedSvd {
         #[cfg(feature = "cpu-faer")]
         debug
             .field("context", &self.binding)
-            .field("scratch_bytes", &self.provider.scratch_bytes());
+            .field("plan_retained_bytes", &self.provider.retained_bytes())
+            .field(
+                "workspace_required_bytes",
+                &self.provider.workspace_required_bytes(self.shape),
+            );
         debug.finish_non_exhaustive()
     }
 }
@@ -461,7 +465,7 @@ impl PreparedSvd {
 /// let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer)?;
 /// let plan = backend.prepare_svd([2, 2], DType::F64, SvdOptions::default())?;
 /// let workspace = plan.allocate_workspace(&mut backend)?;
-/// assert!(format!("{workspace:?}").contains("retained_bytes"));
+/// assert!(format!("{workspace:?}").contains("workspace_retained_bytes"));
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct SvdWorkspace {
@@ -487,15 +491,17 @@ impl fmt::Debug for SvdWorkspace {
         #[cfg(feature = "cpu-faer")]
         debug
             .field("context", &self.binding)
-            .field("retained_bytes", &self.inner.retained_bytes());
+            .field("workspace_required_bytes", &self.inner.required_bytes())
+            .field("workspace_retained_bytes", &self.inner.retained_bytes());
         debug.finish_non_exhaustive()
     }
 }
 
 /// Backend capability for explicit prepared compact SVD execution.
 ///
-/// The default hooks return an explicit unsupported error. Implementations must
-/// not call an owned SVD or allocate replacement outputs as a fallback.
+/// Provider dispatch is sealed and required for every backend implementation.
+/// Unsupported implementations return an explicit capability error rather than
+/// calling an owned SVD or allocating replacement outputs as a fallback.
 ///
 /// # Examples
 ///

--- a/crates/tenferro-linalg/src/prepared_svd.rs
+++ b/crates/tenferro-linalg/src/prepared_svd.rs
@@ -361,7 +361,7 @@ impl fmt::Debug for PreparedSvd {
         #[cfg(feature = "cpu-faer")]
         debug
             .field("context", &self.binding)
-            .field("plan_retained_bytes", &self.provider.retained_bytes())
+            .field("plan_retained_bytes", &self.retained_bytes())
             .field(
                 "workspace_required_bytes",
                 &self.provider.workspace_required_bytes(self.shape),
@@ -371,6 +371,38 @@ impl fmt::Debug for PreparedSvd {
 }
 
 impl PreparedSvd {
+    /// Return the exact provider-private heap bytes currently retained by this plan.
+    ///
+    /// This read-only snapshot does not allocate or mutate the plan. It excludes
+    /// inline Rust object size, backend binding and identity-token metadata,
+    /// shared backend context, workspaces, and outputs. Values are provider
+    /// representations, so no ordering is promised across shapes, dtypes,
+    /// options, or providers.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// use tenferro_tensor::DType;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([3, 2], DType::F64, SvdOptions::default())?;
+    /// let plan_bytes = plan.retained_bytes();
+    /// assert_eq!(plan_bytes, plan.retained_bytes());
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn retained_bytes(&self) -> usize {
+        #[cfg(feature = "cpu-faer")]
+        {
+            self.provider.retained_bytes()
+        }
+        #[cfg(not(feature = "cpu-faer"))]
+        {
+            0
+        }
+    }
+
     /// Return exact `U`, `S`, and `Vt` output metadata.
     ///
     /// # Examples
@@ -555,8 +587,43 @@ impl fmt::Debug for SvdWorkspace {
         debug
             .field("context", &self.binding)
             .field("workspace_required_bytes", &self.inner.required_bytes())
-            .field("workspace_retained_bytes", &self.inner.retained_bytes());
+            .field("workspace_retained_bytes", &self.retained_bytes());
         debug.finish_non_exhaustive()
+    }
+}
+
+impl SvdWorkspace {
+    /// Return the exact provider-private heap bytes currently retained by this workspace.
+    ///
+    /// This read-only snapshot does not allocate or mutate the workspace. It
+    /// includes provider scratch and staging capacities, but excludes inline
+    /// Rust object size, backend binding and identity-token metadata, shared
+    /// backend context, plans, and outputs. Values are provider representations,
+    /// so no ordering is promised across shapes, dtypes, options, or providers.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+    /// use tenferro_tensor::DType;
+    ///
+    /// let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([3, 2], DType::F64, SvdOptions::default())?;
+    /// let workspace = plan.allocate_workspace(&mut backend)?;
+    /// let workspace_bytes = workspace.retained_bytes();
+    /// assert_eq!(workspace_bytes, workspace.retained_bytes());
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn retained_bytes(&self) -> usize {
+        #[cfg(feature = "cpu-faer")]
+        {
+            self.inner.retained_bytes()
+        }
+        #[cfg(not(feature = "cpu-faer"))]
+        {
+            0
+        }
     }
 }
 

--- a/crates/tenferro-linalg/src/prepared_svd.rs
+++ b/crates/tenferro-linalg/src/prepared_svd.rs
@@ -1,0 +1,808 @@
+use std::fmt;
+use std::mem::size_of;
+use std::sync::Arc;
+
+use faer::dyn_stack::{MemBuffer, MemStack, StackReq};
+use faer::{diag::DiagMut, MatMut, MatRef};
+use num_complex::{Complex32, Complex64};
+use tenferro_cpu::{CpuBackend, CpuBackendKind, CpuLinalgBinding};
+use tenferro_tensor::{
+    validate::checked_shape_product, BackendId, DType, Error, MemoryKind, Placement, Tensor,
+    TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensor, TypedTensorView,
+    TypedTensorViewMut,
+};
+
+use crate::{
+    backend::LinalgBackend,
+    extension::{
+        canonicalize_svd_gauge_c32, canonicalize_svd_gauge_c64, canonicalize_svd_gauge_f32,
+        canonicalize_svd_gauge_f64, validate_derivative_eps,
+    },
+    SvdGauge, SvdOptions,
+};
+
+const PREPARE_OP: &str = "prepare_svd";
+const EXECUTE_OP: &str = "PreparedSvd::execute_into";
+const PREPARED_CAPABILITY: &str = "prepared compact SVD";
+const BINDING_CAPABILITY: &str = "prepared SVD backend/context binding";
+const DESTINATION_CAPABILITY: &str = "compact column-major prepared SVD destination";
+
+/// Exact metadata for one prepared SVD output.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::{CpuBackend, CpuBackendKind};
+/// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+/// use tenferro_tensor::DType;
+///
+/// let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer)?;
+/// let plan = backend.prepare_svd([3, 2], DType::F64, SvdOptions::default())?;
+/// assert_eq!(plan.output_specs().u().shape(), &[3, 2]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SvdOutputSpec {
+    shape: Vec<usize>,
+    dtype: DType,
+    placement: Placement,
+}
+
+impl SvdOutputSpec {
+    /// Return the exact output shape.
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    /// Return the exact output dtype.
+    pub fn dtype(&self) -> DType {
+        self.dtype
+    }
+
+    /// Return the default host placement expected for a newly allocated output.
+    ///
+    /// Pinned host destinations are also accepted by execution.
+    pub fn placement(&self) -> &Placement {
+        &self.placement
+    }
+}
+
+/// Output metadata for prepared compact SVD.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::{CpuBackend, CpuBackendKind};
+/// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+/// use tenferro_tensor::DType;
+///
+/// let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer)?;
+/// let plan = backend.prepare_svd([2, 4], DType::C64, SvdOptions::default())?;
+/// let specs = plan.output_specs();
+/// assert_eq!(specs.s().dtype(), DType::F64);
+/// assert_eq!(specs.vt().shape(), &[2, 4]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SvdOutputSpecs {
+    u: SvdOutputSpec,
+    s: SvdOutputSpec,
+    vt: SvdOutputSpec,
+}
+
+impl SvdOutputSpecs {
+    /// Return the left-singular-vector output specification.
+    pub fn u(&self) -> &SvdOutputSpec {
+        &self.u
+    }
+
+    /// Return the singular-value output specification.
+    pub fn s(&self) -> &SvdOutputSpec {
+        &self.s
+    }
+
+    /// Return the conjugate-transposed right-singular-vector output specification.
+    pub fn vt(&self) -> &SvdOutputSpec {
+        &self.vt
+    }
+}
+
+/// Caller-provided writable outputs for compact SVD.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::SvdOutputWrites;
+/// use tenferro_tensor::{Tensor, TensorWrite};
+///
+/// let mut u = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+/// let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+/// let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+/// let writes = SvdOutputWrites::new(
+///     TensorWrite::from_tensor(&mut u),
+///     TensorWrite::from_tensor(&mut s),
+///     TensorWrite::from_tensor(&mut vt),
+/// );
+/// assert_eq!(writes.u().shape(), &[1, 1]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+#[derive(Debug)]
+pub struct SvdOutputWrites<'a> {
+    pub(crate) u: TensorWrite<'a>,
+    pub(crate) s: TensorWrite<'a>,
+    pub(crate) vt: TensorWrite<'a>,
+}
+
+impl<'a> SvdOutputWrites<'a> {
+    /// Bundle caller-owned `U`, `S`, and `Vt` destinations.
+    pub fn new(u: TensorWrite<'a>, s: TensorWrite<'a>, vt: TensorWrite<'a>) -> Self {
+        Self { u, s, vt }
+    }
+
+    /// Inspect the `U` destination without mutating it.
+    pub fn u(&self) -> &TensorWrite<'a> {
+        &self.u
+    }
+
+    /// Inspect the `S` destination without mutating it.
+    pub fn s(&self) -> &TensorWrite<'a> {
+        &self.s
+    }
+
+    /// Inspect the `Vt` destination without mutating it.
+    pub fn vt(&self) -> &TensorWrite<'a> {
+        &self.vt
+    }
+}
+
+/// Immutable prepared compact-SVD plan.
+///
+/// A plan binds shape, dtype, provider, execution context, and options. Allocate
+/// one workspace per concurrent execution lane.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::{CpuBackend, CpuBackendKind};
+/// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions, SvdOutputWrites};
+/// use tenferro_tensor::{DType, Tensor, TensorRead, TensorWrite};
+///
+/// let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer)?;
+/// let plan = backend.prepare_svd([2, 2], DType::F64, SvdOptions::default())?;
+/// let mut workspace = plan.allocate_workspace(&mut backend)?;
+/// let input = Tensor::from_vec_col_major(
+///     vec![2, 2],
+///     vec![3.0_f64, 0.0, 0.0, 2.0],
+/// )?;
+/// let mut u = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4])?;
+/// let mut s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2])?;
+/// let mut vt = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4])?;
+/// for _ in 0..2 {
+///     plan.execute_into(
+///         &mut backend,
+///         &mut workspace,
+///         TensorRead::from_tensor(&input),
+///         SvdOutputWrites::new(
+///             TensorWrite::from_tensor(&mut u),
+///             TensorWrite::from_tensor(&mut s),
+///             TensorWrite::from_tensor(&mut vt),
+///         ),
+///     )?;
+/// }
+/// assert_eq!(s.as_slice::<f64>()?, &[3.0, 2.0]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub struct PreparedSvd {
+    shape: [usize; 2],
+    dtype: DType,
+    options: SvdOptions,
+    specs: SvdOutputSpecs,
+    binding: CpuFaerBinding,
+    plan_token: Arc<()>,
+    provider: FaerPlan,
+}
+
+impl fmt::Debug for PreparedSvd {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PreparedSvd")
+            .field("shape", &self.shape)
+            .field("dtype", &self.dtype)
+            .field("options", &self.options)
+            .field("provider", &"faer")
+            .field("scratch_bytes", &self.provider.scratch_bytes())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PreparedSvd {
+    /// Return exact `U`, `S`, and `Vt` output metadata.
+    pub fn output_specs(&self) -> &SvdOutputSpecs {
+        &self.specs
+    }
+
+    /// Allocate one opaque workspace bound to this plan and backend context.
+    pub fn allocate_workspace<B: PreparedSvdBackendExt>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<SvdWorkspace> {
+        private::PreparedSvdDispatch::allocate_svd_workspace_impl(backend, self)
+    }
+
+    /// Execute into caller-owned outputs, reusing the supplied workspace.
+    ///
+    /// All metadata and overlap checks complete before the first output write.
+    /// Once the provider call starts, a numerical provider failure may leave
+    /// destinations partially overwritten.
+    pub fn execute_into<B: PreparedSvdBackendExt>(
+        &self,
+        backend: &mut B,
+        workspace: &mut SvdWorkspace,
+        input: TensorRead<'_>,
+        outputs: SvdOutputWrites<'_>,
+    ) -> tenferro_tensor::Result<()> {
+        private::PreparedSvdDispatch::execute_prepared_svd_into_impl(
+            backend, self, workspace, input, outputs,
+        )
+    }
+}
+
+/// Opaque caller-owned mutable workspace for a [`PreparedSvd`].
+///
+/// The workspace is intentionally not `Clone`; pass it as `&mut` to enforce
+/// exclusive use and allocate another workspace for another concurrency lane.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::{CpuBackend, CpuBackendKind};
+/// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+/// use tenferro_tensor::DType;
+///
+/// let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer)?;
+/// let plan = backend.prepare_svd([2, 2], DType::F64, SvdOptions::default())?;
+/// let workspace = plan.allocate_workspace(&mut backend)?;
+/// assert!(format!("{workspace:?}").contains("retained_bytes"));
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub struct SvdWorkspace {
+    binding: CpuFaerBinding,
+    shape: [usize; 2],
+    dtype: DType,
+    plan_token: Arc<()>,
+    inner: FaerWorkspace,
+}
+
+impl fmt::Debug for SvdWorkspace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SvdWorkspace")
+            .field("shape", &self.shape)
+            .field("dtype", &self.dtype)
+            .field("provider", &"faer")
+            .field("retained_bytes", &self.inner.retained_bytes())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Backend capability for explicit prepared compact SVD execution.
+///
+/// The default hooks return an explicit unsupported error. Implementations must
+/// not call an owned SVD or allocate replacement outputs as a fallback.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::{CpuBackend, CpuBackendKind};
+/// use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions};
+/// use tenferro_tensor::DType;
+///
+/// let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer)?;
+/// let plan = backend.prepare_svd([3, 2], DType::F64, SvdOptions::default())?;
+/// assert_eq!(plan.output_specs().s().shape(), &[2]);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub trait PreparedSvdBackendExt: private::PreparedSvdDispatch {
+    /// Prepare compact SVD for one fixed rank-2 shape and dtype.
+    fn prepare_svd(
+        &mut self,
+        shape: [usize; 2],
+        dtype: DType,
+        options: SvdOptions,
+    ) -> tenferro_tensor::Result<PreparedSvd> {
+        private::PreparedSvdDispatch::prepare_svd_impl(self, shape, dtype, options)
+    }
+}
+
+impl<T: private::PreparedSvdDispatch> PreparedSvdBackendExt for T {}
+
+mod private {
+    use super::*;
+
+    pub trait PreparedSvdDispatch: LinalgBackend {
+        fn prepare_svd_impl(
+            &mut self,
+            shape: [usize; 2],
+            dtype: DType,
+            options: SvdOptions,
+        ) -> tenferro_tensor::Result<PreparedSvd>;
+
+        fn allocate_svd_workspace_impl(
+            &mut self,
+            plan: &PreparedSvd,
+        ) -> tenferro_tensor::Result<SvdWorkspace>;
+
+        fn execute_prepared_svd_into_impl(
+            &mut self,
+            plan: &PreparedSvd,
+            workspace: &mut SvdWorkspace,
+            input: TensorRead<'_>,
+            outputs: SvdOutputWrites<'_>,
+        ) -> tenferro_tensor::Result<()>;
+    }
+}
+
+struct CpuFaerBinding {
+    resources: CpuLinalgBinding,
+}
+
+impl Clone for CpuFaerBinding {
+    fn clone(&self) -> Self {
+        Self {
+            resources: self.resources.clone(),
+        }
+    }
+}
+
+impl fmt::Debug for CpuFaerBinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.resources.fmt(f)
+    }
+}
+
+impl CpuFaerBinding {
+    fn capture(backend: &CpuBackend) -> Self {
+        Self {
+            resources: backend.linalg_binding(),
+        }
+    }
+
+    fn validate(&self, backend: &CpuBackend, dtype: DType) -> tenferro_tensor::Result<()> {
+        if !self.resources.matches(backend) || backend.kind() != CpuBackendKind::Faer {
+            return Err(Error::unsupported_capability(
+                EXECUTE_OP,
+                BackendId::Cpu,
+                cpu_provider_name(backend.kind()),
+                dtype,
+                BINDING_CAPABILITY,
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+impl private::PreparedSvdDispatch for CpuBackend {
+    fn prepare_svd_impl(
+        &mut self,
+        shape: [usize; 2],
+        dtype: DType,
+        options: SvdOptions,
+    ) -> tenferro_tensor::Result<PreparedSvd> {
+        validate_derivative_eps(PREPARE_OP, options.derivative_eps)?;
+        if self.kind() != CpuBackendKind::Faer {
+            return Err(Error::unsupported_capability(
+                PREPARE_OP,
+                BackendId::Cpu,
+                cpu_provider_name(self.kind()),
+                dtype,
+                PREPARED_CAPABILITY,
+            ));
+        }
+        checked_shape_product(PREPARE_OP, "matrix shape", &shape)?;
+        for &extent in &shape {
+            isize::try_from(extent).map_err(|_| Error::InvalidConfig {
+                op: PREPARE_OP,
+                message: format!("matrix extent {extent} does not fit in isize"),
+            })?;
+        }
+        let singular_dtype = real_dtype(dtype)?;
+        let provider = FaerPlan::new(dtype, shape, self.linalg_context().faer_par())?;
+        let k = shape[0].min(shape[1]);
+        let placement = Placement {
+            memory_kind: MemoryKind::UnpinnedHost,
+            device: None,
+        };
+        let specs = SvdOutputSpecs {
+            u: SvdOutputSpec {
+                shape: vec![shape[0], k],
+                dtype,
+                placement: placement.clone(),
+            },
+            s: SvdOutputSpec {
+                shape: vec![k],
+                dtype: singular_dtype,
+                placement: placement.clone(),
+            },
+            vt: SvdOutputSpec {
+                shape: vec![k, shape[1]],
+                dtype,
+                placement,
+            },
+        };
+        Ok(PreparedSvd {
+            shape,
+            dtype,
+            options,
+            specs,
+            binding: CpuFaerBinding::capture(self),
+            plan_token: Arc::new(()),
+            provider,
+        })
+    }
+
+    fn allocate_svd_workspace_impl(
+        &mut self,
+        plan: &PreparedSvd,
+    ) -> tenferro_tensor::Result<SvdWorkspace> {
+        plan.binding.validate(self, plan.dtype)?;
+        let inner = plan.provider.allocate(plan.shape)?;
+        Ok(SvdWorkspace {
+            binding: plan.binding.clone(),
+            shape: plan.shape,
+            dtype: plan.dtype,
+            plan_token: Arc::clone(&plan.plan_token),
+            inner,
+        })
+    }
+
+    fn execute_prepared_svd_into_impl(
+        &mut self,
+        plan: &PreparedSvd,
+        workspace: &mut SvdWorkspace,
+        input: TensorRead<'_>,
+        outputs: SvdOutputWrites<'_>,
+    ) -> tenferro_tensor::Result<()> {
+        plan.binding.validate(self, plan.dtype)?;
+        workspace.binding.validate(self, workspace.dtype)?;
+        if !workspace.binding.resources.matches(self)
+            || !plan.binding.resources.matches(self)
+            || workspace.shape != plan.shape
+            || workspace.dtype != plan.dtype
+            || !Arc::ptr_eq(&workspace.plan_token, &plan.plan_token)
+        {
+            return Err(Error::unsupported_capability(
+                EXECUTE_OP,
+                BackendId::Cpu,
+                cpu_provider_name(self.kind()),
+                plan.dtype,
+                BINDING_CAPABILITY,
+            ));
+        }
+        validate_execution(plan, &input, &outputs)?;
+        if plan.shape[0] == 0 || plan.shape[1] == 0 {
+            return Ok(());
+        }
+        let par = self.linalg_context().faer_par();
+        self.install(move || execute_faer(plan, &mut workspace.inner, par, input, outputs))
+    }
+}
+
+#[cfg(not(feature = "cpu-faer"))]
+impl private::PreparedSvdDispatch for CpuBackend {
+    fn prepare_svd_impl(
+        &mut self,
+        _shape: [usize; 2],
+        dtype: DType,
+        _options: SvdOptions,
+    ) -> tenferro_tensor::Result<PreparedSvd> {
+        Err(Error::unsupported_capability(
+            PREPARE_OP,
+            BackendId::Cpu,
+            cpu_provider_name(self.kind()),
+            dtype,
+            PREPARED_CAPABILITY,
+        ))
+    }
+
+    fn allocate_svd_workspace_impl(
+        &mut self,
+        plan: &PreparedSvd,
+    ) -> tenferro_tensor::Result<SvdWorkspace> {
+        Err(Error::unsupported_capability(
+            PREPARE_OP,
+            BackendId::Cpu,
+            cpu_provider_name(self.kind()),
+            plan.dtype,
+            PREPARED_CAPABILITY,
+        ))
+    }
+
+    fn execute_prepared_svd_into_impl(
+        &mut self,
+        plan: &PreparedSvd,
+        _workspace: &mut SvdWorkspace,
+        _input: TensorRead<'_>,
+        _outputs: SvdOutputWrites<'_>,
+    ) -> tenferro_tensor::Result<()> {
+        Err(Error::unsupported_capability(
+            EXECUTE_OP,
+            BackendId::Cpu,
+            cpu_provider_name(self.kind()),
+            plan.dtype,
+            PREPARED_CAPABILITY,
+        ))
+    }
+}
+
+fn real_dtype(dtype: DType) -> tenferro_tensor::Result<DType> {
+    match dtype {
+        DType::F32 | DType::C32 => Ok(DType::F32),
+        DType::F64 | DType::C64 => Ok(DType::F64),
+        _ => Err(Error::unsupported_capability(
+            PREPARE_OP,
+            BackendId::Cpu,
+            "faer",
+            dtype,
+            PREPARED_CAPABILITY,
+        )),
+    }
+}
+
+const fn cpu_provider_name(kind: CpuBackendKind) -> &'static str {
+    match kind {
+        CpuBackendKind::Faer => "faer",
+        CpuBackendKind::Blas => "blas",
+    }
+}
+
+fn validate_execution(
+    plan: &PreparedSvd,
+    input: &TensorRead<'_>,
+    outputs: &SvdOutputWrites<'_>,
+) -> tenferro_tensor::Result<()> {
+    if input.shape() != plan.shape || input.dtype() != plan.dtype {
+        return Err(Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: format!(
+                "input must have shape {:?} and dtype {:?}, got {:?} and {:?}",
+                plan.shape,
+                plan.dtype,
+                input.shape(),
+                input.dtype()
+            ),
+        });
+    }
+    validate_host_read(input)?;
+    validate_output(&outputs.u, &plan.specs.u, "U")?;
+    validate_output(&outputs.s, &plan.specs.s, "S")?;
+    validate_output(&outputs.vt, &plan.specs.vt, "Vt")?;
+
+    let input_region = read_region(input)?;
+    let u_region = write_region(&outputs.u)?;
+    let s_region = write_region(&outputs.s)?;
+    let vt_region = write_region(&outputs.vt)?;
+    for (lhs_name, lhs, rhs_name, rhs) in [
+        ("input", input_region, "U", u_region),
+        ("input", input_region, "S", s_region),
+        ("input", input_region, "Vt", vt_region),
+        ("U", u_region, "S", s_region),
+        ("U", u_region, "Vt", vt_region),
+        ("S", s_region, "Vt", vt_region),
+    ] {
+        if regions_overlap(lhs, rhs) {
+            return Err(Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: format!("{lhs_name} and {rhs_name} may overlap"),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_output(
+    output: &TensorWrite<'_>,
+    spec: &SvdOutputSpec,
+    name: &str,
+) -> tenferro_tensor::Result<()> {
+    if output.shape() != spec.shape || output.dtype() != spec.dtype {
+        return Err(Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: format!(
+                "{name} must have shape {:?} and dtype {:?}, got {:?} and {:?}",
+                spec.shape,
+                spec.dtype,
+                output.shape(),
+                output.dtype()
+            ),
+        });
+    }
+    if !output.is_col_major_contiguous()? {
+        let _ = name;
+        return Err(Error::unsupported_capability(
+            EXECUTE_OP,
+            BackendId::Cpu,
+            "faer",
+            spec.dtype,
+            DESTINATION_CAPABILITY,
+        ));
+    }
+    validate_host_read(&output.as_read())
+}
+
+fn validate_host_read(read: &TensorRead<'_>) -> tenferro_tensor::Result<()> {
+    let placement = read_placement(read);
+    if placement.device.is_some()
+        || !matches!(
+            placement.memory_kind,
+            MemoryKind::PinnedHost | MemoryKind::UnpinnedHost
+        )
+    {
+        return Err(Error::unsupported_capability(
+            EXECUTE_OP,
+            BackendId::Cpu,
+            "faer",
+            read.dtype(),
+            "host-resident prepared SVD storage",
+        ));
+    }
+    Ok(())
+}
+
+fn read_placement<'a>(read: &'a TensorRead<'_>) -> &'a Placement {
+    match read {
+        TensorRead::Tensor(tensor) => tensor.placement(),
+        TensorRead::View(view) => match view {
+            TensorView::F32(v) => v.placement(),
+            TensorView::F64(v) => v.placement(),
+            TensorView::I32(v) => v.placement(),
+            TensorView::I64(v) => v.placement(),
+            TensorView::Bool(v) => v.placement(),
+            TensorView::C32(v) => v.placement(),
+            TensorView::C64(v) => v.placement(),
+        },
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ByteRegion {
+    start: usize,
+    end: usize,
+}
+
+fn regions_overlap(lhs: Option<ByteRegion>, rhs: Option<ByteRegion>) -> bool {
+    match (lhs, rhs) {
+        (Some(lhs), Some(rhs)) => lhs.start < rhs.end && rhs.start < lhs.end,
+        _ => false,
+    }
+}
+
+fn read_region(read: &TensorRead<'_>) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    macro_rules! region {
+        ($value:expr, $ty:ty) => {
+            typed_read_region::<$ty>($value)
+        };
+    }
+    match read {
+        TensorRead::Tensor(Tensor::F32(t)) => region!(TypedReadRef::Tensor(t), f32),
+        TensorRead::Tensor(Tensor::F64(t)) => region!(TypedReadRef::Tensor(t), f64),
+        TensorRead::Tensor(Tensor::I32(t)) => region!(TypedReadRef::Tensor(t), i32),
+        TensorRead::Tensor(Tensor::I64(t)) => region!(TypedReadRef::Tensor(t), i64),
+        TensorRead::Tensor(Tensor::Bool(t)) => region!(TypedReadRef::Tensor(t), bool),
+        TensorRead::Tensor(Tensor::C32(t)) => region!(TypedReadRef::Tensor(t), Complex32),
+        TensorRead::Tensor(Tensor::C64(t)) => region!(TypedReadRef::Tensor(t), Complex64),
+        TensorRead::View(TensorView::F32(v)) => region!(TypedReadRef::View(v), f32),
+        TensorRead::View(TensorView::F64(v)) => region!(TypedReadRef::View(v), f64),
+        TensorRead::View(TensorView::I32(v)) => region!(TypedReadRef::View(v), i32),
+        TensorRead::View(TensorView::I64(v)) => region!(TypedReadRef::View(v), i64),
+        TensorRead::View(TensorView::Bool(v)) => region!(TypedReadRef::View(v), bool),
+        TensorRead::View(TensorView::C32(v)) => region!(TypedReadRef::View(v), Complex32),
+        TensorRead::View(TensorView::C64(v)) => region!(TypedReadRef::View(v), Complex64),
+    }
+}
+
+fn write_region(write: &TensorWrite<'_>) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    read_region(&write.as_read())
+}
+
+enum TypedReadRef<'a, T> {
+    Tensor(&'a TypedTensor<T>),
+    View(&'a TypedTensorView<'a, T>),
+}
+
+fn typed_read_region<T: Clone + 'static>(
+    read: TypedReadRef<'_, T>,
+) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    let (base, shape, strides, offset) = match read {
+        TypedReadRef::Tensor(tensor) => {
+            let data = tensor.host_data()?;
+            return byte_region(data.as_ptr(), 0, data.len(), size_of::<T>());
+        }
+        TypedReadRef::View(view) => (
+            view.host_storage()?.as_ptr(),
+            view.shape(),
+            view.strides(),
+            view.offset(),
+        ),
+    };
+    if shape.contains(&0) {
+        return Ok(None);
+    }
+    let mut min = offset;
+    let mut max = offset;
+    for (&extent, &stride) in shape.iter().zip(strides.iter()) {
+        let span = isize::try_from(extent - 1)
+            .ok()
+            .and_then(|extent| extent.checked_mul(stride))
+            .ok_or_else(|| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "input layout span overflows isize".to_owned(),
+            })?;
+        min = min
+            .checked_add(span.min(0))
+            .ok_or_else(|| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "input layout lower bound overflows isize".to_owned(),
+            })?;
+        max = max
+            .checked_add(span.max(0))
+            .ok_or_else(|| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "input layout upper bound overflows isize".to_owned(),
+            })?;
+    }
+    let start = usize::try_from(min).map_err(|_| Error::InvalidConfig {
+        op: EXECUTE_OP,
+        message: "input layout lower bound is negative".to_owned(),
+    })?;
+    let span = max
+        .checked_sub(min)
+        .and_then(|span| span.checked_add(1))
+        .ok_or_else(|| Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: "input layout range overflows isize".to_owned(),
+        })?;
+    let len = usize::try_from(span).map_err(|_| Error::InvalidConfig {
+        op: EXECUTE_OP,
+        message: "input layout range does not fit usize".to_owned(),
+    })?;
+    byte_region(base, start, len, size_of::<T>())
+}
+
+fn byte_region<T>(
+    base: *const T,
+    element_offset: usize,
+    element_len: usize,
+    element_size: usize,
+) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    if element_len == 0 {
+        return Ok(None);
+    }
+    let byte_offset =
+        element_offset
+            .checked_mul(element_size)
+            .ok_or_else(|| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "storage byte offset overflows usize".to_owned(),
+            })?;
+    let byte_len = element_len
+        .checked_mul(element_size)
+        .ok_or_else(|| Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: "storage byte length overflows usize".to_owned(),
+        })?;
+    let start = (base as usize)
+        .checked_add(byte_offset)
+        .ok_or_else(|| Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: "storage address range overflows usize".to_owned(),
+        })?;
+    let end = start
+        .checked_add(byte_len)
+        .ok_or_else(|| Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: "storage address range overflows usize".to_owned(),
+        })?;
+    Ok(Some(ByteRegion { start, end }))
+}
+
+mod faer_impl;
+use faer_impl::{execute_faer, FaerPlan, FaerWorkspace};

--- a/crates/tenferro-linalg/src/prepared_svd.rs
+++ b/crates/tenferro-linalg/src/prepared_svd.rs
@@ -20,6 +20,10 @@ use tenferro_tensor::{
 };
 use tenferro_tensor::{BackendId, DType, Error, Placement, TensorRead, TensorWrite};
 
+use crate::prepared_factorization::{
+    private::PreparedFactorizationDispatch, PreparedFactorizationBackendExt,
+    PreparedFactorizationSession, PreparedFactorizationSessionInner,
+};
 use crate::{backend::LinalgBackend, SvdOptions};
 #[cfg(feature = "cpu-faer")]
 use crate::{
@@ -411,6 +415,10 @@ impl PreparedSvd {
     /// Once the provider call starts, a numerical provider failure may leave
     /// destinations partially overwritten.
     ///
+    /// `TensorRead` and `TensorWrite` descriptor construction is caller-owned
+    /// setup evaluated before this method is entered. In particular, creating
+    /// dynamic-rank shape and stride metadata may allocate.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -444,9 +452,64 @@ impl PreparedSvd {
         input: TensorRead<'_>,
         outputs: SvdOutputWrites<'_>,
     ) -> tenferro_tensor::Result<()> {
-        private::PreparedSvdDispatch::execute_prepared_svd_into_impl(
-            backend, self, workspace, input, outputs,
-        )
+        backend.with_prepared_factorization_session(move |session| {
+            self.execute_into_session(session, workspace, input, outputs)
+        })
+    }
+
+    /// Execute inside an already-entered prepared factorization session.
+    ///
+    /// This leaf operation does not reacquire backend resources or re-enter a
+    /// backend worker pool. All metadata and overlap checks complete before
+    /// the first output write.
+    ///
+    /// The prepared-leaf allocation boundary begins with already-constructed
+    /// `TensorRead` and `TensorWrite` descriptors. Creating dynamic-rank view
+    /// descriptors is caller setup and may allocate before function entry.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::{
+    ///     PreparedFactorizationBackendExt, PreparedSvdBackendExt, SvdOptions,
+    ///     SvdOutputWrites,
+    /// };
+    /// use tenferro_tensor::{DType, Tensor, TensorRead, TensorWrite};
+    /// let mut backend = CpuBackend::new();
+    /// let plan = backend.prepare_svd([1, 1], DType::F64, SvdOptions::default())?;
+    /// let mut workspace = plan.allocate_workspace(&mut backend)?;
+    /// let input = Tensor::from_vec_col_major(vec![1, 1], vec![2.0_f64])?;
+    /// let mut u = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// let mut s = Tensor::from_vec_col_major(vec![1], vec![0.0_f64])?;
+    /// let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![0.0_f64])?;
+    /// backend.with_prepared_factorization_session(|session| {
+    ///     plan.execute_into_session(
+    ///         session,
+    ///         &mut workspace,
+    ///         TensorRead::from_tensor(&input),
+    ///         SvdOutputWrites::new(
+    ///             TensorWrite::from_tensor(&mut u),
+    ///             TensorWrite::from_tensor(&mut s),
+    ///             TensorWrite::from_tensor(&mut vt),
+    ///         ),
+    ///     )
+    /// })?;
+    /// assert_eq!(s.as_slice::<f64>()?, &[2.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    pub fn execute_into_session(
+        &self,
+        session: &mut PreparedFactorizationSession<'_>,
+        workspace: &mut SvdWorkspace,
+        input: TensorRead<'_>,
+        outputs: SvdOutputWrites<'_>,
+    ) -> tenferro_tensor::Result<()> {
+        match &mut session.inner {
+            PreparedFactorizationSessionInner::Cpu(cpu_session) => {
+                cpu::execute_prepared_svd_into_session(cpu_session, self, workspace, input, outputs)
+            }
+        }
     }
 }
 
@@ -515,7 +578,9 @@ impl fmt::Debug for SvdWorkspace {
 /// assert_eq!(plan.output_specs().s().shape(), &[2]);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
-pub trait PreparedSvdBackendExt: private::PreparedSvdDispatch {
+pub trait PreparedSvdBackendExt:
+    private::PreparedSvdDispatch + PreparedFactorizationBackendExt
+{
     /// Prepare compact SVD for one fixed rank-2 shape and dtype.
     ///
     /// # Examples
@@ -539,12 +604,15 @@ pub trait PreparedSvdBackendExt: private::PreparedSvdDispatch {
     }
 }
 
-impl<T: private::PreparedSvdDispatch> PreparedSvdBackendExt for T {}
+impl<T> PreparedSvdBackendExt for T where
+    T: private::PreparedSvdDispatch + PreparedFactorizationBackendExt
+{
+}
 
 mod private {
     use super::*;
 
-    pub trait PreparedSvdDispatch: LinalgBackend {
+    pub trait PreparedSvdDispatch: LinalgBackend + PreparedFactorizationDispatch {
         fn prepare_svd_impl(
             &mut self,
             shape: [usize; 2],
@@ -556,14 +624,6 @@ mod private {
             &mut self,
             plan: &PreparedSvd,
         ) -> tenferro_tensor::Result<SvdWorkspace>;
-
-        fn execute_prepared_svd_into_impl(
-            &mut self,
-            plan: &PreparedSvd,
-            workspace: &mut SvdWorkspace,
-            input: TensorRead<'_>,
-            outputs: SvdOutputWrites<'_>,
-        ) -> tenferro_tensor::Result<()>;
     }
 }
 

--- a/crates/tenferro-linalg/src/prepared_svd/cpu.rs
+++ b/crates/tenferro-linalg/src/prepared_svd/cpu.rs
@@ -1,0 +1,530 @@
+use super::*;
+
+#[cfg(feature = "cpu-faer")]
+pub(super) struct CpuFaerBinding {
+    resources: CpuLinalgBinding,
+}
+
+#[cfg(feature = "cpu-faer")]
+impl Clone for CpuFaerBinding {
+    fn clone(&self) -> Self {
+        Self {
+            resources: self.resources.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+impl fmt::Debug for CpuFaerBinding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.resources.fmt(f)
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+impl CpuFaerBinding {
+    fn capture(backend: &CpuBackend) -> Self {
+        Self {
+            resources: backend.linalg_binding(),
+        }
+    }
+
+    fn validate(&self, backend: &CpuBackend, dtype: DType) -> tenferro_tensor::Result<()> {
+        if !self.resources.matches(backend) || backend.kind() != CpuBackendKind::Faer {
+            return Err(Error::unsupported_capability(
+                EXECUTE_OP,
+                BackendId::Cpu,
+                cpu_provider_name(backend.kind()),
+                dtype,
+                BINDING_CAPABILITY,
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+impl private::PreparedSvdDispatch for CpuBackend {
+    fn prepare_svd_impl(
+        &mut self,
+        shape: [usize; 2],
+        dtype: DType,
+        options: SvdOptions,
+    ) -> tenferro_tensor::Result<PreparedSvd> {
+        validate_derivative_eps(PREPARE_OP, options.derivative_eps)?;
+        if self.kind() != CpuBackendKind::Faer {
+            return Err(Error::unsupported_capability(
+                PREPARE_OP,
+                BackendId::Cpu,
+                cpu_provider_name(self.kind()),
+                dtype,
+                PREPARED_CAPABILITY,
+            ));
+        }
+        checked_shape_product(PREPARE_OP, "matrix shape", &shape)?;
+        for &extent in &shape {
+            isize::try_from(extent).map_err(|_| Error::InvalidConfig {
+                op: PREPARE_OP,
+                message: format!("matrix extent {extent} does not fit in isize"),
+            })?;
+        }
+        let singular_dtype = real_dtype(dtype)?;
+        let provider = FaerPlan::new(dtype, shape, self.linalg_context().faer_par())?;
+        let k = shape[0].min(shape[1]);
+        let placement = Placement {
+            memory_kind: MemoryKind::UnpinnedHost,
+            device: None,
+        };
+        let specs = SvdOutputSpecs {
+            u: SvdOutputSpec {
+                shape: vec![shape[0], k],
+                dtype,
+                placement: placement.clone(),
+            },
+            s: SvdOutputSpec {
+                shape: vec![k],
+                dtype: singular_dtype,
+                placement: placement.clone(),
+            },
+            vt: SvdOutputSpec {
+                shape: vec![k, shape[1]],
+                dtype,
+                placement,
+            },
+        };
+        Ok(PreparedSvd {
+            shape,
+            dtype,
+            options,
+            specs,
+            binding: CpuFaerBinding::capture(self),
+            plan_token: Arc::new(()),
+            provider,
+        })
+    }
+
+    fn allocate_svd_workspace_impl(
+        &mut self,
+        plan: &PreparedSvd,
+    ) -> tenferro_tensor::Result<SvdWorkspace> {
+        plan.binding.validate(self, plan.dtype)?;
+        let inner = plan.provider.allocate(plan.shape)?;
+        Ok(SvdWorkspace {
+            binding: plan.binding.clone(),
+            shape: plan.shape,
+            dtype: plan.dtype,
+            plan_token: Arc::clone(&plan.plan_token),
+            inner,
+        })
+    }
+
+    fn execute_prepared_svd_into_impl(
+        &mut self,
+        plan: &PreparedSvd,
+        workspace: &mut SvdWorkspace,
+        input: TensorRead<'_>,
+        outputs: SvdOutputWrites<'_>,
+    ) -> tenferro_tensor::Result<()> {
+        plan.binding.validate(self, plan.dtype)?;
+        workspace.binding.validate(self, workspace.dtype)?;
+        if !workspace.binding.resources.matches(self)
+            || !plan.binding.resources.matches(self)
+            || workspace.shape != plan.shape
+            || workspace.dtype != plan.dtype
+            || !Arc::ptr_eq(&workspace.plan_token, &plan.plan_token)
+        {
+            return Err(Error::unsupported_capability(
+                EXECUTE_OP,
+                BackendId::Cpu,
+                cpu_provider_name(self.kind()),
+                plan.dtype,
+                BINDING_CAPABILITY,
+            ));
+        }
+        validate_execution(plan, &input, &outputs)?;
+        if plan.shape[0] == 0 || plan.shape[1] == 0 {
+            return Ok(());
+        }
+        let par = self.linalg_context().faer_par();
+        self.install(move || execute_faer(plan, &mut workspace.inner, par, input, outputs))
+    }
+}
+
+#[cfg(not(feature = "cpu-faer"))]
+impl private::PreparedSvdDispatch for CpuBackend {
+    fn prepare_svd_impl(
+        &mut self,
+        _shape: [usize; 2],
+        dtype: DType,
+        _options: SvdOptions,
+    ) -> tenferro_tensor::Result<PreparedSvd> {
+        Err(Error::unsupported_capability(
+            PREPARE_OP,
+            BackendId::Cpu,
+            cpu_provider_name(self.kind()),
+            dtype,
+            PREPARED_CAPABILITY,
+        ))
+    }
+
+    fn allocate_svd_workspace_impl(
+        &mut self,
+        plan: &PreparedSvd,
+    ) -> tenferro_tensor::Result<SvdWorkspace> {
+        Err(Error::unsupported_capability(
+            PREPARE_OP,
+            BackendId::Cpu,
+            cpu_provider_name(self.kind()),
+            plan.dtype,
+            PREPARED_CAPABILITY,
+        ))
+    }
+
+    fn execute_prepared_svd_into_impl(
+        &mut self,
+        plan: &PreparedSvd,
+        _workspace: &mut SvdWorkspace,
+        _input: TensorRead<'_>,
+        _outputs: SvdOutputWrites<'_>,
+    ) -> tenferro_tensor::Result<()> {
+        Err(Error::unsupported_capability(
+            EXECUTE_OP,
+            BackendId::Cpu,
+            cpu_provider_name(self.kind()),
+            plan.dtype,
+            PREPARED_CAPABILITY,
+        ))
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+fn real_dtype(dtype: DType) -> tenferro_tensor::Result<DType> {
+    match dtype {
+        DType::F32 | DType::C32 => Ok(DType::F32),
+        DType::F64 | DType::C64 => Ok(DType::F64),
+        _ => Err(Error::unsupported_capability(
+            PREPARE_OP,
+            BackendId::Cpu,
+            "faer",
+            dtype,
+            PREPARED_CAPABILITY,
+        )),
+    }
+}
+
+const fn cpu_provider_name(kind: CpuBackendKind) -> &'static str {
+    match kind {
+        CpuBackendKind::Faer => "faer",
+        CpuBackendKind::Blas => "blas",
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+fn validate_execution(
+    plan: &PreparedSvd,
+    input: &TensorRead<'_>,
+    outputs: &SvdOutputWrites<'_>,
+) -> tenferro_tensor::Result<()> {
+    if input.shape() != plan.shape || input.dtype() != plan.dtype {
+        return Err(Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: format!(
+                "input must have shape {:?} and dtype {:?}, got {:?} and {:?}",
+                plan.shape,
+                plan.dtype,
+                input.shape(),
+                input.dtype()
+            ),
+        });
+    }
+    validate_host_read(input)?;
+    validate_output(&outputs.u, &plan.specs.u, "U")?;
+    validate_output(&outputs.s, &plan.specs.s, "S")?;
+    validate_output(&outputs.vt, &plan.specs.vt, "Vt")?;
+
+    let input_region = read_region(input)?;
+    let u_region = write_region(&outputs.u)?;
+    let s_region = write_region(&outputs.s)?;
+    let vt_region = write_region(&outputs.vt)?;
+    validate_non_aliasing(input_region, u_region, s_region, vt_region)
+}
+
+#[cfg(feature = "cpu-faer")]
+fn validate_non_aliasing(
+    input_region: Option<ByteRegion>,
+    u_region: Option<ByteRegion>,
+    s_region: Option<ByteRegion>,
+    vt_region: Option<ByteRegion>,
+) -> tenferro_tensor::Result<()> {
+    for (lhs_name, lhs, rhs_name, rhs) in [
+        ("input", input_region, "U", u_region),
+        ("input", input_region, "S", s_region),
+        ("input", input_region, "Vt", vt_region),
+        ("U", u_region, "S", s_region),
+        ("U", u_region, "Vt", vt_region),
+        ("S", s_region, "Vt", vt_region),
+    ] {
+        if regions_overlap(lhs, rhs) {
+            return Err(Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: format!("{lhs_name} and {rhs_name} may overlap"),
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(test, feature = "cpu-faer"))]
+mod alias_tests {
+    use super::*;
+
+    #[test]
+    fn numeric_regions_reject_all_six_alias_pairs_without_touching_sentinels() {
+        let separate = [
+            ByteRegion { start: 0, end: 16 },
+            ByteRegion { start: 32, end: 48 },
+            ByteRegion { start: 64, end: 72 },
+            ByteRegion {
+                start: 96,
+                end: 104,
+            },
+        ];
+        for (expected, lhs, rhs) in [
+            ("input and U", 0, 1),
+            ("input and S", 0, 2),
+            ("input and Vt", 0, 3),
+            ("U and S", 1, 2),
+            ("U and Vt", 1, 3),
+            ("S and Vt", 2, 3),
+        ] {
+            let mut regions = separate;
+            regions[rhs] = regions[lhs];
+            let sentinels = [11_u8, 22, 33];
+            let error = validate_non_aliasing(
+                Some(regions[0]),
+                Some(regions[1]),
+                Some(regions[2]),
+                Some(regions[3]),
+            )
+            .unwrap_err();
+            assert!(error.to_string().contains(expected));
+            assert_eq!(sentinels, [11, 22, 33]);
+        }
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+fn validate_output(
+    output: &TensorWrite<'_>,
+    spec: &SvdOutputSpec,
+    name: &str,
+) -> tenferro_tensor::Result<()> {
+    if output.shape() != spec.shape || output.dtype() != spec.dtype {
+        return Err(Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: format!(
+                "{name} must have shape {:?} and dtype {:?}, got {:?} and {:?}",
+                spec.shape,
+                spec.dtype,
+                output.shape(),
+                output.dtype()
+            ),
+        });
+    }
+    if !output.is_col_major_contiguous()? {
+        let _ = name;
+        return Err(Error::unsupported_capability(
+            EXECUTE_OP,
+            BackendId::Cpu,
+            "faer",
+            spec.dtype,
+            DESTINATION_CAPABILITY,
+        ));
+    }
+    validate_host_read(&output.as_read())
+}
+
+#[cfg(feature = "cpu-faer")]
+fn validate_host_read(read: &TensorRead<'_>) -> tenferro_tensor::Result<()> {
+    let placement = read_placement(read);
+    if placement.device.is_some()
+        || !matches!(
+            placement.memory_kind,
+            MemoryKind::PinnedHost | MemoryKind::UnpinnedHost
+        )
+    {
+        return Err(Error::unsupported_capability(
+            EXECUTE_OP,
+            BackendId::Cpu,
+            "faer",
+            read.dtype(),
+            "host-resident prepared SVD storage",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(feature = "cpu-faer")]
+fn read_placement<'a>(read: &'a TensorRead<'_>) -> &'a Placement {
+    match read {
+        TensorRead::Tensor(tensor) => tensor.placement(),
+        TensorRead::View(view) => match view {
+            TensorView::F32(v) => v.placement(),
+            TensorView::F64(v) => v.placement(),
+            TensorView::I32(v) => v.placement(),
+            TensorView::I64(v) => v.placement(),
+            TensorView::Bool(v) => v.placement(),
+            TensorView::C32(v) => v.placement(),
+            TensorView::C64(v) => v.placement(),
+        },
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+#[derive(Clone, Copy)]
+struct ByteRegion {
+    start: usize,
+    end: usize,
+}
+
+#[cfg(feature = "cpu-faer")]
+fn regions_overlap(lhs: Option<ByteRegion>, rhs: Option<ByteRegion>) -> bool {
+    match (lhs, rhs) {
+        (Some(lhs), Some(rhs)) => lhs.start < rhs.end && rhs.start < lhs.end,
+        _ => false,
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+fn read_region(read: &TensorRead<'_>) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    macro_rules! region {
+        ($value:expr, $ty:ty) => {
+            typed_read_region::<$ty>($value)
+        };
+    }
+    match read {
+        TensorRead::Tensor(Tensor::F32(t)) => region!(TypedReadRef::Tensor(t), f32),
+        TensorRead::Tensor(Tensor::F64(t)) => region!(TypedReadRef::Tensor(t), f64),
+        TensorRead::Tensor(Tensor::I32(t)) => region!(TypedReadRef::Tensor(t), i32),
+        TensorRead::Tensor(Tensor::I64(t)) => region!(TypedReadRef::Tensor(t), i64),
+        TensorRead::Tensor(Tensor::Bool(t)) => region!(TypedReadRef::Tensor(t), bool),
+        TensorRead::Tensor(Tensor::C32(t)) => region!(TypedReadRef::Tensor(t), Complex32),
+        TensorRead::Tensor(Tensor::C64(t)) => region!(TypedReadRef::Tensor(t), Complex64),
+        TensorRead::View(TensorView::F32(v)) => region!(TypedReadRef::View(v), f32),
+        TensorRead::View(TensorView::F64(v)) => region!(TypedReadRef::View(v), f64),
+        TensorRead::View(TensorView::I32(v)) => region!(TypedReadRef::View(v), i32),
+        TensorRead::View(TensorView::I64(v)) => region!(TypedReadRef::View(v), i64),
+        TensorRead::View(TensorView::Bool(v)) => region!(TypedReadRef::View(v), bool),
+        TensorRead::View(TensorView::C32(v)) => region!(TypedReadRef::View(v), Complex32),
+        TensorRead::View(TensorView::C64(v)) => region!(TypedReadRef::View(v), Complex64),
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+fn write_region(write: &TensorWrite<'_>) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    read_region(&write.as_read())
+}
+
+#[cfg(feature = "cpu-faer")]
+enum TypedReadRef<'a, T> {
+    Tensor(&'a TypedTensor<T>),
+    View(&'a TypedTensorView<'a, T>),
+}
+
+#[cfg(feature = "cpu-faer")]
+fn typed_read_region<T: Clone + 'static>(
+    read: TypedReadRef<'_, T>,
+) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    let (base, shape, strides, offset) = match read {
+        TypedReadRef::Tensor(tensor) => {
+            let data = tensor.host_data()?;
+            return byte_region(data.as_ptr(), 0, data.len(), size_of::<T>());
+        }
+        TypedReadRef::View(view) => (
+            view.host_storage()?.as_ptr(),
+            view.shape(),
+            view.strides(),
+            view.offset(),
+        ),
+    };
+    if shape.contains(&0) {
+        return Ok(None);
+    }
+    let mut min = offset;
+    let mut max = offset;
+    for (&extent, &stride) in shape.iter().zip(strides.iter()) {
+        let span = isize::try_from(extent - 1)
+            .ok()
+            .and_then(|extent| extent.checked_mul(stride))
+            .ok_or_else(|| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "input layout span overflows isize".to_owned(),
+            })?;
+        min = min
+            .checked_add(span.min(0))
+            .ok_or_else(|| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "input layout lower bound overflows isize".to_owned(),
+            })?;
+        max = max
+            .checked_add(span.max(0))
+            .ok_or_else(|| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "input layout upper bound overflows isize".to_owned(),
+            })?;
+    }
+    let start = usize::try_from(min).map_err(|_| Error::InvalidConfig {
+        op: EXECUTE_OP,
+        message: "input layout lower bound is negative".to_owned(),
+    })?;
+    let span = max
+        .checked_sub(min)
+        .and_then(|span| span.checked_add(1))
+        .ok_or_else(|| Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: "input layout range overflows isize".to_owned(),
+        })?;
+    let len = usize::try_from(span).map_err(|_| Error::InvalidConfig {
+        op: EXECUTE_OP,
+        message: "input layout range does not fit usize".to_owned(),
+    })?;
+    byte_region(base, start, len, size_of::<T>())
+}
+
+#[cfg(feature = "cpu-faer")]
+fn byte_region<T>(
+    base: *const T,
+    element_offset: usize,
+    element_len: usize,
+    element_size: usize,
+) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    if element_len == 0 {
+        return Ok(None);
+    }
+    let byte_offset =
+        element_offset
+            .checked_mul(element_size)
+            .ok_or_else(|| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "storage byte offset overflows usize".to_owned(),
+            })?;
+    let byte_len = element_len
+        .checked_mul(element_size)
+        .ok_or_else(|| Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: "storage byte length overflows usize".to_owned(),
+        })?;
+    let start = (base as usize)
+        .checked_add(byte_offset)
+        .ok_or_else(|| Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: "storage address range overflows usize".to_owned(),
+        })?;
+    let end = start
+        .checked_add(byte_len)
+        .ok_or_else(|| Error::InvalidConfig {
+            op: EXECUTE_OP,
+            message: "storage address range overflows usize".to_owned(),
+        })?;
+    Ok(Some(ByteRegion { start, end }))
+}

--- a/crates/tenferro-linalg/src/prepared_svd/cpu.rs
+++ b/crates/tenferro-linalg/src/prepared_svd/cpu.rs
@@ -117,37 +117,6 @@ impl private::PreparedSvdDispatch for CpuBackend {
             inner,
         })
     }
-
-    fn execute_prepared_svd_into_impl(
-        &mut self,
-        plan: &PreparedSvd,
-        workspace: &mut SvdWorkspace,
-        input: TensorRead<'_>,
-        outputs: SvdOutputWrites<'_>,
-    ) -> tenferro_tensor::Result<()> {
-        plan.binding.validate(self, plan.dtype)?;
-        workspace.binding.validate(self, workspace.dtype)?;
-        if !workspace.binding.resources.matches(self)
-            || !plan.binding.resources.matches(self)
-            || workspace.shape != plan.shape
-            || workspace.dtype != plan.dtype
-            || !Arc::ptr_eq(&workspace.plan_token, &plan.plan_token)
-        {
-            return Err(Error::unsupported_capability(
-                EXECUTE_OP,
-                BackendId::Cpu,
-                cpu_provider_name(self.kind()),
-                plan.dtype,
-                BINDING_CAPABILITY,
-            ));
-        }
-        validate_execution(plan, &input, &outputs)?;
-        if plan.shape[0] == 0 || plan.shape[1] == 0 {
-            return Ok(());
-        }
-        let par = self.linalg_context().faer_par();
-        self.install(move || execute_faer(plan, &mut workspace.inner, par, input, outputs))
-    }
 }
 
 #[cfg(not(feature = "cpu-faer"))]
@@ -179,22 +148,55 @@ impl private::PreparedSvdDispatch for CpuBackend {
             PREPARED_CAPABILITY,
         ))
     }
+}
 
-    fn execute_prepared_svd_into_impl(
-        &mut self,
-        plan: &PreparedSvd,
-        _workspace: &mut SvdWorkspace,
-        _input: TensorRead<'_>,
-        _outputs: SvdOutputWrites<'_>,
-    ) -> tenferro_tensor::Result<()> {
-        Err(Error::unsupported_capability(
+#[cfg(feature = "cpu-faer")]
+pub(super) fn execute_prepared_svd_into_session(
+    session: &mut crate::prepared_factorization::CpuPreparedFactorizationSession,
+    plan: &PreparedSvd,
+    workspace: &mut SvdWorkspace,
+    input: TensorRead<'_>,
+    outputs: SvdOutputWrites<'_>,
+) -> tenferro_tensor::Result<()> {
+    let backend = &session.backend;
+    plan.binding.validate(backend, plan.dtype)?;
+    workspace.binding.validate(backend, workspace.dtype)?;
+    if !workspace.binding.resources.matches(backend)
+        || !plan.binding.resources.matches(backend)
+        || workspace.shape != plan.shape
+        || workspace.dtype != plan.dtype
+        || !Arc::ptr_eq(&workspace.plan_token, &plan.plan_token)
+    {
+        return Err(Error::unsupported_capability(
             EXECUTE_OP,
             BackendId::Cpu,
-            cpu_provider_name(self.kind()),
+            cpu_provider_name(backend.kind()),
             plan.dtype,
-            PREPARED_CAPABILITY,
-        ))
+            BINDING_CAPABILITY,
+        ));
     }
+    validate_execution(plan, &input, &outputs)?;
+    if plan.shape[0] == 0 || plan.shape[1] == 0 {
+        return Ok(());
+    }
+    execute_faer(plan, &mut workspace.inner, session.par, input, outputs)
+}
+
+#[cfg(not(feature = "cpu-faer"))]
+pub(super) fn execute_prepared_svd_into_session(
+    session: &mut crate::prepared_factorization::CpuPreparedFactorizationSession,
+    plan: &PreparedSvd,
+    _workspace: &mut SvdWorkspace,
+    _input: TensorRead<'_>,
+    _outputs: SvdOutputWrites<'_>,
+) -> tenferro_tensor::Result<()> {
+    Err(Error::unsupported_capability(
+        EXECUTE_OP,
+        BackendId::Cpu,
+        cpu_provider_name(session.backend.kind()),
+        plan.dtype,
+        PREPARED_CAPABILITY,
+    ))
 }
 
 #[cfg(feature = "cpu-faer")]

--- a/crates/tenferro-linalg/src/prepared_svd/cpu.rs
+++ b/crates/tenferro-linalg/src/prepared_svd/cpu.rs
@@ -275,43 +275,7 @@ fn validate_non_aliasing(
 }
 
 #[cfg(all(test, feature = "cpu-faer"))]
-mod alias_tests {
-    use super::*;
-
-    #[test]
-    fn numeric_regions_reject_all_six_alias_pairs_without_touching_sentinels() {
-        let separate = [
-            ByteRegion { start: 0, end: 16 },
-            ByteRegion { start: 32, end: 48 },
-            ByteRegion { start: 64, end: 72 },
-            ByteRegion {
-                start: 96,
-                end: 104,
-            },
-        ];
-        for (expected, lhs, rhs) in [
-            ("input and U", 0, 1),
-            ("input and S", 0, 2),
-            ("input and Vt", 0, 3),
-            ("U and S", 1, 2),
-            ("U and Vt", 1, 3),
-            ("S and Vt", 2, 3),
-        ] {
-            let mut regions = separate;
-            regions[rhs] = regions[lhs];
-            let sentinels = [11_u8, 22, 33];
-            let error = validate_non_aliasing(
-                Some(regions[0]),
-                Some(regions[1]),
-                Some(regions[2]),
-                Some(regions[3]),
-            )
-            .unwrap_err();
-            assert!(error.to_string().contains(expected));
-            assert_eq!(sentinels, [11, 22, 33]);
-        }
-    }
-}
+mod tests;
 
 #[cfg(feature = "cpu-faer")]
 fn validate_output(

--- a/crates/tenferro-linalg/src/prepared_svd/cpu.rs
+++ b/crates/tenferro-linalg/src/prepared_svd/cpu.rs
@@ -307,6 +307,8 @@ fn validate_output(
             DESTINATION_CAPABILITY,
         ));
     }
+    // Why not duplicate writable-placement validation: prepared outputs are
+    // rank <= 2, so the shared read descriptor stays inside ShapeVec inline storage.
     validate_host_read(&output.as_read())
 }
 
@@ -388,6 +390,8 @@ fn read_region(read: &TensorRead<'_>) -> tenferro_tensor::Result<Option<ByteRegi
 
 #[cfg(feature = "cpu-faer")]
 fn write_region(write: &TensorWrite<'_>) -> tenferro_tensor::Result<Option<ByteRegion>> {
+    // Why not add a second writable-region walker: rank <= 2 descriptor clones
+    // stay inline, while this keeps one alias-analysis authority.
     read_region(&write.as_read())
 }
 

--- a/crates/tenferro-linalg/src/prepared_svd/cpu/tests.rs
+++ b/crates/tenferro-linalg/src/prepared_svd/cpu/tests.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+#[test]
+fn numeric_regions_reject_all_six_alias_pairs_without_touching_sentinels() {
+    let separate = [
+        ByteRegion { start: 0, end: 16 },
+        ByteRegion { start: 32, end: 48 },
+        ByteRegion { start: 64, end: 72 },
+        ByteRegion {
+            start: 96,
+            end: 104,
+        },
+    ];
+    for (expected, lhs, rhs) in [
+        ("input and U", 0, 1),
+        ("input and S", 0, 2),
+        ("input and Vt", 0, 3),
+        ("U and S", 1, 2),
+        ("U and Vt", 1, 3),
+        ("S and Vt", 2, 3),
+    ] {
+        let mut regions = separate;
+        regions[rhs] = regions[lhs];
+        let sentinels = [11_u8, 22, 33];
+        let error = validate_non_aliasing(
+            Some(regions[0]),
+            Some(regions[1]),
+            Some(regions[2]),
+            Some(regions[3]),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains(expected));
+        assert_eq!(sentinels, [11, 22, 33]);
+    }
+}

--- a/crates/tenferro-linalg/src/prepared_svd/faer_impl.rs
+++ b/crates/tenferro-linalg/src/prepared_svd/faer_impl.rs
@@ -301,8 +301,10 @@ macro_rules! impl_real_prepared_scalar {
                 par: faer::Par,
                 scratch: &mut MemBuffer,
             ) -> tenferro_tensor::Result<()> {
+                // INVARIANT: input pointer and signed strides describe the validated matrix span.
                 // SAFETY: prepared preflight validates all input/output layouts and aliasing.
                 let input = unsafe { MatRef::from_raw_parts(input, m, n, row_stride, col_stride) };
+                // INVARIANT: `u` is compact column-major and disjoint from every other region.
                 // SAFETY: `u` points to a compact, non-overlapping `m x k` destination.
                 let u = unsafe { MatMut::from_raw_parts_mut(u, m, k, 1, m as isize) };
                 let singular = DiagMut::from_slice_mut(singular_output);
@@ -375,11 +377,13 @@ macro_rules! impl_complex_prepared_scalar {
                 par: faer::Par,
                 scratch: &mut MemBuffer,
             ) -> tenferro_tensor::Result<()> {
+                // INVARIANT: the complex ABI assertions and validated strides remain fixed.
                 // SAFETY: compile-time layout assertions above prove compatible complex scalars;
                 // prepared preflight validates all input/output layouts and aliasing.
                 let input = unsafe {
                     MatRef::from_raw_parts(input.cast::<$faer>(), m, n, row_stride, col_stride)
                 };
+                // INVARIANT: `u` is compact column-major and disjoint from every other region.
                 // SAFETY: `u` points to a compact, non-overlapping `m x k` destination.
                 let u =
                     unsafe { MatMut::from_raw_parts_mut(u.cast::<$faer>(), m, k, 1, m as isize) };

--- a/crates/tenferro-linalg/src/prepared_svd/faer_impl.rs
+++ b/crates/tenferro-linalg/src/prepared_svd/faer_impl.rs
@@ -1,0 +1,538 @@
+use super::*;
+
+pub(super) enum FaerPlan {
+    F32(StackReq),
+    F64(StackReq),
+    C32(StackReq),
+    C64(StackReq),
+}
+
+impl FaerPlan {
+    pub(super) fn new(
+        dtype: DType,
+        shape: [usize; 2],
+        par: faer::Par,
+    ) -> tenferro_tensor::Result<Self> {
+        let [m, n] = shape;
+        let req = match dtype {
+            DType::F32 => Self::F32(faer::linalg::svd::svd_scratch::<f32>(
+                m,
+                n,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                par,
+                Default::default(),
+            )),
+            DType::F64 => Self::F64(faer::linalg::svd::svd_scratch::<f64>(
+                m,
+                n,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                par,
+                Default::default(),
+            )),
+            DType::C32 => Self::C32(faer::linalg::svd::svd_scratch::<faer::c32>(
+                m,
+                n,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                par,
+                Default::default(),
+            )),
+            DType::C64 => Self::C64(faer::linalg::svd::svd_scratch::<faer::c64>(
+                m,
+                n,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                faer::linalg::svd::ComputeSvdVectors::Thin,
+                par,
+                Default::default(),
+            )),
+            _ => return Err(Error::backend_failure(PREPARE_OP, "unsupported SVD dtype")),
+        };
+        Ok(req)
+    }
+
+    pub(super) fn scratch_bytes(&self) -> usize {
+        match self {
+            Self::F32(req) | Self::F64(req) | Self::C32(req) | Self::C64(req) => req.size_bytes(),
+        }
+    }
+
+    pub(super) fn allocate(&self, shape: [usize; 2]) -> tenferro_tensor::Result<FaerWorkspace> {
+        macro_rules! alloc {
+            ($variant:ident, $req:expr, $input:ty, $faer:ty, $stage_singular:expr) => {
+                Ok(FaerWorkspace::$variant(
+                    FaerTypedWorkspace::<$input, $faer>::new(*$req, shape, $stage_singular)?,
+                ))
+            };
+        }
+        match self {
+            Self::F32(req) => alloc!(F32, req, f32, f32, false),
+            Self::F64(req) => alloc!(F64, req, f64, f64, false),
+            Self::C32(req) => alloc!(C32, req, Complex32, faer::c32, true),
+            Self::C64(req) => alloc!(C64, req, Complex64, faer::c64, true),
+        }
+    }
+}
+
+pub(super) enum FaerWorkspace {
+    F32(FaerTypedWorkspace<f32, f32>),
+    F64(FaerTypedWorkspace<f64, f64>),
+    C32(FaerTypedWorkspace<Complex32, faer::c32>),
+    C64(FaerTypedWorkspace<Complex64, faer::c64>),
+}
+
+impl FaerWorkspace {
+    pub(super) fn retained_bytes(&self) -> usize {
+        match self {
+            Self::F32(w) => w.retained_bytes(),
+            Self::F64(w) => w.retained_bytes(),
+            Self::C32(w) => w.retained_bytes(),
+            Self::C64(w) => w.retained_bytes(),
+        }
+    }
+}
+
+pub(super) struct FaerTypedWorkspace<T, F> {
+    scratch: MemBuffer,
+    packed: Vec<T>,
+    singular: Vec<F>,
+    v: Vec<F>,
+}
+
+impl<T: Default + Clone, F: Default + Clone> FaerTypedWorkspace<T, F> {
+    fn new(
+        req: StackReq,
+        [m, n]: [usize; 2],
+        stage_singular: bool,
+    ) -> tenferro_tensor::Result<Self> {
+        let matrix_len = checked_shape_product(PREPARE_OP, "input pack", &[m, n])?;
+        let k = m.min(n);
+        let v_len = checked_shape_product(PREPARE_OP, "right singular vectors", &[n, k])?;
+        let scratch = MemBuffer::try_new(req).map_err(|err| {
+            Error::backend_failure(PREPARE_OP, format!("Faer scratch allocation failed: {err}"))
+        })?;
+        Ok(Self {
+            scratch,
+            packed: vec![T::default(); matrix_len],
+            singular: vec![F::default(); if stage_singular { k } else { 0 }],
+            v: vec![F::default(); v_len],
+        })
+    }
+
+    fn retained_bytes(&self) -> usize {
+        self.scratch.len()
+            + self.packed.capacity() * size_of::<T>()
+            + self.singular.capacity() * size_of::<F>()
+            + self.v.capacity() * size_of::<F>()
+    }
+}
+
+pub(super) fn execute_faer(
+    plan: &PreparedSvd,
+    workspace: &mut FaerWorkspace,
+    par: faer::Par,
+    input: TensorRead<'_>,
+    outputs: SvdOutputWrites<'_>,
+) -> tenferro_tensor::Result<()> {
+    match plan.dtype {
+        DType::F32 => execute_f32(plan, workspace, par, input, outputs),
+        DType::F64 => execute_f64(plan, workspace, par, input, outputs),
+        DType::C32 => execute_c32(plan, workspace, par, input, outputs),
+        DType::C64 => execute_c64(plan, workspace, par, input, outputs),
+        _ => Err(Error::backend_failure(
+            EXECUTE_OP,
+            "unsupported prepared SVD dtype",
+        )),
+    }
+}
+
+// Boxing the view variant would make dispatch smaller but allocate on every warm call.
+#[allow(clippy::large_enum_variant)]
+enum PreparedRead<'a, T> {
+    Tensor(&'a TypedTensor<T>),
+    View(TypedTensorView<'a, T>),
+}
+
+// Output views stay inline because prepared execution must not allocate wrappers.
+#[allow(clippy::large_enum_variant)]
+enum PreparedWrite<'a, T> {
+    Tensor(&'a mut TypedTensor<T>),
+    View(TypedTensorViewMut<'a, T>),
+}
+
+macro_rules! impl_dtype_dispatch {
+    (
+        $fn_name:ident,
+        $workspace_variant:ident,
+        $tensor_variant:ident,
+        $view_variant:ident,
+        $scalar:ty,
+        $real_tensor_variant:ident,
+        $real_view_variant:ident,
+        $real:ty
+    ) => {
+        fn $fn_name(
+            plan: &PreparedSvd,
+            workspace: &mut FaerWorkspace,
+            par: faer::Par,
+            input: TensorRead<'_>,
+            outputs: SvdOutputWrites<'_>,
+        ) -> tenferro_tensor::Result<()> {
+            let input = match input {
+                TensorRead::Tensor(Tensor::$tensor_variant(tensor)) => PreparedRead::Tensor(tensor),
+                TensorRead::View(TensorView::$view_variant(view)) => PreparedRead::View(view),
+                _ => {
+                    return Err(Error::backend_failure(
+                        EXECUTE_OP,
+                        "validated input dtype changed",
+                    ));
+                }
+            };
+            let SvdOutputWrites { u, s, vt } = outputs;
+            let u = match u {
+                TensorWrite::Tensor(Tensor::$tensor_variant(tensor)) => {
+                    PreparedWrite::Tensor(tensor)
+                }
+                TensorWrite::View(TensorViewMut::$view_variant(view)) => PreparedWrite::View(view),
+                _ => {
+                    return Err(Error::backend_failure(
+                        EXECUTE_OP,
+                        "validated U dtype changed",
+                    ));
+                }
+            };
+            let s = match s {
+                TensorWrite::Tensor(Tensor::$real_tensor_variant(tensor)) => {
+                    PreparedWrite::Tensor(tensor)
+                }
+                TensorWrite::View(TensorViewMut::$real_view_variant(view)) => {
+                    PreparedWrite::View(view)
+                }
+                _ => {
+                    return Err(Error::backend_failure(
+                        EXECUTE_OP,
+                        "validated S dtype changed",
+                    ));
+                }
+            };
+            let vt = match vt {
+                TensorWrite::Tensor(Tensor::$tensor_variant(tensor)) => {
+                    PreparedWrite::Tensor(tensor)
+                }
+                TensorWrite::View(TensorViewMut::$view_variant(view)) => PreparedWrite::View(view),
+                _ => {
+                    return Err(Error::backend_failure(
+                        EXECUTE_OP,
+                        "validated Vt dtype changed",
+                    ));
+                }
+            };
+            match workspace {
+                FaerWorkspace::$workspace_variant(workspace) => {
+                    execute_typed::<$scalar, $real>(plan, workspace, par, input, u, s, vt)
+                }
+                _ => Err(Error::backend_failure(
+                    EXECUTE_OP,
+                    "validated workspace dtype changed",
+                )),
+            }
+        }
+    };
+}
+
+impl_dtype_dispatch!(execute_f32, F32, F32, F32, f32, F32, F32, f32);
+impl_dtype_dispatch!(execute_f64, F64, F64, F64, f64, F64, F64, f64);
+impl_dtype_dispatch!(execute_c32, C32, C32, C32, Complex32, F32, F32, f32);
+impl_dtype_dispatch!(execute_c64, C64, C64, C64, Complex64, F64, F64, f64);
+
+trait PreparedSvdScalar<R>: Copy + Default + Send + Sync + 'static {
+    type Faer: Copy + Default;
+
+    fn copy_singular(staging: &[Self::Faer], output: &mut [R]);
+    fn conjugated_output(value: Self::Faer) -> Self;
+    fn apply_gauge(
+        gauge: SvdGauge,
+        u: &mut [Self],
+        vt: &mut [Self],
+        m: usize,
+        k: usize,
+        n: usize,
+    ) -> tenferro_tensor::Result<()>;
+    #[allow(clippy::too_many_arguments)]
+    fn run_svd(
+        input: *const Self,
+        row_stride: isize,
+        col_stride: isize,
+        u: *mut Self,
+        singular_output: &mut [R],
+        singular_staging: &mut [Self::Faer],
+        v: &mut [Self::Faer],
+        m: usize,
+        n: usize,
+        k: usize,
+        par: faer::Par,
+        scratch: &mut MemBuffer,
+    ) -> tenferro_tensor::Result<()>;
+}
+
+macro_rules! impl_real_prepared_scalar {
+    ($ty:ty, $gauge_fn:ident) => {
+        impl PreparedSvdScalar<$ty> for $ty {
+            type Faer = $ty;
+
+            fn copy_singular(_staging: &[Self::Faer], _output: &mut [$ty]) {}
+
+            fn conjugated_output(value: Self::Faer) -> Self {
+                value
+            }
+
+            fn run_svd(
+                input: *const Self,
+                row_stride: isize,
+                col_stride: isize,
+                u: *mut Self,
+                singular_output: &mut [$ty],
+                _singular_staging: &mut [Self::Faer],
+                v: &mut [Self::Faer],
+                m: usize,
+                n: usize,
+                k: usize,
+                par: faer::Par,
+                scratch: &mut MemBuffer,
+            ) -> tenferro_tensor::Result<()> {
+                // SAFETY: prepared preflight validates all input/output layouts and aliasing.
+                let input = unsafe { MatRef::from_raw_parts(input, m, n, row_stride, col_stride) };
+                // SAFETY: `u` points to a compact, non-overlapping `m x k` destination.
+                let u = unsafe { MatMut::from_raw_parts_mut(u, m, k, 1, m as isize) };
+                let singular = DiagMut::from_slice_mut(singular_output);
+                let v = MatMut::from_column_major_slice_mut(v, n, k);
+                faer::linalg::svd::svd(
+                    input,
+                    singular,
+                    Some(u),
+                    Some(v),
+                    par,
+                    MemStack::new(scratch),
+                    Default::default(),
+                )
+                .map_err(|_| Error::backend_failure(EXECUTE_OP, "Faer SVD decomposition failed"))
+            }
+
+            fn apply_gauge(
+                gauge: SvdGauge,
+                u: &mut [Self],
+                vt: &mut [Self],
+                m: usize,
+                k: usize,
+                n: usize,
+            ) -> tenferro_tensor::Result<()> {
+                if gauge == SvdGauge::Raw {
+                    return Ok(());
+                }
+                $gauge_fn(u, vt, m, k, n, 1)
+            }
+        }
+    };
+}
+
+impl_real_prepared_scalar!(f32, canonicalize_svd_gauge_f32);
+impl_real_prepared_scalar!(f64, canonicalize_svd_gauge_f64);
+
+macro_rules! impl_complex_prepared_scalar {
+    ($complex:ty, $faer:ty, $real:ty, $gauge_fn:ident) => {
+        const _: () = {
+            assert!(size_of::<$complex>() == size_of::<$faer>());
+            assert!(std::mem::align_of::<$complex>() == std::mem::align_of::<$faer>());
+            assert!(std::mem::offset_of!($complex, re) == std::mem::offset_of!($faer, re));
+            assert!(std::mem::offset_of!($complex, im) == std::mem::offset_of!($faer, im));
+        };
+
+        impl PreparedSvdScalar<$real> for $complex {
+            type Faer = $faer;
+
+            fn copy_singular(staging: &[Self::Faer], output: &mut [$real]) {
+                for (dst, value) in output.iter_mut().zip(staging) {
+                    *dst = value.re;
+                }
+            }
+
+            fn conjugated_output(value: Self::Faer) -> Self {
+                Self::new(value.re, -value.im)
+            }
+
+            fn run_svd(
+                input: *const Self,
+                row_stride: isize,
+                col_stride: isize,
+                u: *mut Self,
+                _singular_output: &mut [$real],
+                singular_staging: &mut [Self::Faer],
+                v: &mut [Self::Faer],
+                m: usize,
+                n: usize,
+                k: usize,
+                par: faer::Par,
+                scratch: &mut MemBuffer,
+            ) -> tenferro_tensor::Result<()> {
+                // SAFETY: compile-time layout assertions above prove compatible complex scalars;
+                // prepared preflight validates all input/output layouts and aliasing.
+                let input = unsafe {
+                    MatRef::from_raw_parts(input.cast::<$faer>(), m, n, row_stride, col_stride)
+                };
+                // SAFETY: `u` points to a compact, non-overlapping `m x k` destination.
+                let u =
+                    unsafe { MatMut::from_raw_parts_mut(u.cast::<$faer>(), m, k, 1, m as isize) };
+                let singular = DiagMut::from_slice_mut(singular_staging);
+                let v = MatMut::from_column_major_slice_mut(v, n, k);
+                faer::linalg::svd::svd(
+                    input,
+                    singular,
+                    Some(u),
+                    Some(v),
+                    par,
+                    MemStack::new(scratch),
+                    Default::default(),
+                )
+                .map_err(|_| Error::backend_failure(EXECUTE_OP, "Faer SVD decomposition failed"))
+            }
+
+            fn apply_gauge(
+                gauge: SvdGauge,
+                u: &mut [Self],
+                vt: &mut [Self],
+                m: usize,
+                k: usize,
+                n: usize,
+            ) -> tenferro_tensor::Result<()> {
+                if gauge == SvdGauge::Raw {
+                    return Ok(());
+                }
+                $gauge_fn(u, vt, m, k, n, 1)
+            }
+        }
+    };
+}
+
+impl_complex_prepared_scalar!(Complex32, faer::c32, f32, canonicalize_svd_gauge_c32);
+impl_complex_prepared_scalar!(Complex64, faer::c64, f64, canonicalize_svd_gauge_c64);
+
+fn execute_typed<T, R>(
+    plan: &PreparedSvd,
+    workspace: &mut FaerTypedWorkspace<T, T::Faer>,
+    par: faer::Par,
+    input: PreparedRead<'_, T>,
+    mut u: PreparedWrite<'_, T>,
+    mut s: PreparedWrite<'_, R>,
+    mut vt: PreparedWrite<'_, T>,
+) -> tenferro_tensor::Result<()>
+where
+    T: PreparedSvdScalar<R>,
+    R: Copy + Default + 'static,
+{
+    let [m, n] = plan.shape;
+    let k = m.min(n);
+    let (input_ptr, row_stride, col_stride) =
+        prepared_input_parts::<T, R>(&input, workspace, m, n)?;
+    let u_slice = prepared_write_slice(&mut u)?;
+    let s_slice = prepared_write_slice(&mut s)?;
+    let vt_slice = prepared_write_slice(&mut vt)?;
+    T::run_svd(
+        input_ptr,
+        row_stride,
+        col_stride,
+        u_slice.as_mut_ptr(),
+        s_slice,
+        workspace.singular.as_mut_slice(),
+        workspace.v.as_mut_slice(),
+        m,
+        n,
+        k,
+        par,
+        &mut workspace.scratch,
+    )?;
+
+    T::copy_singular(workspace.singular.as_slice(), s_slice);
+    for col in 0..n {
+        for row in 0..k {
+            vt_slice[row + k * col] = T::conjugated_output(workspace.v[col + n * row]);
+        }
+    }
+    T::apply_gauge(plan.options.gauge, u_slice, vt_slice, m, k, n)?;
+    Ok(())
+}
+
+fn prepared_input_parts<T, R>(
+    input: &PreparedRead<'_, T>,
+    workspace: &mut FaerTypedWorkspace<T, T::Faer>,
+    m: usize,
+    n: usize,
+) -> tenferro_tensor::Result<(*const T, isize, isize)>
+where
+    T: PreparedSvdScalar<R>,
+{
+    match input {
+        PreparedRead::Tensor(tensor) => Ok((tensor.host_data()?.as_ptr(), 1, m as isize)),
+        PreparedRead::View(view) if view.strides().iter().all(|&stride| stride > 0) => {
+            let storage = view.host_storage()?;
+            let offset = usize::try_from(view.offset()).map_err(|_| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "input view offset is negative".to_owned(),
+            })?;
+            Ok((
+                storage.as_ptr().wrapping_add(offset),
+                view.strides()[0],
+                view.strides()[1],
+            ))
+        }
+        PreparedRead::View(view) => {
+            let storage = view.host_storage()?;
+            let row_stride = view.strides()[0];
+            let col_stride = view.strides()[1];
+            let base = view.offset();
+            for col in 0..n {
+                for row in 0..m {
+                    let row_offset = isize::try_from(row)
+                        .ok()
+                        .and_then(|row| row.checked_mul(row_stride));
+                    let col_offset = isize::try_from(col)
+                        .ok()
+                        .and_then(|col| col.checked_mul(col_stride));
+                    let offset = row_offset
+                        .and_then(|row| col_offset.and_then(|col| row.checked_add(col)))
+                        .and_then(|delta| base.checked_add(delta))
+                        .and_then(|offset| usize::try_from(offset).ok())
+                        .ok_or_else(|| Error::InvalidConfig {
+                            op: EXECUTE_OP,
+                            message: "input view offset overflows during prepared packing"
+                                .to_owned(),
+                        })?;
+                    workspace.packed[row + m * col] = storage[offset];
+                }
+            }
+            Ok((workspace.packed.as_ptr(), 1, m as isize))
+        }
+    }
+}
+
+fn prepared_write_slice<'a, T: Clone + 'static>(
+    write: &'a mut PreparedWrite<'_, T>,
+) -> tenferro_tensor::Result<&'a mut [T]> {
+    match write {
+        PreparedWrite::Tensor(tensor) => tensor.host_data_mut(),
+        PreparedWrite::View(view) => {
+            let offset = usize::try_from(view.offset()).map_err(|_| Error::InvalidConfig {
+                op: EXECUTE_OP,
+                message: "output view offset is negative".to_owned(),
+            })?;
+            let len = checked_shape_product(EXECUTE_OP, "output shape", view.shape())?;
+            let end = offset
+                .checked_add(len)
+                .ok_or_else(|| Error::InvalidConfig {
+                    op: EXECUTE_OP,
+                    message: "output view range overflows usize".to_owned(),
+                })?;
+            Ok(&mut view.host_storage_mut()?[offset..end])
+        }
+    }
+}

--- a/crates/tenferro-linalg/src/prepared_svd/faer_impl.rs
+++ b/crates/tenferro-linalg/src/prepared_svd/faer_impl.rs
@@ -52,9 +52,17 @@ impl FaerPlan {
         Ok(req)
     }
 
-    pub(super) fn scratch_bytes(&self) -> usize {
+    pub(super) const fn retained_bytes(&self) -> usize {
+        // StackReq is inline metadata; tensor-sized storage belongs to SvdWorkspace.
+        0
+    }
+
+    pub(super) fn workspace_required_bytes(&self, shape: [usize; 2]) -> usize {
         match self {
-            Self::F32(req) | Self::F64(req) | Self::C32(req) | Self::C64(req) => req.size_bytes(),
+            Self::F32(req) => required_bytes::<f32, f32>(*req, shape, false),
+            Self::F64(req) => required_bytes::<f64, f64>(*req, shape, false),
+            Self::C32(req) => required_bytes::<Complex32, faer::c32>(*req, shape, true),
+            Self::C64(req) => required_bytes::<Complex64, faer::c64>(*req, shape, true),
         }
     }
 
@@ -83,6 +91,15 @@ pub(super) enum FaerWorkspace {
 }
 
 impl FaerWorkspace {
+    pub(super) fn required_bytes(&self) -> usize {
+        match self {
+            Self::F32(w) => w.required_bytes(),
+            Self::F64(w) => w.required_bytes(),
+            Self::C32(w) => w.required_bytes(),
+            Self::C64(w) => w.required_bytes(),
+        }
+    }
+
     pub(super) fn retained_bytes(&self) -> usize {
         match self {
             Self::F32(w) => w.retained_bytes(),
@@ -126,6 +143,25 @@ impl<T: Default + Clone, F: Default + Clone> FaerTypedWorkspace<T, F> {
             + self.singular.capacity() * size_of::<F>()
             + self.v.capacity() * size_of::<F>()
     }
+
+    fn required_bytes(&self) -> usize {
+        self.scratch.len()
+            + self.packed.len() * size_of::<T>()
+            + self.singular.len() * size_of::<F>()
+            + self.v.len() * size_of::<F>()
+    }
+}
+
+fn required_bytes<T, F>(req: StackReq, [m, n]: [usize; 2], stage_singular: bool) -> usize {
+    let k = m.min(n);
+    req.size_bytes()
+        .saturating_add(m.saturating_mul(n).saturating_mul(size_of::<T>()))
+        .saturating_add(
+            usize::from(stage_singular)
+                .saturating_mul(k)
+                .saturating_mul(size_of::<F>()),
+        )
+        .saturating_add(n.saturating_mul(k).saturating_mul(size_of::<F>()))
 }
 
 pub(super) fn execute_faer(

--- a/crates/tenferro-linalg/src/prepared_svd/faer_impl.rs
+++ b/crates/tenferro-linalg/src/prepared_svd/faer_impl.rs
@@ -147,14 +147,14 @@ pub(super) fn execute_faer(
     }
 }
 
-// Boxing the view variant would make dispatch smaller but allocate on every warm call.
+// INVARIANT: variants stay inline because boxing a view would allocate on every warm call.
 #[allow(clippy::large_enum_variant)]
 enum PreparedRead<'a, T> {
     Tensor(&'a TypedTensor<T>),
     View(TypedTensorView<'a, T>),
 }
 
-// Output views stay inline because prepared execution must not allocate wrappers.
+// INVARIANT: output variants stay inline because boxing would violate allocation-free reuse.
 #[allow(clippy::large_enum_variant)]
 enum PreparedWrite<'a, T> {
     Tensor(&'a mut TypedTensor<T>),
@@ -259,6 +259,8 @@ trait PreparedSvdScalar<R>: Copy + Default + Send + Sync + 'static {
         k: usize,
         n: usize,
     ) -> tenferro_tensor::Result<()>;
+    // INVARIANT: raw regions and dimensions stay explicit so alias and layout contracts remain
+    // reviewable at the backend boundary; bundling them would hide the unsafe preconditions.
     #[allow(clippy::too_many_arguments)]
     fn run_svd(
         input: *const Self,

--- a/crates/tenferro-linalg/tests/prepared_svd.rs
+++ b/crates/tenferro-linalg/tests/prepared_svd.rs
@@ -1,0 +1,954 @@
+use num_complex::{Complex32, Complex64};
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+use tenferro_linalg::{
+    LinalgBackend, PreparedSvdBackendExt, SvdGauge, SvdOptions, SvdOutputWrites,
+};
+use tenferro_tensor::{
+    BackendId, DType, Error, Tensor, TensorRead, TensorView, TensorViewMut, TensorWrite,
+    TypedTensorView, TypedTensorViewMut,
+};
+
+fn f64_outputs(m: usize, n: usize, fill: f64) -> (Tensor, Tensor, Tensor) {
+    let k = m.min(n);
+    (
+        Tensor::from_vec_col_major(vec![m, k], vec![fill; m * k]).unwrap(),
+        Tensor::from_vec_col_major(vec![k], vec![fill; k]).unwrap(),
+        Tensor::from_vec_col_major(vec![k, n], vec![fill; k * n]).unwrap(),
+    )
+}
+
+fn assert_f64_svd_residual(input: &[f64], u: &[f64], s: &[f64], vt: &[f64], m: usize, n: usize) {
+    let k = m.min(n);
+    let mut max_reconstruction = 0.0_f64;
+    for col in 0..n {
+        for row in 0..m {
+            let mut reconstructed = 0.0;
+            for inner in 0..k {
+                reconstructed += u[row + m * inner] * s[inner] * vt[inner + k * col];
+            }
+            max_reconstruction =
+                max_reconstruction.max((reconstructed - input[row + m * col]).abs());
+        }
+    }
+    let mut max_orthogonality = 0.0_f64;
+    for lhs in 0..k {
+        for rhs in 0..k {
+            let mut dot = 0.0;
+            for row in 0..m {
+                dot += u[row + m * lhs] * u[row + m * rhs];
+            }
+            let expected = if lhs == rhs { 1.0 } else { 0.0 };
+            max_orthogonality = max_orthogonality.max((dot - expected).abs());
+        }
+    }
+    let mut max_vt_orthogonality = 0.0_f64;
+    for lhs in 0..k {
+        for rhs in 0..k {
+            let mut dot = 0.0;
+            for col in 0..n {
+                dot += vt[lhs + k * col] * vt[rhs + k * col];
+            }
+            let expected = if lhs == rhs { 1.0 } else { 0.0 };
+            max_vt_orthogonality = max_vt_orthogonality.max((dot - expected).abs());
+        }
+    }
+    assert!(
+        max_reconstruction < 1.0e-10,
+        "reconstruction residual {max_reconstruction}"
+    );
+    assert!(
+        max_orthogonality < 1.0e-10,
+        "U orthogonality residual {max_orthogonality}"
+    );
+    assert!(
+        max_vt_orthogonality < 1.0e-10,
+        "Vt row orthogonality residual {max_vt_orthogonality}"
+    );
+}
+
+fn assert_c64_svd_residual(
+    input: &[Complex64],
+    u: &[Complex64],
+    s: &[f64],
+    vt: &[Complex64],
+    m: usize,
+    n: usize,
+    tolerance: f64,
+) {
+    let k = m.min(n);
+    let mut max_reconstruction = 0.0_f64;
+    for col in 0..n {
+        for row in 0..m {
+            let mut reconstructed = Complex64::new(0.0, 0.0);
+            for inner in 0..k {
+                reconstructed += u[row + m * inner] * s[inner] * vt[inner + k * col];
+            }
+            max_reconstruction =
+                max_reconstruction.max((reconstructed - input[row + m * col]).norm());
+        }
+    }
+    let mut max_orthogonality = 0.0_f64;
+    for lhs in 0..k {
+        for rhs in 0..k {
+            let mut dot = Complex64::new(0.0, 0.0);
+            for row in 0..m {
+                dot += u[row + m * lhs].conj() * u[row + m * rhs];
+            }
+            let expected = if lhs == rhs {
+                Complex64::new(1.0, 0.0)
+            } else {
+                Complex64::new(0.0, 0.0)
+            };
+            max_orthogonality = max_orthogonality.max((dot - expected).norm());
+        }
+    }
+    let mut max_vt_orthogonality = 0.0_f64;
+    for lhs in 0..k {
+        for rhs in 0..k {
+            let mut dot = Complex64::new(0.0, 0.0);
+            for col in 0..n {
+                dot += vt[lhs + k * col] * vt[rhs + k * col].conj();
+            }
+            let expected = if lhs == rhs {
+                Complex64::new(1.0, 0.0)
+            } else {
+                Complex64::new(0.0, 0.0)
+            };
+            max_vt_orthogonality = max_vt_orthogonality.max((dot - expected).norm());
+        }
+    }
+    assert!(
+        max_reconstruction < tolerance,
+        "reconstruction residual {max_reconstruction}"
+    );
+    assert!(
+        max_orthogonality < tolerance,
+        "U orthogonality residual {max_orthogonality}"
+    );
+    assert!(
+        max_vt_orthogonality < tolerance,
+        "Vt row orthogonality residual {max_vt_orthogonality}"
+    );
+}
+
+fn assert_f32_svd_residual(input: &[f32], u: &[f32], s: &[f32], vt: &[f32], m: usize, n: usize) {
+    let input = input.iter().map(|&x| f64::from(x)).collect::<Vec<_>>();
+    let u = u.iter().map(|&x| f64::from(x)).collect::<Vec<_>>();
+    let s = s.iter().map(|&x| f64::from(x)).collect::<Vec<_>>();
+    let vt = vt.iter().map(|&x| f64::from(x)).collect::<Vec<_>>();
+    let k = m.min(n);
+    let mut reconstruction = 0.0_f64;
+    for col in 0..n {
+        for row in 0..m {
+            let actual = (0..k)
+                .map(|inner| u[row + m * inner] * s[inner] * vt[inner + k * col])
+                .sum::<f64>();
+            reconstruction = reconstruction.max((actual - input[row + m * col]).abs());
+        }
+    }
+    let mut unitary = 0.0_f64;
+    for lhs in 0..k {
+        for rhs in 0..k {
+            let expected = f64::from(lhs == rhs);
+            let u_dot = (0..m)
+                .map(|row| u[row + m * lhs] * u[row + m * rhs])
+                .sum::<f64>();
+            let vt_dot = (0..n)
+                .map(|col| vt[lhs + k * col] * vt[rhs + k * col])
+                .sum::<f64>();
+            unitary = unitary.max((u_dot - expected).abs());
+            unitary = unitary.max((vt_dot - expected).abs());
+        }
+    }
+    assert!(
+        reconstruction < 2.0e-4,
+        "F32 reconstruction residual {reconstruction}"
+    );
+    assert!(unitary < 2.0e-4, "F32 unitarity residual {unitary}");
+}
+
+fn assert_c32_svd_residual(
+    input: &[Complex32],
+    u: &[Complex32],
+    s: &[f32],
+    vt: &[Complex32],
+    m: usize,
+    n: usize,
+) {
+    let lift = |value: &Complex32| Complex64::new(f64::from(value.re), f64::from(value.im));
+    let input = input.iter().map(lift).collect::<Vec<_>>();
+    let u = u.iter().map(lift).collect::<Vec<_>>();
+    let s = s.iter().map(|&x| f64::from(x)).collect::<Vec<_>>();
+    let vt = vt.iter().map(lift).collect::<Vec<_>>();
+    assert_c64_svd_residual(&input, &u, &s, &vt, m, n, 2.0e-4);
+}
+
+#[test]
+fn prepared_svd_all_dtypes_cover_shapes_repeated_values_and_gauges() {
+    let cases = [
+        (2, 2, vec![2.0_f64, 0.0, 0.0, 2.0]),
+        (3, 2, vec![3.0, 1.0, -2.0, 4.0, -1.0, 2.0]),
+        (2, 3, vec![3.0, 1.0, -2.0, 4.0, -1.0, 2.0]),
+    ];
+    for gauge in [SvdGauge::Raw, SvdGauge::CanonicalPivot] {
+        for (m, n, real_data) in &cases {
+            let (m, n) = (*m, *n);
+            let options = SvdOptions::default().gauge(gauge);
+
+            let f32_data = real_data.iter().map(|&x| x as f32).collect::<Vec<_>>();
+            let input = Tensor::from_vec_col_major(vec![m, n], f32_data.clone()).unwrap();
+            let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+            let plan = backend.prepare_svd([m, n], DType::F32, options).unwrap();
+            let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+            let k = m.min(n);
+            let mut u = Tensor::from_vec_col_major(vec![m, k], vec![0.0_f32; m * k]).unwrap();
+            let mut s = Tensor::from_vec_col_major(vec![k], vec![0.0_f32; k]).unwrap();
+            let mut vt = Tensor::from_vec_col_major(vec![k, n], vec![0.0_f32; k * n]).unwrap();
+            plan.execute_into(
+                &mut backend,
+                &mut workspace,
+                TensorRead::from_tensor(&input),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            assert_f32_svd_residual(
+                &f32_data,
+                u.as_slice().unwrap(),
+                s.as_slice().unwrap(),
+                vt.as_slice().unwrap(),
+                m,
+                n,
+            );
+
+            let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+            let input = Tensor::from_vec_col_major(vec![m, n], real_data.clone()).unwrap();
+            let plan = backend.prepare_svd([m, n], DType::F64, options).unwrap();
+            let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+            let (mut u, mut s, mut vt) = f64_outputs(m, n, 0.0);
+            plan.execute_into(
+                &mut backend,
+                &mut workspace,
+                TensorRead::from_tensor(&input),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            assert_f64_svd_residual(
+                real_data,
+                u.as_slice().unwrap(),
+                s.as_slice().unwrap(),
+                vt.as_slice().unwrap(),
+                m,
+                n,
+            );
+
+            let c32_data = real_data
+                .iter()
+                .enumerate()
+                .map(|(i, &x)| Complex32::new(x as f32, (i % 3) as f32 * 0.125))
+                .collect::<Vec<_>>();
+            let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+            let input = Tensor::from_vec_col_major(vec![m, n], c32_data.clone()).unwrap();
+            let plan = backend.prepare_svd([m, n], DType::C32, options).unwrap();
+            let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+            let mut u =
+                Tensor::from_vec_col_major(vec![m, k], vec![Complex32::default(); m * k]).unwrap();
+            let mut s = Tensor::from_vec_col_major(vec![k], vec![0.0_f32; k]).unwrap();
+            let mut vt =
+                Tensor::from_vec_col_major(vec![k, n], vec![Complex32::default(); k * n]).unwrap();
+            plan.execute_into(
+                &mut backend,
+                &mut workspace,
+                TensorRead::from_tensor(&input),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            assert_c32_svd_residual(
+                &c32_data,
+                u.as_slice().unwrap(),
+                s.as_slice().unwrap(),
+                vt.as_slice().unwrap(),
+                m,
+                n,
+            );
+
+            let c64_data = real_data
+                .iter()
+                .enumerate()
+                .map(|(i, &x)| Complex64::new(x, (i % 3) as f64 * 0.125))
+                .collect::<Vec<_>>();
+            let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+            let input = Tensor::from_vec_col_major(vec![m, n], c64_data.clone()).unwrap();
+            let plan = backend.prepare_svd([m, n], DType::C64, options).unwrap();
+            let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+            let mut u =
+                Tensor::from_vec_col_major(vec![m, k], vec![Complex64::default(); m * k]).unwrap();
+            let mut s = Tensor::from_vec_col_major(vec![k], vec![0.0_f64; k]).unwrap();
+            let mut vt =
+                Tensor::from_vec_col_major(vec![k, n], vec![Complex64::default(); k * n]).unwrap();
+            plan.execute_into(
+                &mut backend,
+                &mut workspace,
+                TensorRead::from_tensor(&input),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            assert_c64_svd_residual(
+                &c64_data,
+                u.as_slice().unwrap(),
+                s.as_slice().unwrap(),
+                vt.as_slice().unwrap(),
+                m,
+                n,
+                1.0e-10,
+            );
+        }
+    }
+}
+
+#[test]
+fn prepared_svd_supports_f32_c32_and_c64_with_owned_semantics() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+
+    let input_f32 =
+        Tensor::from_vec_col_major(vec![3, 2], vec![3.0_f32, 1.0, -2.0, 4.0, -1.0, 2.0]).unwrap();
+    let plan_f32 = backend
+        .prepare_svd([3, 2], DType::F32, SvdOptions::default())
+        .unwrap();
+    let mut workspace_f32 = plan_f32.allocate_workspace(&mut backend).unwrap();
+    let mut u_f32 = Tensor::from_vec_col_major(vec![3, 2], vec![0.0_f32; 6]).unwrap();
+    let mut s_f32 = Tensor::from_vec_col_major(vec![2], vec![0.0_f32; 2]).unwrap();
+    let mut vt_f32 = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f32; 4]).unwrap();
+    plan_f32
+        .execute_into(
+            &mut backend,
+            &mut workspace_f32,
+            TensorRead::from_tensor(&input_f32),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u_f32),
+                TensorWrite::from_tensor(&mut s_f32),
+                TensorWrite::from_tensor(&mut vt_f32),
+            ),
+        )
+        .unwrap();
+    let owned_f32 = backend.svd(&input_f32).unwrap();
+    for (prepared, owned) in [
+        (
+            u_f32.as_slice::<f32>().unwrap(),
+            owned_f32[0].as_slice::<f32>().unwrap(),
+        ),
+        (
+            s_f32.as_slice::<f32>().unwrap(),
+            owned_f32[1].as_slice::<f32>().unwrap(),
+        ),
+        (
+            vt_f32.as_slice::<f32>().unwrap(),
+            owned_f32[2].as_slice::<f32>().unwrap(),
+        ),
+    ] {
+        assert!(prepared
+            .iter()
+            .zip(owned)
+            .all(|(a, b)| (*a - *b).abs() < 2.0e-5));
+    }
+
+    let c32_data = vec![
+        Complex32::new(2.0, 1.0),
+        Complex32::new(-1.0, 0.5),
+        Complex32::new(3.0, -2.0),
+        Complex32::new(0.25, 1.5),
+    ];
+    let input_c32 = Tensor::from_vec_col_major(vec![2, 2], c32_data).unwrap();
+    let plan_c32 = backend
+        .prepare_svd([2, 2], DType::C32, SvdOptions::default())
+        .unwrap();
+    let mut workspace_c32 = plan_c32.allocate_workspace(&mut backend).unwrap();
+    let mut u_c32 = Tensor::from_vec_col_major(vec![2, 2], vec![Complex32::default(); 4]).unwrap();
+    let mut s_c32 = Tensor::from_vec_col_major(vec![2], vec![0.0_f32; 2]).unwrap();
+    let mut vt_c32 = Tensor::from_vec_col_major(vec![2, 2], vec![Complex32::default(); 4]).unwrap();
+    plan_c32
+        .execute_into(
+            &mut backend,
+            &mut workspace_c32,
+            TensorRead::from_tensor(&input_c32),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u_c32),
+                TensorWrite::from_tensor(&mut s_c32),
+                TensorWrite::from_tensor(&mut vt_c32),
+            ),
+        )
+        .unwrap();
+    let owned_c32 = backend.svd(&input_c32).unwrap();
+    for (prepared, owned) in [
+        (
+            u_c32.as_slice::<Complex32>().unwrap(),
+            owned_c32[0].as_slice::<Complex32>().unwrap(),
+        ),
+        (
+            vt_c32.as_slice::<Complex32>().unwrap(),
+            owned_c32[2].as_slice::<Complex32>().unwrap(),
+        ),
+    ] {
+        assert!(prepared
+            .iter()
+            .zip(owned)
+            .all(|(a, b)| (*a - *b).norm() < 2.0e-5));
+    }
+    assert!(s_c32
+        .as_slice::<f32>()
+        .unwrap()
+        .iter()
+        .zip(owned_c32[1].as_slice::<f32>().unwrap())
+        .all(|(a, b)| (*a - *b).abs() < 2.0e-5));
+
+    let c64_data = vec![
+        Complex64::new(2.0, 0.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(0.0, 0.0),
+        Complex64::new(2.0, 0.0),
+    ];
+    let input_c64 = Tensor::from_vec_col_major(vec![2, 2], c64_data.clone()).unwrap();
+    let plan_c64 = backend
+        .prepare_svd([2, 2], DType::C64, SvdOptions::default())
+        .unwrap();
+    let mut workspace_c64 = plan_c64.allocate_workspace(&mut backend).unwrap();
+    let mut u_c64 = Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    let mut s_c64 = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut vt_c64 = Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    plan_c64
+        .execute_into(
+            &mut backend,
+            &mut workspace_c64,
+            TensorRead::from_tensor(&input_c64),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u_c64),
+                TensorWrite::from_tensor(&mut s_c64),
+                TensorWrite::from_tensor(&mut vt_c64),
+            ),
+        )
+        .unwrap();
+    assert_c64_svd_residual(
+        &c64_data,
+        u_c64.as_slice::<Complex64>().unwrap(),
+        s_c64.as_slice::<f64>().unwrap(),
+        vt_c64.as_slice::<Complex64>().unwrap(),
+        2,
+        2,
+        1.0e-10,
+    );
+}
+
+#[test]
+fn prepared_svd_canonical_complex_gauge_matches_owned_path() {
+    let options = SvdOptions::default().gauge(SvdGauge::CanonicalPivot);
+    let data = vec![
+        Complex64::new(2.0, 1.0),
+        Complex64::new(-1.0, 0.5),
+        Complex64::new(0.25, -1.0),
+        Complex64::new(3.0, 2.0),
+        Complex64::new(-2.0, 1.0),
+        Complex64::new(0.5, -0.25),
+    ];
+    let input = Tensor::from_vec_col_major(vec![3, 2], data.clone()).unwrap();
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend.prepare_svd([3, 2], DType::C64, options).unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let mut u = Tensor::from_vec_col_major(vec![3, 2], vec![Complex64::default(); 6]).unwrap();
+    let mut s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut vt = Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_tensor(&input),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    let owned = backend.svd_with_options(&input, options).unwrap();
+    assert_eq!(
+        u.as_slice::<Complex64>().unwrap(),
+        owned[0].as_slice::<Complex64>().unwrap()
+    );
+    assert_eq!(
+        s.as_slice::<f64>().unwrap(),
+        owned[1].as_slice::<f64>().unwrap()
+    );
+    assert_eq!(
+        vt.as_slice::<Complex64>().unwrap(),
+        owned[2].as_slice::<Complex64>().unwrap()
+    );
+    assert_c64_svd_residual(
+        &data,
+        u.as_slice::<Complex64>().unwrap(),
+        s.as_slice::<f64>().unwrap(),
+        vt.as_slice::<Complex64>().unwrap(),
+        3,
+        2,
+        1.0e-10,
+    );
+}
+
+#[test]
+fn prepared_svd_f64_raw_reconstructs_square_tall_and_wide_inputs() {
+    for (m, n, data) in [
+        (2, 2, vec![3.0, 1.0, -2.0, 4.0]),
+        (4, 2, vec![3.0, 1.0, -2.0, 0.5, 4.0, -1.0, 2.0, 5.0]),
+        (2, 4, vec![3.0, 1.0, -2.0, 4.0, 0.5, -3.0, 2.0, 1.5]),
+    ] {
+        let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+        let plan = backend
+            .prepare_svd([m, n], DType::F64, SvdOptions::default())
+            .unwrap();
+        let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+        let input = Tensor::from_vec_col_major(vec![m, n], data.clone()).unwrap();
+        let (mut u, mut s, mut vt) = f64_outputs(m, n, 0.0);
+        plan.execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+        assert_f64_svd_residual(
+            &data,
+            u.as_slice::<f64>().unwrap(),
+            s.as_slice::<f64>().unwrap(),
+            vt.as_slice::<f64>().unwrap(),
+            m,
+            n,
+        );
+    }
+}
+
+#[test]
+fn prepared_svd_f64_accepts_positive_negative_and_zero_stride_inputs() {
+    let cases = [
+        ([3, 2], [2, 7], 1_isize, 13_usize),
+        ([3, 2], [-2, 7], 5_isize, 13_usize),
+        ([1, 3], [0, 2], 1_isize, 6_usize),
+    ];
+    for (shape, strides, offset, storage_len) in cases {
+        let [m, n] = shape;
+        let mut storage = vec![97.0_f64; storage_len];
+        let mut expected = vec![0.0; m * n];
+        for col in 0..n {
+            for row in 0..m {
+                let value = 1.0 + row as f64 + 2.5 * col as f64;
+                let physical = offset + row as isize * strides[0] + col as isize * strides[1];
+                storage[usize::try_from(physical).unwrap()] = value;
+                expected[row + m * col] = value;
+            }
+        }
+        let view = TypedTensorView::from_slice(shape, strides, offset, &storage).unwrap();
+        let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+        let plan = backend
+            .prepare_svd(shape, DType::F64, SvdOptions::default())
+            .unwrap();
+        let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+        let (mut u, mut s, mut vt) = f64_outputs(m, n, 0.0);
+        plan.execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_view(TensorView::F64(view)),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+        assert_f64_svd_residual(
+            &expected,
+            u.as_slice::<f64>().unwrap(),
+            s.as_slice::<f64>().unwrap(),
+            vt.as_slice::<f64>().unwrap(),
+            m,
+            n,
+        );
+    }
+}
+
+#[test]
+fn prepared_svd_writes_compact_output_subviews_without_touching_guards() {
+    let (m, n, k) = (3, 2, 2);
+    let input_data = vec![3.0_f64, 1.0, -2.0, 4.0, -1.0, 2.0];
+    let input = Tensor::from_vec_col_major(vec![m, n], input_data.clone()).unwrap();
+    let mut u_storage = vec![41.0_f64; 2 + m * k + 2];
+    let mut s_storage = vec![42.0_f64; 2 + k + 2];
+    let mut vt_storage = vec![43.0_f64; 2 + k * n + 2];
+    let u_view =
+        TypedTensorViewMut::from_slice([m, k], [1, m as isize], 2, &mut u_storage).unwrap();
+    let s_view = TypedTensorViewMut::from_slice([k], [1], 2, &mut s_storage).unwrap();
+    let vt_view =
+        TypedTensorViewMut::from_slice([k, n], [1, k as isize], 2, &mut vt_storage).unwrap();
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([m, n], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_tensor(&input),
+        SvdOutputWrites::new(
+            TensorWrite::from_view(TensorViewMut::F64(u_view)),
+            TensorWrite::from_view(TensorViewMut::F64(s_view)),
+            TensorWrite::from_view(TensorViewMut::F64(vt_view)),
+        ),
+    )
+    .unwrap();
+    assert_eq!(&u_storage[..2], &[41.0; 2]);
+    assert_eq!(&u_storage[2 + m * k..], &[41.0; 2]);
+    assert_eq!(&s_storage[..2], &[42.0; 2]);
+    assert_eq!(&s_storage[2 + k..], &[42.0; 2]);
+    assert_eq!(&vt_storage[..2], &[43.0; 2]);
+    assert_eq!(&vt_storage[2 + k * n..], &[43.0; 2]);
+    assert_f64_svd_residual(
+        &input_data,
+        &u_storage[2..2 + m * k],
+        &s_storage[2..2 + k],
+        &vt_storage[2..2 + k * n],
+        m,
+        n,
+    );
+}
+
+#[test]
+fn prepared_svd_reports_compact_output_specs() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([3, 2], DType::C64, SvdOptions::default())
+        .unwrap();
+    assert_eq!(plan.output_specs().u().shape(), &[3, 2]);
+    assert_eq!(plan.output_specs().u().dtype(), DType::C64);
+    assert_eq!(plan.output_specs().s().shape(), &[2]);
+    assert_eq!(plan.output_specs().s().dtype(), DType::F64);
+    assert_eq!(plan.output_specs().vt().shape(), &[2, 2]);
+}
+
+#[cfg(feature = "cpu-blas")]
+#[test]
+fn prepared_svd_rejects_unsupported_cpu_provider_without_fallback() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Blas).unwrap();
+    let error = backend
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::UnsupportedCapability {
+            op: "prepare_svd",
+            backend: BackendId::Cpu,
+            provider: "blas",
+            dtype: DType::F64,
+            capability: "prepared compact SVD",
+        }
+    ));
+}
+
+#[test]
+fn prepared_svd_reports_unsupported_dtype_as_typed_capability() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let error = backend
+        .prepare_svd([2, 2], DType::I32, SvdOptions::default())
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::UnsupportedCapability {
+            op: "prepare_svd",
+            backend: BackendId::Cpu,
+            provider: "faer",
+            dtype: DType::I32,
+            capability: "prepared compact SVD",
+        }
+    ));
+}
+
+#[test]
+fn prepared_svd_binding_accepts_clone_and_rejects_distinct_backend_before_writes() {
+    let mut creator = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = creator
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut creator).unwrap();
+    let mut clone = creator.clone();
+    drop(creator);
+
+    let input = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 2.0]).unwrap();
+    let (mut u, mut s, mut vt) = f64_outputs(2, 2, -7.0);
+    plan.execute_into(
+        &mut clone,
+        &mut workspace,
+        TensorRead::from_tensor(&input),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    assert_ne!(s.as_slice::<f64>().unwrap(), &[-7.0, -7.0]);
+
+    let mut distinct = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let before_u = vec![-11.0; 4];
+    let before_s = vec![-11.0; 2];
+    let before_vt = vec![-11.0; 4];
+    let mut u = Tensor::from_vec_col_major(vec![2, 2], before_u.clone()).unwrap();
+    let mut s = Tensor::from_vec_col_major(vec![2], before_s.clone()).unwrap();
+    let mut vt = Tensor::from_vec_col_major(vec![2, 2], before_vt.clone()).unwrap();
+    let error = plan
+        .execute_into(
+            &mut distinct,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::UnsupportedCapability {
+            op: "PreparedSvd::execute_into",
+            backend: BackendId::Cpu,
+            provider: "faer",
+            dtype: DType::F64,
+            capability: "prepared SVD backend/context binding",
+        }
+    ));
+    assert_eq!(u.as_slice::<f64>().unwrap(), before_u);
+    assert_eq!(s.as_slice::<f64>().unwrap(), before_s);
+    assert_eq!(vt.as_slice::<f64>().unwrap(), before_vt);
+}
+
+#[test]
+fn prepared_svd_validation_failure_leaves_all_destinations_unchanged() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+    let mut u = Tensor::from_vec_col_major(vec![4], vec![19.0_f64; 4]).unwrap();
+    let mut s = Tensor::from_vec_col_major(vec![2], vec![19.0_f64; 2]).unwrap();
+    let mut vt = Tensor::from_vec_col_major(vec![2, 2], vec![19.0_f64; 4]).unwrap();
+    assert!(plan
+        .execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .is_err());
+    assert_eq!(u.as_slice::<f64>().unwrap(), &[19.0; 4]);
+    assert_eq!(s.as_slice::<f64>().unwrap(), &[19.0; 2]);
+    assert_eq!(vt.as_slice::<f64>().unwrap(), &[19.0; 4]);
+}
+
+#[test]
+fn prepared_svd_rejects_unsupported_destination_stride_before_writes() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([2, 1], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let input = Tensor::from_vec_col_major(vec![2, 1], vec![2.0_f64, 1.0]).unwrap();
+    let mut u_storage = vec![31.0_f64; 3];
+    let before_u = u_storage.clone();
+    let u = TypedTensorViewMut::from_slice([2, 1], [2, 3], 0, &mut u_storage).unwrap();
+    let mut s = Tensor::from_vec_col_major(vec![1], vec![32.0_f64]).unwrap();
+    let mut vt = Tensor::from_vec_col_major(vec![1, 1], vec![33.0_f64]).unwrap();
+    let error = plan
+        .execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_view(TensorViewMut::F64(u)),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::UnsupportedCapability {
+            op: "PreparedSvd::execute_into",
+            backend: BackendId::Cpu,
+            provider: "faer",
+            dtype: DType::F64,
+            capability: "compact column-major prepared SVD destination",
+        }
+    ));
+    assert_eq!(u_storage, before_u);
+    assert_eq!(s.as_slice::<f64>().unwrap(), &[32.0]);
+    assert_eq!(vt.as_slice::<f64>().unwrap(), &[33.0]);
+}
+
+#[test]
+fn prepared_svd_supports_multiple_workspaces_and_rejects_cross_plan_workspace() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let other_plan = backend
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut first_workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let mut second_workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let input = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 2.0]).unwrap();
+
+    for workspace in [&mut first_workspace, &mut second_workspace] {
+        let (mut u, mut s, mut vt) = f64_outputs(2, 2, -1.0);
+        plan.execute_into(
+            &mut backend,
+            workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+        assert_f64_svd_residual(
+            input.as_slice::<f64>().unwrap(),
+            u.as_slice::<f64>().unwrap(),
+            s.as_slice::<f64>().unwrap(),
+            vt.as_slice::<f64>().unwrap(),
+            2,
+            2,
+        );
+    }
+
+    let (mut u, mut s, mut vt) = f64_outputs(2, 2, 37.0);
+    let error = other_plan
+        .execute_into(
+            &mut backend,
+            &mut first_workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::UnsupportedCapability {
+            capability: "prepared SVD backend/context binding",
+            ..
+        }
+    ));
+    assert_eq!(u.as_slice::<f64>().unwrap(), &[37.0; 4]);
+    assert_eq!(s.as_slice::<f64>().unwrap(), &[37.0; 2]);
+    assert_eq!(vt.as_slice::<f64>().unwrap(), &[37.0; 4]);
+}
+
+#[test]
+fn prepared_svd_rejects_every_alias_pair_before_writes() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([2, 1], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let cases = [
+        ("input and U", [0_usize, 0, 8, 12]),
+        ("input and S", [0, 4, 0, 12]),
+        ("input and Vt", [0, 4, 8, 0]),
+        ("U and S", [0, 4, 4, 12]),
+        ("U and Vt", [0, 4, 8, 4]),
+        ("S and Vt", [0, 4, 8, 8]),
+    ];
+    for (expected_pair, [input_offset, u_offset, s_offset, vt_offset]) in cases {
+        let mut shared = vec![23.0_f64; 16];
+        shared[input_offset] = 2.0;
+        shared[input_offset + 1] = 1.0;
+        let before = shared.clone();
+        let ptr = shared.as_mut_ptr();
+        // SAFETY: each case deliberately creates exactly one overlapping pair.
+        // The operation must detect pointer regions before provider or output access.
+        let input_storage = unsafe { std::slice::from_raw_parts(ptr.add(input_offset), 2) };
+        // SAFETY: see the deliberate preflight-only alias contract above.
+        let u_storage = unsafe { std::slice::from_raw_parts_mut(ptr.add(u_offset), 2) };
+        // SAFETY: see the deliberate preflight-only alias contract above.
+        let s_storage = unsafe { std::slice::from_raw_parts_mut(ptr.add(s_offset), 1) };
+        // SAFETY: see the deliberate preflight-only alias contract above.
+        let vt_storage = unsafe { std::slice::from_raw_parts_mut(ptr.add(vt_offset), 1) };
+        let input = TypedTensorView::from_slice([2, 1], [1, 2], 0, input_storage).unwrap();
+        let u = TypedTensorViewMut::from_slice([2, 1], [1, 2], 0, u_storage).unwrap();
+        let s = TypedTensorViewMut::from_slice([1], [1], 0, s_storage).unwrap();
+        let vt = TypedTensorViewMut::from_slice([1, 1], [1, 1], 0, vt_storage).unwrap();
+        let error = plan
+            .execute_into(
+                &mut backend,
+                &mut workspace,
+                TensorRead::from_view(TensorView::F64(input)),
+                SvdOutputWrites::new(
+                    TensorWrite::from_view(TensorViewMut::F64(u)),
+                    TensorWrite::from_view(TensorViewMut::F64(s)),
+                    TensorWrite::from_view(TensorViewMut::F64(vt)),
+                ),
+            )
+            .unwrap_err();
+        assert!(
+            error.to_string().contains(expected_pair),
+            "expected {expected_pair}, got {error}"
+        );
+        assert_eq!(shared, before, "{expected_pair} changed backing storage");
+    }
+}
+
+#[test]
+fn prepared_svd_zero_size_validates_and_skips_provider() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([0, 3], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let input_data: [f64; 0] = [];
+    let input = TypedTensorView::from_slice([0, 3], [1, 0], 0, &input_data).unwrap();
+    let (mut u, mut s, mut vt) = f64_outputs(0, 3, 0.0);
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_view(TensorView::F64(input)),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    assert!(u.as_slice::<f64>().unwrap().is_empty());
+    assert!(s.as_slice::<f64>().unwrap().is_empty());
+    assert!(vt.as_slice::<f64>().unwrap().is_empty());
+}

--- a/crates/tenferro-linalg/tests/prepared_svd.rs
+++ b/crates/tenferro-linalg/tests/prepared_svd.rs
@@ -4,8 +4,8 @@ use tenferro_linalg::{
     LinalgBackend, PreparedSvdBackendExt, SvdGauge, SvdOptions, SvdOutputWrites,
 };
 use tenferro_tensor::{
-    BackendId, DType, Error, Tensor, TensorRead, TensorView, TensorViewMut, TensorWrite,
-    TypedTensorView, TypedTensorViewMut,
+    BackendId, DType, DeviceId, DeviceKind, Error, GpuBackendKind, MemoryKind, Placement, Tensor,
+    TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensorView, TypedTensorViewMut,
 };
 
 fn f64_outputs(m: usize, n: usize, fill: f64) -> (Tensor, Tensor, Tensor) {
@@ -15,6 +15,49 @@ fn f64_outputs(m: usize, n: usize, fill: f64) -> (Tensor, Tensor, Tensor) {
         Tensor::from_vec_col_major(vec![k], vec![fill; k]).unwrap(),
         Tensor::from_vec_col_major(vec![k, n], vec![fill; k * n]).unwrap(),
     )
+}
+
+fn set_tensor_placement(tensor: &mut Tensor, placement: Placement) {
+    match tensor {
+        Tensor::F32(tensor) => tensor.set_placement(placement),
+        Tensor::F64(tensor) => tensor.set_placement(placement),
+        Tensor::I32(tensor) => tensor.set_placement(placement),
+        Tensor::I64(tensor) => tensor.set_placement(placement),
+        Tensor::Bool(tensor) => tensor.set_placement(placement),
+        Tensor::C32(tensor) => tensor.set_placement(placement),
+        Tensor::C64(tensor) => tensor.set_placement(placement),
+    }
+}
+
+fn prepared_execution_error(
+    backend: &mut CpuBackend,
+    plan: &tenferro_linalg::PreparedSvd,
+    workspace: &mut tenferro_linalg::SvdWorkspace,
+    input: &Tensor,
+    mut u: Tensor,
+    mut s: Tensor,
+    mut vt: Tensor,
+) -> Error {
+    let error = plan
+        .execute_into(
+            backend,
+            workspace,
+            TensorRead::from_tensor(input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap_err();
+    for output in [&u, &s, &vt] {
+        match output.dtype() {
+            DType::F64 => assert!(output.as_slice::<f64>().unwrap().iter().all(|&x| x == 41.0)),
+            DType::F32 => assert!(output.as_slice::<f32>().unwrap().iter().all(|&x| x == 41.0)),
+            dtype => panic!("unexpected validation-test dtype {dtype:?}"),
+        }
+    }
+    error
 }
 
 fn assert_f64_svd_residual(input: &[f64], u: &[f64], s: &[f64], vt: &[f64], m: usize, n: usize) {
@@ -646,6 +689,34 @@ fn prepared_svd_reports_compact_output_specs() {
     assert_eq!(plan.output_specs().s().shape(), &[2]);
     assert_eq!(plan.output_specs().s().dtype(), DType::F64);
     assert_eq!(plan.output_specs().vt().shape(), &[2, 2]);
+    let plan_debug = format!("{plan:?}");
+    for field in [
+        "operation",
+        "shape",
+        "dtype",
+        "provider",
+        "device",
+        "context",
+        "scratch_bytes",
+    ] {
+        assert!(plan_debug.contains(field), "missing {field}: {plan_debug}");
+    }
+    let workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let workspace_debug = format!("{workspace:?}");
+    for field in [
+        "operation",
+        "shape",
+        "dtype",
+        "provider",
+        "device",
+        "context",
+        "retained_bytes",
+    ] {
+        assert!(
+            workspace_debug.contains(field),
+            "missing {field}: {workspace_debug}"
+        );
+    }
 }
 
 #[cfg(feature = "cpu-blas")]
@@ -773,6 +844,155 @@ fn prepared_svd_validation_failure_leaves_all_destinations_unchanged() {
 }
 
 #[test]
+fn prepared_svd_validates_every_field_metadata_and_order_before_writes() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let valid_input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+    let valid = || f64_outputs(2, 2, 41.0);
+
+    for input in [
+        Tensor::from_vec_col_major(vec![4], vec![1.0_f64; 4]).unwrap(),
+        Tensor::from_vec_col_major(vec![1, 4], vec![1.0_f64; 4]).unwrap(),
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f32; 4]).unwrap(),
+    ] {
+        let (u, s, vt) = valid();
+        let error = prepared_execution_error(&mut backend, &plan, &mut workspace, &input, u, s, vt);
+        assert!(error.to_string().contains("input must have shape"));
+    }
+
+    let invalid_outputs = [
+        (
+            "U must have shape",
+            Tensor::from_vec_col_major(vec![4], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "U must have shape",
+            Tensor::from_vec_col_major(vec![1, 4], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "U must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f32; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "S must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![1, 2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "S must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![1], vec![41.0_f64]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "S must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f32; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "Vt must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![4], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "Vt must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![1, 4], vec![41.0_f64; 4]).unwrap(),
+        ),
+        (
+            "Vt must have shape",
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f64; 4]).unwrap(),
+            Tensor::from_vec_col_major(vec![2], vec![41.0_f64; 2]).unwrap(),
+            Tensor::from_vec_col_major(vec![2, 2], vec![41.0_f32; 4]).unwrap(),
+        ),
+    ];
+    for (expected, u, s, vt) in invalid_outputs {
+        let error =
+            prepared_execution_error(&mut backend, &plan, &mut workspace, &valid_input, u, s, vt);
+        assert!(error.to_string().contains(expected), "{error}");
+    }
+
+    let wrong_input = Tensor::from_vec_col_major(vec![4], vec![1.0_f64; 4]).unwrap();
+    let wrong_u = Tensor::from_vec_col_major(vec![4], vec![41.0_f64; 4]).unwrap();
+    let wrong_s = Tensor::from_vec_col_major(vec![1], vec![41.0_f64]).unwrap();
+    let wrong_vt = Tensor::from_vec_col_major(vec![4], vec![41.0_f64; 4]).unwrap();
+    let error = prepared_execution_error(
+        &mut backend,
+        &plan,
+        &mut workspace,
+        &wrong_input,
+        wrong_u,
+        wrong_s,
+        wrong_vt,
+    );
+    assert!(error.to_string().contains("input must have shape"));
+}
+
+#[test]
+fn prepared_svd_validates_storage_placement_and_accepts_pinned_host() {
+    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let host = Placement {
+        memory_kind: MemoryKind::PinnedHost,
+        device: None,
+    };
+    let device = Placement {
+        memory_kind: MemoryKind::Device,
+        device: Some(DeviceId {
+            kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+            ordinal: 0,
+        }),
+    };
+    for field in 0..4 {
+        let mut input = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
+        let (mut u, mut s, mut vt) = f64_outputs(2, 2, 41.0);
+        match field {
+            0 => set_tensor_placement(&mut input, device.clone()),
+            1 => set_tensor_placement(&mut u, device.clone()),
+            2 => set_tensor_placement(&mut s, device.clone()),
+            3 => set_tensor_placement(&mut vt, device.clone()),
+            _ => unreachable!(),
+        }
+        let error = prepared_execution_error(&mut backend, &plan, &mut workspace, &input, u, s, vt);
+        assert!(matches!(error, Error::UnsupportedCapability { .. }));
+    }
+
+    let mut input = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 1.0]).unwrap();
+    let (mut u, mut s, mut vt) = f64_outputs(2, 2, 0.0);
+    for tensor in [&mut input, &mut u, &mut s, &mut vt] {
+        set_tensor_placement(tensor, host.clone());
+    }
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_tensor(&input),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    assert_eq!(s.as_slice::<f64>().unwrap(), &[2.0, 1.0]);
+}
+
+#[test]
 fn prepared_svd_rejects_unsupported_destination_stride_before_writes() {
     let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
     let plan = backend
@@ -874,81 +1094,28 @@ fn prepared_svd_supports_multiple_workspaces_and_rejects_cross_plan_workspace() 
 }
 
 #[test]
-fn prepared_svd_rejects_every_alias_pair_before_writes() {
-    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
-    let plan = backend
-        .prepare_svd([2, 1], DType::F64, SvdOptions::default())
-        .unwrap();
-    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
-    let cases = [
-        ("input and U", [0_usize, 0, 8, 12]),
-        ("input and S", [0, 4, 0, 12]),
-        ("input and Vt", [0, 4, 8, 0]),
-        ("U and S", [0, 4, 4, 12]),
-        ("U and Vt", [0, 4, 8, 4]),
-        ("S and Vt", [0, 4, 8, 8]),
-    ];
-    for (expected_pair, [input_offset, u_offset, s_offset, vt_offset]) in cases {
-        let mut shared = vec![23.0_f64; 16];
-        shared[input_offset] = 2.0;
-        shared[input_offset + 1] = 1.0;
-        let before = shared.clone();
-        let ptr = shared.as_mut_ptr();
-        // SAFETY: each case deliberately creates exactly one overlapping pair.
-        // The operation must detect pointer regions before provider or output access.
-        let input_storage = unsafe { std::slice::from_raw_parts(ptr.add(input_offset), 2) };
-        // SAFETY: see the deliberate preflight-only alias contract above.
-        let u_storage = unsafe { std::slice::from_raw_parts_mut(ptr.add(u_offset), 2) };
-        // SAFETY: see the deliberate preflight-only alias contract above.
-        let s_storage = unsafe { std::slice::from_raw_parts_mut(ptr.add(s_offset), 1) };
-        // SAFETY: see the deliberate preflight-only alias contract above.
-        let vt_storage = unsafe { std::slice::from_raw_parts_mut(ptr.add(vt_offset), 1) };
-        let input = TypedTensorView::from_slice([2, 1], [1, 2], 0, input_storage).unwrap();
-        let u = TypedTensorViewMut::from_slice([2, 1], [1, 2], 0, u_storage).unwrap();
-        let s = TypedTensorViewMut::from_slice([1], [1], 0, s_storage).unwrap();
-        let vt = TypedTensorViewMut::from_slice([1, 1], [1, 1], 0, vt_storage).unwrap();
-        let error = plan
-            .execute_into(
-                &mut backend,
-                &mut workspace,
-                TensorRead::from_view(TensorView::F64(input)),
-                SvdOutputWrites::new(
-                    TensorWrite::from_view(TensorViewMut::F64(u)),
-                    TensorWrite::from_view(TensorViewMut::F64(s)),
-                    TensorWrite::from_view(TensorViewMut::F64(vt)),
-                ),
-            )
-            .unwrap_err();
-        assert!(
-            error.to_string().contains(expected_pair),
-            "expected {expected_pair}, got {error}"
-        );
-        assert_eq!(shared, before, "{expected_pair} changed backing storage");
-    }
-}
-
-#[test]
 fn prepared_svd_zero_size_validates_and_skips_provider() {
-    let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
-    let plan = backend
-        .prepare_svd([0, 3], DType::F64, SvdOptions::default())
+    for [m, n] in [[0, 3], [3, 0], [0, 0]] {
+        let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+        let plan = backend
+            .prepare_svd([m, n], DType::F64, SvdOptions::default())
+            .unwrap();
+        let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+        let input = Tensor::from_vec_col_major(vec![m, n], Vec::<f64>::new()).unwrap();
+        let (mut u, mut s, mut vt) = f64_outputs(m, n, 0.0);
+        plan.execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
         .unwrap();
-    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
-    let input_data: [f64; 0] = [];
-    let input = TypedTensorView::from_slice([0, 3], [1, 0], 0, &input_data).unwrap();
-    let (mut u, mut s, mut vt) = f64_outputs(0, 3, 0.0);
-    plan.execute_into(
-        &mut backend,
-        &mut workspace,
-        TensorRead::from_view(TensorView::F64(input)),
-        SvdOutputWrites::new(
-            TensorWrite::from_tensor(&mut u),
-            TensorWrite::from_tensor(&mut s),
-            TensorWrite::from_tensor(&mut vt),
-        ),
-    )
-    .unwrap();
-    assert!(u.as_slice::<f64>().unwrap().is_empty());
-    assert!(s.as_slice::<f64>().unwrap().is_empty());
-    assert!(vt.as_slice::<f64>().unwrap().is_empty());
+        assert!(u.as_slice::<f64>().unwrap().is_empty());
+        assert!(s.as_slice::<f64>().unwrap().is_empty());
+        assert!(vt.as_slice::<f64>().unwrap().is_empty());
+    }
 }

--- a/crates/tenferro-linalg/tests/prepared_svd.rs
+++ b/crates/tenferro-linalg/tests/prepared_svd.rs
@@ -716,7 +716,11 @@ fn prepared_svd_reports_compact_output_specs() {
     ] {
         assert!(plan_debug.contains(field), "missing {field}: {plan_debug}");
     }
-    assert_eq!(debug_usize(&plan_debug, "plan_retained_bytes"), 0);
+    assert_eq!(plan.retained_bytes(), 0);
+    assert_eq!(
+        plan.retained_bytes(),
+        debug_usize(&plan_debug, "plan_retained_bytes")
+    );
     let required_bytes = debug_usize(&plan_debug, "workspace_required_bytes");
     let workspace = plan.allocate_workspace(&mut backend).unwrap();
     let workspace_debug = format!("{workspace:?}");
@@ -742,6 +746,11 @@ fn prepared_svd_reports_compact_output_specs() {
     assert!(
         debug_usize(&workspace_debug, "workspace_retained_bytes") >= required_bytes,
         "workspace retained fewer bytes than required: {workspace_debug}"
+    );
+    assert!(workspace.retained_bytes() > 0);
+    assert_eq!(
+        workspace.retained_bytes(),
+        debug_usize(&workspace_debug, "workspace_retained_bytes")
     );
 }
 

--- a/crates/tenferro-linalg/tests/prepared_svd.rs
+++ b/crates/tenferro-linalg/tests/prepared_svd.rs
@@ -1,7 +1,8 @@
 use num_complex::{Complex32, Complex64};
 use tenferro_cpu::{CpuBackend, CpuBackendKind};
 use tenferro_linalg::{
-    LinalgBackend, PreparedSvdBackendExt, SvdGauge, SvdOptions, SvdOutputWrites,
+    LinalgBackend, PreparedFactorizationBackendExt, PreparedSvdBackendExt, SvdGauge, SvdOptions,
+    SvdOutputWrites,
 };
 use tenferro_tensor::{
     BackendId, DType, DeviceId, DeviceKind, Error, GpuBackendKind, MemoryKind, Placement, Tensor,
@@ -841,6 +842,98 @@ fn prepared_svd_binding_accepts_clone_and_rejects_distinct_backend_before_writes
 }
 
 #[test]
+fn prepared_svd_session_rejects_distinct_binding_before_writes() {
+    let mut creator = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let plan = creator
+        .prepare_svd([2, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut creator).unwrap();
+    let input = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 2.0]).unwrap();
+    let mut distinct = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
+    let (mut u, mut s, mut vt) = f64_outputs(2, 2, 43.0);
+
+    let error = distinct.with_prepared_factorization_session(|session| {
+        plan.execute_into_session(
+            session,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+    });
+
+    assert!(matches!(
+        error,
+        Err(Error::UnsupportedCapability {
+            capability: "prepared SVD backend/context binding",
+            ..
+        })
+    ));
+    assert_eq!(u.as_slice::<f64>().unwrap(), &[43.0; 4]);
+    assert_eq!(s.as_slice::<f64>().unwrap(), &[43.0; 2]);
+    assert_eq!(vt.as_slice::<f64>().unwrap(), &[43.0; 4]);
+    assert_eq!(distinct.with_prepared_factorization_session(|_| 19_u32), 19);
+}
+
+#[test]
+fn prepared_factorization_session_releases_execution_after_panic() {
+    let mut backend = CpuBackend::with_threads_and_kind(2, CpuBackendKind::Faer).unwrap();
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.with_prepared_factorization_session(|_| panic!("forced session panic"));
+    }));
+    assert!(panic.is_err());
+    assert_eq!(backend.with_prepared_factorization_session(|_| 17_u32), 17);
+}
+
+#[test]
+fn prepared_svd_session_repeats_correctly_with_multiple_workers() {
+    let input = Tensor::from_vec_col_major(
+        vec![4, 3],
+        vec![
+            3.0_f64, 1.0, -2.0, 4.0, -1.0, 2.0, 0.5, 3.5, 2.0, -3.0, 1.5, 0.25,
+        ],
+    )
+    .unwrap();
+
+    for workers in [2, 4] {
+        let mut backend = CpuBackend::with_threads_and_kind(workers, CpuBackendKind::Faer).unwrap();
+        let plan = backend
+            .prepare_svd([4, 3], DType::F64, SvdOptions::default())
+            .unwrap();
+        let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+        let (mut u, mut s, mut vt) = f64_outputs(4, 3, -1.0);
+
+        backend.with_prepared_factorization_session(|session| {
+            for _ in 0..128 {
+                plan.execute_into_session(
+                    session,
+                    &mut workspace,
+                    TensorRead::from_tensor(&input),
+                    SvdOutputWrites::new(
+                        TensorWrite::from_tensor(&mut u),
+                        TensorWrite::from_tensor(&mut s),
+                        TensorWrite::from_tensor(&mut vt),
+                    ),
+                )
+                .unwrap();
+            }
+        });
+
+        assert_f64_svd_residual(
+            input.as_slice::<f64>().unwrap(),
+            u.as_slice::<f64>().unwrap(),
+            s.as_slice::<f64>().unwrap(),
+            vt.as_slice::<f64>().unwrap(),
+            4,
+            3,
+        );
+    }
+}
+
+#[test]
 fn prepared_svd_validation_failure_leaves_all_destinations_unchanged() {
     let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
     let plan = backend
@@ -1070,28 +1163,30 @@ fn prepared_svd_supports_multiple_workspaces_and_rejects_cross_plan_workspace() 
     let mut second_workspace = plan.allocate_workspace(&mut backend).unwrap();
     let input = Tensor::from_vec_col_major(vec![2, 2], vec![3.0_f64, 0.0, 0.0, 2.0]).unwrap();
 
-    for workspace in [&mut first_workspace, &mut second_workspace] {
-        let (mut u, mut s, mut vt) = f64_outputs(2, 2, -1.0);
-        plan.execute_into(
-            &mut backend,
-            workspace,
-            TensorRead::from_tensor(&input),
-            SvdOutputWrites::new(
-                TensorWrite::from_tensor(&mut u),
-                TensorWrite::from_tensor(&mut s),
-                TensorWrite::from_tensor(&mut vt),
-            ),
-        )
-        .unwrap();
-        assert_f64_svd_residual(
-            input.as_slice::<f64>().unwrap(),
-            u.as_slice::<f64>().unwrap(),
-            s.as_slice::<f64>().unwrap(),
-            vt.as_slice::<f64>().unwrap(),
-            2,
-            2,
-        );
-    }
+    backend.with_prepared_factorization_session(|session| {
+        for workspace in [&mut first_workspace, &mut second_workspace] {
+            let (mut u, mut s, mut vt) = f64_outputs(2, 2, -1.0);
+            plan.execute_into_session(
+                session,
+                workspace,
+                TensorRead::from_tensor(&input),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut u),
+                    TensorWrite::from_tensor(&mut s),
+                    TensorWrite::from_tensor(&mut vt),
+                ),
+            )
+            .unwrap();
+            assert_f64_svd_residual(
+                input.as_slice::<f64>().unwrap(),
+                u.as_slice::<f64>().unwrap(),
+                s.as_slice::<f64>().unwrap(),
+                vt.as_slice::<f64>().unwrap(),
+                2,
+                2,
+            );
+        }
+    });
 
     let (mut u, mut s, mut vt) = f64_outputs(2, 2, 37.0);
     let error = other_plan

--- a/crates/tenferro-linalg/tests/prepared_svd.rs
+++ b/crates/tenferro-linalg/tests/prepared_svd.rs
@@ -680,6 +680,19 @@ fn prepared_svd_writes_compact_output_subviews_without_touching_guards() {
 
 #[test]
 fn prepared_svd_reports_compact_output_specs() {
+    fn debug_usize(debug: &str, field: &str) -> usize {
+        let marker = format!("{field}: ");
+        debug
+            .split_once(&marker)
+            .unwrap_or_else(|| panic!("missing {field}: {debug}"))
+            .1
+            .split([',', '}'])
+            .next()
+            .unwrap()
+            .parse()
+            .unwrap()
+    }
+
     let mut backend = CpuBackend::with_kind(CpuBackendKind::Faer).unwrap();
     let plan = backend
         .prepare_svd([3, 2], DType::C64, SvdOptions::default())
@@ -697,10 +710,13 @@ fn prepared_svd_reports_compact_output_specs() {
         "provider",
         "device",
         "context",
-        "scratch_bytes",
+        "plan_retained_bytes: 0",
+        "workspace_required_bytes",
     ] {
         assert!(plan_debug.contains(field), "missing {field}: {plan_debug}");
     }
+    assert_eq!(debug_usize(&plan_debug, "plan_retained_bytes"), 0);
+    let required_bytes = debug_usize(&plan_debug, "workspace_required_bytes");
     let workspace = plan.allocate_workspace(&mut backend).unwrap();
     let workspace_debug = format!("{workspace:?}");
     for field in [
@@ -710,13 +726,22 @@ fn prepared_svd_reports_compact_output_specs() {
         "provider",
         "device",
         "context",
-        "retained_bytes",
+        "workspace_required_bytes",
+        "workspace_retained_bytes",
     ] {
         assert!(
             workspace_debug.contains(field),
             "missing {field}: {workspace_debug}"
         );
     }
+    assert_eq!(
+        debug_usize(&workspace_debug, "workspace_required_bytes"),
+        required_bytes
+    );
+    assert!(
+        debug_usize(&workspace_debug, "workspace_retained_bytes") >= required_bytes,
+        "workspace retained fewer bytes than required: {workspace_debug}"
+    );
 }
 
 #[cfg(feature = "cpu-blas")]

--- a/crates/tenferro-linalg/tests/prepared_svd_alloc.rs
+++ b/crates/tenferro-linalg/tests/prepared_svd_alloc.rs
@@ -1,15 +1,19 @@
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Mutex;
 
 use num_complex::Complex64;
 use tenferro_cpu::{CpuBackend, CpuBackendKind};
-use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions, SvdOutputWrites};
+use tenferro_linalg::{
+    PreparedFactorizationBackendExt, PreparedSvdBackendExt, SvdOptions, SvdOutputWrites,
+};
 use tenferro_tensor::{DType, Tensor, TensorRead, TensorView, TensorWrite, TypedTensorView};
 
 struct CountingAllocator;
 
 static ACTIVE: AtomicBool = AtomicBool::new(false);
 static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static TEST_LOCK: Mutex<()> = Mutex::new(());
 
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -47,6 +51,7 @@ fn measured_allocations(run: impl FnOnce()) -> usize {
 
 #[test]
 fn prepared_svd_complete_warm_calls_allocate_zero() {
+    let _serial = TEST_LOCK.lock().unwrap();
     let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
 
     let input =
@@ -202,4 +207,124 @@ fn prepared_svd_complete_warm_calls_allocate_zero() {
             .unwrap();
     });
     assert_eq!(complex_allocations, 0, "contiguous C64 warm allocations");
+}
+
+#[test]
+fn prepared_svd_session_repeated_leaf_calls_allocate_zero() {
+    let _serial = TEST_LOCK.lock().unwrap();
+    for workers in [1, 2, 4] {
+        assert_session_leaf_allocations(workers);
+    }
+}
+
+fn assert_session_leaf_allocations(workers: usize) {
+    let mut backend =
+        CpuBackend::with_threads_and_kind(workers, CpuBackendKind::Faer).unwrap();
+
+    let f64_input =
+        Tensor::from_vec_col_major(vec![3, 2], vec![3.0_f64, 1.0, -2.0, 4.0, -1.0, 2.0])
+            .unwrap();
+    let mut f64_strided_storage = vec![0.0_f64; 13];
+    for col in 0..2 {
+        for row in 0..3 {
+            f64_strided_storage[1 + 2 * row + 7 * col] = 1.0 + row as f64 + 2.0 * col as f64;
+        }
+    }
+    let f64_plan = backend
+        .prepare_svd([3, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut f64_workspace = f64_plan.allocate_workspace(&mut backend).unwrap();
+    let mut f64_u = Tensor::from_vec_col_major(vec![3, 2], vec![0.0_f64; 6]).unwrap();
+    let mut f64_s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut f64_vt = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4]).unwrap();
+
+    let c64_input = Tensor::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(2.0, 1.0),
+            Complex64::new(-1.0, 0.5),
+            Complex64::new(3.0, -2.0),
+            Complex64::new(0.25, 1.5),
+        ],
+    )
+    .unwrap();
+    let mut c64_strided_storage = vec![Complex64::default(); 9];
+    for col in 0..2 {
+        for row in 0..2 {
+            c64_strided_storage[1 + 2 * row + 5 * col] =
+                Complex64::new(1.0 + row as f64, 0.5 + col as f64);
+        }
+    }
+    let c64_plan = backend
+        .prepare_svd([2, 2], DType::C64, SvdOptions::default())
+        .unwrap();
+    let mut c64_workspace = c64_plan.allocate_workspace(&mut backend).unwrap();
+    let mut c64_u =
+        Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    let mut c64_s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut c64_vt =
+        Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+
+    backend.with_prepared_factorization_session(|session| {
+        let allocations = measured_allocations(|| {
+            for _ in 0..128 {
+                f64_plan
+                    .execute_into_session(
+                        session,
+                        &mut f64_workspace,
+                        TensorRead::from_tensor(&f64_input),
+                        SvdOutputWrites::new(
+                            TensorWrite::from_tensor(&mut f64_u),
+                            TensorWrite::from_tensor(&mut f64_s),
+                            TensorWrite::from_tensor(&mut f64_vt),
+                        ),
+                    )
+                    .unwrap();
+                let f64_strided =
+                    TypedTensorView::from_slice([3, 2], [2, 7], 1, &f64_strided_storage).unwrap();
+                f64_plan
+                    .execute_into_session(
+                        session,
+                        &mut f64_workspace,
+                        TensorRead::from_view(TensorView::F64(f64_strided)),
+                        SvdOutputWrites::new(
+                            TensorWrite::from_tensor(&mut f64_u),
+                            TensorWrite::from_tensor(&mut f64_s),
+                            TensorWrite::from_tensor(&mut f64_vt),
+                        ),
+                    )
+                    .unwrap();
+                c64_plan
+                    .execute_into_session(
+                        session,
+                        &mut c64_workspace,
+                        TensorRead::from_tensor(&c64_input),
+                        SvdOutputWrites::new(
+                            TensorWrite::from_tensor(&mut c64_u),
+                            TensorWrite::from_tensor(&mut c64_s),
+                            TensorWrite::from_tensor(&mut c64_vt),
+                        ),
+                    )
+                    .unwrap();
+                let c64_strided =
+                    TypedTensorView::from_slice([2, 2], [2, 5], 1, &c64_strided_storage).unwrap();
+                c64_plan
+                    .execute_into_session(
+                        session,
+                        &mut c64_workspace,
+                        TensorRead::from_view(TensorView::C64(c64_strided)),
+                        SvdOutputWrites::new(
+                            TensorWrite::from_tensor(&mut c64_u),
+                            TensorWrite::from_tensor(&mut c64_s),
+                            TensorWrite::from_tensor(&mut c64_vt),
+                        ),
+                    )
+                    .unwrap();
+            }
+        });
+        assert_eq!(
+            allocations, 0,
+            "prepared factorization session leaf calls with {workers} workers"
+        );
+    });
 }

--- a/crates/tenferro-linalg/tests/prepared_svd_alloc.rs
+++ b/crates/tenferro-linalg/tests/prepared_svd_alloc.rs
@@ -235,6 +235,34 @@ fn prepared_svd_complete_warm_calls_allocate_zero() {
 }
 
 #[test]
+fn prepared_svd_resource_accounting_reads_allocate_zero() {
+    let _serial = TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let plan = backend
+        .prepare_svd([3, 2], DType::C64, SvdOptions::default())
+        .unwrap();
+    let workspace = plan.allocate_workspace(&mut backend).unwrap();
+
+    let expected_plan = std::hint::black_box(plan.retained_bytes());
+    let expected_workspace = std::hint::black_box(workspace.retained_bytes());
+    let allocations = measured_allocations(|| {
+        for _ in 0..128 {
+            assert_eq!(std::hint::black_box(plan.retained_bytes()), expected_plan);
+            assert_eq!(
+                std::hint::black_box(workspace.retained_bytes()),
+                expected_workspace
+            );
+        }
+    });
+
+    assert_eq!(expected_plan, 0);
+    assert!(expected_workspace > 0);
+    assert_eq!(allocations, 0, "resource accounting read allocations");
+}
+
+#[test]
 fn prepared_svd_session_repeated_single_worker_leaf_calls_allocate_zero() {
     let _serial = TEST_LOCK
         .lock()

--- a/crates/tenferro-linalg/tests/prepared_svd_alloc.rs
+++ b/crates/tenferro-linalg/tests/prepared_svd_alloc.rs
@@ -1,0 +1,205 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use num_complex::Complex64;
+use tenferro_cpu::{CpuBackend, CpuBackendKind};
+use tenferro_linalg::{PreparedSvdBackendExt, SvdOptions, SvdOutputWrites};
+use tenferro_tensor::{DType, Tensor, TensorRead, TensorView, TensorWrite, TypedTensorView};
+
+struct CountingAllocator;
+
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if ACTIVE.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        // SAFETY: forwarding the allocator contract unchanged to `System`.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: `ptr` and `layout` came from the forwarded `System` allocation.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if ACTIVE.load(Ordering::Relaxed) {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+        }
+        // SAFETY: forwarding the allocator contract unchanged to `System`.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn measured_allocations(run: impl FnOnce()) -> usize {
+    ALLOCATIONS.store(0, Ordering::SeqCst);
+    ACTIVE.store(true, Ordering::SeqCst);
+    run();
+    ACTIVE.store(false, Ordering::SeqCst);
+    ALLOCATIONS.load(Ordering::SeqCst)
+}
+
+#[test]
+fn prepared_svd_complete_warm_calls_allocate_zero() {
+    let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+
+    let input =
+        Tensor::from_vec_col_major(vec![3, 2], vec![3.0_f64, 1.0, -2.0, 4.0, -1.0, 2.0]).unwrap();
+    let plan = backend
+        .prepare_svd([3, 2], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let mut u = Tensor::from_vec_col_major(vec![3, 2], vec![0.0_f64; 6]).unwrap();
+    let mut s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut vt = Tensor::from_vec_col_major(vec![2, 2], vec![0.0_f64; 4]).unwrap();
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_tensor(&input),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    let contiguous = measured_allocations(|| {
+        plan.execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+    });
+    assert_eq!(contiguous, 0, "contiguous F64 warm allocations");
+
+    let mut positive_storage = vec![0.0_f64; 13];
+    let mut negative_storage = vec![0.0_f64; 13];
+    for col in 0..2 {
+        for row in 0..3 {
+            let value = 1.0 + row as f64 + 2.0 * col as f64;
+            positive_storage[1 + 2 * row + 7 * col] = value;
+            negative_storage[5 - 2 * row + 7 * col] = value;
+        }
+    }
+    let positive_prime = TypedTensorView::from_slice([3, 2], [2, 7], 1, &positive_storage).unwrap();
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_view(TensorView::F64(positive_prime)),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    let positive = TypedTensorView::from_slice([3, 2], [2, 7], 1, &positive_storage).unwrap();
+    let positive_allocations = measured_allocations(|| {
+        plan.execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_view(TensorView::F64(positive)),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+    });
+    assert_eq!(
+        positive_allocations, 0,
+        "positive-stride F64 warm allocations"
+    );
+
+    let negative_prime =
+        TypedTensorView::from_slice([3, 2], [-2, 7], 5, &negative_storage).unwrap();
+    plan.execute_into(
+        &mut backend,
+        &mut workspace,
+        TensorRead::from_view(TensorView::F64(negative_prime)),
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(&mut u),
+            TensorWrite::from_tensor(&mut s),
+            TensorWrite::from_tensor(&mut vt),
+        ),
+    )
+    .unwrap();
+    let negative = TypedTensorView::from_slice([3, 2], [-2, 7], 5, &negative_storage).unwrap();
+    let negative_allocations = measured_allocations(|| {
+        plan.execute_into(
+            &mut backend,
+            &mut workspace,
+            TensorRead::from_view(TensorView::F64(negative)),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut u),
+                TensorWrite::from_tensor(&mut s),
+                TensorWrite::from_tensor(&mut vt),
+            ),
+        )
+        .unwrap();
+    });
+    assert_eq!(
+        negative_allocations, 0,
+        "negative-stride F64 warm allocations"
+    );
+
+    let complex_input = Tensor::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(2.0, 1.0),
+            Complex64::new(-1.0, 0.5),
+            Complex64::new(3.0, -2.0),
+            Complex64::new(0.25, 1.5),
+        ],
+    )
+    .unwrap();
+    let complex_plan = backend
+        .prepare_svd([2, 2], DType::C64, SvdOptions::default())
+        .unwrap();
+    let mut complex_workspace = complex_plan.allocate_workspace(&mut backend).unwrap();
+    let mut complex_u =
+        Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    let mut complex_s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
+    let mut complex_vt =
+        Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    complex_plan
+        .execute_into(
+            &mut backend,
+            &mut complex_workspace,
+            TensorRead::from_tensor(&complex_input),
+            SvdOutputWrites::new(
+                TensorWrite::from_tensor(&mut complex_u),
+                TensorWrite::from_tensor(&mut complex_s),
+                TensorWrite::from_tensor(&mut complex_vt),
+            ),
+        )
+        .unwrap();
+    let complex_allocations = measured_allocations(|| {
+        complex_plan
+            .execute_into(
+                &mut backend,
+                &mut complex_workspace,
+                TensorRead::from_tensor(&complex_input),
+                SvdOutputWrites::new(
+                    TensorWrite::from_tensor(&mut complex_u),
+                    TensorWrite::from_tensor(&mut complex_s),
+                    TensorWrite::from_tensor(&mut complex_vt),
+                ),
+            )
+            .unwrap();
+    });
+    assert_eq!(complex_allocations, 0, "contiguous C64 warm allocations");
+}

--- a/crates/tenferro-linalg/tests/prepared_svd_alloc.rs
+++ b/crates/tenferro-linalg/tests/prepared_svd_alloc.rs
@@ -8,7 +8,10 @@ use tenferro_linalg::{
     PreparedFactorizationBackendExt, PreparedFactorizationSession, PreparedSvd,
     PreparedSvdBackendExt, SvdOptions, SvdOutputWrites, SvdWorkspace,
 };
-use tenferro_tensor::{DType, Tensor, TensorRead, TensorView, TensorWrite, TypedTensorView};
+use tenferro_tensor::{
+    DType, Tensor, TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensorView,
+    TypedTensorViewMut,
+};
 
 struct CountingAllocator;
 
@@ -268,6 +271,144 @@ fn prepared_svd_session_repeated_single_worker_leaf_calls_allocate_zero() {
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     assert_session_leaf_allocations();
+}
+
+#[test]
+fn prepared_svd_session_subview_destinations_allocate_zero_without_workspace_growth() {
+    let _serial = TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    for shape in [[4, 2], [2, 4]] {
+        assert_f64_subview_destination_allocations(shape);
+        assert_c64_subview_destination_allocations(shape);
+    }
+}
+
+fn assert_f64_subview_destination_allocations([m, n]: [usize; 2]) {
+    let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let input = Tensor::from_vec_col_major(
+        vec![m, n],
+        (0..m * n).map(|index| 1.0 + index as f64 / 3.0).collect(),
+    )
+    .unwrap();
+    let plan = backend
+        .prepare_svd([m, n], DType::F64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let k = m.min(n);
+    let mut u_storage = vec![vec![0.0_f64; m * k + 4]; 65];
+    let mut s_storage = vec![vec![0.0_f64; k + 4]; 65];
+    let mut vt_storage = vec![vec![0.0_f64; k * n + 4]; 65];
+    let mut writes = u_storage
+        .iter_mut()
+        .zip(&mut s_storage)
+        .zip(&mut vt_storage)
+        .map(|((u, s), vt)| {
+            SvdOutputWrites::new(
+                TensorWrite::from_view(TensorViewMut::F64(
+                    TypedTensorViewMut::from_slice([m, k], [1, m as isize], 2, u).unwrap(),
+                )),
+                TensorWrite::from_view(TensorViewMut::F64(
+                    TypedTensorViewMut::from_slice([k], [1], 2, s).unwrap(),
+                )),
+                TensorWrite::from_view(TensorViewMut::F64(
+                    TypedTensorViewMut::from_slice([k, n], [1, k as isize], 2, vt).unwrap(),
+                )),
+            )
+        })
+        .collect::<Vec<_>>();
+    let retained_before = workspace.retained_bytes();
+
+    backend.with_prepared_factorization_session(|session| {
+        plan.execute_into_session(
+            session,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            writes.pop().unwrap(),
+        )
+        .unwrap();
+        let allocations = measured_allocations(|| {
+            for outputs in writes.drain(..) {
+                plan.execute_into_session(
+                    session,
+                    &mut workspace,
+                    TensorRead::from_tensor(&input),
+                    outputs,
+                )
+                .unwrap();
+            }
+        });
+        assert_eq!(
+            allocations, 0,
+            "F64 {m}x{n} caller-owned subview destination allocations"
+        );
+    });
+    assert_eq!(workspace.retained_bytes(), retained_before);
+}
+
+fn assert_c64_subview_destination_allocations([m, n]: [usize; 2]) {
+    let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
+    let input = Tensor::from_vec_col_major(
+        vec![m, n],
+        (0..m * n)
+            .map(|index| Complex64::new(1.0 + index as f64 / 3.0, 0.25 + index as f64 / 7.0))
+            .collect(),
+    )
+    .unwrap();
+    let plan = backend
+        .prepare_svd([m, n], DType::C64, SvdOptions::default())
+        .unwrap();
+    let mut workspace = plan.allocate_workspace(&mut backend).unwrap();
+    let k = m.min(n);
+    let mut u_storage = vec![vec![Complex64::default(); m * k + 4]; 65];
+    let mut s_storage = vec![vec![0.0_f64; k + 4]; 65];
+    let mut vt_storage = vec![vec![Complex64::default(); k * n + 4]; 65];
+    let mut writes = u_storage
+        .iter_mut()
+        .zip(&mut s_storage)
+        .zip(&mut vt_storage)
+        .map(|((u, s), vt)| {
+            SvdOutputWrites::new(
+                TensorWrite::from_view(TensorViewMut::C64(
+                    TypedTensorViewMut::from_slice([m, k], [1, m as isize], 2, u).unwrap(),
+                )),
+                TensorWrite::from_view(TensorViewMut::F64(
+                    TypedTensorViewMut::from_slice([k], [1], 2, s).unwrap(),
+                )),
+                TensorWrite::from_view(TensorViewMut::C64(
+                    TypedTensorViewMut::from_slice([k, n], [1, k as isize], 2, vt).unwrap(),
+                )),
+            )
+        })
+        .collect::<Vec<_>>();
+    let retained_before = workspace.retained_bytes();
+
+    backend.with_prepared_factorization_session(|session| {
+        plan.execute_into_session(
+            session,
+            &mut workspace,
+            TensorRead::from_tensor(&input),
+            writes.pop().unwrap(),
+        )
+        .unwrap();
+        let allocations = measured_allocations(|| {
+            for outputs in writes.drain(..) {
+                plan.execute_into_session(
+                    session,
+                    &mut workspace,
+                    TensorRead::from_tensor(&input),
+                    outputs,
+                )
+                .unwrap();
+            }
+        });
+        assert_eq!(
+            allocations, 0,
+            "C64 {m}x{n} caller-owned subview destination allocations"
+        );
+    });
+    assert_eq!(workspace.retained_bytes(), retained_before);
 }
 
 fn assert_session_leaf_allocations() {

--- a/crates/tenferro-linalg/tests/prepared_svd_alloc.rs
+++ b/crates/tenferro-linalg/tests/prepared_svd_alloc.rs
@@ -5,7 +5,8 @@ use std::sync::Mutex;
 use num_complex::Complex64;
 use tenferro_cpu::{CpuBackend, CpuBackendKind};
 use tenferro_linalg::{
-    PreparedFactorizationBackendExt, PreparedSvdBackendExt, SvdOptions, SvdOutputWrites,
+    PreparedFactorizationBackendExt, PreparedFactorizationSession, PreparedSvd,
+    PreparedSvdBackendExt, SvdOptions, SvdOutputWrites, SvdWorkspace,
 };
 use tenferro_tensor::{DType, Tensor, TensorRead, TensorView, TensorWrite, TypedTensorView};
 
@@ -49,9 +50,33 @@ fn measured_allocations(run: impl FnOnce()) -> usize {
     ALLOCATIONS.load(Ordering::SeqCst)
 }
 
+fn execute_leaf(
+    session: &mut PreparedFactorizationSession<'_>,
+    plan: &PreparedSvd,
+    workspace: &mut SvdWorkspace,
+    input: TensorRead<'_>,
+    u: &mut Tensor,
+    s: &mut Tensor,
+    vt: &mut Tensor,
+) {
+    plan.execute_into_session(
+        session,
+        workspace,
+        input,
+        SvdOutputWrites::new(
+            TensorWrite::from_tensor(u),
+            TensorWrite::from_tensor(s),
+            TensorWrite::from_tensor(vt),
+        ),
+    )
+    .unwrap();
+}
+
 #[test]
 fn prepared_svd_complete_warm_calls_allocate_zero() {
-    let _serial = TEST_LOCK.lock().unwrap();
+    let _serial = TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
 
     let input =
@@ -210,20 +235,18 @@ fn prepared_svd_complete_warm_calls_allocate_zero() {
 }
 
 #[test]
-fn prepared_svd_session_repeated_leaf_calls_allocate_zero() {
-    let _serial = TEST_LOCK.lock().unwrap();
-    for workers in [1, 2, 4] {
-        assert_session_leaf_allocations(workers);
-    }
+fn prepared_svd_session_repeated_single_worker_leaf_calls_allocate_zero() {
+    let _serial = TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    assert_session_leaf_allocations();
 }
 
-fn assert_session_leaf_allocations(workers: usize) {
-    let mut backend =
-        CpuBackend::with_threads_and_kind(workers, CpuBackendKind::Faer).unwrap();
+fn assert_session_leaf_allocations() {
+    let mut backend = CpuBackend::with_threads_and_kind(1, CpuBackendKind::Faer).unwrap();
 
     let f64_input =
-        Tensor::from_vec_col_major(vec![3, 2], vec![3.0_f64, 1.0, -2.0, 4.0, -1.0, 2.0])
-            .unwrap();
+        Tensor::from_vec_col_major(vec![3, 2], vec![3.0_f64, 1.0, -2.0, 4.0, -1.0, 2.0]).unwrap();
     let mut f64_strided_storage = vec![0.0_f64; 13];
     for col in 0..2 {
         for row in 0..3 {
@@ -259,72 +282,121 @@ fn assert_session_leaf_allocations(workers: usize) {
         .prepare_svd([2, 2], DType::C64, SvdOptions::default())
         .unwrap();
     let mut c64_workspace = c64_plan.allocate_workspace(&mut backend).unwrap();
-    let mut c64_u =
-        Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    let mut c64_u = Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
     let mut c64_s = Tensor::from_vec_col_major(vec![2], vec![0.0_f64; 2]).unwrap();
-    let mut c64_vt =
-        Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+    let mut c64_vt = Tensor::from_vec_col_major(vec![2, 2], vec![Complex64::default(); 4]).unwrap();
+
+    // Dynamic-rank views own shape/stride metadata. Construct input handles
+    // before measurement so the counter covers factorization leaves only.
+    let mut f64_strided_reads = (0..129)
+        .map(|_| {
+            let view =
+                TypedTensorView::from_slice([3, 2], [2, 7], 1, &f64_strided_storage).unwrap();
+            TensorRead::from_view(TensorView::F64(view))
+        })
+        .collect::<Vec<_>>();
+    let mut c64_strided_reads = (0..129)
+        .map(|_| {
+            let view =
+                TypedTensorView::from_slice([2, 2], [2, 5], 1, &c64_strided_storage).unwrap();
+            TensorRead::from_view(TensorView::C64(view))
+        })
+        .collect::<Vec<_>>();
 
     backend.with_prepared_factorization_session(|session| {
-        let allocations = measured_allocations(|| {
+        execute_leaf(
+            session,
+            &f64_plan,
+            &mut f64_workspace,
+            TensorRead::from_tensor(&f64_input),
+            &mut f64_u,
+            &mut f64_s,
+            &mut f64_vt,
+        );
+        execute_leaf(
+            session,
+            &f64_plan,
+            &mut f64_workspace,
+            f64_strided_reads.pop().unwrap(),
+            &mut f64_u,
+            &mut f64_s,
+            &mut f64_vt,
+        );
+        execute_leaf(
+            session,
+            &c64_plan,
+            &mut c64_workspace,
+            TensorRead::from_tensor(&c64_input),
+            &mut c64_u,
+            &mut c64_s,
+            &mut c64_vt,
+        );
+        execute_leaf(
+            session,
+            &c64_plan,
+            &mut c64_workspace,
+            c64_strided_reads.pop().unwrap(),
+            &mut c64_u,
+            &mut c64_s,
+            &mut c64_vt,
+        );
+
+        let f64_contiguous = measured_allocations(|| {
             for _ in 0..128 {
-                f64_plan
-                    .execute_into_session(
-                        session,
-                        &mut f64_workspace,
-                        TensorRead::from_tensor(&f64_input),
-                        SvdOutputWrites::new(
-                            TensorWrite::from_tensor(&mut f64_u),
-                            TensorWrite::from_tensor(&mut f64_s),
-                            TensorWrite::from_tensor(&mut f64_vt),
-                        ),
-                    )
-                    .unwrap();
-                let f64_strided =
-                    TypedTensorView::from_slice([3, 2], [2, 7], 1, &f64_strided_storage).unwrap();
-                f64_plan
-                    .execute_into_session(
-                        session,
-                        &mut f64_workspace,
-                        TensorRead::from_view(TensorView::F64(f64_strided)),
-                        SvdOutputWrites::new(
-                            TensorWrite::from_tensor(&mut f64_u),
-                            TensorWrite::from_tensor(&mut f64_s),
-                            TensorWrite::from_tensor(&mut f64_vt),
-                        ),
-                    )
-                    .unwrap();
-                c64_plan
-                    .execute_into_session(
-                        session,
-                        &mut c64_workspace,
-                        TensorRead::from_tensor(&c64_input),
-                        SvdOutputWrites::new(
-                            TensorWrite::from_tensor(&mut c64_u),
-                            TensorWrite::from_tensor(&mut c64_s),
-                            TensorWrite::from_tensor(&mut c64_vt),
-                        ),
-                    )
-                    .unwrap();
-                let c64_strided =
-                    TypedTensorView::from_slice([2, 2], [2, 5], 1, &c64_strided_storage).unwrap();
-                c64_plan
-                    .execute_into_session(
-                        session,
-                        &mut c64_workspace,
-                        TensorRead::from_view(TensorView::C64(c64_strided)),
-                        SvdOutputWrites::new(
-                            TensorWrite::from_tensor(&mut c64_u),
-                            TensorWrite::from_tensor(&mut c64_s),
-                            TensorWrite::from_tensor(&mut c64_vt),
-                        ),
-                    )
-                    .unwrap();
+                execute_leaf(
+                    session,
+                    &f64_plan,
+                    &mut f64_workspace,
+                    TensorRead::from_tensor(&f64_input),
+                    &mut f64_u,
+                    &mut f64_s,
+                    &mut f64_vt,
+                );
+            }
+        });
+        let f64_strided = measured_allocations(|| {
+            for input in f64_strided_reads.drain(..) {
+                execute_leaf(
+                    session,
+                    &f64_plan,
+                    &mut f64_workspace,
+                    input,
+                    &mut f64_u,
+                    &mut f64_s,
+                    &mut f64_vt,
+                );
+            }
+        });
+        let c64_contiguous = measured_allocations(|| {
+            for _ in 0..128 {
+                execute_leaf(
+                    session,
+                    &c64_plan,
+                    &mut c64_workspace,
+                    TensorRead::from_tensor(&c64_input),
+                    &mut c64_u,
+                    &mut c64_s,
+                    &mut c64_vt,
+                );
+            }
+        });
+        let c64_strided = measured_allocations(|| {
+            for input in c64_strided_reads.drain(..) {
+                execute_leaf(
+                    session,
+                    &c64_plan,
+                    &mut c64_workspace,
+                    input,
+                    &mut c64_u,
+                    &mut c64_s,
+                    &mut c64_vt,
+                );
             }
         });
         assert_eq!(
-            allocations, 0,
-            "prepared factorization session leaf calls with {workers} workers"
+            [f64_contiguous, f64_strided, c64_contiguous, c64_strided],
+            [0; 4],
+            "single-worker prepared factorization session leaf allocations: [F64 contiguous, F64 strided, C64 contiguous, C64 strided]"
         );
     });
 }

--- a/crates/tenferro-tensor/src/error.rs
+++ b/crates/tenferro-tensor/src/error.rs
@@ -74,6 +74,16 @@ pub enum Error {
         dtype: crate::DType,
         backend: crate::BackendId,
     },
+    #[error(
+        "{backend} backend provider {provider} does not support {capability} for {op} with dtype {dtype:?}"
+    )]
+    UnsupportedCapability {
+        op: &'static str,
+        backend: crate::BackendId,
+        provider: &'static str,
+        dtype: crate::DType,
+        capability: &'static str,
+    },
     #[error("{op}: division by zero for dtype {dtype:?}")]
     DivisionByZero {
         op: &'static str,
@@ -134,6 +144,41 @@ impl Error {
         backend: crate::BackendId,
     ) -> Self {
         Self::UnsupportedOpDType { op, dtype, backend }
+    }
+
+    /// Construct a structured backend/provider capability error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{BackendId, DType, Error};
+    ///
+    /// let err = Error::unsupported_capability(
+    ///     "prepare_svd",
+    ///     BackendId::Cpu,
+    ///     "blas",
+    ///     DType::F64,
+    ///     "prepared compact SVD",
+    /// );
+    /// assert!(matches!(
+    ///     err,
+    ///     Error::UnsupportedCapability { provider: "blas", .. }
+    /// ));
+    /// ```
+    pub fn unsupported_capability(
+        op: &'static str,
+        backend: crate::BackendId,
+        provider: &'static str,
+        dtype: crate::DType,
+        capability: &'static str,
+    ) -> Self {
+        Self::UnsupportedCapability {
+            op,
+            backend,
+            provider,
+            dtype,
+            capability,
+        }
     }
 
     /// Construct a structured division-by-zero domain error.

--- a/crates/tenferro-tensor/src/tests/error_tests.rs
+++ b/crates/tenferro-tensor/src/tests/error_tests.rs
@@ -1,0 +1,37 @@
+use crate::{BackendId, DType, Error};
+
+#[test]
+fn unsupported_capability_preserves_structured_context_and_display_contract() {
+    let error = Error::unsupported_capability(
+        "prepare_svd",
+        BackendId::Cpu,
+        "faer",
+        DType::C64,
+        "prepared compact SVD",
+    );
+
+    assert_eq!(
+        error,
+        Error::UnsupportedCapability {
+            op: "prepare_svd",
+            backend: BackendId::Cpu,
+            provider: "faer",
+            dtype: DType::C64,
+            capability: "prepared compact SVD",
+        }
+    );
+    assert!(matches!(
+        error,
+        Error::UnsupportedCapability {
+            op: "prepare_svd",
+            backend: BackendId::Cpu,
+            provider: "faer",
+            dtype: DType::C64,
+            capability: "prepared compact SVD",
+        }
+    ));
+    assert_eq!(
+        error.to_string(),
+        "cpu backend provider faer does not support prepared compact SVD for prepare_svd with dtype C64"
+    );
+}

--- a/crates/tenferro-tensor/src/tests/mod.rs
+++ b/crates/tenferro-tensor/src/tests/mod.rs
@@ -2,6 +2,7 @@ mod backend_default_read_tests;
 mod capability_tests;
 mod config_tests;
 mod dispatch_tests;
+mod error_tests;
 mod op_vocabulary_contract_tests;
 mod public_surface_contract_tests;
 mod types_tests;

--- a/docs/design/linalg-prims.md
+++ b/docs/design/linalg-prims.md
@@ -185,4 +185,11 @@ Prepared-resource `Debug` output distinguishes ownership from sizing. The plan's
 is the logical byte requirement computed at preparation. A workspace reports
 that logical requirement separately from `workspace_retained_bytes`, which
 counts its actual scratch length and vector capacities. Shared execution-context
-storage and inline Rust object size are outside these provider-resource counts.
+storage, backend binding and identity-token metadata, and inline Rust object
+size are outside these provider-resource counts.
+
+`PreparedSvd::retained_bytes` and `SvdWorkspace::retained_bytes` expose those
+currently retained provider-private heap bytes without parsing `Debug`. They are
+read-only, allocation-free snapshots, not estimates of total process memory.
+Provider representation determines the value; callers must not infer monotonic
+ordering across shapes, dtypes, options, or providers.

--- a/docs/design/linalg-prims.md
+++ b/docs/design/linalg-prims.md
@@ -106,3 +106,40 @@ The scalar side is intentionally split:
 
 That separation keeps public/high-level linalg APIs backend-generic without
 leaking CPU-specific scalar trait names.
+
+## Prepared Factorization Contract
+
+Prepared factorization is a separate public expert path; it does not change
+the convenient owned-output methods on `LinalgBackend`. An immutable plan
+binds the operation, shape, dtype, options, provider, placement, and execution
+context. A caller explicitly allocates one opaque mutable workspace per
+concurrency lane and supplies caller-owned destinations to `execute_into`.
+
+The first implementation is compact SVD through Faer. For an `m x n` input and
+`k = min(m, n)`, its exact outputs are `U: [m, k]`, `S: [k]`, and
+`Vt: [k, n]`. The workspace retains Faer scratch, signed-stride input packing,
+singular-value staging where required by the scalar ABI, and the `V` staging
+needed to produce public conjugate-transposed `Vt`.
+
+Execution follows these invariants:
+
+- validate backend/workspace identity, all metadata, layout, placement, and
+  conservative alias regions before the first output write;
+- return structured capability errors for unsupported provider, dtype,
+  placement, or layout instead of calling the owned API;
+- pass compatible borrowed inputs and compact destinations directly to the
+  provider, using only workspace-owned staging at documented boundaries;
+- apply gauge normalization in place; and
+- perform no Rust global-allocator calls after plan/workspace/output warm-up.
+
+`CpuLinalgBinding` is a narrow opaque interop contract owned by
+`tenferro-cpu`. It retains coordinator and context allocations so backend
+identity cannot suffer pointer reuse, but application code must not inspect or
+construct it. Provider-specific resources remain private to the implementation
+and never appear in the backend-neutral prepared API.
+
+The workspace is deliberately not `Clone`. Multiple workspaces may be created
+from one plan, while Rust's exclusive `&mut SvdWorkspace` prevents ordinary
+concurrent reuse of a single workspace. Validation failures are atomic for all
+destinations; a provider numerical failure after writes begin may leave partial
+output and is reported without an allocating rollback.

--- a/docs/design/linalg-prims.md
+++ b/docs/design/linalg-prims.md
@@ -115,6 +115,22 @@ binds the operation, shape, dtype, options, provider, placement, and execution
 context. A caller explicitly allocates one opaque mutable workspace per
 concurrency lane and supplies caller-owned destinations to `execute_into`.
 
+Callers that factorize many independent matrices may enter an opaque
+`PreparedFactorizationSession` once and call operation-specific leaf methods
+such as `PreparedSvd::execute_into_session`. The session is operation-neutral
+so compact QR and EIGH can share the same lifecycle later. It is neither
+constructible nor cloneable, and its callback-scoped lifetime prevents it from
+escaping the backend execution domain. Standalone `execute_into` is defined as
+a one-leaf session adapter rather than a separate execution path.
+
+`TensorRead` and `TensorWrite` descriptors belong to caller setup and are
+evaluated before an execution method is entered. Dynamic-rank view descriptors
+own shape and stride metadata, so constructing or cloning them may allocate.
+The prepared-leaf contract begins with preconstructed descriptors; it does not
+hide descriptor construction inside execution. A separate rank-2 descriptor
+API is deliberately not introduced because it would duplicate the canonical
+tensor view contract.
+
 The first implementation is compact SVD through Faer. For an `m x n` input and
 `k = min(m, n)`, its exact outputs are `U: [m, k]`, `S: [k]`, and
 `Vt: [k, n]`. The workspace retains Faer scratch, signed-stride input packing,
@@ -130,7 +146,26 @@ Execution follows these invariants:
 - pass compatible borrowed inputs and compact destinations directly to the
   provider, using only workspace-owned staging at documented boundaries;
 - apply gauge normalization in place; and
-- perform no Rust global-allocator calls after plan/workspace/output warm-up.
+- reuse all tenferro-controlled output, input-pack, and provider-workspace
+  storage without growing it after plan/workspace/output warm-up.
+
+Strict Rust global-allocator zero is evidence for the measured small sequential
+Faer regime, not a guarantee for every shape. Faer's numerical kernels may
+allocate their own internal metadata even with one worker, and its parallel
+Rayon/Spindle path may allocate scheduler storage. Those provider-internal
+allocations are explicitly outside the retained tenferro-storage contract and
+must be reported by shape and provider rather than hidden behind an unsupported
+fixed upper bound. The first implementation documents this distinction instead
+of adding a public capability enum before another provider needs one.
+
+On CPU, session entry acquires the resource permit and installs the managed
+execution owner exactly once. Leaves validate the retained backend, plan, and
+workspace bindings and invoke the provider directly; they do not call
+`CpuBackend::install`, broadcast worker state, or reacquire arbitration. The
+CPU implementation uses static session construction plus a private enum at the
+operation leaf. A tensor `BackendSession` trait object was rejected because
+factorization leaves neither need its buffer pool nor its dynamic operation
+surface.
 
 `CpuLinalgBinding` is a narrow opaque interop contract owned by
 `tenferro-cpu`. It retains coordinator and context allocations so backend

--- a/docs/design/linalg-prims.md
+++ b/docs/design/linalg-prims.md
@@ -143,3 +143,11 @@ from one plan, while Rust's exclusive `&mut SvdWorkspace` prevents ordinary
 concurrent reuse of a single workspace. Validation failures are atomic for all
 destinations; a provider numerical failure after writes begin may leave partial
 output and is reported without an allocating rollback.
+
+Prepared-resource `Debug` output distinguishes ownership from sizing. The plan's
+`plan_retained_bytes` counts provider-private heap buffers owned by the plan
+(zero for Faer's inline `StackReq` metadata), while `workspace_required_bytes`
+is the logical byte requirement computed at preparation. A workspace reports
+that logical requirement separately from `workspace_retained_bytes`, which
+counts its actual scratch length and vector capacities. Shared execution-context
+storage and inline Rust object size are outside these provider-resource counts.

--- a/docs/worklogs/2026-07-15-issue-1378-prepared-svd.md
+++ b/docs/worklogs/2026-07-15-issue-1378-prepared-svd.md
@@ -1,0 +1,47 @@
+# Issue 1378: Prepared Compact SVD
+
+## Goal
+
+Implement the accepted backend-neutral prepared factorization lifecycle for
+compact SVD, with Faer as the first provider and no owned-output fallback.
+
+## Decisions
+
+- Keep `PreparedSvd`, `SvdWorkspace`, and `SvdOutputWrites` public while
+  sealing provider dispatch.
+- Bind plans and workspaces to retained CPU coordinator/context identity; raw
+  pointer identity was rejected because allocator address reuse creates an ABA
+  failure mode.
+- Validate every input/output byte region before writes and conservatively
+  reject all six possible overlap pairs.
+- Write compact `U` directly, stage Faer's `V`, and conjugate-transpose it into
+  caller-owned `Vt`. Signed-stride inputs use a workspace pack buffer when they
+  cannot be borrowed directly.
+- Reuse the existing owned-path gauge implementation in place so prepared and
+  owned semantics cannot drift.
+- Represent unsupported provider/dtype/layout/binding as structured capability
+  errors. String-only backend failures were rejected because callers cannot
+  reliably branch on diagnostic text.
+
+## Verification Method
+
+Focused correctness tests compare prepared and owned output semantics and
+check reconstruction plus both `U` and `Vt` unitarity. Contract tests cover
+empty dimensions, signed strides, compact output subviews, unchanged sentinel
+outputs on validation failure, all alias pairs, backend/plan/workspace mismatch,
+and independent workspaces.
+
+The allocator test counts the complete release-mode warm call, including
+validation, packing, provider execution, `Vt` conversion, and gauge. Retaining
+`CpuSet` storage and active-request capacity removed the two one-thread
+coordination allocations: contiguous/strided F64 and contiguous C64 now measure
+zero. A two-thread probe still measured six allocations, exactly matching an
+empty `CpuBackend::install`, while `CpuContext::install` measured zero. That
+multi-thread execution-owner broadcast cost remains under design audit; the
+public zero-allocation contract is not weakened to one thread by this record.
+
+The Criterion benchmark uses one persistent one-thread Faer backend per path.
+Preparation, workspace allocation, and destination allocation are outside the
+prepared timer. Owned `svd_read` includes result allocation and destruction;
+prepared timing includes destination overwrite. Shapes cover square, tall, and
+wide matrices from 4-wide through 64-square.

--- a/docs/worklogs/2026-07-15-issue-1378-prepared-svd.md
+++ b/docs/worklogs/2026-07-15-issue-1378-prepared-svd.md
@@ -22,6 +22,10 @@ compact SVD, with Faer as the first provider and no owned-output fallback.
 - Represent unsupported provider/dtype/layout/binding as structured capability
   errors. String-only backend failures were rejected because callers cannot
   reliably branch on diagnostic text.
+- Report provider-resource bytes without conflating the plan and workspace:
+  Faer's plan retains no heap buffer, workspace required bytes are logical
+  prepared sizes, and workspace retained bytes include actual vector capacity.
+  Shared context storage and inline object size are deliberately excluded.
 
 ## Verification Method
 

--- a/docs/worklogs/2026-07-15-issue-1378-prepared-svd.md
+++ b/docs/worklogs/2026-07-15-issue-1378-prepared-svd.md
@@ -40,8 +40,29 @@ empty `CpuBackend::install`, while `CpuContext::install` measured zero. That
 multi-thread execution-owner broadcast cost remains under design audit; the
 public zero-allocation contract is not weakened to one thread by this record.
 
-The Criterion benchmark uses one persistent one-thread Faer backend per path.
-Preparation, workspace allocation, and destination allocation are outside the
-prepared timer. Owned `svd_read` includes result allocation and destruction;
+The Criterion benchmark uses persistent one- and two-thread Faer backends per
+path. Preparation, workspace allocation, and destination allocation are outside
+the prepared timer. Owned `svd_read` includes result allocation and destruction;
 prepared timing includes destination overwrite. Shapes cover square, tall, and
-wide matrices from 4-wide through 64-square.
+wide matrices from 2-wide through 64-square. A separate one-thread 8x4 case
+compares the same positive-stride borrowed view on both paths.
+
+On the local arm64 macOS host, a release `--quick` run measured these ratios
+using the reported point estimates:
+
+| Shape / input | Threads | Owned | Prepared | Owned / prepared |
+| --- | ---: | ---: | ---: | ---: |
+| 2x2 compact | 1 | 1.162 us | 0.530 us | 2.19x |
+| 4x2 compact | 1 | 1.278 us | 0.648 us | 1.97x |
+| 2x4 compact | 1 | 1.306 us | 0.648 us | 2.02x |
+| 4x4 compact | 1 | 2.325 us | 1.672 us | 1.39x |
+| 8x4 positive stride | 1 | 2.523 us | 1.845 us | 1.37x |
+| 16x16 compact | 1 | 17.385 us | 16.693 us | 1.04x |
+| 2x2 compact | 2 | 20.013 us | 17.719 us | 1.13x |
+| 16x16 compact | 2 | 39.648 us | 38.481 us | 1.03x |
+| 64x64 compact | 2 | 395.64 us | 394.50 us | 1.00x |
+
+Two-thread absolute times expose the current per-call execution-owner broadcast
+cost. The prepared path still avoids owned output work, but the independent CPU
+execution prerequisite is required before claiming multi-thread warm allocation
+or small-matrix latency is complete.

--- a/docs/worklogs/2026-07-15-issue-1378-prepared-svd.md
+++ b/docs/worklogs/2026-07-15-issue-1378-prepared-svd.md
@@ -26,6 +26,41 @@ compact SVD, with Faer as the first provider and no owned-output fallback.
   Faer's plan retains no heap buffer, workspace required bytes are logical
   prepared sizes, and workspace retained bytes include actual vector capacity.
   Shared context storage and inline object size are deliberately excluded.
+- Add an operation-neutral `PreparedFactorizationSession` rather than an
+  SVD-specific session. Standalone execution is a one-leaf adapter, while
+  repeated leaves reuse one CPU permit, execution owner, and pool entry.
+- Keep the leaf path statically dispatched. Reusing tensor `BackendSession`
+  would introduce an unrelated trait object and buffer-pool loan; the prepared
+  session instead uses `CpuBackend::install` once and a private operation enum.
+
+## Session Amendment
+
+The original complete-call allocation contract exposed a multi-worker CPU
+coordination cost before it exposed a provider allocation. The amendment keeps
+the backend arbitration and reentry semantics intact while moving that cost to
+one explicit, operation-neutral session entry. A prepared leaf validates the
+session/backend, plan, workspace, input, destinations, and alias regions before
+writes, then invokes Faer without another install. Ordinary errors remain
+inside the session and panic unwinding releases the outer execution guard.
+
+The session callback uses a higher-ranked lifetime, so the opaque non-`Clone`
+handle cannot escape. One workspace remains exclusive to one lane; independent
+sessions and workspaces are the concurrency mechanism. Provider-specific
+threading and bindings remain private and can be replaced without changing the
+public lifecycle.
+
+Input and destination descriptors are caller-owned setup. Dynamic-rank
+`TensorRead` and `TensorWrite` view construction retains shape and stride
+metadata and may allocate before the leaf is entered. The allocation gate
+therefore preconstructs those descriptors rather than adding a second rank-2
+descriptor API that would duplicate the tensor view contract.
+
+Directly counting one CPU entry and zero leaf reentries would require exposing
+or test-instrumenting private backend coordination. This change does not add a
+public counter solely for tests. CPU reentry tests and the leaf allocation gate
+provide indirect evidence; integration callers should retain a structural
+executor-entry counter when adopting sessions so this invariant is gated at the
+call site as well.
 
 ## Verification Method
 
@@ -41,8 +76,55 @@ validation, packing, provider execution, `Vt` conversion, and gauge. Retaining
 coordination allocations: contiguous/strided F64 and contiguous C64 now measure
 zero. A two-thread probe still measured six allocations, exactly matching an
 empty `CpuBackend::install`, while `CpuContext::install` measured zero. That
-multi-thread execution-owner broadcast cost remains under design audit; the
-public zero-allocation contract is not weakened to one thread by this record.
+probe motivated amortizing backend entry through the session. It did not prove
+that provider scheduler activity inside later leaves would remain globally
+allocation-free.
+
+The session allocator amendment measures at least 128 F64 and C64 leaves for
+contiguous and non-compact strided inputs. Session construction and warm-up are
+excluded. The small one-worker cases retain strict global-zero gates as measured
+evidence, not as an all-shape provider guarantee. Two- and four-worker runs
+retain repeated-leaf correctness and benchmark coverage, but deliberately have
+no allocation upper-bound assertion.
+
+That distinction follows a release-mode repetition study: 23 of 30 multiworker
+runs failed the proposed global-zero assertion even after leaf warm-up. Splitting
+the four input cases showed the allocation bursts moving between measured
+windows; a representative two-worker failure reported `[25, 0, 0, 0]` for F64
+contiguous, F64 strided, C64 contiguous, and C64 strided. Re-running the same
+binary also alternated between zero and nonzero counts. A sequential-provider
+diagnostic made the attribution narrower: these moving bursts were dominated by
+managed Rayon activity from the outer session entry completing after the
+callback allocation counter became active. Separate Faer and Spindle internal
+allocation sources exist, but this experiment did not prove that they produced
+these particular moving counts.
+
+An independent 64x64 F64 source/root diagnostic primed and settled each path,
+then measured 47 provider allocations per call for one-worker sequential Faer.
+Its original two- and four-worker figures were discarded: `Par::rayon(0)` had
+captured the ambient global degree when the plan was prepared outside the
+managed pool, so those figures did not prove either configured worker count.
+After the CPU-context fix passed the configured degree explicitly, five release
+runs each confirmed actual degrees 1, 2, and 4. The allocation counts per call
+were 47 for one worker, 72 for two workers, and a median 112 for four workers;
+the four-worker totals over eight leaves were 896, 903, 896, 896, and 897. The
+sequential source includes the `did_pack_lhs` vectors in `gemm-common` 0.19.0
+`src/gemm.rs` (the sequential allocation at line 490 and per-worker storage at
+line 654). Faer 0.24.4 reaches Spindle 0.2.6 `for_each` through
+`src/utils/mod.rs::thread::join_raw`, including calls from
+`src/linalg/svd/bidiag.rs`; Spindle's `for_each_imp` reserves iterator-split
+storage at `src/lib.rs` line 660 and otherwise delegates work to Rayon when no
+Spindle root is installed. This evidence does not attribute Faer's calls to
+Spindle `with_lock` or its root-manager allocation.
+Consequently the accepted boundary is that
+tenferro-controlled output, pack, and prepared-workspace storage does not grow
+after warm-up. Provider-internal numerical and scheduler allocations remain
+allowed and are recorded by benchmark. No public capability enum is added until
+another provider demonstrates the abstraction it must express.
+
+External merge remains blocked until the accepted prepared-factorization issues
+approve this operation-neutral session amendment. The local implementation and
+verification do not change that issue-acceptance gate.
 
 The Criterion benchmark uses persistent one- and two-thread Faer backends per
 path. Preparation, workspace allocation, and destination allocation are outside
@@ -51,22 +133,17 @@ prepared timing includes destination overwrite. Shapes cover square, tall, and
 wide matrices from 2-wide through 64-square. A separate one-thread 8x4 case
 compares the same positive-stride borrowed view on both paths.
 
-On the local arm64 macOS host, a release `--quick` run measured these ratios
-using the reported point estimates:
+On the local arm64 macOS host, a release `--quick` run at this branch's HEAD
+measured these two-worker ratios using the reported point estimates:
 
 | Shape / input | Threads | Owned | Prepared | Owned / prepared |
 | --- | ---: | ---: | ---: | ---: |
-| 2x2 compact | 1 | 1.162 us | 0.530 us | 2.19x |
-| 4x2 compact | 1 | 1.278 us | 0.648 us | 1.97x |
-| 2x4 compact | 1 | 1.306 us | 0.648 us | 2.02x |
-| 4x4 compact | 1 | 2.325 us | 1.672 us | 1.39x |
-| 8x4 positive stride | 1 | 2.523 us | 1.845 us | 1.37x |
-| 16x16 compact | 1 | 17.385 us | 16.693 us | 1.04x |
-| 2x2 compact | 2 | 20.013 us | 17.719 us | 1.13x |
-| 16x16 compact | 2 | 39.648 us | 38.481 us | 1.03x |
-| 64x64 compact | 2 | 395.64 us | 394.50 us | 1.00x |
+| 2x2 compact | 2 | 6.339 us | 5.737 us | 1.10x |
+| 4x4 compact | 2 | 7.442 us | 6.880 us | 1.08x |
+| 16x16 compact | 2 | 25.944 us | 25.533 us | 1.02x |
+| 64x64 compact | 2 | 435.47 us | 429.45 us | 1.01x |
 
-Two-thread absolute times expose the current per-call execution-owner broadcast
-cost. The prepared path still avoids owned output work, but the independent CPU
-execution prerequisite is required before claiming multi-thread warm allocation
-or small-matrix latency is complete.
+The CPU execution-scope prerequisite removes the former roughly 18 us small
+matrix entry penalty. The standalone prepared adapter still enters one session
+per call; callers with multiple leaves use the explicit session API to amortize
+that remaining entry boundary.


### PR DESCRIPTION
## Why

The owned SVD API is the right default for one-shot decomposition, but it cannot express repeated fixed-shape execution into caller-owned outputs or retain provider workspace across calls. A default `_into` adapter that calls owned SVD would hide allocation and blur provider capability.

Closes #1378.

## Stack dependency

Depends on #1390.

This draft is stacked on #1390. Its base is `perf/cpu-managed-entry-reuse-ci`; it will be retargeted to `main` after #1390 merges.

## What changed

- Add backend-neutral `PreparedSvd`, `SvdWorkspace`, output-spec, output-write, and typed capability-error contracts.
- Implement compact SVD for the Faer CPU provider with fixed shape/dtype/options and explicit binding to backend resources.
- Validate input, destinations, placement, layouts, and all alias pairs before provider writes.
- Reuse tenferro-controlled input packing, singular-vector staging, gauge staging, and Faer scratch.
- Add an operation-neutral `PreparedFactorizationSession`; standalone `execute_into` remains a one-leaf adapter to the same implementation.
- Expose allocation-free `retained_bytes()` diagnostics for prepared plans and workspaces.
- Add correctness, error-atomicity, alias, layout, allocation, resource-accounting, documentation, and benchmark coverage.

## Allocation boundary

Compatible warm execution does not grow or replace tenferro-controlled prepared storage. Strict global-allocator zero is enforced for the measured one-worker small Faer regime. Rayon multiworker scheduling and provider-internal allocation remain separately measured residuals rather than a backend-global zero promise.

Caller-owned compact destination subviews are covered explicitly for F64 and C64, tall and wide shapes, all three outputs, 64 repeated session leaves, and unchanged retained workspace. Prepared outputs have rank one or two, so their dynamic `ShapeVec` metadata remains inline while shared read validation and alias analysis stay the single descriptor authority.

## Verification

- `tenferro-linalg` with `cpu-faer`: all unit and integration tests passed, including prepared SVD 18/18.
- `tenferro-linalg` doctests: 72/72 passed.
- Release prepared allocation tests: 4/4 passed.
- `cargo check --no-default-features --features cpu-blas`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- Restack audit found no changes to TBLIS provider, selection, placement, topology, or Cargo feature files.

## Provider scope

Faer is the first implementation. The CPU BLAS/LAPACK provider returns an explicit `UnsupportedCapability` error until its prepared implementation lands. CUDA does not expose the prepared-factorization capability in this slice. Existing owned SVD behavior is unchanged and is never used as a prepared fallback.
