### PR TITLE
Add a fast non-release local PR gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,12 +235,19 @@ Additionally, verify the following before pushing:
 
 ### Local Rust Build Acceleration
 
-Before the first workspace-wide local Rust build in a session, check whether
-`sccache` is installed and whether `RUSTC_WRAPPER` enables it. If either is
-missing, recommend the developer-local setup in `CONTRIBUTING.md` once.
+Ordinary focused local development, including AI-assisted edit-test loops,
+should use Cargo incremental compilation through the default dev/test
+profiles. Do not recommend or enable `sccache` solely for these loops.
+
+Before a non-incremental `local-gate` run or a workspace-wide build whose
+outputs should be reused across worktrees, check whether `sccache` is installed
+and enabled for that command. If either is missing, recommend the
+developer-local setup in `CONTRIBUTING.md` once.
 
 - Do not install sccache or edit global Cargo configuration without explicit
   user approval.
+- Do not disable incremental compilation in the default dev/test profiles or
+  set `RUSTC_WRAPPER=sccache` globally as a general local-development default.
 - Use developer-local cache only. Do not introduce or recommend a shared remote
   sccache.
 - Correctness checks and PR gates must work on a cache miss.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,33 +198,54 @@ When using git worktrees for feature development, **always branch from the lates
 
 ## Pre-Push / PR Checklist
 
-Before pushing or creating a pull request, **all** of the following must pass:
+Before pushing or creating a pull request, run the non-release local gate:
 
 ```bash
-cargo fmt --all --check   # formatting
-cargo test --workspace --release   # all tests
-cargo llvm-cov --workspace --release --json --output-path coverage.json
-python3 scripts/check-coverage.py coverage.json
-cargo doc --workspace --no-deps
-python3 scripts/check-docs-site.py
+bash scripts/check-pr-fast.sh \
+  --coverage-reviewed \
+  --ci-profile local-gate
+
 python3 scripts/repository-rules-review.py \
   --base origin/main \
   --head HEAD \
   --output-json /tmp/repository-rules-review.json
 ```
 
-If `cargo fmt --all --check` fails, run `cargo fmt --all` to fix formatting automatically.
-Run the local LLM review on the committed PR head; `--worktree` is acceptable
-only as an earlier preview, and must be rerun without `--worktree` before PR
-creation.
+The `local-gate` Cargo profile is non-optimized, preserves debug assertions and
+overflow checks, omits debug symbols, and disables incremental compilation.
+Hosted CI owns the full release workspace tests, coverage enforcement, backend
+matrix, docs-site build, and GPU validation. Do not require those comprehensive
+hosted-CI commands locally before every PR.
+
+Run the relevant release test or benchmark locally when a change is
+performance-sensitive, reproduces a release-only bug, touches unsafe or
+optimization-sensitive behavior, or a maintainer explicitly requests it.
+
+If the formatting step fails, run `cargo fmt --all` to fix formatting
+automatically. Run the local LLM review on the committed PR head;
+`--worktree` is acceptable only as an earlier preview, and must be rerun
+without `--worktree` before PR creation.
 
 Additionally, verify the following before pushing:
 
-- **Clippy parity**: Run clippy locally with the same command and options as the repository CI `clippy` job; do not use a relaxed local variant.
 - **Side review**: Re-read `REPOSITORY_RULES.md` and review the local diff against repository rules before creating a PR. Fix any findings, or explicitly document residual risks.
 - **Sample code verification**: All code examples in `README.md` and `docs/getting-started/` must compile and run correctly. Extract and test any changed examples.
 - **Design document updates**: When code changes affect architecture or specifications, update the corresponding documents in `docs/architecture/`, `docs/spec/`, or `docs/design/`, and update any affected diagrams under `docs/assets/` or embedded in Markdown. Stale documentation is worse than no documentation.
 - **Work log updates**: For nontrivial refactors, cleanup streams, AI-assisted implementation, or explicit tradeoff decisions, add or update a work log under `docs/worklogs/` and link it from the PR body.
+
+### Local Rust Build Acceleration
+
+Before the first workspace-wide local Rust build in a session, check whether
+`sccache` is installed and whether `RUSTC_WRAPPER` enables it. If either is
+missing, recommend the developer-local setup in `CONTRIBUTING.md` once.
+
+- Do not install sccache or edit global Cargo configuration without explicit
+  user approval.
+- Use developer-local cache only. Do not introduce or recommend a shared remote
+  sccache.
+- Correctness checks and PR gates must work on a cache miss.
+- Disable sccache for clean-build measurements and report whether each timing
+  used a cold or warm cache.
 
 ### PR Creation Rules
 
