### PR TITLE
ci: switch hosted Rust builds to thin [profile.ci]

### DIFF
--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -176,7 +176,7 @@ jobs:
         run: |
           set -euo pipefail
           rustc_hash="$(rustc --version --verbose | sha256sum | cut -c1-12)"
-          echo "key=cuda-archive-v4-no-cuda-build-${rustc_hash}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/src/**', '**/tests/**', '.github/workflows/CI_gpu.yml') }}" >> "${GITHUB_OUTPUT}"
+          echo "key=cuda-archive-v5-ci-no-cuda-build-${rustc_hash}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/src/**', '**/tests/**', '.github/workflows/CI_gpu.yml') }}" >> "${GITHUB_OUTPUT}"
       - name: Cache CUDA test archive
         uses: actions/cache@v4
         id: cuda_archive_cache
@@ -187,7 +187,7 @@ jobs:
         if: steps.cuda_archive_cache.outputs.cache-hit != 'true'
         with:
           prefix-key: v0-rust-cuda
-          shared-key: cuda-release
+          shared-key: cuda-ci
           cache-all-crates: true
       - uses: taiki-e/install-action@nextest
         if: steps.cuda_archive_cache.outputs.cache-hit != 'true'
@@ -200,7 +200,7 @@ jobs:
         run: |
           set -euo pipefail
           cargo nextest archive \
-            --release \
+            --cargo-profile ci \
             --archive-file "${CUDA_ARCHIVE}" \
             -p tenferro-gpu \
             -p tenferro-ad \

--- a/.github/workflows/ci-pr-workspace-tests.yml
+++ b/.github/workflows/ci-pr-workspace-tests.yml
@@ -90,7 +90,6 @@ jobs:
         cfg: ${{ fromJSON(needs.changes.outputs.backends) }}
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/../target-${{ matrix.cfg.backend }}
-      CARGO_PROFILE_RELEASE_DEBUG: 0
       RUSTFLAGS: ${{ matrix.cfg.rustflags }}
     steps:
       - uses: actions/checkout@v6
@@ -112,6 +111,13 @@ jobs:
       - name: Run workspace profile
         if: matrix.cfg.profile != ''
         run: python3 scripts/ci/run_profile.py "${{ matrix.cfg.profile }}"
+      - name: Log CI target disk usage
+        if: always() && matrix.cfg.profile != ''
+        run: |
+          set -euo pipefail
+          echo "CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"
+          du -sh "${CARGO_TARGET_DIR}" || true
+          df -h "${CARGO_TARGET_DIR}" || df -h .
       - name: Report workspace no-op
         if: matrix.cfg.profile == ''
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,12 @@ jobs:
       - name: Generate and enforce coverage
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
         run: python3 scripts/ci/run_profile.py coverage
+      - name: Log CI target disk usage
+        if: always() && needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+        run: |
+          set -euo pipefail
+          du -sh target || true
+          df -h .
       - name: Report coverage disposition
         if: always()
         env:

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -548,7 +548,7 @@ jobs:
         id: archive_key
         run: |
           set -euo pipefail
-          key="cuda-archive-v9-ubuntu22.04-cuda${CUDARC_CUDA_VERSION}-ptx${CUDA_RUNTIME_VERSION}-${{ hashFiles('tenferro-rs/Cargo.lock', 'tenferro-rs/**/Cargo.toml', 'tenferro-rs/**/src/**', 'tenferro-rs/**/tests/**', 'tenferro-rs/scripts/ci/runpod_config.json', 'tenferro-rs/.github/workflows/runpod-gpu-test.yml') }}"
+          key="cuda-archive-v10-ci-ubuntu22.04-cuda${CUDARC_CUDA_VERSION}-ptx${CUDA_RUNTIME_VERSION}-${{ hashFiles('tenferro-rs/Cargo.lock', 'tenferro-rs/**/Cargo.toml', 'tenferro-rs/**/src/**', 'tenferro-rs/**/tests/**', 'tenferro-rs/scripts/ci/runpod_config.json', 'tenferro-rs/.github/workflows/runpod-gpu-test.yml') }}"
           echo "key=${key}" >> "${GITHUB_OUTPUT}"
           echo "CUDA archive cache key: ${key}"
 
@@ -570,8 +570,8 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         if: steps.cuda_archive_cache.outputs.cache-hit != 'true'
         with:
