### PR TITLE
fix: remediate API, GPU edge, SVD, and CPU dispatch bugs

### DIFF
--- a/crates/tenferro-cpu/benches/grouped_gemm.rs
+++ b/crates/tenferro-cpu/benches/grouped_gemm.rs
@@ -3,7 +3,7 @@ use tenferro_cpu::CpuBackend;
 use tenferro_tensor::backend::{GroupedGemmConfig, GroupedGemmJob};
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, ContractionScalar, DotGeneralAccumulation,
-    DotGeneralConfig, Tensor, TensorDot, TensorRead, TensorWrite,
+    DotGeneralConfig, Tensor, TensorDot, TensorRead, TensorView, TensorWrite,
 };
 
 #[derive(Clone)]
@@ -41,28 +41,70 @@ fn fixture_from_shapes(shapes: &[(usize, usize, usize)]) -> GroupedFixture {
     }
 }
 
-fn run_grouped(backend: &mut CpuBackend, fixture: &GroupedFixture) -> Tensor {
-    let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
-    let mut out = fixture.out.clone();
-    let config = GroupedGemmConfig::new(
+fn grouped_config(fixture: &GroupedFixture, beta: f64) -> GroupedGemmConfig<'_> {
+    GroupedGemmConfig::new(
         &fixture.jobs,
         DotGeneralAccumulation {
             lhs_conj: false,
             rhs_conj: false,
             alpha: ContractionScalar::F64(1.0),
-            beta: ContractionScalar::F64(1.0),
+            beta: ContractionScalar::F64(beta),
         },
-    );
+    )
+}
+
+fn run_grouped_into(
+    backend: &mut CpuBackend,
+    cache: &mut <CpuBackend as BackendRuntimeCache>::RuntimeCache,
+    fixture: &GroupedFixture,
+    config: &GroupedGemmConfig<'_>,
+    out: &mut Tensor,
+) {
     BackendCachedDot::grouped_gemm_cached(
         backend,
-        &mut cache,
+        cache,
         Some(0),
         TensorRead::from_tensor(&fixture.lhs),
         TensorRead::from_tensor(&fixture.rhs),
-        &config,
-        TensorWrite::from_tensor(&mut out),
+        config,
+        TensorWrite::from_tensor(out),
     )
     .unwrap();
+}
+
+fn f64_view(tensor: &Tensor) -> TensorView<'_> {
+    match tensor {
+        Tensor::F64(tensor) => TensorView::F64(tensor.as_view()),
+        _ => unreachable!("grouped GEMM benchmark fixtures are F64"),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_grouped_views_into(
+    backend: &mut CpuBackend,
+    cache: &mut <CpuBackend as BackendRuntimeCache>::RuntimeCache,
+    lhs: &TensorView<'_>,
+    rhs: &TensorView<'_>,
+    config: &GroupedGemmConfig<'_>,
+    out: &mut Tensor,
+) {
+    BackendCachedDot::grouped_gemm_cached(
+        backend,
+        cache,
+        Some(0),
+        TensorRead::from_view(lhs.clone()),
+        TensorRead::from_view(rhs.clone()),
+        config,
+        TensorWrite::from_tensor(out),
+    )
+    .unwrap();
+}
+
+fn run_grouped(backend: &mut CpuBackend, fixture: &GroupedFixture) -> Tensor {
+    let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
+    let mut out = fixture.out.clone();
+    let config = grouped_config(fixture, 1.0);
+    run_grouped_into(backend, &mut cache, fixture, &config, &mut out);
     out
 }
 
@@ -152,5 +194,42 @@ fn bench_grouped_gemm(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_grouped_gemm);
+fn bench_grouped_gemm_steady_state(c: &mut Criterion) {
+    const PROFILE_WARMUP_ITERATIONS: usize = 2_000;
+    const CALLS_PER_ITERATION: usize = 6;
+
+    let fixture = fixture_from_shapes(&[(4, 4, 4); 8]);
+    let config = grouped_config(&fixture, 0.0);
+    let lhs = f64_view(&fixture.lhs);
+    let rhs = f64_view(&fixture.rhs);
+    let mut backend = CpuBackend::with_threads(1).unwrap();
+    let mut cache = <CpuBackend as BackendRuntimeCache>::RuntimeCache::default();
+    let mut out = fixture.out.clone();
+
+    // Match the steady-state profile that motivated issue #1385: warm the
+    // backend, then issue six small grouped-GEMM calls per measured iteration.
+    for _ in 0..PROFILE_WARMUP_ITERATIONS {
+        for _ in 0..CALLS_PER_ITERATION {
+            run_grouped_views_into(&mut backend, &mut cache, &lhs, &rhs, &config, &mut out);
+        }
+    }
+
+    c.bench_function("grouped_gemm/steady_state/six_calls_8x4x4", |b| {
+        b.iter(|| {
+            for _ in 0..CALLS_PER_ITERATION {
+                run_grouped_views_into(
+                    black_box(&mut backend),
+                    black_box(&mut cache),
+                    black_box(&lhs),
+                    black_box(&rhs),
+                    black_box(&config),
+                    black_box(&mut out),
+                );
+            }
+            black_box(out.as_slice::<f64>().unwrap()[0]);
+        });
+    });
+}
+
+criterion_group!(benches, bench_grouped_gemm, bench_grouped_gemm_steady_state);
 criterion_main!(benches);

--- a/crates/tenferro-cpu/src/analytic.rs
+++ b/crates/tenferro-cpu/src/analytic.rs
@@ -167,7 +167,8 @@ macro_rules! impl_integer_pow_elem {
 impl_integer_pow_elem!(i32);
 impl_integer_pow_elem!(i64);
 
-fn with_local_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
+#[cfg(test)]
+fn with_test_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
     let mut buffers = BufferPool::new();
     f(&mut buffers)
 }
@@ -362,7 +363,7 @@ macro_rules! define_unary_analytic_dispatch {
     ($dispatch_fn:ident, $dispatch_with_pool_fn:ident, $dispatch_read_with_pool_fn:ident, $op_kind:ident, $elem_fn:ident) => {
         #[cfg(test)]
         pub(crate) fn $dispatch_fn(input: &Tensor) -> crate::Result<Tensor> {
-            with_local_pool(|buffers| $dispatch_with_pool_fn(buffers, input))
+            with_test_pool(|buffers| $dispatch_with_pool_fn(buffers, input))
         }
 
         pub(crate) fn $dispatch_with_pool_fn(
@@ -445,8 +446,9 @@ define_unary_analytic_dispatch!(
     log1p_elem
 );
 
-pub fn pow(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| pow_with_pool(buffers, lhs, rhs))
+#[cfg(test)]
+pub(crate) fn pow(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| pow_with_pool(buffers, lhs, rhs))
 }
 
 pub(crate) fn pow_with_pool(

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -129,35 +129,25 @@ fn maybe_print_cpu_session_profile() {
 }
 
 struct BufferPoolLoan<'a> {
-    target: &'a mut BufferPool,
-    buffers: Option<BufferPool>,
+    buffers: &'a mut BufferPool,
 }
 
 impl<'a> BufferPoolLoan<'a> {
-    fn new(target: &'a mut BufferPool) -> Self {
-        Self {
-            buffers: Some(std::mem::take(target)),
-            target,
-        }
+    fn new(buffers: &'a mut BufferPool) -> Self {
+        Self { buffers }
     }
 
     fn get_mut(&mut self) -> &mut BufferPool {
         self.buffers
-            .as_mut()
-            .expect("buffer pool loan already restored")
     }
 }
 
 impl Drop for BufferPoolLoan<'_> {
     fn drop(&mut self) {
-        if let Some(buffers) = self.buffers.take() {
-            let mut buffers = buffers;
-            if thread::panicking() {
-                buffers.replenish_in_flight_retained();
-            } else {
-                buffers.clear_in_flight_retained();
-            }
-            *self.target = buffers;
+        if thread::panicking() {
+            self.buffers.replenish_in_flight_retained();
+        } else {
+            self.buffers.clear_in_flight_retained();
         }
     }
 }
@@ -1952,7 +1942,7 @@ impl TensorDot for CpuBackend {
             #[cfg(feature = "cpu-tblis-provider")]
             {
                 let direct = self.run_with_pool_and_gemm_cache(&mut cache, |buffers, _cache| {
-                    gemm::dot_general_tblis_read_cached(buffers, lhs.clone(), rhs.clone(), config)
+                    gemm::dot_general_tblis_read_cached(buffers, &lhs, &rhs, config)
                 })?;
                 if let Some(result) = self.tblis_not_applicable("dot_general", direct)? {
                     return Ok(result);
@@ -1978,8 +1968,8 @@ impl TensorDot for CpuBackend {
                             cache,
                             None,
                             ctx.as_ref(),
-                            lhs.clone(),
-                            rhs.clone(),
+                            &lhs,
+                            &rhs,
                             config,
                         )
                     })?
@@ -1993,14 +1983,7 @@ impl TensorDot for CpuBackend {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.run_with_pool_and_gemm_cache(&mut cache, |buffers, cache| {
-                        gemm::dot_general_blas_read_cached(
-                            buffers,
-                            cache,
-                            None,
-                            lhs.clone(),
-                            rhs.clone(),
-                            config,
-                        )
+                        gemm::dot_general_blas_read_cached(buffers, cache, None, &lhs, &rhs, config)
                     })?
                 }
                 #[cfg(not(feature = "cpu-blas"))]
@@ -2395,8 +2378,8 @@ impl BackendCachedDot for CpuBackend {
             #[cfg(feature = "cpu-tblis-provider")]
             {
                 let direct = gemm::dot_general_tblis_read_into_accum_cached(
-                    lhs.clone(),
-                    rhs.clone(),
+                    &lhs,
+                    &rhs,
                     config,
                     accumulation,
                     &mut out,
@@ -2421,8 +2404,8 @@ impl BackendCachedDot for CpuBackend {
                             cache,
                             cache_slot,
                             ctx.as_ref(),
-                            lhs.clone(),
-                            rhs.clone(),
+                            &lhs,
+                            &rhs,
                             config,
                             accumulation,
                             &mut out,
@@ -2442,8 +2425,8 @@ impl BackendCachedDot for CpuBackend {
                             buffers,
                             cache,
                             cache_slot,
-                            lhs.clone(),
-                            rhs.clone(),
+                            &lhs,
+                            &rhs,
                             config,
                             accumulation,
                             &mut out,
@@ -2481,13 +2464,7 @@ impl BackendCachedDot for CpuBackend {
                 {
                     let ctx = self.engine.context_arc();
                     self.install_with_pool(|_buffers| {
-                        gemm::grouped_gemm_faer_cached(
-                            ctx.as_ref(),
-                            lhs.clone(),
-                            rhs.clone(),
-                            config,
-                            &mut out,
-                        )
+                        gemm::grouped_gemm_faer_cached(ctx.as_ref(), &lhs, &rhs, config, &mut out)
                     })?
                 }
                 #[cfg(not(feature = "cpu-faer"))]
@@ -2499,7 +2476,7 @@ impl BackendCachedDot for CpuBackend {
                 #[cfg(feature = "cpu-blas")]
                 {
                     self.run_with_pool(|_buffers| {
-                        gemm::grouped_gemm_blas_cached(lhs.clone(), rhs.clone(), config, &mut out)
+                        gemm::grouped_gemm_blas_cached(&lhs, &rhs, config, &mut out)
                     })?
                 }
                 #[cfg(not(feature = "cpu-blas"))]

--- a/crates/tenferro-cpu/src/buffer_pool.rs
+++ b/crates/tenferro-cpu/src/buffer_pool.rs
@@ -14,8 +14,10 @@
 
 use std::collections::BTreeMap;
 use std::env;
+use std::ffi::OsString;
 use std::fmt;
 use std::mem::size_of;
+use std::sync::OnceLock;
 
 use num_complex::{Complex32, Complex64};
 
@@ -33,6 +35,8 @@ pub const BUFFER_POOL_MAX_RETAINED_BYTES_ENV: &str = "TENFERRO_BUFFER_POOL_MAX_R
 /// sizes as tensor shapes grow while still preserving reuse for hot working
 /// sets.
 pub const DEFAULT_MAX_RETAINED_CAPACITY_BYTES: usize = 100 * 1024 * 1024;
+
+static DEFAULT_MAX_RETAINED_CAPACITY_FROM_ENV: OnceLock<usize> = OnceLock::new();
 
 /// Snapshot of typed host buffers retained by a [`BufferPool`].
 ///
@@ -714,8 +718,14 @@ impl BufferPool {
 }
 
 fn default_max_retained_capacity_bytes() -> usize {
-    env::var(BUFFER_POOL_MAX_RETAINED_BYTES_ENV)
-        .ok()
+    *DEFAULT_MAX_RETAINED_CAPACITY_FROM_ENV.get_or_init(|| {
+        parse_default_max_retained_capacity_bytes(env::var_os(BUFFER_POOL_MAX_RETAINED_BYTES_ENV))
+    })
+}
+
+fn parse_default_max_retained_capacity_bytes(value: Option<OsString>) -> usize {
+    value
+        .and_then(|value| value.into_string().ok())
         .and_then(|value| value.parse().ok())
         .unwrap_or(DEFAULT_MAX_RETAINED_CAPACITY_BYTES)
 }

--- a/crates/tenferro-cpu/src/buffer_pool/tests.rs
+++ b/crates/tenferro-cpu/src/buffer_pool/tests.rs
@@ -1,6 +1,40 @@
 use std::mem::size_of;
 
-use super::{BufferPool, PoolScalar};
+use super::{
+    parse_default_max_retained_capacity_bytes, BufferPool, PoolScalar,
+    DEFAULT_MAX_RETAINED_CAPACITY_BYTES,
+};
+
+#[test]
+fn default_retention_limit_parser_covers_missing_invalid_zero_and_valid_values() {
+    assert_eq!(
+        parse_default_max_retained_capacity_bytes(None),
+        DEFAULT_MAX_RETAINED_CAPACITY_BYTES
+    );
+    assert_eq!(
+        parse_default_max_retained_capacity_bytes(Some("invalid".into())),
+        DEFAULT_MAX_RETAINED_CAPACITY_BYTES
+    );
+    assert_eq!(
+        parse_default_max_retained_capacity_bytes(Some("0".into())),
+        0
+    );
+    assert_eq!(
+        parse_default_max_retained_capacity_bytes(Some("4096".into())),
+        4096
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn default_retention_limit_parser_rejects_non_unicode_values() {
+    use std::os::unix::ffi::OsStringExt;
+
+    assert_eq!(
+        parse_default_max_retained_capacity_bytes(Some(std::ffi::OsString::from_vec(vec![0xff]))),
+        DEFAULT_MAX_RETAINED_CAPACITY_BYTES
+    );
+}
 
 #[test]
 fn acquire_release_reuse() {

--- a/crates/tenferro-cpu/src/elementwise.rs
+++ b/crates/tenferro-cpu/src/elementwise.rs
@@ -405,7 +405,8 @@ where
     complex_scalar_tensor(typed_view_from_view("add", input)?.get(&[]))
 }
 
-fn with_local_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
+#[cfg(test)]
+fn with_test_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
     let mut buffers = BufferPool::new();
     f(&mut buffers)
 }
@@ -424,8 +425,9 @@ fn with_local_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn add(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| add_with_pool(buffers, lhs, rhs))
+#[cfg(test)]
+pub(crate) fn add(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| add_with_pool(buffers, lhs, rhs))
 }
 
 pub(crate) fn add_with_pool(
@@ -598,8 +600,9 @@ pub(crate) fn add_read_with_pool(
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[2.0, -2.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn sub(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| sub_with_pool(buffers, lhs, rhs))
+#[cfg(test)]
+pub(crate) fn sub(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| sub_with_pool(buffers, lhs, rhs))
 }
 
 pub(crate) fn sub_with_pool(
@@ -772,8 +775,9 @@ pub(crate) fn sub_read_with_pool(
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[8.0, 15.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn mul(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| mul_with_pool(buffers, lhs, rhs))
+#[cfg(test)]
+pub(crate) fn mul(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| mul_with_pool(buffers, lhs, rhs))
 }
 
 fn binary_read_with_pool(
@@ -2170,8 +2174,9 @@ pub(crate) fn broadcast_multiply_value_with_pool(
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[4.0, 3.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn div(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| div_with_pool(buffers, lhs, rhs))
+#[cfg(test)]
+pub(crate) fn div(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| div_with_pool(buffers, lhs, rhs))
 }
 
 pub(crate) fn div_with_pool(
@@ -2325,8 +2330,9 @@ pub(crate) fn div_read_with_pool(
 /// assert_eq!(out.as_slice::<i32>().unwrap(), &[1, -1]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn rem(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| rem_with_pool(buffers, lhs, rhs))
+#[cfg(test)]
+pub(crate) fn rem(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| rem_with_pool(buffers, lhs, rhs))
 }
 
 pub(crate) fn rem_with_pool(
@@ -2392,8 +2398,9 @@ pub(crate) fn rem_read_with_pool(
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[-1.0, 2.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn neg(input: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| neg_with_pool(buffers, input))
+#[cfg(test)]
+pub(crate) fn neg(input: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| neg_with_pool(buffers, input))
 }
 
 pub(crate) fn neg_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate::Result<Tensor> {
@@ -2474,8 +2481,9 @@ pub(crate) fn neg_read_with_pool(
 /// assert_eq!(out.as_slice::<Complex64>().unwrap(), &[Complex64::new(1.0, -2.0)]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn conj(input: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| conj_with_pool(buffers, input))
+#[cfg(test)]
+pub(crate) fn conj(input: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| conj_with_pool(buffers, input))
 }
 
 pub(crate) fn conj_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate::Result<Tensor> {
@@ -2543,8 +2551,9 @@ pub(crate) fn conj_read_with_pool(
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[3.0, 4.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn abs(input: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| abs_with_pool(buffers, input))
+#[cfg(test)]
+pub(crate) fn abs(input: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| abs_with_pool(buffers, input))
 }
 
 pub(crate) fn abs_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate::Result<Tensor> {
@@ -2614,8 +2623,9 @@ pub(crate) fn abs_read_with_pool(
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[-1.0, 0.0, 1.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn sign(input: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| sign_with_pool(buffers, input))
+#[cfg(test)]
+pub(crate) fn sign(input: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| sign_with_pool(buffers, input))
 }
 
 pub(crate) fn sign_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate::Result<Tensor> {
@@ -2696,8 +2706,9 @@ pub(crate) fn sign_read_with_pool(
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[3.0, 5.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn maximum(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| maximum_with_pool(buffers, lhs, rhs))
+#[cfg(test)]
+pub(crate) fn maximum(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| maximum_with_pool(buffers, lhs, rhs))
 }
 
 pub(crate) fn maximum_with_pool(
@@ -2772,8 +2783,9 @@ pub(crate) fn maximum_read_with_pool(
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[1.0, 4.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn minimum(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| minimum_with_pool(buffers, lhs, rhs))
+#[cfg(test)]
+pub(crate) fn minimum(lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| minimum_with_pool(buffers, lhs, rhs))
 }
 
 pub(crate) fn minimum_with_pool(
@@ -2848,8 +2860,9 @@ pub(crate) fn minimum_read_with_pool(
 /// assert_eq!(out.as_slice::<bool>().unwrap(), &[false, true]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| compare_with_pool(buffers, lhs, rhs, dir))
+#[cfg(test)]
+pub(crate) fn compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| compare_with_pool(buffers, lhs, rhs, dir))
 }
 
 pub(crate) fn compare_with_pool(
@@ -2943,8 +2956,9 @@ pub(crate) fn compare_read_with_pool(
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[1.0, 4.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| select_with_pool(buffers, pred, on_true, on_false))
+#[cfg(test)]
+pub(crate) fn select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| select_with_pool(buffers, pred, on_true, on_false))
 }
 
 pub(crate) fn select_with_pool(
@@ -3051,8 +3065,9 @@ pub(crate) fn select_read_with_pool(
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[0.0, 2.0, 5.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| clamp_with_pool(buffers, input, lower, upper))
+#[cfg(test)]
+pub(crate) fn clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| clamp_with_pool(buffers, input, lower, upper))
 }
 
 pub(crate) fn clamp_with_pool(

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -265,12 +265,8 @@ impl TensorDot for CpuExecSession<'_> {
             DotGeneralProvider::TblisIfAvailable | DotGeneralProvider::TblisRequired => {
                 #[cfg(feature = "cpu-tblis-provider")]
                 {
-                    let direct = gemm::dot_general_tblis_read_cached(
-                        self.buffers,
-                        lhs.clone(),
-                        rhs.clone(),
-                        config,
-                    )?;
+                    let direct =
+                        gemm::dot_general_tblis_read_cached(self.buffers, &lhs, &rhs, config)?;
                     if let Some(result) = self.tblis_not_applicable("dot_general", direct)? {
                         return Ok(result);
                     }
@@ -295,8 +291,8 @@ impl TensorDot for CpuExecSession<'_> {
                         self.gemm_analysis_cache,
                         None,
                         self.ctx,
-                        lhs.clone(),
-                        rhs.clone(),
+                        &lhs,
+                        &rhs,
                         config,
                     )?
                 }
@@ -315,8 +311,8 @@ impl TensorDot for CpuExecSession<'_> {
                         self.buffers,
                         self.gemm_analysis_cache,
                         None,
-                        lhs.clone(),
-                        rhs.clone(),
+                        &lhs,
+                        &rhs,
                         config,
                     )?
                 }
@@ -798,8 +794,8 @@ impl SessionCachedDot for CpuExecSession<'_> {
                 #[cfg(feature = "cpu-tblis-provider")]
                 {
                     let direct = gemm::dot_general_tblis_read_into_accum_cached(
-                        lhs.clone(),
-                        rhs.clone(),
+                        &lhs,
+                        &rhs,
                         config,
                         accumulation,
                         &mut out,
@@ -823,8 +819,8 @@ impl SessionCachedDot for CpuExecSession<'_> {
                         self.gemm_analysis_cache,
                         cache_slot,
                         self.ctx,
-                        lhs.clone(),
-                        rhs.clone(),
+                        &lhs,
+                        &rhs,
                         config,
                         accumulation,
                         &mut out,
@@ -845,8 +841,8 @@ impl SessionCachedDot for CpuExecSession<'_> {
                         self.buffers,
                         self.gemm_analysis_cache,
                         cache_slot,
-                        lhs.clone(),
-                        rhs.clone(),
+                        &lhs,
+                        &rhs,
                         config,
                         accumulation,
                         &mut out,
@@ -883,13 +879,7 @@ impl SessionCachedDot for CpuExecSession<'_> {
             CpuBackendKind::Faer => {
                 #[cfg(feature = "cpu-faer")]
                 {
-                    gemm::grouped_gemm_faer_cached(
-                        self.ctx,
-                        lhs.clone(),
-                        rhs.clone(),
-                        config,
-                        &mut out,
-                    )?
+                    gemm::grouped_gemm_faer_cached(self.ctx, &lhs, &rhs, config, &mut out)?
                 }
                 #[cfg(not(feature = "cpu-faer"))]
                 {
@@ -902,7 +892,7 @@ impl SessionCachedDot for CpuExecSession<'_> {
             CpuBackendKind::Blas => {
                 #[cfg(feature = "cpu-blas")]
                 {
-                    gemm::grouped_gemm_blas_cached(lhs.clone(), rhs.clone(), config, &mut out)?
+                    gemm::grouped_gemm_blas_cached(&lhs, &rhs, config, &mut out)?
                 }
                 #[cfg(not(feature = "cpu-blas"))]
                 {

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -1036,14 +1036,14 @@ pub(crate) fn dot_general_faer_read_cached(
     cache: &mut GemmAnalysisCache,
     cache_slot: Option<usize>,
     ctx: &crate::CpuContext,
-    lhs: TensorRead<'_>,
-    rhs: TensorRead<'_>,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
     config: &DotGeneralConfig,
 ) -> crate::Result<Option<crate::Tensor>> {
     let _ = (cache, cache_slot, ctx);
     macro_rules! dispatch {
         ($owned:ident, $view:ident, $wrap:ident) => {
-            match (&lhs, &rhs) {
+            match (lhs, rhs) {
                 (
                     TensorRead::Tensor(crate::Tensor::$owned(a)),
                     TensorRead::Tensor(crate::Tensor::$owned(b)),
@@ -1115,14 +1115,14 @@ pub(crate) fn dot_general_faer_read_cached(
 
 #[cfg(feature = "cpu-faer")]
 pub(crate) fn dot_general_faer_read_into_cached(
-    lhs: TensorRead<'_>,
-    rhs: TensorRead<'_>,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
     config: &DotGeneralConfig,
     out: &mut TensorWrite<'_>,
 ) -> crate::Result<bool> {
     macro_rules! dispatch {
         ($owned:ident, $view:ident) => {
-            match (&lhs, &rhs, &mut *out) {
+            match (lhs, rhs, &mut *out) {
                 (
                     TensorRead::Tensor(crate::Tensor::$owned(a)),
                     TensorRead::Tensor(crate::Tensor::$owned(b)),
@@ -1211,8 +1211,8 @@ pub(crate) fn dot_general_faer_read_into_accum_cached(
     cache: &mut GemmAnalysisCache,
     cache_slot: Option<usize>,
     ctx: &crate::CpuContext,
-    lhs: TensorRead<'_>,
-    rhs: TensorRead<'_>,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
     config: &DotGeneralConfig,
     accumulation: DotGeneralAccumulation,
     out: &mut TensorWrite<'_>,
@@ -1230,7 +1230,7 @@ pub(crate) fn dot_general_faer_read_into_accum_cached(
             if let (ContractionScalar::$owned(alpha), ContractionScalar::$owned(beta)) =
                 (accumulation.alpha, accumulation.beta)
             {
-                match (&lhs, &rhs, &mut *out) {
+                match (lhs, rhs, &mut *out) {
                     (
                         TensorRead::Tensor(crate::Tensor::$owned(a)),
                         TensorRead::Tensor(crate::Tensor::$owned(b)),
@@ -1395,8 +1395,8 @@ pub(crate) fn dot_general_faer_read_into_accum_cached(
 #[cfg(feature = "cpu-faer")]
 pub(crate) fn grouped_gemm_faer_cached(
     ctx: &crate::CpuContext,
-    lhs: TensorRead<'_>,
-    rhs: TensorRead<'_>,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
     config: &GroupedGemmConfig<'_>,
     out: &mut TensorWrite<'_>,
 ) -> crate::Result<bool> {
@@ -1405,7 +1405,7 @@ pub(crate) fn grouped_gemm_faer_cached(
             if let (ContractionScalar::$owned(alpha), ContractionScalar::$owned(beta)) =
                 (config.accumulation().alpha, config.accumulation().beta)
             {
-                match (&lhs, &rhs, &mut *out) {
+                match (lhs, rhs, &mut *out) {
                     (
                         TensorRead::Tensor(crate::Tensor::$owned(a)),
                         TensorRead::Tensor(crate::Tensor::$owned(b)),
@@ -1904,13 +1904,13 @@ pub(crate) fn dot_general_blas_read_cached(
     buffers: &mut BufferPool,
     cache: &mut GemmAnalysisCache,
     cache_slot: Option<usize>,
-    lhs: TensorRead<'_>,
-    rhs: TensorRead<'_>,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
     config: &DotGeneralConfig,
 ) -> crate::Result<Option<crate::Tensor>> {
     macro_rules! dispatch {
         ($owned:ident, $view:ident, $wrap:ident) => {
-            match (&lhs, &rhs) {
+            match (lhs, rhs) {
                 (
                     TensorRead::Tensor(crate::Tensor::$owned(a)),
                     TensorRead::Tensor(crate::Tensor::$owned(b)),
@@ -2000,8 +2000,8 @@ pub(crate) fn dot_general_blas_read_into_accum_cached(
     _buffers: &mut BufferPool,
     cache: &mut GemmAnalysisCache,
     cache_slot: Option<usize>,
-    lhs: TensorRead<'_>,
-    rhs: TensorRead<'_>,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
     config: &DotGeneralConfig,
     accumulation: DotGeneralAccumulation,
     out: &mut TensorWrite<'_>,
@@ -2011,7 +2011,7 @@ pub(crate) fn dot_general_blas_read_into_accum_cached(
             if let (ContractionScalar::$owned(alpha), ContractionScalar::$owned(beta)) =
                 (accumulation.alpha, accumulation.beta)
             {
-                match (&lhs, &rhs, &mut *out) {
+                match (lhs, rhs, &mut *out) {
                     (
                         TensorRead::Tensor(crate::Tensor::$owned(a)),
                         TensorRead::Tensor(crate::Tensor::$owned(b)),
@@ -2167,8 +2167,8 @@ pub(crate) fn dot_general_blas_read_into_accum_cached(
 
 #[cfg(feature = "cpu-blas")]
 pub(crate) fn grouped_gemm_blas_cached(
-    lhs: TensorRead<'_>,
-    rhs: TensorRead<'_>,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
     config: &GroupedGemmConfig<'_>,
     out: &mut TensorWrite<'_>,
 ) -> crate::Result<bool> {
@@ -2177,7 +2177,7 @@ pub(crate) fn grouped_gemm_blas_cached(
             if let (ContractionScalar::$owned(alpha), ContractionScalar::$owned(beta)) =
                 (config.accumulation().alpha, config.accumulation().beta)
             {
-                match (&lhs, &rhs, &mut *out) {
+                match (lhs, rhs, &mut *out) {
                     (
                         TensorRead::Tensor(crate::Tensor::$owned(a)),
                         TensorRead::Tensor(crate::Tensor::$owned(b)),
@@ -2647,13 +2647,13 @@ where
 #[cfg(feature = "cpu-tblis-provider")]
 pub(crate) fn dot_general_tblis_read_cached(
     buffers: &mut BufferPool,
-    lhs: TensorRead<'_>,
-    rhs: TensorRead<'_>,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
     config: &DotGeneralConfig,
 ) -> crate::Result<Option<crate::Tensor>> {
     macro_rules! dispatch {
         ($owned:ident, $view:ident, $wrap:ident) => {
-            match (&lhs, &rhs) {
+            match (lhs, rhs) {
                 (
                     TensorRead::Tensor(crate::Tensor::$owned(a)),
                     TensorRead::Tensor(crate::Tensor::$owned(b)),
@@ -2708,8 +2708,8 @@ pub(crate) fn dot_general_tblis_read_cached(
 // and output-write metadata for one TBLIS dispatch.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn dot_general_tblis_read_into_accum_cached(
-    lhs: TensorRead<'_>,
-    rhs: TensorRead<'_>,
+    lhs: &TensorRead<'_>,
+    rhs: &TensorRead<'_>,
     config: &DotGeneralConfig,
     accumulation: DotGeneralAccumulation,
     out: &mut TensorWrite<'_>,
@@ -2725,7 +2725,7 @@ pub(crate) fn dot_general_tblis_read_into_accum_cached(
                     accumulation.lhs_conj,
                     accumulation.rhs_conj,
                 );
-                match (&lhs, &rhs, &mut *out) {
+                match (lhs, rhs, &mut *out) {
                     (
                         TensorRead::Tensor(crate::Tensor::$owned(a)),
                         TensorRead::Tensor(crate::Tensor::$owned(b)),

--- a/crates/tenferro-cpu/src/gemm/tests.rs
+++ b/crates/tenferro-cpu/src/gemm/tests.rs
@@ -290,8 +290,8 @@ fn faer_read_transposed_view_uses_strided_dot_without_materializing_input() {
         &mut cache,
         Some(0),
         &ctx,
-        TensorRead::from_view(TensorView::F64(lhs_view)),
-        TensorRead::from_tensor(&rhs),
+        &TensorRead::from_view(TensorView::F64(lhs_view)),
+        &TensorRead::from_tensor(&rhs),
         &config,
     )
     .unwrap()

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -111,7 +111,8 @@ macro_rules! dispatch_same_dtype_without_bool_result {
     };
 }
 
-fn with_local_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
+#[cfg(test)]
+fn with_test_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
     let mut buffers = BufferPool::new();
     f(&mut buffers)
 }
@@ -160,12 +161,13 @@ where
     Ok(out)
 }
 
-pub fn gather(
+#[cfg(test)]
+pub(crate) fn gather(
     operand: &Tensor,
     start_indices: &Tensor,
     config: &GatherConfig,
 ) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| gather_with_pool(buffers, operand, start_indices, config))
+    with_test_pool(|buffers| gather_with_pool(buffers, operand, start_indices, config))
 }
 
 pub(crate) fn gather_with_pool(
@@ -183,13 +185,14 @@ pub(crate) fn gather_with_pool(
     ))
 }
 
-pub fn scatter(
+#[cfg(test)]
+pub(crate) fn scatter(
     operand: &Tensor,
     scatter_indices: &Tensor,
     updates: &Tensor,
     config: &ScatterConfig,
 ) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| scatter_with_pool(buffers, operand, scatter_indices, updates, config))
+    with_test_pool(|buffers| scatter_with_pool(buffers, operand, scatter_indices, updates, config))
 }
 
 pub(crate) fn scatter_with_pool(
@@ -217,12 +220,13 @@ pub(crate) fn try_slice_with_pool(
     dispatch_tensor_unary_result!(input, |t| typed_slice(buffers, t, config))
 }
 
-pub fn dynamic_slice(
+#[cfg(test)]
+pub(crate) fn dynamic_slice(
     input: &Tensor,
     starts: &Tensor,
     slice_sizes: &[usize],
 ) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| dynamic_slice_with_pool(buffers, input, starts, slice_sizes))
+    with_test_pool(|buffers| dynamic_slice_with_pool(buffers, input, starts, slice_sizes))
 }
 
 pub(crate) fn dynamic_slice_with_pool(
@@ -259,12 +263,13 @@ pub(crate) fn dynamic_slice_with_pool(
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[0.0, 0.0, 0.0, 3.0, 4.0]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
-pub fn dynamic_update_slice(
+#[cfg(test)]
+pub(crate) fn dynamic_update_slice(
     operand: &Tensor,
     update: &Tensor,
     starts: &Tensor,
 ) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| dynamic_update_slice_with_pool(buffers, operand, update, starts))
+    with_test_pool(|buffers| dynamic_update_slice_with_pool(buffers, operand, update, starts))
 }
 
 pub(crate) fn dynamic_update_slice_with_pool(
@@ -279,12 +284,14 @@ pub(crate) fn dynamic_update_slice_with_pool(
     })
 }
 
-pub fn pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
+#[cfg(test)]
+pub(crate) fn pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
     try_pad(input, config)
 }
 
+#[cfg(test)]
 fn try_pad(input: &Tensor, config: &PadConfig) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| try_pad_with_pool(buffers, input, config))
+    with_test_pool(|buffers| try_pad_with_pool(buffers, input, config))
 }
 
 pub(crate) fn try_pad_with_pool(

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Examples
 //!
 //! ```rust
-//! use tenferro_cpu::{add, CpuBackend};
+//! use tenferro_cpu::CpuBackend;
 //! use tenferro_tensor::{Tensor, TensorBackend, TensorElementwise};
 //!
 //! let mut backend = CpuBackend::new();
@@ -11,8 +11,6 @@
 //! let b = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0])?;
 //! let c = backend.add(&a, &b)?;
 //! assert_eq!(c.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
-//! let direct = add(&a, &b)?;
-//! assert_eq!(direct.shape(), &[2]);
 //! # Ok::<(), tenferro_tensor::Error>(())
 //! ```
 
@@ -91,7 +89,6 @@ extern crate lapack_src as _;
 extern crate tblis_src as _;
 
 pub use affinity::{available_parallelism, process_cpu_affinity, process_cpu_affinity_count};
-pub use analytic::pow;
 pub use backend::{
     CpuBackend, CpuBackendError, CpuBackendKind, CpuExecutionInfo, CpuExecutionMode,
     DotGeneralProvider,
@@ -99,18 +96,27 @@ pub use backend::{
 pub use buffer_pool::BufferPoolStats;
 pub use capability::cpu_capabilities;
 pub use context::{CpuContext, CpuContextError};
-pub use elementwise::{
-    abs, add, clamp, compare, conj, div, maximum, minimum, mul, neg, rem, select, sign, sub,
-};
-pub use indexing::{dynamic_slice, dynamic_update_slice, gather, pad, scatter};
 pub use placement::{CpuPlacement, CpuPlacementError, ResolvedCpuPlacement};
-pub use reduction::{reduce_max, reduce_min, reduce_prod, reduce_sum};
-pub use structural::{
-    broadcast_in_dim, convert, embed_diagonal, extract_diagonal, reshape, transpose, tril, triu,
-};
 pub use topology::{
     discover_cpu_topology, CpuId, CpuNode, CpuSet, CpuSetError, CpuTopology, CpuTopologyError,
     NumaNodeId,
+};
+
+// Unit tests exercise the pool-aware kernels through the former convenience
+// names without restoring those names to the production crate surface.
+#[cfg(test)]
+pub(crate) use analytic::pow;
+#[cfg(test)]
+pub(crate) use elementwise::{
+    abs, add, clamp, compare, conj, div, maximum, minimum, mul, neg, rem, select, sign, sub,
+};
+#[cfg(test)]
+pub(crate) use indexing::{dynamic_slice, dynamic_update_slice, gather, pad, scatter};
+#[cfg(test)]
+pub(crate) use reduction::{reduce_max, reduce_min, reduce_prod, reduce_sum};
+#[cfg(test)]
+pub(crate) use structural::{
+    broadcast_in_dim, embed_diagonal, extract_diagonal, reshape, transpose, tril, triu,
 };
 
 /// Owner-scoped CPU scratch-pool API for operation-family crates.

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -15,7 +15,8 @@ use super::{
     typed_view, typed_view_from_view,
 };
 
-fn with_local_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
+#[cfg(test)]
+fn with_test_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
     let mut buffers = BufferPool::new();
     f(&mut buffers)
 }
@@ -180,8 +181,9 @@ where
     )
 }
 
-pub fn transpose(input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| transpose_with_pool(buffers, input, perm))
+#[cfg(test)]
+pub(crate) fn transpose(input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| transpose_with_pool(buffers, input, perm))
 }
 
 pub(crate) fn transpose_with_pool(
@@ -192,12 +194,17 @@ pub(crate) fn transpose_with_pool(
     dispatch_tensor_unary_result!(input, |t| typed_transpose_with_pool(buffers, t, perm))
 }
 
-pub fn reshape(input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
+pub(crate) fn reshape(input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
     dispatch_tensor_unary_result!(input, |t| typed_reshape(t, shape))
 }
 
-pub fn broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| broadcast_in_dim_with_pool(buffers, input, shape, dims))
+#[cfg(test)]
+pub(crate) fn broadcast_in_dim(
+    input: &Tensor,
+    shape: &[usize],
+    dims: &[usize],
+) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| broadcast_in_dim_with_pool(buffers, input, shape, dims))
 }
 
 pub(crate) fn broadcast_in_dim_with_pool(
@@ -232,10 +239,12 @@ pub(crate) fn broadcast_in_dim_with_pool(
 ///
 /// Returns an error when the requested conversion is outside tenferro's checked
 /// dtype-promotion lattice.
-pub fn convert(input: &Tensor, to: DType) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| convert_with_pool(buffers, input, to))
+#[cfg(test)]
+pub(crate) fn convert(input: &Tensor, to: DType) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| convert_with_pool(buffers, input, to))
 }
 
+#[cfg(test)]
 pub(crate) fn convert_with_pool(
     buffers: &mut BufferPool,
     input: &Tensor,
@@ -413,8 +422,13 @@ fn invalid_cast_value(message: String) -> crate::Error {
     }
 }
 
-pub fn extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| extract_diagonal_with_pool(buffers, input, axis_a, axis_b))
+#[cfg(test)]
+pub(crate) fn extract_diagonal(
+    input: &Tensor,
+    axis_a: usize,
+    axis_b: usize,
+) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| extract_diagonal_with_pool(buffers, input, axis_a, axis_b))
 }
 
 pub(crate) fn extract_diagonal_with_pool(
@@ -428,8 +442,13 @@ pub(crate) fn extract_diagonal_with_pool(
     ))
 }
 
-pub fn embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| embed_diagonal_with_pool(buffers, input, axis_a, axis_b))
+#[cfg(test)]
+pub(crate) fn embed_diagonal(
+    input: &Tensor,
+    axis_a: usize,
+    axis_b: usize,
+) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| embed_diagonal_with_pool(buffers, input, axis_a, axis_b))
 }
 
 pub(crate) fn embed_diagonal_with_pool(
@@ -448,8 +467,9 @@ pub(crate) fn embed_diagonal_with_pool(
     )
 }
 
-pub fn tril(input: &Tensor, k: i64) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| tril_with_pool(buffers, input, k))
+#[cfg(test)]
+pub(crate) fn tril(input: &Tensor, k: i64) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| tril_with_pool(buffers, input, k))
 }
 
 pub(crate) fn tril_with_pool(
@@ -464,8 +484,9 @@ pub(crate) fn tril_with_pool(
     )
 }
 
-pub fn triu(input: &Tensor, k: i64) -> crate::Result<Tensor> {
-    with_local_pool(|buffers| triu_with_pool(buffers, input, k))
+#[cfg(test)]
+pub(crate) fn triu(input: &Tensor, k: i64) -> crate::Result<Tensor> {
+    with_test_pool(|buffers| triu_with_pool(buffers, input, k))
 }
 
 pub(crate) fn triu_with_pool(

--- a/crates/tenferro-cpu/tests/backend_capability_contracts.rs
+++ b/crates/tenferro-cpu/tests/backend_capability_contracts.rs
@@ -107,3 +107,32 @@ fn gather_scatter_index_component_reuses_index_scratch() {
         "gather/scatter should carry reusable index scratch through index_component"
     );
 }
+
+#[test]
+fn cpu_public_ops_require_backend_owner() {
+    let lib_source = include_str!("../src/lib.rs");
+    for reexport in [
+        "pub use analytic::pow;",
+        "pub use elementwise::",
+        "pub use indexing::",
+        "pub use reduction::",
+        "pub use structural::",
+    ] {
+        assert!(
+            !lib_source.contains(reexport),
+            "resource-bypassing reexport remains: {reexport}"
+        );
+    }
+
+    for (module, source) in [
+        ("analytic", include_str!("../src/analytic.rs")),
+        ("elementwise", include_str!("../src/elementwise.rs")),
+        ("indexing", include_str!("../src/indexing.rs")),
+        ("structural", include_str!("../src/structural.rs")),
+    ] {
+        assert!(
+            !source.contains("fn with_local_pool"),
+            "{module} still constructs a throwaway BufferPool"
+        );
+    }
+}

--- a/crates/tenferro-cpu/tests/backend_capability_contracts.rs
+++ b/crates/tenferro-cpu/tests/backend_capability_contracts.rs
@@ -136,3 +136,22 @@ fn cpu_public_ops_require_backend_owner() {
         );
     }
 }
+
+#[test]
+fn install_pool_has_no_placeholder_construction_or_gemm_descriptor_clones() {
+    let backend_source = include_str!("../src/backend.rs");
+    let buffer_pool_source = include_str!("../src/buffer_pool.rs");
+    let gemm_source = include_str!("../src/gemm/mod.rs");
+    let exec_session_source = include_str!("../src/exec_session.rs");
+
+    assert!(!backend_source.contains("std::mem::take(target)"));
+    assert!(backend_source.contains("buffers: &'a mut BufferPool"));
+    assert!(buffer_pool_source.contains("OnceLock"));
+    assert!(buffer_pool_source.contains("parse_default_max_retained_capacity_bytes"));
+    assert!(gemm_source.contains("lhs: &TensorRead<'_>"));
+    assert!(gemm_source.contains("rhs: &TensorRead<'_>"));
+    assert!(!backend_source.contains("lhs.clone()"));
+    assert!(!backend_source.contains("rhs.clone()"));
+    assert!(!exec_session_source.contains("lhs.clone()"));
+    assert!(!exec_session_source.contains("rhs.clone()"));
+}

--- a/crates/tenferro-einsum/src/concrete.rs
+++ b/crates/tenferro-einsum/src/concrete.rs
@@ -2,7 +2,7 @@
 
 use tenferro_tensor::{
     DType, DotGeneralAccumulation, Error, Result, Tensor, TensorBackend, TensorRead, TensorScalar,
-    TensorWrite, TypedTensor, TypedTensorView,
+    TensorWrite, TypedTensor, TypedTensorView, TypedTensorWrite,
 };
 
 use crate::eager::{
@@ -18,6 +18,8 @@ const TENSOR_READ_EINSUM_OP: &str = "TensorReadEinsumExt::einsum_read";
 const TENSOR_READ_EINSUM_INTO_OP: &str = "TensorReadEinsumIntoExt::einsum_read_into";
 const TYPED_TENSOR_EINSUM_OP: &str = "TypedTensorEinsumExt::einsum";
 const TYPED_TENSOR_EINSUM_INTO_OP: &str = "TypedTensorEinsumIntoExt::einsum_into";
+const TYPED_TENSOR_READ_EINSUM_OP: &str = "TypedTensorReadEinsumExt::einsum_read";
+const TYPED_TENSOR_READ_EINSUM_INTO_OP: &str = "TypedTensorReadEinsumIntoExt::einsum_read_into";
 const PLAN_PREPARE_OP: &str = "ConcreteEinsumPlan::prepare";
 const PLAN_EXECUTE_OP: &str = "ConcreteEinsumPlan::execute";
 
@@ -217,160 +219,231 @@ impl<T: TensorScalar, const N: usize> TypedTensorEinsumExt<T> for [&TypedTensor<
     }
 }
 
-impl<'a, T: TensorScalar> TypedTensorEinsumExt<T> for [TypedTensorView<'a, T>] {
-    fn einsum<B: TensorBackend>(
+/// Backend-explicit einsum methods for typed borrowed views.
+///
+/// The `_read` suffix distinguishes this borrowed-view surface from
+/// [`TypedTensorEinsumExt`], whose unsuffixed methods accept only owned compact
+/// typed tensors.
+pub trait TypedTensorReadEinsumExt<T: TensorScalar> {
+    /// Execute an einsum from string notation over typed borrowed views.
+    fn einsum_read<B: TensorBackend>(
+        &self,
+        subscripts: &str,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>>;
+
+    /// Execute an einsum from parsed integer-label subscripts over typed
+    /// borrowed views.
+    fn einsum_read_subscripts<B: TensorBackend>(
+        &self,
+        subscripts: &EinsumSubscripts,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>>;
+}
+
+impl<'a, T: TensorScalar> TypedTensorReadEinsumExt<T> for [TypedTensorView<'a, T>] {
+    fn einsum_read<B: TensorBackend>(
         &self,
         subscripts: &str,
         backend: &mut B,
     ) -> Result<TypedTensor<T>> {
-        let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_EINSUM_OP)?;
-        typed_view_einsum_subscripts(backend, self, &subscripts, TYPED_TENSOR_EINSUM_OP)
+        let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_READ_EINSUM_OP)?;
+        typed_view_einsum_subscripts(backend, self, &subscripts, TYPED_TENSOR_READ_EINSUM_OP)
     }
 
-    fn einsum_subscripts<B: TensorBackend>(
+    fn einsum_read_subscripts<B: TensorBackend>(
         &self,
         subscripts: &EinsumSubscripts,
         backend: &mut B,
     ) -> Result<TypedTensor<T>> {
         let subscripts = Subscripts::from(subscripts);
-        typed_view_einsum_subscripts(backend, self, &subscripts, TYPED_TENSOR_EINSUM_OP)
+        typed_view_einsum_subscripts(backend, self, &subscripts, TYPED_TENSOR_READ_EINSUM_OP)
     }
 }
 
-impl<'a, T: TensorScalar, const N: usize> TypedTensorEinsumExt<T> for [TypedTensorView<'a, T>; N] {
-    fn einsum<B: TensorBackend>(
+impl<'a, T: TensorScalar, const N: usize> TypedTensorReadEinsumExt<T>
+    for [TypedTensorView<'a, T>; N]
+{
+    fn einsum_read<B: TensorBackend>(
         &self,
         subscripts: &str,
         backend: &mut B,
     ) -> Result<TypedTensor<T>> {
-        self.as_slice().einsum(subscripts, backend)
+        self.as_slice().einsum_read(subscripts, backend)
     }
 
-    fn einsum_subscripts<B: TensorBackend>(
+    fn einsum_read_subscripts<B: TensorBackend>(
         &self,
         subscripts: &EinsumSubscripts,
         backend: &mut B,
     ) -> Result<TypedTensor<T>> {
-        self.as_slice().einsum_subscripts(subscripts, backend)
+        self.as_slice().einsum_read_subscripts(subscripts, backend)
     }
 }
 
 /// Backend-explicit preallocated-output einsum methods for typed concrete tensors.
 pub trait TypedTensorEinsumIntoExt<T: TensorScalar> {
     /// Execute an einsum from string notation into caller-provided typed output.
-    fn einsum_into<B: TensorBackend>(
-        &self,
-        subscripts: &str,
-        backend: &mut B,
-        out: &mut TypedTensor<T>,
-    ) -> Result<()>;
+    fn einsum_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
+    where
+        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>;
 
     /// Execute an einsum from parsed integer-label subscripts into caller-provided typed output.
-    fn einsum_into_subscripts<B: TensorBackend>(
+    fn einsum_into_subscripts<'out, B, O>(
         &self,
         subscripts: &EinsumSubscripts,
         backend: &mut B,
-        out: &mut TypedTensor<T>,
-    ) -> Result<()>;
+        out: O,
+    ) -> Result<()>
+    where
+        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>;
 }
 
 impl<T: TensorScalar> TypedTensorEinsumIntoExt<T> for [&TypedTensor<T>] {
-    fn einsum_into<B: TensorBackend>(
-        &self,
-        subscripts: &str,
-        backend: &mut B,
-        out: &mut TypedTensor<T>,
-    ) -> Result<()> {
+    fn einsum_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
+    where
+        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
         let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_EINSUM_INTO_OP)?;
-        typed_einsum_into_subscripts(backend, self, &subscripts, out, TYPED_TENSOR_EINSUM_INTO_OP)
+        typed_einsum_into_subscripts(
+            backend,
+            self,
+            &subscripts,
+            out.into(),
+            TYPED_TENSOR_EINSUM_INTO_OP,
+        )
     }
 
-    fn einsum_into_subscripts<B: TensorBackend>(
+    fn einsum_into_subscripts<'out, B, O>(
         &self,
         subscripts: &EinsumSubscripts,
         backend: &mut B,
-        out: &mut TypedTensor<T>,
-    ) -> Result<()> {
+        out: O,
+    ) -> Result<()>
+    where
+        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
         let subscripts = Subscripts::from(subscripts);
-        typed_einsum_into_subscripts(backend, self, &subscripts, out, TYPED_TENSOR_EINSUM_INTO_OP)
+        typed_einsum_into_subscripts(
+            backend,
+            self,
+            &subscripts,
+            out.into(),
+            TYPED_TENSOR_EINSUM_INTO_OP,
+        )
     }
 }
 
 impl<T: TensorScalar, const N: usize> TypedTensorEinsumIntoExt<T> for [&TypedTensor<T>; N] {
-    fn einsum_into<B: TensorBackend>(
-        &self,
-        subscripts: &str,
-        backend: &mut B,
-        out: &mut TypedTensor<T>,
-    ) -> Result<()> {
+    fn einsum_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
+    where
+        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
         self.as_slice().einsum_into(subscripts, backend, out)
     }
 
-    fn einsum_into_subscripts<B: TensorBackend>(
+    fn einsum_into_subscripts<'out, B, O>(
         &self,
         subscripts: &EinsumSubscripts,
         backend: &mut B,
-        out: &mut TypedTensor<T>,
-    ) -> Result<()> {
+        out: O,
+    ) -> Result<()>
+    where
+        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
         self.as_slice()
             .einsum_into_subscripts(subscripts, backend, out)
     }
 }
 
-impl<'a, T: TensorScalar> TypedTensorEinsumIntoExt<T> for [TypedTensorView<'a, T>] {
-    fn einsum_into<B: TensorBackend>(
+/// Backend-explicit preallocated-output einsum methods for typed borrowed views.
+pub trait TypedTensorReadEinsumIntoExt<T: TensorScalar> {
+    /// Execute an einsum from string notation over typed borrowed views into a
+    /// caller-provided typed output.
+    fn einsum_read_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
+    where
+        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>;
+
+    /// Execute an einsum from parsed integer-label subscripts over typed
+    /// borrowed views into a caller-provided typed output.
+    fn einsum_read_into_subscripts<'out, B, O>(
         &self,
-        subscripts: &str,
+        subscripts: &EinsumSubscripts,
         backend: &mut B,
-        out: &mut TypedTensor<T>,
-    ) -> Result<()> {
-        let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_EINSUM_INTO_OP)?;
+        out: O,
+    ) -> Result<()>
+    where
+        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>;
+}
+
+impl<'a, T: TensorScalar> TypedTensorReadEinsumIntoExt<T> for [TypedTensorView<'a, T>] {
+    fn einsum_read_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
+    where
+        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
+        let subscripts = parse_subscripts(subscripts, TYPED_TENSOR_READ_EINSUM_INTO_OP)?;
         typed_view_einsum_into_subscripts(
             backend,
             self,
             &subscripts,
-            out,
-            TYPED_TENSOR_EINSUM_INTO_OP,
+            out.into(),
+            TYPED_TENSOR_READ_EINSUM_INTO_OP,
         )
     }
 
-    fn einsum_into_subscripts<B: TensorBackend>(
+    fn einsum_read_into_subscripts<'out, B, O>(
         &self,
         subscripts: &EinsumSubscripts,
         backend: &mut B,
-        out: &mut TypedTensor<T>,
-    ) -> Result<()> {
+        out: O,
+    ) -> Result<()>
+    where
+        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
         let subscripts = Subscripts::from(subscripts);
         typed_view_einsum_into_subscripts(
             backend,
             self,
             &subscripts,
-            out,
-            TYPED_TENSOR_EINSUM_INTO_OP,
+            out.into(),
+            TYPED_TENSOR_READ_EINSUM_INTO_OP,
         )
     }
 }
 
-impl<'a, T: TensorScalar, const N: usize> TypedTensorEinsumIntoExt<T>
+impl<'a, T: TensorScalar, const N: usize> TypedTensorReadEinsumIntoExt<T>
     for [TypedTensorView<'a, T>; N]
 {
-    fn einsum_into<B: TensorBackend>(
-        &self,
-        subscripts: &str,
-        backend: &mut B,
-        out: &mut TypedTensor<T>,
-    ) -> Result<()> {
-        self.as_slice().einsum_into(subscripts, backend, out)
+    fn einsum_read_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
+    where
+        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
+        self.as_slice().einsum_read_into(subscripts, backend, out)
     }
 
-    fn einsum_into_subscripts<B: TensorBackend>(
+    fn einsum_read_into_subscripts<'out, B, O>(
         &self,
         subscripts: &EinsumSubscripts,
         backend: &mut B,
-        out: &mut TypedTensor<T>,
-    ) -> Result<()> {
+        out: O,
+    ) -> Result<()>
+    where
+        B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>,
+    {
         self.as_slice()
-            .einsum_into_subscripts(subscripts, backend, out)
+            .einsum_read_into_subscripts(subscripts, backend, out)
     }
 }
 
@@ -671,21 +744,22 @@ impl ConcreteEinsumPlan {
     }
 
     /// Execute this plan on typed concrete tensor inputs into caller-provided output.
-    pub fn execute_typed_into<'a, T, I, B>(
+    pub fn execute_typed_into<'a, 'out, T, I, B, O>(
         &self,
         inputs: I,
         backend: &mut B,
-        out: &mut TypedTensor<T>,
+        out: O,
     ) -> Result<()>
     where
         T: TensorScalar,
         I: AsRef<[&'a TypedTensor<T>]>,
         B: TensorBackend,
+        O: Into<TypedTensorWrite<'out, T>>,
     {
         let inputs = inputs.as_ref();
         let specs = typed_input_specs(inputs);
         self.validate_inputs(&specs, PLAN_EXECUTE_OP)?;
-        let out = T::tensor_write(out);
+        let out = out.into().into_tensor_write();
         validate_output(&self.inputs, &self.tree, &out, PLAN_EXECUTE_OP)?;
         let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
         backend
@@ -892,12 +966,12 @@ fn typed_view_einsum_into_subscripts<T: TensorScalar>(
     backend: &mut impl TensorBackend,
     inputs: &[TypedTensorView<'_, T>],
     subscripts: &Subscripts,
-    out: &mut TypedTensor<T>,
+    out: TypedTensorWrite<'_, T>,
     op: &'static str,
 ) -> Result<()> {
     let specs = typed_view_input_specs(inputs);
     let plan = ConcreteEinsumPlan::prepare_subscripts_internal(specs.clone(), subscripts)?;
-    let out = T::tensor_write(out);
+    let out = out.into_tensor_write();
     validate_output(&specs, &plan.tree, &out, op)?;
     let reads: Vec<_> = inputs
         .iter()
@@ -911,12 +985,12 @@ fn typed_einsum_into_subscripts<T: TensorScalar>(
     backend: &mut impl TensorBackend,
     inputs: &[&TypedTensor<T>],
     subscripts: &Subscripts,
-    out: &mut TypedTensor<T>,
+    out: TypedTensorWrite<'_, T>,
     op: &'static str,
 ) -> Result<()> {
     let specs = typed_input_specs(inputs);
     let plan = ConcreteEinsumPlan::prepare_subscripts_internal(specs.clone(), subscripts)?;
-    let out = T::tensor_write(out);
+    let out = out.into_tensor_write();
     validate_output(&specs, &plan.tree, &out, op)?;
     let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
     backend.with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))

--- a/crates/tenferro-einsum/src/concrete.rs
+++ b/crates/tenferro-einsum/src/concrete.rs
@@ -224,8 +224,37 @@ impl<T: TensorScalar, const N: usize> TypedTensorEinsumExt<T> for [&TypedTensor<
 /// The `_read` suffix distinguishes this borrowed-view surface from
 /// [`TypedTensorEinsumExt`], whose unsuffixed methods accept only owned compact
 /// typed tensors.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_einsum::TypedTensorReadEinsumExt;
+/// use tenferro_tensor::TypedTensor;
+///
+/// let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0])?;
+/// let rhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0])?;
+/// let mut backend = CpuBackend::new();
+/// let result = [lhs.as_view(), rhs.as_view()].einsum_read("i,i->", &mut backend)?;
+/// assert_eq!(result.as_slice()?, &[11.0]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
 pub trait TypedTensorReadEinsumExt<T: TensorScalar> {
     /// Execute an einsum from string notation over typed borrowed views.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_einsum::TypedTensorReadEinsumExt;
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let input = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 3.0])?;
+    /// let mut backend = CpuBackend::new();
+    /// let result = [input.as_view()].einsum_read("i->i", &mut backend)?;
+    /// assert_eq!(result.as_slice()?, &[2.0, 3.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn einsum_read<B: TensorBackend>(
         &self,
         subscripts: &str,
@@ -234,6 +263,21 @@ pub trait TypedTensorReadEinsumExt<T: TensorScalar> {
 
     /// Execute an einsum from parsed integer-label subscripts over typed
     /// borrowed views.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_einsum::{EinsumSubscripts, TypedTensorReadEinsumExt};
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let input = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 3.0])?;
+    /// let subscripts = EinsumSubscripts::new(&[&[0]], &[0]);
+    /// let mut backend = CpuBackend::new();
+    /// let result = [input.as_view()].einsum_read_subscripts(&subscripts, &mut backend)?;
+    /// assert_eq!(result.as_slice()?, &[2.0, 3.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn einsum_read_subscripts<B: TensorBackend>(
         &self,
         subscripts: &EinsumSubscripts,
@@ -363,9 +407,40 @@ impl<T: TensorScalar, const N: usize> TypedTensorEinsumIntoExt<T> for [&TypedTen
 }
 
 /// Backend-explicit preallocated-output einsum methods for typed borrowed views.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_einsum::TypedTensorReadEinsumIntoExt;
+/// use tenferro_tensor::TypedTensor;
+///
+/// let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0])?;
+/// let rhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0])?;
+/// let mut output = TypedTensor::<f64>::from_vec_col_major(vec![], vec![0.0])?;
+/// let mut backend = CpuBackend::new();
+/// [lhs.as_view(), rhs.as_view()].einsum_read_into("i,i->", &mut backend, &mut output)?;
+/// assert_eq!(output.as_slice()?, &[11.0]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
 pub trait TypedTensorReadEinsumIntoExt<T: TensorScalar> {
     /// Execute an einsum from string notation over typed borrowed views into a
     /// caller-provided typed output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_einsum::TypedTensorReadEinsumIntoExt;
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let input = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 3.0])?;
+    /// let mut output = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0; 2])?;
+    /// let mut backend = CpuBackend::new();
+    /// [input.as_view()].einsum_read_into("i->i", &mut backend, &mut output)?;
+    /// assert_eq!(output.as_slice()?, &[2.0, 3.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn einsum_read_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
     where
         B: TensorBackend,
@@ -373,6 +448,22 @@ pub trait TypedTensorReadEinsumIntoExt<T: TensorScalar> {
 
     /// Execute an einsum from parsed integer-label subscripts over typed
     /// borrowed views into a caller-provided typed output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_einsum::{EinsumSubscripts, TypedTensorReadEinsumIntoExt};
+    /// use tenferro_tensor::TypedTensor;
+    ///
+    /// let input = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![2.0, 3.0])?;
+    /// let mut output = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0; 2])?;
+    /// let subscripts = EinsumSubscripts::new(&[&[0]], &[0]);
+    /// let mut backend = CpuBackend::new();
+    /// [input.as_view()].einsum_read_into_subscripts(&subscripts, &mut backend, &mut output)?;
+    /// assert_eq!(output.as_slice()?, &[2.0, 3.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn einsum_read_into_subscripts<'out, B, O>(
         &self,
         subscripts: &EinsumSubscripts,

--- a/crates/tenferro-einsum/src/concrete_tests.rs
+++ b/crates/tenferro-einsum/src/concrete_tests.rs
@@ -2,12 +2,13 @@ use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{
     ContractionScalar, DType, DotGeneralAccumulation, Tensor, TensorRead, TensorView,
-    TensorViewMut, TensorWrite, TypedTensor, TypedTensorView, TypedTensorViewMut,
+    TensorViewMut, TensorWrite, TypedTensor, TypedTensorView, TypedTensorViewMut, TypedTensorWrite,
 };
 
 use crate::{
     parse_einsum_subscripts, ConcreteEinsumPlan, TensorEinsumExt, TensorEinsumIntoExt,
     TensorReadEinsumExt, TensorReadEinsumIntoExt, TypedTensorEinsumExt, TypedTensorEinsumIntoExt,
+    TypedTensorReadEinsumExt, TypedTensorReadEinsumIntoExt,
 };
 
 fn assert_f64_tensor(tensor: &Tensor, shape: &[usize], expected: &[f64]) {
@@ -117,7 +118,7 @@ fn public_typed_tensor_einsum_ext_accepts_slice_and_integer_subscripts() {
 }
 
 #[test]
-fn public_typed_tensor_einsum_ext_accepts_borrowed_strided_complex_views() {
+fn public_typed_tensor_read_einsum_ext_accepts_borrowed_strided_complex_views() {
     let mut backend = CpuBackend::new();
     let matrix_data = [
         Complex64::new(1.0, 0.0),
@@ -139,10 +140,10 @@ fn public_typed_tensor_einsum_ext_accepts_borrowed_strided_complex_views() {
             .unwrap();
 
     let result = [matrix_view.clone(), vector_view.clone()]
-        .einsum("ij,j->i", &mut backend)
+        .einsum_read("ij,j->i", &mut backend)
         .unwrap();
     [matrix_view, vector_view]
-        .einsum_into("ij,j->i", &mut backend, &mut out)
+        .einsum_read_into("ij,j->i", &mut backend, &mut out)
         .unwrap();
 
     assert_eq!(
@@ -224,6 +225,23 @@ fn public_einsum_into_writes_dynamic_typed_and_read_outputs() {
         .einsum_into("ij,jk->ik", &mut backend, &mut typed_out)
         .unwrap();
     assert_eq!(typed_out.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+
+    let mut typed_strided_data = [-1.0_f64; 8];
+    {
+        let out_view =
+            TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut typed_strided_data).unwrap();
+        [&typed_lhs, &typed_rhs]
+            .einsum_into(
+                "ij,jk->ik",
+                &mut backend,
+                TypedTensorWrite::from_view(out_view),
+            )
+            .unwrap();
+    }
+    assert_eq!(
+        typed_strided_data,
+        [-1.0, 22.0, 28.0, -1.0, 49.0, 64.0, -1.0, -1.0]
+    );
 
     let mut strided_data = [-1.0_f64; 8];
     {
@@ -436,6 +454,22 @@ fn concrete_einsum_plan_execute_typed_and_read_into_outputs() {
     plan.execute_typed_into([&lhs, &rhs], &mut backend, &mut typed_out)
         .unwrap();
     assert_eq!(typed_out.as_slice().unwrap(), &[22.0, 28.0, 49.0, 64.0]);
+
+    let mut typed_strided_data = [-1.0_f64; 8];
+    {
+        let out_view =
+            TypedTensorViewMut::from_slice([2, 2], [1, 3], 1, &mut typed_strided_data).unwrap();
+        plan.execute_typed_into(
+            [&lhs, &rhs],
+            &mut backend,
+            TypedTensorWrite::from_view(out_view),
+        )
+        .unwrap();
+    }
+    assert_eq!(
+        typed_strided_data,
+        [-1.0, 22.0, 28.0, -1.0, 49.0, 64.0, -1.0, -1.0]
+    );
 
     let lhs_erased = Tensor::from(lhs.clone());
     let rhs_erased = Tensor::from(rhs.clone());

--- a/crates/tenferro-einsum/src/lib.rs
+++ b/crates/tenferro-einsum/src/lib.rs
@@ -13,8 +13,9 @@
 //! - **Tensordot sugar**: NumPy-style axis-pair contraction extension methods,
 //!   implemented as contraction sugar rather than as linear algebra APIs.
 //! - **Concrete execution**: backend-explicit [`TensorEinsumExt`],
-//!   [`TypedTensorEinsumExt`], [`TensorReadEinsumExt`], and
-//!   [`ConcreteEinsumPlan`] APIs for non-AD tensor values.
+//!   [`TypedTensorEinsumExt`], [`TensorReadEinsumExt`],
+//!   [`TypedTensorReadEinsumExt`], and [`ConcreteEinsumPlan`] APIs for non-AD
+//!   tensor values.
 //! - **Extension runtime**: traced einsum lowers to a registered tenferro
 //!   extension runtime, keeping core op definitions small.
 //! - **Tensor extension traits**: graph-building and immediate-execution
@@ -83,6 +84,7 @@ pub use cache::EINSUM_EXTENSION_FAMILY_ID;
 pub use concrete::{
     ConcreteEinsumPlan, TensorEinsumExt, TensorEinsumIntoExt, TensorReadEinsumExt,
     TensorReadEinsumIntoExt, TypedTensorEinsumExt, TypedTensorEinsumIntoExt,
+    TypedTensorReadEinsumExt, TypedTensorReadEinsumIntoExt,
 };
 #[cfg(feature = "autodiff")]
 pub use eager_ad::{EagerEinsumExt, EagerTensorEinsumExt};

--- a/crates/tenferro-einsum/tests/public_surface_contract.rs
+++ b/crates/tenferro-einsum/tests/public_surface_contract.rs
@@ -36,3 +36,28 @@ fn einsum_vjp_broadcast_active_mask_matches_dynamic_inputs() {
         "einsum VJP broadcast must not use a fixed two-input active_mask when rank-0 inputs omit shape_source"
     );
 }
+
+#[test]
+fn typed_einsum_view_inputs_use_read_suffix_and_typed_outputs_accept_views() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/concrete.rs");
+    let source = std::fs::read_to_string(root).expect("read concrete einsum source");
+
+    assert!(source.contains("pub trait TypedTensorReadEinsumExt"));
+    assert!(source.contains("fn einsum_read<B: TensorBackend>"));
+    assert!(source.contains("pub trait TypedTensorReadEinsumIntoExt"));
+    assert!(source.contains("fn einsum_read_into<'out, B, O>"));
+    assert!(source.contains("O: Into<TypedTensorWrite<'out, T>>"));
+
+    assert!(
+        !source.contains(
+            "impl<'a, T: TensorScalar> TypedTensorEinsumExt<T> for [TypedTensorView<'a, T>]"
+        ),
+        "borrowed typed inputs must not implement the unsuffixed einsum surface"
+    );
+    assert!(
+        !source.contains(
+            "impl<'a, T: TensorScalar> TypedTensorEinsumIntoExt<T> for [TypedTensorView<'a, T>]"
+        ),
+        "borrowed typed inputs must not implement the unsuffixed einsum_into surface"
+    );
+}

--- a/crates/tenferro-gpu/src/cubecl/fusion/codegen.rs
+++ b/crates/tenferro-gpu/src/cubecl/fusion/codegen.rs
@@ -1,7 +1,7 @@
 use cubecl::ir::{
     Arithmetic, BinaryOperator, Branch, Builtin, ClampOperator, Comparison, ElemType, If,
-    IndexAssignOperator, IndexOperator, Instruction, ManagedVariable, Metadata, Operator, Type,
-    UnaryOperator, Variable,
+    IndexAssignOperator, IndexOperator, Instruction, ManagedVariable, Metadata, Operator, Select,
+    Type, UnaryOperator, Variable,
 };
 use cubecl::prelude::{
     AddressType, CubeDim, CubeElement, CubePrimitive, KernelBuilder, KernelDefinition,
@@ -125,10 +125,10 @@ where
         }
         ElementwiseFusionOp::Abs => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Abs),
         ElementwiseFusionOp::Maximum => {
-            emit_binary_arithmetic(scope, &inputs[0], &inputs[1], Arithmetic::Max)
+            emit_nan_propagating_extrema(scope, &inputs[0], &inputs[1], Arithmetic::Max)
         }
         ElementwiseFusionOp::Minimum => {
-            emit_binary_arithmetic(scope, &inputs[0], &inputs[1], Arithmetic::Min)
+            emit_nan_propagating_extrema(scope, &inputs[0], &inputs[1], Arithmetic::Min)
         }
         ElementwiseFusionOp::Clamp => emit_clamp(scope, &inputs[0], &inputs[1], &inputs[2]),
         ElementwiseFusionOp::Exp => emit_unary_arithmetic(scope, &inputs[0], Arithmetic::Exp),
@@ -172,6 +172,51 @@ fn emit_binary_arithmetic(
     let rhs = rhs.clone().consume();
     let out = scope.create_local(lhs.ty);
     scope.register(Instruction::new(op(BinaryOperator { lhs, rhs }), *out));
+    out
+}
+
+fn emit_nan_propagating_extrema(
+    scope: &mut cubecl::prelude::Scope,
+    lhs: &ManagedVariable,
+    rhs: &ManagedVariable,
+    op: fn(BinaryOperator) -> Arithmetic,
+) -> ManagedVariable {
+    let extrema = emit_binary_arithmetic(scope, lhs, rhs, op);
+    let rhs_is_nan = emit_unary_comparison(scope, rhs, Comparison::IsNan);
+    let rhs_or_extrema = emit_select(scope, &rhs_is_nan, rhs, &extrema);
+    let lhs_is_nan = emit_unary_comparison(scope, lhs, Comparison::IsNan);
+    emit_select(scope, &lhs_is_nan, lhs, &rhs_or_extrema)
+}
+
+fn emit_unary_comparison(
+    scope: &mut cubecl::prelude::Scope,
+    input: &ManagedVariable,
+    op: fn(UnaryOperator) -> Comparison,
+) -> ManagedVariable {
+    let input = input.clone().consume();
+    let out = scope.create_local(Type::scalar(ElemType::Bool));
+    scope.register(Instruction::new(op(UnaryOperator { input }), *out));
+    out
+}
+
+fn emit_select(
+    scope: &mut cubecl::prelude::Scope,
+    condition: &ManagedVariable,
+    then: &ManagedVariable,
+    or_else: &ManagedVariable,
+) -> ManagedVariable {
+    let condition = condition.clone().consume();
+    let then = then.clone().consume();
+    let or_else = or_else.clone().consume();
+    let out = scope.create_local(then.ty);
+    scope.register(Instruction::new(
+        Operator::Select(Select {
+            cond: condition,
+            then,
+            or_else,
+        }),
+        *out,
+    ));
     out
 }
 

--- a/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
@@ -756,6 +756,45 @@ fn test_broadcast_multiply_scalar_operands_match_cpu() {
 
 #[test]
 #[ignore = "requires CUDA 12.8+ GPU"]
+fn test_broadcast_multiply_integer_overflow_matches_cpu_wrapping() {
+    if !gpu_available() {
+        eprintln!("skipping integer broadcast multiply parity test - no CUDA device found");
+        return;
+    }
+
+    let mut cpu = cpu_backend();
+    let mut gpu = gpu_backend();
+    for (scalar, vector) in [
+        (
+            tensor_i32(vec![], vec![i32::MAX]),
+            tensor_i32(vec![2], vec![2, -1]),
+        ),
+        (
+            tensor_i64(vec![], vec![i64::MAX]),
+            tensor_i64(vec![2], vec![2, -1]),
+        ),
+    ] {
+        let expected = cpu.mul(&scalar, &vector).unwrap();
+        let gpu_scalar = upload(&gpu, &scalar);
+        let gpu_vector = upload(&gpu, &vector);
+        let actual = gpu
+            .execute_broadcast_multiply(
+                TensorRead::from_tensor(&gpu_scalar),
+                &[2],
+                &[],
+                TensorRead::from_tensor(&gpu_vector),
+                &[2],
+                &[0],
+            )
+            .unwrap()
+            .expect("integer broadcast multiply should fuse");
+
+        assert_tensor_close(&download(&gpu, &actual), &expected, 0.0);
+    }
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
 fn test_log1p_small_x_f32_precision() {
     if !gpu_available() {
         eprintln!("skipping test_log1p_small_x_f32_precision — no CUDA device found");
@@ -864,6 +903,45 @@ fn test_cubecl_binary_float_elementwise_matches_cpu() {
     let gpu_out = gpu.pow(&gpu_base, &gpu_exp).unwrap();
     let actual = download(&gpu, &gpu_out);
     assert_tensor_close(&actual, &expected, 1e-12);
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn test_cubecl_maximum_minimum_propagate_nan_independent_of_argument_order() {
+    if !gpu_available() {
+        eprintln!("skipping maximum/minimum NaN propagation parity test - no CUDA device found");
+        return;
+    }
+
+    let mut cpu = cpu_backend();
+    let mut gpu = gpu_backend();
+    for (lhs, rhs) in [
+        (
+            tensor_f32(vec![2], vec![f32::NAN, 1.0]),
+            tensor_f32(vec![2], vec![1.0, f32::NAN]),
+        ),
+        (
+            tensor_f64(vec![2], vec![f64::NAN, 1.0]),
+            tensor_f64(vec![2], vec![1.0, f64::NAN]),
+        ),
+    ] {
+        let gpu_lhs = upload(&gpu, &lhs);
+        let gpu_rhs = upload(&gpu, &rhs);
+        for (label, expected, actual) in [
+            (
+                "maximum",
+                cpu.maximum(&lhs, &rhs).unwrap(),
+                gpu.maximum(&gpu_lhs, &gpu_rhs).unwrap(),
+            ),
+            (
+                "minimum",
+                cpu.minimum(&lhs, &rhs).unwrap(),
+                gpu.minimum(&gpu_lhs, &gpu_rhs).unwrap(),
+            ),
+        ] {
+            assert_float_classes_and_zero_signs_match(label, &download(&gpu, &actual), &expected);
+        }
+    }
 }
 
 fn assert_float_classes_and_zero_signs_match(op: &str, actual: &Tensor, expected: &Tensor) {

--- a/crates/tenferro-gpu/src/cubecl/tests/fusion_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/fusion_tests.rs
@@ -42,8 +42,7 @@ fn assert_f32_extrema_match(actual: &[f32], expected: &[f32]) {
             );
         } else {
             assert_eq!(
-                actual.to_bits(),
-                expected.to_bits(),
+                actual, expected,
                 "index {index}: actual={actual:?}, expected={expected:?}"
             );
         }
@@ -60,8 +59,7 @@ fn assert_f64_extrema_match(actual: &[f64], expected: &[f64]) {
             );
         } else {
             assert_eq!(
-                actual.to_bits(),
-                expected.to_bits(),
+                actual, expected,
                 "index {index}: actual={actual:?}, expected={expected:?}"
             );
         }

--- a/crates/tenferro-gpu/src/cubecl/tests/fusion_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/fusion_tests.rs
@@ -20,6 +20,152 @@ fn add_mul_plan() -> ElementwiseFusionPlan {
     )
 }
 
+fn max_min_plan(dtype: crate::DType) -> ElementwiseFusionPlan {
+    ElementwiseFusionPlan::new(
+        dtype,
+        2,
+        vec![2, 3],
+        vec![
+            ElementwiseFusionInst::new(ElementwiseFusionOp::Maximum, vec![0, 1]),
+            ElementwiseFusionInst::new(ElementwiseFusionOp::Minimum, vec![0, 1]),
+        ],
+    )
+}
+
+fn assert_f32_extrema_match(actual: &[f32], expected: &[f32]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        if expected.is_nan() {
+            assert!(
+                actual.is_nan(),
+                "index {index}: expected NaN, got {actual:?}"
+            );
+        } else {
+            assert_eq!(
+                actual.to_bits(),
+                expected.to_bits(),
+                "index {index}: actual={actual:?}, expected={expected:?}"
+            );
+        }
+    }
+}
+
+fn assert_f64_extrema_match(actual: &[f64], expected: &[f64]) {
+    assert_eq!(actual.len(), expected.len());
+    for (index, (&actual, &expected)) in actual.iter().zip(expected).enumerate() {
+        if expected.is_nan() {
+            assert!(
+                actual.is_nan(),
+                "index {index}: expected NaN, got {actual:?}"
+            );
+        } else {
+            assert_eq!(
+                actual.to_bits(),
+                expected.to_bits(),
+                "index {index}: actual={actual:?}, expected={expected:?}"
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn test_fused_f32_max_min_propagate_nan_in_both_operand_orders() {
+    let lhs = tensor_f32(
+        vec![7],
+        vec![
+            f32::NAN,
+            1.0,
+            f32::NAN,
+            3.0,
+            -0.0,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+        ],
+    );
+    let rhs = tensor_f32(
+        vec![7],
+        vec![
+            1.0,
+            f32::NAN,
+            f32::NAN,
+            2.0,
+            0.0,
+            f32::NEG_INFINITY,
+            f32::INFINITY,
+        ],
+    );
+
+    let mut cpu = cpu_backend();
+    let expected_maximum = cpu.maximum(&lhs, &rhs).unwrap();
+    let expected_minimum = cpu.minimum(&lhs, &rhs).unwrap();
+
+    let mut gpu = gpu_backend();
+    let gpu_lhs = upload(&gpu, &lhs);
+    let gpu_rhs = upload(&gpu, &rhs);
+    let outputs = gpu
+        .execute_elementwise_fusion(&[&gpu_lhs, &gpu_rhs], &max_min_plan(crate::DType::F32))
+        .unwrap()
+        .expect("f32 max/min fusion should succeed");
+
+    assert_eq!(outputs.len(), 2);
+    let maximum = download(&gpu, &outputs[0]);
+    let minimum = download(&gpu, &outputs[1]);
+    let maximum = maximum.as_slice::<f32>().unwrap();
+    let minimum = minimum.as_slice::<f32>().unwrap();
+    assert_f32_extrema_match(maximum, expected_maximum.as_slice::<f32>().unwrap());
+    assert_f32_extrema_match(minimum, expected_minimum.as_slice::<f32>().unwrap());
+}
+
+#[test]
+#[ignore]
+fn test_fused_f64_max_min_propagate_nan_in_both_operand_orders() {
+    let lhs = tensor_f64(
+        vec![7],
+        vec![
+            f64::NAN,
+            1.0,
+            f64::NAN,
+            3.0,
+            -0.0,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ],
+    );
+    let rhs = tensor_f64(
+        vec![7],
+        vec![
+            1.0,
+            f64::NAN,
+            f64::NAN,
+            2.0,
+            0.0,
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+        ],
+    );
+
+    let mut cpu = cpu_backend();
+    let expected_maximum = cpu.maximum(&lhs, &rhs).unwrap();
+    let expected_minimum = cpu.minimum(&lhs, &rhs).unwrap();
+
+    let mut gpu = gpu_backend();
+    let gpu_lhs = upload(&gpu, &lhs);
+    let gpu_rhs = upload(&gpu, &rhs);
+    let outputs = gpu
+        .execute_elementwise_fusion(&[&gpu_lhs, &gpu_rhs], &max_min_plan(crate::DType::F64))
+        .unwrap()
+        .expect("f64 max/min fusion should succeed");
+
+    assert_eq!(outputs.len(), 2);
+    let maximum = download(&gpu, &outputs[0]);
+    let minimum = download(&gpu, &outputs[1]);
+    let maximum = maximum.as_slice::<f64>().unwrap();
+    let minimum = minimum.as_slice::<f64>().unwrap();
+    assert_f64_extrema_match(maximum, expected_maximum.as_slice::<f64>().unwrap());
+    assert_f64_extrema_match(minimum, expected_minimum.as_slice::<f64>().unwrap());
+}
+
 #[test]
 #[ignore]
 fn test_fused_add_mul_matches_cpu() {

--- a/crates/tenferro-gpu/src/cubecl/tests/reduction_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/reduction_tests.rs
@@ -105,6 +105,65 @@ fn test_cubecl_float_reductions_match_cpu() {
 }
 
 #[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn test_cubecl_float_max_min_reductions_propagate_nan_for_unit_and_plane() {
+    if !crate::cubecl::gpu_available() {
+        eprintln!("skipping reduction NaN propagation parity test - no CUDA device found");
+        return;
+    }
+
+    fn assert_all_nan(tensor: &crate::Tensor) {
+        match tensor {
+            crate::Tensor::F32(tensor) => {
+                assert!(tensor
+                    .as_slice()
+                    .unwrap()
+                    .iter()
+                    .all(|value| value.is_nan()));
+            }
+            crate::Tensor::F64(tensor) => {
+                assert!(tensor
+                    .as_slice()
+                    .unwrap()
+                    .iter()
+                    .all(|value| value.is_nan()));
+            }
+            other => panic!("expected float reduction output, got {:?}", other.dtype()),
+        }
+    }
+
+    let mut inputs = Vec::new();
+    for len in [4, 1024] {
+        let mut f32_values = vec![1.0_f32; len];
+        f32_values[len / 2 + 1] = f32::NAN;
+        inputs.push(tensor_f32(vec![len], f32_values));
+
+        let mut f64_values = vec![1.0_f64; len];
+        f64_values[len / 2 + 1] = f64::NAN;
+        inputs.push(tensor_f64(vec![len], f64_values));
+    }
+
+    let mut cpu = cpu_backend();
+    let mut gpu = gpu_backend();
+    for input in inputs {
+        let gpu_input = upload(&gpu, &input);
+        for (expected, actual) in [
+            (
+                cpu.reduce_max(&input, &[0]).unwrap(),
+                gpu.reduce_max(&gpu_input, &[0]).unwrap(),
+            ),
+            (
+                cpu.reduce_min(&input, &[0]).unwrap(),
+                gpu.reduce_min(&gpu_input, &[0]).unwrap(),
+            ),
+        ] {
+            assert_all_nan(&expected);
+            assert_all_nan(&download(&gpu, &actual));
+        }
+    }
+}
+
+#[test]
 #[ignore]
 fn test_cubecl_complex_sum_and_prod_match_cpu() {
     let input = tensor_c64(
@@ -245,6 +304,22 @@ fn test_cubecl_integer_reductions_wrap_on_overflow() {
     let gpu_out = gpu.reduce_min(&gpu_input, &[1]).unwrap();
     let actual = download(&gpu, &gpu_out);
     assert_tensor_close(&actual, &expected, 0.0);
+
+    let input = tensor_i32(vec![1024], vec![i32::MAX; 1024]);
+    let gpu_input = upload(&gpu, &input);
+    for (expected, gpu_out) in [
+        (
+            cpu.reduce_sum(&input, &[0]).unwrap(),
+            gpu.reduce_sum(&gpu_input, &[0]).unwrap(),
+        ),
+        (
+            cpu.reduce_prod(&input, &[0]).unwrap(),
+            gpu.reduce_prod(&gpu_input, &[0]).unwrap(),
+        ),
+    ] {
+        let actual = download(&gpu, &gpu_out);
+        assert_tensor_close(&actual, &expected, 0.0);
+    }
 }
 
 #[test]

--- a/crates/tenferro-gpu/src/kernels/elementwise.rs
+++ b/crates/tenferro-gpu/src/kernels/elementwise.rs
@@ -1,6 +1,9 @@
 use cubecl::prelude::*;
 
-use crate::kernels::helpers::{flat_to_tensor_index, multi_to_tensor_index};
+use crate::kernels::helpers::{
+    flat_to_tensor_index, multi_to_tensor_index, nan_propagating_max, nan_propagating_min,
+    wrapping_add, wrapping_mul, wrapping_neg, wrapping_sub,
+};
 
 pub(crate) const COMPARE_EQ: usize = 0;
 pub(crate) const COMPARE_LT: usize = 1;
@@ -27,19 +30,6 @@ macro_rules! binary_float_complex_kernel {
             lhs: &Array<C>,
             rhs: &Array<C>,
         ) {
-            if ABSOLUTE_POS < out.len() {
-                out[ABSOLUTE_POS] = lhs[ABSOLUTE_POS] $op rhs[ABSOLUTE_POS];
-            }
-        }
-    };
-}
-
-macro_rules! binary_float_int_complex_kernel {
-    ($float_name:ident, $int_name:ident, $complex_name:ident, $op:tt) => {
-        binary_float_complex_kernel!($float_name, $complex_name, $op);
-
-        #[cube(launch_unchecked)]
-        pub fn $int_name<I: Int>(out: &mut Array<I>, lhs: &Array<I>, rhs: &Array<I>) {
             if ABSOLUTE_POS < out.len() {
                 out[ABSOLUTE_POS] = lhs[ABSOLUTE_POS] $op rhs[ABSOLUTE_POS];
             }
@@ -91,8 +81,23 @@ macro_rules! broadcast_multiply_kernel {
 }
 
 broadcast_multiply_kernel!(broadcast_multiply_float, Float);
-broadcast_multiply_kernel!(broadcast_multiply_int, Int);
 broadcast_multiply_kernel!(broadcast_multiply_complex, ComplexCore);
+
+#[cube(launch_unchecked)]
+pub fn broadcast_multiply_int<I: Int>(
+    out: &mut Tensor<I>,
+    lhs: &Tensor<I>,
+    rhs: &Tensor<I>,
+    #[comptime] lhs_dims: Sequence<usize>,
+    #[comptime] rhs_dims: Sequence<usize>,
+    #[comptime] output_rank: usize,
+) {
+    if ABSOLUTE_POS < out.len() {
+        let lhs_idx = broadcast_source_index(ABSOLUTE_POS, out, lhs, lhs_dims, output_rank);
+        let rhs_idx = broadcast_source_index(ABSOLUTE_POS, out, rhs, rhs_dims, output_rank);
+        out[ABSOLUTE_POS] = wrapping_mul::<I>(lhs[lhs_idx], rhs[rhs_idx]);
+    }
+}
 
 macro_rules! unary_float_kernel {
     ($name:ident, $method:ident) => {
@@ -125,10 +130,31 @@ macro_rules! unary_both_kernel {
     };
 }
 
-binary_float_int_complex_kernel!(add_float, add_int, add_complex, +);
-binary_float_int_complex_kernel!(sub_float, sub_int, sub_complex, -);
-binary_float_int_complex_kernel!(mul_float, mul_int, mul_complex, *);
+binary_float_complex_kernel!(add_float, add_complex, +);
+binary_float_complex_kernel!(sub_float, sub_complex, -);
+binary_float_complex_kernel!(mul_float, mul_complex, *);
 binary_float_complex_kernel!(div_float, div_complex, /);
+
+#[cube(launch_unchecked)]
+pub fn add_int<I: Int>(out: &mut Array<I>, lhs: &Array<I>, rhs: &Array<I>) {
+    if ABSOLUTE_POS < out.len() {
+        out[ABSOLUTE_POS] = wrapping_add::<I>(lhs[ABSOLUTE_POS], rhs[ABSOLUTE_POS]);
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn sub_int<I: Int>(out: &mut Array<I>, lhs: &Array<I>, rhs: &Array<I>) {
+    if ABSOLUTE_POS < out.len() {
+        out[ABSOLUTE_POS] = wrapping_sub::<I>(lhs[ABSOLUTE_POS], rhs[ABSOLUTE_POS]);
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn mul_int<I: Int>(out: &mut Array<I>, lhs: &Array<I>, rhs: &Array<I>) {
+    if ABSOLUTE_POS < out.len() {
+        out[ABSOLUTE_POS] = wrapping_mul::<I>(lhs[ABSOLUTE_POS], rhs[ABSOLUTE_POS]);
+    }
+}
 
 macro_rules! scalar_binary_float_kernel {
     ($name:ident, |$lhs:ident, $rhs:ident| $body:expr) => {
@@ -228,12 +254,12 @@ pub fn scalar_div_int_checked<I: Int>(
         let x = lhs[lhs_idx];
         let y = rhs[rhs_idx];
         let zero = I::new(0);
-        let minus_one = zero - I::new(1);
+        let minus_one = wrapping_sub::<I>(zero, I::new(1));
         if y == zero {
             err[0] = 1;
             out[ABSOLUTE_POS] = zero;
         } else if y == minus_one {
-            out[ABSOLUTE_POS] = zero - x;
+            out[ABSOLUTE_POS] = wrapping_neg::<I>(x);
         } else {
             out[ABSOLUTE_POS] = x / y;
         }
@@ -254,7 +280,7 @@ pub fn scalar_rem_int_checked<I: Int>(
         let x = lhs[lhs_idx];
         let y = rhs[rhs_idx];
         let zero = I::new(0);
-        let minus_one = zero - I::new(1);
+        let minus_one = wrapping_sub::<I>(zero, I::new(1));
         if y == zero {
             err[0] = 1;
             out[ABSOLUTE_POS] = zero;
@@ -262,7 +288,7 @@ pub fn scalar_rem_int_checked<I: Int>(
             out[ABSOLUTE_POS] = zero;
         } else {
             let quotient = x / y;
-            out[ABSOLUTE_POS] = x - quotient * y;
+            out[ABSOLUTE_POS] = wrapping_sub::<I>(x, wrapping_mul::<I>(quotient, y));
         }
     }
 }
@@ -278,12 +304,12 @@ pub fn div_int_checked<I: Int>(
         let x = lhs[ABSOLUTE_POS];
         let y = rhs[ABSOLUTE_POS];
         let zero = I::new(0);
-        let minus_one = zero - I::new(1);
+        let minus_one = wrapping_sub::<I>(zero, I::new(1));
         if y == zero {
             err[0] = 1;
             out[ABSOLUTE_POS] = zero;
         } else if y == minus_one {
-            out[ABSOLUTE_POS] = zero - x;
+            out[ABSOLUTE_POS] = wrapping_neg::<I>(x);
         } else {
             out[ABSOLUTE_POS] = x / y;
         }
@@ -315,7 +341,7 @@ pub fn rem_int_checked<I: Int>(
         let x = lhs[ABSOLUTE_POS];
         let y = rhs[ABSOLUTE_POS];
         let zero = I::new(0);
-        let minus_one = zero - I::new(1);
+        let minus_one = wrapping_sub::<I>(zero, I::new(1));
         if y == zero {
             err[0] = 1;
             out[ABSOLUTE_POS] = zero;
@@ -323,7 +349,7 @@ pub fn rem_int_checked<I: Int>(
             out[ABSOLUTE_POS] = zero;
         } else {
             let quotient = x / y;
-            out[ABSOLUTE_POS] = x - quotient * y;
+            out[ABSOLUTE_POS] = wrapping_sub::<I>(x, wrapping_mul::<I>(quotient, y));
         }
     }
 }
@@ -331,7 +357,7 @@ unary_both_kernel!(neg_float, neg_complex, |value| -value);
 #[cube(launch_unchecked)]
 pub fn neg_int<I: Int>(out: &mut Array<I>, input: &Array<I>) {
     if ABSOLUTE_POS < out.len() {
-        out[ABSOLUTE_POS] = I::new(0) - input[ABSOLUTE_POS];
+        out[ABSOLUTE_POS] = wrapping_neg::<I>(input[ABSOLUTE_POS]);
     }
 }
 unary_float_kernel!(exp_float, exp);
@@ -389,7 +415,11 @@ pub fn abs_int<I: Int>(out: &mut Array<I>, input: &Array<I>) {
     if ABSOLUTE_POS < out.len() {
         let value = input[ABSOLUTE_POS];
         let zero = I::new(0);
-        out[ABSOLUTE_POS] = if value < zero { zero - value } else { value };
+        out[ABSOLUTE_POS] = if value < zero {
+            wrapping_neg::<I>(value)
+        } else {
+            value
+        };
     }
 }
 
@@ -421,7 +451,7 @@ pub fn sign_int<I: Int>(out: &mut Array<I>, input: &Array<I>) {
         } else if value > zero {
             I::new(1)
         } else {
-            zero - I::new(1)
+            wrapping_sub::<I>(zero, I::new(1))
         };
     }
 }
@@ -429,7 +459,7 @@ pub fn sign_int<I: Int>(out: &mut Array<I>, input: &Array<I>) {
 #[cube(launch_unchecked)]
 pub fn maximum_float<F: Float>(out: &mut Array<F>, lhs: &Array<F>, rhs: &Array<F>) {
     if ABSOLUTE_POS < out.len() {
-        out[ABSOLUTE_POS] = lhs[ABSOLUTE_POS].max(rhs[ABSOLUTE_POS]);
+        out[ABSOLUTE_POS] = nan_propagating_max::<F>(lhs[ABSOLUTE_POS], rhs[ABSOLUTE_POS]);
     }
 }
 
@@ -445,7 +475,7 @@ pub fn maximum_int<I: Int>(out: &mut Array<I>, lhs: &Array<I>, rhs: &Array<I>) {
 #[cube(launch_unchecked)]
 pub fn minimum_float<F: Float>(out: &mut Array<F>, lhs: &Array<F>, rhs: &Array<F>) {
     if ABSOLUTE_POS < out.len() {
-        out[ABSOLUTE_POS] = lhs[ABSOLUTE_POS].min(rhs[ABSOLUTE_POS]);
+        out[ABSOLUTE_POS] = nan_propagating_min::<F>(lhs[ABSOLUTE_POS], rhs[ABSOLUTE_POS]);
     }
 }
 
@@ -485,13 +515,13 @@ pub fn pow_int_checked<I: Int>(
             let mut acc = one;
             while exp > zero {
                 let quotient = exp / two;
-                let remainder = exp - quotient * two;
+                let remainder = wrapping_sub::<I>(exp, wrapping_mul::<I>(quotient, two));
                 if remainder != zero {
-                    acc = acc * base;
+                    acc = wrapping_mul::<I>(acc, base);
                 }
                 exp = quotient;
                 if exp > zero {
-                    base = base * base;
+                    base = wrapping_mul::<I>(base, base);
                 }
             }
             out[ABSOLUTE_POS] = acc;
@@ -522,13 +552,13 @@ pub fn scalar_pow_int_checked<I: Int>(
             let mut acc = one;
             while exp > zero {
                 let quotient = exp / two;
-                let remainder = exp - quotient * two;
+                let remainder = wrapping_sub::<I>(exp, wrapping_mul::<I>(quotient, two));
                 if remainder != zero {
-                    acc = acc * base;
+                    acc = wrapping_mul::<I>(acc, base);
                 }
                 exp = quotient;
                 if exp > zero {
-                    base = base * base;
+                    base = wrapping_mul::<I>(base, base);
                 }
             }
             out[ABSOLUTE_POS] = acc;

--- a/crates/tenferro-gpu/src/kernels/helpers.rs
+++ b/crates/tenferro-gpu/src/kernels/helpers.rs
@@ -67,6 +67,15 @@ pub(crate) fn plane_contains_nan<F: Float>(value: F) -> bool {
     plane_sum(flag) > 0u32
 }
 
+// INVARIANT: The self-comparison is an intentional generic CubeCL NaN test;
+// `Float::is_nan` returns `WithScalar<bool>` instead of a scalar `bool` here.
+#[allow(clippy::eq_op)]
+#[cube]
+pub(crate) fn plane_propagate_nan<F: Float>(value: F) -> F {
+    let nan_or_zero = if value != value { value } else { F::new(0.0) };
+    plane_sum(nan_or_zero)
+}
+
 #[cube]
 pub(crate) fn zero_value<E: CubePrimitive>() -> E {
     E::cast_from(0u32)

--- a/crates/tenferro-gpu/src/kernels/helpers.rs
+++ b/crates/tenferro-gpu/src/kernels/helpers.rs
@@ -1,5 +1,72 @@
 use cubecl::prelude::*;
 
+// INVARIANT: CubeCL fixed-width Int arithmetic and integer plane collectives
+// lower to modulo-2^N operations for I32/I64 on the CUDA backend. Keep every
+// public integer data path routed through these named helpers so wrapping
+// semantics remain explicit and auditable if CubeCL codegen changes.
+#[cube]
+pub(crate) fn wrapping_add<I: Int>(lhs: I, rhs: I) -> I {
+    lhs + rhs
+}
+
+#[cube]
+pub(crate) fn wrapping_sub<I: Int>(lhs: I, rhs: I) -> I {
+    lhs - rhs
+}
+
+#[cube]
+pub(crate) fn wrapping_mul<I: Int>(lhs: I, rhs: I) -> I {
+    lhs * rhs
+}
+
+#[cube]
+pub(crate) fn wrapping_neg<I: Int>(value: I) -> I {
+    I::new(0) - value
+}
+
+#[cube]
+pub(crate) fn wrapping_plane_sum<I: Int>(value: I) -> I {
+    plane_sum(value)
+}
+
+#[cube]
+pub(crate) fn wrapping_plane_prod<I: Int>(value: I) -> I {
+    plane_prod(value)
+}
+
+// CubeCL's generic `is_nan` result uses `WithScalar<bool>`; the self-compare
+// keeps these scalar kernels generic over `F: Float`.
+#[allow(clippy::eq_op)]
+#[cube]
+pub(crate) fn nan_propagating_max<F: Float>(lhs: F, rhs: F) -> F {
+    if lhs != lhs {
+        lhs
+    } else if rhs != rhs {
+        rhs
+    } else {
+        lhs.max(rhs)
+    }
+}
+
+#[allow(clippy::eq_op)]
+#[cube]
+pub(crate) fn nan_propagating_min<F: Float>(lhs: F, rhs: F) -> F {
+    if lhs != lhs {
+        lhs
+    } else if rhs != rhs {
+        rhs
+    } else {
+        lhs.min(rhs)
+    }
+}
+
+#[allow(clippy::eq_op)]
+#[cube]
+pub(crate) fn plane_contains_nan<F: Float>(value: F) -> bool {
+    let flag: u32 = if value != value { 1u32 } else { 0u32 };
+    plane_sum(flag) > 0u32
+}
+
 #[cube]
 pub(crate) fn zero_value<E: CubePrimitive>() -> E {
     E::cast_from(0u32)

--- a/crates/tenferro-gpu/src/kernels/reduce/kernels.rs
+++ b/crates/tenferro-gpu/src/kernels/reduce/kernels.rs
@@ -8,8 +8,8 @@
 use cubecl::prelude::*;
 
 use crate::kernels::helpers::{
-    nan_propagating_max, nan_propagating_min, plane_contains_nan, wrapping_add, wrapping_mul,
-    wrapping_plane_prod, wrapping_plane_sum,
+    nan_propagating_max, nan_propagating_min, plane_contains_nan, plane_propagate_nan,
+    wrapping_add, wrapping_mul, wrapping_plane_prod, wrapping_plane_sum,
 };
 
 macro_rules! reduce_binary_kernel {
@@ -305,10 +305,11 @@ pub(crate) fn reduce_max_float_plane<F: Float>(
         }
 
         let contains_nan = plane_contains_nan::<F>(acc);
+        let propagated_nan = plane_propagate_nan::<F>(acc);
         let reduced = plane_max(acc);
         if UNIT_POS == 0 {
             output[output_offset] = if contains_nan {
-                F::new(f32::NAN)
+                propagated_nan
             } else {
                 reduced
             };
@@ -466,10 +467,11 @@ pub(crate) fn reduce_min_float_plane<F: Float>(
         }
 
         let contains_nan = plane_contains_nan::<F>(acc);
+        let propagated_nan = plane_propagate_nan::<F>(acc);
         let reduced = plane_min(acc);
         if UNIT_POS == 0 {
             output[output_offset] = if contains_nan {
-                F::new(f32::NAN)
+                propagated_nan
             } else {
                 reduced
             };

--- a/crates/tenferro-gpu/src/kernels/reduce/kernels.rs
+++ b/crates/tenferro-gpu/src/kernels/reduce/kernels.rs
@@ -7,6 +7,11 @@
 
 use cubecl::prelude::*;
 
+use crate::kernels::helpers::{
+    nan_propagating_max, nan_propagating_min, plane_contains_nan, wrapping_add, wrapping_mul,
+    wrapping_plane_prod, wrapping_plane_sum,
+};
+
 macro_rules! reduce_binary_kernel {
     ($name:ident, $bound:ident, $op:tt) => {
         #[cube(launch_unchecked)]
@@ -47,11 +52,51 @@ macro_rules! reduce_binary_kernel {
 }
 
 reduce_binary_kernel!(reduce_sum_float, Float, +);
-reduce_binary_kernel!(reduce_sum_int, Int, +);
 reduce_binary_kernel!(reduce_sum_complex, ComplexCore, +);
 reduce_binary_kernel!(reduce_prod_float, Float, *);
-reduce_binary_kernel!(reduce_prod_int, Int, *);
 reduce_binary_kernel!(reduce_prod_complex, ComplexCore, *);
+
+macro_rules! reduce_wrapping_int_kernel {
+    ($name:ident, $combine:ident) => {
+        #[cube(launch_unchecked)]
+        pub(crate) fn $name<I: Int>(
+            input: &Tensor<I>,
+            output: &mut Tensor<I>,
+            axis: usize,
+            output_len: usize,
+        ) {
+            let output_index = ABSOLUTE_POS as usize;
+            if output_index < output_len {
+                let rank = output.rank();
+                let mut remaining = output_index;
+                let mut input_base_offset = 0usize;
+                let mut output_offset = 0usize;
+
+                for dim in 0..rank {
+                    let dim_len = output.shape(dim);
+                    let coord = remaining % dim_len;
+                    remaining /= dim_len;
+                    input_base_offset += coord * input.stride(dim);
+                    output_offset += coord * output.stride(dim);
+                }
+
+                let axis_stride = input.stride(axis);
+                let axis_len = input.shape(axis);
+                let mut acc = input[input_base_offset];
+
+                for reduce_index in 1..axis_len {
+                    let input_offset = input_base_offset + reduce_index * axis_stride;
+                    acc = $combine::<I>(acc, input[input_offset]);
+                }
+
+                output[output_offset] = acc;
+            }
+        }
+    };
+}
+
+reduce_wrapping_int_kernel!(reduce_sum_int, wrapping_add);
+reduce_wrapping_int_kernel!(reduce_prod_int, wrapping_mul);
 
 macro_rules! reduce_binary_plane_kernel {
     ($name:ident, $bound:ident, $op:tt, $plane_reduce:ident) => {
@@ -100,11 +145,58 @@ macro_rules! reduce_binary_plane_kernel {
 }
 
 reduce_binary_plane_kernel!(reduce_sum_float_plane, Float, +, plane_sum);
-reduce_binary_plane_kernel!(reduce_sum_int_plane, Int, +, plane_sum);
 reduce_binary_plane_kernel!(reduce_sum_complex_plane, ComplexCore, +, plane_sum);
 reduce_binary_plane_kernel!(reduce_prod_float_plane, Float, *, plane_prod);
-reduce_binary_plane_kernel!(reduce_prod_int_plane, Int, *, plane_prod);
 reduce_binary_plane_kernel!(reduce_prod_complex_plane, ComplexCore, *, plane_prod);
+
+macro_rules! reduce_wrapping_int_plane_kernel {
+    ($name:ident, $combine:ident, $plane_reduce:ident) => {
+        #[cube(launch_unchecked)]
+        pub(crate) fn $name<I: Int>(
+            input: &Tensor<I>,
+            output: &mut Tensor<I>,
+            axis: usize,
+            output_len: usize,
+        ) {
+            let output_index = CUBE_POS_X as usize;
+            if output_index < output_len {
+                let rank = output.rank();
+                let mut remaining = output_index;
+                let mut input_base_offset = 0usize;
+                let mut output_offset = 0usize;
+
+                for dim in 0..rank {
+                    let dim_len = output.shape(dim);
+                    let coord = remaining % dim_len;
+                    remaining /= dim_len;
+                    input_base_offset += coord * input.stride(dim);
+                    output_offset += coord * output.stride(dim);
+                }
+
+                let axis_stride = input.stride(axis);
+                let axis_len = input.shape(axis);
+                let plane_width = PLANE_DIM as usize;
+                let mut reduce_index = UNIT_POS as usize;
+                let mut acc = input[input_base_offset + reduce_index * axis_stride];
+
+                reduce_index += plane_width;
+                while reduce_index < axis_len {
+                    let input_offset = input_base_offset + reduce_index * axis_stride;
+                    acc = $combine::<I>(acc, input[input_offset]);
+                    reduce_index += plane_width;
+                }
+
+                let reduced = $plane_reduce::<I>(acc);
+                if UNIT_POS == 0 {
+                    output[output_offset] = reduced;
+                }
+            }
+        }
+    };
+}
+
+reduce_wrapping_int_plane_kernel!(reduce_sum_int_plane, wrapping_add, wrapping_plane_sum);
+reduce_wrapping_int_plane_kernel!(reduce_prod_int_plane, wrapping_mul, wrapping_plane_prod);
 
 #[cube(launch_unchecked)]
 pub(crate) fn reduce_max_float<F: Float>(
@@ -134,7 +226,7 @@ pub(crate) fn reduce_max_float<F: Float>(
 
         for reduce_index in 1..axis_len {
             let input_offset = input_base_offset + reduce_index * axis_stride;
-            acc = acc.max(input[input_offset]);
+            acc = nan_propagating_max::<F>(acc, input[input_offset]);
         }
 
         output[output_offset] = acc;
@@ -208,13 +300,18 @@ pub(crate) fn reduce_max_float_plane<F: Float>(
         reduce_index += plane_width;
         while reduce_index < axis_len {
             let input_offset = input_base_offset + reduce_index * axis_stride;
-            acc = acc.max(input[input_offset]);
+            acc = nan_propagating_max::<F>(acc, input[input_offset]);
             reduce_index += plane_width;
         }
 
+        let contains_nan = plane_contains_nan::<F>(acc);
         let reduced = plane_max(acc);
         if UNIT_POS == 0 {
-            output[output_offset] = reduced;
+            output[output_offset] = if contains_nan {
+                F::new(f32::NAN)
+            } else {
+                reduced
+            };
         }
     }
 }
@@ -290,7 +387,7 @@ pub(crate) fn reduce_min_float<F: Float>(
 
         for reduce_index in 1..axis_len {
             let input_offset = input_base_offset + reduce_index * axis_stride;
-            acc = acc.min(input[input_offset]);
+            acc = nan_propagating_min::<F>(acc, input[input_offset]);
         }
 
         output[output_offset] = acc;
@@ -364,13 +461,18 @@ pub(crate) fn reduce_min_float_plane<F: Float>(
         reduce_index += plane_width;
         while reduce_index < axis_len {
             let input_offset = input_base_offset + reduce_index * axis_stride;
-            acc = acc.min(input[input_offset]);
+            acc = nan_propagating_min::<F>(acc, input[input_offset]);
             reduce_index += plane_width;
         }
 
+        let contains_nan = plane_contains_nan::<F>(acc);
         let reduced = plane_min(acc);
         if UNIT_POS == 0 {
-            output[output_offset] = reduced;
+            output[output_offset] = if contains_nan {
+                F::new(f32::NAN)
+            } else {
+                reduced
+            };
         }
     }
 }

--- a/crates/tenferro-gpu/tests/kernel_metadata_contract.rs
+++ b/crates/tenferro-gpu/tests/kernel_metadata_contract.rs
@@ -1,5 +1,20 @@
 use std::{fs, path::Path};
 
+fn kernel_source(path: &[&str]) -> String {
+    let mut source = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("kernels");
+    for component in path {
+        source.push(component);
+    }
+    fs::read_to_string(&source).unwrap_or_else(|err| {
+        panic!(
+            "kernel source {} should be readable: {err}",
+            source.display()
+        )
+    })
+}
+
 fn scatter_kernel_names(source: &str) -> Vec<&str> {
     const PREFIX: &str = "pub fn scatter_";
 
@@ -99,6 +114,96 @@ fn reduction_kernels_do_not_hide_unbounded_axis_work_in_one_worker() {
         violations.is_empty(),
         "CubeCL reductions must not route Auto to a per-output worker with unbounded serial axis work; use a parallel reduction strategy or an explicitly bounded fallback:\n{}",
         violations.join("\n")
+    );
+}
+
+#[test]
+fn integer_kernels_route_user_arithmetic_through_wrapping_helpers() {
+    let helpers = kernel_source(&["helpers.rs"]);
+    for helper in [
+        "fn wrapping_add<I: Int>",
+        "fn wrapping_sub<I: Int>",
+        "fn wrapping_mul<I: Int>",
+        "fn wrapping_neg<I: Int>",
+        "fn wrapping_plane_sum<I: Int>",
+        "fn wrapping_plane_prod<I: Int>",
+    ] {
+        assert!(helpers.contains(helper), "missing CubeCL helper {helper}");
+    }
+    assert!(
+        helpers.contains("INVARIANT: CubeCL fixed-width Int arithmetic"),
+        "wrapping helpers must document the CubeCL codegen proof"
+    );
+
+    let elementwise = kernel_source(&["elementwise.rs"]);
+    for call in [
+        "wrapping_add::<I>(lhs[ABSOLUTE_POS], rhs[ABSOLUTE_POS])",
+        "wrapping_sub::<I>(lhs[ABSOLUTE_POS], rhs[ABSOLUTE_POS])",
+        "wrapping_mul::<I>(lhs[ABSOLUTE_POS], rhs[ABSOLUTE_POS])",
+        "wrapping_mul::<I>(lhs[lhs_idx], rhs[rhs_idx])",
+        "wrapping_neg::<I>(input[ABSOLUTE_POS])",
+        "wrapping_neg::<I>(value)",
+        "wrapping_sub::<I>(x, wrapping_mul::<I>(quotient, y))",
+        "wrapping_sub::<I>(exp, wrapping_mul::<I>(quotient, two))",
+        "wrapping_mul::<I>(acc, base)",
+        "wrapping_mul::<I>(base, base)",
+    ] {
+        assert!(
+            elementwise.contains(call),
+            "integer elementwise kernel must use {call}"
+        );
+    }
+
+    let reductions = kernel_source(&["reduce", "kernels.rs"]);
+    for invocation in [
+        "reduce_wrapping_int_kernel!(reduce_sum_int, wrapping_add);",
+        "reduce_wrapping_int_kernel!(reduce_prod_int, wrapping_mul);",
+        "reduce_wrapping_int_plane_kernel!(reduce_sum_int_plane, wrapping_add, wrapping_plane_sum);",
+        "reduce_wrapping_int_plane_kernel!(reduce_prod_int_plane, wrapping_mul, wrapping_plane_prod);",
+    ] {
+        assert!(
+            reductions.contains(invocation),
+            "integer reduction must use {invocation}"
+        );
+    }
+}
+
+#[test]
+fn float_max_min_kernels_propagate_nan_across_lanes_and_planes() {
+    let helpers = kernel_source(&["helpers.rs"]);
+    for helper in [
+        "fn nan_propagating_max<F: Float>",
+        "fn nan_propagating_min<F: Float>",
+        "fn plane_contains_nan<F: Float>",
+    ] {
+        assert!(helpers.contains(helper), "missing CubeCL helper {helper}");
+    }
+
+    let elementwise = kernel_source(&["elementwise.rs"]);
+    assert!(elementwise.contains("nan_propagating_max::<F>(lhs[ABSOLUTE_POS], rhs[ABSOLUTE_POS])"));
+    assert!(elementwise.contains("nan_propagating_min::<F>(lhs[ABSOLUTE_POS], rhs[ABSOLUTE_POS])"));
+
+    let reductions = kernel_source(&["reduce", "kernels.rs"]);
+    assert!(
+        reductions
+            .match_indices("nan_propagating_max::<F>(acc, input[input_offset])")
+            .count()
+            >= 2,
+        "unit and plane max reductions must both propagate NaN within each lane"
+    );
+    assert!(
+        reductions
+            .match_indices("nan_propagating_min::<F>(acc, input[input_offset])")
+            .count()
+            >= 2,
+        "unit and plane min reductions must both propagate NaN within each lane"
+    );
+    assert!(
+        reductions
+            .match_indices("let contains_nan = plane_contains_nan::<F>(acc);")
+            .count()
+            >= 2,
+        "plane max and min must aggregate a separate NaN flag across lanes"
     );
 }
 

--- a/crates/tenferro-gpu/tests/kernel_metadata_contract.rs
+++ b/crates/tenferro-gpu/tests/kernel_metadata_contract.rs
@@ -175,9 +175,14 @@ fn float_max_min_kernels_propagate_nan_across_lanes_and_planes() {
         "fn nan_propagating_max<F: Float>",
         "fn nan_propagating_min<F: Float>",
         "fn plane_contains_nan<F: Float>",
+        "fn plane_propagate_nan<F: Float>",
     ] {
         assert!(helpers.contains(helper), "missing CubeCL helper {helper}");
     }
+    assert!(
+        helpers.contains("plane_sum(nan_or_zero)"),
+        "plane NaN propagation must carry an input NaN through the collective"
+    );
 
     let elementwise = kernel_source(&["elementwise.rs"]);
     assert!(elementwise.contains("nan_propagating_max::<F>(lhs[ABSOLUTE_POS], rhs[ABSOLUTE_POS])"));
@@ -204,6 +209,17 @@ fn float_max_min_kernels_propagate_nan_across_lanes_and_planes() {
             .count()
             >= 2,
         "plane max and min must aggregate a separate NaN flag across lanes"
+    );
+    assert!(
+        reductions
+            .match_indices("let propagated_nan = plane_propagate_nan::<F>(acc);")
+            .count()
+            >= 2,
+        "plane max and min must propagate an actual NaN lane value"
+    );
+    assert!(
+        !reductions.contains("F::new(f32::NAN)"),
+        "generic CubeCL kernels must not lower a host NaN literal into invalid CUDA source"
     );
 }
 

--- a/crates/tenferro-gpu/tests/kernel_metadata_contract.rs
+++ b/crates/tenferro-gpu/tests/kernel_metadata_contract.rs
@@ -208,6 +208,43 @@ fn float_max_min_kernels_propagate_nan_across_lanes_and_planes() {
 }
 
 #[test]
+fn fused_float_max_min_codegen_propagates_nan_before_native_extrema() {
+    let source = fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("cubecl")
+            .join("fusion")
+            .join("codegen.rs"),
+    )
+    .expect("fusion codegen source should be readable");
+
+    assert!(
+        source.contains("fn emit_nan_propagating_extrema("),
+        "fusion codegen must centralize the NaN contract"
+    );
+    assert!(
+        source.contains("Comparison::IsNan"),
+        "fusion extrema must test both operands for NaN"
+    );
+    assert!(
+        source.contains("Operator::Select"),
+        "fusion extrema must select a NaN operand before the native extrema result"
+    );
+    assert!(
+        source.contains(
+            "ElementwiseFusionOp::Maximum => {\n            emit_nan_propagating_extrema("
+        ),
+        "fused maximum must use the NaN-propagating helper"
+    );
+    assert!(
+        source.contains(
+            "ElementwiseFusionOp::Minimum => {\n            emit_nan_propagating_extrema("
+        ),
+        "fused minimum must use the NaN-propagating helper"
+    );
+}
+
+#[test]
 fn scatter_kernels_are_not_single_thread_fallbacks() {
     let indexing_source = fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/tenferro-linalg/src/cpu/tests/mod.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/mod.rs
@@ -11,12 +11,7 @@ use super::linalg::faer_linalg;
 use crate::LinalgBackend;
 #[cfg(feature = "cpu-faer")]
 use tenferro_cpu::linalg_interop::BufferPool;
-use tenferro_cpu::{
-    abs, add, broadcast_in_dim, clamp, compare, conj, div, dynamic_slice, dynamic_update_slice,
-    embed_diagonal, extract_diagonal, gather, maximum, minimum, mul, neg, pad, reduce_max,
-    reduce_min, reduce_prod, reduce_sum, reshape, scatter, select, sign, transpose, tril, triu,
-    CpuBackend, CpuContext,
-};
+use tenferro_cpu::{CpuBackend, CpuContext};
 use tenferro_tensor::backend::TensorBackend;
 use tenferro_tensor::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -779,41 +779,21 @@ fn apply_canonical_pivot_svd_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::R
             ),
         });
     }
-    let batch_count = u_shape[2..].iter().product::<usize>();
+    let layout = canonical_svd_gauge_layout(m, k, n, &u_shape[2..])?;
 
     match (u, vt) {
-        (Tensor::F64(u), Tensor::F64(vt)) => canonicalize_svd_gauge_f64(
-            u.host_data_mut()?,
-            vt.host_data_mut()?,
-            m,
-            k,
-            n,
-            batch_count,
-        ),
-        (Tensor::F32(u), Tensor::F32(vt)) => canonicalize_svd_gauge_f32(
-            u.host_data_mut()?,
-            vt.host_data_mut()?,
-            m,
-            k,
-            n,
-            batch_count,
-        ),
-        (Tensor::C64(u), Tensor::C64(vt)) => canonicalize_svd_gauge_c64(
-            u.host_data_mut()?,
-            vt.host_data_mut()?,
-            m,
-            k,
-            n,
-            batch_count,
-        ),
-        (Tensor::C32(u), Tensor::C32(vt)) => canonicalize_svd_gauge_c32(
-            u.host_data_mut()?,
-            vt.host_data_mut()?,
-            m,
-            k,
-            n,
-            batch_count,
-        ),
+        (Tensor::F64(u), Tensor::F64(vt)) => {
+            canonicalize_svd_gauge_f64(u.host_data_mut()?, vt.host_data_mut()?, layout)
+        }
+        (Tensor::F32(u), Tensor::F32(vt)) => {
+            canonicalize_svd_gauge_f32(u.host_data_mut()?, vt.host_data_mut()?, layout)
+        }
+        (Tensor::C64(u), Tensor::C64(vt)) => {
+            canonicalize_svd_gauge_c64(u.host_data_mut()?, vt.host_data_mut()?, layout)
+        }
+        (Tensor::C32(u), Tensor::C32(vt)) => {
+            canonicalize_svd_gauge_c32(u.host_data_mut()?, vt.host_data_mut()?, layout)
+        }
         (u, vt) => Err(Error::DTypeMismatch {
             op: "tenferro-linalg.svd",
             lhs: u.dtype(),
@@ -822,28 +802,105 @@ fn apply_canonical_pivot_svd_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::R
     }
 }
 
-fn canonicalize_svd_gauge_f64(
-    u: &mut [f64],
-    vt: &mut [f64],
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct CanonicalSvdGaugeLayout {
+    m: usize,
+    k: usize,
+    batch_count: usize,
+    u_batch_len: usize,
+    vt_batch_len: usize,
+    u_len: usize,
+    vt_len: usize,
+}
+
+impl CanonicalSvdGaugeLayout {
+    fn validate_storage(self, u_len: usize, vt_len: usize) -> tenferro_tensor::Result<()> {
+        if u_len != self.u_len {
+            return Err(Error::InvalidConfig {
+                op: "tenferro-linalg.svd",
+                message: format!(
+                    "canonical SVD gauge expected U storage length {}, got {u_len}",
+                    self.u_len
+                ),
+            });
+        }
+        if vt_len != self.vt_len {
+            return Err(Error::InvalidConfig {
+                op: "tenferro-linalg.svd",
+                message: format!(
+                    "canonical SVD gauge expected VT storage length {}, got {vt_len}",
+                    self.vt_len
+                ),
+            });
+        }
+        Ok(())
+    }
+}
+
+fn canonical_svd_gauge_layout(
     m: usize,
     k: usize,
     n: usize,
-    batch_count: usize,
+    batch_shape: &[usize],
+) -> tenferro_tensor::Result<CanonicalSvdGaugeLayout> {
+    let batch_count = tenferro_tensor::validate::checked_shape_product(
+        "tenferro-linalg.svd",
+        "canonical SVD batch",
+        batch_shape,
+    )?;
+    let u_batch_len = tenferro_tensor::validate::checked_shape_product(
+        "tenferro-linalg.svd",
+        "canonical SVD U batch",
+        &[m, k],
+    )?;
+    let vt_batch_len = tenferro_tensor::validate::checked_shape_product(
+        "tenferro-linalg.svd",
+        "canonical SVD VT batch",
+        &[k, n],
+    )?;
+    let u_len = tenferro_tensor::validate::checked_shape_product(
+        "tenferro-linalg.svd",
+        "canonical SVD U storage",
+        &[u_batch_len, batch_count],
+    )?;
+    let vt_len = tenferro_tensor::validate::checked_shape_product(
+        "tenferro-linalg.svd",
+        "canonical SVD VT storage",
+        &[vt_batch_len, batch_count],
+    )?;
+    Ok(CanonicalSvdGaugeLayout {
+        m,
+        k,
+        batch_count,
+        u_batch_len,
+        vt_batch_len,
+        u_len,
+        vt_len,
+    })
+}
+
+fn canonicalize_svd_gauge_f64(
+    u: &mut [f64],
+    vt: &mut [f64],
+    layout: CanonicalSvdGaugeLayout,
 ) -> tenferro_tensor::Result<()> {
-    for batch in 0..batch_count {
-        let u_batch = batch * m * k;
-        let vt_batch = batch * k * n;
-        for col in 0..k {
-            let pivot = max_abs_pivot_f64(u, u_batch, m, col);
-            let pivot_value = u[u_batch + pivot + m * col];
+    layout.validate_storage(u.len(), vt.len())?;
+    if layout.batch_count == 0 || layout.u_batch_len == 0 || layout.vt_batch_len == 0 {
+        return Ok(());
+    }
+    for (u_batch, vt_batch) in u
+        .chunks_exact_mut(layout.u_batch_len)
+        .zip(vt.chunks_exact_mut(layout.vt_batch_len))
+    {
+        for (col, u_column) in u_batch.chunks_exact_mut(layout.m).enumerate() {
+            let pivot = max_abs_pivot_f64(u_column);
+            let pivot_value = u_column[pivot];
             if pivot_value < 0.0 {
-                for row in 0..m {
-                    let offset = u_batch + row + m * col;
-                    u[offset] = -u[offset];
+                for value in u_column {
+                    *value = -*value;
                 }
-                for vt_col in 0..n {
-                    let offset = vt_batch + col + k * vt_col;
-                    vt[offset] = -vt[offset];
+                for vt_column in vt_batch.chunks_exact_mut(layout.k) {
+                    vt_column[col] = -vt_column[col];
                 }
             }
         }
@@ -854,25 +911,25 @@ fn canonicalize_svd_gauge_f64(
 fn canonicalize_svd_gauge_f32(
     u: &mut [f32],
     vt: &mut [f32],
-    m: usize,
-    k: usize,
-    n: usize,
-    batch_count: usize,
+    layout: CanonicalSvdGaugeLayout,
 ) -> tenferro_tensor::Result<()> {
-    for batch in 0..batch_count {
-        let u_batch = batch * m * k;
-        let vt_batch = batch * k * n;
-        for col in 0..k {
-            let pivot = max_abs_pivot_f32(u, u_batch, m, col);
-            let pivot_value = u[u_batch + pivot + m * col];
+    layout.validate_storage(u.len(), vt.len())?;
+    if layout.batch_count == 0 || layout.u_batch_len == 0 || layout.vt_batch_len == 0 {
+        return Ok(());
+    }
+    for (u_batch, vt_batch) in u
+        .chunks_exact_mut(layout.u_batch_len)
+        .zip(vt.chunks_exact_mut(layout.vt_batch_len))
+    {
+        for (col, u_column) in u_batch.chunks_exact_mut(layout.m).enumerate() {
+            let pivot = max_abs_pivot_f32(u_column);
+            let pivot_value = u_column[pivot];
             if pivot_value < 0.0 {
-                for row in 0..m {
-                    let offset = u_batch + row + m * col;
-                    u[offset] = -u[offset];
+                for value in u_column {
+                    *value = -*value;
                 }
-                for vt_col in 0..n {
-                    let offset = vt_batch + col + k * vt_col;
-                    vt[offset] = -vt[offset];
+                for vt_column in vt_batch.chunks_exact_mut(layout.k) {
+                    vt_column[col] = -vt_column[col];
                 }
             }
         }
@@ -883,30 +940,30 @@ fn canonicalize_svd_gauge_f32(
 fn canonicalize_svd_gauge_c64(
     u: &mut [Complex64],
     vt: &mut [Complex64],
-    m: usize,
-    k: usize,
-    n: usize,
-    batch_count: usize,
+    layout: CanonicalSvdGaugeLayout,
 ) -> tenferro_tensor::Result<()> {
-    for batch in 0..batch_count {
-        let u_batch = batch * m * k;
-        let vt_batch = batch * k * n;
-        for col in 0..k {
-            let pivot = max_abs_pivot_c64(u, u_batch, m, col);
-            let pivot_value = u[u_batch + pivot + m * col];
+    layout.validate_storage(u.len(), vt.len())?;
+    if layout.batch_count == 0 || layout.u_batch_len == 0 || layout.vt_batch_len == 0 {
+        return Ok(());
+    }
+    for (u_batch, vt_batch) in u
+        .chunks_exact_mut(layout.u_batch_len)
+        .zip(vt.chunks_exact_mut(layout.vt_batch_len))
+    {
+        for (col, u_column) in u_batch.chunks_exact_mut(layout.m).enumerate() {
+            let pivot = max_abs_pivot_c64(u_column);
+            let pivot_value = u_column[pivot];
             let pivot_norm = pivot_value.norm();
             if pivot_norm == 0.0 {
                 continue;
             }
             let phase = pivot_value.conj() / pivot_norm;
             let vt_phase = phase.conj();
-            for row in 0..m {
-                let offset = u_batch + row + m * col;
-                u[offset] *= phase;
+            for value in u_column {
+                *value *= phase;
             }
-            for vt_col in 0..n {
-                let offset = vt_batch + col + k * vt_col;
-                vt[offset] *= vt_phase;
+            for vt_column in vt_batch.chunks_exact_mut(layout.k) {
+                vt_column[col] *= vt_phase;
             }
         }
     }
@@ -916,41 +973,41 @@ fn canonicalize_svd_gauge_c64(
 fn canonicalize_svd_gauge_c32(
     u: &mut [Complex32],
     vt: &mut [Complex32],
-    m: usize,
-    k: usize,
-    n: usize,
-    batch_count: usize,
+    layout: CanonicalSvdGaugeLayout,
 ) -> tenferro_tensor::Result<()> {
-    for batch in 0..batch_count {
-        let u_batch = batch * m * k;
-        let vt_batch = batch * k * n;
-        for col in 0..k {
-            let pivot = max_abs_pivot_c32(u, u_batch, m, col);
-            let pivot_value = u[u_batch + pivot + m * col];
+    layout.validate_storage(u.len(), vt.len())?;
+    if layout.batch_count == 0 || layout.u_batch_len == 0 || layout.vt_batch_len == 0 {
+        return Ok(());
+    }
+    for (u_batch, vt_batch) in u
+        .chunks_exact_mut(layout.u_batch_len)
+        .zip(vt.chunks_exact_mut(layout.vt_batch_len))
+    {
+        for (col, u_column) in u_batch.chunks_exact_mut(layout.m).enumerate() {
+            let pivot = max_abs_pivot_c32(u_column);
+            let pivot_value = u_column[pivot];
             let pivot_norm = pivot_value.norm();
             if pivot_norm == 0.0 {
                 continue;
             }
             let phase = pivot_value.conj() / pivot_norm;
             let vt_phase = phase.conj();
-            for row in 0..m {
-                let offset = u_batch + row + m * col;
-                u[offset] *= phase;
+            for value in u_column {
+                *value *= phase;
             }
-            for vt_col in 0..n {
-                let offset = vt_batch + col + k * vt_col;
-                vt[offset] *= vt_phase;
+            for vt_column in vt_batch.chunks_exact_mut(layout.k) {
+                vt_column[col] *= vt_phase;
             }
         }
     }
     Ok(())
 }
 
-fn max_abs_pivot_f64(u: &[f64], u_batch: usize, m: usize, col: usize) -> usize {
+fn max_abs_pivot_f64(u_column: &[f64]) -> usize {
     let mut pivot = 0;
-    let mut pivot_abs = u[u_batch + m * col].abs();
-    for row in 1..m {
-        let candidate_abs = u[u_batch + row + m * col].abs();
+    let mut pivot_abs = u_column[0].abs();
+    for (row, value) in u_column.iter().enumerate().skip(1) {
+        let candidate_abs = value.abs();
         if candidate_abs > pivot_abs {
             pivot = row;
             pivot_abs = candidate_abs;
@@ -959,11 +1016,11 @@ fn max_abs_pivot_f64(u: &[f64], u_batch: usize, m: usize, col: usize) -> usize {
     pivot
 }
 
-fn max_abs_pivot_f32(u: &[f32], u_batch: usize, m: usize, col: usize) -> usize {
+fn max_abs_pivot_f32(u_column: &[f32]) -> usize {
     let mut pivot = 0;
-    let mut pivot_abs = u[u_batch + m * col].abs();
-    for row in 1..m {
-        let candidate_abs = u[u_batch + row + m * col].abs();
+    let mut pivot_abs = u_column[0].abs();
+    for (row, value) in u_column.iter().enumerate().skip(1) {
+        let candidate_abs = value.abs();
         if candidate_abs > pivot_abs {
             pivot = row;
             pivot_abs = candidate_abs;
@@ -972,11 +1029,11 @@ fn max_abs_pivot_f32(u: &[f32], u_batch: usize, m: usize, col: usize) -> usize {
     pivot
 }
 
-fn max_abs_pivot_c64(u: &[Complex64], u_batch: usize, m: usize, col: usize) -> usize {
+fn max_abs_pivot_c64(u_column: &[Complex64]) -> usize {
     let mut pivot = 0;
-    let mut pivot_abs = u[u_batch + m * col].norm_sqr();
-    for row in 1..m {
-        let candidate_abs = u[u_batch + row + m * col].norm_sqr();
+    let mut pivot_abs = u_column[0].norm_sqr();
+    for (row, value) in u_column.iter().enumerate().skip(1) {
+        let candidate_abs = value.norm_sqr();
         if candidate_abs > pivot_abs {
             pivot = row;
             pivot_abs = candidate_abs;
@@ -985,11 +1042,11 @@ fn max_abs_pivot_c64(u: &[Complex64], u_batch: usize, m: usize, col: usize) -> u
     pivot
 }
 
-fn max_abs_pivot_c32(u: &[Complex32], u_batch: usize, m: usize, col: usize) -> usize {
+fn max_abs_pivot_c32(u_column: &[Complex32]) -> usize {
     let mut pivot = 0;
-    let mut pivot_abs = u[u_batch + m * col].norm_sqr();
-    for row in 1..m {
-        let candidate_abs = u[u_batch + row + m * col].norm_sqr();
+    let mut pivot_abs = u_column[0].norm_sqr();
+    for (row, value) in u_column.iter().enumerate().skip(1) {
+        let candidate_abs = value.norm_sqr();
         if candidate_abs > pivot_abs {
             pivot = row;
             pivot_abs = candidate_abs;

--- a/crates/tenferro-linalg/src/extension/tests.rs
+++ b/crates/tenferro-linalg/src/extension/tests.rs
@@ -9,8 +9,8 @@ use tenferro_tensor::{
 };
 
 use super::{
-    apply_eigh_gauge, apply_qr_gauge, apply_svd_gauge, promote_dtypes, EighGauge,
-    LinalgExtensionOp, LinalgOp, QrGauge, SvdGauge, LINALG_EXTENSION_FAMILY_ID,
+    apply_eigh_gauge, apply_qr_gauge, apply_svd_gauge, canonical_svd_gauge_layout, promote_dtypes,
+    EighGauge, LinalgExtensionOp, LinalgOp, QrGauge, SvdGauge, LINALG_EXTENSION_FAMILY_ID,
 };
 
 #[test]
@@ -200,6 +200,166 @@ fn canonical_pivot_svd_gauge_removes_complex_pivot_phase() {
     assert!((vt[0].im - scale).abs() < 1.0e-12);
     assert!((vt[1].re + 1.0 / scale).abs() < 1.0e-12);
     assert!((vt[1].im - 7.0 / scale).abs() < 1.0e-12);
+}
+
+#[test]
+fn canonical_svd_gauge_rejects_batch_product_overflow() {
+    let error = canonical_svd_gauge_layout(1, 1, 1, &[usize::MAX, 2])
+        .expect_err("overflowing SVD batch shape should be rejected");
+
+    assert!(matches!(
+        error,
+        Error::InvalidConfig {
+            op: "tenferro-linalg.svd",
+            ..
+        }
+    ));
+    assert!(error.to_string().contains("canonical SVD batch"));
+}
+
+#[test]
+fn canonical_svd_gauge_rejects_u_batch_span_overflow() {
+    let error = canonical_svd_gauge_layout(usize::MAX, 2, 1, &[])
+        .expect_err("overflowing U batch span should be rejected");
+
+    assert!(matches!(
+        error,
+        Error::InvalidConfig {
+            op: "tenferro-linalg.svd",
+            ..
+        }
+    ));
+    assert!(error.to_string().contains("canonical SVD U batch"));
+}
+
+#[test]
+fn canonical_svd_gauge_rejects_vt_batch_span_overflow() {
+    let error = canonical_svd_gauge_layout(1, usize::MAX, 2, &[])
+        .expect_err("overflowing VT batch span should be rejected");
+
+    assert!(matches!(
+        error,
+        Error::InvalidConfig {
+            op: "tenferro-linalg.svd",
+            ..
+        }
+    ));
+    assert!(error.to_string().contains("canonical SVD VT batch"));
+}
+
+#[test]
+fn canonical_svd_gauge_rejects_u_storage_span_overflow() {
+    let error = canonical_svd_gauge_layout(usize::MAX, 1, 1, &[2])
+        .expect_err("overflowing U storage span should be rejected");
+
+    assert!(matches!(
+        error,
+        Error::InvalidConfig {
+            op: "tenferro-linalg.svd",
+            ..
+        }
+    ));
+    assert!(error.to_string().contains("canonical SVD U storage"));
+}
+
+#[test]
+fn canonical_svd_gauge_rejects_vt_storage_span_overflow() {
+    let error = canonical_svd_gauge_layout(1, 1, usize::MAX, &[2])
+        .expect_err("overflowing VT storage span should be rejected");
+
+    assert!(matches!(
+        error,
+        Error::InvalidConfig {
+            op: "tenferro-linalg.svd",
+            ..
+        }
+    ));
+    assert!(error.to_string().contains("canonical SVD VT storage"));
+}
+
+#[test]
+fn canonical_svd_gauge_rejects_short_u_storage() {
+    let layout = canonical_svd_gauge_layout(1, 1, 1, &[2]).unwrap();
+    let error = layout
+        .validate_storage(1, 2)
+        .expect_err("short U storage should be rejected before gauge indexing");
+
+    assert!(matches!(
+        error,
+        Error::InvalidConfig {
+            op: "tenferro-linalg.svd",
+            ..
+        }
+    ));
+    assert!(error
+        .to_string()
+        .contains("expected U storage length 2, got 1"));
+}
+
+#[test]
+fn canonical_pivot_svd_gauge_handles_batched_f32_and_c32_outputs() {
+    let mut real_outputs = vec![
+        Tensor::from_vec_col_major(vec![2, 1, 2], vec![-2.0_f32, 1.0, 0.5, -3.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![1, 2], vec![2.0_f32, 3.0]).unwrap(),
+        Tensor::from_vec_col_major(vec![1, 2, 2], vec![10.0_f32, 20.0, 30.0, 40.0]).unwrap(),
+    ];
+
+    apply_svd_gauge(SvdGauge::CanonicalPivot, &mut real_outputs).unwrap();
+
+    assert_eq!(
+        real_outputs[0].as_slice::<f32>().unwrap(),
+        &[2.0, -1.0, -0.5, 3.0]
+    );
+    assert_eq!(
+        real_outputs[2].as_slice::<f32>().unwrap(),
+        &[-10.0, -20.0, -30.0, -40.0]
+    );
+
+    let mut complex_outputs = vec![
+        Tensor::C32(
+            TypedTensor::from_vec_col_major(
+                vec![1, 1, 2],
+                vec![Complex32::new(1.0, 1.0), Complex32::new(0.0, -2.0)],
+            )
+            .unwrap(),
+        ),
+        Tensor::from_vec_col_major(vec![1, 2], vec![2.0_f32, 3.0]).unwrap(),
+        Tensor::C32(
+            TypedTensor::from_vec_col_major(
+                vec![1, 1, 2],
+                vec![Complex32::new(2.0, 0.0), Complex32::new(3.0, 0.0)],
+            )
+            .unwrap(),
+        ),
+    ];
+
+    apply_svd_gauge(SvdGauge::CanonicalPivot, &mut complex_outputs).unwrap();
+
+    let scale = 2.0_f32.sqrt();
+    let u = complex_outputs[0].as_slice::<Complex32>().unwrap();
+    assert!((u[0].re - scale).abs() < 1.0e-6);
+    assert!(u[0].im.abs() < 1.0e-6);
+    assert!((u[1].re - 2.0).abs() < 1.0e-6);
+    assert!(u[1].im.abs() < 1.0e-6);
+    let vt = complex_outputs[2].as_slice::<Complex32>().unwrap();
+    assert!((vt[0].re - scale).abs() < 1.0e-6);
+    assert!((vt[0].im - scale).abs() < 1.0e-6);
+    assert!(vt[1].re.abs() < 1.0e-6);
+    assert!((vt[1].im + 3.0).abs() < 1.0e-6);
+}
+
+#[test]
+fn canonical_pivot_svd_gauge_accepts_zero_batch() {
+    let mut outputs = vec![
+        Tensor::from_vec_col_major(vec![2, 1, 0], Vec::<f64>::new()).unwrap(),
+        Tensor::from_vec_col_major(vec![1, 0], Vec::<f64>::new()).unwrap(),
+        Tensor::from_vec_col_major(vec![1, 2, 0], Vec::<f64>::new()).unwrap(),
+    ];
+
+    apply_svd_gauge(SvdGauge::CanonicalPivot, &mut outputs).unwrap();
+
+    assert!(outputs[0].as_slice::<f64>().unwrap().is_empty());
+    assert!(outputs[2].as_slice::<f64>().unwrap().is_empty());
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/cpu_linalg_source_contract.rs
@@ -87,6 +87,15 @@ fn cpu_faer_linalg_source() -> String {
     .unwrap_or_else(|err| panic!("faer linalg source should be readable: {err}"))
 }
 
+fn linalg_extension_source() -> String {
+    fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("extension.rs"),
+    )
+    .unwrap_or_else(|err| panic!("linalg extension source should be readable: {err}"))
+}
+
 #[test]
 fn cpu_linalg_allocation_helpers_remain_fallible_and_checked() {
     let faer = cpu_faer_linalg_source();
@@ -392,6 +401,31 @@ fn linalg_batched_helpers_use_checked_products_and_slice_ranges() {
     assert!(
         !lu_factor.contains("batch * matrix_len") && !lu_factor.contains("start + matrix_len"),
         "faer LU factor batching must use checked_slice_range for batch windows"
+    );
+}
+
+#[test]
+fn canonical_svd_gauge_uses_checked_layout_without_raw_batch_offsets() {
+    let source = linalg_extension_source();
+    let gauge = source_section(
+        &source,
+        "fn apply_canonical_pivot_svd_gauge",
+        "fn require_matrix_meta",
+    );
+
+    for needle in [
+        ".iter().product::<usize>()",
+        "batch * m * k",
+        "batch * k * n",
+    ] {
+        assert!(
+            !gauge.contains(needle),
+            "canonical SVD gauge must use its checked layout instead of {needle}"
+        );
+    }
+    assert!(
+        gauge.contains("canonical_svd_gauge_layout(") && gauge.contains("validate_storage("),
+        "canonical SVD gauge should prepare and validate one checked layout"
     );
 }
 

--- a/crates/tenferro-runtime/src/extension/tests.rs
+++ b/crates/tenferro-runtime/src/extension/tests.rs
@@ -426,6 +426,49 @@ fn graph_analysis_resolves_unregistered_multi_output_parent_on_demand() {
 }
 
 #[test]
+fn graph_analysis_scope_retains_registered_parent_metadata_it_borrows() {
+    let input = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
+
+    let mut parent_builder = GraphBuilder::new();
+    parent_builder.add_parent(Arc::clone(&input.graph));
+    let parent_output = parent_builder.add_operation(
+        StdTensorOp::Neg,
+        vec![ValueRef::External(
+            input.graph.values()[input.val].key.clone(),
+        )],
+        OperationRole::Primary,
+    )[0];
+    parent_builder.set_outputs(vec![parent_output]);
+    let parent = Arc::new(parent_builder.build());
+    let parent_key = parent.values()[parent_output].key.clone();
+    let parent_analysis =
+        crate::metadata::register_scoped_graph_analysis(parent.as_ref(), []).unwrap();
+
+    let mut child_builder = GraphBuilder::new();
+    child_builder.add_parent(Arc::clone(&parent));
+    let child_output = child_builder.add_operation(
+        StdTensorOp::Neg,
+        vec![ValueRef::External(parent_key.clone())],
+        OperationRole::Primary,
+    )[0];
+    child_builder.set_outputs(vec![child_output]);
+    let child = child_builder.build();
+    let child_analysis = crate::metadata::register_scoped_graph_analysis(&child, []).unwrap();
+
+    drop(parent_analysis);
+
+    let retained = crate::metadata::registered_meta(&parent_key)
+        .expect("child analysis scope must retain metadata borrowed from its parent");
+    assert_eq!(retained.dtype, DType::F64);
+    assert_eq!(retained.bound_shape(), Some(vec![SymDim::from(3)]));
+    drop(child_analysis);
+    assert!(
+        crate::metadata::registered_meta(&parent_key).is_err(),
+        "dropping the final analysis scope must release the borrowed metadata"
+    );
+}
+
+#[test]
 fn parent_owner_index_is_built_once_for_many_parents_and_missing_inputs() {
     const PARENTS: usize = 8;
     let mut inputs = Vec::new();

--- a/crates/tenferro-runtime/src/metadata.rs
+++ b/crates/tenferro-runtime/src/metadata.rs
@@ -285,11 +285,10 @@ fn graph_analysis_registrations(
 ) -> Result<GraphAnalysisRegistrations> {
     let seeded: Vec<_> = seeded.into_iter().collect();
     // Start from just the seeded inputs. External keys not in `seeded` are
-    // resolved on demand via a single-key lookup against the global
-    // registry — crucially, we do NOT clone the entire global map. The
-    // global registry grows monotonically across a process, so a full-map
-    // snapshot per graph construction is quadratic in the total number
-    // of registered ops and dominated oracle_replay runtime.
+    // resolved on demand via a single-key lookup against the global registry
+    // and added to this analysis's scoped registrations. This acquires only
+    // metadata the graph actually borrows instead of cloning the entire map,
+    // while keeping the returned scope independent of the original owner.
     let mut known: HashMap<ValueKey<StdTensorOp>, TensorMeta> = seeded.iter().cloned().collect();
 
     let mut registrations = seeded;
@@ -342,18 +341,21 @@ fn append_graph_metadata_registrations(
         }
 
         if !collect_constraints {
-            let mut all_outputs_registered = true;
+            let mut registered_outputs = Vec::with_capacity(op_node.outputs.len());
             for &output_id in &op_node.outputs {
                 let key = graph.values()[output_id].key.clone();
                 let Some(meta) =
                     lookup_global_metadata(&key).map_err(|err| metadata_error(err.to_string()))?
                 else {
-                    all_outputs_registered = false;
                     break;
                 };
-                known.insert(key, meta);
+                registered_outputs.push((key, meta));
             }
-            if all_outputs_registered {
+            if registered_outputs.len() == op_node.outputs.len() {
+                for (key, meta) in registered_outputs {
+                    known.insert(key.clone(), meta.clone());
+                    registrations.push((key, meta));
+                }
                 continue;
             }
         }
@@ -377,6 +379,7 @@ fn append_graph_metadata_registrations(
                 lookup_global_metadata(key).map_err(|err| metadata_error(err.to_string()))?
             {
                 known.insert(key.clone(), meta.clone());
+                registrations.push((key.clone(), meta.clone()));
                 input_metas.push(meta);
                 continue;
             }

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -7,7 +7,7 @@ use crate::types::{
     DType, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Rank, StridedSliceSpec,
     Tensor, TensorBufferRef, TensorBufferRefMut, TensorLayout, TensorOwnedView, TensorRank,
     TensorRead, TensorScalar, TensorValue, TensorView, TensorViewMut, TensorWrite, TypedTensor,
-    TypedTensorView, TypedTensorViewMut,
+    TypedTensorView, TypedTensorViewMut, TypedTensorWrite,
 };
 use crate::{Error, SliceConfig};
 
@@ -1746,6 +1746,38 @@ fn tensor_write_wraps_owned_tensor_or_borrowed_mutable_view() {
         assert!(!write_view.is_col_major_contiguous().unwrap());
 
         write_view
+            .copy_from_tensor(&Tensor::from_vec_col_major(vec![2], vec![30.0_f64, 40.0]).unwrap())
+            .unwrap();
+    }
+    assert_eq!(data, [0.0, 30.0, 0.0, 40.0, 0.0]);
+}
+
+#[test]
+fn typed_tensor_write_wraps_owned_tensor_or_borrowed_mutable_view() {
+    let mut tensor = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap();
+    {
+        let typed_write = TypedTensorWrite::from_tensor(&mut tensor);
+        let mut write = typed_write.into_tensor_write();
+
+        assert_eq!(write.dtype(), DType::F64);
+        assert_eq!(write.shape(), &[2]);
+        write
+            .copy_from_tensor(&Tensor::from_vec_col_major(vec![2], vec![7.0_f64, 8.0]).unwrap())
+            .unwrap();
+    }
+    assert_eq!(tensor.as_slice().unwrap(), &[7.0, 8.0]);
+
+    let mut data = [0.0_f64, 10.0, 0.0, 20.0, 0.0];
+    {
+        let view = TypedTensorViewMut::from_slice([2], [2], 1, &mut data).unwrap();
+        let typed_write = TypedTensorWrite::from_view(view);
+        let mut write = typed_write.into_tensor_write();
+
+        assert_eq!(write.dtype(), DType::F64);
+        assert_eq!(write.shape(), &[2]);
+        assert_eq!(write.strides().unwrap(), [2]);
+        assert_eq!(write.offset(), 1);
+        write
             .copy_from_tensor(&Tensor::from_vec_col_major(vec![2], vec![30.0_f64, 40.0]).unwrap())
             .unwrap();
     }

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -1926,6 +1926,9 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// ```
     fn tensor_view<'a>(view: TypedTensorView<'a, Self>) -> TensorView<'a>;
 
+    /// Wrap a typed mutable borrowed view as a dtype-erased [`TensorViewMut`].
+    fn tensor_view_mut<'a>(view: TypedTensorViewMut<'a, Self>) -> TensorViewMut<'a>;
+
     /// Mutably borrow a typed tensor as a dtype-erased [`TensorWrite`] view.
     ///
     /// This keeps the typed output borrowed instead of wrapping it in a
@@ -2011,6 +2014,10 @@ macro_rules! impl_tensor_scalar {
 
             fn tensor_view<'a>(view: TypedTensorView<'a, Self>) -> TensorView<'a> {
                 TensorView::$variant(view)
+            }
+
+            fn tensor_view_mut<'a>(view: TypedTensorViewMut<'a, Self>) -> TensorViewMut<'a> {
+                TensorViewMut::$variant(view)
             }
 
             fn tensor_write(tensor: &mut TypedTensor<Self>) -> TensorWrite<'_> {
@@ -2179,6 +2186,68 @@ pub enum TensorViewMut<'a> {
 pub enum TensorRead<'a> {
     Tensor(&'a Tensor),
     View(TensorView<'a>),
+}
+
+/// Mutable typed tensor output accepted by synchronous eager kernels.
+///
+/// `TypedTensorWrite` is the typed counterpart to [`TensorWrite`]. It accepts
+/// either an owned compact [`TypedTensor`] or an arbitrary-strided mutable
+/// [`TypedTensorViewMut`] without erasing the scalar type at the public API
+/// boundary.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_tensor::{TypedTensorViewMut, TypedTensorWrite};
+///
+/// let mut data = [0.0_f64, 1.0, 0.0, 2.0];
+/// let view = TypedTensorViewMut::from_slice([2], [2], 1, &mut data)?;
+/// let write = TypedTensorWrite::from_view(view).into_tensor_write();
+/// assert_eq!(write.shape(), &[2]);
+/// assert_eq!(write.strides()?, [2]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum TypedTensorWrite<'a, T> {
+    /// An owned compact typed tensor borrowed mutably for the write.
+    Tensor(&'a mut TypedTensor<T>),
+    /// An arbitrary-strided mutable typed tensor view.
+    View(TypedTensorViewMut<'a, T>),
+}
+
+impl<'a, T> TypedTensorWrite<'a, T> {
+    /// Create a writable target from an owned typed tensor.
+    pub fn from_tensor(tensor: &'a mut TypedTensor<T>) -> Self {
+        Self::Tensor(tensor)
+    }
+
+    /// Create a writable target from a mutable typed tensor view.
+    pub fn from_view(view: TypedTensorViewMut<'a, T>) -> Self {
+        Self::View(view)
+    }
+}
+
+impl<'a, T: TensorScalar> TypedTensorWrite<'a, T> {
+    /// Erase the scalar type while preserving the output layout.
+    pub fn into_tensor_write(self) -> TensorWrite<'a> {
+        match self {
+            Self::Tensor(tensor) => T::tensor_write(tensor),
+            Self::View(view) => TensorWrite::from_view(T::tensor_view_mut(view)),
+        }
+    }
+}
+
+impl<'a, T> From<&'a mut TypedTensor<T>> for TypedTensorWrite<'a, T> {
+    fn from(tensor: &'a mut TypedTensor<T>) -> Self {
+        Self::from_tensor(tensor)
+    }
+}
+
+impl<'a, T> From<TypedTensorViewMut<'a, T>> for TypedTensorWrite<'a, T> {
+    fn from(view: TypedTensorViewMut<'a, T>) -> Self {
+        Self::from_view(view)
+    }
 }
 
 /// Mutable tensor output accepted by synchronous eager kernels.

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -1927,6 +1927,19 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     fn tensor_view<'a>(view: TypedTensorView<'a, Self>) -> TensorView<'a>;
 
     /// Wrap a typed mutable borrowed view as a dtype-erased [`TensorViewMut`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{DType, TensorScalar, TypedTensorViewMut};
+    ///
+    /// let mut data = [1.0_f64, 2.0];
+    /// let view = TypedTensorViewMut::from_col_major(&[2], &mut data)?;
+    /// let erased = f64::tensor_view_mut(view);
+    /// assert_eq!(erased.dtype(), DType::F64);
+    /// assert_eq!(erased.shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn tensor_view_mut<'a>(view: TypedTensorViewMut<'a, Self>) -> TensorViewMut<'a>;
 
     /// Mutably borrow a typed tensor as a dtype-erased [`TensorWrite`] view.
@@ -2218,11 +2231,34 @@ pub enum TypedTensorWrite<'a, T> {
 
 impl<'a, T> TypedTensorWrite<'a, T> {
     /// Create a writable target from an owned typed tensor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{TypedTensor, TypedTensorWrite};
+    ///
+    /// let mut tensor = TypedTensor::<f64>::from_vec_col_major(vec![1], vec![0.0])?;
+    /// let write = TypedTensorWrite::from_tensor(&mut tensor);
+    /// assert!(matches!(write, TypedTensorWrite::Tensor(_)));
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn from_tensor(tensor: &'a mut TypedTensor<T>) -> Self {
         Self::Tensor(tensor)
     }
 
     /// Create a writable target from a mutable typed tensor view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{TypedTensorViewMut, TypedTensorWrite};
+    ///
+    /// let mut data = [0.0_f64, 1.0];
+    /// let view = TypedTensorViewMut::from_col_major(&[2], &mut data)?;
+    /// let write = TypedTensorWrite::from_view(view);
+    /// assert!(matches!(write, TypedTensorWrite::View(_)));
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn from_view(view: TypedTensorViewMut<'a, T>) -> Self {
         Self::View(view)
     }
@@ -2230,6 +2266,18 @@ impl<'a, T> TypedTensorWrite<'a, T> {
 
 impl<'a, T: TensorScalar> TypedTensorWrite<'a, T> {
     /// Erase the scalar type while preserving the output layout.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::{DType, TypedTensor, TypedTensorWrite};
+    ///
+    /// let mut tensor = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0; 2])?;
+    /// let write = TypedTensorWrite::from_tensor(&mut tensor).into_tensor_write();
+    /// assert_eq!(write.dtype(), DType::F64);
+    /// assert_eq!(write.shape(), &[2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     pub fn into_tensor_write(self) -> TensorWrite<'a> {
         match self {
             Self::Tensor(tensor) => T::tensor_write(tensor),

--- a/docs/design/api-and-convention-freeze.md
+++ b/docs/design/api-and-convention-freeze.md
@@ -130,8 +130,9 @@ Release APIs should follow these naming and shape rules.
   otherwise they use methods.
 - Multi-output linalg and decomposition ops are tensor extension-trait methods.
 - Einsum is owned by `tenferro-einsum` through crate-root extension traits:
-  concrete input slices/arrays use `TensorEinsumExt`, `TypedTensorEinsumExt`,
-  and `TensorReadEinsumExt`; repeated concrete executions use
+  concrete owned input slices/arrays use `TensorEinsumExt` and
+  `TypedTensorEinsumExt`, while borrowed inputs use `TensorReadEinsumExt` and
+  `TypedTensorReadEinsumExt`; repeated concrete executions use
   `ConcreteEinsumPlan`; traced graph construction uses
   `GraphCompilerEinsumExt`; autodiff eager inputs use `EagerEinsumExt`.
 - Traced tensor methods do not use a `traced_` prefix.

--- a/docs/design/einsum.md
+++ b/docs/design/einsum.md
@@ -2,9 +2,10 @@
 
 Einsum is a standard extension crate, not part of a root facade.
 The public user-facing paths live under `tenferro_einsum` as crate-root
-extension traits: `TensorEinsumExt`, `TypedTensorEinsumExt`, and
-`TensorReadEinsumExt` for concrete backend-explicit execution, their
-`*IntoExt` counterparts for preallocated output execution,
+extension traits: `TensorEinsumExt` and `TypedTensorEinsumExt` for owned
+concrete inputs, `TensorReadEinsumExt` and `TypedTensorReadEinsumExt` for
+borrowed inputs, and their `*IntoExt` counterparts for preallocated output
+execution,
 `GraphCompilerEinsumExt` for traced graph construction, `EagerEinsumExt` for
 autodiff eager execution, and tensor extension traits for `tensordot`
 contraction sugar. `ConcreteEinsumPlan` owns repeated concrete executions with
@@ -76,12 +77,13 @@ assert_eq!(c.shape(), &[2, 2]);
 ```
 
 `TensorEinsumExt` is the unsuffixed API for compact `Tensor` references.
-`TypedTensorEinsumExt` preserves a statically known scalar type and also
-accepts borrowed typed strided views.
-`TensorReadEinsumExt::einsum_read` accepts `TensorRead` values and therefore
-uses the repository-wide `_read` suffix convention. `TensorEinsumIntoExt`,
-`TypedTensorEinsumIntoExt`, and `TensorReadEinsumIntoExt` write into caller
-provided `TensorWrite` or typed tensor outputs; they validate output dtype and
+`TypedTensorEinsumExt` preserves a statically known scalar type for owned typed
+tensors. Borrowed typed strided views use
+`TypedTensorReadEinsumExt::einsum_read`; dtype-erased borrowed inputs use
+`TensorReadEinsumExt::einsum_read`. Both follow the repository-wide `_read`
+suffix convention. The matching `*IntoExt` traits write into caller-provided
+outputs. Typed output methods accept `TypedTensorWrite`, which represents an
+owned typed tensor or a mutable typed view. All paths validate output dtype and
 shape before any writes and never resize the destination.
 
 `ConcreteEinsumPlan` precomputes the contraction tree for fixed input metadata

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -89,7 +89,7 @@ operations.
 | Need | Without autodiff | Eager path | Traced path |
 | --- | --- | --- | --- |
 | Everyday tensor ops | `TensorOpsExt` / `TypedTensorOpsExt` backend-explicit methods | `EagerTensor` methods / associated functions | `TracedTensor` methods / associated functions |
-| Einsum | `[&a, &b].einsum(...)` via `TensorEinsumExt` / `TypedTensorEinsumExt`; `TensorReadEinsumExt` for views; `ConcreteEinsumPlan` for repeated fixed metadata | `[&a, &b].einsum(...)` via `EagerEinsumExt` | `compiler.einsum(...)` via `GraphCompilerEinsumExt` plus `register_runtime` |
+| Einsum | `[&a, &b].einsum(...)` via `TensorEinsumExt` / `TypedTensorEinsumExt`; `TensorReadEinsumExt` / `TypedTensorReadEinsumExt` for views; `ConcreteEinsumPlan` for repeated fixed metadata | `[&a, &b].einsum(...)` via `EagerEinsumExt` | `compiler.einsum(...)` via `GraphCompilerEinsumExt` plus `register_runtime` |
 | FFT | `x.fft(...)` via `TensorFftExt`; `read.fft_read(...)` via `TensorReadFftExt` | Not exposed today | `x.fft(...)` via `TracedTensorFftExt` plus `register_runtime` |
 | Tensordot sugar | Use `matmul` or `dot_general` directly | `a.tensordot(&b, axes)` via `EagerTensorEinsumExt` | `a.tensordot(&b, axes)` via `TracedTensorEinsumExt` |
 | Linear algebra | `tenferro_linalg::LinalgBackend` methods on a backend | `EagerTensorLinalgExt` methods with `autodiff` | `TracedTensorLinalgExt` methods |

--- a/docs/guides/einsum.md
+++ b/docs/guides/einsum.md
@@ -2,11 +2,11 @@
 
 `einsum` is a standard extension, not part of `tenferro` core. Add the
 `tenferro-einsum` crate and import its extension traits. Concrete tensor
-execution uses `TensorEinsumExt`, `TypedTensorEinsumExt`, and
-`TensorReadEinsumExt`; preallocated-output execution uses the matching
-`TensorEinsumIntoExt`, `TypedTensorEinsumIntoExt`, and
-`TensorReadEinsumIntoExt` traits; repeated-shape concrete workloads can use
-`ConcreteEinsumPlan`. Traced graph construction uses `GraphCompilerEinsumExt`;
+execution uses `TensorEinsumExt` and `TypedTensorEinsumExt` for owned inputs,
+and `TensorReadEinsumExt` and `TypedTensorReadEinsumExt` for borrowed inputs;
+preallocated-output execution uses the matching `*IntoExt` traits;
+repeated-shape concrete workloads can use `ConcreteEinsumPlan`. Traced graph
+construction uses `GraphCompilerEinsumExt`;
 autodiff eager execution uses `EagerEinsumExt`; `tensordot` contraction sugar
 uses tensor extension traits. Compiled traced execution also requires explicit
 runtime registration for einsum extension ops.
@@ -66,9 +66,12 @@ use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::{
     TensorEinsumExt, TensorEinsumIntoExt, TypedTensorEinsumExt,
-    TypedTensorEinsumIntoExt,
+    TypedTensorEinsumIntoExt, TypedTensorReadEinsumIntoExt,
 };
-use tenferro_tensor::{Tensor, TensorWrite, TypedTensor, TypedTensorView};
+use tenferro_tensor::{
+    Tensor, TensorWrite, TypedTensor, TypedTensorView, TypedTensorViewMut,
+    TypedTensorWrite,
+};
 
 let lhs = Tensor::from_vec_col_major(
     vec![2, 3],
@@ -111,23 +114,29 @@ assert_eq!(
 
 let borrowed = TypedTensorView::from_slice([2, 2], [1, 2], 0, complex_lhs.as_slice()?)?;
 let borrowed_rhs = complex_rhs.as_view();
-let mut borrowed_out = TypedTensor::<Complex64>::from_vec_col_major(
-    vec![2, 1],
-    vec![Complex64::new(0.0, 0.0); 2],
+let mut borrowed_storage = [Complex64::new(0.0, 0.0); 4];
+let borrowed_out =
+    TypedTensorViewMut::from_slice([2, 1], [2, 4], 1, &mut borrowed_storage)?;
+[borrowed, borrowed_rhs].einsum_read_into(
+    "ij,jk->ik",
+    &mut backend,
+    TypedTensorWrite::from_view(borrowed_out),
 )?;
-[borrowed, borrowed_rhs].einsum_into("ij,jk->ik", &mut backend, &mut borrowed_out)?;
 assert_eq!(
-    borrowed_out.as_slice()?,
-    &[Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)],
+    [borrowed_storage[1], borrowed_storage[3]],
+    [Complex64::new(23.0, 2.0), Complex64::new(36.0, 3.0)],
 );
 # Ok::<(), tenferro_tensor::Error>(())
 ```
 
 ## TensorRead And Prepared Plans
 
-Use `TensorReadEinsumExt` when any input is a borrowed view. The `_read` suffix
-is reserved for this `TensorRead`-style API; compact owned `Tensor` inputs use
-the unsuffixed `einsum` method.
+Use `TensorReadEinsumExt` for dtype-erased borrowed inputs and
+`TypedTensorReadEinsumExt` for typed borrowed views. The `_read` suffix is
+reserved for these read-oriented APIs; compact owned tensor inputs use the
+unsuffixed `einsum` method. Typed `_into` methods accept `TypedTensorWrite`, so
+the destination can be either an owned `TypedTensor` or a
+`TypedTensorViewMut`.
 
 Use `ConcreteEinsumPlan` when the same subscripts, dtypes, and shapes are
 executed repeatedly. Preparing the plan parses and optimizes the contraction

--- a/docs/spec/api-conventions.md
+++ b/docs/spec/api-conventions.md
@@ -65,13 +65,15 @@ The default stratum is internal.
    otherwise they use methods.
 3. Multi-output linalg and decomposition ops are tensor extension-trait methods.
 4. Einsum is exposed through extension traits owned by `tenferro-einsum`:
-   `TensorEinsumExt`, `TypedTensorEinsumExt`, and `TensorReadEinsumExt` for
-   concrete input slices/arrays; `TensorEinsumIntoExt`,
-   `TypedTensorEinsumIntoExt`, and `TensorReadEinsumIntoExt` for
+   `TensorEinsumExt` and `TypedTensorEinsumExt` for owned concrete input
+   slices/arrays, and `TensorReadEinsumExt` and `TypedTensorReadEinsumExt` for
+   borrowed-view inputs; `TensorEinsumIntoExt`, `TypedTensorEinsumIntoExt`,
+   `TensorReadEinsumIntoExt`, and `TypedTensorReadEinsumIntoExt` for
    preallocated-output concrete execution; `ConcreteEinsumPlan` for repeated
    concrete executions with fixed input metadata; `GraphCompilerEinsumExt` for
    traced graph construction; and `EagerEinsumExt` for autodiff eager input
-   slices/arrays.
+   slices/arrays. Typed preallocated outputs use `TypedTensorWrite` so both
+   owned typed tensors and mutable typed views are accepted.
 5. Standard operation families are first-class crates, not modules under a
    broad facade.
 

--- a/docs/spec/operation-categories.md
+++ b/docs/spec/operation-categories.md
@@ -145,10 +145,11 @@ and traced surfaces (subject to the same parity rule within each family):
   `triangular_solve`, `cholesky`, `lu`, `full_piv_lu` through
   `TracedTensorLinalgExt` / `EagerTensorLinalgExt`.
 - **Einsum** (`tenferro-einsum`): `einsum` + contraction planning.
-  Concrete inputs use `TensorEinsumExt`, `TypedTensorEinsumExt`,
-  `TensorReadEinsumExt`, and `ConcreteEinsumPlan`; traced graph construction
-  uses `GraphCompilerEinsumExt`; autodiff eager inputs use `EagerEinsumExt`;
-  `tensordot` sugar uses tensor extension traits.
+  Concrete inputs use `TensorEinsumExt` and `TypedTensorEinsumExt` for owned
+  tensors, `TensorReadEinsumExt` and `TypedTensorReadEinsumExt` for borrowed
+  views, and `ConcreteEinsumPlan` for repeated execution; traced graph
+  construction uses `GraphCompilerEinsumExt`; autodiff eager inputs use
+  `EagerEinsumExt`; `tensordot` sugar uses tensor extension traits.
 - **FFT** (`tenferro-fft`): `fft`, `ifft`, `rfft`, and `irfft`.
   Concrete inputs use `TensorFftExt` and `TensorReadFftExt`; traced graph
   construction uses `TracedTensorFftExt`.

--- a/docs/superpowers/specs/2026-07-15-batched-bug-remediation-design.md
+++ b/docs/superpowers/specs/2026-07-15-batched-bug-remediation-design.md
@@ -1,0 +1,327 @@
+# Batched Bug Remediation Design
+
+## Status
+
+The six-issue batch and the one-PR strategy were approved interactively on
+2026-07-15. This document records the proposed implementation boundary before
+an implementation plan is written.
+
+The work starts from `origin/main` at `50c6623d` and follows the repository
+remediation workflow: one branch, coherent commits, one PR after local
+verification, and a non-squash merge.
+
+## Goals
+
+- Fix issues #1275, #1276, #1368, #1375, #1381, and #1385 at their root
+  contracts rather than adding compatibility shims around the defects.
+- Use `docs/design/api-and-convention-freeze.md` as the canonical decision for
+  #1276: unsuffixed methods operate on owned tensors, `_read` methods operate on
+  borrowed views, and mutable output surfaces accept both owned tensors and
+  mutable views.
+- Preserve CPU/GPU numerical parity for NaNs, signed zero, infinities, and
+  integer overflow semantics.
+- Eliminate avoidable pool construction, environment reads, and tensor-read
+  descriptor clones from repeated CPU execution.
+- Keep each issue reviewable as a coherent commit while delivering a single
+  remediation PR.
+
+## Non-goals
+
+- Adding a new backend, operation family, dependency, feature flag, or AD
+  convention.
+- Preserving public compatibility for APIs whose current shape is the confirmed
+  bug. The remediation workflow explicitly prefers the canonical root contract.
+- General CPU or GPU performance tuning beyond the repeated work identified by
+  #1385.
+- Expanding GPU integer support beyond the operation and dtype matrix already
+  claimed by the repository.
+- Rewriting historical documents under `docs/plans/`.
+
+## Classification Ledger
+
+| Issue | Classification | Current evidence | Planned disposition | Smallest verification target |
+| --- | --- | --- | --- | --- |
+| [#1375](https://github.com/tensor4all/tenferro-rs/issues/1375) | Auto Fix | SVD gauge batch count uses unchecked `product::<usize>()` and later derives batch offsets from it. | Introduce checked batch metadata and use it for all gauge batch traversal. | Overflow helper tests plus batched real/complex SVD gauge tests. |
+| [#1368](https://github.com/tensor4all/tenferro-rs/issues/1368) | Auto Fix | CPU maximum/minimum explicitly propagate NaN; CubeCL elementwise and reduction paths use native `.max()`/`.min()` directly. | Route GPU maximum/minimum combines through shared NaN-propagating helpers. | f32/f64 elementwise and reduction parity for both NaN operand orders, signed zero, and infinities. |
+| [#1381](https://github.com/tensor4all/tenferro-rs/issues/1381) | Verify First, then Auto Fix | Current CubeCL lowering wraps integer arithmetic, and tests observe wrapping, but source uses bare operators and does not state the contract. | Confine bare CubeCL IR operations to documented `wrapping_*` helpers and make all integer call sites explicit. | Existing overflow tests plus source-contract inventory and boundary-value cases. |
+| [#1276](https://github.com/tensor4all/tenferro-rs/issues/1276) | Auto Fix | Typed tensor views implement unsuffixed einsum traits, and typed `_into` output accepts only `&mut TypedTensor<T>`, unlike the canonical owned/read and tensor/write vocabulary. | Split owned/read traits and add a typed write adapter accepting owned mutable tensors or mutable typed views. | Public-surface contract tests, doctests, owned/read execution, and both output forms. |
+| [#1275](https://github.com/tensor4all/tenferro-rs/issues/1275) | Auto Fix | Public CPU free functions allocate a new local `BufferPool`, bypassing `CpuBackend`, `CpuContext`, placement, and reusable execution resources. | Remove the bypassing public surface and route documented usage through `CpuBackend` plus backend traits. | Public-surface inventory, migrated doctests, and backend pool-reuse tests. |
+| [#1385](https://github.com/tensor4all/tenferro-rs/issues/1385) | Auto Fix | `BufferPoolLoan::new` uses `mem::take`, whose replacement constructs maps and reads the retention-limit environment variable; read GEMM internals consume descriptors and force callers to clone them. | Borrow the installed pool directly, cache the default environment-derived limit, and borrow GEMM read descriptors. | Allocation/overhead benchmarks, pool restoration tests, panic tests, and direct/read GEMM parity. |
+
+The ledger will be reconciled against the issue tracker immediately before
+starting each commit. A newly fixed or narrowed item will be marked stale or
+narrowed rather than reimplemented from historical wording.
+
+## Overall Delivery Strategy
+
+The batch uses one branch and one final PR, but it is not one undifferentiated
+change. Each commit has its own regression boundary and leaves the workspace in
+a passing state. The recommended order starts with small correctness fixes,
+then changes the public API, and finishes with the CPU hot-path refactor. This
+keeps failures attributable and makes the last benchmark comparison measure the
+final public execution path.
+
+The final PR body will reproduce the classification ledger, link the work log,
+state any GPU verification unavailable locally, and close only issues fully
+resolved by the batch.
+
+## #1375: Checked SVD Gauge Batch Metadata
+
+The SVD gauge code must not treat a successful output-shape check as proof that
+all later products and offsets fit in `usize`. A small internal preparation
+helper will validate the `u`, singular-value, and `vt` batch shapes and compute:
+
+- checked batch count;
+- checked per-batch matrix spans;
+- checked offsets or ranges used by the gauge loop.
+
+The execution loop will consume this prepared metadata instead of recomputing
+shape products. Errors remain typed linalg configuration/backend errors and are
+reported before indexing or mutation. Zero-sized batches remain valid no-ops.
+
+Tests will exercise synthetic overflowing dimensions through the preparation
+helper so no impossible allocation is required. Existing batched f32, f64, c32,
+and c64 gauge behavior will remain covered, including zero-batch and malformed
+output cases. A source-contract test will prevent reintroduction of unchecked
+batch `product()` in the gauge family.
+
+## #1368: NaN-Propagating GPU Extrema
+
+CubeCL elementwise and reduction code will share two generic helpers equivalent
+to the CPU contract:
+
+```text
+maximum(a, b): if a is NaN return a; else if b is NaN return b; else native max
+minimum(a, b): if a is NaN return a; else if b is NaN return b; else native min
+```
+
+Returning the encountered NaN avoids inventing host-side values and keeps the
+operation device-native. Non-NaN values continue through CubeCL's native
+maximum/minimum so signed-zero and infinity behavior is preserved.
+
+The helpers will be used by:
+
+- binary elementwise maximum/minimum;
+- unit reductions;
+- plane reductions;
+- any adjacent combine stage found by the required neighborhood scan.
+
+Feature-gated CUDA tests will compare GPU results with CPU results for f32 and
+f64, NaN in either operand order and at different reduction positions, positive
+and negative zero, infinities, unit reduction, and plane reduction. Source-only
+contract tests remain useful on hosts without CUDA but do not replace runtime
+CUDA verification.
+
+## #1381: Explicit GPU Integer Wrapping
+
+The repository already specifies wrapping integer arithmetic, and current
+CubeCL lowering behaves that way. The defect is that bare operators at call
+sites make the intended overflow contract implicit and vulnerable to a future
+lowering or compiler change.
+
+CubeCL does not currently expose Rust-style `wrapping_*` intrinsics for this
+generic kernel layer. Therefore the implementation will centralize the
+permitted bare IR expressions in small helpers named for the semantic contract,
+for example `wrapping_add`, `wrapping_sub`, `wrapping_mul`, `wrapping_neg`, and
+the wrapping accumulation helpers required by reduction and integer power.
+Each helper will carry an `INVARIANT` comment tying the expression to verified
+CubeCL lowering. Kernel call sites will use only these helpers.
+
+Division, remainder, negative exponent, and other domain errors keep their
+existing preflight validation; wrapping helpers must not weaken those checks.
+Integer extrema and comparisons are not overflow operations and remain direct.
+
+The implementation begins by compiling and running a minimal boundary probe for
+the active CubeCL version. If that probe disproves wrapping lowering for any
+operation, that operation stops at the design gate instead of being relabeled
+with a misleading helper. Otherwise, i32/i64 tests cover min/max boundaries,
+negative values, multiplication, negation, power, and reduction accumulation.
+A source-contract inventory ensures new bare arithmetic cannot bypass the
+documented helper set.
+
+## #1276: Canonical Typed Einsum API
+
+`docs/design/api-and-convention-freeze.md` is authoritative. The typed API will
+match the dtype-erased API rather than preserving the current divergence.
+
+### Input trait split
+
+| Input surface | Trait | Method vocabulary |
+| --- | --- | --- |
+| Collections of owned `TypedTensor<T>` values or references to them | `TypedTensorEinsumExt<T>` | `einsum`, `einsum_subscripts` |
+| Collections of `TypedTensorView<'a, T>` | `TypedTensorReadEinsumExt<T>` | `einsum_read`, `einsum_read_subscripts` |
+| Owned typed inputs with caller-provided output | `TypedTensorEinsumIntoExt<T>` | `einsum_into`, `einsum_into_subscripts` |
+| Typed views with caller-provided output | `TypedTensorReadEinsumIntoExt<T>` | `einsum_read_into`, `einsum_read_into_subscripts` |
+
+Unsuffixed trait implementations for typed views will be removed. Compatibility
+aliases are intentionally excluded because they would preserve the
+inconsistency the issue asks to remove.
+
+### Typed mutable output
+
+`tenferro-tensor` will add a public `TypedTensorWrite<'a, T>` adapter with
+conversion from both:
+
+- `&'a mut TypedTensor<T>`;
+- `TypedTensorViewMut<'a, T>`.
+
+The adapter mirrors dtype-erased `TensorWrite` and exposes only the metadata and
+conversion operations needed by backends. Typed einsum `_into` methods and
+`ConcreteEinsumPlan::execute_typed_into` will accept any value convertible to
+this adapter. Validation occurs before execution and checks output dtype, shape,
+placement/residency requirements, and non-overlapping mutable layout through
+the existing view constructors and backend boundary.
+
+Every new public type, trait, and method receives runnable rustdoc examples.
+Tests cover owned inputs, borrowed strided inputs, owned output, strided mutable
+output, prepared-plan output, mismatched shape, and dtype/placement errors.
+Public-surface contract tests ensure view implementations cannot regain
+unsuffixed names.
+
+## #1275: Remove CPU Resource-Bypassing Free Functions
+
+The canonical CPU execution owner is `CpuBackend`, backed by `CpuContext` and
+engine-owned pools/caches. Public module-level helpers that construct a fresh
+`BufferPool` on every call create a second execution model and cannot be made
+consistent merely by hiding a global default backend.
+
+The fix will:
+
+- remove the crate-root free-function reexports that bypass `CpuBackend`;
+- make the corresponding module wrappers private or crate-private when they
+  are no longer part of the supported surface;
+- delete duplicated `with_local_pool` helpers;
+- retain the pool-aware internal kernels used by `CpuBackend` and sessions;
+- migrate rustdoc, README, guide, tutorial, and tests to explicit backend-trait
+  calls or higher-level tensor extension methods.
+
+No process-global default backend will be introduced. Callers that care about
+threading, placement, provider choice, caches, or buffer reuse must keep a
+backend/context handle. A public-surface contract test will inventory the
+removed names, while behavior tests will show repeated calls reuse the selected
+backend's pool.
+
+## #1385: Steady-State CPU Install And GEMM Overhead
+
+### Borrow execution resources without placeholder construction
+
+`BufferPoolLoan` currently moves the pool out with `mem::take`; constructing the
+temporary replacement creates fourteen `BTreeMap`s and rereads the environment.
+The loan will instead hold a direct mutable borrow of the engine-owned pool.
+Panic recovery remains the responsibility of pool in-flight accounting and the
+existing session/resource guard; no empty placeholder pool is required.
+
+Tests will preserve the current guarantees that buffers are returned after
+normal execution and replenished/restored after panic. The neighborhood scan
+will cover `install_with_pool`, `run_with_pool`, linalg pool access, and backend
+sessions so no sibling path retains `mem::take` solely to satisfy borrowing.
+
+### Read the default retention limit once
+
+Standalone `BufferPool::new()` still honors
+`TENFERRO_CPU_BUFFER_POOL_MAX_RETAINED_BYTES`, but the parsed process default is
+stored in `OnceLock`. Explicit constructors and runtime limit setters remain
+fully dynamic. Tests that mutate the environment will target the parsing helper
+directly or use subprocess isolation rather than depending on resettable global
+state.
+
+### Borrow GEMM descriptors
+
+Internal Faer, BLAS, and TBLIS read/into entry points will accept borrowed
+`&TensorRead` descriptors where they do not take ownership. `CpuBackend` and
+`CpuExecSession` will pass their existing descriptors by reference instead of
+cloning them for each dispatch. Ownership is retained only at boundaries that
+actually consume a tensor value.
+
+The change includes direct, conjugated, cached, accumulated, grouped, backend,
+and session paths found by the neighborhood scan. Tests cover owned tensors,
+strided views, f32/f64/c32/c64, output accumulation, and provider-specific
+feature builds.
+
+### Performance acceptance
+
+Existing `cpu_install_overhead` and `grouped_gemm` Criterion benchmarks will be
+extended or supplemented with a warmed repeated-dispatch case. The acceptance
+criterion is structural and measurable:
+
+- no environment lookup or empty `BufferPool` construction per install;
+- no `TensorRead` descriptor clone per direct GEMM dispatch;
+- no regression in pool retention/restoration behavior;
+- before/after benchmark evidence recorded in the work log and PR body.
+
+Wall-clock improvement is expected but is not encoded as a fragile universal
+percentage threshold.
+
+## Commit Structure
+
+1. `fix(linalg): validate SVD gauge batch layout` — #1375.
+2. `fix(gpu): make numeric edge semantics explicit` — #1368 and #1381 after
+   the wrapping probe succeeds.
+3. `fix(einsum): align typed read and write surfaces` — #1276.
+4. `refactor(cpu): remove pool-bypassing free functions` — #1275.
+5. `perf(cpu): eliminate steady-state install allocations` — #1385.
+6. `docs: record batched remediation results` — durable docs, final ledger,
+   work log, benchmark evidence, and residual risks.
+
+If #1381 fails its lowering probe, commit 2 contains #1368 only and the ledger
+records #1381 as design-gated with the precise failing operation. It must not
+block the other five confirmed fixes.
+
+## Verification
+
+Each commit receives targeted tests before moving to the next issue. The final
+committed head must pass the repository checklist:
+
+```bash
+cargo fmt --all --check
+cargo test --workspace --release
+cargo llvm-cov --workspace --release --json --output-path coverage.json
+python3 scripts/check-coverage.py coverage.json
+cargo doc --workspace --no-deps
+python3 scripts/check-docs-site.py
+python3 scripts/repository-rules-review.py \
+  --base origin/main \
+  --head HEAD \
+  --output-json /tmp/repository-rules-review.json
+```
+
+Clippy will use the exact command and feature set from the current CI job.
+Changed README/getting-started samples will be extracted and run. CUDA runtime
+tests will run on an available CUDA host; if no local CUDA host is available,
+the work log and PR body will distinguish source-only verification from the
+required remote GPU check rather than claiming runtime coverage.
+
+Before the PR is opened, the implementation will also receive a side review
+against `REPOSITORY_RULES.md`, a local LLM review on the committed head, and a
+final reconciliation with all six issue threads.
+
+## Documentation And Review Artifacts
+
+The implementation will add one work log under `docs/worklogs/` containing:
+
+- final issue classifications and working-hash evidence;
+- context and rules read;
+- chosen and rejected alternatives;
+- per-commit verification;
+- CPU benchmark commands and before/after results;
+- GPU runtime environment and results;
+- residual risk and follow-up issues.
+
+Durable API wording affected by #1276 and CPU execution wording affected by
+#1275/#1385 will be updated in active design/guides, not only in the work log.
+
+## Primary Risks And Mitigations
+
+- **Public API churn:** #1275 and #1276 intentionally remove inconsistent
+  surfaces. Compile-time public-surface tests and fully migrated docs make the
+  new contract explicit.
+- **Borrow checker pressure in CPU sessions:** replace resource movement in the
+  smallest scope and preserve existing panic guards; do not introduce unsafe
+  aliasing to avoid a refactor.
+- **CubeCL semantic assumptions:** require the #1381 lowering probe and runtime
+  boundary tests before labeling helper operations as wrapping.
+- **GPU availability:** separate source-contract evidence from actual CUDA
+  execution and record exactly which was run.
+- **Batch review size:** keep issue-scoped commits, a live ledger, and one work
+  log so reviewers can inspect or revert a unit without losing the one-PR
+  remediation workflow.

--- a/docs/worklogs/2026-07-15-batched-bug-remediation.md
+++ b/docs/worklogs/2026-07-15-batched-bug-remediation.md
@@ -6,8 +6,9 @@ This work log records the single-PR remediation of issues #1275, #1276, #1368,
 #1375, #1381, and #1385. All six reports were reconciled against
 `origin/main` at `50c6623d`; none had become stale or gained a narrowing comment
 before implementation. The final changes are split into issue-scoped commits,
-one downstream integration follow-up, and two independent-review follow-ups,
-so each contract can be reviewed or reverted independently.
+one downstream integration follow-up, two independent-review follow-ups, one
+hardware-CI follow-up, and one local-gate metadata-ownership follow-up, so each
+contract can be reviewed or reverted independently.
 
 The batch deliberately treats the repository's API and numerical conventions
 as authoritative. In particular, #1276 is a clean break to the owned/read/write
@@ -30,14 +31,16 @@ execution model instead of introducing a process-global default backend.
 
 The repository root occupied about 44.8 GB at the start of work, below the
 100 GB cleanup threshold. Implementation used an isolated worktree based on
-the recorded `origin/main` commit.
+the recorded `origin/main` commit. When work resumed after the first hosted GPU
+run, the root occupied about 108 GB; cleanup of old build artifacts was proposed
+but no user files or build outputs were removed during this remediation.
 
 ## Final Classification Ledger
 
 | Issue | Final classification | Implemented result | Close condition |
 | --- | --- | --- | --- |
 | #1375 | Auto Fix | `763b1246` prepares one checked SVD gauge layout containing batch count, per-batch spans, and total storage spans. Gauge traversal validates storage before indexing and uses checked ranges for f32/f64/c32/c64. | Overflow, malformed-storage, batched, zero-batch, source-contract, and workspace checks pass. Ready to close when the PR merges. |
-| #1368 | Auto Fix | `61f2cffa` routes CubeCL elementwise and unit/plane reductions through shared NaN-propagating max/min helpers. Independent review then found that fusion code generation still emitted native extrema directly; `889fbe46` applies the same contract to fused max/min with explicit `IsNan`/`Select` IR. Both changes retain native non-NaN signed-zero and infinity behavior. | Source contracts and host checks pass; the added ignored CUDA parity tests, including fused f32/f64 cases, must pass in trusted RunPod CI before merge. |
+| #1368 | Auto Fix | `61f2cffa` routes CubeCL elementwise and unit/plane reductions through shared NaN-propagating max/min helpers. Independent review then found that fusion code generation still emitted native extrema directly; `889fbe46` applies the same contract to fused max/min with explicit `IsNan`/`Select` IR. The first RunPod run exposed an invalid generic NaN literal in plane reductions and an over-strict fused signed-zero assertion; `d91fa95e` propagates an actual NaN lane value through `plane_sum` and compares non-NaN fused values numerically. The implementation retains native non-NaN signed-zero and infinity behavior. | Source contracts and host checks pass; the corrected ignored CUDA parity tests must pass in the rerun of trusted RunPod CI before merge. |
 | #1381 | Verify First, then Auto Fix | `61f2cffa` confines the bare CubeCL integer IR operators to named wrapping helpers with `INVARIANT` markers. Elementwise, broadcast multiply, negation, power/remainder internals, and unit/plane reductions call those helpers. | Source inventory and existing host checks pass; the added CUDA overflow tests must pass in trusted RunPod CI before merge. |
 | #1276 | Auto Fix / intentional API correction | `3f57b1cd` adds `TypedTensorWrite`, splits typed view inputs into `TypedTensorReadEinsumExt` and `TypedTensorReadEinsumIntoExt`, uses `_read` method names, and accepts owned or mutable-view outputs through `Into<TypedTensorWrite>`. Active design, spec, and guide text is migrated. `cefa3313` adds runnable examples to the new public traits, methods, and write adapters after independent review. | Public-surface, owned/view/output, error, doctest, and workspace checks pass. Ready to close when the PR merges. |
 | #1275 | Auto Fix / intentional API removal | `2b793176` removes production crate-root CPU operation reexports and per-call `with_local_pool` wrappers. Supported use goes through `CpuBackend` and backend traits; crate-private adapters remain only under `cfg(test)`. `bfa2db37` removes the downstream linalg test module's now-invalid, unused imports found by the release workspace gate. | Public-surface inventory, pool ownership, downstream compilation, docs, and workspace checks pass. Ready to close when the PR merges. |
@@ -63,6 +66,10 @@ the recorded `origin/main` commit.
 - **One-shot environment parsing.** `BufferPool::new()` uses the process
   default cached by `OnceLock`; explicit limits and runtime setters remain
   dynamic. Parser tests do not mutate global process state.
+- **Acquire only borrowed metadata keys.** Child graph analysis may read
+  metadata owned by a parent or overlapping scope. Acquiring those specific
+  keys into the child scope keeps their reference counts balanced without
+  cloning the global metadata map or serializing otherwise independent tests.
 
 ## Regression Boundaries
 
@@ -72,13 +79,20 @@ the recorded `origin/main` commit.
 - #1368/#1381 add CUDA value tests for both float precisions, fused extrema,
   and integer overflow boundaries, plus a host-runnable source inventory
   covering every affected kernel family. The fused tests compare NaN in both
-  operand orders, signed zero, infinity, and ordinary values with CPU results.
+  operand orders, infinity, and ordinary values with CPU results. They exercise
+  signed zero without requiring CPU/GPU sign-bit parity because #1368 defines
+  NaN propagation while native CubeCL extrema retain their non-NaN zero-sign
+  behavior.
 - #1276 adds public-surface tests, typed owned/read execution, owned output,
   strided mutable-view output, and `TypedTensorWrite` conversion coverage.
 - #1275 prevents production free-function reexports and `with_local_pool`
   helpers from returning, while existing backend/pool tests cover reuse.
 - #1385 tests parser edge cases, direct pool ownership, panic replenishment,
   descriptor borrowing, Faer behavior, and BLAS/TBLIS feature compilation.
+- The final workspace gate also fixes a pre-existing metadata-scope ownership
+  race exposed by the larger batch: a deterministic parent/child scope test
+  proves that borrowed metadata survives the parent scope and is released when
+  the final child scope drops.
 
 ## #1385 Benchmark Evidence
 
@@ -127,6 +141,30 @@ Targeted verification completed during implementation:
   7/7, and `cargo check -p tenferro-gpu --features cuda --tests` passed.
 - The independent-review documentation follow-up passed 73 einsum doctests
   and 275 tensor doctests as part of the final release workspace gate.
+- The first trusted RunPod CUDA run executed 842 tests: 839 passed and 3
+  failed. Both fused f32/f64 failures had already passed all NaN cases and
+  failed only because the test compared `+0.0` and `-0.0` by bits. The plane
+  reduction failure was an NVRTC compile error because `F::new(f32::NAN)`
+  lowered to the undefined CUDA identifier `NaN`. The integer-overflow and
+  elementwise NaN tests passed in that run.
+- The CUDA-codegen regression contract was observed RED before `d91fa95e`
+  because `plane_propagate_nan` was absent, then GREEN after the fix. The full
+  `tenferro-gpu` release suite, `cargo check -p tenferro-gpu --features cuda
+  --tests`, formatting, and diff checks passed locally. A CUDA-enabled clippy
+  probe remains unsuitable as an extra gate because the feature combination
+  exposes pre-existing CubeCL macro and FFI lints outside this diff; the
+  repository's required workspace clippy profile remains the authoritative
+  clippy check.
+- The first full workspace rerun after `d91fa95e` exposed an intermittent
+  `qr_sum_grad_optimized_graph_is_structurally_compact` failure: a derived pad
+  tensor had lost its metadata while parallel structural tests were dropping
+  overlapping scopes. The exact test passed 20/20 alone, the parallel test
+  binary reproduced the failure, and `--test-threads=1` passed. A deterministic
+  parent/child scope regression was then observed RED before `bbf9b7e8` and
+  GREEN after graph analysis began acquiring only the global metadata keys it
+  actually borrowed. The complete runtime release suite (232 unit tests and
+  224 doctests), the original 27-test parallel linalg suite, and 20 consecutive
+  repetitions of that suite passed after the fix.
 
 Repository-wide verification on the complete code batch also passed:
 
@@ -134,7 +172,9 @@ Repository-wide verification on the complete code batch also passed:
 - `cargo test --workspace --release`: passed. Its first run exposed unused
   imports of the removed #1275 helpers in the linalg test module; `bfa2db37`
   removed those imports, and the complete release workspace command then
-  passed on the corrected tree.
+  passed on the corrected tree. The post-RunPod rerun later exposed the
+  metadata ownership race described above; after `bbf9b7e8`, the complete
+  release workspace command passed again.
 - `cargo llvm-cov --workspace --release --json --output-path coverage.json`
   and `python3 scripts/check-coverage.py coverage.json`: passed, with 159/159
   measured files meeting their thresholds and 3 files excluded by policy.
@@ -151,17 +191,18 @@ Repository-wide verification on the complete code batch also passed:
   with no findings on the final code batch. The same review is run again on
   the final work-log commit before PR creation.
 
-The trusted RunPod CUDA value tests are intentionally the remaining pre-merge
-gate rather than a local verification claim.
+The corrected trusted RunPod CUDA value tests and the repeated repository-wide
+checks are the remaining pre-merge gates rather than a local CUDA claim.
 
 ## GPU Environment
 
 The implementation host is Apple arm64/macOS and has no NVIDIA runtime, so no
 local CUDA value test is claimed. The new CUDA tests remain `#[ignore]` in the
 repository's established hardware-test suite. The host-runnable source
-contracts prove that all affected entry points route through the new helpers,
-but hardware behavior for #1368/#1381 must be confirmed by the trusted RunPod
-GPU check on the PR before merge.
+contracts prove that all affected entry points route through the new helpers.
+The first trusted RunPod run confirmed #1381 and the elementwise #1368 path,
+then exposed the two narrower failures recorded above; the corrected plane and
+fusion paths still require the rerun before merge.
 
 ## Residual Risks
 
@@ -176,3 +217,6 @@ GPU check on the PR before merge.
   explicit constructor or runtime limit setter.
 - The benchmark isolates the reported small grouped-GEMM workload. It does not
   imply the same percentage for larger GEMMs, other providers, or other hosts.
+- Scoped metadata references now add one refcount operation per borrowed
+  global key. The regression proves balanced final release, and the targeted
+  acquisition avoids a full-map clone or a global serialization workaround.

--- a/docs/worklogs/2026-07-15-batched-bug-remediation.md
+++ b/docs/worklogs/2026-07-15-batched-bug-remediation.md
@@ -6,8 +6,8 @@ This work log records the single-PR remediation of issues #1275, #1276, #1368,
 #1375, #1381, and #1385. All six reports were reconciled against
 `origin/main` at `50c6623d`; none had become stale or gained a narrowing comment
 before implementation. The final changes are split into issue-scoped commits,
-plus one downstream integration follow-up, so each contract can be reviewed or
-reverted independently.
+one downstream integration follow-up, and two independent-review follow-ups,
+so each contract can be reviewed or reverted independently.
 
 The batch deliberately treats the repository's API and numerical conventions
 as authoritative. In particular, #1276 is a clean break to the owned/read/write
@@ -37,9 +37,9 @@ the recorded `origin/main` commit.
 | Issue | Final classification | Implemented result | Close condition |
 | --- | --- | --- | --- |
 | #1375 | Auto Fix | `763b1246` prepares one checked SVD gauge layout containing batch count, per-batch spans, and total storage spans. Gauge traversal validates storage before indexing and uses checked ranges for f32/f64/c32/c64. | Overflow, malformed-storage, batched, zero-batch, source-contract, and workspace checks pass. Ready to close when the PR merges. |
-| #1368 | Auto Fix | `61f2cffa` routes CubeCL elementwise and unit/plane reductions through shared NaN-propagating max/min helpers, retaining native non-NaN signed-zero and infinity behavior. | Source contracts and host checks pass; the added ignored CUDA parity tests must pass in trusted RunPod CI before merge. |
+| #1368 | Auto Fix | `61f2cffa` routes CubeCL elementwise and unit/plane reductions through shared NaN-propagating max/min helpers. Independent review then found that fusion code generation still emitted native extrema directly; `889fbe46` applies the same contract to fused max/min with explicit `IsNan`/`Select` IR. Both changes retain native non-NaN signed-zero and infinity behavior. | Source contracts and host checks pass; the added ignored CUDA parity tests, including fused f32/f64 cases, must pass in trusted RunPod CI before merge. |
 | #1381 | Verify First, then Auto Fix | `61f2cffa` confines the bare CubeCL integer IR operators to named wrapping helpers with `INVARIANT` markers. Elementwise, broadcast multiply, negation, power/remainder internals, and unit/plane reductions call those helpers. | Source inventory and existing host checks pass; the added CUDA overflow tests must pass in trusted RunPod CI before merge. |
-| #1276 | Auto Fix / intentional API correction | `3f57b1cd` adds `TypedTensorWrite`, splits typed view inputs into `TypedTensorReadEinsumExt` and `TypedTensorReadEinsumIntoExt`, uses `_read` method names, and accepts owned or mutable-view outputs through `Into<TypedTensorWrite>`. Active design, spec, and guide text is migrated. | Public-surface, owned/view/output, error, doctest, and workspace checks pass. Ready to close when the PR merges. |
+| #1276 | Auto Fix / intentional API correction | `3f57b1cd` adds `TypedTensorWrite`, splits typed view inputs into `TypedTensorReadEinsumExt` and `TypedTensorReadEinsumIntoExt`, uses `_read` method names, and accepts owned or mutable-view outputs through `Into<TypedTensorWrite>`. Active design, spec, and guide text is migrated. `cefa3313` adds runnable examples to the new public traits, methods, and write adapters after independent review. | Public-surface, owned/view/output, error, doctest, and workspace checks pass. Ready to close when the PR merges. |
 | #1275 | Auto Fix / intentional API removal | `2b793176` removes production crate-root CPU operation reexports and per-call `with_local_pool` wrappers. Supported use goes through `CpuBackend` and backend traits; crate-private adapters remain only under `cfg(test)`. `bfa2db37` removes the downstream linalg test module's now-invalid, unused imports found by the release workspace gate. | Public-surface inventory, pool ownership, downstream compilation, docs, and workspace checks pass. Ready to close when the PR merges. |
 | #1385 | Auto Fix | `028e2668` borrows the installed pool directly, caches the environment-derived default with `OnceLock`, and borrows internal Faer/BLAS/TBLIS GEMM descriptors instead of cloning them in backend/session dispatch. | Pool restoration/panic, provider-feature, structural, benchmark, and workspace checks pass. Ready to close when the PR merges. |
 
@@ -69,9 +69,10 @@ the recorded `origin/main` commit.
 - #1375 adds executable overflow tests without attempting impossible
   near-`usize::MAX` allocations and a source contract forbidding raw gauge
   batch products/offsets.
-- #1368/#1381 add CUDA value tests for both float precisions and integer
-  overflow boundaries, plus a host-runnable source inventory covering every
-  affected kernel family.
+- #1368/#1381 add CUDA value tests for both float precisions, fused extrema,
+  and integer overflow boundaries, plus a host-runnable source inventory
+  covering every affected kernel family. The fused tests compare NaN in both
+  operand orders, signed zero, infinity, and ordinary values with CPU results.
 - #1276 adds public-surface tests, typed owned/read execution, owned output,
   strided mutable-view output, and `TypedTensorWrite` conversion coverage.
 - #1275 prevents production free-function reexports and `with_local_pool`
@@ -120,6 +121,12 @@ Targeted verification completed during implementation:
 - The #1385 Criterion before/after run above completed successfully.
 - Issue-focused linalg, GPU source-contract, tensor, einsum, CPU, public
   surface, doctest, and clippy checks passed before their commits.
+- Independent review found the missing fused #1368 path. Its regression was
+  first observed as a failing source-contract test, then fixed through shared
+  `IsNan`/`Select` code generation. The final GPU source-contract suite passed
+  7/7, and `cargo check -p tenferro-gpu --features cuda --tests` passed.
+- The independent-review documentation follow-up passed 73 einsum doctests
+  and 275 tensor doctests as part of the final release workspace gate.
 
 Repository-wide verification on the complete code batch also passed:
 
@@ -140,9 +147,9 @@ Repository-wide verification on the complete code batch also passed:
 - `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D
   warnings`: passed.
 - `python3 scripts/repository-rules-review.py --base origin/main --head HEAD
-  --output-json /tmp/repository-rules-review-pre-worklog.json`: verdict
-  `pass`, with no findings on the complete code batch. The same review is run
-  again on the final work-log commit before PR creation.
+  --output-json /tmp/repository-rules-review-final-code.json`: verdict `pass`,
+  with no findings on the final code batch. The same review is run again on
+  the final work-log commit before PR creation.
 
 The trusted RunPod CUDA value tests are intentionally the remaining pre-merge
 gate rather than a local verification claim.

--- a/docs/worklogs/2026-07-15-batched-bug-remediation.md
+++ b/docs/worklogs/2026-07-15-batched-bug-remediation.md
@@ -1,0 +1,171 @@
+# Batched Bug Remediation Work Log
+
+## Session Summary
+
+This work log records the single-PR remediation of issues #1275, #1276, #1368,
+#1375, #1381, and #1385. All six reports were reconciled against
+`origin/main` at `50c6623d`; none had become stale or gained a narrowing comment
+before implementation. The final changes are split into issue-scoped commits,
+plus one downstream integration follow-up, so each contract can be reviewed or
+reverted independently.
+
+The batch deliberately treats the repository's API and numerical conventions
+as authoritative. In particular, #1276 is a clean break to the owned/read/write
+vocabulary rather than a compatibility shim, and #1275 removes the second CPU
+execution model instead of introducing a process-global default backend.
+
+## Context And Rules Read
+
+- The repository and subdirectory `AGENTS.md` files, `REPOSITORY_RULES.md`,
+  `CONTRIBUTING.md`, and the bug-fix/remediation contribution workflows.
+- `docs/design/api-and-convention-freeze.md`, `docs/design/einsum.md`, the
+  active API specifications and guides, and the CPU execution/pool code.
+- The current issue bodies and comments for #1275, #1276, #1368, #1375,
+  #1381, and #1385 immediately before implementation and again before final
+  verification.
+- CodeGraph neighborhoods for the affected linalg gauge, CubeCL numeric,
+  typed einsum, CPU public operation, execution-resource, and GEMM paths.
+- The approved design at
+  `docs/superpowers/specs/2026-07-15-batched-bug-remediation-design.md`.
+
+The repository root occupied about 44.8 GB at the start of work, below the
+100 GB cleanup threshold. Implementation used an isolated worktree based on
+the recorded `origin/main` commit.
+
+## Final Classification Ledger
+
+| Issue | Final classification | Implemented result | Close condition |
+| --- | --- | --- | --- |
+| #1375 | Auto Fix | `763b1246` prepares one checked SVD gauge layout containing batch count, per-batch spans, and total storage spans. Gauge traversal validates storage before indexing and uses checked ranges for f32/f64/c32/c64. | Overflow, malformed-storage, batched, zero-batch, source-contract, and workspace checks pass. Ready to close when the PR merges. |
+| #1368 | Auto Fix | `61f2cffa` routes CubeCL elementwise and unit/plane reductions through shared NaN-propagating max/min helpers, retaining native non-NaN signed-zero and infinity behavior. | Source contracts and host checks pass; the added ignored CUDA parity tests must pass in trusted RunPod CI before merge. |
+| #1381 | Verify First, then Auto Fix | `61f2cffa` confines the bare CubeCL integer IR operators to named wrapping helpers with `INVARIANT` markers. Elementwise, broadcast multiply, negation, power/remainder internals, and unit/plane reductions call those helpers. | Source inventory and existing host checks pass; the added CUDA overflow tests must pass in trusted RunPod CI before merge. |
+| #1276 | Auto Fix / intentional API correction | `3f57b1cd` adds `TypedTensorWrite`, splits typed view inputs into `TypedTensorReadEinsumExt` and `TypedTensorReadEinsumIntoExt`, uses `_read` method names, and accepts owned or mutable-view outputs through `Into<TypedTensorWrite>`. Active design, spec, and guide text is migrated. | Public-surface, owned/view/output, error, doctest, and workspace checks pass. Ready to close when the PR merges. |
+| #1275 | Auto Fix / intentional API removal | `2b793176` removes production crate-root CPU operation reexports and per-call `with_local_pool` wrappers. Supported use goes through `CpuBackend` and backend traits; crate-private adapters remain only under `cfg(test)`. `bfa2db37` removes the downstream linalg test module's now-invalid, unused imports found by the release workspace gate. | Public-surface inventory, pool ownership, downstream compilation, docs, and workspace checks pass. Ready to close when the PR merges. |
+| #1385 | Auto Fix | `028e2668` borrows the installed pool directly, caches the environment-derived default with `OnceLock`, and borrows internal Faer/BLAS/TBLIS GEMM descriptors instead of cloning them in backend/session dispatch. | Pool restoration/panic, provider-feature, structural, benchmark, and workspace checks pass. Ready to close when the PR merges. |
+
+## Decisions And Alternatives
+
+- **One PR, issue-scoped commits.** These reports share repository-contract and
+  public-surface concerns, while their commits remain independently reviewable.
+- **No compatibility aliases for #1276.** Retaining unsuffixed typed-view
+  methods would preserve the inconsistency the canonical API design forbids.
+- **No process-global CPU backend for #1275.** A hidden singleton would make
+  threading, placement, provider selection, and resource ownership implicit.
+  Requiring an explicit `CpuBackend` preserves one execution model.
+- **Named CubeCL wrapping helpers for #1381.** The current CubeCL generic
+  integer layer does not expose Rust-style `wrapping_*` intrinsics. Bare IR
+  expressions therefore remain only inside small helpers whose names,
+  invariant comments, source contracts, and CUDA boundary tests state the
+  verified two's-complement lowering contract.
+- **Direct pool borrowing for #1385.** A scratch/default pool or resettable
+  global cache would retain avoidable construction. A mutable loan preserves
+  the existing in-flight panic accounting without unsafe aliasing.
+- **One-shot environment parsing.** `BufferPool::new()` uses the process
+  default cached by `OnceLock`; explicit limits and runtime setters remain
+  dynamic. Parser tests do not mutate global process state.
+
+## Regression Boundaries
+
+- #1375 adds executable overflow tests without attempting impossible
+  near-`usize::MAX` allocations and a source contract forbidding raw gauge
+  batch products/offsets.
+- #1368/#1381 add CUDA value tests for both float precisions and integer
+  overflow boundaries, plus a host-runnable source inventory covering every
+  affected kernel family.
+- #1276 adds public-surface tests, typed owned/read execution, owned output,
+  strided mutable-view output, and `TypedTensorWrite` conversion coverage.
+- #1275 prevents production free-function reexports and `with_local_pool`
+  helpers from returning, while existing backend/pool tests cover reuse.
+- #1385 tests parser edge cases, direct pool ownership, panic replenishment,
+  descriptor borrowing, Faer behavior, and BLAS/TBLIS feature compilation.
+
+## #1385 Benchmark Evidence
+
+The `grouped_gemm` Criterion target now has a steady-state case matching the
+reported profile: one-thread Faer, 2,000 explicit warm-up iterations, six
+grouped calls per measured iteration, eight 4x4x4 jobs per call, persistent
+backend/cache/output, and reusable `TensorView` descriptors.
+
+The benchmark-only change was applied to a detached worktree at parent commit
+`2b793176` and built in a separate target directory so Cargo could not reuse
+the fixed library artifact. Both sides used:
+
+```bash
+cargo bench -p tenferro-cpu --bench grouped_gemm -- \
+  'grouped_gemm/steady_state/six_calls_8x4x4' \
+  --sample-size 20 --measurement-time 2 --warm-up-time 1 --noplot
+```
+
+| Revision | Distribution | Median estimate |
+| --- | --- | --- |
+| Before, `2b793176` plus benchmark only | 3.1435–3.1604 µs | 3.1524 µs |
+| After, `028e2668` | 2.0563–2.0754 µs | 2.0673 µs |
+
+That is a 34.4% reduction in the measured steady-state dispatch time on this
+Apple arm64 host. The percentage is evidence for this workload, not a portable
+performance threshold; the durable acceptance conditions are the structural
+absence of placeholder pool construction, repeated environment lookup, and
+internal descriptor clones.
+
+## Verification Performed
+
+Targeted verification completed during implementation:
+
+- `cargo test -p tenferro-cpu`: 284 unit tests, 9 capability-contract tests,
+  5 provider-contract tests, 25 runtime-error tests, and 105 doctests passed.
+- `cargo check -p tenferro-cpu --no-default-features --features cpu-blas
+  --lib`: passed.
+- `cargo check -p tenferro-cpu --features cpu-tblis --lib`: passed.
+- `cargo clippy -p tenferro-cpu --all-targets -- -D warnings`: passed.
+- The #1385 Criterion before/after run above completed successfully.
+- Issue-focused linalg, GPU source-contract, tensor, einsum, CPU, public
+  surface, doctest, and clippy checks passed before their commits.
+
+Repository-wide verification on the complete code batch also passed:
+
+- `cargo fmt --all --check` and `git diff --check`: passed.
+- `cargo test --workspace --release`: passed. Its first run exposed unused
+  imports of the removed #1275 helpers in the linalg test module; `bfa2db37`
+  removed those imports, and the complete release workspace command then
+  passed on the corrected tree.
+- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
+  and `python3 scripts/check-coverage.py coverage.json`: passed, with 159/159
+  measured files meeting their thresholds and 3 files excluded by policy.
+- `cargo doc --workspace --no-deps`: passed.
+- `python3.11 scripts/check-docs-site.py`: passed, including 4 dependency
+  guide smoke tests and all 13 workspace library crates. The macOS system
+  `python3` is 3.9.6, so the installed Python 3.11 interpreter was used for
+  the script's documented TOML parser requirement.
+- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D
+  warnings`: passed.
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD
+  --output-json /tmp/repository-rules-review-pre-worklog.json`: verdict
+  `pass`, with no findings on the complete code batch. The same review is run
+  again on the final work-log commit before PR creation.
+
+The trusted RunPod CUDA value tests are intentionally the remaining pre-merge
+gate rather than a local verification claim.
+
+## GPU Environment
+
+The implementation host is Apple arm64/macOS and has no NVIDIA runtime, so no
+local CUDA value test is claimed. The new CUDA tests remain `#[ignore]` in the
+repository's established hardware-test suite. The host-runnable source
+contracts prove that all affected entry points route through the new helpers,
+but hardware behavior for #1368/#1381 must be confirmed by the trusted RunPod
+GPU check on the PR before merge.
+
+## Residual Risks
+
+- #1275 and #1276 intentionally remove or rename public APIs. Workspace code
+  and active docs are migrated, but downstream users must move to explicit
+  `CpuBackend` ownership and typed `_read` traits/output adapters.
+- CubeCL lowering is guarded by source contracts and CUDA tests, but future
+  CubeCL/CUDA changes could alter NaN, signed-zero, or integer-overflow
+  behavior; retain the hardware regressions.
+- The `OnceLock` pool default intentionally observes the environment only on
+  its first use in a process. Callers requiring later changes must use the
+  explicit constructor or runtime limit setter.
+- The benchmark isolates the reported small grouped-GEMM workload. It does not
+  imply the same percentage for larger GEMMs, other providers, or other hosts.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [x] Documentation
- [x] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issues

Closes #1275
Closes #1276
Closes #1368
Closes #1375
Closes #1381
Closes #1385

## Summary

This batches six accumulated bug reports while keeping each correction in an issue-scoped commit.

- validates SVD gauge batch products, spans, and storage before indexing;
- makes CubeCL float max/min NaN-propagating across elementwise, reduction, and fused codegen paths, while retaining native signed-zero/infinity behavior for non-NaN operands;
- confines CubeCL integer arithmetic to explicit wrapping-contract helpers and adds boundary regressions;
- applies the canonical owned/read/write API vocabulary to typed einsum, including `TypedTensorWrite` and `_read` methods;
- removes CPU free functions that bypass explicit `CpuBackend` resource ownership;
- removes repeated pool/default/descriptor setup from steady-state grouped GEMM dispatch.

Validation follow-ups also remove a CUDA-invalid generic NaN literal by propagating an actual NaN lane through plane reduction, and retain only the metadata keys borrowed by child graph-analysis scopes so parallel scope drops cannot invalidate live derived metadata.

The #1275 and #1276 changes are intentional public API corrections. No compatibility aliases are retained because they would preserve the inconsistent or resource-bypassing surfaces reported by those issues.

Design: [docs/superpowers/specs/2026-07-15-batched-bug-remediation-design.md](docs/superpowers/specs/2026-07-15-batched-bug-remediation-design.md)

## Work log

Detailed issue classification, decisions, regressions, benchmark method, verification, and residual risks:

[docs/worklogs/2026-07-15-batched-bug-remediation.md](docs/worklogs/2026-07-15-batched-bug-remediation.md)

## Performance evidence for #1385

One-thread Faer steady-state grouped GEMM, six calls per measured iteration with eight 4x4x4 jobs per call:

| Revision | Median |
| --- | ---: |
| Before (`2b793176` + benchmark only) | 3.1524 µs |
| After (`028e2668`) | 2.0673 µs |

This is a 34.4% reduction for the reported small-dispatch workload.

## Verification

- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `cargo test --workspace --release`
- [x] metadata-scope regression: deterministic parent/child ownership test, runtime 232 unit + 224 doctests, parallel linalg suite repeated 20 times
- [x] `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- [x] `python3 scripts/check-coverage.py coverage.json` — 159/159 files passed, 3 policy exclusions
- [x] `cargo doc --workspace --no-deps`
- [x] docs site — 4 dependency guides and 13 workspace library crates
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- [x] `cargo check -p tenferro-gpu --features cuda --tests`
- [x] GPU source contracts — 7/7
- [x] local and hosted repository-rules LLM review — pass, no findings
- [x] [trusted RunPod CUDA run 29459109050](https://github.com/tensor4all/tenferro-rs/actions/runs/29459109050) — 842/842 CUDA tests passed, 0 skipped; OpenXLA PJRT E2E 3/3 passed

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. (Not applicable.)
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