@@ -255,6 +276,9 @@ cargo test -p tenferro-einsum
 
 # Run a single test
 cargo test test_name
+
+# Run the non-release local PR test profile
+python3 scripts/ci/run_profile.py local-gate
 
 # Check formatting
 cargo fmt --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,20 +107,28 @@ prefer these profiles over copying command lists into local scripts.
 ### Optional developer-local sccache
 
 Developers who use multiple worktrees can share compatible compiler outputs
-through a local sccache:
+for non-incremental workspace-wide gates through a local sccache. Keep the
+wrapper scoped to the gate command:
 
 ```bash
-export RUSTC_WRAPPER=sccache
-export SCCACHE_DIR="$HOME/.cache/tensor4all/sccache"
-export SCCACHE_CACHE_SIZE=20G
-sccache --show-stats
+RUSTC_WRAPPER=sccache \
+SCCACHE_DIR="$HOME/.cache/tensor4all/sccache" \
+SCCACHE_CACHE_SIZE=20G \
+  bash scripts/check-pr-fast.sh \
+    --coverage-reviewed \
+    --ci-profile local-gate
+
+SCCACHE_DIR="$HOME/.cache/tensor4all/sccache" sccache --show-stats
 ```
 
 This is an optional local optimization. Do not configure a shared remote cache,
-and do not rely on cache hits for correctness. Ordinary focused debug builds
-may continue to use Cargo incremental compilation; `local-gate` disables
-incremental compilation so sccache can cache eligible crate compilations across
-worktrees. Disable sccache when measuring clean-build performance.
+and do not rely on cache hits for correctness. Ordinary focused local
+development, including AI-assisted edit-test loops, should use Cargo
+incremental compilation through the default dev/test profiles. Do not set
+`RUSTC_WRAPPER=sccache` globally for those loops. The `local-gate` profile
+disables incremental compilation so sccache can cache eligible crate
+compilations across worktrees. Disable sccache when measuring clean-build
+performance.
 
 Pull-request CI classifies a diff conservatively as code, docs-only, or
 CI-only. Docs-only changes run documentation validation. CI-only changes run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,23 @@ Implementation PRs for new features or substantial changes that are opened
 before an accepted issue may be closed with a request to continue the
 discussion in an issue first.
 
-## Local and hosted CI profiles
+## Local PR gate and hosted CI profiles
+
+Before opening or updating a pull request, run the non-release local gate:
+
+```bash
+bash scripts/check-pr-fast.sh \
+  --coverage-reviewed \
+  --ci-profile local-gate
+```
+
+The `local-gate` profile uses non-optimized debug semantics with debug
+assertions and overflow checks enabled. It omits debug symbols and incremental
+state to keep workspace-wide validation bounded and compatible with sccache.
+Hosted CI remains responsible for release tests, coverage, backend variants,
+documentation builds, and GPU validation. Run release locally when validating
+performance, a release-only failure, unsafe or optimization-sensitive behavior,
+or an explicit maintainer request.
 
 The exact command groups used by hosted CI are available locally:
 
@@ -83,10 +99,28 @@ python3 scripts/ci/run_profile.py workspace-blas
 python3 scripts/ci/run_profile.py docs
 ```
 
-`full` expands every profile once. Use `--dry-run` to inspect commands without
-executing them. `scripts/check-pr-fast.sh` also accepts repeatable
-`--ci-profile NAME` options; prefer these profiles over copying hosted-CI
-commands into local scripts.
+`full` expands every hosted profile once and intentionally excludes
+`local-gate`. Use `--dry-run` to inspect commands without executing them.
+`scripts/check-pr-fast.sh` accepts repeatable `--ci-profile NAME` options;
+prefer these profiles over copying command lists into local scripts.
+
+### Optional developer-local sccache
+
+Developers who use multiple worktrees can share compatible compiler outputs
+through a local sccache:
+
+```bash
+export RUSTC_WRAPPER=sccache
+export SCCACHE_DIR="$HOME/.cache/tensor4all/sccache"
+export SCCACHE_CACHE_SIZE=20G
+sccache --show-stats
+```
+
+This is an optional local optimization. Do not configure a shared remote cache,
+and do not rely on cache hits for correctness. Ordinary focused debug builds
+may continue to use Cargo incremental compilation; `local-gate` disables
+incremental compilation so sccache can cache eligible crate compilations across
+worktrees. Disable sccache when measuring clean-build performance.
 
 Pull-request CI classifies a diff conservatively as code, docs-only, or
 CI-only. Docs-only changes run documentation validation. CI-only changes run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,11 @@ cubek-std = { package = "t4a-cubek-std", git = "https://github.com/tensor4all/cu
 sha2 = "0.10"
 omeco = "0.2.4"
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7", version = "0.1.0" }
+
+[profile.local-gate]
+inherits = "dev"
+opt-level = 0
+debug = 0
+debug-assertions = true
+overflow-checks = true
+incremental = false

--- a/ai/contribution-workflows/repository-remediation.md
+++ b/ai/contribution-workflows/repository-remediation.md
@@ -338,13 +338,20 @@ Before opening the PR, run the repository-required checks from `AGENTS.md` when
 the environment supports them:
 
 ```bash
