### PR TITLE
dev: make local PR checks focused and incremental

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,12 +198,13 @@ When using git worktrees for feature development, **always branch from the lates
 
 ## Pre-Push / PR Checklist
 
-Before pushing or creating a pull request, run the non-release local gate:
+Before pushing or creating a pull request with code changes, run focused
+non-release verification through the local gate:
 
 ```bash
 bash scripts/check-pr-fast.sh \
   --coverage-reviewed \
-  --ci-profile local-gate
+  --test 'cargo test -p tenferro-tensor checked_convert_follows_dtype_promotion_lattice'
 
 python3 scripts/repository-rules-review.py \
   --base origin/main \
@@ -211,11 +212,16 @@ python3 scripts/repository-rules-review.py \
   --output-json /tmp/repository-rules-review.json
 ```
 
-The `local-gate` Cargo profile is non-optimized, preserves debug assertions and
-overflow checks, omits debug symbols, and disables incremental compilation.
-Hosted CI owns the full release workspace tests, coverage enforcement, backend
-matrix, docs-site build, and GPU validation. Do not require those comprehensive
-hosted-CI commands locally before every PR.
+For documentation-only changes, run `bash scripts/check-pr-fast.sh` without a
+Rust test or coverage acknowledgement. CI-only changes require a focused CI
+helper command through `--test`. The default dev/test profiles use
+`opt-level=0`, `debug=0`, and `incremental=true`, while preserving debug
+assertions and overflow checks.
+
+Hosted CI owns complete workspace tests, coverage enforcement, backend matrix,
+docs-site builds, GPU validation, and clean builds with incremental compilation
+disabled. Do not require those comprehensive hosted-CI commands locally before
+every PR.
 
 Run the relevant release test or benchmark locally when a change is
 performance-sensitive, reproduces a release-only bug, touches unsafe or
@@ -236,13 +242,10 @@ Additionally, verify the following before pushing:
 ### Local Rust Build Acceleration
 
 Ordinary focused local development, including AI-assisted edit-test loops,
-should use Cargo incremental compilation through the default dev/test
-profiles. Do not recommend or enable `sccache` solely for these loops.
-
-Before a non-incremental `local-gate` run or a workspace-wide build whose
-outputs should be reused across worktrees, check whether `sccache` is installed
-and enabled for that command. If either is missing, recommend the
-developer-local setup in `CONTRIBUTING.md` once.
+should use Cargo incremental compilation through the default dev/test profiles.
+Do not recommend or enable `sccache` solely for these loops. Debugger symbols
+may be enabled for one command with `CARGO_PROFILE_DEV_DEBUG=1` or
+`CARGO_PROFILE_TEST_DEBUG=1`.
 
 - Do not install sccache or edit global Cargo configuration without explicit
   user approval.
@@ -284,8 +287,9 @@ cargo test -p tenferro-einsum
 # Run a single test
 cargo test test_name
 
-# Run the non-release local PR test profile
-python3 scripts/ci/run_profile.py local-gate
+# Run a focused incremental local PR check
+bash scripts/check-pr-fast.sh --coverage-reviewed \
+  --test 'cargo test -p tenferro-tensor checked_convert_follows_dtype_promotion_lattice'
 
 # Check formatting
 cargo fmt --check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,19 +74,26 @@ discussion in an issue first.
 
 ## Local PR gate and hosted CI profiles
 
-Before opening or updating a pull request, run the non-release local gate:
+For code changes, run the non-release local gate with at least one focused test:
 
 ```bash
 bash scripts/check-pr-fast.sh \
   --coverage-reviewed \
-  --ci-profile local-gate
+  --test 'cargo test -p tenferro-tensor checked_convert_follows_dtype_promotion_lattice'
 ```
 
-The `local-gate` profile uses non-optimized debug semantics with debug
-assertions and overflow checks enabled. It omits debug symbols and incremental
-state to keep workspace-wide validation bounded and compatible with sccache.
-Hosted CI remains responsible for release tests, coverage, backend variants,
-documentation builds, and GPU validation. Run release locally when validating
+The default dev/test profiles use `opt-level=0`, `debug=0`, and
+`incremental=true`, with debug assertions and overflow checks enabled. Enable
+debug symbols for one command with `CARGO_PROFILE_DEV_DEBUG=1` or
+`CARGO_PROFILE_TEST_DEBUG=1` when using a debugger.
+
+For documentation-only changes, run `bash scripts/check-pr-fast.sh`; it does not
+compile Rust or require a coverage acknowledgement. CI-only changes require a
+focused CI helper command through `--test`.
+
+Hosted CI remains responsible for complete workspace tests, coverage, backend
+variants, documentation builds, GPU validation, and clean builds with
+incremental compilation disabled. Run release locally when validating
 performance, a release-only failure, unsafe or optimization-sensitive behavior,
 or an explicit maintainer request.
 