-          prefix-key: v5-rust-cuda-ubuntu22-ptx
-          shared-key: cuda-release-${{ env.CUDARC_CUDA_VERSION }}-ptx-${{ env.CUDA_RUNTIME_VERSION }}
+          prefix-key: v6-rust-cuda-ci-ubuntu22-ptx
+          shared-key: cuda-ci-${{ env.CUDARC_CUDA_VERSION }}-ptx-${{ env.CUDA_RUNTIME_VERSION }}
           cache-all-crates: true
           cache-workspace-crates: true
           workspaces: tenferro-rs -> target
@@ -589,7 +589,7 @@ jobs:
         run: |
           set -euo pipefail
           cargo nextest archive \
-            --release \
+            --cargo-profile ci \
             --archive-file "${CUDA_ARCHIVE}" \
             -p tenferro-gpu \
             -p tenferro-ad \
@@ -614,6 +614,8 @@ jobs:
           else
             echo "Built fresh CUDA test archive on Ubuntu 22.04."
           fi
+          du -sh "${CUDA_ARCHIVE}" target/ci 2>/dev/null || du -sh "${CUDA_ARCHIVE}" || true
+          df -h .
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # Self-hosted RunPod runners cannot restore the hosted-runner Actions cache;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,9 +219,10 @@ helper command through `--test`. The default dev/test profiles use
 assertions and overflow checks.
 
 Hosted CI owns complete workspace tests, coverage enforcement, backend matrix,
-docs-site builds, GPU validation, and clean builds with incremental compilation
-disabled. Do not require those comprehensive hosted-CI commands locally before
-every PR.
+docs-site builds, GPU validation, and clean builds through workspace
+`[profile.ci]` (`opt-level=0`, `debug=0`, `incremental=false`,
+`strip="symbols"`). Do not require those comprehensive hosted-CI commands
+locally before every PR.
 
 Run the relevant release test or benchmark locally when a change is
 performance-sensitive, reproduces a release-only bug, touches unsafe or
@@ -296,7 +297,7 @@ cargo fmt --check
 
 # Coverage check (per-file thresholds)
 # Target: 90%+ line coverage per file. Files below 90% should have tests added.
-cargo llvm-cov --workspace --release --json --output-path coverage.json
+cargo llvm-cov --workspace --profile ci --json --output-path coverage.json
 python3 scripts/check-coverage.py coverage.json
 
 # Build rustdoc and docs site inputs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,10 +92,11 @@ compile Rust or require a coverage acknowledgement. CI-only changes require a
 focused CI helper command through `--test`.
 
 Hosted CI remains responsible for complete workspace tests, coverage, backend
-variants, documentation builds, GPU validation, and clean builds with
-incremental compilation disabled. Run release locally when validating
-performance, a release-only failure, unsafe or optimization-sensitive behavior,
-or an explicit maintainer request.
+variants, documentation builds, GPU validation, and clean builds through the
+workspace `[profile.ci]` (`opt-level=0`, `debug=0`, `incremental=false`,
+`strip="symbols"`). Local `dev`/`test` profiles stay incremental. Run release
+locally when validating performance, a release-only failure, unsafe or
+optimization-sensitive behavior, or an explicit maintainer request.
 
 The exact command groups used by hosted CI are available locally:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,3 +95,10 @@ debug = 0
 debug-assertions = true
 overflow-checks = true
 incremental = true
+
+# Hosted-CI cold builds only (`scripts/ci/run_profile.py`, CUDA archives).
+# Keep local [profile.dev]/[profile.test] incremental for edit-test loops.
+[profile.ci]
+inherits = "test"
+incremental = false
+strip = "symbols"

--- a/docs/design/change-aware-ci.md
+++ b/docs/design/change-aware-ci.md
@@ -34,7 +34,9 @@ fallback.
 workspace-blas, provider injection, extensions, documentation, coverage, and
 CI configuration. Local and hosted execution call the same profile names.
 `full` is composition rather than another command list, so repeated profiles
-execute once.
+execute once. Hosted Rust compile/test commands use workspace `[profile.ci]`
+(`opt-level=0`, `debug=0`, `incremental=false`, `strip="symbols"`) rather than
+`--release`; local `dev`/`test` profiles stay incremental.
 
 ## RunPod trust boundary
 

