### PR TITLE
Bootstrap RunPod selector for integrated XLA tests

### DIFF
--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -1253,7 +1253,7 @@ jobs:
           XLA_FLAGS="--xla_gpu_cuda_data_dir=${cuda_nvcc_dir} ${XLA_FLAGS:-}" \
           TENFERRO_PJRT_PLUGIN="${plugin_path}" \
           LD_LIBRARY_PATH="${cudnn_lib}:${LD_LIBRARY_PATH:-}" \
-            cargo test -p tenferro-xla --features pjrt --test pjrt_execution -- --nocapture
+            cargo test -p tenferro-xla --features pjrt --test integration pjrt_execution -- --nocapture
 
       - name: GPU test complete
         run: echo "RUNPOD_TENFERRO_GPU_TEST_OK"


### PR DESCRIPTION
## Summary

- update the trusted RunPod workflow to select the consolidated `integration` test target
- keep the `pjrt_execution` name filter so the GPU lane runs only the intended PJRT tests

## Why this is separate

PR #1398 consolidates the XLA integration-test binaries. RunPod intentionally executes workflow logic from trusted `main`, so #1398 cannot use its own updated selector until that selector first lands on `main`. This bootstrap PR changes only the trusted selector; its own GPU run can still test the pre-consolidation branch using the current trusted workflow.

## Verification

- `git diff --check`
- `python3 -m unittest discover -s scripts/ci/tests -v` (66 passed)

Prerequisite for #1398.