@@ -99,24 +106,22 @@ python3 scripts/ci/run_profile.py workspace-blas
 python3 scripts/ci/run_profile.py docs
 ```
 
-`full` expands every hosted profile once and intentionally excludes
-`local-gate`. Use `--dry-run` to inspect commands without executing them.
+`full` expands every hosted profile once. Use `--dry-run` to inspect commands
+without executing them.
 `scripts/check-pr-fast.sh` accepts repeatable `--ci-profile NAME` options;
 prefer these profiles over copying command lists into local scripts.
 
 ### Optional developer-local sccache
 
-Developers who use multiple worktrees can share compatible compiler outputs
-for non-incremental workspace-wide gates through a local sccache. Keep the
-wrapper scoped to the gate command:
+Developers who explicitly run non-incremental workspace-wide builds across
+multiple worktrees may share compatible compiler outputs through a local
+sccache. Keep the wrapper scoped to that explicit command:
 
 ```bash
 RUSTC_WRAPPER=sccache \
 SCCACHE_DIR="$HOME/.cache/tensor4all/sccache" \
 SCCACHE_CACHE_SIZE=20G \
-  bash scripts/check-pr-fast.sh \
-    --coverage-reviewed \
-    --ci-profile local-gate
+  CARGO_INCREMENTAL=0 cargo test --workspace
 
 SCCACHE_DIR="$HOME/.cache/tensor4all/sccache" sccache --show-stats
 ```
@@ -125,10 +130,8 @@ This is an optional local optimization. Do not configure a shared remote cache,
 and do not rely on cache hits for correctness. Ordinary focused local
 development, including AI-assisted edit-test loops, should use Cargo
 incremental compilation through the default dev/test profiles. Do not set
-`RUSTC_WRAPPER=sccache` globally for those loops. The `local-gate` profile
-disables incremental compilation so sccache can cache eligible crate
-compilations across worktrees. Disable sccache when measuring clean-build
-performance.
+`RUSTC_WRAPPER=sccache` globally for those loops. Disable sccache when measuring
+clean-build performance.
 
 Pull-request CI classifies a diff conservatively as code, docs-only, or
 CI-only. Docs-only changes run documentation validation. CI-only changes run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,10 +82,16 @@ sha2 = "0.10"
 omeco = "0.2.4"
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7", version = "0.1.0" }
 
-[profile.local-gate]
-inherits = "dev"
+[profile.dev]
 opt-level = 0
 debug = 0
 debug-assertions = true
 overflow-checks = true
-incremental = false
+incremental = true
+
+[profile.test]
+opt-level = 0
+debug = 0
+debug-assertions = true
+overflow-checks = true
+incremental = true

--- a/ai/contribution-workflows/repository-remediation.md
+++ b/ai/contribution-workflows/repository-remediation.md
@@ -340,7 +340,7 @@ the environment supports them:
 ```bash
 bash scripts/check-pr-fast.sh \
   --coverage-reviewed \
-  --ci-profile local-gate
+  --test 'cargo test -p tenferro-tensor checked_convert_follows_dtype_promotion_lattice'
 
 python3 scripts/repository-rules-review.py \
   --base origin/main \