--- a/docs/worklogs/2026-07-18-issue-1402-ci-thin-profile.md
+++ b/docs/worklogs/2026-07-18-issue-1402-ci-thin-profile.md
@@ -1,0 +1,43 @@
+# Issue #1402 CI Thin Profile
+
+## Session summary
+
+Switched hosted Rust CI from `--release` to workspace `[profile.ci]`:
+`inherits = "test"`, `incremental = false`, `strip = "symbols"`. Local
+`[profile.dev]` / `[profile.test]` remain incremental. Shared command source is
+`scripts/ci/run_profile.py`; CUDA archives in `runpod-gpu-test.yml` and
+`CI_gpu.yml` use `cargo nextest archive --cargo-profile ci`.
+
+## Context read
+
+- [#1402](https://github.com/tensor4all/tenferro-rs/issues/1402) and parent #1401
+- Local macOS PoC comments on #1402 (thin compile/run, `strip="debuginfo"` no-op,
+  `strip="symbols"` 14 GiB → 8.3 GiB)
+- `docs/worklogs/2026-07-17-issue-1397-build-artifact-reduction.md`
+- `scripts/ci/run_profile.py` and CI workflow contracts
+
+## Chosen design
+
+- Explicit `[profile.ci]` rather than env-only overrides, so hosted cold builds
+  are named and reviewable.
+- Keep `--cargo-profile ci` / `--profile ci` in `run_profile.py` so YAML callers
+  stay thin.
+- Bump CUDA archive / rust-cache keys so previous `--release` artifacts are not
+  reused.
+- Log `du`/`df` after workspace and coverage jobs for acceptance evidence.
+
+## Rejected alternatives
+
+- Changing default `[profile.test]` to non-incremental/stripped: would slow
+  local AI edit-test loops.
+- `strip = "debuginfo"` alone: no size change after `debug = 0` on macOS PoC.
+- Keeping `--release` for coverage only: would leave the heaviest cold-compile
+  path on the old profile without a measured reason.
+
+## Residual risks
+
+- Hosted Linux peak disk and free-space still need confirmation in CI logs.
+- `strip = "symbols"` weakens CI backtraces; test names/assertions remain.
+- Coverage with `debug=0` + strip must still pass thresholds on GitHub runners.
+- CUDA/PJRT archive wall-clock target (<10 minutes) is measured after merge into
+  the GPU workflow path, not locally on macOS.

--- a/docs/worklogs/2026-07-18-issue-1402-ci-thin-profile.md
+++ b/docs/worklogs/2026-07-18-issue-1402-ci-thin-profile.md
@@ -41,3 +41,10 @@ Switched hosted Rust CI from `--release` to workspace `[profile.ci]`:
 - Coverage with `debug=0` + strip must still pass thresholds on GitHub runners.
 - CUDA/PJRT archive wall-clock target (<10 minutes) is measured after merge into
   the GPU workflow path, not locally on macOS.
+
+## Follow-up fix
+
+Nested extension/sample workspaces (`ext/tropical`, `ext/sparse`,
+`samples/kdv-pinn`) do not see the root `[profile.ci]`. CI failed with
+`profile ci is not defined` until those manifests defined a matching profile
+(with explicit `debug = 0`, since nested defaults keep test debuginfo).

--- a/ext/sparse/Cargo.toml
+++ b/ext/sparse/Cargo.toml
@@ -29,3 +29,10 @@ tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "57a2e7ebe7738
 [dev-dependencies]
 tenferro-ad = { path = "../../crates/tenferro-ad", default-features = false, features = ["cpu-faer"] }
 tenferro-cpu = { path = "../../crates/tenferro-cpu", default-features = false, features = ["cpu-faer"] }
+
+# Match workspace [profile.ci] used by scripts/ci/run_profile.py extensions.
+[profile.ci]
+inherits = "test"
+debug = 0
+incremental = false
+strip = "symbols"

--- a/ext/tropical/Cargo.toml
+++ b/ext/tropical/Cargo.toml
@@ -43,3 +43,10 @@ tenferro-cpu = { path = "../../crates/tenferro-cpu" }
 [[bench]]
 name = "tropical_matmul"
 harness = false
+
+# Match workspace [profile.ci] used by scripts/ci/run_profile.py extensions.
+[profile.ci]
+inherits = "test"
+debug = 0
+incremental = false
+strip = "symbols"

--- a/samples/kdv-pinn/Cargo.toml
+++ b/samples/kdv-pinn/Cargo.toml
@@ -20,3 +20,10 @@ plotters = { version = "0.3", default-features = false, features = [
     "line_series",
 ] }
 rand = "0.8"
