### PR TITLE
refactor: unify structured tensor error contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+        with:
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,32 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+      - name: Test public Result error documentation audit
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+        run: python3 scripts/test-check-public-error-docs.py
+      - name: Audit public Result error documentation
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          python3 scripts/check-public-error-docs.py
+          if [ "${EVENT_NAME}" = pull_request ]; then
+            base_sha="${PR_BASE_SHA}"
+          else
+            base_sha="${PUSH_BASE_SHA}"
+          fi
+          python3 scripts/check-public-error-docs.py --changed-from "${base_sha}"
       - name: Run workspace clippy
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
-        run: cargo clippy --workspace --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
       - name: Run tropical extension clippy
         if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
-        run: cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings
+        run: cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+      - name: Run sparse extension clippy
+        if: needs.policy.result == 'success' && needs.policy.outputs.run_rust == 'true'
+        run: cargo clippy --manifest-path ext/sparse/Cargo.toml --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
       - name: Report clippy disposition
         if: always()
         env:

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -127,7 +127,8 @@ rules from `tensor4all-agent-rules`.
 - Public validation APIs must return crate error types, not `String` or `&str`
   errors. If a caller needs to translate into another layer's error type, it
   should do so explicitly while preserving the original typed validation error
-  in the message or source path.
+  in the `source()` chain; render it as text only at the final display,
+  logging, serialization, or message-only external-protocol boundary.
 - Validation helpers for operation configs should return typed prepared
   metadata when downstream code will otherwise repeat indexing, rank-minus-one,
   shape-product, or dimension-role calculations. Prefer passing a validated
@@ -503,16 +504,16 @@ Tests follow implementation ownership.
 - User code must explicitly upload CPU tensors before CUDA backend execution
   and explicitly download CUDA tensors before CPU-only execution or host value
   inspection.
-- A GPU backend op receiving a CPU tensor must return
-  `Error::BackendFailure` with a diagnostic that says the op expected a GPU
-  tensor and points users to `upload_tensor()`.
+- A GPU backend op receiving a CPU tensor must return a runtime-state error
+  with a diagnostic that says the op expected a GPU tensor and points users to
+  `upload_tensor()`.
 - A `Result`-returning CPU backend op receiving a backend/GPU buffer must
-  return `Error::BackendFailure` where the buffer is detected at the CPU
-  backend boundary. The diagnostic should say to download the tensor to host
-  before CPU execution.
+  return a runtime-state error where the buffer is detected at the CPU backend
+  boundary. The diagnostic should say to download the tensor to host before
+  CPU execution.
 - Direct host-inspection APIs such as `TypedTensor::host_data()` and
   `TypedTensor::host_data_mut()` return `Result` and must report backend
-  buffers as typed backend failures. Any infallible host-inspection API that
+  buffers as runtime-state failures. Any infallible host-inspection API that
   returns a borrowed slice instead of `Result` must document an explicit panic
   boundary before it is exposed.
 - Execution pipeline internals may handle placement for documented cases:
@@ -765,8 +766,34 @@ Tests follow implementation ownership.
   device transfer behavior. Any change to those conventions must update that
   document in the same PR.
 - CUDA `eig` (non-symmetric eigenvalue decomposition, LAPACK `dgeev`) is not
-  provided by cuSOLVER. `CudaBackend::eig` returns `BackendFailure`; users
+  provided by cuSOLVER. `CudaBackend::eig` returns `Unsupported`; users
   must explicitly download to CPU and compute via `CpuBackend::eig`.
+
+### Structured Error Classification
+
+- Validation facts use the shared typed vocabulary for shape, rank, axis, dtype,
+  configuration, and invalid arguments. Eager and traced paths must report the
+  same validation kind and payload for the same known input; `ErrorPhase` is a
+  separate graph-build, compile, or execution axis.
+- Unsupported operations and operation-specific unsupported dtypes use the
+  `Unsupported` category. A crate that owns a richer reason retains a typed
+  local source; `UnsupportedDTypeConversion` is reserved for an actual
+  from-dtype to to-dtype conversion.
+- Singularities, non-convergence, division by zero, and other numeric-domain
+  failures use `NumericalFailure` and retain the owning crate's typed source.
+- Typed backend/kernel errors use a source-preserving backend wrapper. The
+  text-only `BackendFailure` category is reserved for vendor/backend status
+  text when no typed source or more specific category exists.
+- Typed file, stream, serialization, and dynamic-library failures use `Io` and
+  retain their source. Missing, uninitialized, poisoned, or otherwise invalid
+  executor, cache, device, and buffer state uses `RuntimeState`, retaining a
+  typed source when one exists. Impossible internal invariants remain
+  `Internal`; these categories must not be used as catch-alls for known input
+  validation.
+- Public error conversion must preserve the `source()` chain across crate
+  boundaries. Converting a typed error to `String` is permitted only for
+  display/logging, vendor/FFI arguments, final serialization, or an explicit
+  message-only external protocol boundary.
 
 ## Documentation Policy
 
@@ -838,6 +865,23 @@ Tests follow implementation ownership.
 - Examples that call CPU or GPU backend operations should bind the backend to a
   local variable and reuse it for related operations instead of chaining
   `Backend::new().op(...)` beyond a single trivial construction example.
+
+### Public Result Error Documentation Gate
+
+- Every public function, inherent method, and public-trait method returning a
+  `Result` must document a `# Errors` section. The section must name the
+  concrete error variants or failure conditions the caller can observe; a
+  generic “returns an error on failure” sentence is insufficient.
+- Documentation for traced or symbolic APIs must describe validation deferred
+  to compile or execution and identify the applicable `ErrorPhase` when that
+  behavior is part of the contract. Intentional panics use `# Panics`; deferred
+  symbolic checks use `# Deferred errors`.
+- `scripts/check-public-error-docs.py` audits the full Rust workspace and the
+  Rust files changed by a PR and is a required CI gate. For traced APIs, prose
+  that promises validation at compile/execution or after input binding must
+  also be under `# Deferred errors`. Keep the audit enabled without `clippy`
+  or source-level allowlists; add the concrete documentation at the API source
+  instead.
 
 ## Generic Over Scalar Type
 

--- a/crates/tenferro-ad/src/ad_rule_error.rs
+++ b/crates/tenferro-ad/src/ad_rule_error.rs
@@ -1,5 +1,56 @@
 use tenferro_runtime::{Error, ErrorPhase};
+use tenferro_tensor::ErrorKind;
 use tidu::ADRuleError;
+
+/// State used while implementing tidu's message-only callback traits.
+///
+/// `tidu::ADRuleError` predates tenferro's structured error model and cannot
+/// carry a source. Keep the typed runtime error alongside the compatibility
+/// value while crossing that external dependency boundary; public tenferro
+/// APIs consume `typed` first and therefore never expose the rendered message
+/// as the primary error.
+#[derive(Default)]
+pub(crate) struct DeferredErrors {
+    ad_rule: Option<ADRuleError>,
+    typed: Option<Error>,
+}
+
+impl DeferredErrors {
+    pub(crate) fn take_ad_rule(&mut self) -> Option<ADRuleError> {
+        self.ad_rule.take()
+    }
+
+    pub(crate) fn take_typed(&mut self) -> Option<Error> {
+        self.typed.take()
+    }
+
+    pub(crate) fn record_ad_rule(&mut self, err: ADRuleError) {
+        if self.ad_rule.is_none() {
+            self.ad_rule = Some(err);
+        }
+    }
+
+    pub(crate) fn has_error(&self) -> bool {
+        self.ad_rule.is_some() || self.typed.is_some()
+    }
+
+    pub(crate) fn runtime(&mut self, transform: &'static str, err: Error) -> ADRuleError {
+        let fallback = runtime_error_to_ad_rule(transform, &err);
+        if self.typed.is_none() {
+            self.typed = Some(err);
+        }
+        self.record_ad_rule(fallback.clone());
+        fallback
+    }
+}
+
+/// Convert only at the external tidu callback boundary.
+fn runtime_error_to_ad_rule(transform: &'static str, err: &Error) -> ADRuleError {
+    match err.kind() {
+        ErrorKind::Unsupported => ADRuleError::unsupported(transform, tidu::ADRuleKind::Transpose),
+        _ => ADRuleError::invalid_input(transform, tidu::ADRuleKind::Transpose, err.to_string()),
+    }
+}
 
 pub(crate) fn ad_rule_error(transform: &'static str, err: ADRuleError) -> Error {
     match err {

--- a/crates/tenferro-ad/src/ad_rule_error.rs
+++ b/crates/tenferro-ad/src/ad_rule_error.rs
@@ -1,3 +1,4 @@
+use tenferro_ops::ShapeGuardContext;
 use tenferro_runtime::{Error, ErrorPhase};
 use tenferro_tensor::ErrorKind;
 use tidu::ADRuleError;
@@ -61,5 +62,70 @@ pub(crate) fn ad_rule_error(transform: &'static str, err: ADRuleError) -> Error 
             "ad_input",
             format!("{op}: {message}"),
         ),
+    }
+}
+
+pub(crate) fn ad_rule_error_with_context(
+    transform: &'static str,
+    err: ADRuleError,
+    ctx: &mut ShapeGuardContext,
+) -> Error {
+    match ctx.take_deferred_shape_error() {
+        Some(source) => Error::ad_rule_source(transform, source),
+        None => ad_rule_error(transform, err),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as StdError;
+
+    use computegraph::types::{ValueKey, ValueRef};
+    use tenferro_ops::input_key::TensorInputKey;
+    use tenferro_ops::std_tensor_op::StdTensorOp;
+    use tenferro_ops::{ShapeGuardContext, ShapeGuardError};
+    use tenferro_tensor::{ErrorKind, ValidationKind};
+
+    use super::ad_rule_error_with_context;
+    use crate::error::Error;
+
+    #[test]
+    fn shape_guard_source_survives_the_message_only_ad_boundary() {
+        let key = ValueKey::<StdTensorOp>::Input(TensorInputKey::User { id: 901 });
+        let value = ValueRef::External(key);
+        let mut ctx = ShapeGuardContext::default();
+        let callback_error: tidu::ADRuleError = ctx.shape_of(&value).unwrap_err().into();
+
+        let error = ad_rule_error_with_context("jvp", callback_error, &mut ctx);
+
+        assert_eq!(
+            error.kind(),
+            ErrorKind::Validation(ValidationKind::InvalidArgument)
+        );
+        assert_eq!(
+            error.phase(),
+            Some(tenferro_runtime::ErrorPhase::GraphBuild)
+        );
+        let source = StdError::source(&error).expect("typed AD source should be retained");
+        assert!(source
+            .downcast_ref::<ShapeGuardError>()
+            .is_some_and(|source| matches!(source, ShapeGuardError::MissingMetadata { .. })));
+        assert!(matches!(error, Error::AdRuleSource { .. }));
+    }
+
+    #[test]
+    fn unrelated_ad_rule_errors_keep_their_existing_mapping() {
+        let mut ctx = ShapeGuardContext::default();
+        let error = ad_rule_error_with_context(
+            "jvp",
+            tidu::ADRuleError::invalid_input(
+                "rule",
+                tidu::ADRuleKind::Jvp,
+                "invalid configuration",
+            ),
+            &mut ctx,
+        );
+
+        assert!(matches!(error, Error::Validation { .. }));
     }
 }

--- a/crates/tenferro-ad/src/ad_rule_error.rs
+++ b/crates/tenferro-ad/src/ad_rule_error.rs
@@ -1,12 +1,14 @@
-use tenferro_runtime::Error;
+use tenferro_runtime::{Error, ErrorPhase};
 use tidu::ADRuleError;
 
 pub(crate) fn ad_rule_error(transform: &'static str, err: ADRuleError) -> Error {
     match err {
         ADRuleError::Unsupported { op, .. } => Error::UnsupportedAdRule { transform, op },
-        ADRuleError::InvalidInput { op, message, .. } => Error::InvalidGraphBuild {
-            op: transform,
-            message: format!("{op}: {message}"),
-        },
+        ADRuleError::InvalidInput { op, message, .. } => Error::invalid_argument(
+            transform,
+            ErrorPhase::GraphBuild,
+            "ad_input",
+            format!("{op}: {message}"),
+        ),
     }
 }

--- a/crates/tenferro-ad/src/context.rs
+++ b/crates/tenferro-ad/src/context.rs
@@ -91,6 +91,11 @@ impl AdContext {
     /// let ad = AdContext::builder().build().unwrap();
     /// assert!(ad.ad_transform_cache_limits().unwrap().max_entries().get() > 0);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if the cache lock is
+    /// poisoned or its state cannot be inspected.
     pub fn ad_transform_cache_limits(&self) -> Result<AdTransformCacheLimits> {
         self.ad_transform_cache.limits()
     }
@@ -108,6 +113,11 @@ impl AdContext {
     /// ad.set_ad_transform_cache_limits(limits).unwrap();
     /// assert_eq!(ad.ad_transform_cache_limits().unwrap(), limits);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if the cache lock is
+    /// poisoned while updating the limits.
     pub fn set_ad_transform_cache_limits(&self, limits: AdTransformCacheLimits) -> Result<()> {
         self.ad_transform_cache.set_limits(limits)
     }
@@ -123,6 +133,11 @@ impl AdContext {
     /// ad.clear_ad_transform_caches().unwrap();
     /// assert_eq!(ad.ad_transform_cache_stats().unwrap().entries, 0);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if the cache lock is
+    /// poisoned while clearing entries.
     pub fn clear_ad_transform_caches(&self) -> Result<()> {
         self.ad_transform_cache.clear()
     }
@@ -137,6 +152,11 @@ impl AdContext {
     /// let ad = AdContext::builder().build().unwrap();
     /// assert_eq!(ad.ad_transform_cache_stats().unwrap().entries, 0);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if the cache lock is
+    /// poisoned while collecting statistics.
     pub fn ad_transform_cache_stats(&self) -> Result<CacheStats> {
         self.ad_transform_cache.stats()
     }
@@ -152,6 +172,11 @@ impl AdContext {
     /// ad.clear_caches().unwrap();
     /// assert_eq!(ad.cache_stats().unwrap().ad_transforms.entries, 0);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if either owned cache
+    /// cannot be locked because its state is poisoned.
     pub fn clear_caches(&self) -> Result<()> {
         self.clear_ad_transform_caches()
     }
@@ -166,6 +191,11 @@ impl AdContext {
     /// let ad = AdContext::builder().build().unwrap();
     /// assert_eq!(ad.cache_stats().unwrap().ad_transforms.retained_bytes, 0);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if an owned cache lock
+    /// is poisoned while collecting statistics.
     pub fn cache_stats(&self) -> Result<AdContextCacheStats> {
         Ok(AdContextCacheStats {
             ad_transforms: self.ad_transform_cache_stats()?,
@@ -191,6 +221,13 @@ impl AdContext {
     /// let grad = ad.grad(&loss, &x).unwrap();
     /// assert_eq!(grad.rank, 0);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::NonScalarGrad`] when `output` is not
+    /// scalar, [`tenferro_runtime::Error::UnsupportedAdRule`] when a graph op
+    /// lacks a registered rule, or a typed [`tenferro_runtime::Error::Validation`]
+    /// / backend error when graph metadata or execution is invalid.
     pub fn grad(&self, output: &TracedTensor, wrt: &TracedTensor) -> Result<TracedTensor> {
         crate::traced::grad_with_rules_and_cache(
             output,
@@ -213,6 +250,14 @@ impl AdContext {
     /// let loss = (&x * &x).unwrap();
     /// assert!(ad.grad_optional(&loss, &x).unwrap().is_some());
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::NonScalarGrad`] for a non-scalar
+    /// output, [`tenferro_runtime::Error::UnsupportedAdRule`] for an
+    /// unregistered AD rule, or a typed [`tenferro_runtime::Error::Validation`]
+    /// / backend error from graph construction and
+    /// execution.
     pub fn grad_optional(
         &self,
         output: &TracedTensor,
@@ -241,6 +286,13 @@ impl AdContext {
     /// let dy = ad.jvp(&y, &x, &dx).unwrap();
     /// assert_eq!(dy.rank, 0);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::UnsupportedAdRule`] when the graph
+    /// has no JVP rule, [`tenferro_runtime::Error::Validation`] for
+    /// inconsistent tangent metadata, or a typed backend/runtime-state error
+    /// during evaluation.
     pub fn jvp(
         &self,
         output: &TracedTensor,
@@ -270,6 +322,13 @@ impl AdContext {
     /// let y = (&x * &x).unwrap();
     /// assert!(ad.jvp_optional(&y, &x, &dx).unwrap().is_some());
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::UnsupportedAdRule`] when the graph
+    /// has no JVP rule, [`tenferro_runtime::Error::Validation`] for
+    /// inconsistent tangent metadata, or a typed backend/runtime-state error
+    /// during evaluation.
     pub fn jvp_optional(
         &self,
         output: &TracedTensor,
@@ -305,6 +364,13 @@ impl AdContext {
     /// let dx = ad.vjp(&y, &x, &dy).unwrap();
     /// assert_eq!(dx.rank, 0);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::Validation`] when the cotangent
+    /// metadata is incompatible, [`tenferro_runtime::Error::UnsupportedAdRule`]
+    /// when a VJP rule is unavailable, or a typed backend/runtime-state error
+    /// during execution.
     pub fn vjp(
         &self,
         output: &TracedTensor,
@@ -334,6 +400,13 @@ impl AdContext {
     /// let y = (&x * &x).unwrap();
     /// assert!(ad.vjp_optional(&y, &x, &dy).unwrap().is_some());
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::Validation`] when the cotangent
+    /// metadata is incompatible, [`tenferro_runtime::Error::UnsupportedAdRule`]
+    /// when a VJP rule is unavailable, or a typed backend/runtime-state error
+    /// during execution.
     pub fn vjp_optional(
         &self,
         output: &TracedTensor,
@@ -408,6 +481,12 @@ impl AdContextBuilder {
     /// let ad = AdContext::builder().build().unwrap();
     /// assert!(ad.extension_rules().lookup_linearize("example.missing.v1").is_none());
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionRegistryError::MalformedFamilyId`] for an invalid
+    /// family identifier or [`ExtensionRegistryError::DuplicateRule`] when
+    /// two supplied rule sets register the same role and family.
     pub fn build(self) -> std::result::Result<AdContext, ExtensionRegistryError> {
         let mut extension_rules = ExtensionRuleSet::new();
         for rules in self.extension_rule_sets {

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -23,6 +23,7 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ExtensionRuleSet;
 use tenferro_ops::ShapeGuardContext;
 use tenferro_runtime::ad_support::ones_tensor;
+use tenferro_runtime::ErrorPhase;
 use tenferro_tensor::BackendSessionHost;
 use tenferro_tensor::{
     CacheStats, DType, Tensor, TensorBackend, TensorElementwise, TensorRead, TensorValue,
@@ -317,39 +318,55 @@ impl fmt::Debug for EagerRuntime {
 
 impl EagerRuntime {
     fn lock_backend(&self) -> Result<MutexGuard<'_, EagerBackend>> {
-        self.backend
-            .lock()
-            .map_err(|_| Error::Internal("backend lock poisoned".to_string()))
+        self.backend.lock().map_err(|_| {
+            Error::runtime_state("eager_backend", ErrorPhase::Execution, "lock poisoned")
+        })
     }
 
     fn lock_extension_executor(&self) -> Result<MutexGuard<'_, ExtensionExecutor<EagerBackend>>> {
-        self.extension_executor
-            .lock()
-            .map_err(|_| Error::Internal("extension executor lock poisoned".to_string()))
+        self.extension_executor.lock().map_err(|_| {
+            Error::runtime_state(
+                "eager_extension_executor",
+                ErrorPhase::Execution,
+                "lock poisoned",
+            )
+        })
     }
 
     fn lock_grad_slots(
         &self,
     ) -> Result<MutexGuard<'_, HashMap<ValueKey<StdTensorOp>, WeakGradSlot>>> {
-        self.grad_slots
-            .lock()
-            .map_err(|_| Error::Internal("gradient slot registry lock poisoned".to_string()))
+        self.grad_slots.lock().map_err(|_| {
+            Error::runtime_state(
+                "eager_gradient_slots",
+                ErrorPhase::Execution,
+                "lock poisoned",
+            )
+        })
     }
 
     fn lock_value_records(
         &self,
     ) -> Result<MutexGuard<'_, HashMap<ValueKey<StdTensorOp>, Weak<EagerTensorRecord>>>> {
-        self.value_records
-            .lock()
-            .map_err(|_| Error::Internal("eager value registry lock poisoned".to_string()))
+        self.value_records.lock().map_err(|_| {
+            Error::runtime_state(
+                "eager_value_registry",
+                ErrorPhase::Execution,
+                "lock poisoned",
+            )
+        })
     }
 
     fn lock_value_ptr_records(
         &self,
     ) -> Result<MutexGuard<'_, HashMap<usize, Weak<EagerTensorRecord>>>> {
-        self.value_ptr_records
-            .lock()
-            .map_err(|_| Error::Internal("eager value pointer registry lock poisoned".to_string()))
+        self.value_ptr_records.lock().map_err(|_| {
+            Error::runtime_state(
+                "eager_value_pointer_registry",
+                ErrorPhase::Execution,
+                "lock poisoned",
+            )
+        })
     }
 
     fn from_backend(backend: EagerBackend) -> Self {
@@ -551,6 +568,13 @@ impl EagerRuntime {
     }
 
     /// Register one extension runtime on this eager context.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionRuntimeRegistryError::PoisonedLock`] when the
+    /// extension executor is unavailable, or propagates the callback's
+    /// [`ExtensionRuntimeRegistryError::MalformedFamilyId`] and
+    /// [`ExtensionRuntimeRegistryError::MissingHostReference`] failures.
     pub fn register_extension(
         &self,
         register: impl FnOnce(
@@ -578,6 +602,11 @@ impl EagerRuntime {
     /// assert_eq!(ctx.cache_stats()?.extensions.entries, 0);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] when the extension
+    /// executor lock is poisoned.
     pub fn clear_extension_caches(&self) -> Result<()> {
         self.lock_extension_executor()?.clear_caches();
         Ok(())
@@ -597,6 +626,11 @@ impl EagerRuntime {
     /// assert_eq!(ctx.cache_stats()?.ad_transforms.entries, 0);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] when either the
+    /// extension executor or AD-transform cache is poisoned.
     pub fn clear_caches(&self) -> Result<()> {
         self.clear_extension_caches()?;
         self.clear_ad_transform_caches()?;
@@ -617,6 +651,11 @@ impl EagerRuntime {
     /// assert_eq!(stats.ad_transforms.entries, 0);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] when an executor or
+    /// AD-transform cache lock is poisoned.
     pub fn cache_stats(&self) -> Result<EagerRuntimeCacheStats> {
         Ok(EagerRuntimeCacheStats {
             extensions: self.lock_extension_executor()?.cache_stats(),
@@ -636,6 +675,11 @@ impl EagerRuntime {
     /// assert!(ctx.ad_transform_cache_limits()?.max_entries().get() > 0);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if the AD-transform
+    /// cache lock is poisoned.
     pub fn ad_transform_cache_limits(&self) -> Result<AdTransformCacheLimits> {
         self.ad_transform_cache.limits()
     }
@@ -655,6 +699,11 @@ impl EagerRuntime {
     /// assert_eq!(ctx.ad_transform_cache_limits()?, limits);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if the AD-transform
+    /// cache lock is poisoned while updating limits.
     pub fn set_ad_transform_cache_limits(&self, limits: AdTransformCacheLimits) -> Result<()> {
         self.ad_transform_cache.set_limits(limits)
     }
@@ -672,16 +721,31 @@ impl EagerRuntime {
     /// assert_eq!(ctx.cache_stats()?.ad_transforms.entries, 0);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if the AD-transform
+    /// cache lock is poisoned while clearing entries.
     pub fn clear_ad_transform_caches(&self) -> Result<()> {
         self.ad_transform_cache.clear()
     }
 
     /// Return the extension cache retention limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if the extension
+    /// executor lock is poisoned.
     pub fn extension_cache_limits(&self) -> Result<ExtensionCacheLimits> {
         Ok(self.lock_extension_executor()?.cache_limits())
     }
 
     /// Replace extension cache retention limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if the extension
+    /// executor lock is poisoned.
     pub fn set_extension_cache_limits(&self, limits: ExtensionCacheLimits) -> Result<()> {
         self.lock_extension_executor()?.set_cache_limits(limits);
         Ok(())
@@ -709,6 +773,11 @@ impl EagerRuntime {
     ///
     /// assert_eq!(ctx.cache_stats().unwrap().extensions.entries, 1);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if the extension
+    /// executor lock is poisoned before the closure can run.
     pub fn with_extension_caches_mut<R>(
         &self,
         f: impl FnOnce(&mut ExtensionCacheStore) -> R,
@@ -735,6 +804,11 @@ impl EagerRuntime {
     /// let answer = ctx.with_backend_mut(|_backend| 42).unwrap();
     /// assert_eq!(answer, 42);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if the eager backend
+    /// lock is poisoned before the closure can run.
     pub fn with_backend_mut<R>(&self, f: impl FnOnce(&mut EagerBackend) -> R) -> Result<R> {
         let mut backend = self.lock_backend()?;
         Ok(f(&mut backend))
@@ -765,6 +839,11 @@ impl EagerRuntime {
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// ctx.synchronize().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if the backend lock is
+    /// poisoned, or a typed tensor backend error if synchronization fails.
     pub fn synchronize(&self) -> Result<()> {
         self.lock_backend()?.synchronize().map_err(Error::from)
     }
@@ -1023,6 +1102,11 @@ impl EagerRuntime {
     /// assert!(y.grad()?.is_none());
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] if a gradient-slot
+    /// lock is poisoned while clearing live gradients.
     pub fn clear_grads(&self) -> Result<()> {
         let live_slots = {
             let mut live_slots = Vec::new();
@@ -1049,7 +1133,11 @@ impl EagerRuntime {
             }
         }
         if poisoned_slot {
-            return Err(Error::Internal("gradient slot lock poisoned".to_string()));
+            return Err(Error::runtime_state(
+                "eager_gradient_slot",
+                ErrorPhase::Execution,
+                "lock poisoned",
+            ));
         }
         Ok(())
     }
@@ -1074,6 +1162,11 @@ impl EagerRuntime {
     /// assert_eq!(z.materialized()?.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] when metadata cannot
+    /// be registered or the backend lock is poisoned.
     pub fn constant_from(self: &Arc<Self>, tensor: Tensor) -> Result<EagerTensor> {
         EagerTensor::new_leaf(Arc::clone(self), tensor, false)
     }
@@ -1098,6 +1191,11 @@ impl EagerRuntime {
     /// assert_eq!(grad.shape(), &[2]);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] when gradient metadata
+    /// or the eager backend state cannot be registered.
     pub fn variable_from(self: &Arc<Self>, tensor: Tensor) -> Result<EagerTensor> {
         EagerTensor::new_leaf(Arc::clone(self), tensor, true)
     }
@@ -1124,6 +1222,13 @@ impl EagerRuntime {
     /// assert_eq!(dx.materialized()?.as_slice::<f64>().unwrap(), &[6.0]);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::NonScalarGrad`] for a non-scalar
+    /// output, [`Error::ContextMismatch`] for tensors from another runtime,
+    /// [`Error::UnsupportedAdRule`] when an AD rule is unavailable, or a typed
+    /// validation/backend error from eager execution.
     pub fn grad(self: &Arc<Self>, output: &EagerTensor, wrt: &EagerTensor) -> Result<EagerTensor> {
         self.grad_optional(output, wrt)?
             .ok_or_else(|| Error::Internal(format!("grad output is inactive for {:?}", wrt.key)))
@@ -1150,6 +1255,12 @@ impl EagerRuntime {
     /// assert!(ctx.grad_optional(&loss, &x)?.is_none());
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::NonScalarGrad`] for a non-scalar
+    /// output, [`Error::ContextMismatch`] for a foreign runtime, or a typed
+    /// validation/backend/runtime-state error from eager execution.
     pub fn grad_optional(
         self: &Arc<Self>,
         output: &EagerTensor,
@@ -1199,6 +1310,13 @@ impl EagerRuntime {
     /// assert_eq!(dx.materialized()?.as_slice::<f64>().unwrap(), &[4.0, 6.0]);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ContextMismatch`] for tensors from different eager
+    /// runtimes, [`Error::Validation`] when the cotangent shape or dtype does
+    /// not match the output, [`Error::UnsupportedAdRule`] when a rule is not
+    /// registered, or a typed backend/runtime-state error.
     pub fn vjp(
         self: &Arc<Self>,
         output: &EagerTensor,
@@ -1234,6 +1352,13 @@ impl EagerRuntime {
     /// assert!(ctx.vjp_optional(&loss, &x, &seed)?.is_none());
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ContextMismatch`] for tensors from different eager
+    /// runtimes, [`Error::Validation`] when the cotangent shape or dtype does
+    /// not match the output, [`Error::UnsupportedAdRule`] when a rule is not
+    /// registered, or a typed backend/runtime-state error.
     pub fn vjp_optional(
         self: &Arc<Self>,
         output: &EagerTensor,
@@ -1269,6 +1394,13 @@ impl EagerRuntime {
     /// assert_eq!(dy.materialized()?.as_slice::<f64>().unwrap(), &[6.0]);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ContextMismatch`] for tensors from different eager
+    /// runtimes, [`Error::Validation`] when the tangent shape or dtype does not
+    /// match `wrt`, [`Error::UnsupportedAdRule`] when a rule is unavailable, or
+    /// a typed backend/runtime-state error.
     pub fn jvp(
         self: &Arc<Self>,
         output: &EagerTensor,
@@ -1304,6 +1436,13 @@ impl EagerRuntime {
     /// assert!(ctx.jvp_optional(&loss, &x, &tangent)?.is_none());
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ContextMismatch`] for tensors from different eager
+    /// runtimes, [`Error::Validation`] when the tangent shape or dtype does not
+    /// match `wrt`, [`Error::UnsupportedAdRule`] when a rule is unavailable, or
+    /// a typed backend/runtime-state error.
     pub fn jvp_optional(
         self: &Arc<Self>,
         output: &EagerTensor,
@@ -1340,9 +1479,13 @@ impl EagerRuntime {
         }
 
         for (slot, incoming) in updates {
-            let mut current = slot
-                .lock()
-                .map_err(|_| Error::Internal("gradient slot lock poisoned".to_string()))?;
+            let mut current = slot.lock().map_err(|_| {
+                Error::runtime_state(
+                    "eager_gradient_slot",
+                    ErrorPhase::Execution,
+                    "lock poisoned",
+                )
+            })?;
             let next = match current.as_ref() {
                 Some(existing) => Arc::new(backend.add(existing.as_ref(), incoming.as_ref())?),
                 None => incoming,
@@ -1464,6 +1607,12 @@ impl EagerTensor {
     /// assert_eq!(x.materialized()?.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] when metadata cannot
+    /// be registered in the target context, or a typed tensor/backend error
+    /// while materializing the source value.
     pub fn from_tensor_in(tensor: Tensor, ctx: Arc<EagerRuntime>) -> Result<Self> {
         Self::new_leaf(ctx, tensor, false)
     }
@@ -1482,6 +1631,12 @@ impl EagerTensor {
     /// assert!(x.grad().unwrap().is_none());
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::RuntimeState`] when gradient metadata
+    /// cannot be registered in the target context, or a typed tensor/backend
+    /// error while creating the leaf.
     pub fn requires_grad_in(tensor: Tensor, ctx: Arc<EagerRuntime>) -> Result<Self> {
         Self::new_leaf(ctx, tensor, true)
     }
@@ -1494,7 +1649,9 @@ impl EagerTensor {
         let key = eager_val_key();
         let metadata_scope =
             register_scoped_value_metadata(key.clone(), tensor_meta_from_tensor(&tensor)).map_err(
-                |err| Error::Internal(format!("eager leaf metadata registration failed: {err}")),
+                |err| {
+                    Error::runtime_state_source("eager leaf metadata", ErrorPhase::GraphBuild, err)
+                },
             )?;
         Self::from_parts(
             ctx,
@@ -1691,6 +1848,11 @@ impl EagerTensor {
     /// assert_eq!(d.ctx_id(), ctx_b.id());
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeState`] if the source cannot be materialized or
+    /// the target context cannot register its metadata.
     pub fn detach_into(&self, ctx: &Arc<EagerRuntime>) -> Result<Self> {
         Self::from_tensor_in(self.to_tensor()?, Arc::clone(ctx))
     }
@@ -1708,6 +1870,11 @@ impl EagerTensor {
     /// assert_eq!(x.materialized()?.as_slice::<f64>().unwrap(), &[3.0]);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeState`] when lazy/backend-resident storage cannot
+    /// be materialized, or when eager value-record state is poisoned.
     pub fn materialized(&self) -> Result<Arc<Tensor>> {
         self.materialized_arc()
     }
@@ -1738,6 +1905,11 @@ impl EagerTensor {
     /// This is the owned materialization boundary for callers that need a
     /// standalone compact tensor. The operation is fallible because eager
     /// values may be backed by lazy or backend-resident storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeState`] if backend state is unavailable, or a
+    /// typed tensor backend error when contiguous materialization fails.
     pub fn to_tensor(&self) -> Result<Tensor> {
         self.ctx.materialize_value(self.value.as_ref())
     }
@@ -1791,10 +1963,21 @@ impl EagerTensor {
     /// assert_eq!(grad.shape(), &[2]);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeState`] if the gradient slot is poisoned or no
+    /// longer available.
     pub fn grad(&self) -> Result<Option<Arc<Tensor>>> {
         self.grad_slot
             .lock()
-            .map_err(|_| Error::Internal("gradient slot lock poisoned".to_string()))
+            .map_err(|_| {
+                Error::runtime_state(
+                    "eager_gradient_slot",
+                    ErrorPhase::Execution,
+                    "lock poisoned",
+                )
+            })
             .map(|slot| slot.clone())
     }
 
@@ -1822,11 +2005,18 @@ impl EagerTensor {
     /// assert!(y.grad()?.is_some());
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeState`] if the gradient slot lock is poisoned.
     pub fn clear_grad(&self) -> Result<()> {
-        *self
-            .grad_slot
-            .lock()
-            .map_err(|_| Error::Internal("gradient slot lock poisoned".to_string()))? = None;
+        *self.grad_slot.lock().map_err(|_| {
+            Error::runtime_state(
+                "eager_gradient_slot",
+                ErrorPhase::Execution,
+                "lock poisoned",
+            )
+        })? = None;
         Ok(())
     }
 
@@ -2024,6 +2214,12 @@ impl EagerTensor {
     ///
     /// assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[4.0, 4.0, 4.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NonScalarGrad`] when this output is not scalar,
+    /// [`Error::UnsupportedAdRule`] when a graph operation lacks a reverse rule,
+    /// or a typed validation/backend/runtime-state error during the reverse pass.
     pub fn backward(&self) -> Result<HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>> {
         if !self.shape().is_empty() {
             return Err(Error::NonScalarGrad {
@@ -2066,6 +2262,13 @@ impl EagerTensor {
     /// assert_eq!(x.grad()?.unwrap().as_slice::<f64>().unwrap(), &[4.0, 12.0]);
     /// # Ok::<(), tenferro_ad::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ContextMismatch`] when `cotangent` belongs to another
+    /// eager runtime, [`Error::Validation`] when its shape or dtype is not a
+    /// valid seed, [`Error::UnsupportedAdRule`] for an unavailable reverse
+    /// rule, or a typed backend/runtime-state error during execution.
     pub fn backward_with(
         &self,
         cotangent: &EagerTensor,
@@ -2103,8 +2306,12 @@ impl EagerTensor {
             &mut callbacks,
             &mut ad_ctx,
         );
+        let callback_typed_error = callbacks.take_typed_error();
         let callback_error = callbacks.take_error();
         drop(callbacks);
+        if let Some(err) = callback_typed_error {
+            return Err(err);
+        }
         let cotangents = match (cotangents_result, callback_error) {
             (_, Some(err)) => return Err(crate::ad_rule_error::ad_rule_error("backward", err)),
             (Err(err), None) => return Err(crate::ad_rule_error::ad_rule_error("backward", err)),
@@ -2194,7 +2401,7 @@ pub(crate) fn record_eager_recorded_graph_outputs(
 }
 
 fn eager_record_error(err: tidu::eager::EagerRecordError) -> Error {
-    Error::Internal(format!("invalid eager recording metadata: {err}"))
+    Error::runtime_state_source("eager recording", ErrorPhase::GraphBuild, err)
 }
 
 fn eager_ad_transform_cache_error(message: impl ToString) -> ADRuleError {

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -1375,23 +1375,14 @@ pub(crate) fn tensor_ptr(tensor: &Arc<Tensor>) -> usize {
 
 fn validate_seed_tensor(op: &'static str, primal: &EagerTensor, seed: &EagerTensor) -> Result<()> {
     if primal.dtype() != seed.dtype() {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op,
-            message: format!(
-                "{op} cotangent dtype must match primal dtype: {:?} vs {:?}",
-                seed.dtype(),
-                primal.dtype()
-            ),
-        }
-        .into());
+        return Err(
+            tenferro_tensor::Error::dtype_mismatch(op, primal.dtype(), seed.dtype()).into(),
+        );
     }
     if primal.shape() != seed.shape() {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
-            op,
-            lhs: primal.shape().to_vec(),
-            rhs: seed.shape().to_vec(),
-        }
-        .into());
+        return Err(
+            tenferro_tensor::Error::shape_mismatch(op, primal.shape(), seed.shape()).into(),
+        );
     }
     Ok(())
 }

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -2313,8 +2313,20 @@ impl EagerTensor {
             return Err(err);
         }
         let cotangents = match (cotangents_result, callback_error) {
-            (_, Some(err)) => return Err(crate::ad_rule_error::ad_rule_error("backward", err)),
-            (Err(err), None) => return Err(crate::ad_rule_error::ad_rule_error("backward", err)),
+            (_, Some(err)) => {
+                return Err(crate::ad_rule_error::ad_rule_error_with_context(
+                    "backward",
+                    err,
+                    &mut ad_ctx,
+                ));
+            }
+            (Err(err), None) => {
+                return Err(crate::ad_rule_error::ad_rule_error_with_context(
+                    "backward",
+                    err,
+                    &mut ad_ctx,
+                ));
+            }
             (Ok(cotangents), None) => cotangents,
         };
         self.ctx.store_grads(&cotangents, &mut backend)?;

--- a/crates/tenferro-ad/src/eager/backward.rs
+++ b/crates/tenferro-ad/src/eager/backward.rs
@@ -6,10 +6,12 @@ use computegraph::{LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeGuardContext, TensorMeta};
+use tenferro_runtime::{Error, ErrorPhase};
 use tenferro_tensor::{DType, Tensor, TensorBackend, TypedTensor};
 use tidu::eager::{BackwardExecutor, RecordedGraph};
-use tidu::{ADRuleError, ADRuleKind, ADRuleResult, LinearizedGraph, PrimitiveGraph};
+use tidu::{ADRuleError, ADRuleResult, LinearizedGraph, PrimitiveGraph};
 
+use crate::ad_rule_error::DeferredErrors;
 use crate::eager_builder::EagerPrimitiveBuilder;
 use crate::eager_exec::{exec_op_on_tensors, exec_op_on_tensors_with_extension_executor};
 use crate::extension_runtime::ExtensionExecutor;
@@ -20,12 +22,48 @@ use crate::metadata::{
 
 use super::{zero_like_tensor, EagerRuntime};
 
+#[derive(Debug)]
+pub(super) enum EagerAdFailure {
+    Rule(ADRuleError),
+    Runtime(Error),
+}
+
+impl std::fmt::Display for EagerAdFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rule(error) => error.fmt(formatter),
+            Self::Runtime(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for EagerAdFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Rule(error) => Some(error),
+            Self::Runtime(error) => Some(error),
+        }
+    }
+}
+
+impl From<ADRuleError> for EagerAdFailure {
+    fn from(error: ADRuleError) -> Self {
+        Self::Rule(error)
+    }
+}
+
+impl From<Error> for EagerAdFailure {
+    fn from(error: Error) -> Self {
+        Self::Runtime(error)
+    }
+}
+
 pub(crate) struct TenferroBackwardCallbacks<'a, B: TensorBackend + 'static> {
     backend: &'a mut B,
     extension_executor: Option<&'a mut ExtensionExecutor<B>>,
     runtime: Option<&'a EagerRuntime>,
     metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
-    deferred_error: Option<ADRuleError>,
+    errors: DeferredErrors,
 }
 
 impl<'a, B: TensorBackend + 'static> TenferroBackwardCallbacks<'a, B> {
@@ -49,17 +87,33 @@ impl<'a, B: TensorBackend + 'static> TenferroBackwardCallbacks<'a, B> {
             extension_executor,
             runtime,
             metadata_scopes,
-            deferred_error: None,
+            errors: DeferredErrors::default(),
         }
     }
 
     pub(crate) fn take_error(&mut self) -> Option<ADRuleError> {
-        self.deferred_error.take()
+        self.errors.take_ad_rule()
+    }
+
+    pub(crate) fn take_typed_error(&mut self) -> Option<Error> {
+        self.errors.take_typed()
     }
 
     fn record_error(&mut self, err: ADRuleError) {
-        if self.deferred_error.is_none() {
-            self.deferred_error = Some(err);
+        self.errors.record_ad_rule(err);
+    }
+
+    fn runtime_error(&mut self, err: Error) -> ADRuleError {
+        self.errors.runtime("tenferro-ad.eager", err)
+    }
+
+    fn record_failure(&mut self, failure: EagerAdFailure) -> ADRuleError {
+        match failure {
+            EagerAdFailure::Rule(err) => {
+                self.record_error(err.clone());
+                err
+            }
+            EagerAdFailure::Runtime(err) => self.runtime_error(err),
         }
     }
 
@@ -68,7 +122,7 @@ impl<'a, B: TensorBackend + 'static> TenferroBackwardCallbacks<'a, B> {
         graph: &Graph<StdTensorOp>,
         initial_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     ) -> HashMap<ValueKey<StdTensorOp>, Arc<Tensor>> {
-        if self.deferred_error.is_some() {
+        if self.errors.has_error() {
             return initial_data.clone();
         }
         let mut all_values = initial_data.clone();
@@ -79,7 +133,8 @@ impl<'a, B: TensorBackend + 'static> TenferroBackwardCallbacks<'a, B> {
             match eager_forward_input_metadata(&key, initial_data) {
                 Ok(meta) => input_metadata.push((key, meta)),
                 Err(err) => {
-                    self.record_error(err);
+                    let ad_error = self.record_failure(err);
+                    self.record_error(ad_error);
                     return all_values;
                 }
             }
@@ -111,7 +166,8 @@ impl<'a, B: TensorBackend + 'static> TenferroBackwardCallbacks<'a, B> {
                 match resolved {
                     Ok(value) => resolved_values.push(value),
                     Err(err) => {
-                        self.record_error(err);
+                        let ad_error = self.record_failure(err);
+                        self.record_error(ad_error);
                         return all_values;
                     }
                 }
@@ -132,10 +188,8 @@ impl<'a, B: TensorBackend + 'static> TenferroBackwardCallbacks<'a, B> {
             let outputs = match outputs_result {
                 Ok(outputs) => outputs,
                 Err(err) => {
-                    self.record_error(eager_ad_invalid_input(format!(
-                        "eager forward exec failed for {:?}: {err}",
-                        op_node.operation
-                    )));
+                    let ad_error = self.runtime_error(err);
+                    self.record_error(ad_error);
                     return all_values;
                 }
             };
@@ -150,9 +204,8 @@ impl<'a, B: TensorBackend + 'static> TenferroBackwardCallbacks<'a, B> {
             match register_scoped_live_graph_metadata(graph, &live_values, input_metadata) {
                 Ok(scope) => scope,
                 Err(err) => {
-                    self.record_error(eager_ad_invalid_input(format!(
-                        "eager replay metadata registration failed: {err}"
-                    )));
+                    let ad_error = self.runtime_error(err);
+                    self.record_error(ad_error);
                     return all_values;
                 }
             };
@@ -177,16 +230,24 @@ pub(super) fn missing_tangent_base_key(
 pub(super) fn eager_forward_input_metadata(
     key: &ValueKey<StdTensorOp>,
     initial_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
-) -> ADRuleResult<TensorMeta> {
+) -> Result<TensorMeta, EagerAdFailure> {
     if let Some(value) = initial_data.get(key) {
         return Ok(tensor_meta_from_tensor(value.as_ref()));
     }
 
     let base_key = missing_tangent_base_key(key).ok_or_else(|| {
-        eager_ad_invalid_input(format!("missing concrete eager value for {key:?}"))
+        EagerAdFailure::Runtime(Error::runtime_state(
+            "eager AD forward metadata",
+            ErrorPhase::Execution,
+            format!("missing concrete eager value for {key:?}"),
+        ))
     })?;
     let base = initial_data.get(&base_key).ok_or_else(|| {
-        eager_ad_invalid_input(format!("missing base eager value for {base_key:?}"))
+        EagerAdFailure::Runtime(Error::runtime_state(
+            "eager AD forward metadata",
+            ErrorPhase::Execution,
+            format!("missing base eager value for {base_key:?}"),
+        ))
     })?;
     Ok(tensor_meta_from_tensor(base.as_ref()))
 }
@@ -196,20 +257,27 @@ pub(super) fn eager_forward_value<B: TensorBackend>(
     key: &ValueKey<StdTensorOp>,
     initial_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     backend: &mut B,
-) -> ADRuleResult<Arc<Tensor>> {
+) -> Result<Arc<Tensor>, EagerAdFailure> {
     if let Some(value) = all_values.get(key) {
         return Ok(Arc::clone(value));
     }
 
     let base_key = missing_tangent_base_key(key).ok_or_else(|| {
-        eager_ad_invalid_input(format!("missing concrete eager value for {key:?}"))
+        EagerAdFailure::Runtime(Error::runtime_state(
+            "eager AD forward value",
+            ErrorPhase::Execution,
+            format!("missing concrete eager value for {key:?}"),
+        ))
     })?;
     let base = initial_data.get(&base_key).ok_or_else(|| {
-        eager_ad_invalid_input(format!("missing base eager value for {base_key:?}"))
+        EagerAdFailure::Runtime(Error::runtime_state(
+            "eager AD forward value",
+            ErrorPhase::Execution,
+            format!("missing base eager value for {base_key:?}"),
+        ))
     })?;
-    let value = Arc::new(zero_like_tensor(base.as_ref(), backend).map_err(|err| {
-        eager_ad_invalid_input(format!("failed to create eager tangent zero: {err}"))
-    })?);
+    let value =
+        Arc::new(zero_like_tensor(base.as_ref(), backend).map_err(EagerAdFailure::Runtime)?);
     all_values.insert(key.clone(), Arc::clone(&value));
     Ok(value)
 }
@@ -248,7 +316,7 @@ fn linear_op_depends_on_tangents(mode: &OperationRole) -> bool {
 pub(super) fn zero_from_exact_metadata<B: TensorBackend>(
     meta: &TensorMeta,
     backend: &mut B,
-) -> ADRuleResult<Option<Tensor>> {
+) -> Result<Option<Tensor>, EagerAdFailure> {
     let Some(shape) = meta.exact_shape() else {
         return Ok(None);
     };
@@ -259,37 +327,41 @@ pub(super) fn zero_from_exact_metadata<B: TensorBackend>(
     let Some(shape) = shape else {
         return Ok(None);
     };
-    let host =
-        match meta.dtype {
-            DType::F32 => Tensor::F32(TypedTensor::zeros(shape).map_err(|err| {
-                eager_ad_invalid_input(format!("failed to create F32 zero: {err}"))
-            })?),
-            DType::F64 => Tensor::F64(TypedTensor::zeros(shape).map_err(|err| {
-                eager_ad_invalid_input(format!("failed to create F64 zero: {err}"))
-            })?),
-            DType::I32 => Tensor::I32(TypedTensor::zeros(shape).map_err(|err| {
-                eager_ad_invalid_input(format!("failed to create I32 zero: {err}"))
-            })?),
-            DType::I64 => Tensor::I64(TypedTensor::zeros(shape).map_err(|err| {
-                eager_ad_invalid_input(format!("failed to create I64 zero: {err}"))
-            })?),
-            DType::Bool => {
-                let len = checked_zero_element_count(&shape)?;
-                Tensor::Bool(
-                    TypedTensor::from_vec_col_major(shape, vec![false; len]).map_err(|err| {
-                        eager_ad_invalid_input(format!("failed to create bool zero: {err}"))
-                    })?,
-                )
-            }
-            DType::C32 => Tensor::C32(TypedTensor::zeros(shape).map_err(|err| {
-                eager_ad_invalid_input(format!("failed to create C32 zero: {err}"))
-            })?),
-            DType::C64 => Tensor::C64(TypedTensor::zeros(shape).map_err(|err| {
-                eager_ad_invalid_input(format!("failed to create C64 zero: {err}"))
-            })?),
-        };
+    let host = match meta.dtype {
+        DType::F32 => Tensor::F32(
+            TypedTensor::zeros(shape)
+                .map_err(|err| EagerAdFailure::Runtime(Error::TensorRuntime(err)))?,
+        ),
+        DType::F64 => Tensor::F64(
+            TypedTensor::zeros(shape)
+                .map_err(|err| EagerAdFailure::Runtime(Error::TensorRuntime(err)))?,
+        ),
+        DType::I32 => Tensor::I32(
+            TypedTensor::zeros(shape)
+                .map_err(|err| EagerAdFailure::Runtime(Error::TensorRuntime(err)))?,
+        ),
+        DType::I64 => Tensor::I64(
+            TypedTensor::zeros(shape)
+                .map_err(|err| EagerAdFailure::Runtime(Error::TensorRuntime(err)))?,
+        ),
+        DType::Bool => {
+            let len = checked_zero_element_count(&shape)?;
+            Tensor::Bool(
+                TypedTensor::from_vec_col_major(shape, vec![false; len])
+                    .map_err(|err| EagerAdFailure::Runtime(Error::TensorRuntime(err)))?,
+            )
+        }
+        DType::C32 => Tensor::C32(
+            TypedTensor::zeros(shape)
+                .map_err(|err| EagerAdFailure::Runtime(Error::TensorRuntime(err)))?,
+        ),
+        DType::C64 => Tensor::C64(
+            TypedTensor::zeros(shape)
+                .map_err(|err| EagerAdFailure::Runtime(Error::TensorRuntime(err)))?,
+        ),
+    };
     Ok(Some(backend.upload_host_tensor(&host).map_err(|err| {
-        eager_ad_invalid_input(format!("failed to upload eager zero tensor: {err}"))
+        EagerAdFailure::Runtime(Error::TensorRuntime(err))
     })?))
 }
 
@@ -298,7 +370,7 @@ pub(super) fn prefill_missing_linear_zero_values<B: TensorBackend>(
     external_data: &mut HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     ctx: &mut ShapeGuardContext,
     backend: &mut B,
-) -> ADRuleResult<()> {
+) -> Result<(), EagerAdFailure> {
     for value in linear.as_graph().values() {
         if external_data.contains_key(&value.key) {
             continue;
@@ -322,7 +394,7 @@ pub(super) fn prefill_linear_residual_values<B: TensorBackend + 'static>(
     external_data: &mut HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     backend: &mut B,
     mut extension_executor: Option<&mut ExtensionExecutor<B>>,
-) -> ADRuleResult<()> {
+) -> Result<(), EagerAdFailure> {
     let mut visited = HashSet::new();
     prefill_residual_graph_values(
         linear.residual_graph(),
@@ -339,7 +411,7 @@ fn prefill_residual_graph_values<B: TensorBackend + 'static>(
     backend: &mut B,
     extension_executor: &mut Option<&mut ExtensionExecutor<B>>,
     visited: &mut HashSet<*const Graph<StdTensorOp>>,
-) -> ADRuleResult<()> {
+) -> Result<(), EagerAdFailure> {
     let graph_ptr: *const Graph<StdTensorOp> = graph;
     if !visited.insert(graph_ptr) {
         return Ok(());
@@ -378,12 +450,7 @@ fn prefill_residual_graph_values<B: TensorBackend + 'static>(
             ),
             None => exec_op_on_tensors(&op_node.operation, &resolved_inputs, backend),
         }
-        .map_err(|err| {
-            eager_ad_invalid_input(format!(
-                "eager residual exec failed for {:?}: {err}",
-                op_node.operation
-            ))
-        })?;
+        .map_err(EagerAdFailure::Runtime)?;
 
         for (output_id, output) in op_node.outputs.iter().zip(outputs) {
             let key = graph.values()[*output_id].key.clone();
@@ -398,40 +465,42 @@ pub(super) fn eager_residual_value<B: TensorBackend>(
     all_values: &mut HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     key: &ValueKey<StdTensorOp>,
     backend: &mut B,
-) -> ADRuleResult<Arc<Tensor>> {
+) -> Result<Arc<Tensor>, EagerAdFailure> {
     if let Some(value) = all_values.get(key) {
         return Ok(Arc::clone(value));
     }
 
     let base_key = missing_tangent_base_key(key).ok_or_else(|| {
-        eager_ad_invalid_input(format!("missing concrete eager residual value for {key:?}"))
+        EagerAdFailure::Runtime(Error::runtime_state(
+            "eager AD residual value",
+            ErrorPhase::Execution,
+            format!("missing concrete eager residual value for {key:?}"),
+        ))
     })?;
     let base = all_values.get(&base_key).ok_or_else(|| {
-        eager_ad_invalid_input(format!(
-            "missing base eager residual value for {base_key:?}"
+        EagerAdFailure::Runtime(Error::runtime_state(
+            "eager AD residual value",
+            ErrorPhase::Execution,
+            format!("missing base eager residual value for {base_key:?}"),
         ))
     })?;
-    let value = Arc::new(zero_like_tensor(base.as_ref(), backend).map_err(|err| {
-        eager_ad_invalid_input(format!(
-            "failed to create eager residual tangent zero: {err}"
-        ))
-    })?);
+    let value =
+        Arc::new(zero_like_tensor(base.as_ref(), backend).map_err(EagerAdFailure::Runtime)?);
     all_values.insert(key.clone(), Arc::clone(&value));
     Ok(value)
 }
 
-fn checked_zero_element_count(shape: &[usize]) -> ADRuleResult<usize> {
+fn checked_zero_element_count(shape: &[usize]) -> Result<usize, EagerAdFailure> {
     shape.iter().try_fold(1usize, |acc, &dim| {
         acc.checked_mul(dim).ok_or_else(|| {
-            eager_ad_invalid_input(format!(
-                "zero tensor shape product overflows for shape {shape:?}"
+            EagerAdFailure::Runtime(Error::invalid_argument(
+                "eager AD zero",
+                ErrorPhase::Execution,
+                "shape",
+                format!("zero tensor shape product overflows for shape {shape:?}"),
             ))
         })
     })
-}
-
-fn eager_ad_invalid_input(message: impl Into<String>) -> ADRuleError {
-    ADRuleError::invalid_input("tenferro-ad.eager", ADRuleKind::Transpose, message)
 }
 
 impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
@@ -473,9 +542,11 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
             &mut external_data,
             self.backend,
             self.extension_executor.as_deref_mut(),
-        )?;
+        )
+        .map_err(|err| self.record_failure(err))?;
         ctx.refresh_global_metadata();
-        prefill_missing_linear_zero_values(linear, &mut external_data, ctx, self.backend)?;
+        prefill_missing_linear_zero_values(linear, &mut external_data, ctx, self.backend)
+            .map_err(|err| self.record_failure(err))?;
 
         let mut builder = if let Some(extension_executor) = self.extension_executor.as_deref_mut() {
             EagerPrimitiveBuilder::with_extension_executor(self.backend, extension_executor)
@@ -494,26 +565,46 @@ impl<B: TensorBackend + 'static> BackwardExecutor<StdTensorOp>
 
         let transpose_result =
             tidu::linear_transpose_with_builder(linear, &mut builder, &cotangent_seed_ids, ctx);
-        if let Some(err) = builder.take_error() {
-            return Err(err);
-        }
-        let cotangent_ids = transpose_result?;
-        cotangent_ids
+        let cotangent_ids = match transpose_result {
+            Ok(ids) => ids,
+            Err(err) => {
+                let builder_typed_error = builder.take_typed_error();
+                let builder_error = builder.take_error();
+                drop(builder);
+                if let Some(err) = builder_typed_error {
+                    return Err(self.runtime_error(err));
+                }
+                if let Some(err) = builder_error {
+                    return Err(err);
+                }
+                return Err(err);
+            }
+        };
+        let cotangent_tensors_result = cotangent_ids
             .into_iter()
             .map(|maybe_id| maybe_id.map(|id| builder.tensor(id)).transpose())
-            .collect()
+            .collect::<ADRuleResult<Vec<_>>>();
+        let builder_typed_error = builder.take_typed_error();
+        let builder_error = builder.take_error();
+        drop(builder);
+        if let Some(err) = builder_typed_error {
+            return Err(self.runtime_error(err));
+        }
+        if let Some(err) = builder_error {
+            return Err(err);
+        }
+        cotangent_tensors_result
     }
 
     fn add_operands(&mut self, a: &Arc<Tensor>, b: &Arc<Tensor>) -> Arc<Tensor> {
-        if self.deferred_error.is_some() {
+        if self.errors.has_error() {
             return Arc::clone(a);
         }
         match self.backend.add(a.as_ref(), b.as_ref()) {
             Ok(sum) => Arc::new(sum),
             Err(err) => {
-                self.record_error(eager_ad_invalid_input(format!(
-                    "eager cotangent add failed: {err}"
-                )));
+                let ad_error = self.runtime_error(Error::TensorRuntime(err));
+                self.record_error(ad_error);
                 Arc::clone(a)
             }
         }

--- a/crates/tenferro-ad/src/eager/functional.rs
+++ b/crates/tenferro-ad/src/eager/functional.rs
@@ -13,14 +13,14 @@ use tidu::{
     PrimitiveValue,
 };
 
-use crate::ad_rule_error::ad_rule_error;
+use crate::ad_rule_error::{ad_rule_error, DeferredErrors};
 use crate::eager_exec::exec_op_on_tensors_with_extension_executor;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::extension_runtime::ExtensionExecutor;
 
 use super::backward::{
     eager_forward_input_metadata, eager_forward_value, live_graph_values, missing_tangent_base_key,
-    prefill_linear_residual_values, prefill_missing_linear_zero_values,
+    prefill_linear_residual_values, prefill_missing_linear_zero_values, EagerAdFailure,
 };
 use super::{
     eager_val_key, record_eager_outputs, tensor_ptr, zero_like_tensor, EagerRuntime, EagerTensor,
@@ -60,11 +60,13 @@ pub(super) fn functional_vjp_optional(
         &mut callbacks,
         &mut ad_ctx,
     );
+    let callback_typed_error = callbacks.take_typed_error();
     let callback_error = callbacks.take_error();
-    let cotangents = match (cotangents_result, callback_error) {
-        (_, Some(err)) => return Err(ad_rule_error("vjp", err)),
-        (Err(err), None) => return Err(ad_rule_error("vjp", err)),
-        (Ok(cotangents), None) => cotangents,
+    let cotangents = match (callback_typed_error, cotangents_result, callback_error) {
+        (Some(err), _, _) => return Err(err),
+        (_, _, Some(err)) => return Err(ad_rule_error("vjp", err)),
+        (_, Err(err), None) => return Err(ad_rule_error("vjp", err)),
+        (_, Ok(cotangents), None) => cotangents,
     };
 
     cotangents
@@ -104,11 +106,13 @@ pub(super) fn functional_jvp(
         &mut callbacks,
         &mut ad_ctx,
     );
+    let callback_typed_error = callbacks.take_typed_error();
     let callback_error = callbacks.take_error();
-    let tangent = match (tangent_result, callback_error) {
-        (_, Some(err)) => return Err(ad_rule_error("jvp", err)),
-        (Err(err), None) => return Err(ad_rule_error("jvp", err)),
-        (Ok(tangent), None) => tangent,
+    let tangent = match (callback_typed_error, tangent_result, callback_error) {
+        (Some(err), _, _) => return Err(err),
+        (_, _, Some(err)) => return Err(ad_rule_error("jvp", err)),
+        (_, Err(err), None) => return Err(ad_rule_error("jvp", err)),
+        (_, Ok(tangent), None) => tangent,
     };
 
     tangent
@@ -123,7 +127,7 @@ struct RecordingCallbacks<'a> {
     extension_executor: Option<&'a mut ExtensionExecutor<super::EagerBackend>>,
     metadata_scopes: Vec<Arc<GlobalMetadataScope>>,
     tensors_by_ptr: HashMap<usize, EagerTensor>,
-    deferred_error: Option<ADRuleError>,
+    errors: DeferredErrors,
 }
 
 impl<'a> RecordingCallbacks<'a> {
@@ -139,17 +143,33 @@ impl<'a> RecordingCallbacks<'a> {
             extension_executor,
             metadata_scopes,
             tensors_by_ptr: HashMap::new(),
-            deferred_error: None,
+            errors: DeferredErrors::default(),
         }
     }
 
     fn take_error(&mut self) -> Option<ADRuleError> {
-        self.deferred_error.take()
+        self.errors.take_ad_rule()
+    }
+
+    fn take_typed_error(&mut self) -> Option<Error> {
+        self.errors.take_typed()
     }
 
     fn record_error(&mut self, err: ADRuleError) {
-        if self.deferred_error.is_none() {
-            self.deferred_error = Some(err);
+        self.errors.record_ad_rule(err);
+    }
+
+    fn runtime_error(&mut self, err: Error) -> ADRuleError {
+        self.errors.runtime("tenferro-ad.eager.functional", err)
+    }
+
+    fn record_failure(&mut self, failure: EagerAdFailure) -> ADRuleError {
+        match failure {
+            EagerAdFailure::Rule(err) => {
+                self.record_error(err.clone());
+                err
+            }
+            EagerAdFailure::Runtime(err) => self.runtime_error(err),
         }
     }
 
@@ -165,7 +185,9 @@ impl<'a> RecordingCallbacks<'a> {
     }
 
     fn remember_result(&mut self, tensor: EagerTensor) -> ADRuleResult<Arc<Tensor>> {
-        let value = tensor.materialized_arc().map_err(recording_error)?;
+        let value = tensor
+            .materialized_arc()
+            .map_err(|err| self.runtime_error(err))?;
         self.tensors_by_ptr.insert(Self::ptr(&value), tensor);
         Ok(value)
     }
@@ -197,13 +219,17 @@ impl<'a> RecordingCallbacks<'a> {
         if let Some(record) = self
             .ctx
             .value_record_by_tensor(value)
-            .map_err(recording_error)?
+            .map_err(|err| self.runtime_error(err))?
         {
             let tensor = EagerTensor::from_record(record);
             self.tensors_by_ptr.insert(Self::ptr(value), tensor.clone());
             return Ok(tensor);
         }
-        if let Some(record) = self.ctx.value_record(key).map_err(recording_error)? {
+        if let Some(record) = self
+            .ctx
+            .value_record(key)
+            .map_err(|err| self.runtime_error(err))?
+        {
             let tensor = EagerTensor::from_record(record);
             self.tensors_by_ptr.insert(Self::ptr(value), tensor.clone());
             return Ok(tensor);
@@ -216,7 +242,7 @@ impl<'a> RecordingCallbacks<'a> {
             None,
             Vec::new(),
         )
-        .map_err(recording_error)?;
+        .map_err(|err| self.runtime_error(err))?;
         self.tensors_by_ptr.insert(Self::ptr(value), tensor.clone());
         Ok(tensor)
     }
@@ -235,20 +261,33 @@ impl<'a> RecordingCallbacks<'a> {
     }
 
     fn add_recorded(&mut self, a: &Arc<Tensor>, b: &Arc<Tensor>) -> ADRuleResult<Arc<Tensor>> {
-        let lhs = self.tensor_for_arc(a).map_err(recording_error)?;
-        let rhs = self.tensor_for_arc(b).map_err(recording_error)?;
+        let lhs = self
+            .tensor_for_arc(a)
+            .map_err(|err| self.runtime_error(err))?;
+        let rhs = self
+            .tensor_for_arc(b)
+            .map_err(|err| self.runtime_error(err))?;
         let mut builder = RecordingPrimitiveBuilder::new(
             Arc::clone(&self.ctx),
             self.backend,
             self.extension_executor.as_deref_mut(),
             HashMap::new(),
         );
-        let outputs = builder.execute_operation(&StdTensorOp::Add, vec![lhs, rhs])?;
+        let outputs_result = builder.execute_operation(&StdTensorOp::Add, vec![lhs, rhs]);
+        let builder_typed_error = builder.take_typed_error();
+        let builder_error = builder.take_error();
+        drop(builder);
+        if let Some(err) = builder_typed_error {
+            return Err(self.runtime_error(err));
+        }
+        if let Some(err) = builder_error {
+            return Err(err);
+        }
+        let outputs = outputs_result?;
         let output = outputs
             .into_iter()
             .next()
             .ok_or_else(|| recording_error("eager AD add produced no outputs"))?;
-        drop(builder);
         self.remember_result(output)
     }
 }
@@ -269,7 +308,7 @@ impl BackwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
         graph: PrimitiveGraph<'_, StdTensorOp>,
         initial_data: &HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     ) -> HashMap<ValueKey<StdTensorOp>, Arc<Tensor>> {
-        if self.deferred_error.is_some() {
+        if self.errors.has_error() {
             return initial_data.clone();
         }
         let graph = graph.as_graph();
@@ -280,7 +319,8 @@ impl BackwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
             match eager_forward_input_metadata(&key, initial_data) {
                 Ok(meta) => input_metadata.push((key, meta)),
                 Err(err) => {
-                    self.record_error(err);
+                    let ad_error = self.record_failure(err);
+                    self.record_error(ad_error);
                     return all_values;
                 }
             }
@@ -301,7 +341,8 @@ impl BackwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
                 match resolved {
                     Ok(value) => resolved_values.push(value),
                     Err(err) => {
-                        self.record_error(err);
+                        let ad_error = self.record_failure(err);
+                        self.record_error(ad_error);
                         return all_values;
                     }
                 }
@@ -316,10 +357,8 @@ impl BackwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
             ) {
                 Ok(outputs) => outputs,
                 Err(err) => {
-                    self.record_error(recording_error(format!(
-                        "eager forward exec failed for {:?}: {err}",
-                        op_node.operation
-                    )));
+                    let ad_error = self.runtime_error(err);
+                    self.record_error(ad_error);
                     return all_values;
                 }
             };
@@ -333,9 +372,10 @@ impl BackwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
         let live_values = live_graph_values(graph);
         match register_scoped_live_graph_metadata(graph, &live_values, input_metadata) {
             Ok(scope) => push_ad_metadata_scope(&mut self.metadata_scopes, Arc::new(scope)),
-            Err(err) => self.record_error(recording_error(format!(
-                "eager replay metadata registration failed: {err}"
-            ))),
+            Err(err) => {
+                let ad_error = self.runtime_error(err);
+                self.record_error(ad_error);
+            }
         }
 
         all_values
@@ -357,16 +397,21 @@ impl BackwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
             &mut external_data,
             self.backend,
             self.extension_executor.as_deref_mut(),
-        )?;
+        )
+        .map_err(|err| self.record_failure(err))?;
         ctx.refresh_global_metadata();
-        prefill_missing_linear_zero_values(linear, &mut external_data, ctx, self.backend)?;
+        prefill_missing_linear_zero_values(linear, &mut external_data, ctx, self.backend)
+            .map_err(|err| self.record_failure(err))?;
         let external_tensors = self.external_tensors(&external_data)?;
         let seed_tensors = cotangent_out
             .iter()
             .map(|maybe_seed| {
                 maybe_seed
                     .as_ref()
-                    .map(|seed| self.tensor_for_arc(seed).map_err(recording_error))
+                    .map(|seed| {
+                        self.tensor_for_arc(seed)
+                            .map_err(|err| self.runtime_error(err))
+                    })
                     .transpose()
             })
             .collect::<ADRuleResult<Vec<_>>>()?;
@@ -383,15 +428,34 @@ impl BackwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
 
         let transpose_result =
             tidu::linear_transpose_with_builder(linear, &mut builder, &cotangent_seed_ids, ctx);
-        if let Some(err) = builder.take_error() {
-            return Err(err);
-        }
-        let cotangent_ids = transpose_result?;
+        let cotangent_ids = match transpose_result {
+            Ok(ids) => ids,
+            Err(err) => {
+                let builder_typed_error = builder.take_typed_error();
+                let builder_error = builder.take_error();
+                drop(builder);
+                if let Some(err) = builder_typed_error {
+                    return Err(self.runtime_error(err));
+                }
+                if let Some(err) = builder_error {
+                    return Err(err);
+                }
+                return Err(err);
+            }
+        };
         let cotangent_tensors = cotangent_ids
             .into_iter()
             .map(|maybe_id| maybe_id.map(|id| builder.tensor(id)).transpose())
             .collect::<ADRuleResult<Vec<_>>>()?;
+        let builder_typed_error = builder.take_typed_error();
+        let builder_error = builder.take_error();
         drop(builder);
+        if let Some(err) = builder_typed_error {
+            return Err(self.runtime_error(err));
+        }
+        if let Some(err) = builder_error {
+            return Err(err);
+        }
         cotangent_tensors
             .into_iter()
             .map(|maybe_tensor| {
@@ -403,7 +467,7 @@ impl BackwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
     }
 
     fn add_operands(&mut self, a: &Arc<Tensor>, b: &Arc<Tensor>) -> Arc<Tensor> {
-        if self.deferred_error.is_some() {
+        if self.errors.has_error() {
             return Arc::clone(a);
         }
         match self.add_recorded(a, b) {
@@ -439,7 +503,8 @@ impl ForwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
         }
         let mut external_data = external_data.clone();
         ctx.refresh_global_metadata();
-        prefill_missing_linear_zero_values(linear, &mut external_data, ctx, self.backend)?;
+        prefill_missing_linear_zero_values(linear, &mut external_data, ctx, self.backend)
+            .map_err(|err| self.record_failure(err))?;
         let tangent_by_key: HashMap<_, _> = tangent_in
             .iter()
             .map(|(key, value)| (key.clone(), value.clone()))
@@ -449,7 +514,9 @@ impl ForwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
             .iter()
             .map(
                 |(key, _)| match tangent_by_key.get(key).cloned().flatten() {
-                    Some(tangent) => self.tensor_for_arc(&tangent).map_err(recording_error),
+                    Some(tangent) => self
+                        .tensor_for_arc(&tangent)
+                        .map_err(|err| self.runtime_error(err)),
                     None => self.zero_tangent_for_key(key, &external_data),
                 },
             )
@@ -481,7 +548,14 @@ impl ForwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
                 .collect();
             let output_ids =
                 builder.add_primitive(op_node.operation.clone(), inputs, op_node.role.clone());
-            if let Some(err) = builder.take_error() {
+            let builder_typed_error = builder.take_typed_error();
+            let builder_error = builder.take_error();
+            if let Some(err) = builder_typed_error {
+                drop(builder);
+                return Err(self.runtime_error(err));
+            }
+            if let Some(err) = builder_error {
+                drop(builder);
                 return Err(err);
             }
             if output_ids != op_node.outputs {
@@ -497,7 +571,15 @@ impl ForwardExecutor<StdTensorOp> for RecordingCallbacks<'_> {
             .iter()
             .map(|maybe_id| maybe_id.map(|id| builder.tensor(id)).transpose())
             .collect::<ADRuleResult<Vec<_>>>()?;
+        let builder_typed_error = builder.take_typed_error();
+        let builder_error = builder.take_error();
         drop(builder);
+        if let Some(err) = builder_typed_error {
+            return Err(self.runtime_error(err));
+        }
+        if let Some(err) = builder_error {
+            return Err(err);
+        }
         tangent_tensors
             .into_iter()
             .map(|maybe_tensor| {
@@ -525,7 +607,8 @@ impl RecordingCallbacks<'_> {
         let base = external_data.get(&base_key).ok_or_else(|| {
             recording_error(format!("missing tangent base eager value for {base_key:?}"))
         })?;
-        let zero = zero_like_tensor(base.as_ref(), self.backend).map_err(recording_error)?;
+        let zero =
+            zero_like_tensor(base.as_ref(), self.backend).map_err(|err| self.runtime_error(err))?;
         EagerTensor::new_result_arc(
             Arc::clone(&self.ctx),
             eager_val_key(),
@@ -534,7 +617,7 @@ impl RecordingCallbacks<'_> {
             None,
             Vec::new(),
         )
-        .map_err(recording_error)
+        .map_err(|err| self.runtime_error(err))
     }
 }
 
@@ -544,7 +627,7 @@ struct RecordingPrimitiveBuilder<'a> {
     extension_executor: Option<&'a mut ExtensionExecutor<super::EagerBackend>>,
     external_data: HashMap<ValueKey<StdTensorOp>, EagerTensor>,
     results: Vec<EagerTensor>,
-    error: Option<ADRuleError>,
+    errors: DeferredErrors,
 }
 
 impl<'a> RecordingPrimitiveBuilder<'a> {
@@ -560,7 +643,7 @@ impl<'a> RecordingPrimitiveBuilder<'a> {
             extension_executor,
             external_data,
             results: Vec::new(),
-            error: None,
+            errors: DeferredErrors::default(),
         }
     }
 
@@ -578,13 +661,19 @@ impl<'a> RecordingPrimitiveBuilder<'a> {
     }
 
     fn take_error(&mut self) -> Option<ADRuleError> {
-        self.error.take()
+        self.errors.take_ad_rule()
+    }
+
+    fn take_typed_error(&mut self) -> Option<Error> {
+        self.errors.take_typed()
     }
 
     fn record_error(&mut self, err: ADRuleError) {
-        if self.error.is_none() {
-            self.error = Some(err);
-        }
+        self.errors.record_ad_rule(err);
+    }
+
+    fn runtime_error(&mut self, err: Error) -> ADRuleError {
+        self.errors.runtime("tenferro-ad.eager.functional", err)
     }
 
     fn dummy_output_ids(&self, operation: &StdTensorOp) -> Vec<LocalValueId> {
@@ -603,11 +692,11 @@ impl<'a> RecordingPrimitiveBuilder<'a> {
                 "missing tangent base eager AD value for {base_key:?}"
             ))
         })?;
-        let zero = zero_like_tensor(
-            base.materialized_arc().map_err(recording_error)?.as_ref(),
-            self.backend,
-        )
-        .map_err(recording_error)?;
+        let base = base
+            .materialized_arc()
+            .map_err(|err| self.runtime_error(err))?;
+        let zero =
+            zero_like_tensor(base.as_ref(), self.backend).map_err(|err| self.runtime_error(err))?;
         let tensor = EagerTensor::new_result_arc(
             Arc::clone(&self.ctx),
             eager_val_key(),
@@ -616,7 +705,7 @@ impl<'a> RecordingPrimitiveBuilder<'a> {
             None,
             Vec::new(),
         )
-        .map_err(recording_error)?;
+        .map_err(|err| self.runtime_error(err))?;
         self.external_data.insert(key.clone(), tensor.clone());
         Ok(tensor)
     }
@@ -638,7 +727,11 @@ impl<'a> RecordingPrimitiveBuilder<'a> {
     ) -> ADRuleResult<Vec<EagerTensor>> {
         let input_values = inputs
             .iter()
-            .map(|tensor| tensor.materialized_arc().map_err(recording_error))
+            .map(|tensor| {
+                tensor
+                    .materialized_arc()
+                    .map_err(|err| self.runtime_error(err))
+            })
             .collect::<ADRuleResult<Vec<_>>>()?;
         let input_refs: Vec<_> = input_values.iter().map(|tensor| tensor.as_ref()).collect();
         let outputs = exec_op_on_tensors_with_extension_executor(
@@ -647,7 +740,7 @@ impl<'a> RecordingPrimitiveBuilder<'a> {
             self.backend,
             self.extension_executor.as_deref_mut(),
         )
-        .map_err(|err| recording_error(format!("eager AD exec failed for {operation:?}: {err}")))?;
+        .map_err(|err| self.runtime_error(err))?;
         let output_arcs: Vec<_> = outputs.into_iter().map(Arc::new).collect();
 
         if !inputs.iter().any(|tensor| tensor.requires_grad) {
@@ -662,14 +755,14 @@ impl<'a> RecordingPrimitiveBuilder<'a> {
                         None,
                         Vec::new(),
                     )
-                    .map_err(recording_error)
+                    .map_err(|err| self.runtime_error(err))
                 })
                 .collect();
         }
 
         let input_refs: Vec<_> = inputs.iter().collect();
-        let recorded =
-            record_eager_outputs(operation, &output_arcs, &input_refs).map_err(recording_error)?;
+        let recorded = record_eager_outputs(operation, &output_arcs, &input_refs)
+            .map_err(|err| self.runtime_error(err))?;
         if recorded.traces.len() != output_arcs.len() {
             return Err(recording_error(format!(
                 "expected {} eager AD traces for {:?}, got {}",
@@ -698,7 +791,7 @@ impl<'a> RecordingPrimitiveBuilder<'a> {
                     trace.trace,
                     metadata_scopes.clone(),
                 )
-                .map_err(recording_error)
+                .map_err(|err| self.runtime_error(err))
             })
             .collect()
     }
@@ -734,4 +827,93 @@ fn recording_error(message: impl ToString) -> ADRuleError {
         ADRuleKind::Transpose,
         message.to_string(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn functional_walkers_cover_active_and_inactive_inputs() {
+        let ctx = EagerRuntime::with_cpu_backend(tenferro_cpu::CpuBackend::new());
+        let active = EagerTensor::requires_grad_in(
+            Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+            Arc::clone(&ctx),
+        )
+        .unwrap();
+        let inactive = EagerTensor::requires_grad_in(
+            Tensor::from_vec_col_major(vec![2], vec![5.0_f64, 7.0]).unwrap(),
+            Arc::clone(&ctx),
+        )
+        .unwrap();
+        let seed = EagerTensor::from_tensor_in(
+            Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 1.0]).unwrap(),
+            Arc::clone(&ctx),
+        )
+        .unwrap();
+        let output = active.mul(&active).unwrap();
+
+        let vjp = functional_vjp_optional(&ctx, &output, &active, &seed)
+            .unwrap()
+            .unwrap();
+        let jvp = functional_jvp(&ctx, &output, &active, &seed)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            vjp.materialized().unwrap().as_slice::<f64>().unwrap(),
+            &[4.0, 6.0]
+        );
+        assert_eq!(
+            jvp.materialized().unwrap().as_slice::<f64>().unwrap(),
+            &[4.0, 6.0]
+        );
+
+        assert!(functional_vjp_optional(&ctx, &output, &inactive, &seed)
+            .unwrap()
+            .is_none());
+        assert!(functional_jvp(&ctx, &output, &inactive, &seed)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn recording_callbacks_keep_typed_failures_and_cache_materialized_values() {
+        let ctx = EagerRuntime::with_cpu_backend(tenferro_cpu::CpuBackend::new());
+        let mut backend = ctx.lock_backend().unwrap();
+        let mut extension_executor = ctx.lock_extension_executor().unwrap();
+        let mut callbacks = RecordingCallbacks::new(
+            Arc::clone(&ctx),
+            &mut backend,
+            Some(&mut *extension_executor),
+            Vec::new(),
+        );
+
+        let rule_error = ADRuleError::invalid_input(
+            "tenferro-ad.tests",
+            ADRuleKind::Transpose,
+            "synthetic callback rule failure",
+        );
+        let recorded_rule = callbacks.record_failure(EagerAdFailure::Rule(rule_error));
+        assert!(matches!(recorded_rule, ADRuleError::InvalidInput { .. }));
+        assert!(callbacks.take_error().is_some());
+
+        let recorded_runtime =
+            callbacks.record_failure(EagerAdFailure::Runtime(Error::runtime_state(
+                "functional-tests",
+                tenferro_runtime::ErrorPhase::Execution,
+                "synthetic runtime failure",
+            )));
+        assert!(matches!(recorded_runtime, ADRuleError::InvalidInput { .. }));
+        assert!(callbacks.take_typed_error().is_some());
+        assert!(callbacks.take_error().is_some());
+
+        let value = Arc::new(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap());
+        let first = callbacks.tensor_for_arc(&value).unwrap();
+        let second = callbacks.tensor_for_arc(&value).unwrap();
+        assert_eq!(
+            first.materialized().unwrap().as_slice::<f64>().unwrap(),
+            &[1.0, 2.0]
+        );
+        assert_eq!(first.key, second.key);
+    }
 }

--- a/crates/tenferro-ad/src/eager/functional.rs
+++ b/crates/tenferro-ad/src/eager/functional.rs
@@ -13,7 +13,7 @@ use tidu::{
     PrimitiveValue,
 };
 
-use crate::ad_rule_error::{ad_rule_error, DeferredErrors};
+use crate::ad_rule_error::{ad_rule_error_with_context, DeferredErrors};
 use crate::eager_exec::exec_op_on_tensors_with_extension_executor;
 use crate::error::{Error, Result};
 use crate::extension_runtime::ExtensionExecutor;
@@ -64,8 +64,12 @@ pub(super) fn functional_vjp_optional(
     let callback_error = callbacks.take_error();
     let cotangents = match (callback_typed_error, cotangents_result, callback_error) {
         (Some(err), _, _) => return Err(err),
-        (_, _, Some(err)) => return Err(ad_rule_error("vjp", err)),
-        (_, Err(err), None) => return Err(ad_rule_error("vjp", err)),
+        (_, _, Some(err)) => {
+            return Err(ad_rule_error_with_context("vjp", err, &mut ad_ctx));
+        }
+        (_, Err(err), None) => {
+            return Err(ad_rule_error_with_context("vjp", err, &mut ad_ctx));
+        }
         (_, Ok(cotangents), None) => cotangents,
     };
 
@@ -110,8 +114,12 @@ pub(super) fn functional_jvp(
     let callback_error = callbacks.take_error();
     let tangent = match (callback_typed_error, tangent_result, callback_error) {
         (Some(err), _, _) => return Err(err),
-        (_, _, Some(err)) => return Err(ad_rule_error("jvp", err)),
-        (_, Err(err), None) => return Err(ad_rule_error("jvp", err)),
+        (_, _, Some(err)) => {
+            return Err(ad_rule_error_with_context("jvp", err, &mut ad_ctx));
+        }
+        (_, Err(err), None) => {
+            return Err(ad_rule_error_with_context("jvp", err, &mut ad_ctx));
+        }
         (_, Ok(tangent), None) => tangent,
     };
 

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -342,8 +342,12 @@ impl<B: TensorBackend + 'static> ExtensionRuntime<B> for ReadPathFallbackRuntime
         _ctx: &mut ExtensionExecutionContext<'_, B>,
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
         op.host_reference()
-            .ok_or(tenferro_tensor::Error::NoHostReference {
-                family_id: op.family_id(),
+            .ok_or_else(|| {
+                tenferro_tensor::Error::invalid_argument(
+                    "extension",
+                    "host_reference",
+                    format!("family {} has no host reference", op.family_id()),
+                )
             })?
             .execute(inputs)
     }

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -8,6 +8,7 @@ use std::sync::{
 };
 use std::time::Duration;
 
+use crate::context::AdContext;
 use computegraph::graph::{Graph, GraphBuilder};
 use computegraph::resolve::resolve;
 use computegraph::types::ValueKey;
@@ -22,6 +23,7 @@ use tenferro_runtime::{Error, ExtensionExecutionContext, ExtensionExecutor, Exte
 use tenferro_tensor::Tensor;
 use tenferro_tensor::TypedTensorView;
 use tenferro_tensor::{DType, DotGeneralConfig, TensorBackend, TensorElementwise};
+use tenferro_tensor::{ErrorKind, ValidationKind};
 use tenferro_tensor::{TensorFusion, TensorRead, TensorStructural, TensorView, TensorWrite};
 use tidu::eager::BackwardExecutor;
 use tidu::{linearize, ADKey};
@@ -75,9 +77,13 @@ fn eager_runtime_synchronize_reports_poisoned_backend_lock() {
 
     let err = ctx.synchronize().unwrap_err();
 
+    assert_eq!(err.kind(), ErrorKind::RuntimeState);
     assert!(matches!(
         err,
-        Error::Internal(ref message) if message.contains("backend lock poisoned")
+        Error::RuntimeState {
+            phase: tenferro_runtime::ErrorPhase::Execution,
+            ..
+        }
     ));
 }
 
@@ -185,9 +191,13 @@ fn eager_runtime_backend_closure_reports_poisoned_backend_lock() {
 
     let err = ctx.with_backend_mut(|_| ()).unwrap_err();
 
+    assert_eq!(err.kind(), ErrorKind::RuntimeState);
     assert!(matches!(
         err,
-        Error::Internal(ref message) if message.contains("backend lock poisoned")
+        Error::RuntimeState {
+            phase: tenferro_runtime::ErrorPhase::Execution,
+            ..
+        }
     ));
 }
 
@@ -207,9 +217,13 @@ fn eager_index_select_reports_poisoned_backend_lock() {
 
     let err = x.index_select(0, &[0]).unwrap_err();
 
+    assert_eq!(err.kind(), ErrorKind::RuntimeState);
     assert!(matches!(
         err,
-        Error::Internal(ref message) if message.contains("backend lock poisoned")
+        Error::RuntimeState {
+            phase: tenferro_runtime::ErrorPhase::Execution,
+            ..
+        }
     ));
 }
 
@@ -560,13 +574,18 @@ fn eager_backward_callbacks_record_add_errors_without_panicking() {
     let second = callbacks.add_operands(&a, &b);
     assert!(Arc::ptr_eq(&second, &a));
 
-    let err = callbacks
-        .take_error()
-        .expect("shape mismatch should be recorded");
-    assert!(
-        err.to_string().contains("eager cotangent add failed"),
-        "{err}"
+    let typed = callbacks
+        .take_typed_error()
+        .expect("shape mismatch should retain its typed runtime error");
+    assert_eq!(
+        typed.kind(),
+        ErrorKind::Validation(ValidationKind::ShapeMismatch)
     );
+    assert!(matches!(
+        typed,
+        Error::TensorRuntime(tenferro_tensor::Error::Validation { .. })
+    ));
+    assert!(callbacks.take_error().is_some());
     assert!(callbacks.take_error().is_none());
 }
 
@@ -865,10 +884,17 @@ fn eager_backward_with_rejects_mismatched_seed_shape() {
 
     let err = y.backward_with(&seed).unwrap_err();
 
-    assert!(
-        err.to_string().contains("shape mismatch"),
-        "unexpected error: {err}"
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::ShapeMismatch)
     );
+    assert!(matches!(
+        err,
+        Error::TensorRuntime(tenferro_tensor::Error::Validation {
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+            ..
+        })
+    ));
     assert!(x.grad().unwrap().is_none());
 }
 
@@ -895,6 +921,52 @@ fn eager_runtime_vjp_returns_composable_tensor_without_touching_grad_slot() {
         &[4.0, 12.0]
     );
     assert!(x.grad().unwrap().is_none());
+}
+
+#[test]
+fn eager_functional_ad_reports_inactive_inputs_and_accepts_explicit_rule_context() {
+    let ad = AdContext::builder().build().unwrap();
+    let ctx = EagerRuntime::with_cpu_backend_and_ad_context(CpuBackend::new(), &ad);
+    let active = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let inactive = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2], vec![5.0_f64, 7.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let seed = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 1.0]).unwrap(),
+        Arc::clone(&ctx),
+    )
+    .unwrap();
+    let loss = active.mul(&active).unwrap();
+
+    let inactive_vjp = ctx.vjp_optional(&loss, &inactive, &seed).unwrap();
+    let inactive_jvp = ctx.jvp_optional(&loss, &inactive, &seed).unwrap();
+    assert!(inactive_vjp.is_none());
+    assert!(inactive_jvp.is_none());
+
+    let active_vjp = ctx.vjp_optional(&loss, &active, &seed).unwrap().unwrap();
+    let active_jvp = ctx.jvp_optional(&loss, &active, &seed).unwrap().unwrap();
+    assert_eq!(
+        active_vjp
+            .materialized()
+            .unwrap()
+            .as_slice::<f64>()
+            .unwrap(),
+        &[4.0, 6.0]
+    );
+    assert_eq!(
+        active_jvp
+            .materialized()
+            .unwrap()
+            .as_slice::<f64>()
+            .unwrap(),
+        &[4.0, 6.0]
+    );
 }
 
 #[test]

--- a/crates/tenferro-ad/src/eager_builder.rs
+++ b/crates/tenferro-ad/src/eager_builder.rs
@@ -6,9 +6,11 @@ use crate::extension_runtime::ExtensionExecutor;
 use computegraph::{GraphOperation, LocalValueId, OperationRole, ValueKey, ValueRef};
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
+use tenferro_runtime::Error;
 use tenferro_tensor::{Tensor, TensorBackend, TypedTensor};
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult, PrimitiveBuilder, PrimitiveValue};
 
+use crate::ad_rule_error::DeferredErrors;
 use crate::eager_exec::{exec_op_on_tensors, exec_op_on_tensors_with_extension_executor};
 
 pub(crate) struct EagerPrimitiveBuilder<'a, B: TensorBackend + 'static> {
@@ -16,7 +18,7 @@ pub(crate) struct EagerPrimitiveBuilder<'a, B: TensorBackend + 'static> {
     pub(crate) extension_executor: Option<&'a mut ExtensionExecutor<B>>,
     pub(crate) external_data: HashMap<ValueKey<StdTensorOp>, Arc<Tensor>>,
     pub(crate) results: Vec<Arc<Tensor>>,
-    error: Option<ADRuleError>,
+    errors: DeferredErrors,
 }
 
 impl<B: TensorBackend + 'static> fmt::Debug for EagerPrimitiveBuilder<'_, B> {
@@ -26,7 +28,7 @@ impl<B: TensorBackend + 'static> fmt::Debug for EagerPrimitiveBuilder<'_, B> {
             .field("has_extension_executor", &self.extension_executor.is_some())
             .field("external_data_len", &self.external_data.len())
             .field("results_len", &self.results.len())
-            .field("has_error", &self.error.is_some())
+            .field("has_error", &self.errors.has_error())
             .finish_non_exhaustive()
     }
 }
@@ -38,7 +40,7 @@ impl<'a, B: TensorBackend + 'static> EagerPrimitiveBuilder<'a, B> {
             extension_executor: None,
             external_data: HashMap::new(),
             results: Vec::new(),
-            error: None,
+            errors: DeferredErrors::default(),
         }
     }
 
@@ -51,7 +53,7 @@ impl<'a, B: TensorBackend + 'static> EagerPrimitiveBuilder<'a, B> {
             extension_executor: Some(extension_executor),
             external_data: HashMap::new(),
             results: Vec::new(),
-            error: None,
+            errors: DeferredErrors::default(),
         }
     }
 
@@ -68,13 +70,19 @@ impl<'a, B: TensorBackend + 'static> EagerPrimitiveBuilder<'a, B> {
     }
 
     pub(crate) fn take_error(&mut self) -> Option<ADRuleError> {
-        self.error.take()
+        self.errors.take_ad_rule()
+    }
+
+    pub(crate) fn take_typed_error(&mut self) -> Option<Error> {
+        self.errors.take_typed()
     }
 
     fn record_error(&mut self, err: ADRuleError) {
-        if self.error.is_none() {
-            self.error = Some(err);
-        }
+        self.errors.record_ad_rule(err);
+    }
+
+    fn runtime_error(&mut self, err: Error) -> ADRuleError {
+        self.errors.runtime("tenferro-ad.eager", err)
     }
 
     fn dummy_output_ids(&self, operation: &StdTensorOp) -> Vec<LocalValueId> {
@@ -93,11 +101,8 @@ impl<'a, B: TensorBackend + 'static> EagerPrimitiveBuilder<'a, B> {
             eager_builder_error(format!("missing tangent base eager value for {base_key:?}"))
         })?;
         let zero = Arc::new(
-            zero_like_tensor(base.as_ref(), self.backend).map_err(|err| {
-                eager_builder_error(format!(
-                    "failed to create eager primitive tangent zero: {err}"
-                ))
-            })?,
+            zero_like_tensor(base.as_ref(), self.backend)
+                .map_err(|err| self.runtime_error(Error::TensorRuntime(err)))?,
         );
         self.external_data.insert(key.clone(), Arc::clone(&zero));
         Ok(zero)
@@ -108,7 +113,7 @@ impl<'a, B: TensorBackend + 'static> EagerPrimitiveBuilder<'a, B> {
         operation: StdTensorOp,
         inputs: Vec<ValueRef<StdTensorOp>>,
     ) -> Vec<LocalValueId> {
-        if self.error.is_some() {
+        if self.errors.has_error() {
             return self.dummy_output_ids(&operation);
         }
 
@@ -143,7 +148,7 @@ impl<'a, B: TensorBackend + 'static> EagerPrimitiveBuilder<'a, B> {
         } else {
             exec_op_on_tensors(&operation, &concrete, self.backend)
         }
-        .map_err(|err| eager_builder_error(format!("eager exec failed for {operation:?}: {err}")));
+        .map_err(|err| self.runtime_error(err));
 
         let outputs = match outputs {
             Ok(outputs) => outputs,

--- a/crates/tenferro-ad/src/eager_exec.rs
+++ b/crates/tenferro-ad/src/eager_exec.rs
@@ -255,24 +255,26 @@ fn extension_error(
 }
 
 fn missing_extension_executor_error(ext: &dyn tenferro_ops::ext_op::ExtensionOp) -> Error {
-    Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
-        op: "extension",
-        message: format!(
+    Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
+        "extension",
+        "executor",
+        format!(
             "extension op for family_id {:?} requires an ExtensionExecutor; execute through EagerRuntime or register and pass the extension runtime owner",
             ext.family_id()
         ),
-    })
+    ))
 }
 
 fn axis_out_of_bounds(op: &'static str, axis: usize, rank: usize) -> Error {
-    Error::TensorRuntime(tenferro_tensor::Error::AxisOutOfBounds { op, axis, rank })
+    Error::TensorRuntime(tenferro_tensor::Error::axis_out_of_bounds(op, axis, rank))
 }
 
 fn invalid_config(op: &'static str, message: impl Into<String>) -> Error {
-    Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
+    Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
         op,
-        message: message.into(),
-    })
+        "configuration",
+        message,
+    ))
 }
 
 fn pad_to_match_high_padding(target_size: usize, current_size: usize) -> Result<i64> {

--- a/crates/tenferro-ad/src/eager_exec.rs
+++ b/crates/tenferro-ad/src/eager_exec.rs
@@ -248,10 +248,13 @@ fn extension_error(
     ext: &dyn tenferro_ops::ext_op::ExtensionOp,
     err: tenferro_tensor::Error,
 ) -> Error {
-    Error::TensorRuntime(tenferro_tensor::Error::backend_failure(
+    Error::extension(
         "extension",
-        format!("family_id={:?}: {err}", ext.family_id()),
-    ))
+        tenferro_runtime::ErrorPhase::Execution,
+        ext.family_id(),
+        err.kind(),
+        err,
+    )
 }
 
 fn missing_extension_executor_error(ext: &dyn tenferro_ops::ext_op::ExtensionOp) -> Error {
@@ -298,11 +301,7 @@ fn upload_generated_host_tensor<B: TensorBackend>(
 
 fn shape_of_host_tensor(axis: usize, shape: &[usize]) -> Result<Tensor> {
     if axis >= shape.len() {
-        return Err(Error::Internal(format!(
-            "ShapeOf: axis {} out of bounds for rank {}",
-            axis,
-            shape.len()
-        )));
+        return Err(axis_out_of_bounds("ShapeOf", axis, shape.len()));
     }
     let size = shape[axis] as f64;
     Ok(Tensor::F64(TypedTensor::from_vec_col_major(
@@ -825,11 +824,9 @@ fn exec_standard_op_on_tensors<B: TensorBackend>(
 
 fn resolve_tensor_shape_exprs(inputs: &[&Tensor], exprs: &[DimExpr]) -> Result<Vec<usize>> {
     let input_shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
-    DimExpr::eval_all(exprs, &input_shapes).map_err(|err| {
-        invalid_config(
-            "eager shape expression",
-            format!("failed to resolve eager shape expression: {err}"),
-        )
+    DimExpr::eval_all(exprs, &input_shapes).map_err(|err| Error::ShapeExpressionEvaluation {
+        expression: format!("{exprs:?}"),
+        cause: err.into(),
     })
 }
 
@@ -838,11 +835,9 @@ fn resolve_tensor_read_shape_exprs(
     exprs: &[DimExpr],
 ) -> Result<Vec<usize>> {
     let input_shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
-    DimExpr::eval_all(exprs, &input_shapes).map_err(|err| {
-        invalid_config(
-            "eager shape expression",
-            format!("failed to resolve eager shape expression: {err}"),
-        )
+    DimExpr::eval_all(exprs, &input_shapes).map_err(|err| Error::ShapeExpressionEvaluation {
+        expression: format!("{exprs:?}"),
+        cause: err.into(),
     })
 }
 

--- a/crates/tenferro-ad/src/eager_exec/tests.rs
+++ b/crates/tenferro-ad/src/eager_exec/tests.rs
@@ -167,10 +167,9 @@ fn dynamic_truncate_invalid_axis_returns_tensor_runtime_error() {
 
     assert!(matches!(
         err,
-        tenferro_runtime::Error::TensorRuntime(tenferro_tensor::Error::AxisOutOfBounds {
+        tenferro_runtime::Error::TensorRuntime(tenferro_tensor::Error::Validation {
             op: "DynamicTruncate",
-            axis: 1,
-            rank: 1,
+            source: tenferro_tensor::ValidationError::AxisOutOfBounds { axis: 1, rank: 1 },
         })
     ));
 }
@@ -189,10 +188,9 @@ fn pad_to_match_rejects_reference_axis_out_of_bounds_without_panicking() {
 
     assert!(matches!(
         err,
-        tenferro_runtime::Error::TensorRuntime(tenferro_tensor::Error::AxisOutOfBounds {
+        tenferro_runtime::Error::TensorRuntime(tenferro_tensor::Error::Validation {
             op: "PadToMatch",
-            axis: 0,
-            rank: 0,
+            source: tenferro_tensor::ValidationError::AxisOutOfBounds { axis: 0, rank: 0 },
         })
     ));
 }

--- a/crates/tenferro-ad/src/eager_exec/tests.rs
+++ b/crates/tenferro-ad/src/eager_exec/tests.rs
@@ -13,7 +13,7 @@ use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::SymDim;
-use tenferro_tensor::{DType, Tensor, TypedTensor};
+use tenferro_tensor::{DType, ErrorKind, Tensor, TypedTensor, ValidationKind};
 
 fn f64t(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
@@ -211,11 +211,15 @@ fn eager_shape_expr_resolution_returns_error_instead_of_panicking() {
     )
     .unwrap_err();
 
-    assert!(
-        err.to_string()
-            .contains("failed to resolve eager shape expression"),
-        "{err}"
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
     );
+    assert_eq!(err.phase(), Some(tenferro_runtime::ErrorPhase::Execution));
+    assert!(matches!(
+        err,
+        tenferro_runtime::Error::ShapeExpressionEvaluation { .. }
+    ));
 }
 
 #[test]

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use computegraph::GraphOperation;
 use tenferro_ops::broadcast::{
-    broadcast_input_plan, broadcast_shape, broadcast_shapes, BroadcastError,
+    broadcast_error_to_validation, broadcast_in_dim_extent_error, broadcast_input_plan,
+    broadcast_shape, broadcast_shapes,
 };
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
@@ -71,21 +72,8 @@ fn broadcast_to(
     source.broadcast_in_dim(target_shape, &plan.dims)
 }
 
-fn broadcast_error(op: &'static str, err: BroadcastError) -> Error {
-    match err {
-        BroadcastError::IncompatibleBinary { lhs, rhs } => {
-            tenferro_tensor::Error::shape_mismatch(op, lhs, rhs).into()
-        }
-        BroadcastError::IncompatibleInput { input, output }
-        | BroadcastError::RankTooLarge { input, output } => {
-            tenferro_tensor::Error::invalid_argument(
-                op,
-                "shape",
-                format!("cannot broadcast shape {input:?} to {output:?}"),
-            )
-            .into()
-        }
-    }
+fn broadcast_error(op: &'static str, err: tenferro_ops::broadcast::BroadcastError) -> Error {
+    tenferro_tensor::Error::validation(op, broadcast_error_to_validation(err)).into()
 }
 
 fn ensure_same_context(lhs: &EagerTensor, rhs: &EagerTensor) -> Result<()> {
@@ -569,6 +557,9 @@ impl EagerTensor {
     /// `DuplicateAxis`, or `ShapeMismatch` when `shape`/`dims` cannot broadcast
     /// the input, or a typed backend/runtime-state error.
     pub fn broadcast_in_dim(&self, shape: &[usize], dims: &[usize]) -> Result<Self> {
+        if let Some(error) = broadcast_in_dim_extent_error(self.shape(), shape, dims) {
+            return Err(broadcast_error("EagerTensor::broadcast_in_dim", error));
+        }
         let op = StdTensorOp::BroadcastInDim {
             shape: DimExpr::from_concrete(shape),
             dims: dims.to_vec(),

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -662,9 +662,14 @@ impl EagerTensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`tenferro_tensor::Error::Validation`] with `InvalidArgument`
-    /// when padding vectors do not match the input rank or checked output-size
-    /// arithmetic overflows, or a typed backend/runtime-state error.
+    /// Returns [`tenferro_runtime::Error::TensorRuntime`] containing
+    /// [`tenferro_tensor::ValidationError::InvalidArgument`] when a
+    /// padding vector has a length different from the input rank, interior
+    /// padding is negative, or edge/interior padding produces a negative
+    /// dimension or checked output-size arithmetic overflows.
+    /// Backend execution and unavailable runtime state are propagated as their
+    /// typed [`tenferro_runtime::Error::TensorRuntime`] or
+    /// [`tenferro_runtime::Error::RuntimeState`] variants.
     pub fn pad(&self, config: PadConfig) -> Result<Self> {
         self.unary_op(StdTensorOp::Pad(config))
     }

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -74,14 +74,17 @@ fn broadcast_to(
 fn broadcast_error(op: &'static str, err: BroadcastError) -> Error {
     match err {
         BroadcastError::IncompatibleBinary { lhs, rhs } => {
-            tenferro_tensor::Error::ShapeMismatch { op, lhs, rhs }.into()
+            tenferro_tensor::Error::shape_mismatch(op, lhs, rhs).into()
         }
         BroadcastError::IncompatibleInput { input, output }
-        | BroadcastError::RankTooLarge { input, output } => tenferro_tensor::Error::InvalidConfig {
-            op,
-            message: format!("cannot broadcast shape {input:?} to {output:?}"),
+        | BroadcastError::RankTooLarge { input, output } => {
+            tenferro_tensor::Error::invalid_argument(
+                op,
+                "shape",
+                format!("cannot broadcast shape {input:?} to {output:?}"),
+            )
+            .into()
         }
-        .into(),
     }
 }
 
@@ -363,28 +366,15 @@ impl EagerTensor {
         let lhs_shape = self.shape();
         let rhs_shape = other.shape();
         if lhs_shape.len() != 2 {
-            return Err(tenferro_tensor::Error::RankMismatch {
-                op: "matmul",
-                expected: 2,
-                actual: lhs_shape.len(),
-            }
-            .into());
+            return Err(tenferro_tensor::Error::rank_mismatch("matmul", 2, lhs_shape.len()).into());
         }
         if rhs_shape.len() != 2 {
-            return Err(tenferro_tensor::Error::RankMismatch {
-                op: "matmul",
-                expected: 2,
-                actual: rhs_shape.len(),
-            }
-            .into());
+            return Err(tenferro_tensor::Error::rank_mismatch("matmul", 2, rhs_shape.len()).into());
         }
         if lhs_shape[1] != rhs_shape[0] {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "matmul",
-                lhs: lhs_shape.to_vec(),
-                rhs: rhs_shape.to_vec(),
-            }
-            .into());
+            return Err(
+                tenferro_tensor::Error::shape_mismatch("matmul", lhs_shape, rhs_shape).into(),
+            );
         }
         self.dot_general(
             other,
@@ -1011,33 +1001,30 @@ fn validate_eager_axes(op: &'static str, rank: usize, axes: &[usize]) -> Result<
 }
 
 fn validate_eager_dot_general_config(
-    op: &'static str,
+    _op: &'static str,
     config: &DotGeneralConfig,
     lhs_rank: usize,
     rhs_rank: usize,
 ) -> Result<()> {
     config
         .validate_dims_with_ranks(lhs_rank, rhs_rank)
-        .map_err(|err| {
-            Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
-                op,
-                message: err.to_string(),
-            })
-        })
+        .map_err(Error::TensorRuntime)
 }
 
 fn empty_nary_input_error(op: &StdTensorOp) -> Error {
-    Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
-        op: eager_validation_op_name(op),
-        message: "operation requires at least one input tensor".to_string(),
-    })
+    Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
+        eager_validation_op_name(op),
+        "inputs",
+        "operation requires at least one input tensor",
+    ))
 }
 
 fn wrong_nary_input_count_error(op: &StdTensorOp, expected: usize, actual: usize) -> Error {
-    Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
-        op: eager_validation_op_name(op),
-        message: format!("operation expects {expected} inputs, got {actual}"),
-    })
+    Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
+        eager_validation_op_name(op),
+        "inputs",
+        format!("operation expects {expected} inputs, got {actual}"),
+    ))
 }
 
 fn eager_validation_op_name(op: &StdTensorOp) -> &'static str {

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -162,12 +162,26 @@ impl EagerTensor {
     ///
     /// assert_eq!(z.materialized().unwrap().as_slice::<f64>().unwrap(), &[4.0, 6.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ContextMismatch`] for tensors from different eager
+    /// runtimes, [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch`/`DTypeMismatch` for incompatible operands, or a typed
+    /// backend/runtime-state error during execution.
     pub fn add(&self, other: &Self) -> Result<Self> {
         let (lhs, rhs) = broadcast_binary("add", self, other)?;
         lhs.binary_op(&rhs, StdTensorOp::Add)
     }
 
     /// Elementwise subtraction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ContextMismatch`] for tensors from different eager
+    /// runtimes, [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch`/`DTypeMismatch` for incompatible operands, or a typed
+    /// backend/runtime-state error during execution.
     pub fn sub(&self, other: &Self) -> Result<Self> {
         let (lhs, rhs) = broadcast_binary("sub", self, other)?;
         lhs.binary_op(&rhs, StdTensorOp::Sub)
@@ -188,6 +202,13 @@ impl EagerTensor {
     ///
     /// assert_eq!(z.materialized().unwrap().as_slice::<f64>().unwrap(), &[3.0, 8.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ContextMismatch`] for tensors from different eager
+    /// runtimes, [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch`/`DTypeMismatch` for incompatible operands, or a typed
+    /// backend/runtime-state error during execution.
     pub fn mul(&self, other: &Self) -> Result<Self> {
         let (lhs, rhs) = broadcast_binary("mul", self, other)?;
         lhs.binary_op(&rhs, StdTensorOp::Mul)
@@ -207,6 +228,12 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[-1.0, 2.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] when the backend does
+    /// not implement negation for the dtype, or a typed backend/runtime-state
+    /// error during execution.
     pub fn neg(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Neg)
     }
@@ -225,6 +252,12 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] when the backend does
+    /// not implement exponentiation for the dtype, or a typed backend/
+    /// runtime-state error during execution.
     pub fn exp(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Exp)
     }
@@ -243,6 +276,12 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[10.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
+    /// `DuplicateAxis` for an invalid reduction axis, or a typed
+    /// unsupported/backend/runtime-state error for the selected dtype.
     pub fn reduce_sum(&self, axes: &[usize]) -> Result<Self> {
         validate_eager_axes("EagerTensor::reduce_sum", self.shape().len(), axes)?;
         self.unary_op(StdTensorOp::ReduceSum {
@@ -270,6 +309,13 @@ impl EagerTensor {
     ///
     /// assert_eq!(c.shape(), &[2, 2]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch`,
+    /// `AxisOutOfBounds`, `DuplicateAxis`, `ShapeMismatch`, or `DTypeMismatch`
+    /// when `config` or the operands are invalid; backend and runtime-state
+    /// failures retain their typed sources.
     pub fn dot_general(&self, other: &Self, config: DotGeneralConfig) -> Result<Self> {
         validate_eager_dot_general_config(
             "EagerTensor::dot_general",
@@ -286,6 +332,12 @@ impl EagerTensor {
     /// the conjugated operand does not need to be materialized. Tracked tensors
     /// fall back to explicit `Conj` plus `DotGeneral` so reverse-mode AD keeps
     /// the same graph semantics as the standard eager ops.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ContextMismatch`] for operands from different eager
+    /// runtimes, [`tenferro_tensor::Error::Validation`] for rank/axis/shape or
+    /// dtype mismatches in `config`, or a typed backend/runtime-state error.
     pub fn dot_general_with_conj(
         &self,
         other: &Self,
@@ -362,6 +414,12 @@ impl EagerTensor {
     /// assert_eq!(c.shape(), &[2, 1]);
     /// assert_eq!(c.materialized().unwrap().as_slice::<f64>().unwrap(), &[23.0, 34.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::ValidationError::RankMismatch`] when either operand is
+    /// not rank 2, `ShapeMismatch` when the inner dimensions differ, or a typed
+    /// dtype/backend/runtime-state error during the contraction.
     pub fn matmul(&self, other: &Self) -> Result<Self> {
         let lhs_shape = self.shape();
         let rhs_shape = other.shape();
@@ -405,6 +463,12 @@ impl EagerTensor {
     /// assert_eq!(y.shape(), &[3, 2]);
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds`
+    /// or `DuplicateAxis` when `perm` is not a permutation, or a typed
+    /// backend/runtime-state error while creating the view.
     pub fn transpose(&self, perm: &[usize]) -> Result<Self> {
         let op = StdTensorOp::Transpose {
             perm: perm.to_vec(),
@@ -434,6 +498,12 @@ impl EagerTensor {
     /// assert_eq!(y.shape(), &[6]);
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::ValidationError::ShapeMismatch`] when the element count
+    /// changes, `InvalidArgument` when the target shape product overflows, or a
+    /// typed backend/runtime-state error.
     pub fn reshape(&self, shape: &[usize]) -> Result<Self> {
         let op = StdTensorOp::Reshape {
             to_shape: DimExpr::from_concrete(shape),
@@ -464,6 +534,12 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[2.0, 3.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `AxisOutOfBounds`/`InvalidArgument` when starts, limits, or strides are
+    /// invalid, or a typed backend/runtime-state error while creating the view.
     pub fn slice(&self, config: SliceConfig) -> Result<Self> {
         let value = self
             .value
@@ -486,6 +562,12 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.shape(), &[3, 2]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds`,
+    /// `DuplicateAxis`, or `ShapeMismatch` when `shape`/`dims` cannot broadcast
+    /// the input, or a typed backend/runtime-state error.
     pub fn broadcast_in_dim(&self, shape: &[usize], dims: &[usize]) -> Result<Self> {
         let op = StdTensorOp::BroadcastInDim {
             shape: DimExpr::from_concrete(shape),
@@ -518,9 +600,10 @@ impl EagerTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when the requested conversion is outside tenferro's
-    /// checked dtype-promotion lattice. Use [`cast`](Self::cast) for explicit
-    /// lossy dtype projection.
+    /// Returns [`tenferro_tensor::Error::UnsupportedDTypeConversion`] when the
+    /// requested pair is outside tenferro's checked dtype-promotion lattice.
+    /// Use [`cast`](Self::cast) for explicit lossy projection; backend
+    /// execution can additionally return a typed runtime-state error.
     pub fn convert(&self, to: DType) -> Result<Self> {
         tenferro_tensor::validate::validate_convert_dtype("EagerTensor::convert", self.dtype(), to)
             .map_err(Error::TensorRuntime)?;
@@ -545,6 +628,11 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<i32>().unwrap(), &[1, -2]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns a typed [`tenferro_tensor::Error::Unsupported`] when the eager
+    /// backend cannot project the requested dtype, or a backend/runtime-state
+    /// error during execution.
     pub fn cast(&self, to: DType) -> Result<Self> {
         self.unary_op(StdTensorOp::Convert {
             from: self.dtype(),
@@ -572,6 +660,11 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[0.0, 1.0, 0.0, 2.0, 0.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `InvalidArgument`
+    /// when padding vectors do not match the input rank or checked output-size
+    /// arithmetic overflows, or a typed backend/runtime-state error.
     pub fn pad(&self, config: PadConfig) -> Result<Self> {
         self.unary_op(StdTensorOp::Pad(config))
     }
@@ -590,6 +683,11 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[4.0, 3.0, 2.0, 1.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
+    /// `DuplicateAxis` for an invalid axis list, or a typed backend/
+    /// runtime-state error during execution.
     pub fn reverse(&self, axes: &[usize]) -> Result<Self> {
         validate_eager_axes("EagerTensor::reverse", self.shape().len(), axes)?;
         self.unary_op(StdTensorOp::Reverse {
@@ -626,6 +724,11 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[50.0, 20.0, 10.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] when the gather
+    /// configuration has an invalid rank, axis, shape, or index dtype, or a
+    /// typed backend/runtime-state error.
     pub fn gather(&self, indices: &Self, config: GatherConfig) -> Result<Self> {
         self.binary_op(indices, StdTensorOp::Gather(config))
     }
@@ -657,6 +760,11 @@ impl EagerTensor {
     ///
     /// assert_eq!(result.materialized().unwrap().as_slice::<f64>().unwrap(), &[0.0, 5.0, 0.0, 7.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] when the scatter
+    /// configuration, index/update shapes, or index dtype is invalid, or a
+    /// typed backend/runtime-state error.
     pub fn scatter(&self, indices: &Self, updates: &Self, config: ScatterConfig) -> Result<Self> {
         self.ternary_op(indices, updates, StdTensorOp::Scatter(config))
     }
@@ -676,6 +784,12 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] when `starts` has the
+    /// wrong dtype/shape or `sizes` exceeds the operand rank, including an
+    /// `AxisOutOfBounds` or `ShapeMismatch`, or a typed backend/runtime-state
+    /// error.
     pub fn dynamic_slice(&self, starts: &Self, sizes: &[usize]) -> Result<Self> {
         self.binary_op(
             starts,
@@ -700,6 +814,12 @@ impl EagerTensor {
     ///
     /// assert_eq!(z.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::ValidationError::InvalidArgument`] when `tensors` is
+    /// empty or `axis` is outside the rank, `ShapeMismatch`/`DTypeMismatch`
+    /// when inputs cannot be concatenated, or a typed backend/runtime-state
+    /// error.
     pub fn concatenate(tensors: &[&Self], axis: usize) -> Result<Self> {
         Self::nary_op(
             tensors,
@@ -727,6 +847,11 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0, 5.0, 9.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch`,
+    /// `AxisOutOfBounds`, or `DuplicateAxis` when the selected axes cannot form
+    /// a diagonal, or a typed backend/runtime-state error.
     pub fn extract_diag(&self, axis_a: usize, axis_b: usize) -> Result<Self> {
         self.unary_op(StdTensorOp::ExtractDiag { axis_a, axis_b })
     }
@@ -746,6 +871,11 @@ impl EagerTensor {
     /// assert_eq!(y.shape(), &[3, 3]);
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch`,
+    /// `AxisOutOfBounds`, or `DuplicateAxis` when the diagonal axes are not
+    /// valid for embedding, or a typed backend/runtime-state error.
     pub fn embed_diag(&self, axis_a: usize, axis_b: usize) -> Result<Self> {
         self.unary_op(StdTensorOp::EmbedDiag { axis_a, axis_b })
     }
@@ -764,6 +894,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0, 2.0, 0.0, 4.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::ValidationError::RankMismatch`] when the operand is not
+    /// a matrix, or a typed unsupported/backend/runtime-state error.
     pub fn tril(&self, k: i64) -> Result<Self> {
         self.unary_op(StdTensorOp::Tril { k })
     }
@@ -782,6 +916,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0, 0.0, 3.0, 4.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::ValidationError::RankMismatch`] when the operand is not
+    /// a matrix, or a typed unsupported/backend/runtime-state error.
     pub fn triu(&self, k: i64) -> Result<Self> {
         self.unary_op(StdTensorOp::Triu { k })
     }
@@ -800,6 +938,11 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[24.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
+    /// `DuplicateAxis` for an invalid reduction axis, or a typed
+    /// unsupported/backend/runtime-state error for the selected dtype.
     pub fn reduce_prod(&self, axes: &[usize]) -> Result<Self> {
         validate_eager_axes("EagerTensor::reduce_prod", self.shape().len(), axes)?;
         self.unary_op(StdTensorOp::ReduceProd {
@@ -821,6 +964,11 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[4.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
+    /// `DuplicateAxis` for an invalid reduction axis, or a typed
+    /// unsupported/backend/runtime-state error for the selected dtype.
     pub fn reduce_max(&self, axes: &[usize]) -> Result<Self> {
         validate_eager_axes("EagerTensor::reduce_max", self.shape().len(), axes)?;
         self.unary_op(StdTensorOp::ReduceMax {
@@ -842,6 +990,11 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
+    /// `DuplicateAxis` for an invalid reduction axis, or a typed
+    /// unsupported/backend/runtime-state error for the selected dtype.
     pub fn reduce_min(&self, axes: &[usize]) -> Result<Self> {
         validate_eager_axes("EagerTensor::reduce_min", self.shape().len(), axes)?;
         self.unary_op(StdTensorOp::ReduceMin {

--- a/crates/tenferro-ad/src/eager_ops_elementwise.rs
+++ b/crates/tenferro-ad/src/eager_ops_elementwise.rs
@@ -268,8 +268,9 @@ impl EagerTensor {
     /// Returns [`crate::error::Error::ContextMismatch`] for different eager runtimes,
     /// [`tenferro_tensor::ValidationError::ShapeMismatch`] or
     /// `ValidationError::DTypeMismatch` for
-    /// incompatible operands, `DivisionByZero` for a checked zero divisor, or
-    /// a typed backend/runtime-state error.
+    /// incompatible operands, or a typed backend/runtime-state error. Addition
+    /// does not have a zero-divisor failure; numerical zero-divisor errors are
+    /// specific to division and remainder.
     pub fn div(&self, other: &Self) -> Result<Self> {
         let (lhs, rhs) = broadcast_binary("div", self, other)?;
         lhs.binary_op(&rhs, StdTensorOp::Div)
@@ -281,8 +282,9 @@ impl EagerTensor {
     /// Returns [`crate::error::Error::ContextMismatch`] for different eager runtimes,
     /// [`tenferro_tensor::ValidationError::ShapeMismatch`] or
     /// `ValidationError::DTypeMismatch` for
-    /// incompatible operands, `DivisionByZero` for a checked zero divisor, or
-    /// a typed backend/runtime-state error.
+    /// incompatible operands, or a typed backend/runtime-state error.
+    /// Subtraction does not have a zero-divisor failure; numerical
+    /// zero-divisor errors are specific to division and remainder.
     pub fn rem(&self, other: &Self) -> Result<Self> {
         let (lhs, rhs) = broadcast_binary("rem", self, other)?;
         lhs.binary_op(&rhs, StdTensorOp::Rem)

--- a/crates/tenferro-ad/src/eager_ops_elementwise.rs
+++ b/crates/tenferro-ad/src/eager_ops_elementwise.rs
@@ -20,6 +20,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] when the dtype has no
+    /// absolute-value implementation, or a typed backend/runtime-state error.
     pub fn abs(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Abs)
     }
@@ -38,6 +42,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0, -2.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] when conjugation is not
+    /// defined for the dtype, or a typed backend/runtime-state error.
     pub fn conj(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Conj)
     }
@@ -56,6 +64,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[-1.0, 1.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] when sign is not
+    /// defined for the dtype, or a typed backend/runtime-state error.
     pub fn sign(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Sign)
     }
@@ -74,6 +86,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[0.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype, or a typed backend/runtime-state error during execution.
     pub fn log(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Log)
     }
@@ -92,6 +108,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[2.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype, or a typed backend/runtime-state error during execution.
     pub fn sqrt(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Sqrt)
     }
@@ -110,6 +130,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[0.5]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype, or a typed backend/runtime-state error during execution.
     pub fn rsqrt(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Rsqrt)
     }
@@ -128,6 +152,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[0.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype, or a typed backend/runtime-state error during execution.
     pub fn sin(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Sin)
     }
@@ -146,6 +174,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype, or a typed backend/runtime-state error during execution.
     pub fn cos(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Cos)
     }
@@ -164,6 +196,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[0.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype, or a typed backend/runtime-state error during execution.
     pub fn tanh(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Tanh)
     }
@@ -182,6 +218,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[0.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype, or a typed backend/runtime-state error during execution.
     pub fn expm1(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Expm1)
     }
@@ -200,6 +240,10 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[0.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype, or a typed backend/runtime-state error during execution.
     pub fn log1p(&self) -> Result<Self> {
         self.unary_op(StdTensorOp::Log1p)
     }
@@ -219,12 +263,26 @@ impl EagerTensor {
     ///
     /// assert_eq!(z.materialized().unwrap().as_slice::<f64>().unwrap(), &[4.0, -2.0, 3.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::ContextMismatch`] for different eager runtimes,
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`] or
+    /// `ValidationError::DTypeMismatch` for
+    /// incompatible operands, `DivisionByZero` for a checked zero divisor, or
+    /// a typed backend/runtime-state error.
     pub fn div(&self, other: &Self) -> Result<Self> {
         let (lhs, rhs) = broadcast_binary("div", self, other)?;
         lhs.binary_op(&rhs, StdTensorOp::Div)
     }
 
     /// Elementwise remainder.
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::ContextMismatch`] for different eager runtimes,
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`] or
+    /// `ValidationError::DTypeMismatch` for
+    /// incompatible operands, `DivisionByZero` for a checked zero divisor, or
+    /// a typed backend/runtime-state error.
     pub fn rem(&self, other: &Self) -> Result<Self> {
         let (lhs, rhs) = broadcast_binary("rem", self, other)?;
         lhs.binary_op(&rhs, StdTensorOp::Rem)
@@ -245,6 +303,13 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[8.0, 9.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::ContextMismatch`] for different eager runtimes,
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`] or
+    /// `ValidationError::DTypeMismatch` for
+    /// incompatible operands, `NumericalFailure` for a checked invalid power,
+    /// or a typed backend/runtime-state error.
     pub fn pow(&self, other: &Self) -> Result<Self> {
         let (lhs, rhs) = broadcast_binary("pow", self, other)?;
         lhs.binary_op(&rhs, StdTensorOp::Pow)
@@ -265,6 +330,13 @@ impl EagerTensor {
     ///
     /// assert_eq!(z.materialized().unwrap().as_slice::<f64>().unwrap(), &[3.0, 5.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::ContextMismatch`] for different eager runtimes,
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`] or
+    /// `ValidationError::DTypeMismatch` for
+    /// incompatible operands, or a typed unsupported/backend/runtime-state
+    /// error.
     pub fn maximum(&self, other: &Self) -> Result<Self> {
         let (lhs, rhs) = broadcast_binary("maximum", self, other)?;
         lhs.binary_op(&rhs, StdTensorOp::Maximum)
@@ -285,12 +357,26 @@ impl EagerTensor {
     ///
     /// assert_eq!(z.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0, 4.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::ContextMismatch`] for different eager runtimes,
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`] or
+    /// `ValidationError::DTypeMismatch` for
+    /// incompatible operands, or a typed unsupported/backend/runtime-state
+    /// error.
     pub fn minimum(&self, other: &Self) -> Result<Self> {
         let (lhs, rhs) = broadcast_binary("minimum", self, other)?;
         lhs.binary_op(&rhs, StdTensorOp::Minimum)
     }
 
     /// Elementwise comparison.
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::ContextMismatch`] for different eager runtimes,
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`] or
+    /// `ValidationError::DTypeMismatch` for
+    /// incompatible operands, or a typed unsupported/backend/runtime-state
+    /// error.
     pub fn compare(&self, other: &Self, dir: CompareDir) -> Result<Self> {
         let (lhs, rhs) = broadcast_binary("compare", self, other)?;
         lhs.binary_op(&rhs, StdTensorOp::Compare(dir))
@@ -312,11 +398,23 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0, 20.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::ContextMismatch`] for different eager runtimes,
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`] when the three operands do not
+    /// broadcast, `DTypeMismatch` for incompatible value dtypes, or a typed
+    /// backend/runtime-state error.
     pub fn select(condition: &Self, on_true: &Self, on_false: &Self) -> Result<Self> {
         Self::where_select(condition, on_true, on_false)
     }
 
     /// Select values from `on_true` or `on_false` using `condition`.
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::ContextMismatch`] for different eager runtimes,
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`] when the three operands do not
+    /// broadcast, `DTypeMismatch` for incompatible value dtypes, or a typed
+    /// backend/runtime-state error.
     pub fn where_select(condition: &Self, on_true: &Self, on_false: &Self) -> Result<Self> {
         let (condition, on_true, on_false) =
             broadcast_ternary("where_select", condition, on_true, on_false)?;
@@ -339,6 +437,12 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[-1.0, 0.5, 4.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::error::Error::ContextMismatch`] for different eager runtimes,
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`] when the three operands do not
+    /// broadcast, `DTypeMismatch` for incompatible bounds, or a typed
+    /// unsupported/backend/runtime-state error.
     pub fn clamp(&self, lower: &Self, upper: &Self) -> Result<Self> {
         let (input, lower, upper) = broadcast_ternary("clamp", self, lower, upper)?;
         input.ternary_op(&lower, &upper, StdTensorOp::Clamp)

--- a/crates/tenferro-ad/src/extension.rs
+++ b/crates/tenferro-ad/src/extension.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use computegraph::GraphOperation;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_runtime::ad_support::push_metadata_scope;
-use tenferro_runtime::{Error, Result};
+use tenferro_runtime::{Error, ErrorPhase, Result};
 use tenferro_tensor::{Tensor, TensorValue};
 
 use crate::eager::{eager_grad_recording_enabled, record_eager_outputs, EagerRuntime, EagerTensor};
@@ -67,19 +67,33 @@ pub fn adopt_untracked_eager_value(ctx: Arc<EagerRuntime>, value: TensorValue) -
 /// let _ = &x;
 /// let _apply = apply_eager;
 /// ```
+/// # Errors
+///
+/// Returns `Error::Validation` with `InvalidArgument` when `inputs` is empty
+/// or its length differs from the extension's declared input count. Returns
+/// `Error::ContextMismatch` when tensors belong to different eager runtimes;
+/// backend, extension, and runtime-state failures retain their typed sources.
 pub fn apply_eager(op: Arc<dyn ExtensionOp>, inputs: &[&EagerTensor]) -> Result<Vec<EagerTensor>> {
     let Some(first) = inputs.first() else {
-        return Err(Error::Internal(
-            "extension::apply_eager requires at least one input tensor".to_string(),
+        return Err(Error::invalid_argument(
+            "extension::apply_eager",
+            ErrorPhase::Execution,
+            "inputs",
+            "at least one input tensor is required",
         ));
     };
     if inputs.len() != op.input_count() {
-        return Err(Error::Internal(format!(
-            "extension::apply_eager: op family {:?} expects {} inputs, got {}",
-            op.family_id(),
-            op.input_count(),
-            inputs.len()
-        )));
+        return Err(Error::invalid_argument(
+            "extension::apply_eager",
+            ErrorPhase::Execution,
+            "inputs",
+            format!(
+                "op family {:?} expects {} inputs, got {}",
+                op.family_id(),
+                op.input_count(),
+                inputs.len()
+            ),
+        ));
     }
 
     let ctx = Arc::clone(&first.ctx);
@@ -149,10 +163,19 @@ pub fn apply_eager(op: Arc<dyn ExtensionOp>, inputs: &[&EagerTensor]) -> Result<
 ///
 /// Extension crates use this when an extension-level eager operation expands
 /// into ordinary `StdTensorOp` nodes instead of a custom extension primitive.
+///
+/// # Errors
+///
+/// Returns `Error::Validation` with `InvalidArgument` if an extension op is
+/// passed to this standard-op entry point. Propagates concrete tensor,
+/// backend, and runtime-state failures from the selected eager context.
 pub fn apply_standard_op(op: StdTensorOp, inputs: &[&EagerTensor]) -> Result<EagerTensor> {
     if matches!(op, StdTensorOp::Extension(_)) {
-        return Err(Error::Internal(
-            "extension::apply_standard_op does not accept Extension ops".into(),
+        return Err(Error::invalid_argument(
+            "extension::apply_standard_op",
+            ErrorPhase::Execution,
+            "op",
+            "Extension ops must be passed to apply_eager",
         ));
     }
     EagerTensor::nary_op(inputs, op)

--- a/crates/tenferro-ad/src/extension.rs
+++ b/crates/tenferro-ad/src/extension.rs
@@ -166,9 +166,12 @@ pub fn apply_eager(op: Arc<dyn ExtensionOp>, inputs: &[&EagerTensor]) -> Result<
 ///
 /// # Errors
 ///
-/// Returns `Error::Validation` with `InvalidArgument` if an extension op is
-/// passed to this standard-op entry point. Propagates concrete tensor,
-/// backend, and runtime-state failures from the selected eager context.
+/// Returns [`tenferro_runtime::Error::TensorRuntime`] containing
+/// [`tenferro_tensor::ValidationError::InvalidArgument`] if an extension
+/// op is passed to this standard-op entry point. Returns
+/// [`tenferro_runtime::Error::ContextMismatch`] for tensors from different
+/// eager contexts and propagates typed tensor/backend/runtime-state failures
+/// from the selected eager context.
 pub fn apply_standard_op(op: StdTensorOp, inputs: &[&EagerTensor]) -> Result<EagerTensor> {
     if matches!(op, StdTensorOp::Extension(_)) {
         return Err(Error::invalid_argument(

--- a/crates/tenferro-ad/src/shape_packing.rs
+++ b/crates/tenferro-ad/src/shape_packing.rs
@@ -4,6 +4,7 @@ use tenferro_tensor::{GatherConfig, SliceConfig, Tensor, TensorDeviceTransfer, T
 
 use crate::eager::EagerTensor;
 use crate::error::{Error, Result};
+use tenferro_runtime::ErrorPhase;
 
 fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
     let normalized = if axis >= 0 {
@@ -304,6 +305,12 @@ impl<'a> EagerSliceBuilder<'a> {
     /// let y = x.slice_builder().axis(0, 1..4).apply().unwrap();
     /// assert_eq!(y.shape(), &[3]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::ValidationError::AxisOutOfBounds`] or
+    /// `DuplicateAxis` when selections address an invalid/repeated axis,
+    /// `InvalidArgument` for zero steps or out-of-bounds ranges, or a typed
+    /// backend/runtime-state error while applying the selections.
     pub fn apply(self) -> Result<EagerTensor> {
         let shape = self.tensor.shape().to_vec();
         let mut seen = vec![false; shape.len()];
@@ -343,6 +350,11 @@ impl EagerTensor {
     /// let y = x.slice_axis(0, 1..3).unwrap();
     /// assert_eq!(y.shape(), &[2]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::ValidationError::AxisOutOfBounds`] when `axis` is not
+    /// present, `InvalidArgument` when `range` exceeds the axis extent, or a
+    /// typed backend/runtime-state error.
     pub fn slice_axis(&self, axis: usize, range: Range<usize>) -> Result<Self> {
         self.slice_builder().axis(axis, range).apply()
     }
@@ -386,6 +398,11 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[30.0, 10.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::ValidationError::AxisOutOfBounds`] for an invalid axis,
+    /// `InvalidArgument` when an index is outside the axis extent or cannot fit
+    /// in the backend index dtype, or a typed backend/runtime-state error.
     pub fn take_axis(&self, axis: usize, indices: &[usize]) -> Result<Self> {
         let axis = isize::try_from(axis).map_err(|_| {
             Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
@@ -415,6 +432,11 @@ impl EagerTensor {
     /// assert_eq!(y.shape(), &[1, 2]);
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::ValidationError::InvalidArgument`] for a row index
+    /// outside the matrix, or [`Error::Validation`] for a non-matrix input;
+    /// backend/runtime-state failures retain their typed source.
     pub fn take_rows(&self, rows: &[usize]) -> Result<Self> {
         self.take_axis(0, rows)
     }
@@ -437,6 +459,11 @@ impl EagerTensor {
     /// assert_eq!(y.shape(), &[2, 1]);
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::ValidationError::InvalidArgument`] for a column index
+    /// outside the matrix, or [`Error::Validation`] for a non-matrix input;
+    /// backend/runtime-state failures retain their typed source.
     pub fn take_cols(&self, cols: &[usize]) -> Result<Self> {
         self.take_axis(1, cols)
     }
@@ -463,6 +490,11 @@ impl EagerTensor {
     /// assert_eq!(y.shape(), &[1, 1]);
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[2.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Propagates [`tenferro_tensor::ValidationError::InvalidArgument`] for an out of
+    /// bounds row or column and [`Error::Validation`] for a non-matrix input;
+    /// backend/runtime-state failures retain their typed source.
     pub fn take_block(&self, rows: &[usize], cols: &[usize]) -> Result<Self> {
         self.take_rows(rows)?.take_cols(cols)
     }
@@ -484,14 +516,17 @@ impl EagerTensor {
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[30.0, 10.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::ValidationError::AxisOutOfBounds`] for an invalid
+    /// signed axis, `InvalidArgument` for an out-of-range position or integer
+    /// conversion overflow, or a typed backend/runtime-state error.
     pub fn index_select(&self, axis: isize, positions: &[usize]) -> Result<Self> {
         let (indices, config) = index_select_config(self.shape(), axis, positions)?;
         let indices = {
-            let mut backend = self
-                .ctx
-                .backend
-                .lock()
-                .map_err(|_| Error::Internal("backend lock poisoned".to_string()))?;
+            let mut backend = self.ctx.backend.lock().map_err(|_| {
+                Error::runtime_state("eager_backend", ErrorPhase::Execution, "lock poisoned")
+            })?;
             backend.upload_host_tensor(&indices)?
         };
         let indices = self.ctx.constant_from(indices)?;
@@ -517,6 +552,11 @@ impl EagerTensor {
     /// assert_eq!(out.shape(), &[2]);
     /// assert_eq!(out.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0, 2.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::ValidationError::InvalidArgument`] when `tensors` is
+    /// empty or `dim` is outside the insertion rank, `ShapeMismatch` when
+    /// inputs differ in shape, or a typed context/backend/runtime-state error.
     pub fn stack(tensors: &[&Self], dim: isize) -> Result<Self> {
         let first = tensors.first().copied().ok_or_else(|| {
             Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(

--- a/crates/tenferro-ad/src/shape_packing.rs
+++ b/crates/tenferro-ad/src/shape_packing.rs
@@ -9,20 +9,14 @@ fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> Result
     let normalized = if axis >= 0 {
         axis as usize
     } else {
-        rank.checked_sub(axis.unsigned_abs())
-            .ok_or(tenferro_tensor::Error::AxisOutOfBounds {
-                op,
-                axis: axis.unsigned_abs(),
-                rank,
-            })?
+        rank.checked_sub(axis.unsigned_abs()).ok_or_else(|| {
+            tenferro_tensor::Error::axis_out_of_bounds(op, axis.unsigned_abs(), rank)
+        })?
     };
     if normalized >= rank {
-        return Err(tenferro_tensor::Error::AxisOutOfBounds {
-            op,
-            axis: axis.unsigned_abs(),
-            rank,
-        }
-        .into());
+        return Err(
+            tenferro_tensor::Error::axis_out_of_bounds(op, axis.unsigned_abs(), rank).into(),
+        );
     }
     Ok(normalized)
 }
@@ -30,28 +24,22 @@ fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> Result
 fn normalize_insert_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
     let insert_rank = rank
         .checked_add(1)
-        .ok_or(tenferro_tensor::Error::AxisOutOfBounds {
-            op,
-            axis: axis.unsigned_abs(),
-            rank,
-        })?;
+        .ok_or_else(|| tenferro_tensor::Error::axis_out_of_bounds(op, axis.unsigned_abs(), rank))?;
     let normalized = if axis >= 0 {
         axis as usize
     } else {
-        insert_rank.checked_sub(axis.unsigned_abs()).ok_or(
-            tenferro_tensor::Error::AxisOutOfBounds {
-                op,
-                axis: axis.unsigned_abs(),
-                rank: insert_rank,
-            },
-        )?
+        insert_rank
+            .checked_sub(axis.unsigned_abs())
+            .ok_or_else(|| {
+                tenferro_tensor::Error::axis_out_of_bounds(op, axis.unsigned_abs(), insert_rank)
+            })?
     };
     if normalized > rank {
-        return Err(tenferro_tensor::Error::AxisOutOfBounds {
+        return Err(tenferro_tensor::Error::axis_out_of_bounds(
             op,
-            axis: axis.unsigned_abs(),
-            rank: insert_rank,
-        }
+            axis.unsigned_abs(),
+            insert_rank,
+        )
         .into());
     }
     Ok(normalized)
@@ -66,12 +54,13 @@ fn index_select_config(
     let axis_extent = shape[axis];
     for &position in positions {
         if position >= axis_extent {
-            return Err(tenferro_tensor::Error::InvalidConfig {
-                op: "index_select",
-                message: format!(
+            return Err(tenferro_tensor::Error::invalid_argument(
+                "index_select",
+                "position",
+                format!(
                     "position {position} out of bounds for axis {axis} with extent {axis_extent}"
                 ),
-            }
+            )
             .into());
         }
     }
@@ -83,9 +72,12 @@ fn index_select_config(
     let index_data = positions
         .iter()
         .map(|&position| {
-            i64::try_from(position).map_err(|_| tenferro_tensor::Error::InvalidConfig {
-                op: "index_select",
-                message: format!("position {position} cannot be represented as i64"),
+            i64::try_from(position).map_err(|_| {
+                tenferro_tensor::Error::invalid_argument(
+                    "index_select",
+                    "position",
+                    format!("position {position} cannot be represented as i64"),
+                )
             })
         })
         .collect::<tenferro_tensor::Result<Vec<_>>>()?;
@@ -107,20 +99,16 @@ fn index_select_config(
 
 fn validate_stack_shapes(op: &'static str, shapes: &[&[usize]]) -> Result<()> {
     let Some(first) = shapes.first() else {
-        return Err(tenferro_tensor::Error::InvalidConfig {
+        return Err(tenferro_tensor::Error::invalid_argument(
             op,
-            message: "stack requires at least one input".into(),
-        }
+            "inputs",
+            "stack requires at least one input",
+        )
         .into());
     };
     for shape in shapes.iter().skip(1) {
         if *shape != *first {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op,
-                lhs: first.to_vec(),
-                rhs: shape.to_vec(),
-            }
-            .into());
+            return Err(tenferro_tensor::Error::shape_mismatch(op, *first, *shape).into());
         }
     }
     Ok(())
@@ -146,15 +134,10 @@ fn validate_axis_selection(
     axis: usize,
 ) -> Result<()> {
     if axis >= rank {
-        return Err(tenferro_tensor::Error::AxisOutOfBounds { op, axis, rank }.into());
+        return Err(tenferro_tensor::Error::axis_out_of_bounds(op, axis, rank).into());
     }
     if seen[axis] {
-        return Err(tenferro_tensor::Error::DuplicateAxis {
-            op,
-            axis,
-            role: "selection",
-        }
-        .into());
+        return Err(tenferro_tensor::Error::duplicate_axis(op, axis, "selection").into());
     }
     seen[axis] = true;
     Ok(())
@@ -174,21 +157,23 @@ fn apply_slice_axis_config(
             continue;
         };
         if *step == 0 {
-            return Err(tenferro_tensor::Error::InvalidConfig {
+            return Err(tenferro_tensor::Error::invalid_argument(
                 op,
-                message: format!("axis {axis} has zero step"),
-            }
+                "step",
+                format!("axis {axis} has zero step"),
+            )
             .into());
         }
         let extent = shape[*axis];
         if range.start > range.end || range.end > extent {
-            return Err(tenferro_tensor::Error::InvalidConfig {
+            return Err(tenferro_tensor::Error::invalid_argument(
                 op,
-                message: format!(
+                "range",
+                format!(
                     "axis {axis} range {}..{} is out of bounds for extent {extent}",
                     range.start, range.end
                 ),
-            }
+            )
             .into());
         }
         starts[*axis] = range.start;
@@ -403,10 +388,11 @@ impl EagerTensor {
     /// ```
     pub fn take_axis(&self, axis: usize, indices: &[usize]) -> Result<Self> {
         let axis = isize::try_from(axis).map_err(|_| {
-            Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
-                op: "take_axis",
-                message: format!("axis {axis} cannot be represented as isize"),
-            })
+            Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
+                "take_axis",
+                "axis",
+                format!("{axis} cannot be represented as isize"),
+            ))
         })?;
         self.index_select(axis, indices)
     }
@@ -533,10 +519,11 @@ impl EagerTensor {
     /// ```
     pub fn stack(tensors: &[&Self], dim: isize) -> Result<Self> {
         let first = tensors.first().copied().ok_or_else(|| {
-            Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
-                op: "stack",
-                message: "stack requires at least one input".into(),
-            })
+            Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
+                "stack",
+                "inputs",
+                "stack requires at least one input",
+            ))
         })?;
         let shapes = tensors
             .iter()

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -19,7 +19,7 @@ use tenferro_runtime::ad_support::{
     resolve_roots as tensor_resolve_roots, shape_hint as tensor_shape_hint, tensor_from_parts,
     tensor_meta_from_tensor, ConstraintScopeTransfer, RegisteredGraphAnalysis, TracedTensorParts,
 };
-use tenferro_runtime::{Error, GraphCompiler, GraphExecutor, Result, TracedTensor};
+use tenferro_runtime::{Error, ErrorPhase, GraphCompiler, GraphExecutor, Result, TracedTensor};
 use tenferro_tensor::TensorBackend;
 use tidu::{linear_transpose, linearize, ADRuleError};
 
@@ -624,14 +624,14 @@ fn jvp_optional_impl(
         return Ok(None);
     };
     let tangent_input_key = linear_input_key(linear.as_graph(), linear.tangent_inputs()[0].1)?;
-    let tangent_data =
-        tangent
-            .attached_data()
-            .cloned()
-            .ok_or_else(|| Error::InvalidGraphBuild {
-                op: "jvp",
-                message: "jvp tangent must have concrete tensor data".to_string(),
-            })?;
+    let tangent_data = tangent.attached_data().cloned().ok_or_else(|| {
+        Error::invalid_argument(
+            "jvp",
+            ErrorPhase::GraphBuild,
+            "tangent",
+            "jvp tangent must have concrete tensor data",
+        )
+    })?;
     let analysis = register_scoped_graph_analysis(
         linear.as_graph(),
         vec![(
@@ -912,14 +912,14 @@ fn build_vjp_tensor(
 ) -> Result<Option<TracedTensor>> {
     let cotangent_input_key =
         linear_input_key(transposed.as_graph(), transposed.tangent_inputs()[0].1)?;
-    let cotangent_data =
-        cotangent
-            .attached_data()
-            .cloned()
-            .ok_or_else(|| Error::InvalidGraphBuild {
-                op: "vjp",
-                message: "vjp cotangent must have concrete tensor data".to_string(),
-            })?;
+    let cotangent_data = cotangent.attached_data().cloned().ok_or_else(|| {
+        Error::invalid_argument(
+            "vjp",
+            ErrorPhase::GraphBuild,
+            "cotangent",
+            "vjp cotangent must have concrete tensor data",
+        )
+    })?;
     let transposed_analysis = register_scoped_graph_analysis(
         transposed.as_graph(),
         vec![(

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use crate::ad_rule_error::ad_rule_error;
+use crate::ad_rule_error::{ad_rule_error, ad_rule_error_with_context};
 use computegraph::graph::Graph;
 use computegraph::resolve::resolve;
 use computegraph::resolve::{ResolvedView, ValueDef};
@@ -684,7 +684,7 @@ fn jvp_optional_impl(
                     &mut ad_ctx,
                     &aliases,
                 )
-                .map_err(|err| ad_rule_error("jvp", err))?;
+                .map_err(|err| ad_rule_error_with_context("jvp", err, &mut ad_ctx))?;
                 let linear = Arc::new(OptimizedLinearGraph::from_tidu(linear).into_cached());
                 cache.put_traced_linearized(key, Arc::clone(&linear))?;
                 linear
@@ -700,7 +700,7 @@ fn jvp_optional_impl(
                 &mut ad_ctx,
                 &aliases,
             )
-            .map_err(|err| ad_rule_error("jvp", err))?;
+            .map_err(|err| ad_rule_error_with_context("jvp", err, &mut ad_ctx))?;
             Arc::new(OptimizedLinearGraph::from_tidu(linear).into_cached())
         }
     };
@@ -823,7 +823,12 @@ fn compute_linear_vjp_transform(
         aliases,
     ) {
         Ok(linear) => linear,
-        Err(err) => return Ok(Err(err)),
+        Err(err) => {
+            if let Some(source) = linear_ad_ctx.take_deferred_shape_error() {
+                return Err(Error::ad_rule_source("vjp", source));
+            }
+            return Ok(Err(err));
+        }
     };
     if linear.tangent_outputs()[0].is_none() {
         return Ok(Ok(None));
@@ -840,7 +845,12 @@ fn compute_linear_vjp_transform(
     linear_ad_ctx.refresh_global_metadata();
     let transposed = match linear_transpose(&linear, &mut linear_ad_ctx) {
         Ok(transposed) => OptimizedLinearGraph::from_tidu(transposed).into_cached(),
-        Err(err) => return Ok(Err(err)),
+        Err(err) => {
+            if let Some(source) = linear_ad_ctx.take_deferred_shape_error() {
+                return Err(Error::ad_rule_source("vjp", source));
+            }
+            return Ok(Err(err));
+        }
     };
     let (_linear_graph, residual_graph) = linear.into_graphs();
     let residual_analysis =
@@ -923,9 +933,18 @@ fn vjp_optional_impl(
                 return Ok(None);
             }
             Err(err) if !is_not_applicable_custom_vjp(&err) => {
-                return Err(ad_rule_error(transform, err));
+                return Err(ad_rule_error_with_context(
+                    transform,
+                    err,
+                    &mut primal_ad_ctx,
+                ));
             }
-            Err(_) => {}
+            Err(err) => {
+                if let Some(source) = primal_ad_ctx.take_deferred_shape_error() {
+                    return Err(Error::ad_rule_source(transform, source));
+                }
+                let _ = err;
+            }
         }
     }
 

--- a/crates/tenferro-ad/src/traced.rs
+++ b/crates/tenferro-ad/src/traced.rs
@@ -348,6 +348,19 @@ pub trait TracedTensorAdExt {
     ///
     /// assert_eq!(eval(&dx).as_slice::<f64>().unwrap(), &[6.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::NonScalarGrad`] for a non-scalar
+    /// output, [`tenferro_runtime::Error::UnsupportedAdRule`] when an AD rule
+    /// is unavailable, or a typed validation/backend/runtime-state error.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape constraints can later produce
+    /// [`tenferro_runtime::Error::ShapeConstraintViolation`] or
+    /// [`tenferro_runtime::Error::ShapeConstraintEvaluation`] during compile
+    /// or execution.
     fn grad(&self, wrt: &TracedTensor) -> Result<TracedTensor>;
 
     /// Like [`grad`](Self::grad), but returns `None` when `wrt` is inactive.
@@ -364,6 +377,19 @@ pub trait TracedTensorAdExt {
     ///
     /// assert!(loss.grad_optional(&x).unwrap().is_none());
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::NonScalarGrad`] for a non-scalar
+    /// output, [`Error::UnsupportedAdRule`] when an AD rule is unavailable, or
+    /// a typed validation/backend/runtime-state error.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape constraints can later produce
+    /// [`tenferro_runtime::Error::ShapeConstraintViolation`] or
+    /// [`tenferro_runtime::Error::ShapeConstraintEvaluation`] during compile
+    /// or execution.
     fn grad_optional(&self, wrt: &TracedTensor) -> Result<Option<TracedTensor>>;
 
     /// Evaluate this tensor and replace its graph with a concrete leaf while
@@ -386,6 +412,12 @@ pub trait TracedTensorAdExt {
     /// let value = y.attached_data().unwrap();
     /// assert_eq!(value.as_slice::<f64>().unwrap(), &[9.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::Validation`] when checkpoint metadata
+    /// is invalid, [`Error::RuntimeState`] when graph metadata or executor
+    /// state is unavailable, or a typed backend error from evaluation.
     fn checkpoint<B: TensorBackend>(
         &mut self,
         compiler: &mut GraphCompiler,
@@ -415,6 +447,19 @@ pub trait TracedTensorAdExt {
     ///
     /// assert_eq!(eval(&dy).as_slice::<f64>().unwrap(), &[12.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::UnsupportedAdRule`] when a JVP rule
+    /// is unavailable, [`Error::Validation`] for incompatible tangent metadata,
+    /// or a typed backend/runtime-state error.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape constraints can later produce
+    /// [`tenferro_runtime::Error::ShapeConstraintViolation`] or
+    /// [`tenferro_runtime::Error::ShapeConstraintEvaluation`] during compile
+    /// or execution.
     fn jvp(&self, wrt: &TracedTensor, tangent: &TracedTensor) -> Result<TracedTensor>;
 
     /// Like [`jvp`](Self::jvp), but returns `None` when `wrt` is inactive.
@@ -432,6 +477,19 @@ pub trait TracedTensorAdExt {
     ///
     /// assert!(loss.jvp_optional(&x, &tangent).unwrap().is_none());
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::UnsupportedAdRule`] when a JVP rule
+    /// is unavailable, [`Error::Validation`] for incompatible tangent metadata,
+    /// or a typed backend/runtime-state error.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape constraints can later produce
+    /// [`tenferro_runtime::Error::ShapeConstraintViolation`] or
+    /// [`tenferro_runtime::Error::ShapeConstraintEvaluation`] during compile
+    /// or execution.
     fn jvp_optional(
         &self,
         wrt: &TracedTensor,
@@ -466,6 +524,19 @@ pub trait TracedTensorAdExt {
     ///
     /// assert_eq!(eval(&dx).as_slice::<f64>().unwrap(), &[3.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::UnsupportedAdRule`] when a VJP rule
+    /// is unavailable, [`Error::Validation`] for incompatible cotangent
+    /// metadata, or a typed backend/runtime-state error.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape constraints can later produce
+    /// [`tenferro_runtime::Error::ShapeConstraintViolation`] or
+    /// [`tenferro_runtime::Error::ShapeConstraintEvaluation`] during compile
+    /// or execution.
     fn vjp(&self, wrt: &TracedTensor, cotangent: &TracedTensor) -> Result<TracedTensor>;
 
     /// Like [`vjp`](Self::vjp), but returns `None` when `wrt` is inactive.
@@ -483,6 +554,19 @@ pub trait TracedTensorAdExt {
     ///
     /// assert!(loss.vjp_optional(&x, &cotangent).unwrap().is_none());
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::UnsupportedAdRule`] when a VJP rule
+    /// is unavailable, [`Error::Validation`] for incompatible cotangent
+    /// metadata, or a typed backend/runtime-state error.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape constraints can later produce
+    /// [`tenferro_runtime::Error::ShapeConstraintViolation`] or
+    /// [`tenferro_runtime::Error::ShapeConstraintEvaluation`] during compile
+    /// or execution.
     fn vjp_optional(
         &self,
         wrt: &TracedTensor,

--- a/crates/tenferro-ad/src/transform_cache.rs
+++ b/crates/tenferro-ad/src/transform_cache.rs
@@ -11,7 +11,7 @@ use computegraph::{LocalValueId, ValueKey};
 use lru::LruCache;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_runtime::{CacheStats, Error, Result};
+use tenferro_runtime::{CacheStats, Error, ErrorPhase, Result};
 use tidu::eager::RecordedGraph;
 use tidu::LinearizedGraph;
 
@@ -399,9 +399,9 @@ impl AdTransformCache {
     }
 
     fn lock_store(&self) -> Result<MutexGuard<'_, AdTransformCacheStore>> {
-        self.store
-            .lock()
-            .map_err(|_| Error::Internal("AD transform cache lock poisoned".to_string()))
+        self.store.lock().map_err(|_| {
+            Error::runtime_state("ad_transform_cache", ErrorPhase::Compile, "lock poisoned")
+        })
     }
 }
 

--- a/crates/tenferro-ad/tests/integration.rs
+++ b/crates/tenferro-ad/tests/integration.rs
@@ -11,6 +11,8 @@ mod ad_optimizer;
 mod ad_structural_primitives;
 #[path = "integration/binding_validation.rs"]
 mod binding_validation;
+#[path = "integration/broadcast_error_parity.rs"]
+mod broadcast_error_parity;
 #[path = "integration/cache_management.rs"]
 mod cache_management;
 #[path = "integration/checkpoint.rs"]

--- a/crates/tenferro-ad/tests/integration/broadcast_error_parity.rs
+++ b/crates/tenferro-ad/tests/integration/broadcast_error_parity.rs
@@ -1,0 +1,139 @@
+use std::sync::Arc;
+
+use tenferro_ad::{EagerRuntime, EagerTensor};
+use tenferro_cpu::CpuBackend;
+use tenferro_runtime::{Error, ErrorPhase, TracedTensor};
+use tenferro_tensor::{Error as TensorError, ShapeMismatch, ValidationError};
+
+fn eager_tensor(ctx: Arc<EagerRuntime>, shape: Vec<usize>) -> EagerTensor {
+    let size = shape.iter().product();
+    EagerTensor::from_tensor_in(
+        tenferro_tensor::Tensor::from_vec_col_major(shape, vec![1.0_f64; size]).unwrap(),
+        ctx,
+    )
+    .unwrap()
+}
+
+fn assert_expected_actual(source: &ValidationError, expected: &[usize], actual: &[usize]) {
+    assert!(matches!(
+        source,
+        ValidationError::ShapeMismatch(shape)
+            if matches!(shape.as_ref(), ShapeMismatch::ExpectedActual { expected: found_expected, actual: found_actual }
+                if found_expected.as_slice() == expected && found_actual.as_slice() == actual)
+    ));
+}
+
+fn assert_rank_mismatch(source: &ValidationError, expected: usize, actual: usize) {
+    assert!(matches!(
+        source,
+        ValidationError::RankMismatch {
+            expected: found_expected,
+            actual: found_actual,
+        } if *found_expected == expected && *found_actual == actual
+    ));
+}
+
+#[test]
+fn eager_and_traced_broadcast_errors_share_payloads_across_discovery_phases() {
+    let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
+    let cases = [
+        "incompatible_binary",
+        "incompatible_input",
+        "rank_too_large",
+    ];
+
+    for case in cases {
+        let eager_error = match case {
+            "incompatible_binary" => {
+                let lhs = eager_tensor(ctx.clone(), vec![2]);
+                let rhs = eager_tensor(ctx.clone(), vec![3]);
+                lhs.add(&rhs).unwrap_err()
+            }
+            "incompatible_input" => {
+                let input = eager_tensor(ctx.clone(), vec![2, 3]);
+                input.broadcast_in_dim(&[2, 4], &[0, 1]).unwrap_err()
+            }
+            "rank_too_large" => {
+                let input = eager_tensor(ctx.clone(), vec![2, 3]);
+                input.broadcast_in_dim(&[3], &[0, 0]).unwrap_err()
+            }
+            _ => unreachable!(),
+        };
+
+        let traced_error = match case {
+            "incompatible_binary" => {
+                let lhs = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]).unwrap();
+                let rhs = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
+                lhs.add(&rhs).unwrap_err()
+            }
+            "incompatible_input" => {
+                let input = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+                input.broadcast_in_dim(&[2, 4], &[0, 1]).unwrap_err()
+            }
+            "rank_too_large" => {
+                let input = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
+                input.broadcast_in_dim(&[3], &[0, 0]).unwrap_err()
+            }
+            _ => unreachable!(),
+        };
+
+        assert_eq!(eager_error.kind(), traced_error.kind(), "{case}");
+        match case {
+            "incompatible_binary" => {
+                match eager_error {
+                    Error::TensorRuntime(TensorError::Validation { source, .. }) => {
+                        assert!(matches!(
+                            source,
+                            ValidationError::ShapeMismatch(shape)
+                                if matches!(shape.as_ref(), ShapeMismatch::IncompatibleShapes { lhs, rhs }
+                                    if lhs.as_slice() == [2] && rhs.as_slice() == [3])
+                        ));
+                    }
+                    other => panic!("unexpected eager error: {other:?}"),
+                }
+                assert!(matches!(
+                    traced_error,
+                    Error::Validation {
+                        phase: ErrorPhase::GraphBuild,
+                        source: ValidationError::ShapeMismatch(shape),
+                        ..
+                    } if matches!(shape.as_ref(), ShapeMismatch::IncompatibleShapes { lhs, rhs }
+                        if lhs.as_slice() == [2] && rhs.as_slice() == [3])
+                ));
+            }
+            "incompatible_input" => {
+                match eager_error {
+                    Error::TensorRuntime(TensorError::Validation { source, .. }) => {
+                        assert_expected_actual(&source, &[2, 4], &[2, 3]);
+                    }
+                    other => panic!("unexpected eager error: {other:?}"),
+                }
+                assert!(matches!(
+                    traced_error,
+                    Error::Validation {
+                        phase: ErrorPhase::GraphBuild,
+                        source,
+                        ..
+                    } if { assert_expected_actual(&source, &[2, 4], &[2, 3]); true }
+                ));
+            }
+            "rank_too_large" => {
+                match eager_error {
+                    Error::TensorRuntime(TensorError::Validation { source, .. }) => {
+                        assert_rank_mismatch(&source, 1, 2);
+                    }
+                    other => panic!("unexpected eager error: {other:?}"),
+                }
+                assert!(matches!(
+                    traced_error,
+                    Error::Validation {
+                        phase: ErrorPhase::GraphBuild,
+                        source,
+                        ..
+                    } if { assert_rank_mismatch(&source, 1, 2); true }
+                ));
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/crates/tenferro-ad/tests/integration/dot_general_validation.rs
+++ b/crates/tenferro-ad/tests/integration/dot_general_validation.rs
@@ -3,13 +3,17 @@ use support::RunTraced;
 
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::traced::TracedTensor;
-use tenferro_tensor::{DotGeneralConfig, Tensor, TypedTensor};
+use tenferro_runtime::{Error as RuntimeError, ErrorPhase};
+use tenferro_tensor::{
+    DotGeneralConfig, Error as TensorError, ErrorKind, Tensor, TypedTensor, ValidationError,
+    ValidationKind,
+};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
-fn assert_error_contains(config: DotGeneralConfig, expected_substring: &str) {
+fn assert_validation_error(config: DotGeneralConfig, expected_kind: ValidationKind) {
     let a =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]))
             .unwrap();
@@ -19,11 +23,13 @@ fn assert_error_contains(config: DotGeneralConfig, expected_substring: &str) {
     let err = a
         .dot_general(&b, config)
         .expect_err("invalid dot_general config should return an error");
-    let msg = err.to_string();
-    assert!(
-        msg.contains(expected_substring),
-        "expected message containing '{expected_substring}', got: {msg}"
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(expected_kind),
+        "unexpected structured classification: {err}"
     );
+    assert_eq!(err.phase(), Some(ErrorPhase::GraphBuild));
+    assert!(matches!(err, RuntimeError::Validation { .. }));
 }
 
 // Tests for stale lhs_rank/rhs_rank in config were removed after Task 4 of the
@@ -34,27 +40,27 @@ fn assert_error_contains(config: DotGeneralConfig, expected_substring: &str) {
 
 #[test]
 fn traced_dot_general_rejects_out_of_bounds_contracting_dim() {
-    assert_error_contains(
+    assert_validation_error(
         DotGeneralConfig {
             lhs_contracting_dims: vec![5],
             rhs_contracting_dims: vec![0],
             lhs_batch_dims: vec![],
             rhs_batch_dims: vec![],
         },
-        "out of bounds",
+        ValidationKind::AxisOutOfBounds,
     );
 }
 
 #[test]
 fn traced_dot_general_rejects_contracting_batch_overlap() {
-    assert_error_contains(
+    assert_validation_error(
         DotGeneralConfig {
             lhs_contracting_dims: vec![1],
             rhs_contracting_dims: vec![0],
             lhs_batch_dims: vec![1],
             rhs_batch_dims: vec![],
         },
-        "both contracting and batch",
+        ValidationKind::InvalidArgument,
     );
 }
 
@@ -99,7 +105,17 @@ fn dot_general_config_validate_dims_out_of_bounds() {
         rhs_batch_dims: vec![],
     };
     let err = config.validate_dims_with_ranks(2, 2).unwrap_err();
-    assert!(err.to_string().contains("out of bounds"));
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::AxisOutOfBounds)
+    );
+    assert!(matches!(
+        err,
+        TensorError::Validation {
+            source: ValidationError::AxisOutOfBounds { axis: 3, rank: 2 },
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -111,7 +127,10 @@ fn dot_general_config_validate_dims_contracting_count_mismatch() {
         rhs_batch_dims: vec![],
     };
     let err = config.validate_dims_with_ranks(2, 2).unwrap_err();
-    assert!(err.to_string().contains("contracting dim counts differ"));
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
+    );
 }
 
 #[test]
@@ -123,71 +142,74 @@ fn dot_general_config_validate_dims_batch_count_mismatch() {
         rhs_batch_dims: vec![],
     };
     let err = config.validate_dims_with_ranks(2, 2).unwrap_err();
-    assert!(err.to_string().contains("batch dim counts differ"));
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
+    );
 }
 
 #[test]
 fn traced_dot_general_rejects_rhs_out_of_bounds_contracting_dim() {
-    assert_error_contains(
+    assert_validation_error(
         DotGeneralConfig {
             lhs_contracting_dims: vec![1],
             rhs_contracting_dims: vec![5],
             lhs_batch_dims: vec![],
             rhs_batch_dims: vec![],
         },
-        "out of bounds",
+        ValidationKind::AxisOutOfBounds,
     );
 }
 
 #[test]
 fn traced_dot_general_rejects_lhs_batch_out_of_bounds() {
-    assert_error_contains(
+    assert_validation_error(
         DotGeneralConfig {
             lhs_contracting_dims: vec![1],
             rhs_contracting_dims: vec![0],
             lhs_batch_dims: vec![5],
             rhs_batch_dims: vec![],
         },
-        "out of bounds",
+        ValidationKind::AxisOutOfBounds,
     );
 }
 
 #[test]
 fn traced_dot_general_rejects_rhs_batch_out_of_bounds() {
-    assert_error_contains(
+    assert_validation_error(
         DotGeneralConfig {
             lhs_contracting_dims: vec![1],
             rhs_contracting_dims: vec![0],
             lhs_batch_dims: vec![],
             rhs_batch_dims: vec![5],
         },
-        "out of bounds",
+        ValidationKind::AxisOutOfBounds,
     );
 }
 
 #[test]
 fn traced_dot_general_rejects_rhs_contracting_batch_overlap() {
-    assert_error_contains(
+    assert_validation_error(
         DotGeneralConfig {
             lhs_contracting_dims: vec![1],
             rhs_contracting_dims: vec![0],
             lhs_batch_dims: vec![],
             rhs_batch_dims: vec![0],
         },
-        "both contracting and batch",
+        ValidationKind::InvalidArgument,
     );
 }
 
 #[test]
 fn traced_dot_general_rejects_duplicate_contracting_dims() {
-    assert_error_contains(
+    assert_validation_error(
         DotGeneralConfig {
             lhs_contracting_dims: vec![0, 0],
             rhs_contracting_dims: vec![0, 1],
             lhs_batch_dims: vec![],
             rhs_batch_dims: vec![],
         },
-        "duplicate dim",
+        ValidationKind::InvalidArgument,
     );
 }
 
@@ -200,7 +222,17 @@ fn dot_general_config_validate_dims_rhs_out_of_bounds() {
         rhs_batch_dims: vec![],
     };
     let err = config.validate_dims_with_ranks(2, 2).unwrap_err();
-    assert!(err.to_string().contains("out of bounds"));
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::AxisOutOfBounds)
+    );
+    assert!(matches!(
+        err,
+        TensorError::Validation {
+            source: ValidationError::AxisOutOfBounds { axis: 5, rank: 2 },
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -212,7 +244,17 @@ fn dot_general_config_validate_dims_duplicate_batch_dims() {
         rhs_batch_dims: vec![1, 1],
     };
     let err = config.validate_dims_with_ranks(3, 3).unwrap_err();
-    assert!(err.to_string().contains("duplicate dim"));
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
+    );
+    assert!(matches!(
+        err,
+        TensorError::Validation {
+            source: ValidationError::DuplicateAxis { axis: 0, .. },
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/crates/tenferro-ad/tests/integration/dynamic_truncate.rs
+++ b/crates/tenferro-ad/tests/integration/dynamic_truncate.rs
@@ -8,8 +8,8 @@ use tenferro_runtime::{
     DType, Error as RuntimeError, GraphExecutor, Tensor, TracedTensor, TypedTensor,
 };
 use tenferro_tensor::{
-    Buffer, BufferHandle, DeviceId, DeviceKind, Error as TensorError, GpuBackendKind, MemoryKind,
-    Placement,
+    Buffer, BufferHandle, DeviceId, DeviceKind, Error as TensorError, ErrorKind, GpuBackendKind,
+    MemoryKind, Placement,
 };
 
 const TOL: f64 = 1.0e-5;
@@ -146,12 +146,13 @@ fn dynamic_truncate_rejects_backend_size_binding_on_cpu() {
         .run_with_inputs_auto(&mut engine, &[(&size, &backend_f64_scalar())])
         .unwrap_err();
 
+    assert_eq!(err.kind(), ErrorKind::RuntimeState);
     assert!(matches!(
         err,
-        RuntimeError::TensorRuntime(TensorError::BackendFailure {
+        RuntimeError::TensorRuntime(TensorError::RuntimeState {
             op: "CpuBackend::download_to_host",
-            ref message,
-        }) if message.contains("download")
+            ..
+        })
     ));
 }
 

--- a/crates/tenferro-ad/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-ad/tests/integration/eager_tensor.rs
@@ -223,7 +223,7 @@ fn eager_concatenate_empty_reports_typed_validation_error() {
 
     assert!(matches!(
         err,
-        tenferro_ad::Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
+        tenferro_ad::Error::TensorRuntime(tenferro_tensor::Error::Validation {
             op: "concatenate",
             ..
         })
@@ -242,10 +242,9 @@ fn eager_reductions_and_reverse_validate_axes_before_ad_recording() {
     let out_of_bounds = x.reduce_sum(&[2]).unwrap_err();
     assert!(matches!(
         out_of_bounds,
-        tenferro_ad::Error::TensorRuntime(tenferro_tensor::Error::AxisOutOfBounds {
+        tenferro_ad::Error::TensorRuntime(tenferro_tensor::Error::Validation {
             op: "EagerTensor::reduce_sum",
-            axis: 2,
-            rank: 2,
+            source: tenferro_tensor::ValidationError::AxisOutOfBounds { axis: 2, rank: 2 },
         })
     ));
 
@@ -259,10 +258,12 @@ fn eager_reductions_and_reverse_validate_axes_before_ad_recording() {
         assert!(
             matches!(
                 err,
-                tenferro_ad::Error::TensorRuntime(tenferro_tensor::Error::DuplicateAxis {
-                    axis: 0,
-                    role: "axis",
-                    ..
+                tenferro_ad::Error::TensorRuntime(tenferro_tensor::Error::Validation {
+                    op: _,
+                    source: tenferro_tensor::ValidationError::DuplicateAxis {
+                        axis: 0,
+                        role: "axis",
+                    },
                 })
             ),
             "{err}"
@@ -386,7 +387,7 @@ fn eager_dot_general_with_conj_validates_config_before_untracked_backend_dispatc
 
     assert!(matches!(
         err,
-        tenferro_ad::Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
+        tenferro_ad::Error::TensorRuntime(tenferro_tensor::Error::Validation {
             op: "EagerTensor::dot_general_with_conj",
             ..
         })

--- a/crates/tenferro-ad/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-ad/tests/integration/eager_tensor.rs
@@ -4,8 +4,10 @@ use tenferro_ad::{EagerRuntime, EagerTensor};
 use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{
-    DType, DotGeneralConfig, GatherConfig, PadConfig, SliceConfig, Tensor, TensorRead, TensorView,
+    DType, DotGeneralConfig, Error as RuntimeError, ErrorPhase, GatherConfig, PadConfig,
+    SliceConfig, Tensor, TensorRead, TensorView,
 };
+use tenferro_tensor::{Error as TensorError, ErrorKind, ValidationError, ValidationKind};
 
 #[path = "eager_tensor/context_and_promotion.rs"]
 mod context_and_promotion;
@@ -385,12 +387,14 @@ fn eager_dot_general_with_conj_validates_config_before_untracked_backend_dispatc
         .dot_general_with_conj(&rhs, &config, true, false)
         .unwrap_err();
 
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::AxisOutOfBounds)
+    );
+    assert_eq!(err.phase(), Some(ErrorPhase::Execution));
     assert!(matches!(
         err,
-        tenferro_ad::Error::TensorRuntime(tenferro_tensor::Error::Validation {
-            op: "EagerTensor::dot_general_with_conj",
-            ..
-        })
+        RuntimeError::TensorRuntime(TensorError::Validation { .. })
     ));
 }
 
@@ -507,8 +511,21 @@ fn eager_index_select_rejects_invalid_axis_and_position() {
 #[test]
 fn eager_stack_rejects_empty_mismatched_shapes_and_invalid_axis() {
     let empty: [&EagerTensor; 0] = [];
-    let empty_err = EagerTensor::stack(&empty, 0).err().unwrap().to_string();
-    assert!(empty_err.contains("stack requires at least one input"));
+    let empty_err = EagerTensor::stack(&empty, 0).err().unwrap();
+    assert_eq!(
+        empty_err.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
+    );
+    assert!(matches!(
+        empty_err,
+        RuntimeError::TensorRuntime(TensorError::Validation {
+            source: ValidationError::InvalidArgument {
+                argument: "inputs",
+                ..
+            },
+            ..
+        })
+    ));
 
     let a = EagerTensor::from_tensor_in(
         Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
@@ -520,11 +537,31 @@ fn eager_stack_rejects_empty_mismatched_shapes_and_invalid_axis() {
         test_ctx(),
     )
     .unwrap();
-    let shape_err = EagerTensor::stack(&[&a, &b], -1).err().unwrap().to_string();
-    assert!(shape_err.contains("shape mismatch"), "got: {shape_err}");
+    let shape_err = EagerTensor::stack(&[&a, &b], -1).err().unwrap();
+    assert_eq!(
+        shape_err.kind(),
+        ErrorKind::Validation(ValidationKind::ShapeMismatch)
+    );
+    assert!(matches!(
+        shape_err,
+        RuntimeError::TensorRuntime(TensorError::Validation {
+            source: ValidationError::ShapeMismatch(_),
+            ..
+        })
+    ));
 
-    let axis_err = EagerTensor::stack(&[&a], 2).err().unwrap().to_string();
-    assert!(axis_err.contains("axis"), "got: {axis_err}");
+    let axis_err = EagerTensor::stack(&[&a], 2).err().unwrap();
+    assert_eq!(
+        axis_err.kind(),
+        ErrorKind::Validation(ValidationKind::AxisOutOfBounds)
+    );
+    assert!(matches!(
+        axis_err,
+        RuntimeError::TensorRuntime(TensorError::Validation {
+            source: ValidationError::AxisOutOfBounds { .. },
+            ..
+        })
+    ));
 
     let c = EagerTensor::from_tensor_in(
         Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(),

--- a/crates/tenferro-ad/tests/integration/extension_op.rs
+++ b/crates/tenferro-ad/tests/integration/extension_op.rs
@@ -420,10 +420,11 @@ impl ExtensionOp for TestSwap {
         let lhs_dtype = ctx.input_dtype(0)?;
         let rhs_dtype = ctx.input_dtype(1)?;
         if lhs_dtype != rhs_dtype {
-            return Err(tenferro_tensor::Error::InvalidConfig {
-                op: self.family_id(),
-                message: "TestSwap expects matching dtypes".into(),
-            });
+            return Err(tenferro_tensor::Error::invalid_argument(
+                self.family_id(),
+                "dtype",
+                "TestSwap expects matching dtypes",
+            ));
         }
         Ok(vec![
             (rhs_dtype, ctx.input_shape(1)?.to_vec()),

--- a/crates/tenferro-ad/tests/integration/extension_op.rs
+++ b/crates/tenferro-ad/tests/integration/extension_op.rs
@@ -36,8 +36,8 @@ use tenferro_ops::ext_op::ExtensionOp;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::{ShapeGuardContext, ShapeRelation, SymDim};
 use tenferro_runtime::extension::{apply, HostReferenceRuntime};
-use tenferro_runtime::{Error as RuntimeError, GraphExecutor, Tensor, TracedTensor};
-use tenferro_tensor::{DType, TensorBackend, TypedTensor};
+use tenferro_runtime::{Error as RuntimeError, ErrorPhase, GraphExecutor, Tensor, TracedTensor};
+use tenferro_tensor::{DType, TensorBackend, TypedTensor, ValidationError};
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult, PrimitiveTransposeInput};
 
 // ----------------------------------------------------------------------

--- a/crates/tenferro-ad/tests/integration/extension_op/api_and_registry.rs
+++ b/crates/tenferro-ad/tests/integration/extension_op/api_and_registry.rs
@@ -25,7 +25,17 @@ fn apply_eager_rejects_empty_input_list() {
         Err(err) => err,
     };
 
-    assert!(err.to_string().contains("requires at least one input"));
+    assert!(matches!(
+        err,
+        RuntimeError::Validation {
+            phase: ErrorPhase::Execution,
+            source: ValidationError::InvalidArgument {
+                argument: "inputs",
+                ..
+            },
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/crates/tenferro-ad/tests/integration/fallible_api.rs
+++ b/crates/tenferro-ad/tests/integration/fallible_api.rs
@@ -201,6 +201,9 @@ fn eager_binary_methods_return_shape_errors() {
 
     assert!(matches!(
         err,
-        tenferro_ad::Error::TensorRuntime(TensorError::ShapeMismatch { op: "add", .. })
+        tenferro_ad::Error::TensorRuntime(TensorError::Validation {
+            op: "add",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        })
     ));
 }

--- a/crates/tenferro-ad/tests/integration/numpy_api.rs
+++ b/crates/tenferro-ad/tests/integration/numpy_api.rs
@@ -6,9 +6,10 @@ use tenferro_ad::{EagerRuntime, EagerTensor};
 use tenferro_cpu::CpuBackend;
 use tenferro_ops::{ext_op::ExtensionOp, std_tensor_op::StdTensorOp, SymDim};
 use tenferro_runtime::{
-    CompareDir, DType, GraphCompiler, GraphExecutor, Tensor, TensorOpsExt, TracedTensor,
-    TypedTensor, TypedTensorMaskOpsExt, TypedTensorOpsExt,
+    CompareDir, DType, Error as RuntimeError, ErrorPhase, GraphCompiler, GraphExecutor, Tensor,
+    TensorOpsExt, TracedTensor, TypedTensor, TypedTensorMaskOpsExt, TypedTensorOpsExt,
 };
+use tenferro_tensor::ValidationError;
 
 #[derive(Clone, Debug)]
 struct TestExtensionOp;
@@ -286,12 +287,14 @@ fn eager_tensor_methods_cover_conversion_matmul_and_extension_standard_op() {
     )
     .err()
     .unwrap();
-    assert!(
-        extension_err
-            .to_string()
-            .contains("does not accept Extension ops"),
-        "got: {extension_err}"
-    );
+    assert!(matches!(
+        extension_err,
+        RuntimeError::Validation {
+            phase: ErrorPhase::Execution,
+            source: ValidationError::InvalidArgument { argument: "op", .. },
+            ..
+        }
+    ));
 
     let a = EagerTensor::from_tensor_in(
         Tensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),

--- a/crates/tenferro-ad/tests/integration/primitive_ops.rs
+++ b/crates/tenferro-ad/tests/integration/primitive_ops.rs
@@ -2,9 +2,10 @@ use crate::support;
 use support::{run_many_traced_with, RunTraced};
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::traced::TracedTensor;
-use tenferro_runtime::DType;
-use tenferro_runtime::GraphExecutor;
-use tenferro_tensor::{DotGeneralConfig, Tensor, TypedTensor};
+use tenferro_runtime::{DType, Error as RuntimeError, GraphExecutor};
+use tenferro_tensor::{
+    DotGeneralConfig, ErrorKind, Tensor, TypedTensor, ValidationError, ValidationKind,
+};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
@@ -310,11 +311,18 @@ fn traced_stack_rejects_empty_mismatched_invalid_axis_and_symbolic_shapes() {
     let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2], vec![1.0, 2.0])).unwrap();
     let b =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![3.0, 4.0, 5.0])).unwrap();
-    let shape_err = TracedTensor::stack(&[&a, &b], -1)
-        .err()
-        .unwrap()
-        .to_string();
-    assert!(shape_err.contains("shape mismatch"), "got: {shape_err}");
+    let shape_err = TracedTensor::stack(&[&a, &b], -1).err().unwrap();
+    assert_eq!(
+        shape_err.kind(),
+        ErrorKind::Validation(ValidationKind::ShapeMismatch)
+    );
+    assert!(matches!(
+        shape_err,
+        RuntimeError::Validation {
+            source: ValidationError::ShapeMismatch(_),
+            ..
+        }
+    ));
 
     let axis_err = TracedTensor::stack(&[&a], 2).err().unwrap().to_string();
     assert!(axis_err.contains("axis"), "got: {axis_err}");

--- a/crates/tenferro-ad/tests/integration/support/mod.rs
+++ b/crates/tenferro-ad/tests/integration/support/mod.rs
@@ -4,11 +4,25 @@ use tenferro_runtime::error::Result;
 use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TensorBackend, TracedTensor};
 
 pub trait RunTraced {
+    /// Compile and execute one traced output.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`tenferro_runtime::Error::Validation`] for invalid graph
+    /// metadata, [`Error::RuntimeState`] for missing executor state, or a
+    /// typed backend error from execution.
     fn run_with<B: TensorBackend + 'static>(
         &self,
         executor: &mut GraphExecutor<B>,
     ) -> Result<Tensor>;
 
+    /// Compile and execute one traced output with automatic input specs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_runtime::Error::Validation`] for dtype/rank/shape
+    /// binding mismatches, [`Error::RuntimeState`] for missing bindings or
+    /// executor state, or a typed backend error from execution.
     fn run_with_inputs_auto<B: TensorBackend + 'static>(
         &self,
         executor: &mut GraphExecutor<B>,
@@ -46,6 +60,13 @@ impl RunTraced for TracedTensor {
     }
 }
 
+/// Compile and execute several traced outputs with one executor.
+///
+/// # Errors
+///
+/// Returns [`tenferro_runtime::Error::Validation`] for inconsistent graph
+/// metadata or duplicate bindings, [`Error::RuntimeState`] for missing
+/// executor state, or a typed backend error from execution.
 pub fn run_many_traced_with<B: TensorBackend + 'static>(
     executor: &mut GraphExecutor<B>,
     outputs: &[&TracedTensor],

--- a/crates/tenferro-ad/tests/integration/sym_dim.rs
+++ b/crates/tenferro-ad/tests/integration/sym_dim.rs
@@ -4,6 +4,7 @@ use tenferro_cpu::CpuBackend;
 use tenferro_runtime::error::Error;
 use tenferro_runtime::GraphExecutor;
 use tenferro_runtime::{SymDim, Tensor, TracedTensor, TypedTensor};
+use tenferro_tensor::{ErrorKind, ValidationKind};
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
     Tensor::F64(TypedTensor::from_vec_col_major(shape, data).unwrap())
@@ -84,9 +85,12 @@ fn reshape_sym_rejects_symbolic_dims_from_another_tensor() {
         Ok(_) => panic!("reshape_sym should reject symbolic dimensions from another tensor"),
         Err(err) => err,
     };
-    assert!(
-        matches!(err, Error::Internal(message) if message.contains("unknown symbolic tensor id"))
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
     );
+    assert_eq!(err.phase(), Some(tenferro_runtime::ErrorPhase::GraphBuild));
+    assert!(matches!(err, Error::SymbolicShapeConversion { .. }));
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/affinity.rs
+++ b/crates/tenferro-cpu/src/affinity.rs
@@ -1,23 +1,82 @@
 use std::num::NonZeroUsize;
 
+use thiserror::Error;
+
 use crate::{CpuId, CpuSet};
 
+/// Typed failures from the operating-system CPU-affinity boundary.
+///
+/// These errors stay CPU-local until a context-construction failure is
+/// reported to the tensor API, where the complete value is retained as the
+/// source of [`crate::CpuContextError`].
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::CpuAffinityError;
+///
+/// let error = CpuAffinityError::UnsupportedPlatform;
+/// assert!(error.to_string().contains("unsupported"));
+/// ```
+#[derive(Debug, Error)]
+pub enum CpuAffinityError {
+    /// Constructing the one-CPU mask failed because the CPU set was invalid.
+    #[error("CPU affinity set is invalid: {0}")]
+    CpuSet(#[from] crate::CpuSetError),
+    /// The operating system rejected the requested affinity mask.
+    #[error("setting thread affinity failed: {source}")]
+    Set {
+        #[source]
+        source: std::io::Error,
+    },
+    /// Querying the current worker affinity failed.
+    #[error("querying worker affinity failed: {source}")]
+    Query {
+        #[source]
+        source: std::io::Error,
+    },
+    /// The platform has no supported thread-affinity implementation.
+    #[error("setting thread affinity is unsupported on this platform")]
+    UnsupportedPlatform,
+    /// The operating system did not expose a process affinity mask.
+    #[error("failed to verify worker affinity")]
+    VerificationUnavailable,
+    /// The returned affinity did not contain exactly the requested worker.
+    #[error("verification returned affinity {observed:?}")]
+    Verification { observed: Vec<CpuId> },
+    /// The requested CPU would overflow the affinity-mask size calculation.
+    #[error("affinity mask size overflow")]
+    MaskSizeOverflow,
+    /// The requested CPU exceeds the supported mask allocation limit.
+    #[error("CPU {cpu} exceeds supported affinity mask size of {max_bytes} bytes")]
+    MaskTooLarge { cpu: CpuId, max_bytes: usize },
+    /// Allocating the operating-system affinity mask failed.
+    #[error("failed to allocate affinity mask: {source}")]
+    MaskAllocation {
+        #[source]
+        source: std::collections::TryReserveError,
+    },
+    /// The affinity mask had no CPU entries.
+    #[error("cannot set an empty affinity mask")]
+    EmptyMask,
+}
+
 pub(crate) trait ThreadAffinity: Clone + Send + Sync + 'static {
-    fn pin_current(&self, cpu: CpuId) -> Result<CpuSet, String>;
+    fn pin_current(&self, cpu: CpuId) -> Result<CpuSet, CpuAffinityError>;
 }
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct SystemThreadAffinity;
 
 impl ThreadAffinity for SystemThreadAffinity {
-    fn pin_current(&self, cpu: CpuId) -> Result<CpuSet, String> {
-        set_current_thread_affinity(&CpuSet::new([cpu]).map_err(|err| err.to_string())?)?;
-        process_cpu_affinity().ok_or_else(|| "failed to verify worker affinity".to_owned())
+    fn pin_current(&self, cpu: CpuId) -> Result<CpuSet, CpuAffinityError> {
+        set_current_thread_affinity(&CpuSet::new([cpu])?)?;
+        process_cpu_affinity().ok_or(CpuAffinityError::VerificationUnavailable)
     }
 }
 
 #[cfg(all(test, target_os = "linux"))]
-pub(crate) fn current_cpu() -> Result<CpuId, String> {
+pub(crate) fn current_cpu() -> Result<CpuId, CpuAffinityError> {
     unsafe extern "C" {
         fn sched_getcpu() -> i32;
     }
@@ -26,10 +85,12 @@ pub(crate) fn current_cpu() -> Result<CpuId, String> {
     let cpu = unsafe { sched_getcpu() };
     usize::try_from(cpu)
         .map(CpuId::new)
-        .map_err(|_| std::io::Error::last_os_error().to_string())
+        .map_err(|_| CpuAffinityError::Query {
+            source: std::io::Error::last_os_error(),
+        })
 }
 
-fn set_current_thread_affinity(cpus: &CpuSet) -> Result<(), String> {
+fn set_current_thread_affinity(cpus: &CpuSet) -> Result<(), CpuAffinityError> {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {
         unsafe extern "C" {
@@ -47,17 +108,19 @@ fn set_current_thread_affinity(cpus: &CpuSet) -> Result<(), String> {
             unsafe { sched_setaffinity(0, mask.len(), mask.as_ptr().cast::<core::ffi::c_void>()) };
         (rc == 0)
             .then_some(())
-            .ok_or_else(|| std::io::Error::last_os_error().to_string())
+            .ok_or_else(|| CpuAffinityError::Set {
+                source: std::io::Error::last_os_error(),
+            })
     }
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
     {
         let _ = cpus;
-        Err("setting thread affinity is unsupported on this platform".to_owned())
+        Err(CpuAffinityError::UnsupportedPlatform)
     }
 }
 
 #[cfg(any(target_os = "linux", target_os = "android", test))]
-fn build_affinity_mask(cpus: &CpuSet) -> Result<Vec<u8>, String> {
+fn build_affinity_mask(cpus: &CpuSet) -> Result<Vec<u8>, CpuAffinityError> {
     const MIN_MASK_BYTES: usize = 128;
     const MAX_MASK_BYTES: usize = 1 << 20;
 
@@ -65,22 +128,23 @@ fn build_affinity_mask(cpus: &CpuSet) -> Result<Vec<u8>, String> {
         .as_slice()
         .last()
         .copied()
-        .ok_or_else(|| "cannot set an empty affinity mask".to_owned())?;
+        .ok_or(CpuAffinityError::EmptyMask)?;
     let required_bytes = highest_cpu
         .as_usize()
         .checked_div(u8::BITS as usize)
         .and_then(|index| index.checked_add(1))
-        .ok_or_else(|| "affinity mask size overflow".to_owned())?
+        .ok_or(CpuAffinityError::MaskSizeOverflow)?
         .max(MIN_MASK_BYTES);
     if required_bytes > MAX_MASK_BYTES {
-        return Err(format!(
-            "CPU {highest_cpu} exceeds supported affinity mask size of {MAX_MASK_BYTES} bytes"
-        ));
+        return Err(CpuAffinityError::MaskTooLarge {
+            cpu: highest_cpu,
+            max_bytes: MAX_MASK_BYTES,
+        });
     }
 
     let mut mask = Vec::new();
     mask.try_reserve_exact(required_bytes)
-        .map_err(|error| format!("failed to allocate affinity mask: {error}"))?;
+        .map_err(|source| CpuAffinityError::MaskAllocation { source })?;
     mask.resize(required_bytes, 0u8);
     for cpu in cpus.as_slice() {
         let byte = cpu.as_usize() / u8::BITS as usize;

--- a/crates/tenferro-cpu/src/affinity/tests.rs
+++ b/crates/tenferro-cpu/src/affinity/tests.rs
@@ -25,7 +25,7 @@ fn affinity_mask_preserves_sparse_logical_cpu_ids() {
 fn affinity_mask_rejects_extreme_cpu_ids_before_allocation() {
     let cpus = CpuSet::new([CpuId::new(usize::MAX)]).unwrap();
     let error = build_affinity_mask(&cpus).unwrap_err();
-    assert!(error.contains("exceeds supported affinity mask"));
+    assert!(matches!(error, CpuAffinityError::MaskTooLarge { .. }));
 }
 
 #[test]
@@ -44,10 +44,7 @@ fn affinity_mask_builds_sparse_logical_cpu_ids() {
 fn system_thread_affinity_reports_unsupported_platform() {
     let error = SystemThreadAffinity.pin_current(CpuId::new(0)).unwrap_err();
 
-    assert_eq!(
-        error,
-        "setting thread affinity is unsupported on this platform"
-    );
+    assert!(matches!(error, CpuAffinityError::UnsupportedPlatform));
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/crates/tenferro-cpu/src/analytic.rs
+++ b/crates/tenferro-cpu/src/analytic.rs
@@ -214,7 +214,7 @@ where
     // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
     map_into(&mut out.view_mut(), &typed_view(op, input)?, f)
-        .map_err(|err| crate::Error::backend_failure(op, err))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -231,7 +231,7 @@ where
     // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
     map_into(&mut out.view_mut(), &typed_view_from_view(op, input)?, f)
-        .map_err(|err| crate::Error::backend_failure(op, err))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -276,10 +276,11 @@ fn require_cpu_capability(
     if supported {
         Ok(())
     } else {
-        Err(crate::Error::unsupported_op_dtype(
+        Err(crate::Error::unsupported_dtype_conversion(
             op,
             dtype,
-            BackendId::Cpu,
+            dtype,
+            format!("CPU backend does not support this operation for {dtype:?}"),
         ))
     }
 }
@@ -293,7 +294,7 @@ where
     T: Copy + Send + Sync,
 {
     reduce(view, pred, |lhs, rhs| lhs || rhs, false)
-        .map_err(|err| crate::Error::backend_failure(op, err))
+        .map_err(|err| crate::Error::backend_source(op, err))
 }
 
 fn ensure_nonnegative_integer_exponents<T>(
@@ -304,7 +305,7 @@ where
     T: IntegerPowElem,
 {
     if strided_view_contains(op, rhs, |value| value.is_negative_exponent())? {
-        return Err(crate::Error::negative_integer_exponent(op, T::dtype()));
+        return Err(crate::cpu_negative_integer_exponent(op, T::dtype()));
     }
     Ok(())
 }
@@ -327,11 +328,11 @@ where
     } else if rhs.shape().is_empty() {
         lhs.shape()
     } else {
-        return Err(crate::Error::ShapeMismatch {
+        return Err(crate::Error::shape_mismatch(
             op,
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        });
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ));
     };
     // SAFETY: the selected map kernel overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, output_shape) }?;
@@ -342,19 +343,19 @@ where
             &typed_view_from_view(op, rhs)?,
             |x, y| x.pow_elem(y),
         )
-        .map_err(|err| crate::Error::backend_failure(op, err))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
     } else if lhs.shape().is_empty() {
         let scalar = typed_view_from_view(op, lhs)?.get(&[]);
         map_into(&mut out.view_mut(), &typed_view_from_view(op, rhs)?, |x| {
             scalar.pow_elem(x)
         })
-        .map_err(|err| crate::Error::backend_failure(op, err))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
     } else {
         let scalar = typed_view_from_view(op, rhs)?.get(&[]);
         map_into(&mut out.view_mut(), &typed_view_from_view(op, lhs)?, |x| {
             x.pow_elem(scalar)
         })
-        .map_err(|err| crate::Error::backend_failure(op, err))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
     }
     Ok(tensor_from_array(out))
 }
@@ -467,11 +468,11 @@ pub(crate) fn pow_with_pool(
         }
         (Tensor::C32(a), Tensor::C32(b)) => Ok(Tensor::C32(typed_pow_with_pool(buffers, a, b)?)),
         (Tensor::C64(a), Tensor::C64(b)) => Ok(Tensor::C64(typed_pow_with_pool(buffers, a, b)?)),
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "pow",
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        }),
+        _ => Err(crate::Error::dtype_mismatch(
+            "pow",
+            lhs.dtype(),
+            rhs.dtype(),
+        )),
     }
 }
 
@@ -501,11 +502,7 @@ pub(crate) fn pow_read_with_pool(
         (AnalyticReadView::C64(a), AnalyticReadView::C64(b)) => Ok(Tensor::C64(
             typed_pow_view_with_pool("pow", buffers, &a, &b)?,
         )),
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "pow",
-            lhs: lhs_dtype,
-            rhs: rhs_dtype,
-        }),
+        _ => Err(crate::Error::dtype_mismatch("pow", lhs_dtype, rhs_dtype)),
     }
 }
 
@@ -524,11 +521,11 @@ where
     } else if rhs.shape().is_empty() {
         lhs.shape()
     } else {
-        return Err(crate::Error::ShapeMismatch {
-            op: "pow",
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "pow",
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ));
     };
     // SAFETY: the selected map kernel overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, output_shape) }?;
@@ -539,19 +536,19 @@ where
             &typed_view("pow", rhs)?,
             |x, y| x.pow_elem(y),
         )
-        .map_err(|err| crate::Error::backend_failure("pow", err))?;
+        .map_err(|err| crate::Error::backend_source("pow", err))?;
     } else if lhs.shape().is_empty() {
         let scalar = typed_view("pow", lhs)?.get(&[]);
         map_into(&mut out.view_mut(), &typed_view("pow", rhs)?, |x| {
             scalar.pow_elem(x)
         })
-        .map_err(|err| crate::Error::backend_failure("pow", err))?;
+        .map_err(|err| crate::Error::backend_source("pow", err))?;
     } else {
         let scalar = typed_view("pow", rhs)?.get(&[]);
         map_into(&mut out.view_mut(), &typed_view("pow", lhs)?, |x| {
             x.pow_elem(scalar)
         })
-        .map_err(|err| crate::Error::backend_failure("pow", err))?;
+        .map_err(|err| crate::Error::backend_source("pow", err))?;
     }
     Ok(tensor_from_array(out))
 }

--- a/crates/tenferro-cpu/src/analytic.rs
+++ b/crates/tenferro-cpu/src/analytic.rs
@@ -276,9 +276,8 @@ fn require_cpu_capability(
     if supported {
         Ok(())
     } else {
-        Err(crate::Error::unsupported_dtype_conversion(
+        Err(crate::Error::unsupported_dtype(
             op,
-            dtype,
             dtype,
             format!("CPU backend does not support this operation for {dtype:?}"),
         ))

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -287,7 +287,7 @@ pub enum CpuExecutionMode {
 /// let error = CpuBackend::with_threads(0).unwrap_err();
 /// assert!(matches!(error, CpuBackendError::Tensor(_)));
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum CpuBackendError {
     /// CPU context configuration or provider selection failed.
     #[error(transparent)]
@@ -332,7 +332,7 @@ impl From<CpuBackendError> for crate::Error {
     fn from(error: CpuBackendError) -> Self {
         match error {
             CpuBackendError::Tensor(error) => error,
-            CpuBackendError::Placement { op, source } => Self::backend_failure(op, source),
+            CpuBackendError::Placement { op, source } => Self::backend_source(op, source),
         }
     }
 }
@@ -487,10 +487,11 @@ fn ensure_cpu_backend_kind_available(kind: CpuBackendKind, op: &'static str) -> 
             }
             #[cfg(not(feature = "cpu-faer"))]
             {
-                Err(crate::Error::InvalidConfig {
+                Err(crate::Error::invalid_argument(
                     op,
-                    message: "CpuBackendKind::Faer requires the cpu-faer feature".to_string(),
-                })
+                    "configuration",
+                    "CpuBackendKind::Faer requires the cpu-faer feature".to_string(),
+                ))
             }
         }
         CpuBackendKind::Blas => {
@@ -500,10 +501,11 @@ fn ensure_cpu_backend_kind_available(kind: CpuBackendKind, op: &'static str) -> 
             }
             #[cfg(not(feature = "cpu-blas"))]
             {
-                Err(crate::Error::InvalidConfig {
+                Err(crate::Error::invalid_argument(
                     op,
-                    message: "CpuBackendKind::Blas requires the cpu-blas feature".to_string(),
-                })
+                    "configuration",
+                    "CpuBackendKind::Blas requires the cpu-blas feature".to_string(),
+                ))
             }
         }
     }
@@ -511,24 +513,21 @@ fn ensure_cpu_backend_kind_available(kind: CpuBackendKind, op: &'static str) -> 
 
 #[cfg(not(feature = "cpu-tblis-provider"))]
 pub(crate) fn tblis_required_unavailable(op: &'static str) -> crate::Error {
-    crate::Error::InvalidConfig {
+    crate::Error::invalid_argument(
         op,
-        message: "DotGeneralProvider::TblisRequired requires cpu-tblis or cpu-tblis-linked"
-            .to_string(),
-    }
+        "configuration",
+        "DotGeneralProvider::TblisRequired requires cpu-tblis or cpu-tblis-linked".to_string(),
+    )
 }
 
 #[cfg(feature = "cpu-tblis-provider")]
 pub(crate) fn tblis_required_not_applicable(op: &'static str) -> crate::Error {
-    crate::Error::InvalidConfig {
-        op,
-        message: "DotGeneralProvider::TblisRequired could not execute this contraction with TBLIS; the TBLIS runtime may be unavailable or the adapter could not build a safe plan".to_string(),
-    }
+    crate::Error::invalid_argument(op, "configuration", "DotGeneralProvider::TblisRequired could not execute this contraction with TBLIS; the TBLIS runtime may be unavailable or the adapter could not build a safe plan".to_string())
 }
 
 fn constructor_tensor_error(op: &'static str, error: crate::Error) -> CpuBackendError {
     CpuBackendError::Tensor(match error {
-        crate::Error::InvalidConfig { message, .. } => crate::Error::InvalidConfig { op, message },
+        crate::Error::Validation { source, .. } => crate::Error::validation(op, source),
         crate::Error::BackendFailure { message, .. } => crate::Error::backend_failure(op, message),
         error => error,
     })
@@ -538,10 +537,11 @@ fn constructor_tensor_error(op: &'static str, error: crate::Error) -> CpuBackend
 // direct call site for one provider.
 #[allow(dead_code)]
 pub(super) fn unavailable_cpu_backend_kind(kind: CpuBackendKind, op: &'static str) -> crate::Error {
-    crate::Error::InvalidConfig {
+    crate::Error::invalid_argument(
         op,
-        message: format!("CPU backend kind {} is not compiled in", kind.name()),
-    }
+        "configuration",
+        format!("CPU backend kind {} is not compiled in", kind.name()),
+    )
 }
 
 struct CpuBackendState {
@@ -1003,6 +1003,11 @@ impl CpuBackend {
     /// }
     /// # Ok::<(), tenferro_cpu::CpuPlacementError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuPlacementError`] when the requested placement is not
+    /// available for this backend or its affinity cannot be configured.
     pub fn for_placement(&self, requested: CpuPlacement) -> Result<Self, CpuPlacementError> {
         self.for_placement_with_affinity(
             requested,
@@ -2081,11 +2086,11 @@ impl BackendCachedDot for CpuBackend {
                             .map(|result| result.map(Tensor::C64))
                     }
                     _ if lhs.dtype() == rhs.dtype() => Ok(None),
-                    _ => Err(crate::Error::DTypeMismatch {
-                        op: "dot_general",
-                        lhs: lhs.dtype(),
-                        rhs: rhs.dtype(),
-                    }),
+                    _ => Err(crate::Error::dtype_mismatch(
+                        "dot_general",
+                        lhs.dtype(),
+                        rhs.dtype(),
+                    )),
                 })?;
                 if let Some(result) = self.tblis_not_applicable("dot_general", direct)? {
                     return Ok(result);
@@ -2147,11 +2152,11 @@ impl BackendCachedDot for CpuBackend {
                                 config,
                             )
                             .map(Tensor::C64),
-                            _ => Err(crate::Error::DTypeMismatch {
-                                op: "dot_general",
-                                lhs: lhs.dtype(),
-                                rhs: rhs.dtype(),
-                            }),
+                            _ => Err(crate::Error::dtype_mismatch(
+                                "dot_general",
+                                lhs.dtype(),
+                                rhs.dtype(),
+                            )),
                         }
                     })
                 }
@@ -2180,11 +2185,11 @@ impl BackendCachedDot for CpuBackend {
                             gemm::dot_general_blas_cached(buffers, cache, cache_slot, a, b, config)
                                 .map(Tensor::C64)
                         }
-                        _ => Err(crate::Error::DTypeMismatch {
-                            op: "dot_general",
-                            lhs: lhs.dtype(),
-                            rhs: rhs.dtype(),
-                        }),
+                        _ => Err(crate::Error::dtype_mismatch(
+                            "dot_general",
+                            lhs.dtype(),
+                            rhs.dtype(),
+                        )),
                     })
                 }
                 #[cfg(not(feature = "cpu-blas"))]
@@ -2226,11 +2231,11 @@ impl BackendCachedDot for CpuBackend {
                     )
                     .map(|result| result.map(Tensor::C64)),
                     _ if lhs.dtype() == rhs.dtype() => Ok(None),
-                    _ => Err(crate::Error::DTypeMismatch {
-                        op: "dot_general",
-                        lhs: lhs.dtype(),
-                        rhs: rhs.dtype(),
-                    }),
+                    _ => Err(crate::Error::dtype_mismatch(
+                        "dot_general",
+                        lhs.dtype(),
+                        rhs.dtype(),
+                    )),
                 })?;
                 if let Some(result) = self.tblis_not_applicable("dot_general", direct)? {
                     return Ok(result);
@@ -2308,11 +2313,11 @@ impl BackendCachedDot for CpuBackend {
                                 )
                                 .map(Tensor::C64)
                             }
-                            _ => Err(crate::Error::DTypeMismatch {
-                                op: "dot_general",
-                                lhs: lhs.dtype(),
-                                rhs: rhs.dtype(),
-                            }),
+                            _ => Err(crate::Error::dtype_mismatch(
+                                "dot_general",
+                                lhs.dtype(),
+                                rhs.dtype(),
+                            )),
                         }
                     })
                 }
@@ -2349,11 +2354,11 @@ impl BackendCachedDot for CpuBackend {
                             )
                             .map(Tensor::C64)
                         }
-                        _ => Err(crate::Error::DTypeMismatch {
-                            op: "dot_general",
-                            lhs: lhs.dtype(),
-                            rhs: rhs.dtype(),
-                        }),
+                        _ => Err(crate::Error::dtype_mismatch(
+                            "dot_general",
+                            lhs.dtype(),
+                            rhs.dtype(),
+                        )),
                     })
                 }
                 #[cfg(not(feature = "cpu-blas"))]

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -13,7 +13,10 @@ use crate::arbiter::{
 };
 use crate::buffer_pool::{BufferPool, BufferPoolStats, PoolScalar};
 use crate::engine::{CpuEngine, EngineResources};
-use crate::placement::{resolve_placement, resolve_placement_with_affinity, ResolvedCpuExecution};
+use crate::placement::{
+    resolve_placement, resolve_placement_with_affinity, CpuEngineConstructionError,
+    ResolvedCpuExecution,
+};
 use crate::{
     discover_cpu_topology, CpuId, CpuPlacement, CpuPlacementError, CpuSet, CpuTopology,
     CpuTopologyError, NumaNodeId, ResolvedCpuPlacement,
@@ -332,7 +335,21 @@ impl From<CpuBackendError> for crate::Error {
     fn from(error: CpuBackendError) -> Self {
         match error {
             CpuBackendError::Tensor(error) => error,
-            CpuBackendError::Placement { op, source } => Self::backend_source(op, source),
+            CpuBackendError::Placement { op, source } => match source {
+                CpuPlacementError::TopologyDiscovery { .. }
+                | CpuPlacementError::ManagedAffinityUnavailable { .. }
+                | CpuPlacementError::NumaDiscoveryUnavailable { .. }
+                | CpuPlacementError::UnknownNumaNode { .. } => {
+                    Self::runtime_state_source(op, source)
+                }
+                CpuPlacementError::ExternalProviderAffinityUnmanaged { .. } => {
+                    Self::extension(op, "cpu", crate::ErrorKind::Unsupported, source)
+                }
+                CpuPlacementError::EngineConstruction { .. } => Self::backend_source(op, source),
+                CpuPlacementError::InternalState { .. } => {
+                    Self::extension(op, "cpu", crate::ErrorKind::Internal, source)
+                }
+            },
         }
     }
 }
@@ -528,7 +545,6 @@ pub(crate) fn tblis_required_not_applicable(op: &'static str) -> crate::Error {
 fn constructor_tensor_error(op: &'static str, error: crate::Error) -> CpuBackendError {
     CpuBackendError::Tensor(match error {
         crate::Error::Validation { source, .. } => crate::Error::validation(op, source),
-        crate::Error::BackendFailure { message, .. } => crate::Error::backend_failure(op, message),
         error => error,
     })
 }
@@ -681,7 +697,7 @@ impl CpuBackend {
                 CpuPlacementError::EngineConstruction {
                     requested: CpuPlacement::Auto,
                     backend: kind,
-                    message: error.to_string(),
+                    source: CpuEngineConstructionError::Tensor(error),
                 }
             })?;
             Ok(Self::compatibility_with_topology(
@@ -702,7 +718,7 @@ impl CpuBackend {
                     .map_err(|error| CpuPlacementError::EngineConstruction {
                         requested: CpuPlacement::Auto,
                         backend: kind,
-                        message: error.to_string(),
+                        source: CpuEngineConstructionError::Context(error),
                     })?,
             );
             let all_allowed = OnceLock::new();
@@ -824,8 +840,9 @@ impl CpuBackend {
     ///
     /// # Errors
     ///
-    /// Returns an error when the provider is unavailable or CPU topology and
-    /// placement initialization fails.
+    /// Returns [`CpuBackendError::Tensor`] when the provider is unavailable or
+    /// its configuration is invalid, and [`CpuBackendError::Placement`] when
+    /// CPU topology discovery or placement initialization fails.
     pub fn with_kind(kind: CpuBackendKind) -> Result<Self, CpuBackendError> {
         let op = "CpuBackend::with_kind";
         ensure_cpu_backend_kind_available(kind, op)
@@ -853,8 +870,10 @@ impl CpuBackend {
     ///
     /// # Errors
     ///
-    /// Returns an error when the environment-driven thread configuration is
-    /// invalid or CPU topology and placement initialization fails.
+    /// Returns [`CpuBackendError::Tensor`] when `RAYON_NUM_THREADS` is zero,
+    /// malformed, or the compiled provider cannot be selected, and
+    /// [`CpuBackendError::Placement`] when CPU topology or managed placement
+    /// initialization is unavailable.
     pub fn try_new() -> Result<Self, CpuBackendError> {
         let op = "CpuBackend::try_new";
         let context =
@@ -934,8 +953,9 @@ impl CpuBackend {
     ///
     /// # Errors
     ///
-    /// Returns an error when `num_threads` is zero, Rayon rejects the pool, or
-    /// CPU topology and placement initialization fails.
+    /// Returns [`CpuBackendError::Tensor`] with `ValidationError::InvalidArgument`
+    /// when `num_threads` is zero or the context cannot be configured, and
+    /// [`CpuBackendError::Placement`] when CPU topology or placement fails.
     pub fn with_threads(num_threads: usize) -> Result<Self, CpuBackendError> {
         let op = "CpuBackend::with_threads";
         let context = CpuContext::with_threads(num_threads)
@@ -965,9 +985,9 @@ impl CpuBackend {
     ///
     /// # Errors
     ///
-    /// Returns an error when `num_threads` is zero, Rayon rejects the pool, or
-    /// the selected provider is unavailable, or CPU topology and placement
-    /// initialization fails.
+    /// Returns [`CpuBackendError::Tensor`] with `ValidationError::InvalidArgument`
+    /// when `num_threads` is zero or the provider is unavailable, and
+    /// [`CpuBackendError::Placement`] when CPU topology or placement fails.
     pub fn with_threads_and_kind(
         num_threads: usize,
         kind: CpuBackendKind,
@@ -1041,11 +1061,10 @@ impl CpuBackend {
                 cpus: self.shared.topology.allowed_cpus().clone(),
             },
             ResolvedCpuExecution::Compatibility => {
-                return Err(CpuPlacementError::EngineConstruction {
+                return Err(CpuPlacementError::InternalState {
                     requested,
                     backend: self.kind(),
-                    message: "placement resolution returned an internal compatibility mode"
-                        .to_owned(),
+                    message: "placement resolution returned an internal compatibility mode",
                 });
             }
         };
@@ -1053,7 +1072,7 @@ impl CpuBackend {
             CpuPlacementError::EngineConstruction {
                 requested,
                 backend: self.kind(),
-                message: error.to_string(),
+                source: CpuEngineConstructionError::Context(error),
             }
         })?;
         Ok(Self {
@@ -2725,7 +2744,7 @@ impl TensorFusion for CpuBackend {
 impl TensorDeviceTransfer for CpuBackend {
     fn download_to_host(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
         if tensor.is_backend_buffer() {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "CpuBackend::download_to_host",
                 "CPU backend received a backend buffer; download the tensor to host with its owning backend before CPU execution",
             ));
@@ -2735,7 +2754,7 @@ impl TensorDeviceTransfer for CpuBackend {
 
     fn upload_host_tensor(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
         if tensor.is_backend_buffer() {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "CpuBackend::upload_host_tensor",
                 "CPU backend upload_host_tensor expects a host tensor; download backend buffers to host before CPU execution",
             ));

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -682,7 +682,7 @@ fn with_threads_and_kind_records_selection_and_validates_threads() {
     };
     assert!(matches!(
         err,
-        CpuBackendError::Tensor(crate::Error::InvalidConfig {
+        CpuBackendError::Tensor(crate::Error::Validation {
             op: "CpuBackend::with_threads_and_kind",
             ..
         })
@@ -698,7 +698,7 @@ fn unavailable_blas_backend_kind_reports_config_errors() {
     };
     assert!(matches!(
         err,
-        CpuBackendError::Tensor(crate::Error::InvalidConfig {
+        CpuBackendError::Tensor(crate::Error::Validation {
             op: "CpuBackend::with_kind",
             ..
         })
@@ -738,7 +738,7 @@ fn unavailable_blas_backend_kind_reports_config_errors() {
         let err = result.unwrap_err();
         assert!(matches!(
             err,
-            crate::Error::InvalidConfig {
+            crate::Error::Validation {
                 op: "dot_general",
                 ..
             }
@@ -849,9 +849,9 @@ fn cached_dot_dispatch_reports_dtype_mismatches() {
     let dot_error = backend.dot_general_cached(&mut cache, Some(0), &lhs, &rhs, &config);
     assert!(matches!(
         dot_error,
-        Err(crate::Error::DTypeMismatch {
+        Err(crate::Error::Validation {
             op: "dot_general",
-            ..
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
         })
     ));
 
@@ -859,9 +859,9 @@ fn cached_dot_dispatch_reports_dtype_mismatches() {
         backend.dot_general_with_conj_cached(&mut cache, Some(1), &lhs, &rhs, &config, true, false);
     assert!(matches!(
         dot_conj_error,
-        Err(crate::Error::DTypeMismatch {
+        Err(crate::Error::Validation {
             op: "dot_general",
-            ..
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
         })
     ));
 }
@@ -872,7 +872,7 @@ fn with_threads_rejects_invalid_thread_count() {
     let error = result.unwrap_err();
     assert!(matches!(
         error,
-        CpuBackendError::Tensor(crate::Error::InvalidConfig {
+        CpuBackendError::Tensor(crate::Error::Validation {
             op: "CpuBackend::with_threads",
             ..
         })

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -881,17 +881,58 @@ fn with_threads_rejects_invalid_thread_count() {
 
 #[test]
 fn backend_error_keeps_placement_failure_typed() {
-    let placement = CpuPlacementError::TopologyDiscovery {
-        requested: CpuPlacement::Auto,
-        backend: CpuBackendKind::Faer,
-        source: CpuTopologyError::InvalidCpuList {
-            list: "bad".to_owned(),
-            reason: "test failure",
+    let error = CpuBackendError::placement(
+        "CpuBackend::try_new",
+        CpuPlacementError::TopologyDiscovery {
+            requested: CpuPlacement::Auto,
+            backend: CpuBackendKind::Faer,
+            source: CpuTopologyError::InvalidCpuList {
+                list: "bad".to_owned(),
+                reason: "test failure",
+            },
         },
-    };
+    );
+    assert!(matches!(
+        error.placement_error(),
+        Some(CpuPlacementError::TopologyDiscovery {
+            requested: CpuPlacement::Auto,
+            backend: CpuBackendKind::Faer,
+            source: CpuTopologyError::InvalidCpuList { .. },
+        })
+    ));
+}
 
-    let error = CpuBackendError::placement("CpuBackend::try_new", placement.clone());
-    assert_eq!(error.placement_error(), Some(&placement));
+#[test]
+fn placement_error_conversion_uses_runtime_state_for_environment_failures() {
+    let error = CpuBackendError::placement(
+        "CpuBackend::try_new",
+        CpuPlacementError::ManagedAffinityUnavailable {
+            requested: CpuPlacement::AllAllowed,
+            backend: CpuBackendKind::Faer,
+        },
+    );
+
+    let error: crate::Error = error.into();
+    assert_eq!(error.kind(), crate::ErrorKind::RuntimeState);
+    assert!(matches!(
+        std::error::Error::source(&error),
+        Some(source) if source.downcast_ref::<CpuPlacementError>().is_some()
+    ));
+}
+
+#[test]
+fn placement_error_conversion_keeps_unsupported_affinity_distinct() {
+    let error = CpuBackendError::placement(
+        "CpuBackend::with_placement",
+        CpuPlacementError::ExternalProviderAffinityUnmanaged {
+            requested: CpuPlacement::AllAllowed,
+            backend: CpuBackendKind::Blas,
+        },
+    );
+
+    let error: crate::Error = error.into();
+    assert_eq!(error.kind(), crate::ErrorKind::Unsupported);
+    assert!(std::error::Error::source(&error).is_some());
 }
 
 #[test]
@@ -901,15 +942,15 @@ fn fallible_backend_construction_preserves_topology_error_category() {
         reason: "component is not a CPU number",
     };
 
-    let error = resolve_discovered_topology(CpuBackendKind::Faer, Err(source.clone())).unwrap_err();
-    assert_eq!(
-        error,
+    let error = resolve_discovered_topology(CpuBackendKind::Faer, Err(source)).unwrap_err();
+    match error {
         CpuPlacementError::TopologyDiscovery {
             requested: CpuPlacement::Auto,
             backend: CpuBackendKind::Faer,
-            source,
-        }
-    );
+            source: CpuTopologyError::InvalidCpuList { list, .. },
+        } => assert_eq!(list, "not-a-cpu"),
+        other => panic!("unexpected placement error: {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -3,11 +3,11 @@ use std::sync::{Arc, Mutex};
 
 use thiserror::Error as ThisError;
 
-use crate::affinity::{SystemThreadAffinity, ThreadAffinity};
+use crate::affinity::{CpuAffinityError, SystemThreadAffinity, ThreadAffinity};
 use crate::arbiter::{
     set_pool_execution_owner, with_execution_owner, with_pool_execution_owner, ResourceOwner,
 };
-use crate::{CpuId, CpuSet, Error, Result};
+use crate::{CpuId, CpuSet, Error, ErrorKind, Result, ValidationKind};
 
 #[derive(Debug, Default)]
 struct ExecutionOwnerState {
@@ -25,7 +25,7 @@ struct ExecutionOwnerState {
 /// let error = CpuContextError::InvalidThreadCount;
 /// assert!(error.to_string().contains("thread count"));
 /// ```
-#[derive(Clone, Debug, ThisError, PartialEq, Eq)]
+#[derive(Debug, ThisError)]
 pub enum CpuContextError {
     /// A context must contain at least one worker.
     #[error("thread count must be at least 1")]
@@ -39,24 +39,30 @@ pub enum CpuContextError {
         cpus: usize,
     },
     /// Rayon could not construct the custom thread pool.
-    #[error("failed to build pinned CPU thread pool: {message}")]
+    #[error("failed to build pinned CPU thread pool: {source}")]
     PoolBuild {
-        /// Rayon or OS thread-spawn error detail.
-        message: String,
+        /// Rayon or OS thread-spawn error.
+        #[source]
+        source: rayon::ThreadPoolBuildError,
     },
     /// A worker could not set or verify its assigned CPU affinity.
-    #[error("failed to pin worker {worker} to CPU {cpu}: {message}")]
+    #[error("failed to pin worker {worker} to CPU {cpu}: {source}")]
     WorkerPinning {
         /// Stable Rayon worker index.
         worker: usize,
         /// Assigned operating-system logical CPU.
         cpu: CpuId,
-        /// OS or verification failure detail.
-        message: String,
+        /// OS or verification failure.
+        #[source]
+        source: CpuAffinityError,
     },
     /// A worker terminated before reporting startup affinity.
-    #[error("worker startup channel closed before all workers reported")]
-    WorkerStartupClosed,
+    #[error("worker startup channel closed before all workers reported: {source}")]
+    WorkerStartupClosed {
+        /// Channel receive failure from the worker startup handshake.
+        #[source]
+        source: std::sync::mpsc::RecvError,
+    },
 }
 
 /// Reusable CPU execution context carrying CPU parallelism policy.
@@ -123,10 +129,11 @@ impl CpuContext {
         match env::var("RAYON_NUM_THREADS") {
             Ok(value) => {
                 let num_threads = value.parse::<usize>().map_err(|err| {
-                    Error::invalid_argument(
+                    Error::extension(
                         "CpuContext::try_from_env",
-                        "configuration",
-                        format!("invalid RAYON_NUM_THREADS value {value:?}: {err}"),
+                        "cpu",
+                        ErrorKind::Validation(ValidationKind::InvalidArgument),
+                        err,
                     )
                 })?;
                 Self::with_threads(num_threads).map_err(|err| match err {
@@ -139,10 +146,11 @@ impl CpuContext {
             Err(env::VarError::NotPresent) => {
                 Self::with_threads(super::affinity::available_parallelism())
             }
-            Err(err) => Err(Error::invalid_argument(
+            Err(err) => Err(Error::extension(
                 "CpuContext::try_from_env",
-                "configuration",
-                format!("failed to read RAYON_NUM_THREADS: {err}"),
+                "cpu",
+                ErrorKind::Validation(ValidationKind::InvalidArgument),
+                err,
             )),
         }
     }
@@ -160,7 +168,9 @@ impl CpuContext {
     ///
     /// # Errors
     ///
-    /// Returns an error when `num_threads` is zero or Rayon rejects the pool.
+    /// Returns [`CpuContextError::InvalidThreadCount`] through
+    /// [`Error::Validation`] when `num_threads` is zero, or
+    /// [`Error::BackendSource`] when Rayon rejects the thread pool.
     pub fn with_threads(num_threads: usize) -> Result<Self> {
         if num_threads == 0 {
             return Err(Error::invalid_argument(
@@ -176,13 +186,7 @@ impl CpuContext {
                 rayon::ThreadPoolBuilder::new()
                     .num_threads(num_threads)
                     .build()
-                    .map_err(|err| {
-                        Error::invalid_argument(
-                            "CpuContext::with_threads",
-                            "configuration",
-                            format!("failed to build CPU thread pool: {err}"),
-                        )
-                    })?,
+                    .map_err(|err| Error::backend_source("CpuContext::with_threads", err))?,
             ))
         };
         Ok(Self {
@@ -254,11 +258,8 @@ impl CpuContext {
                         let result = affinity.pin_current(cpu).and_then(|observed| {
                             (observed.len() == 1 && observed.contains(cpu))
                                 .then_some(())
-                                .ok_or_else(|| {
-                                    format!(
-                                        "verification returned affinity {:?}",
-                                        observed.as_usize_vec()
-                                    )
+                                .ok_or_else(|| CpuAffinityError::Verification {
+                                    observed: observed.as_slice().to_vec(),
                                 })
                         });
                         let _ = startup_tx.send((worker, cpu, result));
@@ -267,19 +268,17 @@ impl CpuContext {
                     .map(|_| ())
             })
             .build()
-            .map_err(|err| CpuContextError::PoolBuild {
-                message: err.to_string(),
-            })?;
+            .map_err(|source| CpuContextError::PoolBuild { source })?;
         let pool = Arc::new(pool);
         for _ in 0..num_threads {
             let (worker, cpu, result) = startup_rx
                 .recv()
-                .map_err(|_| CpuContextError::WorkerStartupClosed)?;
-            if let Err(message) = result {
+                .map_err(|source| CpuContextError::WorkerStartupClosed { source })?;
+            if let Err(source) = result {
                 return Err(CpuContextError::WorkerPinning {
                     worker,
                     cpu,
-                    message,
+                    source,
                 });
             }
         }

--- a/crates/tenferro-cpu/src/context.rs
+++ b/crates/tenferro-cpu/src/context.rs
@@ -114,28 +114,36 @@ impl CpuContext {
     ///     .unwrap_or_else(|_| CpuContext::with_threads(1).unwrap());
     /// assert!(ctx.num_threads() >= 1);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuContextError`] when `RAYON_NUM_THREADS` is malformed or
+    /// requests an invalid worker count.
     pub fn try_from_env() -> Result<Self> {
         match env::var("RAYON_NUM_THREADS") {
             Ok(value) => {
-                let num_threads = value.parse::<usize>().map_err(|err| Error::InvalidConfig {
-                    op: "CpuContext::try_from_env",
-                    message: format!("invalid RAYON_NUM_THREADS value {value:?}: {err}"),
+                let num_threads = value.parse::<usize>().map_err(|err| {
+                    Error::invalid_argument(
+                        "CpuContext::try_from_env",
+                        "configuration",
+                        format!("invalid RAYON_NUM_THREADS value {value:?}: {err}"),
+                    )
                 })?;
                 Self::with_threads(num_threads).map_err(|err| match err {
-                    Error::InvalidConfig { message, .. } => Error::InvalidConfig {
-                        op: "CpuContext::try_from_env",
-                        message: format!("invalid RAYON_NUM_THREADS value {value:?}: {message}"),
-                    },
+                    Error::Validation { source, .. } => {
+                        Error::validation("CpuContext::try_from_env", source)
+                    }
                     err => err,
                 })
             }
             Err(env::VarError::NotPresent) => {
                 Self::with_threads(super::affinity::available_parallelism())
             }
-            Err(err) => Err(Error::InvalidConfig {
-                op: "CpuContext::try_from_env",
-                message: format!("failed to read RAYON_NUM_THREADS: {err}"),
-            }),
+            Err(err) => Err(Error::invalid_argument(
+                "CpuContext::try_from_env",
+                "configuration",
+                format!("failed to read RAYON_NUM_THREADS: {err}"),
+            )),
         }
     }
 
@@ -155,10 +163,11 @@ impl CpuContext {
     /// Returns an error when `num_threads` is zero or Rayon rejects the pool.
     pub fn with_threads(num_threads: usize) -> Result<Self> {
         if num_threads == 0 {
-            return Err(Error::InvalidConfig {
-                op: "CpuContext::with_threads",
-                message: "thread count must be at least 1".into(),
-            });
+            return Err(Error::invalid_argument(
+                "CpuContext::with_threads",
+                "configuration",
+                "thread count must be at least 1",
+            ));
         }
         let pool = if num_threads == 1 {
             None
@@ -167,9 +176,12 @@ impl CpuContext {
                 rayon::ThreadPoolBuilder::new()
                     .num_threads(num_threads)
                     .build()
-                    .map_err(|err| Error::InvalidConfig {
-                        op: "CpuContext::with_threads",
-                        message: format!("failed to build CPU thread pool: {err}"),
+                    .map_err(|err| {
+                        Error::invalid_argument(
+                            "CpuContext::with_threads",
+                            "configuration",
+                            format!("failed to build CPU thread pool: {err}"),
+                        )
                     })?,
             ))
         };
@@ -198,6 +210,12 @@ impl CpuContext {
     /// }
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuContextError::InvalidThreadCount`] for zero workers,
+    /// [`CpuContextError::TooManyWorkers`] when the request exceeds the CPU
+    /// set, or an affinity error when workers cannot be pinned.
     pub fn with_pinned_cpus(
         cpus: CpuSet,
         num_threads: usize,

--- a/crates/tenferro-cpu/src/context/tests.rs
+++ b/crates/tenferro-cpu/src/context/tests.rs
@@ -1,7 +1,7 @@
 use super::{select_worker_cpus, CpuContext, CpuContextError};
 #[cfg(target_os = "linux")]
 use crate::affinity::current_cpu;
-use crate::affinity::ThreadAffinity;
+use crate::affinity::{CpuAffinityError, ThreadAffinity};
 #[cfg(target_os = "linux")]
 use crate::process_cpu_affinity;
 use crate::{CpuId, CpuSet};
@@ -87,7 +87,7 @@ fn worker_assignment_spreads_a_reduced_budget_across_the_domain() {
 struct FailingAffinitySetter;
 
 impl ThreadAffinity for FailingAffinitySetter {
-    fn pin_current(&self, _cpu: CpuId) -> Result<CpuSet, String> {
-        Err("forced test failure".to_owned())
+    fn pin_current(&self, _cpu: CpuId) -> Result<CpuSet, CpuAffinityError> {
+        Err(CpuAffinityError::UnsupportedPlatform)
     }
 }

--- a/crates/tenferro-cpu/src/elementwise.rs
+++ b/crates/tenferro-cpu/src/elementwise.rs
@@ -28,14 +28,30 @@ macro_rules! dispatch_ternary_result_with_pool {
         match ($a, $b, $c) {
             (Tensor::F32($x), Tensor::F32($y), Tensor::F32($z)) => Ok(Tensor::F32($body?)),
             (Tensor::F64($x), Tensor::F64($y), Tensor::F64($z)) => Ok(Tensor::F64($body?)),
-            _ => Err(crate::Error::backend_failure($op, "dtype mismatch")),
+            _ => Err(ternary_dtype_error(
+                $op,
+                [$a.dtype(), $b.dtype(), $c.dtype()],
+            )),
         }
     };
 }
 
+fn ternary_dtype_error(op: &'static str, dtypes: [DType; 3]) -> crate::Error {
+    if dtypes[0] != dtypes[1] {
+        dtype_pair_error(op, dtypes[0], dtypes[1])
+    } else if dtypes[0] != dtypes[2] {
+        dtype_pair_error(op, dtypes[0], dtypes[2])
+    } else {
+        crate::Error::unsupported(
+            op,
+            format!("unsupported dtype {:?} for all three inputs", dtypes[0]),
+        )
+    }
+}
+
 fn dtype_pair_error(op: &'static str, lhs: DType, rhs: DType) -> crate::Error {
     if lhs == rhs {
-        crate::Error::backend_failure(op, format!("unsupported dtype {lhs:?}"))
+        crate::Error::unsupported(op, format!("unsupported dtype {lhs:?}"))
     } else {
         crate::Error::dtype_mismatch(op, lhs, rhs)
     }
@@ -54,7 +70,10 @@ fn is_complex_dtype(dtype: DType) -> bool {
 }
 
 fn ordered_complex_error(op: &'static str) -> crate::Error {
-    crate::Error::invalid_argument(op, "configuration", "complex tensors do not have a total order; compute abs/norm explicitly before ordered operations")
+    crate::Error::unsupported(
+        op,
+        "complex tensors do not have a total order; compute abs/norm explicitly before ordered operations",
+    )
 }
 
 fn reject_complex_ordered_dtypes(op: &'static str, dtypes: &[DType]) -> crate::Result<()> {
@@ -72,8 +91,9 @@ fn validate_elementwise_fusion_inputs(
     plan: &ElementwiseFusionPlan,
 ) -> crate::Result<bool> {
     if inputs.len() != plan.input_count() {
-        return Err(crate::Error::backend_failure(
+        return Err(crate::Error::invalid_argument(
             ELEMENTWISE_FUSION_OP,
+            "inputs",
             format!(
                 "plan expects {} inputs but backend received {}",
                 plan.input_count(),
@@ -82,8 +102,9 @@ fn validate_elementwise_fusion_inputs(
         ));
     }
     if plan.input_views().len() != plan.input_count() {
-        return Err(crate::Error::backend_failure(
+        return Err(crate::Error::invalid_argument(
             ELEMENTWISE_FUSION_OP,
+            "input_views",
             format!(
                 "plan has {} input views for {} inputs",
                 plan.input_views().len(),
@@ -1500,8 +1521,9 @@ where
     T: 'static,
 {
     axes.iter().try_fold(1usize, |acc, &axis| {
-        acc.checked_mul(view.shape()[axis])
-            .ok_or_else(|| crate::Error::backend_failure(op, "shape size overflows usize"))
+        acc.checked_mul(view.shape()[axis]).ok_or_else(|| {
+            crate::Error::invalid_argument(op, "shape", "shape size overflows usize")
+        })
     })
 }
 
@@ -1810,8 +1832,9 @@ fn lazy_outer_product_strides(spec: LazyOuterProductStrideSpec<'_>) -> crate::Re
     for (&lhs_axis, &rhs_axis) in spec.lhs_batch_axes.iter().zip(spec.rhs_batch_axes.iter()) {
         let output_axis = spec.lhs_dims[lhs_axis];
         if spec.rhs_dims[rhs_axis] != output_axis {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::invalid_argument(
                 "broadcast_multiply",
+                "dimensions",
                 "batch axes disagree while building lazy outer-product layout",
             ));
         }
@@ -1823,8 +1846,9 @@ fn lazy_outer_product_strides(spec: LazyOuterProductStrideSpec<'_>) -> crate::Re
         .into_iter()
         .collect::<Option<Vec<_>>>()
         .ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::invalid_argument(
                 "broadcast_multiply",
+                "dimensions",
                 "lazy outer-product layout did not cover every output axis",
             )
         })
@@ -2059,7 +2083,11 @@ where
 {
     let len = shape.iter().try_fold(1usize, |acc, &dim| {
         acc.checked_mul(dim).ok_or_else(|| {
-            crate::Error::backend_failure("broadcast_multiply", "output shape size overflows usize")
+            crate::Error::invalid_argument(
+                "broadcast_multiply",
+                "shape",
+                "output shape size overflows usize",
+            )
         })
     })?;
     // SAFETY: every pooled element is initialized with `fill` before tensor construction.
@@ -2403,7 +2431,7 @@ pub(crate) fn neg_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate::
         Tensor::F64(t) => Ok(Tensor::F64(typed_neg_with_pool(buffers, t)?)),
         Tensor::I32(t) => Ok(Tensor::I32(typed_wrapping_neg_with_pool(buffers, t)?)),
         Tensor::I64(t) => Ok(Tensor::I64(typed_wrapping_neg_with_pool(buffers, t)?)),
-        Tensor::Bool(_) => Err(crate::Error::backend_failure(
+        Tensor::Bool(_) => Err(crate::Error::unsupported(
             "neg",
             format!("unsupported dtype {:?}", input.dtype()),
         )),
@@ -2454,7 +2482,7 @@ pub(crate) fn neg_read_with_pool(
             &t,
             |x| -x,
         )?)),
-        _ => Err(crate::Error::backend_failure(
+        _ => Err(crate::Error::unsupported(
             "neg",
             format!("unsupported dtype {dtype:?}"),
         )),
@@ -2484,7 +2512,7 @@ pub(crate) fn conj_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate:
     match input {
         Tensor::F32(t) => Ok(Tensor::F32(typed_conj_with_pool(buffers, t)?)),
         Tensor::F64(t) => Ok(Tensor::F64(typed_conj_with_pool(buffers, t)?)),
-        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => Err(crate::Error::backend_failure(
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => Err(crate::Error::unsupported(
             "conj",
             format!("unsupported dtype {:?}", input.dtype()),
         )),
@@ -2523,7 +2551,7 @@ pub(crate) fn conj_read_with_pool(
             &t,
             |x| x.conj_elem(),
         )?)),
-        _ => Err(crate::Error::backend_failure(
+        _ => Err(crate::Error::unsupported(
             "conj",
             format!("unsupported dtype {dtype:?}"),
         )),
@@ -2556,7 +2584,7 @@ pub(crate) fn abs_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate::
         Tensor::F64(t) => Ok(Tensor::F64(typed_abs_with_pool(buffers, t)?)),
         Tensor::I32(t) => Ok(Tensor::I32(typed_wrapping_abs_with_pool(buffers, t)?)),
         Tensor::I64(t) => Ok(Tensor::I64(typed_wrapping_abs_with_pool(buffers, t)?)),
-        Tensor::Bool(_) => Err(crate::Error::backend_failure(
+        Tensor::Bool(_) => Err(crate::Error::unsupported(
             "abs",
             format!("unsupported dtype {:?}", input.dtype()),
         )),
@@ -2597,7 +2625,7 @@ pub(crate) fn abs_read_with_pool(
         )?)),
         CpuReadView::C32(t) => Ok(Tensor::F32(typed_complex_abs_view_with_pool(buffers, &t)?)),
         CpuReadView::C64(t) => Ok(Tensor::F64(typed_complex_abs_view_with_pool(buffers, &t)?)),
-        _ => Err(crate::Error::backend_failure(
+        _ => Err(crate::Error::unsupported(
             "abs",
             format!("unsupported dtype {dtype:?}"),
         )),
@@ -2628,7 +2656,7 @@ pub(crate) fn sign_with_pool(buffers: &mut BufferPool, input: &Tensor) -> crate:
         Tensor::F64(t) => Ok(Tensor::F64(typed_sign_with_pool(buffers, t)?)),
         Tensor::I32(t) => Ok(Tensor::I32(typed_integer_sign_with_pool(buffers, t)?)),
         Tensor::I64(t) => Ok(Tensor::I64(typed_integer_sign_with_pool(buffers, t)?)),
-        Tensor::Bool(_) => Err(crate::Error::backend_failure(
+        Tensor::Bool(_) => Err(crate::Error::unsupported(
             "sign",
             format!("unsupported dtype {:?}", input.dtype()),
         )),
@@ -2679,7 +2707,7 @@ pub(crate) fn sign_read_with_pool(
             &t,
             |x| x.sign_elem(),
         )?)),
-        _ => Err(crate::Error::backend_failure(
+        _ => Err(crate::Error::unsupported(
             "sign",
             format!("unsupported dtype {dtype:?}"),
         )),
@@ -3122,7 +3150,7 @@ where
             &typed_view("add", rhs)?,
             |x, y| x + y,
         )
-        .map_err(|err| crate::Error::backend_failure("add", err.to_string()))?;
+        .map_err(|err| crate::Error::backend_source("add", err))?;
         Ok(tensor_from_array(out))
     } else if lhs.shape().is_empty() {
         let scalar = typed_host_data("add", lhs)?[0];
@@ -3131,7 +3159,7 @@ where
         map_into(&mut out.view_mut(), &typed_view("add", rhs)?, |x| {
             scalar + x
         })
-        .map_err(|err| crate::Error::backend_failure("add", err.to_string()))?;
+        .map_err(|err| crate::Error::backend_source("add", err))?;
         Ok(tensor_from_array(out))
     } else if rhs.shape().is_empty() {
         let scalar = typed_host_data("add", rhs)?[0];
@@ -3140,7 +3168,7 @@ where
         map_into(&mut out.view_mut(), &typed_view("add", lhs)?, |x| {
             x + scalar
         })
-        .map_err(|err| crate::Error::backend_failure("add", err.to_string()))?;
+        .map_err(|err| crate::Error::backend_source("add", err))?;
         Ok(tensor_from_array(out))
     } else {
         Err(crate::Error::shape_mismatch(
@@ -3170,21 +3198,21 @@ where
             &typed_view(op, rhs)?,
             f,
         )
-        .map_err(|err| crate::Error::backend_failure(op, err.to_string()))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
         Ok(tensor_from_array(out))
     } else if lhs.shape().is_empty() {
         let scalar = typed_host_data(op, lhs)?[0];
         // SAFETY: map_into overwrites every output element.
         let mut out = unsafe { typed_array_uninit_from_pool(buffers, rhs.shape()) }?;
         map_into(&mut out.view_mut(), &typed_view(op, rhs)?, |x| f(scalar, x))
-            .map_err(|err| crate::Error::backend_failure(op, err.to_string()))?;
+            .map_err(|err| crate::Error::backend_source(op, err))?;
         Ok(tensor_from_array(out))
     } else if rhs.shape().is_empty() {
         let scalar = typed_host_data(op, rhs)?[0];
         // SAFETY: map_into overwrites every output element.
         let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
         map_into(&mut out.view_mut(), &typed_view(op, lhs)?, |x| f(x, scalar))
-            .map_err(|err| crate::Error::backend_failure(op, err.to_string()))?;
+            .map_err(|err| crate::Error::backend_source(op, err))?;
         Ok(tensor_from_array(out))
     } else {
         Err(crate::Error::shape_mismatch(
@@ -3238,7 +3266,7 @@ where
             &typed_view_from_view("add", rhs)?,
             |x, y| x + y,
         )
-        .map_err(|err| crate::Error::backend_failure("add", err.to_string()))?;
+        .map_err(|err| crate::Error::backend_source("add", err))?;
         Ok(tensor_from_array(out))
     } else if lhs.shape().is_empty() {
         let scalar = typed_view_from_view("add", lhs)?.get(&[]);
@@ -3249,7 +3277,7 @@ where
             &typed_view_from_view("add", rhs)?,
             |x| scalar + x,
         )
-        .map_err(|err| crate::Error::backend_failure("add", err.to_string()))?;
+        .map_err(|err| crate::Error::backend_source("add", err))?;
         Ok(tensor_from_array(out))
     } else if rhs.shape().is_empty() {
         let scalar = typed_view_from_view("add", rhs)?.get(&[]);
@@ -3260,7 +3288,7 @@ where
             &typed_view_from_view("add", lhs)?,
             |x| x + scalar,
         )
-        .map_err(|err| crate::Error::backend_failure("add", err.to_string()))?;
+        .map_err(|err| crate::Error::backend_source("add", err))?;
         Ok(tensor_from_array(out))
     } else {
         Err(crate::Error::shape_mismatch(

--- a/crates/tenferro-cpu/src/elementwise.rs
+++ b/crates/tenferro-cpu/src/elementwise.rs
@@ -37,7 +37,7 @@ fn dtype_pair_error(op: &'static str, lhs: DType, rhs: DType) -> crate::Error {
     if lhs == rhs {
         crate::Error::backend_failure(op, format!("unsupported dtype {lhs:?}"))
     } else {
-        crate::Error::DTypeMismatch { op, lhs, rhs }
+        crate::Error::dtype_mismatch(op, lhs, rhs)
     }
 }
 
@@ -54,10 +54,7 @@ fn is_complex_dtype(dtype: DType) -> bool {
 }
 
 fn ordered_complex_error(op: &'static str) -> crate::Error {
-    crate::Error::InvalidConfig {
-        op,
-        message: "complex tensors do not have a total order; compute abs/norm explicitly before ordered operations".into(),
-    }
+    crate::Error::invalid_argument(op, "configuration", "complex tensors do not have a total order; compute abs/norm explicitly before ordered operations")
 }
 
 fn reject_complex_ordered_dtypes(op: &'static str, dtypes: &[DType]) -> crate::Result<()> {
@@ -99,11 +96,11 @@ fn validate_elementwise_fusion_inputs(
     }
     for input in inputs {
         if input.dtype() != plan.dtype() {
-            return Err(crate::Error::DTypeMismatch {
-                op: ELEMENTWISE_FUSION_OP,
-                lhs: input.dtype(),
-                rhs: plan.dtype(),
-            });
+            return Err(crate::Error::dtype_mismatch(
+                ELEMENTWISE_FUSION_OP,
+                input.dtype(),
+                plan.dtype(),
+            ));
         }
     }
     Ok(true)
@@ -366,7 +363,7 @@ where
     T: Copy + Send + Sync,
 {
     reduce(view, pred, |lhs, rhs| lhs || rhs, false)
-        .map_err(|err| crate::Error::backend_failure(op, err))
+        .map_err(|err| crate::Error::backend_source(op, err))
 }
 
 fn ensure_no_zero_divisor<T>(op: &'static str, rhs: &StridedView<'_, T>) -> crate::Result<()>
@@ -374,7 +371,7 @@ where
     T: WrappingIntegerElem,
 {
     if strided_view_contains(op, rhs, |value| value == T::zero())? {
-        return Err(crate::Error::division_by_zero(op, T::dtype()));
+        return Err(crate::cpu_division_by_zero(op, T::dtype()));
     }
     Ok(())
 }
@@ -1000,11 +997,11 @@ pub(crate) fn elementwise_fusion_with_pool(
                 .iter()
                 .map(|input| match input {
                     Tensor::F32(tensor) => Ok(tensor),
-                    _ => Err(crate::Error::DTypeMismatch {
-                        op: ELEMENTWISE_FUSION_OP,
-                        lhs: input.dtype(),
-                        rhs: plan.dtype(),
-                    }),
+                    _ => Err(crate::Error::dtype_mismatch(
+                        ELEMENTWISE_FUSION_OP,
+                        input.dtype(),
+                        plan.dtype(),
+                    )),
                 })
                 .collect::<crate::Result<Vec<_>>>()?;
             typed_elementwise_fusion_with_pool(buffers, &typed_inputs, plan, Tensor::F32)
@@ -1014,11 +1011,11 @@ pub(crate) fn elementwise_fusion_with_pool(
                 .iter()
                 .map(|input| match input {
                     Tensor::F64(tensor) => Ok(tensor),
-                    _ => Err(crate::Error::DTypeMismatch {
-                        op: ELEMENTWISE_FUSION_OP,
-                        lhs: input.dtype(),
-                        rhs: plan.dtype(),
-                    }),
+                    _ => Err(crate::Error::dtype_mismatch(
+                        ELEMENTWISE_FUSION_OP,
+                        input.dtype(),
+                        plan.dtype(),
+                    )),
                 })
                 .collect::<crate::Result<Vec<_>>>()?;
             typed_elementwise_fusion_with_pool(buffers, &typed_inputs, plan, Tensor::F64)
@@ -1031,11 +1028,11 @@ pub(crate) fn elementwise_fusion_with_pool(
                 .iter()
                 .map(|input| match input {
                     Tensor::C32(tensor) => Ok(tensor),
-                    _ => Err(crate::Error::DTypeMismatch {
-                        op: ELEMENTWISE_FUSION_OP,
-                        lhs: input.dtype(),
-                        rhs: plan.dtype(),
-                    }),
+                    _ => Err(crate::Error::dtype_mismatch(
+                        ELEMENTWISE_FUSION_OP,
+                        input.dtype(),
+                        plan.dtype(),
+                    )),
                 })
                 .collect::<crate::Result<Vec<_>>>()?;
             typed_elementwise_fusion_with_pool(buffers, &typed_inputs, plan, Tensor::C32)
@@ -1048,11 +1045,11 @@ pub(crate) fn elementwise_fusion_with_pool(
                 .iter()
                 .map(|input| match input {
                     Tensor::C64(tensor) => Ok(tensor),
-                    _ => Err(crate::Error::DTypeMismatch {
-                        op: ELEMENTWISE_FUSION_OP,
-                        lhs: input.dtype(),
-                        rhs: plan.dtype(),
-                    }),
+                    _ => Err(crate::Error::dtype_mismatch(
+                        ELEMENTWISE_FUSION_OP,
+                        input.dtype(),
+                        plan.dtype(),
+                    )),
                 })
                 .collect::<crate::Result<Vec<_>>>()?;
             typed_elementwise_fusion_with_pool(buffers, &typed_inputs, plan, Tensor::C64)
@@ -1154,7 +1151,7 @@ where
             .map(|output| output.view_mut())
             .collect::<Vec<_>>();
         fused_elementwise_into(&mut output_views, input_views, &fused_plan)
-            .map_err(|err| crate::Error::backend_failure(ELEMENTWISE_FUSION_OP, err))?;
+            .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
     }
 
     Ok(Some(
@@ -1203,7 +1200,7 @@ where
         ),
         _ => return Ok(None),
     }
-    .map_err(|err| crate::Error::backend_failure(ELEMENTWISE_FUSION_OP, err))?;
+    .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
 
     Ok(Some(vec![wrap(tensor_from_array(out))]))
 }
@@ -1220,14 +1217,15 @@ where
         return Ok(base);
     };
     if dims.len() != input.shape().len() {
-        return Err(crate::Error::InvalidConfig {
-            op: ELEMENTWISE_FUSION_OP,
-            message: format!(
+        return Err(crate::Error::invalid_argument(
+            ELEMENTWISE_FUSION_OP,
+            "configuration",
+            format!(
                 "broadcast dims length {} does not match input rank {}",
                 dims.len(),
                 input.shape().len()
             ),
-        });
+        ));
     }
 
     let mut strides = vec![0; shape.len()];
@@ -1235,28 +1233,28 @@ where
     seen.resize(shape.len(), false);
     for (source_axis, &target_axis) in dims.iter().enumerate() {
         if target_axis >= shape.len() {
-            return Err(crate::Error::AxisOutOfBounds {
-                op: ELEMENTWISE_FUSION_OP,
-                axis: target_axis,
-                rank: shape.len(),
-            });
+            return Err(crate::Error::axis_out_of_bounds(
+                ELEMENTWISE_FUSION_OP,
+                target_axis,
+                shape.len(),
+            ));
         }
         if seen[target_axis] {
-            return Err(crate::Error::DuplicateAxis {
-                op: ELEMENTWISE_FUSION_OP,
-                axis: target_axis,
-                role: "broadcast dims",
-            });
+            return Err(crate::Error::duplicate_axis(
+                ELEMENTWISE_FUSION_OP,
+                target_axis,
+                "broadcast dims",
+            ));
         }
         seen[target_axis] = true;
         let source_dim = input.shape()[source_axis];
         let target_dim = shape[target_axis];
         if source_dim != target_dim && source_dim != 1 {
-            return Err(crate::Error::ShapeMismatch {
-                op: ELEMENTWISE_FUSION_OP,
-                lhs: shape.to_vec(),
-                rhs: input.shape().to_vec(),
-            });
+            return Err(crate::Error::shape_mismatch(
+                ELEMENTWISE_FUSION_OP,
+                shape.to_vec(),
+                input.shape().to_vec(),
+            ));
         }
         if source_dim == target_dim {
             strides[target_axis] = base.strides()[source_axis];
@@ -1264,7 +1262,7 @@ where
     }
 
     StridedView::new(base.data(), shape, &strides, base.offset())
-        .map_err(|err| crate::Error::backend_failure(ELEMENTWISE_FUSION_OP, err))
+        .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))
 }
 
 fn typed_binary_view_with_pool<T, L, R>(
@@ -1288,7 +1286,7 @@ where
             &typed_view_from_view(op, rhs)?,
             f,
         )
-        .map_err(|err| crate::Error::backend_failure(op, err))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
         Ok(tensor_from_array(out))
     } else if lhs.shape().is_empty() {
         let scalar = typed_view_from_view(op, lhs)?.get(&[]);
@@ -1297,7 +1295,7 @@ where
         map_into(&mut out.view_mut(), &typed_view_from_view(op, rhs)?, |x| {
             f(scalar, x)
         })
-        .map_err(|err| crate::Error::backend_failure(op, err))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
         Ok(tensor_from_array(out))
     } else if rhs.shape().is_empty() {
         let scalar = typed_view_from_view(op, rhs)?.get(&[]);
@@ -1306,14 +1304,14 @@ where
         map_into(&mut out.view_mut(), &typed_view_from_view(op, lhs)?, |x| {
             f(x, scalar)
         })
-        .map_err(|err| crate::Error::backend_failure(op, err))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
         Ok(tensor_from_array(out))
     } else {
-        Err(crate::Error::ShapeMismatch {
+        Err(crate::Error::shape_mismatch(
             op,
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        })
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ))
     }
 }
 
@@ -1330,7 +1328,7 @@ where
     // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
     map_into(&mut out.view_mut(), &typed_view_from_view(op, input)?, f)
-        .map_err(|err| crate::Error::backend_failure(op, err))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -1348,11 +1346,11 @@ where
     R: TensorRank,
 {
     if lhs.shape() != rhs.shape() {
-        return Err(crate::Error::ShapeMismatch {
+        return Err(crate::Error::shape_mismatch(
             op,
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        });
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ));
     }
     // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
@@ -1362,7 +1360,7 @@ where
         &typed_view_from_view(op, rhs)?,
         f,
     )
-    .map_err(|err| crate::Error::backend_failure(op, err))?;
+    .map_err(|err| crate::Error::backend_source(op, err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -1379,18 +1377,18 @@ where
     B: TensorRank,
 {
     if pred.shape() != on_true.shape() {
-        return Err(crate::Error::ShapeMismatch {
-            op: "select",
-            lhs: pred.shape().to_vec(),
-            rhs: on_true.shape().to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "select",
+            pred.shape().to_vec(),
+            on_true.shape().to_vec(),
+        ));
     }
     if pred.shape() != on_false.shape() {
-        return Err(crate::Error::ShapeMismatch {
-            op: "select",
-            lhs: pred.shape().to_vec(),
-            rhs: on_false.shape().to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "select",
+            pred.shape().to_vec(),
+            on_false.shape().to_vec(),
+        ));
     }
     // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, pred.shape()) }?;
@@ -1401,7 +1399,7 @@ where
         &typed_view_from_view("select", on_false)?,
         |p, t, f| if p { t } else { f },
     )
-    .map_err(|err| crate::Error::backend_failure("select", err))?;
+    .map_err(|err| crate::Error::backend_source("select", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -1418,18 +1416,18 @@ where
     U: TensorRank,
 {
     if input.shape() != lower.shape() {
-        return Err(crate::Error::ShapeMismatch {
-            op: "clamp",
-            lhs: input.shape().to_vec(),
-            rhs: lower.shape().to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "clamp",
+            input.shape().to_vec(),
+            lower.shape().to_vec(),
+        ));
     }
     if input.shape() != upper.shape() {
-        return Err(crate::Error::ShapeMismatch {
-            op: "clamp",
-            lhs: input.shape().to_vec(),
-            rhs: upper.shape().to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "clamp",
+            input.shape().to_vec(),
+            upper.shape().to_vec(),
+        ));
     }
     // SAFETY: the following kernel overwrites every output element before any read.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
@@ -1440,7 +1438,7 @@ where
         &typed_view_from_view("clamp", upper)?,
         |x, lo, hi| hi.min_elem(lo.max_elem(x)),
     )
-    .map_err(|err| crate::Error::backend_failure("clamp", err))?;
+    .map_err(|err| crate::Error::backend_source("clamp", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -1681,10 +1679,10 @@ where
                 .collect();
             let lhs_outer = lhs_view
                 .permute(&lhs_perm)
-                .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+                .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
             let rhs_outer = rhs_view
                 .permute(&rhs_perm)
-                .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+                .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
             batched_outer_product_into(
                 &mut out.view_mut(),
                 &lhs_outer,
@@ -1692,7 +1690,7 @@ where
                 plan.lhs_free_axes.len(),
                 plan.rhs_free_axes.len(),
             )
-            .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+            .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
         }
         SplitOuterProductLayout::RhsPrefix => {
             let lhs_perm: Vec<_> = plan
@@ -1709,10 +1707,10 @@ where
                 .collect();
             let lhs_outer = lhs_view
                 .permute(&lhs_perm)
-                .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+                .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
             let rhs_outer = rhs_view
                 .permute(&rhs_perm)
-                .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+                .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
             batched_outer_product_into(
                 &mut out.view_mut(),
                 &rhs_outer,
@@ -1720,7 +1718,7 @@ where
                 plan.rhs_free_axes.len(),
                 plan.lhs_free_axes.len(),
             )
-            .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+            .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
         }
     }
     Ok(Some(tensor_from_array(out)))
@@ -1760,17 +1758,17 @@ fn set_lazy_stride(
     let rank = logical_strides.len();
     let slot = logical_strides
         .get_mut(output_axis)
-        .ok_or(crate::Error::AxisOutOfBounds {
-            op: "broadcast_multiply",
-            axis: output_axis,
+        .ok_or(crate::Error::axis_out_of_bounds(
+            "broadcast_multiply",
+            output_axis,
             rank,
-        })?;
+        ))?;
     if slot.replace(stride).is_some() {
-        return Err(crate::Error::DuplicateAxis {
-            op: "broadcast_multiply",
-            axis: output_axis,
-            role: "lazy output layout",
-        });
+        return Err(crate::Error::duplicate_axis(
+            "broadcast_multiply",
+            output_axis,
+            "lazy output layout",
+        ));
     }
     Ok(())
 }
@@ -1885,10 +1883,10 @@ where
                 .collect();
             let lhs_outer = lhs_view
                 .permute(&lhs_perm)
-                .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+                .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
             let rhs_outer = rhs_view
                 .permute(&rhs_perm)
-                .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+                .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
 
             let mut base_shape = Vec::with_capacity(lhs_shape.len());
             append_axis_shapes(&mut base_shape, lhs, &lhs_free_axes);
@@ -1916,7 +1914,7 @@ where
                 lhs_free_axes.len(),
                 rhs_free_axes.len(),
             )
-            .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+            .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
             Ok(Some(LazyOuterProduct {
                 base: tensor_from_array(base),
                 shape: lhs_shape.to_vec(),
@@ -1936,10 +1934,10 @@ where
                 .collect();
             let lhs_outer = lhs_view
                 .permute(&lhs_perm)
-                .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+                .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
             let rhs_outer = rhs_view
                 .permute(&rhs_perm)
-                .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+                .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
 
             let mut base_shape = Vec::with_capacity(lhs_shape.len());
             append_axis_shapes(&mut base_shape, rhs, &rhs_free_axes);
@@ -1967,7 +1965,7 @@ where
                 rhs_free_axes.len(),
                 lhs_free_axes.len(),
             )
-            .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+            .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
             Ok(Some(LazyOuterProduct {
                 base: tensor_from_array(base),
                 shape: lhs_shape.to_vec(),
@@ -1993,11 +1991,11 @@ where
     R: TensorRank,
 {
     if lhs_shape != rhs_shape {
-        return Err(crate::Error::ShapeMismatch {
-            op: "broadcast_multiply",
-            lhs: lhs_shape.to_vec(),
-            rhs: rhs_shape.to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "broadcast_multiply",
+            lhs_shape.to_vec(),
+            rhs_shape.to_vec(),
+        ));
     }
     let output_rank = lhs_shape.len();
     let lhs_is_scalar = lhs.shape().is_empty() && lhs_dims.is_empty();
@@ -2020,7 +2018,7 @@ where
             &typed_view_from_view("broadcast_multiply", rhs)?,
             |x| scalar * x,
         )
-        .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+        .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
         return Ok(tensor_from_array(out));
     }
     if rhs_is_scalar && lhs_is_full_output {
@@ -2032,7 +2030,7 @@ where
             &typed_view_from_view("broadcast_multiply", lhs)?,
             |x| x * scalar,
         )
-        .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+        .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
         return Ok(tensor_from_array(out));
     }
 
@@ -2047,7 +2045,7 @@ where
         &rhs_view,
         rhs_dims,
     )
-    .map_err(|err| crate::Error::backend_failure("broadcast_multiply", err))?;
+    .map_err(|err| crate::Error::backend_source("broadcast_multiply", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -2211,11 +2209,11 @@ pub(crate) fn div_with_pool(
             let scalar = complex_scalar_tensor(typed_host_data("div", b)?[0])?;
             Ok(Tensor::C64(typed_div_with_pool(buffers, a, &scalar)?))
         }
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "div",
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        }),
+        _ => Err(crate::Error::dtype_mismatch(
+            "div",
+            lhs.dtype(),
+            rhs.dtype(),
+        )),
     }
 }
 
@@ -2305,11 +2303,7 @@ pub(crate) fn div_read_with_pool(
                 |x, y| x / y,
             )?))
         }
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "div",
-            lhs: lhs_dtype,
-            rhs: rhs_dtype,
-        }),
+        _ => Err(crate::Error::dtype_mismatch("div", lhs_dtype, rhs_dtype)),
     }
 }
 
@@ -2889,11 +2883,11 @@ pub(crate) fn compare_with_pool(
         (Tensor::Bool(a), Tensor::Bool(b)) => {
             Ok(Tensor::Bool(typed_compare_with_pool(buffers, a, b, dir)?))
         }
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "compare",
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        }),
+        _ => Err(crate::Error::dtype_mismatch(
+            "compare",
+            lhs.dtype(),
+            rhs.dtype(),
+        )),
     }
 }
 
@@ -2933,11 +2927,9 @@ pub(crate) fn compare_read_with_pool(
                 x.compare_elem(y, dir)
             })?,
         )),
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "compare",
-            lhs: lhs_dtype,
-            rhs: rhs_dtype,
-        }),
+        _ => Err(crate::Error::dtype_mismatch(
+            "compare", lhs_dtype, rhs_dtype,
+        )),
     }
 }
 
@@ -2989,16 +2981,16 @@ pub(crate) fn select_with_pool(
         (Tensor::Bool(p), Tensor::C64(t), Tensor::C64(f)) => {
             Ok(Tensor::C64(typed_select_with_pool(buffers, p, t, f)?))
         }
-        (Tensor::Bool(_), _, _) => Err(crate::Error::DTypeMismatch {
-            op: "select",
-            lhs: on_true.dtype(),
-            rhs: on_false.dtype(),
-        }),
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "select",
-            lhs: pred.dtype(),
-            rhs: crate::DType::Bool,
-        }),
+        (Tensor::Bool(_), _, _) => Err(crate::Error::dtype_mismatch(
+            "select",
+            on_true.dtype(),
+            on_false.dtype(),
+        )),
+        _ => Err(crate::Error::dtype_mismatch(
+            "select",
+            pred.dtype(),
+            crate::DType::Bool,
+        )),
     }
 }
 
@@ -3037,16 +3029,16 @@ pub(crate) fn select_read_with_pool(
         (CpuReadView::Bool(p), CpuReadView::C64(t), CpuReadView::C64(f)) => Ok(Tensor::C64(
             typed_select_view_with_pool(buffers, &p, &t, &f)?,
         )),
-        (CpuReadView::Bool(_), _, _) => Err(crate::Error::DTypeMismatch {
-            op: "select",
-            lhs: true_dtype,
-            rhs: false_dtype,
-        }),
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "select",
-            lhs: pred_dtype,
-            rhs: crate::DType::Bool,
-        }),
+        (CpuReadView::Bool(_), _, _) => Err(crate::Error::dtype_mismatch(
+            "select",
+            true_dtype,
+            false_dtype,
+        )),
+        _ => Err(crate::Error::dtype_mismatch(
+            "select",
+            pred_dtype,
+            crate::DType::Bool,
+        )),
     }
 }
 
@@ -3105,11 +3097,11 @@ pub(crate) fn clamp_read_with_pool(
         (CpuReadView::F64(input), CpuReadView::F64(lower), CpuReadView::F64(upper)) => Ok(
             Tensor::F64(typed_clamp_view_with_pool(buffers, &input, &lower, &upper)?),
         ),
-        _ => Err(crate::Error::DTypeMismatch {
-            op: "clamp",
-            lhs: input_dtype,
-            rhs: lower_dtype,
-        }),
+        _ => Err(crate::Error::dtype_mismatch(
+            "clamp",
+            input_dtype,
+            lower_dtype,
+        )),
     }
 }
 
@@ -3151,11 +3143,11 @@ where
         .map_err(|err| crate::Error::backend_failure("add", err.to_string()))?;
         Ok(tensor_from_array(out))
     } else {
-        Err(crate::Error::ShapeMismatch {
-            op: "add",
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        })
+        Err(crate::Error::shape_mismatch(
+            "add",
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ))
     }
 }
 
@@ -3195,11 +3187,11 @@ where
             .map_err(|err| crate::Error::backend_failure(op, err.to_string()))?;
         Ok(tensor_from_array(out))
     } else {
-        Err(crate::Error::ShapeMismatch {
+        Err(crate::Error::shape_mismatch(
             op,
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        })
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ))
     }
 }
 
@@ -3271,11 +3263,11 @@ where
         .map_err(|err| crate::Error::backend_failure("add", err.to_string()))?;
         Ok(tensor_from_array(out))
     } else {
-        Err(crate::Error::ShapeMismatch {
-            op: "add",
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        })
+        Err(crate::Error::shape_mismatch(
+            "add",
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ))
     }
 }
 
@@ -3343,7 +3335,7 @@ where
             &typed_view("mul", lhs)?,
             &typed_view("mul", rhs)?,
         )
-        .map_err(|err| crate::Error::backend_failure("mul", err))?;
+        .map_err(|err| crate::Error::backend_source("mul", err))?;
         Ok(tensor_from_array(out))
     } else if lhs.shape().is_empty() {
         let scalar = typed_host_data("mul", lhs)?[0];
@@ -3352,7 +3344,7 @@ where
         map_into(&mut out.view_mut(), &typed_view("mul", rhs)?, |x| {
             scalar * x
         })
-        .map_err(|err| crate::Error::backend_failure("mul", err))?;
+        .map_err(|err| crate::Error::backend_source("mul", err))?;
         Ok(tensor_from_array(out))
     } else if rhs.shape().is_empty() {
         let scalar = typed_host_data("mul", rhs)?[0];
@@ -3361,14 +3353,14 @@ where
         map_into(&mut out.view_mut(), &typed_view("mul", lhs)?, |x| {
             x * scalar
         })
-        .map_err(|err| crate::Error::backend_failure("mul", err))?;
+        .map_err(|err| crate::Error::backend_source("mul", err))?;
         Ok(tensor_from_array(out))
     } else {
-        Err(crate::Error::ShapeMismatch {
-            op: "mul",
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        })
+        Err(crate::Error::shape_mismatch(
+            "mul",
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ))
     }
 }
 
@@ -3414,7 +3406,7 @@ where
             &typed_view_from_view("mul", lhs)?,
             &typed_view_from_view("mul", rhs)?,
         )
-        .map_err(|err| crate::Error::backend_failure("mul", err))?;
+        .map_err(|err| crate::Error::backend_source("mul", err))?;
         Ok(tensor_from_array(out))
     } else if lhs.shape().is_empty() {
         let scalar = typed_view_from_view("mul", lhs)?.get(&[]);
@@ -3425,7 +3417,7 @@ where
             &typed_view_from_view("mul", rhs)?,
             |x| scalar * x,
         )
-        .map_err(|err| crate::Error::backend_failure("mul", err))?;
+        .map_err(|err| crate::Error::backend_source("mul", err))?;
         Ok(tensor_from_array(out))
     } else if rhs.shape().is_empty() {
         let scalar = typed_view_from_view("mul", rhs)?.get(&[]);
@@ -3436,14 +3428,14 @@ where
             &typed_view_from_view("mul", lhs)?,
             |x| x * scalar,
         )
-        .map_err(|err| crate::Error::backend_failure("mul", err))?;
+        .map_err(|err| crate::Error::backend_source("mul", err))?;
         Ok(tensor_from_array(out))
     } else {
-        Err(crate::Error::ShapeMismatch {
-            op: "mul",
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        })
+        Err(crate::Error::shape_mismatch(
+            "mul",
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ))
     }
 }
 
@@ -3464,7 +3456,7 @@ where
             &typed_view("div", rhs)?,
             |x, y| x / y,
         )
-        .map_err(|err| crate::Error::backend_failure("div", err))?;
+        .map_err(|err| crate::Error::backend_source("div", err))?;
         Ok(tensor_from_array(out))
     } else if lhs.shape().is_empty() {
         let scalar = typed_host_data("div", lhs)?[0];
@@ -3473,7 +3465,7 @@ where
         map_into(&mut out.view_mut(), &typed_view("div", rhs)?, |x| {
             scalar / x
         })
-        .map_err(|err| crate::Error::backend_failure("div", err))?;
+        .map_err(|err| crate::Error::backend_source("div", err))?;
         Ok(tensor_from_array(out))
     } else if rhs.shape().is_empty() {
         let scalar = typed_host_data("div", rhs)?[0];
@@ -3482,14 +3474,14 @@ where
         map_into(&mut out.view_mut(), &typed_view("div", lhs)?, |x| {
             x / scalar
         })
-        .map_err(|err| crate::Error::backend_failure("div", err))?;
+        .map_err(|err| crate::Error::backend_source("div", err))?;
         Ok(tensor_from_array(out))
     } else {
-        Err(crate::Error::ShapeMismatch {
-            op: "div",
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        })
+        Err(crate::Error::shape_mismatch(
+            "div",
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ))
     }
 }
 
@@ -3570,7 +3562,7 @@ where
     // SAFETY: map_into overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
     map_into(&mut out.view_mut(), &typed_view("neg", input)?, |x| -x)
-        .map_err(|err| crate::Error::backend_failure("neg", err))?;
+        .map_err(|err| crate::Error::backend_source("neg", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -3586,7 +3578,7 @@ where
     // SAFETY: map_into overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
     map_into(&mut out.view_mut(), &typed_view(op, input)?, f)
-        .map_err(|err| crate::Error::backend_failure(op, err))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -3622,7 +3614,7 @@ where
     map_into(&mut out.view_mut(), &typed_view("conj", input)?, |x| {
         x.conj_elem()
     })
-    .map_err(|err| crate::Error::backend_failure("conj", err))?;
+    .map_err(|err| crate::Error::backend_source("conj", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -3638,7 +3630,7 @@ where
     map_into(&mut out.view_mut(), &typed_view("abs", input)?, |x| {
         x.abs_elem()
     })
-    .map_err(|err| crate::Error::backend_failure("abs", err))?;
+    .map_err(|err| crate::Error::backend_source("abs", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -3654,7 +3646,7 @@ where
     map_into(&mut out.view_mut(), &typed_view("abs", input)?, |x| {
         x.norm()
     })
-    .map_err(|err| crate::Error::backend_failure("abs", err))?;
+    .map_err(|err| crate::Error::backend_source("abs", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -3673,7 +3665,7 @@ where
         &typed_view_from_view("abs", input)?,
         |x| x.norm(),
     )
-    .map_err(|err| crate::Error::backend_failure("abs", err))?;
+    .map_err(|err| crate::Error::backend_source("abs", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -3689,7 +3681,7 @@ where
     map_into(&mut out.view_mut(), &typed_view("sign", input)?, |x| {
         x.sign_elem()
     })
-    .map_err(|err| crate::Error::backend_failure("sign", err))?;
+    .map_err(|err| crate::Error::backend_source("sign", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -3712,11 +3704,11 @@ where
     T: OrderedElem + PoolScalar,
 {
     if lhs.shape() != rhs.shape() {
-        return Err(crate::Error::ShapeMismatch {
-            op: "maximum",
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "maximum",
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ));
     }
     // SAFETY: zip_map2_into overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
@@ -3726,7 +3718,7 @@ where
         &typed_view("maximum", rhs)?,
         |x, y| x.max_elem(y),
     )
-    .map_err(|err| crate::Error::backend_failure("maximum", err))?;
+    .map_err(|err| crate::Error::backend_source("maximum", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -3739,11 +3731,11 @@ where
     T: OrderedElem + PoolScalar,
 {
     if lhs.shape() != rhs.shape() {
-        return Err(crate::Error::ShapeMismatch {
-            op: "minimum",
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "minimum",
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ));
     }
     // SAFETY: zip_map2_into overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
@@ -3753,7 +3745,7 @@ where
         &typed_view("minimum", rhs)?,
         |x, y| x.min_elem(y),
     )
-    .map_err(|err| crate::Error::backend_failure("minimum", err))?;
+    .map_err(|err| crate::Error::backend_source("minimum", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -3767,11 +3759,11 @@ where
     T: CompareElem,
 {
     if lhs.shape() != rhs.shape() {
-        return Err(crate::Error::ShapeMismatch {
-            op: "compare",
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "compare",
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ));
     }
     // SAFETY: zip_map2_into overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, lhs.shape()) }?;
@@ -3781,7 +3773,7 @@ where
         &typed_view("compare", rhs)?,
         |x, y| x.compare_elem(y, dir),
     )
-    .map_err(|err| crate::Error::backend_failure("compare", err))?;
+    .map_err(|err| crate::Error::backend_source("compare", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -3795,18 +3787,18 @@ where
     T: Copy + PoolScalar,
 {
     if pred.shape() != on_true.shape() {
-        return Err(crate::Error::ShapeMismatch {
-            op: "select",
-            lhs: pred.shape().to_vec(),
-            rhs: on_true.shape().to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "select",
+            pred.shape().to_vec(),
+            on_true.shape().to_vec(),
+        ));
     }
     if pred.shape() != on_false.shape() {
-        return Err(crate::Error::ShapeMismatch {
-            op: "select",
-            lhs: pred.shape().to_vec(),
-            rhs: on_false.shape().to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "select",
+            pred.shape().to_vec(),
+            on_false.shape().to_vec(),
+        ));
     }
     // SAFETY: zip_map3_into overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, pred.shape()) }?;
@@ -3817,7 +3809,7 @@ where
         &typed_view("select", on_false)?,
         |p, t, f| if p { t } else { f },
     )
-    .map_err(|err| crate::Error::backend_failure("select", err))?;
+    .map_err(|err| crate::Error::backend_source("select", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -3831,18 +3823,18 @@ where
     T: OrderedElem + PoolScalar,
 {
     if input.shape() != lower.shape() {
-        return Err(crate::Error::ShapeMismatch {
-            op: "clamp",
-            lhs: input.shape().to_vec(),
-            rhs: lower.shape().to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "clamp",
+            input.shape().to_vec(),
+            lower.shape().to_vec(),
+        ));
     }
     if input.shape() != upper.shape() {
-        return Err(crate::Error::ShapeMismatch {
-            op: "clamp",
-            lhs: input.shape().to_vec(),
-            rhs: upper.shape().to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "clamp",
+            input.shape().to_vec(),
+            upper.shape().to_vec(),
+        ));
     }
     // SAFETY: zip_map3_into overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, input.shape()) }?;
@@ -3853,7 +3845,7 @@ where
         &typed_view("clamp", upper)?,
         |x, lo, hi| hi.min_elem(lo.max_elem(x)),
     )
-    .map_err(|err| crate::Error::backend_failure("clamp", err))?;
+    .map_err(|err| crate::Error::backend_source("clamp", err))?;
     Ok(tensor_from_array(out))
 }
 

--- a/crates/tenferro-cpu/src/elementwise/tests.rs
+++ b/crates/tenferro-cpu/src/elementwise/tests.rs
@@ -29,10 +29,12 @@ fn elementwise_fusion_validation_covers_descriptor_errors_and_empty_outputs() {
     let dtype_mismatch = ElementwiseFusionPlan::new(DType::F64, 1, vec![0], Vec::new());
     assert!(matches!(
         validate_elementwise_fusion_inputs(&[&input], &dtype_mismatch),
-        Err(crate::Error::DTypeMismatch {
+        Err(crate::Error::Validation {
             op: ELEMENTWISE_FUSION_OP,
-            lhs: DType::F32,
-            rhs: DType::F64,
+            source: tenferro_tensor::ValidationError::DTypeMismatch {
+                expected: _,
+                actual: _,
+            },
         })
     ));
 
@@ -61,7 +63,7 @@ fn elementwise_fusion_validation_covers_descriptor_errors_and_empty_outputs() {
     assert!(reject_complex_ordered_dtypes("maximum", &[DType::F32]).is_ok());
     assert!(matches!(
         reject_complex_ordered_dtypes("maximum", &[DType::C64]),
-        Err(crate::Error::InvalidConfig { op: "maximum", .. })
+        Err(crate::Error::Validation { op: "maximum", .. })
     ));
 }
 
@@ -410,14 +412,14 @@ fn assert_c64_close(actual: Complex<f64>, expected: Complex<f64>) {
 fn assert_shape_mismatch<T>(result: crate::Result<T>, op: &'static str) {
     assert!(matches!(
         result,
-        Err(crate::Error::ShapeMismatch { op: actual, .. }) if actual == op
+        Err(crate::Error::Validation { op: actual, .. }) if actual == op
     ));
 }
 
 fn assert_dtype_mismatch<T>(result: crate::Result<T>, op: &'static str) {
     assert!(matches!(
         result,
-        Err(crate::Error::DTypeMismatch { op: actual, .. }) if actual == op
+        Err(crate::Error::Validation { op: actual, .. }) if actual == op
     ));
 }
 
@@ -431,10 +433,10 @@ fn assert_backend_failure<T>(result: crate::Result<T>, op: &'static str) {
 fn assert_invalid_config_contains<T>(result: crate::Result<T>, op: &'static str, expected: &str) {
     assert!(matches!(
         result,
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::Validation {
             op: actual,
-            ref message,
-        }) if actual == op && message.contains(expected)
+            source,
+        }) if actual == op && source.to_string().contains(expected)
     ));
 }
 

--- a/crates/tenferro-cpu/src/elementwise/tests.rs
+++ b/crates/tenferro-cpu/src/elementwise/tests.rs
@@ -17,8 +17,9 @@ fn elementwise_fusion_validation_covers_descriptor_errors_and_empty_outputs() {
     );
     assert!(matches!(
         validate_elementwise_fusion_inputs(&[&input], &wrong_input_count),
-        Err(crate::Error::BackendFailure {
+        Err(crate::Error::Validation {
             op: ELEMENTWISE_FUSION_OP,
+            source: tenferro_tensor::ValidationError::InvalidArgument { .. },
             ..
         })
     ));
@@ -63,7 +64,7 @@ fn elementwise_fusion_validation_covers_descriptor_errors_and_empty_outputs() {
     assert!(reject_complex_ordered_dtypes("maximum", &[DType::F32]).is_ok());
     assert!(matches!(
         reject_complex_ordered_dtypes("maximum", &[DType::C64]),
-        Err(crate::Error::Validation { op: "maximum", .. })
+        Err(crate::Error::Unsupported { op: "maximum", .. })
     ));
 }
 
@@ -423,20 +424,20 @@ fn assert_dtype_mismatch<T>(result: crate::Result<T>, op: &'static str) {
     ));
 }
 
-fn assert_backend_failure<T>(result: crate::Result<T>, op: &'static str) {
+fn assert_unsupported<T>(result: crate::Result<T>, op: &'static str) {
     assert!(matches!(
         result,
-        Err(crate::Error::BackendFailure { op: actual, .. }) if actual == op
+        Err(crate::Error::Unsupported { op: actual, .. }) if actual == op
     ));
 }
 
-fn assert_invalid_config_contains<T>(result: crate::Result<T>, op: &'static str, expected: &str) {
+fn assert_unsupported_contains<T>(result: crate::Result<T>, op: &'static str, expected: &str) {
     assert!(matches!(
         result,
-        Err(crate::Error::Validation {
+        Err(crate::Error::Unsupported {
             op: actual,
-            source,
-        }) if actual == op && source.to_string().contains(expected)
+            message,
+        }) if actual == op && message.contains(expected)
     ));
 }
 
@@ -450,10 +451,18 @@ fn complex_ordered_ops_are_explicitly_rejected() {
         ("minimum", minimum(&lhs, &rhs)),
         ("compare", compare(&lhs, &rhs, &CompareDir::Le)),
     ] {
-        assert_invalid_config_contains(result, op, "total order");
+        assert!(matches!(
+            result,
+            Err(crate::Error::Unsupported { op: actual, message })
+                if actual == op && message.contains("total order")
+        ));
     }
 
-    assert_invalid_config_contains(clamp(&lhs, &rhs, &lhs), "clamp", "total order");
+    assert!(matches!(
+        clamp(&lhs, &rhs, &lhs),
+        Err(crate::Error::Unsupported { op: "clamp", message })
+            if message.contains("total order")
+    ));
 }
 
 #[test]
@@ -836,7 +845,7 @@ fn tensor_read_elementwise_dispatch_covers_view_and_complex_scalar_branches() {
     )
     .unwrap();
     assert_c32_close(conj.as_slice::<Complex<f32>>().unwrap()[0], c32(3.0, -4.0));
-    assert_backend_failure(
+    assert_unsupported(
         conj_read_with_pool(
             &mut buffers,
             TensorRead::from_view(TensorView::Bool(bool_a.as_view())),
@@ -868,7 +877,7 @@ fn tensor_read_elementwise_dispatch_covers_view_and_complex_scalar_branches() {
         c32(0.6, 0.8),
     );
 
-    assert_invalid_config_contains(
+    assert_unsupported_contains(
         maximum_read_with_pool(
             &mut buffers,
             TensorRead::from_view(TensorView::C32(c32_a.as_view())),
@@ -877,7 +886,7 @@ fn tensor_read_elementwise_dispatch_covers_view_and_complex_scalar_branches() {
         "maximum",
         "total order",
     );
-    assert_invalid_config_contains(
+    assert_unsupported_contains(
         minimum_read_with_pool(
             &mut buffers,
             TensorRead::from_view(TensorView::C64(c64_a.as_view())),
@@ -914,7 +923,7 @@ fn tensor_read_elementwise_dispatch_covers_view_and_complex_scalar_branches() {
     .unwrap();
     assert_eq!(cmp_bool.as_slice::<bool>().unwrap(), &[false, true]);
 
-    assert_invalid_config_contains(
+    assert_unsupported_contains(
         compare_read_with_pool(
             &mut buffers,
             TensorRead::from_view(TensorView::C32(c32_a.as_view())),
@@ -974,7 +983,7 @@ fn tensor_read_elementwise_dispatch_covers_view_and_complex_scalar_branches() {
         "select",
     );
 
-    assert_invalid_config_contains(
+    assert_unsupported_contains(
         clamp_read_with_pool(
             &mut buffers,
             TensorRead::from_view(TensorView::C32(c32_a.as_view())),
@@ -984,7 +993,7 @@ fn tensor_read_elementwise_dispatch_covers_view_and_complex_scalar_branches() {
         "clamp",
         "total order",
     );
-    assert_invalid_config_contains(
+    assert_unsupported_contains(
         clamp_read_with_pool(
             &mut buffers,
             TensorRead::from_view(TensorView::C64(c64_a.as_view())),

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -41,7 +41,7 @@ impl CpuExecSession<'_> {
 impl TensorDeviceTransfer for CpuExecSession<'_> {
     fn download_to_host(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
         if tensor.is_backend_buffer() {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "CpuBackend::download_to_host",
                 "CPU backend received a backend buffer; download the tensor to host with its owning backend before CPU execution",
             ));
@@ -51,7 +51,7 @@ impl TensorDeviceTransfer for CpuExecSession<'_> {
 
     fn upload_host_tensor(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
         if tensor.is_backend_buffer() {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "CpuBackend::upload_host_tensor",
                 "CPU backend upload_host_tensor expects a host tensor; download backend buffers to host before CPU execution",
             ));

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -407,11 +407,11 @@ impl SessionCachedDot for CpuExecSession<'_> {
                                 .map(|result| result.map(Tensor::C64))
                         }
                         _ if lhs.dtype() == rhs.dtype() => Ok(None),
-                        _ => Err(crate::Error::DTypeMismatch {
-                            op: "dot_general",
-                            lhs: lhs.dtype(),
-                            rhs: rhs.dtype(),
-                        }),
+                        _ => Err(crate::Error::dtype_mismatch(
+                            "dot_general",
+                            lhs.dtype(),
+                            rhs.dtype(),
+                        )),
                     }?;
                     if let Some(result) = self.tblis_not_applicable("dot_general", direct)? {
                         return Ok(result);
@@ -473,11 +473,11 @@ impl SessionCachedDot for CpuExecSession<'_> {
                             config,
                         )
                         .map(Tensor::C64),
-                        _ => Err(crate::Error::DTypeMismatch {
-                            op: "dot_general",
-                            lhs: lhs.dtype(),
-                            rhs: rhs.dtype(),
-                        }),
+                        _ => Err(crate::Error::dtype_mismatch(
+                            "dot_general",
+                            lhs.dtype(),
+                            rhs.dtype(),
+                        )),
                     }
                 }
                 #[cfg(not(feature = "cpu-faer"))]
@@ -528,11 +528,11 @@ impl SessionCachedDot for CpuExecSession<'_> {
                             config,
                         )
                         .map(Tensor::C64),
-                        _ => Err(crate::Error::DTypeMismatch {
-                            op: "dot_general",
-                            lhs: lhs.dtype(),
-                            rhs: rhs.dtype(),
-                        }),
+                        _ => Err(crate::Error::dtype_mismatch(
+                            "dot_general",
+                            lhs.dtype(),
+                            rhs.dtype(),
+                        )),
                     }
                 }
                 #[cfg(not(feature = "cpu-blas"))]
@@ -606,11 +606,11 @@ impl SessionCachedDot for CpuExecSession<'_> {
                             .map(|result| result.map(Tensor::C64))
                         }
                         _ if lhs.dtype() == rhs.dtype() => Ok(None),
-                        _ => Err(crate::Error::DTypeMismatch {
-                            op: "dot_general",
-                            lhs: lhs.dtype(),
-                            rhs: rhs.dtype(),
-                        }),
+                        _ => Err(crate::Error::dtype_mismatch(
+                            "dot_general",
+                            lhs.dtype(),
+                            rhs.dtype(),
+                        )),
                     }?;
                     if let Some(result) = self.tblis_not_applicable("dot_general", direct)? {
                         return Ok(result);
@@ -687,11 +687,11 @@ impl SessionCachedDot for CpuExecSession<'_> {
                             )
                             .map(Tensor::C64)
                         }
-                        _ => Err(crate::Error::DTypeMismatch {
-                            op: "dot_general",
-                            lhs: lhs.dtype(),
-                            rhs: rhs.dtype(),
-                        }),
+                        _ => Err(crate::Error::dtype_mismatch(
+                            "dot_general",
+                            lhs.dtype(),
+                            rhs.dtype(),
+                        )),
                     }
                 }
                 #[cfg(not(feature = "cpu-faer"))]
@@ -758,11 +758,11 @@ impl SessionCachedDot for CpuExecSession<'_> {
                             )
                             .map(Tensor::C64)
                         }
-                        _ => Err(crate::Error::DTypeMismatch {
-                            op: "dot_general",
-                            lhs: lhs.dtype(),
-                            rhs: rhs.dtype(),
-                        }),
+                        _ => Err(crate::Error::dtype_mismatch(
+                            "dot_general",
+                            lhs.dtype(),
+                            rhs.dtype(),
+                        )),
                     }
                 }
                 #[cfg(not(feature = "cpu-blas"))]

--- a/crates/tenferro-cpu/src/gemm/blas_gemm.rs
+++ b/crates/tenferro-cpu/src/gemm/blas_gemm.rs
@@ -211,7 +211,7 @@ fn infer_a_layout(
         Err(Error::invalid_argument(
             "dot_general",
             "configuration",
-            "BLAS requires unit stride on one axis of A".into(),
+            "BLAS requires unit stride on one axis of A",
         ))
     }
 }
@@ -248,7 +248,7 @@ fn infer_b_layout(
         Err(Error::invalid_argument(
             "dot_general",
             "configuration",
-            "BLAS requires unit stride on one axis of B".into(),
+            "BLAS requires unit stride on one axis of B",
         ))
     }
 }

--- a/crates/tenferro-cpu/src/gemm/blas_gemm.rs
+++ b/crates/tenferro-cpu/src/gemm/blas_gemm.rs
@@ -159,19 +159,23 @@ pub(crate) trait BlasGemm: Sized + Copy {
 }
 
 fn dim_to_i32(name: &'static str, value: usize) -> crate::Result<i32> {
-    i32::try_from(value).map_err(|_| Error::InvalidConfig {
-        op: "dot_general",
-        message: format!("{name}={value} exceeds BLAS i32 range"),
+    i32::try_from(value).map_err(|_| {
+        Error::invalid_argument(
+            "dot_general",
+            "configuration",
+            format!("{name}={value} exceeds BLAS i32 range"),
+        )
     })
 }
 
 fn stride_to_i32(name: &'static str, value: isize) -> crate::Result<i32> {
     match i32::try_from(value) {
         Ok(value) if value > 0 => Ok(value),
-        _ => Err(Error::InvalidConfig {
-            op: "dot_general",
-            message: format!("{name}={value} must be a positive BLAS stride"),
-        }),
+        _ => Err(Error::invalid_argument(
+            "dot_general",
+            "configuration",
+            format!("{name}={value} must be a positive BLAS stride"),
+        )),
     }
 }
 
@@ -185,27 +189,30 @@ fn infer_a_layout(
         let lda = stride_to_i32("lda", a_cs)?;
         let min_lda = dim_to_i32("m", m)?;
         if lda < min_lda {
-            return Err(Error::InvalidConfig {
-                op: "dot_general",
-                message: format!("lda={lda} must be >= max(1, m)={min_lda} for NoTrans A"),
-            });
+            return Err(Error::invalid_argument(
+                "dot_general",
+                "configuration",
+                format!("lda={lda} must be >= max(1, m)={min_lda} for NoTrans A"),
+            ));
         }
         Ok((CBLAS_TRANSPOSE::CblasNoTrans, lda))
     } else if a_cs == 1 {
         let lda = stride_to_i32("lda", a_rs)?;
         let min_lda = dim_to_i32("k", k)?;
         if lda < min_lda {
-            return Err(Error::InvalidConfig {
-                op: "dot_general",
-                message: format!("lda={lda} must be >= max(1, k)={min_lda} for Trans A"),
-            });
+            return Err(Error::invalid_argument(
+                "dot_general",
+                "configuration",
+                format!("lda={lda} must be >= max(1, k)={min_lda} for Trans A"),
+            ));
         }
         Ok((CBLAS_TRANSPOSE::CblasTrans, lda))
     } else {
-        Err(Error::InvalidConfig {
-            op: "dot_general",
-            message: "BLAS requires unit stride on one axis of A".into(),
-        })
+        Err(Error::invalid_argument(
+            "dot_general",
+            "configuration",
+            "BLAS requires unit stride on one axis of A".into(),
+        ))
     }
 }
 
@@ -219,44 +226,49 @@ fn infer_b_layout(
         let ldb = stride_to_i32("ldb", b_cs)?;
         let min_ldb = dim_to_i32("k", k)?;
         if ldb < min_ldb {
-            return Err(Error::InvalidConfig {
-                op: "dot_general",
-                message: format!("ldb={ldb} must be >= max(1, k)={min_ldb} for NoTrans B"),
-            });
+            return Err(Error::invalid_argument(
+                "dot_general",
+                "configuration",
+                format!("ldb={ldb} must be >= max(1, k)={min_ldb} for NoTrans B"),
+            ));
         }
         Ok((CBLAS_TRANSPOSE::CblasNoTrans, ldb))
     } else if b_cs == 1 {
         let ldb = stride_to_i32("ldb", b_rs)?;
         let min_ldb = dim_to_i32("n", n)?;
         if ldb < min_ldb {
-            return Err(Error::InvalidConfig {
-                op: "dot_general",
-                message: format!("ldb={ldb} must be >= max(1, n)={min_ldb} for Trans B"),
-            });
+            return Err(Error::invalid_argument(
+                "dot_general",
+                "configuration",
+                format!("ldb={ldb} must be >= max(1, n)={min_ldb} for Trans B"),
+            ));
         }
         Ok((CBLAS_TRANSPOSE::CblasTrans, ldb))
     } else {
-        Err(Error::InvalidConfig {
-            op: "dot_general",
-            message: "BLAS requires unit stride on one axis of B".into(),
-        })
+        Err(Error::invalid_argument(
+            "dot_general",
+            "configuration",
+            "BLAS requires unit stride on one axis of B".into(),
+        ))
     }
 }
 
 fn infer_c_layout(m: usize, c_rs: isize, c_cs: isize) -> crate::Result<i32> {
     if c_rs != 1 {
-        return Err(Error::InvalidConfig {
-            op: "dot_general",
-            message: format!("BLAS output requires unit row stride, got {c_rs}"),
-        });
+        return Err(Error::invalid_argument(
+            "dot_general",
+            "configuration",
+            format!("BLAS output requires unit row stride, got {c_rs}"),
+        ));
     }
     let ldc = stride_to_i32("ldc", c_cs)?;
     let min_ldc = dim_to_i32("m", m)?;
     if ldc < min_ldc {
-        return Err(Error::InvalidConfig {
-            op: "dot_general",
-            message: format!("ldc={ldc} must be >= max(1, m)={min_ldc}"),
-        });
+        return Err(Error::invalid_argument(
+            "dot_general",
+            "configuration",
+            format!("ldc={ldc} must be >= max(1, m)={min_ldc}"),
+        ));
     }
     Ok(ldc)
 }
@@ -397,17 +409,19 @@ mod provider_batch {
             match self.groups.last().copied() {
                 Some(last) if same_group(last, group) => {
                     let Some(last_size) = self.group_size.last_mut() else {
-                        return Err(Error::InvalidConfig {
-                            op: "grouped_gemm",
-                            message: "BLAS grouped GEMM metadata is inconsistent".into(),
-                        });
+                        return Err(Error::invalid_argument(
+                            "grouped_gemm",
+                            "configuration",
+                            "BLAS grouped GEMM metadata is inconsistent".into(),
+                        ));
                     };
-                    *last_size = last_size
-                        .checked_add(1)
-                        .ok_or_else(|| Error::InvalidConfig {
-                            op: "grouped_gemm",
-                            message: "BLAS grouped GEMM group_size overflows i32".into(),
-                        })?;
+                    *last_size = last_size.checked_add(1).ok_or_else(|| {
+                        Error::invalid_argument(
+                            "grouped_gemm",
+                            "configuration",
+                            "BLAS grouped GEMM group_size overflows i32".into(),
+                        )
+                    })?;
                 }
                 _ => {
                     self.groups.push(group);

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -617,8 +617,9 @@ where
     let beta_is_zero = beta == T::zero();
     let shape = out.shape().to_vec();
     let element_count = checked_product(&shape).ok_or_else(|| {
-        Error::backend_failure(
+        Error::invalid_argument(
             OP,
+            "configuration",
             "output element count overflow while scaling empty contraction output",
         )
     })?;
@@ -1060,7 +1061,7 @@ where
         rhs_conj,
     )?
     .ok_or_else(|| {
-        Error::backend_failure(
+        Error::runtime_state(
             "dot_general",
             "CPU GEMM requires host-backed canonical inputs",
         )
@@ -1729,8 +1730,13 @@ where
     let Some(dims) = analyse_gemm_cached(cache, cache_slot, cache_kind, lhs, rhs, config)? else {
         return Ok(None);
     };
-    let out_n = checked_product(&dims.out_shape)
-        .ok_or_else(|| Error::backend_failure("dot_general", "output element count overflow"))?;
+    let out_n = checked_product(&dims.out_shape).ok_or_else(|| {
+        Error::invalid_argument(
+            "dot_general",
+            "configuration",
+            "output element count overflow",
+        )
+    })?;
     if dims.m == 0 || dims.n == 0 || dims.k == 0 || dims.batch_total == 0 {
         let data = T::pool_acquire_zeroed(buffers, out_n);
         return Ok(Some(TypedTensor::from_buffer_col_major(
@@ -1852,7 +1858,7 @@ where
         &new_config,
     )?
     .ok_or_else(|| {
-        Error::backend_failure(
+        Error::runtime_state(
             "dot_general",
             "CPU GEMM requires host-backed canonical inputs",
         )
@@ -2484,8 +2490,13 @@ where
         Some(dims) => dims,
         None => return Ok(None),
     };
-    let out_n = checked_product(&dims.out_shape)
-        .ok_or_else(|| Error::backend_failure("dot_general", "output element count overflow"))?;
+    let out_n = checked_product(&dims.out_shape).ok_or_else(|| {
+        Error::invalid_argument(
+            "dot_general",
+            "configuration",
+            "output element count overflow",
+        )
+    })?;
     if dims.m == 0 || dims.n == 0 || dims.k == 0 || dims.batch_total == 0 {
         let data = T::pool_acquire_zeroed(buffers, out_n);
         return Ok(Some(TypedTensor::from_buffer_col_major(
@@ -2584,8 +2595,13 @@ where
         Some(dims) => dims,
         None => return Ok(None),
     };
-    let out_n = checked_product(&dims.out_shape)
-        .ok_or_else(|| Error::backend_failure("dot_general", "output element count overflow"))?;
+    let out_n = checked_product(&dims.out_shape).ok_or_else(|| {
+        Error::invalid_argument(
+            "dot_general",
+            "configuration",
+            "output element count overflow",
+        )
+    })?;
     if dims.m == 0 || dims.n == 0 || dims.k == 0 || dims.batch_total == 0 {
         let data = T::pool_acquire_zeroed(buffers, out_n);
         return Ok(Some(TypedTensor::from_buffer_col_major(

--- a/crates/tenferro-cpu/src/gemm/mod.rs
+++ b/crates/tenferro-cpu/src/gemm/mod.rs
@@ -17,7 +17,7 @@ use rayon::prelude::*;
 use tenferro_tensor::backend::GroupedGemmConfig;
 use tenferro_tensor::{
     col_major_strides, Buffer, TensorRead, TensorView, TensorViewMut, TensorWrite, TypedTensor,
-    TypedTensorView, TypedTensorViewMut,
+    TypedTensorView, TypedTensorViewMut, ValidationError,
 };
 use tenferro_tensor::{CacheStats, RuntimeCacheControl};
 use tenferro_tensor::{ContractionScalar, DotGeneralAccumulation, DotGeneralConfig};
@@ -369,10 +369,10 @@ fn validate_axis_list(
     let mut seen: SmallVec<[bool; 8]> = smallvec::smallvec![false; rank];
     for &axis in axes {
         if axis >= rank {
-            return Err(Error::AxisOutOfBounds { op, axis, rank });
+            return Err(Error::axis_out_of_bounds(op, axis, rank));
         }
         if seen[axis] {
-            return Err(Error::DuplicateAxis { op, axis, role });
+            return Err(Error::duplicate_axis(op, axis, role));
         }
         seen[axis] = true;
     }
@@ -388,12 +388,14 @@ fn validate_role_disjoint(
 ) -> crate::Result<()> {
     for &axis in first_axes {
         if second_axes.contains(&axis) {
-            return Err(Error::AxisRoleConflict {
+            return Err(Error::validation(
                 op,
-                axis,
-                first_role,
-                second_role,
-            });
+                ValidationError::AxisRoleConflict {
+                    axis,
+                    first_role,
+                    second_role,
+                },
+            ));
         }
     }
     Ok(())
@@ -408,16 +410,18 @@ where
     let rhs_shape = rhs.shape();
 
     if config.lhs_contracting_dims.len() != config.rhs_contracting_dims.len() {
-        return Err(Error::InvalidConfig {
-            op: OP,
-            message: "lhs/rhs contracting dim counts differ".into(),
-        });
+        return Err(Error::invalid_argument(
+            OP,
+            "configuration",
+            "lhs/rhs contracting dim counts differ",
+        ));
     }
     if config.lhs_batch_dims.len() != config.rhs_batch_dims.len() {
-        return Err(Error::InvalidConfig {
-            op: OP,
-            message: "lhs/rhs batch dim counts differ".into(),
-        });
+        return Err(Error::invalid_argument(
+            OP,
+            "configuration",
+            "lhs/rhs batch dim counts differ",
+        ));
     }
 
     let lhs_rank = lhs_shape.len();
@@ -457,24 +461,26 @@ where
         .zip(&config.rhs_contracting_dims)
     {
         if lhs_shape[lhs_axis] != rhs_shape[rhs_axis] {
-            return Err(Error::InvalidConfig {
-                op: OP,
-                message: format!(
+            return Err(Error::invalid_argument(
+                OP,
+                "configuration",
+                format!(
                     "contracting dim size mismatch: lhs axis {lhs_axis}={} rhs axis {rhs_axis}={}",
                     lhs_shape[lhs_axis], rhs_shape[rhs_axis]
                 ),
-            });
+            ));
         }
     }
     for (&lhs_axis, &rhs_axis) in config.lhs_batch_dims.iter().zip(&config.rhs_batch_dims) {
         if lhs_shape[lhs_axis] != rhs_shape[rhs_axis] {
-            return Err(Error::InvalidConfig {
-                op: OP,
-                message: format!(
+            return Err(Error::invalid_argument(
+                OP,
+                "configuration",
+                format!(
                     "batch dim size mismatch: lhs axis {lhs_axis}={} rhs axis {rhs_axis}={}",
                     lhs_shape[lhs_axis], rhs_shape[rhs_axis]
                 ),
-            });
+            ));
         }
     }
 
@@ -507,40 +513,51 @@ fn try_fuse_dims(shapes: &[usize], strides: &[isize]) -> Result<Option<(usize, i
             return Ok(None);
         }
         let shape = dim_to_isize(shape, "try_fuse_dims")?;
-        expected = stride
-            .checked_mul(shape)
-            .ok_or_else(|| Error::InvalidConfig {
-                op: OP,
-                message: format!("fused stride overflows isize: stride={stride} shape={shape}"),
-            })?;
+        expected = stride.checked_mul(shape).ok_or_else(|| {
+            Error::invalid_argument(
+                OP,
+                "configuration",
+                format!("fused stride overflows isize: stride={stride} shape={shape}"),
+            )
+        })?;
     }
-    let fused = checked_product(shapes).ok_or_else(|| Error::InvalidConfig {
-        op: OP,
-        message: format!("fused dimension product overflows usize for shape {shapes:?}"),
+    let fused = checked_product(shapes).ok_or_else(|| {
+        Error::invalid_argument(
+            OP,
+            "configuration",
+            format!("fused dimension product overflows usize for shape {shapes:?}"),
+        )
     })?;
     Ok(Some((fused, base_stride)))
 }
 
 fn checked_batch_offset(batch: usize, stride: isize) -> Result<isize> {
-    let batch_isize = isize::try_from(batch).map_err(|_| Error::InvalidConfig {
-        op: OP,
-        message: format!("batch index {batch} does not fit in isize"),
+    let batch_isize = isize::try_from(batch).map_err(|_| {
+        Error::invalid_argument(
+            OP,
+            "configuration",
+            format!("batch index {batch} does not fit in isize"),
+        )
     })?;
-    batch_isize
-        .checked_mul(stride)
-        .ok_or_else(|| Error::InvalidConfig {
-            op: OP,
-            message: format!("batch offset overflows isize: batch={batch} stride={stride}"),
-        })
+    batch_isize.checked_mul(stride).ok_or_else(|| {
+        Error::invalid_argument(
+            OP,
+            "configuration",
+            format!("batch offset overflows isize: batch={batch} stride={stride}"),
+        )
+    })
 }
 
 fn checked_view_batch_offset(base: isize, batch: usize, stride: isize) -> Result<isize> {
     base.checked_add(checked_batch_offset(batch, stride)?)
-        .ok_or_else(|| Error::InvalidConfig {
-            op: OP,
-            message: format!(
-                "view batch offset overflows isize: base={base} batch={batch} stride={stride}"
-            ),
+        .ok_or_else(|| {
+            Error::invalid_argument(
+                OP,
+                "configuration",
+                format!(
+                    "view batch offset overflows isize: base={base} batch={batch} stride={stride}"
+                ),
+            )
         })
 }
 
@@ -553,15 +570,21 @@ fn output_gemm_strides(
 ) -> crate::Result<Option<(isize, isize, isize)>> {
     let nm = lhs_rank
         .checked_sub(config.lhs_contracting_dims.len() + config.lhs_batch_dims.len())
-        .ok_or_else(|| Error::InvalidConfig {
-            op: OP,
-            message: "lhs free rank underflow while analyzing output strides".into(),
+        .ok_or_else(|| {
+            Error::invalid_argument(
+                OP,
+                "configuration",
+                "lhs free rank underflow while analyzing output strides",
+            )
         })?;
     let nn = rhs_rank
         .checked_sub(config.rhs_contracting_dims.len() + config.rhs_batch_dims.len())
-        .ok_or_else(|| Error::InvalidConfig {
-            op: OP,
-            message: "rhs free rank underflow while analyzing output strides".into(),
+        .ok_or_else(|| {
+            Error::invalid_argument(
+                OP,
+                "configuration",
+                "rhs free rank underflow while analyzing output strides",
+            )
         })?;
     let nb = config.lhs_batch_dims.len();
     if out_shape.len() != nm + nn + nb || out_strides.len() != out_shape.len() {
@@ -601,9 +624,12 @@ where
     })?;
     for linear in 0..element_count {
         let indices = flat_to_multi_for_shape(&shape, linear);
-        let output = out.get_mut(&indices).ok_or_else(|| Error::InvalidConfig {
-            op: OP,
-            message: format!("output index {indices:?} is outside accumulation target"),
+        let output = out.get_mut(&indices).ok_or_else(|| {
+            Error::invalid_argument(
+                OP,
+                "configuration",
+                format!("output index {indices:?} is outside accumulation target"),
+            )
         })?;
         // INVARIANT: beta == 0 follows GEMM semantics and overwrites the
         // destination with zero without reading its previous value.
@@ -630,22 +656,30 @@ fn flat_to_multi_for_shape(shape: &[usize], mut linear: usize) -> SmallVec<[usiz
 }
 
 fn dim_to_isize(dim: usize, context: &'static str) -> Result<isize> {
-    isize::try_from(dim).map_err(|_| Error::InvalidConfig {
-        op: OP,
-        message: format!("{context}: dimension {dim} does not fit in isize"),
+    isize::try_from(dim).map_err(|_| {
+        Error::invalid_argument(
+            OP,
+            "configuration",
+            format!("{context}: dimension {dim} does not fit in isize"),
+        )
     })
 }
 
 fn add_job_offset(base: isize, offset: usize, role: &'static str) -> Result<isize> {
-    let offset = isize::try_from(offset).map_err(|_| Error::InvalidConfig {
-        op: "grouped_gemm",
-        message: format!("{role} offset {offset} does not fit in isize"),
+    let offset = isize::try_from(offset).map_err(|_| {
+        Error::invalid_argument(
+            "grouped_gemm",
+            "configuration",
+            format!("{role} offset {offset} does not fit in isize"),
+        )
     })?;
-    base.checked_add(offset)
-        .ok_or_else(|| Error::InvalidConfig {
-            op: "grouped_gemm",
-            message: format!("{role} offset overflows isize: base={base} offset={offset}"),
-        })
+    base.checked_add(offset).ok_or_else(|| {
+        Error::invalid_argument(
+            "grouped_gemm",
+            "configuration",
+            format!("{role} offset overflows isize: base={base} offset={offset}"),
+        )
+    })
 }
 
 fn scale_grouped_empty_output<T>(
@@ -662,9 +696,12 @@ where
     }
     let beta_is_zero = beta == T::zero();
     for col in 0..cols {
-        let col_offset = col.checked_mul(rows).ok_or_else(|| Error::InvalidConfig {
-            op: "grouped_gemm",
-            message: format!("output column offset overflows usize: col={col} rows={rows}"),
+        let col_offset = col.checked_mul(rows).ok_or_else(|| {
+            Error::invalid_argument(
+                "grouped_gemm",
+                "configuration",
+                format!("output column offset overflows usize: col={col} rows={rows}"),
+            )
         })?;
         for row in 0..rows {
             let offset = col_offset + row;
@@ -1105,11 +1142,11 @@ pub(crate) fn dot_general_faer_read_cached(
     if lhs.dtype() == rhs.dtype() {
         Ok(None)
     } else {
-        Err(Error::DTypeMismatch {
-            op: "dot_general",
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        })
+        Err(Error::dtype_mismatch(
+            "dot_general",
+            lhs.dtype(),
+            rhs.dtype(),
+        ))
     }
 }
 
@@ -1984,11 +2021,11 @@ pub(crate) fn dot_general_blas_read_cached(
     if lhs.dtype() == rhs.dtype() {
         Ok(None)
     } else {
-        Err(Error::DTypeMismatch {
-            op: "dot_general",
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        })
+        Err(Error::dtype_mismatch(
+            "dot_general",
+            lhs.dtype(),
+            rhs.dtype(),
+        ))
     }
 }
 
@@ -2695,11 +2732,11 @@ pub(crate) fn dot_general_tblis_read_cached(
     if lhs.dtype() == rhs.dtype() {
         Ok(None)
     } else {
-        Err(Error::DTypeMismatch {
-            op: "dot_general",
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        })
+        Err(Error::dtype_mismatch(
+            "dot_general",
+            lhs.dtype(),
+            rhs.dtype(),
+        ))
     }
 }
 

--- a/crates/tenferro-cpu/src/gemm/strided_dot.rs
+++ b/crates/tenferro-cpu/src/gemm/strided_dot.rs
@@ -18,8 +18,11 @@ pub(super) fn test_dispatch_count() -> usize {
     DISPATCH_COUNT.load(Ordering::SeqCst)
 }
 
-fn map_strided_error(err: impl std::fmt::Display) -> Error {
-    Error::backend_failure("dot_general", err)
+fn map_strided_error<E>(err: E) -> Error
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    Error::backend_source("dot_general", err)
 }
 
 fn to_strided_config(config: &TensorDotGeneralConfig) -> strided_einsum2::DotGeneralConfig<'_> {
@@ -124,11 +127,11 @@ where
         .expected_output_shape(lhs.shape(), rhs.shape())
         .map_err(map_strided_error)?;
     if out.shape() != out_shape.as_slice() {
-        return Err(Error::ShapeMismatch {
-            op: "dot_general",
-            lhs: out.shape().to_vec(),
-            rhs: out_shape,
-        });
+        return Err(Error::shape_mismatch(
+            "dot_general",
+            out.shape().to_vec(),
+            out_shape,
+        ));
     }
 
     let out_shape = out.shape().to_vec();

--- a/crates/tenferro-cpu/src/gemm/strided_dot.rs
+++ b/crates/tenferro-cpu/src/gemm/strided_dot.rs
@@ -38,7 +38,13 @@ fn checked_product(shape: &[usize]) -> crate::Result<usize> {
     shape
         .iter()
         .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
-        .ok_or_else(|| Error::backend_failure("dot_general", "output element count overflow"))
+        .ok_or_else(|| {
+            Error::invalid_argument(
+                "dot_general",
+                "configuration",
+                "output element count overflow",
+            )
+        })
 }
 
 fn as_strided_view<'a, R, T>(read: &'a R) -> crate::Result<strided_einsum2::StridedView<'a, T>>
@@ -47,7 +53,7 @@ where
     T: 'static,
 {
     let Some(data) = read.host_data_opt()? else {
-        return Err(Error::backend_failure(
+        return Err(Error::runtime_state(
             "dot_general",
             "CPU dot_general requires host-backed inputs",
         ));

--- a/crates/tenferro-cpu/src/gemm/tblis_gemm.rs
+++ b/crates/tenferro-cpu/src/gemm/tblis_gemm.rs
@@ -277,21 +277,26 @@ where
 {
     ensure_runtime_available()?;
     if out.offset() < 0 {
-        return Err(Error::InvalidConfig {
-            op: OP,
-            message: "TBLIS output offset must be non-negative".into(),
-        });
+        return Err(Error::invalid_argument(
+            OP,
+            "configuration",
+            "TBLIS output offset must be non-negative".into(),
+        ));
     }
-    let out_offset = usize::try_from(out.offset()).map_err(|_| Error::InvalidConfig {
-        op: OP,
-        message: "TBLIS output offset does not fit in usize".into(),
+    let out_offset = usize::try_from(out.offset()).map_err(|_| {
+        Error::invalid_argument(
+            OP,
+            "configuration",
+            "TBLIS output offset does not fit in usize".into(),
+        )
     })?;
     let out_storage = out.host_storage_mut()?;
     if out_offset > out_storage.len() {
-        return Err(Error::InvalidConfig {
-            op: OP,
-            message: "TBLIS output offset is outside host storage".into(),
-        });
+        return Err(Error::invalid_argument(
+            OP,
+            "configuration",
+            "TBLIS output offset is outside host storage".into(),
+        ));
     }
     let out_ptr = out_storage.as_mut_ptr();
 
@@ -300,9 +305,12 @@ where
         conj: c_int::from(execution.lhs_conj),
         scalar: T::scalar(execution.alpha),
         data: lhs_ptr.cast_mut() as *mut c_void,
-        ndim: c_int::try_from(plan.lhs_len.len()).map_err(|_| Error::InvalidConfig {
-            op: OP,
-            message: "TBLIS lhs rank exceeds c_int range".into(),
+        ndim: c_int::try_from(plan.lhs_len.len()).map_err(|_| {
+            Error::invalid_argument(
+                OP,
+                "configuration",
+                "TBLIS lhs rank exceeds c_int range".into(),
+            )
         })?,
         len: plan.lhs_len.as_mut_ptr(),
         stride: plan.lhs_stride.as_mut_ptr(),
@@ -312,9 +320,12 @@ where
         conj: c_int::from(execution.rhs_conj),
         scalar: T::scalar(T::one()),
         data: rhs_ptr.cast_mut() as *mut c_void,
-        ndim: c_int::try_from(plan.rhs_len.len()).map_err(|_| Error::InvalidConfig {
-            op: OP,
-            message: "TBLIS rhs rank exceeds c_int range".into(),
+        ndim: c_int::try_from(plan.rhs_len.len()).map_err(|_| {
+            Error::invalid_argument(
+                OP,
+                "configuration",
+                "TBLIS rhs rank exceeds c_int range".into(),
+            )
         })?,
         len: plan.rhs_len.as_mut_ptr(),
         stride: plan.rhs_stride.as_mut_ptr(),
@@ -324,9 +335,12 @@ where
         conj: 0,
         scalar: T::scalar(execution.beta),
         data: out_ptr.wrapping_add(out_offset) as *mut c_void,
-        ndim: c_int::try_from(plan.out_len.len()).map_err(|_| Error::InvalidConfig {
-            op: OP,
-            message: "TBLIS output rank exceeds c_int range".into(),
+        ndim: c_int::try_from(plan.out_len.len()).map_err(|_| {
+            Error::invalid_argument(
+                OP,
+                "configuration",
+                "TBLIS output rank exceeds c_int range".into(),
+            )
         })?,
         len: plan.out_len.as_mut_ptr(),
         stride: plan.out_stride.as_mut_ptr(),
@@ -355,10 +369,11 @@ where
 
 fn ensure_runtime_available() -> Result<()> {
     if !runtime_available()? {
-        return Err(Error::InvalidConfig {
-            op: OP,
-            message: "TBLIS runtime library is unavailable".into(),
-        });
+        return Err(Error::invalid_argument(
+            OP,
+            "configuration",
+            "TBLIS runtime library is unavailable".into(),
+        ));
     }
     Ok(())
 }
@@ -402,9 +417,12 @@ fn free_dims(rank: usize, contracting: &[usize], batch: &[usize]) -> SmallVec<[u
 fn dims_to_tblis(dims: &[usize]) -> Result<SmallVec<[len_type; 8]>> {
     dims.iter()
         .map(|&dim| {
-            len_type::try_from(dim).map_err(|_| Error::InvalidConfig {
-                op: OP,
-                message: format!("TBLIS dimension {dim} exceeds len_type range"),
+            len_type::try_from(dim).map_err(|_| {
+                Error::invalid_argument(
+                    OP,
+                    "configuration",
+                    format!("TBLIS dimension {dim} exceeds len_type range"),
+                )
             })
         })
         .collect()
@@ -414,9 +432,12 @@ fn strides_to_tblis(strides: &[isize]) -> Result<SmallVec<[stride_type; 8]>> {
     strides
         .iter()
         .map(|&stride| {
-            stride_type::try_from(stride).map_err(|_| Error::InvalidConfig {
-                op: OP,
-                message: format!("TBLIS stride {stride} exceeds stride_type range"),
+            stride_type::try_from(stride).map_err(|_| {
+                Error::invalid_argument(
+                    OP,
+                    "configuration",
+                    format!("TBLIS stride {stride} exceeds stride_type range"),
+                )
             })
         })
         .collect()

--- a/crates/tenferro-cpu/src/gemm/tblis_gemm.rs
+++ b/crates/tenferro-cpu/src/gemm/tblis_gemm.rs
@@ -404,7 +404,11 @@ pub(crate) fn runtime_available() -> Result<bool> {
 
 pub(crate) fn output_element_count(shape: &[usize]) -> Result<usize> {
     checked_product(shape).ok_or_else(|| {
-        Error::backend_failure(OP, "TBLIS output element count overflow while allocating")
+        Error::invalid_argument(
+            OP,
+            "configuration",
+            "TBLIS output element count overflow while allocating",
+        )
     })
 }
 

--- a/crates/tenferro-cpu/src/gemm/tests.rs
+++ b/crates/tenferro-cpu/src/gemm/tests.rs
@@ -221,6 +221,46 @@ fn gemm_analysis_cache_reuses_matching_direct_plan_and_reports_stats() {
 }
 
 #[test]
+fn gemm_analysis_cache_matches_view_layouts_before_reusing_a_plan() {
+    let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]).unwrap();
+    let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![0.0; 6]).unwrap();
+    let lhs_view = lhs.as_view();
+    let rhs_view = rhs.as_view();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    };
+    let mut cache = GemmAnalysisCache::default();
+
+    let first = analyse_gemm_cached(
+        &mut cache,
+        Some(11),
+        GemmAnalysisCacheKind::Direct,
+        &lhs_view,
+        &rhs_view,
+        &config,
+    )
+    .unwrap()
+    .expect("view layout should be representable as GEMM");
+    let cached = analyse_gemm_cached(
+        &mut cache,
+        Some(11),
+        GemmAnalysisCacheKind::Direct,
+        &lhs_view,
+        &rhs_view,
+        &config,
+    )
+    .unwrap()
+    .expect("the matching view layout should reuse the cached analysis");
+
+    assert_eq!((first.m, first.n, first.k), (2, 2, 3));
+    assert_eq!((cached.m, cached.n, cached.k), (2, 2, 3));
+    assert_eq!(cache.stats().entries, 1);
+}
+
+#[test]
 fn gemm_analysis_cache_shrink_invalidates_entries_instead_of_truncating_by_slot() {
     let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]).unwrap();
     let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3, 2], vec![0.0; 6]).unwrap();
@@ -259,6 +299,21 @@ fn gemm_analysis_cache_shrink_invalidates_entries_instead_of_truncating_by_slot(
         0,
         "shrinking a direct-indexed cache should not retain arbitrary low-slot entries as a fake LRU"
     );
+}
+
+#[test]
+fn gemm_analysis_cache_exposes_debug_capacity_and_clear_contract() {
+    let mut cache = GemmAnalysisCache::with_capacity(2);
+
+    assert_eq!(cache.capacity(), 2);
+    let debug = format!("{cache:?}");
+    assert!(debug.contains("GemmAnalysisCache"));
+    assert!(debug.contains("max_slots"));
+
+    cache.set_capacity(0);
+    assert_eq!(cache.capacity(), 0);
+    cache.clear();
+    assert_eq!(cache.stats().entries, 0);
 }
 
 #[cfg(feature = "cpu-faer")]

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -590,7 +590,7 @@ fn f32_index_to_i64(value: f32) -> crate::Result<i64> {
     if !value.is_finite() || value.fract() != 0.0 || value.abs() > F32_MAX_EXACT_INT {
         return Err(crate::Error::invalid_argument(
             "index_tensor",
-            "configuration",
+            "index",
             format!("index value {value} is not an exactly representable i64"),
         ));
     }
@@ -601,7 +601,7 @@ fn f64_index_to_i64(value: f64) -> crate::Result<i64> {
     if !value.is_finite() || value.fract() != 0.0 || value.abs() > F64_MAX_EXACT_INT {
         return Err(crate::Error::invalid_argument(
             "index_tensor",
-            "configuration",
+            "index",
             format!("index value {value} is not an exactly representable i64"),
         ));
     }
@@ -1255,14 +1255,14 @@ fn typed_dynamic_slice<T: Copy + Clone + PoolScalar>(
     if starts.shape.len() != 1 {
         return Err(crate::Error::invalid_argument(
             "dynamic_slice",
-            "configuration",
+            "starts",
             "starts must be a rank-1 tensor",
         ));
     }
     if starts.values.len() != input_shape.len() {
         return Err(crate::Error::invalid_argument(
             "dynamic_slice",
-            "configuration",
+            "starts",
             format!(
                 "starts length {} must match input rank {}",
                 starts.values.len(),

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -100,7 +100,7 @@ macro_rules! dispatch_same_dtype_without_bool_result {
             (Tensor::C32($lhs_t), Tensor::C32($rhs_t)) => Ok(Tensor::C32($body?)),
             (Tensor::C64($lhs_t), Tensor::C64($rhs_t)) => Ok(Tensor::C64($body?)),
             (Tensor::Bool(_), Tensor::Bool(_)) => {
-                Err(crate::Error::backend_failure($op, $bool_message))
+                Err(crate::Error::unsupported($op, $bool_message))
             }
             _ => Err(crate::Error::dtype_mismatch(
                 $op,

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -81,11 +81,11 @@ macro_rules! dispatch_same_dtype_result {
             (Tensor::Bool($lhs_t), Tensor::Bool($rhs_t)) => Ok(Tensor::Bool($body?)),
             (Tensor::C32($lhs_t), Tensor::C32($rhs_t)) => Ok(Tensor::C32($body?)),
             (Tensor::C64($lhs_t), Tensor::C64($rhs_t)) => Ok(Tensor::C64($body?)),
-            _ => Err(crate::Error::DTypeMismatch {
-                op: $op,
-                lhs: $lhs.dtype(),
-                rhs: $rhs.dtype(),
-            }),
+            _ => Err(crate::Error::dtype_mismatch(
+                $op,
+                $lhs.dtype(),
+                $rhs.dtype(),
+            )),
         }
     };
 }
@@ -102,11 +102,11 @@ macro_rules! dispatch_same_dtype_without_bool_result {
             (Tensor::Bool(_), Tensor::Bool(_)) => {
                 Err(crate::Error::backend_failure($op, $bool_message))
             }
-            _ => Err(crate::Error::DTypeMismatch {
-                op: $op,
-                lhs: $lhs.dtype(),
-                rhs: $rhs.dtype(),
-            }),
+            _ => Err(crate::Error::dtype_mismatch(
+                $op,
+                $lhs.dtype(),
+                $rhs.dtype(),
+            )),
         }
     };
 }
@@ -311,13 +311,13 @@ pub(crate) fn try_concatenate_with_pool(
     inputs: &[&Tensor],
     axis: usize,
 ) -> crate::Result<Tensor> {
-    let first = inputs
-        .first()
-        .copied()
-        .ok_or_else(|| crate::Error::InvalidConfig {
-            op: "concatenate",
-            message: "concatenate requires at least one input".into(),
-        })?;
+    let first = inputs.first().copied().ok_or_else(|| {
+        crate::Error::invalid_argument(
+            "concatenate",
+            "configuration",
+            "concatenate requires at least one input",
+        )
+    })?;
     dispatch_tensor_unary_result!(first, |t| typed_concatenate_from_dyn_inputs(
         buffers, t, inputs, axis
     ))
@@ -339,25 +339,25 @@ fn typed_slice<T: Copy + Clone + PoolScalar>(
     let input_shape = input.shape();
     let rank = input_shape.len();
     if config.starts.len() != rank {
-        return Err(crate::Error::RankMismatch {
-            op: "slice",
-            expected: rank,
-            actual: config.starts.len(),
-        });
+        return Err(crate::Error::rank_mismatch(
+            "slice",
+            rank,
+            config.starts.len(),
+        ));
     }
     if config.limits.len() != rank {
-        return Err(crate::Error::RankMismatch {
-            op: "slice",
-            expected: rank,
-            actual: config.limits.len(),
-        });
+        return Err(crate::Error::rank_mismatch(
+            "slice",
+            rank,
+            config.limits.len(),
+        ));
     }
     if config.strides.len() != rank {
-        return Err(crate::Error::RankMismatch {
-            op: "slice",
-            expected: rank,
-            actual: config.strides.len(),
-        });
+        return Err(crate::Error::rank_mismatch(
+            "slice",
+            rank,
+            config.strides.len(),
+        ));
     }
 
     let out_shape: Vec<usize> = input
@@ -369,23 +369,21 @@ fn typed_slice<T: Copy + Clone + PoolScalar>(
             let limit = config.limits[axis];
             let stride = config.strides[axis];
             if start > limit {
-                return Err(crate::Error::InvalidConfig {
-                    op: "slice",
-                    message: format!("start exceeds limit on axis {axis}"),
-                });
+                return Err(crate::Error::invalid_argument(
+                    "slice",
+                    "configuration",
+                    format!("start exceeds limit on axis {axis}"),
+                ));
             }
             if limit > dim {
-                return Err(crate::Error::AxisOutOfBounds {
-                    op: "slice",
-                    axis,
-                    rank,
-                });
+                return Err(crate::Error::axis_out_of_bounds("slice", axis, rank));
             }
             if stride == 0 {
-                return Err(crate::Error::InvalidConfig {
-                    op: "slice",
-                    message: format!("stride must be positive on axis {axis}"),
-                });
+                return Err(crate::Error::invalid_argument(
+                    "slice",
+                    "configuration",
+                    format!("stride must be positive on axis {axis}"),
+                ));
             }
             let span = limit - start;
             Ok(span.div_ceil(stride))
@@ -420,9 +418,12 @@ where
 {
     let first_dtype = inputs
         .first()
-        .ok_or_else(|| crate::Error::InvalidConfig {
-            op: "concatenate",
-            message: "concatenate requires at least one input".into(),
+        .ok_or_else(|| {
+            crate::Error::invalid_argument(
+                "concatenate",
+                "configuration",
+                "concatenate requires at least one input",
+            )
         })?
         .dtype();
     let typed_inputs = collect_typed_inputs(first_dtype, inputs)?;
@@ -439,10 +440,8 @@ where
     inputs
         .iter()
         .map(|tensor| {
-            TensorAsTyped::<T>::as_typed(*tensor).ok_or_else(|| crate::Error::DTypeMismatch {
-                op: "concatenate",
-                lhs: first_dtype,
-                rhs: tensor.dtype(),
+            TensorAsTyped::<T>::as_typed(*tensor).ok_or_else(|| {
+                crate::Error::dtype_mismatch("concatenate", first_dtype, tensor.dtype())
             })
         })
         .collect()
@@ -453,21 +452,17 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar>(
     inputs: &[&TypedTensor<T>],
     axis: usize,
 ) -> crate::Result<TypedTensor<T>> {
-    let first = inputs
-        .first()
-        .copied()
-        .ok_or_else(|| crate::Error::InvalidConfig {
-            op: "concatenate",
-            message: "concatenate requires at least one input".into(),
-        })?;
+    let first = inputs.first().copied().ok_or_else(|| {
+        crate::Error::invalid_argument(
+            "concatenate",
+            "configuration",
+            "concatenate requires at least one input",
+        )
+    })?;
     let first_shape = first.shape();
     let rank = first_shape.len();
     if axis >= rank {
-        return Err(crate::Error::AxisOutOfBounds {
-            op: "concatenate",
-            axis,
-            rank,
-        });
+        return Err(crate::Error::axis_out_of_bounds("concatenate", axis, rank));
     }
 
     let mut out_shape = first_shape.to_vec();
@@ -475,26 +470,27 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar>(
     for input in inputs {
         let input_shape = input.shape();
         if input_shape.len() != rank {
-            return Err(crate::Error::RankMismatch {
-                op: "concatenate",
-                expected: rank,
-                actual: input_shape.len(),
-            });
+            return Err(crate::Error::rank_mismatch(
+                "concatenate",
+                rank,
+                input_shape.len(),
+            ));
         }
         for dim in 0..rank {
             if dim == axis {
                 axis_extent = axis_extent.checked_add(input_shape[dim]).ok_or_else(|| {
-                    crate::Error::InvalidConfig {
-                        op: "concatenate",
-                        message: "concatenate axis extent overflows usize".to_string(),
-                    }
+                    crate::Error::invalid_argument(
+                        "concatenate",
+                        "configuration",
+                        "concatenate axis extent overflows usize".to_string(),
+                    )
                 })?;
             } else if input_shape[dim] != first_shape[dim] {
-                return Err(crate::Error::ShapeMismatch {
-                    op: "concatenate",
-                    lhs: first_shape.to_vec(),
-                    rhs: input_shape.to_vec(),
-                });
+                return Err(crate::Error::shape_mismatch(
+                    "concatenate",
+                    first_shape.to_vec(),
+                    input_shape.to_vec(),
+                ));
             }
         }
     }
@@ -505,9 +501,12 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar>(
     for input in inputs {
         segment_end = segment_end
             .checked_add(input.shape()[axis])
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "concatenate",
-                message: "concatenate segment offset overflows usize".to_string(),
+            .ok_or_else(|| {
+                crate::Error::invalid_argument(
+                    "concatenate",
+                    "configuration",
+                    "concatenate segment offset overflows usize".to_string(),
+                )
             })?;
         segment_ends.push(segment_end);
     }
@@ -521,10 +520,11 @@ fn typed_concatenate<T: Copy + Clone + PoolScalar>(
         let concat_idx = out_idx[axis];
         let input_pos = segment_ends.partition_point(|&end| concat_idx >= end);
         if input_pos == segment_ends.len() {
-            return Err(crate::Error::InvalidConfig {
-                op: "concatenate",
-                message: "output index must map to an input".to_string(),
-            });
+            return Err(crate::Error::invalid_argument(
+                "concatenate",
+                "configuration",
+                "output index must map to an input".to_string(),
+            ));
         }
         let axis_base = if input_pos == 0 {
             0
@@ -551,11 +551,7 @@ fn typed_reverse<T: Copy + Clone + PoolScalar>(
     let mut reverse_axis = vec![false; rank];
     for &axis in axes {
         if axis >= rank {
-            return Err(crate::Error::AxisOutOfBounds {
-                op: "reverse",
-                axis,
-                rank,
-            });
+            return Err(crate::Error::axis_out_of_bounds("reverse", axis, rank));
         }
         reverse_axis[axis] = true;
     }
@@ -592,20 +588,22 @@ const F64_MAX_EXACT_INT: f64 = 9_007_199_254_740_992.0;
 
 fn f32_index_to_i64(value: f32) -> crate::Result<i64> {
     if !value.is_finite() || value.fract() != 0.0 || value.abs() > F32_MAX_EXACT_INT {
-        return Err(crate::Error::InvalidConfig {
-            op: "index_tensor",
-            message: format!("index value {value} is not an exactly representable i64"),
-        });
+        return Err(crate::Error::invalid_argument(
+            "index_tensor",
+            "configuration",
+            format!("index value {value} is not an exactly representable i64"),
+        ));
     }
     Ok(value as i64)
 }
 
 fn f64_index_to_i64(value: f64) -> crate::Result<i64> {
     if !value.is_finite() || value.fract() != 0.0 || value.abs() > F64_MAX_EXACT_INT {
-        return Err(crate::Error::InvalidConfig {
-            op: "index_tensor",
-            message: format!("index value {value} is not an exactly representable i64"),
-        });
+        return Err(crate::Error::invalid_argument(
+            "index_tensor",
+            "configuration",
+            format!("index value {value} is not an exactly representable i64"),
+        ));
     }
     Ok(value as i64)
 }
@@ -643,63 +641,62 @@ fn try_index_tensor(tensor: &Tensor) -> crate::Result<IndexTensor> {
                 values: values?,
             })
         }
-        Tensor::Bool(_) => Err(crate::Error::InvalidConfig {
-            op: "index_tensor",
-            message: "bool index tensors are not supported".into(),
-        }),
-        Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::InvalidConfig {
-            op: "index_tensor",
-            message: "complex index tensors are not supported".into(),
-        }),
+        Tensor::Bool(_) => Err(crate::Error::invalid_argument(
+            "index_tensor",
+            "configuration",
+            "bool index tensors are not supported",
+        )),
+        Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::invalid_argument(
+            "index_tensor",
+            "configuration",
+            "complex index tensors are not supported",
+        )),
     }
 }
 
 fn checked_product(op: &'static str, role: &'static str, shape: &[usize]) -> crate::Result<usize> {
     shape.iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim)
-            .ok_or_else(|| crate::Error::InvalidConfig {
+        acc.checked_mul(dim).ok_or_else(|| {
+            crate::Error::invalid_argument(
                 op,
-                message: format!("{role} element count overflows usize"),
-            })
+                "configuration",
+                format!("{role} element count overflows usize"),
+            )
+        })
     })
 }
 
 fn linear_offset(op: &'static str, shape: &[usize], indices: &[usize]) -> crate::Result<usize> {
     if indices.len() != shape.len() {
-        return Err(crate::Error::RankMismatch {
-            op,
-            expected: shape.len(),
-            actual: indices.len(),
-        });
+        return Err(crate::Error::rank_mismatch(op, shape.len(), indices.len()));
     }
     let mut offset = 0usize;
     let mut stride = 1usize;
     for (axis, &index) in indices.iter().enumerate() {
         if index >= shape[axis] {
-            return Err(crate::Error::AxisOutOfBounds {
-                op,
-                axis,
-                rank: shape.len(),
-            });
+            return Err(crate::Error::axis_out_of_bounds(op, axis, shape.len()));
         }
-        let scaled = index
-            .checked_mul(stride)
-            .ok_or_else(|| crate::Error::InvalidConfig {
+        let scaled = index.checked_mul(stride).ok_or_else(|| {
+            crate::Error::invalid_argument(
                 op,
-                message: format!("linear index component overflows usize on axis {axis}"),
-            })?;
-        offset = offset
-            .checked_add(scaled)
-            .ok_or_else(|| crate::Error::InvalidConfig {
+                "configuration",
+                format!("linear index component overflows usize on axis {axis}"),
+            )
+        })?;
+        offset = offset.checked_add(scaled).ok_or_else(|| {
+            crate::Error::invalid_argument(
                 op,
-                message: format!("linear offset overflows usize on axis {axis}"),
-            })?;
-        stride = stride
-            .checked_mul(shape[axis])
-            .ok_or_else(|| crate::Error::InvalidConfig {
+                "configuration",
+                format!("linear offset overflows usize on axis {axis}"),
+            )
+        })?;
+        stride = stride.checked_mul(shape[axis]).ok_or_else(|| {
+            crate::Error::invalid_argument(
                 op,
-                message: format!("linear stride overflows usize after axis {axis}"),
-            })?;
+                "configuration",
+                format!("linear stride overflows usize after axis {axis}"),
+            )
+        })?;
     }
     Ok(offset)
 }
@@ -710,11 +707,11 @@ fn try_index_vector_size(
     index_vector_dim: usize,
 ) -> crate::Result<usize> {
     if index_vector_dim > shape.len() {
-        return Err(crate::Error::AxisOutOfBounds {
+        return Err(crate::Error::axis_out_of_bounds(
             op,
-            axis: index_vector_dim,
-            rank: shape.len(),
-        });
+            index_vector_dim,
+            shape.len(),
+        ));
     }
     Ok(if index_vector_dim == shape.len() {
         1
@@ -729,11 +726,11 @@ fn try_index_batch_shape(
     index_vector_dim: usize,
 ) -> crate::Result<Vec<usize>> {
     if index_vector_dim > shape.len() {
-        return Err(crate::Error::AxisOutOfBounds {
+        return Err(crate::Error::axis_out_of_bounds(
             op,
-            axis: index_vector_dim,
-            rank: shape.len(),
-        });
+            index_vector_dim,
+            shape.len(),
+        ));
     }
     if index_vector_dim == shape.len() {
         return Ok(shape.to_vec());
@@ -755,33 +752,36 @@ fn index_component(
 ) -> crate::Result<i64> {
     if index_vector_dim == indices.shape.len() {
         if component != 0 {
-            return Err(crate::Error::InvalidConfig {
+            return Err(crate::Error::invalid_argument(
                 op,
-                message: "implicit index_vector_dim only supports scalar index vectors".into(),
-            });
+                "configuration",
+                "implicit index_vector_dim only supports scalar index vectors",
+            ));
         }
         return Ok(indices.values[linear_offset(op, &indices.shape, batch_idx)?]);
     }
 
     if index_scratch.len() != indices.shape.len() {
-        return Err(crate::Error::InvalidConfig {
+        return Err(crate::Error::invalid_argument(
             op,
-            message: format!(
+            "configuration",
+            format!(
                 "index scratch length {} must match index tensor rank {}",
                 index_scratch.len(),
                 indices.shape.len()
             ),
-        });
+        ));
     }
     if batch_idx.len() + 1 != indices.shape.len() {
-        return Err(crate::Error::InvalidConfig {
+        return Err(crate::Error::invalid_argument(
             op,
-            message: format!(
+            "configuration",
+            format!(
                 "batch index rank {} must be one less than index tensor rank {}",
                 batch_idx.len(),
                 indices.shape.len()
             ),
-        });
+        ));
     }
     let mut batch_axis = 0usize;
     for (axis, slot) in index_scratch.iter_mut().enumerate() {
@@ -802,10 +802,11 @@ fn clamp_window_start(
     window_size: usize,
 ) -> crate::Result<usize> {
     if window_size > dim_size {
-        return Err(crate::Error::InvalidConfig {
+        return Err(crate::Error::invalid_argument(
             op,
-            message: format!("window size {window_size} exceeds dimension size {dim_size}"),
-        });
+            "configuration",
+            format!("window size {window_size} exceeds dimension size {dim_size}"),
+        ));
     }
     let max_start = dim_size.saturating_sub(window_size) as i64;
     Ok(start.clamp(0, max_start) as usize)
@@ -826,77 +827,75 @@ fn typed_gather<T: Copy + Clone + PoolScalar>(
     let operand_shape = operand.shape();
     let rank = operand_shape.len();
     if config.slice_sizes.len() != rank {
-        return Err(crate::Error::RankMismatch {
-            op: "gather",
-            expected: rank,
-            actual: config.slice_sizes.len(),
-        });
+        return Err(crate::Error::rank_mismatch(
+            "gather",
+            rank,
+            config.slice_sizes.len(),
+        ));
     }
 
     for &dim in &config.collapsed_slice_dims {
         if dim >= rank {
-            return Err(crate::Error::AxisOutOfBounds {
-                op: "gather",
-                axis: dim,
-                rank,
-            });
+            return Err(crate::Error::axis_out_of_bounds("gather", dim, rank));
         }
     }
     {
         let mut seen = vec![false; rank];
         for &dim in &config.collapsed_slice_dims {
             if seen[dim] {
-                return Err(crate::Error::DuplicateAxis {
-                    op: "gather",
-                    axis: dim,
-                    role: "collapsed_slice_dims",
-                });
+                return Err(crate::Error::duplicate_axis(
+                    "gather",
+                    dim,
+                    "collapsed_slice_dims",
+                ));
             }
             seen[dim] = true;
         }
     }
     for &dim in &config.collapsed_slice_dims {
         if config.slice_sizes[dim] != 1 {
-            return Err(crate::Error::InvalidConfig {
-                op: "gather",
-                message: format!(
+            return Err(crate::Error::invalid_argument(
+                "gather",
+                "configuration",
+                format!(
                     "collapsed slice dimension {dim} must have slice_size == 1, got {}",
                     config.slice_sizes[dim]
                 ),
-            });
+            ));
         }
     }
 
     let index_size =
         try_index_vector_size("gather", &start_indices.shape, config.index_vector_dim)?;
     if index_size != config.start_index_map.len() {
-        return Err(crate::Error::InvalidConfig {
-            op: "gather",
-            message: format!(
+        return Err(crate::Error::invalid_argument(
+            "gather",
+            "configuration",
+            format!(
                 "start_index_map length {} does not match index vector size {}",
                 config.start_index_map.len(),
                 index_size
             ),
-        });
+        ));
     }
     for &operand_dim in &config.start_index_map {
         if operand_dim >= rank {
-            return Err(crate::Error::AxisOutOfBounds {
-                op: "gather",
-                axis: operand_dim,
+            return Err(crate::Error::axis_out_of_bounds(
+                "gather",
+                operand_dim,
                 rank,
-            });
+            ));
         }
     }
     {
         let mut seen = vec![false; rank];
         for &operand_dim in &config.start_index_map {
             if seen[operand_dim] {
-                return Err(crate::Error::DuplicateAxis {
-                    op: "gather",
-                    axis: operand_dim,
-                    role: "start_index_map",
-                });
+                return Err(crate::Error::duplicate_axis(
+                    "gather",
+                    operand_dim,
+                    "start_index_map",
+                ));
             }
             seen[operand_dim] = true;
         }
@@ -904,14 +903,15 @@ fn typed_gather<T: Copy + Clone + PoolScalar>(
 
     let window_dims = operand_window_dims(rank, &config.collapsed_slice_dims);
     if config.offset_dims.len() != window_dims.len() {
-        return Err(crate::Error::InvalidConfig {
-            op: "gather",
-            message: format!(
+        return Err(crate::Error::invalid_argument(
+            "gather",
+            "configuration",
+            format!(
                 "offset_dims length {} does not match window dims count {}",
                 config.offset_dims.len(),
                 window_dims.len()
             ),
-        });
+        ));
     }
 
     let batch_shape =
@@ -919,22 +919,20 @@ fn typed_gather<T: Copy + Clone + PoolScalar>(
     let out_rank = batch_shape.len() + config.offset_dims.len();
     for &out_axis in &config.offset_dims {
         if out_axis >= out_rank {
-            return Err(crate::Error::AxisOutOfBounds {
-                op: "gather",
-                axis: out_axis,
-                rank: out_rank,
-            });
+            return Err(crate::Error::axis_out_of_bounds(
+                "gather", out_axis, out_rank,
+            ));
         }
     }
     {
         let mut seen = vec![false; out_rank];
         for &out_axis in &config.offset_dims {
             if seen[out_axis] {
-                return Err(crate::Error::DuplicateAxis {
-                    op: "gather",
-                    axis: out_axis,
-                    role: "offset_dims",
-                });
+                return Err(crate::Error::duplicate_axis(
+                    "gather",
+                    out_axis,
+                    "offset_dims",
+                ));
             }
             seen[out_axis] = true;
         }
@@ -1029,22 +1027,18 @@ where
     let op_rank = operand_shape.len();
     for &dim in &config.inserted_window_dims {
         if dim >= op_rank {
-            return Err(crate::Error::AxisOutOfBounds {
-                op: "scatter",
-                axis: dim,
-                rank: op_rank,
-            });
+            return Err(crate::Error::axis_out_of_bounds("scatter", dim, op_rank));
         }
     }
     {
         let mut seen = vec![false; op_rank];
         for &dim in &config.inserted_window_dims {
             if seen[dim] {
-                return Err(crate::Error::DuplicateAxis {
-                    op: "scatter",
-                    axis: dim,
-                    role: "inserted_window_dims",
-                });
+                return Err(crate::Error::duplicate_axis(
+                    "scatter",
+                    dim,
+                    "inserted_window_dims",
+                ));
             }
             seen[dim] = true;
         }
@@ -1053,33 +1047,34 @@ where
     let index_size =
         try_index_vector_size("scatter", &scatter_indices.shape, config.index_vector_dim)?;
     if index_size != config.scatter_dims_to_operand_dims.len() {
-        return Err(crate::Error::InvalidConfig {
-            op: "scatter",
-            message: format!(
+        return Err(crate::Error::invalid_argument(
+            "scatter",
+            "configuration",
+            format!(
                 "scatter_dims_to_operand_dims length {} does not match index vector size {}",
                 config.scatter_dims_to_operand_dims.len(),
                 index_size
             ),
-        });
+        ));
     }
     for &operand_dim in &config.scatter_dims_to_operand_dims {
         if operand_dim >= op_rank {
-            return Err(crate::Error::AxisOutOfBounds {
-                op: "scatter",
-                axis: operand_dim,
-                rank: op_rank,
-            });
+            return Err(crate::Error::axis_out_of_bounds(
+                "scatter",
+                operand_dim,
+                op_rank,
+            ));
         }
     }
     {
         let mut seen = vec![false; op_rank];
         for &operand_dim in &config.scatter_dims_to_operand_dims {
             if seen[operand_dim] {
-                return Err(crate::Error::DuplicateAxis {
-                    op: "scatter",
-                    axis: operand_dim,
-                    role: "scatter_dims_to_operand_dims",
-                });
+                return Err(crate::Error::duplicate_axis(
+                    "scatter",
+                    operand_dim,
+                    "scatter_dims_to_operand_dims",
+                ));
             }
             seen[operand_dim] = true;
         }
@@ -1089,56 +1084,61 @@ where
         try_index_batch_shape("scatter", &scatter_indices.shape, config.index_vector_dim)?;
     let window_dims = operand_window_dims(op_rank, &config.inserted_window_dims);
     if config.update_window_dims.len() != window_dims.len() {
-        return Err(crate::Error::InvalidConfig {
-            op: "scatter",
-            message: format!(
+        return Err(crate::Error::invalid_argument(
+            "scatter",
+            "configuration",
+            format!(
                 "update_window_dims length {} does not match window dims count {}",
                 config.update_window_dims.len(),
                 window_dims.len()
             ),
-        });
+        ));
     }
 
     let update_rank = updates_shape.len();
     let expected_batch_rank = update_rank
         .checked_sub(config.update_window_dims.len())
-        .ok_or_else(|| crate::Error::InvalidConfig {
-            op: "scatter",
-            message: format!(
-                "update_window_dims length {} exceeds update rank {}",
-                config.update_window_dims.len(),
-                update_rank
-            ),
+        .ok_or_else(|| {
+            crate::Error::invalid_argument(
+                "scatter",
+                "configuration",
+                format!(
+                    "update_window_dims length {} exceeds update rank {}",
+                    config.update_window_dims.len(),
+                    update_rank
+                ),
+            )
         })?;
     if expected_batch_rank != batch_shape.len() {
-        return Err(crate::Error::InvalidConfig {
-            op: "scatter",
-            message: format!(
+        return Err(crate::Error::invalid_argument(
+            "scatter",
+            "configuration",
+            format!(
                 "updates batch rank {} does not match index batch shape length {}",
                 expected_batch_rank,
                 batch_shape.len()
             ),
-        });
+        ));
     }
 
     for &axis in &config.update_window_dims {
         if axis >= update_rank {
-            return Err(crate::Error::AxisOutOfBounds {
-                op: "scatter",
+            return Err(crate::Error::axis_out_of_bounds(
+                "scatter",
                 axis,
-                rank: update_rank,
-            });
+                update_rank,
+            ));
         }
     }
     {
         let mut seen = vec![false; update_rank];
         for &axis in &config.update_window_dims {
             if seen[axis] {
-                return Err(crate::Error::DuplicateAxis {
-                    op: "scatter",
+                return Err(crate::Error::duplicate_axis(
+                    "scatter",
                     axis,
-                    role: "update_window_dims",
-                });
+                    "update_window_dims",
+                ));
             }
             seen[axis] = true;
         }
@@ -1154,16 +1154,13 @@ where
         for axis in 0..update_rank {
             if !is_update_window_dim[axis] {
                 if updates_shape[axis] != batch_shape[batch_axis] {
-                    return Err(crate::Error::InvalidConfig {
-                        op: "scatter",
-                        message: format!(
+                    return Err(crate::Error::invalid_argument("scatter", "configuration", format!(
                             "updates batch dim {} extent {} does not match index batch dim {} extent {}",
                             axis,
                             updates_shape[axis],
                             batch_axis,
                             batch_shape[batch_axis]
-                        ),
-                    });
+                        )));
                 }
                 batch_axis += 1;
             }
@@ -1249,27 +1246,29 @@ fn typed_dynamic_slice<T: Copy + Clone + PoolScalar>(
 ) -> crate::Result<TypedTensor<T>> {
     let input_shape = input.shape();
     if slice_sizes.len() != input_shape.len() {
-        return Err(crate::Error::RankMismatch {
-            op: "dynamic_slice",
-            expected: input_shape.len(),
-            actual: slice_sizes.len(),
-        });
+        return Err(crate::Error::rank_mismatch(
+            "dynamic_slice",
+            input_shape.len(),
+            slice_sizes.len(),
+        ));
     }
     if starts.shape.len() != 1 {
-        return Err(crate::Error::InvalidConfig {
-            op: "dynamic_slice",
-            message: "starts must be a rank-1 tensor".into(),
-        });
+        return Err(crate::Error::invalid_argument(
+            "dynamic_slice",
+            "configuration",
+            "starts must be a rank-1 tensor",
+        ));
     }
     if starts.values.len() != input_shape.len() {
-        return Err(crate::Error::InvalidConfig {
-            op: "dynamic_slice",
-            message: format!(
+        return Err(crate::Error::invalid_argument(
+            "dynamic_slice",
+            "configuration",
+            format!(
                 "starts length {} must match input rank {}",
                 starts.values.len(),
                 input_shape.len()
             ),
-        });
+        ));
     }
 
     let mut clamped_starts = vec![0usize; input_shape.len()];
@@ -1308,27 +1307,29 @@ fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar>(
     let operand_shape = operand.shape();
     let update_shape = update.shape();
     if update_shape.len() != operand_shape.len() {
-        return Err(crate::Error::RankMismatch {
-            op: "dynamic_update_slice",
-            expected: operand_shape.len(),
-            actual: update_shape.len(),
-        });
+        return Err(crate::Error::rank_mismatch(
+            "dynamic_update_slice",
+            operand_shape.len(),
+            update_shape.len(),
+        ));
     }
     if starts.shape.len() != 1 {
-        return Err(crate::Error::InvalidConfig {
-            op: "dynamic_update_slice",
-            message: "starts must be a rank-1 tensor".into(),
-        });
+        return Err(crate::Error::invalid_argument(
+            "dynamic_update_slice",
+            "configuration",
+            "starts must be a rank-1 tensor",
+        ));
     }
     if starts.values.len() != operand_shape.len() {
-        return Err(crate::Error::InvalidConfig {
-            op: "dynamic_update_slice",
-            message: format!(
+        return Err(crate::Error::invalid_argument(
+            "dynamic_update_slice",
+            "configuration",
+            format!(
                 "starts length {} must match operand rank {}",
                 starts.values.len(),
                 operand_shape.len()
             ),
-        });
+        ));
     }
 
     let mut clamped_starts = vec![0usize; operand_shape.len()];
@@ -1373,45 +1374,51 @@ fn typed_pad_with_fill<T: Copy + Clone + PoolScalar>(
     let input_shape = input.shape();
     let rank = input_shape.len();
     if config.edge_padding_low.len() != rank {
-        return Err(crate::Error::RankMismatch {
-            op: "pad",
-            expected: rank,
-            actual: config.edge_padding_low.len(),
-        });
+        return Err(crate::Error::rank_mismatch(
+            "pad",
+            rank,
+            config.edge_padding_low.len(),
+        ));
     }
     if config.edge_padding_high.len() != rank {
-        return Err(crate::Error::RankMismatch {
-            op: "pad",
-            expected: rank,
-            actual: config.edge_padding_high.len(),
-        });
+        return Err(crate::Error::rank_mismatch(
+            "pad",
+            rank,
+            config.edge_padding_high.len(),
+        ));
     }
     if config.interior_padding.len() != rank {
-        return Err(crate::Error::RankMismatch {
-            op: "pad",
-            expected: rank,
-            actual: config.interior_padding.len(),
-        });
+        return Err(crate::Error::rank_mismatch(
+            "pad",
+            rank,
+            config.interior_padding.len(),
+        ));
     }
 
     let mut out_shape = Vec::with_capacity(input_shape.len());
     for (axis, &input_extent) in input_shape.iter().enumerate() {
         if config.interior_padding[axis] < 0 {
-            return Err(crate::Error::InvalidConfig {
-                op: "pad",
-                message: format!("interior padding must be non-negative on axis {axis}"),
-            });
+            return Err(crate::Error::invalid_argument(
+                "pad",
+                "configuration",
+                format!("interior padding must be non-negative on axis {axis}"),
+            ));
         }
-        let input_extent_i64 =
-            i64::try_from(input_extent).map_err(|_| crate::Error::InvalidConfig {
-                op: "pad",
-                message: format!("input extent on axis {axis} does not fit in i64"),
-            })?;
+        let input_extent_i64 = i64::try_from(input_extent).map_err(|_| {
+            crate::Error::invalid_argument(
+                "pad",
+                "configuration",
+                format!("input extent on axis {axis} does not fit in i64"),
+            )
+        })?;
         let spacing = config.interior_padding[axis]
             .checked_add(1)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "pad",
-                message: format!("interior padding overflow on axis {axis}"),
+            .ok_or_else(|| {
+                crate::Error::invalid_argument(
+                    "pad",
+                    "configuration",
+                    format!("interior padding overflow on axis {axis}"),
+                )
             })?;
         let base = if input_extent == 0 {
             0
@@ -1420,24 +1427,31 @@ fn typed_pad_with_fill<T: Copy + Clone + PoolScalar>(
                 .checked_sub(1)
                 .and_then(|extent| extent.checked_mul(spacing))
                 .and_then(|extent| extent.checked_add(1))
-                .ok_or_else(|| crate::Error::InvalidConfig {
-                    op: "pad",
-                    message: format!("padded input extent overflow on axis {axis}"),
+                .ok_or_else(|| {
+                    crate::Error::invalid_argument(
+                        "pad",
+                        "configuration",
+                        format!("padded input extent overflow on axis {axis}"),
+                    )
                 })?
         };
         let dim = config.edge_padding_low[axis]
             .checked_add(config.edge_padding_high[axis])
             .and_then(|edge| edge.checked_add(base))
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "pad",
-                message: format!("output dimension overflow on axis {axis}"),
+            .ok_or_else(|| {
+                crate::Error::invalid_argument(
+                    "pad",
+                    "configuration",
+                    format!("output dimension overflow on axis {axis}"),
+                )
             })?;
-        out_shape.push(
-            usize::try_from(dim).map_err(|_| crate::Error::InvalidConfig {
-                op: "pad",
-                message: format!("negative output dimension on axis {axis}"),
-            })?,
-        );
+        out_shape.push(usize::try_from(dim).map_err(|_| {
+            crate::Error::invalid_argument(
+                "pad",
+                "configuration",
+                format!("negative output dimension on axis {axis}"),
+            )
+        })?);
     }
 
     let mut out = pooled_filled_tensor(buffers, out_shape.clone(), fill)?;

--- a/crates/tenferro-cpu/src/indexing/tests.rs
+++ b/crates/tenferro-cpu/src/indexing/tests.rs
@@ -14,7 +14,7 @@ fn typed_concatenate_rejects_empty_typed_inputs_without_panicking() {
     assert!(result.is_ok(), "empty typed concatenate should return Err");
     assert!(matches!(
         result.unwrap().unwrap_err(),
-        Error::InvalidConfig {
+        Error::Validation {
             op: "concatenate",
             ..
         }
@@ -39,7 +39,7 @@ fn index_component_rejects_mismatched_scratch_len_without_panicking() {
     );
     assert!(matches!(
         result.unwrap().unwrap_err(),
-        Error::InvalidConfig { op: "gather", .. }
+        Error::Validation { op: "gather", .. }
     ));
 }
 

--- a/crates/tenferro-cpu/src/indexing/tests.rs
+++ b/crates/tenferro-cpu/src/indexing/tests.rs
@@ -1,7 +1,10 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
-use super::{index_component, typed_concatenate, BufferPool, IndexTensor};
-use tenferro_tensor::{Error, TypedTensor};
+use super::{
+    dynamic_slice, f32_index_to_i64, f64_index_to_i64, index_component, typed_concatenate,
+    BufferPool, IndexTensor,
+};
+use tenferro_tensor::{Error, Tensor, TypedTensor, ValidationError};
 
 #[test]
 fn typed_concatenate_rejects_empty_typed_inputs_without_panicking() {
@@ -54,4 +57,44 @@ fn typed_concatenate_accepts_nonempty_typed_inputs() {
 
     assert_eq!(out.shape(), &[3]);
     assert_eq!(out.host_data().unwrap(), &[1.0, 2.0, 3.0]);
+}
+
+#[test]
+fn float_index_validation_identifies_the_index_argument() {
+    for error in [
+        f32_index_to_i64(1.5).unwrap_err(),
+        f64_index_to_i64(f64::NAN).unwrap_err(),
+    ] {
+        assert!(matches!(
+            error,
+            Error::Validation {
+                op: "index_tensor",
+                source: ValidationError::InvalidArgument {
+                    argument: "index",
+                    ..
+                },
+            }
+        ));
+    }
+}
+
+#[test]
+fn dynamic_slice_validation_identifies_the_starts_argument() {
+    let input = Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap();
+    let wrong_rank = Tensor::from_vec_col_major(vec![], vec![0_i64]).unwrap();
+    let wrong_length = Tensor::from_vec_col_major(vec![2], vec![0_i64, 1]).unwrap();
+
+    for starts in [&wrong_rank, &wrong_length] {
+        let error = dynamic_slice(&input, starts, &[1]).unwrap_err();
+        assert!(matches!(
+            error,
+            Error::Validation {
+                op: "dynamic_slice",
+                source: ValidationError::InvalidArgument {
+                    argument: "starts",
+                    ..
+                },
+            }
+        ));
+    }
 }

--- a/crates/tenferro-cpu/src/indexing_alloc.rs
+++ b/crates/tenferro-cpu/src/indexing_alloc.rs
@@ -6,7 +6,11 @@ fn checked_shape_product(op: &'static str, shape: &[usize]) -> crate::Result<usi
         .iter()
         .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
         .ok_or_else(|| {
-            crate::Error::backend_failure(op, format!("shape product overflow for {shape:?}"))
+            crate::Error::invalid_argument(
+                op,
+                "shape",
+                format!("shape product overflow for {shape:?}"),
+            )
         })
 }
 
@@ -21,4 +25,32 @@ where
     // SAFETY: callers use this helper only for pooled outputs that are fully overwritten.
     let data = unsafe { T::pool_acquire(buffers, len) };
     TypedTensor::from_vec_col_major(shape, data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pooled_uninit_tensor;
+    use crate::buffer_pool::BufferPool;
+    use tenferro_tensor::{ErrorKind, ValidationKind};
+
+    #[test]
+    fn pooled_uninit_tensor_preserves_shape_for_full_overwrite_callers() {
+        let mut buffers = BufferPool::new();
+        let output = pooled_uninit_tensor::<f64>(&mut buffers, vec![2, 3]).unwrap();
+
+        assert_eq!(output.shape(), &[2, 3]);
+    }
+
+    #[test]
+    fn pooled_uninit_tensor_reports_shape_product_overflow() {
+        let mut buffers = BufferPool::new();
+        let error = pooled_uninit_tensor::<f64>(&mut buffers, vec![usize::MAX, 2])
+            .expect_err("an overflowing output shape must be rejected before allocation");
+
+        assert_eq!(
+            error.kind(),
+            ErrorKind::Validation(ValidationKind::InvalidArgument)
+        );
+        assert!(error.to_string().contains("shape product overflow"));
+    }
 }

--- a/crates/tenferro-cpu/src/inject.rs
+++ b/crates/tenferro-cpu/src/inject.rs
@@ -369,6 +369,12 @@ fn lapack_registration_status(
 ///     ProviderRegistrationError::NullPointer { symbol: "dgemm" }
 /// );
 /// ```
+///
+/// # Errors
+///
+/// Returns [`ProviderRegistrationError::NullPointer`] for a null supplied
+/// pointer, `FunctionPointerSizeMismatch` when the ABI pointer width is not
+/// representable, or `AlreadyRegistered`/`UnknownStatus` from the injector.
 pub unsafe fn register_blas_gemm_provider_ptrs(
     abi: ProviderAbi,
     ptrs: BlasGemmProviderPtrSet,
@@ -508,6 +514,12 @@ unsafe fn cast_provider_function_pointer<F: Copy>(
 ///     ProviderRegistrationError::NullPointer { symbol: "dgesvd" }
 /// );
 /// ```
+///
+/// # Errors
+///
+/// Returns [`ProviderRegistrationError::NullPointer`] for a null supplied
+/// pointer, `FunctionPointerSizeMismatch` when the ABI pointer width is not
+/// representable, or `AlreadyRegistered`/`UnknownStatus` from the injector.
 pub unsafe fn register_lapack_provider_ptrs(
     abi: ProviderAbi,
     ptrs: LapackProviderPtrSet,

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -88,7 +88,9 @@ extern crate lapack_src as _;
 #[cfg(feature = "cpu-tblis-linked")]
 extern crate tblis_src as _;
 
-pub use affinity::{available_parallelism, process_cpu_affinity, process_cpu_affinity_count};
+pub use affinity::{
+    available_parallelism, process_cpu_affinity, process_cpu_affinity_count, CpuAffinityError,
+};
 pub use backend::{
     CpuBackend, CpuBackendError, CpuBackendKind, CpuExecutionInfo, CpuExecutionMode,
     DotGeneralProvider,
@@ -96,7 +98,9 @@ pub use backend::{
 pub use buffer_pool::BufferPoolStats;
 pub use capability::cpu_capabilities;
 pub use context::{CpuContext, CpuContextError};
-pub use placement::{CpuPlacement, CpuPlacementError, ResolvedCpuPlacement};
+pub use placement::{
+    CpuEngineConstructionError, CpuPlacement, CpuPlacementError, ResolvedCpuPlacement,
+};
 pub use topology::{
     discover_cpu_topology, CpuId, CpuNode, CpuSet, CpuSetError, CpuTopology, CpuTopologyError,
     NumaNodeId,
@@ -130,7 +134,7 @@ pub mod linalg_interop {
 }
 
 pub(crate) fn cpu_backend_buffer_error(op: &'static str) -> crate::Error {
-    crate::Error::backend_failure(
+    crate::Error::runtime_state(
         op,
         "CPU backend received backend buffer; download to host before CPU execution",
     )

--- a/crates/tenferro-cpu/src/lib.rs
+++ b/crates/tenferro-cpu/src/lib.rs
@@ -136,6 +136,32 @@ pub(crate) fn cpu_backend_buffer_error(op: &'static str) -> crate::Error {
     )
 }
 
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CpuNumericalError {
+    #[error("{op} detected division by zero for dtype {dtype:?}")]
+    DivisionByZero { op: &'static str, dtype: DType },
+    #[error("{op} received a negative integer exponent for dtype {dtype:?}")]
+    NegativeIntegerExponent { op: &'static str, dtype: DType },
+}
+
+pub(crate) fn cpu_division_by_zero(op: &'static str, dtype: DType) -> crate::Error {
+    crate::Error::extension(
+        op,
+        "cpu",
+        ErrorKind::NumericalFailure,
+        CpuNumericalError::DivisionByZero { op, dtype },
+    )
+}
+
+pub(crate) fn cpu_negative_integer_exponent(op: &'static str, dtype: DType) -> crate::Error {
+    crate::Error::extension(
+        op,
+        "cpu",
+        ErrorKind::NumericalFailure,
+        CpuNumericalError::NegativeIntegerExponent { op, dtype },
+    )
+}
+
 pub(crate) trait ConjElem {
     fn conj_elem(self) -> Self;
 }
@@ -182,7 +208,7 @@ pub(crate) fn typed_view<'a, T: Copy>(
         Buffer::Host(data) => {
             let strides = kernel_col_major_strides(tensor.shape());
             StridedView::new(data.as_slice(), tensor.shape(), &strides, 0)
-                .map_err(|err| crate::Error::backend_failure(op, err))
+                .map_err(|err| crate::Error::backend_source(op, err))
         }
         Buffer::Backend(_) => Err(cpu_backend_buffer_error(op)),
     }
@@ -201,7 +227,7 @@ pub(crate) fn typed_view_from_view<'a, T: Copy + 'static, R: TensorRank>(
         view.strides(),
         view.offset(),
     )
-    .map_err(|err| crate::Error::backend_failure(op, err))
+    .map_err(|err| crate::Error::backend_source(op, err))
 }
 
 pub(crate) fn materialize_tensor_read(
@@ -233,11 +259,7 @@ pub(crate) fn copy_tensor_read_into(
                 TensorWrite::View(TensorViewMut::$variant(mut dst)) => {
                     structural::typed_copy_view_into(&src, &mut dst, op)
                 }
-                _ => Err(crate::Error::DTypeMismatch {
-                    op,
-                    lhs: src_dtype,
-                    rhs: dst_dtype,
-                }),
+                _ => Err(crate::Error::dtype_mismatch(op, src_dtype, dst_dtype)),
             }
         }};
     }
@@ -345,7 +367,7 @@ where
     // Invariant: callers pass validated tensor-derived or prechecked output
     // shapes, and `strides` is their compact column-major layout.
     StridedArray::from_parts(data, shape, &strides, 0)
-        .map_err(|err| crate::Error::backend_failure("typed_array_uninit_from_pool", err))
+        .map_err(|err| crate::Error::backend_source("typed_array_uninit_from_pool", err))
 }
 
 pub(crate) fn tensor_from_array<T: Clone>(array: StridedArray<T>) -> TypedTensor<T> {

--- a/crates/tenferro-cpu/src/placement.rs
+++ b/crates/tenferro-cpu/src/placement.rs
@@ -1,6 +1,32 @@
 use thiserror::Error;
 
-use crate::{CpuBackendKind, CpuSet, CpuTopology, CpuTopologyError, NumaNodeId};
+use crate::{CpuBackendKind, CpuContextError, CpuSet, CpuTopology, CpuTopologyError, NumaNodeId};
+
+/// Typed failure raised while constructing a CPU execution engine.
+///
+/// The tensor-backed compatibility path and the managed engine path expose
+/// different concrete construction errors. This wrapper keeps both sources
+/// typed while allowing [`CpuPlacementError`] to present one public error
+/// shape.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::{CpuEngineConstructionError, CpuContextError};
+/// use std::error::Error;
+///
+/// let error = CpuEngineConstructionError::Context(CpuContextError::InvalidThreadCount);
+/// assert!(error.source().is_some());
+/// ```
+#[derive(Debug, Error)]
+pub enum CpuEngineConstructionError {
+    /// A managed CPU context or pinned worker engine could not be built.
+    #[error("managed CPU engine construction failed: {0}")]
+    Context(#[source] CpuContextError),
+    /// The tensor-backed compatibility engine could not be built.
+    #[error("tensor CPU engine construction failed: {0}")]
+    Tensor(#[source] tenferro_tensor::Error),
+}
 
 /// Requested CPU execution placement.
 ///
@@ -110,7 +136,7 @@ impl ResolvedCpuPlacement {
 /// };
 /// assert!(error.to_string().contains("affinity"));
 /// ```
-#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Error)]
 pub enum CpuPlacementError {
     /// Process-visible topology discovery failed before placement resolution.
     #[error("cannot resolve {requested:?} for {backend:?}: topology discovery failed: {source}")]
@@ -162,14 +188,25 @@ pub enum CpuPlacementError {
         backend: CpuBackendKind,
     },
     /// A pinned engine could not be built for an otherwise valid placement.
-    #[error("cannot resolve {requested:?} for {backend:?}: engine construction failed: {message}")]
+    #[error("cannot resolve {requested:?} for {backend:?}: engine construction failed: {source}")]
     EngineConstruction {
         /// The placement requested by the caller.
         requested: CpuPlacement,
         /// The selected public backend kind.
         backend: CpuBackendKind,
-        /// Worker-pool construction or affinity verification detail.
-        message: String,
+        /// Typed worker-pool construction or affinity failure.
+        #[source]
+        source: CpuEngineConstructionError,
+    },
+    /// The placement state reached an impossible internal compatibility mode.
+    #[error("cannot resolve {requested:?} for {backend:?}: {message}")]
+    InternalState {
+        /// The placement requested by the caller.
+        requested: CpuPlacement,
+        /// The selected public backend kind.
+        backend: CpuBackendKind,
+        /// Stable internal-state diagnostic.
+        message: &'static str,
     },
 }
 

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -12,14 +12,10 @@ fn validate_axes(op: &'static str, axes: &[usize], rank: usize) -> crate::Result
     let mut seen = vec![false; rank];
     for &axis in axes {
         if axis >= rank {
-            return Err(crate::Error::AxisOutOfBounds { op, axis, rank });
+            return Err(crate::Error::axis_out_of_bounds(op, axis, rank));
         }
         if seen[axis] {
-            return Err(crate::Error::DuplicateAxis {
-                op,
-                axis,
-                role: "axes",
-            });
+            return Err(crate::Error::duplicate_axis(op, axis, "axes"));
         }
         seen[axis] = true;
     }
@@ -53,10 +49,11 @@ fn validate_reduced_axes_nonempty(
     validate_axes(op, axes, shape.len())?;
     for &axis in axes {
         if shape[axis] == 0 {
-            return Err(crate::Error::InvalidConfig {
+            return Err(crate::Error::invalid_argument(
                 op,
-                message: format!("cannot reduce over zero-length axis {axis}"),
-            });
+                "configuration",
+                format!("cannot reduce over zero-length axis {axis}"),
+            ));
         }
     }
     Ok(())
@@ -523,11 +520,11 @@ where
 
     let input_view = typed_view(label, input)?;
     let mut current = reduce_axis(&input_view, first_axis, map_fn, reduce_fn, init)
-        .map_err(|err| crate::Error::backend_failure(label, err))?;
+        .map_err(|err| crate::Error::backend_source(label, err))?;
 
     for &axis in remaining_axes {
         current = reduce_axis(&current.view(), axis, map_fn, reduce_fn, init)
-            .map_err(|err| crate::Error::backend_failure(label, err))?;
+            .map_err(|err| crate::Error::backend_source(label, err))?;
     }
 
     TypedTensor::from_vec_col_major(output_shape, current.into_data())
@@ -574,11 +571,11 @@ where
 
     let input_view = typed_view_from_view(label, input)?;
     let mut current = reduce_axis(&input_view, first_axis, map_fn, reduce_fn, init)
-        .map_err(|err| crate::Error::backend_failure(label, err))?;
+        .map_err(|err| crate::Error::backend_source(label, err))?;
 
     for &axis in remaining_axes {
         current = reduce_axis(&current.view(), axis, map_fn, reduce_fn, init)
-            .map_err(|err| crate::Error::backend_failure(label, err))?;
+            .map_err(|err| crate::Error::backend_source(label, err))?;
     }
 
     TypedTensor::from_vec_col_major(output_shape, current.into_data())

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -142,6 +142,12 @@ macro_rules! impl_wrapping_reduction_elem {
 impl_wrapping_reduction_elem!(i32);
 impl_wrapping_reduction_elem!(i64);
 
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `AxisOutOfBounds`,
+/// `DuplicateAxis`, or `InvalidArgument` for invalid axes or zero-length
+/// reductions, [`crate::Error::Unsupported`] for `Bool`, or a typed backend
+/// error when the input storage cannot be read.
 pub fn reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     if let Some(output) = reduction_empty_axes_noop("reduce_sum", input, axes)? {
         return Ok(output);
@@ -152,7 +158,7 @@ pub fn reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_sum(t, axes)?)),
         Tensor::I32(t) => Ok(Tensor::I32(typed_reduce_sum_wrapping(t, axes)?)),
         Tensor::I64(t) => Ok(Tensor::I64(typed_reduce_sum_wrapping(t, axes)?)),
-        Tensor::Bool(_) => Err(crate::Error::backend_failure(
+        Tensor::Bool(_) => Err(crate::Error::unsupported(
             "reduce_sum",
             "unsupported dtype Bool",
         )),
@@ -207,7 +213,7 @@ pub(crate) fn reduce_sum_read(
             i64::zero(),
             "reduce_sum",
         )?)),
-        TensorRead::View(TensorView::Bool(_)) => Err(crate::Error::backend_failure(
+        TensorRead::View(TensorView::Bool(_)) => Err(crate::Error::unsupported(
             "reduce_sum",
             "unsupported dtype Bool",
         )),
@@ -230,6 +236,12 @@ pub(crate) fn reduce_sum_read(
     }
 }
 
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `AxisOutOfBounds`,
+/// `DuplicateAxis`, or `InvalidArgument` for invalid axes or zero-length
+/// reductions, [`crate::Error::Unsupported`] for `Bool`, or a typed backend
+/// error when the input storage cannot be read.
 pub fn reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     if let Some(output) = reduction_empty_axes_noop("reduce_prod", input, axes)? {
         return Ok(output);
@@ -240,7 +252,7 @@ pub fn reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_prod(t, axes)?)),
         Tensor::I32(t) => Ok(Tensor::I32(typed_reduce_prod_wrapping(t, axes)?)),
         Tensor::I64(t) => Ok(Tensor::I64(typed_reduce_prod_wrapping(t, axes)?)),
-        Tensor::Bool(_) => Err(crate::Error::backend_failure(
+        Tensor::Bool(_) => Err(crate::Error::unsupported(
             "reduce_prod",
             "unsupported dtype Bool",
         )),
@@ -295,7 +307,7 @@ pub(crate) fn reduce_prod_read(
             i64::one(),
             "reduce_prod",
         )?)),
-        TensorRead::View(TensorView::Bool(_)) => Err(crate::Error::backend_failure(
+        TensorRead::View(TensorView::Bool(_)) => Err(crate::Error::unsupported(
             "reduce_prod",
             "unsupported dtype Bool",
         )),
@@ -318,6 +330,12 @@ pub(crate) fn reduce_prod_read(
     }
 }
 
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `AxisOutOfBounds`,
+/// `DuplicateAxis`, or `InvalidArgument` for invalid axes or zero-length
+/// reductions, [`crate::Error::Unsupported`] for `Bool` and complex dtypes, or
+/// a typed backend error when the input storage cannot be read.
 pub fn reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     if let Some(output) = reduction_empty_axes_noop("reduce_max", input, axes)? {
         return Ok(output);
@@ -328,7 +346,7 @@ pub fn reduce_max(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         Tensor::F64(tensor) => Ok(Tensor::F64(typed_reduce_max(tensor, axes)?)),
         Tensor::I32(tensor) => Ok(Tensor::I32(typed_reduce_max_integer(tensor, axes)?)),
         Tensor::I64(tensor) => Ok(Tensor::I64(typed_reduce_max_integer(tensor, axes)?)),
-        Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::backend_failure(
+        Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::unsupported(
             "reduce_max",
             format!("unsupported dtype {:?}", input.dtype()),
         )),
@@ -393,13 +411,19 @@ pub(crate) fn reduce_max_read(
                 "reduce_max",
             )?))
         }
-        view => Err(crate::Error::backend_failure(
+        view => Err(crate::Error::unsupported(
             "reduce_max",
             format!("unsupported dtype {:?}", view.dtype()),
         )),
     }
 }
 
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `AxisOutOfBounds`,
+/// `DuplicateAxis`, or `InvalidArgument` for invalid axes or zero-length
+/// reductions, [`crate::Error::Unsupported`] for `Bool` and complex dtypes, or
+/// a typed backend error when the input storage cannot be read.
 pub fn reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
     if let Some(output) = reduction_empty_axes_noop("reduce_min", input, axes)? {
         return Ok(output);
@@ -410,7 +434,7 @@ pub fn reduce_min(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
         Tensor::F64(tensor) => Ok(Tensor::F64(typed_reduce_min(tensor, axes)?)),
         Tensor::I32(tensor) => Ok(Tensor::I32(typed_reduce_min_integer(tensor, axes)?)),
         Tensor::I64(tensor) => Ok(Tensor::I64(typed_reduce_min_integer(tensor, axes)?)),
-        Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::backend_failure(
+        Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => Err(crate::Error::unsupported(
             "reduce_min",
             format!("unsupported dtype {:?}", input.dtype()),
         )),
@@ -475,7 +499,7 @@ pub(crate) fn reduce_min_read(
                 "reduce_min",
             )?))
         }
-        view => Err(crate::Error::backend_failure(
+        view => Err(crate::Error::unsupported(
             "reduce_min",
             format!("unsupported dtype {:?}", view.dtype()),
         )),
@@ -546,7 +570,7 @@ where
 {
     validate_reduced_axes_nonempty(label, input.shape(), axes)?;
     if axes.is_empty() {
-        return Err(crate::Error::backend_failure(
+        return Err(crate::Error::unsupported(
             label,
             "empty-axis view reductions require backend-owned materialization",
         ));
@@ -563,7 +587,7 @@ where
     let mut sorted_axes = axes.to_vec();
     sorted_axes.sort_unstable_by(|a, b| b.cmp(a));
     let Some((&first_axis, remaining_axes)) = sorted_axes.split_first() else {
-        return Err(crate::Error::backend_failure(
+        return Err(crate::Error::unsupported(
             label,
             "empty-axis view reductions require backend-owned materialization",
         ));
@@ -581,6 +605,11 @@ where
     TypedTensor::from_vec_col_major(output_shape, current.into_data())
 }
 
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `AxisOutOfBounds`,
+/// `DuplicateAxis`, or `InvalidArgument` for invalid axes or zero-length
+/// reductions, or a typed backend error while materializing the result.
 pub fn typed_reduce_sum<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Send + Sync + Zero + Add<Output = T>,
@@ -605,6 +634,11 @@ where
     )
 }
 
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `AxisOutOfBounds`,
+/// `DuplicateAxis`, or `InvalidArgument` for invalid axes or zero-length
+/// reductions, or a typed backend error while materializing the result.
 pub fn typed_reduce_prod<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Send + Sync + One + Mul<Output = T>,
@@ -629,6 +663,11 @@ where
     )
 }
 
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `AxisOutOfBounds`,
+/// `DuplicateAxis`, or `InvalidArgument` for invalid axes or zero-length
+/// reductions, or a typed backend error while materializing the result.
 pub fn typed_reduce_max<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>
 where
     T: Float + Send + Sync,
@@ -662,6 +701,11 @@ where
     )
 }
 
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `AxisOutOfBounds`,
+/// `DuplicateAxis`, or `InvalidArgument` for invalid axes or zero-length
+/// reductions, or a typed backend error while materializing the result.
 pub fn typed_reduce_min<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>
 where
     T: Float + Send + Sync,

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -252,7 +252,7 @@ pub(crate) fn validate_cpu_host_placement(
     ) {
         return Ok(());
     }
-    Err(crate::Error::backend_failure(
+    Err(crate::Error::runtime_state(
         op,
         format!(
             "CPU backend requires {role} host placement for {op}, got {:?}",
@@ -729,6 +729,11 @@ where
     })
 }
 
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `ShapeMismatch` when the input and
+/// output element counts differ, or `InvalidArgument` when checked shape
+/// products overflow `usize` or output storage cannot be constructed.
 pub fn typed_reshape<T: Clone + 'static>(
     tensor: &TypedTensor<T>,
     shape: &[usize],

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -29,29 +29,21 @@ fn with_test_pool<T>(f: impl FnOnce(&mut BufferPool) -> T) -> T {
 
 fn validate_rank(op: &'static str, expected: usize, actual: usize) -> crate::Result<()> {
     if expected != actual {
-        return Err(crate::Error::RankMismatch {
-            op,
-            expected,
-            actual,
-        });
+        return Err(crate::Error::rank_mismatch(op, expected, actual));
     }
     Ok(())
 }
 
 fn validate_axis(op: &'static str, axis: usize, rank: usize) -> crate::Result<()> {
     if axis >= rank {
-        return Err(crate::Error::AxisOutOfBounds { op, axis, rank });
+        return Err(crate::Error::axis_out_of_bounds(op, axis, rank));
     }
     Ok(())
 }
 
 fn validate_axes_distinct(op: &'static str, axis_a: usize, axis_b: usize) -> crate::Result<()> {
     if axis_a == axis_b {
-        return Err(crate::Error::DuplicateAxis {
-            op,
-            axis: axis_a,
-            role: "axes",
-        });
+        return Err(crate::Error::duplicate_axis(op, axis_a, "axes"));
     }
     Ok(())
 }
@@ -62,11 +54,13 @@ fn checked_shape_product(
     shape: &[usize],
 ) -> crate::Result<usize> {
     shape.iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim)
-            .ok_or_else(|| crate::Error::InvalidConfig {
+        acc.checked_mul(dim).ok_or_else(|| {
+            crate::Error::invalid_argument(
                 op,
-                message: format!("{role} element count overflows usize"),
-            })
+                "configuration",
+                format!("{role} element count overflows usize"),
+            )
+        })
     })
 }
 
@@ -76,11 +70,7 @@ fn validate_permutation(op: &'static str, perm: &[usize], rank: usize) -> crate:
     for &axis in perm {
         validate_axis(op, axis, rank)?;
         if seen[axis] {
-            return Err(crate::Error::DuplicateAxis {
-                op,
-                axis,
-                role: "perm",
-            });
+            return Err(crate::Error::duplicate_axis(op, axis, "perm"));
         }
         seen[axis] = true;
     }
@@ -137,7 +127,7 @@ fn host_view<'a, T: Copy>(
         crate::Buffer::Host(data) => {
             let strides = col_major_strides(tensor.shape());
             StridedView::new(data.as_slice(), tensor.shape(), &strides, 0)
-                .map_err(|err| crate::Error::backend_failure(op, err))
+                .map_err(|err| crate::Error::backend_source(op, err))
         }
         crate::Buffer::Backend(_) => Err(cpu_backend_buffer_error(op)),
     }
@@ -149,7 +139,7 @@ fn copy_view_to_array<T: Copy + Clone + Send + Sync + 'static>(
     src: &StridedView<'_, T>,
     placement: &tenferro_tensor::Placement,
 ) -> crate::Result<TypedTensor<T>> {
-    copy_into(&mut out.view_mut(), src).map_err(|err| crate::Error::backend_failure(op, err))?;
+    copy_into(&mut out.view_mut(), src).map_err(|err| crate::Error::backend_source(op, err))?;
     tensor_from_array_with_placement(op, out, placement)
 }
 
@@ -164,7 +154,7 @@ fn tensor_from_array_with_placement<T: 'static>(
         crate::Buffer::Host(out.into_data()),
         placement.clone(),
     )
-    .map_err(|err| crate::Error::backend_failure(op, err))
+    .map_err(|err| crate::Error::backend_source(op, err))
 }
 
 pub(crate) fn typed_materialize_view_with_pool<T, R>(
@@ -186,13 +176,13 @@ where
         view.strides(),
         view.offset(),
     )
-    .map_err(|err| crate::Error::backend_failure(op, err))?;
+    .map_err(|err| crate::Error::backend_source(op, err))?;
     // INVARIANT: validated equal-shaped copy_into overwrites every logical output element.
     // SAFETY: copy_into overwrites every logical output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, view.shape()) }?;
-    copy_into(&mut out.view_mut(), &src).map_err(|err| crate::Error::backend_failure(op, err))?;
+    copy_into(&mut out.view_mut(), &src).map_err(|err| crate::Error::backend_source(op, err))?;
     let shape = R::shape_from_vec(view.shape().to_vec().into())
-        .map_err(|err| crate::Error::backend_failure(op, err))?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
     TypedTensor::from_buffer_col_major(
         shape,
         crate::Buffer::Host(out.into_data()),
@@ -210,18 +200,19 @@ where
     R: TensorRank,
 {
     if src.shape() != dst.shape() {
-        return Err(crate::Error::ShapeMismatch {
+        return Err(crate::Error::shape_mismatch(
             op,
-            lhs: src.shape().to_vec(),
-            rhs: dst.shape().to_vec(),
-        });
+            src.shape().to_vec(),
+            dst.shape().to_vec(),
+        ));
     }
     if let (Some(src_buffer), Some(dst_buffer)) = (src.backend_buffer(), dst.backend_buffer()) {
         if Arc::ptr_eq(src_buffer, dst_buffer) {
-            return Err(crate::Error::InvalidConfig {
+            return Err(crate::Error::invalid_argument(
                 op,
-                message: "CPU copy source and destination allocations must not alias".into(),
-            });
+                "configuration",
+                "CPU copy source and destination allocations must not alias",
+            ));
         }
     }
     if src.backend_buffer().is_some() || dst.backend_buffer().is_some() {
@@ -236,7 +227,7 @@ where
         src.strides(),
         src.offset(),
     )
-    .map_err(|err| crate::Error::backend_failure(op, err))?;
+    .map_err(|err| crate::Error::backend_source(op, err))?;
     let dst_shape = dst.shape().to_vec();
     let dst_strides = dst.strides().to_vec();
     let dst_offset = dst.offset();
@@ -246,8 +237,8 @@ where
         &dst_strides,
         dst_offset,
     )
-    .map_err(|err| crate::Error::backend_failure(op, err))?;
-    copy_into(&mut dst_view, &src_view).map_err(|err| crate::Error::backend_failure(op, err))
+    .map_err(|err| crate::Error::backend_source(op, err))?;
+    copy_into(&mut dst_view, &src_view).map_err(|err| crate::Error::backend_source(op, err))
 }
 
 pub(crate) fn validate_cpu_host_placement(
@@ -594,10 +585,7 @@ fn validate_real_cast_to_i64(value: f64) -> crate::Result<()> {
 }
 
 fn invalid_cast_value(message: String) -> crate::Error {
-    crate::Error::InvalidConfig {
-        op: "cast",
-        message,
-    }
+    crate::Error::invalid_argument("cast", "configuration", message)
 }
 
 #[cfg(test)]
@@ -688,7 +676,7 @@ pub(crate) fn typed_transpose<T: Copy + Clone + Send + Sync + 'static>(
     let src = host_view("transpose", tensor)?;
     let permuted = src
         .permute(perm)
-        .map_err(|err| crate::Error::backend_failure("transpose", err))?;
+        .map_err(|err| crate::Error::backend_source("transpose", err))?;
     // SAFETY: copy_into overwrites every output element.
     let out = unsafe { typed_array_uninit(permuted.dims()) };
     copy_view_to_array("transpose", out, &permuted, tensor.placement())
@@ -707,7 +695,7 @@ where
     let src = typed_view_from_view("transpose", view)?;
     let permuted = src
         .permute(perm)
-        .map_err(|err| crate::Error::backend_failure("transpose", err))?;
+        .map_err(|err| crate::Error::backend_source("transpose", err))?;
     checked_shape_product("transpose", "output shape", permuted.dims())?;
     // SAFETY: copy_into overwrites every output element.
     let out = make_out(permuted.dims())?;
@@ -748,11 +736,11 @@ pub fn typed_reshape<T: Clone + 'static>(
     let old_n = checked_shape_product("reshape", "input shape", tensor.shape())?;
     let new_n = checked_shape_product("reshape", "output shape", shape)?;
     if old_n != new_n {
-        return Err(crate::Error::ShapeMismatch {
-            op: "reshape",
-            lhs: tensor.shape().to_vec(),
-            rhs: shape.to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "reshape",
+            tensor.shape().to_vec(),
+            shape.to_vec(),
+        ));
     }
     TypedTensor::from_buffer_col_major(
         shape.to_vec(),
@@ -773,11 +761,11 @@ where
     let old_n = checked_shape_product("reshape", "input shape", view.shape())?;
     let new_n = checked_shape_product("reshape", "output shape", shape)?;
     if old_n != new_n {
-        return Err(crate::Error::ShapeMismatch {
-            op: "reshape",
-            lhs: view.shape().to_vec(),
-            rhs: shape.to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "reshape",
+            view.shape().to_vec(),
+            shape.to_vec(),
+        ));
     }
 
     let src = typed_view_from_view("reshape", view)?;
@@ -787,9 +775,9 @@ where
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, shape) }?;
     let copy_strides = col_major_strides(view.shape());
     let mut copy_target = StridedViewMut::new(out.data_mut(), view.shape(), &copy_strides, 0)
-        .map_err(|err| crate::Error::backend_failure("reshape", err))?;
+        .map_err(|err| crate::Error::backend_source("reshape", err))?;
     copy_into(&mut copy_target, &src)
-        .map_err(|err| crate::Error::backend_failure("reshape", err))?;
+        .map_err(|err| crate::Error::backend_source("reshape", err))?;
     TypedTensor::from_buffer_col_major(
         shape.to_vec(),
         crate::Buffer::Host(out.into_data()),
@@ -855,21 +843,21 @@ where
     for (src_axis, &dst_axis) in dims.iter().enumerate() {
         validate_axis("broadcast_in_dim", dst_axis, shape.len())?;
         if seen[dst_axis] {
-            return Err(crate::Error::DuplicateAxis {
-                op: "broadcast_in_dim",
-                axis: dst_axis,
-                role: "dims",
-            });
+            return Err(crate::Error::duplicate_axis(
+                "broadcast_in_dim",
+                dst_axis,
+                "dims",
+            ));
         }
         seen[dst_axis] = true;
         let source_dim = view.shape()[src_axis];
         let target_dim = shape[dst_axis];
         if source_dim != target_dim && source_dim != 1 {
-            return Err(crate::Error::ShapeMismatch {
-                op: "broadcast_in_dim",
-                lhs: view.shape().to_vec(),
-                rhs: shape.to_vec(),
-            });
+            return Err(crate::Error::shape_mismatch(
+                "broadcast_in_dim",
+                view.shape().to_vec(),
+                shape.to_vec(),
+            ));
         }
         base_dims[dst_axis] = source_dim;
         base_strides[dst_axis] = view.strides()[src_axis];
@@ -883,15 +871,15 @@ where
         &base_strides,
         view.offset(),
     )
-    .map_err(|err| crate::Error::backend_failure("broadcast_in_dim", err))?;
+    .map_err(|err| crate::Error::backend_source("broadcast_in_dim", err))?;
     let broadcast: StridedView<'_, T, Identity> = base
         .broadcast(shape)
-        .map_err(|err| crate::Error::backend_failure("broadcast_in_dim", err))?;
+        .map_err(|err| crate::Error::backend_source("broadcast_in_dim", err))?;
     checked_shape_product("broadcast_in_dim", "output shape", shape)?;
     // SAFETY: copy_into overwrites every output element.
     let mut out = make_out(shape)?;
     copy_into(&mut out.view_mut(), &broadcast)
-        .map_err(|err| crate::Error::backend_failure("broadcast_in_dim", err))?;
+        .map_err(|err| crate::Error::backend_source("broadcast_in_dim", err))?;
     tensor_from_array_with_placement("broadcast_in_dim", out, view.placement())
 }
 
@@ -907,7 +895,7 @@ where
     // SAFETY: map_into overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, tensor.shape()) }?;
     map_into(&mut out.view_mut(), &typed_view("convert", tensor)?, f)
-        .map_err(|err| crate::Error::backend_failure("convert", err))?;
+        .map_err(|err| crate::Error::backend_source("convert", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -923,11 +911,11 @@ pub(crate) fn typed_extract_diagonal<T: Copy + Clone + Send + Sync>(
 
     let diag = host_view("extract_diagonal", tensor)?
         .diagonal_view(&[(axis_a, axis_b)])
-        .map_err(|err| crate::Error::backend_failure("extract_diagonal", err))?;
+        .map_err(|err| crate::Error::backend_source("extract_diagonal", err))?;
     // SAFETY: copy_into overwrites every output element.
     let mut out = unsafe { typed_array_uninit(diag.dims()) };
     copy_into(&mut out.view_mut(), &diag)
-        .map_err(|err| crate::Error::backend_failure("extract_diagonal", err))?;
+        .map_err(|err| crate::Error::backend_source("extract_diagonal", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -946,11 +934,11 @@ where
 
     let diag = host_view("extract_diagonal", tensor)?
         .diagonal_view(&[(axis_a, axis_b)])
-        .map_err(|err| crate::Error::backend_failure("extract_diagonal", err))?;
+        .map_err(|err| crate::Error::backend_source("extract_diagonal", err))?;
     // SAFETY: copy_into overwrites every output element.
     let mut out = unsafe { typed_array_uninit_from_pool(buffers, diag.dims()) }?;
     copy_into(&mut out.view_mut(), &diag)
-        .map_err(|err| crate::Error::backend_failure("extract_diagonal", err))?;
+        .map_err(|err| crate::Error::backend_source("extract_diagonal", err))?;
     Ok(tensor_from_array(out))
 }
 
@@ -988,11 +976,11 @@ where
 {
     validate_axis("embed_diagonal", axis_a, tensor.shape().len())?;
     if axis_b > tensor.shape().len() {
-        return Err(crate::Error::AxisOutOfBounds {
-            op: "embed_diagonal",
-            axis: axis_b,
-            rank: tensor.shape().len(),
-        });
+        return Err(crate::Error::axis_out_of_bounds(
+            "embed_diagonal",
+            axis_b,
+            tensor.shape().len(),
+        ));
     }
 
     let n = tensor.shape()[axis_a];
@@ -1080,11 +1068,7 @@ fn typed_triangular_mask<T: Copy + Zero + Clone>(
 ) -> crate::Result<TypedTensor<T>> {
     let op = if upper { "triu" } else { "tril" };
     if tensor.shape().len() < 2 {
-        return Err(crate::Error::RankMismatch {
-            op,
-            expected: 2,
-            actual: tensor.shape().len(),
-        });
+        return Err(crate::Error::rank_mismatch(op, 2, tensor.shape().len()));
     }
 
     let rows = tensor.shape()[0];
@@ -1134,11 +1118,7 @@ where
 {
     let op = if upper { "triu" } else { "tril" };
     if tensor.shape().len() < 2 {
-        return Err(crate::Error::RankMismatch {
-            op,
-            expected: 2,
-            actual: tensor.shape().len(),
-        });
+        return Err(crate::Error::rank_mismatch(op, 2, tensor.shape().len()));
     }
 
     let rows = tensor.shape()[0];
@@ -1183,18 +1163,21 @@ fn checked_triangular_extent(
     cols: usize,
 ) -> crate::Result<(usize, usize)> {
     let batch_count = shape[2..].iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim)
-            .ok_or_else(|| crate::Error::InvalidConfig {
+        acc.checked_mul(dim).ok_or_else(|| {
+            crate::Error::invalid_argument(
                 op,
-                message: format!("batch extent overflows usize: {acc} * {dim}"),
-            })
+                "configuration",
+                format!("batch extent overflows usize: {acc} * {dim}"),
+            )
+        })
     })?;
-    let block_size = rows
-        .checked_mul(cols)
-        .ok_or_else(|| crate::Error::InvalidConfig {
+    let block_size = rows.checked_mul(cols).ok_or_else(|| {
+        crate::Error::invalid_argument(
             op,
-            message: format!("matrix block size overflows usize: {rows} * {cols}"),
-        })?;
+            "configuration",
+            format!("matrix block size overflows usize: {rows} * {cols}"),
+        )
+    })?;
     Ok((batch_count, block_size))
 }
 
@@ -1206,22 +1189,27 @@ fn checked_triangular_offset(
     rows: usize,
     row_idx: usize,
 ) -> crate::Result<usize> {
-    let base = batch_idx
-        .checked_mul(block_size)
-        .ok_or_else(|| crate::Error::InvalidConfig {
+    let base = batch_idx.checked_mul(block_size).ok_or_else(|| {
+        crate::Error::invalid_argument(
             op,
-            message: format!("batch offset overflows usize: {batch_idx} * {block_size}"),
-        })?;
-    let col_offset = col
-        .checked_mul(rows)
-        .ok_or_else(|| crate::Error::InvalidConfig {
+            "configuration",
+            format!("batch offset overflows usize: {batch_idx} * {block_size}"),
+        )
+    })?;
+    let col_offset = col.checked_mul(rows).ok_or_else(|| {
+        crate::Error::invalid_argument(
             op,
-            message: format!("column offset overflows usize: {col} * {rows}"),
-        })?;
+            "configuration",
+            format!("column offset overflows usize: {col} * {rows}"),
+        )
+    })?;
     base.checked_add(col_offset)
         .and_then(|offset| offset.checked_add(row_idx))
-        .ok_or_else(|| crate::Error::InvalidConfig {
-            op,
-            message: "triangular mask offset overflows usize".to_string(),
+        .ok_or_else(|| {
+            crate::Error::invalid_argument(
+                op,
+                "configuration",
+                "triangular mask offset overflows usize".to_string(),
+            )
         })
 }

--- a/crates/tenferro-cpu/src/structural.rs
+++ b/crates/tenferro-cpu/src/structural.rs
@@ -585,7 +585,7 @@ fn validate_real_cast_to_i64(value: f64) -> crate::Result<()> {
 }
 
 fn invalid_cast_value(message: String) -> crate::Error {
-    crate::Error::invalid_argument("cast", "configuration", message)
+    crate::Error::invalid_argument("cast", "value", message)
 }
 
 #[cfg(test)]

--- a/crates/tenferro-cpu/src/tests.rs
+++ b/crates/tenferro-cpu/src/tests.rs
@@ -493,7 +493,7 @@ fn typed_array_uninit_from_pool_rejects_shape_product_overflow_without_panicking
     );
     assert!(matches!(
         result.unwrap(),
-        Err(tenferro_tensor::Error::InvalidConfig {
+        Err(tenferro_tensor::Error::Validation {
             op: "typed_array_uninit_from_pool",
             ..
         })

--- a/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
@@ -37,28 +37,28 @@ fn diagonal_scatter_config() -> ScatterConfig {
 fn expect_invalid_config(result: crate::Result<Tensor>, op: &'static str) {
     assert!(matches!(
         result,
-        Err(crate::Error::InvalidConfig { op: actual, .. }) if actual == op
+        Err(crate::Error::Validation { op: actual, .. }) if actual == op
     ));
 }
 
 fn expect_rank_mismatch(result: crate::Result<Tensor>, op: &'static str) {
     assert!(matches!(
         result,
-        Err(crate::Error::RankMismatch { op: actual, .. }) if actual == op
+        Err(crate::Error::Validation { op: actual, source: tenferro_tensor::ValidationError::RankMismatch { .. } }) if actual == op
     ));
 }
 
 fn expect_axis_oob(result: crate::Result<Tensor>, op: &'static str) {
     assert!(matches!(
         result,
-        Err(crate::Error::AxisOutOfBounds { op: actual, .. }) if actual == op
+        Err(crate::Error::Validation { op: actual, source: tenferro_tensor::ValidationError::AxisOutOfBounds { .. } }) if actual == op
     ));
 }
 
 fn expect_duplicate_axis(result: crate::Result<Tensor>, op: &'static str) {
     assert!(matches!(
         result,
-        Err(crate::Error::DuplicateAxis { op: actual, .. }) if actual == op
+        Err(crate::Error::Validation { op: actual, source: tenferro_tensor::ValidationError::DuplicateAxis { .. } }) if actual == op
     ));
 }
 
@@ -217,7 +217,10 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
             &Tensor::F64(TypedTensor::zeros(vec![2]).unwrap()),
             &diagonal_scatter_config(),
         ),
-        Err(crate::Error::DTypeMismatch { op: "scatter", .. })
+        Err(crate::Error::Validation {
+            op: "scatter",
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
     ));
 
     let slice_cfg = SliceConfig {
@@ -712,9 +715,9 @@ fn cpu_exec_session_covers_dot_errors_and_reclaim_dispatch() {
         };
         assert!(matches!(
             exec.dot_general(&f64_vec, &f32_vec, &dot_cfg),
-            Err(crate::Error::DTypeMismatch {
+            Err(crate::Error::Validation {
                 op: "dot_general",
-                ..
+                source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
             })
         ));
 

--- a/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_indexing_coverage_tests.rs
@@ -208,7 +208,7 @@ fn cpu_indexing_dispatch_covers_supported_dtypes() {
             &Tensor::from_vec_col_major(vec![2], vec![true, false]).unwrap(),
             &diagonal_scatter_config(),
         ),
-        Err(crate::Error::BackendFailure { op: "scatter", .. })
+        Err(crate::Error::Unsupported { op: "scatter", .. })
     ));
     assert!(matches!(
         scatter(

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -63,7 +63,7 @@ fn cpu_runtime_materialization_rejects_owned_host_buffer_with_device_placement()
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::RuntimeState {
             op: "CpuBackend::to_contiguous_read",
             ref message,
         } if message.contains("source host placement") && message.contains("Device")
@@ -82,7 +82,7 @@ fn cpu_runtime_materialization_rejects_host_view_with_device_placement() {
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::RuntimeState {
             op: "CpuBackend::to_contiguous_read",
             ref message,
         } if message.contains("source host placement") && message.contains("Device")
@@ -203,7 +203,7 @@ fn cpu_runtime_copy_reports_dtype_shape_placement_and_alias_errors() {
             TensorRead::from_tensor(&src),
             TensorWrite::from_tensor(&mut misplaced),
         ),
-        Err(Error::BackendFailure {
+        Err(Error::RuntimeState {
             op: "CpuBackend::copy_read_into",
             ref message,
         }) if message.contains("destination") && message.contains("host placement")
@@ -283,7 +283,7 @@ fn cpu_copy_into_rejects_backend_source_without_download() {
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::RuntimeState {
             op: "CpuBackend::copy_into",
             ref message,
         } if message.contains("download")
@@ -307,7 +307,7 @@ fn cpu_copy_into_rejects_backend_destination_without_download() {
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::RuntimeState {
             op: "CpuBackend::copy_into",
             ref message,
         } if message.contains("download")
@@ -327,7 +327,7 @@ fn cpu_copy_into_rejects_host_source_with_device_placement() {
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::RuntimeState {
             op: "CpuBackend::copy_into",
             ref message,
         } if message.contains("source") && message.contains("host placement")
@@ -347,7 +347,7 @@ fn cpu_copy_into_rejects_host_destination_with_device_placement() {
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::RuntimeState {
             op: "CpuBackend::copy_into",
             ref message,
         } if message.contains("destination") && message.contains("host placement")
@@ -1170,7 +1170,7 @@ fn cpu_view_materialization_rejects_backend_buffer_with_caller_operation_name() 
 
     assert!(matches!(
         error,
-        crate::Error::BackendFailure {
+        crate::Error::RuntimeState {
             op: "review_materialize_op",
             ref message,
         } if message.contains("download to host")
@@ -1681,12 +1681,10 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
     )
     .unwrap_err();
     assert!(matches!(
-        add_view_err,
-        crate::Error::BackendFailure {
-            op: "add",
-            ref message,
-        } if message.contains("borrowed tensor views")
+        &add_view_err,
+        crate::Error::Unsupported { op: "add", .. }
     ));
+    assert_eq!(add_view_err.kind(), tenferro_tensor::ErrorKind::Unsupported);
 
     let reduce_input = Tensor::from_vec_col_major(vec![2], vec![2.0_f64, 3.0]).unwrap();
     let reduce_view_shape = [2usize];
@@ -1782,11 +1780,8 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
         ),
     ] {
         assert!(matches!(
-            err,
-            crate::Error::BackendFailure {
-                op: actual_op,
-                ref message,
-            } if actual_op == op && message.contains("borrowed tensor views")
+            &err,
+            crate::Error::Unsupported { op: actual_op, .. } if *actual_op == op
         ));
     }
 
@@ -1817,11 +1812,11 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
     )
     .unwrap_err();
     assert!(matches!(
-        read_views_err,
-        crate::Error::BackendFailure {
+        &read_views_err,
+        crate::Error::Unsupported {
             op: "to_contiguous_read",
-            ref message,
-        } if message.contains("borrowed tensor views")
+            ..
+        }
     ));
 
     let rhs_folded = BackendCachedDot::dot_general_with_conj_cached(
@@ -1879,11 +1874,11 @@ fn test_default_backend_session_methods_cover_cache_fallbacks() {
     )
     .unwrap_err();
     assert!(matches!(
-        exec_read_views_err,
-        crate::Error::BackendFailure {
+        &exec_read_views_err,
+        crate::Error::Unsupported {
             op: "to_contiguous_read",
-            ref message,
-        } if message.contains("borrowed tensor views")
+            ..
+        }
     ));
     let exec_no_conj =
         TensorDot::dot_general_with_conj(&mut exec, &lhs, &rhs, &config, false, false).unwrap();
@@ -1993,24 +1988,24 @@ fn test_pool_backed_elementwise_public_paths_cover_dtypes_and_scalars() {
     );
     assert!(matches!(
         maximum(&a, &b),
-        Err(crate::Error::Validation {
+        Err(crate::Error::Unsupported {
             op: "maximum",
-            source,
-        }) if source.to_string().contains("total order")
+            message,
+        }) if message.contains("total order")
     ));
     assert!(matches!(
         minimum(&a, &b),
-        Err(crate::Error::Validation {
+        Err(crate::Error::Unsupported {
             op: "minimum",
-            source,
-        }) if source.to_string().contains("total order")
+            message,
+        }) if message.contains("total order")
     ));
     assert!(matches!(
         compare(&a, &b, &CompareDir::Ge),
-        Err(crate::Error::Validation {
+        Err(crate::Error::Unsupported {
             op: "compare",
-            source,
-        }) if source.to_string().contains("total order")
+            message,
+        }) if message.contains("total order")
     ));
     let pred = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, true]).unwrap());
     assert_c64_close(
@@ -2019,10 +2014,10 @@ fn test_pool_backed_elementwise_public_paths_cover_dtypes_and_scalars() {
     );
     assert!(matches!(
         clamp(&a, &b, &a),
-        Err(crate::Error::Validation {
+        Err(crate::Error::Unsupported {
             op: "clamp",
-            source,
-        }) if source.to_string().contains("total order")
+            message,
+        }) if message.contains("total order")
     ));
 }
 
@@ -2091,9 +2086,9 @@ fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
     let int_tensor = Tensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap();
     assert!(matches!(
         crate::analytic::exp(&int_tensor),
-        Err(crate::Error::UnsupportedDTypeConversion {
+        Err(crate::Error::UnsupportedDType {
             op: "exp",
-            from: DType::I64,
+            dtype: DType::I64,
             ..
         })
     ));
@@ -2102,9 +2097,9 @@ fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
             &mut crate::buffer_pool::BufferPool::new(),
             TensorRead::from_tensor(&int_tensor),
         ),
-        Err(crate::Error::UnsupportedDTypeConversion {
+        Err(crate::Error::UnsupportedDType {
             op: "exp",
-            from: DType::I64,
+            dtype: DType::I64,
             ..
         })
     ));

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -175,9 +175,9 @@ fn cpu_runtime_copy_reports_dtype_shape_placement_and_alias_errors() {
             TensorRead::from_tensor(&src),
             TensorWrite::from_tensor(&mut wrong_dtype),
         ),
-        Err(Error::DTypeMismatch {
+        Err(Error::Validation {
             op: "CpuBackend::copy_read_into",
-            ..
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
         })
     ));
 
@@ -187,9 +187,9 @@ fn cpu_runtime_copy_reports_dtype_shape_placement_and_alias_errors() {
             TensorRead::from_tensor(&src),
             TensorWrite::from_tensor(&mut wrong_shape),
         ),
-        Err(Error::ShapeMismatch {
+        Err(Error::Validation {
             op: "CpuBackend::copy_read_into",
-            ..
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
         })
     ));
 
@@ -227,10 +227,10 @@ fn cpu_runtime_copy_reports_dtype_shape_placement_and_alias_errors() {
             TensorRead::from_tensor(&aliased_src),
             TensorWrite::from_tensor(&mut aliased_dst),
         ),
-        Err(Error::InvalidConfig {
+        Err(Error::Validation {
             op: "CpuBackend::copy_read_into",
-            ref message,
-        }) if message.contains("alias")
+            source,
+        }) if source.to_string().contains("alias")
     ));
 }
 
@@ -259,11 +259,10 @@ fn cpu_copy_into_reports_shape_mismatch_with_canonical_op_name() {
 
     assert!(matches!(
         err,
-        Error::ShapeMismatch {
+        Error::Validation {
             op: "CpuBackend::copy_into",
-            lhs,
-            rhs,
-        } if lhs == vec![2] && rhs == vec![3]
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        }
     ));
 }
 
@@ -892,7 +891,8 @@ fn cpu_structural_read_direct_helpers_match_owned_validation_errors() {
         &[1],
     )
     .unwrap_err();
-    assert_eq!(view_transpose, owned_transpose);
+    assert_eq!(view_transpose.kind(), owned_transpose.kind());
+    assert_eq!(view_transpose.to_string(), owned_transpose.to_string());
 
     let owned_reshape = crate::structural::reshape(&input, &[3]).unwrap_err();
     let view_reshape = crate::structural::reshape_read_with_pool(
@@ -904,7 +904,8 @@ fn cpu_structural_read_direct_helpers_match_owned_validation_errors() {
         &[3],
     )
     .unwrap_err();
-    assert_eq!(view_reshape, owned_reshape);
+    assert_eq!(view_reshape.kind(), owned_reshape.kind());
+    assert_eq!(view_reshape.to_string(), owned_reshape.to_string());
 
     let owned_broadcast =
         crate::structural::broadcast_in_dim_with_pool(&mut buffers, &input, &[3], &[0])
@@ -919,7 +920,8 @@ fn cpu_structural_read_direct_helpers_match_owned_validation_errors() {
         &[0],
     )
     .unwrap_err();
-    assert_eq!(view_broadcast, owned_broadcast);
+    assert_eq!(view_broadcast.kind(), owned_broadcast.kind());
+    assert_eq!(view_broadcast.to_string(), owned_broadcast.to_string());
 }
 
 #[test]
@@ -946,10 +948,10 @@ fn cpu_structural_read_empty_pathological_layout_returns_typed_errors_without_pa
         .unwrap_err();
     assert!(matches!(
         transpose,
-        crate::Error::BackendFailure {
+        crate::Error::BackendSource {
             op: "transpose",
-            ref message,
-        } if message.contains("overflow")
+            ref source,
+        } if source.to_string().contains("overflow")
     ));
 
     let broadcast = std::panic::catch_unwind(AssertUnwindSafe(|| {
@@ -968,10 +970,10 @@ fn cpu_structural_read_empty_pathological_layout_returns_typed_errors_without_pa
         .unwrap_err();
     assert!(matches!(
         broadcast,
-        crate::Error::BackendFailure {
+        crate::Error::BackendSource {
             op: "broadcast_in_dim",
-            ref message,
-        } if message.contains("overflow")
+            ref source,
+        } if source.to_string().contains("overflow")
     ));
 }
 
@@ -1991,24 +1993,24 @@ fn test_pool_backed_elementwise_public_paths_cover_dtypes_and_scalars() {
     );
     assert!(matches!(
         maximum(&a, &b),
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::Validation {
             op: "maximum",
-            ref message,
-        }) if message.contains("total order")
+            source,
+        }) if source.to_string().contains("total order")
     ));
     assert!(matches!(
         minimum(&a, &b),
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::Validation {
             op: "minimum",
-            ref message,
-        }) if message.contains("total order")
+            source,
+        }) if source.to_string().contains("total order")
     ));
     assert!(matches!(
         compare(&a, &b, &CompareDir::Ge),
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::Validation {
             op: "compare",
-            ref message,
-        }) if message.contains("total order")
+            source,
+        }) if source.to_string().contains("total order")
     ));
     let pred = Tensor::Bool(TypedTensor::from_vec_col_major(vec![2], vec![true, true]).unwrap());
     assert_c64_close(
@@ -2017,10 +2019,10 @@ fn test_pool_backed_elementwise_public_paths_cover_dtypes_and_scalars() {
     );
     assert!(matches!(
         clamp(&a, &b, &a),
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::Validation {
             op: "clamp",
-            ref message,
-        }) if message.contains("total order")
+            source,
+        }) if source.to_string().contains("total order")
     ));
 }
 
@@ -2089,10 +2091,10 @@ fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
     let int_tensor = Tensor::from_vec_col_major(vec![1], vec![1_i64]).unwrap();
     assert!(matches!(
         crate::analytic::exp(&int_tensor),
-        Err(crate::Error::UnsupportedOpDType {
+        Err(crate::Error::UnsupportedDTypeConversion {
             op: "exp",
-            dtype: DType::I64,
-            backend: tenferro_tensor::BackendId::Cpu,
+            from: DType::I64,
+            ..
         })
     ));
     assert!(matches!(
@@ -2100,10 +2102,10 @@ fn test_pool_backed_analytic_public_paths_cover_supported_dtypes() {
             &mut crate::buffer_pool::BufferPool::new(),
             TensorRead::from_tensor(&int_tensor),
         ),
-        Err(crate::Error::UnsupportedOpDType {
+        Err(crate::Error::UnsupportedDTypeConversion {
             op: "exp",
-            dtype: DType::I64,
-            backend: tenferro_tensor::BackendId::Cpu,
+            from: DType::I64,
+            ..
         })
     ));
     assert!(crate::analytic::pow(&real, &base).is_err());

--- a/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
@@ -375,9 +375,11 @@ fn test_pow_rank_zero_read_views_and_domain_contracts() {
     ] {
         assert!(matches!(
             pow(&base, &exponent),
-            Err(Error::NegativeIntegerExponent {
+            Err(Error::Extension {
                 op: "pow",
-                dtype: DType::I64
+                family: "cpu",
+                kind: tenferro_tensor::ErrorKind::NumericalFailure,
+                ..
             })
         ));
     }
@@ -436,18 +438,22 @@ fn test_integer_div_rem_pow_domain_errors_are_structured() {
     let err = div(&lhs, &zero_rhs).unwrap_err();
     assert!(matches!(
         err,
-        Error::DivisionByZero {
+        Error::Extension {
             op: "div",
-            dtype: DType::I32
+            family: "cpu",
+            kind: tenferro_tensor::ErrorKind::NumericalFailure,
+            ..
         }
     ));
 
     let err = rem(&lhs, &zero_rhs).unwrap_err();
     assert!(matches!(
         err,
-        Error::DivisionByZero {
+        Error::Extension {
             op: "rem",
-            dtype: DType::I32
+            family: "cpu",
+            kind: tenferro_tensor::ErrorKind::NumericalFailure,
+            ..
         }
     ));
 
@@ -456,9 +462,11 @@ fn test_integer_div_rem_pow_domain_errors_are_structured() {
     let err = pow(&base, &exp).unwrap_err();
     assert!(matches!(
         err,
-        Error::NegativeIntegerExponent {
+        Error::Extension {
             op: "pow",
-            dtype: DType::I32
+            family: "cpu",
+            kind: tenferro_tensor::ErrorKind::NumericalFailure,
+            ..
         }
     ));
 }
@@ -521,7 +529,7 @@ fn float_div_rem_preserve_ieee_special_values() {
     assert!(f64_rem[4].is_nan());
     assert_eq!(f64_rem[5].to_bits(), (-0.0_f64).to_bits());
 
-    for (zero_rhs, expected_dtype) in [
+    for (zero_rhs, _expected_dtype) in [
         (
             Tensor::from_vec_col_major(vec![1], vec![0_i32]).unwrap(),
             DType::I32,
@@ -538,11 +546,21 @@ fn float_div_rem_preserve_ieee_special_values() {
         };
         assert!(matches!(
             div(&lhs, &zero_rhs),
-            Err(Error::DivisionByZero { op: "div", dtype }) if dtype == expected_dtype
+            Err(Error::Extension {
+                op: "div",
+                family: "cpu",
+                kind: tenferro_tensor::ErrorKind::NumericalFailure,
+                ..
+            })
         ));
         assert!(matches!(
             rem(&lhs, &zero_rhs),
-            Err(Error::DivisionByZero { op: "rem", dtype }) if dtype == expected_dtype
+            Err(Error::Extension {
+                op: "rem",
+                family: "cpu",
+                kind: tenferro_tensor::ErrorKind::NumericalFailure,
+                ..
+            })
         ));
     }
 }
@@ -929,10 +947,9 @@ fn test_reverse_axis_out_of_bounds_returns_error() {
 
     assert!(matches!(
         err,
-        crate::Error::AxisOutOfBounds {
+        crate::Error::Validation {
             op: "reverse",
-            axis: 1,
-            rank: 1,
+            source: tenferro_tensor::ValidationError::AxisOutOfBounds { axis: 1, rank: 1 },
         }
     ));
 }
@@ -952,7 +969,7 @@ fn test_gather_rejects_fractional_float_indices() {
 
     assert!(matches!(
         err,
-        crate::Error::InvalidConfig {
+        crate::Error::Validation {
             op: "index_tensor",
             ..
         }
@@ -975,7 +992,7 @@ fn test_gather_rejects_complex_indices() {
 
     assert!(matches!(
         err,
-        crate::Error::InvalidConfig {
+        crate::Error::Validation {
             op: "index_tensor",
             ..
         }
@@ -992,7 +1009,7 @@ fn test_dynamic_slice_rejects_oversized_window() {
 
     assert!(matches!(
         err,
-        crate::Error::InvalidConfig {
+        crate::Error::Validation {
             op: "dynamic_slice",
             ..
         }
@@ -1015,7 +1032,7 @@ fn test_large_float_index_outside_exact_integer_range_returns_error() {
 
     assert!(matches!(
         err,
-        crate::Error::InvalidConfig {
+        crate::Error::Validation {
             op: "index_tensor",
             ..
         }
@@ -1038,10 +1055,7 @@ fn test_invalid_slice_config_returns_error() {
             },
         )
         .unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::RankMismatch { op: "slice", .. }
-    ));
+    assert!(matches!(err, crate::Error::Validation { op: "slice", .. }));
 }
 
 #[test]
@@ -1059,7 +1073,7 @@ fn test_invalid_pad_config_returns_error() {
             },
         )
         .unwrap_err();
-    assert!(matches!(err, crate::Error::RankMismatch { op: "pad", .. }));
+    assert!(matches!(err, crate::Error::Validation { op: "pad", .. }));
 }
 
 #[test]
@@ -1080,10 +1094,7 @@ fn test_gather_rejects_malformed_offset_dims() {
     let err = backend
         .gather(&operand, &start_indices, &config)
         .unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::AxisOutOfBounds { op: "gather", .. }
-    ));
+    assert!(matches!(err, crate::Error::Validation { op: "gather", .. }));
 }
 
 #[test]
@@ -1106,10 +1117,9 @@ fn test_scatter_rejects_update_window_dim_out_of_bounds() {
         .unwrap_err();
     assert!(matches!(
         err,
-        crate::Error::AxisOutOfBounds {
+        crate::Error::Validation {
             op: "scatter",
-            axis: 3,
-            ..
+            source: tenferro_tensor::ValidationError::AxisOutOfBounds { axis: 3, .. },
         }
     ));
 }
@@ -1133,8 +1143,8 @@ fn test_scatter_rejects_too_many_update_window_dims() {
         .unwrap_err();
     assert!(matches!(
         err,
-        crate::Error::InvalidConfig { op: "scatter", ref message }
-        if message.contains("exceeds update rank")
+        crate::Error::Validation { op: "scatter", source }
+        if source.to_string().contains("exceeds update rank")
     ));
 }
 

--- a/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/context.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use tenferro_tensor::{ErrorKind, ValidationKind};
+
 #[test]
 fn cpu_context_from_env_respects_rayon_num_threads() {
     with_rayon_num_threads(Some("3"), || {
@@ -41,10 +43,16 @@ fn cpu_context_try_from_env_rejects_non_unicode_rayon_num_threads() {
 
     let err = CpuContext::try_from_env().unwrap_err();
 
-    assert!(
-        err.to_string().contains("failed to read RAYON_NUM_THREADS"),
-        "{err}"
-    );
+    assert!(matches!(
+        &err,
+        Error::Extension {
+            op: "CpuContext::try_from_env",
+            family: "cpu",
+            kind: ErrorKind::Validation(ValidationKind::InvalidArgument),
+            ..
+        }
+    ));
+    assert!(std::error::Error::source(&err).is_some());
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
@@ -219,9 +219,9 @@ fn test_dot_general_read_into_rejects_output_shape_and_dtype_mismatch() {
         .unwrap_err();
     assert!(matches!(
         shape_err,
-        Error::ShapeMismatch {
+        Error::Validation {
             op: "dot_general",
-            ..
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
         }
     ));
 
@@ -236,10 +236,9 @@ fn test_dot_general_read_into_rejects_output_shape_and_dtype_mismatch() {
         .unwrap_err();
     assert!(matches!(
         dtype_err,
-        Error::DTypeMismatch {
+        Error::Validation {
             op: "dot_general",
-            lhs: DType::F32,
-            rhs: DType::F64,
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
         }
     ));
 }
@@ -415,10 +414,9 @@ fn test_dot_general_read_into_accum_rejects_scalar_dtype_mismatch() {
 
     assert!(matches!(
         err,
-        Error::DTypeMismatch {
+        Error::Validation {
             op: "dot_general",
-            lhs: DType::F32,
-            rhs: DType::F64,
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
         }
     ));
 }
@@ -1140,16 +1138,16 @@ fn test_tier2_elementwise_ops_complex() {
 
     assert!(matches!(
         backend.maximum(&lhs, &rhs),
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::Validation {
             op: "maximum",
-            ref message,
-        }) if message.contains("total order")
+            source,
+        }) if source.to_string().contains("total order")
     ));
     assert!(matches!(
         backend.minimum(&lhs, &rhs),
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::Validation {
             op: "minimum",
-            ref message,
-        }) if message.contains("total order")
+            source,
+        }) if source.to_string().contains("total order")
     ));
 }

--- a/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/dot_structural_analytic.rs
@@ -1138,16 +1138,16 @@ fn test_tier2_elementwise_ops_complex() {
 
     assert!(matches!(
         backend.maximum(&lhs, &rhs),
-        Err(crate::Error::Validation {
+        Err(crate::Error::Unsupported {
             op: "maximum",
-            source,
-        }) if source.to_string().contains("total order")
+            message,
+        }) if message.contains("total order")
     ));
     assert!(matches!(
         backend.minimum(&lhs, &rhs),
-        Err(crate::Error::Validation {
+        Err(crate::Error::Unsupported {
             op: "minimum",
-            source,
-        }) if source.to_string().contains("total order")
+            message,
+        }) if message.contains("total order")
     ));
 }

--- a/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
@@ -3,10 +3,10 @@ use super::*;
 fn assert_ordered_complex_error<T>(result: crate::Result<T>, op: &'static str) {
     assert!(matches!(
         result,
-        Err(crate::Error::Validation {
+        Err(crate::Error::Unsupported {
             op: actual,
-            source,
-        }) if actual == op && source.to_string().contains("total order")
+            message,
+        }) if actual == op && message.contains("total order")
     ));
 }
 
@@ -181,7 +181,7 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
             TensorRead::from_view(TensorView::Bool(bools.as_view())),
             &[0]
         ),
-        Err(crate::Error::BackendFailure {
+        Err(crate::Error::Unsupported {
             op: "reduce_sum",
             ..
         })
@@ -191,7 +191,7 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
             TensorRead::from_view(TensorView::Bool(bools.as_view())),
             &[0]
         ),
-        Err(crate::Error::BackendFailure {
+        Err(crate::Error::Unsupported {
             op: "reduce_prod",
             ..
         })
@@ -206,7 +206,7 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
     );
     assert!(matches!(
         backend.reduce_min_read(TensorRead::from_view(TensorView::C32(c32s.as_view())), &[0]),
-        Err(crate::Error::BackendFailure {
+        Err(crate::Error::Unsupported {
             op: "reduce_min",
             ..
         })
@@ -397,14 +397,14 @@ fn reduce_read_tensors_cover_host_dtype_dispatch() {
         Tensor::Bool(TypedTensor::<bool>::from_vec_col_major(vec![2], vec![true, false]).unwrap());
     assert!(matches!(
         backend.reduce_sum_read(TensorRead::from_tensor(&bools), &[0]),
-        Err(crate::Error::BackendFailure {
+        Err(crate::Error::Unsupported {
             op: "reduce_sum",
             ..
         })
     ));
     assert!(matches!(
         backend.reduce_prod_read(TensorRead::from_tensor(&bools), &[0]),
-        Err(crate::Error::BackendFailure {
+        Err(crate::Error::Unsupported {
             op: "reduce_prod",
             ..
         })
@@ -586,14 +586,14 @@ fn equal_bool_add_and_mul_report_unsupported_dtype_not_mismatch() {
 
     assert!(matches!(
         add(&lhs, &rhs),
-        Err(crate::Error::BackendFailure {
+        Err(crate::Error::Unsupported {
             op: "add",
             message,
         }) if message == "unsupported dtype Bool"
     ));
     assert!(matches!(
         mul(&lhs, &rhs),
-        Err(crate::Error::BackendFailure {
+        Err(crate::Error::Unsupported {
             op: "mul",
             message,
         }) if message == "unsupported dtype Bool"
@@ -910,10 +910,10 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
     ));
     assert!(matches!(
         clamp(&lhs_f32, &lhs_f32, &rhs_f64),
-        Err(crate::Error::BackendFailure {
+        Err(crate::Error::Validation {
             op: "clamp",
-            message,
-        }) if message == "dtype mismatch"
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
     ));
 
     assert!(matches!(
@@ -1024,14 +1024,14 @@ fn test_reduction_helpers_cover_complex_and_error_paths() {
     ));
     assert!(matches!(
         reduce_max(&complex, &[0]),
-        Err(crate::Error::BackendFailure {
+        Err(crate::Error::Unsupported {
             op: "reduce_max",
             ..
         })
     ));
     assert!(matches!(
         reduce_min(&complex, &[0]),
-        Err(crate::Error::BackendFailure {
+        Err(crate::Error::Unsupported {
             op: "reduce_min",
             ..
         })

--- a/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
@@ -3,10 +3,10 @@ use super::*;
 fn assert_ordered_complex_error<T>(result: crate::Result<T>, op: &'static str) {
     assert!(matches!(
         result,
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::Validation {
             op: actual,
-            ref message,
-        }) if actual == op && message.contains("total order")
+            source,
+        }) if actual == op && source.to_string().contains("total order")
     ));
 }
 
@@ -213,10 +213,9 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
     ));
     assert!(matches!(
         backend.reduce_sum_read(TensorRead::from_view(TensorView::F64(f64s.as_view())), &[2]),
-        Err(crate::Error::AxisOutOfBounds {
+        Err(crate::Error::Validation {
             op: "reduce_sum",
-            axis: 2,
-            rank: 2
+            source: tenferro_tensor::ValidationError::AxisOutOfBounds { axis: 2, rank: 2 }
         })
     ));
     assert!(matches!(
@@ -224,10 +223,12 @@ fn reduce_read_views_cover_dtype_and_validation_branches() {
             TensorRead::from_view(TensorView::F64(f64s.as_view())),
             &[0, 0]
         ),
-        Err(crate::Error::DuplicateAxis {
+        Err(crate::Error::Validation {
             op: "reduce_prod",
-            axis: 0,
-            role: "axes"
+            source: tenferro_tensor::ValidationError::DuplicateAxis {
+                axis: 0,
+                role: "axes"
+            }
         })
     ));
 }
@@ -560,7 +561,10 @@ fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
             &lhs_f32,
             &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap())
         ),
-        Err(crate::Error::DTypeMismatch { op: "div", .. })
+        Err(crate::Error::Validation {
+            op: "div",
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
     ));
     assert!(matches!(
         clamp(
@@ -568,7 +572,10 @@ fn test_direct_elementwise_helpers_cover_f32_c32_and_error_paths() {
             &Tensor::F32(TypedTensor::from_vec_col_major(vec![1], vec![0.0f32]).unwrap()),
             &upper_f32
         ),
-        Err(crate::Error::ShapeMismatch { op: "clamp", .. })
+        Err(crate::Error::Validation {
+            op: "clamp",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        })
     ));
 }
 
@@ -639,28 +646,28 @@ fn reduce_sum_zero_length_axis_is_rejected_like_other_reductions() {
 
     assert!(matches!(
         reduce_sum(&empty, &[0]),
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::Validation {
             op: "reduce_sum",
             ..
         })
     ));
     assert!(matches!(
         reduce_prod(&empty, &[0]),
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::Validation {
             op: "reduce_prod",
             ..
         })
     ));
     assert!(matches!(
         reduce_max(&empty, &[0]),
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::Validation {
             op: "reduce_max",
             ..
         })
     ));
     assert!(matches!(
         reduce_min(&empty, &[0]),
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::Validation {
             op: "reduce_min",
             ..
         })
@@ -861,27 +868,45 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
 
     assert!(matches!(
         add(&lhs_f32, &rhs_f64),
-        Err(crate::Error::DTypeMismatch { op: "add", .. })
+        Err(crate::Error::Validation {
+            op: "add",
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
     ));
     assert!(matches!(
         mul(&lhs_f32, &rhs_f64),
-        Err(crate::Error::DTypeMismatch { op: "mul", .. })
+        Err(crate::Error::Validation {
+            op: "mul",
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
     ));
     assert!(matches!(
         maximum(&lhs_f32, &rhs_f64),
-        Err(crate::Error::DTypeMismatch { op: "maximum", .. })
+        Err(crate::Error::Validation {
+            op: "maximum",
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
     ));
     assert!(matches!(
         minimum(&lhs_f32, &rhs_f64),
-        Err(crate::Error::DTypeMismatch { op: "minimum", .. })
+        Err(crate::Error::Validation {
+            op: "minimum",
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
     ));
     assert!(matches!(
         compare(&lhs_f32, &rhs_f64, &CompareDir::Eq),
-        Err(crate::Error::DTypeMismatch { op: "compare", .. })
+        Err(crate::Error::Validation {
+            op: "compare",
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
     ));
     assert!(matches!(
         select(&lhs_f32, &lhs_f32, &rhs_f64),
-        Err(crate::Error::DTypeMismatch { op: "select", .. })
+        Err(crate::Error::Validation {
+            op: "select",
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+        })
     ));
     assert!(matches!(
         clamp(&lhs_f32, &lhs_f32, &rhs_f64),
@@ -893,39 +918,66 @@ fn test_direct_elementwise_helpers_cover_f64_c64_dispatch_and_mismatch_paths() {
 
     assert!(matches!(
         add(&lhs_f64, &short_f64),
-        Err(crate::Error::ShapeMismatch { op: "add", .. })
+        Err(crate::Error::Validation {
+            op: "add",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        })
     ));
     assert!(matches!(
         mul(&lhs_f64, &short_f64),
-        Err(crate::Error::ShapeMismatch { op: "mul", .. })
+        Err(crate::Error::Validation {
+            op: "mul",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        })
     ));
     assert!(matches!(
         div(&lhs_f64, &short_f64),
-        Err(crate::Error::ShapeMismatch { op: "div", .. })
+        Err(crate::Error::Validation {
+            op: "div",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        })
     ));
     assert!(matches!(
         maximum(&lhs_f64, &short_f64),
-        Err(crate::Error::ShapeMismatch { op: "maximum", .. })
+        Err(crate::Error::Validation {
+            op: "maximum",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        })
     ));
     assert!(matches!(
         minimum(&lhs_f64, &short_f64),
-        Err(crate::Error::ShapeMismatch { op: "minimum", .. })
+        Err(crate::Error::Validation {
+            op: "minimum",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        })
     ));
     assert!(matches!(
         compare(&lhs_f64, &short_f64, &CompareDir::Eq),
-        Err(crate::Error::ShapeMismatch { op: "compare", .. })
+        Err(crate::Error::Validation {
+            op: "compare",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        })
     ));
     assert!(matches!(
         select(&pred_bool, &short_f64, &rhs_f64),
-        Err(crate::Error::ShapeMismatch { op: "select", .. })
+        Err(crate::Error::Validation {
+            op: "select",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        })
     ));
     assert!(matches!(
         select(&pred_bool, &rhs_f64, &short_f64),
-        Err(crate::Error::ShapeMismatch { op: "select", .. })
+        Err(crate::Error::Validation {
+            op: "select",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        })
     ));
     assert!(matches!(
         clamp(&lhs_f64, &lower_f64, &short_f64),
-        Err(crate::Error::ShapeMismatch { op: "clamp", .. })
+        Err(crate::Error::Validation {
+            op: "clamp",
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
+        })
     ));
 }
 
@@ -955,9 +1007,9 @@ fn test_reduction_helpers_cover_complex_and_error_paths() {
             &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap()),
             &[2]
         ),
-        Err(crate::Error::AxisOutOfBounds {
+        Err(crate::Error::Validation {
             op: "reduce_sum",
-            ..
+            source: tenferro_tensor::ValidationError::AxisOutOfBounds { .. },
         })
     ));
     assert!(matches!(
@@ -965,9 +1017,9 @@ fn test_reduction_helpers_cover_complex_and_error_paths() {
             &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap()),
             &[0, 0]
         ),
-        Err(crate::Error::DuplicateAxis {
+        Err(crate::Error::Validation {
             op: "reduce_prod",
-            ..
+            source: tenferro_tensor::ValidationError::DuplicateAxis { .. },
         })
     ));
     assert!(matches!(
@@ -988,16 +1040,16 @@ fn test_reduction_helpers_cover_complex_and_error_paths() {
     let real = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap());
     assert!(matches!(
         reduce_max(&real, &[2]),
-        Err(crate::Error::AxisOutOfBounds {
+        Err(crate::Error::Validation {
             op: "reduce_max",
-            ..
+            source: tenferro_tensor::ValidationError::AxisOutOfBounds { .. },
         })
     ));
     assert!(matches!(
         reduce_min(&real, &[0, 0]),
-        Err(crate::Error::DuplicateAxis {
+        Err(crate::Error::Validation {
             op: "reduce_min",
-            ..
+            source: tenferro_tensor::ValidationError::DuplicateAxis { .. },
         })
     ));
 }
@@ -1035,16 +1087,16 @@ fn test_structural_helpers_cover_f32_success_and_error_paths() {
 
     assert!(matches!(
         transpose(&matrix, &[0]),
-        Err(crate::Error::RankMismatch {
+        Err(crate::Error::Validation {
             op: "transpose",
-            ..
+            source: tenferro_tensor::ValidationError::RankMismatch { .. },
         })
     ));
     assert!(matches!(
         transpose(&matrix, &[0, 0]),
-        Err(crate::Error::DuplicateAxis {
+        Err(crate::Error::Validation {
             op: "transpose",
-            ..
+            source: tenferro_tensor::ValidationError::DuplicateAxis { .. },
         })
     ));
     assert!(matches!(
@@ -1053,16 +1105,16 @@ fn test_structural_helpers_cover_f32_success_and_error_paths() {
             &[3, 2],
             &[0]
         ),
-        Err(crate::Error::ShapeMismatch {
+        Err(crate::Error::Validation {
             op: "broadcast_in_dim",
-            ..
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
         })
     ));
     assert!(matches!(
         extract_diagonal(&matrix, 1, 1),
-        Err(crate::Error::DuplicateAxis {
+        Err(crate::Error::Validation {
             op: "extract_diagonal",
-            ..
+            source: tenferro_tensor::ValidationError::DuplicateAxis { .. },
         })
     ));
     assert!(matches!(
@@ -1071,18 +1123,24 @@ fn test_structural_helpers_cover_f32_success_and_error_paths() {
             0,
             2
         ),
-        Err(crate::Error::AxisOutOfBounds {
+        Err(crate::Error::Validation {
             op: "embed_diagonal",
-            ..
+            source: tenferro_tensor::ValidationError::AxisOutOfBounds { .. },
         })
     ));
     let vector = Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap());
     assert!(matches!(
         tril(&vector, 0),
-        Err(crate::Error::RankMismatch { op: "tril", .. })
+        Err(crate::Error::Validation {
+            op: "tril",
+            source: tenferro_tensor::ValidationError::RankMismatch { .. },
+        })
     ));
     assert!(matches!(
         triu(&vector, 0),
-        Err(crate::Error::RankMismatch { op: "triu", .. })
+        Err(crate::Error::Validation {
+            op: "triu",
+            source: tenferro_tensor::ValidationError::RankMismatch { .. },
+        })
     ));
 }

--- a/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
@@ -455,8 +455,11 @@ fn test_backend_cast_rejects_nonfinite_or_out_of_range_float_to_int_values() {
         err,
         crate::Error::Validation {
             op: "cast",
-            source,
-        } if source.to_string().contains("finite") || source.to_string().contains("out of i32 range")
+            source: tenferro_tensor::ValidationError::InvalidArgument {
+                argument: "value",
+                message,
+            },
+        } if message.contains("finite") || message.contains("out of i32 range")
     ));
 
     let f32_bad =

--- a/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
@@ -453,10 +453,10 @@ fn test_backend_cast_rejects_nonfinite_or_out_of_range_float_to_int_values() {
     let err = backend.cast(&f64_bad, DType::I32).unwrap_err();
     assert!(matches!(
         err,
-        crate::Error::InvalidConfig {
+        crate::Error::Validation {
             op: "cast",
-            ref message,
-        } if message.contains("finite") || message.contains("out of i32 range")
+            source,
+        } if source.to_string().contains("finite") || source.to_string().contains("out of i32 range")
     ));
 
     let f32_bad =
@@ -464,10 +464,10 @@ fn test_backend_cast_rejects_nonfinite_or_out_of_range_float_to_int_values() {
     let err = backend.cast(&f32_bad, DType::I64).unwrap_err();
     assert!(matches!(
         err,
-        crate::Error::InvalidConfig {
+        crate::Error::Validation {
             op: "cast",
-            ref message,
-        } if message.contains("out of i64 range")
+            source,
+        } if source.to_string().contains("out of i64 range")
     ));
 
     let c64_bad = Tensor::C64(
@@ -476,10 +476,10 @@ fn test_backend_cast_rejects_nonfinite_or_out_of_range_float_to_int_values() {
     let err = backend.cast(&c64_bad, DType::I64).unwrap_err();
     assert!(matches!(
         err,
-        crate::Error::InvalidConfig {
+        crate::Error::Validation {
             op: "cast",
-            ref message,
-        } if message.contains("finite")
+            source,
+        } if source.to_string().contains("finite")
     ));
 }
 
@@ -676,9 +676,9 @@ fn test_backend_dot_general_f32_c32_and_dtype_mismatch() {
     let err = backend.dot_general(&f64_t, &f32_t, &config).unwrap_err();
     assert!(matches!(
         err,
-        crate::Error::DTypeMismatch {
+        crate::Error::Validation {
             op: "dot_general",
-            ..
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
         }
     ));
 }

--- a/crates/tenferro-cpu/src/topology.rs
+++ b/crates/tenferro-cpu/src/topology.rs
@@ -146,6 +146,10 @@ impl CpuSet {
     /// assert_eq!(cpus.as_usize_vec(), vec![0, 2]);
     /// # Ok::<(), tenferro_cpu::CpuSetError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuSetError::Empty`] when the iterator yields no CPUs.
     pub fn new(cpus: impl IntoIterator<Item = CpuId>) -> Result<Self, CpuSetError> {
         let mut cpus: Vec<_> = cpus.into_iter().collect();
         cpus.sort_unstable();
@@ -452,6 +456,11 @@ pub(crate) fn parse_linux_cpu_list(input: &str) -> Result<CpuSet, CpuTopologyErr
 /// assert!(!topology.allowed_cpus().is_empty());
 /// # Ok::<(), tenferro_cpu::CpuTopologyError>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns [`CpuTopologyError`] when the process affinity or NUMA topology
+/// cannot be read or contains inconsistent CPU domains.
 pub fn discover_cpu_topology() -> Result<CpuTopology, CpuTopologyError> {
     #[cfg(target_os = "linux")]
     {

--- a/crates/tenferro-cpu/tests/integration/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/integration/runtime_error_tests.rs
@@ -6,7 +6,7 @@ use tenferro_tensor::{
     Buffer, BufferHandle, DeviceId, DeviceKind, DotGeneralConfig, Error, GpuBackendKind,
     MemoryKind, PadConfig, Placement, ScatterConfig, SliceConfig, Tensor, TensorAnalytic,
     TensorDeviceTransfer, TensorDot, TensorElementwise, TensorIndexing, TensorStructural,
-    TypedTensor,
+    TypedTensor, ValidationError,
 };
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
@@ -339,7 +339,7 @@ fn cpu_backend_with_threads_rejects_zero_without_panicking() {
 
     assert!(matches!(
         err,
-        tenferro_cpu::CpuBackendError::Tensor(Error::InvalidConfig {
+        tenferro_cpu::CpuBackendError::Tensor(Error::Validation {
             op: "CpuBackend::with_threads",
             ..
         })
@@ -367,10 +367,9 @@ fn dot_general_rejects_out_of_bounds_contracting_dim() {
 
     assert!(matches!(
         err,
-        Error::AxisOutOfBounds {
+        Error::Validation {
             op: "dot_general",
-            axis: 2,
-            rank: 2,
+            source: ValidationError::AxisOutOfBounds { axis: 2, rank: 2 },
         }
     ));
 }
@@ -385,11 +384,10 @@ fn add_rejects_shape_mismatch() {
 
     assert!(matches!(
         err,
-        Error::ShapeMismatch {
+        Error::Validation {
             op: "add",
-            lhs,
-            rhs,
-        } if lhs == vec![2] && rhs == vec![3]
+            source: ValidationError::ShapeMismatch(_),
+        }
     ));
 }
 
@@ -423,16 +421,7 @@ fn transpose_returns_error_instead_of_panicking() {
         Error::BackendFailure {
             op: "transpose",
             ..
-        } | Error::InvalidConfig {
-            op: "transpose",
-            ..
-        } | Error::RankMismatch {
-            op: "transpose",
-            ..
-        } | Error::AxisOutOfBounds {
-            op: "transpose",
-            ..
-        } | Error::DuplicateAxis {
+        } | Error::Validation {
             op: "transpose",
             ..
         }
@@ -450,9 +439,7 @@ fn reshape_returns_error_instead_of_panicking() {
     let err = result.unwrap().unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure { op: "reshape", .. }
-            | Error::InvalidConfig { op: "reshape", .. }
-            | Error::ShapeMismatch { op: "reshape", .. }
+        Error::BackendFailure { op: "reshape", .. } | Error::Validation { op: "reshape", .. }
     ));
 }
 
@@ -468,7 +455,7 @@ fn pow_returns_error_on_shape_mismatch_instead_of_panicking() {
     let err = result.unwrap().unwrap_err();
     assert!(matches!(
         err,
-        Error::ShapeMismatch { op: "pow", .. } | Error::BackendFailure { op: "pow", .. }
+        Error::Validation { op: "pow", .. } | Error::BackendFailure { op: "pow", .. }
     ));
 }
 
@@ -488,10 +475,7 @@ fn slice_returns_error_instead_of_panicking() {
     let err = result.unwrap().unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure { op: "slice", .. }
-            | Error::InvalidConfig { op: "slice", .. }
-            | Error::RankMismatch { op: "slice", .. }
-            | Error::AxisOutOfBounds { op: "slice", .. }
+        Error::BackendFailure { op: "slice", .. } | Error::Validation { op: "slice", .. }
     ));
 }
 
@@ -511,9 +495,7 @@ fn pad_returns_error_instead_of_panicking() {
     let err = result.unwrap().unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure { op: "pad", .. }
-            | Error::InvalidConfig { op: "pad", .. }
-            | Error::RankMismatch { op: "pad", .. }
+        Error::BackendFailure { op: "pad", .. } | Error::Validation { op: "pad", .. }
     ));
 }
 
@@ -528,7 +510,7 @@ fn concatenate_returns_error_on_empty_inputs() {
     let err = result.unwrap().unwrap_err();
     assert!(matches!(
         err,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "concatenate",
             ..
         }
@@ -550,9 +532,9 @@ fn concatenate_returns_error_on_dtype_mismatch() {
     let err = result.unwrap().unwrap_err();
     assert!(matches!(
         err,
-        Error::DTypeMismatch {
+        Error::Validation {
             op: "concatenate",
-            ..
+            source: ValidationError::DTypeMismatch { .. },
         }
     ));
 }
@@ -572,9 +554,9 @@ fn concatenate_returns_error_on_rank_mismatch() {
     let err = result.unwrap().unwrap_err();
     assert!(matches!(
         err,
-        Error::RankMismatch {
+        Error::Validation {
             op: "concatenate",
-            ..
+            source: ValidationError::RankMismatch { .. },
         }
     ));
 }
@@ -594,9 +576,9 @@ fn concatenate_returns_error_on_axis_out_of_bounds() {
     let err = result.unwrap().unwrap_err();
     assert!(matches!(
         err,
-        Error::AxisOutOfBounds {
+        Error::Validation {
             op: "concatenate",
-            ..
+            source: ValidationError::AxisOutOfBounds { .. },
         }
     ));
 }
@@ -619,9 +601,9 @@ fn concatenate_returns_error_on_shape_mismatch() {
     let err = result.unwrap().unwrap_err();
     assert!(matches!(
         err,
-        Error::ShapeMismatch {
+        Error::Validation {
             op: "concatenate",
-            ..
+            source: ValidationError::ShapeMismatch(_),
         }
     ));
 }

--- a/crates/tenferro-cpu/tests/integration/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/integration/runtime_error_tests.rs
@@ -79,7 +79,7 @@ fn cpu_device_transfer_rejects_backend_buffers_at_boundary() {
         let err = actual.unwrap_err();
         assert!(matches!(
             err,
-            Error::BackendFailure {
+            Error::RuntimeState {
                 op,
                 ref message,
             } if op == expected_op && message.contains(expected_hint)
@@ -403,7 +403,7 @@ fn cpu_backend_rejects_backend_buffers_without_panicking() {
 
     assert!(result.is_ok(), "CPU backend should return Err, not panic");
     let err = result.unwrap().unwrap_err();
-    assert!(matches!(err, Error::BackendFailure { op: "add", .. }));
+    assert!(matches!(err, Error::RuntimeState { op: "add", .. }));
     assert!(err.to_string().contains("download to host"));
 }
 

--- a/crates/tenferro-einsum/src/builder.rs
+++ b/crates/tenferro-einsum/src/builder.rs
@@ -78,7 +78,7 @@ fn localize_value_ref(
 }
 
 fn builder_invalid_argument(message: impl Into<String>) -> Error {
-    Error::InvalidArgument(format!("einsum builder: {}", message.into()))
+    Error::planning(format!("einsum builder: {}", message.into()))
 }
 
 fn find_label_axis(labels: &[u32], label: u32) -> Result<usize> {

--- a/crates/tenferro-einsum/src/concrete.rs
+++ b/crates/tenferro-einsum/src/concrete.rs
@@ -935,30 +935,27 @@ impl ConcreteEinsumPlan {
 
     fn validate_inputs(&self, actual: &[ConcreteEinsumInputSpec], op: &'static str) -> Result<()> {
         if actual.len() != self.inputs.len() {
-            return Err(Error::InvalidConfig {
+            return Err(Error::invalid_argument(
                 op,
-                message: format!(
+                "inputs",
+                format!(
                     "prepared einsum expects {} inputs, got {}",
                     self.inputs.len(),
                     actual.len()
                 ),
-            });
+            ));
         }
 
         for (expected, actual) in self.inputs.iter().zip(actual.iter()) {
             if expected.dtype != actual.dtype {
-                return Err(Error::DTypeMismatch {
-                    op,
-                    lhs: expected.dtype,
-                    rhs: actual.dtype,
-                });
+                return Err(Error::dtype_mismatch(op, expected.dtype, actual.dtype));
             }
             if expected.shape != actual.shape {
-                return Err(Error::ShapeMismatch {
+                return Err(Error::shape_mismatch(
                     op,
-                    lhs: expected.shape.clone(),
-                    rhs: actual.shape.clone(),
-                });
+                    expected.shape.clone(),
+                    actual.shape.clone(),
+                ));
             }
         }
 
@@ -973,9 +970,8 @@ struct ConcreteEinsumInputSpec {
 }
 
 fn parse_subscripts(subscripts: &str, op: &'static str) -> Result<Subscripts> {
-    Subscripts::parse(subscripts).map_err(|err| Error::InvalidConfig {
-        op,
-        message: format!("invalid subscripts: {err}"),
+    Subscripts::parse(subscripts).map_err(|err| {
+        Error::invalid_argument(op, "subscripts", format!("invalid subscripts: {err}"))
     })
 }
 
@@ -1108,18 +1104,14 @@ fn validate_output(
 ) -> Result<()> {
     let expected = output_spec(inputs, tree, op)?;
     if out.dtype() != expected.dtype {
-        return Err(Error::DTypeMismatch {
-            op,
-            lhs: out.dtype(),
-            rhs: expected.dtype,
-        });
+        return Err(Error::dtype_mismatch(op, expected.dtype, out.dtype()));
     }
     if out.shape() != expected.shape.as_slice() {
-        return Err(Error::ShapeMismatch {
+        return Err(Error::shape_mismatch(
             op,
-            lhs: out.shape().to_vec(),
-            rhs: expected.shape,
-        });
+            out.shape().to_vec(),
+            expected.shape.clone(),
+        ));
     }
     Ok(())
 }
@@ -1131,18 +1123,13 @@ fn output_spec(
 ) -> Result<ConcreteEinsumInputSpec> {
     let dtype = inputs
         .first()
-        .ok_or_else(|| Error::InvalidConfig {
-            op,
-            message: "einsum requires at least one input tensor".to_string(),
+        .ok_or_else(|| {
+            Error::invalid_argument(op, "inputs", "einsum requires at least one input tensor")
         })?
         .dtype;
     for input in inputs {
         if input.dtype != dtype {
-            return Err(Error::DTypeMismatch {
-                op,
-                lhs: dtype,
-                rhs: input.dtype,
-            });
+            return Err(Error::dtype_mismatch(op, dtype, input.dtype));
         }
     }
 
@@ -1151,11 +1138,7 @@ fn output_spec(
         let mut found = None;
         for (input, labels) in inputs.iter().zip(tree.subscripts.inputs.iter()) {
             if labels.len() != input.shape.len() {
-                return Err(Error::RankMismatch {
-                    op,
-                    expected: labels.len(),
-                    actual: input.shape.len(),
-                });
+                return Err(Error::rank_mismatch(op, labels.len(), input.shape.len()));
             }
             if let Some(axis) = labels.iter().position(|candidate| *candidate == label) {
                 found = Some(input.shape[axis]);
@@ -1163,10 +1146,11 @@ fn output_spec(
             }
         }
         let Some(extent) = found else {
-            return Err(Error::InvalidConfig {
+            return Err(Error::invalid_argument(
                 op,
-                message: format!("output label {label} is missing from inputs"),
-            });
+                "output labels",
+                format!("output label {label} is missing from inputs"),
+            ));
         };
         output_shape.push(extent);
     }
@@ -1192,9 +1176,5 @@ pub(crate) fn into_typed_result<T: TensorScalar>(
     op: &'static str,
 ) -> Result<TypedTensor<T>> {
     let actual = result.dtype();
-    T::into_typed(result).map_err(|_| Error::DTypeMismatch {
-        op,
-        lhs: T::dtype(),
-        rhs: actual,
-    })
+    T::into_typed(result).map_err(|_| Error::dtype_mismatch(op, T::dtype(), actual))
 }

--- a/crates/tenferro-einsum/src/concrete.rs
+++ b/crates/tenferro-einsum/src/concrete.rs
@@ -1,8 +1,8 @@
 //! Public concrete tensor einsum extension API.
 
 use tenferro_tensor::{
-    DType, DotGeneralAccumulation, Error, Result, Tensor, TensorBackend, TensorRead, TensorScalar,
-    TensorWrite, TypedTensor, TypedTensorView, TypedTensorWrite,
+    DType, DotGeneralAccumulation, Tensor, TensorBackend, TensorRead, TensorScalar, TensorWrite,
+    TypedTensor, TypedTensorView, TypedTensorWrite,
 };
 
 use crate::eager::{
@@ -10,7 +10,7 @@ use crate::eager::{
     eager_einsum_exec_read_into_accum, eager_einsum_read_subscripts, eager_einsum_subscripts,
     plan_subscripts,
 };
-use crate::{ContractionTree, EinsumSubscripts, Subscripts};
+use crate::{ContractionTree, EinsumSubscripts, Error, Result, Subscripts};
 
 const TENSOR_EINSUM_OP: &str = "TensorEinsumExt::einsum";
 const TENSOR_EINSUM_INTO_OP: &str = "TensorEinsumIntoExt::einsum_into";
@@ -42,13 +42,24 @@ const PLAN_EXECUTE_OP: &str = "ConcreteEinsumPlan::execute";
 ///
 /// let out = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend)?;
 /// assert_eq!(out.shape(), &[2, 4]);
-/// # Ok::<(), tenferro_tensor::Error>(())
+/// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
 pub trait TensorEinsumExt {
     /// Execute an einsum from string notation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] with shape, rank, or dtype payloads for an invalid
+    /// contraction, or [`Error::Tensor`] for a typed backend failure.
     fn einsum<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor>;
 
     /// Execute an einsum from parsed integer-label subscripts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with shape, rank, or dtype payloads for an
+    /// invalid contraction, or [`Error::Tensor`] for a typed backend failure.
     fn einsum_subscripts<B: TensorBackend>(
         &self,
         subscripts: &EinsumSubscripts,
@@ -59,7 +70,7 @@ pub trait TensorEinsumExt {
 impl TensorEinsumExt for [&Tensor] {
     fn einsum<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor> {
         let subscripts = parse_subscripts(subscripts, TENSOR_EINSUM_OP)?;
-        eager_einsum_subscripts(backend, self, &subscripts)
+        eager_einsum_subscripts(backend, self, &subscripts).map_err(Error::from)
     }
 
     fn einsum_subscripts<B: TensorBackend>(
@@ -68,7 +79,7 @@ impl TensorEinsumExt for [&Tensor] {
         backend: &mut B,
     ) -> Result<Tensor> {
         let subscripts = Subscripts::from(subscripts);
-        eager_einsum_subscripts(backend, self, &subscripts)
+        eager_einsum_subscripts(backend, self, &subscripts).map_err(Error::from)
     }
 }
 
@@ -89,6 +100,12 @@ impl<const N: usize> TensorEinsumExt for [&Tensor; N] {
 /// Backend-explicit preallocated-output einsum methods for dtype-erased tensors.
 pub trait TensorEinsumIntoExt {
     /// Execute an einsum from string notation into caller-provided output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] with a shape, rank, or dtype payload when inputs or
+    /// output do not match, or [`Error::Tensor`] for a typed backend failure.
     fn einsum_into<B: TensorBackend>(
         &self,
         subscripts: &str,
@@ -97,6 +114,12 @@ pub trait TensorEinsumIntoExt {
     ) -> Result<()>;
 
     /// Execute an einsum from parsed integer-label subscripts into caller-provided output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with a shape, rank, or dtype payload when
+    /// inputs or output do not match, or [`Error::Tensor`] for a typed backend
+    /// failure.
     fn einsum_into_subscripts<B: TensorBackend>(
         &self,
         subscripts: &EinsumSubscripts,
@@ -166,14 +189,25 @@ impl<const N: usize> TensorEinsumIntoExt for [&Tensor; N] {
 ///
 /// let out = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend)?;
 /// assert_eq!(out.shape(), &[2, 4]);
-/// # Ok::<(), tenferro_tensor::Error>(())
+/// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
 pub trait TypedTensorEinsumExt<T: TensorScalar> {
     /// Execute an einsum from string notation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] with shape or rank payloads for an invalid
+    /// contraction, or [`Error::Tensor`] for a typed backend failure.
     fn einsum<B: TensorBackend>(&self, subscripts: &str, backend: &mut B)
         -> Result<TypedTensor<T>>;
 
     /// Execute an einsum from parsed integer-label subscripts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with shape or rank payloads for an invalid
+    /// contraction, or [`Error::Tensor`] for a typed backend failure.
     fn einsum_subscripts<B: TensorBackend>(
         &self,
         subscripts: &EinsumSubscripts,
@@ -237,7 +271,7 @@ impl<T: TensorScalar, const N: usize> TypedTensorEinsumExt<T> for [&TypedTensor<
 /// let mut backend = CpuBackend::new();
 /// let result = [lhs.as_view(), rhs.as_view()].einsum_read("i,i->", &mut backend)?;
 /// assert_eq!(result.as_slice()?, &[11.0]);
-/// # Ok::<(), tenferro_tensor::Error>(())
+/// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
 pub trait TypedTensorReadEinsumExt<T: TensorScalar> {
     /// Execute an einsum from string notation over typed borrowed views.
@@ -253,8 +287,14 @@ pub trait TypedTensorReadEinsumExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// let result = [input.as_view()].einsum_read("i->i", &mut backend)?;
     /// assert_eq!(result.as_slice()?, &[2.0, 3.0]);
-    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// # Ok::<(), tenferro_einsum::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] with shape or rank payloads for incompatible
+    /// views, or [`Error::Tensor`] for a typed backend failure.
     fn einsum_read<B: TensorBackend>(
         &self,
         subscripts: &str,
@@ -276,8 +316,13 @@ pub trait TypedTensorReadEinsumExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// let result = [input.as_view()].einsum_read_subscripts(&subscripts, &mut backend)?;
     /// assert_eq!(result.as_slice()?, &[2.0, 3.0]);
-    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// # Ok::<(), tenferro_einsum::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with shape or rank payloads for
+    /// incompatible views, or [`Error::Tensor`] for a typed backend failure.
     fn einsum_read_subscripts<B: TensorBackend>(
         &self,
         subscripts: &EinsumSubscripts,
@@ -328,12 +373,24 @@ impl<'a, T: TensorScalar, const N: usize> TypedTensorReadEinsumExt<T>
 /// Backend-explicit preallocated-output einsum methods for typed concrete tensors.
 pub trait TypedTensorEinsumIntoExt<T: TensorScalar> {
     /// Execute an einsum from string notation into caller-provided typed output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] with a shape, rank, or dtype payload when inputs or
+    /// output do not match, or [`Error::Tensor`] for a typed backend failure.
     fn einsum_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
     where
         B: TensorBackend,
         O: Into<TypedTensorWrite<'out, T>>;
 
     /// Execute an einsum from parsed integer-label subscripts into caller-provided typed output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with a shape, rank, or dtype payload when
+    /// inputs or output do not match, or [`Error::Tensor`] for a typed backend
+    /// failure.
     fn einsum_into_subscripts<'out, B, O>(
         &self,
         subscripts: &EinsumSubscripts,
@@ -421,7 +478,7 @@ impl<T: TensorScalar, const N: usize> TypedTensorEinsumIntoExt<T> for [&TypedTen
 /// let mut backend = CpuBackend::new();
 /// [lhs.as_view(), rhs.as_view()].einsum_read_into("i,i->", &mut backend, &mut output)?;
 /// assert_eq!(output.as_slice()?, &[11.0]);
-/// # Ok::<(), tenferro_tensor::Error>(())
+/// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
 pub trait TypedTensorReadEinsumIntoExt<T: TensorScalar> {
     /// Execute an einsum from string notation over typed borrowed views into a
@@ -439,8 +496,14 @@ pub trait TypedTensorReadEinsumIntoExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// [input.as_view()].einsum_read_into("i->i", &mut backend, &mut output)?;
     /// assert_eq!(output.as_slice()?, &[2.0, 3.0]);
-    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// # Ok::<(), tenferro_einsum::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] with a shape, rank, or dtype payload when inputs or
+    /// output do not match, or [`Error::Tensor`] for a typed backend failure.
     fn einsum_read_into<'out, B, O>(&self, subscripts: &str, backend: &mut B, out: O) -> Result<()>
     where
         B: TensorBackend,
@@ -462,8 +525,14 @@ pub trait TypedTensorReadEinsumIntoExt<T: TensorScalar> {
     /// let mut backend = CpuBackend::new();
     /// [input.as_view()].einsum_read_into_subscripts(&subscripts, &mut backend, &mut output)?;
     /// assert_eq!(output.as_slice()?, &[2.0, 3.0]);
-    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// # Ok::<(), tenferro_einsum::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with a shape, rank, or dtype payload when
+    /// inputs or output do not match, or [`Error::Tensor`] for a typed backend
+    /// failure.
     fn einsum_read_into_subscripts<'out, B, O>(
         &self,
         subscripts: &EinsumSubscripts,
@@ -562,14 +631,25 @@ impl<'a, T: TensorScalar, const N: usize> TypedTensorReadEinsumIntoExt<T>
 ///
 /// let out = inputs.einsum_read("ij,j->i", &mut backend)?;
 /// assert_eq!(out.shape(), &[2]);
-/// # Ok::<(), tenferro_tensor::Error>(())
+/// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
 pub trait TensorReadEinsumExt {
     /// Execute an einsum from string notation over read-only tensor inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] with shape, rank, or dtype payloads for an invalid
+    /// contraction, or [`Error::Tensor`] for a typed backend failure.
     fn einsum_read<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor>;
 
     /// Execute an einsum from parsed integer-label subscripts over read-only
     /// tensor inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with shape, rank, or dtype payloads for an
+    /// invalid contraction, or [`Error::Tensor`] for a typed backend failure.
     fn einsum_read_subscripts<B: TensorBackend>(
         &self,
         subscripts: &EinsumSubscripts,
@@ -580,7 +660,7 @@ pub trait TensorReadEinsumExt {
 impl<'a> TensorReadEinsumExt for [TensorRead<'a>] {
     fn einsum_read<B: TensorBackend>(&self, subscripts: &str, backend: &mut B) -> Result<Tensor> {
         let subscripts = parse_subscripts(subscripts, TENSOR_READ_EINSUM_OP)?;
-        eager_einsum_read_subscripts(backend, self, &subscripts)
+        eager_einsum_read_subscripts(backend, self, &subscripts).map_err(Error::from)
     }
 
     fn einsum_read_subscripts<B: TensorBackend>(
@@ -589,7 +669,7 @@ impl<'a> TensorReadEinsumExt for [TensorRead<'a>] {
         backend: &mut B,
     ) -> Result<Tensor> {
         let subscripts = Subscripts::from(subscripts);
-        eager_einsum_read_subscripts(backend, self, &subscripts)
+        eager_einsum_read_subscripts(backend, self, &subscripts).map_err(Error::from)
     }
 }
 
@@ -610,6 +690,12 @@ impl<'a, const N: usize> TensorReadEinsumExt for [TensorRead<'a>; N] {
 /// Backend-explicit preallocated-output einsum methods for [`TensorRead`] inputs.
 pub trait TensorReadEinsumIntoExt {
     /// Execute an einsum from string notation over read-only inputs into caller-provided output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] with a shape, rank, or dtype payload when inputs or
+    /// output do not match, or [`Error::Tensor`] for a typed backend failure.
     fn einsum_read_into<B: TensorBackend>(
         &self,
         subscripts: &str,
@@ -618,6 +704,12 @@ pub trait TensorReadEinsumIntoExt {
     ) -> Result<()>;
 
     /// Execute an einsum from parsed integer-label subscripts over read-only inputs into output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with a shape, rank, or dtype payload when
+    /// inputs or output do not match, or [`Error::Tensor`] for a typed backend
+    /// failure.
     fn einsum_read_into_subscripts<B: TensorBackend>(
         &self,
         subscripts: &EinsumSubscripts,
@@ -702,7 +794,7 @@ impl<'a, const N: usize> TensorReadEinsumIntoExt for [TensorRead<'a>; N] {
 /// let mut backend = CpuBackend::new();
 /// let out = plan.execute([&lhs, &rhs], &mut backend)?;
 /// assert_eq!(out.shape(), &[2, 4]);
-/// # Ok::<(), tenferro_tensor::Error>(())
+/// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
 #[derive(Debug)]
 pub struct ConcreteEinsumPlan {
@@ -713,6 +805,12 @@ pub struct ConcreteEinsumPlan {
 impl ConcreteEinsumPlan {
     /// Prepare a plan from dtype-erased concrete tensor inputs and string
     /// notation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] for rank, shape, or dtype contract violations, or
+    /// [`Error::Planning`] when no valid contraction tree can be built.
     pub fn prepare<'a, I>(inputs: I, subscripts: &str) -> Result<Self>
     where
         I: AsRef<[&'a Tensor]>,
@@ -723,6 +821,12 @@ impl ConcreteEinsumPlan {
 
     /// Prepare a plan from dtype-erased concrete tensor inputs and parsed
     /// integer-label subscripts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] for rank, shape, or dtype contract
+    /// violations, or [`Error::Planning`] when no valid contraction tree can be
+    /// built.
     pub fn prepare_subscripts<'a, I>(inputs: I, subscripts: &EinsumSubscripts) -> Result<Self>
     where
         I: AsRef<[&'a Tensor]>,
@@ -732,6 +836,12 @@ impl ConcreteEinsumPlan {
     }
 
     /// Prepare a plan from typed concrete tensor inputs and string notation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] for rank or shape contract violations, or
+    /// [`Error::Planning`] when no valid contraction tree can be built.
     pub fn prepare_typed<'a, T, I>(inputs: I, subscripts: &str) -> Result<Self>
     where
         T: TensorScalar,
@@ -743,6 +853,11 @@ impl ConcreteEinsumPlan {
 
     /// Prepare a plan from typed concrete tensor inputs and parsed integer-label
     /// subscripts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] for rank or shape contract violations, or
+    /// [`Error::Planning`] when no valid contraction tree can be built.
     pub fn prepare_typed_subscripts<'a, T, I>(
         inputs: I,
         subscripts: &EinsumSubscripts,
@@ -756,6 +871,12 @@ impl ConcreteEinsumPlan {
     }
 
     /// Prepare a plan from read-only tensor inputs and string notation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] for rank, shape, or dtype contract violations, or
+    /// [`Error::Planning`] when no valid contraction tree can be built.
     pub fn prepare_read<'a, I>(inputs: I, subscripts: &str) -> Result<Self>
     where
         I: AsRef<[TensorRead<'a>]>,
@@ -766,6 +887,12 @@ impl ConcreteEinsumPlan {
 
     /// Prepare a plan from read-only tensor inputs and parsed integer-label
     /// subscripts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] for rank, shape, or dtype contract
+    /// violations, or [`Error::Planning`] when no valid contraction tree can be
+    /// built.
     pub fn prepare_read_subscripts<'a, I>(inputs: I, subscripts: &EinsumSubscripts) -> Result<Self>
     where
         I: AsRef<[TensorRead<'a>]>,
@@ -775,6 +902,12 @@ impl ConcreteEinsumPlan {
     }
 
     /// Execute this plan on dtype-erased concrete tensor inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] when inputs differ from the prepared
+    /// rank, shape, or dtype contract, or [`Error::Tensor`] for a typed backend
+    /// failure.
     pub fn execute<'a, I, B>(&self, inputs: I, backend: &mut B) -> Result<Tensor>
     where
         I: AsRef<[&'a Tensor]>,
@@ -782,10 +915,17 @@ impl ConcreteEinsumPlan {
     {
         let inputs = inputs.as_ref();
         self.validate_inputs(&input_specs(inputs), PLAN_EXECUTE_OP)?;
-        backend.with_backend_session(|exec| eager_einsum_exec(exec, inputs, &self.tree))
+        backend
+            .with_backend_session(|exec| eager_einsum_exec(exec, inputs, &self.tree))
+            .map_err(Error::from)
     }
 
     /// Execute this plan on typed concrete tensor inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] when inputs differ from the prepared rank
+    /// or shape contract, or [`Error::Tensor`] for a typed backend failure.
     pub fn execute_typed<'a, T, I, B>(&self, inputs: I, backend: &mut B) -> Result<TypedTensor<T>>
     where
         T: TensorScalar,
@@ -801,6 +941,12 @@ impl ConcreteEinsumPlan {
     }
 
     /// Execute this plan on read-only tensor inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] when inputs differ from the prepared
+    /// rank, shape, or dtype contract, or [`Error::Tensor`] for a typed backend
+    /// failure.
     pub fn execute_read<'a, I, B>(&self, inputs: I, backend: &mut B) -> Result<Tensor>
     where
         I: AsRef<[TensorRead<'a>]>,
@@ -808,10 +954,17 @@ impl ConcreteEinsumPlan {
     {
         let inputs = inputs.as_ref();
         self.validate_inputs(&read_input_specs(inputs), PLAN_EXECUTE_OP)?;
-        backend.with_backend_session(|exec| eager_einsum_exec_read(exec, inputs, &self.tree))
+        backend
+            .with_backend_session(|exec| eager_einsum_exec_read(exec, inputs, &self.tree))
+            .map_err(Error::from)
     }
 
     /// Execute this plan on dtype-erased concrete tensor inputs into caller-provided output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] for input or output rank, shape, or dtype
+    /// mismatches, or [`Error::Tensor`] for a typed backend failure.
     pub fn execute_into<'a, I, B>(
         &self,
         inputs: I,
@@ -832,9 +985,15 @@ impl ConcreteEinsumPlan {
             .collect();
         backend
             .with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &self.tree, out))
+            .map_err(Error::from)
     }
 
     /// Execute this plan on typed concrete tensor inputs into caller-provided output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] for input or output rank or shape
+    /// mismatches, or [`Error::Tensor`] for a typed backend failure.
     pub fn execute_typed_into<'a, 'out, T, I, B, O>(
         &self,
         inputs: I,
@@ -855,9 +1014,15 @@ impl ConcreteEinsumPlan {
         let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
         backend
             .with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &self.tree, out))
+            .map_err(Error::from)
     }
 
     /// Execute this plan on read-only tensor inputs into caller-provided output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] for input or output rank, shape, or dtype
+    /// mismatches, or [`Error::Tensor`] for a typed backend failure.
     pub fn execute_read_into<'a, I, B>(
         &self,
         inputs: I,
@@ -874,6 +1039,7 @@ impl ConcreteEinsumPlan {
         validate_output(&self.inputs, &self.tree, &out, PLAN_EXECUTE_OP)?;
         backend
             .with_backend_session(|exec| eager_einsum_exec_read_into(exec, inputs, &self.tree, out))
+            .map_err(Error::from)
     }
 
     /// Execute this plan on read-only inputs with scaled output accumulation.
@@ -902,8 +1068,14 @@ impl ConcreteEinsumPlan {
     ///     TensorWrite::from_tensor(&mut out),
     /// )?;
     /// assert_eq!(out.as_slice::<f64>()?, &[7.0]);
-    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// # Ok::<(), tenferro_einsum::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] for input or output rank, shape, or dtype
+    /// mismatches, [`Error::Numerical`] for an invalid accumulation, or
+    /// [`Error::Tensor`] for a typed backend failure.
     pub fn execute_read_into_accum<'a, I, B>(
         &self,
         inputs: I,
@@ -919,9 +1091,11 @@ impl ConcreteEinsumPlan {
         let specs = read_input_specs(inputs);
         self.validate_inputs(&specs, PLAN_EXECUTE_OP)?;
         validate_output(&self.inputs, &self.tree, &out, PLAN_EXECUTE_OP)?;
-        backend.with_backend_session(|exec| {
-            eager_einsum_exec_read_into_accum(exec, inputs, &self.tree, accumulation, out)
-        })
+        backend
+            .with_backend_session(|exec| {
+                eager_einsum_exec_read_into_accum(exec, inputs, &self.tree, accumulation, out)
+            })
+            .map_err(Error::from)
     }
 
     fn prepare_subscripts_internal(
@@ -969,10 +1143,8 @@ struct ConcreteEinsumInputSpec {
     shape: Vec<usize>,
 }
 
-fn parse_subscripts(subscripts: &str, op: &'static str) -> Result<Subscripts> {
-    Subscripts::parse(subscripts).map_err(|err| {
-        Error::invalid_argument(op, "subscripts", format!("invalid subscripts: {err}"))
-    })
+fn parse_subscripts(subscripts: &str, _op: &'static str) -> Result<Subscripts> {
+    Subscripts::parse(subscripts)
 }
 
 fn input_specs(inputs: &[&Tensor]) -> Vec<ConcreteEinsumInputSpec> {
@@ -1046,7 +1218,9 @@ fn tensor_einsum_into_subscripts(
         .iter()
         .map(|tensor| TensorRead::from_tensor(tensor))
         .collect();
-    backend.with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))
+    backend
+        .with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))
+        .map_err(Error::from)
 }
 
 fn typed_view_einsum_into_subscripts<T: TensorScalar>(
@@ -1065,7 +1239,9 @@ fn typed_view_einsum_into_subscripts<T: TensorScalar>(
         .cloned()
         .map(|view| TensorRead::from_view(T::tensor_view(view)))
         .collect();
-    backend.with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))
+    backend
+        .with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))
+        .map_err(Error::from)
 }
 
 fn typed_einsum_into_subscripts<T: TensorScalar>(
@@ -1080,7 +1256,9 @@ fn typed_einsum_into_subscripts<T: TensorScalar>(
     let out = out.into_tensor_write();
     validate_output(&specs, &plan.tree, &out, op)?;
     let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
-    backend.with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))
+    backend
+        .with_backend_session(|exec| eager_einsum_exec_read_into(exec, &reads, &plan.tree, out))
+        .map_err(Error::from)
 }
 
 fn tensor_read_einsum_into_subscripts(
@@ -1093,7 +1271,9 @@ fn tensor_read_einsum_into_subscripts(
     let specs = read_input_specs(inputs);
     let plan = ConcreteEinsumPlan::prepare_subscripts_internal(specs.clone(), subscripts)?;
     validate_output(&specs, &plan.tree, &out, op)?;
-    backend.with_backend_session(|exec| eager_einsum_exec_read_into(exec, inputs, &plan.tree, out))
+    backend
+        .with_backend_session(|exec| eager_einsum_exec_read_into(exec, inputs, &plan.tree, out))
+        .map_err(Error::from)
 }
 
 fn validate_output(

--- a/crates/tenferro-einsum/src/concrete_tests.rs
+++ b/crates/tenferro-einsum/src/concrete_tests.rs
@@ -6,7 +6,7 @@ use tenferro_tensor::{
 };
 
 use crate::{
-    parse_einsum_subscripts, ConcreteEinsumPlan, TensorEinsumExt, TensorEinsumIntoExt,
+    parse_einsum_subscripts, ConcreteEinsumPlan, Error, TensorEinsumExt, TensorEinsumIntoExt,
     TensorReadEinsumExt, TensorReadEinsumIntoExt, TypedTensorEinsumExt, TypedTensorEinsumIntoExt,
     TypedTensorReadEinsumExt, TypedTensorReadEinsumIntoExt,
 };
@@ -308,7 +308,7 @@ fn public_einsum_into_rejects_output_shape_and_dtype_mismatch() {
         .unwrap_err();
     assert!(matches!(
         shape_err,
-        tenferro_tensor::Error::Validation {
+        Error::Validation {
             op: "TensorEinsumIntoExt::einsum_into",
             source: tenferro_tensor::ValidationError::ShapeMismatch(_),
         }
@@ -324,10 +324,10 @@ fn public_einsum_into_rejects_output_shape_and_dtype_mismatch() {
         .unwrap_err();
     assert!(matches!(
         dtype_err,
-        tenferro_tensor::Error::Validation {
+        Error::Tensor(tenferro_tensor::Error::Validation {
             op: "TensorEinsumIntoExt::einsum_into",
             source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
-        }
+        })
     ));
 }
 
@@ -513,7 +513,7 @@ fn concrete_einsum_plan_execute_into_rejects_incompatible_output() {
 
     assert!(matches!(
         err,
-        tenferro_tensor::Error::Validation {
+        Error::Validation {
             op: "ConcreteEinsumPlan::execute",
             source: tenferro_tensor::ValidationError::ShapeMismatch(_),
         }
@@ -613,17 +613,17 @@ fn concrete_einsum_plan_rejects_shape_and_dtype_mismatches() {
 
     assert!(matches!(
         shape_err,
-        tenferro_tensor::Error::Validation {
+        Error::Validation {
             op: "ConcreteEinsumPlan::execute",
             source: tenferro_tensor::ValidationError::ShapeMismatch(_),
         }
     ));
     assert!(matches!(
         dtype_err,
-        tenferro_tensor::Error::Validation {
+        Error::Tensor(tenferro_tensor::Error::Validation {
             op: "ConcreteEinsumPlan::execute",
             source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
-        }
+        })
     ));
 }
 
@@ -641,16 +641,10 @@ fn concrete_einsum_public_api_reports_parse_and_input_count_errors() {
     let plan = ConcreteEinsumPlan::prepare([&lhs, &rhs], "ij,jk->ik").unwrap();
     let count_err = plan.execute([&lhs], &mut backend).unwrap_err();
 
-    assert!(matches!(
-        parse_err,
-        tenferro_tensor::Error::Validation {
-            op: "TensorEinsumExt::einsum",
-            ..
-        }
-    ));
+    assert!(matches!(parse_err, Error::InvalidSubscripts { .. }));
     assert!(matches!(
         count_err,
-        tenferro_tensor::Error::Validation {
+        Error::Validation {
             op: "ConcreteEinsumPlan::execute",
             ..
         }
@@ -665,9 +659,9 @@ fn concrete_einsum_typed_result_reports_defensive_dtype_mismatch() {
 
     assert!(matches!(
         err,
-        tenferro_tensor::Error::Validation {
+        Error::Tensor(tenferro_tensor::Error::Validation {
             op: "test typed result",
             source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
-        }
+        })
     ));
 }

--- a/crates/tenferro-einsum/src/concrete_tests.rs
+++ b/crates/tenferro-einsum/src/concrete_tests.rs
@@ -308,9 +308,9 @@ fn public_einsum_into_rejects_output_shape_and_dtype_mismatch() {
         .unwrap_err();
     assert!(matches!(
         shape_err,
-        tenferro_tensor::Error::ShapeMismatch {
+        tenferro_tensor::Error::Validation {
             op: "TensorEinsumIntoExt::einsum_into",
-            ..
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
         }
     ));
 
@@ -324,10 +324,9 @@ fn public_einsum_into_rejects_output_shape_and_dtype_mismatch() {
         .unwrap_err();
     assert!(matches!(
         dtype_err,
-        tenferro_tensor::Error::DTypeMismatch {
+        tenferro_tensor::Error::Validation {
             op: "TensorEinsumIntoExt::einsum_into",
-            lhs: DType::F32,
-            rhs: DType::F64,
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
         }
     ));
 }
@@ -514,9 +513,9 @@ fn concrete_einsum_plan_execute_into_rejects_incompatible_output() {
 
     assert!(matches!(
         err,
-        tenferro_tensor::Error::ShapeMismatch {
+        tenferro_tensor::Error::Validation {
             op: "ConcreteEinsumPlan::execute",
-            ..
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
         }
     ));
 }
@@ -614,17 +613,16 @@ fn concrete_einsum_plan_rejects_shape_and_dtype_mismatches() {
 
     assert!(matches!(
         shape_err,
-        tenferro_tensor::Error::ShapeMismatch {
+        tenferro_tensor::Error::Validation {
             op: "ConcreteEinsumPlan::execute",
-            ..
+            source: tenferro_tensor::ValidationError::ShapeMismatch(_),
         }
     ));
     assert!(matches!(
         dtype_err,
-        tenferro_tensor::Error::DTypeMismatch {
+        tenferro_tensor::Error::Validation {
             op: "ConcreteEinsumPlan::execute",
-            lhs: DType::F64,
-            rhs: DType::F32,
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
         }
     ));
 }
@@ -645,14 +643,14 @@ fn concrete_einsum_public_api_reports_parse_and_input_count_errors() {
 
     assert!(matches!(
         parse_err,
-        tenferro_tensor::Error::InvalidConfig {
+        tenferro_tensor::Error::Validation {
             op: "TensorEinsumExt::einsum",
             ..
         }
     ));
     assert!(matches!(
         count_err,
-        tenferro_tensor::Error::InvalidConfig {
+        tenferro_tensor::Error::Validation {
             op: "ConcreteEinsumPlan::execute",
             ..
         }
@@ -667,10 +665,9 @@ fn concrete_einsum_typed_result_reports_defensive_dtype_mismatch() {
 
     assert!(matches!(
         err,
-        tenferro_tensor::Error::DTypeMismatch {
+        tenferro_tensor::Error::Validation {
             op: "test typed result",
-            lhs: DType::F64,
-            rhs: DType::F32,
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
         }
     ));
 }

--- a/crates/tenferro-einsum/src/eager.rs
+++ b/crates/tenferro-einsum/src/eager.rs
@@ -279,7 +279,7 @@ pub(crate) fn plan_subscripts(
     }
 
     ContractionTree::optimize(subs, input_shapes)
-        .map_err(|err| eager_invalid_config(format!("failed to optimize contraction tree: {err}")))
+        .map_err(|error| error.into_tensor_error(EAGER_EINSUM_OP))
 }
 
 fn take_labeled<'a>(
@@ -956,8 +956,8 @@ pub(crate) fn eager_einsum(
     inputs: &[&Tensor],
     subscripts: &str,
 ) -> Result<Tensor> {
-    let subscripts = Subscripts::parse(subscripts)
-        .map_err(|err| eager_invalid_config(format!("invalid subscripts: {err}")))?;
+    let subscripts =
+        Subscripts::parse(subscripts).map_err(|error| error.into_tensor_error(EAGER_EINSUM_OP))?;
     eager_einsum_subscripts(ctx, inputs, &subscripts)
 }
 
@@ -1060,8 +1060,8 @@ pub(crate) fn eager_einsum_owned(
     inputs: Vec<Tensor>,
     subscripts: &str,
 ) -> Result<Tensor> {
-    let subscripts = Subscripts::parse(subscripts)
-        .map_err(|err| eager_invalid_config(format!("invalid subscripts: {err}")))?;
+    let subscripts =
+        Subscripts::parse(subscripts).map_err(|error| error.into_tensor_error(EAGER_EINSUM_OP))?;
     eager_einsum_owned_subscripts(ctx, inputs, &subscripts)
 }
 

--- a/crates/tenferro-einsum/src/eager.rs
+++ b/crates/tenferro-einsum/src/eager.rs
@@ -96,40 +96,36 @@ fn broadcast_shape_strides<T: 'static, R: TensorRank>(
     dims: &[usize],
 ) -> Result<(Vec<usize>, Vec<isize>)> {
     if dims.len() != view.shape().len() {
-        return Err(Error::RankMismatch {
-            op: EAGER_EINSUM_OP,
-            expected: view.shape().len(),
-            actual: dims.len(),
-        });
+        return Err(Error::rank_mismatch(
+            EAGER_EINSUM_OP,
+            view.shape().len(),
+            dims.len(),
+        ));
     }
 
     let mut seen = vec![false; shape.len()];
     let mut strides = vec![0isize; shape.len()];
     for (src_axis, &dst_axis) in dims.iter().enumerate() {
         if dst_axis >= shape.len() {
-            return Err(Error::AxisOutOfBounds {
-                op: EAGER_EINSUM_OP,
-                axis: dst_axis,
-                rank: shape.len(),
-            });
+            return Err(Error::axis_out_of_bounds(
+                EAGER_EINSUM_OP,
+                dst_axis,
+                shape.len(),
+            ));
         }
         if seen[dst_axis] {
-            return Err(Error::DuplicateAxis {
-                op: EAGER_EINSUM_OP,
-                axis: dst_axis,
-                role: "broadcast dims",
-            });
+            return Err(Error::duplicate_axis(
+                EAGER_EINSUM_OP,
+                dst_axis,
+                "broadcast dims",
+            ));
         }
         seen[dst_axis] = true;
 
         let source_dim = view.shape()[src_axis];
         let target_dim = shape[dst_axis];
         if source_dim != target_dim && source_dim != 1 {
-            return Err(Error::ShapeMismatch {
-                op: EAGER_EINSUM_OP,
-                lhs: view.shape().to_vec(),
-                rhs: shape.to_vec(),
-            });
+            return Err(Error::shape_mismatch(EAGER_EINSUM_OP, view.shape(), shape));
         }
         if source_dim == target_dim {
             strides[dst_axis] = view.strides()[src_axis];
@@ -261,10 +257,7 @@ fn execute_binary_dot_fast_plan<'a>(
 }
 
 fn eager_invalid_config(message: impl Into<String>) -> Error {
-    Error::InvalidConfig {
-        op: EAGER_EINSUM_OP,
-        message: message.into(),
-    }
+    Error::invalid_argument(EAGER_EINSUM_OP, "configuration", message)
 }
 
 pub(crate) fn plan_subscripts(

--- a/crates/tenferro-einsum/src/eager_ad.rs
+++ b/crates/tenferro-einsum/src/eager_ad.rs
@@ -1,6 +1,7 @@
 //! EagerTensor einsum extension API.
 
 use std::collections::hash_map::DefaultHasher;
+use std::error::Error as StdError;
 use std::hash::{Hash, Hasher};
 use std::mem::size_of;
 use std::sync::Arc;
@@ -10,14 +11,13 @@ use computegraph::graph::GraphBuilder;
 use computegraph::materialize::materialize_merge;
 use computegraph::resolve::resolve;
 use computegraph::types::{ValueKey, ValueRef};
-use tenferro_ad::error::{Error, Result};
 use tenferro_ad::extension::{adopt_untracked_eager_value, apply_eager};
 use tenferro_ad::{EagerRuntime, EagerTensor};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_runtime::ExtensionCacheKey;
-use tenferro_tensor::TensorFusion;
+use tenferro_runtime::{ErrorPhase, ExtensionCacheKey};
+use tenferro_tensor::{ErrorKind, ShapeMismatch, TensorFusion, ValidationError, ValidationKind};
 
 use crate::binary_dot::{try_build_exact_output_binary_dot_plan, BinaryDotOperandOrder};
 use crate::builder::build_einsum_graph;
@@ -30,11 +30,28 @@ use crate::optimize::{
     default_auto_options, hash_einsum_plan_spec, plan_specs_equal, resolve_plan_spec,
     EinsumPlanSpec,
 };
-use crate::{parse_einsum_subscripts, EinsumSubscripts, Subscripts, TensorDotAxes};
+use crate::{parse_einsum_subscripts, EinsumSubscripts, Error, Result, Subscripts, TensorDotAxes};
 
 /// Eager einsum extension methods for slices or arrays of [`EagerTensor`] refs.
 pub trait EagerEinsumExt {
+    /// Execute an einsum from string notation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] for rank/shape/dtype mismatches, or
+    /// [`Error::Planning`] / [`Error::Runtime`] for contraction planning and
+    /// execution failures.
     fn einsum(&self, subscripts: &str) -> Result<EagerTensor>;
+
+    /// Execute an einsum from parsed integer labels.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] for rank/shape/dtype mismatches,
+    /// [`Error::Planning`] for an invalid contraction plan, or
+    /// [`Error::Runtime`] for extension registration or backend execution
+    /// failures.
     fn einsum_subscripts(&self, subscripts: &EinsumSubscripts) -> Result<EagerTensor>;
 }
 
@@ -60,6 +77,13 @@ impl<const N: usize> EagerEinsumExt for [&EagerTensor; N] {
 
 /// Eager tensor contraction-sugar methods.
 pub trait EagerTensorEinsumExt {
+    /// Contract two eager tensors over the requested axes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds`, `DuplicateAxis`,
+    /// `RankMismatch`, or `ShapeMismatch` for invalid axes/shapes, or
+    /// [`Error::Runtime`] for backend execution failures.
     fn tensordot(&self, rhs: &EagerTensor, axes: TensorDotAxes<'_>) -> Result<EagerTensor>;
 }
 
@@ -90,11 +114,17 @@ impl EagerTensorEinsumExt for EagerTensor {
 /// ).unwrap();
 /// let out = [&a, &b].einsum("ij,jk->ik")?;
 /// assert_eq!(out.shape(), &[2, 4]);
-/// # Ok::<(), tenferro_ad::error::Error>(())
+/// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidSubscripts`] for malformed notation,
+/// [`Error::Validation`] for input count/rank/shape/dtype mismatches,
+/// [`Error::Planning`] when no contraction path is valid, or [`Error::Runtime`]
+/// for extension registration and backend execution failures.
 pub fn einsum(inputs: &[&EagerTensor], subscripts: &str) -> Result<EagerTensor> {
-    let subscripts = parse_einsum_subscripts(subscripts)
-        .map_err(|err| Error::ContractionError(err.to_string()))?;
+    let subscripts = parse_einsum_subscripts(subscripts)?;
     einsum_subscripts(inputs, &subscripts)
 }
 
@@ -120,8 +150,14 @@ pub fn einsum(inputs: &[&EagerTensor], subscripts: &str) -> Result<EagerTensor> 
 /// let subscripts = parse_einsum_subscripts("ij,jk->ik").unwrap();
 /// let out = [&a, &b].einsum_subscripts(&subscripts)?;
 /// assert_eq!(out.shape(), &[2, 4]);
-/// # Ok::<(), tenferro_ad::error::Error>(())
+/// # Ok::<(), tenferro_einsum::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`] for input count/rank/shape/dtype mismatches,
+/// [`Error::Planning`] when no contraction path is valid, or [`Error::Runtime`]
+/// for extension registration and backend execution failures.
 pub fn einsum_subscripts(
     inputs: &[&EagerTensor],
     subscripts: &EinsumSubscripts,
@@ -143,7 +179,7 @@ pub fn einsum_subscripts(
         first
             .runtime()
             .register_extension(register_runtime)
-            .map_err(|err| Error::Internal(err.to_string()))?;
+            .map_err(|error| runtime_extension_error("einsum", ErrorKind::RuntimeState, error))?;
     }
 
     let op = Arc::new(EinsumExtensionOp::with_output_shape_hint(
@@ -152,9 +188,11 @@ pub fn einsum_subscripts(
         EinsumPlanSpec::Auto(default_auto_options()),
     ));
     let mut outputs = apply_eager(op, inputs)?;
-    outputs
-        .pop()
-        .ok_or_else(|| Error::Internal("einsum extension produced no eager output".to_string()))
+    outputs.pop().ok_or_else(|| {
+        Error::Runtime(tenferro_runtime::Error::MissingInput(
+            "einsum extension produced no eager output".into(),
+        ))
+    })
 }
 
 fn try_direct_binary_dot_general(
@@ -175,8 +213,12 @@ fn try_direct_binary_dot_general(
         try_build_exact_output_binary_dot_plan(lhs_labels, rhs_labels, &subscripts.output)
     {
         return Some(match plan.operand_order {
-            BinaryDotOperandOrder::Original => inputs[0].dot_general(inputs[1], plan.config),
-            BinaryDotOperandOrder::Swapped => inputs[1].dot_general(inputs[0], plan.config),
+            BinaryDotOperandOrder::Original => inputs[0]
+                .dot_general(inputs[1], plan.config)
+                .map_err(Error::Runtime),
+            BinaryDotOperandOrder::Swapped => inputs[1]
+                .dot_general(inputs[0], plan.config)
+                .map_err(Error::Runtime),
         });
     }
     None
@@ -222,7 +264,7 @@ fn try_whole_program_untracked(
     let subs = Subscripts::from(subscripts);
     let tensor_arcs = inputs
         .iter()
-        .map(|tensor| tensor.materialized())
+        .map(|tensor| tensor.materialized().map_err(Error::Runtime))
         .collect::<Result<Vec<_>>>()?;
     let tensors: Vec<_> = tensor_arcs.iter().map(|tensor| tensor.as_ref()).collect();
     let result = runtime.with_backend_mut(|backend| {
@@ -269,11 +311,17 @@ fn einsum_whole_program_untracked(
     tree: &crate::ContractionTree,
 ) -> Result<EagerTensor> {
     let first = inputs.first().ok_or_else(|| {
-        Error::ContractionError("einsum requires at least one input tensor".into())
+        Error::invalid_argument(
+            "einsum",
+            "inputs",
+            "einsum requires at least one input tensor",
+        )
     })?;
     if inputs.iter().any(|tensor| tensor.tracks_grad()) {
-        return Err(Error::Internal(
-            "whole-program eager einsum requires untracked inputs".into(),
+        return Err(Error::invalid_argument(
+            "einsum",
+            "inputs",
+            "whole-program eager einsum requires untracked inputs",
         ));
     }
     let runtime = first.runtime();
@@ -281,19 +329,21 @@ fn einsum_whole_program_untracked(
         .iter()
         .any(|tensor| !Arc::ptr_eq(tensor.runtime(), runtime))
     {
-        return Err(Error::Internal(
-            "whole-program eager einsum requires inputs from one runtime".into(),
+        return Err(Error::invalid_argument(
+            "einsum",
+            "inputs",
+            "whole-program eager einsum requires inputs from one runtime",
         ));
     }
     let tensor_arcs = inputs
         .iter()
-        .map(|tensor| tensor.materialized())
+        .map(|tensor| tensor.materialized().map_err(Error::Runtime))
         .collect::<Result<Vec<_>>>()?;
     let tensors: Vec<_> = tensor_arcs.iter().map(|tensor| tensor.as_ref()).collect();
     let result = runtime.with_backend_mut(|backend| {
         crate::eager::eager_einsum_with_tree(backend, &tensors, tree)
     })??;
-    EagerTensor::from_tensor_in(result, runtime.clone())
+    EagerTensor::from_tensor_in(result, runtime.clone()).map_err(Error::Runtime)
 }
 
 fn try_expand_eager_einsum(
@@ -391,8 +441,7 @@ fn cached_expanded_eager_program(
             }
         }
 
-        let tree = resolve_plan_spec(plan_spec, subs, shape_refs)
-            .map_err(|err| Error::ContractionError(err.to_string()))?;
+        let tree = resolve_plan_spec(plan_spec, subs, shape_refs)?;
         let program = Arc::new(build_expanded_eager_program(&tree, shapes)?);
         let key_data = ExpandedEagerProgramCacheKeyData::new(subscripts, shapes, plan_spec);
         let retained_bytes = saturating_sum([
@@ -460,12 +509,11 @@ fn build_expanded_eager_program(
         input_vals.push(ValueRef::Local(local));
     }
 
-    let result_ref = build_einsum_graph(&mut builder, tree, &input_vals, shapes)
-        .map_err(|err| Error::ContractionError(err.to_string()))?;
+    let result_ref = build_einsum_graph(&mut builder, tree, &input_vals, shapes)?;
     let ValueRef::Local(result_local) = result_ref else {
-        return Err(Error::Internal(
+        return Err(Error::Runtime(tenferro_runtime::Error::Internal(
             "expanded eager einsum returned an external value".into(),
-        ));
+        )));
     };
     builder.set_outputs(vec![result_local]);
     let graph = Arc::new(builder.build());
@@ -479,7 +527,7 @@ fn build_expanded_eager_program(
         .zip(graph.inputs.iter())
         .map(|(&slot, key)| {
             let ValueKey::Input(TensorInputKey::User { id }) = key else {
-                return Err(Error::Internal(format!(
+                return Err(runtime_internal(format!(
                     "expanded eager einsum saw unexpected input key: {key:?}"
                 )));
             };
@@ -500,7 +548,7 @@ fn execute_eager_einsum_program(
     let mut slots: Vec<Option<EagerTensor>> = vec![None; program.compiled.n_slots];
     for &(slot, input_idx) in &program.input_slots {
         let tensor = inputs.get(input_idx).ok_or_else(|| {
-            Error::Internal(format!(
+            runtime_missing(format!(
                 "expanded eager einsum input {input_idx} is missing"
             ))
         })?;
@@ -522,7 +570,7 @@ fn execute_eager_einsum_program(
 
         let instr = &program.compiled.instructions[instruction_idx];
         if instr.outputs.len() != 1 {
-            return Err(Error::Internal(format!(
+            return Err(runtime_internal(format!(
                 "expanded eager einsum expected single-output op, got {} outputs",
                 instr.outputs.len()
             )));
@@ -536,7 +584,7 @@ fn execute_eager_einsum_program(
                     .and_then(Option::as_ref)
                     .cloned()
                     .ok_or_else(|| {
-                        Error::Internal(format!(
+                        runtime_missing(format!(
                             "expanded eager einsum missing value for slot {slot}"
                         ))
                     })
@@ -550,7 +598,7 @@ fn execute_eager_einsum_program(
     }
 
     let [output_slot] = program.compiled.output_slots.as_slice() else {
-        return Err(Error::Internal(format!(
+        return Err(runtime_internal(format!(
             "expanded eager einsum expected one graph output, got {}",
             program.compiled.output_slots.len()
         )));
@@ -559,7 +607,7 @@ fn execute_eager_einsum_program(
         .get_mut(*output_slot)
         .and_then(Option::take)
         .map(Some)
-        .ok_or_else(|| Error::Internal("expanded eager einsum output slot is missing".into()))
+        .ok_or_else(|| runtime_missing("expanded eager einsum output slot is missing"))
 }
 
 fn expanded_eager_program_retained_bytes(program: &ExpandedEagerProgram) -> usize {
@@ -699,10 +747,11 @@ fn backend_broadcast_multiply_untracked(
     rhs_dims: &[usize],
 ) -> Result<Option<EagerTensor>> {
     if !Arc::ptr_eq(lhs.runtime(), rhs.runtime()) {
-        return Err(Error::ContextMismatch {
+        return Err(tenferro_runtime::Error::ContextMismatch {
             lhs: lhs.ctx_id(),
             rhs: rhs.ctx_id(),
-        });
+        }
+        .into());
     }
     if lhs.tracks_grad() || rhs.tracks_grad() {
         return Ok(None);
@@ -736,15 +785,20 @@ fn eval_shape_exprs(
         .iter()
         .map(|tensor| tensor.shape())
         .collect::<Vec<_>>();
-    DimExpr::eval_all(shape, &input_shapes)
-        .map_err(|err| Error::Internal(format!("invalid eager einsum shape expression: {err}")))
+    DimExpr::eval_all(shape, &input_shapes).map_err(|error| {
+        runtime_extension_error(
+            "einsum",
+            ErrorKind::Validation(ValidationKind::InvalidArgument),
+            error,
+        )
+    })
 }
 
 fn slot_tensor(slots: &[Option<EagerTensor>], slot: usize) -> Result<&EagerTensor> {
     slots.get(slot).and_then(Option::as_ref).ok_or_else(|| {
-        Error::Internal(format!(
+        Error::Runtime(tenferro_runtime::Error::MissingInput(format!(
             "expanded eager einsum missing value for slot {slot}"
-        ))
+        )))
     })
 }
 
@@ -753,34 +807,47 @@ fn infer_eager_output_shape(
     inputs: &[&EagerTensor],
 ) -> Result<Vec<tenferro_runtime::SymDim>> {
     if inputs.is_empty() {
-        return Err(Error::ContractionError(
-            "einsum requires at least one input tensor".into(),
+        return Err(Error::invalid_argument(
+            "einsum",
+            "inputs",
+            "einsum requires at least one input tensor",
         ));
     }
     if subscripts.inputs.len() != inputs.len() {
-        return Err(Error::ContractionError(format!(
-            "einsum subscripts expect {} inputs, got {}",
-            subscripts.inputs.len(),
-            inputs.len()
-        )));
+        return Err(Error::invalid_argument(
+            "einsum",
+            "inputs",
+            format!(
+                "einsum subscripts expect {} inputs, got {}",
+                subscripts.inputs.len(),
+                inputs.len()
+            ),
+        ));
     }
 
     let mut label_dims = std::collections::HashMap::new();
     for (labels, tensor) in subscripts.inputs.iter().zip(inputs.iter()) {
         let shape = tensor.shape();
         if labels.len() != shape.len() {
-            return Err(Error::ContractionError(format!(
-                "einsum input rank mismatch: labels={}, shape={}",
-                labels.len(),
-                shape.len()
-            )));
+            return Err(Error::validation(
+                "einsum",
+                ValidationError::RankMismatch {
+                    expected: labels.len(),
+                    actual: shape.len(),
+                },
+            ));
         }
         for (&label, &dim) in labels.iter().zip(shape.iter()) {
             if let Some(existing) = label_dims.insert(label, dim) {
                 if existing != dim {
-                    return Err(Error::ContractionError(format!(
-                        "einsum label {label} has inconsistent dimensions {existing} and {dim}"
-                    )));
+                    return Err(Error::validation(
+                        "einsum",
+                        ShapeMismatch::ExpectedActual {
+                            expected: tenferro_tensor::ShapeVec::from_vec(vec![existing]),
+                            actual: tenferro_tensor::ShapeVec::from_vec(vec![dim]),
+                        }
+                        .into(),
+                    ));
                 }
             }
         }
@@ -795,12 +862,35 @@ fn infer_eager_output_shape(
                 .copied()
                 .map(tenferro_runtime::SymDim::from)
                 .ok_or_else(|| {
-                    Error::ContractionError(format!(
-                        "einsum output label {label} is missing from input labels"
-                    ))
+                    Error::invalid_argument(
+                        "einsum",
+                        "output",
+                        format!("einsum output label {label} is missing from input labels"),
+                    )
                 })
         })
         .collect()
+}
+
+fn runtime_extension_error<E>(op: &'static str, kind: ErrorKind, source: E) -> Error
+where
+    E: StdError + Send + Sync + 'static,
+{
+    Error::Runtime(tenferro_runtime::Error::extension(
+        op,
+        ErrorPhase::Execution,
+        EINSUM_EXTENSION_FAMILY_ID,
+        kind,
+        source,
+    ))
+}
+
+fn runtime_internal(message: impl Into<String>) -> Error {
+    Error::Runtime(tenferro_runtime::Error::Internal(message.into()))
+}
+
+fn runtime_missing(message: impl Into<String>) -> Error {
+    Error::Runtime(tenferro_runtime::Error::MissingInput(message.into()))
 }
 
 /// Execute a NumPy-style tensor contraction on [`EagerTensor`] values.
@@ -829,6 +919,12 @@ fn infer_eager_output_shape(
 ///
 /// assert_eq!(out.shape(), &[2, 4]);
 /// ```
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`] with `AxisOutOfBounds`, `DuplicateAxis`,
+/// `RankMismatch`, or `ShapeMismatch` for invalid contraction axes and shapes,
+/// or [`Error::Runtime`] for eager backend execution failures.
 pub fn tensordot(
     lhs: &EagerTensor,
     rhs: &EagerTensor,
@@ -836,7 +932,7 @@ pub fn tensordot(
 ) -> Result<EagerTensor> {
     let config = crate::tensordot::dot_general_config(axes, lhs.shape().len(), rhs.shape().len())?;
     crate::tensordot::validate_concrete_contract_dims(lhs.shape(), rhs.shape(), &config)?;
-    lhs.dot_general(rhs, config)
+    lhs.dot_general(rhs, config).map_err(Error::Runtime)
 }
 
 #[cfg(test)]

--- a/crates/tenferro-einsum/src/eager_ad.rs
+++ b/crates/tenferro-einsum/src/eager_ad.rs
@@ -736,9 +736,8 @@ fn eval_shape_exprs(
         .iter()
         .map(|tensor| tensor.shape())
         .collect::<Vec<_>>();
-    DimExpr::eval_all(shape, &input_shapes).map_err(|err| Error::InvalidCompiledGraph {
-        message: format!("invalid eager einsum shape expression: {err}"),
-    })
+    DimExpr::eval_all(shape, &input_shapes)
+        .map_err(|err| Error::Internal(format!("invalid eager einsum shape expression: {err}")))
 }
 
 fn slot_tensor(slots: &[Option<EagerTensor>], slot: usize) -> Result<&EagerTensor> {

--- a/crates/tenferro-einsum/src/error.rs
+++ b/crates/tenferro-einsum/src/error.rs
@@ -52,7 +52,7 @@ impl Error {
     ///
     /// assert!(matches!(
     ///     err,
-    ///     TensorError::BackendFailure {
+    ///     TensorError::BackendSource {
     ///         op: "einsum_extension",
     ///         ..
     ///     }
@@ -60,7 +60,7 @@ impl Error {
     /// ```
     #[must_use]
     pub fn to_tensor_error(&self, op: &'static str) -> tenferro_tensor::Error {
-        tenferro_tensor::Error::backend_failure(op, self)
+        tenferro_tensor::Error::backend_source(op, self.clone())
     }
 }
 

--- a/crates/tenferro-einsum/src/error.rs
+++ b/crates/tenferro-einsum/src/error.rs
@@ -1,77 +1,291 @@
 //! Error types owned by the einsum crate.
 //!
+//! Parsing and planning remain einsum-domain concerns, while shared tensor
+//! validation is represented by the common validation vocabulary. At erased
+//! runtime boundaries [`Error::into_tensor_error`] preserves this distinction
+//! and keeps the original einsum error as a typed source.
+//!
 //! # Examples
 //!
 //! ```rust
 //! use tenferro_einsum::Error;
+//! use tenferro_tensor::{ErrorKind, ValidationKind};
 //!
-//! let err = Error::InvalidArgument("bad subscripts".into());
-//! assert_eq!(err.to_string(), "invalid argument: bad subscripts");
+//! let err = Error::invalid_subscripts("missing output arrow");
+//! assert_eq!(err.kind(), ErrorKind::Validation(ValidationKind::InvalidArgument));
 //! ```
 
-/// Errors produced while parsing, planning, or lowering einsum expressions.
+use tenferro_tensor::{DType, ErrorKind, ShapeMismatch, ShapeVec, ValidationError, ValidationKind};
+
+use crate::EINSUM_EXTENSION_FAMILY_ID;
+
+/// Errors produced while parsing, planning, lowering, or executing einsum
+/// expressions.
 ///
 /// # Examples
 ///
 /// ```rust
 /// use tenferro_einsum::Error;
+/// use tenferro_tensor::{ErrorKind, ShapeMismatch, ShapeVec, ValidationKind};
 ///
-/// let err = Error::ShapeMismatch {
-///     expected: vec![2, 3],
-///     got: vec![2, 4],
-/// };
-/// assert!(err.to_string().contains("shape mismatch"));
+/// let err = Error::validation(
+///     "einsum",
+///     ShapeMismatch::ExpectedActual {
+///         expected: ShapeVec::from_vec(vec![2, 3]),
+///         actual: ShapeVec::from_vec(vec![2, 4]),
+///     }
+///     .into(),
+/// );
+/// assert_eq!(err.kind(), ErrorKind::Validation(ValidationKind::ShapeMismatch));
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
-    /// Tensor shapes are incompatible for an einsum expression.
-    #[error("shape mismatch: expected {expected:?}, got {got:?}")]
-    ShapeMismatch {
-        /// Expected shape or dimension sizes.
-        expected: Vec<usize>,
-        /// Actual shape or dimension sizes.
-        got: Vec<usize>,
+    /// A shared tensor validation fact discovered by an einsum operation.
+    #[error("{op}: {source}")]
+    Validation {
+        /// Public operation name.
+        op: &'static str,
+        /// Machine-readable validation payload.
+        #[source]
+        source: ValidationError,
     },
 
-    /// An invalid einsum argument was provided.
-    #[error("invalid argument: {0}")]
-    InvalidArgument(String),
+    /// Einsum notation is malformed or cannot be parsed.
+    #[error("invalid einsum subscripts: {message}")]
+    InvalidSubscripts {
+        /// Human-readable parser detail.
+        message: String,
+    },
+
+    /// No valid contraction plan could be constructed for the supplied
+    /// expression or optimizer configuration.
+    #[error("einsum planning failed: {message}")]
+    Planning {
+        /// Human-readable planning detail.
+        message: String,
+    },
+
+    /// A numerical contraction or backend accumulation failed to converge.
+    #[error("einsum numerical failure: {message}")]
+    Numerical {
+        /// Human-readable numerical detail.
+        message: String,
+    },
+
+    /// A concrete tensor/backend operation failed.
+    #[error(transparent)]
+    Tensor(#[from] tenferro_tensor::Error),
+
+    /// Graph construction or extension execution failed in the runtime.
+    #[error(transparent)]
+    Runtime(#[from] tenferro_runtime::Error),
 }
 
 impl Error {
-    /// Convert this einsum error into a tensor backend failure.
+    /// Construct a shared validation error.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use tenferro_einsum::Error;
-    /// use tenferro_tensor::Error as TensorError;
+    /// use tenferro_tensor::ValidationError;
     ///
-    /// let err = Error::InvalidArgument("bad subscripts".into())
-    ///     .to_tensor_error("einsum_extension");
+    /// let error = Error::validation("einsum", ValidationError::RankMismatch {
+    ///     expected: 2,
+    ///     actual: 1,
+    /// });
+    /// assert!(matches!(error, Error::Validation { .. }));
+    /// ```
+    pub fn validation(op: &'static str, source: ValidationError) -> Self {
+        Self::Validation { op, source }
+    }
+
+    /// Construct an invalid-argument validation error.
     ///
-    /// assert!(matches!(
-    ///     err,
-    ///     TensorError::BackendSource {
-    ///         op: "einsum_extension",
-    ///         ..
-    ///     }
-    /// ));
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_einsum::Error;
+    ///
+    /// let error = Error::invalid_argument("einsum", "inputs", "at least one input is required");
+    /// assert!(matches!(error, Error::Validation { .. }));
+    /// ```
+    pub fn invalid_argument(
+        op: &'static str,
+        argument: &'static str,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::validation(
+            op,
+            ValidationError::InvalidArgument {
+                argument,
+                message: message.into(),
+            },
+        )
+    }
+
+    /// Construct a shape-mismatch validation error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_einsum::Error;
+    ///
+    /// let error = Error::shape_mismatch("einsum", [2, 3], [2, 4]);
+    /// assert!(matches!(error, Error::Validation { .. }));
+    /// ```
+    pub fn shape_mismatch(
+        op: &'static str,
+        expected: impl Into<Vec<usize>>,
+        actual: impl Into<Vec<usize>>,
+    ) -> Self {
+        Self::validation(
+            op,
+            ShapeMismatch::ExpectedActual {
+                expected: ShapeVec::from_vec(expected.into()),
+                actual: ShapeVec::from_vec(actual.into()),
+            }
+            .into(),
+        )
+    }
+
+    /// Construct a dtype-mismatch validation error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_einsum::Error;
+    /// use tenferro_tensor::DType;
+    ///
+    /// let error = Error::dtype_mismatch("einsum", DType::F32, DType::F64);
+    /// assert!(matches!(error, Error::Tensor(_)));
+    /// ```
+    pub fn dtype_mismatch(op: &'static str, expected: DType, actual: DType) -> Self {
+        Self::Tensor(tenferro_tensor::Error::dtype_mismatch(op, expected, actual))
+    }
+
+    /// Construct a rank-mismatch validation error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_einsum::Error;
+    ///
+    /// let error = Error::rank_mismatch("einsum", 2, 1);
+    /// assert!(matches!(error, Error::Validation { .. }));
+    /// ```
+    pub fn rank_mismatch(op: &'static str, expected: usize, actual: usize) -> Self {
+        Self::validation(op, ValidationError::RankMismatch { expected, actual })
+    }
+
+    /// Construct an invalid-notation error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_einsum::Error;
+    ///
+    /// let error = Error::invalid_subscripts("missing `->`");
+    /// assert!(matches!(error, Error::InvalidSubscripts { .. }));
+    /// ```
+    pub fn invalid_subscripts(message: impl Into<String>) -> Self {
+        Self::InvalidSubscripts {
+            message: message.into(),
+        }
+    }
+
+    /// Construct a planning failure.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_einsum::Error;
+    ///
+    /// let error = Error::planning("no contraction path");
+    /// assert!(matches!(error, Error::Planning { .. }));
+    /// ```
+    pub fn planning(message: impl Into<String>) -> Self {
+        Self::Planning {
+            message: message.into(),
+        }
+    }
+
+    /// Construct a numerical failure.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_einsum::Error;
+    ///
+    /// let error = Error::numerical("contraction did not converge");
+    /// assert!(matches!(error, Error::Numerical { .. }));
+    /// ```
+    pub fn numerical(message: impl Into<String>) -> Self {
+        Self::Numerical {
+            message: message.into(),
+        }
+    }
+
+    /// Return the stable coarse classification of this einsum failure.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_einsum::Error;
+    /// use tenferro_tensor::{ErrorKind, ValidationKind};
+    ///
+    /// assert_eq!(
+    ///     Error::invalid_subscripts("bad").kind(),
+    ///     ErrorKind::Validation(ValidationKind::InvalidArgument),
+    /// );
     /// ```
     #[must_use]
-    pub fn to_tensor_error(&self, op: &'static str) -> tenferro_tensor::Error {
-        tenferro_tensor::Error::backend_source(op, self.clone())
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            Self::Validation { source, .. } => ErrorKind::Validation(source.kind()),
+            Self::InvalidSubscripts { .. } => {
+                ErrorKind::Validation(ValidationKind::InvalidArgument)
+            }
+            Self::Planning { .. } => ErrorKind::RuntimeState,
+            Self::Numerical { .. } => ErrorKind::NumericalFailure,
+            Self::Tensor(error) => error.kind(),
+            Self::Runtime(error) => error.kind(),
+        }
+    }
+
+    /// Promote this error to the tensor error used by a type-erased extension
+    /// boundary without formatting away its typed source.
+    ///
+    /// Shared validation is promoted directly. All crate-local and nested
+    /// errors remain a boxed source under the einsum extension family.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::error::Error as _;
+    /// use tenferro_einsum::Error;
+    /// use tenferro_tensor::{Error as TensorError, ErrorKind};
+    ///
+    /// let tensor_error = Error::planning("no valid contraction path")
+    ///     .into_tensor_error("einsum_extension");
+    /// assert_eq!(tensor_error.kind(), ErrorKind::RuntimeState);
+    /// assert!(matches!(tensor_error, TensorError::Extension { .. }));
+    /// assert!(tensor_error.source().is_some());
+    /// ```
+    #[must_use]
+    pub fn into_tensor_error(self, op: &'static str) -> tenferro_tensor::Error {
+        match self {
+            Self::Validation { op, source } => tenferro_tensor::Error::validation(op, source),
+            Self::Tensor(error) => error,
+            error => {
+                let kind = error.kind();
+                tenferro_tensor::Error::extension(op, EINSUM_EXTENSION_FAMILY_ID, kind, error)
+            }
+        }
     }
 }
 
-/// Result type alias for einsum parsing, planning, and lowering.
-///
-/// # Examples
-///
-/// ```rust
-/// use tenferro_einsum::{Error, Result};
-///
-/// let result: Result<()> = Err(Error::InvalidArgument("bad input".into()));
-/// assert!(result.is_err());
-/// ```
+/// Result type alias for einsum parsing, planning, and all public extension
+/// APIs.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/tenferro-einsum/src/error.rs
+++ b/crates/tenferro-einsum/src/error.rs
@@ -19,6 +19,41 @@ use tenferro_tensor::{DType, ErrorKind, ShapeMismatch, ShapeVec, ValidationError
 
 use crate::EINSUM_EXTENSION_FAMILY_ID;
 
+/// Domain-specific cause of an einsum planning failure.
+///
+/// Caller-controlled expressions, shapes, and optimizer options use
+/// [`PlanningError::InvalidConfiguration`]. Runtime-state classification is
+/// reserved for an unavailable or poisoned planner state.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_einsum::{Error, PlanningError};
+///
+/// let error = Error::planning("the requested path is invalid");
+/// assert!(matches!(
+///     error,
+///     Error::Planning {
+///         source: PlanningError::InvalidConfiguration { .. }
+///     }
+/// ));
+/// ```
+#[derive(Debug, thiserror::Error)]
+pub enum PlanningError {
+    /// The requested expression, path, or planner option is invalid.
+    #[error("invalid einsum planning configuration: {message}")]
+    InvalidConfiguration {
+        /// Human-readable configuration detail.
+        message: String,
+    },
+    /// Planner state required by a valid request is unavailable.
+    #[error("einsum planning runtime state unavailable: {message}")]
+    RuntimeState {
+        /// Human-readable state detail.
+        message: String,
+    },
+}
+
 /// Errors produced while parsing, planning, lowering, or executing einsum
 /// expressions.
 ///
@@ -60,10 +95,11 @@ pub enum Error {
 
     /// No valid contraction plan could be constructed for the supplied
     /// expression or optimizer configuration.
-    #[error("einsum planning failed: {message}")]
+    #[error("einsum planning failed: {source}")]
     Planning {
-        /// Human-readable planning detail.
-        message: String,
+        /// Typed planning-domain cause.
+        #[source]
+        source: PlanningError,
     },
 
     /// A numerical contraction or backend accumulation failed to converge.
@@ -207,7 +243,34 @@ impl Error {
     /// ```
     pub fn planning(message: impl Into<String>) -> Self {
         Self::Planning {
-            message: message.into(),
+            source: PlanningError::InvalidConfiguration {
+                message: message.into(),
+            },
+        }
+    }
+
+    /// Construct a planning failure caused by unavailable planner state.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_einsum::{Error, PlanningError};
+    /// use tenferro_tensor::ErrorKind;
+    ///
+    /// let error = Error::planning_runtime_state("planner lock is poisoned");
+    /// assert_eq!(error.kind(), ErrorKind::RuntimeState);
+    /// assert!(matches!(
+    ///     error,
+    ///     Error::Planning {
+    ///         source: PlanningError::RuntimeState { .. }
+    ///     }
+    /// ));
+    /// ```
+    pub fn planning_runtime_state(message: impl Into<String>) -> Self {
+        Self::Planning {
+            source: PlanningError::RuntimeState {
+                message: message.into(),
+            },
         }
     }
 
@@ -247,7 +310,12 @@ impl Error {
             Self::InvalidSubscripts { .. } => {
                 ErrorKind::Validation(ValidationKind::InvalidArgument)
             }
-            Self::Planning { .. } => ErrorKind::RuntimeState,
+            Self::Planning { source } => match source {
+                PlanningError::InvalidConfiguration { .. } => {
+                    ErrorKind::Validation(ValidationKind::InvalidArgument)
+                }
+                PlanningError::RuntimeState { .. } => ErrorKind::RuntimeState,
+            },
             Self::Numerical { .. } => ErrorKind::NumericalFailure,
             Self::Tensor(error) => error.kind(),
             Self::Runtime(error) => error.kind(),
@@ -265,11 +333,14 @@ impl Error {
     /// ```rust
     /// use std::error::Error as _;
     /// use tenferro_einsum::Error;
-    /// use tenferro_tensor::{Error as TensorError, ErrorKind};
+    /// use tenferro_tensor::{Error as TensorError, ErrorKind, ValidationKind};
     ///
     /// let tensor_error = Error::planning("no valid contraction path")
     ///     .into_tensor_error("einsum_extension");
-    /// assert_eq!(tensor_error.kind(), ErrorKind::RuntimeState);
+    /// assert_eq!(
+    ///     tensor_error.kind(),
+    ///     ErrorKind::Validation(ValidationKind::InvalidArgument)
+    /// );
     /// assert!(matches!(tensor_error, TensorError::Extension { .. }));
     /// assert!(tensor_error.source().is_some());
     /// ```

--- a/crates/tenferro-einsum/src/extension.rs
+++ b/crates/tenferro-einsum/src/extension.rs
@@ -301,10 +301,12 @@ impl ExtensionOp for EinsumExtensionOp {
         };
         let shape_refs: Vec<&[usize]> = shapes.iter().map(Vec::as_slice).collect();
         let subs = Subscripts::from(&self.subscripts);
-        let tree = resolve_plan_spec(self.plan_spec(), &subs, &shape_refs)
-            .map_err(ExtensionLoweringError::from_source)?;
-        let output = build_einsum_graph(builder, &tree, inputs, &shapes)
-            .map_err(ExtensionLoweringError::from_source)?;
+        let tree = resolve_plan_spec(self.plan_spec(), &subs, &shape_refs).map_err(|source| {
+            ExtensionLoweringError::from_source_with_kind(source.kind(), source)
+        })?;
+        let output = build_einsum_graph(builder, &tree, inputs, &shapes).map_err(|source| {
+            ExtensionLoweringError::from_source_with_kind(source.kind(), source)
+        })?;
         Ok(Some(vec![output]))
     }
 }

--- a/crates/tenferro-einsum/src/extension.rs
+++ b/crates/tenferro-einsum/src/extension.rs
@@ -228,14 +228,11 @@ impl ExtensionOp for EinsumExtensionOp {
         let mut label_dims: HashMap<u32, SymDim> = HashMap::new();
         for (labels, shape) in self.subscripts.inputs.iter().zip(input_shapes.iter()) {
             if labels.len() != shape.len() {
-                return Err(TensorError::InvalidConfig {
-                    op: "einsum",
-                    message: format!(
-                        "subscript rank {} does not match input rank {}",
-                        labels.len(),
-                        shape.len()
-                    ),
-                });
+                return Err(TensorError::rank_mismatch(
+                    "einsum",
+                    labels.len(),
+                    shape.len(),
+                ));
             }
             for (&label, dim) in labels.iter().zip(shape.iter()) {
                 if let Some(existing) = label_dims.get(&label) {
@@ -254,20 +251,20 @@ impl ExtensionOp for EinsumExtensionOp {
                 .iter()
                 .map(|label| label_dims.get(label).cloned())
                 .collect::<Option<Vec<_>>>()
-                .ok_or_else(|| TensorError::InvalidConfig {
-                    op: "einsum",
-                    message: "output labels must be present in input metadata".into(),
+                .ok_or_else(|| {
+                    TensorError::invalid_argument(
+                        "einsum",
+                        "output labels",
+                        "must be present in input metadata",
+                    )
                 })?,
         };
         if output_shape.len() != self.subscripts.output.len() {
-            return Err(TensorError::InvalidConfig {
-                op: "einsum",
-                message: format!(
-                    "output rank {} does not match subscript rank {}",
-                    output_shape.len(),
-                    self.subscripts.output.len()
-                ),
-            });
+            return Err(TensorError::rank_mismatch(
+                "einsum",
+                self.subscripts.output.len(),
+                output_shape.len(),
+            ));
         }
         Ok(vec![(
             promote_dtypes(input_dtypes.iter().copied()),
@@ -934,10 +931,11 @@ fn execute_einsum_extension<B: TensorBackend + 'static>(
     ctx: &mut ExtensionExecutionContext<'_, B>,
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
     if inputs.is_empty() {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "einsum_extension",
-            message: "einsum requires at least one input tensor".into(),
-        });
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "einsum_extension",
+            "inputs",
+            "einsum requires at least one input tensor",
+        ));
     }
 
     let shapes: Vec<Vec<usize>> = inputs
@@ -1008,7 +1006,7 @@ fn execute_einsum_extension<B: TensorBackend + 'static>(
         program_inputs,
         &mut cached.backend_cache,
     )
-    .map_err(|err| tenferro_tensor::Error::backend_failure("einsum_extension", err.to_string()))?;
+    .map_err(|err| tenferro_tensor::Error::backend_source("einsum_extension", err))?;
     if outputs.len() != 1 {
         return Err(tenferro_tensor::Error::backend_failure(
             "einsum_extension",
@@ -1038,10 +1036,11 @@ fn execute_einsum_extension_reads<B: TensorBackend + 'static>(
     }
 
     if inputs.is_empty() {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "einsum_extension",
-            message: "einsum requires at least one input tensor".into(),
-        });
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "einsum_extension",
+            "inputs",
+            "einsum requires at least one input tensor",
+        ));
     }
 
     let shapes: Vec<Vec<usize>> = inputs.iter().map(|input| input.shape().to_vec()).collect();
@@ -1270,7 +1269,7 @@ fn build_runtime_exec_program<B: TensorBackend>(
         &input_shapes,
         compiler_options,
     )
-    .map_err(|err| tenferro_tensor::Error::backend_failure("einsum_extension", err.to_string()))?;
+    .map_err(|err| tenferro_tensor::Error::backend_source("einsum_extension", err))?;
     Ok(CachedRuntimeExecProgram {
         key_data,
         program,

--- a/crates/tenferro-einsum/src/extension.rs
+++ b/crates/tenferro-einsum/src/extension.rs
@@ -302,9 +302,9 @@ impl ExtensionOp for EinsumExtensionOp {
         let shape_refs: Vec<&[usize]> = shapes.iter().map(Vec::as_slice).collect();
         let subs = Subscripts::from(&self.subscripts);
         let tree = resolve_plan_spec(self.plan_spec(), &subs, &shape_refs)
-            .map_err(|err| ExtensionLoweringError::new(err.to_string()))?;
+            .map_err(ExtensionLoweringError::from_source)?;
         let output = build_einsum_graph(builder, &tree, inputs, &shapes)
-            .map_err(|err| ExtensionLoweringError::new(err.to_string()))?;
+            .map_err(ExtensionLoweringError::from_source)?;
         Ok(Some(vec![output]))
     }
 }
@@ -332,6 +332,12 @@ fn concrete_sym_shape_slices(input_shapes: &[&[SymDim]]) -> Option<Vec<Vec<usize
 
 /// Return the explicit einsum extension AD rule set.
 #[cfg(feature = "autodiff")]
+///
+/// # Errors
+///
+/// Returns [`ExtensionRegistryError::MalformedFamilyId`] if the einsum family
+/// identifier is invalid, or [`ExtensionRegistryError::DuplicateRule`] if a
+/// rule for the family and role is already present.
 pub fn ad_rules() -> Result<ExtensionRuleSet, ExtensionRegistryError> {
     ExtensionRuleSet::new()
         .with_linearize(Arc::new(EinsumAdRule))?
@@ -987,14 +993,14 @@ fn execute_einsum_extension<B: TensorBackend + 'static>(
     let cached = caches
         .get_mut::<CachedRuntimeExecProgram<B::RuntimeCache>>(&key)
         .ok_or_else(|| {
-            tenferro_tensor::Error::backend_failure(
+            tenferro_tensor::Error::runtime_state(
                 "einsum_extension",
                 "runtime exec program cache entry missing after insertion",
             )
         })?;
     let key_data = &cached.key_data;
     if !key_data.matches_runtime_exec_program(op, inputs, &shapes, optimizer_fingerprint) {
-        return Err(tenferro_tensor::Error::backend_failure(
+        return Err(tenferro_tensor::Error::runtime_state(
             "einsum_extension",
             "runtime exec program cache hash collision was not replaced",
         ));
@@ -1008,7 +1014,7 @@ fn execute_einsum_extension<B: TensorBackend + 'static>(
     )
     .map_err(|err| tenferro_tensor::Error::backend_source("einsum_extension", err))?;
     if outputs.len() != 1 {
-        return Err(tenferro_tensor::Error::backend_failure(
+        return Err(tenferro_tensor::Error::runtime_state(
             "einsum_extension",
             format!("expected 1 output, got {}", outputs.len()),
         ));
@@ -1221,7 +1227,7 @@ fn build_runtime_exec_program<B: TensorBackend>(
     let result_local = match result_ref {
         ValueRef::Local(local) => local,
         ValueRef::External(_) => {
-            return Err(tenferro_tensor::Error::backend_failure(
+            return Err(tenferro_tensor::Error::runtime_state(
                 "einsum_extension",
                 "einsum builder returned an external value at runtime",
             ))
@@ -1243,7 +1249,7 @@ fn build_runtime_exec_program<B: TensorBackend>(
             ValueKey::Input(TensorInputKey::User { id }) => {
                 let input_idx = *id as usize;
                 let tensor = inputs.get(input_idx).ok_or_else(|| {
-                    tenferro_tensor::Error::backend_failure(
+                    tenferro_tensor::Error::runtime_state(
                         "einsum_extension",
                         format!("runtime input {input_idx} missing"),
                     )
@@ -1255,7 +1261,7 @@ fn build_runtime_exec_program<B: TensorBackend>(
                 ));
             }
             other => {
-                return Err(tenferro_tensor::Error::backend_failure(
+                return Err(tenferro_tensor::Error::runtime_state(
                     "einsum_extension",
                     format!("unexpected runtime input key: {other:?}"),
                 ))
@@ -1285,7 +1291,7 @@ fn runtime_program_inputs(
     let mut program_inputs = Vec::with_capacity(input_indices.len());
     for &input_idx in input_indices {
         let tensor = inputs.get(input_idx).ok_or_else(|| {
-            tenferro_tensor::Error::backend_failure(
+            tenferro_tensor::Error::runtime_state(
                 "einsum_extension",
                 format!("runtime input {input_idx} missing"),
             )
@@ -1390,7 +1396,7 @@ fn cached_runtime_tree<B: TensorBackend>(
 }
 
 fn einsum_runtime_error(error: EinsumError) -> tenferro_tensor::Error {
-    error.to_tensor_error("einsum_extension")
+    error.into_tensor_error("einsum_extension")
 }
 
 fn runtime_tree_cache_discriminator(

--- a/crates/tenferro-einsum/src/lib.rs
+++ b/crates/tenferro-einsum/src/lib.rs
@@ -88,7 +88,7 @@ pub use concrete::{
 };
 #[cfg(feature = "autodiff")]
 pub use eager_ad::{EagerEinsumExt, EagerTensorEinsumExt};
-pub use error::{Error, Result};
+pub use error::{Error, PlanningError, Result};
 #[cfg(feature = "autodiff")]
 pub use extension::ad_rules;
 pub use extension::register_runtime;

--- a/crates/tenferro-einsum/src/lib.rs
+++ b/crates/tenferro-einsum/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! let out = [&a, &b].einsum("ij,jk->ik", &mut backend)?;
 //! assert_eq!(out.shape(), &[2, 4]);
-//! # Ok::<(), tenferro_tensor::Error>(())
+//! # Ok::<(), tenferro_einsum::Error>(())
 //! ```
 //!
 //! ```

--- a/crates/tenferro-einsum/src/optimize.rs
+++ b/crates/tenferro-einsum/src/optimize.rs
@@ -109,9 +109,8 @@ pub(crate) fn plan_spec_from_optimize(
             let _ = jax_path_to_v1_pairs(&path, subscripts.inputs.len())?;
             Ok(EinsumPlanSpec::Path(path))
         }
-        EinsumOptimize::Tree(_) => Err(Error::InvalidArgument(
-            "precomputed contraction tree requires concrete input shapes; use Path or parenthesized notation for symbolic traced einsum"
-                .into(),
+        EinsumOptimize::Tree(_) => Err(Error::planning(
+            "precomputed contraction tree requires concrete input shapes; use Path or parenthesized notation for symbolic traced einsum",
         )),
     }
 }
@@ -202,7 +201,7 @@ fn tree_pairs(tree: &ContractionTree) -> Vec<(usize, usize)> {
 fn validate_fixed_pairs(pairs: &[(usize, usize)], input_count: usize) -> Result<()> {
     let required_steps = input_count.saturating_sub(1);
     if pairs.len() != required_steps {
-        return Err(Error::InvalidArgument(format!(
+        return Err(Error::planning(format!(
             "explicit contraction path for {input_count} operands must have {required_steps} steps, got {}",
             pairs.len()
         )));
@@ -216,17 +215,17 @@ fn validate_fixed_pairs(pairs: &[(usize, usize)], input_count: usize) -> Result<
     for (step_idx, &(left, right)) in pairs.iter().enumerate() {
         let next_idx = input_count + step_idx;
         if left == right {
-            return Err(Error::InvalidArgument(format!(
+            return Err(Error::planning(format!(
                 "pair ({left}, {right}) must reference two distinct live operands"
             )));
         }
         if left >= next_idx || right >= next_idx {
-            return Err(Error::InvalidArgument(format!(
+            return Err(Error::planning(format!(
                 "pair ({left}, {right}) references non-existent operand"
             )));
         }
         if !live[left] || !live[right] {
-            return Err(Error::InvalidArgument(format!(
+            return Err(Error::planning(format!(
                 "pair ({left}, {right}) references an operand or intermediate that is no longer live"
             )));
         }
@@ -238,7 +237,7 @@ fn validate_fixed_pairs(pairs: &[(usize, usize)], input_count: usize) -> Result<
 
     let live_count = live.iter().filter(|&&is_live| is_live).count();
     if live_count != 1 {
-        return Err(Error::InvalidArgument(format!(
+        return Err(Error::planning(format!(
             "explicit contraction path must leave exactly one live result, got {live_count}"
         )));
     }
@@ -294,7 +293,7 @@ pub(crate) fn jax_path_to_v1_pairs(
 ) -> Result<Vec<(usize, usize)>> {
     let required_steps = input_count.saturating_sub(1);
     if jax_path.len() != required_steps {
-        return Err(Error::InvalidArgument(format!(
+        return Err(Error::planning(format!(
             "explicit contraction path for {input_count} operands must have {required_steps} steps, got {}",
             jax_path.len()
         )));
@@ -305,13 +304,13 @@ pub(crate) fn jax_path_to_v1_pairs(
 
     for (step, &(pos_a, pos_b)) in jax_path.iter().enumerate() {
         if pos_a == pos_b {
-            return Err(Error::InvalidArgument(format!(
+            return Err(Error::planning(format!(
                 "path step {step} references the same operand position twice: {pos_a}"
             )));
         }
         let current_len = positions.len();
         if pos_a >= current_len || pos_b >= current_len {
-            return Err(Error::InvalidArgument(format!(
+            return Err(Error::planning(format!(
                 "path step {step} references operand positions ({pos_a}, {pos_b}) with only {current_len} live operands"
             )));
         }
@@ -347,8 +346,8 @@ pub(crate) fn nested_to_v1_pairs(
     let mut next_id = input_count;
     let root_id = walk_nested(nested, input_count, &mut pairs, &mut next_id)?;
     if input_count == 0 || root_id >= next_id {
-        return Err(Error::InvalidArgument(
-            "nested einsum did not produce a valid root operand".into(),
+        return Err(Error::planning(
+            "nested einsum did not produce a valid root operand",
         ));
     }
     Ok(pairs)
@@ -363,7 +362,7 @@ fn walk_nested(
     match nested {
         NestedEinsum::Leaf(idx) => {
             if *idx >= input_count {
-                return Err(Error::InvalidArgument(format!(
+                return Err(Error::planning(format!(
                     "nested einsum leaf {idx} is outside 0..{input_count}"
                 )));
             }
@@ -371,8 +370,8 @@ fn walk_nested(
         }
         NestedEinsum::Node { children, .. } => {
             let Some(first) = children.first() else {
-                return Err(Error::InvalidArgument(
-                    "nested einsum node must have at least one child".into(),
+                return Err(Error::planning(
+                    "nested einsum node must have at least one child",
                 ));
             };
             let mut result_id = walk_nested(first, input_count, pairs, next_id)?;

--- a/crates/tenferro-einsum/src/optimize/tests.rs
+++ b/crates/tenferro-einsum/src/optimize/tests.rs
@@ -99,7 +99,7 @@ fn concrete_tree_strategy_revalidates_current_shapes() {
         };
 
     assert!(
-        matches!(err, Error::ShapeMismatch { .. }),
+        matches!(err, Error::Validation { .. }),
         "expected ShapeMismatch, got {err}"
     );
 }

--- a/crates/tenferro-einsum/src/planning/plan.rs
+++ b/crates/tenferro-einsum/src/planning/plan.rs
@@ -370,7 +370,7 @@ fn product_or_one_for_empty(sizes: &[usize], label: &'static str) -> EinsumResul
 fn checked_product(sizes: &[usize], label: &'static str) -> EinsumResult<usize> {
     sizes.iter().try_fold(1usize, |acc, &size| {
         acc.checked_mul(size).ok_or_else(|| {
-            crate::Error::InvalidArgument(format!(
+            crate::Error::planning(format!(
                 "dimension product overflow while fusing {label} dimensions {sizes:?}"
             ))
         })

--- a/crates/tenferro-einsum/src/planning/plan_tests.rs
+++ b/crates/tenferro-einsum/src/planning/plan_tests.rs
@@ -90,7 +90,7 @@ fn pairwise_step_plan_preserves_strict_lowering_error_type() {
 
     assert!(matches!(
         err,
-        Error::InvalidArgument(message)
+        Error::Planning { message }
             if message.contains("unknown size")
     ));
 }
@@ -105,7 +105,7 @@ fn pairwise_step_plan_rejects_overflowing_fused_dimensions() {
 
     assert!(matches!(
         err,
-        Error::InvalidArgument(message)
+        Error::Planning { message }
             if message.contains("dimension product overflow")
     ));
 }
@@ -119,7 +119,7 @@ fn strict_binary_lowering_rejects_overflowing_fused_dimensions() {
 
     assert!(matches!(
         err,
-        Error::InvalidArgument(message)
+        Error::Planning { message }
             if message.contains("dimension product overflow")
     ));
 }

--- a/crates/tenferro-einsum/src/planning/plan_tests.rs
+++ b/crates/tenferro-einsum/src/planning/plan_tests.rs
@@ -90,8 +90,8 @@ fn pairwise_step_plan_preserves_strict_lowering_error_type() {
 
     assert!(matches!(
         err,
-        Error::Planning { message }
-            if message.contains("unknown size")
+        Error::Planning { source }
+            if source.to_string().contains("unknown size")
     ));
 }
 
@@ -105,8 +105,8 @@ fn pairwise_step_plan_rejects_overflowing_fused_dimensions() {
 
     assert!(matches!(
         err,
-        Error::Planning { message }
-            if message.contains("dimension product overflow")
+        Error::Planning { source }
+            if source.to_string().contains("dimension product overflow")
     ));
 }
 
@@ -119,7 +119,7 @@ fn strict_binary_lowering_rejects_overflowing_fused_dimensions() {
 
     assert!(matches!(
         err,
-        Error::Planning { message }
-            if message.contains("dimension product overflow")
+        Error::Planning { source }
+            if source.to_string().contains("dimension product overflow")
     ));
 }

--- a/crates/tenferro-einsum/src/planning/strict_binary.rs
+++ b/crates/tenferro-einsum/src/planning/strict_binary.rs
@@ -28,7 +28,7 @@ fn product(dims: &[usize], label: &'static str) -> crate::Result<usize> {
     }
     dims.iter().try_fold(1usize, |acc, &dim| {
         acc.checked_mul(dim).ok_or_else(|| {
-            Error::InvalidArgument(format!(
+            Error::planning(format!(
                 "dimension product overflow while fusing {label} dimensions {dims:?}"
             ))
         })
@@ -159,7 +159,7 @@ fn compile_strict_binary_lowering_plan_from_parts(
                 .iter()
                 .position(|candidate| candidate == label)
                 .ok_or_else(|| {
-                    Error::InvalidArgument(format!("strict lowering: missing output label {label}"))
+                    Error::planning(format!("strict lowering: missing output label {label}"))
                 })
         })
         .collect::<EinsumResult<_>>()?;
@@ -192,7 +192,7 @@ pub(crate) fn compile_strict_binary_lowering_step_plan(
         subs.iter()
             .map(|label| {
                 size_dict.get(label).copied().ok_or_else(|| {
-                    Error::InvalidArgument(format!(
+                    Error::planning(format!(
                         "strict lowering: missing dimension for label {label}"
                     ))
                 })

--- a/crates/tenferro-einsum/src/planning/tree.rs
+++ b/crates/tenferro-einsum/src/planning/tree.rs
@@ -59,13 +59,13 @@ impl ContractionOptimizerOptions {
 
     pub(crate) fn validate(&self) -> Result<()> {
         if self.ntrials == 0 {
-            return Err(Error::InvalidArgument(
-                "contraction optimizer ntrials must be at least 1".into(),
+            return Err(Error::planning(
+                "contraction optimizer ntrials must be at least 1",
             ));
         }
         if self.betas.iter().any(|value| value.is_nan()) {
-            return Err(Error::InvalidArgument(
-                "contraction optimizer betas must not contain NaN".into(),
+            return Err(Error::planning(
+                "contraction optimizer betas must not contain NaN",
             ));
         }
         if self.score.tc_weight.is_nan()
@@ -73,8 +73,8 @@ impl ContractionOptimizerOptions {
             || self.score.rw_weight.is_nan()
             || self.score.sc_target.is_nan()
         {
-            return Err(Error::InvalidArgument(
-                "contraction optimizer score fields must not contain NaN".into(),
+            return Err(Error::planning(
+                "contraction optimizer score fields must not contain NaN",
             ));
         }
         Ok(())
@@ -131,7 +131,9 @@ impl ContractionTree {
     ///
     /// # Errors
     ///
-    /// Returns an error if subscripts and shapes are inconsistent.
+    /// Returns [`Error::Validation`] when subscripts and shapes have different
+    /// ranks or incompatible dimensions, or [`Error::Planning`] when no valid
+    /// contraction order can be constructed.
     pub fn optimize(subscripts: &Subscripts, shapes: &[&[usize]]) -> Result<Self> {
         Self::optimize_with_options(subscripts, shapes, &ContractionOptimizerOptions::default())
     }
@@ -145,7 +147,9 @@ impl ContractionTree {
     ///
     /// # Errors
     ///
-    /// Returns an error if subscripts, shapes, or planner options are invalid.
+    /// Returns [`Error::Validation`] for rank, shape, or dimension mismatches,
+    /// or [`Error::Planning`] when planner options such as `ntrials` are
+    /// invalid or no contraction order can be constructed.
     pub fn optimize_with_options(
         subscripts: &Subscripts,
         shapes: &[&[usize]],
@@ -197,7 +201,9 @@ impl ContractionTree {
     ///
     /// # Errors
     ///
-    /// Returns an error if the pairs do not form a valid contraction sequence.
+    /// Returns [`Error::Planning`] when the pair count, operand indices, or
+    /// intermediate sequence is invalid, or [`Error::Validation`] when the
+    /// supplied shapes do not match the subscripts.
     pub fn from_pairs(
         subscripts: &Subscripts,
         shapes: &[&[usize]],
@@ -206,7 +212,7 @@ impl ContractionTree {
         let input_count = subscripts.inputs.len();
         let required_steps = input_count.saturating_sub(1);
         if pairs.len() != required_steps {
-            return Err(Error::InvalidArgument(format!(
+            return Err(Error::planning(format!(
                 "explicit contraction path for {input_count} operands must have {required_steps} steps, got {}",
                 pairs.len()
             )));
@@ -223,17 +229,17 @@ impl ContractionTree {
         for (step_idx, &(left, right)) in pairs.iter().enumerate() {
             let next_idx = input_count + step_idx;
             if left == right {
-                return Err(Error::InvalidArgument(format!(
+                return Err(Error::planning(format!(
                     "pair ({left}, {right}) must reference two distinct live operands"
                 )));
             }
             if left >= next_idx || right >= next_idx {
-                return Err(Error::InvalidArgument(format!(
+                return Err(Error::planning(format!(
                     "pair ({left}, {right}) references non-existent operand"
                 )));
             }
             if !live[left] || !live[right] {
-                return Err(Error::InvalidArgument(format!(
+                return Err(Error::planning(format!(
                     "pair ({left}, {right}) references an operand or intermediate that is no longer live"
                 )));
             }
@@ -256,7 +262,7 @@ impl ContractionTree {
 
         let live_count = live.iter().filter(|&&is_live| is_live).count();
         if live_count != 1 {
-            return Err(Error::InvalidArgument(format!(
+            return Err(Error::planning(format!(
                 "explicit contraction path must leave exactly one live result, got {live_count}"
             )));
         }
@@ -482,7 +488,7 @@ fn nested_to_pairs(
         NestedEinsum::Leaf { tensor_index } => Ok(*tensor_index),
         NestedEinsum::Node { args, .. } => {
             if args.len() != 2 {
-                return Err(Error::InvalidArgument(format!(
+                return Err(Error::planning(format!(
                     "omeco returned non-binary contraction node with {} children",
                     args.len()
                 )));
@@ -602,7 +608,7 @@ fn candidate_contraction_cost(
     let mut cost = 1usize;
     for &label in candidate_subs.iter() {
         let size = context.size_dict.get(&label).copied().ok_or_else(|| {
-            Error::InvalidArgument(format!(
+            Error::planning(format!(
                 "unknown size for label {label} in contraction cost"
             ))
         })?;

--- a/crates/tenferro-einsum/src/planning/tree/tests.rs
+++ b/crates/tenferro-einsum/src/planning/tree/tests.rs
@@ -104,7 +104,7 @@ fn optimize_with_options_rejects_zero_trials() {
         Ok(_) => panic!("expected invalid ntrials to be rejected"),
         Err(err) => err,
     };
-    assert!(matches!(err, Error::Planning { message } if message.contains("ntrials")));
+    assert!(matches!(err, Error::Planning { source } if source.to_string().contains("ntrials")));
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn optimizer_options_reject_nan_betas() {
         Ok(_) => panic!("expected NaN betas to be rejected"),
         Err(err) => err,
     };
-    assert!(matches!(err, Error::Planning { message } if message.contains("NaN")));
+    assert!(matches!(err, Error::Planning { source } if source.to_string().contains("NaN")));
 }
 
 #[test]
@@ -154,7 +154,7 @@ fn optimizer_options_reject_nan_score_fields() {
             Err(err) => err,
         };
         assert!(
-            matches!(err, Error::Planning { message } if message.contains("NaN")),
+            matches!(err, Error::Planning { source } if source.to_string().contains("NaN")),
             "expected InvalidArgument mentioning NaN for {field}"
         );
     }
@@ -173,7 +173,7 @@ fn single_operand_optimize_with_options_rejects_invalid_options() {
         Ok(_) => panic!("expected invalid single-operand options to be rejected"),
         Err(err) => err,
     };
-    assert!(matches!(err, Error::Planning { message } if message.contains("ntrials")));
+    assert!(matches!(err, Error::Planning { source } if source.to_string().contains("ntrials")));
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn nested_to_pairs_rejects_non_binary_nodes() {
     let mut pairs = Vec::new();
 
     let err = nested_to_pairs(&nested, &mut next_operand, &mut pairs).unwrap_err();
-    assert!(matches!(err, Error::Planning { message } if message.contains("non-binary")));
+    assert!(matches!(err, Error::Planning { source } if source.to_string().contains("non-binary")));
 }
 
 #[test]
@@ -237,7 +237,7 @@ fn self_greedy_pair_optimizer_rejects_missing_needed_label() {
     let err = optimize_self_greedy_pairs(&subs, &size_dict).unwrap_err();
 
     assert!(
-        matches!(err, Error::Planning { message } if message.contains("unknown size for label 4"))
+        matches!(err, Error::Planning { source } if source.to_string().contains("unknown size for label 4"))
     );
 }
 
@@ -291,7 +291,7 @@ fn from_pairs_rejects_duplicate_pair_indices() {
     let shapes = [&[2, 3][..], &[3, 4][..]];
     let result = ContractionTree::from_pairs(&subs, &shapes, &[(0, 0)]);
     match result {
-        Err(Error::Planning { message: msg }) if msg.contains("distinct") => {}
+        Err(Error::Planning { source }) if source.to_string().contains("distinct") => {}
         other => panic!(
             "expected InvalidArgument with 'distinct', got: {:?}",
             other.as_ref().map(|_| "Ok").map_err(|e| e.to_string())
@@ -305,7 +305,7 @@ fn from_pairs_rejects_pair_referencing_nonexistent_operand() {
     let shapes = [&[2, 3][..], &[3, 4][..]];
     let result = ContractionTree::from_pairs(&subs, &shapes, &[(0, 5)]);
     match result {
-        Err(Error::Planning { message: msg }) if msg.contains("non-existent") => {}
+        Err(Error::Planning { source }) if source.to_string().contains("non-existent") => {}
         other => panic!(
             "expected InvalidArgument with 'non-existent', got: {:?}",
             other.as_ref().map(|_| "Ok").map_err(|e| e.to_string())
@@ -319,7 +319,7 @@ fn from_pairs_rejects_pair_referencing_dead_operand() {
     let shapes = [&[2, 2][..], &[2, 2][..], &[2, 2][..]];
     let result = ContractionTree::from_pairs(&subs, &shapes, &[(0, 1), (0, 3)]);
     match result {
-        Err(Error::Planning { message: msg }) if msg.contains("no longer live") => {}
+        Err(Error::Planning { source }) if source.to_string().contains("no longer live") => {}
         other => panic!(
             "expected InvalidArgument with 'no longer live', got: {:?}",
             other.as_ref().map(|_| "Ok").map_err(|e| e.to_string())
@@ -333,7 +333,7 @@ fn from_pairs_rejects_wrong_step_count() {
     let shapes = [&[2, 2][..], &[2, 2][..], &[2, 2][..]];
     let result = ContractionTree::from_pairs(&subs, &shapes, &[(0, 1)]);
     match result {
-        Err(Error::Planning { message: msg }) if msg.contains("must have") => {}
+        Err(Error::Planning { source }) if source.to_string().contains("must have") => {}
         other => panic!(
             "expected InvalidArgument with 'must have', got: {:?}",
             other.as_ref().map(|_| "Ok").map_err(|e| e.to_string())

--- a/crates/tenferro-einsum/src/planning/tree/tests.rs
+++ b/crates/tenferro-einsum/src/planning/tree/tests.rs
@@ -104,7 +104,7 @@ fn optimize_with_options_rejects_zero_trials() {
         Ok(_) => panic!("expected invalid ntrials to be rejected"),
         Err(err) => err,
     };
-    assert!(matches!(err, Error::InvalidArgument(message) if message.contains("ntrials")));
+    assert!(matches!(err, Error::Planning { message } if message.contains("ntrials")));
 }
 
 #[test]
@@ -120,7 +120,7 @@ fn optimizer_options_reject_nan_betas() {
         Ok(_) => panic!("expected NaN betas to be rejected"),
         Err(err) => err,
     };
-    assert!(matches!(err, Error::InvalidArgument(message) if message.contains("NaN")));
+    assert!(matches!(err, Error::Planning { message } if message.contains("NaN")));
 }
 
 #[test]
@@ -154,7 +154,7 @@ fn optimizer_options_reject_nan_score_fields() {
             Err(err) => err,
         };
         assert!(
-            matches!(err, Error::InvalidArgument(message) if message.contains("NaN")),
+            matches!(err, Error::Planning { message } if message.contains("NaN")),
             "expected InvalidArgument mentioning NaN for {field}"
         );
     }
@@ -173,7 +173,7 @@ fn single_operand_optimize_with_options_rejects_invalid_options() {
         Ok(_) => panic!("expected invalid single-operand options to be rejected"),
         Err(err) => err,
     };
-    assert!(matches!(err, Error::InvalidArgument(message) if message.contains("ntrials")));
+    assert!(matches!(err, Error::Planning { message } if message.contains("ntrials")));
 }
 
 #[test]
@@ -213,7 +213,7 @@ fn nested_to_pairs_rejects_non_binary_nodes() {
     let mut pairs = Vec::new();
 
     let err = nested_to_pairs(&nested, &mut next_operand, &mut pairs).unwrap_err();
-    assert!(matches!(err, Error::InvalidArgument(message) if message.contains("non-binary")));
+    assert!(matches!(err, Error::Planning { message } if message.contains("non-binary")));
 }
 
 #[test]
@@ -237,7 +237,7 @@ fn self_greedy_pair_optimizer_rejects_missing_needed_label() {
     let err = optimize_self_greedy_pairs(&subs, &size_dict).unwrap_err();
 
     assert!(
-        matches!(err, Error::InvalidArgument(message) if message.contains("unknown size for label 4"))
+        matches!(err, Error::Planning { message } if message.contains("unknown size for label 4"))
     );
 }
 
@@ -291,7 +291,7 @@ fn from_pairs_rejects_duplicate_pair_indices() {
     let shapes = [&[2, 3][..], &[3, 4][..]];
     let result = ContractionTree::from_pairs(&subs, &shapes, &[(0, 0)]);
     match result {
-        Err(Error::InvalidArgument(msg)) if msg.contains("distinct") => {}
+        Err(Error::Planning { message: msg }) if msg.contains("distinct") => {}
         other => panic!(
             "expected InvalidArgument with 'distinct', got: {:?}",
             other.as_ref().map(|_| "Ok").map_err(|e| e.to_string())
@@ -305,7 +305,7 @@ fn from_pairs_rejects_pair_referencing_nonexistent_operand() {
     let shapes = [&[2, 3][..], &[3, 4][..]];
     let result = ContractionTree::from_pairs(&subs, &shapes, &[(0, 5)]);
     match result {
-        Err(Error::InvalidArgument(msg)) if msg.contains("non-existent") => {}
+        Err(Error::Planning { message: msg }) if msg.contains("non-existent") => {}
         other => panic!(
             "expected InvalidArgument with 'non-existent', got: {:?}",
             other.as_ref().map(|_| "Ok").map_err(|e| e.to_string())
@@ -319,7 +319,7 @@ fn from_pairs_rejects_pair_referencing_dead_operand() {
     let shapes = [&[2, 2][..], &[2, 2][..], &[2, 2][..]];
     let result = ContractionTree::from_pairs(&subs, &shapes, &[(0, 1), (0, 3)]);
     match result {
-        Err(Error::InvalidArgument(msg)) if msg.contains("no longer live") => {}
+        Err(Error::Planning { message: msg }) if msg.contains("no longer live") => {}
         other => panic!(
             "expected InvalidArgument with 'no longer live', got: {:?}",
             other.as_ref().map(|_| "Ok").map_err(|e| e.to_string())
@@ -333,7 +333,7 @@ fn from_pairs_rejects_wrong_step_count() {
     let shapes = [&[2, 2][..], &[2, 2][..], &[2, 2][..]];
     let result = ContractionTree::from_pairs(&subs, &shapes, &[(0, 1)]);
     match result {
-        Err(Error::InvalidArgument(msg)) if msg.contains("must have") => {}
+        Err(Error::Planning { message: msg }) if msg.contains("must have") => {}
         other => panic!(
             "expected InvalidArgument with 'must have', got: {:?}",
             other.as_ref().map(|_| "Ok").map_err(|e| e.to_string())

--- a/crates/tenferro-einsum/src/subscripts.rs
+++ b/crates/tenferro-einsum/src/subscripts.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Result, Subscripts};
+use crate::{Result, Subscripts};
 
 /// Canonical N-ary einsum subscripts using integer labels.
 ///
@@ -101,11 +101,10 @@ impl From<&EinsumSubscripts> for Subscripts {
 ///
 /// # Errors
 ///
-/// Returns an error if the notation is malformed.
+/// Returns [`crate::Error::InvalidSubscripts`] when the notation is malformed,
+/// contains an invalid label, or has an invalid input/output separator.
 pub fn parse_einsum_subscripts(notation: &str) -> Result<EinsumSubscripts> {
-    Subscripts::parse(notation)
-        .map(EinsumSubscripts::from)
-        .map_err(|err| Error::InvalidArgument(format!("invalid einsum subscripts: {err}")))
+    Subscripts::parse(notation).map(EinsumSubscripts::from)
 }
 
 #[cfg(test)]

--- a/crates/tenferro-einsum/src/syntax/nested.rs
+++ b/crates/tenferro-einsum/src/syntax/nested.rs
@@ -73,8 +73,8 @@ impl NestedEinsum {
     ///
     /// # Errors
     ///
-    /// Returns an error if parentheses are mismatched or the notation is
-    /// otherwise malformed.
+    /// Returns [`Error::InvalidSubscripts`] when parentheses are mismatched,
+    /// labels are invalid, or the notation is otherwise malformed.
     pub fn parse(notation: &str) -> Result<Self> {
         let (lhs, output_str) = split_and_validate_notation(notation)?;
 
@@ -162,7 +162,7 @@ impl NestedEinsum {
                 '(' => depth += 1,
                 ')' => {
                     if depth == 0 {
-                        return Err(Error::InvalidArgument(format!(
+                        return Err(Error::invalid_subscripts(format!(
                             "unmatched ')' in einsum group: {s}"
                         )));
                     }

--- a/crates/tenferro-einsum/src/syntax/notation.rs
+++ b/crates/tenferro-einsum/src/syntax/notation.rs
@@ -12,7 +12,7 @@ const RESERVED_CHARS: &[char] = &[',', '-', '>', '(', ')', ' '];
 /// generate when the ASCII label space is exhausted.
 pub(crate) fn char_to_label(c: char) -> Result<u32> {
     if RESERVED_CHARS.contains(&c) {
-        return Err(Error::InvalidArgument(format!(
+        return Err(Error::invalid_subscripts(format!(
             "invalid einsum label character: {c:?} (U+{:04X}); reserved syntax character",
             c as u32
         )));
@@ -25,19 +25,19 @@ pub(crate) fn char_to_label(c: char) -> Result<u32> {
 /// Returns `(lhs, rhs)` where `lhs` is the input side and `rhs` is the output side.
 pub(crate) fn split_and_validate_notation(notation: &str) -> Result<(&str, &str)> {
     if notation.contains("...") {
-        return Err(Error::InvalidArgument(
-            "einsum ellipsis '...' is not supported yet".into(),
+        return Err(Error::invalid_subscripts(
+            "einsum ellipsis '...' is not supported yet",
         ));
     }
     if notation.contains('.') {
-        return Err(Error::InvalidArgument(
-            "einsum label '.' is reserved for ellipsis, which is not supported yet".into(),
+        return Err(Error::invalid_subscripts(
+            "einsum label '.' is reserved for ellipsis, which is not supported yet",
         ));
     }
 
     let parts: Vec<&str> = notation.split("->").collect();
     if parts.len() != 2 {
-        return Err(Error::InvalidArgument(format!(
+        return Err(Error::invalid_subscripts(format!(
             "einsum notation must contain exactly one '->', got: {notation}"
         )));
     }
@@ -52,7 +52,7 @@ pub(crate) fn split_and_validate_notation(notation: &str) -> Result<(&str, &str)
             ')' => {
                 depth -= 1;
                 if depth < 0 {
-                    return Err(Error::InvalidArgument(format!(
+                    return Err(Error::invalid_subscripts(format!(
                         "unmatched ')' in einsum notation: {notation}"
                     )));
                 }
@@ -61,7 +61,7 @@ pub(crate) fn split_and_validate_notation(notation: &str) -> Result<(&str, &str)
         }
     }
     if depth != 0 {
-        return Err(Error::InvalidArgument(format!(
+        return Err(Error::invalid_subscripts(format!(
             "unmatched '(' in einsum notation: {notation}"
         )));
     }

--- a/crates/tenferro-einsum/src/syntax/subscripts.rs
+++ b/crates/tenferro-einsum/src/syntax/subscripts.rs
@@ -84,14 +84,13 @@ impl Subscripts {
     /// - `"ijk->"` — full contraction (scalar result)
     /// # Errors
     ///
-    /// Returns an error if the notation is malformed or contains
-    /// parenthesized contraction order.
+    /// Returns [`Error::InvalidSubscripts`] if the notation is malformed or
+    /// contains parenthesized contraction order.
     pub fn parse(notation: &str) -> Result<Self> {
         let (inputs_str, output_str) = split_and_validate_notation(notation)?;
         if inputs_str.contains(['(', ')']) {
-            return Err(Error::InvalidArgument(
-                "Subscripts::parse does not accept parentheses; use NestedEinsum::parse to preserve parenthesized contraction order"
-                    .into(),
+            return Err(Error::invalid_subscripts(
+                "Subscripts::parse does not accept parentheses; use NestedEinsum::parse to preserve parenthesized contraction order",
             ));
         }
 

--- a/crates/tenferro-einsum/src/syntax/subscripts/tests.rs
+++ b/crates/tenferro-einsum/src/syntax/subscripts/tests.rs
@@ -7,7 +7,7 @@ fn parse_rejects_parenthesized_order_without_discarding_it() {
 
     assert!(matches!(
         err,
-        Error::InvalidArgument(message)
+        Error::InvalidSubscripts { message }
             if message.contains("parentheses")
                 && message.contains("NestedEinsum::parse")
     ));
@@ -19,7 +19,7 @@ fn parse_rejects_ellipsis_with_specific_error() {
 
     assert!(matches!(
         err,
-        Error::InvalidArgument(message)
+        Error::InvalidSubscripts { message }
             if message.contains("ellipsis")
                 && message.contains("not supported")
     ));

--- a/crates/tenferro-einsum/src/tensordot.rs
+++ b/crates/tenferro-einsum/src/tensordot.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 
-use tenferro_runtime::error::{Error, Result};
+use tenferro_runtime::error::{Error, ErrorPhase, Result};
 use tenferro_runtime::{DotGeneralConfig, TracedTensor};
+use tenferro_tensor::{ShapeMismatch, ValidationError};
 
 /// Axis specification for [`TracedTensorEinsumExt::tensordot`](crate::TracedTensorEinsumExt::tensordot)
 /// contraction sugar.
@@ -46,20 +47,30 @@ pub(crate) fn dot_general_config(
     let (lhs_contracting_dims, rhs_contracting_dims) = match axes {
         TensorDotAxes::Count(count) => {
             if count > lhs_rank || count > rhs_rank {
-                return Err(contraction_error(format!(
-                    "TensorDotAxes::Count({count}) cannot contract {count} axes \
-                     for lhs rank {lhs_rank} and rhs rank {rhs_rank}"
-                )));
+                return Err(Error::invalid_argument(
+                    "tensordot",
+                    ErrorPhase::GraphBuild,
+                    "axes",
+                    format!(
+                        "TensorDotAxes::Count({count}) cannot contract {count} axes \
+                         for lhs rank {lhs_rank} and rhs rank {rhs_rank}"
+                    ),
+                ));
             }
             ((lhs_rank - count..lhs_rank).collect(), (0..count).collect())
         }
         TensorDotAxes::Axes { lhs, rhs } => {
             if lhs.len() != rhs.len() {
-                return Err(contraction_error(format!(
-                    "tensordot explicit axes must have matching lengths, got lhs {} and rhs {}",
-                    lhs.len(),
-                    rhs.len()
-                )));
+                return Err(Error::invalid_argument(
+                    "tensordot",
+                    ErrorPhase::GraphBuild,
+                    "axes",
+                    format!(
+                        "tensordot explicit axes must have matching lengths, got lhs {} and rhs {}",
+                        lhs.len(),
+                        rhs.len()
+                    ),
+                ));
             }
             (
                 normalize_axes(lhs, lhs_rank, "lhs")?,
@@ -76,7 +87,7 @@ pub(crate) fn dot_general_config(
     };
     config
         .validate_dims_with_ranks(lhs_rank, rhs_rank)
-        .map_err(|err| contraction_error(err.to_string()))?;
+        .map_err(|error| graph_build_tensor_error("tensordot", error))?;
     Ok(config)
 }
 
@@ -88,7 +99,7 @@ pub(crate) fn validate_concrete_contract_dims(
 ) -> Result<()> {
     config
         .validate_dims_with_ranks(lhs_shape.len(), rhs_shape.len())
-        .map_err(|err| contraction_error(err.to_string()))?;
+        .map_err(|error| graph_build_tensor_error("tensordot", error))?;
     for (&lhs_axis, &rhs_axis) in config
         .lhs_contracting_dims
         .iter()
@@ -110,7 +121,7 @@ pub(crate) fn validate_traced_contract_dims(
 ) -> Result<()> {
     config
         .validate_dims_with_ranks(lhs.rank, rhs.rank)
-        .map_err(|err| contraction_error(err.to_string()))?;
+        .map_err(|error| graph_build_tensor_error("tensordot", error))?;
     for (&lhs_axis, &rhs_axis) in config
         .lhs_contracting_dims
         .iter()
@@ -134,37 +145,51 @@ pub(crate) fn validate_traced_contract_dims(
     Ok(())
 }
 
-fn normalize_axes(axes: &[isize], rank: usize, operand: &str) -> Result<Vec<usize>> {
+fn normalize_axes(axes: &[isize], rank: usize, operand: &'static str) -> Result<Vec<usize>> {
     let mut normalized = Vec::with_capacity(axes.len());
     let mut seen = HashSet::with_capacity(axes.len());
     for &axis in axes {
         let normalized_axis = normalize_axis(axis, rank, operand)?;
         if !seen.insert(normalized_axis) {
-            return Err(contraction_error(format!(
-                "duplicate {operand} axis {normalized_axis} in tensordot axes"
-            )));
+            return Err(Error::validation(
+                "tensordot",
+                ErrorPhase::GraphBuild,
+                ValidationError::DuplicateAxis {
+                    axis: normalized_axis,
+                    role: operand,
+                },
+            ));
         }
         normalized.push(normalized_axis);
     }
     Ok(normalized)
 }
 
-fn normalize_axis(axis: isize, rank: usize, operand: &str) -> Result<usize> {
+fn normalize_axis(axis: isize, rank: usize, _operand: &'static str) -> Result<usize> {
     let rank_isize = isize::try_from(rank).map_err(|_| {
-        contraction_error(format!(
-            "{operand} rank {rank} is too large to normalize tensordot axes"
-        ))
+        Error::validation(
+            "tensordot",
+            ErrorPhase::GraphBuild,
+            ValidationError::IntegerOverflow,
+        )
     })?;
     let normalized = if axis < 0 { rank_isize + axis } else { axis };
     if normalized < 0 || normalized >= rank_isize {
-        return Err(contraction_error(format!(
-            "{operand} axis {axis} out of bounds for rank {rank}"
-        )));
+        return Err(Error::validation(
+            "tensordot",
+            ErrorPhase::GraphBuild,
+            ValidationError::AxisOutOfBounds {
+                axis: axis.unsigned_abs(),
+                rank,
+            },
+        ));
     }
     usize::try_from(normalized).map_err(|_| {
-        contraction_error(format!(
-            "{operand} axis {axis} could not be normalized for rank {rank}"
-        ))
+        Error::validation(
+            "tensordot",
+            ErrorPhase::GraphBuild,
+            ValidationError::IntegerOverflow,
+        )
     })
 }
 
@@ -174,14 +199,26 @@ fn contracted_dims_error(
     rhs_axis: usize,
     rhs_dim: usize,
 ) -> Error {
-    contraction_error(format!(
-        "contracted dimensions differ for lhs axis {lhs_axis} ({lhs_dim}) \
-         and rhs axis {rhs_axis} ({rhs_dim})"
-    ))
+    Error::validation(
+        "tensordot",
+        ErrorPhase::GraphBuild,
+        ShapeMismatch::ContractedDimensions {
+            lhs_axis,
+            lhs_size: lhs_dim,
+            rhs_axis,
+            rhs_size: rhs_dim,
+        }
+        .into(),
+    )
 }
 
-fn contraction_error(message: impl Into<String>) -> Error {
-    Error::ContractionError(message.into())
+fn graph_build_tensor_error(op: &'static str, error: tenferro_tensor::Error) -> Error {
+    match error {
+        tenferro_tensor::Error::Validation { source, .. } => {
+            Error::validation(op, ErrorPhase::GraphBuild, source)
+        }
+        error => Error::TensorRuntime(error),
+    }
 }
 
 #[cfg(test)]

--- a/crates/tenferro-einsum/src/tests/builder_tests.rs
+++ b/crates/tenferro-einsum/src/tests/builder_tests.rs
@@ -46,7 +46,7 @@ fn builder_reports_missing_output_label_instead_of_panicking() {
 
     assert!(matches!(
         err,
-        Error::InvalidArgument(message)
+        Error::Planning { message }
             if message.contains("missing") && message.contains("label")
     ));
 }

--- a/crates/tenferro-einsum/src/tests/builder_tests.rs
+++ b/crates/tenferro-einsum/src/tests/builder_tests.rs
@@ -46,8 +46,8 @@ fn builder_reports_missing_output_label_instead_of_panicking() {
 
     assert!(matches!(
         err,
-        Error::Planning { message }
-            if message.contains("missing") && message.contains("label")
+        Error::Planning { source }
+            if source.to_string().contains("missing") && source.to_string().contains("label")
     ));
 }
 

--- a/crates/tenferro-einsum/src/tests/eager_tests.rs
+++ b/crates/tenferro-einsum/src/tests/eager_tests.rs
@@ -125,7 +125,10 @@ fn eager_einsum_read_views_match_owned_inputs() {
     let read = eager_einsum_read_subscripts(&mut read_ctx, &inputs, &subscripts).unwrap();
 
     assert_eq!(read.shape(), owned.shape());
-    assert_eq!(read.as_slice::<f64>(), owned.as_slice::<f64>());
+    assert_eq!(
+        read.as_slice::<f64>().unwrap(),
+        owned.as_slice::<f64>().unwrap()
+    );
 }
 
 #[test]
@@ -182,7 +185,7 @@ fn eager_einsum_rejects_empty_inputs_and_operand_count_mismatch() {
     let empty = eager_einsum(&mut ctx, &[], "->").unwrap_err();
     assert!(matches!(
         empty,
-        tenferro_tensor::Error::InvalidConfig {
+        tenferro_tensor::Error::Validation {
             op: "eager_einsum",
             ..
         }
@@ -191,7 +194,7 @@ fn eager_einsum_rejects_empty_inputs_and_operand_count_mismatch() {
     let mismatch = eager_einsum(&mut ctx, &[&tensor], "i,j->ij").unwrap_err();
     assert!(matches!(
         mismatch,
-        tenferro_tensor::Error::InvalidConfig {
+        tenferro_tensor::Error::Validation {
             op: "eager_einsum",
             ..
         }
@@ -273,8 +276,8 @@ fn eager_einsum_owned_matches_borrowed_for_representative_cases() {
             "shape mismatch for {subscripts}"
         );
         assert_eq!(
-            owned.as_slice::<f64>(),
-            borrowed.as_slice::<f64>(),
+            owned.as_slice::<f64>().unwrap(),
+            borrowed.as_slice::<f64>().unwrap(),
             "values mismatch for {subscripts}"
         );
     }

--- a/crates/tenferro-einsum/src/tests/helper_tests.rs
+++ b/crates/tenferro-einsum/src/tests/helper_tests.rs
@@ -44,7 +44,7 @@ fn char_to_label_accepts_unicode_symbols() {
 fn char_to_label_rejects_reserved_syntax_chars() {
     let err = char_to_label('-').unwrap_err();
     match err {
-        Error::InvalidArgument(msg) => {
+        Error::InvalidSubscripts { message: msg } => {
             assert!(msg.contains("invalid einsum label character"));
             assert!(msg.contains("reserved syntax character"));
         }
@@ -70,11 +70,11 @@ fn split_and_validate_notation_rejects_missing_or_extra_arrow() {
     let extra = split_and_validate_notation("ij->jk->ik").unwrap_err();
 
     match missing {
-        Error::InvalidArgument(msg) => assert!(msg.contains("exactly one '->'")),
+        Error::InvalidSubscripts { message: msg } => assert!(msg.contains("exactly one '->'")),
         other => panic!("unexpected error: {other:?}"),
     }
     match extra {
-        Error::InvalidArgument(msg) => assert!(msg.contains("exactly one '->'")),
+        Error::InvalidSubscripts { message: msg } => assert!(msg.contains("exactly one '->'")),
         other => panic!("unexpected error: {other:?}"),
     }
 }
@@ -85,11 +85,11 @@ fn split_and_validate_notation_rejects_unbalanced_parentheses() {
     let unmatched_close = split_and_validate_notation("ij),jk->ik").unwrap_err();
 
     match unmatched_open {
-        Error::InvalidArgument(msg) => assert!(msg.contains("unmatched '('")),
+        Error::InvalidSubscripts { message: msg } => assert!(msg.contains("unmatched '('")),
         other => panic!("unexpected error: {other:?}"),
     }
     match unmatched_close {
-        Error::InvalidArgument(msg) => assert!(msg.contains("unmatched ')'")),
+        Error::InvalidSubscripts { message: msg } => assert!(msg.contains("unmatched ')'")),
         other => panic!("unexpected error: {other:?}"),
     }
 }

--- a/crates/tenferro-einsum/src/traced.rs
+++ b/crates/tenferro-einsum/src/traced.rs
@@ -26,6 +26,8 @@ use crate::{
 
 /// Traced einsum extension methods for [`GraphCompiler`].
 pub trait GraphCompilerEinsumExt {
+    /// Build a traced einsum from textual subscripts using the default
+    /// optimizer.
     ///
     /// # Errors
     ///
@@ -41,6 +43,9 @@ pub trait GraphCompilerEinsumExt {
     /// graph construction are checked during compilation or execution and
     /// retain the runtime [`ErrorPhase`](tenferro_runtime::ErrorPhase).
     fn einsum(&mut self, inputs: &[&TracedTensor], subscripts: &str) -> Result<TracedTensor>;
+
+    /// Build a traced einsum from parsed integer-label subscripts using the
+    /// default optimizer.
     ///
     /// # Errors
     ///
@@ -59,6 +64,9 @@ pub trait GraphCompilerEinsumExt {
         inputs: &[&TracedTensor],
         subscripts: &EinsumSubscripts,
     ) -> Result<TracedTensor>;
+
+    /// Build a traced einsum from textual subscripts with an explicit
+    /// optimizer strategy.
     ///
     /// # Errors
     ///
@@ -79,6 +87,9 @@ pub trait GraphCompilerEinsumExt {
         subscripts: &str,
         optimize: EinsumOptimize,
     ) -> Result<TracedTensor>;
+
+    /// Build a traced einsum from parsed integer-label subscripts with an
+    /// explicit optimizer strategy.
     ///
     /// # Errors
     ///

--- a/crates/tenferro-einsum/src/traced.rs
+++ b/crates/tenferro-einsum/src/traced.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 
 use computegraph::types::ValueRef;
 use tenferro_ops::dim_expr::DimExpr;
-use tenferro_runtime::error::{Error, Result};
 use tenferro_runtime::extension::{self, ExtensionCacheKey, ExtensionCacheStore};
 use tenferro_runtime::{GraphCompiler, SymDim, TracedTensor};
+use tenferro_tensor::{ShapeMismatch, ValidationError};
 
 use crate::binary_dot::{try_build_exact_output_binary_dot_plan, BinaryDotOperandOrder};
 use crate::builder::build_einsum_graph_dim_expr;
@@ -20,24 +20,78 @@ use crate::optimize::{
     resolve_einsum_strategy_with_spec, resolve_plan_spec, EinsumPlanSpec,
 };
 use crate::{
-    parse_einsum_subscripts, ContractionTree, EinsumOptimize, EinsumSubscripts,
-    Error as EinsumError, Result as EinsumResult, Subscripts, TensorDotAxes,
+    parse_einsum_subscripts, ContractionTree, EinsumOptimize, EinsumSubscripts, Error, Result,
+    Subscripts, TensorDotAxes,
 };
 
 /// Traced einsum extension methods for [`GraphCompiler`].
 pub trait GraphCompilerEinsumExt {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Validation`] with `InvalidArgument`, `RankMismatch`, or
+    /// `ShapeMismatch` for input-count/rank/label inconsistencies,
+    /// [`Error::Planning`] when no contraction plan is available, or
+    /// [`Error::Runtime`] for graph-build/lowering failures.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic label-dimension equalities that are not decidable during
+    /// graph construction are checked during compilation or execution and
+    /// retain the runtime [`ErrorPhase`](tenferro_runtime::ErrorPhase).
     fn einsum(&mut self, inputs: &[&TracedTensor], subscripts: &str) -> Result<TracedTensor>;
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `InvalidArgument`, `RankMismatch`,
+    /// or `ShapeMismatch` for input-count/rank/label inconsistencies,
+    /// [`Error::Planning`] when no contraction plan is available, or
+    /// [`Error::Runtime`] for graph-build/lowering failures.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic label-dimension equalities that are not decidable during
+    /// graph construction are checked during compilation or execution and
+    /// retain the runtime [`ErrorPhase`](tenferro_runtime::ErrorPhase).
     fn einsum_subscripts(
         &mut self,
         inputs: &[&TracedTensor],
         subscripts: &EinsumSubscripts,
     ) -> Result<TracedTensor>;
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSubscripts`] for malformed notation,
+    /// [`Error::Planning`] when the requested strategy cannot be resolved,
+    /// [`Error::Validation`] with `InvalidArgument`, `RankMismatch`, or
+    /// `ShapeMismatch` for input/label inconsistencies, or [`Error::Runtime`]
+    /// for graph-build/lowering failures.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic label-dimension equalities that are not decidable during
+    /// graph construction are checked during compilation or execution and
+    /// retain the runtime [`ErrorPhase`](tenferro_runtime::ErrorPhase).
     fn einsum_with(
         &mut self,
         inputs: &[&TracedTensor],
         subscripts: &str,
         optimize: EinsumOptimize,
     ) -> Result<TracedTensor>;
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Planning`] when the requested strategy cannot be
+    /// resolved, [`Error::Validation`] with `InvalidArgument`, `RankMismatch`,
+    /// or `ShapeMismatch` for input/label inconsistencies, or [`Error::Runtime`]
+    /// for graph-build/lowering failures.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic label-dimension equalities that are not decidable during
+    /// graph construction are checked during compilation or execution and
+    /// retain the runtime [`ErrorPhase`](tenferro_runtime::ErrorPhase).
     fn einsum_subscripts_with(
         &mut self,
         inputs: &[&TracedTensor],
@@ -80,6 +134,18 @@ impl GraphCompilerEinsumExt for GraphCompiler {
 
 /// Traced tensor contraction-sugar methods.
 pub trait TracedTensorEinsumExt {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with rank, axis, duplicate-axis, or
+    /// contracted-dimension payloads for invalid axes, or [`Error::Runtime`]
+    /// for graph-build failures.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic contracted-dimension equalities are checked during compilation
+    /// or execution and retain the runtime
+    /// [`ErrorPhase`](tenferro_runtime::ErrorPhase).
     fn tensordot(&self, rhs: &TracedTensor, axes: TensorDotAxes<'_>) -> Result<TracedTensor>;
 }
 
@@ -95,6 +161,17 @@ impl TracedTensorEinsumExt for TracedTensor {
 /// specification stored in the extension payload. That payload identity
 /// participates in traced extension-op equality and in compile/runtime einsum
 /// plan caches.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidSubscripts`] for malformed notation,
+/// [`Error::Validation`] for input-count or symbolic shape mismatches, or
+/// [`Error::Runtime`] for graph-build/lowering failures.
+///
+/// # Deferred errors
+///
+/// Symbolic shape constraints that cannot be decided during graph construction
+/// are checked during compile or execution and retain their runtime phase.
 pub fn einsum(
     compiler: &mut GraphCompiler,
     inputs: &[&TracedTensor],
@@ -109,6 +186,17 @@ pub fn einsum(
 /// specification stored in the extension payload. That payload identity
 /// participates in traced extension-op equality and in compile/runtime einsum
 /// plan caches.
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`] for input-count or symbolic shape mismatches,
+/// [`Error::Planning`] when no contraction plan can be built, or
+/// [`Error::Runtime`] for graph-build/lowering failures.
+///
+/// # Deferred errors
+///
+/// Symbolic shape constraints that cannot be decided during graph construction
+/// are checked during compile or execution and retain their runtime phase.
 pub fn einsum_subscripts(
     compiler: &mut GraphCompiler,
     inputs: &[&TracedTensor],
@@ -130,6 +218,18 @@ pub fn einsum_subscripts(
 /// extension payload identity and the einsum compile/runtime plan caches.
 /// Different options or paths are therefore not treated as identical extension
 /// ops.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidSubscripts`] for malformed notation,
+/// [`Error::Validation`] for input-count or symbolic shape mismatches,
+/// [`Error::Planning`] when the strategy cannot be resolved, or
+/// [`Error::Runtime`] for graph-build/lowering failures.
+///
+/// # Deferred errors
+///
+/// Symbolic shape constraints that cannot be decided during graph construction
+/// are checked during compile or execution and retain their runtime phase.
 pub fn einsum_with(
     compiler: &mut GraphCompiler,
     inputs: &[&TracedTensor],
@@ -153,6 +253,17 @@ pub fn einsum_with(
 /// extension payload identity and the einsum compile/runtime plan caches.
 /// Different options or paths are therefore not treated as identical extension
 /// ops.
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`] for input-count or symbolic shape mismatches,
+/// [`Error::Planning`] when the strategy cannot be resolved, or
+/// [`Error::Runtime`] for graph-build/lowering failures.
+///
+/// # Deferred errors
+///
+/// Symbolic shape constraints that cannot be decided during graph construction
+/// are checked during compile or execution and retain their runtime phase.
 pub fn einsum_subscripts_with(
     compiler: &mut GraphCompiler,
     inputs: &[&TracedTensor],
@@ -160,16 +271,22 @@ pub fn einsum_subscripts_with(
     optimize: EinsumOptimize,
 ) -> Result<TracedTensor> {
     if inputs.is_empty() {
-        return Err(Error::ContractionError(
-            "einsum requires at least one input tensor".into(),
+        return Err(Error::invalid_argument(
+            "einsum",
+            "inputs",
+            "einsum requires at least one input tensor",
         ));
     }
     if subscripts.inputs.len() != inputs.len() {
-        return Err(Error::ContractionError(format!(
-            "einsum subscripts expect {} inputs, got {}",
-            subscripts.inputs.len(),
-            inputs.len()
-        )));
+        return Err(Error::invalid_argument(
+            "einsum",
+            "inputs",
+            format!(
+                "einsum subscripts expect {} inputs, got {}",
+                subscripts.inputs.len(),
+                inputs.len()
+            ),
+        ));
     }
 
     let output_shape_hint = infer_symbolic_output_shape(subscripts, inputs)?;
@@ -179,7 +296,8 @@ pub fn einsum_subscripts_with(
             output_shape_hint,
             EinsumPlanSpec::LeftToRight,
         );
-        return extension::attach_expanded_shape_contract(&contract_op, inputs, result);
+        return extension::attach_expanded_shape_contract(&contract_op, inputs, result)
+            .map_err(Error::Runtime);
     }
 
     let subs = Subscripts::from(subscripts);
@@ -192,8 +310,7 @@ pub fn einsum_subscripts_with(
                     EinsumOptimize::Tree(tree),
                     &subs,
                     &shape_refs,
-                )
-                .map_err(to_tenferro_error)?;
+                )?;
                 let tree = cached_static_tree(
                     compiler.extension_caches_mut(),
                     subscripts,
@@ -204,8 +321,7 @@ pub fn einsum_subscripts_with(
                 (plan_spec, tree)
             }
             optimize => {
-                let plan_spec =
-                    plan_spec_from_optimize(optimize, &subs).map_err(to_tenferro_error)?;
+                let plan_spec = plan_spec_from_optimize(optimize, &subs)?;
                 let tree = cached_static_tree(
                     compiler.extension_caches_mut(),
                     subscripts,
@@ -218,7 +334,7 @@ pub fn einsum_subscripts_with(
         };
         (plan_spec, Some(tree))
     } else {
-        let plan_spec = plan_spec_from_optimize(optimize, &subs).map_err(to_tenferro_error)?;
+        let plan_spec = plan_spec_from_optimize(optimize, &subs)?;
         let tree = symbolic_fixed_path_tree(&plan_spec, &subs, inputs)?;
         (plan_spec, tree.map(Arc::new))
     };
@@ -230,10 +346,11 @@ pub fn einsum_subscripts_with(
     let op =
         EinsumExtensionOp::with_output_shape_hint(subscripts.clone(), output_shape_hint, plan_spec);
     let outputs = extension::apply(Arc::new(op), inputs)?;
-    outputs
-        .into_iter()
-        .next()
-        .ok_or_else(|| Error::Internal("einsum extension produced no output".into()))
+    outputs.into_iter().next().ok_or_else(|| {
+        Error::Runtime(tenferro_runtime::Error::Internal(
+            "einsum extension produced no output".into(),
+        ))
+    })
 }
 
 fn tensordot(
@@ -243,7 +360,7 @@ fn tensordot(
 ) -> Result<TracedTensor> {
     let config = crate::tensordot::dot_general_config(axes, lhs.rank, rhs.rank)?;
     crate::tensordot::validate_traced_contract_dims(lhs, rhs, &config)?;
-    lhs.dot_general(rhs, config)
+    lhs.dot_general(rhs, config).map_err(Error::Runtime)
 }
 
 fn expand_traced_einsum_graph(
@@ -262,19 +379,28 @@ fn expand_traced_einsum_graph(
     let outputs =
         extension::apply_expanded_graph_with_shape_contract(&op, inputs, |builder, input_refs| {
             let result = build_einsum_graph_dim_expr(builder, tree, input_refs, &input_dim_shapes)
-                .map_err(|err| Error::ContractionError(err.to_string()))?;
+                .map_err(|error| {
+                    tenferro_runtime::Error::extension(
+                        "einsum",
+                        tenferro_runtime::ErrorPhase::GraphBuild,
+                        EINSUM_EXTENSION_FAMILY_ID,
+                        error.kind(),
+                        error,
+                    )
+                })?;
             let ValueRef::Local(local) = result else {
-                return Err(Error::Internal(
+                return Err(tenferro_runtime::Error::Internal(
                     "expanded einsum returned an external value".into(),
                 ));
             };
             Ok(vec![local])
         })?;
 
-    outputs
-        .into_iter()
-        .next()
-        .ok_or_else(|| Error::Internal("expanded einsum produced no output".into()))
+    outputs.into_iter().next().ok_or_else(|| {
+        Error::Runtime(tenferro_runtime::Error::Internal(
+            "expanded einsum produced no output".into(),
+        ))
+    })
 }
 
 fn traced_dim_expr_shapes(inputs: &[&TracedTensor]) -> Vec<Vec<DimExpr>> {
@@ -294,9 +420,7 @@ fn symbolic_fixed_path_tree(
     }
     let dummy_shapes = symbolic_dummy_shapes(inputs);
     let shape_refs: Vec<&[usize]> = dummy_shapes.iter().map(Vec::as_slice).collect();
-    resolve_plan_spec(plan_spec, subs, &shape_refs)
-        .map(Some)
-        .map_err(to_tenferro_error)
+    resolve_plan_spec(plan_spec, subs, &shape_refs).map(Some)
 }
 
 fn symbolic_dummy_shapes(inputs: &[&TracedTensor]) -> Vec<Vec<usize>> {
@@ -350,9 +474,14 @@ fn validate_direct_binary_dot_label_dims(
             };
             if let Some(existing) = label_dims.insert(label, dim) {
                 if existing != dim {
-                    return Err(Error::ContractionError(format!(
-                        "einsum label {label} has inconsistent dimensions {existing} and {dim}"
-                    )));
+                    return Err(Error::validation(
+                        "einsum",
+                        ShapeMismatch::ExpectedActual {
+                            expected: tenferro_tensor::ShapeVec::from_vec(vec![existing]),
+                            actual: tenferro_tensor::ShapeVec::from_vec(vec![dim]),
+                        }
+                        .into(),
+                    ));
                 }
             }
         }
@@ -363,7 +492,7 @@ fn validate_direct_binary_dot_label_dims(
 fn optimize_allows_direct_binary_dot(optimize: &EinsumOptimize) -> Result<bool> {
     match optimize {
         EinsumOptimize::Auto(options) => {
-            options.validate().map_err(to_tenferro_error)?;
+            options.validate()?;
             Ok(true)
         }
         EinsumOptimize::False => Ok(true),
@@ -401,7 +530,7 @@ fn cached_subscripts(
     }
 
     let parsed = Arc::new(ParsedEinsum {
-        subscripts: parse_einsum_subscripts(notation).map_err(to_tenferro_error)?,
+        subscripts: parse_einsum_subscripts(notation)?,
     });
     let entry = ParsedEinsumCacheEntry {
         notation: notation.to_owned(),
@@ -465,7 +594,7 @@ fn cached_static_tree(
     subscripts: &EinsumSubscripts,
     plan_spec: &EinsumPlanSpec,
     shapes: &[Vec<usize>],
-    build: impl FnOnce() -> EinsumResult<ContractionTree>,
+    build: impl FnOnce() -> Result<ContractionTree>,
 ) -> Result<Arc<ContractionTree>> {
     let plan_hash = plan_spec_hash(plan_spec);
     let key = ExtensionCacheKey::new(
@@ -480,7 +609,7 @@ fn cached_static_tree(
         }
     }
 
-    let tree = Arc::new(build().map_err(to_tenferro_error)?);
+    let tree = Arc::new(build()?);
     let key_data = StaticTreeCacheKeyData::new(subscripts, shapes, plan_spec);
     let retained_bytes = saturating_sum([
         key_data.retained_bytes(),
@@ -551,15 +680,17 @@ fn infer_symbolic_output_shape(
         let shape: Vec<_> = match tensor.sym_shape() {
             Some(shape) => shape.to_vec(),
             None => (0..tensor.rank)
-                .map(|axis| tensor.axis_sym_dim(axis))
+                .map(|axis| tensor.axis_sym_dim(axis).map_err(Error::Runtime))
                 .collect::<Result<_>>()?,
         };
         if labels.len() != shape.len() {
-            return Err(Error::ContractionError(format!(
-                "einsum input rank mismatch: labels={}, shape={}",
-                labels.len(),
-                shape.len()
-            )));
+            return Err(Error::validation(
+                "einsum",
+                ValidationError::RankMismatch {
+                    expected: labels.len(),
+                    actual: shape.len(),
+                },
+            ));
         }
         for (&label, dim) in labels.iter().zip(shape) {
             label_dims.entry(label).or_insert(dim);
@@ -570,16 +701,14 @@ fn infer_symbolic_output_shape(
         .iter()
         .map(|label| {
             label_dims.get(label).cloned().ok_or_else(|| {
-                Error::ContractionError(format!(
-                    "einsum output label {label} is missing from inputs"
-                ))
+                Error::invalid_argument(
+                    "einsum",
+                    "output",
+                    format!("einsum output label {label} is missing from inputs"),
+                )
             })
         })
         .collect()
-}
-
-fn to_tenferro_error(error: EinsumError) -> Error {
-    Error::ContractionError(error.to_string())
 }
 
 fn hash_value<T: Hash + ?Sized>(value: &T) -> u64 {

--- a/crates/tenferro-einsum/src/typed_eager.rs
+++ b/crates/tenferro-einsum/src/typed_eager.rs
@@ -11,10 +11,11 @@ pub(crate) fn typed_eager_einsum<T: TensorScalar>(
     subscripts: &str,
 ) -> Result<TypedTensor<T>> {
     let subscripts = Subscripts::parse(subscripts).map_err(|err| {
-        Error::invalid_argument(
+        Error::extension(
             "typed_eager_einsum",
-            "subscripts",
-            format!("invalid subscripts: {err}"),
+            crate::EINSUM_EXTENSION_FAMILY_ID,
+            err.kind(),
+            err,
         )
     })?;
     let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();

--- a/crates/tenferro-einsum/src/typed_eager.rs
+++ b/crates/tenferro-einsum/src/typed_eager.rs
@@ -10,16 +10,16 @@ pub(crate) fn typed_eager_einsum<T: TensorScalar>(
     inputs: &[&TypedTensor<T>],
     subscripts: &str,
 ) -> Result<TypedTensor<T>> {
-    let subscripts = Subscripts::parse(subscripts).map_err(|err| Error::InvalidConfig {
-        op: "typed_eager_einsum",
-        message: format!("invalid subscripts: {err}"),
+    let subscripts = Subscripts::parse(subscripts).map_err(|err| {
+        Error::invalid_argument(
+            "typed_eager_einsum",
+            "subscripts",
+            format!("invalid subscripts: {err}"),
+        )
     })?;
     let reads: Vec<_> = inputs.iter().map(|tensor| T::tensor_read(tensor)).collect();
     let result = eager_einsum_read_subscripts(ctx, &reads, &subscripts)?;
     let actual = result.dtype();
-    T::into_typed(result).map_err(|_| Error::DTypeMismatch {
-        op: "typed_eager_einsum",
-        lhs: T::dtype(),
-        rhs: actual,
-    })
+    T::into_typed(result)
+        .map_err(|_| Error::dtype_mismatch("typed_eager_einsum", T::dtype(), actual))
 }

--- a/crates/tenferro-einsum/src/typed_eager_tests.rs
+++ b/crates/tenferro-einsum/src/typed_eager_tests.rs
@@ -198,7 +198,10 @@ fn eager_einsum_subscripts_and_read_views_use_integer_api() {
         borrowed.as_slice::<f64>().unwrap(),
         &[22.0, 28.0, 49.0, 64.0]
     );
-    assert_eq!(read.as_slice::<f64>(), borrowed.as_slice::<f64>());
+    assert_eq!(
+        read.as_slice::<f64>().unwrap(),
+        borrowed.as_slice::<f64>().unwrap()
+    );
 }
 
 #[test]
@@ -213,7 +216,10 @@ fn eager_einsum_owned_matches_borrowed() {
     let owned = eager_einsum_owned(&mut owned_ctx, vec![a, b], "ij,jk->ik").unwrap();
 
     assert_eq!(owned.shape(), borrowed.shape());
-    assert_eq!(owned.as_slice::<f64>(), borrowed.as_slice::<f64>());
+    assert_eq!(
+        owned.as_slice::<f64>().unwrap(),
+        borrowed.as_slice::<f64>().unwrap()
+    );
     assert!(owned_ctx.buffer_pool_len() >= 2);
 }
 
@@ -265,10 +271,9 @@ fn typed_einsum_reports_dtype_mismatch_from_backend_result() {
 
     assert!(matches!(
         err,
-        tenferro_tensor::Error::DTypeMismatch {
+        tenferro_tensor::Error::Validation {
             op: "typed_eager_einsum",
-            lhs: DType::F32,
-            rhs: DType::F64,
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
         }
     ));
 }

--- a/crates/tenferro-einsum/src/typed_eager_tests.rs
+++ b/crates/tenferro-einsum/src/typed_eager_tests.rs
@@ -279,6 +279,27 @@ fn typed_einsum_reports_dtype_mismatch_from_backend_result() {
 }
 
 #[test]
+fn typed_einsum_preserves_typed_parser_source_for_invalid_notation() {
+    let mut ctx = CpuBackend::new();
+    let input = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
+
+    let error = typed_eager_einsum(&mut ctx, &[&input], "ij,(jk,kl)->il")
+        .expect_err("malformed notation must fail before backend execution");
+
+    assert!(matches!(
+        error,
+        tenferro_tensor::Error::Extension {
+            op: "typed_eager_einsum",
+            kind: tenferro_tensor::ErrorKind::Validation(
+                tenferro_tensor::ValidationKind::InvalidArgument
+            ),
+            ..
+        }
+    ));
+    assert!(std::error::Error::source(&error).is_some());
+}
+
+#[test]
 fn tensor_backend_default_cached_methods_delegate_to_backend_ops() {
     let lhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1], vec![1.0]).unwrap());
     let rhs = Tensor::F64(TypedTensor::from_vec_col_major(vec![1, 1], vec![3.0]).unwrap());

--- a/crates/tenferro-einsum/src/util.rs
+++ b/crates/tenferro-einsum/src/util.rs
@@ -10,7 +10,7 @@ pub(crate) fn build_size_dict(
     extra: Option<&HashMap<u32, usize>>,
 ) -> Result<HashMap<u32, usize>> {
     if subscripts.inputs.len() != shapes.len() {
-        return Err(Error::InvalidArgument(format!(
+        return Err(Error::planning(format!(
             "expected {} input shapes, got {}",
             subscripts.inputs.len(),
             shapes.len()
@@ -19,7 +19,7 @@ pub(crate) fn build_size_dict(
     let mut size_dict: HashMap<u32, usize> = HashMap::new();
     for (i, input_subs) in subscripts.inputs.iter().enumerate() {
         if input_subs.len() != shapes[i].len() {
-            return Err(Error::InvalidArgument(format!(
+            return Err(Error::planning(format!(
                 "input {} has {} subscript labels but shape has {} dimensions",
                 i,
                 input_subs.len(),
@@ -30,10 +30,7 @@ pub(crate) fn build_size_dict(
             let size = shapes[i][j];
             if let Some(&existing) = size_dict.get(&label) {
                 if existing != size {
-                    return Err(Error::ShapeMismatch {
-                        expected: vec![existing],
-                        got: vec![size],
-                    });
+                    return Err(Error::shape_mismatch("einsum", [existing], [size]));
                 }
             } else {
                 size_dict.insert(label, size);
@@ -59,7 +56,7 @@ pub(crate) fn compute_output_shape(
             size_dict
                 .get(&label)
                 .copied()
-                .ok_or_else(|| Error::InvalidArgument(format!("unknown size for label {label}")))
+                .ok_or_else(|| Error::planning(format!("unknown size for label {label}")))
         })
         .collect()
 }

--- a/crates/tenferro-einsum/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-einsum/tests/integration/eager_tensor.rs
@@ -6,7 +6,8 @@ use tenferro_ad::{EagerRuntime, EagerTensor};
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::{EagerEinsumExt, EagerTensorEinsumExt};
 use tenferro_einsum::{EinsumSubscripts, TensorDotAxes};
-use tenferro_runtime::Tensor;
+use tenferro_runtime::{Error as RuntimeError, ErrorPhase, Tensor};
+use tenferro_tensor::ValidationError;
 
 fn f64_data(tensor: &Tensor) -> &[f64] {
     tensor.as_slice::<f64>().unwrap()
@@ -183,7 +184,14 @@ fn eager_tensor_tensordot_rejects_explicit_out_of_bounds_axis() {
         Err(err) => err,
     };
 
-    assert!(err.to_string().contains("lhs axis 2 out of bounds"));
+    assert!(matches!(
+        err,
+        tenferro_einsum::Error::Runtime(RuntimeError::Validation {
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::AxisOutOfBounds { axis: 2, rank: 2 },
+            ..
+        })
+    ));
 }
 
 #[test]

--- a/crates/tenferro-einsum/tests/integration/error_public.rs
+++ b/crates/tenferro-einsum/tests/integration/error_public.rs
@@ -1,31 +1,44 @@
+use std::error::Error as _;
+
 use tenferro_einsum::{Error, Result};
-use tenferro_tensor::Error as TensorError;
+use tenferro_tensor::{Error as TensorError, ErrorKind, ShapeMismatch, ShapeVec, ValidationKind};
 
 #[test]
-fn local_error_preserves_existing_invalid_argument_text() {
-    let result: Result<()> = Err(Error::InvalidArgument("bad labels".into()));
+fn invalid_subscripts_are_a_typed_local_validation_error() {
+    let result: Result<()> = Err(Error::invalid_subscripts("bad labels"));
 
     let Err(err) = result else {
-        panic!("expected invalid argument error");
+        panic!("expected invalid subscripts error");
     };
 
-    assert_eq!(err.to_string(), "invalid argument: bad labels");
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
+    );
+    assert!(err.to_string().contains("bad labels"));
 }
 
 #[test]
-fn local_error_maps_to_tensor_backend_failure() {
-    let err = Error::ShapeMismatch {
-        expected: vec![2, 3],
-        got: vec![2, 4],
-    };
+fn shared_einsum_validation_promotes_directly_to_tensor_validation() {
+    let err = Error::validation(
+        "einsum",
+        ShapeMismatch::ExpectedActual {
+            expected: ShapeVec::from_vec(vec![2, 3]),
+            actual: ShapeVec::from_vec(vec![2, 4]),
+        }
+        .into(),
+    );
 
-    let tensor_err = err.to_tensor_error("einsum_extension");
+    let tensor_err = err.into_tensor_error("einsum_extension");
+    assert!(matches!(tensor_err, TensorError::Validation { .. }));
+}
 
-    assert!(matches!(
-        tensor_err,
-        TensorError::BackendFailure {
-            op: "einsum_extension",
-            ref message,
-        } if message == "shape mismatch: expected [2, 3], got [2, 4]"
-    ));
+#[test]
+fn einsum_planning_error_remains_a_typed_extension_source() {
+    let err = Error::planning("no valid contraction path");
+    let tensor_err = err.into_tensor_error("einsum_extension");
+
+    assert_eq!(tensor_err.kind(), ErrorKind::RuntimeState);
+    assert!(matches!(tensor_err, TensorError::Extension { .. }));
+    assert!(tensor_err.source().is_some());
 }

--- a/crates/tenferro-einsum/tests/integration/error_public.rs
+++ b/crates/tenferro-einsum/tests/integration/error_public.rs
@@ -1,6 +1,6 @@
 use std::error::Error as _;
 
-use tenferro_einsum::{Error, Result};
+use tenferro_einsum::{Error, PlanningError, Result};
 use tenferro_tensor::{Error as TensorError, ErrorKind, ShapeMismatch, ShapeVec, ValidationKind};
 
 #[test]
@@ -38,7 +38,23 @@ fn einsum_planning_error_remains_a_typed_extension_source() {
     let err = Error::planning("no valid contraction path");
     let tensor_err = err.into_tensor_error("einsum_extension");
 
-    assert_eq!(tensor_err.kind(), ErrorKind::RuntimeState);
+    assert_eq!(
+        tensor_err.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
+    );
     assert!(matches!(tensor_err, TensorError::Extension { .. }));
     assert!(tensor_err.source().is_some());
+}
+
+#[test]
+fn einsum_planning_runtime_state_is_classified_separately() {
+    let err = Error::planning_runtime_state("planner state is unavailable");
+
+    assert_eq!(err.kind(), ErrorKind::RuntimeState);
+    assert!(matches!(
+        err,
+        Error::Planning {
+            source: PlanningError::RuntimeState { .. }
+        }
+    ));
 }

--- a/crates/tenferro-einsum/tests/integration/traced_correctness.rs
+++ b/crates/tenferro-einsum/tests/integration/traced_correctness.rs
@@ -7,13 +7,14 @@ use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
 use tenferro_einsum::EinsumOptimize;
 use tenferro_einsum::GraphCompilerEinsumExt;
+use tenferro_einsum::Result as EinsumResult;
 use tenferro_einsum::TracedTensorEinsumExt;
 use tenferro_einsum::{
     ContractionTree, NestedEinsum, Subscripts, TensorDotAxes, EINSUM_EXTENSION_FAMILY_ID,
 };
-use tenferro_runtime::error::Result;
+use tenferro_runtime::error::{Error as RuntimeError, Result as RuntimeResult};
 use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
-use tenferro_tensor::TypedTensor;
+use tenferro_tensor::{TypedTensor, ValidationError};
 
 #[path = "traced_correctness/ported_and_paths.rs"]
 mod ported_and_paths;
@@ -34,17 +35,26 @@ fn get_f64_data(t: &Tensor) -> &[f64] {
 }
 
 trait TestEinsumContext {
-    fn with_compiler<R>(&mut self, f: impl FnOnce(&mut GraphCompiler) -> Result<R>) -> Result<R>;
+    fn with_compiler<R>(
+        &mut self,
+        f: impl FnOnce(&mut GraphCompiler) -> EinsumResult<R>,
+    ) -> EinsumResult<R>;
 }
 
 impl TestEinsumContext for GraphCompiler {
-    fn with_compiler<R>(&mut self, f: impl FnOnce(&mut GraphCompiler) -> Result<R>) -> Result<R> {
+    fn with_compiler<R>(
+        &mut self,
+        f: impl FnOnce(&mut GraphCompiler) -> EinsumResult<R>,
+    ) -> EinsumResult<R> {
         f(self)
     }
 }
 
 impl TestEinsumContext for GraphExecutor<CpuBackend> {
-    fn with_compiler<R>(&mut self, f: impl FnOnce(&mut GraphCompiler) -> Result<R>) -> Result<R> {
+    fn with_compiler<R>(
+        &mut self,
+        f: impl FnOnce(&mut GraphCompiler) -> EinsumResult<R>,
+    ) -> EinsumResult<R> {
         let mut compiler = GraphCompiler::new();
         f(&mut compiler)
     }
@@ -54,7 +64,7 @@ fn einsum<C: TestEinsumContext>(
     ctx: &mut C,
     inputs: &[&TracedTensor],
     subscripts: &str,
-) -> Result<TracedTensor> {
+) -> EinsumResult<TracedTensor> {
     ctx.with_compiler(|compiler| compiler.einsum(inputs, subscripts))
 }
 
@@ -63,16 +73,16 @@ fn einsum_with<C: TestEinsumContext>(
     inputs: &[&TracedTensor],
     subscripts: &str,
     optimize: EinsumOptimize,
-) -> Result<TracedTensor> {
+) -> EinsumResult<TracedTensor> {
     ctx.with_compiler(|compiler| compiler.einsum_with(inputs, subscripts, optimize))
 }
 
 trait RunTraced {
-    fn run_with(&self, executor: &mut GraphExecutor<CpuBackend>) -> Result<Tensor>;
+    fn run_with(&self, executor: &mut GraphExecutor<CpuBackend>) -> RuntimeResult<Tensor>;
 }
 
 impl RunTraced for TracedTensor {
-    fn run_with(&self, executor: &mut GraphExecutor<CpuBackend>) -> Result<Tensor> {
+    fn run_with(&self, executor: &mut GraphExecutor<CpuBackend>) -> RuntimeResult<Tensor> {
         if !executor
             .extension_executor()
             .registry()
@@ -213,13 +223,25 @@ fn traced_tensor_einsum_ext_tensordot_rejects_invalid_axes() {
         Ok(_) => panic!("expected duplicate tensordot axis error"),
         Err(err) => err,
     };
-    assert!(duplicate.to_string().contains("duplicate lhs axis"));
+    assert!(matches!(
+        duplicate,
+        tenferro_einsum::Error::Runtime(RuntimeError::Validation {
+            source: ValidationError::DuplicateAxis {
+                axis: 0,
+                role: "lhs"
+            },
+            ..
+        })
+    ));
 
     let out_of_bounds = match lhs.tensordot(&rhs, TensorDotAxes::Count(3)) {
         Ok(_) => panic!("expected Count(3) tensordot axis error"),
         Err(err) => err,
     };
-    assert!(out_of_bounds.to_string().contains("Count(3)"));
+    assert!(matches!(
+        out_of_bounds,
+        tenferro_einsum::Error::Runtime(RuntimeError::Validation { .. })
+    ));
 
     let explicit_out_of_bounds = match lhs.tensordot(
         &rhs,
@@ -231,9 +253,13 @@ fn traced_tensor_einsum_ext_tensordot_rejects_invalid_axes() {
         Ok(_) => panic!("expected explicit tensordot axis bounds error"),
         Err(err) => err,
     };
-    assert!(explicit_out_of_bounds
-        .to_string()
-        .contains("lhs axis 2 out of bounds"));
+    assert!(matches!(
+        explicit_out_of_bounds,
+        tenferro_einsum::Error::Runtime(RuntimeError::Validation {
+            source: ValidationError::AxisOutOfBounds { axis: 2, rank: 2 },
+            ..
+        })
+    ));
 }
 
 #[test]

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -38,6 +38,7 @@ computegraph.workspace = true
 num-complex.workspace = true
 num-traits.workspace = true
 rustfft = "6"
+thiserror.workspace = true
 
 [dev-dependencies]
 tenferro-cpu = { path = "../tenferro-cpu", version = "0.2.0", default-features = false }

--- a/crates/tenferro-fft/src/concrete_tests.rs
+++ b/crates/tenferro-fft/src/concrete_tests.rs
@@ -1,6 +1,6 @@
 use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
-use tenferro_tensor::{Tensor, TensorRead, TensorView, TypedTensorView};
+use tenferro_tensor::{ErrorKind, Tensor, TensorRead, TensorView, TypedTensorView};
 
 use crate::{cached_fft_plan_from_cache, FftNorm, FftPlanCache, TensorFftExt, TensorReadFftExt};
 
@@ -131,8 +131,9 @@ fn public_tensor_fft_ext_reports_invalid_dtype_and_shape_errors() {
 
     assert!(matches!(
         dtype_err,
-        tenferro_tensor::Error::UnsupportedDTypeConversion {
+        tenferro_tensor::Error::Extension {
             op: "TensorFftExt::fft",
+            kind: ErrorKind::Unsupported,
             ..
         }
     ));
@@ -157,7 +158,7 @@ fn poisoned_fft_plan_cache_returns_typed_error() {
     };
     assert!(matches!(
         err,
-        tenferro_tensor::Error::BackendFailure {
+        tenferro_tensor::Error::RuntimeState {
             op: "fft_plan_cache",
             ..
         }

--- a/crates/tenferro-fft/src/concrete_tests.rs
+++ b/crates/tenferro-fft/src/concrete_tests.rs
@@ -131,14 +131,14 @@ fn public_tensor_fft_ext_reports_invalid_dtype_and_shape_errors() {
 
     assert!(matches!(
         dtype_err,
-        tenferro_tensor::Error::InvalidConfig {
+        tenferro_tensor::Error::UnsupportedDTypeConversion {
             op: "TensorFftExt::fft",
             ..
         }
     ));
     assert!(matches!(
         shape_err,
-        tenferro_tensor::Error::InvalidConfig { op: "irfft", .. }
+        tenferro_tensor::Error::Validation { op: "irfft", .. }
     ));
 }
 

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -520,19 +520,21 @@ impl ExtensionOp for FftOp {
         let input_dtype = ctx.input_dtype(0)?;
         let input_shape = ctx.input_shape(0)?;
         if self.axis >= input_shape.len() {
-            return Err(tenferro_tensor::Error::AxisOutOfBounds {
-                op: "tenferro-fft",
-                axis: self.axis,
-                rank: input_shape.len(),
-            });
+            return Err(tenferro_tensor::Error::axis_out_of_bounds(
+                "tenferro-fft",
+                self.axis,
+                input_shape.len(),
+            ));
         }
 
         let mut out_shape = input_shape.to_vec();
         let output_dtype = match self.kind {
             FftKind::C2C { .. } => {
                 if !matches!(input_dtype, DType::C32 | DType::C64) {
-                    return Err(tenferro_tensor::Error::backend_failure(
+                    return Err(tenferro_tensor::Error::unsupported_dtype_conversion(
                         "tenferro-fft",
+                        input_dtype,
+                        input_dtype,
                         format!("unsupported dtype {input_dtype:?} for complex FFT"),
                     ));
                 }
@@ -545,8 +547,10 @@ impl ExtensionOp for FftOp {
                     DType::F32 => DType::C32,
                     DType::F64 => DType::C64,
                     _ => {
-                        return Err(tenferro_tensor::Error::backend_failure(
+                        return Err(tenferro_tensor::Error::unsupported_dtype_conversion(
                             "tenferro-fft",
+                            input_dtype,
+                            input_dtype,
                             format!("unsupported dtype {input_dtype:?} for real FFT"),
                         ));
                     }
@@ -558,8 +562,10 @@ impl ExtensionOp for FftOp {
                     DType::C32 => DType::F32,
                     DType::C64 => DType::F64,
                     _ => {
-                        return Err(tenferro_tensor::Error::backend_failure(
+                        return Err(tenferro_tensor::Error::unsupported_dtype_conversion(
                             "tenferro-fft",
+                            input_dtype,
+                            input_dtype,
                             format!("unsupported dtype {input_dtype:?} for inverse real FFT"),
                         ));
                     }
@@ -587,10 +593,11 @@ impl HostReference for FftOp {
 
 fn execute_host_fft_op(op: &FftOp, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
     if inputs.len() != 1 {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "tenferro-fft",
-            message: format!("expected 1 input, got {}", inputs.len()),
-        });
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "tenferro-fft",
+            "inputs",
+            format!("expected 1 input, got {}", inputs.len()),
+        ));
     }
     validate_host_fft_input(fft_op_name(op.kind), inputs[0])?;
 
@@ -628,15 +635,15 @@ fn execute_host_fft_op(op: &FftOp, inputs: &[&Tensor]) -> tenferro_tensor::Resul
             execute_c2r(input, op.axis, op.n, op.norm)?,
         )?),
         (kind, other) => {
-            return Err(tenferro_tensor::Error::DTypeMismatch {
-                op: match kind {
+            return Err(tenferro_tensor::Error::dtype_mismatch(
+                match kind {
                     FftKind::C2C { .. } => "fft",
                     FftKind::R2C { .. } => "rfft",
                     FftKind::C2R => "irfft",
                 },
-                lhs: expected_dtype_for(kind),
-                rhs: other.dtype(),
-            });
+                expected_dtype_for(kind),
+                other.dtype(),
+            ));
         }
     };
     Ok(vec![output])
@@ -669,10 +676,11 @@ fn execute_concrete_fft_read_op<B: TensorBackend>(
 
 fn single_fft_output(mut outputs: Vec<Tensor>) -> tenferro_tensor::Result<Tensor> {
     if outputs.len() != 1 {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "tenferro-fft",
-            message: format!("expected 1 FFT output, got {}", outputs.len()),
-        });
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "tenferro-fft",
+            "outputs",
+            format!("expected 1 FFT output, got {}", outputs.len()),
+        ));
     }
     Ok(outputs.remove(0))
 }
@@ -791,10 +799,7 @@ fn tensor_fft_config_error(
     op: &'static str,
     message: impl std::fmt::Display,
 ) -> tenferro_tensor::Error {
-    tenferro_tensor::Error::InvalidConfig {
-        op,
-        message: message.to_string(),
-    }
+    tenferro_tensor::Error::invalid_argument(op, "configuration", message.to_string())
 }
 
 fn tensor_placement(input: &Tensor) -> &Placement {
@@ -1381,10 +1386,11 @@ fn validate_resolved_transform_len(
 }
 
 fn fft_config_error(op: &'static str, message: impl std::fmt::Display) -> Error {
-    Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
+    Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
         op,
-        message: message.to_string(),
-    })
+        "configuration",
+        message.to_string(),
+    ))
 }
 
 fn transform_len_dim(n: Option<usize>, input_dim: &SymDim) -> SymDim {
@@ -1458,10 +1464,11 @@ fn output_shape_c2r(
         None => default_c2r_output_len(input_len)?,
     };
     if len == 0 {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "irfft",
-            message: "output length must be positive".to_string(),
-        });
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "irfft",
+            "output length",
+            "must be positive",
+        ));
     }
     validate_c2r_spectrum_len(input_len, len)?;
     let mut out_shape = shape.to_vec();
@@ -1473,10 +1480,11 @@ fn output_dim_c2r(input_dim: &SymDim, n: Option<usize>) -> tenferro_tensor::Resu
     match (input_dim.constant_value(), n) {
         (Some(input_len), Some(output_len)) => {
             if output_len == 0 {
-                return Err(tenferro_tensor::Error::InvalidConfig {
-                    op: "irfft",
-                    message: "output length must be positive".to_string(),
-                });
+                return Err(tenferro_tensor::Error::invalid_argument(
+                    "irfft",
+                    "output length",
+                    "must be positive",
+                ));
             }
             validate_c2r_spectrum_len(input_len, output_len)?;
             Ok(SymDim::from(output_len))
@@ -1484,10 +1492,11 @@ fn output_dim_c2r(input_dim: &SymDim, n: Option<usize>) -> tenferro_tensor::Resu
         (Some(input_len), None) => Ok(SymDim::from(default_c2r_output_len(input_len)?)),
         (None, Some(output_len)) => {
             if output_len == 0 {
-                return Err(tenferro_tensor::Error::InvalidConfig {
-                    op: "irfft",
-                    message: "output length must be positive".to_string(),
-                });
+                return Err(tenferro_tensor::Error::invalid_argument(
+                    "irfft",
+                    "output length",
+                    "must be positive",
+                ));
             }
             Ok(SymDim::from(output_len))
         }
@@ -1497,17 +1506,21 @@ fn output_dim_c2r(input_dim: &SymDim, n: Option<usize>) -> tenferro_tensor::Resu
 
 fn default_c2r_output_len(input_len: usize) -> tenferro_tensor::Result<usize> {
     if input_len == 0 {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "irfft",
-            message: "input spectrum axis length must be positive".to_string(),
-        });
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "irfft",
+            "input spectrum axis length",
+            "must be positive",
+        ));
     }
     input_len
         .checked_sub(1)
         .and_then(|len| len.checked_mul(2))
-        .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-            op: "irfft",
-            message: "default output length overflows usize".to_string(),
+        .ok_or_else(|| {
+            tenferro_tensor::Error::invalid_argument(
+                "irfft",
+                "default output length",
+                "overflows usize",
+            )
         })
 }
 
@@ -1517,12 +1530,13 @@ fn validate_c2r_spectrum_len(
 ) -> tenferro_tensor::Result<usize> {
     let expected = output_len / 2 + 1;
     if input_len != expected {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "irfft",
-            message: format!(
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "irfft",
+            "spectrum",
+            format!(
                 "one-sided spectrum axis length mismatch: expected {expected} for output length {output_len}, got {input_len}"
             ),
-        });
+        ));
     }
     Ok(expected)
 }
@@ -1531,21 +1545,22 @@ fn transform_len(shape: &[usize], axis: usize, n: Option<usize>) -> tenferro_ten
     validate_axis("fft", shape, axis)?;
     let len = n.unwrap_or(shape[axis]);
     if len == 0 {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "fft",
-            message: "transform length must be positive".to_string(),
-        });
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "fft",
+            "transform length",
+            "must be positive",
+        ));
     }
     Ok(len)
 }
 
 fn validate_axis(op: &'static str, shape: &[usize], axis: usize) -> tenferro_tensor::Result<()> {
     if axis >= shape.len() {
-        return Err(tenferro_tensor::Error::AxisOutOfBounds {
+        return Err(tenferro_tensor::Error::axis_out_of_bounds(
             op,
             axis,
-            rank: shape.len(),
-        });
+            shape.len(),
+        ));
     }
     Ok(())
 }
@@ -1558,9 +1573,12 @@ fn checked_shape_product(
     shape
         .iter()
         .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
-        .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-            op,
-            message: format!("{role} shape product overflows usize"),
+        .ok_or_else(|| {
+            tenferro_tensor::Error::invalid_argument(
+                op,
+                "shape product",
+                format!("{role} shape product overflows usize"),
+            )
         })
 }
 
@@ -1570,11 +1588,13 @@ fn checked_mul(
     lhs: usize,
     rhs: usize,
 ) -> tenferro_tensor::Result<usize> {
-    lhs.checked_mul(rhs)
-        .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
+    lhs.checked_mul(rhs).ok_or_else(|| {
+        tenferro_tensor::Error::invalid_argument(
             op,
-            message: format!("{role} overflows usize"),
-        })
+            "arithmetic",
+            format!("{role} overflows usize"),
+        )
+    })
 }
 
 fn checked_add(
@@ -1583,11 +1603,13 @@ fn checked_add(
     lhs: usize,
     rhs: usize,
 ) -> tenferro_tensor::Result<usize> {
-    lhs.checked_add(rhs)
-        .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
+    lhs.checked_add(rhs).ok_or_else(|| {
+        tenferro_tensor::Error::invalid_argument(
             op,
-            message: format!("{role} overflows usize"),
-        })
+            "arithmetic",
+            format!("{role} overflows usize"),
+        )
+    })
 }
 
 fn uninit_output_vec<T>(len: usize) -> Vec<MaybeUninit<T>> {
@@ -1842,9 +1864,12 @@ fn scale_for<T>(norm: FftNorm, forward: bool, n: usize) -> tenferro_tensor::Resu
 where
     T: Float + FromPrimitive,
 {
-    let len = T::from_usize(n).ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-        op: "tenferro_fft::scale_for",
-        message: format!("FFT length {n} cannot be represented as scalar"),
+    let len = T::from_usize(n).ok_or_else(|| {
+        tenferro_tensor::Error::invalid_argument(
+            "tenferro_fft::scale_for",
+            "FFT length",
+            format!("{n} cannot be represented as scalar"),
+        )
     })?;
     Ok(match (norm, forward) {
         (FftNorm::Backward, true) | (FftNorm::Forward, false) => T::one(),

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -73,9 +73,10 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
 use tenferro_ops::SymDim;
 use tenferro_runtime::extension::{apply, ExtensionExecutionContext, ExtensionOp, HostReference};
-use tenferro_runtime::{Error, Result, TracedTensor};
+use tenferro_runtime::{Error, ErrorPhase, Result, TracedTensor};
 use tenferro_tensor::{
-    DType, DeviceKind, MemoryKind, Placement, Tensor, TensorBackend, TensorRead, TypedTensor,
+    DType, DeviceKind, ErrorKind, MemoryKind, Placement, Tensor, TensorBackend, TensorRead,
+    TypedTensor, ValidationError,
 };
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
@@ -94,9 +95,61 @@ pub const FFT_EXTENSION_FAMILY_ID: &str = "tenferro-fft.fft.v1";
 
 /// FFT extension methods for [`TracedTensor`].
 pub trait TracedTensorFftExt {
+    /// Build a traced complex or full-spectrum real FFT.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` with `AxisOutOfBounds` or
+    /// `InvalidArgument` for invalid `axis`/`n`, or `Error::Extension` with
+    /// `ErrorKind::Unsupported` for integer, boolean, or otherwise unsupported
+    /// dtypes.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic axis extents and extension execution failures are checked at
+    /// compile or execution time after concrete inputs are bound.
     fn fft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<TracedTensor>;
+
+    /// Build a traced inverse complex FFT.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` with `AxisOutOfBounds` or
+    /// `InvalidArgument` for invalid `axis`/`n`, or `Error::Extension` with
+    /// `ErrorKind::Unsupported` when the input is not `C32`/`C64`.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape and extension execution failures may be deferred to
+    /// compile or execution.
     fn ifft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<TracedTensor>;
+
+    /// Build a traced one-sided real FFT.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` with `AxisOutOfBounds` or
+    /// `InvalidArgument` for invalid `axis`/`n`, or `Error::Extension` with
+    /// `ErrorKind::Unsupported` when the input is not `F32`/`F64`.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape and extension execution failures may be deferred to
+    /// compile or execution.
     fn rfft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<TracedTensor>;
+
+    /// Build a traced inverse one-sided real FFT.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` with `AxisOutOfBounds` or
+    /// `InvalidArgument` for invalid `axis`/`n` or spectrum length, or
+    /// `Error::Extension` with `ErrorKind::Unsupported` for non-complex input.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic spectrum lengths and extension execution failures may be
+    /// deferred to compile or execution.
     fn irfft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<TracedTensor>;
 }
 
@@ -143,6 +196,12 @@ impl TracedTensorFftExt for TracedTensor {
 /// ```
 pub trait TensorFftExt {
     /// Execute a one-dimensional FFT along `axis`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
+    /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for an
+    /// integer or boolean input, or a typed backend source for execution.
     fn fft<B: TensorBackend>(
         &self,
         n: Option<usize>,
@@ -152,6 +211,12 @@ pub trait TensorFftExt {
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Execute a one-dimensional inverse FFT along `axis`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
+    /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for a
+    /// non-complex input, or a typed backend source for execution.
     fn ifft<B: TensorBackend>(
         &self,
         n: Option<usize>,
@@ -161,6 +226,12 @@ pub trait TensorFftExt {
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Execute a one-dimensional real FFT along `axis`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
+    /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for a
+    /// non-`F32`/`F64` input, or a typed backend source for execution.
     fn rfft<B: TensorBackend>(
         &self,
         n: Option<usize>,
@@ -170,6 +241,13 @@ pub trait TensorFftExt {
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Execute a one-dimensional inverse real FFT along `axis`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` with `AxisOutOfBounds`, `InvalidArgument`,
+    /// or spectrum-length details, `Error::Extension` with
+    /// `ErrorKind::Unsupported` for a non-complex input, or a typed backend
+    /// source for execution.
     fn irfft<B: TensorBackend>(
         &self,
         n: Option<usize>,
@@ -277,6 +355,13 @@ impl TensorFftExt for Tensor {
 /// ```
 pub trait TensorReadFftExt {
     /// Execute a one-dimensional FFT along `axis`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
+    /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for an
+    /// integer or boolean input, or a typed backend source for materialization
+    /// or execution.
     fn fft_read<B: TensorBackend>(
         &self,
         n: Option<usize>,
@@ -286,6 +371,12 @@ pub trait TensorReadFftExt {
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Execute a one-dimensional inverse FFT along `axis`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
+    /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for a
+    /// non-complex input, or a typed backend source for materialization.
     fn ifft_read<B: TensorBackend>(
         &self,
         n: Option<usize>,
@@ -295,6 +386,12 @@ pub trait TensorReadFftExt {
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Execute a one-dimensional real FFT along `axis`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
+    /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for a
+    /// non-`F32`/`F64` input, or a typed backend source for materialization.
     fn rfft_read<B: TensorBackend>(
         &self,
         n: Option<usize>,
@@ -304,6 +401,13 @@ pub trait TensorReadFftExt {
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Execute a one-dimensional inverse real FFT along `axis`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` with `AxisOutOfBounds`, `InvalidArgument`,
+    /// or spectrum-length details, `Error::Extension` with
+    /// `ErrorKind::Unsupported` for a non-complex input, or a typed backend
+    /// source for materialization.
     fn irfft_read<B: TensorBackend>(
         &self,
         n: Option<usize>,
@@ -428,6 +532,16 @@ enum FftKind {
     C2R,
 }
 
+#[derive(Debug, thiserror::Error)]
+enum FftError {
+    #[error("{op} does not support dtype {dtype:?}; expected {expected}")]
+    UnsupportedDType {
+        op: &'static str,
+        dtype: DType,
+        expected: &'static str,
+    },
+}
+
 #[derive(Clone, Debug, PartialEq)]
 struct FftOp {
     kind: FftKind,
@@ -531,11 +645,10 @@ impl ExtensionOp for FftOp {
         let output_dtype = match self.kind {
             FftKind::C2C { .. } => {
                 if !matches!(input_dtype, DType::C32 | DType::C64) {
-                    return Err(tenferro_tensor::Error::unsupported_dtype_conversion(
+                    return Err(tensor_unsupported_dtype(
                         "tenferro-fft",
                         input_dtype,
-                        input_dtype,
-                        format!("unsupported dtype {input_dtype:?} for complex FFT"),
+                        "C32 or C64",
                     ));
                 }
                 input_dtype
@@ -547,11 +660,10 @@ impl ExtensionOp for FftOp {
                     DType::F32 => DType::C32,
                     DType::F64 => DType::C64,
                     _ => {
-                        return Err(tenferro_tensor::Error::unsupported_dtype_conversion(
+                        return Err(tensor_unsupported_dtype(
                             "tenferro-fft",
                             input_dtype,
-                            input_dtype,
-                            format!("unsupported dtype {input_dtype:?} for real FFT"),
+                            "F32 or F64",
                         ));
                     }
                 }
@@ -562,11 +674,10 @@ impl ExtensionOp for FftOp {
                     DType::C32 => DType::F32,
                     DType::C64 => DType::F64,
                     _ => {
-                        return Err(tenferro_tensor::Error::unsupported_dtype_conversion(
+                        return Err(tensor_unsupported_dtype(
                             "tenferro-fft",
                             input_dtype,
-                            input_dtype,
-                            format!("unsupported dtype {input_dtype:?} for inverse real FFT"),
+                            "C32 or C64",
                         ));
                     }
                 }
@@ -635,14 +746,10 @@ fn execute_host_fft_op(op: &FftOp, inputs: &[&Tensor]) -> tenferro_tensor::Resul
             execute_c2r(input, op.axis, op.n, op.norm)?,
         )?),
         (kind, other) => {
-            return Err(tenferro_tensor::Error::dtype_mismatch(
-                match kind {
-                    FftKind::C2C { .. } => "fft",
-                    FftKind::R2C { .. } => "rfft",
-                    FftKind::C2R => "irfft",
-                },
-                expected_dtype_for(kind),
+            return Err(tensor_unsupported_dtype(
+                fft_op_name(kind),
                 other.dtype(),
+                expected_dtype_description(kind),
             ));
         }
     };
@@ -706,45 +813,45 @@ fn concrete_fft_kind(op: &'static str, dtype: DType) -> tenferro_tensor::Result<
     match dtype {
         DType::C32 | DType::C64 => Ok(FftKind::C2C { forward: true }),
         DType::F32 | DType::F64 => Ok(FftKind::R2C { onesided: false }),
-        DType::I32 | DType::I64 | DType::Bool => Err(tensor_fft_config_error(
-            op,
-            format!("fft expects real or complex floating input, got {dtype:?}"),
-        )),
+        DType::I32 | DType::I64 | DType::Bool => {
+            Err(tensor_unsupported_dtype(op, dtype, "F32, F64, C32, or C64"))
+        }
     }
 }
 
 fn concrete_ifft_kind(op: &'static str, dtype: DType) -> tenferro_tensor::Result<FftKind> {
     match dtype {
         DType::C32 | DType::C64 => Ok(FftKind::C2C { forward: false }),
-        DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => Err(
-            tensor_fft_config_error(op, format!("ifft expects C32 or C64 input; got {dtype:?}")),
-        ),
+        DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => {
+            Err(tensor_unsupported_dtype(op, dtype, "C32 or C64"))
+        }
     }
 }
 
 fn concrete_rfft_kind(op: &'static str, dtype: DType) -> tenferro_tensor::Result<FftKind> {
     match dtype {
         DType::F32 | DType::F64 => Ok(FftKind::R2C { onesided: true }),
-        DType::C32 | DType::C64 | DType::I32 | DType::I64 | DType::Bool => Err(
-            tensor_fft_config_error(op, format!("rfft expects F32 or F64 input; got {dtype:?}")),
-        ),
+        DType::C32 | DType::C64 | DType::I32 | DType::I64 | DType::Bool => {
+            Err(tensor_unsupported_dtype(op, dtype, "F32 or F64"))
+        }
     }
 }
 
 fn concrete_irfft_kind(op: &'static str, dtype: DType) -> tenferro_tensor::Result<FftKind> {
     match dtype {
         DType::C32 | DType::C64 => Ok(FftKind::C2R),
-        DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => Err(
-            tensor_fft_config_error(op, format!("irfft expects C32 or C64 input; got {dtype:?}")),
-        ),
+        DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => {
+            Err(tensor_unsupported_dtype(op, dtype, "C32 or C64"))
+        }
     }
 }
 
 fn validate_concrete_n(op: &'static str, n: Option<usize>) -> tenferro_tensor::Result<()> {
     if n == Some(0) {
-        return Err(tensor_fft_config_error(
+        return Err(tenferro_tensor::Error::invalid_argument(
             op,
-            "tenferro-fft transform length n must be positive",
+            "n",
+            "transform length must be positive",
         ));
     }
     Ok(())
@@ -757,9 +864,10 @@ fn validate_concrete_transform_len(
     axis: usize,
 ) -> tenferro_tensor::Result<()> {
     if n.is_none() && input_shape.get(axis).copied() == Some(0) {
-        return Err(tensor_fft_config_error(
+        return Err(tenferro_tensor::Error::invalid_argument(
             op,
-            "tenferro-fft transform length n must be positive",
+            "n",
+            "transform length must be positive",
         ));
     }
     Ok(())
@@ -771,35 +879,42 @@ fn normalize_concrete_axis(
     rank: usize,
 ) -> tenferro_tensor::Result<usize> {
     if rank == 0 {
-        return Err(tensor_fft_config_error(
+        return Err(tenferro_tensor::Error::invalid_argument(
             op,
-            "tenferro-fft requires rank >= 1",
+            "rank",
+            "FFT requires rank >= 1",
         ));
     }
     let normalized = if axis >= 0 {
         axis as usize
     } else {
         rank.checked_sub(axis.unsigned_abs()).ok_or_else(|| {
-            tensor_fft_config_error(
-                op,
-                format!("tenferro-fft axis {axis} out of bounds for rank {rank}"),
-            )
+            tenferro_tensor::Error::axis_out_of_bounds(op, axis.unsigned_abs(), rank)
         })?
     };
     if normalized >= rank {
-        return Err(tensor_fft_config_error(
-            op,
-            format!("tenferro-fft axis {axis} out of bounds for rank {rank}"),
+        return Err(tenferro_tensor::Error::axis_out_of_bounds(
+            op, normalized, rank,
         ));
     }
     Ok(normalized)
 }
 
-fn tensor_fft_config_error(
+fn tensor_unsupported_dtype(
     op: &'static str,
-    message: impl std::fmt::Display,
+    dtype: DType,
+    expected: &'static str,
 ) -> tenferro_tensor::Error {
-    tenferro_tensor::Error::invalid_argument(op, "configuration", message.to_string())
+    tenferro_tensor::Error::extension(
+        op,
+        FFT_EXTENSION_FAMILY_ID,
+        ErrorKind::Unsupported,
+        FftError::UnsupportedDType {
+            op,
+            dtype,
+            expected,
+        },
+    )
 }
 
 fn tensor_placement(input: &Tensor) -> &Placement {
@@ -823,7 +938,7 @@ fn validate_host_fft_input(op: &'static str, input: &Tensor) -> tenferro_tensor:
         None if is_device => "device tensor without device metadata".to_string(),
         None => "backend buffer".to_string(),
     };
-    Err(tenferro_tensor::Error::backend_failure(
+    Err(tenferro_tensor::Error::unsupported(
         op,
         format!(
             "tenferro-fft supports host tensors only; unsupported {location} input; \
@@ -1095,6 +1210,12 @@ fn restore_c2c_adjoint_input_length_from_transpose_input(
 
 /// Return the explicit FFT extension AD rule set.
 #[cfg(feature = "autodiff")]
+///
+/// # Errors
+///
+/// Returns [`ExtensionRegistryError::MalformedFamilyId`] if the FFT family
+/// identifier is invalid, or [`ExtensionRegistryError::DuplicateRule`] if a
+/// rule for the family and role is already registered.
 pub fn ad_rules() -> std::result::Result<ExtensionRuleSet, ExtensionRegistryError> {
     ExtensionRuleSet::new()
         .with_linearize(Arc::new(FftAdRule))?
@@ -1165,12 +1286,10 @@ fn fft(input: &TracedTensor, n: Option<usize>, axis: isize, norm: FftNorm) -> Re
         DType::C32 | DType::C64 => FftKind::C2C { forward: true },
         DType::F32 | DType::F64 => FftKind::R2C { onesided: false },
         DType::I32 | DType::I64 | DType::Bool => {
-            return Err(fft_config_error(
+            return Err(runtime_unsupported_dtype(
                 "fft",
-                format!(
-                    "fft expects real or complex floating input, got {:?}",
-                    input.dtype
-                ),
+                input.dtype,
+                "F32, F64, C32, or C64",
             ))
         }
     };
@@ -1204,10 +1323,7 @@ fn ifft(
     norm: FftNorm,
 ) -> Result<TracedTensor> {
     if !matches!(input.dtype, DType::C32 | DType::C64) {
-        return Err(fft_config_error(
-            "ifft",
-            format!("ifft expects C32 or C64 input; got {:?}", input.dtype),
-        ));
+        return Err(runtime_unsupported_dtype("ifft", input.dtype, "C32 or C64"));
     }
     apply_unary_fft(
         "ifft",
@@ -1250,10 +1366,7 @@ fn rfft(
     norm: FftNorm,
 ) -> Result<TracedTensor> {
     if !matches!(input.dtype, DType::F32 | DType::F64) {
-        return Err(fft_config_error(
-            "rfft",
-            format!("rfft expects F32 or F64 input; got {:?}", input.dtype),
-        ));
+        return Err(runtime_unsupported_dtype("rfft", input.dtype, "F32 or F64"));
     }
     apply_unary_fft(
         "rfft",
@@ -1299,9 +1412,10 @@ fn irfft(
     norm: FftNorm,
 ) -> Result<TracedTensor> {
     if !matches!(input.dtype, DType::C32 | DType::C64) {
-        return Err(fft_config_error(
+        return Err(runtime_unsupported_dtype(
             "irfft",
-            format!("irfft expects C32 or C64 input; got {:?}", input.dtype),
+            input.dtype,
+            "C32 or C64",
         ));
     }
     apply_unary_fft("irfft", input, FftKind::C2R, n, axis, norm)
@@ -1332,32 +1446,30 @@ fn apply_unary_fft(
 
 fn normalize_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
     if rank == 0 {
-        return Err(fft_config_error(op, "tenferro-fft requires rank >= 1"));
+        return Err(runtime_invalid_argument(
+            op,
+            "rank",
+            "FFT requires rank >= 1",
+        ));
     }
     let normalized = if axis >= 0 {
         axis as usize
     } else {
-        rank.checked_sub(axis.unsigned_abs()).ok_or_else(|| {
-            fft_config_error(
-                op,
-                format!("tenferro-fft axis {axis} out of bounds for rank {rank}"),
-            )
-        })?
+        rank.checked_sub(axis.unsigned_abs())
+            .ok_or_else(|| runtime_axis_out_of_bounds(op, axis.unsigned_abs(), rank))?
     };
     if normalized >= rank {
-        return Err(fft_config_error(
-            op,
-            format!("tenferro-fft axis {axis} out of bounds for rank {rank}"),
-        ));
+        return Err(runtime_axis_out_of_bounds(op, normalized, rank));
     }
     Ok(normalized)
 }
 
 fn validate_n(op: &'static str, n: Option<usize>) -> Result<()> {
     if n == Some(0) {
-        return Err(fft_config_error(
+        return Err(runtime_invalid_argument(
             op,
-            "tenferro-fft transform length n must be positive",
+            "n",
+            "transform length must be positive",
         ));
     }
     Ok(())
@@ -1377,30 +1489,60 @@ fn validate_resolved_transform_len(
         .and_then(|shape| shape.get(axis).copied())
         == Some(0)
     {
-        return Err(fft_config_error(
+        return Err(runtime_invalid_argument(
             op,
-            "tenferro-fft transform length n must be positive",
+            "n",
+            "transform length must be positive",
         ));
     }
     Ok(())
 }
 
-fn fft_config_error(op: &'static str, message: impl std::fmt::Display) -> Error {
-    Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
+fn runtime_invalid_argument(
+    op: &'static str,
+    argument: &'static str,
+    message: impl Into<String>,
+) -> Error {
+    Error::validation(
         op,
-        "configuration",
-        message.to_string(),
-    ))
+        ErrorPhase::GraphBuild,
+        ValidationError::InvalidArgument {
+            argument,
+            message: message.into(),
+        },
+    )
+}
+
+fn runtime_axis_out_of_bounds(op: &'static str, axis: usize, rank: usize) -> Error {
+    Error::validation(
+        op,
+        ErrorPhase::GraphBuild,
+        ValidationError::AxisOutOfBounds { axis, rank },
+    )
+}
+
+fn runtime_unsupported_dtype(op: &'static str, dtype: DType, expected: &'static str) -> Error {
+    Error::extension(
+        op,
+        ErrorPhase::GraphBuild,
+        FFT_EXTENSION_FAMILY_ID,
+        ErrorKind::Unsupported,
+        FftError::UnsupportedDType {
+            op,
+            dtype,
+            expected,
+        },
+    )
 }
 
 fn transform_len_dim(n: Option<usize>, input_dim: &SymDim) -> SymDim {
     n.map(SymDim::from).unwrap_or_else(|| input_dim.clone())
 }
 
-fn expected_dtype_for(kind: FftKind) -> DType {
+fn expected_dtype_description(kind: FftKind) -> &'static str {
     match kind {
-        FftKind::C2C { .. } | FftKind::C2R => DType::C64,
-        FftKind::R2C { .. } => DType::F64,
+        FftKind::C2C { .. } | FftKind::C2R => "C32 or C64",
+        FftKind::R2C { .. } => "F32 or F64",
     }
 }
 
@@ -1675,7 +1817,7 @@ fn cached_fft_plan_from_cache<T: FftNum + 'static>(
         .get_or_init(|| Mutex::new(HashMap::new()))
         .lock()
         .map_err(|_| {
-            tenferro_tensor::Error::backend_failure(
+            tenferro_tensor::Error::runtime_state(
                 "fft_plan_cache",
                 "FFT plan cache lock is poisoned",
             )

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -3,9 +3,12 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 use tenferro_cpu::CpuBackend;
 use tenferro_fft::{FftNorm, TracedTensorFftExt};
-use tenferro_runtime::{DType, GraphCompiler, GraphExecutor, Tensor, TracedTensor};
+use tenferro_runtime::{
+    DType, Error as RuntimeError, ErrorPhase, GraphCompiler, GraphExecutor, Tensor, TracedTensor,
+};
 use tenferro_tensor::{
-    Buffer, BufferHandle, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, TypedTensor,
+    Buffer, BufferHandle, DeviceId, DeviceKind, ErrorKind, GpuBackendKind, MemoryKind, Placement,
+    TypedTensor, ValidationError,
 };
 
 fn run(output: &TracedTensor) -> Tensor {
@@ -463,14 +466,30 @@ fn traced_fft_rejects_invalid_dtype_axis_and_length() {
         Ok(_) => panic!("expected fft to reject integer input"),
         Err(err) => err,
     };
-    assert!(err.to_string().contains("floating"), "{err}");
+    assert!(matches!(
+        err,
+        RuntimeError::Extension {
+            op: "fft",
+            phase: ErrorPhase::GraphBuild,
+            family: "tenferro-fft.fft.v1",
+            kind: ErrorKind::Unsupported,
+            ..
+        }
+    ));
 
     let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     let err = match x.rfft(Some(0), -1, FftNorm::Backward) {
         Ok(_) => panic!("expected rfft to reject zero transform length"),
         Err(err) => err,
     };
-    assert!(err.to_string().contains("positive"), "{err}");
+    assert!(matches!(
+        err,
+        RuntimeError::Validation {
+            op: "rfft",
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::InvalidArgument { argument: "n", .. },
+        }
+    ));
 
     let zero_axis = TracedTensor::from_tensor_concrete_shape(Tensor::F64(
         TypedTensor::from_vec_col_major(vec![0], Vec::<f64>::new()).unwrap(),
@@ -480,13 +499,27 @@ fn traced_fft_rejects_invalid_dtype_axis_and_length() {
         Ok(_) => panic!("expected rfft to reject zero-length input axis"),
         Err(err) => err,
     };
-    assert!(err.to_string().contains("positive"), "{err}");
+    assert!(matches!(
+        err,
+        RuntimeError::Validation {
+            op: "rfft",
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::InvalidArgument { argument: "n", .. },
+        }
+    ));
 
     let err = match x.rfft(None, 3, FftNorm::Backward) {
         Ok(_) => panic!("expected rfft to reject out-of-bounds axis"),
         Err(err) => err,
     };
-    assert!(err.to_string().contains("out of bounds"), "{err}");
+    assert!(matches!(
+        err,
+        RuntimeError::Validation {
+            op: "rfft",
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::AxisOutOfBounds { axis: 3, rank: 1 },
+        }
+    ));
 }
 
 #[test]

--- a/crates/tenferro-gpu/src/cubecl/dispatch.rs
+++ b/crates/tenferro-gpu/src/cubecl/dispatch.rs
@@ -942,11 +942,7 @@ where
 }
 
 pub(crate) fn dtype_mismatch(op: &'static str, lhs: &Tensor, rhs: &Tensor) -> crate::Error {
-    crate::Error::DTypeMismatch {
-        op,
-        lhs: lhs.dtype(),
-        rhs: rhs.dtype(),
-    }
+    crate::Error::dtype_mismatch(op, lhs.dtype(), rhs.dtype())
 }
 
 pub(crate) fn ternary_dtype_mismatch(
@@ -972,29 +968,21 @@ pub(crate) fn ensure_same_shape(
     rhs: &[usize],
 ) -> crate::Result<()> {
     if lhs != rhs {
-        return Err(crate::Error::ShapeMismatch {
-            op,
-            lhs: lhs.to_vec(),
-            rhs: rhs.to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(op, lhs.to_vec(), rhs.to_vec()));
     }
     Ok(())
 }
 
 pub(crate) fn ensure_rank(op: &'static str, expected: usize, actual: usize) -> crate::Result<()> {
     if expected != actual {
-        return Err(crate::Error::RankMismatch {
-            op,
-            expected,
-            actual,
-        });
+        return Err(crate::Error::rank_mismatch(op, expected, actual));
     }
     Ok(())
 }
 
 pub(crate) fn ensure_axis(op: &'static str, axis: usize, rank: usize) -> crate::Result<()> {
     if axis >= rank {
-        return Err(crate::Error::AxisOutOfBounds { op, axis, rank });
+        return Err(crate::Error::axis_out_of_bounds(op, axis, rank));
     }
     Ok(())
 }
@@ -1025,7 +1013,7 @@ pub(crate) fn ensure_axes_unique(
     for &axis in axes {
         ensure_axis(op, axis, rank)?;
         if seen[axis] {
-            return Err(crate::Error::DuplicateAxis { op, axis, role });
+            return Err(crate::Error::duplicate_axis(op, axis, role));
         }
         seen[axis] = true;
     }
@@ -1282,11 +1270,7 @@ macro_rules! dispatch_unary_float_complex_int {
                 num_complex::Complex64,
                 C64
             ),
-            Tensor::Bool(_) => Err(crate::Error::unsupported_op_dtype(
-                op,
-                input.dtype(),
-                tenferro_tensor::BackendId::Cuda,
-            )),
+            Tensor::Bool(_) => Err($crate::cubecl::unsupported_dtype(op, input.dtype())),
         }
     }};
 }
@@ -1342,11 +1326,7 @@ macro_rules! dispatch_unary_float_int {
                 )
             }
             Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => {
-                Err(crate::Error::unsupported_op_dtype(
-                    op,
-                    input.dtype(),
-                    tenferro_tensor::BackendId::Cuda,
-                ))
+                Err($crate::cubecl::unsupported_dtype(op, input.dtype()))
             }
         }
     }};
@@ -1382,11 +1362,7 @@ macro_rules! dispatch_unary_float_only {
                     F64
                 )
             }
-            _ => Err(crate::Error::unsupported_op_dtype(
-                op,
-                input.dtype(),
-                tenferro_tensor::BackendId::Cuda,
-            )),
+            _ => Err($crate::cubecl::unsupported_dtype(op, input.dtype())),
         }
     }};
 }

--- a/crates/tenferro-gpu/src/cubecl/dispatch.rs
+++ b/crates/tenferro-gpu/src/cubecl/dispatch.rs
@@ -18,8 +18,9 @@ pub(crate) const DEFAULT_CUBE_DIM_X: u32 = 256;
 pub(crate) fn cube_count_for_len(len: usize) -> crate::Result<CubeCount> {
     let cubes = len.div_ceil(DEFAULT_CUBE_DIM_X as usize);
     let cubes = u32::try_from(cubes).map_err(|_| {
-        crate::Error::backend_failure(
+        crate::Error::invalid_argument(
             "cube_count_for_len",
+            "length",
             format!(
                 "1D CubeCL launch for {len} elements requires {cubes} cubes, \
                  which exceeds u32::MAX"
@@ -49,7 +50,7 @@ pub(crate) fn cubecl_buffer<'a, T: 'static>(
     op: &'static str,
 ) -> crate::Result<&'a CubeclBuffer<T>> {
     match tensor.buffer() {
-        Buffer::Host(_) => Err(crate::Error::backend_failure(
+        Buffer::Host(_) => Err(crate::Error::runtime_state(
             op,
             "expected CubeCL GPU tensor, got host tensor. \
                       Use upload_tensor() to transfer to GPU before calling GPU ops.",
@@ -58,7 +59,7 @@ pub(crate) fn cubecl_buffer<'a, T: 'static>(
             .as_any()
             .downcast_ref::<CubeclBuffer<T>>()
             .ok_or_else(|| {
-                crate::Error::backend_failure(
+                crate::Error::runtime_state(
                     op,
                     format!(
                         "expected CubeCL GPU tensor, got backend buffer family `{}`",
@@ -74,7 +75,7 @@ pub(crate) fn cubecl_view_buffer<'a, T: 'static>(
     op: &'static str,
 ) -> crate::Result<&'a CubeclBuffer<T>> {
     let buffer = view.backend_buffer().ok_or_else(|| {
-        crate::Error::backend_failure(
+        crate::Error::runtime_state(
             op,
             "expected CubeCL GPU tensor view, got host tensor. \
                       Use upload_tensor() to transfer to GPU before calling GPU ops.",
@@ -84,7 +85,7 @@ pub(crate) fn cubecl_view_buffer<'a, T: 'static>(
         .as_any()
         .downcast_ref::<CubeclBuffer<T>>()
         .ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::runtime_state(
                 op,
                 format!(
                     "expected CubeCL GPU tensor view, got backend buffer family `{}`",
@@ -99,7 +100,7 @@ pub(crate) fn cubecl_view_mut_buffer<'a, T: 'static>(
     op: &'static str,
 ) -> crate::Result<&'a CubeclBuffer<T>> {
     let buffer = view.backend_buffer().ok_or_else(|| {
-        crate::Error::backend_failure(
+        crate::Error::runtime_state(
             op,
             "expected CubeCL GPU tensor view, got host tensor. \
                       Use upload_tensor() to transfer to GPU before calling GPU ops.",
@@ -109,7 +110,7 @@ pub(crate) fn cubecl_view_mut_buffer<'a, T: 'static>(
         .as_any()
         .downcast_ref::<CubeclBuffer<T>>()
         .ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::runtime_state(
                 op,
                 format!(
                     "expected CubeCL GPU tensor view, got backend buffer family `{}`",
@@ -142,8 +143,9 @@ fn checked_shape_product(op: &'static str, shape: &[usize]) -> crate::Result<usi
         .iter()
         .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
         .ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::invalid_argument(
                 op,
+                "shape",
                 format!("shape product overflow for CubeCL tensor shape {shape:?}"),
             )
         })
@@ -157,7 +159,7 @@ fn validate_cubecl_buffer_len<T>(
     let expected_len = checked_shape_product(op, tensor.shape())?;
     let actual_len = buffer.element_len();
     if expected_len != actual_len {
-        return Err(crate::Error::backend_failure(
+        return Err(crate::Error::runtime_state(
             op,
             format!(
                 "expected shape product {expected_len} elements, actual CubeclBuffer::len {}",
@@ -372,7 +374,7 @@ fn ensure_placement_resident_on_runtime(
     op: &'static str,
 ) -> crate::Result<()> {
     if !matches!(&placement.memory_kind, MemoryKind::Device) {
-        return Err(crate::Error::backend_failure(
+        return Err(crate::Error::runtime_state(
             op,
             format!(
                 "expected GPU tensor placement, got {:?}",
@@ -387,7 +389,7 @@ fn ensure_placement_resident_on_runtime(
         {
             Ok(())
         }
-        Some(device) => Err(crate::Error::backend_failure(
+        Some(device) => Err(crate::Error::runtime_state(
             op,
             format!(
                 "expected GPU tensor resident on cuda:{}, got {:?}:{}",
@@ -396,7 +398,7 @@ fn ensure_placement_resident_on_runtime(
                 device.ordinal
             ),
         )),
-        None => Err(crate::Error::backend_failure(
+        None => Err(crate::Error::runtime_state(
             op,
             format!(
                 "expected GPU tensor resident on cuda:{}, got missing device metadata",
@@ -430,8 +432,9 @@ pub(crate) fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
 ) -> crate::Result<TypedTensor<T>> {
     let len = checked_shape_product("cubecl_alloc_output", shape)?;
     let byte_len = len.checked_mul(core::mem::size_of::<T>()).ok_or_else(|| {
-        crate::Error::backend_failure(
+        crate::Error::invalid_argument(
             "cubecl_alloc_output",
+            "shape",
             format!("output byte length overflow for shape {shape:?}"),
         )
     })?;
@@ -520,8 +523,9 @@ where
     let buffer = cubecl_buffer(tensor, op)?;
     validate_cubecl_buffer_len(tensor, buffer, op)?;
     let requested_bytes = len.checked_mul(core::mem::size_of::<U>()).ok_or_else(|| {
-        crate::Error::backend_failure(
+        crate::Error::invalid_argument(
             op,
+            "length",
             format!("reinterpreted CubeCL array length overflow for len {len}"),
         )
     })?;
@@ -529,7 +533,7 @@ where
         .element_len()
         .checked_mul(core::mem::size_of::<T>())
         .ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::runtime_state(
                 op,
                 format!(
                     "CubeCL buffer byte length overflow for {} elements",
@@ -538,7 +542,7 @@ where
             )
         })?;
     if requested_bytes > available_bytes {
-        return Err(crate::Error::backend_failure(op, format!(
+        return Err(crate::Error::runtime_state(op, format!(
                 "reinterpreted CubeCL array needs {requested_bytes} bytes, buffer has {available_bytes}"
             )));
     }
@@ -951,15 +955,12 @@ pub(crate) fn ternary_dtype_mismatch(
     second: &Tensor,
     third: &Tensor,
 ) -> crate::Error {
-    crate::Error::backend_failure(
-        op,
-        format!(
-            "dtype mismatch first={:?} second={:?} third={:?}",
-            first.dtype(),
-            second.dtype(),
-            third.dtype()
-        ),
-    )
+    let (expected, actual) = if first.dtype() != second.dtype() {
+        (first.dtype(), second.dtype())
+    } else {
+        (first.dtype(), third.dtype())
+    };
+    crate::Error::dtype_mismatch(op, expected, actual)
 }
 
 pub(crate) fn ensure_same_shape(
@@ -1196,9 +1197,9 @@ macro_rules! dispatch_binary_float_int {
                     I64
                 )
             }
-            (Tensor::C32(_), Tensor::C32(_)) | (Tensor::C64(_), Tensor::C64(_)) => Err(
-                crate::Error::backend_failure(op, format!("unsupported dtype {:?}", $lhs.dtype())),
-            ),
+            (Tensor::C32(_), Tensor::C32(_)) | (Tensor::C64(_), Tensor::C64(_)) => {
+                Err($crate::cubecl::unsupported_dtype(op, $lhs.dtype()))
+            }
             _ => Err(dtype_mismatch(op, $lhs, $rhs)),
         }
     }};

--- a/crates/tenferro-gpu/src/cubecl/dispatch.rs
+++ b/crates/tenferro-gpu/src/cubecl/dispatch.rs
@@ -996,12 +996,17 @@ pub(crate) fn require_owned_capability<B>(
 where
     B: TensorBackendCapabilityTrait + ?Sized,
 {
-    backend
-        .require_capability(
-            CapabilityQuery::new(kind, dtype),
-            CapabilityAxis::OwnedResult,
-        )
-        .map(|_| ())
+    match backend.require_capability(
+        CapabilityQuery::new(kind, dtype),
+        CapabilityAxis::OwnedResult,
+    ) {
+        Ok(_) => Ok(()),
+        Err(crate::Error::UnsupportedDType { .. }) => Err(crate::cubecl::unsupported_dtype(
+            tenferro_core_ops::descriptor(kind).name,
+            dtype,
+        )),
+        Err(error) => Err(error),
+    }
 }
 
 pub(crate) fn ensure_axes_unique(
@@ -1375,3 +1380,46 @@ pub(crate) use dispatch_unary_float_int;
 pub(crate) use dispatch_unary_float_only;
 pub(crate) use launch_binary_elementwise_kernel;
 pub(crate) use launch_unary_elementwise_kernel;
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as _;
+
+    use tenferro_core_ops::PrimitiveOpKind;
+    use tenferro_tensor::{BackendId, ErrorKind, OperationCapability, TensorBackendCapability};
+
+    use super::*;
+
+    struct UnsupportedCudaCapability;
+
+    impl TensorBackendCapability for UnsupportedCudaCapability {
+        fn backend_id(&self) -> BackendId {
+            BackendId::Cuda
+        }
+
+        fn capabilities(&self) -> &'static [OperationCapability] {
+            &[]
+        }
+    }
+
+    #[test]
+    fn owned_capability_rejection_preserves_the_typed_cuda_source() {
+        let error =
+            require_owned_capability(&UnsupportedCudaCapability, PrimitiveOpKind::Exp, DType::C64)
+                .unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::Unsupported);
+        let source = error
+            .source()
+            .expect("CUDA capability failures preserve a source")
+            .downcast_ref::<crate::cubecl::error::CudaError>()
+            .expect("CUDA capability failures preserve CudaError");
+        assert!(matches!(
+            source,
+            crate::cubecl::error::CudaError::UnsupportedDType {
+                op: "exp",
+                dtype: DType::C64,
+            }
+        ));
+    }
+}

--- a/crates/tenferro-gpu/src/cubecl/error.rs
+++ b/crates/tenferro-gpu/src/cubecl/error.rs
@@ -8,6 +8,23 @@ pub(crate) enum CudaError {
     /// The operation does not have a CUDA implementation for this dtype.
     #[error("{op} does not support dtype {dtype:?} on CUDA")]
     UnsupportedDType { op: &'static str, dtype: DType },
+    /// The backend does not implement an operation or configuration.
+    #[error("{op} is unsupported on CUDA: {detail}")]
+    UnsupportedOperation {
+        op: &'static str,
+        detail: &'static str,
+    },
+    /// A CUDA library call returned a non-success status.
+    #[error("{library} call {call} returned status {status}")]
+    ProviderStatus {
+        library: &'static str,
+        call: &'static str,
+        status: i32,
+    },
+    /// A CUDA provider reported a workspace size that cannot be represented
+    /// by the host allocator.
+    #[error("{op} workspace size {size} does not fit in usize")]
+    WorkspaceSizeOverflow { op: &'static str, size: u64 },
     /// Integer arithmetic encountered a zero divisor.
     #[error("{op} detected division by zero for dtype {dtype:?} on CUDA")]
     DivisionByZero { op: &'static str, dtype: DType },
@@ -34,6 +51,45 @@ pub(crate) fn division_by_zero(op: &'static str, dtype: DType) -> crate::Error {
         "cuda",
         ErrorKind::NumericalFailure,
         CudaError::DivisionByZero { op, dtype },
+    )
+}
+
+/// Construct a typed CUDA operation-capability failure.
+pub(crate) fn unsupported_operation(op: &'static str, detail: &'static str) -> crate::Error {
+    crate::Error::extension(
+        op,
+        "cuda",
+        ErrorKind::Unsupported,
+        CudaError::UnsupportedOperation { op, detail },
+    )
+}
+
+/// Preserve a CUDA library status as a typed backend source.
+pub(crate) fn provider_status(
+    op: &'static str,
+    library: &'static str,
+    call: &'static str,
+    status: i32,
+) -> crate::Error {
+    crate::Error::extension(
+        op,
+        "cuda",
+        ErrorKind::BackendFailure,
+        CudaError::ProviderStatus {
+            library,
+            call,
+            status,
+        },
+    )
+}
+
+/// Preserve a CUDA workspace allocation overflow as a typed backend source.
+pub(crate) fn workspace_size_overflow(op: &'static str, size: u64) -> crate::Error {
+    crate::Error::extension(
+        op,
+        "cuda",
+        ErrorKind::BackendFailure,
+        CudaError::WorkspaceSizeOverflow { op, size },
     )
 }
 
@@ -67,6 +123,43 @@ mod tests {
             CudaError::UnsupportedDType {
                 op: "exp",
                 dtype: DType::I32
+            }
+        ));
+    }
+
+    #[test]
+    fn provider_status_preserves_classification_and_source() {
+        let error = provider_status("dot_general", "cuTENSOR", "cutensorContract", 7);
+
+        assert_eq!(error.kind(), ErrorKind::BackendFailure);
+        let source = error.source().expect("CUDA errors have a source");
+        let source = source
+            .downcast_ref::<CudaError>()
+            .expect("CUDA errors preserve their typed source");
+        assert!(matches!(
+            source,
+            CudaError::ProviderStatus {
+                library: "cuTENSOR",
+                call: "cutensorContract",
+                status: 7,
+            }
+        ));
+    }
+
+    #[test]
+    fn workspace_overflow_preserves_classification_and_source() {
+        let error = workspace_size_overflow("dot_general", u64::MAX);
+
+        assert_eq!(error.kind(), ErrorKind::BackendFailure);
+        let source = error.source().expect("CUDA errors have a source");
+        let source = source
+            .downcast_ref::<CudaError>()
+            .expect("CUDA errors preserve their typed source");
+        assert!(matches!(
+            source,
+            CudaError::WorkspaceSizeOverflow {
+                op: "dot_general",
+                size: u64::MAX,
             }
         ));
     }

--- a/crates/tenferro-gpu/src/cubecl/error.rs
+++ b/crates/tenferro-gpu/src/cubecl/error.rs
@@ -31,6 +31,14 @@ pub(crate) enum CudaError {
     /// Integer power received a negative exponent.
     #[error("{op} received a negative integer exponent for dtype {dtype:?} on CUDA")]
     NegativeIntegerExponent { op: &'static str, dtype: DType },
+    /// A backend validation flag was returned with a dtype different from the
+    /// one used to allocate it.
+    #[error("{op} validation flag returned dtype {actual:?}, expected {expected:?} on CUDA")]
+    UnexpectedValidationFlagDType {
+        op: &'static str,
+        expected: DType,
+        actual: DType,
+    },
 }
 
 /// Construct an operation-level unsupported-dtype error without pretending it
@@ -103,6 +111,25 @@ pub(crate) fn negative_integer_exponent(op: &'static str, dtype: DType) -> crate
     )
 }
 
+/// Preserve an impossible validation-flag dtype change as a typed backend
+/// source instead of exposing an unstructured internal string.
+pub(crate) fn unexpected_validation_flag_dtype(
+    op: &'static str,
+    expected: DType,
+    actual: DType,
+) -> crate::Error {
+    crate::Error::extension(
+        op,
+        "cuda",
+        ErrorKind::BackendFailure,
+        CudaError::UnexpectedValidationFlagDType {
+            op,
+            expected,
+            actual,
+        },
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::error::Error as _;
@@ -160,6 +187,26 @@ mod tests {
             CudaError::WorkspaceSizeOverflow {
                 op: "dot_general",
                 size: u64::MAX,
+            }
+        ));
+    }
+
+    #[test]
+    fn unexpected_validation_flag_dtype_preserves_classification_and_source() {
+        let error = unexpected_validation_flag_dtype("cast", DType::F32, DType::I32);
+
+        assert_eq!(error.kind(), ErrorKind::BackendFailure);
+        let source = error
+            .source()
+            .expect("CUDA validation errors have a source")
+            .downcast_ref::<CudaError>()
+            .expect("CUDA validation errors keep their typed source");
+        assert!(matches!(
+            source,
+            CudaError::UnexpectedValidationFlagDType {
+                op: "cast",
+                expected: DType::F32,
+                actual: DType::I32,
             }
         ));
     }

--- a/crates/tenferro-gpu/src/cubecl/error.rs
+++ b/crates/tenferro-gpu/src/cubecl/error.rs
@@ -1,0 +1,73 @@
+use tenferro_tensor::{DType, ErrorKind};
+use thiserror::Error;
+
+/// Structured errors owned by the CUDA backend.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub(crate) enum CudaError {
+    /// The operation does not have a CUDA implementation for this dtype.
+    #[error("{op} does not support dtype {dtype:?} on CUDA")]
+    UnsupportedDType { op: &'static str, dtype: DType },
+    /// Integer arithmetic encountered a zero divisor.
+    #[error("{op} detected division by zero for dtype {dtype:?} on CUDA")]
+    DivisionByZero { op: &'static str, dtype: DType },
+    /// Integer power received a negative exponent.
+    #[error("{op} received a negative integer exponent for dtype {dtype:?} on CUDA")]
+    NegativeIntegerExponent { op: &'static str, dtype: DType },
+}
+
+/// Construct an operation-level unsupported-dtype error without pretending it
+/// is a conversion between two different dtypes.
+pub(crate) fn unsupported_dtype(op: &'static str, dtype: DType) -> crate::Error {
+    crate::Error::extension(
+        op,
+        "cuda",
+        ErrorKind::Unsupported,
+        CudaError::UnsupportedDType { op, dtype },
+    )
+}
+
+/// Construct a typed CUDA numerical-domain failure.
+pub(crate) fn division_by_zero(op: &'static str, dtype: DType) -> crate::Error {
+    crate::Error::extension(
+        op,
+        "cuda",
+        ErrorKind::NumericalFailure,
+        CudaError::DivisionByZero { op, dtype },
+    )
+}
+
+/// Construct a typed CUDA negative-exponent failure.
+pub(crate) fn negative_integer_exponent(op: &'static str, dtype: DType) -> crate::Error {
+    crate::Error::extension(
+        op,
+        "cuda",
+        ErrorKind::NumericalFailure,
+        CudaError::NegativeIntegerExponent { op, dtype },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as _;
+
+    use super::*;
+
+    #[test]
+    fn unsupported_dtype_preserves_classification_and_source() {
+        let error = unsupported_dtype("exp", DType::I32);
+
+        assert_eq!(error.kind(), ErrorKind::Unsupported);
+        let source = error.source().expect("extension errors have a source");
+        let source = source
+            .downcast_ref::<CudaError>()
+            .expect("CUDA errors preserve their typed source");
+        assert!(matches!(
+            source,
+            CudaError::UnsupportedDType {
+                op: "exp",
+                dtype: DType::I32
+            }
+        ));
+    }
+}

--- a/crates/tenferro-gpu/src/cubecl/ffi/cutensor.rs
+++ b/crates/tenferro-gpu/src/cubecl/ffi/cutensor.rs
@@ -23,6 +23,23 @@ type CutensorStatus = i32;
 
 const CUTENSOR_STATUS_SUCCESS: CutensorStatus = 0;
 
+#[derive(Debug, thiserror::Error)]
+enum CutensorLoadError {
+    #[error("failed to load cuTENSOR symbol {name}: {source}")]
+    Symbol {
+        name: String,
+        #[source]
+        source: libloading::Error,
+    },
+    #[error("failed to load cuTENSOR library (tried {paths}): {source}; attempts: {attempts}")]
+    Library {
+        paths: String,
+        attempts: String,
+        #[source]
+        source: libloading::Error,
+    },
+}
+
 #[repr(i32)]
 #[derive(Clone, Copy)]
 pub(crate) enum CudaDataType {
@@ -172,13 +189,16 @@ impl CutensorVtable {
 unsafe fn load_symbol<T: Copy>(lib: &Library, name: &[u8]) -> crate::Result<T> {
     // SAFETY: `name` is a NUL-terminated cuTENSOR symbol and the requested
     // type `T` is the exact FFI function-pointer type declared in this module.
-    let symbol = lib.get::<T>(name).map_err(|err| {
-        crate::Error::backend_failure(
+    let symbol_name = String::from_utf8_lossy(name)
+        .trim_end_matches('\0')
+        .to_owned();
+    let symbol = lib.get::<T>(name).map_err(|source| {
+        crate::Error::io_source(
             OP,
-            format!(
-                "failed to load cuTENSOR symbol {}: {err}",
-                String::from_utf8_lossy(name).trim_end_matches('\0')
-            ),
+            CutensorLoadError::Symbol {
+                name: symbol_name,
+                source,
+            },
         )
     })?;
     Ok(*symbol)
@@ -190,24 +210,25 @@ unsafe fn load_data_symbol<T: Copy>(lib: &Library, name: &[u8]) -> crate::Result
         .to_owned();
     // SAFETY: cuTENSOR compute descriptors are exported as static data symbols
     // whose value is a process-lifetime pointer-like descriptor.
-    let symbol = lib.get::<*const T>(name).map_err(|err| {
-        crate::Error::backend_failure(
+    let symbol = lib.get::<*const T>(name).map_err(|source| {
+        crate::Error::io_source(
             OP,
-            format!("failed to load cuTENSOR data symbol {symbol_name}: {err}"),
+            CutensorLoadError::Symbol {
+                name: symbol_name.clone(),
+                source,
+            },
         )
     })?;
     let ptr = *symbol;
     if ptr.is_null() {
-        return Err(crate::Error::backend_failure(
-            OP,
-            format!("cuTENSOR data symbol {symbol_name} resolved to a null pointer"),
-        ));
+        return Err(crate::Error::Internal(format!(
+            "cuTENSOR data symbol {symbol_name} resolved to a null pointer"
+        )));
     }
     if !ptr.is_aligned() {
-        return Err(crate::Error::backend_failure(
-            OP,
-            format!("cuTENSOR data symbol {symbol_name} resolved to a misaligned pointer"),
-        ));
+        return Err(crate::Error::Internal(format!(
+            "cuTENSOR data symbol {symbol_name} resolved to a misaligned pointer"
+        )));
     }
     // SAFETY: null and alignment were checked above; cuTENSOR exports this as
     // static process-lifetime data and `T: Copy`, so reading copies the descriptor value.
@@ -231,11 +252,13 @@ impl CutensorLibrary {
     fn load() -> crate::Result<Arc<Self>> {
         let paths = super::library_search_paths("TENFERRO_CUTENSOR_PATH", CUTENSOR_DEFAULT_PATHS);
         let mut errors = Vec::new();
+        let mut last_source = None;
         for path in &paths {
             let lib = match unsafe { Library::new(path) } {
                 Ok(lib) => lib,
                 Err(err) => {
                     errors.push(format!("{path}: {err}"));
+                    last_source = Some(err);
                     continue;
                 }
             };
@@ -243,14 +266,23 @@ impl CutensorLibrary {
             return Ok(Arc::new(Self { _lib: lib, vtable }));
         }
 
-        Err(crate::Error::backend_failure(
-            OP,
-            format!(
-                "failed to load cuTENSOR library (tried {}): {}",
-                paths.join(", "),
-                errors.join("; ")
-            ),
-        ))
+        match last_source {
+            Some(source) => Err(crate::Error::io_source(
+                OP,
+                CutensorLoadError::Library {
+                    paths: paths.join(", "),
+                    attempts: errors.join("; "),
+                    source,
+                },
+            )),
+            None => Err(crate::Error::io_source(
+                OP,
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("no cuTENSOR library search paths configured for {OP}"),
+                ),
+            )),
+        }
     }
 
     fn status_message(&self, status: CutensorStatus) -> String {
@@ -276,12 +308,8 @@ impl CutensorLibrary {
         if status == CUTENSOR_STATUS_SUCCESS {
             return Ok(());
         }
-        Err(crate::Error::backend_failure(
-            op,
-            format!(
-                "{call} failed with cuTENSOR {} ({status})",
-                self.status_message(status)
-            ),
+        Err(super::super::error::provider_status(
+            op, "cuTENSOR", call, status,
         ))
     }
 }
@@ -405,7 +433,7 @@ impl TensorDescriptor {
         op: &'static str,
     ) -> crate::Result<Self> {
         let num_modes = u32::try_from(extents.len()).map_err(|_| {
-            crate::Error::backend_failure(op, "tensor rank exceeds cuTENSOR u32 limit")
+            crate::Error::invalid_argument(op, "rank", "tensor rank exceeds cuTENSOR u32 limit")
         })?;
         let mut raw = std::ptr::null_mut();
         let status = unsafe {

--- a/crates/tenferro-gpu/src/cubecl/fusion/classify.rs
+++ b/crates/tenferro-gpu/src/cubecl/fusion/classify.rs
@@ -31,14 +31,7 @@ where
     let mut typed_inputs = Vec::with_capacity(inputs.len());
     for tensor in inputs {
         typed_inputs.push(T::tensor_ref(tensor).ok_or_else(|| {
-            crate::Error::backend_failure(
-                "fused_elementwise",
-                format!(
-                    "plan dtype {:?} does not match runtime tensor dtype {:?}",
-                    plan.dtype(),
-                    tensor.dtype()
-                ),
-            )
+            crate::Error::dtype_mismatch("fused_elementwise", plan.dtype(), tensor.dtype())
         })?);
     }
 

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -325,11 +325,11 @@ macro_rules! impl_from_contraction_scalar {
             fn from_contraction_scalar(value: ContractionScalar) -> crate::Result<Self> {
                 match value {
                     ContractionScalar::$variant(value) => Ok(value),
-                    other => Err(Error::DTypeMismatch {
-                        op: OP,
-                        lhs: <$ty as tenferro_tensor::TensorScalar>::dtype(),
-                        rhs: other.dtype(),
-                    }),
+                    other => Err(Error::dtype_mismatch(
+                        OP,
+                        <$ty as tenferro_tensor::TensorScalar>::dtype(),
+                        other.dtype(),
+                    )),
                 }
             }
         }
@@ -489,11 +489,11 @@ where
     validate_dot_general(lhs.shape(), rhs.shape(), config)?;
     let layout = build_layout(lhs.shape(), rhs.shape(), config)?;
     if out.shape() != layout.output_shape.as_slice() {
-        return Err(Error::ShapeMismatch {
-            op: OP,
-            lhs: out.shape().to_vec(),
-            rhs: layout.output_shape.clone(),
-        });
+        return Err(Error::shape_mismatch(
+            OP,
+            out.shape().to_vec(),
+            layout.output_shape.clone(),
+        ));
     }
     // Residency, buffer-family, stride-sign, and bounds validation for all
     // three slots happens here, before any degenerate-case early return.
@@ -984,11 +984,14 @@ fn build_layout(
         rhs_modes[rhs_axis] = mode;
         contracting_elements = contracting_elements
             .checked_mul(lhs_shape[lhs_axis])
-            .ok_or_else(|| Error::InvalidConfig {
-                op: OP,
-                message: format!(
-                    "contracting dimension product overflows usize for lhs shape {lhs_shape:?}"
-                ),
+            .ok_or_else(|| {
+                Error::invalid_argument(
+                    OP,
+                    "shape",
+                    format!(
+                        "contracting dimension product overflows usize for lhs shape {lhs_shape:?}"
+                    ),
+                )
             })?;
     }
 
@@ -1045,9 +1048,12 @@ fn build_layout(
 fn dims_to_i64(dims: &[usize]) -> crate::Result<Vec<i64>> {
     dims.iter()
         .map(|&dim| {
-            i64::try_from(dim).map_err(|_| Error::InvalidConfig {
-                op: OP,
-                message: format!("extent {dim} exceeds cuTENSOR i64 limit"),
+            i64::try_from(dim).map_err(|_| {
+                Error::invalid_argument(
+                    OP,
+                    "shape",
+                    format!("extent {dim} exceeds cuTENSOR i64 limit"),
+                )
             })
         })
         .collect()
@@ -1057,9 +1063,12 @@ fn strides_to_i64(strides: &[isize]) -> crate::Result<Vec<i64>> {
     strides
         .iter()
         .map(|&stride| {
-            i64::try_from(stride).map_err(|_| Error::InvalidConfig {
-                op: OP,
-                message: format!("stride {stride} exceeds cuTENSOR i64 limit"),
+            i64::try_from(stride).map_err(|_| {
+                Error::invalid_argument(
+                    OP,
+                    "stride",
+                    format!("stride {stride} exceeds cuTENSOR i64 limit"),
+                )
             })
         })
         .collect()
@@ -1080,10 +1089,10 @@ fn validate_axis_list(
     let mut seen = vec![false; rank];
     for &axis in axes {
         if axis >= rank {
-            return Err(Error::AxisOutOfBounds { op, axis, rank });
+            return Err(Error::axis_out_of_bounds(op, axis, rank));
         }
         if seen[axis] {
-            return Err(Error::DuplicateAxis { op, axis, role });
+            return Err(Error::duplicate_axis(op, axis, role));
         }
         seen[axis] = true;
     }
@@ -1099,12 +1108,14 @@ fn validate_role_disjoint(
 ) -> crate::Result<()> {
     for &axis in first_axes {
         if second_axes.contains(&axis) {
-            return Err(Error::AxisRoleConflict {
+            return Err(Error::validation(
                 op,
-                axis,
-                first_role,
-                second_role,
-            });
+                tenferro_tensor::ValidationError::AxisRoleConflict {
+                    axis,
+                    first_role,
+                    second_role,
+                },
+            ));
         }
     }
     Ok(())
@@ -1116,16 +1127,18 @@ fn validate_dot_general(
     config: &DotGeneralConfig,
 ) -> crate::Result<()> {
     if config.lhs_contracting_dims.len() != config.rhs_contracting_dims.len() {
-        return Err(Error::InvalidConfig {
-            op: OP,
-            message: "lhs/rhs contracting dim counts differ".into(),
-        });
+        return Err(Error::invalid_argument(
+            OP,
+            "contracting_dims",
+            "lhs/rhs contracting dim counts differ",
+        ));
     }
     if config.lhs_batch_dims.len() != config.rhs_batch_dims.len() {
-        return Err(Error::InvalidConfig {
-            op: OP,
-            message: "lhs/rhs batch dim counts differ".into(),
-        });
+        return Err(Error::invalid_argument(
+            OP,
+            "batch_dims",
+            "lhs/rhs batch dim counts differ",
+        ));
     }
 
     let lhs_rank = lhs_shape.len();
@@ -1166,25 +1179,26 @@ fn validate_dot_general(
         .zip(&config.rhs_contracting_dims)
     {
         if lhs_shape[lhs_axis] != rhs_shape[rhs_axis] {
-            return Err(Error::InvalidConfig {
-                op: OP,
-                message: format!(
-                    "contracting dim size mismatch: lhs axis {lhs_axis}={} rhs axis {rhs_axis}={}",
-                    lhs_shape[lhs_axis], rhs_shape[rhs_axis]
-                ),
-            });
+            return Err(Error::validation(
+                OP,
+                tenferro_tensor::ShapeMismatch::ContractedDimensions {
+                    lhs_axis,
+                    lhs_size: lhs_shape[lhs_axis],
+                    rhs_axis,
+                    rhs_size: rhs_shape[rhs_axis],
+                }
+                .into(),
+            ));
         }
     }
 
     for (&lhs_axis, &rhs_axis) in config.lhs_batch_dims.iter().zip(&config.rhs_batch_dims) {
         if lhs_shape[lhs_axis] != rhs_shape[rhs_axis] {
-            return Err(Error::InvalidConfig {
-                op: OP,
-                message: format!(
-                    "batch dim size mismatch: lhs axis {lhs_axis}={} rhs axis {rhs_axis}={}",
-                    lhs_shape[lhs_axis], rhs_shape[rhs_axis]
-                ),
-            });
+            return Err(Error::shape_mismatch(
+                OP,
+                lhs_shape.to_vec(),
+                rhs_shape.to_vec(),
+            ));
         }
     }
 

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -11,6 +11,7 @@ use super::dispatch::{
     ensure_view_mut_resident_on_runtime, ensure_view_resident_on_runtime, launch_nullary_into,
     typed_tensor_array_arg,
 };
+use super::error::{unsupported_dtype, unsupported_operation, workspace_size_overflow};
 use super::ffi::cutensor::{
     CudaDataType, CutensorComputeDescriptor, CutensorCudaStream, CutensorHandle, CutensorOperator,
     CutensorWorksizePreference, OperationDescriptor, Plan, PlanPreference, TensorDescriptor,
@@ -426,12 +427,7 @@ pub(super) fn dot_general_read_into_accum(
         DType::F64 => accum_erased::<f64>(backend, lhs, rhs, config, accumulation, out),
         DType::C32 => accum_erased::<Complex32>(backend, lhs, rhs, config, accumulation, out),
         DType::C64 => accum_erased::<Complex64>(backend, lhs, rhs, config, accumulation, out),
-        dtype => Err(Error::backend_failure(
-            OP,
-            format!(
-                "CUDA dot-general accumulation supports f32/f64/c32/c64 operands, got {dtype:?}"
-            ),
-        )),
+        dtype => Err(unsupported_dtype(OP, dtype)),
     }
 }
 
@@ -452,10 +448,12 @@ where
         read_operand::<T>(rhs),
         write_operand::<T>(out),
     ) else {
-        return Err(Error::backend_failure(
-            OP,
-            format!("dtype mismatch lhs={lhs_dtype:?} rhs={rhs_dtype:?} out={out_dtype:?}"),
-        ));
+        let (expected, actual) = if lhs_dtype != rhs_dtype {
+            (lhs_dtype, rhs_dtype)
+        } else {
+            (lhs_dtype, out_dtype)
+        };
+        return Err(Error::dtype_mismatch(OP, expected, actual));
     };
     dot_general_typed_into_accum(
         backend,
@@ -513,11 +511,9 @@ where
                 } else {
                     // No strided in-place scale kernel exists yet; an explicit
                     // error is required instead of a silent wrong result.
-                    Err(Error::backend_failure(
+                    Err(unsupported_operation(
                         OP,
-                        "zero-sized contraction with beta != 1 is not supported for \
-                         borrowed view outputs on CUDA; use an owned output tensor \
-                         or scale the region explicitly",
+                        "zero-sized contraction with beta != 1 is not supported for borrowed view outputs",
                     ))
                 }
             }
@@ -655,8 +651,9 @@ fn resolve_device_region<T: 'static>(
     let mut strides_i64 = Vec::with_capacity(strides.len());
     for &stride in strides {
         if stride < 0 {
-            return Err(Error::backend_failure(
+            return Err(Error::invalid_argument(
                 OP,
+                "layout",
                 format!(
                     "cuTENSOR dot-general accumulation requires nonnegative view \
                      strides, got {strides:?}; canonicalize the view on device first"
@@ -666,8 +663,9 @@ fn resolve_device_region<T: 'static>(
         strides_i64.push(stride as i64);
     }
     let offset = usize::try_from(offset).map_err(|_| {
-        Error::backend_failure(
+        Error::invalid_argument(
             OP,
+            "layout",
             format!(
                 "view offset {offset} must be nonnegative for cuTENSOR dot-general accumulation"
             ),
@@ -680,11 +678,14 @@ fn resolve_device_region<T: 'static>(
             max_offset = (dim - 1)
                 .checked_mul(stride as usize)
                 .and_then(|span| max_offset.checked_add(span))
-                .ok_or_else(|| Error::backend_failure(OP, "view element span overflows usize"))?;
+                .ok_or_else(|| {
+                    Error::invalid_argument(OP, "layout", "view element span overflows usize")
+                })?;
         }
         if max_offset >= buffer.element_len() {
-            return Err(Error::backend_failure(
+            return Err(Error::invalid_argument(
                 OP,
+                "layout",
                 format!(
                     "view region reaches element offset {max_offset} but the device \
                      buffer holds only {} elements",
@@ -696,17 +697,17 @@ fn resolve_device_region<T: 'static>(
     let resource = rt
         .client()
         .get_resource(buffer.handle().clone())
-        .map_err(|err| {
-            Error::backend_failure(OP, format!("failed to obtain CubeCL resource: {err:?}"))
-        })?;
+        .map_err(|err| Error::backend_source(OP, err))?;
     let offset_bytes = (offset as u64)
         .checked_mul(std::mem::size_of::<T>() as u64)
-        .ok_or_else(|| Error::backend_failure(OP, "view byte offset overflows u64"))?;
+        .ok_or_else(|| Error::invalid_argument(OP, "layout", "view byte offset overflows u64"))?;
     let addr = resource
         .resource()
         .ptr
         .checked_add(offset_bytes)
-        .ok_or_else(|| Error::backend_failure(OP, "view device address overflows u64"))?;
+        .ok_or_else(|| {
+            Error::invalid_argument(OP, "layout", "view device address overflows u64")
+        })?;
     Ok(ResolvedOperand {
         ptr: cuda_device_ptr_from_addr(addr, OP)?,
         strides: strides_i64,
@@ -750,7 +751,7 @@ where
     let factor_host = T::wrap_tensor(TypedTensor::from_vec_col_major(vec![1], vec![beta])?);
     let factor_device = upload_tensor(rt, &factor_host)?;
     let factor_typed = T::unwrap_tensor(&factor_device)
-        .ok_or_else(|| Error::backend_failure(OP, "scale factor upload changed dtype"))?;
+        .ok_or_else(|| Error::Internal("scale factor upload changed dtype".to_string()))?;
     ensure_resident_on_runtime(rt, out, OP)?;
     ensure_resident_on_runtime(rt, factor_typed, OP)?;
     let out_arg = typed_tensor_array_arg(out, OP)?;
@@ -894,16 +895,13 @@ fn alloc_workspace(rt: &CudaRuntime, workspace_size: u64) -> crate::Result<Works
     if workspace_size == 0 {
         return Ok(Workspace::none());
     }
-    let workspace_len = usize::try_from(workspace_size).map_err(|_| {
-        crate::Error::backend_failure(
-            OP,
-            format!("workspace size {workspace_size} does not fit in usize"),
-        )
-    })?;
+    let workspace_len =
+        usize::try_from(workspace_size).map_err(|_| workspace_size_overflow(OP, workspace_size))?;
     let handle = rt.client().empty(workspace_len);
-    let resource = rt.client().get_resource(handle.clone()).map_err(|err| {
-        crate::Error::backend_failure(OP, format!("failed to obtain workspace resource: {err:?}"))
-    })?;
+    let resource = rt
+        .client()
+        .get_resource(handle.clone())
+        .map_err(|err| crate::Error::backend_source(OP, err))?;
     Ok(Workspace {
         _handle: Some(handle),
         ptr: cuda_device_ptr_from_addr(resource.resource().ptr, OP)?,
@@ -920,9 +918,7 @@ fn typed_device_ptr<T: 'static>(
     let resource = rt
         .client()
         .get_resource(buffer.handle().clone())
-        .map_err(|err| {
-            crate::Error::backend_failure(OP, format!("failed to obtain CubeCL resource: {err:?}"))
-        })?;
+        .map_err(|err| crate::Error::backend_source(OP, err))?;
     // The residency check above ties this raw FFI pointer to the caller's runtime/device.
     cuda_device_ptr_from_addr(resource.resource().ptr, OP)
 }

--- a/crates/tenferro-gpu/src/cubecl/interop.rs
+++ b/crates/tenferro-gpu/src/cubecl/interop.rs
@@ -53,7 +53,11 @@ impl DeviceByteBuffer {
 
 pub(crate) fn cuda_device_ptr_from_addr(addr: u64, op: &'static str) -> crate::Result<*mut c_void> {
     let addr = usize::try_from(addr).map_err(|_| {
-        crate::Error::backend_failure(op, format!("CUDA device address {addr} exceeds usize"))
+        crate::Error::invalid_argument(
+            op,
+            "device_address",
+            format!("CUDA device address {addr} exceeds usize"),
+        )
     })?;
     Ok(std::ptr::with_exposed_provenance_mut::<c_void>(addr))
 }
@@ -70,19 +74,30 @@ pub fn with_cubecl_client<R>(
 }
 
 /// Flush the CubeCL client after an unchecked kernel launch.
+/// # Errors
+///
+/// Returns [`crate::Error::BackendSource`] when CubeCL cannot flush the client.
 pub fn flush_cubecl_client(rt: &CudaRuntime, op: &'static str) -> crate::Result<()> {
     rt.client()
         .flush()
-        .map_err(|err| crate::Error::backend_failure(op, format!("CubeCL launch failed: {err:?}")))
+        .map_err(|err| crate::Error::backend_source(op, err))
 }
 
 /// Return the CUDA stream pointer for libraries that must enqueue onto CubeCL's stream.
+/// # Errors
+///
+/// Returns [`crate::Error::BackendSource`] when CubeCL cannot expose the
+/// stream, or [`crate::Error::RuntimeState`] when its server is unavailable.
 pub fn raw_cuda_stream(rt: &CudaRuntime, op: &'static str) -> crate::Result<u64> {
     rt.raw_cuda_stream()
-        .map_err(|err| crate::Error::backend_failure(op, err.to_string()))
+        .map_err(|err| crate::Error::backend_source(op, err))
 }
 
 /// Return the launch cube count for a one-dimensional kernel domain.
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `InvalidArgument` when `len`
+/// cannot be represented by CubeCL's launch-count type.
 pub fn cube_count_for_len(len: usize) -> crate::Result<CubeCount> {
     dispatch::cube_count_for_len(len)
 }
@@ -93,6 +108,10 @@ pub fn cube_dim_1d() -> CubeDim {
 }
 
 /// Allocate a dense GPU tensor on the runtime's device.
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `InvalidArgument` when the shape
+/// product overflows, or [`crate::Error::BackendSource`] when allocation fails.
 pub fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
     rt: &CudaRuntime,
     shape: &[usize],
@@ -101,6 +120,10 @@ pub fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
 }
 
 /// Validate that a tensor is backed by a CubeCL buffer.
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeState`] when the tensor is host-backed,
+/// belongs to another GPU runtime, or has the wrong backend buffer family.
 pub fn ensure_typed_tensor_resident<T: 'static>(
     tensor: &TypedTensor<T, impl TensorRank>,
     op: &'static str,
@@ -110,6 +133,10 @@ pub fn ensure_typed_tensor_resident<T: 'static>(
 }
 
 /// Build a CubeCL tensor binding for operation-family kernels.
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeState`] when the tensor is not CubeCL
+/// resident, or [`crate::Error::Validation`] when its layout cannot be bound.
 pub fn typed_tensor_binding<T: CubeElement + Clone>(
     tensor: &TypedTensor<T, impl TensorRank>,
     op: &'static str,
@@ -118,6 +145,10 @@ pub fn typed_tensor_binding<T: CubeElement + Clone>(
 }
 
 /// Build a CubeCL array argument for operation-family kernels.
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeState`] when the tensor is not CubeCL
+/// resident, or [`crate::Error::Validation`] when its layout cannot be bound.
 pub fn typed_tensor_array_arg<T: CubeElement + Clone>(
     tensor: &TypedTensor<T, impl TensorRank>,
     op: &'static str,
@@ -126,6 +157,11 @@ pub fn typed_tensor_array_arg<T: CubeElement + Clone>(
 }
 
 /// Return a raw CUDA device pointer for a CubeCL-backed tensor.
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeState`] for a non-resident or foreign tensor,
+/// [`crate::Error::BackendSource`] when its resource cannot be inspected, or
+/// [`crate::Error::Validation`] when the pointer address overflows `usize`.
 pub fn typed_device_ptr<T: 'static>(
     rt: &CudaRuntime,
     tensor: &TypedTensor<T, impl TensorRank>,
@@ -136,14 +172,17 @@ pub fn typed_device_ptr<T: 'static>(
     let resource = rt
         .client()
         .get_resource(buffer.handle().clone())
-        .map_err(|err| {
-            crate::Error::backend_failure(op, format!("failed to obtain CubeCL resource: {err:?}"))
-        })?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
     // The residency check above ties this raw FFI pointer to the caller's runtime/device.
     cuda_device_ptr_from_addr(resource.resource().ptr, op)
 }
 
 /// Upload host data into a dense GPU tensor on the runtime's device.
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] when `shape` and `data` have different
+/// element counts, or [`crate::Error::BackendSource`] when device allocation
+/// fails.
 pub fn upload_typed_tensor<T>(
     rt: &CudaRuntime,
     shape: Vec<usize>,
@@ -162,6 +201,11 @@ where
 }
 
 /// Download a dense CubeCL-backed typed tensor to host memory.
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeState`] for a host-backed or foreign tensor,
+/// [`crate::Error::BackendSource`] when synchronization/readback fails, or a
+/// typed validation error when downloaded bytes do not form the declared shape.
 pub fn download_typed_tensor<T>(
     rt: &CudaRuntime,
     tensor: &TypedTensor<T, impl TensorRank>,
@@ -179,13 +223,16 @@ where
     let bytes = rt
         .client()
         .read_one(buffer.handle().clone())
-        .map_err(|err| {
-            crate::Error::backend_failure(op, format!("failed to download tensor: {err:?}"))
-        })?;
+        .map_err(|err| crate::Error::backend_source(op, err))?;
     TypedTensor::from_vec_col_major(tensor.shape().to_vec(), T::from_bytes(&bytes).to_vec())
 }
 
 /// Allocate a CubeCL-owned byte workspace and return its CUDA pointer.
+/// # Errors
+///
+/// Returns [`crate::Error::BackendSource`] when CubeCL cannot allocate or
+/// inspect the workspace resource, or [`crate::Error::Validation`] when its
+/// pointer address cannot be represented as `usize`.
 pub fn alloc_device_bytes(
     rt: &CudaRuntime,
     nbytes: usize,
@@ -199,6 +246,10 @@ pub fn alloc_device_bytes(
 }
 
 /// Upload bytes into a CubeCL-owned workspace and return its CUDA pointer.
+/// # Errors
+///
+/// Returns [`crate::Error::BackendSource`] when CubeCL cannot upload or inspect
+/// the workspace resource, or [`crate::Error::Validation`] on pointer overflow.
 pub fn upload_device_bytes(
     rt: &CudaRuntime,
     bytes: &[u8],
@@ -216,9 +267,10 @@ fn device_bytes_from_handle(
     handle: cubecl_runtime::server::Handle,
     op: &'static str,
 ) -> crate::Result<DeviceByteBuffer> {
-    let resource = rt.client().get_resource(handle.clone()).map_err(|err| {
-        crate::Error::backend_failure(op, format!("failed to obtain CubeCL resource: {err:?}"))
-    })?;
+    let resource = rt
+        .client()
+        .get_resource(handle.clone())
+        .map_err(|err| crate::Error::backend_source(op, err))?;
     Ok(DeviceByteBuffer {
         handle: Some(handle),
         ptr: cuda_device_ptr_from_addr(resource.resource().ptr, op)?,

--- a/crates/tenferro-gpu/src/cubecl/interop.rs
+++ b/crates/tenferro-gpu/src/cubecl/interop.rs
@@ -96,8 +96,10 @@ pub fn raw_cuda_stream(rt: &CudaRuntime, op: &'static str) -> crate::Result<u64>
 /// Return the launch cube count for a one-dimensional kernel domain.
 /// # Errors
 ///
-/// Returns [`crate::Error::Validation`] with `InvalidArgument` when `len`
-/// cannot be represented by CubeCL's launch-count type.
+/// Returns [`crate::Error::Validation`] containing
+/// [`tenferro_tensor::ValidationError::InvalidArgument`] when the
+/// one-dimensional launch for `len` elements would require more than
+/// `u32::MAX` CubeCL workgroups.
 pub fn cube_count_for_len(len: usize) -> crate::Result<CubeCount> {
     dispatch::cube_count_for_len(len)
 }

--- a/crates/tenferro-gpu/src/cubecl/memory.rs
+++ b/crates/tenferro-gpu/src/cubecl/memory.rs
@@ -23,6 +23,12 @@ use crate::types::{
 ///
 /// let _upload: fn(&CudaRuntime, &Tensor) -> Result<Tensor> = upload_tensor;
 /// ```
+///
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeState`] when the source is backend-resident
+/// or belongs to another placement, [`crate::Error::Unsupported`] for a dtype
+/// unavailable in CubeCL, or [`crate::Error::BackendSource`] on allocation.
 pub fn upload_tensor(rt: &CudaRuntime, tensor: &Tensor) -> crate::Result<Tensor> {
     let client = rt.client();
     match tensor {
@@ -50,6 +56,12 @@ pub fn upload_tensor(rt: &CudaRuntime, tensor: &Tensor) -> crate::Result<Tensor>
 ///
 /// let _download: fn(&CudaRuntime, &Tensor) -> Result<Tensor> = download_tensor;
 /// ```
+///
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeState`] for a host-backed or foreign tensor,
+/// [`crate::Error::BackendSource`] when synchronization/readback fails, or a
+/// typed validation error when device data cannot be decoded.
 pub fn download_tensor(rt: &CudaRuntime, tensor: &Tensor) -> crate::Result<Tensor> {
     ensure_tensor_resident_on_runtime(rt, tensor, "download")?;
     match tensor {
@@ -73,13 +85,18 @@ pub fn download_tensor(rt: &CudaRuntime, tensor: &Tensor) -> crate::Result<Tenso
 ///
 /// let _device_ptr: fn(&CudaRuntime, &Tensor) -> Result<u64> = device_ptr;
 /// ```
+///
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeState`] for a host-backed or foreign tensor,
+/// or [`crate::Error::BackendSource`] when CubeCL cannot inspect its resource.
 pub fn device_ptr(rt: &CudaRuntime, tensor: &Tensor) -> crate::Result<u64> {
     ensure_tensor_resident_on_runtime(rt, tensor, "device_ptr")?;
     let handle = cubecl_handle(tensor)?;
     let resource = rt
         .client()
         .get_resource(handle)
-        .map_err(|err| crate::Error::backend_failure("device_ptr", format!("{err:?}")))?;
+        .map_err(|err| crate::Error::backend_source("device_ptr", err))?;
     Ok(resource.resource().ptr)
 }
 
@@ -91,7 +108,7 @@ fn upload_typed<T: CubeElement + Clone + Send + Sync + 'static>(
     let host_data = match typed.buffer() {
         Buffer::Host(data) => data,
         Buffer::Backend(buffer) => {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "upload",
                 format!(
                     "expected host buffer, got `{}` backend buffer",
@@ -121,7 +138,7 @@ fn download_typed<T: CubeElement + Clone + 'static>(
 ) -> crate::Result<TypedTensor<T>> {
     let handle = match typed.buffer() {
         Buffer::Host(_) => {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "download",
                 "expected CubeCL buffer",
             ));
@@ -137,7 +154,7 @@ fn download_typed<T: CubeElement + Clone + 'static>(
     let bytes = rt
         .client()
         .read_one(handle)
-        .map_err(|err| crate::Error::backend_failure("download", format!("{err:?}")))?;
+        .map_err(|err| crate::Error::backend_source("download", err))?;
     let data = T::from_bytes(&bytes).to_vec();
     TypedTensor::from_vec_col_major(typed.shape().to_vec(), data)
 }
@@ -150,7 +167,7 @@ fn upload_bool(
     let host_data = match typed.buffer() {
         Buffer::Host(data) => data,
         Buffer::Backend(buffer) => {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "upload",
                 format!(
                     "expected host buffer, got `{}` backend buffer",
@@ -178,7 +195,7 @@ fn upload_bool(
 fn download_bool(rt: &CudaRuntime, typed: &TypedTensor<bool>) -> crate::Result<TypedTensor<bool>> {
     let handle = match typed.buffer() {
         Buffer::Host(_) => {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "download",
                 "expected CubeCL buffer",
             ));
@@ -194,7 +211,7 @@ fn download_bool(rt: &CudaRuntime, typed: &TypedTensor<bool>) -> crate::Result<T
     let bytes = rt
         .client()
         .read_one(handle)
-        .map_err(|err| crate::Error::backend_failure("download", format!("{err:?}")))?;
+        .map_err(|err| crate::Error::backend_source("download", err))?;
     let data = bytes.iter().map(|&byte| byte != 0).collect();
     TypedTensor::from_vec_col_major(typed.shape().to_vec(), data)
 }
@@ -231,7 +248,7 @@ fn cubecl_handle_from_buffer<T: 'static>(
     buffer: &Buffer<T>,
 ) -> crate::Result<cubecl_runtime::server::Handle> {
     match buffer {
-        Buffer::Host(_) => Err(crate::Error::backend_failure(
+        Buffer::Host(_) => Err(crate::Error::runtime_state(
             "cubecl_handle",
             "expected CubeCL buffer",
         )),
@@ -248,7 +265,7 @@ fn cubecl_handle_from_backend<T: 'static>(
         .downcast_ref::<CubeclBuffer<T>>()
         .map(|buffer| buffer.handle().clone())
         .ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::runtime_state(
                 op,
                 format!(
                     "expected CubeCL buffer, got `{}` backend buffer",

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -4759,7 +4759,7 @@ impl TensorIndexing for CudaBackend {
             (_, Tensor::C32(_) | Tensor::C64(_), _) => {
                 Err(unsupported_dtype("scatter", scatter_indices.dtype()))
             }
-            (Tensor::Bool(_), _, Tensor::Bool(_)) => Err(unsupported_operation(
+            (Tensor::Bool(_), _, _) => Err(unsupported_operation(
                 "scatter",
                 "Bool data tensors are not supported by additive scatter",
             )),

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -136,7 +136,7 @@ use dispatch::{
     ternary_dtype_mismatch, typed_tensor_array_arg, typed_tensor_array_arg_as,
     typed_tensor_binding, typed_view_array_arg, typed_view_mut_array_arg,
 };
-use error::unsupported_dtype;
+use error::{unsupported_dtype, unsupported_operation};
 
 pub use capability::cuda_capabilities;
 pub use memory::{device_ptr, download_tensor, upload_tensor};
@@ -162,9 +162,9 @@ fn ensure_atomic_add_supported<T: CubePrimitive>(
     {
         Ok(())
     } else {
-        Err(crate::Error::backend_failure(
+        Err(unsupported_operation(
             op,
-            format!("CubeCL runtime does not support atomic add for {elem:?}"),
+            "CubeCL runtime does not support atomic add",
         ))
     }
 }
@@ -176,8 +176,9 @@ fn checked_dim_product(
 ) -> crate::Result<usize> {
     shape.iter().try_fold(1usize, |acc, &dim| {
         acc.checked_mul(dim).ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::invalid_argument(
                 op,
+                role,
                 format!("{role} product overflow for shape {shape:?}"),
             )
         })
@@ -189,8 +190,9 @@ fn view_strides_i64(strides: &[isize], op: &'static str) -> crate::Result<Vec<i6
         .iter()
         .map(|&stride| {
             i64::try_from(stride).map_err(|_| {
-                crate::Error::backend_failure(
+                crate::Error::invalid_argument(
                     op,
+                    "layout",
                     format!("view stride {stride} exceeds CubeCL i64 metadata limit"),
                 )
             })
@@ -200,8 +202,9 @@ fn view_strides_i64(strides: &[isize], op: &'static str) -> crate::Result<Vec<i6
 
 fn view_offset_i64(offset: isize, op: &'static str) -> crate::Result<i64> {
     i64::try_from(offset).map_err(|_| {
-        crate::Error::backend_failure(
+        crate::Error::invalid_argument(
             op,
+            "layout",
             format!("view offset {offset} exceeds CubeCL i64 metadata limit"),
         )
     })
@@ -212,8 +215,9 @@ fn scatter_update_len(meta: &ScatterLaunchMeta) -> crate::Result<usize> {
     let window_len =
         checked_dim_product("scatter", "window update shape", &meta.window_shape_updates)?;
     batch_len.checked_mul(window_len).ok_or_else(|| {
-        crate::Error::backend_failure(
+        crate::Error::invalid_argument(
             "scatter",
+            "shape",
             format!(
                 "scatter update domain product overflow for batch {:?} and window {:?}",
                 meta.batch_shape, meta.window_shape_updates
@@ -321,7 +325,7 @@ impl CudaExtensionCacheInner {
 
 impl CudaExtensionCache {
     fn poisoned_lock_error() -> crate::Error {
-        crate::Error::backend_failure("cuda_extension_cache", "extension cache lock poisoned")
+        crate::Error::runtime_state("cuda_extension_cache", "extension cache lock poisoned")
     }
 
     fn lock_inner(&self) -> crate::Result<MutexGuard<'_, CudaExtensionCacheInner>> {
@@ -339,6 +343,10 @@ impl CudaExtensionCache {
     /// assert!(cache.is_empty()?);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// This constructor is infallible; later cache operations return
+    /// [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
     pub fn new() -> Self {
         let max_entries = NonZeroUsize::new(DEFAULT_CUDA_EXTENSION_CACHE_MAX_ENTRIES)
             .unwrap_or(NonZeroUsize::MIN);
@@ -362,11 +370,17 @@ impl CudaExtensionCache {
     /// assert!(CudaExtensionCache::new().is_empty()?);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
     pub fn is_empty(&self) -> crate::Result<bool> {
         Ok(self.lock_inner()?.entries.is_empty())
     }
 
     /// Remove every cached CUDA extension state value.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
     pub fn clear(&self) -> crate::Result<()> {
         let mut inner = self.lock_inner()?;
         inner.entries.clear();
@@ -376,6 +390,9 @@ impl CudaExtensionCache {
     }
 
     /// Snapshot the number of retained entries and logical retained bytes.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
     pub fn stats(&self) -> crate::Result<CacheStats> {
         let inner = self.lock_inner()?;
         Ok(CacheStats {
@@ -385,11 +402,18 @@ impl CudaExtensionCache {
     }
 
     /// Return the configured entry bound.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
     pub fn max_entries(&self) -> crate::Result<NonZeroUsize> {
         Ok(self.lock_inner()?.max_entries)
     }
 
     /// Replace the entry bound and evict oldest entries if needed.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned
+    /// while changing the bound.
     pub fn set_max_entries(&self, max_entries: NonZeroUsize) -> crate::Result<()> {
         let mut inner = self.lock_inner()?;
         inner.max_entries = max_entries;
@@ -408,6 +432,11 @@ impl CudaExtensionCache {
     /// let value = cache.get_or_try_init::<usize>(|| Ok(3)).unwrap();
     /// assert_eq!(*value, 3);
     /// ```
+    /// # Errors
+    ///
+    /// Propagates the initializer's typed error, returns
+    /// [`crate::Error::RuntimeState`] for a poisoned cache or a missing/wrongly
+    /// typed entry, and preserves backend errors from initialization.
     pub fn get_or_try_init<T>(
         &self,
         init: impl FnOnce() -> crate::Result<T>,
@@ -426,7 +455,7 @@ impl CudaExtensionCache {
             .and_then(|entry| entry.value.downcast_ref::<T>())
             .map(NonNull::from)
             .ok_or_else(|| {
-                crate::Error::backend_failure(
+                crate::Error::runtime_state(
                     "cuda_extension_cache",
                     format!(
                         "stored entry for {} is missing or has the wrong type",
@@ -494,6 +523,10 @@ impl CudaBackend {
     ///
     /// let _ctor: fn(usize) -> tenferro_tensor::Result<CudaBackend> = CudaBackend::new;
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::BackendSource`] when CUDA initialization,
+    /// context creation, or CubeCL client creation fails.
     pub fn new(device_ordinal: usize) -> crate::Result<Self> {
         Ok(Self {
             cutensor: OnceCell::new(),
@@ -522,7 +555,7 @@ impl CudaBackend {
         let handle = ffi::cutensor::CutensorHandle::load()?;
         let _ = self.cutensor.set(handle);
         self.cutensor.get().ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::runtime_state(
                 "dot_general",
                 "cuTENSOR handle initialization completed without a stored handle",
             )
@@ -535,21 +568,37 @@ impl CudaBackend {
     }
 
     /// Clear CUDA extension-owned backend state.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the extension cache mutex is
+    /// poisoned.
     pub fn clear_cuda_extension_cache(&self) -> crate::Result<()> {
         self.extension_cache.clear()
     }
 
     /// Return CUDA extension cache stats.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the extension cache mutex is
+    /// poisoned.
     pub fn cuda_extension_cache_stats(&self) -> crate::Result<CacheStats> {
         self.extension_cache.stats()
     }
 
     /// Return the CUDA extension cache entry bound.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the extension cache mutex is
+    /// poisoned.
     pub fn cuda_extension_cache_max_entries(&self) -> crate::Result<NonZeroUsize> {
         self.extension_cache.max_entries()
     }
 
     /// Configure the CUDA extension cache entry bound.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the extension cache mutex is
+    /// poisoned while changing the bound.
     pub fn set_cuda_extension_cache_max_entries(
         &self,
         max_entries: NonZeroUsize,
@@ -729,14 +778,15 @@ impl CudaBackend {
     {
         let len = checked_dim_product(op, "output shape", shape)?;
         let bytes = len.checked_mul(core::mem::size_of::<T>()).ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::invalid_argument(
                 op,
+                "shape",
                 format!("CubeCL output byte length overflow for shape {shape:?}"),
             )
         })?;
         let handle = self.runtime().client().empty(bytes);
         let shape = R::shape_from_vec(shape.to_vec().into())
-            .map_err(|err| crate::Error::invalid_argument(op, "shape", err.to_string()))?;
+            .map_err(|err| crate::Error::validation(op, err))?;
         Ok(TypedTensor::from_buffer_col_major(
             shape,
             Buffer::Backend(Arc::new(crate::CubeclBuffer::new(handle, len))),
@@ -809,13 +859,13 @@ impl CudaBackend {
             ));
         }
         let source_buffer = src.backend_buffer().ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::runtime_state(
                 op,
                 "CUDA backend expected a GPU source view; call upload_tensor() first",
             )
         })?;
         let destination_buffer = dst.backend_buffer().ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::runtime_state(
                 op,
                 "CUDA backend expected a GPU destination view; call upload_tensor() first",
             )
@@ -838,7 +888,7 @@ impl CudaBackend {
             ));
         }
         let source_shape = R::shape_from_vec(src.shape().to_vec().into())
-            .map_err(|err| crate::Error::invalid_argument(op, "source shape", err.to_string()))?;
+            .map_err(|err| crate::Error::validation(op, err))?;
         let source_tensor: TypedTensor<T, R> = TypedTensor::from_buffer_col_major(
             source_shape,
             Buffer::Backend(Arc::clone(source_buffer)),
@@ -1044,7 +1094,7 @@ impl CudaBackend {
         ensure_resident_on_runtime(self.runtime(), input, "cast")?;
         let n = input.n_elements();
         let part_len = n.checked_mul(2).ok_or_else(|| {
-            crate::Error::backend_failure("cast", "complex output part length overflow")
+            crate::Error::invalid_argument("cast", "shape", "complex output part length overflow")
         })?;
         let input_arg = bool_tensor_array_arg(input, "cast")?;
         let count = if n == 0 {
@@ -1094,7 +1144,7 @@ impl CudaBackend {
     {
         ensure_resident_on_runtime(self.runtime(), input, "cast")?;
         let part_len = input.n_elements().checked_mul(2).ok_or_else(|| {
-            crate::Error::backend_failure("cast", "complex input part length overflow")
+            crate::Error::invalid_argument("cast", "shape", "complex input part length overflow")
         })?;
         let input_arg = typed_tensor_array_arg_as::<In, F>(input, part_len, "cast")?;
         let n = input.n_elements();
@@ -1243,7 +1293,11 @@ impl CudaBackend {
         let input_arg = typed_tensor_array_arg(input, "convert")?;
         let n = input.n_elements();
         let output_part_len = n.checked_mul(2).ok_or_else(|| {
-            crate::Error::backend_failure("convert", "complex output part length overflow")
+            crate::Error::invalid_argument(
+                "convert",
+                "shape",
+                "complex output part length overflow",
+            )
         })?;
         let count = if n == 0 {
             None
@@ -1343,7 +1397,7 @@ impl CudaBackend {
     {
         ensure_resident_on_runtime(self.runtime(), input, "cast")?;
         let parts = input.n_elements().checked_mul(2).ok_or_else(|| {
-            crate::Error::backend_failure("cast", "complex component length overflow")
+            crate::Error::invalid_argument("cast", "shape", "complex component length overflow")
         })?;
         let input_arg = typed_tensor_array_arg_as::<In, InFloat>(input, parts, "cast")?;
         let count = if parts == 0 {
@@ -1646,7 +1700,7 @@ impl CudaBackend {
 
         let output_binding = typed_tensor_binding(&output, op)?;
         launch(self.runtime().client(), input_binding, output_binding)
-            .map_err(|err| crate::Error::backend_failure(op, err.to_string()))?;
+            .map_err(|err| crate::Error::backend_source(op, err))?;
         Ok(output)
     }
 
@@ -2416,10 +2470,18 @@ impl CudaBackend {
         let update_len = scatter_update_len(&meta)?;
         let output_len = checked_dim_product("scatter", "output shape", operand.shape())?;
         let output_part_len = output_len.checked_mul(2).ok_or_else(|| {
-            crate::Error::backend_failure("scatter", "complex output part length overflow")
+            crate::Error::invalid_argument(
+                "scatter",
+                "shape",
+                "complex output part length overflow",
+            )
         })?;
         let update_part_len = updates.n_elements().checked_mul(2).ok_or_else(|| {
-            crate::Error::backend_failure("scatter", "complex update part length overflow")
+            crate::Error::invalid_argument(
+                "scatter",
+                "shape",
+                "complex update part length overflow",
+            )
         })?;
         if output_len != 0 {
             cube_count_for_len(output_len)?;
@@ -2558,11 +2620,14 @@ macro_rules! impl_cuda_cast_float {
             fn read_flag(backend: &CudaBackend, flag: &TypedTensor<Self>) -> crate::Result<Self> {
                 match download_tensor(backend.runtime(), &Tensor::$variant(flag.clone()))? {
                     Tensor::$variant(host) => host.as_slice()?.get(1).copied().ok_or_else(|| {
-                        crate::Error::backend_failure("cast", "validation flag was malformed")
+                        crate::Error::invalid_argument(
+                            "cast",
+                            "validation_flag",
+                            "validation flag was malformed",
+                        )
                     }),
-                    _ => Err(crate::Error::backend_failure(
-                        "cast",
-                        "validation flag had unexpected dtype",
+                    _ => Err(crate::Error::Internal(
+                        "cast validation flag had unexpected dtype".to_string(),
                     )),
                 }
             }
@@ -2613,18 +2678,24 @@ where
         return Ok(());
     }
     u32::try_from(n).map_err(|_| {
-        crate::Error::backend_failure("cast", "validation domain exceeds u32::MAX elements")
+        crate::Error::invalid_argument(
+            "cast",
+            "shape",
+            "validation domain exceeds u32::MAX elements",
+        )
     })?;
     let count = cube_count_for_len(n)?;
-    let input_parts = n
-        .checked_mul(stride)
-        .ok_or_else(|| crate::Error::backend_failure("cast", "validation input length overflow"))?;
+    let input_parts = n.checked_mul(stride).ok_or_else(|| {
+        crate::Error::invalid_argument("cast", "shape", "validation input length overflow")
+    })?;
     let input_arg = typed_tensor_array_arg_as::<S, F>(input, input_parts, "cast")?;
     let flag = alloc_output::<F>(backend.runtime(), &[2])?;
     let flag_u32_len = std::mem::size_of::<F>()
         .checked_mul(2)
         .and_then(|x| x.checked_div(std::mem::size_of::<u32>()))
-        .ok_or_else(|| crate::Error::backend_failure("cast", "validation flag size overflow"))?;
+        .ok_or_else(|| {
+            crate::Error::invalid_argument("cast", "shape", "validation flag size overflow")
+        })?;
     let flag_atomic = typed_tensor_array_arg_as::<F, u32>(&flag, flag_u32_len, "cast")?;
     let flag_values = typed_tensor_array_arg(&flag, "cast")?;
     unsafe {
@@ -2684,17 +2755,12 @@ fn checked_integer_domain_error(
     }
 }
 
-fn read_checked_integer_flag(
-    backend: &CudaBackend,
-    flag: &TypedTensor<i32>,
-    op: &'static str,
-) -> crate::Result<i32> {
+fn read_checked_integer_flag(backend: &CudaBackend, flag: &TypedTensor<i32>) -> crate::Result<i32> {
     let host = download_tensor(backend.runtime(), &Tensor::I32(flag.clone()))?;
     match host {
         Tensor::I32(flag) => Ok(flag.as_slice()?.first().copied().unwrap_or_default()),
-        _ => Err(crate::Error::backend_failure(
-            op,
-            "integer domain flag download returned unexpected dtype",
+        _ => Err(crate::Error::Internal(
+            "integer domain flag download returned unexpected dtype".to_string(),
         )),
     }
 }
@@ -2753,11 +2819,14 @@ impl CudaFloatIndex for f32 {
     fn read_invalid_flag(backend: &CudaBackend, flag: &TypedTensor<Self>) -> crate::Result<Self> {
         match download_tensor(backend.runtime(), &Tensor::F32(flag.clone()))? {
             Tensor::F32(host) => host.as_slice()?.get(1).copied().ok_or_else(|| {
-                crate::Error::backend_failure("index_tensor", "validation flag was malformed")
+                crate::Error::invalid_argument(
+                    "index_tensor",
+                    "validation_flag",
+                    "validation flag was malformed",
+                )
             }),
-            _ => Err(crate::Error::backend_failure(
-                "index_tensor",
-                "validation flag had unexpected dtype",
+            _ => Err(crate::Error::Internal(
+                "index_tensor validation flag had unexpected dtype".to_string(),
             )),
         }
     }
@@ -2773,11 +2842,14 @@ impl CudaFloatIndex for f64 {
     fn read_invalid_flag(backend: &CudaBackend, flag: &TypedTensor<Self>) -> crate::Result<Self> {
         match download_tensor(backend.runtime(), &Tensor::F64(flag.clone()))? {
             Tensor::F64(host) => host.as_slice()?.get(1).copied().ok_or_else(|| {
-                crate::Error::backend_failure("index_tensor", "validation flag was malformed")
+                crate::Error::invalid_argument(
+                    "index_tensor",
+                    "validation_flag",
+                    "validation flag was malformed",
+                )
             }),
-            _ => Err(crate::Error::backend_failure(
-                "index_tensor",
-                "validation flag had unexpected dtype",
+            _ => Err(crate::Error::Internal(
+                "index_tensor validation flag had unexpected dtype".to_string(),
             )),
         }
     }
@@ -2796,8 +2868,9 @@ where
         return Ok(());
     }
     u32::try_from(indices.n_elements()).map_err(|_| {
-        crate::Error::backend_failure(
+        crate::Error::invalid_argument(
             "index_tensor",
+            "shape",
             "float index validation domain exceeds u32::MAX elements",
         )
     })?;
@@ -2805,7 +2878,9 @@ where
     let flag_u32_len = std::mem::size_of::<F>()
         .checked_mul(2)
         .and_then(|bytes| bytes.checked_div(std::mem::size_of::<u32>()))
-        .ok_or_else(|| crate::Error::backend_failure("index_tensor", "flag size overflow"))?;
+        .ok_or_else(|| {
+            crate::Error::invalid_argument("index_tensor", "shape", "flag size overflow")
+        })?;
     let flag = alloc_output::<F>(backend.runtime(), &[2])?;
     let flag_values = typed_tensor_array_arg(&flag, "index_tensor")?;
     let flag_atomic = typed_tensor_array_arg_as::<F, u32>(&flag, flag_u32_len, "index_tensor")?;
@@ -2917,7 +2992,7 @@ where
         flag_arg,
     );
 
-    if read_checked_integer_flag(backend, &flag, op)? != 0 {
+    if read_checked_integer_flag(backend, &flag)? != 0 {
         return Err(checked_integer_domain_error(domain, op, dtype));
     }
     Ok(output)
@@ -3001,10 +3076,9 @@ where
     }
     ensure_resident_on_runtime(backend.runtime(), real, op)?;
     ensure_resident_on_runtime(backend.runtime(), complex, op)?;
-    let component_len = complex
-        .n_elements()
-        .checked_mul(2)
-        .ok_or_else(|| crate::Error::backend_failure(op, "complex component length overflow"))?;
+    let component_len = complex.n_elements().checked_mul(2).ok_or_else(|| {
+        crate::Error::invalid_argument(op, "shape", "complex component length overflow")
+    })?;
     let real_arg = typed_tensor_array_arg(real, op)?;
     // INVARIANT: `num_complex::Complex<T>` is `repr(C)` with interleaved `{ re, im }`
     // fields; the checked `2 * n_elements` length and binding validator prove this
@@ -3124,7 +3198,7 @@ where
         flag_arg,
         lhs_scalar,
     );
-    if read_checked_integer_flag(backend, &flag, op)? != 0 {
+    if read_checked_integer_flag(backend, &flag)? != 0 {
         return Err(checked_integer_domain_error(domain, op, dtype));
     }
     Ok(output)
@@ -3693,9 +3767,9 @@ impl TensorElementwise for CudaBackend {
                 },
             )
             .map(Tensor::Bool),
-            (Tensor::C32(_), Tensor::C32(_)) | (Tensor::C64(_), Tensor::C64(_)) => Err(
-                crate::Error::backend_failure(op, format!("unsupported dtype {:?}", lhs.dtype())),
-            ),
+            (Tensor::C32(_), Tensor::C32(_)) | (Tensor::C64(_), Tensor::C64(_)) => {
+                Err(unsupported_dtype(op, lhs.dtype()))
+            }
             _ => Err(dtype_mismatch(op, lhs, rhs)),
         }
     }
@@ -3776,9 +3850,9 @@ impl TensorElementwise for CudaBackend {
                 .map(Tensor::I64)
             }
             (Tensor::C32(_), Tensor::C32(_), Tensor::C32(_))
-            | (Tensor::C64(_), Tensor::C64(_), Tensor::C64(_)) => Err(
-                crate::Error::backend_failure(op, format!("unsupported dtype {:?}", pred.dtype())),
-            ),
+            | (Tensor::C64(_), Tensor::C64(_), Tensor::C64(_)) => {
+                Err(unsupported_dtype(op, pred.dtype()))
+            }
             _ => Err(ternary_dtype_mismatch(op, pred, on_true, on_false)),
         }
     }
@@ -3818,9 +3892,9 @@ impl TensorElementwise for CudaBackend {
             )
             .map(Tensor::F64),
             (Tensor::C32(_), Tensor::C32(_), Tensor::C32(_))
-            | (Tensor::C64(_), Tensor::C64(_), Tensor::C64(_)) => Err(
-                crate::Error::backend_failure(op, format!("unsupported dtype {:?}", input.dtype())),
-            ),
+            | (Tensor::C64(_), Tensor::C64(_), Tensor::C64(_)) => {
+                Err(unsupported_dtype(op, input.dtype()))
+            }
             _ => Err(ternary_dtype_mismatch(op, input, lower, upper)),
         }
     }
@@ -4444,9 +4518,9 @@ impl TensorReduction for CudaBackend {
             Tensor::F64(t) => self.reduce_max_float_typed(t, axes).map(Tensor::F64),
             Tensor::I32(t) => self.reduce_max_int_typed(t, axes).map(Tensor::I32),
             Tensor::I64(t) => self.reduce_max_int_typed(t, axes).map(Tensor::I64),
-            Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => Err(
-                crate::Error::backend_failure(op, format!("unsupported dtype {:?}", input.dtype())),
-            ),
+            Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => {
+                Err(unsupported_dtype(op, input.dtype()))
+            }
         }
     }
 
@@ -4460,9 +4534,9 @@ impl TensorReduction for CudaBackend {
             Tensor::F64(t) => self.reduce_min_float_typed(t, axes).map(Tensor::F64),
             Tensor::I32(t) => self.reduce_min_int_typed(t, axes).map(Tensor::I32),
             Tensor::I64(t) => self.reduce_min_int_typed(t, axes).map(Tensor::I64),
-            Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => Err(
-                crate::Error::backend_failure(op, format!("unsupported dtype {:?}", input.dtype())),
-            ),
+            Tensor::Bool(_) | Tensor::C32(_) | Tensor::C64(_) => {
+                Err(unsupported_dtype(op, input.dtype()))
+            }
         }
     }
 }
@@ -4594,10 +4668,9 @@ impl TensorIndexing for CudaBackend {
                 self.gather_bool(operand, indices, config).map(Tensor::Bool)
             }
             (_, Tensor::Bool(_)) => Err(unsupported_dtype("gather", start_indices.dtype())),
-            (_, Tensor::C32(_) | Tensor::C64(_)) => Err(crate::Error::backend_failure(
-                "gather",
-                "complex index tensors are not supported",
-            )),
+            (_, Tensor::C32(_) | Tensor::C64(_)) => {
+                Err(unsupported_dtype("gather", start_indices.dtype()))
+            }
             (Tensor::I64(_), _) => Err(unsupported_dtype("gather", operand.dtype())),
         }
     }
@@ -4659,14 +4732,10 @@ impl TensorIndexing for CudaBackend {
                 .scatter_complex_typed::<_, f64, _>(operand, indices, updates, config)
                 .map(Tensor::C64),
             (_, Tensor::Bool(_), _) => Err(unsupported_dtype("scatter", scatter_indices.dtype())),
-            (_, Tensor::C32(_) | Tensor::C64(_), _) => Err(crate::Error::backend_failure(
-                "scatter",
-                "complex index tensors are not supported",
-            )),
-            (Tensor::Bool(_), _, _) => Err(crate::Error::backend_failure(
-                "scatter",
-                "Bool data tensors are not supported by additive scatter",
-            )),
+            (_, Tensor::C32(_) | Tensor::C64(_), _) => {
+                Err(unsupported_dtype("scatter", scatter_indices.dtype()))
+            }
+            (Tensor::Bool(_), _, _) => Err(unsupported_dtype("scatter", operand.dtype())),
             (Tensor::I32(_), _, _) | (Tensor::I64(_), _, _) => {
                 Err(unsupported_dtype("scatter", operand.dtype()))
             }
@@ -4771,10 +4840,9 @@ impl TensorIndexing for CudaBackend {
                 .dynamic_slice_bool(input, starts, slice_sizes)
                 .map(Tensor::Bool),
             (_, Tensor::Bool(_)) => Err(unsupported_dtype("dynamic_slice", starts.dtype())),
-            (_, Tensor::C32(_) | Tensor::C64(_)) => Err(crate::Error::backend_failure(
-                "dynamic_slice",
-                "complex index tensors are not supported",
-            )),
+            (_, Tensor::C32(_) | Tensor::C64(_)) => {
+                Err(unsupported_dtype("dynamic_slice", starts.dtype()))
+            }
             (Tensor::I64(_), _) => Err(unsupported_dtype("dynamic_slice", input.dtype())),
         }
     }
@@ -4785,9 +4853,9 @@ impl TensorIndexing for CudaBackend {
         _update: &Tensor,
         _starts: &Tensor,
     ) -> crate::Result<Tensor> {
-        Err(crate::Error::backend_failure(
+        Err(unsupported_operation(
             "dynamic_update_slice",
-            "dynamic_update_slice is not implemented for the CubeCL backend",
+            "not implemented for the CubeCL backend",
         ))
     }
 
@@ -5610,8 +5678,9 @@ fn concatenate_output_shape<T>(
         for dim in 0..rank {
             if dim == axis {
                 axis_extent = axis_extent.checked_add(input.shape()[dim]).ok_or_else(|| {
-                    crate::Error::backend_failure(
+                    crate::Error::invalid_argument(
                         "concatenate",
+                        "shape",
                         "concatenate axis extent overflows usize",
                     )
                 })?;

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -116,6 +116,7 @@ use crate::{
 
 mod capability;
 mod dispatch;
+mod error;
 mod ffi;
 mod fusion;
 mod gemm;
@@ -135,14 +136,11 @@ use dispatch::{
     ternary_dtype_mismatch, typed_tensor_array_arg, typed_tensor_array_arg_as,
     typed_tensor_binding, typed_view_array_arg, typed_view_mut_array_arg,
 };
+use error::unsupported_dtype;
 
 pub use capability::cuda_capabilities;
 pub use memory::{device_ptr, download_tensor, upload_tensor};
 pub use runtime::{gpu_available, CudaRuntime};
-
-fn unsupported_dtype(op: &'static str, dtype: crate::DType) -> crate::Error {
-    crate::Error::backend_failure(op, format!("unsupported dtype {dtype:?}"))
-}
 
 fn op_name(
     kind: PrimitiveOpKind,
@@ -237,7 +235,7 @@ pub struct CudaBackend {
     // CUDA library handles are dropped before `rt`; Rust drops fields in
     // declaration order, so cache-owned handles release while the CUDA primary
     // context is still retained by `CudaRuntime`.
-    cutensor: OnceCell<crate::Result<ffi::cutensor::CutensorHandle>>,
+    cutensor: OnceCell<ffi::cutensor::CutensorHandle>,
     extension_cache: CudaExtensionCache,
     rt: CudaRuntime,
 }
@@ -518,13 +516,17 @@ impl CudaBackend {
     }
 
     fn cutensor_handle(&self) -> crate::Result<&ffi::cutensor::CutensorHandle> {
-        match self
-            .cutensor
-            .get_or_init(ffi::cutensor::CutensorHandle::load)
-        {
-            Ok(handle) => Ok(handle),
-            Err(err) => Err(err.clone()),
+        if let Some(handle) = self.cutensor.get() {
+            return Ok(handle);
         }
+        let handle = ffi::cutensor::CutensorHandle::load()?;
+        let _ = self.cutensor.set(handle);
+        self.cutensor.get().ok_or_else(|| {
+            crate::Error::backend_failure(
+                "dot_general",
+                "cuTENSOR handle initialization completed without a stored handle",
+            )
+        })
     }
 
     #[doc(hidden)]
@@ -733,12 +735,8 @@ impl CudaBackend {
             )
         })?;
         let handle = self.runtime().client().empty(bytes);
-        let shape = R::shape_from_vec(shape.to_vec().into()).map_err(|err| {
-            crate::Error::InvalidConfig {
-                op,
-                message: format!("output rank mismatch: {err}"),
-            }
-        })?;
+        let shape = R::shape_from_vec(shape.to_vec().into())
+            .map_err(|err| crate::Error::invalid_argument(op, "shape", err.to_string()))?;
         Ok(TypedTensor::from_buffer_col_major(
             shape,
             Buffer::Backend(Arc::new(crate::CubeclBuffer::new(handle, len))),
@@ -804,11 +802,11 @@ impl CudaBackend {
         ensure_view_resident_on_runtime(self.runtime(), src, op)?;
         ensure_view_mut_resident_on_runtime(self.runtime(), dst, op)?;
         if src.shape() != dst.shape() {
-            return Err(crate::Error::ShapeMismatch {
+            return Err(crate::Error::shape_mismatch(
                 op,
-                lhs: src.shape().to_vec(),
-                rhs: dst.shape().to_vec(),
-            });
+                src.shape().to_vec(),
+                dst.shape().to_vec(),
+            ));
         }
         let source_buffer = src.backend_buffer().ok_or_else(|| {
             crate::Error::backend_failure(
@@ -823,28 +821,24 @@ impl CudaBackend {
             )
         })?;
         if Arc::ptr_eq(source_buffer, destination_buffer) {
-            return Err(crate::Error::InvalidConfig {
+            return Err(crate::Error::invalid_argument(
                 op,
-                message: "CUDA copy_into source and destination allocations must not alias"
-                    .to_string(),
-            });
+                "source/destination",
+                "CUDA copy_into source and destination allocations must not alias",
+            ));
         }
         if !src.is_col_major_contiguous()?
             || src.offset() != 0
             || source_buffer.len() != src.n_elements()
         {
-            return Err(crate::Error::InvalidConfig {
+            return Err(crate::Error::invalid_argument(
                 op,
-                message: "CUDA copy_into requires a compact source view covering its full allocation; arbitrary-stride source views are unsupported without explicit canonicalization"
-                    .to_string(),
-            });
+                "source",
+                "CUDA copy_into requires a compact source view covering its full allocation; arbitrary-stride source views are unsupported without explicit canonicalization",
+            ));
         }
-        let source_shape = R::shape_from_vec(src.shape().to_vec().into()).map_err(|err| {
-            crate::Error::InvalidConfig {
-                op,
-                message: format!("source rank mismatch: {err}"),
-            }
-        })?;
+        let source_shape = R::shape_from_vec(src.shape().to_vec().into())
+            .map_err(|err| crate::Error::invalid_argument(op, "source shape", err.to_string()))?;
         let source_tensor: TypedTensor<T, R> = TypedTensor::from_buffer_col_major(
             source_shape,
             Buffer::Backend(Arc::clone(source_buffer)),
@@ -1539,11 +1533,7 @@ impl CudaBackend {
         T: CubeElement + CubePrimitive + Clone,
     {
         if input.shape().len() < 2 {
-            return Err(crate::Error::RankMismatch {
-                op: "tril",
-                expected: 2,
-                actual: input.shape().len(),
-            });
+            return Err(crate::Error::rank_mismatch("tril", 2, input.shape().len()));
         }
         launch_unary_tensor(
             self.runtime(),
@@ -1565,11 +1555,7 @@ impl CudaBackend {
 
     fn tril_bool(&self, input: &TypedTensor<bool>, k: i64) -> crate::Result<TypedTensor<bool>> {
         if input.shape().len() < 2 {
-            return Err(crate::Error::RankMismatch {
-                op: "tril",
-                expected: 2,
-                actual: input.shape().len(),
-            });
+            return Err(crate::Error::rank_mismatch("tril", 2, input.shape().len()));
         }
         launch_unary_bool_tensor(
             self.runtime(),
@@ -1595,11 +1581,7 @@ impl CudaBackend {
         T: CubeElement + CubePrimitive + Clone,
     {
         if input.shape().len() < 2 {
-            return Err(crate::Error::RankMismatch {
-                op: "triu",
-                expected: 2,
-                actual: input.shape().len(),
-            });
+            return Err(crate::Error::rank_mismatch("triu", 2, input.shape().len()));
         }
         launch_unary_tensor(
             self.runtime(),
@@ -1621,11 +1603,7 @@ impl CudaBackend {
 
     fn triu_bool(&self, input: &TypedTensor<bool>, k: i64) -> crate::Result<TypedTensor<bool>> {
         if input.shape().len() < 2 {
-            return Err(crate::Error::RankMismatch {
-                op: "triu",
-                expected: 2,
-                actual: input.shape().len(),
-            });
+            return Err(crate::Error::rank_mismatch("triu", 2, input.shape().len()));
         }
         launch_unary_bool_tensor(
             self.runtime(),
@@ -1986,18 +1964,19 @@ impl CudaBackend {
         ensure_rank("dynamic_slice", input.shape().len(), slice_sizes.len())?;
         ensure_rank("dynamic_slice", 1, starts.shape().len())?;
         if starts.shape()[0] != input.shape().len() {
-            return Err(crate::Error::RankMismatch {
-                op: "dynamic_slice",
-                expected: input.shape().len(),
-                actual: starts.shape()[0],
-            });
+            return Err(crate::Error::rank_mismatch(
+                "dynamic_slice",
+                input.shape().len(),
+                starts.shape()[0],
+            ));
         }
         for (axis, (&window, &dim)) in slice_sizes.iter().zip(input.shape()).enumerate() {
             if window > dim {
-                return Err(crate::Error::InvalidConfig {
-                    op: "dynamic_slice",
-                    message: format!("slice size exceeds dimension on axis {axis}"),
-                });
+                return Err(crate::Error::invalid_argument(
+                    "dynamic_slice",
+                    "slice_sizes",
+                    format!("slice size exceeds dimension on axis {axis}"),
+                ));
             }
         }
         let output_len = checked_dim_product("dynamic_slice", "output shape", slice_sizes)?;
@@ -2040,27 +2019,30 @@ impl CudaBackend {
     {
         ensure_rank("dynamic_slice", input.shape().len(), slice_sizes.len())?;
         if starts.shape().len() != 1 {
-            return Err(crate::Error::InvalidConfig {
-                op: "dynamic_slice",
-                message: "starts must be a rank-1 tensor".into(),
-            });
+            return Err(crate::Error::invalid_argument(
+                "dynamic_slice",
+                "starts",
+                "starts must be a rank-1 tensor",
+            ));
         }
         if starts.shape()[0] != input.shape().len() {
-            return Err(crate::Error::InvalidConfig {
-                op: "dynamic_slice",
-                message: format!(
+            return Err(crate::Error::invalid_argument(
+                "dynamic_slice",
+                "starts",
+                format!(
                     "starts length {} must match input rank {}",
                     starts.shape()[0],
                     input.shape().len()
                 ),
-            });
+            ));
         }
         for (axis, (&window, &dim)) in slice_sizes.iter().zip(input.shape()).enumerate() {
             if window > dim {
-                return Err(crate::Error::InvalidConfig {
-                    op: "dynamic_slice",
-                    message: format!("slice size exceeds dimension on axis {axis}"),
-                });
+                return Err(crate::Error::invalid_argument(
+                    "dynamic_slice",
+                    "slice_sizes",
+                    format!("slice size exceeds dimension on axis {axis}"),
+                ));
             }
         }
         let output_len = checked_dim_product("dynamic_slice", "output shape", slice_sizes)?;
@@ -2600,10 +2582,7 @@ macro_rules! impl_cuda_cast_float {
                         self.cpu_real_display()
                     )
                 };
-                crate::Error::InvalidConfig {
-                    op: "cast",
-                    message,
-                }
+                crate::Error::invalid_argument("cast", "value", message)
             }
             fn is_nonfinite(self) -> bool {
                 !self.is_finite()
@@ -2700,10 +2679,8 @@ fn checked_integer_domain_error(
     dtype: crate::DType,
 ) -> crate::Error {
     match domain {
-        CheckedIntegerDomain::DivisionByZero => crate::Error::division_by_zero(op, dtype),
-        CheckedIntegerDomain::NegativeExponent => {
-            crate::Error::negative_integer_exponent(op, dtype)
-        }
+        CheckedIntegerDomain::DivisionByZero => error::division_by_zero(op, dtype),
+        CheckedIntegerDomain::NegativeExponent => error::negative_integer_exponent(op, dtype),
     }
 }
 
@@ -2874,10 +2851,11 @@ where
     }
     let invalid = F::read_invalid_flag(backend, &flag)?;
     if invalid.is_invalid_index() {
-        return Err(crate::Error::InvalidConfig {
-            op: "index_tensor",
-            message: format!("index value {invalid} is not an exactly representable i64"),
-        });
+        return Err(crate::Error::invalid_argument(
+            "index_tensor",
+            "index",
+            format!("index value {invalid} is not an exactly representable i64"),
+        ));
     }
     Ok(())
 }
@@ -2964,11 +2942,11 @@ where
     I: CubeElement + CubePrimitive + Clone + Send + Sync + 'static,
 {
     if !(lhs.shape().is_empty() ^ rhs.shape().is_empty()) {
-        return Err(crate::Error::ShapeMismatch {
+        return Err(crate::Error::shape_mismatch(
             op,
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        });
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ));
     }
     ensure_resident_on_runtime(backend.runtime(), lhs, op)?;
     ensure_resident_on_runtime(backend.runtime(), rhs, op)?;
@@ -3007,19 +2985,19 @@ where
     C: CubeComplex<FloatElem = R> + CubeElement + CubePrimitive + Clone + Send + Sync + 'static,
 {
     if !real.shape().is_empty() {
-        return Err(crate::Error::ShapeMismatch {
+        return Err(crate::Error::shape_mismatch(
             op,
-            lhs: if real_lhs {
+            if real_lhs {
                 real.shape().to_vec()
             } else {
                 complex.shape().to_vec()
             },
-            rhs: if real_lhs {
+            if real_lhs {
                 complex.shape().to_vec()
             } else {
                 real.shape().to_vec()
             },
-        });
+        ));
     }
     ensure_resident_on_runtime(backend.runtime(), real, op)?;
     ensure_resident_on_runtime(backend.runtime(), complex, op)?;
@@ -3103,11 +3081,11 @@ where
     I: CubeElement + CubePrimitive + Clone + Send + Sync + 'static,
 {
     if !(lhs.shape().is_empty() ^ rhs.shape().is_empty()) {
-        return Err(crate::Error::ShapeMismatch {
+        return Err(crate::Error::shape_mismatch(
             op,
-            lhs: lhs.shape().to_vec(),
-            rhs: rhs.shape().to_vec(),
-        });
+            lhs.shape().to_vec(),
+            rhs.shape().to_vec(),
+        ));
     }
     ensure_resident_on_runtime(backend.runtime(), lhs, op)?;
     ensure_resident_on_runtime(backend.runtime(), rhs, op)?;
@@ -3547,11 +3525,7 @@ impl TensorElementwise for CudaBackend {
             )
             .map(Tensor::I64),
             (Tensor::C32(_), Tensor::C32(_)) | (Tensor::C64(_), Tensor::C64(_)) => {
-                Err(crate::Error::unsupported_op_dtype(
-                    op,
-                    lhs.dtype(),
-                    tenferro_tensor::BackendId::Cuda,
-                ))
+                Err(unsupported_dtype(op, lhs.dtype()))
             }
             _ => Err(dtype_mismatch(op, lhs, rhs)),
         }
@@ -3601,11 +3575,7 @@ impl TensorElementwise for CudaBackend {
                 },
             )
             .map(Tensor::F64),
-            Tensor::Bool(_) => Err(crate::Error::unsupported_op_dtype(
-                op,
-                input.dtype(),
-                tenferro_tensor::BackendId::Cuda,
-            )),
+            Tensor::Bool(_) => Err(unsupported_dtype(op, input.dtype())),
         }
     }
 
@@ -4016,19 +3986,11 @@ impl TensorAnalytic for CudaBackend {
             .map(Tensor::I64),
             (Tensor::C32(lhs), Tensor::C32(rhs)) => {
                 dispatch::ensure_same_shape(op, lhs.shape(), rhs.shape())?;
-                Err(crate::Error::unsupported_op_dtype(
-                    op,
-                    crate::DType::C32,
-                    tenferro_tensor::BackendId::Cuda,
-                ))
+                Err(unsupported_dtype(op, crate::DType::C32))
             }
             (Tensor::C64(lhs), Tensor::C64(rhs)) => {
                 dispatch::ensure_same_shape(op, lhs.shape(), rhs.shape())?;
-                Err(crate::Error::unsupported_op_dtype(
-                    op,
-                    crate::DType::C64,
-                    tenferro_tensor::BackendId::Cuda,
-                ))
+                Err(unsupported_dtype(op, crate::DType::C64))
             }
             _ => {
                 dispatch::ensure_same_shape(op, lhs.shape(), rhs.shape())?;
@@ -4094,11 +4056,11 @@ impl TensorStructural for CudaBackend {
                     TensorWrite::View(TensorViewMut::$variant(mut dst)) => {
                         self.copy_view_to_view_typed(&src, &mut dst, "CudaBackend::copy_read_into")
                     }
-                    _ => Err(crate::Error::DTypeMismatch {
-                        op: "CudaBackend::copy_read_into",
-                        lhs: src_dtype,
-                        rhs: dst_dtype,
-                    }),
+                    _ => Err(crate::Error::dtype_mismatch(
+                        "CudaBackend::copy_read_into",
+                        src_dtype,
+                        dst_dtype,
+                    )),
                 }
             }};
         }
@@ -4110,11 +4072,11 @@ impl TensorStructural for CudaBackend {
                         "CudaBackend::copy_read_into",
                         crate::DType::Bool,
                     )),
-                    _ => Err(crate::Error::DTypeMismatch {
-                        op: "CudaBackend::copy_read_into",
-                        lhs: src_dtype,
-                        rhs: dst_dtype,
-                    }),
+                    _ => Err(crate::Error::dtype_mismatch(
+                        "CudaBackend::copy_read_into",
+                        src_dtype,
+                        dst_dtype,
+                    )),
                 }
             }};
         }
@@ -4153,11 +4115,14 @@ impl TensorStructural for CudaBackend {
         let old_n = checked_dim_product("reshape", "input shape", input.shape())?;
         let new_n = checked_dim_product("reshape", "output shape", shape)?;
         if old_n != new_n {
-            return Err(crate::Error::ShapeMismatch {
-                op: "reshape",
-                lhs: input.shape().to_vec(),
-                rhs: shape.to_vec(),
-            });
+            return Err(crate::Error::validation(
+                "reshape",
+                tenferro_tensor::ShapeMismatch::ReshapeElementCount {
+                    from: old_n,
+                    to: new_n,
+                }
+                .into(),
+            ));
         }
         match input {
             Tensor::F32(t) => Ok(Tensor::F32(TypedTensor::from_buffer_col_major(
@@ -4839,13 +4804,13 @@ impl TensorIndexing for CudaBackend {
     }
 
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
-        let first = inputs
-            .first()
-            .copied()
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "concatenate",
-                message: "concatenate requires at least one input".into(),
-            })?;
+        let first = inputs.first().copied().ok_or_else(|| {
+            crate::Error::invalid_argument(
+                "concatenate",
+                "inputs",
+                "concatenate requires at least one input",
+            )
+        })?;
         match first {
             Tensor::F32(_) => {
                 let typed: crate::Result<Vec<&TypedTensor<f32>>> = inputs
@@ -5073,11 +5038,11 @@ fn ensure_same_shape_for_broadcast_multiply(
     rhs_shape: &[usize],
 ) -> crate::Result<()> {
     if lhs_shape != rhs_shape {
-        return Err(crate::Error::ShapeMismatch {
-            op: "broadcast_multiply",
-            lhs: lhs_shape.to_vec(),
-            rhs: rhs_shape.to_vec(),
-        });
+        return Err(crate::Error::shape_mismatch(
+            "broadcast_multiply",
+            lhs_shape.to_vec(),
+            rhs_shape.to_vec(),
+        ));
     }
     Ok(())
 }
@@ -5203,21 +5168,21 @@ fn validate_broadcast_in_dim(
     for (src_axis, &dst_axis) in dims.iter().enumerate() {
         ensure_axis("broadcast_in_dim", dst_axis, shape.len())?;
         if seen[dst_axis] {
-            return Err(crate::Error::DuplicateAxis {
-                op: "broadcast_in_dim",
-                axis: dst_axis,
-                role: "dims",
-            });
+            return Err(crate::Error::duplicate_axis(
+                "broadcast_in_dim",
+                dst_axis,
+                "dims",
+            ));
         }
         seen[dst_axis] = true;
         let src = input_shape[src_axis];
         let dst = shape[dst_axis];
         if src != dst && src != 1 {
-            return Err(crate::Error::ShapeMismatch {
-                op: "broadcast_in_dim",
-                lhs: input_shape.to_vec(),
-                rhs: shape.to_vec(),
-            });
+            return Err(crate::Error::shape_mismatch(
+                "broadcast_in_dim",
+                input_shape.to_vec(),
+                shape.to_vec(),
+            ));
         }
     }
     Ok(())
@@ -5231,11 +5196,11 @@ fn extract_diagonal_shape(
     ensure_axis("extract_diagonal", axis_a, input_shape.len())?;
     ensure_axis("extract_diagonal", axis_b, input_shape.len())?;
     if axis_a == axis_b {
-        return Err(crate::Error::DuplicateAxis {
-            op: "extract_diagonal",
-            axis: axis_a,
-            role: "axes",
-        });
+        return Err(crate::Error::duplicate_axis(
+            "extract_diagonal",
+            axis_a,
+            "axes",
+        ));
     }
     let diag_output_axis = if axis_a < axis_b { axis_a } else { axis_a - 1 };
     let diag_dim = input_shape[axis_a].min(input_shape[axis_b]);
@@ -5252,11 +5217,11 @@ fn embed_diagonal_shape(
 ) -> crate::Result<Vec<usize>> {
     ensure_axis("embed_diagonal", axis_a, input_shape.len())?;
     if axis_b > input_shape.len() {
-        return Err(crate::Error::AxisOutOfBounds {
-            op: "embed_diagonal",
-            axis: axis_b,
-            rank: input_shape.len(),
-        });
+        return Err(crate::Error::axis_out_of_bounds(
+            "embed_diagonal",
+            axis_b,
+            input_shape.len(),
+        ));
     }
     let mut output_shape = input_shape.to_vec();
     output_shape.insert(axis_b, input_shape[axis_a]);
@@ -5286,17 +5251,22 @@ fn cubecl_reshape_metadata<T: CubeElement + Clone>(
         .iter()
         .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
         .ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::invalid_argument(
                 op,
+                "shape",
                 format!("shape product overflow for CubeCL reshape shape {shape:?}"),
             )
         })?;
     let tensor_len = tensor.n_elements();
     if len != tensor_len {
-        return Err(crate::Error::backend_failure(op, format!(
-                "cannot reshape CubeCL output metadata from {:?} ({tensor_len} elements) to {:?} ({len} elements)",
-                tensor.shape(), shape
-            )));
+        return Err(crate::Error::validation(
+            op,
+            tenferro_tensor::ShapeMismatch::ReshapeElementCount {
+                from: tensor_len,
+                to: len,
+            }
+            .into(),
+        ));
     }
 
     let (buffer, _, placement) = tensor.into_parts();
@@ -5318,23 +5288,21 @@ fn validate_slice(input_shape: &[usize], config: &SliceConfig) -> crate::Result<
             let limit = config.limits[axis];
             let stride = config.strides[axis];
             if start > limit {
-                return Err(crate::Error::InvalidConfig {
-                    op: "slice",
-                    message: format!("start exceeds limit on axis {axis}"),
-                });
+                return Err(crate::Error::invalid_argument(
+                    "slice",
+                    "bounds",
+                    format!("start exceeds limit on axis {axis}"),
+                ));
             }
             if limit > dim {
-                return Err(crate::Error::AxisOutOfBounds {
-                    op: "slice",
-                    axis,
-                    rank,
-                });
+                return Err(crate::Error::axis_out_of_bounds("slice", axis, rank));
             }
             if stride == 0 {
-                return Err(crate::Error::InvalidConfig {
-                    op: "slice",
-                    message: format!("stride must be positive on axis {axis}"),
-                });
+                return Err(crate::Error::invalid_argument(
+                    "slice",
+                    "strides",
+                    format!("stride must be positive on axis {axis}"),
+                ));
             }
             let span = limit - start;
             Ok(span.div_ceil(stride))
@@ -5350,47 +5318,60 @@ fn pad_output_shape(input_shape: &[usize], config: &PadConfig) -> crate::Result<
     let mut out_shape = Vec::with_capacity(rank);
     for axis in 0..rank {
         if config.interior_padding[axis] < 0 {
-            return Err(crate::Error::InvalidConfig {
-                op: "pad",
-                message: format!("interior padding must be non-negative on axis {axis}"),
-            });
+            return Err(crate::Error::invalid_argument(
+                "pad",
+                "interior_padding",
+                format!("interior padding must be non-negative on axis {axis}"),
+            ));
         }
-        let input_dim =
-            i64::try_from(input_shape[axis]).map_err(|_| crate::Error::InvalidConfig {
-                op: "pad",
-                message: format!("input dimension on axis {axis} must fit in i64"),
-            })?;
+        let input_dim = i64::try_from(input_shape[axis]).map_err(|_| {
+            crate::Error::invalid_argument(
+                "pad",
+                "input_shape",
+                format!("input dimension on axis {axis} must fit in i64"),
+            )
+        })?;
         let base = if input_dim == 0 {
             0
         } else {
             let spacing = config.interior_padding[axis]
                 .checked_add(1)
-                .ok_or_else(|| crate::Error::InvalidConfig {
-                    op: "pad",
-                    message: format!("interior padding overflow on axis {axis}"),
+                .ok_or_else(|| {
+                    crate::Error::invalid_argument(
+                        "pad",
+                        "interior_padding",
+                        format!("interior padding overflow on axis {axis}"),
+                    )
                 })?;
             input_dim
                 .checked_sub(1)
                 .and_then(|extent| extent.checked_mul(spacing))
                 .and_then(|extent| extent.checked_add(1))
-                .ok_or_else(|| crate::Error::InvalidConfig {
-                    op: "pad",
-                    message: format!("padded interior extent overflow on axis {axis}"),
+                .ok_or_else(|| {
+                    crate::Error::invalid_argument(
+                        "pad",
+                        "interior_padding",
+                        format!("padded interior extent overflow on axis {axis}"),
+                    )
                 })?
         };
         let dim = config.edge_padding_low[axis]
             .checked_add(config.edge_padding_high[axis])
             .and_then(|edge| edge.checked_add(base))
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "pad",
-                message: format!("output dimension overflow on axis {axis}"),
+            .ok_or_else(|| {
+                crate::Error::invalid_argument(
+                    "pad",
+                    "padding",
+                    format!("output dimension overflow on axis {axis}"),
+                )
             })?;
-        out_shape.push(
-            usize::try_from(dim).map_err(|_| crate::Error::InvalidConfig {
-                op: "pad",
-                message: format!("negative output dimension on axis {axis}"),
-            })?,
-        );
+        out_shape.push(usize::try_from(dim).map_err(|_| {
+            crate::Error::invalid_argument(
+                "pad",
+                "padding",
+                format!("negative output dimension on axis {axis}"),
+            )
+        })?);
     }
     Ok(out_shape)
 }
@@ -5403,12 +5384,11 @@ fn validate_slice_sizes_within_operand(
     ensure_rank(op, operand_shape.len(), slice_sizes.len())?;
     for (axis, (&slice_size, &dim_size)) in slice_sizes.iter().zip(operand_shape).enumerate() {
         if slice_size > dim_size {
-            return Err(crate::Error::InvalidConfig {
+            return Err(crate::Error::invalid_argument(
                 op,
-                message: format!(
-                    "slice_sizes[{axis}]={slice_size} exceeds operand dimension {dim_size}"
-                ),
-            });
+                "slice_sizes",
+                format!("slice_sizes[{axis}]={slice_size} exceeds operand dimension {dim_size}"),
+            ));
         }
     }
     Ok(())
@@ -5453,18 +5433,19 @@ fn gather_launch_meta(
     ensure_rank("gather", operand_shape.len(), config.slice_sizes.len())?;
     validate_slice_sizes_within_operand("gather", operand_shape, &config.slice_sizes)?;
     if config.index_vector_dim > start_indices_shape.len() {
-        return Err(crate::Error::AxisOutOfBounds {
-            op: "gather",
-            axis: config.index_vector_dim,
-            rank: start_indices_shape.len(),
-        });
+        return Err(crate::Error::axis_out_of_bounds(
+            "gather",
+            config.index_vector_dim,
+            start_indices_shape.len(),
+        ));
     }
     let index_size = index_vector_size(start_indices_shape, config.index_vector_dim);
     if index_size != config.start_index_map.len() {
-        return Err(crate::Error::InvalidConfig {
-            op: "gather",
-            message: "start_index_map length mismatch".into(),
-        });
+        return Err(crate::Error::invalid_argument(
+            "gather",
+            "start_index_map",
+            "start_index_map length mismatch",
+        ));
     }
     ensure_axes_unique(
         "gather",
@@ -5474,13 +5455,14 @@ fn gather_launch_meta(
     )?;
     for &dim in &config.collapsed_slice_dims {
         if config.slice_sizes[dim] != 1 {
-            return Err(crate::Error::InvalidConfig {
-                op: "gather",
-                message: format!(
+            return Err(crate::Error::invalid_argument(
+                "gather",
+                "collapsed_slice_dims",
+                format!(
                     "collapsed slice dimension {dim} must have slice_size == 1, got {}",
                     config.slice_sizes[dim]
                 ),
-            });
+            ));
         }
     }
     ensure_axes_unique(
@@ -5491,10 +5473,11 @@ fn gather_launch_meta(
     )?;
     let window_dims = operand_window_dims(operand_shape.len(), &config.collapsed_slice_dims);
     if config.offset_dims.len() != window_dims.len() {
-        return Err(crate::Error::InvalidConfig {
-            op: "gather",
-            message: "offset_dims length mismatch".into(),
-        });
+        return Err(crate::Error::invalid_argument(
+            "gather",
+            "offset_dims",
+            "offset_dims length mismatch",
+        ));
     }
     let batch_shape = index_batch_shape(start_indices_shape, config.index_vector_dim);
     let out_rank = batch_shape.len() + config.offset_dims.len();
@@ -5533,18 +5516,19 @@ fn scatter_launch_meta(
     config: &ScatterConfig,
 ) -> crate::Result<ScatterLaunchMeta> {
     if config.index_vector_dim > scatter_indices_shape.len() {
-        return Err(crate::Error::AxisOutOfBounds {
-            op: "scatter",
-            axis: config.index_vector_dim,
-            rank: scatter_indices_shape.len(),
-        });
+        return Err(crate::Error::axis_out_of_bounds(
+            "scatter",
+            config.index_vector_dim,
+            scatter_indices_shape.len(),
+        ));
     }
     let index_size = index_vector_size(scatter_indices_shape, config.index_vector_dim);
     if index_size != config.scatter_dims_to_operand_dims.len() {
-        return Err(crate::Error::InvalidConfig {
-            op: "scatter",
-            message: "scatter_dims_to_operand_dims length mismatch".into(),
-        });
+        return Err(crate::Error::invalid_argument(
+            "scatter",
+            "scatter_dims_to_operand_dims",
+            "scatter_dims_to_operand_dims length mismatch",
+        ));
     }
     ensure_axes_unique(
         "scatter",
@@ -5567,16 +5551,19 @@ fn scatter_launch_meta(
     let batch_shape = index_batch_shape(scatter_indices_shape, config.index_vector_dim);
     let window_dims = operand_window_dims(operand_shape.len(), &config.inserted_window_dims);
     if config.update_window_dims.len() != window_dims.len() {
-        return Err(crate::Error::InvalidConfig {
-            op: "scatter",
-            message: "update_window_dims length mismatch".into(),
-        });
+        return Err(crate::Error::invalid_argument(
+            "scatter",
+            "update_window_dims",
+            "update_window_dims length mismatch",
+        ));
     }
-    if updates_shape.len() - config.update_window_dims.len() != batch_shape.len() {
-        return Err(crate::Error::InvalidConfig {
-            op: "scatter",
-            message: "updates batch rank mismatch".into(),
-        });
+    let updates_batch_rank = updates_shape.len() - config.update_window_dims.len();
+    if updates_batch_rank != batch_shape.len() {
+        return Err(crate::Error::rank_mismatch(
+            "scatter",
+            batch_shape.len(),
+            updates_batch_rank,
+        ));
     }
     let mut is_update_window_dim = vec![false; updates_shape.len()];
     for &axis in &config.update_window_dims {
@@ -5589,13 +5576,11 @@ fn scatter_launch_meta(
         }
         let expected = batch_shape[batch_axis];
         if actual != expected {
-            return Err(crate::Error::InvalidConfig {
-                op: "scatter",
-                message: format!(
-                    "updates batch dim {batch_axis} extent {actual} does not match \
-                     scatter batch extent {expected}"
-                ),
-            });
+            return Err(crate::Error::shape_mismatch(
+                "scatter",
+                vec![expected],
+                vec![actual],
+            ));
         }
         batch_axis += 1;
     }
@@ -5631,11 +5616,11 @@ fn concatenate_output_shape<T>(
                     )
                 })?;
             } else if input.shape()[dim] != first.shape()[dim] {
-                return Err(crate::Error::ShapeMismatch {
-                    op: "concatenate",
-                    lhs: first.shape().to_vec(),
-                    rhs: input.shape().to_vec(),
-                });
+                return Err(crate::Error::shape_mismatch(
+                    "concatenate",
+                    first.shape().to_vec(),
+                    input.shape().to_vec(),
+                ));
             }
         }
     }

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -568,6 +568,7 @@ impl CudaBackend {
     }
 
     /// Clear CUDA extension-owned backend state.
+    ///
     /// # Errors
     ///
     /// Returns [`crate::Error::RuntimeState`] if the extension cache mutex is
@@ -577,6 +578,7 @@ impl CudaBackend {
     }
 
     /// Return CUDA extension cache stats.
+    ///
     /// # Errors
     ///
     /// Returns [`crate::Error::RuntimeState`] if the extension cache mutex is
@@ -586,6 +588,7 @@ impl CudaBackend {
     }
 
     /// Return the CUDA extension cache entry bound.
+    ///
     /// # Errors
     ///
     /// Returns [`crate::Error::RuntimeState`] if the extension cache mutex is
@@ -595,6 +598,7 @@ impl CudaBackend {
     }
 
     /// Configure the CUDA extension cache entry bound.
+    ///
     /// # Errors
     ///
     /// Returns [`crate::Error::RuntimeState`] if the extension cache mutex is

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -136,7 +136,7 @@ use dispatch::{
     ternary_dtype_mismatch, typed_tensor_array_arg, typed_tensor_array_arg_as,
     typed_tensor_binding, typed_view_array_arg, typed_view_mut_array_arg,
 };
-use error::{unsupported_dtype, unsupported_operation};
+use error::{unexpected_validation_flag_dtype, unsupported_dtype, unsupported_operation};
 
 pub use capability::cuda_capabilities;
 pub use memory::{device_ptr, download_tensor, upload_tensor};
@@ -343,10 +343,11 @@ impl CudaExtensionCache {
     /// assert!(cache.is_empty()?);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    /// # Errors
     ///
-    /// This constructor is infallible; later cache operations return
-    /// [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
+    /// The cache retains at most 16 extension states by default. Use
+    /// [`Self::with_max_entries`] to choose a different bound. Later cache
+    /// operations return [`crate::Error::RuntimeState`] if the cache mutex is
+    /// poisoned.
     pub fn new() -> Self {
         let max_entries = NonZeroUsize::new(DEFAULT_CUDA_EXTENSION_CACHE_MAX_ENTRIES)
             .unwrap_or(NonZeroUsize::MIN);
@@ -378,6 +379,10 @@ impl CudaExtensionCache {
     }
 
     /// Remove every cached CUDA extension state value.
+    ///
+    /// This operation returns a runtime-state error if the cache mutex is
+    /// poisoned.
+    ///
     /// # Errors
     ///
     /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
@@ -2622,6 +2627,7 @@ macro_rules! impl_cuda_cast_float {
                 }
             }
             fn read_flag(backend: &CudaBackend, flag: &TypedTensor<Self>) -> crate::Result<Self> {
+                let expected = Tensor::$variant(flag.clone()).dtype();
                 match download_tensor(backend.runtime(), &Tensor::$variant(flag.clone()))? {
                     Tensor::$variant(host) => host.as_slice()?.get(1).copied().ok_or_else(|| {
                         crate::Error::invalid_argument(
@@ -2630,8 +2636,10 @@ macro_rules! impl_cuda_cast_float {
                             "validation flag was malformed",
                         )
                     }),
-                    _ => Err(crate::Error::Internal(
-                        "cast validation flag had unexpected dtype".to_string(),
+                    other => Err(unexpected_validation_flag_dtype(
+                        "cast",
+                        expected,
+                        other.dtype(),
                     )),
                 }
             }
@@ -2759,12 +2767,18 @@ fn checked_integer_domain_error(
     }
 }
 
-fn read_checked_integer_flag(backend: &CudaBackend, flag: &TypedTensor<i32>) -> crate::Result<i32> {
+fn read_checked_integer_flag(
+    backend: &CudaBackend,
+    flag: &TypedTensor<i32>,
+    op: &'static str,
+) -> crate::Result<i32> {
     let host = download_tensor(backend.runtime(), &Tensor::I32(flag.clone()))?;
     match host {
         Tensor::I32(flag) => Ok(flag.as_slice()?.first().copied().unwrap_or_default()),
-        _ => Err(crate::Error::Internal(
-            "integer domain flag download returned unexpected dtype".to_string(),
+        other => Err(unexpected_validation_flag_dtype(
+            op,
+            crate::DType::I32,
+            other.dtype(),
         )),
     }
 }
@@ -2821,6 +2835,7 @@ impl CudaFloatIndex for f32 {
     }
 
     fn read_invalid_flag(backend: &CudaBackend, flag: &TypedTensor<Self>) -> crate::Result<Self> {
+        let expected = Tensor::F32(flag.clone()).dtype();
         match download_tensor(backend.runtime(), &Tensor::F32(flag.clone()))? {
             Tensor::F32(host) => host.as_slice()?.get(1).copied().ok_or_else(|| {
                 crate::Error::invalid_argument(
@@ -2829,8 +2844,10 @@ impl CudaFloatIndex for f32 {
                     "validation flag was malformed",
                 )
             }),
-            _ => Err(crate::Error::Internal(
-                "index_tensor validation flag had unexpected dtype".to_string(),
+            other => Err(unexpected_validation_flag_dtype(
+                "index_tensor",
+                expected,
+                other.dtype(),
             )),
         }
     }
@@ -2844,6 +2861,7 @@ impl CudaFloatIndex for f64 {
     }
 
     fn read_invalid_flag(backend: &CudaBackend, flag: &TypedTensor<Self>) -> crate::Result<Self> {
+        let expected = Tensor::F64(flag.clone()).dtype();
         match download_tensor(backend.runtime(), &Tensor::F64(flag.clone()))? {
             Tensor::F64(host) => host.as_slice()?.get(1).copied().ok_or_else(|| {
                 crate::Error::invalid_argument(
@@ -2852,8 +2870,10 @@ impl CudaFloatIndex for f64 {
                     "validation flag was malformed",
                 )
             }),
-            _ => Err(crate::Error::Internal(
-                "index_tensor validation flag had unexpected dtype".to_string(),
+            other => Err(unexpected_validation_flag_dtype(
+                "index_tensor",
+                expected,
+                other.dtype(),
             )),
         }
     }
@@ -2996,7 +3016,7 @@ where
         flag_arg,
     );
 
-    if read_checked_integer_flag(backend, &flag)? != 0 {
+    if read_checked_integer_flag(backend, &flag, op)? != 0 {
         return Err(checked_integer_domain_error(domain, op, dtype));
     }
     Ok(output)
@@ -3202,7 +3222,7 @@ where
         flag_arg,
         lhs_scalar,
     );
-    if read_checked_integer_flag(backend, &flag)? != 0 {
+    if read_checked_integer_flag(backend, &flag, op)? != 0 {
         return Err(checked_integer_domain_error(domain, op, dtype));
     }
     Ok(output)

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -4759,7 +4759,10 @@ impl TensorIndexing for CudaBackend {
             (_, Tensor::C32(_) | Tensor::C64(_), _) => {
                 Err(unsupported_dtype("scatter", scatter_indices.dtype()))
             }
-            (Tensor::Bool(_), _, _) => Err(unsupported_dtype("scatter", operand.dtype())),
+            (Tensor::Bool(_), _, Tensor::Bool(_)) => Err(unsupported_operation(
+                "scatter",
+                "Bool data tensors are not supported by additive scatter",
+            )),
             (Tensor::I32(_), _, _) | (Tensor::I64(_), _, _) => {
                 Err(unsupported_dtype("scatter", operand.dtype()))
             }

--- a/crates/tenferro-gpu/src/cubecl/op_descriptor.rs
+++ b/crates/tenferro-gpu/src/cubecl/op_descriptor.rs
@@ -70,7 +70,7 @@ pub(crate) fn require_gpu_descriptor(
     expected: GpuLaunchKind,
 ) -> crate::Result<GpuOpDescriptor> {
     let descriptor = gpu_descriptor(kind).ok_or_else(|| {
-        crate::Error::backend_failure(
+        crate::Error::unsupported(
             "gpu_dispatch",
             format!("primitive {kind:?} is not implemented by CubeCL dispatch"),
         )

--- a/crates/tenferro-gpu/src/cubecl/runtime.rs
+++ b/crates/tenferro-gpu/src/cubecl/runtime.rs
@@ -58,12 +58,7 @@ struct CudaPrimaryContext {
 impl CudaPrimaryContext {
     fn retain(cuda_device: CUdevice) -> crate::Result<Self> {
         let cuda_context = unsafe { cudarc::driver::result::primary_ctx::retain(cuda_device) }
-            .map_err(|err| {
-                crate::Error::backend_failure(
-                    "cubecl_runtime_init",
-                    format!("failed to retain CUDA primary context: {err:?}"),
-                )
-            })?;
+            .map_err(|err| crate::Error::backend_source("cubecl_runtime_init", err))?;
         Ok(Self {
             cuda_device,
             cuda_context,
@@ -104,37 +99,24 @@ impl CudaRuntime {
     ///
     /// let _ctor: fn(usize) -> tenferro_tensor::Result<CudaRuntime> = CudaRuntime::new;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::BackendSource`] when CUDA device selection,
+    /// driver initialization, primary-context retention, or CubeCL client
+    /// creation fails.
     pub fn new(device_ordinal: usize) -> crate::Result<Self> {
         // INVARIANT: CUDA ordinals are device identifiers, not tensor extents;
         // an unrepresentable ordinal becomes a CUDA invalid-device error.
-        cudarc::runtime::result::device::set(device_ordinal as i32).map_err(|err| {
-            crate::Error::backend_failure(
-                "cubecl_runtime_init",
-                format!("failed to set CUDA runtime device: {err:?}"),
-            )
-        })?;
-        cudarc::driver::result::init().map_err(|err| {
-            crate::Error::backend_failure(
-                "cubecl_runtime_init",
-                format!("failed to initialize CUDA driver: {err:?}"),
-            )
-        })?;
-        let cuda_device =
-            cudarc::driver::result::device::get(device_ordinal as i32).map_err(|err| {
-                crate::Error::backend_failure(
-                    "cubecl_runtime_init",
-                    format!("failed to obtain CUDA device {device_ordinal}: {err:?}"),
-                )
-            })?;
+        cudarc::runtime::result::device::set(device_ordinal as i32)
+            .map_err(|err| crate::Error::backend_source("cubecl_runtime_init", err))?;
+        cudarc::driver::result::init()
+            .map_err(|err| crate::Error::backend_source("cubecl_runtime_init", err))?;
+        let cuda_device = cudarc::driver::result::device::get(device_ordinal as i32)
+            .map_err(|err| crate::Error::backend_source("cubecl_runtime_init", err))?;
         let primary_context = CudaPrimaryContext::retain(cuda_device)?;
-        unsafe { cudarc::driver::result::ctx::set_current(primary_context.context()) }.map_err(
-            |err| {
-                crate::Error::backend_failure(
-                    "cubecl_runtime_init",
-                    format!("failed to set CUDA primary context current: {err:?}"),
-                )
-            },
-        )?;
+        unsafe { cudarc::driver::result::ctx::set_current(primary_context.context()) }
+            .map_err(|err| crate::Error::backend_source("cubecl_runtime_init", err))?;
         let device = CudaDevice::new(device_ordinal);
         let client = CubeclCudaRuntime::client(&device);
         Ok(Self {
@@ -165,17 +147,10 @@ impl CudaRuntime {
     pub fn set_current_cuda_context(&self, op: &'static str) -> crate::Result<()> {
         // INVARIANT: CUDA ordinals are device identifiers; bad ordinals are
         // reported by CUDA instead of indexing memory in tenferro.
-        cudarc::runtime::result::device::set(self.device_ordinal as i32).map_err(|err| {
-            crate::Error::backend_failure(op, format!("failed to set CUDA runtime device: {err:?}"))
-        })?;
-        unsafe { cudarc::driver::result::ctx::set_current(self.primary_context.context()) }.map_err(
-            |err| {
-                crate::Error::backend_failure(
-                    op,
-                    format!("failed to activate CUDA primary context: {err:?}"),
-                )
-            },
-        )
+        cudarc::runtime::result::device::set(self.device_ordinal as i32)
+            .map_err(|err| crate::Error::backend_source(op, err))?;
+        unsafe { cudarc::driver::result::ctx::set_current(self.primary_context.context()) }
+            .map_err(|err| crate::Error::backend_source(op, err))
     }
 
     pub(crate) fn raw_cuda_stream(&self) -> crate::Result<u64> {
@@ -184,12 +159,10 @@ impl CudaRuntime {
                 server
                     .raw_stream(StreamId::current())
                     .map(|stream| stream as u64)
-                    .map_err(|err| {
-                        crate::Error::backend_failure("raw_cuda_stream", format!("{err:?}"))
-                    })
+                    .map_err(|err| crate::Error::backend_source("raw_cuda_stream", err))
             })
             .ok_or_else(|| {
-                crate::Error::backend_failure("raw_cuda_stream", "with_server returned None")
+                crate::Error::runtime_state("raw_cuda_stream", "CubeCL server is unavailable")
             })?
     }
 
@@ -203,13 +176,18 @@ impl CudaRuntime {
     /// let _sync: fn(&CudaRuntime) -> tenferro_tensor::Result<()> =
     ///     CudaRuntime::synchronize;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] when CubeCL cannot expose the
+    /// current stream, or [`crate::Error::BackendSource`] when CUDA context or
+    /// stream synchronization fails.
     pub fn synchronize(&self) -> crate::Result<()> {
         const OP: &str = "cubecl_runtime_synchronize";
         self.set_current_cuda_context(OP)?;
         let stream = self.raw_cuda_stream()? as usize as cudaStream_t;
-        unsafe { cuda_result::stream::synchronize(stream) }.map_err(|err| {
-            crate::Error::backend_failure(OP, format!("CUDA stream synchronize failed: {err:?}"))
-        })
+        unsafe { cuda_result::stream::synchronize(stream) }
+            .map_err(|err| crate::Error::backend_source(OP, err))
     }
 }
 

--- a/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
@@ -3,14 +3,14 @@ use crate::config::CompareDir;
 use crate::cubecl::gpu_available;
 use crate::{DType, DeviceKind, GpuBackendKind, Tensor};
 use num_complex::{Complex32, Complex64};
-use tenferro_tensor::BackendId;
 use tenferro_tensor::{
     TensorAnalytic, TensorElementwise, TensorFusion, TensorRead, TensorStructural,
 };
 
 use super::{
-    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c32, tensor_c64, tensor_f32,
-    tensor_f64, tensor_i32, tensor_i64, upload,
+    assert_cuda_numerical_error, assert_cuda_unsupported_dtype, assert_dtype_mismatch,
+    assert_shape_mismatch, assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c32,
+    tensor_c64, tensor_f32, tensor_f64, tensor_i32, tensor_i64, upload,
 };
 
 fn assert_complex_classes_and_values_match(actual: &Tensor, expected: &Tensor) {
@@ -173,11 +173,8 @@ fn test_real_scalar_complex_binary_ops_match_cpu() {
                 scalar.dtype(),
             ),
         ] {
-            assert!(matches!(
-                result,
-                Err(crate::Error::DTypeMismatch { op: actual, lhs, rhs })
-                    if actual == op && lhs == expected_lhs && rhs == expected_rhs
-            ));
+            let error = result.expect_err("complex dtype mismatch must be rejected");
+            assert_dtype_mismatch(&error, op, expected_lhs, expected_rhs);
         }
     }
 
@@ -319,11 +316,8 @@ fn test_real_scalar_complex_binary_ops_match_cpu() {
             ("mul", gpu.mul(&gpu_lhs, &gpu_rhs)),
             ("div", gpu.div(&gpu_lhs, &gpu_rhs)),
         ] {
-            assert!(matches!(
-                result,
-                Err(crate::Error::DTypeMismatch { op: actual, lhs, rhs })
-                    if actual == op && lhs == expected_lhs && rhs == expected_rhs
-            ));
+            let error = result.expect_err("mixed dtype operation must be rejected");
+            assert_dtype_mismatch(&error, op, expected_lhs, expected_rhs);
         }
         for (op, result) in [
             ("add", gpu.add(&gpu_rhs, &gpu_lhs)),
@@ -331,11 +325,8 @@ fn test_real_scalar_complex_binary_ops_match_cpu() {
             ("mul", gpu.mul(&gpu_rhs, &gpu_lhs)),
             ("div", gpu.div(&gpu_rhs, &gpu_lhs)),
         ] {
-            assert!(matches!(
-                result,
-                Err(crate::Error::DTypeMismatch { op: actual, lhs, rhs })
-                    if actual == op && lhs == expected_rhs && rhs == expected_lhs
-            ));
+            let error = result.expect_err("mixed dtype operation must be rejected");
+            assert_dtype_mismatch(&error, op, expected_rhs, expected_lhs);
         }
     }
 }
@@ -447,14 +438,10 @@ fn test_scalar_div_rem_pow_match_cpu() {
     ] {
         let gpu_lhs = upload(&gpu, &lhs);
         let gpu_zero = upload(&gpu, &zero);
-        assert!(matches!(
-            gpu.div(&gpu_lhs, &gpu_zero),
-            Err(crate::Error::DivisionByZero { op: "div", dtype: actual }) if actual == dtype
-        ));
-        assert!(matches!(
-            gpu.rem(&gpu_lhs, &gpu_zero),
-            Err(crate::Error::DivisionByZero { op: "rem", dtype: actual }) if actual == dtype
-        ));
+        let error = gpu.div(&gpu_lhs, &gpu_zero).unwrap_err();
+        assert_cuda_numerical_error(&error, "div", dtype, false);
+        let error = gpu.rem(&gpu_lhs, &gpu_zero).unwrap_err();
+        assert_cuda_numerical_error(&error, "rem", dtype, false);
 
         let (scalar_one, zero_rhs) = match dtype {
             DType::I32 => (tensor_i32(vec![], vec![1]), tensor_i32(vec![2], vec![1, 0])),
@@ -463,14 +450,10 @@ fn test_scalar_div_rem_pow_match_cpu() {
         };
         let gpu_scalar_one = upload(&gpu, &scalar_one);
         let gpu_zero_rhs = upload(&gpu, &zero_rhs);
-        assert!(matches!(
-            gpu.div(&gpu_scalar_one, &gpu_zero_rhs),
-            Err(crate::Error::DivisionByZero { op: "div", dtype: actual }) if actual == dtype
-        ));
-        assert!(matches!(
-            gpu.rem(&gpu_scalar_one, &gpu_zero_rhs),
-            Err(crate::Error::DivisionByZero { op: "rem", dtype: actual }) if actual == dtype
-        ));
+        let error = gpu.div(&gpu_scalar_one, &gpu_zero_rhs).unwrap_err();
+        assert_cuda_numerical_error(&error, "div", dtype, false);
+        let error = gpu.rem(&gpu_scalar_one, &gpu_zero_rhs).unwrap_err();
+        assert_cuda_numerical_error(&error, "rem", dtype, false);
 
         let minus_one = match dtype {
             DType::I32 => tensor_i32(vec![], vec![-1]),
@@ -582,20 +565,14 @@ fn test_scalar_div_rem_pow_match_cpu() {
         let dtype = base.dtype();
         let gpu_base = upload(&gpu, &base);
         let gpu_exponent = upload(&gpu, &exponent);
-        assert!(matches!(
-            gpu.pow(&gpu_base, &gpu_exponent),
-            Err(crate::Error::NegativeIntegerExponent { op: "pow", dtype: actual })
-                if actual == dtype
-        ));
+        let error = gpu.pow(&gpu_base, &gpu_exponent).unwrap_err();
+        assert_cuda_numerical_error(&error, "pow", dtype, true);
     }
 
     let unequal_lhs = upload(&gpu, &tensor_f32(vec![2], vec![2.0, 3.0]));
     let unequal_rhs = upload(&gpu, &tensor_f32(vec![3], vec![2.0, 3.0, 4.0]));
-    assert!(matches!(
-        gpu.pow(&unequal_lhs, &unequal_rhs),
-        Err(crate::Error::ShapeMismatch { op: "pow", lhs, rhs })
-            if lhs == vec![2] && rhs == vec![3]
-    ));
+    let error = gpu.pow(&unequal_lhs, &unequal_rhs).unwrap_err();
+    assert_shape_mismatch(&error, "pow", &[2], &[3]);
 
     for (tensor, scalar) in [
         (
@@ -1372,33 +1349,15 @@ fn test_cubecl_integer_domain_errors_match_cpu() {
     let gpu_zero_rhs = upload(&gpu, &zero_rhs);
 
     let err = gpu.div(&gpu_lhs, &gpu_zero_rhs).unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::DivisionByZero {
-            op: "div",
-            dtype: DType::I32
-        }
-    ));
+    assert_cuda_numerical_error(&err, "div", DType::I32, false);
 
     let err = gpu.rem(&gpu_lhs, &gpu_zero_rhs).unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::DivisionByZero {
-            op: "rem",
-            dtype: DType::I32
-        }
-    ));
+    assert_cuda_numerical_error(&err, "rem", DType::I32, false);
 
     let exp = tensor_i32(vec![2], vec![2, -1]);
     let gpu_exp = upload(&gpu, &exp);
     let err = gpu.pow(&gpu_lhs, &gpu_exp).unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::NegativeIntegerExponent {
-            op: "pow",
-            dtype: DType::I32
-        }
-    ));
+    assert_cuda_numerical_error(&err, "pow", DType::I32, true);
 }
 
 #[test]
@@ -1447,14 +1406,7 @@ fn test_cubecl_complex_elementwise_matches_cpu_and_rejects_unsupported_ops() {
     assert_tensor_close(&actual, &expected, 1e-12);
 
     let err = gpu.rem(&gpu_lhs, &gpu_rhs).unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::UnsupportedOpDType {
-            op: "rem",
-            dtype: DType::C64,
-            backend: BackendId::Cuda,
-        }
-    ));
+    assert_cuda_unsupported_dtype(&err, "rem", DType::C64);
 
     let expected = cpu.neg(&lhs).unwrap();
     let gpu_out = gpu.neg(&gpu_lhs).unwrap();
@@ -1472,14 +1424,7 @@ fn test_cubecl_complex_elementwise_matches_cpu_and_rejects_unsupported_ops() {
     assert_tensor_close(&actual, &expected, 1e-12);
 
     let err = gpu.exp(&gpu_lhs).unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::UnsupportedOpDType {
-            op: "exp",
-            dtype: DType::C64,
-            backend: tenferro_tensor::BackendId::Cuda,
-        }
-    ));
+    assert_cuda_unsupported_dtype(&err, "exp", DType::C64);
 
     let err = gpu
         .compare(&gpu_lhs, &gpu_rhs, &CompareDir::Eq)

--- a/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/elementwise_tests.rs
@@ -4,7 +4,7 @@ use crate::cubecl::gpu_available;
 use crate::{DType, DeviceKind, GpuBackendKind, Tensor};
 use num_complex::{Complex32, Complex64};
 use tenferro_tensor::{
-    TensorAnalytic, TensorElementwise, TensorFusion, TensorRead, TensorStructural,
+    ErrorKind, TensorAnalytic, TensorElementwise, TensorFusion, TensorRead, TensorStructural,
 };
 
 use super::{
@@ -1429,22 +1429,13 @@ fn test_cubecl_complex_elementwise_matches_cpu_and_rejects_unsupported_ops() {
     let err = gpu
         .compare(&gpu_lhs, &gpu_rhs, &CompareDir::Eq)
         .unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::BackendFailure { op: "compare", .. }
-    ));
+    assert_cuda_unsupported_dtype(&err, "compare", DType::C64);
 
     let err = gpu.select(&gpu_lhs, &gpu_lhs, &gpu_rhs).unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::BackendFailure { op: "select", .. }
-    ));
+    assert_cuda_unsupported_dtype(&err, "select", DType::C64);
 
     let err = gpu.clamp(&gpu_lhs, &gpu_lhs, &gpu_rhs).unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::BackendFailure { op: "clamp", .. }
-    ));
+    assert_cuda_unsupported_dtype(&err, "clamp", DType::C64);
 
     let converted = gpu.convert(&gpu_lhs, DType::C64).unwrap();
     let actual = download(&gpu, &converted);
@@ -1499,8 +1490,5 @@ fn test_cubecl_conj_real_clone_rejects_missing_resident_device_metadata() {
 
     let err = gpu.conj(&Tensor::F64(gpu_input)).unwrap_err();
 
-    assert!(matches!(
-        err,
-        crate::Error::BackendFailure { op: "conj", .. }
-    ));
+    assert_eq!(err.kind(), ErrorKind::RuntimeState);
 }

--- a/crates/tenferro-gpu/src/cubecl/tests/fusion_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/fusion_tests.rs
@@ -3,8 +3,8 @@ use crate::backend::{ElementwiseFusionInst, ElementwiseFusionOp, ElementwiseFusi
 use tenferro_tensor::{TensorAnalytic, TensorElementwise, TensorFusion};
 
 use super::{
-    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_c32, tensor_c64, tensor_f32,
-    tensor_f64, upload,
+    assert_tensor_close, assert_validation_kind, cpu_backend, download, gpu_backend, tensor_c32,
+    tensor_c64, tensor_f32, tensor_f64, upload,
 };
 
 /// Build a plan for: out = (a + b) * a
@@ -447,5 +447,9 @@ fn fusion_plan_runtime_dtype_descriptor_mismatch_remains_a_hard_error() {
     let err = gpu
         .execute_elementwise_fusion(&[&gpu_lhs, &gpu_rhs], &add_mul_plan())
         .expect_err("a runtime dtype mismatch must remain a typed hard error");
-    assert!(matches!(err, crate::Error::BackendFailure { .. }));
+    assert_validation_kind(
+        &err,
+        "fused_elementwise",
+        tenferro_tensor::ValidationKind::DTypeMismatch,
+    );
 }

--- a/crates/tenferro-gpu/src/cubecl/tests/indexing_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/indexing_tests.rs
@@ -7,9 +7,10 @@ use tenferro_tensor::{
 };
 
 use super::{
-    assert_backend_failure, assert_error_parity, assert_tensor_close, assert_validation_kind,
-    cpu_backend, diagonal_scatter_config, download, gpu_backend, simple_gather_config, tensor_bool,
-    tensor_c64, tensor_f32, tensor_f64, tensor_i32, tensor_i64, upload,
+    assert_error_parity, assert_runtime_state, assert_tensor_close, assert_unsupported,
+    assert_validation_kind, cpu_backend, diagonal_scatter_config, download, gpu_backend,
+    simple_gather_config, tensor_bool, tensor_c64, tensor_f32, tensor_f64, tensor_i32, tensor_i64,
+    upload,
 };
 use tenferro_tensor::{ValidationError, ValidationKind};
 
@@ -464,7 +465,7 @@ fn cuda_indexing_zero_domains_validate_wrong_device_and_malformed_buffers() {
     let err = gpu
         .dynamic_slice(&empty_operand, &wrong_starts, &[0])
         .unwrap_err();
-    assert_backend_failure(&err, "dynamic_slice", &wrong_device_message);
+    assert_runtime_state(&err, "dynamic_slice", &wrong_device_message);
 
     let empty_bool = upload(&gpu, &tensor_bool(vec![0], vec![]));
     let wrong_float_starts = crate::Tensor::F32(with_cuda_ordinal(
@@ -477,7 +478,7 @@ fn cuda_indexing_zero_domains_validate_wrong_device_and_malformed_buffers() {
     let err = gpu
         .dynamic_slice(&empty_bool, &wrong_float_starts, &[0])
         .unwrap_err();
-    assert_backend_failure(&err, "dynamic_slice", &wrong_device_message);
+    assert_runtime_state(&err, "dynamic_slice", &wrong_device_message);
 
     let malformed_bool = crate::Tensor::Bool(
         TypedTensor::from_buffer_col_major(
@@ -500,7 +501,7 @@ fn cuda_indexing_zero_domains_validate_wrong_device_and_malformed_buffers() {
             &[0],
         )
         .unwrap_err();
-    assert_backend_failure(
+    assert_runtime_state(
         &err,
         "dynamic_slice",
         "expected CubeCL GPU tensor, got host tensor. Use upload_tensor() to transfer to GPU before calling GPU ops.",
@@ -517,28 +518,28 @@ fn cuda_indexing_zero_domains_validate_wrong_device_and_malformed_buffers() {
     let err = gpu
         .gather(&gather_operand, &wrong_indices, &simple_gather_config())
         .unwrap_err();
-    assert_backend_failure(&err, "gather", &wrong_device_message);
+    assert_runtime_state(&err, "gather", &wrong_device_message);
 
     let host_updates = tensor_f64(vec![0], vec![]);
     let host_message = "expected CubeCL GPU tensor, got host tensor. Use upload_tensor() to transfer to GPU before calling GPU ops.".to_string();
     let err = gpu
         .scatter(&empty_operand, &indices, &host_updates, &config)
         .unwrap_err();
-    assert_backend_failure(&err, "scatter", &host_message);
+    assert_runtime_state(&err, "scatter", &host_message);
 
     let operand = upload(&gpu, &tensor_f64(vec![2], vec![1.0, 2.0]));
     let updates = upload(&gpu, &tensor_f64(vec![0], vec![]));
     let err = gpu
         .scatter(&operand, &wrong_indices, &updates, &config)
         .unwrap_err();
-    assert_backend_failure(&err, "scatter", &wrong_device_message);
+    assert_runtime_state(&err, "scatter", &wrong_device_message);
 
     let complex_operand = upload(&gpu, &tensor_c64(vec![0], vec![]));
     let complex_updates = upload(&gpu, &tensor_c64(vec![0], vec![]));
     let err = gpu
         .scatter(&complex_operand, &wrong_indices, &complex_updates, &config)
         .unwrap_err();
-    assert_backend_failure(&err, "scatter", &wrong_device_message);
+    assert_runtime_state(&err, "scatter", &wrong_device_message);
     let nonempty_complex_operand = upload(
         &gpu,
         &tensor_c64(vec![2], vec![Complex64::new(1.0, 2.0); 2]),
@@ -551,7 +552,7 @@ fn cuda_indexing_zero_domains_validate_wrong_device_and_malformed_buffers() {
             &config,
         )
         .unwrap_err();
-    assert_backend_failure(&err, "scatter", &wrong_device_message);
+    assert_runtime_state(&err, "scatter", &wrong_device_message);
 
     let malformed_updates = crate::Tensor::F64(
         TypedTensor::from_buffer_col_major(
@@ -570,7 +571,7 @@ fn cuda_indexing_zero_domains_validate_wrong_device_and_malformed_buffers() {
     let err = gpu
         .scatter(&empty_operand, &indices, &malformed_updates, &config)
         .unwrap_err();
-    assert_backend_failure(&err, "scatter", &host_message);
+    assert_runtime_state(&err, "scatter", &host_message);
 }
 
 #[test]
@@ -767,7 +768,7 @@ fn cuda_bool_indexing_ops_match_cpu() {
     let expected_scatter_error = cpu
         .scatter(&input, &scatter_indices, &updates, &config)
         .unwrap_err();
-    assert_backend_failure(
+    assert_unsupported(
         &expected_scatter_error,
         "scatter",
         "Bool data tensors are not supported by additive scatter",
@@ -777,7 +778,7 @@ fn cuda_bool_indexing_ops_match_cpu() {
     let actual = gpu
         .scatter(&gi, &gpu_scatter_indices, &gpu_updates, &config)
         .unwrap_err();
-    assert_backend_failure(
+    assert_unsupported(
         &actual,
         "scatter",
         "Bool data tensors are not supported by additive scatter",

--- a/crates/tenferro-gpu/src/cubecl/tests/indexing_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/indexing_tests.rs
@@ -7,10 +7,11 @@ use tenferro_tensor::{
 };
 
 use super::{
-    assert_tensor_close, cpu_backend, diagonal_scatter_config, download, gpu_backend,
-    simple_gather_config, tensor_bool, tensor_c64, tensor_f32, tensor_f64, tensor_i32, tensor_i64,
-    upload,
+    assert_backend_failure, assert_error_parity, assert_tensor_close, assert_validation_kind,
+    cpu_backend, diagonal_scatter_config, download, gpu_backend, simple_gather_config, tensor_bool,
+    tensor_c64, tensor_f32, tensor_f64, tensor_i32, tensor_i64, upload,
 };
+use tenferro_tensor::{ValidationError, ValidationKind};
 
 fn with_cuda_ordinal<T: Clone + 'static>(
     tensor: &TypedTensor<T>,
@@ -102,7 +103,7 @@ fn cuda_float_index_validation_matches_cpu() {
                     .unwrap_or_else(|| panic!("{label} {op} CPU unexpectedly succeeded"));
                 match gpu_result {
                     Ok(_) => failures.push(format!("{label} {op}: CUDA unexpectedly succeeded")),
-                    Err(actual) if actual != expected => {
+                    Err(actual) if actual.kind() != expected.kind() => {
                         failures.push(format!("{label} {op}: CUDA {actual:?} != CPU {expected:?}"))
                     }
                     Err(_) => {}
@@ -230,24 +231,26 @@ fn cuda_bool_dynamic_slice_float_starts_match_cpu() {
             tensor_f64(vec![1], vec![-9_007_199_254_740_994.0]),
         ),
     ] {
-        assert_eq!(
-            gpu.dynamic_slice(&gpu_input, &upload(&gpu, &starts), &[2])
-                .unwrap_err(),
-            cpu.dynamic_slice(&input, &starts, &[2]).unwrap_err(),
-            "{label}"
-        );
+        let actual = gpu
+            .dynamic_slice(&gpu_input, &upload(&gpu, &starts), &[2])
+            .unwrap_err();
+        let expected = cpu.dynamic_slice(&input, &starts, &[2]).unwrap_err();
+        assert_eq!(actual.kind(), expected.kind(), "{label}");
+        assert_error_parity(expected, actual);
     }
 
     let invalid_starts = tensor_f64(vec![1], vec![f64::NAN]);
-    assert_eq!(
-        gpu.dynamic_slice(&gpu_input, &upload(&gpu, &invalid_starts), &[5])
-            .unwrap_err(),
-        Error::InvalidConfig {
-            op: "dynamic_slice",
-            message: "slice size exceeds dimension on axis 0".into(),
-        },
-        "invalid slice metadata must precede float value validation"
-    );
+    let err = gpu
+        .dynamic_slice(&gpu_input, &upload(&gpu, &invalid_starts), &[5])
+        .unwrap_err();
+    assert_validation_kind(&err, "dynamic_slice", ValidationKind::InvalidArgument);
+    assert!(matches!(
+        err,
+        Error::Validation {
+            source: ValidationError::InvalidArgument { argument: "slice_sizes", message },
+            ..
+        } if message.contains("slice size exceeds dimension on axis 0")
+    ));
 
     let empty = tensor_bool(vec![0], vec![]);
     for starts in [
@@ -270,11 +273,11 @@ fn cuda_bool_dynamic_slice_float_starts_match_cpu() {
 #[test]
 #[ignore = "requires CUDA 12.8+ GPU"]
 fn cuda_indexing_invalid_config_precedes_invalid_float_index_values() {
-    fn assert_error_parity(
+    fn assert_result_error_parity(
         cpu: tenferro_tensor::Result<crate::Tensor>,
         gpu: tenferro_tensor::Result<crate::Tensor>,
     ) {
-        assert_eq!(cpu.unwrap_err(), gpu.unwrap_err());
+        super::assert_error_parity(cpu.unwrap_err(), gpu.unwrap_err());
     }
 
     let mut cpu = cpu_backend();
@@ -289,19 +292,15 @@ fn cuda_indexing_invalid_config_precedes_invalid_float_index_values() {
         (operand_f32.clone(), starts_f32),
     ] {
         assert!(cpu.dynamic_slice(&operand, &valid_starts, &[3]).is_err());
-        assert_eq!(
-            gpu.dynamic_slice(
+        let err = gpu
+            .dynamic_slice(
                 &upload(&gpu, &operand),
                 &upload(&gpu, &invalid_starts),
                 &[3],
             )
-            .unwrap_err(),
-            Error::InvalidConfig {
-                op: "dynamic_slice",
-                message: "slice size exceeds dimension on axis 0".into(),
-            },
-        );
-        assert_error_parity(
+            .unwrap_err();
+        assert_validation_kind(&err, "dynamic_slice", ValidationKind::InvalidArgument);
+        assert_result_error_parity(
             cpu.dynamic_slice(&operand, &invalid_starts, &[1]),
             gpu.dynamic_slice(
                 &upload(&gpu, &operand),
@@ -313,7 +312,7 @@ fn cuda_indexing_invalid_config_precedes_invalid_float_index_values() {
 
     let operand_bool = tensor_bool(vec![2], vec![true, false]);
     let starts_i32 = tensor_i32(vec![2], vec![0, 1]);
-    assert_error_parity(
+    assert_result_error_parity(
         cpu.dynamic_slice(&operand_bool, &starts_i32, &[1]),
         gpu.dynamic_slice(
             &upload(&gpu, &operand_bool),
@@ -339,16 +338,15 @@ fn cuda_indexing_invalid_config_precedes_invalid_float_index_values() {
         let expected = cpu
             .gather(&operand, &valid_gather_indices, &bad_gather)
             .unwrap_err();
-        assert_eq!(
-            gpu.gather(
+        let actual = gpu
+            .gather(
                 &upload(&gpu, &operand),
                 &upload(&gpu, &gather_indices),
                 &bad_gather,
             )
-            .unwrap_err(),
-            expected,
-        );
-        assert_error_parity(
+            .unwrap_err();
+        assert_error_parity(expected, actual);
+        assert_result_error_parity(
             cpu.gather(&operand, &gather_indices, &simple_gather_config()),
             gpu.gather(
                 &upload(&gpu, &operand),
@@ -380,17 +378,16 @@ fn cuda_indexing_invalid_config_precedes_invalid_float_index_values() {
             &bad_scatter,
         )
         .unwrap_err();
-    assert_eq!(
-        gpu.scatter(
+    let actual = gpu
+        .scatter(
             &upload(&gpu, &operand_f64),
             &upload(&gpu, &gather_indices),
             &upload(&gpu, &updates_f64),
             &bad_scatter,
         )
-        .unwrap_err(),
-        expected,
-    );
-    assert_error_parity(
+        .unwrap_err();
+    assert_error_parity(expected, actual);
+    assert_result_error_parity(
         cpu.scatter(&operand_f64, &gather_indices, &updates_f64, &valid_scatter),
         gpu.scatter(
             &upload(&gpu, &operand_f64),
@@ -409,17 +406,16 @@ fn cuda_indexing_invalid_config_precedes_invalid_float_index_values() {
             &bad_scatter,
         )
         .unwrap_err();
-    assert_eq!(
-        gpu.scatter(
+    let actual = gpu
+        .scatter(
             &upload(&gpu, &operand_c64),
             &upload(&gpu, &gather_indices),
             &upload(&gpu, &updates_c64),
             &bad_scatter,
         )
-        .unwrap_err(),
-        expected,
-    );
-    assert_error_parity(
+        .unwrap_err();
+    assert_error_parity(expected, actual);
+    assert_result_error_parity(
         cpu.scatter(&operand_c64, &gather_indices, &updates_c64, &valid_scatter),
         gpu.scatter(
             &upload(&gpu, &operand_c64),
@@ -465,14 +461,10 @@ fn cuda_indexing_zero_domains_validate_wrong_device_and_malformed_buffers() {
         },
         1,
     ));
-    assert_eq!(
-        gpu.dynamic_slice(&empty_operand, &wrong_starts, &[0])
-            .unwrap_err(),
-        Error::BackendFailure {
-            op: "dynamic_slice",
-            message: wrong_device_message.clone(),
-        }
-    );
+    let err = gpu
+        .dynamic_slice(&empty_operand, &wrong_starts, &[0])
+        .unwrap_err();
+    assert_backend_failure(&err, "dynamic_slice", &wrong_device_message);
 
     let empty_bool = upload(&gpu, &tensor_bool(vec![0], vec![]));
     let wrong_float_starts = crate::Tensor::F32(with_cuda_ordinal(
@@ -482,14 +474,10 @@ fn cuda_indexing_zero_domains_validate_wrong_device_and_malformed_buffers() {
         },
         1,
     ));
-    assert_eq!(
-        gpu.dynamic_slice(&empty_bool, &wrong_float_starts, &[0])
-            .unwrap_err(),
-        Error::BackendFailure {
-            op: "dynamic_slice",
-            message: wrong_device_message.clone(),
-        }
-    );
+    let err = gpu
+        .dynamic_slice(&empty_bool, &wrong_float_starts, &[0])
+        .unwrap_err();
+    assert_backend_failure(&err, "dynamic_slice", &wrong_device_message);
 
     let malformed_bool = crate::Tensor::Bool(
         TypedTensor::from_buffer_col_major(
@@ -505,18 +493,17 @@ fn cuda_indexing_zero_domains_validate_wrong_device_and_malformed_buffers() {
         )
         .unwrap(),
     );
-    assert_eq!(
-        gpu.dynamic_slice(
+    let err = gpu
+        .dynamic_slice(
             &malformed_bool,
             &upload(&gpu, &tensor_f64(vec![1], vec![f64::NAN])),
             &[0],
         )
-        .unwrap_err(),
-        Error::BackendFailure {
-            op: "dynamic_slice",
-            message: "expected CubeCL GPU tensor, got host tensor. Use upload_tensor() to transfer to GPU before calling GPU ops.".into(),
-        },
-        "malformed Bool input must be rejected before scanning float starts"
+        .unwrap_err();
+    assert_backend_failure(
+        &err,
+        "dynamic_slice",
+        "expected CubeCL GPU tensor, got host tensor. Use upload_tensor() to transfer to GPU before calling GPU ops.",
     );
 
     let wrong_indices = crate::Tensor::I32(with_cuda_ordinal(
@@ -527,64 +514,44 @@ fn cuda_indexing_zero_domains_validate_wrong_device_and_malformed_buffers() {
         1,
     ));
     let gather_operand = upload(&gpu, &tensor_f64(vec![2], vec![1.0, 2.0]));
-    assert_eq!(
-        gpu.gather(&gather_operand, &wrong_indices, &simple_gather_config())
-            .unwrap_err(),
-        Error::BackendFailure {
-            op: "gather",
-            message: wrong_device_message.clone(),
-        }
-    );
+    let err = gpu
+        .gather(&gather_operand, &wrong_indices, &simple_gather_config())
+        .unwrap_err();
+    assert_backend_failure(&err, "gather", &wrong_device_message);
 
     let host_updates = tensor_f64(vec![0], vec![]);
     let host_message = "expected CubeCL GPU tensor, got host tensor. Use upload_tensor() to transfer to GPU before calling GPU ops.".to_string();
-    assert_eq!(
-        gpu.scatter(&empty_operand, &indices, &host_updates, &config)
-            .unwrap_err(),
-        Error::BackendFailure {
-            op: "scatter",
-            message: host_message.clone(),
-        }
-    );
+    let err = gpu
+        .scatter(&empty_operand, &indices, &host_updates, &config)
+        .unwrap_err();
+    assert_backend_failure(&err, "scatter", &host_message);
 
     let operand = upload(&gpu, &tensor_f64(vec![2], vec![1.0, 2.0]));
     let updates = upload(&gpu, &tensor_f64(vec![0], vec![]));
-    assert_eq!(
-        gpu.scatter(&operand, &wrong_indices, &updates, &config)
-            .unwrap_err(),
-        Error::BackendFailure {
-            op: "scatter",
-            message: wrong_device_message.clone(),
-        }
-    );
+    let err = gpu
+        .scatter(&operand, &wrong_indices, &updates, &config)
+        .unwrap_err();
+    assert_backend_failure(&err, "scatter", &wrong_device_message);
 
     let complex_operand = upload(&gpu, &tensor_c64(vec![0], vec![]));
     let complex_updates = upload(&gpu, &tensor_c64(vec![0], vec![]));
-    assert_eq!(
-        gpu.scatter(&complex_operand, &wrong_indices, &complex_updates, &config)
-            .unwrap_err(),
-        Error::BackendFailure {
-            op: "scatter",
-            message: wrong_device_message.clone(),
-        }
-    );
+    let err = gpu
+        .scatter(&complex_operand, &wrong_indices, &complex_updates, &config)
+        .unwrap_err();
+    assert_backend_failure(&err, "scatter", &wrong_device_message);
     let nonempty_complex_operand = upload(
         &gpu,
         &tensor_c64(vec![2], vec![Complex64::new(1.0, 2.0); 2]),
     );
-    assert_eq!(
-        gpu.scatter(
+    let err = gpu
+        .scatter(
             &nonempty_complex_operand,
             &wrong_indices,
             &complex_updates,
             &config,
         )
-        .unwrap_err(),
-        Error::BackendFailure {
-            op: "scatter",
-            message: wrong_device_message.clone(),
-        }
-    );
+        .unwrap_err();
+    assert_backend_failure(&err, "scatter", &wrong_device_message);
 
     let malformed_updates = crate::Tensor::F64(
         TypedTensor::from_buffer_col_major(
@@ -600,14 +567,10 @@ fn cuda_indexing_zero_domains_validate_wrong_device_and_malformed_buffers() {
         )
         .unwrap(),
     );
-    assert_eq!(
-        gpu.scatter(&empty_operand, &indices, &malformed_updates, &config)
-            .unwrap_err(),
-        Error::BackendFailure {
-            op: "scatter",
-            message: host_message,
-        }
-    );
+    let err = gpu
+        .scatter(&empty_operand, &indices, &malformed_updates, &config)
+        .unwrap_err();
+    assert_backend_failure(&err, "scatter", &host_message);
 }
 
 #[test]
@@ -657,11 +620,10 @@ fn cuda_float_index_validation_reports_first_invalid_value() {
                 gpu.scatter(&gpu_operand, &gpu_indices, &gpu_updates, &scatter_config),
             ),
         ] {
-            assert_eq!(
-                actual.unwrap_err(),
-                expected.unwrap_err(),
-                "{label} {op} must report the lower flat invalid index"
-            );
+            let actual = actual.unwrap_err();
+            let expected = expected.unwrap_err();
+            assert_eq!(actual.kind(), expected.kind(), "{label} {op}");
+            assert_error_parity(expected, actual);
         }
     }
 
@@ -726,7 +688,7 @@ fn cuda_bool_indexing_ops_match_cpu() {
     }
     macro_rules! error_parity {
         ($cpu:expr, $gpu:expr) => {{
-            assert_eq!($cpu.unwrap_err(), $gpu.unwrap_err());
+            super::assert_error_parity($cpu.unwrap_err(), $gpu.unwrap_err());
         }};
     }
     parity!(cpu.slice(&input, &slice), gpu.slice(&gi, &slice));
@@ -802,21 +764,23 @@ fn cuda_bool_indexing_ops_match_cpu() {
         scatter_dims_to_operand_dims: vec![0],
         index_vector_dim: 1,
     };
-    let expected_scatter_error = Error::BackendFailure {
-        op: "scatter",
-        message: "Bool data tensors are not supported by additive scatter".into(),
-    };
-    assert_eq!(
-        cpu.scatter(&input, &scatter_indices, &updates, &config)
-            .unwrap_err(),
-        expected_scatter_error
+    let expected_scatter_error = cpu
+        .scatter(&input, &scatter_indices, &updates, &config)
+        .unwrap_err();
+    assert_backend_failure(
+        &expected_scatter_error,
+        "scatter",
+        "Bool data tensors are not supported by additive scatter",
     );
     let gpu_updates = upload(&gpu, &updates);
     let gpu_scatter_indices = upload(&gpu, &scatter_indices);
-    assert_eq!(
-        gpu.scatter(&gi, &gpu_scatter_indices, &gpu_updates, &config)
-            .unwrap_err(),
-        expected_scatter_error
+    let actual = gpu
+        .scatter(&gi, &gpu_scatter_indices, &gpu_updates, &config)
+        .unwrap_err();
+    assert_backend_failure(
+        &actual,
+        "scatter",
+        "Bool data tensors are not supported by additive scatter",
     );
 }
 

--- a/crates/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
@@ -9,6 +9,7 @@ use crate::cubecl::CudaExtensionCache;
 use crate::{
     Buffer, CubeclBuffer, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, TypedTensor,
 };
+use tenferro_tensor::{Error, ErrorKind, ValidationError, ValidationKind};
 
 #[test]
 fn scalar_reduction_shape_stays_separate_from_cubecl_launch_metadata() {
@@ -129,7 +130,7 @@ fn cuda_extension_cache_has_configurable_entry_bound() {
 
 #[test]
 fn typed_tensor_binding_accepts_valid_backend_metadata() {
-    let tensor = cubecl_tensor_with_len(vec![2, 3], 6);
+    let tensor = cubecl_tensor_with_len(vec![2, 3], 6).unwrap();
 
     typed_tensor_binding(&tensor, "metadata_test").unwrap();
     typed_tensor_array_arg(&tensor, "metadata_test").unwrap();
@@ -137,41 +138,45 @@ fn typed_tensor_binding_accepts_valid_backend_metadata() {
 
 #[test]
 fn from_buffer_col_major_rejects_backend_buffer_len_mismatch() {
-    let panic = constructor_panic_message(vec![2, 3], 5);
+    let error = cubecl_tensor_with_len(vec![2, 3], 5).unwrap_err();
 
-    assert!(panic.contains("from_buffer_col_major"));
-    assert!(panic.contains("data length 5 does not match shape product 6"));
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::ShapeMismatch)
+    );
+    assert!(matches!(
+        error,
+        Error::Validation {
+            op: "from_buffer_col_major",
+            source: ValidationError::ShapeDataLengthMismatch {
+                expected: 6,
+                actual: 5,
+            },
+        }
+    ));
 }
 
 #[test]
 fn from_buffer_col_major_rejects_shape_product_overflow() {
-    let panic = constructor_panic_message(vec![usize::MAX, 2], 1);
+    let error = cubecl_tensor_with_len(vec![usize::MAX, 2], 1).unwrap_err();
 
-    assert!(
-        panic.contains("attempt to multiply with overflow")
-            || panic.contains("invalid compact tensor layout")
-            || panic.contains("from_buffer_col_major: data length")
-            || (panic.contains("integer overflow") && panic.contains("tensor metadata")),
-        "unexpected panic message: {panic}"
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
     );
+    assert!(matches!(
+        error,
+        Error::Validation {
+            op: "from_buffer_col_major",
+            source: ValidationError::IntegerOverflow,
+        }
+    ));
 }
 
-fn constructor_panic_message(shape: Vec<usize>, len: usize) -> String {
-    let panic = panic::catch_unwind(|| {
-        let _ = cubecl_tensor_with_len(shape, len);
-    })
-    .expect_err("expected TypedTensor::from_buffer_col_major to reject invalid metadata");
-
-    if let Some(message) = panic.downcast_ref::<String>() {
-        return message.clone();
-    }
-    if let Some(message) = panic.downcast_ref::<&'static str>() {
-        return (*message).to_string();
-    }
-    "non-string panic payload".to_string()
-}
-
-fn cubecl_tensor_with_len(shape: Vec<usize>, len: usize) -> TypedTensor<f32> {
+fn cubecl_tensor_with_len(
+    shape: Vec<usize>,
+    len: usize,
+) -> tenferro_tensor::Result<TypedTensor<f32>> {
     let handle = cubecl::server::Handle::new(
         StreamId::current(),
         (len * core::mem::size_of::<f32>()) as u64,
@@ -187,5 +192,4 @@ fn cubecl_tensor_with_len(shape: Vec<usize>, len: usize) -> TypedTensor<f32> {
             }),
         },
     )
-    .unwrap()
 }

--- a/crates/tenferro-gpu/src/cubecl/tests/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/mod.rs
@@ -117,14 +117,20 @@ fn assert_shape_mismatch(error: &Error, op: &'static str, lhs: &[usize], rhs: &[
     ));
 }
 
-fn assert_backend_failure(error: &Error, op: &'static str, message: &str) {
+fn assert_runtime_state(error: &Error, op: &'static str, message: &str) {
     assert!(matches!(
         error,
-        Error::BackendFailure {
+        Error::RuntimeState {
             op: actual_op,
             message: actual_message,
         } if *actual_op == op && actual_message == message
     ));
+}
+
+fn assert_unsupported(error: &Error, op: &'static str, message: &str) {
+    assert_eq!(error.kind(), ErrorKind::Unsupported);
+    assert!(error.to_string().contains(op));
+    assert!(error.to_string().contains(message));
 }
 
 fn assert_error_parity(expected: Error, actual: Error) {

--- a/crates/tenferro-gpu/src/cubecl/tests/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/mod.rs
@@ -1,9 +1,12 @@
+use std::error::Error as _;
+
 use num_complex::{Complex32, Complex64};
 
 use crate::config::{GatherConfig, ScatterConfig};
 use crate::cubecl::{download_tensor, upload_tensor, CudaBackend};
-use crate::{Error, Tensor, TypedTensor};
+use crate::{DType, Error, Tensor, TypedTensor};
 use tenferro_cpu::CpuBackend;
+use tenferro_tensor::{ErrorKind, ValidationError, ValidationKind};
 
 mod capability_tests;
 mod elementwise_tests;
@@ -60,6 +63,118 @@ fn tensor_c64(shape: Vec<usize>, data: Vec<Complex64>) -> Tensor {
     Tensor::C64(TypedTensor::from_vec_col_major(shape, data).unwrap())
 }
 
+fn assert_validation_kind(error: &Error, op: &'static str, kind: ValidationKind) {
+    assert_eq!(error.kind(), ErrorKind::Validation(kind));
+    assert!(matches!(
+        error,
+        Error::Validation {
+            op: actual,
+            source,
+        } if *actual == op && source.kind() == kind
+    ));
+}
+
+fn assert_dtype_mismatch(error: &Error, op: &'static str, expected: DType, actual: DType) {
+    assert_validation_kind(error, op, ValidationKind::DTypeMismatch);
+    let expected = core_dtype(expected);
+    let actual = core_dtype(actual);
+    assert!(matches!(
+        error,
+        Error::Validation {
+            source: ValidationError::DTypeMismatch {
+                expected: source_expected,
+                actual: source_actual,
+            },
+            ..
+        } if *source_expected == expected && *source_actual == actual
+    ));
+}
+
+fn core_dtype(dtype: DType) -> tenferro_tensor::core::DType {
+    match dtype {
+        DType::F32 => tenferro_tensor::core::DType::F32,
+        DType::F64 => tenferro_tensor::core::DType::F64,
+        DType::I32 => tenferro_tensor::core::DType::I32,
+        DType::I64 => tenferro_tensor::core::DType::I64,
+        DType::Bool => tenferro_tensor::core::DType::Bool,
+        DType::C32 => tenferro_tensor::core::DType::C32,
+        DType::C64 => tenferro_tensor::core::DType::C64,
+    }
+}
+
+fn assert_shape_mismatch(error: &Error, op: &'static str, lhs: &[usize], rhs: &[usize]) {
+    assert_validation_kind(error, op, ValidationKind::ShapeMismatch);
+    assert!(matches!(
+        error,
+        Error::Validation {
+            source: ValidationError::ShapeMismatch(source),
+            ..
+        } if matches!(
+            source.as_ref(),
+            tenferro_tensor::ShapeMismatch::IncompatibleShapes { lhs: source_lhs, rhs: source_rhs }
+                if source_lhs.as_slice() == lhs && source_rhs.as_slice() == rhs
+        )
+    ));
+}
+
+fn assert_backend_failure(error: &Error, op: &'static str, message: &str) {
+    assert!(matches!(
+        error,
+        Error::BackendFailure {
+            op: actual_op,
+            message: actual_message,
+        } if *actual_op == op && actual_message == message
+    ));
+}
+
+fn assert_error_parity(expected: Error, actual: Error) {
+    assert_eq!(actual.kind(), expected.kind());
+    assert_eq!(actual.to_string(), expected.to_string());
+    assert_eq!(actual.source().is_some(), expected.source().is_some());
+}
+
+fn assert_cuda_unsupported_dtype(error: &Error, op: &'static str, dtype: DType) {
+    assert_eq!(error.kind(), ErrorKind::Unsupported);
+    let source = error
+        .source()
+        .expect("unsupported CUDA errors have a source");
+    let source = source
+        .downcast_ref::<super::error::CudaError>()
+        .expect("CUDA unsupported dtype keeps its typed source");
+    assert!(matches!(
+        source,
+        super::error::CudaError::UnsupportedDType {
+            op: actual_op,
+            dtype: actual_dtype,
+        } if *actual_op == op && *actual_dtype == dtype
+    ));
+}
+
+fn assert_cuda_numerical_error(error: &Error, op: &'static str, dtype: DType, negative: bool) {
+    assert_eq!(error.kind(), ErrorKind::NumericalFailure);
+    let source = error.source().expect("CUDA numerical errors have a source");
+    let source = source
+        .downcast_ref::<super::error::CudaError>()
+        .expect("CUDA numerical errors keep their typed source");
+    if negative {
+        assert!(matches!(
+            source,
+            super::error::CudaError::NegativeIntegerExponent {
+                op: actual_op,
+                dtype: actual_dtype,
+            } if *actual_op == op && *actual_dtype == dtype
+        ));
+    } else {
+        assert!(matches!(
+            source,
+            super::error::CudaError::DivisionByZero {
+                op: actual_op,
+                dtype: actual_dtype,
+            } if *actual_op == op && *actual_dtype == dtype
+        ));
+    }
+}
+
 #[test]
 fn gather_launch_meta_rejects_offset_dim_outside_output_rank() {
     let err = super::gather_launch_meta(
@@ -75,12 +190,15 @@ fn gather_launch_meta_rejects_offset_dim_outside_output_rank() {
     )
     .unwrap_err();
 
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::AxisOutOfBounds)
+    );
     assert!(matches!(
         err,
-        Error::AxisOutOfBounds {
+        Error::Validation {
             op: "gather",
-            axis: 1,
-            rank: 1
+            source: ValidationError::AxisOutOfBounds { axis: 1, rank: 1 },
         }
     ));
 }
@@ -100,10 +218,17 @@ fn gather_launch_meta_rejects_collapsed_non_unit_slice_sizes() {
     )
     .unwrap_err();
 
-    assert!(
-        matches!(err, Error::InvalidConfig { op: "gather", .. }),
-        "{err:?}"
-    );
+    assert_validation_kind(&err, "gather", ValidationKind::InvalidArgument);
+    assert!(matches!(
+        err,
+        Error::Validation {
+            source: ValidationError::InvalidArgument {
+                argument: "collapsed_slice_dims",
+                ..
+            },
+            ..
+        }
+    ));
     assert!(err.to_string().contains("slice_size == 1"), "{err}");
 }
 
@@ -122,14 +247,7 @@ fn scatter_launch_meta_rejects_mismatched_update_batch_extents() {
     )
     .unwrap_err();
 
-    assert!(
-        matches!(err, Error::InvalidConfig { op: "scatter", .. }),
-        "{err:?}"
-    );
-    assert!(
-        err.to_string().contains("updates batch dim 0 extent 3"),
-        "{err}"
-    );
+    assert_shape_mismatch(&err, "scatter", &[2], &[3]);
 }
 
 fn assert_tensor_close(actual: &Tensor, expected: &Tensor, tol: f64) {

--- a/crates/tenferro-gpu/src/cubecl/tests/reduction_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/reduction_tests.rs
@@ -1,9 +1,9 @@
 // Run with: cargo test --features cuda -- --ignored
-use tenferro_tensor::TensorReduction;
+use tenferro_tensor::{DType, TensorReduction};
 
 use super::{
-    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_bool, tensor_c32, tensor_c64,
-    tensor_f32, tensor_f64, tensor_i32, tensor_i64, upload,
+    assert_cuda_unsupported_dtype, assert_tensor_close, cpu_backend, download, gpu_backend,
+    tensor_bool, tensor_c32, tensor_c64, tensor_f32, tensor_f64, tensor_i32, tensor_i64, upload,
 };
 
 #[test]
@@ -191,22 +191,10 @@ fn test_cubecl_complex_sum_and_prod_match_cpu() {
     assert_tensor_close(&actual, &expected, 1e-12);
 
     let err = gpu.reduce_max(&gpu_input, &[0]).unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::BackendFailure {
-            op: "reduce_max",
-            ..
-        }
-    ));
+    assert_cuda_unsupported_dtype(&err, "reduce_max", DType::C64);
 
     let err = gpu.reduce_min(&gpu_input, &[0]).unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::BackendFailure {
-            op: "reduce_min",
-            ..
-        }
-    ));
+    assert_cuda_unsupported_dtype(&err, "reduce_min", DType::C64);
 }
 
 #[test]
@@ -331,22 +319,10 @@ fn test_cubecl_bool_reductions_are_unsupported() {
     let gpu_input = upload(&gpu, &input);
 
     let err = gpu.reduce_sum(&gpu_input, &[0]).unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::BackendFailure {
-            op: "reduce_sum",
-            ..
-        }
-    ));
+    assert_cuda_unsupported_dtype(&err, "reduce_sum", DType::Bool);
 
     let err = gpu.reduce_prod(&gpu_input, &[1]).unwrap_err();
-    assert!(matches!(
-        err,
-        crate::Error::BackendFailure {
-            op: "reduce_prod",
-            ..
-        }
-    ));
+    assert_cuda_unsupported_dtype(&err, "reduce_prod", DType::Bool);
 }
 
 #[test]

--- a/crates/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/runtime_tests.rs
@@ -35,10 +35,13 @@ fn cube_count_for_len_rejects_u32_overflow() {
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Validation {
             op: "cube_count_for_len",
-            ref message,
-        } if message.contains("exceeds u32::MAX")
+            source: tenferro_tensor::ValidationError::InvalidArgument {
+                argument: "length",
+                ..
+            },
+        }
     ));
 }
 
@@ -134,7 +137,7 @@ gpu_test!(test_download_empty_host_bool_rejects_before_fast_path, {
 });
 
 fn assert_download_rejects_host_tensor_before_empty_fast_path(err: Error) {
-    assert!(matches!(err, Error::BackendFailure { .. }));
+    assert!(matches!(err, Error::RuntimeState { .. }));
 }
 
 gpu_test!(test_upload_download_c64, {

--- a/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
@@ -7,9 +7,11 @@ use tenferro_tensor::{
 };
 
 use super::{
-    assert_tensor_close, cpu_backend, download, gpu_backend, tensor_bool, tensor_c32, tensor_c64,
-    tensor_f32, tensor_f64, tensor_i32, tensor_i64, upload,
+    assert_cuda_unsupported_dtype, assert_error_parity, assert_shape_mismatch, assert_tensor_close,
+    assert_validation_kind, cpu_backend, download, gpu_backend, tensor_bool, tensor_c32,
+    tensor_c64, tensor_f32, tensor_f64, tensor_i32, tensor_i64, upload,
 };
+use tenferro_tensor::{ValidationError, ValidationKind};
 
 fn with_cuda_ordinal<T: Clone + 'static>(
     tensor: &TypedTensor<T>,
@@ -56,7 +58,7 @@ fn cuda_bool_structural_ops_match_cpu() {
     }
     macro_rules! error_parity {
         ($cpu:expr, $gpu:expr) => {{
-            assert_eq!($cpu.unwrap_err(), $gpu.unwrap_err());
+            assert_error_parity($cpu.unwrap_err(), $gpu.unwrap_err());
         }};
     }
     parity!(cpu.transpose(&matrix, &[1, 0]), gpu.transpose(&gm, &[1, 0]));
@@ -383,7 +385,7 @@ fn test_cuda_explicit_cast_matrix_matches_cpu() {
             let expected = cpu.cast(source, target);
             let actual = gpu.cast(&gpu_source, target);
             match (expected, actual) {
-                (Err(expected), Err(actual)) => assert_eq!(actual, expected),
+                (Err(expected), Err(actual)) => assert_error_parity(expected, actual),
                 (Ok(expected), Ok(actual)) => {
                     let actual = download(&gpu, &actual);
                     assert_cast_tensor_equal(&actual, &expected);
@@ -457,9 +459,9 @@ fn test_cuda_explicit_cast_matrix_matches_cpu() {
         ),
     ] {
         let gpu_source = upload(&gpu, &source);
-        assert_eq!(
+        assert_error_parity(
+            cpu.cast(&source, target).unwrap_err(),
             gpu.cast(&gpu_source, target).unwrap_err(),
-            cpu.cast(&source, target).unwrap_err()
         );
     }
 
@@ -492,9 +494,9 @@ fn test_cuda_explicit_cast_matrix_matches_cpu() {
         tensor_c32(vec![1], vec![Complex32::new(-2_147_483_904.0, 3.0)]),
     ] {
         let gpu_source = upload(&gpu, &source);
-        assert_eq!(
+        assert_error_parity(
+            cpu.cast(&source, DType::I32).unwrap_err(),
             gpu.cast(&gpu_source, DType::I32).unwrap_err(),
-            cpu.cast(&source, DType::I32).unwrap_err()
         );
     }
 
@@ -524,9 +526,9 @@ fn test_cuda_explicit_cast_matrix_matches_cpu() {
         tensor_c32(vec![1], vec![Complex32::new(i64_lower_invalid, 2.0)]),
     ] {
         let gpu_source = upload(&gpu, &source);
-        assert_eq!(
+        assert_error_parity(
+            cpu.cast(&source, DType::I64).unwrap_err(),
             gpu.cast(&gpu_source, DType::I64).unwrap_err(),
-            cpu.cast(&source, DType::I64).unwrap_err()
         );
     }
 }
@@ -651,13 +653,18 @@ fn cuda_runtime_copy_rejects_noncompact_source_with_erased_operation_name() {
         )
         .unwrap_err();
 
-    assert_eq!(
-        err,
-        Error::InvalidConfig {
-            op: "CudaBackend::copy_read_into",
-            message: "CUDA copy_into requires a compact source view covering its full allocation; arbitrary-stride source views are unsupported without explicit canonicalization".into(),
-        }
+    assert_validation_kind(
+        &err,
+        "CudaBackend::copy_read_into",
+        ValidationKind::InvalidArgument,
     );
+    assert!(matches!(
+        err,
+        Error::Validation {
+            source: ValidationError::InvalidArgument { argument: "source", message },
+            ..
+        } if message.contains("compact source view")
+    ));
 }
 
 #[test]
@@ -670,13 +677,7 @@ fn cuda_runtime_bool_materialization_reports_intentional_erased_limitation() {
         .to_contiguous_read(TensorRead::from_tensor(&gpu_input))
         .unwrap_err();
 
-    assert_eq!(
-        err,
-        Error::BackendFailure {
-            op: "CudaBackend::to_contiguous_read",
-            message: "unsupported dtype Bool".into(),
-        }
-    );
+    assert_cuda_unsupported_dtype(&err, "CudaBackend::to_contiguous_read", DType::Bool);
 }
 
 #[test]
@@ -693,13 +694,7 @@ fn cuda_runtime_bool_copy_reports_intentional_erased_limitation() {
         )
         .unwrap_err();
 
-    assert_eq!(
-        err,
-        Error::BackendFailure {
-            op: "CudaBackend::copy_read_into",
-            message: "unsupported dtype Bool".into(),
-        }
-    );
+    assert_cuda_unsupported_dtype(&err, "CudaBackend::copy_read_into", DType::Bool);
 }
 
 #[test]
@@ -882,11 +877,16 @@ fn cuda_copy_into_rejects_arbitrary_stride_source_without_materializing() {
         .copy_into(&src_view, &mut dst.as_view_mut())
         .unwrap_err();
 
+    assert_validation_kind(
+        &err,
+        "CudaBackend::copy_into",
+        ValidationKind::InvalidArgument,
+    );
     assert!(matches!(
         err,
-        Error::InvalidConfig {
-            op: "CudaBackend::copy_into",
-            ref message,
+        Error::Validation {
+            source: ValidationError::InvalidArgument { argument: "source", message },
+            ..
         } if message.contains("compact source view")
     ));
 }
@@ -956,11 +956,16 @@ fn cuda_copy_into_rejects_cloned_aliased_allocation() {
 
     let err = gpu.copy_into(&src.as_view(), &mut dst_view).unwrap_err();
 
+    assert_validation_kind(
+        &err,
+        "CudaBackend::copy_into",
+        ValidationKind::InvalidArgument,
+    );
     assert!(matches!(
         err,
-        Error::InvalidConfig {
-            op: "CudaBackend::copy_into",
-            ref message,
+        Error::Validation {
+            source: ValidationError::InvalidArgument { argument: "source/destination", message },
+            ..
         } if message.contains("alias")
     ));
 }
@@ -979,12 +984,5 @@ fn cuda_copy_into_reports_typed_shape_mismatch() {
         .copy_into(&src.as_view(), &mut dst.as_view_mut())
         .unwrap_err();
 
-    assert_eq!(
-        err,
-        Error::ShapeMismatch {
-            op: "CudaBackend::copy_into",
-            lhs: vec![2],
-            rhs: vec![3],
-        }
-    );
+    assert_shape_mismatch(&err, "CudaBackend::copy_into", &[2], &[3]);
 }

--- a/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
@@ -7,9 +7,10 @@ use tenferro_tensor::{
 };
 
 use super::{
-    assert_cuda_unsupported_dtype, assert_error_parity, assert_shape_mismatch, assert_tensor_close,
-    assert_validation_kind, cpu_backend, download, gpu_backend, tensor_bool, tensor_c32,
-    tensor_c64, tensor_f32, tensor_f64, tensor_i32, tensor_i64, upload,
+    assert_cuda_unsupported_dtype, assert_error_parity, assert_runtime_state,
+    assert_shape_mismatch, assert_tensor_close, assert_validation_kind, cpu_backend, download,
+    gpu_backend, tensor_bool, tensor_c32, tensor_c64, tensor_f32, tensor_f64, tensor_i32,
+    tensor_i64, upload,
 };
 use tenferro_tensor::{ValidationError, ValidationKind};
 
@@ -756,7 +757,7 @@ fn cuda_to_contiguous_empty_view_stays_on_cuda() {
 
 #[test]
 #[ignore]
-fn cuda_to_contiguous_bool_view_returns_backend_failure() {
+fn cuda_to_contiguous_bool_view_returns_unsupported_dtype() {
     let mut gpu = gpu_backend();
     let input = tensor_bool(vec![2], vec![true, false]);
     let gpu_input = upload(&gpu, &input);
@@ -766,13 +767,7 @@ fn cuda_to_contiguous_bool_view_returns_backend_failure() {
 
     let err = gpu.to_contiguous(&gpu_tensor.as_view()).unwrap_err();
 
-    assert!(matches!(
-        err,
-        Error::BackendFailure {
-            op: "CudaBackend::to_contiguous",
-            ref message,
-        } if message.contains("unsupported dtype")
-    ));
+    assert_cuda_unsupported_dtype(&err, "CudaBackend::to_contiguous", DType::Bool);
 }
 
 #[test]
@@ -783,13 +778,11 @@ fn cuda_to_contiguous_host_view_returns_upload_hint() {
 
     let err = gpu.to_contiguous(&host.as_view()).unwrap_err();
 
-    assert!(matches!(
-        err,
-        Error::BackendFailure {
-            op: "CudaBackend::to_contiguous",
-            ref message,
-        } if message.contains("upload_tensor()")
-    ));
+    assert_runtime_state(
+        &err,
+        "CudaBackend::to_contiguous",
+        "expected CubeCL GPU tensor view, got host tensor. Use upload_tensor() to transfer to GPU before calling GPU ops.",
+    );
 }
 
 #[test]
@@ -807,13 +800,11 @@ fn cuda_copy_into_host_source_returns_upload_hint() {
         .copy_into(&src.as_view(), &mut dst.as_view_mut())
         .unwrap_err();
 
-    assert!(matches!(
-        err,
-        Error::BackendFailure {
-            op: "CudaBackend::copy_into",
-            ref message,
-        } if message.contains("upload_tensor()")
-    ));
+    assert_runtime_state(
+        &err,
+        "CudaBackend::copy_into",
+        "expected CubeCL GPU tensor view, got host tensor. Use upload_tensor() to transfer to GPU before calling GPU ops.",
+    );
 }
 
 #[test]
@@ -831,13 +822,11 @@ fn cuda_copy_into_host_destination_returns_upload_hint() {
         .copy_into(&src.as_view(), &mut dst.as_view_mut())
         .unwrap_err();
 
-    assert!(matches!(
-        err,
-        Error::BackendFailure {
-            op: "CudaBackend::copy_into",
-            ref message,
-        } if message.contains("upload_tensor()")
-    ));
+    assert_runtime_state(
+        &err,
+        "CudaBackend::copy_into",
+        "expected CubeCL GPU tensor view, got host tensor. Use upload_tensor() to transfer to GPU before calling GPU ops.",
+    );
 }
 
 #[test]
@@ -910,7 +899,7 @@ fn cuda_copy_into_rejects_source_on_wrong_device() {
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::RuntimeState {
             op: "CudaBackend::copy_into",
             ref message,
         } if message.contains("cuda:0") && message.contains("Cuda):1")
@@ -936,7 +925,7 @@ fn cuda_copy_into_rejects_destination_on_wrong_device() {
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::RuntimeState {
             op: "CudaBackend::copy_into",
             ref message,
         } if message.contains("cuda:0") && message.contains("Cuda):1")

--- a/crates/tenferro-gpu/src/webgpu/error.rs
+++ b/crates/tenferro-gpu/src/webgpu/error.rs
@@ -1,0 +1,30 @@
+use crate::{DType, Error, ErrorKind};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum WebGpuError {
+    #[error("{op} does not support dtype {dtype:?}")]
+    UnsupportedDType { op: &'static str, dtype: DType },
+    #[error("{op} is unsupported on WebGPU: {detail}")]
+    UnsupportedOperation {
+        op: &'static str,
+        detail: &'static str,
+    },
+}
+
+pub(crate) fn unsupported_dtype(op: &'static str, dtype: DType) -> Error {
+    Error::extension(
+        op,
+        "webgpu",
+        ErrorKind::Unsupported,
+        WebGpuError::UnsupportedDType { op, dtype },
+    )
+}
+
+pub(crate) fn unsupported_operation(op: &'static str, detail: &'static str) -> Error {
+    Error::extension(
+        op,
+        "webgpu",
+        ErrorKind::Unsupported,
+        WebGpuError::UnsupportedOperation { op, detail },
+    )
+}

--- a/crates/tenferro-gpu/src/webgpu/gemm.rs
+++ b/crates/tenferro-gpu/src/webgpu/gemm.rs
@@ -10,9 +10,10 @@ use smallvec::SmallVec;
 
 use super::{
     alloc_output, comptime_sequence, cube_count_for_len, cube_dim_1d, ensure_resident_on_runtime,
-    kernels, typed_tensor_binding_with_layout, WebGpuBackend,
+    kernels, typed_tensor_binding_with_layout, unsupported_dtype, unsupported_operation,
+    WebGpuBackend,
 };
-use crate::{col_major_strides, DotGeneralConfig, Error, Tensor, TypedTensor};
+use crate::{col_major_strides, DotGeneralConfig, Error, ShapeMismatch, Tensor, TypedTensor};
 
 const DOT_GENERAL_OP: &str = "webgpu_dot_general";
 
@@ -44,18 +45,15 @@ struct PreparedOperand<T> {
 }
 
 fn dtype_mismatch(op: &'static str, lhs: &Tensor, rhs: &Tensor) -> Error {
-    Error::DTypeMismatch {
-        op,
-        lhs: lhs.dtype(),
-        rhs: rhs.dtype(),
-    }
+    Error::dtype_mismatch(op, lhs.dtype(), rhs.dtype())
 }
 
 fn checked_product(label: &str, dims: &[usize]) -> crate::Result<usize> {
     dims.iter().try_fold(1usize, |acc, &dim| {
         acc.checked_mul(dim).ok_or_else(|| {
-            Error::backend_failure(
+            Error::invalid_argument(
                 DOT_GENERAL_OP,
+                "shape",
                 format!("{label} product overflow for dimensions {dims:?}"),
             )
         })
@@ -77,10 +75,9 @@ fn dense_strides(shape: &[usize]) -> crate::Result<Vec<usize>> {
         .into_iter()
         .map(|stride| {
             usize::try_from(stride).map_err(|_| {
-                Error::backend_failure(
-                    DOT_GENERAL_OP,
-                    format!("negative stride is not valid for dense shape {shape:?}"),
-                )
+                Error::Internal(format!(
+                    "negative stride is not valid for dense shape {shape:?}"
+                ))
             })
         })
         .collect()
@@ -130,8 +127,9 @@ fn dense_layout_strides(shape: &[usize]) -> crate::Result<Vec<usize>> {
 
 fn output_cubek_strides(m: usize, n: usize, batch_shape: &[usize]) -> crate::Result<Vec<usize>> {
     let mn = m.checked_mul(n).ok_or_else(|| {
-        Error::backend_failure(
+        Error::invalid_argument(
             DOT_GENERAL_OP,
+            "shape",
             format!("output matrix product overflow for M={m} N={n}"),
         )
     })?;
@@ -140,8 +138,9 @@ fn output_cubek_strides(m: usize, n: usize, batch_shape: &[usize]) -> crate::Res
     for &dim in batch_shape {
         strides.push(next_batch_stride);
         next_batch_stride = next_batch_stride.checked_mul(dim).ok_or_else(|| {
-            Error::backend_failure(
+            Error::invalid_argument(
                 DOT_GENERAL_OP,
+                "shape",
                 format!("output batch stride overflow for batch shape {batch_shape:?}"),
             )
         })?;
@@ -164,12 +163,7 @@ fn build_dot_general_plan(
     rhs_shape: &[usize],
     config: &DotGeneralConfig,
 ) -> crate::Result<DotGeneralPlan> {
-    config
-        .validate_dims_with_ranks(lhs_shape.len(), rhs_shape.len())
-        .map_err(|err| Error::InvalidConfig {
-            op: DOT_GENERAL_OP,
-            message: err.to_string(),
-        })?;
+    config.validate_dims_with_ranks(lhs_shape.len(), rhs_shape.len())?;
 
     let lhs_free = free_axes(
         lhs_shape.len(),
@@ -190,24 +184,30 @@ fn build_dot_general_plan(
         let lhs_dim = lhs_shape[lhs_axis];
         let rhs_dim = rhs_shape[rhs_axis];
         if lhs_dim != rhs_dim {
-            return Err(Error::InvalidConfig {
-                op: DOT_GENERAL_OP,
-                message: format!(
-                    "contracting dim size mismatch: lhs axis {lhs_axis}={lhs_dim} rhs axis {rhs_axis}={rhs_dim}"
-                ),
-            });
+            return Err(Error::validation(
+                DOT_GENERAL_OP,
+                ShapeMismatch::ContractedDimensions {
+                    lhs_axis,
+                    lhs_size: lhs_dim,
+                    rhs_axis,
+                    rhs_size: rhs_dim,
+                }
+                .into(),
+            ));
         }
     }
     for (&lhs_axis, &rhs_axis) in lhs_batch.iter().zip(&rhs_batch) {
         let lhs_dim = lhs_shape[lhs_axis];
         let rhs_dim = rhs_shape[rhs_axis];
         if lhs_dim != rhs_dim {
-            return Err(Error::InvalidConfig {
-                op: DOT_GENERAL_OP,
-                message: format!(
-                    "batch dim size mismatch: lhs axis {lhs_axis}={lhs_dim} rhs axis {rhs_axis}={rhs_dim}"
-                ),
-            });
+            return Err(Error::validation(
+                DOT_GENERAL_OP,
+                ShapeMismatch::IncompatibleShapes {
+                    lhs: ShapeVec::from_vec(vec![lhs_dim]),
+                    rhs: ShapeVec::from_vec(vec![rhs_dim]),
+                }
+                .into(),
+            ));
         }
     }
 
@@ -407,9 +407,9 @@ fn dot_general_f32(
         return Ok(output);
     }
     if plan.k == 0 {
-        return Err(Error::backend_failure(
+        return Err(unsupported_operation(
             DOT_GENERAL_OP,
-            "WebGPU CubeK matmul does not support zero-sized contracting dimensions yet",
+            "CubeK matmul does not support zero-sized contracting dimensions yet",
         ));
     }
     let lhs = prepare_lhs_operand(backend, lhs, &plan)?;
@@ -440,7 +440,7 @@ fn dot_general_f32(
         output_binding,
         &mut dtypes,
     )
-    .map_err(|err| Error::backend_failure(DOT_GENERAL_OP, format!("{err:?}")))?;
+    .map_err(|err| Error::backend_source(DOT_GENERAL_OP, err))?;
 
     Ok(output)
 }
@@ -462,9 +462,9 @@ fn dot_general_c32(
         return Ok(output);
     }
     if plan.k == 0 {
-        return Err(Error::backend_failure(
+        return Err(unsupported_operation(
             DOT_GENERAL_OP,
-            "WebGPU CubeK matmul does not support zero-sized contracting dimensions yet",
+            "CubeK matmul does not support zero-sized contracting dimensions yet",
         ));
     }
     let lhs = prepare_lhs_operand(backend, lhs, &plan)?;
@@ -496,7 +496,7 @@ fn dot_general_c32(
         &mut dtypes,
         ComplexMatmulOptions { lhs_conj, rhs_conj },
     )
-    .map_err(|err| Error::backend_failure(DOT_GENERAL_OP, format!("{err:?}")))?;
+    .map_err(|err| Error::backend_source(DOT_GENERAL_OP, err))?;
 
     Ok(output)
 }
@@ -513,17 +513,15 @@ pub(super) fn dot_general_with_conj(
         (Tensor::F32(lhs), Tensor::F32(rhs)) => {
             dot_general_f32(backend, lhs, rhs, config).map(Tensor::F32)
         }
-        (Tensor::F64(_), Tensor::F64(_)) => Err(Error::backend_failure(
-            DOT_GENERAL_OP,
-            "WebGPU CubeK matmul currently supports f32 real inputs; f64 is not available in the initial WebGPU path",
-        )),
+        (Tensor::F64(_), Tensor::F64(_)) => {
+            Err(unsupported_dtype(DOT_GENERAL_OP, crate::DType::F64))
+        }
         (Tensor::C32(lhs), Tensor::C32(rhs)) => {
             dot_general_c32(backend, lhs, rhs, config, lhs_conj, rhs_conj).map(Tensor::C32)
         }
-        (Tensor::C64(_), Tensor::C64(_)) => Err(Error::backend_failure(
-            DOT_GENERAL_OP,
-            "WebGPU complex64 matmul requires f64 support and is not available in the initial WebGPU path",
-        )),
+        (Tensor::C64(_), Tensor::C64(_)) => {
+            Err(unsupported_dtype(DOT_GENERAL_OP, crate::DType::C64))
+        }
         _ => Err(dtype_mismatch(DOT_GENERAL_OP, lhs, rhs)),
     }
 }

--- a/crates/tenferro-gpu/src/webgpu/memory.rs
+++ b/crates/tenferro-gpu/src/webgpu/memory.rs
@@ -20,6 +20,13 @@ use crate::{Buffer, Tensor, TypedTensor};
 ///
 /// let _upload: fn(&WebGpuRuntime, &Tensor) -> Result<Tensor> = upload_webgpu_tensor;
 /// ```
+///
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeState`] when the source buffer is backend
+/// resident or belongs to another placement, [`crate::Error::Unsupported`] for
+/// a dtype unavailable in WebGPU, or [`crate::Error::BackendSource`] on
+/// allocation.
 pub fn upload_webgpu_tensor(rt: &WebGpuRuntime, tensor: &Tensor) -> crate::Result<Tensor> {
     let client = rt.client();
     match tensor {
@@ -47,6 +54,12 @@ pub fn upload_webgpu_tensor(rt: &WebGpuRuntime, tensor: &Tensor) -> crate::Resul
 ///
 /// let _download: fn(&WebGpuRuntime, &Tensor) -> Result<Tensor> = download_webgpu_tensor;
 /// ```
+///
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeState`] for missing or foreign device state,
+/// [`crate::Error::BackendSource`] when queue synchronization/readback fails,
+/// or a typed validation error when bytes do not match the tensor shape.
 pub fn download_webgpu_tensor(rt: &WebGpuRuntime, tensor: &Tensor) -> crate::Result<Tensor> {
     let client = rt.client();
     match tensor {
@@ -68,7 +81,7 @@ pub(super) fn upload_typed<T: CubeElement + Clone + Send + Sync + 'static>(
     let host_data = match typed.buffer() {
         Buffer::Host(data) => data,
         Buffer::Backend(buffer) => {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "webgpu_upload",
                 format!(
                     "expected host buffer, got `{}` backend buffer",
@@ -94,7 +107,7 @@ pub(super) fn download_typed<T: CubeElement + Clone + 'static>(
     ensure_resident_on_runtime(rt, typed, "webgpu_download")?;
     let handle = match typed.buffer() {
         Buffer::Host(_) => {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "webgpu_download",
                 "expected WebGPU backend buffer",
             ));
@@ -111,7 +124,7 @@ pub(super) fn download_typed<T: CubeElement + Clone + 'static>(
 
     let bytes = client
         .read_one(handle)
-        .map_err(|err| crate::Error::backend_failure("webgpu_download", format!("{err:?}")))?;
+        .map_err(|err| crate::Error::backend_source("webgpu_download", err))?;
     let data = T::from_bytes(&bytes).to_vec();
     Ok(TypedTensor::from_vec_col_major(
         typed.shape().to_vec(),
@@ -127,7 +140,7 @@ fn upload_bool(
     let host_data = match typed.buffer() {
         Buffer::Host(data) => data,
         Buffer::Backend(buffer) => {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "webgpu_upload",
                 format!(
                     "expected host buffer, got `{}` backend buffer",
@@ -154,7 +167,7 @@ fn download_bool(
     ensure_resident_on_runtime(rt, typed, "webgpu_download")?;
     let handle = match typed.buffer() {
         Buffer::Host(_) => {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "webgpu_download",
                 "expected WebGPU backend buffer",
             ));
@@ -171,7 +184,7 @@ fn download_bool(
 
     let bytes = client
         .read_one(handle)
-        .map_err(|err| crate::Error::backend_failure("webgpu_download", format!("{err:?}")))?;
+        .map_err(|err| crate::Error::backend_source("webgpu_download", err))?;
     let data = bytes.iter().map(|&byte| byte != 0).collect();
     Ok(TypedTensor::from_vec_col_major(
         typed.shape().to_vec(),

--- a/crates/tenferro-gpu/src/webgpu/mod.rs
+++ b/crates/tenferro-gpu/src/webgpu/mod.rs
@@ -15,11 +15,13 @@ use crate::{
 
 const DEFAULT_CUBE_DIM_X: u32 = 256;
 
+mod error;
 mod gemm;
 mod kernels;
 mod memory;
 mod runtime;
 
+pub(crate) use error::{unsupported_dtype, unsupported_operation};
 pub use memory::{download_webgpu_tensor, upload_webgpu_tensor};
 pub use runtime::{webgpu_available, WebGpuRuntime};
 
@@ -80,7 +82,7 @@ fn webgpu_handle_from_backend<T: 'static>(
         .downcast_ref::<WebGpuBuffer<T>>()
         .map(|buffer| buffer.handle().clone())
         .ok_or_else(|| {
-            crate::Error::backend_failure(
+            crate::Error::runtime_state(
                 op,
                 format!(
                     "expected WebGPU backend buffer, got `{}` backend buffer",
@@ -95,15 +97,20 @@ fn checked_shape_product(op: &'static str, shape: &[usize]) -> crate::Result<usi
         .iter()
         .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
         .ok_or_else(|| {
-            Error::backend_failure(op, format!("shape product overflow for shape {shape:?}"))
+            Error::invalid_argument(
+                op,
+                "shape",
+                format!("shape product overflow for shape {shape:?}"),
+            )
         })
 }
 
 fn cube_count_for_len(len: usize) -> crate::Result<CubeCount> {
     let cubes = len.div_ceil(DEFAULT_CUBE_DIM_X as usize);
     let cubes = u32::try_from(cubes).map_err(|_| {
-        Error::backend_failure(
+        Error::invalid_argument(
             "cube_count_for_len",
+            "length",
             format!(
                 "1D WebGPU launch for {len} elements requires {cubes} cubes, \
                  which exceeds u32::MAX"
@@ -136,7 +143,7 @@ fn validate_webgpu_buffer_len<T>(
     let expected_len = checked_shape_product(op, tensor.shape())?;
     let actual_len = buffer.element_len();
     if expected_len != actual_len {
-        return Err(Error::backend_failure(
+        return Err(Error::runtime_state(
             op,
             format!(
                 "expected shape product {expected_len} elements, actual WebGpuBuffer::len {actual_len}"
@@ -151,7 +158,7 @@ fn webgpu_buffer<'a, T: 'static>(
     op: &'static str,
 ) -> crate::Result<&'a WebGpuBuffer<T>> {
     match tensor.buffer() {
-        Buffer::Host(_) => Err(Error::backend_failure(
+        Buffer::Host(_) => Err(Error::runtime_state(
             op,
             "expected WebGPU tensor, got host tensor. \
              Use upload_webgpu_tensor() to transfer to WebGPU before calling WebGPU ops.",
@@ -160,7 +167,7 @@ fn webgpu_buffer<'a, T: 'static>(
             .as_any()
             .downcast_ref::<WebGpuBuffer<T>>()
             .ok_or_else(|| {
-                Error::backend_failure(
+                Error::runtime_state(
                     op,
                     format!(
                         "expected WebGPU tensor, got backend buffer family `{}`",
@@ -178,20 +185,13 @@ fn typed_tensor_binding_with_layout<T: CubeElement + Clone>(
     op: &'static str,
 ) -> crate::Result<TensorBinding<WgpuRuntime>> {
     if shape.len() != strides.len() {
-        return Err(Error::backend_failure(
-            op,
-            format!(
-                "WebGPU tensor binding layout rank mismatch: shape rank {} stride rank {}",
-                shape.len(),
-                strides.len()
-            ),
-        ));
+        return Err(Error::rank_mismatch(op, shape.len(), strides.len()));
     }
     let buffer = webgpu_buffer(tensor, op)?;
     validate_webgpu_buffer_len(tensor, buffer, op)?;
     let layout_len = checked_shape_product(op, shape)?;
     if layout_len != buffer.element_len() {
-        return Err(Error::backend_failure(
+        return Err(Error::runtime_state(
             op,
             format!(
                 "WebGPU tensor binding layout covers {layout_len} elements, backing buffer has {}",
@@ -230,7 +230,7 @@ fn ensure_placement_resident_on_runtime(
     op: &'static str,
 ) -> crate::Result<()> {
     if !matches!(&placement.memory_kind, MemoryKind::Device) {
-        return Err(Error::backend_failure(
+        return Err(Error::runtime_state(
             op,
             format!(
                 "expected WebGPU tensor placement, got {:?}",
@@ -245,7 +245,7 @@ fn ensure_placement_resident_on_runtime(
         {
             Ok(())
         }
-        Some(device) => Err(Error::backend_failure(
+        Some(device) => Err(Error::runtime_state(
             op,
             format!(
                 "expected WebGPU tensor resident on webgpu:{}, got {:?}:{}",
@@ -254,7 +254,7 @@ fn ensure_placement_resident_on_runtime(
                 device.ordinal
             ),
         )),
-        None => Err(Error::backend_failure(
+        None => Err(Error::runtime_state(
             op,
             format!(
                 "expected WebGPU tensor resident on webgpu:{}, got missing device metadata",
@@ -283,8 +283,9 @@ fn alloc_output<T: CubeElement + Clone + Send + Sync + 'static>(
 ) -> crate::Result<TypedTensor<T>> {
     let len = checked_shape_product(op, shape)?;
     let bytes = len.checked_mul(core::mem::size_of::<T>()).ok_or_else(|| {
-        Error::backend_failure(
+        Error::invalid_argument(
             op,
+            "shape",
             format!("WebGPU output byte length overflow for shape {shape:?}"),
         )
     })?;
@@ -337,6 +338,12 @@ impl WebGpuBackend {
     ///
     /// let _ctor: fn(usize) -> tenferro_tensor::Result<WebGpuBackend> = WebGpuBackend::new;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] when no adapter/device is
+    /// available, or [`crate::Error::BackendSource`] when CubeCL initialization
+    /// fails.
     pub fn new(device_ordinal: usize) -> crate::Result<Self> {
         WebGpuRuntime::new(device_ordinal).map(Self::from_runtime)
     }
@@ -350,6 +357,12 @@ impl WebGpuBackend {
     ///
     /// let _ctor: fn() -> tenferro_tensor::Result<WebGpuBackend> = WebGpuBackend::new_default;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] when default adapter selection
+    /// is unavailable, or [`crate::Error::BackendSource`] when initialization
+    /// fails.
     pub fn new_default() -> crate::Result<Self> {
         WebGpuRuntime::new_default().map(Self::from_runtime)
     }
@@ -389,13 +402,19 @@ impl WebGpuBackend {
     ///
     /// let _sync: fn(&WebGpuBackend) -> tenferro_tensor::Result<()> = WebGpuBackend::synchronize;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::BackendSource`] when queue flush or
+    /// synchronization fails, or [`crate::Error::RuntimeState`] when the
+    /// runtime has lost its device state.
     pub fn synchronize(&self) -> crate::Result<()> {
         self.runtime.synchronize()
     }
 }
 
 fn unsupported_op(op: &'static str) -> crate::Error {
-    crate::Error::backend_failure(
+    crate::Error::unsupported(
         op,
         "WebGPU backend does not support this operation yet; upload/download explicitly and use a supported backend operation",
     )

--- a/crates/tenferro-gpu/src/webgpu/runtime.rs
+++ b/crates/tenferro-gpu/src/webgpu/runtime.rs
@@ -52,6 +52,11 @@ impl WebGpuRuntime {
     ///
     /// let _ctor: fn(usize) -> tenferro_tensor::Result<WebGpuRuntime> = WebGpuRuntime::new;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] when the requested adapter is
+    /// unavailable or CubeCL initialization panics while selecting it.
     pub fn new(device_ordinal: usize) -> crate::Result<Self> {
         Self::from_device(WgpuDevice::DiscreteGpu(device_ordinal), device_ordinal)
     }
@@ -65,6 +70,11 @@ impl WebGpuRuntime {
     ///
     /// let _ctor: fn() -> tenferro_tensor::Result<WebGpuRuntime> = WebGpuRuntime::new_default;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] when default adapter selection is
+    /// unavailable or CubeCL initialization panics.
     pub fn new_default() -> crate::Result<Self> {
         Self::from_device(WgpuDevice::DefaultDevice, 0)
     }
@@ -74,7 +84,7 @@ impl WebGpuRuntime {
             WgpuRuntime::client(&device)
         }))
         .map_err(|payload| {
-            crate::Error::backend_failure(
+            crate::Error::runtime_state(
                 "webgpu_runtime_init",
                 format!("failed to initialize CubeCL WebGPU runtime: {payload:?}"),
             )
@@ -112,12 +122,15 @@ impl WebGpuRuntime {
     /// let _sync: fn(&WebGpuRuntime) -> tenferro_tensor::Result<()> =
     ///     WebGpuRuntime::synchronize;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::BackendSource`] when queue flush or sync fails.
     pub fn synchronize(&self) -> crate::Result<()> {
         const OP: &str = "webgpu_runtime_synchronize";
         self.client
             .flush()
-            .map_err(|err| crate::Error::backend_failure(OP, format!("{err:?}")))?;
-        future::block_on(self.client.sync())
-            .map_err(|err| crate::Error::backend_failure(OP, format!("{err:?}")))
+            .map_err(|err| crate::Error::backend_source(OP, err))?;
+        future::block_on(self.client.sync()).map_err(|err| crate::Error::backend_source(OP, err))
     }
 }

--- a/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
@@ -33,8 +33,12 @@ fn bool_structural_support_uses_copy_kernels_and_scatter_stays_excluded() {
             "missing Bool copy/index dispatch: {needle}"
         );
     }
-    assert!(source.contains("Bool data tensors are not supported by additive scatter"));
-    assert!(!source.contains("scatter_bool_typed"));
+    let scatter = source_section(&source, "    fn scatter(", "    fn slice(");
+    assert!(
+        scatter.contains("(Tensor::Bool(_), _, _)")
+            && scatter.contains("Err(unsupported_dtype(\"scatter\", operand.dtype()))")
+    );
+    assert!(!scatter.contains("scatter_bool_typed"));
 }
 
 #[test]
@@ -1054,7 +1058,7 @@ fn cubecl_real_complex_scalar_promotion_stays_device_native_and_narrow() {
             "if !real.shape().is_empty()",
             "ensure_resident_on_runtime(backend.runtime(), real, op)?",
             "ensure_resident_on_runtime(backend.runtime(), complex, op)?",
-            "let component_len = complex\n        .n_elements()\n        .checked_mul(2)",
+            "let component_len = complex.n_elements().checked_mul(2)",
             "let real_arg = typed_tensor_array_arg(real, op)?",
             "// INVARIANT: `num_complex::Complex<T>` is `repr(C)` with interleaved `{ re, im }`",
             "let complex_arg = typed_tensor_array_arg_as::<C, R>(complex, component_len, op)?",

--- a/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
@@ -36,7 +36,8 @@ fn bool_structural_support_uses_copy_kernels_and_scatter_stays_excluded() {
     let scatter = source_section(&source, "    fn scatter(", "    fn slice(");
     assert!(
         scatter.contains("(Tensor::Bool(_), _, _)")
-            && scatter.contains("Err(unsupported_dtype(\"scatter\", operand.dtype()))")
+            && scatter.contains("Err(unsupported_operation(")
+            && scatter.contains("Bool data tensors are not supported by additive scatter")
     );
     assert!(!scatter.contains("scatter_bool_typed"));
 }

--- a/crates/tenferro-gpu/tests/integration/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/public_surface_contract.rs
@@ -336,9 +336,9 @@ fn cubecl_copy_into_reports_typed_shape_mismatch() {
         .0;
 
     assert!(
-        copy_body.contains("crate::Error::ShapeMismatch")
-            && copy_body.contains("lhs: src.shape().to_vec()")
-            && copy_body.contains("rhs: dst.shape().to_vec()"),
+        copy_body.contains("crate::Error::shape_mismatch(")
+            && copy_body.contains("src.shape().to_vec()")
+            && copy_body.contains("dst.shape().to_vec()"),
         "CUDA copy_into shape mismatch must use the shared typed error"
     );
 }

--- a/crates/tenferro-internal-extension-macros/src/lib.rs
+++ b/crates/tenferro-internal-extension-macros/src/lib.rs
@@ -226,6 +226,8 @@ fn expand_extension_runtime(args: RuntimeArgs) -> proc_macro2::TokenStream {
             }
         }
 
+        #[doc = "Register this extension runtime with an executor registry."]
+        #[doc = "\n# Errors\n\nReturns `ExtensionRuntimeRegistryError::MalformedFamilyId` when the generated family identifier is invalid."]
         pub fn #register_fn<B: #backend_bound + 'static>(
             executor: &mut tenferro_runtime::extension::ExtensionExecutor<B>,
         ) -> std::result::Result<

--- a/crates/tenferro-internal-extension-macros/src/lib.rs
+++ b/crates/tenferro-internal-extension-macros/src/lib.rs
@@ -200,10 +200,11 @@ fn expand_extension_runtime(args: RuntimeArgs) -> proc_macro2::TokenStream {
                 let op = op
                     .as_any()
                     .downcast_ref::<#op_type>()
-                    .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-                        op: "extension_runtime",
-                        message: format!("payload type mismatch for {}", #family_id),
-                    })?;
+                    .ok_or_else(|| tenferro_tensor::Error::invalid_argument(
+                        "extension_runtime",
+                        "payload",
+                        format!("type mismatch for {}", #family_id),
+                    ))?;
                 #execute(op, inputs, ctx)
             }
 
@@ -216,10 +217,11 @@ fn expand_extension_runtime(args: RuntimeArgs) -> proc_macro2::TokenStream {
                 let op = op
                     .as_any()
                     .downcast_ref::<#op_type>()
-                    .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-                        op: "extension_runtime",
-                        message: format!("payload type mismatch for {}", #family_id),
-                    })?;
+                    .ok_or_else(|| tenferro_tensor::Error::invalid_argument(
+                        "extension_runtime",
+                        "payload",
+                        format!("type mismatch for {}", #family_id),
+                    ))?;
                 #execute_reads(op, inputs, ctx)
             }
         }

--- a/crates/tenferro-internal-ops/src/ad/context.rs
+++ b/crates/tenferro-internal-ops/src/ad/context.rs
@@ -474,6 +474,11 @@ impl ShapeGuardContext {
     /// let shape = ctx.shape_of(&value).unwrap();
     /// assert_eq!(shape, &[SymDim::from(4usize)]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ShapeGuardError`] when the value cannot be resolved, metadata
+    /// is missing, or the metadata does not describe an exact shape.
     pub fn shape_of(&mut self, val: &ValueRef<StdTensorOp>) -> ShapeGuardResult<Vec<SymDim>> {
         let key = self.resolve_key(val)?.clone();
         self.ensure_metadata_loaded(&key);
@@ -511,6 +516,11 @@ impl ShapeGuardContext {
     ///
     /// assert_eq!(ctx.rank_of(&value).unwrap(), 1);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ShapeGuardError`] when the value cannot be resolved or its
+    /// metadata is unavailable.
     pub fn rank_of(&mut self, val: &ValueRef<StdTensorOp>) -> ShapeGuardResult<usize> {
         self.metadata_of(val).map(TensorMeta::rank)
     }
@@ -537,6 +547,11 @@ impl ShapeGuardContext {
     /// let extents = ctx.extents_of(&value).unwrap();
     /// assert_eq!(extents[0], ShapeExtent::upper_bound(SymDim::from(8usize)));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ShapeGuardError`] when the value cannot be resolved or its
+    /// metadata is unavailable.
     pub fn extents_of(
         &mut self,
         val: &ValueRef<StdTensorOp>,
@@ -566,6 +581,11 @@ impl ShapeGuardContext {
     /// let maybe_shape = ctx.exact_shape_of(&value).unwrap();
     /// assert_eq!(maybe_shape, None);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ShapeGuardError`] when the value cannot be resolved or its
+    /// metadata is unavailable.
     pub fn exact_shape_of(
         &mut self,
         val: &ValueRef<StdTensorOp>,
@@ -598,6 +618,11 @@ impl ShapeGuardContext {
     /// let dtype = ctx.dtype_of(&value).unwrap();
     /// assert_eq!(dtype, DType::F64);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ShapeGuardError`] when the value cannot be resolved or its
+    /// metadata is unavailable.
     pub fn dtype_of(&mut self, val: &ValueRef<StdTensorOp>) -> ShapeGuardResult<DType> {
         self.metadata_of(val).map(|meta| meta.dtype)
     }
@@ -621,6 +646,11 @@ impl ShapeGuardContext {
     /// let meta = ctx.metadata_of(&value).unwrap();
     /// assert_eq!(meta.dtype, DType::F64);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ShapeGuardError`] when the value cannot be resolved or its
+    /// metadata is unavailable.
     pub fn metadata_of(&mut self, val: &ValueRef<StdTensorOp>) -> ShapeGuardResult<&TensorMeta> {
         let key = self.resolve_key(val)?.clone();
         self.ensure_metadata_loaded(&key);
@@ -713,6 +743,11 @@ impl ShapeGuardContext {
 /// let meta = lookup_global_metadata(&key).unwrap();
 /// assert!(meta.is_none());
 /// ```
+///
+/// # Errors
+///
+/// Returns [`MetadataRegistryError::LockPoisoned`] when the global metadata
+/// registry lock is poisoned.
 pub fn lookup_global_metadata(
     key: &ValueKey<StdTensorOp>,
 ) -> Result<Option<TensorMeta>, MetadataRegistryError> {
@@ -723,6 +758,11 @@ pub fn lookup_global_metadata(
 }
 
 #[doc(hidden)]
+///
+/// # Errors
+///
+/// Returns [`MetadataRegistryError::LockPoisoned`] when the global metadata
+/// registry lock is poisoned.
 pub fn register_scoped_global_metadata_batch<I>(
     entries: I,
 ) -> Result<GlobalMetadataScope, MetadataRegistryError>

--- a/crates/tenferro-internal-ops/src/ad/context.rs
+++ b/crates/tenferro-internal-ops/src/ad/context.rs
@@ -44,6 +44,15 @@ pub enum MetadataRegistryError {
 }
 
 /// Error returned when shape-guard metadata cannot be resolved.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_ops::ShapeGuardError;
+///
+/// let error = ShapeGuardError::LocalWithoutAttachedGraph { local_id: 0 };
+/// assert!(error.to_string().contains("attached graph"));
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ShapeGuardError {
     /// A local graph value was queried before a graph was attached.
@@ -73,18 +82,114 @@ pub enum ShapeGuardError {
 }
 
 /// Result type used by shape-guard metadata queries.
-pub type ShapeGuardResult<T> = Result<T, ShapeGuardError>;
+///
+/// The error side preserves a [`ShapeGuardFailure`] wrapper so an AD callback
+/// can retain the original [`ShapeGuardError`] even when a foreign callback
+/// protocol accepts only a rendered message.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_ops::ShapeGuardResult;
+///
+/// let result: ShapeGuardResult<()> = Ok(());
+/// assert!(result.is_ok());
+/// ```
+pub type ShapeGuardResult<T> = Result<T, ShapeGuardFailure>;
 
 #[cfg(feature = "autodiff")]
-impl From<ShapeGuardError> for tidu::ADRuleError {
-    fn from(err: ShapeGuardError) -> Self {
+impl From<ShapeGuardFailure> for tidu::ADRuleError {
+    fn from(err: ShapeGuardFailure) -> Self {
+        err.record_for_ad_boundary();
         tidu::ADRuleError::invalid_input(
             "tenferro.shape_guard",
             tidu::ADRuleKind::Jvp,
-            err.to_string(),
+            err.typed_source().to_string(),
         )
     }
 }
+
+/// Error returned by a shape-guard metadata query.
+///
+/// The public [`ShapeGuardError`] remains the typed source. The private side
+/// channel is shared with the owning [`ShapeGuardContext`] so an external
+/// message-only AD callback can report the same typed source at the runtime
+/// boundary without changing the callback protocol.
+///
+/// # Examples
+///
+/// ```
+/// use computegraph::types::{ValueKey, ValueRef};
+/// use tenferro_ops::input_key::TensorInputKey;
+/// use tenferro_ops::std_tensor_op::StdTensorOp;
+/// use tenferro_ops::{ShapeGuardContext, ShapeGuardError};
+///
+/// let key = ValueKey::<StdTensorOp>::Input(TensorInputKey::User { id: 8 });
+/// let value = ValueRef::External(key);
+/// let mut ctx = ShapeGuardContext::default();
+/// let failure = ctx.shape_of(&value).unwrap_err();
+/// assert!(matches!(
+///     failure.typed_source(),
+///     ShapeGuardError::MissingMetadata { .. }
+/// ));
+/// ```
+#[derive(Clone, Debug)]
+pub struct ShapeGuardFailure {
+    source: ShapeGuardError,
+    #[cfg(feature = "autodiff")]
+    deferred: Arc<Mutex<Option<ShapeGuardError>>>,
+}
+
+impl ShapeGuardFailure {
+    #[cfg(feature = "autodiff")]
+    fn new(source: ShapeGuardError, deferred: Arc<Mutex<Option<ShapeGuardError>>>) -> Self {
+        Self { source, deferred }
+    }
+
+    #[cfg(not(feature = "autodiff"))]
+    fn new(source: ShapeGuardError) -> Self {
+        Self { source }
+    }
+
+    /// Return the original typed shape-guard failure.
+    pub fn typed_source(&self) -> &ShapeGuardError {
+        &self.source
+    }
+
+    /// Consume this boundary error and return its original typed failure.
+    pub fn into_typed_source(self) -> ShapeGuardError {
+        self.source
+    }
+
+    #[cfg(feature = "autodiff")]
+    fn record_for_ad_boundary(&self) {
+        if let Ok(mut deferred) = self.deferred.lock() {
+            if deferred.is_none() {
+                *deferred = Some(self.source.clone());
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ShapeGuardFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.source.fmt(f)
+    }
+}
+
+impl std::error::Error for ShapeGuardFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl PartialEq for ShapeGuardFailure {
+    fn eq(&self, other: &Self) -> bool {
+        self.source == other.source
+    }
+}
+
+impl Eq for ShapeGuardFailure {}
 
 /// Global metadata registry.
 ///
@@ -273,6 +378,8 @@ pub struct ShapeGuardContext {
     use_global_registry: bool,
     local_keys: Option<Vec<ValueKey<StdTensorOp>>>,
     #[cfg(feature = "autodiff")]
+    deferred_shape_error: Arc<Mutex<Option<ShapeGuardError>>>,
+    #[cfg(feature = "autodiff")]
     extension_rules: Option<ExtensionRuleSet>,
     #[cfg(feature = "autodiff")]
     active_value_keys: Option<std::sync::Arc<std::collections::HashSet<ValueKey<StdTensorOp>>>>,
@@ -455,6 +562,21 @@ impl ShapeGuardContext {
         self.guards.clear();
     }
 
+    /// Take the first typed shape-guard failure recorded while crossing an AD
+    /// callback boundary.
+    ///
+    /// `tidu` currently exposes only a message-bearing callback error. AD
+    /// frontends call this after the callback returns and attach the typed
+    /// value to their public runtime error.
+    #[doc(hidden)]
+    #[cfg(feature = "autodiff")]
+    pub fn take_deferred_shape_error(&mut self) -> Option<ShapeGuardError> {
+        self.deferred_shape_error
+            .lock()
+            .ok()
+            .and_then(|mut error| error.take())
+    }
+
     /// Return the shape metadata for a value reference.
     ///
     /// # Examples
@@ -482,12 +604,11 @@ impl ShapeGuardContext {
     pub fn shape_of(&mut self, val: &ValueRef<StdTensorOp>) -> ShapeGuardResult<Vec<SymDim>> {
         let key = self.resolve_key(val)?.clone();
         self.ensure_metadata_loaded(&key);
-        let meta = self
-            .metadata
-            .get(&key)
-            .ok_or_else(|| ShapeGuardError::MissingMetadata { key: key.clone() })?;
+        let meta = self.metadata.get(&key).ok_or_else(|| {
+            self.shape_guard_failure(ShapeGuardError::MissingMetadata { key: key.clone() })
+        })?;
         meta.exact_shape()
-            .ok_or(ShapeGuardError::NonExactShape { key })
+            .ok_or_else(|| self.shape_guard_failure(ShapeGuardError::NonExactShape { key }))
     }
 
     /// Return the rank for a value reference without requiring exact extents.
@@ -656,7 +777,7 @@ impl ShapeGuardContext {
         self.ensure_metadata_loaded(&key);
         self.metadata
             .get(&key)
-            .ok_or(ShapeGuardError::MissingMetadata { key })
+            .ok_or_else(|| self.shape_guard_failure(ShapeGuardError::MissingMetadata { key }))
     }
 
     #[doc(hidden)]
@@ -703,19 +824,30 @@ impl ShapeGuardContext {
     ) -> ShapeGuardResult<&'a ValueKey<StdTensorOp>> {
         match val {
             ValueRef::External(key) => Ok(key),
-            ValueRef::Local(local_id) if self.local_keys.is_none() => {
-                Err(ShapeGuardError::LocalWithoutAttachedGraph {
+            ValueRef::Local(local_id) if self.local_keys.is_none() => Err(self
+                .shape_guard_failure(ShapeGuardError::LocalWithoutAttachedGraph {
                     local_id: *local_id,
-                })
-            }
+                })),
             ValueRef::Local(local_id) => self
                 .local_keys
                 .as_ref()
                 .and_then(|keys| keys.get(*local_id))
-                .ok_or(ShapeGuardError::LocalOutOfBounds {
-                    local_id: *local_id,
+                .ok_or_else(|| {
+                    self.shape_guard_failure(ShapeGuardError::LocalOutOfBounds {
+                        local_id: *local_id,
+                    })
                 }),
         }
+    }
+
+    #[cfg(feature = "autodiff")]
+    fn shape_guard_failure(&self, source: ShapeGuardError) -> ShapeGuardFailure {
+        ShapeGuardFailure::new(source, Arc::clone(&self.deferred_shape_error))
+    }
+
+    #[cfg(not(feature = "autodiff"))]
+    fn shape_guard_failure(&self, source: ShapeGuardError) -> ShapeGuardFailure {
+        ShapeGuardFailure::new(source)
     }
 
     fn ensure_metadata_loaded(&mut self, key: &ValueKey<StdTensorOp>) {

--- a/crates/tenferro-internal-ops/src/ad/mod.rs
+++ b/crates/tenferro-internal-ops/src/ad/mod.rs
@@ -124,6 +124,13 @@ impl PrimitiveRuleBuilder for GraphBuilder<StdTensorOp> {
 /// Rules per op live in the category submodules (`semiring`, `analytic`,
 /// `elementwise`, `structural`, `contraction`, `indexing`, `diagonal`,
 /// `dynamic`). `StdTensorOp::Extension(_)` delegates to the trait.
+///
+/// # Errors
+///
+/// Returns [`ADRuleError::InvalidInput`] when the operation is not a known
+/// primitive or when a registered rule rejects the graph metadata. Returns
+/// [`ADRuleError::Unsupported`] when no AD rule is registered for the
+/// operation. Errors returned by an extension rule are propagated unchanged.
 #[cfg(feature = "autodiff")]
 pub fn linearize(
     op: &StdTensorOp,
@@ -158,6 +165,13 @@ pub fn linearize(
 ///
 /// See [`linearize`] for the category split; the same categories appear
 /// here.
+///
+/// # Errors
+///
+/// Returns [`ADRuleError::InvalidInput`] when the operation, transpose inputs,
+/// or graph metadata are inconsistent. Returns [`ADRuleError::Unsupported`]
+/// when the required primitive or extension transpose rule is unavailable.
+/// Errors returned by a registered rule are propagated unchanged.
 #[cfg(feature = "autodiff")]
 pub fn transpose_rule(
     op: &StdTensorOp,

--- a/crates/tenferro-internal-ops/src/ad/structural.rs
+++ b/crates/tenferro-internal-ops/src/ad/structural.rs
@@ -538,7 +538,7 @@ fn broadcast_transpose_reduce_axes(
                     needs_input_shape_restore = true;
                 }
             }
-            Err(ShapeGuardError::MissingMetadata { .. }) => {}
+            Err(err) if matches!(err.typed_source(), ShapeGuardError::MissingMetadata { .. }) => {}
             Err(err) => return Err(err.into()),
         }
     }

--- a/crates/tenferro-internal-ops/src/ad/tests/mod.rs
+++ b/crates/tenferro-internal-ops/src/ad/tests/mod.rs
@@ -164,7 +164,11 @@ fn metadata_exact_shape_rejects_upper_bound() {
     assert_eq!(ctx.exact_shape_of(&value).unwrap(), None);
     assert!(matches!(
         ctx.shape_of(&value),
-        Err(crate::ad::context::ShapeGuardError::NonExactShape { .. })
+        Err(err)
+            if matches!(
+                err.typed_source(),
+                crate::ad::context::ShapeGuardError::NonExactShape { .. }
+            )
     ));
 }
 

--- a/crates/tenferro-internal-ops/src/axis.rs
+++ b/crates/tenferro-internal-ops/src/axis.rs
@@ -21,6 +21,11 @@ pub enum AxisError {
 /// assert_eq!(normalize_axis(-1, 3).unwrap(), 2);
 /// assert!(normalize_axis(3, 3).is_err());
 /// ```
+///
+/// # Errors
+///
+/// Returns [`AxisError::OutOfBounds`] when `axis` is outside the normalized
+/// range for `rank`.
 pub fn normalize_axis(axis: isize, rank: usize) -> Result<usize, AxisError> {
     let normalized = if axis >= 0 {
         axis as usize
@@ -44,6 +49,11 @@ pub fn normalize_axis(axis: isize, rank: usize) -> Result<usize, AxisError> {
 /// assert_eq!(normalize_axes(&[0, -1], 3).unwrap(), vec![0, 2]);
 /// assert!(normalize_axes(&[1, -2], 3).is_err());
 /// ```
+///
+/// # Errors
+///
+/// Returns [`AxisError::OutOfBounds`] for an invalid axis or
+/// [`AxisError::Duplicate`] when two axes normalize to the same position.
 pub fn normalize_axes(axes: &[isize], rank: usize) -> Result<Vec<usize>, AxisError> {
     let mut out = Vec::with_capacity(axes.len());
     let mut seen = vec![false; rank];

--- a/crates/tenferro-internal-ops/src/broadcast.rs
+++ b/crates/tenferro-internal-ops/src/broadcast.rs
@@ -1,3 +1,4 @@
+use tenferro_tensor::{ShapeMismatch, ShapeVec, ValidationError};
 use thiserror::Error;
 
 /// Lowering plan for broadcasting one input to an output shape.
@@ -27,6 +28,97 @@ pub enum BroadcastError {
         input: Vec<usize>,
         output: Vec<usize>,
     },
+}
+
+/// Convert a broadcast-planning failure to the shared validation vocabulary.
+///
+/// Every eager, traced, and direct broadcast surface uses this mapping so the
+/// same invalid shapes have the same machine-readable payload regardless of
+/// where the check is discovered.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_ops::broadcast::{broadcast_error_to_validation, BroadcastError};
+/// use tenferro_tensor::{ShapeMismatch, ValidationError};
+///
+/// let error = broadcast_error_to_validation(BroadcastError::IncompatibleInput {
+///     input: vec![2, 3],
+///     output: vec![2, 4],
+/// });
+/// assert!(matches!(
+///     error,
+///     ValidationError::ShapeMismatch(source)
+///         if matches!(source.as_ref(), ShapeMismatch::ExpectedActual { expected, actual }
+///             if expected.as_slice() == [2, 4] && actual.as_slice() == [2, 3])
+/// ));
+/// ```
+pub fn broadcast_error_to_validation(error: BroadcastError) -> ValidationError {
+    match error {
+        BroadcastError::IncompatibleBinary { lhs, rhs } => ShapeMismatch::IncompatibleShapes {
+            lhs: ShapeVec::from_vec(lhs),
+            rhs: ShapeVec::from_vec(rhs),
+        }
+        .into(),
+        BroadcastError::IncompatibleInput { input, output } => ShapeMismatch::ExpectedActual {
+            expected: ShapeVec::from_vec(output),
+            actual: ShapeVec::from_vec(input),
+        }
+        .into(),
+        BroadcastError::RankTooLarge { input, output } => ValidationError::RankMismatch {
+            expected: output.len(),
+            actual: input.len(),
+        },
+    }
+}
+
+/// Find a broadcast extent failure for an already structurally validated
+/// `BroadcastInDim` mapping.
+///
+/// Structural mapping failures (wrong dimension count, an out-of-range axis,
+/// or a duplicate axis) remain the caller's axis/rank validation errors. This
+/// helper owns only the shared rank/extent cases represented by
+/// [`BroadcastError`], so eager and traced callers can feed the result through
+/// [`broadcast_error_to_validation`].
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_ops::broadcast::{broadcast_in_dim_extent_error, BroadcastError};
+///
+/// let error = broadcast_in_dim_extent_error(&[2, 3], &[2, 4], &[0, 1]);
+/// assert!(matches!(error, Some(BroadcastError::IncompatibleInput { .. })));
+/// ```
+pub fn broadcast_in_dim_extent_error(
+    input: &[usize],
+    output: &[usize],
+    dims: &[usize],
+) -> Option<BroadcastError> {
+    if input.len() > output.len() {
+        return Some(BroadcastError::RankTooLarge {
+            input: input.to_vec(),
+            output: output.to_vec(),
+        });
+    }
+    if dims.len() != input.len()
+        || dims.iter().any(|&axis| axis >= output.len())
+        || dims
+            .iter()
+            .enumerate()
+            .any(|(index, &axis)| dims[..index].contains(&axis))
+    {
+        return None;
+    }
+    input
+        .iter()
+        .zip(dims)
+        .find_map(|(&input_dim, &output_axis)| {
+            let output_dim = output[output_axis];
+            (input_dim != output_dim && input_dim != 1).then(|| BroadcastError::IncompatibleInput {
+                input: input.to_vec(),
+                output: output.to_vec(),
+            })
+        })
 }
 
 /// Compute the NumPy-style broadcast shape for two concrete shapes.

--- a/crates/tenferro-internal-ops/src/broadcast.rs
+++ b/crates/tenferro-internal-ops/src/broadcast.rs
@@ -39,6 +39,11 @@ pub enum BroadcastError {
 /// assert_eq!(broadcast_shape(&[3, 1], &[1, 4]).unwrap(), vec![3, 4]);
 /// assert_eq!(broadcast_shape(&[], &[2, 3]).unwrap(), vec![2, 3]);
 /// ```
+///
+/// # Errors
+///
+/// Returns [`BroadcastError::IncompatibleBinary`] when a pair of aligned
+/// dimensions is incompatible.
 pub fn broadcast_shape(lhs: &[usize], rhs: &[usize]) -> Result<Vec<usize>, BroadcastError> {
     let rank = lhs.len().max(rhs.len());
     let mut out = Vec::with_capacity(rank);
@@ -71,6 +76,11 @@ pub fn broadcast_shape(lhs: &[usize], rhs: &[usize]) -> Result<Vec<usize>, Broad
 /// let shape = broadcast_shapes([&[3, 1][..], &[1, 4][..], &[3, 4][..]]).unwrap();
 /// assert_eq!(shape, vec![3, 4]);
 /// ```
+///
+/// # Errors
+///
+/// Returns [`BroadcastError::IncompatibleBinary`] when any pair of input
+/// shapes cannot be broadcast together.
 pub fn broadcast_shapes<'a>(
     shapes: impl IntoIterator<Item = &'a [usize]>,
 ) -> Result<Vec<usize>, BroadcastError> {
@@ -99,6 +109,11 @@ pub fn broadcast_shapes<'a>(
 /// assert_eq!(plan.source_shape, vec![3]);
 /// assert_eq!(plan.dims, vec![0]);
 /// ```
+///
+/// # Errors
+///
+/// Returns [`BroadcastError::RankTooLarge`] when `input` has higher rank than
+/// `output`, or [`BroadcastError::IncompatibleInput`] for incompatible axes.
 pub fn broadcast_input_plan(
     input: &[usize],
     output: &[usize],

--- a/crates/tenferro-internal-ops/src/dim_expr.rs
+++ b/crates/tenferro-internal-ops/src/dim_expr.rs
@@ -90,6 +90,12 @@ impl DimExpr {
     /// );
     /// assert_eq!(expr.eval(&[&[5, 7]]).unwrap(), 7);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DimExprEvalError`] when an input or axis is unavailable, an
+    /// arithmetic operation overflows, subtraction underflows, or division
+    /// would use zero as its divisor.
     pub fn eval(&self, input_shapes: &[&[usize]]) -> Result<usize, DimExprEvalError> {
         match self {
             Self::Const(v) => Ok(*v),
@@ -370,6 +376,11 @@ impl DimExpr {
     /// ];
     /// assert_eq!(DimExpr::eval_all(&exprs, &[&[3, 5]]).unwrap(), vec![3, 4]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`DimExprEvalError`] encountered while evaluating an
+    /// expression.
     pub fn eval_all(
         exprs: &[Self],
         input_shapes: &[&[usize]],

--- a/crates/tenferro-internal-ops/src/ext_op.rs
+++ b/crates/tenferro-internal-ops/src/ext_op.rs
@@ -19,6 +19,7 @@
 //!   Frontends carry them directly as `Arc<dyn ExtensionOp>`.
 
 use std::any::Any;
+use std::error::Error as StdError;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -160,10 +161,21 @@ pub fn invoke_extension_shape_inference(
 /// let err = ExtensionLoweringError::new("example extension cannot lower");
 /// assert!(err.to_string().contains("cannot lower"));
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
-#[error("{message}")]
-pub struct ExtensionLoweringError {
-    message: String,
+#[derive(Debug, thiserror::Error)]
+pub enum ExtensionLoweringError {
+    /// A lowering failure that has no typed source.
+    #[error("{message}")]
+    Message {
+        /// Human-readable lowering detail.
+        message: String,
+    },
+    /// A lowering failure retaining the domain source that caused it.
+    #[error("{source}")]
+    Source {
+        /// Original typed lowering source.
+        #[source]
+        source: Box<dyn StdError + Send + Sync + 'static>,
+    },
 }
 
 impl ExtensionLoweringError {
@@ -178,8 +190,29 @@ impl ExtensionLoweringError {
     /// assert_eq!(err.to_string(), "shape must be static");
     /// ```
     pub fn new(message: impl Into<String>) -> Self {
-        Self {
+        Self::Message {
             message: message.into(),
+        }
+    }
+
+    /// Create a lowering error while retaining a typed source.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::error::Error as _;
+    /// use tenferro_ops::ext_op::ExtensionLoweringError;
+    ///
+    /// let source = std::io::Error::new(std::io::ErrorKind::Other, "shape unavailable");
+    /// let err = ExtensionLoweringError::from_source(source);
+    /// assert!(err.source().is_some());
+    /// ```
+    pub fn from_source<E>(source: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        Self::Source {
+            source: Box::new(source),
         }
     }
 }
@@ -216,6 +249,13 @@ pub type ExtensionLoweringResult =
 /// ```
 pub trait HostReference: Debug + Send + Sync + 'static {
     /// Execute the extension op on host/reference tensors.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] for invalid input
+    /// shapes/dtypes or output arity, [`tenferro_tensor::Error::Unsupported`]
+    /// when the reference implementation does not support an operation, or a
+    /// typed [`tenferro_tensor::Error::BackendSource`] failure from execution.
     fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>>;
 }
 
@@ -348,6 +388,12 @@ pub trait ExtensionOp: Debug + Send + Sync + 'static {
     /// On success, the returned vector MUST have length `self.output_count()`,
     /// one `(dtype, shape)` entry per output slot. Shapes use [`SymDim`] so
     /// extension ops compose with graph-global symbolic metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] for invalid rank, axis,
+    /// or dtype metadata, or [`tenferro_tensor::Error::RuntimeState`] when the
+    /// output contract cannot be inferred from unavailable metadata.
     fn infer_output_meta(
         &self,
         ctx: &mut ExtensionShapeContext<'_>,
@@ -378,6 +424,11 @@ pub trait ExtensionOp: Debug + Send + Sync + 'static {
     /// The default implementation returns `Ok(None)` so existing extension
     /// runtimes keep their native dispatch behavior until their owning crate
     /// deliberately implements this hook.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionLoweringError`] when the payload or input metadata
+    /// cannot be lowered safely.
     fn lower_to_standard_ops(
         &self,
         _builder: &mut GraphBuilder<StdTensorOp>,
@@ -412,6 +463,13 @@ pub trait ExtensionLinearizeRule: Debug + Send + Sync + 'static {
     fn family_id(&self) -> &'static str;
 
     /// Emit the linear (JVP) rule.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ADRuleError::InvalidInput`] when the operation or graph
+    /// metadata is inconsistent, and [`ADRuleError::Unsupported`] when this
+    /// rule cannot provide a JVP for the operation. Implementations may return
+    /// more specific [`ADRuleError`] values for their own validation.
     fn linearize(
         &self,
         op: &dyn ExtensionOp,
@@ -432,6 +490,14 @@ pub trait ExtensionLinearTransposeRule: Debug + Send + Sync + 'static {
     fn family_id(&self) -> &'static str;
 
     /// Emit cotangents for active linear inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ADRuleError::InvalidInput`] when the transpose inputs or
+    /// active mask do not match the operation, and
+    /// [`ADRuleError::Unsupported`] when the operation has no supported
+    /// transpose. Implementations may return more specific [`ADRuleError`]
+    /// values for their own validation.
     fn linear_transpose(
         &self,
         op: &dyn ExtensionOp,
@@ -453,6 +519,13 @@ pub trait ExtensionPrimalVjpRule: Debug + Send + Sync + 'static {
     fn family_id(&self) -> &'static str;
 
     /// Emit a direct VJP from the primal op.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ADRuleError::InvalidInput`] when the primal inputs or graph
+    /// metadata are inconsistent, and [`ADRuleError::Unsupported`] when this
+    /// rule cannot provide a VJP. Implementations may return more specific
+    /// [`ADRuleError`] values for their own validation.
     fn primal_vjp(
         &self,
         op: &dyn ExtensionOp,
@@ -581,6 +654,13 @@ impl ExtensionRuleSet {
     /// rules.register_linearize(Arc::new(Rule)).unwrap();
     /// assert!(rules.lookup_linearize("example.register_linearize.v1").is_some());
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionRegistryError::MalformedFamilyId`] when the rule's
+    /// family id is not namespaced, or
+    /// [`ExtensionRegistryError::DuplicateRule`] when a linearize rule for the
+    /// family is already registered.
     pub fn register_linearize(
         &mut self,
         rule: Arc<dyn ExtensionLinearizeRule>,
@@ -593,6 +673,13 @@ impl ExtensionRuleSet {
     }
 
     /// Add one linear-transpose rule to this owned set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionRegistryError::MalformedFamilyId`] when the rule's
+    /// family id is not namespaced, or
+    /// [`ExtensionRegistryError::DuplicateRule`] when a linear-transpose rule
+    /// for the family is already registered.
     pub fn register_linear_transpose(
         &mut self,
         rule: Arc<dyn ExtensionLinearTransposeRule>,
@@ -605,6 +692,13 @@ impl ExtensionRuleSet {
     }
 
     /// Add one primal-VJP rule to this owned set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionRegistryError::MalformedFamilyId`] when the rule's
+    /// family id is not namespaced, or
+    /// [`ExtensionRegistryError::DuplicateRule`] when a primal-VJP rule for
+    /// the family is already registered.
     pub fn register_primal_vjp(
         &mut self,
         rule: Arc<dyn ExtensionPrimalVjpRule>,
@@ -650,6 +744,13 @@ impl ExtensionRuleSet {
     /// let rules = ExtensionRuleSet::new().with_linearize(Arc::new(Rule)).unwrap();
     /// assert!(rules.is_linearize_registered("example.with_linearize.v1"));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionRegistryError::MalformedFamilyId`] when the rule's
+    /// family id is not namespaced, or
+    /// [`ExtensionRegistryError::DuplicateRule`] when that family already has
+    /// a linearize rule.
     pub fn with_linearize(
         mut self,
         rule: Arc<dyn ExtensionLinearizeRule>,
@@ -659,6 +760,13 @@ impl ExtensionRuleSet {
     }
 
     /// Return a new rule set containing a linear-transpose rule.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionRegistryError::MalformedFamilyId`] when the rule's
+    /// family id is not namespaced, or
+    /// [`ExtensionRegistryError::DuplicateRule`] when that family already has
+    /// a linear-transpose rule.
     pub fn with_linear_transpose(
         mut self,
         rule: Arc<dyn ExtensionLinearTransposeRule>,
@@ -668,6 +776,12 @@ impl ExtensionRuleSet {
     }
 
     /// Return a new rule set containing a primal-VJP rule.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionRegistryError::MalformedFamilyId`] when the rule's
+    /// family id is not namespaced, or [`ExtensionRegistryError::DuplicateRule`]
+    /// when that family already has a primal-VJP rule.
     pub fn with_primal_vjp(
         mut self,
         rule: Arc<dyn ExtensionPrimalVjpRule>,
@@ -690,6 +804,13 @@ impl ExtensionRuleSet {
     /// rules.merge(ExtensionRuleSet::new()).unwrap();
     /// assert!(!rules.is_linearize_registered("example.missing.v1"));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionRegistryError::MalformedFamilyId`] when any rule in
+    /// `other` is not namespaced, or [`ExtensionRegistryError::DuplicateRule`]
+    /// when any rule duplicates a rule already present in `self` or another
+    /// role-equivalent rule in `other`. The receiver is unchanged on error.
     pub fn merge(&mut self, other: ExtensionRuleSet) -> Result<(), ExtensionRegistryError> {
         let mut linearize_rules = (*self.linearize_rules).clone();
         let mut linear_transpose_rules = (*self.linear_transpose_rules).clone();
@@ -879,6 +1000,12 @@ fn validate_primal_vjp_insert(
 }
 
 /// Emit a registered extension linearization rule.
+///
+/// # Errors
+///
+/// Returns [`ADRuleError::Unsupported`] when the extension family has no
+/// registered linearize rule. Otherwise propagates the rule's typed
+/// [`ADRuleError`] unchanged.
 #[cfg(feature = "autodiff")]
 pub fn linearize_extension_rule(
     op: &dyn ExtensionOp,
@@ -895,6 +1022,14 @@ pub fn linearize_extension_rule(
 }
 
 /// Emit a registered extension transpose rule.
+///
+/// # Errors
+///
+/// Returns [`ADRuleError::Unsupported`] when the operation role has no
+/// registered transpose or primal-VJP rule, and
+/// [`ADRuleError::InvalidInput`] when a primary transpose input cannot be
+/// represented as a value input. Errors returned by the selected rule are
+/// propagated unchanged.
 #[cfg(feature = "autodiff")]
 pub fn transpose_extension_rule(
     op: &dyn ExtensionOp,

--- a/crates/tenferro-internal-ops/src/ext_op.rs
+++ b/crates/tenferro-internal-ops/src/ext_op.rs
@@ -116,30 +116,32 @@ pub fn invoke_extension_shape_inference(
 ) -> tenferro_tensor::Result<ExtensionShapeInference> {
     let expected_inputs = op.input_count();
     if input_dtypes.len() != expected_inputs || input_shapes.len() != expected_inputs {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "extension",
-            message: format!(
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "extension",
+            "input metadata",
+            format!(
                 "family_id={:?}: infer_output_meta expects {expected_inputs} input metadata entries, got {} dtypes and {} shapes",
                 op.family_id(),
                 input_dtypes.len(),
                 input_shapes.len()
             ),
-        });
+        ));
     }
 
     let mut ctx =
         ExtensionShapeContext::new_for_inference(op.family_id(), input_dtypes, input_shapes);
     let output_metas = op.infer_output_meta(&mut ctx)?;
     if output_metas.len() != op.output_count() {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "extension",
-            message: format!(
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "extension",
+            "output metadata",
+            format!(
                 "family_id={:?}: infer_output_meta produced {} output metadata entries; op declared {} outputs",
                 op.family_id(),
                 output_metas.len(),
                 op.output_count()
             ),
-        });
+        ));
     }
 
     Ok(ExtensionShapeInference {

--- a/crates/tenferro-internal-ops/src/ext_op.rs
+++ b/crates/tenferro-internal-ops/src/ext_op.rs
@@ -29,7 +29,7 @@ use computegraph::graph::GraphBuilder;
 use computegraph::types::ValueRef;
 #[cfg(feature = "autodiff")]
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
-use tenferro_tensor::{DType, Tensor};
+use tenferro_tensor::{DType, ErrorKind, Tensor, ValidationKind};
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult, PrimitiveTransposeInput};
 
@@ -168,10 +168,14 @@ pub enum ExtensionLoweringError {
     Message {
         /// Human-readable lowering detail.
         message: String,
+        /// Coarse classification supplied by the extension owner.
+        kind: ErrorKind,
     },
     /// A lowering failure retaining the domain source that caused it.
     #[error("{source}")]
     Source {
+        /// Coarse classification supplied by the extension owner.
+        kind: ErrorKind,
         /// Original typed lowering source.
         #[source]
         source: Box<dyn StdError + Send + Sync + 'static>,
@@ -190,8 +194,30 @@ impl ExtensionLoweringError {
     /// assert_eq!(err.to_string(), "shape must be static");
     /// ```
     pub fn new(message: impl Into<String>) -> Self {
+        Self::new_with_kind(
+            ErrorKind::Validation(ValidationKind::InvalidArgument),
+            message,
+        )
+    }
+
+    /// Create a lowering error with an explicit coarse classification.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ops::ext_op::ExtensionLoweringError;
+    /// use tenferro_tensor::ErrorKind;
+    ///
+    /// let err = ExtensionLoweringError::new_with_kind(
+    ///     ErrorKind::Unsupported,
+    ///     "extension is not supported by this lowering target",
+    /// );
+    /// assert_eq!(err.kind(), ErrorKind::Unsupported);
+    /// ```
+    pub fn new_with_kind(kind: ErrorKind, message: impl Into<String>) -> Self {
         Self::Message {
             message: message.into(),
+            kind,
         }
     }
 
@@ -211,8 +237,54 @@ impl ExtensionLoweringError {
     where
         E: StdError + Send + Sync + 'static,
     {
+        Self::from_source_with_kind(
+            ErrorKind::Validation(ValidationKind::InvalidArgument),
+            source,
+        )
+    }
+
+    /// Create a lowering error with a typed source and explicit classification.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ops::ext_op::ExtensionLoweringError;
+    /// use tenferro_tensor::ErrorKind;
+    ///
+    /// let err = ExtensionLoweringError::from_source_with_kind(
+    ///     ErrorKind::BackendFailure,
+    ///     std::io::Error::other("backend rejected lowering"),
+    /// );
+    /// assert_eq!(err.kind(), ErrorKind::BackendFailure);
+    /// assert!(std::error::Error::source(&err).is_some());
+    /// ```
+    pub fn from_source_with_kind<E>(kind: ErrorKind, source: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
         Self::Source {
+            kind,
             source: Box::new(source),
+        }
+    }
+
+    /// Return the stable classification carried by this lowering failure.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_ops::ext_op::ExtensionLoweringError;
+    /// use tenferro_tensor::ErrorKind;
+    ///
+    /// let error = ExtensionLoweringError::new_with_kind(
+    ///     ErrorKind::Unsupported,
+    ///     "target has no lowering",
+    /// );
+    /// assert_eq!(error.kind(), ErrorKind::Unsupported);
+    /// ```
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            Self::Message { kind, .. } | Self::Source { kind, .. } => *kind,
         }
     }
 }

--- a/crates/tenferro-internal-ops/src/lib.rs
+++ b/crates/tenferro-internal-ops/src/lib.rs
@@ -37,7 +37,9 @@ pub mod shape_extent;
 pub mod std_tensor_op;
 pub mod sym_dim;
 
-pub use ad::context::{ShapeGuard, ShapeGuardContext, TensorMeta};
+pub use ad::context::{
+    ShapeGuard, ShapeGuardContext, ShapeGuardError, ShapeGuardFailure, ShapeGuardResult, TensorMeta,
+};
 #[cfg(feature = "autodiff")]
 pub use ext_op::{
     linearize_extension_rule, transpose_extension_rule, ExtensionLinearTransposeRule,

--- a/crates/tenferro-internal-ops/src/lib.rs
+++ b/crates/tenferro-internal-ops/src/lib.rs
@@ -48,7 +48,7 @@ pub use ext_op::{
 pub use ext_op::{ExtensionOp, HostReference};
 pub use shape_constraint::{ExtensionShapeContext, ExtensionShapeError, ShapeRelation};
 pub use shape_extent::ShapeExtent;
-pub use sym_dim::SymDim;
+pub use sym_dim::{SymDim, SymDimConversionError};
 pub use tenferro_extension_macros::ExtensionFamilyId;
 pub use tenferro_tensor::config;
 

--- a/crates/tenferro-internal-ops/src/reduction.rs
+++ b/crates/tenferro-internal-ops/src/reduction.rs
@@ -21,6 +21,11 @@ pub enum ReductionShapeError {
 /// assert_eq!(reduced_shape(&[2, 3, 4], &[1], false).unwrap(), vec![2, 4]);
 /// assert_eq!(reduced_shape(&[2, 3, 4], &[1], true).unwrap(), vec![2, 1, 4]);
 /// ```
+///
+/// # Errors
+///
+/// Returns [`ReductionShapeError::AxisOutOfBounds`] for an invalid axis or
+/// [`ReductionShapeError::DuplicateAxis`] when an axis is repeated.
 pub fn reduced_shape(
     input_shape: &[usize],
     axes: &[usize],

--- a/crates/tenferro-internal-ops/src/shape_constraint.rs
+++ b/crates/tenferro-internal-ops/src/shape_constraint.rs
@@ -190,6 +190,11 @@ impl<'a> ExtensionShapeContext<'a> {
     ///     Ok(ctx.input_dtype(0)?)
     /// }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionShapeError::InputOutOfBounds`] when `input` is not
+    /// present in the extension metadata.
     pub fn input_dtype(&self, input: usize) -> Result<DType, ExtensionShapeError> {
         self.input_dtypes
             .get(input)
@@ -213,6 +218,11 @@ impl<'a> ExtensionShapeContext<'a> {
     ///     Ok(())
     /// }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionShapeError::InputOutOfBounds`] when `input` is not
+    /// present in the extension metadata.
     pub fn input_shape(&self, input: usize) -> Result<&[SymDim], ExtensionShapeError> {
         self.input_shapes
             .get(input)
@@ -236,6 +246,12 @@ impl<'a> ExtensionShapeContext<'a> {
     ///     Ok(ctx.input_axis(0, 0)?)
     /// }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionShapeError::InputOutOfBounds`] for an unknown input
+    /// or [`ExtensionShapeError::AxisOutOfBounds`] for an axis outside that
+    /// input's rank.
     pub fn input_axis(&self, input: usize, axis: usize) -> Result<SymDim, ExtensionShapeError> {
         let shape = self.input_shape(input)?;
         shape
@@ -265,6 +281,11 @@ impl<'a> ExtensionShapeContext<'a> {
     ///     Ok(())
     /// }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Ok(())`; this method only records a symbolic equality and does
+    /// not evaluate it or produce an [`ExtensionShapeError`].
     pub fn require_equal(&mut self, lhs: SymDim, rhs: SymDim) -> Result<(), ExtensionShapeError> {
         self.constraints
             .push(ExtensionShapeConstraint::equal(lhs, rhs));
@@ -283,6 +304,12 @@ impl<'a> ExtensionShapeContext<'a> {
     ///     Ok(())
     /// }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionShapeError::InputOutOfBounds`] or
+    /// [`ExtensionShapeError::AxisOutOfBounds`] when either referenced axis is
+    /// absent from the extension metadata.
     pub fn require_axes_equal(
         &mut self,
         lhs: (usize, usize),
@@ -307,6 +334,12 @@ impl<'a> ExtensionShapeContext<'a> {
     ///     Ok(())
     /// }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionShapeError::InputOutOfBounds`] when an input is
+    /// absent, or [`ExtensionShapeError::RankMismatch`] when the two inputs do
+    /// not have the same rank.
     pub fn require_same_shape(
         &mut self,
         lhs_input: usize,

--- a/crates/tenferro-internal-ops/src/shape_constraint.rs
+++ b/crates/tenferro-internal-ops/src/shape_constraint.rs
@@ -1,4 +1,4 @@
-use tenferro_tensor::DType;
+use tenferro_tensor::{DType, ErrorKind, ValidationKind};
 
 use crate::SymDim;
 
@@ -119,19 +119,21 @@ pub enum ExtensionShapeError {
 
 impl From<ExtensionShapeError> for tenferro_tensor::Error {
     fn from(error: ExtensionShapeError) -> Self {
-        // `tenferro_tensor::Error` has no source-carrying extension-config
-        // variant. Keep the context's native error typed, and cross the
-        // ExtensionOp callback boundary through its structured InvalidConfig
-        // carrier while retaining every field in the diagnostic.
-        let op = match &error {
-            ExtensionShapeError::InputOutOfBounds { family_id, .. }
-            | ExtensionShapeError::AxisOutOfBounds { family_id, .. }
-            | ExtensionShapeError::RankMismatch { family_id, .. } => *family_id,
+        let (family_id, kind) = match &error {
+            ExtensionShapeError::InputOutOfBounds { family_id, .. } => (
+                *family_id,
+                ErrorKind::Validation(ValidationKind::InvalidArgument),
+            ),
+            ExtensionShapeError::AxisOutOfBounds { family_id, .. } => (
+                *family_id,
+                ErrorKind::Validation(ValidationKind::AxisOutOfBounds),
+            ),
+            ExtensionShapeError::RankMismatch { family_id, .. } => (
+                *family_id,
+                ErrorKind::Validation(ValidationKind::RankMismatch),
+            ),
         };
-        Self::InvalidConfig {
-            op,
-            message: error.to_string(),
-        }
+        tenferro_tensor::Error::extension("extension", family_id, kind, error)
     }
 }
 

--- a/crates/tenferro-internal-ops/src/shape_constraint/tests.rs
+++ b/crates/tenferro-internal-ops/src/shape_constraint/tests.rs
@@ -1,4 +1,4 @@
-use tenferro_tensor::DType;
+use tenferro_tensor::{DType, Error as TensorError, ErrorKind, ValidationKind};
 
 use super::{ExtensionShapeContext, ExtensionShapeError, ShapeRelation};
 use crate::SymDim;
@@ -27,43 +27,50 @@ fn context_errors_compose_with_tensor_result_and_preserve_diagnostic() {
     let input_shapes: [&[SymDim]; 2] = [&lhs_shape, &rhs_shape];
     let mut ctx = inference_context(&input_dtypes, &input_shapes);
 
-    assert_eq!(
-        callback_with_tensor_result(&mut ctx),
-        Err(tenferro_tensor::Error::InvalidConfig {
-            op: "test.shape.v1",
-            message: "extension family \"test.shape.v1\" axis 0 out of bounds for input 1 rank 0"
-                .into(),
-        })
-    );
+    let error = callback_with_tensor_result(&mut ctx).unwrap_err();
+    assert!(matches!(
+        error,
+        TensorError::Extension {
+            op: "extension",
+            family: "test.shape.v1",
+            kind: ErrorKind::Validation(ValidationKind::AxisOutOfBounds),
+            ..
+        }
+    ));
 }
 
 #[test]
 fn tensor_error_conversion_preserves_input_and_rank_diagnostics() {
-    assert_eq!(
-        tenferro_tensor::Error::from(ExtensionShapeError::InputOutOfBounds {
-            family_id: "test.shape.v1",
-            input: 3,
-            input_count: 2,
-        }),
-        tenferro_tensor::Error::InvalidConfig {
-            op: "test.shape.v1",
-            message: "extension family \"test.shape.v1\" input index 3 out of bounds for 2 inputs"
-                .into(),
+    let input_error = tenferro_tensor::Error::from(ExtensionShapeError::InputOutOfBounds {
+        family_id: "test.shape.v1",
+        input: 3,
+        input_count: 2,
+    });
+    assert!(matches!(
+        input_error,
+        TensorError::Extension {
+            op: "extension",
+            family: "test.shape.v1",
+            kind: ErrorKind::Validation(ValidationKind::InvalidArgument),
+            ..
         }
-    );
-    assert_eq!(
-        tenferro_tensor::Error::from(ExtensionShapeError::RankMismatch {
-            family_id: "test.shape.v1",
-            lhs_input: 0,
-            lhs_rank: 1,
-            rhs_input: 1,
-            rhs_rank: 2,
-        }),
-        tenferro_tensor::Error::InvalidConfig {
-            op: "test.shape.v1",
-            message: "extension family \"test.shape.v1\" requires inputs 0 and 1 to have the same shape, but their ranks are 1 and 2".into(),
+    ));
+    let rank_error = tenferro_tensor::Error::from(ExtensionShapeError::RankMismatch {
+        family_id: "test.shape.v1",
+        lhs_input: 0,
+        lhs_rank: 1,
+        rhs_input: 1,
+        rhs_rank: 2,
+    });
+    assert!(matches!(
+        rank_error,
+        TensorError::Extension {
+            op: "extension",
+            family: "test.shape.v1",
+            kind: ErrorKind::Validation(ValidationKind::RankMismatch),
+            ..
         }
-    );
+    ));
 }
 
 #[test]

--- a/crates/tenferro-internal-ops/src/sym_dim.rs
+++ b/crates/tenferro-internal-ops/src/sym_dim.rs
@@ -1,5 +1,7 @@
 use std::ops::{Add, Div, Mul, Sub};
 
+use thiserror::Error;
+
 use crate::dim_expr::DimExpr;
 
 /// A symbolic tensor dimension expression used to build shape-agnostic graphs.
@@ -18,6 +20,15 @@ use crate::dim_expr::DimExpr;
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SymDim(pub(crate) RawSymDim);
+
+/// A symbolic dimension referenced a tensor that is not present in the
+/// conversion map supplied by the graph builder.
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+#[error("unknown symbolic tensor id {tensor_id}")]
+pub struct SymDimConversionError {
+    /// Identifier of the missing symbolic tensor.
+    pub tensor_id: u64,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum RawSymDim {
@@ -101,7 +112,10 @@ impl SymDim {
     }
 
     #[doc(hidden)]
-    pub fn to_dim_expr(&self, tensor_map: &[(u64, usize)]) -> std::result::Result<DimExpr, String> {
+    pub fn to_dim_expr(
+        &self,
+        tensor_map: &[(u64, usize)],
+    ) -> std::result::Result<DimExpr, SymDimConversionError> {
         raw_to_dim_expr(&self.0, tensor_map)
     }
 
@@ -175,7 +189,7 @@ impl From<usize> for SymDim {
 fn raw_to_dim_expr(
     raw: &RawSymDim,
     tensor_map: &[(u64, usize)],
-) -> std::result::Result<DimExpr, String> {
+) -> std::result::Result<DimExpr, SymDimConversionError> {
     Ok(match raw {
         RawSymDim::Const(value) => DimExpr::Const(*value),
         RawSymDim::TensorAxis { tensor_id, axis } => {
@@ -184,7 +198,9 @@ fn raw_to_dim_expr(
                 .find_map(|(candidate_id, input_idx)| {
                     (candidate_id == tensor_id).then_some(*input_idx)
                 })
-                .ok_or_else(|| format!("unknown symbolic tensor id {tensor_id}"))?;
+                .ok_or(SymDimConversionError {
+                    tensor_id: *tensor_id,
+                })?;
             DimExpr::InputDim {
                 input_idx,
                 axis: *axis,

--- a/crates/tenferro-internal-ops/src/tests/broadcast_tests.rs
+++ b/crates/tenferro-internal-ops/src/tests/broadcast_tests.rs
@@ -1,0 +1,72 @@
+use tenferro_tensor::{ErrorKind, ShapeMismatch, ValidationError, ValidationKind};
+
+use crate::broadcast::{broadcast_error_to_validation, BroadcastError};
+
+#[test]
+fn broadcast_error_mapping_preserves_each_structured_category() {
+    let cases = [
+        (
+            BroadcastError::IncompatibleBinary {
+                lhs: vec![2, 3],
+                rhs: vec![2, 4],
+            },
+            ValidationKind::ShapeMismatch,
+        ),
+        (
+            BroadcastError::IncompatibleInput {
+                input: vec![2, 3],
+                output: vec![2, 4],
+            },
+            ValidationKind::ShapeMismatch,
+        ),
+        (
+            BroadcastError::RankTooLarge {
+                input: vec![2, 3],
+                output: vec![3],
+            },
+            ValidationKind::RankMismatch,
+        ),
+    ];
+
+    for (error, expected_kind) in cases {
+        let validation = broadcast_error_to_validation(error);
+        assert_eq!(validation.kind(), expected_kind);
+        assert_eq!(
+            ErrorKind::Validation(validation.kind()),
+            ErrorKind::Validation(expected_kind)
+        );
+    }
+
+    let incompatible_binary = broadcast_error_to_validation(BroadcastError::IncompatibleBinary {
+        lhs: vec![2, 3],
+        rhs: vec![2, 4],
+    });
+    assert!(matches!(
+        incompatible_binary,
+        ValidationError::ShapeMismatch(source)
+            if matches!(source.as_ref(), ShapeMismatch::IncompatibleShapes { lhs, rhs }
+                if lhs.as_slice() == [2, 3] && rhs.as_slice() == [2, 4])
+    ));
+
+    let incompatible_input = broadcast_error_to_validation(BroadcastError::IncompatibleInput {
+        input: vec![2, 3],
+        output: vec![2, 4],
+    });
+    assert!(matches!(
+        incompatible_input,
+        ValidationError::ShapeMismatch(source)
+            if matches!(source.as_ref(), ShapeMismatch::ExpectedActual { expected, actual }
+                if expected.as_slice() == [2, 4] && actual.as_slice() == [2, 3])
+    ));
+
+    assert!(matches!(
+        broadcast_error_to_validation(BroadcastError::RankTooLarge {
+            input: vec![2, 3],
+            output: vec![3],
+        }),
+        ValidationError::RankMismatch {
+            expected: 1,
+            actual: 2,
+        }
+    ));
+}

--- a/crates/tenferro-internal-ops/src/tests/mod.rs
+++ b/crates/tenferro-internal-ops/src/tests/mod.rs
@@ -1,3 +1,4 @@
+mod broadcast_tests;
 mod catalog_kind_tests;
 mod dim_expr_tests;
 #[cfg(feature = "autodiff")]

--- a/crates/tenferro-linalg/Cargo.toml
+++ b/crates/tenferro-linalg/Cargo.toml
@@ -94,6 +94,7 @@ lapack-inject = { workspace = true, optional = true }
 libloading = { workspace = true, optional = true }
 num-complex.workspace = true
 num-traits.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -48,6 +48,12 @@ pub mod support;
 /// assert!(rules.is_linearize_registered(tenferro_linalg::LINALG_EXTENSION_FAMILY_ID));
 /// assert!(rules.is_linear_transpose_registered(tenferro_linalg::LINALG_EXTENSION_FAMILY_ID));
 /// ```
+///
+/// # Errors
+///
+/// Returns `ExtensionRegistryError::MalformedFamilyId` if the linalg family
+/// identifier is invalid, or `ExtensionRegistryError::DuplicateRule` if the
+/// rule set already contains a rule for this family and transform.
 pub fn ad_rules() -> Result<ExtensionRuleSet, ExtensionRegistryError> {
     ExtensionRuleSet::new()
         .with_linearize(Arc::new(LinalgAdRule))?

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -1,22 +1,10 @@
 use tenferro_tensor::{Tensor, TensorBackend, TensorView};
 
+pub(crate) use crate::error::unsupported_dtype;
 use crate::extension::{
     apply_eigh_gauge, apply_qr_gauge, apply_svd_gauge, validate_derivative_eps, EighOptions,
     QrOptions, SvdOptions,
 };
-
-/// Build the shared "unsupported dtype" backend-failure error used by the
-/// linalg backends.
-///
-/// Both the CPU and GPU linalg backends reject integer and boolean dtypes for
-/// floating-point decompositions with an identical message; this helper keeps
-/// that error construction in one place.
-pub(crate) fn unsupported_dtype(
-    op: &'static str,
-    dtype: tenferro_tensor::DType,
-) -> tenferro_tensor::Error {
-    tenferro_tensor::Error::backend_failure(op, format!("unsupported dtype {dtype:?}"))
-}
 
 /// Backend surface required by the linalg extension runtime.
 ///
@@ -33,10 +21,24 @@ pub(crate) fn unsupported_dtype(
 /// ```
 pub trait LinalgBackend: TensorBackend {
     /// Compute a Cholesky factorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for non-matrix, non-square, or unsupported
+    /// input dtypes; `Error::Extension` with `ErrorKind::NumericalFailure`
+    /// when the matrix is not positive definite; or a typed backend source
+    /// when the provider cannot execute the factorization.
     fn cholesky(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor>;
 
     /// Solve a triangular linear system with explicit side, triangle,
     /// transpose, and unit-diagonal flags.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for incompatible matrix/rhs shapes, rank,
+    /// or dtype; `Error::Extension` with `ErrorKind::NumericalFailure` for a
+    /// singular or zero-diagonal system; or a typed backend source for a
+    /// provider failure.
     fn triangular_solve(
         &mut self,
         a: &Tensor,
@@ -48,11 +50,17 @@ pub trait LinalgBackend: TensorBackend {
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Compute public LU outputs `(P, L, U, parity)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` when the input is not a supported matrix or
+    /// dtype, and `Error::Extension` or a typed backend source when LU
+    /// execution or pivot storage fails.
     fn lu(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
 
     #[doc(hidden)]
     fn lu_factor(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Err(tenferro_tensor::Error::backend_failure(
+        Err(tenferro_tensor::Error::unsupported(
             "lu_factor",
             format!(
                 "backend {} does not implement internal packed LU factorization",
@@ -67,12 +75,24 @@ pub trait LinalgBackend: TensorBackend {
     /// `P * A * Q^T = L * U`. `parity` is a scalar real tensor containing
     /// `+1` or `-1`: `F32` for `F32`/`C32` inputs and `F64` for `F64`/`C64`
     /// inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for an invalid rank, square-shape
+    /// requirement, or dtype, and `Error::Extension` or a typed backend source
+    /// when complete-pivot factorization cannot be executed.
     fn full_piv_lu(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
 
     /// Solve a linear system through the complete-pivot LU path.
     ///
     /// With `transpose_a = false`, this solves `A * x = b`. With
     /// `transpose_a = true`, this solves `A^T * x = b`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for incompatible coefficient/rhs shapes or
+    /// dtypes, `Error::Extension` with `ErrorKind::NumericalFailure` for a
+    /// singular system, or a typed backend source for provider failure.
     fn full_piv_lu_solve(
         &mut self,
         a: &Tensor,
@@ -81,6 +101,11 @@ pub trait LinalgBackend: TensorBackend {
     ) -> tenferro_tensor::Result<Tensor>;
 
     /// Compute public SVD outputs `(U, S, Vt)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for an unsupported rank or dtype and a
+    /// typed `Error::Extension` or backend source when the solver fails.
     fn svd(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
 
     /// Compute public SVD outputs `(U, S, Vt)` with explicit options.
@@ -105,6 +130,12 @@ pub trait LinalgBackend: TensorBackend {
     /// assert_eq!(outputs[1].shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation::InvalidArgument` when `derivative_eps` is
+    /// non-finite or non-positive, then propagates the concrete `svd` and
+    /// gauge validation/backend errors.
     fn svd_with_options(
         &mut self,
         input: &Tensor,
@@ -118,7 +149,7 @@ pub trait LinalgBackend: TensorBackend {
 
     #[doc(hidden)]
     fn svd_values(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
-        Err(tenferro_tensor::Error::backend_failure(
+        Err(tenferro_tensor::Error::unsupported(
             "svd_values",
             format!(
                 "backend {} does not implement internal singular-values-only decomposition",
@@ -148,8 +179,15 @@ pub trait LinalgBackend: TensorBackend {
     /// assert_eq!(outputs[1].shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns `Error::Unsupported` because the
+    /// backend does not accept borrowed views; an implementation may instead
+    /// return validation or typed backend-source errors after canonicalizing
+    /// the view.
     fn svd_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Err(tenferro_tensor::Error::backend_failure(
+        Err(tenferro_tensor::Error::unsupported(
             "svd",
             "backend does not accept borrowed tensor views at this execution boundary",
         ))
@@ -159,6 +197,12 @@ pub trait LinalgBackend: TensorBackend {
     ///
     /// QR is thin: for an `m x n` input, `Q` has shape `m x min(m, n)` and
     /// `R` has shape `min(m, n) x n`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for an unsupported rank, shape, or dtype,
+    /// and a typed `Error::Extension` or backend source when QR execution
+    /// fails.
     fn qr(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
 
     /// Compute public QR outputs `(Q, R)` with explicit options.
@@ -181,6 +225,11 @@ pub trait LinalgBackend: TensorBackend {
     /// assert_eq!(outputs[0].shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Propagates `Error::Validation` from the input or gauge configuration,
+    /// plus typed extension/backend errors from QR execution.
     fn qr_with_options(
         &mut self,
         input: &Tensor,
@@ -213,8 +262,14 @@ pub trait LinalgBackend: TensorBackend {
     /// assert_eq!(outputs[1].shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns `Error::Unsupported` because the
+    /// backend does not accept borrowed views; implementations may return
+    /// validation or typed backend-source errors.
     fn qr_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Err(tenferro_tensor::Error::backend_failure(
+        Err(tenferro_tensor::Error::unsupported(
             "qr",
             "backend does not accept borrowed tensor views at this execution boundary",
         ))
@@ -224,6 +279,12 @@ pub trait LinalgBackend: TensorBackend {
     ///
     /// The returned vector order is `[values, vectors]`, where `values` has
     /// shape `[n]` and `vectors` has shape `[n, n]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for a non-square or unsupported-dtype input
+    /// and a typed `Error::Extension` or backend source when eigendecomposition
+    /// fails.
     fn eigh(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
 
     /// Compute public Hermitian eigendecomposition outputs with explicit options.
@@ -250,6 +311,12 @@ pub trait LinalgBackend: TensorBackend {
     /// assert_eq!(outputs[0].shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation::InvalidArgument` for an invalid
+    /// `derivative_eps`, then propagates eigensolver, gauge, and typed backend
+    /// errors.
     fn eigh_with_options(
         &mut self,
         input: &Tensor,
@@ -283,8 +350,14 @@ pub trait LinalgBackend: TensorBackend {
     /// assert_eq!(outputs[1].shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns `Error::Unsupported` because the
+    /// backend does not accept borrowed views; implementations may return
+    /// validation or typed backend-source errors.
     fn eigh_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Err(tenferro_tensor::Error::backend_failure(
+        Err(tenferro_tensor::Error::unsupported(
             "eigh",
             "backend does not accept borrowed tensor views at this execution boundary",
         ))
@@ -311,8 +384,14 @@ pub trait LinalgBackend: TensorBackend {
     /// assert_eq!(output.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns `Error::Unsupported` because the
+    /// backend does not accept borrowed views; implementations may return
+    /// validation or typed backend-source errors.
     fn cholesky_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Tensor> {
-        Err(tenferro_tensor::Error::backend_failure(
+        Err(tenferro_tensor::Error::unsupported(
             "cholesky",
             "backend does not accept borrowed tensor views at this execution boundary",
         ))
@@ -339,8 +418,14 @@ pub trait LinalgBackend: TensorBackend {
     /// assert_eq!(outputs.len(), 4);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns `Error::Unsupported` because the
+    /// backend does not accept borrowed views; implementations may return
+    /// validation or typed backend-source errors.
     fn lu_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Err(tenferro_tensor::Error::backend_failure(
+        Err(tenferro_tensor::Error::unsupported(
             "lu",
             "backend does not accept borrowed tensor views at this execution boundary",
         ))
@@ -367,8 +452,14 @@ pub trait LinalgBackend: TensorBackend {
     /// assert_eq!(outputs.len(), 5);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns `Error::Unsupported` because the
+    /// backend does not accept borrowed views; implementations may return
+    /// validation or typed backend-source errors.
     fn full_piv_lu_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Err(tenferro_tensor::Error::backend_failure(
+        Err(tenferro_tensor::Error::unsupported(
             "full_piv_lu",
             "backend does not accept borrowed tensor views at this execution boundary",
         ))
@@ -395,8 +486,14 @@ pub trait LinalgBackend: TensorBackend {
     /// assert_eq!(outputs.len(), 2);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns `Error::Unsupported` because the
+    /// backend does not accept borrowed views; implementations may return
+    /// validation or typed backend-source errors.
     fn eig_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
-        Err(tenferro_tensor::Error::backend_failure(
+        Err(tenferro_tensor::Error::unsupported(
             "eig",
             "backend does not accept borrowed tensor views at this execution boundary",
         ))
@@ -404,7 +501,7 @@ pub trait LinalgBackend: TensorBackend {
 
     #[doc(hidden)]
     fn eigh_values(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
-        Err(tenferro_tensor::Error::backend_failure(
+        Err(tenferro_tensor::Error::unsupported(
             "eigh_values",
             format!(
                 "backend {} does not implement internal Hermitian eigenvalues-only decomposition",
@@ -414,11 +511,17 @@ pub trait LinalgBackend: TensorBackend {
     }
 
     /// Compute public general eigendecomposition outputs `(values, vectors)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for a non-square, rank, or dtype mismatch,
+    /// and a typed `Error::Extension` or backend source when the eigensolver
+    /// fails.
     fn eig(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>>;
 
     #[doc(hidden)]
     fn eig_values(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
-        Err(tenferro_tensor::Error::backend_failure(
+        Err(tenferro_tensor::Error::unsupported(
             "eig_values",
             format!(
                 "backend {} does not implement internal general eigenvalues-only decomposition",
@@ -428,6 +531,12 @@ pub trait LinalgBackend: TensorBackend {
     }
 
     /// Solve a dense linear system.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for incompatible matrix/rhs shapes, rank,
+    /// or dtype; `Error::Extension` with `ErrorKind::NumericalFailure` for a
+    /// singular system; or a typed backend source for provider failure.
     fn solve(&mut self, a: &Tensor, b: &Tensor) -> tenferro_tensor::Result<Tensor>;
 
     #[doc(hidden)]
@@ -440,7 +549,7 @@ pub trait LinalgBackend: TensorBackend {
         _transpose_a: bool,
         _conjugate_a: bool,
     ) -> tenferro_tensor::Result<Tensor> {
-        Err(tenferro_tensor::Error::backend_failure(
+        Err(tenferro_tensor::Error::unsupported(
             "lu_solve_prepared",
             format!(
                 "backend {} does not implement internal prepared LU solve",

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -133,9 +133,21 @@ pub trait LinalgBackend: TensorBackend {
     ///
     /// # Errors
     ///
-    /// Returns `Error::Validation::InvalidArgument` when `derivative_eps` is
-    /// non-finite or non-positive, then propagates the concrete `svd` and
-    /// gauge validation/backend errors.
+    /// Returns [`tenferro_tensor::Error::Validation`] containing
+    /// [`tenferro_tensor::ValidationError::InvalidArgument`] when
+    /// `derivative_eps` is non-finite or non-positive, or when canonical gauge
+    /// output metadata is malformed. It can return
+    /// [`tenferro_tensor::Error::Validation`] with
+    /// [`tenferro_tensor::ValidationError::RankMismatch`],
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`], or
+    /// [`tenferro_tensor::ValidationError::DTypeMismatch`] for the input
+    /// or generated outputs, [`tenferro_tensor::Error::Extension`] with the
+    /// typed `tenferro_linalg::Error::UnsupportedDType` or
+    /// `NonConvergence` source, [`tenferro_tensor::Error::BackendSource`] for
+    /// provider calls, and [`tenferro_tensor::Error::RuntimeState`] for
+    /// placement failures. A CPU provider that was not compiled is reported
+    /// as [`tenferro_tensor::ValidationError::InvalidArgument`] on the
+    /// provider configuration.
     fn svd_with_options(
         &mut self,
         input: &Tensor,
@@ -228,8 +240,17 @@ pub trait LinalgBackend: TensorBackend {
     ///
     /// # Errors
     ///
-    /// Propagates `Error::Validation` from the input or gauge configuration,
-    /// plus typed extension/backend errors from QR execution.
+    /// Returns [`tenferro_tensor::Error::Validation`] containing
+    /// [`tenferro_tensor::ValidationError::RankMismatch`] or
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`] for an invalid
+    /// matrix input, or [`tenferro_tensor::ValidationError::InvalidArgument`]
+    /// for malformed gauge output metadata, checked size arithmetic, or an
+    /// unavailable compiled provider. A mismatched generated `Q`/`R` dtype is reported as
+    /// [`tenferro_tensor::ValidationError::DTypeMismatch`]. Provider
+    /// unsupported dtype or numerical rejection is
+    /// [`tenferro_tensor::Error::Extension`] with a typed linalg source, while
+    /// provider failures use [`tenferro_tensor::Error::BackendSource`] and a
+    /// backend-resident input uses [`tenferro_tensor::Error::RuntimeState`].
     fn qr_with_options(
         &mut self,
         input: &Tensor,
@@ -314,9 +335,20 @@ pub trait LinalgBackend: TensorBackend {
     ///
     /// # Errors
     ///
-    /// Returns `Error::Validation::InvalidArgument` for an invalid
-    /// `derivative_eps`, then propagates eigensolver, gauge, and typed backend
-    /// errors.
+    /// Returns [`tenferro_tensor::Error::Validation`] containing
+    /// [`tenferro_tensor::ValidationError::InvalidArgument`] when
+    /// `derivative_eps` is non-finite or non-positive, when canonical gauge
+    /// output metadata is malformed, or when checked output-size arithmetic
+    /// overflows. It can return [`tenferro_tensor::Error::Validation`] with
+    /// [`tenferro_tensor::ValidationError::RankMismatch`] or
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`] for the
+    /// matrix input, or [`tenferro_tensor::ValidationError::DTypeMismatch`]
+    /// for generated outputs. It can also return
+    /// [`tenferro_tensor::Error::Extension`] with typed
+    /// `tenferro_linalg::Error::UnsupportedDType` or `NonConvergence`, and
+    /// [`tenferro_tensor::Error::BackendSource`] or
+    /// [`tenferro_tensor::Error::RuntimeState`] for provider and placement
+    /// failures.
     fn eigh_with_options(
         &mut self,
         input: &Tensor,

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -1155,11 +1155,7 @@ impl LinalgBackend for CpuBackend {
         ensure_supported_linalg_pair(OP, a, b)?;
         ensure_supported_linalg_pair(OP, a, packed_lu)?;
         if !matches!(pivots, Tensor::I32(_)) {
-            return Err(Error::DTypeMismatch {
-                op: OP,
-                lhs: DType::I32,
-                rhs: pivots.dtype(),
-            });
+            return Err(Error::dtype_mismatch(OP, DType::I32, pivots.dtype()));
         }
         if has_zero_dim(a.shape()) || has_zero_dim(b.shape()) {
             return zeros_like_tensor(b);
@@ -1322,11 +1318,7 @@ fn ensure_supported_linalg_pair(
     rhs: &Tensor,
 ) -> tenferro_tensor::Result<()> {
     if lhs.dtype() != rhs.dtype() {
-        return Err(Error::DTypeMismatch {
-            op,
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        });
+        return Err(Error::dtype_mismatch(op, lhs.dtype(), rhs.dtype()));
     }
     match lhs {
         Tensor::F32(_) | Tensor::F64(_) | Tensor::C32(_) | Tensor::C64(_) => Ok(()),
@@ -1346,9 +1338,8 @@ fn checked_product(
     shape: &[usize],
 ) -> tenferro_tensor::Result<usize> {
     shape.iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim).ok_or_else(|| Error::InvalidConfig {
-            op,
-            message: format!("{role} element count overflow"),
+        acc.checked_mul(dim).ok_or_else(|| {
+            Error::invalid_argument(op, "shape", format!("{role} element count overflow"))
         })
     })
 }
@@ -1365,10 +1356,7 @@ fn checked_batch_offset(
 ) -> tenferro_tensor::Result<usize> {
     batch
         .checked_mul(stride)
-        .ok_or_else(|| Error::InvalidConfig {
-            op,
-            message: format!("{role} overflows usize"),
-        })
+        .ok_or_else(|| Error::invalid_argument(op, "shape", format!("{role} overflows usize")))
 }
 
 fn batched_vector_rhs_shape(a: &Tensor, b: &Tensor) -> Option<Vec<usize>> {
@@ -1560,11 +1548,11 @@ fn apply_lu_pivots_cpu(
     inverse: bool,
 ) -> tenferro_tensor::Result<Tensor> {
     let Tensor::I32(pivots) = pivots else {
-        return Err(Error::DTypeMismatch {
-            op: "lu_solve_prepared",
-            lhs: DType::I32,
-            rhs: pivots.dtype(),
-        });
+        return Err(Error::dtype_mismatch(
+            "lu_solve_prepared",
+            DType::I32,
+            pivots.dtype(),
+        ));
     };
     match input {
         Tensor::F32(t) => apply_lu_pivots_typed(t, pivots, inverse).map(Tensor::F32),
@@ -1584,21 +1572,17 @@ fn apply_lu_pivots_typed<T: Clone>(
 ) -> tenferro_tensor::Result<TypedTensor<T>> {
     let shape = input.shape();
     if shape.len() < 2 {
-        return Err(Error::RankMismatch {
-            op: "lu_solve_prepared",
-            expected: 2,
-            actual: shape.len(),
-        });
+        return Err(Error::rank_mismatch("lu_solve_prepared", 2, shape.len()));
     }
     let rows = shape[0];
     let cols = shape[1];
     let k = pivots.shape()[0];
     if k > rows || pivots.shape()[1..] != shape[2..] {
-        return Err(Error::ShapeMismatch {
-            op: "lu_solve_prepared",
-            lhs: pivots.shape().to_vec(),
-            rhs: shape.to_vec(),
-        });
+        return Err(Error::shape_mismatch(
+            "lu_solve_prepared",
+            pivots.shape().to_vec(),
+            shape.to_vec(),
+        ));
     }
     let batch_total = batch_count("lu_solve_prepared", &shape[2..])?;
     let matrix_stride = checked_product("lu_solve_prepared", "matrix shape", &[rows, cols])?;
@@ -1667,37 +1651,34 @@ fn validate_lu_solve_prepared_shapes(
     let n = square_matrix_dim("lu_solve_prepared", lu_shape)?;
     let (b_rows, _) = matrix_dims("lu_solve_prepared", b_shape)?;
     if b_rows != n {
-        return Err(Error::InvalidConfig {
-            op: "lu_solve_prepared",
-            message: format!("rhs row count mismatch: expected {n}, got {b_rows}"),
-        });
+        return Err(Error::invalid_argument(
+            "lu_solve_prepared",
+            "rhs rows",
+            format!("expected {n}, got {b_rows}"),
+        ));
     }
     if lu_shape[2..] != b_shape[2..] {
-        return Err(Error::ShapeMismatch {
-            op: "lu_solve_prepared",
-            lhs: lu_shape.to_vec(),
-            rhs: b_shape.to_vec(),
-        });
+        return Err(Error::shape_mismatch(
+            "lu_solve_prepared",
+            lu_shape.to_vec(),
+            b_shape.to_vec(),
+        ));
     }
     let mut expected_pivots = vec![n];
     expected_pivots.extend_from_slice(&lu_shape[2..]);
     if pivots_shape != expected_pivots {
-        return Err(Error::ShapeMismatch {
-            op: "lu_solve_prepared",
-            lhs: expected_pivots,
-            rhs: pivots_shape.to_vec(),
-        });
+        return Err(Error::shape_mismatch(
+            "lu_solve_prepared",
+            expected_pivots,
+            pivots_shape.to_vec(),
+        ));
     }
     Ok(())
 }
 
 fn matrix_dims(op: &'static str, shape: &[usize]) -> tenferro_tensor::Result<(usize, usize)> {
     if shape.len() < 2 {
-        return Err(Error::RankMismatch {
-            op,
-            expected: 2,
-            actual: shape.len(),
-        });
+        return Err(Error::rank_mismatch(op, 2, shape.len()));
     }
     Ok((shape[0], shape[1]))
 }
@@ -1705,11 +1686,7 @@ fn matrix_dims(op: &'static str, shape: &[usize]) -> tenferro_tensor::Result<(us
 fn square_matrix_dim(op: &'static str, shape: &[usize]) -> tenferro_tensor::Result<usize> {
     let (rows, cols) = matrix_dims(op, shape)?;
     if rows != cols {
-        return Err(Error::ShapeMismatch {
-            op,
-            lhs: vec![rows],
-            rhs: vec![cols],
-        });
+        return Err(Error::shape_mismatch(op, vec![rows], vec![cols]));
     }
     Ok(rows)
 }
@@ -1718,10 +1695,11 @@ fn square_matrix_dim(op: &'static str, shape: &[usize]) -> tenferro_tensor::Resu
 // may not compile a direct call site.
 #[allow(dead_code)]
 fn unsupported_provider(op: &'static str, kind: CpuBackendKind) -> Error {
-    Error::InvalidConfig {
+    Error::invalid_argument(
         op,
-        message: format!("CPU linalg provider {kind:?} is not compiled in"),
-    }
+        "provider",
+        format!("CPU linalg provider {kind:?} is not compiled in"),
+    )
 }
 
 fn unsupported_pair(
@@ -1730,11 +1708,7 @@ fn unsupported_pair(
     rhs: &Tensor,
 ) -> tenferro_tensor::Result<Tensor> {
     if lhs.dtype() != rhs.dtype() {
-        Err(Error::DTypeMismatch {
-            op,
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        })
+        Err(Error::dtype_mismatch(op, lhs.dtype(), rhs.dtype()))
     } else {
         Err(unsupported_dtype(op, lhs.dtype()))
     }

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -1304,7 +1304,7 @@ fn ensure_host_typed_tensor<T: 'static>(
     input: &TypedTensor<T>,
 ) -> tenferro_tensor::Result<()> {
     if input.as_view().backend_buffer().is_some() {
-        return Err(Error::backend_failure(
+        return Err(Error::runtime_state(
             op,
             "CPU linalg backend received a backend buffer; download the tensor to host before CPU execution",
         ));
@@ -1415,15 +1415,21 @@ fn complex64_real_part_tensor(
 }
 
 fn svd_output_count_error(count: usize) -> Error {
-    Error::backend_failure("svd", format!("expected 3 outputs, got {count}"))
+    Error::Internal(format!(
+        "svd produced an invalid output count: expected 3, got {count}"
+    ))
 }
 
 fn full_piv_lu_output_count_error(count: usize) -> Error {
-    Error::backend_failure("full_piv_lu", format!("expected 5 outputs, got {count}"))
+    Error::Internal(format!(
+        "full_piv_lu produced an invalid output count: expected 5, got {count}"
+    ))
 }
 
 fn eigh_output_count_error(count: usize) -> Error {
-    Error::backend_failure("eigh", format!("expected 2 outputs, got {count}"))
+    Error::Internal(format!(
+        "eigh produced an invalid output count: expected 2, got {count}"
+    ))
 }
 
 fn full_piv_lu_c32_outputs_to_public_tensors(
@@ -1602,17 +1608,19 @@ fn apply_lu_pivots_typed<T: Clone>(
         for step in 0..k {
             let pivot_one_based = pivot_data[pivot_offset + step];
             if pivot_one_based <= 0 {
-                return Err(Error::backend_failure(
+                return Err(Error::invalid_argument(
                     "lu_solve_prepared",
+                    "pivot",
                     "LU pivot index must be 1-based and positive",
                 ));
             }
             let pivot = usize::try_from(pivot_one_based - 1).map_err(|_| {
-                Error::backend_failure("lu_solve_prepared", "LU pivot index is invalid")
+                Error::invalid_argument("lu_solve_prepared", "pivot", "LU pivot index is invalid")
             })?;
             if pivot >= rows {
-                return Err(Error::backend_failure(
+                return Err(Error::invalid_argument(
                     "lu_solve_prepared",
+                    "pivot",
                     "LU pivot index is out of bounds",
                 ));
             }

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -288,7 +288,11 @@ impl_complex_faer_casts!(
 );
 
 fn decomposition_failed(op: &'static str) -> tenferro_tensor::Error {
-    tenferro_tensor::Error::backend_failure(op, "decomposition failed")
+    crate::error::into_tensor_error(op, crate::Error::NonConvergence { op })
+}
+
+fn singular_matrix(op: &'static str) -> tenferro_tensor::Error {
+    crate::error::into_tensor_error(op, crate::Error::Singular { op })
 }
 
 fn invalid_config(op: &'static str, message: impl Into<String>) -> tenferro_tensor::Error {
@@ -1033,7 +1037,7 @@ macro_rules! impl_faer_linalg_for_real {
             stack,
             Default::default(),
         )
-        .map_err(|_| tenferro_tensor::Error::backend_failure("cholesky", "matrix is not positive definite"))?;
+        .map_err(|_| decomposition_failed("cholesky"))?;
         tensor_from_vec_with_template(
             vec![n, n],
             lower_triangle_vec_from_mat(l.as_ref())?,
@@ -1262,7 +1266,7 @@ macro_rules! impl_faer_linalg_for_real {
                 max_diagonal,
                 <$scalar>::EPSILON as f64,
             ) {
-                return Err(tenferro_tensor::Error::backend_failure("full_piv_lu_solve", "matrix is singular"));
+                return Err(singular_matrix("full_piv_lu_solve"));
             }
         }
 
@@ -1344,7 +1348,7 @@ macro_rules! impl_faer_linalg_for_real {
                 max_diagonal,
                 <$scalar>::EPSILON as f64,
             ) {
-                return Err(tenferro_tensor::Error::backend_failure("solve", "matrix is singular"));
+                return Err(singular_matrix("solve"));
             }
         }
 
@@ -1865,7 +1869,7 @@ macro_rules! impl_faer_linalg_for_complex {
             stack,
             Default::default(),
         )
-        .map_err(|_| tenferro_tensor::Error::backend_failure("cholesky", "matrix is not positive definite"))?;
+        .map_err(|_| decomposition_failed("cholesky"))?;
         tensor_from_vec_with_template(
             vec![n, n],
             $matrix_from_predicate(l.as_ref(), n, n, |row, col| row >= col)?,
@@ -2129,7 +2133,7 @@ macro_rules! impl_faer_linalg_for_complex {
                 max_diagonal,
                 <$real>::EPSILON as f64,
             ) {
-                return Err(tenferro_tensor::Error::backend_failure("full_piv_lu_solve", "matrix is singular"));
+                return Err(singular_matrix("full_piv_lu_solve"));
             }
         }
 
@@ -2224,7 +2228,7 @@ macro_rules! impl_faer_linalg_for_complex {
                 max_diagonal,
                 <$real>::EPSILON as f64,
             ) {
-                return Err(tenferro_tensor::Error::backend_failure("solve", "matrix is singular"));
+                return Err(singular_matrix("solve"));
             }
         }
 
@@ -3172,14 +3176,14 @@ fn host_base_ptr<T: 'static>(view: &TypedTensorView<'_, T>) -> tenferro_tensor::
     let storage = view.host_storage()?;
     let offset = view.offset();
     if offset < 0 {
-        return Err(tenferro_tensor::Error::backend_failure(
+        return Err(tenferro_tensor::Error::runtime_state(
             "faer_view",
             "view offset is negative",
         ));
     }
     let offset_usize = offset as usize;
     if !storage.is_empty() && offset_usize >= storage.len() {
-        return Err(tenferro_tensor::Error::backend_failure(
+        return Err(tenferro_tensor::Error::runtime_state(
             "faer_view",
             "view offset is outside host buffer",
         ));
@@ -3550,10 +3554,7 @@ pub(crate) fn eig(
                 Tensor::C64(TypedTensor::from_vec_col_major(value_shape, Vec::new())?),
                 Tensor::C64(TypedTensor::from_vec_col_major(vector_shape, Vec::new())?),
             ]),
-            _ => Err(tenferro_tensor::Error::backend_failure(
-                "eig",
-                format!("unsupported dtype {:?}", input.dtype()),
-            )),
+            _ => Err(crate::error::unsupported_dtype("eig", input.dtype())),
         };
     }
 
@@ -3598,10 +3599,7 @@ pub(crate) fn eig(
                 .collect(),
             )
         }
-        _ => Err(tenferro_tensor::Error::backend_failure(
-            "eig",
-            format!("unsupported dtype {:?}", input.dtype()),
-        )),
+        _ => Err(crate::error::unsupported_dtype("eig", input.dtype())),
     }
 }
 
@@ -3631,10 +3629,7 @@ pub(crate) fn eig_values(
                 value_shape,
                 Vec::new(),
             )?)),
-            _ => Err(tenferro_tensor::Error::backend_failure(
-                "eig_values",
-                format!("unsupported dtype {:?}", input.dtype()),
-            )),
+            _ => Err(crate::error::unsupported_dtype("eig_values", input.dtype())),
         };
     }
 
@@ -3667,10 +3662,7 @@ pub(crate) fn eig_values(
                 })?;
             Ok(Tensor::C64(outputs.remove(0)))
         }
-        _ => Err(tenferro_tensor::Error::backend_failure(
-            "eig_values",
-            format!("unsupported dtype {:?}", input.dtype()),
-        )),
+        _ => Err(crate::error::unsupported_dtype("eig_values", input.dtype())),
     }
 }
 

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -151,11 +151,11 @@ fn matrix_dims<T>(
     op: &'static str,
 ) -> tenferro_tensor::Result<(usize, usize)> {
     if input.shape().len() != 2 {
-        return Err(tenferro_tensor::Error::RankMismatch {
+        return Err(tenferro_tensor::Error::rank_mismatch(
             op,
-            expected: 2,
-            actual: input.shape().len(),
-        });
+            2,
+            input.shape().len(),
+        ));
     }
     Ok((input.shape()[0], input.shape()[1]))
 }
@@ -166,11 +166,11 @@ fn square_matrix_dim<T>(
 ) -> tenferro_tensor::Result<usize> {
     let (rows, cols) = matrix_dims(input, op)?;
     if rows != cols {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
+        return Err(tenferro_tensor::Error::shape_mismatch(
             op,
-            lhs: vec![rows],
-            rhs: vec![cols],
-        });
+            vec![rows],
+            vec![cols],
+        ));
     }
     Ok(rows)
 }
@@ -292,10 +292,7 @@ fn decomposition_failed(op: &'static str) -> tenferro_tensor::Error {
 }
 
 fn invalid_config(op: &'static str, message: impl Into<String>) -> tenferro_tensor::Error {
-    tenferro_tensor::Error::InvalidConfig {
-        op,
-        message: message.into(),
-    }
+    tenferro_tensor::Error::invalid_argument(op, "configuration", message)
 }
 
 fn eig_imag_is_effectively_zero(real: f64, imag: f64, eps: f64) -> bool {
@@ -578,11 +575,11 @@ fn split_shape_core_and_batch<'a>(
     op: &'static str,
 ) -> tenferro_tensor::Result<(&'a [usize], &'a [usize])> {
     if shape.len() < core_rank {
-        return Err(tenferro_tensor::Error::RankMismatch {
+        return Err(tenferro_tensor::Error::rank_mismatch(
             op,
-            expected: core_rank,
-            actual: shape.len(),
-        });
+            core_rank,
+            shape.len(),
+        ));
     }
     Ok(shape.split_at(core_rank))
 }
@@ -609,11 +606,11 @@ fn square_core_and_batch<'a, T>(
 ) -> tenferro_tensor::Result<(usize, &'a [usize])> {
     let (rows, cols, batch_shape) = matrix_core_and_batch(input, op)?;
     if rows != cols {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
+        return Err(tenferro_tensor::Error::shape_mismatch(
             op,
-            lhs: vec![rows],
-            rhs: vec![cols],
-        });
+            vec![rows],
+            vec![cols],
+        ));
     }
     Ok((rows, batch_shape))
 }
@@ -678,11 +675,11 @@ where
 
         if let Some(expected_shape) = &out_core_shape {
             if batch_output.shape() != expected_shape.as_slice() {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: op_name,
-                    lhs: batch_output.shape().to_vec(),
-                    rhs: expected_shape.clone(),
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch(
+                    op_name,
+                    batch_output.shape().to_vec(),
+                    expected_shape.clone(),
+                ));
             }
         } else {
             let output_elements =
@@ -770,21 +767,21 @@ where
             out_data = pooled_outputs;
         } else {
             if batch_outputs.len() != out_shapes.len() {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: op_name,
-                    lhs: vec![batch_outputs.len()],
-                    rhs: vec![out_shapes.len()],
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch(
+                    op_name,
+                    vec![batch_outputs.len()],
+                    vec![out_shapes.len()],
+                ));
             }
         }
 
         for (idx, batch_output) in batch_outputs.iter().enumerate() {
             if batch_output.shape() != out_shapes[idx].as_slice() {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: op_name,
-                    lhs: batch_output.shape().to_vec(),
-                    rhs: out_shapes[idx].clone(),
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch(
+                    op_name,
+                    batch_output.shape().to_vec(),
+                    out_shapes[idx].clone(),
+                ));
             }
             out_data[idx].extend_from_slice(batch_output.host_data()?);
         }
@@ -860,21 +857,21 @@ where
             out_data = pooled_outputs;
         } else {
             if batch_outputs.len() != out_shapes.len() {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: op_name,
-                    lhs: vec![batch_outputs.len()],
-                    rhs: vec![out_shapes.len()],
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch(
+                    op_name,
+                    vec![batch_outputs.len()],
+                    vec![out_shapes.len()],
+                ));
             }
         }
 
         for (idx, batch_output) in batch_outputs.iter().enumerate() {
             if batch_output.shape() != out_shapes[idx].as_slice() {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: op_name,
-                    lhs: batch_output.shape().to_vec(),
-                    rhs: out_shapes[idx].clone(),
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch(
+                    op_name,
+                    batch_output.shape().to_vec(),
+                    out_shapes[idx].clone(),
+                ));
             }
             out_data[idx].extend_from_slice(batch_output.host_data()?);
         }
@@ -910,11 +907,11 @@ where
     let (a_core_shape, a_batch_shape) = split_core_and_batch(a, core_rank_a, op_name)?;
     let (b_core_shape, b_batch_shape) = split_core_and_batch(b, core_rank_b, op_name)?;
     if a_batch_shape != b_batch_shape {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
-            op: op_name,
-            lhs: a_batch_shape.to_vec(),
-            rhs: b_batch_shape.to_vec(),
-        });
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            op_name,
+            a_batch_shape.to_vec(),
+            b_batch_shape.to_vec(),
+        ));
     }
 
     if a_batch_shape.is_empty() {
@@ -960,11 +957,11 @@ where
 
         if let Some(expected_shape) = &out_core_shape {
             if batch_output.shape() != expected_shape.as_slice() {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: op_name,
-                    lhs: batch_output.shape().to_vec(),
-                    rhs: expected_shape.clone(),
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch(
+                    op_name,
+                    batch_output.shape().to_vec(),
+                    expected_shape.clone(),
+                ));
             }
         } else {
             let output_elements =
@@ -1228,11 +1225,7 @@ macro_rules! impl_faer_linalg_for_real {
         let n = square_matrix_dim(a, "full_piv_lu_solve")?;
         let (b_rows, b_cols) = matrix_dims(b, "full_piv_lu_solve")?;
         if b_rows != n {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "full_piv_lu_solve",
-                lhs: vec![n],
-                rhs: vec![b_rows],
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch("full_piv_lu_solve", vec![n], vec![b_rows]));
         }
 
         let mut lu = Mat::zeros(n, n);
@@ -1318,11 +1311,7 @@ macro_rules! impl_faer_linalg_for_real {
         let n = square_matrix_dim(a, "solve")?;
         let (b_rows, b_cols) = matrix_dims(b, "solve")?;
         if b_rows != n {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "solve",
-                lhs: vec![n],
-                rhs: vec![b_rows],
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch("solve", vec![n], vec![b_rows]));
         }
 
         let mut lu = Mat::zeros(n, n);
@@ -1413,11 +1402,7 @@ macro_rules! impl_faer_linalg_for_real {
 
         if left_side {
             if b_rows != n {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: "triangular_solve",
-                    lhs: vec![n],
-                    rhs: vec![b_rows],
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch("triangular_solve", vec![n], vec![b_rows]));
             }
             let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data()?.len());
             rhs_data.extend_from_slice(b.host_data()?);
@@ -1483,11 +1468,7 @@ macro_rules! impl_faer_linalg_for_real {
             Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())?)
         } else {
             if b_cols != n {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: "triangular_solve",
-                    lhs: vec![n],
-                    rhs: vec![b_cols],
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch("triangular_solve", vec![n], vec![b_cols]));
             }
             let nrhs = b_rows;
             let mut rhs_transposed = transpose_col_major_data(buffers, b.host_data()?, nrhs, n);
@@ -2102,11 +2083,7 @@ macro_rules! impl_faer_linalg_for_complex {
         let n = square_matrix_dim(a, "full_piv_lu_solve")?;
         let (b_rows, b_cols) = matrix_dims(b, "full_piv_lu_solve")?;
         if b_rows != n {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "full_piv_lu_solve",
-                lhs: vec![n],
-                rhs: vec![b_rows],
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch("full_piv_lu_solve", vec![n], vec![b_rows]));
         }
 
         let mut lu = Mat::zeros(n, n);
@@ -2205,11 +2182,7 @@ macro_rules! impl_faer_linalg_for_complex {
         let n = square_matrix_dim(a, "solve")?;
         let (b_rows, b_cols) = matrix_dims(b, "solve")?;
         if b_rows != n {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "solve",
-                lhs: vec![n],
-                rhs: vec![b_rows],
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch("solve", vec![n], vec![b_rows]));
         }
 
         let mut lu = Mat::zeros(n, n);
@@ -2309,11 +2282,7 @@ macro_rules! impl_faer_linalg_for_complex {
 
         if left_side {
             if b_rows != n {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: "triangular_solve",
-                    lhs: vec![n],
-                    rhs: vec![b_rows],
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch("triangular_solve", vec![n], vec![b_rows]));
             }
             let mut rhs_data = buffers.acquire_with_capacity::<Self>(b.host_data()?.len());
             rhs_data.extend_from_slice(b.host_data()?);
@@ -2383,11 +2352,7 @@ macro_rules! impl_faer_linalg_for_complex {
             Ok(tensor_from_vec_with_template(vec![n, b_cols], rhs_data, b.placement())?)
         } else {
             if b_cols != n {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: "triangular_solve",
-                    lhs: vec![n],
-                    rhs: vec![b_cols],
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch("triangular_solve", vec![n], vec![b_cols]));
             }
             let nrhs = b_rows;
             let mut rhs_transposed = transpose_col_major_data(buffers, b.host_data()?, nrhs, n);
@@ -2975,18 +2940,18 @@ pub(crate) fn full_piv_lu_solve<T: FaerLinalg>(
         let (n, a_batch_shape) = square_core_and_batch(a, "full_piv_lu_solve")?;
         let (b_rows, _, b_batch_shape) = matrix_core_and_batch(b, "full_piv_lu_solve")?;
         if b_rows != n {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "full_piv_lu_solve",
-                lhs: vec![n],
-                rhs: vec![b_rows],
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "full_piv_lu_solve",
+                vec![n],
+                vec![b_rows],
+            ));
         }
         if a_batch_shape != b_batch_shape {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "full_piv_lu_solve",
-                lhs: a_batch_shape.to_vec(),
-                rhs: b_batch_shape.to_vec(),
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "full_piv_lu_solve",
+                a_batch_shape.to_vec(),
+                b_batch_shape.to_vec(),
+            ));
         }
         return tensor_from_vec_with_template(b.shape().to_vec(), Vec::new(), b.placement());
     }
@@ -3006,18 +2971,18 @@ pub(crate) fn solve<T: FaerLinalg>(
         let (n, a_batch_shape) = square_core_and_batch(a, "solve")?;
         let (b_rows, _, b_batch_shape) = matrix_core_and_batch(b, "solve")?;
         if b_rows != n {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "solve",
-                lhs: vec![n],
-                rhs: vec![b_rows],
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "solve",
+                vec![n],
+                vec![b_rows],
+            ));
         }
         if a_batch_shape != b_batch_shape {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "solve",
-                lhs: a_batch_shape.to_vec(),
-                rhs: b_batch_shape.to_vec(),
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "solve",
+                a_batch_shape.to_vec(),
+                b_batch_shape.to_vec(),
+            ));
         }
         return tensor_from_vec_with_template(b.shape().to_vec(), Vec::new(), b.placement());
     }
@@ -3043,18 +3008,18 @@ pub(crate) fn triangular_solve<T: FaerLinalg>(
         let (b_rows, b_cols, b_batch_shape) = matrix_core_and_batch(b, "triangular_solve")?;
         let rhs_core_dim = if left_side { b_rows } else { b_cols };
         if rhs_core_dim != n {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "triangular_solve",
-                lhs: vec![n],
-                rhs: vec![rhs_core_dim],
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "triangular_solve",
+                vec![n],
+                vec![rhs_core_dim],
+            ));
         }
         if a_batch_shape != b_batch_shape {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "triangular_solve",
-                lhs: a_batch_shape.to_vec(),
-                rhs: b_batch_shape.to_vec(),
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "triangular_solve",
+                a_batch_shape.to_vec(),
+                b_batch_shape.to_vec(),
+            ));
         }
         return tensor_from_vec_with_template(b.shape().to_vec(), Vec::new(), b.placement());
     }
@@ -3228,11 +3193,11 @@ fn matrix_dims_view<T: 'static>(
     op: &'static str,
 ) -> tenferro_tensor::Result<(usize, usize)> {
     if view.shape().len() != 2 {
-        return Err(tenferro_tensor::Error::RankMismatch {
+        return Err(tenferro_tensor::Error::rank_mismatch(
             op,
-            expected: 2,
-            actual: view.shape().len(),
-        });
+            2,
+            view.shape().len(),
+        ));
     }
     Ok((view.shape()[0], view.shape()[1]))
 }
@@ -3268,11 +3233,11 @@ pub(crate) fn eigh_view<T: FaerLinalg + 'static>(
 ) -> tenferro_tensor::Result<Vec<TypedTensor<T>>> {
     let (m, n) = matrix_dims_view(&view, "eigh")?;
     if m != n {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
-            op: "eigh",
-            lhs: vec![m],
-            rhs: vec![n],
-        });
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "eigh",
+            vec![m],
+            vec![n],
+        ));
     }
     let placement = view.placement().clone();
     let base = host_base_ptr(&view)?;
@@ -3288,11 +3253,11 @@ pub(crate) fn cholesky_view<T: FaerLinalg + 'static>(
 ) -> tenferro_tensor::Result<TypedTensor<T>> {
     let (m, n) = matrix_dims_view(&view, "cholesky")?;
     if m != n {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
-            op: "cholesky",
-            lhs: vec![m],
-            rhs: vec![n],
-        });
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "cholesky",
+            vec![m],
+            vec![n],
+        ));
     }
     let placement = view.placement().clone();
     let base = host_base_ptr(&view)?;
@@ -3321,11 +3286,11 @@ pub(crate) fn full_piv_lu_view<T: FaerLinalg + 'static>(
 ) -> tenferro_tensor::Result<Vec<TypedTensor<T>>> {
     let (m, n) = matrix_dims_view(&view, "full_piv_lu")?;
     if m != n {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
-            op: "full_piv_lu",
-            lhs: vec![m],
-            rhs: vec![n],
-        });
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "full_piv_lu",
+            vec![m],
+            vec![n],
+        ));
     }
     let placement = view.placement().clone();
     let base = host_base_ptr(&view)?;
@@ -3568,11 +3533,11 @@ pub(crate) fn eig(
         let (matrix_shape, batch_shape) = split_shape_core_and_batch(input.shape(), 2, "eig")?;
         let n = matrix_shape[0];
         if matrix_shape[1] != n {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "eig",
-                lhs: vec![n],
-                rhs: vec![matrix_shape[1]],
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "eig",
+                vec![n],
+                vec![matrix_shape[1]],
+            ));
         }
         let value_shape = vector_with_batch_shape(n, batch_shape);
         let vector_shape = matrix_with_batch_shape(n, n, batch_shape);
@@ -3650,11 +3615,11 @@ pub(crate) fn eig_values(
             split_shape_core_and_batch(input.shape(), 2, "eig_values")?;
         let n = matrix_shape[0];
         if matrix_shape[1] != n {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "eig_values",
-                lhs: vec![n],
-                rhs: vec![matrix_shape[1]],
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "eig_values",
+                vec![n],
+                vec![matrix_shape[1]],
+            ));
         }
         let value_shape = vector_with_batch_shape(n, batch_shape);
         return match input {

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg/tests.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg/tests.rs
@@ -7,7 +7,7 @@ fn checked_matrix_element_count_reports_typed_overflow() {
 
     assert!(matches!(
         err,
-        tenferro_tensor::Error::InvalidConfig {
+        tenferro_tensor::Error::Validation {
             op: "test_faer_allocation",
             ..
         }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg.rs
@@ -1,3 +1,5 @@
+pub(crate) use crate::error::unsupported_dtype;
+
 mod cholesky;
 mod eig;
 mod eigh;

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/cholesky.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/cholesky.rs
@@ -63,9 +63,9 @@ fn cholesky_2d<T: LapackCholesky>(
     let mut info = 0;
     T::potrf(b'L', n_i32, &mut factor, n_i32, &mut info);
     if info > 0 {
-        return Err(tenferro_tensor::Error::backend_failure(
+        return Err(crate::error::into_tensor_error(
             "cholesky",
-            "matrix is not positive definite",
+            crate::Error::NonConvergence { op: "cholesky" },
         ));
     }
     check_lapack_info("cholesky", "dpotrf", info)?;

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eig.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eig.rs
@@ -8,6 +8,7 @@ use super::helpers::{
     square_matrix_dim, tensor_from_vec_with_template, vector_with_batch_shape, work_len,
     zero_dim_eig_outputs,
 };
+use super::unsupported_dtype;
 
 fn eig_imag_is_effectively_zero(real: f64, imag: f64, eps: f64) -> bool {
     imag.abs() <= eps * real.abs().max(1.0)
@@ -422,29 +423,26 @@ pub(crate) fn eig(
             .into_iter()
             .map(Tensor::C64)
             .collect()),
-        _ => Err(tenferro_tensor::Error::backend_failure(
-            "eig",
-            format!("unsupported dtype {:?}", input.dtype()),
-        )),
+        _ => Err(unsupported_dtype("eig", input.dtype())),
     }
 }
 
 fn zero_dim_eig_values_output(input: &Tensor) -> tenferro_tensor::Result<Tensor> {
     let shape = input.shape();
     if shape.len() < 2 {
-        return Err(tenferro_tensor::Error::RankMismatch {
-            op: "eig_values",
-            expected: 2,
-            actual: shape.len(),
-        });
+        return Err(tenferro_tensor::Error::rank_mismatch(
+            "eig_values",
+            2,
+            shape.len(),
+        ));
     }
     let n = shape[0];
     if shape[1] != n {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
-            op: "eig_values",
-            lhs: vec![n],
-            rhs: vec![shape[1]],
-        });
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "eig_values",
+            vec![n],
+            vec![shape[1]],
+        ));
     }
     let value_shape = vector_with_batch_shape(n, &shape[2..]);
     match input {
@@ -456,10 +454,7 @@ fn zero_dim_eig_values_output(input: &Tensor) -> tenferro_tensor::Result<Tensor>
             value_shape,
             Vec::new(),
         )?)),
-        _ => Err(tenferro_tensor::Error::backend_failure(
-            "eig_values",
-            format!("unsupported dtype {:?}", input.dtype()),
-        )),
+        _ => Err(unsupported_dtype("eig_values", input.dtype())),
     }
 }
 
@@ -496,9 +491,6 @@ pub(crate) fn eig_values(
             })?;
             Ok(Tensor::C64(outputs.remove(0)))
         }
-        _ => Err(tenferro_tensor::Error::backend_failure(
-            "eig_values",
-            format!("unsupported dtype {:?}", input.dtype()),
-        )),
+        _ => Err(unsupported_dtype("eig_values", input.dtype())),
     }
 }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eigh.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eigh.rs
@@ -24,9 +24,11 @@ pub(crate) trait LapackEigh: Clone + Copy + Default + PoolScalar {
 
 fn iwork_len(query: i32, op: &'static str, routine: &'static str) -> tenferro_tensor::Result<i32> {
     if query < 1 {
-        return Err(tenferro_tensor::Error::backend_failure(
+        return Err(crate::error::invalid_workspace(
             op,
-            format!("LAPACK {routine} returned invalid integer workspace size {query}"),
+            "LAPACK",
+            routine,
+            format!("invalid integer workspace size {query}"),
         ));
     }
     Ok(query)
@@ -38,9 +40,11 @@ fn queried_iwork_len(
     routine: &'static str,
 ) -> tenferro_tensor::Result<i32> {
     let query = query.first().copied().ok_or_else(|| {
-        tenferro_tensor::Error::backend_failure(
+        crate::error::invalid_workspace(
             op,
-            format!("LAPACK {routine} did not return an integer workspace size"),
+            "LAPACK",
+            routine,
+            "did not return an integer workspace size",
         )
     })?;
     iwork_len(query, op, routine)
@@ -52,9 +56,11 @@ fn iwork_capacity(
     routine: &'static str,
 ) -> tenferro_tensor::Result<usize> {
     usize::try_from(len).map_err(|_| {
-        tenferro_tensor::Error::backend_failure(
+        crate::error::invalid_workspace(
             op,
-            format!("LAPACK {routine} integer workspace size {len} does not fit usize"),
+            "LAPACK",
+            routine,
+            format!("integer workspace size {len} does not fit usize"),
         )
     })
 }
@@ -372,9 +378,8 @@ pub(crate) fn eigh_values<T: LapackEigh>(
         })?;
     match outputs.pop() {
         Some(values) if outputs.is_empty() => Ok(values),
-        _ => Err(tenferro_tensor::Error::InvalidConfig {
-            op: "eigh_values",
-            message: "expected exactly one output from batched eigenvalue helper".into(),
-        }),
+        _ => Err(tenferro_tensor::Error::Internal(
+            "eigh_values: expected exactly one output from batched eigenvalue helper".into(),
+        )),
     }
 }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs
@@ -420,10 +420,9 @@ fn permutation_from_lapack_pivots(
         let pivot = match usize::try_from(pivot_one_based - 1) {
             Ok(pivot) if pivot < pivots.len() => pivot,
             _ => {
-                return Err(tenferro_tensor::Error::backend_failure(
-                    op,
-                    "LAPACK getc2 returned invalid pivot index",
-                ));
+                return Err(tenferro_tensor::Error::Internal(format!(
+                    "{op}: LAPACK getc2 returned an invalid pivot index"
+                )));
             }
         };
         if pivot != idx {
@@ -457,9 +456,9 @@ fn factor_getc2<T: LapackFullPivLu>(
     T::getc2(n_i32, data, n_i32, &mut ipiv, &mut jpiv, &mut info);
     check_lapack_info(op, "getc2", info.min(0))?;
     if info > 0 {
-        return Err(tenferro_tensor::Error::backend_failure(
+        return Err(crate::error::into_tensor_error(
             op,
-            "matrix is singular",
+            crate::Error::Singular { op },
         ));
     }
     Ok((ipiv, jpiv, info))
@@ -516,11 +515,11 @@ fn solve_2d<T: LapackFullPivLu>(
     let n = square_matrix_dim(a, "full_piv_lu_solve")?;
     let (b_rows, b_cols) = matrix_dims(b, "full_piv_lu_solve")?;
     if b_rows != n {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
-            op: "full_piv_lu_solve",
-            lhs: vec![n],
-            rhs: vec![b_rows],
-        });
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "full_piv_lu_solve",
+            vec![n],
+            vec![b_rows],
+        ));
     }
 
     let mut lu = if transpose_a {
@@ -530,9 +529,11 @@ fn solve_2d<T: LapackFullPivLu>(
     };
     let (ipiv, jpiv, info) = factor_getc2("full_piv_lu_solve", &mut lu, n)?;
     if info > 0 {
-        return Err(tenferro_tensor::Error::backend_failure(
+        return Err(crate::error::into_tensor_error(
             "full_piv_lu_solve",
-            "matrix is singular",
+            crate::Error::Singular {
+                op: "full_piv_lu_solve",
+            },
         ));
     }
 
@@ -605,18 +606,18 @@ pub(crate) fn full_piv_lu_solve<T: LapackFullPivLu>(
         let (n, a_batch_shape) = square_core_and_batch_result(a, "full_piv_lu_solve")?;
         let (b_rows, _, b_batch_shape) = matrix_core_and_batch_result(b, "full_piv_lu_solve")?;
         if b_rows != n {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "full_piv_lu_solve",
-                lhs: vec![n],
-                rhs: vec![b_rows],
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "full_piv_lu_solve",
+                vec![n],
+                vec![b_rows],
+            ));
         }
         if a_batch_shape != b_batch_shape {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "full_piv_lu_solve",
-                lhs: a_batch_shape.to_vec(),
-                rhs: b_batch_shape.to_vec(),
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "full_piv_lu_solve",
+                a_batch_shape.to_vec(),
+                b_batch_shape.to_vec(),
+            ));
         }
         return tensor_from_vec_with_template(b.shape().to_vec(), Vec::new(), b);
     }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/helpers.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/helpers.rs
@@ -12,11 +12,11 @@ pub(crate) fn matrix_dims<T>(
     op: &'static str,
 ) -> tenferro_tensor::Result<(usize, usize)> {
     if input.shape().len() != 2 {
-        return Err(tenferro_tensor::Error::RankMismatch {
+        return Err(tenferro_tensor::Error::rank_mismatch(
             op,
-            expected: 2,
-            actual: input.shape().len(),
-        });
+            2,
+            input.shape().len(),
+        ));
     }
     Ok((input.shape()[0], input.shape()[1]))
 }
@@ -27,11 +27,11 @@ pub(crate) fn square_matrix_dim<T>(
 ) -> tenferro_tensor::Result<usize> {
     let (rows, cols) = matrix_dims(input, op)?;
     if rows != cols {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
+        return Err(tenferro_tensor::Error::shape_mismatch(
             op,
-            lhs: vec![rows],
-            rhs: vec![cols],
-        });
+            vec![rows],
+            vec![cols],
+        ));
     }
     Ok(rows)
 }
@@ -71,11 +71,11 @@ pub(crate) fn split_core_and_batch_result<'a, T>(
     op: &'static str,
 ) -> tenferro_tensor::Result<(&'a [usize], &'a [usize])> {
     if input.shape().len() < core_rank {
-        return Err(tenferro_tensor::Error::RankMismatch {
+        return Err(tenferro_tensor::Error::rank_mismatch(
             op,
-            expected: core_rank,
-            actual: input.shape().len(),
-        });
+            core_rank,
+            input.shape().len(),
+        ));
     }
     Ok(input.shape().split_at(core_rank))
 }
@@ -94,11 +94,11 @@ pub(crate) fn square_core_and_batch_result<'a, T>(
 ) -> tenferro_tensor::Result<(usize, &'a [usize])> {
     let (rows, cols, batch_shape) = matrix_core_and_batch_result(input, op)?;
     if rows != cols {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
+        return Err(tenferro_tensor::Error::shape_mismatch(
             op,
-            lhs: vec![rows],
-            rhs: vec![cols],
-        });
+            vec![rows],
+            vec![cols],
+        ));
     }
     Ok((rows, batch_shape))
 }
@@ -111,11 +111,12 @@ pub(crate) fn batch_element_count(
         return Ok(1);
     }
     batch_shape.iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim)
-            .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
+        acc.checked_mul(dim).ok_or_else(|| {
+            tenferro_tensor::Error::validation(
                 op,
-                message: "batch element count overflow".into(),
-            })
+                tenferro_tensor::ValidationError::IntegerOverflow,
+            )
+        })
     })
 }
 
@@ -125,11 +126,13 @@ pub(crate) fn checked_product(
     shape: &[usize],
 ) -> tenferro_tensor::Result<usize> {
     shape.iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim)
-            .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
+        acc.checked_mul(dim).ok_or_else(|| {
+            tenferro_tensor::Error::invalid_argument(
                 op,
-                message: format!("{role} element count overflow"),
-            })
+                "shape",
+                format!("{role} element count overflow"),
+            )
+        })
     })
 }
 
@@ -139,12 +142,13 @@ fn checked_repeated_len(
     per_batch: usize,
     batch_count: usize,
 ) -> tenferro_tensor::Result<usize> {
-    per_batch
-        .checked_mul(batch_count)
-        .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
+    per_batch.checked_mul(batch_count).ok_or_else(|| {
+        tenferro_tensor::Error::invalid_argument(
             op,
-            message: format!("{role} repeated batch length overflow"),
-        })
+            "batch",
+            format!("{role} repeated batch length overflow"),
+        )
+    })
 }
 
 pub(crate) fn checked_slice_range(
@@ -152,20 +156,12 @@ pub(crate) fn checked_slice_range(
     batch_idx: usize,
     slice_size: usize,
 ) -> tenferro_tensor::Result<Range<usize>> {
-    let start =
-        batch_idx
-            .checked_mul(slice_size)
-            .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-                op,
-                message: "batch slice start overflow".into(),
-            })?;
-    let end =
-        start
-            .checked_add(slice_size)
-            .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-                op,
-                message: "batch slice end overflow".into(),
-            })?;
+    let start = batch_idx.checked_mul(slice_size).ok_or_else(|| {
+        tenferro_tensor::Error::validation(op, tenferro_tensor::ValidationError::IntegerOverflow)
+    })?;
+    let end = start.checked_add(slice_size).ok_or_else(|| {
+        tenferro_tensor::Error::validation(op, tenferro_tensor::ValidationError::IntegerOverflow)
+    })?;
     Ok(start..end)
 }
 
@@ -190,9 +186,12 @@ pub(crate) fn vector_with_batch_shape(len: usize, batch_shape: &[usize]) -> Vec<
 }
 
 pub(crate) fn dim_i32(value: usize, op: &'static str) -> tenferro_tensor::Result<i32> {
-    i32::try_from(value).map_err(|_| tenferro_tensor::Error::InvalidConfig {
-        op,
-        message: format!("dimension {value} exceeds LAPACK i32 range"),
+    i32::try_from(value).map_err(|_| {
+        tenferro_tensor::Error::invalid_argument(
+            op,
+            "dimension",
+            format!("dimension {value} exceeds LAPACK i32 range"),
+        )
     })
 }
 
@@ -202,9 +201,11 @@ pub(crate) fn work_len(
     routine: &'static str,
 ) -> tenferro_tensor::Result<i32> {
     if !(query.is_finite() && query >= 1.0) {
-        return Err(tenferro_tensor::Error::backend_failure(
+        return Err(crate::error::invalid_workspace(
             op,
-            format!("LAPACK {routine} returned invalid workspace size {query}"),
+            "LAPACK",
+            routine,
+            format!("returned invalid workspace size {query}"),
         ));
     }
     dim_i32(query.ceil() as usize, op)
@@ -216,15 +217,16 @@ pub(crate) fn check_lapack_info(
     info: i32,
 ) -> tenferro_tensor::Result<()> {
     if info < 0 {
-        return Err(tenferro_tensor::Error::InvalidConfig {
+        return Err(tenferro_tensor::Error::invalid_argument(
             op,
-            message: format!("LAPACK {routine} argument {} had an illegal value", -info),
-        });
+            "lapack_argument",
+            format!("LAPACK {routine} argument {} had an illegal value", -info),
+        ));
     }
     if info > 0 {
-        return Err(tenferro_tensor::Error::backend_failure(
+        return Err(crate::error::into_tensor_error(
             op,
-            format!("LAPACK {routine} failed with info {info}"),
+            crate::Error::NonConvergence { op },
         ));
     }
     Ok(())
@@ -289,10 +291,11 @@ where
     let slice_size = checked_product(op_name, "core shape", core_shape)?;
     let batch_count = batch_element_count(op_name, batch_shape)?;
     if batch_count == 0 {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: op_name,
-            message: "zero-sized batch dims must be handled by the caller".into(),
-        });
+        return Err(tenferro_tensor::Error::invalid_argument(
+            op_name,
+            "batch",
+            "zero-sized batch dims must be handled by the caller",
+        ));
     }
 
     let mut out_core_shape: Option<Vec<usize>> = None;
@@ -315,11 +318,11 @@ where
 
         if let Some(expected_shape) = &out_core_shape {
             if batch_output.shape() != expected_shape.as_slice() {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: op_name,
-                    lhs: batch_output.shape().to_vec(),
-                    rhs: expected_shape.clone(),
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch(
+                    op_name,
+                    batch_output.shape().to_vec(),
+                    expected_shape.clone(),
+                ));
             }
         } else {
             out_data = Some(Vec::with_capacity(checked_repeated_len(
@@ -334,22 +337,19 @@ where
         match &mut out_data {
             Some(data) => data.extend_from_slice(batch_output.host_data()?),
             None => {
-                return Err(tenferro_tensor::Error::InvalidConfig {
-                    op: op_name,
-                    message: "missing output buffer after first batch".into(),
-                });
+                return Err(tenferro_tensor::Error::Internal(format!(
+                    "{op_name}: missing output buffer after first batch"
+                )));
             }
         }
     }
 
-    let mut out_shape = out_core_shape.ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-        op: op_name,
-        message: "missing output shape".into(),
+    let mut out_shape = out_core_shape.ok_or_else(|| {
+        tenferro_tensor::Error::Internal(format!("{op_name}: missing output shape"))
     })?;
     out_shape.extend_from_slice(batch_shape);
-    let out_data = out_data.ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-        op: op_name,
-        message: "missing output data".into(),
+    let out_data = out_data.ok_or_else(|| {
+        tenferro_tensor::Error::Internal(format!("{op_name}: missing output data"))
     })?;
     tensor_from_vec_with_template(out_shape, out_data, input)
 }
@@ -372,10 +372,11 @@ where
     let slice_size = checked_product(op_name, "core shape", core_shape)?;
     let batch_count = batch_element_count(op_name, batch_shape)?;
     if batch_count == 0 {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: op_name,
-            message: "zero-sized batch dims must be handled by the caller".into(),
-        });
+        return Err(tenferro_tensor::Error::invalid_argument(
+            op_name,
+            "batch",
+            "zero-sized batch dims must be handled by the caller",
+        ));
     }
 
     let mut out_shapes: Vec<Vec<usize>> = Vec::new();
@@ -398,10 +399,9 @@ where
 
         if out_shapes.is_empty() {
             if batch_outputs.is_empty() {
-                return Err(tenferro_tensor::Error::InvalidConfig {
-                    op: op_name,
-                    message: "missing outputs for first batch".into(),
-                });
+                return Err(tenferro_tensor::Error::Internal(format!(
+                    "{op_name}: missing outputs for first batch"
+                )));
             }
             out_shapes = batch_outputs
                 .iter()
@@ -416,24 +416,25 @@ where
                 .collect::<tenferro_tensor::Result<_>>()?;
         } else {
             if batch_outputs.len() != out_shapes.len() {
-                return Err(tenferro_tensor::Error::InvalidConfig {
-                    op: op_name,
-                    message: format!(
+                return Err(tenferro_tensor::Error::invalid_argument(
+                    op_name,
+                    "outputs",
+                    format!(
                         "output count mismatch across batches: got {}, expected {}",
                         batch_outputs.len(),
                         out_shapes.len()
                     ),
-                });
+                ));
             }
         }
 
         for (idx, batch_output) in batch_outputs.iter().enumerate() {
             if batch_output.shape() != out_shapes[idx].as_slice() {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: op_name,
-                    lhs: batch_output.shape().to_vec(),
-                    rhs: out_shapes[idx].clone(),
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch(
+                    op_name,
+                    batch_output.shape().to_vec(),
+                    out_shapes[idx].clone(),
+                ));
             }
             out_data[idx].extend_from_slice(batch_output.host_data()?);
         }
@@ -466,10 +467,11 @@ where
     let slice_size = checked_product(op_name, "core shape", core_shape)?;
     let batch_count = batch_element_count(op_name, batch_shape)?;
     if batch_count == 0 {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: op_name,
-            message: "zero-sized batch dims must be handled by the caller".into(),
-        });
+        return Err(tenferro_tensor::Error::invalid_argument(
+            op_name,
+            "batch",
+            "zero-sized batch dims must be handled by the caller",
+        ));
     }
 
     let mut out_shapes: Vec<Vec<usize>> = Vec::new();
@@ -492,10 +494,9 @@ where
 
         if out_shapes.is_empty() {
             if batch_outputs.is_empty() {
-                return Err(tenferro_tensor::Error::InvalidConfig {
-                    op: op_name,
-                    message: "missing outputs for first batch".into(),
-                });
+                return Err(tenferro_tensor::Error::Internal(format!(
+                    "{op_name}: missing outputs for first batch"
+                )));
             }
             out_shapes = batch_outputs
                 .iter()
@@ -510,24 +511,25 @@ where
                 .collect::<tenferro_tensor::Result<_>>()?;
         } else {
             if batch_outputs.len() != out_shapes.len() {
-                return Err(tenferro_tensor::Error::InvalidConfig {
-                    op: op_name,
-                    message: format!(
+                return Err(tenferro_tensor::Error::invalid_argument(
+                    op_name,
+                    "outputs",
+                    format!(
                         "output count mismatch across batches: got {}, expected {}",
                         batch_outputs.len(),
                         out_shapes.len()
                     ),
-                });
+                ));
             }
         }
 
         for (idx, batch_output) in batch_outputs.iter().enumerate() {
             if batch_output.shape() != out_shapes[idx].as_slice() {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: op_name,
-                    lhs: batch_output.shape().to_vec(),
-                    rhs: out_shapes[idx].clone(),
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch(
+                    op_name,
+                    batch_output.shape().to_vec(),
+                    out_shapes[idx].clone(),
+                ));
             }
             out_data[idx].extend_from_slice(batch_output.host_data()?);
         }
@@ -561,11 +563,11 @@ where
     let (a_core_shape, a_batch_shape) = split_core_and_batch_result(a, 2, op_name)?;
     let (b_core_shape, b_batch_shape) = split_core_and_batch_result(b, 2, op_name)?;
     if a_batch_shape != b_batch_shape {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
-            op: op_name,
-            lhs: a_batch_shape.to_vec(),
-            rhs: b_batch_shape.to_vec(),
-        });
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            op_name,
+            a_batch_shape.to_vec(),
+            b_batch_shape.to_vec(),
+        ));
     }
 
     if a_batch_shape.is_empty() {
@@ -576,10 +578,11 @@ where
     let b_slice_size = checked_product(op_name, "rhs core shape", b_core_shape)?;
     let batch_count = batch_element_count(op_name, a_batch_shape)?;
     if batch_count == 0 {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: op_name,
-            message: "zero-sized batch dims must be handled by the caller".into(),
-        });
+        return Err(tenferro_tensor::Error::invalid_argument(
+            op_name,
+            "batch",
+            "zero-sized batch dims must be handled by the caller",
+        ));
     }
 
     let mut out_core_shape: Option<Vec<usize>> = None;
@@ -611,11 +614,11 @@ where
 
         if let Some(expected_shape) = &out_core_shape {
             if batch_output.shape() != expected_shape.as_slice() {
-                return Err(tenferro_tensor::Error::ShapeMismatch {
-                    op: op_name,
-                    lhs: batch_output.shape().to_vec(),
-                    rhs: expected_shape.clone(),
-                });
+                return Err(tenferro_tensor::Error::shape_mismatch(
+                    op_name,
+                    batch_output.shape().to_vec(),
+                    expected_shape.clone(),
+                ));
             }
         } else {
             out_data = Some(Vec::with_capacity(checked_repeated_len(
@@ -630,22 +633,19 @@ where
         match &mut out_data {
             Some(data) => data.extend_from_slice(batch_output.host_data()?),
             None => {
-                return Err(tenferro_tensor::Error::InvalidConfig {
-                    op: op_name,
-                    message: "missing output buffer after first batch".into(),
-                });
+                return Err(tenferro_tensor::Error::Internal(format!(
+                    "{op_name}: missing output buffer after first batch"
+                )));
             }
         }
     }
 
-    let mut out_shape = out_core_shape.ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-        op: op_name,
-        message: "missing output shape".into(),
+    let mut out_shape = out_core_shape.ok_or_else(|| {
+        tenferro_tensor::Error::Internal(format!("{op_name}: missing output shape"))
     })?;
     out_shape.extend_from_slice(a_batch_shape);
-    let out_data = out_data.ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-        op: op_name,
-        message: "missing output data".into(),
+    let out_data = out_data.ok_or_else(|| {
+        tenferro_tensor::Error::Internal(format!("{op_name}: missing output data"))
     })?;
     tensor_from_vec_with_template(out_shape, out_data, b)
 }
@@ -653,19 +653,15 @@ where
 pub(crate) fn zero_dim_eig_outputs(input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
     let shape = input.shape();
     if shape.len() < 2 {
-        return Err(tenferro_tensor::Error::RankMismatch {
-            op: "eig",
-            expected: 2,
-            actual: shape.len(),
-        });
+        return Err(tenferro_tensor::Error::rank_mismatch("eig", 2, shape.len()));
     }
     let n = shape[0];
     if shape[1] != n {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
-            op: "eig",
-            lhs: vec![n],
-            rhs: vec![shape[1]],
-        });
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "eig",
+            vec![n],
+            vec![shape[1]],
+        ));
     }
     let batch_shape = &shape[2..];
     let value_shape = vector_with_batch_shape(n, batch_shape);
@@ -679,9 +675,6 @@ pub(crate) fn zero_dim_eig_outputs(input: &Tensor) -> tenferro_tensor::Result<Ve
             Tensor::C64(TypedTensor::from_vec_col_major(value_shape, Vec::new())?),
             Tensor::C64(TypedTensor::from_vec_col_major(vector_shape, Vec::new())?),
         ]),
-        _ => Err(tenferro_tensor::Error::backend_failure(
-            "eig",
-            format!("unsupported dtype {:?}", input.dtype()),
-        )),
+        _ => Err(super::unsupported_dtype("eig", input.dtype())),
     }
 }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/helpers/tests.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/helpers/tests.rs
@@ -7,9 +7,9 @@ fn checked_matrix_element_count_reports_typed_overflow() {
 
     assert!(matches!(
         err,
-        tenferro_tensor::Error::InvalidConfig {
+        tenferro_tensor::Error::Validation {
             op: "test_lapack_allocation",
-            ..
+            source: tenferro_tensor::ValidationError::InvalidArgument { .. },
         }
     ));
 }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs
@@ -108,16 +108,14 @@ fn lu_2d<T: LapackLu>(
         let pivot = match usize::try_from(pivot_one_based - 1) {
             Ok(pivot) => pivot,
             Err(_) => {
-                return Err(tenferro_tensor::Error::backend_failure(
-                    "lu",
-                    "LAPACK getrf returned invalid pivot index",
+                return Err(tenferro_tensor::Error::Internal(
+                    "LAPACK getrf returned an invalid pivot index".to_string(),
                 ));
             }
         };
         if pivot >= m {
-            return Err(tenferro_tensor::Error::backend_failure(
-                "lu",
-                "LAPACK getrf returned out-of-bounds pivot index",
+            return Err(tenferro_tensor::Error::Internal(
+                "LAPACK getrf returned an out-of-bounds pivot index".to_string(),
             ));
         }
         if pivot != idx {
@@ -131,7 +129,7 @@ fn lu_2d<T: LapackLu>(
     for (row, &source_row) in permutation.iter().enumerate() {
         p_data[row + source_row * m] = T::one();
     }
-    let parity = if swap_count % 2 == 0 {
+    let parity = if swap_count.is_multiple_of(2) {
         T::one()
     } else {
         T::negative_one()
@@ -173,7 +171,7 @@ fn lu_factor_2d<T: LapackLu>(
         .enumerate()
         .filter(|(idx, pivot_one_based)| **pivot_one_based != (*idx as i32 + 1))
         .count();
-    let parity = if swap_count % 2 == 0 {
+    let parity = if swap_count.is_multiple_of(2) {
         T::one()
     } else {
         T::negative_one()

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/solve.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/solve.rs
@@ -10,17 +10,19 @@ use super::helpers::{
 
 pub(crate) trait LapackSolve: Clone + Copy + PoolScalar {
     fn getrf(m: i32, n: i32, data: &mut [Self], lda: i32, ipiv: &mut [i32], info: &mut i32);
-    fn getrs(
-        trans: u8,
-        n: i32,
-        nrhs: i32,
-        a: &[Self],
-        lda: i32,
-        ipiv: &[i32],
-        b: &mut [Self],
-        ldb: i32,
-        info: &mut i32,
-    );
+    fn getrs(args: GetrsArgs<'_, Self>);
+}
+
+pub(crate) struct GetrsArgs<'a, T> {
+    trans: u8,
+    n: i32,
+    nrhs: i32,
+    a: &'a [T],
+    lda: i32,
+    ipiv: &'a [i32],
+    b: &'a mut [T],
+    ldb: i32,
+    info: &'a mut i32,
 }
 
 impl LapackSolve for f64 {
@@ -32,17 +34,18 @@ impl LapackSolve for f64 {
         }
     }
 
-    fn getrs(
-        trans: u8,
-        n: i32,
-        nrhs: i32,
-        a: &[Self],
-        lda: i32,
-        ipiv: &[i32],
-        b: &mut [Self],
-        ldb: i32,
-        info: &mut i32,
-    ) {
+    fn getrs(args: GetrsArgs<'_, Self>) {
+        let GetrsArgs {
+            trans,
+            n,
+            nrhs,
+            a,
+            lda,
+            ipiv,
+            b,
+            ldb,
+            info,
+        } = args;
         // SAFETY: `a` holds a prior getrf factorization, `ipiv` matches it,
         // `b` is a mutable `ldb x nrhs` RHS buffer, and all dims are validated.
         unsafe {
@@ -60,17 +63,18 @@ impl LapackSolve for f32 {
         }
     }
 
-    fn getrs(
-        trans: u8,
-        n: i32,
-        nrhs: i32,
-        a: &[Self],
-        lda: i32,
-        ipiv: &[i32],
-        b: &mut [Self],
-        ldb: i32,
-        info: &mut i32,
-    ) {
+    fn getrs(args: GetrsArgs<'_, Self>) {
+        let GetrsArgs {
+            trans,
+            n,
+            nrhs,
+            a,
+            lda,
+            ipiv,
+            b,
+            ldb,
+            info,
+        } = args;
         // SAFETY: `a` holds a prior getrf factorization, `ipiv` matches it,
         // `b` is a mutable `ldb x nrhs` RHS buffer, and all dims are validated.
         unsafe {
@@ -88,17 +92,18 @@ impl LapackSolve for Complex32 {
         }
     }
 
-    fn getrs(
-        trans: u8,
-        n: i32,
-        nrhs: i32,
-        a: &[Self],
-        lda: i32,
-        ipiv: &[i32],
-        b: &mut [Self],
-        ldb: i32,
-        info: &mut i32,
-    ) {
+    fn getrs(args: GetrsArgs<'_, Self>) {
+        let GetrsArgs {
+            trans,
+            n,
+            nrhs,
+            a,
+            lda,
+            ipiv,
+            b,
+            ldb,
+            info,
+        } = args;
         // SAFETY: `a` holds a prior getrf factorization, `ipiv` matches it,
         // `b` is a mutable `ldb x nrhs` RHS buffer, and all dims are validated.
         unsafe {
@@ -116,17 +121,18 @@ impl LapackSolve for Complex64 {
         }
     }
 
-    fn getrs(
-        trans: u8,
-        n: i32,
-        nrhs: i32,
-        a: &[Self],
-        lda: i32,
-        ipiv: &[i32],
-        b: &mut [Self],
-        ldb: i32,
-        info: &mut i32,
-    ) {
+    fn getrs(args: GetrsArgs<'_, Self>) {
+        let GetrsArgs {
+            trans,
+            n,
+            nrhs,
+            a,
+            lda,
+            ipiv,
+            b,
+            ldb,
+            info,
+        } = args;
         // SAFETY: `a` holds a prior getrf factorization, `ipiv` matches it,
         // `b` is a mutable `ldb x nrhs` RHS buffer, and all dims are validated.
         unsafe {
@@ -144,11 +150,11 @@ fn solve_2d<T: LapackSolve>(
     let n = square_matrix_dim(a, "solve")?;
     let (b_rows, b_cols) = matrix_dims(b, "solve")?;
     if b_rows != n {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
-            op: "solve",
-            lhs: vec![n],
-            rhs: vec![b_rows],
-        });
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "solve",
+            vec![n],
+            vec![b_rows],
+        ));
     }
 
     let n_i32 = dim_i32(n, "solve")?;
@@ -159,25 +165,25 @@ fn solve_2d<T: LapackSolve>(
     T::getrf(n_i32, n_i32, &mut lu, n_i32, &mut ipiv, &mut info);
     check_lapack_info("solve", "getrf", info.min(0))?;
     if info > 0 {
-        return Err(tenferro_tensor::Error::backend_failure(
+        return Err(crate::error::into_tensor_error(
             "solve",
-            "matrix is singular",
+            crate::Error::Singular { op: "solve" },
         ));
     }
 
     let mut rhs = b.host_data()?.to_vec();
     let mut info = 0;
-    T::getrs(
-        if transpose_a { b'T' } else { b'N' },
-        n_i32,
-        b_cols_i32,
-        &lu,
-        n_i32,
-        &ipiv,
-        &mut rhs,
-        n_i32,
-        &mut info,
-    );
+    T::getrs(GetrsArgs {
+        trans: if transpose_a { b'T' } else { b'N' },
+        n: n_i32,
+        nrhs: b_cols_i32,
+        a: &lu,
+        lda: n_i32,
+        ipiv: &ipiv,
+        b: &mut rhs,
+        ldb: n_i32,
+        info: &mut info,
+    });
     check_lapack_info("solve", "getrs", info)?;
 
     tensor_from_vec_with_template(vec![n, b_cols], rhs, b)
@@ -193,18 +199,18 @@ pub(crate) fn solve<T: LapackSolve>(
         let (n, a_batch_shape) = square_core_and_batch_result(a, "solve")?;
         let (b_rows, _, b_batch_shape) = matrix_core_and_batch_result(b, "solve")?;
         if b_rows != n {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "solve",
-                lhs: vec![n],
-                rhs: vec![b_rows],
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "solve",
+                vec![n],
+                vec![b_rows],
+            ));
         }
         if a_batch_shape != b_batch_shape {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "solve",
-                lhs: a_batch_shape.to_vec(),
-                rhs: b_batch_shape.to_vec(),
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "solve",
+                a_batch_shape.to_vec(),
+                b_batch_shape.to_vec(),
+            ));
         }
         return tensor_from_vec_with_template(b.shape().to_vec(), Vec::new(), b);
     }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/svd.rs
@@ -38,10 +38,7 @@ fn complex_gesdd_rwork_len(jobz: u8, m: usize, n: usize) -> tenferro_tensor::Res
     let square_term = checked_product("svd", "real workspace square term", &[5, mn, mn])?;
     let linear_term = checked_product("svd", "real workspace linear term", &[5, mn])?;
     let small_shape_len = square_term.checked_add(linear_term).ok_or_else(|| {
-        tenferro_tensor::Error::InvalidConfig {
-            op: "svd",
-            message: "real workspace length overflow".into(),
-        }
+        tenferro_tensor::Error::validation("svd", tenferro_tensor::ValidationError::IntegerOverflow)
     })?;
     if mx > threshold {
         return Ok(small_shape_len);
@@ -52,9 +49,11 @@ fn complex_gesdd_rwork_len(jobz: u8, m: usize, n: usize) -> tenferro_tensor::Res
     let large_shape_len = rectangular_term
         .checked_add(second_square_term)
         .and_then(|len| len.checked_add(mn))
-        .ok_or_else(|| tenferro_tensor::Error::InvalidConfig {
-            op: "svd",
-            message: "real workspace length overflow".into(),
+        .ok_or_else(|| {
+            tenferro_tensor::Error::validation(
+                "svd",
+                tenferro_tensor::ValidationError::IntegerOverflow,
+            )
         })?;
     Ok(small_shape_len.max(large_shape_len))
 }
@@ -631,9 +630,8 @@ pub(crate) fn svd_values<T: LapackSvd>(
         })?;
     match outputs.pop() {
         Some(values) if outputs.is_empty() => Ok(values),
-        _ => Err(tenferro_tensor::Error::InvalidConfig {
-            op: "svd_values",
-            message: "expected exactly one output from batched singular-value helper".into(),
-        }),
+        _ => Err(tenferro_tensor::Error::Internal(
+            "svd_values: expected exactly one output from batched singular-value helper".into(),
+        )),
     }
 }

--- a/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/triangular_solve.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/triangular_solve.rs
@@ -13,46 +13,51 @@ use super::helpers::{
 pub(crate) trait LapackTriangularSolve:
     Clone + Copy + PartialEq + PoolScalar + Zero
 {
-    fn trtrs(
-        uplo: u8,
-        trans: u8,
-        diag: u8,
-        n: i32,
-        nrhs: i32,
-        a: &[Self],
-        lda: i32,
-        b: &mut [Self],
-        ldb: i32,
-        info: &mut i32,
-    );
+    fn trtrs(args: TrtrsArgs<'_, Self>);
 
-    fn trsm(
-        side: CBLAS_SIDE,
-        uplo: CBLAS_UPLO,
-        transa: CBLAS_TRANSPOSE,
-        diag: CBLAS_DIAG,
-        m: i32,
-        n: i32,
-        a: &[Self],
-        lda: i32,
-        b: &mut [Self],
-        ldb: i32,
-    );
+    fn trsm(args: TrsmArgs<'_, Self>);
+}
+
+pub(crate) struct TrtrsArgs<'a, T> {
+    uplo: u8,
+    trans: u8,
+    diag: u8,
+    n: i32,
+    nrhs: i32,
+    a: &'a [T],
+    lda: i32,
+    b: &'a mut [T],
+    ldb: i32,
+    info: &'a mut i32,
+}
+
+pub(crate) struct TrsmArgs<'a, T> {
+    side: CBLAS_SIDE,
+    uplo: CBLAS_UPLO,
+    transa: CBLAS_TRANSPOSE,
+    diag: CBLAS_DIAG,
+    m: i32,
+    n: i32,
+    a: &'a [T],
+    lda: i32,
+    b: &'a mut [T],
+    ldb: i32,
 }
 
 impl LapackTriangularSolve for f64 {
-    fn trtrs(
-        uplo: u8,
-        trans: u8,
-        diag: u8,
-        n: i32,
-        nrhs: i32,
-        a: &[Self],
-        lda: i32,
-        b: &mut [Self],
-        ldb: i32,
-        info: &mut i32,
-    ) {
+    fn trtrs(args: TrtrsArgs<'_, Self>) {
+        let TrtrsArgs {
+            uplo,
+            trans,
+            diag,
+            n,
+            nrhs,
+            a,
+            lda,
+            b,
+            ldb,
+            info,
+        } = args;
         // SAFETY: callers validate the triangular matrix and RHS shapes,
         // provide column-major `a`/`b` buffers matching `lda`/`ldb`, and live `info`.
         unsafe {
@@ -60,18 +65,19 @@ impl LapackTriangularSolve for f64 {
         }
     }
 
-    fn trsm(
-        side: CBLAS_SIDE,
-        uplo: CBLAS_UPLO,
-        transa: CBLAS_TRANSPOSE,
-        diag: CBLAS_DIAG,
-        m: i32,
-        n: i32,
-        a: &[Self],
-        lda: i32,
-        b: &mut [Self],
-        ldb: i32,
-    ) {
+    fn trsm(args: TrsmArgs<'_, Self>) {
+        let TrsmArgs {
+            side,
+            uplo,
+            transa,
+            diag,
+            m,
+            n,
+            a,
+            lda,
+            b,
+            ldb,
+        } = args;
         // SAFETY: callers validate dimensions and provide compact column-major
         // `a` and writable `b` buffers with matching leading dimensions.
         unsafe {
@@ -94,18 +100,19 @@ impl LapackTriangularSolve for f64 {
 }
 
 impl LapackTriangularSolve for f32 {
-    fn trtrs(
-        uplo: u8,
-        trans: u8,
-        diag: u8,
-        n: i32,
-        nrhs: i32,
-        a: &[Self],
-        lda: i32,
-        b: &mut [Self],
-        ldb: i32,
-        info: &mut i32,
-    ) {
+    fn trtrs(args: TrtrsArgs<'_, Self>) {
+        let TrtrsArgs {
+            uplo,
+            trans,
+            diag,
+            n,
+            nrhs,
+            a,
+            lda,
+            b,
+            ldb,
+            info,
+        } = args;
         // SAFETY: callers validate the triangular matrix and RHS shapes,
         // provide column-major `a`/`b` buffers matching `lda`/`ldb`, and live `info`.
         unsafe {
@@ -113,18 +120,19 @@ impl LapackTriangularSolve for f32 {
         }
     }
 
-    fn trsm(
-        side: CBLAS_SIDE,
-        uplo: CBLAS_UPLO,
-        transa: CBLAS_TRANSPOSE,
-        diag: CBLAS_DIAG,
-        m: i32,
-        n: i32,
-        a: &[Self],
-        lda: i32,
-        b: &mut [Self],
-        ldb: i32,
-    ) {
+    fn trsm(args: TrsmArgs<'_, Self>) {
+        let TrsmArgs {
+            side,
+            uplo,
+            transa,
+            diag,
+            m,
+            n,
+            a,
+            lda,
+            b,
+            ldb,
+        } = args;
         // SAFETY: callers validate dimensions and provide compact column-major
         // `a` and writable `b` buffers with matching leading dimensions.
         unsafe {
@@ -147,18 +155,19 @@ impl LapackTriangularSolve for f32 {
 }
 
 impl LapackTriangularSolve for Complex32 {
-    fn trtrs(
-        uplo: u8,
-        trans: u8,
-        diag: u8,
-        n: i32,
-        nrhs: i32,
-        a: &[Self],
-        lda: i32,
-        b: &mut [Self],
-        ldb: i32,
-        info: &mut i32,
-    ) {
+    fn trtrs(args: TrtrsArgs<'_, Self>) {
+        let TrtrsArgs {
+            uplo,
+            trans,
+            diag,
+            n,
+            nrhs,
+            a,
+            lda,
+            b,
+            ldb,
+            info,
+        } = args;
         // SAFETY: callers validate the triangular matrix and RHS shapes,
         // provide column-major `a`/`b` buffers matching `lda`/`ldb`, and live `info`.
         unsafe {
@@ -166,18 +175,19 @@ impl LapackTriangularSolve for Complex32 {
         }
     }
 
-    fn trsm(
-        side: CBLAS_SIDE,
-        uplo: CBLAS_UPLO,
-        transa: CBLAS_TRANSPOSE,
-        diag: CBLAS_DIAG,
-        m: i32,
-        n: i32,
-        a: &[Self],
-        lda: i32,
-        b: &mut [Self],
-        ldb: i32,
-    ) {
+    fn trsm(args: TrsmArgs<'_, Self>) {
+        let TrsmArgs {
+            side,
+            uplo,
+            transa,
+            diag,
+            m,
+            n,
+            a,
+            lda,
+            b,
+            ldb,
+        } = args;
         let alpha = Complex32::new(1.0, 0.0);
         // SAFETY: callers validate dimensions and provide compact column-major
         // `a` and writable `b` buffers with matching leading dimensions.
@@ -201,18 +211,19 @@ impl LapackTriangularSolve for Complex32 {
 }
 
 impl LapackTriangularSolve for Complex64 {
-    fn trtrs(
-        uplo: u8,
-        trans: u8,
-        diag: u8,
-        n: i32,
-        nrhs: i32,
-        a: &[Self],
-        lda: i32,
-        b: &mut [Self],
-        ldb: i32,
-        info: &mut i32,
-    ) {
+    fn trtrs(args: TrtrsArgs<'_, Self>) {
+        let TrtrsArgs {
+            uplo,
+            trans,
+            diag,
+            n,
+            nrhs,
+            a,
+            lda,
+            b,
+            ldb,
+            info,
+        } = args;
         // SAFETY: callers validate the triangular matrix and RHS shapes,
         // provide column-major `a`/`b` buffers matching `lda`/`ldb`, and live `info`.
         unsafe {
@@ -220,18 +231,19 @@ impl LapackTriangularSolve for Complex64 {
         }
     }
 
-    fn trsm(
-        side: CBLAS_SIDE,
-        uplo: CBLAS_UPLO,
-        transa: CBLAS_TRANSPOSE,
-        diag: CBLAS_DIAG,
-        m: i32,
-        n: i32,
-        a: &[Self],
-        lda: i32,
-        b: &mut [Self],
-        ldb: i32,
-    ) {
+    fn trsm(args: TrsmArgs<'_, Self>) {
+        let TrsmArgs {
+            side,
+            uplo,
+            transa,
+            diag,
+            m,
+            n,
+            a,
+            lda,
+            b,
+            ldb,
+        } = args;
         let alpha = Complex64::new(1.0, 0.0);
         // SAFETY: callers validate dimensions and provide compact column-major
         // `a` and writable `b` buffers with matching leading dimensions.
@@ -290,9 +302,11 @@ fn validate_non_unit_diagonal<T: LapackTriangularSolve>(
     let data = a.host_data()?;
     for idx in 0..n {
         if data[idx + idx * n] == T::zero() {
-            return Err(tenferro_tensor::Error::backend_failure(
+            return Err(crate::error::into_tensor_error(
                 "triangular_solve",
-                "matrix is singular",
+                crate::Error::Singular {
+                    op: "triangular_solve",
+                },
             ));
         }
     }
@@ -309,27 +323,27 @@ fn solve_left<T: LapackTriangularSolve>(
     let n = square_matrix_dim(a, "triangular_solve")?;
     let (b_rows, b_cols) = matrix_dims(b, "triangular_solve")?;
     if b_rows != n {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
-            op: "triangular_solve",
-            lhs: vec![n],
-            rhs: vec![b_rows],
-        });
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "triangular_solve",
+            vec![n],
+            vec![b_rows],
+        ));
     }
 
     let mut rhs = b.host_data()?.to_vec();
     let mut info = 0;
-    T::trtrs(
-        if lower { b'L' } else { b'U' },
-        if transpose_a { b'T' } else { b'N' },
-        if unit_diagonal { b'U' } else { b'N' },
-        dim_i32(n, "triangular_solve")?,
-        dim_i32(b_cols, "triangular_solve")?,
-        a.host_data()?,
-        dim_i32(n, "triangular_solve")?,
-        &mut rhs,
-        dim_i32(n, "triangular_solve")?,
-        &mut info,
-    );
+    T::trtrs(TrtrsArgs {
+        uplo: if lower { b'L' } else { b'U' },
+        trans: if transpose_a { b'T' } else { b'N' },
+        diag: if unit_diagonal { b'U' } else { b'N' },
+        n: dim_i32(n, "triangular_solve")?,
+        nrhs: dim_i32(b_cols, "triangular_solve")?,
+        a: a.host_data()?,
+        lda: dim_i32(n, "triangular_solve")?,
+        b: &mut rhs,
+        ldb: dim_i32(n, "triangular_solve")?,
+        info: &mut info,
+    });
     check_lapack_info("triangular_solve", "trtrs", info)?;
     tensor_from_vec_with_template(vec![n, b_cols], rhs, b)
 }
@@ -344,27 +358,27 @@ fn solve_right<T: LapackTriangularSolve>(
     let n = square_matrix_dim(a, "triangular_solve")?;
     let (b_rows, b_cols) = matrix_dims(b, "triangular_solve")?;
     if b_cols != n {
-        return Err(tenferro_tensor::Error::ShapeMismatch {
-            op: "triangular_solve",
-            lhs: vec![n],
-            rhs: vec![b_cols],
-        });
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "triangular_solve",
+            vec![n],
+            vec![b_cols],
+        ));
     }
 
     validate_non_unit_diagonal(a, n, unit_diagonal)?;
     let mut rhs = b.host_data()?.to_vec();
-    T::trsm(
-        CBLAS_SIDE::CblasRight,
-        cblas_uplo(lower),
-        cblas_transpose(transpose_a),
-        cblas_diag(unit_diagonal),
-        dim_i32(b_rows, "triangular_solve")?,
-        dim_i32(n, "triangular_solve")?,
-        a.host_data()?,
-        dim_i32(n, "triangular_solve")?,
-        &mut rhs,
-        dim_i32(b_rows, "triangular_solve")?,
-    );
+    T::trsm(TrsmArgs {
+        side: CBLAS_SIDE::CblasRight,
+        uplo: cblas_uplo(lower),
+        transa: cblas_transpose(transpose_a),
+        diag: cblas_diag(unit_diagonal),
+        m: dim_i32(b_rows, "triangular_solve")?,
+        n: dim_i32(n, "triangular_solve")?,
+        a: a.host_data()?,
+        lda: dim_i32(n, "triangular_solve")?,
+        b: &mut rhs,
+        ldb: dim_i32(b_rows, "triangular_solve")?,
+    });
     tensor_from_vec_with_template(vec![b_rows, n], rhs, b)
 }
 
@@ -398,18 +412,18 @@ pub(crate) fn triangular_solve<T: LapackTriangularSolve>(
         let (b_rows, b_cols, b_batch_shape) = matrix_core_and_batch_result(b, "triangular_solve")?;
         let rhs_core_dim = if left_side { b_rows } else { b_cols };
         if rhs_core_dim != n {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "triangular_solve",
-                lhs: vec![n],
-                rhs: vec![rhs_core_dim],
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "triangular_solve",
+                vec![n],
+                vec![rhs_core_dim],
+            ));
         }
         if a_batch_shape != b_batch_shape {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
-                op: "triangular_solve",
-                lhs: a_batch_shape.to_vec(),
-                rhs: b_batch_shape.to_vec(),
-            });
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "triangular_solve",
+                a_batch_shape.to_vec(),
+                b_batch_shape.to_vec(),
+            ));
         }
         return tensor_from_vec_with_template(b.shape().to_vec(), Vec::new(), b);
     }

--- a/crates/tenferro-linalg/src/cpu/tests/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/backend.rs
@@ -56,9 +56,9 @@ fn test_triangular_solve_dtype_mismatch_and_unsupported() {
         .unwrap_err();
     assert!(matches!(
         err,
-        tenferro_tensor::Error::DTypeMismatch {
+        tenferro_tensor::Error::Validation {
             op: "triangular_solve",
-            ..
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
         }
     ));
 

--- a/crates/tenferro-linalg/src/cpu/tests/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/backend.rs
@@ -70,8 +70,10 @@ fn test_triangular_solve_dtype_mismatch_and_unsupported() {
         .unwrap_err();
     assert!(matches!(
         err,
-        tenferro_tensor::Error::BackendFailure {
+        tenferro_tensor::Error::Extension {
             op: "triangular_solve",
+            family: crate::LINALG_EXTENSION_FAMILY_ID,
+            kind: tenferro_tensor::ErrorKind::Unsupported,
             ..
         }
     ));

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -286,11 +286,19 @@ fn linalg_read_rejects_non_float_view_dtypes() {
         let err = result.unwrap_err();
         assert!(matches!(
             err,
-            tenferro_tensor::Error::BackendFailure {
+            tenferro_tensor::Error::Extension {
                 op,
-                ref message,
-            } if op == expected_op && message.contains("unsupported dtype")
+                family: crate::LINALG_EXTENSION_FAMILY_ID,
+                kind: tenferro_tensor::ErrorKind::Unsupported,
+                ..
+            } if op == expected_op
         ));
+        assert!(std::error::Error::source(&err)
+            .and_then(|source| source.downcast_ref::<crate::Error>())
+            .is_some_and(|source| matches!(
+                source,
+                crate::Error::UnsupportedDType { op, .. } if *op == expected_op
+            )));
     }
 
     let i32_input = TypedTensor::<i32>::from_vec_col_major(vec![2, 2], vec![1, 0, 0, 1]).unwrap();
@@ -339,11 +347,19 @@ fn linalg_read_rejects_non_float_view_dtypes() {
         let err = result.unwrap_err();
         assert!(matches!(
             err,
-            tenferro_tensor::Error::BackendFailure {
+            tenferro_tensor::Error::Extension {
                 op,
-                ref message,
-            } if op == expected_op && message.contains("unsupported dtype")
+                family: crate::LINALG_EXTENSION_FAMILY_ID,
+                kind: tenferro_tensor::ErrorKind::Unsupported,
+                ..
+            } if op == expected_op
         ));
+        assert!(std::error::Error::source(&err)
+            .and_then(|source| source.downcast_ref::<crate::Error>())
+            .is_some_and(|source| matches!(
+                source,
+                crate::Error::UnsupportedDType { op, .. } if *op == expected_op
+            )));
     }
 
     assert_unsupported_dtype_single(
@@ -1117,7 +1133,11 @@ fn test_real_cholesky_returns_error_for_non_positive_definite_input() {
     let err = backend.cholesky(&input).unwrap_err();
     assert!(matches!(
         err,
-        tenferro_tensor::Error::BackendFailure { op: "cholesky", .. }
+        tenferro_tensor::Error::Extension {
+            op: "cholesky",
+            kind: tenferro_tensor::ErrorKind::NumericalFailure,
+            ..
+        }
     ));
 }
 
@@ -1130,8 +1150,15 @@ fn test_real_solve_returns_error_for_singular_matrix() {
     let err = backend.solve(&a, &b).unwrap_err();
     assert!(matches!(
         err,
-        tenferro_tensor::Error::BackendFailure { op: "solve", .. }
+        tenferro_tensor::Error::Extension {
+            op: "solve",
+            kind: tenferro_tensor::ErrorKind::NumericalFailure,
+            ..
+        }
     ));
+    assert!(std::error::Error::source(&err)
+        .and_then(|source| source.downcast_ref::<crate::Error>())
+        .is_some_and(|source| matches!(source, crate::Error::Singular { op: "solve" })));
 }
 
 #[test]
@@ -1174,7 +1201,11 @@ fn test_complex_cholesky_returns_error_for_non_positive_definite_input() {
     let err = backend.cholesky(&input).unwrap_err();
     assert!(matches!(
         err,
-        tenferro_tensor::Error::BackendFailure { op: "cholesky", .. }
+        tenferro_tensor::Error::Extension {
+            op: "cholesky",
+            kind: tenferro_tensor::ErrorKind::NumericalFailure,
+            ..
+        }
     ));
 }
 
@@ -1363,7 +1394,11 @@ fn test_complex_solve_returns_error_for_singular_matrix() {
     let err = backend.solve(&a, &b).unwrap_err();
     assert!(matches!(
         err,
-        tenferro_tensor::Error::BackendFailure { op: "solve", .. }
+        tenferro_tensor::Error::Extension {
+            op: "solve",
+            kind: tenferro_tensor::ErrorKind::NumericalFailure,
+            ..
+        }
     ));
 }
 

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use tenferro_ad::error::{Error, Result};
 use tenferro_ad::extension::apply_eager;
 use tenferro_ad::EagerTensor;
+use tenferro_runtime::ErrorPhase;
 
 use crate::extension::{
     validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, QrOptions, SvdOptions,
@@ -11,14 +12,48 @@ use crate::register_runtime;
 
 /// Linear algebra extension methods for [`EagerTensor`].
 pub trait EagerTensorLinalgExt {
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for an invalid rank, shape, or dtype,
+    /// `Error::Extension` with an unsupported-operation or unsupported-dtype
+    /// source when the selected backend cannot execute the decomposition, and
+    /// `Error::RuntimeState` when the eager runtime or backend is unavailable.
     fn svd(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor)>;
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` when `derivative_eps` is non-finite or
+    /// non-positive, `Error::Extension` for unsupported dtypes or numerical
+    /// non-convergence, and `Error::Internal` if the extension violates its
+    /// output-count contract.
     fn svd_with_options(
         &self,
         options: SvdOptions,
     ) -> Result<(EagerTensor, EagerTensor, EagerTensor)>;
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for invalid matrix rank or shape,
+    /// `Error::Extension` for unsupported dtypes or numerical failure, and
+    /// `Error::RuntimeState` when the eager runtime or backend is unavailable.
     fn qr(&self) -> Result<(EagerTensor, EagerTensor)>;
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for invalid matrix rank or shape,
+    /// `Error::Extension` for unsupported dtypes or numerical failure, and
+    /// `Error::Internal` if the extension violates its output-count contract.
     fn qr_with_options(&self, options: QrOptions) -> Result<(EagerTensor, EagerTensor)>;
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for an invalid matrix rank or shape,
+    /// `Error::Extension` for an unsupported dtype or singular numerical
+    /// result, and `Error::RuntimeState` when execution cannot access its
+    /// backend.
     fn lu(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor, EagerTensor)>;
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for an invalid matrix rank or shape,
+    /// `Error::Extension` for unsupported dtypes or singular numerical
+    /// results, and `Error::Internal` if the extension violates its output
+    /// contract.
     fn full_piv_lu(
         &self,
     ) -> Result<(
@@ -28,12 +63,48 @@ pub trait EagerTensorLinalgExt {
         EagerTensor,
         EagerTensor,
     )>;
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` when `a` and `b` have incompatible matrix
+    /// or batch shapes, `Error::Extension` for an unsupported dtype or
+    /// singular system, and `Error::RuntimeState` when the backend is
+    /// unavailable.
     fn full_piv_lu_solve(&self, b: &EagerTensor) -> Result<EagerTensor>;
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for incompatible matrix, batch, or dtype
+    /// metadata, `Error::Extension` for an unsupported dtype or singular
+    /// system, and `Error::RuntimeState` when the backend is unavailable.
     fn solve(&self, b: &EagerTensor) -> Result<EagerTensor>;
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for a non-square or invalid-rank input,
+    /// `Error::Extension` for unsupported dtypes or a non-positive-definite
+    /// matrix, and `Error::RuntimeState` when the backend is unavailable.
     fn cholesky(&self) -> Result<EagerTensor>;
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for a non-square or invalid-rank input,
+    /// `Error::Extension` for unsupported dtypes or numerical non-convergence,
+    /// and `Error::RuntimeState` when the backend is unavailable.
     fn eigh(&self) -> Result<(EagerTensor, EagerTensor)>;
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for an invalid rank, shape, or
+    /// `derivative_eps`, `Error::Extension` for unsupported dtypes or
+    /// non-convergence, and `Error::Internal` for an output-count violation.
     fn eigh_with_options(&self, options: EighOptions) -> Result<(EagerTensor, EagerTensor)>;
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for a non-square or invalid-rank input,
+    /// `Error::Extension` for unsupported dtypes or numerical non-convergence,
+    /// and `Error::RuntimeState` when the backend is unavailable.
     fn eig(&self) -> Result<(EagerTensor, EagerTensor)>;
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for incompatible matrix, batch, or dtype
+    /// metadata, `Error::Extension` for unsupported dtypes or a singular
+    /// system, and `Error::RuntimeState` when the backend is unavailable.
     fn triangular_solve(
         &self,
         b: &EagerTensor,
@@ -121,7 +192,9 @@ fn apply_linalg_eager(op: LinalgOp, inputs: &[&EagerTensor]) -> Result<Vec<Eager
         first
             .runtime()
             .register_extension(register_runtime)
-            .map_err(|err| Error::Internal(err.to_string()))?;
+            .map_err(|source| {
+                Error::runtime_state_source("linalg", ErrorPhase::GraphBuild, source)
+            })?;
     }
     apply_eager(Arc::new(LinalgExtensionOp::new(op)), inputs)
 }
@@ -143,6 +216,13 @@ fn apply_linalg_eager(op: LinalgOp, inputs: &[&EagerTensor]) -> Result<Vec<Eager
 /// assert_eq!(s.shape(), &[2]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for an invalid rank, matrix shape, or dtype,
+/// `Error::Extension` with an unsupported-dtype or non-convergence source when
+/// the backend cannot compute the decomposition, and `Error::RuntimeState`
+/// when the eager runtime or backend is unavailable.
 pub fn svd(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor, EagerTensor)> {
     svd_with_options(a, SvdOptions::default())
 }
@@ -170,6 +250,13 @@ pub fn svd(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor, EagerTensor)> {
 /// assert_eq!(s.shape(), &[2]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` when `derivative_eps` is non-finite or
+/// non-positive, `Error::Extension` for unsupported dtypes or numerical
+/// non-convergence, and `Error::Internal` if the extension returns an
+/// unexpected number of outputs.
 pub fn svd_with_options(
     a: &EagerTensor,
     options: SvdOptions,
@@ -214,6 +301,12 @@ pub fn svd_with_options(
 /// assert_eq!(r.shape(), &[2, 2]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for an invalid rank or matrix shape,
+/// `Error::Extension` for an unsupported dtype or numerical failure, and
+/// `Error::RuntimeState` when the eager runtime or backend is unavailable.
 pub fn qr(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
     qr_with_options(a, QrOptions::default())
 }
@@ -238,6 +331,12 @@ pub fn qr(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
 /// assert_eq!(r.shape(), &[2, 2]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for an invalid rank or matrix shape,
+/// `Error::Extension` for an unsupported dtype or numerical failure, and
+/// `Error::Internal` if the extension returns an unexpected number of outputs.
 pub fn qr_with_options(a: &EagerTensor, options: QrOptions) -> Result<(EagerTensor, EagerTensor)> {
     two_outputs(
         apply_linalg_eager(
@@ -269,6 +368,12 @@ pub fn qr_with_options(a: &EagerTensor, options: QrOptions) -> Result<(EagerTens
 /// assert_eq!(parity.shape(), &[] as &[usize]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for an invalid rank or matrix shape,
+/// `Error::Extension` for an unsupported dtype or singular numerical result,
+/// and `Error::RuntimeState` when the eager runtime or backend is unavailable.
 pub fn lu(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor, EagerTensor, EagerTensor)> {
     let mut outputs = apply_linalg_eager(LinalgOp::Lu, &[a])?.into_iter();
     match (
@@ -309,6 +414,13 @@ pub fn lu(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor, EagerTensor, Eag
 /// assert_eq!(parity.shape(), &[] as &[usize]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for an invalid rank or matrix shape,
+/// `Error::Extension` for an unsupported dtype or singular numerical result,
+/// and `Error::Internal` if the extension returns an unexpected number of
+/// outputs.
 pub fn full_piv_lu(
     a: &EagerTensor,
 ) -> Result<(
@@ -355,6 +467,12 @@ pub fn full_piv_lu(
 /// assert_eq!(x.shape(), &[2, 1]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` when `a` and `b` have incompatible matrix or
+/// batch shapes, `Error::Extension` for an unsupported dtype or singular
+/// system, and `Error::RuntimeState` when the backend is unavailable.
 pub fn full_piv_lu_solve(a: &EagerTensor, b: &EagerTensor) -> Result<EagerTensor> {
     one_output(
         apply_linalg_eager(LinalgOp::FullPivLuSolve { transpose_a: false }, &[a, b])?,
@@ -383,6 +501,12 @@ pub fn full_piv_lu_solve(a: &EagerTensor, b: &EagerTensor) -> Result<EagerTensor
 /// assert_eq!(x.shape(), &[2, 1]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for incompatible matrix, batch, or dtype
+/// metadata, `Error::Extension` for an unsupported dtype or singular system,
+/// and `Error::RuntimeState` when the backend is unavailable.
 pub fn solve(a: &EagerTensor, b: &EagerTensor) -> Result<EagerTensor> {
     let mut factor_outputs = apply_linalg_eager(LinalgOp::LuFactor, &[a])?.into_iter();
     let (packed_lu, pivots) = match (
@@ -427,6 +551,12 @@ pub fn solve(a: &EagerTensor, b: &EagerTensor) -> Result<EagerTensor> {
 /// assert_eq!(l.shape(), &[2, 2]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a non-square or invalid-rank input,
+/// `Error::Extension` for an unsupported dtype or a non-positive-definite
+/// matrix, and `Error::RuntimeState` when the backend is unavailable.
 pub fn cholesky(a: &EagerTensor) -> Result<EagerTensor> {
     one_output(apply_linalg_eager(LinalgOp::Cholesky, &[a])?, "cholesky")
 }
@@ -449,6 +579,12 @@ pub fn cholesky(a: &EagerTensor) -> Result<EagerTensor> {
 /// assert_eq!(vectors.shape(), &[2, 2]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a non-square or invalid-rank input,
+/// `Error::Extension` for an unsupported dtype or numerical non-convergence,
+/// and `Error::RuntimeState` when the backend is unavailable.
 pub fn eigh(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
     eigh_with_options(a, EighOptions::default())
 }
@@ -479,6 +615,12 @@ pub fn eigh(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
 /// assert_eq!(vectors.shape(), &[2, 2]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for an invalid rank, shape, or
+/// `derivative_eps`, `Error::Extension` for unsupported dtypes or numerical
+/// non-convergence, and `Error::Internal` for an output-count violation.
 pub fn eigh_with_options(
     a: &EagerTensor,
     options: EighOptions,
@@ -514,6 +656,12 @@ pub fn eigh_with_options(
 /// assert_eq!(vectors.shape(), &[2, 2]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a non-square or invalid-rank input,
+/// `Error::Extension` for an unsupported dtype or numerical non-convergence,
+/// and `Error::RuntimeState` when the backend is unavailable.
 pub fn eig(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
     two_outputs(
         apply_linalg_eager(
@@ -547,6 +695,12 @@ pub fn eig(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
 /// assert_eq!(x.shape(), &[2, 1]);
 /// # Ok::<(), tenferro_ad::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for incompatible matrix, batch, or dtype
+/// metadata, `Error::Extension` for an unsupported dtype or singular system,
+/// and `Error::RuntimeState` when the backend is unavailable.
 pub fn triangular_solve(
     a: &EagerTensor,
     b: &EagerTensor,

--- a/crates/tenferro-linalg/src/error.rs
+++ b/crates/tenferro-linalg/src/error.rs
@@ -1,0 +1,202 @@
+//! Domain errors owned by the linear-algebra extension.
+//!
+//! Numerical failures and unsupported dtypes remain linalg-owned values until
+//! they cross into the tensor/runtime boundary. That boundary wraps the value
+//! as a typed extension source, so callers can classify the failure without
+//! losing the operation-specific payload.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use tenferro_linalg::Error;
+//! use tenferro_tensor::{ErrorKind, DType};
+//!
+//! let error = Error::UnsupportedDType {
+//!     op: "svd",
+//!     dtype: DType::I32,
+//! };
+//! assert_eq!(error.kind(), ErrorKind::Unsupported);
+//! ```
+
+use tenferro_tensor::{DType, ErrorKind};
+
+/// Typed diagnostics for provider status and workspace contracts.
+#[cfg(any(feature = "cpu-blas", feature = "cuda"))]
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum BackendError {
+    #[cfg(feature = "cuda")]
+    #[error("{library} call {call} returned status {status}")]
+    ProviderStatus {
+        library: &'static str,
+        call: &'static str,
+        status: i32,
+    },
+    #[cfg(feature = "cpu-blas")]
+    #[error("{library} routine {routine} returned an invalid workspace: {detail}")]
+    InvalidWorkspace {
+        library: &'static str,
+        routine: &'static str,
+        detail: String,
+    },
+}
+
+/// Failures owned by a linalg algorithm or provider boundary.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::Error;
+/// use tenferro_tensor::ErrorKind;
+///
+/// let error = Error::Singular { op: "solve" };
+/// assert_eq!(error.kind(), ErrorKind::NumericalFailure);
+/// ```
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// The algorithm could not converge for the supplied numeric input.
+    #[error("{op} did not converge")]
+    NonConvergence {
+        /// Linalg operation that failed to converge.
+        op: &'static str,
+    },
+    /// The input matrix or factorization became singular.
+    #[error("{op} is singular")]
+    Singular {
+        /// Linalg operation that encountered a singular matrix.
+        op: &'static str,
+    },
+    /// The selected linalg operation has no implementation for this dtype.
+    #[error("{op} does not support dtype {dtype:?}")]
+    UnsupportedDType {
+        /// Linalg operation that rejected the dtype.
+        op: &'static str,
+        /// Rejected input dtype.
+        dtype: DType,
+    },
+}
+
+impl Error {
+    /// Return the stable coarse classification for this linalg failure.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_linalg::Error;
+    /// use tenferro_tensor::ErrorKind;
+    ///
+    /// assert_eq!(
+    ///     Error::NonConvergence { op: "svd" }.kind(),
+    ///     ErrorKind::NumericalFailure
+    /// );
+    /// ```
+    #[must_use]
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            Self::NonConvergence { .. } | Self::Singular { .. } => ErrorKind::NumericalFailure,
+            Self::UnsupportedDType { .. } => ErrorKind::Unsupported,
+        }
+    }
+}
+
+/// Result type for linalg-owned domain operations.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::{Error, Result};
+///
+/// let result: Result<()> = Err(Error::Singular { op: "solve" });
+/// assert!(result.is_err());
+/// ```
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Wrap a linalg-owned source at the tensor extension boundary.
+pub(crate) fn into_tensor_error(op: &'static str, source: Error) -> tenferro_tensor::Error {
+    tenferro_tensor::Error::extension(
+        op,
+        crate::extension::LINALG_EXTENSION_FAMILY_ID,
+        source.kind(),
+        source,
+    )
+}
+
+/// Construct a typed unsupported-dtype tensor error for linalg backends.
+pub(crate) fn unsupported_dtype(op: &'static str, dtype: DType) -> tenferro_tensor::Error {
+    into_tensor_error(op, Error::UnsupportedDType { op, dtype })
+}
+
+/// Preserve a provider status as a typed backend source.
+#[cfg(feature = "cuda")]
+pub(crate) fn backend_status(
+    op: &'static str,
+    library: &'static str,
+    call: &'static str,
+    status: i32,
+) -> tenferro_tensor::Error {
+    tenferro_tensor::Error::backend_source(
+        op,
+        BackendError::ProviderStatus {
+            library,
+            call,
+            status,
+        },
+    )
+}
+
+/// Preserve an invalid provider workspace response as a typed backend source.
+#[cfg(feature = "cpu-blas")]
+pub(crate) fn invalid_workspace(
+    op: &'static str,
+    library: &'static str,
+    routine: &'static str,
+    detail: impl Into<String>,
+) -> tenferro_tensor::Error {
+    tenferro_tensor::Error::backend_source(
+        op,
+        BackendError::InvalidWorkspace {
+            library,
+            routine,
+            detail: detail.into(),
+        },
+    )
+}
+
+#[cfg(all(test, any(feature = "cpu-blas", feature = "cuda")))]
+mod tests {
+    use std::error::Error as _;
+
+    use super::*;
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn provider_status_keeps_typed_backend_source() {
+        let error = backend_status("svd", "cuSOLVER", "cusolverDnSgesvd", 7);
+
+        assert_eq!(error.kind(), ErrorKind::BackendFailure);
+        assert!(matches!(
+            error.source().and_then(|source| source.downcast_ref()),
+            Some(BackendError::ProviderStatus {
+                library: "cuSOLVER",
+                call: "cusolverDnSgesvd",
+                status: 7,
+            })
+        ));
+    }
+
+    #[cfg(feature = "cpu-blas")]
+    #[test]
+    fn invalid_workspace_keeps_typed_backend_source() {
+        let error = invalid_workspace("eigh", "LAPACK", "dsyevd", "query was zero");
+
+        assert_eq!(error.kind(), ErrorKind::BackendFailure);
+        assert!(matches!(
+            error.source().and_then(|source| source.downcast_ref()),
+            Some(BackendError::InvalidWorkspace {
+                library: "LAPACK",
+                routine: "dsyevd",
+                detail,
+            }) if detail == "query was zero"
+        ));
+    }
+}

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -389,16 +389,16 @@ fn input_eager_device(input: &Tensor) -> tenferro_tensor::Result<EagerLinalgDevi
     match (&placement.memory_kind, placement.device.as_ref()) {
         (MemoryKind::Device, Some(device)) => match &device.kind {
             DeviceKind::Gpu(GpuBackendKind::Cuda) => Ok(EagerLinalgDevice::Cuda(device.ordinal)),
-            DeviceKind::Gpu(kind) => Err(Error::backend_failure(
+            DeviceKind::Gpu(kind) => Err(Error::unsupported(
                 "linalg_host_reference",
                 format!("unsupported GPU backend {kind:?} for eager linalg"),
             )),
-            kind => Err(Error::backend_failure(
+            kind => Err(Error::runtime_state(
                 "linalg_host_reference",
                 format!("unsupported device kind {kind:?} for eager linalg"),
             )),
         },
-        (MemoryKind::Device, None) => Err(Error::backend_failure(
+        (MemoryKind::Device, None) => Err(Error::runtime_state(
             "linalg_host_reference",
             "device tensor is missing placement device metadata",
         )),
@@ -415,8 +415,9 @@ fn eager_linalg_device(inputs: &[&Tensor]) -> tenferro_tensor::Result<EagerLinal
             (Some(EagerLinalgDevice::Cpu), EagerLinalgDevice::Cpu) => {}
             (Some(EagerLinalgDevice::Cuda(lhs)), EagerLinalgDevice::Cuda(rhs)) if lhs == rhs => {}
             (Some(lhs), rhs) => {
-                return Err(Error::backend_failure(
+                return Err(Error::invalid_argument(
                     "linalg_host_reference",
+                    "inputs",
                     format!("all eager linalg inputs must be on the same device, got {lhs:?} and {rhs:?}"),
                 ));
             }
@@ -441,7 +442,7 @@ fn execute_cuda_eager_linalg(
     _inputs: &[&Tensor],
     device_ordinal: usize,
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
-    Err(Error::backend_failure(
+    Err(Error::unsupported(
         "linalg_host_reference",
         format!(
             "received CUDA tensor on cuda:{device_ordinal}, but tenferro-linalg was built \

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -259,10 +259,11 @@ pub(crate) fn validate_derivative_eps(
     if derivative_eps.is_finite() && derivative_eps > 0.0 {
         Ok(())
     } else {
-        Err(Error::InvalidConfig {
+        Err(Error::invalid_argument(
             op,
-            message: format!("derivative_eps must be positive and finite, got {derivative_eps}"),
-        })
+            "derivative_eps",
+            format!("must be positive and finite, got {derivative_eps}"),
+        ))
     }
 }
 
@@ -604,14 +605,15 @@ impl HostReference for LinalgExtensionOp {
     fn execute(&self, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
         let expected = self.input_count();
         if inputs.len() != expected {
-            return Err(Error::InvalidConfig {
-                op: "linalg_host_reference",
-                message: format!(
+            return Err(Error::invalid_argument(
+                "linalg_host_reference",
+                "inputs",
+                format!(
                     "expected {expected} inputs for {:?}, got {}",
                     self.op,
                     inputs.len()
                 ),
-            });
+            ));
         }
 
         match eager_linalg_device(inputs)? {
@@ -741,13 +743,14 @@ pub(crate) fn apply_svd_gauge(
 
 fn apply_canonical_pivot_svd_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::Result<()> {
     if outputs.len() != 3 {
-        return Err(Error::InvalidConfig {
-            op: "tenferro-linalg.svd",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "tenferro-linalg.svd",
+            "outputs",
+            format!(
                 "canonical SVD gauge expected three outputs, got {}",
                 outputs.len()
             ),
-        });
+        ));
     }
 
     let (u_slice, rest) = outputs.split_at_mut(1);
@@ -759,12 +762,13 @@ fn apply_canonical_pivot_svd_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::R
     let s_shape = singular_values.shape().to_vec();
     let vt_shape = vt.shape().to_vec();
     if u_shape.len() < 2 || vt_shape.len() < 2 || s_shape.is_empty() {
-        return Err(Error::InvalidConfig {
-            op: "tenferro-linalg.svd",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "tenferro-linalg.svd",
+            "outputs",
+            format!(
                 "canonical SVD gauge expected U rank >= 2, S rank >= 1, VT rank >= 2; got U={u_shape:?}, S={s_shape:?}, VT={vt_shape:?}"
             ),
-        });
+        ));
     }
 
     let m = u_shape[0];
@@ -775,12 +779,13 @@ fn apply_canonical_pivot_svd_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::R
         || u_shape[2..] != vt_shape[2..]
         || s_shape[1..] != u_shape[2..]
     {
-        return Err(Error::InvalidConfig {
-            op: "tenferro-linalg.svd",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "tenferro-linalg.svd",
+            "outputs",
+            format!(
                 "canonical SVD gauge expected compatible compact SVD shapes, got U={u_shape:?}, S={s_shape:?}, VT={vt_shape:?}"
             ),
-        });
+        ));
     }
     let layout = canonical_svd_gauge_layout(m, k, n, &u_shape[2..])?;
 
@@ -797,11 +802,11 @@ fn apply_canonical_pivot_svd_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::R
         (Tensor::C32(u), Tensor::C32(vt)) => {
             canonicalize_svd_gauge_c32(u.host_data_mut()?, vt.host_data_mut()?, layout)
         }
-        (u, vt) => Err(Error::DTypeMismatch {
-            op: "tenferro-linalg.svd",
-            lhs: u.dtype(),
-            rhs: vt.dtype(),
-        }),
+        (u, vt) => Err(Error::dtype_mismatch(
+            "tenferro-linalg.svd",
+            u.dtype(),
+            vt.dtype(),
+        )),
     }
 }
 
@@ -819,22 +824,24 @@ struct CanonicalSvdGaugeLayout {
 impl CanonicalSvdGaugeLayout {
     fn validate_storage(self, u_len: usize, vt_len: usize) -> tenferro_tensor::Result<()> {
         if u_len != self.u_len {
-            return Err(Error::InvalidConfig {
-                op: "tenferro-linalg.svd",
-                message: format!(
+            return Err(Error::invalid_argument(
+                "tenferro-linalg.svd",
+                "U storage",
+                format!(
                     "canonical SVD gauge expected U storage length {}, got {u_len}",
                     self.u_len
                 ),
-            });
+            ));
         }
         if vt_len != self.vt_len {
-            return Err(Error::InvalidConfig {
-                op: "tenferro-linalg.svd",
-                message: format!(
+            return Err(Error::invalid_argument(
+                "tenferro-linalg.svd",
+                "VT storage",
+                format!(
                     "canonical SVD gauge expected VT storage length {}, got {vt_len}",
                     self.vt_len
                 ),
-            });
+            ));
         }
         Ok(())
     }
@@ -1060,11 +1067,7 @@ fn max_abs_pivot_c32(u_column: &[Complex32]) -> usize {
 
 fn require_matrix_meta(op: &'static str, shape: &[SymDim]) -> tenferro_tensor::Result<()> {
     if shape.len() < 2 {
-        return Err(Error::RankMismatch {
-            op,
-            expected: 2,
-            actual: shape.len(),
-        });
+        return Err(Error::rank_mismatch(op, 2, shape.len()));
     }
     Ok(())
 }

--- a/crates/tenferro-linalg/src/extension/gauge.rs
+++ b/crates/tenferro-linalg/src/extension/gauge.rs
@@ -25,13 +25,14 @@ pub(crate) fn apply_qr_gauge(
 
 fn apply_canonical_pivot_eigh_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::Result<()> {
     if outputs.len() != 2 {
-        return Err(Error::InvalidConfig {
-            op: "tenferro-linalg.eigh",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "tenferro-linalg.eigh",
+            "outputs",
+            format!(
                 "canonical eigh gauge expected two outputs, got {}",
                 outputs.len()
             ),
-        });
+        ));
     }
 
     let (values_slice, vectors_slice) = outputs.split_at_mut(1);
@@ -39,22 +40,24 @@ fn apply_canonical_pivot_eigh_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::
     let vectors = &mut vectors_slice[0];
     let vectors_shape = vectors.shape().to_vec();
     if values_shape.is_empty() || vectors_shape.len() < 2 {
-        return Err(Error::InvalidConfig {
-            op: "tenferro-linalg.eigh",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "tenferro-linalg.eigh",
+            "outputs",
+            format!(
                 "canonical eigh gauge expected values rank >= 1 and vectors rank >= 2; got values={values_shape:?}, vectors={vectors_shape:?}"
             ),
-        });
+        ));
     }
 
     let n = vectors_shape[0];
     if vectors_shape[1] != n || values_shape[0] != n || values_shape[1..] != vectors_shape[2..] {
-        return Err(Error::InvalidConfig {
-            op: "tenferro-linalg.eigh",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "tenferro-linalg.eigh",
+            "outputs",
+            format!(
                 "canonical eigh gauge expected compatible eigendecomposition shapes, got values={values_shape:?}, vectors={vectors_shape:?}"
             ),
-        });
+        ));
     }
     let batch_count = checked_batch_count("tenferro-linalg.eigh", &vectors_shape[2..])?;
 
@@ -92,13 +95,14 @@ fn apply_canonical_pivot_eigh_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::
 
 fn apply_positive_diagonal_qr_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::Result<()> {
     if outputs.len() != 2 {
-        return Err(Error::InvalidConfig {
-            op: "tenferro-linalg.qr",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "tenferro-linalg.qr",
+            "outputs",
+            format!(
                 "positive-diagonal QR gauge expected two outputs, got {}",
                 outputs.len()
             ),
-        });
+        ));
     }
 
     let (q_slice, r_slice) = outputs.split_at_mut(1);
@@ -107,24 +111,26 @@ fn apply_positive_diagonal_qr_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::
     let q_shape = q.shape().to_vec();
     let r_shape = r.shape().to_vec();
     if q_shape.len() < 2 || r_shape.len() < 2 {
-        return Err(Error::InvalidConfig {
-            op: "tenferro-linalg.qr",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "tenferro-linalg.qr",
+            "outputs",
+            format!(
                 "positive-diagonal QR gauge expected Q and R rank >= 2; got Q={q_shape:?}, R={r_shape:?}"
             ),
-        });
+        ));
     }
 
     let m = q_shape[0];
     let k = q_shape[1];
     let n = r_shape[1];
     if r_shape[0] != k || q_shape[2..] != r_shape[2..] {
-        return Err(Error::InvalidConfig {
-            op: "tenferro-linalg.qr",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "tenferro-linalg.qr",
+            "outputs",
+            format!(
                 "positive-diagonal QR gauge expected compatible QR shapes, got Q={q_shape:?}, R={r_shape:?}"
             ),
-        });
+        ));
     }
     let batch_count = checked_batch_count("tenferro-linalg.qr", &q_shape[2..])?;
 
@@ -165,11 +171,11 @@ fn apply_positive_diagonal_qr_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::
             batch_count,
             "tenferro-linalg.qr",
         ),
-        (q, r) => Err(Error::DTypeMismatch {
-            op: "tenferro-linalg.qr",
-            lhs: q.dtype(),
-            rhs: r.dtype(),
-        }),
+        (q, r) => Err(Error::dtype_mismatch(
+            "tenferro-linalg.qr",
+            q.dtype(),
+            r.dtype(),
+        )),
     }
 }
 
@@ -474,8 +480,5 @@ fn checked_batch_offset(
 }
 
 fn invalid_config(op: &'static str, message: &'static str) -> Error {
-    Error::InvalidConfig {
-        op,
-        message: message.to_string(),
-    }
+    Error::invalid_argument(op, "configuration", message)
 }

--- a/crates/tenferro-linalg/src/extension/gauge.rs
+++ b/crates/tenferro-linalg/src/extension/gauge.rs
@@ -86,7 +86,7 @@ fn apply_canonical_pivot_eigh_gauge(outputs: &mut [Tensor]) -> tenferro_tensor::
             batch_count,
             "tenferro-linalg.eigh",
         ),
-        vectors => Err(Error::backend_failure(
+        vectors => Err(Error::unsupported(
             "tenferro-linalg.eigh",
             format!("unsupported eigenvector dtype {:?}", vectors.dtype()),
         )),

--- a/crates/tenferro-linalg/src/extension/tests.rs
+++ b/crates/tenferro-linalg/src/extension/tests.rs
@@ -38,12 +38,12 @@ fn eager_linalg_rejects_cuda_tensor_when_cuda_feature_is_disabled() {
         .unwrap_err();
 
     match err {
-        Error::BackendFailure { op, message } => {
+        Error::Unsupported { op, message } => {
             assert_eq!(op, "linalg_host_reference");
             assert!(message.contains("cuda feature"));
             assert!(message.contains("download"));
         }
-        other => panic!("expected BackendFailure, got {other:?}"),
+        other => panic!("expected Unsupported, got {other:?}"),
     }
 }
 
@@ -701,7 +701,7 @@ fn gauge_validation_errors_cover_malformed_outputs() {
     ];
     assert!(matches!(
         apply_eigh_gauge(EighGauge::CanonicalPivot, &mut bad_eigh_dtype),
-        Err(Error::BackendFailure { .. })
+        Err(Error::Unsupported { .. })
     ));
 
     assert_invalid_config(apply_qr_gauge(QrGauge::PositiveDiagonal, &mut []));

--- a/crates/tenferro-linalg/src/extension/tests.rs
+++ b/crates/tenferro-linalg/src/extension/tests.rs
@@ -55,10 +55,10 @@ fn infer_output_meta_returns_error_on_input_count_mismatch() {
 
     assert!(matches!(
         err,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "extension",
-            ref message,
-        } if message.contains(LINALG_EXTENSION_FAMILY_ID)
+            source,
+        } if source.to_string().contains(LINALG_EXTENSION_FAMILY_ID)
     ));
 }
 
@@ -209,7 +209,7 @@ fn canonical_svd_gauge_rejects_batch_product_overflow() {
 
     assert!(matches!(
         error,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "tenferro-linalg.svd",
             ..
         }
@@ -224,7 +224,7 @@ fn canonical_svd_gauge_rejects_u_batch_span_overflow() {
 
     assert!(matches!(
         error,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "tenferro-linalg.svd",
             ..
         }
@@ -239,7 +239,7 @@ fn canonical_svd_gauge_rejects_vt_batch_span_overflow() {
 
     assert!(matches!(
         error,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "tenferro-linalg.svd",
             ..
         }
@@ -254,7 +254,7 @@ fn canonical_svd_gauge_rejects_u_storage_span_overflow() {
 
     assert!(matches!(
         error,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "tenferro-linalg.svd",
             ..
         }
@@ -269,7 +269,7 @@ fn canonical_svd_gauge_rejects_vt_storage_span_overflow() {
 
     assert!(matches!(
         error,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "tenferro-linalg.svd",
             ..
         }
@@ -286,7 +286,7 @@ fn canonical_svd_gauge_rejects_short_u_storage() {
 
     assert!(matches!(
         error,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "tenferro-linalg.svd",
             ..
         }
@@ -724,7 +724,10 @@ fn gauge_validation_errors_cover_malformed_outputs() {
     ];
     assert!(matches!(
         apply_qr_gauge(QrGauge::PositiveDiagonal, &mut bad_qr_dtype),
-        Err(Error::DTypeMismatch { .. })
+        Err(Error::Validation {
+            source: tenferro_tensor::ValidationError::DTypeMismatch { .. },
+            ..
+        })
     ));
 }
 
@@ -811,5 +814,5 @@ fn assert_slice_close_c64(actual: &[Complex64], expected: &[Complex64], tol: f64
 }
 
 fn assert_invalid_config(result: tenferro_tensor::Result<()>) {
-    assert!(matches!(result, Err(Error::InvalidConfig { .. })));
+    assert!(matches!(result, Err(Error::Validation { .. })));
 }

--- a/crates/tenferro-linalg/src/gpu/ffi/cusolver.rs
+++ b/crates/tenferro-linalg/src/gpu/ffi/cusolver.rs
@@ -23,6 +23,25 @@ const CUBLAS_DEFAULT_PATHS: &[&str] = &[
     "/usr/lib/x86_64-linux-gnu/libcublas.so",
 ];
 
+#[derive(Debug, thiserror::Error)]
+enum CudaLibraryLoadError {
+    #[error("failed to load {library} symbol {name}: {source}")]
+    Symbol {
+        library: &'static str,
+        name: String,
+        #[source]
+        source: libloading::Error,
+    },
+    #[error("failed to load {library} library (tried {paths}): {source}; attempts: {attempts}")]
+    Library {
+        library: &'static str,
+        paths: String,
+        attempts: String,
+        #[source]
+        source: libloading::Error,
+    },
+}
+
 pub type CusolverDnHandleRaw = *mut c_void;
 pub type CublasHandleRaw = *mut c_void;
 pub type CudaStream = *mut c_void;
@@ -966,12 +985,15 @@ unsafe fn load_symbol<T: Copy>(
     // SAFETY: `name` is a NUL-terminated CUDA library symbol and `T` is the
     // exact FFI function-pointer type declared in this module's vtables.
     let symbol = lib.get::<T>(name).map_err(|err| {
-        Error::backend_failure(
+        Error::io_source(
             "cubecl_linalg",
-            format!(
-                "failed to load {library_name} symbol {}: {err}",
-                String::from_utf8_lossy(name).trim_end_matches('\0')
-            ),
+            CudaLibraryLoadError::Symbol {
+                library: library_name,
+                name: String::from_utf8_lossy(name)
+                    .trim_end_matches('\0')
+                    .to_owned(),
+                source: err,
+            },
         )
     })?;
     Ok(*symbol)
@@ -997,11 +1019,13 @@ impl CusolverLibrary {
     fn load() -> Result<Arc<Self>> {
         let paths = library_search_paths("TENFERRO_CUSOLVER_PATH", CUSOLVER_DEFAULT_PATHS);
         let mut errors = Vec::new();
+        let mut last_source = None;
         for path in &paths {
             let lib = match unsafe { Library::new(path) } {
                 Ok(lib) => lib,
                 Err(err) => {
                     errors.push(format!("{path}: {err}"));
+                    last_source = Some(err);
                     continue;
                 }
             };
@@ -1025,14 +1049,24 @@ impl CusolverLibrary {
             }));
         }
 
-        Err(Error::backend_failure(
-            "cubecl_linalg",
-            format!(
-                "failed to load cuSOLVER library (tried {}): {}",
-                paths.join(", "),
-                errors.join("; ")
-            ),
-        ))
+        match last_source {
+            Some(source) => Err(Error::io_source(
+                "cubecl_linalg",
+                CudaLibraryLoadError::Library {
+                    library: "cuSOLVER",
+                    paths: paths.join(", "),
+                    attempts: errors.join("; "),
+                    source,
+                },
+            )),
+            None => Err(Error::io_source(
+                "cubecl_linalg",
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "no cuSOLVER library search paths configured",
+                ),
+            )),
+        }
     }
 
     fn check_status(
@@ -1044,13 +1078,7 @@ impl CusolverLibrary {
         if status == CUSOLVER_STATUS_SUCCESS {
             return Ok(());
         }
-        Err(Error::backend_failure(
-            op,
-            format!(
-                "{call} failed with cuSOLVER {} ({status})",
-                cusolver_status_name(status)
-            ),
-        ))
+        Err(crate::error::backend_status(op, "cuSOLVER", call, status))
     }
 }
 
@@ -1070,11 +1098,13 @@ impl CublasLibrary {
     fn load() -> Result<Arc<Self>> {
         let paths = library_search_paths("TENFERRO_CUBLAS_PATH", CUBLAS_DEFAULT_PATHS);
         let mut errors = Vec::new();
+        let mut last_source = None;
         for path in &paths {
             let lib = match unsafe { Library::new(path) } {
                 Ok(lib) => lib,
                 Err(err) => {
                     errors.push(format!("{path}: {err}"));
+                    last_source = Some(err);
                     continue;
                 }
             };
@@ -1082,14 +1112,24 @@ impl CublasLibrary {
             return Ok(Arc::new(Self { _lib: lib, vtable }));
         }
 
-        Err(Error::backend_failure(
-            "triangular_solve",
-            format!(
-                "failed to load cuBLAS library (tried {}): {}",
-                paths.join(", "),
-                errors.join("; ")
-            ),
-        ))
+        match last_source {
+            Some(source) => Err(Error::io_source(
+                "triangular_solve",
+                CudaLibraryLoadError::Library {
+                    library: "cuBLAS",
+                    paths: paths.join(", "),
+                    attempts: errors.join("; "),
+                    source,
+                },
+            )),
+            None => Err(Error::io_source(
+                "triangular_solve",
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "no cuBLAS library search paths configured",
+                ),
+            )),
+        }
     }
 
     fn check_status(
@@ -1101,13 +1141,7 @@ impl CublasLibrary {
         if status == CUBLAS_STATUS_SUCCESS {
             return Ok(());
         }
-        Err(Error::backend_failure(
-            op,
-            format!(
-                "{call} failed with cuBLAS {} ({status})",
-                cublas_status_name(status)
-            ),
-        ))
+        Err(crate::error::backend_status(op, "cuBLAS", call, status))
     }
 }
 
@@ -1216,6 +1250,13 @@ impl Drop for GesvdjInfo<'_> {
 }
 
 impl CusolverDnHandle {
+    /// Load cuSOLVER and create a native handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::IoSource` with the typed `CudaLibraryLoadError` when
+    /// the shared library or a required symbol cannot be loaded, and
+    /// `Error::BackendFailure` when `cusolverDnCreate` rejects handle creation.
     pub fn load() -> Result<Self> {
         let lib = CusolverLibrary::load()?;
         let mut raw = std::ptr::null_mut();
@@ -1224,11 +1265,23 @@ impl CusolverDnHandle {
         Ok(Self { lib, raw })
     }
 
+    /// Attach the native handle to a CUDA stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the stream or
+    /// reports a non-success status.
     pub fn set_stream(&self, stream: CudaStream, op: &'static str) -> Result<()> {
         let status = unsafe { (self.lib.vtable.set_stream)(self.raw, stream) };
         self.lib.check_status(status, op, "cusolverDnSetStream")
     }
 
+    /// Create the cuSOLVER parameters used by Jacobi SVD.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER cannot allocate the
+    /// parameter object or reports another non-success status.
     pub fn create_gesvdj_info(&self, op: &'static str) -> Result<GesvdjInfo<'_>> {
         let mut raw = std::ptr::null_mut();
         let status = unsafe { (self.lib.vtable.create_gesvdj_info)(&mut raw) };
@@ -1237,6 +1290,13 @@ impl CusolverDnHandle {
         Ok(GesvdjInfo { handle: self, raw })
     }
 
+    /// Query the workspace required by Cholesky factorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the dimensions,
+    /// leading dimension, pointer, dtype, or reports another non-success
+    /// status.
     pub fn potrf_buffer_size(
         &self,
         dtype: CudaDataType,
@@ -1288,6 +1348,17 @@ impl CusolverDnHandle {
         Ok(lwork)
     }
 
+    /// Execute Cholesky factorization through cuSOLVER.
+    ///
+    /// # Safety
+    ///
+    /// The caller must provide valid device pointers for `a`, `workspace`, and
+    /// `info`, with dimensions and workspace size accepted by cuSOLVER.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the arguments or
+    /// reports a factorization/backend status such as a non-positive pivot.
     pub unsafe fn potrf(
         &self,
         dtype: CudaDataType,
@@ -1345,6 +1416,13 @@ impl CusolverDnHandle {
         self.lib.check_status(status, op, "cusolverDn*potrf")
     }
 
+    /// Query the workspace required by LU factorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the dimensions,
+    /// leading dimension, pointer, dtype, or reports another non-success
+    /// status.
     pub fn getrf_buffer_size(
         &self,
         dtype: CudaDataType,
@@ -1376,6 +1454,18 @@ impl CusolverDnHandle {
         Ok(lwork)
     }
 
+    /// Execute LU factorization through cuSOLVER.
+    ///
+    /// # Safety
+    ///
+    /// The caller must provide valid device pointers for `a`, `workspace`,
+    /// `pivots`, and `info`, with dimensions and workspace size accepted by
+    /// cuSOLVER.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the arguments or
+    /// reports a non-success factorization status.
     pub unsafe fn getrf(
         &self,
         dtype: CudaDataType,
@@ -1433,6 +1523,13 @@ impl CusolverDnHandle {
         self.lib.check_status(status, op, "cusolverDn*getrf")
     }
 
+    /// Query the workspace required by QR factorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the dimensions,
+    /// leading dimension, pointer, dtype, or reports another non-success
+    /// status.
     pub fn geqrf_buffer_size(
         &self,
         dtype: CudaDataType,
@@ -1464,6 +1561,18 @@ impl CusolverDnHandle {
         Ok(lwork)
     }
 
+    /// Execute QR factorization through cuSOLVER.
+    ///
+    /// # Safety
+    ///
+    /// The caller must provide valid device pointers for `a`, `tau`,
+    /// `workspace`, and `info`, with dimensions and workspace size accepted by
+    /// cuSOLVER.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the arguments or
+    /// reports a non-success factorization status.
     pub unsafe fn geqrf(
         &self,
         dtype: CudaDataType,
@@ -1526,6 +1635,13 @@ impl CusolverDnHandle {
         self.lib.check_status(status, op, "cusolverDn*geqrf")
     }
 
+    /// Query the workspace required to form the explicit Q factor.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the dimensions,
+    /// leading dimension, pointer, dtype, or reports another non-success
+    /// status.
     pub fn orgqr_buffer_size(
         &self,
         dtype: CudaDataType,
@@ -1587,6 +1703,18 @@ impl CusolverDnHandle {
         Ok(lwork)
     }
 
+    /// Form the explicit Q factor from a QR factorization.
+    ///
+    /// # Safety
+    ///
+    /// The caller must provide valid device pointers for `a`, `tau`,
+    /// `workspace`, and `info`, with dimensions and workspace size accepted by
+    /// cuSOLVER.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the arguments or
+    /// reports a non-success factorization status.
     pub unsafe fn orgqr(
         &self,
         dtype: CudaDataType,
@@ -1654,6 +1782,12 @@ impl CusolverDnHandle {
         self.lib.check_status(status, op, "cusolverDn*orgqr")
     }
 
+    /// Query the workspace required by the standard SVD routine.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the dimensions,
+    /// dtype, or reports another non-success status.
     pub fn gesvd_buffer_size(
         &self,
         dtype: CudaDataType,
@@ -1683,6 +1817,13 @@ impl CusolverDnHandle {
         Ok(lwork)
     }
 
+    /// Query the workspace required by the Jacobi SVD routine.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the dimensions,
+    /// leading dimensions, device pointers, Jacobi parameters, dtype, or
+    /// reports another non-success status.
     pub fn gesvdj_buffer_size(
         &self,
         dtype: CudaDataType,
@@ -1774,6 +1915,18 @@ impl CusolverDnHandle {
         Ok(lwork)
     }
 
+    /// Execute the standard SVD routine through cuSOLVER.
+    ///
+    /// # Safety
+    ///
+    /// The caller must provide valid device pointers for all matrix,
+    /// singular-value, workspace, and `info` arguments, with dimensions and
+    /// workspace size accepted by cuSOLVER.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the arguments or
+    /// reports a non-success SVD status.
     pub unsafe fn gesvd(
         &self,
         dtype: CudaDataType,
@@ -1871,6 +2024,19 @@ impl CusolverDnHandle {
         self.lib.check_status(status, op, "cusolverDn*gesvd")
     }
 
+    /// Execute the Jacobi SVD routine through cuSOLVER.
+    ///
+    /// # Safety
+    ///
+    /// The caller must provide valid device pointers for all matrix,
+    /// singular-value, workspace, and `info` arguments, and keep `params`
+    /// alive for the call. Dimensions and workspace size must be accepted by
+    /// cuSOLVER.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the arguments,
+    /// Jacobi parameters, or reports a non-success SVD status.
     pub unsafe fn gesvdj(
         &self,
         dtype: CudaDataType,
@@ -1968,6 +2134,13 @@ impl CusolverDnHandle {
         self.lib.check_status(status, op, "cusolverDn*gesvdj")
     }
 
+    /// Query the workspace required by a symmetric/Hermitian eigensolver.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the dimensions,
+    /// leading dimension, device pointers, dtype, or reports another
+    /// non-success status.
     pub fn syevd_buffer_size(
         &self,
         dtype: CudaDataType,
@@ -2029,6 +2202,18 @@ impl CusolverDnHandle {
         Ok(lwork)
     }
 
+    /// Execute a symmetric/Hermitian eigendecomposition through cuSOLVER.
+    ///
+    /// # Safety
+    ///
+    /// The caller must provide valid device pointers for the input matrix,
+    /// eigenvalues, workspace, and `info`, with dimensions and workspace size
+    /// accepted by cuSOLVER.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuSOLVER rejects the arguments or
+    /// reports a non-success eigensolver status, including non-convergence.
     pub unsafe fn syevd(
         &self,
         dtype: CudaDataType,
@@ -2122,6 +2307,13 @@ impl fmt::Debug for CublasHandle {
 unsafe impl Send for CublasHandle {}
 
 impl CublasHandle {
+    /// Load cuBLAS and create a native handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::IoSource` with the typed `CudaLibraryLoadError` when
+    /// the shared library or required symbol cannot be loaded, and
+    /// `Error::BackendFailure` when `cublasCreate_v2` rejects handle creation.
     pub fn load() -> Result<Self> {
         let lib = CublasLibrary::load()?;
         let mut raw = std::ptr::null_mut();
@@ -2130,11 +2322,28 @@ impl CublasHandle {
         Ok(Self { lib, raw })
     }
 
+    /// Attach the native cuBLAS handle to a CUDA stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuBLAS rejects the stream or
+    /// reports a non-success status.
     pub fn set_stream(&self, stream: CudaStream, op: &'static str) -> Result<()> {
         let status = unsafe { (self.lib.vtable.set_stream)(self.raw, stream) };
         self.lib.check_status(status, op, "cublasSetStream_v2")
     }
 
+    /// Execute a triangular solve through cuBLAS.
+    ///
+    /// # Safety
+    ///
+    /// The caller must provide valid device pointers for `alpha`, `a`, and
+    /// `b`, with dimensions and leading dimensions accepted by cuBLAS.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuBLAS rejects the flags, dtype,
+    /// pointers, dimensions, or reports a singular/backend status.
     pub unsafe fn trsm(
         &self,
         dtype: CudaDataType,
@@ -2212,6 +2421,19 @@ impl CublasHandle {
         self.lib.check_status(status, op, "cublas*trsm_v2")
     }
 
+    /// Execute a batched triangular solve through cuBLAS.
+    ///
+    /// # Safety
+    ///
+    /// The caller must provide valid device arrays for `alpha`, `a_array`,
+    /// and `b_array`, with `batch_count`, dimensions, and leading dimensions
+    /// accepted by cuBLAS.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::BackendFailure` when cuBLAS rejects the flags, dtype,
+    /// pointers, batch count, dimensions, or reports a singular/backend
+    /// status.
     pub unsafe fn trsm_batched(
         &self,
         dtype: CudaDataType,
@@ -2317,6 +2539,12 @@ impl fmt::Debug for CudaLinalgHandles {
 }
 
 impl CudaLinalgHandles {
+    /// Load the cuSOLVER and cuBLAS handles used by CUDA linalg operations.
+    ///
+    /// # Errors
+    ///
+    /// Returns the typed `Error::IoSource` from either dynamic-library load,
+    /// or `Error::BackendFailure` from native handle creation.
     pub fn load() -> Result<Self> {
         Ok(Self {
             cusolver: CusolverDnHandle::load()?,

--- a/crates/tenferro-linalg/src/gpu/linalg.rs
+++ b/crates/tenferro-linalg/src/gpu/linalg.rs
@@ -26,6 +26,7 @@ use tenferro_gpu::{download_tensor, CudaBackend, CudaRuntime};
 use tenferro_tensor::config::SliceConfig;
 use tenferro_tensor::{
     DType, Error, Tensor, TensorElementwise, TensorReduction, TensorStructural, TypedTensor,
+    ValidationError,
 };
 
 type Result<T> = tenferro_tensor::Result<T>;
@@ -127,16 +128,12 @@ fn select_svd_driver(m: usize, n: usize) -> SvdDriver {
 }
 
 fn unsupported_linalg_dtype(op: &'static str, input: &Tensor) -> Error {
-    Error::backend_failure(op, format!("unsupported dtype {:?}", input.dtype()))
+    crate::error::unsupported_dtype(op, input.dtype())
 }
 
 fn ensure_supported_linalg_pair(op: &'static str, lhs: &Tensor, rhs: &Tensor) -> Result<()> {
     if lhs.dtype() != rhs.dtype() {
-        return Err(Error::DTypeMismatch {
-            op,
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        });
+        return Err(Error::dtype_mismatch(op, lhs.dtype(), rhs.dtype()));
     }
     match lhs {
         Tensor::F32(_) | Tensor::F64(_) | Tensor::C32(_) | Tensor::C64(_) => Ok(()),
@@ -223,14 +220,14 @@ pub(super) fn triangular_solve(
             triangular_solve_typed(backend, a, b, left_side, lower, transpose_a, unit_diagonal)
                 .map(Tensor::C64)
         }
-        _ if a.dtype() != b.dtype() => Err(Error::DTypeMismatch {
-            op: "triangular_solve",
-            lhs: a.dtype(),
-            rhs: b.dtype(),
-        }),
-        _ => Err(Error::backend_failure(
+        _ if a.dtype() != b.dtype() => Err(Error::dtype_mismatch(
             "triangular_solve",
-            format!("unsupported dtype {:?}", a.dtype()),
+            a.dtype(),
+            b.dtype(),
+        )),
+        _ => Err(crate::error::unsupported_dtype(
+            "triangular_solve",
+            a.dtype(),
         )),
     }
 }
@@ -312,7 +309,7 @@ pub(super) fn lu_factor(backend: &mut CudaBackend, input: &Tensor) -> Result<Vec
 }
 
 pub(super) fn full_piv_lu(_backend: &mut CudaBackend, _input: &Tensor) -> Result<Vec<Tensor>> {
-    Err(Error::backend_failure(
+    Err(Error::unsupported(
         "full_piv_lu",
         "complete-pivoting LU is not implemented for the CubeCL backend",
     ))
@@ -324,7 +321,7 @@ pub(super) fn full_piv_lu_solve(
     _b: &Tensor,
     _transpose_a: bool,
 ) -> Result<Tensor> {
-    Err(Error::backend_failure(
+    Err(Error::unsupported(
         "full_piv_lu_solve",
         "complete-pivoting LU solve is not implemented for the CubeCL backend",
     ))
@@ -395,7 +392,7 @@ pub(super) fn eigh_values(backend: &mut CudaBackend, input: &Tensor) -> Result<T
 }
 
 pub(super) fn eig(_backend: &mut CudaBackend, _input: &Tensor) -> Result<Vec<Tensor>> {
-    Err(Error::backend_failure(
+    Err(Error::unsupported(
         "eig",
         "non-symmetric eigendecomposition is not supported on the CubeCL GPU backend \
                   because cuSOLVER does not provide it. Download to CPU explicitly via \
@@ -426,9 +423,8 @@ pub(super) fn solve(backend: &mut CudaBackend, a: &Tensor, b: &Tensor) -> Result
 
     let factors = lu_factor(backend, a)?;
     let [packed_lu, pivots, _parity] = factors.as_slice() else {
-        return Err(Error::backend_failure(
-            OP,
-            "lu_factor returned an unexpected number of outputs",
+        return Err(Error::Internal(
+            "solve: lu_factor returned an unexpected number of outputs".into(),
         ));
     };
     let x = lu_solve_prepared(backend, a, packed_lu, pivots, &rhs, false, false)?;
@@ -458,11 +454,7 @@ pub(super) fn lu_solve_prepared(
     ensure_supported_linalg_pair(OP, a, b)?;
     ensure_supported_linalg_pair(OP, a, packed_lu)?;
     if !matches!(pivots, Tensor::I32(_)) {
-        return Err(Error::DTypeMismatch {
-            op: OP,
-            lhs: DType::I32,
-            rhs: pivots.dtype(),
-        });
+        return Err(Error::dtype_mismatch(OP, DType::I32, pivots.dtype()));
     }
     if has_zero_dim(a.shape()) || has_zero_dim(b.shape()) {
         return zero_like_linalg_device_tensor(backend.runtime(), b, OP);
@@ -495,9 +487,8 @@ pub(super) fn lu_solve_prepared(
             lu_solve_prepared_typed(backend, lu, pivots, rhs, transpose_a, conjugate_a)
                 .map(Tensor::C64)
         }
-        _ => Err(Error::backend_failure(
-            OP,
-            "packed LU, pivots, and rhs dtypes are inconsistent",
+        _ => Err(Error::Internal(
+            "lu_solve_prepared: packed LU, pivots, and rhs dtypes are inconsistent".into(),
         )),
     }?;
 
@@ -831,8 +822,9 @@ where
     let host_info = download_device_tensor(backend.runtime(), &info, OP)?;
     for &info_value in host_info.host_data()? {
         if info_value < 0 {
-            return Err(Error::backend_failure(
+            return Err(Error::invalid_argument(
                 OP,
+                "cusolver_argument",
                 format!(
                     "cusolverDn*getrf reported invalid parameter {}",
                     -info_value
@@ -905,7 +897,7 @@ where
             )?;
             apply_lu_pivots_typed(backend.runtime(), &y, pivots, true)
         }
-        (false, true) => Err(Error::backend_failure(
+        (false, true) => Err(Error::unsupported(
             OP,
             "conjugate-only prepared LU solve is unsupported on CUDA; use transpose+conjugate or solve the conjugated matrix explicitly",
         )),
@@ -1885,9 +1877,8 @@ fn sync_stream(rt: &CudaRuntime, op: &'static str) -> Result<()> {
     let stream = raw_stream(rt, op)? as cudaStream_t;
     // SAFETY: `raw_stream` returns the live CUDA stream owned by this runtime's
     // current context; synchronizing it does not outlive the runtime.
-    unsafe { cuda_result::stream::synchronize(stream) }.map_err(|err| {
-        Error::backend_failure(op, format!("CUDA stream synchronize failed: {err:?}"))
-    })
+    unsafe { cuda_result::stream::synchronize(stream) }
+        .map_err(|err| Error::backend_source(op, err))
 }
 
 fn alloc_workspace_bytes(rt: &CudaRuntime, nbytes: usize, op: &'static str) -> Result<Workspace> {
@@ -1898,9 +1889,17 @@ fn alloc_workspace_elems<T>(rt: &CudaRuntime, len: i32, op: &'static str) -> Res
 where
     T: CubeElement + Clone,
 {
-    let len = usize::try_from(len)
-        .map_err(|_| Error::backend_failure(op, format!("workspace length was negative: {len}")))?;
-    alloc_workspace_bytes(rt, len * std::mem::size_of::<T>(), op)
+    let len = usize::try_from(len).map_err(|_| {
+        Error::invalid_argument(
+            op,
+            "workspace_length",
+            format!("must be non-negative, got {len}"),
+        )
+    })?;
+    let nbytes = len
+        .checked_mul(std::mem::size_of::<T>())
+        .ok_or_else(|| Error::invalid_argument(op, "workspace_length", "byte size overflowed"))?;
+    alloc_workspace_bytes(rt, nbytes, op)
 }
 
 fn typed_device_ptr<T: 'static>(
@@ -1973,7 +1972,7 @@ fn copy_device_to_device(
     // SAFETY: callers pass device pointers obtained from live tensors or
     // workspaces, `nbytes` is checked before zero-size return, and the stream is current.
     unsafe { cuda_result::memcpy_dtod_async(dst, src, nbytes, stream) }
-        .map_err(|err| Error::backend_failure(op, format!("cudaMemcpyAsync DtoD failed: {err:?}")))
+        .map_err(|err| Error::backend_source(op, err))
 }
 
 fn matrix_slice_config(shape: &[usize], row_limit: usize, col_limit: usize) -> SliceConfig {
@@ -1989,11 +1988,7 @@ fn matrix_slice_config(shape: &[usize], row_limit: usize, col_limit: usize) -> S
 
 fn matrix_dims(op: &'static str, shape: &[usize]) -> Result<(usize, usize)> {
     if shape.len() < 2 {
-        return Err(Error::RankMismatch {
-            op,
-            expected: 2,
-            actual: shape.len(),
-        });
+        return Err(Error::rank_mismatch(op, 2, shape.len()));
     }
     Ok((shape[0], shape[1]))
 }
@@ -2001,10 +1996,7 @@ fn matrix_dims(op: &'static str, shape: &[usize]) -> Result<(usize, usize)> {
 fn square_matrix_dim(op: &'static str, shape: &[usize]) -> Result<usize> {
     let (rows, cols) = matrix_dims(op, shape)?;
     if rows != cols {
-        return Err(Error::InvalidConfig {
-            op,
-            message: format!("expected square matrix, got shape {shape:?}"),
-        });
+        return Err(Error::shape_mismatch(op, [rows], [cols]));
     }
     Ok(rows)
 }
@@ -2018,23 +2010,17 @@ fn validate_triangular_rhs(
     let n = square_matrix_dim(op, a_shape)?;
     let (b_rows, b_cols) = matrix_dims(op, b_shape)?;
     if a_shape[2..] != b_shape[2..] {
-        return Err(Error::ShapeMismatch {
+        return Err(Error::shape_mismatch(
             op,
-            lhs: a_shape.to_vec(),
-            rhs: b_shape.to_vec(),
-        });
+            a_shape.to_vec(),
+            b_shape.to_vec(),
+        ));
     }
     if left_side && b_rows != n {
-        return Err(Error::InvalidConfig {
-            op,
-            message: format!("rhs row count mismatch: expected {n}, got {b_rows}"),
-        });
+        return Err(Error::shape_mismatch(op, [n], [b_rows]));
     }
     if !left_side && b_cols != n {
-        return Err(Error::InvalidConfig {
-            op,
-            message: format!("rhs column count mismatch: expected {n}, got {b_cols}"),
-        });
+        return Err(Error::shape_mismatch(op, [n], [b_cols]));
     }
     Ok(())
 }
@@ -2047,26 +2033,23 @@ fn validate_lu_solve_prepared_shapes(
     let n = square_matrix_dim("lu_solve_prepared", lu_shape)?;
     let (b_rows, _) = matrix_dims("lu_solve_prepared", b_shape)?;
     if b_rows != n {
-        return Err(Error::InvalidConfig {
-            op: "lu_solve_prepared",
-            message: format!("rhs row count mismatch: expected {n}, got {b_rows}"),
-        });
+        return Err(Error::shape_mismatch("lu_solve_prepared", [n], [b_rows]));
     }
     if lu_shape[2..] != b_shape[2..] {
-        return Err(Error::ShapeMismatch {
-            op: "lu_solve_prepared",
-            lhs: lu_shape.to_vec(),
-            rhs: b_shape.to_vec(),
-        });
+        return Err(Error::shape_mismatch(
+            "lu_solve_prepared",
+            lu_shape.to_vec(),
+            b_shape.to_vec(),
+        ));
     }
     let mut expected_pivots = vec![n];
     expected_pivots.extend_from_slice(&lu_shape[2..]);
     if pivots_shape != expected_pivots {
-        return Err(Error::ShapeMismatch {
-            op: "lu_solve_prepared",
-            lhs: expected_pivots,
-            rhs: pivots_shape.to_vec(),
-        });
+        return Err(Error::shape_mismatch(
+            "lu_solve_prepared",
+            expected_pivots,
+            pivots_shape.to_vec(),
+        ));
     }
     Ok(())
 }
@@ -2076,14 +2059,15 @@ fn check_solver_info(op: &'static str, call: &'static str, info: i32) -> Result<
         return Ok(());
     }
     if info < 0 {
-        return Err(Error::backend_failure(
+        return Err(Error::invalid_argument(
             op,
+            "cusolver_parameter",
             format!("{call} reported invalid parameter {}", -info),
         ));
     }
-    Err(Error::backend_failure(
+    Err(crate::error::into_tensor_error(
         op,
-        format!("{call} failed with info={info}"),
+        crate::Error::NonConvergence { op },
     ))
 }
 
@@ -2106,9 +2090,9 @@ fn has_zero_dim(shape: &[usize]) -> bool {
 
 fn checked_shape_product(op: &'static str, label: &'static str, shape: &[usize]) -> Result<usize> {
     shape.iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim).ok_or_else(|| Error::InvalidConfig {
-            op,
-            message: format!("{label} element count overflows usize"),
+        acc.checked_mul(dim).ok_or_else(|| {
+            let _ = label;
+            Error::validation(op, ValidationError::IntegerOverflow)
         })
     })
 }
@@ -2124,9 +2108,9 @@ fn checked_mul_usize(
     lhs: usize,
     rhs: usize,
 ) -> Result<usize> {
-    lhs.checked_mul(rhs).ok_or_else(|| Error::InvalidConfig {
-        op,
-        message: format!("{label} overflows usize: {lhs} * {rhs}"),
+    lhs.checked_mul(rhs).ok_or_else(|| {
+        let _ = label;
+        Error::validation(op, ValidationError::IntegerOverflow)
     })
 }
 
@@ -2141,7 +2125,7 @@ fn checked_batch_offset(
 
 fn as_i32(value: usize, op: &'static str, label: &'static str) -> Result<i32> {
     i32::try_from(value)
-        .map_err(|_| Error::backend_failure(op, format!("{label} does not fit in i32: {value}")))
+        .map_err(|_| Error::invalid_argument(op, label, format!("{value} does not fit in i32")))
 }
 
 /// Offset a mutable device pointer by `offset` typed elements.
@@ -2226,9 +2210,9 @@ fn validate_nonsingular_gpu(backend: &mut CudaBackend, u: &Tensor) -> Result<()>
     let is_singular = !value.is_finite() || !max_magnitude.is_finite() || value <= tolerance;
 
     if is_singular {
-        Err(Error::backend_failure(
+        Err(crate::error::into_tensor_error(
             "solve",
-            "singular matrix: near-zero or non-finite diagonal entry in U",
+            crate::Error::Singular { op: "solve" },
         ))
     } else {
         Ok(())
@@ -2305,9 +2289,8 @@ fn host_min_max_magnitudes(host_min: &Tensor, host_max: &Tensor) -> Result<(f64,
             f64::from(min.host_data()?[0]),
             f64::from(max.host_data()?[0]),
         )),
-        _ => Err(Error::backend_failure(
-            "solve",
-            "unexpected dtype after magnitude reduction",
+        _ => Err(Error::Internal(
+            "solve: unexpected dtype after magnitude reduction".into(),
         )),
     }
 }

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -34,6 +34,7 @@ mod cpu;
 mod eager_backend;
 #[cfg(feature = "autodiff")]
 mod eager_ext;
+pub mod error;
 mod extension;
 #[cfg(feature = "cuda")]
 mod gpu;
@@ -49,6 +50,7 @@ pub use ad::support::{
 pub use backend::LinalgBackend;
 #[cfg(feature = "autodiff")]
 pub use eager_ext::EagerTensorLinalgExt;
+pub use error::{Error, Result};
 pub use extension::{
     register_runtime, EighGauge, EighOptions, QrGauge, QrOptions, SvdGauge, SvdOptions,
     DEFAULT_DECOMPOSITION_DERIVATIVE_EPS, LINALG_EXTENSION_FAMILY_ID,

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -12,17 +12,126 @@ use crate::extension::{
 
 /// Linear algebra extension methods for [`TracedTensor`].
 pub trait TracedTensorLinalgExt {
+    /// Build a traced SVD operation with default options.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Extension` with `ErrorKind::Unsupported` for an
+    /// unsupported dtype, or `Error::Validation` for invalid graph metadata.
+    ///
+    /// # Deferred errors
+    ///
+    /// Backend numerical failures and concrete shape mismatches can be
+    /// reported as `Error::Extension` or `Error::Validation` during compile or
+    /// execution when symbolic inputs are bound.
     fn svd(&self) -> Result<(TracedTensor, TracedTensor, TracedTensor)>;
+
+    /// Build a traced SVD operation with explicit derivative and gauge options.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation::InvalidArgument` for a non-finite or
+    /// non-positive derivative epsilon, or `Error::Extension` for unsupported
+    /// dtype and graph registration failures.
+    ///
+    /// # Deferred errors
+    ///
+    /// Solver convergence and symbolic shape checks may be reported during
+    /// compile or execution.
     fn svd_with_options(
         &self,
         options: SvdOptions,
     ) -> Result<(TracedTensor, TracedTensor, TracedTensor)>;
+    /// Build a traced QR operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Extension` with `ErrorKind::Unsupported` for an
+    /// unsupported dtype or `Error::Validation` for invalid graph metadata.
+    ///
+    /// # Deferred errors
+    ///
+    /// Concrete shape validation and backend QR failures may be reported at
+    /// compile or execution time for symbolic inputs.
     fn qr(&self) -> Result<(TracedTensor, TracedTensor)>;
+
+    /// Build a traced QR operation with explicit gauge options.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Extension` with `ErrorKind::Unsupported` for an
+    /// unsupported dtype, or `Error::Validation` for invalid graph metadata.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic shape checks and backend QR failures can be deferred to compile
+    /// or execution.
     fn qr_with_options(&self, options: QrOptions) -> Result<(TracedTensor, TracedTensor)>;
+
+    /// Build a traced Hermitian eigendecomposition operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Extension` with `ErrorKind::Unsupported` for an
+    /// unsupported dtype or `Error::Validation` for invalid graph metadata.
+    ///
+    /// # Deferred errors
+    ///
+    /// Concrete square-shape validation and solver failures may be reported at
+    /// compile or execution time.
     fn eigh(&self) -> Result<(TracedTensor, TracedTensor)>;
+
+    /// Build a traced Hermitian eigendecomposition with explicit options.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation::InvalidArgument` for an invalid derivative
+    /// epsilon, or `Error::Extension` for unsupported dtype and registration
+    /// failures.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic square-shape checks and numerical eigensolver failures may be
+    /// reported during compile or execution.
     fn eigh_with_options(&self, options: EighOptions) -> Result<(TracedTensor, TracedTensor)>;
+
+    /// Build a traced Cholesky factorization operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Extension` with `ErrorKind::Unsupported` for an
+    /// unsupported dtype or `Error::Validation` for invalid graph metadata.
+    ///
+    /// # Deferred errors
+    ///
+    /// Non-square or non-positive-definite concrete inputs can produce
+    /// validation or numerical extension errors during compile or execution.
     fn cholesky(&self) -> Result<TracedTensor>;
+
+    /// Build a traced LU factorization operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Extension` with `ErrorKind::Unsupported` for an
+    /// unsupported dtype or `Error::Validation` for invalid graph metadata.
+    ///
+    /// # Deferred errors
+    ///
+    /// Concrete shape checks and backend factorization failures may be
+    /// reported during compile or execution.
     fn lu(&self) -> Result<(TracedTensor, TracedTensor, TracedTensor, TracedTensor)>;
+
+    /// Build a traced complete-pivot LU factorization operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Extension` with `ErrorKind::Unsupported` for an
+    /// unsupported dtype or `Error::Validation` for invalid graph metadata.
+    ///
+    /// # Deferred errors
+    ///
+    /// Concrete square-shape checks and backend factorization failures may be
+    /// reported during compile or execution.
     fn full_piv_lu(
         &self,
     ) -> Result<(
@@ -32,9 +141,56 @@ pub trait TracedTensorLinalgExt {
         TracedTensor,
         TracedTensor,
     )>;
+    /// Build a traced general eigendecomposition operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Extension` with `ErrorKind::Unsupported` for an
+    /// unsupported dtype or `Error::Validation` for invalid graph metadata.
+    ///
+    /// # Deferred errors
+    ///
+    /// Concrete shape validation and numerical eigensolver failures may be
+    /// reported during compile or execution.
     fn eig(&self) -> Result<(TracedTensor, TracedTensor)>;
+
+    /// Build a traced linear solve operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for incompatible coefficient/rhs metadata
+    /// and `Error::Extension` for unsupported dtype or registration failures.
+    ///
+    /// # Deferred errors
+    ///
+    /// Singular systems and concrete shape mismatches are reported as
+    /// numerical or validation errors during compile or execution.
     fn solve(&self, b: &TracedTensor) -> Result<TracedTensor>;
+
+    /// Build a traced complete-pivot LU solve operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for incompatible coefficient/rhs metadata
+    /// and `Error::Extension` for unsupported dtype or registration failures.
+    ///
+    /// # Deferred errors
+    ///
+    /// Singular systems and concrete shape mismatches may be reported during
+    /// compile or execution.
     fn full_piv_lu_solve(&self, b: &TracedTensor) -> Result<TracedTensor>;
+
+    /// Build a traced triangular solve operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for incompatible coefficient/rhs shapes or
+    /// invalid solve flags, and `Error::Extension` for unsupported dtype.
+    ///
+    /// # Deferred errors
+    ///
+    /// Singular or zero-diagonal systems can fail numerically during compile or
+    /// execution after symbolic inputs are bound.
     fn triangular_solve(
         &self,
         b: &TracedTensor,
@@ -43,13 +199,107 @@ pub trait TracedTensorLinalgExt {
         transpose_a: bool,
         unit_diagonal: bool,
     ) -> Result<TracedTensor>;
+    /// Build a traced sign/log-determinant operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for invalid matrix metadata or
+    /// `Error::Extension` for unsupported dtype and registration failures.
+    ///
+    /// # Deferred errors
+    ///
+    /// Concrete singularity and shape failures can be reported during compile
+    /// or execution.
     fn slogdet(&self) -> Result<(TracedTensor, TracedTensor)>;
+
+    /// Build a traced determinant operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for invalid matrix metadata or
+    /// `Error::Extension` for unsupported dtype.
+    ///
+    /// # Deferred errors
+    ///
+    /// Concrete singularity and shape failures may be reported during compile
+    /// or execution.
     fn det(&self) -> Result<TracedTensor>;
+
+    /// Build a traced matrix-inverse operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for incompatible rank/shape metadata or
+    /// `Error::Extension` for unsupported dtype.
+    ///
+    /// # Deferred errors
+    ///
+    /// Singular matrices produce a numerical error during compile or execution.
     fn inv(&self) -> Result<TracedTensor>;
+
+    /// Build a traced Hermitian eigenvalue-only operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for non-square metadata or
+    /// `Error::Extension` for unsupported dtype.
+    ///
+    /// # Deferred errors
+    ///
+    /// Concrete square-shape and solver failures may be reported during compile
+    /// or execution.
     fn eigvalsh(&self) -> Result<TracedTensor>;
+
+    /// Build a traced general eigenvalue-only operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for invalid matrix metadata or
+    /// `Error::Extension` for unsupported dtype.
+    ///
+    /// # Deferred errors
+    ///
+    /// Concrete shape and eigensolver failures may be reported during compile
+    /// or execution.
     fn eigvals(&self) -> Result<TracedTensor>;
+
+    /// Build a traced pseudoinverse operation with the default tolerance.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for invalid rank/shape metadata or
+    /// `Error::Extension` for unsupported dtype.
+    ///
+    /// # Deferred errors
+    ///
+    /// SVD convergence and concrete shape failures may be reported during
+    /// compile or execution.
     fn pinv(&self) -> Result<TracedTensor>;
+
+    /// Build a traced pseudoinverse with an explicit relative tolerance.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation::InvalidArgument` when `rtol` is non-finite
+    /// or negative, or `Error::Extension` for unsupported dtype.
+    ///
+    /// # Deferred errors
+    ///
+    /// SVD convergence and concrete shape failures may be reported during
+    /// compile or execution.
     fn pinv_with_rtol(&self, rtol: f64) -> Result<TracedTensor>;
+
+    /// Build a traced vector/matrix norm operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for an invalid norm order or axis and
+    /// `Error::Extension` for unsupported dtype.
+    ///
+    /// # Deferred errors
+    ///
+    /// Symbolic axis and shape checks may be reported during compile or
+    /// execution.
     fn norm(&self, ord: Option<f64>, dim: Option<&[usize]>, keepdim: bool) -> Result<TracedTensor>;
 }
 
@@ -171,6 +421,19 @@ impl TracedTensorLinalgExt for TracedTensor {
 /// assert_eq!(s.rank, 1);
 /// assert_eq!(vt.rank, 2);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a known invalid rank, matrix shape, or
+/// dtype, `Error::Extension` with an unsupported-dtype or non-convergence
+/// source when the registered linalg backend cannot construct the operation,
+/// and `Error::RuntimeState` when extension registration is unavailable.
+///
+/// # Deferred errors
+///
+/// A symbolic matrix or batch-shape mismatch is reported later as
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation` during compile or
+/// execution.
 pub fn svd(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor, TracedTensor)> {
     svd_with_options(a, SvdOptions::default())
 }
@@ -193,6 +456,18 @@ pub fn svd(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor, TracedTensor
 /// let (_u, s, _vt) = a.svd_with_options(options).unwrap();
 /// assert_eq!(s.rank, 1);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` when `derivative_eps` is non-finite or
+/// non-positive, `Error::Extension` for an unsupported dtype or numerical
+/// non-convergence, and `Error::Internal` if the extension output contract is
+/// violated.
+///
+/// # Deferred errors
+///
+/// Symbolic rank or shape constraints are checked later and can produce
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn svd_with_options(
     a: &TracedTensor,
     options: SvdOptions,
@@ -223,6 +498,17 @@ pub fn svd_with_options(
 /// assert_eq!(q.rank, 2);
 /// assert_eq!(r.rank, 2);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a known invalid rank or matrix shape,
+/// `Error::Extension` for an unsupported dtype or numerical failure, and
+/// `Error::RuntimeState` when the linalg extension is not registered.
+///
+/// # Deferred errors
+///
+/// Unknown matrix or batch dimensions can fail later as
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn qr(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
     qr_with_options(a, QrOptions::default())
 }
@@ -242,6 +528,17 @@ pub fn qr(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
 /// assert_eq!(q.rank, 2);
 /// assert_eq!(r.rank, 2);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a known invalid rank or matrix shape,
+/// `Error::Extension` for an unsupported dtype or numerical failure, and
+/// `Error::Internal` if the extension output contract is violated.
+///
+/// # Deferred errors
+///
+/// Symbolic matrix or batch constraints are checked later and can produce
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn qr_with_options(
     a: &TracedTensor,
     options: QrOptions,
@@ -270,6 +567,18 @@ pub fn qr_with_options(
 /// assert_eq!(values.rank, 1);
 /// assert_eq!(vectors.rank, 2);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a known non-square or invalid-rank input,
+/// `Error::Extension` for an unsupported dtype or eigensolver
+/// non-convergence, and `Error::RuntimeState` when the extension is not
+/// registered.
+///
+/// # Deferred errors
+///
+/// Symbolic square-shape constraints can fail later as
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn eigh(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
     eigh_with_options(a, EighOptions::default())
 }
@@ -295,6 +604,18 @@ pub fn eigh(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
 ///     .unwrap();
 /// assert_eq!(values.rank, 1);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a known non-square or invalid-rank input,
+/// or for non-finite/non-positive `derivative_eps`; `Error::Extension` for an
+/// unsupported dtype or eigensolver non-convergence; and `Error::Internal` for
+/// an output-count contract violation.
+///
+/// # Deferred errors
+///
+/// Symbolic square-shape constraints can fail later as
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn eigh_with_options(
     a: &TracedTensor,
     options: EighOptions,
@@ -324,6 +645,17 @@ pub fn eigh_with_options(
 /// let factor = a.cholesky().unwrap();
 /// assert_eq!(factor.rank, 2);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a known non-square or invalid-rank input,
+/// `Error::Extension` for an unsupported dtype or a non-positive-definite
+/// matrix, and `Error::RuntimeState` when the extension is not registered.
+///
+/// # Deferred errors
+///
+/// Symbolic square-shape constraints can fail later as
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn cholesky(a: &TracedTensor) -> Result<TracedTensor> {
     one_output(
         apply(Arc::new(LinalgExtensionOp::new(LinalgOp::Cholesky)), &[a])?,
@@ -346,6 +678,17 @@ pub fn cholesky(a: &TracedTensor) -> Result<TracedTensor> {
 /// assert_eq!(u.rank, 2);
 /// assert_eq!(parity.rank, 0);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a known invalid rank or matrix shape,
+/// `Error::Extension` for an unsupported dtype or singular numerical result,
+/// and `Error::RuntimeState` when the extension is not registered.
+///
+/// # Deferred errors
+///
+/// Symbolic square-shape constraints can fail later as
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn lu(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor, TracedTensor, TracedTensor)> {
     four_outputs(
         apply(Arc::new(LinalgExtensionOp::new(LinalgOp::Lu)), &[a])?,
@@ -374,6 +717,17 @@ pub fn lu(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor, TracedTensor,
 /// assert_eq!(q.rank, 2);
 /// assert_eq!(parity.rank, 0);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a known invalid rank or matrix shape,
+/// `Error::Extension` for an unsupported dtype or singular numerical result,
+/// and `Error::Internal` for an output-count contract violation.
+///
+/// # Deferred errors
+///
+/// Symbolic square-shape constraints can fail later as
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn full_piv_lu(
     a: &TracedTensor,
 ) -> Result<(
@@ -402,6 +756,18 @@ pub fn full_piv_lu(
 /// assert_eq!(values.rank, 1);
 /// assert_eq!(vectors.rank, 2);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a known non-square or invalid-rank input,
+/// `Error::Extension` for an unsupported dtype or eigensolver
+/// non-convergence, and `Error::RuntimeState` when the extension is not
+/// registered.
+///
+/// # Deferred errors
+///
+/// Symbolic square-shape constraints can fail later as
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn eig(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
     two_outputs(
         apply(
@@ -427,6 +793,18 @@ pub fn eig(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
 /// let x = a.solve(&b).unwrap();
 /// assert_eq!(x.rank, 2);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for known incompatible matrix, batch, or dtype
+/// metadata, `Error::Extension` for an unsupported dtype or singular system,
+/// and `Error::RuntimeState` when the extension is not registered.
+///
+/// # Deferred errors
+///
+/// Symbolic matrix and batch constraints can fail later as
+/// `ShapeConstraintViolation`, `ShapeConstraintEvaluation`, or
+/// `ShapeExpressionEvaluation`.
 pub fn solve(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
     let mut factor_outputs =
         apply(Arc::new(LinalgExtensionOp::new(LinalgOp::LuFactor)), &[a])?.into_iter();
@@ -464,6 +842,18 @@ pub fn solve(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
 /// let x = a.full_piv_lu_solve(&b).unwrap();
 /// assert_eq!(x.rank, 2);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for known incompatible matrix, batch, or dtype
+/// metadata, `Error::Extension` for an unsupported dtype or singular system,
+/// and `Error::RuntimeState` when the extension is not registered.
+///
+/// # Deferred errors
+///
+/// Symbolic matrix and batch constraints can fail later as
+/// `ShapeConstraintViolation`, `ShapeConstraintEvaluation`, or
+/// `ShapeExpressionEvaluation`.
 pub fn full_piv_lu_solve(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
     one_output(
         apply(
@@ -489,6 +879,18 @@ pub fn full_piv_lu_solve(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTen
 /// let x = a.triangular_solve(&b, true, true, false, false).unwrap();
 /// assert_eq!(x.rank, 2);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for incompatible matrix, batch, or dtype
+/// metadata, `Error::Extension` for an unsupported dtype or singular system,
+/// and `Error::RuntimeState` when the extension is not registered.
+///
+/// # Deferred errors
+///
+/// Symbolic matrix and batch constraints can fail later as
+/// `ShapeConstraintViolation`, `ShapeConstraintEvaluation`, or
+/// `ShapeExpressionEvaluation`.
 pub fn triangular_solve(
     a: &TracedTensor,
     b: &TracedTensor,
@@ -524,6 +926,17 @@ pub fn triangular_solve(
 /// assert_eq!(sign.rank, 0);
 /// assert_eq!(logabsdet.rank, 0);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a known non-square or invalid-rank input,
+/// `Error::Extension` for an unsupported dtype or singular factorization, and
+/// `Error::Internal` if the factorization output contract is violated.
+///
+/// # Deferred errors
+///
+/// Symbolic square-shape constraints can fail later as
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn slogdet(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
     let mut factor_outputs =
         apply(Arc::new(LinalgExtensionOp::new(LinalgOp::LuFactor)), &[a])?.into_iter();
@@ -555,6 +968,17 @@ pub fn slogdet(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
 /// let determinant = a.det().unwrap();
 /// assert_eq!(determinant.rank, 0);
 /// ```
+///
+/// # Errors
+///
+/// Returns the same `Error::Validation`, `Error::Extension`, and
+/// `Error::RuntimeState` failures as [`slogdet`], including a singular
+/// factorization and an invalid matrix shape.
+///
+/// # Deferred errors
+///
+/// Symbolic shape checks can later produce `ShapeConstraintViolation`,
+/// `ShapeConstraintEvaluation`, or `ShapeExpressionEvaluation`.
 pub fn det(a: &TracedTensor) -> Result<TracedTensor> {
     let (sign, logabsdet) = slogdet(a)?;
     &sign * &logabsdet.exp()?
@@ -572,6 +996,17 @@ pub fn det(a: &TracedTensor) -> Result<TracedTensor> {
 /// let inverse = a.inv().unwrap();
 /// assert_eq!(inverse.rank, 2);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` when the input is not at least rank two or is
+/// not square, `Error::Extension` for an unsupported dtype or singular system,
+/// and `Error::RuntimeState` when the extension is not registered.
+///
+/// # Deferred errors
+///
+/// A symbolic shape that cannot provide the identity size fails later as
+/// `ShapeConstraintEvaluation` or `ShapeExpressionEvaluation`.
 pub fn inv(a: &TracedTensor) -> Result<TracedTensor> {
     ensure_min_rank("inv", a.rank, 2)?;
     let shape = require_concrete_shape("inv", a)?;
@@ -591,6 +1026,18 @@ pub fn inv(a: &TracedTensor) -> Result<TracedTensor> {
 /// let values = a.eigvalsh().unwrap();
 /// assert_eq!(values.rank, 1);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a known non-square or invalid-rank input,
+/// `Error::Extension` for an unsupported dtype or eigensolver
+/// non-convergence, and `Error::RuntimeState` when the extension is not
+/// registered.
+///
+/// # Deferred errors
+///
+/// Symbolic square-shape constraints can fail later as
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn eigvalsh(a: &TracedTensor) -> Result<TracedTensor> {
     eigh_values(a)
 }
@@ -607,6 +1054,18 @@ pub fn eigvalsh(a: &TracedTensor) -> Result<TracedTensor> {
 /// let values = a.eigvals().unwrap();
 /// assert_eq!(values.rank, 1);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for a known non-square or invalid-rank input,
+/// `Error::Extension` for an unsupported dtype or eigensolver
+/// non-convergence, and `Error::RuntimeState` when the extension is not
+/// registered.
+///
+/// # Deferred errors
+///
+/// Symbolic square-shape constraints can fail later as
+/// `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 pub fn eigvals(a: &TracedTensor) -> Result<TracedTensor> {
     eig_values(a)
 }
@@ -626,6 +1085,18 @@ pub fn eigvals(a: &TracedTensor) -> Result<TracedTensor> {
 /// let inverse = a.pinv().unwrap();
 /// assert_eq!(inverse.rank, 2);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for an invalid rank, shape, or negative/non-
+/// finite `rtol`, `Error::Extension` for unsupported integer or boolean dtypes,
+/// numerical non-convergence, or a backend failure, and `Error::RuntimeState`
+/// when the extension is not registered.
+///
+/// # Deferred errors
+///
+/// Symbolic shapes are materialized by this helper; failures are reported as
+/// `ShapeConstraintEvaluation` or `ShapeExpressionEvaluation`.
 pub fn pinv(a: &TracedTensor) -> Result<TracedTensor> {
     ensure_float_or_complex("pinv", a.dtype)?;
     let shape = require_concrete_shape("pinv", a)?;
@@ -652,6 +1123,18 @@ pub fn pinv(a: &TracedTensor) -> Result<TracedTensor> {
 /// let inverse = a.pinv_with_rtol(1e-12).unwrap();
 /// assert_eq!(inverse.rank, 2);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for an invalid rank, shape, or non-finite
+/// `rtol`, `Error::Extension` for unsupported integer or boolean dtypes,
+/// numerical non-convergence, or a backend failure, and `Error::RuntimeState`
+/// when the extension is not registered.
+///
+/// # Deferred errors
+///
+/// Symbolic shapes are materialized by this helper; failures are reported as
+/// `ShapeConstraintEvaluation` or `ShapeExpressionEvaluation`.
 pub fn pinv_with_rtol(a: &TracedTensor, rtol: f64) -> Result<TracedTensor> {
     ensure_float_or_complex("pinv_with_rtol", a.dtype)?;
     require_concrete_shape("pinv_with_rtol", a)?;
@@ -691,6 +1174,18 @@ pub fn pinv_with_rtol(a: &TracedTensor, rtol: f64) -> Result<TracedTensor> {
 /// let length = x.norm(Some(2.0), Some(&[0]), false).unwrap();
 /// assert_eq!(length.rank, 0);
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for an invalid axis, rank, or norm order,
+/// `Error::Extension` for unsupported integer or boolean dtypes or a backend
+/// numerical failure, and `Error::RuntimeState` when the extension is not
+/// registered.
+///
+/// # Deferred errors
+///
+/// Symbolic shapes needed to restore `keepdim` are evaluated later and can
+/// produce `ShapeConstraintEvaluation` or `ShapeExpressionEvaluation`.
 pub fn norm(
     a: &TracedTensor,
     ord: Option<f64>,
@@ -821,7 +1316,7 @@ fn ensure_float_or_complex(op: &'static str, dtype: DType) -> Result<()> {
     match dtype {
         DType::F32 | DType::F64 | DType::C32 | DType::C64 => Ok(()),
         DType::I32 | DType::I64 | DType::Bool => Err(Error::TensorRuntime(
-            tenferro_tensor::Error::backend_failure(op, format!("unsupported dtype {dtype:?}")),
+            crate::error::unsupported_dtype(op, dtype),
         )),
     }
 }
@@ -848,8 +1343,9 @@ fn validate_axes(op: &'static str, rank: usize, axes: &[usize]) -> Result<()> {
 
 fn require_concrete_shape(op: &'static str, input: &TracedTensor) -> Result<Vec<usize>> {
     input.try_concrete_shape().ok_or_else(|| {
-        Error::TensorRuntime(tenferro_tensor::Error::backend_failure(
+        Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
             op,
+            "shape",
             "symbolic shape is not supported by this traced linalg helper",
         ))
     })

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use num_complex::{Complex32, Complex64};
 use tenferro_runtime::extension::apply;
-use tenferro_runtime::{CompareDir, DType, DotGeneralConfig, Error, Result, TracedTensor};
+use tenferro_runtime::{
+    CompareDir, DType, DotGeneralConfig, Error, ErrorPhase, Result, TracedTensor,
+};
 
 use crate::extension::{
     validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, QrOptions, SvdOptions,
@@ -826,11 +828,9 @@ fn ensure_float_or_complex(op: &'static str, dtype: DType) -> Result<()> {
 
 fn ensure_min_rank(op: &'static str, actual: usize, expected: usize) -> Result<()> {
     if actual < expected {
-        return Err(Error::TensorRuntime(tenferro_tensor::Error::RankMismatch {
-            op,
-            expected,
-            actual,
-        }));
+        return Err(Error::TensorRuntime(tenferro_tensor::Error::rank_mismatch(
+            op, expected, actual,
+        )));
     }
     Ok(())
 }
@@ -839,7 +839,7 @@ fn validate_axes(op: &'static str, rank: usize, axes: &[usize]) -> Result<()> {
     for &axis in axes {
         if axis >= rank {
             return Err(Error::TensorRuntime(
-                tenferro_tensor::Error::AxisOutOfBounds { op, axis, rank },
+                tenferro_tensor::Error::axis_out_of_bounds(op, axis, rank),
             ));
         }
     }
@@ -923,10 +923,12 @@ fn frobenius_norm(abs: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
 
 fn p_norm(abs: &TracedTensor, axes: &[usize], p: f64) -> Result<TracedTensor> {
     if !p.is_finite() || p == 0.0 {
-        return Err(Error::InvalidGraphBuild {
-            op: "norm",
-            message: format!("p-norm order must be finite and nonzero, got {p}"),
-        });
+        return Err(Error::invalid_argument(
+            "norm",
+            ErrorPhase::GraphBuild,
+            "p",
+            format!("p-norm order must be finite and nonzero, got {p}"),
+        ));
     }
     let power = abs.pow(&scalar_real(abs.dtype, p)?)?;
     let inv_p = scalar_real(abs.dtype, 1.0 / p)?;

--- a/crates/tenferro-linalg/tests/integration/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/integration/backend_errors.rs
@@ -9,7 +9,7 @@ use tenferro_tensor::{
     DType, DotGeneralConfig, Error, GatherConfig, MemoryKind, PadConfig, Placement, ScatterConfig,
     SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer,
     TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
-    TensorView, TypedTensor,
+    TensorView, TypedTensor, ValidationError,
 };
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
@@ -522,9 +522,9 @@ fn cpu_lu_solve_prepared_restores_vector_rhs_and_validates_inputs() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::DTypeMismatch {
+        Error::Validation {
             op: "lu_solve_prepared",
-            ..
+            source: ValidationError::DTypeMismatch { .. },
         }
     ));
 
@@ -537,9 +537,9 @@ fn cpu_lu_solve_prepared_restores_vector_rhs_and_validates_inputs() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::DTypeMismatch {
+        Error::Validation {
             op: "lu_solve_prepared",
-            ..
+            source: ValidationError::DTypeMismatch { .. },
         }
     ));
 
@@ -569,9 +569,9 @@ fn cpu_lu_solve_prepared_rejects_rank_less_than_two() {
 
     assert!(matches!(
         err,
-        Error::RankMismatch {
+        Error::Validation {
             op: "lu_solve_prepared",
-            ..
+            source: ValidationError::RankMismatch { .. },
         }
     ));
 }
@@ -621,10 +621,9 @@ fn solve_rejects_invalid_dtype_pairs_before_zero_dim_fast_path() {
     let err = backend.solve(&f64_a, &c64_b).unwrap_err();
     assert!(matches!(
         err,
-        Error::DTypeMismatch {
+        Error::Validation {
             op: "solve",
-            lhs: DType::F64,
-            rhs: DType::C64,
+            source: ValidationError::DTypeMismatch { .. },
         }
     ));
 
@@ -651,10 +650,9 @@ fn full_piv_lu_solve_rejects_invalid_dtype_pairs_before_zero_dim_fast_path() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::DTypeMismatch {
+        Error::Validation {
             op: "full_piv_lu_solve",
-            lhs: DType::F64,
-            rhs: DType::C64,
+            source: ValidationError::DTypeMismatch { .. },
         }
     ));
 
@@ -681,10 +679,12 @@ fn cholesky_rejects_rank_less_than_two_even_when_zero_dim() {
     let err = result.unwrap().unwrap_err();
     assert!(matches!(
         err,
-        Error::RankMismatch {
+        Error::Validation {
             op: "cholesky",
-            expected: 2,
-            actual: 1,
+            source: ValidationError::RankMismatch {
+                expected: 2,
+                actual: 1,
+            },
         }
     ));
 }
@@ -717,9 +717,9 @@ fn triangular_solve_rejects_batch_mismatch_without_backend_panic() {
     let err = result.unwrap().unwrap_err();
     assert!(matches!(
         err,
-        Error::ShapeMismatch {
+        Error::Validation {
             op: "triangular_solve",
-            ..
+            source: ValidationError::ShapeMismatch(_),
         }
     ));
 }
@@ -741,9 +741,9 @@ fn full_piv_lu_solve_rejects_batch_mismatch_without_backend_panic() {
     let err = result.unwrap().unwrap_err();
     assert!(matches!(
         err,
-        Error::ShapeMismatch {
+        Error::Validation {
             op: "full_piv_lu_solve",
-            ..
+            source: ValidationError::ShapeMismatch(_),
         }
     ));
 }

--- a/crates/tenferro-linalg/tests/integration/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/integration/backend_errors.rs
@@ -1,3 +1,4 @@
+use std::error::Error as _;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
@@ -6,10 +7,10 @@ use tenferro_cpu::CpuBackend;
 use tenferro_linalg::LinalgBackend;
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSessionHost, Buffer, BufferHandle, CompareDir,
-    DType, DotGeneralConfig, Error, GatherConfig, MemoryKind, PadConfig, Placement, ScatterConfig,
-    SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer,
-    TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
-    TensorView, TypedTensor, ValidationError,
+    DType, DotGeneralConfig, Error, ErrorKind, GatherConfig, MemoryKind, PadConfig, Placement,
+    ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorReduction, TensorStructural, TensorView, TypedTensor, ValidationError,
 };
 
 fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> Tensor {
@@ -73,7 +74,7 @@ fn assert_backend_download_error<T>(result: tenferro_tensor::Result<T>, expected
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::RuntimeState {
             op,
             ref message,
         } if op == expected_op && message.contains("download")
@@ -215,7 +216,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
     let err = backend.lu_factor(&Tensor::F64(input.clone())).unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Unsupported {
             op: "lu_factor",
             ref message,
         } if message.contains("does not implement")
@@ -224,7 +225,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
     let err = backend.svd_values(&Tensor::F64(input.clone())).unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Unsupported {
             op: "svd_values",
             ref message,
         } if message.contains("does not implement")
@@ -236,7 +237,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Unsupported {
             op: "svd",
             ref message,
         } if message.contains("borrowed tensor views")
@@ -248,7 +249,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Unsupported {
             op: "qr",
             ref message,
         } if message.contains("borrowed tensor views")
@@ -260,7 +261,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Unsupported {
             op: "eigh",
             ref message,
         } if message.contains("borrowed tensor views")
@@ -271,7 +272,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Unsupported {
             op: "eigh_values",
             ref message,
         } if message.contains("does not implement")
@@ -290,7 +291,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Unsupported {
             op: "lu_solve_prepared",
             ref message,
         } if message.contains("does not implement")
@@ -301,7 +302,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Unsupported {
             op: "cholesky",
             ref message,
         } if message.contains("borrowed tensor views")
@@ -312,7 +313,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Unsupported {
             op: "lu",
             ref message,
         } if message.contains("borrowed tensor views")
@@ -323,7 +324,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Unsupported {
             op: "full_piv_lu",
             ref message,
         } if message.contains("borrowed tensor views")
@@ -334,7 +335,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Unsupported {
             op: "eig",
             ref message,
         } if message.contains("borrowed tensor views")
@@ -549,10 +550,13 @@ fn cpu_lu_solve_prepared_restores_vector_rhs_and_validates_inputs() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Validation {
             op: "lu_solve_prepared",
-            ref message,
-        } if message.contains("1-based")
+            source: ValidationError::InvalidArgument {
+                argument: "pivot",
+                ..
+            },
+        }
     ));
 }
 
@@ -630,10 +634,12 @@ fn solve_rejects_invalid_dtype_pairs_before_zero_dim_fast_path() {
     let err = backend.solve(&i32_a, &i32_b).unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Extension {
             op: "solve",
-            ref message,
-        } if message.contains("unsupported dtype I32")
+            family: tenferro_linalg::LINALG_EXTENSION_FAMILY_ID,
+            kind: tenferro_tensor::ErrorKind::Unsupported,
+            ..
+        }
     ));
 }
 
@@ -661,10 +667,12 @@ fn full_piv_lu_solve_rejects_invalid_dtype_pairs_before_zero_dim_fast_path() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::Extension {
             op: "full_piv_lu_solve",
-            ref message,
-        } if message.contains("unsupported dtype I32")
+            family: tenferro_linalg::LINALG_EXTENSION_FAMILY_ID,
+            kind: tenferro_tensor::ErrorKind::Unsupported,
+            ..
+        }
     ));
 }
 
@@ -697,7 +705,12 @@ fn solve_rejects_singular_matrix() {
 
     let err = backend.solve(&a, &b).unwrap_err();
 
-    assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+    assert_eq!(err.kind(), ErrorKind::NumericalFailure);
+    assert!(matches!(
+        err.source()
+            .and_then(|source| source.downcast_ref::<tenferro_linalg::Error>()),
+        Some(tenferro_linalg::Error::Singular { op: "solve" })
+    ));
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/integration/cpu_linalg_source_contract.rs
+++ b/crates/tenferro-linalg/tests/integration/cpu_linalg_source_contract.rs
@@ -297,8 +297,8 @@ fn lapack_full_piv_lu_rejects_positive_getc2_info() {
         "factor_getc2 should not discard positive getc2 singularity info"
     );
     assert!(
-        factor.contains("matrix is singular"),
-        "positive getc2 info should be reported as a singular matrix"
+        factor.contains("crate::Error::Singular"),
+        "positive getc2 info should be reported through the typed singular source"
     );
 }
 

--- a/crates/tenferro-linalg/tests/integration/full_piv_lu.rs
+++ b/crates/tenferro-linalg/tests/integration/full_piv_lu.rs
@@ -106,10 +106,11 @@ fn full_piv_lu_blas_rejects_singular_matrix() {
 
     assert!(matches!(
         err,
-        tenferro_tensor::Error::BackendFailure {
+        tenferro_tensor::Error::Extension {
             op: "full_piv_lu",
-            ref message,
-        } if message.contains("singular")
+            kind: tenferro_tensor::ErrorKind::NumericalFailure,
+            ..
+        }
     ));
 }
 

--- a/crates/tenferro-linalg/tests/integration/gpu_linalg.rs
+++ b/crates/tenferro-linalg/tests/integration/gpu_linalg.rs
@@ -542,21 +542,21 @@ fn test_gpu_eig_returns_unsupported_error() {
     let gpu = upload(&backend, &cpu);
 
     let err = backend.eig(&gpu).unwrap_err();
-    assert!(matches!(err, Error::BackendFailure { op: "eig", .. }));
+    assert!(matches!(err, Error::Unsupported { op: "eig", .. }));
 }
 
 #[test]
 #[ignore]
-fn test_cubecl_eig_f32_returns_backend_failure() {
+fn test_cubecl_eig_f32_returns_unsupported_error() {
     let input = tensor_f32(vec![2, 2], vec![1.0, 0.0, 0.0, 3.0]);
     let mut gpu = gpu_backend();
     let err = gpu.eig(&upload(&gpu, &input)).unwrap_err();
-    assert!(matches!(err, Error::BackendFailure { op: "eig", .. }));
+    assert!(matches!(err, Error::Unsupported { op: "eig", .. }));
 }
 
 #[test]
 #[ignore]
-fn test_cubecl_eig_c32_returns_backend_failure() {
+fn test_cubecl_eig_c32_returns_unsupported_error() {
     let input = tensor_c32(
         vec![2, 2],
         vec![
@@ -568,7 +568,7 @@ fn test_cubecl_eig_c32_returns_backend_failure() {
     );
     let mut gpu = gpu_backend();
     let err = gpu.eig(&upload(&gpu, &input)).unwrap_err();
-    assert!(matches!(err, Error::BackendFailure { op: "eig", .. }));
+    assert!(matches!(err, Error::Unsupported { op: "eig", .. }));
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/integration/traced_ad_explicit.rs
+++ b/crates/tenferro-linalg/tests/integration/traced_ad_explicit.rs
@@ -139,7 +139,11 @@ fn assert_invalid_ad_graph_build(
         .unwrap_or_else(|_| panic!("{linalg_op} {transform} should return Err, not panic"))
         .unwrap_err();
     match err {
-        Error::InvalidGraphBuild { op, message } => {
+        Error::Validation {
+            op,
+            phase: tenferro_runtime::ErrorPhase::GraphBuild,
+            source: tenferro_tensor::ValidationError::InvalidArgument { message, .. },
+        } => {
             assert_eq!(op, transform);
             assert!(
                 message.contains(linalg_op),
@@ -150,7 +154,7 @@ fn assert_invalid_ad_graph_build(
                 "expected {detail:?} in message, got: {message}"
             );
         }
-        other => panic!("expected InvalidGraphBuild, got {other:?}"),
+        other => panic!("expected graph-build validation, got {other:?}"),
     }
 }
 
@@ -164,10 +168,13 @@ fn assert_traced_op_rank_mismatch<T>(
         Err(err) => err,
     };
     match err {
-        Error::TensorRuntime(TensorError::RankMismatch {
+        Error::TensorRuntime(TensorError::Validation {
             op,
-            expected: 2,
-            actual: got,
+            source:
+                tenferro_tensor::ValidationError::RankMismatch {
+                    expected: 2,
+                    actual: got,
+                },
         }) => {
             assert_eq!(op, linalg_op);
             assert_eq!(got, actual);

--- a/crates/tenferro-linalg/tests/integration/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/integration/traced_extension.rs
@@ -399,10 +399,12 @@ fn traced_inv_rejects_rank_less_than_two_without_panicking() {
 
     assert!(matches!(
         err,
-        Error::TensorRuntime(TensorError::RankMismatch {
+        Error::TensorRuntime(TensorError::Validation {
             op: "inv",
-            expected: 2,
-            actual: 0,
+            source: tenferro_tensor::ValidationError::RankMismatch {
+                expected: 2,
+                actual: 0,
+            },
         })
     ));
 }
@@ -415,10 +417,12 @@ fn assert_linalg_rank_mismatch<T>(name: &str, result: tenferro_runtime::Result<T
     assert!(
         matches!(
             err,
-            Error::TensorRuntime(TensorError::RankMismatch {
-                expected: 2,
-                actual: got,
-                ..
+            Error::TensorRuntime(TensorError::Validation {
+                op: _,
+                source: tenferro_tensor::ValidationError::RankMismatch {
+                    expected: 2,
+                    actual: got,
+                },
             }) if got == actual
         ),
         "expected rank mismatch for {name}, got {err:?}"
@@ -477,10 +481,9 @@ fn traced_norm_rejects_out_of_range_axis_without_panicking() {
 
     assert!(matches!(
         err,
-        Error::TensorRuntime(TensorError::AxisOutOfBounds {
+        Error::TensorRuntime(TensorError::Validation {
             op: "norm",
-            axis: 5,
-            rank: 1,
+            source: tenferro_tensor::ValidationError::AxisOutOfBounds { axis: 5, rank: 1 },
         })
     ));
 }

--- a/crates/tenferro-linalg/tests/integration/traced_extension.rs
+++ b/crates/tenferro-linalg/tests/integration/traced_extension.rs
@@ -366,10 +366,12 @@ fn traced_norm_rejects_integer_and_bool_dtypes_before_scalar_rounding() {
         assert!(
             matches!(
                 err,
-                Error::TensorRuntime(TensorError::BackendFailure {
+                Error::TensorRuntime(TensorError::Extension {
                     op: "norm",
-                    ref message,
-                }) if message.contains("unsupported dtype")
+                    family: tenferro_linalg::LINALG_EXTENSION_FAMILY_ID,
+                    kind: tenferro_tensor::ErrorKind::Unsupported,
+                    ..
+                })
             ),
             "expected unsupported dtype error for {dtype:?}, got {err:?}"
         );
@@ -381,10 +383,12 @@ fn traced_norm_rejects_integer_and_bool_dtypes_before_scalar_rounding() {
         assert!(
             matches!(
                 err,
-                Error::TensorRuntime(TensorError::BackendFailure {
+                Error::TensorRuntime(TensorError::Extension {
                     op: "pinv_with_rtol",
-                    ref message,
-                }) if message.contains("unsupported dtype")
+                    family: tenferro_linalg::LINALG_EXTENSION_FAMILY_ID,
+                    kind: tenferro_tensor::ErrorKind::Unsupported,
+                    ..
+                })
             ),
             "expected unsupported dtype error for {dtype:?}, got {err:?}"
         );
@@ -463,10 +467,13 @@ fn traced_linalg_helpers_reject_symbolic_shapes_without_panicking() {
         assert!(
             matches!(
                 err,
-                Error::TensorRuntime(TensorError::BackendFailure {
+                Error::TensorRuntime(TensorError::Validation {
                     op: actual_op,
-                    ref message,
-                }) if actual_op == op && message.contains("symbolic shape")
+                    source: tenferro_tensor::ValidationError::InvalidArgument {
+                        argument: "shape",
+                        ..
+                    },
+                }) if actual_op == op
             ),
             "expected symbolic-shape error for {op}, got {err:?}"
         );
@@ -499,10 +506,12 @@ fn traced_pinv_rejects_integer_and_bool_dtypes_before_scalar_rounding() {
         assert!(
             matches!(
                 err,
-                Error::TensorRuntime(TensorError::BackendFailure {
+                Error::TensorRuntime(TensorError::Extension {
                     op: "pinv",
-                    ref message,
-                }) if message.contains("unsupported dtype")
+                    family: tenferro_linalg::LINALG_EXTENSION_FAMILY_ID,
+                    kind: tenferro_tensor::ErrorKind::Unsupported,
+                    ..
+                })
             ),
             "expected unsupported dtype error for {dtype:?}, got {err:?}"
         );

--- a/crates/tenferro-runtime/src/ad_support.rs
+++ b/crates/tenferro-runtime/src/ad_support.rs
@@ -300,6 +300,13 @@ pub fn resolve_roots(tensor: &TracedTensor) -> Vec<Arc<Graph<StdTensorOp>>> {
     tensor.resolve_roots()
 }
 
+///
+/// # Errors
+///
+/// Returns [`Error::RuntimeStateSource`] when either metadata scope cannot be
+/// registered because the global registry is poisoned. The tensor metadata is
+/// derived from the already-valid `Tensor`; no dtype/shape validation is
+/// deferred by this operation.
 pub fn checkpoint_tensor(tensor: &mut TracedTensor, data: Arc<Tensor>) -> Result<()> {
     let old_graph = tensor.graph.clone();
     let old_output_key = old_graph.values()[tensor.val].key.clone();
@@ -347,6 +354,11 @@ pub fn allocate_input_key() -> TensorInputKey {
     next_input_key()
 }
 
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`] with `ValidationError::InvalidArgument` when
+/// `tensor` is an operation result rather than a placeholder input.
 pub fn leaf_input_key(tensor: &TracedTensor) -> Result<TensorInputKey> {
     match &tensor.graph.values()[tensor.val].key {
         ValueKey::Input(key) => Ok(key.clone()),
@@ -359,6 +371,11 @@ pub fn leaf_input_key(tensor: &TracedTensor) -> Result<TensorInputKey> {
     }
 }
 
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`] with `ValidationError::InvalidArgument` when
+/// `local_id` does not refer to an input value in the linearized graph.
 pub fn linear_input_key(
     graph: &Graph<StdTensorOp>,
     local_id: LocalValueId,
@@ -374,6 +391,12 @@ pub fn linear_input_key(
     }
 }
 
+///
+/// # Errors
+///
+/// Returns [`Error::TensorRuntime`] containing `ValidationError::IntegerOverflow`
+/// when the shape product overflows, or the typed tensor's validation source
+/// when it cannot be constructed from `shape`.
 pub fn ones_tensor(dtype: DType, shape: Vec<usize>) -> Result<Tensor> {
     match dtype {
         DType::F32 => Ok(Tensor::F32(TypedTensor::ones(shape)?)),

--- a/crates/tenferro-runtime/src/ad_support.rs
+++ b/crates/tenferro-runtime/src/ad_support.rs
@@ -12,6 +12,7 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{DType, Tensor, TypedTensor};
 
 pub use crate::checkpoint::CheckpointNode;
+use crate::error::ErrorPhase;
 use crate::metadata::MetadataScopeChain;
 pub use crate::metadata::{
     metadata_scopes_for_scope, metadata_scopes_with_new, metadata_scopes_with_scope,
@@ -349,10 +350,12 @@ pub fn allocate_input_key() -> TensorInputKey {
 pub fn leaf_input_key(tensor: &TracedTensor) -> Result<TensorInputKey> {
     match &tensor.graph.values()[tensor.val].key {
         ValueKey::Input(key) => Ok(key.clone()),
-        other => Err(Error::InvalidGraphBuild {
-            op: "ad_support::leaf_input_key",
-            message: format!("expected traced leaf input, got {other:?}"),
-        }),
+        other => Err(Error::invalid_argument(
+            "ad_support::leaf_input_key",
+            ErrorPhase::GraphBuild,
+            "tensor",
+            format!("expected traced leaf input, got {other:?}"),
+        )),
     }
 }
 
@@ -362,10 +365,12 @@ pub fn linear_input_key(
 ) -> Result<TensorInputKey> {
     match &graph.values()[local_id].key {
         ValueKey::Input(key) => Ok(key.clone()),
-        other => Err(Error::InvalidGraphBuild {
-            op: "ad_support::linear_input_key",
-            message: format!("expected linear graph input, got {other:?}"),
-        }),
+        other => Err(Error::invalid_argument(
+            "ad_support::linear_input_key",
+            ErrorPhase::Compile,
+            "graph",
+            format!("expected linear graph input, got {other:?}"),
+        )),
     }
 }
 

--- a/crates/tenferro-runtime/src/ad_support/tests.rs
+++ b/crates/tenferro-runtime/src/ad_support/tests.rs
@@ -160,7 +160,7 @@ fn bool_ones_tensor_rejects_shape_product_overflow_without_panicking() {
 
     assert!(matches!(
         err,
-        crate::Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
+        crate::Error::TensorRuntime(tenferro_tensor::Error::Validation {
             op: "ones_tensor",
             ..
         })

--- a/crates/tenferro-runtime/src/compiler/dot_decomposer.rs
+++ b/crates/tenferro-runtime/src/compiler/dot_decomposer.rs
@@ -48,6 +48,14 @@ use super::{exact_extents_from_shape, invalid_compiled_graph, missing_slot_meta}
 /// `input_shapes` are the program-input shapes (matching `program.input_slots`).
 /// They are needed because `ExecProgram` does not otherwise carry input-slot
 /// shape metadata.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::Internal`] when an input/output slot is outside its
+/// slot table, output metadata is missing, or another canonicalization
+/// invariant is invalid. Returns [`crate::Error::Validation`] with
+/// `ShapeMismatch`, `RankMismatch`, or `InvalidArgument` when a dot shape or
+/// dimension expression cannot be validated.
 pub fn dot_decomposer(program: &mut ExecProgram, input_shapes: &[Vec<DimExpr>]) -> Result<()> {
     if program.input_slots.len() != input_shapes.len() {
         return Err(invalid_compiled_graph(format!(

--- a/crates/tenferro-runtime/src/compiler/mod.rs
+++ b/crates/tenferro-runtime/src/compiler/mod.rs
@@ -34,6 +34,23 @@ enum MissingConstraintOrigin {
     Preserve,
 }
 
+/// Compile a standard operation program into executable instructions.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_runtime::extension::compile_std_to_exec;
+/// let _compile = compile_std_to_exec;
+/// ```
+///
+/// # Errors
+///
+/// Returns [`Error::Internal`] when input counts disagree with the program or
+/// a slot is missing/out of bounds or has duplicate producers,
+/// [`Error::Validation`] with `DTypeMismatch`, `ShapeMismatch`,
+/// `RankMismatch`, `AxisOutOfBounds`, `DuplicateAxis`, or `InvalidArgument`
+/// for operation metadata and discharged shape constraints, and
+/// [`Error::Unsupported`] when an extension cannot be lowered or dispatched.
 pub fn compile_std_to_exec(
     prog: &CompiledProgram<StdTensorOp>,
     input_dtypes: &[DType],
@@ -49,6 +66,23 @@ pub fn compile_std_to_exec(
     )
 }
 
+/// Compile a standard operation program with explicit compiler options.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_runtime::extension::compile_std_to_exec_with_options;
+/// let _compile = compile_std_to_exec_with_options;
+/// ```
+///
+/// # Errors
+///
+/// Returns [`Error::Internal`] when input counts disagree with the program or
+/// a slot is missing/out of bounds or has duplicate producers,
+/// [`Error::Validation`] with `DTypeMismatch`, `ShapeMismatch`,
+/// `RankMismatch`, `AxisOutOfBounds`, `DuplicateAxis`, or `InvalidArgument`
+/// for operation metadata and discharged shape constraints, and
+/// [`Error::Unsupported`] when an extension cannot be lowered or dispatched.
 pub fn compile_std_to_exec_with_options(
     prog: &CompiledProgram<StdTensorOp>,
     input_dtypes: &[DType],

--- a/crates/tenferro-runtime/src/compiler/mod.rs
+++ b/crates/tenferro-runtime/src/compiler/mod.rs
@@ -451,9 +451,7 @@ fn lower_scoped_dim_expr(
 }
 
 fn invalid_compiled_graph(message: impl Into<String>) -> Error {
-    Error::InvalidCompiledGraph {
-        message: message.into(),
-    }
+    Error::Internal(message.into())
 }
 
 fn missing_slot_meta(kind: &'static str, slot: usize) -> Error {

--- a/crates/tenferro-runtime/src/compiler/optimizer/mod.rs
+++ b/crates/tenferro-runtime/src/compiler/optimizer/mod.rs
@@ -7,6 +7,15 @@ use crate::Result;
 use super::options::OptimizerConfig;
 
 /// Run the standard execution-IR optimizer pipeline.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `ShapeMismatch`, `DTypeMismatch`,
+/// `RankMismatch`, or `InvalidArgument` when shape/dtype metadata is
+/// inconsistent with an optimizer pass, [`crate::Error::Unsupported`] when a
+/// configured decomposition cannot support an operation, and
+/// [`crate::Error::Internal`] when the execution IR violates an invariant such
+/// as a missing slot metadata entry.
 pub fn optimize_exec_program(
     program: &mut ExecProgram,
     input_dtypes: &[DType],

--- a/crates/tenferro-runtime/src/compiler/tests.rs
+++ b/crates/tenferro-runtime/src/compiler/tests.rs
@@ -5,12 +5,14 @@ use super::{
     slot_use_counts, transpose_folding, CompilerOptions, OptimizerConfig,
 };
 use crate::exec::{ExecInstruction, ExecOp, ExecProgram};
-use crate::{Error, GraphExecutor};
+use crate::{Error, ErrorPhase, GraphExecutor};
 use computegraph::compile::{CompiledProgram, Instruction};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeExtent;
-use tenferro_tensor::{DType, DotGeneralConfig};
+use tenferro_tensor::{
+    DType, DotGeneralConfig, ErrorKind, ShapeMismatch, ValidationError, ValidationKind,
+};
 
 #[path = "tests/dot_decomposer_tests.rs"]
 mod dot_decomposer_tests;
@@ -133,7 +135,7 @@ fn compile_reports_missing_slot_metadata_as_error() {
 
     assert!(matches!(
         err,
-        Error::InvalidCompiledGraph { ref message }
+        Error::Internal(ref message)
             if message.contains("missing dtype for slot 1")
     ));
 }
@@ -155,10 +157,21 @@ fn compile_reports_incompatible_broadcast_as_error() {
     .unwrap_err();
 
     assert!(matches!(
-        err,
-        Error::InvalidCompiledGraph { ref message }
-            if message.contains("incompatible Add/Mul broadcast dimensions: 2 and 3")
+        &err,
+        Error::Validation {
+            phase: ErrorPhase::Compile,
+            source: ValidationError::ShapeMismatch(source),
+            ..
+        } if matches!(
+            source.as_ref(),
+            ShapeMismatch::IncompatibleShapes { lhs, rhs }
+                if lhs.as_slice() == [2] && rhs.as_slice() == [3]
+        )
     ));
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::ShapeMismatch)
+    );
 }
 
 #[test]
@@ -167,7 +180,7 @@ fn resolve_slot_redirect_rejects_cycles() {
 
     assert!(matches!(
         err,
-        Error::InvalidCompiledGraph { ref message }
+        Error::Internal(ref message)
             if message.contains("redirect cycle") && message.contains("slot 0")
     ));
 }
@@ -181,7 +194,7 @@ fn record_producer_rejects_out_of_range_output_slot() {
 
     assert!(matches!(
         err,
-        Error::InvalidCompiledGraph { ref message }
+        Error::Internal(ref message)
             if message.contains("producer output slot 3")
     ));
 }
@@ -195,7 +208,7 @@ fn producer_index_by_slot_rejects_out_of_range_output_slot() {
 
     assert!(matches!(
         err,
-        Error::InvalidCompiledGraph { ref message }
+        Error::Internal(ref message)
             if message.contains("producer output slot 3")
     ));
 }
@@ -210,7 +223,7 @@ fn producer_index_by_slot_rejects_duplicate_output_slot() {
 
     assert!(matches!(
         err,
-        Error::InvalidCompiledGraph { ref message }
+        Error::Internal(ref message)
             if message == "producer output slot 1 has duplicate producers at instructions 0 and 1"
     ));
 }
@@ -224,7 +237,7 @@ fn slot_use_counts_rejects_out_of_range_slots() {
 
     assert!(matches!(
         err,
-        Error::InvalidCompiledGraph { ref message }
+        Error::Internal(ref message)
             if message.contains("use-count input slot 2")
     ));
 }
@@ -237,7 +250,7 @@ fn populate_last_use_rejects_out_of_range_output_slot() {
 
     assert!(matches!(
         err,
-        Error::InvalidCompiledGraph { ref message }
+        Error::Internal(ref message)
             if message.contains("last-use output slot 2")
     ));
 }

--- a/crates/tenferro-runtime/src/compiler/tests/dot_decomposer_tests.rs
+++ b/crates/tenferro-runtime/src/compiler/tests/dot_decomposer_tests.rs
@@ -62,7 +62,7 @@ fn test_dot_decomposer_missing_slot_metadata_returns_error() {
 
     assert!(matches!(
         err,
-        Error::InvalidCompiledGraph { ref message }
+        Error::Internal(ref message)
             if message.contains("missing shape for slot 2")
     ));
 }
@@ -84,7 +84,7 @@ fn test_dot_decomposer_mismatched_batch_dim_count_returns_error() {
 
     assert!(matches!(
         err,
-        Error::InvalidCompiledGraph { ref message }
+        Error::Internal(ref message)
             if message.contains("lhs batch dim count 1")
     ));
 }

--- a/crates/tenferro-runtime/src/compiler/tests/shape_constraints.rs
+++ b/crates/tenferro-runtime/src/compiler/tests/shape_constraints.rs
@@ -4,7 +4,7 @@ use computegraph::compile::{CompiledProgram, Instruction};
 use tenferro_ops::{
     dim_expr::DimExpr, ext_op::ExtensionOp, std_tensor_op::StdTensorOp, ShapeRelation, SymDim,
 };
-use tenferro_tensor::DType;
+use tenferro_tensor::{DType, ErrorKind, ValidationKind};
 
 use super::{compile_std_to_exec, dim_shape, make_std_instr};
 use crate::{Error, ShapeGuard};
@@ -363,7 +363,7 @@ fn compiler_rejects_duplicate_output_slot_producers_before_optimization() {
 
     assert!(matches!(
         compile_std_to_exec(&program, &[DType::F64], &[dim_shape(&[2])]),
-        Err(Error::InvalidCompiledGraph { ref message })
+        Err(Error::Internal(ref message))
             if message.contains("output slot 1")
                 && message.contains("instructions 0 and 1")
     ));
@@ -380,7 +380,7 @@ fn compiler_rejects_out_of_range_output_slot_before_optimization() {
 
     assert!(matches!(
         compile_std_to_exec(&program, &[DType::F64], &[dim_shape(&[2])]),
-        Err(Error::InvalidCompiledGraph { message })
+        Err(Error::Internal(message))
             if message == "output slot 2 is outside slot table of length 2"
     ));
 }
@@ -439,7 +439,7 @@ fn constraint_origin_without_outputs_hits_instruction_invariant_first() {
             &[DType::F64, DType::F64],
             &[dim_shape(&[2]), dim_shape(&[2])],
         ),
-        Err(Error::InvalidCompiledGraph { ref message })
+        Err(Error::Internal(ref message))
             if message == "instruction has no outputs"
     ));
 }
@@ -458,15 +458,10 @@ fn compiler_preserves_constraint_inference_errors() {
     };
 
     let error = compile_std_to_exec(&program, &[DType::F64], &[dim_shape(&[2])]).unwrap_err();
-    assert!(
-        matches!(
-            &error,
-            Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
-                op: "test.compiler-invalid-constraint-axis.v1",
-                message,
-            }) if message
-                == "extension family \"test.compiler-invalid-constraint-axis.v1\" axis 1 out of bounds for input 0 rank 1"
-        ),
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::AxisOutOfBounds),
         "unexpected compiler error: {error:?}"
     );
+    assert!(std::error::Error::source(&error).is_some());
 }

--- a/crates/tenferro-runtime/src/error.rs
+++ b/crates/tenferro-runtime/src/error.rs
@@ -9,12 +9,41 @@
 //! assert!(err.to_string().contains("bad label"));
 //! ```
 
+use std::error::Error as StdError;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tenferro_ops::ShapeRelation;
-use tenferro_tensor::DType;
+use tenferro_tensor::{DType, ErrorKind, ValidationError, ValidationKind};
 
 static NEXT_CONTEXT_ID: AtomicUsize = AtomicUsize::new(1);
+
+/// Boxed source used when a runtime registry or compiler subsystem crosses
+/// the runtime error boundary with a concrete error owned by another crate.
+pub type BoxError = Box<dyn StdError + Send + Sync + 'static>;
+
+/// Phase at which a runtime failure was discovered.
+///
+/// The phase is independent from [`ErrorKind`]: the same validation fact can
+/// be discovered while building a graph, compiling it for concrete inputs,
+/// or executing a compiled program.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_runtime::ErrorPhase;
+///
+/// assert_ne!(ErrorPhase::GraphBuild, ErrorPhase::Execution);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ErrorPhase {
+    /// A caller-controlled graph construction check failed.
+    GraphBuild,
+    /// Shape inference or lowering discovered the failure.
+    Compile,
+    /// Input binding or backend execution discovered the failure.
+    Execution,
+}
 
 /// Typed reason that a symbolic shape constraint could not be evaluated.
 ///
@@ -76,6 +105,18 @@ pub enum ShapeConstraintEvalError {
 /// ```
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// A shared tensor validation fact, annotated with the runtime phase.
+    #[error("{op} ({phase:?}): {source}")]
+    Validation {
+        /// Public operation name.
+        op: &'static str,
+        /// Phase that discovered the validation fact.
+        phase: ErrorPhase,
+        /// Machine-readable validation payload.
+        #[source]
+        source: ValidationError,
+    },
+
     /// Einsum subscript string is invalid or cannot be parsed.
     #[error("invalid subscripts: {0}")]
     InvalidSubscripts(String),
@@ -95,6 +136,14 @@ pub enum Error {
     /// Runtime tensor execution failed in the backend layer.
     #[error(transparent)]
     TensorRuntime(#[from] tenferro_tensor::Error),
+
+    /// A runtime metadata or registry subsystem failed with a typed source.
+    #[error("runtime metadata failure: {source}")]
+    Metadata {
+        /// Typed metadata subsystem source.
+        #[source]
+        source: BoxError,
+    },
 
     /// A `TracedTensor` passed to graph-executor input bindings is not a
     /// placeholder (has attached data).
@@ -143,15 +192,6 @@ pub enum Error {
     )]
     ContextMismatch { lhs: ContextId, rhs: ContextId },
 
-    /// Traced graph construction rejected an invalid operation configuration.
-    #[error("{op}: invalid traced graph build: {message}")]
-    InvalidGraphBuild {
-        /// Public operation name.
-        op: &'static str,
-        /// Validation failure details.
-        message: String,
-    },
-
     /// An AD transform requires a primitive or extension rule that is not
     /// registered for the requested operation.
     #[error("unsupported {transform} AD rule for {op}")]
@@ -160,13 +200,6 @@ pub enum Error {
         transform: &'static str,
         /// Operation or extension family identifier that has no applicable rule.
         op: String,
-    },
-
-    /// Lowering rejected an inconsistent compiled graph.
-    #[error("invalid compiled graph: {message}")]
-    InvalidCompiledGraph {
-        /// Validation failure details.
-        message: String,
     },
 
     /// A symbolic extension shape equality evaluated to unequal dimensions.
@@ -211,6 +244,148 @@ pub enum Error {
     /// An unexpected internal error.
     #[error("internal error: {0}")]
     Internal(String),
+}
+
+impl Error {
+    /// Wrap a shared validation payload with its operation and discovery
+    /// phase.
+    ///
+    /// # Errors
+    ///
+    /// This constructor does not fail; callers receive the returned
+    /// [`Error`] value and can inspect its [`Error::kind`] and
+    /// [`Error::phase`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::{Error, ErrorPhase};
+    /// use tenferro_tensor::{ErrorKind, ShapeMismatch, ValidationKind};
+    ///
+    /// let error = Error::validation(
+    ///     "reshape",
+    ///     ErrorPhase::GraphBuild,
+    ///     ShapeMismatch::ReshapeElementCount { from: 2, to: 3 }.into(),
+    /// );
+    /// assert_eq!(
+    ///     error.kind(),
+    ///     ErrorKind::Validation(ValidationKind::ShapeMismatch)
+    /// );
+    /// assert_eq!(error.phase(), Some(ErrorPhase::GraphBuild));
+    /// ```
+    pub fn validation(op: &'static str, phase: ErrorPhase, source: ValidationError) -> Self {
+        Self::Validation { op, phase, source }
+    }
+
+    /// Construct a validation error for a caller-controlled argument whose
+    /// failure does not have a more specific shared payload.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::{Error, ErrorPhase};
+    ///
+    /// let error = Error::invalid_argument(
+    ///     "broadcast_in_dim",
+    ///     ErrorPhase::GraphBuild,
+    ///     "dims",
+    ///     "dimension mapping has the wrong length",
+    /// );
+    /// assert!(matches!(error, Error::Validation { .. }));
+    /// ```
+    pub fn invalid_argument(
+        op: &'static str,
+        phase: ErrorPhase,
+        argument: &'static str,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::validation(
+            op,
+            phase,
+            ValidationError::InvalidArgument {
+                argument,
+                message: message.into(),
+            },
+        )
+    }
+
+    /// Return the stable coarse classification of this runtime failure.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::{Error, ErrorPhase};
+    /// use tenferro_tensor::{ErrorKind, ValidationError, ValidationKind};
+    ///
+    /// let error = Error::validation(
+    ///     "transpose",
+    ///     ErrorPhase::GraphBuild,
+    ///     ValidationError::AxisOutOfBounds { axis: 2, rank: 2 },
+    /// );
+    /// assert_eq!(error.kind(), ErrorKind::Validation(ValidationKind::AxisOutOfBounds));
+    /// ```
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            Self::Validation { source, .. } => ErrorKind::Validation(source.kind()),
+            Self::InvalidSubscripts(_) => ErrorKind::Validation(ValidationKind::InvalidArgument),
+            Self::ContractionError(_) => ErrorKind::RuntimeState,
+            Self::MissingInput(_)
+            | Self::UnexpectedBinding { .. }
+            | Self::UnboundPlaceholder { .. }
+            | Self::DuplicateBinding { .. }
+            | Self::ContextMismatch { .. } => ErrorKind::RuntimeState,
+            Self::NonScalarGrad { .. } => ErrorKind::Validation(ValidationKind::InvalidArgument),
+            Self::TensorRuntime(error) => error.kind(),
+            Self::Metadata { .. } => ErrorKind::Internal,
+            Self::PlaceholderDtypeMismatch { .. } => {
+                ErrorKind::Validation(ValidationKind::DTypeMismatch)
+            }
+            Self::PlaceholderShapeMismatch { .. } => {
+                ErrorKind::Validation(ValidationKind::ShapeMismatch)
+            }
+            Self::PlaceholderRankMismatch { .. } => {
+                ErrorKind::Validation(ValidationKind::RankMismatch)
+            }
+            Self::UnsupportedAdRule { .. } => ErrorKind::Unsupported,
+            Self::ShapeConstraintViolation { .. } => {
+                ErrorKind::Validation(ValidationKind::ShapeMismatch)
+            }
+            Self::ShapeConstraintEvaluation { .. } => {
+                ErrorKind::Validation(ValidationKind::InvalidArgument)
+            }
+            Self::Internal(_) => ErrorKind::Internal,
+        }
+    }
+
+    /// Return the discovery phase when this error has one.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::{Error, ErrorPhase};
+    /// use tenferro_tensor::ValidationError;
+    ///
+    /// let error = Error::validation(
+    ///     "reshape",
+    ///     ErrorPhase::Compile,
+    ///     ValidationError::RankMismatch { expected: 2, actual: 1 },
+    /// );
+    /// assert_eq!(error.phase(), Some(ErrorPhase::Compile));
+    /// ```
+    pub fn phase(&self) -> Option<ErrorPhase> {
+        match self {
+            Self::Validation { phase, .. } => Some(*phase),
+            Self::TensorRuntime(_) => Some(ErrorPhase::Execution),
+            Self::Metadata { .. } => Some(ErrorPhase::Compile),
+            Self::PlaceholderDtypeMismatch { .. }
+            | Self::PlaceholderShapeMismatch { .. }
+            | Self::PlaceholderRankMismatch { .. }
+            | Self::UnexpectedBinding { .. }
+            | Self::UnboundPlaceholder { .. }
+            | Self::DuplicateBinding { .. } => Some(ErrorPhase::Execution),
+            _ => None,
+        }
+    }
 }
 
 /// Opaque identifier for an eager AD runtime, used in [`Error::ContextMismatch`].

--- a/crates/tenferro-runtime/src/error.rs
+++ b/crates/tenferro-runtime/src/error.rs
@@ -275,6 +275,16 @@ pub enum Error {
         op: String,
     },
 
+    /// A typed AD rule source that crossed an external message-only callback.
+    #[error("{transform} AD rule failed: {source}")]
+    AdRuleSource {
+        /// AD transform that requested the rule.
+        transform: &'static str,
+        /// Original typed source from the AD rule context.
+        #[source]
+        source: BoxError,
+    },
+
     /// A symbolic extension shape equality evaluated to unequal dimensions.
     #[error(
         "extension family {family:?} shape constraint at instruction {instruction_index:?} failed: {lhs_expr} ({lhs_value}) {relation:?} {rhs_expr} ({rhs_value})"
@@ -530,6 +540,31 @@ impl Error {
         }
     }
 
+    /// Preserve a typed source returned by an AD rule through a callback
+    /// protocol that can carry only a rendered message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::error::Error as _;
+    /// use tenferro_runtime::Error;
+    ///
+    /// let error = Error::ad_rule_source(
+    ///     "jvp",
+    ///     std::io::Error::other("shape metadata missing"),
+    /// );
+    /// assert!(error.source().is_some());
+    /// ```
+    pub fn ad_rule_source<E>(transform: &'static str, source: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        Self::AdRuleSource {
+            transform,
+            source: Box::new(source),
+        }
+    }
+
     /// Construct an operation-level unsupported error with an explicit
     /// discovery phase.
     ///
@@ -580,6 +615,7 @@ impl Error {
             | Self::ContextMismatch { .. } => ErrorKind::RuntimeState,
             Self::NonScalarGrad { .. } => ErrorKind::Validation(ValidationKind::InvalidArgument),
             Self::Unsupported { .. } | Self::UnsupportedAdRule { .. } => ErrorKind::Unsupported,
+            Self::AdRuleSource { .. } => ErrorKind::Validation(ValidationKind::InvalidArgument),
             Self::TensorRuntime(error) => error.kind(),
             Self::Extension { kind, .. } => *kind,
             Self::RuntimeState { .. } | Self::RuntimeStateSource { .. } => ErrorKind::RuntimeState,
@@ -632,6 +668,7 @@ impl Error {
             Self::RuntimeState { phase, .. } | Self::RuntimeStateSource { phase, .. } => {
                 Some(*phase)
             }
+            Self::AdRuleSource { .. } => Some(ErrorPhase::GraphBuild),
             Self::PlaceholderDtypeMismatch { .. }
             | Self::PlaceholderShapeMismatch { .. }
             | Self::PlaceholderRankMismatch { .. }

--- a/crates/tenferro-runtime/src/error.rs
+++ b/crates/tenferro-runtime/src/error.rs
@@ -3,16 +3,21 @@
 //! # Examples
 //!
 //! ```rust
-//! use tenferro_runtime::error::Error;
+//! use tenferro_runtime::error::{Error, ErrorPhase};
 //!
-//! let err = Error::InvalidSubscripts("bad label".into());
+//! let err = Error::invalid_argument(
+//!     "einsum",
+//!     ErrorPhase::GraphBuild,
+//!     "subscripts",
+//!     "bad label",
+//! );
 //! assert!(err.to_string().contains("bad label"));
 //! ```
 
 use std::error::Error as StdError;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use tenferro_ops::ShapeRelation;
+use tenferro_ops::{dim_expr::DimExprEvalError, ShapeRelation, SymDimConversionError};
 use tenferro_tensor::{DType, ErrorKind, ValidationError, ValidationKind};
 
 static NEXT_CONTEXT_ID: AtomicUsize = AtomicUsize::new(1);
@@ -94,14 +99,47 @@ pub enum ShapeConstraintEvalError {
     DivisionByZero,
 }
 
+impl From<DimExprEvalError> for ShapeConstraintEvalError {
+    fn from(error: DimExprEvalError) -> Self {
+        match error {
+            DimExprEvalError::InputOutOfBounds {
+                input_idx,
+                input_count,
+            } => Self::MissingInput {
+                input_idx,
+                input_count,
+            },
+            DimExprEvalError::AxisOutOfBounds {
+                input_idx,
+                axis,
+                rank,
+            } => Self::AxisOutOfBounds {
+                input_idx,
+                axis,
+                rank,
+            },
+            DimExprEvalError::AddOverflow { .. } | DimExprEvalError::MulOverflow { .. } => {
+                Self::Overflow
+            }
+            DimExprEvalError::SubUnderflow { .. } => Self::Underflow,
+            DimExprEvalError::FloorDivByZero { .. } => Self::DivisionByZero,
+        }
+    }
+}
+
 /// Errors produced by einsum, eval, and other tenferro operations.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use tenferro_runtime::error::Error;
+/// use tenferro_runtime::error::{Error, ErrorPhase};
 ///
-/// let err = Error::InvalidSubscripts("rank mismatch".into());
+/// let err = Error::invalid_argument(
+///     "einsum",
+///     ErrorPhase::GraphBuild,
+///     "subscripts",
+///     "rank mismatch",
+/// );
 /// ```
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -117,14 +155,6 @@ pub enum Error {
         source: ValidationError,
     },
 
-    /// Einsum subscript string is invalid or cannot be parsed.
-    #[error("invalid subscripts: {0}")]
-    InvalidSubscripts(String),
-
-    /// Contraction optimization failed (shape mismatch, bad path, etc.).
-    #[error("contraction error: {0}")]
-    ContractionError(String),
-
     /// A required input tensor is missing from the inputs map.
     #[error("missing input: {0}")]
     MissingInput(String),
@@ -133,14 +163,57 @@ pub enum Error {
     #[error("grad requires a scalar output, got shape {shape:?}")]
     NonScalarGrad { shape: Vec<usize> },
 
+    /// The operation is known not to support the requested input or
+    /// configuration at the phase where it was requested.
+    #[error("{op} ({phase:?}) is unsupported: {message}")]
+    Unsupported {
+        /// Operation that does not provide the requested behavior.
+        op: &'static str,
+        /// Phase that established the unsupported combination.
+        phase: ErrorPhase,
+        /// Human-readable unsupported-operation detail.
+        message: String,
+    },
+
     /// Runtime tensor execution failed in the backend layer.
     #[error(transparent)]
     TensorRuntime(#[from] tenferro_tensor::Error),
 
-    /// A runtime metadata or registry subsystem failed with a typed source.
-    #[error("runtime metadata failure: {source}")]
-    Metadata {
-        /// Typed metadata subsystem source.
+    /// A typed extension-domain error crossed a runtime registry boundary.
+    #[error("extension {family} ({phase:?}) failed for {op}: {source}")]
+    Extension {
+        /// Operation that discovered the extension failure.
+        op: &'static str,
+        /// Phase that discovered the extension failure.
+        phase: ErrorPhase,
+        /// Stable extension family identifier.
+        family: &'static str,
+        /// Coarse classification supplied by the extension owner.
+        kind: ErrorKind,
+        /// Original extension-domain source.
+        #[source]
+        source: BoxError,
+    },
+
+    /// Executor, cache, registry, or device state is unavailable or invalid.
+    #[error("{op} ({phase:?}): runtime state failure: {message}")]
+    RuntimeState {
+        /// Operation whose state was unavailable.
+        op: &'static str,
+        /// Phase that discovered the invalid state.
+        phase: ErrorPhase,
+        /// Human-readable state detail.
+        message: String,
+    },
+
+    /// A runtime-state failure retaining a typed source.
+    #[error("{op} ({phase:?}): runtime state failure: {source}")]
+    RuntimeStateSource {
+        /// Operation whose state was unavailable.
+        op: &'static str,
+        /// Phase that discovered the invalid state.
+        phase: ErrorPhase,
+        /// Typed state source.
         #[source]
         source: BoxError,
     },
@@ -241,6 +314,30 @@ pub enum Error {
         cause: ShapeConstraintEvalError,
     },
 
+    /// A symbolic dimension could not be converted into the graph's local
+    /// dimension-expression vocabulary.
+    #[error("{op} ({phase:?}): symbolic shape conversion failed: {source}")]
+    SymbolicShapeConversion {
+        /// Operation that requested the symbolic shape conversion.
+        op: &'static str,
+        /// Phase that discovered the invalid symbolic reference.
+        phase: ErrorPhase,
+        /// Typed symbolic-dimension conversion failure.
+        #[source]
+        source: SymDimConversionError,
+    },
+
+    /// A runtime dimension expression could not be evaluated for concrete
+    /// input shapes.
+    #[error("runtime shape expression {expression} could not evaluate: {cause}")]
+    ShapeExpressionEvaluation {
+        /// Expression that failed during execution.
+        expression: String,
+        /// Typed evaluation failure.
+        #[source]
+        cause: ShapeConstraintEvalError,
+    },
+
     /// An unexpected internal error.
     #[error("internal error: {0}")]
     Internal(String),
@@ -309,6 +406,155 @@ impl Error {
         )
     }
 
+    /// Construct a dtype-mismatch validation error using the runtime dtype
+    /// vocabulary.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::{DType, Error, ErrorPhase};
+    /// use tenferro_tensor::{ErrorKind, ValidationKind};
+    ///
+    /// let error = Error::dtype_mismatch(
+    ///     "add",
+    ///     ErrorPhase::GraphBuild,
+    ///     DType::F32,
+    ///     DType::F64,
+    /// );
+    /// assert_eq!(error.kind(), ErrorKind::Validation(ValidationKind::DTypeMismatch));
+    /// ```
+    pub fn dtype_mismatch(
+        op: &'static str,
+        phase: ErrorPhase,
+        expected: DType,
+        actual: DType,
+    ) -> Self {
+        Self::validation(
+            op,
+            phase,
+            ValidationError::DTypeMismatch {
+                expected: core_dtype(expected),
+                actual: core_dtype(actual),
+            },
+        )
+    }
+
+    /// Preserve a typed extension-domain source at the runtime boundary.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::error::Error as _;
+    /// use tenferro_runtime::{Error, ErrorPhase};
+    /// use tenferro_tensor::ErrorKind;
+    ///
+    /// let source = std::io::Error::new(std::io::ErrorKind::Other, "extension failed");
+    /// let error = Error::extension(
+    ///     "einsum",
+    ///     ErrorPhase::GraphBuild,
+    ///     "example.extension.v1",
+    ///     ErrorKind::RuntimeState,
+    ///     source,
+    /// );
+    /// assert_eq!(error.kind(), ErrorKind::RuntimeState);
+    /// assert!(error.source().is_some());
+    /// ```
+    pub fn extension<E>(
+        op: &'static str,
+        phase: ErrorPhase,
+        family: &'static str,
+        kind: ErrorKind,
+        source: E,
+    ) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        Self::Extension {
+            op,
+            phase,
+            family,
+            kind,
+            source: Box::new(source),
+        }
+    }
+
+    /// Construct a runtime-state failure for an unavailable or invalid
+    /// executor, cache, registry, or device state.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::{Error, ErrorPhase};
+    /// use tenferro_tensor::ErrorKind;
+    ///
+    /// let error = Error::runtime_state(
+    ///     "executor",
+    ///     ErrorPhase::Execution,
+    ///     "the executor is not initialized",
+    /// );
+    /// assert_eq!(error.kind(), ErrorKind::RuntimeState);
+    /// ```
+    pub fn runtime_state(op: &'static str, phase: ErrorPhase, message: impl Into<String>) -> Self {
+        Self::RuntimeState {
+            op,
+            phase,
+            message: message.into(),
+        }
+    }
+
+    /// Preserve a typed source for an unavailable or invalid runtime state.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::error::Error as _;
+    /// use tenferro_runtime::{Error, ErrorPhase};
+    /// use tenferro_tensor::ErrorKind;
+    ///
+    /// let error = Error::runtime_state_source(
+    ///     "metadata",
+    ///     ErrorPhase::Compile,
+    ///     std::io::Error::other("registry lock poisoned"),
+    /// );
+    /// assert_eq!(error.kind(), ErrorKind::RuntimeState);
+    /// assert!(error.source().is_some());
+    /// ```
+    pub fn runtime_state_source<E>(op: &'static str, phase: ErrorPhase, source: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        Self::RuntimeStateSource {
+            op,
+            phase,
+            source: Box::new(source),
+        }
+    }
+
+    /// Construct an operation-level unsupported error with an explicit
+    /// discovery phase.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_runtime::{Error, ErrorPhase};
+    /// use tenferro_tensor::ErrorKind;
+    ///
+    /// let error = Error::unsupported(
+    ///     "compare",
+    ///     ErrorPhase::Compile,
+    ///     "complex values have no total order",
+    /// );
+    /// assert_eq!(error.kind(), ErrorKind::Unsupported);
+    /// assert_eq!(error.phase(), Some(ErrorPhase::Compile));
+    /// ```
+    pub fn unsupported(op: &'static str, phase: ErrorPhase, message: impl Into<String>) -> Self {
+        Self::Unsupported {
+            op,
+            phase,
+            message: message.into(),
+        }
+    }
+
     /// Return the stable coarse classification of this runtime failure.
     ///
     /// # Examples
@@ -327,16 +573,16 @@ impl Error {
     pub fn kind(&self) -> ErrorKind {
         match self {
             Self::Validation { source, .. } => ErrorKind::Validation(source.kind()),
-            Self::InvalidSubscripts(_) => ErrorKind::Validation(ValidationKind::InvalidArgument),
-            Self::ContractionError(_) => ErrorKind::RuntimeState,
             Self::MissingInput(_)
             | Self::UnexpectedBinding { .. }
             | Self::UnboundPlaceholder { .. }
             | Self::DuplicateBinding { .. }
             | Self::ContextMismatch { .. } => ErrorKind::RuntimeState,
             Self::NonScalarGrad { .. } => ErrorKind::Validation(ValidationKind::InvalidArgument),
+            Self::Unsupported { .. } | Self::UnsupportedAdRule { .. } => ErrorKind::Unsupported,
             Self::TensorRuntime(error) => error.kind(),
-            Self::Metadata { .. } => ErrorKind::Internal,
+            Self::Extension { kind, .. } => *kind,
+            Self::RuntimeState { .. } | Self::RuntimeStateSource { .. } => ErrorKind::RuntimeState,
             Self::PlaceholderDtypeMismatch { .. } => {
                 ErrorKind::Validation(ValidationKind::DTypeMismatch)
             }
@@ -346,11 +592,16 @@ impl Error {
             Self::PlaceholderRankMismatch { .. } => {
                 ErrorKind::Validation(ValidationKind::RankMismatch)
             }
-            Self::UnsupportedAdRule { .. } => ErrorKind::Unsupported,
             Self::ShapeConstraintViolation { .. } => {
                 ErrorKind::Validation(ValidationKind::ShapeMismatch)
             }
             Self::ShapeConstraintEvaluation { .. } => {
+                ErrorKind::Validation(ValidationKind::InvalidArgument)
+            }
+            Self::SymbolicShapeConversion { .. } => {
+                ErrorKind::Validation(ValidationKind::InvalidArgument)
+            }
+            Self::ShapeExpressionEvaluation { .. } => {
                 ErrorKind::Validation(ValidationKind::InvalidArgument)
             }
             Self::Internal(_) => ErrorKind::Internal,
@@ -376,15 +627,33 @@ impl Error {
         match self {
             Self::Validation { phase, .. } => Some(*phase),
             Self::TensorRuntime(_) => Some(ErrorPhase::Execution),
-            Self::Metadata { .. } => Some(ErrorPhase::Compile),
+            Self::Unsupported { phase, .. } => Some(*phase),
+            Self::Extension { phase, .. } => Some(*phase),
+            Self::RuntimeState { phase, .. } | Self::RuntimeStateSource { phase, .. } => {
+                Some(*phase)
+            }
             Self::PlaceholderDtypeMismatch { .. }
             | Self::PlaceholderShapeMismatch { .. }
             | Self::PlaceholderRankMismatch { .. }
             | Self::UnexpectedBinding { .. }
             | Self::UnboundPlaceholder { .. }
             | Self::DuplicateBinding { .. } => Some(ErrorPhase::Execution),
+            Self::SymbolicShapeConversion { phase, .. } => Some(*phase),
+            Self::ShapeExpressionEvaluation { .. } => Some(ErrorPhase::Execution),
             _ => None,
         }
+    }
+}
+
+fn core_dtype(dtype: DType) -> tenferro_tensor::core::DType {
+    match dtype {
+        DType::F32 => tenferro_tensor::core::DType::F32,
+        DType::F64 => tenferro_tensor::core::DType::F64,
+        DType::I32 => tenferro_tensor::core::DType::I32,
+        DType::I64 => tenferro_tensor::core::DType::I64,
+        DType::Bool => tenferro_tensor::core::DType::Bool,
+        DType::C32 => tenferro_tensor::core::DType::C32,
+        DType::C64 => tenferro_tensor::core::DType::C64,
     }
 }
 
@@ -412,3 +681,424 @@ impl std::fmt::Display for ContextId {
 
 /// Result type alias for tenferro operations.
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as StdError;
+
+    use tenferro_ops::dim_expr::{DimExpr, DimExprEvalError};
+    use tenferro_tensor::{
+        DType, ErrorKind, ShapeMismatch, ShapeVec, ValidationError, ValidationKind,
+    };
+
+    use super::{ContextId, Error, ErrorPhase, ShapeConstraintEvalError};
+
+    #[test]
+    fn dimension_evaluation_errors_keep_the_runtime_vocabulary() {
+        let cases = [
+            (
+                DimExpr::InputDim {
+                    input_idx: 2,
+                    axis: 0,
+                }
+                .eval(&[&[1usize]])
+                .unwrap_err(),
+                ShapeConstraintEvalError::MissingInput {
+                    input_idx: 2,
+                    input_count: 1,
+                },
+            ),
+            (
+                DimExpr::InputDim {
+                    input_idx: 0,
+                    axis: 2,
+                }
+                .eval(&[&[1usize]])
+                .unwrap_err(),
+                ShapeConstraintEvalError::AxisOutOfBounds {
+                    input_idx: 0,
+                    axis: 2,
+                    rank: 1,
+                },
+            ),
+            (
+                DimExpr::Add(
+                    Box::new(DimExpr::Const(usize::MAX)),
+                    Box::new(DimExpr::Const(1)),
+                )
+                .eval(&[])
+                .unwrap_err(),
+                ShapeConstraintEvalError::Overflow,
+            ),
+            (
+                DimExpr::Mul(
+                    Box::new(DimExpr::Const(usize::MAX)),
+                    Box::new(DimExpr::Const(2)),
+                )
+                .eval(&[])
+                .unwrap_err(),
+                ShapeConstraintEvalError::Overflow,
+            ),
+            (
+                DimExpr::Sub(Box::new(DimExpr::Const(0)), Box::new(DimExpr::Const(1)))
+                    .eval(&[])
+                    .unwrap_err(),
+                ShapeConstraintEvalError::Underflow,
+            ),
+            (
+                DimExpr::FloorDiv(Box::new(DimExpr::Const(1)), Box::new(DimExpr::Const(0)))
+                    .eval(&[])
+                    .unwrap_err(),
+                ShapeConstraintEvalError::DivisionByZero,
+            ),
+        ];
+
+        for (actual, expected) in cases {
+            assert_eq!(ShapeConstraintEvalError::from(actual), expected);
+        }
+
+        assert_eq!(
+            ShapeConstraintEvalError::from(DimExprEvalError::AddOverflow { lhs: 1, rhs: 2 }),
+            ShapeConstraintEvalError::Overflow
+        );
+    }
+
+    #[test]
+    fn constructors_preserve_classification_and_typed_sources() {
+        let shape = Error::validation(
+            "reshape",
+            ErrorPhase::GraphBuild,
+            ShapeMismatch::ExpectedActual {
+                expected: ShapeVec::from_vec(vec![2, 3]),
+                actual: ShapeVec::from_vec(vec![6]),
+            }
+            .into(),
+        );
+        assert_eq!(
+            shape.kind(),
+            ErrorKind::Validation(ValidationKind::ShapeMismatch)
+        );
+        assert_eq!(shape.phase(), Some(ErrorPhase::GraphBuild));
+
+        let invalid =
+            Error::invalid_argument("slice", ErrorPhase::Compile, "step", "must be non-zero");
+        assert!(matches!(
+            invalid,
+            Error::Validation {
+                source: ValidationError::InvalidArgument {
+                    argument: "step",
+                    ..
+                },
+                ..
+            }
+        ));
+
+        for dtype in [
+            DType::F32,
+            DType::F64,
+            DType::I32,
+            DType::I64,
+            DType::Bool,
+            DType::C32,
+            DType::C64,
+        ] {
+            let error = Error::dtype_mismatch("cast", ErrorPhase::GraphBuild, dtype, dtype);
+            assert!(matches!(
+                error,
+                Error::Validation {
+                    source: ValidationError::DTypeMismatch { .. },
+                    ..
+                }
+            ));
+        }
+
+        let extension = Error::extension(
+            "extension",
+            ErrorPhase::Compile,
+            "example.v1",
+            ErrorKind::Io,
+            std::io::Error::other("manifest read failed"),
+        );
+        assert_eq!(extension.kind(), ErrorKind::Io);
+        assert!(StdError::source(&extension).is_some());
+
+        let state = Error::runtime_state(
+            "executor",
+            ErrorPhase::Execution,
+            "executor is not initialized",
+        );
+        assert_eq!(state.kind(), ErrorKind::RuntimeState);
+        let state_source = Error::runtime_state_source(
+            "registry",
+            ErrorPhase::Compile,
+            std::io::Error::other("registry lock poisoned"),
+        );
+        assert_eq!(state_source.kind(), ErrorKind::RuntimeState);
+        assert!(StdError::source(&state_source).is_some());
+        let unsupported = Error::unsupported(
+            "compare",
+            ErrorPhase::Compile,
+            "complex values have no total order",
+        );
+        assert_eq!(unsupported.kind(), ErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn kind_classifies_every_runtime_variant_without_string_inspection() {
+        let errors = [
+            (
+                Error::validation(
+                    "shape",
+                    ErrorPhase::GraphBuild,
+                    ValidationError::RankMismatch {
+                        expected: 2,
+                        actual: 1,
+                    },
+                ),
+                ErrorKind::Validation(ValidationKind::RankMismatch),
+            ),
+            (Error::MissingInput("x".into()), ErrorKind::RuntimeState),
+            (
+                Error::NonScalarGrad { shape: vec![2] },
+                ErrorKind::Validation(ValidationKind::InvalidArgument),
+            ),
+            (
+                Error::unsupported("op", ErrorPhase::Compile, "missing rule"),
+                ErrorKind::Unsupported,
+            ),
+            (
+                Error::TensorRuntime(tenferro_tensor::Error::unsupported("op", "not available")),
+                ErrorKind::Unsupported,
+            ),
+            (
+                Error::extension(
+                    "op",
+                    ErrorPhase::Execution,
+                    "family.v1",
+                    ErrorKind::NumericalFailure,
+                    std::io::Error::other("numerical source"),
+                ),
+                ErrorKind::NumericalFailure,
+            ),
+            (
+                Error::runtime_state("op", ErrorPhase::Execution, "state"),
+                ErrorKind::RuntimeState,
+            ),
+            (
+                Error::runtime_state_source(
+                    "op",
+                    ErrorPhase::Execution,
+                    std::io::Error::other("state"),
+                ),
+                ErrorKind::RuntimeState,
+            ),
+            (
+                Error::UnexpectedBinding { binding_index: 0 },
+                ErrorKind::RuntimeState,
+            ),
+            (
+                Error::UnboundPlaceholder {
+                    input_key: "x".into(),
+                },
+                ErrorKind::RuntimeState,
+            ),
+            (
+                Error::DuplicateBinding {
+                    input_key: "x".into(),
+                },
+                ErrorKind::RuntimeState,
+            ),
+            (
+                Error::PlaceholderDtypeMismatch {
+                    expected: DType::F32,
+                    actual: DType::F64,
+                },
+                ErrorKind::Validation(ValidationKind::DTypeMismatch),
+            ),
+            (
+                Error::PlaceholderShapeMismatch {
+                    expected: vec![2],
+                    actual: vec![3],
+                },
+                ErrorKind::Validation(ValidationKind::ShapeMismatch),
+            ),
+            (
+                Error::PlaceholderRankMismatch {
+                    expected: 2,
+                    actual: 1,
+                },
+                ErrorKind::Validation(ValidationKind::RankMismatch),
+            ),
+            (
+                Error::ContextMismatch {
+                    lhs: ContextId::fresh(),
+                    rhs: ContextId::fresh(),
+                },
+                ErrorKind::RuntimeState,
+            ),
+            (
+                Error::UnsupportedAdRule {
+                    transform: "vjp",
+                    op: "example".into(),
+                },
+                ErrorKind::Unsupported,
+            ),
+            (
+                Error::ShapeConstraintViolation {
+                    family: "example.v1",
+                    instruction_index: Some(3),
+                    relation: tenferro_ops::ShapeRelation::Equal,
+                    lhs_expr: "m".into(),
+                    rhs_expr: "n".into(),
+                    lhs_value: 2,
+                    rhs_value: 3,
+                },
+                ErrorKind::Validation(ValidationKind::ShapeMismatch),
+            ),
+            (
+                Error::ShapeConstraintEvaluation {
+                    family: "example.v1",
+                    instruction_index: None,
+                    relation: tenferro_ops::ShapeRelation::Equal,
+                    expression: "m+n".into(),
+                    cause: ShapeConstraintEvalError::Overflow,
+                },
+                ErrorKind::Validation(ValidationKind::InvalidArgument),
+            ),
+            (
+                Error::SymbolicShapeConversion {
+                    op: "broadcast",
+                    phase: ErrorPhase::GraphBuild,
+                    source: tenferro_ops::SymDimConversionError { tensor_id: 7 },
+                },
+                ErrorKind::Validation(ValidationKind::InvalidArgument),
+            ),
+            (
+                Error::ShapeExpressionEvaluation {
+                    expression: "m/0".into(),
+                    cause: ShapeConstraintEvalError::DivisionByZero,
+                },
+                ErrorKind::Validation(ValidationKind::InvalidArgument),
+            ),
+            (Error::Internal("invariant".into()), ErrorKind::Internal),
+        ];
+
+        for (error, expected) in errors {
+            assert_eq!(error.kind(), expected, "classified {error:?}");
+        }
+    }
+
+    #[test]
+    fn phase_reports_discovery_axis_separately_from_kind() {
+        let with_phase = [
+            Error::validation(
+                "op",
+                ErrorPhase::GraphBuild,
+                ValidationError::InvalidArgument {
+                    argument: "x",
+                    message: "bad".into(),
+                },
+            ),
+            Error::TensorRuntime(tenferro_tensor::Error::invalid_argument("op", "x", "bad")),
+            Error::unsupported("op", ErrorPhase::Compile, "unsupported"),
+            Error::extension(
+                "op",
+                ErrorPhase::GraphBuild,
+                "family.v1",
+                ErrorKind::Internal,
+                std::io::Error::other("extension"),
+            ),
+            Error::runtime_state("op", ErrorPhase::Execution, "state"),
+            Error::runtime_state_source("op", ErrorPhase::Compile, std::io::Error::other("state")),
+            Error::PlaceholderDtypeMismatch {
+                expected: DType::F32,
+                actual: DType::F64,
+            },
+            Error::PlaceholderShapeMismatch {
+                expected: vec![2],
+                actual: vec![3],
+            },
+            Error::PlaceholderRankMismatch {
+                expected: 2,
+                actual: 1,
+            },
+            Error::UnexpectedBinding { binding_index: 0 },
+            Error::UnboundPlaceholder {
+                input_key: "x".into(),
+            },
+            Error::DuplicateBinding {
+                input_key: "x".into(),
+            },
+            Error::SymbolicShapeConversion {
+                op: "op",
+                phase: ErrorPhase::Compile,
+                source: tenferro_ops::SymDimConversionError { tensor_id: 1 },
+            },
+            Error::ShapeExpressionEvaluation {
+                expression: "m".into(),
+                cause: ShapeConstraintEvalError::Overflow,
+            },
+        ];
+        let expected = [
+            Some(ErrorPhase::GraphBuild),
+            Some(ErrorPhase::Execution),
+            Some(ErrorPhase::Compile),
+            Some(ErrorPhase::GraphBuild),
+            Some(ErrorPhase::Execution),
+            Some(ErrorPhase::Compile),
+            Some(ErrorPhase::Execution),
+            Some(ErrorPhase::Execution),
+            Some(ErrorPhase::Execution),
+            Some(ErrorPhase::Execution),
+            Some(ErrorPhase::Execution),
+            Some(ErrorPhase::Execution),
+            Some(ErrorPhase::Compile),
+            Some(ErrorPhase::Execution),
+        ];
+        for (error, expected) in with_phase.into_iter().zip(expected) {
+            assert_eq!(error.phase(), expected);
+        }
+
+        let without_phase = [
+            Error::MissingInput("x".into()),
+            Error::NonScalarGrad { shape: vec![2] },
+            Error::ContextMismatch {
+                lhs: ContextId::fresh(),
+                rhs: ContextId::fresh(),
+            },
+            Error::UnsupportedAdRule {
+                transform: "jvp",
+                op: "example".into(),
+            },
+            Error::ShapeConstraintViolation {
+                family: "example.v1",
+                instruction_index: None,
+                relation: tenferro_ops::ShapeRelation::Equal,
+                lhs_expr: "m".into(),
+                rhs_expr: "n".into(),
+                lhs_value: 1,
+                rhs_value: 2,
+            },
+            Error::ShapeConstraintEvaluation {
+                family: "example.v1",
+                instruction_index: None,
+                relation: tenferro_ops::ShapeRelation::Equal,
+                expression: "m".into(),
+                cause: ShapeConstraintEvalError::Overflow,
+            },
+            Error::Internal("invariant".into()),
+        ];
+        for error in without_phase {
+            assert_eq!(error.phase(), None);
+        }
+    }
+
+    #[test]
+    fn context_ids_are_opaque_but_displayable() {
+        let first = ContextId::fresh();
+        let second = ContextId::fresh();
+
+        assert_ne!(first, second);
+        assert!(first.to_string().starts_with("ctx@"));
+    }
+}

--- a/crates/tenferro-runtime/src/exec.rs
+++ b/crates/tenferro-runtime/src/exec.rs
@@ -578,8 +578,10 @@ pub(crate) fn resolve_tensor_shape_exprs(
     for &slot in input_slots {
         input_shapes.push(slot_ref(slots, slot, "input", "resolve_tensor_shape_exprs")?.shape());
     }
-    DimExpr::eval_all(exprs, &input_shapes)
-        .map_err(|err| Error::Internal(format!("shape expression evaluation failed: {err}")))
+    DimExpr::eval_all(exprs, &input_shapes).map_err(|cause| Error::ShapeExpressionEvaluation {
+        expression: format!("{} expression(s)", exprs.len()),
+        cause: cause.into(),
+    })
 }
 
 pub(crate) fn ensure_core_exec_program(program: &ExecProgram, caller: &str) -> Result<()> {

--- a/crates/tenferro-runtime/src/exec.rs
+++ b/crates/tenferro-runtime/src/exec.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::error::{Error, Result};
+use crate::error::{Error, ErrorPhase, Result};
 use num_complex::{Complex32, Complex64};
 use smallvec::SmallVec;
 use tenferro_ops::ext_op::ExtensionOp;
@@ -9,7 +9,7 @@ use tenferro_tensor::backend::ElementwiseFusionOp;
 use tenferro_tensor::Error as TensorError;
 use tenferro_tensor::{
     BackendSession, CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig,
-    SliceConfig, Tensor, TensorBackend, TensorRead, TensorValue, TypedTensor,
+    SliceConfig, Tensor, TensorBackend, TensorRead, TensorValue, TypedTensor, ValidationError,
 };
 
 use crate::extension_runtime::ExtensionExecutor;
@@ -189,9 +189,7 @@ impl<'a> ExecSlot<'a> {
 }
 
 fn invalid_compiled_graph(message: impl Into<String>) -> Error {
-    Error::InvalidCompiledGraph {
-        message: message.into(),
-    }
+    Error::Internal(message.into())
 }
 
 fn checked_input_slot(input_slots: &[usize], idx: usize, caller: &'static str) -> Result<usize> {
@@ -580,21 +578,24 @@ pub(crate) fn resolve_tensor_shape_exprs(
     for &slot in input_slots {
         input_shapes.push(slot_ref(slots, slot, "input", "resolve_tensor_shape_exprs")?.shape());
     }
-    DimExpr::eval_all(exprs, &input_shapes).map_err(|err| Error::InvalidCompiledGraph {
-        message: format!("shape expression evaluation failed: {err}"),
-    })
+    DimExpr::eval_all(exprs, &input_shapes)
+        .map_err(|err| Error::Internal(format!("shape expression evaluation failed: {err}")))
 }
 
 pub(crate) fn ensure_core_exec_program(program: &ExecProgram, caller: &str) -> Result<()> {
     for (idx, inst) in program.instructions.iter().enumerate() {
         if let ExecOp::Extension(ext) = &inst.op {
-            return Err(Error::TensorRuntime(TensorError::InvalidConfig {
-                op: "extension",
-                message: format!(
+            return Err(Error::validation(
+                "extension",
+                ErrorPhase::Execution,
+                ValidationError::InvalidArgument {
+                    argument: "program",
+                    message: format!(
                     "{caller} can execute only core ExecProgram instructions; instruction {idx} uses extension family_id {:?}",
                     ext.family_id()
-                ),
-            }));
+                    ),
+                },
+            ));
         }
     }
     Ok(())
@@ -924,26 +925,25 @@ fn execute_extension_instruction<B: TensorBackend + 'static>(
 ) -> Result<()> {
     let inputs = collect_tensor_refs(slots, &inst.input_slots)?;
     let Some(extension_executor) = extension_executor else {
-        return Err(Error::TensorRuntime(TensorError::InvalidConfig {
-            op: "extension",
-            message: format!(
+        return Err(Error::validation(
+            "extension",
+            ErrorPhase::Execution,
+            ValidationError::InvalidArgument {
+                argument: "executor",
+                message: format!(
                 "extension instruction for family_id {:?} requires an ExtensionExecutor; execute compiled programs through GraphExecutor and register the extension runtime on that executor",
                 ext.family_id()
-            ),
-        }));
+                ),
+            },
+        ));
     };
-    let outputs = extension_executor
-        .execute(backend, ext, &inputs)
-        .map_err(|err| {
-            Error::TensorRuntime(tenferro_tensor::Error::backend_failure(
-                "extension",
-                format!("family_id={:?}: {err}", ext.family_id()),
-            ))
-        })?;
+    let outputs = extension_executor.execute(backend, ext, &inputs)?;
     if outputs.len() != inst.output_slots.len() {
-        return Err(Error::TensorRuntime(
-            tenferro_tensor::Error::InvalidConfig {
-                op: "extension",
+        return Err(Error::validation(
+            "extension",
+            ErrorPhase::Execution,
+            ValidationError::InvalidArgument {
+                argument: "outputs",
                 message: format!(
                     "family_id={:?}: extension runtime returned {} outputs for {} slots",
                     ext.family_id(),

--- a/crates/tenferro-runtime/src/exec/dispatch.rs
+++ b/crates/tenferro-runtime/src/exec/dispatch.rs
@@ -325,11 +325,15 @@ fn execute_shape_of_host<B: HostExecution + ?Sized>(
     };
     let input = get_read(slots, &inst.input_slots, 0)?;
     if *axis >= input.shape().len() {
-        return Err(Error::Internal(format!(
-            "ShapeOf: axis {} out of bounds for rank {}",
-            axis,
-            input.shape().len()
-        )));
+        return Err(Error::invalid_argument(
+            "shape_of",
+            crate::ErrorPhase::Execution,
+            "axis",
+            format!(
+                "axis {axis} is out of bounds for rank {}",
+                input.shape().len()
+            ),
+        ));
     }
     let host = Tensor::F64(tenferro_tensor::TypedTensor::from_vec_col_major(
         vec![],
@@ -352,11 +356,15 @@ fn execute_dynamic_truncate_host<B: HostExecution + ?Sized>(
     };
     let input = get(slots, &inst.input_slots, 0)?;
     if *axis >= input.shape().len() {
-        return Err(Error::Internal(format!(
-            "DynamicTruncate: axis {} out of bounds for rank {}",
-            axis,
-            input.shape().len()
-        )));
+        return Err(Error::invalid_argument(
+            "dynamic_truncate",
+            crate::ErrorPhase::Execution,
+            "axis",
+            format!(
+                "axis {axis} is out of bounds for rank {}",
+                input.shape().len()
+            ),
+        ));
     }
     let size_tensor = backend.download_to_host(get(slots, &inst.input_slots, 1)?)?;
     let axis_extent = input.shape()[*axis];
@@ -387,11 +395,15 @@ fn execute_pad_to_match_host<B: HostExecution + ?Sized>(
     let input = get(slots, &inst.input_slots, 0)?;
     let reference = get(slots, &inst.input_slots, 1)?;
     if *axis >= input.shape().len() {
-        return Err(Error::Internal(format!(
-            "PadToMatch: axis {} out of bounds for rank {}",
-            axis,
-            input.shape().len()
-        )));
+        return Err(Error::invalid_argument(
+            "pad_to_match",
+            crate::ErrorPhase::Execution,
+            "axis",
+            format!(
+                "axis {axis} is out of bounds for rank {}",
+                input.shape().len()
+            ),
+        ));
     }
     let target_size = reference.shape()[*axis];
     let current_size = input.shape()[*axis];

--- a/crates/tenferro-runtime/src/exec/tests.rs
+++ b/crates/tenferro-runtime/src/exec/tests.rs
@@ -166,9 +166,7 @@ fn exec_accessors_reject_bad_input_slot_index_without_panicking() {
 
     let err = get(&slots, &[], 0).unwrap_err();
 
-    let message = err.to_string();
-    assert!(message.contains("invalid compiled graph"), "{message}");
-    assert!(message.contains("input index 0"), "{message}");
+    assert!(matches!(err, crate::Error::Internal(message) if message.contains("input index 0")));
 }
 
 #[test]

--- a/crates/tenferro-runtime/src/extension.rs
+++ b/crates/tenferro-runtime/src/extension.rs
@@ -126,11 +126,13 @@ pub fn execute_lowered_program_with_backend_cache<B: TensorBackend + 'static>(
 ///
 /// # Errors
 ///
-/// Returns a graph-build validation error when the extension receives the
-/// wrong number of traced inputs. Canonical metadata inference failures,
-/// including a returned metadata count that differs from
-/// [`ExtensionOp::output_count`], are returned as [`Error::TensorRuntime`]
-/// containing the typed tensor validation source.
+/// Returns [`Error::Validation`] with `ValidationError::InvalidArgument` when
+/// the extension receives the wrong number of traced inputs or produces an
+/// unknown output shape. Canonical metadata inference failures, including a
+/// returned metadata count that differs from [`ExtensionOp::output_count`],
+/// are returned as [`Error::TensorRuntime`] containing the typed tensor
+/// validation source, while poisoned metadata state is retained as
+/// [`Error::RuntimeStateSource`].
 pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Result<Vec<TracedTensor>> {
     if inputs.len() != op.input_count() {
         return Err(Error::invalid_argument(
@@ -427,6 +429,13 @@ pub fn apply_expanded_graph_with_shape_contract(
 /// This is for extension crates whose operation can be expanded at graph-build
 /// time. It preserves the same parent graph and metadata merging behavior as
 /// [`apply`], but does not insert a `StdTensorOp::Extension` carrier.
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`] with `InvalidArgument` when lowering produces
+/// an invalid output count or unknown output metadata, [`Error::Internal`] for
+/// an invalid graph reference, and [`Error::RuntimeStateSource`] when metadata
+/// registration cannot retain the lowered graph state.
 pub fn apply_expanded_graph(
     inputs: &[&TracedTensor],
     output_metas: Vec<(tenferro_tensor::DType, Vec<SymDim>)>,

--- a/crates/tenferro-runtime/src/extension.rs
+++ b/crates/tenferro-runtime/src/extension.rs
@@ -26,7 +26,7 @@ use tenferro_ops::SymDim;
 use tenferro_tensor::{Tensor, TensorBackend};
 
 use crate::checkpoint::CheckpointNode;
-use crate::error::{Error, Result};
+use crate::error::{Error, ErrorPhase, Result};
 use crate::metadata::{
     register_scoped_graph_analysis, registered_meta, MetadataScopeChain, RegisteredGraphAnalysis,
 };
@@ -126,22 +126,24 @@ pub fn execute_lowered_program_with_backend_cache<B: TensorBackend + 'static>(
 ///
 /// # Errors
 ///
-/// Returns [`Error::InvalidGraphBuild`] when the extension receives the wrong
-/// number of traced inputs. Canonical metadata inference failures, including a
-/// returned metadata count that differs from [`ExtensionOp::output_count`],
-/// are returned as [`Error::TensorRuntime`] containing
-/// [`tenferro_tensor::Error::InvalidConfig`].
+/// Returns a graph-build validation error when the extension receives the
+/// wrong number of traced inputs. Canonical metadata inference failures,
+/// including a returned metadata count that differs from
+/// [`ExtensionOp::output_count`], are returned as [`Error::TensorRuntime`]
+/// containing the typed tensor validation source.
 pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Result<Vec<TracedTensor>> {
     if inputs.len() != op.input_count() {
-        return Err(Error::InvalidGraphBuild {
-            op: "extension::apply",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "extension::apply",
+            ErrorPhase::GraphBuild,
+            "inputs",
+            format!(
                 "op family {:?} expects {} inputs, got {}",
                 op.family_id(),
                 op.input_count(),
                 inputs.len()
             ),
-        });
+        ));
     }
 
     // Build the carrier graph first; the graph-analysis pass below resolves
@@ -163,12 +165,16 @@ pub fn apply(op: Arc<dyn ExtensionOp>, inputs: &[&TracedTensor]) -> Result<Vec<T
         .iter()
         .map(|&output| {
             let meta = registered_meta(&graph.values()[output].key)?;
-            let shape = meta.bound_shape().ok_or_else(|| Error::InvalidGraphBuild {
-                op: "extension::apply",
-                message: format!(
-                    "extension family {:?} produced unknown output shape metadata",
-                    op.family_id()
-                ),
+            let shape = meta.bound_shape().ok_or_else(|| {
+                Error::invalid_argument(
+                    "extension::apply",
+                    ErrorPhase::Compile,
+                    "output_metadata",
+                    format!(
+                        "extension family {:?} produced unknown output shape metadata",
+                        op.family_id()
+                    ),
+                )
             })?;
             Ok((meta.dtype, shape))
         })
@@ -225,14 +231,16 @@ pub fn attach_expanded_shape_contract(
     output: TracedTensor,
 ) -> Result<TracedTensor> {
     if op.output_count() != 1 {
-        return Err(Error::InvalidGraphBuild {
-            op: "extension::attach_expanded_shape_contract",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "extension::attach_expanded_shape_contract",
+            ErrorPhase::GraphBuild,
+            "outputs",
+            format!(
                 "extension family {:?} contract expects {} outputs, got one expanded output",
                 op.family_id(),
                 op.output_count(),
             ),
-        });
+        ));
     }
     let (_, inferred) = infer_expanded_shape_contract(op, inputs)?;
     attach_inferred_expanded_shape_contract(inputs, vec![output], inferred)?
@@ -246,15 +254,17 @@ fn infer_expanded_shape_contract(
     inputs: &[&TracedTensor],
 ) -> Result<(ExpandedOutputMetas, InferredExtensionMeta)> {
     if inputs.len() != op.input_count() {
-        return Err(Error::InvalidGraphBuild {
-            op: "extension::infer_expanded_shape_contract",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "extension::infer_expanded_shape_contract",
+            ErrorPhase::GraphBuild,
+            "inputs",
+            format!(
                 "extension family {:?} contract expects {} inputs, got {}",
                 op.family_id(),
                 op.input_count(),
                 inputs.len()
             ),
-        });
+        ));
     }
     let input_dtypes: Vec<_> = inputs.iter().map(|input| input.dtype).collect();
     let input_shapes: Vec<_> = inputs
@@ -299,27 +309,31 @@ fn attach_inferred_expanded_shape_contract(
     inferred: InferredExtensionMeta,
 ) -> Result<Vec<TracedTensor>> {
     if inferred.output_metas.len() != outputs.len() {
-        return Err(Error::InvalidGraphBuild {
-            op: "extension::attach_expanded_shape_contract",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "extension::attach_expanded_shape_contract",
+            ErrorPhase::GraphBuild,
+            "outputs",
+            format!(
                 "extension contract inferred {} outputs, but expanded graph produced {}",
                 inferred.output_metas.len(),
                 outputs.len()
             ),
-        });
+        ));
     }
     for (output, (dtype, local_shape)) in outputs.iter().zip(inferred.output_metas.iter()) {
         if output.dtype != *dtype || output.rank != local_shape.len() {
-            return Err(Error::InvalidGraphBuild {
-                op: "extension::attach_expanded_shape_contract",
-                message: format!(
+            return Err(Error::invalid_argument(
+                "extension::attach_expanded_shape_contract",
+                ErrorPhase::GraphBuild,
+                "outputs",
+                format!(
                     "extension contract inferred output {:?} rank {}, but expanded output is {:?} rank {}",
                     dtype,
                     local_shape.len(),
                     output.dtype,
                     output.rank
                 ),
-            });
+            ));
         }
     }
     if inferred.constraints.is_empty() {
@@ -428,14 +442,16 @@ pub fn apply_expanded_graph(
         .collect();
     let outputs = build(&mut builder, &op_inputs)?;
     if outputs.len() != output_metas.len() {
-        return Err(Error::InvalidGraphBuild {
-            op: "extension::apply_expanded_graph",
-            message: format!(
+        return Err(Error::invalid_argument(
+            "extension::apply_expanded_graph",
+            ErrorPhase::GraphBuild,
+            "outputs",
+            format!(
                 "extension expanded graph returned {} outputs for {} output metadata entries",
                 outputs.len(),
                 output_metas.len()
             ),
-        });
+        ));
     }
     builder.set_outputs(outputs.clone());
     let graph = Arc::new(builder.build());

--- a/crates/tenferro-runtime/src/extension/tests.rs
+++ b/crates/tenferro-runtime/src/extension/tests.rs
@@ -1,7 +1,7 @@
 use computegraph::types::OperationRole;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tenferro_ops::{dim_expr::DimExpr, ShapeExtent};
-use tenferro_tensor::DType;
+use tenferro_tensor::{DType, ValidationError};
 
 use super::*;
 
@@ -83,14 +83,18 @@ fn apply_returns_error_for_output_metadata_count_mismatch() {
     };
 
     match err {
-        Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig { op, message }) => {
+        Error::TensorRuntime(tenferro_tensor::Error::Validation { op, source }) => {
             assert_eq!(op, "extension");
-            assert_eq!(
-                message,
-                "family_id=\"test.extension\": infer_output_meta produced 1 output metadata entries; op declared 2 outputs"
-            );
+            assert!(matches!(
+                source,
+                ValidationError::InvalidArgument {
+                    argument: "output metadata",
+                    message,
+                } if message.contains("family_id=\"test.extension\"")
+                    && message.contains("declared 2 outputs")
+            ));
         }
-        other => panic!("expected structured extension InvalidConfig, got {other:?}"),
+        other => panic!("expected structured extension validation error, got {other:?}"),
     }
 }
 

--- a/crates/tenferro-runtime/src/extension_runtime.rs
+++ b/crates/tenferro-runtime/src/extension_runtime.rs
@@ -115,6 +115,15 @@ impl<'a, B: TensorBackend> ExtensionExecutionContext<'a, B> {
     ///     .unwrap();
     /// assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[3.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with
+    /// `ValidationError::InvalidArgument` when the program has an invalid
+    /// input/slot contract, [`crate::Error::Internal`] when it contains a
+    /// nested extension or violates an execution-IR invariant, and
+    /// [`crate::Error::TensorRuntime`] when backend execution returns a typed
+    /// validation, backend, or runtime-state source.
     pub fn execute_core_exec_program_unsegmented(
         &mut self,
         program: &crate::extension::ExecProgram,
@@ -142,6 +151,15 @@ pub trait ExtensionRuntime<B: TensorBackend + 'static>: Debug + Send + Sync + 's
     fn family_id(&self) -> &'static str;
 
     /// Execute the extension op with backend and cache state supplied by core.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ValidationError::InvalidArgument` for an invalid input/output arity
+    /// or metadata contract, [`tenferro_tensor::Error::Unsupported`] when the
+    /// operation is not implemented, or a typed
+    /// [`tenferro_tensor::Error::BackendSource`] /
+    /// [`tenferro_tensor::Error::RuntimeStateSource`] from backend execution.
     fn execute(
         &self,
         op: &dyn ExtensionOp,
@@ -154,6 +172,14 @@ pub trait ExtensionRuntime<B: TensorBackend + 'static>: Debug + Send + Sync + 's
     /// Implementations that need compact tensors must materialize inputs here
     /// explicitly. Keeping this method required prevents implicit read-path
     /// fallbacks from hiding backend or view handling bugs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ValidationError::InvalidArgument` for an invalid input/output arity
+    /// or metadata contract, [`tenferro_tensor::Error::RuntimeStateSource`]
+    /// when a borrowed view cannot be materialized, or a typed
+    /// [`tenferro_tensor::Error::BackendSource`] from execution.
     fn execute_reads(
         &self,
         op: &dyn ExtensionOp,
@@ -324,6 +350,11 @@ impl<B: TensorBackend + 'static> ExtensionRegistry<B> {
     /// Registration is idempotent by family id: registering the same extension
     /// family more than once succeeds and keeps the first runtime. This lets
     /// extension crates register their own dependency extensions defensively.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionRuntimeRegistryError::MalformedFamilyId`] when the
+    /// executor advertises an invalid family identifier.
     pub fn register(
         &mut self,
         executor: Arc<dyn ExtensionRuntime<B>>,
@@ -433,6 +464,15 @@ impl<B: TensorBackend + 'static> ExtensionExecutor<B> {
     }
 
     /// Execute an extension using a registered runtime executor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ValidationError::InvalidArgument` when the input/output count or
+    /// registered family is invalid, [`tenferro_tensor::Error::Extension`]
+    /// when the extension source fails, or a typed
+    /// [`tenferro_tensor::Error::BackendSource`] /
+    /// [`tenferro_tensor::Error::RuntimeStateSource`] from execution.
     pub fn execute(
         &mut self,
         backend: &mut B,
@@ -530,6 +570,15 @@ impl<B: TensorBackend + 'static> ExtensionExecutor<B> {
     /// assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[1.0, 2.0]);
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ValidationError::InvalidArgument` when the input/output count or
+    /// registered family is invalid, [`tenferro_tensor::Error::Extension`]
+    /// when the extension source fails, or a typed
+    /// [`tenferro_tensor::Error::BackendSource`] /
+    /// [`tenferro_tensor::Error::RuntimeStateSource`] from execution.
     pub fn execute_reads(
         &mut self,
         backend: &mut B,

--- a/crates/tenferro-runtime/src/extension_runtime.rs
+++ b/crates/tenferro-runtime/src/extension_runtime.rs
@@ -11,7 +11,9 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use tenferro_ops::ext_op::ExtensionOp;
-use tenferro_tensor::{CacheStats, Tensor, TensorBackend, TensorRead};
+use tenferro_tensor::{
+    CacheStats, Error as TensorError, ErrorKind, Tensor, TensorBackend, TensorRead,
+};
 
 use crate::extension_cache::{ExtensionCacheLimits, ExtensionCacheSelector, ExtensionCacheStore};
 
@@ -25,6 +27,10 @@ pub enum ExtensionRuntimeRegistryError {
     /// A registry lock was poisoned by a panic in another thread.
     #[error("{name} poisoned")]
     PoisonedLock { name: &'static str },
+    /// A host-reference executor was asked to run an operation without a
+    /// host implementation.
+    #[error("extension family {family_id:?} has no host reference implementation")]
+    MissingHostReference { family_id: &'static str },
 }
 
 /// Backend and cache state passed to one extension execution.
@@ -207,11 +213,16 @@ impl<B: TensorBackend + 'static> ExtensionRuntime<B> for HostReferenceRuntime<B>
         inputs: &[&Tensor],
         _ctx: &mut ExtensionExecutionContext<'_, B>,
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
-        let host = op
-            .host_reference()
-            .ok_or(tenferro_tensor::Error::NoHostReference {
-                family_id: op.family_id(),
-            })?;
+        let host = op.host_reference().ok_or_else(|| {
+            TensorError::extension(
+                "extension",
+                op.family_id(),
+                ErrorKind::Unsupported,
+                ExtensionRuntimeRegistryError::MissingHostReference {
+                    family_id: op.family_id(),
+                },
+            )
+        })?;
         host.execute(inputs)
     }
 
@@ -239,15 +250,16 @@ fn validate_runtime_output_count(
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
     let expected = op.output_count();
     if outputs.len() != expected {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "extension",
-            message: format!(
+        return Err(TensorError::invalid_argument(
+            "extension",
+            "outputs",
+            format!(
                 "family_id {:?}: runtime returned {} outputs but op declared {} outputs",
                 op.family_id(),
                 outputs.len(),
                 expected
             ),
-        });
+        ));
     }
     Ok(outputs)
 }
@@ -258,15 +270,16 @@ fn validate_runtime_input_count(
 ) -> tenferro_tensor::Result<()> {
     let expected = op.input_count();
     if actual != expected {
-        return Err(tenferro_tensor::Error::InvalidConfig {
-            op: "extension",
-            message: format!(
+        return Err(TensorError::invalid_argument(
+            "extension",
+            "inputs",
+            format!(
                 "family_id {:?}: op expects {} inputs, got {}",
                 op.family_id(),
                 expected,
                 actual
             ),
-        });
+        ));
     }
     Ok(())
 }
@@ -428,13 +441,14 @@ impl<B: TensorBackend + 'static> ExtensionExecutor<B> {
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
         validate_runtime_input_count(op, inputs.len())?;
         let Some(executor) = self.registry.get(op.family_id()) else {
-            return Err(tenferro_tensor::Error::InvalidConfig {
-                op: "extension",
-                message: format!(
+            return Err(TensorError::invalid_argument(
+                "extension",
+                "runtime",
+                format!(
                     "missing runtime for family_id {:?}; register the extension on this runtime owner, for example `executor.register_extension(<extension_crate>::register_runtime)` or `eager_runtime.register_extension(<extension_crate>::register_runtime)`",
                     op.family_id()
                 ),
-            });
+            ));
         };
         let mut ctx = ExtensionExecutionContext::new(backend, &mut self.caches);
         validate_runtime_output_count(op, executor.execute(op, inputs, &mut ctx)?)
@@ -524,13 +538,14 @@ impl<B: TensorBackend + 'static> ExtensionExecutor<B> {
     ) -> tenferro_tensor::Result<Vec<Tensor>> {
         validate_runtime_input_count(op, inputs.len())?;
         let Some(executor) = self.registry.get(op.family_id()) else {
-            return Err(tenferro_tensor::Error::InvalidConfig {
-                op: "extension",
-                message: format!(
+            return Err(TensorError::invalid_argument(
+                "extension",
+                "runtime",
+                format!(
                     "missing runtime for family_id {:?}; register the extension on this runtime owner, for example `executor.register_extension(<extension_crate>::register_runtime)` or `eager_runtime.register_extension(<extension_crate>::register_runtime)`",
                     op.family_id()
                 ),
-            });
+            ));
         };
         let mut ctx = ExtensionExecutionContext::new(backend, &mut self.caches);
         validate_runtime_output_count(op, executor.execute_reads(op, inputs, &mut ctx)?)

--- a/crates/tenferro-runtime/src/graph/compiler.rs
+++ b/crates/tenferro-runtime/src/graph/compiler.rs
@@ -649,9 +649,7 @@ fn prune_compiled_extension_outputs(prog: &mut CompiledProgram<StdTensorOp>) -> 
 }
 
 fn invalid_compiled_graph(message: impl Into<String>) -> Error {
-    Error::InvalidCompiledGraph {
-        message: message.into(),
-    }
+    Error::Internal(message.into())
 }
 
 fn default_tensors_equivalent(lhs: &Arc<Tensor>, rhs: &Arc<Tensor>) -> bool {

--- a/crates/tenferro-runtime/src/graph/compiler.rs
+++ b/crates/tenferro-runtime/src/graph/compiler.rs
@@ -127,6 +127,15 @@ impl GraphCompiler {
     /// let program = compiler.compile(&y).unwrap();
     /// assert_eq!(program.input_count(), 1);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `ShapeMismatch`, `RankMismatch`,
+    /// `DTypeMismatch`, or `InvalidArgument` for invalid graph metadata or
+    /// shape constraints, [`Error::RuntimeState`] for missing/inconsistent
+    /// metadata or cache state, and [`Error::Internal`] when the graph
+    /// violates a compiler invariant. Extension lowering failures retain
+    /// their typed [`Error::Extension`] source.
     pub fn compile(&mut self, output: &TracedTensor) -> Result<GraphProgram> {
         self.compile_many(&[output])
     }
@@ -144,6 +153,15 @@ impl GraphCompiler {
     /// let program = compiler.compile_many(&[&x, &y]).unwrap();
     /// assert_eq!(program.output_count(), 2);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `ShapeMismatch`, `RankMismatch`,
+    /// `DTypeMismatch`, or `InvalidArgument` for invalid graph metadata or
+    /// shape constraints, [`Error::RuntimeState`] for missing/inconsistent
+    /// metadata or cache state, and [`Error::Internal`] when the graph
+    /// violates a compiler invariant. Extension lowering failures retain
+    /// their typed [`Error::Extension`] source.
     pub fn compile_many(&mut self, outputs: &[&TracedTensor]) -> Result<GraphProgram> {
         let mut all_inputs = HashMap::new();
         for output in outputs {
@@ -177,6 +195,17 @@ impl GraphCompiler {
     ///     .unwrap();
     /// assert_eq!(program.input_specs()[0].shape(), &[3]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnexpectedBinding`] for a data-carrying tensor,
+    /// [`Error::DuplicateBinding`] for repeated placeholders,
+    /// [`Error::PlaceholderDtypeMismatch`],
+    /// [`Error::PlaceholderShapeMismatch`], or
+    /// [`Error::PlaceholderRankMismatch`] for incompatible specs, and
+    /// [`Error::Validation`] with `ShapeMismatch`, `RankMismatch`,
+    /// `DTypeMismatch`, or `InvalidArgument` / [`Error::RuntimeState`] when
+    /// compilation or metadata lowering fails.
     pub fn compile_with_input_specs(
         &mut self,
         output: &TracedTensor,

--- a/crates/tenferro-runtime/src/graph/executor.rs
+++ b/crates/tenferro-runtime/src/graph/executor.rs
@@ -1271,10 +1271,11 @@ fn zeros_tensor(dtype: DType, shape: Vec<usize>) -> Result<Tensor> {
 
 fn checked_default_element_count(shape: &[usize]) -> Result<usize> {
     shape.iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim)
-            .ok_or_else(|| Error::InvalidCompiledGraph {
-                message: format!("deferred zero shape product overflows usize for shape {shape:?}"),
-            })
+        acc.checked_mul(dim).ok_or_else(|| {
+            Error::Internal(format!(
+                "deferred zero shape product overflows usize for shape {shape:?}"
+            ))
+        })
     })
 }
 

--- a/crates/tenferro-runtime/src/graph/executor.rs
+++ b/crates/tenferro-runtime/src/graph/executor.rs
@@ -117,6 +117,13 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// let compact = executor.materialize_value(&value).unwrap();
     /// assert_eq!(compact.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::TensorRuntime`] containing a typed
+    /// `BackendSource` when backend canonicalization fails, or
+    /// `RuntimeStateSource` when the value's placement/storage state cannot be
+    /// materialized.
     pub fn materialize_value(&mut self, value: &TensorValue) -> Result<Tensor> {
         if let Some(tensor) = value.as_tensor_arc() {
             return Ok(tensor.as_ref().clone());
@@ -220,6 +227,11 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// let mut executor = GraphExecutor::new(CpuBackend::new());
     /// executor.register_extension(|_| Ok(())).unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExtensionRuntimeRegistryError::MalformedFamilyId`] when a
+    /// registered runtime advertises an invalid family identifier.
     pub fn register_extension(
         &mut self,
         register: impl FnOnce(
@@ -245,6 +257,12 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// let out = executor.run(&program).unwrap();
     /// assert_eq!(out.as_slice::<f64>().unwrap(), &[-3.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnboundPlaceholder`] for a missing default input,
+    /// [`Error::TensorRuntime`] for typed backend/validation failures, or
+    /// [`Error::Internal`] when the program produces zero or multiple outputs.
     pub fn run(&mut self, program: &GraphProgram) -> Result<Tensor> {
         let mut outputs = self.run_many(program)?;
         expect_single_output(&mut outputs)
@@ -276,6 +294,12 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     ///     &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
     /// );
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnboundPlaceholder`] for a missing default input,
+    /// [`Error::TensorRuntime`] for typed backend/validation failures, or
+    /// [`Error::Internal`] when the program produces zero or multiple outputs.
     pub fn run_value(&mut self, program: &GraphProgram) -> Result<TensorValue> {
         let mut outputs = self.run_many_values(program)?;
         expect_single_value(&mut outputs)
@@ -297,6 +321,13 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// let outputs = executor.run_many(&program).unwrap();
     /// assert_eq!(outputs.len(), 2);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnboundPlaceholder`] when a program input has no
+    /// default tensor, [`Error::ShapeConstraintViolation`] or
+    /// [`Error::ShapeConstraintEvaluation`] for failed symbolic guards, and
+    /// [`Error::TensorRuntime`] for typed backend execution failures.
     pub fn run_many(&mut self, program: &GraphProgram) -> Result<Vec<Tensor>> {
         self.run_many_with_inputs(program, &[])
     }
@@ -320,6 +351,13 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// assert!(matches!(&outputs[0], TensorValue::View(_)));
     /// assert_eq!(outputs[0].shape(), &[2, 2]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnboundPlaceholder`] when a program input has no
+    /// default tensor, [`Error::ShapeConstraintViolation`] or
+    /// [`Error::ShapeConstraintEvaluation`] for failed symbolic guards, and
+    /// [`Error::TensorRuntime`] for typed backend execution failures.
     pub fn run_many_values(&mut self, program: &GraphProgram) -> Result<Vec<TensorValue>> {
         self.run_many_values_with_inputs(program, &[])
     }
@@ -346,6 +384,18 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// let out = executor.run_with_inputs(&program, &[(&x, &bound)]).unwrap();
     /// assert_eq!(out.as_slice::<f64>().unwrap(), &[2.0, 4.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnexpectedBinding`] for a non-placeholder or foreign
+    /// binding, [`Error::DuplicateBinding`] for a repeated placeholder,
+    /// [`Error::PlaceholderDtypeMismatch`],
+    /// [`Error::PlaceholderShapeMismatch`], or
+    /// [`Error::PlaceholderRankMismatch`] for an incompatible tensor,
+    /// [`Error::UnboundPlaceholder`] for a missing input, and
+    /// [`Error::ShapeConstraintViolation`],
+    /// [`Error::ShapeConstraintEvaluation`], or [`Error::TensorRuntime`] when
+    /// execution discovers a symbolic-guard or typed backend failure.
     pub fn run_with_inputs(
         &mut self,
         program: &GraphProgram,
@@ -376,6 +426,18 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// assert!(matches!(&value, TensorValue::View(_)));
     /// assert_eq!(executor.materialize_value(&value).unwrap().as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnexpectedBinding`] for a non-placeholder or foreign
+    /// binding, [`Error::DuplicateBinding`] for a repeated placeholder,
+    /// [`Error::PlaceholderDtypeMismatch`],
+    /// [`Error::PlaceholderShapeMismatch`], or
+    /// [`Error::PlaceholderRankMismatch`] for an incompatible tensor,
+    /// [`Error::UnboundPlaceholder`] for a missing input, and
+    /// [`Error::ShapeConstraintViolation`],
+    /// [`Error::ShapeConstraintEvaluation`], or [`Error::TensorRuntime`] when
+    /// execution discovers a symbolic-guard or typed backend failure.
     pub fn run_value_with_inputs(
         &mut self,
         program: &GraphProgram,
@@ -413,6 +475,18 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// let out = executor.run_with_input_reads(&program, &[(&x, read)]).unwrap();
     /// assert_eq!(out.as_slice::<f64>().unwrap(), &[2.0, 4.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnexpectedBinding`] for a non-placeholder or foreign
+    /// binding, [`Error::DuplicateBinding`] for a repeated placeholder,
+    /// [`Error::PlaceholderDtypeMismatch`],
+    /// [`Error::PlaceholderShapeMismatch`], or
+    /// [`Error::PlaceholderRankMismatch`] for an incompatible tensor,
+    /// [`Error::UnboundPlaceholder`] for a missing input, and
+    /// [`Error::ShapeConstraintViolation`],
+    /// [`Error::ShapeConstraintEvaluation`], or [`Error::TensorRuntime`] when
+    /// execution discovers a symbolic-guard or typed backend failure.
     pub fn run_with_input_reads<'a>(
         &mut self,
         program: &'a GraphProgram,
@@ -450,6 +524,18 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// assert!(matches!(&value, TensorValue::View(_)));
     /// assert_eq!(value.shape(), &[2, 2]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnexpectedBinding`] for a non-placeholder or foreign
+    /// binding, [`Error::DuplicateBinding`] for a repeated placeholder,
+    /// [`Error::PlaceholderDtypeMismatch`],
+    /// [`Error::PlaceholderShapeMismatch`], or
+    /// [`Error::PlaceholderRankMismatch`] for an incompatible tensor,
+    /// [`Error::UnboundPlaceholder`] for a missing input, and
+    /// [`Error::ShapeConstraintViolation`],
+    /// [`Error::ShapeConstraintEvaluation`], or [`Error::TensorRuntime`] when
+    /// execution discovers a symbolic-guard or typed backend failure.
     pub fn run_value_with_input_reads<'a>(
         &mut self,
         program: &'a GraphProgram,
@@ -479,6 +565,18 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// assert_eq!(outputs.len(), 1);
     /// assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[2.0, 4.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnexpectedBinding`] for a non-placeholder or foreign
+    /// binding, [`Error::DuplicateBinding`] for a repeated placeholder,
+    /// [`Error::PlaceholderDtypeMismatch`],
+    /// [`Error::PlaceholderShapeMismatch`], or
+    /// [`Error::PlaceholderRankMismatch`] for an incompatible tensor,
+    /// [`Error::UnboundPlaceholder`] for a missing input, and
+    /// [`Error::ShapeConstraintViolation`],
+    /// [`Error::ShapeConstraintEvaluation`], or [`Error::TensorRuntime`] when
+    /// execution discovers a symbolic-guard or typed backend failure.
     pub fn run_many_with_inputs(
         &mut self,
         program: &GraphProgram,
@@ -511,6 +609,18 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// assert_eq!(outputs.len(), 1);
     /// assert!(matches!(&outputs[0], TensorValue::View(_)));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnexpectedBinding`] for a non-placeholder or foreign
+    /// binding, [`Error::DuplicateBinding`] for a repeated placeholder,
+    /// [`Error::PlaceholderDtypeMismatch`],
+    /// [`Error::PlaceholderShapeMismatch`], or
+    /// [`Error::PlaceholderRankMismatch`] for an incompatible tensor,
+    /// [`Error::UnboundPlaceholder`] for a missing input, and
+    /// [`Error::ShapeConstraintViolation`],
+    /// [`Error::ShapeConstraintEvaluation`], or [`Error::TensorRuntime`] when
+    /// execution discovers a symbolic-guard or typed backend failure.
     pub fn run_many_values_with_inputs(
         &mut self,
         program: &GraphProgram,
@@ -548,6 +658,18 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// let outputs = executor.run_many_with_input_reads(&program, &[(&x, read)]).unwrap();
     /// assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[2.0, 4.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnexpectedBinding`] for a non-placeholder or foreign
+    /// binding, [`Error::DuplicateBinding`] for a repeated placeholder,
+    /// [`Error::PlaceholderDtypeMismatch`],
+    /// [`Error::PlaceholderShapeMismatch`], or
+    /// [`Error::PlaceholderRankMismatch`] for an incompatible tensor,
+    /// [`Error::UnboundPlaceholder`] for a missing input, and
+    /// [`Error::ShapeConstraintViolation`],
+    /// [`Error::ShapeConstraintEvaluation`], or [`Error::TensorRuntime`] when
+    /// execution discovers a symbolic-guard or typed backend failure.
     pub fn run_many_with_input_reads<'a>(
         &mut self,
         program: &'a GraphProgram,
@@ -585,6 +707,18 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// assert_eq!(outputs.len(), 1);
     /// assert!(matches!(&outputs[0], TensorValue::View(_)));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::UnexpectedBinding`] for a non-placeholder or foreign
+    /// binding, [`Error::DuplicateBinding`] for a repeated placeholder,
+    /// [`Error::PlaceholderDtypeMismatch`],
+    /// [`Error::PlaceholderShapeMismatch`], or
+    /// [`Error::PlaceholderRankMismatch`] for an incompatible tensor,
+    /// [`Error::UnboundPlaceholder`] for a missing input, and
+    /// [`Error::ShapeConstraintViolation`],
+    /// [`Error::ShapeConstraintEvaluation`], or [`Error::TensorRuntime`] when
+    /// execution discovers a symbolic-guard or typed backend failure.
     pub fn run_many_values_with_input_reads<'a>(
         &mut self,
         program: &'a GraphProgram,
@@ -613,6 +747,14 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// let out = executor.run(&program).unwrap();
     /// assert_eq!(out.as_slice::<f64>().unwrap(), &[-2.0]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Internal`] when the input count does not match the
+    /// execution program, [`Error::ShapeConstraintViolation`] or
+    /// [`Error::ShapeConstraintEvaluation`] when symbolic guards fail, and
+    /// [`Error::TensorRuntime`] or [`Error::Extension`] when typed backend or
+    /// extension execution fails.
     pub fn eval_exec_ir(
         &mut self,
         program: &ExecProgram,
@@ -649,6 +791,14 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// assert!(matches!(&value, TensorValue::View(_)));
     /// assert_eq!(value.shape(), &[2, 2]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Internal`] when the input count does not match the
+    /// execution program, [`Error::ShapeConstraintViolation`] or
+    /// [`Error::ShapeConstraintEvaluation`] when symbolic guards fail, and
+    /// [`Error::TensorRuntime`] or [`Error::Extension`] when typed backend or
+    /// extension execution fails.
     pub fn eval_exec_ir_values(
         &mut self,
         program: &ExecProgram,
@@ -684,6 +834,14 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// let out = executor.run(&program).unwrap();
     /// assert_eq!(out.shape(), &[1]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Internal`] when the input count does not match the
+    /// execution program, [`Error::ShapeConstraintViolation`] or
+    /// [`Error::ShapeConstraintEvaluation`] when symbolic guards fail, and
+    /// [`Error::TensorRuntime`] or [`Error::Extension`] when typed backend or
+    /// extension execution fails.
     pub fn eval_exec_ir_non_consuming(
         &mut self,
         program: &ExecProgram,
@@ -714,6 +872,14 @@ impl<B: TensorBackend + 'static> GraphExecutor<B> {
     /// assert!(matches!(&value, TensorValue::View(_)));
     /// assert_eq!(executor.materialize_value(&value).unwrap().shape(), &[2, 2]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Internal`] when the input count does not match the
+    /// execution program, [`Error::ShapeConstraintViolation`] or
+    /// [`Error::ShapeConstraintEvaluation`] when symbolic guards fail, and
+    /// [`Error::TensorRuntime`] or [`Error::Extension`] when typed backend or
+    /// extension execution fails.
     pub fn eval_exec_ir_non_consuming_values(
         &mut self,
         program: &ExecProgram,

--- a/crates/tenferro-runtime/src/graph/executor/tests.rs
+++ b/crates/tenferro-runtime/src/graph/executor/tests.rs
@@ -545,7 +545,7 @@ fn deferred_zero_tensor_covers_supported_dtypes_and_overflow() {
     }
 
     let err = super::zeros_tensor(DType::Bool, vec![usize::MAX, 2]).unwrap_err();
-    assert!(matches!(err, Error::InvalidCompiledGraph { .. }));
+    assert!(matches!(err, Error::Internal(_)));
 }
 
 #[test]

--- a/crates/tenferro-runtime/src/graph/executor/tests/preflight.rs
+++ b/crates/tenferro-runtime/src/graph/executor/tests/preflight.rs
@@ -723,9 +723,7 @@ fn deferred_zero_factory_errors_follow_metadata_and_guard_validation() {
     assert!(matches!(error, Error::PlaceholderShapeMismatch { .. }));
     assert_counts(&uploads, &dispatches, &sessions, 0, 0, 0);
 
-    let injected_error = || Error::InvalidCompiledGraph {
-        message: "injected deferred-zero factory failure".to_string(),
-    };
+    let injected_error = || Error::Internal("injected deferred-zero factory failure".to_string());
     let (mut backend, _, _, _) = counting_backend();
     let mut factory_calls = 0;
     let error = super::super::materialize_inputs(
@@ -751,7 +749,7 @@ fn deferred_zero_factory_errors_follow_metadata_and_guard_validation() {
         },
     )
     .unwrap_err();
-    assert!(matches!(error, Error::InvalidCompiledGraph { .. }));
+    assert!(matches!(error, Error::Internal(_)));
     assert_eq!(factory_calls, 1);
 }
 

--- a/crates/tenferro-runtime/src/graph/lowering_view.rs
+++ b/crates/tenferro-runtime/src/graph/lowering_view.rs
@@ -285,6 +285,14 @@ impl<'a> GraphInstructionView<'a> {
     /// let inst = program.lowering_view().instructions().next().unwrap();
     /// assert_eq!(inst.static_output_shape(0, &[&[1]]).unwrap(), vec![1]);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GraphProgramLoweringShapeError::MissingOutput`] when
+    /// `output_index` is absent, [`GraphProgramLoweringShapeError::NonStatic`]
+    /// when an extent is only an upper bound, or
+    /// [`GraphProgramLoweringShapeError::InvalidDimExpr`] when a symbolic
+    /// dimension cannot be evaluated for `input_shapes`.
     pub fn static_output_shape(
         &self,
         output_index: usize,

--- a/crates/tenferro-runtime/src/lib.rs
+++ b/crates/tenferro-runtime/src/lib.rs
@@ -106,89 +106,244 @@ pub use tenferro_tensor::{
 /// ```
 pub trait TensorOpsExt {
     /// Convert to a different dtype using the checked conversion lattice.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::UnsupportedDTypeConversion`] when the
+    /// conversion is outside the checked lattice,
+    /// [`tenferro_tensor::Error::Validation`] with `DTypeMismatch` or
+    /// `InvalidArgument` for invalid tensor metadata, or
+    /// [`tenferro_tensor::Error::BackendSource`] when the backend reports a
+    /// typed failure.
     fn convert<B: TensorBackend>(
         &self,
         to: DType,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Cast to a different dtype using explicit lossy projection.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::UnsupportedDTypeConversion`] when the
+    /// requested cast is unsupported, [`tenferro_tensor::Error::Validation`]
+    /// with `DTypeMismatch` or `InvalidArgument` for invalid tensor metadata,
+    /// or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn cast<B: TensorBackend>(&self, to: DType, backend: &mut B)
         -> tenferro_tensor::Result<Tensor>;
     /// Elementwise addition with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with a
+    /// [`ShapeMismatch`](tenferro_tensor::ValidationError::ShapeMismatch) or
+    /// `DTypeMismatch` payload when operands are incompatible, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn add<B: TensorBackend>(
         &self,
         rhs: &Tensor,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise subtraction with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch` or `DTypeMismatch` for incompatible operands, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn sub<B: TensorBackend>(
         &self,
         rhs: &Tensor,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise multiplication with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch` or `DTypeMismatch` for incompatible operands, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn mul<B: TensorBackend>(
         &self,
         rhs: &Tensor,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise division with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` for shape/dtype incompatibility,
+    /// [`tenferro_tensor::Error::Extension`] with a numerical classification
+    /// for a detected zero divisor, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn div<B: TensorBackend>(
         &self,
         rhs: &Tensor,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise remainder with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` for shape/dtype incompatibility, a numerical
+    /// [`tenferro_tensor::Error::Extension`] for a detected zero divisor, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn rem<B: TensorBackend>(
         &self,
         rhs: &Tensor,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise power with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` for incompatible metadata, a numerical
+    /// [`tenferro_tensor::Error::Extension`] for a detected negative integer
+    /// exponent, or [`tenferro_tensor::Error::BackendSource`] for a typed
+    /// backend failure.
     fn pow<B: TensorBackend>(
         &self,
         rhs: &Tensor,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise maximum with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch` or `DTypeMismatch` for incompatible operands, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn maximum<B: TensorBackend>(
         &self,
         rhs: &Tensor,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise minimum with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch` or `DTypeMismatch` for incompatible operands, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn minimum<B: TensorBackend>(
         &self,
         rhs: &Tensor,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise negation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] when the dtype is not
+    /// supported by the operation, or [`tenferro_tensor::Error::BackendSource`]
+    /// for a typed backend failure.
     fn neg<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise absolute value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn abs<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise sign.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn sign<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise complex conjugate.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn conj<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise exponential.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn exp<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise natural logarithm.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn log<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise sine.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn sin<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise cosine.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn cos<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise hyperbolic tangent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn tanh<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise square root.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn sqrt<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise reciprocal square root.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn rsqrt<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise `exp(x) - 1`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn expm1<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise `log(1 + x)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn log1p<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
     /// Elementwise comparison with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` for incompatible shape/dtype metadata, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn compare<B: TensorBackend>(
         &self,
         rhs: &Tensor,
@@ -196,6 +351,12 @@ pub trait TensorOpsExt {
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Select values from `on_true` or `on_false` using this tensor as condition.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` when the condition and branches are incompatible, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn where_select<B: TensorBackend>(
         &self,
         on_true: &Tensor,
@@ -203,6 +364,12 @@ pub trait TensorOpsExt {
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Clamp values elementwise between lower and upper bounds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` or
+    /// `DTypeMismatch` when bounds are incompatible with the input, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn clamp<B: TensorBackend>(
         &self,
         lower: &Tensor,
@@ -210,24 +377,50 @@ pub trait TensorOpsExt {
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Rank-2 matrix multiplication.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch`,
+    /// `ShapeMismatch`, or `DTypeMismatch` for incompatible matrices, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn matmul<B: TensorBackend>(
         &self,
         rhs: &Tensor,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Reshape without changing element order.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch`, `RankMismatch`, or `InvalidArgument` when element
+    /// counts or ranks are invalid, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn reshape<B: TensorBackend>(
         &self,
         shape: &[usize],
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Permute axes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `InvalidPermutationLength`, `AxisOutOfBounds`, or `DuplicateAxis` for
+    /// an invalid permutation, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn transpose<B: TensorBackend>(
         &self,
         perm: &[usize],
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
     /// Sum over one or more axes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds`
+    /// or `DuplicateAxis` for invalid reductions, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn reduce_sum<B: TensorBackend>(
         &self,
         axes: &[usize],
@@ -263,80 +456,216 @@ pub trait TensorOpsExt {
 /// ```
 pub trait TypedTensorOpsExt<T: TensorScalar> {
     /// Elementwise addition with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
+    /// a typed backend failure.
     fn add<B: TensorBackend>(
         &self,
         rhs: &TypedTensor<T>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise subtraction with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
+    /// a typed backend failure.
     fn sub<B: TensorBackend>(
         &self,
         rhs: &TypedTensor<T>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise multiplication with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
+    /// a typed backend failure.
     fn mul<B: TensorBackend>(
         &self,
         rhs: &TypedTensor<T>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise division with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible shapes, a numerical [`tenferro_tensor::Error::Extension`]
+    /// for a detected zero divisor, or [`tenferro_tensor::Error::BackendSource`]
+    /// for a typed backend failure.
     fn div<B: TensorBackend>(
         &self,
         rhs: &TypedTensor<T>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise remainder with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible shapes, a numerical [`tenferro_tensor::Error::Extension`]
+    /// for a detected zero divisor, or [`tenferro_tensor::Error::BackendSource`]
+    /// for a typed backend failure.
     fn rem<B: TensorBackend>(
         &self,
         rhs: &TypedTensor<T>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise power with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible shapes, a numerical [`tenferro_tensor::Error::Extension`]
+    /// for a detected negative integer exponent, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn pow<B: TensorBackend>(
         &self,
         rhs: &TypedTensor<T>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise maximum with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
+    /// a typed backend failure.
     fn maximum<B: TensorBackend>(
         &self,
         rhs: &TypedTensor<T>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise minimum with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `ShapeMismatch` for
+    /// incompatible operands, or [`tenferro_tensor::Error::BackendSource`] for
+    /// a typed backend failure.
     fn minimum<B: TensorBackend>(
         &self,
         rhs: &TypedTensor<T>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise negation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn neg<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise absolute value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn abs<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise sign.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn sign<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise complex conjugate.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn conj<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise exponential.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn exp<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise natural logarithm.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn log<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise sine.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn sin<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise cosine.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn cos<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise hyperbolic tangent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn tanh<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise square root.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn sqrt<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise reciprocal square root.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn rsqrt<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise `exp(x) - 1`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn expm1<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise `log(1 + x)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// dtype or [`tenferro_tensor::Error::BackendSource`] for a typed backend
+    /// failure.
     fn log1p<B: TensorBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Elementwise comparison with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch::IncompatibleShapes` when broadcasting the operands is
+    /// impossible, or [`tenferro_tensor::Error::BackendSource`] for a typed
+    /// backend failure.
     fn compare<B: TensorBackend>(
         &self,
         rhs: &TypedTensor<T>,
@@ -344,6 +673,13 @@ pub trait TypedTensorOpsExt<T: TensorScalar> {
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<bool>>;
     /// Clamp values elementwise between lower and upper bounds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch::IncompatibleShapes` when a bound cannot broadcast to
+    /// the input, or [`tenferro_tensor::Error::BackendSource`] for a typed
+    /// backend failure.
     fn clamp<B: TensorBackend>(
         &self,
         lower: &TypedTensor<T>,
@@ -351,30 +687,68 @@ pub trait TypedTensorOpsExt<T: TensorScalar> {
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Rank-2 matrix multiplication.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch` when
+    /// either operand is not rank two or `ShapeMismatch::ContractedDimensions`
+    /// when the inner dimensions differ, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn matmul<B: TensorBackend>(
         &self,
         rhs: &TypedTensor<T>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Sum over one or more axes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds`
+    /// for an axis outside the input rank or `DuplicateAxis` when `axes`
+    /// repeats an axis, or [`tenferro_tensor::Error::BackendSource`] for a
+    /// typed backend failure.
     fn reduce_sum<B: TensorBackend>(
         &self,
         axes: &[usize],
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Reshape through the backend structural operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch::ReshapeElementCount` when the element counts differ,
+    /// `IntegerOverflow` when shape arithmetic overflows, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn reshape<B: TensorBackend>(
         &self,
         shape: &[usize],
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Permute axes through the backend structural operation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `InvalidPermutationLength` when `perm` has the wrong length,
+    /// `AxisOutOfBounds` for an invalid axis, or `DuplicateAxis` for a
+    /// repeated axis, or [`tenferro_tensor::Error::BackendSource`] for a typed
+    /// backend failure.
     fn transpose<B: TensorBackend>(
         &self,
         perm: &[usize],
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
     /// Broadcast into a larger shape.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `RankMismatch` when
+    /// `dims` does not match the input rank, `AxisOutOfBounds` or
+    /// `DuplicateAxis` for an invalid mapping, or
+    /// `ShapeMismatch::IncompatibleShapes` when known dimensions cannot
+    /// broadcast. [`tenferro_tensor::Error::BackendSource`] reports a typed
+    /// backend failure.
     fn broadcast_in_dim<B: TensorBackend>(
         &self,
         shape: &[usize],
@@ -393,6 +767,13 @@ pub trait TypedTensorOpsExt<T: TensorScalar> {
 /// helper in the private `typed_tensor` module is not a compatibility API.
 pub trait TypedTensorMaskOpsExt {
     /// Select typed values using this bool tensor as condition.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with
+    /// `ShapeMismatch::IncompatibleShapes` when the condition or either branch
+    /// cannot broadcast to the other operands, or
+    /// [`tenferro_tensor::Error::BackendSource`] for a typed backend failure.
     fn where_select<T: TensorScalar, B: TensorBackend>(
         &self,
         on_true: &TypedTensor<T>,

--- a/crates/tenferro-runtime/src/lib.rs
+++ b/crates/tenferro-runtime/src/lib.rs
@@ -55,7 +55,7 @@ pub mod traced;
 mod typed_tensor;
 
 pub use compiler::{CompilerOptions, OptimizerConfig};
-pub use error::{ContextId, Error, Result, ShapeConstraintEvalError};
+pub use error::{ContextId, Error, ErrorPhase, Result, ShapeConstraintEvalError};
 pub use extension_cache::{
     ExtensionCacheKey, ExtensionCacheLimits, ExtensionCacheSelector, ExtensionCacheStore,
 };

--- a/crates/tenferro-runtime/src/metadata.rs
+++ b/crates/tenferro-runtime/src/metadata.rs
@@ -15,7 +15,6 @@ use tenferro_ops::sym_dim::SymDim;
 use tenferro_tensor::DType;
 use tenferro_tensor::Tensor;
 
-use crate::error::BoxError;
 use crate::shape_constraint::{ScopedShapeConstraint, ShapeConstraintScope};
 use crate::shape_infer::{
     infer_extension_output_meta_with_constraints, infer_output_dtype, infer_output_extents,
@@ -123,10 +122,26 @@ pub(crate) fn symbolic_input_meta(dtype: DType, tensor_id: u64, rank: usize) -> 
     )
 }
 
+/// Convert a tensor's concrete metadata into the runtime metadata form.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_runtime::ad_support::tensor_meta_from_tensor;
+/// use tenferro_tensor::Tensor;
+/// let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+/// assert_eq!(tensor_meta_from_tensor(&tensor).rank(), 1);
+/// ```
 pub fn tensor_meta_from_tensor(tensor: &Tensor) -> TensorMeta {
     concrete_tensor_meta(tensor.dtype(), tensor.shape())
 }
 
+/// Register metadata for one value for the lifetime of the returned scope.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeStateSource`] when the global metadata
+/// registry lock is poisoned while installing `meta`.
 pub fn register_scoped_value_metadata(
     key: ValueKey<StdTensorOp>,
     meta: TensorMeta,
@@ -134,18 +149,38 @@ pub fn register_scoped_value_metadata(
     register_scoped_global_metadata_batch([(key, meta)]).map_err(metadata_source)
 }
 
+/// Register a batch of value metadata for the lifetime of the returned scope.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeStateSource`] when the global metadata
+/// registry lock is poisoned while installing one of the entries.
 pub fn register_scoped_metadata_batch(
     entries: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
 ) -> Result<GlobalMetadataScope> {
     register_scoped_global_metadata_batch(entries).map_err(metadata_source)
 }
 
+/// Look up metadata registered for one graph value.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::RuntimeStateSource`] when the global metadata
+/// registry lock is poisoned, or [`crate::Error::RuntimeState`] when `key`
+/// has no registered metadata.
 pub fn registered_meta(key: &ValueKey<StdTensorOp>) -> Result<TensorMeta> {
     lookup_global_metadata(key)
         .map_err(metadata_source)?
         .ok_or_else(|| metadata_error(format!("missing registered metadata for {:?}", key)))
 }
 
+/// Register graph metadata for the lifetime of the returned scope.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `InvalidArgument` when graph
+/// metadata cannot be analyzed, or [`crate::Error::RuntimeStateSource`] when
+/// the metadata registry lock is poisoned.
 pub fn register_scoped_graph_metadata(
     graph: &Graph<StdTensorOp>,
     seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
@@ -195,6 +230,13 @@ impl std::fmt::Debug for RegisteredGraphAnalysis {
 /// let analysis = register_scoped_graph_analysis(input.graph(), []).unwrap();
 /// assert!(analysis.constraints.is_empty());
 /// ```
+///
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `InvalidArgument` when graph
+/// metadata or a symbolic dimension cannot be analyzed, or
+/// [`crate::Error::RuntimeStateSource`] when the metadata registry lock is
+/// poisoned.
 pub fn register_scoped_graph_analysis(
     graph: &Graph<StdTensorOp>,
     seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
@@ -208,6 +250,13 @@ pub fn register_scoped_graph_analysis(
     })
 }
 
+/// Register metadata only for live values in a graph.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `InvalidArgument` when a live
+/// graph value has invalid metadata, or [`crate::Error::RuntimeStateSource`]
+/// when the metadata registry lock is poisoned.
 pub fn register_scoped_live_graph_metadata(
     graph: &Graph<StdTensorOp>,
     live_values: &HashSet<LocalValueId>,
@@ -519,14 +568,16 @@ fn resolved_bound_shapes(input_metas: &[TensorMeta]) -> Result<Vec<Vec<SymDim>>>
 }
 
 fn metadata_error(message: impl Into<String>) -> Error {
-    Error::Internal(format!("metadata registration: {}", message.into()))
+    Error::runtime_state(
+        "metadata",
+        crate::ErrorPhase::Compile,
+        format!("metadata registration: {}", message.into()),
+    )
 }
 
 fn metadata_source<E>(error: E) -> Error
 where
     E: std::error::Error + Send + Sync + 'static,
 {
-    Error::Metadata {
-        source: Box::new(error) as BoxError,
-    }
+    Error::runtime_state_source("metadata", crate::ErrorPhase::Compile, error)
 }

--- a/crates/tenferro-runtime/src/metadata.rs
+++ b/crates/tenferro-runtime/src/metadata.rs
@@ -15,6 +15,7 @@ use tenferro_ops::sym_dim::SymDim;
 use tenferro_tensor::DType;
 use tenferro_tensor::Tensor;
 
+use crate::error::BoxError;
 use crate::shape_constraint::{ScopedShapeConstraint, ShapeConstraintScope};
 use crate::shape_infer::{
     infer_extension_output_meta_with_constraints, infer_output_dtype, infer_output_extents,
@@ -130,19 +131,18 @@ pub fn register_scoped_value_metadata(
     key: ValueKey<StdTensorOp>,
     meta: TensorMeta,
 ) -> Result<GlobalMetadataScope> {
-    register_scoped_global_metadata_batch([(key, meta)])
-        .map_err(|err| metadata_error(err.to_string()))
+    register_scoped_global_metadata_batch([(key, meta)]).map_err(metadata_source)
 }
 
 pub fn register_scoped_metadata_batch(
     entries: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
 ) -> Result<GlobalMetadataScope> {
-    register_scoped_global_metadata_batch(entries).map_err(|err| metadata_error(err.to_string()))
+    register_scoped_global_metadata_batch(entries).map_err(metadata_source)
 }
 
 pub fn registered_meta(key: &ValueKey<StdTensorOp>) -> Result<TensorMeta> {
     lookup_global_metadata(key)
-        .map_err(|err| metadata_error(err.to_string()))?
+        .map_err(metadata_source)?
         .ok_or_else(|| metadata_error(format!("missing registered metadata for {:?}", key)))
 }
 
@@ -200,8 +200,8 @@ pub fn register_scoped_graph_analysis(
     seeded: impl IntoIterator<Item = (ValueKey<StdTensorOp>, TensorMeta)>,
 ) -> Result<RegisteredGraphAnalysis> {
     let analysis = graph_analysis_registrations(graph, None, seeded)?;
-    let metadata = register_scoped_global_metadata_batch(analysis.metadata)
-        .map_err(|err| metadata_error(err.to_string()))?;
+    let metadata =
+        register_scoped_global_metadata_batch(analysis.metadata).map_err(metadata_source)?;
     Ok(RegisteredGraphAnalysis {
         metadata,
         constraints: ShapeConstraintScope::new(analysis.constraints),
@@ -216,7 +216,7 @@ pub fn register_scoped_live_graph_metadata(
     register_scoped_global_metadata_batch(
         graph_analysis_registrations(graph, Some(live_values), seeded)?.metadata,
     )
-    .map_err(|err| metadata_error(err.to_string()))
+    .map_err(metadata_source)
 }
 
 pub fn metadata_scopes_with_new<'a>(
@@ -344,9 +344,7 @@ fn append_graph_metadata_registrations(
             let mut registered_outputs = Vec::with_capacity(op_node.outputs.len());
             for &output_id in &op_node.outputs {
                 let key = graph.values()[output_id].key.clone();
-                let Some(meta) =
-                    lookup_global_metadata(&key).map_err(|err| metadata_error(err.to_string()))?
-                else {
+                let Some(meta) = lookup_global_metadata(&key).map_err(metadata_source)? else {
                     break;
                 };
                 registered_outputs.push((key, meta));
@@ -375,9 +373,7 @@ fn append_graph_metadata_registrations(
                 input_metas.push(meta);
                 continue;
             }
-            if let Some(meta) =
-                lookup_global_metadata(key).map_err(|err| metadata_error(err.to_string()))?
-            {
+            if let Some(meta) = lookup_global_metadata(key).map_err(metadata_source)? {
                 known.insert(key.clone(), meta.clone());
                 registrations.push((key.clone(), meta.clone()));
                 input_metas.push(meta);
@@ -523,7 +519,14 @@ fn resolved_bound_shapes(input_metas: &[TensorMeta]) -> Result<Vec<Vec<SymDim>>>
 }
 
 fn metadata_error(message: impl Into<String>) -> Error {
-    Error::InvalidCompiledGraph {
-        message: format!("metadata registration: {}", message.into()),
+    Error::Internal(format!("metadata registration: {}", message.into()))
+}
+
+fn metadata_source<E>(error: E) -> Error
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    Error::Metadata {
+        source: Box::new(error) as BoxError,
     }
 }

--- a/crates/tenferro-runtime/src/scalar_semantics.rs
+++ b/crates/tenferro-runtime/src/scalar_semantics.rs
@@ -1,13 +1,15 @@
 use tenferro_tensor::{DType, Tensor};
 
-use crate::error::{Error, Result};
+use crate::error::{Error, ErrorPhase, Result};
 
 fn finite_real_scalar(op: &'static str, value: f64) -> Result<f64> {
     if !value.is_finite() {
-        return Err(Error::InvalidGraphBuild {
+        return Err(Error::invalid_argument(
             op,
-            message: format!("real scalar value must be finite, got {value}"),
-        });
+            ErrorPhase::GraphBuild,
+            "value",
+            format!("real scalar value must be finite, got {value}"),
+        ));
     }
     Ok(value)
 }
@@ -19,19 +21,25 @@ pub(crate) fn round_real_to_i64(value: f64) -> Result<i64> {
 pub(crate) fn round_real_to_i64_for_op(op: &'static str, value: f64) -> Result<i64> {
     let rounded = finite_real_scalar(op, value)?.round();
     if rounded < i64::MIN as f64 || rounded > i64::MAX as f64 {
-        return Err(Error::InvalidGraphBuild {
+        return Err(Error::invalid_argument(
             op,
-            message: format!("rounded real scalar {rounded} is out of i64 range"),
-        });
+            ErrorPhase::GraphBuild,
+            "value",
+            format!("rounded real scalar {rounded} is out of i64 range"),
+        ));
     }
     Ok(rounded as i64)
 }
 
 pub(crate) fn round_real_to_i32_for_op(op: &'static str, value: f64) -> Result<i32> {
     let rounded = round_real_to_i64_for_op(op, value)?;
-    i32::try_from(rounded).map_err(|_| Error::InvalidGraphBuild {
-        op,
-        message: format!("rounded real scalar {rounded} is out of i32 range"),
+    i32::try_from(rounded).map_err(|_| {
+        Error::invalid_argument(
+            op,
+            ErrorPhase::GraphBuild,
+            "value",
+            format!("rounded real scalar {rounded} is out of i32 range"),
+        )
     })
 }
 

--- a/crates/tenferro-runtime/src/scalar_semantics.rs
+++ b/crates/tenferro-runtime/src/scalar_semantics.rs
@@ -3,10 +3,14 @@ use tenferro_tensor::{DType, Tensor};
 use crate::error::{Error, ErrorPhase, Result};
 
 fn finite_real_scalar(op: &'static str, value: f64) -> Result<f64> {
+    finite_real_scalar_at(op, ErrorPhase::GraphBuild, value)
+}
+
+fn finite_real_scalar_at(op: &'static str, phase: ErrorPhase, value: f64) -> Result<f64> {
     if !value.is_finite() {
         return Err(Error::invalid_argument(
             op,
-            ErrorPhase::GraphBuild,
+            phase,
             "value",
             format!("real scalar value must be finite, got {value}"),
         ));
@@ -47,19 +51,29 @@ pub(crate) fn bool_from_real_for_op(op: &'static str, value: f64) -> Result<bool
     Ok(finite_real_scalar(op, value)? != 0.0)
 }
 
+/// Evaluate the scalar size supplied to a dynamic truncation operation.
+///
+/// # Errors
+///
+/// Returns `Validation(InvalidArgument)` when `size_tensor` is not scalar,
+/// `Unsupported` when its dtype is not `f32`, `f64`, or `i64`,
+/// `Validation(InvalidArgument)` for a non-finite floating value, and
+/// `RuntimeState` when the scalar's backend storage is unexpectedly empty.
 pub fn dynamic_truncate_size(size_tensor: &Tensor, axis_extent: usize) -> Result<usize> {
     if !size_tensor.shape().is_empty() {
-        return Err(Error::Internal(format!(
-            "DynamicTruncate size must be an f32, f64, or i64 scalar, got shape {:?}",
-            size_tensor.shape()
-        )));
+        return Err(Error::invalid_argument(
+            "dynamic_truncate",
+            ErrorPhase::Execution,
+            "size",
+            format!("size must be scalar, got shape {:?}", size_tensor.shape()),
+        ));
     }
     if let Tensor::I64(inner) = size_tensor {
         let value = scalar_host_value(inner.host_data()?, DType::I64)?;
         return Ok(truncate_i64_size(value, axis_extent));
     }
     let value = scalar_size_value(size_tensor)?;
-    let rounded = finite_real_scalar("DynamicTruncate", value)?.round();
+    let rounded = finite_real_scalar_at("dynamic_truncate", ErrorPhase::Execution, value)?.round();
     Ok(rounded.max(0.0).min(axis_extent as f64) as usize)
 }
 
@@ -72,26 +86,35 @@ fn truncate_i64_size(value: i64, axis_extent: usize) -> usize {
 
 fn scalar_size_value(size_tensor: &Tensor) -> Result<f64> {
     if !size_tensor.shape().is_empty() {
-        return Err(Error::Internal(format!(
-            "DynamicTruncate size must be an f32, f64, or i64 scalar, got shape {:?}",
-            size_tensor.shape()
-        )));
+        return Err(Error::invalid_argument(
+            "dynamic_truncate",
+            ErrorPhase::Execution,
+            "size",
+            format!("size must be scalar, got shape {:?}", size_tensor.shape()),
+        ));
     }
 
     match size_tensor {
         Tensor::F64(inner) => scalar_host_value(inner.host_data()?, DType::F64),
         Tensor::F32(inner) => Ok(scalar_host_value(inner.host_data()?, DType::F32)? as f64),
-        _ => Err(Error::Internal(
-            "DynamicTruncate size must be an f32, f64, or i64 scalar".into(),
+        _ => Err(Error::unsupported(
+            "dynamic_truncate",
+            ErrorPhase::Execution,
+            format!(
+                "dtype {:?} is not accepted for the size scalar",
+                size_tensor.dtype()
+            ),
         )),
     }
 }
 
 fn scalar_host_value<T: Copy>(data: &[T], dtype: DType) -> Result<T> {
     data.first().copied().ok_or_else(|| {
-        Error::Internal(format!(
-            "DynamicTruncate size scalar had empty {dtype:?} host buffer"
-        ))
+        Error::runtime_state(
+            "dynamic_truncate",
+            ErrorPhase::Execution,
+            format!("dynamic_truncate size scalar had empty {dtype:?} host buffer"),
+        )
     })
 }
 
@@ -101,7 +124,8 @@ mod tests {
         bool_from_real_for_op, dynamic_truncate_size, round_real_to_i32_for_op, round_real_to_i64,
         round_real_to_i64_for_op, scalar_host_value,
     };
-    use tenferro_tensor::{DType, Tensor, TypedTensor};
+    use crate::{Error, ErrorPhase};
+    use tenferro_tensor::{DType, ErrorKind, Tensor, TypedTensor};
 
     fn f64_scalar(value: f64) -> Tensor {
         Tensor::F64(TypedTensor::from_vec_col_major(vec![], vec![value]).unwrap())
@@ -178,10 +202,15 @@ mod tests {
         let bool_scalar =
             Tensor::Bool(TypedTensor::from_vec_col_major(vec![], vec![true]).unwrap());
         let err = dynamic_truncate_size(&bool_scalar, 4).unwrap_err();
-        assert!(
-            err.to_string().contains("f32, f64, or i64"),
-            "expected dtype error, got {err:?}"
-        );
+        assert!(matches!(
+            &err,
+            Error::Unsupported {
+                op: "dynamic_truncate",
+                phase: ErrorPhase::Execution,
+                ..
+            }
+        ));
+        assert_eq!(err.kind(), ErrorKind::Unsupported);
     }
 
     #[test]

--- a/crates/tenferro-runtime/src/shape_infer.rs
+++ b/crates/tenferro-runtime/src/shape_infer.rs
@@ -8,8 +8,12 @@ use tenferro_ops::ext_op::{invoke_extension_shape_inference, ExtensionOp};
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::sym_dim::SymDim;
 use tenferro_ops::ShapeExtent;
-use tenferro_tensor::{DType, DotGeneralConfig, GatherConfig, PadConfig, SliceConfig};
+use tenferro_tensor::{
+    DType, DotGeneralConfig, Error as TensorError, GatherConfig, PadConfig, ShapeMismatch,
+    ShapeVec, SliceConfig, ValidationError,
+};
 
+use crate::error::ErrorPhase;
 use crate::shape_constraint::{ConstraintSource, LocalShapeConstraint};
 use crate::{Error, Result};
 
@@ -322,10 +326,10 @@ pub fn infer_output_shapes(
         StdTensorOp::DynamicTruncate { axis } => {
             let shape = require_input(op, input_shapes, 0)?.to_vec();
             if *axis >= shape.len() {
-                return Err(shape_infer_error(format!(
-                    "DynamicTruncate axis {axis} out of bounds for rank {}",
-                    shape.len()
-                )));
+                return Err(shape_infer_validation(ValidationError::AxisOutOfBounds {
+                    axis: *axis,
+                    rank: shape.len(),
+                }));
             }
             vec![shape]
         }
@@ -356,10 +360,10 @@ pub fn infer_output_extents(
         StdTensorOp::DynamicTruncate { axis } => {
             let shape = require_input(op, input_shapes, 0)?;
             if *axis >= shape.len() {
-                return Err(shape_infer_error(format!(
-                    "DynamicTruncate axis {axis} out of bounds for rank {}",
-                    shape.len()
-                )));
+                return Err(shape_infer_validation(ValidationError::AxisOutOfBounds {
+                    axis: *axis,
+                    rank: shape.len(),
+                }));
             }
             let mut extents: Vec<_> = shape.iter().cloned().map(ShapeExtent::exact).collect();
             extents[*axis] = ShapeExtent::upper_bound(shape[*axis].clone());
@@ -615,21 +619,33 @@ fn broadcast_dim(lhs: DimExpr, rhs: DimExpr) -> Result<DimExpr> {
     match (&lhs, &rhs) {
         (DimExpr::Const(1), _) => Ok(rhs),
         (_, DimExpr::Const(1)) => Ok(lhs),
-        (DimExpr::Const(lhs_value), DimExpr::Const(rhs_value)) => Err(shape_infer_error(format!(
-            "incompatible Add/Mul broadcast dimensions: {lhs_value} and {rhs_value}"
-        ))),
+        (DimExpr::Const(lhs_value), DimExpr::Const(rhs_value)) => {
+            Err(shape_infer_validation(ShapeMismatch::IncompatibleShapes {
+                lhs: ShapeVec::from_vec(vec![*lhs_value]),
+                rhs: ShapeVec::from_vec(vec![*rhs_value]),
+            }))
+        }
         _ => Ok(dim_max(lhs, rhs)),
     }
 }
 
 fn shape_infer_error(message: impl Into<String>) -> Error {
-    Error::InvalidCompiledGraph {
-        message: message.into(),
-    }
+    Error::Internal(format!("shape inference failed: {}", message.into()))
 }
 
-fn shape_infer_from_tensor_error(err: tenferro_tensor::Error) -> Error {
-    shape_infer_error(err.to_string())
+fn shape_infer_validation(source: impl Into<ValidationError>) -> Error {
+    Error::validation("shape_infer", ErrorPhase::Compile, source.into())
+}
+
+fn shape_infer_invalid_argument(argument: &'static str, message: impl Into<String>) -> Error {
+    Error::invalid_argument("shape_infer", ErrorPhase::Compile, argument, message)
+}
+
+fn shape_infer_from_tensor_error(err: TensorError) -> Error {
+    match err {
+        TensorError::Validation { source, .. } => shape_infer_validation(source),
+        other => Error::TensorRuntime(other),
+    }
 }
 
 fn extract_diag_shape(
@@ -638,13 +654,16 @@ fn extract_diag_shape(
     axis_b: usize,
 ) -> Result<Vec<DimExpr>> {
     if axis_a >= input_shape.len() || axis_b >= input_shape.len() {
-        return Err(shape_infer_error(format!(
-            "ExtractDiag axes ({axis_a}, {axis_b}) out of bounds for rank {}",
-            input_shape.len()
-        )));
+        return Err(shape_infer_validation(ValidationError::AxisOutOfBounds {
+            axis: axis_a.max(axis_b),
+            rank: input_shape.len(),
+        }));
     }
     if axis_a == axis_b {
-        return Err(shape_infer_error("ExtractDiag requires distinct axes"));
+        return Err(shape_infer_validation(ValidationError::DuplicateAxis {
+            axis: axis_a,
+            role: "diagonal",
+        }));
     }
     let diag_output_axis = if axis_a < axis_b { axis_a } else { axis_a - 1 };
     let diag_dim = dim_min(input_shape[axis_a].clone(), input_shape[axis_b].clone());
@@ -656,16 +675,19 @@ fn extract_diag_shape(
 
 fn embed_diag_shape(input_shape: &[DimExpr], axis_a: usize, axis_b: usize) -> Result<Vec<DimExpr>> {
     if axis_a >= input_shape.len() {
-        return Err(shape_infer_error(format!(
-            "EmbedDiag axis_a {axis_a} out of bounds for rank {}",
-            input_shape.len()
-        )));
+        return Err(shape_infer_validation(ValidationError::AxisOutOfBounds {
+            axis: axis_a,
+            rank: input_shape.len(),
+        }));
     }
     if axis_b > input_shape.len() {
-        return Err(shape_infer_error(format!(
-            "EmbedDiag axis_b {axis_b} out of bounds for rank {}",
-            input_shape.len()
-        )));
+        return Err(shape_infer_validation(ValidationError::InvalidArgument {
+            argument: "axis_b",
+            message: format!(
+                "axis {axis_b} out of bounds for rank {} insertion",
+                input_shape.len()
+            ),
+        }));
     }
     let mut output_shape = input_shape.to_vec();
     output_shape.insert(axis_b, input_shape[axis_a].clone());
@@ -681,7 +703,7 @@ fn dot_general_shape(
     let rhs_rank = rhs_shape.len();
     config
         .validate_dims_with_ranks(lhs_rank, rhs_rank)
-        .map_err(|err| shape_infer_error(err.to_string()))?;
+        .map_err(shape_infer_from_tensor_error)?;
 
     let lhs_free = (0..lhs_rank).filter(|axis| {
         !config.lhs_contracting_dims.contains(axis) && !config.lhs_batch_dims.contains(axis)
@@ -732,18 +754,17 @@ fn gather_shape_from_slice_sizes(
     slice_sizes: &[DimExpr],
 ) -> Result<Vec<DimExpr>> {
     if slice_sizes.len() != operand_shape.len() {
-        return Err(shape_infer_error(format!(
-            "gather: slice_sizes rank mismatch: got {}, expected {}",
-            slice_sizes.len(),
-            operand_shape.len()
-        )));
+        return Err(shape_infer_validation(ValidationError::RankMismatch {
+            expected: operand_shape.len(),
+            actual: slice_sizes.len(),
+        }));
     }
     validate_gather_slice_sizes_within_operand(operand_shape, slice_sizes)?;
     if index_vector_dim > index_shape.len() {
-        return Err(shape_infer_error(format!(
-            "gather: index_vector_dim {index_vector_dim} out of bounds for index rank {}",
-            index_shape.len()
-        )));
+        return Err(shape_infer_validation(ValidationError::AxisOutOfBounds {
+            axis: index_vector_dim,
+            rank: index_shape.len(),
+        }));
     }
     ensure_unique_axes("gather", "offset_dims", offset_dims)?;
     ensure_unique_axes("gather", "collapsed_slice_dims", collapsed_slice_dims)?;
@@ -751,10 +772,15 @@ fn gather_shape_from_slice_sizes(
         .iter()
         .any(|&axis| axis >= operand_shape.len())
     {
-        return Err(shape_infer_error(format!(
-            "gather: collapsed_slice_dims {collapsed_slice_dims:?} out of bounds for operand rank {}",
-            operand_shape.len()
-        )));
+        let axis = collapsed_slice_dims
+            .iter()
+            .copied()
+            .find(|&axis| axis >= operand_shape.len())
+            .unwrap_or(operand_shape.len());
+        return Err(shape_infer_validation(ValidationError::AxisOutOfBounds {
+            axis,
+            rank: operand_shape.len(),
+        }));
     }
 
     let batch_shape = if index_vector_dim == index_shape.len() {
@@ -771,11 +797,10 @@ fn gather_shape_from_slice_sizes(
         .filter(|dim| !collapsed_slice_dims.contains(dim))
         .collect();
     if offset_dims.len() != window_dims.len() {
-        return Err(shape_infer_error(format!(
-            "gather: offset_dims length mismatch: got {}, expected {}",
-            offset_dims.len(),
-            window_dims.len()
-        )));
+        return Err(shape_infer_validation(ValidationError::RankMismatch {
+            expected: window_dims.len(),
+            actual: offset_dims.len(),
+        }));
     }
 
     let out_rank = batch_shape.len() + offset_dims.len();
@@ -783,9 +808,10 @@ fn gather_shape_from_slice_sizes(
     let mut out_axis_to_operand_dim = vec![None; out_rank];
     for (offset_axis, &out_axis) in offset_dims.iter().enumerate() {
         let Some(target) = out_axis_to_operand_dim.get_mut(out_axis) else {
-            return Err(shape_infer_error(format!(
-                "gather: offset_dim {out_axis} out of bounds for output rank {out_rank}"
-            )));
+            return Err(shape_infer_validation(ValidationError::AxisOutOfBounds {
+                axis: out_axis,
+                rank: out_rank,
+            }));
         };
         *target = Some(window_dims[offset_axis]);
     }
@@ -807,12 +833,13 @@ fn validate_gather_slice_sizes_within_operand(
     operand_shape: &[DimExpr],
     slice_sizes: &[DimExpr],
 ) -> Result<()> {
-    for (axis, (slice_size, dim_size)) in slice_sizes.iter().zip(operand_shape).enumerate() {
+    for (_axis, (slice_size, dim_size)) in slice_sizes.iter().zip(operand_shape).enumerate() {
         if let (DimExpr::Const(slice_size), DimExpr::Const(dim_size)) = (slice_size, dim_size) {
             if slice_size > dim_size {
-                return Err(shape_infer_error(format!(
-                    "gather: slice_sizes[{axis}]={slice_size} exceeds operand dimension {dim_size}"
-                )));
+                return Err(shape_infer_validation(ShapeMismatch::ExpectedActual {
+                    expected: ShapeVec::from_vec(vec![*dim_size]),
+                    actual: ShapeVec::from_vec(vec![*slice_size]),
+                }));
             }
         }
     }
@@ -822,9 +849,11 @@ fn validate_gather_slice_sizes_within_operand(
 fn ensure_unique_axes(op: &'static str, role: &'static str, axes: &[usize]) -> Result<()> {
     for (idx, &axis) in axes.iter().enumerate() {
         if axes[..idx].contains(&axis) {
-            return Err(shape_infer_error(format!(
-                "{op}: duplicate {role} axis {axis}"
-            )));
+            return Err(Error::validation(
+                op,
+                ErrorPhase::Compile,
+                ValidationError::DuplicateAxis { axis, role },
+            ));
         }
     }
     Ok(())
@@ -833,27 +862,26 @@ fn ensure_unique_axes(op: &'static str, role: &'static str, axes: &[usize]) -> R
 fn slice_shape(input_shape: &[DimExpr], config: &SliceConfig) -> Result<Vec<DimExpr>> {
     let rank = input_shape.len();
     if config.starts.len() != rank || config.limits.len() != rank || config.strides.len() != rank {
-        return Err(shape_infer_error(format!(
-            "slice: config rank mismatch for rank {rank}: starts={}, limits={}, strides={}",
-            config.starts.len(),
-            config.limits.len(),
-            config.strides.len()
-        )));
+        return Err(shape_infer_validation(ValidationError::RankMismatch {
+            expected: rank,
+            actual: config.starts.len(),
+        }));
     }
     (0..rank)
         .map(|axis| {
             let span = config.limits[axis]
                 .checked_sub(config.starts[axis])
                 .ok_or_else(|| {
-                    shape_infer_error(format!(
-                        "slice: limit {} is smaller than start {} on axis {axis}",
-                        config.limits[axis], config.starts[axis]
-                    ))
+                    shape_infer_validation(ValidationError::InvalidSliceBounds {
+                        start: config.starts[axis] as isize,
+                        end: config.limits[axis] as isize,
+                        axis_len: usize::MAX,
+                    })
                 })?;
             if config.strides[axis] == 0 {
-                return Err(shape_infer_error(format!(
-                    "slice: stride must be non-zero on axis {axis}"
-                )));
+                return Err(shape_infer_validation(ValidationError::InvalidSliceStep {
+                    step: 0,
+                }));
             }
             Ok(DimExpr::Const(span.div_ceil(config.strides[axis])))
         })
@@ -866,12 +894,10 @@ fn pad_shape(input_shape: &[DimExpr], config: &PadConfig) -> Result<Vec<DimExpr>
         || config.edge_padding_high.len() != rank
         || config.interior_padding.len() != rank
     {
-        return Err(shape_infer_error(format!(
-            "pad: config rank mismatch for rank {rank}: low={}, high={}, interior={}",
-            config.edge_padding_low.len(),
-            config.edge_padding_high.len(),
-            config.interior_padding.len()
-        )));
+        return Err(shape_infer_validation(ValidationError::RankMismatch {
+            expected: rank,
+            actual: config.edge_padding_low.len(),
+        }));
     }
 
     input_shape
@@ -879,9 +905,10 @@ fn pad_shape(input_shape: &[DimExpr], config: &PadConfig) -> Result<Vec<DimExpr>
         .enumerate()
         .map(|(axis, dim)| {
             if config.interior_padding[axis] < 0 {
-                return Err(shape_infer_error(format!(
-                    "pad: interior padding must be non-negative on axis {axis}"
-                )));
+                return Err(shape_infer_validation(ValidationError::InvalidArgument {
+                    argument: "interior_padding",
+                    message: format!("interior padding must be non-negative on axis {axis}"),
+                }));
             }
             if let DimExpr::Const(extent) = dim {
                 let base = if *extent == 0 {
@@ -980,31 +1007,33 @@ fn signed_padding_sum(low: i64, high: i64, axis: usize) -> Result<i64> {
 }
 
 fn concatenate_shape(input_shapes: &[&[DimExpr]], axis: usize) -> Result<Vec<DimExpr>> {
-    let first = input_shapes
-        .first()
-        .copied()
-        .ok_or_else(|| shape_infer_error("concatenate expects at least one input shape"))?;
+    let first = input_shapes.first().copied().ok_or_else(|| {
+        shape_infer_validation(ValidationError::InvalidArgument {
+            argument: "inputs",
+            message: "concatenate expects at least one input shape".into(),
+        })
+    })?;
     if axis >= first.len() {
-        return Err(shape_infer_error(format!(
-            "concatenate axis {axis} out of bounds for rank {}",
-            first.len()
-        )));
+        return Err(shape_infer_validation(ValidationError::AxisOutOfBounds {
+            axis,
+            rank: first.len(),
+        }));
     }
     let mut output_shape = first.to_vec();
     let mut axis_dim = first[axis].clone();
     for (input_idx, shape) in input_shapes.iter().enumerate().skip(1) {
         if shape.len() != first.len() {
-            return Err(shape_infer_error(format!(
-                "concatenate input {input_idx} rank mismatch: got {}, expected {}",
-                shape.len(),
-                first.len()
-            )));
+            return Err(shape_infer_validation(ValidationError::RankMismatch {
+                expected: first.len(),
+                actual: shape.len(),
+            }));
         }
         for (dim_idx, (expected, actual)) in first.iter().zip(*shape).enumerate() {
             if dim_idx != axis && actual != expected {
-                return Err(shape_infer_error(format!(
-                    "concatenate dimension mismatch on non-axis dim {dim_idx}: input {input_idx} has {actual:?}, expected {expected:?}"
-                )));
+                return Err(shape_infer_invalid_argument(
+                    "shapes",
+                    format!("input {input_idx} dimension {dim_idx} does not match the first input"),
+                ));
             }
         }
         axis_dim = dim_add(axis_dim, shape[axis].clone())?;
@@ -1019,16 +1048,16 @@ fn pad_to_match_shape(
     axis: usize,
 ) -> Result<Vec<DimExpr>> {
     if axis >= input_shape.len() {
-        return Err(shape_infer_error(format!(
-            "PadToMatch input axis {axis} out of bounds for rank {}",
-            input_shape.len()
-        )));
+        return Err(shape_infer_validation(ValidationError::AxisOutOfBounds {
+            axis,
+            rank: input_shape.len(),
+        }));
     }
     if axis >= reference_shape.len() {
-        return Err(shape_infer_error(format!(
-            "PadToMatch reference axis {axis} out of bounds for rank {}",
-            reference_shape.len()
-        )));
+        return Err(shape_infer_validation(ValidationError::AxisOutOfBounds {
+            axis,
+            rank: reference_shape.len(),
+        }));
     }
     let mut output_shape = input_shape.to_vec();
     output_shape[axis] = dim_max(input_shape[axis].clone(), reference_shape[axis].clone());

--- a/crates/tenferro-runtime/src/shape_infer.rs
+++ b/crates/tenferro-runtime/src/shape_infer.rs
@@ -95,15 +95,21 @@ fn ordered_dtype_op_name(op: &StdTensorOp) -> Option<&'static str> {
     }
 }
 
-fn reject_complex_ordered_dtypes(op: &StdTensorOp, input_dtypes: &[DType]) -> Result<()> {
+fn reject_complex_ordered_dtypes(
+    op: &StdTensorOp,
+    input_dtypes: &[DType],
+    phase: ErrorPhase,
+) -> Result<()> {
     let Some(op_name) = ordered_dtype_op_name(op) else {
         return Ok(());
     };
     if input_dtypes.iter().copied().any(is_complex_dtype) {
         return Err(Error::unsupported(
             op_name,
-            ErrorPhase::Compile,
-            "{op_name} does not support complex dtypes because complex numbers have no total order",
+            phase,
+            format!(
+                "{op_name} does not support complex dtypes because complex numbers have no total order"
+            ),
         ));
     }
     Ok(())
@@ -122,7 +128,16 @@ fn reject_complex_ordered_dtypes(op: &StdTensorOp, input_dtypes: &[DType]) -> Re
 /// receives a complex dtype, or [`Error::Extension`] when an extension's
 /// typed dtype inference fails.
 pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> Result<DType> {
-    reject_complex_ordered_dtypes(op, input_dtypes)?;
+    infer_output_dtype_at(op, input_dtypes, ErrorPhase::Compile)
+}
+
+/// Infer an operation's output dtype at a caller-selected discovery phase.
+pub(crate) fn infer_output_dtype_at(
+    op: &StdTensorOp,
+    input_dtypes: &[DType],
+    phase: ErrorPhase,
+) -> Result<DType> {
+    reject_complex_ordered_dtypes(op, input_dtypes, phase)?;
 
     let dtype = match op {
         StdTensorOp::Constant { dtype, .. } => *dtype,
@@ -131,10 +146,10 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> Result<DT
             return extension_first_output_dtype(ext.as_ref(), input_dtypes)
         }
         StdTensorOp::Compare(_) => DType::Bool,
-        StdTensorOp::Abs => real_dtype_for_abs(dtype_input(op, input_dtypes, 0)?),
+        StdTensorOp::Abs => real_dtype_for_abs(dtype_input(op, input_dtypes, 0, phase)?),
         StdTensorOp::Select => promote_dtype(
-            dtype_input(op, input_dtypes, 1)?,
-            dtype_input(op, input_dtypes, 2)?,
+            dtype_input(op, input_dtypes, 1, phase)?,
+            dtype_input(op, input_dtypes, 2, phase)?,
         ),
         StdTensorOp::Clamp => promote_dtypes(input_dtypes.iter().copied()),
         // Binary / ternary / N-ary ops — promote input dtypes.
@@ -147,20 +162,20 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> Result<DT
         | StdTensorOp::Minimum
         | StdTensorOp::DotGeneral { .. }
         | StdTensorOp::Concatenate { .. } => promote_dtype(
-            dtype_input(op, input_dtypes, 0)?,
-            dtype_input(op, input_dtypes, 1)?,
+            dtype_input(op, input_dtypes, 0, phase)?,
+            dtype_input(op, input_dtypes, 1, phase)?,
         ),
         StdTensorOp::Pow => promote_dtype_pow_like(
-            dtype_input(op, input_dtypes, 0)?,
-            dtype_input(op, input_dtypes, 1)?,
+            dtype_input(op, input_dtypes, 0, phase)?,
+            dtype_input(op, input_dtypes, 1, phase)?,
         ),
         StdTensorOp::Scatter(_) => promote_dtype(
-            dtype_input(op, input_dtypes, 0)?,
-            dtype_input(op, input_dtypes, 2)?,
+            dtype_input(op, input_dtypes, 0, phase)?,
+            dtype_input(op, input_dtypes, 2, phase)?,
         ),
         StdTensorOp::DynamicUpdateSlice => promote_dtype(
-            dtype_input(op, input_dtypes, 0)?,
-            dtype_input(op, input_dtypes, 1)?,
+            dtype_input(op, input_dtypes, 0, phase)?,
+            dtype_input(op, input_dtypes, 1, phase)?,
         ),
         // Unary / structural — output dtype equals input dtype.
         StdTensorOp::Neg
@@ -193,15 +208,22 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> Result<DT
         | StdTensorOp::PadToMatch { .. }
         | StdTensorOp::Slice(_)
         | StdTensorOp::Pad(_)
-        | StdTensorOp::Reverse { .. } => dtype_input(op, input_dtypes, 0)?,
+        | StdTensorOp::Reverse { .. } => dtype_input(op, input_dtypes, 0, phase)?,
         StdTensorOp::ShapeOf { .. } => DType::F64,
     };
     Ok(dtype)
 }
 
-fn dtype_input(op: &StdTensorOp, input_dtypes: &[DType], index: usize) -> Result<DType> {
+fn dtype_input(
+    op: &StdTensorOp,
+    input_dtypes: &[DType],
+    index: usize,
+    phase: ErrorPhase,
+) -> Result<DType> {
     input_dtypes.get(index).copied().ok_or_else(|| {
-        shape_infer_invalid_argument(
+        Error::invalid_argument(
+            "shape_infer",
+            phase,
             "input_dtypes",
             format!(
                 "{op:?} missing input dtype at index {index}; got {} input dtypes",

--- a/crates/tenferro-runtime/src/shape_infer.rs
+++ b/crates/tenferro-runtime/src/shape_infer.rs
@@ -100,9 +100,11 @@ fn reject_complex_ordered_dtypes(op: &StdTensorOp, input_dtypes: &[DType]) -> Re
         return Ok(());
     };
     if input_dtypes.iter().copied().any(is_complex_dtype) {
-        return Err(shape_infer_error(format!(
-            "{op_name} does not support complex dtypes because complex numbers have no total order"
-        )));
+        return Err(Error::unsupported(
+            op_name,
+            ErrorPhase::Compile,
+            "{op_name} does not support complex dtypes because complex numbers have no total order",
+        ));
     }
     Ok(())
 }
@@ -112,6 +114,13 @@ fn reject_complex_ordered_dtypes(op: &StdTensorOp, input_dtypes: &[DType]) -> Re
 /// For `StdTensorOp::Extension`, prefer the combined
 /// `infer_extension_output_meta` helper when shape metadata is also needed.
 /// This function returns only the first output's dtype.
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`] with `InvalidArgument` when an operation is
+/// missing an input dtype, [`Error::Unsupported`] when an ordered operation
+/// receives a complex dtype, or [`Error::Extension`] when an extension's
+/// typed dtype inference fails.
 pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> Result<DType> {
     reject_complex_ordered_dtypes(op, input_dtypes)?;
 
@@ -192,10 +201,13 @@ pub fn infer_output_dtype(op: &StdTensorOp, input_dtypes: &[DType]) -> Result<DT
 
 fn dtype_input(op: &StdTensorOp, input_dtypes: &[DType], index: usize) -> Result<DType> {
     input_dtypes.get(index).copied().ok_or_else(|| {
-        shape_infer_error(format!(
-            "{op:?} missing input dtype at index {index}; got {} input dtypes",
-            input_dtypes.len()
-        ))
+        shape_infer_invalid_argument(
+            "input_dtypes",
+            format!(
+                "{op:?} missing input dtype at index {index}; got {} input dtypes",
+                input_dtypes.len()
+            ),
+        )
     })
 }
 
@@ -212,6 +224,13 @@ fn real_dtype_for_abs(dtype: DType) -> DType {
 /// Returns a vector of shapes (one per output slot). For single-output ops,
 /// the vector has length 1. Multi-output extension ops return one entry per
 /// output.
+///
+/// # Errors
+///
+/// Returns [`Error::Validation`] with `ShapeMismatch`, `RankMismatch`,
+/// `AxisOutOfBounds`, `DuplicateAxis`, or `InvalidArgument` when input shape
+/// metadata or an operation configuration is invalid, and [`Error::Extension`]
+/// when an extension's typed shape inference fails.
 pub fn infer_output_shapes(
     op: &StdTensorOp,
     input_shapes: &[&[DimExpr]],
@@ -352,6 +371,12 @@ pub fn infer_output_shapes(
 /// can instead report a known upper bound so metadata consumers do not treat a
 /// bound expression as proof of exactness.
 ///
+/// # Errors
+///
+/// Returns [`Error::Validation`] with `ShapeMismatch`, `RankMismatch`,
+/// `AxisOutOfBounds`, `DuplicateAxis`, or `InvalidArgument` when input shape
+/// metadata or an operation configuration is invalid, and [`Error::Extension`]
+/// when an extension's typed extent inference fails.
 pub fn infer_output_extents(
     op: &StdTensorOp,
     input_shapes: &[&[DimExpr]],
@@ -386,6 +411,16 @@ pub fn infer_output_extents(
 /// `input_dtypes` must have length `op.input_count()` and be consistent with
 /// `input_shapes`. `input_shapes` uses [`DimExpr`] expressions so shape
 /// inference can flow through composed symbolic graphs.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with `DTypeMismatch`, `RankMismatch`,
+/// `ShapeMismatch`, or `InvalidArgument` when input metadata is inconsistent,
+/// [`crate::Error::SymbolicShapeConversion`] when an extension dimension cannot
+/// be mapped to the graph vocabulary, and [`crate::Error::Unsupported`] when
+/// the extension does not provide output metadata for the supplied
+/// configuration. The extension's typed source is retained in
+/// [`crate::Error::Extension`] when it supplies one.
 pub fn infer_extension_output_meta(
     op: &dyn ExtensionOp,
     input_dtypes: &[DType],
@@ -426,13 +461,13 @@ pub(crate) fn infer_extension_output_meta_with_constraints(
         .collect::<Result<_>>()?;
 
     let convert = |dim: &SymDim| {
-        let local_expr = dim.to_dim_expr(&tensor_map).map_err(|err| {
-            shape_infer_error(format!(
-                "ExtensionOp::infer_output_meta for family {:?} returned a SymDim \
-                 that cannot be converted to a local DimExpr: {err}",
-                op.family_id()
-            ))
-        })?;
+        let local_expr =
+            dim.to_dim_expr(&tensor_map)
+                .map_err(|source| Error::SymbolicShapeConversion {
+                    op: "ExtensionOp::infer_output_meta",
+                    phase: ErrorPhase::Compile,
+                    source,
+                })?;
         resolve_dim_expr_from_shapes(&local_expr, input_shapes)
     };
 
@@ -469,14 +504,16 @@ pub(crate) fn infer_extension_output_meta_with_constraints(
 
 fn extension_local_tensor_id(input_idx: usize) -> Result<u64> {
     let offset = u64::try_from(input_idx).map_err(|_| {
-        shape_infer_error(format!(
-            "extension input index {input_idx} does not fit the local symbolic namespace"
-        ))
+        shape_infer_invalid_argument(
+            "input_index",
+            "extension input index {input_idx} does not fit the local symbolic namespace",
+        )
     })?;
     u64::MAX.checked_sub(offset).ok_or_else(|| {
-        shape_infer_error(format!(
-            "extension input index {input_idx} exhausts the local symbolic namespace"
-        ))
+        shape_infer_invalid_argument(
+            "input_index",
+            "extension input index {input_idx} exhausts the local symbolic namespace",
+        )
     })
 }
 
@@ -493,7 +530,7 @@ fn extension_first_output_dtype(op: &dyn ExtensionOp, input_dtypes: &[DType]) ->
         .first()
         .map(|meta| meta.0)
         .ok_or_else(|| {
-            shape_infer_error(format!(
+            Error::Internal(format!(
                 "ExtensionOp::infer_output_meta for family {:?} returned an empty meta list",
                 op.family_id()
             ))
@@ -506,10 +543,13 @@ fn require_input<'a>(
     idx: usize,
 ) -> Result<&'a [DimExpr]> {
     input_shapes.get(idx).copied().ok_or_else(|| {
-        shape_infer_error(format!(
-            "{op:?} expects input index {idx}, got {} input shapes",
-            input_shapes.len()
-        ))
+        shape_infer_invalid_argument(
+            "input_shapes",
+            format!(
+                "{op:?} expects input index {idx}, got {} input shapes",
+                input_shapes.len()
+            ),
+        )
     })
 }
 
@@ -556,12 +596,15 @@ fn require_input_expr(
         .and_then(|shape| shape.get(axis))
         .cloned()
         .ok_or_else(|| {
-            shape_infer_error(format!(
-                "InputDim({}, {}) cannot be resolved from {} input shapes",
-                input_idx,
-                axis,
-                input_shapes.len()
-            ))
+            shape_infer_invalid_argument(
+                "shape_expression",
+                format!(
+                    "InputDim({}, {}) cannot be resolved from {} input shapes",
+                    input_idx,
+                    axis,
+                    input_shapes.len()
+                ),
+            )
         })
 }
 
@@ -627,10 +670,6 @@ fn broadcast_dim(lhs: DimExpr, rhs: DimExpr) -> Result<DimExpr> {
         }
         _ => Ok(dim_max(lhs, rhs)),
     }
-}
-
-fn shape_infer_error(message: impl Into<String>) -> Error {
-    Error::Internal(format!("shape inference failed: {}", message.into()))
 }
 
 fn shape_infer_validation(source: impl Into<ValidationError>) -> Error {
@@ -833,7 +872,7 @@ fn validate_gather_slice_sizes_within_operand(
     operand_shape: &[DimExpr],
     slice_sizes: &[DimExpr],
 ) -> Result<()> {
-    for (_axis, (slice_size, dim_size)) in slice_sizes.iter().zip(operand_shape).enumerate() {
+    for (slice_size, dim_size) in slice_sizes.iter().zip(operand_shape) {
         if let (DimExpr::Const(slice_size), DimExpr::Const(dim_size)) = (slice_size, dim_size) {
             if slice_size > dim_size {
                 return Err(shape_infer_validation(ShapeMismatch::ExpectedActual {
@@ -914,38 +953,23 @@ fn pad_shape(input_shape: &[DimExpr], config: &PadConfig) -> Result<Vec<DimExpr>
                 let base = if *extent == 0 {
                     0
                 } else {
-                    let extent = i64::try_from(*extent).map_err(|_| {
-                        shape_infer_error(format!(
-                            "pad: input extent {extent} exceeds i64 on axis {axis}"
-                        ))
-                    })?;
+                    let extent = i64::try_from(*extent)
+                        .map_err(|_| shape_infer_validation(ValidationError::IntegerOverflow))?;
                     let stride = config.interior_padding[axis]
                         .checked_add(1)
-                        .ok_or_else(|| {
-                            shape_infer_error(format!(
-                                "pad: interior padding overflow on axis {axis}"
-                            ))
-                        })?;
+                        .ok_or_else(|| shape_infer_validation(ValidationError::IntegerOverflow))?;
                     extent
                         .checked_sub(1)
                         .and_then(|value| value.checked_mul(stride))
                         .and_then(|value| value.checked_add(1))
-                        .ok_or_else(|| {
-                            shape_infer_error(format!(
-                                "pad: stretched extent overflow on axis {axis}"
-                            ))
-                        })?
+                        .ok_or_else(|| shape_infer_validation(ValidationError::IntegerOverflow))?
                 };
                 let padded = config.edge_padding_low[axis]
                     .checked_add(config.edge_padding_high[axis])
                     .and_then(|value| value.checked_add(base))
-                    .ok_or_else(|| {
-                        shape_infer_error(format!("pad: output extent overflow on axis {axis}"))
-                    })?;
+                    .ok_or_else(|| shape_infer_validation(ValidationError::IntegerOverflow))?;
                 Ok(DimExpr::Const(usize::try_from(padded).map_err(|_| {
-                    shape_infer_error(format!(
-                        "pad: output extent {padded} must be representable as usize on axis {axis}"
-                    ))
+                    shape_infer_validation(ValidationError::IntegerOverflow)
                 })?))
             } else if config.interior_padding[axis] == 0 {
                 add_signed(
@@ -953,18 +977,13 @@ fn pad_shape(input_shape: &[DimExpr], config: &PadConfig) -> Result<Vec<DimExpr>
                     signed_padding_sum(
                         config.edge_padding_low[axis],
                         config.edge_padding_high[axis],
-                        axis,
                     )?,
                 )
             } else {
                 let stride = DimExpr::Const(usize_from_nonnegative_i64(
                     config.interior_padding[axis]
                         .checked_add(1)
-                        .ok_or_else(|| {
-                            shape_infer_error(format!(
-                                "pad: interior padding overflow on axis {axis}"
-                            ))
-                        })?,
+                        .ok_or_else(|| shape_infer_validation(ValidationError::IntegerOverflow))?,
                     "pad",
                 )?);
                 let stretched = dim_add(
@@ -976,7 +995,6 @@ fn pad_shape(input_shape: &[DimExpr], config: &PadConfig) -> Result<Vec<DimExpr>
                     signed_padding_sum(
                         config.edge_padding_low[axis],
                         config.edge_padding_high[axis],
-                        axis,
                     )?,
                 )
             }
@@ -993,7 +1011,7 @@ fn add_signed(expr: DimExpr, amount: i64) -> Result<DimExpr> {
     } else {
         let magnitude = amount
             .checked_neg()
-            .ok_or_else(|| shape_infer_error("add_signed: negative amount magnitude overflow"))?;
+            .ok_or_else(|| shape_infer_validation(ValidationError::IntegerOverflow))?;
         dim_sub(
             expr,
             DimExpr::Const(usize_from_nonnegative_i64(magnitude, "add_signed")?),
@@ -1001,9 +1019,9 @@ fn add_signed(expr: DimExpr, amount: i64) -> Result<DimExpr> {
     }
 }
 
-fn signed_padding_sum(low: i64, high: i64, axis: usize) -> Result<i64> {
+fn signed_padding_sum(low: i64, high: i64) -> Result<i64> {
     low.checked_add(high)
-        .ok_or_else(|| shape_infer_error(format!("pad: edge padding overflow on axis {axis}")))
+        .ok_or_else(|| shape_infer_validation(ValidationError::IntegerOverflow))
 }
 
 fn concatenate_shape(input_shapes: &[&[DimExpr]], axis: usize) -> Result<Vec<DimExpr>> {
@@ -1066,40 +1084,37 @@ fn pad_to_match_shape(
 
 fn dim_add(lhs: DimExpr, rhs: DimExpr) -> Result<DimExpr> {
     match (lhs, rhs) {
-        (DimExpr::Const(lhs), DimExpr::Const(rhs)) => {
-            lhs.checked_add(rhs).map(DimExpr::Const).ok_or_else(|| {
-                shape_infer_error(format!("dimension addition overflow: {lhs} + {rhs}"))
-            })
-        }
+        (DimExpr::Const(lhs), DimExpr::Const(rhs)) => lhs
+            .checked_add(rhs)
+            .map(DimExpr::Const)
+            .ok_or_else(|| shape_infer_validation(ValidationError::IntegerOverflow)),
         (lhs, rhs) => Ok(DimExpr::add(lhs, rhs)),
     }
 }
 
 fn dim_sub(lhs: DimExpr, rhs: DimExpr) -> Result<DimExpr> {
     match (lhs, rhs) {
-        (DimExpr::Const(lhs), DimExpr::Const(rhs)) => {
-            lhs.checked_sub(rhs).map(DimExpr::Const).ok_or_else(|| {
-                shape_infer_error(format!("dimension subtraction underflow: {lhs} - {rhs}"))
-            })
-        }
+        (DimExpr::Const(lhs), DimExpr::Const(rhs)) => lhs
+            .checked_sub(rhs)
+            .map(DimExpr::Const)
+            .ok_or_else(|| shape_infer_validation(ValidationError::IntegerOverflow)),
         (lhs, rhs) => Ok(DimExpr::sub(lhs, rhs)),
     }
 }
 
 fn dim_mul(lhs: DimExpr, rhs: DimExpr) -> Result<DimExpr> {
     match (lhs, rhs) {
-        (DimExpr::Const(lhs), DimExpr::Const(rhs)) => {
-            lhs.checked_mul(rhs).map(DimExpr::Const).ok_or_else(|| {
-                shape_infer_error(format!("dimension multiplication overflow: {lhs} * {rhs}"))
-            })
-        }
+        (DimExpr::Const(lhs), DimExpr::Const(rhs)) => lhs
+            .checked_mul(rhs)
+            .map(DimExpr::Const)
+            .ok_or_else(|| shape_infer_validation(ValidationError::IntegerOverflow)),
         (lhs, rhs) => Ok(DimExpr::mul(lhs, rhs)),
     }
 }
 
 fn usize_from_nonnegative_i64(value: i64, op: &'static str) -> Result<usize> {
-    usize::try_from(value)
-        .map_err(|_| shape_infer_error(format!("{op}: value {value} must fit in usize")))
+    let _ = op;
+    usize::try_from(value).map_err(|_| shape_infer_validation(ValidationError::IntegerOverflow))
 }
 
 fn dim_min(lhs: DimExpr, rhs: DimExpr) -> DimExpr {

--- a/crates/tenferro-runtime/src/shape_infer/tests.rs
+++ b/crates/tenferro-runtime/src/shape_infer/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{Error, ErrorPhase};
-use tenferro_tensor::{ShapeMismatch, ValidationError};
+use tenferro_tensor::{ErrorKind, ShapeMismatch, ValidationError};
 
 #[derive(Clone, Debug)]
 struct AxisEqualityExtension;
@@ -348,6 +348,8 @@ fn ordered_ops_reject_complex_dtypes() {
 
     for (op, dtypes) in cases {
         let err = infer_output_dtype(&op, &dtypes).unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Unsupported);
+        assert_eq!(err.phase(), Some(ErrorPhase::Compile));
         let message = err.to_string();
         assert!(message.contains("complex"), "{op:?}: {message}");
         assert!(message.contains("total order"), "{op:?}: {message}");

--- a/crates/tenferro-runtime/src/shape_infer/tests.rs
+++ b/crates/tenferro-runtime/src/shape_infer/tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::{Error, ErrorPhase};
+use tenferro_tensor::{ShapeMismatch, ValidationError};
 
 #[derive(Clone, Debug)]
 struct AxisEqualityExtension;
@@ -446,9 +448,17 @@ fn concatenate_rejects_non_axis_dimension_mismatch() {
 
     let err = infer_output_shapes(&op, &[&lhs, &rhs]).unwrap_err();
 
-    let message = err.to_string();
-    assert!(message.contains("concatenate"), "{message}");
-    assert!(message.contains("dimension mismatch"), "{message}");
+    assert!(matches!(
+        &err,
+        Error::Validation {
+            phase: ErrorPhase::Compile,
+            source: ValidationError::InvalidArgument {
+                argument: "shapes",
+                ..
+            },
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -487,9 +497,18 @@ fn gather_rejects_concrete_slice_sizes_larger_than_operand_dims() {
     });
 
     let err = infer_output_shapes(&op, &[&operand, &indices]).unwrap_err();
-    let message = err.to_string();
-    assert!(message.contains("gather"), "{message}");
-    assert!(message.contains("slice_sizes[0]"), "{message}");
+    assert!(matches!(
+        &err,
+        Error::Validation {
+            phase: ErrorPhase::Compile,
+            source: ValidationError::ShapeMismatch(source),
+            ..
+        } if matches!(
+            source.as_ref(),
+            ShapeMismatch::ExpectedActual { expected, actual }
+                if expected.as_slice() == [4] && actual.as_slice() == [5]
+        )
+    ));
 }
 
 #[test]

--- a/crates/tenferro-runtime/src/shape_infer/tests.rs
+++ b/crates/tenferro-runtime/src/shape_infer/tests.rs
@@ -341,6 +341,7 @@ fn ordered_ops_reject_complex_dtypes() {
         ),
         (StdTensorOp::Maximum, vec![DType::C32, DType::C32]),
         (StdTensorOp::Minimum, vec![DType::C64, DType::C64]),
+        (StdTensorOp::Rem, vec![DType::C64, DType::C64]),
         (StdTensorOp::Clamp, vec![DType::C64, DType::C64, DType::C64]),
         (StdTensorOp::ReduceMax { axes: vec![0] }, vec![DType::C64]),
         (StdTensorOp::ReduceMin { axes: vec![0] }, vec![DType::C32]),
@@ -354,6 +355,22 @@ fn ordered_ops_reject_complex_dtypes() {
         assert!(message.contains("complex"), "{op:?}: {message}");
         assert!(message.contains("total order"), "{op:?}: {message}");
     }
+}
+
+#[test]
+fn ordered_dtype_rejection_uses_the_discovery_phase() {
+    let err = infer_output_dtype_at(
+        &StdTensorOp::Rem,
+        &[DType::C64, DType::C64],
+        ErrorPhase::GraphBuild,
+    )
+    .unwrap_err();
+
+    assert_eq!(err.kind(), ErrorKind::Unsupported);
+    assert_eq!(err.phase(), Some(ErrorPhase::GraphBuild));
+    assert!(err
+        .to_string()
+        .contains("Rem does not support complex dtypes"));
 }
 
 #[test]

--- a/crates/tenferro-runtime/src/shape_packing.rs
+++ b/crates/tenferro-runtime/src/shape_packing.rs
@@ -374,6 +374,13 @@ impl<'a> TracedSliceBuilder<'a> {
     /// let y = x.slice_builder().axis(0, 1..4).apply().unwrap();
     /// assert_eq!(y.try_concrete_shape(), Some(vec![3]));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` or
+    /// `DuplicateAxis` when selections are invalid, and propagates the
+    /// underlying [`Error::Validation`] from a slice/take graph operation
+    /// that cannot be built.
     pub fn apply(self) -> Result<TracedTensor> {
         let shape = concrete_shape_for_axis_slice(self.tensor, "slice_builder")?;
         let mut seen = vec![false; shape.len()];
@@ -409,6 +416,12 @@ impl TracedTensor {
     /// let y = x.slice_axis(0, 1..3).unwrap();
     /// assert_eq!(y.try_concrete_shape(), Some(vec![2]));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when `axis` is
+    /// outside the concrete rank, or `InvalidArgument` when `range` is
+    /// outside the selected axis extent.
     pub fn slice_axis(&self, axis: usize, range: Range<usize>) -> Result<Self> {
         self.slice_builder().axis(axis, range).apply()
     }
@@ -439,6 +452,12 @@ impl TracedTensor {
     /// let y = x.take_axis(0, &[2, 0]).unwrap();
     /// assert_eq!(y.try_concrete_shape(), Some(vec![2]));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when `axis` is
+    /// outside the concrete rank, or `InvalidArgument` when an index list
+    /// cannot be applied to the selected axis.
     pub fn take_axis(&self, axis: usize, indices: &[usize]) -> Result<Self> {
         let axis = isize::try_from(axis).map_err(|_| {
             Error::validation(
@@ -475,6 +494,13 @@ impl TracedTensor {
     ///     &[30.0, 10.0],
     /// );
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `InvalidArgument` when the tensor
+    /// shape is not concrete, `AxisOutOfBounds` when `axis` is outside its
+    /// rank, or `InvalidArgument` when a position is outside the selected
+    /// axis extent.
     pub fn index_select(&self, axis: isize, positions: &[usize]) -> Result<Self> {
         let shape = try_concrete_shape(self).ok_or_else(|| {
             Error::validation(
@@ -518,6 +544,12 @@ impl TracedTensor {
     ///     &[1.0, 2.0],
     /// );
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `InvalidArgument` for an empty input
+    /// list, `ShapeMismatch` for incompatible input shapes, or
+    /// `AxisOutOfBounds` when `dim` is outside the output rank.
     pub fn stack(tensors: &[&Self], dim: isize) -> Result<Self> {
         let first = tensors.first().copied().ok_or_else(|| {
             Error::validation(
@@ -575,6 +607,12 @@ impl TracedTensor {
     }
 
     /// Concatenate tensors along one existing axis.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `InvalidArgument` for an empty input
+    /// list, `RankMismatch`/`ShapeMismatch` for incompatible input shapes, or
+    /// `AxisOutOfBounds` when `axis` is outside the input rank.
     pub fn concatenate(tensors: &[&Self], axis: usize) -> Result<Self> {
         let first = tensors.first().copied().ok_or_else(|| {
             Error::validation(
@@ -659,7 +697,7 @@ fn apply_nary_concatenate(
     let graph = Arc::new(builder.build());
     // Callers route through shape inference before graph construction.
     let metadata_scope =
-        super::traced::register_metadata_or_internal(register_scoped_value_metadata(
+        super::traced::register_metadata_or_runtime_state(register_scoped_value_metadata(
             graph.values()[outputs[0]].key.clone(),
             tensor_meta(out_dtype, out_shape.clone()),
         ))?;
@@ -695,7 +733,16 @@ fn apply_nary_concatenate(
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_existing_axis, normalize_insert_axis};
+    use std::ops::Range;
+
+    use tenferro_tensor::{DType, ErrorKind, ValidationError, ValidationKind};
+
+    use super::{
+        apply_slice_axis_config, concrete_shape_for_axis_slice, index_select_config,
+        normalize_existing_axis, normalize_insert_axis, validate_axis_selection,
+        validate_stack_shapes, AxisSelection,
+    };
+    use crate::TracedTensor;
 
     #[test]
     fn axis_normalization_handles_ranks_larger_than_isize_max() {
@@ -709,5 +756,248 @@ mod tests {
             usize::MAX - 1
         );
         assert!(normalize_insert_axis("test", -1, usize::MAX).is_err());
+    }
+
+    #[test]
+    fn axis_normalization_reports_positive_and_negative_bounds() {
+        assert_eq!(normalize_existing_axis("test", 1, 3).unwrap(), 1);
+        assert_eq!(normalize_existing_axis("test", -1, 3).unwrap(), 2);
+        assert_eq!(normalize_insert_axis("test", 3, 3).unwrap(), 3);
+        assert_eq!(normalize_insert_axis("test", -1, 3).unwrap(), 3);
+
+        for error in [
+            normalize_existing_axis("test", 3, 3).unwrap_err(),
+            normalize_existing_axis("test", -4, 3).unwrap_err(),
+            normalize_insert_axis("test", 4, 3).unwrap_err(),
+            normalize_insert_axis("test", -5, 3).unwrap_err(),
+        ] {
+            assert_eq!(
+                error.kind(),
+                ErrorKind::Validation(ValidationKind::AxisOutOfBounds)
+            );
+        }
+    }
+
+    #[test]
+    fn index_select_config_validates_positions_and_builds_gather_metadata() {
+        let (indices, config, output_shape) = index_select_config(&[3, 4], -1, &[3, 1]).unwrap();
+        assert_eq!(indices.as_slice::<i64>().unwrap(), &[3, 1]);
+        assert_eq!(output_shape, vec![3, 2]);
+        assert_eq!(config.collapsed_slice_dims, vec![1]);
+        assert_eq!(config.offset_dims, vec![0]);
+        assert_eq!(config.start_index_map, vec![1]);
+        assert_eq!(config.slice_sizes, vec![3, 1]);
+
+        let error = index_select_config(&[3], 0, &[3]).unwrap_err();
+        assert!(matches!(
+            error,
+            crate::Error::Validation {
+                source: ValidationError::InvalidArgument {
+                    argument: "positions",
+                    ..
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn stack_shape_and_selection_helpers_cover_validation_contracts() {
+        let first = [2usize, 3];
+        let same = [2usize, 3];
+        let different = [2usize, 4];
+        assert!(validate_stack_shapes("stack", &[&first, &same]).is_ok());
+        assert!(matches!(
+            validate_stack_shapes("stack", &[]).unwrap_err(),
+            crate::Error::Validation {
+                source: ValidationError::InvalidArgument {
+                    argument: "tensors",
+                    ..
+                },
+                ..
+            }
+        ));
+        assert!(matches!(
+            validate_stack_shapes("stack", &[&first, &different]).unwrap_err(),
+            crate::Error::Validation {
+                source: ValidationError::ShapeMismatch(_),
+                ..
+            }
+        ));
+
+        let mut seen = vec![false; 2];
+        validate_axis_selection("slice", 2, &mut seen, 1).unwrap();
+        assert!(matches!(
+            validate_axis_selection("slice", 2, &mut seen, 1).unwrap_err(),
+            crate::Error::Validation {
+                source: ValidationError::DuplicateAxis { axis: 1, .. },
+                ..
+            }
+        ));
+        assert!(matches!(
+            validate_axis_selection("slice", 2, &mut seen, 2).unwrap_err(),
+            crate::Error::Validation {
+                source: ValidationError::AxisOutOfBounds { axis: 2, rank: 2 },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn slice_config_distinguishes_take_only_from_ranges_and_rejects_bad_ranges() {
+        let take_only = [AxisSelection::Take {
+            axis: 0,
+            indices: vec![1],
+        }];
+        assert!(apply_slice_axis_config("slice", &[3], &take_only)
+            .unwrap()
+            .is_none());
+
+        let ranges = [AxisSelection::Slice {
+            axis: 0,
+            range: 1..3,
+            step: 2,
+        }];
+        assert_eq!(
+            apply_slice_axis_config("slice", &[4], &ranges)
+                .unwrap()
+                .unwrap()
+                .strides,
+            vec![2]
+        );
+
+        let zero_step = [AxisSelection::Slice {
+            axis: 0,
+            range: 0..1,
+            step: 0,
+        }];
+        assert!(matches!(
+            apply_slice_axis_config("slice", &[2], &zero_step).unwrap_err(),
+            crate::Error::Validation {
+                source: ValidationError::InvalidSliceStep { step: 0 },
+                ..
+            }
+        ));
+
+        let bad_bounds = [AxisSelection::Slice {
+            axis: 0,
+            range: Range { start: 2, end: 4 },
+            step: 1,
+        }];
+        assert!(matches!(
+            apply_slice_axis_config("slice", &[3], &bad_bounds).unwrap_err(),
+            crate::Error::Validation {
+                source: ValidationError::InvalidSliceBounds { axis_len: 3, .. },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn public_slice_stack_and_concatenate_paths_preserve_structured_errors() {
+        let x = TracedTensor::from_vec_col_major(
+            vec![4, 5],
+            (0..20).map(|value| value as f64).collect(),
+        )
+        .unwrap();
+        let sliced = x
+            .slice_builder()
+            .axis(0, 1..4)
+            .take_axis(1, &[4, 0])
+            .apply()
+            .unwrap();
+        assert_eq!(sliced.try_concrete_shape(), Some(vec![3, 2]));
+
+        assert!(matches!(
+            x.slice_builder()
+                .axis(0, 0..2)
+                .axis_step(0, 0..2, 1)
+                .apply(),
+            Err(crate::Error::Validation {
+                source: ValidationError::DuplicateAxis { .. },
+                ..
+            })
+        ));
+
+        let symbolic = TracedTensor::input_symbolic_shape(DType::F64, 2).unwrap();
+        assert!(matches!(
+            concrete_shape_for_axis_slice(&symbolic, "slice_builder"),
+            Err(crate::Error::Validation {
+                source: ValidationError::InvalidArgument {
+                    argument: "shape",
+                    ..
+                },
+                ..
+            })
+        ));
+        assert!(matches!(
+            symbolic.index_select(0, &[0]),
+            Err(crate::Error::Validation {
+                source: ValidationError::InvalidArgument {
+                    argument: "shape",
+                    ..
+                },
+                ..
+            })
+        ));
+
+        let a = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+        let b = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
+        let stacked = TracedTensor::stack(&[&a, &b], -1).unwrap();
+        assert_eq!(stacked.try_concrete_shape(), Some(vec![2, 2]));
+        assert!(matches!(
+            TracedTensor::stack(&[], 0),
+            Err(crate::Error::Validation {
+                source: ValidationError::InvalidArgument {
+                    argument: "tensors",
+                    ..
+                },
+                ..
+            })
+        ));
+        assert!(matches!(
+            TracedTensor::stack(&[&a, &x], 0),
+            Err(crate::Error::Validation {
+                source: ValidationError::ShapeMismatch(_),
+                ..
+            })
+        ));
+        assert!(matches!(
+            TracedTensor::stack(&[&a, &b], 2),
+            Err(crate::Error::Validation {
+                source: ValidationError::AxisOutOfBounds { .. },
+                ..
+            })
+        ));
+
+        let c = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f32, 4.0]).unwrap();
+        let concatenated = TracedTensor::concatenate(&[&a, &c], 0).unwrap();
+        assert_eq!(concatenated.dtype, DType::F64);
+        assert_eq!(concatenated.try_concrete_shape(), Some(vec![4]));
+        assert!(matches!(
+            TracedTensor::concatenate(&[], 0),
+            Err(crate::Error::Validation {
+                source: ValidationError::InvalidArgument {
+                    argument: "tensors",
+                    ..
+                },
+                ..
+            })
+        ));
+        assert!(matches!(
+            TracedTensor::concatenate(&[&a, &b], 1),
+            Err(crate::Error::Validation {
+                source: ValidationError::AxisOutOfBounds { .. },
+                ..
+            })
+        ));
+        let rank_one = TracedTensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 2.0]).unwrap();
+        assert!(matches!(
+            TracedTensor::concatenate(&[&a, &rank_one], 0),
+            Err(crate::Error::Validation {
+                source: ValidationError::RankMismatch { .. },
+                ..
+            })
+        ));
     }
 }

--- a/crates/tenferro-runtime/src/shape_packing.rs
+++ b/crates/tenferro-runtime/src/shape_packing.rs
@@ -4,10 +4,12 @@ use std::sync::Arc;
 use computegraph::graph::GraphBuilder;
 use computegraph::types::{OperationRole, ValueRef};
 use tenferro_ops::std_tensor_op::StdTensorOp;
-use tenferro_tensor::{GatherConfig, SliceConfig, Tensor, TypedTensor};
+use tenferro_tensor::{
+    GatherConfig, ShapeMismatch, ShapeVec, SliceConfig, Tensor, TypedTensor, ValidationError,
+};
 
 use crate::checkpoint::CheckpointNode;
-use crate::error::{Error, Result};
+use crate::error::{Error, ErrorPhase, Result};
 use crate::metadata::{register_scoped_value_metadata, tensor_meta, MetadataScopeChain};
 use crate::shape_constraint::ConstraintScopeChain;
 use crate::shape_infer::promote_dtypes;
@@ -22,50 +24,66 @@ fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> Result
     let normalized = if axis >= 0 {
         axis as usize
     } else {
-        rank.checked_sub(axis.unsigned_abs())
-            .ok_or(tenferro_tensor::Error::AxisOutOfBounds {
+        rank.checked_sub(axis.unsigned_abs()).ok_or_else(|| {
+            Error::validation(
                 op,
-                axis: axis.unsigned_abs(),
-                rank,
-            })?
+                ErrorPhase::GraphBuild,
+                ValidationError::AxisOutOfBounds {
+                    axis: axis.unsigned_abs(),
+                    rank,
+                },
+            )
+        })?
     };
     if normalized >= rank {
-        return Err(tenferro_tensor::Error::AxisOutOfBounds {
+        return Err(Error::validation(
             op,
-            axis: axis.unsigned_abs(),
-            rank,
-        }
-        .into());
+            ErrorPhase::GraphBuild,
+            ValidationError::AxisOutOfBounds {
+                axis: axis.unsigned_abs(),
+                rank,
+            },
+        ));
     }
     Ok(normalized)
 }
 
 fn normalize_insert_axis(op: &'static str, axis: isize, rank: usize) -> Result<usize> {
-    let insert_rank = rank
-        .checked_add(1)
-        .ok_or(tenferro_tensor::Error::AxisOutOfBounds {
+    let insert_rank = rank.checked_add(1).ok_or_else(|| {
+        Error::validation(
             op,
-            axis: axis.unsigned_abs(),
-            rank,
-        })?;
+            ErrorPhase::GraphBuild,
+            ValidationError::AxisOutOfBounds {
+                axis: axis.unsigned_abs(),
+                rank,
+            },
+        )
+    })?;
     let normalized = if axis >= 0 {
         axis as usize
     } else {
-        insert_rank.checked_sub(axis.unsigned_abs()).ok_or(
-            tenferro_tensor::Error::AxisOutOfBounds {
-                op,
+        insert_rank
+            .checked_sub(axis.unsigned_abs())
+            .ok_or_else(|| {
+                Error::validation(
+                    op,
+                    ErrorPhase::GraphBuild,
+                    ValidationError::AxisOutOfBounds {
+                        axis: axis.unsigned_abs(),
+                        rank: insert_rank,
+                    },
+                )
+            })?
+    };
+    if normalized > rank {
+        return Err(Error::validation(
+            op,
+            ErrorPhase::GraphBuild,
+            ValidationError::AxisOutOfBounds {
                 axis: axis.unsigned_abs(),
                 rank: insert_rank,
             },
-        )?
-    };
-    if normalized > rank {
-        return Err(tenferro_tensor::Error::AxisOutOfBounds {
-            op,
-            axis: axis.unsigned_abs(),
-            rank: insert_rank,
-        }
-        .into());
+        ));
     }
     Ok(normalized)
 }
@@ -79,13 +97,16 @@ fn index_select_config(
     let axis_extent = shape[axis];
     for &position in positions {
         if position >= axis_extent {
-            return Err(tenferro_tensor::Error::InvalidConfig {
-                op: "index_select",
-                message: format!(
+            return Err(Error::validation(
+                "index_select",
+                ErrorPhase::GraphBuild,
+                ValidationError::InvalidArgument {
+                    argument: "positions",
+                    message: format!(
                     "position {position} out of bounds for axis {axis} with extent {axis_extent}"
-                ),
-            }
-            .into());
+                    ),
+                },
+            ));
         }
     }
 
@@ -99,12 +120,18 @@ fn index_select_config(
     let index_data = positions
         .iter()
         .map(|&position| {
-            i64::try_from(position).map_err(|_| tenferro_tensor::Error::InvalidConfig {
-                op: "index_select",
-                message: format!("position {position} cannot be represented as i64"),
+            i64::try_from(position).map_err(|_| {
+                Error::validation(
+                    "index_select",
+                    ErrorPhase::GraphBuild,
+                    ValidationError::InvalidArgument {
+                        argument: "positions",
+                        message: format!("position {position} cannot be represented as i64"),
+                    },
+                )
             })
         })
-        .collect::<tenferro_tensor::Result<Vec<_>>>()?;
+        .collect::<Result<Vec<_>>>()?;
     let indices = Tensor::I64(TypedTensor::from_vec_col_major(
         vec![positions.len(), 1],
         index_data,
@@ -123,20 +150,26 @@ fn index_select_config(
 
 fn validate_stack_shapes(op: &'static str, shapes: &[&[usize]]) -> Result<()> {
     let Some(first) = shapes.first() else {
-        return Err(tenferro_tensor::Error::InvalidConfig {
+        return Err(Error::validation(
             op,
-            message: "stack requires at least one input".into(),
-        }
-        .into());
+            ErrorPhase::GraphBuild,
+            ValidationError::InvalidArgument {
+                argument: "tensors",
+                message: "stack requires at least one input".into(),
+            },
+        ));
     };
     for shape in shapes.iter().skip(1) {
         if *shape != *first {
-            return Err(tenferro_tensor::Error::ShapeMismatch {
+            return Err(Error::validation(
                 op,
-                lhs: first.to_vec(),
-                rhs: shape.to_vec(),
-            }
-            .into());
+                ErrorPhase::GraphBuild,
+                ShapeMismatch::IncompatibleShapes {
+                    lhs: ShapeVec::from_vec(first.to_vec()),
+                    rhs: ShapeVec::from_vec(shape.to_vec()),
+                }
+                .into(),
+            ));
         }
     }
     Ok(())
@@ -156,9 +189,15 @@ enum AxisSelection {
 }
 
 fn concrete_shape_for_axis_slice(tensor: &TracedTensor, op: &'static str) -> Result<Vec<usize>> {
-    try_concrete_shape(tensor).ok_or_else(|| Error::InvalidGraphBuild {
-        op,
-        message: format!("{op} requires a concrete shape hint"),
+    try_concrete_shape(tensor).ok_or_else(|| {
+        Error::validation(
+            op,
+            ErrorPhase::GraphBuild,
+            ValidationError::InvalidArgument {
+                argument: "shape",
+                message: format!("{op} requires a concrete shape hint"),
+            },
+        )
     })
 }
 
@@ -169,15 +208,21 @@ fn validate_axis_selection(
     axis: usize,
 ) -> Result<()> {
     if axis >= rank {
-        return Err(tenferro_tensor::Error::AxisOutOfBounds { op, axis, rank }.into());
+        return Err(Error::validation(
+            op,
+            ErrorPhase::GraphBuild,
+            ValidationError::AxisOutOfBounds { axis, rank },
+        ));
     }
     if seen[axis] {
-        return Err(tenferro_tensor::Error::DuplicateAxis {
+        return Err(Error::validation(
             op,
-            axis,
-            role: "selection",
-        }
-        .into());
+            ErrorPhase::GraphBuild,
+            ValidationError::DuplicateAxis {
+                axis,
+                role: "selection",
+            },
+        ));
     }
     seen[axis] = true;
     Ok(())
@@ -197,22 +242,29 @@ fn apply_slice_axis_config(
             continue;
         };
         if *step == 0 {
-            return Err(tenferro_tensor::Error::InvalidConfig {
+            return Err(Error::validation(
                 op,
-                message: format!("axis {axis} has zero step"),
-            }
-            .into());
+                ErrorPhase::GraphBuild,
+                ValidationError::InvalidSliceStep { step: 0 },
+            ));
         }
         let extent = shape[*axis];
         if range.start > range.end || range.end > extent {
-            return Err(tenferro_tensor::Error::InvalidConfig {
+            let start = isize::try_from(range.start).map_err(|_| {
+                Error::validation(op, ErrorPhase::GraphBuild, ValidationError::IntegerOverflow)
+            })?;
+            let end = isize::try_from(range.end).map_err(|_| {
+                Error::validation(op, ErrorPhase::GraphBuild, ValidationError::IntegerOverflow)
+            })?;
+            return Err(Error::validation(
                 op,
-                message: format!(
-                    "axis {axis} range {}..{} is out of bounds for extent {extent}",
-                    range.start, range.end
-                ),
-            }
-            .into());
+                ErrorPhase::GraphBuild,
+                ValidationError::InvalidSliceBounds {
+                    start,
+                    end,
+                    axis_len: extent,
+                },
+            ));
         }
         starts[*axis] = range.start;
         limits[*axis] = range.end;
@@ -389,10 +441,14 @@ impl TracedTensor {
     /// ```
     pub fn take_axis(&self, axis: usize, indices: &[usize]) -> Result<Self> {
         let axis = isize::try_from(axis).map_err(|_| {
-            Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
-                op: "take_axis",
-                message: format!("axis {axis} cannot be represented as isize"),
-            })
+            Error::validation(
+                "take_axis",
+                ErrorPhase::GraphBuild,
+                ValidationError::InvalidArgument {
+                    argument: "axis",
+                    message: format!("axis {axis} cannot be represented as isize"),
+                },
+            )
         })?;
         self.index_select(axis, indices)
     }
@@ -420,9 +476,15 @@ impl TracedTensor {
     /// );
     /// ```
     pub fn index_select(&self, axis: isize, positions: &[usize]) -> Result<Self> {
-        let shape = try_concrete_shape(self).ok_or_else(|| Error::InvalidGraphBuild {
-            op: "index_select",
-            message: "index_select requires a concrete shape hint".into(),
+        let shape = try_concrete_shape(self).ok_or_else(|| {
+            Error::validation(
+                "index_select",
+                ErrorPhase::GraphBuild,
+                ValidationError::InvalidArgument {
+                    argument: "shape",
+                    message: "index_select requires a concrete shape hint".into(),
+                },
+            )
         })?;
         let (indices_tensor, config, out_shape) = index_select_config(&shape, axis, positions)?;
         let indices = TracedTensor::from_tensor_concrete_shape(indices_tensor)?;
@@ -458,24 +520,38 @@ impl TracedTensor {
     /// ```
     pub fn stack(tensors: &[&Self], dim: isize) -> Result<Self> {
         let first = tensors.first().copied().ok_or_else(|| {
-            Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
-                op: "stack",
-                message: "stack requires at least one input".into(),
-            })
+            Error::validation(
+                "stack",
+                ErrorPhase::GraphBuild,
+                ValidationError::InvalidArgument {
+                    argument: "tensors",
+                    message: "stack requires at least one input".into(),
+                },
+            )
         })?;
-        let first_shape = try_concrete_shape(first).ok_or_else(|| Error::InvalidGraphBuild {
-            op: "stack",
-            message: "stack requires concrete shape hints".into(),
+        let first_shape = try_concrete_shape(first).ok_or_else(|| {
+            Error::validation(
+                "stack",
+                ErrorPhase::GraphBuild,
+                ValidationError::InvalidArgument {
+                    argument: "shape",
+                    message: "stack requires concrete shape hints".into(),
+                },
+            )
         })?;
         let mut shapes = Vec::with_capacity(tensors.len());
         shapes.push(first_shape.as_slice());
         let mut owned_shapes = Vec::with_capacity(tensors.len().saturating_sub(1));
         for tensor in tensors.iter().copied().skip(1) {
             owned_shapes.push(try_concrete_shape(tensor).ok_or_else(|| {
-                Error::InvalidGraphBuild {
-                    op: "stack",
-                    message: "stack requires concrete shape hints".into(),
-                }
+                Error::validation(
+                    "stack",
+                    ErrorPhase::GraphBuild,
+                    ValidationError::InvalidArgument {
+                        argument: "shape",
+                        message: "stack requires concrete shape hints".into(),
+                    },
+                )
             })?);
         }
         shapes.extend(owned_shapes.iter().map(Vec::as_slice));
@@ -501,27 +577,35 @@ impl TracedTensor {
     /// Concatenate tensors along one existing axis.
     pub fn concatenate(tensors: &[&Self], axis: usize) -> Result<Self> {
         let first = tensors.first().copied().ok_or_else(|| {
-            Error::TensorRuntime(tenferro_tensor::Error::InvalidConfig {
-                op: "concatenate",
-                message: "concatenate requires at least one input".into(),
-            })
+            Error::validation(
+                "concatenate",
+                ErrorPhase::GraphBuild,
+                ValidationError::InvalidArgument {
+                    argument: "tensors",
+                    message: "concatenate requires at least one input".into(),
+                },
+            )
         })?;
         if axis >= first.rank {
-            return Err(tenferro_tensor::Error::AxisOutOfBounds {
-                op: "concatenate",
-                axis,
-                rank: first.rank,
-            }
-            .into());
+            return Err(Error::validation(
+                "concatenate",
+                ErrorPhase::GraphBuild,
+                ValidationError::AxisOutOfBounds {
+                    axis,
+                    rank: first.rank,
+                },
+            ));
         }
         for tensor in tensors.iter().copied().skip(1) {
             if tensor.rank != first.rank {
-                return Err(tenferro_tensor::Error::RankMismatch {
-                    op: "concatenate",
-                    expected: first.rank,
-                    actual: tensor.rank,
-                }
-                .into());
+                return Err(Error::validation(
+                    "concatenate",
+                    ErrorPhase::GraphBuild,
+                    ValidationError::RankMismatch {
+                        expected: first.rank,
+                        actual: tensor.rank,
+                    },
+                ));
             }
         }
 

--- a/crates/tenferro-runtime/src/tensor.rs
+++ b/crates/tenferro-runtime/src/tensor.rs
@@ -4,7 +4,7 @@
 //! provides backend-parametric operation methods through [`TensorOpsExt`].
 
 use tenferro_ops::broadcast::{
-    broadcast_input_plan, broadcast_shape, broadcast_shapes, BroadcastError,
+    broadcast_error_to_validation, broadcast_input_plan, broadcast_shape, broadcast_shapes,
 };
 use tenferro_tensor::validate::matmul_config_for_shapes;
 use tenferro_tensor::{CompareDir, DType, Error, Result, TensorBackend};
@@ -499,16 +499,6 @@ fn broadcast_to(
     backend.with_backend_session(|exec| exec.broadcast_in_dim(&source, target_shape, &plan.dims))
 }
 
-fn broadcast_error(err: BroadcastError) -> Error {
-    match err {
-        BroadcastError::IncompatibleBinary { lhs, rhs } => {
-            Error::shape_mismatch("broadcast", lhs, rhs)
-        }
-        BroadcastError::IncompatibleInput { input, output } => {
-            Error::shape_mismatch("broadcast", input, output)
-        }
-        BroadcastError::RankTooLarge { input, output } => {
-            Error::rank_mismatch("broadcast", output.len(), input.len())
-        }
-    }
+fn broadcast_error(err: tenferro_ops::broadcast::BroadcastError) -> Error {
+    Error::validation("broadcast", broadcast_error_to_validation(err))
 }

--- a/crates/tenferro-runtime/src/tensor.rs
+++ b/crates/tenferro-runtime/src/tensor.rs
@@ -3,7 +3,9 @@
 //! `tenferro-tensor` owns storage and backend traits. This runtime crate
 //! provides backend-parametric operation methods through [`TensorOpsExt`].
 
-use tenferro_ops::broadcast::{broadcast_input_plan, broadcast_shape, broadcast_shapes};
+use tenferro_ops::broadcast::{
+    broadcast_input_plan, broadcast_shape, broadcast_shapes, BroadcastError,
+};
 use tenferro_tensor::validate::matmul_config_for_shapes;
 use tenferro_tensor::{CompareDir, DType, Error, Result, TensorBackend};
 
@@ -497,6 +499,16 @@ fn broadcast_to(
     backend.with_backend_session(|exec| exec.broadcast_in_dim(&source, target_shape, &plan.dims))
 }
 
-fn broadcast_error(err: impl std::fmt::Display) -> Error {
-    Error::backend_failure("broadcast", err.to_string())
+fn broadcast_error(err: BroadcastError) -> Error {
+    match err {
+        BroadcastError::IncompatibleBinary { lhs, rhs } => {
+            Error::shape_mismatch("broadcast", lhs, rhs)
+        }
+        BroadcastError::IncompatibleInput { input, output } => {
+            Error::shape_mismatch("broadcast", input, output)
+        }
+        BroadcastError::RankTooLarge { input, output } => {
+            Error::rank_mismatch("broadcast", output.len(), input.len())
+        }
+    }
 }

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -8,16 +8,18 @@ use computegraph::types::{OperationRole, ValueKey, ValueRef};
 use computegraph::LocalValueId;
 use num_complex::{Complex32, Complex64};
 use tenferro_ops::ad::context::GlobalMetadataScope;
-use tenferro_ops::broadcast::{broadcast_input_plan, broadcast_shape, broadcast_shapes};
+use tenferro_ops::broadcast::{
+    broadcast_input_plan, broadcast_shape, broadcast_shapes, BroadcastError,
+};
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{
-    CompareDir, DType, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
-    Tensor, TensorScalar,
+    CompareDir, DType, DotGeneralConfig, Error as TensorError, GatherConfig, PadConfig,
+    ScatterConfig, ShapeMismatch, ShapeVec, SliceConfig, Tensor, TensorScalar, ValidationError,
 };
 
-use super::error::{Error, Result};
+use super::error::{Error, ErrorPhase, Result};
 use super::sym_dim::SymDim;
 use crate::checkpoint::CheckpointNode;
 use crate::metadata::{
@@ -132,21 +134,84 @@ pub(crate) fn try_concrete_shape(tensor: &TracedTensor) -> Option<Vec<usize>> {
         .collect()
 }
 
+fn graph_validation(op: &'static str, source: impl Into<ValidationError>) -> Error {
+    Error::validation(op, ErrorPhase::GraphBuild, source.into())
+}
+
+fn graph_invalid_argument(
+    op: &'static str,
+    argument: &'static str,
+    message: impl Into<String>,
+) -> Error {
+    graph_validation(
+        op,
+        ValidationError::InvalidArgument {
+            argument,
+            message: message.into(),
+        },
+    )
+}
+
+fn graph_broadcast_error(op: &'static str, error: BroadcastError) -> Error {
+    match error {
+        BroadcastError::IncompatibleBinary { lhs, rhs } => graph_validation(
+            op,
+            ShapeMismatch::IncompatibleShapes {
+                lhs: ShapeVec::from_vec(lhs),
+                rhs: ShapeVec::from_vec(rhs),
+            },
+        ),
+        BroadcastError::IncompatibleInput { input, output } => graph_validation(
+            op,
+            ShapeMismatch::ExpectedActual {
+                expected: ShapeVec::from_vec(output),
+                actual: ShapeVec::from_vec(input),
+            },
+        ),
+        BroadcastError::RankTooLarge { input, output } => graph_validation(
+            op,
+            ValidationError::RankMismatch {
+                expected: output.len(),
+                actual: input.len(),
+            },
+        ),
+    }
+}
+
+fn graph_tensor_error(op: &'static str, error: TensorError) -> Error {
+    match error {
+        TensorError::Validation { source, .. } => graph_validation(op, source),
+        other => Error::TensorRuntime(other),
+    }
+}
+
+fn graph_error_with_context(op: &'static str, error: Error) -> Error {
+    match error {
+        Error::Validation { source, .. } => graph_validation(op, source),
+        other => other,
+    }
+}
+
 pub(crate) fn concrete_shape(tensor: &TracedTensor) -> Result<Vec<usize>> {
     tensor
         .shape_hint
         .as_ref()
-        .ok_or_else(|| Error::InvalidGraphBuild {
-            op: "TracedTensor::concrete_shape",
-            message: format!("missing shape hint for traced tensor {}", tensor.id),
+        .ok_or_else(|| {
+            graph_invalid_argument(
+                "TracedTensor::concrete_shape",
+                "shape",
+                format!("missing shape hint for traced tensor {}", tensor.id),
+            )
         })?
         .iter()
         .map(|dim| {
-            dim.constant_value()
-                .ok_or_else(|| Error::InvalidGraphBuild {
-                    op: "TracedTensor::concrete_shape",
-                    message: format!("symbolic dimension in shape hint for tensor {}", tensor.id),
-                })
+            dim.constant_value().ok_or_else(|| {
+                graph_invalid_argument(
+                    "TracedTensor::concrete_shape",
+                    "shape",
+                    format!("symbolic dimension in shape hint for tensor {}", tensor.id),
+                )
+            })
         })
         .collect()
 }
@@ -161,12 +226,8 @@ pub(crate) fn broadcast_to(tensor: &TracedTensor, target_shape: &[usize]) -> Res
         return Ok(tensor.clone());
     }
 
-    let plan = broadcast_input_plan(&tensor_shape, target_shape).map_err(|err| {
-        Error::InvalidGraphBuild {
-            op: "broadcast_to",
-            message: err.to_string(),
-        }
-    })?;
+    let plan = broadcast_input_plan(&tensor_shape, target_shape)
+        .map_err(|err| graph_broadcast_error("broadcast_to", err))?;
 
     let source = if plan.source_shape == tensor_shape {
         tensor.clone()
@@ -189,10 +250,8 @@ pub(crate) fn broadcast_binary(
     }
     let a_shape = concrete_shape(a)?;
     let b_shape = concrete_shape(b)?;
-    let target = broadcast_shape(&a_shape, &b_shape).map_err(|err| Error::InvalidGraphBuild {
-        op: "broadcast_binary",
-        message: err.to_string(),
-    })?;
+    let target = broadcast_shape(&a_shape, &b_shape)
+        .map_err(|err| graph_broadcast_error("broadcast_binary", err))?;
     Ok((broadcast_to(a, &target)?, broadcast_to(b, &target)?))
 }
 
@@ -205,10 +264,7 @@ pub(crate) fn broadcast_ternary(
     let b_shape = concrete_shape(b)?;
     let c_shape = concrete_shape(c)?;
     let target = broadcast_shapes([a_shape.as_slice(), b_shape.as_slice(), c_shape.as_slice()])
-        .map_err(|err| Error::InvalidGraphBuild {
-            op: "broadcast_ternary",
-            message: err.to_string(),
-        })?;
+        .map_err(|err| graph_broadcast_error("broadcast_ternary", err))?;
     Ok((
         broadcast_to(a, &target)?,
         broadcast_to(b, &target)?,
@@ -227,20 +283,13 @@ fn scale_with_constant(input: &TracedTensor, op: StdTensorOp) -> Result<TracedTe
     )
 }
 
-fn dtype_inference_error(op: &StdTensorOp, context: &'static str, err: String) -> Error {
-    Error::InvalidGraphBuild {
-        op: context,
-        message: format!("built-in traced dtype inference failed for {op:?}: {err}"),
-    }
-}
-
 fn try_inferred_output_dtype(
     op: &StdTensorOp,
     inputs: &[DType],
     context: &'static str,
 ) -> Result<DType> {
     crate::shape_infer::infer_output_dtype(op, inputs)
-        .map_err(|err| dtype_inference_error(op, context, err.to_string()))
+        .map_err(|err| graph_error_with_context(context, err))
 }
 
 fn inferred_output_dtype(op: &StdTensorOp, inputs: &[DType], context: &'static str) -> DType {
@@ -255,14 +304,11 @@ fn inferred_output_dtype(op: &StdTensorOp, inputs: &[DType], context: &'static s
 fn checked_shape_product_for_graph_build(
     shape: &[usize],
     context: &'static str,
-    role: &'static str,
+    _role: &'static str,
 ) -> Result<usize> {
     shape.iter().copied().try_fold(1usize, |acc, dim| {
         acc.checked_mul(dim)
-            .ok_or_else(|| Error::InvalidGraphBuild {
-                op: context,
-                message: format!("{role} shape element count overflows usize"),
-            })
+            .ok_or_else(|| graph_validation(context, ValidationError::IntegerOverflow))
     })
 }
 
@@ -274,10 +320,10 @@ fn validate_concrete_reshape_shape(input: &TracedTensor, shape: &[usize]) -> Res
     let from =
         checked_shape_product_for_graph_build(&input_shape, "TracedTensor::reshape", "input")?;
     if from != to {
-        return Err(Error::InvalidGraphBuild {
-            op: "TracedTensor::reshape",
-            message: format!("reshape element-count mismatch: from {from} to {to}"),
-        });
+        return Err(graph_validation(
+            "TracedTensor::reshape",
+            ShapeMismatch::ReshapeElementCount { from, to },
+        ));
     }
     Ok(())
 }
@@ -317,27 +363,16 @@ pub(crate) fn infer_traced_single_output_shape(
         .map(|(input_idx, tensor)| traced_input_shape_exprs(input_idx, tensor))
         .collect();
     let input_shape_refs: Vec<&[DimExpr]> = input_shape_exprs.iter().map(Vec::as_slice).collect();
-    let output_shapes =
-        crate::shape_infer::infer_output_shapes(op, &input_shape_refs).map_err(|err| {
-            Error::InvalidGraphBuild {
-                op: op_name,
-                message: err.to_string(),
-            }
-        })?;
-    let output_shape = output_shapes
-        .first()
-        .ok_or_else(|| Error::InvalidGraphBuild {
-            op: op_name,
-            message: "shape inference returned no outputs".into(),
-        })?;
+    let output_shapes = crate::shape_infer::infer_output_shapes(op, &input_shape_refs)
+        .map_err(|err| graph_error_with_context(op_name, err))?;
+    let output_shape = output_shapes.first().ok_or_else(|| {
+        Error::Internal(format!("{op_name}: shape inference returned no outputs"))
+    })?;
     if output_shapes.len() != 1 {
-        return Err(Error::InvalidGraphBuild {
-            op: op_name,
-            message: format!(
-                "expected single-output shape inference, got {} outputs",
-                output_shapes.len()
-            ),
-        });
+        return Err(Error::Internal(format!(
+            "{op_name}: expected single-output shape inference, got {} outputs",
+            output_shapes.len()
+        )));
     }
 
     let input_sym_shapes: Vec<Vec<SymDim>> = inputs
@@ -366,16 +401,22 @@ fn reduction_output_meta(
     let mut seen = vec![false; tensor.rank];
     for &axis in axes {
         if axis >= tensor.rank {
-            return Err(Error::InvalidGraphBuild {
+            return Err(graph_validation(
                 op,
-                message: format!("axis {axis} out of bounds for rank {}", tensor.rank),
-            });
+                ValidationError::AxisOutOfBounds {
+                    axis,
+                    rank: tensor.rank,
+                },
+            ));
         }
         if seen[axis] {
-            return Err(Error::InvalidGraphBuild {
+            return Err(graph_validation(
                 op,
-                message: format!("duplicate reduction axis {axis}"),
-            });
+                ValidationError::DuplicateAxis {
+                    axis,
+                    role: "reduction",
+                },
+            ));
         }
         seen[axis] = true;
     }
@@ -391,10 +432,13 @@ fn reduction_output_meta(
 
 fn validate_traced_axis(tensor: &TracedTensor, axis: usize, op: &'static str) -> Result<()> {
     if axis >= tensor.rank {
-        return Err(Error::InvalidGraphBuild {
+        return Err(graph_validation(
             op,
-            message: format!("axis {axis} out of bounds for rank {}", tensor.rank),
-        });
+            ValidationError::AxisOutOfBounds {
+                axis,
+                rank: tensor.rank,
+            },
+        ));
     }
     Ok(())
 }
@@ -403,16 +447,16 @@ fn validate_traced_axes(rank: usize, axes: &[usize], op: &'static str) -> Result
     let mut seen = vec![false; rank];
     for &axis in axes {
         if axis >= rank {
-            return Err(Error::InvalidGraphBuild {
+            return Err(graph_validation(
                 op,
-                message: format!("axis {axis} out of bounds for rank {rank}"),
-            });
+                ValidationError::AxisOutOfBounds { axis, rank },
+            ));
         }
         if seen[axis] {
-            return Err(Error::InvalidGraphBuild {
+            return Err(graph_validation(
                 op,
-                message: format!("duplicate axis {axis}"),
-            });
+                ValidationError::DuplicateAxis { axis, role: "axis" },
+            ));
         }
         seen[axis] = true;
     }
@@ -421,37 +465,41 @@ fn validate_traced_axes(rank: usize, axes: &[usize], op: &'static str) -> Result
 
 fn validate_traced_insert_axis(rank: usize, axis: usize, op: &'static str) -> Result<()> {
     if axis > rank {
-        return Err(Error::InvalidGraphBuild {
+        return Err(graph_invalid_argument(
             op,
-            message: format!("axis {axis} out of bounds for rank {rank} insertion"),
-        });
+            "axis",
+            format!("axis {axis} out of bounds for rank {rank} insertion"),
+        ));
     }
     Ok(())
 }
 
 fn validate_traced_perm(rank: usize, perm: &[usize], op: &'static str) -> Result<()> {
     if perm.len() != rank {
-        return Err(Error::InvalidGraphBuild {
+        return Err(graph_validation(
             op,
-            message: format!(
-                "permutation length {} does not match rank {rank}",
-                perm.len()
-            ),
-        });
+            ValidationError::InvalidPermutationLength {
+                expected: rank,
+                actual: perm.len(),
+            },
+        ));
     }
     let mut seen = vec![false; rank];
     for &axis in perm {
         if axis >= rank {
-            return Err(Error::InvalidGraphBuild {
+            return Err(graph_validation(
                 op,
-                message: format!("permutation axis {axis} out of bounds for rank {rank}"),
-            });
+                ValidationError::AxisOutOfBounds { axis, rank },
+            ));
         }
         if seen[axis] {
-            return Err(Error::InvalidGraphBuild {
+            return Err(graph_validation(
                 op,
-                message: format!("duplicate permutation axis {axis}"),
-            });
+                ValidationError::DuplicateAxis {
+                    axis,
+                    role: "permutation",
+                },
+            ));
         }
         seen[axis] = true;
     }
@@ -465,32 +513,34 @@ fn validate_broadcast_in_dim_args(
     op: &'static str,
 ) -> Result<()> {
     if dims.len() != input.rank {
-        return Err(Error::InvalidGraphBuild {
+        return Err(graph_validation(
             op,
-            message: format!(
-                "dims length {} must match input rank {}",
-                dims.len(),
-                input.rank
-            ),
-        });
+            ValidationError::RankMismatch {
+                expected: input.rank,
+                actual: dims.len(),
+            },
+        ));
     }
 
     let mut seen = vec![false; output_shape.len()];
     for &dim in dims {
         if dim >= output_shape.len() {
-            return Err(Error::InvalidGraphBuild {
+            return Err(graph_validation(
                 op,
-                message: format!(
-                    "broadcast dim {dim} out of bounds for output rank {}",
-                    output_shape.len()
-                ),
-            });
+                ValidationError::AxisOutOfBounds {
+                    axis: dim,
+                    rank: output_shape.len(),
+                },
+            ));
         }
         if seen[dim] {
-            return Err(Error::InvalidGraphBuild {
+            return Err(graph_validation(
                 op,
-                message: format!("duplicate broadcast dim {dim}"),
-            });
+                ValidationError::DuplicateAxis {
+                    axis: dim,
+                    role: "broadcast",
+                },
+            ));
         }
         seen[dim] = true;
     }
@@ -500,13 +550,14 @@ fn validate_broadcast_in_dim_args(
             let input_dim = &input_shape[input_axis];
             let output_dim = &output_shape[output_axis];
             if input_dim != output_dim && input_dim.constant_value() != Some(1) {
-                return Err(Error::InvalidGraphBuild {
+                return Err(graph_invalid_argument(
                     op,
-                    message: format!(
+                    "shape",
+                    format!(
                         "input axis {input_axis} with dim {input_dim:?} cannot broadcast to \
                          output axis {output_axis} with dim {output_dim:?}"
                     ),
-                });
+                ));
             }
         }
     }
@@ -1150,10 +1201,11 @@ impl TracedTensor {
                 StdTensorOp::constant(Complex32::new(factor.re as f32, factor.im as f32)),
             ),
             DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => {
-                Err(Error::InvalidGraphBuild {
-                    op: "scale_complex",
-                    message: format!("requires complex tensor dtype, got {:?}", self.dtype),
-                })
+                Err(graph_invalid_argument(
+                    "scale_complex",
+                    "dtype",
+                    format!("requires complex tensor dtype, got {:?}", self.dtype),
+                ))
             }
         }
     }
@@ -1382,10 +1434,7 @@ impl TracedTensor {
     ) -> Result<TracedTensor> {
         config
             .validate_dims_with_ranks(self.rank, other.rank)
-            .map_err(|err| Error::InvalidGraphBuild {
-                op: "dot_general",
-                message: err.to_string(),
-            })?;
+            .map_err(|err| graph_tensor_error("dot_general", err))?;
         let lhs_free: Vec<usize> = (0..self.rank)
             .filter(|d| {
                 !config.lhs_contracting_dims.contains(d) && !config.lhs_batch_dims.contains(d)
@@ -1426,28 +1475,37 @@ impl TracedTensor {
     /// Matrix multiplication for rank-2 tensors.
     pub fn matmul(&self, other: &TracedTensor) -> Result<TracedTensor> {
         if self.rank != 2 {
-            return Err(Error::InvalidGraphBuild {
-                op: "TracedTensor::matmul",
-                message: format!("matmul requires rank-2 inputs, got lhs rank {}", self.rank),
-            });
+            return Err(graph_validation(
+                "TracedTensor::matmul",
+                ValidationError::RankMismatch {
+                    expected: 2,
+                    actual: self.rank,
+                },
+            ));
         }
         if other.rank != 2 {
-            return Err(Error::InvalidGraphBuild {
-                op: "TracedTensor::matmul",
-                message: format!("matmul requires rank-2 inputs, got rhs rank {}", other.rank),
-            });
+            return Err(graph_validation(
+                "TracedTensor::matmul",
+                ValidationError::RankMismatch {
+                    expected: 2,
+                    actual: other.rank,
+                },
+            ));
         }
         if let (Some(lhs_shape), Some(rhs_shape)) = (&self.shape_hint, &other.shape_hint) {
             if let (Some(lhs_cols), Some(rhs_rows)) =
                 (lhs_shape[1].constant_value(), rhs_shape[0].constant_value())
             {
                 if lhs_cols != rhs_rows {
-                    return Err(Error::InvalidGraphBuild {
-                        op: "TracedTensor::matmul",
-                        message: format!(
-                            "matmul dimension mismatch: lhs columns {lhs_cols} != rhs rows {rhs_rows}"
-                        ),
-                    });
+                    return Err(graph_validation(
+                        "TracedTensor::matmul",
+                        ShapeMismatch::ContractedDimensions {
+                            lhs_axis: 1,
+                            lhs_size: lhs_cols,
+                            rhs_axis: 0,
+                            rhs_size: rhs_rows,
+                        },
+                    ));
                 }
             }
         }
@@ -1829,14 +1887,16 @@ impl TracedTensor {
         let to_shape: Vec<DimExpr> = shape
             .iter()
             .map(|dim| {
-                dim.to_dim_expr(&tensor_map)
-                    .map_err(|err| Error::InvalidGraphBuild {
-                        op: "broadcast_in_dim_sym",
-                        message: format!(
+                dim.to_dim_expr(&tensor_map).map_err(|err| {
+                    graph_invalid_argument(
+                        "broadcast_in_dim_sym",
+                        "shape",
+                        format!(
                             "unresolved symbolic dimension: {err}; \
                              pass every referenced tensor via `shape_refs`"
                         ),
-                    })
+                    )
+                })
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -2042,10 +2102,11 @@ impl TracedTensor {
         validate_traced_axis(self, axis_a, "TracedTensor::extract_diag")?;
         validate_traced_axis(self, axis_b, "TracedTensor::extract_diag")?;
         if axis_a == axis_b {
-            return Err(Error::InvalidGraphBuild {
-                op: "TracedTensor::extract_diag",
-                message: "diagonal axes must be distinct".into(),
-            });
+            return Err(graph_invalid_argument(
+                "TracedTensor::extract_diag",
+                "axes",
+                "diagonal axes must be distinct",
+            ));
         }
         let op = StdTensorOp::ExtractDiag { axis_a, axis_b };
         let (out_rank, out_shape_hint) =
@@ -2145,10 +2206,13 @@ impl TracedTensor {
     pub fn dynamic_truncate(&self, size: &TracedTensor, axis: usize) -> Result<TracedTensor> {
         validate_traced_axis(self, axis, "TracedTensor::dynamic_truncate")?;
         if size.rank != 0 {
-            return Err(Error::InvalidGraphBuild {
-                op: "TracedTensor::dynamic_truncate",
-                message: format!("size must be a scalar tensor, got rank {}", size.rank),
-            });
+            return Err(graph_validation(
+                "TracedTensor::dynamic_truncate",
+                ValidationError::RankMismatch {
+                    expected: 0,
+                    actual: size.rank,
+                },
+            ));
         }
         apply_binary_preserve_input_dtypes(
             StdTensorOp::DynamicTruncate { axis },

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -536,25 +536,6 @@ fn validate_broadcast_in_dim_args(
         seen[dim] = true;
     }
 
-    if concrete_output_shape.is_none() {
-        if let Some(input_shape) = input.shape_hint.as_ref() {
-            for (input_axis, &output_axis) in dims.iter().enumerate() {
-                let input_dim = &input_shape[input_axis];
-                let output_dim = &output_shape[output_axis];
-                if input_dim != output_dim && input_dim.constant_value() != Some(1) {
-                    return Err(graph_invalid_argument(
-                        op,
-                        "shape",
-                        format!(
-                            "input axis {input_axis} with dim {input_dim:?} cannot broadcast to \
-                             output axis {output_axis} with dim {output_dim:?}"
-                        ),
-                    ));
-                }
-            }
-        }
-    }
-
     Ok(())
 }
 
@@ -1119,7 +1100,13 @@ impl TracedTensor {
     ///
     /// If symbolic ranks prevent shape comparison during graph construction,
     /// the same `ShapeMismatch` can be reported during compilation or
-    /// execution, with the corresponding [`ErrorPhase`].
+    /// execution, with the corresponding [`ErrorPhase`]. For integer inputs,
+    /// a zero divisor is reported during execution as
+    /// [`Error::TensorRuntime`] containing a
+    /// [`tenferro_tensor::Error::Extension`] classified as
+    /// `tenferro_tensor::ErrorKind::NumericalFailure` and retaining the typed
+    /// backend source; floating-point and complex zero divisors follow their
+    /// numeric semantics instead.
     pub fn div(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
         apply_binary(
@@ -1145,7 +1132,13 @@ impl TracedTensor {
     ///
     /// If symbolic ranks prevent shape comparison during graph construction,
     /// the same `ShapeMismatch` can be reported during compilation or
-    /// execution, with the corresponding [`ErrorPhase`].
+    /// execution, with the corresponding [`ErrorPhase`]. For integer inputs,
+    /// a zero divisor is reported during execution as
+    /// [`Error::TensorRuntime`] containing a
+    /// [`tenferro_tensor::Error::Extension`] classified as
+    /// `tenferro_tensor::ErrorKind::NumericalFailure` and retaining the typed
+    /// backend source; floating-point and complex zero divisors follow their
+    /// numeric semantics instead.
     pub fn rem(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
         apply_binary(

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::error::Error as StdError;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -387,10 +388,13 @@ pub(crate) fn infer_traced_single_output_shape(
     Ok((output_shape.len(), Some(out_shape_hint)))
 }
 
-pub(crate) fn register_metadata_or_internal(
-    result: std::result::Result<GlobalMetadataScope, impl std::fmt::Display>,
-) -> Result<GlobalMetadataScope> {
-    result.map_err(|err| Error::Internal(format!("metadata registration failed: {err}")))
+pub(crate) fn register_metadata_or_runtime_state<E>(
+    result: std::result::Result<GlobalMetadataScope, E>,
+) -> Result<GlobalMetadataScope>
+where
+    E: StdError + Send + Sync + 'static,
+{
+    result.map_err(|err| Error::runtime_state_source("metadata", ErrorPhase::Compile, err))
 }
 
 fn reduction_output_meta(
@@ -685,6 +689,11 @@ impl TracedTensor {
     /// assert_eq!(a.rank, 2);
     /// assert!(a.is_concrete_shape());
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when graph metadata registration
+    /// cannot retain the concrete tensor's shape or dtype.
     pub fn from_tensor_concrete_shape(tensor: Tensor) -> Result<Self> {
         let shape = tensor.shape().to_vec();
         let rank = shape.len();
@@ -697,7 +706,7 @@ impl TracedTensor {
         let val = builder.add_input(key.clone());
         builder.set_outputs(vec![val]);
         let graph = Arc::new(builder.build());
-        let metadata_scope = register_metadata_or_internal(register_scoped_value_metadata(
+        let metadata_scope = register_metadata_or_runtime_state(register_scoped_value_metadata(
             graph.values()[val].key.clone(),
             concrete_tensor_meta(dtype, &shape),
         ))?;
@@ -741,6 +750,11 @@ impl TracedTensor {
     /// assert_eq!(t.rank, 2);
     /// assert!(!t.is_concrete_shape());
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when symbolic graph metadata
+    /// registration is unavailable or its registry state is poisoned.
     pub fn from_tensor_symbolic_shape(tensor: Tensor) -> Result<Self> {
         let rank = tensor.shape().len();
         let dtype = tensor.dtype();
@@ -752,7 +766,7 @@ impl TracedTensor {
         let val = builder.add_input(key.clone());
         builder.set_outputs(vec![val]);
         let graph = Arc::new(builder.build());
-        let metadata_scope = register_metadata_or_internal(register_scoped_value_metadata(
+        let metadata_scope = register_metadata_or_runtime_state(register_scoped_value_metadata(
             graph.values()[val].key.clone(),
             symbolic_input_meta(dtype, id, rank),
         ))?;
@@ -792,6 +806,12 @@ impl TracedTensor {
     /// assert_eq!(x.rank, 2);
     /// assert!(x.is_concrete_shape());
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when graph metadata registration
+    /// fails or the registry state is poisoned. `dtype` and `shape` are
+    /// metadata values and are not revalidated by this constructor.
     pub fn input_concrete_shape(dtype: DType, shape: &[usize]) -> Result<Self> {
         let shape = shape.to_vec();
         let rank = shape.len();
@@ -802,7 +822,7 @@ impl TracedTensor {
         let val = builder.add_input(key.clone());
         builder.set_outputs(vec![val]);
         let graph = Arc::new(builder.build());
-        let metadata_scope = register_metadata_or_internal(register_scoped_value_metadata(
+        let metadata_scope = register_metadata_or_runtime_state(register_scoped_value_metadata(
             graph.values()[val].key.clone(),
             concrete_tensor_meta(dtype, &shape),
         ))?;
@@ -839,6 +859,12 @@ impl TracedTensor {
     /// assert_eq!(x.rank, 2);
     /// assert!(!x.is_concrete_shape());
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when graph metadata registration
+    /// fails or the registry state is poisoned. `rank` is recorded as the
+    /// symbolic placeholder rank and is not otherwise rejected here.
     pub fn input_symbolic_shape(dtype: DType, rank: usize) -> Result<Self> {
         let key = next_input_key();
         let id = next_traced_id();
@@ -847,7 +873,7 @@ impl TracedTensor {
         let val = builder.add_input(key.clone());
         builder.set_outputs(vec![val]);
         let graph = Arc::new(builder.build());
-        let metadata_scope = register_metadata_or_internal(register_scoped_value_metadata(
+        let metadata_scope = register_metadata_or_runtime_state(register_scoped_value_metadata(
             graph.values()[val].key.clone(),
             symbolic_input_meta(dtype, id, rank),
         ))?;
@@ -885,6 +911,13 @@ impl TracedTensor {
     /// assert_eq!(a.rank, 2);
     /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::TensorRuntime`] containing
+    /// `ValidationError::ShapeDataLengthMismatch` when the shape product does
+    /// not equal `data.len()`, or `ValidationError::IntegerOverflow` when the
+    /// shape product cannot be represented by `usize`.
     pub fn from_vec_col_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Result<Self> {
         Self::from_tensor_concrete_shape(Tensor::from_vec_col_major(shape, data)?)
     }
@@ -936,6 +969,11 @@ impl TracedTensor {
     /// Returns an error when a shape hint is missing or any dimension is
     /// symbolic. Composite traced ops that require concrete sizes should
     /// propagate this error instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `InvalidArgument` when this tensor
+    /// has no shape hint or any dimension is symbolic.
     pub fn concrete_shape(&self) -> Result<Vec<usize>> {
         concrete_shape(self)
     }
@@ -962,6 +1000,20 @@ impl TracedTensor {
     /// let y = x.add(&z);
     /// let y2 = &x + &z;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `ShapeMismatch` when operand shapes
+    /// cannot be broadcast, or [`Error::RuntimeStateSource`] when graph
+    /// metadata registration fails.
+    ///
+    /// # Deferred errors
+    ///
+    /// If symbolic dimensions prevent shape comparison during graph
+    /// construction, the same `ShapeMismatch` can be reported during
+    /// compilation or execution, with the corresponding [`ErrorPhase`]. A
+    /// backend-detected integer zero divisor is returned during execution as
+    /// [`Error::TensorRuntime`] with a typed `DivisionByZero` numerical source.
     pub fn add(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
         apply_binary(
@@ -976,6 +1028,20 @@ impl TracedTensor {
     /// Elementwise subtraction with NumPy-style broadcasting.
     ///
     /// Prefer using the `-` operator when it reads naturally.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `ShapeMismatch` when operand shapes
+    /// cannot be broadcast, or [`Error::RuntimeStateSource`] when graph
+    /// metadata registration fails.
+    ///
+    /// # Deferred errors
+    ///
+    /// If symbolic dimensions prevent shape comparison during graph
+    /// construction, the same `ShapeMismatch` can be reported during
+    /// compilation or execution, with the corresponding [`ErrorPhase`]. A
+    /// backend-detected integer zero divisor is returned during execution as
+    /// [`Error::TensorRuntime`] with a typed `DivisionByZero` numerical source.
     pub fn sub(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
         apply_binary(
@@ -1000,6 +1066,18 @@ impl TracedTensor {
     /// let y = x.mul(&z);
     /// let y2 = &x * &z;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `ShapeMismatch` when operand shapes
+    /// cannot be broadcast, or [`Error::RuntimeStateSource`] when graph
+    /// metadata registration fails.
+    ///
+    /// # Deferred errors
+    ///
+    /// If symbolic ranks prevent shape comparison during graph construction,
+    /// the same `ShapeMismatch` can be reported during compilation or
+    /// execution, with the corresponding [`ErrorPhase`].
     pub fn mul(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
         apply_binary(
@@ -1024,6 +1102,18 @@ impl TracedTensor {
     /// let y = x.div(&z);
     /// let y2 = &x / &z;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `ShapeMismatch` when operand shapes
+    /// cannot be broadcast, or [`Error::RuntimeStateSource`] when graph
+    /// metadata registration fails.
+    ///
+    /// # Deferred errors
+    ///
+    /// If symbolic ranks prevent shape comparison during graph construction,
+    /// the same `ShapeMismatch` can be reported during compilation or
+    /// execution, with the corresponding [`ErrorPhase`].
     pub fn div(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
         apply_binary(
@@ -1038,6 +1128,18 @@ impl TracedTensor {
     /// Elementwise remainder with NumPy-style broadcasting.
     ///
     /// Prefer using the `%` operator when it reads naturally.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `ShapeMismatch` when operand shapes
+    /// cannot be broadcast, or [`Error::RuntimeStateSource`] when graph
+    /// metadata registration fails.
+    ///
+    /// # Deferred errors
+    ///
+    /// If symbolic ranks prevent shape comparison during graph construction,
+    /// the same `ShapeMismatch` can be reported during compilation or
+    /// execution, with the corresponding [`ErrorPhase`].
     pub fn rem(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
         apply_binary(
@@ -1050,21 +1152,70 @@ impl TracedTensor {
     }
 
     /// Elementwise comparison with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `ShapeMismatch` when the concrete
+    /// operands cannot be broadcast, [`Error::Unsupported`] when ordered
+    /// comparison rejects a complex dtype, or [`Error::RuntimeStateSource`]
+    /// when result metadata cannot be registered.
+    ///
+    /// # Deferred errors
+    ///
+    /// With same-rank symbolic operands, shape compatibility is retained as a
+    /// graph constraint. A concrete mismatch is reported later as
+    /// [`Error::TensorRuntime`] containing a typed validation source, with the
+    /// failure phase identifying compilation or execution.
     pub fn compare(&self, other: &TracedTensor, dir: CompareDir) -> Result<TracedTensor> {
         apply_broadcast_binary_op(StdTensorOp::Compare(dir), self, other)
     }
 
     /// Elementwise maximum with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `ShapeMismatch` when the concrete
+    /// operands cannot be broadcast, [`Error::Unsupported`] when ordered
+    /// maximum rejects a complex dtype, or [`Error::RuntimeStateSource`] when
+    /// result metadata cannot be registered.
+    ///
+    /// # Deferred errors
+    ///
+    /// With same-rank symbolic operands, the broadcast constraint may fail at
+    /// compile or execution and is returned as [`Error::TensorRuntime`] with
+    /// its typed validation source.
     pub fn maximum(&self, other: &TracedTensor) -> Result<TracedTensor> {
         apply_broadcast_binary_op(StdTensorOp::Maximum, self, other)
     }
 
     /// Elementwise minimum with NumPy-style broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `ShapeMismatch` when the concrete
+    /// operands cannot be broadcast, [`Error::Unsupported`] when ordered
+    /// minimum rejects a complex dtype, or [`Error::RuntimeStateSource`] when
+    /// result metadata cannot be registered.
+    ///
+    /// # Deferred errors
+    ///
+    /// With same-rank symbolic operands, the broadcast constraint may fail at
+    /// compile or execution and is returned as [`Error::TensorRuntime`] with
+    /// its typed validation source.
     pub fn minimum(&self, other: &TracedTensor) -> Result<TracedTensor> {
         apply_broadcast_binary_op(StdTensorOp::Minimum, self, other)
     }
 
     /// Select values from `on_true` or `on_false` using `condition`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `InvalidArgument` when an operand
+    /// lacks concrete shape metadata, or `ShapeMismatch` when the concrete
+    /// condition and branches cannot share a broadcast shape. Dtype promotion
+    /// failures are returned as [`Error::TensorRuntime`] with the typed
+    /// `UnsupportedDTypeConversion` source; metadata failures retain
+    /// [`Error::RuntimeStateSource`].
     pub fn where_select(
         condition: &TracedTensor,
         on_true: &TracedTensor,
@@ -1074,6 +1225,14 @@ impl TracedTensor {
     }
 
     /// Alias for [`Self::where_select`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the same concrete failures as [`Self::where_select`]:
+    /// [`Error::Validation`] with `InvalidArgument`/`ShapeMismatch` for shape
+    /// metadata or broadcasting, [`Error::TensorRuntime`] with
+    /// `UnsupportedDTypeConversion` for failed promotion, and
+    /// [`Error::RuntimeStateSource`] for metadata registration.
     pub fn select(
         condition: &TracedTensor,
         on_true: &TracedTensor,
@@ -1083,6 +1242,14 @@ impl TracedTensor {
     }
 
     /// Clamp values elementwise between lower and upper bounds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `InvalidArgument` when an operand
+    /// lacks concrete shape metadata, `ShapeMismatch` when bounds cannot be
+    /// broadcast with the input, [`Error::Unsupported`] for an ordered
+    /// complex dtype, or [`Error::RuntimeStateSource`] when metadata cannot be
+    /// registered.
     pub fn clamp(&self, lower: &TracedTensor, upper: &TracedTensor) -> Result<TracedTensor> {
         apply_broadcast_ternary_op(StdTensorOp::Clamp, self, lower, upper)
     }
@@ -1103,6 +1270,11 @@ impl TracedTensor {
     /// let y = x.neg().unwrap();
     /// let y2 = (-&x).unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn neg(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Neg)
     }
@@ -1121,6 +1293,11 @@ impl TracedTensor {
     /// # .unwrap();
     /// let y = x.conj().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn conj(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Conj)
     }
@@ -1136,6 +1313,11 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![-1.0_f64, 2.0]).unwrap();
     /// let y = x.abs().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn abs(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Abs)
     }
@@ -1149,6 +1331,11 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![-1.0_f64, 2.0]).unwrap();
     /// let y = x.sign().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn sign(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Sign)
     }
@@ -1163,6 +1350,12 @@ impl TracedTensor {
     /// let y = x.scale_real(2.0)?;
     /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `InvalidArgument` when an integer or
+    /// boolean factor is non-finite or out of range for the input dtype, or
+    /// [`Error::RuntimeStateSource`] when output metadata registration fails.
     pub fn scale_real(&self, factor: f64) -> Result<TracedTensor> {
         let op = match self.dtype {
             DType::F64 => StdTensorOp::constant(factor),
@@ -1193,6 +1386,12 @@ impl TracedTensor {
     /// # .unwrap();
     /// let y = x.scale_complex(Complex64::new(0.0, 1.0)).unwrap(); // multiply by i
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `InvalidArgument` when a complex
+    /// factor is applied to a non-complex dtype, or
+    /// [`Error::RuntimeStateSource`] when output metadata registration fails.
     pub fn scale_complex(&self, factor: Complex64) -> Result<TracedTensor> {
         match self.dtype {
             DType::C64 => scale_with_constant(self, StdTensorOp::constant(factor)),
@@ -1219,6 +1418,11 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.exp().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn exp(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Exp)
     }
@@ -1232,6 +1436,11 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.log().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn log(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Log)
     }
@@ -1245,6 +1454,11 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.sin().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn sin(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Sin)
     }
@@ -1258,6 +1472,11 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.cos().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn cos(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Cos)
     }
@@ -1271,6 +1490,11 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.tanh().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn tanh(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Tanh)
     }
@@ -1284,6 +1508,11 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap();
     /// let y = x.sqrt().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn sqrt(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Sqrt)
     }
@@ -1297,6 +1526,11 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 4.0]).unwrap();
     /// let y = x.rsqrt().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn rsqrt(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Rsqrt)
     }
@@ -1311,6 +1545,20 @@ impl TracedTensor {
     /// # let exp = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 2.0]).unwrap();
     /// let y = base.pow(&exp);
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `ShapeMismatch` when the concrete
+    /// operands cannot be broadcast, or [`Error::RuntimeStateSource`] when
+    /// result metadata cannot be registered.
+    ///
+    /// # Deferred errors
+    ///
+    /// A symbolic broadcast mismatch or integer negative exponent is
+    /// discovered at compile or execution and is returned as
+    /// [`Error::TensorRuntime`] with a typed `ShapeMismatch` or
+    /// `NegativeIntegerExponent` numerical source and the corresponding
+    /// [`ErrorPhase`].
     pub fn pow(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
         apply_binary(
@@ -1331,6 +1579,11 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.expm1().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn expm1(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Expm1)
     }
@@ -1344,6 +1597,11 @@ impl TracedTensor {
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// let y = x.log1p().unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::RuntimeStateSource`] when the graph metadata registry
+    /// is unavailable or poisoned while recording the unary result.
     pub fn log1p(&self) -> Result<TracedTensor> {
         self.apply_same_shape_unary(StdTensorOp::Log1p)
     }
@@ -1365,9 +1623,10 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when the requested conversion is outside tenferro's
-    /// checked dtype-promotion lattice. Use [`cast`](Self::cast) for explicit
-    /// lossy dtype projection.
+    /// Returns [`tenferro_tensor::Error::UnsupportedDTypeConversion`] when the
+    /// requested pair is outside tenferro's checked dtype-promotion lattice,
+    /// or [`Error::Validation`] when graph metadata rejects the conversion.
+    /// Use [`cast`](Self::cast) for explicit lossy dtype projection.
     pub fn convert(&self, to: DType) -> Result<TracedTensor> {
         tenferro_tensor::validate::validate_convert_dtype("TracedTensor::convert", self.dtype, to)?;
         self.cast(to)
@@ -1388,6 +1647,13 @@ impl TracedTensor {
     ///
     /// let y = x.cast(DType::I32).unwrap();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::TensorRuntime`] containing
+    /// `UnsupportedDTypeConversion` when the requested input-to-target
+    /// projection is not supported, or [`Error::RuntimeStateSource`] when
+    /// converted-output metadata cannot be registered.
     pub fn cast(&self, to: DType) -> Result<TracedTensor> {
         if self.dtype == to {
             return Ok(self.clone());
@@ -1425,8 +1691,17 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when the dimension-numbering configuration is invalid
-    /// for the operand ranks.
+    /// Returns [`Error::Validation`] with `RankMismatch`, `AxisOutOfBounds`,
+    /// `DuplicateAxis`, or `AxisRoleConflict` when dimension numbers are
+    /// invalid for the operand ranks, and [`Error::RuntimeStateSource`] when
+    /// output metadata cannot be registered.
+    ///
+    /// # Deferred errors
+    ///
+    /// Contracting or batch dimensions whose sizes are symbolic are checked
+    /// when concrete inputs reach compilation or execution. A mismatch is
+    /// returned as [`Error::TensorRuntime`] with a typed `ShapeMismatch`
+    /// source and its corresponding [`ErrorPhase`].
     pub fn dot_general(
         &self,
         other: &TracedTensor,
@@ -1473,6 +1748,19 @@ impl TracedTensor {
     }
 
     /// Matrix multiplication for rank-2 tensors.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `RankMismatch` when either operand is
+    /// not rank 2, `ShapeMismatch::ContractedDimensions` when known matrix
+    /// dimensions differ, or [`Error::RuntimeStateSource`] when output
+    /// metadata cannot be registered.
+    ///
+    /// # Deferred errors
+    ///
+    /// If either contracted dimension is symbolic, the mismatch is discovered
+    /// at compilation or execution and returned as [`Error::TensorRuntime`]
+    /// with its typed `ShapeMismatch` source.
     pub fn matmul(&self, other: &TracedTensor) -> Result<TracedTensor> {
         if self.rank != 2 {
             return Err(graph_validation(
@@ -1534,7 +1822,10 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when an axis is out of bounds or duplicated.
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when an axis is
+    /// outside the input rank or `DuplicateAxis` when `axes` repeats an axis,
+    /// or [`Error::RuntimeStateSource`] when output metadata cannot be
+    /// registered.
     pub fn reduce_sum(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_sum")?;
@@ -1564,7 +1855,11 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when an axis is out of bounds or duplicated.
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when an axis is
+    /// outside the input rank or `DuplicateAxis` when `axes` repeats an axis,
+    /// [`Error::Unsupported`] when a non-empty maximum reduction receives a
+    /// complex dtype, or [`Error::RuntimeStateSource`] when output metadata
+    /// cannot be registered.
     pub fn reduce_max(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_max")?;
@@ -1595,7 +1890,11 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when an axis is out of bounds or duplicated.
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when an axis is
+    /// outside the input rank or `DuplicateAxis` when `axes` repeats an axis,
+    /// [`Error::Unsupported`] when a non-empty minimum reduction receives a
+    /// complex dtype, or [`Error::RuntimeStateSource`] when output metadata
+    /// cannot be registered.
     pub fn reduce_min(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_min")?;
@@ -1623,7 +1922,10 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when an axis is out of bounds or duplicated.
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when an axis is
+    /// outside the input rank or `DuplicateAxis` when `axes` repeats an axis,
+    /// or [`Error::RuntimeStateSource`] when output metadata cannot be
+    /// registered.
     pub fn reduce_prod(&self, axes: &[usize]) -> Result<TracedTensor> {
         let (out_rank, out_shape_hint) =
             reduction_output_meta(self, axes, "TracedTensor::reduce_prod")?;
@@ -1650,9 +1952,9 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when the input has a concrete shape and the target
-    /// shape has a different element count, or when the target shape product
-    /// overflows `usize`.
+    /// Returns [`Error::Validation`] with `ShapeMismatch::ReshapeElementCount`
+    /// when a concrete input has a different element count, or
+    /// `IntegerOverflow` when the target shape product overflows `usize`.
     pub fn reshape(&self, shape: &[usize]) -> Result<TracedTensor> {
         validate_concrete_reshape_shape(self, shape)?;
         apply_unary_with_dtype(
@@ -1695,7 +1997,8 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when `axis` is out of bounds.
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when `axis` is
+    /// outside this tensor's rank.
     pub fn sym_size(&self, axis: usize) -> Result<SymDim> {
         validate_traced_axis(self, axis, "TracedTensor::sym_size")?;
         Ok(self
@@ -1734,7 +2037,8 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when `axis` is out of bounds.
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when `axis` is
+    /// outside this tensor's rank.
     pub fn axis_sym_dim(&self, axis: usize) -> Result<SymDim> {
         validate_traced_axis(self, axis, "TracedTensor::axis_sym_dim")?;
         match self.shape_hint.as_ref().and_then(|shape| shape.get(axis)) {
@@ -1780,11 +2084,30 @@ impl TracedTensor {
     /// let y = x.reshape_sym(&[rows * cols]).unwrap();
     /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::SymbolicShapeConversion`] when a supplied symbolic
+    /// dimension cannot be mapped to this graph, or [`Error::RuntimeStateSource`]
+    /// when result metadata cannot be registered.
+    ///
+    /// # Deferred errors
+    ///
+    /// Element-count compatibility for symbolic dimensions is checked when
+    /// concrete inputs reach compilation or execution. A mismatch is returned
+    /// as [`Error::TensorRuntime`] with a typed `ShapeMismatch` source.
     pub fn reshape_sym(&self, shape: &[SymDim]) -> Result<TracedTensor> {
         let tensor_map = [(self.id, 0usize)];
         let to_shape = shape
             .iter()
-            .map(|dim| dim.to_dim_expr(&tensor_map).map_err(Error::Internal))
+            .map(|dim| {
+                dim.to_dim_expr(&tensor_map)
+                    .map_err(|source| Error::SymbolicShapeConversion {
+                        op: "TracedTensor::reshape_sym",
+                        phase: ErrorPhase::GraphBuild,
+                        source,
+                    })
+            })
             .collect::<Result<Vec<_>>>()?;
         let out_shape_hint = Some(shape.to_vec());
         apply_unary(
@@ -1808,9 +2131,11 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when `dims` is not a duplicate-free mapping from every
-    /// input axis into the output rank, or when a known input dimension cannot
-    /// broadcast to the corresponding output dimension.
+    /// Returns [`Error::Validation`] with `RankMismatch` when `dims` does not
+    /// have one entry per input axis, `AxisOutOfBounds` or `DuplicateAxis` for
+    /// an invalid output mapping, or `InvalidArgument` when known dimensions
+    /// cannot broadcast. [`Error::RuntimeStateSource`] reports failure to
+    /// register the result metadata.
     pub fn broadcast_in_dim(&self, shape: &[usize], dims: &[usize]) -> Result<TracedTensor> {
         let out_shape_hint: Vec<SymDim> = shape.iter().copied().map(SymDim::from).collect();
         validate_broadcast_in_dim_args(
@@ -1863,6 +2188,21 @@ impl TracedTensor {
     /// assert_eq!(a_b.rank, 3);
     /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `RankMismatch`, `AxisOutOfBounds`,
+    /// `DuplicateAxis`, or `InvalidArgument` when the output mapping or shape
+    /// references are invalid, [`Error::SymbolicShapeConversion`] for an
+    /// unmappable symbolic dimension, or [`Error::RuntimeStateSource`] when
+    /// metadata cannot be registered.
+    ///
+    /// # Deferred errors
+    ///
+    /// If a symbolic output dimension is smaller than a non-unit input axis,
+    /// the concrete broadcast check is deferred to compilation or execution
+    /// and is returned as [`Error::TensorRuntime`] with a typed validation
+    /// source.
     pub fn broadcast_in_dim_sym(
         &self,
         shape: &[SymDim],
@@ -1887,16 +2227,12 @@ impl TracedTensor {
         let to_shape: Vec<DimExpr> = shape
             .iter()
             .map(|dim| {
-                dim.to_dim_expr(&tensor_map).map_err(|err| {
-                    graph_invalid_argument(
-                        "broadcast_in_dim_sym",
-                        "shape",
-                        format!(
-                            "unresolved symbolic dimension: {err}; \
-                             pass every referenced tensor via `shape_refs`"
-                        ),
-                    )
-                })
+                dim.to_dim_expr(&tensor_map)
+                    .map_err(|source| Error::SymbolicShapeConversion {
+                        op: "broadcast_in_dim_sym",
+                        phase: ErrorPhase::GraphBuild,
+                        source,
+                    })
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -1923,6 +2259,14 @@ impl TracedTensor {
     }
 
     /// Slice with explicit start, limit, and stride per axis.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `RankMismatch` when the start/limit/
+    /// stride vectors do not match the input rank, `InvalidSliceStep` when a
+    /// stride is zero, `InvalidSliceBounds` when a limit precedes its start,
+    /// or [`Error::RuntimeStateSource`] when output metadata cannot be
+    /// registered.
     pub fn slice(&self, config: SliceConfig) -> Result<TracedTensor> {
         let op = StdTensorOp::Slice(config);
         let (out_rank, out_shape_hint) =
@@ -1931,6 +2275,14 @@ impl TracedTensor {
     }
 
     /// Pad with zeros using StableHLO-style edge and interior padding.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `RankMismatch` when padding vectors
+    /// do not match the input rank, `InvalidArgument` for negative interior
+    /// padding, or `IntegerOverflow` when the padded extent exceeds `usize`.
+    /// [`Error::RuntimeStateSource`] is returned when output metadata cannot be
+    /// registered.
     pub fn pad(&self, config: PadConfig) -> Result<TracedTensor> {
         let op = StdTensorOp::Pad(config);
         let (out_rank, out_shape_hint) =
@@ -1939,6 +2291,13 @@ impl TracedTensor {
     }
 
     /// Reverse the order of elements along the requested axes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when an axis is
+    /// outside the input rank or `DuplicateAxis` when `axes` repeats one, or
+    /// [`Error::RuntimeStateSource`] when result metadata cannot be
+    /// registered.
     pub fn reverse(&self, axes: &[usize]) -> Result<TracedTensor> {
         validate_traced_axes(self.rank, axes, "TracedTensor::reverse")?;
         apply_unary(
@@ -1952,6 +2311,20 @@ impl TracedTensor {
     }
 
     /// Gather slices from `self` using integer start indices.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `RankMismatch`, `AxisOutOfBounds`,
+    /// `DuplicateAxis`, or `ShapeMismatch` when indices or the gather
+    /// configuration is incompatible with the input, and
+    /// [`Error::RuntimeStateSource`] when output metadata cannot be
+    /// registered.
+    ///
+    /// # Deferred errors
+    ///
+    /// Runtime index values are checked after binding. An out-of-range index
+    /// is returned as [`Error::TensorRuntime`] with the backend's typed
+    /// validation source and [`ErrorPhase::Execution`].
     pub fn gather(&self, indices: &TracedTensor, config: GatherConfig) -> Result<TracedTensor> {
         let op = StdTensorOp::Gather(config);
         let (out_rank, out_shape_hint) =
@@ -1960,6 +2333,21 @@ impl TracedTensor {
     }
 
     /// Scatter updates into `self` using StableHLO scatter semantics.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `RankMismatch`, `AxisOutOfBounds`,
+    /// `DuplicateAxis`, or `ShapeMismatch` when indices, updates, or the
+    /// scatter configuration is incompatible, [`Error::TensorRuntime`] with
+    /// `UnsupportedDTypeConversion` when dtype promotion cannot be
+    /// represented, or [`Error::RuntimeStateSource`] when output metadata
+    /// cannot be registered.
+    ///
+    /// # Deferred errors
+    ///
+    /// Runtime index/update values are checked after binding. An invalid
+    /// index or update shape is returned as [`Error::TensorRuntime`] with its
+    /// typed validation source and [`ErrorPhase::Execution`].
     pub fn scatter(
         &self,
         indices: &TracedTensor,
@@ -1995,6 +2383,19 @@ impl TracedTensor {
     }
 
     /// Slice using runtime start indices.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `RankMismatch`, `AxisOutOfBounds`,
+    /// or `InvalidArgument` when `starts` or `sizes` has an incompatible rank
+    /// or extent, and [`Error::RuntimeStateSource`] when output metadata cannot
+    /// be registered.
+    ///
+    /// # Deferred errors
+    ///
+    /// Runtime start values are checked after binding. An out-of-range start
+    /// is returned as [`Error::TensorRuntime`] with the backend's typed
+    /// validation source and [`ErrorPhase::Execution`].
     pub fn dynamic_slice(&self, starts: &TracedTensor, sizes: &[usize]) -> Result<TracedTensor> {
         let op = StdTensorOp::DynamicSlice {
             slice_sizes: sizes.to_vec(),
@@ -2018,7 +2419,8 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error if traced output metadata registration fails.
+    /// Returns [`Error::RuntimeStateSource`] when traced output metadata
+    /// registration is unavailable or inconsistent with the graph.
     pub fn tril(&self, k: i64) -> Result<TracedTensor> {
         apply_unary(
             StdTensorOp::Tril { k },
@@ -2042,7 +2444,8 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error if traced output metadata registration fails.
+    /// Returns [`Error::RuntimeStateSource`] when traced output metadata
+    /// registration is unavailable or inconsistent with the graph.
     pub fn triu(&self, k: i64) -> Result<TracedTensor> {
         apply_unary(
             StdTensorOp::Triu { k },
@@ -2065,8 +2468,10 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when `perm` is not a valid permutation of the tensor
-    /// axes.
+    /// Returns [`Error::Validation`] with `InvalidPermutationLength`,
+    /// `AxisOutOfBounds`, or `DuplicateAxis` when `perm` is not a valid
+    /// permutation of the tensor axes, or [`Error::RuntimeStateSource`] when
+    /// output metadata registration fails.
     pub fn transpose(&self, perm: &[usize]) -> Result<TracedTensor> {
         validate_traced_perm(self.rank, perm, "TracedTensor::transpose")?;
         let out_shape_hint = self
@@ -2096,8 +2501,8 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when either axis is out of bounds or the two axes are
-    /// equal.
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when either axis
+    /// is outside the input rank or `InvalidArgument` when `axis_a == axis_b`.
     pub fn extract_diag(&self, axis_a: usize, axis_b: usize) -> Result<TracedTensor> {
         validate_traced_axis(self, axis_a, "TracedTensor::extract_diag")?;
         validate_traced_axis(self, axis_b, "TracedTensor::extract_diag")?;
@@ -2127,7 +2532,8 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when `axis_a` is out of bounds or `axis_b` is not a
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when `axis_a` is
+    /// outside the input rank or `InvalidArgument` when `axis_b` is not a
     /// valid insertion axis.
     pub fn embed_diag(&self, axis_a: usize, axis_b: usize) -> Result<TracedTensor> {
         validate_traced_axis(self, axis_a, "TracedTensor::embed_diag")?;
@@ -2166,7 +2572,9 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when `axis` is out of bounds.
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when `axis` is
+    /// outside the input rank, or [`Error::RuntimeStateSource`] when scalar
+    /// output metadata cannot be registered.
     pub fn shape_of(&self, axis: usize) -> Result<TracedTensor> {
         validate_traced_axis(self, axis, "TracedTensor::shape_of")?;
         apply_unary_with_dtype(
@@ -2202,7 +2610,15 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when `axis` is out of bounds or `size` is not scalar.
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when `axis` is
+    /// outside the input rank or `RankMismatch` when `size` is not scalar.
+    ///
+    /// # Deferred errors
+    ///
+    /// At execution, non-`f32`/`f64`/`i64` size dtypes return
+    /// [`Error::TensorRuntime`] with `Unsupported`, non-finite size values
+    /// return a typed `InvalidArgument`, and an empty scalar buffer returns a
+    /// typed runtime-state source.
     pub fn dynamic_truncate(&self, size: &TracedTensor, axis: usize) -> Result<TracedTensor> {
         validate_traced_axis(self, axis, "TracedTensor::dynamic_truncate")?;
         if size.rank != 0 {
@@ -2246,7 +2662,9 @@ impl TracedTensor {
     ///
     /// # Errors
     ///
-    /// Returns an error when `axis` is out of bounds for either tensor.
+    /// Returns [`Error::Validation`] with `AxisOutOfBounds` when `axis` is
+    /// outside either tensor's rank, or [`Error::RuntimeStateSource`] when
+    /// output metadata cannot be registered.
     pub fn pad_to_match(&self, reference: &TracedTensor, axis: usize) -> Result<TracedTensor> {
         validate_traced_axis(self, axis, "TracedTensor::pad_to_match")?;
         validate_traced_axis(reference, axis, "TracedTensor::pad_to_match")?;
@@ -2695,14 +3113,17 @@ fn register_single_output_metadata(
     if let Some(shape) = shape_hint {
         // Fresh graph output keys are generated in this builder, so metadata
         // registration failure would indicate a global metadata invariant bug.
-        register_metadata_or_internal(register_scoped_value_metadata(
+        register_metadata_or_runtime_state(register_scoped_value_metadata(
             graph.values()[output].key.clone(),
             tensor_meta(dtype, shape.clone()),
         ))
     } else {
         // Fresh graph output keys are generated in this builder, so metadata
         // registration failure would indicate a global metadata invariant bug.
-        register_metadata_or_internal(register_scoped_graph_metadata(graph, std::iter::empty()))
+        register_metadata_or_runtime_state(register_scoped_graph_metadata(
+            graph,
+            std::iter::empty(),
+        ))
     }
 }
 

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -1125,8 +1125,9 @@ impl TracedTensor {
     /// # Errors
     ///
     /// Returns [`Error::Validation`] with `ShapeMismatch` when operand shapes
-    /// cannot be broadcast, or [`Error::RuntimeStateSource`] when graph
-    /// metadata registration fails.
+    /// cannot be broadcast, [`Error::Unsupported`] at
+    /// [`ErrorPhase::GraphBuild`] when either operand has a complex dtype, or
+    /// [`Error::RuntimeStateSource`] when graph metadata registration fails.
     ///
     /// # Deferred errors
     ///
@@ -1137,8 +1138,8 @@ impl TracedTensor {
     /// [`Error::TensorRuntime`] containing a
     /// [`tenferro_tensor::Error::Extension`] classified as
     /// `tenferro_tensor::ErrorKind::NumericalFailure` and retaining the typed
-    /// backend source; floating-point and complex zero divisors follow their
-    /// numeric semantics instead.
+    /// backend source; floating-point zero divisors follow their numeric
+    /// semantics.
     pub fn rem(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
         apply_binary(

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -10,14 +10,15 @@ use computegraph::LocalValueId;
 use num_complex::{Complex32, Complex64};
 use tenferro_ops::ad::context::GlobalMetadataScope;
 use tenferro_ops::broadcast::{
-    broadcast_input_plan, broadcast_shape, broadcast_shapes, BroadcastError,
+    broadcast_error_to_validation, broadcast_in_dim_extent_error, broadcast_input_plan,
+    broadcast_shape, broadcast_shapes, BroadcastError,
 };
 use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{
     CompareDir, DType, DotGeneralConfig, Error as TensorError, GatherConfig, PadConfig,
-    ScatterConfig, ShapeMismatch, ShapeVec, SliceConfig, Tensor, TensorScalar, ValidationError,
+    ScatterConfig, ShapeMismatch, SliceConfig, Tensor, TensorScalar, ValidationError,
 };
 
 use super::error::{Error, ErrorPhase, Result};
@@ -154,29 +155,7 @@ fn graph_invalid_argument(
 }
 
 fn graph_broadcast_error(op: &'static str, error: BroadcastError) -> Error {
-    match error {
-        BroadcastError::IncompatibleBinary { lhs, rhs } => graph_validation(
-            op,
-            ShapeMismatch::IncompatibleShapes {
-                lhs: ShapeVec::from_vec(lhs),
-                rhs: ShapeVec::from_vec(rhs),
-            },
-        ),
-        BroadcastError::IncompatibleInput { input, output } => graph_validation(
-            op,
-            ShapeMismatch::ExpectedActual {
-                expected: ShapeVec::from_vec(output),
-                actual: ShapeVec::from_vec(input),
-            },
-        ),
-        BroadcastError::RankTooLarge { input, output } => graph_validation(
-            op,
-            ValidationError::RankMismatch {
-                expected: output.len(),
-                actual: input.len(),
-            },
-        ),
-    }
+    graph_validation(op, broadcast_error_to_validation(error))
 }
 
 fn graph_tensor_error(op: &'static str, error: TensorError) -> Error {
@@ -289,17 +268,8 @@ fn try_inferred_output_dtype(
     inputs: &[DType],
     context: &'static str,
 ) -> Result<DType> {
-    crate::shape_infer::infer_output_dtype(op, inputs)
+    crate::shape_infer::infer_output_dtype_at(op, inputs, ErrorPhase::GraphBuild)
         .map_err(|err| graph_error_with_context(context, err))
-}
-
-fn inferred_output_dtype(op: &StdTensorOp, inputs: &[DType], context: &'static str) -> DType {
-    match crate::shape_infer::infer_output_dtype(op, inputs) {
-        Ok(dtype) => dtype,
-        Err(err) => {
-            panic!("{context}: built-in traced dtype inference failed for {op:?}: {err}");
-        }
-    }
 }
 
 fn checked_shape_product_for_graph_build(
@@ -526,6 +496,23 @@ fn validate_broadcast_in_dim_args(
         ));
     }
 
+    let concrete_input_shape: Option<Vec<usize>> = input
+        .shape_hint
+        .as_ref()
+        .and_then(|shape| shape.iter().map(SymDim::constant_value).collect());
+    let concrete_output_shape = output_shape
+        .iter()
+        .map(SymDim::constant_value)
+        .collect::<Option<Vec<_>>>();
+    if let (Some(input_shape), Some(output_shape)) = (
+        concrete_input_shape.as_deref(),
+        concrete_output_shape.as_deref(),
+    ) {
+        if let Some(error) = broadcast_in_dim_extent_error(input_shape, output_shape, dims) {
+            return Err(graph_broadcast_error(op, error));
+        }
+    }
+
     let mut seen = vec![false; output_shape.len()];
     for &dim in dims {
         if dim >= output_shape.len() {
@@ -549,19 +536,21 @@ fn validate_broadcast_in_dim_args(
         seen[dim] = true;
     }
 
-    if let Some(input_shape) = input.shape_hint.as_ref() {
-        for (input_axis, &output_axis) in dims.iter().enumerate() {
-            let input_dim = &input_shape[input_axis];
-            let output_dim = &output_shape[output_axis];
-            if input_dim != output_dim && input_dim.constant_value() != Some(1) {
-                return Err(graph_invalid_argument(
-                    op,
-                    "shape",
-                    format!(
-                        "input axis {input_axis} with dim {input_dim:?} cannot broadcast to \
-                         output axis {output_axis} with dim {output_dim:?}"
-                    ),
-                ));
+    if concrete_output_shape.is_none() {
+        if let Some(input_shape) = input.shape_hint.as_ref() {
+            for (input_axis, &output_axis) in dims.iter().enumerate() {
+                let input_dim = &input_shape[input_axis];
+                let output_dim = &output_shape[output_axis];
+                if input_dim != output_dim && input_dim.constant_value() != Some(1) {
+                    return Err(graph_invalid_argument(
+                        op,
+                        "shape",
+                        format!(
+                            "input axis {input_axis} with dim {input_dim:?} cannot broadcast to \
+                             output axis {output_axis} with dim {output_dim:?}"
+                        ),
+                    ));
+                }
             }
         }
     }
@@ -991,15 +980,36 @@ impl TracedTensor {
     ///
     /// Prefer using the `+` operator when it reads naturally.
     ///
+    /// A longer expression such as `a + b + c` does not compose because the
+    /// first `+` returns `Result<TracedTensor, Error>`, so the second `+`
+    /// would receive a result rather than a tensor. Use `?` at each step or
+    /// the explicit fallible method chain shown below when the operation
+    /// sequence is more important than notation:
+    ///
     /// # Examples
     ///
     /// ```rust
-    /// # use tenferro_runtime::TracedTensor;
+    /// # use tenferro_runtime::{Error, TracedTensor};
     /// # let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
     /// # let z = TracedTensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
     /// let y = x.add(&z);
     /// let y2 = &x + &z;
+    /// # fn add_three(
+    /// #     a: &TracedTensor,
+    /// #     b: &TracedTensor,
+    /// #     c: &TracedTensor,
+    /// # ) -> Result<TracedTensor, Error> {
+    /// let ab = (a + b)?;
+    /// let sum = (&ab + c)?;
+    /// let method_chain = a.add(b)?.add(c)?;
+    /// let _ = method_chain;
+    /// # Ok(sum)
+    /// # }
     /// ```
+    ///
+    /// Tenferro prioritizes robust error handling over the conciseness of
+    /// chained operator notation; the explicit fallible methods are the
+    /// canonical form for longer sequences.
     ///
     /// # Errors
     ///
@@ -1011,9 +1021,7 @@ impl TracedTensor {
     ///
     /// If symbolic dimensions prevent shape comparison during graph
     /// construction, the same `ShapeMismatch` can be reported during
-    /// compilation or execution, with the corresponding [`ErrorPhase`]. A
-    /// backend-detected integer zero divisor is returned during execution as
-    /// [`Error::TensorRuntime`] with a typed `DivisionByZero` numerical source.
+    /// compilation or execution, with the corresponding [`ErrorPhase`].
     pub fn add(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
         apply_binary(
@@ -1039,9 +1047,7 @@ impl TracedTensor {
     ///
     /// If symbolic dimensions prevent shape comparison during graph
     /// construction, the same `ShapeMismatch` can be reported during
-    /// compilation or execution, with the corresponding [`ErrorPhase`]. A
-    /// backend-detected integer zero divisor is returned during execution as
-    /// [`Error::TensorRuntime`] with a typed `DivisionByZero` numerical source.
+    /// compilation or execution, with the corresponding [`ErrorPhase`].
     pub fn sub(&self, other: &TracedTensor) -> Result<TracedTensor> {
         let (lhs, rhs) = broadcast_binary(self, other)?;
         apply_binary(
@@ -2691,7 +2697,7 @@ pub(crate) fn apply_unary(
     out_rank: usize,
     out_shape_hint: Option<Vec<SymDim>>,
 ) -> Result<TracedTensor> {
-    let out_dtype = inferred_output_dtype(&op, &[input.dtype], "apply_unary");
+    let out_dtype = try_inferred_output_dtype(&op, &[input.dtype], "apply_unary")?;
     apply_unary_with_dtype(op, input, out_rank, out_shape_hint, out_dtype)
 }
 
@@ -2845,7 +2851,7 @@ pub(crate) fn apply_binary(
     out_shape_hint: Option<Vec<SymDim>>,
 ) -> Result<TracedTensor> {
     let input_dtype = crate::shape_infer::promote_dtype_for_binary_op(&op, lhs.dtype, rhs.dtype);
-    let out_dtype = inferred_output_dtype(&op, &[lhs.dtype, rhs.dtype], "apply_binary");
+    let out_dtype = try_inferred_output_dtype(&op, &[lhs.dtype, rhs.dtype], "apply_binary")?;
 
     // Insert Convert ops when an input dtype differs from the primitive input dtype.
     let lhs = if lhs.dtype != input_dtype {

--- a/crates/tenferro-runtime/src/traced/tests.rs
+++ b/crates/tenferro-runtime/src/traced/tests.rs
@@ -2,7 +2,7 @@ use num_complex::Complex64;
 use std::sync::Arc;
 
 use crate::{DType, DotGeneralConfig, Error, ErrorPhase, TracedTensor};
-use tenferro_tensor::{ShapeMismatch, ValidationError};
+use tenferro_tensor::{ErrorKind, ShapeMismatch, ValidationError, ValidationKind};
 
 #[test]
 fn traced_binary_reuses_input_map_when_rhs_is_already_present() {
@@ -160,13 +160,22 @@ fn broadcast_in_dim_sym_rejects_missing_shape_reference() {
         .broadcast_in_dim_sym(&target_shape, &[0], &[])
         .unwrap_err();
 
-    let message = err.to_string();
     assert!(
-        message.contains("broadcast_in_dim_sym")
-            && message.contains("unresolved symbolic dimension")
-            && message.contains("shape_refs"),
-        "{message}"
+        matches!(
+            &err,
+            Error::SymbolicShapeConversion {
+                op: "broadcast_in_dim_sym",
+                phase: ErrorPhase::GraphBuild,
+                source: tenferro_ops::SymDimConversionError { .. },
+            }
+        ),
+        "{err}"
     );
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
+    );
+    assert_eq!(err.phase(), Some(ErrorPhase::GraphBuild));
 }
 
 #[test]

--- a/crates/tenferro-runtime/src/traced/tests.rs
+++ b/crates/tenferro-runtime/src/traced/tests.rs
@@ -1,7 +1,8 @@
 use num_complex::Complex64;
 use std::sync::Arc;
 
-use crate::{DType, DotGeneralConfig, Error, TracedTensor};
+use crate::{DType, DotGeneralConfig, Error, ErrorPhase, TracedTensor};
+use tenferro_tensor::{ShapeMismatch, ValidationError};
 
 #[test]
 fn traced_binary_reuses_input_map_when_rhs_is_already_present() {
@@ -61,11 +62,14 @@ fn dot_general_returns_error_for_invalid_config() {
         panic!("invalid dim config should be a typed runtime error");
     };
 
-    let message = err.to_string();
-    assert!(
-        message.contains("lhs_contracting_dim 2 out of bounds"),
-        "{message}"
-    );
+    assert!(matches!(
+        &err,
+        Error::Validation {
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::AxisOutOfBounds { axis: 2, rank: 2 },
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -170,26 +174,40 @@ fn broadcast_in_dim_rejects_invalid_dimension_mappings() {
     let x = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
 
     let rank_mismatch = x.broadcast_in_dim(&[2, 3, 4], &[0]).unwrap_err();
-    assert!(
-        rank_mismatch
-            .to_string()
-            .contains("dims length 1 must match input rank 2"),
-        "{rank_mismatch}"
-    );
+    assert!(matches!(
+        &rank_mismatch,
+        Error::Validation {
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::RankMismatch {
+                expected: 2,
+                actual: 1,
+            },
+            ..
+        }
+    ));
 
     let out_of_bounds = x.broadcast_in_dim(&[2, 3, 4], &[0, 3]).unwrap_err();
-    assert!(
-        out_of_bounds
-            .to_string()
-            .contains("broadcast dim 3 out of bounds for output rank 3"),
-        "{out_of_bounds}"
-    );
+    assert!(matches!(
+        &out_of_bounds,
+        Error::Validation {
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::AxisOutOfBounds { axis: 3, rank: 3 },
+            ..
+        }
+    ));
 
     let duplicate = x.broadcast_in_dim(&[2, 3, 4], &[1, 1]).unwrap_err();
-    assert!(
-        duplicate.to_string().contains("duplicate broadcast dim 1"),
-        "{duplicate}"
-    );
+    assert!(matches!(
+        &duplicate,
+        Error::Validation {
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::DuplicateAxis {
+                axis: 1,
+                role: "broadcast",
+            },
+            ..
+        }
+    ));
 
     let valid = x.broadcast_in_dim(&[2, 3, 4], &[0, 1]).unwrap();
     assert_eq!(valid.rank, 3);
@@ -203,11 +221,16 @@ fn reshape_rejects_concrete_element_count_mismatch_at_graph_build() {
     let err = x.reshape(&[3]).unwrap_err();
 
     assert!(matches!(
-        err,
-        Error::InvalidGraphBuild {
+        &err,
+        Error::Validation {
             op: "TracedTensor::reshape",
-            ..
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::ShapeMismatch(source),
         }
+        if matches!(
+            source.as_ref(),
+            ShapeMismatch::ReshapeElementCount { from: 4, to: 3 }
+        )
     ));
     assert!(err.to_string().contains("element-count mismatch"), "{err}");
 }

--- a/crates/tenferro-runtime/src/traced/tests.rs
+++ b/crates/tenferro-runtime/src/traced/tests.rs
@@ -1,4 +1,5 @@
 use num_complex::Complex64;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
 use crate::{DType, DotGeneralConfig, Error, ErrorPhase, TracedTensor};
@@ -261,6 +262,30 @@ fn ordered_binary_ops_reject_complex_dtype_without_panicking() {
 
     let err = lhs.maximum(&rhs).unwrap_err();
 
+    assert!(
+        err.to_string()
+            .contains("complex numbers have no total order"),
+        "{err}"
+    );
+}
+
+#[test]
+fn remainder_rejects_complex_dtype_at_graph_build_without_panicking() {
+    let lhs = TracedTensor::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 2.0)]).unwrap();
+    let rhs = TracedTensor::from_vec_col_major(vec![1], vec![Complex64::new(3.0, 4.0)]).unwrap();
+
+    let result = catch_unwind(AssertUnwindSafe(|| lhs.rem(&rhs)));
+    let result = result.expect("complex remainder validation must not panic");
+    let err = result.expect_err("complex remainder must return a typed error");
+
+    assert!(matches!(
+        &err,
+        Error::Unsupported {
+            op: "Rem",
+            phase: ErrorPhase::GraphBuild,
+            ..
+        }
+    ));
     assert!(
         err.to_string()
             .contains("complex numbers have no total order"),

--- a/crates/tenferro-runtime/src/traced/tests.rs
+++ b/crates/tenferro-runtime/src/traced/tests.rs
@@ -2,8 +2,13 @@ use num_complex::Complex64;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 
-use crate::{DType, DotGeneralConfig, Error, ErrorPhase, TracedTensor};
-use tenferro_tensor::{ErrorKind, ShapeMismatch, ValidationError, ValidationKind};
+use crate::{
+    DType, DotGeneralConfig, Error, ErrorPhase, GraphCompiler, GraphExecutor, Tensor, TracedTensor,
+};
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::{
+    Error as TensorError, ErrorKind, ShapeMismatch, ValidationError, ValidationKind,
+};
 
 #[test]
 fn traced_binary_reuses_input_map_when_rhs_is_already_present() {
@@ -222,6 +227,69 @@ fn broadcast_in_dim_rejects_invalid_dimension_mappings() {
     let valid = x.broadcast_in_dim(&[2, 3, 4], &[0, 1]).unwrap();
     assert_eq!(valid.rank, 3);
     assert_eq!(valid.try_concrete_shape().unwrap(), &[2, 3, 4]);
+}
+
+#[test]
+fn broadcast_in_dim_rejects_known_incompatible_extent_at_graph_build() {
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]).unwrap();
+
+    let err = x.broadcast_in_dim(&[3], &[0]).unwrap_err();
+
+    assert!(matches!(
+        &err,
+        Error::Validation {
+            op: "TracedTensor::broadcast_in_dim",
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::ShapeMismatch(source),
+        } if matches!(
+            source.as_ref(),
+            ShapeMismatch::ExpectedActual { expected, actual }
+                if expected.as_slice() == [3] && actual.as_slice() == [2]
+        )
+    ));
+}
+
+#[test]
+fn broadcast_in_dim_sym_defers_cross_tensor_symbolic_extent_validation() {
+    let input = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let shape_ref = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
+    let target_shape = [shape_ref.axis_sym_dim(0).unwrap()];
+
+    let output = input
+        .broadcast_in_dim_sym(&target_shape, &[0], &[&shape_ref])
+        .expect("a symbolic extent from another tensor must remain deferred");
+    assert_eq!(output.try_concrete_shape(), None);
+
+    let mut compiler = GraphCompiler::new();
+    let program = compiler
+        .compile_with_input_specs(&output, &[(&shape_ref, DType::F64, &[2])])
+        .unwrap();
+    let matching_shape_ref = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 0.0]).unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    let result = executor
+        .run_with_inputs(&program, &[(&shape_ref, &matching_shape_ref)])
+        .unwrap();
+    assert_eq!(result.shape(), &[2]);
+    assert_eq!(result.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
+
+    let mismatch_program = compiler
+        .compile_with_input_specs(&output, &[(&shape_ref, DType::F64, &[3])])
+        .unwrap();
+    let mismatched_shape_ref = Tensor::from_vec_col_major(vec![3], vec![0.0_f64; 3]).unwrap();
+    let err = executor
+        .run_with_inputs(&mismatch_program, &[(&shape_ref, &mismatched_shape_ref)])
+        .unwrap_err();
+    assert!(matches!(
+        &err,
+        Error::TensorRuntime(TensorError::Validation {
+            source: ValidationError::ShapeMismatch(source),
+            ..
+        }) if matches!(
+            source.as_ref(),
+            ShapeMismatch::IncompatibleShapes { lhs, rhs }
+                if lhs.as_slice() == [2] && rhs.as_slice() == [3]
+        )
+    ));
 }
 
 #[test]

--- a/crates/tenferro-runtime/src/typed_tensor.rs
+++ b/crates/tenferro-runtime/src/typed_tensor.rs
@@ -3,9 +3,14 @@
 //! Operation families that are no longer part of core, including einsum, live
 //! in their extension crates.
 
-use tenferro_ops::broadcast::{broadcast_input_plan, broadcast_shape, broadcast_shapes};
+use tenferro_ops::broadcast::{
+    broadcast_input_plan, broadcast_shape, broadcast_shapes, BroadcastError,
+};
 use tenferro_tensor::validate::matmul_config_for_shapes;
-use tenferro_tensor::{CompareDir, Error, Result, Tensor, TensorBackend, TensorRead, TensorScalar};
+use tenferro_tensor::{
+    CompareDir, DType, Error, Result, Tensor, TensorBackend, TensorRead, TensorScalar,
+    ValidationError,
+};
 
 use crate::{TypedTensorMaskOpsExt, TypedTensorOpsExt};
 use tenferro_tensor::TypedTensor;
@@ -618,15 +623,41 @@ fn broadcast_to_read<'a, T: TensorScalar>(
     Ok(ReadInput::Owned(out))
 }
 
-fn broadcast_error(err: impl std::fmt::Display) -> Error {
-    Error::backend_failure("broadcast", err.to_string())
+fn broadcast_error(err: BroadcastError) -> Error {
+    match err {
+        BroadcastError::IncompatibleBinary { lhs, rhs } => {
+            Error::shape_mismatch("broadcast", lhs, rhs)
+        }
+        BroadcastError::IncompatibleInput { input, output } => {
+            Error::shape_mismatch("broadcast", input, output)
+        }
+        BroadcastError::RankTooLarge { input, output } => {
+            Error::rank_mismatch("broadcast", output.len(), input.len())
+        }
+    }
 }
 
 fn into_typed_result<T: TensorScalar>(op: &'static str, tensor: Tensor) -> Result<TypedTensor<T>> {
     let actual = tensor.dtype();
-    T::into_typed(tensor).map_err(|_| Error::DTypeMismatch {
-        op,
-        lhs: T::dtype(),
-        rhs: actual,
+    T::into_typed(tensor).map_err(|_| {
+        Error::validation(
+            op,
+            ValidationError::DTypeMismatch {
+                expected: core_dtype(T::dtype()),
+                actual: core_dtype(actual),
+            },
+        )
     })
+}
+
+fn core_dtype(dtype: DType) -> tenferro_tensor::core::DType {
+    match dtype {
+        DType::F32 => tenferro_tensor::core::DType::F32,
+        DType::F64 => tenferro_tensor::core::DType::F64,
+        DType::I32 => tenferro_tensor::core::DType::I32,
+        DType::I64 => tenferro_tensor::core::DType::I64,
+        DType::Bool => tenferro_tensor::core::DType::Bool,
+        DType::C32 => tenferro_tensor::core::DType::C32,
+        DType::C64 => tenferro_tensor::core::DType::C64,
+    }
 }

--- a/crates/tenferro-runtime/tests/integration.rs
+++ b/crates/tenferro-runtime/tests/integration.rs
@@ -4,6 +4,8 @@ mod extension_runtime;
 mod graph_default_input_placement;
 #[path = "integration/public_surface_contract.rs"]
 mod public_surface_contract;
+#[path = "integration/runtime_error_api.rs"]
+mod runtime_error_api;
 #[path = "integration/runtime_public_api.rs"]
 mod runtime_public_api;
 #[path = "integration/typed_tensor_contract.rs"]

--- a/crates/tenferro-runtime/tests/integration/extension_runtime.rs
+++ b/crates/tenferro-runtime/tests/integration/extension_runtime.rs
@@ -13,7 +13,7 @@ use tenferro_runtime::{
     HostReferenceRuntime,
 };
 use tenferro_tensor::{
-    BackendSessionHost, Buffer, BufferHandle, DType, MemoryKind, Placement, Tensor,
+    BackendSessionHost, Buffer, BufferHandle, DType, ErrorKind, MemoryKind, Placement, Tensor,
     TensorOwnedView, TensorRead, TypedTensor,
 };
 
@@ -300,8 +300,11 @@ fn host_reference_runtime_reports_backend_only_family() {
 
     assert!(matches!(
         err,
-        tenferro_tensor::Error::NoHostReference {
-            family_id: "runtime.backend-only.v1"
+        tenferro_tensor::Error::Extension {
+            op: "extension",
+            family: "runtime.backend-only.v1",
+            kind: ErrorKind::Unsupported,
+            ..
         }
     ));
 }

--- a/crates/tenferro-runtime/tests/integration/public_surface_contract.rs
+++ b/crates/tenferro-runtime/tests/integration/public_surface_contract.rs
@@ -129,9 +129,9 @@ fn context_id_pointer_constructor_is_not_public_api() {
 fn traced_dtype_inference_must_not_fall_back_in_release_builds() {
     let source = repo_file("crates/tenferro-runtime/src/traced.rs");
     let helper = source
-        .split_once("fn inferred_output_dtype")
+        .split_once("fn try_inferred_output_dtype")
         .and_then(|(_, rest)| {
-            rest.split_once("fn traced_input_shape_exprs")
+            rest.split_once("fn checked_shape_product_for_graph_build")
                 .map(|(body, _)| body)
         })
         .expect("traced dtype inference helper should exist");
@@ -143,6 +143,14 @@ fn traced_dtype_inference_must_not_fall_back_in_release_builds() {
     assert!(
         !helper.contains("fallback"),
         "traced dtype inference must not silently return a fallback dtype"
+    );
+    assert!(
+        helper.contains("infer_output_dtype_at") && helper.contains("ErrorPhase::GraphBuild"),
+        "traced dtype inference must preserve the graph-build discovery phase"
+    );
+    assert!(
+        !helper.contains("panic!("),
+        "traced dtype inference must return typed errors instead of panicking"
     );
 }
 

--- a/crates/tenferro-runtime/tests/integration/runtime_error_api.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_error_api.rs
@@ -15,3 +15,15 @@ fn runtime_validation_separates_kind_from_phase() {
     );
     assert_eq!(err.phase(), Some(ErrorPhase::GraphBuild));
 }
+
+#[test]
+fn runtime_state_preserves_kind_phase_and_source() {
+    use std::error::Error as _;
+
+    let source = std::io::Error::other("registry lock poisoned");
+    let err = Error::runtime_state_source("metadata", ErrorPhase::Compile, source);
+
+    assert_eq!(err.kind(), ErrorKind::RuntimeState);
+    assert_eq!(err.phase(), Some(ErrorPhase::Compile));
+    assert!(err.source().is_some());
+}

--- a/crates/tenferro-runtime/tests/integration/runtime_error_api.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_error_api.rs
@@ -1,0 +1,17 @@
+use tenferro_runtime::{Error, ErrorPhase};
+use tenferro_tensor::{ErrorKind, ShapeMismatch, ValidationKind};
+
+#[test]
+fn runtime_validation_separates_kind_from_phase() {
+    let err = Error::validation(
+        "reshape",
+        ErrorPhase::GraphBuild,
+        ShapeMismatch::ReshapeElementCount { from: 2, to: 3 }.into(),
+    );
+
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::ShapeMismatch)
+    );
+    assert_eq!(err.phase(), Some(ErrorPhase::GraphBuild));
+}

--- a/crates/tenferro-runtime/tests/integration/runtime_public_api.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_public_api.rs
@@ -1,9 +1,10 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{
-    DType, DotGeneralConfig, Error, GatherConfig, GraphCompiler, GraphExecutor, PadConfig,
-    ScatterConfig, SliceConfig, Tensor, TensorOpsExt, TensorRead, TensorValue, TracedTensor,
+    DType, DotGeneralConfig, Error, ErrorPhase, GatherConfig, GraphCompiler, GraphExecutor,
+    PadConfig, ScatterConfig, SliceConfig, Tensor, TensorOpsExt, TensorRead, TensorValue,
+    TracedTensor,
 };
-use tenferro_tensor::Error as TensorError;
+use tenferro_tensor::{Error as TensorError, ValidationError};
 
 #[test]
 fn runtime_crate_exposes_traced_graph_execution_api() {
@@ -56,10 +57,12 @@ fn concrete_tensor_matmul_rejects_non_matrix_inputs_without_rank_underflow() {
 
     assert!(matches!(
         err,
-        TensorError::RankMismatch {
+        TensorError::Validation {
             op: "matmul",
-            expected: 2,
-            actual: 0,
+            source: ValidationError::RankMismatch {
+                expected: 2,
+                actual: 0,
+            },
         }
     ));
 }
@@ -77,10 +80,14 @@ fn traced_tensor_methods_cover_conversion_and_rank_errors() {
 
     let err = scalar.matmul(&vector).unwrap_err();
     assert!(matches!(
-        err,
-        Error::InvalidGraphBuild {
+        &err,
+        Error::Validation {
             op: "TracedTensor::matmul",
-            ..
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::RankMismatch {
+                expected: 2,
+                actual: 0,
+            },
         }
     ));
 }
@@ -231,15 +238,23 @@ fn traced_shape_packing_rejects_symbolic_shapes_as_graph_build_errors() {
 
     let err = x.index_select(0, &[0]).unwrap_err();
     assert!(matches!(
-        err,
-        Error::InvalidGraphBuild {
-            op: "index_select",
+        &err,
+        Error::Validation {
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::InvalidArgument { .. },
             ..
         }
     ));
 
     let err = TracedTensor::stack(&[&x], 0).unwrap_err();
-    assert!(matches!(err, Error::InvalidGraphBuild { op: "stack", .. }));
+    assert!(matches!(
+        &err,
+        Error::Validation {
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::InvalidArgument { .. },
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/crates/tenferro-runtime/tests/integration/typed_tensor_ops.rs
+++ b/crates/tenferro-runtime/tests/integration/typed_tensor_ops.rs
@@ -1,6 +1,6 @@
 use tenferro_cpu::CpuBackend;
-use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-use tenferro_tensor::{Error as TensorError, ValidationError};
+use tenferro_runtime::{TensorOpsExt, TypedTensor, TypedTensorOpsExt};
+use tenferro_tensor::{Error as TensorError, ShapeMismatch, ValidationError};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -67,5 +67,23 @@ fn typed_tensor_matmul_rejects_non_matrix_inputs_without_rank_underflow() {
                 actual: 0,
             },
         }
+    ));
+}
+
+#[test]
+fn direct_tensor_broadcast_uses_the_shared_shape_payload() {
+    let mut backend = CpuBackend::new();
+    let lhs = tenferro_tensor::Tensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]).unwrap();
+    let rhs = tenferro_tensor::Tensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
+
+    let error = lhs.add(&rhs, &mut backend).unwrap_err();
+
+    assert!(matches!(
+        error,
+        TensorError::Validation {
+            source: ValidationError::ShapeMismatch(shape),
+            ..
+        } if matches!(shape.as_ref(), ShapeMismatch::IncompatibleShapes { lhs, rhs }
+            if lhs.as_slice() == [2] && rhs.as_slice() == [3])
     ));
 }

--- a/crates/tenferro-runtime/tests/integration/typed_tensor_ops.rs
+++ b/crates/tenferro-runtime/tests/integration/typed_tensor_ops.rs
@@ -1,6 +1,6 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{TypedTensor, TypedTensorOpsExt};
-use tenferro_tensor::Error as TensorError;
+use tenferro_tensor::{Error as TensorError, ValidationError};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -60,10 +60,12 @@ fn typed_tensor_matmul_rejects_non_matrix_inputs_without_rank_underflow() {
 
     assert!(matches!(
         err,
-        TensorError::RankMismatch {
+        TensorError::Validation {
             op: "matmul",
-            expected: 2,
-            actual: 0,
+            source: ValidationError::RankMismatch {
+                expected: 2,
+                actual: 0,
+            },
         }
     ));
 }

--- a/crates/tenferro-tensor-core/src/error.rs
+++ b/crates/tenferro-tensor-core/src/error.rs
@@ -1,0 +1,176 @@
+use crate::{DType, ShapeVec};
+
+/// Coarse classification for shared tensor validation failures.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor_core::{ValidationError, ValidationKind};
+///
+/// let error = ValidationError::RankMismatch {
+///     expected: 2,
+///     actual: 1,
+/// };
+/// assert_eq!(error.kind(), ValidationKind::RankMismatch);
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ValidationKind {
+    ShapeMismatch,
+    RankMismatch,
+    AxisOutOfBounds,
+    DTypeMismatch,
+    InvalidArgument,
+}
+
+/// Coarse classification shared by crate-local error types.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor_core::{ErrorKind, ValidationKind};
+///
+/// assert_eq!(
+///     ErrorKind::Validation(ValidationKind::ShapeMismatch),
+///     ErrorKind::Validation(ValidationKind::ShapeMismatch),
+/// );
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    Validation(ValidationKind),
+    Unsupported,
+    NumericalFailure,
+    BackendFailure,
+    Io,
+    RuntimeState,
+    Internal,
+}
+
+/// Structured facts describing why two tensor shapes are incompatible.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor_core::{ShapeMismatch, ShapeVec};
+///
+/// let mismatch = ShapeMismatch::IncompatibleShapes {
+///     lhs: ShapeVec::from_vec(vec![2, 3]),
+///     rhs: ShapeVec::from_vec(vec![2, 4]),
+/// };
+/// assert!(mismatch.to_string().contains("incompatible shapes"));
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ShapeMismatch {
+    #[error("incompatible shapes: lhs={lhs:?}, rhs={rhs:?}")]
+    IncompatibleShapes { lhs: ShapeVec, rhs: ShapeVec },
+    #[error("shape mismatch: expected={expected:?}, actual={actual:?}")]
+    ExpectedActual {
+        expected: ShapeVec,
+        actual: ShapeVec,
+    },
+    #[error("reshape element-count mismatch: from {from} to {to}")]
+    ReshapeElementCount { from: usize, to: usize },
+    #[error(
+        "contracted dimensions differ: lhs axis {lhs_axis} ({lhs_size}) vs rhs axis {rhs_axis} ({rhs_size})"
+    )]
+    ContractedDimensions {
+        lhs_axis: usize,
+        lhs_size: usize,
+        rhs_axis: usize,
+        rhs_size: usize,
+    },
+}
+
+/// Structured validation failures owned by the tensor data model.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor_core::{ShapeMismatch, ShapeVec, ValidationError};
+///
+/// let error: ValidationError = ShapeMismatch::ExpectedActual {
+///     expected: ShapeVec::from_vec(vec![2, 3]),
+///     actual: ShapeVec::from_vec(vec![6]),
+/// }
+/// .into();
+/// assert!(error.to_string().contains("shape mismatch"));
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ValidationError {
+    #[error("{0}")]
+    ShapeMismatch(#[source] Box<ShapeMismatch>),
+    #[error("shape product {expected} does not match data length {actual}")]
+    ShapeDataLengthMismatch { expected: usize, actual: usize },
+    #[error("rank mismatch: expected {expected}, actual {actual}")]
+    RankMismatch { expected: usize, actual: usize },
+    #[error("axis {axis} out of bounds for rank {rank}")]
+    AxisOutOfBounds { axis: usize, rank: usize },
+    #[error("duplicate {role} axis {axis}")]
+    DuplicateAxis { axis: usize, role: &'static str },
+    #[error("axis {axis} appears in both {first_role} and {second_role}")]
+    AxisRoleConflict {
+        axis: usize,
+        first_role: &'static str,
+        second_role: &'static str,
+    },
+    #[error("invalid permutation length: expected {expected}, actual {actual}")]
+    InvalidPermutationLength { expected: usize, actual: usize },
+    #[error("invalid slice step {step}; zero is invalid")]
+    InvalidSliceStep { step: isize },
+    #[error("invalid slice bounds: start={start}, end={end}, axis_len={axis_len}")]
+    InvalidSliceBounds {
+        start: isize,
+        end: isize,
+        axis_len: usize,
+    },
+    #[error("dtype mismatch: expected {expected:?}, actual {actual:?}")]
+    DTypeMismatch { expected: DType, actual: DType },
+    #[error("invalid argument {argument}: {message}")]
+    InvalidArgument {
+        argument: &'static str,
+        message: String,
+    },
+    #[error("view is not slice-contiguous")]
+    NonContiguousViewAsSlice,
+    #[error("view metadata is out of borrowed-slice bounds")]
+    ViewOutOfBounds,
+    #[error("mutable tensor layout may overlap physical elements")]
+    OverlappingMutableLayout,
+    #[error("integer overflow while validating tensor metadata")]
+    IntegerOverflow,
+}
+
+impl From<ShapeMismatch> for ValidationError {
+    fn from(error: ShapeMismatch) -> Self {
+        Self::ShapeMismatch(Box::new(error))
+    }
+}
+
+impl ValidationError {
+    /// Return the stable coarse classification for this validation failure.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor_core::{ValidationError, ValidationKind};
+    ///
+    /// let error = ValidationError::AxisOutOfBounds { axis: 3, rank: 2 };
+    /// assert_eq!(error.kind(), ValidationKind::AxisOutOfBounds);
+    /// ```
+    pub fn kind(&self) -> ValidationKind {
+        match self {
+            Self::ShapeMismatch(_) | Self::ShapeDataLengthMismatch { .. } => {
+                ValidationKind::ShapeMismatch
+            }
+            Self::RankMismatch { .. } | Self::InvalidPermutationLength { .. } => {
+                ValidationKind::RankMismatch
+            }
+            Self::AxisOutOfBounds { .. } => ValidationKind::AxisOutOfBounds,
+            Self::DTypeMismatch { .. } => ValidationKind::DTypeMismatch,
+            _ => ValidationKind::InvalidArgument,
+        }
+    }
+}

--- a/crates/tenferro-tensor-core/src/layout.rs
+++ b/crates/tenferro-tensor-core/src/layout.rs
@@ -1,6 +1,6 @@
 use crate::{
     checked_logical_element_count, checked_product, col_major_strides, validate_permutation,
-    DynRank, Error, Result, ShapeVec, SliceSpec, StrideVec, TensorRank,
+    DynRank, Result, ShapeMismatch, ShapeVec, SliceSpec, StrideVec, TensorRank, ValidationError,
 };
 use smallvec::SmallVec;
 use std::collections::HashSet;
@@ -24,12 +24,19 @@ pub(crate) fn reachable_offset_range(
     let mut min = offset;
     let mut max = offset;
     for (&extent, &stride) in shape.iter().zip(strides) {
-        let last = isize::try_from(extent.saturating_sub(1)).map_err(|_| Error::IntegerOverflow)?;
-        let delta = last.checked_mul(stride).ok_or(Error::IntegerOverflow)?;
+        let last = isize::try_from(extent.saturating_sub(1))
+            .map_err(|_| ValidationError::IntegerOverflow)?;
+        let delta = last
+            .checked_mul(stride)
+            .ok_or(ValidationError::IntegerOverflow)?;
         if delta < 0 {
-            min = min.checked_add(delta).ok_or(Error::IntegerOverflow)?;
+            min = min
+                .checked_add(delta)
+                .ok_or(ValidationError::IntegerOverflow)?;
         } else {
-            max = max.checked_add(delta).ok_or(Error::IntegerOverflow)?;
+            max = max
+                .checked_add(delta)
+                .ok_or(ValidationError::IntegerOverflow)?;
         }
     }
     Ok(Some((min, max)))
@@ -42,7 +49,7 @@ pub(crate) fn validate_reachable_bounds(
     buffer_len: usize,
 ) -> Result<()> {
     if shape.len() != strides.len() {
-        return Err(Error::RankMismatch {
+        return Err(ValidationError::RankMismatch {
             expected: shape.len(),
             actual: strides.len(),
         });
@@ -51,24 +58,24 @@ pub(crate) fn validate_reachable_bounds(
     match reachable_offset_range(shape, strides, offset)? {
         Some((min, max)) => {
             if min < 0 {
-                return Err(Error::ViewOutOfBounds);
+                return Err(ValidationError::ViewOutOfBounds);
             }
-            let max = usize::try_from(max).map_err(|_| Error::IntegerOverflow)?;
+            let max = usize::try_from(max).map_err(|_| ValidationError::IntegerOverflow)?;
             if max < buffer_len {
                 Ok(())
             } else {
-                Err(Error::ViewOutOfBounds)
+                Err(ValidationError::ViewOutOfBounds)
             }
         }
         None => {
             if offset < 0 {
-                return Err(Error::ViewOutOfBounds);
+                return Err(ValidationError::ViewOutOfBounds);
             }
-            let offset = usize::try_from(offset).map_err(|_| Error::IntegerOverflow)?;
+            let offset = usize::try_from(offset).map_err(|_| ValidationError::IntegerOverflow)?;
             if offset <= buffer_len {
                 Ok(())
             } else {
-                Err(Error::ViewOutOfBounds)
+                Err(ValidationError::ViewOutOfBounds)
             }
         }
     }
@@ -90,31 +97,31 @@ fn layout_from_vecs<R: TensorRank>(
 
 fn positive_ceil_div(numerator: isize, denominator: isize) -> Result<usize> {
     if numerator < 0 || denominator <= 0 {
-        return Err(Error::IntegerOverflow);
+        return Err(ValidationError::IntegerOverflow);
     }
     let extent = if numerator == 0 {
         0
     } else {
         1 + (numerator - 1) / denominator
     };
-    usize::try_from(extent).map_err(|_| Error::IntegerOverflow)
+    usize::try_from(extent).map_err(|_| ValidationError::IntegerOverflow)
 }
 
 fn normalize_slice(slice: SliceSpec, axis_len: usize) -> Result<(isize, usize)> {
     if slice.step == 0 {
-        return Err(Error::InvalidSliceStep { step: slice.step });
+        return Err(ValidationError::InvalidSliceStep { step: slice.step });
     }
     if axis_len == 0 {
         return Ok((0, 0));
     }
 
-    let axis_len = isize::try_from(axis_len).map_err(|_| Error::IntegerOverflow)?;
+    let axis_len = isize::try_from(axis_len).map_err(|_| ValidationError::IntegerOverflow)?;
     if slice.step > 0 {
         let start = if slice.start < 0 {
             slice
                 .start
                 .checked_add(axis_len)
-                .ok_or(Error::IntegerOverflow)?
+                .ok_or(ValidationError::IntegerOverflow)?
         } else {
             slice.start
         };
@@ -122,15 +129,16 @@ fn normalize_slice(slice: SliceSpec, axis_len: usize) -> Result<(isize, usize)> 
             slice
                 .end
                 .checked_add(axis_len)
-                .ok_or(Error::IntegerOverflow)?
+                .ok_or(ValidationError::IntegerOverflow)?
         } else {
             slice.end
         };
         if start < 0 || start > axis_len || end < 0 || end > axis_len {
-            return Err(Error::InvalidSliceBounds {
+            return Err(ValidationError::InvalidSliceBounds {
                 start: slice.start,
                 end: slice.end,
-                axis_len: usize::try_from(axis_len).map_err(|_| Error::IntegerOverflow)?,
+                axis_len: usize::try_from(axis_len)
+                    .map_err(|_| ValidationError::IntegerOverflow)?,
             });
         }
         if start >= end {
@@ -143,7 +151,7 @@ fn normalize_slice(slice: SliceSpec, axis_len: usize) -> Result<(isize, usize)> 
         slice
             .start
             .checked_add(axis_len)
-            .ok_or(Error::IntegerOverflow)?
+            .ok_or(ValidationError::IntegerOverflow)?
     } else {
         slice.start
     };
@@ -151,21 +159,24 @@ fn normalize_slice(slice: SliceSpec, axis_len: usize) -> Result<(isize, usize)> 
         slice
             .end
             .checked_add(axis_len)
-            .ok_or(Error::IntegerOverflow)?
+            .ok_or(ValidationError::IntegerOverflow)?
     } else {
         slice.end
     };
     if start < 0 || start >= axis_len || end < -1 || end >= axis_len {
-        return Err(Error::InvalidSliceBounds {
+        return Err(ValidationError::InvalidSliceBounds {
             start: slice.start,
             end: slice.end,
-            axis_len: usize::try_from(axis_len).map_err(|_| Error::IntegerOverflow)?,
+            axis_len: usize::try_from(axis_len).map_err(|_| ValidationError::IntegerOverflow)?,
         });
     }
     if start <= end {
         return Ok((start, 0));
     }
-    let step = slice.step.checked_neg().ok_or(Error::IntegerOverflow)?;
+    let step = slice
+        .step
+        .checked_neg()
+        .ok_or(ValidationError::IntegerOverflow)?;
     Ok((start, positive_ceil_div(start - end, step)?))
 }
 
@@ -179,7 +190,7 @@ fn normalize_slice(slice: SliceSpec, axis_len: usize) -> Result<(isize, usize)> 
 /// let layout = TensorLayout::<Rank<2>>::compact([2, 3])?;
 /// assert_eq!(layout.shape(), &[2, 3]);
 /// assert_eq!(layout.strides(), &[1, 2]);
-/// # Ok::<(), tenferro_tensor_core::Error>(())
+/// # Ok::<(), tenferro_tensor_core::ValidationError>(())
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TensorLayout<R: TensorRank = DynRank> {
@@ -198,8 +209,13 @@ impl<R: TensorRank> TensorLayout<R> {
     ///
     /// let layout = TensorLayout::<Rank<2>>::compact([2, 3])?;
     /// assert_eq!(layout.strides(), &[1, 2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::IntegerOverflow`] when compact strides
+    /// cannot be computed for `shape`.
     pub fn compact(shape: R::Shape) -> Result<Self> {
         let strides = R::strides_from_vec(col_major_strides(shape.as_ref())?)?;
         Ok(Self {
@@ -223,8 +239,15 @@ impl<R: TensorRank> TensorLayout<R> {
     ///     6,
     /// )?;
     /// assert!(layout.is_compact_col_major()?);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::RankMismatch`] for incompatible shape and
+    /// stride ranks, [`ValidationError::ViewOutOfBounds`] when the reachable
+    /// range exceeds `buffer_len`, or [`ValidationError::IntegerOverflow`]
+    /// when metadata arithmetic overflows.
     pub fn from_parts(
         shape: R::Shape,
         strides: R::Strides,
@@ -249,7 +272,7 @@ impl<R: TensorRank> TensorLayout<R> {
     ///
     /// let layout = TensorLayout::<Rank<1>>::compact([4])?;
     /// assert_eq!(layout.shape(), &[4]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn shape(&self) -> &[usize] {
         self.shape.as_ref()
@@ -264,7 +287,7 @@ impl<R: TensorRank> TensorLayout<R> {
     ///
     /// let layout = TensorLayout::<Rank<2>>::compact([2, 3])?;
     /// assert_eq!(layout.strides(), &[1, 2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn strides(&self) -> &[isize] {
         self.strides.as_ref()
@@ -279,7 +302,7 @@ impl<R: TensorRank> TensorLayout<R> {
     ///
     /// let layout = TensorLayout::<DynRank>::from_parts(vec![3].into(), vec![1].into(), 2, 5)?;
     /// assert_eq!(layout.offset(), 2);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn offset(&self) -> isize {
         self.offset
@@ -294,8 +317,13 @@ impl<R: TensorRank> TensorLayout<R> {
     ///
     /// let layout = TensorLayout::<Rank<2>>::compact([2, 3])?;
     /// assert!(layout.is_compact_col_major()?);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::IntegerOverflow`] when compactness
+    /// validation overflows metadata arithmetic.
     pub fn is_compact_col_major(&self) -> Result<bool> {
         if self.shape().contains(&0) {
             return Ok(true);
@@ -318,8 +346,14 @@ impl<R: TensorRank> TensorLayout<R> {
     ///
     /// let layout = TensorLayout::<DynRank>::from_parts(vec![3].into(), vec![-1].into(), 2, 3)?;
     /// layout.validate_mutable_no_overlap()?;
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::OverlappingMutableLayout`] when multiple
+    /// logical elements can alias, or [`ValidationError::IntegerOverflow`]
+    /// when overlap validation arithmetic overflows.
     pub fn validate_mutable_no_overlap(&self) -> Result<()> {
         if self.shape().contains(&0) {
             return Ok(());
@@ -327,7 +361,7 @@ impl<R: TensorRank> TensorLayout<R> {
 
         for (&extent, &stride) in self.shape().iter().zip(self.strides()) {
             if extent > 1 && stride == 0 {
-                return Err(Error::OverlappingMutableLayout);
+                return Err(ValidationError::OverlappingMutableLayout);
             }
         }
 
@@ -351,9 +385,9 @@ impl<R: TensorRank> TensorLayout<R> {
                 .checked_add(
                     (extent - 1)
                         .checked_mul(stride)
-                        .ok_or(Error::IntegerOverflow)?,
+                        .ok_or(ValidationError::IntegerOverflow)?,
                 )
-                .ok_or(Error::IntegerOverflow)?;
+                .ok_or(ValidationError::IntegerOverflow)?;
         }
 
         Ok(())
@@ -361,7 +395,7 @@ impl<R: TensorRank> TensorLayout<R> {
 
     fn validate_mutable_no_overlap_exact_or_reject(&self, element_count: usize) -> Result<()> {
         if element_count > MUTABLE_NO_OVERLAP_EXACT_ELEMENT_LIMIT {
-            return Err(Error::OverlappingMutableLayout);
+            return Err(ValidationError::OverlappingMutableLayout);
         }
 
         let mut seen = HashSet::with_capacity(element_count);
@@ -371,15 +405,17 @@ impl<R: TensorRank> TensorLayout<R> {
         loop {
             let mut physical_offset = self.offset;
             for (&index, &stride) in indices.iter().zip(self.strides()) {
-                let index = isize::try_from(index).map_err(|_| Error::IntegerOverflow)?;
-                let delta = index.checked_mul(stride).ok_or(Error::IntegerOverflow)?;
+                let index = isize::try_from(index).map_err(|_| ValidationError::IntegerOverflow)?;
+                let delta = index
+                    .checked_mul(stride)
+                    .ok_or(ValidationError::IntegerOverflow)?;
                 physical_offset = physical_offset
                     .checked_add(delta)
-                    .ok_or(Error::IntegerOverflow)?;
+                    .ok_or(ValidationError::IntegerOverflow)?;
             }
 
             if !seen.insert(physical_offset) {
-                return Err(Error::OverlappingMutableLayout);
+                return Err(ValidationError::OverlappingMutableLayout);
             }
 
             let mut axis = 0;
@@ -408,8 +444,15 @@ impl<R: TensorRank> TensorLayout<R> {
     /// let transposed = layout.transpose_view([1, 0])?;
     /// assert_eq!(transposed.shape(), &[3, 2]);
     /// assert_eq!(transposed.strides(), &[2, 1]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::InvalidPermutationLength`],
+    /// [`ValidationError::AxisOutOfBounds`], or
+    /// [`ValidationError::DuplicateAxis`] when `axes` is not a permutation of
+    /// the layout rank.
     pub fn transpose_view(&self, axes: impl AsRef<[usize]>) -> Result<Self> {
         let axes = axes.as_ref();
         validate_permutation(self.shape().len(), axes)?;
@@ -439,12 +482,20 @@ impl<R: TensorRank> TensorLayout<R> {
     /// let view = layout.slice_view([SliceSpec { start: 3, end: -1, step: -2 }], 4)?;
     /// assert_eq!(view.shape(), &[2]);
     /// assert_eq!(view.strides(), &[-2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::RankMismatch`] when `spec` does not cover
+    /// every axis, [`ValidationError::InvalidSliceStep`] or
+    /// [`ValidationError::InvalidSliceBounds`] for invalid slice parameters,
+    /// or [`ValidationError::ViewOutOfBounds`] when the result is outside the
+    /// backing buffer.
     pub fn slice_view(&self, spec: impl AsRef<[SliceSpec]>, buffer_len: usize) -> Result<Self> {
         let spec = spec.as_ref();
         if spec.len() != self.shape().len() {
-            return Err(Error::RankMismatch {
+            return Err(ValidationError::RankMismatch {
                 expected: self.shape().len(),
                 actual: spec.len(),
             });
@@ -460,15 +511,17 @@ impl<R: TensorRank> TensorLayout<R> {
             .zip(spec.iter())
         {
             let (start, extent) = normalize_slice(slice, axis_len)?;
-            let start_offset = start.checked_mul(stride).ok_or(Error::IntegerOverflow)?;
+            let start_offset = start
+                .checked_mul(stride)
+                .ok_or(ValidationError::IntegerOverflow)?;
             offset = offset
                 .checked_add(start_offset)
-                .ok_or(Error::IntegerOverflow)?;
+                .ok_or(ValidationError::IntegerOverflow)?;
             shape.push(extent);
             strides.push(
                 stride
                     .checked_mul(slice.step)
-                    .ok_or(Error::IntegerOverflow)?,
+                    .ok_or(ValidationError::IntegerOverflow)?,
             );
         }
         layout_from_vecs(shape, strides, offset, buffer_len)
@@ -485,20 +538,27 @@ impl<R: TensorRank> TensorLayout<R> {
     /// let reshaped = layout.reshape_view_as::<Rank<1>>([6], 6)?;
     /// assert_eq!(reshaped.shape(), &[6]);
     /// assert_eq!(reshaped.strides(), &[1]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::NonContiguousViewAsSlice`] for a noncompact
+    /// source, [`ValidationError::ShapeMismatch`] for a different element
+    /// count, or [`ValidationError::IntegerOverflow`] when shape arithmetic
+    /// overflows.
     pub fn reshape_view_as<R2: TensorRank>(
         &self,
         shape: R2::Shape,
         buffer_len: usize,
     ) -> Result<TensorLayout<R2>> {
         if !self.is_compact_col_major()? {
-            return Err(Error::NonContiguousViewAsSlice);
+            return Err(ValidationError::NonContiguousViewAsSlice);
         }
         let from = checked_product(self.shape())?;
         let to = checked_product(shape.as_ref())?;
         if from != to {
-            return Err(Error::ReshapeElementCountMismatch { from, to });
+            return Err(ShapeMismatch::ReshapeElementCount { from, to }.into());
         }
         let strides = R2::strides_from_vec(col_major_strides(shape.as_ref())?)?;
         TensorLayout::from_parts(shape, strides, self.offset, buffer_len)
@@ -515,8 +575,16 @@ impl<R: TensorRank> TensorLayout<R> {
     /// let broadcast = layout.broadcast_in_dim_view::<Rank<2>>([2, 3], [1], 3)?;
     /// assert_eq!(broadcast.shape(), &[2, 3]);
     /// assert_eq!(broadcast.strides(), &[0, 1]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::RankMismatch`],
+    /// [`ValidationError::AxisOutOfBounds`], or
+    /// [`ValidationError::DuplicateAxis`] for invalid broadcast axes;
+    /// [`ValidationError::ShapeDataLengthMismatch`] for incompatible extents;
+    /// or [`ValidationError::ViewOutOfBounds`] for an invalid result layout.
     pub fn broadcast_in_dim_view<R2: TensorRank>(
         &self,
         shape: R2::Shape,
@@ -525,7 +593,7 @@ impl<R: TensorRank> TensorLayout<R> {
     ) -> Result<TensorLayout<R2>> {
         let broadcast_dims = broadcast_dims.as_ref();
         if broadcast_dims.len() != self.shape().len() {
-            return Err(Error::RankMismatch {
+            return Err(ValidationError::RankMismatch {
                 expected: self.shape().len(),
                 actual: broadcast_dims.len(),
             });
@@ -537,20 +605,23 @@ impl<R: TensorRank> TensorLayout<R> {
         strides.resize(output_rank, 0);
         for (input_axis, &output_axis) in broadcast_dims.iter().enumerate() {
             if output_axis >= output_rank {
-                return Err(Error::AxisOutOfBounds {
+                return Err(ValidationError::AxisOutOfBounds {
                     axis: output_axis,
                     rank: output_rank,
                 });
             }
             if seen[output_axis] {
-                return Err(Error::DuplicateAxis { axis: output_axis });
+                return Err(ValidationError::DuplicateAxis {
+                    axis: output_axis,
+                    role: "permutation",
+                });
             }
             seen[output_axis] = true;
 
             let input_extent = self.shape()[input_axis];
             let output_extent = shape.as_ref()[output_axis];
             if input_extent != output_extent && input_extent != 1 {
-                return Err(Error::ShapeDataLengthMismatch {
+                return Err(ValidationError::ShapeDataLengthMismatch {
                     expected: input_extent,
                     actual: output_extent,
                 });
@@ -572,7 +643,7 @@ impl<R: TensorRank> TensorLayout<R> {
 #[cfg(test)]
 mod tests {
     use super::positive_ceil_div;
-    use crate::Error;
+    use crate::ValidationError;
     use std::panic::{catch_unwind, AssertUnwindSafe};
 
     #[test]
@@ -586,7 +657,10 @@ mod tests {
                 result.is_ok(),
                 "invalid positive_ceil_div inputs should return Err"
             );
-            assert!(matches!(result.unwrap(), Err(Error::IntegerOverflow)));
+            assert!(matches!(
+                result.unwrap(),
+                Err(ValidationError::IntegerOverflow)
+            ));
         }
     }
 }

--- a/crates/tenferro-tensor-core/src/lib.rs
+++ b/crates/tenferro-tensor-core/src/lib.rs
@@ -25,15 +25,17 @@
 //! let layout = TensorLayout::<Rank<2>>::compact([2, 3])?;
 //! let transposed = layout.transpose_view([1, 0])?;
 //! assert_eq!(transposed.shape(), &[3, 2]);
-//! # Ok::<(), tenferro_tensor_core::Error>(())
+//! # Ok::<(), tenferro_tensor_core::ValidationError>(())
 //! ```
 
 use num_complex::{Complex32, Complex64};
 use smallvec::SmallVec;
 
+mod error;
 mod layout;
 mod rank;
 
+pub use error::{ErrorKind, ShapeMismatch, ValidationError, ValidationKind};
 pub use layout::TensorLayout;
 pub use rank::{DynRank, Rank, TensorRank};
 
@@ -66,59 +68,12 @@ pub type StrideVec = SmallVec<[isize; 8]>;
 /// # Examples
 ///
 /// ```rust
-/// use tenferro_tensor_core::{Error, Result};
+/// use tenferro_tensor_core::{Result, ValidationError};
 ///
-/// let result: Result<()> = Err(Error::RankMismatch { expected: 2, actual: 1 });
+/// let result: Result<()> = Err(ValidationError::RankMismatch { expected: 2, actual: 1 });
 /// assert!(result.is_err());
 /// ```
-pub type Result<T> = std::result::Result<T, Error>;
-
-/// Data-model validation errors.
-///
-/// # Examples
-///
-/// ```rust
-/// use tenferro_tensor_core::Error;
-///
-/// let err = Error::ReshapeElementCountMismatch { from: 4, to: 5 };
-/// assert!(err.to_string().contains("reshape"));
-/// ```
-#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
-pub enum Error {
-    #[error("shape product {expected} does not match data length {actual}")]
-    ShapeDataLengthMismatch { expected: usize, actual: usize },
-    #[error("rank mismatch: expected {expected}, actual {actual}")]
-    RankMismatch { expected: usize, actual: usize },
-    #[error("axis {axis} out of bounds for rank {rank}")]
-    AxisOutOfBounds { axis: usize, rank: usize },
-    #[error("duplicate axis {axis} in permutation")]
-    DuplicateAxis { axis: usize },
-    #[error("invalid permutation length: expected {expected}, actual {actual}")]
-    InvalidPermutationLength { expected: usize, actual: usize },
-    #[error("invalid slice step {step}; zero is invalid and this API may require a positive step")]
-    InvalidSliceStep { step: isize },
-    #[error(
-        "slice bounds are invalid or unsupported: start={start}, end={end}, axis_len={axis_len}"
-    )]
-    InvalidSliceBounds {
-        start: isize,
-        end: isize,
-        axis_len: usize,
-    },
-    #[error("reshape element-count mismatch: from {from} to {to}")]
-    ReshapeElementCountMismatch { from: usize, to: usize },
-    #[error("view is not slice-contiguous")]
-    NonContiguousViewAsSlice,
-    #[error("dtype mismatch: expected {expected:?}, actual {actual:?}")]
-    DTypeMismatch { expected: DType, actual: DType },
-    #[error("view metadata is out of borrowed-slice bounds")]
-    ViewOutOfBounds,
-    /// Mutable layout metadata may alias the same physical element.
-    #[error("mutable tensor layout may overlap physical elements")]
-    OverlappingMutableLayout,
-    #[error("integer overflow while validating tensor metadata")]
-    IntegerOverflow,
-}
+pub type Result<T> = std::result::Result<T, ValidationError>;
 
 /// Runtime scalar dtype tag.
 ///
@@ -174,8 +129,14 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     ///
     /// let tensor = <f64 as TensorScalar>::into_tensor(ShapeVec::from_slice(&[1]), vec![2.0])?;
     /// assert_eq!(tensor.dtype(), DType::F64);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::ShapeDataLengthMismatch`] when the shape
+    /// product differs from the data length, or [`ValidationError::IntegerOverflow`]
+    /// when validating the shape overflows.
     fn into_tensor(shape: ShapeVec, data: Vec<Self>) -> Result<Tensor>;
     fn tensor_slice(tensor: &Tensor) -> Option<&[Self]>;
     fn tensor_mut_slice(tensor: &mut Tensor) -> Option<&mut [Self]>;
@@ -269,7 +230,7 @@ pub struct SliceSpec {
 ///
 /// let tensor = HostTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
 /// assert_eq!(tensor.as_slice(), &[1.0, 2.0]);
-/// # Ok::<(), tenferro_tensor_core::Error>(())
+/// # Ok::<(), tenferro_tensor_core::ValidationError>(())
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct HostTensor<T> {
@@ -286,7 +247,7 @@ pub struct HostTensor<T> {
 ///
 /// let tensor = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
 /// assert_eq!(tensor.dtype(), DType::F64);
-/// # Ok::<(), tenferro_tensor_core::Error>(())
+/// # Ok::<(), tenferro_tensor_core::ValidationError>(())
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub enum Tensor {
@@ -313,7 +274,7 @@ pub enum Tensor {
 /// let tensor = HostTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
 /// let view = tensor.as_view();
 /// assert_eq!(view.shape(), &[2]);
-/// # Ok::<(), tenferro_tensor_core::Error>(())
+/// # Ok::<(), tenferro_tensor_core::ValidationError>(())
 /// ```
 ///
 /// ```compile_fail
@@ -341,7 +302,7 @@ pub struct HostTensorView<'a, T> {
 /// let tensor = Tensor::from_vec_col_major(vec![1], vec![true])?;
 /// let view = tensor.as_view();
 /// assert_eq!(view.dtype(), DType::Bool);
-/// # Ok::<(), tenferro_tensor_core::Error>(())
+/// # Ok::<(), tenferro_tensor_core::ValidationError>(())
 /// ```
 ///
 /// ```compile_fail
@@ -372,7 +333,7 @@ pub enum TensorView<'a> {
 /// let tensor = Tensor::from_vec_col_major(vec![1], vec![1.0_f32])?;
 /// let reference = TensorRef::Tensor(&tensor);
 /// assert_eq!(reference.shape(), &[1]);
-/// # Ok::<(), tenferro_tensor_core::Error>(())
+/// # Ok::<(), tenferro_tensor_core::ValidationError>(())
 /// ```
 #[derive(Clone, Debug)]
 pub enum TensorRef<'a> {
@@ -382,7 +343,7 @@ pub enum TensorRef<'a> {
 
 fn checked_product(shape: &[usize]) -> Result<usize> {
     shape.iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim).ok_or(Error::IntegerOverflow)
+        acc.checked_mul(dim).ok_or(ValidationError::IntegerOverflow)
     })
 }
 
@@ -397,7 +358,7 @@ fn checked_shape_len(shape: &[usize], data_len: usize) -> Result<usize> {
     validate_shape_metadata(shape)?;
     let expected = checked_product(shape)?;
     if expected != data_len {
-        return Err(Error::ShapeDataLengthMismatch {
+        return Err(ValidationError::ShapeDataLengthMismatch {
             expected,
             actual: data_len,
         });
@@ -424,22 +385,29 @@ fn compact_col_major_strides(shape: &[usize]) -> StrideVec {
 /// use tenferro_tensor_core::col_major_strides;
 ///
 /// assert_eq!(col_major_strides(&[2, 3])?.as_slice(), &[1, 2]);
-/// # Ok::<(), tenferro_tensor_core::Error>(())
+/// # Ok::<(), tenferro_tensor_core::ValidationError>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns [`ValidationError::IntegerOverflow`] when a stride or extent
+/// cannot be represented by the metadata arithmetic.
 pub fn col_major_strides(shape: &[usize]) -> Result<StrideVec> {
     let mut strides = StrideVec::new();
     let mut stride = 1isize;
     for &extent in shape {
         strides.push(stride);
-        let extent = isize::try_from(extent).map_err(|_| Error::IntegerOverflow)?;
-        stride = stride.checked_mul(extent).ok_or(Error::IntegerOverflow)?;
+        let extent = isize::try_from(extent).map_err(|_| ValidationError::IntegerOverflow)?;
+        stride = stride
+            .checked_mul(extent)
+            .ok_or(ValidationError::IntegerOverflow)?;
     }
     Ok(strides)
 }
 
 fn validate_permutation(rank: usize, axes: &[usize]) -> Result<()> {
     if axes.len() != rank {
-        return Err(Error::InvalidPermutationLength {
+        return Err(ValidationError::InvalidPermutationLength {
             expected: rank,
             actual: axes.len(),
         });
@@ -447,10 +415,13 @@ fn validate_permutation(rank: usize, axes: &[usize]) -> Result<()> {
     let mut seen = vec![false; rank];
     for &axis in axes {
         if axis >= rank {
-            return Err(Error::AxisOutOfBounds { axis, rank });
+            return Err(ValidationError::AxisOutOfBounds { axis, rank });
         }
         if seen[axis] {
-            return Err(Error::DuplicateAxis { axis });
+            return Err(ValidationError::DuplicateAxis {
+                axis,
+                role: "permutation",
+            });
         }
         seen[axis] = true;
     }
@@ -482,8 +453,10 @@ fn is_slice_contiguous(shape: &[usize], strides: &[isize]) -> Result<bool> {
         if stride != expected {
             return Ok(false);
         }
-        let extent = isize::try_from(extent).map_err(|_| Error::IntegerOverflow)?;
-        let next = expected.checked_mul(extent).ok_or(Error::IntegerOverflow)?;
+        let extent = isize::try_from(extent).map_err(|_| ValidationError::IntegerOverflow)?;
+        let next = expected
+            .checked_mul(extent)
+            .ok_or(ValidationError::IntegerOverflow)?;
         expected = next;
     }
     Ok(true)
@@ -499,8 +472,14 @@ impl<T> HostTensor<T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![2], vec![1_i64, 2])?;
     /// assert_eq!(tensor.shape(), &[2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::ShapeDataLengthMismatch`] when the shape
+    /// product differs from `data.len()`, or [`ValidationError::IntegerOverflow`]
+    /// when validating the shape overflows.
     pub fn from_vec_col_major(shape: impl Into<ShapeVec>, data: Vec<T>) -> Result<Self> {
         let shape = shape.into();
         checked_shape_len(&shape, data.len())?;
@@ -516,7 +495,7 @@ impl<T> HostTensor<T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![2], vec![true, false])?;
     /// assert_eq!(tensor.shape(), &[2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn shape(&self) -> &[usize] {
         &self.shape
@@ -531,7 +510,7 @@ impl<T> HostTensor<T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![2, 1], vec![1.0_f32, 2.0])?;
     /// assert_eq!(tensor.rank(), 2);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn rank(&self) -> usize {
         self.shape.len()
@@ -546,7 +525,7 @@ impl<T> HostTensor<T> {
     ///
     /// let tensor = HostTensor::<f64>::from_vec_col_major(vec![0], vec![])?;
     /// assert!(tensor.is_empty());
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
@@ -561,7 +540,7 @@ impl<T> HostTensor<T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![1], vec![7_i32])?;
     /// assert_eq!(tensor.as_slice(), &[7]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn as_slice(&self) -> &[T] {
         &self.data
@@ -577,7 +556,7 @@ impl<T> HostTensor<T> {
     /// let mut tensor = HostTensor::from_vec_col_major(vec![1], vec![7_i32])?;
     /// tensor.as_mut_slice()[0] = 8;
     /// assert_eq!(tensor.as_slice(), &[8]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         &mut self.data
@@ -592,7 +571,7 @@ impl<T> HostTensor<T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
     /// assert!(tensor.as_view().is_zero_offset_col_major()?);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn as_view(&self) -> HostTensorView<'_, T> {
         HostTensorView {
@@ -612,7 +591,7 @@ impl<T> HostTensor<T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![1], vec![3.0_f64])?;
     /// assert_eq!(tensor.into_vec_col_major().1, vec![3.0]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn into_vec_col_major(self) -> (ShapeVec, Vec<T>) {
         (self.shape, self.data)
@@ -627,14 +606,20 @@ impl<T> HostTensor<T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0])?;
     /// assert_eq!(tensor.into_reshaped(vec![2, 2])?.shape(), &[2, 2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::ShapeMismatch`] when the requested shape has
+    /// a different element count, or [`ValidationError::IntegerOverflow`] when
+    /// validating that count overflows.
     pub fn into_reshaped(self, shape: impl Into<ShapeVec>) -> Result<Self> {
         let shape = shape.into();
         let from = self.data.len();
         let to = checked_product(&shape)?;
         if from != to {
-            return Err(Error::ReshapeElementCountMismatch { from, to });
+            return Err(ShapeMismatch::ReshapeElementCount { from, to }.into());
         }
         validate_shape_metadata(&shape)?;
         Ok(Self {
@@ -655,8 +640,15 @@ impl<'a, T> HostTensorView<'a, T> {
     /// let data = [1.0_f64, 2.0, 3.0, 4.0];
     /// let view = HostTensorView::from_slice(vec![2], vec![1], 1, &data)?;
     /// assert_eq!(view.as_slice()?, &[2.0, 3.0]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::RankMismatch`] for shape/stride rank
+    /// disagreement, [`ValidationError::ViewOutOfBounds`] for an unreachable
+    /// view, or [`ValidationError::IntegerOverflow`] when bounds arithmetic
+    /// overflows.
     pub fn from_slice(
         shape: impl Into<ShapeVec>,
         strides: impl Into<StrideVec>,
@@ -683,7 +675,7 @@ impl<'a, T> HostTensorView<'a, T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?;
     /// assert_eq!(tensor.as_view().shape(), &[2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn shape(&self) -> &[usize] {
         &self.shape
@@ -698,7 +690,7 @@ impl<'a, T> HostTensorView<'a, T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![2, 3], vec![0_i32; 6])?;
     /// assert_eq!(tensor.as_view().strides(), &[1, 2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn strides(&self) -> &[isize] {
         &self.strides
@@ -713,7 +705,7 @@ impl<'a, T> HostTensorView<'a, T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![1], vec![true])?;
     /// assert_eq!(tensor.as_view().offset(), 0);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn offset(&self) -> isize {
         self.offset
@@ -728,7 +720,7 @@ impl<'a, T> HostTensorView<'a, T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![2, 1], vec![1.0_f64, 2.0])?;
     /// assert_eq!(tensor.as_view().rank(), 2);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn rank(&self) -> usize {
         self.shape.len()
@@ -744,7 +736,7 @@ impl<'a, T> HostTensorView<'a, T> {
     /// let data = [1.0_f64];
     /// let view = HostTensorView::from_slice(vec![0], vec![1], 0, &data)?;
     /// assert!(view.is_empty());
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn is_empty(&self) -> bool {
         self.shape.contains(&0)
@@ -759,8 +751,13 @@ impl<'a, T> HostTensorView<'a, T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![2, 2], vec![0_i32; 4])?;
     /// assert!(tensor.as_view().is_compact_col_major()?);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::IntegerOverflow`] if compactness validation
+    /// overflows metadata arithmetic.
     pub fn is_compact_col_major(&self) -> Result<bool> {
         is_slice_contiguous(&self.shape, &self.strides)
     }
@@ -774,8 +771,13 @@ impl<'a, T> HostTensorView<'a, T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![1], vec![1_i64])?;
     /// assert!(tensor.as_view().is_zero_offset_col_major()?);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::IntegerOverflow`] if compactness validation
+    /// overflows metadata arithmetic.
     pub fn is_zero_offset_col_major(&self) -> Result<bool> {
         Ok(self.offset == 0 && self.is_compact_col_major()?)
     }
@@ -790,16 +792,27 @@ impl<'a, T> HostTensorView<'a, T> {
     /// let data = [1_i32, 2, 3, 4];
     /// let view = HostTensorView::from_slice(vec![2], vec![1], 1, &data)?;
     /// assert_eq!(view.as_slice()?, &[2, 3]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::NonContiguousViewAsSlice`] for a view that
+    /// is not slice-contiguous, [`ValidationError::ViewOutOfBounds`] for an
+    /// invalid backing range, or [`ValidationError::IntegerOverflow`] when
+    /// range arithmetic overflows.
     pub fn as_slice(&self) -> Result<&'a [T]> {
         if !is_slice_contiguous(&self.shape, &self.strides)? {
-            return Err(Error::NonContiguousViewAsSlice);
+            return Err(ValidationError::NonContiguousViewAsSlice);
         }
         let len = checked_product(&self.shape)?;
-        let start = usize::try_from(self.offset).map_err(|_| Error::IntegerOverflow)?;
-        let end = start.checked_add(len).ok_or(Error::IntegerOverflow)?;
-        self.data.get(start..end).ok_or(Error::ViewOutOfBounds)
+        let start = usize::try_from(self.offset).map_err(|_| ValidationError::IntegerOverflow)?;
+        let end = start
+            .checked_add(len)
+            .ok_or(ValidationError::IntegerOverflow)?;
+        self.data
+            .get(start..end)
+            .ok_or(ValidationError::ViewOutOfBounds)
     }
 
     /// Return a metadata-only reshape of this compact column-major view.
@@ -811,17 +824,24 @@ impl<'a, T> HostTensorView<'a, T> {
     ///
     /// let tensor = HostTensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0])?;
     /// assert_eq!(tensor.as_view().reshape_view(vec![2, 2])?.shape(), &[2, 2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::NonContiguousViewAsSlice`] for a view that
+    /// is not slice-contiguous, [`ValidationError::ShapeMismatch`] for a
+    /// different element count, or [`ValidationError::IntegerOverflow`] when
+    /// shape arithmetic overflows.
     pub fn reshape_view(&self, shape: impl Into<ShapeVec>) -> Result<Self> {
         if !self.is_compact_col_major()? {
-            return Err(Error::NonContiguousViewAsSlice);
+            return Err(ValidationError::NonContiguousViewAsSlice);
         }
         let shape = shape.into();
         let from = checked_product(&self.shape)?;
         let to = checked_product(&shape)?;
         if from != to {
-            return Err(Error::ReshapeElementCountMismatch { from, to });
+            return Err(ShapeMismatch::ReshapeElementCount { from, to }.into());
         }
         Self::from_slice(
             shape.clone(),
@@ -842,8 +862,16 @@ impl<'a, T> HostTensorView<'a, T> {
     /// let view = tensor.as_view().transpose_view(&[1, 0])?;
     /// assert_eq!(view.shape(), &[3, 2]);
     /// assert_eq!(view.strides(), &[2, 1]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::InvalidPermutationLength`],
+    /// [`ValidationError::AxisOutOfBounds`], or
+    /// [`ValidationError::DuplicateAxis`] when `axes` is not a permutation of
+    /// the view rank; it may also return [`ValidationError::ViewOutOfBounds`]
+    /// or [`ValidationError::IntegerOverflow`] while validating the result.
     pub fn transpose_view(&self, axes: &[usize]) -> Result<Self> {
         validate_permutation(self.rank(), axes)?;
         let shape = axes
@@ -869,11 +897,18 @@ impl<'a, T> HostTensorView<'a, T> {
     ///     .as_view()
     ///     .slice_view(&[SliceSpec { start: 1, end: 4, step: 2 }])?;
     /// assert_eq!(view.shape(), &[2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::RankMismatch`] when `spec` does not cover
+    /// every axis, [`ValidationError::InvalidSliceStep`] or
+    /// [`ValidationError::InvalidSliceBounds`] for invalid slice parameters,
+    /// or [`ValidationError::ViewOutOfBounds`] for an invalid result view.
     pub fn slice_view(&self, spec: &[SliceSpec]) -> Result<Self> {
         if spec.len() != self.rank() {
-            return Err(Error::RankMismatch {
+            return Err(ValidationError::RankMismatch {
                 expected: self.rank(),
                 actual: spec.len(),
             });
@@ -883,43 +918,44 @@ impl<'a, T> HostTensorView<'a, T> {
         let mut offset = self.offset;
         for ((&axis_len, &stride), slice) in self.shape.iter().zip(self.strides.iter()).zip(spec) {
             if slice.step <= 0 {
-                return Err(Error::InvalidSliceStep { step: slice.step });
+                return Err(ValidationError::InvalidSliceStep { step: slice.step });
             }
             if slice.start < 0 || slice.end < 0 {
-                return Err(Error::InvalidSliceBounds {
+                return Err(ValidationError::InvalidSliceBounds {
                     start: slice.start,
                     end: slice.end,
                     axis_len,
                 });
             }
-            let start = usize::try_from(slice.start).map_err(|_| Error::IntegerOverflow)?;
-            let end = usize::try_from(slice.end).map_err(|_| Error::IntegerOverflow)?;
+            let start =
+                usize::try_from(slice.start).map_err(|_| ValidationError::IntegerOverflow)?;
+            let end = usize::try_from(slice.end).map_err(|_| ValidationError::IntegerOverflow)?;
             if start > axis_len || end > axis_len {
-                return Err(Error::InvalidSliceBounds {
+                return Err(ValidationError::InvalidSliceBounds {
                     start: slice.start,
                     end: slice.end,
                     axis_len,
                 });
             }
-            let step = usize::try_from(slice.step).map_err(|_| Error::IntegerOverflow)?;
+            let step = usize::try_from(slice.step).map_err(|_| ValidationError::IntegerOverflow)?;
             let extent = if start >= end {
                 0
             } else {
                 end.checked_sub(start)
                     .and_then(|span| span.checked_add(step - 1))
-                    .ok_or(Error::IntegerOverflow)?
+                    .ok_or(ValidationError::IntegerOverflow)?
                     / step
             };
             let start_offset = isize::try_from(start)
-                .map_err(|_| Error::IntegerOverflow)?
+                .map_err(|_| ValidationError::IntegerOverflow)?
                 .checked_mul(stride)
-                .ok_or(Error::IntegerOverflow)?;
+                .ok_or(ValidationError::IntegerOverflow)?;
             offset = offset
                 .checked_add(start_offset)
-                .ok_or(Error::IntegerOverflow)?;
+                .ok_or(ValidationError::IntegerOverflow)?;
             let new_stride = stride
                 .checked_mul(slice.step)
-                .ok_or(Error::IntegerOverflow)?;
+                .ok_or(ValidationError::IntegerOverflow)?;
             shape.push(extent);
             strides.push(new_stride);
         }
@@ -937,8 +973,14 @@ impl Tensor {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![1], vec![2.0_f32])?;
     /// assert_eq!(tensor.dtype(), DType::F32);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::ShapeDataLengthMismatch`] when the shape
+    /// product differs from `data.len()`, or [`ValidationError::IntegerOverflow`]
+    /// when validating the shape overflows.
     pub fn from_vec_col_major<T: TensorScalar>(
         shape: impl Into<ShapeVec>,
         data: Vec<T>,
@@ -955,7 +997,7 @@ impl Tensor {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![1], vec![false])?;
     /// assert_eq!(tensor.dtype(), DType::Bool);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn dtype(&self) -> DType {
         match self {
@@ -978,7 +1020,7 @@ impl Tensor {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![2], vec![1_i32, 2])?;
     /// assert_eq!(tensor.shape(), &[2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn shape(&self) -> &[usize] {
         match self {
@@ -1001,7 +1043,7 @@ impl Tensor {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![1, 1], vec![1_i64])?;
     /// assert_eq!(tensor.rank(), 2);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn rank(&self) -> usize {
         self.shape().len()
@@ -1016,7 +1058,7 @@ impl Tensor {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![0], Vec::<f64>::new())?;
     /// assert!(tensor.is_empty());
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn is_empty(&self) -> bool {
         match self {
@@ -1040,10 +1082,15 @@ impl Tensor {
     /// let tensor = Tensor::from_vec_col_major(vec![1], vec![3.0_f64])?;
     /// assert_eq!(tensor.as_slice::<f64>()?, &[3.0]);
     /// assert!(tensor.as_slice::<f32>().is_err());
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::DTypeMismatch`] when `T` does not match the
+    /// tensor's runtime dtype.
     pub fn as_slice<T: TensorScalar>(&self) -> Result<&[T]> {
-        T::tensor_slice(self).ok_or(Error::DTypeMismatch {
+        T::tensor_slice(self).ok_or(ValidationError::DTypeMismatch {
             expected: T::dtype(),
             actual: self.dtype(),
         })
@@ -1059,11 +1106,16 @@ impl Tensor {
     /// let mut tensor = Tensor::from_vec_col_major(vec![1], vec![3.0_f64])?;
     /// tensor.as_mut_slice::<f64>()?[0] = 4.0;
     /// assert_eq!(tensor.as_slice::<f64>()?, &[4.0]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::DTypeMismatch`] when `T` does not match the
+    /// tensor's runtime dtype.
     pub fn as_mut_slice<T: TensorScalar>(&mut self) -> Result<&mut [T]> {
         let actual = self.dtype();
-        T::tensor_mut_slice(self).ok_or(Error::DTypeMismatch {
+        T::tensor_mut_slice(self).ok_or(ValidationError::DTypeMismatch {
             expected: T::dtype(),
             actual,
         })
@@ -1078,7 +1130,7 @@ impl Tensor {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![1], vec![1_i64])?;
     /// assert_eq!(tensor.as_view().dtype(), DType::I64);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn as_view(&self) -> TensorView<'_> {
         match self {
@@ -1101,13 +1153,18 @@ impl Tensor {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![1], vec![2.0_f32])?;
     /// assert_eq!(tensor.into_vec_col_major::<f32>()?.1, vec![2.0]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::DTypeMismatch`] when `T` does not match the
+    /// tensor's runtime dtype.
     pub fn into_vec_col_major<T: TensorScalar>(self) -> Result<(ShapeVec, Vec<T>)> {
         let actual = self.dtype();
         T::into_typed(self)
             .map(HostTensor::into_vec_col_major)
-            .ok_or(Error::DTypeMismatch {
+            .ok_or(ValidationError::DTypeMismatch {
                 expected: T::dtype(),
                 actual,
             })
@@ -1138,7 +1195,7 @@ impl<'a> TensorView<'a> {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![1], vec![1.0_f32])?;
     /// assert_eq!(tensor.as_view().dtype(), DType::F32);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn dtype(&self) -> DType {
         match self {
@@ -1161,7 +1218,7 @@ impl<'a> TensorView<'a> {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![1], vec![1.0_f64])?;
     /// assert_eq!(tensor.as_view().shape(), &[1]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn shape(&self) -> &[usize] {
         match self {
@@ -1184,7 +1241,7 @@ impl<'a> TensorView<'a> {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![1, 1], vec![1_i64])?;
     /// assert_eq!(tensor.as_view().rank(), 2);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn rank(&self) -> usize {
         self.shape().len()
@@ -1199,7 +1256,7 @@ impl<'a> TensorView<'a> {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![0], Vec::<f64>::new())?;
     /// assert!(tensor.as_view().is_empty());
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn is_empty(&self) -> bool {
         match self {
@@ -1222,8 +1279,15 @@ impl<'a> TensorView<'a> {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![4], vec![1_i32, 2, 3, 4])?;
     /// assert_eq!(tensor.as_view().reshape_view(vec![2, 2])?.shape(), &[2, 2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying view's validation errors, including
+    /// [`ValidationError::ShapeMismatch`],
+    /// [`ValidationError::NonContiguousViewAsSlice`], or
+    /// [`ValidationError::IntegerOverflow`].
     pub fn reshape_view(&self, shape: impl Into<ShapeVec>) -> Result<Self> {
         let shape = shape.into();
         Ok(impl_dynamic_view!(self, reshape_view(shape) => view))
@@ -1238,8 +1302,15 @@ impl<'a> TensorView<'a> {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![1, 2], vec![1_i64, 2])?;
     /// assert_eq!(tensor.as_view().transpose_view(&[1, 0])?.shape(), &[2, 1]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::InvalidPermutationLength`],
+    /// [`ValidationError::AxisOutOfBounds`], or
+    /// [`ValidationError::DuplicateAxis`] when `axes` is not a permutation of
+    /// the view rank.
     pub fn transpose_view(&self, axes: &[usize]) -> Result<Self> {
         Ok(impl_dynamic_view!(self, transpose_view(axes) => view))
     }
@@ -1256,8 +1327,14 @@ impl<'a> TensorView<'a> {
     ///     tensor.as_view().slice_view(&[SliceSpec { start: 1, end: 3, step: 1 }])?.shape(),
     ///     &[2],
     /// );
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::RankMismatch`],
+    /// [`ValidationError::InvalidSliceStep`], or
+    /// [`ValidationError::InvalidSliceBounds`] for invalid slice parameters.
     pub fn slice_view(&self, spec: &[SliceSpec]) -> Result<Self> {
         Ok(impl_dynamic_view!(self, slice_view(spec) => view))
     }
@@ -1273,7 +1350,7 @@ impl<'a> TensorRef<'a> {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![1], vec![1_i64])?;
     /// assert_eq!(TensorRef::Tensor(&tensor).dtype(), DType::I64);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn dtype(&self) -> DType {
         match self {
@@ -1291,7 +1368,7 @@ impl<'a> TensorRef<'a> {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![1], vec![1_i64])?;
     /// assert_eq!(TensorRef::Tensor(&tensor).shape(), &[1]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn shape(&self) -> &[usize] {
         match self {
@@ -1309,7 +1386,7 @@ impl<'a> TensorRef<'a> {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![1, 1], vec![1_i64])?;
     /// assert_eq!(TensorRef::Tensor(&tensor).rank(), 2);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn rank(&self) -> usize {
         self.shape().len()
@@ -1324,7 +1401,7 @@ impl<'a> TensorRef<'a> {
     ///
     /// let tensor = Tensor::from_vec_col_major(vec![0], Vec::<f64>::new())?;
     /// assert!(TensorRef::Tensor(&tensor).is_empty());
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     pub fn is_empty(&self) -> bool {
         match self {

--- a/crates/tenferro-tensor-core/src/rank.rs
+++ b/crates/tenferro-tensor-core/src/rank.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Result, ShapeVec, StrideVec};
+use crate::{Result, ShapeVec, StrideVec, ValidationError};
 use std::fmt::Debug;
 
 /// Rank contract for tensor metadata shapes and strides.
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 ///
 /// let shape = <Rank<2> as TensorRank>::shape_from_vec(vec![2, 3].into())?;
 /// assert_eq!(shape.as_ref(), &[2, 3]);
-/// # Ok::<(), tenferro_tensor_core::Error>(())
+/// # Ok::<(), tenferro_tensor_core::ValidationError>(())
 /// ```
 pub trait TensorRank: private::Sealed + Clone + Copy + Debug + Eq + Send + Sync + 'static {
     /// Static rank when known at compile time.
@@ -58,8 +58,13 @@ pub trait TensorRank: private::Sealed + Clone + Copy + Debug + Eq + Send + Sync 
     ///
     /// let shape = <Rank<1> as TensorRank>::shape_from_vec(vec![4].into())?;
     /// assert_eq!(shape.as_ref(), &[4]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::RankMismatch`] when the shape length does
+    /// not equal the compile-time rank.
     fn shape_from_vec(shape: ShapeVec) -> Result<Self::Shape>;
 
     /// Convert this rank's shape representation into a dynamic shape vector.
@@ -71,7 +76,7 @@ pub trait TensorRank: private::Sealed + Clone + Copy + Debug + Eq + Send + Sync 
     ///
     /// let shape = <Rank<2> as TensorRank>::shape_from_vec(vec![2, 3].into())?;
     /// assert_eq!(<Rank<2> as TensorRank>::shape_into_vec(shape).as_slice(), &[2, 3]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     fn shape_into_vec(shape: Self::Shape) -> ShapeVec;
 
@@ -84,8 +89,13 @@ pub trait TensorRank: private::Sealed + Clone + Copy + Debug + Eq + Send + Sync 
     ///
     /// let strides = <Rank<2> as TensorRank>::strides_from_vec(vec![1, 2].into())?;
     /// assert_eq!(strides.as_ref(), &[1, 2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationError::RankMismatch`] when the stride length does
+    /// not equal the compile-time rank.
     fn strides_from_vec(strides: StrideVec) -> Result<Self::Strides>;
 
     /// Convert this rank's stride representation into a dynamic stride vector.
@@ -97,7 +107,7 @@ pub trait TensorRank: private::Sealed + Clone + Copy + Debug + Eq + Send + Sync 
     ///
     /// let strides = <Rank<2> as TensorRank>::strides_from_vec(vec![1, 2].into())?;
     /// assert_eq!(<Rank<2> as TensorRank>::strides_into_vec(strides).as_slice(), &[1, 2]);
-    /// # Ok::<(), tenferro_tensor_core::Error>(())
+    /// # Ok::<(), tenferro_tensor_core::ValidationError>(())
     /// ```
     fn strides_into_vec(strides: Self::Strides) -> StrideVec;
 }
@@ -160,7 +170,7 @@ impl<const N: usize> TensorRank for Rank<N> {
         shape
             .into_vec()
             .try_into()
-            .map_err(|_| Error::RankMismatch {
+            .map_err(|_| ValidationError::RankMismatch {
                 expected: N,
                 actual,
             })
@@ -175,7 +185,7 @@ impl<const N: usize> TensorRank for Rank<N> {
         strides
             .into_vec()
             .try_into()
-            .map_err(|_| Error::RankMismatch {
+            .map_err(|_| ValidationError::RankMismatch {
                 expected: N,
                 actual,
             })

--- a/crates/tenferro-tensor-core/tests/core.rs
+++ b/crates/tenferro-tensor-core/tests/core.rs
@@ -1,8 +1,39 @@
 use num_complex::{Complex32, Complex64};
 use tenferro_tensor_core::{
-    col_major_strides, DType, DynRank, Error, HostTensor, HostTensorView, Rank, SliceSpec, Tensor,
-    TensorLayout, TensorRank, TensorRef, TensorScalar,
+    col_major_strides, DType, DynRank, ErrorKind, HostTensor, HostTensorView, Rank, ShapeMismatch,
+    SliceSpec, Tensor, TensorLayout, TensorRank, TensorRef, TensorScalar, ValidationError,
+    ValidationKind,
 };
+
+#[test]
+fn shape_mismatch_keeps_machine_readable_payload() {
+    let err: ValidationError = ShapeMismatch::IncompatibleShapes {
+        lhs: tenferro_tensor_core::ShapeVec::from_vec(vec![2, 3]),
+        rhs: tenferro_tensor_core::ShapeVec::from_vec(vec![2, 4]),
+    }
+    .into();
+
+    assert_eq!(err.kind(), ValidationKind::ShapeMismatch);
+    assert!(matches!(
+        err,
+        ValidationError::ShapeMismatch(ref mismatch)
+            if matches!(mismatch.as_ref(), ShapeMismatch::IncompatibleShapes {
+                ref lhs,
+                ref rhs,
+            } if lhs.as_slice() == [2, 3] && rhs.as_slice() == [2, 4])
+    ));
+
+    let source = std::error::Error::source(&err).expect("shape mismatch source");
+    assert!(source.downcast_ref::<Box<ShapeMismatch>>().is_some());
+}
+
+#[test]
+fn public_error_kind_can_classify_validation() {
+    assert_eq!(
+        ErrorKind::Validation(ValidationKind::RankMismatch),
+        ErrorKind::Validation(ValidationKind::RankMismatch)
+    );
+}
 
 #[test]
 fn host_tensor_uses_host_specific_public_name() {
@@ -64,7 +95,7 @@ fn static_rank_rejects_wrong_shape_length() {
     let err = <Rank<2> as TensorRank>::shape_from_vec(vec![2, 3, 4].into()).unwrap_err();
     assert!(matches!(
         err,
-        Error::RankMismatch {
+        ValidationError::RankMismatch {
             expected: 2,
             actual: 3
         }
@@ -76,7 +107,7 @@ fn static_rank_rejects_wrong_stride_length() {
     let err = <Rank<2> as TensorRank>::strides_from_vec(vec![1, 2, 3].into()).unwrap_err();
     assert!(matches!(
         err,
-        Error::RankMismatch {
+        ValidationError::RankMismatch {
             expected: 2,
             actual: 3
         }
@@ -147,7 +178,7 @@ fn reshape_view_as_requires_compact_layout() {
 
     let non_compact = TensorLayout::<Rank<2>>::from_parts([2, 3], [2, 1], 0, 6).unwrap();
     let err = non_compact.reshape_view_as::<Rank<1>>([6], 6).unwrap_err();
-    assert!(matches!(err, Error::NonContiguousViewAsSlice));
+    assert!(matches!(err, ValidationError::NonContiguousViewAsSlice));
 }
 
 #[test]
@@ -163,7 +194,7 @@ fn slice_view_rejects_zero_step_with_exact_error() {
             4,
         )
         .unwrap_err();
-    assert!(matches!(err, Error::InvalidSliceStep { step: 0 }));
+    assert!(matches!(err, ValidationError::InvalidSliceStep { step: 0 }));
 }
 
 #[test]
@@ -181,7 +212,7 @@ fn slice_view_rejects_invalid_normalized_bounds_with_exact_error() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::InvalidSliceBounds {
+        ValidationError::InvalidSliceBounds {
             start: 3,
             end: -6,
             axis_len: 4
@@ -205,7 +236,7 @@ fn dynamic_layout_rejects_shape_stride_rank_mismatch() {
         TensorLayout::<DynRank>::from_parts(vec![2, 3].into(), vec![1].into(), 0, 6).unwrap_err();
     assert!(matches!(
         err,
-        Error::RankMismatch {
+        ValidationError::RankMismatch {
             expected: 2,
             actual: 1
         }
@@ -232,7 +263,7 @@ fn non_compact_layout_reports_false() {
 #[test]
 fn compact_layout_reports_stride_overflow() {
     let err = TensorLayout::<Rank<2>>::compact([usize::MAX, 2]).unwrap_err();
-    assert!(matches!(err, Error::IntegerOverflow));
+    assert!(matches!(err, ValidationError::IntegerOverflow));
 }
 
 #[test]
@@ -245,7 +276,7 @@ fn layout_rejects_non_empty_broadcast_shape_product_overflow() {
         1,
     )
     .unwrap_err();
-    assert!(matches!(err, Error::IntegerOverflow));
+    assert!(matches!(err, ValidationError::IntegerOverflow));
 }
 
 #[test]
@@ -312,7 +343,7 @@ fn layout_reports_overflow_for_unreachable_offset_arithmetic() {
     assert!(matches!(
         TensorLayout::<DynRank>::from_parts(vec![3].into(), vec![isize::MAX].into(), 0, 3)
             .unwrap_err(),
-        Error::IntegerOverflow
+        ValidationError::IntegerOverflow
     ));
 }
 
@@ -321,7 +352,7 @@ fn mutable_layout_rejects_zero_stride_broadcast() {
     let layout = TensorLayout::<DynRank>::from_parts(vec![2].into(), vec![0].into(), 0, 1).unwrap();
     assert!(matches!(
         layout.validate_mutable_no_overlap(),
-        Err(Error::OverlappingMutableLayout)
+        Err(ValidationError::OverlappingMutableLayout)
     ));
 }
 
@@ -331,7 +362,7 @@ fn mutable_layout_rejects_overlapping_strides() {
         TensorLayout::<DynRank>::from_parts(vec![2, 2].into(), vec![1, 1].into(), 0, 4).unwrap();
     assert!(matches!(
         layout.validate_mutable_no_overlap(),
-        Err(Error::OverlappingMutableLayout)
+        Err(ValidationError::OverlappingMutableLayout)
     ));
 }
 
@@ -368,7 +399,7 @@ fn mutable_layout_rejects_large_ambiguous_layout_without_exact_fallback() {
             .unwrap();
     assert!(matches!(
         layout.validate_mutable_no_overlap(),
-        Err(Error::OverlappingMutableLayout)
+        Err(ValidationError::OverlappingMutableLayout)
     ));
 }
 
@@ -377,7 +408,7 @@ fn layout_rejects_huge_non_empty_zero_stride_before_product_overflow() {
     let huge_extent = isize::MAX as usize + 1;
     assert!(matches!(
         TensorLayout::<DynRank>::from_parts(vec![huge_extent, 3].into(), vec![0, 1].into(), 0, 3),
-        Err(Error::IntegerOverflow)
+        Err(ValidationError::IntegerOverflow)
     ));
 }
 
@@ -390,7 +421,7 @@ fn constructs_contiguous_col_major_and_validates_count() {
     let err = HostTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64]).unwrap_err();
     assert!(matches!(
         err,
-        Error::ShapeDataLengthMismatch {
+        ValidationError::ShapeDataLengthMismatch {
             expected: 4,
             actual: 1
         }
@@ -419,7 +450,7 @@ fn reshape_view_requires_compact_col_major_but_allows_nonzero_offset() {
 
     let non_contiguous = HostTensorView::from_slice(vec![2, 2], vec![1, 3], 0, &data).unwrap();
     let err = non_contiguous.reshape_view(vec![4]).unwrap_err();
-    assert!(matches!(err, Error::NonContiguousViewAsSlice));
+    assert!(matches!(err, ValidationError::NonContiguousViewAsSlice));
 }
 
 #[test]
@@ -431,7 +462,10 @@ fn transpose_view_only_reorders_metadata() {
     assert_eq!(view.offset(), 0);
     assert!(matches!(
         tensor.as_view().transpose_view(&[0, 0]).unwrap_err(),
-        Error::DuplicateAxis { axis: 0 }
+        ValidationError::DuplicateAxis {
+            axis: 0,
+            role: "permutation",
+        }
     ));
 }
 
@@ -474,7 +508,7 @@ fn invalid_slice_steps_and_negative_bounds_are_rejected() {
                 step: 0
             }])
             .unwrap_err(),
-        Error::InvalidSliceStep { step: 0 }
+        ValidationError::InvalidSliceStep { step: 0 }
     ));
     assert!(matches!(
         tensor
@@ -485,7 +519,7 @@ fn invalid_slice_steps_and_negative_bounds_are_rejected() {
                 step: 1
             }])
             .unwrap_err(),
-        Error::InvalidSliceBounds { .. }
+        ValidationError::InvalidSliceBounds { .. }
     ));
 }
 
@@ -494,11 +528,11 @@ fn view_bounds_are_validated_eagerly_with_checked_arithmetic() {
     let data = [1_i32, 2, 3];
     assert!(matches!(
         HostTensorView::from_slice(vec![4], vec![1], 0, &data).unwrap_err(),
-        Error::ViewOutOfBounds
+        ValidationError::ViewOutOfBounds
     ));
     assert!(matches!(
         HostTensorView::from_slice(vec![usize::MAX, 2], vec![1, 2], 0, &data).unwrap_err(),
-        Error::IntegerOverflow
+        ValidationError::IntegerOverflow
     ));
 
     let reversed = HostTensorView::from_slice(vec![3], vec![-1], 2, &data).unwrap();
@@ -507,7 +541,7 @@ fn view_bounds_are_validated_eagerly_with_checked_arithmetic() {
     assert_eq!(reversed.offset(), 2);
     assert!(matches!(
         HostTensorView::from_slice(vec![3], vec![-1], 1, &data).unwrap_err(),
-        Error::ViewOutOfBounds
+        ValidationError::ViewOutOfBounds
     ));
 }
 
@@ -520,7 +554,7 @@ fn empty_view_offsets_may_point_one_past_the_borrowed_slice() {
 
     assert!(matches!(
         HostTensorView::from_slice(vec![0], vec![1], 4, &data).unwrap_err(),
-        Error::ViewOutOfBounds
+        ValidationError::ViewOutOfBounds
     ));
 }
 
@@ -572,7 +606,7 @@ fn as_slice_accepts_nonzero_offset_and_rejects_non_contiguous_views() {
     let non_contiguous = HostTensorView::from_slice(vec![2], vec![2], 0, &data).unwrap();
     assert!(matches!(
         non_contiguous.as_slice().unwrap_err(),
-        Error::NonContiguousViewAsSlice
+        ValidationError::NonContiguousViewAsSlice
     ));
 }
 
@@ -583,7 +617,7 @@ fn dynamic_tensor_and_view_report_dtype_mismatch() {
     assert_eq!(tensor.as_slice::<f64>().unwrap(), &[1.0, 2.0]);
     assert!(matches!(
         tensor.as_slice::<f32>().unwrap_err(),
-        Error::DTypeMismatch {
+        ValidationError::DTypeMismatch {
             expected: DType::F32,
             actual: DType::F64
         }
@@ -600,7 +634,7 @@ fn tensor_scalar_into_tensor_rejects_shape_data_length_mismatch() {
 
     assert!(matches!(
         err,
-        Error::ShapeDataLengthMismatch {
+        ValidationError::ShapeDataLengthMismatch {
             expected: 6,
             actual: 2
         }
@@ -627,7 +661,8 @@ fn typed_owned_accessors_and_exports_cover_success_and_errors() {
     assert_eq!(reshaped.shape(), &[1, 2]);
     assert!(matches!(
         tensor.into_reshaped(vec![3]).unwrap_err(),
-        Error::ReshapeElementCountMismatch { from: 2, to: 3 }
+        ValidationError::ShapeMismatch(ref mismatch)
+            if matches!(mismatch.as_ref(), ShapeMismatch::ReshapeElementCount { from: 2, to: 3 })
     ));
 
     let (shape, data) = reshaped.into_vec_col_major();
@@ -695,7 +730,7 @@ fn dynamic_tensor_mutation_and_owned_exports_validate_dtype() {
     assert_eq!(tensor.as_slice::<f64>().unwrap(), &[5.0, 2.0]);
     assert!(matches!(
         tensor.as_mut_slice::<f32>().unwrap_err(),
-        Error::DTypeMismatch {
+        ValidationError::DTypeMismatch {
             expected: DType::F32,
             actual: DType::F64
         }
@@ -708,7 +743,7 @@ fn dynamic_tensor_mutation_and_owned_exports_validate_dtype() {
     let tensor = Tensor::from_vec_col_major(vec![1], vec![1_i32]).unwrap();
     assert!(matches!(
         tensor.into_vec_col_major::<i64>().unwrap_err(),
-        Error::DTypeMismatch {
+        ValidationError::DTypeMismatch {
             expected: DType::I64,
             actual: DType::I32
         }
@@ -747,7 +782,7 @@ fn view_validation_reports_rank_permutation_and_slice_errors() {
     let data = [1_i32, 2, 3, 4];
     assert!(matches!(
         HostTensorView::from_slice(vec![2], vec![1, 2], 0, &data).unwrap_err(),
-        Error::RankMismatch {
+        ValidationError::RankMismatch {
             expected: 1,
             actual: 2
         }
@@ -758,18 +793,19 @@ fn view_validation_reports_rank_permutation_and_slice_errors() {
     assert!(view.is_compact_col_major().unwrap());
     assert!(matches!(
         view.transpose_view(&[0]).unwrap_err(),
-        Error::InvalidPermutationLength {
+        ValidationError::InvalidPermutationLength {
             expected: 2,
             actual: 1
         }
     ));
     assert!(matches!(
         view.transpose_view(&[0, 2]).unwrap_err(),
-        Error::AxisOutOfBounds { axis: 2, rank: 2 }
+        ValidationError::AxisOutOfBounds { axis: 2, rank: 2 }
     ));
     assert!(matches!(
         view.reshape_view(vec![3]).unwrap_err(),
-        Error::ReshapeElementCountMismatch { from: 4, to: 3 }
+        ValidationError::ShapeMismatch(ref mismatch)
+            if matches!(mismatch.as_ref(), ShapeMismatch::ReshapeElementCount { from: 4, to: 3 })
     ));
     assert!(matches!(
         view.slice_view(&[SliceSpec {
@@ -778,7 +814,7 @@ fn view_validation_reports_rank_permutation_and_slice_errors() {
             step: 1
         }])
         .unwrap_err(),
-        Error::RankMismatch {
+        ValidationError::RankMismatch {
             expected: 2,
             actual: 1
         }
@@ -797,7 +833,7 @@ fn view_validation_reports_rank_permutation_and_slice_errors() {
             },
         ])
         .unwrap_err(),
-        Error::InvalidSliceBounds {
+        ValidationError::InvalidSliceBounds {
             start: 0,
             end: 3,
             axis_len: 2

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -13,7 +13,7 @@ use crate::{
 use num_complex::{Complex32, Complex64};
 
 fn read_boundary_error(op: &'static str) -> crate::Error {
-    crate::Error::backend_failure(
+    crate::Error::unsupported(
         op,
         "backend does not accept borrowed tensor views at this execution boundary",
     )
@@ -737,7 +737,7 @@ fn typed_read_storage<'a, T>(
 ) -> crate::Result<(&'a [T], isize)> {
     match tensor.buffer() {
         Buffer::Host(data) => Ok((data, 0)),
-        Buffer::Backend(_) => Err(crate::Error::backend_failure(
+        Buffer::Backend(_) => Err(crate::Error::runtime_state(
             op,
             "grouped GEMM default path requires host-backed tensor storage",
         )),
@@ -1769,7 +1769,7 @@ pub trait TensorElementwise: TensorStructural {
     /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
     /// backend execution or storage access cannot provide the requested result.
     fn rem(&mut self, lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
-        Err(crate::Error::backend_failure(
+        Err(crate::Error::unsupported(
             "rem",
             format!("backend does not implement rem for dtype {:?}", lhs.dtype()),
         ))
@@ -2195,7 +2195,7 @@ pub trait TensorStructural {
                 crate::MemoryKind::PinnedHost | crate::MemoryKind::UnpinnedHost
             )
         {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 "to_contiguous_read",
                 "default materialization accepts only host-owned tensors; use the storage's owning backend",
             ));
@@ -2254,7 +2254,7 @@ pub trait TensorStructural {
     /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
     /// backend execution or storage access cannot provide the requested result.
     fn copy_read_into(&mut self, _src: TensorRead<'_>, _dst: TensorWrite<'_>) -> crate::Result<()> {
-        Err(crate::Error::backend_failure(
+        Err(crate::Error::unsupported(
             "copy_read_into",
             "backend-owned runtime copy is unsupported by this backend",
         ))
@@ -2459,7 +2459,7 @@ pub trait TensorReduction {
     fn reduce_sum_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
         match input.as_tensor() {
             Some(input) => self.reduce_sum(input, axes),
-            None => Err(crate::Error::backend_failure(
+            None => Err(crate::Error::unsupported(
                 "reduce_sum",
                 "backend does not accept borrowed tensor views at this execution boundary",
             )),
@@ -2497,7 +2497,7 @@ pub trait TensorReduction {
     fn reduce_prod_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
         match input.as_tensor() {
             Some(input) => self.reduce_prod(input, axes),
-            None => Err(crate::Error::backend_failure(
+            None => Err(crate::Error::unsupported(
                 "reduce_prod",
                 "backend does not accept borrowed tensor views at this execution boundary",
             )),
@@ -2535,7 +2535,7 @@ pub trait TensorReduction {
     fn reduce_max_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
         match input.as_tensor() {
             Some(input) => self.reduce_max(input, axes),
-            None => Err(crate::Error::backend_failure(
+            None => Err(crate::Error::unsupported(
                 "reduce_max",
                 "backend does not accept borrowed tensor views at this execution boundary",
             )),
@@ -2573,7 +2573,7 @@ pub trait TensorReduction {
     fn reduce_min_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
         match input.as_tensor() {
             Some(input) => self.reduce_min(input, axes),
-            None => Err(crate::Error::backend_failure(
+            None => Err(crate::Error::unsupported(
                 "reduce_min",
                 "backend does not accept borrowed tensor views at this execution boundary",
             )),

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -6,7 +6,10 @@ use crate::types::{
     TypedTensorViewMut,
 };
 use crate::validate::validate_convert_dtype;
-use crate::{DType, RuntimeCacheControl, Tensor, TensorRead, TensorValue, TensorWrite};
+use crate::{
+    DType, Error, RuntimeCacheControl, ShapeMismatch, Tensor, TensorRead, TensorValue, TensorWrite,
+    ValidationError,
+};
 use num_complex::{Complex32, Complex64};
 
 fn read_boundary_error(op: &'static str) -> crate::Error {
@@ -14,6 +17,14 @@ fn read_boundary_error(op: &'static str) -> crate::Error {
         op,
         "backend does not accept borrowed tensor views at this execution boundary",
     )
+}
+
+fn validation(op: &'static str, source: ValidationError) -> crate::Error {
+    Error::validation(op, source)
+}
+
+fn invalid_argument(op: &'static str, argument: &'static str, message: impl Into<String>) -> Error {
+    Error::invalid_argument(op, argument, message)
 }
 
 fn read_tensor<'a>(op: &'static str, input: TensorRead<'a>) -> crate::Result<&'a Tensor> {
@@ -29,10 +40,16 @@ fn validate_axis_list(
     let mut seen = vec![false; rank];
     for &axis in axes {
         if axis >= rank {
-            return Err(crate::Error::AxisOutOfBounds { op, axis, rank });
+            return Err(validation(
+                op,
+                ValidationError::AxisOutOfBounds { axis, rank },
+            ));
         }
         if seen[axis] {
-            return Err(crate::Error::DuplicateAxis { op, axis, role });
+            return Err(validation(
+                op,
+                ValidationError::DuplicateAxis { axis, role },
+            ));
         }
         seen[axis] = true;
     }
@@ -48,12 +65,14 @@ fn validate_role_disjoint(
 ) -> crate::Result<()> {
     for &axis in first_axes {
         if second_axes.contains(&axis) {
-            return Err(crate::Error::AxisRoleConflict {
+            return Err(validation(
                 op,
-                axis,
-                first_role,
-                second_role,
-            });
+                ValidationError::AxisRoleConflict {
+                    axis,
+                    first_role,
+                    second_role,
+                },
+            ));
         }
     }
     Ok(())
@@ -68,16 +87,18 @@ pub fn dot_general_output_shape(
     op: &'static str,
 ) -> crate::Result<Vec<usize>> {
     if config.lhs_contracting_dims.len() != config.rhs_contracting_dims.len() {
-        return Err(crate::Error::InvalidConfig {
+        return Err(invalid_argument(
             op,
-            message: "lhs/rhs contracting dim counts differ".into(),
-        });
+            "contracting_dims",
+            "lhs/rhs contracting dim counts differ",
+        ));
     }
     if config.lhs_batch_dims.len() != config.rhs_batch_dims.len() {
-        return Err(crate::Error::InvalidConfig {
+        return Err(invalid_argument(
             op,
-            message: "lhs/rhs batch dim counts differ".into(),
-        });
+            "batch_dims",
+            "lhs/rhs batch dim counts differ",
+        ));
     }
 
     let lhs_rank = lhs_shape.len();
@@ -117,20 +138,30 @@ pub fn dot_general_output_shape(
         .zip(&config.rhs_contracting_dims)
     {
         if lhs_shape[lhs_axis] != rhs_shape[rhs_axis] {
-            return Err(crate::Error::ShapeMismatch {
+            return Err(validation(
                 op,
-                lhs: lhs_shape.to_vec(),
-                rhs: rhs_shape.to_vec(),
-            });
+                ShapeMismatch::ContractedDimensions {
+                    lhs_axis,
+                    lhs_size: lhs_shape[lhs_axis],
+                    rhs_axis,
+                    rhs_size: rhs_shape[rhs_axis],
+                }
+                .into(),
+            ));
         }
     }
     for (&lhs_axis, &rhs_axis) in config.lhs_batch_dims.iter().zip(&config.rhs_batch_dims) {
         if lhs_shape[lhs_axis] != rhs_shape[rhs_axis] {
-            return Err(crate::Error::ShapeMismatch {
+            return Err(validation(
                 op,
-                lhs: lhs_shape.to_vec(),
-                rhs: rhs_shape.to_vec(),
-            });
+                ShapeMismatch::ContractedDimensions {
+                    lhs_axis,
+                    lhs_size: lhs_shape[lhs_axis],
+                    rhs_axis,
+                    rhs_size: rhs_shape[rhs_axis],
+                }
+                .into(),
+            ));
         }
     }
 
@@ -159,26 +190,33 @@ pub fn validate_dot_general_read_into(
     op: &'static str,
 ) -> crate::Result<Vec<usize>> {
     if lhs.dtype() != rhs.dtype() {
-        return Err(crate::Error::DTypeMismatch {
+        return Err(validation(
             op,
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        });
+            ValidationError::DTypeMismatch {
+                expected: crate::core_dtype(lhs.dtype()),
+                actual: crate::core_dtype(rhs.dtype()),
+            },
+        ));
     }
     if out.dtype() != lhs.dtype() {
-        return Err(crate::Error::DTypeMismatch {
+        return Err(validation(
             op,
-            lhs: out.dtype(),
-            rhs: lhs.dtype(),
-        });
+            ValidationError::DTypeMismatch {
+                expected: crate::core_dtype(out.dtype()),
+                actual: crate::core_dtype(lhs.dtype()),
+            },
+        ));
     }
     let expected = dot_general_output_shape(lhs.shape(), rhs.shape(), config, op)?;
     if out.shape() != expected.as_slice() {
-        return Err(crate::Error::ShapeMismatch {
+        return Err(validation(
             op,
-            lhs: out.shape().to_vec(),
-            rhs: expected.clone(),
-        });
+            ShapeMismatch::ExpectedActual {
+                expected: expected.clone().into(),
+                actual: out.shape().to_vec().into(),
+            }
+            .into(),
+        ));
     }
     Ok(expected)
 }
@@ -234,17 +272,25 @@ impl ContractionScalar {
     /// assert_eq!(ContractionScalar::one(DType::F64).unwrap(), ContractionScalar::F64(1.0));
     /// assert!(ContractionScalar::one(DType::I32).is_err());
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     pub fn one(dtype: DType) -> crate::Result<Self> {
         match dtype {
             DType::F32 => Ok(Self::F32(1.0)),
             DType::F64 => Ok(Self::F64(1.0)),
             DType::C32 => Ok(Self::C32(Complex32::new(1.0, 0.0))),
             DType::C64 => Ok(Self::C64(Complex64::new(1.0, 0.0))),
-            DType::I32 | DType::I64 | DType::Bool => Err(crate::Error::DTypeMismatch {
-                op: "dot_general",
-                lhs: dtype,
-                rhs: DType::F32,
-            }),
+            DType::I32 | DType::I64 | DType::Bool => Err(validation(
+                "dot_general",
+                ValidationError::DTypeMismatch {
+                    expected: crate::core_dtype(dtype),
+                    actual: crate::core_dtype(DType::F32),
+                },
+            )),
         }
     }
 
@@ -257,17 +303,25 @@ impl ContractionScalar {
     ///
     /// assert_eq!(ContractionScalar::zero(DType::F64).unwrap(), ContractionScalar::F64(0.0));
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     pub fn zero(dtype: DType) -> crate::Result<Self> {
         match dtype {
             DType::F32 => Ok(Self::F32(0.0)),
             DType::F64 => Ok(Self::F64(0.0)),
             DType::C32 => Ok(Self::C32(Complex32::new(0.0, 0.0))),
             DType::C64 => Ok(Self::C64(Complex64::new(0.0, 0.0))),
-            DType::I32 | DType::I64 | DType::Bool => Err(crate::Error::DTypeMismatch {
-                op: "dot_general",
-                lhs: dtype,
-                rhs: DType::F32,
-            }),
+            DType::I32 | DType::I64 | DType::Bool => Err(validation(
+                "dot_general",
+                ValidationError::DTypeMismatch {
+                    expected: crate::core_dtype(dtype),
+                    actual: crate::core_dtype(DType::F32),
+                },
+            )),
         }
     }
 }
@@ -381,6 +435,12 @@ impl<'a> GroupedGemmConfig<'a> {
 
 impl DotGeneralAccumulation {
     /// Return overwrite semantics, `out = lhs dot rhs`, for `dtype`.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     pub fn overwrite(dtype: DType) -> crate::Result<Self> {
         Ok(Self {
             lhs_conj: false,
@@ -402,6 +462,12 @@ impl DotGeneralAccumulation {
     /// assert_eq!(accum.beta, ContractionScalar::F64(1.0));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     pub fn add_to(dtype: DType) -> crate::Result<Self> {
         Ok(Self {
             lhs_conj: false,
@@ -425,13 +491,21 @@ impl DotGeneralAccumulation {
     /// assert_eq!(accum.alpha, ContractionScalar::F32(0.5));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     pub fn scaled(alpha: ContractionScalar, beta: ContractionScalar) -> crate::Result<Self> {
         if alpha.dtype() != beta.dtype() {
-            return Err(crate::Error::DTypeMismatch {
-                op: "dot_general",
-                lhs: alpha.dtype(),
-                rhs: beta.dtype(),
-            });
+            return Err(validation(
+                "dot_general",
+                ValidationError::DTypeMismatch {
+                    expected: crate::core_dtype(alpha.dtype()),
+                    actual: crate::core_dtype(beta.dtype()),
+                },
+            ));
         }
         Ok(Self {
             lhs_conj: false,
@@ -444,11 +518,13 @@ impl DotGeneralAccumulation {
     fn validate_for_dtype(self, dtype: DType) -> crate::Result<()> {
         for scalar in [self.alpha, self.beta] {
             if scalar.dtype() != dtype {
-                return Err(crate::Error::DTypeMismatch {
-                    op: "dot_general",
-                    lhs: scalar.dtype(),
-                    rhs: dtype,
-                });
+                return Err(validation(
+                    "dot_general",
+                    ValidationError::DTypeMismatch {
+                        expected: crate::core_dtype(scalar.dtype()),
+                        actual: crate::core_dtype(dtype),
+                    },
+                ));
             }
         }
         Ok(())
@@ -495,11 +571,13 @@ fn grouped_checked_product(
     dims: &[usize],
 ) -> crate::Result<usize> {
     dims.iter().try_fold(1usize, |acc, &dim| {
-        acc.checked_mul(dim)
-            .ok_or_else(|| crate::Error::InvalidConfig {
+        acc.checked_mul(dim).ok_or_else(|| {
+            invalid_argument(
                 op,
-                message: format!("{role} logical element count overflows usize for shape {dims:?}"),
-            })
+                role,
+                format!("logical element count overflows usize for shape {dims:?}"),
+            )
+        })
     })
 }
 
@@ -510,23 +588,23 @@ fn checked_gemm_span(
     rows: usize,
     cols: usize,
 ) -> crate::Result<Option<std::ops::Range<usize>>> {
-    let len = rows
-        .checked_mul(cols)
-        .ok_or_else(|| crate::Error::InvalidConfig {
+    let len = rows.checked_mul(cols).ok_or_else(|| {
+        invalid_argument(
             op,
-            message: format!(
-                "{role} matrix element count overflows usize: rows={rows} cols={cols}"
-            ),
-        })?;
+            role,
+            format!("matrix element count overflows usize: rows={rows} cols={cols}"),
+        )
+    })?;
     if len == 0 {
         return Ok(None);
     }
-    let end = offset
-        .checked_add(len)
-        .ok_or_else(|| crate::Error::InvalidConfig {
+    let end = offset.checked_add(len).ok_or_else(|| {
+        invalid_argument(
             op,
-            message: format!("{role} matrix range overflows usize: offset={offset} len={len}"),
-        })?;
+            role,
+            format!("matrix range overflows usize: offset={offset} len={len}"),
+        )
+    })?;
     Ok(Some(offset..end))
 }
 
@@ -540,13 +618,14 @@ fn validate_grouped_gemm_range(
         return Ok(());
     };
     if range.end > len {
-        return Err(crate::Error::InvalidConfig {
+        return Err(invalid_argument(
             op,
-            message: format!(
-                "{role} matrix range {}..{} exceeds shared buffer logical length {len}",
+            role,
+            format!(
+                "matrix range {}..{} exceeds shared buffer logical length {len}",
                 range.start, range.end
             ),
-        });
+        ));
     }
     Ok(())
 }
@@ -560,18 +639,22 @@ pub fn validate_grouped_gemm(
     op: &'static str,
 ) -> crate::Result<()> {
     if lhs.dtype() != rhs.dtype() {
-        return Err(crate::Error::DTypeMismatch {
+        return Err(validation(
             op,
-            lhs: lhs.dtype(),
-            rhs: rhs.dtype(),
-        });
+            ValidationError::DTypeMismatch {
+                expected: crate::core_dtype(lhs.dtype()),
+                actual: crate::core_dtype(rhs.dtype()),
+            },
+        ));
     }
     if lhs.dtype() != out.dtype() {
-        return Err(crate::Error::DTypeMismatch {
+        return Err(validation(
             op,
-            lhs: lhs.dtype(),
-            rhs: out.dtype(),
-        });
+            ValidationError::DTypeMismatch {
+                expected: crate::core_dtype(lhs.dtype()),
+                actual: crate::core_dtype(out.dtype()),
+            },
+        ));
     }
     config.accumulation.validate_for_dtype(lhs.dtype())?;
 
@@ -607,13 +690,14 @@ pub fn validate_grouped_gemm(
         let (prev_idx, previous) = &pair[0];
         let (idx, current) = &pair[1];
         if previous.end > current.start {
-            return Err(crate::Error::InvalidConfig {
+            return Err(invalid_argument(
                 op,
-                message: format!(
+                "jobs",
+                format!(
                     "grouped GEMM output range for job {idx} overlaps job {prev_idx} range {}..{}",
                     previous.start, previous.end
                 ),
-            });
+            ));
         }
     }
     Ok(())
@@ -625,21 +709,25 @@ fn add_element_offsets(
     offset: usize,
     role: &'static str,
 ) -> crate::Result<isize> {
-    let offset = isize::try_from(offset).map_err(|_| crate::Error::InvalidConfig {
-        op,
-        message: format!("{role} offset {offset} does not fit in isize"),
+    let offset = isize::try_from(offset).map_err(|_| {
+        invalid_argument(op, role, format!("offset {offset} does not fit in isize"))
     })?;
-    base.checked_add(offset)
-        .ok_or_else(|| crate::Error::InvalidConfig {
+    base.checked_add(offset).ok_or_else(|| {
+        invalid_argument(
             op,
-            message: format!("{role} offset overflows isize: base={base} offset={offset}"),
-        })
+            role,
+            format!("offset overflows isize: base={base} offset={offset}"),
+        )
+    })
 }
 
 fn dim_stride(op: &'static str, dim: usize, role: &'static str) -> crate::Result<isize> {
-    isize::try_from(dim).map_err(|_| crate::Error::InvalidConfig {
-        op,
-        message: format!("{role} leading dimension {dim} does not fit in isize"),
+    isize::try_from(dim).map_err(|_| {
+        invalid_argument(
+            op,
+            role,
+            format!("leading dimension {dim} does not fit in isize"),
+        )
     })
 }
 
@@ -924,11 +1012,13 @@ where
     dispatch!(F64, GroupedF64);
     dispatch!(C32, GroupedC32);
     dispatch!(C64, GroupedC64);
-    Err(crate::Error::DTypeMismatch {
-        op: "grouped_gemm",
-        lhs: lhs.dtype(),
-        rhs: out.dtype(),
-    })
+    Err(validation(
+        "grouped_gemm",
+        ValidationError::DTypeMismatch {
+            expected: crate::core_dtype(lhs.dtype()),
+            actual: crate::core_dtype(out.dtype()),
+        },
+    ))
 }
 
 fn grouped_gemm_default<B>(
@@ -979,11 +1069,13 @@ pub fn accumulate_dot_result_into(
     dispatch!(C32, Complex32);
     dispatch!(C64, Complex64);
 
-    Err(crate::Error::DTypeMismatch {
-        op: "dot_general",
-        lhs: accumulation.alpha.dtype(),
-        rhs: dot.dtype(),
-    })
+    Err(validation(
+        "dot_general",
+        ValidationError::DTypeMismatch {
+            expected: crate::core_dtype(accumulation.alpha.dtype()),
+            actual: crate::core_dtype(dot.dtype()),
+        },
+    ))
 }
 
 fn accumulate_typed<T>(
@@ -1003,12 +1095,13 @@ where
     let beta_is_zero = beta == T::zero();
     for (linear, dot_value) in dot.iter().copied().enumerate() {
         let indices = flat_to_multi_for_shape(out.shape(), linear);
-        let output = out
-            .get_mut(&indices)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "dot_general",
-                message: format!("output index {indices:?} is outside accumulation target"),
-            })?;
+        let output = out.get_mut(&indices).ok_or_else(|| {
+            invalid_argument(
+                "dot_general",
+                "output",
+                format!("index {indices:?} is outside accumulation target"),
+            )
+        })?;
         // INVARIANT: beta == 0 follows BLAS GEMM semantics and does not read
         // the existing output element; beta != 0 requires an initialized
         // TensorWrite target and performs a read-modify-write update.
@@ -1306,6 +1399,12 @@ impl ElementwiseFusionInst {
 /// fn accepts_elementwise<B: TensorElementwise>(_backend: &mut B) {}
 /// ```
 pub trait TensorElementwise: TensorStructural {
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
 
     /// Elementwise addition accepting either owned tensors or borrowed views.
@@ -1327,6 +1426,12 @@ pub trait TensorElementwise: TensorStructural {
     ///     backend.add_read(TensorRead::from_tensor(lhs), TensorRead::from_tensor(rhs))
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn add_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
         self.add(read_tensor("add", lhs)?, read_tensor("add", rhs)?)
     }
@@ -1350,6 +1455,12 @@ pub trait TensorElementwise: TensorStructural {
     ///     Ok(out)
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn add_into(&mut self, lhs: &Tensor, rhs: &Tensor, out: TensorWrite<'_>) -> crate::Result<()> {
         self.add_read_into(
             TensorRead::from_tensor(lhs),
@@ -1374,6 +1485,12 @@ pub trait TensorElementwise: TensorStructural {
     ///     backend.add_read_into(lhs, rhs, out)
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn add_read_into(
         &mut self,
         lhs: TensorRead<'_>,
@@ -1384,6 +1501,12 @@ pub trait TensorElementwise: TensorStructural {
         self.copy_read_into(TensorRead::from_tensor(&result), out)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn sub(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
 
     /// Elementwise subtraction accepting either owned tensors or borrowed views.
@@ -1401,11 +1524,23 @@ pub trait TensorElementwise: TensorStructural {
     ///     backend.sub_read(TensorRead::from_tensor(lhs), TensorRead::from_tensor(rhs))
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn sub_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
         self.sub(read_tensor("sub", lhs)?, read_tensor("sub", rhs)?)
     }
 
     /// Overwrite caller-provided output with elementwise subtraction.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn sub_into(&mut self, lhs: &Tensor, rhs: &Tensor, out: TensorWrite<'_>) -> crate::Result<()> {
         self.sub_read_into(
             TensorRead::from_tensor(lhs),
@@ -1415,6 +1550,12 @@ pub trait TensorElementwise: TensorStructural {
     }
 
     /// Overwrite caller-provided output with elementwise subtraction from reads.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn sub_read_into(
         &mut self,
         lhs: TensorRead<'_>,
@@ -1425,12 +1566,30 @@ pub trait TensorElementwise: TensorStructural {
         self.copy_read_into(TensorRead::from_tensor(&result), out)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn mul(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn mul_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
         self.mul(read_tensor("mul", lhs)?, read_tensor("mul", rhs)?)
     }
 
     /// Overwrite caller-provided output with elementwise multiplication.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn mul_into(&mut self, lhs: &Tensor, rhs: &Tensor, out: TensorWrite<'_>) -> crate::Result<()> {
         self.mul_read_into(
             TensorRead::from_tensor(lhs),
@@ -1440,6 +1599,12 @@ pub trait TensorElementwise: TensorStructural {
     }
 
     /// Overwrite caller-provided output with elementwise multiplication from reads.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn mul_read_into(
         &mut self,
         lhs: TensorRead<'_>,
@@ -1450,44 +1615,110 @@ pub trait TensorElementwise: TensorStructural {
         self.copy_read_into(TensorRead::from_tensor(&result), out)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn neg(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn neg_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.neg(read_tensor("neg", input)?)
     }
 
     /// Overwrite caller-provided output with elementwise negation.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn neg_into(&mut self, input: &Tensor, out: TensorWrite<'_>) -> crate::Result<()> {
         self.neg_read_into(TensorRead::from_tensor(input), out)
     }
 
     /// Overwrite caller-provided output with elementwise negation from a read.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn neg_read_into(&mut self, input: TensorRead<'_>, out: TensorWrite<'_>) -> crate::Result<()> {
         let result = self.neg_read(input)?;
         self.copy_read_into(TensorRead::from_tensor(&result), out)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn conj(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn conj_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.conj(read_tensor("conj", input)?)
     }
 
     /// Overwrite caller-provided output with elementwise conjugation.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn conj_into(&mut self, input: &Tensor, out: TensorWrite<'_>) -> crate::Result<()> {
         self.conj_read_into(TensorRead::from_tensor(input), out)
     }
 
     /// Overwrite caller-provided output with elementwise conjugation from a read.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn conj_read_into(&mut self, input: TensorRead<'_>, out: TensorWrite<'_>) -> crate::Result<()> {
         let result = self.conj_read(input)?;
         self.copy_read_into(TensorRead::from_tensor(&result), out)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn div(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn div_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
         self.div(read_tensor("div", lhs)?, read_tensor("div", rhs)?)
     }
 
     /// Overwrite caller-provided output with elementwise division.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn div_into(&mut self, lhs: &Tensor, rhs: &Tensor, out: TensorWrite<'_>) -> crate::Result<()> {
         self.div_read_into(
             TensorRead::from_tensor(lhs),
@@ -1497,6 +1728,12 @@ pub trait TensorElementwise: TensorStructural {
     }
 
     /// Overwrite caller-provided output with elementwise division from reads.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn div_read_into(
         &mut self,
         lhs: TensorRead<'_>,
@@ -1525,6 +1762,12 @@ pub trait TensorElementwise: TensorStructural {
     ///     backend.rem(lhs, rhs)
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn rem(&mut self, lhs: &Tensor, _rhs: &Tensor) -> crate::Result<Tensor> {
         Err(crate::Error::backend_failure(
             "rem",
@@ -1547,31 +1790,97 @@ pub trait TensorElementwise: TensorStructural {
     ///     backend.rem_read(TensorRead::from_tensor(lhs), TensorRead::from_tensor(rhs))
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn rem_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
         self.rem(read_tensor("rem", lhs)?, read_tensor("rem", rhs)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn abs(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn abs_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.abs(read_tensor("abs", input)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn sign(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn sign_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.sign(read_tensor("sign", input)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn maximum(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn maximum_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
         self.maximum(read_tensor("maximum", lhs)?, read_tensor("maximum", rhs)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn minimum(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn minimum_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
         self.minimum(read_tensor("minimum", lhs)?, read_tensor("minimum", rhs)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn compare(&mut self, lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn compare_read(
         &mut self,
         lhs: TensorRead<'_>,
@@ -1585,12 +1894,24 @@ pub trait TensorElementwise: TensorStructural {
         )
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn select(
         &mut self,
         pred: &Tensor,
         on_true: &Tensor,
         on_false: &Tensor,
     ) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn select_read(
         &mut self,
         pred: TensorRead<'_>,
@@ -1604,7 +1925,19 @@ pub trait TensorElementwise: TensorStructural {
         )
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn clamp(&mut self, input: &Tensor, lower: &Tensor, upper: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn clamp_read(
         &mut self,
         input: TensorRead<'_>,
@@ -1629,52 +1962,172 @@ pub trait TensorElementwise: TensorStructural {
 /// fn accepts_analytic<B: TensorAnalytic>(_backend: &mut B) {}
 /// ```
 pub trait TensorAnalytic {
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn exp(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn exp_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.exp(read_tensor("exp", input)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn log(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn log_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.log(read_tensor("log", input)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn sin(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn sin_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.sin(read_tensor("sin", input)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn cos(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn cos_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.cos(read_tensor("cos", input)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn tanh(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn tanh_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.tanh(read_tensor("tanh", input)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn sqrt(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn sqrt_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.sqrt(read_tensor("sqrt", input)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn rsqrt(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn rsqrt_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.rsqrt(read_tensor("rsqrt", input)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn pow(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn pow_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {
         self.pow(read_tensor("pow", lhs)?, read_tensor("pow", rhs)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn expm1(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn expm1_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.expm1(read_tensor("expm1", input)?)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn log1p(&mut self, input: &Tensor) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn log1p_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         self.log1p(read_tensor("log1p", input)?)
     }
@@ -1728,6 +2181,12 @@ pub trait TensorStructural {
     /// assert_eq!(output.as_slice::<i32>()?, &[1, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         let input = read_tensor("to_contiguous_read", input)?;
         if input.is_backend_buffer()
@@ -1788,6 +2247,12 @@ pub trait TensorStructural {
     /// assert_eq!(dst.as_slice::<i32>()?, &[0, 0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn copy_read_into(&mut self, _src: TensorRead<'_>, _dst: TensorWrite<'_>) -> crate::Result<()> {
         Err(crate::Error::backend_failure(
             "copy_read_into",
@@ -1795,22 +2260,58 @@ pub trait TensorStructural {
         ))
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn transpose_read(&mut self, input: TensorRead<'_>, perm: &[usize]) -> crate::Result<Tensor> {
         self.transpose(read_tensor("transpose", input)?, perm)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn reshape(&mut self, input: &Tensor, shape: &[usize]) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn reshape_read(&mut self, input: TensorRead<'_>, shape: &[usize]) -> crate::Result<Tensor> {
         self.reshape(read_tensor("reshape", input)?, shape)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn broadcast_in_dim(
         &mut self,
         input: &Tensor,
         shape: &[usize],
         dims: &[usize],
     ) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn broadcast_in_dim_read(
         &mut self,
         input: TensorRead<'_>,
@@ -1837,6 +2338,12 @@ pub trait TensorStructural {
     ///     backend.cast(input, DType::I32)
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn cast(&mut self, input: &Tensor, to: crate::DType) -> crate::Result<Tensor>;
 
     /// Convert a tensor to another dtype using checked dtype conversion.
@@ -1856,24 +2363,54 @@ pub trait TensorStructural {
     ///     backend.convert(input, DType::F64)
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn convert(&mut self, input: &Tensor, to: crate::DType) -> crate::Result<Tensor> {
         validate_convert_dtype("convert", input.dtype(), to)?;
         self.cast(input, to)
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn extract_diagonal(
         &mut self,
         input: &Tensor,
         axis_a: usize,
         axis_b: usize,
     ) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn embed_diagonal(
         &mut self,
         input: &Tensor,
         axis_a: usize,
         axis_b: usize,
     ) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn tril(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn triu(&mut self, input: &Tensor, k: i64) -> crate::Result<Tensor>;
 }
 
@@ -1891,6 +2428,12 @@ pub trait TensorStructural {
 /// fn accepts_reduction<B: TensorReduction>(_backend: &mut B) {}
 /// ```
 pub trait TensorReduction {
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
 
     /// Sum elements across axes from an owned tensor or borrowed view.
@@ -1907,6 +2450,12 @@ pub trait TensorReduction {
     ///     backend.reduce_sum_read(TensorRead::from_tensor(input), &[0])
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn reduce_sum_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
         match input.as_tensor() {
             Some(input) => self.reduce_sum(input, axes),
@@ -1917,6 +2466,12 @@ pub trait TensorReduction {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
 
     /// Multiply elements across axes from an owned tensor or borrowed view.
@@ -1933,6 +2488,12 @@ pub trait TensorReduction {
     ///     backend.reduce_prod_read(TensorRead::from_tensor(input), &[0])
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn reduce_prod_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
         match input.as_tensor() {
             Some(input) => self.reduce_prod(input, axes),
@@ -1943,6 +2504,12 @@ pub trait TensorReduction {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn reduce_max(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
 
     /// Take maximum values across axes from an owned tensor or borrowed view.
@@ -1959,6 +2526,12 @@ pub trait TensorReduction {
     ///     backend.reduce_max_read(TensorRead::from_tensor(input), &[0])
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn reduce_max_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
         match input.as_tensor() {
             Some(input) => self.reduce_max(input, axes),
@@ -1969,6 +2542,12 @@ pub trait TensorReduction {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn reduce_min(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
 
     /// Take minimum values across axes from an owned tensor or borrowed view.
@@ -1985,6 +2564,12 @@ pub trait TensorReduction {
     ///     backend.reduce_min_read(TensorRead::from_tensor(input), &[0])
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn reduce_min_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
         match input.as_tensor() {
             Some(input) => self.reduce_min(input, axes),
@@ -2006,6 +2591,12 @@ pub trait TensorReduction {
 /// fn accepts_dot<B: TensorDot>(_backend: &mut B) {}
 /// ```
 pub trait TensorDot: TensorElementwise {
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn dot_general(
         &mut self,
         lhs: &Tensor,
@@ -2051,6 +2642,12 @@ pub trait TensorDot: TensorElementwise {
     ///     backend.dot_general_read_into(lhs, rhs, config, out)
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn dot_general_read_into(
         &mut self,
         lhs: TensorRead<'_>,
@@ -2146,6 +2743,12 @@ pub trait TensorDot: TensorElementwise {
     ///     backend.dot_general_read_into_accum(lhs, rhs, config, accumulation, out)
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn dot_general_read_into_accum(
         &mut self,
         lhs: TensorRead<'_>,
@@ -2275,6 +2878,12 @@ pub trait SessionCachedDot: TensorDot {
     ///     )
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn dot_general_read_into_accum_cached(
         &mut self,
         _cache_slot: Option<usize>,
@@ -2310,12 +2919,24 @@ pub trait SessionCachedDot: TensorDot {
 /// fn accepts_indexing<B: TensorIndexing>(_backend: &mut B) {}
 /// ```
 pub trait TensorIndexing {
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn gather(
         &mut self,
         operand: &Tensor,
         start_indices: &Tensor,
         config: &GatherConfig,
     ) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn scatter(
         &mut self,
         operand: &Tensor,
@@ -2323,21 +2944,57 @@ pub trait TensorIndexing {
         updates: &Tensor,
         config: &ScatterConfig,
     ) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn slice(&mut self, input: &Tensor, config: &SliceConfig) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn dynamic_slice(
         &mut self,
         input: &Tensor,
         starts: &Tensor,
         slice_sizes: &[usize],
     ) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn dynamic_update_slice(
         &mut self,
         operand: &Tensor,
         update: &Tensor,
         starts: &Tensor,
     ) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn pad(&mut self, input: &Tensor, config: &PadConfig) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor>;
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn reverse(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor>;
 }
 
@@ -2386,11 +3043,23 @@ pub trait TensorIndexing {
 /// }
 /// ```
 pub trait TensorViewCanonicalization<T: TensorScalar, R: TensorRank> {
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn to_contiguous(
         &mut self,
         view: &TypedTensorView<'_, T, R>,
     ) -> crate::Result<TypedTensor<T, R>>;
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn copy_into(
         &mut self,
         src: &TypedTensorView<'_, T, R>,
@@ -2470,10 +3139,22 @@ pub trait TensorBuffer {
 /// fn accepts_transfer<B: TensorDeviceTransfer>(_backend: &mut B) {}
 /// ```
 pub trait TensorDeviceTransfer {
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn download_to_host(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
         Ok(tensor.clone())
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn upload_host_tensor(&mut self, tensor: &Tensor) -> crate::Result<Tensor> {
         Ok(tensor.clone())
     }
@@ -2623,6 +3304,12 @@ pub trait BackendCachedDot: BackendRuntimeCache + TensorDot {
     /// }
     /// ```
     #[allow(clippy::too_many_arguments)]
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
+    /// for invalid shapes, ranks, axes, dtypes, or output metadata. It returns
+    /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
+    /// backend execution or storage access cannot provide the requested result.
     fn dot_general_read_into_accum_cached(
         &mut self,
         _cache: &mut Self::RuntimeCache,

--- a/crates/tenferro-tensor/src/capability.rs
+++ b/crates/tenferro-tensor/src/capability.rs
@@ -341,21 +341,20 @@ pub trait TensorBackendCapability {
     ///         CapabilityAxis::OwnedResult,
     ///     )
     ///     .unwrap_err();
-    /// assert!(matches!(err, Error::UnsupportedDTypeConversion { op: "neg", .. }));
+    /// assert!(matches!(err, Error::UnsupportedDType { op: "neg", dtype: DType::I32, .. }));
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::UnsupportedDTypeConversion`] when the backend
-    /// capability table does not support the requested operation and dtype.
+    /// Returns [`crate::Error::UnsupportedDType`] when the backend capability
+    /// table does not support the requested operation and dtype.
     fn require_capability(
         &self,
         query: CapabilityQuery,
         axis: CapabilityAxis,
     ) -> crate::Result<OperationCapability> {
         let entry = self.capability(query).ok_or_else(|| {
-            crate::Error::unsupported_dtype_conversion(
+            crate::Error::unsupported_dtype(
                 descriptor(query.op).name,
-                query.dtype,
                 query.dtype,
                 format!(
                     "backend {} does not support this operation/dtype",
@@ -366,9 +365,8 @@ pub trait TensorBackendCapability {
         if entry.axis(axis).is_supported() {
             Ok(entry)
         } else {
-            Err(crate::Error::unsupported_dtype_conversion(
+            Err(crate::Error::unsupported_dtype(
                 descriptor(query.op).name,
-                query.dtype,
                 query.dtype,
                 format!(
                     "backend {} does not support this operation/dtype",

--- a/crates/tenferro-tensor/src/capability.rs
+++ b/crates/tenferro-tensor/src/capability.rs
@@ -341,27 +341,39 @@ pub trait TensorBackendCapability {
     ///         CapabilityAxis::OwnedResult,
     ///     )
     ///     .unwrap_err();
-    /// assert!(matches!(err, Error::UnsupportedOpDType { backend: BackendId::Cuda, .. }));
+    /// assert!(matches!(err, Error::UnsupportedDTypeConversion { op: "neg", .. }));
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::UnsupportedDTypeConversion`] when the backend
+    /// capability table does not support the requested operation and dtype.
     fn require_capability(
         &self,
         query: CapabilityQuery,
         axis: CapabilityAxis,
     ) -> crate::Result<OperationCapability> {
         let entry = self.capability(query).ok_or_else(|| {
-            crate::Error::unsupported_op_dtype(
+            crate::Error::unsupported_dtype_conversion(
                 descriptor(query.op).name,
                 query.dtype,
-                self.backend_id(),
+                query.dtype,
+                format!(
+                    "backend {} does not support this operation/dtype",
+                    self.backend_id()
+                ),
             )
         })?;
         if entry.axis(axis).is_supported() {
             Ok(entry)
         } else {
-            Err(crate::Error::unsupported_op_dtype(
+            Err(crate::Error::unsupported_dtype_conversion(
                 descriptor(query.op).name,
                 query.dtype,
-                self.backend_id(),
+                query.dtype,
+                format!(
+                    "backend {} does not support this operation/dtype",
+                    self.backend_id()
+                ),
             ))
         }
     }

--- a/crates/tenferro-tensor/src/config.rs
+++ b/crates/tenferro-tensor/src/config.rs
@@ -1,12 +1,9 @@
-use crate::{Error, Result};
+use crate::{Error, Result, ValidationError};
 
 const DOT_GENERAL_OP: &str = "dot_general";
 
 fn invalid_dot_general_config(message: impl Into<String>) -> Error {
-    Error::InvalidConfig {
-        op: DOT_GENERAL_OP,
-        message: message.into(),
-    }
+    Error::invalid_argument(DOT_GENERAL_OP, "dot_general_config", message)
 }
 
 /// DotGeneral dimension configuration.
@@ -42,14 +39,17 @@ pub struct DotGeneralConfig {
 }
 
 impl DotGeneralConfig {
-    fn check_no_duplicates(dims: &[usize], label: &str) -> Result<()> {
+    fn check_no_duplicates(dims: &[usize], label: &'static str) -> Result<()> {
         let mut seen = std::collections::HashSet::new();
         for &d in dims {
             if !seen.insert(d) {
-                return Err(invalid_dot_general_config(format!(
-                    "{} contains duplicate dim {}",
-                    label, d
-                )));
+                return Err(Error::validation(
+                    DOT_GENERAL_OP,
+                    ValidationError::DuplicateAxis {
+                        axis: d,
+                        role: label,
+                    },
+                ));
             }
         }
         Ok(())
@@ -74,37 +74,53 @@ impl DotGeneralConfig {
     /// };
     /// config.validate_dims_with_ranks(2, 2).unwrap();
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with an axis, duplicate-axis,
+    /// or configuration source when the dimension roles are invalid.
     pub fn validate_dims_with_ranks(&self, lhs_rank: usize, rhs_rank: usize) -> Result<()> {
         for &d in &self.lhs_contracting_dims {
             if d >= lhs_rank {
-                return Err(invalid_dot_general_config(format!(
-                    "lhs_contracting_dim {} out of bounds for lhs_rank {}",
-                    d, lhs_rank
-                )));
+                return Err(Error::validation(
+                    DOT_GENERAL_OP,
+                    ValidationError::AxisOutOfBounds {
+                        axis: d,
+                        rank: lhs_rank,
+                    },
+                ));
             }
         }
         for &d in &self.rhs_contracting_dims {
             if d >= rhs_rank {
-                return Err(invalid_dot_general_config(format!(
-                    "rhs_contracting_dim {} out of bounds for rhs_rank {}",
-                    d, rhs_rank
-                )));
+                return Err(Error::validation(
+                    DOT_GENERAL_OP,
+                    ValidationError::AxisOutOfBounds {
+                        axis: d,
+                        rank: rhs_rank,
+                    },
+                ));
             }
         }
         for &d in &self.lhs_batch_dims {
             if d >= lhs_rank {
-                return Err(invalid_dot_general_config(format!(
-                    "lhs_batch_dim {} out of bounds for lhs_rank {}",
-                    d, lhs_rank
-                )));
+                return Err(Error::validation(
+                    DOT_GENERAL_OP,
+                    ValidationError::AxisOutOfBounds {
+                        axis: d,
+                        rank: lhs_rank,
+                    },
+                ));
             }
         }
         for &d in &self.rhs_batch_dims {
             if d >= rhs_rank {
-                return Err(invalid_dot_general_config(format!(
-                    "rhs_batch_dim {} out of bounds for rhs_rank {}",
-                    d, rhs_rank
-                )));
+                return Err(Error::validation(
+                    DOT_GENERAL_OP,
+                    ValidationError::AxisOutOfBounds {
+                        axis: d,
+                        rank: rhs_rank,
+                    },
+                ));
             }
         }
         Self::check_no_duplicates(&self.lhs_contracting_dims, "lhs_contracting_dims")?;
@@ -113,18 +129,26 @@ impl DotGeneralConfig {
         Self::check_no_duplicates(&self.rhs_batch_dims, "rhs_batch_dims")?;
         for &d in &self.lhs_contracting_dims {
             if self.lhs_batch_dims.contains(&d) {
-                return Err(invalid_dot_general_config(format!(
-                    "lhs dim {} appears in both contracting and batch dims",
-                    d
-                )));
+                return Err(Error::validation(
+                    DOT_GENERAL_OP,
+                    ValidationError::AxisRoleConflict {
+                        axis: d,
+                        first_role: "lhs contracting",
+                        second_role: "lhs batch",
+                    },
+                ));
             }
         }
         for &d in &self.rhs_contracting_dims {
             if self.rhs_batch_dims.contains(&d) {
-                return Err(invalid_dot_general_config(format!(
-                    "rhs dim {} appears in both contracting and batch dims",
-                    d
-                )));
+                return Err(Error::validation(
+                    DOT_GENERAL_OP,
+                    ValidationError::AxisRoleConflict {
+                        axis: d,
+                        first_role: "rhs contracting",
+                        second_role: "rhs batch",
+                    },
+                ));
             }
         }
         if self.lhs_contracting_dims.len() != self.rhs_contracting_dims.len() {

--- a/crates/tenferro-tensor/src/dispatch.rs
+++ b/crates/tenferro-tensor/src/dispatch.rs
@@ -44,10 +44,11 @@ macro_rules! with_scalar {
             $crate::Tensor::I64($typed) => $body,
             $crate::Tensor::C32($typed) => $body,
             $crate::Tensor::C64($typed) => $body,
-            other => Err($crate::Error::unsupported_op_dtype(
+            other => Err($crate::Error::unsupported_dtype_conversion(
                 $op,
                 other.dtype(),
-                $backend,
+                other.dtype(),
+                format!("backend {} does not support this operation/dtype", $backend),
             )),
         }
     }};
@@ -57,10 +58,11 @@ macro_rules! with_scalar {
             $crate::Tensor::F64($typed) => $body,
             $crate::Tensor::C32($typed) => $body,
             $crate::Tensor::C64($typed) => $body,
-            other => Err($crate::Error::unsupported_op_dtype(
+            other => Err($crate::Error::unsupported_dtype_conversion(
                 $op,
                 other.dtype(),
-                $backend,
+                other.dtype(),
+                format!("backend {} does not support this operation/dtype", $backend),
             )),
         }
     }};
@@ -68,10 +70,11 @@ macro_rules! with_scalar {
         match $tensor {
             $crate::Tensor::F32($typed) => $body,
             $crate::Tensor::F64($typed) => $body,
-            other => Err($crate::Error::unsupported_op_dtype(
+            other => Err($crate::Error::unsupported_dtype_conversion(
                 $op,
                 other.dtype(),
-                $backend,
+                other.dtype(),
+                format!("backend {} does not support this operation/dtype", $backend),
             )),
         }
     }};
@@ -172,9 +175,12 @@ macro_rules! with_scalar_read {
                     let $view = tensor.as_view();
                     $body
                 }
-                $crate::Tensor::Bool(_) => {
-                    Err($crate::Error::unsupported_op_dtype($op, dtype, $backend))
-                }
+                $crate::Tensor::Bool(_) => Err($crate::Error::unsupported_dtype_conversion(
+                    $op,
+                    dtype,
+                    dtype,
+                    format!("backend {} does not support this operation/dtype", $backend),
+                )),
             },
             $crate::TensorRead::View(view) => match view {
                 $crate::TensorView::F32($view) => $body,
@@ -183,9 +189,12 @@ macro_rules! with_scalar_read {
                 $crate::TensorView::I64($view) => $body,
                 $crate::TensorView::C32($view) => $body,
                 $crate::TensorView::C64($view) => $body,
-                $crate::TensorView::Bool(_) => {
-                    Err($crate::Error::unsupported_op_dtype($op, dtype, $backend))
-                }
+                $crate::TensorView::Bool(_) => Err($crate::Error::unsupported_dtype_conversion(
+                    $op,
+                    dtype,
+                    dtype,
+                    format!("backend {} does not support this operation/dtype", $backend),
+                )),
             },
         }
     }};
@@ -211,7 +220,12 @@ macro_rules! with_scalar_read {
                     $body
                 }
                 $crate::Tensor::I32(_) | $crate::Tensor::I64(_) | $crate::Tensor::Bool(_) => {
-                    Err($crate::Error::unsupported_op_dtype($op, dtype, $backend))
+                    Err($crate::Error::unsupported_dtype_conversion(
+                        $op,
+                        dtype,
+                        dtype,
+                        format!("backend {} does not support this operation/dtype", $backend),
+                    ))
                 }
             },
             $crate::TensorRead::View(view) => match view {
@@ -221,9 +235,12 @@ macro_rules! with_scalar_read {
                 $crate::TensorView::C64($view) => $body,
                 $crate::TensorView::I32(_)
                 | $crate::TensorView::I64(_)
-                | $crate::TensorView::Bool(_) => {
-                    Err($crate::Error::unsupported_op_dtype($op, dtype, $backend))
-                }
+                | $crate::TensorView::Bool(_) => Err($crate::Error::unsupported_dtype_conversion(
+                    $op,
+                    dtype,
+                    dtype,
+                    format!("backend {} does not support this operation/dtype", $backend),
+                )),
             },
         }
     }};
@@ -244,9 +261,12 @@ macro_rules! with_scalar_read {
                 | $crate::Tensor::I64(_)
                 | $crate::Tensor::Bool(_)
                 | $crate::Tensor::C32(_)
-                | $crate::Tensor::C64(_) => {
-                    Err($crate::Error::unsupported_op_dtype($op, dtype, $backend))
-                }
+                | $crate::Tensor::C64(_) => Err($crate::Error::unsupported_dtype_conversion(
+                    $op,
+                    dtype,
+                    dtype,
+                    format!("backend {} does not support this operation/dtype", $backend),
+                )),
             },
             $crate::TensorRead::View(view) => match view {
                 $crate::TensorView::F32($view) => $body,
@@ -255,9 +275,12 @@ macro_rules! with_scalar_read {
                 | $crate::TensorView::I64(_)
                 | $crate::TensorView::Bool(_)
                 | $crate::TensorView::C32(_)
-                | $crate::TensorView::C64(_) => {
-                    Err($crate::Error::unsupported_op_dtype($op, dtype, $backend))
-                }
+                | $crate::TensorView::C64(_) => Err($crate::Error::unsupported_dtype_conversion(
+                    $op,
+                    dtype,
+                    dtype,
+                    format!("backend {} does not support this operation/dtype", $backend),
+                )),
             },
         }
     }};

--- a/crates/tenferro-tensor/src/dispatch.rs
+++ b/crates/tenferro-tensor/src/dispatch.rs
@@ -44,9 +44,8 @@ macro_rules! with_scalar {
             $crate::Tensor::I64($typed) => $body,
             $crate::Tensor::C32($typed) => $body,
             $crate::Tensor::C64($typed) => $body,
-            other => Err($crate::Error::unsupported_dtype_conversion(
+            other => Err($crate::Error::unsupported_dtype(
                 $op,
-                other.dtype(),
                 other.dtype(),
                 format!("backend {} does not support this operation/dtype", $backend),
             )),
@@ -58,9 +57,8 @@ macro_rules! with_scalar {
             $crate::Tensor::F64($typed) => $body,
             $crate::Tensor::C32($typed) => $body,
             $crate::Tensor::C64($typed) => $body,
-            other => Err($crate::Error::unsupported_dtype_conversion(
+            other => Err($crate::Error::unsupported_dtype(
                 $op,
-                other.dtype(),
                 other.dtype(),
                 format!("backend {} does not support this operation/dtype", $backend),
             )),
@@ -70,9 +68,8 @@ macro_rules! with_scalar {
         match $tensor {
             $crate::Tensor::F32($typed) => $body,
             $crate::Tensor::F64($typed) => $body,
-            other => Err($crate::Error::unsupported_dtype_conversion(
+            other => Err($crate::Error::unsupported_dtype(
                 $op,
-                other.dtype(),
                 other.dtype(),
                 format!("backend {} does not support this operation/dtype", $backend),
             )),
@@ -175,9 +172,8 @@ macro_rules! with_scalar_read {
                     let $view = tensor.as_view();
                     $body
                 }
-                $crate::Tensor::Bool(_) => Err($crate::Error::unsupported_dtype_conversion(
+                $crate::Tensor::Bool(_) => Err($crate::Error::unsupported_dtype(
                     $op,
-                    dtype,
                     dtype,
                     format!("backend {} does not support this operation/dtype", $backend),
                 )),
@@ -189,9 +185,8 @@ macro_rules! with_scalar_read {
                 $crate::TensorView::I64($view) => $body,
                 $crate::TensorView::C32($view) => $body,
                 $crate::TensorView::C64($view) => $body,
-                $crate::TensorView::Bool(_) => Err($crate::Error::unsupported_dtype_conversion(
+                $crate::TensorView::Bool(_) => Err($crate::Error::unsupported_dtype(
                     $op,
-                    dtype,
                     dtype,
                     format!("backend {} does not support this operation/dtype", $backend),
                 )),
@@ -220,9 +215,8 @@ macro_rules! with_scalar_read {
                     $body
                 }
                 $crate::Tensor::I32(_) | $crate::Tensor::I64(_) | $crate::Tensor::Bool(_) => {
-                    Err($crate::Error::unsupported_dtype_conversion(
+                    Err($crate::Error::unsupported_dtype(
                         $op,
-                        dtype,
                         dtype,
                         format!("backend {} does not support this operation/dtype", $backend),
                     ))
@@ -235,9 +229,8 @@ macro_rules! with_scalar_read {
                 $crate::TensorView::C64($view) => $body,
                 $crate::TensorView::I32(_)
                 | $crate::TensorView::I64(_)
-                | $crate::TensorView::Bool(_) => Err($crate::Error::unsupported_dtype_conversion(
+                | $crate::TensorView::Bool(_) => Err($crate::Error::unsupported_dtype(
                     $op,
-                    dtype,
                     dtype,
                     format!("backend {} does not support this operation/dtype", $backend),
                 )),
@@ -261,9 +254,8 @@ macro_rules! with_scalar_read {
                 | $crate::Tensor::I64(_)
                 | $crate::Tensor::Bool(_)
                 | $crate::Tensor::C32(_)
-                | $crate::Tensor::C64(_) => Err($crate::Error::unsupported_dtype_conversion(
+                | $crate::Tensor::C64(_) => Err($crate::Error::unsupported_dtype(
                     $op,
-                    dtype,
                     dtype,
                     format!("backend {} does not support this operation/dtype", $backend),
                 )),
@@ -275,9 +267,8 @@ macro_rules! with_scalar_read {
                 | $crate::TensorView::I64(_)
                 | $crate::TensorView::Bool(_)
                 | $crate::TensorView::C32(_)
-                | $crate::TensorView::C64(_) => Err($crate::Error::unsupported_dtype_conversion(
+                | $crate::TensorView::C64(_) => Err($crate::Error::unsupported_dtype(
                     $op,
-                    dtype,
                     dtype,
                     format!("backend {} does not support this operation/dtype", $backend),
                 )),

--- a/crates/tenferro-tensor/src/error.rs
+++ b/crates/tenferro-tensor/src/error.rs
@@ -60,6 +60,14 @@ pub enum Error {
         to: crate::DType,
         message: String,
     },
+    #[error("{op}: unsupported dtype {dtype:?}: {message}")]
+    UnsupportedDType {
+        op: &'static str,
+        dtype: crate::DType,
+        message: String,
+    },
+    #[error("{op}: unsupported operation: {message}")]
+    Unsupported { op: &'static str, message: String },
     #[error("{op}: backend failure: {message}")]
     BackendFailure { op: &'static str, message: String },
     #[error("{op}: backend failure: {source}")]
@@ -254,6 +262,55 @@ impl Error {
         }
     }
 
+    /// Construct an operation-level unsupported-dtype error.
+    ///
+    /// This is for an operation that cannot run for the supplied dtype. It is
+    /// deliberately distinct from [`Error::unsupported_dtype_conversion`],
+    /// which is reserved for an actual from-dtype to to-dtype conversion.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{DType, Error, ErrorKind};
+    ///
+    /// let error = Error::unsupported_dtype("exp", DType::I64, "integer exponentials are not implemented");
+    /// assert!(matches!(error, Error::UnsupportedDType { op: "exp", dtype: DType::I64, .. }));
+    /// assert_eq!(error.kind(), ErrorKind::Unsupported);
+    /// ```
+    pub fn unsupported_dtype(
+        op: &'static str,
+        dtype: crate::DType,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::UnsupportedDType {
+            op,
+            dtype,
+            message: message.into(),
+        }
+    }
+
+    /// Construct a structured unsupported-operation error.
+    ///
+    /// Use this for an operation or execution surface that is not implemented
+    /// by the selected backend. Dtype conversion failures use
+    /// [`Error::unsupported_dtype_conversion`] instead, and operation-specific
+    /// typed reasons should use [`Error::extension`] with `ErrorKind::Unsupported`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{Error, ErrorKind};
+    ///
+    /// let error = Error::unsupported("full_piv_lu", "backend has no implementation");
+    /// assert_eq!(error.kind(), ErrorKind::Unsupported);
+    /// ```
+    pub fn unsupported(op: &'static str, message: impl Into<String>) -> Self {
+        Self::Unsupported {
+            op,
+            message: message.into(),
+        }
+    }
+
     /// Construct a text-only backend failure.
     ///
     /// Use [`Error::backend_source`] when a typed source is available.
@@ -412,7 +469,9 @@ impl Error {
     pub fn kind(&self) -> ErrorKind {
         match self {
             Self::Validation { source, .. } => ErrorKind::Validation(source.kind()),
-            Self::UnsupportedDTypeConversion { .. } => ErrorKind::Unsupported,
+            Self::UnsupportedDTypeConversion { .. }
+            | Self::UnsupportedDType { .. }
+            | Self::Unsupported { .. } => ErrorKind::Unsupported,
             Self::BackendFailure { .. } | Self::BackendSource { .. } => ErrorKind::BackendFailure,
             Self::IoSource { .. } => ErrorKind::Io,
             Self::RuntimeState { .. } | Self::RuntimeStateSource { .. } => ErrorKind::RuntimeState,

--- a/crates/tenferro-tensor/src/error.rs
+++ b/crates/tenferro-tensor/src/error.rs
@@ -68,6 +68,20 @@ pub enum Error {
         #[source]
         source: BoxError,
     },
+    #[error("{op}: I/O failure: {source}")]
+    IoSource {
+        op: &'static str,
+        #[source]
+        source: BoxError,
+    },
+    #[error("{op}: runtime state failure: {message}")]
+    RuntimeState { op: &'static str, message: String },
+    #[error("{op}: runtime state failure: {source}")]
+    RuntimeStateSource {
+        op: &'static str,
+        #[source]
+        source: BoxError,
+    },
     #[error("{op}: extension {family} failed: {source}")]
     Extension {
         op: &'static str,
@@ -280,6 +294,75 @@ impl Error {
         }
     }
 
+    /// Construct an I/O failure while preserving its typed source.
+    ///
+    /// I/O errors are intentionally separate from backend failures: callers
+    /// can classify them as [`ErrorKind::Io`] without parsing a message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{Error, ErrorKind};
+    ///
+    /// let error = Error::io_source("load", std::io::Error::other("read failed"));
+    /// assert_eq!(error.kind(), ErrorKind::Io);
+    /// assert!(std::error::Error::source(&error).is_some());
+    /// ```
+    pub fn io_source<E>(op: &'static str, source: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        Self::IoSource {
+            op,
+            source: Box::new(source),
+        }
+    }
+
+    /// Construct a runtime-state failure when no typed source exists.
+    ///
+    /// Use this for missing, uninitialized, or invalid execution state. It is
+    /// distinct from [`Error::backend_failure`], which is reserved for
+    /// vendor/backend status text.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{Error, ErrorKind};
+    ///
+    /// let error = Error::runtime_state("execute", "backend session is not initialized");
+    /// assert_eq!(error.kind(), ErrorKind::RuntimeState);
+    /// ```
+    pub fn runtime_state(op: &'static str, message: impl Into<String>) -> Self {
+        Self::RuntimeState {
+            op,
+            message: message.into(),
+        }
+    }
+
+    /// Construct a runtime-state failure while preserving a typed source.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{Error, ErrorKind};
+    ///
+    /// let error = Error::runtime_state_source(
+    ///     "execute",
+    ///     std::io::Error::other("executor lock poisoned"),
+    /// );
+    /// assert_eq!(error.kind(), ErrorKind::RuntimeState);
+    /// assert!(std::error::Error::source(&error).is_some());
+    /// ```
+    pub fn runtime_state_source<E>(op: &'static str, source: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        Self::RuntimeStateSource {
+            op,
+            source: Box::new(source),
+        }
+    }
+
     /// Construct an extension failure while preserving its typed source and
     /// coarse classification.
     ///
@@ -331,6 +414,8 @@ impl Error {
             Self::Validation { source, .. } => ErrorKind::Validation(source.kind()),
             Self::UnsupportedDTypeConversion { .. } => ErrorKind::Unsupported,
             Self::BackendFailure { .. } | Self::BackendSource { .. } => ErrorKind::BackendFailure,
+            Self::IoSource { .. } => ErrorKind::Io,
+            Self::RuntimeState { .. } | Self::RuntimeStateSource { .. } => ErrorKind::RuntimeState,
             Self::Extension { kind, .. } => *kind,
             Self::MissingValue { .. } => ErrorKind::RuntimeState,
             Self::Internal(_) => ErrorKind::Internal,

--- a/crates/tenferro-tensor/src/error.rs
+++ b/crates/tenferro-tensor/src/error.rs
@@ -3,17 +3,11 @@
 //! # Examples
 //!
 //! ```rust
-//! use tenferro_tensor::{Error, ShapeMismatch, ShapeVec};
-//!
-//! let error = Error::validation(
-//!     "add",
-//!     ShapeMismatch::IncompatibleShapes {
-//!         lhs: ShapeVec::from_vec(vec![2]),
-//!         rhs: ShapeVec::from_vec(vec![3]),
-//!     }
-//!     .into(),
-//! );
-//! assert!(error.to_string().contains("add"));
+//! let error = tenferro_tensor::Error::shape_mismatch("add", [2], [3]);
+//! assert!(matches!(
+//!     error,
+//!     tenferro_tensor::Error::Validation { op: "add", .. }
+//! ));
 //! ```
 
 use std::error::Error as StdError;
@@ -33,16 +27,11 @@ pub type BoxError = Box<dyn StdError + Send + Sync + 'static>;
 /// # Examples
 ///
 /// ```rust
-/// use tenferro_tensor::{Error, ErrorKind, ValidationError, ValidationKind};
-///
-/// let error = Error::validation(
-///     "reshape",
-///     ValidationError::RankMismatch {
-///         expected: 2,
-///         actual: 1,
-///     },
-/// );
-/// assert_eq!(error.kind(), ErrorKind::Validation(ValidationKind::RankMismatch));
+/// let error = tenferro_tensor::Error::rank_mismatch("reshape", 2, 1);
+/// assert!(matches!(
+///     error,
+///     tenferro_tensor::Error::Validation { op: "reshape", .. }
+/// ));
 /// ```
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -238,15 +227,16 @@ impl Error {
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_tensor::{Error, ErrorKind, DType};
-    ///
-    /// let error = Error::unsupported_dtype_conversion(
+    /// let error = tenferro_tensor::Error::unsupported_dtype_conversion(
     ///     "convert",
-    ///     DType::F64,
-    ///     DType::I32,
+    ///     tenferro_tensor::DType::F64,
+    ///     tenferro_tensor::DType::I32,
     ///     "lossy conversion is disabled",
     /// );
-    /// assert_eq!(error.kind(), ErrorKind::Unsupported);
+    /// assert!(matches!(
+    ///     error,
+    ///     tenferro_tensor::Error::UnsupportedDTypeConversion { .. }
+    /// ));
     /// ```
     pub fn unsupported_dtype_conversion(
         op: &'static str,
@@ -271,11 +261,19 @@ impl Error {
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_tensor::{DType, Error, ErrorKind};
-    ///
-    /// let error = Error::unsupported_dtype("exp", DType::I64, "integer exponentials are not implemented");
-    /// assert!(matches!(error, Error::UnsupportedDType { op: "exp", dtype: DType::I64, .. }));
-    /// assert_eq!(error.kind(), ErrorKind::Unsupported);
+    /// let error = tenferro_tensor::Error::unsupported_dtype(
+    ///     "exp",
+    ///     tenferro_tensor::DType::I64,
+    ///     "integer exponentials are not implemented",
+    /// );
+    /// assert!(matches!(
+    ///     error,
+    ///     tenferro_tensor::Error::UnsupportedDType {
+    ///         op: "exp",
+    ///         dtype: tenferro_tensor::DType::I64,
+    ///         ..
+    ///     }
+    /// ));
     /// ```
     pub fn unsupported_dtype(
         op: &'static str,
@@ -299,10 +297,14 @@ impl Error {
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_tensor::{Error, ErrorKind};
-    ///
-    /// let error = Error::unsupported("full_piv_lu", "backend has no implementation");
-    /// assert_eq!(error.kind(), ErrorKind::Unsupported);
+    /// let error = tenferro_tensor::Error::unsupported(
+    ///     "full_piv_lu",
+    ///     "backend has no implementation",
+    /// );
+    /// assert!(matches!(
+    ///     error,
+    ///     tenferro_tensor::Error::Unsupported { op: "full_piv_lu", .. }
+    /// ));
     /// ```
     pub fn unsupported(op: &'static str, message: impl Into<String>) -> Self {
         Self::Unsupported {
@@ -318,10 +320,14 @@ impl Error {
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_tensor::Error;
-    ///
-    /// let error = Error::backend_failure("matmul", "backend rejected launch");
-    /// assert!(matches!(error, Error::BackendFailure { op: "matmul", .. }));
+    /// let error = tenferro_tensor::Error::backend_failure(
+    ///     "matmul",
+    ///     "backend rejected launch",
+    /// );
+    /// assert!(matches!(
+    ///     error,
+    ///     tenferro_tensor::Error::BackendFailure { op: "matmul", .. }
+    /// ));
     /// ```
     pub fn backend_failure(op: &'static str, message: impl Into<String>) -> Self {
         Self::BackendFailure {
@@ -335,11 +341,11 @@ impl Error {
     /// # Examples
     ///
     /// ```rust
-    /// use std::error::Error as _;
-    /// use tenferro_tensor::Error;
-    ///
-    /// let error = Error::backend_source("load", std::io::Error::other("read failed"));
-    /// assert!(error.source().is_some());
+    /// let error = tenferro_tensor::Error::backend_source(
+    ///     "load",
+    ///     std::io::Error::other("read failed"),
+    /// );
+    /// assert!(std::error::Error::source(&error).is_some());
     /// ```
     pub fn backend_source<E>(op: &'static str, source: E) -> Self
     where

--- a/crates/tenferro-tensor/src/error.rs
+++ b/crates/tenferro-tensor/src/error.rs
@@ -3,63 +3,55 @@
 //! # Examples
 //!
 //! ```rust
-//! use tenferro_tensor::Error;
+//! use tenferro_tensor::{Error, ShapeMismatch, ShapeVec};
 //!
-//! let err = Error::AxisOutOfBounds {
-//!     op: "dot_general",
-//!     axis: 2,
-//!     rank: 1,
-//! };
-//! assert!(err.to_string().contains("dot_general"));
+//! let error = Error::validation(
+//!     "add",
+//!     ShapeMismatch::IncompatibleShapes {
+//!         lhs: ShapeVec::from_vec(vec![2]),
+//!         rhs: ShapeVec::from_vec(vec![3]),
+//!     }
+//!     .into(),
+//! );
+//! assert!(error.to_string().contains("add"));
 //! ```
 
+use std::error::Error as StdError;
+
+use tenferro_tensor_core::{ErrorKind, ValidationError};
+
+/// Boxed source used for backend and extension failures whose concrete type is
+/// owned by another crate or a vendor API.
+pub type BoxError = Box<dyn StdError + Send + Sync + 'static>;
+
 /// Runtime failures produced by tensor execution backends and helpers.
+///
+/// Validation failures retain the shared tensor-core payload as a typed source.
+/// Backend and extension failures retain opaque typed sources when one exists;
+/// text-only vendor failures use [`Error::BackendFailure`].
 ///
 /// # Examples
 ///
 /// ```rust
-/// use tenferro_tensor::Error;
+/// use tenferro_tensor::{Error, ErrorKind, ValidationError, ValidationKind};
 ///
-/// let err = Error::MissingValue { slot: 3 };
+/// let error = Error::validation(
+///     "reshape",
+///     ValidationError::RankMismatch {
+///         expected: 2,
+///         actual: 1,
+///     },
+/// );
+/// assert_eq!(error.kind(), ErrorKind::Validation(ValidationKind::RankMismatch));
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
-    #[error("{op}: axis {axis} out of bounds for rank {rank}")]
-    AxisOutOfBounds {
+    #[error("{op}: {source}")]
+    Validation {
         op: &'static str,
-        axis: usize,
-        rank: usize,
-    },
-    #[error("{op}: duplicate {role} axis {axis}")]
-    DuplicateAxis {
-        op: &'static str,
-        axis: usize,
-        role: &'static str,
-    },
-    #[error("{op}: axis {axis} appears in both {first_role} and {second_role}")]
-    AxisRoleConflict {
-        op: &'static str,
-        axis: usize,
-        first_role: &'static str,
-        second_role: &'static str,
-    },
-    #[error("{op}: shape mismatch lhs={lhs:?} rhs={rhs:?}")]
-    ShapeMismatch {
-        op: &'static str,
-        lhs: Vec<usize>,
-        rhs: Vec<usize>,
-    },
-    #[error("{op}: rank mismatch expected {expected}, actual {actual}")]
-    RankMismatch {
-        op: &'static str,
-        expected: usize,
-        actual: usize,
-    },
-    #[error("{op}: dtype mismatch lhs={lhs:?} rhs={rhs:?}")]
-    DTypeMismatch {
-        op: &'static str,
-        lhs: crate::DType,
-        rhs: crate::DType,
+        #[source]
+        source: ValidationError,
     },
     #[error("{op}: unsupported dtype conversion from {from:?} to {to:?}: {message}")]
     UnsupportedDTypeConversion {
@@ -68,110 +60,196 @@ pub enum Error {
         to: crate::DType,
         message: String,
     },
-    #[error("{backend} backend does not support {op} for dtype {dtype:?}")]
-    UnsupportedOpDType {
-        op: &'static str,
-        dtype: crate::DType,
-        backend: crate::BackendId,
-    },
-    #[error("{op}: division by zero for dtype {dtype:?}")]
-    DivisionByZero {
-        op: &'static str,
-        dtype: crate::DType,
-    },
-    #[error("{op}: negative integer exponent for dtype {dtype:?}")]
-    NegativeIntegerExponent {
-        op: &'static str,
-        dtype: crate::DType,
-    },
-    #[error("{op}: invalid config: {message}")]
-    InvalidConfig { op: &'static str, message: String },
-    #[error("extension family {family_id:?} has no host reference implementation")]
-    NoHostReference { family_id: &'static str },
     #[error("{op}: backend failure: {message}")]
     BackendFailure { op: &'static str, message: String },
+    #[error("{op}: backend failure: {source}")]
+    BackendSource {
+        op: &'static str,
+        #[source]
+        source: BoxError,
+    },
+    #[error("{op}: extension {family} failed: {source}")]
+    Extension {
+        op: &'static str,
+        family: &'static str,
+        kind: ErrorKind,
+        #[source]
+        source: BoxError,
+    },
     #[error("missing runtime value for slot {slot}")]
     MissingValue { slot: usize },
+    #[error("internal tensor error: {0}")]
+    Internal(String),
 }
 
 impl Error {
-    /// Construct a backend failure error while preserving the operation name.
+    /// Wrap shared tensor validation with the operation that requested it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{Error, ValidationError};
+    ///
+    /// let error = Error::validation(
+    ///     "transpose",
+    ///     ValidationError::AxisOutOfBounds { axis: 2, rank: 2 },
+    /// );
+    /// assert!(matches!(error, Error::Validation { op: "transpose", .. }));
+    /// ```
+    pub fn validation(op: &'static str, source: ValidationError) -> Self {
+        Self::Validation { op, source }
+    }
+
+    /// Construct a structured invalid-argument validation error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{Error, ErrorKind, ValidationKind};
+    ///
+    /// let error = Error::invalid_argument("slice", "step", "must be non-zero");
+    /// assert_eq!(error.kind(), ErrorKind::Validation(ValidationKind::InvalidArgument));
+    /// ```
+    pub fn invalid_argument(
+        op: &'static str,
+        argument: &'static str,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::validation(
+            op,
+            ValidationError::InvalidArgument {
+                argument,
+                message: message.into(),
+            },
+        )
+    }
+
+    /// Construct an unsupported dtype conversion error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{Error, ErrorKind, DType};
+    ///
+    /// let error = Error::unsupported_dtype_conversion(
+    ///     "convert",
+    ///     DType::F64,
+    ///     DType::I32,
+    ///     "lossy conversion is disabled",
+    /// );
+    /// assert_eq!(error.kind(), ErrorKind::Unsupported);
+    /// ```
+    pub fn unsupported_dtype_conversion(
+        op: &'static str,
+        from: crate::DType,
+        to: crate::DType,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::UnsupportedDTypeConversion {
+            op,
+            from,
+            to,
+            message: message.into(),
+        }
+    }
+
+    /// Construct a text-only backend failure.
+    ///
+    /// Use [`Error::backend_source`] when a typed source is available.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use tenferro_tensor::Error;
     ///
-    /// let err = Error::backend_failure("matmul", "backend rejected launch");
-    /// assert!(matches!(
-    ///     err,
-    ///     Error::BackendFailure {
-    ///         op: "matmul",
-    ///         ref message,
-    ///     } if message == "backend rejected launch"
-    /// ));
+    /// let error = Error::backend_failure("matmul", "backend rejected launch");
+    /// assert!(matches!(error, Error::BackendFailure { op: "matmul", .. }));
     /// ```
-    pub fn backend_failure(op: &'static str, message: impl std::fmt::Display) -> Self {
+    pub fn backend_failure(op: &'static str, message: impl Into<String>) -> Self {
         Self::BackendFailure {
             op,
-            message: message.to_string(),
+            message: message.into(),
         }
     }
 
-    /// Construct a structured unsupported operation/dtype error.
+    /// Construct a backend failure while preserving its typed source.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_tensor::{BackendId, DType, Error};
+    /// use std::error::Error as _;
+    /// use tenferro_tensor::Error;
     ///
-    /// let err = Error::unsupported_op_dtype("add", DType::Bool, BackendId::Cuda);
-    /// assert!(matches!(err, Error::UnsupportedOpDType { backend: BackendId::Cuda, .. }));
+    /// let error = Error::backend_source("load", std::io::Error::other("read failed"));
+    /// assert!(error.source().is_some());
     /// ```
-    pub fn unsupported_op_dtype(
-        op: &'static str,
-        dtype: crate::DType,
-        backend: crate::BackendId,
-    ) -> Self {
-        Self::UnsupportedOpDType { op, dtype, backend }
+    pub fn backend_source<E>(op: &'static str, source: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        Self::BackendSource {
+            op,
+            source: Box::new(source),
+        }
     }
 
-    /// Construct a structured division-by-zero domain error.
+    /// Construct an extension failure while preserving its typed source and
+    /// coarse classification.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_tensor::{DType, Error};
+    /// use std::error::Error as _;
+    /// use tenferro_tensor::{Error, ErrorKind};
     ///
-    /// let err = Error::division_by_zero("div", DType::I32);
-    /// assert!(matches!(err, Error::DivisionByZero { op: "div", .. }));
+    /// let error = Error::extension(
+    ///     "einsum",
+    ///     "einsum",
+    ///     ErrorKind::Internal,
+    ///     std::io::Error::other("planner failed"),
+    /// );
+    /// assert!(error.source().is_some());
     /// ```
-    pub fn division_by_zero(op: &'static str, dtype: crate::DType) -> Self {
-        Self::DivisionByZero { op, dtype }
+    pub fn extension<E>(op: &'static str, family: &'static str, kind: ErrorKind, source: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        Self::Extension {
+            op,
+            family,
+            kind,
+            source: Box::new(source),
+        }
     }
 
-    /// Construct a structured negative-integer-exponent domain error.
+    /// Return the stable coarse classification for this tensor failure.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use tenferro_tensor::{DType, Error};
+    /// use tenferro_tensor::{Error, ErrorKind, ValidationError, ValidationKind};
+    /// use tenferro_tensor::core::DType;
     ///
-    /// let err = Error::negative_integer_exponent("pow", DType::I64);
-    /// assert!(matches!(err, Error::NegativeIntegerExponent { op: "pow", .. }));
+    /// let error = Error::validation(
+    ///     "add",
+    ///     ValidationError::DTypeMismatch {
+    ///         expected: DType::F32,
+    ///         actual: DType::F64,
+    ///     },
+    /// );
+    /// assert_eq!(error.kind(), ErrorKind::Validation(ValidationKind::DTypeMismatch));
     /// ```
-    pub fn negative_integer_exponent(op: &'static str, dtype: crate::DType) -> Self {
-        Self::NegativeIntegerExponent { op, dtype }
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            Self::Validation { source, .. } => ErrorKind::Validation(source.kind()),
+            Self::UnsupportedDTypeConversion { .. } => ErrorKind::Unsupported,
+            Self::BackendFailure { .. } | Self::BackendSource { .. } => ErrorKind::BackendFailure,
+            Self::Extension { kind, .. } => *kind,
+            Self::MissingValue { .. } => ErrorKind::RuntimeState,
+            Self::Internal(_) => ErrorKind::Internal,
+        }
     }
 }
 
 /// Result type alias for runtime tensor operations.
-///
-/// # Examples
-///
-/// ```rust
-/// use tenferro_tensor::{Error, Result};
-///
-/// let output: Result<()> = Err(Error::MissingValue { slot: 0 });
-/// ```
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/tenferro-tensor/src/error.rs
+++ b/crates/tenferro-tensor/src/error.rs
@@ -83,6 +83,93 @@ pub enum Error {
 }
 
 impl Error {
+    /// Construct an incompatible-shapes validation error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::Error;
+    ///
+    /// let error = Error::shape_mismatch("add", [2, 3], [2, 4]);
+    /// assert!(matches!(error, Error::Validation { .. }));
+    /// ```
+    pub fn shape_mismatch(
+        op: &'static str,
+        lhs: impl Into<Vec<usize>>,
+        rhs: impl Into<Vec<usize>>,
+    ) -> Self {
+        Self::validation(
+            op,
+            tenferro_tensor_core::ShapeMismatch::IncompatibleShapes {
+                lhs: tenferro_tensor_core::ShapeVec::from_vec(lhs.into()),
+                rhs: tenferro_tensor_core::ShapeVec::from_vec(rhs.into()),
+            }
+            .into(),
+        )
+    }
+
+    /// Construct a rank-mismatch validation error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::Error;
+    ///
+    /// let error = Error::rank_mismatch("transpose", 2, 3);
+    /// assert!(matches!(error, Error::Validation { .. }));
+    /// ```
+    pub fn rank_mismatch(op: &'static str, expected: usize, actual: usize) -> Self {
+        Self::validation(op, ValidationError::RankMismatch { expected, actual })
+    }
+
+    /// Construct an axis-out-of-bounds validation error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::Error;
+    ///
+    /// let error = Error::axis_out_of_bounds("sum", 2, 2);
+    /// assert!(matches!(error, Error::Validation { .. }));
+    /// ```
+    pub fn axis_out_of_bounds(op: &'static str, axis: usize, rank: usize) -> Self {
+        Self::validation(op, ValidationError::AxisOutOfBounds { axis, rank })
+    }
+
+    /// Construct a duplicate-axis validation error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::Error;
+    ///
+    /// let error = Error::duplicate_axis("transpose", 1, "permutation");
+    /// assert!(matches!(error, Error::Validation { .. }));
+    /// ```
+    pub fn duplicate_axis(op: &'static str, axis: usize, role: &'static str) -> Self {
+        Self::validation(op, ValidationError::DuplicateAxis { axis, role })
+    }
+
+    /// Construct a dtype-mismatch validation error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_tensor::{DType, Error};
+    ///
+    /// let error = Error::dtype_mismatch("add", DType::F32, DType::F64);
+    /// assert!(matches!(error, Error::Validation { .. }));
+    /// ```
+    pub fn dtype_mismatch(op: &'static str, expected: crate::DType, actual: crate::DType) -> Self {
+        Self::validation(
+            op,
+            ValidationError::DTypeMismatch {
+                expected: crate::core_dtype(expected),
+                actual: crate::core_dtype(actual),
+            },
+        )
+    }
+
     /// Wrap shared tensor validation with the operation that requested it.
     ///
     /// # Examples

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -43,7 +43,10 @@ pub mod core {
     pub use tenferro_tensor_core::*;
 }
 
-pub use tenferro_tensor_core::{ShapeVec, SliceSpec, StrideVec, TensorRef};
+pub use tenferro_tensor_core::{
+    ErrorKind, ShapeMismatch, ShapeVec, SliceSpec, StrideVec, TensorRef, ValidationError,
+    ValidationKind,
+};
 
 pub mod backend;
 pub mod cache;
@@ -69,6 +72,18 @@ pub use capability::{
 pub use config::*;
 pub use error::*;
 pub use types::*;
+
+pub(crate) fn core_dtype(dtype: DType) -> tenferro_tensor_core::DType {
+    match dtype {
+        DType::F32 => tenferro_tensor_core::DType::F32,
+        DType::F64 => tenferro_tensor_core::DType::F64,
+        DType::I32 => tenferro_tensor_core::DType::I32,
+        DType::I64 => tenferro_tensor_core::DType::I64,
+        DType::Bool => tenferro_tensor_core::DType::Bool,
+        DType::C32 => tenferro_tensor_core::DType::C32,
+        DType::C64 => tenferro_tensor_core::DType::C64,
+    }
+}
 
 #[cfg(test)]
 mod tests;

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -275,18 +275,23 @@ impl TensorStructural for DefaultReadBackend {
             ));
         }
         if src.dtype() != dst.dtype() {
-            return Err(crate::Error::DTypeMismatch {
-                op: "copy_read_into",
-                lhs: src.dtype(),
-                rhs: dst.dtype(),
-            });
+            return Err(crate::Error::validation(
+                "copy_read_into",
+                crate::ValidationError::DTypeMismatch {
+                    expected: crate::core_dtype(dst.dtype()),
+                    actual: crate::core_dtype(src.dtype()),
+                },
+            ));
         }
         if src.shape() != dst.shape() {
-            return Err(crate::Error::ShapeMismatch {
-                op: "copy_read_into",
-                lhs: src.shape().to_vec(),
-                rhs: dst.shape().to_vec(),
-            });
+            return Err(crate::Error::validation(
+                "copy_read_into",
+                crate::ShapeMismatch::IncompatibleShapes {
+                    lhs: src.shape().to_vec().into(),
+                    rhs: dst.shape().to_vec().into(),
+                }
+                .into(),
+            ));
         }
         let src = self.to_contiguous_read(src)?;
         macro_rules! copy_typed {
@@ -675,13 +680,25 @@ fn elementwise_into_defaults_overwrite_outputs_and_validate_output() {
     let err = backend
         .add_into(&a, &b, TensorWrite::from_tensor(&mut wrong_shape))
         .unwrap_err();
-    assert!(matches!(err, crate::Error::ShapeMismatch { .. }));
+    assert!(matches!(
+        err,
+        crate::Error::Validation {
+            source: crate::ValidationError::ShapeMismatch(_),
+            ..
+        }
+    ));
 
     let mut wrong_dtype = Tensor::from_vec_col_major(vec![1], vec![0_i32]).unwrap();
     let err = backend
         .add_into(&a, &b, TensorWrite::from_tensor(&mut wrong_dtype))
         .unwrap_err();
-    assert!(matches!(err, crate::Error::DTypeMismatch { .. }));
+    assert!(matches!(
+        err,
+        crate::Error::Validation {
+            source: crate::ValidationError::DTypeMismatch { .. },
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -1210,7 +1227,16 @@ fn grouped_gemm_validation_rejects_invalid_metadata() {
         "test_grouped_gemm",
     )
     .unwrap_err();
-    assert!(err.to_string().contains("lhs matrix range"));
+    assert!(matches!(
+        err,
+        crate::Error::Validation {
+            source: crate::ValidationError::InvalidArgument {
+                argument: "lhs",
+                ..
+            },
+            ..
+        }
+    ));
 
     let rhs_range_jobs = [GroupedGemmJob::new(0, 0, 1, 1, 1, 2)];
     let err = validate_grouped_gemm(
@@ -1221,7 +1247,16 @@ fn grouped_gemm_validation_rejects_invalid_metadata() {
         "test_grouped_gemm",
     )
     .unwrap_err();
-    assert!(err.to_string().contains("rhs matrix range"));
+    assert!(matches!(
+        err,
+        crate::Error::Validation {
+            source: crate::ValidationError::InvalidArgument {
+                argument: "rhs",
+                ..
+            },
+            ..
+        }
+    ));
 
     let out_range_jobs = [GroupedGemmJob::new(1, 0, 0, 1, 1, 2)];
     let err = validate_grouped_gemm(
@@ -1232,7 +1267,16 @@ fn grouped_gemm_validation_rejects_invalid_metadata() {
         "test_grouped_gemm",
     )
     .unwrap_err();
-    assert!(err.to_string().contains("out matrix range"));
+    assert!(matches!(
+        err,
+        crate::Error::Validation {
+            source: crate::ValidationError::InvalidArgument {
+                argument: "out",
+                ..
+            },
+            ..
+        }
+    ));
 
     let overlapping_jobs = [
         GroupedGemmJob::new(0, 0, 0, 1, 1, 1),
@@ -1246,7 +1290,16 @@ fn grouped_gemm_validation_rejects_invalid_metadata() {
         "test_grouped_gemm",
     )
     .unwrap_err();
-    assert!(err.to_string().contains("overlaps job"));
+    assert!(matches!(
+        err,
+        crate::Error::Validation {
+            source: crate::ValidationError::InvalidArgument {
+                argument: "jobs",
+                ..
+            },
+            ..
+        }
+    ));
 
     let overflow_jobs = [GroupedGemmJob::new(0, 0, 0, usize::MAX, 0, 2)];
     let err = validate_grouped_gemm(
@@ -1257,7 +1310,13 @@ fn grouped_gemm_validation_rejects_invalid_metadata() {
         "test_grouped_gemm",
     )
     .unwrap_err();
-    assert!(err.to_string().contains("element count overflows"));
+    assert!(matches!(
+        err,
+        crate::Error::Validation {
+            source: crate::ValidationError::InvalidArgument { .. },
+            ..
+        }
+    ));
 
     let empty_jobs = [GroupedGemmJob::new(
         usize::MAX,
@@ -1348,7 +1407,13 @@ fn tensor_stack_reshapes_then_concatenates_and_validates_inputs() {
 
     let c = Tensor::from_vec_col_major(vec![3], vec![0.0_f64; 3]).unwrap();
     let shape_err = Tensor::stack(&[&a, &c], 0, &mut backend).unwrap_err();
-    assert!(shape_err.to_string().contains("shape mismatch"));
+    assert!(matches!(
+        shape_err,
+        crate::Error::Validation {
+            source: crate::ValidationError::ShapeMismatch(_),
+            ..
+        }
+    ));
 
     let axis_err = Tensor::stack(&[&a], 2, &mut backend).unwrap_err();
     assert!(axis_err.to_string().contains("axis 2"));

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -237,7 +237,7 @@ impl TensorStructural for DefaultReadBackend {
     fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
         if !self.structural_runtime_enabled {
             let TensorRead::Tensor(tensor) = input else {
-                return Err(crate::Error::backend_failure(
+                return Err(crate::Error::unsupported(
                     "to_contiguous_read",
                     "backend does not accept borrowed tensor views at this execution boundary",
                 ));
@@ -248,7 +248,7 @@ impl TensorStructural for DefaultReadBackend {
                     crate::MemoryKind::PinnedHost | crate::MemoryKind::UnpinnedHost
                 )
             {
-                return Err(crate::Error::backend_failure(
+                return Err(crate::Error::runtime_state(
                     "to_contiguous_read",
                     "default materialization accepts only host-owned tensors; use the storage's owning backend",
                 ));
@@ -269,7 +269,7 @@ impl TensorStructural for DefaultReadBackend {
 
     fn copy_read_into(&mut self, src: TensorRead<'_>, dst: TensorWrite<'_>) -> crate::Result<()> {
         if !self.structural_runtime_enabled {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::unsupported(
                 "copy_read_into",
                 "backend-owned runtime copy is unsupported by this backend",
             ));
@@ -1452,7 +1452,7 @@ fn structural_runtime_materialization_rejects_views_by_default() {
 
     assert!(matches!(
         err,
-        crate::Error::BackendFailure {
+        crate::Error::Unsupported {
             op: "to_contiguous_read",
             ref message,
         } if message.contains("borrowed tensor views")
@@ -1489,7 +1489,7 @@ fn structural_runtime_materialization_rejects_foreign_backend_storage_by_default
 
     assert!(matches!(
         err,
-        crate::Error::BackendFailure {
+        crate::Error::RuntimeState {
             op: "to_contiguous_read",
             ref message,
         } if message.contains("host-owned") && message.contains("owning backend")
@@ -1515,7 +1515,7 @@ fn structural_runtime_copy_is_explicitly_unsupported_by_default() {
 
     assert!(matches!(
         err,
-        crate::Error::BackendFailure {
+        crate::Error::Unsupported {
             op: "copy_read_into",
             ref message,
         } if message.contains("unsupported")

--- a/crates/tenferro-tensor/src/tests/capability_tests.rs
+++ b/crates/tenferro-tensor/src/tests/capability_tests.rs
@@ -112,10 +112,9 @@ fn backend_require_capability_reports_structured_unsupported_errors() {
 
     assert!(matches!(
         err,
-        Error::UnsupportedDTypeConversion {
+        Error::UnsupportedDType {
             op: "add",
-            from: DType::Bool,
-            to: DType::Bool,
+            dtype: DType::Bool,
             ..
         }
     ));
@@ -128,10 +127,9 @@ fn backend_require_capability_reports_structured_unsupported_errors() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::UnsupportedDTypeConversion {
+        Error::UnsupportedDType {
             op: "add",
-            from: DType::I32,
-            to: DType::I32,
+            dtype: DType::I32,
             ..
         }
     ));

--- a/crates/tenferro-tensor/src/tests/capability_tests.rs
+++ b/crates/tenferro-tensor/src/tests/capability_tests.rs
@@ -112,10 +112,11 @@ fn backend_require_capability_reports_structured_unsupported_errors() {
 
     assert!(matches!(
         err,
-        Error::UnsupportedOpDType {
+        Error::UnsupportedDTypeConversion {
             op: "add",
-            dtype: DType::Bool,
-            backend: BackendId::Cpu,
+            from: DType::Bool,
+            to: DType::Bool,
+            ..
         }
     ));
 
@@ -127,10 +128,11 @@ fn backend_require_capability_reports_structured_unsupported_errors() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::UnsupportedOpDType {
+        Error::UnsupportedDTypeConversion {
             op: "add",
-            dtype: DType::I32,
-            backend: BackendId::Cpu,
+            from: DType::I32,
+            to: DType::I32,
+            ..
         }
     ));
 }

--- a/crates/tenferro-tensor/src/tests/config_tests.rs
+++ b/crates/tenferro-tensor/src/tests/config_tests.rs
@@ -1,4 +1,4 @@
-use crate::{DotGeneralConfig, Error};
+use crate::{DotGeneralConfig, Error, ValidationError};
 
 #[test]
 fn validate_dims_with_explicit_ranks_rejects_out_of_range_contract() {
@@ -13,8 +13,9 @@ fn validate_dims_with_explicit_ranks_rejects_out_of_range_contract() {
         .expect_err("dim index 2 is out of range for rank 2");
     assert!(matches!(
         err,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "dot_general",
+            source: ValidationError::AxisOutOfBounds { .. },
             ..
         }
     ));

--- a/crates/tenferro-tensor/src/tests/dispatch_tests.rs
+++ b/crates/tenferro-tensor/src/tests/dispatch_tests.rs
@@ -44,10 +44,11 @@ fn with_scalar_rejects_dtype_outside_guard_with_structured_error() {
 
     assert!(matches!(
         err,
-        Error::UnsupportedOpDType {
+        Error::UnsupportedDTypeConversion {
             op: "dtype_probe",
-            dtype: DType::I32,
-            backend: BackendId::Cuda,
+            from: DType::I32,
+            to: DType::I32,
+            ..
         }
     ));
 }

--- a/crates/tenferro-tensor/src/tests/dispatch_tests.rs
+++ b/crates/tenferro-tensor/src/tests/dispatch_tests.rs
@@ -44,10 +44,9 @@ fn with_scalar_rejects_dtype_outside_guard_with_structured_error() {
 
     assert!(matches!(
         err,
-        Error::UnsupportedDTypeConversion {
+        Error::UnsupportedDType {
             op: "dtype_probe",
-            from: DType::I32,
-            to: DType::I32,
+            dtype: DType::I32,
             ..
         }
     ));

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -455,7 +455,7 @@ fn typed_tensor_static_rank_shape_conversion_reports_rank_mismatch() {
 
     assert!(matches!(
         err,
-        tenferro_tensor_core::Error::RankMismatch {
+        tenferro_tensor_core::ValidationError::RankMismatch {
             expected: 2,
             actual: 3
         }

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -64,6 +64,19 @@ fn runtime_state_source_is_not_classified_as_backend_failure() {
     assert!(err.source().is_some());
 }
 
+#[test]
+fn unsupported_operation_has_a_distinct_coarse_classification() {
+    let err = Error::unsupported("full_piv_lu", "backend has no implementation");
+    assert_eq!(err.kind(), ErrorKind::Unsupported);
+    assert!(matches!(
+        err,
+        Error::Unsupported {
+            op: "full_piv_lu",
+            ..
+        }
+    ));
+}
+
 #[derive(Debug)]
 struct NonCloneElement;
 
@@ -419,7 +432,7 @@ fn typed_tensor_as_view_preserves_rank_and_layout() {
 }
 
 #[test]
-fn typed_tensor_view_backend_as_slice_returns_backend_failure() {
+fn typed_tensor_view_backend_as_slice_returns_runtime_state() {
     let tensor = TypedTensor::<f64>::from_buffer_col_major(
         vec![2],
         Buffer::Backend(Arc::new(BufferHandle::<f64>::new_with_len(77, 2))),
@@ -437,7 +450,7 @@ fn typed_tensor_view_backend_as_slice_returns_backend_failure() {
 
     assert!(matches!(
         err,
-        Error::BackendFailure {
+        Error::RuntimeState {
             op: "TypedTensorView::as_slice",
             ..
         }
@@ -572,7 +585,7 @@ fn backend_buffer_handle_metadata_and_host_export_errors_are_explicit() {
     .unwrap();
     let col_err = tensor.clone().into_vec_col_major().unwrap_err();
 
-    assert!(matches!(col_err, Error::BackendFailure { .. }));
+    assert!(matches!(col_err, Error::RuntimeState { .. }));
     assert!(col_err
         .to_string()
         .contains("backend buffers cannot be exported"));

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{error::Error as _, sync::Arc};
 
 use num_complex::{Complex32, Complex64};
 
@@ -9,9 +9,43 @@ use crate::types::{
     TensorValue, TensorView, TensorViewMut, TensorWrite, TypedTensor, TypedTensorView,
     TypedTensorViewMut, TypedTensorWrite,
 };
-use crate::{Error, SliceConfig};
+use crate::{
+    Error, ErrorKind, ShapeMismatch, ShapeVec, SliceConfig, ValidationError, ValidationKind,
+};
 
 mod strided_dynamic;
+
+#[test]
+fn tensor_error_preserves_shared_validation_source() {
+    let err = Error::validation(
+        "add",
+        ShapeMismatch::IncompatibleShapes {
+            lhs: ShapeVec::from_vec(vec![2]),
+            rhs: ShapeVec::from_vec(vec![3]),
+        }
+        .into(),
+    );
+
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::ShapeMismatch)
+    );
+    assert!(err.source().is_some());
+    assert!(matches!(
+        err,
+        Error::Validation {
+            op: "add",
+            source: ValidationError::ShapeMismatch(_),
+        }
+    ));
+}
+
+#[test]
+fn typed_backend_source_is_not_formatted_away() {
+    let err = Error::backend_source("load", std::io::Error::other("device read failed"));
+    assert_eq!(err.kind(), ErrorKind::BackendFailure);
+    assert!(err.source().is_some());
+}
 
 #[derive(Debug)]
 struct NonCloneElement;
@@ -157,7 +191,10 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
     ] {
         assert!(matches!(
             owned.slice_view(&bad_config),
-            Err(Error::RankMismatch { .. })
+            Err(Error::Validation {
+                source: ValidationError::RankMismatch { .. },
+                ..
+            })
         ));
     }
 
@@ -200,7 +237,7 @@ fn col_major_helpers_cover_scalar_and_higher_rank_shapes() {
     assert_eq!(col_major_strides(&[2, 3, 4]).unwrap(), vec![1, 2, 6]);
     assert!(matches!(
         col_major_strides(&[usize::MAX, 2]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 
     let mut scalar_idx = [];
@@ -311,9 +348,11 @@ fn typed_tensor_try_into_rank_validates_rank() {
 
     assert!(matches!(
         err,
-        Error::RankMismatch {
-            expected: 3,
-            actual: 2,
+        Error::Validation {
+            source: ValidationError::RankMismatch {
+                expected: 3,
+                actual: 2,
+            },
             ..
         }
     ));
@@ -398,8 +437,9 @@ fn typed_tensor_view_as_slice_rejects_non_contiguous_layout() {
 
     assert!(matches!(
         err,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "TypedTensorView::as_slice",
+            source: ValidationError::InvalidArgument { .. },
             ..
         }
     ));
@@ -446,7 +486,7 @@ fn typed_tensor_backend_buffer_layout_length_mismatch_returns_error() {
     )
     .unwrap_err();
 
-    assert!(matches!(err, Error::InvalidConfig { .. }));
+    assert!(matches!(err, Error::Validation { .. }));
 }
 
 #[test]
@@ -481,7 +521,13 @@ fn tensor_owned_export_reports_dtype_mismatch() {
         .into_vec_col_major::<f32>()
         .unwrap_err();
 
-    assert!(matches!(err, Error::DTypeMismatch { .. }));
+    assert!(matches!(
+        err,
+        Error::Validation {
+            source: ValidationError::DTypeMismatch { .. },
+            ..
+        }
+    ));
 }
 
 #[test]
@@ -680,11 +726,14 @@ fn tensor_checked_accessors_are_typed_and_use_physical_order() {
     assert_eq!(tensor.get::<f64>(&[1, 2]).unwrap(), &6.0);
     assert!(matches!(
         tensor.get::<f32>(&[1, 2]),
-        Err(Error::DTypeMismatch { .. })
+        Err(Error::Validation {
+            source: ValidationError::DTypeMismatch { .. },
+            ..
+        })
     ));
     assert!(matches!(
         tensor.get::<f64>(&[2, 0]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 
     tensor.as_slice_mut::<f64>().unwrap()[0] = 10.0;
@@ -708,18 +757,21 @@ fn tensor_checked_accessors_are_typed_and_use_physical_order() {
 fn typed_tensor_accessors_report_length_and_indexing_errors() {
     assert!(matches!(
         TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 
     let tensor = TypedTensor::<f64>::zeros(vec![2, 3]).unwrap();
     assert!(matches!(
         tensor.linear_offset(&[0]),
-        Err(Error::RankMismatch { .. })
+        Err(Error::Validation {
+            source: ValidationError::RankMismatch { .. },
+            ..
+        })
     ));
 
     assert!(matches!(
         tensor.linear_offset(&[2, 0]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 }
 
@@ -727,19 +779,19 @@ fn typed_tensor_accessors_report_length_and_indexing_errors() {
 fn typed_tensor_apis_report_shape_arithmetic_errors() {
     assert!(matches!(
         TypedTensor::<f64>::from_vec_col_major(vec![usize::MAX, 2], Vec::new()),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
     assert!(matches!(
         TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
     assert!(matches!(
         TypedTensor::<f64>::zeros(vec![usize::MAX, 2]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
     assert!(matches!(
         TypedTensor::<f64>::ones(vec![usize::MAX, 2]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 
     let tensor = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![0.0; 6]).unwrap();
@@ -747,7 +799,7 @@ fn typed_tensor_apis_report_shape_arithmetic_errors() {
     assert_eq!(tensor.linear_offset(&[1, 2]).unwrap(), 5);
     assert!(matches!(
         tensor.linear_offset(&[2, 0]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 }
 
@@ -755,11 +807,11 @@ fn typed_tensor_apis_report_shape_arithmetic_errors() {
 fn tensor_constructors_report_shape_arithmetic_errors() {
     assert!(matches!(
         Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
     assert!(matches!(
         Tensor::from_vec_col_major(vec![usize::MAX, 2], Vec::<f64>::new()),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 }
 
@@ -770,22 +822,19 @@ fn typed_tensor_ranked_accessors_return_errors_instead_of_panicking() {
     assert_eq!(tensor.linear_offset2(1, 2).unwrap(), 5);
     assert!(matches!(
         tensor.linear_offset2(10, 0),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
-    assert!(matches!(
-        tensor.get2(10, 0),
-        Err(Error::InvalidConfig { .. })
-    ));
+    assert!(matches!(tensor.get2(10, 0), Err(Error::Validation { .. })));
 
     let rank3 = TypedTensor::<f64>::from_vec_col_major(vec![2, 3, 2], vec![0.0; 12]).unwrap();
     assert_eq!(rank3.linear_offset3(1, 2, 1).unwrap(), 11);
     assert!(matches!(
         rank3.linear_offset3(1, 2, 99),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
     assert!(matches!(
         rank3.get3(1, 2, 99),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 }
 
@@ -796,14 +845,14 @@ fn tensor_ranked_linear_offsets_return_errors_instead_of_panicking() {
     assert_eq!(tensor.linear_offset2(1, 2).unwrap(), 5);
     assert!(matches!(
         tensor.linear_offset2(10, 0),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 
     let rank3 = Tensor::from_vec_col_major(vec![2, 3, 2], vec![0.0_f64; 12]).unwrap();
     assert_eq!(rank3.linear_offset3(1, 2, 1).unwrap(), 11);
     assert!(matches!(
         rank3.linear_offset3(1, 2, 99),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 }
 
@@ -1013,7 +1062,7 @@ fn typed_tensor_view_validates_shape_and_exposes_slice() {
     assert_eq!(view.as_slice().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
 
     let err = TypedTensorView::from_col_major(&shape, &data[..3]).unwrap_err();
-    assert!(matches!(err, Error::InvalidConfig { .. }));
+    assert!(matches!(err, Error::Validation { .. }));
 }
 
 #[test]
@@ -1136,7 +1185,7 @@ fn strided_tensor_view_mut_rejects_aliasing_layouts() {
 
     let mut data = [1_i32, 2, 3, 4];
     let err = TypedTensorViewMut::from_slice([2, 2], [1, 1], 0, &mut data).unwrap_err();
-    assert!(matches!(err, Error::InvalidConfig { .. }));
+    assert!(matches!(err, Error::Validation { .. }));
 
     let mut data = [1_i32, 2];
     assert!(TypedTensorViewMut::from_slice([2], [0], 0, &mut data).is_err());
@@ -1240,20 +1289,23 @@ fn strided_tensor_view_validation_covers_error_edges() {
     assert_eq!(empty.get(&[0, 0]), None);
     assert!(matches!(
         TypedTensorView::<i32>::from_slice([0], [1], 4, &data),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 
     assert!(matches!(
         TypedTensorView::<i32>::from_slice([2], [1, 1], 0, &data),
-        Err(Error::RankMismatch { .. })
+        Err(Error::Validation {
+            source: ValidationError::RankMismatch { .. },
+            ..
+        })
     ));
     assert!(matches!(
         TypedTensorView::<i32>::from_slice([2], [-1], 0, &data[..1]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
     assert!(matches!(
         TypedTensorView::<i32>::from_slice([2], [2], 0, &data[..1]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 
     let view = TypedTensorView::from_slice([3], [1], 0, &data).unwrap();
@@ -1263,7 +1315,7 @@ fn strided_tensor_view_validation_covers_error_edges() {
 
     assert!(matches!(
         TypedTensorView::<i32>::from_slice([usize::MAX, 2], [1, 1], 0, &[]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
     assert!(matches!(
         TypedTensorView::<i32>::from_slice(
@@ -1272,18 +1324,18 @@ fn strided_tensor_view_validation_covers_error_edges() {
             0,
             &[7],
         ),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
     let empty_after_large_prefix =
         TypedTensorView::from_slice([2, usize::MAX, 0], [0, 0, 1], 0, &[7]).unwrap();
     assert_eq!(empty_after_large_prefix.n_elements(), 0);
     assert!(matches!(
         TypedTensorView::<i32>::from_slice([3], [isize::MAX], 0, &[]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
     assert!(matches!(
         TypedTensorView::<i32>::from_slice([2, 2], [isize::MAX, 1], 0, &[]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 }
 
@@ -1294,39 +1346,54 @@ fn typed_tensor_view_slice_transpose_and_reshape_cover_boundaries() {
 
     assert!(matches!(
         view.transpose_view([0]),
-        Err(Error::RankMismatch { .. })
+        Err(Error::Validation {
+            source: ValidationError::InvalidPermutationLength { .. },
+            ..
+        })
     ));
     assert!(matches!(
         view.transpose_view([2, 0]),
-        Err(Error::AxisOutOfBounds { .. })
+        Err(Error::Validation {
+            source: ValidationError::AxisOutOfBounds { .. },
+            ..
+        })
     ));
     assert!(matches!(
         view.transpose_view([0, 0]),
-        Err(Error::DuplicateAxis { .. })
+        Err(Error::Validation {
+            source: ValidationError::DuplicateAxis { .. },
+            ..
+        })
     ));
 
     assert!(matches!(
         view.try_slice(&[StridedSliceSpec::all()]),
-        Err(Error::RankMismatch { .. })
+        Err(Error::Validation {
+            source: ValidationError::RankMismatch { .. },
+            ..
+        })
     ));
     assert!(matches!(
         view.try_slice_axis(2, StridedSliceSpec::all()),
-        Err(Error::AxisOutOfBounds { .. })
+        Err(Error::Validation {
+            source: ValidationError::AxisOutOfBounds { .. },
+            ..
+        })
     ));
     assert!(matches!(
         view.try_slice(&[StridedSliceSpec::all(), StridedSliceSpec::new(0, None, 0)]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
     assert!(matches!(
         view.try_slice(&[StridedSliceSpec::all(), StridedSliceSpec::new(-4, None, 1)]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
     assert!(matches!(
         view.try_slice(&[
             StridedSliceSpec::all(),
             StridedSliceSpec::new(0, Some(4), 1)
         ]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 
     let empty = view
@@ -1337,11 +1404,11 @@ fn typed_tensor_view_slice_transpose_and_reshape_cover_boundaries() {
 
     assert!(matches!(
         view.try_reshape(&[5]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
     assert!(matches!(
         TypedTensorView::<i32>::from_col_major(&[isize::MAX as usize, 2, 2], &[]),
-        Err(Error::InvalidConfig { .. })
+        Err(Error::Validation { .. })
     ));
 
     let scalar = TypedTensorView::from_col_major(&[], &data[..1]).unwrap();
@@ -1760,11 +1827,10 @@ fn memory_kind_variants_are_constructible() {
 
 #[test]
 fn runtime_error_formats_include_op_name() {
-    let err = Error::AxisOutOfBounds {
-        op: "dot_general",
-        axis: 2,
-        rank: 1,
-    };
+    let err = Error::validation(
+        "dot_general",
+        ValidationError::AxisOutOfBounds { axis: 2, rank: 1 },
+    );
 
     assert!(err.to_string().contains("dot_general"));
 }

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -47,6 +47,23 @@ fn typed_backend_source_is_not_formatted_away() {
     assert!(err.source().is_some());
 }
 
+#[test]
+fn typed_io_source_is_not_classified_as_backend_failure() {
+    let err = Error::io_source("load", std::io::Error::other("file read failed"));
+    assert_eq!(err.kind(), ErrorKind::Io);
+    assert!(err.source().is_some());
+}
+
+#[test]
+fn runtime_state_source_is_not_classified_as_backend_failure() {
+    let err = Error::runtime_state_source(
+        "execute",
+        std::io::Error::other("executor state is unavailable"),
+    );
+    assert_eq!(err.kind(), ErrorKind::RuntimeState);
+    assert!(err.source().is_some());
+}
+
 #[derive(Debug)]
 struct NonCloneElement;
 

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -909,10 +909,11 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::InvalidPermutationLength`],
+    /// [`tenferro_tensor_core::ValidationError::AxisOutOfBounds`], or
+    /// [`tenferro_tensor_core::ValidationError::DuplicateAxis`] when `axes` is
+    /// not a valid permutation of the view rank.
     pub fn transpose_view(&self, axes: impl AsRef<[usize]>) -> crate::Result<Self> {
         let layout = self
             .layout
@@ -940,10 +941,15 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the slice
+    /// count differs from the view rank,
+    /// [`tenferro_tensor_core::ValidationError::InvalidSliceStep`] or
+    /// [`tenferro_tensor_core::ValidationError::InvalidSliceBounds`] for an
+    /// invalid slice, [`tenferro_tensor_core::ValidationError::IntegerOverflow`]
+    /// for slice arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// resulting layout exceeds the backing buffer.
     pub fn try_slice(&self, slices: &[StridedSliceSpec]) -> crate::Result<Self> {
         let specs = core_slice_specs(slices, self.shape(), "TypedTensorView::try_slice")?;
         let layout = self
@@ -971,10 +977,14 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::AxisOutOfBounds`] when `axis`
+    /// is outside the view rank, [`tenferro_tensor_core::ValidationError::InvalidSliceStep`]
+    /// or [`tenferro_tensor_core::ValidationError::InvalidSliceBounds`] for an
+    /// invalid slice, [`tenferro_tensor_core::ValidationError::IntegerOverflow`]
+    /// for slice arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// resulting layout exceeds the backing buffer.
     pub fn try_slice_axis(&self, axis: usize, slice: StridedSliceSpec) -> crate::Result<Self> {
         let slices = slice_axis_specs(
             self.shape().len(),
@@ -999,10 +1009,16 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::NonContiguousViewAsSlice`] when
+    /// the source is not compact column-major,
+    /// [`tenferro_tensor_core::ValidationError::ShapeMismatch`] (whose
+    /// [`tenferro_tensor_core::ShapeMismatch::ReshapeElementCount`] source
+    /// records the counts) when element counts differ,
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for shape
+    /// arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// reshaped view exceeds the backing buffer.
     pub fn try_reshape(&self, shape: &[usize]) -> crate::Result<TypedTensorView<'a, T, DynRank>> {
         let layout = reshape_layout_dyn(
             &self.layout,
@@ -1076,10 +1092,11 @@ impl<'a, T: 'static> TypedTensorViewMut<'a, T, DynRank> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for compact
+    /// shape or offset arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// compact shape reaches beyond `data`.
     pub fn from_col_major(shape: &[usize], data: &'a mut [T]) -> crate::Result<Self> {
         let layout = TensorLayout::<DynRank>::compact(shape.to_vec().into())
             .map_err(|err| tensor_layout_error("TypedTensorViewMut::from_col_major", err))?;
@@ -1108,10 +1125,15 @@ impl<'a, T: 'static> TypedTensorViewMut<'a, T, DynRank> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `shape` and
+    /// `strides` have different ranks,
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// layout reaches beyond `data`,
+    /// [`tenferro_tensor_core::ValidationError::OverlappingMutableLayout`] when
+    /// logical elements alias, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
+    /// arithmetic overflow.
     pub fn from_slice(
         shape: impl AsRef<[usize]>,
         strides: impl AsRef<[isize]>,
@@ -1144,10 +1166,15 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the typed
+    /// rank does not match `shape` or `strides`,
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// layout reaches beyond `data`,
+    /// [`tenferro_tensor_core::ValidationError::OverlappingMutableLayout`] when
+    /// logical elements alias, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
+    /// arithmetic overflow.
     pub fn from_slice_ranked(
         shape: impl Into<R::Shape>,
         strides: impl Into<R::Strides>,
@@ -1251,10 +1278,8 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::RuntimeState`] when this view wraps a backend
+    /// buffer; backend storage must be downloaded before host inspection.
     pub fn host_storage(&self) -> crate::Result<&[T]> {
         match &self.buffer {
             TensorBufferRefMut::Host(data) => Ok(data),
@@ -1284,10 +1309,8 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::RuntimeState`] when this view wraps a backend
+    /// buffer; backend storage must be downloaded before host inspection.
     pub fn host_storage_mut(&mut self) -> crate::Result<&mut [T]> {
         match &mut self.buffer {
             TensorBufferRefMut::Host(data) => Ok(data),
@@ -1391,10 +1414,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `indices`
+    /// has the wrong rank, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when an index is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when offset
+    /// arithmetic overflows.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         checked_view_offset_result(
             self.shape(),
@@ -1419,10 +1444,9 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         self.layout
             .is_compact_col_major()
@@ -1459,10 +1483,11 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows, or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] when the
+    /// view is not compact column-major.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         assert_layout_col_major_contiguous(
             self.is_col_major_contiguous()?,
@@ -1577,10 +1602,14 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::InvalidPermutationLength`],
+    /// [`tenferro_tensor_core::ValidationError::AxisOutOfBounds`], or
+    /// [`tenferro_tensor_core::ValidationError::DuplicateAxis`] when `axes` is
+    /// not a valid permutation, [`tenferro_tensor_core::ValidationError::OverlappingMutableLayout`]
+    /// when the permutation creates aliases, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
+    /// arithmetic overflow.
     pub fn transpose_view(
         self,
         axes: impl AsRef<[usize]>,
@@ -1625,10 +1654,17 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the slice
+    /// count differs from the view rank,
+    /// [`tenferro_tensor_core::ValidationError::InvalidSliceStep`] or
+    /// [`tenferro_tensor_core::ValidationError::InvalidSliceBounds`] for an
+    /// invalid slice, [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`]
+    /// when the result exceeds the backing buffer,
+    /// [`tenferro_tensor_core::ValidationError::OverlappingMutableLayout`] when
+    /// logical elements alias, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
+    /// arithmetic overflow.
     pub fn try_slice(
         &mut self,
         slices: &[StridedSliceSpec],
@@ -1670,10 +1706,16 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::AxisOutOfBounds`] when `axis`
+    /// is outside the view rank, [`tenferro_tensor_core::ValidationError::InvalidSliceStep`]
+    /// or [`tenferro_tensor_core::ValidationError::InvalidSliceBounds`] for an
+    /// invalid slice, [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`]
+    /// when the result exceeds the backing buffer,
+    /// [`tenferro_tensor_core::ValidationError::OverlappingMutableLayout`] when
+    /// logical elements alias, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
+    /// arithmetic overflow.
     pub fn try_slice_axis(
         &mut self,
         axis: usize,
@@ -1710,10 +1752,18 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] for either
+    /// slice count, [`tenferro_tensor_core::ValidationError::InvalidSliceStep`]
+    /// or [`tenferro_tensor_core::ValidationError::InvalidSliceBounds`] for
+    /// invalid parameters, [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`]
+    /// when a result exceeds the backing buffer,
+    /// [`tenferro_tensor_core::ValidationError::OverlappingMutableLayout`] when
+    /// a result aliases, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// for a negative reachable offset, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
+    /// arithmetic overflow. The method returns `Ok(None)` when the two ranges
+    /// overlap or the view uses backend storage.
     pub fn try_multi_slice_mut(
         &mut self,
         first: &[StridedSliceSpec],
@@ -1850,10 +1900,17 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::NonContiguousViewAsSlice`] when
+    /// the source is not compact column-major,
+    /// [`tenferro_tensor_core::ValidationError::ShapeMismatch`] (whose
+    /// [`tenferro_tensor_core::ShapeMismatch::ReshapeElementCount`] source
+    /// records the counts) when element counts differ,
+    /// [`tenferro_tensor_core::ValidationError::OverlappingMutableLayout`] when
+    /// the reshaped layout aliases, [`tenferro_tensor_core::ValidationError::IntegerOverflow`]
+    /// for shape or layout arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// reshaped view exceeds the backing buffer.
     pub fn try_reshape(
         &mut self,
         shape: &[usize],
@@ -1936,10 +1993,11 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// Wrap typed column-major data into a [`Tensor`] enum variant.
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::ShapeDataLengthMismatch`] when
+    /// the shape product differs from `data.len()`, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when shape
+    /// arithmetic overflows.
     fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> crate::Result<Tensor>;
 
     /// Wrap a typed tensor into its dynamic [`Tensor`] enum variant.
@@ -2022,10 +2080,11 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// Borrow the host data from a [`Tensor`].
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::DTypeMismatch`] when `tensor`
+    /// is not the scalar type represented by this implementation, or
+    /// [`crate::Error::RuntimeState`] when the matching tensor uses backend
+    /// storage that has not been downloaded.
     fn as_slice(tensor: &Tensor) -> crate::Result<&[Self]>;
 
     /// Mutably borrow the host data from a [`Tensor`].
@@ -2043,10 +2102,11 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::DTypeMismatch`] when `tensor`
+    /// is not the scalar type represented by this implementation, or
+    /// [`crate::Error::RuntimeState`] when the matching tensor uses backend
+    /// storage that has not been downloaded.
     fn as_slice_mut(tensor: &mut Tensor) -> crate::Result<&mut [Self]>;
 
     /// Extract a [`TypedTensor<Self>`] from a dynamic [`Tensor`].
@@ -2064,10 +2124,9 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::DTypeMismatch`] when `tensor`
+    /// is not the scalar type represented by this implementation.
     fn into_typed(tensor: Tensor) -> crate::Result<TypedTensor<Self>>;
 }
 
@@ -2438,10 +2497,13 @@ impl TensorOwnedView {
     /// Create an owned view with explicit layout metadata.
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `shape` and
+    /// `strides` have different ranks,
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// layout exceeds the base tensor buffer, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
+    /// arithmetic overflow.
     pub fn from_parts(
         base: Arc<Tensor>,
         shape: Vec<usize>,
@@ -2484,10 +2546,11 @@ impl TensorOwnedView {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::InvalidPermutationLength`],
+    /// [`tenferro_tensor_core::ValidationError::AxisOutOfBounds`], or
+    /// [`tenferro_tensor_core::ValidationError::DuplicateAxis`] when `axes` is
+    /// not a valid permutation of the view rank.
     pub fn transpose_view(&self, axes: impl AsRef<[usize]>) -> crate::Result<Self> {
         let layout = self
             .layout
@@ -2501,10 +2564,16 @@ impl TensorOwnedView {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::NonContiguousViewAsSlice`] when
+    /// the source is not compact column-major,
+    /// [`tenferro_tensor_core::ValidationError::ShapeMismatch`] (whose
+    /// [`tenferro_tensor_core::ShapeMismatch::ReshapeElementCount`] source
+    /// records the counts) when element counts differ,
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for shape
+    /// arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// reshaped view exceeds the base buffer.
     pub fn reshape_view(&self, shape: &[usize]) -> crate::Result<Self> {
         let layout = reshape_layout_dyn(
             &self.layout,
@@ -2520,10 +2589,17 @@ impl TensorOwnedView {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when a slice
+    /// vector does not match the view rank,
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] when a bound
+    /// or stride cannot be represented or is invalid,
+    /// [`tenferro_tensor_core::ValidationError::InvalidSliceStep`] or
+    /// [`tenferro_tensor_core::ValidationError::InvalidSliceBounds`] for slice
+    /// parameters, [`tenferro_tensor_core::ValidationError::IntegerOverflow`]
+    /// for slice arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// result exceeds the base buffer.
     pub fn slice_view(&self, config: &SliceConfig) -> crate::Result<Self> {
         let op = "TensorOwnedView::slice_view";
         if config.starts.len() != self.shape().len() {
@@ -2598,10 +2674,17 @@ impl TensorOwnedView {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`],
+    /// [`tenferro_tensor_core::ValidationError::AxisOutOfBounds`], or
+    /// [`tenferro_tensor_core::ValidationError::DuplicateAxis`] for invalid
+    /// dimension mappings,
+    /// [`tenferro_tensor_core::ValidationError::ShapeDataLengthMismatch`] for
+    /// incompatible extents,
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// result exceeds the base buffer, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
+    /// arithmetic overflow.
     pub fn broadcast_in_dim_view(&self, shape: &[usize], dims: &[usize]) -> crate::Result<Self> {
         let layout = self
             .layout
@@ -2657,10 +2740,11 @@ impl TensorValue {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::InvalidPermutationLength`],
+    /// [`tenferro_tensor_core::ValidationError::AxisOutOfBounds`], or
+    /// [`tenferro_tensor_core::ValidationError::DuplicateAxis`] when `axes` is
+    /// not a valid permutation of the value rank.
     pub fn transpose_view(&self, axes: impl AsRef<[usize]>) -> crate::Result<Self> {
         match self {
             Self::Tensor(tensor) => TensorOwnedView::from_tensor(Arc::clone(tensor))
@@ -2672,10 +2756,16 @@ impl TensorValue {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::NonContiguousViewAsSlice`] when
+    /// the source is not compact column-major,
+    /// [`tenferro_tensor_core::ValidationError::ShapeMismatch`] (whose
+    /// [`tenferro_tensor_core::ShapeMismatch::ReshapeElementCount`] source
+    /// records the counts) when element counts differ,
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for shape
+    /// arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// reshaped view exceeds the backing buffer.
     pub fn reshape_view(&self, shape: &[usize]) -> crate::Result<Self> {
         match self {
             Self::Tensor(tensor) => TensorOwnedView::from_tensor(Arc::clone(tensor))
@@ -2687,10 +2777,17 @@ impl TensorValue {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when a slice
+    /// vector does not match the value rank,
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] when a bound
+    /// or stride cannot be represented or is invalid,
+    /// [`tenferro_tensor_core::ValidationError::InvalidSliceStep`] or
+    /// [`tenferro_tensor_core::ValidationError::InvalidSliceBounds`] for slice
+    /// parameters, [`tenferro_tensor_core::ValidationError::IntegerOverflow`]
+    /// for slice arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// result exceeds the backing buffer.
     pub fn slice_view(&self, config: &SliceConfig) -> crate::Result<Self> {
         match self {
             Self::Tensor(tensor) => TensorOwnedView::from_tensor(Arc::clone(tensor))
@@ -2702,10 +2799,17 @@ impl TensorValue {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`],
+    /// [`tenferro_tensor_core::ValidationError::AxisOutOfBounds`], or
+    /// [`tenferro_tensor_core::ValidationError::DuplicateAxis`] for invalid
+    /// dimension mappings,
+    /// [`tenferro_tensor_core::ValidationError::ShapeDataLengthMismatch`] for
+    /// incompatible extents,
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// result exceeds the backing buffer, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
+    /// arithmetic overflow.
     pub fn broadcast_in_dim_view(&self, shape: &[usize], dims: &[usize]) -> crate::Result<Self> {
         match self {
             Self::Tensor(tensor) => TensorOwnedView::from_tensor(Arc::clone(tensor))
@@ -2921,10 +3025,11 @@ impl<'a> TensorView<'a> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for compact
+    /// shape or offset arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// compact shape reaches beyond `data`.
     pub fn f32(shape: &'a [usize], data: &'a [f32]) -> crate::Result<Self> {
         Ok(Self::F32(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -2943,10 +3048,11 @@ impl<'a> TensorView<'a> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for compact
+    /// shape or offset arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// compact shape reaches beyond `data`.
     pub fn f64(shape: &'a [usize], data: &'a [f64]) -> crate::Result<Self> {
         Ok(Self::F64(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -2965,10 +3071,11 @@ impl<'a> TensorView<'a> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for compact
+    /// shape or offset arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// compact shape reaches beyond `data`.
     pub fn i64(shape: &'a [usize], data: &'a [i64]) -> crate::Result<Self> {
         Ok(Self::I64(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -2987,10 +3094,11 @@ impl<'a> TensorView<'a> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for compact
+    /// shape or offset arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// compact shape reaches beyond `data`.
     pub fn i32(shape: &'a [usize], data: &'a [i32]) -> crate::Result<Self> {
         Ok(Self::I32(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -3009,10 +3117,11 @@ impl<'a> TensorView<'a> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for compact
+    /// shape or offset arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// compact shape reaches beyond `data`.
     pub fn bool(shape: &'a [usize], data: &'a [bool]) -> crate::Result<Self> {
         Ok(Self::Bool(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -3032,10 +3141,11 @@ impl<'a> TensorView<'a> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for compact
+    /// shape or offset arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// compact shape reaches beyond `data`.
     pub fn c32(shape: &'a [usize], data: &'a [Complex32]) -> crate::Result<Self> {
         Ok(Self::C32(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -3055,10 +3165,11 @@ impl<'a> TensorView<'a> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for compact
+    /// shape or offset arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// compact shape reaches beyond `data`.
     pub fn c64(shape: &'a [usize], data: &'a [Complex64]) -> crate::Result<Self> {
         Ok(Self::C64(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -3116,10 +3227,12 @@ impl<'a> TensorView<'a> {
     /// Compute the physical element offset for a logical index.
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `indices`
+    /// has the wrong rank, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when an index is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when offset
+    /// arithmetic overflows.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         match self {
             Self::F32(t) => t.layout_linear_offset(indices),
@@ -3135,10 +3248,9 @@ impl<'a> TensorView<'a> {
     /// Return whether this view is compact column-major.
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         match self {
             Self::F32(t) => t.is_col_major_contiguous(),
@@ -3159,10 +3271,11 @@ impl<'a> TensorView<'a> {
     /// Assert this view is compact column-major.
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows, or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] when the
+    /// view is not compact column-major.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         assert_layout_col_major_contiguous(
             self.is_col_major_contiguous()?,
@@ -3178,10 +3291,11 @@ impl<'a> TensorViewMut<'a> {
     /// Create a dynamic `f64` mutable view over compact column-major host data.
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for compact
+    /// shape or offset arithmetic overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// compact shape reaches beyond `data`.
     pub fn f64(shape: &'a [usize], data: &'a mut [f64]) -> crate::Result<Self> {
         Ok(Self::F64(TypedTensorViewMut::from_col_major(shape, data)?))
     }
@@ -3234,12 +3348,16 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
+    /// Compute the physical element offset for a logical index.
+    ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `indices`
+    /// has the wrong rank, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when an index is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when offset
+    /// arithmetic overflows.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         match self {
             Self::F32(t) => t.layout_linear_offset(indices),
@@ -3252,12 +3370,13 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
+    /// Return whether this view is compact column-major.
+    ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         match self {
             Self::F32(t) => t.is_col_major_contiguous(),
@@ -3274,12 +3393,15 @@ impl<'a> TensorViewMut<'a> {
         layout_summary(self.shape(), self.strides(), self.offset())
     }
 
+    /// Assert this view is compact column-major.
+    ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows, or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] when the
+    /// view is not compact column-major.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         assert_layout_col_major_contiguous(
             self.is_col_major_contiguous()?,
@@ -3328,10 +3450,9 @@ impl<'a> TensorRead<'a> {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// column-major stride arithmetic overflows.
     pub fn strides(&self) -> crate::Result<Vec<isize>> {
         match self {
             Self::Tensor(tensor) => col_major_strides(tensor.shape()),
@@ -3348,10 +3469,12 @@ impl<'a> TensorRead<'a> {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `indices`
+    /// has the wrong rank, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when an index is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when offset
+    /// arithmetic overflows.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         match self {
             Self::Tensor(tensor) => tensor.layout_linear_offset(indices),
@@ -3361,10 +3484,9 @@ impl<'a> TensorRead<'a> {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         match self {
             Self::Tensor(tensor) => tensor.is_col_major_contiguous(),
@@ -3382,10 +3504,11 @@ impl<'a> TensorRead<'a> {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows, or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] when the
+    /// view is not compact column-major.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         let strides = self.strides()?;
         assert_layout_col_major_contiguous(
@@ -3454,10 +3577,9 @@ impl<'a> TensorWrite<'a> {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// column-major stride arithmetic overflows.
     pub fn strides(&self) -> crate::Result<Vec<isize>> {
         match self {
             Self::Tensor(tensor) => col_major_strides(tensor.shape()),
@@ -3474,10 +3596,12 @@ impl<'a> TensorWrite<'a> {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `indices`
+    /// has the wrong rank, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when an index is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when offset
+    /// arithmetic overflows.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         match self {
             Self::Tensor(tensor) => tensor.layout_linear_offset(indices),
@@ -3487,10 +3611,9 @@ impl<'a> TensorWrite<'a> {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         match self {
             Self::Tensor(tensor) => tensor.is_col_major_contiguous(),
@@ -3508,10 +3631,11 @@ impl<'a> TensorWrite<'a> {
 
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows, or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] when the
+    /// view is not compact column-major.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         let strides = self.strides()?;
         assert_layout_col_major_contiguous(
@@ -3536,10 +3660,9 @@ impl<'a> TensorWrite<'a> {
 /// ```
 /// # Errors
 ///
-/// Returns [`crate::Error::Validation`] with a typed validation source for
-/// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-/// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-/// when the requested host or backend storage access is unavailable.
+/// Returns [`crate::Error::Validation`] with
+/// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when a
+/// column-major stride product overflows.
 pub fn col_major_strides(shape: &[usize]) -> crate::Result<Vec<isize>> {
     let mut strides = Vec::with_capacity(shape.len());
     let mut stride = 1isize;
@@ -4134,10 +4257,9 @@ impl<T: Clone + Zero, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when shape
+    /// product or compact-stride arithmetic overflows.
     pub fn zeros(shape: impl Into<R::Shape>) -> crate::Result<Self> {
         typed_tensor_zeros(shape)
     }
@@ -4156,10 +4278,9 @@ impl<T: Clone + One + Zero, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when shape
+    /// product or compact-stride arithmetic overflows.
     pub fn ones(shape: impl Into<R::Shape>) -> crate::Result<Self> {
         typed_tensor_ones(shape)
     }
@@ -4189,10 +4310,13 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::ShapeDataLengthMismatch`] when
+    /// the shape product differs from the buffer length,
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when shape or
+    /// stride arithmetic overflows, or
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when a supplied
+    /// rank-specific shape cannot be represented.
     pub fn from_buffer_col_major(
         shape: impl Into<R::Shape>,
         buffer: Buffer<T>,
@@ -4221,10 +4345,13 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the typed
+    /// rank does not match the existing shape,
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when compact
+    /// strides cannot be computed, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// preserved buffer cannot hold the rank-converted layout.
     pub fn try_into_rank<const N: usize>(self) -> crate::Result<TypedTensor<T, Rank<N>>> {
         let op = "TypedTensor::try_into_rank";
         let shape = <Rank<N> as TensorRank>::shape_from_vec(self.shape().to_vec().into())
@@ -4427,10 +4554,14 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::RuntimeState`] when this tensor is host-backed;
+    /// backend region views require a backend buffer. It returns
+    /// [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] for incompatible
+    /// shape/stride ranks, [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`]
+    /// when the region exceeds the backend buffer, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
+    /// arithmetic overflow.
     pub fn backend_region_view(
         &self,
         shape: Vec<usize>,
@@ -4485,10 +4616,16 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::RuntimeState`] when this tensor is host-backed;
+    /// mutable backend region views require a backend buffer. It returns
+    /// [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] for incompatible
+    /// shape/stride ranks, [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`]
+    /// when the region exceeds the backend buffer,
+    /// [`tenferro_tensor_core::ValidationError::OverlappingMutableLayout`] when
+    /// logical elements alias, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
+    /// arithmetic overflow.
     pub fn backend_region_view_mut(
         &mut self,
         shape: Vec<usize>,
@@ -4564,10 +4701,11 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::ShapeDataLengthMismatch`] when
+    /// the shape product differs from `data.len()`, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when shape
+    /// arithmetic overflows.
     pub fn from_vec_col_major(shape: impl Into<R::Shape>, data: Vec<T>) -> crate::Result<Self> {
         typed_tensor_from_vec_col_major(shape, data, "from_vec_col_major")
     }
@@ -4586,10 +4724,8 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::RuntimeState`] when this tensor uses backend
+    /// storage; download it before exporting a host `Vec`.
     pub fn into_vec_col_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
         let shape = self.shape().to_vec();
         match self.buffer {
@@ -4614,10 +4750,8 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::RuntimeState`] when this tensor uses backend
+    /// storage; download it before borrowing host data.
     pub fn host_data(&self) -> crate::Result<&[T]> {
         match &self.buffer {
             Buffer::Host(v) => Ok(v),
@@ -4644,10 +4778,8 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::RuntimeState`] when this tensor uses backend
+    /// storage; download it before borrowing it as a host slice.
     pub fn as_slice(&self) -> crate::Result<&[T]> {
         self.host_data()
     }
@@ -4666,10 +4798,8 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::RuntimeState`] when this tensor uses backend
+    /// storage; download it before mutably borrowing host data.
     pub fn host_data_mut(&mut self) -> crate::Result<&mut [T]> {
         match &mut self.buffer {
             Buffer::Host(v) => Ok(v),
@@ -4693,10 +4823,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `indices`
+    /// has the wrong rank, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when an index is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when offset
+    /// arithmetic overflows.
     pub fn linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), indices, "TypedTensor::linear_offset")
     }
@@ -4714,10 +4846,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `indices`
+    /// has the wrong rank, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when an index is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when offset
+    /// arithmetic overflows.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), indices, "TypedTensor::layout_linear_offset")
     }
@@ -4735,10 +4869,9 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         self.layout
             .is_compact_col_major()
@@ -4773,10 +4906,11 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows, or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] when the
+    /// tensor is not compact column-major.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         assert_layout_col_major_contiguous(
             self.is_col_major_contiguous()?,
@@ -4800,10 +4934,13 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `indices`
+    /// has the wrong rank, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when an index is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// computed offset is outside the host buffer. It returns
+    /// [`crate::Error::RuntimeState`] when the tensor uses backend storage.
     pub fn get(&self, indices: &[usize]) -> crate::Result<&T> {
         let off = self.linear_offset(indices)?;
         self.host_data()?.get(off).ok_or_else(|| {
@@ -4825,10 +4962,13 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `indices`
+    /// has the wrong rank, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when an index is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// computed offset is outside the host buffer. It returns
+    /// [`crate::Error::RuntimeState`] when the tensor uses backend storage.
     pub fn get_mut(&mut self, indices: &[usize]) -> crate::Result<&mut T> {
         let off = self.linear_offset(indices)?;
         self.host_data_mut()?.get_mut(off).ok_or_else(|| {
@@ -4854,10 +4994,11 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::ShapeDataLengthMismatch`] when
+    /// the shape product differs from `data.len()`, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when shape
+    /// arithmetic overflows.
     pub fn from_vec_col_major<T: TensorScalar>(
         shape: Vec<usize>,
         data: Vec<T>,
@@ -4966,10 +5107,12 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `indices`
+    /// has the wrong rank, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when an index is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when offset
+    /// arithmetic overflows.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         match self {
             Tensor::F32(t) => t.layout_linear_offset(indices),
@@ -4995,10 +5138,9 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         match self {
             Tensor::F32(t) => t.is_col_major_contiguous(),
@@ -5040,10 +5182,11 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows, or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] when the
+    /// tensor is not compact column-major.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         let layout = tensor_layout(self);
         assert_layout_col_major_contiguous(
@@ -5070,10 +5213,10 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::DTypeMismatch`] when `T` does
+    /// not match the tensor dtype, or [`crate::Error::RuntimeState`] when the
+    /// matching tensor uses backend storage that has not been downloaded.
     pub fn as_slice<T: TensorScalar>(&self) -> crate::Result<&[T]> {
         T::as_slice(self)
     }
@@ -5091,10 +5234,10 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::DTypeMismatch`] when `T` does
+    /// not match the tensor dtype, or [`crate::Error::RuntimeState`] when the
+    /// matching tensor uses backend storage that has not been downloaded.
     pub fn into_vec_col_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
         let typed = T::into_typed(self)?;
         typed.into_vec_col_major()

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -5,8 +5,8 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::config::SliceConfig;
-use tenferro_tensor_core::SliceSpec as CoreSliceSpec;
 pub use tenferro_tensor_core::{DynRank, Rank, TensorLayout, TensorRank};
+use tenferro_tensor_core::{SliceSpec as CoreSliceSpec, ValidationError};
 
 mod accessors;
 mod shape_packing;
@@ -460,6 +460,12 @@ impl<'a, T: 'static> TypedTensorView<'a, T, DynRank> {
     /// assert_eq!(view.strides(), &[1, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn from_col_major(shape: &[usize], data: &'a [T]) -> crate::Result<Self> {
         let layout = TensorLayout::<DynRank>::compact(shape.to_vec().into())
             .map_err(|err| tensor_layout_error("TypedTensorView::from_col_major", err))?;
@@ -485,6 +491,12 @@ impl<'a, T: 'static> TypedTensorView<'a, T, DynRank> {
     /// assert_eq!(view.get(&[2]), Some(&1));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn from_slice(
         shape: impl AsRef<[usize]>,
         strides: impl AsRef<[isize]>,
@@ -515,6 +527,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert_eq!(view.get(&[1, 1]), Some(&4));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn from_slice_ranked(
         shape: impl Into<R::Shape>,
         strides: impl Into<R::Strides>,
@@ -612,6 +630,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert_eq!(view.host_storage()?, &[1, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn host_storage(&self) -> crate::Result<&'a [T]> {
         match &self.buffer {
             TensorBufferRef::Host(data) => Ok(data),
@@ -713,6 +737,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert_eq!(view.layout_linear_offset(&[2])?, 0);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         checked_view_offset_result(
             self.shape(),
@@ -735,6 +765,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert!(view.is_col_major_contiguous()?);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         self.layout
             .is_compact_col_major()
@@ -769,6 +805,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// view.assert_col_major_contiguous()?;
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         assert_layout_col_major_contiguous(
             self.is_col_major_contiguous()?,
@@ -816,6 +858,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert_eq!(view.as_slice()?, &[2, 3]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn as_slice(&self) -> crate::Result<&'a [T]> {
         let data =
             match &self.buffer {
@@ -841,6 +889,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert_eq!(transposed.shape(), &[3, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn transpose_view(&self, axes: impl AsRef<[usize]>) -> crate::Result<Self> {
         let layout = self
             .layout
@@ -866,6 +920,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert_eq!(reversed.get(&[0]), Some(&3));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn try_slice(&self, slices: &[StridedSliceSpec]) -> crate::Result<Self> {
         let specs = core_slice_specs(slices, self.shape(), "TypedTensorView::try_slice")?;
         let layout = self
@@ -891,6 +951,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert_eq!(view.try_slice_axis(1, StridedSliceSpec::reverse())?.get(&[0, 0]), Some(&3));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn try_slice_axis(&self, axis: usize, slice: StridedSliceSpec) -> crate::Result<Self> {
         let slices = slice_axis_specs(
             self.shape().len(),
@@ -913,6 +979,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert_eq!(view.try_reshape(&[4])?.shape(), &[4]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn try_reshape(&self, shape: &[usize]) -> crate::Result<TypedTensorView<'a, T, DynRank>> {
         let layout = reshape_layout_dyn(
             &self.layout,
@@ -984,6 +1056,12 @@ impl<'a, T: 'static> TypedTensorViewMut<'a, T, DynRank> {
     /// assert_eq!(view.strides(), &[1, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn from_col_major(shape: &[usize], data: &'a mut [T]) -> crate::Result<Self> {
         let layout = TensorLayout::<DynRank>::compact(shape.to_vec().into())
             .map_err(|err| tensor_layout_error("TypedTensorViewMut::from_col_major", err))?;
@@ -1010,6 +1088,12 @@ impl<'a, T: 'static> TypedTensorViewMut<'a, T, DynRank> {
     /// let mut data = [1_i32, 2];
     /// assert!(TypedTensorViewMut::from_slice(vec![2], vec![0], 0, &mut data).is_err());
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn from_slice(
         shape: impl AsRef<[usize]>,
         strides: impl AsRef<[isize]>,
@@ -1040,6 +1124,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// assert_eq!(view.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn from_slice_ranked(
         shape: impl Into<R::Shape>,
         strides: impl Into<R::Strides>,
@@ -1141,6 +1231,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// assert_eq!(view.host_storage()?, &[1, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn host_storage(&self) -> crate::Result<&[T]> {
         match &self.buffer {
             TensorBufferRefMut::Host(data) => Ok(data),
@@ -1168,6 +1264,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// assert_eq!(view.get(&[0]), Some(&3));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn host_storage_mut(&mut self) -> crate::Result<&mut [T]> {
         match &mut self.buffer {
             TensorBufferRefMut::Host(data) => Ok(data),
@@ -1269,6 +1371,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// assert_eq!(view.layout_linear_offset(&[2])?, 0);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         checked_view_offset_result(
             self.shape(),
@@ -1291,6 +1399,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// assert!(view.is_col_major_contiguous()?);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         self.layout
             .is_compact_col_major()
@@ -1325,6 +1439,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// view.assert_col_major_contiguous()?;
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         assert_layout_col_major_contiguous(
             self.is_col_major_contiguous()?,
@@ -1437,6 +1557,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// assert_eq!(transposed.strides(), &[2, 1]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn transpose_view(
         self,
         axes: impl AsRef<[usize]>,
@@ -1479,6 +1605,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// assert_eq!(view.get(&[2]), Some(&30));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn try_slice(
         &mut self,
         slices: &[StridedSliceSpec],
@@ -1518,6 +1650,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// assert_eq!(view.try_slice_axis(1, StridedSliceSpec::reverse())?.get(&[0, 0]), Some(&3));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn try_slice_axis(
         &mut self,
         axis: usize,
@@ -1552,6 +1690,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// assert_eq!(right.shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn try_multi_slice_mut(
         &mut self,
         first: &[StridedSliceSpec],
@@ -1686,6 +1830,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     /// assert_eq!(view.try_reshape(&[4])?.shape(), &[4]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn try_reshape(
         &mut self,
         shape: &[usize],
@@ -1766,6 +1916,12 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     fn dtype() -> DType;
 
     /// Wrap typed column-major data into a [`Tensor`] enum variant.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     fn into_tensor(shape: Vec<usize>, data: Vec<Self>) -> crate::Result<Tensor>;
 
     /// Wrap a typed tensor into its dynamic [`Tensor`] enum variant.
@@ -1846,6 +2002,12 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     fn tensor_write(tensor: &mut TypedTensor<Self>) -> TensorWrite<'_>;
 
     /// Borrow the host data from a [`Tensor`].
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     fn as_slice(tensor: &Tensor) -> crate::Result<&[Self]>;
 
     /// Mutably borrow the host data from a [`Tensor`].
@@ -1861,6 +2023,12 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// assert_eq!(tensor.as_slice::<f64>()?, &[3.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     fn as_slice_mut(tensor: &mut Tensor) -> crate::Result<&mut [Self]>;
 
     /// Extract a [`TypedTensor<Self>`] from a dynamic [`Tensor`].
@@ -1876,6 +2044,12 @@ pub trait TensorScalar: Copy + Clone + Send + Sync + 'static + private::Sealed {
     /// assert_eq!(typed.as_slice()?, &[1.0, 2.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     fn into_typed(tensor: Tensor) -> crate::Result<TypedTensor<Self>>;
 }
 
@@ -1928,11 +2102,13 @@ macro_rules! impl_tensor_scalar {
                 let actual = tensor.dtype();
                 match tensor {
                     Tensor::$variant(t) => t.host_data(),
-                    _ => Err(crate::Error::DTypeMismatch {
-                        op: "Tensor::as_slice",
-                        lhs: Self::dtype(),
-                        rhs: actual,
-                    }),
+                    _ => Err(crate::Error::validation(
+                        "Tensor::as_slice",
+                        ValidationError::DTypeMismatch {
+                            expected: crate::core_dtype(Self::dtype()),
+                            actual: crate::core_dtype(actual),
+                        },
+                    )),
                 }
             }
 
@@ -1940,11 +2116,13 @@ macro_rules! impl_tensor_scalar {
                 let actual = tensor.dtype();
                 match tensor {
                     Tensor::$variant(t) => t.host_data_mut(),
-                    _ => Err(crate::Error::DTypeMismatch {
-                        op: "Tensor::as_slice_mut",
-                        lhs: Self::dtype(),
-                        rhs: actual,
-                    }),
+                    _ => Err(crate::Error::validation(
+                        "Tensor::as_slice_mut",
+                        ValidationError::DTypeMismatch {
+                            expected: crate::core_dtype(Self::dtype()),
+                            actual: crate::core_dtype(actual),
+                        },
+                    )),
                 }
             }
 
@@ -1952,11 +2130,13 @@ macro_rules! impl_tensor_scalar {
                 let actual = tensor.dtype();
                 match tensor {
                     Tensor::$variant(inner) => Ok(inner),
-                    _ => Err(crate::Error::DTypeMismatch {
-                        op: "TensorScalar::into_typed",
-                        lhs: Self::dtype(),
-                        rhs: actual,
-                    }),
+                    _ => Err(crate::Error::validation(
+                        "TensorScalar::into_typed",
+                        ValidationError::DTypeMismatch {
+                            expected: crate::core_dtype(Self::dtype()),
+                            actual: crate::core_dtype(actual),
+                        },
+                    )),
                 }
             }
         }
@@ -2238,6 +2418,12 @@ impl TensorOwnedView {
     }
 
     /// Create an owned view with explicit layout metadata.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn from_parts(
         base: Arc<Tensor>,
         shape: Vec<usize>,
@@ -2278,6 +2464,12 @@ impl TensorOwnedView {
         TensorRead::from_view(self.tensor_view())
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn transpose_view(&self, axes: impl AsRef<[usize]>) -> crate::Result<Self> {
         let layout = self
             .layout
@@ -2289,6 +2481,12 @@ impl TensorOwnedView {
         })
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn reshape_view(&self, shape: &[usize]) -> crate::Result<Self> {
         let layout = reshape_layout_dyn(
             &self.layout,
@@ -2302,28 +2500,40 @@ impl TensorOwnedView {
         })
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn slice_view(&self, config: &SliceConfig) -> crate::Result<Self> {
         let op = "TensorOwnedView::slice_view";
         if config.starts.len() != self.shape().len() {
-            return Err(crate::Error::RankMismatch {
+            return Err(crate::Error::validation(
                 op,
-                expected: self.shape().len(),
-                actual: config.starts.len(),
-            });
+                ValidationError::RankMismatch {
+                    expected: self.shape().len(),
+                    actual: config.starts.len(),
+                },
+            ));
         }
         if config.limits.len() != self.shape().len() {
-            return Err(crate::Error::RankMismatch {
+            return Err(crate::Error::validation(
                 op,
-                expected: self.shape().len(),
-                actual: config.limits.len(),
-            });
+                ValidationError::RankMismatch {
+                    expected: self.shape().len(),
+                    actual: config.limits.len(),
+                },
+            ));
         }
         if config.strides.len() != self.shape().len() {
-            return Err(crate::Error::RankMismatch {
+            return Err(crate::Error::validation(
                 op,
-                expected: self.shape().len(),
-                actual: config.strides.len(),
-            });
+                ValidationError::RankMismatch {
+                    expected: self.shape().len(),
+                    actual: config.strides.len(),
+                },
+            ));
         }
 
         let mut slices = Vec::with_capacity(self.shape().len());
@@ -2333,17 +2543,26 @@ impl TensorOwnedView {
             .zip(config.limits.iter())
             .zip(config.strides.iter())
         {
-            let start = isize::try_from(start).map_err(|_| crate::Error::InvalidConfig {
-                op,
-                message: format!("slice start {start} does not fit in isize"),
+            let start = isize::try_from(start).map_err(|_| {
+                crate::Error::invalid_argument(
+                    op,
+                    "slice start",
+                    format!("slice start {start} does not fit in isize"),
+                )
             })?;
-            let limit = isize::try_from(limit).map_err(|_| crate::Error::InvalidConfig {
-                op,
-                message: format!("slice limit {limit} does not fit in isize"),
+            let limit = isize::try_from(limit).map_err(|_| {
+                crate::Error::invalid_argument(
+                    op,
+                    "slice limit",
+                    format!("slice limit {limit} does not fit in isize"),
+                )
             })?;
-            let stride = isize::try_from(stride).map_err(|_| crate::Error::InvalidConfig {
-                op,
-                message: format!("slice stride {stride} does not fit in isize"),
+            let stride = isize::try_from(stride).map_err(|_| {
+                crate::Error::invalid_argument(
+                    op,
+                    "slice stride",
+                    format!("slice stride {stride} does not fit in isize"),
+                )
             })?;
             slices.push(StridedSliceSpec::new(start, Some(limit), stride));
         }
@@ -2359,6 +2578,12 @@ impl TensorOwnedView {
         })
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn broadcast_in_dim_view(&self, shape: &[usize], dims: &[usize]) -> crate::Result<Self> {
         let layout = self
             .layout
@@ -2412,6 +2637,12 @@ impl TensorValue {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn transpose_view(&self, axes: impl AsRef<[usize]>) -> crate::Result<Self> {
         match self {
             Self::Tensor(tensor) => TensorOwnedView::from_tensor(Arc::clone(tensor))
@@ -2421,6 +2652,12 @@ impl TensorValue {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn reshape_view(&self, shape: &[usize]) -> crate::Result<Self> {
         match self {
             Self::Tensor(tensor) => TensorOwnedView::from_tensor(Arc::clone(tensor))
@@ -2430,6 +2667,12 @@ impl TensorValue {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn slice_view(&self, config: &SliceConfig) -> crate::Result<Self> {
         match self {
             Self::Tensor(tensor) => TensorOwnedView::from_tensor(Arc::clone(tensor))
@@ -2439,6 +2682,12 @@ impl TensorValue {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn broadcast_in_dim_view(&self, shape: &[usize], dims: &[usize]) -> crate::Result<Self> {
         match self {
             Self::Tensor(tensor) => TensorOwnedView::from_tensor(Arc::clone(tensor))
@@ -2652,6 +2901,12 @@ impl<'a> TensorView<'a> {
     /// assert_eq!(view.dtype(), DType::F32);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn f32(shape: &'a [usize], data: &'a [f32]) -> crate::Result<Self> {
         Ok(Self::F32(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -2668,6 +2923,12 @@ impl<'a> TensorView<'a> {
     /// assert_eq!(view.dtype(), DType::F64);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn f64(shape: &'a [usize], data: &'a [f64]) -> crate::Result<Self> {
         Ok(Self::F64(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -2684,6 +2945,12 @@ impl<'a> TensorView<'a> {
     /// assert_eq!(view.dtype(), DType::I64);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn i64(shape: &'a [usize], data: &'a [i64]) -> crate::Result<Self> {
         Ok(Self::I64(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -2700,6 +2967,12 @@ impl<'a> TensorView<'a> {
     /// assert_eq!(view.dtype(), DType::I32);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn i32(shape: &'a [usize], data: &'a [i32]) -> crate::Result<Self> {
         Ok(Self::I32(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -2716,6 +2989,12 @@ impl<'a> TensorView<'a> {
     /// assert_eq!(view.dtype(), DType::Bool);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn bool(shape: &'a [usize], data: &'a [bool]) -> crate::Result<Self> {
         Ok(Self::Bool(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -2733,6 +3012,12 @@ impl<'a> TensorView<'a> {
     /// assert_eq!(view.dtype(), DType::C32);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn c32(shape: &'a [usize], data: &'a [Complex32]) -> crate::Result<Self> {
         Ok(Self::C32(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -2750,6 +3035,12 @@ impl<'a> TensorView<'a> {
     /// assert_eq!(view.dtype(), DType::C64);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn c64(shape: &'a [usize], data: &'a [Complex64]) -> crate::Result<Self> {
         Ok(Self::C64(TypedTensorView::from_col_major(shape, data)?))
     }
@@ -2805,6 +3096,12 @@ impl<'a> TensorView<'a> {
     }
 
     /// Compute the physical element offset for a logical index.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         match self {
             Self::F32(t) => t.layout_linear_offset(indices),
@@ -2818,6 +3115,12 @@ impl<'a> TensorView<'a> {
     }
 
     /// Return whether this view is compact column-major.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         match self {
             Self::F32(t) => t.is_col_major_contiguous(),
@@ -2836,6 +3139,12 @@ impl<'a> TensorView<'a> {
     }
 
     /// Assert this view is compact column-major.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         assert_layout_col_major_contiguous(
             self.is_col_major_contiguous()?,
@@ -2849,6 +3158,12 @@ impl<'a> TensorView<'a> {
 
 impl<'a> TensorViewMut<'a> {
     /// Create a dynamic `f64` mutable view over compact column-major host data.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn f64(shape: &'a [usize], data: &'a mut [f64]) -> crate::Result<Self> {
         Ok(Self::F64(TypedTensorViewMut::from_col_major(shape, data)?))
     }
@@ -2901,6 +3216,12 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         match self {
             Self::F32(t) => t.layout_linear_offset(indices),
@@ -2913,6 +3234,12 @@ impl<'a> TensorViewMut<'a> {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         match self {
             Self::F32(t) => t.is_col_major_contiguous(),
@@ -2929,6 +3256,12 @@ impl<'a> TensorViewMut<'a> {
         layout_summary(self.shape(), self.strides(), self.offset())
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         assert_layout_col_major_contiguous(
             self.is_col_major_contiguous()?,
@@ -2975,6 +3308,12 @@ impl<'a> TensorRead<'a> {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn strides(&self) -> crate::Result<Vec<isize>> {
         match self {
             Self::Tensor(tensor) => col_major_strides(tensor.shape()),
@@ -2989,6 +3328,12 @@ impl<'a> TensorRead<'a> {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         match self {
             Self::Tensor(tensor) => tensor.layout_linear_offset(indices),
@@ -2996,6 +3341,12 @@ impl<'a> TensorRead<'a> {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         match self {
             Self::Tensor(tensor) => tensor.is_col_major_contiguous(),
@@ -3011,6 +3362,12 @@ impl<'a> TensorRead<'a> {
         layout_summary(self.shape(), &strides, self.offset())
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         let strides = self.strides()?;
         assert_layout_col_major_contiguous(
@@ -3077,6 +3434,12 @@ impl<'a> TensorWrite<'a> {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn strides(&self) -> crate::Result<Vec<isize>> {
         match self {
             Self::Tensor(tensor) => col_major_strides(tensor.shape()),
@@ -3091,6 +3454,12 @@ impl<'a> TensorWrite<'a> {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         match self {
             Self::Tensor(tensor) => tensor.layout_linear_offset(indices),
@@ -3098,6 +3467,12 @@ impl<'a> TensorWrite<'a> {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         match self {
             Self::Tensor(tensor) => tensor.is_col_major_contiguous(),
@@ -3113,6 +3488,12 @@ impl<'a> TensorWrite<'a> {
         layout_summary(self.shape(), &strides, self.offset())
     }
 
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         let strides = self.strides()?;
         assert_layout_col_major_contiguous(
@@ -3135,21 +3516,23 @@ impl<'a> TensorWrite<'a> {
 /// assert_eq!(col_major_strides(&[2, 3])?, vec![1, 2]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with a typed validation source for
+/// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+/// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+/// when the requested host or backend storage access is unavailable.
 pub fn col_major_strides(shape: &[usize]) -> crate::Result<Vec<isize>> {
     let mut strides = Vec::with_capacity(shape.len());
     let mut stride = 1isize;
     for &extent in shape {
         strides.push(stride);
-        let extent = isize::try_from(extent).map_err(|_| crate::Error::InvalidConfig {
-            op: "col_major_strides",
-            message: format!("shape extent {extent} does not fit in isize"),
+        let extent = isize::try_from(extent).map_err(|_| {
+            crate::Error::validation("col_major_strides", ValidationError::IntegerOverflow)
         })?;
-        stride = stride
-            .checked_mul(extent)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "col_major_strides",
-                message: format!("column-major stride overflows for shape {shape:?}"),
-            })?;
+        stride = stride.checked_mul(extent).ok_or_else(|| {
+            crate::Error::validation("col_major_strides", ValidationError::IntegerOverflow)
+        })?;
     }
     Ok(strides)
 }
@@ -3160,39 +3543,33 @@ fn try_linear_offset_for_shape(
     op: &'static str,
 ) -> crate::Result<usize> {
     if indices.len() != shape.len() {
-        return Err(crate::Error::RankMismatch {
+        return Err(crate::Error::validation(
             op,
-            expected: shape.len(),
-            actual: indices.len(),
-        });
+            ValidationError::RankMismatch {
+                expected: shape.len(),
+                actual: indices.len(),
+            },
+        ));
     }
     let mut offset = 0usize;
     let mut stride = 1usize;
     for (axis, (&idx, &extent)) in indices.iter().zip(shape).enumerate() {
         if idx >= extent {
-            return Err(crate::Error::InvalidConfig {
+            return Err(crate::Error::invalid_argument(
                 op,
-                message: format!("index {idx} out of bounds for axis {axis} extent {extent}"),
-            });
+                "index",
+                format!("index {idx} out of bounds for axis {axis} extent {extent}"),
+            ));
         }
-        offset = offset
-            .checked_add(
-                idx.checked_mul(stride)
-                    .ok_or_else(|| crate::Error::InvalidConfig {
-                        op,
-                        message: "linear offset multiply overflows".to_string(),
-                    })?,
-            )
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op,
-                message: "linear offset add overflows".to_string(),
-            })?;
+        offset =
+            offset
+                .checked_add(idx.checked_mul(stride).ok_or_else(|| {
+                    crate::Error::validation(op, ValidationError::IntegerOverflow)
+                })?)
+                .ok_or_else(|| crate::Error::validation(op, ValidationError::IntegerOverflow))?;
         stride = stride
             .checked_mul(extent)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op,
-                message: "linear offset stride overflows".to_string(),
-            })?;
+            .ok_or_else(|| crate::Error::validation(op, ValidationError::IntegerOverflow))?;
     }
     Ok(offset)
 }
@@ -3205,28 +3582,25 @@ fn checked_view_offset_result(
     op: &'static str,
 ) -> crate::Result<usize> {
     if indices.len() != shape.len() {
-        return Err(crate::Error::RankMismatch {
+        return Err(crate::Error::validation(
             op,
-            expected: shape.len(),
-            actual: indices.len(),
-        });
+            ValidationError::RankMismatch {
+                expected: shape.len(),
+                actual: indices.len(),
+            },
+        ));
     }
     for (axis, (&index, &extent)) in indices.iter().zip(shape).enumerate() {
         if index >= extent {
-            return Err(crate::Error::InvalidConfig {
+            return Err(crate::Error::invalid_argument(
                 op,
-                message: format!("index {index} out of bounds for axis {axis} extent {extent}"),
-            });
+                "index",
+                format!("index {index} out of bounds for axis {axis} extent {extent}"),
+            ));
         }
     }
-    checked_view_offset(shape, strides, base_offset, indices).ok_or_else(|| {
-        crate::Error::InvalidConfig {
-            op,
-            message: format!(
-                "layout offset overflow for shape={shape:?} strides={strides:?} offset={base_offset} indices={indices:?}"
-            ),
-        }
-    })
+    checked_view_offset(shape, strides, base_offset, indices)
+        .ok_or_else(|| crate::Error::validation(op, ValidationError::IntegerOverflow))
 }
 
 fn layout_summary(shape: &[usize], strides: &[isize], offset: isize) -> String {
@@ -3243,33 +3617,34 @@ fn assert_layout_col_major_contiguous(
     if is_contiguous {
         Ok(())
     } else {
-        Err(crate::Error::InvalidConfig {
+        Err(crate::Error::invalid_argument(
             op,
-            message: format!(
+            "layout",
+            format!(
                 "expected compact column-major layout, got {}",
                 layout_summary(shape, strides, offset)
             ),
-        })
+        ))
     }
 }
 
 fn try_shape_product(shape: &[usize], op: &'static str) -> crate::Result<usize> {
     shape.iter().try_fold(1usize, |acc, &dim| {
         acc.checked_mul(dim)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op,
-                message: format!("shape product overflows for shape {shape:?}"),
-            })
+            .ok_or_else(|| crate::Error::validation(op, ValidationError::IntegerOverflow))
     })
 }
 
 fn try_checked_shape_len(shape: &[usize], data_len: usize, op: &'static str) -> crate::Result<()> {
     let n = try_shape_product(shape, op)?;
     if data_len != n {
-        return Err(crate::Error::InvalidConfig {
+        return Err(crate::Error::validation(
             op,
-            message: format!("data length {data_len} does not match shape product {n}"),
-        });
+            ValidationError::ShapeDataLengthMismatch {
+                expected: n,
+                actual: data_len,
+            },
+        ));
     }
     Ok(())
 }
@@ -3285,36 +3660,7 @@ fn tensor_layout_error(
     op: &'static str,
     err: tenferro_tensor_core::ValidationError,
 ) -> crate::Error {
-    match err {
-        tenferro_tensor_core::ValidationError::RankMismatch { expected, actual } => {
-            crate::Error::RankMismatch {
-                op,
-                expected,
-                actual,
-            }
-        }
-        tenferro_tensor_core::ValidationError::AxisOutOfBounds { axis, rank } => {
-            crate::Error::AxisOutOfBounds { op, axis, rank }
-        }
-        tenferro_tensor_core::ValidationError::DuplicateAxis { axis, .. } => {
-            crate::Error::DuplicateAxis {
-                op,
-                axis,
-                role: "permutation",
-            }
-        }
-        tenferro_tensor_core::ValidationError::InvalidPermutationLength { expected, actual } => {
-            crate::Error::RankMismatch {
-                op,
-                expected,
-                actual,
-            }
-        }
-        other => crate::Error::InvalidConfig {
-            op,
-            message: other.to_string(),
-        },
-    }
+    crate::Error::validation(op, err)
 }
 
 fn checked_view_element_count(shape: &[usize], op: &'static str) -> crate::Result<usize> {
@@ -3324,10 +3670,7 @@ fn checked_view_element_count(shape: &[usize], op: &'static str) -> crate::Resul
     shape.iter().try_fold(1usize, |product, &dim| {
         product
             .checked_mul(dim)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op,
-                message: format!("shape product overflows for shape {shape:?}"),
-            })
+            .ok_or_else(|| crate::Error::validation(op, ValidationError::IntegerOverflow))
     })
 }
 
@@ -3366,41 +3709,46 @@ fn reachable_layout_span(
     let mut min_offset = offset;
     let mut max_offset = offset;
     for (&extent, &stride) in shape.iter().zip(strides) {
-        let steps =
-            isize::try_from(extent.saturating_sub(1)).map_err(|_| crate::Error::InvalidConfig {
-                op: "TypedTensorViewMut::try_multi_slice_mut",
-                message: "shape extent does not fit in isize".to_string(),
-            })?;
-        let end = stride
-            .checked_mul(steps)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "TypedTensorViewMut::try_multi_slice_mut",
-                message: "stride span overflows".to_string(),
-            })?;
+        let steps = isize::try_from(extent.saturating_sub(1)).map_err(|_| {
+            crate::Error::validation(
+                "TypedTensorViewMut::try_multi_slice_mut",
+                ValidationError::IntegerOverflow,
+            )
+        })?;
+        let end = stride.checked_mul(steps).ok_or_else(|| {
+            crate::Error::validation(
+                "TypedTensorViewMut::try_multi_slice_mut",
+                ValidationError::IntegerOverflow,
+            )
+        })?;
         let (axis_min, axis_max) = if end < 0 { (end, 0) } else { (0, end) };
-        min_offset =
-            min_offset
-                .checked_add(axis_min)
-                .ok_or_else(|| crate::Error::InvalidConfig {
-                    op: "TypedTensorViewMut::try_multi_slice_mut",
-                    message: "minimum reachable offset overflows".to_string(),
-                })?;
-        max_offset =
-            max_offset
-                .checked_add(axis_max)
-                .ok_or_else(|| crate::Error::InvalidConfig {
-                    op: "TypedTensorViewMut::try_multi_slice_mut",
-                    message: "maximum reachable offset overflows".to_string(),
-                })?;
+        min_offset = min_offset.checked_add(axis_min).ok_or_else(|| {
+            crate::Error::validation(
+                "TypedTensorViewMut::try_multi_slice_mut",
+                ValidationError::IntegerOverflow,
+            )
+        })?;
+        max_offset = max_offset.checked_add(axis_max).ok_or_else(|| {
+            crate::Error::validation(
+                "TypedTensorViewMut::try_multi_slice_mut",
+                ValidationError::IntegerOverflow,
+            )
+        })?;
     }
 
-    let min_offset = usize::try_from(min_offset).map_err(|_| crate::Error::InvalidConfig {
-        op: "TypedTensorViewMut::try_multi_slice_mut",
-        message: "minimum reachable offset is negative".to_string(),
+    let min_offset = usize::try_from(min_offset).map_err(|_| {
+        crate::Error::invalid_argument(
+            "TypedTensorViewMut::try_multi_slice_mut",
+            "layout",
+            "minimum reachable offset is negative",
+        )
     })?;
-    let max_offset = usize::try_from(max_offset).map_err(|_| crate::Error::InvalidConfig {
-        op: "TypedTensorViewMut::try_multi_slice_mut",
-        message: "maximum reachable offset is negative".to_string(),
+    let max_offset = usize::try_from(max_offset).map_err(|_| {
+        crate::Error::invalid_argument(
+            "TypedTensorViewMut::try_multi_slice_mut",
+            "layout",
+            "maximum reachable offset is negative",
+        )
     })?;
     Ok(Some((min_offset, max_offset)))
 }
@@ -3428,16 +3776,18 @@ fn split_two_mut_ranges<T>(
 }
 
 fn adjusted_view_offset(offset: isize, span_start: usize) -> crate::Result<isize> {
-    let span_start = isize::try_from(span_start).map_err(|_| crate::Error::InvalidConfig {
-        op: "TypedTensorViewMut::try_multi_slice_mut",
-        message: "view span start does not fit in isize".to_string(),
+    let span_start = isize::try_from(span_start).map_err(|_| {
+        crate::Error::validation(
+            "TypedTensorViewMut::try_multi_slice_mut",
+            ValidationError::IntegerOverflow,
+        )
     })?;
-    offset
-        .checked_sub(span_start)
-        .ok_or_else(|| crate::Error::InvalidConfig {
-            op: "TypedTensorViewMut::try_multi_slice_mut",
-            message: "adjusted view offset overflows".to_string(),
-        })
+    offset.checked_sub(span_start).ok_or_else(|| {
+        crate::Error::validation(
+            "TypedTensorViewMut::try_multi_slice_mut",
+            ValidationError::IntegerOverflow,
+        )
+    })
 }
 
 fn view_mut_from_layout_and_slice<'a, T: 'static, R: TensorRank>(
@@ -3469,27 +3819,20 @@ fn contiguous_layout_slice<'a, T, R: TensorRank>(
         .is_compact_col_major()
         .map_err(|err| tensor_layout_error(op, err))?
     {
-        return Err(crate::Error::InvalidConfig {
+        return Err(crate::Error::invalid_argument(
             op,
-            message: "view is not contiguous column-major".to_string(),
-        });
+            "layout",
+            "view is not contiguous column-major",
+        ));
     }
     let len = checked_view_element_count(layout.shape(), op)?;
-    let start = usize::try_from(layout.offset()).map_err(|_| crate::Error::InvalidConfig {
-        op,
-        message: "view offset is negative".to_string(),
-    })?;
+    let start = usize::try_from(layout.offset())
+        .map_err(|_| crate::Error::invalid_argument(op, "layout", "view offset is negative"))?;
     let end = start
         .checked_add(len)
-        .ok_or_else(|| crate::Error::InvalidConfig {
-            op,
-            message: "contiguous view range overflows".to_string(),
-        })?;
+        .ok_or_else(|| crate::Error::validation(op, ValidationError::IntegerOverflow))?;
     data.get(start..end)
-        .ok_or_else(|| crate::Error::InvalidConfig {
-            op,
-            message: "contiguous view range is outside host buffer".to_string(),
-        })
+        .ok_or_else(|| crate::Error::validation(op, ValidationError::ViewOutOfBounds))
 }
 
 fn relaxed_col_major_contiguous(
@@ -3509,16 +3852,11 @@ fn relaxed_col_major_contiguous(
         if stride != expected {
             return Ok(false);
         }
-        let extent = isize::try_from(extent).map_err(|_| crate::Error::InvalidConfig {
-            op,
-            message: "shape extent does not fit in isize".to_string(),
-        })?;
+        let extent = isize::try_from(extent)
+            .map_err(|_| crate::Error::validation(op, ValidationError::IntegerOverflow))?;
         expected = expected
             .checked_mul(extent)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op,
-                message: "contiguous stride overflows".to_string(),
-            })?;
+            .ok_or_else(|| crate::Error::validation(op, ValidationError::IntegerOverflow))?;
     }
     Ok(true)
 }
@@ -3563,11 +3901,13 @@ fn core_slice_specs(
     op: &'static str,
 ) -> crate::Result<Vec<CoreSliceSpec>> {
     if slices.len() != shape.len() {
-        return Err(crate::Error::RankMismatch {
+        return Err(crate::Error::validation(
             op,
-            expected: shape.len(),
-            actual: slices.len(),
-        });
+            ValidationError::RankMismatch {
+                expected: shape.len(),
+                actual: slices.len(),
+            },
+        ));
     }
 
     let mut specs = Vec::with_capacity(slices.len());
@@ -3583,19 +3923,17 @@ fn core_slice_spec(
     op: &'static str,
 ) -> crate::Result<CoreSliceSpec> {
     if slice.step() == 0 {
-        return Err(crate::Error::InvalidConfig {
+        return Err(crate::Error::validation(
             op,
-            message: "slice step must not be zero".to_string(),
-        });
+            ValidationError::InvalidSliceStep { step: slice.step() },
+        ));
     }
 
     let start = normalize_strided_bound(slice.start(), axis_len, op, "slice start")?;
     let end = match slice.end() {
         Some(end) => normalize_strided_bound(end, axis_len, op, "slice end")?,
-        None => isize::try_from(axis_len).map_err(|_| crate::Error::InvalidConfig {
-            op,
-            message: format!("axis length {axis_len} does not fit in isize"),
-        })?,
+        None => isize::try_from(axis_len)
+            .map_err(|_| crate::Error::validation(op, ValidationError::IntegerOverflow))?,
     };
 
     if slice.step() > 0 {
@@ -3617,16 +3955,10 @@ fn core_slice_spec(
     Ok(CoreSliceSpec {
         start: end
             .checked_sub(1)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op,
-                message: "negative-step slice start overflows".to_string(),
-            })?,
+            .ok_or_else(|| crate::Error::validation(op, ValidationError::IntegerOverflow))?,
         end: start
             .checked_sub(1)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op,
-                message: "negative-step slice end overflows".to_string(),
-            })?,
+            .ok_or_else(|| crate::Error::validation(op, ValidationError::IntegerOverflow))?,
         step: slice.step(),
     })
 }
@@ -3637,25 +3969,30 @@ fn normalize_strided_bound(
     op: &'static str,
     role: &'static str,
 ) -> crate::Result<isize> {
-    let axis_len = isize::try_from(axis_len).map_err(|_| crate::Error::InvalidConfig {
-        op,
-        message: format!("axis length {axis_len} does not fit in isize"),
-    })?;
+    let original_axis_len = axis_len;
+    let axis_len = isize::try_from(axis_len)
+        .map_err(|_| crate::Error::validation(op, ValidationError::IntegerOverflow))?;
     let bound = if bound < 0 {
         axis_len
             .checked_add(bound)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op,
-                message: format!("{role} {bound} overflows"),
-            })?
+            .ok_or_else(|| crate::Error::validation(op, ValidationError::IntegerOverflow))?
     } else {
         bound
     };
     if !(0..=axis_len).contains(&bound) {
-        return Err(crate::Error::InvalidConfig {
+        let (start, end) = if role == "slice start" {
+            (bound, bound)
+        } else {
+            (0, bound)
+        };
+        return Err(crate::Error::validation(
             op,
-            message: format!("{role} {bound} is outside 0..={axis_len}"),
-        });
+            ValidationError::InvalidSliceBounds {
+                start,
+                end,
+                axis_len: original_axis_len,
+            },
+        ));
     }
     Ok(bound)
 }
@@ -3667,7 +4004,10 @@ fn slice_axis_specs(
     op: &'static str,
 ) -> crate::Result<Vec<StridedSliceSpec>> {
     if axis >= rank {
-        return Err(crate::Error::AxisOutOfBounds { op, axis, rank });
+        return Err(crate::Error::validation(
+            op,
+            ValidationError::AxisOutOfBounds { axis, rank },
+        ));
     }
 
     let mut slices = vec![StridedSliceSpec::all(); rank];
@@ -3774,6 +4114,12 @@ impl<T: Clone + Zero, R: TensorRank> TypedTensor<T, R> {
     /// let t = TypedTensor::<f64>::zeros(vec![2, 3]).unwrap();
     /// assert_eq!(t.n_elements(), 6);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn zeros(shape: impl Into<R::Shape>) -> crate::Result<Self> {
         typed_tensor_zeros(shape)
     }
@@ -3790,6 +4136,12 @@ impl<T: Clone + One + Zero, R: TensorRank> TypedTensor<T, R> {
     /// let t = TypedTensor::<f64>::ones(vec![2]).unwrap();
     /// assert_eq!(t.host_data().unwrap(), &[1.0, 1.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn ones(shape: impl Into<R::Shape>) -> crate::Result<Self> {
         typed_tensor_ones(shape)
     }
@@ -3817,6 +4169,12 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     /// .unwrap();
     /// assert_eq!(tensor.shape(), &[2]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn from_buffer_col_major(
         shape: impl Into<R::Shape>,
         buffer: Buffer<T>,
@@ -3843,6 +4201,12 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(ranked.shape(), &[2, 3]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn try_into_rank<const N: usize>(self) -> crate::Result<TypedTensor<T, Rank<N>>> {
         let op = "TypedTensor::try_into_rank";
         let shape = <Rank<N> as TensorRank>::shape_from_vec(self.shape().to_vec().into())
@@ -4043,6 +4407,12 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     /// let err = host.backend_region_view(vec![2, 2], vec![1, 2], 0).unwrap_err();
     /// assert!(err.to_string().contains("backend"));
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn backend_region_view(
         &self,
         shape: Vec<usize>,
@@ -4095,6 +4465,12 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     /// let err = host.backend_region_view_mut(vec![2, 2], vec![1, 2], 0).unwrap_err();
     /// assert!(err.to_string().contains("backend"));
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn backend_region_view_mut(
         &mut self,
         shape: Vec<usize>,
@@ -4168,6 +4544,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.get(&[1, 0])?, &2.0);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn from_vec_col_major(shape: impl Into<R::Shape>, data: Vec<T>) -> crate::Result<Self> {
         typed_tensor_from_vec_col_major(shape, data, "from_vec_col_major")
     }
@@ -4184,6 +4566,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(shape, vec![2]);
     /// assert_eq!(data, vec![1.0, 2.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn into_vec_col_major(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
         let shape = self.shape().to_vec();
         match self.buffer {
@@ -4206,6 +4594,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.host_data()?, &[1.0, 2.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn host_data(&self) -> crate::Result<&[T]> {
         match &self.buffer {
             Buffer::Host(v) => Ok(v),
@@ -4230,6 +4624,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.as_slice()?, &[1.0, 2.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn as_slice(&self) -> crate::Result<&[T]> {
         self.host_data()
     }
@@ -4246,6 +4646,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.host_data()?, &[3.0, 0.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn host_data_mut(&mut self) -> crate::Result<&mut [T]> {
         match &mut self.buffer {
             Buffer::Host(v) => Ok(v),
@@ -4267,6 +4673,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.linear_offset(&[1, 2])?, 5);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), indices, "TypedTensor::linear_offset")
     }
@@ -4282,6 +4694,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.layout_linear_offset(&[1, 2])?, 5);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), indices, "TypedTensor::layout_linear_offset")
     }
@@ -4297,6 +4715,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert!(t.is_col_major_contiguous()?);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         self.layout
             .is_compact_col_major()
@@ -4329,6 +4753,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// t.assert_col_major_contiguous()?;
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         assert_layout_col_major_contiguous(
             self.is_col_major_contiguous()?,
@@ -4350,14 +4780,17 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.get(&[1])?, &2.0);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn get(&self, indices: &[usize]) -> crate::Result<&T> {
         let off = self.linear_offset(indices)?;
-        self.host_data()?
-            .get(off)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "TypedTensor::get",
-                message: format!("linear offset {off} is outside host buffer"),
-            })
+        self.host_data()?.get(off).ok_or_else(|| {
+            crate::Error::validation("TypedTensor::get", ValidationError::ViewOutOfBounds)
+        })
     }
 
     /// Mutably borrow a single element by multi-index.
@@ -4372,14 +4805,17 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.host_data()?, &[7.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn get_mut(&mut self, indices: &[usize]) -> crate::Result<&mut T> {
         let off = self.linear_offset(indices)?;
-        self.host_data_mut()?
-            .get_mut(off)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "TypedTensor::get_mut",
-                message: format!("linear offset {off} is outside host buffer"),
-            })
+        self.host_data_mut()?.get_mut(off).ok_or_else(|| {
+            crate::Error::validation("TypedTensor::get_mut", ValidationError::ViewOutOfBounds)
+        })
     }
 }
 
@@ -4398,6 +4834,12 @@ impl Tensor {
     /// assert_eq!(t.shape(), &[2, 2]);
     /// assert_eq!(t.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn from_vec_col_major<T: TensorScalar>(
         shape: Vec<usize>,
         data: Vec<T>,
@@ -4504,6 +4946,12 @@ impl Tensor {
     /// assert_eq!(t.layout_linear_offset(&[1])?, 1);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         match self {
             Tensor::F32(t) => t.layout_linear_offset(indices),
@@ -4527,6 +4975,12 @@ impl Tensor {
     /// assert!(t.is_col_major_contiguous()?);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         match self {
             Tensor::F32(t) => t.is_col_major_contiguous(),
@@ -4566,6 +5020,12 @@ impl Tensor {
     /// t.assert_col_major_contiguous()?;
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         let layout = tensor_layout(self);
         assert_layout_col_major_contiguous(
@@ -4590,6 +5050,12 @@ impl Tensor {
     /// assert_eq!(t.as_slice::<f64>().unwrap(), [1.0, 2.0, 3.0].as_slice());
     /// assert!(t.as_slice::<f32>().is_err());
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn as_slice<T: TensorScalar>(&self) -> crate::Result<&[T]> {
         T::as_slice(self)
     }
@@ -4605,6 +5071,12 @@ impl Tensor {
     /// let t = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     /// assert_eq!(t.into_vec_col_major::<f64>().unwrap().1, vec![2.0]);
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed validation source for
+    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
+    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
+    /// when the requested host or backend storage access is unavailable.
     pub fn into_vec_col_major<T: TensorScalar>(self) -> crate::Result<(Vec<usize>, Vec<T>)> {
         let typed = T::into_typed(self)?;
         typed.into_vec_col_major()

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -460,12 +460,14 @@ impl<'a, T: 'static> TypedTensorView<'a, T, DynRank> {
     /// assert_eq!(view.strides(), &[1, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when compact
+    /// strides or reachable bounds overflow, or
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// requested shape reaches beyond `data`.
     pub fn from_col_major(shape: &[usize], data: &'a [T]) -> crate::Result<Self> {
         let layout = TensorLayout::<DynRank>::compact(shape.to_vec().into())
             .map_err(|err| tensor_layout_error("TypedTensorView::from_col_major", err))?;
@@ -491,12 +493,16 @@ impl<'a, T: 'static> TypedTensorView<'a, T, DynRank> {
     /// assert_eq!(view.get(&[2]), Some(&1));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `shape` and
+    /// `strides` have different ranks,
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// reachable layout exceeds `data`, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when layout
+    /// arithmetic overflows.
     pub fn from_slice(
         shape: impl AsRef<[usize]>,
         strides: impl AsRef<[isize]>,
@@ -527,12 +533,16 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert_eq!(view.get(&[1, 1]), Some(&4));
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the typed
+    /// rank does not match `shape` or `strides`,
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
+    /// reachable layout exceeds `data`, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when layout
+    /// arithmetic overflows.
     pub fn from_slice_ranked(
         shape: impl Into<R::Shape>,
         strides: impl Into<R::Strides>,
@@ -630,12 +640,11 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert_eq!(view.host_storage()?, &[1, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::RuntimeState`] when this view wraps a backend
+    /// buffer; backend storage must be downloaded before host inspection.
     pub fn host_storage(&self) -> crate::Result<&'a [T]> {
         match &self.buffer {
             TensorBufferRef::Host(data) => Ok(data),
@@ -737,12 +746,15 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert_eq!(view.layout_linear_offset(&[2])?, 0);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `indices`
+    /// has the wrong rank, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when an index is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when offset
+    /// arithmetic overflows.
     pub fn layout_linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         checked_view_offset_result(
             self.shape(),
@@ -765,12 +777,12 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert!(view.is_col_major_contiguous()?);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] if compactness
+    /// arithmetic overflows.
     pub fn is_col_major_contiguous(&self) -> crate::Result<bool> {
         self.layout
             .is_compact_col_major()
@@ -805,12 +817,14 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// view.assert_col_major_contiguous()?;
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+    /// compactness arithmetic overflows, or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] when the
+    /// view is not compact column-major.
     pub fn assert_col_major_contiguous(&self) -> crate::Result<()> {
         assert_layout_col_major_contiguous(
             self.is_col_major_contiguous()?,
@@ -858,12 +872,16 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     /// assert_eq!(view.as_slice()?, &[2, 3]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed validation source for
-    /// invalid shape, rank, axis, dtype, slice, index, or layout metadata. It
-    /// returns [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`]
-    /// when the requested host or backend storage access is unavailable.
+    /// Returns [`crate::Error::RuntimeState`] when this view wraps a backend
+    /// buffer, [`tenferro_tensor_core::ValidationError::InvalidArgument`] when
+    /// the layout is not slice-contiguous or has a negative offset, or
+    /// [`crate::Error::Validation`] with
+    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when the
+    /// requested host range is invalid.
     pub fn as_slice(&self) -> crate::Result<&'a [T]> {
         let data =
             match &self.buffer {

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -3281,24 +3281,29 @@ fn try_compact_layout<R: TensorRank>(
     TensorLayout::compact(shape.into()).map_err(|err| tensor_layout_error(op, err))
 }
 
-fn tensor_layout_error(op: &'static str, err: tenferro_tensor_core::Error) -> crate::Error {
+fn tensor_layout_error(
+    op: &'static str,
+    err: tenferro_tensor_core::ValidationError,
+) -> crate::Error {
     match err {
-        tenferro_tensor_core::Error::RankMismatch { expected, actual } => {
+        tenferro_tensor_core::ValidationError::RankMismatch { expected, actual } => {
             crate::Error::RankMismatch {
                 op,
                 expected,
                 actual,
             }
         }
-        tenferro_tensor_core::Error::AxisOutOfBounds { axis, rank } => {
+        tenferro_tensor_core::ValidationError::AxisOutOfBounds { axis, rank } => {
             crate::Error::AxisOutOfBounds { op, axis, rank }
         }
-        tenferro_tensor_core::Error::DuplicateAxis { axis } => crate::Error::DuplicateAxis {
-            op,
-            axis,
-            role: "permutation",
-        },
-        tenferro_tensor_core::Error::InvalidPermutationLength { expected, actual } => {
+        tenferro_tensor_core::ValidationError::DuplicateAxis { axis, .. } => {
+            crate::Error::DuplicateAxis {
+                op,
+                axis,
+                role: "permutation",
+            }
+        }
+        tenferro_tensor_core::ValidationError::InvalidPermutationLength { expected, actual } => {
             crate::Error::RankMismatch {
                 op,
                 expected,
@@ -3535,7 +3540,7 @@ fn reshape_layout_dyn<R: TensorRank>(
             if from != to {
                 return Err(tensor_layout_error(
                     op,
-                    tenferro_tensor_core::Error::ReshapeElementCountMismatch { from, to },
+                    tenferro_tensor_core::ShapeMismatch::ReshapeElementCount { from, to }.into(),
                 ));
             }
             TensorLayout::<DynRank>::compact(shape.to_vec().into())

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -639,7 +639,7 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
     pub fn host_storage(&self) -> crate::Result<&'a [T]> {
         match &self.buffer {
             TensorBufferRef::Host(data) => Ok(data),
-            TensorBufferRef::Backend(_) => Err(crate::Error::backend_failure(
+            TensorBufferRef::Backend(_) => Err(crate::Error::runtime_state(
                 "TypedTensorView::host_storage",
                 "backend buffers cannot expose host storage; download explicitly first",
             )),
@@ -868,7 +868,7 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorView<'a, T, R> {
         let data =
             match &self.buffer {
                 TensorBufferRef::Host(data) => data,
-                TensorBufferRef::Backend(_) => return Err(crate::Error::backend_failure(
+                TensorBufferRef::Backend(_) => return Err(crate::Error::runtime_state(
                     "TypedTensorView::as_slice",
                     "backend buffers cannot be inspected as host slices; download explicitly first",
                 )),
@@ -1240,7 +1240,7 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     pub fn host_storage(&self) -> crate::Result<&[T]> {
         match &self.buffer {
             TensorBufferRefMut::Host(data) => Ok(data),
-            TensorBufferRefMut::Backend(_) => Err(crate::Error::backend_failure(
+            TensorBufferRefMut::Backend(_) => Err(crate::Error::runtime_state(
                 "TypedTensorViewMut::host_storage",
                 "backend buffers cannot expose host storage; download explicitly first",
             )),
@@ -1273,7 +1273,7 @@ impl<'a, T: 'static, R: TensorRank> TypedTensorViewMut<'a, T, R> {
     pub fn host_storage_mut(&mut self) -> crate::Result<&mut [T]> {
         match &mut self.buffer {
             TensorBufferRefMut::Host(data) => Ok(data),
-            TensorBufferRefMut::Backend(_) => Err(crate::Error::backend_failure(
+            TensorBufferRefMut::Backend(_) => Err(crate::Error::runtime_state(
                 "TypedTensorViewMut::host_storage_mut",
                 "backend buffers cannot expose mutable host storage; download explicitly first",
             )),
@@ -4424,7 +4424,7 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     {
         let op = "TypedTensor::backend_region_view";
         let Buffer::Backend(buffer) = &self.buffer else {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 op,
                 "expected a backend (device) buffer; host tensors use \
                  TypedTensorView::from_slice over host storage",
@@ -4482,7 +4482,7 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     {
         let op = "TypedTensor::backend_region_view_mut";
         let Buffer::Backend(buffer) = &self.buffer else {
-            return Err(crate::Error::backend_failure(
+            return Err(crate::Error::runtime_state(
                 op,
                 "expected a backend (device) buffer; mutable host regions use \
                  TypedTensorViewMut host constructors or try_multi_slice_mut",
@@ -4576,7 +4576,7 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
         let shape = self.shape().to_vec();
         match self.buffer {
             Buffer::Host(data) => Ok((shape, data)),
-            Buffer::Backend(_) => Err(crate::Error::backend_failure(
+            Buffer::Backend(_) => Err(crate::Error::runtime_state(
                 "into_vec_col_major",
                 "backend buffers cannot be exported as host Vec",
             )),
@@ -4603,7 +4603,7 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     pub fn host_data(&self) -> crate::Result<&[T]> {
         match &self.buffer {
             Buffer::Host(v) => Ok(v),
-            Buffer::Backend(_) => Err(crate::Error::backend_failure(
+            Buffer::Backend(_) => Err(crate::Error::runtime_state(
                 "TypedTensor::host_data",
                 "backend buffers cannot be inspected as host slices; download explicitly first",
             )),
@@ -4655,7 +4655,7 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     pub fn host_data_mut(&mut self) -> crate::Result<&mut [T]> {
         match &mut self.buffer {
             Buffer::Host(v) => Ok(v),
-            Buffer::Backend(_) => Err(crate::Error::backend_failure(
+            Buffer::Backend(_) => Err(crate::Error::runtime_state(
                 "TypedTensor::host_data_mut",
                 "backend buffers cannot be mutated as host slices; download explicitly first",
             )),

--- a/crates/tenferro-tensor/src/types/accessors.rs
+++ b/crates/tenferro-tensor/src/types/accessors.rs
@@ -44,6 +44,10 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(sum, 3.0);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn iter(&self) -> crate::Result<std::slice::Iter<'_, T>> {
         Ok(self.host_data()?.iter())
     }
@@ -62,6 +66,10 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.as_slice()?, &[2.0, 4.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn iter_mut(&mut self) -> crate::Result<std::slice::IterMut<'_, T>> {
         Ok(self.host_data_mut()?.iter_mut())
     }
@@ -77,6 +85,10 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.linear_offset2(1, 2)?, 5);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn linear_offset2(&self, i: usize, j: usize) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), &[i, j], "TypedTensor::linear_offset2")
     }
@@ -92,6 +104,10 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.linear_offset3(1, 2, 1)?, 11);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn linear_offset3(&self, i: usize, j: usize, k: usize) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), &[i, j, k], "TypedTensor::linear_offset3")
     }
@@ -107,14 +123,19 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.get2(1, 0)?, &2.0);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn get2(&self, i: usize, j: usize) -> crate::Result<&T> {
         let off = self.linear_offset2(i, j)?;
-        self.host_data()?
-            .get(off)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "TypedTensor::get2",
-                message: format!("linear offset {off} is outside host buffer"),
-            })
+        self.host_data()?.get(off).ok_or_else(|| {
+            crate::Error::invalid_argument(
+                "TypedTensor::get2",
+                "index",
+                format!("linear offset {off} is outside host buffer"),
+            )
+        })
     }
 
     /// Borrow a single element by rank-3 logical index.
@@ -128,14 +149,19 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.get3(0, 0, 1)?, &4.0);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn get3(&self, i: usize, j: usize, k: usize) -> crate::Result<&T> {
         let off = self.linear_offset3(i, j, k)?;
-        self.host_data()?
-            .get(off)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "TypedTensor::get3",
-                message: format!("linear offset {off} is outside host buffer"),
-            })
+        self.host_data()?.get(off).ok_or_else(|| {
+            crate::Error::invalid_argument(
+                "TypedTensor::get3",
+                "index",
+                format!("linear offset {off} is outside host buffer"),
+            )
+        })
     }
 
     /// Borrow a single element by multi-index without release-mode bounds
@@ -157,6 +183,10 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(unsafe { *t.get_unchecked(&[1])? }, 2.0);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub unsafe fn get_unchecked(&self, indices: &[usize]) -> crate::Result<&T> {
         let off = linear_offset_unchecked(self.shape(), indices);
         Ok(unsafe { self.host_data()?.get_unchecked(off) })
@@ -174,14 +204,19 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.as_slice()?, &[1.0, 5.0, 3.0, 4.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn get_mut2(&mut self, i: usize, j: usize) -> crate::Result<&mut T> {
         let off = self.linear_offset2(i, j)?;
-        self.host_data_mut()?
-            .get_mut(off)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "TypedTensor::get_mut2",
-                message: format!("linear offset {off} is outside host buffer"),
-            })
+        self.host_data_mut()?.get_mut(off).ok_or_else(|| {
+            crate::Error::invalid_argument(
+                "TypedTensor::get_mut2",
+                "index",
+                format!("linear offset {off} is outside host buffer"),
+            )
+        })
     }
 
     /// Mutably borrow a single element by rank-3 logical index.
@@ -196,14 +231,19 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.as_slice()?, &[3.0, 5.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn get_mut3(&mut self, i: usize, j: usize, k: usize) -> crate::Result<&mut T> {
         let off = self.linear_offset3(i, j, k)?;
-        self.host_data_mut()?
-            .get_mut(off)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "TypedTensor::get_mut3",
-                message: format!("linear offset {off} is outside host buffer"),
-            })
+        self.host_data_mut()?.get_mut(off).ok_or_else(|| {
+            crate::Error::invalid_argument(
+                "TypedTensor::get_mut3",
+                "index",
+                format!("linear offset {off} is outside host buffer"),
+            )
+        })
     }
 
     /// Mutably borrow a single element by multi-index without release-mode
@@ -228,6 +268,10 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// assert_eq!(t.as_slice()?, &[2.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub unsafe fn get_unchecked_mut(&mut self, indices: &[usize]) -> crate::Result<&mut T> {
         let off = linear_offset_unchecked(self.shape(), indices);
         Ok(unsafe { self.host_data_mut()?.get_unchecked_mut(off) })
@@ -246,6 +290,10 @@ impl Tensor {
     /// assert_eq!(t.linear_offset(&[1, 2])?, 5);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), indices, "Tensor::linear_offset")
     }
@@ -261,6 +309,10 @@ impl Tensor {
     /// assert_eq!(t.linear_offset2(1, 2)?, 5);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn linear_offset2(&self, i: usize, j: usize) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), &[i, j], "Tensor::linear_offset2")
     }
@@ -276,6 +328,10 @@ impl Tensor {
     /// assert_eq!(t.linear_offset3(1, 2, 1)?, 11);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn linear_offset3(&self, i: usize, j: usize, k: usize) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), &[i, j, k], "Tensor::linear_offset3")
     }
@@ -292,14 +348,19 @@ impl Tensor {
     /// assert!(t.get::<f32>(&[1]).is_err());
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn get<T: TensorScalar>(&self, indices: &[usize]) -> crate::Result<&T> {
         let off = self.linear_offset(indices)?;
-        self.as_slice::<T>()?
-            .get(off)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "Tensor::get",
-                message: format!("linear offset {off} is outside host buffer"),
-            })
+        self.as_slice::<T>()?.get(off).ok_or_else(|| {
+            crate::Error::invalid_argument(
+                "Tensor::get",
+                "index",
+                format!("linear offset {off} is outside host buffer"),
+            )
+        })
     }
 
     /// Mutably borrow a single typed element by multi-index.
@@ -314,14 +375,19 @@ impl Tensor {
     /// assert_eq!(t.as_slice::<f64>()?, &[2.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn get_mut<T: TensorScalar>(&mut self, indices: &[usize]) -> crate::Result<&mut T> {
         let off = self.linear_offset(indices)?;
-        self.as_slice_mut::<T>()?
-            .get_mut(off)
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "Tensor::get_mut",
-                message: format!("linear offset {off} is outside host buffer"),
-            })
+        self.as_slice_mut::<T>()?.get_mut(off).ok_or_else(|| {
+            crate::Error::invalid_argument(
+                "Tensor::get_mut",
+                "index",
+                format!("linear offset {off} is outside host buffer"),
+            )
+        })
     }
 
     /// Try to borrow a single typed element by multi-index without
@@ -344,6 +410,10 @@ impl Tensor {
     /// assert_eq!(unsafe { *t.get_unchecked::<f64>(&[1])? }, 2.0);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub unsafe fn get_unchecked<T: TensorScalar>(&self, indices: &[usize]) -> crate::Result<&T> {
         let off = linear_offset_unchecked(self.shape(), indices);
         let data = self.as_slice::<T>()?;
@@ -373,6 +443,10 @@ impl Tensor {
     /// assert_eq!(t.as_slice::<f64>()?, &[2.0]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub unsafe fn get_unchecked_mut<T: TensorScalar>(
         &mut self,
         indices: &[usize],
@@ -395,6 +469,10 @@ impl Tensor {
     /// assert!(t.as_slice_mut::<f32>().is_err());
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn as_slice_mut<T: TensorScalar>(&mut self) -> crate::Result<&mut [T]> {
         T::as_slice_mut(self)
     }
@@ -412,6 +490,10 @@ impl Tensor {
     /// assert!(t.iter::<f32>().is_err());
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn iter<T: TensorScalar>(&self) -> crate::Result<std::slice::Iter<'_, T>> {
         Ok(self.as_slice::<T>()?.iter())
     }
@@ -431,6 +513,10 @@ impl Tensor {
     /// assert!(t.iter_mut::<f32>().is_err());
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
+    /// source when the requested accessor cannot be applied.
     pub fn iter_mut<T: TensorScalar>(&mut self) -> crate::Result<std::slice::IterMut<'_, T>> {
         Ok(self.as_slice_mut::<T>()?.iter_mut())
     }

--- a/crates/tenferro-tensor/src/types/accessors.rs
+++ b/crates/tenferro-tensor/src/types/accessors.rs
@@ -46,8 +46,8 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::RuntimeState`] when the tensor is backed by a
+    /// device buffer and has not been downloaded to host memory.
     pub fn iter(&self) -> crate::Result<std::slice::Iter<'_, T>> {
         Ok(self.host_data()?.iter())
     }
@@ -68,8 +68,8 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::RuntimeState`] when the tensor is backed by a
+    /// device buffer and has not been downloaded to host memory.
     pub fn iter_mut(&mut self) -> crate::Result<std::slice::IterMut<'_, T>> {
         Ok(self.host_data_mut()?.iter_mut())
     }
@@ -87,8 +87,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::Validation`] containing
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the tensor
+    /// rank is not two, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when `i` or `j` is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when checked
+    /// offset arithmetic overflows.
     pub fn linear_offset2(&self, i: usize, j: usize) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), &[i, j], "TypedTensor::linear_offset2")
     }
@@ -106,8 +110,12 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::Validation`] containing
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the tensor
+    /// rank is not three, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when `i`, `j`, or `k` is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when checked
+    /// offset arithmetic overflows.
     pub fn linear_offset3(&self, i: usize, j: usize, k: usize) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), &[i, j, k], "TypedTensor::linear_offset3")
     }
@@ -125,8 +133,15 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::Validation`] containing
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the tensor
+    /// rank is not two, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when `i` or `j` is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when checked
+    /// offset arithmetic overflows. It returns [`crate::Error::RuntimeState`]
+    /// when the tensor is backed by a device buffer, or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] if the
+    /// computed offset is outside the host buffer.
     pub fn get2(&self, i: usize, j: usize) -> crate::Result<&T> {
         let off = self.linear_offset2(i, j)?;
         self.host_data()?.get(off).ok_or_else(|| {
@@ -151,8 +166,15 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::Validation`] containing
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the tensor
+    /// rank is not three, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when `i`, `j`, or `k` is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when checked
+    /// offset arithmetic overflows. It returns [`crate::Error::RuntimeState`]
+    /// when the tensor is backed by a device buffer, or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] if the
+    /// computed offset is outside the host buffer.
     pub fn get3(&self, i: usize, j: usize, k: usize) -> crate::Result<&T> {
         let off = self.linear_offset3(i, j, k)?;
         self.host_data()?.get(off).ok_or_else(|| {
@@ -185,8 +207,13 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::RuntimeState`] when the tensor is backed by a
+    /// device buffer and has not been downloaded to host memory.
+    ///
+    /// # Panics
+    ///
+    /// May panic if the unsafe rank/bounds precondition is violated and the
+    /// checked linear-offset calculation overflows.
     pub unsafe fn get_unchecked(&self, indices: &[usize]) -> crate::Result<&T> {
         let off = linear_offset_unchecked(self.shape(), indices);
         Ok(unsafe { self.host_data()?.get_unchecked(off) })
@@ -206,8 +233,15 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::Validation`] containing
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the tensor
+    /// rank is not two, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when `i` or `j` is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when checked
+    /// offset arithmetic overflows. It returns [`crate::Error::RuntimeState`]
+    /// when the tensor is backed by a device buffer, or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] if the
+    /// computed offset is outside the host buffer.
     pub fn get_mut2(&mut self, i: usize, j: usize) -> crate::Result<&mut T> {
         let off = self.linear_offset2(i, j)?;
         self.host_data_mut()?.get_mut(off).ok_or_else(|| {
@@ -233,8 +267,15 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::Validation`] containing
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the tensor
+    /// rank is not three, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when `i`, `j`, or `k` is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when checked
+    /// offset arithmetic overflows. It returns [`crate::Error::RuntimeState`]
+    /// when the tensor is backed by a device buffer, or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] if the
+    /// computed offset is outside the host buffer.
     pub fn get_mut3(&mut self, i: usize, j: usize, k: usize) -> crate::Result<&mut T> {
         let off = self.linear_offset3(i, j, k)?;
         self.host_data_mut()?.get_mut(off).ok_or_else(|| {
@@ -270,8 +311,13 @@ impl<T: Clone, R: TensorRank> TypedTensor<T, R> {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::RuntimeState`] when the tensor is backed by a
+    /// device buffer and has not been downloaded to host memory.
+    ///
+    /// # Panics
+    ///
+    /// May panic if the unsafe rank/bounds precondition is violated and the
+    /// checked linear-offset calculation overflows.
     pub unsafe fn get_unchecked_mut(&mut self, indices: &[usize]) -> crate::Result<&mut T> {
         let off = linear_offset_unchecked(self.shape(), indices);
         Ok(unsafe { self.host_data_mut()?.get_unchecked_mut(off) })
@@ -292,8 +338,12 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::Validation`] containing
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when `indices`
+    /// has a rank different from the tensor, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when an index is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when checked
+    /// offset arithmetic overflows.
     pub fn linear_offset(&self, indices: &[usize]) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), indices, "Tensor::linear_offset")
     }
@@ -311,8 +361,12 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::Validation`] containing
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the tensor
+    /// rank is not two, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when `i` or `j` is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when checked
+    /// offset arithmetic overflows.
     pub fn linear_offset2(&self, i: usize, j: usize) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), &[i, j], "Tensor::linear_offset2")
     }
@@ -330,8 +384,12 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::Validation`] containing
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] when the tensor
+    /// rank is not three, [`tenferro_tensor_core::ValidationError::InvalidArgument`]
+    /// when `i`, `j`, or `k` is outside its axis extent, or
+    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when checked
+    /// offset arithmetic overflows.
     pub fn linear_offset3(&self, i: usize, j: usize, k: usize) -> crate::Result<usize> {
         try_linear_offset_for_shape(self.shape(), &[i, j, k], "Tensor::linear_offset3")
     }
@@ -350,8 +408,12 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::Validation`] containing
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] for an
+    /// invalid index, [`tenferro_tensor_core::ValidationError::DTypeMismatch`]
+    /// when `T` does not match the tensor dtype, or
+    /// [`crate::Error::RuntimeState`] for a device-backed tensor.
     pub fn get<T: TensorScalar>(&self, indices: &[usize]) -> crate::Result<&T> {
         let off = self.linear_offset(indices)?;
         self.as_slice::<T>()?.get(off).ok_or_else(|| {
@@ -377,8 +439,12 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::Validation`] containing
+    /// [`tenferro_tensor_core::ValidationError::RankMismatch`] or
+    /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] for an
+    /// invalid index, [`tenferro_tensor_core::ValidationError::DTypeMismatch`]
+    /// when `T` does not match the tensor dtype, or
+    /// [`crate::Error::RuntimeState`] for a device-backed tensor.
     pub fn get_mut<T: TensorScalar>(&mut self, indices: &[usize]) -> crate::Result<&mut T> {
         let off = self.linear_offset(indices)?;
         self.as_slice_mut::<T>()?.get_mut(off).ok_or_else(|| {
@@ -412,8 +478,14 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::RuntimeState`] for a device-backed tensor and
+    /// [`tenferro_tensor_core::ValidationError::DTypeMismatch`] when `T` does
+    /// not match the tensor dtype.
+    ///
+    /// # Panics
+    ///
+    /// May panic if the unsafe rank/bounds precondition is violated and the
+    /// checked linear-offset calculation overflows.
     pub unsafe fn get_unchecked<T: TensorScalar>(&self, indices: &[usize]) -> crate::Result<&T> {
         let off = linear_offset_unchecked(self.shape(), indices);
         let data = self.as_slice::<T>()?;
@@ -445,8 +517,14 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`crate::Error::RuntimeState`] for a device-backed tensor and
+    /// [`tenferro_tensor_core::ValidationError::DTypeMismatch`] when `T` does
+    /// not match the tensor dtype.
+    ///
+    /// # Panics
+    ///
+    /// May panic if the unsafe rank/bounds precondition is violated and the
+    /// checked linear-offset calculation overflows.
     pub unsafe fn get_unchecked_mut<T: TensorScalar>(
         &mut self,
         indices: &[usize],
@@ -471,8 +549,9 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`tenferro_tensor_core::ValidationError::DTypeMismatch`] when
+    /// `T` does not match the tensor dtype, or [`crate::Error::RuntimeState`]
+    /// when the tensor is backed by a device buffer.
     pub fn as_slice_mut<T: TensorScalar>(&mut self) -> crate::Result<&mut [T]> {
         T::as_slice_mut(self)
     }
@@ -492,8 +571,9 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`tenferro_tensor_core::ValidationError::DTypeMismatch`] when
+    /// `T` does not match the tensor dtype, or [`crate::Error::RuntimeState`]
+    /// when the tensor is backed by a device buffer.
     pub fn iter<T: TensorScalar>(&self) -> crate::Result<std::slice::Iter<'_, T>> {
         Ok(self.as_slice::<T>()?.iter())
     }
@@ -515,8 +595,9 @@ impl Tensor {
     /// ```
     /// # Errors
     ///
-    /// Returns [`crate::Error::Validation`] with a typed rank, index, or layout
-    /// source when the requested accessor cannot be applied.
+    /// Returns [`tenferro_tensor_core::ValidationError::DTypeMismatch`] when
+    /// `T` does not match the tensor dtype, or [`crate::Error::RuntimeState`]
+    /// when the tensor is backed by a device buffer.
     pub fn iter_mut<T: TensorScalar>(&mut self) -> crate::Result<std::slice::IterMut<'_, T>> {
         Ok(self.as_slice_mut::<T>()?.iter_mut())
     }

--- a/crates/tenferro-tensor/src/types/shape_packing.rs
+++ b/crates/tenferro-tensor/src/types/shape_packing.rs
@@ -1,4 +1,4 @@
-use crate::{GatherConfig, TensorBackend};
+use crate::{GatherConfig, ShapeMismatch, TensorBackend, ValidationError};
 
 use super::{Tensor, TypedTensor};
 
@@ -6,46 +6,61 @@ fn normalize_existing_axis(op: &'static str, axis: isize, rank: usize) -> crate:
     let normalized = if axis >= 0 {
         axis as usize
     } else {
-        rank.checked_sub(axis.unsigned_abs())
-            .ok_or(crate::Error::AxisOutOfBounds {
+        rank.checked_sub(axis.unsigned_abs()).ok_or_else(|| {
+            crate::Error::validation(
                 op,
-                axis: axis.unsigned_abs(),
-                rank,
-            })?
+                ValidationError::AxisOutOfBounds {
+                    axis: axis.unsigned_abs(),
+                    rank,
+                },
+            )
+        })?
     };
     if normalized >= rank {
-        return Err(crate::Error::AxisOutOfBounds {
+        return Err(crate::Error::validation(
             op,
-            axis: axis.unsigned_abs(),
-            rank,
-        });
+            ValidationError::AxisOutOfBounds {
+                axis: axis.unsigned_abs(),
+                rank,
+            },
+        ));
     }
     Ok(normalized)
 }
 
 fn normalize_insert_axis(op: &'static str, axis: isize, rank: usize) -> crate::Result<usize> {
-    let insert_rank = rank.checked_add(1).ok_or(crate::Error::AxisOutOfBounds {
-        op,
-        axis: axis.unsigned_abs(),
-        rank,
+    let insert_rank = rank.checked_add(1).ok_or_else(|| {
+        crate::Error::validation(
+            op,
+            ValidationError::AxisOutOfBounds {
+                axis: axis.unsigned_abs(),
+                rank,
+            },
+        )
     })?;
     let normalized = if axis >= 0 {
         axis as usize
     } else {
         insert_rank
             .checked_sub(axis.unsigned_abs())
-            .ok_or(crate::Error::AxisOutOfBounds {
-                op,
-                axis: axis.unsigned_abs(),
-                rank: insert_rank,
+            .ok_or_else(|| {
+                crate::Error::validation(
+                    op,
+                    ValidationError::AxisOutOfBounds {
+                        axis: axis.unsigned_abs(),
+                        rank: insert_rank,
+                    },
+                )
             })?
     };
     if normalized > rank {
-        return Err(crate::Error::AxisOutOfBounds {
+        return Err(crate::Error::validation(
             op,
-            axis: axis.unsigned_abs(),
-            rank: insert_rank,
-        });
+            ValidationError::AxisOutOfBounds {
+                axis: axis.unsigned_abs(),
+                rank: insert_rank,
+            },
+        ));
     }
     Ok(normalized)
 }
@@ -59,12 +74,13 @@ fn index_select_parts(
     let axis_extent = shape[axis];
     for &position in positions {
         if position >= axis_extent {
-            return Err(crate::Error::InvalidConfig {
-                op: "index_select",
-                message: format!(
+            return Err(crate::Error::invalid_argument(
+                "index_select",
+                "positions",
+                format!(
                     "position {position} out of bounds for axis {axis} with extent {axis_extent}"
                 ),
-            });
+            ));
         }
     }
 
@@ -75,9 +91,12 @@ fn index_select_parts(
     let index_data = positions
         .iter()
         .map(|&position| {
-            i64::try_from(position).map_err(|_| crate::Error::InvalidConfig {
-                op: "index_select",
-                message: format!("position {position} cannot be represented as i64"),
+            i64::try_from(position).map_err(|_| {
+                crate::Error::invalid_argument(
+                    "index_select",
+                    "positions",
+                    format!("position {position} cannot be represented as i64"),
+                )
             })
         })
         .collect::<crate::Result<Vec<_>>>()?;
@@ -112,6 +131,10 @@ impl Tensor {
     ///     x.index_select(-1, &[2, 0], backend)
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed shape, axis, or argument
+    /// source when the inputs cannot be packed without violating their metadata.
     pub fn index_select(
         &self,
         axis: isize,
@@ -137,27 +160,30 @@ impl Tensor {
     ///     Tensor::stack(&[a, b], -1, backend)
     /// }
     /// ```
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Validation`] with a typed shape, axis, or argument
+    /// source when the inputs cannot be packed without violating their metadata.
     pub fn stack(
         tensors: &[&Self],
         dim: isize,
         ctx: &mut impl TensorBackend,
     ) -> crate::Result<Self> {
-        let first = tensors
-            .first()
-            .copied()
-            .ok_or_else(|| crate::Error::InvalidConfig {
-                op: "stack",
-                message: "stack requires at least one input".into(),
-            })?;
+        let first = tensors.first().copied().ok_or_else(|| {
+            crate::Error::invalid_argument("stack", "tensors", "requires at least one input")
+        })?;
         let axis = normalize_insert_axis("stack", dim, first.shape().len())?;
 
         for tensor in tensors.iter().copied().skip(1) {
             if tensor.shape() != first.shape() {
-                return Err(crate::Error::ShapeMismatch {
-                    op: "stack",
-                    lhs: first.shape().to_vec(),
-                    rhs: tensor.shape().to_vec(),
-                });
+                return Err(crate::Error::validation(
+                    "stack",
+                    ShapeMismatch::IncompatibleShapes {
+                        lhs: first.shape().to_vec().into(),
+                        rhs: tensor.shape().to_vec().into(),
+                    }
+                    .into(),
+                ));
             }
         }
 

--- a/crates/tenferro-tensor/src/validate/mod.rs
+++ b/crates/tenferro-tensor/src/validate/mod.rs
@@ -129,8 +129,10 @@ pub fn validate_convert_dtype(op: &'static str, from: DType, to: DType) -> Resul
 /// ```
 /// # Errors
 ///
-/// Returns [`crate::Error::Validation`] with an `InvalidArgument` source when
-/// the shape product overflows `usize`.
+/// Returns [`crate::Error::Validation`] containing
+/// [`tenferro_tensor_core::ValidationError::InvalidArgument`] when the
+/// product of `shape` exceeds `usize::MAX`; `role` identifies the shape-like
+/// argument in the diagnostic.
 pub fn checked_shape_product(
     op: &'static str,
     role: &'static str,

--- a/crates/tenferro-tensor/src/validate/mod.rs
+++ b/crates/tenferro-tensor/src/validate/mod.rs
@@ -12,7 +12,9 @@
 
 use num_complex::{Complex32, Complex64};
 
-use crate::{DType, DotGeneralConfig, Error, Result, Tensor, TypedTensor};
+use crate::{
+    DType, DotGeneralConfig, Error, Result, ShapeMismatch, Tensor, TypedTensor, ValidationError,
+};
 
 /// Promote two dtypes according to tenferro's public dtype-promotion lattice.
 ///
@@ -71,17 +73,22 @@ pub fn can_convert_dtype(from: DType, to: DType) -> bool {
 /// assert!(validate_convert_dtype("convert", DType::F32, DType::F64).is_ok());
 /// assert!(validate_convert_dtype("convert", DType::C64, DType::F64).is_err());
 /// ```
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
+/// axis, dtype, or argument source when validation fails. Singular or
+/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
 pub fn validate_convert_dtype(op: &'static str, from: DType, to: DType) -> Result<()> {
     if can_convert_dtype(from, to) {
         return Ok(());
     }
 
-    Err(Error::UnsupportedDTypeConversion {
+    Err(Error::unsupported_dtype_conversion(
         op,
         from,
         to,
-        message: "checked convert only accepts conversions allowed by dtype promotion; use explicit cast for lossy dtype projection".to_string(),
-    })
+        "checked convert only accepts conversions allowed by dtype promotion; use explicit cast for lossy dtype projection",
+    ))
 }
 
 /// Compute a shape product with overflow reported as a typed tensor error.
@@ -94,6 +101,11 @@ pub fn validate_convert_dtype(op: &'static str, from: DType, to: DType) -> Resul
 /// assert_eq!(checked_shape_product("zeros", "shape", &[2, 3])?, 6);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
+/// axis, dtype, or argument source when validation fails. Singular or
+/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
 pub fn checked_shape_product(
     op: &'static str,
     role: &'static str,
@@ -102,9 +114,8 @@ pub fn checked_shape_product(
     shape
         .iter()
         .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
-        .ok_or_else(|| Error::InvalidConfig {
-            op,
-            message: format!("{role} product overflows for shape {shape:?}"),
+        .ok_or_else(|| {
+            Error::invalid_argument(op, role, format!("product overflows for shape {shape:?}"))
         })
 }
 
@@ -118,26 +129,38 @@ pub fn checked_shape_product(
 /// validate_permutation_axes("transpose", 2, &[1, 0])?;
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
+/// axis, dtype, or argument source when validation fails. Singular or
+/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
 pub fn validate_permutation_axes(op: &'static str, rank: usize, perm: &[usize]) -> Result<()> {
     if perm.len() != rank {
-        return Err(Error::RankMismatch {
+        return Err(Error::validation(
             op,
-            expected: rank,
-            actual: perm.len(),
-        });
+            ValidationError::RankMismatch {
+                expected: rank,
+                actual: perm.len(),
+            },
+        ));
     }
 
     let mut seen = vec![false; rank];
     for &axis in perm {
         if axis >= rank {
-            return Err(Error::AxisOutOfBounds { op, axis, rank });
+            return Err(Error::validation(
+                op,
+                ValidationError::AxisOutOfBounds { axis, rank },
+            ));
         }
         if seen[axis] {
-            return Err(Error::DuplicateAxis {
+            return Err(Error::validation(
                 op,
-                axis,
-                role: "permutation",
-            });
+                ValidationError::DuplicateAxis {
+                    axis,
+                    role: "permutation",
+                },
+            ));
         }
         seen[axis] = true;
     }
@@ -156,6 +179,11 @@ pub fn validate_permutation_axes(op: &'static str, rank: usize, perm: &[usize]) 
 /// assert!(validate_unique_axes("reduce_sum", "axis", 2, &[0, 0]).is_err());
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
+/// axis, dtype, or argument source when validation fails. Singular or
+/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
 pub fn validate_unique_axes(
     op: &'static str,
     role: &'static str,
@@ -165,10 +193,16 @@ pub fn validate_unique_axes(
     let mut seen = vec![false; rank];
     for &axis in axes {
         if axis >= rank {
-            return Err(Error::AxisOutOfBounds { op, axis, rank });
+            return Err(Error::validation(
+                op,
+                ValidationError::AxisOutOfBounds { axis, rank },
+            ));
         }
         if seen[axis] {
-            return Err(Error::DuplicateAxis { op, axis, role });
+            return Err(Error::validation(
+                op,
+                ValidationError::DuplicateAxis { axis, role },
+            ));
         }
         seen[axis] = true;
     }
@@ -186,31 +220,43 @@ pub fn validate_unique_axes(
 /// assert_eq!(config.lhs_contracting_dims, vec![1]);
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
+/// axis, dtype, or argument source when validation fails. Singular or
+/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
 pub fn matmul_config_for_shapes(
     op: &'static str,
     lhs_shape: &[usize],
     rhs_shape: &[usize],
 ) -> Result<DotGeneralConfig> {
     if lhs_shape.len() != 2 {
-        return Err(Error::RankMismatch {
+        return Err(Error::validation(
             op,
-            expected: 2,
-            actual: lhs_shape.len(),
-        });
+            ValidationError::RankMismatch {
+                expected: 2,
+                actual: lhs_shape.len(),
+            },
+        ));
     }
     if rhs_shape.len() != 2 {
-        return Err(Error::RankMismatch {
+        return Err(Error::validation(
             op,
-            expected: 2,
-            actual: rhs_shape.len(),
-        });
+            ValidationError::RankMismatch {
+                expected: 2,
+                actual: rhs_shape.len(),
+            },
+        ));
     }
     if lhs_shape[1] != rhs_shape[0] {
-        return Err(Error::ShapeMismatch {
+        return Err(Error::validation(
             op,
-            lhs: lhs_shape.to_vec(),
-            rhs: rhs_shape.to_vec(),
-        });
+            ShapeMismatch::IncompatibleShapes {
+                lhs: lhs_shape.to_vec().into(),
+                rhs: rhs_shape.to_vec().into(),
+            }
+            .into(),
+        ));
     }
 
     Ok(DotGeneralConfig {
@@ -265,7 +311,8 @@ impl_diag_singularity_complex!(Complex64, Complex32);
 /// Iterates over all batch slices and inspects the diagonal entries
 /// `data[i + i * rows]` for `i` in `0..min(rows, cols)`. Returns
 /// [`Error::BackendFailure`] with `op: "solve"` on the first offending entry,
-/// or [`Error::RankMismatch`] when `t` has rank less than two.
+/// or [`ValidationError::RankMismatch`] wrapped in [`Error::Validation`] when
+/// `t` has rank less than two.
 ///
 /// # Examples
 ///
@@ -276,15 +323,22 @@ impl_diag_singularity_complex!(Complex64, Complex32);
 /// let t = TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0f32, 0.0, 0.0, 2.0]).unwrap();
 /// assert!(check_singular_diagonal(&t).is_ok());
 /// ```
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
+/// axis, dtype, or argument source when validation fails. Singular or
+/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
 pub fn check_singular_diagonal<T: DiagSingularity + Copy + std::fmt::Debug>(
     t: &TypedTensor<T>,
 ) -> Result<()> {
     if t.shape().len() < 2 {
-        return Err(Error::RankMismatch {
-            op: "solve",
-            expected: 2,
-            actual: t.shape().len(),
-        });
+        return Err(Error::validation(
+            "solve",
+            ValidationError::RankMismatch {
+                expected: 2,
+                actual: t.shape().len(),
+            },
+        ));
     }
     let rows = t.shape()[0];
     let cols = t.shape()[1];
@@ -332,6 +386,11 @@ pub fn check_singular_diagonal<T: DiagSingularity + Copy + std::fmt::Debug>(
 /// let t = Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 0.0, 0.0, 1.0]).unwrap());
 /// assert!(validate_nonsingular_u(&t).is_ok());
 /// ```
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
+/// axis, dtype, or argument source when validation fails. Singular or
+/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
 pub fn validate_nonsingular_u(u: &Tensor) -> Result<()> {
     match u {
         Tensor::F64(t) => check_singular_diagonal(t),

--- a/crates/tenferro-tensor/src/validate/mod.rs
+++ b/crates/tenferro-tensor/src/validate/mod.rs
@@ -13,8 +13,34 @@
 use num_complex::{Complex32, Complex64};
 
 use crate::{
-    DType, DotGeneralConfig, Error, Result, ShapeMismatch, Tensor, TypedTensor, ValidationError,
+    DType, DotGeneralConfig, Error, ErrorKind, Result, ShapeMismatch, Tensor, TypedTensor,
+    ValidationError,
 };
+
+/// Domain-specific reasons reported by triangular-factor validation.
+///
+/// The outer tensor error classifies these failures as numerical or unsupported
+/// while retaining this value as its typed source.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_tensor::validate::DiagonalError;
+///
+/// let error = DiagonalError::SingularOrNonFinite {
+///     index: 1,
+/// };
+/// assert!(error.to_string().contains("position [1,1]"));
+/// ```
+#[derive(Debug, thiserror::Error)]
+pub enum DiagonalError {
+    #[error("singular or non-finite diagonal at position [{index},{index}]")]
+    SingularOrNonFinite { index: usize },
+    #[error("singular or non-finite diagonal at batch {batch}, position [{index},{index}]")]
+    BatchedSingularOrNonFinite { batch: usize, index: usize },
+    #[error("triangular solve does not support dtype {dtype:?}")]
+    UnsupportedDType { dtype: DType },
+}
 
 /// Promote two dtypes according to tenferro's public dtype-promotion lattice.
 ///
@@ -75,9 +101,9 @@ pub fn can_convert_dtype(from: DType, to: DType) -> bool {
 /// ```
 /// # Errors
 ///
-/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
-/// axis, dtype, or argument source when validation fails. Singular or
-/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
+/// Returns [`crate::Error::UnsupportedDTypeConversion`] when the requested
+/// conversion is outside the checked promotion lattice. Use an explicit cast
+/// for lossy projections.
 pub fn validate_convert_dtype(op: &'static str, from: DType, to: DType) -> Result<()> {
     if can_convert_dtype(from, to) {
         return Ok(());
@@ -103,9 +129,8 @@ pub fn validate_convert_dtype(op: &'static str, from: DType, to: DType) -> Resul
 /// ```
 /// # Errors
 ///
-/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
-/// axis, dtype, or argument source when validation fails. Singular or
-/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
+/// Returns [`crate::Error::Validation`] with an `InvalidArgument` source when
+/// the shape product overflows `usize`.
 pub fn checked_shape_product(
     op: &'static str,
     role: &'static str,
@@ -131,9 +156,8 @@ pub fn checked_shape_product(
 /// ```
 /// # Errors
 ///
-/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
-/// axis, dtype, or argument source when validation fails. Singular or
-/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
+/// Returns [`crate::Error::Validation`] with `RankMismatch`,
+/// `AxisOutOfBounds`, or `DuplicateAxis` as appropriate.
 pub fn validate_permutation_axes(op: &'static str, rank: usize, perm: &[usize]) -> Result<()> {
     if perm.len() != rank {
         return Err(Error::validation(
@@ -181,9 +205,8 @@ pub fn validate_permutation_axes(op: &'static str, rank: usize, perm: &[usize]) 
 /// ```
 /// # Errors
 ///
-/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
-/// axis, dtype, or argument source when validation fails. Singular or
-/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
+/// Returns [`crate::Error::Validation`] with `AxisOutOfBounds` for an invalid
+/// axis or `DuplicateAxis` when an axis occurs more than once.
 pub fn validate_unique_axes(
     op: &'static str,
     role: &'static str,
@@ -222,9 +245,8 @@ pub fn validate_unique_axes(
 /// ```
 /// # Errors
 ///
-/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
-/// axis, dtype, or argument source when validation fails. Singular or
-/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
+/// Returns [`crate::Error::Validation`] with `RankMismatch` for a non-matrix
+/// input or `ShapeMismatch` when the contracting dimensions differ.
 pub fn matmul_config_for_shapes(
     op: &'static str,
     lhs_shape: &[usize],
@@ -310,7 +332,8 @@ impl_diag_singularity_complex!(Complex64, Complex32);
 ///
 /// Iterates over all batch slices and inspects the diagonal entries
 /// `data[i + i * rows]` for `i` in `0..min(rows, cols)`. Returns
-/// [`Error::BackendFailure`] with `op: "solve"` on the first offending entry,
+/// a numerical [`crate::Error::Extension`] carrying a typed
+/// [`DiagonalError::SingularOrNonFinite`] source for the first offending entry,
 /// or [`ValidationError::RankMismatch`] wrapped in [`Error::Validation`] when
 /// `t` has rank less than two.
 ///
@@ -325,9 +348,11 @@ impl_diag_singularity_complex!(Complex64, Complex32);
 /// ```
 /// # Errors
 ///
-/// Returns [`crate::Error::Validation`] with the applicable typed shape, rank,
-/// axis, dtype, or argument source when validation fails. Singular or
-/// non-finite diagonal checks return [`crate::Error::BackendFailure`].
+/// Returns [`crate::Error::Validation`] with `RankMismatch` for a non-matrix
+/// tensor, a numerical [`crate::Error::Extension`] with a typed
+/// [`DiagonalError::SingularOrNonFinite`] source for a singular or non-finite
+/// diagonal, or an unsupported [`crate::Error::Extension`] with a typed
+/// [`DiagonalError::UnsupportedDType`] source for integer and boolean inputs.
 pub fn check_singular_diagonal<T: DiagSingularity + Copy + std::fmt::Debug>(
     t: &TypedTensor<T>,
 ) -> Result<()> {
@@ -351,18 +376,17 @@ pub fn check_singular_diagonal<T: DiagSingularity + Copy + std::fmt::Debug>(
         for i in 0..n {
             let diag = batch[i + i * rows];
             if diag.is_singular_or_nonfinite() {
-                return Err(Error::backend_failure(
+                return Err(Error::extension(
                     "solve",
+                    "tensor-validation",
+                    ErrorKind::NumericalFailure,
                     if batch_total > 1 {
-                        format!(
-                            "singular matrix: non-finite or zero diagonal at batch {}, position [{},{}] = {:?}",
-                            batch_idx, i, i, diag
-                        )
+                        DiagonalError::BatchedSingularOrNonFinite {
+                            batch: batch_idx,
+                            index: i,
+                        }
                     } else {
-                        format!(
-                            "singular matrix: non-finite or zero diagonal at position [{},{}] = {:?}",
-                            i, i, diag
-                        )
+                        DiagonalError::SingularOrNonFinite { index: i }
                     },
                 ));
             }
@@ -397,9 +421,11 @@ pub fn validate_nonsingular_u(u: &Tensor) -> Result<()> {
         Tensor::F32(t) => check_singular_diagonal(t),
         Tensor::C64(t) => check_singular_diagonal(t),
         Tensor::C32(t) => check_singular_diagonal(t),
-        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => Err(Error::backend_failure(
+        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => Err(Error::extension(
             "solve",
-            format!("unsupported dtype {:?}", u.dtype()),
+            "tensor-validation",
+            ErrorKind::Unsupported,
+            DiagonalError::UnsupportedDType { dtype: u.dtype() },
         )),
     }
 }

--- a/crates/tenferro-tensor/src/validate/tests.rs
+++ b/crates/tenferro-tensor/src/validate/tests.rs
@@ -58,7 +58,13 @@ macro_rules! float_singular_tests {
                     ],
                 );
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
@@ -81,21 +87,39 @@ macro_rules! float_singular_tests {
                     ],
                 );
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
             fn zero_diagonal() {
                 let t = tensor(vec![2, 2], vec![0.0 as $t, 1.0 as $t, 1.0 as $t, 0.0 as $t]);
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
             fn nan_diagonal() {
                 let t = tensor(vec![2, 2], vec![<$t>::NAN, 1.0 as $t, 0.0 as $t, 1.0 as $t]);
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
@@ -105,7 +129,13 @@ macro_rules! float_singular_tests {
                     vec![<$t>::INFINITY, 1.0 as $t, 0.0 as $t, 1.0 as $t],
                 );
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
@@ -115,14 +145,26 @@ macro_rules! float_singular_tests {
                     vec![<$t>::NEG_INFINITY, 1.0 as $t, 0.0 as $t, 1.0 as $t],
                 );
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
             fn single_element_singular() {
                 let t = tensor(vec![1, 1], vec![0.0 as $t]);
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
@@ -141,7 +183,13 @@ macro_rules! float_singular_tests {
                     ],
                 );
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
@@ -198,7 +246,13 @@ macro_rules! complex_singular_tests {
                     ],
                 );
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
@@ -231,7 +285,13 @@ macro_rules! complex_singular_tests {
                     ],
                 );
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
@@ -260,7 +320,13 @@ macro_rules! complex_singular_tests {
                     ],
                 );
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
@@ -275,7 +341,13 @@ macro_rules! complex_singular_tests {
                     ],
                 );
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
@@ -290,7 +362,13 @@ macro_rules! complex_singular_tests {
                     ],
                 );
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
@@ -305,14 +383,26 @@ macro_rules! complex_singular_tests {
                     ],
                 );
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
             fn single_element_singular() {
                 let t = tensor(vec![1, 1], vec![<$t>::new(0.0 as $float, 0.0 as $float)]);
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
@@ -337,7 +427,13 @@ macro_rules! complex_singular_tests {
                     ],
                 );
                 let err = check_singular_diagonal(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]
@@ -397,10 +493,7 @@ fn f64_batched_error_includes_batch_index_and_position() {
     )
     .unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
-    let msg = match &err {
-        Error::BackendFailure { message, .. } => message.clone(),
-        _ => unreachable!(),
-    };
+    let msg = std::error::Error::source(&err).unwrap().to_string();
     assert!(
         msg.contains("batch 1"),
         "expected batch index in error message, got: {msg}"
@@ -425,10 +518,7 @@ fn singular_diagonal_uses_checked_shape_products_before_indexing() {
 fn f64_unbatched_error_omits_batch_index_and_includes_position() {
     let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![0.0, 1.0, 1.0, 0.0]).unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
-    let msg = match &err {
-        Error::BackendFailure { message, .. } => message.clone(),
-        _ => unreachable!(),
-    };
+    let msg = std::error::Error::source(&err).unwrap().to_string();
     assert!(
         !msg.contains("batch"),
         "unbatched error should not mention batch, got: {msg}"
@@ -443,10 +533,7 @@ fn f64_unbatched_error_omits_batch_index_and_includes_position() {
 fn f64_unbatched_error_second_diagonal_reports_correct_position() {
     let t = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![3.0, 1.0, 1.0, 0.0]).unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
-    let msg = match &err {
-        Error::BackendFailure { message, .. } => message.clone(),
-        _ => unreachable!(),
-    };
+    let msg = std::error::Error::source(&err).unwrap().to_string();
     assert!(
         msg.contains("position [1,1]"),
         "expected second diagonal position in error message, got: {msg}"
@@ -461,10 +548,7 @@ fn f64_batched_error_first_batch_reports_correct_position() {
     )
     .unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
-    let msg = match &err {
-        Error::BackendFailure { message, .. } => message.clone(),
-        _ => unreachable!(),
-    };
+    let msg = std::error::Error::source(&err).unwrap().to_string();
     assert!(
         msg.contains("batch 0"),
         "expected batch 0 in error message, got: {msg}"
@@ -480,10 +564,7 @@ fn f32_unbatched_error_includes_exact_position() {
     let t =
         TypedTensor::<f32>::from_vec_col_major(vec![2, 2], vec![0.0f32, 1.0, 1.0, 0.0]).unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
-    let msg = match &err {
-        Error::BackendFailure { message, .. } => message.clone(),
-        _ => unreachable!(),
-    };
+    let msg = std::error::Error::source(&err).unwrap().to_string();
     assert!(
         msg.contains("position [0,0]"),
         "expected exact diagonal position in error message, got: {msg}"
@@ -507,10 +588,7 @@ fn c64_unbatched_error_includes_exact_position() {
     )
     .unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
-    let msg = match &err {
-        Error::BackendFailure { message, .. } => message.clone(),
-        _ => unreachable!(),
-    };
+    let msg = std::error::Error::source(&err).unwrap().to_string();
     assert!(
         msg.contains("position [0,0]"),
         "expected exact position in c64 error, got: {msg}"
@@ -534,10 +612,7 @@ fn c32_unbatched_error_includes_exact_position() {
     )
     .unwrap();
     let err = check_singular_diagonal(&t).unwrap_err();
-    let msg = match &err {
-        Error::BackendFailure { message, .. } => message.clone(),
-        _ => unreachable!(),
-    };
+    let msg = std::error::Error::source(&err).unwrap().to_string();
     assert!(
         msg.contains("position [0,0]"),
         "expected exact position in c32 error, got: {msg}"
@@ -546,6 +621,27 @@ fn c32_unbatched_error_includes_exact_position() {
         !msg.contains("batch"),
         "unbatched c32 error should not mention batch, got: {msg}"
     );
+}
+
+#[test]
+fn diagonal_validation_preserves_numerical_source_and_unsupported_dtype() {
+    let singular = TypedTensor::<f64>::from_vec_col_major(vec![1, 1], vec![0.0]).unwrap();
+    let singular_error = check_singular_diagonal(&singular).unwrap_err();
+    assert_eq!(singular_error.kind(), ErrorKind::NumericalFailure);
+    assert!(matches!(
+        std::error::Error::source(&singular_error)
+            .and_then(|source| source.downcast_ref::<DiagonalError>()),
+        Some(DiagonalError::SingularOrNonFinite { index: 0 })
+    ));
+
+    let integer = Tensor::I32(TypedTensor::from_vec_col_major(vec![1, 1], vec![1]).unwrap());
+    let unsupported_error = validate_nonsingular_u(&integer).unwrap_err();
+    assert_eq!(unsupported_error.kind(), ErrorKind::Unsupported);
+    assert!(matches!(
+        std::error::Error::source(&unsupported_error)
+            .and_then(|source| source.downcast_ref::<DiagonalError>()),
+        Some(DiagonalError::UnsupportedDType { dtype: DType::I32 })
+    ));
 }
 
 macro_rules! validate_nonsingular_u_test {
@@ -570,7 +666,13 @@ macro_rules! validate_nonsingular_u_test {
                     .unwrap(),
                 );
                 let err = validate_nonsingular_u(&t).unwrap_err();
-                assert!(matches!(err, Error::BackendFailure { op: "solve", .. }));
+                assert!(matches!(
+                    err,
+                    Error::Extension {
+                        kind: ErrorKind::NumericalFailure,
+                        ..
+                    }
+                ));
             }
 
             #[test]

--- a/crates/tenferro-tensor/src/validate/tests.rs
+++ b/crates/tenferro-tensor/src/validate/tests.rs
@@ -378,10 +378,12 @@ fn rank_less_than_two_returns_error_instead_of_panicking() {
         let err = check_singular_diagonal(&t).unwrap_err();
         assert!(matches!(
             err,
-            Error::RankMismatch {
+            Error::Validation {
                 op: "solve",
-                expected: 2,
-                actual
+                source: tenferro_tensor_core::ValidationError::RankMismatch {
+                    expected: 2,
+                    actual,
+                },
             } if actual == shape.len()
         ));
     }

--- a/crates/tenferro-xla/src/error.rs
+++ b/crates/tenferro-xla/src/error.rs
@@ -87,9 +87,7 @@ impl Error {
             Self::NonStaticShape { .. } => ErrorKind::Validation(ValidationKind::ShapeMismatch),
             Self::InvalidProgram { .. } => ErrorKind::Validation(ValidationKind::InvalidArgument),
             Self::Tensor(source) => source.kind(),
-            Self::ExtensionLowering { .. } => {
-                ErrorKind::Validation(ValidationKind::InvalidArgument)
-            }
+            Self::ExtensionLowering { source } => source.kind(),
             Self::PjrtFeatureDisabled | Self::PjrtPluginNotLoaded | Self::MissingEnv { .. } => {
                 ErrorKind::RuntimeState
             }
@@ -162,9 +160,12 @@ mod tests {
             ),
             (
                 Error::ExtensionLowering {
-                    source: ExtensionLoweringError::new("cannot lower"),
+                    source: ExtensionLoweringError::new_with_kind(
+                        ErrorKind::Unsupported,
+                        "cannot lower",
+                    ),
                 },
-                ErrorKind::Validation(ValidationKind::InvalidArgument),
+                ErrorKind::Unsupported,
             ),
             (Error::PjrtFeatureDisabled, ErrorKind::RuntimeState),
             (Error::PjrtPluginNotLoaded, ErrorKind::RuntimeState),
@@ -202,15 +203,36 @@ mod tests {
         assert!(StdError::source(&tensor).is_some());
 
         let lowering = Error::ExtensionLowering {
-            source: ExtensionLoweringError::from_source(std::io::Error::other("shape source")),
+            source: ExtensionLoweringError::from_source_with_kind(
+                ErrorKind::BackendFailure,
+                std::io::Error::other("shape source"),
+            ),
         };
+        assert_eq!(lowering.kind(), ErrorKind::BackendFailure);
         let source = StdError::source(&lowering).expect("lowering source should be retained");
-        assert!(source.source().is_some());
+        let typed_source = source
+            .source()
+            .expect("typed lowering source should remain in the chain");
+        assert!(typed_source.downcast_ref::<std::io::Error>().is_some());
 
         let plugin = Error::PluginLoad {
             path: PathBuf::from("plugin.so"),
             source: Box::new(std::io::Error::other("dlopen failed")),
         };
         assert!(StdError::source(&plugin).is_some());
+    }
+
+    #[test]
+    fn xla_extension_lowering_preserves_non_validation_kinds() {
+        for expected in [
+            ErrorKind::NumericalFailure,
+            ErrorKind::BackendFailure,
+            ErrorKind::RuntimeState,
+        ] {
+            let error = Error::ExtensionLowering {
+                source: ExtensionLoweringError::new_with_kind(expected, "typed failure"),
+            };
+            assert_eq!(error.kind(), expected);
+        }
     }
 }

--- a/crates/tenferro-xla/src/error.rs
+++ b/crates/tenferro-xla/src/error.rs
@@ -1,6 +1,10 @@
+use std::error::Error as StdError;
 use std::path::PathBuf;
 
-use tenferro_tensor::DType;
+use tenferro_tensor::{DType, ErrorKind, ValidationKind};
+
+/// Erased typed source used only at the XLA plugin boundary.
+pub type BoxError = Box<dyn StdError + Send + Sync + 'static>;
 
 /// Error type for StableHLO lowering and runtime PJRT plugin loading.
 ///
@@ -39,6 +43,13 @@ pub enum Error {
     },
     #[error("invalid XLA program: {message}")]
     InvalidProgram { message: String },
+    #[error("XLA tensor input/output error: {0}")]
+    Tensor(#[from] tenferro_tensor::Error),
+    #[error("XLA extension standard-op lowering failed: {source}")]
+    ExtensionLowering {
+        #[source]
+        source: tenferro_ops::ext_op::ExtensionLoweringError,
+    },
     #[error("PJRT support requires enabling the tenferro-xla `pjrt` feature")]
     PjrtFeatureDisabled,
     #[error("PJRT execution requires an executor created from a loaded plugin")]
@@ -47,8 +58,45 @@ pub enum Error {
     PjrtCall { call: &'static str, message: String },
     #[error("environment variable {var} is not set; set it to a PJRT plugin .so path")]
     MissingEnv { var: &'static str },
-    #[error("failed to load PJRT plugin from {path}: {message}")]
-    PluginLoad { path: PathBuf, message: String },
+    #[error("failed to load PJRT plugin from {path}: {source}")]
+    PluginLoad {
+        path: PathBuf,
+        #[source]
+        source: BoxError,
+    },
+}
+
+impl Error {
+    /// Return the stable coarse classification for this XLA failure.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tenferro_tensor::ErrorKind;
+    /// use tenferro_xla::Error;
+    ///
+    /// assert_eq!(
+    ///     Error::UnsupportedOp { op: "Maximum", reason: "not lowered" }.kind(),
+    ///     ErrorKind::Unsupported,
+    /// );
+    /// ```
+    #[must_use]
+    pub fn kind(&self) -> ErrorKind {
+        match self {
+            Self::UnsupportedDType { .. } | Self::UnsupportedOp { .. } => ErrorKind::Unsupported,
+            Self::NonStaticShape { .. } => ErrorKind::Validation(ValidationKind::ShapeMismatch),
+            Self::InvalidProgram { .. } => ErrorKind::Validation(ValidationKind::InvalidArgument),
+            Self::Tensor(source) => source.kind(),
+            Self::ExtensionLowering { .. } => {
+                ErrorKind::Validation(ValidationKind::InvalidArgument)
+            }
+            Self::PjrtFeatureDisabled | Self::PjrtPluginNotLoaded | Self::MissingEnv { .. } => {
+                ErrorKind::RuntimeState
+            }
+            Self::PluginLoad { .. } => ErrorKind::Io,
+            Self::PjrtCall { .. } => ErrorKind::BackendFailure,
+        }
+    }
 }
 
 /// Result alias for `tenferro-xla`.
@@ -65,3 +113,104 @@ pub enum Error {
 /// ok().unwrap();
 /// ```
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as StdError;
+    use std::path::PathBuf;
+
+    use tenferro_ops::ext_op::ExtensionLoweringError;
+    use tenferro_tensor::{Error as TensorError, ErrorKind, ValidationKind};
+
+    use super::Error;
+
+    #[test]
+    fn xla_error_kind_distinguishes_capability_state_io_and_backend_failures() {
+        let cases = [
+            (
+                Error::UnsupportedDType {
+                    dtype: tenferro_tensor::DType::I64,
+                    context: "constant",
+                },
+                ErrorKind::Unsupported,
+            ),
+            (
+                Error::UnsupportedOp {
+                    op: "Custom",
+                    reason: "not lowered",
+                },
+                ErrorKind::Unsupported,
+            ),
+            (
+                Error::NonStaticShape {
+                    op: "Reshape",
+                    output_index: 0,
+                    axis: 1,
+                    kind: "symbolic",
+                },
+                ErrorKind::Validation(ValidationKind::ShapeMismatch),
+            ),
+            (
+                Error::InvalidProgram {
+                    message: "missing output".into(),
+                },
+                ErrorKind::Validation(ValidationKind::InvalidArgument),
+            ),
+            (
+                Error::Tensor(TensorError::invalid_argument("xla", "input", "invalid")),
+                ErrorKind::Validation(ValidationKind::InvalidArgument),
+            ),
+            (
+                Error::ExtensionLowering {
+                    source: ExtensionLoweringError::new("cannot lower"),
+                },
+                ErrorKind::Validation(ValidationKind::InvalidArgument),
+            ),
+            (Error::PjrtFeatureDisabled, ErrorKind::RuntimeState),
+            (Error::PjrtPluginNotLoaded, ErrorKind::RuntimeState),
+            (
+                Error::MissingEnv { var: "PJRT_PLUGIN" },
+                ErrorKind::RuntimeState,
+            ),
+            (
+                Error::PluginLoad {
+                    path: PathBuf::from("plugin.so"),
+                    source: Box::new(std::io::Error::other("not found")),
+                },
+                ErrorKind::Io,
+            ),
+            (
+                Error::PjrtCall {
+                    call: "pjrt_execute",
+                    message: "invalid status".into(),
+                },
+                ErrorKind::BackendFailure,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(error.kind(), expected, "classified {error:?}");
+        }
+    }
+
+    #[test]
+    fn xla_error_sources_remain_typed_at_boundary() {
+        let tensor = Error::Tensor(TensorError::backend_source(
+            "xla_input",
+            std::io::Error::other("device read failed"),
+        ));
+        assert!(StdError::source(&tensor).is_some());
+
+        let lowering = Error::ExtensionLowering {
+            source: ExtensionLoweringError::from_source(std::io::Error::other("shape source")),
+        };
+        let source = StdError::source(&lowering).expect("lowering source should be retained");
+        assert!(source.source().is_some());
+
+        let plugin = Error::PluginLoad {
+            path: PathBuf::from("plugin.so"),
+            source: Box::new(std::io::Error::other("dlopen failed")),
+        };
+        assert!(StdError::source(&plugin).is_some());
+    }
+}

--- a/crates/tenferro-xla/src/executor.rs
+++ b/crates/tenferro-xla/src/executor.rs
@@ -90,6 +90,12 @@ impl XlaExecutor {
     ///     assert!(matches!(err, Error::PjrtFeatureDisabled | Error::MissingEnv { .. } | Error::PluginLoad { .. }));
     /// }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Without `pjrt`, returns `Error::PjrtFeatureDisabled`. With `pjrt`,
+    /// returns `Error::MissingEnv` for an unset plugin path or
+    /// `Error::PluginLoad` with the typed dynamic-library source.
     #[cfg(not(feature = "pjrt"))]
     pub fn from_env() -> Result<Self> {
         Err(Error::PjrtFeatureDisabled)
@@ -104,6 +110,12 @@ impl XlaExecutor {
     ///
     /// let _ = XlaExecutor::from_env();
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::MissingEnv` when the configured plugin-path variable is
+    /// unset, or `Error::PluginLoad` with the typed dynamic-library source
+    /// when the path cannot be loaded.
     #[cfg(feature = "pjrt")]
     pub fn from_env() -> Result<Self> {
         Self::from_env_var(crate::TENFERRO_PJRT_PLUGIN_ENV)
@@ -119,6 +131,11 @@ impl XlaExecutor {
     ///
     /// let _ = XlaExecutor::from_env_var("__TENFERRO_XLA_DOCS_UNSET");
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::MissingEnv` when `var` is unset, or `Error::PluginLoad`
+    /// with the typed dynamic-library source when its value cannot be loaded.
     #[cfg(feature = "pjrt")]
     pub fn from_env_var(var: &'static str) -> Result<Self> {
         let plugin = crate::pjrt::PjrtPlugin::load_from_env(var)?;
@@ -176,6 +193,12 @@ impl XlaExecutor {
     /// let module = XlaExecutor::default().lower_to_stablehlo(&program).unwrap();
     /// assert!(module.as_str().contains("stablehlo.negate"));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::UnsupportedDType`, `Error::UnsupportedOp`, or
+    /// `Error::NonStaticShape` for unsupported graph content, and
+    /// `Error::InvalidProgram` for inconsistent graph metadata.
     pub fn lower_to_stablehlo(&self, program: &GraphProgram) -> Result<StableHloModule> {
         lower_to_stablehlo(program)
     }
@@ -203,6 +226,13 @@ impl XlaExecutor {
     ///     .unwrap_err();
     /// assert!(matches!(err, Error::PjrtFeatureDisabled | Error::PjrtPluginNotLoaded));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::PjrtFeatureDisabled` or `Error::PjrtPluginNotLoaded`
+    /// when no PJRT executor is available, `Error::InvalidProgram` for input
+    /// count/dtype/shape mismatches, and `Error::PjrtCall` for vendor status
+    /// failures.
     pub fn run_many_with_inputs(
         &self,
         program: &GraphProgram,
@@ -239,6 +269,12 @@ impl XlaExecutor {
     /// let err = XlaExecutor::default().run_with_inputs(&program, &[&input]).unwrap_err();
     /// assert!(matches!(err, Error::PjrtFeatureDisabled | Error::PjrtPluginNotLoaded));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Propagates the `run_many_with_inputs` errors and returns
+    /// `Error::InvalidProgram` if the program does not have exactly one
+    /// output.
     pub fn run_with_inputs(&self, program: &GraphProgram, inputs: &[&Tensor]) -> Result<Tensor> {
         single_output_tensor(self.run_many_with_inputs(program, inputs)?)
     }

--- a/crates/tenferro-xla/src/lib.rs
+++ b/crates/tenferro-xla/src/lib.rs
@@ -71,6 +71,12 @@ pub const TENFERRO_PJRT_GPU_PLUGIN_ENV: &str = "TENFERRO_PJRT_GPU_PLUGIN";
 /// let module = lower_to_stablehlo(&program).unwrap();
 /// assert!(module.as_str().contains("stablehlo.negate"));
 /// ```
+///
+/// # Errors
+///
+/// Returns `Error::UnsupportedDType`, `Error::UnsupportedOp`, or
+/// `Error::NonStaticShape` for unsupported graph content, and
+/// `Error::InvalidProgram` for inconsistent graph metadata.
 pub fn lower_to_stablehlo(program: &tenferro_runtime::GraphProgram) -> Result<StableHloModule> {
     lowering::lower_to_stablehlo(program)
 }

--- a/crates/tenferro-xla/src/lowering/program.rs
+++ b/crates/tenferro-xla/src/lowering/program.rs
@@ -265,12 +265,7 @@ fn lower_extension_instruction(
             &input_dtypes,
             &input_sym_shape_refs,
         )
-        .map_err(|err| Error::InvalidProgram {
-            message: format!(
-                "extension family {:?} standard-op lowering failed: {err}",
-                op.family_id()
-            ),
-        })?
+        .map_err(|source| Error::ExtensionLowering { source })?
     else {
         return Err(Error::UnsupportedOp {
             op: op.family_id(),
@@ -710,9 +705,7 @@ fn stablehlo_dot_shape(
 ) -> Result<Vec<usize>> {
     config
         .validate_dims_with_ranks(lhs_shape.len(), rhs_shape.len())
-        .map_err(|err| Error::InvalidProgram {
-            message: err.to_string(),
-        })?;
+        .map_err(Error::from)?;
     let lhs_free = free_dims(
         lhs_shape.len(),
         &config.lhs_contracting_dims,

--- a/crates/tenferro-xla/src/lowering/program/tests.rs
+++ b/crates/tenferro-xla/src/lowering/program/tests.rs
@@ -1,4 +1,4 @@
-use tenferro_tensor::{DType, DotGeneralConfig};
+use tenferro_tensor::{DType, DotGeneralConfig, ValidationError};
 
 use super::*;
 
@@ -127,9 +127,11 @@ fn dot_shape_rejects_invalid_dimension_config() {
         },
     )
     .unwrap_err();
-
     assert!(matches!(
         err,
-        Error::InvalidProgram { ref message } if message.contains("lhs_contracting_dim")
+        Error::Tensor(tenferro_tensor::Error::Validation {
+            source: ValidationError::AxisOutOfBounds { axis: 2, rank: 2 },
+            ..
+        })
     ));
 }

--- a/crates/tenferro-xla/src/pjrt/execute.rs
+++ b/crates/tenferro-xla/src/pjrt/execute.rs
@@ -207,9 +207,7 @@ fn element_count(shape: &[usize]) -> Result<usize> {
 }
 
 fn tensor_slice<T: tenferro_tensor::TensorScalar>(tensor: &Tensor) -> Result<&[T]> {
-    tensor.as_slice::<T>().map_err(|err| Error::InvalidProgram {
-        message: format!("PJRT input tensor is not compact host data: {err}"),
-    })
+    tensor.as_slice::<T>().map_err(Error::from)
 }
 
 fn pjrt_error_message(api: &PJRT_Api, error: *mut PJRT_Error) -> String {
@@ -672,17 +670,13 @@ impl PjrtBuffer<'_> {
             DType::F32 => {
                 let col_major = self.download_host_vec::<f32>(&spec.shape)?;
                 let tensor = TypedTensor::from_vec_col_major(spec.shape.clone(), col_major)
-                    .map_err(|err| Error::InvalidProgram {
-                        message: format!("PJRT F32 output tensor construction failed: {err}"),
-                    })?;
+                    .map_err(Error::from)?;
                 Ok(Tensor::F32(tensor))
             }
             DType::F64 => {
                 let col_major = self.download_host_vec::<f64>(&spec.shape)?;
                 let tensor = TypedTensor::from_vec_col_major(spec.shape.clone(), col_major)
-                    .map_err(|err| Error::InvalidProgram {
-                        message: format!("PJRT F64 output tensor construction failed: {err}"),
-                    })?;
+                    .map_err(Error::from)?;
                 Ok(Tensor::F64(tensor))
             }
             other => Err(Error::UnsupportedDType {

--- a/crates/tenferro-xla/src/pjrt/plugin.rs
+++ b/crates/tenferro-xla/src/pjrt/plugin.rs
@@ -42,6 +42,12 @@ impl PjrtPlugin {
     /// let err = PjrtPlugin::load_from_env("__TENFERRO_XLA_DOCS_UNSET").unwrap_err();
     /// assert!(matches!(err, Error::MissingEnv { .. }));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::MissingEnv` when `var` is unset, or `Error::PluginLoad`
+    /// with the typed dynamic-library source when loading or symbol lookup
+    /// fails.
     pub fn load_from_env(var: &'static str) -> Result<Self> {
         let path = super::plugin_path_from_env(var)?;
         Self::load_path(path)
@@ -57,13 +63,19 @@ impl PjrtPlugin {
     /// let err = PjrtPlugin::load_path("/definitely/missing/pjrt.so").unwrap_err();
     /// assert!(matches!(err, Error::PluginLoad { .. }));
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::PluginLoad` with the original dynamic-library error as
+    /// its source when the file cannot be opened or `GetPjrtApi` is missing,
+    /// or `Error::PjrtCall` when the plugin returns a null API table.
     pub fn load_path(path: impl Into<PathBuf>) -> Result<Self> {
         let path = path.into();
         // SAFETY: Loading a dynamic library is inherently unsafe. The library is
         // retained in `Self` for at least as long as the API pointer is exposed.
-        let library = unsafe { Library::new(&path) }.map_err(|err| Error::PluginLoad {
+        let library = unsafe { Library::new(&path) }.map_err(|source| Error::PluginLoad {
             path: path.clone(),
-            message: err.to_string(),
+            source: Box::new(source),
         })?;
         // SAFETY: OpenXLA PJRT plugins export `GetPjrtApi` with this signature.
         // The returned table is owned by the plugin and remains valid while the
@@ -72,16 +84,16 @@ impl PjrtPlugin {
             let symbol: libloading::Symbol<'_, GetPjrtApiFn> =
                 library
                     .get(b"GetPjrtApi")
-                    .map_err(|err| Error::PluginLoad {
+                    .map_err(|source| Error::PluginLoad {
                         path: path.clone(),
-                        message: err.to_string(),
+                        source: Box::new(source),
                     })?;
             symbol()
         };
         if api.is_null() {
-            return Err(Error::PluginLoad {
-                path,
-                message: "GetPjrtApi returned null".to_string(),
+            return Err(Error::PjrtCall {
+                call: "GetPjrtApi",
+                message: format!("plugin at {path:?} returned a null API table"),
             });
         }
         Ok(Self {

--- a/crates/tenferro-xla/tests/integration.rs
+++ b/crates/tenferro-xla/tests/integration.rs
@@ -1,3 +1,12 @@
+#[cfg(feature = "pjrt")]
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+#[cfg(feature = "pjrt")]
+fn pjrt_env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+}
+
 #[path = "integration/pjrt_env.rs"]
 mod pjrt_env;
 #[path = "integration/pjrt_execution.rs"]

--- a/crates/tenferro-xla/tests/integration/pjrt_env.rs
+++ b/crates/tenferro-xla/tests/integration/pjrt_env.rs
@@ -1,19 +1,13 @@
 #![cfg(feature = "pjrt")]
 
 use std::ffi::OsString;
-use std::sync::{Mutex, OnceLock};
 
 use tenferro_xla::{
     Error, PjrtPlugin, XlaExecutor, TENFERRO_PJRT_GPU_PLUGIN_ENV, TENFERRO_PJRT_PLUGIN_ENV,
 };
 
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
-}
-
 fn with_env_var<T>(var: &'static str, value: Option<&str>, f: impl FnOnce() -> T) -> T {
-    let _guard = env_lock();
+    let _guard = super::pjrt_env_lock();
     let previous = std::env::var_os(var);
     match value {
         Some(value) => std::env::set_var(var, value),
@@ -94,7 +88,7 @@ fn empty_plugin_env_var_is_treated_as_missing() {
 
 #[test]
 fn env_restore_handles_non_utf8_values() {
-    let _guard = env_lock();
+    let _guard = super::pjrt_env_lock();
     let var = "__TENFERRO_XLA_PJRT_NON_UTF8";
     let previous = std::env::var_os(var);
     std::env::set_var(var, OsString::from("/tmp/non_utf8_marker"));

--- a/crates/tenferro-xla/tests/integration/pjrt_execution.rs
+++ b/crates/tenferro-xla/tests/integration/pjrt_execution.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "pjrt")]
 
-use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::sync::MutexGuard;
 
 use tenferro_einsum::GraphCompilerEinsumExt;
 use tenferro_runtime::{DType, GraphCompiler, TracedTensor};
@@ -146,19 +146,12 @@ fn pjrt_executes_nary_einsum_plus_elementwise_from_rust_when_configured() {
 }
 
 fn configured_executor() -> Option<(MutexGuard<'static, ()>, XlaExecutor)> {
-    let guard = pjrt_lock();
-    if std::env::var_os(TENFERRO_PJRT_PLUGIN_ENV).is_none() {
+    let guard = super::pjrt_env_lock();
+    if std::env::var_os(TENFERRO_PJRT_PLUGIN_ENV).is_none_or(|path| path.is_empty()) {
         eprintln!("skipping PJRT execution check; set {TENFERRO_PJRT_PLUGIN_ENV}");
         return None;
     }
     Some((guard, XlaExecutor::from_env().unwrap()))
-}
-
-fn pjrt_lock() -> MutexGuard<'static, ()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 fn expected_ij_jk_kl_to_il(lhs: &[f32], mid: &[f32], rhs: &[f32]) -> Vec<f32> {

--- a/crates/tenferro-xla/tests/integration/source_contract.rs
+++ b/crates/tenferro-xla/tests/integration/source_contract.rs
@@ -1,5 +1,10 @@
 use std::{fs, path::Path};
 
+use std::error::Error as _;
+
+use tenferro_tensor::{ErrorKind, ValidationKind};
+use tenferro_xla::Error;
+
 fn lowering_program_source() -> String {
     fs::read_to_string(
         Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -8,6 +13,17 @@ fn lowering_program_source() -> String {
             .join("program.rs"),
     )
     .unwrap_or_else(|err| panic!("XLA lowering source should be readable: {err}"))
+}
+
+#[test]
+fn xla_tensor_errors_preserve_kind_and_source_chain() {
+    let error = Error::from(tenferro_tensor::Error::rank_mismatch("input", 2, 1));
+
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::RankMismatch)
+    );
+    assert!(error.source().is_some());
 }
 
 fn pjrt_execute_source() -> String {

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -162,6 +162,38 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 <!-- end-snippet-source -->
 
+### Fallible operator chaining
+
+Tensor operator overloads are deliberately fallible: each `+` produces a
+`Result<TracedTensor, Error>`. Consequently, `a + b + c` parses as
+`(a + b) + c`, and the second `+` would receive the first `Result` rather
+than a tensor. The chained expression therefore does not compose for dynamic
+tensors.
+
+Use `?` at each step, or use the explicit fallible methods when a longer
+operation sequence is clearer:
+
+```rust
+use tenferro_runtime::{Error, TracedTensor};
+
+fn add_three(
+    a: &TracedTensor,
+    b: &TracedTensor,
+    c: &TracedTensor,
+) -> Result<TracedTensor, Error> {
+    let ab = (a + b)?;
+    let sum = (&ab + c)?;
+
+    let method_chain = a.add(b)?.add(c)?;
+    let _ = method_chain;
+    Ok(sum)
+}
+```
+
+Tenferro prioritizes robust error handling over the conciseness of chained
+operator notation. The explicit methods are the canonical form for code that
+needs to make fallible control flow and deferred graph errors easy to review.
+
 Traced mode is the right API when `grad`, `vjp`, `jvp`, or HVP-style
 composition should run on traced graphs with symbolic inputs, graph
 optimization, and repeated execution.

--- a/docs/guides/tensor-operations.md
+++ b/docs/guides/tensor-operations.md
@@ -258,6 +258,35 @@ assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[5.0, 7.0, 9.0]);
 assert_eq!(outputs[1].as_slice::<f64>().unwrap(), &[4.0, 10.0, 18.0]);
 ```
 
+### Fallible operator chains
+
+The overloaded operators are fallible: `a + b` returns a
+`Result<TracedTensor, Error>`. Therefore `a + b + c` parses as `(a + b) + c`,
+and the second operator receives a `Result`, not a tensor. It is not a
+composable chain for dynamic tensors.
+
+Unwrap each step with `?`, or use the explicit fallible method chain:
+
+```rust
+use tenferro_runtime::{Error, TracedTensor};
+
+fn add_three(
+    a: &TracedTensor,
+    b: &TracedTensor,
+    c: &TracedTensor,
+) -> Result<TracedTensor, Error> {
+    let ab = (a + b)?;
+    let sum = (&ab + c)?;
+    let canonical = a.add(b)?.add(c)?;
+    let _ = canonical;
+    Ok(sum)
+}
+```
+
+Tenferro prioritizes robust error handling over concise chained operator
+notation, so explicit fallible methods are the canonical choice for longer
+sequences and code that needs deferred graph errors to remain visible.
+
 ## Elementwise Math Functions
 
 ```rust

--- a/docs/superpowers/plans/2026-07-17-structured-error-model.md
+++ b/docs/superpowers/plans/2026-07-17-structured-error-model.md
@@ -1009,6 +1009,13 @@ Use this decision rule at every current `backend_failure`, `InvalidConfig`, or `
 2. typed in-workspace kernel/extension error: `backend_source` or `extension` with its source;
 3. vendor status/message only: `BackendFailure` text is allowed;
 4. impossible internal state: typed `Internal`, not validation.
+5. typed file, stream, serialization, or dynamic-library I/O: preserve the
+   source and classify it as `ErrorKind::Io` (use the tensor/runtime I/O source
+   constructor or a crate-local source variant).
+6. missing, uninitialized, poisoned, or invalid executor/cache/device state:
+   classify it as `ErrorKind::RuntimeState`, preserving a typed source when
+   available. `BackendFailure` is reserved for vendor/backend status text with
+   no typed source or more specific category.
 
 Do not rewrite display-only `to_string()` calls in tests, logs, cache keys, or actual FFI message extraction. Update tests that match removed variants.
 

--- a/docs/superpowers/plans/2026-07-17-structured-error-model.md
+++ b/docs/superpowers/plans/2026-07-17-structured-error-model.md
@@ -1,0 +1,1312 @@
+# Structured Error Model Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace duplicated and stringly tensor errors with shared structured validation, align eager and traced failure timing, make traced reshape fallible, and enforce complete public `# Errors` / `# Panics` documentation.
+
+**Architecture:** `tenferro-tensor-core` owns `ValidationError`, detailed shape payloads, and coarse `ErrorKind`; higher crates wrap those values with operation and runtime phase context while retaining crate-local domain errors. Implementation proceeds strictly bottom-up so every consumer migrates to one public model before release, with no compatibility aliases or deprecated variants.
+
+**Tech Stack:** Rust 2021, `thiserror`, Cargo workspace, Clippy, rustdoc/doctests, Python repository-rules review.
+
+## Global Constraints
+
+- Caller-controlled invalid input returns a typed error and must not panic.
+- Validate at the earliest phase with sufficient information.
+- Error kind and error phase remain separate.
+- Never convert a typed in-workspace error to `String`; strings are allowed only when an external/vendor API supplies no structured source, or at display/logging/FFI/serialization boundaries.
+- Explicit fallible methods are canonical; `Add<Output = Result<_>>` remains convenience syntax.
+- Do not implement fallible `AddAssign` or add a panicking operator alternative.
+- Every public `Result` function/method/trait method has a concrete `# Errors` section; traced deferred validation also has `# Deferred errors`.
+- Every documented public panic contract has `# Panics`.
+- Pre-1.0 API cleanliness takes priority over compatibility: no aliases, deprecated shims, legacy error variants, or old traced reshape wrapper survive the final tree.
+- Keep `tenferro-runtime` free of AD ownership and preserve the existing runtime/AD dependency boundary.
+- Work test-first, keep the workspace compiling at each commit, and commit only files named by the current task.
+
+---
+
+## File and dependency map
+
+| Layer | Primary files | Responsibility |
+|---|---|---|
+| Shared validation | `crates/tenferro-tensor-core/src/error.rs`, `src/lib.rs`, `src/layout.rs`, `src/rank.rs` | Detailed validation payloads and stable classification |
+| Runtime tensor error | `crates/tenferro-tensor/src/error.rs`, `src/validate/mod.rs`, `src/types.rs`, `src/config.rs`, `src/backend.rs` | Operation context, backend/extension sources, tensor execution errors |
+| Graph/runtime error | `crates/tenferro-runtime/src/error.rs`, `src/traced.rs`, `src/shape_infer.rs`, `src/graph/compiler.rs`, `src/graph/executor.rs`, `src/eager_exec.rs` | Graph phase context and earliest validation |
+| AD propagation | `crates/tenferro-ad/src/ad_rule_error.rs`, `src/eager_ops.rs`, `src/eager_exec.rs`, `src/shape_packing.rs`, `src/traced.rs` | Preserve runtime/tensor classification through eager and traced AD |
+| Extension ownership | `crates/tenferro-einsum/src/error.rs`, `src/concrete.rs`, `src/eager_ad.rs`, `src/traced.rs`, `src/extension.rs`; linalg/FFT/XLA and `ext/*` error sites | Local parsing/planning/numerical sources plus shared validation |
+| Public explanation | `crates/tenferro-runtime/src/lib.rs`, `src/traced.rs`, `docs/getting-started/core-concepts.md`, `docs/spec/api-conventions.md` | Correct fallible operator and deferred-error examples |
+| Governance | `REPOSITORY_RULES.md`, `.github/workflows/ci.yml`, `scripts/test-repository-rules-review.py` | Required docs and workspace/extension audit gates |
+
+---
+
+### Task 1: Introduce the shared validation vocabulary in tensor-core
+
+**Files:**
+- Create: `crates/tenferro-tensor-core/src/error.rs`
+- Modify: `crates/tenferro-tensor-core/src/lib.rs:35-125`
+- Modify: `crates/tenferro-tensor-core/src/layout.rs:175-535`
+- Modify: `crates/tenferro-tensor-core/src/rank.rs:1-110`
+- Modify: `crates/tenferro-tensor-core/tests/core.rs:1-180`
+
+**Interfaces:**
+- Produces: `ValidationError`, `ShapeMismatch`, `ValidationKind`, `ErrorKind`, and `Result<T> = core::result::Result<T, ValidationError>`.
+- Produces: `ValidationError::kind(&self) -> ValidationKind`.
+- Consumed by: every later task.
+
+- [ ] **Step 1: Add failing classification and payload tests**
+
+Add these tests to `crates/tenferro-tensor-core/tests/core.rs` and replace the existing `Error` import with `ValidationError`:
+
+```rust
+use tenferro_tensor_core::{
+    ErrorKind, ShapeMismatch, ShapeVec, ValidationError, ValidationKind,
+};
+
+#[test]
+fn shape_mismatch_keeps_machine_readable_payload() {
+    let err = ValidationError::ShapeMismatch(ShapeMismatch::IncompatibleShapes {
+        lhs: ShapeVec::from_vec(vec![2, 3]),
+        rhs: ShapeVec::from_vec(vec![2, 4]),
+    });
+
+    assert_eq!(err.kind(), ValidationKind::ShapeMismatch);
+    assert!(matches!(
+        err,
+        ValidationError::ShapeMismatch(ShapeMismatch::IncompatibleShapes {
+            ref lhs,
+            ref rhs,
+        }) if lhs.as_slice() == [2, 3] && rhs.as_slice() == [2, 4]
+    ));
+}
+
+#[test]
+fn public_error_kind_can_classify_validation() {
+    assert_eq!(
+        ErrorKind::Validation(ValidationKind::RankMismatch),
+        ErrorKind::Validation(ValidationKind::RankMismatch)
+    );
+}
+```
+
+- [ ] **Step 2: Run the tests to verify the new API is absent**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor-core --test core shape_mismatch_keeps_machine_readable_payload
+```
+
+Expected: compile failure for unresolved `ValidationError`, `ShapeMismatch`, `ValidationKind`, and `ErrorKind`.
+
+- [ ] **Step 3: Move the error model into `src/error.rs`**
+
+Create the following public shape, retaining every existing tensor-core validation case as a structured `ValidationError` variant:
+
+```rust
+use crate::{DType, ShapeVec};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ValidationKind {
+    ShapeMismatch,
+    RankMismatch,
+    AxisOutOfBounds,
+    DTypeMismatch,
+    InvalidArgument,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    Validation(ValidationKind),
+    Unsupported,
+    NumericalFailure,
+    BackendFailure,
+    Io,
+    RuntimeState,
+    Internal,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ShapeMismatch {
+    #[error("incompatible shapes: lhs={lhs:?}, rhs={rhs:?}")]
+    IncompatibleShapes { lhs: ShapeVec, rhs: ShapeVec },
+    #[error("shape mismatch: expected={expected:?}, actual={actual:?}")]
+    ExpectedActual { expected: ShapeVec, actual: ShapeVec },
+    #[error("reshape element-count mismatch: from {from} to {to}")]
+    ReshapeElementCount { from: usize, to: usize },
+    #[error(
+        "contracted dimensions differ: lhs axis {lhs_axis} ({lhs_size}) vs rhs axis {rhs_axis} ({rhs_size})"
+    )]
+    ContractedDimensions {
+        lhs_axis: usize,
+        lhs_size: usize,
+        rhs_axis: usize,
+        rhs_size: usize,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum ValidationError {
+    #[error(transparent)]
+    ShapeMismatch(#[from] ShapeMismatch),
+    #[error("shape product {expected} does not match data length {actual}")]
+    ShapeDataLengthMismatch { expected: usize, actual: usize },
+    #[error("rank mismatch: expected {expected}, actual {actual}")]
+    RankMismatch { expected: usize, actual: usize },
+    #[error("axis {axis} out of bounds for rank {rank}")]
+    AxisOutOfBounds { axis: usize, rank: usize },
+    #[error("duplicate {role} axis {axis}")]
+    DuplicateAxis { axis: usize, role: &'static str },
+    #[error("axis {axis} appears in both {first_role} and {second_role}")]
+    AxisRoleConflict {
+        axis: usize,
+        first_role: &'static str,
+        second_role: &'static str,
+    },
+    #[error("invalid permutation length: expected {expected}, actual {actual}")]
+    InvalidPermutationLength { expected: usize, actual: usize },
+    #[error("invalid slice step {step}; zero is invalid")]
+    InvalidSliceStep { step: isize },
+    #[error("invalid slice bounds: start={start}, end={end}, axis_len={axis_len}")]
+    InvalidSliceBounds { start: isize, end: isize, axis_len: usize },
+    #[error("dtype mismatch: expected {expected:?}, actual {actual:?}")]
+    DTypeMismatch { expected: DType, actual: DType },
+    #[error("invalid argument {argument}: {message}")]
+    InvalidArgument { argument: &'static str, message: String },
+    #[error("view is not slice-contiguous")]
+    NonContiguousViewAsSlice,
+    #[error("view metadata is out of borrowed-slice bounds")]
+    ViewOutOfBounds,
+    #[error("mutable tensor layout may overlap physical elements")]
+    OverlappingMutableLayout,
+    #[error("integer overflow while validating tensor metadata")]
+    IntegerOverflow,
+}
+
+impl ValidationError {
+    pub fn kind(&self) -> ValidationKind {
+        match self {
+            Self::ShapeMismatch(_) | Self::ShapeDataLengthMismatch { .. } => {
+                ValidationKind::ShapeMismatch
+            }
+            Self::RankMismatch { .. } | Self::InvalidPermutationLength { .. } => {
+                ValidationKind::RankMismatch
+            }
+            Self::AxisOutOfBounds { .. } => ValidationKind::AxisOutOfBounds,
+            Self::DTypeMismatch { .. } => ValidationKind::DTypeMismatch,
+            _ => ValidationKind::InvalidArgument,
+        }
+    }
+}
+```
+
+Move `Result<T>` to use `ValidationError`, add `mod error; pub use error::{...};` after `ShapeVec` is declared, and remove the old `Error` enum completely. Update tensor-core call sites and tests from `Error::...` to `ValidationError::...`; `DuplicateAxis` constructors now supply the role (`"permutation"` where applicable), and reshape uses `ShapeMismatch::ReshapeElementCount`.
+
+- [ ] **Step 4: Add concrete `# Errors` sections for tensor-core**
+
+The baseline Clippy run reports 27 missing sections in `src/layout.rs`, `src/rank.rs`, and `src/lib.rs`. For each reported public function, name the actual `ValidationError` variant. Use wording such as:
+
+```rust
+/// # Errors
+///
+/// Returns [`ValidationError::RankMismatch`] when the supplied shape length
+/// differs from the compile-time rank.
+```
+
+Do not use “returns an error on failure.” Run Clippy repeatedly until the package has zero `missing_errors_doc` and `missing_panics_doc` findings.
+
+- [ ] **Step 5: Verify tensor-core**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor-core
+cargo clippy -p tenferro-tensor-core --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 6: Commit the shared layer**
+
+```bash
+git add -- \
+  crates/tenferro-tensor-core/src/error.rs \
+  crates/tenferro-tensor-core/src/lib.rs \
+  crates/tenferro-tensor-core/src/layout.rs \
+  crates/tenferro-tensor-core/src/rank.rs \
+  crates/tenferro-tensor-core/tests/core.rs
+git commit -m "refactor: centralize tensor validation errors"
+```
+
+---
+
+### Task 2: Wrap shared validation in tenferro-tensor without losing sources
+
+**Files:**
+- Modify: `crates/tenferro-tensor/src/error.rs:1-113`
+- Modify: `crates/tenferro-tensor/src/lib.rs:35-65`
+- Modify: `crates/tenferro-tensor/src/validate/mod.rs:1-240`
+- Modify: `crates/tenferro-tensor/src/validate/tests.rs:1-80`
+- Modify: `crates/tenferro-tensor/src/types.rs:3431-3467`
+- Modify: `crates/tenferro-tensor/src/config.rs`
+- Modify: `crates/tenferro-tensor/src/backend.rs`
+- Test: `crates/tenferro-tensor/src/tests/types_tests.rs`
+
+**Interfaces:**
+- Consumes: Task 1 `ValidationError`, `ShapeMismatch`, `ValidationKind`, `ErrorKind`.
+- Produces: `tenferro_tensor::Error::{Validation, UnsupportedDTypeConversion, BackendFailure, BackendSource, Extension, MissingValue, Internal}`.
+- Produces: constructors `validation`, `invalid_argument`, `backend_failure`, `backend_source`, `extension`, plus `kind()`.
+
+- [ ] **Step 1: Add failing tensor-wrapper tests**
+
+Add to `crates/tenferro-tensor/src/tests/types_tests.rs`:
+
+```rust
+use std::error::Error as _;
+use tenferro_tensor::{
+    Error, ErrorKind, ShapeMismatch, ShapeVec, ValidationError, ValidationKind,
+};
+
+#[test]
+fn tensor_error_preserves_shared_validation_source() {
+    let err = Error::validation(
+        "add",
+        ShapeMismatch::IncompatibleShapes {
+            lhs: ShapeVec::from_vec(vec![2]),
+            rhs: ShapeVec::from_vec(vec![3]),
+        }
+        .into(),
+    );
+
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::ShapeMismatch)
+    );
+    assert!(err.source().is_some());
+    assert!(matches!(
+        err,
+        Error::Validation {
+            op: "add",
+            source: ValidationError::ShapeMismatch(_),
+        }
+    ));
+}
+
+#[test]
+fn typed_backend_source_is_not_formatted_away() {
+    let err = Error::backend_source("load", std::io::Error::other("device read failed"));
+    assert_eq!(err.kind(), ErrorKind::BackendFailure);
+    assert!(err.source().is_some());
+}
+```
+
+- [ ] **Step 2: Verify the tests fail against the old enum**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor tensor_error_preserves_shared_validation_source
+```
+
+Expected: compile failure because the constructors and wrapper variants do not exist.
+
+- [ ] **Step 3: Replace duplicated tensor validation variants**
+
+Implement this outer shape in `src/error.rs`:
+
+```rust
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{op}: {source}")]
+    Validation {
+        op: &'static str,
+        #[source]
+        source: ValidationError,
+    },
+    #[error("{op}: unsupported dtype conversion from {from:?} to {to:?}: {message}")]
+    UnsupportedDTypeConversion {
+        op: &'static str,
+        from: DType,
+        to: DType,
+        message: String,
+    },
+    #[error("{op}: backend failure: {message}")]
+    BackendFailure { op: &'static str, message: String },
+    #[error("{op}: backend failure: {source}")]
+    BackendSource {
+        op: &'static str,
+        #[source]
+        source: BoxError,
+    },
+    #[error("{op}: extension {family} failed: {source}")]
+    Extension {
+        op: &'static str,
+        family: &'static str,
+        kind: ErrorKind,
+        #[source]
+        source: BoxError,
+    },
+    #[error("missing runtime value for slot {slot}")]
+    MissingValue { slot: usize },
+    #[error("internal tensor error: {0}")]
+    Internal(String),
+}
+```
+
+Implement:
+
+```rust
+pub fn validation(op: &'static str, source: ValidationError) -> Self;
+pub fn invalid_argument(
+    op: &'static str,
+    argument: &'static str,
+    message: impl Into<String>,
+) -> Self;
+pub fn backend_failure(op: &'static str, message: impl Into<String>) -> Self;
+pub fn backend_source<E>(op: &'static str, source: E) -> Self
+where
+    E: std::error::Error + Send + Sync + 'static;
+pub fn extension<E>(
+    op: &'static str,
+    family: &'static str,
+    kind: ErrorKind,
+    source: E,
+) -> Self
+where
+    E: std::error::Error + Send + Sync + 'static;
+pub fn kind(&self) -> ErrorKind;
+```
+
+`backend_failure` deliberately accepts `Into<String>`, not `Display`, so passing an arbitrary typed error does not silently stringify it. `backend_source` and `extension` box the original source. Drop `Clone`, `Eq`, and `PartialEq` from the outer error instead of sacrificing sources.
+
+- [ ] **Step 4: Migrate tensor validation producers**
+
+Use this mapping throughout the named tensor files:
+
+| Old tensor variant | New representation |
+|---|---|
+| `AxisOutOfBounds` | `Error::validation(op, ValidationError::AxisOutOfBounds { axis, rank })` |
+| `DuplicateAxis` | `Error::validation(op, ValidationError::DuplicateAxis { axis, role })` |
+| `AxisRoleConflict` | `Error::validation(op, ValidationError::AxisRoleConflict { ... })` |
+| `ShapeMismatch` | `Error::validation(op, ShapeMismatch::IncompatibleShapes { ... }.into())` |
+| `RankMismatch` | `Error::validation(op, ValidationError::RankMismatch { ... })` |
+| `DTypeMismatch` | `Error::validation(op, ValidationError::DTypeMismatch { expected, actual })` |
+| `InvalidConfig` | `Error::invalid_argument(op, argument_name, message)` |
+| typed error passed to `backend_failure` | `Error::backend_source(op, error)` |
+| backend/vendor text only | `Error::backend_failure(op, message)` |
+
+Change `tensor_layout_error` to wrap the complete tensor-core source instead of matching and stringifying unmatched variants:
+
+```rust
+fn tensor_layout_error(op: &'static str, err: ValidationError) -> crate::Error {
+    crate::Error::validation(op, err)
+}
+```
+
+Top-level reexports must include `ErrorKind`, `ShapeMismatch`, `ValidationError`, and `ValidationKind` so normal tensor and extension users do not need to reach through `tenferro_tensor::core`.
+
+- [ ] **Step 5: Update tensor rustdoc and tests to match structured variants**
+
+Replace string-format assertions with `kind()` and payload matching. Add concrete `# Errors` sections for all public `Result` APIs reported by package Clippy, naming the exact validation/backend variant.
+
+- [ ] **Step 6: Verify and commit tensor**
+
+Run:
+
+```bash
+cargo test -p tenferro-tensor
+cargo clippy -p tenferro-tensor --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+```
+
+Expected: pass.
+
+```bash
+git add -- \
+  crates/tenferro-tensor/src/error.rs \
+  crates/tenferro-tensor/src/lib.rs \
+  crates/tenferro-tensor/src/validate/mod.rs \
+  crates/tenferro-tensor/src/validate/tests.rs \
+  crates/tenferro-tensor/src/types.rs \
+  crates/tenferro-tensor/src/config.rs \
+  crates/tenferro-tensor/src/backend.rs \
+  crates/tenferro-tensor/src/tests/types_tests.rs
+git commit -m "refactor: preserve structured tensor error sources"
+```
+
+---
+
+### Task 3: Add runtime phase context and remove stringly graph validation
+
+**Files:**
+- Modify: `crates/tenferro-runtime/src/error.rs:1-150`
+- Modify: `crates/tenferro-runtime/src/traced.rs`
+- Modify: `crates/tenferro-runtime/src/shape_infer.rs`
+- Modify: `crates/tenferro-runtime/src/shape_packing.rs`
+- Modify: `crates/tenferro-runtime/src/graph/compiler.rs`
+- Modify: `crates/tenferro-runtime/src/graph/executor.rs`
+- Modify: `crates/tenferro-runtime/src/eager_exec.rs`
+- Modify: `crates/tenferro-runtime/tests/runtime_public_api.rs`
+- Modify: `crates/tenferro-runtime/src/traced/tests.rs`
+- Modify: `crates/tenferro-runtime/src/shape_infer/tests.rs`
+
+**Interfaces:**
+- Consumes: Tasks 1-2 error types.
+- Produces: `ErrorPhase::{GraphBuild, Compile, Execution}`.
+- Produces: `Error::validation(op, phase, source)`, `Error::kind()`, and `Error::phase()`.
+
+- [ ] **Step 1: Add failing runtime classification tests**
+
+Add to `crates/tenferro-runtime/tests/runtime_public_api.rs`:
+
+```rust
+use tenferro_runtime::{Error, ErrorPhase};
+use tenferro_tensor::{ErrorKind, ShapeMismatch, ValidationKind};
+
+#[test]
+fn runtime_validation_separates_kind_from_phase() {
+    let err = Error::validation(
+        "reshape",
+        ErrorPhase::GraphBuild,
+        ShapeMismatch::ReshapeElementCount { from: 2, to: 3 }.into(),
+    );
+
+    assert_eq!(
+        err.kind(),
+        ErrorKind::Validation(ValidationKind::ShapeMismatch)
+    );
+    assert_eq!(err.phase(), Some(ErrorPhase::GraphBuild));
+}
+```
+
+- [ ] **Step 2: Verify the runtime API test fails**
+
+Run:
+
+```bash
+cargo test -p tenferro-runtime --test runtime_public_api runtime_validation_separates_kind_from_phase
+```
+
+Expected: compile failure for missing `ErrorPhase` and `Error::validation`.
+
+- [ ] **Step 3: Implement phase-aware runtime errors**
+
+Add:
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum ErrorPhase {
+    GraphBuild,
+    Compile,
+    Execution,
+}
+
+#[error("{op} ({phase:?}): {source}")]
+Validation {
+    op: &'static str,
+    phase: ErrorPhase,
+    #[source]
+    source: ValidationError,
+},
+```
+
+Keep `TensorRuntime(#[from] tenferro_tensor::Error)` as the typed execution boundary; `kind()` delegates to the tensor error and `phase()` returns `Some(ErrorPhase::Execution)` for it. Runtime-state variants such as context mismatch and poisoned/missing bindings map to `ErrorKind::RuntimeState`. `UnsupportedAdRule` maps to `ErrorKind::Unsupported`; `Internal` maps to `ErrorKind::Internal`.
+
+During this task, leave the einsum-owned legacy `InvalidSubscripts` and `ContractionError` variants only as a temporary compile bridge. Task 6 removes both before the final release. Do not add any new call sites.
+
+- [ ] **Step 4: Replace graph validation strings with shared payloads**
+
+For caller-controlled shape/rank/axis/dtype/config failures in `traced.rs`, `shape_infer.rs`, `shape_packing.rs`, and graph binding validation, construct `Error::Validation` with the earliest phase. Convert:
+
+- concrete graph-builder failures to `GraphBuild`;
+- failures found while lowering/inference with concrete input specs to `Compile`;
+- binding/executor failures to `Execution`.
+
+Use specialized shared variants where facts exist. Use `ValidationError::InvalidArgument { argument, message }` only for caller-invalid configurations that do not have a more specific shared payload. Graph corruption or impossible instruction shapes become `Error::Internal`, not `InvalidArgument`.
+
+Remove `shape_infer_from_tensor_error(err.to_string())`; match `tenferro_tensor::Error::Validation { source, .. }` and retain `source`, otherwise retain the complete tensor error through `TensorRuntime` or an internal typed source. Replace the extension wrapper in `eager_exec.rs` with `tenferro_tensor::Error::extension(...)` rather than formatting `family_id` and the source.
+
+- [ ] **Step 5: Update runtime tests to assert kinds, phases, and sources**
+
+Replace tests that match `InvalidGraphBuild` or inspect messages for known validation with structured matches. Keep message assertions only for genuinely opaque external messages.
+
+- [ ] **Step 6: Add complete runtime rustdoc**
+
+Run package Clippy with the two documentation lints and add `# Errors` to every reported public `Result` API. For traced functions that may defer symbolic checks, add `# Deferred errors` separately.
+
+- [ ] **Step 7: Verify and commit runtime phase support**
+
+Run:
+
+```bash
+cargo test -p tenferro-runtime
+cargo clippy -p tenferro-runtime --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+```
+
+Expected: pass.
+
+```bash
+git add -- \
+  crates/tenferro-runtime/src/error.rs \
+  crates/tenferro-runtime/src/traced.rs \
+  crates/tenferro-runtime/src/shape_infer.rs \
+  crates/tenferro-runtime/src/shape_packing.rs \
+  crates/tenferro-runtime/src/graph/compiler.rs \
+  crates/tenferro-runtime/src/graph/executor.rs \
+  crates/tenferro-runtime/src/eager_exec.rs \
+  crates/tenferro-runtime/tests/runtime_public_api.rs \
+  crates/tenferro-runtime/src/traced/tests.rs \
+  crates/tenferro-runtime/src/shape_infer/tests.rs
+git commit -m "refactor: classify runtime errors by phase"
+```
+
+---
+
+### Task 4: Make traced reshape fallible and validate at the earliest phase
+
+**Files:**
+- Modify: `crates/tenferro-runtime/src/traced.rs:1463-1610`
+- Modify: `crates/tenferro-runtime/src/shape_infer.rs:220-250`
+- Modify: `crates/tenferro-runtime/src/graph/compiler.rs:386-431`
+- Modify: `crates/tenferro-runtime/src/traced/tests.rs`
+- Modify: `crates/tenferro-runtime/src/shape_infer/tests.rs`
+- Modify: all workspace call sites that consume `TracedTensor::reshape`
+
+**Interfaces:**
+- Changes: `TracedTensor::reshape(&self, shape: &[usize]) -> Result<TracedTensor>`.
+- Preserves: `reshape_sym` as fallible; both concrete and symbolic APIs use the same element-count validation.
+
+- [ ] **Step 1: Add graph-build and compile-phase reshape tests**
+
+Add to `crates/tenferro-runtime/src/traced/tests.rs`:
+
+```rust
+use crate::{Error, ErrorPhase, GraphCompiler};
+use tenferro_tensor::{ShapeMismatch, ValidationError};
+
+#[test]
+fn concrete_reshape_rejects_element_count_at_graph_build() {
+    let x = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let err = x.reshape(&[3]).unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::Validation {
+            phase: ErrorPhase::GraphBuild,
+            source: ValidationError::ShapeMismatch(
+                ShapeMismatch::ReshapeElementCount { from: 2, to: 3 }
+            ),
+            ..
+        }
+    ));
+}
+
+#[test]
+fn symbolic_reshape_defers_until_input_specs_are_concrete() {
+    let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
+    let y = x.reshape(&[3]).unwrap();
+    let mut compiler = GraphCompiler::new();
+
+    let err = compiler
+        .compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        Error::Validation {
+            phase: ErrorPhase::Compile,
+            source: ValidationError::ShapeMismatch(
+                ShapeMismatch::ReshapeElementCount { from: 2, to: 3 }
+            ),
+            ..
+        }
+    ));
+}
+```
+
+- [ ] **Step 2: Verify the new contract fails**
+
+Run:
+
+```bash
+cargo test -p tenferro-runtime concrete_reshape_rejects_element_count_at_graph_build
+```
+
+Expected: compile failure because `reshape` still returns `TracedTensor`.
+
+- [ ] **Step 3: Implement one reshape validation helper**
+
+Create a private helper in `traced.rs` that uses checked products and returns:
+
+```rust
+Error::validation(
+    "TracedTensor::reshape",
+    ErrorPhase::GraphBuild,
+    ShapeMismatch::ReshapeElementCount { from, to }.into(),
+)
+```
+
+when both shapes are concrete and products differ. Shape-product overflow returns `ValidationError::IntegerOverflow` at the same phase. `reshape` calls the helper before creating the node and returns `Ok(apply_unary(...))`.
+
+In `shape_infer.rs`, the `StdTensorOp::Reshape` arm compares products whenever the input and target `DimExpr` values are all constants. It returns the same `ShapeMismatch::ReshapeElementCount` under `ErrorPhase::Compile`. When any dimension remains symbolic, it returns the target expression and leaves the existing reshape node as the deferred execution constraint. The backend reshape path must already return the same shared payload after Task 2; retain it as the execution fallback.
+
+- [ ] **Step 4: Migrate all call sites without a shim**
+
+Change successful traced calls to `x.reshape(shape)?`, `.reshape(shape).unwrap()`, or `.reshape(shape).expect("...")` only in tests/internal proven setup. Do not add `reshape_unchecked`, `reshape_infallible`, or a deprecated wrapper. Use:
+
+```bash
+rg -n '\.reshape\(' crates docs samples ext
+```
+
+and let `cargo check --workspace --all-targets` identify type-directed traced call sites that the textual search cannot distinguish.
+
+- [ ] **Step 5: Document immediate and deferred errors**
+
+The `reshape` rustdoc must contain exact `# Errors` and `# Deferred errors` sections, naming `ShapeMismatch::ReshapeElementCount` and integer overflow. Update `reshape_sym` with the same distinction.
+
+- [ ] **Step 6: Verify and commit reshape**
+
+Run:
+
+```bash
+cargo test -p tenferro-runtime concrete_reshape_rejects_element_count_at_graph_build
+cargo test -p tenferro-runtime symbolic_reshape_defers_until_input_specs_are_concrete
+cargo check --workspace --all-targets
+```
+
+Expected: pass.
+
+```bash
+git ls-files --modified --others --exclude-standard -z -- \
+  crates docs samples ext | xargs -0 git add --
+git diff --cached --name-only
+git commit -m "refactor: make traced reshape validate fallibly"
+```
+
+The staged-name review must contain only the runtime reshape files and the
+compile-discovered call sites changed in Step 4. Unstage anything unrelated
+before committing.
+
+---
+
+### Task 5: Align eager and traced AD error propagation
+
+**Files:**
+- Modify: `crates/tenferro-ad/src/ad_rule_error.rs`
+- Modify: `crates/tenferro-ad/src/eager_ops.rs`
+- Modify: `crates/tenferro-ad/src/eager_exec.rs`
+- Modify: `crates/tenferro-ad/src/shape_packing.rs`
+- Modify: `crates/tenferro-ad/src/traced.rs`
+- Modify: `crates/tenferro-ad/tests/fallible_api.rs`
+- Modify: `crates/tenferro-ad/tests/dot_general_validation.rs`
+
+**Interfaces:**
+- Consumes: runtime `Error::validation`, tensor shared payloads.
+- Produces: eager and traced public paths with the same `ValidationKind` for equivalent concrete invalid input.
+
+- [ ] **Step 1: Add a failing eager/traced parity test**
+
+Extend `crates/tenferro-ad/tests/fallible_api.rs` so `eager_binary_methods_return_shape_errors` matches the new tensor wrapper and add:
+
+```rust
+#[test]
+fn eager_and_traced_shape_mismatch_share_validation_kind() {
+    let ctx = EagerRuntime::new();
+    let eager_lhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let eager_rhs = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap(),
+        ctx,
+    )
+    .unwrap();
+    let eager_err = eager_lhs.add(&eager_rhs).unwrap_err();
+
+    let traced_lhs = TracedTensor::from_vec_col_major(vec![2], vec![1.0_f64; 2]).unwrap();
+    let traced_rhs = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
+    let traced_err = traced_lhs.add(&traced_rhs).unwrap_err();
+
+    assert_eq!(eager_err.kind(), traced_err.kind());
+    assert_eq!(
+        traced_err.kind(),
+        tenferro_tensor::ErrorKind::Validation(
+            tenferro_tensor::ValidationKind::ShapeMismatch
+        )
+    );
+}
+```
+
+- [ ] **Step 2: Run the parity test and observe the mismatch**
+
+Run:
+
+```bash
+cargo test -p tenferro-ad --test fallible_api eager_and_traced_shape_mismatch_share_validation_kind
+```
+
+Expected: failure until both surfaces expose the shared kind.
+
+- [ ] **Step 3: Preserve typed AD categories**
+
+Map `tidu::ADRuleError::InvalidInput { op, message, .. }` to `Error::validation(transform, ErrorPhase::GraphBuild, ValidationError::InvalidArgument { argument: "ad rule input", message: format!("{op}: {message}") })`. Map `Unsupported` to `ErrorKind::Unsupported` through the existing `UnsupportedAdRule` variant.
+
+Where `tidu` itself exposes only a message field, preserve its structured `InvalidInput` versus `Unsupported` category and treat the message as an external dependency boundary; do not stringify another Tenferro error before constructing it.
+
+Update eager validation helpers to construct tensor shared payloads and traced helpers to construct runtime phase-aware payloads. Replace message-only assertions for known rank/axis/shape cases.
+
+- [ ] **Step 4: Add `# Errors` / `# Panics` sections throughout tenferro-ad**
+
+Run package Clippy and fix every reported public item. `# Errors` must name shared variants or delegated runtime kinds; `# Panics` must describe actual contract preconditions, never implementation accidents.
+
+- [ ] **Step 5: Verify and commit AD**
+
+Run:
+
+```bash
+cargo test -p tenferro-ad --test fallible_api
+cargo test -p tenferro-ad --test dot_general_validation
+cargo clippy -p tenferro-ad --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+```
+
+Expected: pass.
+
+```bash
+git add -- \
+  crates/tenferro-ad/src/ad_rule_error.rs \
+  crates/tenferro-ad/src/eager_ops.rs \
+  crates/tenferro-ad/src/eager_exec.rs \
+  crates/tenferro-ad/src/shape_packing.rs \
+  crates/tenferro-ad/src/traced.rs \
+  crates/tenferro-ad/tests/fallible_api.rs \
+  crates/tenferro-ad/tests/dot_general_validation.rs
+git commit -m "refactor: align eager and traced validation errors"
+```
+
+---
+
+### Task 6: Make einsum own its domain errors and preserve them at runtime boundaries
+
+**Files:**
+- Modify: `crates/tenferro-einsum/src/error.rs`
+- Modify: `crates/tenferro-einsum/src/concrete.rs`
+- Modify: `crates/tenferro-einsum/src/eager.rs`
+- Modify: `crates/tenferro-einsum/src/eager_ad.rs`
+- Modify: `crates/tenferro-einsum/src/traced.rs`
+- Modify: `crates/tenferro-einsum/src/tensordot.rs`
+- Modify: `crates/tenferro-einsum/src/extension.rs`
+- Modify: `crates/tenferro-einsum/tests/error_public.rs`
+- Modify: `crates/tenferro-einsum/tests/public_surface_contract.rs`
+- Modify: `crates/tenferro-runtime/src/error.rs`
+
+**Interfaces:**
+- Produces: one `tenferro_einsum::Error` across concrete, eager, and traced public extension APIs.
+- Produces: `Error::kind()` and consuming `into_tensor_error(op)`.
+- Removes: runtime `InvalidSubscripts` and `ContractionError` variants.
+
+- [ ] **Step 1: Replace the lossy conversion test with source-preservation tests**
+
+Replace `local_error_maps_to_tensor_backend_failure` in `tests/error_public.rs` with:
+
+```rust
+#[test]
+fn shared_einsum_validation_promotes_directly_to_tensor_validation() {
+    let err = Error::validation(
+        "einsum",
+        tenferro_tensor::ShapeMismatch::ExpectedActual {
+            expected: tenferro_tensor::ShapeVec::from_vec(vec![2, 3]),
+            actual: tenferro_tensor::ShapeVec::from_vec(vec![2, 4]),
+        }
+        .into(),
+    );
+
+    let tensor_err = err.into_tensor_error("einsum_extension");
+    assert!(matches!(tensor_err, TensorError::Validation { .. }));
+}
+
+#[test]
+fn einsum_planning_error_remains_a_typed_extension_source() {
+    let err = Error::planning("no valid contraction path");
+    let tensor_err = err.into_tensor_error("einsum_extension");
+
+    assert_eq!(tensor_err.kind(), tenferro_tensor::ErrorKind::RuntimeState);
+    assert!(matches!(tensor_err, TensorError::Extension { .. }));
+}
+```
+
+- [ ] **Step 2: Verify the source-preservation tests fail**
+
+Run:
+
+```bash
+cargo test -p tenferro-einsum --test error_public
+```
+
+Expected: compile failure because `validation`, `planning`, and `into_tensor_error` do not exist.
+
+- [ ] **Step 3: Redesign the einsum outer error**
+
+Use these owned categories:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("{op}: {source}")]
+    Validation {
+        op: &'static str,
+        #[source]
+        source: ValidationError,
+    },
+    #[error("invalid einsum subscripts: {message}")]
+    InvalidSubscripts { message: String },
+    #[error("einsum planning failed: {message}")]
+    Planning { message: String },
+    #[error("einsum numerical failure: {message}")]
+    Numerical { message: String },
+    #[error(transparent)]
+    Tensor(#[from] tenferro_tensor::Error),
+    #[error(transparent)]
+    Runtime(#[from] tenferro_runtime::Error),
+    #[cfg(feature = "autodiff")]
+    #[error(transparent)]
+    Ad(#[from] tenferro_ad::Error),
+}
+```
+
+The transparent tuple variants provide both `#[source]` and `From`. `kind()` delegates to nested Tenferro errors and maps invalid subscripts to validation-invalid-argument, planning to runtime state, and numerical to numerical failure.
+
+`into_tensor_error(self, op)` consumes `self`: promote `Validation` directly to `TensorError::validation`; unwrap `Tensor`; convert all remaining variants with `TensorError::extension(op, EINSUM_EXTENSION_FAMILY_ID, self.kind(), self)`. Remove the old borrowing `to_tensor_error(&self, ...)` so the source cannot be formatted away.
+
+- [ ] **Step 4: Unify public Result ownership**
+
+Concrete, eager, and traced einsum extension traits and free functions return `crate::Result<T>` and use `?` through `From` implementations for tensor/runtime/AD errors. Parsing and planning remain local variants. The type-erased extension runtime still satisfies `tenferro_tensor::Result` by calling `into_tensor_error` at the final registry boundary.
+
+Remove `to_tenferro_error(error.to_string())`, `ContractionError(String)`, and every other string conversion of an `EinsumError`. Once all call sites compile, delete the temporary runtime `InvalidSubscripts` and `ContractionError` variants.
+
+- [ ] **Step 5: Update einsum rustdoc and test surfaces**
+
+All public trait methods and functions returning `crate::Result` receive exact `# Errors`. Examples use `# Ok::<(), tenferro_einsum::Error>(())`. Tests match local variants, shared validation, `kind()`, or `source()` rather than formatted text.
+
+- [ ] **Step 6: Verify and commit einsum ownership**
+
+Run:
+
+```bash
+cargo test -p tenferro-einsum --all-features
+cargo test -p tenferro-runtime
+cargo clippy -p tenferro-einsum --all-targets --all-features -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+```
+
+Expected: pass.
+
+```bash
+git add -- \
+  crates/tenferro-einsum/src/error.rs \
+  crates/tenferro-einsum/src/concrete.rs \
+  crates/tenferro-einsum/src/eager.rs \
+  crates/tenferro-einsum/src/eager_ad.rs \
+  crates/tenferro-einsum/src/traced.rs \
+  crates/tenferro-einsum/src/tensordot.rs \
+  crates/tenferro-einsum/src/extension.rs \
+  crates/tenferro-einsum/tests/error_public.rs \
+  crates/tenferro-einsum/tests/public_surface_contract.rs \
+  crates/tenferro-runtime/src/error.rs
+git commit -m "refactor: preserve einsum domain errors"
+```
+
+---
+
+### Task 7: Migrate linalg, FFT, XLA, CPU/GPU, and standalone extensions
+
+**Files:**
+- Create: `crates/tenferro-linalg/src/error.rs`
+- Modify: `crates/tenferro-linalg/src/lib.rs`
+- Modify: `crates/tenferro-linalg/src/ad.rs`
+- Modify: `crates/tenferro-linalg/src/backend.rs`
+- Modify: `crates/tenferro-linalg/src/cpu/backend.rs`
+- Modify: `crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs`
+- Modify: `crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/cholesky.rs`
+- Modify: `crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eig.rs`
+- Modify: `crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/eigh.rs`
+- Modify: `crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/full_piv_lu.rs`
+- Modify: `crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/helpers.rs`
+- Modify: `crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/lu.rs`
+- Modify: `crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/solve.rs`
+- Modify: `crates/tenferro-linalg/src/cpu/linalg/lapack_linalg/triangular_solve.rs`
+- Modify: `crates/tenferro-linalg/src/eager_ext.rs`
+- Modify: `crates/tenferro-linalg/src/extension.rs`
+- Modify: `crates/tenferro-linalg/src/gpu/ffi/cusolver.rs`
+- Modify: `crates/tenferro-linalg/src/gpu/ffi/mod.rs`
+- Modify: `crates/tenferro-linalg/src/gpu/linalg.rs`
+- Modify: `crates/tenferro-linalg/src/traced.rs`
+- Modify: `crates/tenferro-linalg/tests/backend_errors.rs`
+- Modify: `crates/tenferro-fft/src/lib.rs`
+- Modify: `crates/tenferro-fft/src/concrete_tests.rs`
+- Modify: `crates/tenferro-xla/src/error.rs`
+- Modify: `crates/tenferro-xla/tests/public_api.rs`
+- Modify: the error-producing CPU files printed by `rg -l 'backend_failure|InvalidConfig|to_string\(\)' crates/tenferro-cpu/src`, currently `analytic.rs`, `backend.rs`, `context.rs`, `elementwise.rs`, `exec_session.rs`, `gemm/{blas_gemm,mod,strided_dot}.rs`, `indexing.rs`, `indexing_alloc.rs`, `inject.rs`, `lib.rs`, `reduction.rs`, and `structural.rs`, plus their colocated tests when assertions change
+- Modify: the error-producing GPU files printed by the same scan under `crates/tenferro-gpu/src`, currently `cubecl/{dispatch,gemm,interop,memory,mod,op_descriptor,runtime}.rs`, `cubecl/ffi/{cutensor,mod}.rs`, `cubecl/fusion/classify.rs`, and `webgpu/{gemm,memory,mod,runtime}.rs`, plus their colocated tests when assertions change
+- Modify: `ext/tropical/src/cpu.rs`
+- Modify: `ext/tropical/src/einsum.rs`
+- Modify: `ext/tropical/src/extension.rs`
+- Modify: `ext/tropical/src/traced.rs`
+- Modify: `ext/sparse/src/extension.rs`
+- Modify: `ext/sparse/src/sparse.rs`
+- Test: existing package and extension error tests named below
+
+**Interfaces:**
+- Consumes: shared validation and tensor extension-source constructors.
+- Produces: local `tenferro_linalg::Error` payloads for numerical/unsupported linalg failures and `kind()` for XLA errors.
+
+- [ ] **Step 1: Add cross-extension classification regressions**
+
+Add focused assertions to existing tests:
+
+- `tenferro-linalg/tests/backend_errors.rs`: singular/non-converging failures report `ErrorKind::NumericalFailure` and retain a `tenferro_linalg::Error` source.
+- `tenferro-fft/src/concrete_tests.rs`: invalid FFT axis reports `ValidationKind::AxisOutOfBounds`, not `InvalidConfig(String)`.
+- `tenferro-xla/tests/public_api.rs`: unsupported dtype reports `ErrorKind::Unsupported`.
+- `ext/tropical/tests/tropical_einsum.rs`: incompatible tensor shapes report shared `ValidationKind::ShapeMismatch`.
+- `ext/sparse/tests/sparse_ad.rs`: invalid sparse metadata reports shared validation, not backend failure.
+
+Run each targeted test and confirm it fails against the old classifications.
+
+- [ ] **Step 2: Add linalg domain sources**
+
+Create this exact initial public linalg error set:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    #[error("{op} did not converge")]
+    NonConvergence { op: &'static str },
+    #[error("{op} is singular")]
+    Singular { op: &'static str },
+    #[error("{op} does not support dtype {dtype:?}")]
+    UnsupportedDType { op: &'static str, dtype: DType },
+}
+```
+
+Implement `kind()`: non-convergence/singular are numerical failures and unsupported dtype is unsupported. At tensor/runtime boundaries wrap these with `TensorError::extension(..., LINALG_EXTENSION_FAMILY_ID, error.kind(), error)` instead of calling `backend_failure(error.to_string())`. Shared rank/shape/axis/dtype validation bypasses the extension box and uses `TensorError::validation`.
+
+- [ ] **Step 3: Migrate FFT and XLA**
+
+Replace `tensor_fft_config_error` and `fft_config_error` with shared validation constructors. Negative/out-of-range axes use `AxisOutOfBounds`; invalid lengths and norm/config values use `InvalidArgument`; incompatible real/complex dtype relations use `DTypeMismatch` or the existing structured unsupported category.
+
+Add `tenferro_xla::Error::kind() -> ErrorKind`; retain structured local variants. Replace any conversion from a typed I/O, plugin, runtime, or tensor error to a message with a `#[source]` variant. Vendor/PJRT text that has no source may remain text and maps to backend failure.
+
+- [ ] **Step 4: Migrate CPU, GPU, tropical, and sparse boundaries**
+
+Use this decision rule at every current `backend_failure`, `InvalidConfig`, or `to_string()` call site:
+
+1. caller tensor relationship known: shared `ValidationError`;
+2. typed in-workspace kernel/extension error: `backend_source` or `extension` with its source;
+3. vendor status/message only: `BackendFailure` text is allowed;
+4. impossible internal state: typed `Internal`, not validation.
+
+Do not rewrite display-only `to_string()` calls in tests, logs, cache keys, or actual FFI message extraction. Update tests that match removed variants.
+
+- [ ] **Step 5: Complete public error documentation package by package**
+
+Run Clippy separately for `tenferro-linalg`, `tenferro-fft`, `tenferro-xla`, `tenferro-cpu`, `tenferro-gpu`, `ext/tropical`, and `ext/sparse`; add concrete `# Errors` / `# Panics` sections until every command is clean.
+
+- [ ] **Step 6: Verify extension migration**
+
+Run:
+
+```bash
+cargo test -p tenferro-linalg --all-features
+cargo test -p tenferro-fft --all-features
+cargo test -p tenferro-xla
+cargo test -p tenferro-cpu
+cargo test -p tenferro-gpu
+cargo test --manifest-path ext/tropical/Cargo.toml --features autodiff
+cargo test --manifest-path ext/sparse/Cargo.toml --features autodiff
+```
+
+Expected: pass on available non-hardware tests; feature-gated GPU tests that require hardware remain under their existing CI lanes.
+
+- [ ] **Step 7: Commit extension migration**
+
+```bash
+git ls-files --modified --others --exclude-standard -z -- \
+  crates/tenferro-linalg crates/tenferro-fft crates/tenferro-xla \
+  crates/tenferro-cpu crates/tenferro-gpu ext/tropical ext/sparse \
+  | xargs -0 git add --
+git diff --cached --name-only
+git commit -m "refactor: preserve structured extension failures"
+```
+
+The staged-name review must contain only the files listed in Task 7 and
+colocated assertion tests changed by the classification migration.
+
+---
+
+### Task 8: Explain fallible operators and deferred errors in online documentation
+
+**Files:**
+- Modify: `crates/tenferro-runtime/src/lib.rs:1-40`
+- Modify: `crates/tenferro-runtime/src/traced.rs:780-875`
+- Modify: `docs/getting-started/core-concepts.md:136-175`
+- Modify: `docs/spec/api-conventions.md:50-80`
+- Modify: the current user-facing reshape examples identified in Task 4; do not edit historical files under `docs/plans/` or `docs/superpowers/specs/`
+
+**Interfaces:**
+- Documents: explicit methods as canonical, fallible operators as sugar, `a + b + c` limitation, and immediate/deferred validation.
+
+- [ ] **Step 1: Add a documentation consistency regression**
+
+Extend `scripts/test-doc-consistency.py` to assert that `crates/tenferro-runtime/src/traced.rs` contains all of:
+
+```python
+required = [
+    "let ab = (&a + &b)?;",
+    "let abc = (&ab + &c)?;",
+    "robust error handling",
+    "# Deferred errors",
+]
+```
+
+Run `python3 scripts/test-doc-consistency.py`; expect failure before the docs change.
+
+- [ ] **Step 2: Correct the crate-root and method examples**
+
+The runtime crate-root example uses:
+
+```rust
+let y = (&x + &x)?;
+# Ok::<(), tenferro_runtime::Error>(())
+```
+
+The `TracedTensor::add` docs show both canonical and operator forms plus composition:
+
+```rust
+let method = a.add(&b)?.add(&c)?;
+let ab = (&a + &b)?;
+let abc = (&ab + &c)?;
+assert_eq!(method.rank, abc.rank);
+```
+
+State verbatim: “Tenferro prioritizes robust error handling over the conciseness of chained operator notation.” Explain that `a + b + c` parses as `(a + b) + c`, while the first expression is a `Result`. Mention that generic `T: Add<Output = T>` and fallible assignment operators are not supported for dynamic tensors.
+
+- [ ] **Step 3: Document traced timing**
+
+In `core-concepts.md` and `api-conventions.md`, explain:
+
+- concrete invalid relationships fail during graph build;
+- symbolic relationships record constraints and may fail during compile/run;
+- both paths expose the same validation kind, with `ErrorPhase` identifying timing.
+
+Update every affected reshape and extension example to handle `Result`; do not hide fallibility solely with unexplained `unwrap()` in user guides.
+
+- [ ] **Step 4: Verify and commit docs**
+
+Run:
+
+```bash
+python3 scripts/test-doc-consistency.py
+python3 scripts/test-check-docs-site.py
+cargo test -p tenferro-runtime --doc
+```
+
+Expected: pass.
+
+```bash
+git add -- \
+  crates/tenferro-runtime/src/lib.rs \
+  crates/tenferro-runtime/src/traced.rs \
+  docs/getting-started/core-concepts.md \
+  docs/spec/api-conventions.md \
+  scripts/test-doc-consistency.py
+git commit -m "docs: explain fallible tensor operators"
+```
+
+---
+
+### Task 9: Enforce repository rules and Clippy documentation gates
+
+**Files:**
+- Modify: `REPOSITORY_RULES.md:60-135`
+- Modify: `.github/workflows/ci.yml:30-43`
+- Modify: `scripts/test-repository-rules-review.py`
+
+**Interfaces:**
+- Produces: mandatory `# Errors` / `# Panics` repository policy.
+- Produces: deterministic Clippy gates for workspace, tropical, and sparse.
+- Preserves: semantic review through the always-selected `Public Boundary Safety Audits` section.
+
+- [ ] **Step 1: Add failing policy and workflow source tests**
+
+Add to `scripts/test-repository-rules-review.py`:
+
+```python
+def test_public_boundary_rules_are_always_selected() -> None:
+    mod = load_module()
+    sections = mod.select_rule_sections(["crates/tenferro-runtime/src/traced.rs"])
+    assert "Public Boundary Safety Audits" in sections
+```
+
+Extend `scripts/test-doc-consistency.py` to assert that `.github/workflows/ci.yml` contains both lint names and both standalone extension manifests. Run both scripts; expect the workflow assertion to fail.
+
+- [ ] **Step 2: Add the normative repository rule**
+
+Insert under `Public Boundary Safety Audits`:
+
+```text
+- Every public function, inherent method, and workspace-owned trait method
+  returning `Result` must document concrete failure conditions under `# Errors`
+  and name the public error variant or stable kind. Generic text such as
+  “returns an error on failure” is insufficient. Public operator APIs whose
+  effective `Output` is `Result` must document the same behavior on the owning
+  type/operator surface. Traced APIs must additionally use `# Deferred errors`
+  when symbolic validation may fail during compilation or execution.
+- Every public API with an intentional panic contract must document the exact
+  precondition under `# Panics`. Caller-controlled invalid input must remain a
+  typed error.
+- Crate-boundary conversion must preserve structured error kind, payload, and
+  `source()` chain. Convert to text only for display/logging/FFI/serialization
+  or when an external API supplied no structured source.
+```
+
+Because this section is in `ALWAYS_SECTIONS`, the existing LLM review automatically performs the requested semantic audit; do not add a hand-written Rust parser.
+
+- [ ] **Step 3: Strengthen the CI lint commands**
+
+Change the workspace command to:
+
+```yaml
+run: >-
+  cargo clippy --workspace --all-targets --
+  -D warnings
+  -D clippy::missing_errors_doc
+  -D clippy::missing_panics_doc
+```
+
+Use the same flags for `ext/tropical/Cargo.toml` and add a third command for `ext/sparse/Cargo.toml`.
+
+- [ ] **Step 4: Clear the complete lint inventory**
+
+Run the exact workspace command. The pre-change baseline stops first at 27 tensor-core errors; after earlier tasks it must continue through every crate. Fix every remaining public item with concrete documentation. Do not add crate-level `allow`, item-level `allow`, or a baseline file.
+
+- [ ] **Step 5: Verify and commit governance**
+
+Run:
+
+```bash
+python3 scripts/test-repository-rules-review.py
+python3 scripts/test-doc-consistency.py
+cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+cargo clippy --manifest-path ext/sparse/Cargo.toml --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+```
+
+Expected: pass.
+
+```bash
+git add -- \
+  REPOSITORY_RULES.md \
+  .github/workflows/ci.yml \
+  scripts/test-repository-rules-review.py \
+  scripts/test-doc-consistency.py
+git commit -m "ci: enforce public error documentation"
+```
+
+---
+
+### Task 10: Remove transitional surfaces and run the complete release gate
+
+**Files:**
+- Create: `docs/worklogs/2026-07-17-structured-error-model.md`
+
+No source change is expected in this task. If a forbidden scan finds a match,
+return to the task that owns that exact file, fix and verify it there, then
+restart Task 10 from Step 1.
+
+**Interfaces:**
+- Removes: every legacy variant, alias, lossy conversion, and compatibility shim.
+- Produces: a clean pre-1.0 public error model ready for review.
+
+- [ ] **Step 1: Run final forbidden-pattern scans**
+
+Run:
+
+```bash
+rg -n 'InvalidGraphBuild|InvalidCompiledGraph|ContractionError\(String\)|pub type Error = ValidationError|to_tensor_error\(&self' crates ext
+rg -n 'backend_failure\([^\n]*\.to_string\(\)|map_err\([^\n]*\.to_string\(\)' crates ext
+rg -n 'pub fn reshape\(&self, shape: &\[usize\]\) -> TracedTensor' crates
+```
+
+Expected: no matches. Review any broader `to_string()` results manually and retain only display/logging/cache-key/vendor-message boundaries.
+
+- [ ] **Step 2: Write the migration worklog**
+
+Record:
+
+- old-to-new public error mapping;
+- traced reshape signature change;
+- fallible operator composition example;
+- eager/traced detection-phase matrix;
+- extension source-preservation behavior;
+- verification commands and exact outcomes;
+- explicit statement that no compatibility layer remains.
+
+- [ ] **Step 3: Run formatting, tests, docs, and lints**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo test --workspace --all-targets
+cargo test --workspace --doc
+cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+cargo test --manifest-path ext/tropical/Cargo.toml --features autodiff
+cargo test --manifest-path ext/sparse/Cargo.toml --features autodiff
+cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+cargo clippy --manifest-path ext/sparse/Cargo.toml --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+python3 scripts/test-repository-rules-review.py
+python3 scripts/test-doc-consistency.py
+python3 scripts/test-check-docs-site.py
+```
+
+Expected: every command passes. If a hardware-only feature cannot run locally, record the exact skipped command and leave it to its existing CI lane; do not claim it passed.
+
+- [ ] **Step 4: Run the repository-rules deterministic review over the implementation diff**
+
+Run:
+
+```bash
+impl_base=$(git merge-base HEAD origin/main)
+python3 scripts/repository-rules-review.py \
+  --base "$impl_base" \
+  --head HEAD \
+  --dry-run \
+  --llm-skipped-reason "local deterministic preflight; CI performs semantic review"
+```
+
+Expected: deterministic verdict passes.
+
+- [ ] **Step 5: Commit the final cleanup and worklog**
+
+```bash
+git add -- docs/worklogs/2026-07-17-structured-error-model.md
+git commit -m "docs: record structured error migration"
+```
+
+---
+
+## Plan self-review checklist
+
+- Shared payload ownership is implemented before any consumer migration.
+- Runtime phase never enters tensor-core payloads.
+- Tensor, runtime, AD, and extension boundaries retain `source()`.
+- Concrete traced reshape fails at graph build; symbolic reshape fails only when concrete facts arrive.
+- Explicit methods remain canonical and operator notation remains fallible.
+- `a + b + c`, generic `Add<Output = T>`, and `AddAssign` limitations are documented.
+- Repository policy, Clippy presence checks, semantic review, and behavior tests all enforce the model.
+- The final scan forbids compatibility aliases and legacy string variants.

--- a/docs/superpowers/specs/2026-07-17-structured-error-model-design.md
+++ b/docs/superpowers/specs/2026-07-17-structured-error-model-design.md
@@ -1,0 +1,564 @@
+# Structured error model and fallible tensor API
+
+**Date:** 2026-07-17
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+Tenferro deliberately does not turn caller-controlled invalid input into a
+panic at a public API boundary. Dynamic tensor operations therefore need a
+fallible API when compatibility cannot be proved statically. The current code
+implements that principle inconsistently:
+
+- `tenferro-tensor-core`, `tenferro-tensor`, `tenferro-runtime`, and extension
+  crates own overlapping error variants for shape, rank, axis, and dtype
+  validation.
+- Several crate-boundary conversions call `to_string()` and place the result in
+  a generic `InvalidGraphBuild`, `ContractionError`, `InvalidConfig`, or
+  `BackendFailure` variant. Callers can no longer distinguish a shape mismatch
+  from an unsupported operation or a backend failure.
+- Eager operations generally report concrete validation errors immediately,
+  while traced operations may report the same failure under a stringly graph
+  error or delay it until compilation or execution even when all relevant
+  dimensions were already concrete.
+- Eager `reshape` returns `Result`, while concrete traced `reshape` currently
+  returns `TracedTensor` directly and defers element-count validation.
+- `Add<Output = Result<_>>` is legal Rust and preserves fallibility, but it is
+  unusual: `a + b + c` does not compose directly because `a + b` produces a
+  `Result`. Current online examples do not consistently explain this.
+- Public `Result` APIs do not consistently document their concrete failure
+  conditions under `# Errors`.
+
+The result is locally reasonable error handling without a stable, workspace-
+wide semantic model.
+
+## Design principles
+
+1. Caller-controlled invalid input is a typed error, not a panic.
+2. Internal invariant violations may panic only when the invariant and its
+   proof boundary are local and documented. Otherwise they are typed internal
+   errors.
+3. The same semantic validation failure uses the same shared payload in eager,
+   traced, backend, and extension paths.
+4. Error kind and error phase are separate. `ShapeMismatch` describes what
+   failed; graph build, compilation, or execution describes when it was
+   detected.
+5. Validation happens at the earliest phase with sufficient information.
+6. Crate-specific errors remain owned by the crate that defines their
+   semantics.
+7. Error conversion preserves structured payloads and the `source()` chain.
+   Strings are for display, logging, vendor/FFI input, or final serialization,
+   not internal classification.
+8. Explicit fallible methods are the canonical API. Fallible operators are
+   optional notation layered on those methods.
+9. Before 1.0, API cleanliness takes priority over compatibility. This change
+   is a coordinated breaking migration with no deprecated compatibility layer.
+
+## Goals
+
+- Establish one shared representation for tensor validation failures.
+- Let in-workspace and out-of-tree extension crates return the same structured
+  shape, rank, axis, dtype, and argument errors.
+- Preserve crate ownership of parsing, planning, numerical, backend, graph,
+  and extension-specific failures.
+- Make eager and traced behavior agree whenever both have the information
+  needed to validate.
+- Document immediate and deferred failure behavior accurately.
+- Enforce `# Errors` and `# Panics` documentation across the workspace and
+  separately built extension crates.
+- Explain the composition limits and robustness rationale of fallible operator
+  notation.
+
+## Non-goals
+
+- A single closed `Error` enum containing every error from every crate.
+- Recovering from allocator out-of-memory behavior.
+- Turning proven internal invariants into caller-recoverable validation errors.
+- Erasing useful einsum, linalg, FFT, XLA, device, or vendor-specific details
+  merely to fit a universal payload.
+- Making dynamic-shape `AddAssign` fallible; Rust's trait cannot return an
+  error.
+- Introducing an infallible or panicking dynamic tensor operator for prettier
+  notation.
+- Preserving pre-change error variants or the current infallible traced
+  `reshape` signature through deprecated shims.
+
+## 1. Shared validation ownership
+
+`tenferro-tensor-core` will own the shared tensor validation vocabulary. It is
+already the lowest-level crate that owns `DType`, shape/layout metadata, and
+most of the relevant validation errors. Using it avoids a new dependency cycle
+and removes the current duplication between tensor-core and tensor.
+
+The current broad `tenferro_tensor_core::Error` becomes a deliberately named
+`ValidationError`. There is no deprecated `Error` alias: all workspace call
+sites migrate in the same change.
+
+Illustrative public shape:
+
+```rust
+#[non_exhaustive]
+pub enum ValidationError {
+    ShapeMismatch(ShapeMismatch),
+    ShapeDataLengthMismatch {
+        expected: usize,
+        actual: usize,
+    },
+    RankMismatch {
+        expected: usize,
+        actual: usize,
+    },
+    AxisOutOfBounds {
+        axis: usize,
+        rank: usize,
+    },
+    DTypeMismatch {
+        expected: DType,
+        actual: DType,
+    },
+    InvalidArgument(InvalidArgument),
+    // Existing layout-validation cases remain structured here.
+}
+
+#[non_exhaustive]
+pub enum ShapeMismatch {
+    IncompatibleShapes {
+        lhs: ShapeVec,
+        rhs: ShapeVec,
+    },
+    ExpectedActual {
+        expected: ShapeVec,
+        actual: ShapeVec,
+    },
+    ReshapeElementCount {
+        from: usize,
+        to: usize,
+    },
+    ContractedDimensions {
+        lhs_axis: usize,
+        lhs_size: usize,
+        rhs_axis: usize,
+        rhs_size: usize,
+    },
+}
+```
+
+The final variant inventory should preserve distinct machine-readable facts.
+For example, reshape element-count mismatch and binary broadcast mismatch share
+the broad kind `ShapeMismatch`, but should not be flattened into an ambiguous
+`expected`/`actual` pair or a message string.
+
+Shared payload types expose constructors and read-only accessors. They do not
+carry runtime-specific context such as graph phase, backend name, or extension
+family. Public enums are `#[non_exhaustive]` so downstream matching includes a
+fallback without preventing extension crates from constructing known variants.
+
+### Stable classification
+
+`tenferro-tensor-core` also exposes coarse, copyable classifications used at
+crate, dynamic-extension, and language-binding boundaries:
+
+```rust
+#[non_exhaustive]
+pub enum ValidationKind {
+    ShapeMismatch,
+    RankMismatch,
+    AxisOutOfBounds,
+    DTypeMismatch,
+    InvalidArgument,
+}
+
+#[non_exhaustive]
+pub enum ErrorKind {
+    Validation(ValidationKind),
+    Unsupported,
+    NumericalFailure,
+    BackendFailure,
+    Io,
+    RuntimeState,
+    Internal,
+}
+
+impl ValidationError {
+    pub fn kind(&self) -> ValidationKind;
+}
+```
+
+Callers use the detailed variant when they need fields and `kind()` when they
+only need stable control-flow classification. Every public crate-local outer
+error exposes `kind() -> ErrorKind`. This gives FFI, bindings, runtime
+registries, and generic application code one classification surface without
+forcing all crates into one concrete outer enum.
+
+## 2. Crate-local outer errors
+
+Each crate retains an outer error that expresses its own domain. Shared
+validation is wrapped as a typed source rather than copied or formatted.
+
+Conceptually:
+
+```rust
+// tenferro-tensor
+pub enum Error {
+    Validation {
+        op: &'static str,
+        #[source]
+        source: ValidationError,
+    },
+    Backend(BackendError),
+    MissingValue { slot: usize },
+    Internal(InternalError),
+}
+
+// tenferro-runtime
+pub enum Error {
+    Validation {
+        op: &'static str,
+        phase: ErrorPhase,
+        #[source]
+        source: ValidationError,
+    },
+    GraphBuild(GraphBuildError),
+    Compile(CompileError),
+    Execution(ExecutionError),
+    Extension(ExtensionError),
+    Internal(InternalError),
+}
+
+// tenferro-einsum
+pub enum Error {
+    Validation {
+        op: &'static str,
+        #[source]
+        source: ValidationError,
+    },
+    InvalidSubscripts(InvalidSubscripts),
+    Planning(PlanningError),
+    Numerical(NumericalError),
+}
+```
+
+These sketches define ownership, not mandatory variant spelling. The
+implementation plan will inventory current variants and map each one to the
+owning domain without changing this boundary.
+
+Outer errors are not required to remain `Clone`, `Eq`, or `PartialEq` if doing
+so would force a typed source to become a string. Tests should match stable
+kinds and payload fields rather than require equality for opaque backend or
+vendor sources.
+
+### Extension boundary
+
+Extension crates depend directly on `tenferro-tensor-core` when they construct
+shared validation payloads. They keep a crate-local outer error for parsing,
+planning, and numerical failures.
+
+When an extension is called through its own public API, callers receive its
+concrete outer error. When it crosses a type-erased runtime registry boundary:
+
+- shared validation is promoted directly to the runtime/tensor validation
+  wrapper;
+- other extension errors retain the extension family, a stable broad kind,
+  and a boxed typed `source` where the boundary requires erasure;
+- callers may use the broad kind without downcasting and may downcast the
+  source when extension-specific recovery is required.
+
+The following conversions are prohibited inside the Rust workspace:
+
+```rust
+Error::ContractionError(source.to_string())
+Error::InvalidGraphBuild { message: source.to_string() }
+Error::backend_failure(op, source) // when `source` is already a typed error
+```
+
+A vendor API that supplies only an error code and message may still populate a
+structured backend error containing that code and message; the design cannot
+recover structure that the vendor did not provide.
+
+## 3. Error phase and validation timing
+
+Runtime validation errors carry a phase separate from their semantic payload:
+
+```rust
+#[non_exhaustive]
+pub enum ErrorPhase {
+    GraphBuild,
+    Compile,
+    Execution,
+}
+```
+
+An eager tensor error does not need a graph phase; the direct API call is its
+context. A runtime error exposes `phase()` where phase is meaningful.
+
+The governing rule is:
+
+> Validate at the earliest phase where the required facts are known, while
+> preserving the same validation kind and payload shape at later phases.
+
+Examples:
+
+| Operation and input | Detection | Error |
+|---|---|---|
+| Eager binary op with incompatible concrete shapes | API call | `ShapeMismatch` |
+| Traced binary op with incompatible constant dimensions | Graph build | `ShapeMismatch`, `GraphBuild` |
+| Traced binary op with unresolved symbolic dimensions | Constraint recorded | No immediate error |
+| Symbolic constraint violated by concrete bindings | Compile or execution, according to where bindings become available | `ShapeMismatch` with that phase |
+| Concrete traced reshape with unequal element counts | Graph build | `ShapeMismatch::ReshapeElementCount` |
+| Symbolic reshape whose product cannot yet be resolved | Constraint recorded | Same payload category when later disproved |
+
+`InvalidGraphBuild { message: String }` is not a substitute for caller-facing
+validation. It is replaced by structured graph-build errors for genuine graph
+construction failures and shared validation wrappers for invalid tensor
+relationships. Graph corruption that cannot be caused by valid public input is
+an internal error or a locally proven invariant panic.
+
+### Traced reshape
+
+Traced reshape becomes fallible and agrees with eager reshape:
+
+```rust
+pub fn reshape(&self, shape: impl Into<...>) -> Result<TracedTensor>;
+```
+
+- Concrete input and output sizes are checked immediately.
+- A partially or fully symbolic relationship records an element-count
+  constraint and returns `Ok(TracedTensor)`.
+- Compilation or execution reports the same structured shape mismatch if the
+  eventual binding violates the constraint.
+- The current direct-return signature is removed without a compatibility
+  method.
+
+## 4. Fallible methods and operators
+
+Explicit methods are canonical:
+
+```rust
+let abc = a.add(&b)?.add(&c)?;
+let reshaped = x.reshape([2, 3])?;
+```
+
+The existing method names remain verbs such as `add` and `reshape`. A `try_`
+prefix is not required when the operation is fundamentally fallible and there
+is no infallible peer.
+
+`Add<Output = Result<_>>` remains available as convenience notation and
+delegates to the same validation path. It does not panic on shape mismatch.
+Documentation must show its composition limitation:
+
+```rust
+// Does not compose: `&a + &b` is a Result, not a Tensor.
+// let abc = &a + &b + &c;
+
+let ab = (&a + &b)?;
+let abc = (&ab + &c)?;
+```
+
+The explanation presented to users is explicit:
+
+> Tenferro prioritizes robust error handling over the conciseness of chained
+> operator notation. Tensor operators return `Result` because compatibility
+> may only be known at runtime.
+
+Consequences that must also be documented:
+
+- Generic numeric bounds such as `T: Add<Output = T>` do not accept these
+  dynamic tensors.
+- `AddAssign` and similar assignment traits are not implemented for operations
+  that may fail, because those traits cannot return `Result`.
+- A future statically shape-safe tensor type may provide an infallible operator
+  without changing the dynamic tensor contract.
+
+## 5. Panic policy
+
+The public contract is not an absolute claim that no panic can ever occur. It
+is the narrower and enforceable rule that caller-controlled invalid input is
+not converted into a panic.
+
+- Shape, rank, axis, dtype, configuration, I/O, and numerical convergence
+  failures use `Result` when they are part of the callable contract.
+- Floating-point division follows the documented numeric semantics; integer or
+  operation-specific invalid division must be validated according to its
+  contract.
+- Allocator out-of-memory behavior is outside this recoverable error model.
+- `unwrap`, `expect`, unchecked indexing, and debug-only assertions must not be
+  the validation mechanism for public input.
+- An internal panic is allowed only near a documented proof that the state is
+  unreachable through valid public APIs.
+
+Public functions that intentionally panic on a documented contract violation
+must include `# Panics` with the exact precondition.
+
+## 6. Rustdoc requirements
+
+The repository rules gain the following normative requirement:
+
+> Every public function, inherent method, trait method, extension method, and
+> operator whose effective output is `Result` must contain an `# Errors`
+> section. It must state the concrete failure conditions and public error
+> variant or stable kind. Generic text such as “returns an error on failure” is
+> insufficient.
+
+For traced APIs, `# Errors` documents errors returned by the call itself. When
+the operation can record a constraint that fails later, rustdoc also includes
+`# Deferred errors`:
+
+```rust
+/// # Errors
+///
+/// Returns [`ValidationError::ShapeMismatch`] when the element counts are
+/// known and incompatible while building the graph.
+///
+/// # Deferred errors
+///
+/// If symbolic dimensions prevent validation during graph construction, the
+/// same error may be reported while compiling or executing the graph.
+```
+
+The repository rules also require:
+
+- a `# Panics` section for every public API with an intentional documented
+  panic condition;
+- structured error preservation across crate boundaries;
+- eager/traced parity for equivalent known inputs;
+- documentation of the earliest validation phase and any deferred phase.
+
+Online documentation is updated to include:
+
+- a correct traced `a + b` example using `?` or explicit handling;
+- the `a + b + c` limitation and its two-step/method-chain alternatives;
+- the robustness-over-conciseness rationale;
+- immediate versus deferred traced validation.
+
+## 7. Enforcement and audit
+
+Enforcement has three layers.
+
+### Deterministic lint gate
+
+After existing violations are fixed, CI denies:
+
+```text
+clippy::missing_errors_doc
+clippy::missing_panics_doc
+```
+
+The gate covers the root workspace and every separately built supported
+extension manifest. Existing violations are repaired before enabling `deny`;
+there is no permanent baseline allowlist.
+
+Clippy checks header presence, not semantic accuracy. Operator implementations
+whose associated `Output` resolves to `Result` may also require explicit audit
+because the effective return type is indirect.
+
+### Repository-rules semantic review
+
+The repository-rules review audits:
+
+- missing or generic `# Errors` text;
+- mismatch between documented and implemented variants/kinds;
+- missing `# Deferred errors` for symbolic constraints;
+- concrete failures delayed beyond the earliest available phase;
+- eager/traced kind or payload disagreement;
+- `to_string()` conversions that erase a typed source;
+- `BackendFailure(String)` or generic graph errors used for known validation;
+- operator examples that omit `Result` handling;
+- public panic paths reachable from caller-controlled invalid input.
+
+### Behavioral tests
+
+Tests assert both positive behavior and classification:
+
+| Case | Required assertion |
+|---|---|
+| Eager concrete mismatch | Immediate shared validation kind and fields |
+| Traced concrete mismatch | Graph-build phase and same shared payload |
+| Traced symbolic mismatch | Deferred phase and same shared kind |
+| Extension validation | Shared payload survives every boundary |
+| Extension-local failure | Local type or typed source survives; no string-only conversion |
+| Backend/vendor failure | Backend identity and available status code/message retained |
+| `source()` traversal | Original structured source remains reachable |
+| Rustdoc examples | Examples compile and demonstrate the documented error behavior |
+
+Tests compare stable kinds and relevant payload fields instead of formatting
+strings.
+
+## 8. Breaking migration
+
+This is a coordinated pre-1.0 breaking change. Clean API boundaries take
+priority over preserving names or variants that encode the wrong model.
+
+No compatibility layer is retained:
+
+- no deprecated alias from `tenferro_tensor_core::Error` to
+  `ValidationError`;
+- no duplicate legacy runtime/tensor validation variants;
+- no stringly fallback for errors that have a structured representation;
+- no old direct-return traced `reshape` under another name;
+- no long-lived lint allowlist.
+
+Implementation proceeds bottom-up:
+
+1. Inventory every public error producer, conversion, `Result` API, panic
+   contract, and separately built extension.
+2. Define the shared validation types and classification in
+   `tenferro-tensor-core`; migrate its own APIs and tests.
+3. Replace duplicated `tenferro-tensor` validation variants with a structured
+   wrapper and migrate backend/provider conversions.
+4. Add runtime phase-aware validation wrapping; remove string conversions in
+   graph construction, shape inference, compilation, and execution.
+5. Make traced operations validate known facts early, including fallible
+   `reshape`, and add symbolic constraints where validation must be deferred.
+6. Migrate AD eager/traced paths and verify parity.
+7. Migrate einsum, linalg, FFT, XLA, CPU, GPU, and other extensions while
+   retaining domain-specific outer errors.
+8. Update all public rustdoc, examples, guides, and downstream workspace call
+   sites, including fallible operator examples.
+9. Add semantic audit rules and behavioral tests.
+10. Enable workspace-wide and extension-wide lint denial only after the full
+    tree is clean.
+
+The implementation plan may split these steps into reviewable commits, but the
+release must not expose a mixed old/new public model.
+
+## Risks and mitigations
+
+- **Large blast radius.** Error variants and traced reshape are widely used.
+  Mitigation: migrate in dependency order and keep the workspace compiling at
+  each implementation-plan checkpoint.
+- **Over-generalized shared payloads.** A universal shape payload could discard
+  einsum axes or reshape counts. Mitigation: use distinct structured
+  `ShapeMismatch` forms with one coarse kind.
+- **Dependency inversion.** Putting runtime phases, runtime context, or
+  runtime-specific payloads into tensor-core would pollute the metadata layer.
+  Mitigation: tensor-core owns shared classifications and validation facts;
+  runtime owns graph phases and runtime context.
+- **Type erasure at dynamic extension boundaries.** A registry cannot expose a
+  closed enum for unknown out-of-tree extension errors. Mitigation: promote
+  common validation directly and otherwise retain stable kind plus boxed typed
+  source.
+- **False confidence from Clippy.** A heading may exist but be inaccurate.
+  Mitigation: pair lints with semantic repository review and behavior tests.
+- **Source-breaking migration.** Downstream matches and traced reshape call
+  sites must change. Mitigation: make the break deliberate before 1.0, publish
+  migration notes, and avoid a confusing dual API.
+
+## Success criteria
+
+- One shared tensor validation vocabulary is owned by
+  `tenferro-tensor-core` and constructible by extension crates.
+- No known structured Rust error is converted to a string at an internal crate
+  boundary.
+- Equivalent eager and traced failures expose the same validation kind and
+  relevant payload fields.
+- Concrete traced validation fails at graph build; symbolic validation fails
+  only when bindings make the contradiction knowable.
+- Traced reshape is fallible and records deferred element-count constraints
+  when necessary.
+- Explicit methods are canonical; fallible operators remain documented sugar.
+- Online docs show correct `a + b`, `a + b + c`, and deferred-error examples.
+- Every public fallible API has a concrete `# Errors` section, and every public
+  intentional panic contract has `# Panics`.
+- Clippy, semantic repository audit, doctests, and behavioral tests enforce the
+  model across the workspace and supported extensions.
+- No compatibility layer or deprecated legacy error surface remains.

--- a/docs/superpowers/specs/2026-07-17-structured-error-model-design.md
+++ b/docs/superpowers/specs/2026-07-17-structured-error-model-design.md
@@ -190,6 +190,20 @@ error exposes `kind() -> ErrorKind`. This gives FFI, bindings, runtime
 registries, and generic application code one classification surface without
 forcing all crates into one concrete outer enum.
 
+The classification is also a routing policy, not a fallback label:
+
+- typed file, stream, serialization, or dynamic-library I/O sources use the
+  `Io` category and remain available through `source()`;
+- missing, uninitialized, poisoned, or otherwise invalid executor/cache/device
+  state uses `RuntimeState`, preserving a typed source when one exists;
+- `BackendFailure` is reserved for vendor/backend status text for which no
+  typed source or more specific category exists.
+
+An operation phase such as graph construction, compilation, or execution is
+orthogonal to these categories. In particular, a runtime-state or I/O failure
+must not be reclassified as a generic backend failure merely because it was
+observed while a backend was executing.
+
 ## 2. Crate-local outer errors
 
 Each crate retains an outer error that expresses its own domain. Shared

--- a/docs/worklogs/2026-07-17-structured-error-model.md
+++ b/docs/worklogs/2026-07-17-structured-error-model.md
@@ -407,7 +407,7 @@ preflight portable. With the fix, the focused CI policy tests pass:
 
 ```text
 PATH=/Users/hiroshi/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin:$PATH /Users/hiroshi/.local/bin/python3.11 -m unittest discover -s scripts/ci/tests -p 'test_change_policy.py' -v
-# exit 0; 15 tests passed
+# exit 0; 16 tests passed
 ```
 
 The full `ci-config` profile reaches its final `actionlint` step after 81 CI
@@ -416,6 +416,58 @@ command not found`). It is therefore an environmental limitation and is not
 claimed as a passing local gate. The obsolete `--ci-profile local-gate`
 argument was also verified to be rejected because current `origin/main`
 removed that profile; the current profiles above are authoritative.
+
+## Independent re-review follow-up on 2026-07-18
+
+The follow-up review identified one semantic overvalidation and two small
+portability/documentation gaps. The structural-equality check in
+`validate_broadcast_in_dim_args` was removed: when the target extent is
+symbolic, a concrete input extent is now left for the existing deferred shape
+guard, while known-known incompatible extents still fail during graph build.
+The regression constructs a concrete `[2]` input and a symbolic extent owned by
+another tensor, verifies execution for the compatible `[2]` binding, and
+verifies an incompatible `[3]` binding returns the typed shape mismatch at
+execution. A separate test asserts the known-known `[2]` to `[3]` mismatch is
+reported with `ErrorPhase::GraphBuild`.
+
+The traced `div` and `rem` deferred-error sections now state that integer zero
+divisors are execution-time `Error::TensorRuntime` numerical failures whose
+typed backend source remains in the source chain; floating-point and complex
+zero divisors retain their numeric semantics.
+
+The fast preflight now uses explicit changed/untracked-file counters before
+expanding arrays, covering both changed-file loops under macOS Bash 3.2's
+`set -u` behavior. The new no-change regression invokes `/bin/bash` directly
+against a clean temporary repository with `--base HEAD`; because this host's
+system Python 3.9 cannot import the repository's `StrEnum`-based policy
+module, the test prepends the resolved Python 3.11 runtime directory so the
+script still executes the same `python3` entry point.
+
+The focused RED/GREEN and final gates were:
+
+```text
+cargo test -p tenferro-runtime broadcast_in_dim_sym --lib
+# exit 0; 2 tests passed
+PATH=/Users/hiroshi/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin:$PATH \
+  /Users/hiroshi/.local/bin/python3.11 -m unittest discover -s scripts/ci/tests -p 'test_change_policy.py' -v
+# exit 0; 16 tests passed
+cargo test -p tenferro-runtime --all-targets --no-fail-fast --message-format=short
+# exit 0; 247 unit tests and 41 integration tests passed
+cargo test --workspace --release
+# exit 0; all workspace unit, integration, and doctests passed
+cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+# exit 0
+cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+cargo clippy --manifest-path ext/sparse/Cargo.toml --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+# both exit 0
+cargo fmt --all --check
+/bin/bash -n scripts/check-pr-fast.sh
+# both exit 0
+PATH=/Users/hiroshi/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin:$PATH \
+  /bin/bash scripts/check-pr-fast.sh --base origin/main --no-fetch --coverage-reviewed \
+  --test 'cargo test -p tenferro-runtime broadcast_in_dim_sym_defers_cross_tensor_symbolic_extent_validation'
+# exit 0; fast PR checks passed
+```
 
 ## Residual risks
 

--- a/docs/worklogs/2026-07-17-structured-error-model.md
+++ b/docs/worklogs/2026-07-17-structured-error-model.md
@@ -499,6 +499,46 @@ configuration checks passed; a separate extension test lane failed on
 tropical tests asserting the old validation payload and is not silenced or
 folded into this checkout fix.
 
+## Tropical AD host-boundary classification follow-up on 2026-07-18
+
+The two failing tropical tests were stale expectations, not an implementation
+classification defect. The structured implementation already validates the
+three cases in this order and preserves the shared error vocabulary:
+
+| Surface | Input defect | Required result |
+| --- | --- | --- |
+| JVP and VJP host reference | wrong input arity/configuration | `Validation(InvalidArgument { argument: "configuration" })` |
+| JVP tangent or VJP cotangent | dtype differs from the primal/active input | `Validation(DTypeMismatch { expected: F64, actual: I64 })` |
+| JVP tangent or VJP cotangent | exact shape differs from the required shape | `Validation(ShapeMismatch(IncompatibleShapes { lhs: expected, rhs: actual }))` |
+
+The tests now assert each operation name, `ErrorKind`, concrete payload, and
+the `thiserror` source chain while retaining the `catch_unwind` boundary
+regression. Operation-level unsupported dtype remains a distinct typed
+tropical extension error when the primal inputs themselves use an unsupported
+but matching dtype; it is not substituted for a tangent/cotangent dtype
+mismatch. The direct `HostReference` contract returns the tensor error, while
+the runtime execution wrapper preserves that typed source in
+`Error::TensorRuntime` and supplies the execution phase.
+
+The focused RED/GREEN and strict feature-enabled gates were:
+
+```text
+cargo test --manifest-path ext/tropical/Cargo.toml --features autodiff --lib tropical_jvp_host_boundary_rejects_count_dtype_and_exact_shape -- --nocapture
+# initial RED: stale InvalidArgument assertion failed
+# final GREEN: 1 passed
+cargo test --manifest-path ext/tropical/Cargo.toml --features autodiff --lib tropical_vjp_host_boundary_rejects_count_dtype_and_exact_shape -- --nocapture
+# exit 0; 1 passed
+cargo test --manifest-path ext/tropical/Cargo.toml --features autodiff --all-targets -- --nocapture
+# exit 0; all tropical unit, integration, and benchmark targets passed
+cargo clippy --manifest-path ext/tropical/Cargo.toml --features autodiff --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+# exit 0
+```
+
+The feature-enabled Clippy gate also exposed two pre-existing lint findings
+inside the same tropical validation/AD module: an unused `enumerate()` index
+and an elidable helper lifetime. Both were removed without changing behavior
+or error mapping.
+
 ## Residual risks
 
 Hardware-dependent CUDA/WebGPU/PJRT execution and hosted affinity/NUMA

--- a/docs/worklogs/2026-07-17-structured-error-model.md
+++ b/docs/worklogs/2026-07-17-structured-error-model.md
@@ -237,6 +237,20 @@ returned `Verdict: pass / No findings`. Rustdoc produced no broken-link
 warnings after replacing cross-crate links with the public
 `tenferro_tensor::ValidationError` path.
 
+After checkpoint `05221f5a`, the committed-head gates were rerun without a
+worktree overlay. `cargo check --workspace --all-targets
+--message-format=short` exited 0, as did the CI-identical commands:
+
+```text
+cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+cargo clippy --manifest-path ext/tropical/Cargo.toml --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+cargo clippy --manifest-path ext/sparse/Cargo.toml --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-final.json
+```
+
+The final committed-head review again returned `Verdict: pass / No
+findings`, and `git diff HEAD^ HEAD --check` was clean.
+
 The current WebGPU feature check was rerun as
 `cargo check -p tenferro-gpu --no-default-features --features 'webgpu cpu-faer' --all-targets --message-format=short` and still exits 101 with 18 diagnostics. Its first errors remain the CubeCL `TensorBinding`, `StorageType`, and `Type` mismatches recorded above; this is the same dependency mismatch proven on clean `origin/main`, not a structured-error change.
 

--- a/docs/worklogs/2026-07-17-structured-error-model.md
+++ b/docs/worklogs/2026-07-17-structured-error-model.md
@@ -183,7 +183,7 @@ command passes with all 36 tests.
 The same release run found two einsum doctests whose trailing `Ok::<...>`
 annotations still named the removed AD error type after the einsum API became
 crate-local. The examples now return `tenferro_einsum::Error`; the exact
-`cargo test -p tenferro-einsum --doc --release` gate passes all 78 doctests.
+`cargo test -p tenferro-einsum --doc --release` gate passes all 81 doctests.
 
 The next workspace release run found one remaining stale doctest in
 `tenferro_tensor::validate::DiagonalError`: the example constructed the
@@ -203,10 +203,39 @@ passed `python3.11 scripts/check-coverage.py coverage.json` for 163/163 files
 The remaining static gates also passed: `cargo fmt --all --check`,
 `git diff --check`, `cargo doc --workspace --no-deps`, full and
 `--changed-from origin/main` public-error documentation audits, the audit's
-eight unit tests, docs consistency tests, repository-rule review tests, the
+nine unit tests, docs consistency tests, repository-rule review tests, the
 workspace strict Clippy command, and strict Clippy for both nested extension
 manifests. The public-error audit reported `public-error-docs-ok` in both
 modes; no `result_large_err` or documentation allowlist was added.
+
+The audit was then tightened after the committed-head repository review
+identified eight `TypedTensorView` methods and four CUDA cache methods whose
+sections were either generic or separated from the heading by a missing blank
+doc line. The concrete-variant matcher now rejects `Error::Validation` unless
+the section also names a payload variant or an observable condition; its
+negative regression test covers the exact category-only wording. The affected
+accessors now name rank/index/layout/dtype/runtime-state conditions, the linalg
+option methods name their input, gauge, provider, and placement failures, and
+the eager pad/extension and CubeCL launch docs name their concrete sources.
+The exact follow-up checks passed:
+
+```text
+python3.11 scripts/test-check-public-error-docs.py       # 9 tests
+python3.11 scripts/check-public-error-docs.py            # public-error-docs-ok
+python3.11 scripts/check-public-error-docs.py --changed-from origin/main
+python3 scripts/test-doc-consistency.py
+python3 scripts/test-repository-rules-review.py
+cargo doc --workspace --no-deps
+cargo test -p tenferro-ad --doc --release                    # 130 passed
+cargo test -p tenferro-linalg --doc --release                # 49 passed
+```
+
+The worktree-inclusive repository-rules review was rerun with
+`python3 scripts/repository-rules-review.py --base origin/main --head HEAD
+--worktree --output-json /tmp/repository-rules-review-worktree.json` and
+returned `Verdict: pass / No findings`. Rustdoc produced no broken-link
+warnings after replacing cross-crate links with the public
+`tenferro_tensor::ValidationError` path.
 
 The current WebGPU feature check was rerun as
 `cargo check -p tenferro-gpu --no-default-features --features 'webgpu cpu-faer' --all-targets --message-format=short` and still exits 101 with 18 diagnostics. Its first errors remain the CubeCL `TensorBinding`, `StorageType`, and `Type` mismatches recorded above; this is the same dependency mismatch proven on clean `origin/main`, not a structured-error change.

--- a/docs/worklogs/2026-07-17-structured-error-model.md
+++ b/docs/worklogs/2026-07-17-structured-error-model.md
@@ -1,0 +1,71 @@
+# Structured Error Model
+
+Date: 2026-07-17
+
+## Scope
+
+This work implements the approved structured error model from
+`docs/superpowers/specs/2026-07-17-structured-error-model-design.md` and the
+ordered plan in `docs/superpowers/plans/2026-07-17-structured-error-model.md`.
+The branch starts from `origin/main` at `1ec2062e` and contains only the
+approved design and plan commits before implementation.
+
+## Classification policy
+
+The migration applies one policy at every crate boundary:
+
+1. Caller-controlled tensor relationships use shared typed validation payloads
+   (`ShapeMismatch`, rank, axis, dtype, or `InvalidArgument`).
+2. Unsupported operations and dtypes use `Unsupported`, with a typed local
+   source when the domain owns a more specific reason.
+3. Numerical failure (singularity, non-convergence, division by zero, and
+   related numeric-domain failures) uses `NumericalFailure` and retains the
+   typed local source.
+4. Typed in-workspace backend/kernel failures use `BackendSource`; vendor
+   status text with no typed source is the only remaining `BackendFailure` text
+   case.
+5. Typed file, stream, serialization, or dynamic-library failures use
+   `ErrorKind::Io` and retain their source. They are not backend failures just
+   because they occurred during backend execution.
+6. Missing, uninitialized, poisoned, or invalid executor/cache/device state
+   uses `ErrorKind::RuntimeState`, retaining a typed source when available.
+   Impossible invariants remain `Internal`.
+
+`ErrorPhase` is orthogonal to the category: eager and traced paths use the
+same validation payload and classification for the same known input, while
+the phase records whether the fact was discovered during graph construction,
+compilation, or execution.
+
+## Checkpoints
+
+- `109a8d11`: shared tensor validation payloads and boxed shape mismatch.
+- `13bcf73d`: tensor outer source-chain model and public error docs.
+- `772d9c4e`: CPU structured validation and typed backend sources.
+- `89d3ab42`: CUDA structured errors, including typed unsupported-dtype source.
+- `1a9b8b4f`: runtime and default-feature extension migration.
+
+Further checkpoints will record the linalg, optional extension, audit, and
+release-gate work below.
+
+## Verification notes
+
+The CPU all-target test suite ran 311 unit and 43 integration tests before the
+benchmark failed because the local environment cannot resolve the requested
+NUMA/affinity placement:
+
+```text
+faer AllAllowed placement should resolve: ManagedAffinityUnavailable {
+    requested: AllAllowed,
+    backend: Faer,
+}
+```
+
+This is an environment limitation, not a passing claim for the complete
+all-target command. The exact optional WebGPU dependency evidence will be
+recorded after the isolated clean-`origin/main` comparison.
+
+## Residual risks
+
+Hardware-dependent CUDA/WebGPU/PJRT execution and hosted affinity/NUMA
+benchmarks require their documented environments. No dependency revision or
+lint allowlist is added to hide those limitations.

--- a/docs/worklogs/2026-07-17-structured-error-model.md
+++ b/docs/worklogs/2026-07-17-structured-error-model.md
@@ -469,6 +469,36 @@ PATH=/Users/hiroshi/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin:$
 # exit 0; fast PR checks passed
 ```
 
+## CI changed-base audit fix on 2026-07-18
+
+The public-error documentation audit keeps its `revision...HEAD` comparison:
+the triple-dot form is required because the audit must inspect the merge-base
+diff and must fail loudly when the requested base object is unavailable. PR
+CI's `clippy` job was invoking `--changed-from` after the default
+`actions/checkout` shallow checkout, so a base SHA such as
+`e8ef92c9e62260eb83e2c1e221234d945e9e9c3c` was not guaranteed to be present.
+The correct boundary fix is `fetch-depth: 0` on that checkout. A workflow
+contract test scans every workflow job that invokes `--changed-from` and
+requires this full-history setting; no two-dot fallback or audit error
+suppression was added.
+
+The public-error audit tests also create a two-commit repository, clone only
+the head with `git clone --depth 1`, and verify that the missing-base
+`git diff base...HEAD` returns exit 128 and that the Python audit propagates
+the failure. The same fixture passes against the full-history repository.
+This reproduces the hosted checkout failure without depending on GitHub's
+runner filesystem.
+
+The failing PR run `29627808652` confirmed the same sequence: the full audit
+printed `public-error-docs-ok`, then the changed audit raised
+`CalledProcessError` for
+`git diff --name-only e8ef92c9e62260eb83e2c1e221234d945e9e9c3c...HEAD -- *.rs`
+with `returned non-zero exit status 128`. The checkout-depth change addresses
+that Git object availability failure at the workflow boundary. The same run's
+configuration checks passed; a separate extension test lane failed on
+tropical tests asserting the old validation payload and is not silenced or
+folded into this checkout fix.
+
 ## Residual risks
 
 Hardware-dependent CUDA/WebGPU/PJRT execution and hosted affinity/NUMA

--- a/docs/worklogs/2026-07-17-structured-error-model.md
+++ b/docs/worklogs/2026-07-17-structured-error-model.md
@@ -570,6 +570,44 @@ cargo clippy --manifest-path ext/sparse/Cargo.toml --features autodiff --all-tar
 # exit 0
 ```
 
+## CUDA validation-flag source follow-up on 2026-07-18
+
+The rerun of the hosted repository-rules review identified three CUDA
+validation-flag branches that had been converted to `Error::Internal(String)`
+during the structured migration. The same boundary also contained an integer
+domain flag branch with the same erasure, although the model did not report it.
+These are backend invariant failures: the host download returned a dtype other
+than the dtype used to allocate the typed validation flag. They are not caller
+configuration errors, so the canonical mapping is `BackendFailure` with a
+typed `CudaError::UnexpectedValidationFlagDType` source. The operation name,
+expected dtype, and actual dtype remain machine-readable through the source
+chain; no message parsing or compatibility variant was added.
+
+`CudaExtensionCache::new` now documents its default 16-entry bound, and
+`clear` states its poisoned-lock runtime-state condition. The six
+`EagerTensor` methods named by the same review already contain concrete
+`# Errors` sections in the branch source; the deterministic public-error audit
+passes, so no duplicate or boilerplate documentation was added for the
+review bot's contradictory LLM output.
+
+Focused verification:
+
+```text
+cargo test -p tenferro-gpu --features cuda --lib cubecl::error::tests -- --nocapture
+# exit 0; 4 typed CUDA error/source tests passed
+cargo check -p tenferro-gpu --features cuda --lib --message-format=short
+# exit 0
+cargo clippy -p tenferro-gpu --features cuda --lib -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+# not a passing gate: the current toolchain reports 22 unscoped CUDA-module
+# lint findings across dispatch/FFI/fusion/kernel code; none are silenced by
+# this change
+```
+
+The hosted rerun of the review bot still reported a changing set of false
+missing-`# Errors` findings despite the sections being present. This remains a
+review-service limitation rather than a source omission; the local
+deterministic review and public-error audit are the authoritative local gates.
+
 ## Residual risks
 
 Hardware-dependent CUDA/WebGPU/PJRT execution and hosted affinity/NUMA

--- a/docs/worklogs/2026-07-17-structured-error-model.md
+++ b/docs/worklogs/2026-07-17-structured-error-model.md
@@ -300,6 +300,56 @@ state, shape-data length, index, and layout failures; and `TensorRead`/
 `TensorWrite` name stride and offset arithmetic failures. The full workspace
 docs build and the worktree repository-rules review now return no findings.
 
+## Review remediation on 2026-07-18
+
+The follow-up review was handled as boundary-level changes rather than
+per-call-site compile fixes:
+
+- Traced unary, binary, and ternary construction now uses fallible dtype
+  inference at `GraphBuild`. Ordered operations, including complex `Rem`,
+  return a typed `Unsupported` error with the graph-build phase instead of
+  reaching an inference panic. The compiler keeps the same inference helper
+  on the `Compile` phase, and the public-operation audit found no remaining
+  infallible dtype-inference helper.
+- `BroadcastError` has one conversion to the shared validation vocabulary.
+  Eager, traced, and direct runtime tensor surfaces use that conversion for
+  `IncompatibleBinary`, `IncompatibleInput`, and `RankTooLarge`; parity tests
+  assert identical payloads while allowing the discovery phase to differ.
+- `ShapeGuardFailure` wraps the original typed `ShapeGuardError`. Its
+  autodiff-only side channel records that value before it crosses tidu's
+  message-only `ADRuleError` boundary; the eager and traced frontends consume
+  the side channel and expose `Error::AdRuleSource` with a real source chain.
+  Non-autodiff builds compile without a dead side-channel field.
+- Einsum planning now owns a typed `PlanningError`: caller-invalid
+  expressions, shapes, paths, and optimizer options classify as validation,
+  while an explicitly unavailable or poisoned planner state classifies as
+  runtime state. Extension lowering passes the source's `kind()` through the
+  typed `ExtensionLoweringError`, so XLA no longer flattens unsupported,
+  numerical, backend, or runtime-state failures into invalid argument.
+- Online guides and `TracedTensor::add` explain why `a + b + c` cannot compose
+  when `Add<Output = Result<_>>`, show the two-step `?` form and the explicit
+  method chain, and state that robust error handling takes priority over
+  operator-chain concision. Add/sub docs no longer claim zero-divisor errors;
+  div/rem retain their execution-time numerical condition.
+
+The focused review-fix verification completed before the final workspace gate:
+
+```text
+cargo test -p tenferro-runtime --all-targets --no-fail-fast --message-format=short
+cargo test -p tenferro-ad eager_and_traced_broadcast_errors_share_payloads_across_discovery_phases --test integration --message-format=short
+cargo test -p tenferro-internal-ops --all-targets --no-fail-fast --message-format=short
+cargo test -p tenferro-ad ad_rule_error --lib --message-format=short
+cargo test -p tenferro-einsum --test integration error_public --message-format=short
+cargo test -p tenferro-xla error::tests --lib --message-format=short
+cargo test -p tenferro-internal-ops --doc --message-format=short
+cargo test -p tenferro-einsum -p tenferro-xla --doc --message-format=short
+```
+
+All commands above exited successfully. The implementation adds no
+compatibility variants, deprecated aliases, or long-lived lint allowlists;
+staged file lists and `git diff --cached --check` were reviewed before each
+checkpoint commit.
+
 ## Residual risks
 
 Hardware-dependent CUDA/WebGPU/PJRT execution and hosted affinity/NUMA

--- a/docs/worklogs/2026-07-17-structured-error-model.md
+++ b/docs/worklogs/2026-07-17-structured-error-model.md
@@ -350,6 +350,73 @@ compatibility variants, deprecated aliases, or long-lived lint allowlists;
 staged file lists and `git diff --cached --check` were reviewed before each
 checkpoint commit.
 
+## Final review-fix gates after the latest-main rebase
+
+The branch was rebased from merge-base `1ec2062e` onto the current
+`origin/main` `83f7c48b` after local preflight rejected the stale base. The
+rebase had no conflicts; `git merge-base HEAD origin/main` now returns
+`83f7c48b`.
+
+The complete release and coverage gates passed:
+
+```text
+cargo test --workspace --release
+# exit 0; all workspace unit, integration, and doctests passed
+cargo llvm-cov --workspace --release --json --output-path coverage.json
+python3.11 scripts/check-coverage.py coverage.json
+# exit 0; Coverage check: 163/163 files passed (excluded: 3)
+```
+
+The optional compile gates also passed:
+
+```text
+cargo check -p tenferro-cpu --no-default-features --features cpu-blas --all-targets --message-format=short
+cargo check -p tenferro-linalg --no-default-features --features cpu-blas --all-targets
+cargo check -p tenferro-runtime --no-default-features --features cpu-blas --all-targets --message-format=short
+cargo check -p tenferro-gpu --no-default-features --features 'cuda cpu-faer' --all-targets --message-format=short
+cargo check -p tenferro-xla --no-default-features --features pjrt --all-targets --message-format=short
+```
+
+The CUDA feature's hardware-independent tests passed with 38 passed and 108
+ignored. The following BLAS test commands were run but are not claimed as
+passing: both stop at the arm64 linker because this host lacks matching BLAS
+and LAPACK symbols. The first causal symbols are `_cblas_ctrsm`,
+`_cblas_dtrsm`, `_cblas_strsm`, `_cblas_ztrsm`, `_cgetrf_`, and `_dgetrf_` for
+linalg; the runtime test additionally reports `_cblas_cgemm`,
+`_cblas_dgemm`, `_cblas_sgemm`, and `_cblas_zgemm`.
+
+```text
+cargo test -p tenferro-linalg --no-default-features --features cpu-blas --all-targets
+cargo test -p tenferro-runtime --no-default-features --features cpu-blas --all-targets
+```
+
+The current CI profiles were exercised with Python 3.11 on this macOS host:
+
+```text
+PATH=/Users/hiroshi/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin:$PATH bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-runtime remainder_rejects_complex_dtype_at_graph_build_without_panicking' --ci-profile docs
+# exit 0; docs-site and all 9 stages passed (optional Graphviz dependency graph skipped: dot not installed)
+PATH=/Users/hiroshi/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin:$PATH bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-runtime remainder_rejects_complex_dtype_at_graph_build_without_panicking' --ci-profile workspace-faer
+# exit 0; nextest 2243/2243 passed (one leaky test reported), workspace release doctests passed
+```
+
+The CI unit tests initially exposed a macOS Bash 3.2 bug in
+`check-pr-fast.sh`: `set -u` rejects the length expansion of an empty array.
+The script now tracks explicit focused-test/profile counts and only expands
+non-empty arrays. This keeps the existing CI policy intact while making the
+preflight portable. With the fix, the focused CI policy tests pass:
+
+```text
+PATH=/Users/hiroshi/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin:$PATH /Users/hiroshi/.local/bin/python3.11 -m unittest discover -s scripts/ci/tests -p 'test_change_policy.py' -v
+# exit 0; 15 tests passed
+```
+
+The full `ci-config` profile reaches its final `actionlint` step after 81 CI
+unit tests pass, but this host has no `actionlint` executable (`actionlint:
+command not found`). It is therefore an environmental limitation and is not
+claimed as a passing local gate. The obsolete `--ci-profile local-gate`
+argument was also verified to be rejected because current `origin/main`
+removed that profile; the current profiles above are authoritative.
+
 ## Residual risks
 
 Hardware-dependent CUDA/WebGPU/PJRT execution and hosted affinity/NUMA

--- a/docs/worklogs/2026-07-17-structured-error-model.md
+++ b/docs/worklogs/2026-07-17-structured-error-model.md
@@ -539,6 +539,37 @@ inside the same tropical validation/AD module: an unused `enumerate()` index
 and an elidable helper lifetime. Both were removed without changing behavior
 or error mapping.
 
+## Sparse AD host-boundary follow-up on 2026-07-18
+
+The first rerun of the hosted `extensions` profile confirmed that the tropical
+tests were fixed, then exposed the analogous stale sparse JVP/VJP assertions.
+Both sparse tests still expected `InvalidArgument` for count, dtype, and shape.
+The host path already used the shared value-tensor validator for tangent and
+cotangent inputs, so the observed dtype and shape results were the intended
+structured errors rather than an implementation regression.
+
+The owning sparse metadata boundary was then audited as well. Its primal,
+tangent, and cotangent metadata checks had been erasing dtype and rank facts
+into the configuration bucket. They now use the same exact constructors as
+the host boundary: invalid arity/active-input configuration remains
+`InvalidArgument`, wrong dtype is `DTypeMismatch`, wrong rank is
+`RankMismatch`, and known value extent is `ShapeMismatch`. The tests assert
+the concrete payloads, coarse `ErrorKind`, operation name, and source chain
+for the host path, plus shared metadata dtype/rank classification.
+
+The sparse RED/GREEN gates were:
+
+```text
+cargo test --manifest-path ext/sparse/Cargo.toml --features autodiff --lib sparse_jvp_host_boundary_rejects_count_dtype_and_exact_shape -- --nocapture
+# initial RED: stale InvalidArgument assertion failed with Validation(DTypeMismatch)
+cargo test --manifest-path ext/sparse/Cargo.toml --features autodiff --lib extension::tests::sparse_ -- --nocapture
+# exit 0; 3 focused classification tests passed
+cargo test --manifest-path ext/sparse/Cargo.toml --features autodiff --all-targets -- --nocapture
+# exit 0; 3 unit, 6 AD integration, and 2 constructor tests passed
+cargo clippy --manifest-path ext/sparse/Cargo.toml --features autodiff --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+# exit 0
+```
+
 ## Residual risks
 
 Hardware-dependent CUDA/WebGPU/PJRT execution and hosted affinity/NUMA

--- a/docs/worklogs/2026-07-17-structured-error-model.md
+++ b/docs/worklogs/2026-07-17-structured-error-model.md
@@ -44,8 +44,9 @@ compilation, or execution.
 - `89d3ab42`: CUDA structured errors, including typed unsupported-dtype source.
 - `1a9b8b4f`: runtime and default-feature extension migration.
 
-Further checkpoints will record the linalg, optional extension, audit, and
-release-gate work below.
+The linalg, optional extension, audit, and release-gate verification is
+recorded below; implementation commits will be added after the final staged
+diff review.
 
 ## Verification notes
 
@@ -61,8 +62,179 @@ faer AllAllowed placement should resolve: ManagedAffinityUnavailable {
 ```
 
 This is an environment limitation, not a passing claim for the complete
-all-target command. The exact optional WebGPU dependency evidence will be
-recorded after the isolated clean-`origin/main` comparison.
+all-target command. The isolated clean-`origin/main` WebGPU comparison is
+recorded below.
+
+## Public API documentation audit
+
+The runtime audit initially reported 149 public `Result` APIs without a
+usable concrete `# Errors` contract. Each runtime section was reviewed at the
+operation boundary rather than filled with a category-only sentence. The
+sections name the observable validation payloads (`ShapeMismatch`,
+`RankMismatch`, `AxisOutOfBounds`, `DuplicateAxis`, `DTypeMismatch`, and
+`InvalidArgument`), operation-level unsupported cases, numerical failures,
+typed backend/extension sources, and runtime-state failures where those paths
+are reachable. Traced operations additionally describe which checks happen at
+graph build and which symbolic constraints or bound indices can fail at
+compile/execution, under a separate `# Deferred errors` heading.
+
+The repository gate is `scripts/check-public-error-docs.py`. It audits public
+functions and public trait methods returning `Result`, understands both
+`///` and proc-macro `#[doc = ...]` documentation, rejects a missing or
+category-only `# Errors` section, and requires a `# Deferred errors` section
+when a traced API documents deferred validation. Its unit tests are in
+`scripts/test-check-public-error-docs.py`; CI runs the unit test, the complete
+workspace audit, and the audit of lines changed from the event base. The
+Clippy job also explicitly denies both
+`clippy::missing_errors_doc` and `clippy::missing_panics_doc` for the workspace,
+`ext/tropical`, and `ext/sparse`. This makes future public `Result` APIs fail
+the source audit/CI instead of relying on a long-lived lint allowlist.
+
+## Boundary mapping audit
+
+The implementation was audited by source owner and failure meaning, not by
+call-site compilation alone:
+
+- Tensor-core owns the shared validation vocabulary. `ShapeMismatch` is boxed
+  at the outer tensor boundary to keep error values below the large-error lint
+  threshold while preserving `matches!`, `source()`, and
+  `ShapeMismatch::... .into()` ergonomics.
+- Operation-level unsupported dtypes use `UnsupportedDType { op, dtype }` and
+  a typed CUDA/WebGPU/linalg source. `UnsupportedDTypeConversion` is reserved
+  for a real input-to-target conversion or cast; no operation-only rejection
+  is represented as `from == to`.
+- Singularity, non-convergence, zero divisors, and negative integer powers are
+  numerical failures with local typed sources. CUDA/cuTENSOR/cuSOLVER/LAPACK
+  status and workspace failures retain typed provider sources and are backend
+  failures. CPU placement discovery, unavailable managed affinity, and
+  unknown NUMA nodes are runtime-state failures; unsupported external affinity
+  is an unsupported extension condition, not a backend catch-all.
+- Typed file, stream, serialization, and dynamic-library failures use the I/O
+  classification. Missing/uninitialized/poisoned registry, executor, cache,
+  device, and buffer state uses runtime-state. `BackendFailure(String)` is
+  retained only for boundaries that genuinely expose no typed source and for
+  explicit test injection; production typed boundaries use `backend_source` or
+  an extension source. The AD adapter necessarily converts the typed runtime
+  error to the external `tidu::ADRuleError` message-only type at that foreign
+  API boundary, while retaining the typed runtime error in deferred errors.
+
+## Optional feature and dependency evidence
+
+These checks passed with the structured model:
+
+```text
+cargo check -p tenferro-cpu --no-default-features --features cpu-blas --all-targets --message-format=short
+cargo check -p tenferro-linalg --no-default-features --features cpu-blas --all-targets
+cargo clippy -p tenferro-linalg --no-default-features --features cpu-blas --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+cargo check -p tenferro-runtime --no-default-features --features cpu-blas --all-targets --message-format=short
+cargo check -p tenferro-gpu --no-default-features --features 'cuda cpu-faer' --all-targets --message-format=short
+cargo check -p tenferro-xla --no-default-features --features pjrt --all-targets --message-format=short
+cargo clippy --manifest-path ext/sparse/Cargo.toml --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc
+```
+
+The correct CUDA feature check includes `cpu-faer`; the intentionally
+incomplete command
+`cargo check -p tenferro-gpu --no-default-features --features cuda --all-targets`
+fails at the repository's required CPU-fallback `compile_error!`, so it is not
+used as a feature-support claim.
+
+WebGPU remains unavailable for a pre-existing dependency-resolution reason.
+To prove that it was not introduced here, an isolated clean worktree at
+`/private/tmp/tenferro-origin-main-webgpu-1784299674-45394` was checked at
+clean `origin/main` commit `1ec2062e` with the exact command:
+
+```text
+cargo check -p tenferro-gpu --features webgpu --all-targets --message-format=short
+```
+
+Its first causal errors were `TensorBinding<_>` versus
+`TensorBinding<WgpuRuntime>`, followed by `cubecl_ir::StorageType` and type
+mismatches (12 errors). The current branch's
+`cargo check -p tenferro-gpu --no-default-features --features 'webgpu cpu-faer' --all-targets --message-format=short`
+reproduces the same CubeCL binding/storage mismatch (18 diagnostics, with the
+same first error family). The clean main resolution uses direct CubeCL commit
+`b9e8f0f3...`, cubek commit `7d9e382...`, and CubeCL dependency
+`6424d9da...`; this PR does not alter those revisions.
+
+The documented CUDA ignored-test command was not run because this macOS host
+has no `/usr/local/cuda-12.8` toolkit or NVIDIA runtime:
+
+```text
+CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda-12.8 LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:/usr/lib/x86_64-linux-gnu/libcutensor/12:$LD_LIBRARY_PATH cargo test -p tenferro-gpu --features cuda -- --ignored
+```
+
+The full CPU all-target command is likewise not claimed as passing because
+the local Faer `AllAllowed` affinity test returns the
+`ManagedAffinityUnavailable` runtime-state error shown above. The focused CPU
+library/integration commands pass. The docs-site checker passes under
+Python 3.11 and 3.12; the host default `python3` is 3.9.6 and exits with the
+checker’s explicit “Python 3.11+ is required” diagnostic.
+
+The first post-migration `cargo test --workspace --release` also exposed two
+environment-sensitive test/documentation issues during verification. The
+XLA PJRT execution test could race the `pjrt_env` tests: both ran in one test
+binary, but each used a different static mutex while `pjrt_env` temporarily
+set `TENFERRO_PJRT_PLUGIN=/definitely/missing/pjrt.so`. The execution test then
+observed that temporary value and unwrapped a deliberate `PluginLoad` error.
+The fix is a shared parent-module lock used by both modules; the full
+`cargo test -p tenferro-xla --features pjrt --test integration --release`
+command passes with all 36 tests.
+
+The same release run found two einsum doctests whose trailing `Ok::<...>`
+annotations still named the removed AD error type after the einsum API became
+crate-local. The examples now return `tenferro_einsum::Error`; the exact
+`cargo test -p tenferro-einsum --doc --release` gate passes all 78 doctests.
+
+The next workspace release run found one remaining stale doctest in
+`tenferro_tensor::validate::DiagonalError`: the example constructed the
+non-batched `SingularOrNonFinite` variant with the removed `batch` field. The
+example now uses the current `{ index }` payload, and
+`cargo test -p tenferro-tensor --doc --release` passes all 284 doctests.
+
+The complete release gate was then rerun exactly as
+`cargo test --workspace --release`; it exited successfully. The resulting
+workspace run included the XLA integration suite (36 tests), runtime doctests
+(238), and tensor doctests (284), with no failed tests or doctests. Coverage
+was collected with
+`cargo llvm-cov --workspace --release --json --output-path coverage.json` and
+passed `python3.11 scripts/check-coverage.py coverage.json` for 163/163 files
+(three excluded by policy).
+
+The remaining static gates also passed: `cargo fmt --all --check`,
+`git diff --check`, `cargo doc --workspace --no-deps`, full and
+`--changed-from origin/main` public-error documentation audits, the audit's
+eight unit tests, docs consistency tests, repository-rule review tests, the
+workspace strict Clippy command, and strict Clippy for both nested extension
+manifests. The public-error audit reported `public-error-docs-ok` in both
+modes; no `result_large_err` or documentation allowlist was added.
+
+The current WebGPU feature check was rerun as
+`cargo check -p tenferro-gpu --no-default-features --features 'webgpu cpu-faer' --all-targets --message-format=short` and still exits 101 with 18 diagnostics. Its first errors remain the CubeCL `TensorBinding`, `StorageType`, and `Type` mismatches recorded above; this is the same dependency mismatch proven on clean `origin/main`, not a structured-error change.
+
+The hardware-independent CUDA feature test command
+`cargo test -p tenferro-gpu --no-default-features --features 'cuda cpu-faer' --all-targets`
+passes 38 tests and explicitly skips 108 GPU-dependent tests. The exact CUDA
+`-- --ignored` command remains unrun because the host lacks the required
+toolkit/runtime. The two optional CPU-BLAS test commands were rerun and still
+fail before tests at the arm64 linker with missing BLAS/LAPACK symbols; their
+`cargo check` and strict Clippy gates pass.
+
+The optional BLAS test commands were attempted but are not claimed as
+passing on this macOS arm64 host:
+
+```text
+cargo test -p tenferro-linalg --no-default-features --features cpu-blas --all-targets
+cargo test -p tenferro-runtime --no-default-features --features cpu-blas --all-targets
+```
+
+Both fail during linking, before tests run. The first causal linker symbols
+are `_cblas_ctrsm`, `_cblas_dtrsm`, `_cblas_strsm`, `_cblas_ztrsm`, and
+LAPACK symbols such as `_cgetrf_`/`_dgetrf_`; the runtime command additionally
+reports `_cblas_cgemm`/`_cblas_dgemm`/`_cblas_sgemm`/`_cblas_zgemm`. No matching
+arm64 BLAS/LAPACK provider is configured in this environment. The same
+features do pass `cargo check` and strict lints. CUDA-feature non-ignored
+tests compile and pass, while the CUDA tests marked `ignored` remain
+hardware-dependent and were not run.
 
 ## Residual risks
 

--- a/docs/worklogs/2026-07-17-structured-error-model.md
+++ b/docs/worklogs/2026-07-17-structured-error-model.md
@@ -279,6 +279,27 @@ features do pass `cargo check` and strict lints. CUDA-feature non-ignored
 tests compile and pass, while the CUDA tests marked `ignored` remain
 hardware-dependent and were not run.
 
+The committed-head repository-rules review then identified two documentation
+quality issues in the public surface: the four `GraphCompilerEinsumExt` methods
+had concrete `# Errors` text but no method-specific summary before the section,
+and several tensor-error doctests relied on imports or type aliases that a
+reviewer could not verify from the example alone. The methods now describe
+their exact default/explicit optimizer and textual/parsed-subscript behavior.
+The tensor-error examples use fully qualified public paths and match concrete
+variants, including the typed backend source chain, so their compilation and
+runtime contract is visible without inference. The targeted doctests pass
+(284 tensor examples and 78 einsum examples), and the committed-head review
+was rerun after these changes.
+
+The follow-up review also rejected the remaining blanket view/tensor wording
+as too broad. The tensor public surface was audited by operation family rather
+than patched call-site by call-site: strided views now name rank/slice/layout
+and mutable-overlap variants; owned views name reshape, broadcast, and slice
+payloads; typed/dynamic tensors distinguish dtype mismatch, host-access runtime
+state, shape-data length, index, and layout failures; and `TensorRead`/
+`TensorWrite` name stride and offset arithmetic failures. The full workspace
+docs build and the worktree repository-rules review now return no findings.
+
 ## Residual risks
 
 Hardware-dependent CUDA/WebGPU/PJRT execution and hosted affinity/NUMA

--- a/ext/sparse/src/extension.rs
+++ b/ext/sparse/src/extension.rs
@@ -61,13 +61,26 @@ impl SparseMatmulPlan {
         right_shape: &[usize],
         right_entries: &[[usize; 2]],
     ) -> Result<Self> {
-        if left_shape.len() != 2 || right_shape.len() != 2 {
-            return Err(invalid("sparse matmul requires rank-2 operands"));
+        if left_shape.len() != 2 {
+            return Err(tenferro_tensor::Error::rank_mismatch(
+                OP,
+                2,
+                left_shape.len(),
+            ));
+        }
+        if right_shape.len() != 2 {
+            return Err(tenferro_tensor::Error::rank_mismatch(
+                OP,
+                2,
+                right_shape.len(),
+            ));
         }
         if left_shape[1] != right_shape[0] {
-            return Err(invalid(format!(
-                "shape mismatch for sparse matmul: lhs {left_shape:?}, rhs {right_shape:?}"
-            )));
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                OP,
+                vec![left_shape[1]],
+                vec![right_shape[0]],
+            ));
         }
 
         let mut raw = Vec::new();
@@ -128,7 +141,10 @@ impl SparseMatmulPlan {
 ///
 /// # Errors
 ///
-/// Returns an error if runtime registration fails.
+/// Returns [`ExtensionRuntimeRegistryError::MalformedFamilyId`] when a
+/// runtime family identifier is invalid, or
+/// [`ExtensionRuntimeRegistryError::PoisonedLock`] if registry state was
+/// poisoned while registering the family.
 ///
 /// # Examples
 ///
@@ -554,7 +570,9 @@ impl ExtensionLinearTransposeRule for SparseMatmulJvpAdRule {
 ///
 /// # Errors
 ///
-/// Returns an error if rule registration fails.
+/// Returns `ExtensionRegistryError::MalformedFamilyId` if a generated sparse
+/// family identifier is invalid, or `ExtensionRegistryError::DuplicateRule`
+/// if a sparse linearize or linear-transpose rule is already registered.
 ///
 /// # Examples
 ///
@@ -759,10 +777,7 @@ fn hash_plan(plan: &SparseMatmulPlan, hasher: &mut dyn Hasher) {
 }
 
 fn invalid(message: impl Into<String>) -> Error {
-    Error::InvalidConfig {
-        op: OP,
-        message: message.into(),
-    }
+    Error::invalid_argument(OP, "configuration", message)
 }
 
 #[cfg(all(test, feature = "autodiff"))]

--- a/ext/sparse/src/extension.rs
+++ b/ext/sparse/src/extension.rs
@@ -347,13 +347,17 @@ impl ExtensionOp for SparseMatmulJvpOp {
             }
             let tangent_idx = 2 + active_pos;
             if input_dtypes[tangent_idx] != input_dtypes[active] {
-                return Err(invalid(
-                    "sparse tangent dtype must match active input dtype",
+                return Err(Error::dtype_mismatch(
+                    OP,
+                    input_dtypes[active],
+                    input_dtypes[tangent_idx],
                 ));
             }
             if !is_rank1_shape(&input_shapes[tangent_idx]) {
-                return Err(invalid(
-                    "sparse tangent inputs must be rank-1 value tensors",
+                return Err(Error::rank_mismatch(
+                    OP,
+                    1,
+                    input_shapes[tangent_idx].len(),
                 ));
             }
             ctx.require_same_shape(tangent_idx, active)?;
@@ -436,14 +440,14 @@ impl ExtensionOp for SparseMatmulVjpOp {
         validate_primal_meta(&input_dtypes[..2], &primal_shapes)?;
         require_primal_shape_constraints(ctx, &self.plan)?;
         if input_dtypes[2] != input_dtypes[self.active_input] {
-            return Err(invalid(
-                "sparse VJP cotangent dtype does not match active input dtype",
+            return Err(Error::dtype_mismatch(
+                OP,
+                input_dtypes[self.active_input],
+                input_dtypes[2],
             ));
         }
         if !is_rank1_shape(&input_shapes[2]) {
-            return Err(invalid(
-                "sparse VJP cotangent must be a rank-1 value tensor",
-            ));
+            return Err(Error::rank_mismatch(OP, 1, input_shapes[2].len()));
         }
         ctx.require_equal(ctx.input_axis(2, 0)?, SymDim::from(self.plan.output_nnz()))?;
         Ok(vec![(
@@ -658,14 +662,25 @@ fn validate_primal_meta(input_dtypes: &[DType], input_shapes: &[&[SymDim]]) -> R
             input_shapes.len()
         )));
     }
-    if input_dtypes[0] != DType::F64 || input_dtypes[1] != DType::F64 {
-        return Err(invalid(format!(
-            "sparse matmul supports F64 values, got {:?} and {:?}",
-            input_dtypes[0], input_dtypes[1]
-        )));
+    if input_dtypes[0] != DType::F64 {
+        return Err(Error::dtype_mismatch(
+            OP,
+            DType::F64,
+            input_dtypes[0],
+        ));
     }
-    if !is_rank1_shape(input_shapes[0]) || !is_rank1_shape(input_shapes[1]) {
-        return Err(invalid("sparse matmul inputs must be rank-1 value tensors"));
+    if input_dtypes[1] != DType::F64 {
+        return Err(Error::dtype_mismatch(
+            OP,
+            DType::F64,
+            input_dtypes[1],
+        ));
+    }
+    if !is_rank1_shape(input_shapes[0]) {
+        return Err(Error::rank_mismatch(OP, 1, input_shapes[0].len()));
+    }
+    if !is_rank1_shape(input_shapes[1]) {
+        return Err(Error::rank_mismatch(OP, 1, input_shapes[1].len()));
     }
     Ok(())
 }

--- a/ext/sparse/src/extension/tests.rs
+++ b/ext/sparse/src/extension/tests.rs
@@ -1,7 +1,7 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use tenferro_ops::ext_op::HostReference;
-use tenferro_tensor::{Error, Tensor};
+use tenferro_tensor::{Error, ErrorKind, Tensor, ValidationKind};
 
 use super::{SparseMatmulJvpOp, SparseMatmulPlan, SparseMatmulVjpOp};
 
@@ -23,7 +23,8 @@ fn assert_invalid_without_panic(result: std::thread::Result<tenferro_tensor::Res
     let error = result
         .expect("host-reference validation must not panic")
         .expect_err("malformed host-reference inputs must be rejected");
-    assert!(matches!(error, Error::InvalidConfig { .. }));
+    assert_eq!(error.kind(), ErrorKind::Validation(ValidationKind::InvalidArgument));
+    assert!(matches!(error, Error::Validation { .. }));
 }
 
 #[test]

--- a/ext/sparse/src/extension/tests.rs
+++ b/ext/sparse/src/extension/tests.rs
@@ -1,7 +1,10 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
-use tenferro_ops::ext_op::HostReference;
-use tenferro_tensor::{Error, ErrorKind, Tensor, ValidationKind};
+use tenferro_ops::{ext_op::HostReference, SymDim};
+use tenferro_tensor::{
+    core::DType as CoreDType, DType, Error, ErrorKind, ShapeMismatch, Tensor, ValidationError,
+    ValidationKind,
+};
 
 use super::{SparseMatmulJvpOp, SparseMatmulPlan, SparseMatmulVjpOp};
 
@@ -19,12 +22,72 @@ fn f64_values(len: usize) -> Tensor {
     Tensor::from_vec_col_major(vec![len], vec![1.0_f64; len]).unwrap()
 }
 
-fn assert_invalid_without_panic(result: std::thread::Result<tenferro_tensor::Result<Vec<Tensor>>>) {
-    let error = result
+fn host_error(
+    result: std::thread::Result<tenferro_tensor::Result<Vec<Tensor>>>,
+) -> Error {
+    result
         .expect("host-reference validation must not panic")
-        .expect_err("malformed host-reference inputs must be rejected");
-    assert_eq!(error.kind(), ErrorKind::Validation(ValidationKind::InvalidArgument));
-    assert!(matches!(error, Error::Validation { .. }));
+        .expect_err("malformed host-reference inputs must be rejected")
+}
+
+fn assert_invalid_argument(error: &Error) {
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
+    );
+    assert!(matches!(
+        error,
+        Error::Validation {
+            op: "tenferro-ext-sparse",
+            source: ValidationError::InvalidArgument {
+                argument: "configuration",
+                ..
+            },
+        }
+    ));
+    assert!(std::error::Error::source(error).is_some());
+}
+
+fn assert_dtype_mismatch(error: &Error, expected: CoreDType, actual: CoreDType) {
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::DTypeMismatch)
+    );
+    assert!(matches!(
+        error,
+        Error::Validation {
+            op: "tenferro-ext-sparse",
+            source: ValidationError::DTypeMismatch {
+                expected: actual_expected,
+                actual: actual_actual,
+            },
+        } if *actual_expected == expected && *actual_actual == actual
+    ));
+    assert!(std::error::Error::source(error).is_some());
+}
+
+fn assert_shape_mismatch(error: &Error, expected: &[usize], actual: &[usize]) {
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::ShapeMismatch)
+    );
+    assert!(matches!(
+        error,
+        Error::Validation {
+            op: "tenferro-ext-sparse",
+            source: ValidationError::ShapeMismatch(payload),
+        } if matches!(
+            payload.as_ref(),
+            ShapeMismatch::IncompatibleShapes { lhs, rhs }
+                if lhs.as_slice() == expected && rhs.as_slice() == actual
+        )
+    ));
+    let validation_source =
+        std::error::Error::source(error).expect("shape mismatch must retain its validation source");
+    assert!(
+        std::error::Error::source(validation_source).is_some(),
+        "shape mismatch must retain its typed payload source"
+    );
 }
 
 #[test]
@@ -40,15 +103,20 @@ fn sparse_jvp_host_boundary_rejects_count_dtype_and_exact_shape() {
     let wrong_dtype = Tensor::from_vec_col_major(vec![3], vec![1_i64; 3]).unwrap();
     let wrong_shape = f64_values(4);
 
-    assert_invalid_without_panic(catch_unwind(AssertUnwindSafe(|| {
+    let error = host_error(catch_unwind(AssertUnwindSafe(|| {
         HostReference::execute(&op, &[&lhs])
     })));
-    assert_invalid_without_panic(catch_unwind(AssertUnwindSafe(|| {
+    assert_invalid_argument(&error);
+
+    let error = host_error(catch_unwind(AssertUnwindSafe(|| {
         HostReference::execute(&op, &[&lhs, &rhs, &valid_lhs_tangent, &wrong_dtype])
     })));
-    assert_invalid_without_panic(catch_unwind(AssertUnwindSafe(|| {
+    assert_dtype_mismatch(&error, CoreDType::F64, CoreDType::I64);
+
+    let error = host_error(catch_unwind(AssertUnwindSafe(|| {
         HostReference::execute(&op, &[&lhs, &rhs, &valid_lhs_tangent, &wrong_shape])
     })));
+    assert_shape_mismatch(&error, &[3], &[4]);
 }
 
 #[test]
@@ -65,13 +133,50 @@ fn sparse_vjp_host_boundary_rejects_count_dtype_and_exact_shape() {
         Tensor::from_vec_col_major(vec![output_nnz], vec![1_i64; output_nnz]).unwrap();
     let wrong_shape = f64_values(output_nnz + 1);
 
-    assert_invalid_without_panic(catch_unwind(AssertUnwindSafe(|| {
+    let error = host_error(catch_unwind(AssertUnwindSafe(|| {
         HostReference::execute(&op, &[&lhs, &rhs])
     })));
-    assert_invalid_without_panic(catch_unwind(AssertUnwindSafe(|| {
+    assert_invalid_argument(&error);
+
+    let error = host_error(catch_unwind(AssertUnwindSafe(|| {
         HostReference::execute(&op, &[&lhs, &rhs, &wrong_dtype])
     })));
-    assert_invalid_without_panic(catch_unwind(AssertUnwindSafe(|| {
+    assert_dtype_mismatch(&error, CoreDType::F64, CoreDType::I64);
+
+    let error = host_error(catch_unwind(AssertUnwindSafe(|| {
         HostReference::execute(&op, &[&lhs, &rhs, &wrong_shape])
     })));
+    assert_shape_mismatch(&error, &[output_nnz], &[output_nnz + 1]);
+}
+
+#[test]
+fn sparse_metadata_validation_preserves_dtype_and_rank_payloads() {
+    let shape = [SymDim::from(3_usize)];
+    let dtype_error = super::validate_primal_meta(
+        &[DType::I64, DType::F64],
+        &[&shape[..], &shape[..]],
+    )
+    .unwrap_err();
+    assert_dtype_mismatch(&dtype_error, CoreDType::F64, CoreDType::I64);
+
+    let rank_shape = [SymDim::from(3_usize), SymDim::from(1_usize)];
+    let rank_error = super::validate_primal_meta(
+        &[DType::F64, DType::F64],
+        &[&rank_shape[..], &shape[..]],
+    )
+    .unwrap_err();
+    assert_eq!(
+        rank_error.kind(),
+        ErrorKind::Validation(ValidationKind::RankMismatch)
+    );
+    assert!(matches!(
+        rank_error,
+        Error::Validation {
+            op: "tenferro-ext-sparse",
+            source: ValidationError::RankMismatch {
+                expected: 1,
+                actual: 2,
+            },
+        }
+    ));
 }

--- a/ext/sparse/src/sparse.rs
+++ b/ext/sparse/src/sparse.rs
@@ -237,8 +237,10 @@ impl SparseCooTracedTensor {
 ///
 /// # Errors
 ///
-/// Returns an error when the sparse shapes are not matrix-multiplication
-/// compatible or when value tensors have unsupported metadata.
+/// Returns [`tenferro_tensor::Error::Validation`] for non-matrix ranks,
+/// contracting-dimension mismatches, invalid COO coordinates, or value shape
+/// mismatches, and [`tenferro_tensor::Error::Unsupported`] for unsupported
+/// value dtypes.
 ///
 /// # Examples
 ///
@@ -275,32 +277,38 @@ pub(crate) fn validate_coordinates(
     coordinates: &Tensor,
 ) -> Result<Vec<[usize; 2]>> {
     if shape.len() != 2 {
-        return Err(invalid(format!(
-            "expected rank-2 sparse shape, got {shape:?}"
-        )));
+        return Err(Error::rank_mismatch(OP, 2, shape.len()));
     }
     if coordinates.dtype() != DType::I64 {
-        return Err(invalid(format!(
-            "coordinate tensor must have dtype I64, got {:?}",
-            coordinates.dtype()
-        )));
+        return Err(Error::dtype_mismatch(OP, DType::I64, coordinates.dtype()));
     }
     let coord_shape = coordinates.shape();
-    if coord_shape.len() != 2 || coord_shape[0] != 2 {
-        return Err(invalid(format!(
-            "coordinate tensor must have shape [2, nnz], got {coord_shape:?}"
-        )));
+    if coord_shape.len() != 2 {
+        return Err(Error::rank_mismatch(OP, 2, coord_shape.len()));
+    }
+    if coord_shape[0] != 2 {
+        return Err(Error::shape_mismatch(
+            OP,
+            vec![2, coord_shape[1]],
+            coord_shape.to_vec(),
+        ));
     }
     let mut entries = Vec::with_capacity(coord_shape[1]);
     for pair in coordinates.as_slice::<i64>()?.chunks_exact(2) {
         let row =
-            usize::try_from(pair[0]).map_err(|_| invalid("negative sparse row coordinate"))?;
+            usize::try_from(pair[0]).map_err(|_| {
+                Error::invalid_argument(OP, "coordinates", "negative sparse row coordinate")
+            })?;
         let col =
-            usize::try_from(pair[1]).map_err(|_| invalid("negative sparse column coordinate"))?;
+            usize::try_from(pair[1]).map_err(|_| {
+                Error::invalid_argument(OP, "coordinates", "negative sparse column coordinate")
+            })?;
         if row >= shape[0] || col >= shape[1] {
-            return Err(invalid(format!(
-                "coordinate [{row}, {col}] is out of bounds for shape {shape:?}"
-            )));
+            return Err(Error::invalid_argument(
+                OP,
+                "coordinates",
+                format!("coordinate [{row}, {col}] is out of bounds for shape {shape:?}"),
+            ));
         }
         entries.push([row, col]);
     }
@@ -309,38 +317,34 @@ pub(crate) fn validate_coordinates(
 
 pub(crate) fn validate_value_tensor(values: &Tensor, nnz: usize) -> Result<()> {
     if values.dtype() != DType::F64 {
-        return Err(invalid(format!(
-            "sparse tutorial supports F64 values, got {:?}",
-            values.dtype()
-        )));
+        return Err(Error::dtype_mismatch(OP, DType::F64, values.dtype()));
     }
     if values.shape() != [nnz] {
-        return Err(invalid(format!(
-            "value tensor must have shape [{nnz}], got {:?}",
-            values.shape()
-        )));
+        return Err(Error::shape_mismatch(OP, vec![nnz], values.shape().to_vec()));
     }
     Ok(())
 }
 
 pub(crate) fn validate_traced_values(values: &TracedTensor, nnz: usize) -> RuntimeResult<()> {
     if values.dtype != DType::F64 {
-        return Err(RuntimeError::TensorRuntime(invalid(format!(
-            "sparse tutorial supports F64 values, got {:?}",
-            values.dtype
-        ))));
+        return Err(RuntimeError::TensorRuntime(Error::dtype_mismatch(
+            OP,
+            DType::F64,
+            values.dtype,
+        )));
     }
     if values.rank != 1 {
-        return Err(RuntimeError::TensorRuntime(invalid(format!(
-            "value tensor must have rank 1, got rank {}",
-            values.rank
-        ))));
+        return Err(RuntimeError::TensorRuntime(Error::rank_mismatch(
+            OP, 1, values.rank,
+        )));
     }
     if let Some(shape) = values.try_concrete_shape() {
         if shape != [nnz] {
-            return Err(RuntimeError::TensorRuntime(invalid(format!(
-                "value tensor must have shape [{nnz}], got {shape:?}"
-            ))));
+            return Err(RuntimeError::TensorRuntime(Error::shape_mismatch(
+                OP,
+                vec![nnz],
+                shape.to_vec(),
+            )));
         }
     }
     Ok(())
@@ -349,15 +353,12 @@ pub(crate) fn validate_traced_values(values: &TracedTensor, nnz: usize) -> Runti
 pub(crate) fn coordinates_tensor(entries: &[[usize; 2]]) -> Result<Tensor> {
     let mut data = Vec::with_capacity(entries.len() * 2);
     for &[row, col] in entries {
-        data.push(i64::try_from(row).map_err(|_| invalid("row coordinate exceeds i64"))?);
-        data.push(i64::try_from(col).map_err(|_| invalid("column coordinate exceeds i64"))?);
+        data.push(i64::try_from(row).map_err(|_| {
+            Error::invalid_argument(OP, "coordinates", "row coordinate exceeds i64")
+        })?);
+        data.push(i64::try_from(col).map_err(|_| {
+            Error::invalid_argument(OP, "coordinates", "column coordinate exceeds i64")
+        })?);
     }
     Tensor::from_vec_col_major(vec![2, entries.len()], data)
-}
-
-fn invalid(message: impl Into<String>) -> Error {
-    Error::InvalidConfig {
-        op: OP,
-        message: message.into(),
-    }
 }

--- a/ext/sparse/tests/sparse_constructor.rs
+++ b/ext/sparse/tests/sparse_constructor.rs
@@ -1,6 +1,6 @@
 use tenferro_ext_sparse::SparseCooTracedTensor;
 use tenferro_runtime::{Error as RuntimeError, TracedTensor};
-use tenferro_tensor::{DType, Error as TensorError, Tensor};
+use tenferro_tensor::{DType, Error as TensorError, ShapeMismatch, Tensor, ValidationError};
 
 fn one_coordinate() -> Tensor {
     Tensor::from_vec_col_major(vec![2, 1], vec![0_i64, 0]).unwrap()
@@ -26,9 +26,13 @@ fn traced_constructor_rejects_known_concrete_nnz_mismatch() {
 
     assert!(matches!(
         error,
-        RuntimeError::TensorRuntime(TensorError::InvalidConfig {
+        RuntimeError::TensorRuntime(TensorError::Validation {
             op: "tenferro-ext-sparse",
-            message,
-        }) if message == "value tensor must have shape [1], got [2]"
+            source: ValidationError::ShapeMismatch(payload),
+        }) if matches!(
+            payload.as_ref(),
+            ShapeMismatch::IncompatibleShapes { lhs, rhs }
+                if lhs.as_slice() == [1] && rhs.as_slice() == [2]
+        )
     ));
 }

--- a/ext/tropical/Cargo.toml
+++ b/ext/tropical/Cargo.toml
@@ -33,6 +33,7 @@ tenferro-tensor = { path = "../../crates/tenferro-tensor" }
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7", optional = true }
 tidu = { git = "https://github.com/tensor4all/tidu-rs.git", rev = "57a2e7ebe7738ca2f8b5c96f4c6ce4e467b20495", optional = true }
 num-traits = "0.2"
+thiserror = "2"
 tropical-gemm = { version = "0.2", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/ext/tropical/src/cpu.rs
+++ b/ext/tropical/src/cpu.rs
@@ -102,7 +102,7 @@ pub struct TropicalGemmArgmax<T> {
 ///
 /// # Errors
 ///
-/// Returns [`tenferro_tensor::Error::InvalidConfig`] when input lengths do not
+/// Returns [`tenferro_tensor::Error::Validation`] when input lengths do not
 /// exactly match the provided dimensions, when `k == 0` with a non-empty
 /// output, or when `k` is too large to represent a winning contracted index as
 /// `u32`.
@@ -155,10 +155,11 @@ where
 ///
 /// # Errors
 ///
-/// Returns [`tenferro_tensor::Error::InvalidConfig`] when input lengths do not
-/// exactly match the provided dimensions, when `k == 0` with a non-empty
-/// output, or when `k` is too large to represent a winning contracted index as
-/// `u32`.
+/// Returns a structured shape or argument validation error when input lengths
+/// do not exactly match the provided dimensions, when `k == 0` with a
+/// [`tenferro_tensor::Error::Validation`] when input lengths do not exactly
+/// match the provided dimensions, when `k == 0` with a non-empty output, or
+/// when `k` is too large to represent a winning contracted index as `u32`.
 ///
 /// # Examples
 ///
@@ -364,18 +365,24 @@ fn validate_inputs<T>(
 ) -> tenferro_tensor::Result<()> {
     let expected_a = checked_len(m, k, "a")?;
     if a.len() != expected_a {
-        return Err(invalid_config(format!(
-            "a length mismatch: expected {expected_a} elements for shape [{m}, {k}], got {}",
-            a.len()
-        )));
+        return Err(tenferro_tensor::Error::validation(
+            OP,
+            tenferro_tensor::ValidationError::ShapeDataLengthMismatch {
+                expected: expected_a,
+                actual: a.len(),
+            },
+        ));
     }
 
     let expected_b = checked_len(k, n, "b")?;
     if b.len() != expected_b {
-        return Err(invalid_config(format!(
-            "b length mismatch: expected {expected_b} elements for shape [{k}, {n}], got {}",
-            b.len()
-        )));
+        return Err(tenferro_tensor::Error::validation(
+            OP,
+            tenferro_tensor::ValidationError::ShapeDataLengthMismatch {
+                expected: expected_b,
+                actual: b.len(),
+            },
+        ));
     }
 
     let out_len = checked_len(m, n, "output")?;
@@ -383,14 +390,14 @@ fn validate_inputs<T>(
         if out_len == 0 {
             return Ok(());
         }
-        return Err(invalid_config(
+        return Err(invalid_argument(
             "contracting dimension k must be nonzero for non-empty outputs",
         ));
     }
 
     let max_argmax_len = (u32::MAX as usize).saturating_add(1);
     if k > max_argmax_len {
-        return Err(invalid_config(format!(
+        return Err(invalid_argument(format!(
             "contracting dimension k={k} cannot be represented as u32 argmax indices"
         )));
     }
@@ -398,17 +405,15 @@ fn validate_inputs<T>(
     Ok(())
 }
 
-fn checked_len(lhs: usize, rhs: usize, label: &str) -> tenferro_tensor::Result<usize> {
+fn checked_len(lhs: usize, rhs: usize, _label: &str) -> tenferro_tensor::Result<usize> {
     lhs.checked_mul(rhs).ok_or_else(|| {
-        invalid_config(format!(
-            "{label} element count overflows usize for dimensions {lhs} and {rhs}"
-        ))
+        tenferro_tensor::Error::validation(
+            OP,
+            tenferro_tensor::ValidationError::IntegerOverflow,
+        )
     })
 }
 
-fn invalid_config(message: impl Into<String>) -> tenferro_tensor::Error {
-    tenferro_tensor::Error::InvalidConfig {
-        op: OP,
-        message: message.into(),
-    }
+fn invalid_argument(message: impl Into<String>) -> tenferro_tensor::Error {
+    tenferro_tensor::Error::invalid_argument(OP, "configuration", message)
 }

--- a/ext/tropical/src/einsum.rs
+++ b/ext/tropical/src/einsum.rs
@@ -29,6 +29,7 @@ use tenferro_einsum::{ContractionTree, Subscripts};
 use tenferro_tensor::{DType, Tensor, TensorScalar};
 
 use crate::cpu::{tropical_gemm_with_argmax, TropicalGemmKind};
+use crate::error::{from_einsum_error, unsupported_dtype};
 use crate::TropicalKind;
 
 const OP: &str = "tropical_einsum_with_argmax";
@@ -232,12 +233,12 @@ pub struct TropicalEinsumResult {
 /// This supports binary contractions over compact host `f32` and `f64`
 /// tensors, including batched GEMM-style contractions and a generic fallback
 /// for unique-label binary contractions. Unsupported cases return
-/// [`tenferro_tensor::Error::InvalidConfig`] instead of panicking.
+/// structured validation errors instead of panicking.
 ///
 /// # Errors
 ///
-/// Returns [`tenferro_tensor::Error::InvalidConfig`] when notation, shapes,
-/// dtype, or lowering features are outside the supported surface.
+/// Returns shared validation errors for invalid notation, shapes, and dtypes;
+/// unsupported lowering features use a structured argument error.
 ///
 /// # Examples
 ///
@@ -257,8 +258,7 @@ pub fn tropical_einsum_with_argmax(
     inputs: &[&Tensor],
     notation: &str,
 ) -> tenferro_tensor::Result<TropicalEinsumResult> {
-    let subscripts = Subscripts::parse(notation)
-        .map_err(|err| invalid_config(format!("invalid einsum notation `{notation}`: {err}")))?;
+    let subscripts = Subscripts::parse(notation).map_err(|err| from_einsum_error(OP, err))?;
     tropical_einsum_subscripts_with_argmax(kind, inputs, &subscripts)
 }
 
@@ -270,8 +270,9 @@ pub fn tropical_einsum_with_argmax(
 ///
 /// # Errors
 ///
-/// Returns [`tenferro_tensor::Error::InvalidConfig`] when shapes, dtype, or
-/// lowering features are outside the supported binary tropical surface.
+/// Returns [`tenferro_tensor::Error::Validation`] for invalid shapes or
+/// lowering features, or [`tenferro_tensor::Error::Extension`] containing the
+/// typed `UnsupportedDType` source when the input dtype is not `F32` or `F64`.
 ///
 /// # Examples
 ///
@@ -315,7 +316,7 @@ pub fn tropical_einsum_subscripts_with_argmax(
 
     let shapes: Vec<&[usize]> = inputs.iter().map(|tensor| tensor.shape()).collect();
     let tree = ContractionTree::optimize(subscripts, &shapes)
-        .map_err(|err| invalid_config(format!("einsum lowering failed: {err}")))?;
+        .map_err(|err| from_einsum_error(OP, err))?;
     if tree.step_count() != 1 {
         return Err(invalid_config(format!(
             "only one pairwise contraction step is supported, got {}",
@@ -371,12 +372,8 @@ pub fn tropical_einsum_subscripts_with_argmax(
             output_subs,
             &gemm,
         ),
-        (lhs, rhs) if lhs != rhs => Err(invalid_config(format!(
-            "input dtype mismatch: left is {lhs:?}, right is {rhs:?}"
-        ))),
-        (dtype, _) => Err(invalid_config(format!(
-            "unsupported dtype {dtype:?}; only F32 and F64 are supported"
-        ))),
+        (lhs, rhs) if lhs != rhs => Err(tenferro_tensor::Error::dtype_mismatch(OP, lhs, rhs)),
+        (dtype, _) => Err(unsupported_dtype(OP, dtype)),
     }
 }
 
@@ -635,9 +632,7 @@ trait TropicalFloat: Float + TensorScalar {
 impl TropicalFloat for f32 {
     fn host_slice(tensor: &Tensor) -> tenferro_tensor::Result<&[Self]> {
         match tensor {
-            Tensor::F32(tensor) => tensor.as_view().as_slice().map_err(|err| {
-                invalid_config(format!("input must be a compact host F32 tensor: {err}"))
-            }),
+            Tensor::F32(tensor) => tensor.as_view().as_slice(),
             _ => Err(invalid_config(format!(
                 "expected F32 input, got {:?}",
                 tensor.dtype()
@@ -649,9 +644,7 @@ impl TropicalFloat for f32 {
 impl TropicalFloat for f64 {
     fn host_slice(tensor: &Tensor) -> tenferro_tensor::Result<&[Self]> {
         match tensor {
-            Tensor::F64(tensor) => tensor.as_view().as_slice().map_err(|err| {
-                invalid_config(format!("input must be a compact host F64 tensor: {err}"))
-            }),
+            Tensor::F64(tensor) => tensor.as_view().as_slice(),
             _ => Err(invalid_config(format!(
                 "expected F64 input, got {:?}",
                 tensor.dtype()
@@ -928,8 +921,5 @@ fn decode_col_major_index(mut flat: usize, shape: &[usize]) -> Option<Vec<usize>
 }
 
 fn invalid_config(message: impl Into<String>) -> tenferro_tensor::Error {
-    tenferro_tensor::Error::InvalidConfig {
-        op: OP,
-        message: message.into(),
-    }
+    tenferro_tensor::Error::invalid_argument(OP, "configuration", message)
 }

--- a/ext/tropical/src/error.rs
+++ b/ext/tropical/src/error.rs
@@ -1,0 +1,24 @@
+use tenferro_einsum::Error as EinsumError;
+use tenferro_tensor::{DType, Error, ErrorKind};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum TropicalError {
+    #[error("{op} does not support dtype {dtype:?}")]
+    UnsupportedDType { op: &'static str, dtype: DType },
+}
+
+pub(crate) fn unsupported_dtype(op: &'static str, dtype: DType) -> Error {
+    Error::extension(
+        op,
+        "tropical",
+        ErrorKind::Unsupported,
+        TropicalError::UnsupportedDType { op, dtype },
+    )
+}
+
+pub(crate) fn from_einsum_error(op: &'static str, error: EinsumError) -> Error {
+    match error {
+        EinsumError::Validation { source, .. } => Error::validation(op, source),
+        error => Error::extension(op, "tropical", error.kind(), error),
+    }
+}

--- a/ext/tropical/src/extension.rs
+++ b/ext/tropical/src/extension.rs
@@ -632,7 +632,7 @@ fn validate_tropical_primal_host_meta(
     }
 
     let mut label_dims = HashMap::new();
-    for (input_idx, (labels, input)) in subscripts.inputs.iter().zip(inputs).enumerate() {
+    for (labels, input) in subscripts.inputs.iter().zip(inputs) {
         if labels.len() != input.shape().len() {
             return Err(tenferro_tensor::Error::rank_mismatch(
                 op,
@@ -919,7 +919,7 @@ fn routed_input_offset(
 }
 
 #[cfg(feature = "autodiff")]
-fn typed_slice<'a, T>(tensor: &'a Tensor) -> tenferro_tensor::Result<&'a [T]>
+fn typed_slice<T>(tensor: &Tensor) -> tenferro_tensor::Result<&[T]>
 where
     T: TensorScalar,
 {

--- a/ext/tropical/src/extension.rs
+++ b/ext/tropical/src/extension.rs
@@ -26,6 +26,7 @@ use tenferro_tensor::{DType, Tensor, TensorBackend};
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult, PrimitiveTransposeInput};
 
 use crate::einsum::tropical_einsum_subscripts_with_argmax;
+use crate::error::unsupported_dtype;
 #[cfg(feature = "autodiff")]
 use crate::einsum::TropicalArgmaxStep;
 use crate::TropicalKind;
@@ -37,10 +38,7 @@ const TROPICAL_EINSUM_JVP_FAMILY_ID: &str = "tenferro-ext-tropical.einsum_jvp.v1
 const TROPICAL_EINSUM_VJP_FAMILY_ID: &str = "tenferro-ext-tropical.einsum_vjp.v1";
 
 fn invalid_config(op: &'static str, message: impl Into<String>) -> tenferro_tensor::Error {
-    tenferro_tensor::Error::InvalidConfig {
-        op,
-        message: message.into(),
-    }
+    tenferro_tensor::Error::invalid_argument(op, "configuration", message)
 }
 
 /// Register tropical extension runtimes on a graph or eager executor.
@@ -272,10 +270,7 @@ impl HostReference for TropicalEinsumJvpOp {
                 execute_jvp_typed::<f64>(inputs, &self.subscripts, step, &self.active_inputs)
                     .map(|tensor| vec![tensor])
             }
-            dtype => Err(invalid_config(
-                "tropical_einsum_jvp",
-                format!("unsupported output dtype {dtype:?}"),
-            )),
+            dtype => Err(unsupported_dtype("tropical_einsum_jvp", dtype)),
         }
     }
 }
@@ -362,19 +357,17 @@ impl ExtensionOp for TropicalEinsumVjpOp {
             "tropical_einsum_vjp",
         )?;
         if input_dtypes[2] != input_dtypes[self.active_input] {
-            return Err(invalid_config(
+            return Err(tenferro_tensor::Error::dtype_mismatch(
                 "tropical_einsum_vjp",
-                "cotangent dtype does not match active primal dtype",
+                input_dtypes[self.active_input],
+                input_dtypes[2],
             ));
         }
         if input_shapes[2].len() != primal_output_shape.len() {
-            return Err(invalid_config(
+            return Err(tenferro_tensor::Error::rank_mismatch(
                 "tropical_einsum_vjp",
-                format!(
-                    "cotangent rank {} does not match primal output rank {}",
-                    input_shapes[2].len(),
-                    primal_output_shape.len()
-                ),
+                primal_output_shape.len(),
+                input_shapes[2].len(),
             ));
         }
         for (cotangent_dim, output_dim) in input_shapes[2].iter().cloned().zip(primal_output_shape)
@@ -411,10 +404,7 @@ impl HostReference for TropicalEinsumVjpOp {
                 execute_vjp_typed::<f64>(inputs, &self.subscripts, step, self.active_input)
                     .map(|tensor| vec![tensor])
             }
-            dtype => Err(invalid_config(
-                "tropical_einsum_vjp",
-                format!("unsupported active input dtype {dtype:?}"),
-            )),
+            dtype => Err(unsupported_dtype("tropical_einsum_vjp", dtype)),
         }
     }
 }
@@ -573,23 +563,27 @@ fn infer_tropical_output_meta(
             ),
         ));
     }
-    if subscripts.inputs.len() != 2 || input_dtypes[0] != input_dtypes[1] {
-        return Err(invalid_config(
+    if subscripts.inputs.len() != 2 {
+        return Err(invalid_config(op, "tropical einsum requires two inputs"));
+    }
+    if input_dtypes[0] != input_dtypes[1] {
+        return Err(tenferro_tensor::Error::dtype_mismatch(
             op,
-            "tropical einsum requires two inputs with matching dtypes",
+            input_dtypes[0],
+            input_dtypes[1],
         ));
+    }
+    if !matches!(input_dtypes[0], DType::F32 | DType::F64) {
+        return Err(unsupported_dtype(op, input_dtypes[0]));
     }
 
     let mut label_dims: HashMap<u32, SymDim> = HashMap::new();
     for (labels, shape) in subscripts.inputs.iter().zip(input_shapes.iter()) {
         if labels.len() != shape.len() {
-            return Err(invalid_config(
+            return Err(tenferro_tensor::Error::rank_mismatch(
                 op,
-                format!(
-                    "subscript rank {} does not match input rank {}",
-                    labels.len(),
-                    shape.len()
-                ),
+                labels.len(),
+                shape.len(),
             ));
         }
         for (&label, dim) in labels.iter().zip(shape.iter()) {
@@ -626,35 +620,33 @@ fn validate_tropical_primal_host_meta(
         ));
     }
     let dtype = inputs[0].dtype();
-    if inputs[1].dtype() != dtype || !matches!(dtype, DType::F32 | DType::F64) {
-        return Err(invalid_config(
+    if inputs[1].dtype() != dtype {
+        return Err(tenferro_tensor::Error::dtype_mismatch(
             op,
-            format!(
-                "primal inputs must have matching F32 or F64 dtype, got {:?} and {:?}",
-                inputs[0].dtype(),
-                inputs[1].dtype()
-            ),
+            dtype,
+            inputs[1].dtype(),
         ));
+    }
+    if !matches!(dtype, DType::F32 | DType::F64) {
+        return Err(unsupported_dtype(op, dtype));
     }
 
     let mut label_dims = HashMap::new();
     for (input_idx, (labels, input)) in subscripts.inputs.iter().zip(inputs).enumerate() {
         if labels.len() != input.shape().len() {
-            return Err(invalid_config(
+            return Err(tenferro_tensor::Error::rank_mismatch(
                 op,
-                format!(
-                    "input {input_idx} subscript rank {} does not match tensor rank {}",
-                    labels.len(),
-                    input.shape().len()
-                ),
+                labels.len(),
+                input.shape().len(),
             ));
         }
         for (&label, &dim) in labels.iter().zip(input.shape()) {
             if let Some(existing) = label_dims.insert(label, dim) {
                 if existing != dim {
-                    return Err(invalid_config(
+                    return Err(tenferro_tensor::Error::shape_mismatch(
                         op,
-                        format!("label {label} has conflicting extents {existing} and {dim}"),
+                        vec![existing],
+                        vec![dim],
                     ));
                 }
             }
@@ -694,16 +686,18 @@ fn validate_tropical_jvp_inputs(
             ));
         }
         let tangent = inputs[2 + active_pos];
-        if tangent.dtype() != inputs[active].dtype() || tangent.shape() != inputs[active].shape() {
-            return Err(invalid_config(
+        if tangent.dtype() != inputs[active].dtype() {
+            return Err(tenferro_tensor::Error::dtype_mismatch(
                 "tropical_einsum_jvp",
-                format!(
-                    "tangent {active_pos} metadata {:?} {:?} does not match active input {active} {:?} {:?}",
-                    tangent.dtype(),
-                    tangent.shape(),
-                    inputs[active].dtype(),
-                    inputs[active].shape()
-                ),
+                inputs[active].dtype(),
+                tangent.dtype(),
+            ));
+        }
+        if tangent.shape() != inputs[active].shape() {
+            return Err(tenferro_tensor::Error::shape_mismatch(
+                "tropical_einsum_jvp",
+                inputs[active].shape().to_vec(),
+                tangent.shape().to_vec(),
             ));
         }
     }
@@ -731,16 +725,18 @@ fn validate_tropical_vjp_inputs(
     let output_shape =
         validate_tropical_primal_host_meta(&inputs[..2], subscripts, "tropical_einsum_vjp")?;
     let cotangent = inputs[2];
-    if cotangent.dtype() != inputs[active_input].dtype() || cotangent.shape() != output_shape {
-        return Err(invalid_config(
+    if cotangent.dtype() != inputs[active_input].dtype() {
+        return Err(tenferro_tensor::Error::dtype_mismatch(
             "tropical_einsum_vjp",
-            format!(
-                "cotangent metadata {:?} {:?} does not match output {:?} {:?}",
-                cotangent.dtype(),
-                cotangent.shape(),
-                inputs[active_input].dtype(),
-                output_shape
-            ),
+            inputs[active_input].dtype(),
+            cotangent.dtype(),
+        ));
+    }
+    if cotangent.shape() != output_shape {
+        return Err(tenferro_tensor::Error::shape_mismatch(
+            "tropical_einsum_vjp",
+            output_shape,
+            cotangent.shape().to_vec(),
         ));
     }
     Ok(())
@@ -813,7 +809,7 @@ where
     let output_len = element_count(&output_shape)?;
     let mut out = vec![T::default(); output_len];
     for (active_pos, &active_input) in active_inputs.iter().enumerate() {
-        let tangent = typed_slice::<T>(inputs[2 + active_pos], "tropical_einsum_jvp tangent")?;
+        let tangent = typed_slice::<T>(inputs[2 + active_pos])?;
         let labels = &subscripts.inputs[active_input];
         for (output_index, out_value) in out.iter_mut().enumerate() {
             let offset = routed_input_offset(
@@ -842,7 +838,7 @@ fn execute_vjp_typed<T>(
 where
     T: TensorScalar + Copy + Default + std::ops::AddAssign,
 {
-    let cotangent = typed_slice::<T>(inputs[2], "tropical_einsum_vjp cotangent")?;
+    let cotangent = typed_slice::<T>(inputs[2])?;
     let output_len = element_count(step.output_shape())?;
     if cotangent.len() != output_len {
         return Err(invalid_config(
@@ -923,16 +919,11 @@ fn routed_input_offset(
 }
 
 #[cfg(feature = "autodiff")]
-fn typed_slice<'a, T>(tensor: &'a Tensor, op: &'static str) -> tenferro_tensor::Result<&'a [T]>
+fn typed_slice<'a, T>(tensor: &'a Tensor) -> tenferro_tensor::Result<&'a [T]>
 where
     T: TensorScalar,
 {
-    tensor.as_slice::<T>().map_err(|_| {
-        invalid_config(
-            op,
-            format!("expected compact host {:?} tensor", tensor.dtype()),
-        )
-    })
+    tensor.as_slice::<T>()
 }
 
 #[cfg(feature = "autodiff")]

--- a/ext/tropical/src/extension/tests.rs
+++ b/ext/tropical/src/extension/tests.rs
@@ -16,7 +16,16 @@ fn assert_invalid_without_panic(result: std::thread::Result<tenferro_tensor::Res
     let error = result
         .expect("host-reference validation must not panic")
         .expect_err("malformed host-reference inputs must be rejected");
-    assert!(matches!(error, Error::InvalidConfig { .. }));
+    assert!(matches!(
+        error,
+        Error::Validation {
+            source: tenferro_tensor::ValidationError::InvalidArgument {
+                argument: "configuration",
+                ..
+            },
+            ..
+        }
+    ));
 }
 
 #[test]

--- a/ext/tropical/src/extension/tests.rs
+++ b/ext/tropical/src/extension/tests.rs
@@ -2,7 +2,10 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use tenferro_einsum::Subscripts;
 use tenferro_ops::ext_op::HostReference;
-use tenferro_tensor::{Error, Tensor};
+use tenferro_tensor::{
+    core::DType as CoreDType, Error, ErrorKind, ShapeMismatch, Tensor, ValidationError,
+    ValidationKind,
+};
 
 use super::{TropicalEinsumJvpOp, TropicalEinsumVjpOp};
 use crate::TropicalKind;
@@ -12,20 +15,72 @@ fn matrix(shape: Vec<usize>) -> Tensor {
     Tensor::from_vec_col_major(shape, vec![1.0_f64; len]).unwrap()
 }
 
-fn assert_invalid_without_panic(result: std::thread::Result<tenferro_tensor::Result<Vec<Tensor>>>) {
-    let error = result
+fn host_error(
+    result: std::thread::Result<tenferro_tensor::Result<Vec<Tensor>>>,
+) -> Error {
+    result
         .expect("host-reference validation must not panic")
-        .expect_err("malformed host-reference inputs must be rejected");
+        .expect_err("malformed host-reference inputs must be rejected")
+}
+
+fn assert_invalid_argument(error: &Error, op: &str) {
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::InvalidArgument)
+    );
     assert!(matches!(
         error,
         Error::Validation {
-            source: tenferro_tensor::ValidationError::InvalidArgument {
+            op: actual_op,
+            source: ValidationError::InvalidArgument {
                 argument: "configuration",
                 ..
             },
-            ..
-        }
+        } if *actual_op == op
     ));
+    assert!(std::error::Error::source(error).is_some());
+}
+
+fn assert_dtype_mismatch(error: &Error, op: &str, expected: CoreDType, actual: CoreDType) {
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::DTypeMismatch)
+    );
+    assert!(matches!(
+        error,
+        Error::Validation {
+            op: actual_op,
+            source: ValidationError::DTypeMismatch {
+                expected: actual_expected,
+                actual: actual_actual,
+            },
+        } if *actual_op == op && *actual_expected == expected && *actual_actual == actual
+    ));
+    assert!(std::error::Error::source(error).is_some());
+}
+
+fn assert_shape_mismatch(error: &Error, op: &str, expected: &[usize], actual: &[usize]) {
+    assert_eq!(
+        error.kind(),
+        ErrorKind::Validation(ValidationKind::ShapeMismatch)
+    );
+    assert!(matches!(
+        error,
+        Error::Validation {
+            op: actual_op,
+            source: ValidationError::ShapeMismatch(payload),
+        } if *actual_op == op && matches!(
+            payload.as_ref(),
+            ShapeMismatch::IncompatibleShapes { lhs, rhs }
+                if lhs.as_slice() == expected && rhs.as_slice() == actual
+        )
+    ));
+    let validation_source =
+        std::error::Error::source(error).expect("shape mismatch must retain its validation source");
+    assert!(
+        std::error::Error::source(validation_source).is_some(),
+        "shape mismatch must retain its typed payload source"
+    );
 }
 
 #[test]
@@ -41,15 +96,25 @@ fn tropical_jvp_host_boundary_rejects_count_dtype_and_exact_shape() {
     let wrong_dtype = Tensor::from_vec_col_major(vec![3, 2], vec![1_i64; 6]).unwrap();
     let wrong_shape = matrix(vec![2, 3]);
 
-    assert_invalid_without_panic(catch_unwind(AssertUnwindSafe(|| {
+    let error = host_error(catch_unwind(AssertUnwindSafe(|| {
         HostReference::execute(&op, &[&lhs])
     })));
-    assert_invalid_without_panic(catch_unwind(AssertUnwindSafe(|| {
+    assert_invalid_argument(&error, "tropical_einsum_jvp");
+
+    let error = host_error(catch_unwind(AssertUnwindSafe(|| {
         HostReference::execute(&op, &[&lhs, &rhs, &valid_lhs_tangent, &wrong_dtype])
     })));
-    assert_invalid_without_panic(catch_unwind(AssertUnwindSafe(|| {
+    assert_dtype_mismatch(
+        &error,
+        "tropical_einsum_jvp",
+        CoreDType::F64,
+        CoreDType::I64,
+    );
+
+    let error = host_error(catch_unwind(AssertUnwindSafe(|| {
         HostReference::execute(&op, &[&lhs, &rhs, &valid_lhs_tangent, &wrong_shape])
     })));
+    assert_shape_mismatch(&error, "tropical_einsum_jvp", &[3, 2], &[2, 3]);
 }
 
 #[test]
@@ -64,13 +129,23 @@ fn tropical_vjp_host_boundary_rejects_count_dtype_and_exact_shape() {
     let wrong_dtype = Tensor::from_vec_col_major(vec![2, 2], vec![1_i64; 4]).unwrap();
     let wrong_shape = matrix(vec![4]);
 
-    assert_invalid_without_panic(catch_unwind(AssertUnwindSafe(|| {
+    let error = host_error(catch_unwind(AssertUnwindSafe(|| {
         HostReference::execute(&op, &[&lhs, &rhs])
     })));
-    assert_invalid_without_panic(catch_unwind(AssertUnwindSafe(|| {
+    assert_invalid_argument(&error, "tropical_einsum_vjp");
+
+    let error = host_error(catch_unwind(AssertUnwindSafe(|| {
         HostReference::execute(&op, &[&lhs, &rhs, &wrong_dtype])
     })));
-    assert_invalid_without_panic(catch_unwind(AssertUnwindSafe(|| {
+    assert_dtype_mismatch(
+        &error,
+        "tropical_einsum_vjp",
+        CoreDType::F64,
+        CoreDType::I64,
+    );
+
+    let error = host_error(catch_unwind(AssertUnwindSafe(|| {
         HostReference::execute(&op, &[&lhs, &rhs, &wrong_shape])
     })));
+    assert_shape_mismatch(&error, "tropical_einsum_vjp", &[2, 2], &[4]);
 }

--- a/ext/tropical/src/lib.rs
+++ b/ext/tropical/src/lib.rs
@@ -41,6 +41,7 @@
 
 pub mod cpu;
 pub mod einsum;
+mod error;
 mod extension;
 pub mod newtype;
 pub mod traced;

--- a/ext/tropical/src/traced.rs
+++ b/ext/tropical/src/traced.rs
@@ -23,17 +23,22 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use tenferro_einsum::Subscripts;
-use tenferro_runtime::{extension, DType, Error, Result, TracedTensor};
+use tenferro_runtime::{extension, DType, Error, ErrorPhase, Result, TracedTensor};
+use tenferro_tensor::{ShapeMismatch, ShapeVec, ValidationError};
 
 use crate::extension::TropicalEinsumOp;
 use crate::TropicalKind;
 
-fn try_require_rank2(tensor: &TracedTensor, label: &str) -> Result<()> {
+fn try_require_rank2(tensor: &TracedTensor, op: &'static str) -> Result<()> {
     if tensor.rank != 2 {
-        return Err(Error::ContractionError(format!(
-            "{label}: tropical matrix composition requires rank-2 input, got rank {}",
-            tensor.rank
-        )));
+        return Err(Error::validation(
+            op,
+            ErrorPhase::GraphBuild,
+            ValidationError::RankMismatch {
+                expected: 2,
+                actual: tensor.rank,
+            },
+        ));
     }
     Ok(())
 }
@@ -41,14 +46,21 @@ fn try_require_rank2(tensor: &TracedTensor, label: &str) -> Result<()> {
 fn try_require_contracting_axes_compatible(
     a: &TracedTensor,
     b: &TracedTensor,
-    label: &str,
+    op: &'static str,
 ) -> Result<()> {
     if let (Some(a_shape), Some(b_shape)) = (a.try_concrete_shape(), b.try_concrete_shape()) {
         if a_shape[1] != b_shape[0] {
-            return Err(Error::ContractionError(format!(
-                "{label}: contracting axes must match, got a[1]={} and b[0]={}",
-                a_shape[1], b_shape[0]
-            )));
+            return Err(Error::validation(
+                op,
+                ErrorPhase::GraphBuild,
+                ShapeMismatch::ContractedDimensions {
+                    lhs_axis: 1,
+                    lhs_size: a_shape[1],
+                    rhs_axis: 0,
+                    rhs_size: b_shape[0],
+                }
+                .into(),
+            ));
         }
     }
     Ok(())
@@ -58,11 +70,11 @@ fn checked_tropical_dot_general_impl(
     a: &TracedTensor,
     b: &TracedTensor,
     reduce: impl FnOnce(&TracedTensor) -> Result<TracedTensor>,
-    label: &str,
+    op: &'static str,
 ) -> Result<TracedTensor> {
-    try_require_rank2(a, &format!("{label}.a"))?;
-    try_require_rank2(b, &format!("{label}.b"))?;
-    try_require_contracting_axes_compatible(a, b, label)?;
+    try_require_rank2(a, op)?;
+    try_require_rank2(b, op)?;
+    try_require_contracting_axes_compatible(a, b, op)?;
 
     let m = a.axis_sym_dim(0)?;
     let k = a.axis_sym_dim(1)?;
@@ -82,8 +94,16 @@ fn checked_tropical_dot_general_impl(
 ///
 /// # Errors
 ///
-/// Returns an error if either input is not rank 2 or if concrete contracting
-/// dimensions are known and incompatible.
+/// Returns `Error::Validation` if either input is not rank 2 or if known
+/// contracting dimensions are incompatible, `Error::Extension` with an
+/// unsupported-dtype source for non-floating inputs, and `Error::RuntimeState`
+/// if the tropical runtime extension is unavailable.
+///
+/// # Deferred errors
+///
+/// Symbolic contracting dimensions are checked during compilation or
+/// execution and can produce `ShapeConstraintViolation` or
+/// `ShapeConstraintEvaluation`.
 ///
 /// # Examples
 ///
@@ -112,8 +132,16 @@ pub fn tropical_dot_general(a: &TracedTensor, b: &TracedTensor) -> Result<Traced
 ///
 /// # Errors
 ///
-/// Returns an error if either input is not rank 2 or if concrete contracting
-/// dimensions are known and incompatible.
+/// Returns `Error::Validation` if either input is not rank 2 or if known
+/// contracting dimensions are incompatible, `Error::Extension` with an
+/// unsupported-dtype source for non-floating inputs, and `Error::RuntimeState`
+/// if the tropical runtime extension is unavailable.
+///
+/// # Deferred errors
+///
+/// Symbolic contracting dimensions are checked during compilation or
+/// execution and can produce `ShapeConstraintViolation` or
+/// `ShapeConstraintEvaluation`.
 ///
 /// # Examples
 ///
@@ -142,8 +170,15 @@ pub fn min_plus_dot_general(a: &TracedTensor, b: &TracedTensor) -> Result<Traced
 ///
 /// # Errors
 ///
-/// Returns an error when the notation is invalid or outside the supported
-/// two-input tropical contraction surface.
+/// Returns `Error::Validation` when `subscripts` describe anything other than
+/// two inputs with compatible contracting axes, `Error::Extension` with an
+/// unsupported-dtype source for non-floating inputs, or `Error::Internal` if
+/// the extension returns no output.
+///
+/// # Deferred errors
+///
+/// Symbolic dimension equalities are checked during compilation or execution
+/// and can produce `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 ///
 /// # Examples
 ///
@@ -168,9 +203,8 @@ pub fn tropical_einsum(
     inputs: &[&TracedTensor],
     notation: &str,
 ) -> Result<TracedTensor> {
-    let subscripts = Subscripts::parse(notation).map_err(|err| {
-        Error::InvalidSubscripts(format!("invalid tropical einsum notation: {err}"))
-    })?;
+    let subscripts = Subscripts::parse(notation)
+        .map_err(|err| crate::error::from_einsum_error("tropical_einsum", err))?;
     tropical_einsum_subscripts(kind, inputs, &subscripts)
 }
 
@@ -181,8 +215,15 @@ pub fn tropical_einsum(
 ///
 /// # Errors
 ///
-/// Returns an error when the parsed subscripts are outside the supported
-/// two-input tropical contraction surface.
+/// Returns `Error::Validation` when `subscripts` describe anything other than
+/// two inputs with compatible contracting axes, `Error::Extension` with an
+/// unsupported-dtype source for non-floating inputs, or `Error::Internal` if
+/// the extension returns no output.
+///
+/// # Deferred errors
+///
+/// Symbolic dimension equalities are checked during compilation or execution
+/// and can produce `ShapeConstraintViolation` or `ShapeConstraintEvaluation`.
 ///
 /// # Examples
 ///
@@ -227,8 +268,16 @@ pub fn tropical_einsum_subscripts(
 ///
 /// # Errors
 ///
-/// Returns an error if either input is not rank 2 or if concrete contracting
-/// dimensions are known and incompatible.
+/// Returns `Error::Validation` if either input is not rank 2 or if known
+/// contracting dimensions are incompatible, `Error::Extension` with an
+/// unsupported-dtype source for non-floating inputs, and `Error::RuntimeState`
+/// if the tropical runtime extension is unavailable.
+///
+/// # Deferred errors
+///
+/// Symbolic contracting dimensions are checked during compilation or
+/// execution and can produce `ShapeConstraintViolation` or
+/// `ShapeConstraintEvaluation`.
 ///
 /// # Examples
 ///
@@ -259,8 +308,16 @@ pub fn tropical_dot_general_fused(a: &TracedTensor, b: &TracedTensor) -> Result<
 ///
 /// # Errors
 ///
-/// Returns an error if either input is not rank 2 or if concrete contracting
-/// dimensions are known and incompatible.
+/// Returns `Error::Validation` if either input is not rank 2 or if known
+/// contracting dimensions are incompatible, `Error::Extension` with an
+/// unsupported-dtype source for non-floating inputs, and `Error::RuntimeState`
+/// if the tropical runtime extension is unavailable.
+///
+/// # Deferred errors
+///
+/// Symbolic contracting dimensions are checked during compilation or
+/// execution and can produce `ShapeConstraintViolation` or
+/// `ShapeConstraintEvaluation`.
 ///
 /// # Examples
 ///
@@ -288,11 +345,11 @@ fn try_fused_dot_general_impl(
     kind: TropicalKind,
     a: &TracedTensor,
     b: &TracedTensor,
-    label: &str,
+    op: &'static str,
 ) -> Result<TracedTensor> {
-    try_require_rank2(a, &format!("{label}.a"))?;
-    try_require_rank2(b, &format!("{label}.b"))?;
-    try_require_contracting_axes_compatible(a, b, label)?;
+    try_require_rank2(a, op)?;
+    try_require_rank2(b, op)?;
+    try_require_contracting_axes_compatible(a, b, op)?;
     let subscripts = Subscripts::new(
         &[&[b'i' as u32, b'j' as u32], &[b'j' as u32, b'k' as u32]],
         &[b'i' as u32, b'k' as u32],
@@ -305,59 +362,82 @@ fn validate_tropical_einsum_inputs(
     subscripts: &Subscripts,
 ) -> Result<()> {
     if inputs.len() != 2 {
-        return Err(Error::ContractionError(format!(
-            "tropical einsum supports exactly two inputs, got {}",
-            inputs.len()
-        )));
+        return Err(Error::invalid_argument(
+            "tropical_einsum_subscripts",
+            ErrorPhase::GraphBuild,
+            "inputs",
+            format!("tropical einsum supports exactly two inputs, got {}", inputs.len()),
+        ));
     }
     if subscripts.inputs.len() != 2 {
-        return Err(Error::ContractionError(format!(
-            "tropical einsum subscripts describe {} inputs, expected 2",
-            subscripts.inputs.len()
-        )));
+        return Err(Error::invalid_argument(
+            "tropical_einsum_subscripts",
+            ErrorPhase::GraphBuild,
+            "subscripts",
+            format!(
+                "tropical einsum subscripts describe {} inputs, expected 2",
+                subscripts.inputs.len()
+            ),
+        ));
     }
-    for (input_idx, tensor) in inputs.iter().enumerate() {
+    for tensor in inputs.iter() {
         if !matches!(tensor.dtype, DType::F32 | DType::F64) {
-            return Err(Error::ContractionError(format!(
-                "tropical einsum input {input_idx} dtype {:?} is not supported",
-                tensor.dtype
+            return Err(Error::TensorRuntime(crate::error::unsupported_dtype(
+                "tropical_einsum_subscripts",
+                tensor.dtype,
             )));
         }
     }
     if inputs[0].dtype != inputs[1].dtype {
-        return Err(Error::ContractionError(format!(
-            "tropical einsum input dtypes must match, got {:?} and {:?}",
-            inputs[0].dtype, inputs[1].dtype
-        )));
+        return Err(Error::dtype_mismatch(
+            "tropical_einsum_subscripts",
+            ErrorPhase::GraphBuild,
+            inputs[0].dtype,
+            inputs[1].dtype,
+        ));
     }
 
     let mut labels_seen = HashSet::new();
     let mut concrete_label_dims = HashMap::new();
-    for (input_idx, (labels, tensor)) in subscripts.inputs.iter().zip(inputs).enumerate() {
+    for (labels, tensor) in subscripts.inputs.iter().zip(inputs) {
         if labels.len() != tensor.rank {
-            return Err(Error::ContractionError(format!(
-                "tropical einsum input {input_idx} rank mismatch: labels={}, rank={}",
-                labels.len(),
-                tensor.rank
-            )));
+            return Err(Error::validation(
+                "tropical_einsum_subscripts",
+                ErrorPhase::GraphBuild,
+                ValidationError::RankMismatch {
+                    expected: labels.len(),
+                    actual: tensor.rank,
+                },
+            ));
         }
         if labels
             .iter()
             .enumerate()
             .any(|(idx, label)| labels[..idx].contains(label))
         {
-            return Err(Error::ContractionError(format!(
-                "tropical einsum input {input_idx} repeated labels are not supported"
-            )));
+            return Err(Error::validation(
+                "tropical_einsum_subscripts",
+                ErrorPhase::GraphBuild,
+                ValidationError::DuplicateAxis {
+                    axis: 0,
+                    role: "input label",
+                },
+            ));
         }
         labels_seen.extend(labels.iter().copied());
         if let Some(shape) = tensor.try_concrete_shape() {
             for (&label, &extent) in labels.iter().zip(shape.iter()) {
                 if let Some(previous) = concrete_label_dims.insert(label, extent) {
                     if previous != extent {
-                        return Err(Error::ContractionError(format!(
-                            "tropical einsum label {label} has inconsistent concrete sizes {previous} and {extent}"
-                        )));
+                        return Err(Error::validation(
+                            "tropical_einsum_subscripts",
+                            ErrorPhase::GraphBuild,
+                            ShapeMismatch::ExpectedActual {
+                                expected: ShapeVec::from_vec(vec![previous]),
+                                actual: ShapeVec::from_vec(vec![extent]),
+                            }
+                            .into(),
+                        ));
                     }
                 }
             }
@@ -369,23 +449,34 @@ fn validate_tropical_einsum_inputs(
         .enumerate()
         .any(|(idx, label)| subscripts.output[..idx].contains(label))
     {
-        return Err(Error::ContractionError(
-            "tropical einsum repeated output labels are not supported".to_string(),
+        return Err(Error::validation(
+            "tropical_einsum_subscripts",
+            ErrorPhase::GraphBuild,
+            ValidationError::DuplicateAxis {
+                axis: 0,
+                role: "output label",
+            },
         ));
     }
     for &label in &subscripts.output {
         if !labels_seen.contains(&label) {
-            return Err(Error::ContractionError(format!(
-                "tropical einsum output label {label} is not present in any input"
-            )));
+            return Err(Error::invalid_argument(
+                "tropical_einsum_subscripts",
+                ErrorPhase::GraphBuild,
+                "output",
+                format!("output label {label} is not present in any input"),
+            ));
         }
     }
     let has_contracted = subscripts.inputs[0]
         .iter()
         .any(|label| subscripts.inputs[1].contains(label) && !subscripts.output.contains(label));
     if !has_contracted {
-        return Err(Error::ContractionError(
-            "tropical einsum requires at least one contracted label".to_string(),
+        return Err(Error::invalid_argument(
+            "tropical_einsum_subscripts",
+            ErrorPhase::GraphBuild,
+            "subscripts",
+            "tropical einsum requires at least one contracted label",
         ));
     }
     Ok(())
@@ -412,6 +503,13 @@ fn validate_tropical_einsum_inputs(
 /// let out = executor.run(&program).unwrap();
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[5.0]);
 /// ```
+///
+/// # Errors
+///
+/// Returns [`tenferro_runtime::Error::Validation`] with an
+/// `AxisOutOfBounds` or `DuplicateAxis` payload when `axes` is invalid, or
+/// [`tenferro_runtime::Error::Internal`] if output metadata registration
+/// fails.
 pub fn tropical_reduce_sum(a: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
     a.reduce_max(axes)
 }
@@ -426,7 +524,17 @@ mod tests {
         let rhs = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
 
         let err = tropical_dot_general(&lhs, &rhs).unwrap_err();
-        assert!(err.to_string().contains("requires rank-2 input"));
+        assert!(matches!(
+            err,
+            Error::Validation {
+                op: "tropical_dot_general",
+                phase: ErrorPhase::GraphBuild,
+                source: ValidationError::RankMismatch {
+                    expected: 2,
+                    actual: 1,
+                },
+            }
+        ));
     }
 
     #[test]
@@ -435,6 +543,21 @@ mod tests {
         let rhs = TracedTensor::from_vec_col_major(vec![4, 2], vec![1.0_f64; 8]).unwrap();
 
         let err = min_plus_dot_general(&lhs, &rhs).unwrap_err();
-        assert!(err.to_string().contains("contracting axes must match"));
+        assert!(matches!(
+            err,
+            Error::Validation {
+                op: "min_plus_dot_general",
+                phase: ErrorPhase::GraphBuild,
+                source: ValidationError::ShapeMismatch(payload),
+            } if matches!(
+                payload.as_ref(),
+                ShapeMismatch::ContractedDimensions {
+                    lhs_axis: 1,
+                    lhs_size: 3,
+                    rhs_axis: 0,
+                    rhs_size: 4,
+                }
+            )
+        ));
     }
 }

--- a/ext/tropical/tests/tropical_argmax.rs
+++ b/ext/tropical/tests/tropical_argmax.rs
@@ -2,7 +2,7 @@ use tenferro_ext_tropical::{
     cpu::{tropical_gemm_with_argmax, tropical_gemm_with_argmax_generic, TropicalGemmKind},
     TropicalKind,
 };
-use tenferro_tensor::Error;
+use tenferro_tensor::{Error, ValidationError};
 
 #[test]
 fn maxplus_gemm_returns_values_and_first_winner_indices() {
@@ -167,14 +167,17 @@ fn gemm_kind_accepts_crate_level_tropical_kind() {
 }
 
 #[test]
-fn invalid_dimensions_return_invalid_config() {
+fn invalid_dimensions_return_validation_errors() {
     let err = tropical_gemm_with_argmax(TropicalGemmKind::MaxPlus, &[1.0_f64], 2, 2, &[1.0], 1)
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "tropical_gemm_with_argmax",
-            ..
+            source: ValidationError::ShapeDataLengthMismatch {
+                expected: 4,
+                actual: 1,
+            },
         }
     ));
 
@@ -182,9 +185,12 @@ fn invalid_dimensions_return_invalid_config() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "tropical_gemm_with_argmax",
-            ..
+            source: ValidationError::InvalidArgument {
+                argument: "configuration",
+                ..
+            },
         }
     ));
 }
@@ -200,33 +206,39 @@ fn zero_contracting_dimension_is_allowed_only_for_empty_outputs() {
         .unwrap_err();
     assert!(matches!(
         err,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "tropical_gemm_with_argmax",
-            ..
+            source: ValidationError::InvalidArgument {
+                argument: "configuration",
+                ..
+            },
         }
     ));
 }
 
 #[cfg(target_pointer_width = "64")]
 #[test]
-fn oversized_contracting_dimension_returns_invalid_config_before_reading_inputs() {
+fn oversized_contracting_dimension_returns_validation_error_before_reading_inputs() {
     let too_large_k = u32::MAX as usize + 2;
 
     let err = tropical_gemm_with_argmax(
         TropicalGemmKind::MaxPlus,
         &[] as &[f64],
-        1,
+        0,
         too_large_k,
         &[],
-        1,
+        0,
     )
     .unwrap_err();
 
     assert!(matches!(
         err,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "tropical_gemm_with_argmax",
-            ..
+            source: ValidationError::InvalidArgument {
+                argument: "configuration",
+                ..
+            },
         }
     ));
 }

--- a/ext/tropical/tests/tropical_einsum.rs
+++ b/ext/tropical/tests/tropical_einsum.rs
@@ -3,7 +3,7 @@ use tenferro_ext_tropical::{
     einsum::tropical_einsum_with_argmax, traced::tropical_einsum_subscripts, TropicalKind,
 };
 use tenferro_runtime::{DType, GraphCompiler, TracedTensor};
-use tenferro_tensor::{Error, Tensor};
+use tenferro_tensor::{Error, ErrorKind, Tensor, ValidationError};
 
 #[test]
 fn independent_symbolic_contract_enforces_repeated_tropical_labels() {
@@ -302,7 +302,7 @@ fn empty_outputs_allow_zero_sized_contracted_modes() {
 }
 
 #[test]
-fn unsupported_cases_return_invalid_config() {
+fn unsupported_cases_return_structured_errors() {
     let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
     let b = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
 
@@ -320,9 +320,12 @@ fn unsupported_cases_return_invalid_config() {
         assert!(
             matches!(
                 err,
-                Error::InvalidConfig {
+                Error::Validation {
                     op: "tropical_einsum_with_argmax",
-                    ..
+                    source: ValidationError::InvalidArgument {
+                        argument: "configuration",
+                        ..
+                    },
                 }
             ),
             "{case} returned {err:?}"
@@ -338,8 +341,10 @@ fn unsupported_cases_return_invalid_config() {
     .unwrap_err();
     assert!(matches!(
         err,
-        Error::InvalidConfig {
+        Error::Extension {
             op: "tropical_einsum_with_argmax",
+            family: "tropical",
+            kind: ErrorKind::Unsupported,
             ..
         }
     ));
@@ -351,9 +356,12 @@ fn unsupported_cases_return_invalid_config() {
             .unwrap_err();
     assert!(matches!(
         err,
-        Error::InvalidConfig {
+        Error::Validation {
             op: "tropical_einsum_with_argmax",
-            ..
+            source: ValidationError::InvalidArgument {
+                argument: "configuration",
+                ..
+            },
         }
     ));
 }

--- a/scripts/check-pr-fast.sh
+++ b/scripts/check-pr-fast.sh
@@ -7,6 +7,8 @@ DOC_SNIPPETS="auto"
 COVERAGE_REVIEWED=0
 FOCUSED_TESTS=()
 CI_PROFILES=()
+focused_test_count=0
+ci_profile_count=0
 CI_PROFILE_DRY_RUN=0
 
 usage() {
@@ -66,11 +68,13 @@ while [[ $# -gt 0 ]]; do
     --test)
       [[ $# -ge 2 ]] || die "--test requires a command"
       FOCUSED_TESTS+=("$2")
+      focused_test_count=$((focused_test_count + 1))
       shift 2
       ;;
     --ci-profile)
       [[ $# -ge 2 ]] || die "--ci-profile requires a name"
       CI_PROFILES+=("$2")
+      ci_profile_count=$((ci_profile_count + 1))
       shift 2
       ;;
     --ci-profile-dry-run)
@@ -208,16 +212,18 @@ else
   log "docs snippets: skipped"
 fi
 
-if [[ "${change_class}" != "docs-only" && "${#FOCUSED_TESTS[@]}" -eq 0 && "${#CI_PROFILES[@]}" -eq 0 ]]; then
+if [[ "${change_class}" != "docs-only" && "$focused_test_count" -eq 0 && "$ci_profile_count" -eq 0 ]]; then
   die "focused verification command required for ${change_class} changes; pass --test COMMAND or --ci-profile NAME"
 fi
 
-for command in "${FOCUSED_TESTS[@]}"; do
-  log "+ ${command}"
-  bash -lc "$command"
-done
+if [[ "$focused_test_count" -gt 0 ]]; then
+  for command in "${FOCUSED_TESTS[@]}"; do
+    log "+ ${command}"
+    bash -lc "$command"
+  done
+fi
 
-if [[ "${#CI_PROFILES[@]}" -gt 0 ]]; then
+if [[ "$ci_profile_count" -gt 0 ]]; then
   profile_args=("${CI_PROFILES[@]}")
   if [[ "$CI_PROFILE_DRY_RUN" -eq 1 ]]; then
     profile_args=(--dry-run "${profile_args[@]}")

--- a/scripts/check-pr-fast.sh
+++ b/scripts/check-pr-fast.sh
@@ -125,8 +125,10 @@ log "base:   ${BASE_REF} (${base_short})"
 log "head:   ${head_short}"
 
 changed_files=()
+changed_file_count=0
 while IFS= read -r path; do
   changed_files+=("$path")
+  changed_file_count=$((changed_file_count + 1))
 done < <(
   {
     git diff --name-only "${BASE_REF}...HEAD"
@@ -137,11 +139,13 @@ done < <(
 )
 
 untracked_files=()
+untracked_file_count=0
 while IFS= read -r path; do
   untracked_files+=("$path")
+  untracked_file_count=$((untracked_file_count + 1))
 done < <(git ls-files --others --exclude-standard | awk 'NF' | sort -u)
 
-if [[ "${#changed_files[@]}" -eq 0 ]]; then
+if [[ "$changed_file_count" -eq 0 ]]; then
   log "changed files: none"
 else
   log "changed files:"
@@ -149,9 +153,11 @@ else
 fi
 
 policy_args=(python3 scripts/ci/change_policy.py)
-for path in "${changed_files[@]}"; do
-  policy_args+=(--path "$path")
-done
+if [[ "$changed_file_count" -gt 0 ]]; then
+  for path in "${changed_files[@]}"; do
+    policy_args+=(--path "$path")
+  done
+fi
 policy_json="$("${policy_args[@]}")"
 policy_fields=()
 while IFS= read -r field; do
@@ -169,7 +175,7 @@ log "classification reason: ${change_reason}"
 run git diff --check "${BASE_REF}...HEAD"
 run git diff --cached --check
 run git diff --check
-if [[ "${#untracked_files[@]}" -gt 0 ]]; then
+if [[ "$untracked_file_count" -gt 0 ]]; then
   untracked_whitespace_errors=0
   for path in "${untracked_files[@]}"; do
     whitespace_output="$(git diff --no-index --check -- /dev/null "$path" 2>&1 || true)"
@@ -197,12 +203,14 @@ case "$DOC_SNIPPETS" in
     run_doc_snippets=0
     ;;
   auto)
-    for path in "${changed_files[@]}"; do
-      if [[ "$path" == docs/* || "$path" == README.md || "$path" == *.md || "$path" == *.qmd ]]; then
-        run_doc_snippets=1
-        break
-      fi
-    done
+    if [[ "$changed_file_count" -gt 0 ]]; then
+      for path in "${changed_files[@]}"; do
+        if [[ "$path" == docs/* || "$path" == README.md || "$path" == *.md || "$path" == *.qmd ]]; then
+          run_doc_snippets=1
+          break
+        fi
+      done
+    fi
     ;;
 esac
 

--- a/scripts/check-public-error-docs.py
+++ b/scripts/check-public-error-docs.py
@@ -48,7 +48,8 @@ DEFERRED_HINT_RE = re.compile(
 # prose spell-checker so boilerplate cannot satisfy the repository contract.
 CONCRETE_ERROR_RE = re.compile(
     r"(?:"
-    r"\b(?:Error|ErrorKind|ValidationError)::[A-Za-z0-9_]+\b|"
+    r"\b(?:Error|ErrorKind)::(?!Validation\b)[A-Za-z0-9_]+\b|"
+    r"\bValidationError::[A-Za-z0-9_]+\b|"
     r"\b[A-Z][A-Za-z0-9_]*(?:Error|Failure|Mismatch|OutOfBounds|Overflow|"
     r"Underflow|Unavailable|NonConvergence|Singular|Unsupported|Invalid|"
     r"Poisoned|Conversion|State)\b|"

--- a/scripts/check-public-error-docs.py
+++ b/scripts/check-public-error-docs.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Audit public Rust ``Result`` APIs for concrete ``# Errors`` docs.
+
+The Rust compiler cannot make ``clippy::missing_errors_doc`` a repository
+contract by itself: it checks only whether a heading exists, and it does not
+cover all public trait methods consistently across toolchain versions. This
+small source audit complements Clippy by checking the public API surface and
+requiring the section to name a concrete error variant or failure condition.
+It intentionally does not rewrite source; missing documentation is a review
+failure that must be fixed at the API's source of truth.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PUBLIC_FN_RE = re.compile(
+    r"^\s*pub\s+(?!(?:\([^)]*\)))"
+    r"(?:(?:async|const|unsafe)\s+)*fn\b"
+)
+TRAIT_FN_RE = re.compile(r"^\s*(?:(?:async|unsafe)\s+)*fn\b")
+RESULT_RE = re.compile(r"\b(?:[A-Za-z_][\w:]*::)?Result\s*<")
+TRAIT_RE = re.compile(r"^\s*pub\s+(?:unsafe\s+)?trait\b")
+DOC_RE = re.compile(r"^\s*///")
+DOC_ATTRIBUTE_RE = re.compile(r'^\s*#\[doc\s*=\s*("(?:\\.|[^"\\])*")\s*\]\s*$')
+ATTRIBUTE_RE = re.compile(r"^\s*#\[")
+ERROR_HEADING_RE = re.compile(r"^\s*#\s+Errors\s*$", re.IGNORECASE)
+DEFERRED_HEADING_RE = re.compile(r"^\s*#\s+Deferred errors\s*$", re.IGNORECASE)
+NEXT_HEADING_RE = re.compile(r"^\s*#\s+")
+# A traced API may mention a deferred check in its prose. Such a statement is
+# required to live under an explicit ``# Deferred errors`` heading so callers
+# can distinguish graph-build failures from compile/execution failures.
+DEFERRED_HINT_RE = re.compile(
+    r"\b(?:deferred|compile(?:d)? or execution|compilation or execution|"
+    r"after binding|at execution,)\b",
+    re.IGNORECASE,
+)
+# A category label such as "backend error" or "validation failure" is not
+# enough: the section must identify an observable variant or a condition that
+# lets a caller decide how to recover. Keep this deliberately narrower than a
+# prose spell-checker so boilerplate cannot satisfy the repository contract.
+CONCRETE_ERROR_RE = re.compile(
+    r"(?:"
+    r"\b(?:Error|ErrorKind|ValidationError)::[A-Za-z0-9_]+\b|"
+    r"\b[A-Z][A-Za-z0-9_]*(?:Error|Failure|Mismatch|OutOfBounds|Overflow|"
+    r"Underflow|Unavailable|NonConvergence|Singular|Unsupported|Invalid|"
+    r"Poisoned|Conversion|State)\b|"
+    r"\b(?:shape|rank|axis|dtype|configuration|config|input|output|"
+    r"cotangent|tangent|operand|index|placement|buffer|metadata|program|"
+    r"graph|cache|device|plugin|lock|file|stream|serialization|worker|"
+    r"operation|extension|family|backend|runtime|divisor|exponent)\b"
+    r"[^.\n]{0,80}\b(?:mismatch|out of bounds|overflow|underflow|invalid|"
+    r"incompatible|missing|poisoned|unavailable|unsupported|singular|"
+    r"non[- ]?convergen\w*|zero|failure|(?:do not )?match)\b|"
+    r"\binvalid\s+(?:shape|shapes|rank|axis|axes|dtype|dtypes|configuration|"
+    r"config|input|output|notation|subscripts|metadata|binding|indices|"
+    r"positions|range|dimensions?)\b|"
+    r"\b(?:no|missing|without)\b[^.\n]{0,50}\b(?:shape|rank|axis|dtype|"
+    r"metadata|input|output|binding|executor|cache|runtime|plugin)\b|"
+    r"\b(?:division by zero|zero divisor|non[- ]?convergen\w*|singular|"
+    r"overflow|underflow|poisoned|out of bounds|missing [A-Za-z]|"
+    r"unsupported[- ](?:operation|dtype|conversion|backend|extension|rule))\b"
+    r")",
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: Path
+    line: int
+    function: str
+    reason: str
+
+
+def rust_files(root: Path) -> list[Path]:
+    excluded = {".git", ".codegraph", "target"}
+    paths: list[Path] = []
+    for path in root.rglob("*.rs"):
+        if any(part in excluded for part in path.parts):
+            continue
+        paths.append(path)
+    return sorted(paths)
+
+
+def brace_delta(line: str) -> int:
+    # This is a documentation audit, not a Rust parser. Removing comments and
+    # string literals avoids the common false positives in examples while
+    # keeping the trait-range tracking deterministic and dependency-free.
+    code = re.sub(r'//.*$', "", line)
+    code = re.sub(r'"(?:\\.|[^"\\])*"', "", code)
+    return code.count("{") - code.count("}")
+
+
+def preceding_docs(lines: list[str], index: int) -> tuple[str, bool]:
+    docs: list[str] = []
+    hidden = False
+    cursor = index - 1
+    while cursor >= 0:
+        stripped = lines[cursor].strip()
+        if DOC_RE.match(lines[cursor]):
+            docs.append(lines[cursor])
+        elif (match := DOC_ATTRIBUTE_RE.match(lines[cursor])) is not None:
+            # Procedural-macro source commonly uses #[doc = "..."] because
+            # quote! cannot emit a literal /// block. Treat that attribute as
+            # the generated rustdoc it represents so macro-generated Result
+            # APIs are held to the same documentation contract.
+            docs.append(f"/// {ast.literal_eval(match.group(1))}")
+        elif ATTRIBUTE_RE.match(lines[cursor]):
+            hidden = hidden or "doc(hidden)" in stripped
+        elif stripped == "" and docs:
+            break
+        else:
+            break
+        cursor -= 1
+    return "\n".join(reversed(docs)), hidden
+
+
+def function_signature(lines: list[str], index: int) -> str:
+    parts: list[str] = []
+    for line in lines[index : index + 80]:
+        parts.append(line)
+        if ";" in line or "{" in line:
+            break
+    return " ".join(parts)
+
+
+def function_name(signature: str) -> str:
+    match = re.search(r"\bfn\s+([A-Za-z_][\w]*)", signature)
+    return match.group(1) if match else "<anonymous>"
+
+
+def doc_section(doc: str, heading: re.Pattern[str]) -> str | None:
+    if not doc:
+        return None
+    cleaned = [line.split("///", 1)[-1].strip() for line in doc.splitlines()]
+    start = next((index for index, line in enumerate(cleaned) if heading.match(line)), None)
+    if start is None:
+        return None
+    body: list[str] = []
+    for line in cleaned[start + 1 :]:
+        if NEXT_HEADING_RE.match(line):
+            break
+        body.append(line)
+    return "\n".join(body).strip()
+
+
+def error_section(doc: str) -> str | None:
+    return doc_section(doc, ERROR_HEADING_RE)
+
+
+def deferred_section(doc: str) -> str | None:
+    return doc_section(doc, DEFERRED_HEADING_RE)
+
+
+def audit_file(path: Path, changed_lines: set[int] | None = None) -> list[Finding]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    findings: list[Finding] = []
+    trait_depth: int | None = None
+    depth = 0
+
+    for index, line in enumerate(lines):
+        if TRAIT_RE.match(line):
+            trait_depth = depth + max(brace_delta(line), 0)
+
+        is_public = bool(PUBLIC_FN_RE.match(line))
+        is_trait_method = trait_depth is not None and bool(TRAIT_FN_RE.match(line))
+        if is_public or is_trait_method:
+            if changed_lines is not None and index + 1 not in changed_lines:
+                depth += brace_delta(line)
+                if trait_depth is not None and depth < trait_depth:
+                    trait_depth = None
+                continue
+            signature = function_signature(lines, index)
+            if RESULT_RE.search(signature):
+                docs, hidden = preceding_docs(lines, index)
+                if not hidden:
+                    section = error_section(docs)
+                    if section is None:
+                        findings.append(
+                            Finding(path, index + 1, function_name(signature), "missing # Errors")
+                        )
+                    elif not CONCRETE_ERROR_RE.search(re.sub(r"\s+", " ", section)):
+                        findings.append(
+                            Finding(
+                                path,
+                                index + 1,
+                                function_name(signature),
+                                "# Errors does not name a concrete variant or condition",
+                            )
+                        )
+                    elif (
+                        path.name == "traced.rs"
+                        and DEFERRED_HINT_RE.search(docs)
+                        and deferred_section(docs) is None
+                    ):
+                        findings.append(
+                            Finding(
+                                path,
+                                index + 1,
+                                function_name(signature),
+                                "deferred validation must be documented under # Deferred errors",
+                            )
+                        )
+
+        depth += brace_delta(line)
+        if trait_depth is not None and depth < trait_depth:
+            trait_depth = None
+
+    return findings
+
+
+def audit(
+    root: Path,
+    paths: list[Path] | None = None,
+    changed_lines: dict[Path, set[int]] | None = None,
+) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in paths if paths is not None else rust_files(root):
+        lines = changed_lines.get(path) if changed_lines is not None else None
+        findings.extend(audit_file(path, lines))
+    return findings
+
+
+def changed_rust_lines(root: Path, revision: str) -> dict[Path, set[int]]:
+    """Return added Rust source lines between ``revision`` and ``HEAD``."""
+
+    diff = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--unified=0",
+            f"{revision}...HEAD",
+            "--",
+            "*.rs",
+        ],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    result: dict[Path, set[int]] = {}
+    current: Path | None = None
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current = (root / line.removeprefix("+++ b/")).resolve()
+            result.setdefault(current, set())
+            continue
+        if current is None or not line.startswith("@@"):
+            continue
+        match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+        if match is None:
+            continue
+        start = int(match.group(1))
+        count = int(match.group(2) or "1")
+        result[current].update(range(start, start + count))
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root-dir", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument(
+        "--changed-from",
+        metavar="REV",
+        help="audit only Rust files changed between REV and HEAD",
+    )
+    parser.add_argument("paths", nargs="*", type=Path)
+    args = parser.parse_args()
+    root = args.root_dir.resolve()
+    paths = [((root / path).resolve() if not path.is_absolute() else path) for path in args.paths]
+    changed_lines = None
+    if args.changed_from:
+        changed = subprocess.run(
+            ["git", "diff", "--name-only", f"{args.changed_from}...HEAD", "--", "*.rs"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.splitlines()
+        paths = [(root / path).resolve() for path in changed]
+        changed_lines = changed_rust_lines(root, args.changed_from)
+    findings = audit(root, paths or None, changed_lines)
+    if findings:
+        print("public Result APIs with incomplete error documentation:", file=sys.stderr)
+        for finding in findings:
+            print(
+                f"- {finding.path.relative_to(root)}:{finding.line}: "
+                f"{finding.function}: {finding.reason}",
+                file=sys.stderr,
+            )
+        print(
+            "Each public Result API must document concrete variants/conditions "
+            "under `# Errors`; traced symbolic APIs must also explain deferred "
+            "validation where applicable.",
+            file=sys.stderr,
+        )
+        return 1
+    print("public-error-docs-ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/tests/test_change_policy.py
+++ b/scripts/ci/tests/test_change_policy.py
@@ -245,6 +245,31 @@ class LocalGateTests(unittest.TestCase):
         self.assertIn("classification: code", result.stdout)
         self.assertTrue(self.marker.exists(), "code changes should run cargo fmt")
 
+    def test_clean_base_head_is_a_valid_no_change_gate_under_bin_bash(self) -> None:
+        compatible_python_dir = Path(sys.executable).resolve().parent
+        env = self.env | {
+            "PATH": f"{compatible_python_dir}:{self.env['PATH']}",
+        }
+        result = subprocess.run(
+            [
+                "/bin/bash",
+                "scripts/check-pr-fast.sh",
+                "--base",
+                "HEAD",
+                "--no-fetch",
+                "--skip-doc-snippets",
+                "--coverage-reviewed",
+                "--test",
+                "true",
+            ],
+            cwd=self.repo,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("changed files: none", result.stdout)
+
     def test_docs_only_change_skips_cargo_and_coverage_acknowledgement(self) -> None:
         self.write_change("docs/guide.md")
         result = self.run_gate()

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -54,6 +54,27 @@ class WorkflowContractTests(unittest.TestCase):
             "github.com/rhysd/actionlint/cmd/actionlint@v1.7.7", text
         )
 
+    def test_changed_error_audit_jobs_fetch_base_history(self) -> None:
+        job_header = re.compile(r"^  (?P<name>[A-Za-z0-9_-]+):\s*$", re.MULTILINE)
+        audited_jobs: list[str] = []
+        workflow_dir = ROOT / ".github" / "workflows"
+        for path in sorted(workflow_dir.iterdir()):
+            if path.suffix not in {".yml", ".yaml"}:
+                continue
+            text = path.read_text()
+            matches = list(job_header.finditer(text))
+            for index, match in enumerate(matches):
+                end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+                block = text[match.start() : end]
+                if "check-public-error-docs.py --changed-from" not in block:
+                    continue
+                job = f"{path.name}:{match.group('name')}"
+                audited_jobs.append(job)
+                self.assertIn("uses: actions/checkout@", block, job)
+                self.assertRegex(block, r"(?m)^\s+fetch-depth:\s*0\s*$", job)
+
+        self.assertTrue(audited_jobs, "no changed public-error audit job was found")
+
     def test_runpod_schema_preflight_precedes_archive(self) -> None:
         text = read(".github/workflows/runpod-gpu-test.yml")
         self.assertIn("runpod-contract:", text)

--- a/scripts/test-check-public-error-docs.py
+++ b/scripts/test-check-public-error-docs.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -142,6 +143,93 @@ class PublicErrorDocsTests(unittest.TestCase):
             """
         )
         self.assertEqual(findings, [])
+
+    def test_changed_audit_requires_base_object_in_shallow_checkout(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="tenferro-error-docs-git-") as directory:
+            root = Path(directory)
+            source = root / "source"
+            source.mkdir()
+
+            def git(*args: str, cwd: Path = source) -> subprocess.CompletedProcess[str]:
+                return subprocess.run(
+                    ["git", *args],
+                    cwd=cwd,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+
+            git("init", "-b", "main")
+            git("config", "user.name", "public-error-docs-test")
+            git("config", "user.email", "public-error-docs-test@example.invalid")
+            sample = source / "sample.rs"
+            sample.write_text(
+                """
+                /// Compute a value.
+                ///
+                /// # Errors
+                ///
+                /// Returns `Error::InvalidArgument` when input is invalid.
+                pub fn compute() -> Result<(), Error> { Ok(()) }
+                """.lstrip(),
+                encoding="utf-8",
+            )
+            git("add", "sample.rs")
+            git("commit", "-m", "base")
+            base = git("rev-parse", "HEAD").stdout.strip()
+
+            sample.write_text(
+                sample.read_text(encoding="utf-8").replace(
+                    "Compute a value.", "Compute another value."
+                ),
+                encoding="utf-8",
+            )
+            git("add", "sample.rs")
+            git("commit", "-m", "head")
+
+            full = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--root-dir",
+                    str(source),
+                    "--changed-from",
+                    base,
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(full.returncode, 0, full.stderr)
+
+            shallow = root / "shallow"
+            subprocess.run(
+                ["git", "clone", "--depth", "1", source.as_uri(), str(shallow)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            missing_base_diff = subprocess.run(
+                ["git", "diff", "--name-only", f"{base}...HEAD", "--", "*.rs"],
+                cwd=shallow,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(missing_base_diff.returncode, 128, missing_base_diff.stderr)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--root-dir",
+                    str(shallow),
+                    "--changed-from",
+                    base,
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("128", result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/test-check-public-error-docs.py
+++ b/scripts/test-check-public-error-docs.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("check-public-error-docs.py")
+SPEC = importlib.util.spec_from_file_location("check_public_error_docs", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class PublicErrorDocsTests(unittest.TestCase):
+    def audit(self, source: str, filename: str = "sample.rs"):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / filename
+            path.write_text(source, encoding="utf-8")
+            return MODULE.audit_file(path)
+
+    def test_public_result_requires_errors_section(self) -> None:
+        findings = self.audit(
+            """
+            /// Compute a value.
+            pub fn compute() -> Result<(), MyError> { Ok(()) }
+            """
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].reason, "missing # Errors")
+
+    def test_errors_section_must_name_concrete_failure(self) -> None:
+        findings = self.audit(
+            """
+            /// Compute a value.
+            ///
+            /// # Errors
+            ///
+            /// Returns an error when computation fails.
+            pub fn compute() -> Result<(), MyError> { Ok(()) }
+            """
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertIn("concrete", findings[0].reason)
+
+    def test_category_only_errors_section_is_not_concrete(self) -> None:
+        findings = self.audit(
+            """
+            /// Compute a value.
+            ///
+            /// # Errors
+            ///
+            /// Returns a typed backend/runtime-state error.
+            pub fn compute() -> Result<(), MyError> { Ok(()) }
+            """
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertIn("concrete", findings[0].reason)
+
+    def test_trait_method_and_variant_are_accepted(self) -> None:
+        findings = self.audit(
+            """
+            pub trait Compute {
+                /// Compute a value.
+                ///
+                /// # Errors
+                ///
+                /// Returns `Error::Validation` for invalid input.
+                fn compute(&self) -> Result<(), Error>;
+            }
+            """
+        )
+        self.assertEqual(findings, [])
+
+    def test_doc_attributes_are_treated_as_generated_rustdoc(self) -> None:
+        findings = self.audit(
+            r'''
+            #[doc = "Register an extension."]
+            #[doc = "\n# Errors\n\nReturns `Error::Validation` for an invalid family id."]
+            pub fn register() -> Result<(), Error> { Ok(()) }
+            '''
+        )
+        self.assertEqual(findings, [])
+
+    def test_traced_deferred_validation_requires_deferred_section(self) -> None:
+        findings = self.audit(
+            """
+            /// Build a symbolic operation.
+            ///
+            /// # Errors
+            ///
+            /// Returns `Error::Validation` when shape compatibility is checked
+            /// during compilation or execution.
+            pub fn build() -> Result<(), Error> { Ok(()) }
+            """,
+            filename="traced.rs",
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertIn("Deferred errors", findings[0].reason)
+
+    def test_traced_deferred_section_is_accepted(self) -> None:
+        findings = self.audit(
+            """
+            /// Build a symbolic operation.
+            ///
+            /// # Errors
+            ///
+            /// Returns `Error::Validation` for an invalid shape.
+            ///
+            /// # Deferred errors
+            ///
+            /// A symbolic mismatch is reported at execution.
+            pub fn build() -> Result<(), Error> { Ok(()) }
+            """,
+            filename="traced.rs",
+        )
+        self.assertEqual(findings, [])
+
+    def test_non_result_function_is_not_a_finding(self) -> None:
+        findings = self.audit(
+            """
+            /// Return a value.
+            pub fn value() -> usize { 1 }
+            """
+        )
+        self.assertEqual(findings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-check-public-error-docs.py
+++ b/scripts/test-check-public-error-docs.py
@@ -61,6 +61,20 @@ class PublicErrorDocsTests(unittest.TestCase):
         self.assertEqual(len(findings), 1)
         self.assertIn("concrete", findings[0].reason)
 
+    def test_validation_wrapper_without_payload_is_not_concrete(self) -> None:
+        findings = self.audit(
+            """
+            /// Compute a value.
+            ///
+            /// # Errors
+            ///
+            /// Returns `Error::Validation` with a typed validation source.
+            pub fn compute() -> Result<(), MyError> { Ok(()) }
+            """
+        )
+        self.assertEqual(len(findings), 1)
+        self.assertIn("concrete", findings[0].reason)
+
     def test_trait_method_and_variant_are_accepted(self) -> None:
         findings = self.audit(
             """
@@ -69,7 +83,7 @@ class PublicErrorDocsTests(unittest.TestCase):
                 ///
                 /// # Errors
                 ///
-                /// Returns `Error::Validation` for invalid input.
+            /// Returns `ValidationError::ShapeMismatch` for incompatible input.
                 fn compute(&self) -> Result<(), Error>;
             }
             """
@@ -80,7 +94,7 @@ class PublicErrorDocsTests(unittest.TestCase):
         findings = self.audit(
             r'''
             #[doc = "Register an extension."]
-            #[doc = "\n# Errors\n\nReturns `Error::Validation` for an invalid family id."]
+            #[doc = "\n# Errors\n\nReturns `Error::InvalidArgument` for an invalid family id."]
             pub fn register() -> Result<(), Error> { Ok(()) }
             '''
         )
@@ -93,7 +107,7 @@ class PublicErrorDocsTests(unittest.TestCase):
             ///
             /// # Errors
             ///
-            /// Returns `Error::Validation` when shape compatibility is checked
+            /// Returns `ValidationError::ShapeMismatch` when shape compatibility is checked
             /// during compilation or execution.
             pub fn build() -> Result<(), Error> { Ok(()) }
             """,
@@ -109,7 +123,7 @@ class PublicErrorDocsTests(unittest.TestCase):
             ///
             /// # Errors
             ///
-            /// Returns `Error::Validation` for an invalid shape.
+            /// Returns `ValidationError::ShapeMismatch` for an invalid shape.
             ///
             /// # Deferred errors
             ///

--- a/scripts/test-doc-consistency.py
+++ b/scripts/test-doc-consistency.py
@@ -303,6 +303,22 @@ def test_documentation_policy_matches_rendered_internals() -> None:
     assert "architecture, specification, and active design notes" in normalized
 
 
+def test_traced_remainder_docs_distinguish_complex_unsupported_from_float_zero() -> None:
+    text = read("crates/tenferro-runtime/src/traced.rs")
+    start = text.index("    /// Elementwise remainder")
+    end = text.index("    pub fn rem", start)
+    docs = " ".join(
+        line.removeprefix("    ///").strip() for line in text[start:end].splitlines()
+    )
+
+    assert (
+        "[`Error::Unsupported`] at [`ErrorPhase::GraphBuild`] when either operand "
+        "has a complex dtype"
+    ) in docs
+    assert "floating-point zero divisors follow their numeric semantics" in docs
+    assert "floating-point and complex zero divisors" not in docs
+
+
 def main() -> int:
     for test in [
         test_architecture_svg_lists_cpu_crate_xla_boundary_and_background,
@@ -319,6 +335,7 @@ def main() -> int:
         test_api_consistency_checker_rejects_public_try_compatibility_escape,
         test_removed_tensor_module_paths_do_not_compile,
         test_documentation_policy_matches_rendered_internals,
+        test_traced_remainder_docs_distinguish_complex_unsupported_from_float_zero,
     ]:
         test()
     return 0

--- a/scripts/test-doc-consistency.py
+++ b/scripts/test-doc-consistency.py
@@ -84,6 +84,16 @@ def test_docs_ci_runs_docs_script_tests() -> None:
     )
 
 
+def test_ci_enforces_public_error_docs_and_extension_clippy() -> None:
+    text = read(".github/workflows/ci.yml")
+
+    assert "scripts/check-public-error-docs.py" in text
+    assert "-D clippy::missing_errors_doc" in text
+    assert "-D clippy::missing_panics_doc" in text
+    assert "cargo clippy --manifest-path ext/tropical/Cargo.toml" in text
+    assert "cargo clippy --manifest-path ext/sparse/Cargo.toml" in text
+
+
 def test_review_bot_workflow_exists() -> None:
     text = read(".github/workflows/review_bot.yml")
 
@@ -298,6 +308,7 @@ def main() -> int:
         test_architecture_svg_lists_cpu_crate_xla_boundary_and_background,
         test_agents_layer_diagram_lists_cpu_crate,
         test_docs_ci_runs_docs_script_tests,
+        test_ci_enforces_public_error_docs_and_extension_clippy,
         test_review_bot_workflow_exists,
         test_repo_settings_requires_repository_rules_review,
         test_gpu_ci_waits_for_review_bot_gate_before_cuda_work,

--- a/scripts/test-repository-rules-review.py
+++ b/scripts/test-repository-rules-review.py
@@ -162,6 +162,12 @@ def test_select_rule_sections_includes_performance_for_tensor_crates() -> None:
     assert "Unsafe Code Boundary" in sections
 
 
+def test_select_rule_sections_includes_public_boundary_audits() -> None:
+    mod = load_module()
+    sections = mod.select_rule_sections(["crates/tenferro-runtime/src/traced.rs"])
+    assert "Public Boundary Safety Audits" in sections
+
+
 def test_extract_json_payload_strips_fence() -> None:
     mod = load_module()
     parsed = mod.extract_json_payload(
@@ -489,6 +495,7 @@ def main() -> int:
         test_select_rule_sections_includes_ad_for_ad_paths,
         test_select_rule_sections_includes_ad_for_tenferro_ad_crate,
         test_select_rule_sections_includes_performance_for_tensor_crates,
+        test_select_rule_sections_includes_public_boundary_audits,
         test_extract_json_payload_strips_fence,
         test_extract_json_payload_reports_malformed_embedded_object,
         test_parse_findings_caps_model_output,


### PR DESCRIPTION
## Summary

- introduce shared structured error vocabulary with semantic ErrorKind and separate ErrorPhase while keeping crate-local domain errors
- preserve typed sources across eager, traced, AD, backend, einsum, XLA, and extension boundaries
- make known graph-build validation fallible and align eager/traced validation classifications
- document every public Result contract, deferred error behavior, and fallible operator composition including the a + b + c limitation
- enforce public # Errors repository audits and repair macOS Bash 3.2 fast-preflight portability

This intentionally makes clean pre-1.0 breaking changes and adds no compatibility layer.

## Verification

- cargo test --workspace --release
- cargo nextest run --workspace --release: 2243/2243 passed
- cargo llvm-cov workspace audit: 163/163 files passed
- cargo check --workspace --all-targets
- strict workspace Clippy plus tropical/sparse extension Clippy
- rustdoc and docs-site audits
- public error-doc and repository-rules audits
- focused eager/traced broadcast parity, complex remainder, AD source-chain, einsum, XLA, and CI portability tests

## Environment constraints

- arm64 BLAS test linking requires unavailable CBLAS/LAPACK symbols in this environment
- CUDA hardware-dependent tests remain ignored without GPU/toolkit
- optional Graphviz/actionlint checks were unavailable locally

Full command evidence and constraints are recorded in docs/worklogs/2026-07-17-structured-error-model.md.