@@ -348,10 +348,12 @@ python3 scripts/repository-rules-review.py \
   --output-json /tmp/repository-rules-review.json
 ```
 
-The local gate does not require a release build. Run release-mode checks
-locally only for performance, release-only, unsafe or optimization-sensitive
-changes, or when a maintainer requests them. Hosted CI owns the comprehensive
-release, coverage, backend, documentation, and GPU checks.
+Choose focused commands that cover every changed subsystem in the remediation
+batch. The local gate uses incremental non-release builds. Run release-mode
+checks locally only for performance, release-only, unsafe or
+optimization-sensitive changes, or when a maintainer requests them. Hosted CI
+owns comprehensive clean workspace, coverage, backend, documentation, and GPU
+checks.
 
 For CUDA/GPU work, run the documented CUDA ignored tests when hardware and
 libraries are available. If they are unavailable, add CPU-side or ignored CUDA

--- a/docs/superpowers/specs/2026-07-17-lightweight-local-pr-gate-design.md
+++ b/docs/superpowers/specs/2026-07-17-lightweight-local-pr-gate-design.md
@@ -1,0 +1,132 @@
+# Lightweight Local Pull-Request Gate Design
+
+## Scope
+
+Local development and pull-request preparation should optimize for short edit-test
+cycles. GitHub-hosted CI remains the comprehensive correctness gate. A contributor
+must not rebuild and execute the complete Rust workspace locally merely to open or
+update a pull request.
+
+This change updates Cargo development profiles, the local PR helper scripts,
+repository policy, and their contract tests. It does not reduce hosted CI test,
+coverage, backend, documentation, or GPU requirements.
+
+## Cargo profile contract
+
+The default development and test profiles use:
+
+```toml
+opt-level = 0
+debug = 0
+debug-assertions = true
+overflow-checks = true
+incremental = true
+```
+
+This is the default for ordinary local builds, focused tests, and AI-assisted
+edit-test loops. Developers who need debugger symbols may override `debug` for an
+individual command through Cargo profile environment variables. Release mode is
+reserved for benchmarks, performance validation, release-only failures, unsafe or
+optimization-sensitive changes, and explicit maintainer requests.
+
+The custom non-incremental `local-gate` profile is removed. Comprehensive hosted
+CI builds use profiles with incremental compilation disabled. Existing release
+profiles already have that Cargo default; future unoptimized hosted-CI profiles
+must set `incremental = false` explicitly.
+
+## Local gate contract
+
+`scripts/check-pr-fast.sh` classifies the complete local diff, including committed,
+staged, unstaged, and untracked paths, using the same conservative path policy as
+hosted CI.
+
+### Code or unknown changes
+
+The gate runs formatting, whitespace checks, relevant documentation snippet checks,
+and one or more contributor-selected focused verification commands. At least one
+`--test COMMAND` is required. These commands use the default incremental dev/test
+profiles unless the contributor deliberately requests another profile.
+
+Manual coverage review remains required for code or unknown changes. The review
+confirms that new branches, errors, dtypes, ranks, shapes, devices, and AD paths
+have suitable focused coverage or an explicit reason to rely on hosted coverage.
+
+### Documentation-only changes
+
+The gate runs whitespace checks and the documentation snippet synchronization
+checks selected by the changed paths. It does not require Rust compilation,
+focused Rust tests, or a code-coverage review acknowledgement. Hosted CI continues
+to run the complete documentation lane selected by the shared change policy.
+
+### CI-only changes
+
+The gate runs whitespace and formatting checks as applicable and requires a
+focused CI helper verification command. Changes to CI control-plane code are not
+treated as documentation-only. Hosted CI continues to run CI configuration checks
+and any GPU control-plane checks selected by policy.
+
+Empty or unrecognized diffs remain conservatively classified as code changes.
+
+## Pull-request creation
+
+`scripts/create-pr.sh` accepts repeatable `--test COMMAND` arguments and forwards
+them to `scripts/check-pr-fast.sh`. It no longer invokes the workspace-wide
+`local-gate` profile. It still requires a clean named branch, checks repository
+settings, runs the repository-rules review on the committed head, pushes, creates
+the PR, enables auto-merge for ordinary PRs, and monitors required checks.
+
+Generated PR verification text records the focused commands actually supplied.
+For documentation-only changes it records the lightweight documentation gate and
+does not claim that Rust workspace tests ran locally.
+
+The repository-remediation workflow adopts the same local contract: focused
+incremental tests before PR creation and comprehensive validation in hosted CI.
+
+## Hosted CI ownership
+
+GitHub-hosted CI remains responsible for:
+
+- complete workspace tests and doctests;
+- coverage generation and threshold enforcement;
+- BLAS and extension feature variants;
+- clippy and documentation-site validation;
+- CUDA/PJRT archive and GPU execution; and
+- clean-build behavior with incremental compilation disabled.
+
+Documentation-only pull requests continue to bypass Rust and GPU lanes through the
+existing change policy while running the hosted documentation lane. The local
+classification and hosted classification must agree for representative code,
+documentation-only, CI-only, empty, and unknown path sets.
+
+## Rule ownership
+
+The tenferro implementation PR updates `AGENTS.md`, `CONTRIBUTING.md`, the previous
+local-gate design record, repository-remediation guidance, and source-contract
+tests. The old design record remains historical and receives a supersession note
+rather than being rewritten as if it had always described the new policy.
+
+A separate documentation-only PR to `tensor4all-agent-rules` records the durable
+cross-repository principle:
+
+- ordinary local development and focused tests use non-release incremental builds;
+- local PR preparation is proportional to the changed surface;
+- comprehensive clean, non-incremental validation belongs to hosted CI; and
+- release mode is required only when its optimization semantics are relevant.
+
+Repository-local policy remains authoritative when a project needs stricter gates.
+
+## Verification
+
+Contract tests cover:
+
+- exact default dev/test Cargo profile fields;
+- removal of the `local-gate` profile and profile runner entry;
+- focused-test requirements for code and CI-only changes;
+- documentation-only bypass of Rust tests and coverage acknowledgement;
+- forwarding and PR-body recording of focused commands;
+- repository-remediation guidance; and
+- unchanged hosted CI path classification and required-lane behavior.
+
+The implementation is verified with formatting, CI helper unit tests, shell syntax
+checks, representative dry runs for code/docs-only/CI-only diffs, and focused Cargo
+tests. The PR itself relies on hosted CI for the comprehensive workspace gate.

--- a/docs/superpowers/specs/2026-07-17-local-pr-gate-design.md
+++ b/docs/superpowers/specs/2026-07-17-local-pr-gate-design.md
@@ -1,5 +1,9 @@
 # Local PR Gate Design
 
+> **Superseded:** This design records the former non-incremental workspace-wide
+> local gate. The current policy is defined by
+> [`2026-07-17-lightweight-local-pr-gate-design.md`](2026-07-17-lightweight-local-pr-gate-design.md).
+
 ## Scope
 
 Local pull-request preparation should catch ordinary Rust correctness failures

--- a/scripts/check-pr-fast.sh
+++ b/scripts/check-pr-fast.sh
@@ -149,7 +149,10 @@ for path in "${changed_files[@]}"; do
   policy_args+=(--path "$path")
 done
 policy_json="$("${policy_args[@]}")"
-mapfile -t policy_fields < <(
+policy_fields=()
+while IFS= read -r field; do
+  policy_fields+=("$field")
+done < <(
   python3 -c \
     'import json, sys; data = json.load(sys.stdin); print(data["classification"]); print(data["reason"])' \
     <<<"${policy_json}"
@@ -163,8 +166,17 @@ run git diff --check "${BASE_REF}...HEAD"
 run git diff --cached --check
 run git diff --check
 if [[ "${#untracked_files[@]}" -gt 0 ]]; then
-  log "note: untracked files are listed above, but git diff --check only covers tracked/staged content"
-  log "      stage or commit new files before relying on this whitespace check"
+  untracked_whitespace_errors=0
+  for path in "${untracked_files[@]}"; do
+    whitespace_output="$(git diff --no-index --check -- /dev/null "$path" 2>&1 || true)"
+    if [[ -n "$whitespace_output" ]]; then
+      printf '%s\n' "$whitespace_output" >&2
+      untracked_whitespace_errors=1
+    fi
+  done
+  if [[ "$untracked_whitespace_errors" -ne 0 ]]; then
+    die "untracked files contain whitespace errors"
+  fi
 fi
 if [[ "${change_class}" == "code" ]]; then
   run cargo fmt --all --check

--- a/scripts/check-pr-fast.sh
+++ b/scripts/check-pr-fast.sh
@@ -144,6 +144,21 @@ else
   printf '  %s\n' "${changed_files[@]}"
 fi
 
+policy_args=(python3 scripts/ci/change_policy.py)
+for path in "${changed_files[@]}"; do
+  policy_args+=(--path "$path")
+done
+policy_json="$("${policy_args[@]}")"
+mapfile -t policy_fields < <(
+  python3 -c \
+    'import json, sys; data = json.load(sys.stdin); print(data["classification"]); print(data["reason"])' \
+    <<<"${policy_json}"
+)
+change_class="${policy_fields[0]}"
+change_reason="${policy_fields[1]}"
+log "classification: ${change_class}"
+log "classification reason: ${change_reason}"
+
 run git diff --check "${BASE_REF}...HEAD"
 run git diff --cached --check
 run git diff --check
@@ -151,7 +166,11 @@ if [[ "${#untracked_files[@]}" -gt 0 ]]; then
   log "note: untracked files are listed above, but git diff --check only covers tracked/staged content"
   log "      stage or commit new files before relying on this whitespace check"
 fi
-run cargo fmt --all --check
+if [[ "${change_class}" == "code" ]]; then
+  run cargo fmt --all --check
+else
+  log "cargo fmt: skipped for ${change_class} changes"
+fi
 
 run_doc_snippets=0
 case "$DOC_SNIPPETS" in
@@ -177,6 +196,10 @@ else
   log "docs snippets: skipped"
 fi
 
+if [[ "${change_class}" != "docs-only" && "${#FOCUSED_TESTS[@]}" -eq 0 ]]; then
+  die "focused verification command required for ${change_class} changes; pass --test COMMAND"
+fi
+
 for command in "${FOCUSED_TESTS[@]}"; do
   log "+ ${command}"
   bash -lc "$command"
@@ -192,7 +215,7 @@ elif [[ "$CI_PROFILE_DRY_RUN" -eq 1 ]]; then
   die "--ci-profile-dry-run requires at least one --ci-profile"
 fi
 
-if [[ "$COVERAGE_REVIEWED" -ne 1 ]]; then
+if [[ "${change_class}" == "code" && "$COVERAGE_REVIEWED" -ne 1 ]]; then
   cat >&2 <<'EOF'
 coverage review not confirmed
 

--- a/scripts/check-pr-fast.sh
+++ b/scripts/check-pr-fast.sh
@@ -196,8 +196,8 @@ else
   log "docs snippets: skipped"
 fi
 
-if [[ "${change_class}" != "docs-only" && "${#FOCUSED_TESTS[@]}" -eq 0 ]]; then
-  die "focused verification command required for ${change_class} changes; pass --test COMMAND"
+if [[ "${change_class}" != "docs-only" && "${#FOCUSED_TESTS[@]}" -eq 0 && "${#CI_PROFILES[@]}" -eq 0 ]]; then
+  die "focused verification command required for ${change_class} changes; pass --test COMMAND or --ci-profile NAME"
 fi
 
 for command in "${FOCUSED_TESTS[@]}"; do

--- a/scripts/ci/change_policy.py
+++ b/scripts/ci/change_policy.py
@@ -153,7 +153,7 @@ def classify_paths(
 
 def _changed_paths(base: str, head: str) -> list[str]:
     result = subprocess.run(
-        ["git", "diff", "--name-only", "--diff-filter=ACMR", base, head, "--"],
+        ["git", "diff", "--name-only", base, head, "--"],
         check=True,
         capture_output=True,
         text=True,

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -12,11 +12,6 @@ from typing import TextIO
 
 
 PROFILE_COMMANDS: dict[str, tuple[str, ...]] = {
-    "local-gate": (
-        "cargo nextest run --workspace --cargo-profile local-gate "
-        "--no-fail-fast",
-        "cargo test --doc --workspace --profile local-gate",
-    ),
     "workspace-faer": (
         "cargo nextest run --workspace --release --no-fail-fast",
         "cargo test --doc --workspace --release",

--- a/scripts/ci/tests/test_change_policy.py
+++ b/scripts/ci/tests/test_change_policy.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -92,7 +93,102 @@ class ChangePolicyTests(unittest.TestCase):
             self.assertEqual(values["classification"], "docs-only")
             self.assertEqual(values["run_docs"], "true")
             self.assertEqual(values["run_rust"], "false")
-            self.assertIn("README.md", values["reason"])
+        self.assertIn("README.md", values["reason"])
+
+
+class LocalGateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo = Path(self.temp_dir.name)
+        (self.repo / "scripts" / "ci").mkdir(parents=True)
+        shutil.copy2(ROOT / "scripts" / "check-pr-fast.sh", self.repo / "scripts")
+        shutil.copy2(
+            ROOT / "scripts" / "ci" / "change_policy.py",
+            self.repo / "scripts" / "ci",
+        )
+        bin_dir = self.repo / "bin"
+        bin_dir.mkdir()
+        cargo = bin_dir / "cargo"
+        cargo.write_text(
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\n' \"$*\" >> \"$CARGO_MARKER\"\n"
+        )
+        cargo.chmod(0o755)
+        subprocess.run(["git", "init", "-b", "test-branch"], cwd=self.repo, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=self.repo,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=self.repo,
+            check=True,
+        )
+        (self.repo / "README.md").write_text("baseline\n")
+        subprocess.run(["git", "add", "."], cwd=self.repo, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+        )
+        self.marker = self.repo / "cargo-calls"
+        self.env = os.environ | {
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "CARGO_MARKER": str(self.marker),
+        }
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def run_gate(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "bash",
+                "scripts/check-pr-fast.sh",
+                "--base",
+                "HEAD",
+                "--no-fetch",
+                "--skip-doc-snippets",
+                *args,
+            ],
+            cwd=self.repo,
+            env=self.env,
+            capture_output=True,
+            text=True,
+        )
+
+    def write_change(self, path: str) -> None:
+        target = self.repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("changed\n")
+
+    def test_code_change_requires_a_focused_command(self) -> None:
+        self.write_change("src/lib.rs")
+        result = self.run_gate("--coverage-reviewed")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("focused verification command required", result.stderr)
+
+    def test_code_change_runs_focused_command_incrementally(self) -> None:
+        self.write_change("src/lib.rs")
+        result = self.run_gate("--coverage-reviewed", "--test", "true")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("classification: code", result.stdout)
+        self.assertTrue(self.marker.exists(), "code changes should run cargo fmt")
+
+    def test_docs_only_change_skips_cargo_and_coverage_acknowledgement(self) -> None:
+        self.write_change("docs/guide.md")
+        result = self.run_gate()
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("classification: docs-only", result.stdout)
+        self.assertFalse(self.marker.exists(), "docs-only must not invoke Cargo")
+
+    def test_ci_only_change_requires_a_focused_command(self) -> None:
+        self.write_change("scripts/ci/example.py")
+        result = self.run_gate()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("focused verification command required", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_change_policy.py
+++ b/scripts/ci/tests/test_change_policy.py
@@ -93,7 +93,71 @@ class ChangePolicyTests(unittest.TestCase):
             self.assertEqual(values["classification"], "docs-only")
             self.assertEqual(values["run_docs"], "true")
             self.assertEqual(values["run_rust"], "false")
-        self.assertIn("README.md", values["reason"])
+            self.assertIn("README.md", values["reason"])
+
+    def test_cli_classifies_deleted_documentation_as_docs_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = Path(temp_dir)
+            subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "test@example.com"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Test User"],
+                cwd=repo,
+                check=True,
+            )
+            docs = repo / "docs"
+            docs.mkdir()
+            guide = docs / "guide.md"
+            guide.write_text("guide\n")
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", "add guide"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+            )
+            base = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            guide.unlink()
+            subprocess.run(["git", "add", "-u"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", "remove guide"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+            )
+            head = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--base",
+                    base,
+                    "--head",
+                    head,
+                ],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(json.loads(result.stdout)["classification"], "docs-only")
 
 
 class LocalGateTests(unittest.TestCase):
@@ -187,6 +251,14 @@ class LocalGateTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("classification: docs-only", result.stdout)
         self.assertFalse(self.marker.exists(), "docs-only must not invoke Cargo")
+
+    def test_untracked_docs_with_trailing_whitespace_fail(self) -> None:
+        target = self.repo / "docs" / "guide.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("trailing whitespace   \n")
+        result = self.run_gate()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("trailing whitespace", result.stdout + result.stderr)
 
     def test_ci_only_change_requires_a_focused_command(self) -> None:
         self.write_change("scripts/ci/example.py")

--- a/scripts/ci/tests/test_change_policy.py
+++ b/scripts/ci/tests/test_change_policy.py
@@ -106,6 +106,10 @@ class LocalGateTests(unittest.TestCase):
             ROOT / "scripts" / "ci" / "change_policy.py",
             self.repo / "scripts" / "ci",
         )
+        shutil.copy2(
+            ROOT / "scripts" / "ci" / "run_profile.py",
+            self.repo / "scripts" / "ci",
+        )
         bin_dir = self.repo / "bin"
         bin_dir.mkdir()
         cargo = bin_dir / "cargo"
@@ -189,6 +193,14 @@ class LocalGateTests(unittest.TestCase):
         result = self.run_gate()
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("focused verification command required", result.stderr)
+
+    def test_ci_only_change_accepts_an_explicit_ci_profile(self) -> None:
+        self.write_change("scripts/ci/example.py")
+        result = self.run_gate(
+            "--ci-profile", "ci-config", "--ci-profile-dry-run"
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("python3 -m unittest discover", result.stdout)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -117,6 +117,14 @@ class RunProfileTests(unittest.TestCase):
         self.assertNotIn("cargo nextest run --workspace --release", source)
         self.assertNotIn("cargo llvm-cov", source)
 
+    def test_create_pr_pushes_the_named_branch_not_its_base_upstream(self) -> None:
+        source = (ROOT / "scripts" / "create-pr.sh").read_text()
+        self.assertIn('git push -u origin "$current_branch"', source)
+        self.assertNotIn(
+            "git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}'",
+            source,
+        )
+
     def test_remediation_workflow_uses_focused_tests_before_pr(self) -> None:
         source = (
             ROOT / "ai" / "contribution-workflows" / "repository-remediation.md"

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -11,29 +11,23 @@ ROOT = Path(__file__).resolve().parents[3]
 
 
 class RunProfileTests(unittest.TestCase):
-    def test_local_gate_uses_non_release_workspace_commands(self) -> None:
-        self.assertEqual(
-            commands_for("local-gate"),
-            (
-                "cargo nextest run --workspace --cargo-profile local-gate "
-                "--no-fail-fast",
-                "cargo test --doc --workspace --profile local-gate",
-            ),
-        )
-
-    def test_local_gate_cargo_profile_preserves_debug_checks(self) -> None:
+    def test_default_local_profiles_are_incremental_and_unoptimized(self) -> None:
         manifest = tomllib.loads((ROOT / "Cargo.toml").read_text())
-        self.assertEqual(
-            manifest["profile"]["local-gate"],
-            {
-                "inherits": "dev",
-                "opt-level": 0,
-                "debug": 0,
-                "debug-assertions": True,
-                "overflow-checks": True,
-                "incremental": False,
-            },
-        )
+        expected = {
+            "opt-level": 0,
+            "debug": 0,
+            "debug-assertions": True,
+            "overflow-checks": True,
+            "incremental": True,
+        }
+        self.assertEqual(manifest["profile"]["dev"], expected)
+        self.assertEqual(manifest["profile"]["test"], expected)
+
+    def test_non_incremental_local_gate_profile_is_removed(self) -> None:
+        manifest = tomllib.loads((ROOT / "Cargo.toml").read_text())
+        self.assertNotIn("local-gate", manifest["profile"])
+        with self.assertRaisesRegex(ValueError, "unknown CI profile"):
+            commands_for("local-gate")
 
     def test_hosted_full_profile_does_not_include_local_gate(self) -> None:
         self.assertNotIn("local-gate", expand_profiles(["full"]))

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -112,12 +112,13 @@ class RunProfileTests(unittest.TestCase):
         self.assertNotIn("cargo nextest run --workspace --release", source)
         self.assertNotIn("cargo llvm-cov", source)
 
-    def test_remediation_workflow_uses_local_gate_before_pr(self) -> None:
+    def test_remediation_workflow_uses_focused_tests_before_pr(self) -> None:
         source = (
             ROOT / "ai" / "contribution-workflows" / "repository-remediation.md"
         ).read_text()
         self.assertIn("bash scripts/check-pr-fast.sh", source)
-        self.assertIn("--ci-profile local-gate", source)
+        self.assertIn("--test 'cargo test -p tenferro-tensor", source)
+        self.assertNotIn("--ci-profile local-gate", source)
         self.assertNotIn("cargo test --workspace --release", source)
         self.assertNotIn("cargo llvm-cov --workspace --release", source)
 
@@ -139,6 +140,27 @@ class RunProfileTests(unittest.TestCase):
         self.assertNotIn(
             "Before the first workspace-wide local Rust build", agents
         )
+
+    def test_policy_assigns_comprehensive_validation_to_hosted_ci(self) -> None:
+        agents = (ROOT / "AGENTS.md").read_text()
+        contributing = (ROOT / "CONTRIBUTING.md").read_text()
+        old_design = (
+            ROOT
+            / "docs"
+            / "superpowers"
+            / "specs"
+            / "2026-07-17-local-pr-gate-design.md"
+        ).read_text()
+
+        for source in (agents, contributing):
+            self.assertIn("incremental=true", source)
+            self.assertIn("documentation-only", source)
+            self.assertIn("focused", source)
+            self.assertIn("Hosted CI", source)
+            self.assertNotIn("--ci-profile local-gate", source)
+
+        self.assertIn("Superseded", old_design)
+        self.assertIn("2026-07-17-lightweight-local-pr-gate-design.md", old_design)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -100,6 +100,11 @@ class RunProfileTests(unittest.TestCase):
         self.assertIn('python3 scripts/ci/run_profile.py "${profile_args[@]}"', source)
         self.assertNotIn("cargo nextest run --workspace", source)
 
+    def test_fast_preflight_avoids_bash4_only_mapfile(self) -> None:
+        source = (ROOT / "scripts" / "check-pr-fast.sh").read_text()
+        self.assertNotIn("mapfile", source)
+        self.assertIn("while IFS= read -r field", source)
+
     def test_create_pr_forwards_focused_tests(self) -> None:
         source = (ROOT / "scripts" / "create-pr.sh").read_text()
         self.assertIn("bash scripts/check-pr-fast.sh", source)

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -100,11 +100,15 @@ class RunProfileTests(unittest.TestCase):
         self.assertIn('python3 scripts/ci/run_profile.py "${profile_args[@]}"', source)
         self.assertNotIn("cargo nextest run --workspace", source)
 
-    def test_create_pr_uses_local_gate_instead_of_release_suite(self) -> None:
+    def test_create_pr_forwards_focused_tests(self) -> None:
         source = (ROOT / "scripts" / "create-pr.sh").read_text()
         self.assertIn("bash scripts/check-pr-fast.sh", source)
-        self.assertIn("--ci-profile local-gate", source)
+        self.assertIn("FOCUSED_TESTS=()", source)
+        self.assertIn("--test)", source)
+        self.assertIn('fast_gate_args+=(--test "$command")', source)
+        self.assertIn("Focused local verification", source)
         self.assertIn("python3 scripts/repository-rules-review.py", source)
+        self.assertNotIn("--ci-profile local-gate", source)
         self.assertNotIn("cargo nextest run --workspace --release", source)
         self.assertNotIn("cargo llvm-cov", source)
 

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -164,11 +164,7 @@ fi
 ensure_body_file
 append_ai_attribution
 
-if git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' >/dev/null 2>&1; then
-  git push
-else
-  git push -u origin "$current_branch"
-fi
+git push -u origin "$current_branch"
 
 create_args=(pr create --base "$BASE_BRANCH" --title "$TITLE" --body-file "$BODY_FILE")
 if [[ "$DRAFT" -eq 1 ]]; then

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -8,6 +8,7 @@ AUTO_MERGE=1
 DRAFT=0
 AI_TOOL_NAME=""
 AI_TOOL_URL=""
+FOCUSED_TESTS=()
 
 usage() {
   cat <<'EOF'
@@ -17,6 +18,7 @@ Options:
   --base BRANCH          Base branch for the pull request (default: main)
   --title TITLE          Pull request title (defaults to the latest commit subject)
   --body-file PATH       Markdown body file to pass to gh pr create
+  --test COMMAND         Focused local verification command; repeatable
   --no-auto-merge        Do not enable auto-merge after PR creation
   --draft                Create the PR as a draft
   --ai-tool-name NAME    Attribution display name, for example "Claude Code"
@@ -47,7 +49,14 @@ ensure_body_file() {
     printf '## Summary\n\n'
     git log --format='- %s' "${BASE_BRANCH}..HEAD" 2>/dev/null || true
     printf '\n## Verification\n\n'
-    printf -- '- `bash scripts/check-pr-fast.sh --coverage-reviewed --ci-profile local-gate`\n'
+    printf -- '- Focused local verification:\n'
+    if [[ "${#FOCUSED_TESTS[@]}" -eq 0 ]]; then
+      printf -- '  - `bash scripts/check-pr-fast.sh` (documentation-only path)\n'
+    else
+      for command in "${FOCUSED_TESTS[@]}"; do
+        printf -- '  - `%s`\n' "$command"
+      done
+    fi
     printf -- '- `python3 scripts/repository-rules-review.py --base origin/%s --head HEAD`\n' "$BASE_BRANCH"
     printf '\n## Documentation\n\n'
     printf -- '- Reviewed `README.md`, `docs/design/**`, `docs/api/index.md`, and public rustdoc for consistency.\n'
@@ -67,10 +76,14 @@ append_ai_attribution() {
 }
 
 run_required_checks() {
-  bash scripts/check-pr-fast.sh \
-    --base "origin/${BASE_BRANCH}" \
-    --coverage-reviewed \
-    --ci-profile local-gate
+  fast_gate_args=(
+    --base "origin/${BASE_BRANCH}"
+    --coverage-reviewed
+  )
+  for command in "${FOCUSED_TESTS[@]}"; do
+    fast_gate_args+=(--test "$command")
+  done
+  bash scripts/check-pr-fast.sh "${fast_gate_args[@]}"
   python3 scripts/repository-rules-review.py \
     --base "origin/${BASE_BRANCH}" \
     --head HEAD \
@@ -89,6 +102,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --body-file)
       BODY_FILE="$2"
+      shift 2
+      ;;
+    --test)
+      [[ $# -ge 2 ]] || {
+        log "--test requires a command"
+        exit 1
+      }
+      FOCUSED_TESTS+=("$2")
       shift 2
       ;;
     --no-auto-merge)


### PR DESCRIPTION
## Summary

- make default local dev/test builds unoptimized, symbol-free, and incremental
- replace the workspace-wide local PR gate with change-aware focused verification
- let documentation-only changes skip Cargo and coverage acknowledgement while hosted CI retains comprehensive validation
- forward focused commands through `scripts/create-pr.sh` and document the local/hosted responsibility boundary

## Behavior

- code or unknown changes require at least one `--test` command or explicit CI profile plus coverage review
- CI-only changes require focused verification
- documentation-only changes run diff and documentation checks without invoking Cargo
- untracked files receive whitespace checks, deleted paths use the same classifier locally and in CI, and the shell remains compatible with macOS Bash 3.2

## Verification

- `cargo fmt --all --check`
- `bash -n scripts/check-pr-fast.sh scripts/create-pr.sh`
- `python3 -m unittest discover -s scripts/ci/tests -v` — 80 passed
- `python3 scripts/check-doc-snippets.py --root-dir . --check`
- `cargo metadata --no-deps --format-version 1`
- `cargo test -p tenferro-tensor checked_convert_follows_dtype_promotion_lattice`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD` — pass, no findings

## Validation ownership

The local checks are intentionally proportional and incremental. Hosted CI remains authoritative for complete workspace tests, coverage, backend matrices, documentation builds, and clean non-incremental validation.