-cargo fmt --all --check
-cargo test --workspace --release
-cargo llvm-cov --workspace --release --json --output-path coverage.json
-python3 scripts/check-coverage.py coverage.json
-cargo doc --workspace --no-deps
-python3 scripts/check-docs-site.py
+bash scripts/check-pr-fast.sh \
+  --coverage-reviewed \
+  --ci-profile local-gate
+
+python3 scripts/repository-rules-review.py \
+  --base origin/main \
+  --head HEAD \
+  --output-json /tmp/repository-rules-review.json
 ```
+
+The local gate does not require a release build. Run release-mode checks
+locally only for performance, release-only, unsafe or optimization-sensitive
+changes, or when a maintainer requests them. Hosted CI owns the comprehensive
+release, coverage, backend, documentation, and GPU checks.
 
 For CUDA/GPU work, run the documented CUDA ignored tests when hardware and
 libraries are available. If they are unavailable, add CPU-side or ignored CUDA

--- a/docs/superpowers/specs/2026-07-17-local-pr-gate-design.md
+++ b/docs/superpowers/specs/2026-07-17-local-pr-gate-design.md
@@ -49,13 +49,20 @@ coverage, BLAS/backend variants, documentation builds, and GPU validation.
 
 ## Local sccache policy
 
-Before a workspace-wide local Rust build, agents check whether `sccache` is
-available and enabled. If not, they recommend the documented developer-local
-setup once. Agents do not install software, edit global Cargo configuration,
-or enable a remote cache without explicit approval.
+Ordinary focused local development, including AI-assisted edit-test loops,
+uses Cargo incremental compilation through the default dev/test profiles.
+Agents do not recommend or enable `sccache` solely for these loops and do not
+disable incremental compilation in the default profiles.
+
+Before a non-incremental `local-gate` run or a workspace-wide build whose
+outputs should be reused across worktrees, agents check whether `sccache` is
+available and enabled for that command. If not, they recommend the documented
+developer-local setup once. Agents do not install software, edit global Cargo
+configuration, or enable a remote cache without explicit approval.
 
 Each developer owns an independent local cache. The repository does not define
-or recommend a shared remote sccache. Correctness checks must work on a cache
+or recommend a shared remote sccache. The wrapper is command-scoped rather than
+a global local-development default. Correctness checks must work on a cache
 miss, and clean-build measurements must disable sccache and state their cache
 condition.
 

--- a/docs/superpowers/specs/2026-07-17-local-pr-gate-design.md
+++ b/docs/superpowers/specs/2026-07-17-local-pr-gate-design.md
@@ -1,0 +1,67 @@
+# Local PR Gate Design
+
+## Scope
+
+Local pull-request preparation should catch ordinary Rust correctness failures
+without requiring contributors to repeat the repository's release, coverage,
+backend-matrix, or GPU validation before every push. Hosted CI remains the
+owner of those comprehensive checks.
+
+This change is local-development policy only. It does not change GitHub Actions,
+RunPod, CI caches, required checks, or the release profiles used by hosted CI.
+
+## Local profile
+
+The workspace defines a `local-gate` Cargo profile with non-optimized debug
+semantics but without debug symbols or incremental state:
+
+```toml
+[profile.local-gate]
+inherits = "dev"
+opt-level = 0
+debug = 0
+debug-assertions = true
+overflow-checks = true
+incremental = false
+```
+
+This preserves debug assertions and overflow checks while avoiding the disk
+cost of full debug information. Disabling incremental compilation also makes
+the profile compatible with developer-local sccache. The profile is not a
+performance benchmark profile and must not be used for performance claims.
+
+## Local PR contract
+
+`scripts/ci/run_profile.py local-gate` runs workspace nextest tests and
+workspace doctests with the Cargo `local-gate` profile. The existing
+`scripts/check-pr-fast.sh` profile delegation remains the entry point:
+
+```bash
+bash scripts/check-pr-fast.sh \
+  --coverage-reviewed \
+  --ci-profile local-gate
+```
+
+Local release validation is required only for performance-sensitive changes,
+release-only bug reproduction, unsafe or optimization-sensitive work, or an
+explicit maintainer request. Hosted CI owns full release workspace tests,
+coverage, BLAS/backend variants, documentation builds, and GPU validation.
+
+## Local sccache policy
+
+Before a workspace-wide local Rust build, agents check whether `sccache` is
+available and enabled. If not, they recommend the documented developer-local
+setup once. Agents do not install software, edit global Cargo configuration,
+or enable a remote cache without explicit approval.
+
+Each developer owns an independent local cache. The repository does not define
+or recommend a shared remote sccache. Correctness checks must work on a cache
+miss, and clean-build measurements must disable sccache and state their cache
+condition.
+
+## Verification
+
+Repository tests lock the exact local profile commands and Cargo profile
+settings. CI helper tests, formatting, profile dry-run, and the local fast
+preflight validate the implementation. No hosted workflow file changes in this
+work.

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -12,6 +12,11 @@ from typing import TextIO
 
 
 PROFILE_COMMANDS: dict[str, tuple[str, ...]] = {
+    "local-gate": (
+        "cargo nextest run --workspace --cargo-profile local-gate "
+        "--no-fail-fast",
+        "cargo test --doc --workspace --profile local-gate",
+    ),
     "workspace-faer": (
         "cargo nextest run --workspace --release --no-fail-fast",
         "cargo test --doc --workspace --release",

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -106,6 +106,23 @@ class RunProfileTests(unittest.TestCase):
         self.assertIn('python3 scripts/ci/run_profile.py "${profile_args[@]}"', source)
         self.assertNotIn("cargo nextest run --workspace", source)
 
+    def test_create_pr_uses_local_gate_instead_of_release_suite(self) -> None:
+        source = (ROOT / "scripts" / "create-pr.sh").read_text()
+        self.assertIn("bash scripts/check-pr-fast.sh", source)
+        self.assertIn("--ci-profile local-gate", source)
+        self.assertIn("python3 scripts/repository-rules-review.py", source)
+        self.assertNotIn("cargo nextest run --workspace --release", source)
+        self.assertNotIn("cargo llvm-cov", source)
+
+    def test_remediation_workflow_uses_local_gate_before_pr(self) -> None:
+        source = (
+            ROOT / "ai" / "contribution-workflows" / "repository-remediation.md"
+        ).read_text()
+        self.assertIn("bash scripts/check-pr-fast.sh", source)
+        self.assertIn("--ci-profile local-gate", source)
+        self.assertNotIn("cargo test --workspace --release", source)
+        self.assertNotIn("cargo llvm-cov --workspace --release", source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -123,6 +123,25 @@ class RunProfileTests(unittest.TestCase):
         self.assertNotIn("cargo test --workspace --release", source)
         self.assertNotIn("cargo llvm-cov --workspace --release", source)
 
+    def test_sccache_policy_preserves_incremental_ai_development(self) -> None:
+        agents = (ROOT / "AGENTS.md").read_text()
+        contributing = (ROOT / "CONTRIBUTING.md").read_text()
+        design = (
+            ROOT
+            / "docs"
+            / "superpowers"
+            / "specs"
+            / "2026-07-17-local-pr-gate-design.md"
+        ).read_text()
+
+        for source in (agents, contributing, design):
+            self.assertIn("AI-assisted edit-test loops", source)
+            self.assertRegex(source, r"Cargo\s+incremental compilation")
+
+        self.assertNotIn(
+            "Before the first workspace-wide local Rust build", agents
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -1,4 +1,5 @@
 import io
+import tomllib
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -10,6 +11,33 @@ ROOT = Path(__file__).resolve().parents[3]
 
 
 class RunProfileTests(unittest.TestCase):
+    def test_local_gate_uses_non_release_workspace_commands(self) -> None:
+        self.assertEqual(
+            commands_for("local-gate"),
+            (
+                "cargo nextest run --workspace --cargo-profile local-gate "
+                "--no-fail-fast",
+                "cargo test --doc --workspace --profile local-gate",
+            ),
+        )
+
+    def test_local_gate_cargo_profile_preserves_debug_checks(self) -> None:
+        manifest = tomllib.loads((ROOT / "Cargo.toml").read_text())
+        self.assertEqual(
+            manifest["profile"]["local-gate"],
+            {
+                "inherits": "dev",
+                "opt-level": 0,
+                "debug": 0,
+                "debug-assertions": True,
+                "overflow-checks": True,
+                "incremental": False,
+            },
+        )
+
+    def test_hosted_full_profile_does_not_include_local_gate(self) -> None:
+        self.assertNotIn("local-gate", expand_profiles(["full"]))
+
     def test_workspace_blas_matches_ci_feature_contract(self) -> None:
         self.assertEqual(
             commands_for("workspace-blas"),

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -47,13 +47,8 @@ ensure_body_file() {
     printf '## Summary\n\n'
     git log --format='- %s' "${BASE_BRANCH}..HEAD" 2>/dev/null || true
     printf '\n## Verification\n\n'
-    printf -- '- `cargo fmt --all --check`\n'
-    printf -- '- `cargo nextest run --workspace --release --no-fail-fast`\n'
-    printf -- '- `cargo test --doc --workspace --release`\n'
-    printf -- '- `cargo llvm-cov nextest --workspace --release --json --output-path coverage.json`\n'
-    printf -- '- `python3 scripts/check-coverage.py coverage.json`\n'
-    printf -- '- `cargo doc --workspace --no-deps`\n'
-    printf -- '- `python3 scripts/check-docs-site.py`\n'
+    printf -- '- `bash scripts/check-pr-fast.sh --coverage-reviewed --ci-profile local-gate`\n'
+    printf -- '- `python3 scripts/repository-rules-review.py --base origin/%s --head HEAD`\n' "$BASE_BRANCH"
     printf '\n## Documentation\n\n'
     printf -- '- Reviewed `README.md`, `docs/design/**`, `docs/api/index.md`, and public rustdoc for consistency.\n'
   } >"$BODY_FILE"
@@ -72,13 +67,14 @@ append_ai_attribution() {
 }
 
 run_required_checks() {
-  cargo fmt --all --check
-  cargo nextest run --workspace --release --no-fail-fast
-  cargo test --doc --workspace --release
-  cargo llvm-cov nextest --workspace --release --json --output-path coverage.json
-  python3 scripts/check-coverage.py coverage.json
-  cargo doc --workspace --no-deps
-  python3 scripts/check-docs-site.py
+  bash scripts/check-pr-fast.sh \
+    --base "origin/${BASE_BRANCH}" \
+    --coverage-reviewed \
+    --ci-profile local-gate
+  python3 scripts/repository-rules-review.py \
+    --base "origin/${BASE_BRANCH}" \
+    --head HEAD \
+    --output-json /tmp/repository-rules-review.json
 }
 
 while [[ $# -gt 0 ]]; do
@@ -137,7 +133,7 @@ require_clean_tree
 
 bash scripts/check-repo-settings.sh --quiet
 
-log "docs gate: review README.md, docs/design/**, docs/api/index.md, and public rustdoc before continuing"
+log "local PR gate: fast debug checks plus repository-rules review"
 run_required_checks
 
 if [[ -z "$TITLE" ]]; then


### PR DESCRIPTION
## Summary

- add a non-release `local-gate` Cargo profile for the normal local pre-PR gate
- route `check-pr-fast.sh`, `create-pr.sh`, and remediation guidance through that profile
- preserve Cargo incremental compilation for ordinary focused development, including AI-assisted edit-test loops
- keep developer-local `sccache` optional and command-scoped to non-incremental gates or cross-worktree reuse
- leave hosted CI release, coverage, backend, documentation, and GPU workflows unchanged

## Build-mode contract

- ordinary focused local/AI development: default dev/test profiles with incremental compilation
- local PR gate: `local-gate` with `incremental = false`, optionally wrapped by local `sccache`
- clean-build measurements: disable `sccache` and report cache condition
- hosted CI: comprehensive release, coverage, backend, docs, and GPU validation

## Verification

- `CARGO_BUILD_JOBS=4 bash scripts/check-pr-fast.sh --coverage-reviewed --ci-profile local-gate` (2,209 workspace tests and all workspace doctests passed)
- `python3 -m unittest discover -s scripts/ci/tests -v` (66 passed)
- `python3 scripts/test-doc-consistency.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD` (pass, no findings)
- `python3 scripts/check-doc-snippets.py --root-dir . --check`
- `cargo fmt --all --check`
- `git diff --check`

Local release and coverage checks were intentionally not run: the contract assigns comprehensive release and coverage validation to hosted CI unless a change is performance-, release-, unsafe-, or optimization-sensitive.