+
+# Match workspace [profile.ci] used by scripts/ci/run_profile.py extensions.
+[profile.ci]
+inherits = "test"
+debug = 0
+incremental = false
+strip = "symbols"

--- a/scripts/ci/run_profile.py
+++ b/scripts/ci/run_profile.py
@@ -10,28 +10,33 @@ import sys
 from collections.abc import Sequence
 from typing import TextIO
 
+# Hosted CI uses Cargo `[profile.ci]`: opt-level=0, debug=0, incremental=false,
+# strip="symbols". nextest takes `--cargo-profile`; cargo/llvm-cov take `--profile`.
+_CARGO_PROFILE = "ci"
+_NEXTEST_PROFILE = f"--cargo-profile {_CARGO_PROFILE}"
+_CARGO_TEST_PROFILE = f"--profile {_CARGO_PROFILE}"
 
 PROFILE_COMMANDS: dict[str, tuple[str, ...]] = {
     "workspace-faer": (
-        "cargo nextest run --workspace --release --no-fail-fast",
-        "cargo test --doc --workspace --release",
+        f"cargo nextest run --workspace {_NEXTEST_PROFILE} --no-fail-fast",
+        f"cargo test --doc --workspace {_CARGO_TEST_PROFILE}",
     ),
     "workspace-blas": (
-        "cargo nextest run --workspace --release --no-default-features "
+        f"cargo nextest run --workspace {_NEXTEST_PROFILE} --no-default-features "
         "--features cpu-blas --no-fail-fast",
-        "cargo test --doc --workspace --release --no-default-features "
+        f"cargo test --doc --workspace {_CARGO_TEST_PROFILE} --no-default-features "
         "--features cpu-blas",
     ),
     "blas-inject": (
-        "cargo test -p tenferro-cpu --release --no-default-features "
+        f"cargo test -p tenferro-cpu {_CARGO_TEST_PROFILE} --no-default-features "
         '--features "cpu-blas,provider-inject" --test integration inject_tests',
     ),
     "extensions": (
-        "cargo test --manifest-path ext/tropical/Cargo.toml --release "
+        f"cargo test --manifest-path ext/tropical/Cargo.toml {_CARGO_TEST_PROFILE} "
         "--features autodiff",
-        "cargo test --manifest-path ext/sparse/Cargo.toml --release "
+        f"cargo test --manifest-path ext/sparse/Cargo.toml {_CARGO_TEST_PROFILE} "
         "--features autodiff",
-        "cargo check --manifest-path samples/kdv-pinn/Cargo.toml --release "
+        f"cargo check --manifest-path samples/kdv-pinn/Cargo.toml {_CARGO_TEST_PROFILE} "
         "--all-targets",
     ),
     "docs": (
@@ -43,7 +48,8 @@ PROFILE_COMMANDS: dict[str, tuple[str, ...]] = {
         "bash scripts/build_docs_site.sh",
     ),
     "coverage": (
-        "cargo llvm-cov --workspace --release --json --output-path coverage.json",
+        f"cargo llvm-cov --workspace {_CARGO_TEST_PROFILE} --json "
+        "--output-path coverage.json",
         "python3 scripts/check-coverage.py coverage.json",
     ),
     "ci-config": (

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -23,6 +23,13 @@ class RunProfileTests(unittest.TestCase):
         self.assertEqual(manifest["profile"]["dev"], expected)
         self.assertEqual(manifest["profile"]["test"], expected)
 
+    def test_hosted_ci_profile_is_non_incremental_and_stripped(self) -> None:
+        manifest = tomllib.loads((ROOT / "Cargo.toml").read_text())
+        ci = manifest["profile"]["ci"]
+        self.assertEqual(ci["inherits"], "test")
+        self.assertFalse(ci["incremental"])
+        self.assertEqual(ci["strip"], "symbols")
+
     def test_non_incremental_local_gate_profile_is_removed(self) -> None:
         manifest = tomllib.loads((ROOT / "Cargo.toml").read_text())
         self.assertNotIn("local-gate", manifest["profile"])
@@ -36,12 +43,27 @@ class RunProfileTests(unittest.TestCase):
         self.assertEqual(
             commands_for("workspace-blas"),
             (
-                "cargo nextest run --workspace --release --no-default-features "
+                "cargo nextest run --workspace --cargo-profile ci --no-default-features "
                 "--features cpu-blas --no-fail-fast",
-                "cargo test --doc --workspace --release --no-default-features "
+                "cargo test --doc --workspace --profile ci --no-default-features "
                 "--features cpu-blas",
             ),
         )
+
+    def test_hosted_profiles_use_cargo_ci_profile_not_release(self) -> None:
+        for name in (
+            "workspace-faer",
+            "workspace-blas",
+            "blas-inject",
+            "extensions",
+            "coverage",
+        ):
+            joined = "\n".join(commands_for(name))
+            with self.subTest(profile=name):
+                self.assertNotIn("--release", joined)
+                self.assertTrue(
+                    "--cargo-profile ci" in joined or "--profile ci" in joined
+                )
 
     def test_full_profile_expands_named_profiles_once(self) -> None:
         expanded = expand_profiles(["full"])

--- a/scripts/ci/tests/test_run_profile.py
+++ b/scripts/ci/tests/test_run_profile.py
@@ -24,11 +24,25 @@ class RunProfileTests(unittest.TestCase):
         self.assertEqual(manifest["profile"]["test"], expected)
 
     def test_hosted_ci_profile_is_non_incremental_and_stripped(self) -> None:
-        manifest = tomllib.loads((ROOT / "Cargo.toml").read_text())
-        ci = manifest["profile"]["ci"]
-        self.assertEqual(ci["inherits"], "test")
-        self.assertFalse(ci["incremental"])
-        self.assertEqual(ci["strip"], "symbols")
+        root = tomllib.loads((ROOT / "Cargo.toml").read_text())["profile"]["ci"]
+        self.assertEqual(root["inherits"], "test")
+        self.assertFalse(root["incremental"])
+        self.assertEqual(root["strip"], "symbols")
+
+        nested_expected = {
+            "inherits": "test",
+            "debug": 0,
+            "incremental": False,
+            "strip": "symbols",
+        }
+        for relative in (
+            "ext/tropical/Cargo.toml",
+            "ext/sparse/Cargo.toml",
+            "samples/kdv-pinn/Cargo.toml",
+        ):
+            manifest = tomllib.loads((ROOT / relative).read_text())
+            with self.subTest(manifest=relative):
+                self.assertEqual(manifest["profile"]["ci"], nested_expected)
 
     def test_non_incremental_local_gate_profile_is_removed(self) -> None:
         manifest = tomllib.loads((ROOT / "Cargo.toml").read_text())

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -131,6 +131,23 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("hashFiles(", key_line)
         self.assertIn("runpod_config.json", key_line)
 
+    def test_cuda_archives_use_cargo_ci_profile_not_release(self) -> None:
+        for path in (
+            ".github/workflows/runpod-gpu-test.yml",
+            ".github/workflows/CI_gpu.yml",
+        ):
+            text = read(path)
+            with self.subTest(path=path):
+                self.assertIn("cargo nextest archive", text)
+                self.assertIn("--cargo-profile ci", text)
+                archive = text[
+                    text.index("cargo nextest archive") : text.index(
+                        "cargo nextest archive"
+                    )
+                    + 200
+                ]
+                self.assertNotIn("--release", archive)
+
     def test_runpod_cuda_runtime_matches_cudarc_floor(self) -> None:
         text = read(".github/workflows/runpod-gpu-test.yml")
         cargo = read("Cargo.toml")


### PR DESCRIPTION
## Summary

- Add workspace `[profile.ci]` (`opt-level=0`, `debug=0`, `incremental=false`, `strip="symbols"`) for hosted cold builds while keeping local `dev`/`test` incremental.
- Point `scripts/ci/run_profile.py` and CUDA `nextest archive` jobs at `--cargo-profile ci` / `--profile ci` instead of `--release`.
- Bump CUDA archive/rust-cache keys and log `du`/`df` after workspace/coverage builds for #1402 acceptance evidence.

Work log: `docs/worklogs/2026-07-18-issue-1402-ci-thin-profile.md`

## Test plan

- [x] `bash scripts/check-pr-fast.sh --coverage-reviewed --test '… unittest test_run_profile test_workflow_contracts'`
- [x] `cargo test -p tenferro-tensor-core --profile ci --no-run`
- [ ] Hosted CI: confirm workspace/coverage wall-clock and peak disk (`du`/`df` logs); peak target ≲12 GiB with ≥2 GiB free
- [ ] Hosted CUDA archive cold build under 10 minutes (or document residual)
- [ ] Coverage thresholds still pass under `[profile.ci]`


Made with [Cursor](https://cursor.com)