### PR TITLE
refactor: unify strided materialization behind backends

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -574,6 +574,11 @@ Tests follow implementation ownership.
 - No naive CPU loop fallbacks. CPU tensor kernels must use optimized
   implementations unless the operation is explicitly listed as an exception
   below.
+- CPU affine-strided copy, permutation, broadcast, map, zip-map, and axis reduction
+  delegate to `strided-rs`. Tenferro owns tensor semantics, validation, dtype
+  dispatch, placement checks, error translation, execution contexts, and
+  reusable output storage; it does not duplicate the tensor-sized affine
+  traversal.
 - Required CPU implementations by operation category:
 
   | Category | Required implementation |
@@ -584,6 +589,36 @@ Tests follow implementation ownership.
   | GEMM (`dot_general`) | faer (`cpu-faer`) or BLAS (`cpu-blas`) |
   | Linalg (`svd`, `qr`, `cholesky`, `eigh`, `solve`) | faer (`cpu-faer`) or LAPACK (`cpu-blas`) |
 
+- The ownership and overlap boundary is:
+
+  | Operation or responsibility | `strided-rs` owner | tenferro owner |
+  |---|---|---|
+  | Affine-strided copy and permutation | Bulk `copy_into` traversal and serial/parallel kernel selection | Shape, stride, offset, reachable-range, dtype, placement, and destination validation; backend-scoped allocation and error mapping |
+  | Broadcast | Zero-stride broadcast views and bulk copy/map traversal | Broadcast dimension semantics, output shape, placement, and allocation |
+  | Unary map and binary zip-map | Affine iteration, tiling, and parallel execution | Operation semantics, dtype dispatch/promotion, capability checks, and errors |
+  | Axis reduction | Per-axis strided reduction kernels | Multi-axis orchestration, axis validation, identities, dtype policy, and output wrapping |
+  | Gather/scatter and indirect indexing | No ownership until a suitable general primitive exists | Indirect-index semantics and current dedicated kernels |
+  | Einsum/dot-general | Reusable strided primitives may be consumed where they fit | Planning, optimized preparation, provider integration, and benchmark accountability |
+
+- Ownership priority is lower-layer first: when a CPU operation can be
+  expressed as metadata preparation followed by an existing `strided-rs`
+  primitive, tenferro must delegate the bulk traversal. If a generally useful
+  primitive is missing, add it to `strided-rs` first and then consume it from
+  tenferro. A tenferro-owned traversal is allowed only for semantics outside
+  the affine-strided primitive model or for an explicitly approved,
+  benchmark-backed exception. Einsum is the benchmark-backed tenferro exception;
+  new exceptions require an accepted issue, comparative benchmark evidence,
+  and a recorded ownership rationale.
+- Calling a `strided-rs` primitive is necessary but not sufficient. Public
+  tensor-sized CPU work must enter through `CpuBackend` and its configured
+  execution scope. High-performance materialization needs the backend's
+  persistent `BufferPool`, fully-overwritten uninitialized output allocation,
+  configured `CpuContext` Rayon pool, nested-execution safety, and
+  serial/parallel threshold policy. A context-free `strided-rs` call, a
+  throwaway pool, or Rayon's ambient global Rayon pool is non-compliant.
+  Memory reuse and thread policy are execution resources, not tensor metadata;
+  backend-neutral tensor/view types therefore expose metadata-only layout
+  transforms and do not own data-moving convenience methods.
 - Exceptions with dedicated implementations are `reshape` (metadata-only),
   `embed_diagonal`, index-dependent triangular masks (`tril`/`triu`), and
   indexing ops such as gather, scatter, slice, pad, concatenate, and reverse.

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -600,6 +600,21 @@ Tests follow implementation ownership.
   | Gather/scatter and indirect indexing | No ownership until a suitable general primitive exists | Indirect-index semantics and current dedicated kernels |
   | Einsum/dot-general | Reusable strided primitives may be consumed where they fit | Planning, optimized preparation, provider integration, and benchmark accountability |
 
+<!-- TENFERRO_CPU_STRIDED_OWNERSHIP_CONTRACT_BEGIN -->
+
+  ```text
+  schema = tenferro.cpu-strided-ownership.v1
+  affine-kernel-owner = strided-rs
+  affine-kernels = copy,permutation,broadcast,map,zip-map,axis-reduction
+  einsum-owner = tenferro:benchmark-backed-exception
+  execution-entry = CpuBackend
+  execution-resources = persistent-BufferPool,uninitialized-full-overwrite,CpuContext-Rayon,nested-execution,serial-parallel-threshold
+  noncompliant = context-free-strided-call,throwaway-pool,ambient-global-Rayon
+  resource-classification = memory-reuse-and-thread-policy:execution-not-metadata
+  ```
+
+<!-- TENFERRO_CPU_STRIDED_OWNERSHIP_CONTRACT_END -->
+
 - Ownership priority is lower-layer first: when a CPU operation can be
   expressed as metadata preparation followed by an existing `strided-rs`
   primitive, tenferro must delegate the bulk traversal. If a generally useful

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -3,6 +3,8 @@ use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::env;
 use std::fmt;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -23,7 +25,6 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ExtensionRuleSet;
 use tenferro_ops::ShapeGuardContext;
 use tenferro_runtime::ad_support::ones_tensor;
-#[cfg(test)]
 use tenferro_tensor::BackendSessionHost;
 use tenferro_tensor::{
     CacheStats, DType, Tensor, TensorBackend, TensorElementwise, TensorRead, TensorValue,
@@ -257,6 +258,8 @@ pub struct EagerRuntime {
     value_records: Mutex<HashMap<ValueKey<StdTensorOp>, Weak<EagerTensorRecord>>>,
     value_ptr_records: Mutex<HashMap<usize, Weak<EagerTensorRecord>>>,
     ad_transform_cache: Arc<AdTransformCache>,
+    #[cfg(test)]
+    recorded_to_contiguous_reads: AtomicUsize,
 }
 
 impl fmt::Debug for EagerRuntime {
@@ -382,7 +385,14 @@ impl EagerRuntime {
             value_records: Mutex::new(HashMap::new()),
             value_ptr_records: Mutex::new(HashMap::new()),
             ad_transform_cache,
+            #[cfg(test)]
+            recorded_to_contiguous_reads: AtomicUsize::new(0),
         }
+    }
+
+    #[cfg(test)]
+    fn recorded_to_contiguous_reads(&self) -> usize {
+        self.recorded_to_contiguous_reads.load(Ordering::Relaxed)
     }
 
     /// Create a shared CPU eager execution context.
@@ -739,6 +749,22 @@ impl EagerRuntime {
     pub fn with_backend_mut<R>(&self, f: impl FnOnce(&mut EagerBackend) -> R) -> Result<R> {
         let mut backend = self.lock_backend()?;
         Ok(f(&mut backend))
+    }
+
+    pub(crate) fn materialize_value(&self, value: &TensorValue) -> Result<Tensor> {
+        if let Some(tensor) = value.as_tensor_arc() {
+            return Ok(tensor.as_ref().clone());
+        }
+
+        let mut backend = self.lock_backend()?;
+        backend
+            .with_backend_session(|exec| {
+                #[cfg(test)]
+                self.recorded_to_contiguous_reads
+                    .fetch_add(1, Ordering::Relaxed);
+                exec.to_contiguous_read(value.tensor_read())
+            })
+            .map_err(Error::from)
     }
 
     /// Block the current thread until backend work submitted by this eager runtime completes.
@@ -1738,7 +1764,7 @@ impl EagerTensor {
     /// standalone compact tensor. The operation is fallible because eager
     /// values may be backed by lazy or backend-resident storage.
     pub fn to_tensor(&self) -> Result<Tensor> {
-        self.value.to_tensor().map_err(Error::from)
+        self.ctx.materialize_value(self.value.as_ref())
     }
 
     pub(crate) fn materialized_arc(&self) -> Result<Arc<Tensor>> {
@@ -1751,7 +1777,7 @@ impl EagerTensor {
             return Ok(Arc::clone(tensor));
         }
 
-        let materialized = Arc::new(self.value.to_tensor().map_err(Error::from)?);
+        let materialized = Arc::new(self.ctx.materialize_value(self.value.as_ref())?);
         let _ = self.materialized_cache.set(Arc::clone(&materialized));
         self.ctx.try_register_value_record_ptr(&self._record)?;
         Ok(self

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -3,8 +3,6 @@ use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::env;
 use std::fmt;
-#[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -258,8 +256,6 @@ pub struct EagerRuntime {
     value_records: Mutex<HashMap<ValueKey<StdTensorOp>, Weak<EagerTensorRecord>>>,
     value_ptr_records: Mutex<HashMap<usize, Weak<EagerTensorRecord>>>,
     ad_transform_cache: Arc<AdTransformCache>,
-    #[cfg(test)]
-    recorded_to_contiguous_reads: AtomicUsize,
 }
 
 impl fmt::Debug for EagerRuntime {
@@ -385,14 +381,7 @@ impl EagerRuntime {
             value_records: Mutex::new(HashMap::new()),
             value_ptr_records: Mutex::new(HashMap::new()),
             ad_transform_cache,
-            #[cfg(test)]
-            recorded_to_contiguous_reads: AtomicUsize::new(0),
         }
-    }
-
-    #[cfg(test)]
-    fn recorded_to_contiguous_reads(&self) -> usize {
-        self.recorded_to_contiguous_reads.load(Ordering::Relaxed)
     }
 
     /// Create a shared CPU eager execution context.
@@ -758,12 +747,7 @@ impl EagerRuntime {
 
         let mut backend = self.lock_backend()?;
         backend
-            .with_backend_session(|exec| {
-                #[cfg(test)]
-                self.recorded_to_contiguous_reads
-                    .fetch_add(1, Ordering::Relaxed);
-                exec.to_contiguous_read(value.tensor_read())
-            })
+            .with_backend_session(|exec| exec.to_contiguous_read(value.tensor_read()))
             .map_err(Error::from)
     }
 

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -2,7 +2,10 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::hash::Hasher;
 use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use std::time::Duration;
 
 use computegraph::graph::{Graph, GraphBuilder};
@@ -79,7 +82,10 @@ fn eager_runtime_synchronize_reports_poisoned_backend_lock() {
 
 #[test]
 fn eager_materialization_uses_backend() {
-    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let materializations = Arc::new(AtomicUsize::new(0));
+    let ctx = Arc::new(EagerRuntime::from_backend(EagerBackend::recording_cpu(
+        Arc::clone(&materializations),
+    )));
     let x = EagerTensor::from_tensor_in(
         Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
         Arc::clone(&ctx),
@@ -88,12 +94,12 @@ fn eager_materialization_uses_backend() {
 
     let compact = x.to_tensor().unwrap();
     assert_eq!(compact.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
-    assert_eq!(ctx.recorded_to_contiguous_reads(), 0);
+    assert_eq!(materializations.load(Ordering::Relaxed), 0);
 
     let view = x.transpose(&[1, 0]).unwrap();
     let compact = view.to_tensor().unwrap();
     assert_eq!(compact.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
-    assert_eq!(ctx.recorded_to_contiguous_reads(), 1);
+    assert_eq!(materializations.load(Ordering::Relaxed), 1);
 }
 
 #[test]

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -20,7 +20,7 @@ use tenferro_ops::{ShapeExtent, ShapeGuardContext, SymDim, TensorMeta};
 use tenferro_runtime::ExtensionCacheLimits;
 use tenferro_runtime::{Error, ExtensionExecutionContext, ExtensionExecutor, ExtensionRuntime};
 use tenferro_tensor::Tensor;
-use tenferro_tensor::{DType, DotGeneralConfig, TensorBackend};
+use tenferro_tensor::{DType, DotGeneralConfig, TensorBackend, TensorElementwise};
 use tenferro_tensor::{TensorFusion, TensorRead};
 use tidu::eager::BackwardExecutor;
 use tidu::{linearize, ADKey};
@@ -82,10 +82,19 @@ fn eager_runtime_synchronize_reports_poisoned_backend_lock() {
 
 #[test]
 fn eager_materialization_uses_backend() {
+    let mut cpu_backend = EagerBackend::cpu(CpuBackend::new());
+    assert!(format!("{cpu_backend:?}").contains("Cpu"));
+    cpu_backend.synchronize().unwrap();
+
     let materializations = Arc::new(AtomicUsize::new(0));
-    let ctx = Arc::new(EagerRuntime::from_backend(EagerBackend::recording_cpu(
-        Arc::clone(&materializations),
-    )));
+    let mut backend = EagerBackend::recording_cpu(Arc::clone(&materializations));
+    assert!(format!("{backend:?}").contains("Recording"));
+    backend.synchronize().unwrap();
+    let probe = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
+    let sum = TensorElementwise::add(&mut backend, &probe, &probe).unwrap();
+    assert_eq!(sum.as_slice::<f64>().unwrap(), &[4.0]);
+    assert_eq!(materializations.load(Ordering::Relaxed), 0);
+    let ctx = Arc::new(EagerRuntime::from_backend(backend));
     let x = EagerTensor::from_tensor_in(
         Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
         Arc::clone(&ctx),

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -20,8 +20,9 @@ use tenferro_ops::{ShapeExtent, ShapeGuardContext, SymDim, TensorMeta};
 use tenferro_runtime::ExtensionCacheLimits;
 use tenferro_runtime::{Error, ExtensionExecutionContext, ExtensionExecutor, ExtensionRuntime};
 use tenferro_tensor::Tensor;
+use tenferro_tensor::TypedTensorView;
 use tenferro_tensor::{DType, DotGeneralConfig, TensorBackend, TensorElementwise};
-use tenferro_tensor::{TensorFusion, TensorRead};
+use tenferro_tensor::{TensorFusion, TensorRead, TensorStructural, TensorView, TensorWrite};
 use tidu::eager::BackwardExecutor;
 use tidu::{linearize, ADKey};
 
@@ -94,6 +95,27 @@ fn eager_materialization_uses_backend() {
     let sum = TensorElementwise::add(&mut backend, &probe, &probe).unwrap();
     assert_eq!(sum.as_slice::<f64>().unwrap(), &[4.0]);
     assert_eq!(materializations.load(Ordering::Relaxed), 0);
+
+    let view_data = [1.0_f64, 2.0, 3.0, 4.0];
+    let view = TensorView::F64(
+        TypedTensorView::from_col_major(&[2, 2], &view_data)
+            .unwrap()
+            .transpose_view([1, 0])
+            .unwrap(),
+    );
+    let direct =
+        TensorStructural::to_contiguous_read(&mut backend, TensorRead::from_view(view)).unwrap();
+    assert_eq!(direct.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
+    assert_eq!(materializations.swap(0, Ordering::Relaxed), 1);
+
+    let mut destination = Tensor::from_vec_col_major(vec![1], vec![0.0_f64]).unwrap();
+    TensorStructural::copy_read_into(
+        &mut backend,
+        TensorRead::from_tensor(&probe),
+        TensorWrite::from_tensor(&mut destination),
+    )
+    .unwrap();
+    assert_eq!(destination.as_slice::<f64>().unwrap(), &[2.0]);
     let ctx = Arc::new(EagerRuntime::from_backend(backend));
     let x = EagerTensor::from_tensor_in(
         Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -78,6 +78,25 @@ fn eager_runtime_synchronize_reports_poisoned_backend_lock() {
 }
 
 #[test]
+fn eager_materialization_uses_backend() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+
+    let compact = x.to_tensor().unwrap();
+    assert_eq!(compact.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(ctx.recorded_to_contiguous_reads(), 0);
+
+    let view = x.transpose(&[1, 0]).unwrap();
+    let compact = view.to_tensor().unwrap();
+    assert_eq!(compact.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
+    assert_eq!(ctx.recorded_to_contiguous_reads(), 1);
+}
+
+#[test]
 fn eager_runtime_register_extension_reports_poisoned_executor_lock() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -298,10 +317,13 @@ impl<B: TensorBackend + 'static> ExtensionRuntime<B> for ReadPathFallbackRuntime
         inputs: &[TensorRead<'_>],
         ctx: &mut ExtensionExecutionContext<'_, B>,
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
-        let materialized_inputs: Vec<Tensor> = inputs
-            .iter()
-            .map(TensorRead::to_tensor)
-            .collect::<tenferro_tensor::Result<_>>()?;
+        let materialized_inputs = ctx.backend_mut().with_backend_session(|exec| {
+            inputs
+                .iter()
+                .cloned()
+                .map(|input| exec.to_contiguous_read(input))
+                .collect::<tenferro_tensor::Result<Vec<_>>>()
+        })?;
         let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
         self.execute(op, &input_refs, ctx)
     }

--- a/crates/tenferro-ad/src/eager_backend.rs
+++ b/crates/tenferro-ad/src/eager_backend.rs
@@ -14,7 +14,7 @@ use tenferro_tensor::{
     DotGeneralConfig, GatherConfig, PadConfig, Result as TensorResult, ScatterConfig, SliceConfig,
     Tensor, TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot,
     TensorElementwise, TensorFusion, TensorIndexing, TensorRead, TensorReduction, TensorStructural,
-    TensorValue,
+    TensorValue, TensorWrite,
 };
 
 pub enum EagerBackend {
@@ -154,6 +154,10 @@ impl TensorStructural for RecordingBackend {
     fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> TensorResult<Tensor> {
         self.materializations.fetch_add(1, Ordering::Relaxed);
         self.inner.to_contiguous_read(input)
+    }
+
+    fn copy_read_into(&mut self, src: TensorRead<'_>, dst: TensorWrite<'_>) -> TensorResult<()> {
+        self.inner.copy_read_into(src, dst)
     }
 
     delegate_recording_backend_methods! {
@@ -298,6 +302,8 @@ impl TensorAnalytic for EagerBackend {
 
 impl TensorStructural for EagerBackend {
     delegate_tensor_backend_methods! {
+        fn to_contiguous_read(input: TensorRead<'_>) -> TensorResult<Tensor>;
+        fn copy_read_into(src: TensorRead<'_>, dst: TensorWrite<'_>) -> TensorResult<()>;
         fn transpose(input: &Tensor, perm: &[usize]) -> TensorResult<Tensor>;
         fn reshape(input: &Tensor, shape: &[usize]) -> TensorResult<Tensor>;
         fn reshape_read(input: TensorRead<'_>, shape: &[usize]) -> TensorResult<Tensor>;

--- a/crates/tenferro-ad/src/eager_backend.rs
+++ b/crates/tenferro-ad/src/eager_backend.rs
@@ -1,3 +1,8 @@
+#[cfg(test)]
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use tenferro_cpu::CpuBackend;
 #[cfg(feature = "cuda")]
 use tenferro_gpu::CudaBackend;
@@ -14,6 +19,8 @@ use tenferro_tensor::{
 
 pub enum EagerBackend {
     Cpu(CpuBackend),
+    #[cfg(test)]
+    Recording(RecordingBackend),
     #[cfg(feature = "cuda")]
     Cuda(CudaBackend),
     #[cfg(feature = "webgpu")]
@@ -24,6 +31,8 @@ impl std::fmt::Debug for EagerBackend {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Cpu(backend) => f.debug_tuple("Cpu").field(backend).finish(),
+            #[cfg(test)]
+            Self::Recording(backend) => f.debug_tuple("Recording").field(backend).finish(),
             #[cfg(feature = "cuda")]
             Self::Cuda(backend) => f.debug_tuple("Cuda").field(backend).finish(),
             #[cfg(feature = "webgpu")]
@@ -35,6 +44,14 @@ impl std::fmt::Debug for EagerBackend {
 impl EagerBackend {
     pub(crate) fn cpu(backend: CpuBackend) -> Self {
         Self::Cpu(backend)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn recording_cpu(materializations: Arc<AtomicUsize>) -> Self {
+        Self::Recording(RecordingBackend {
+            materializations,
+            inner: CpuBackend::new(),
+        })
     }
 
     #[cfg(feature = "cuda")]
@@ -50,6 +67,8 @@ impl EagerBackend {
     pub(crate) fn synchronize(&mut self) -> TensorResult<()> {
         match self {
             Self::Cpu(_) => Ok(()),
+            #[cfg(test)]
+            Self::Recording(_) => Ok(()),
             #[cfg(feature = "cuda")]
             Self::Cuda(backend) => backend.runtime().synchronize(),
             #[cfg(feature = "webgpu")]
@@ -62,6 +81,8 @@ macro_rules! dispatch {
     ($backend:expr, $method:ident($($arg:expr),* $(,)?)) => {
         match $backend {
             EagerBackend::Cpu(backend) => backend.$method($($arg),*),
+            #[cfg(test)]
+            EagerBackend::Recording(backend) => backend.$method($($arg),*),
             #[cfg(feature = "cuda")]
             EagerBackend::Cuda(backend) => backend.$method($($arg),*),
             #[cfg(feature = "webgpu")]
@@ -69,6 +90,139 @@ macro_rules! dispatch {
         }
     };
 }
+
+#[cfg(test)]
+#[derive(Debug)]
+pub struct RecordingBackend {
+    materializations: Arc<AtomicUsize>,
+    inner: CpuBackend,
+}
+
+#[cfg(test)]
+macro_rules! delegate_recording_backend_methods {
+    ($(fn $method:ident($($arg:ident: $ty:ty),* $(,)?) -> $ret:ty;)*) => {
+        $(
+            fn $method(&mut self, $($arg: $ty),*) -> $ret {
+                self.inner.$method($($arg),*)
+            }
+        )*
+    };
+}
+
+#[cfg(test)]
+impl BackendRuntimeCache for RecordingBackend {
+    type RuntimeCache = ();
+}
+
+#[cfg(test)]
+impl TensorElementwise for RecordingBackend {
+    delegate_recording_backend_methods! {
+        fn add(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn sub(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn mul(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn neg(input: &Tensor) -> TensorResult<Tensor>;
+        fn conj(input: &Tensor) -> TensorResult<Tensor>;
+        fn div(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn abs(input: &Tensor) -> TensorResult<Tensor>;
+        fn sign(input: &Tensor) -> TensorResult<Tensor>;
+        fn maximum(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn minimum(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> TensorResult<Tensor>;
+        fn select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> TensorResult<Tensor>;
+        fn clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> TensorResult<Tensor>;
+    }
+}
+
+#[cfg(test)]
+impl TensorAnalytic for RecordingBackend {
+    delegate_recording_backend_methods! {
+        fn exp(input: &Tensor) -> TensorResult<Tensor>;
+        fn log(input: &Tensor) -> TensorResult<Tensor>;
+        fn sin(input: &Tensor) -> TensorResult<Tensor>;
+        fn cos(input: &Tensor) -> TensorResult<Tensor>;
+        fn tanh(input: &Tensor) -> TensorResult<Tensor>;
+        fn sqrt(input: &Tensor) -> TensorResult<Tensor>;
+        fn rsqrt(input: &Tensor) -> TensorResult<Tensor>;
+        fn pow(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
+        fn expm1(input: &Tensor) -> TensorResult<Tensor>;
+        fn log1p(input: &Tensor) -> TensorResult<Tensor>;
+    }
+}
+
+#[cfg(test)]
+impl TensorStructural for RecordingBackend {
+    fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> TensorResult<Tensor> {
+        self.materializations.fetch_add(1, Ordering::Relaxed);
+        self.inner.to_contiguous_read(input)
+    }
+
+    delegate_recording_backend_methods! {
+        fn transpose(input: &Tensor, perm: &[usize]) -> TensorResult<Tensor>;
+        fn reshape(input: &Tensor, shape: &[usize]) -> TensorResult<Tensor>;
+        fn broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> TensorResult<Tensor>;
+        fn cast(input: &Tensor, to: DType) -> TensorResult<Tensor>;
+        fn extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> TensorResult<Tensor>;
+        fn embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> TensorResult<Tensor>;
+        fn tril(input: &Tensor, k: i64) -> TensorResult<Tensor>;
+        fn triu(input: &Tensor, k: i64) -> TensorResult<Tensor>;
+    }
+}
+
+#[cfg(test)]
+impl TensorReduction for RecordingBackend {
+    delegate_recording_backend_methods! {
+        fn reduce_sum(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+        fn reduce_prod(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+        fn reduce_max(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+        fn reduce_min(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+    }
+}
+
+#[cfg(test)]
+impl TensorIndexing for RecordingBackend {
+    delegate_recording_backend_methods! {
+        fn gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> TensorResult<Tensor>;
+        fn scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> TensorResult<Tensor>;
+        fn slice(input: &Tensor, config: &SliceConfig) -> TensorResult<Tensor>;
+        fn dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> TensorResult<Tensor>;
+        fn dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) -> TensorResult<Tensor>;
+        fn pad(input: &Tensor, config: &PadConfig) -> TensorResult<Tensor>;
+        fn concatenate(inputs: &[&Tensor], axis: usize) -> TensorResult<Tensor>;
+        fn reverse(input: &Tensor, axes: &[usize]) -> TensorResult<Tensor>;
+    }
+}
+
+#[cfg(test)]
+impl TensorDot for RecordingBackend {
+    fn dot_general(
+        &mut self,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        config: &DotGeneralConfig,
+    ) -> TensorResult<Tensor> {
+        self.inner.dot_general(lhs, rhs, config)
+    }
+}
+
+#[cfg(test)]
+impl TensorFusion for RecordingBackend {}
+#[cfg(test)]
+impl TensorBuffer for RecordingBackend {}
+#[cfg(test)]
+impl TensorDeviceTransfer for RecordingBackend {}
+#[cfg(test)]
+impl BackendCachedDot for RecordingBackend {}
+#[cfg(test)]
+impl BackendSessionHost for RecordingBackend {
+    fn with_backend_session<R: Send>(
+        &mut self,
+        f: impl FnOnce(&mut dyn BackendSession) -> R + Send,
+    ) -> R {
+        f(self)
+    }
+}
+#[cfg(test)]
+impl TensorBackend for RecordingBackend {}
 
 macro_rules! delegate_tensor_backend_methods {
     ($(fn $method:ident($($arg:ident: $ty:ty),* $(,)?) -> $ret:ty;)*) => {

--- a/crates/tenferro-ad/src/eager_exec.rs
+++ b/crates/tenferro-ad/src/eager_exec.rs
@@ -91,21 +91,32 @@ fn promote_binary<'a>(
     promote_binary_to_dtype(exec, a, b, promoted)
 }
 
-fn materialize_tensor_read(input: TensorRead<'_>) -> Result<Tensor> {
-    input.to_tensor().map_err(Error::from)
+fn materialize_tensor_read(exec: &mut dyn BackendSession, input: TensorRead<'_>) -> Result<Tensor> {
+    exec.to_contiguous_read(input).map_err(Error::from)
 }
 
-fn concrete_tensor_read(input: TensorRead<'_>) -> Result<ConcreteTensorRead<'_>> {
+fn concrete_tensor_read<'a>(
+    exec: &mut dyn BackendSession,
+    input: TensorRead<'a>,
+) -> Result<ConcreteTensorRead<'a>> {
     match input {
         TensorRead::Tensor(tensor) => Ok(ConcreteTensorRead::Borrowed(tensor)),
         TensorRead::View(view) => Ok(ConcreteTensorRead::Owned(Box::new(
-            view.to_tensor().map_err(Error::from)?,
+            exec.to_contiguous_read(TensorRead::from_view(view))
+                .map_err(Error::from)?,
         ))),
     }
 }
 
-fn concrete_tensor_reads<'a>(inputs: &[TensorRead<'a>]) -> Result<Vec<ConcreteTensorRead<'a>>> {
-    inputs.iter().cloned().map(concrete_tensor_read).collect()
+fn concrete_tensor_reads<'a>(
+    exec: &mut dyn BackendSession,
+    inputs: &[TensorRead<'a>],
+) -> Result<Vec<ConcreteTensorRead<'a>>> {
+    inputs
+        .iter()
+        .cloned()
+        .map(|input| concrete_tensor_read(exec, input))
+        .collect()
 }
 
 fn concrete_promoted_read_to_dtype<'a>(
@@ -114,9 +125,9 @@ fn concrete_promoted_read_to_dtype<'a>(
     promoted: DType,
 ) -> Result<ConcreteTensorRead<'a>> {
     if input.dtype() == promoted {
-        concrete_tensor_read(input)
+        concrete_tensor_read(exec, input)
     } else {
-        let input = concrete_tensor_read(input)?;
+        let input = concrete_tensor_read(exec, input)?;
         Ok(ConcreteTensorRead::Owned(Box::new(
             exec.convert(input.tensor(), promoted)
                 .map_err(Error::from)?,
@@ -132,7 +143,7 @@ fn promote_read_to_dtype<'a>(
     if input.dtype() == promoted {
         Ok(PromotedTensorRead::Borrowed(Box::new(input)))
     } else {
-        let input = concrete_tensor_read(input)?;
+        let input = concrete_tensor_read(exec, input)?;
         Ok(PromotedTensorRead::Owned(Box::new(
             exec.convert(input.tensor(), promoted)
                 .map_err(Error::from)?,
@@ -407,31 +418,31 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
             vec![exec.broadcast_in_dim_read(inputs[0].clone(), &shape, dims)?]
         }
         StdTensorOp::ExtractDiag { axis_a, axis_b } => {
-            let input = concrete_tensor_read(inputs[0].clone())?;
+            let input = concrete_tensor_read(exec, inputs[0].clone())?;
             vec![exec.extract_diagonal(input.tensor(), *axis_a, *axis_b)?]
         }
         StdTensorOp::EmbedDiag { axis_a, axis_b } => {
-            let input = concrete_tensor_read(inputs[0].clone())?;
+            let input = concrete_tensor_read(exec, inputs[0].clone())?;
             vec![exec.embed_diagonal(input.tensor(), *axis_a, *axis_b)?]
         }
         StdTensorOp::Tril { k } => {
-            let input = concrete_tensor_read(inputs[0].clone())?;
+            let input = concrete_tensor_read(exec, inputs[0].clone())?;
             vec![exec.tril(input.tensor(), *k)?]
         }
         StdTensorOp::Triu { k } => {
-            let input = concrete_tensor_read(inputs[0].clone())?;
+            let input = concrete_tensor_read(exec, inputs[0].clone())?;
             vec![exec.triu(input.tensor(), *k)?]
         }
         StdTensorOp::Slice(config) => {
-            let input = concrete_tensor_read(inputs[0].clone())?;
+            let input = concrete_tensor_read(exec, inputs[0].clone())?;
             vec![exec.slice(input.tensor(), config)?]
         }
         StdTensorOp::Pad(config) => {
-            let input = concrete_tensor_read(inputs[0].clone())?;
+            let input = concrete_tensor_read(exec, inputs[0].clone())?;
             vec![exec.pad(input.tensor(), config)?]
         }
         StdTensorOp::Reverse { axes } => {
-            let input = concrete_tensor_read(inputs[0].clone())?;
+            let input = concrete_tensor_read(exec, inputs[0].clone())?;
             vec![exec.reverse(input.tensor(), axes)?]
         }
         StdTensorOp::ReduceProd { axes, .. } => {
@@ -446,7 +457,7 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
         StdTensorOp::Expm1 => vec![exec.expm1_read(inputs[0].clone())?],
         StdTensorOp::Log1p => vec![exec.log1p_read(inputs[0].clone())?],
         StdTensorOp::Convert { to, .. } => {
-            let input = concrete_tensor_read(inputs[0].clone())?;
+            let input = concrete_tensor_read(exec, inputs[0].clone())?;
             vec![exec.cast(input.tensor(), *to)?]
         }
         StdTensorOp::Constant { .. } => {
@@ -487,7 +498,7 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
             vec![exec.concatenate(&refs, *axis)?]
         }
         StdTensorOp::Gather(config) => {
-            let tensors = concrete_tensor_reads(inputs)?;
+            let tensors = concrete_tensor_reads(exec, inputs)?;
             vec![exec.gather(tensors[0].tensor(), tensors[1].tensor(), config)?]
         }
         StdTensorOp::GatherDynamicSliceSizes {
@@ -505,7 +516,7 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
                 index_vector_dim: *index_vector_dim,
                 slice_sizes,
             };
-            let tensors = concrete_tensor_reads(inputs)?;
+            let tensors = concrete_tensor_reads(exec, inputs)?;
             vec![exec.gather(tensors[0].tensor(), tensors[1].tensor(), &config)?]
         }
         StdTensorOp::Scatter(config) => {
@@ -513,11 +524,11 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
                 crate::shape_infer::promote_dtype(inputs[0].dtype(), inputs[2].dtype());
             let operand = concrete_promoted_read_to_dtype(exec, inputs[0].clone(), operand_dtype)?;
             let updates = concrete_promoted_read_to_dtype(exec, inputs[2].clone(), operand_dtype)?;
-            let indices = concrete_tensor_read(inputs[1].clone())?;
+            let indices = concrete_tensor_read(exec, inputs[1].clone())?;
             vec![exec.scatter(operand.tensor(), indices.tensor(), updates.tensor(), config)?]
         }
         StdTensorOp::DynamicSlice { slice_sizes } => {
-            let tensors = concrete_tensor_reads(inputs)?;
+            let tensors = concrete_tensor_reads(exec, inputs)?;
             vec![exec.dynamic_slice(tensors[0].tensor(), tensors[1].tensor(), slice_sizes)?]
         }
         StdTensorOp::DynamicUpdateSlice => {
@@ -525,7 +536,7 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
                 crate::shape_infer::promote_dtype(inputs[0].dtype(), inputs[1].dtype());
             let operand = concrete_promoted_read_to_dtype(exec, inputs[0].clone(), operand_dtype)?;
             let update = concrete_promoted_read_to_dtype(exec, inputs[1].clone(), operand_dtype)?;
-            let starts = concrete_tensor_read(inputs[2].clone())?;
+            let starts = concrete_tensor_read(exec, inputs[2].clone())?;
             vec![exec.dynamic_update_slice(operand.tensor(), update.tensor(), starts.tensor())?]
         }
         StdTensorOp::ShapeOf { .. } => {
@@ -543,7 +554,7 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
                     input.shape().len(),
                 ));
             }
-            let size_tensor = concrete_tensor_read(inputs[1].clone())?;
+            let size_tensor = concrete_tensor_read(exec, inputs[1].clone())?;
             let axis_extent = input.shape()[*axis];
             let size = dynamic_truncate_size(size_tensor.tensor(), axis_extent)?;
             let rank = input.shape().len();
@@ -554,7 +565,7 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
                 limits,
                 strides: vec![1; rank],
             };
-            let input = concrete_tensor_read(inputs[0].clone())?;
+            let input = concrete_tensor_read(exec, inputs[0].clone())?;
             vec![exec.slice(input.tensor(), &config)?]
         }
         StdTensorOp::PadToMatch { axis } => {
@@ -573,7 +584,7 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
             let target_size = reference.shape()[*axis];
             let current_size = input.shape()[*axis];
             if current_size >= target_size {
-                vec![materialize_tensor_read(inputs[0].clone())?]
+                vec![materialize_tensor_read(exec, inputs[0].clone())?]
             } else {
                 let rank = input.shape().len();
                 let mut high = vec![0i64; rank];
@@ -583,7 +594,7 @@ pub(crate) fn exec_standard_op_on_tensor_reads_in_session(
                     edge_padding_high: high,
                     interior_padding: vec![0i64; rank],
                 };
-                let input = concrete_tensor_read(inputs[0].clone())?;
+                let input = concrete_tensor_read(exec, inputs[0].clone())?;
                 vec![exec.pad(input.tensor(), &config)?]
             }
         }

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -894,7 +894,7 @@ impl EagerTensor {
             return Ok(Self::new_untracked_value_result(ctx, value));
         }
 
-        let output = Arc::new(value.to_tensor().map_err(Error::from)?);
+        let output = Arc::new(ctx.materialize_value(&value)?);
         let outputs = vec![Arc::clone(&output)];
         let mut recorded = record_eager_outputs(&op, &outputs, tensors)?;
         let trace = recorded.traces.pop().ok_or_else(|| {

--- a/crates/tenferro-ad/tests/segment_tests.rs
+++ b/crates/tenferro-ad/tests/segment_tests.rs
@@ -260,7 +260,7 @@ fn segmented_value_dispatch_preserves_terminal_lazy_broadcast_multiply_view() {
         "terminal broadcast-multiply segment should preserve a lazy output view"
     );
 
-    let output = outputs.pop().unwrap().to_tensor().unwrap();
+    let output = executor.materialize_value(&outputs.pop().unwrap()).unwrap();
     assert_eq!(output.shape(), &[2, 2, 4, 3]);
     let Tensor::F64(output) = output else {
         panic!("expected f64 output")

--- a/crates/tenferro-cpu/Cargo.toml
+++ b/crates/tenferro-cpu/Cargo.toml
@@ -95,6 +95,10 @@ name = "cpu_install_overhead"
 harness = false
 
 [[bench]]
+name = "view_materialization"
+harness = false
+
+[[bench]]
 name = "openblas_direct_overhead"
 harness = false
 required-features = ["cpu-blas"]

--- a/crates/tenferro-cpu/benches/view_materialization.rs
+++ b/crates/tenferro-cpu/benches/view_materialization.rs
@@ -14,8 +14,9 @@ const TN_24D_SCATTERED_STRIDES: [isize; 24] = [
 struct MaterializationCase {
     name: &'static str,
     storage: Vec<f64>,
-    shape: Vec<usize>,
-    strides: Vec<isize>,
+    source_shape: Vec<usize>,
+    source_strides: Vec<isize>,
+    permutation: Option<Vec<usize>>,
     offset: isize,
 }
 
@@ -78,15 +79,12 @@ fn make_case(
 ) -> MaterializationCase {
     let storage_len = storage_len(&source_shape, &source_strides, 0);
     let storage = (0..storage_len).map(|index| index as f64).collect();
-    let (shape, strides) = perm.map_or_else(
-        || (source_shape.clone(), source_strides.clone()),
-        |perm| permute_layout(&source_shape, &source_strides, perm),
-    );
     MaterializationCase {
         name,
         storage,
-        shape,
-        strides,
+        source_shape,
+        source_strides,
+        permutation: perm.map(<[usize]>::to_vec),
         offset: 0,
     }
 }
@@ -128,33 +126,70 @@ fn build_case(spec: MaterializationSpec) -> MaterializationCase {
     }
 }
 
+fn output_shape(case: &MaterializationCase) -> Vec<usize> {
+    case.permutation.as_ref().map_or_else(
+        || case.source_shape.clone(),
+        |permutation| {
+            permutation
+                .iter()
+                .map(|&source_axis| case.source_shape[source_axis])
+                .collect()
+        },
+    )
+}
+
+fn expected_physical_offset(case: &MaterializationCase, output_index: &[usize]) -> isize {
+    output_index
+        .iter()
+        .enumerate()
+        .try_fold(case.offset, |position, (output_axis, &coordinate)| {
+            let source_axis = case
+                .permutation
+                .as_ref()
+                .map_or(output_axis, |permutation| permutation[output_axis]);
+            position.checked_add(
+                isize::try_from(coordinate)
+                    .expect("benchmark coordinate fits in isize")
+                    .checked_mul(case.source_strides[source_axis])
+                    .expect("benchmark physical offset fits in isize"),
+            )
+        })
+        .expect("benchmark physical offset fits in isize")
+}
+
 fn verify_exact_output(case: &MaterializationCase, output: &[f64]) {
-    let elements = case.shape.iter().product::<usize>();
+    let shape = output_shape(case);
+    let elements = shape.iter().product::<usize>();
     assert_eq!(output.len(), elements);
-    let mut index = vec![0usize; case.shape.len()];
+    let mut index = vec![0usize; shape.len()];
     for (logical_offset, &actual) in output.iter().enumerate() {
-        let physical_offset = index.iter().zip(&case.strides).try_fold(
-            case.offset,
-            |position, (&coordinate, &stride)| {
-                position.checked_add(
-                    isize::try_from(coordinate)
-                        .expect("benchmark coordinate fits in isize")
-                        .checked_mul(stride)
-                        .expect("benchmark physical offset fits in isize"),
-                )
-            },
-        );
-        let expected = physical_offset.expect("benchmark physical offset fits in isize") as f64;
+        let expected = expected_physical_offset(case, &index) as f64;
         assert_eq!(actual, expected, "logical offset {logical_offset}");
 
         for axis in 0..index.len() {
             index[axis] += 1;
-            if index[axis] < case.shape[axis] {
+            if index[axis] < shape[axis] {
                 break;
             }
             index[axis] = 0;
         }
     }
+}
+
+fn verify_case_once(
+    backend: &mut CpuBackend,
+    view: &TypedTensorView<'_, f64>,
+    case: &MaterializationCase,
+) {
+    let checked = backend
+        .to_contiguous(view)
+        .expect("pre-timing materialization succeeds");
+    verify_exact_output(
+        case,
+        checked
+            .as_slice()
+            .expect("CPU materialization returns host storage"),
+    );
 }
 
 fn bench_view_materialization(c: &mut Criterion) {
@@ -164,24 +199,22 @@ fn bench_view_materialization(c: &mut Criterion) {
 
         for spec in CASES {
             let case = build_case(spec);
+            let (view_shape, view_strides) = case.permutation.as_ref().map_or_else(
+                || (case.source_shape.clone(), case.source_strides.clone()),
+                |permutation| permute_layout(&case.source_shape, &case.source_strides, permutation),
+            );
             let view =
-                TypedTensorView::from_slice(&case.shape, &case.strides, case.offset, &case.storage)
+                TypedTensorView::from_slice(&view_shape, &view_strides, case.offset, &case.storage)
                     .expect("benchmark view layout is valid");
             let mut backend = CpuBackend::with_threads(threads)
                 .expect("benchmark CPU thread configuration is valid");
 
-            let checked = backend
-                .to_contiguous(&view)
-                .expect("pre-timing materialization succeeds");
-            verify_exact_output(
-                &case,
-                checked
-                    .as_slice()
-                    .expect("CPU materialization returns host storage"),
-            );
+            // The checked tensor is dropped when this helper returns, before
+            // Criterion starts measuring allocation-inclusive materialization.
+            verify_case_once(&mut backend, &view, &case);
 
             group.throughput(Throughput::Elements(
-                case.shape.iter().product::<usize>() as u64
+                view_shape.iter().product::<usize>() as u64
             ));
             group.bench_function(case.name, |b| {
                 b.iter(|| {

--- a/crates/tenferro-cpu/benches/view_materialization.rs
+++ b/crates/tenferro-cpu/benches/view_materialization.rs
@@ -1,0 +1,200 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::{TensorViewCanonicalization, TypedTensorView};
+
+const TN_24D_PERM: [usize; 24] = [
+    0, 1, 2, 3, 22, 4, 23, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+];
+
+const TN_24D_SCATTERED_STRIDES: [isize; 24] = [
+    1, 2, 4, 8, 4_194_304, 16, 8_388_608, 32, 64, 128, 256, 512, 1_024, 2_048, 4_096, 8_192,
+    16_384, 32_768, 65_536, 131_072, 262_144, 524_288, 1_048_576, 2_097_152,
+];
+
+struct MaterializationCase {
+    name: &'static str,
+    storage: Vec<f64>,
+    shape: Vec<usize>,
+    strides: Vec<isize>,
+    offset: isize,
+}
+
+#[derive(Clone, Copy)]
+enum MaterializationSpec {
+    Compact3d,
+    Permuted3d,
+    HighRankContiguousPermutation,
+    Scattered24dExplicitStride,
+    TinyTranspose,
+}
+
+const CASES: [MaterializationSpec; 5] = [
+    MaterializationSpec::Compact3d,
+    MaterializationSpec::Permuted3d,
+    MaterializationSpec::HighRankContiguousPermutation,
+    MaterializationSpec::Scattered24dExplicitStride,
+    MaterializationSpec::TinyTranspose,
+];
+
+fn compact_strides(shape: &[usize]) -> Vec<isize> {
+    let mut strides = Vec::with_capacity(shape.len());
+    let mut stride = 1isize;
+    for &extent in shape {
+        strides.push(stride);
+        stride = stride
+            .checked_mul(isize::try_from(extent).expect("benchmark extent fits in isize"))
+            .expect("benchmark compact stride fits in isize");
+    }
+    strides
+}
+
+fn permute_layout(shape: &[usize], strides: &[isize], perm: &[usize]) -> (Vec<usize>, Vec<isize>) {
+    (
+        perm.iter().map(|&axis| shape[axis]).collect(),
+        perm.iter().map(|&axis| strides[axis]).collect(),
+    )
+}
+
+fn storage_len(shape: &[usize], strides: &[isize], offset: isize) -> usize {
+    let max_offset = shape
+        .iter()
+        .zip(strides)
+        .try_fold(offset, |position, (&extent, &stride)| {
+            let last = isize::try_from(extent.saturating_sub(1)).ok()?;
+            position.checked_add(last.checked_mul(stride)?)
+        })
+        .expect("benchmark layout has a representable reachable range");
+    usize::try_from(max_offset)
+        .expect("benchmark layout has a non-negative reachable range")
+        .checked_add(1)
+        .expect("benchmark storage length fits in usize")
+}
+
+fn make_case(
+    name: &'static str,
+    source_shape: Vec<usize>,
+    source_strides: Vec<isize>,
+    perm: Option<&[usize]>,
+) -> MaterializationCase {
+    let storage_len = storage_len(&source_shape, &source_strides, 0);
+    let storage = (0..storage_len).map(|index| index as f64).collect();
+    let (shape, strides) = perm.map_or_else(
+        || (source_shape.clone(), source_strides.clone()),
+        |perm| permute_layout(&source_shape, &source_strides, perm),
+    );
+    MaterializationCase {
+        name,
+        storage,
+        shape,
+        strides,
+        offset: 0,
+    }
+}
+
+fn build_case(spec: MaterializationSpec) -> MaterializationCase {
+    match spec {
+        MaterializationSpec::Compact3d => {
+            let shape = vec![128, 128, 128];
+            let strides = compact_strides(&shape);
+            make_case("compact_3d", shape, strides, None)
+        }
+        MaterializationSpec::Permuted3d => {
+            let shape = vec![128, 128, 128];
+            let strides = compact_strides(&shape);
+            make_case("permuted_3d", shape, strides, Some(&[2, 0, 1]))
+        }
+        MaterializationSpec::HighRankContiguousPermutation => {
+            let shape = vec![2; 24];
+            let strides = compact_strides(&shape);
+            make_case(
+                "high_rank_contiguous_permutation",
+                shape,
+                strides,
+                Some(&TN_24D_PERM),
+            )
+        }
+        MaterializationSpec::Scattered24dExplicitStride => make_case(
+            "scattered_24d_explicit_stride",
+            vec![2; 24],
+            TN_24D_SCATTERED_STRIDES.to_vec(),
+            Some(&TN_24D_PERM),
+        ),
+        MaterializationSpec::TinyTranspose => make_case(
+            "tiny_transpose",
+            vec![16, 16],
+            compact_strides(&[16, 16]),
+            Some(&[1, 0]),
+        ),
+    }
+}
+
+fn verify_exact_output(case: &MaterializationCase, output: &[f64]) {
+    let elements = case.shape.iter().product::<usize>();
+    assert_eq!(output.len(), elements);
+    let mut index = vec![0usize; case.shape.len()];
+    for (logical_offset, &actual) in output.iter().enumerate() {
+        let physical_offset = index.iter().zip(&case.strides).try_fold(
+            case.offset,
+            |position, (&coordinate, &stride)| {
+                position.checked_add(
+                    isize::try_from(coordinate)
+                        .expect("benchmark coordinate fits in isize")
+                        .checked_mul(stride)
+                        .expect("benchmark physical offset fits in isize"),
+                )
+            },
+        );
+        let expected = physical_offset.expect("benchmark physical offset fits in isize") as f64;
+        assert_eq!(actual, expected, "logical offset {logical_offset}");
+
+        for axis in 0..index.len() {
+            index[axis] += 1;
+            if index[axis] < case.shape[axis] {
+                break;
+            }
+            index[axis] = 0;
+        }
+    }
+}
+
+fn bench_view_materialization(c: &mut Criterion) {
+    for threads in [1, 4] {
+        let mut group = c.benchmark_group(format!("view_materialization/{threads}_threads"));
+        group.sample_size(10);
+
+        for spec in CASES {
+            let case = build_case(spec);
+            let view =
+                TypedTensorView::from_slice(&case.shape, &case.strides, case.offset, &case.storage)
+                    .expect("benchmark view layout is valid");
+            let mut backend = CpuBackend::with_threads(threads)
+                .expect("benchmark CPU thread configuration is valid");
+
+            let checked = backend
+                .to_contiguous(&view)
+                .expect("pre-timing materialization succeeds");
+            verify_exact_output(
+                &case,
+                checked
+                    .as_slice()
+                    .expect("CPU materialization returns host storage"),
+            );
+
+            group.throughput(Throughput::Elements(
+                case.shape.iter().product::<usize>() as u64
+            ));
+            group.bench_function(case.name, |b| {
+                b.iter(|| {
+                    let materialized = backend
+                        .to_contiguous(black_box(&view))
+                        .expect("timed materialization succeeds");
+                    black_box(materialized);
+                });
+            });
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_view_materialization);
+criterion_main!(benches);

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -38,8 +38,8 @@ use tenferro_tensor::{
 
 use super::exec_session::CpuExecSession;
 use super::{
-    analytic, elementwise, gemm, indexing, materialize_tensor_read, reduction, structural,
-    CpuContext,
+    analytic, copy_tensor_read_into, elementwise, gemm, indexing, materialize_tensor_read,
+    reduction, structural, CpuContext,
 };
 
 #[derive(Debug, Default, Clone)]
@@ -1800,6 +1800,16 @@ impl TensorAnalytic for CpuBackend {
 }
 
 impl TensorStructural for CpuBackend {
+    fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
+        self.install_with_pool(|buffers| {
+            materialize_tensor_read(buffers, "CpuBackend::to_contiguous_read", input)
+        })
+    }
+
+    fn copy_read_into(&mut self, src: TensorRead<'_>, dst: TensorWrite<'_>) -> crate::Result<()> {
+        self.install(|| copy_tensor_read_into("CpuBackend::copy_read_into", src, dst))
+    }
+
     fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
         self.install_with_pool(|buffers| structural::transpose_with_pool(buffers, input, perm))
     }

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -1889,7 +1889,7 @@ impl TensorReduction for CpuBackend {
     }
 
     fn reduce_sum_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        self.install(|| reduction::reduce_sum_read(input, axes))
+        self.install_with_pool(|buffers| reduction::reduce_sum_read(buffers, input, axes))
     }
 
     fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
@@ -1897,7 +1897,7 @@ impl TensorReduction for CpuBackend {
     }
 
     fn reduce_prod_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        self.install(|| reduction::reduce_prod_read(input, axes))
+        self.install_with_pool(|buffers| reduction::reduce_prod_read(buffers, input, axes))
     }
 
     fn reduce_max(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
@@ -1905,7 +1905,7 @@ impl TensorReduction for CpuBackend {
     }
 
     fn reduce_max_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        self.install(|| reduction::reduce_max_read(input, axes))
+        self.install_with_pool(|buffers| reduction::reduce_max_read(buffers, input, axes))
     }
 
     fn reduce_min(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
@@ -1913,7 +1913,7 @@ impl TensorReduction for CpuBackend {
     }
 
     fn reduce_min_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        self.install(|| reduction::reduce_min_read(input, axes))
+        self.install_with_pool(|buffers| reduction::reduce_min_read(buffers, input, axes))
     }
 }
 

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -19,8 +19,8 @@ use crate::{
     CpuTopologyError, NumaNodeId, ResolvedCpuPlacement,
 };
 use crate::{
-    Buffer, CacheStats, Tensor, TensorRank, TensorRead, TensorValue, TensorWrite, TypedTensor,
-    TypedTensorView, TypedTensorViewMut,
+    Buffer, CacheStats, Tensor, TensorRank, TensorRead, TensorScalar, TensorValue, TensorWrite,
+    TypedTensor, TypedTensorView, TypedTensorViewMut,
 };
 use tenferro_tensor::backend::{
     dot_general_accum_via_temp, grouped_gemm_via_sequential, validate_dot_general_accumulation,
@@ -2640,40 +2640,26 @@ impl TensorBuffer for CpuBackend {
 
 impl<T, R> TensorViewCanonicalization<T, R> for CpuBackend
 where
-    T: Clone + 'static,
+    T: TensorScalar + PoolScalar,
     R: TensorRank,
+    R::Shape: Send + Sync,
+    R::Strides: Send + Sync,
 {
     fn to_contiguous(
         &mut self,
         view: &TypedTensorView<'_, T, R>,
     ) -> crate::Result<TypedTensor<T, R>> {
-        if view.backend_buffer().is_some() {
-            return Err(crate::Error::backend_failure(
-                "CpuBackend::to_contiguous",
-                "CPU backend received a backend tensor view; download the tensor to host before CPU view canonicalization",
-            ));
-        }
-        view.to_contiguous()
+        self.install_with_pool(|buffers| {
+            structural::typed_materialize_view_with_pool(buffers, view, "CpuBackend::to_contiguous")
+        })
     }
 
-    fn copy_from_contiguous(
+    fn copy_into(
         &mut self,
-        src: &TypedTensor<T, R>,
+        src: &TypedTensorView<'_, T, R>,
         dst: &mut TypedTensorViewMut<'_, T, R>,
     ) -> crate::Result<()> {
-        if matches!(src.buffer(), Buffer::Backend(_)) {
-            return Err(crate::Error::backend_failure(
-                "CpuBackend::copy_from_contiguous",
-                "CPU backend received a backend source tensor; download the tensor to host before CPU view copy-back",
-            ));
-        }
-        if dst.backend_buffer().is_some() {
-            return Err(crate::Error::backend_failure(
-                "CpuBackend::copy_from_contiguous",
-                "CPU backend received a backend destination view; download the tensor to host before CPU view copy-back",
-            ));
-        }
-        dst.copy_from_contiguous(src)
+        self.install(|| structural::typed_copy_view_into(src, dst, "CpuBackend::copy_into"))
     }
 }
 

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -1809,7 +1809,8 @@ impl TensorStructural for CpuBackend {
             return self.transpose(input, perm);
         }
 
-        let input = materialize_tensor_read("transpose", input)?;
+        let input =
+            self.install_with_pool(|buffers| materialize_tensor_read(buffers, "transpose", input))?;
         self.transpose(&input, perm)
     }
 
@@ -1822,7 +1823,8 @@ impl TensorStructural for CpuBackend {
             return self.reshape(input, shape);
         }
 
-        let input = materialize_tensor_read("reshape", input)?;
+        let input =
+            self.install_with_pool(|buffers| materialize_tensor_read(buffers, "reshape", input))?;
         self.reshape(&input, shape)
     }
 
@@ -1847,7 +1849,9 @@ impl TensorStructural for CpuBackend {
             return self.broadcast_in_dim(input, shape, dims);
         }
 
-        let input = materialize_tensor_read("broadcast_in_dim", input)?;
+        let input = self.install_with_pool(|buffers| {
+            materialize_tensor_read(buffers, "broadcast_in_dim", input)
+        })?;
         self.broadcast_in_dim(&input, shape, dims)
     }
 
@@ -1996,8 +2000,12 @@ impl TensorDot for CpuBackend {
             return Ok(result);
         }
 
-        let lhs = materialize_tensor_read("dot_general", lhs)?;
-        let rhs = materialize_tensor_read("dot_general", rhs)?;
+        let (lhs, rhs) = self.install_with_pool(|buffers| {
+            Ok::<_, crate::Error>((
+                materialize_tensor_read(buffers, "dot_general", lhs)?,
+                materialize_tensor_read(buffers, "dot_general", rhs)?,
+            ))
+        })?;
         self.with_base_dot_general_provider(|this| {
             BackendCachedDot::dot_general_cached(this, &mut cache, None, &lhs, &rhs, config)
         })

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -1805,13 +1805,7 @@ impl TensorStructural for CpuBackend {
     }
 
     fn transpose_read(&mut self, input: TensorRead<'_>, perm: &[usize]) -> crate::Result<Tensor> {
-        if let Some(input) = input.as_tensor() {
-            return self.transpose(input, perm);
-        }
-
-        let input =
-            self.install_with_pool(|buffers| materialize_tensor_read(buffers, "transpose", input))?;
-        self.transpose(&input, perm)
+        self.install_with_pool(|buffers| structural::transpose_read_with_pool(buffers, input, perm))
     }
 
     fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
@@ -1819,13 +1813,7 @@ impl TensorStructural for CpuBackend {
     }
 
     fn reshape_read(&mut self, input: TensorRead<'_>, shape: &[usize]) -> crate::Result<Tensor> {
-        if let Some(input) = input.as_tensor() {
-            return self.reshape(input, shape);
-        }
-
-        let input =
-            self.install_with_pool(|buffers| materialize_tensor_read(buffers, "reshape", input))?;
-        self.reshape(&input, shape)
+        self.install_with_pool(|buffers| structural::reshape_read_with_pool(buffers, input, shape))
     }
 
     fn broadcast_in_dim(
@@ -1845,14 +1833,9 @@ impl TensorStructural for CpuBackend {
         shape: &[usize],
         dims: &[usize],
     ) -> crate::Result<Tensor> {
-        if let Some(input) = input.as_tensor() {
-            return self.broadcast_in_dim(input, shape, dims);
-        }
-
-        let input = self.install_with_pool(|buffers| {
-            materialize_tensor_read(buffers, "broadcast_in_dim", input)
-        })?;
-        self.broadcast_in_dim(&input, shape, dims)
+        self.install_with_pool(|buffers| {
+            structural::broadcast_in_dim_read_with_pool(buffers, input, shape, dims)
+        })
     }
 
     fn cast(&mut self, input: &Tensor, to: crate::DType) -> crate::Result<Tensor> {

--- a/crates/tenferro-cpu/src/elementwise/tests.rs
+++ b/crates/tenferro-cpu/src/elementwise/tests.rs
@@ -316,7 +316,8 @@ fn broadcast_multiply_handles_scalar_full_output_pairs() {
     )
     .unwrap()
     .expect("complex scalar broadcast multiply should materialize");
-    let complex_tensor = complex_value.to_tensor().unwrap();
+    let complex_tensor =
+        crate::materialize_tensor_read(&mut buffers, "test", complex_value.tensor_read()).unwrap();
     let complex_data = complex_tensor.as_slice::<Complex<f64>>().unwrap();
     assert_c64_close(complex_data[0], c64(3.5, -0.5));
     assert_c64_close(complex_data[1], c64(-0.75, 4.75));
@@ -345,7 +346,7 @@ fn lazy_outer_product_lhs_prefix_preserves_logical_output_order() {
     assert_eq!(out.shape, vec![2, 3, 4]);
     assert_ne!(out.strides, col_major_strides(&out.shape).unwrap());
     let value = lazy_outer_product_value(Tensor::F64(out.base), out.shape, out.strides).unwrap();
-    let tensor = value.to_tensor().unwrap();
+    let tensor = crate::materialize_tensor_read(&mut buffers, "test", value.tensor_read()).unwrap();
     let expected: Vec<f64> = (0..4)
         .flat_map(|k| {
             (0..3).flat_map(move |j| (0..2).map(move |i| lhs_data[i * 3 + j] * rhs_data[k]))
@@ -378,7 +379,7 @@ fn lazy_outer_product_rhs_prefix_preserves_logical_output_order() {
     assert_eq!(out.shape, vec![4, 2, 3]);
     assert_ne!(out.strides, col_major_strides(&out.shape).unwrap());
     let value = lazy_outer_product_value(Tensor::F64(out.base), out.shape, out.strides).unwrap();
-    let tensor = value.to_tensor().unwrap();
+    let tensor = crate::materialize_tensor_read(&mut buffers, "test", value.tensor_read()).unwrap();
     let expected: Vec<f64> = (0..3)
         .flat_map(|j| {
             (0..2).flat_map(move |i| (0..4).map(move |k| rhs_data[k] * lhs_data[i * 3 + j]))
@@ -1026,7 +1027,12 @@ fn broadcast_multiply_read_and_value_cover_dtypes_and_error_paths() {
     .unwrap()
     .expect("non-canonical f32 outer product should stay lazy");
     assert!(matches!(value_f32, TensorValue::View(_)));
-    assert_eq!(value_f32.to_tensor().unwrap().shape(), &lhs_shape);
+    assert_eq!(
+        crate::materialize_tensor_read(&mut buffers, "test", value_f32.tensor_read())
+            .unwrap()
+            .shape(),
+        &lhs_shape
+    );
 
     let lhs_i32_data = [1_i32, 2, 3, 4, 5, 6];
     let rhs_i32_data = [2_i32, 3, 4, 5];
@@ -1127,7 +1133,10 @@ fn broadcast_multiply_read_and_value_cover_dtypes_and_error_paths() {
     .expect("same-shape multiply should materialize");
     assert!(matches!(materialized, TensorValue::Tensor(_)));
     assert_eq!(
-        materialized.to_tensor().unwrap().as_slice::<i64>().unwrap(),
+        crate::materialize_tensor_read(&mut buffers, "test", materialized.tensor_read())
+            .unwrap()
+            .as_slice::<i64>()
+            .unwrap(),
         &[8, 15]
     );
 

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -184,25 +184,25 @@ impl TensorReduction for CpuExecSession<'_> {
     delegate!(reduce_sum(input: &Tensor, axes: &[usize]) => reduction::reduce_sum(input, axes));
 
     fn reduce_sum_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        self.run_native(|_| reduction::reduce_sum_read(input, axes))
+        self.run_native(|buffers| reduction::reduce_sum_read(buffers, input, axes))
     }
 
     delegate!(reduce_prod(input: &Tensor, axes: &[usize]) => reduction::reduce_prod(input, axes));
 
     fn reduce_prod_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        self.run_native(|_| reduction::reduce_prod_read(input, axes))
+        self.run_native(|buffers| reduction::reduce_prod_read(buffers, input, axes))
     }
 
     delegate!(reduce_max(input: &Tensor, axes: &[usize]) => reduction::reduce_max(input, axes));
 
     fn reduce_max_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        self.run_native(|_| reduction::reduce_max_read(input, axes))
+        self.run_native(|buffers| reduction::reduce_max_read(buffers, input, axes))
     }
 
     delegate!(reduce_min(input: &Tensor, axes: &[usize]) => reduction::reduce_min(input, axes));
 
     fn reduce_min_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        self.run_native(|_| reduction::reduce_min_read(input, axes))
+        self.run_native(|buffers| reduction::reduce_min_read(buffers, input, axes))
     }
 }
 

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -142,24 +142,12 @@ impl TensorStructural for CpuExecSession<'_> {
     // Structural
     delegate_with_pool!(transpose(input: &Tensor, perm: &[usize]) => structural::transpose_with_pool);
     fn transpose_read(&mut self, input: TensorRead<'_>, perm: &[usize]) -> crate::Result<Tensor> {
-        self.run_native(|buffers| {
-            if let Some(input) = input.as_tensor() {
-                return structural::transpose_with_pool(buffers, input, perm);
-            }
-            let input = materialize_tensor_read(buffers, "transpose", input)?;
-            structural::transpose_with_pool(buffers, &input, perm)
-        })
+        self.run_native(|buffers| structural::transpose_read_with_pool(buffers, input, perm))
     }
 
     delegate!(reshape(input: &Tensor, shape: &[usize]) => structural::reshape(input, shape));
     fn reshape_read(&mut self, input: TensorRead<'_>, shape: &[usize]) -> crate::Result<Tensor> {
-        self.run_native(|buffers| {
-            if let Some(input) = input.as_tensor() {
-                return structural::reshape(input, shape);
-            }
-            let input = materialize_tensor_read(buffers, "reshape", input)?;
-            structural::reshape(&input, shape)
-        })
+        self.run_native(|buffers| structural::reshape_read_with_pool(buffers, input, shape))
     }
 
     delegate_with_pool!(broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) => structural::broadcast_in_dim_with_pool);
@@ -170,11 +158,7 @@ impl TensorStructural for CpuExecSession<'_> {
         dims: &[usize],
     ) -> crate::Result<Tensor> {
         self.run_native(|buffers| {
-            if let Some(input) = input.as_tensor() {
-                return structural::broadcast_in_dim_with_pool(buffers, input, shape, dims);
-            }
-            let input = materialize_tensor_read(buffers, "broadcast_in_dim", input)?;
-            structural::broadcast_in_dim_with_pool(buffers, &input, shape, dims)
+            structural::broadcast_in_dim_read_with_pool(buffers, input, shape, dims)
         })
     }
 

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -14,8 +14,8 @@ use tenferro_tensor::{
 
 use super::backend::reclaim_typed;
 use super::{
-    analytic, elementwise, gemm, indexing, materialize_tensor_read, reduction, structural,
-    CpuContext,
+    analytic, copy_tensor_read_into, elementwise, gemm, indexing, materialize_tensor_read,
+    reduction, structural, CpuContext,
 };
 use super::{CpuBackendKind, DotGeneralProvider};
 
@@ -140,6 +140,16 @@ impl TensorAnalytic for CpuExecSession<'_> {
 
 impl TensorStructural for CpuExecSession<'_> {
     // Structural
+    fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
+        self.run_native(|buffers| {
+            materialize_tensor_read(buffers, "CpuBackend::to_contiguous_read", input)
+        })
+    }
+
+    fn copy_read_into(&mut self, src: TensorRead<'_>, dst: TensorWrite<'_>) -> crate::Result<()> {
+        self.run_native(|_| copy_tensor_read_into("CpuBackend::copy_read_into", src, dst))
+    }
+
     delegate_with_pool!(transpose(input: &Tensor, perm: &[usize]) => structural::transpose_with_pool);
     fn transpose_read(&mut self, input: TensorRead<'_>, perm: &[usize]) -> crate::Result<Tensor> {
         self.run_native(|buffers| structural::transpose_read_with_pool(buffers, input, perm))

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -146,18 +146,18 @@ impl TensorStructural for CpuExecSession<'_> {
             if let Some(input) = input.as_tensor() {
                 return structural::transpose_with_pool(buffers, input, perm);
             }
-            let input = materialize_tensor_read("transpose", input)?;
+            let input = materialize_tensor_read(buffers, "transpose", input)?;
             structural::transpose_with_pool(buffers, &input, perm)
         })
     }
 
     delegate!(reshape(input: &Tensor, shape: &[usize]) => structural::reshape(input, shape));
     fn reshape_read(&mut self, input: TensorRead<'_>, shape: &[usize]) -> crate::Result<Tensor> {
-        self.run_native(|_| {
+        self.run_native(|buffers| {
             if let Some(input) = input.as_tensor() {
                 return structural::reshape(input, shape);
             }
-            let input = materialize_tensor_read("reshape", input)?;
+            let input = materialize_tensor_read(buffers, "reshape", input)?;
             structural::reshape(&input, shape)
         })
     }
@@ -173,7 +173,7 @@ impl TensorStructural for CpuExecSession<'_> {
             if let Some(input) = input.as_tensor() {
                 return structural::broadcast_in_dim_with_pool(buffers, input, shape, dims);
             }
-            let input = materialize_tensor_read("broadcast_in_dim", input)?;
+            let input = materialize_tensor_read(buffers, "broadcast_in_dim", input)?;
             structural::broadcast_in_dim_with_pool(buffers, &input, shape, dims)
         })
     }
@@ -329,8 +329,12 @@ impl TensorDot for CpuExecSession<'_> {
             return Ok(result);
         }
 
-        let lhs = materialize_tensor_read("dot_general", lhs)?;
-        let rhs = materialize_tensor_read("dot_general", rhs)?;
+        let (lhs, rhs) = self.run_native(|buffers| {
+            Ok::<_, crate::Error>((
+                materialize_tensor_read(buffers, "dot_general", lhs)?,
+                materialize_tensor_read(buffers, "dot_general", rhs)?,
+            ))
+        })?;
         self.with_base_dot_general_provider(|this| {
             this.dot_general_cached(None, &lhs, &rhs, config)
         })

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -215,6 +215,51 @@ pub(crate) fn materialize_tensor_read(
     }
 }
 
+pub(crate) fn copy_tensor_read_into(
+    op: &'static str,
+    src: TensorRead<'_>,
+    dst: TensorWrite<'_>,
+) -> crate::Result<()> {
+    let src_dtype = src.dtype();
+    let dst_dtype = dst.dtype();
+    macro_rules! copy_source {
+        ($variant:ident, $src:expr) => {{
+            let src = $src;
+            match dst {
+                TensorWrite::Tensor(Tensor::$variant(dst)) => {
+                    let mut dst = dst.as_view_mut();
+                    structural::typed_copy_view_into(&src, &mut dst, op)
+                }
+                TensorWrite::View(TensorViewMut::$variant(mut dst)) => {
+                    structural::typed_copy_view_into(&src, &mut dst, op)
+                }
+                _ => Err(crate::Error::DTypeMismatch {
+                    op,
+                    lhs: src_dtype,
+                    rhs: dst_dtype,
+                }),
+            }
+        }};
+    }
+
+    match src {
+        TensorRead::Tensor(Tensor::F32(src)) => copy_source!(F32, src.as_view()),
+        TensorRead::Tensor(Tensor::F64(src)) => copy_source!(F64, src.as_view()),
+        TensorRead::Tensor(Tensor::I32(src)) => copy_source!(I32, src.as_view()),
+        TensorRead::Tensor(Tensor::I64(src)) => copy_source!(I64, src.as_view()),
+        TensorRead::Tensor(Tensor::Bool(src)) => copy_source!(Bool, src.as_view()),
+        TensorRead::Tensor(Tensor::C32(src)) => copy_source!(C32, src.as_view()),
+        TensorRead::Tensor(Tensor::C64(src)) => copy_source!(C64, src.as_view()),
+        TensorRead::View(TensorView::F32(src)) => copy_source!(F32, src),
+        TensorRead::View(TensorView::F64(src)) => copy_source!(F64, src),
+        TensorRead::View(TensorView::I32(src)) => copy_source!(I32, src),
+        TensorRead::View(TensorView::I64(src)) => copy_source!(I64, src),
+        TensorRead::View(TensorView::Bool(src)) => copy_source!(Bool, src),
+        TensorRead::View(TensorView::C32(src)) => copy_source!(C32, src),
+        TensorRead::View(TensorView::C64(src)) => copy_source!(C64, src),
+    }
+}
+
 fn clone_host_tensor_read(op: &'static str, tensor: &Tensor) -> crate::Result<Tensor> {
     macro_rules! clone_host {
         ($variant:ident, $tensor:expr) => {{

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -205,12 +205,13 @@ pub(crate) fn typed_view_from_view<'a, T: Copy + 'static, R: TensorRank>(
 }
 
 pub(crate) fn materialize_tensor_read(
+    buffers: &mut BufferPool,
     op: &'static str,
     input: TensorRead<'_>,
 ) -> crate::Result<Tensor> {
     match input {
         TensorRead::Tensor(tensor) => clone_host_tensor_read(op, tensor),
-        TensorRead::View(view) => materialize_tensor_view(op, view),
+        TensorRead::View(view) => materialize_tensor_view(buffers, op, view),
     }
 }
 
@@ -233,13 +234,16 @@ fn clone_host_tensor_read(op: &'static str, tensor: &Tensor) -> crate::Result<Te
     }
 }
 
-fn materialize_tensor_view(op: &'static str, view: TensorView<'_>) -> crate::Result<Tensor> {
+fn materialize_tensor_view(
+    buffers: &mut BufferPool,
+    op: &'static str,
+    view: TensorView<'_>,
+) -> crate::Result<Tensor> {
     macro_rules! materialize {
         ($variant:ident, $view:expr) => {{
-            if $view.backend_buffer().is_some() {
-                return Err(cpu_backend_buffer_error(op));
-            }
-            Ok(Tensor::$variant($view.to_contiguous()?))
+            Ok(Tensor::$variant(
+                structural::typed_materialize_view_with_pool(buffers, &$view, op)?,
+            ))
         }};
     }
 

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -263,6 +263,7 @@ pub(crate) fn copy_tensor_read_into(
 fn clone_host_tensor_read(op: &'static str, tensor: &Tensor) -> crate::Result<Tensor> {
     macro_rules! clone_host {
         ($variant:ident, $tensor:expr) => {{
+            structural::validate_cpu_host_placement(op, "source", $tensor.placement())?;
             typed_host_data(op, $tensor)?;
             Ok(Tensor::$variant($tensor.clone()))
         }};

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -4,6 +4,8 @@ use num_traits::{Float, One, Zero};
 use strided_kernel::reduce_axis;
 
 use super::{typed_host_data, typed_view, typed_view_from_view};
+use crate::buffer_pool::BufferPool;
+use crate::materialize_tensor_read;
 use tenferro_tensor::{Tensor, TensorRank, TensorRead, TensorView, TypedTensor, TypedTensorView};
 
 fn validate_axes(op: &'static str, axes: &[usize], rank: usize) -> crate::Result<()> {
@@ -72,6 +74,7 @@ fn reduction_empty_axes_noop(
 }
 
 fn reduction_read_empty_axes_noop(
+    buffers: &mut BufferPool,
     op: &'static str,
     input: &TensorRead<'_>,
     axes: &[usize],
@@ -81,15 +84,7 @@ fn reduction_read_empty_axes_noop(
         return Ok(None);
     }
 
-    match input.clone() {
-        TensorRead::Tensor(input) => {
-            ensure_host_tensor(op, input)?;
-            // INVARIANT: empty-axis reduction is semantic identity, but the
-            // `_read` API returns an owned tensor even for borrowed input.
-            Ok(Some(input.clone()))
-        }
-        TensorRead::View(input) => Ok(Some(view_to_contiguous_tensor(input)?)),
-    }
+    materialize_tensor_read(buffers, op, input.clone()).map(Some)
 }
 
 fn nan_propagating_max<T: Float>(a: T, b: T) -> T {
@@ -169,8 +164,12 @@ pub fn reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     }
 }
 
-pub(crate) fn reduce_sum_read(input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-    if let Some(output) = reduction_read_empty_axes_noop("reduce_sum", &input, axes)? {
+pub(crate) fn reduce_sum_read(
+    buffers: &mut BufferPool,
+    input: TensorRead<'_>,
+    axes: &[usize],
+) -> crate::Result<Tensor> {
+    if let Some(output) = reduction_read_empty_axes_noop(buffers, "reduce_sum", &input, axes)? {
         return Ok(output);
     }
 
@@ -253,8 +252,12 @@ pub fn reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     }
 }
 
-pub(crate) fn reduce_prod_read(input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-    if let Some(output) = reduction_read_empty_axes_noop("reduce_prod", &input, axes)? {
+pub(crate) fn reduce_prod_read(
+    buffers: &mut BufferPool,
+    input: TensorRead<'_>,
+    axes: &[usize],
+) -> crate::Result<Tensor> {
+    if let Some(output) = reduction_read_empty_axes_noop(buffers, "reduce_prod", &input, axes)? {
         return Ok(output);
     }
 
@@ -335,8 +338,12 @@ pub fn reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     }
 }
 
-pub(crate) fn reduce_max_read(input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-    if let Some(output) = reduction_read_empty_axes_noop("reduce_max", &input, axes)? {
+pub(crate) fn reduce_max_read(
+    buffers: &mut BufferPool,
+    input: TensorRead<'_>,
+    axes: &[usize],
+) -> crate::Result<Tensor> {
+    if let Some(output) = reduction_read_empty_axes_noop(buffers, "reduce_max", &input, axes)? {
         return Ok(output);
     }
 
@@ -413,8 +420,12 @@ pub fn reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     }
 }
 
-pub(crate) fn reduce_min_read(input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-    if let Some(output) = reduction_read_empty_axes_noop("reduce_min", &input, axes)? {
+pub(crate) fn reduce_min_read(
+    buffers: &mut BufferPool,
+    input: TensorRead<'_>,
+    axes: &[usize],
+) -> crate::Result<Tensor> {
+    if let Some(output) = reduction_read_empty_axes_noop(buffers, "reduce_min", &input, axes)? {
         return Ok(output);
     }
 
@@ -538,7 +549,10 @@ where
 {
     validate_reduced_axes_nonempty(label, input.shape(), axes)?;
     if axes.is_empty() {
-        return view_to_dyn_contiguous(input);
+        return Err(crate::Error::backend_failure(
+            label,
+            "empty-axis view reductions require backend-owned materialization",
+        ));
     }
 
     let output_shape: Vec<usize> = input
@@ -552,7 +566,10 @@ where
     let mut sorted_axes = axes.to_vec();
     sorted_axes.sort_unstable_by(|a, b| b.cmp(a));
     let Some((&first_axis, remaining_axes)) = sorted_axes.split_first() else {
-        return view_to_dyn_contiguous(input);
+        return Err(crate::Error::backend_failure(
+            label,
+            "empty-axis view reductions require backend-owned materialization",
+        ));
     };
 
     let input_view = typed_view_from_view(label, input)?;
@@ -565,28 +582,6 @@ where
     }
 
     TypedTensor::from_vec_col_major(output_shape, current.into_data())
-}
-
-fn view_to_dyn_contiguous<T, R>(input: &TypedTensorView<'_, T, R>) -> crate::Result<TypedTensor<T>>
-where
-    T: Clone + 'static,
-    R: TensorRank,
-{
-    let compact = input.to_contiguous()?;
-    let (shape, data) = compact.into_vec_col_major()?;
-    TypedTensor::from_vec_col_major(shape, data)
-}
-
-fn view_to_contiguous_tensor(input: TensorView<'_>) -> crate::Result<Tensor> {
-    match input {
-        TensorView::F32(t) => Ok(Tensor::F32(view_to_dyn_contiguous(&t)?)),
-        TensorView::F64(t) => Ok(Tensor::F64(view_to_dyn_contiguous(&t)?)),
-        TensorView::I32(t) => Ok(Tensor::I32(view_to_dyn_contiguous(&t)?)),
-        TensorView::I64(t) => Ok(Tensor::I64(view_to_dyn_contiguous(&t)?)),
-        TensorView::Bool(t) => Ok(Tensor::Bool(view_to_dyn_contiguous(&t)?)),
-        TensorView::C32(t) => Ok(Tensor::C32(view_to_dyn_contiguous(&t)?)),
-        TensorView::C64(t) => Ok(Tensor::C64(view_to_dyn_contiguous(&t)?)),
-    }
 }
 
 pub fn typed_reduce_sum<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -1,12 +1,16 @@
 use num_complex::{Complex32, Complex64};
 use num_traits::Zero;
-use strided_kernel::{col_major_strides, copy_into, map_into, Identity, StridedView};
+use strided_kernel::{
+    col_major_strides, copy_into, map_into, Identity, StridedView, StridedViewMut,
+};
 
 use crate::{
     buffer_pool::{BufferPool, PoolScalar},
     flat_to_multi,
 };
-use tenferro_tensor::{DType, Tensor, TensorRank, TypedTensor, TypedTensorView};
+use tenferro_tensor::{
+    DType, Tensor, TensorRank, TensorRead, TensorView, TypedTensor, TypedTensorView,
+};
 
 #[cfg(test)]
 use super::typed_array_uninit;
@@ -91,6 +95,20 @@ macro_rules! dispatch_tensor_unary_result {
             Tensor::Bool($tensor) => Ok(Tensor::Bool($body?)),
             Tensor::C32($tensor) => Ok(Tensor::C32($body?)),
             Tensor::C64($tensor) => Ok(Tensor::C64($body?)),
+        }
+    };
+}
+
+macro_rules! dispatch_tensor_view_unary_result {
+    ($input:expr, |$view:ident| $body:expr) => {
+        match $input {
+            TensorView::F32($view) => Ok(Tensor::F32($body?)),
+            TensorView::F64($view) => Ok(Tensor::F64($body?)),
+            TensorView::I32($view) => Ok(Tensor::I32($body?)),
+            TensorView::I64($view) => Ok(Tensor::I64($body?)),
+            TensorView::Bool($view) => Ok(Tensor::Bool($body?)),
+            TensorView::C32($view) => Ok(Tensor::C32($body?)),
+            TensorView::C64($view) => Ok(Tensor::C64($body?)),
         }
     };
 }
@@ -226,8 +244,34 @@ pub(crate) fn transpose_with_pool(
     dispatch_tensor_unary_result!(input, |t| typed_transpose_with_pool(buffers, t, perm))
 }
 
+pub(crate) fn transpose_read_with_pool(
+    buffers: &mut BufferPool,
+    input: TensorRead<'_>,
+    perm: &[usize],
+) -> crate::Result<Tensor> {
+    match input {
+        TensorRead::Tensor(input) => transpose_with_pool(buffers, input, perm),
+        TensorRead::View(input) => dispatch_tensor_view_unary_result!(input, |view| {
+            typed_transpose_view_with_pool(buffers, &view, perm)
+        }),
+    }
+}
+
 pub(crate) fn reshape(input: &Tensor, shape: &[usize]) -> crate::Result<Tensor> {
     dispatch_tensor_unary_result!(input, |t| typed_reshape(t, shape))
+}
+
+pub(crate) fn reshape_read_with_pool(
+    buffers: &mut BufferPool,
+    input: TensorRead<'_>,
+    shape: &[usize],
+) -> crate::Result<Tensor> {
+    match input {
+        TensorRead::Tensor(input) => reshape(input, shape),
+        TensorRead::View(input) => dispatch_tensor_view_unary_result!(input, |view| {
+            typed_reshape_view_with_pool(buffers, &view, shape)
+        }),
+    }
 }
 
 #[cfg(test)]
@@ -248,6 +292,20 @@ pub(crate) fn broadcast_in_dim_with_pool(
     dispatch_tensor_unary_result!(input, |t| typed_broadcast_in_dim_with_pool(
         buffers, t, shape, dims
     ))
+}
+
+pub(crate) fn broadcast_in_dim_read_with_pool(
+    buffers: &mut BufferPool,
+    input: TensorRead<'_>,
+    shape: &[usize],
+    dims: &[usize],
+) -> crate::Result<Tensor> {
+    match input {
+        TensorRead::Tensor(input) => broadcast_in_dim_with_pool(buffers, input, shape, dims),
+        TensorRead::View(input) => dispatch_tensor_view_unary_result!(input, |view| {
+            typed_broadcast_in_dim_view_with_pool(buffers, &view, shape, dims)
+        }),
+    }
 }
 
 /// Convert a tensor to another dtype using checked dtype conversion.
@@ -589,6 +647,7 @@ where
     R: TensorRank,
 {
     typed_transpose_view_impl(view, perm, |shape| unsafe {
+        // INVARIANT: validated transpose copy overwrites every pooled output element.
         // SAFETY: transpose materialization copies every output element before returning.
         typed_array_uninit_from_pool(buffers, shape)
     })
@@ -614,13 +673,49 @@ pub fn typed_reshape<T: Clone + 'static>(
     )
 }
 
+pub(crate) fn typed_reshape_view_with_pool<T, R>(
+    buffers: &mut BufferPool,
+    view: &TypedTensorView<'_, T, R>,
+    shape: &[usize],
+) -> crate::Result<TypedTensor<T>>
+where
+    T: Copy + Clone + PoolScalar + 'static,
+    R: TensorRank,
+{
+    let old_n = checked_shape_product("reshape", "input shape", view.shape())?;
+    let new_n = checked_shape_product("reshape", "output shape", shape)?;
+    if old_n != new_n {
+        return Err(crate::Error::ShapeMismatch {
+            op: "reshape",
+            lhs: view.shape().to_vec(),
+            rhs: shape.to_vec(),
+        });
+    }
+
+    let src = typed_view_from_view("reshape", view)?;
+    // INVARIANT: equal element counts let the source-shaped copy target fully overwrite the
+    // pooled compact output before the same storage is attached to `shape`.
+    // SAFETY: copy_into overwrites every pooled output element before returning.
+    let mut out = unsafe { typed_array_uninit_from_pool(buffers, shape) }?;
+    let copy_strides = col_major_strides(view.shape());
+    let mut copy_target = StridedViewMut::new(out.data_mut(), view.shape(), &copy_strides, 0)
+        .map_err(|err| crate::Error::backend_failure("reshape", err))?;
+    copy_into(&mut copy_target, &src)
+        .map_err(|err| crate::Error::backend_failure("reshape", err))?;
+    TypedTensor::from_buffer_col_major(
+        shape.to_vec(),
+        crate::Buffer::Host(out.into_data()),
+        view.placement().clone(),
+    )
+}
+
 #[cfg(test)]
-pub(crate) fn typed_broadcast_in_dim<T: Copy + Clone + Send + Sync>(
+pub(crate) fn typed_broadcast_in_dim<T: Copy + Clone + Send + Sync + 'static>(
     tensor: &TypedTensor<T>,
     shape: &[usize],
     dims: &[usize],
 ) -> crate::Result<TypedTensor<T>> {
-    typed_broadcast_in_dim_impl(tensor, shape, dims, |shape| unsafe {
+    typed_broadcast_in_dim_view_impl(&tensor.as_view(), shape, dims, |shape| unsafe {
         // SAFETY: broadcast materialization writes every output element before returning.
         Ok(typed_array_uninit(shape))
     })
@@ -633,28 +728,42 @@ pub(crate) fn typed_broadcast_in_dim_with_pool<T>(
     dims: &[usize],
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + PoolScalar,
+    T: Copy + Clone + PoolScalar + 'static,
 {
-    typed_broadcast_in_dim_impl(tensor, shape, dims, |shape| unsafe {
+    typed_broadcast_in_dim_view_with_pool(buffers, &tensor.as_view(), shape, dims)
+}
+
+pub(crate) fn typed_broadcast_in_dim_view_with_pool<T, R>(
+    buffers: &mut BufferPool,
+    view: &TypedTensorView<'_, T, R>,
+    shape: &[usize],
+    dims: &[usize],
+) -> crate::Result<TypedTensor<T>>
+where
+    T: Copy + Clone + PoolScalar + 'static,
+    R: TensorRank,
+{
+    typed_broadcast_in_dim_view_impl(view, shape, dims, |shape| unsafe {
+        // INVARIANT: validated broadcast copy overwrites every pooled output element.
         // SAFETY: broadcast materialization writes every output element before returning.
         typed_array_uninit_from_pool(buffers, shape)
     })
 }
 
-fn typed_broadcast_in_dim_impl<T>(
-    tensor: &TypedTensor<T>,
+fn typed_broadcast_in_dim_view_impl<T, R>(
+    view: &TypedTensorView<'_, T, R>,
     shape: &[usize],
     dims: &[usize],
     make_out: impl FnOnce(&[usize]) -> crate::Result<strided_kernel::StridedArray<T>>,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + Send + Sync,
+    T: Copy + Clone + Send + Sync + 'static,
+    R: TensorRank,
 {
-    validate_rank("broadcast_in_dim", tensor.shape().len(), dims.len())?;
+    validate_rank("broadcast_in_dim", view.shape().len(), dims.len())?;
     let mut seen = vec![false; shape.len()];
     let mut base_dims = vec![1usize; shape.len()];
     let mut base_strides = vec![0isize; shape.len()];
-    let source_strides = col_major_strides(tensor.shape());
     for (src_axis, &dst_axis) in dims.iter().enumerate() {
         validate_axis("broadcast_in_dim", dst_axis, shape.len())?;
         if seen[dst_axis] {
@@ -665,25 +774,28 @@ where
             });
         }
         seen[dst_axis] = true;
-        let source_dim = tensor.shape()[src_axis];
+        let source_dim = view.shape()[src_axis];
         let target_dim = shape[dst_axis];
         if source_dim != target_dim && source_dim != 1 {
             return Err(crate::Error::ShapeMismatch {
                 op: "broadcast_in_dim",
-                lhs: tensor.shape().to_vec(),
+                lhs: view.shape().to_vec(),
                 rhs: shape.to_vec(),
             });
         }
         base_dims[dst_axis] = source_dim;
-        base_strides[dst_axis] = source_strides[src_axis];
+        base_strides[dst_axis] = view.strides()[src_axis];
     }
-    let base: StridedView<'_, T, Identity> = match tensor.buffer() {
-        crate::Buffer::Host(data) => {
-            StridedView::new(data.as_slice(), &base_dims, &base_strides, 0)
-                .map_err(|err| crate::Error::backend_failure("broadcast_in_dim", err))?
-        }
-        crate::Buffer::Backend(_) => return Err(cpu_backend_buffer_error("broadcast_in_dim")),
-    };
+    if view.backend_buffer().is_some() {
+        return Err(cpu_backend_buffer_error("broadcast_in_dim"));
+    }
+    let base: StridedView<'_, T, Identity> = StridedView::new(
+        view.host_storage()?,
+        &base_dims,
+        &base_strides,
+        view.offset(),
+    )
+    .map_err(|err| crate::Error::backend_failure("broadcast_in_dim", err))?;
     let broadcast: StridedView<'_, T, Identity> = base
         .broadcast(shape)
         .map_err(|err| crate::Error::backend_failure("broadcast_in_dim", err))?;

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 use tenferro_tensor::{
     DType, Tensor, TensorRank, TensorRead, TensorView, TypedTensor, TypedTensorView,
+    TypedTensorViewMut,
 };
 
 #[cfg(test)]
@@ -195,6 +196,46 @@ where
         crate::Buffer::Host(out.into_data()),
         view.placement().clone(),
     )
+}
+
+pub(crate) fn typed_copy_view_into<T, R>(
+    src: &TypedTensorView<'_, T, R>,
+    dst: &mut TypedTensorViewMut<'_, T, R>,
+    op: &'static str,
+) -> crate::Result<()>
+where
+    T: Copy + Send + Sync + 'static,
+    R: TensorRank,
+{
+    if src.shape() != dst.shape() {
+        return Err(crate::Error::ShapeMismatch {
+            op,
+            lhs: src.shape().to_vec(),
+            rhs: dst.shape().to_vec(),
+        });
+    }
+    if src.backend_buffer().is_some() || dst.backend_buffer().is_some() {
+        return Err(cpu_backend_buffer_error(op));
+    }
+
+    let src_view: StridedView<'_, T, Identity> = StridedView::new(
+        src.host_storage()?,
+        src.shape(),
+        src.strides(),
+        src.offset(),
+    )
+    .map_err(|err| crate::Error::backend_failure(op, err))?;
+    let dst_shape = dst.shape().to_vec();
+    let dst_strides = dst.strides().to_vec();
+    let dst_offset = dst.offset();
+    let mut dst_view = StridedViewMut::new(
+        dst.host_storage_mut()?,
+        &dst_shape,
+        &dst_strides,
+        dst_offset,
+    )
+    .map_err(|err| crate::Error::backend_failure(op, err))?;
+    copy_into(&mut dst_view, &src_view).map_err(|err| crate::Error::backend_failure(op, err))
 }
 
 fn zeroed_tensor_from_pool<T>(

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -9,8 +9,8 @@ use crate::{
     flat_to_multi,
 };
 use tenferro_tensor::{
-    DType, Tensor, TensorRank, TensorRead, TensorView, TypedTensor, TypedTensorView,
-    TypedTensorViewMut,
+    DType, MemoryKind, Placement, Tensor, TensorRank, TensorRead, TensorView, TypedTensor,
+    TypedTensorView, TypedTensorViewMut,
 };
 
 #[cfg(test)]
@@ -217,6 +217,8 @@ where
     if src.backend_buffer().is_some() || dst.backend_buffer().is_some() {
         return Err(cpu_backend_buffer_error(op));
     }
+    validate_cpu_host_placement(op, "source", src.placement())?;
+    validate_cpu_host_placement(op, "destination", dst.placement())?;
 
     let src_view: StridedView<'_, T, Identity> = StridedView::new(
         src.host_storage()?,
@@ -236,6 +238,26 @@ where
     )
     .map_err(|err| crate::Error::backend_failure(op, err))?;
     copy_into(&mut dst_view, &src_view).map_err(|err| crate::Error::backend_failure(op, err))
+}
+
+fn validate_cpu_host_placement(
+    op: &'static str,
+    role: &'static str,
+    placement: &Placement,
+) -> crate::Result<()> {
+    if matches!(
+        placement.memory_kind,
+        MemoryKind::PinnedHost | MemoryKind::UnpinnedHost
+    ) {
+        return Ok(());
+    }
+    Err(crate::Error::backend_failure(
+        op,
+        format!(
+            "CPU backend copy_into requires {role} host placement, got {:?}",
+            placement.memory_kind
+        ),
+    ))
 }
 
 fn zeroed_tensor_from_pool<T>(

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -1,5 +1,6 @@
 use num_complex::{Complex32, Complex64};
 use num_traits::Zero;
+use std::sync::Arc;
 use strided_kernel::{
     col_major_strides, copy_into, map_into, Identity, StridedView, StridedViewMut,
 };
@@ -213,6 +214,14 @@ where
             lhs: src.shape().to_vec(),
             rhs: dst.shape().to_vec(),
         });
+    }
+    if let (Some(src_buffer), Some(dst_buffer)) = (src.backend_buffer(), dst.backend_buffer()) {
+        if Arc::ptr_eq(src_buffer, dst_buffer) {
+            return Err(crate::Error::InvalidConfig {
+                op,
+                message: "CPU copy source and destination allocations must not alias".into(),
+            });
+        }
     }
     if src.backend_buffer().is_some() || dst.backend_buffer().is_some() {
         return Err(cpu_backend_buffer_error(op));

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -132,6 +132,37 @@ fn copy_view_to_array<T: Copy + Clone + Send + Sync>(
     Ok(tensor_from_array(out))
 }
 
+pub(crate) fn typed_materialize_view_with_pool<T, R>(
+    buffers: &mut BufferPool,
+    view: &TypedTensorView<'_, T, R>,
+    op: &'static str,
+) -> crate::Result<TypedTensor<T, R>>
+where
+    T: Copy + Clone + PoolScalar + 'static,
+    R: TensorRank,
+{
+    if view.backend_buffer().is_some() {
+        return Err(cpu_backend_buffer_error(op));
+    }
+    let src: StridedView<'_, T, Identity> = StridedView::new(
+        view.host_storage()?,
+        view.shape(),
+        view.strides(),
+        view.offset(),
+    )
+    .map_err(|err| crate::Error::backend_failure(op, err))?;
+    // SAFETY: copy_into overwrites every logical output element.
+    let mut out = unsafe { typed_array_uninit_from_pool(buffers, view.shape()) }?;
+    copy_into(&mut out.view_mut(), &src).map_err(|err| crate::Error::backend_failure(op, err))?;
+    let shape = R::shape_from_vec(view.shape().to_vec().into())
+        .map_err(|err| crate::Error::backend_failure(op, err))?;
+    TypedTensor::from_buffer_col_major(
+        shape,
+        crate::Buffer::Host(out.into_data()),
+        view.placement().clone(),
+    )
+}
+
 fn zeroed_tensor_from_pool<T>(
     buffers: &mut BufferPool,
     op: &'static str,

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -179,6 +179,7 @@ where
     if view.backend_buffer().is_some() {
         return Err(cpu_backend_buffer_error(op));
     }
+    validate_cpu_host_placement(op, "source", view.placement())?;
     let src: StridedView<'_, T, Identity> = StridedView::new(
         view.host_storage()?,
         view.shape(),
@@ -249,7 +250,7 @@ where
     copy_into(&mut dst_view, &src_view).map_err(|err| crate::Error::backend_failure(op, err))
 }
 
-fn validate_cpu_host_placement(
+pub(crate) fn validate_cpu_host_placement(
     op: &'static str,
     role: &'static str,
     placement: &Placement,
@@ -263,7 +264,7 @@ fn validate_cpu_host_placement(
     Err(crate::Error::backend_failure(
         op,
         format!(
-            "CPU backend copy_into requires {role} host placement, got {:?}",
+            "CPU backend requires {role} host placement for {op}, got {:?}",
             placement.memory_kind
         ),
     ))

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -141,13 +141,28 @@ fn host_view<'a, T: Copy>(
     }
 }
 
-fn copy_view_to_array<T: Copy + Clone + Send + Sync>(
+fn copy_view_to_array<T: Copy + Clone + Send + Sync + 'static>(
     op: &'static str,
     mut out: strided_kernel::StridedArray<T>,
     src: &StridedView<'_, T>,
+    placement: &tenferro_tensor::Placement,
 ) -> crate::Result<TypedTensor<T>> {
     copy_into(&mut out.view_mut(), src).map_err(|err| crate::Error::backend_failure(op, err))?;
-    Ok(tensor_from_array(out))
+    tensor_from_array_with_placement(op, out, placement)
+}
+
+fn tensor_from_array_with_placement<T: 'static>(
+    op: &'static str,
+    out: strided_kernel::StridedArray<T>,
+    placement: &tenferro_tensor::Placement,
+) -> crate::Result<TypedTensor<T>> {
+    let shape = out.dims().to_vec();
+    TypedTensor::from_buffer_col_major(
+        shape,
+        crate::Buffer::Host(out.into_data()),
+        placement.clone(),
+    )
+    .map_err(|err| crate::Error::backend_failure(op, err))
 }
 
 pub(crate) fn typed_materialize_view_with_pool<T, R>(
@@ -592,7 +607,7 @@ pub(crate) fn triu_with_pool(
 }
 
 #[cfg(test)]
-pub(crate) fn typed_transpose<T: Copy + Clone + Send + Sync>(
+pub(crate) fn typed_transpose<T: Copy + Clone + Send + Sync + 'static>(
     tensor: &TypedTensor<T>,
     perm: &[usize],
 ) -> crate::Result<TypedTensor<T>> {
@@ -603,7 +618,7 @@ pub(crate) fn typed_transpose<T: Copy + Clone + Send + Sync>(
         .map_err(|err| crate::Error::backend_failure("transpose", err))?;
     // SAFETY: copy_into overwrites every output element.
     let out = unsafe { typed_array_uninit(permuted.dims()) };
-    copy_view_to_array("transpose", out, &permuted)
+    copy_view_to_array("transpose", out, &permuted, tensor.placement())
 }
 
 fn typed_transpose_view_impl<T, R>(
@@ -623,7 +638,7 @@ where
     checked_shape_product("transpose", "output shape", permuted.dims())?;
     // SAFETY: copy_into overwrites every output element.
     let out = make_out(permuted.dims())?;
-    copy_view_to_array("transpose", out, &permuted)
+    copy_view_to_array("transpose", out, &permuted, view.placement())
 }
 
 pub(crate) fn typed_transpose_with_pool<T>(
@@ -804,7 +819,7 @@ where
     let mut out = make_out(shape)?;
     copy_into(&mut out.view_mut(), &broadcast)
         .map_err(|err| crate::Error::backend_failure("broadcast_in_dim", err))?;
-    Ok(tensor_from_array(out))
+    tensor_from_array_with_placement("broadcast_in_dim", out, view.placement())
 }
 
 fn typed_convert_with_pool<S, T>(

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -151,6 +151,7 @@ where
         view.offset(),
     )
     .map_err(|err| crate::Error::backend_failure(op, err))?;
+    // INVARIANT: validated equal-shaped copy_into overwrites every logical output element.
     // SAFETY: copy_into overwrites every logical output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, view.shape()) }?;
     copy_into(&mut out.view_mut(), &src).map_err(|err| crate::Error::backend_failure(op, err))?;

--- a/crates/tenferro-cpu/src/tests/cpu_stub_tests.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_stub_tests.rs
@@ -55,7 +55,7 @@ fn cpu_backend_rejects_backend_view_without_download() {
 }
 
 #[test]
-fn cpu_backend_rejects_backend_copy_back_without_download() {
+fn cpu_backend_copy_into_rejects_backend_destination_without_download() {
     let mut backend = crate::CpuBackend::new();
     let src = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
     let mut dst = TypedTensor::<f64>::from_buffer_col_major(
@@ -65,13 +65,13 @@ fn cpu_backend_rejects_backend_copy_back_without_download() {
     ).unwrap();
 
     let err = backend
-        .copy_from_contiguous(&src, &mut dst.as_view_mut())
+        .copy_into(&src.as_view(), &mut dst.as_view_mut())
         .unwrap_err();
 
     assert!(matches!(
         err,
         Error::BackendFailure {
-            op: "CpuBackend::copy_from_contiguous",
+            op: "CpuBackend::copy_into",
             ref message,
         } if message.contains("download")
     ));

--- a/crates/tenferro-cpu/src/tests/cpu_stub_tests.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_stub_tests.rs
@@ -177,6 +177,7 @@ fn cpu_reduce_read_rejects_backend_views_without_download() {
 
 #[test]
 fn cpu_materialize_tensor_read_covers_host_tensor_and_view_dtypes() {
+    let mut buffers = crate::buffer_pool::BufferPool::new();
     let tensors = [
         Tensor::F32(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f32]).unwrap()),
         Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap()),
@@ -193,9 +194,12 @@ fn cpu_materialize_tensor_read_covers_host_tensor_and_view_dtypes() {
         ).unwrap()),
     ];
     for tensor in &tensors {
-        let materialized =
-            crate::materialize_tensor_read("dot_general", TensorRead::from_tensor(tensor))
-                .unwrap();
+        let materialized = crate::materialize_tensor_read(
+            &mut buffers,
+            "dot_general",
+            TensorRead::from_tensor(tensor),
+        )
+        .unwrap();
         assert_eq!(materialized.dtype(), tensor.dtype());
         assert_eq!(materialized.shape(), tensor.shape());
     }
@@ -219,9 +223,12 @@ fn cpu_materialize_tensor_read_covers_host_tensor_and_view_dtypes() {
     ];
     for view in views {
         let dtype = view.dtype();
-        let materialized =
-            crate::materialize_tensor_read("dot_general", TensorRead::from_view(view))
-                .unwrap();
+        let materialized = crate::materialize_tensor_read(
+            &mut buffers,
+            "dot_general",
+            TensorRead::from_view(view),
+        )
+        .unwrap();
         assert_eq!(materialized.dtype(), dtype);
         assert_eq!(materialized.shape(), &[1]);
     }

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -212,56 +212,88 @@ fn test_materialize_tensor_read_covers_host_tensor_and_view_variants() {
         assert_eq!(materialized.shape(), tensor.shape());
     }
 
-    let shape = [1usize];
-    let f32s = [1.0_f32];
-    let f64s = [1.0_f64];
-    let i32s = [1_i32];
-    let i64s = [1_i64];
-    let bools = [true];
-    let c32s = [Complex32::new(1.0, 0.0)];
-    let c64s = [Complex64::new(1.0, 0.0)];
-    let views = [
-        TensorView::f32(&shape, &f32s).unwrap(),
-        TensorView::f64(&shape, &f64s).unwrap(),
-        TensorView::i32(&shape, &i32s).unwrap(),
-        TensorView::i64(&shape, &i64s).unwrap(),
-        TensorView::bool(&shape, &bools).unwrap(),
-        TensorView::c32(&shape, &c32s).unwrap(),
-        TensorView::c64(&shape, &c64s).unwrap(),
-    ];
-
-    for view in views {
-        let dtype = view.dtype();
-        let materialized = crate::materialize_tensor_read(
-            &mut buffers,
-            "dot_general",
-            TensorRead::from_view(view),
-        )
-        .unwrap();
-        assert_eq!(materialized.dtype(), dtype);
-        assert_eq!(materialized.shape(), &[1]);
+    macro_rules! assert_materialized_view {
+        ($view:expr, $ty:ty, $expected:expr) => {{
+            let materialized = crate::materialize_tensor_read(
+                &mut buffers,
+                "dot_general",
+                TensorRead::from_view($view),
+            )
+            .unwrap();
+            assert_eq!(materialized.shape(), &[2]);
+            assert_eq!(materialized.as_slice::<$ty>().unwrap(), $expected);
+        }};
     }
+
+    let shape = [2usize];
+    let f32s = [1.25_f32, -2.5];
+    let f64s = [3.5_f64, -4.75];
+    let i32s = [5_i32, -6];
+    let i64s = [7_i64, -8];
+    let bools = [true, false];
+    let c32s = [Complex32::new(1.0, -2.0), Complex32::new(-3.0, 4.0)];
+    let c64s = [Complex64::new(5.0, -6.0), Complex64::new(-7.0, 8.0)];
+    assert_materialized_view!(TensorView::f32(&shape, &f32s).unwrap(), f32, &f32s);
+    assert_materialized_view!(TensorView::f64(&shape, &f64s).unwrap(), f64, &f64s);
+    assert_materialized_view!(TensorView::i32(&shape, &i32s).unwrap(), i32, &i32s);
+    assert_materialized_view!(TensorView::i64(&shape, &i64s).unwrap(), i64, &i64s);
+    assert_materialized_view!(TensorView::bool(&shape, &bools).unwrap(), bool, &bools);
+    assert_materialized_view!(TensorView::c32(&shape, &c32s).unwrap(), Complex32, &c32s);
+    assert_materialized_view!(TensorView::c64(&shape, &c64s).unwrap(), Complex64, &c64s);
 }
 
 #[test]
 fn cpu_view_materialization_uses_pool_aware_strided_copy() {
     let cpu_lib = include_str!("../../lib.rs");
-    let materializer = cpu_lib
+    let dispatcher = cpu_lib
         .split_once("fn materialize_tensor_view")
         .unwrap()
         .1
         .split_once("#[cfg(test)]")
         .unwrap()
         .0;
+    let structural = include_str!("../../structural.rs");
+    let helper = structural
+        .split_once("pub(crate) fn typed_materialize_view_with_pool")
+        .unwrap()
+        .1
+        .split_once("fn zeroed_tensor_from_pool")
+        .unwrap()
+        .0;
 
     assert!(
-        materializer.contains("structural::typed_materialize_view_with_pool"),
+        dispatcher.contains("structural::typed_materialize_view_with_pool"),
         "CPU TensorView materialization must dispatch through the pool-aware strided helper"
     );
     assert!(
-        !materializer.contains("to_contiguous"),
+        !dispatcher.contains("to_contiguous"),
         "CPU TensorView materialization must not bypass the CPU pool with TypedTensorView::to_contiguous"
     );
+    assert!(helper.contains("StridedView::new"));
+    assert!(helper.contains("copy_into("));
+    assert!(helper.contains("typed_array_uninit_from_pool"));
+    assert!(helper.contains("// SAFETY:"));
+    assert!(
+        helper.contains(
+            "// INVARIANT: validated equal-shaped copy_into overwrites every logical output element."
+        ),
+        "full-overwrite pooled allocation requires the repository invariant marker"
+    );
+    for forbidden in [
+        "for ",
+        "flat_to_multi",
+        "to_contiguous",
+        "materialize_view_buffer_col_major",
+        "zeroed_tensor_from_pool",
+        "filled_tensor_from_pool",
+        "TypedTensor::zeros",
+        "vec![",
+    ] {
+        assert!(
+            !helper.contains(forbidden),
+            "typed materialization helper must not contain `{forbidden}`"
+        );
+    }
 }
 
 #[test]
@@ -304,6 +336,138 @@ fn cpu_view_materialization_preserves_transposed_and_scattered_values() {
         scattered.as_slice::<f64>().unwrap(),
         &[20.0, 50.0, 130.0, 160.0]
     );
+}
+
+#[test]
+fn cpu_view_materialization_handles_negative_and_zero_strides() {
+    let mut buffers = crate::buffer_pool::BufferPool::new();
+
+    let reversed_storage = [0_i32, 10, 20, 30, 40, 50];
+    let reversed =
+        tenferro_tensor::TypedTensorView::from_slice([3], [-2], 5, &reversed_storage).unwrap();
+    let reversed = crate::structural::typed_materialize_view_with_pool(
+        &mut buffers,
+        &reversed,
+        "negative_stride_materialize",
+    )
+    .unwrap();
+    assert_eq!(reversed.as_slice().unwrap(), &[50, 30, 10]);
+
+    let broadcast_storage = [7_i32, 11];
+    let broadcast =
+        tenferro_tensor::TypedTensorView::from_slice([2, 3], [1, 0], 0, &broadcast_storage)
+            .unwrap();
+    let broadcast = crate::structural::typed_materialize_view_with_pool(
+        &mut buffers,
+        &broadcast,
+        "zero_stride_materialize",
+    )
+    .unwrap();
+    assert_eq!(broadcast.shape(), &[2, 3]);
+    assert_eq!(broadcast.as_slice().unwrap(), &[7, 11, 7, 11, 7, 11]);
+}
+
+#[test]
+fn cpu_view_materialization_handles_empty_and_rank_zero_views() {
+    let mut buffers = crate::buffer_pool::BufferPool::new();
+
+    let empty_storage: [f64; 0] = [];
+    let empty = tenferro_tensor::TypedTensorView::from_col_major(&[0, 3], &empty_storage).unwrap();
+    let empty = crate::structural::typed_materialize_view_with_pool(
+        &mut buffers,
+        &empty,
+        "empty_materialize",
+    )
+    .unwrap();
+    assert_eq!(empty.shape(), &[0, 3]);
+    assert_eq!(empty.as_slice().unwrap(), &[]);
+
+    let scalar_storage = [42.5_f64];
+    let scalar = tenferro_tensor::TypedTensorView::from_col_major(&[], &scalar_storage).unwrap();
+    let scalar = crate::structural::typed_materialize_view_with_pool(
+        &mut buffers,
+        &scalar,
+        "rank_zero_materialize",
+    )
+    .unwrap();
+    assert_eq!(scalar.shape(), &[]);
+    assert_eq!(scalar.as_slice().unwrap(), &[42.5]);
+}
+
+#[test]
+fn cpu_view_materialization_preserves_static_rank_and_placement() {
+    let mut buffers = crate::buffer_pool::BufferPool::new();
+    let storage = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let ranked =
+        tenferro_tensor::TypedTensorView::<_, tenferro_tensor::Rank<2>>::from_slice_ranked(
+            [3, 2],
+            [2, 1],
+            0,
+            &storage,
+        )
+        .unwrap();
+    let ranked: TypedTensor<f64, tenferro_tensor::Rank<2>> =
+        crate::structural::typed_materialize_view_with_pool(
+            &mut buffers,
+            &ranked,
+            "static_rank_materialize",
+        )
+        .unwrap();
+    assert_eq!(ranked.shape(), &[3, 2]);
+    assert_eq!(ranked.as_slice().unwrap(), &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
+
+    let mut placed = TypedTensor::<i64>::from_vec_col_major(vec![2], vec![9_i64, 13]).unwrap();
+    placed.set_placement(tenferro_tensor::Placement {
+        memory_kind: tenferro_tensor::MemoryKind::PinnedHost,
+        device: None,
+    });
+    let placed = crate::structural::typed_materialize_view_with_pool(
+        &mut buffers,
+        &placed.as_view(),
+        "placement_materialize",
+    )
+    .unwrap();
+    assert_eq!(
+        placed.placement().memory_kind,
+        tenferro_tensor::MemoryKind::PinnedHost
+    );
+    assert_eq!(placed.as_slice().unwrap(), &[9, 13]);
+}
+
+#[test]
+fn cpu_view_materialization_rejects_backend_buffer_with_caller_operation_name() {
+    let backend_tensor = TypedTensor::<f64>::from_buffer_col_major(
+        vec![2],
+        tenferro_tensor::Buffer::Backend(Arc::new(
+            tenferro_tensor::BufferHandle::<f64>::new_with_len(17, 2),
+        )),
+        tenferro_tensor::Placement {
+            memory_kind: tenferro_tensor::MemoryKind::Device,
+            device: Some(tenferro_tensor::DeviceId {
+                kind: tenferro_tensor::DeviceKind::Gpu(tenferro_tensor::GpuBackendKind::Cuda),
+                ordinal: 0,
+            }),
+        },
+    )
+    .unwrap();
+    let view = backend_tensor
+        .backend_region_view(vec![2], vec![1], 0)
+        .unwrap();
+    let mut buffers = crate::buffer_pool::BufferPool::new();
+    let error = crate::structural::typed_materialize_view_with_pool(
+        &mut buffers,
+        &view,
+        "review_materialize_op",
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        crate::Error::BackendFailure {
+            op: "review_materialize_op",
+            ref message,
+        } if message.contains("download to host")
+    ));
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -51,6 +51,45 @@ fn cpu_runtime_materialization_dispatches_all_dtypes_with_backend_session_parity
 }
 
 #[test]
+fn cpu_runtime_materialization_rejects_owned_host_buffer_with_device_placement() {
+    let mut input = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
+    input.set_placement(opaque_backend_placement());
+    let input = Tensor::F64(input);
+    let mut backend = CpuBackend::new();
+
+    let err = backend
+        .to_contiguous_read(TensorRead::from_tensor(&input))
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "CpuBackend::to_contiguous_read",
+            ref message,
+        } if message.contains("source host placement") && message.contains("Device")
+    ));
+}
+
+#[test]
+fn cpu_runtime_materialization_rejects_host_view_with_device_placement() {
+    let mut input = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
+    input.set_placement(opaque_backend_placement());
+    let mut backend = CpuBackend::new();
+
+    let err = backend
+        .to_contiguous_read(TensorRead::from_view(TensorView::F64(input.as_view())))
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "CpuBackend::to_contiguous_read",
+            ref message,
+        } if message.contains("source host placement") && message.contains("Device")
+    ));
+}
+
+#[test]
 fn cpu_runtime_copy_dispatches_all_dtypes_with_backend_session_parity() {
     macro_rules! assert_copied {
         ($variant:ident, $ty:ty, $values:expr, $zeros:expr) => {{

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -93,6 +93,46 @@ fn cpu_copy_into_rejects_backend_destination_without_download() {
 }
 
 #[test]
+fn cpu_copy_into_rejects_host_source_with_device_placement() {
+    let mut backend = CpuBackend::new();
+    let mut src = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
+    src.set_placement(opaque_backend_placement());
+    let mut dst = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, 0.0]).unwrap();
+
+    let err = backend
+        .copy_into(&src.as_view(), &mut dst.as_view_mut())
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "CpuBackend::copy_into",
+            ref message,
+        } if message.contains("source") && message.contains("host placement")
+    ));
+}
+
+#[test]
+fn cpu_copy_into_rejects_host_destination_with_device_placement() {
+    let mut backend = CpuBackend::new();
+    let src = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
+    let mut dst = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, 0.0]).unwrap();
+    dst.set_placement(opaque_backend_placement());
+
+    let err = backend
+        .copy_into(&src.as_view(), &mut dst.as_view_mut())
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "CpuBackend::copy_into",
+            ref message,
+        } if message.contains("destination") && message.contains("host placement")
+    ));
+}
+
+#[test]
 fn test_reclaim_buffer_returns_host_buffer_to_pool() {
     let mut backend = CpuBackend::new();
     assert_eq!(backend.buffer_pool_len(), 0);

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -186,6 +186,7 @@ fn test_cpu_elementwise_fusion_broadcasts_mapped_unit_axes() {
 
 #[test]
 fn test_materialize_tensor_read_covers_host_tensor_and_view_variants() {
+    let mut buffers = crate::buffer_pool::BufferPool::new();
     let tensors = [
         Tensor::F32(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f32]).unwrap()),
         Tensor::F64(TypedTensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap()),
@@ -201,8 +202,12 @@ fn test_materialize_tensor_read_covers_host_tensor_and_view_variants() {
     ];
 
     for tensor in &tensors {
-        let materialized =
-            crate::materialize_tensor_read("dot_general", TensorRead::from_tensor(tensor)).unwrap();
+        let materialized = crate::materialize_tensor_read(
+            &mut buffers,
+            "dot_general",
+            TensorRead::from_tensor(tensor),
+        )
+        .unwrap();
         assert_eq!(materialized.dtype(), tensor.dtype());
         assert_eq!(materialized.shape(), tensor.shape());
     }
@@ -227,11 +232,78 @@ fn test_materialize_tensor_read_covers_host_tensor_and_view_variants() {
 
     for view in views {
         let dtype = view.dtype();
-        let materialized =
-            crate::materialize_tensor_read("dot_general", TensorRead::from_view(view)).unwrap();
+        let materialized = crate::materialize_tensor_read(
+            &mut buffers,
+            "dot_general",
+            TensorRead::from_view(view),
+        )
+        .unwrap();
         assert_eq!(materialized.dtype(), dtype);
         assert_eq!(materialized.shape(), &[1]);
     }
+}
+
+#[test]
+fn cpu_view_materialization_uses_pool_aware_strided_copy() {
+    let cpu_lib = include_str!("../../lib.rs");
+    let materializer = cpu_lib
+        .split_once("fn materialize_tensor_view")
+        .unwrap()
+        .1
+        .split_once("#[cfg(test)]")
+        .unwrap()
+        .0;
+
+    assert!(
+        materializer.contains("structural::typed_materialize_view_with_pool"),
+        "CPU TensorView materialization must dispatch through the pool-aware strided helper"
+    );
+    assert!(
+        !materializer.contains("to_contiguous"),
+        "CPU TensorView materialization must not bypass the CPU pool with TypedTensorView::to_contiguous"
+    );
+}
+
+#[test]
+fn cpu_view_materialization_preserves_transposed_and_scattered_values() {
+    let mut backend = CpuBackend::new();
+
+    let transposed_storage = [1.0_f64, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let transposed = tenferro_tensor::TypedTensorView::from_col_major(&[2, 3], &transposed_storage)
+        .unwrap()
+        .transpose_view([1, 0])
+        .unwrap();
+    let transposed = backend
+        .reshape_read(TensorRead::from_view(TensorView::F64(transposed)), &[3, 2])
+        .unwrap();
+    assert_eq!(transposed.shape(), &[3, 2]);
+    assert_eq!(
+        transposed.as_slice::<f64>().unwrap(),
+        &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
+    );
+
+    let scattered_storage = (0..20).map(|value| value as f64 * 10.0).collect::<Vec<_>>();
+    let mut scattered_shape = vec![1; 24];
+    scattered_shape[0] = 2;
+    scattered_shape[11] = 2;
+    let mut scattered_strides = vec![19; 24];
+    scattered_strides[0] = 3;
+    scattered_strides[11] = 11;
+    let scattered = tenferro_tensor::TypedTensorView::from_slice(
+        scattered_shape,
+        scattered_strides,
+        2,
+        &scattered_storage,
+    )
+    .unwrap();
+    let scattered = backend
+        .reshape_read(TensorRead::from_view(TensorView::F64(scattered)), &[4])
+        .unwrap();
+    assert_eq!(scattered.shape(), &[4]);
+    assert_eq!(
+        scattered.as_slice::<f64>().unwrap(),
+        &[20.0, 50.0, 130.0, 160.0]
+    );
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -612,7 +612,7 @@ fn cpu_view_materialization_uses_pool_aware_strided_copy() {
         .split_once("pub(crate) fn typed_materialize_view_with_pool")
         .unwrap()
         .1
-        .split_once("fn zeroed_tensor_from_pool")
+        .split_once("pub(crate) fn typed_copy_view_into")
         .unwrap()
         .0;
 
@@ -713,7 +713,7 @@ fn cpu_structural_read_transpose_explicit_stride_exact_output() {
 #[test]
 fn cpu_structural_read_reshape_explicit_stride_exact_output() {
     let mut backend = CpuBackend::new();
-    let storage = (0..10).map(|value| value as i32).collect::<Vec<_>>();
+    let storage = (0..10).collect::<Vec<i32>>();
     let view = tenferro_tensor::TypedTensorView::from_slice([2, 2], [3, -1], 5, &storage).unwrap();
 
     let output = backend
@@ -1807,14 +1807,20 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         TensorDot::dot_general_with_conj(&mut backend, &lhs, &rhs, &config, true, true).unwrap();
     assert_eq!(both_folded.as_slice::<f64>().unwrap(), &[6.0]);
 
-    let read_views = TensorDot::dot_general_read(
+    let read_views_err = TensorDot::dot_general_read(
         &mut backend,
         TensorRead::from_view(TensorView::f64(&one_shape, &lhs_data).unwrap()),
         TensorRead::from_view(TensorView::f64(&one_shape, &rhs_data).unwrap()),
         &config,
     )
-    .unwrap();
-    assert_eq!(read_views.as_slice::<f64>().unwrap(), &[6.0]);
+    .unwrap_err();
+    assert!(matches!(
+        read_views_err,
+        crate::Error::BackendFailure {
+            op: "to_contiguous_read",
+            ref message,
+        } if message.contains("borrowed tensor views")
+    ));
 
     let rhs_folded = BackendCachedDot::dot_general_with_conj_cached(
         &mut backend,
@@ -1863,14 +1869,20 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
     )
     .unwrap();
     assert_eq!(exec_read_tensor.as_slice::<f64>().unwrap(), &[6.0]);
-    let exec_read_views = TensorDot::dot_general_read(
+    let exec_read_views_err = TensorDot::dot_general_read(
         &mut exec,
         TensorRead::from_view(TensorView::f64(&one_shape, &lhs_data).unwrap()),
         TensorRead::from_view(TensorView::f64(&one_shape, &rhs_data).unwrap()),
         &config,
     )
-    .unwrap();
-    assert_eq!(exec_read_views.as_slice::<f64>().unwrap(), &[6.0]);
+    .unwrap_err();
+    assert!(matches!(
+        exec_read_views_err,
+        crate::Error::BackendFailure {
+            op: "to_contiguous_read",
+            ref message,
+        } if message.contains("borrowed tensor views")
+    ));
     let exec_no_conj =
         TensorDot::dot_general_with_conj(&mut exec, &lhs, &rhs, &config, false, false).unwrap();
     assert_eq!(exec_no_conj.as_slice::<f64>().unwrap(), &[6.0]);

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -388,6 +388,307 @@ fn cpu_structural_read_broadcast_in_dim_explicit_stride_exact_output() {
 }
 
 #[test]
+fn cpu_structural_read_direct_helpers_preserve_view_placement() {
+    let mut buffers = crate::buffer_pool::BufferPool::new();
+    let mut input = TypedTensor::<i64>::from_vec_col_major(vec![2], vec![9, 13]).unwrap();
+    input.set_placement(tenferro_tensor::Placement {
+        memory_kind: tenferro_tensor::MemoryKind::PinnedHost,
+        device: None,
+    });
+
+    let transpose = crate::structural::transpose_read_with_pool(
+        &mut buffers,
+        TensorRead::from_view(TensorView::I64(input.as_view())),
+        &[0],
+    )
+    .unwrap();
+    let reshape = crate::structural::reshape_read_with_pool(
+        &mut buffers,
+        TensorRead::from_view(TensorView::I64(input.as_view())),
+        &[1, 2],
+    )
+    .unwrap();
+    let broadcast = crate::structural::broadcast_in_dim_read_with_pool(
+        &mut buffers,
+        TensorRead::from_view(TensorView::I64(input.as_view())),
+        &[2, 2],
+        &[0],
+    )
+    .unwrap();
+
+    for output in [transpose, reshape, broadcast] {
+        assert_eq!(
+            output.placement().memory_kind,
+            tenferro_tensor::MemoryKind::PinnedHost
+        );
+        assert_eq!(output.placement().device, None);
+    }
+}
+
+#[test]
+fn cpu_structural_read_direct_helpers_cover_all_dtypes() {
+    let mut buffers = crate::buffer_pool::BufferPool::new();
+
+    macro_rules! assert_dtype_dispatch {
+        ($variant:ident, $dtype:expr, $storage:expr) => {{
+            let storage = $storage;
+            let view = tenferro_tensor::TypedTensorView::from_slice([2], [1], 0, &storage).unwrap();
+            let transpose = crate::structural::transpose_read_with_pool(
+                &mut buffers,
+                TensorRead::from_view(TensorView::$variant(view)),
+                &[0],
+            )
+            .unwrap();
+
+            let view = tenferro_tensor::TypedTensorView::from_slice([2], [1], 0, &storage).unwrap();
+            let reshape = crate::structural::reshape_read_with_pool(
+                &mut buffers,
+                TensorRead::from_view(TensorView::$variant(view)),
+                &[1, 2],
+            )
+            .unwrap();
+
+            let view = tenferro_tensor::TypedTensorView::from_slice([2], [1], 0, &storage).unwrap();
+            let broadcast = crate::structural::broadcast_in_dim_read_with_pool(
+                &mut buffers,
+                TensorRead::from_view(TensorView::$variant(view)),
+                &[2, 2],
+                &[0],
+            )
+            .unwrap();
+
+            assert_eq!(transpose.dtype(), $dtype);
+            assert_eq!(reshape.dtype(), $dtype);
+            assert_eq!(broadcast.dtype(), $dtype);
+        }};
+    }
+
+    assert_dtype_dispatch!(F32, DType::F32, [1.0_f32, 2.0]);
+    assert_dtype_dispatch!(F64, DType::F64, [1.0_f64, 2.0]);
+    assert_dtype_dispatch!(I32, DType::I32, [1_i32, 2]);
+    assert_dtype_dispatch!(I64, DType::I64, [1_i64, 2]);
+    assert_dtype_dispatch!(Bool, DType::Bool, [true, false]);
+    assert_dtype_dispatch!(
+        C32,
+        DType::C32,
+        [Complex32::new(1.0, 2.0), Complex32::new(3.0, 4.0)]
+    );
+    assert_dtype_dispatch!(
+        C64,
+        DType::C64,
+        [Complex64::new(1.0, 2.0), Complex64::new(3.0, 4.0)]
+    );
+}
+
+#[test]
+fn cpu_structural_read_direct_helpers_cover_zero_stride_empty_and_rank_zero() {
+    let mut buffers = crate::buffer_pool::BufferPool::new();
+
+    let repeated_storage = [7_i32, 11];
+    let repeated =
+        tenferro_tensor::TypedTensorView::from_slice([2, 3], [1, 0], 0, &repeated_storage).unwrap();
+    let repeated = crate::structural::transpose_read_with_pool(
+        &mut buffers,
+        TensorRead::from_view(TensorView::I32(repeated)),
+        &[1, 0],
+    )
+    .unwrap();
+    assert_eq!(repeated.shape(), &[3, 2]);
+    assert_eq!(repeated.as_slice::<i32>().unwrap(), &[7, 7, 7, 11, 11, 11]);
+
+    let empty_storage: [f64; 0] = [];
+    let empty =
+        tenferro_tensor::TypedTensorView::from_slice([0, 3], [5, -2], 0, &empty_storage).unwrap();
+    let empty = crate::structural::broadcast_in_dim_read_with_pool(
+        &mut buffers,
+        TensorRead::from_view(TensorView::F64(empty)),
+        &[0, 3, 2],
+        &[0, 1],
+    )
+    .unwrap();
+    assert_eq!(empty.shape(), &[0, 3, 2]);
+    assert_eq!(empty.as_slice::<f64>().unwrap(), &[]);
+
+    let scalar_storage = [42.5_f64];
+    let scalar = tenferro_tensor::TypedTensorView::from_slice([], [], 0, &scalar_storage).unwrap();
+    let scalar = crate::structural::reshape_read_with_pool(
+        &mut buffers,
+        TensorRead::from_view(TensorView::F64(scalar)),
+        &[],
+    )
+    .unwrap();
+    assert_eq!(scalar.shape(), &[]);
+    assert_eq!(scalar.as_slice::<f64>().unwrap(), &[42.5]);
+}
+
+#[test]
+fn cpu_structural_read_direct_helpers_match_owned_validation_errors() {
+    let mut buffers = crate::buffer_pool::BufferPool::new();
+    let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
+
+    let owned_transpose =
+        crate::structural::transpose_with_pool(&mut buffers, &input, &[1]).unwrap_err();
+    let view_transpose = crate::structural::transpose_read_with_pool(
+        &mut buffers,
+        TensorRead::from_view(TensorView::F64(match &input {
+            Tensor::F64(input) => input.as_view(),
+            _ => unreachable!(),
+        })),
+        &[1],
+    )
+    .unwrap_err();
+    assert_eq!(view_transpose, owned_transpose);
+
+    let owned_reshape = crate::structural::reshape(&input, &[3]).unwrap_err();
+    let view_reshape = crate::structural::reshape_read_with_pool(
+        &mut buffers,
+        TensorRead::from_view(TensorView::F64(match &input {
+            Tensor::F64(input) => input.as_view(),
+            _ => unreachable!(),
+        })),
+        &[3],
+    )
+    .unwrap_err();
+    assert_eq!(view_reshape, owned_reshape);
+
+    let owned_broadcast =
+        crate::structural::broadcast_in_dim_with_pool(&mut buffers, &input, &[3], &[0])
+            .unwrap_err();
+    let view_broadcast = crate::structural::broadcast_in_dim_read_with_pool(
+        &mut buffers,
+        TensorRead::from_view(TensorView::F64(match &input {
+            Tensor::F64(input) => input.as_view(),
+            _ => unreachable!(),
+        })),
+        &[3],
+        &[0],
+    )
+    .unwrap_err();
+    assert_eq!(view_broadcast, owned_broadcast);
+}
+
+#[test]
+fn cpu_structural_read_empty_pathological_layout_returns_typed_errors_without_panicking() {
+    let empty_storage: [f64; 0] = [];
+
+    let transpose = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let mut buffers = crate::buffer_pool::BufferPool::new();
+        let view = tenferro_tensor::TypedTensorView::from_slice(
+            [0, usize::MAX],
+            [0, 0],
+            0,
+            &empty_storage,
+        )
+        .unwrap();
+        crate::structural::transpose_read_with_pool(
+            &mut buffers,
+            TensorRead::from_view(TensorView::F64(view)),
+            &[0, 1],
+        )
+    }));
+    let transpose = transpose
+        .expect("transpose_read must not panic")
+        .unwrap_err();
+    assert!(matches!(
+        transpose,
+        crate::Error::BackendFailure {
+            op: "transpose",
+            ref message,
+        } if message.contains("overflow")
+    ));
+
+    let broadcast = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let mut buffers = crate::buffer_pool::BufferPool::new();
+        let view =
+            tenferro_tensor::TypedTensorView::from_slice([0], [0], 0, &empty_storage).unwrap();
+        crate::structural::broadcast_in_dim_read_with_pool(
+            &mut buffers,
+            TensorRead::from_view(TensorView::F64(view)),
+            &[0, usize::MAX],
+            &[0],
+        )
+    }));
+    let broadcast = broadcast
+        .expect("broadcast_in_dim_read must not panic")
+        .unwrap_err();
+    assert!(matches!(
+        broadcast,
+        crate::Error::BackendFailure {
+            op: "broadcast_in_dim",
+            ref message,
+        } if message.contains("overflow")
+    ));
+}
+
+#[test]
+fn cpu_structural_read_backend_and_exec_session_outputs_match() {
+    let storage = [0.0_f64, 10.0, 20.0, 30.0, 40.0, 50.0];
+    let mut backend = CpuBackend::new();
+
+    let backend_outputs = {
+        let transpose_view =
+            tenferro_tensor::TypedTensorView::from_slice([2, 2], [2, -1], 3, &storage).unwrap();
+        let reshape_view =
+            tenferro_tensor::TypedTensorView::from_slice([2, 2], [2, -1], 3, &storage).unwrap();
+        let broadcast_view =
+            tenferro_tensor::TypedTensorView::from_slice([2, 1], [2, 0], 1, &storage).unwrap();
+        [
+            backend
+                .transpose_read(
+                    TensorRead::from_view(TensorView::F64(transpose_view)),
+                    &[1, 0],
+                )
+                .unwrap(),
+            backend
+                .reshape_read(TensorRead::from_view(TensorView::F64(reshape_view)), &[4])
+                .unwrap(),
+            backend
+                .broadcast_in_dim_read(
+                    TensorRead::from_view(TensorView::F64(broadcast_view)),
+                    &[2, 3],
+                    &[0, 1],
+                )
+                .unwrap(),
+        ]
+    };
+
+    let session_outputs = backend.with_backend_session(|session| {
+        let transpose_view =
+            tenferro_tensor::TypedTensorView::from_slice([2, 2], [2, -1], 3, &storage).unwrap();
+        let reshape_view =
+            tenferro_tensor::TypedTensorView::from_slice([2, 2], [2, -1], 3, &storage).unwrap();
+        let broadcast_view =
+            tenferro_tensor::TypedTensorView::from_slice([2, 1], [2, 0], 1, &storage).unwrap();
+        [
+            session
+                .transpose_read(
+                    TensorRead::from_view(TensorView::F64(transpose_view)),
+                    &[1, 0],
+                )
+                .unwrap(),
+            session
+                .reshape_read(TensorRead::from_view(TensorView::F64(reshape_view)), &[4])
+                .unwrap(),
+            session
+                .broadcast_in_dim_read(
+                    TensorRead::from_view(TensorView::F64(broadcast_view)),
+                    &[2, 3],
+                    &[0, 1],
+                )
+                .unwrap(),
+        ]
+    });
+
+    for (backend_output, session_output) in backend_outputs.iter().zip(&session_outputs) {
+        assert_eq!(backend_output.shape(), session_output.shape());
+        assert_eq!(
+            backend_output.as_slice::<f64>().unwrap(),
+            session_output.as_slice::<f64>().unwrap()
+        );
+    }
+}
+
+#[test]
 fn cpu_view_materialization_handles_negative_and_zero_strides() {
     let mut buffers = crate::buffer_pool::BufferPool::new();
 

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -339,6 +339,55 @@ fn cpu_view_materialization_preserves_transposed_and_scattered_values() {
 }
 
 #[test]
+fn cpu_structural_read_transpose_explicit_stride_exact_output() {
+    let mut backend = CpuBackend::new();
+    let storage = (0..16).map(|value| value as f64 * 10.0).collect::<Vec<_>>();
+    let view = tenferro_tensor::TypedTensorView::from_slice([2, 3], [2, 5], 1, &storage).unwrap();
+
+    let output = backend
+        .transpose_read(TensorRead::from_view(TensorView::F64(view)), &[1, 0])
+        .unwrap();
+
+    assert_eq!(output.shape(), &[3, 2]);
+    assert_eq!(
+        output.as_slice::<f64>().unwrap(),
+        &[10.0, 60.0, 110.0, 30.0, 80.0, 130.0]
+    );
+}
+
+#[test]
+fn cpu_structural_read_reshape_explicit_stride_exact_output() {
+    let mut backend = CpuBackend::new();
+    let storage = (0..10).map(|value| value as i32).collect::<Vec<_>>();
+    let view = tenferro_tensor::TypedTensorView::from_slice([2, 2], [3, -1], 5, &storage).unwrap();
+
+    let output = backend
+        .reshape_read(TensorRead::from_view(TensorView::I32(view)), &[4])
+        .unwrap();
+
+    assert_eq!(output.shape(), &[4]);
+    assert_eq!(output.as_slice::<i32>().unwrap(), &[5, 8, 4, 7]);
+}
+
+#[test]
+fn cpu_structural_read_broadcast_in_dim_explicit_stride_exact_output() {
+    let mut backend = CpuBackend::new();
+    let storage = [0_i64, 10, 20, 30, 40];
+    let view = tenferro_tensor::TypedTensorView::from_slice([2, 1], [-2, 7], 4, &storage).unwrap();
+
+    let output = backend
+        .broadcast_in_dim_read(
+            TensorRead::from_view(TensorView::I64(view)),
+            &[2, 3],
+            &[0, 1],
+        )
+        .unwrap();
+
+    assert_eq!(output.shape(), &[2, 3]);
+    assert_eq!(output.as_slice::<i64>().unwrap(), &[40, 20, 40, 20, 40, 20]);
+}
+
+#[test]
 fn cpu_view_materialization_handles_negative_and_zero_strides() {
     let mut buffers = crate::buffer_pool::BufferPool::new();
 

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -12,6 +12,190 @@ fn opaque_backend_placement() -> Placement {
 }
 
 #[test]
+fn cpu_runtime_materialization_dispatches_all_dtypes_with_backend_session_parity() {
+    macro_rules! assert_materialized {
+        ($variant:ident, $ty:ty, $values:expr) => {{
+            let values: [$ty; 2] = $values;
+            let view = TensorView::$variant(
+                TypedTensorView::from_slice(vec![2], vec![-1], 1, &values).unwrap(),
+            );
+            let read = TensorRead::from_view(view);
+            let mut backend = CpuBackend::with_threads(2).unwrap();
+
+            let direct = backend.to_contiguous_read(read.clone()).unwrap();
+            let session = backend
+                .with_backend_session(|exec| exec.to_contiguous_read(read))
+                .unwrap();
+
+            let expected = [values[1], values[0]];
+            assert_eq!(direct.as_slice::<$ty>().unwrap(), &expected);
+            assert_eq!(session.as_slice::<$ty>().unwrap(), &expected);
+        }};
+    }
+
+    assert_materialized!(F32, f32, [1.25, -2.5]);
+    assert_materialized!(F64, f64, [3.5, -4.75]);
+    assert_materialized!(I32, i32, [5, -6]);
+    assert_materialized!(I64, i64, [7, -8]);
+    assert_materialized!(Bool, bool, [true, false]);
+    assert_materialized!(
+        C32,
+        Complex32,
+        [Complex32::new(1.0, -2.0), Complex32::new(-3.0, 4.0)]
+    );
+    assert_materialized!(
+        C64,
+        Complex64,
+        [Complex64::new(5.0, -6.0), Complex64::new(-7.0, 8.0)]
+    );
+}
+
+#[test]
+fn cpu_runtime_copy_dispatches_all_dtypes_with_backend_session_parity() {
+    macro_rules! assert_copied {
+        ($variant:ident, $ty:ty, $values:expr, $zeros:expr) => {{
+            let values: Vec<$ty> = $values;
+            let src =
+                Tensor::$variant(TypedTensor::from_vec_col_major(vec![2], values.clone()).unwrap());
+            let mut direct_dst =
+                Tensor::$variant(TypedTensor::from_vec_col_major(vec![2], $zeros).unwrap());
+            let mut session_dst =
+                Tensor::$variant(TypedTensor::from_vec_col_major(vec![2], $zeros).unwrap());
+            let mut backend = CpuBackend::with_threads(2).unwrap();
+
+            backend
+                .copy_read_into(
+                    TensorRead::from_tensor(&src),
+                    TensorWrite::from_tensor(&mut direct_dst),
+                )
+                .unwrap();
+            backend
+                .with_backend_session(|exec| {
+                    exec.copy_read_into(
+                        TensorRead::from_tensor(&src),
+                        TensorWrite::from_tensor(&mut session_dst),
+                    )
+                })
+                .unwrap();
+
+            assert_eq!(direct_dst.as_slice::<$ty>().unwrap(), values.as_slice());
+            assert_eq!(session_dst.as_slice::<$ty>().unwrap(), values.as_slice());
+        }};
+    }
+
+    assert_copied!(F32, f32, vec![1.25, -2.5], vec![0.0; 2]);
+    assert_copied!(F64, f64, vec![3.5, -4.75], vec![0.0; 2]);
+    assert_copied!(I32, i32, vec![5, -6], vec![0; 2]);
+    assert_copied!(I64, i64, vec![7, -8], vec![0; 2]);
+    assert_copied!(Bool, bool, vec![true, false], vec![false; 2]);
+    assert_copied!(
+        C32,
+        Complex32,
+        vec![Complex32::new(1.0, -2.0), Complex32::new(-3.0, 4.0)],
+        vec![Complex32::new(0.0, 0.0); 2]
+    );
+    assert_copied!(
+        C64,
+        Complex64,
+        vec![Complex64::new(5.0, -6.0), Complex64::new(-7.0, 8.0)],
+        vec![Complex64::new(0.0, 0.0); 2]
+    );
+}
+
+#[test]
+fn cpu_runtime_copy_handles_strided_source_and_destination_without_allocation() {
+    let mut backend = CpuBackend::with_threads(2).unwrap();
+    backend.reclaim_buffer(Tensor::I32(
+        TypedTensor::from_vec_col_major(vec![4], vec![0_i32; 4]).unwrap(),
+    ));
+    let retained_before = backend.buffer_pool_len();
+    let src_data = [0_i32, 1, 2, 3, 4, 5, 6, 7];
+    let src = TypedTensorView::from_slice(vec![2, 2], vec![2, 4], 1, &src_data).unwrap();
+    let mut dst_data = [-1_i32; 8];
+    let dst = TypedTensorViewMut::from_slice(vec![2, 2], vec![3, 1], 1, &mut dst_data).unwrap();
+
+    backend
+        .copy_read_into(
+            TensorRead::from_view(TensorView::I32(src)),
+            TensorWrite::from_view(TensorViewMut::I32(dst)),
+        )
+        .unwrap();
+
+    assert_eq!(dst_data, [-1, 1, 5, -1, 3, 7, -1, -1]);
+    assert_eq!(backend.buffer_pool_len(), retained_before);
+}
+
+#[test]
+fn cpu_runtime_copy_reports_dtype_shape_placement_and_alias_errors() {
+    let mut backend = CpuBackend::new();
+
+    let src = Tensor::from_vec_col_major(vec![2], vec![1_i32, 2]).unwrap();
+    let mut wrong_dtype = Tensor::from_vec_col_major(vec![2], vec![0_i64, 0]).unwrap();
+    assert!(matches!(
+        backend.copy_read_into(
+            TensorRead::from_tensor(&src),
+            TensorWrite::from_tensor(&mut wrong_dtype),
+        ),
+        Err(Error::DTypeMismatch {
+            op: "CpuBackend::copy_read_into",
+            ..
+        })
+    ));
+
+    let mut wrong_shape = Tensor::from_vec_col_major(vec![3], vec![0_i32; 3]).unwrap();
+    assert!(matches!(
+        backend.copy_read_into(
+            TensorRead::from_tensor(&src),
+            TensorWrite::from_tensor(&mut wrong_shape),
+        ),
+        Err(Error::ShapeMismatch {
+            op: "CpuBackend::copy_read_into",
+            ..
+        })
+    ));
+
+    let mut misplaced = Tensor::from_vec_col_major(vec![2], vec![0_i32; 2]).unwrap();
+    match &mut misplaced {
+        Tensor::I32(tensor) => tensor.set_placement(opaque_backend_placement()),
+        _ => unreachable!(),
+    }
+    assert!(matches!(
+        backend.copy_read_into(
+            TensorRead::from_tensor(&src),
+            TensorWrite::from_tensor(&mut misplaced),
+        ),
+        Err(Error::BackendFailure {
+            op: "CpuBackend::copy_read_into",
+            ref message,
+        }) if message.contains("destination") && message.contains("host placement")
+    ));
+
+    let shared = Arc::new(BufferHandle::<f64>::new_with_len(91, 2));
+    let placement = opaque_backend_placement();
+    let aliased_src = Tensor::F64(
+        TypedTensor::from_buffer_col_major(
+            vec![2],
+            Buffer::Backend(shared.clone()),
+            placement.clone(),
+        )
+        .unwrap(),
+    );
+    let mut aliased_dst = Tensor::F64(
+        TypedTensor::from_buffer_col_major(vec![2], Buffer::Backend(shared), placement).unwrap(),
+    );
+    assert!(matches!(
+        backend.copy_read_into(
+            TensorRead::from_tensor(&aliased_src),
+            TensorWrite::from_tensor(&mut aliased_dst),
+        ),
+        Err(Error::InvalidConfig {
+            op: "CpuBackend::copy_read_into",
+            ref message,
+        }) if message.contains("alias")
+    ));
+}
+
+#[test]
 fn cpu_copy_into_copies_exactly_between_strided_host_views() {
     let mut backend = CpuBackend::with_threads(2).unwrap();
     let src_data = [0_i32, 1, 2, 3, 4, 5, 6, 7];

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -1,4 +1,96 @@
 use super::*;
+use tenferro_tensor::{
+    Buffer, BufferHandle, MemoryKind, Placement, TensorViewCanonicalization, TypedTensorView,
+    TypedTensorViewMut,
+};
+
+fn opaque_backend_placement() -> Placement {
+    Placement {
+        memory_kind: MemoryKind::Device,
+        device: None,
+    }
+}
+
+#[test]
+fn cpu_copy_into_copies_exactly_between_strided_host_views() {
+    let mut backend = CpuBackend::with_threads(2).unwrap();
+    let src_data = [0_i32, 1, 2, 3, 4, 5, 6, 7];
+    let src = TypedTensorView::from_slice(vec![2, 2], vec![2, 4], 1, &src_data).unwrap();
+    let mut dst_data = [-1_i32; 8];
+    let mut dst = TypedTensorViewMut::from_slice(vec![2, 2], vec![3, 1], 1, &mut dst_data).unwrap();
+
+    backend.copy_into(&src, &mut dst).unwrap();
+
+    assert_eq!(dst_data, [-1, 1, 5, -1, 3, 7, -1, -1]);
+}
+
+#[test]
+fn cpu_copy_into_reports_shape_mismatch_with_canonical_op_name() {
+    let mut backend = CpuBackend::new();
+    let src = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]).unwrap();
+    let mut dst = TypedTensor::<i32>::from_vec_col_major(vec![3], vec![0, 0, 0]).unwrap();
+
+    let err = backend
+        .copy_into(&src.as_view(), &mut dst.as_view_mut())
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::ShapeMismatch {
+            op: "CpuBackend::copy_into",
+            lhs,
+            rhs,
+        } if lhs == vec![2] && rhs == vec![3]
+    ));
+}
+
+#[test]
+fn cpu_copy_into_rejects_backend_source_without_download() {
+    let mut backend = CpuBackend::new();
+    let src = TypedTensor::<f64>::from_buffer_col_major(
+        vec![2],
+        Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(9, 2))),
+        opaque_backend_placement(),
+    )
+    .unwrap();
+    let mut dst = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![0.0, 0.0]).unwrap();
+
+    let err = backend
+        .copy_into(&src.as_view(), &mut dst.as_view_mut())
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "CpuBackend::copy_into",
+            ref message,
+        } if message.contains("download")
+    ));
+}
+
+#[test]
+fn cpu_copy_into_rejects_backend_destination_without_download() {
+    let mut backend = CpuBackend::new();
+    let src = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
+    let mut dst = TypedTensor::<f64>::from_buffer_col_major(
+        vec![2],
+        Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(8, 2))),
+        opaque_backend_placement(),
+    )
+    .unwrap();
+
+    let err = backend
+        .copy_into(&src.as_view(), &mut dst.as_view_mut())
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "CpuBackend::copy_into",
+            ref message,
+        } if message.contains("download")
+    ));
+}
 
 #[test]
 fn test_reclaim_buffer_returns_host_buffer_to_pool() {

--- a/crates/tenferro-cpu/tests/backend_capability_contracts.rs
+++ b/crates/tenferro-cpu/tests/backend_capability_contracts.rs
@@ -1,3 +1,7 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{
     BackendSession, BackendSessionHost, TensorAnalytic, TensorBackend, TensorBuffer,
@@ -23,6 +27,160 @@ fn rust_function_body<'a>(source: &'a str, function: &str) -> Option<&'a str> {
         }
     }
     None
+}
+
+fn rust_tokens(source: &str) -> Vec<String> {
+    let bytes = source.as_bytes();
+    let mut tokens = Vec::new();
+    let mut cursor = 0usize;
+    while cursor < bytes.len() {
+        if let Some((content_start, hashes)) = raw_string_open(bytes, cursor) {
+            cursor = content_start;
+            while cursor < bytes.len() {
+                if bytes[cursor] == b'"'
+                    && bytes
+                        .get(cursor + 1..cursor + 1 + hashes)
+                        .is_some_and(|suffix| suffix.iter().all(|&byte| byte == b'#'))
+                {
+                    cursor += 1 + hashes;
+                    break;
+                }
+                cursor += 1;
+            }
+        } else if bytes[cursor..].starts_with(b"//") {
+            cursor += 2;
+            while cursor < bytes.len() && bytes[cursor] != b'\n' {
+                cursor += 1;
+            }
+        } else if bytes[cursor..].starts_with(b"/*") {
+            cursor += 2;
+            let mut depth = 1usize;
+            while cursor < bytes.len() && depth > 0 {
+                if bytes[cursor..].starts_with(b"/*") {
+                    depth += 1;
+                    cursor += 2;
+                } else if bytes[cursor..].starts_with(b"*/") {
+                    depth -= 1;
+                    cursor += 2;
+                } else {
+                    cursor += 1;
+                }
+            }
+        } else if bytes[cursor] == b'"' {
+            cursor += 1;
+            while cursor < bytes.len() {
+                if bytes[cursor] == b'\\' {
+                    cursor = (cursor + 2).min(bytes.len());
+                } else if bytes[cursor] == b'"' {
+                    cursor += 1;
+                    break;
+                } else {
+                    cursor += 1;
+                }
+            }
+        } else if bytes[cursor] == b'\''
+            && ((cursor + 2 < bytes.len() && bytes[cursor + 2] == b'\'')
+                || (cursor + 3 < bytes.len()
+                    && bytes[cursor + 1] == b'\\'
+                    && bytes[cursor + 3] == b'\''))
+        {
+            cursor += if bytes[cursor + 1] == b'\\' { 4 } else { 3 };
+        } else if bytes[cursor].is_ascii_alphabetic() || bytes[cursor] == b'_' {
+            let start = cursor;
+            cursor += 1;
+            while cursor < bytes.len()
+                && (bytes[cursor].is_ascii_alphanumeric() || bytes[cursor] == b'_')
+            {
+                cursor += 1;
+            }
+            tokens.push(source[start..cursor].to_string());
+        } else if bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        } else {
+            tokens.push(char::from(bytes[cursor]).to_string());
+            cursor += 1;
+        }
+    }
+    tokens
+}
+
+fn raw_string_open(bytes: &[u8], start: usize) -> Option<(usize, usize)> {
+    let mut cursor = if bytes.get(start..start + 2) == Some(b"br") {
+        start + 2
+    } else if bytes.get(start) == Some(&b'r') {
+        start + 1
+    } else {
+        return None;
+    };
+    let hashes_start = cursor;
+    while bytes.get(cursor) == Some(&b'#') {
+        cursor += 1;
+    }
+    (bytes.get(cursor) == Some(&b'"')).then_some((cursor + 1, cursor - hashes_start))
+}
+
+fn function_names(tokens: &[String]) -> BTreeSet<String> {
+    tokens
+        .windows(2)
+        .filter(|window| window[0] == "fn")
+        .map(|window| window[1].clone())
+        .collect()
+}
+
+fn public_function_names(tokens: &[String]) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    for (index, token) in tokens.iter().enumerate() {
+        if token != "pub" || tokens.get(index + 1).is_some_and(|next| next == "(") {
+            continue;
+        }
+        let mut cursor = index + 1;
+        while tokens.get(cursor).is_some_and(|modifier| {
+            matches!(modifier.as_str(), "async" | "const" | "unsafe" | "extern")
+        }) {
+            cursor += 1;
+        }
+        if tokens.get(cursor).is_some_and(|token| token == "fn") {
+            if let Some(name) = tokens.get(cursor + 1) {
+                names.insert(name.clone());
+            }
+        }
+    }
+    names
+}
+
+fn rust_source_files(root: &Path) -> Vec<PathBuf> {
+    fn visit(directory: &Path, files: &mut Vec<PathBuf>) {
+        for entry in fs::read_dir(directory).expect("Rust source directory must be readable") {
+            let path = entry.expect("Rust source entry must be readable").path();
+            if path.is_dir() {
+                visit(&path, files);
+            } else if path.extension().is_some_and(|extension| extension == "rs") {
+                files.push(path);
+            }
+        }
+    }
+
+    let mut files = Vec::new();
+    visit(root, &mut files);
+    files.sort();
+    files
+}
+
+fn ownership_contract(rules: &str) -> BTreeMap<&str, &str> {
+    const BEGIN: &str = "<!-- TENFERRO_CPU_STRIDED_OWNERSHIP_CONTRACT_BEGIN -->";
+    const END: &str = "<!-- TENFERRO_CPU_STRIDED_OWNERSHIP_CONTRACT_END -->";
+    let block = rules
+        .split_once(BEGIN)
+        .expect("CPU strided ownership contract begin marker must exist")
+        .1
+        .split_once(END)
+        .expect("CPU strided ownership contract end marker must exist")
+        .0;
+    block
+        .lines()
+        .filter_map(|line| line.trim().split_once('='))
+        .map(|(key, value)| (key.trim(), value.trim()))
+        .collect()
 }
 
 fn accepts_backend_capabilities<B>()
@@ -209,38 +367,109 @@ fn cpu_public_ops_require_backend_owner() {
 #[test]
 fn strided_kernel_ownership_requires_backend_execution_resources() {
     let rules = include_str!("../../../REPOSITORY_RULES.md");
-
-    for required in [
-        "CPU affine-strided copy, permutation, broadcast, map, zip-map, and axis reduction",
-        "delegate to `strided-rs`",
-        "Einsum is the benchmark-backed tenferro exception",
-        "persistent `BufferPool`",
-        "fully-overwritten uninitialized output",
-        "configured `CpuContext` Rayon pool",
-        "nested-execution safety",
-        "serial/parallel threshold",
-        "ambient global Rayon pool",
-        "throwaway pool",
-        "execution resources, not tensor metadata",
+    let contract = ownership_contract(rules);
+    assert_eq!(
+        contract.get("schema"),
+        Some(&"tenferro.cpu-strided-ownership.v1")
+    );
+    assert_eq!(contract.get("affine-kernel-owner"), Some(&"strided-rs"));
+    assert_eq!(
+        contract.get("einsum-owner"),
+        Some(&"tenferro:benchmark-backed-exception")
+    );
+    assert_eq!(contract.get("execution-entry"), Some(&"CpuBackend"));
+    for vocabulary in [
+        "copy",
+        "permutation",
+        "broadcast",
+        "map",
+        "zip-map",
+        "axis-reduction",
+        "BufferPool",
+        "uninitialized-full-overwrite",
+        "CpuContext",
+        "Rayon",
+        "nested-execution",
+        "serial-parallel-threshold",
+        "context-free-strided-call",
+        "throwaway-pool",
+        "ambient-global-Rayon",
+        "execution-not-metadata",
     ] {
         assert!(
-            rules.contains(required),
-            "REPOSITORY_RULES.md must contain ownership contract text: {required}"
+            contract.values().any(|value| value.contains(vocabulary)),
+            "CPU strided ownership contract lacks essential vocabulary: {vocabulary}"
         );
     }
+}
 
-    let tensor_types = include_str!("../../tenferro-tensor/src/types.rs");
+#[test]
+fn tensor_public_surface_has_no_context_free_materialization_api() {
+    let tensor_source_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../tenferro-tensor/src");
+    let files = rust_source_files(&tensor_source_root);
+    assert!(
+        files.iter().any(|path| path.ends_with("backend.rs"))
+            && files.iter().any(|path| path.ends_with("types.rs")),
+        "source scan must cover the complete tenferro-tensor source tree"
+    );
+
+    let mut public_functions = BTreeMap::<String, Vec<PathBuf>>::new();
+    let mut all_functions = BTreeMap::<String, Vec<PathBuf>>::new();
+    for path in files {
+        let source = fs::read_to_string(&path).expect("Rust source file must be readable");
+        let tokens = rust_tokens(&source);
+        for name in public_function_names(&tokens) {
+            public_functions.entry(name).or_default().push(path.clone());
+        }
+        for name in function_names(&tokens) {
+            all_functions.entry(name).or_default().push(path.clone());
+        }
+    }
+
+    for forbidden in ["to_contiguous", "copy_from_contiguous", "to_tensor"] {
+        assert!(
+            !public_functions.contains_key(forbidden),
+            "context-free public materialization function `{forbidden}` remains in {:?}",
+            public_functions.get(forbidden)
+        );
+    }
     for forbidden in [
-        "pub fn to_contiguous(&self)",
-        "pub fn copy_from_contiguous",
-        "pub fn to_tensor(&self) -> crate::Result<Tensor>",
-        "fn materialize_typed_view_col_major",
+        "materialize_view_buffer_col_major",
+        "materialize_typed_view_col_major",
     ] {
         assert!(
-            !tensor_types.contains(forbidden),
-            "context-free tensor materialization surface/helper remains: {forbidden}"
+            !all_functions.contains_key(forbidden),
+            "context-free materialization helper `{forbidden}` remains in {:?}",
+            all_functions.get(forbidden)
         );
     }
+}
+
+#[test]
+fn rust_public_function_scan_is_format_and_literal_independent() {
+    let fixture = r####"
+        // pub fn to_tensor(&self) {}
+        const DECOY: &str = "pub fn to_contiguous(&self)";
+        const RAW_DECOY: &str = r###"pub fn copy_from_contiguous() { "still raw" }"###;
+        pub(crate) fn to_tensor() {}
+        pub
+        async
+        fn relocated_materializer() {}
+        fn private_helper() {}
+    "####;
+    let tokens = rust_tokens(fixture);
+    assert_eq!(
+        public_function_names(&tokens),
+        BTreeSet::from(["relocated_materializer".to_string()])
+    );
+    assert_eq!(
+        function_names(&tokens),
+        BTreeSet::from([
+            "private_helper".to_string(),
+            "relocated_materializer".to_string(),
+            "to_tensor".to_string(),
+        ])
+    );
 }
 
 #[test]

--- a/crates/tenferro-cpu/tests/backend_capability_contracts.rs
+++ b/crates/tenferro-cpu/tests/backend_capability_contracts.rs
@@ -183,6 +183,77 @@ fn ownership_contract(rules: &str) -> BTreeMap<&str, &str> {
         .collect()
 }
 
+fn contract_set<'a>(contract: &BTreeMap<&str, &'a str>, key: &str) -> BTreeSet<&'a str> {
+    contract
+        .get(key)
+        .unwrap_or_else(|| panic!("CPU strided ownership contract lacks field `{key}`"))
+        .split(',')
+        .collect()
+}
+
+fn token_tree_end(tokens: &[String], open: usize) -> Option<usize> {
+    let mut delimiters = Vec::new();
+    for (index, token) in tokens.iter().enumerate().skip(open) {
+        match token.as_str() {
+            "(" => delimiters.push(")"),
+            "[" => delimiters.push("]"),
+            "{" => delimiters.push("}"),
+            ")" | "]" | "}" => {
+                if delimiters.pop() != Some(token.as_str()) {
+                    return None;
+                }
+                if delimiters.is_empty() {
+                    return Some(index);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn macro_literal_identifiers(tokens: &[String]) -> BTreeSet<String> {
+    let mut identifiers = BTreeSet::new();
+    for index in 0..tokens.len() {
+        let open = if tokens
+            .get(index)
+            .is_some_and(|token| token == "macro_rules")
+            && tokens.get(index + 1).is_some_and(|token| token == "!")
+        {
+            (index + 2..tokens.len())
+                .find(|&candidate| matches!(tokens[candidate].as_str(), "(" | "[" | "{"))
+        } else if tokens.get(index + 1).is_some_and(|token| token == "!")
+            && tokens
+                .get(index + 2)
+                .is_some_and(|token| matches!(token.as_str(), "(" | "[" | "{"))
+        {
+            Some(index + 2)
+        } else {
+            None
+        };
+        let Some(open) = open else {
+            continue;
+        };
+        let Some(end) = token_tree_end(tokens, open) else {
+            continue;
+        };
+        identifiers.extend(tokens[open + 1..end].iter().filter_map(|token| {
+            (token
+                .as_bytes()
+                .first()
+                .is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'_'))
+            .then(|| token.clone())
+        }));
+    }
+    identifiers
+}
+
+fn contains_include_macro(tokens: &[String]) -> bool {
+    tokens
+        .windows(2)
+        .any(|window| window[0] == "include" && window[1] == "!")
+}
+
 fn accepts_backend_capabilities<B>()
 where
     B: TensorElementwise
@@ -378,29 +449,52 @@ fn strided_kernel_ownership_requires_backend_execution_resources() {
         Some(&"tenferro:benchmark-backed-exception")
     );
     assert_eq!(contract.get("execution-entry"), Some(&"CpuBackend"));
-    for vocabulary in [
-        "copy",
-        "permutation",
-        "broadcast",
-        "map",
-        "zip-map",
-        "axis-reduction",
-        "BufferPool",
-        "uninitialized-full-overwrite",
-        "CpuContext",
-        "Rayon",
-        "nested-execution",
-        "serial-parallel-threshold",
-        "context-free-strided-call",
-        "throwaway-pool",
-        "ambient-global-Rayon",
-        "execution-not-metadata",
-    ] {
-        assert!(
-            contract.values().any(|value| value.contains(vocabulary)),
-            "CPU strided ownership contract lacks essential vocabulary: {vocabulary}"
-        );
-    }
+    assert_eq!(
+        contract_set(&contract, "affine-kernels"),
+        BTreeSet::from([
+            "axis-reduction",
+            "broadcast",
+            "copy",
+            "map",
+            "permutation",
+            "zip-map",
+        ])
+    );
+    assert_eq!(
+        contract_set(&contract, "execution-resources"),
+        BTreeSet::from([
+            "CpuContext-Rayon",
+            "nested-execution",
+            "persistent-BufferPool",
+            "serial-parallel-threshold",
+            "uninitialized-full-overwrite",
+        ])
+    );
+    assert_eq!(
+        contract_set(&contract, "noncompliant"),
+        BTreeSet::from([
+            "ambient-global-Rayon",
+            "context-free-strided-call",
+            "throwaway-pool",
+        ])
+    );
+    assert_eq!(
+        contract.get("resource-classification"),
+        Some(&"memory-reuse-and-thread-policy:execution-not-metadata")
+    );
+    assert_eq!(
+        contract.keys().copied().collect::<BTreeSet<_>>(),
+        BTreeSet::from([
+            "affine-kernel-owner",
+            "affine-kernels",
+            "einsum-owner",
+            "execution-entry",
+            "execution-resources",
+            "noncompliant",
+            "resource-classification",
+            "schema",
+        ])
+    );
 }
 
 #[test]
@@ -415,9 +509,31 @@ fn tensor_public_surface_has_no_context_free_materialization_api() {
 
     let mut public_functions = BTreeMap::<String, Vec<PathBuf>>::new();
     let mut all_functions = BTreeMap::<String, Vec<PathBuf>>::new();
+    let forbidden_identifiers = BTreeSet::from([
+        "copy_from_contiguous",
+        "materialize_typed_view_col_major",
+        "materialize_view_buffer_col_major",
+        "to_contiguous",
+        "to_tensor",
+    ]);
     for path in files {
         let source = fs::read_to_string(&path).expect("Rust source file must be readable");
         let tokens = rust_tokens(&source);
+        assert!(
+            !contains_include_macro(&tokens),
+            "`include!` can hide generated public API and is forbidden in tenferro-tensor source: {}",
+            path.display()
+        );
+        let forbidden_macro_identifiers = macro_literal_identifiers(&tokens)
+            .into_iter()
+            .filter(|identifier| forbidden_identifiers.contains(identifier.as_str()))
+            .collect::<BTreeSet<_>>();
+        assert!(
+            forbidden_macro_identifiers.is_empty(),
+            "macro token stream in {} contains forbidden materialization identifiers: {:?}",
+            path.display(),
+            forbidden_macro_identifiers
+        );
         for name in public_function_names(&tokens) {
             public_functions.entry(name).or_default().push(path.clone());
         }
@@ -469,6 +585,18 @@ fn rust_public_function_scan_is_format_and_literal_independent() {
             "relocated_materializer".to_string(),
             "to_tensor".to_string(),
         ])
+    );
+
+    let generated_fixture = r#"
+        macro_rules! expose { ($name:ident) => { pub fn $name() {} } }
+        expose!(to_tensor);
+        include!("generated.rs");
+    "#;
+    let generated_tokens = rust_tokens(generated_fixture);
+    assert!(contains_include_macro(&generated_tokens));
+    assert!(
+        macro_literal_identifiers(&generated_tokens).contains("to_tensor"),
+        "literal forbidden identifiers in macro definitions/invocations must be visible"
     );
 }
 

--- a/crates/tenferro-cpu/tests/backend_capability_contracts.rs
+++ b/crates/tenferro-cpu/tests/backend_capability_contracts.rs
@@ -5,6 +5,26 @@ use tenferro_tensor::{
     TensorReduction, TensorStructural,
 };
 
+fn rust_function_body<'a>(source: &'a str, function: &str) -> Option<&'a str> {
+    let signature = format!("fn {function}(");
+    let function_start = source.find(&signature)?;
+    let body_start = function_start + source[function_start..].find('{')?;
+    let mut depth = 0usize;
+    for (offset, character) in source[body_start..].char_indices() {
+        match character {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&source[body_start..=body_start + offset]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 fn accepts_backend_capabilities<B>()
 where
     B: TensorElementwise
@@ -68,6 +88,55 @@ fn read_elementwise_and_analytic_paths_do_not_materialize_views() {
         !analytic_source.contains("materialize_tensor_read"),
         "analytic read paths must dispatch over TensorRead views directly"
     );
+}
+
+#[test]
+fn structural_read_paths_dispatch_directly_to_typed_view_helpers() {
+    let backend_source = include_str!("../src/backend.rs");
+    let session_source = include_str!("../src/exec_session.rs");
+    let structural_source = include_str!("../src/structural.rs");
+
+    for (surface, source) in [
+        ("CpuBackend", backend_source),
+        ("CpuExecSession", session_source),
+    ] {
+        let structural_impl = source
+            .split_once(&format!("impl TensorStructural for {surface}"))
+            .expect("TensorStructural implementation must exist")
+            .1;
+        for (operation, helper) in [
+            ("transpose_read", "transpose_read_with_pool"),
+            ("reshape_read", "reshape_read_with_pool"),
+            ("broadcast_in_dim_read", "broadcast_in_dim_read_with_pool"),
+        ] {
+            let implementation = rust_function_body(structural_impl, operation)
+                .unwrap_or_else(|| panic!("{surface}::{operation} must be implemented"));
+            assert!(
+                !implementation.contains("materialize_tensor_read"),
+                "{surface}::{operation} must not materialize an intermediate input"
+            );
+            assert!(
+                implementation.contains(&format!("structural::{helper}")),
+                "{surface}::{operation} must dispatch to structural::{helper}"
+            );
+        }
+    }
+
+    for (read_helper, typed_view_helper) in [
+        ("transpose_read_with_pool", "typed_transpose_view_with_pool"),
+        ("reshape_read_with_pool", "typed_reshape_view_with_pool"),
+        (
+            "broadcast_in_dim_read_with_pool",
+            "typed_broadcast_in_dim_view_with_pool",
+        ),
+    ] {
+        let implementation = rust_function_body(structural_source, read_helper)
+            .unwrap_or_else(|| panic!("structural::{read_helper} must own dtype dispatch"));
+        assert!(
+            implementation.contains(typed_view_helper),
+            "structural::{read_helper} must dispatch to {typed_view_helper}"
+        );
+    }
 }
 
 #[test]

--- a/crates/tenferro-cpu/tests/backend_capability_contracts.rs
+++ b/crates/tenferro-cpu/tests/backend_capability_contracts.rs
@@ -237,13 +237,17 @@ fn macro_literal_identifiers(tokens: &[String]) -> BTreeSet<String> {
         let Some(end) = token_tree_end(tokens, open) else {
             continue;
         };
-        identifiers.extend(tokens[open + 1..end].iter().filter_map(|token| {
-            (token
-                .as_bytes()
-                .first()
-                .is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'_'))
-            .then(|| token.clone())
-        }));
+        identifiers.extend(
+            tokens[open + 1..end]
+                .iter()
+                .filter(|token| {
+                    token
+                        .as_bytes()
+                        .first()
+                        .is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'_')
+                })
+                .cloned(),
+        );
     }
     identifiers
 }

--- a/crates/tenferro-cpu/tests/backend_capability_contracts.rs
+++ b/crates/tenferro-cpu/tests/backend_capability_contracts.rs
@@ -207,6 +207,43 @@ fn cpu_public_ops_require_backend_owner() {
 }
 
 #[test]
+fn strided_kernel_ownership_requires_backend_execution_resources() {
+    let rules = include_str!("../../../REPOSITORY_RULES.md");
+
+    for required in [
+        "CPU affine-strided copy, permutation, broadcast, map, zip-map, and axis reduction",
+        "delegate to `strided-rs`",
+        "Einsum is the benchmark-backed tenferro exception",
+        "persistent `BufferPool`",
+        "fully-overwritten uninitialized output",
+        "configured `CpuContext` Rayon pool",
+        "nested-execution safety",
+        "serial/parallel threshold",
+        "ambient global Rayon pool",
+        "throwaway pool",
+        "execution resources, not tensor metadata",
+    ] {
+        assert!(
+            rules.contains(required),
+            "REPOSITORY_RULES.md must contain ownership contract text: {required}"
+        );
+    }
+
+    let tensor_types = include_str!("../../tenferro-tensor/src/types.rs");
+    for forbidden in [
+        "pub fn to_contiguous(&self)",
+        "pub fn copy_from_contiguous",
+        "pub fn to_tensor(&self) -> crate::Result<Tensor>",
+        "fn materialize_typed_view_col_major",
+    ] {
+        assert!(
+            !tensor_types.contains(forbidden),
+            "context-free tensor materialization surface/helper remains: {forbidden}"
+        );
+    }
+}
+
+#[test]
 fn install_pool_has_no_placeholder_construction_or_gemm_descriptor_clones() {
     let backend_source = include_str!("../src/backend.rs");
     let buffer_pool_source = include_str!("../src/buffer_pool.rs");

--- a/crates/tenferro-cpu/tests/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/runtime_error_tests.rs
@@ -318,7 +318,11 @@ fn cpu_reductions_use_common_empty_axes_validation_helpers() {
         ),
     ] {
         let section = source_section(reduction, start, end);
-        let call = format!("{helper}(\"{op}\",");
+        let call = if helper == "reduction_read_empty_axes_noop" {
+            format!("{helper}(buffers, \"{op}\",")
+        } else {
+            format!("{helper}(\"{op}\",")
+        };
         assert!(
             section.contains(&call),
             "{start} should route empty-axis handling through {helper}"

--- a/crates/tenferro-einsum/src/eager.rs
+++ b/crates/tenferro-einsum/src/eager.rs
@@ -35,10 +35,10 @@ impl TensorValue<'_> {
         }
     }
 
-    fn into_tensor(self) -> Result<Tensor> {
+    fn into_tensor(self, exec: &mut dyn BackendSession) -> Result<Tensor> {
         match self {
             Self::Borrowed(tensor) => Ok(tensor.clone()),
-            Self::View(view) => view.to_tensor(),
+            Self::View(view) => exec.to_contiguous_read(TensorRead::from_view(view)),
             Self::Owned(tensor) => Ok(tensor),
         }
     }
@@ -216,10 +216,10 @@ impl LabeledTensor<'_> {
         self.tensor.tensor_read()
     }
 
-    fn tensor_cow(&self) -> Result<Cow<'_, Tensor>> {
+    fn tensor_cow(&self, exec: &mut dyn BackendSession) -> Result<Cow<'_, Tensor>> {
         match self.tensor() {
             Some(tensor) => Ok(Cow::Borrowed(tensor)),
-            None => Ok(Cow::Owned(self.tensor_read().to_tensor()?)),
+            None => Ok(Cow::Owned(exec.to_contiguous_read(self.tensor_read())?)),
         }
     }
 
@@ -359,7 +359,7 @@ fn reduce_tensor<'a>(
         .filter(|(axis, _)| !reduce_set.contains(axis))
         .map(|(_, label)| *label)
         .collect();
-    let operand_tensor = operand.tensor_cow()?;
+    let operand_tensor = operand.tensor_cow(exec)?;
     let tensor = exec.reduce_sum(&operand_tensor, &reduce_axes)?;
     operand.reclaim_if_owned(exec);
     Ok(LabeledTensor {
@@ -386,7 +386,7 @@ fn diagonalize_repeated<'a>(
             return Ok(operand);
         };
 
-        let operand_tensor = operand.tensor_cow()?;
+        let operand_tensor = operand.tensor_cow(exec)?;
         let tensor = exec.extract_diagonal(&operand_tensor, axis_a, axis_b)?;
         let mut labels = operand.labels.clone();
         labels.remove(axis_b);
@@ -418,7 +418,7 @@ fn embed_repeated<'a>(
             if output_count > current_count {
                 let axis_a = find_label_axis(&operand.labels, label)?;
                 let axis_b = axis_a + 1;
-                let operand_tensor = operand.tensor_cow()?;
+                let operand_tensor = operand.tensor_cow(exec)?;
                 let tensor = exec.embed_diagonal(&operand_tensor, axis_a, axis_b)?;
                 let mut labels = operand.labels.clone();
                 labels.insert(axis_b, label);
@@ -456,7 +456,7 @@ fn transpose_to_labels<'a>(
         return Ok(operand);
     }
 
-    let operand_tensor = operand.tensor_cow()?;
+    let operand_tensor = operand.tensor_cow(exec)?;
     let tensor = exec.transpose(&operand_tensor, &perm)?;
     operand.reclaim_if_owned(exec);
     Ok(LabeledTensor {
@@ -514,8 +514,8 @@ fn outer_product<'a>(
         ) {
             (Some(lhs_read), Some(rhs_read)) => exec.mul_read(lhs_read?, rhs_read?)?,
             _ => {
-                let lhs_input = lhs.tensor_cow()?;
-                let rhs_input = rhs.tensor_cow()?;
+                let lhs_input = lhs.tensor_cow(exec)?;
+                let rhs_input = rhs.tensor_cow(exec)?;
                 let lhs_tensor = exec.broadcast_in_dim(&lhs_input, &combined_shape, &lhs_dims)?;
                 let rhs_tensor = exec.broadcast_in_dim(&rhs_input, &combined_shape, &rhs_dims)?;
                 let tensor = exec.mul(&lhs_tensor, &rhs_tensor)?;
@@ -726,7 +726,7 @@ fn eager_einsum_exec_values<'a>(
         let reduced = reduce_tensor(exec, operand, &reduce_labels)?;
         let embedded = embed_repeated(exec, reduced, output_labels)?;
         let reordered = transpose_to_labels(exec, embedded, output_labels)?;
-        return reordered.tensor.into_tensor();
+        return reordered.tensor.into_tensor(exec);
     }
 
     for step_idx in 0..tree.step_count() {
@@ -770,7 +770,7 @@ fn eager_einsum_exec_values<'a>(
     let reordered = profile_eager_einsum_section("exec.final_transpose", || {
         transpose_to_labels(exec, reduced, output_labels)
     })?;
-    reordered.tensor.into_tensor()
+    reordered.tensor.into_tensor(exec)
 }
 
 /// Run a whole einsum contraction tree in one backend session.
@@ -820,7 +820,7 @@ pub(crate) fn eager_einsum_exec_read_into(
     exec: &mut dyn BackendSession,
     inputs: &[TensorRead<'_>],
     tree: &ContractionTree,
-    mut out: TensorWrite<'_>,
+    out: TensorWrite<'_>,
 ) -> Result<()> {
     record_eager_einsum_profile("exec_read_into.enter", Duration::ZERO);
     let subscripts = &tree.subscripts;
@@ -848,7 +848,7 @@ pub(crate) fn eager_einsum_exec_read_into(
     }
 
     let result = eager_einsum_exec_read(exec, inputs, tree)?;
-    out.copy_from_tensor(&result)
+    exec.copy_read_into(TensorRead::from_tensor(&result), out)
 }
 
 pub(crate) fn eager_einsum_exec_read_into_accum(
@@ -915,7 +915,7 @@ fn eager_einsum_exec_binary_read_fast(
         labels: subscripts.inputs[1].clone(),
     };
     execute_binary_dot_fast_plan(exec, lhs, rhs, plan, true)
-        .and_then(|result| result.tensor.into_tensor())
+        .and_then(|result| result.tensor.into_tensor(exec))
 }
 
 fn try_eager_einsum_binary_read_fast(

--- a/crates/tenferro-einsum/src/eager/tests.rs
+++ b/crates/tenferro-einsum/src/eager/tests.rs
@@ -30,8 +30,13 @@ fn tensor_value_view_paths_materialize_and_read() {
     let view_value = TensorValue::View(view);
     assert!(view_value.as_tensor().is_none());
     assert_eq!(view_value.tensor_read().shape(), &[2]);
+    let mut backend = CpuBackend::new();
     assert_eq!(
-        view_value.into_tensor().unwrap().as_slice::<f64>().unwrap(),
+        backend
+            .with_backend_session(|exec| view_value.into_tensor(exec))
+            .unwrap()
+            .as_slice::<f64>()
+            .unwrap(),
         &[3.0, 4.0]
     );
 }
@@ -58,7 +63,9 @@ fn generic_outer_product_with_views_uses_broadcast_path() {
         .with_backend_session(|exec| binary_contract(exec, lhs, rhs, &[0, 1], true))
         .unwrap();
     let labels = result.labels;
-    let tensor = result.tensor.into_tensor().unwrap();
+    let tensor = ctx
+        .with_backend_session(|exec| result.tensor.into_tensor(exec))
+        .unwrap();
 
     assert_eq!(labels, vec![0, 1]);
     assert_eq!(tensor.shape(), &[2, 3]);
@@ -87,7 +94,7 @@ fn generic_outer_product_uses_broadcast_views_without_materialized_broadcast_ops
     };
 
     let result = binary_contract(&mut backend, lhs, rhs, &[0, 1], true).unwrap();
-    let tensor = result.tensor.into_tensor().unwrap();
+    let tensor = result.tensor.into_tensor(&mut backend).unwrap();
 
     assert_eq!(result.labels, vec![0, 1]);
     assert_eq!(tensor.shape(), &[2, 3]);
@@ -116,7 +123,7 @@ fn generic_outer_product_uses_target_order_without_final_transpose() {
     };
 
     let result = binary_contract(&mut backend, lhs, rhs, &[1, 0], true).unwrap();
-    let tensor = result.tensor.into_tensor().unwrap();
+    let tensor = result.tensor.into_tensor(&mut backend).unwrap();
 
     assert_eq!(result.labels, vec![1, 0]);
     assert_eq!(tensor.shape(), &[3, 2]);
@@ -144,7 +151,9 @@ fn generic_binary_contract_reduces_then_builds_dot_config() {
         .with_backend_session(|exec| binary_contract(exec, lhs, rhs, &[0, 2], false))
         .unwrap();
     let labels = result.labels;
-    let tensor = result.tensor.into_tensor().unwrap();
+    let tensor = ctx
+        .with_backend_session(|exec| result.tensor.into_tensor(exec))
+        .unwrap();
 
     assert_eq!(labels, vec![0, 2]);
     assert_eq!(tensor.shape(), &[2, 5]);

--- a/crates/tenferro-einsum/src/typed_eager_tests.rs
+++ b/crates/tenferro-einsum/src/typed_eager_tests.rs
@@ -3,7 +3,7 @@ use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSessionHost, CompareDir, DType, DotGeneralConfig,
     GatherConfig, PadConfig, ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend,
     TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
-    TensorRead, TensorReduction, TensorStructural, TensorView, TypedTensor,
+    TensorRead, TensorReduction, TensorStructural, TensorView, TensorWrite, TypedTensor,
 };
 
 use crate::eager::{
@@ -78,6 +78,18 @@ impl TensorAnalytic for WrongDTypeBackend {
 }
 
 impl TensorStructural for WrongDTypeBackend {
+    fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Tensor> {
+        CpuBackend::new().to_contiguous_read(input)
+    }
+
+    fn copy_read_into(
+        &mut self,
+        src: TensorRead<'_>,
+        dst: TensorWrite<'_>,
+    ) -> tenferro_tensor::Result<()> {
+        CpuBackend::new().copy_read_into(src, dst)
+    }
+
     panic_backend_methods! {
         transpose(input: &Tensor, perm: &[usize]) -> tenferro_tensor::Result<Tensor>;
         reshape(input: &Tensor, shape: &[usize]) -> tenferro_tensor::Result<Tensor>;

--- a/crates/tenferro-einsum/tests/traced_extension.rs
+++ b/crates/tenferro-einsum/tests/traced_extension.rs
@@ -88,7 +88,11 @@ fn traced_einsum_final_permutation_can_return_lazy_value() {
         TensorValue::Tensor(_) => panic!("final einsum permutation should stay as a lazy view"),
     }
     assert_eq!(
-        values[0].to_tensor().unwrap().as_slice::<f64>().unwrap(),
+        executor
+            .materialize_value(&values[0])
+            .unwrap()
+            .as_slice::<f64>()
+            .unwrap(),
         &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
     );
 }

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -661,8 +661,10 @@ fn execute_concrete_fft_read_op<B: TensorBackend>(
     backend: &mut B,
 ) -> tenferro_tensor::Result<Tensor> {
     let op = concrete_fft_op(op_name, kind, input.shape(), n, axis, norm)?;
-    let materialized = input.to_tensor()?;
-    execute_concrete_fft_op(&materialized, &op, backend)
+    backend.with_backend_session(|exec| {
+        let materialized = exec.to_contiguous_read(input.clone())?;
+        single_fft_output(execute_host_fft_op(&op, &[&materialized])?)
+    })
 }
 
 fn single_fft_output(mut outputs: Vec<Tensor>) -> tenferro_tensor::Result<Tensor> {
@@ -1108,13 +1110,15 @@ fn execute_fft_extension_reads<B: TensorBackend + 'static>(
     inputs: &[TensorRead<'_>],
     ctx: &mut ExtensionExecutionContext<'_, B>,
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
-    let _ = ctx;
     // rustfft consumes compact host tensors; materialization is explicit so
     // backend-backed views produce a normal error instead of an implicit path.
-    let materialized_inputs: Vec<Tensor> = inputs
-        .iter()
-        .map(TensorRead::to_tensor)
-        .collect::<tenferro_tensor::Result<_>>()?;
+    let materialized_inputs = ctx.backend_mut().with_backend_session(|exec| {
+        inputs
+            .iter()
+            .cloned()
+            .map(|input| exec.to_contiguous_read(input))
+            .collect::<tenferro_tensor::Result<Vec<_>>>()
+    })?;
     let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
     execute_host_fft_op(op, &input_refs)
 }

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -4051,7 +4051,8 @@ impl TensorStructural for CudaBackend {
         macro_rules! materialize {
             ($variant:ident, $view:expr) => {{
                 let view = $view;
-                TensorViewCanonicalization::to_contiguous(self, &view).map(Tensor::$variant)
+                self.to_contiguous_view_typed(&view, "CudaBackend::to_contiguous_read")
+                    .map(Tensor::$variant)
             }};
         }
 
@@ -4060,14 +4061,20 @@ impl TensorStructural for CudaBackend {
             TensorRead::Tensor(Tensor::F64(input)) => materialize!(F64, input.as_view()),
             TensorRead::Tensor(Tensor::I32(input)) => materialize!(I32, input.as_view()),
             TensorRead::Tensor(Tensor::I64(input)) => materialize!(I64, input.as_view()),
-            TensorRead::Tensor(Tensor::Bool(input)) => materialize!(Bool, input.as_view()),
+            TensorRead::Tensor(Tensor::Bool(_)) => Err(unsupported_dtype(
+                "CudaBackend::to_contiguous_read",
+                crate::DType::Bool,
+            )),
             TensorRead::Tensor(Tensor::C32(input)) => materialize!(C32, input.as_view()),
             TensorRead::Tensor(Tensor::C64(input)) => materialize!(C64, input.as_view()),
             TensorRead::View(TensorView::F32(input)) => materialize!(F32, input),
             TensorRead::View(TensorView::F64(input)) => materialize!(F64, input),
             TensorRead::View(TensorView::I32(input)) => materialize!(I32, input),
             TensorRead::View(TensorView::I64(input)) => materialize!(I64, input),
-            TensorRead::View(TensorView::Bool(input)) => materialize!(Bool, input),
+            TensorRead::View(TensorView::Bool(_)) => Err(unsupported_dtype(
+                "CudaBackend::to_contiguous_read",
+                crate::DType::Bool,
+            )),
             TensorRead::View(TensorView::C32(input)) => materialize!(C32, input),
             TensorRead::View(TensorView::C64(input)) => materialize!(C64, input),
         }
@@ -4082,11 +4089,27 @@ impl TensorStructural for CudaBackend {
                 match dst {
                     TensorWrite::Tensor(Tensor::$variant(dst)) => {
                         let mut dst = dst.as_view_mut();
-                        TensorViewCanonicalization::copy_into(self, &src, &mut dst)
+                        self.copy_view_to_view_typed(&src, &mut dst, "CudaBackend::copy_read_into")
                     }
                     TensorWrite::View(TensorViewMut::$variant(mut dst)) => {
-                        TensorViewCanonicalization::copy_into(self, &src, &mut dst)
+                        self.copy_view_to_view_typed(&src, &mut dst, "CudaBackend::copy_read_into")
                     }
+                    _ => Err(crate::Error::DTypeMismatch {
+                        op: "CudaBackend::copy_read_into",
+                        lhs: src_dtype,
+                        rhs: dst_dtype,
+                    }),
+                }
+            }};
+        }
+        macro_rules! reject_bool_source {
+            () => {{
+                match dst {
+                    TensorWrite::Tensor(Tensor::Bool(_))
+                    | TensorWrite::View(TensorViewMut::Bool(_)) => Err(unsupported_dtype(
+                        "CudaBackend::copy_read_into",
+                        crate::DType::Bool,
+                    )),
                     _ => Err(crate::Error::DTypeMismatch {
                         op: "CudaBackend::copy_read_into",
                         lhs: src_dtype,
@@ -4101,14 +4124,14 @@ impl TensorStructural for CudaBackend {
             TensorRead::Tensor(Tensor::F64(src)) => copy_source!(F64, src.as_view()),
             TensorRead::Tensor(Tensor::I32(src)) => copy_source!(I32, src.as_view()),
             TensorRead::Tensor(Tensor::I64(src)) => copy_source!(I64, src.as_view()),
-            TensorRead::Tensor(Tensor::Bool(src)) => copy_source!(Bool, src.as_view()),
+            TensorRead::Tensor(Tensor::Bool(_)) => reject_bool_source!(),
             TensorRead::Tensor(Tensor::C32(src)) => copy_source!(C32, src.as_view()),
             TensorRead::Tensor(Tensor::C64(src)) => copy_source!(C64, src.as_view()),
             TensorRead::View(TensorView::F32(src)) => copy_source!(F32, src),
             TensorRead::View(TensorView::F64(src)) => copy_source!(F64, src),
             TensorRead::View(TensorView::I32(src)) => copy_source!(I32, src),
             TensorRead::View(TensorView::I64(src)) => copy_source!(I64, src),
-            TensorRead::View(TensorView::Bool(src)) => copy_source!(Bool, src),
+            TensorRead::View(TensorView::Bool(_)) => reject_bool_source!(),
             TensorRead::View(TensorView::C32(src)) => copy_source!(C32, src),
             TensorRead::View(TensorView::C64(src)) => copy_source!(C64, src),
         }

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -803,13 +803,10 @@ impl CudaBackend {
         ensure_view_resident_on_runtime(self.runtime(), src, op)?;
         ensure_view_mut_resident_on_runtime(self.runtime(), dst, op)?;
         if src.shape() != dst.shape() {
-            return Err(crate::Error::InvalidConfig {
+            return Err(crate::Error::ShapeMismatch {
                 op,
-                message: format!(
-                    "shape mismatch: source {:?} does not match destination {:?}",
-                    src.shape(),
-                    dst.shape()
-                ),
+                lhs: src.shape().to_vec(),
+                rhs: dst.shape().to_vec(),
             });
         }
         let source_buffer = src.backend_buffer().ok_or_else(|| {
@@ -818,6 +815,19 @@ impl CudaBackend {
                 "CUDA backend expected a GPU source view; call upload_tensor() first",
             )
         })?;
+        let destination_buffer = dst.backend_buffer().ok_or_else(|| {
+            crate::Error::backend_failure(
+                op,
+                "CUDA backend expected a GPU destination view; call upload_tensor() first",
+            )
+        })?;
+        if Arc::ptr_eq(source_buffer, destination_buffer) {
+            return Err(crate::Error::InvalidConfig {
+                op,
+                message: "CUDA copy_into source and destination allocations must not alias"
+                    .to_string(),
+            });
+        }
         if !src.is_col_major_contiguous()?
             || src.offset() != 0
             || source_buffer.len() != src.n_elements()
@@ -850,9 +860,11 @@ impl CudaBackend {
         let rank = dst.shape().len();
         unsafe {
             // SAFETY: The source is an owned compact CubeCL tensor on this
-            // runtime. The destination view has validated reachable offsets
-            // and no overlap, and the launch domain covers each source element
-            // and destination logical coordinate exactly once.
+            // runtime. Allocation identity validation above proves source and
+            // destination do not alias. The destination view has validated
+            // reachable offsets and no internal overlap, and the launch domain
+            // covers each source element and destination logical coordinate
+            // exactly once.
             structural::contiguous_to_view_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
                 self.runtime().client(),
                 cube_count_for_len(len)?,

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -110,7 +110,8 @@ use crate::kernels::reduce::{self as cubecl_reduce, ReduceStrategy};
 use crate::kernels::{diagonal, elementwise, indexing, structural};
 use crate::{
     Buffer, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Tensor, TensorRank,
-    TensorViewCanonicalization, TypedTensor, TypedTensorView, TypedTensorViewMut,
+    TensorView, TensorViewCanonicalization, TensorViewMut, TypedTensor, TypedTensorView,
+    TypedTensorViewMut,
 };
 
 mod capability;
@@ -4046,6 +4047,73 @@ impl TensorAnalytic for CudaBackend {
 }
 
 impl TensorStructural for CudaBackend {
+    fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
+        macro_rules! materialize {
+            ($variant:ident, $view:expr) => {{
+                let view = $view;
+                TensorViewCanonicalization::to_contiguous(self, &view).map(Tensor::$variant)
+            }};
+        }
+
+        match input {
+            TensorRead::Tensor(Tensor::F32(input)) => materialize!(F32, input.as_view()),
+            TensorRead::Tensor(Tensor::F64(input)) => materialize!(F64, input.as_view()),
+            TensorRead::Tensor(Tensor::I32(input)) => materialize!(I32, input.as_view()),
+            TensorRead::Tensor(Tensor::I64(input)) => materialize!(I64, input.as_view()),
+            TensorRead::Tensor(Tensor::Bool(input)) => materialize!(Bool, input.as_view()),
+            TensorRead::Tensor(Tensor::C32(input)) => materialize!(C32, input.as_view()),
+            TensorRead::Tensor(Tensor::C64(input)) => materialize!(C64, input.as_view()),
+            TensorRead::View(TensorView::F32(input)) => materialize!(F32, input),
+            TensorRead::View(TensorView::F64(input)) => materialize!(F64, input),
+            TensorRead::View(TensorView::I32(input)) => materialize!(I32, input),
+            TensorRead::View(TensorView::I64(input)) => materialize!(I64, input),
+            TensorRead::View(TensorView::Bool(input)) => materialize!(Bool, input),
+            TensorRead::View(TensorView::C32(input)) => materialize!(C32, input),
+            TensorRead::View(TensorView::C64(input)) => materialize!(C64, input),
+        }
+    }
+
+    fn copy_read_into(&mut self, src: TensorRead<'_>, dst: TensorWrite<'_>) -> crate::Result<()> {
+        let src_dtype = src.dtype();
+        let dst_dtype = dst.dtype();
+        macro_rules! copy_source {
+            ($variant:ident, $src:expr) => {{
+                let src = $src;
+                match dst {
+                    TensorWrite::Tensor(Tensor::$variant(dst)) => {
+                        let mut dst = dst.as_view_mut();
+                        TensorViewCanonicalization::copy_into(self, &src, &mut dst)
+                    }
+                    TensorWrite::View(TensorViewMut::$variant(mut dst)) => {
+                        TensorViewCanonicalization::copy_into(self, &src, &mut dst)
+                    }
+                    _ => Err(crate::Error::DTypeMismatch {
+                        op: "CudaBackend::copy_read_into",
+                        lhs: src_dtype,
+                        rhs: dst_dtype,
+                    }),
+                }
+            }};
+        }
+
+        match src {
+            TensorRead::Tensor(Tensor::F32(src)) => copy_source!(F32, src.as_view()),
+            TensorRead::Tensor(Tensor::F64(src)) => copy_source!(F64, src.as_view()),
+            TensorRead::Tensor(Tensor::I32(src)) => copy_source!(I32, src.as_view()),
+            TensorRead::Tensor(Tensor::I64(src)) => copy_source!(I64, src.as_view()),
+            TensorRead::Tensor(Tensor::Bool(src)) => copy_source!(Bool, src.as_view()),
+            TensorRead::Tensor(Tensor::C32(src)) => copy_source!(C32, src.as_view()),
+            TensorRead::Tensor(Tensor::C64(src)) => copy_source!(C64, src.as_view()),
+            TensorRead::View(TensorView::F32(src)) => copy_source!(F32, src),
+            TensorRead::View(TensorView::F64(src)) => copy_source!(F64, src),
+            TensorRead::View(TensorView::I32(src)) => copy_source!(I32, src),
+            TensorRead::View(TensorView::I64(src)) => copy_source!(I64, src),
+            TensorRead::View(TensorView::Bool(src)) => copy_source!(Bool, src),
+            TensorRead::View(TensorView::C32(src)) => copy_source!(C32, src),
+            TensorRead::View(TensorView::C64(src)) => copy_source!(C64, src),
+        }
+    }
+
     fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
         match input {
             Tensor::F32(t) => self.transpose_typed(t, perm).map(Tensor::F32),

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -790,9 +790,9 @@ impl CudaBackend {
         Ok(output)
     }
 
-    fn copy_contiguous_to_view_typed<T, R>(
+    fn copy_view_to_view_typed<T, R>(
         &self,
-        src: &TypedTensor<T, R>,
+        src: &TypedTensorView<'_, T, R>,
         dst: &mut TypedTensorViewMut<'_, T, R>,
         op: &'static str,
     ) -> crate::Result<()>
@@ -800,7 +800,7 @@ impl CudaBackend {
         T: CubeElement + CubePrimitive + Clone + Send + Sync + 'static,
         R: TensorRank,
     {
-        ensure_resident_on_runtime(self.runtime(), src, op)?;
+        ensure_view_resident_on_runtime(self.runtime(), src, op)?;
         ensure_view_mut_resident_on_runtime(self.runtime(), dst, op)?;
         if src.shape() != dst.shape() {
             return Err(crate::Error::InvalidConfig {
@@ -812,13 +812,40 @@ impl CudaBackend {
                 ),
             });
         }
+        let source_buffer = src.backend_buffer().ok_or_else(|| {
+            crate::Error::backend_failure(
+                op,
+                "CUDA backend expected a GPU source view; call upload_tensor() first",
+            )
+        })?;
+        if !src.is_col_major_contiguous()?
+            || src.offset() != 0
+            || source_buffer.len() != src.n_elements()
+        {
+            return Err(crate::Error::InvalidConfig {
+                op,
+                message: "CUDA copy_into requires a compact source view covering its full allocation; arbitrary-stride source views are unsupported without explicit canonicalization"
+                    .to_string(),
+            });
+        }
+        let source_shape = R::shape_from_vec(src.shape().to_vec().into()).map_err(|err| {
+            crate::Error::InvalidConfig {
+                op,
+                message: format!("source rank mismatch: {err}"),
+            }
+        })?;
+        let source_tensor: TypedTensor<T, R> = TypedTensor::from_buffer_col_major(
+            source_shape,
+            Buffer::Backend(Arc::clone(source_buffer)),
+            src.placement().clone(),
+        )?;
         let len = src.n_elements();
         if len == 0 {
             return Ok(());
         }
         let strides = view_strides_i64(dst.strides(), op)?;
         let base_offset = view_offset_i64(dst.offset(), op)?;
-        let src_arg = typed_tensor_binding(src, op)?;
+        let src_arg = typed_tensor_binding(&source_tensor, op)?;
         let dst_arg = typed_view_mut_array_arg(dst, op)?;
         let rank = dst.shape().len();
         unsafe {
@@ -4827,16 +4854,12 @@ macro_rules! impl_cubecl_view_canonicalization {
                     self.to_contiguous_view_typed(view, "CudaBackend::to_contiguous")
                 }
 
-                fn copy_from_contiguous(
+                fn copy_into(
                     &mut self,
-                    src: &TypedTensor<$ty, R>,
+                    src: &TypedTensorView<'_, $ty, R>,
                     dst: &mut TypedTensorViewMut<'_, $ty, R>,
                 ) -> crate::Result<()> {
-                    self.copy_contiguous_to_view_typed(
-                        src,
-                        dst,
-                        "CudaBackend::copy_from_contiguous",
-                    )
+                    self.copy_view_to_view_typed(src, dst, "CudaBackend::copy_into")
                 }
             }
         )*
@@ -4859,13 +4882,13 @@ where
         ))
     }
 
-    fn copy_from_contiguous(
+    fn copy_into(
         &mut self,
-        _src: &TypedTensor<bool, R>,
+        _src: &TypedTensorView<'_, bool, R>,
         _dst: &mut TypedTensorViewMut<'_, bool, R>,
     ) -> crate::Result<()> {
         Err(unsupported_dtype(
-            "CudaBackend::copy_from_contiguous",
+            "CudaBackend::copy_into",
             crate::DType::Bool,
         ))
     }

--- a/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
@@ -668,7 +668,7 @@ fn cuda_to_contiguous_host_view_returns_upload_hint() {
 
 #[test]
 #[ignore]
-fn cuda_copy_from_contiguous_host_source_returns_upload_hint() {
+fn cuda_copy_into_host_source_returns_upload_hint() {
     let mut gpu = gpu_backend();
     let src = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]).unwrap();
     let dst_host = tensor_i32(vec![2], vec![0, 0]);
@@ -678,13 +678,13 @@ fn cuda_copy_from_contiguous_host_source_returns_upload_hint() {
     };
 
     let err = gpu
-        .copy_from_contiguous(&src, &mut dst.as_view_mut())
+        .copy_into(&src.as_view(), &mut dst.as_view_mut())
         .unwrap_err();
 
     assert!(matches!(
         err,
         Error::BackendFailure {
-            op: "CudaBackend::copy_from_contiguous",
+            op: "CudaBackend::copy_into",
             ref message,
         } if message.contains("upload_tensor()")
     ));
@@ -692,7 +692,7 @@ fn cuda_copy_from_contiguous_host_source_returns_upload_hint() {
 
 #[test]
 #[ignore]
-fn cuda_copy_from_contiguous_host_destination_returns_upload_hint() {
+fn cuda_copy_into_host_destination_returns_upload_hint() {
     let mut gpu = gpu_backend();
     let src_host = tensor_i32(vec![2], vec![1, 2]);
     let gpu_src = upload(&gpu, &src_host);
@@ -702,13 +702,13 @@ fn cuda_copy_from_contiguous_host_destination_returns_upload_hint() {
     let mut dst = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![0, 0]).unwrap();
 
     let err = gpu
-        .copy_from_contiguous(src, &mut dst.as_view_mut())
+        .copy_into(&src.as_view(), &mut dst.as_view_mut())
         .unwrap_err();
 
     assert!(matches!(
         err,
         Error::BackendFailure {
-            op: "CudaBackend::copy_from_contiguous",
+            op: "CudaBackend::copy_into",
             ref message,
         } if message.contains("upload_tensor()")
     ));
@@ -716,7 +716,7 @@ fn cuda_copy_from_contiguous_host_destination_returns_upload_hint() {
 
 #[test]
 #[ignore]
-fn cuda_copy_from_contiguous_updates_strided_view_on_cuda() {
+fn cuda_copy_into_updates_strided_view_on_cuda() {
     let mut gpu = gpu_backend();
     let dst_host = tensor_i32(vec![2, 2], vec![0, 0, 0, 0]);
     let src_host = tensor_i32(vec![2, 2], vec![1, 2, 3, 4]);
@@ -728,8 +728,34 @@ fn cuda_copy_from_contiguous_updates_strided_view_on_cuda() {
     };
     let mut dst_view = dst.as_view_mut().transpose_view([1, 0]).unwrap();
 
-    gpu.copy_from_contiguous(src, &mut dst_view).unwrap();
+    gpu.copy_into(&src.as_view(), &mut dst_view).unwrap();
 
     let actual = download(&gpu, &gpu_dst);
     assert_eq!(actual.as_slice::<i32>().unwrap(), &[1, 3, 2, 4]);
+}
+
+#[test]
+#[ignore]
+fn cuda_copy_into_rejects_arbitrary_stride_source_without_materializing() {
+    let mut gpu = gpu_backend();
+    let src_host = tensor_i32(vec![2, 2], vec![1, 2, 3, 4]);
+    let dst_host = tensor_i32(vec![2, 2], vec![0, 0, 0, 0]);
+    let gpu_src = upload(&gpu, &src_host);
+    let mut gpu_dst = upload(&gpu, &dst_host);
+    let (Tensor::I32(src), Tensor::I32(dst)) = (&gpu_src, &mut gpu_dst) else {
+        panic!("expected i32 tensors");
+    };
+    let src_view = src.as_view().transpose_view([1, 0]).unwrap();
+
+    let err = gpu
+        .copy_into(&src_view, &mut dst.as_view_mut())
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::InvalidConfig {
+            op: "CudaBackend::copy_into",
+            ref message,
+        } if message.contains("compact source view")
+    ));
 }

--- a/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
@@ -1,5 +1,5 @@
 // Run with: cargo test --features cuda -- --ignored
-use crate::{DType, Error, MemoryKind, Tensor, TypedTensor};
+use crate::{DType, DeviceId, DeviceKind, Error, MemoryKind, Placement, Tensor, TypedTensor};
 use num_complex::{Complex32, Complex64};
 use tenferro_tensor::{
     GpuBackendKind, StridedSliceSpec, TensorIndexing, TensorStructural, TensorViewCanonicalization,
@@ -9,6 +9,24 @@ use super::{
     assert_tensor_close, cpu_backend, download, gpu_backend, tensor_bool, tensor_c32, tensor_c64,
     tensor_f32, tensor_f64, tensor_i32, tensor_i64, upload,
 };
+
+fn with_cuda_ordinal<T: Clone + 'static>(
+    tensor: &TypedTensor<T>,
+    ordinal: usize,
+) -> TypedTensor<T> {
+    TypedTensor::from_buffer_col_major(
+        tensor.shape().to_vec(),
+        tensor.buffer().clone(),
+        Placement {
+            memory_kind: MemoryKind::Device,
+            device: Some(DeviceId {
+                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+                ordinal,
+            }),
+        },
+    )
+    .unwrap()
+}
 
 #[test]
 #[ignore = "requires CUDA 12.8+ GPU"]
@@ -757,5 +775,57 @@ fn cuda_copy_into_rejects_arbitrary_stride_source_without_materializing() {
             op: "CudaBackend::copy_into",
             ref message,
         } if message.contains("compact source view")
+    ));
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_copy_into_rejects_source_on_wrong_device() {
+    let mut gpu = gpu_backend();
+    let src_host = tensor_i32(vec![2], vec![1, 2]);
+    let dst_host = tensor_i32(vec![2], vec![0, 0]);
+    let gpu_src = upload(&gpu, &src_host);
+    let mut gpu_dst = upload(&gpu, &dst_host);
+    let (Tensor::I32(src), Tensor::I32(dst)) = (&gpu_src, &mut gpu_dst) else {
+        panic!("expected i32 tensors");
+    };
+    let wrong_src = with_cuda_ordinal(src, 1);
+
+    let err = gpu
+        .copy_into(&wrong_src.as_view(), &mut dst.as_view_mut())
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "CudaBackend::copy_into",
+            ref message,
+        } if message.contains("cuda:0") && message.contains("Cuda):1")
+    ));
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_copy_into_rejects_destination_on_wrong_device() {
+    let mut gpu = gpu_backend();
+    let src_host = tensor_i32(vec![2], vec![1, 2]);
+    let dst_host = tensor_i32(vec![2], vec![0, 0]);
+    let gpu_src = upload(&gpu, &src_host);
+    let gpu_dst = upload(&gpu, &dst_host);
+    let (Tensor::I32(src), Tensor::I32(dst)) = (&gpu_src, &gpu_dst) else {
+        panic!("expected i32 tensors");
+    };
+    let mut wrong_dst = with_cuda_ordinal(dst, 1);
+
+    let err = gpu
+        .copy_into(&src.as_view(), &mut wrong_dst.as_view_mut())
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::BackendFailure {
+            op: "CudaBackend::copy_into",
+            ref message,
+        } if message.contains("cuda:0") && message.contains("Cuda):1")
     ));
 }

--- a/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
@@ -634,6 +634,75 @@ fn cuda_runtime_copy_is_object_safe_and_updates_strided_destination() {
 }
 
 #[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_runtime_copy_rejects_noncompact_source_with_erased_operation_name() {
+    let mut gpu = gpu_backend();
+    let gpu_src = upload(&gpu, &tensor_i32(vec![2, 2], vec![1, 2, 3, 4]));
+    let mut gpu_dst = upload(&gpu, &tensor_i32(vec![2, 2], vec![0, 0, 0, 0]));
+    let Tensor::I32(src) = &gpu_src else {
+        panic!("expected i32 source");
+    };
+    let src_view = src.as_view().transpose_view([1, 0]).unwrap();
+
+    let err = gpu
+        .copy_read_into(
+            TensorRead::from_view(TensorView::I32(src_view)),
+            TensorWrite::from_tensor(&mut gpu_dst),
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        Error::InvalidConfig {
+            op: "CudaBackend::copy_read_into",
+            message: "CUDA copy_into requires a compact source view covering its full allocation; arbitrary-stride source views are unsupported without explicit canonicalization".into(),
+        }
+    );
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_runtime_bool_materialization_reports_intentional_erased_limitation() {
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &tensor_bool(vec![2], vec![true, false]));
+
+    let err = gpu
+        .to_contiguous_read(TensorRead::from_tensor(&gpu_input))
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        Error::BackendFailure {
+            op: "CudaBackend::to_contiguous_read",
+            message: "unsupported dtype Bool".into(),
+        }
+    );
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_runtime_bool_copy_reports_intentional_erased_limitation() {
+    let mut gpu = gpu_backend();
+    let gpu_src = upload(&gpu, &tensor_bool(vec![2], vec![true, false]));
+    let mut gpu_dst = upload(&gpu, &tensor_bool(vec![2], vec![false, false]));
+
+    let err = gpu
+        .copy_read_into(
+            TensorRead::from_tensor(&gpu_src),
+            TensorWrite::from_tensor(&mut gpu_dst),
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        Error::BackendFailure {
+            op: "CudaBackend::copy_read_into",
+            message: "unsupported dtype Bool".into(),
+        }
+    );
+}
+
+#[test]
 #[ignore]
 fn cuda_to_contiguous_preserves_negative_stride_view() {
     let mut gpu = gpu_backend();

--- a/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
@@ -829,3 +829,49 @@ fn cuda_copy_into_rejects_destination_on_wrong_device() {
         } if message.contains("cuda:0") && message.contains("Cuda):1")
     ));
 }
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_copy_into_rejects_cloned_aliased_allocation() {
+    let mut gpu = gpu_backend();
+    let gpu_tensor = upload(&gpu, &tensor_i32(vec![2, 2], vec![1, 2, 3, 4]));
+    let Tensor::I32(src) = &gpu_tensor else {
+        panic!("expected i32 tensor");
+    };
+    let mut dst = src.clone();
+    let mut dst_view = dst.as_view_mut().transpose_view([1, 0]).unwrap();
+
+    let err = gpu.copy_into(&src.as_view(), &mut dst_view).unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::InvalidConfig {
+            op: "CudaBackend::copy_into",
+            ref message,
+        } if message.contains("alias")
+    ));
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_copy_into_reports_typed_shape_mismatch() {
+    let mut gpu = gpu_backend();
+    let gpu_src = upload(&gpu, &tensor_i32(vec![2], vec![1, 2]));
+    let mut gpu_dst = upload(&gpu, &tensor_i32(vec![3], vec![0, 0, 0]));
+    let (Tensor::I32(src), Tensor::I32(dst)) = (&gpu_src, &mut gpu_dst) else {
+        panic!("expected i32 tensors");
+    };
+
+    let err = gpu
+        .copy_into(&src.as_view(), &mut dst.as_view_mut())
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        Error::ShapeMismatch {
+            op: "CudaBackend::copy_into",
+            lhs: vec![2],
+            rhs: vec![3],
+        }
+    );
+}

--- a/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
@@ -2,7 +2,8 @@
 use crate::{DType, DeviceId, DeviceKind, Error, MemoryKind, Placement, Tensor, TypedTensor};
 use num_complex::{Complex32, Complex64};
 use tenferro_tensor::{
-    GpuBackendKind, StridedSliceSpec, TensorIndexing, TensorStructural, TensorViewCanonicalization,
+    BackendSession, GpuBackendKind, StridedSliceSpec, TensorIndexing, TensorRead, TensorStructural,
+    TensorView, TensorViewCanonicalization, TensorViewMut, TensorWrite,
 };
 
 use super::{
@@ -587,6 +588,49 @@ fn cuda_to_contiguous_keeps_tensor_on_cuda() {
     ));
     let actual = download(&gpu, &Tensor::I32(compact));
     assert_eq!(actual.as_slice::<i32>().unwrap(), &[1, 3, 5, 2, 4, 6]);
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_runtime_materialization_is_object_safe_and_stays_on_device() {
+    let mut gpu = gpu_backend();
+    let gpu_input = upload(&gpu, &tensor_i32(vec![2, 3], vec![1, 2, 3, 4, 5, 6]));
+    let Tensor::I32(input) = &gpu_input else {
+        panic!("expected i32 tensor");
+    };
+    let view = input.as_view().transpose_view([1, 0]).unwrap();
+    let exec: &mut dyn BackendSession = &mut gpu;
+
+    let output = exec
+        .to_contiguous_read(TensorRead::from_view(TensorView::I32(view)))
+        .unwrap();
+
+    assert_eq!(output.shape(), &[3, 2]);
+    assert_eq!(output.placement().memory_kind, MemoryKind::Device);
+    let actual = download(&gpu, &output);
+    assert_eq!(actual.as_slice::<i32>().unwrap(), &[1, 3, 5, 2, 4, 6]);
+}
+
+#[test]
+#[ignore = "requires CUDA 12.8+ GPU"]
+fn cuda_runtime_copy_is_object_safe_and_updates_strided_destination() {
+    let mut gpu = gpu_backend();
+    let gpu_src = upload(&gpu, &tensor_i32(vec![2, 2], vec![1, 2, 3, 4]));
+    let mut gpu_dst = upload(&gpu, &tensor_i32(vec![2, 2], vec![0, 0, 0, 0]));
+    let Tensor::I32(dst) = &mut gpu_dst else {
+        panic!("expected i32 destination");
+    };
+    let dst_view = dst.as_view_mut().transpose_view([1, 0]).unwrap();
+    let exec: &mut dyn BackendSession = &mut gpu;
+
+    exec.copy_read_into(
+        TensorRead::from_tensor(&gpu_src),
+        TensorWrite::from_view(TensorViewMut::I32(dst_view)),
+    )
+    .unwrap();
+
+    let actual = download(&gpu, &gpu_dst);
+    assert_eq!(actual.as_slice::<i32>().unwrap(), &[1, 3, 2, 4]);
 }
 
 #[test]

--- a/crates/tenferro-gpu/src/webgpu/mod.rs
+++ b/crates/tenferro-gpu/src/webgpu/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     DType, DeviceId, DeviceKind, DotGeneralConfig, Error, GatherConfig, GpuBackendKind, MemoryKind,
     PadConfig, Placement, ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend,
     TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
-    TensorReduction, TensorStructural, TypedTensor,
+    TensorRead, TensorReduction, TensorStructural, TensorWrite, TypedTensor,
 };
 
 const DEFAULT_CUBE_DIM_X: u32 = 256;
@@ -519,6 +519,14 @@ impl TensorAnalytic for WebGpuBackend {
 }
 
 impl TensorStructural for WebGpuBackend {
+    fn to_contiguous_read(&mut self, _input: TensorRead<'_>) -> crate::Result<Tensor> {
+        unsupported!("WebGpuBackend::to_contiguous_read")
+    }
+
+    fn copy_read_into(&mut self, _src: TensorRead<'_>, _dst: TensorWrite<'_>) -> crate::Result<()> {
+        unsupported!("WebGpuBackend::copy_read_into")
+    }
+
     fn transpose(&mut self, _input: &Tensor, _perm: &[usize]) -> crate::Result<Tensor> {
         unsupported!("webgpu_transpose")
     }

--- a/crates/tenferro-gpu/tests/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/public_surface_contract.rs
@@ -235,6 +235,20 @@ fn webgpu_provider_keeps_runtime_transfer_and_gemm_boundaries_split() {
 }
 
 #[test]
+fn webgpu_materialization_does_not_inherit_host_defaults() {
+    let webgpu_mod = repo_file("crates/tenferro-gpu/src/webgpu/mod.rs");
+    for (method, op) in [
+        ("fn to_contiguous_read", "WebGpuBackend::to_contiguous_read"),
+        ("fn copy_read_into", "WebGpuBackend::copy_read_into"),
+    ] {
+        assert!(
+            webgpu_mod.contains(method) && webgpu_mod.contains(op),
+            "WebGPU must explicitly reject {method} instead of inheriting host defaults"
+        );
+    }
+}
+
+#[test]
 fn cubecl_output_allocations_use_checked_shape_products() {
     let dispatch = repo_file("crates/tenferro-gpu/src/cubecl/dispatch.rs");
     assert!(

--- a/crates/tenferro-gpu/tests/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/public_surface_contract.rs
@@ -353,16 +353,19 @@ fn cubecl_runtime_materialization_and_copy_stay_device_owned_and_typed() {
             "CUDA TensorStructural must override {method}"
         );
     }
-    for variant in ["F32", "F64", "I32", "I64", "Bool", "C32", "C64"] {
-        assert!(
-            runtime_methods.contains(variant),
-            "CUDA runtime read/copy dispatch must account for {variant}"
-        );
-    }
     assert!(
-        runtime_methods.contains("TensorViewCanonicalization::to_contiguous")
-            && runtime_methods.contains("TensorViewCanonicalization::copy_into"),
-        "CUDA runtime read/copy methods must reuse same-device typed paths"
+        runtime_methods.contains("to_contiguous_view_typed")
+            && runtime_methods.contains("\"CudaBackend::to_contiguous_read\""),
+        "CUDA erased materialization must reuse the typed path with its own operation name"
+    );
+    assert!(
+        runtime_methods.contains("copy_view_to_view_typed")
+            && runtime_methods.contains("\"CudaBackend::copy_read_into\""),
+        "CUDA erased copy must reuse the typed path with its own operation name"
+    );
+    assert!(
+        runtime_methods.contains("unsupported_dtype") && runtime_methods.contains("DType::Bool"),
+        "CUDA Bool erased materialization/copy must remain explicit unsupported paths"
     );
     assert!(
         !runtime_methods.contains("download_tensor(")
@@ -381,6 +384,22 @@ fn cubecl_runtime_materialization_and_copy_stay_device_owned_and_typed() {
     assert!(copy_helper.contains("ensure_view_mut_resident_on_runtime"));
     assert!(copy_helper.contains("Arc::ptr_eq(source_buffer, destination_buffer)"));
     assert!(copy_helper.contains("compact source view covering its full allocation"));
+}
+
+#[test]
+fn cuda_runtime_materialization_limitations_are_documented() {
+    let design = repo_file("docs/design/gpu-backend-design.md");
+    let guide = repo_file("docs/guides/devices-and-gpu.md");
+
+    for document in [&design, &guide] {
+        let rendered_text = document.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert!(rendered_text.contains("to_contiguous_read"));
+        assert!(rendered_text.contains("copy_read_into"));
+        assert!(rendered_text.contains("offset zero"));
+        assert!(rendered_text.contains("full allocation"));
+        assert!(rendered_text.contains("Bool"));
+        assert!(rendered_text.contains("must not alias"));
+    }
 }
 
 #[test]

--- a/crates/tenferro-gpu/tests/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/public_surface_contract.rs
@@ -276,6 +276,24 @@ fn cubecl_structural_shape_arithmetic_is_checked() {
 }
 
 #[test]
+fn cubecl_copy_into_validates_both_views_on_the_active_runtime() {
+    let cubecl_mod = repo_file("crates/tenferro-gpu/src/cubecl/mod.rs");
+    let copy_body = cubecl_mod
+        .split_once("fn copy_view_to_view_typed")
+        .expect("CUDA copy-view helper must exist")
+        .1
+        .split_once("fn convert_float_to_float")
+        .expect("CUDA copy-view helper must precede conversion helpers")
+        .0;
+
+    assert!(
+        copy_body.contains("ensure_view_resident_on_runtime(self.runtime(), src, op)?;")
+            && copy_body.contains("ensure_view_mut_resident_on_runtime(self.runtime(), dst, op)?;"),
+        "CUDA copy_into must validate source and destination views against the active runtime"
+    );
+}
+
+#[test]
 fn cubecl_gemm_contracting_element_product_is_checked() {
     let gemm = repo_file("crates/tenferro-gpu/src/cubecl/gemm.rs");
     assert!(

--- a/crates/tenferro-gpu/tests/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/public_surface_contract.rs
@@ -294,6 +294,42 @@ fn cubecl_copy_into_validates_both_views_on_the_active_runtime() {
 }
 
 #[test]
+fn cubecl_copy_into_rejects_aliased_backend_allocations() {
+    let cubecl_mod = repo_file("crates/tenferro-gpu/src/cubecl/mod.rs");
+    let copy_body = cubecl_mod
+        .split_once("fn copy_view_to_view_typed")
+        .expect("CUDA copy-view helper must exist")
+        .1
+        .split_once("fn convert_float_to_float")
+        .expect("CUDA copy-view helper must precede conversion helpers")
+        .0;
+
+    assert!(
+        copy_body.contains("Arc::ptr_eq(source_buffer, destination_buffer)"),
+        "CUDA copy_into must reject source and destination views backed by the same allocation"
+    );
+}
+
+#[test]
+fn cubecl_copy_into_reports_typed_shape_mismatch() {
+    let cubecl_mod = repo_file("crates/tenferro-gpu/src/cubecl/mod.rs");
+    let copy_body = cubecl_mod
+        .split_once("fn copy_view_to_view_typed")
+        .expect("CUDA copy-view helper must exist")
+        .1
+        .split_once("fn convert_float_to_float")
+        .expect("CUDA copy-view helper must precede conversion helpers")
+        .0;
+
+    assert!(
+        copy_body.contains("crate::Error::ShapeMismatch")
+            && copy_body.contains("lhs: src.shape().to_vec()")
+            && copy_body.contains("rhs: dst.shape().to_vec()"),
+        "CUDA copy_into shape mismatch must use the shared typed error"
+    );
+}
+
+#[test]
 fn cubecl_gemm_contracting_element_product_is_checked() {
     let gemm = repo_file("crates/tenferro-gpu/src/cubecl/gemm.rs");
     assert!(

--- a/crates/tenferro-gpu/tests/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/public_surface_contract.rs
@@ -330,6 +330,60 @@ fn cubecl_copy_into_reports_typed_shape_mismatch() {
 }
 
 #[test]
+fn cubecl_runtime_materialization_and_copy_stay_device_owned_and_typed() {
+    let cubecl_mod = repo_file("crates/tenferro-gpu/src/cubecl/mod.rs");
+    let structural = cubecl_mod
+        .split_once("impl TensorStructural for CudaBackend")
+        .expect("CUDA structural implementation must exist")
+        .1
+        .split_once("impl TensorReduction for CudaBackend")
+        .expect("CUDA structural implementation must precede reductions")
+        .0;
+    let runtime_methods = structural
+        .split_once("fn to_contiguous_read(")
+        .expect("CUDA runtime materialization override must exist")
+        .1
+        .split_once("fn transpose(")
+        .expect("CUDA runtime methods must precede transpose")
+        .0;
+
+    for method in ["fn to_contiguous_read(", "fn copy_read_into("] {
+        assert!(
+            structural.contains(method),
+            "CUDA TensorStructural must override {method}"
+        );
+    }
+    for variant in ["F32", "F64", "I32", "I64", "Bool", "C32", "C64"] {
+        assert!(
+            runtime_methods.contains(variant),
+            "CUDA runtime read/copy dispatch must account for {variant}"
+        );
+    }
+    assert!(
+        runtime_methods.contains("TensorViewCanonicalization::to_contiguous")
+            && runtime_methods.contains("TensorViewCanonicalization::copy_into"),
+        "CUDA runtime read/copy methods must reuse same-device typed paths"
+    );
+    assert!(
+        !runtime_methods.contains("download_tensor(")
+            && !runtime_methods.contains("upload_tensor("),
+        "CUDA runtime materialization/copy must not transfer payloads through host memory"
+    );
+
+    let copy_helper = cubecl_mod
+        .split_once("fn copy_view_to_view_typed")
+        .expect("CUDA copy-view helper must exist")
+        .1
+        .split_once("fn convert_float_to_float")
+        .expect("CUDA copy-view helper must precede conversion helpers")
+        .0;
+    assert!(copy_helper.contains("ensure_view_resident_on_runtime"));
+    assert!(copy_helper.contains("ensure_view_mut_resident_on_runtime"));
+    assert!(copy_helper.contains("Arc::ptr_eq(source_buffer, destination_buffer)"));
+    assert!(copy_helper.contains("compact source view covering its full allocation"));
+}
+
+#[test]
 fn cubecl_gemm_contracting_element_product_is_checked() {
     let gemm = repo_file("crates/tenferro-gpu/src/cubecl/gemm.rs");
     assert!(

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -641,10 +641,13 @@ fn execute_linalg_extension_reads<B: LinalgBackend + 'static>(
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
     // Linalg backends currently operate on compact tensors; materialization is
     // explicit here so borrowed views cannot silently bypass backend errors.
-    let materialized_inputs: Vec<Tensor> = inputs
-        .iter()
-        .map(TensorRead::to_tensor)
-        .collect::<tenferro_tensor::Result<_>>()?;
+    let materialized_inputs = ctx.backend_mut().with_backend_session(|exec| {
+        inputs
+            .iter()
+            .cloned()
+            .map(|input| exec.to_contiguous_read(input))
+            .collect::<tenferro_tensor::Result<Vec<_>>>()
+    })?;
     let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
     execute_linalg_extension(op, &input_refs, ctx)
 }

--- a/crates/tenferro-runtime/src/exec.rs
+++ b/crates/tenferro-runtime/src/exec.rs
@@ -164,19 +164,26 @@ impl<'a> ExecSlot<'a> {
         }
     }
 
-    pub(crate) fn into_tensor(self) -> Result<Tensor> {
+    pub(crate) fn into_tensor(self, exec: &mut dyn BackendSession) -> Result<Tensor> {
         match self {
             Self::Owned(tensor) => Ok(tensor),
-            Self::Value(value) => Ok(value.to_tensor()?),
-            Self::Read(read) => Ok(read.to_tensor()?),
+            Self::Value(TensorValue::Tensor(tensor)) => Ok(tensor.as_ref().clone()),
+            Self::Value(TensorValue::View(view)) => {
+                Ok(exec.to_contiguous_read(view.tensor_read())?)
+            }
+            Self::Read(TensorRead::Tensor(tensor)) => Ok(tensor.clone()),
+            Self::Read(read @ TensorRead::View(_)) => Ok(exec.to_contiguous_read(read)?),
         }
     }
 
-    pub(crate) fn into_value(self) -> Result<TensorValue> {
+    pub(crate) fn into_value(self, exec: &mut dyn BackendSession) -> Result<TensorValue> {
         match self {
             Self::Owned(tensor) => Ok(TensorValue::from_tensor(tensor)),
             Self::Value(value) => Ok(value),
-            Self::Read(read) => Ok(TensorValue::from_tensor(read.to_tensor()?)),
+            Self::Read(TensorRead::Tensor(tensor)) => Ok(TensorValue::from_tensor(tensor.clone())),
+            Self::Read(read @ TensorRead::View(_)) => {
+                Ok(TensorValue::from_tensor(exec.to_contiguous_read(read)?))
+            }
         }
     }
 }
@@ -410,13 +417,14 @@ pub(crate) fn initialize_exec_slots_in<'input>(
 pub(crate) fn collect_outputs_from<'input>(
     program: &ExecProgram,
     slots: &mut [Option<ExecSlot<'input>>],
+    exec: &mut dyn BackendSession,
 ) -> Result<Vec<Tensor>> {
     program
         .output_slots
         .iter()
         .map(|&slot| {
             let value = take_slot(slots, slot, "output", "collect_outputs_from")?;
-            value.into_tensor()
+            value.into_tensor(exec)
         })
         .collect()
 }
@@ -424,13 +432,14 @@ pub(crate) fn collect_outputs_from<'input>(
 pub(crate) fn collect_output_values_from<'input>(
     program: &ExecProgram,
     slots: &mut [Option<ExecSlot<'input>>],
+    exec: &mut dyn BackendSession,
 ) -> Result<Vec<TensorValue>> {
     program
         .output_slots
         .iter()
         .map(|&slot| {
             let value = take_slot(slots, slot, "output", "collect_output_values_from")?;
-            value.into_value()
+            value.into_value(exec)
         })
         .collect()
 }
@@ -457,6 +466,7 @@ pub(crate) fn terminal_output_slots(program: &ExecProgram) -> Vec<bool> {
 }
 
 pub(crate) fn try_execute_terminal_value_instruction<'input>(
+    exec: &mut dyn BackendSession,
     slots: &mut [Option<ExecSlot<'input>>],
     inst: &ExecInstruction,
     terminal_slots: &[bool],
@@ -477,14 +487,14 @@ pub(crate) fn try_execute_terminal_value_instruction<'input>(
         ExecOp::Transpose { perm } => {
             let input_slot = inst.input_slots[0];
             let consume_input = inst.last_use.first().copied().unwrap_or(false);
-            let input = tensor_value_for_lazy_view(slots, input_slot, consume_input)?;
+            let input = tensor_value_for_lazy_view(exec, slots, input_slot, consume_input)?;
             input.transpose_view(perm).map_err(Error::TensorRuntime)?
         }
         ExecOp::Reshape { shape } => {
             let input_slot = inst.input_slots[0];
             let consume_input = inst.last_use.first().copied().unwrap_or(false);
             let shape = resolve_tensor_shape_exprs(slots, &inst.input_slots, shape)?;
-            let input = tensor_value_for_lazy_view(slots, input_slot, consume_input)?;
+            let input = tensor_value_for_lazy_view(exec, slots, input_slot, consume_input)?;
             match input.reshape_view(&shape) {
                 Ok(value) => value,
                 Err(_) => {
@@ -499,7 +509,7 @@ pub(crate) fn try_execute_terminal_value_instruction<'input>(
             let input_slot = inst.input_slots[0];
             let consume_input = inst.last_use.first().copied().unwrap_or(false);
             let shape = resolve_tensor_shape_exprs(slots, &inst.input_slots, shape)?;
-            let input = tensor_value_for_lazy_view(slots, input_slot, consume_input)?;
+            let input = tensor_value_for_lazy_view(exec, slots, input_slot, consume_input)?;
             input
                 .broadcast_in_dim_view(&shape, dims)
                 .map_err(Error::TensorRuntime)?
@@ -507,7 +517,7 @@ pub(crate) fn try_execute_terminal_value_instruction<'input>(
         ExecOp::Slice(config) => {
             let input_slot = inst.input_slots[0];
             let consume_input = inst.last_use.first().copied().unwrap_or(false);
-            let input = tensor_value_for_lazy_view(slots, input_slot, consume_input)?;
+            let input = tensor_value_for_lazy_view(exec, slots, input_slot, consume_input)?;
             input.slice_view(config).map_err(Error::TensorRuntime)?
         }
         _ => return Ok(false),
@@ -517,13 +527,14 @@ pub(crate) fn try_execute_terminal_value_instruction<'input>(
 }
 
 fn tensor_value_for_lazy_view<'input>(
+    exec: &mut dyn BackendSession,
     slots: &mut [Option<ExecSlot<'input>>],
     slot: usize,
     consume: bool,
 ) -> Result<TensorValue> {
     if consume {
         let value = take_slot(slots, slot, "input", "tensor_value_for_lazy_view")?;
-        return value.into_value();
+        return value.into_value(exec);
     }
 
     let slot = checked_slot_index(slot, slots.len(), "input", "tensor_value_for_lazy_view")?;
@@ -540,7 +551,7 @@ fn tensor_value_for_lazy_view<'input>(
             Ok(output)
         }
         Some(ExecSlot::Read(read)) => {
-            let output = TensorValue::from_tensor(read.to_tensor()?);
+            let output = TensorValue::from_tensor(exec.to_contiguous_read(read.clone())?);
             slots[slot] = Some(ExecSlot::Read(read));
             Ok(output)
         }
@@ -692,7 +703,7 @@ pub(crate) fn eval_exec_ir_unsegmented_slots_with_cache_and_workspace<
             reclaim_last_use_inputs_backend(slots, inst, backend);
         }
 
-        collect_outputs_from(program, slots)
+        backend.with_backend_session(|exec| collect_outputs_from(program, slots, exec))
     })();
     slots.clear();
     result
@@ -715,7 +726,9 @@ pub(crate) fn eval_exec_ir_unsegmented_slot_values_with_cache_and_workspace<
         let terminal_slots = terminal_output_slots(program);
 
         for (inst_idx, inst) in program.instructions.iter().enumerate() {
-            if try_execute_terminal_value_instruction(slots, inst, &terminal_slots)? {
+            if backend.with_backend_session(|exec| {
+                try_execute_terminal_value_instruction(exec, slots, inst, &terminal_slots)
+            })? {
                 // Already handled as a metadata-only TensorValue.
             } else if is_host_instruction(inst) {
                 execute_host_instruction(backend, slots, inst)?;
@@ -737,7 +750,7 @@ pub(crate) fn eval_exec_ir_unsegmented_slot_values_with_cache_and_workspace<
             reclaim_last_use_inputs_backend(slots, inst, backend);
         }
 
-        collect_output_values_from(program, slots)
+        backend.with_backend_session(|exec| collect_output_values_from(program, slots, exec))
     })();
     slots.clear();
     result
@@ -761,7 +774,7 @@ pub(crate) fn eval_exec_ir_single_session_slots_with_workspace<'input, B: Tensor
         validate_exec_program(program, "single-session executor")?;
         initialize_exec_slots_in(program, inputs, slots)?;
 
-        backend.with_backend_session_cached(backend_cache, |exec| -> Result<()> {
+        backend.with_backend_session_cached(backend_cache, |exec| {
             for (inst_idx, inst) in program.instructions.iter().enumerate() {
                 if is_host_instruction(inst) {
                     execute_host_instruction_exec(exec, slots, inst)?;
@@ -773,10 +786,8 @@ pub(crate) fn eval_exec_ir_single_session_slots_with_workspace<'input, B: Tensor
                 }
                 reclaim_last_use_inputs_exec(slots, inst, exec);
             }
-            Ok(())
-        })?;
-
-        collect_outputs_from(program, slots)
+            collect_outputs_from(program, slots, exec)
+        })
     })();
     slots.clear();
     result

--- a/crates/tenferro-runtime/src/exec/tests.rs
+++ b/crates/tenferro-runtime/src/exec/tests.rs
@@ -7,8 +7,8 @@ use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::{ShapeExtent, SymDim};
 use tenferro_tensor::{
-    CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
-    Tensor,
+    BackendSessionHost, CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig,
+    ScatterConfig, SliceConfig, Tensor,
 };
 
 use super::dispatch::{
@@ -144,8 +144,11 @@ fn exec_instruction_single_output_metadata_stays_inline() {
 fn lazy_view_input_conversion_shares_live_owned_tensor() {
     let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let mut slots = vec![Some(ExecSlot::Owned(tensor))];
+    let mut backend = CpuBackend::new();
 
-    let value = tensor_value_for_lazy_view(&mut slots, 0, false).unwrap();
+    let value = backend
+        .with_backend_session(|exec| tensor_value_for_lazy_view(exec, &mut slots, 0, false))
+        .unwrap();
 
     let output = value.as_tensor_arc().unwrap();
     let stored = match slots[0].as_ref().unwrap() {
@@ -205,7 +208,10 @@ fn collect_outputs_rejects_out_of_range_slot_without_panicking() {
         Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap(),
     ))];
 
-    let err = collect_outputs_from(&program, &mut slots).unwrap_err();
+    let mut backend = CpuBackend::new();
+    let err = backend
+        .with_backend_session(|exec| collect_outputs_from(&program, &mut slots, exec))
+        .unwrap_err();
 
     let message = err.to_string();
     assert!(message.contains("output slot 3"), "{message}");

--- a/crates/tenferro-runtime/src/extension_runtime.rs
+++ b/crates/tenferro-runtime/src/extension_runtime.rs
@@ -221,10 +221,13 @@ impl<B: TensorBackend + 'static> ExtensionRuntime<B> for HostReferenceRuntime<B>
         inputs: &[TensorRead<'_>],
         ctx: &mut ExtensionExecutionContext<'_, B>,
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
-        let materialized_inputs: Vec<Tensor> = inputs
-            .iter()
-            .map(TensorRead::to_tensor)
-            .collect::<tenferro_tensor::Result<_>>()?;
+        let materialized_inputs = ctx.backend_mut().with_backend_session(|exec| {
+            inputs
+                .iter()
+                .cloned()
+                .map(|input| exec.to_contiguous_read(input))
+                .collect::<tenferro_tensor::Result<Vec<_>>>()
+        })?;
         let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
         self.execute(op, &input_refs, ctx)
     }

--- a/crates/tenferro-runtime/src/graph/executor.rs
+++ b/crates/tenferro-runtime/src/graph/executor.rs
@@ -98,6 +98,34 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
         &self.backend
     }
 
+    /// Materialize an executor value as a compact tensor on its current placement.
+    ///
+    /// Compact owned values are cloned without backend dispatch. Lazy views are
+    /// canonicalized by this executor's active backend session, preserving its
+    /// allocation, threading, and device-placement policy.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_runtime::GraphExecutor;
+    /// use tenferro_tensor::{Tensor, TensorValue};
+    ///
+    /// let tensor = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    /// let value = TensorValue::from_tensor(tensor).transpose_view([1, 0]).unwrap();
+    /// let mut executor = GraphExecutor::new(CpuBackend::new());
+    /// let compact = executor.materialize_value(&value).unwrap();
+    /// assert_eq!(compact.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
+    /// ```
+    pub fn materialize_value(&mut self, value: &TensorValue) -> Result<Tensor> {
+        if let Some(tensor) = value.as_tensor_arc() {
+            return Ok(tensor.as_ref().clone());
+        }
+        self.backend
+            .with_backend_session(|exec| exec.to_contiguous_read(value.tensor_read()))
+            .map_err(Error::from)
+    }
+
     /// Return output tensors to the executor backend's reusable buffer pool.
     ///
     /// This is useful for tight benchmark or serving loops that consume an
@@ -244,7 +272,7 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// assert!(matches!(&value, TensorValue::View(_)));
     /// assert_eq!(value.shape(), &[3, 2]);
     /// assert_eq!(
-    ///     value.to_tensor().unwrap().as_slice::<f64>().unwrap(),
+    ///     executor.materialize_value(&value).unwrap().as_slice::<f64>().unwrap(),
     ///     &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
     /// );
     /// ```
@@ -346,7 +374,7 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     ///
     /// let value = executor.run_value_with_inputs(&program, &[(&x, &bound)]).unwrap();
     /// assert!(matches!(&value, TensorValue::View(_)));
-    /// assert_eq!(value.to_tensor().unwrap().as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
+    /// assert_eq!(executor.materialize_value(&value).unwrap().as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
     /// ```
     pub fn run_value_with_inputs(
         &mut self,
@@ -684,7 +712,7 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     ///
     /// let value = executor.run_value(&program).unwrap();
     /// assert!(matches!(&value, TensorValue::View(_)));
-    /// assert_eq!(value.to_tensor().unwrap().shape(), &[2, 2]);
+    /// assert_eq!(executor.materialize_value(&value).unwrap().shape(), &[2, 2]);
     /// ```
     pub fn eval_exec_ir_non_consuming_values(
         &mut self,

--- a/crates/tenferro-runtime/src/graph/executor/tests.rs
+++ b/crates/tenferro-runtime/src/graph/executor/tests.rs
@@ -7,7 +7,7 @@ use std::sync::{
 
 use tenferro_cpu::CpuBackend;
 use tenferro_ops::{dim_expr::DimExpr, ext_op::ExtensionOp, ShapeRelation, SymDim};
-use tenferro_tensor::{DType, Tensor, TensorRead, TensorValue, TypedTensor};
+use tenferro_tensor::{BackendSessionHost, DType, Tensor, TensorRead, TensorValue, TypedTensor};
 
 use super::GraphExecutor;
 use crate::exec::{ExecInstruction, ExecOp, ExecProgram};
@@ -81,10 +81,12 @@ impl ExtensionRuntime<CpuBackend> for CountedIdentityRuntime {
         &self,
         _op: &dyn ExtensionOp,
         inputs: &[TensorRead<'_>],
-        _ctx: &mut ExtensionExecutionContext<'_, CpuBackend>,
+        ctx: &mut ExtensionExecutionContext<'_, CpuBackend>,
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
         self.calls.fetch_add(1, Ordering::Relaxed);
-        Ok(vec![inputs[0].to_tensor()?])
+        Ok(vec![ctx.backend_mut().with_backend_session(|exec| {
+            exec.to_contiguous_read(inputs[0].clone())
+        })?])
     }
 }
 

--- a/crates/tenferro-runtime/src/graph/executor/tests/preflight.rs
+++ b/crates/tenferro-runtime/src/graph/executor/tests/preflight.rs
@@ -26,6 +26,8 @@ struct CountingBackend {
     dispatches: Arc<AtomicUsize>,
     session_entries: Arc<AtomicUsize>,
     session_depth: Arc<AtomicUsize>,
+    materializations: Arc<AtomicUsize>,
+    materializer: tenferro_cpu::CpuBackend,
 }
 
 macro_rules! unreachable_backend_methods {
@@ -91,6 +93,11 @@ impl TensorAnalytic for CountingBackend {
 }
 
 impl TensorStructural for CountingBackend {
+    fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Tensor> {
+        self.materializations.fetch_add(1, Ordering::Relaxed);
+        self.materializer.to_contiguous_read(input)
+    }
+
     unreachable_backend_methods! {
         transpose(input: &Tensor, perm: &[usize]) -> tenferro_tensor::Result<Tensor>;
         reshape(input: &Tensor, shape: &[usize]) -> tenferro_tensor::Result<Tensor>;
@@ -165,6 +172,7 @@ fn counting_backend() -> (
     let dispatches = Arc::new(AtomicUsize::new(0));
     let session_entries = Arc::new(AtomicUsize::new(0));
     let session_depth = Arc::new(AtomicUsize::new(0));
+    let materializations = Arc::new(AtomicUsize::new(0));
     (
         CountingBackend {
             uploads: uploads.clone(),
@@ -172,11 +180,31 @@ fn counting_backend() -> (
             dispatches: dispatches.clone(),
             session_entries: session_entries.clone(),
             session_depth,
+            materializations,
+            materializer: tenferro_cpu::CpuBackend::new(),
         },
         uploads,
         dispatches,
         session_entries,
     )
+}
+
+#[test]
+fn runtime_materialization_uses_backend() {
+    let (backend, _, _, _) = counting_backend();
+    let materializations = Arc::clone(&backend.materializations);
+    let mut executor = GraphExecutor::new(backend);
+    let tensor = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+
+    let owned = tenferro_tensor::TensorValue::from_tensor(tensor);
+    let compact = executor.materialize_value(&owned).unwrap();
+    assert_eq!(compact.as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(materializations.load(Ordering::Relaxed), 0);
+
+    let view = owned.transpose_view([1, 0]).unwrap();
+    let compact = executor.materialize_value(&view).unwrap();
+    assert_eq!(compact.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
+    assert_eq!(materializations.load(Ordering::Relaxed), 1);
 }
 
 #[test]
@@ -192,6 +220,8 @@ fn host_native_and_session_ffi_share_one_backend_session() {
         dispatches: dispatches.clone(),
         session_entries: session_entries.clone(),
         session_depth,
+        materializations: Arc::new(AtomicUsize::new(0)),
+        materializer: tenferro_cpu::CpuBackend::new(),
     };
     let program = ExecProgram {
         instructions: vec![

--- a/crates/tenferro-runtime/src/segment.rs
+++ b/crates/tenferro-runtime/src/segment.rs
@@ -287,7 +287,7 @@ pub(crate) fn eval_exec_segmented_slots_with_cache_and_workspace<
             }
         }
 
-        collect_outputs_from(program, slots)
+        backend.with_backend_session(|exec| collect_outputs_from(program, slots, exec))
     })();
     slots.clear();
     result
@@ -354,7 +354,9 @@ pub(crate) fn eval_exec_segmented_slot_values_with_cache_and_workspace<
                     inst_idx += instructions.len();
                 }
                 Segment::Ffi(inst) => {
-                    if try_execute_terminal_value_instruction(slots, inst, &terminal_slots)? {
+                    if backend.with_backend_session(|exec| {
+                        try_execute_terminal_value_instruction(exec, slots, inst, &terminal_slots)
+                    })? {
                         // Already handled as a metadata-only TensorValue.
                     } else {
                         execute_ffi_instruction_cached(
@@ -371,7 +373,9 @@ pub(crate) fn eval_exec_segmented_slot_values_with_cache_and_workspace<
                     inst_idx += 1;
                 }
                 Segment::Host(inst) => {
-                    if try_execute_terminal_value_instruction(slots, inst, &terminal_slots)? {
+                    if backend.with_backend_session(|exec| {
+                        try_execute_terminal_value_instruction(exec, slots, inst, &terminal_slots)
+                    })? {
                         // Already handled as a metadata-only TensorValue.
                     } else {
                         execute_host_instruction(backend, slots, inst)?;
@@ -382,7 +386,7 @@ pub(crate) fn eval_exec_segmented_slot_values_with_cache_and_workspace<
             }
         }
 
-        collect_output_values_from(program, slots)
+        backend.with_backend_session(|exec| collect_output_values_from(program, slots, exec))
     })();
     slots.clear();
     result
@@ -399,7 +403,7 @@ fn eval_exec_segmented_single_session_slots_with_workspace<'input, B: TensorBack
         initialize_exec_slots_in(program, inputs, slots)?;
         let segments = segment_exec_program(program);
 
-        backend.with_backend_session_cached(backend_cache, |exec| -> Result<()> {
+        backend.with_backend_session_cached(backend_cache, |exec| {
             let mut inst_idx = 0usize;
             for segment in &segments {
                 match segment {
@@ -430,10 +434,8 @@ fn eval_exec_segmented_single_session_slots_with_workspace<'input, B: TensorBack
                     Segment::Ffi(_) | Segment::Host(_) => 1,
                 };
             }
-            Ok(())
-        })?;
-
-        collect_outputs_from(program, slots)
+            collect_outputs_from(program, slots, exec)
+        })
     })();
     slots.clear();
     result
@@ -451,7 +453,7 @@ fn eval_exec_segmented_single_session_slot_values_with_workspace<'input, B: Tens
         let terminal_slots = terminal_output_slots(program);
         let segments = segment_exec_program(program);
 
-        backend.with_backend_session_cached(backend_cache, |exec| -> Result<()> {
+        backend.with_backend_session_cached(backend_cache, |exec| {
             let mut inst_idx = 0usize;
             for segment in &segments {
                 match segment {
@@ -470,13 +472,23 @@ fn eval_exec_segmented_single_session_slot_values_with_workspace<'input, B: Tens
                         &terminal_slots,
                     )?,
                     Segment::Ffi(inst) => {
-                        if !try_execute_terminal_value_instruction(slots, inst, &terminal_slots)? {
+                        if !try_execute_terminal_value_instruction(
+                            exec,
+                            slots,
+                            inst,
+                            &terminal_slots,
+                        )? {
                             execute_ffi_instruction_exec(exec, slots, inst, Some(inst_idx))?;
                         }
                         reclaim_last_use_inputs_exec(slots, inst, exec);
                     }
                     Segment::Host(inst) => {
-                        if !try_execute_terminal_value_instruction(slots, inst, &terminal_slots)? {
+                        if !try_execute_terminal_value_instruction(
+                            exec,
+                            slots,
+                            inst,
+                            &terminal_slots,
+                        )? {
                             execute_host_instruction_exec(exec, slots, inst)?;
                         }
                         reclaim_last_use_inputs_exec(slots, inst, exec);
@@ -487,10 +499,8 @@ fn eval_exec_segmented_single_session_slot_values_with_workspace<'input, B: Tens
                     Segment::Ffi(_) | Segment::Host(_) => 1,
                 };
             }
-            Ok(())
-        })?;
-
-        collect_output_values_from(program, slots)
+            collect_output_values_from(program, slots, exec)
+        })
     })();
     slots.clear();
     result
@@ -608,7 +618,7 @@ fn execute_fused_value_segment(
     }
 
     for inst in instructions {
-        if !try_execute_terminal_value_instruction(slots, inst, terminal_slots)? {
+        if !try_execute_terminal_value_instruction(exec, slots, inst, terminal_slots)? {
             let result = execute_backend_op(exec, slots, inst)?;
             slots[inst.output_slots[0]] = Some(ExecSlot::Owned(result));
         }

--- a/crates/tenferro-runtime/tests/extension_runtime.rs
+++ b/crates/tenferro-runtime/tests/extension_runtime.rs
@@ -13,8 +13,8 @@ use tenferro_runtime::{
     HostReferenceRuntime,
 };
 use tenferro_tensor::{
-    Buffer, BufferHandle, DType, MemoryKind, Placement, Tensor, TensorOwnedView, TensorRead,
-    TypedTensor,
+    BackendSessionHost, Buffer, BufferHandle, DType, MemoryKind, Placement, Tensor,
+    TensorOwnedView, TensorRead, TypedTensor,
 };
 
 #[derive(Clone, Debug)]
@@ -148,10 +148,13 @@ impl ExtensionRuntime<CpuBackend> for IdentityRuntime {
         inputs: &[TensorRead<'_>],
         ctx: &mut ExtensionExecutionContext<'_, CpuBackend>,
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
-        let materialized_inputs: Vec<Tensor> = inputs
-            .iter()
-            .map(TensorRead::to_tensor)
-            .collect::<tenferro_tensor::Result<_>>()?;
+        let materialized_inputs = ctx.backend_mut().with_backend_session(|exec| {
+            inputs
+                .iter()
+                .cloned()
+                .map(|input| exec.to_contiguous_read(input))
+                .collect::<tenferro_tensor::Result<Vec<_>>>()
+        })?;
         let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
         self.execute(op, &input_refs, ctx)
     }
@@ -185,10 +188,13 @@ impl ExtensionRuntime<CpuBackend> for WrongOutputCountRuntime {
         inputs: &[TensorRead<'_>],
         ctx: &mut ExtensionExecutionContext<'_, CpuBackend>,
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
-        let materialized_inputs: Vec<Tensor> = inputs
-            .iter()
-            .map(TensorRead::to_tensor)
-            .collect::<tenferro_tensor::Result<_>>()?;
+        let materialized_inputs = ctx.backend_mut().with_backend_session(|exec| {
+            inputs
+                .iter()
+                .cloned()
+                .map(|input| exec.to_contiguous_read(input))
+                .collect::<tenferro_tensor::Result<Vec<_>>>()
+        })?;
         let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
         self.execute(op, &input_refs, ctx)
     }
@@ -427,10 +433,13 @@ fn extension_executor_read_fallback_reports_backend_view_materialization_error_w
         .expect_err("backend view materialization should error");
     let message = err.to_string();
     assert!(
-        message.contains("backend buffers cannot be materialized"),
+        message.contains("CpuBackend::to_contiguous_read"),
         "{message}"
     );
-    assert!(message.contains("download explicitly first"), "{message}");
+    assert!(
+        message.contains("download to host before CPU execution"),
+        "{message}"
+    );
 }
 
 #[test]

--- a/crates/tenferro-runtime/tests/runtime_public_api.rs
+++ b/crates/tenferro-runtime/tests/runtime_public_api.rs
@@ -367,7 +367,11 @@ fn graph_executor_can_return_final_transpose_as_lazy_value() {
         TensorValue::Tensor(_) => panic!("final transpose should stay as a lazy owned view"),
     }
     assert_eq!(
-        values[0].to_tensor().unwrap().as_slice::<f64>().unwrap(),
+        executor
+            .materialize_value(&values[0])
+            .unwrap()
+            .as_slice::<f64>()
+            .unwrap(),
         &[2.0, 6.0, 10.0, 4.0, 8.0, 12.0]
     );
 }

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -1305,7 +1305,7 @@ impl ElementwiseFusionInst {
 ///
 /// fn accepts_elementwise<B: TensorElementwise>(_backend: &mut B) {}
 /// ```
-pub trait TensorElementwise {
+pub trait TensorElementwise: TensorStructural {
     fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
 
     /// Elementwise addition accepting either owned tensors or borrowed views.
@@ -1378,10 +1378,10 @@ pub trait TensorElementwise {
         &mut self,
         lhs: TensorRead<'_>,
         rhs: TensorRead<'_>,
-        mut out: TensorWrite<'_>,
+        out: TensorWrite<'_>,
     ) -> crate::Result<()> {
         let result = self.add_read(lhs, rhs)?;
-        out.copy_from_tensor(&result)
+        self.copy_read_into(TensorRead::from_tensor(&result), out)
     }
 
     fn sub(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
@@ -1419,10 +1419,10 @@ pub trait TensorElementwise {
         &mut self,
         lhs: TensorRead<'_>,
         rhs: TensorRead<'_>,
-        mut out: TensorWrite<'_>,
+        out: TensorWrite<'_>,
     ) -> crate::Result<()> {
         let result = self.sub_read(lhs, rhs)?;
-        out.copy_from_tensor(&result)
+        self.copy_read_into(TensorRead::from_tensor(&result), out)
     }
 
     fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
@@ -1444,10 +1444,10 @@ pub trait TensorElementwise {
         &mut self,
         lhs: TensorRead<'_>,
         rhs: TensorRead<'_>,
-        mut out: TensorWrite<'_>,
+        out: TensorWrite<'_>,
     ) -> crate::Result<()> {
         let result = self.mul_read(lhs, rhs)?;
-        out.copy_from_tensor(&result)
+        self.copy_read_into(TensorRead::from_tensor(&result), out)
     }
 
     fn neg(&mut self, input: &Tensor) -> crate::Result<Tensor>;
@@ -1461,13 +1461,9 @@ pub trait TensorElementwise {
     }
 
     /// Overwrite caller-provided output with elementwise negation from a read.
-    fn neg_read_into(
-        &mut self,
-        input: TensorRead<'_>,
-        mut out: TensorWrite<'_>,
-    ) -> crate::Result<()> {
+    fn neg_read_into(&mut self, input: TensorRead<'_>, out: TensorWrite<'_>) -> crate::Result<()> {
         let result = self.neg_read(input)?;
-        out.copy_from_tensor(&result)
+        self.copy_read_into(TensorRead::from_tensor(&result), out)
     }
 
     fn conj(&mut self, input: &Tensor) -> crate::Result<Tensor>;
@@ -1481,13 +1477,9 @@ pub trait TensorElementwise {
     }
 
     /// Overwrite caller-provided output with elementwise conjugation from a read.
-    fn conj_read_into(
-        &mut self,
-        input: TensorRead<'_>,
-        mut out: TensorWrite<'_>,
-    ) -> crate::Result<()> {
+    fn conj_read_into(&mut self, input: TensorRead<'_>, out: TensorWrite<'_>) -> crate::Result<()> {
         let result = self.conj_read(input)?;
-        out.copy_from_tensor(&result)
+        self.copy_read_into(TensorRead::from_tensor(&result), out)
     }
 
     fn div(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
@@ -1509,10 +1501,10 @@ pub trait TensorElementwise {
         &mut self,
         lhs: TensorRead<'_>,
         rhs: TensorRead<'_>,
-        mut out: TensorWrite<'_>,
+        out: TensorWrite<'_>,
     ) -> crate::Result<()> {
         let result = self.div_read(lhs, rhs)?;
-        out.copy_from_tensor(&result)
+        self.copy_read_into(TensorRead::from_tensor(&result), out)
     }
 
     /// Elementwise remainder.
@@ -2031,8 +2023,8 @@ pub trait TensorDot: TensorElementwise {
         match (lhs.as_tensor(), rhs.as_tensor()) {
             (Some(lhs), Some(rhs)) => self.dot_general(lhs, rhs, config),
             _ => {
-                let lhs = lhs.to_tensor()?;
-                let rhs = rhs.to_tensor()?;
+                let lhs = self.to_contiguous_read(lhs)?;
+                let rhs = self.to_contiguous_read(rhs)?;
                 self.dot_general(&lhs, &rhs, config)
             }
         }
@@ -2118,14 +2110,14 @@ pub trait TensorDot: TensorElementwise {
         let lhs_ref = if let Some(tensor) = lhs.as_tensor() {
             tensor
         } else {
-            lhs_tmp = lhs.to_tensor()?;
+            lhs_tmp = self.to_contiguous_read(lhs)?;
             &lhs_tmp
         };
         let rhs_tmp;
         let rhs_ref = if let Some(tensor) = rhs.as_tensor() {
             tensor
         } else {
-            rhs_tmp = rhs.to_tensor()?;
+            rhs_tmp = self.to_contiguous_read(rhs)?;
             &rhs_tmp
         };
         self.dot_general_with_conj(lhs_ref, rhs_ref, config, lhs_conj, rhs_conj)
@@ -2198,8 +2190,8 @@ pub trait SessionCachedDot: TensorDot {
         match (lhs.as_tensor(), rhs.as_tensor()) {
             (Some(lhs), Some(rhs)) => self.dot_general_cached(cache_slot, lhs, rhs, config),
             _ => {
-                let lhs = lhs.to_tensor()?;
-                let rhs = rhs.to_tensor()?;
+                let lhs = self.to_contiguous_read(lhs)?;
+                let rhs = self.to_contiguous_read(rhs)?;
                 self.dot_general_cached(cache_slot, &lhs, &rhs, config)
             }
         }
@@ -2240,14 +2232,14 @@ pub trait SessionCachedDot: TensorDot {
         let lhs_ref = if let Some(tensor) = lhs.as_tensor() {
             tensor
         } else {
-            lhs_tmp = lhs.to_tensor()?;
+            lhs_tmp = self.to_contiguous_read(lhs)?;
             &lhs_tmp
         };
         let rhs_tmp;
         let rhs_ref = if let Some(tensor) = rhs.as_tensor() {
             tensor
         } else {
-            rhs_tmp = rhs.to_tensor()?;
+            rhs_tmp = self.to_contiguous_read(rhs)?;
             &rhs_tmp
         };
         self.dot_general_with_conj_cached(cache_slot, lhs_ref, rhs_ref, config, lhs_conj, rhs_conj)
@@ -2535,8 +2527,8 @@ pub trait BackendCachedDot: BackendRuntimeCache + TensorDot {
         match (lhs.as_tensor(), rhs.as_tensor()) {
             (Some(lhs), Some(rhs)) => self.dot_general_cached(cache, cache_slot, lhs, rhs, config),
             _ => {
-                let lhs = lhs.to_tensor()?;
-                let rhs = rhs.to_tensor()?;
+                let lhs = self.to_contiguous_read(lhs)?;
+                let rhs = self.to_contiguous_read(rhs)?;
                 self.dot_general_cached(cache, cache_slot, &lhs, &rhs, config)
             }
         }
@@ -2579,14 +2571,14 @@ pub trait BackendCachedDot: BackendRuntimeCache + TensorDot {
         let lhs_ref = if let Some(tensor) = lhs.as_tensor() {
             tensor
         } else {
-            lhs_tmp = lhs.to_tensor()?;
+            lhs_tmp = self.to_contiguous_read(lhs)?;
             &lhs_tmp
         };
         let rhs_tmp;
         let rhs_ref = if let Some(tensor) = rhs.as_tensor() {
             tensor
         } else {
-            rhs_tmp = rhs.to_tensor()?;
+            rhs_tmp = self.to_contiguous_read(rhs)?;
             &rhs_tmp
         };
         self.dot_general_with_conj_cached(

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -2,7 +2,8 @@ use crate::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
 use crate::types::{
-    Buffer, TensorRank, TensorView, TensorViewMut, TypedTensor, TypedTensorView, TypedTensorViewMut,
+    Buffer, TensorRank, TensorScalar, TensorView, TensorViewMut, TypedTensor, TypedTensorView,
+    TypedTensorViewMut,
 };
 use crate::validate::validate_convert_dtype;
 use crate::{DType, RuntimeCacheControl, Tensor, TensorRead, TensorValue, TensorWrite};
@@ -2265,16 +2266,24 @@ pub trait TensorIndexing {
 /// ) -> tenferro_tensor::Result<TypedTensor<i32>> {
 ///     backend.to_contiguous(&tensor.as_view())
 /// }
+///
+/// fn copy_i32<B: TensorViewCanonicalization<i32, DynRank>>(
+///     backend: &mut B,
+///     src: &TypedTensor<i32>,
+///     dst: &mut TypedTensor<i32>,
+/// ) -> tenferro_tensor::Result<()> {
+///     backend.copy_into(&src.as_view(), &mut dst.as_view_mut())
+/// }
 /// ```
-pub trait TensorViewCanonicalization<T: Clone + 'static, R: TensorRank> {
+pub trait TensorViewCanonicalization<T: TensorScalar, R: TensorRank> {
     fn to_contiguous(
         &mut self,
         view: &TypedTensorView<'_, T, R>,
     ) -> crate::Result<TypedTensor<T, R>>;
 
-    fn copy_from_contiguous(
+    fn copy_into(
         &mut self,
-        src: &TypedTensor<T, R>,
+        src: &TypedTensorView<'_, T, R>,
         dst: &mut TypedTensorViewMut<'_, T, R>,
     ) -> crate::Result<()>;
 }

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -2252,6 +2252,19 @@ pub trait TensorIndexing {
 /// backends canonicalize GPU-resident views on the same device and reject host
 /// buffers with an upload hint.
 ///
+/// [`TensorViewCanonicalization::copy_into`] requires source and destination
+/// shapes, scalar dtypes, and placement families to match. The destination
+/// view must be internally non-overlapping, and source and destination backing
+/// allocations must not alias unless an implementation explicitly documents
+/// and supports that case. Implementations may reject layouts their native
+/// kernels cannot consume.
+///
+/// CUDA currently accepts only a compact column-major source view with offset
+/// zero that covers its full allocation; arbitrary-stride destinations remain
+/// supported. Canonicalization and copying are same-placement operations: they
+/// must not perform hidden host/device transfers or silently materialize an
+/// unsupported source layout.
+///
 /// This trait is intentionally separate from [`BackendSession`] so generic
 /// typed methods do not change the object-safety contract of `dyn BackendSession`.
 ///

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -1698,19 +1698,104 @@ pub trait TensorAnalytic {
 /// fn accepts_structural<B: TensorStructural>(_backend: &mut B) {}
 /// ```
 pub trait TensorStructural {
-    /// Materialize an owned tensor or borrowed view into compact storage owned
-    /// by this backend.
+    /// Materialize an owned tensor or borrowed view into fresh compact storage.
     ///
-    /// The conservative default clones owned compact tensors and rejects
-    /// borrowed views because materializing a view requires backend context.
+    /// The result has the input's shape and dtype, uses compact column-major
+    /// layout, and remains in the input's placement. This operation is a
+    /// same-placement canonicalization boundary, never an implicit host/device
+    /// transfer. The conservative default accepts only compact host-owned
+    /// tensors and clones them; it rejects views, backend buffers, and device
+    /// placement because only an owning backend can materialize those safely.
+    ///
+    /// Backend overrides may accept strided views. CUDA accepts numeric and
+    /// complex views on its active device, including arbitrary valid strides,
+    /// but currently reports an explicit unsupported-dtype error for `Bool`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{DType, Tensor, TensorRead, TensorStructural};
+    ///
+    /// struct HostDefaults;
+    /// impl TensorStructural for HostDefaults {
+    ///     fn transpose(&mut self, _: &Tensor, _: &[usize]) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn reshape(&mut self, _: &Tensor, _: &[usize]) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn broadcast_in_dim(&mut self, _: &Tensor, _: &[usize], _: &[usize]) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn cast(&mut self, _: &Tensor, _: DType) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn extract_diagonal(&mut self, _: &Tensor, _: usize, _: usize) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn embed_diagonal(&mut self, _: &Tensor, _: usize, _: usize) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn tril(&mut self, _: &Tensor, _: i64) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn triu(&mut self, _: &Tensor, _: i64) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    /// }
+    ///
+    /// let input = Tensor::from_vec_col_major(vec![2], vec![1_i32, 2])?;
+    /// let mut backend = HostDefaults;
+    /// let structural: &mut dyn TensorStructural = &mut backend;
+    /// let output = structural.to_contiguous_read(TensorRead::from_tensor(&input))?;
+    /// assert_eq!(output.shape(), &[2]);
+    /// assert_eq!(output.as_slice::<i32>()?, &[1, 2]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
-        Ok(read_tensor("to_contiguous_read", input)?.clone())
+        let input = read_tensor("to_contiguous_read", input)?;
+        if input.is_backend_buffer()
+            || !matches!(
+                input.placement().memory_kind,
+                crate::MemoryKind::PinnedHost | crate::MemoryKind::UnpinnedHost
+            )
+        {
+            return Err(crate::Error::backend_failure(
+                "to_contiguous_read",
+                "default materialization accepts only host-owned tensors; use the storage's owning backend",
+            ));
+        }
+        Ok(input.clone())
     }
 
-    /// Copy a readable tensor or view into caller-provided writable storage.
+    /// Overwrite caller-provided storage from a readable tensor or view.
     ///
-    /// Backends must override this method when they can preserve placement,
-    /// layout, and aliasing guarantees. The default never host-materializes.
+    /// Source and destination must have identical dtype and shape and belong to
+    /// the executing backend's placement. The destination is not resized, and
+    /// every logical destination element is overwritten without reading its old
+    /// value. Source and destination allocations must not alias. Implementations
+    /// must not materialize through host memory or perform an implicit transfer.
+    ///
+    /// CPU accepts arbitrary valid source and destination strides and performs
+    /// no tensor allocation. CUDA currently accepts only a compact column-major
+    /// source with offset zero covering its full allocation; CUDA destinations
+    /// may be arbitrary valid non-overlapping views. CUDA rejects aliased
+    /// allocations and currently reports an explicit unsupported-dtype error
+    /// for `Bool`. The conservative default is explicitly unsupported.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{DType, Tensor, TensorRead, TensorStructural, TensorWrite};
+    ///
+    /// struct ConservativeDefaults;
+    /// impl TensorStructural for ConservativeDefaults {
+    ///     fn transpose(&mut self, _: &Tensor, _: &[usize]) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn reshape(&mut self, _: &Tensor, _: &[usize]) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn broadcast_in_dim(&mut self, _: &Tensor, _: &[usize], _: &[usize]) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn cast(&mut self, _: &Tensor, _: DType) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn extract_diagonal(&mut self, _: &Tensor, _: usize, _: usize) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn embed_diagonal(&mut self, _: &Tensor, _: usize, _: usize) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn tril(&mut self, _: &Tensor, _: i64) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    ///     fn triu(&mut self, _: &Tensor, _: i64) -> tenferro_tensor::Result<Tensor> { unimplemented!() }
+    /// }
+    ///
+    /// let src = Tensor::from_vec_col_major(vec![2], vec![1_i32, 2])?;
+    /// let mut dst = Tensor::from_vec_col_major(vec![2], vec![0_i32, 0])?;
+    /// let mut backend = ConservativeDefaults;
+    /// let structural: &mut dyn TensorStructural = &mut backend;
+    /// let error = structural.copy_read_into(
+    ///     TensorRead::from_tensor(&src),
+    ///     TensorWrite::from_tensor(&mut dst),
+    /// ).unwrap_err();
+    /// assert!(error.to_string().contains("unsupported"));
+    /// assert_eq!(dst.as_slice::<i32>()?, &[0, 0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
     fn copy_read_into(&mut self, _src: TensorRead<'_>, _dst: TensorWrite<'_>) -> crate::Result<()> {
         Err(crate::Error::backend_failure(
             "copy_read_into",

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -1698,6 +1698,26 @@ pub trait TensorAnalytic {
 /// fn accepts_structural<B: TensorStructural>(_backend: &mut B) {}
 /// ```
 pub trait TensorStructural {
+    /// Materialize an owned tensor or borrowed view into compact storage owned
+    /// by this backend.
+    ///
+    /// The conservative default clones owned compact tensors and rejects
+    /// borrowed views because materializing a view requires backend context.
+    fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
+        Ok(read_tensor("to_contiguous_read", input)?.clone())
+    }
+
+    /// Copy a readable tensor or view into caller-provided writable storage.
+    ///
+    /// Backends must override this method when they can preserve placement,
+    /// layout, and aliasing guarantees. The default never host-materializes.
+    fn copy_read_into(&mut self, _src: TensorRead<'_>, _dst: TensorWrite<'_>) -> crate::Result<()> {
+        Err(crate::Error::backend_failure(
+            "copy_read_into",
+            "backend-owned runtime copy is unsupported by this backend",
+        ))
+    }
+
     fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor>;
     fn transpose_read(&mut self, input: TensorRead<'_>, perm: &[usize]) -> crate::Result<Tensor> {
         self.transpose(read_tensor("transpose", input)?, perm)

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -9,8 +9,9 @@
 //! [`TypedTensorView`] is a borrowed typed view over an existing tensor buffer.
 //! It carries logical shape, arbitrary strides, and an offset, so metadata-only
 //! layout changes such as transposes, slices, and broadcasts can be represented
-//! without copying. A view can be materialized explicitly with
-//! [`TypedTensorView::to_contiguous`] when a compact owned tensor is required.
+//! without copying. Backend-aware code materializes and copies views through
+//! [`TensorViewCanonicalization`], preserving placement and backend execution
+//! policy.
 //!
 //! [`TensorRead`] is the dtype-erased borrowed input type used by eager kernels
 //! and backend dispatch. It can borrow either an owned [`Tensor`] or a

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -64,7 +64,7 @@ fn materialize_host_view<T: TensorScalar>(view: TypedTensorView<'_, T>) -> crate
     let mut data = Vec::with_capacity(shape.iter().product());
     let mut error = None;
     for_each_index_col_major(&shape, |index| match view.get(index) {
-        Some(value) => data.push(value.clone()),
+        Some(value) => data.push(*value),
         None => {
             error = Some(crate::Error::backend_failure(
                 "to_contiguous_read",

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -1,11 +1,11 @@
 use crate::{
     backend::{validate_grouped_gemm, GroupedGemmConfig, GroupedGemmJob},
-    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, CompareDir, ContractionScalar,
-    DType, DotGeneralAccumulation, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,
-    SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer,
-    TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead, TensorReduction,
-    TensorStructural, TensorView, TensorViewMut, TensorWrite, TypedTensor, TypedTensorView,
-    TypedTensorViewMut,
+    BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir,
+    ContractionScalar, DType, DotGeneralAccumulation, DotGeneralConfig, GatherConfig, PadConfig,
+    ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
+    TensorReduction, TensorStructural, TensorView, TensorViewMut, TensorWrite, TypedTensor,
+    TypedTensorView, TypedTensorViewMut,
 };
 use num_complex::{Complex32, Complex64};
 
@@ -1200,4 +1200,62 @@ fn tensor_stack_reshapes_then_concatenates_and_validates_inputs() {
 
     let axis_err = Tensor::stack(&[&a], 2, &mut backend).unwrap_err();
     assert!(axis_err.to_string().contains("axis 2"));
+}
+
+#[test]
+fn structural_runtime_materialization_is_object_safe_and_clones_owned_input_by_default() {
+    let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let mut backend = DefaultReadBackend::default();
+    let session: &mut dyn BackendSession = &mut backend;
+
+    let output = session
+        .to_contiguous_read(TensorRead::from_tensor(&input))
+        .unwrap();
+
+    assert_eq!(output.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    assert_eq!(input.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+}
+
+#[test]
+fn structural_runtime_materialization_rejects_views_by_default() {
+    let data = [1.0_f64, 2.0];
+    let view = TensorView::f64(&[2], &data).unwrap();
+    let mut backend = DefaultReadBackend::default();
+    let session: &mut dyn BackendSession = &mut backend;
+
+    let err = session
+        .to_contiguous_read(TensorRead::from_view(view))
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        crate::Error::BackendFailure {
+            op: "to_contiguous_read",
+            ref message,
+        } if message.contains("borrowed tensor views")
+    ));
+}
+
+#[test]
+fn structural_runtime_copy_is_explicitly_unsupported_by_default() {
+    let src = Tensor::from_vec_col_major(vec![2], vec![1_i32, 2]).unwrap();
+    let mut dst = Tensor::from_vec_col_major(vec![2], vec![0_i32, 0]).unwrap();
+    let mut backend = DefaultReadBackend::default();
+    let session: &mut dyn BackendSession = &mut backend;
+
+    let err = session
+        .copy_read_into(
+            TensorRead::from_tensor(&src),
+            TensorWrite::from_tensor(&mut dst),
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        crate::Error::BackendFailure {
+            op: "copy_read_into",
+            ref message,
+        } if message.contains("unsupported")
+    ));
+    assert_eq!(dst.as_slice::<i32>().unwrap(), &[0, 0]);
 }

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -1237,6 +1237,40 @@ fn structural_runtime_materialization_rejects_views_by_default() {
 }
 
 #[test]
+fn structural_runtime_materialization_rejects_foreign_backend_storage_by_default() {
+    let input = Tensor::F64(
+        TypedTensor::from_buffer_col_major(
+            vec![2],
+            crate::Buffer::Backend(std::sync::Arc::new(
+                crate::BufferHandle::<f64>::new_with_len(41, 2),
+            )),
+            crate::Placement {
+                memory_kind: crate::MemoryKind::Device,
+                device: Some(crate::DeviceId {
+                    kind: crate::DeviceKind::Gpu(crate::GpuBackendKind::Cuda),
+                    ordinal: 0,
+                }),
+            },
+        )
+        .unwrap(),
+    );
+    let mut backend = DefaultReadBackend::default();
+    let session: &mut dyn BackendSession = &mut backend;
+
+    let err = session
+        .to_contiguous_read(TensorRead::from_tensor(&input))
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        crate::Error::BackendFailure {
+            op: "to_contiguous_read",
+            ref message,
+        } if message.contains("host-owned") && message.contains("owning backend")
+    ));
+}
+
+#[test]
 fn structural_runtime_copy_is_explicitly_unsupported_by_default() {
     let src = Tensor::from_vec_col_major(vec![2], vec![1_i32, 2]).unwrap();
     let mut dst = Tensor::from_vec_col_major(vec![2], vec![0_i32, 0]).unwrap();

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -4,12 +4,11 @@ use crate::{
     ContractionScalar, DType, DotGeneralAccumulation, DotGeneralConfig, GatherConfig, PadConfig,
     ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
     TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
-    TensorReduction, TensorStructural, TensorView, TensorViewMut, TensorWrite, TypedTensor,
-    TypedTensorView, TypedTensorViewMut,
+    TensorReduction, TensorScalar, TensorStructural, TensorView, TensorViewMut, TensorWrite,
+    TypedTensor, TypedTensorView, TypedTensorViewMut,
 };
 use num_complex::{Complex32, Complex64};
 
-#[derive(Default)]
 struct DefaultReadBackend {
     calls: Vec<&'static str>,
     dot_result: Option<Tensor>,
@@ -17,10 +16,87 @@ struct DefaultReadBackend {
     gather_config: Option<GatherConfig>,
     reshape_shapes: Vec<Vec<usize>>,
     concatenate_axis: Option<usize>,
+    structural_runtime_enabled: bool,
+}
+
+impl Default for DefaultReadBackend {
+    fn default() -> Self {
+        Self {
+            calls: Vec::new(),
+            dot_result: None,
+            gather_indices: None,
+            gather_config: None,
+            reshape_shapes: Vec::new(),
+            concatenate_axis: None,
+            structural_runtime_enabled: true,
+        }
+    }
 }
 
 fn marker() -> Tensor {
     Tensor::from_vec_col_major(vec![1], vec![42.0_f64]).unwrap()
+}
+
+fn for_each_index_col_major(shape: &[usize], mut visit: impl FnMut(&[usize])) {
+    if shape.contains(&0) {
+        return;
+    }
+    let mut index = vec![0; shape.len()];
+    loop {
+        visit(&index);
+        let Some(axis) = (0..shape.len()).find(|&axis| {
+            index[axis] += 1;
+            if index[axis] < shape[axis] {
+                true
+            } else {
+                index[axis] = 0;
+                false
+            }
+        }) else {
+            break;
+        };
+        let _ = axis;
+    }
+}
+
+fn materialize_host_view<T: TensorScalar>(view: TypedTensorView<'_, T>) -> crate::Result<Tensor> {
+    let shape = view.shape().to_vec();
+    let mut data = Vec::with_capacity(shape.iter().product());
+    let mut error = None;
+    for_each_index_col_major(&shape, |index| match view.get(index) {
+        Some(value) => data.push(value.clone()),
+        None => {
+            error = Some(crate::Error::backend_failure(
+                "to_contiguous_read",
+                "test backend could not read a host view element",
+            ))
+        }
+    });
+    if let Some(error) = error {
+        return Err(error);
+    }
+    Tensor::from_vec_col_major(shape, data)
+}
+
+fn copy_host_view<T: TensorScalar>(
+    src: &TypedTensor<T>,
+    mut dst: TypedTensorViewMut<'_, T>,
+) -> crate::Result<()> {
+    let shape = src.shape().to_vec();
+    let mut error = None;
+    for_each_index_col_major(&shape, |index| {
+        let value = src.get(index).cloned();
+        match (value, dst.get_mut(index)) {
+            (Ok(value), Some(slot)) => *slot = value,
+            _ => {
+                error = Some(crate::Error::backend_failure(
+                    "copy_read_into",
+                    "test backend could not copy a host view element",
+                ));
+            }
+        }
+    });
+    error.map_or(Ok(()), Err)
 }
 
 impl TensorElementwise for DefaultReadBackend {
@@ -158,6 +234,82 @@ impl TensorAnalytic for DefaultReadBackend {
 }
 
 impl TensorStructural for DefaultReadBackend {
+    fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
+        if !self.structural_runtime_enabled {
+            let TensorRead::Tensor(tensor) = input else {
+                return Err(crate::Error::backend_failure(
+                    "to_contiguous_read",
+                    "backend does not accept borrowed tensor views at this execution boundary",
+                ));
+            };
+            if tensor.is_backend_buffer()
+                || !matches!(
+                    tensor.placement().memory_kind,
+                    crate::MemoryKind::PinnedHost | crate::MemoryKind::UnpinnedHost
+                )
+            {
+                return Err(crate::Error::backend_failure(
+                    "to_contiguous_read",
+                    "default materialization accepts only host-owned tensors; use the storage's owning backend",
+                ));
+            }
+            return Ok(tensor.clone());
+        }
+        match input {
+            TensorRead::Tensor(tensor) => Ok(tensor.clone()),
+            TensorRead::View(TensorView::F32(view)) => materialize_host_view(view),
+            TensorRead::View(TensorView::F64(view)) => materialize_host_view(view),
+            TensorRead::View(TensorView::I32(view)) => materialize_host_view(view),
+            TensorRead::View(TensorView::I64(view)) => materialize_host_view(view),
+            TensorRead::View(TensorView::Bool(view)) => materialize_host_view(view),
+            TensorRead::View(TensorView::C32(view)) => materialize_host_view(view),
+            TensorRead::View(TensorView::C64(view)) => materialize_host_view(view),
+        }
+    }
+
+    fn copy_read_into(&mut self, src: TensorRead<'_>, dst: TensorWrite<'_>) -> crate::Result<()> {
+        if !self.structural_runtime_enabled {
+            return Err(crate::Error::backend_failure(
+                "copy_read_into",
+                "backend-owned runtime copy is unsupported by this backend",
+            ));
+        }
+        if src.dtype() != dst.dtype() {
+            return Err(crate::Error::DTypeMismatch {
+                op: "copy_read_into",
+                lhs: src.dtype(),
+                rhs: dst.dtype(),
+            });
+        }
+        if src.shape() != dst.shape() {
+            return Err(crate::Error::ShapeMismatch {
+                op: "copy_read_into",
+                lhs: src.shape().to_vec(),
+                rhs: dst.shape().to_vec(),
+            });
+        }
+        let src = self.to_contiguous_read(src)?;
+        macro_rules! copy_typed {
+            ($src:expr, $dst:expr, $variant:ident) => {
+                match $dst {
+                    TensorWrite::Tensor(dst) => *dst = Tensor::$variant($src),
+                    TensorWrite::View(TensorViewMut::$variant(dst)) => copy_host_view(&$src, dst)?,
+                    _ => unreachable!("dtype was validated before copy dispatch"),
+                }
+            };
+        }
+        match src {
+            Tensor::F32(src) => copy_typed!(src, dst, F32),
+            Tensor::F64(src) => copy_typed!(src, dst, F64),
+            Tensor::I32(src) => copy_typed!(src, dst, I32),
+            Tensor::I64(src) => copy_typed!(src, dst, I64),
+            Tensor::Bool(src) => copy_typed!(src, dst, Bool),
+            Tensor::C32(src) => copy_typed!(src, dst, C32),
+            Tensor::C64(src) => copy_typed!(src, dst, C64),
+        }
+        Ok(())
+    }
+
     fn transpose(&mut self, _input: &Tensor, _perm: &[usize]) -> crate::Result<Tensor> {
         self.calls.push("transpose");
         Ok(marker())
@@ -1205,7 +1357,10 @@ fn tensor_stack_reshapes_then_concatenates_and_validates_inputs() {
 #[test]
 fn structural_runtime_materialization_is_object_safe_and_clones_owned_input_by_default() {
     let input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    let mut backend = DefaultReadBackend::default();
+    let mut backend = DefaultReadBackend {
+        structural_runtime_enabled: false,
+        ..Default::default()
+    };
     let session: &mut dyn BackendSession = &mut backend;
 
     let output = session
@@ -1220,7 +1375,10 @@ fn structural_runtime_materialization_is_object_safe_and_clones_owned_input_by_d
 fn structural_runtime_materialization_rejects_views_by_default() {
     let data = [1.0_f64, 2.0];
     let view = TensorView::f64(&[2], &data).unwrap();
-    let mut backend = DefaultReadBackend::default();
+    let mut backend = DefaultReadBackend {
+        structural_runtime_enabled: false,
+        ..Default::default()
+    };
     let session: &mut dyn BackendSession = &mut backend;
 
     let err = session
@@ -1254,7 +1412,10 @@ fn structural_runtime_materialization_rejects_foreign_backend_storage_by_default
         )
         .unwrap(),
     );
-    let mut backend = DefaultReadBackend::default();
+    let mut backend = DefaultReadBackend {
+        structural_runtime_enabled: false,
+        ..Default::default()
+    };
     let session: &mut dyn BackendSession = &mut backend;
 
     let err = session
@@ -1274,7 +1435,10 @@ fn structural_runtime_materialization_rejects_foreign_backend_storage_by_default
 fn structural_runtime_copy_is_explicitly_unsupported_by_default() {
     let src = Tensor::from_vec_col_major(vec![2], vec![1_i32, 2]).unwrap();
     let mut dst = Tensor::from_vec_col_major(vec![2], vec![0_i32, 0]).unwrap();
-    let mut backend = DefaultReadBackend::default();
+    let mut backend = DefaultReadBackend {
+        structural_runtime_enabled: false,
+        ..Default::default()
+    };
     let session: &mut dyn BackendSession = &mut backend;
 
     let err = session

--- a/crates/tenferro-tensor/src/tests/public_surface_contract_tests.rs
+++ b/crates/tenferro-tensor/src/tests/public_surface_contract_tests.rs
@@ -177,3 +177,39 @@ fn view_canonicalization_uses_symmetric_copy_into_contract() {
     )
     .unwrap();
 }
+
+#[test]
+fn structural_runtime_materialization_is_erased_and_object_safe_without_removing_local_apis() {
+    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let backend = fs::read_to_string(crate_dir.join("src/backend.rs"))
+        .expect("tenferro-tensor backend source must be readable");
+    let structural = backend
+        .split_once("pub trait TensorStructural")
+        .expect("TensorStructural trait must exist")
+        .1
+        .split_once("/// Reduction operations.")
+        .expect("TensorStructural must precede TensorReduction")
+        .0;
+
+    assert!(
+        structural.contains(
+            "fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor>"
+        ),
+        "runtime materialization must use the erased TensorRead/Tensor result surface"
+    );
+    assert!(
+        structural.contains("fn copy_read_into(")
+            && structural.contains("src: TensorRead<'_>")
+            && structural.contains("dst: TensorWrite<'_>"),
+        "runtime copy must use erased read/write values"
+    );
+    assert!(
+        !structural.contains("where\n        Self: Sized"),
+        "runtime materialization methods must remain callable through dyn BackendSession"
+    );
+
+    let types = fs::read_to_string(crate_dir.join("src/types.rs"))
+        .expect("tenferro-tensor types source must be readable");
+    assert!(types.contains("pub fn to_tensor(&self) -> crate::Result<Tensor>"));
+    assert!(types.contains("pub fn to_contiguous(&self)"));
+}

--- a/crates/tenferro-tensor/src/tests/public_surface_contract_tests.rs
+++ b/crates/tenferro-tensor/src/tests/public_surface_contract_tests.rs
@@ -179,7 +179,7 @@ fn view_canonicalization_uses_symmetric_copy_into_contract() {
 }
 
 #[test]
-fn structural_runtime_materialization_is_erased_and_object_safe_without_removing_local_apis() {
+fn structural_runtime_materialization_is_erased_without_removing_local_apis() {
     let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let backend = fs::read_to_string(crate_dir.join("src/backend.rs"))
         .expect("tenferro-tensor backend source must be readable");
@@ -203,11 +203,6 @@ fn structural_runtime_materialization_is_erased_and_object_safe_without_removing
             && structural.contains("dst: TensorWrite<'_>"),
         "runtime copy must use erased read/write values"
     );
-    assert!(
-        !structural.contains("where\n        Self: Sized"),
-        "runtime materialization methods must remain callable through dyn BackendSession"
-    );
-
     let types = fs::read_to_string(crate_dir.join("src/types.rs"))
         .expect("tenferro-tensor types source must be readable");
     assert!(types.contains("pub fn to_tensor(&self) -> crate::Result<Tensor>"));

--- a/crates/tenferro-tensor/src/tests/public_surface_contract_tests.rs
+++ b/crates/tenferro-tensor/src/tests/public_surface_contract_tests.rs
@@ -11,9 +11,12 @@ struct CopyContractBackend;
 impl TensorViewCanonicalization<i32, DynRank> for CopyContractBackend {
     fn to_contiguous(
         &mut self,
-        view: &TypedTensorView<'_, i32>,
+        _view: &TypedTensorView<'_, i32>,
     ) -> crate::Result<TypedTensor<i32>> {
-        view.to_contiguous()
+        Err(crate::Error::backend_failure(
+            "test",
+            "materialization is not exercised by this copy contract test",
+        ))
     }
 
     fn copy_into(
@@ -179,7 +182,7 @@ fn view_canonicalization_uses_symmetric_copy_into_contract() {
 }
 
 #[test]
-fn structural_runtime_materialization_is_erased_without_removing_local_apis() {
+fn structural_runtime_materialization_is_erased_and_context_free_copies_are_removed() {
     let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let backend = fs::read_to_string(crate_dir.join("src/backend.rs"))
         .expect("tenferro-tensor backend source must be readable");
@@ -205,6 +208,16 @@ fn structural_runtime_materialization_is_erased_without_removing_local_apis() {
     );
     let types = fs::read_to_string(crate_dir.join("src/types.rs"))
         .expect("tenferro-tensor types source must be readable");
-    assert!(types.contains("pub fn to_tensor(&self) -> crate::Result<Tensor>"));
-    assert!(types.contains("pub fn to_contiguous(&self)"));
+    for removed in [
+        "pub fn to_contiguous(&self)",
+        "pub fn copy_from_contiguous(",
+        "pub fn to_tensor(&self) -> crate::Result<Tensor>",
+        "materialize_view_buffer_col_major",
+        "materialize_typed_view_col_major",
+    ] {
+        assert!(
+            !types.contains(removed),
+            "context-free tensor movement must be absent: {removed}"
+        );
+    }
 }

--- a/crates/tenferro-tensor/src/tests/public_surface_contract_tests.rs
+++ b/crates/tenferro-tensor/src/tests/public_surface_contract_tests.rs
@@ -1,6 +1,43 @@
 use std::fs;
 use std::path::Path;
 
+use crate::{
+    DynRank, TensorRank, TensorScalar, TensorViewCanonicalization, TypedTensor, TypedTensorView,
+    TypedTensorViewMut,
+};
+
+struct CopyContractBackend;
+
+impl TensorViewCanonicalization<i32, DynRank> for CopyContractBackend {
+    fn to_contiguous(
+        &mut self,
+        view: &TypedTensorView<'_, i32>,
+    ) -> crate::Result<TypedTensor<i32>> {
+        view.to_contiguous()
+    }
+
+    fn copy_into(
+        &mut self,
+        _src: &TypedTensorView<'_, i32>,
+        _dst: &mut TypedTensorViewMut<'_, i32>,
+    ) -> crate::Result<()> {
+        Ok(())
+    }
+}
+
+fn copy_between_views<T, R, B>(
+    backend: &mut B,
+    src: &TypedTensorView<'_, T, R>,
+    dst: &mut TypedTensorViewMut<'_, T, R>,
+) -> crate::Result<()>
+where
+    T: TensorScalar,
+    R: TensorRank,
+    B: TensorViewCanonicalization<T, R>,
+{
+    backend.copy_into(src, dst)
+}
+
 #[test]
 fn typed_tensor_storage_fields_are_accessor_based() {
     let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -101,4 +138,42 @@ fn tensor_scalar_helpers_do_not_expose_cpu_conjugation_hook() {
         !source.contains("pub trait ConjElem"),
         "CPU conjugation helpers must not be part of the public tensor scalar API"
     );
+}
+
+#[test]
+fn view_canonicalization_uses_symmetric_copy_into_contract() {
+    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let source = fs::read_to_string(crate_dir.join("src/backend.rs"))
+        .expect("tenferro-tensor backend source must be readable");
+    let trait_body = source
+        .split_once("pub trait TensorViewCanonicalization")
+        .expect("TensorViewCanonicalization trait must exist")
+        .1
+        .split_once("/// Optional elementwise fusion execution.")
+        .expect("TensorViewCanonicalization trait must precede TensorFusion")
+        .0;
+
+    assert!(
+        source.contains("TensorViewCanonicalization<T: TensorScalar, R: TensorRank>"),
+        "view canonicalization must use the execution scalar contract"
+    );
+    assert!(
+        trait_body.contains("fn copy_into(")
+            && trait_body.contains("src: &TypedTensorView<'_, T, R>")
+            && trait_body.contains("dst: &mut TypedTensorViewMut<'_, T, R>"),
+        "copy_into must accept readable and writable views with the trait rank"
+    );
+    assert!(
+        !trait_body.contains("copy_from_contiguous"),
+        "the asymmetric copy_from_contiguous method must leave the backend trait"
+    );
+
+    let src = TypedTensor::<i32>::from_vec_col_major(vec![1], vec![1]).unwrap();
+    let mut dst = TypedTensor::<i32>::from_vec_col_major(vec![1], vec![0]).unwrap();
+    copy_between_views(
+        &mut CopyContractBackend,
+        &src.as_view(),
+        &mut dst.as_view_mut(),
+    )
+    .unwrap();
 }

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 use num_complex::{Complex32, Complex64};
 
 use crate::types::{
-    col_major_strides, flat_to_multi, materialize_typed_view_col_major, Buffer, BufferHandle,
-    DType, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Rank, StridedSliceSpec,
-    Tensor, TensorBufferRef, TensorBufferRefMut, TensorLayout, TensorOwnedView, TensorRank,
-    TensorRead, TensorScalar, TensorValue, TensorView, TensorViewMut, TensorWrite, TypedTensor,
-    TypedTensorView, TypedTensorViewMut, TypedTensorWrite,
+    col_major_strides, flat_to_multi, Buffer, BufferHandle, DType, DeviceId, DeviceKind,
+    GpuBackendKind, MemoryKind, Placement, Rank, StridedSliceSpec, Tensor, TensorBufferRef,
+    TensorBufferRefMut, TensorLayout, TensorOwnedView, TensorRank, TensorRead, TensorScalar,
+    TensorValue, TensorView, TensorViewMut, TensorWrite, TypedTensor, TypedTensorView,
+    TypedTensorViewMut, TypedTensorWrite,
 };
 use crate::{Error, SliceConfig};
 
@@ -71,7 +71,7 @@ fn tensor_scalar_tensor_read_covers_all_variants() {
 }
 
 #[test]
-fn tensor_value_keeps_owned_transpose_as_view_until_materialized() {
+fn tensor_value_keeps_owned_transpose_as_view() {
     let tensor = Arc::new(
         Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap(),
     );
@@ -83,13 +83,6 @@ fn tensor_value_keeps_owned_transpose_as_view_until_materialized() {
         TensorRead::View(view) => assert_eq!(view.shape(), &[3, 2]),
         TensorRead::Tensor(_) => panic!("owned transpose should be exposed as a view"),
     }
-
-    let materialized = transposed.to_tensor().unwrap();
-    assert_eq!(materialized.shape(), &[3, 2]);
-    assert_eq!(
-        materialized.as_slice::<f64>().unwrap(),
-        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
-    );
 }
 
 #[test]
@@ -111,18 +104,11 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
         TensorRead::View(TensorView::F64(view)) => assert_eq!(view.shape(), &[2, 3]),
         other => panic!("owned view should expose TensorRead::View, got {other:?}"),
     }
-    assert_eq!(
-        owned.to_tensor().unwrap().as_slice::<f64>().unwrap(),
-        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
-    );
 
     let explicit =
         TensorOwnedView::from_parts(Arc::clone(&base), vec![3, 2], vec![2, 1], 0).unwrap();
     assert_eq!(explicit.shape(), &[3, 2]);
-    assert_eq!(
-        explicit.to_tensor().unwrap().as_slice::<f64>().unwrap(),
-        &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
-    );
+    assert_eq!(explicit.strides(), &[2, 1]);
 
     let transposed = owned.transpose_view([1, 0]).unwrap();
     assert_eq!(transposed.shape(), &[3, 2]);
@@ -139,10 +125,13 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
         })
         .unwrap();
     assert_eq!(sliced.shape(), &[2, 2]);
-    assert_eq!(
-        sliced.to_tensor().unwrap().as_slice::<f64>().unwrap(),
-        &[3.0, 4.0, 5.0, 6.0]
-    );
+    match sliced.tensor_view() {
+        TensorView::F64(view) => {
+            assert_eq!(view.get(&[0, 0]), Some(&3.0));
+            assert_eq!(view.get(&[1, 1]), Some(&6.0));
+        }
+        other => panic!("expected f64 view, got {other:?}"),
+    }
 
     let vector = TensorOwnedView::from_parts(Arc::clone(&base), vec![2], vec![1], 0).unwrap();
     let broadcast = vector.broadcast_in_dim_view(&[2, 3], &[0]).unwrap();
@@ -177,10 +166,6 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
     assert_eq!(value.dtype(), DType::F64);
     assert_eq!(value.shape(), &[2, 3]);
     assert!(matches!(value.tensor_read(), TensorRead::Tensor(_)));
-    assert_eq!(
-        value.to_tensor().unwrap().as_slice::<f64>().unwrap(),
-        &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
-    );
 
     let view_value = value.transpose_view([1, 0]).unwrap();
     assert!(view_value.as_tensor_arc().is_none());
@@ -191,20 +176,14 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
 
     let compact_view = value.reshape_view(&[6]).unwrap();
     assert_eq!(compact_view.reshape_view(&[2, 3]).unwrap().shape(), &[2, 3]);
-    assert_eq!(
-        compact_view
-            .slice_view(&SliceConfig {
-                starts: vec![1],
-                limits: vec![5],
-                strides: vec![2],
-            })
-            .unwrap()
-            .to_tensor()
-            .unwrap()
-            .as_slice::<f64>()
-            .unwrap(),
-        &[2.0, 4.0]
-    );
+    let sliced_value = compact_view
+        .slice_view(&SliceConfig {
+            starts: vec![1],
+            limits: vec![5],
+            strides: vec![2],
+        })
+        .unwrap();
+    assert_eq!(sliced_value.shape(), &[2]);
     assert_eq!(
         compact_view
             .broadcast_in_dim_view(&[6, 2], &[0])
@@ -435,175 +414,6 @@ fn typed_tensor_view_transpose_is_metadata_only() {
     assert_eq!(view.shape(), &[3, 2]);
     assert_eq!(view.strides(), &[2, 1]);
     assert_eq!(view.get(&[2, 1]), Some(&6));
-}
-
-#[test]
-fn non_contiguous_host_view_to_contiguous_preserves_column_major_order() {
-    let tensor =
-        TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 3], vec![1, 2, 3, 4, 5, 6]).unwrap();
-    let view = tensor.as_view().transpose_view([1, 0]).unwrap();
-    let compact = view.to_contiguous().unwrap();
-    assert_eq!(compact.shape(), &[3, 2]);
-    assert_eq!(compact.as_slice().unwrap(), &[1, 3, 5, 2, 4, 6]);
-}
-
-#[test]
-fn non_contiguous_host_view_to_contiguous_preserves_host_placement() {
-    let placement = Placement {
-        memory_kind: MemoryKind::PinnedHost,
-        device: None,
-    };
-    let tensor = TypedTensor::<i32, Rank<2>>::from_buffer_col_major(
-        [2, 2],
-        Buffer::Host(vec![1, 2, 3, 4]),
-        placement.clone(),
-    )
-    .unwrap();
-    let view = tensor.as_view().transpose_view([1, 0]).unwrap();
-
-    let compact = view.to_contiguous().unwrap();
-
-    assert_eq!(compact.as_slice().unwrap(), &[1, 3, 2, 4]);
-    assert_eq!(compact.placement(), &placement);
-}
-
-#[test]
-fn non_contiguous_host_view_to_contiguous_ignores_singleton_axis_stride_overflow() {
-    let data = [10_i32, 20];
-    let view = TypedTensorView::from_slice(vec![1], vec![isize::MAX], 1, &data).unwrap();
-
-    let compact = view.to_contiguous().unwrap();
-
-    assert_eq!(compact.as_slice().unwrap(), &[20]);
-}
-
-#[test]
-fn typed_tensor_view_backend_to_contiguous_returns_backend_failure() {
-    let tensor = TypedTensor::<i32>::from_buffer_col_major(
-        vec![2],
-        Buffer::Backend(Arc::new(BufferHandle::<i32>::new_with_len(78, 2))),
-        Placement {
-            memory_kind: MemoryKind::Device,
-            device: Some(DeviceId {
-                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
-                ordinal: 0,
-            }),
-        },
-    )
-    .unwrap();
-
-    let err = tensor.as_view().to_contiguous().unwrap_err();
-
-    assert!(matches!(
-        err,
-        Error::BackendFailure {
-            op: "TypedTensorView::to_contiguous",
-            ..
-        }
-    ));
-    assert!(err.to_string().contains("download explicitly first"));
-}
-
-#[test]
-fn mutable_host_copy_back_writes_strided_output() {
-    let mut tensor =
-        TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 2], vec![0, 0, 0, 0]).unwrap();
-    {
-        let mut out = tensor.as_view_mut().transpose_view([1, 0]).unwrap();
-        let scratch =
-            TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 2], vec![1, 2, 3, 4]).unwrap();
-        out.copy_from_contiguous(&scratch).unwrap();
-    }
-    assert_eq!(tensor.as_slice().unwrap(), &[1, 3, 2, 4]);
-}
-
-#[test]
-fn mutable_host_copy_back_ignores_singleton_axis_stride_overflow() {
-    let mut data = vec![10_i32, 20];
-    let mut view = TypedTensorViewMut::from_slice(vec![1], vec![isize::MAX], 1, &mut data).unwrap();
-    let scratch = TypedTensor::<i32>::from_vec_col_major(vec![1], vec![99]).unwrap();
-
-    view.copy_from_contiguous(&scratch).unwrap();
-
-    assert_eq!(data, vec![10, 99]);
-}
-
-#[test]
-fn mutable_host_copy_back_rejects_shape_mismatch() {
-    let mut tensor =
-        TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 2], vec![0, 0, 0, 0]).unwrap();
-    let scratch =
-        TypedTensor::<i32, Rank<2>>::from_vec_col_major([4, 1], vec![1, 2, 3, 4]).unwrap();
-    let mut out = tensor.as_view_mut().transpose_view([1, 0]).unwrap();
-
-    let err = out.copy_from_contiguous(&scratch).unwrap_err();
-
-    assert!(matches!(
-        err,
-        Error::InvalidConfig {
-            op: "TypedTensorViewMut::copy_from_contiguous",
-            ..
-        }
-    ));
-    assert!(err.to_string().contains("shape mismatch"));
-}
-
-#[test]
-fn mutable_host_copy_back_rejects_backend_source() {
-    let mut tensor = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![0, 0]).unwrap();
-    let scratch = TypedTensor::<i32>::from_buffer_col_major(
-        vec![2],
-        Buffer::Backend(Arc::new(BufferHandle::<i32>::new_with_len(79, 2))),
-        Placement {
-            memory_kind: MemoryKind::Device,
-            device: Some(DeviceId {
-                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
-                ordinal: 0,
-            }),
-        },
-    )
-    .unwrap();
-    let mut out = tensor.as_view_mut();
-
-    let err = out.copy_from_contiguous(&scratch).unwrap_err();
-
-    assert!(matches!(
-        err,
-        Error::BackendFailure {
-            op: "TypedTensorViewMut::copy_from_contiguous",
-            ..
-        }
-    ));
-    assert!(err.to_string().contains("download explicitly first"));
-}
-
-#[test]
-fn mutable_typed_tensor_view_backend_copy_from_contiguous_returns_backend_failure() {
-    let mut tensor = TypedTensor::<i32>::from_buffer_col_major(
-        vec![2],
-        Buffer::Backend(Arc::new(BufferHandle::<i32>::new_with_len(80, 2))),
-        Placement {
-            memory_kind: MemoryKind::Device,
-            device: Some(DeviceId {
-                kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
-                ordinal: 0,
-            }),
-        },
-    )
-    .unwrap();
-    let scratch = TypedTensor::<i32>::from_vec_col_major(vec![2], vec![1, 2]).unwrap();
-    let mut out = tensor.as_view_mut();
-
-    let err = out.copy_from_contiguous(&scratch).unwrap_err();
-
-    assert!(matches!(
-        err,
-        Error::BackendFailure {
-            op: "TypedTensorViewMut::copy_from_contiguous",
-            ..
-        }
-    ));
-    assert!(err.to_string().contains("download explicitly first"));
 }
 
 #[test]
@@ -1207,7 +1017,7 @@ fn typed_tensor_view_validates_shape_and_exposes_slice() {
 }
 
 #[test]
-fn tensor_view_covers_dtype_shape_and_materialization() {
+fn tensor_view_covers_dtype_and_shape() {
     let f32_data = [1.0_f32, 2.0];
     let f64_data = [1.0_f64, 2.0];
     let i32_data = [1_i32, 2];
@@ -1239,58 +1049,34 @@ fn tensor_view_covers_dtype_shape_and_materialization() {
     for (view, dtype) in views.iter().zip(dtypes) {
         assert_eq!(view.dtype(), dtype);
         assert_eq!(view.shape(), &[2]);
-        let tensor = view.to_tensor().unwrap();
-        assert_eq!(tensor.dtype(), dtype);
-        assert_eq!(tensor.shape(), &[2]);
     }
 }
 
 #[test]
-fn typed_tensor_view_materializes_sliced_host_layouts() {
+fn typed_tensor_view_sliced_layouts_preserve_indexed_access() {
     let row_major = [1_i32, 2, 3, 4, 5, 6];
     let view = TypedTensorView::from_slice([2, 3], [3, 1], 0, &row_major).unwrap();
 
     assert_eq!(view.shape(), &[2, 3]);
     assert_eq!(view.strides(), &[3, 1]);
     assert_eq!(view.get(&[1, 2]), Some(&6));
-    assert_eq!(
-        materialize_typed_view_col_major(&view, "test")
-            .unwrap()
-            .as_slice()
-            .unwrap(),
-        &[1, 4, 2, 5, 3, 6]
-    );
+    assert_eq!(view.get(&[0, 0]), Some(&1));
+    assert_eq!(view.get(&[1, 2]), Some(&6));
 
     let transposed = view.transpose_view([1, 0]).unwrap();
     assert_eq!(transposed.shape(), &[3, 2]);
-    assert_eq!(
-        materialize_typed_view_col_major(&transposed, "test")
-            .unwrap()
-            .as_slice()
-            .unwrap(),
-        &[1, 2, 3, 4, 5, 6]
-    );
+    assert_eq!(transposed.get(&[2, 1]), Some(&6));
 
     let reversed_cols = view.try_slice_axis(1, StridedSliceSpec::reverse()).unwrap();
     assert_eq!(reversed_cols.strides(), &[3, -1]);
-    assert_eq!(
-        materialize_typed_view_col_major(&reversed_cols, "test")
-            .unwrap()
-            .as_slice()
-            .unwrap(),
-        &[3, 6, 2, 5, 1, 4]
-    );
+    assert_eq!(reversed_cols.get(&[0, 0]), Some(&3));
+    assert_eq!(reversed_cols.get(&[1, 2]), Some(&4));
 
     let every_other_col = view
         .try_slice(&[StridedSliceSpec::all(), StridedSliceSpec::new(0, None, 2)])
         .unwrap();
-    assert_eq!(
-        materialize_typed_view_col_major(&every_other_col, "test")
-            .unwrap()
-            .as_slice()
-            .unwrap(),
-        &[1, 4, 3, 6]
-    );
+    assert_eq!(every_other_col.get(&[0, 1]), Some(&3));
+    assert_eq!(every_other_col.get(&[1, 1]), Some(&6));
     assert!(view.try_reshape(&[6]).is_err());
 
     let col_major = [1_i32, 4, 2, 5, 3, 6];
@@ -1304,19 +1090,13 @@ fn tensor_view_covers_strided_i32_and_bool() {
     let i32_view =
         TensorView::I32(TypedTensorView::from_slice([2, 2], [2, 1], 0, &i32_data).unwrap());
     assert_eq!(i32_view.dtype(), DType::I32);
-    assert_eq!(
-        i32_view.to_tensor().unwrap().as_slice::<i32>().unwrap(),
-        &[1, 3, 2, 4]
-    );
+    assert_eq!(i32_view.strides(), &[2, 1]);
 
     let bool_data = [false, true, true];
     let bool_view =
         TensorView::Bool(TypedTensorView::from_slice([3], [-1], 2, &bool_data).unwrap());
     assert_eq!(bool_view.dtype(), DType::Bool);
-    assert_eq!(
-        bool_view.to_tensor().unwrap().as_slice::<bool>().unwrap(),
-        &[true, true, false]
-    );
+    assert_eq!(bool_view.strides(), &[-1]);
 }
 
 #[test]
@@ -1345,8 +1125,8 @@ fn strided_tensor_view_mut_updates_sliced_host_layouts() {
     }
     assert_eq!(view.get(&[0, 2]), Some(&30));
 
-    let materialized = materialize_typed_view_col_major(&view.as_read_only(), "test").unwrap();
-    assert_eq!(materialized.as_slice().unwrap(), &[1, 4, 2, 5, 30, 600]);
+    assert_eq!(view.get(&[0, 2]), Some(&30));
+    assert_eq!(view.get(&[1, 2]), Some(&600));
 }
 
 #[test]
@@ -1411,24 +1191,14 @@ fn typed_tensor_view_mut_covers_i32_and_bool_strided_layouts() {
     let mut i32_data = [1_i32, 2, 3, 4];
     let mut i32_view = TypedTensorViewMut::from_slice([2, 2], [2, 1], 0, &mut i32_data).unwrap();
     *i32_view.get_mut(&[1, 1]).unwrap() = 40;
-    assert_eq!(
-        materialize_typed_view_col_major(&i32_view.as_read_only(), "test")
-            .unwrap()
-            .as_slice()
-            .unwrap(),
-        &[1, 3, 2, 40]
-    );
+    assert_eq!(i32_view.get(&[0, 0]), Some(&1));
+    assert_eq!(i32_view.get(&[1, 1]), Some(&40));
 
     let mut bool_data = [false, true, true];
     let mut bool_view = TypedTensorViewMut::from_slice([3], [-1], 2, &mut bool_data).unwrap();
     *bool_view.get_mut(&[2]).unwrap() = true;
-    assert_eq!(
-        materialize_typed_view_col_major(&bool_view.as_read_only(), "test")
-            .unwrap()
-            .as_slice()
-            .unwrap(),
-        &[true, true, true]
-    );
+    assert_eq!(bool_view.get(&[0]), Some(&true));
+    assert_eq!(bool_view.get(&[2]), Some(&true));
 }
 
 #[test]
@@ -1462,25 +1232,11 @@ fn strided_tensor_view_validation_covers_error_edges() {
 
     let empty = TypedTensorView::from_slice([0, 3], [1, 0], 3, &data).unwrap();
     assert_eq!(empty.n_elements(), 0);
-    assert_eq!(
-        materialize_typed_view_col_major(&empty, "test")
-            .unwrap()
-            .as_slice()
-            .unwrap(),
-        &[] as &[i32]
-    );
     assert_eq!(empty.try_reshape(&[0]).unwrap().shape(), &[0]);
     let reversed_empty = empty
         .try_slice_axis(0, StridedSliceSpec::reverse())
         .unwrap();
     assert_eq!(reversed_empty.shape(), &[0, 3]);
-    assert_eq!(
-        materialize_typed_view_col_major(&reversed_empty, "test")
-            .unwrap()
-            .as_slice()
-            .unwrap(),
-        &[] as &[i32]
-    );
     assert_eq!(empty.get(&[0, 0]), None);
     assert!(matches!(
         TypedTensorView::<i32>::from_slice([0], [1], 4, &data),
@@ -1577,13 +1333,7 @@ fn typed_tensor_view_slice_transpose_and_reshape_cover_boundaries() {
         .try_slice_axis(1, StridedSliceSpec::new(2, Some(1), 1))
         .unwrap();
     assert_eq!(empty.shape(), &[2, 0]);
-    assert_eq!(
-        materialize_typed_view_col_major(&empty, "test")
-            .unwrap()
-            .as_slice()
-            .unwrap(),
-        &[] as &[i32]
-    );
+    assert_eq!(empty.n_elements(), 0);
 
     assert!(matches!(
         view.try_reshape(&[5]),
@@ -1697,10 +1447,6 @@ fn tensor_read_wraps_owned_tensor_or_borrowed_view() {
     assert_eq!(read_tensor.dtype(), DType::F64);
     assert_eq!(read_tensor.shape(), &[2]);
     assert!(read_tensor.as_tensor().is_some());
-    assert_eq!(
-        read_tensor.to_tensor().unwrap().as_slice::<f64>().unwrap(),
-        &[3.0, 4.0]
-    );
 
     let shape = [2usize];
     let data = [5.0_f64, 6.0];
@@ -1709,47 +1455,36 @@ fn tensor_read_wraps_owned_tensor_or_borrowed_view() {
     assert_eq!(read_view.dtype(), DType::F64);
     assert_eq!(read_view.shape(), &[2]);
     assert!(read_view.as_tensor().is_none());
-    assert_eq!(
-        read_view.to_tensor().unwrap().as_slice::<f64>().unwrap(),
-        &[5.0, 6.0]
-    );
+    assert_eq!(read_view.layout_linear_offset(&[1]).unwrap(), 1);
 }
 
 #[test]
 fn tensor_write_wraps_owned_tensor_or_borrowed_mutable_view() {
     let mut tensor = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
     {
-        let mut write_tensor = TensorWrite::from_tensor(&mut tensor);
+        let write_tensor = TensorWrite::from_tensor(&mut tensor);
 
         assert_eq!(write_tensor.dtype(), DType::F64);
         assert_eq!(write_tensor.shape(), &[2]);
         assert_eq!(write_tensor.strides().unwrap().as_slice(), &[1]);
         assert_eq!(write_tensor.offset(), 0);
         assert!(write_tensor.is_col_major_contiguous().unwrap());
-
-        write_tensor
-            .copy_from_tensor(&Tensor::from_vec_col_major(vec![2], vec![7.0_f64, 8.0]).unwrap())
-            .unwrap();
     }
-    assert_eq!(tensor.as_slice::<f64>().unwrap(), &[7.0, 8.0]);
+    assert_eq!(tensor.as_slice::<f64>().unwrap(), &[3.0, 4.0]);
 
     let mut data = [0.0_f64, 10.0, 0.0, 20.0, 0.0];
     {
         let view =
             TensorViewMut::F64(TypedTensorViewMut::from_slice([2], [2], 1, &mut data).unwrap());
-        let mut write_view = TensorWrite::from_view(view);
+        let write_view = TensorWrite::from_view(view);
 
         assert_eq!(write_view.dtype(), DType::F64);
         assert_eq!(write_view.shape(), &[2]);
         assert_eq!(write_view.strides().unwrap().as_slice(), &[2]);
         assert_eq!(write_view.offset(), 1);
         assert!(!write_view.is_col_major_contiguous().unwrap());
-
-        write_view
-            .copy_from_tensor(&Tensor::from_vec_col_major(vec![2], vec![30.0_f64, 40.0]).unwrap())
-            .unwrap();
     }
-    assert_eq!(data, [0.0, 30.0, 0.0, 40.0, 0.0]);
+    assert_eq!(data, [0.0, 10.0, 0.0, 20.0, 0.0]);
 }
 
 #[test]
@@ -1757,31 +1492,25 @@ fn typed_tensor_write_wraps_owned_tensor_or_borrowed_mutable_view() {
     let mut tensor = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap();
     {
         let typed_write = TypedTensorWrite::from_tensor(&mut tensor);
-        let mut write = typed_write.into_tensor_write();
+        let write = typed_write.into_tensor_write();
 
         assert_eq!(write.dtype(), DType::F64);
         assert_eq!(write.shape(), &[2]);
-        write
-            .copy_from_tensor(&Tensor::from_vec_col_major(vec![2], vec![7.0_f64, 8.0]).unwrap())
-            .unwrap();
     }
-    assert_eq!(tensor.as_slice().unwrap(), &[7.0, 8.0]);
+    assert_eq!(tensor.as_slice().unwrap(), &[3.0, 4.0]);
 
     let mut data = [0.0_f64, 10.0, 0.0, 20.0, 0.0];
     {
         let view = TypedTensorViewMut::from_slice([2], [2], 1, &mut data).unwrap();
         let typed_write = TypedTensorWrite::from_view(view);
-        let mut write = typed_write.into_tensor_write();
+        let write = typed_write.into_tensor_write();
 
         assert_eq!(write.dtype(), DType::F64);
         assert_eq!(write.shape(), &[2]);
         assert_eq!(write.strides().unwrap(), [2]);
         assert_eq!(write.offset(), 1);
-        write
-            .copy_from_tensor(&Tensor::from_vec_col_major(vec![2], vec![30.0_f64, 40.0]).unwrap())
-            .unwrap();
     }
-    assert_eq!(data, [0.0, 30.0, 0.0, 40.0, 0.0]);
+    assert_eq!(data, [0.0, 10.0, 0.0, 20.0, 0.0]);
 }
 
 #[test]
@@ -1817,7 +1546,6 @@ fn tensor_view_layout_helpers_cover_all_dtype_variants() {
             assert!(view.is_col_major_contiguous().unwrap());
             assert!(view.layout_summary().contains("shape=[2]"));
             view.assert_col_major_contiguous().unwrap();
-            assert_eq!(view.to_tensor().unwrap().dtype(), $dtype);
         }};
     }
 
@@ -1844,13 +1572,13 @@ fn tensor_view_layout_helpers_cover_all_dtype_variants() {
 }
 
 #[test]
-fn tensor_view_mut_layout_and_copy_cover_all_dtype_variants() {
+fn tensor_view_mut_layout_helpers_cover_all_dtype_variants() {
     macro_rules! assert_view_mut {
         ($variant:ident, $ty:ty, $dtype:expr, $initial:expr, $replacement:expr) => {{
             let mut data: [$ty; 2] = $initial;
             {
                 let typed = TypedTensorViewMut::from_slice([2], [1], 0, &mut data).unwrap();
-                let mut view = TensorViewMut::$variant(typed);
+                let view = TensorViewMut::$variant(typed);
                 assert_eq!(view.dtype(), $dtype);
                 assert_eq!(view.shape(), &[2]);
                 assert_eq!(view.strides(), &[1]);
@@ -1863,12 +1591,8 @@ fn tensor_view_mut_layout_and_copy_cover_all_dtype_variants() {
                 let read = view.as_read_only();
                 assert_eq!(read.dtype(), $dtype);
                 assert_eq!(read.shape(), &[2]);
-
-                let src =
-                    Tensor::from_vec_col_major(vec![2], Vec::<$ty>::from($replacement)).unwrap();
-                view.copy_from_tensor(&src).unwrap();
             }
-            assert_eq!(data, $replacement);
+            assert_eq!(data, $initial);
         }};
     }
 
@@ -1916,20 +1640,19 @@ fn tensor_read_and_write_layout_helpers_cover_tensor_and_view_paths() {
 
     let mut write_tensor_dst = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 0.0]).unwrap();
     {
-        let mut write_tensor = TensorWrite::from_tensor(&mut write_tensor_dst);
+        let write_tensor = TensorWrite::from_tensor(&mut write_tensor_dst);
         assert_eq!(write_tensor.strides().unwrap(), vec![1]);
         assert_eq!(write_tensor.offset(), 0);
         assert_eq!(write_tensor.layout_linear_offset(&[1]).unwrap(), 1);
         assert!(write_tensor.is_col_major_contiguous().unwrap());
         assert!(write_tensor.layout_summary().contains("shape=[2]"));
         write_tensor.assert_col_major_contiguous().unwrap();
-        write_tensor.copy_from_tensor(&tensor).unwrap();
     }
-    assert_eq!(write_tensor_dst.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+    assert_eq!(write_tensor_dst.as_slice::<f64>().unwrap(), &[0.0, 0.0]);
 
     let mut write_view_data = [0.0_f64, 10.0, 0.0, 20.0];
     {
-        let mut write_view = TensorWrite::from_view(TensorViewMut::F64(
+        let write_view = TensorWrite::from_view(TensorViewMut::F64(
             TypedTensorViewMut::from_slice([2], [2], 1, &mut write_view_data).unwrap(),
         ));
         assert_eq!(write_view.strides().unwrap(), vec![2]);
@@ -1937,44 +1660,8 @@ fn tensor_read_and_write_layout_helpers_cover_tensor_and_view_paths() {
         assert_eq!(write_view.layout_linear_offset(&[1]).unwrap(), 3);
         assert!(!write_view.is_col_major_contiguous().unwrap());
         assert!(write_view.assert_col_major_contiguous().is_err());
-        write_view.copy_from_tensor(&tensor).unwrap();
     }
-    assert_eq!(write_view_data, [0.0, 1.0, 0.0, 2.0]);
-}
-
-#[test]
-fn tensor_write_copy_rejects_dtype_and_shape_mismatch() {
-    let src_f64 = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
-    let src_i32 = Tensor::from_vec_col_major(vec![2], vec![1_i32, 2]).unwrap();
-    let src_short = Tensor::from_vec_col_major(vec![1], vec![1.0_f64]).unwrap();
-
-    let mut dst = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 0.0]).unwrap();
-    {
-        let mut write = TensorWrite::from_tensor(&mut dst);
-        assert!(matches!(
-            write.copy_from_tensor(&src_i32),
-            Err(Error::DTypeMismatch { .. })
-        ));
-        assert!(matches!(
-            write.copy_from_tensor(&src_short),
-            Err(Error::ShapeMismatch { .. })
-        ));
-    }
-
-    let mut data = [0.0_f64, 0.0];
-    {
-        let mut write = TensorViewMut::f64(&[2], &mut data).unwrap();
-        assert!(matches!(
-            write.copy_from_tensor(&src_i32),
-            Err(Error::DTypeMismatch { .. })
-        ));
-        assert!(matches!(
-            write.copy_from_tensor(&src_short),
-            Err(Error::ShapeMismatch { .. })
-        ));
-        write.copy_from_tensor(&src_f64).unwrap();
-    }
-    assert_eq!(data, [1.0, 2.0]);
+    assert_eq!(write_view_data, [0.0, 10.0, 0.0, 20.0]);
 }
 
 tensor_scalar_roundtrip_test!(
@@ -2051,10 +1738,8 @@ fn tensor_write_as_read_borrows_tensor_and_view_outputs() {
     let read = write.as_read();
     assert_eq!(read.dtype(), DType::F64);
     assert_eq!(read.shape(), &[2]);
-    assert_eq!(
-        read.to_tensor().unwrap().as_slice::<f64>().unwrap(),
-        &[3.0, 4.0]
-    );
+    assert!(read.as_tensor().is_none());
+    assert_eq!(read.layout_linear_offset(&[1]).unwrap(), 2);
 }
 
 #[test]

--- a/crates/tenferro-tensor/src/tests/types_tests/strided_dynamic.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests/strided_dynamic.rs
@@ -9,10 +9,7 @@ fn tensor_view_covers_all_dtype_variants() {
             let view = TensorView::$variant(typed);
             assert_eq!(view.dtype(), $dtype);
             assert_eq!(view.shape(), &[2, 2]);
-            assert_eq!(
-                view.to_tensor().unwrap().as_slice::<$ty>().unwrap(),
-                &[$a, $c, $b, $d]
-            );
+            assert_eq!(view.strides(), &[2, 1]);
         }};
     }
 
@@ -61,13 +58,10 @@ fn typed_tensor_view_mut_covers_all_dtype_variants() {
             assert_eq!(view.strides(), &[2, 1]);
             assert_eq!(view.offset(), 0);
             *view.get_mut(&[1, 1]).unwrap() = $replacement;
-            assert_eq!(
-                materialize_typed_view_col_major(&view.as_read_only(), "test")
-                    .unwrap()
-                    .as_slice()
-                    .unwrap(),
-                &[$a, $c, $b, $replacement]
-            );
+            assert_eq!(view.get(&[0, 0]), Some(&$a));
+            assert_eq!(view.get(&[1, 0]), Some(&$c));
+            assert_eq!(view.get(&[0, 1]), Some(&$b));
+            assert_eq!(view.get(&[1, 1]), Some(&$replacement));
             let read = TensorView::$variant(view.as_read_only());
             assert_eq!(read.dtype(), $dtype);
         }};
@@ -126,13 +120,10 @@ fn typed_tensor_view_mut_multi_slice_covers_all_dtype_variants() {
                 *lhs.get_mut(&[1]).unwrap() = $left;
                 *rhs.get_mut(&[0]).unwrap() = $right;
             }
-            assert_eq!(
-                materialize_typed_view_col_major(&view.as_read_only(), "test")
-                    .unwrap()
-                    .as_slice()
-                    .unwrap(),
-                &[$a, $left, $right, $d]
-            );
+            assert_eq!(view.get(&[0]), Some(&$a));
+            assert_eq!(view.get(&[1]), Some(&$left));
+            assert_eq!(view.get(&[2]), Some(&$right));
+            assert_eq!(view.get(&[3]), Some(&$d));
         }};
     }
 

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -425,9 +425,10 @@ impl<T: 'static> TensorBufferRefMut<'_, T> {
 /// stride-compatible, and [`transpose_view`](TypedTensorView::transpose_view)
 /// update only metadata and do not copy storage.
 ///
-/// Use [`TypedTensorView::to_contiguous`] when a compact owned
-/// [`TypedTensor`] is required. Use [`TypedTensorView::as_slice`] only when the
-/// current view is contiguous in the requested layout.
+/// Materialize through [`TensorStructural::to_contiguous_read`](crate::TensorStructural::to_contiguous_read)
+/// on the active backend session when a compact owned [`TypedTensor`] is
+/// required. Use [`TypedTensorView::as_slice`] only when the current view is
+/// contiguous in the requested layout.
 ///
 /// # Examples
 ///
@@ -827,41 +828,6 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
         contiguous_layout_slice(self.layout(), data, "TypedTensorView::as_slice")
     }
 
-    /// Materialize this view as compact column-major host tensor storage.
-    ///
-    /// This is an explicit same-placement copy boundary. Host placement
-    /// metadata is preserved on the materialized tensor. Backend buffers return
-    /// an error here instead of being downloaded implicitly; backend-specific
-    /// compacting paths must stay on that backend.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor::{Rank, TypedTensor};
-    ///
-    /// let tensor = TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 2], vec![1, 2, 3, 4]).unwrap();
-    /// let transposed = tensor.as_view().transpose_view([1, 0])?;
-    /// let compact = transposed.to_contiguous()?;
-    /// assert_eq!(compact.as_slice()?, &[1, 3, 2, 4]);
-    /// # Ok::<(), tenferro_tensor::Error>(())
-    /// ```
-    pub fn to_contiguous(&self) -> crate::Result<TypedTensor<T, R>>
-    where
-        T: Clone,
-    {
-        let op = "TypedTensorView::to_contiguous";
-        let data = materialize_view_buffer_col_major(
-            self.shape(),
-            self.strides(),
-            self.offset(),
-            &self.buffer,
-            op,
-        )?;
-        let shape = R::shape_from_vec(self.shape().to_vec().into())
-            .map_err(|err| tensor_layout_error(op, err))?;
-        TypedTensor::from_buffer_col_major(shape, Buffer::Host(data), self.placement.clone())
-    }
-
     /// Return a metadata-only axis permutation.
     ///
     /// # Examples
@@ -1188,8 +1154,8 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// Mutably borrow the host storage backing this view.
     ///
     /// This exposes the entire backing host allocation, not just the logical
-    /// slice covered by this view. Use [`TypedTensorViewMut::copy_from_contiguous`]
-    /// or element accessors when mutating the logical region instead.
+    /// slice covered by this view. Prefer scalar element accessors when mutating
+    /// a logical region; tensor-sized copies belong to an active backend.
     ///
     /// # Examples
     ///
@@ -1408,85 +1374,6 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
             TensorBufferRefMut::Host(data) => data.get_mut(offset),
             TensorBufferRefMut::Backend(_) => None,
         }
-    }
-
-    /// Copy compact column-major host tensor values into this mutable view.
-    ///
-    /// This is an explicit copy-back boundary. Backend source or destination
-    /// buffers return an error instead of transferring data implicitly.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor::{Rank, TypedTensor};
-    ///
-    /// let mut tensor = TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 2], vec![0, 0, 0, 0]).unwrap();
-    /// let src = TypedTensor::<i32, Rank<2>>::from_vec_col_major([2, 2], vec![1, 2, 3, 4]).unwrap();
-    /// tensor.as_view_mut().transpose_view([1, 0])?.copy_from_contiguous(&src)?;
-    /// assert_eq!(tensor.as_slice()?, &[1, 3, 2, 4]);
-    /// # Ok::<(), tenferro_tensor::Error>(())
-    /// ```
-    pub fn copy_from_contiguous(&mut self, src: &TypedTensor<T, R>) -> crate::Result<()>
-    where
-        T: Clone,
-    {
-        let op = "TypedTensorViewMut::copy_from_contiguous";
-        if self.shape() != src.shape() {
-            return Err(crate::Error::InvalidConfig {
-                op,
-                message: format!(
-                    "shape mismatch: destination {:?} does not match source {:?}",
-                    self.shape(),
-                    src.shape()
-                ),
-            });
-        }
-
-        let src_data = match &src.buffer {
-            Buffer::Host(data) => contiguous_layout_slice(src.layout(), data, op)?,
-            Buffer::Backend(_) => {
-                return Err(crate::Error::backend_failure(
-                    op,
-                    "source backend buffer cannot be copied through host memory; download explicitly first",
-                ))
-            }
-        };
-
-        let shape = self.shape().to_vec();
-        let strides = self.strides().to_vec();
-        let offset = self.offset();
-        let dst_data = match &mut self.buffer {
-            TensorBufferRefMut::Host(data) => data,
-            TensorBufferRefMut::Backend(_) => {
-                return Err(crate::Error::backend_failure(
-                    op,
-                    "destination backend buffer cannot be updated through host memory; download explicitly first",
-                ))
-            }
-        };
-
-        let mut src_iter = src_data.iter();
-        for_each_layout_offset_col_major(&shape, &strides, offset, op, |offset| {
-            let value = src_iter.next().ok_or_else(|| crate::Error::InvalidConfig {
-                op,
-                message: "source tensor ended before destination view".to_string(),
-            })?;
-            let dst = dst_data
-                .get_mut(offset)
-                .ok_or_else(|| crate::Error::InvalidConfig {
-                    op,
-                    message: "destination view offset is outside host buffer".to_string(),
-                })?;
-            *dst = value.clone();
-            Ok(())
-        })?;
-        if src_iter.next().is_some() {
-            return Err(crate::Error::InvalidConfig {
-                op,
-                message: "source tensor has elements remaining after destination copy".to_string(),
-            });
-        }
-        Ok(())
     }
 
     /// Borrow this mutable view as a read-only view.
@@ -2324,8 +2211,8 @@ pub enum TensorWrite<'a> {
 /// Owned lazy tensor view over a shared base tensor.
 ///
 /// This stores only ownership of the base allocation plus logical layout
-/// metadata. Borrow it as [`TensorRead`] for kernels that understand strides,
-/// or materialize it explicitly with [`TensorOwnedView::to_tensor`].
+/// metadata. Borrow it as [`TensorRead`] and materialize it through an active
+/// backend session when compact storage is required.
 #[derive(Clone, Debug)]
 pub struct TensorOwnedView {
     base: Arc<Tensor>,
@@ -2389,27 +2276,6 @@ impl TensorOwnedView {
 
     pub fn tensor_read(&self) -> TensorRead<'_> {
         TensorRead::from_view(self.tensor_view())
-    }
-
-    /// Materialize this owned view into an owned compact tensor.
-    ///
-    /// This returns an explicit error for backend-backed views because no
-    /// backend context is available for an implicit download.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use std::sync::Arc;
-    /// use tenferro_tensor::{Tensor, TensorOwnedView};
-    ///
-    /// let base = Arc::new(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap());
-    /// let view = TensorOwnedView::from_tensor(base);
-    /// let tensor = view.to_tensor()?;
-    /// assert_eq!(tensor.shape(), &[2]);
-    /// # Ok::<(), tenferro_tensor::Error>(())
-    /// ```
-    pub fn to_tensor(&self) -> crate::Result<Tensor> {
-        self.tensor_view().to_tensor()
     }
 
     pub fn transpose_view(&self, axes: impl AsRef<[usize]>) -> crate::Result<Self> {
@@ -2543,31 +2409,6 @@ impl TensorValue {
         match self {
             Self::Tensor(tensor) => TensorRead::from_tensor(tensor.as_ref()),
             Self::View(view) => view.tensor_read(),
-        }
-    }
-
-    /// Materialize this tensor value into an owned compact tensor.
-    ///
-    /// Compact tensor values are cloned. Lazy host views are materialized.
-    /// Backend-backed views return an explicit error instead of panicking.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor::{Tensor, TensorValue};
-    ///
-    /// let value = TensorValue::from_tensor(Tensor::from_vec_col_major(
-    ///     vec![2],
-    ///     vec![1.0_f64, 2.0],
-    /// ).unwrap());
-    /// let tensor = value.to_tensor()?;
-    /// assert_eq!(tensor.shape(), &[2]);
-    /// # Ok::<(), tenferro_tensor::Error>(())
-    /// ```
-    pub fn to_tensor(&self) -> crate::Result<Tensor> {
-        match self {
-            Self::Tensor(tensor) => Ok(tensor.as_ref().clone()),
-            Self::View(view) => view.to_tensor(),
         }
     }
 
@@ -3004,50 +2845,6 @@ impl<'a> TensorView<'a> {
             "TensorView::assert_col_major_contiguous",
         )
     }
-
-    /// Materialize this host view into an owned tensor.
-    ///
-    /// This method has no backend context and does not download backend
-    /// buffers. Use a backend-specific `TensorViewCanonicalization` method or
-    /// an explicit device transfer before materializing backend views on the
-    /// host.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor::{DType, TensorView};
-    ///
-    /// let data = [1.0_f64, 2.0];
-    /// let view = TensorView::f64(&[2], &data)?;
-    /// let tensor = view.to_tensor()?;
-    /// assert_eq!(tensor.dtype(), DType::F64);
-    /// # Ok::<(), tenferro_tensor::Error>(())
-    /// ```
-    pub fn to_tensor(&self) -> crate::Result<Tensor> {
-        match self {
-            Self::F32(t) => {
-                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::F32)
-            }
-            Self::F64(t) => {
-                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::F64)
-            }
-            Self::I32(t) => {
-                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::I32)
-            }
-            Self::I64(t) => {
-                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::I64)
-            }
-            Self::Bool(t) => {
-                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::Bool)
-            }
-            Self::C32(t) => {
-                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::C32)
-            }
-            Self::C64(t) => {
-                materialize_typed_view_col_major(t, "TensorView::to_tensor").map(Tensor::C64)
-            }
-        }
-    }
 }
 
 impl<'a> TensorViewMut<'a> {
@@ -3153,10 +2950,6 @@ impl<'a> TensorViewMut<'a> {
             Self::C64(t) => TensorView::C64(t.as_read_only()),
         }
     }
-
-    pub fn copy_from_tensor(&mut self, src: &Tensor) -> crate::Result<()> {
-        copy_tensor_to_view_mut(self, src, "TensorViewMut::copy_from_tensor")
-    }
 }
 
 impl<'a> TensorRead<'a> {
@@ -3233,31 +3026,6 @@ impl<'a> TensorRead<'a> {
         match self {
             Self::Tensor(tensor) => Some(*tensor),
             Self::View(_) => None,
-        }
-    }
-
-    /// Convert an owned tensor reference or host view into an owned tensor.
-    ///
-    /// This method clones owned tensor inputs and materializes host views. It
-    /// has no backend context and does not download backend buffers. Use a
-    /// backend-specific `TensorViewCanonicalization` method or an explicit
-    /// device transfer before materializing backend views on the host.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use tenferro_tensor::{TensorRead, TensorView};
-    ///
-    /// let data = [1_i32, 2, 3];
-    /// let read = TensorRead::from_view(TensorView::i32(&[3], &data)?);
-    /// let tensor = read.to_tensor()?;
-    /// assert_eq!(tensor.shape(), &[3]);
-    /// # Ok::<(), tenferro_tensor::Error>(())
-    /// ```
-    pub fn to_tensor(&self) -> crate::Result<Tensor> {
-        match self {
-            Self::Tensor(tensor) => Ok((*tensor).clone()),
-            Self::View(view) => view.to_tensor(),
         }
     }
 }
@@ -3354,13 +3122,6 @@ impl<'a> TensorWrite<'a> {
             self.offset(),
             "TensorWrite::assert_col_major_contiguous",
         )
-    }
-
-    pub fn copy_from_tensor(&mut self, src: &Tensor) -> crate::Result<()> {
-        match self {
-            Self::Tensor(dst) => copy_tensor_to_tensor(dst, src, "TensorWrite::copy_from_tensor"),
-            Self::View(view) => copy_tensor_to_view_mut(view, src, "TensorWrite::copy_from_tensor"),
-        }
     }
 }
 
@@ -3492,80 +3253,6 @@ fn assert_layout_col_major_contiguous(
     }
 }
 
-fn validate_tensor_copy_target(
-    dst_dtype: DType,
-    dst_shape: &[usize],
-    src: &Tensor,
-    op: &'static str,
-) -> crate::Result<()> {
-    if dst_dtype != src.dtype() {
-        return Err(crate::Error::DTypeMismatch {
-            op,
-            lhs: dst_dtype,
-            rhs: src.dtype(),
-        });
-    }
-    if dst_shape != src.shape() {
-        return Err(crate::Error::ShapeMismatch {
-            op,
-            lhs: dst_shape.to_vec(),
-            rhs: src.shape().to_vec(),
-        });
-    }
-    Ok(())
-}
-
-fn copy_tensor_to_tensor(dst: &mut Tensor, src: &Tensor, op: &'static str) -> crate::Result<()> {
-    validate_tensor_copy_target(dst.dtype(), dst.shape(), src, op)?;
-    macro_rules! copy_variant {
-        ($variant:ident) => {
-            if let (Tensor::$variant(dst), Tensor::$variant(src)) = (&mut *dst, src) {
-                dst.host_data_mut()?.clone_from_slice(src.host_data()?);
-                return Ok(());
-            }
-        };
-    }
-    copy_variant!(F32);
-    copy_variant!(F64);
-    copy_variant!(I32);
-    copy_variant!(I64);
-    copy_variant!(Bool);
-    copy_variant!(C32);
-    copy_variant!(C64);
-    Err(crate::Error::DTypeMismatch {
-        op,
-        lhs: dst.dtype(),
-        rhs: src.dtype(),
-    })
-}
-
-fn copy_tensor_to_view_mut(
-    dst: &mut TensorViewMut<'_>,
-    src: &Tensor,
-    op: &'static str,
-) -> crate::Result<()> {
-    validate_tensor_copy_target(dst.dtype(), dst.shape(), src, op)?;
-    macro_rules! copy_variant {
-        ($variant:ident) => {
-            if let (TensorViewMut::$variant(dst), Tensor::$variant(src)) = (&mut *dst, src) {
-                return dst.copy_from_contiguous(src);
-            }
-        };
-    }
-    copy_variant!(F32);
-    copy_variant!(F64);
-    copy_variant!(I32);
-    copy_variant!(I64);
-    copy_variant!(Bool);
-    copy_variant!(C32);
-    copy_variant!(C64);
-    Err(crate::Error::DTypeMismatch {
-        op,
-        lhs: dst.dtype(),
-        rhs: src.dtype(),
-    })
-}
-
 fn try_shape_product(shape: &[usize], op: &'static str) -> crate::Result<usize> {
     shape.iter().try_fold(1usize, |acc, &dim| {
         acc.checked_mul(dim)
@@ -3660,95 +3347,6 @@ fn checked_view_offset(
     }
 
     usize::try_from(offset).ok()
-}
-
-fn for_each_layout_offset_col_major(
-    shape: &[usize],
-    strides: &[isize],
-    base_offset: isize,
-    op: &'static str,
-    mut f: impl FnMut(usize) -> crate::Result<()>,
-) -> crate::Result<()> {
-    if shape.len() != strides.len() {
-        return Err(crate::Error::InvalidConfig {
-            op,
-            message: format!(
-                "shape rank {} does not match stride rank {}",
-                shape.len(),
-                strides.len()
-            ),
-        });
-    }
-
-    if shape.contains(&0) {
-        return Ok(());
-    }
-
-    let mut offset = base_offset;
-    if shape.is_empty() {
-        let offset = usize::try_from(offset).map_err(|_| crate::Error::InvalidConfig {
-            op,
-            message: "view offset is negative".to_string(),
-        })?;
-        return f(offset);
-    }
-
-    let mut index = vec![0usize; shape.len()];
-    loop {
-        let physical = usize::try_from(offset).map_err(|_| crate::Error::InvalidConfig {
-            op,
-            message: "view offset is negative".to_string(),
-        })?;
-        f(physical)?;
-
-        let mut advance_axis = None;
-        for axis in 0..shape.len() {
-            let next_index =
-                index[axis]
-                    .checked_add(1)
-                    .ok_or_else(|| crate::Error::InvalidConfig {
-                        op,
-                        message: "logical index overflows".to_string(),
-                    })?;
-            if next_index < shape[axis] {
-                advance_axis = Some((axis, next_index));
-                break;
-            }
-        }
-
-        let Some((advance_axis, next_index)) = advance_axis else {
-            return Ok(());
-        };
-
-        for axis in 0..advance_axis {
-            let steps = isize::try_from(index[axis]).map_err(|_| crate::Error::InvalidConfig {
-                op,
-                message: "logical index does not fit in isize".to_string(),
-            })?;
-            let rewind =
-                strides[axis]
-                    .checked_mul(steps)
-                    .ok_or_else(|| crate::Error::InvalidConfig {
-                        op,
-                        message: "stride rewind overflows".to_string(),
-                    })?;
-            offset = offset
-                .checked_sub(rewind)
-                .ok_or_else(|| crate::Error::InvalidConfig {
-                    op,
-                    message: "view offset rewind overflows".to_string(),
-                })?;
-            index[axis] = 0;
-        }
-
-        offset = offset.checked_add(strides[advance_axis]).ok_or_else(|| {
-            crate::Error::InvalidConfig {
-                op,
-                message: "view offset overflows".to_string(),
-            }
-        })?;
-        index[advance_axis] = next_index;
-    }
 }
 
 fn reachable_layout_span(
@@ -3887,36 +3485,6 @@ fn contiguous_layout_slice<'a, T, R: TensorRank>(
             op,
             message: "contiguous view range is outside host buffer".to_string(),
         })
-}
-
-fn materialize_view_buffer_col_major<T: Clone>(
-    shape: &[usize],
-    strides: &[isize],
-    offset: isize,
-    buffer: &TensorBufferRef<'_, T>,
-    op: &'static str,
-) -> crate::Result<Vec<T>> {
-    let source = match buffer {
-        TensorBufferRef::Host(data) => *data,
-        TensorBufferRef::Backend(_) => return Err(crate::Error::backend_failure(
-            op,
-            "backend buffers cannot be materialized through host memory; download explicitly first",
-        )),
-    };
-
-    let n_elements = checked_view_element_count(shape, op)?;
-    let mut out = Vec::with_capacity(n_elements);
-    for_each_layout_offset_col_major(shape, strides, offset, op, |physical| {
-        let value = source
-            .get(physical)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op,
-                message: "view offset is outside host buffer".to_string(),
-            })?;
-        out.push(value.clone());
-        Ok(())
-    })?;
-    Ok(out)
 }
 
 fn relaxed_col_major_contiguous(
@@ -4100,20 +3668,6 @@ fn slice_axis_specs(
     let mut slices = vec![StridedSliceSpec::all(); rank];
     slices[axis] = slice;
     Ok(slices)
-}
-
-pub(crate) fn materialize_typed_view_col_major<T: Clone + 'static, R: TensorRank>(
-    view: &TypedTensorView<'_, T, R>,
-    op: &'static str,
-) -> crate::Result<TypedTensor<T>> {
-    let data = materialize_view_buffer_col_major(
-        view.shape(),
-        view.strides(),
-        view.offset(),
-        &view.buffer,
-        op,
-    )?;
-    TypedTensor::from_vec_col_major(view.shape().to_vec(), data)
 }
 
 pub(crate) fn default_placement() -> Placement {

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -328,6 +328,14 @@ Same-placement canonicalization is allowed: host views may be copied into host
 compact tensors, and GPU views may be copied into compact tensors on the same
 GPU provider. It is not a transfer mechanism.
 
+The object-safe CUDA runtime boundaries have deliberately narrower current
+contracts. `to_contiguous_read` canonicalizes numeric and complex CUDA reads on
+the active device; `Bool` is an explicit current limitation. `copy_read_into`
+requires a compact column-major source with offset zero covering its full
+allocation. Its destination may be an arbitrary valid non-overlapping CUDA
+view, but source and destination allocations must not alias. Both operations
+preserve CUDA residency and never stage tensor payloads through host memory.
+
 ```text
 use tenferro_gpu::{download_tensor, upload_tensor, CudaBackend};
 use tenferro_tensor::{Tensor, TensorBackend};

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -264,6 +264,8 @@ descriptor.
 | `gather` | operand `F32`, `F64`, `I32`, `Bool`, `C32`, `C64`; indices `F32`, `F64`, `I32`, or `I64` | Complex and `Bool` index tensors; `I64` operands are not implemented |
 | `scatter` | operand/update `F32`, `F64`, `C32`, `C64`; indices `F32`, `F64`, `I32`, or `I64` | Add-scatter semantics; complex and `Bool` index tensors and integer/`Bool` operands are not implemented |
 | `slice`, `pad`, `concatenate`, `reverse` | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Dense structural/indexing operations |
+| `to_contiguous_read` | `F32`, `F64`, `I32`, `I64`, `C32`, `C64` | Same-device canonicalization of owned tensors and arbitrary valid CUDA views; `Bool` is an explicit current limitation |
+| `copy_read_into` | `F32`, `F64`, `I32`, `I64`, `C32`, `C64` | Source must be compact column-major with offset zero and cover its full allocation; destination may be strided; allocations must not alias; `Bool` is an explicit current limitation |
 | `dynamic_slice` | input `F32`, `F64`, `I32`, `Bool`, `C32`, `C64` with starts `F32`, `F64`, `I32`, or `I64` | Complex and `Bool` start tensors; `I64` inputs are not implemented |
 | `dynamic_update_slice` | No CUDA implementation | Returns an error |
 | `cholesky`, `triangular_solve`, `lu`, `svd`, `qr`, `eigh`, `solve` | `F32`, `F64`, `C32`, `C64` | cuSOLVER/cuBLAS-backed; integer and `Bool` dtypes are not implemented |

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -122,6 +122,33 @@ Owned tensors stay compact column-major. Metadata-only strided views live on
 storage may copy a view into compact storage on the same device, but they do
 not silently upload CPU tensors or download CUDA tensors.
 
+## Materializing metadata-only views
+
+View transforms such as transpose and slice only change layout metadata. When
+an owned compact tensor is required, materialize through the active backend so
+the copy uses that backend's memory pool and thread policy:
+
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::{TensorViewCanonicalization, TypedTensor};
+
+let tensor = TypedTensor::<f64>::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+).unwrap();
+let view = tensor.as_view().transpose_view([1, 0]).unwrap();
+let mut backend = CpuBackend::new();
+let compact = backend.to_contiguous(&view).unwrap();
+
+assert_eq!(compact.shape(), &[3, 2]);
+assert_eq!(compact.as_slice().unwrap(), &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
+```
+
+The same rule applies to caller-owned destinations through the backend
+canonicalization capability. Backend-neutral tensor and view types own layout
+metadata, not CPU memory reuse or Rayon configuration. Same-placement
+canonicalization never performs a hidden CPU/GPU transfer.
+
 ## Arithmetic
 
 ```rust

--- a/docs/guides/parallelism-and-caching.md
+++ b/docs/guides/parallelism-and-caching.md
@@ -85,11 +85,48 @@ pool before dispatching tensor-sized kernels.
 | --- | --- |
 | Elementwise and analytic ops | `strided-kernel` map/zip kernels run under `CpuContext` and can use Rayon when the context has more than one thread. |
 | Reductions | `strided-kernel::reduce_axis` runs under `CpuContext` and can use Rayon when the context has more than one thread. |
-| Materialized transpose/permute, broadcast, convert, and diagonal extraction | `strided-kernel` copy/map kernels run under `CpuContext` and can use Rayon for tensor-sized copies. |
+| View materialization, transpose/permute, broadcast, convert, and diagonal extraction | `strided-kernel` copy/map kernels run under `CpuContext` and can use Rayon for tensor-sized copies. |
 | `dot_general` through `cpu-faer` | faer receives `Par::Seq` for one-thread contexts and `Par::rayon(0)` inside the owned `CpuContext` pool for multi-thread contexts. |
 | GEMM and linalg through `cpu-blas` | Threading is owned by the linked BLAS/LAPACK provider, not Rayon. Configure the provider variables below. |
 | Supported `dot_general` contractions through `cpu-tblis` | TBLIS owns provider threading; unsupported TBLIS shapes fall back to the compiled faer/BLAS provider. |
 | Indexing, scatter/gather, slicing, padding, concatenation, reverse, triangular masks, and `embed_diagonal` | These are dedicated sequential CPU loops today because their per-output indexing patterns do not yet have a strided-kernel/backend-native parallel primitive. They still run inside `CpuContext::install`, and source comments mark the intentional sequential path. |
+
+CPU affine-strided copy, permutation, broadcast, map, zip-map, and axis
+reduction delegate to `strided-rs`, while tenferro supplies operation semantics,
+validation, dtype and placement checks, error translation, and execution
+resources. Einsum/dot-general is the benchmark-backed tenferro exception:
+tenferro owns its planning, optimized preparation, and provider integration.
+
+Even a host-to-host materialization must enter through `CpuBackend`. The
+backend owns a persistent buffer pool, can allocate an uninitialized output
+when the copy fully overwrites it, and runs the kernel in the configured
+`CpuContext` Rayon pool. That scope also preserves nested-execution safety and
+the kernel's serial/parallel threshold. A context-free copy, a temporary buffer
+pool, or Rayon's ambient global pool would create a second memory and threading
+policy. Memory reuse and thread policy are execution resources, not tensor
+metadata.
+
+Use the backend-owned canonicalization operation when a metadata-only view must
+become compact:
+
+```rust
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::{TensorViewCanonicalization, TypedTensor};
+
+let tensor = TypedTensor::<f64>::from_vec_col_major(
+    vec![2, 3],
+    vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+).unwrap();
+let transposed = tensor.as_view().transpose_view([1, 0]).unwrap();
+let mut backend = CpuBackend::with_threads(4).unwrap();
+let compact = backend.to_contiguous(&transposed).unwrap();
+
+assert_eq!(compact.shape(), &[3, 2]);
+assert_eq!(compact.as_slice().unwrap(), &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
+```
+
+Canonicalization preserves placement; it does not silently upload host data or
+download device data.
 
 ## BLAS And LAPACK Threads
 

--- a/docs/superpowers/plans/2026-07-16-strided-materialization-api-convergence.md
+++ b/docs/superpowers/plans/2026-07-16-strided-materialization-api-convergence.md
@@ -1,0 +1,471 @@
+# Strided Materialization API Convergence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make backend-owned `strided-rs` copying the only CPU implementation for tensor-view materialization, copy-back, and structural read paths.
+
+**Architecture:** `tenferro-tensor` retains layout metadata and object-safe backend contracts but no public context-free tensor-sized copy loops. `tenferro-cpu` converts validated tenferro views to `strided_kernel` views, allocates through its `BufferPool`, and runs every copy inside `CpuContext`; CPU structural read operations reuse that helper without intermediate materialization. CUDA keeps same-device kernels behind the same renamed copy contract.
+
+**Tech Stack:** Rust 2021, `tenferro-tensor`, `tenferro-cpu`, `tenferro-gpu`, `strided-kernel 0.3`, Rayon through `CpuContext`, Criterion, Cargo tests/doctests.
+
+---
+
+### Task 1: Establish one pool-aware CPU view-copy primitive
+
+**Files:**
+- Modify: `crates/tenferro-cpu/src/lib.rs`
+- Modify: `crates/tenferro-cpu/src/structural.rs`
+- Test: `crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs`
+- Test: `crates/tenferro-cpu/src/tests/cpu_stub_tests.rs`
+
+- [ ] **Step 1: Write failing materialization tests**
+
+Add tests that call a pool-aware CPU materializer on compact, transposed,
+negative-stride, zero-stride broadcast, empty, rank-zero, and nonzero-offset
+views. Include a 24-axis scattered layout with explicit positive strides and
+compare exact column-major output against logical `get` traversal. Exercise all
+seven dtype variants through `TensorView`.
+
+The core regression should use the public backend path:
+
+```rust
+let mut backend = CpuBackend::with_threads(4).unwrap();
+let view = tensor.as_view().transpose_view(&perm).unwrap();
+let compact = backend.to_contiguous(&view).unwrap();
+assert_eq!(compact.as_slice().unwrap(), expected.as_slice());
+```
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p tenferro-cpu --release cpu_view_materialization -- --nocapture
+```
+
+Expected: FAIL because `CpuBackend::to_contiguous` still delegates to the
+serial `TypedTensorView::to_contiguous` path and the new source-contract
+assertion cannot find a `strided_kernel::copy_into` materializer.
+
+- [ ] **Step 3: Implement the typed strided copy helpers**
+
+In `structural.rs`, add crate-private helpers with these responsibilities:
+
+```rust
+pub(crate) fn typed_materialize_view_with_pool<T, R>(
+    buffers: &mut BufferPool,
+    view: &TypedTensorView<'_, T, R>,
+    op: &'static str,
+) -> crate::Result<TypedTensor<T, R>>
+where
+    T: Copy + Clone + PoolScalar + 'static,
+    R: TensorRank;
+
+pub(crate) fn typed_copy_view_into<T, RS, RD>(
+    src: &TypedTensorView<'_, T, RS>,
+    dst: &mut TypedTensorViewMut<'_, T, RD>,
+    op: &'static str,
+) -> crate::Result<()>
+where
+    T: Copy + Send + Sync + 'static,
+    RS: TensorRank,
+    RD: TensorRank;
+```
+
+Both helpers must construct `StridedView`/`StridedViewMut` from the existing
+shape, strides, offset, and host allocation, validate shape equality, map
+`strided-kernel` errors to the supplied operation name, and call
+`strided_kernel::copy_into`. Allocate the materialized destination with
+`typed_array_uninit_from_pool`; preserve rank and placement metadata when
+wrapping the output.
+
+Replace `materialize_tensor_read` with a `BufferPool`-accepting dtype dispatcher
+that invokes `typed_materialize_view_with_pool` for views and uses the existing
+compact clone path for owned tensors.
+
+- [ ] **Step 4: Route `CpuBackend` and `CpuExecSession` through the helper**
+
+Use `install_with_pool`/`run_native` so both public backend and session paths run
+inside the configured `CpuContext` and persistent pool. Do not construct a
+temporary `CpuBackend` or `BufferPool`.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+```bash
+cargo test -p tenferro-cpu --release cpu_view_materialization -- --nocapture
+cargo test -p tenferro-cpu --release materialize_tensor_read -- --nocapture
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/tenferro-cpu/src/lib.rs crates/tenferro-cpu/src/structural.rs \
+  crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs \
+  crates/tenferro-cpu/src/tests/cpu_stub_tests.rs
+git commit -m "perf(cpu): materialize views through strided copy"
+```
+
+### Task 2: Eliminate double materialization in structural read operations
+
+**Files:**
+- Modify: `crates/tenferro-cpu/src/structural.rs`
+- Modify: `crates/tenferro-cpu/src/backend.rs`
+- Modify: `crates/tenferro-cpu/src/exec_session.rs`
+- Test: `crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs`
+- Test: `crates/tenferro-cpu/tests/backend_capability_contracts.rs`
+
+- [ ] **Step 1: Write failing direct-view tests**
+
+Add exact-output tests for `transpose_read`, `reshape_read`, and
+`broadcast_in_dim_read` using explicit-stride `TensorView` inputs. Add a
+source-contract test requiring those methods to dispatch to typed view helpers
+and forbidding `materialize_tensor_read("transpose"`,
+`materialize_tensor_read("reshape"`, and
+`materialize_tensor_read("broadcast_in_dim"` in their bodies.
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+```bash
+cargo test -p tenferro-cpu --release structural_read -- --nocapture
+cargo test -p tenferro-cpu --test backend_capability_contracts --release
+```
+
+Expected: the source contract fails because all three view paths currently
+materialize an intermediate tensor.
+
+- [ ] **Step 3: Add dtype-dispatched direct view helpers**
+
+Add these helpers in `structural.rs`:
+
+```rust
+pub(crate) fn transpose_read_with_pool(
+    buffers: &mut BufferPool,
+    input: TensorRead<'_>,
+    perm: &[usize],
+) -> crate::Result<Tensor>;
+
+pub(crate) fn reshape_read_with_pool(
+    buffers: &mut BufferPool,
+    input: TensorRead<'_>,
+    shape: &[usize],
+) -> crate::Result<Tensor>;
+
+pub(crate) fn broadcast_in_dim_read_with_pool(
+    buffers: &mut BufferPool,
+    input: TensorRead<'_>,
+    shape: &[usize],
+    dims: &[usize],
+) -> crate::Result<Tensor>;
+```
+
+`transpose_read_with_pool` calls `typed_transpose_view_with_pool` directly.
+`reshape_read_with_pool` validates element counts, copies the source logical
+order once into compact pooled storage, then attaches the requested compact
+shape. `broadcast_in_dim_read_with_pool` builds aligned dimensions and strides
+from the original view, uses `StridedView::broadcast`, and copies directly to
+the final output.
+
+- [ ] **Step 4: Share helpers across backend and execution session**
+
+Replace the duplicated `TensorStructural` overrides in `backend.rs` and
+`exec_session.rs` with calls to the three helpers inside their existing
+execution-resource scopes.
+
+- [ ] **Step 5: Verify GREEN and commit**
+
+```bash
+cargo test -p tenferro-cpu --release structural_read -- --nocapture
+cargo test -p tenferro-cpu --test backend_capability_contracts --release
+git add crates/tenferro-cpu/src/structural.rs crates/tenferro-cpu/src/backend.rs \
+  crates/tenferro-cpu/src/exec_session.rs \
+  crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs \
+  crates/tenferro-cpu/tests/backend_capability_contracts.rs
+git commit -m "perf(cpu): consume strided views in structural reads"
+```
+
+### Task 3: Replace asymmetric copy-back with backend `copy_into`
+
+**Files:**
+- Modify: `crates/tenferro-tensor/src/backend.rs`
+- Modify: `crates/tenferro-tensor/src/lib.rs`
+- Modify: `crates/tenferro-cpu/src/backend.rs`
+- Modify: `crates/tenferro-gpu/src/cubecl/mod.rs`
+- Test: `crates/tenferro-cpu/src/tests/cpu_stub_tests.rs`
+- Test: `crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs`
+- Test: `crates/tenferro-tensor/src/tests/public_surface_contract_tests.rs`
+
+- [ ] **Step 1: Write failing public-contract and behavior tests**
+
+Require `TensorViewCanonicalization::copy_into` to accept readable and writable
+views, including strided source and destination layouts. Assert that
+`copy_from_contiguous` is absent from the public trait. Cover shape mismatch,
+CPU/backend-buffer rejection, CUDA host/device rejection, and exact transpose
+copy-back behavior.
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test -p tenferro-tensor --release public_surface_contract -- --nocapture
+cargo test -p tenferro-cpu --release canonicalization -- --nocapture
+```
+
+Expected: compile/source-contract failure because only
+`copy_from_contiguous` exists.
+
+- [ ] **Step 3: Change the typed capability contract**
+
+Tighten the trait scalar bound from `T: Clone` to `T: TensorScalar` and replace
+the copy method with:
+
+```rust
+fn copy_into(
+    &mut self,
+    src: &TypedTensorView<'_, T, R>,
+    dst: &mut TypedTensorViewMut<'_, T, R>,
+) -> crate::Result<()>;
+```
+
+The typed trait continues to require matching rank parameters. The dtype-erased
+runtime operation in Task 4 handles dynamically ranked views. Do not restore a
+serial fallback.
+
+- [ ] **Step 4: Implement CPU and CUDA adapters**
+
+CPU delegates to `typed_copy_view_into` inside `CpuContext::install`. CUDA
+renames the existing contiguous-to-view kernel path and validates that its
+source is compact; arbitrary-stride CUDA source-to-destination copying is not
+added in this CPU-focused change. Preserve same-device and no-hidden-transfer
+errors.
+
+- [ ] **Step 5: Verify GREEN and commit**
+
+```bash
+cargo test -p tenferro-tensor --release public_surface_contract -- --nocapture
+cargo test -p tenferro-cpu --release canonicalization -- --nocapture
+cargo test -p tenferro-gpu --release structural_tests -- --nocapture
+git add crates/tenferro-tensor/src/backend.rs crates/tenferro-tensor/src/lib.rs \
+  crates/tenferro-cpu/src/backend.rs crates/tenferro-gpu/src/cubecl/mod.rs \
+  crates/tenferro-cpu/src/tests/cpu_stub_tests.rs \
+  crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs \
+  crates/tenferro-tensor/src/tests/public_surface_contract_tests.rs
+git commit -m "refactor(tensor): make backend copy_into canonical"
+```
+
+### Task 4: Make runtime and eager materialization backend-owned
+
+**Files:**
+- Modify: `crates/tenferro-tensor/src/backend.rs`
+- Modify: `crates/tenferro-tensor/src/types.rs`
+- Modify: `crates/tenferro-runtime/src/exec.rs`
+- Modify: `crates/tenferro-runtime/src/graph/executor.rs`
+- Modify: `crates/tenferro-runtime/src/graph/executor/tests.rs`
+- Modify: `crates/tenferro-runtime/tests/runtime_public_api.rs`
+- Modify: `crates/tenferro-ad/src/eager.rs`
+- Modify: `crates/tenferro-ad/src/eager_exec.rs`
+- Modify: `crates/tenferro-ad/src/eager_ops.rs`
+- Modify: `crates/tenferro-ad/tests/eager_tensor.rs`
+- Modify: `crates/tenferro-ad/tests/numpy_api.rs`
+- Modify: `crates/tenferro-ad/tests/segment_tests.rs`
+- Modify: `crates/tenferro-einsum/src/eager.rs`
+- Modify: `crates/tenferro-einsum/tests/traced_extension.rs`
+- Modify: `crates/tenferro-einsum/tests/traced_graph_cache.rs`
+- Modify: `crates/tenferro-fft/src/lib.rs`
+- Modify: `crates/tenferro-tensor/src/tests/backend_default_read_tests.rs`
+- Modify: `crates/tenferro-tensor/src/tests/types_tests.rs`
+- Modify: `crates/tenferro-tensor/src/tests/types_tests/strided_dynamic.rs`
+- Test: `crates/tenferro-ad/tests/eager_tensor.rs`
+- Test: `crates/tenferro-runtime/tests/runtime_public_api.rs`
+
+- [ ] **Step 1: Write failing backend-owned materialization tests**
+
+Add tests proving that lazy `EagerTensor::to_tensor` and graph/runtime result
+materialization invoke a backend session canonicalizer. Use a recording backend
+whose materialization method increments a counter; assert one call for a lazy
+view and zero calls for an already-owned tensor.
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test -p tenferro-ad --release eager_materialization_uses_backend -- --nocapture
+cargo test -p tenferro-runtime --release runtime_materialization_uses_backend -- --nocapture
+```
+
+Expected: tests fail because `TensorValue::to_tensor` and `TensorRead::to_tensor`
+currently materialize without a backend.
+
+- [ ] **Step 3: Add an object-safe runtime materialization operation**
+
+Add to `TensorStructural`:
+
+```rust
+fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor>;
+fn copy_read_into(
+    &mut self,
+    src: TensorRead<'_>,
+    dst: TensorWrite<'_>,
+) -> crate::Result<()>;
+```
+
+Provide conservative defaults that clone an owned compact input and reject
+unsupported views with the existing read-boundary error. Override both methods
+in CPU and CUDA backends/sessions. CPU dispatches to Tasks 1 and 3; CUDA
+dispatches to its same-device typed kernels.
+
+- [ ] **Step 4: Remove context-free data-moving methods**
+
+Delete the public methods and their serial helpers:
+
+```text
+TypedTensorView::to_contiguous
+TypedTensorViewMut::copy_from_contiguous
+TensorView::to_tensor
+TensorRead::to_tensor
+TensorOwnedView::to_tensor
+TensorValue::to_tensor
+materialize_view_buffer_col_major
+materialize_typed_view_col_major
+```
+
+Keep metadata-only methods and scalar indexed access. Update rustdoc links and
+public-surface tests so no context-free equivalent remains.
+
+- [ ] **Step 5: Migrate runtime/eager/extension callers**
+
+Pass the active `dyn BackendSession` to materialization sites. Add
+`GraphExecutor::materialize_value(&TensorValue) -> Result<Tensor>` for public
+graph results and update examples to call it. Keep
+`EagerTensor::to_tensor` as a public no-argument method because its context owns
+the backend; implement it through `with_backend_session`. Ensure graph executor
+internal result APIs materialize through their executor-owned backend before
+returning compact output where their existing public API promises `Tensor`.
+Update FFT/einsum fallback paths to call their active backend/session rather
+than tensor-type methods.
+
+- [ ] **Step 6: Verify GREEN and commit**
+
+```bash
+cargo test -p tenferro-tensor --release
+cargo test -p tenferro-runtime --release
+cargo test -p tenferro-ad --release
+cargo test -p tenferro-einsum --release
+cargo test -p tenferro-fft --release
+git add crates/tenferro-tensor crates/tenferro-runtime crates/tenferro-ad \
+  crates/tenferro-einsum crates/tenferro-fft
+git commit -m "refactor(runtime): require backend-owned materialization"
+```
+
+### Task 5: Record ownership policy and add focused benchmarks
+
+**Files:**
+- Modify: `REPOSITORY_RULES.md`
+- Modify: `docs/guides/parallelism-and-caching.md`
+- Modify: `docs/guides/eager-operations.md`
+- Create: `crates/tenferro-cpu/benches/view_materialization.rs`
+- Modify: `crates/tenferro-cpu/Cargo.toml`
+- Create: `docs/worklogs/2026-07-16-strided-materialization-api-convergence.md`
+- Test: `crates/tenferro-cpu/tests/backend_capability_contracts.rs`
+
+- [ ] **Step 1: Write failing ownership source-contract test**
+
+Require repository rules to state that CPU affine-strided copy, permutation,
+broadcast, map, zip-map, and axis reduction delegate to `strided-rs`; record
+einsum as the benchmark-backed exception. Require context-free materialization
+method names to be absent from `tenferro-tensor` source.
+
+- [ ] **Step 2: Verify RED**
+
+```bash
+cargo test -p tenferro-cpu --test backend_capability_contracts --release
+```
+
+Expected: FAIL until rules and removed-surface assertions are updated.
+
+- [ ] **Step 3: Update rules and user documentation**
+
+Document the ownership table from the approved design, the backend-required
+materialization API, CPU threading/pool behavior, and the no-hidden-transfer
+contract. Remove examples using context-free `to_contiguous`/`to_tensor`.
+
+- [ ] **Step 4: Add a non-asserting Criterion benchmark**
+
+Benchmark `CpuBackend::to_contiguous` at one and four threads for:
+
+- compact 3D input;
+- permuted 3D input;
+- high-rank contiguous permutation;
+- the scattered 24D explicit-stride layout;
+- a tiny transpose to expose dispatch overhead.
+
+Allocate the destination inside each timed iteration and verify exact output
+once before timing. Register the bench with `harness = false` in the CPU crate
+manifest.
+
+- [ ] **Step 5: Write the worklog, verify, and commit**
+
+```bash
+cargo test -p tenferro-cpu --test backend_capability_contracts --release
+cargo bench -p tenferro-cpu --bench view_materialization --no-run
+git add REPOSITORY_RULES.md docs/guides crates/tenferro-cpu/Cargo.toml \
+  crates/tenferro-cpu/benches/view_materialization.rs \
+  crates/tenferro-cpu/tests/backend_capability_contracts.rs \
+  docs/worklogs/2026-07-16-strided-materialization-api-convergence.md
+git commit -m "docs(cpu): contract strided kernel ownership"
+```
+
+### Task 6: Full verification
+
+**Files:**
+- Review: all files changed since `origin/main`
+
+- [ ] **Step 1: Run formatting and clippy parity**
+
+```bash
+cargo fmt --all --check
+```
+
+Read `.github/workflows` and run the exact non-GPU clippy command used by CI.
+Expected: exit 0 with no warnings.
+
+- [ ] **Step 2: Run the full release test and docs gates**
+
+```bash
+cargo test --workspace --release
+cargo doc --workspace --no-deps
+python3 scripts/check-docs-site.py
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 3: Run coverage**
+
+```bash
+cargo llvm-cov --workspace --release --json --output-path coverage.json
+python3 scripts/check-coverage.py coverage.json
+```
+
+Expected: coverage policy passes for every modified source file.
+
+- [ ] **Step 4: Run repository-rule review**
+
+```bash
+python3 scripts/repository-rules-review.py \
+  --base origin/main \
+  --head HEAD \
+  --output-json /tmp/repository-rules-review.json
+```
+
+Read the JSON and fix every actionable finding or record a justified residual
+risk in the worklog.
+
+- [ ] **Step 5: Inspect final diff and status**
+
+```bash
+git diff --check origin/main...HEAD
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+Expected: no whitespace errors, no uncommitted files other than explicitly
+reported generated coverage output, and coherent commits matching Tasks 1-5.

--- a/docs/superpowers/plans/2026-07-16-strided-materialization-api-convergence.md
+++ b/docs/superpowers/plans/2026-07-16-strided-materialization-api-convergence.md
@@ -374,6 +374,14 @@ broadcast, map, zip-map, and axis reduction delegate to `strided-rs`; record
 einsum as the benchmark-backed exception. Require context-free materialization
 method names to be absent from `tenferro-tensor` source.
 
+The source contract must also require the rule rationale: CPU materialization
+enters through `CpuBackend` because high-performance execution needs its
+persistent `BufferPool`, fully-overwritten uninitialized output allocation,
+configured `CpuContext` Rayon pool, nested-execution safety, and
+serial/parallel threshold policy. Merely calling `strided-rs` from a
+context-free method or on Rayon's ambient global pool is explicitly
+non-compliant.
+
 - [ ] **Step 2: Verify RED**
 
 ```bash
@@ -386,7 +394,10 @@ Expected: FAIL until rules and removed-surface assertions are updated.
 
 Document the ownership table from the approved design, the backend-required
 materialization API, CPU threading/pool behavior, and the no-hidden-transfer
-contract. Remove examples using context-free `to_contiguous`/`to_tensor`.
+contract. Explain why CPU host copies still require backend ownership: memory
+reuse and thread policy are execution resources, not tensor metadata. Ban
+throwaway pools and ambient-global-Rayon execution for public tensor-sized CPU
+operations. Remove examples using context-free `to_contiguous`/`to_tensor`.
 
 - [ ] **Step 4: Add a non-asserting Criterion benchmark**
 

--- a/docs/superpowers/specs/2026-07-16-strided-materialization-api-convergence-design.md
+++ b/docs/superpowers/specs/2026-07-16-strided-materialization-api-convergence-design.md
@@ -30,6 +30,14 @@ Public APIs with the same materialization semantics must converge on one
 backend-aware implementation. Tenferro will not retain a context-free serial
 fallback under an equivalent public name.
 
+This boundary is required even for host-only CPU data. Fast materialization is
+not only a choice of copy loop: it requires ownership of reusable memory
+buffers, uninitialized destinations that will be fully overwritten, the
+configured Rayon thread pool, nested-execution safety, and serial/parallel
+threshold policy. Those resources and policies belong to `CpuBackend` and
+`CpuContext`; a context-free tensor method would either bypass them or create a
+second hidden/global execution policy.
+
 Einsum is the explicit exception to the general CPU delegation rule. Tenferro
 keeps its optimized einsum/dot-general preparation and provider integration.
 New exceptions require an accepted issue, comparative benchmark evidence, and
@@ -133,6 +141,12 @@ by an existing `strided-rs` primitive, the bulk traversal must use that
 primitive. If the primitive is missing and the operation is generally useful,
 the preferred sequence is to add it to `strided-rs` first and then consume it
 from tenferro.
+
+Using a `strided-rs` function outside a backend execution scope does not satisfy
+this contract. CPU tensor-sized work must enter through the backend so the
+operation uses the backend's persistent `BufferPool` and configured
+`CpuContext`/Rayon policy. Public free functions or context-free methods must
+not allocate throwaway pools or run on Rayon's ambient global pool.
 
 ## Scope
 

--- a/docs/superpowers/specs/2026-07-16-strided-materialization-api-convergence-design.md
+++ b/docs/superpowers/specs/2026-07-16-strided-materialization-api-convergence-design.md
@@ -1,0 +1,217 @@
+# Strided Materialization API Convergence Design
+
+## Context
+
+Issue #1393 shows that two public routes with the same materialization
+semantics have materially different CPU performance:
+
+- `TypedTensorView::to_contiguous` performs a context-free serial logical
+  traversal in `tenferro-tensor`.
+- backend structural operations such as `CpuBackend::transpose` materialize
+  through the backend buffer pool and `strided-kernel::copy_into` inside the
+  configured `CpuContext`.
+
+The split is historical. The context-free method descended from a generic
+host-view adapter requiring only `T: Clone`; the backend canonicalization trait
+was later added for same-placement CPU/GPU behavior and delegated to that host
+adapter on CPU. Subsequent `strided-kernel` parallelization improved structural
+operations but did not migrate view canonicalization.
+
+This design treats the performance divergence as an API ownership defect, not
+as a request for a second optimized convenience method.
+
+## Decision
+
+For CPU execution, affine-strided traversal and bulk data movement are owned by
+`strided-rs`. Tenferro owns tensor semantics, validation, dtype dispatch,
+placement checks, `CpuContext`, buffer pooling, and error translation.
+
+Public APIs with the same materialization semantics must converge on one
+backend-aware implementation. Tenferro will not retain a context-free serial
+fallback under an equivalent public name.
+
+Einsum is the explicit exception to the general CPU delegation rule. Tenferro
+keeps its optimized einsum/dot-general preparation and provider integration.
+New exceptions require an accepted issue, comparative benchmark evidence, and
+a recorded ownership rationale.
+
+## API Surface
+
+### Canonical backend operations
+
+The backend canonicalization capability remains the public execution boundary
+and provides two operations:
+
+1. `to_contiguous`: allocate a compact column-major tensor in the same
+   placement and copy a readable view into it.
+2. `copy_into`: copy from a readable tensor/view into a caller-owned mutable
+   tensor/view with matching shape and dtype.
+
+`copy_into` replaces the asymmetric `copy_from_contiguous` contract. The source
+and destination may both be strided. Validation occurs before allocation or
+kernel dispatch.
+
+The dtype-erased operation must be usable through runtime/backend trait objects.
+Typed convenience entry points may remain on concrete backends, but they must
+delegate to the same internal implementation and require `TensorScalar`, whose
+`Copy + Send + Sync` bounds match `strided-kernel`.
+
+### Removed context-free execution APIs
+
+The following data-moving APIs are removed from the backend-neutral tensor
+types:
+
+- `TypedTensorView::to_contiguous`
+- `TypedTensorViewMut::copy_from_contiguous`
+- `TensorView::to_tensor`
+- backend-less `to_tensor` methods on lazy owned-view/value wrappers
+
+Metadata-only methods such as `transpose_view`, `reshape_view`, and
+`slice_view` remain on view types. High-level APIs such as `EagerTensor::to_tensor`
+remain available because their runtime context owns a backend; their
+implementation must call the backend canonicalization operation rather than a
+host fallback.
+
+No deprecated compatibility shims are retained. Repository policy prefers
+changing the canonical API directly when a public design mismatch is the root
+cause.
+
+## CPU Architecture
+
+`tenferro-cpu` gains one pool-aware typed copy helper with this data flow:
+
+```text
+TypedTensorView / TensorView
+    -> validate host placement, shape, strides, offset, and reachable range
+    -> construct strided_kernel::StridedView without copying
+    -> acquire compact or caller-provided destination storage
+    -> construct strided_kernel::StridedViewMut
+    -> strided_kernel::copy_into inside CpuContext::install
+    -> wrap the output with tenferro placement and layout metadata
+```
+
+The helper supports all tenferro scalar dtypes, rank zero, empty tensors,
+singleton axes, positive and negative strides, nonzero offsets, and zero-stride
+read-only broadcast views. Mutable destination construction continues to rely
+on tenferro's no-overlap validation.
+
+Allocation for `to_contiguous` uses the backend `BufferPool` and does not
+zero-initialize storage that the copy kernel fully overwrites. `copy_into`
+performs no destination allocation.
+
+## Structural Read Paths
+
+The following CPU read operations consume the original view directly:
+
+- `transpose_read`: permute the original strided metadata and copy once.
+- `broadcast_in_dim_read`: apply aligned zero-stride broadcast metadata to the
+  original view and copy once.
+- `reshape_read`: copy the original logical order once into the required owned
+  compact result and attach the requested compact shape; do not first create an
+  intermediate tensor with the source shape.
+- `materialize_tensor_read`: dispatch directly to the canonical copy helper.
+
+These paths must not first invoke a generic host materializer. Owned compact
+inputs may retain existing contiguous fast paths, provided they enter the same
+backend/context and pool ownership model.
+
+## Ownership Contract
+
+The durable repository rule is:
+
+| Responsibility | Owner |
+|---|---|
+| Shape/stride/offset metadata and validation | `tenferro-tensor-core` / `tenferro-tensor` |
+| CPU affine-strided copy, permutation, broadcast, map, zip-map, and axis reduction kernels | `strided-rs` |
+| Dtype dispatch, placement, CPU thread policy, buffer pool, and error mapping | `tenferro-cpu` |
+| Multi-axis reduction orchestration and operation semantics | tenferro, delegating each supported kernel step |
+| Gather/scatter and other indirect-index operations without a matching strided primitive | tenferro |
+| Einsum/dot-general planning and optimized preparation | tenferro |
+
+When a tenferro CPU operation can be expressed as metadata preparation followed
+by an existing `strided-rs` primitive, the bulk traversal must use that
+primitive. If the primitive is missing and the operation is generally useful,
+the preferred sequence is to add it to `strided-rs` first and then consume it
+from tenferro.
+
+## Scope
+
+This change includes:
+
+- canonical CPU `to_contiguous` and general `copy_into` implementation;
+- removal and migration of equivalent context-free materialization APIs;
+- direct arbitrary-stride `transpose_read`, `broadcast_in_dim_read`, and
+  `reshape_read` paths;
+- runtime/eager caller migration to backend-owned materialization;
+- repository-rule and user/developer documentation updates;
+- correctness, source-contract, and focused performance benchmarks.
+
+This change does not rewrite gather, scatter, pad, concatenate, triangular
+masks, or diagonal embedding. Their semantics and available strided primitives
+need separate focused work. It also does not change GPU kernel behavior beyond
+adapting the shared canonicalization trait surface without weakening existing
+same-device guarantees.
+
+The external `tenferro-benchmark` suite should be updated separately to invoke
+the canonical backend materialization API explicitly.
+
+## Error Handling
+
+- Shape and dtype mismatches return tenferro typed errors before dispatch.
+- CPU canonicalization rejects backend/device buffers and does not download
+  implicitly.
+- GPU canonicalization rejects host buffers and does not upload implicitly.
+- Invalid stride/offset/reachable-range metadata remains owned by tenferro's
+  layout validation.
+- `strided-rs` errors are translated to `Error::BackendFailure` with the public
+  tenferro operation name preserved.
+- Empty and rank-zero tensors are valid and must not enter unchecked allocation
+  or pointer-offset paths.
+
+## Testing And Performance Evidence
+
+Implementation follows test-driven development. Each behavior is introduced by
+a failing test before production changes.
+
+Required correctness coverage:
+
+- compact and permuted sources;
+- the scattered 24D explicit-stride layout from #1393;
+- negative strides and nonzero offsets;
+- zero-stride broadcast views;
+- singleton, empty, and rank-zero tensors;
+- all supported tenferro dtypes;
+- caller-owned strided destinations;
+- shape/dtype/placement rejection;
+- proof that `transpose_read` and `broadcast_in_dim_read` do not perform an
+  intermediate host materialization.
+
+Focused benchmarks compare one and four threads for compact, permuted, and
+scattered high-rank sources. Small inputs are included to guard dispatch
+overhead. The repository benchmark records behavior but does not use unstable
+wall-clock assertions in unit tests.
+
+Acceptance requires the full repository verification gates and a refreshed
+external #1393 benchmark report. The scattered 24D case should show meaningful
+thread scaling and substantially reduce the current gap to direct
+`strided-rs`.
+
+## Alternatives Rejected
+
+### Keep both APIs and optimize both
+
+Rejected because a context-free method cannot honor the configured
+`CpuContext` and buffer-pool ownership without introducing a hidden backend or
+global execution policy. Equivalent public APIs would remain free to diverge.
+
+### Add `strided-kernel` directly to `tenferro-tensor`
+
+Rejected because it moves CPU execution and threading policy into the
+backend-neutral contract crate. It would also use ambient Rayon policy when no
+backend context is available.
+
+### Keep a generic `T: Clone` serial fallback
+
+Rejected as a public execution API. Tenferro execution scalars already satisfy
+`TensorScalar` and the strided kernel bounds. A generic fallback would preserve
+the exact performance ambiguity this change removes.

--- a/docs/worklogs/2026-07-16-strided-materialization-api-convergence.md
+++ b/docs/worklogs/2026-07-16-strided-materialization-api-convergence.md
@@ -92,6 +92,32 @@ rationale.
   `crates/tenferro-runtime/src/graph/executor/tests/preflight.rs`; Task 5 did
   not modify that file.
 
+## Backend-Owned Runtime Materialization
+
+- Added object-safe `to_contiguous_read` and `copy_read_into` operations to the
+  backend/session structural contract. CPU implementations enter the configured
+  `CpuContext` and reuse its persistent materialization pool; CUDA implementations
+  retain the same-device, no-hidden-transfer boundary.
+- Removed context-free tensor-sized movement from tensor/view metadata types,
+  including `to_contiguous`, `copy_from_contiguous`, view/value `to_tensor`, and
+  their serial materialization helpers. Metadata-only transforms and scalar
+  indexed access remain available.
+- Added `GraphExecutor::materialize_value` as the public graph-result boundary.
+  `EagerTensor::to_tensor` remains convenient because an eager tensor owns its
+  runtime context, but it now fast-paths compact values and enters that runtime's
+  backend session for lazy views.
+- Propagated the already-active backend session through runtime segment and
+  extension collection, AD concrete-read fallbacks, einsum fallbacks, and FFT
+  extension reads. Materialization therefore occurs before releasing the active
+  session and does not reacquire the backend lock recursively.
+- RED tests showed the missing graph API and showed that eager lazy-view
+  materialization bypassed backend dispatch. Recording backends now increment
+  inside their actual `to_contiguous_read` implementations: compact owned values
+  record zero calls and lazy views record exactly one.
+- Focused release tests passed for `tenferro-tensor`, `tenferro-runtime`,
+  `tenferro-ad`, `tenferro-einsum`, and `tenferro-fft`. Task 6 records the fresh
+  workspace-wide verification evidence.
+
 ## Remaining Risks And Follow-Up
 
 - This repository benchmark records representative behavior but does not make
@@ -99,6 +125,11 @@ rationale.
   suite remains the acceptance evidence for Apple M4 scaling and peer gaps.
 - Einsum remains an intentional ownership exception; future exceptions must
   meet the repository's issue, benchmark, and rationale gate.
+- Recording tests count backend materialization calls but do not separately
+  count session-entry depth. The reviewed implementation propagates one active
+  session through runtime/extension/FFT fallbacks and contains no nested backend
+  acquisition; a dedicated maximum-depth counter remains optional defense in
+  depth if these lock paths are refactored later.
 
 ## Task 5 Quality Follow-Up
 

--- a/docs/worklogs/2026-07-16-strided-materialization-api-convergence.md
+++ b/docs/worklogs/2026-07-16-strided-materialization-api-convergence.md
@@ -99,3 +99,32 @@ rationale.
   suite remains the acceptance evidence for Apple M4 scaling and peer gaps.
 - Einsum remains an intentional ownership exception; future exceptions must
   meet the repository's issue, benchmark, and rationale gate.
+
+## Task 5 Quality Follow-Up
+
+- Replaced exact prose assertions with the versioned
+  `TENFERRO_CPU_STRIDED_OWNERSHIP_CONTRACT` key/value block. The source test
+  verifies stable owner/resource fields and only the vocabulary necessary to
+  preserve the policy; surrounding explanatory prose may be edited freely.
+- Replaced the single-file formatting-sensitive API check with a recursive scan
+  of every Rust file under `tenferro-tensor/src`. A small lexer discards line
+  comments, nested block comments, string literals, and character literals,
+  then identifies `pub fn` signatures independent of whitespace and modifiers.
+  It rejects the removed public method names wherever they relocate while
+  allowing backend trait methods (which have no inherent `pub fn` signature),
+  and rejects the named private serial helpers anywhere in the source tree.
+  A fixture guards formatting, comment/string decoys, restricted visibility,
+  public modifiers, and private-helper detection. Compile-fail coverage is not
+  used because standard integration tests cannot reliably depend on a missing
+  method.
+- Benchmark cases now retain canonical source shape, source strides, and
+  permutation. Exact expected offsets are computed directly from those inputs,
+  independently of the already-permuted view metadata used by the operation.
+- Pre-timing materialization is confined to `verify_case_once`; its checked
+  output is dropped when the helper returns, before Criterion begins timing the
+  allocation-inclusive operation.
+- Follow-up verification passed for the structured ownership test, the complete
+  recursive public-surface guard, its lexer fixture, and
+  `cargo bench -p tenferro-cpu --bench view_materialization --no-run`. Scoped
+  `rustfmt --check` and `git diff --check` also passed; no broader checks were
+  run while Task 4B shared-tree edits were active.

--- a/docs/worklogs/2026-07-16-strided-materialization-api-convergence.md
+++ b/docs/worklogs/2026-07-16-strided-materialization-api-convergence.md
@@ -1,0 +1,101 @@
+# Strided Materialization API Convergence
+
+## Summary
+
+Issue [#1393](https://github.com/tensor4all/tenferro-rs/issues/1393)
+identified a CPU API ownership split: context-free view materialization used a
+serial logical traversal, while backend structural operations reached pooled,
+parallel `strided-rs` kernels. This change records one durable ownership rule,
+updates user guidance to require backend-owned canonicalization, and adds an
+allocation-inclusive Criterion benchmark for the converged API.
+
+## Context Read
+
+- Root and repository `AGENTS.md`, workspace `CODING_RULES.md`, and
+  `REPOSITORY_RULES.md`.
+- The approved strided-materialization design and Task 5 implementation plan.
+- Issue #1393 and its root-cause follow-up, including the external benchmark's
+  exact scattered 24D shape, permutation, and source strides.
+- CPU context, buffer-pool, canonicalization, structural-kernel, test, and
+  Criterion benchmark patterns.
+- Shared Tensor4all Rust, performance, documentation, test, and benchmark
+  rules.
+
+## Historical Reason
+
+`TypedTensorView::to_contiguous` descended from a generic host-view adapter
+requiring only `T: Clone`. The later backend canonicalization trait initially
+delegated CPU work back to that adapter. `strided-kernel` subsequently gained
+parallel structural kernels, but the context-free canonicalization route did
+not migrate, leaving equivalent public semantics with different performance
+and no access to the backend's execution resources.
+
+The accepted design treats that divergence as an ownership defect. A fast CPU
+copy is not only a loop choice: it needs persistent reusable storage,
+full-overwrite uninitialized allocation, the configured Rayon pool,
+nested-execution safety, and serial/parallel threshold policy. These belong to
+`CpuBackend`/`CpuContext`, not tensor layout metadata.
+
+## Overlap Inventory And Decision
+
+| Area | `strided-rs` | tenferro |
+|---|---|---|
+| Copy/permutation | Affine traversal and kernel parallelism | Metadata validation, placement, allocation, context, and errors |
+| Broadcast | Zero-stride views and bulk traversal | Dimension semantics and output ownership |
+| Map/zip-map | Strided element traversal | Operation and dtype semantics |
+| Axis reduction | Per-axis kernel | Axis validation and multi-axis orchestration |
+| Indirect indexing | No matching general primitive today | Gather/scatter and related dedicated kernels |
+| Einsum/dot-general | Reusable lower-level primitives where applicable | Benchmark-backed exception for planning, preparation, and providers |
+
+The priority rule is to express an operation as tenferro metadata/semantic
+preparation followed by an existing `strided-rs` primitive. A missing generally
+useful primitive should be added to `strided-rs` first. New tenferro traversal
+exceptions require an accepted issue, comparative benchmarks, and a recorded
+rationale.
+
+## Implementation
+
+- Added a source contract requiring the ownership rationale and rejecting the
+  removed context-free tensor methods/helper.
+- Expanded repository rules with the ownership/overlap table, delegation
+  priority, explicit einsum exception, and backend execution-resource contract.
+- Updated eager and parallelism guides with backend-owned materialization
+  examples and the same-placement/no-hidden-transfer boundary.
+- Added `view_materialization`, a Criterion `harness = false` benchmark of
+  `CpuBackend::to_contiguous` at one and four threads. It covers compact and
+  permuted 3D inputs, the issue's contiguous and scattered 24D layouts, and a
+  tiny transpose. Every timed iteration creates the materialized result, and
+  each case is checked exactly once before timing against independently
+  computed physical offsets.
+
+## TDD And Verification
+
+- RED: `cargo test -p tenferro-cpu --test backend_capability_contracts
+  --release strided_kernel_ownership_requires_backend_execution_resources --
+  --exact --nocapture` first failed at
+  `REPOSITORY_RULES.md must contain ownership contract text: CPU
+  affine-strided copy, permutation, broadcast, map, zip-map, and axis
+  reduction`.
+- After adding the ownership policy, the same command advanced to the
+  concurrent Task 4B boundary and failed solely at `context-free tensor
+  materialization surface/helper remains: pub fn to_contiguous(&self)`. At
+  that point tensor source also still contained
+  `TypedTensorViewMut::copy_from_contiguous`, context-free `to_tensor` methods,
+  and `materialize_typed_view_col_major`; Task 5 did not edit or revert them.
+- The complete `backend_capability_contracts` release target reported 10 passed
+  and this one Task 4B-dependent source-contract failure.
+- `cargo bench -p tenferro-cpu --bench view_materialization --no-run`: passed.
+- `cargo check -p tenferro-cpu --benches`: passed.
+- The two scoped Rust files were formatted with `rustfmt --edition 2021`.
+  `cargo fmt --all --check` remained blocked solely by concurrent, out-of-scope
+  formatting changes in
+  `crates/tenferro-runtime/src/graph/executor/tests/preflight.rs`; Task 5 did
+  not modify that file.
+
+## Remaining Risks And Follow-Up
+
+- This repository benchmark records representative behavior but does not make
+  unstable timing assertions. The external `tenferro-benchmark` permutation
+  suite remains the acceptance evidence for Apple M4 scaling and peer gaps.
+- Einsum remains an intentional ownership exception; future exceptions must
+  meet the repository's issue, benchmark, and rationale gate.

--- a/docs/worklogs/2026-07-16-strided-materialization-api-convergence.md
+++ b/docs/worklogs/2026-07-16-strided-materialization-api-convergence.md
@@ -175,3 +175,22 @@ rationale.
   a heavyweight parsing/compiler dependency.
 - Final focused verification passed for the exact keyed ownership contract,
   recursive public-surface/macro guard, and scanner fixture.
+
+## Final Verification
+
+- `cargo fmt --all --check`: passed.
+- `cargo clippy --workspace --all-targets -- -D warnings`: passed.
+- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`: passed.
+- `cargo test --workspace --release`: passed, including workspace doctests.
+- `cargo doc --workspace --no-deps`: passed.
+- `python3 scripts/check-docs-site.py`: passed for all 13 workspace library crates.
+- `cargo llvm-cov --no-clean --workspace --release --json ...` completed successfully;
+  `scripts/check-coverage.py` reported 159/159 files passing (3 excluded).
+- `cargo bench -p tenferro-cpu --bench view_materialization --no-run`: passed.
+- `cargo check -p tenferro-gpu --features webgpu`: passed.
+- `scripts/repository-rules-review.py --base origin/main --head HEAD`: pass with no findings.
+- `git diff --check origin/main...HEAD`: passed and the worktree was clean after the final commits.
+
+The repository benchmark is intentionally non-asserting. Comparative Apple M4
+measurements in the external `tenferro-benchmark` suite remain a separate
+follow-up and are not represented as evidence produced by this branch.

--- a/docs/worklogs/2026-07-16-strided-materialization-api-convergence.md
+++ b/docs/worklogs/2026-07-16-strided-materialization-api-convergence.md
@@ -128,3 +128,19 @@ rationale.
   `cargo bench -p tenferro-cpu --bench view_materialization --no-run`. Scoped
   `rustfmt --check` and `git diff --check` also passed; no broader checks were
   run while Task 4B shared-tree edits were active.
+- The final contract test compares each structured field under its own key:
+  scalar owner/classification values are exact, comma-delimited kernel,
+  execution-resource, and noncompliance fields are exact sets, and the field
+  key set itself is closed.
+- The recursive source guard rejects `include!` because included source would
+  evade repository-tree inspection. It also walks balanced token trees for
+  `macro_rules!` definitions and macro invocations and rejects literal forbidden
+  API/helper identifiers there, covering direct macro-generated names and
+  identifier metavariables supplied literally at invocation sites. This remains
+  intentionally lightweight: identifiers synthesized from fragments by
+  procedural/pasting macros cannot be reconstructed reliably without compiler
+  expansion. Banning `include!`, scanning literal macro tokens, and retaining
+  the ordinary public-signature scan provide the in-scope guard without adding
+  a heavyweight parsing/compiler dependency.
+- Final focused verification passed for the exact keyed ownership contract,
+  recursive public-surface/macro guard, and scanner fixture.


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] Documentation
- [x] Refactor / cleanup
- [x] Implementation of accepted issue

## Related issue

Refs #1393

## Summary

This PR converges strided tensor materialization on backend-owned APIs and makes the CPU ownership boundary explicit.

Historically, tenferro had two materialization paths: context-free tensor-view helpers performed generic serial host copies, while CPU backend operations used `strided-rs` through `CpuContext`. That split allowed semantically equivalent APIs to have different performance and resource-management behavior.

The canonical contract is now:

- tensor-level code owns shape/stride validation and typed view semantics;
- backends own materialization and destination allocation through `TensorStructural::{to_contiguous_read, copy_read_into}`;
- the CPU backend delegates affine-strided traversal to `strided-rs` while retaining tenferro's buffer pool, configured Rayon thread pool, nested-execution safety, and error/device contracts;
- optimized einsum/dot-general remains an explicit, benchmark-backed tenferro exception;
- CUDA implements same-device materialization under its documented restrictions, and WebGPU rejects unsupported materialization explicitly instead of falling back to hidden host work.

The context-free `to_tensor` / `to_contiguous` / contiguous-copy helpers were removed, and eager, runtime, AD, einsum, FFT, and linalg call sites now materialize through an active backend session. CPU structural reads consume strided views directly and perform one final pooled copy.

The repository rules now include a stable ownership table for overlapping `tenferro-rs` and `strided-rs` functionality, including the reason CPU copies must still enter through the backend: fast copies require coordinated buffer reuse and Rayon thread management, not only a traversal kernel.

## Scope and deferred work

The same-root-cause search covered tensor public APIs, eager/runtime/AD facades, CPU structural operations, einsum, FFT, linalg, CUDA, and WebGPU. All context-free materialization entry points found in those paths were migrated or explicitly rejected by unsupported backends.

External Apple M4 benchmark execution and reporting remain a separate follow-up. This PR adds the non-asserting Criterion benchmark matrix for 1-thread and 4-thread compact, permuted, high-rank contiguous/scattered, and tiny-transpose cases; it does not claim new M4 measurements or close #1393 by itself.

## Work log

- [`docs/worklogs/2026-07-16-strided-materialization-api-convergence.md`](docs/worklogs/2026-07-16-strided-materialization-api-convergence.md)
- [`docs/superpowers/specs/2026-07-16-strided-materialization-api-convergence-design.md`](docs/superpowers/specs/2026-07-16-strided-materialization-api-convergence-design.md)
- [`docs/superpowers/plans/2026-07-16-strided-materialization-api-convergence.md`](docs/superpowers/plans/2026-07-16-strided-materialization-api-convergence.md)

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path /tmp/tenferro-issue-1393-coverage.json`
- `python3 scripts/check-coverage.py /tmp/tenferro-issue-1393-coverage.json` (`159/159` files passed; 3 excluded)
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py`
- `cargo bench -p tenferro-cpu --bench view_materialization --no-run`
- `cargo check -p tenferro-gpu --features webgpu`
- repository-rules review against `origin/main...HEAD` (pass, no findings)
- final implementation review and re-review (no Critical/Important findings; Ready: Yes)

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [ ] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`. (Not a bug-fix PR; this implements the accepted performance/API-convergence issue.)
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.

AI-assisted implementation. The repository workflow, architecture rules, and full PR gates were applied before publication.
