### PR TITLE
ci: archive PJRT tests on hosted runners for RunPod

### DIFF
--- a/.github/workflows/CI_gpu.yml
+++ b/.github/workflows/CI_gpu.yml
@@ -35,6 +35,7 @@ env:
   CARGO_TERM_COLOR: always
   CUBECL_DEBUG_LOG: "0"
   CUDA_ARCHIVE: cuda-tests.tar.zst
+  PJRT_ARCHIVE: pjrt-tests.tar.zst
   CUDA_RUNTIME_VERSION: "12.8"
   CUTENSOR_VERSION: "2.6.0.4"
   JAX_CUDA12_PJRT_VERSION: "0.10.2"
@@ -154,7 +155,7 @@ jobs:
             core.setFailed(`Timed out waiting for prerequisite checks: ${required.join(", ")}`);
 
   cuda-archive:
-    name: CUDA test archive
+    name: CUDA/PJRT test archive
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
@@ -171,23 +172,25 @@ jobs:
         with:
           ref: ${{ inputs.tenferro_ref || github.ref }}
       - uses: dtolnay/rust-toolchain@stable
-      - name: Compute CUDA archive cache key
+      - name: Compute CUDA/PJRT archive cache key
         id: archive_key
         run: |
           set -euo pipefail
           rustc_hash="$(rustc --version --verbose | sha256sum | cut -c1-12)"
-          echo "key=cuda-archive-v5-ci-no-cuda-build-${rustc_hash}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/src/**', '**/tests/**', '.github/workflows/CI_gpu.yml') }}" >> "${GITHUB_OUTPUT}"
-      - name: Cache CUDA test archive
+          echo "key=cuda-pjrt-archive-v6-ci-no-cuda-build-${rustc_hash}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/src/**', '**/tests/**', '.github/workflows/CI_gpu.yml') }}" >> "${GITHUB_OUTPUT}"
+      - name: Cache CUDA/PJRT test archives
         uses: actions/cache@v4
         id: cuda_archive_cache
         with:
-          path: ${{ env.CUDA_ARCHIVE }}
+          path: |
+            ${{ env.CUDA_ARCHIVE }}
+            ${{ env.PJRT_ARCHIVE }}
           key: ${{ steps.archive_key.outputs.key }}
       - uses: Swatinem/rust-cache@v2
         if: steps.cuda_archive_cache.outputs.cache-hit != 'true'
         with:
-          prefix-key: v0-rust-cuda
-          shared-key: cuda-ci
+          prefix-key: v1-rust-cuda-pjrt
+          shared-key: cuda-pjrt-ci
           cache-all-crates: true
       - uses: taiki-e/install-action@nextest
         if: steps.cuda_archive_cache.outputs.cache-hit != 'true'
@@ -206,7 +209,18 @@ jobs:
             -p tenferro-ad \
             -p tenferro-linalg \
             --features cuda
-      - name: Verify CUDA test archive
+      - name: Build PJRT test archive
+        if: steps.cuda_archive_cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          # Hosted CPU build only: pjrt feature is libloading + dynamic plugin load
+          # at GPU-runtime. Keep this archive separate from --features cuda.
+          cargo nextest archive \
+            --cargo-profile ci \
+            --archive-file "${PJRT_ARCHIVE}" \
+            -p tenferro-xla \
+            --features pjrt
+      - name: Verify CUDA/PJRT test archives
         env:
           ARCHIVE_CACHE_HIT: ${{ steps.cuda_archive_cache.outputs.cache-hit }}
         run: |
@@ -215,15 +229,22 @@ jobs:
             echo "Missing archive: ${CUDA_ARCHIVE}"
             exit 1
           fi
-          if [ "${ARCHIVE_CACHE_HIT}" = "true" ]; then
-            echo "Reusing cached CUDA test archive."
-          else
-            echo "Built fresh CUDA test archive."
+          if [ ! -f "${PJRT_ARCHIVE}" ]; then
+            echo "Missing archive: ${PJRT_ARCHIVE}"
+            exit 1
           fi
+          if [ "${ARCHIVE_CACHE_HIT}" = "true" ]; then
+            echo "Reusing cached CUDA/PJRT test archives."
+          else
+            echo "Built fresh CUDA/PJRT test archives."
+          fi
+          du -sh "${CUDA_ARCHIVE}" "${PJRT_ARCHIVE}" || true
       - uses: actions/upload-artifact@v4
         with:
           name: cuda-tests
-          path: ${{ env.CUDA_ARCHIVE }}
+          path: |
+            ${{ env.CUDA_ARCHIVE }}
+            ${{ env.PJRT_ARCHIVE }}
           if-no-files-found: error
           retention-days: 7
 
@@ -471,9 +492,15 @@ jobs:
             --run-ignored all \
             --no-fail-fast \
             -j 1
-      - name: Run OpenXLA PJRT E2E tests
+      - name: Run OpenXLA PJRT E2E tests from archive
+        env:
+          NEXTEST_TEST_THREADS: "1"
         run: |
           set -euo pipefail
+          if [ ! -f "${PJRT_ARCHIVE}" ]; then
+            echo "Missing PJRT archive: ${PJRT_ARCHIVE}"
+            exit 1
+          fi
           wheel_dir="${RUNNER_TEMP}/openxla-pjrt-wheels"
           unpack_dir="${RUNNER_TEMP}/openxla-pjrt"
           rm -rf "${wheel_dir}" "${unpack_dir}"
@@ -513,10 +540,17 @@ jobs:
           test -x "${cuda_nvcc_dir}/bin/ptxas"
           test -f "${cuda_nvcc_dir}/nvvm/libdevice/libdevice.10.bc"
           nm -D "${plugin_path}" | grep -q GetPjrtApi
+          # Runtime-only plugin setup; Rust binaries come from the hosted PJRT archive.
           XLA_FLAGS="--xla_gpu_cuda_data_dir=${cuda_nvcc_dir} ${XLA_FLAGS:-}" \
           TENFERRO_PJRT_PLUGIN="${plugin_path}" \
           LD_LIBRARY_PATH="${cudnn_lib}:${LD_LIBRARY_PATH:-}" \
-            cargo test -p tenferro-xla --features pjrt --test integration pjrt_execution -- --nocapture
+            cargo nextest run \
+              --archive-file "${PJRT_ARCHIVE}" \
+              --workspace-remap "${GITHUB_WORKSPACE}" \
+              --run-ignored all \
+              --no-fail-fast \
+              -j 1 \
+              -E 'test(pjrt_execution)'
 
   cuda-gate:
     name: CI GPU gate

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -69,6 +69,7 @@ env:
   CARGO_TERM_COLOR: always
   CUBECL_DEBUG_LOG: "0"
   CUDA_ARCHIVE: cuda-tests.tar.zst
+  PJRT_ARCHIVE: pjrt-tests.tar.zst
   # Match the CUDA 12.8 cudarc bindings and CubeCL compiler API floor.
   CUDARC_CUDA_VERSION: "12080"
   CUDA_RUNTIME_VERSION: "12.8"
@@ -390,7 +391,7 @@ jobs:
             core.setFailed(`Timed out waiting for prerequisite checks: ${required.join(", ")}`);
 
   cuda-archive:
-    name: CUDA test archive
+    name: CUDA/PJRT test archive
     needs:
       - authorize
       - runpod-contract
@@ -544,34 +545,36 @@ jobs:
           echo "LD_LIBRARY_PATH=${cuda_library_path}:${LD_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
           "${nvcc_bin}" --version
 
-      - name: Compute CUDA archive cache key
+      - name: Compute CUDA/PJRT archive cache key
         id: archive_key
         run: |
           set -euo pipefail
-          key="cuda-archive-v10-ci-ubuntu22.04-cuda${CUDARC_CUDA_VERSION}-ptx${CUDA_RUNTIME_VERSION}-${{ hashFiles('tenferro-rs/Cargo.lock', 'tenferro-rs/**/Cargo.toml', 'tenferro-rs/**/src/**', 'tenferro-rs/**/tests/**', 'tenferro-rs/scripts/ci/runpod_config.json', 'tenferro-rs/.github/workflows/runpod-gpu-test.yml') }}"
+          key="cuda-pjrt-archive-v11-ci-ubuntu22.04-cuda${CUDARC_CUDA_VERSION}-ptx${CUDA_RUNTIME_VERSION}-${{ hashFiles('tenferro-rs/Cargo.lock', 'tenferro-rs/**/Cargo.toml', 'tenferro-rs/**/src/**', 'tenferro-rs/**/tests/**', 'tenferro-rs/scripts/ci/runpod_config.json', 'tenferro-rs/.github/workflows/runpod-gpu-test.yml') }}"
           echo "key=${key}" >> "${GITHUB_OUTPUT}"
-          echo "CUDA archive cache key: ${key}"
+          echo "CUDA/PJRT archive cache key: ${key}"
 
-      - name: Cache CUDA test archive
+      - name: Cache CUDA/PJRT test archives
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: cuda_archive_cache
         with:
-          path: tenferro-rs/${{ env.CUDA_ARCHIVE }}
+          path: |
+            tenferro-rs/${{ env.CUDA_ARCHIVE }}
+            tenferro-rs/${{ env.PJRT_ARCHIVE }}
           key: ${{ steps.archive_key.outputs.key }}
 
-      - name: Log CUDA archive cache status
+      - name: Log CUDA/PJRT archive cache status
         run: |
           if [ "${{ steps.cuda_archive_cache.outputs.cache-hit }}" = "true" ]; then
-            echo "CUDA archive cache hit; skipping build."
+            echo "CUDA/PJRT archive cache hit; skipping build."
           else
-            echo "CUDA archive cache miss; will build archive with CUDA ${CUDA_RUNTIME_VERSION} PTX."
+            echo "CUDA/PJRT archive cache miss; will build CUDA ${CUDA_RUNTIME_VERSION} PTX and PJRT archives."
           fi
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         if: steps.cuda_archive_cache.outputs.cache-hit != 'true'
         with:
-          prefix-key: v6-rust-cuda-ci-ubuntu22-ptx
-          shared-key: cuda-ci-${{ env.CUDARC_CUDA_VERSION }}-ptx-${{ env.CUDA_RUNTIME_VERSION }}
+          prefix-key: v7-rust-cuda-pjrt-ci-ubuntu22-ptx
+          shared-key: cuda-pjrt-ci-${{ env.CUDARC_CUDA_VERSION }}-ptx-${{ env.CUDA_RUNTIME_VERSION }}
           cache-all-crates: true
           cache-workspace-crates: true
           workspaces: tenferro-rs -> target
@@ -596,7 +599,20 @@ jobs:
             -p tenferro-linalg \
             --features cuda
 
-      - name: Verify CUDA test archive
+      - name: Build PJRT test archive
+        if: steps.cuda_archive_cache.outputs.cache-hit != 'true'
+        working-directory: tenferro-rs
+        run: |
+          set -euo pipefail
+          # Hosted CPU build only: pjrt feature is libloading + dynamic plugin load at
+          # RunPod runtime. Keep this archive separate from --features cuda.
+          cargo nextest archive \
+            --cargo-profile ci \
+            --archive-file "${PJRT_ARCHIVE}" \
+            -p tenferro-xla \
+            --features pjrt
+
+      - name: Verify CUDA/PJRT test archives
         working-directory: tenferro-rs
         env:
           ARCHIVE_CACHE_HIT: ${{ steps.cuda_archive_cache.outputs.cache-hit }}
@@ -606,23 +622,30 @@ jobs:
             echo "Missing archive: ${CUDA_ARCHIVE}"
             exit 1
           fi
+          if [ ! -f "${PJRT_ARCHIVE}" ]; then
+            echo "Missing archive: ${PJRT_ARCHIVE}"
+            exit 1
+          fi
           echo "Build environment glibc: $(ldd --version | head -1)"
           nvcc_bin="${CUDA_PATH}/bin/nvcc"
           echo "Archive PTX toolkit: ${CUDA_PATH} ($("${nvcc_bin}" --version | head -1))"
           if [ "${ARCHIVE_CACHE_HIT}" = "true" ]; then
-            echo "Reusing cached CUDA test archive."
+            echo "Reusing cached CUDA/PJRT test archives."
           else
-            echo "Built fresh CUDA test archive on Ubuntu 22.04."
+            echo "Built fresh CUDA/PJRT test archives on Ubuntu 22.04."
           fi
-          du -sh "${CUDA_ARCHIVE}" target/ci 2>/dev/null || du -sh "${CUDA_ARCHIVE}" || true
+          du -sh "${CUDA_ARCHIVE}" "${PJRT_ARCHIVE}" target/ci 2>/dev/null \
+            || du -sh "${CUDA_ARCHIVE}" "${PJRT_ARCHIVE}" || true
           df -h .
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         # Self-hosted RunPod runners cannot restore the hosted-runner Actions cache;
-        # always publish the archive so run-gpu-tests can download it on cache miss.
+        # always publish the archives so run-gpu-tests can download them on cache miss.
         with:
           name: cuda-tests
-          path: tenferro-rs/${{ env.CUDA_ARCHIVE }}
+          path: |
+            tenferro-rs/${{ env.CUDA_ARCHIVE }}
+            tenferro-rs/${{ env.PJRT_ARCHIVE }}
           if-no-files-found: error
           retention-days: 7
 
@@ -904,11 +927,13 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Restore CUDA test archive
+      - name: Restore CUDA/PJRT test archives
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: cuda_archive_restore
         with:
-          path: tenferro-rs/${{ env.CUDA_ARCHIVE }}
+          path: |
+            tenferro-rs/${{ env.CUDA_ARCHIVE }}
+            tenferro-rs/${{ env.PJRT_ARCHIVE }}
           key: ${{ needs.cuda-archive.outputs.archive_cache_key }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -917,14 +942,14 @@ jobs:
           name: cuda-tests
           path: tenferro-rs
 
-      - name: Log CUDA archive source
+      - name: Log CUDA/PJRT archive source
         run: |
           if [ "${{ steps.cuda_archive_restore.outputs.cache-hit }}" = "true" ]; then
-            echo "Using CUDA test archive restored from GitHub Actions cache."
+            echo "Using CUDA/PJRT test archives restored from GitHub Actions cache."
           else
-            echo "Using CUDA test archive downloaded from workflow artifact."
+            echo "Using CUDA/PJRT test archives downloaded from workflow artifact."
           fi
-          ls -lh "tenferro-rs/${CUDA_ARCHIVE}"
+          ls -lh "tenferro-rs/${CUDA_ARCHIVE}" "tenferro-rs/${PJRT_ARCHIVE}"
 
       - uses: taiki-e/install-action@3ad7ed62b9acd4b43f91777bf240fac23e489eac # nextest (resolved 2026-07-07)
         with:
@@ -1208,10 +1233,16 @@ jobs:
             --no-fail-fast \
             -j 1
 
-      - name: Run OpenXLA PJRT E2E tests
+      - name: Run OpenXLA PJRT E2E tests from archive
         working-directory: tenferro-rs
+        env:
+          NEXTEST_TEST_THREADS: "1"
         run: |
           set -euo pipefail
+          if [ ! -f "${PJRT_ARCHIVE}" ]; then
+            echo "Missing PJRT archive: ${PJRT_ARCHIVE}"
+            exit 1
+          fi
           wheel_dir="${RUNNER_TEMP}/openxla-pjrt-wheels"
           unpack_dir="${RUNNER_TEMP}/openxla-pjrt"
           rm -rf "${wheel_dir}" "${unpack_dir}"
@@ -1252,10 +1283,17 @@ jobs:
           test -x "${cuda_nvcc_dir}/bin/ptxas"
           test -f "${cuda_nvcc_dir}/nvvm/libdevice/libdevice.10.bc"
           nm -D "${plugin_path}" | grep -q GetPjrtApi
+          # Runtime-only plugin setup; Rust binaries come from the hosted PJRT archive.
           XLA_FLAGS="--xla_gpu_cuda_data_dir=${cuda_nvcc_dir} ${XLA_FLAGS:-}" \
           TENFERRO_PJRT_PLUGIN="${plugin_path}" \
           LD_LIBRARY_PATH="${cudnn_lib}:${LD_LIBRARY_PATH:-}" \
-            cargo test -p tenferro-xla --features pjrt --test integration pjrt_execution -- --nocapture
+            cargo nextest run \
+              --archive-file "${PJRT_ARCHIVE}" \
+              --workspace-remap "${GITHUB_WORKSPACE}/tenferro-rs" \
+              --run-ignored all \
+              --no-fail-fast \
+              -j 1 \
+              -E 'test(pjrt_execution)'
 
       - name: GPU test complete
         run: echo "RUNPOD_TENFERRO_GPU_TEST_OK"

--- a/docs/design/change-aware-ci.md
+++ b/docs/design/change-aware-ci.md
@@ -75,11 +75,13 @@ requested tier, is rejected before the external runner starts. The created pod
 ID is still forwarded to the trusted startup-failure cleanup path so rejection
 cannot leave a paid pod running.
 
-The CUDA test archive key is content-addressed across source, manifests,
+The CUDA/PJRT test archive key is content-addressed across source, manifests,
 tests, lockfile, workflow, and RunPod configuration. It excludes branch, ref,
 and commit identity, allowing equivalent automatic and recovery runs to reuse
 the hosted cache while still uploading a per-run artifact for the external
-runner.
+runner. Hosted archive builds produce separate `cuda-tests.tar.zst` and
+`pjrt-tests.tar.zst` nextest archives; the GPU node runs both from archive and
+does not compile Rust (PJRT plugin wheels remain a runtime download).
 
 The archive toolkit and external-runner CUDA runtime must match the workspace
 `cudarc` CUDA binding floor. The current floor is CUDA 12.8, which is required

--- a/docs/worklogs/2026-07-18-issue-1402-ci-thin-profile.md
+++ b/docs/worklogs/2026-07-18-issue-1402-ci-thin-profile.md
@@ -41,6 +41,9 @@ Switched hosted Rust CI from `--release` to workspace `[profile.ci]`:
 - Coverage with `debug=0` + strip must still pass thresholds on GitHub runners.
 - CUDA/PJRT archive wall-clock target (<10 minutes) is measured after merge into
   the GPU workflow path, not locally on macOS.
+- PJRT previously still compiled on RunPod; follow-up worklog
+  `2026-07-18-issue-1402-pjrt-archive.md` moves that binary into a hosted
+  archive.
 
 ## Follow-up fix
 

--- a/docs/worklogs/2026-07-18-issue-1402-pjrt-archive.md
+++ b/docs/worklogs/2026-07-18-issue-1402-pjrt-archive.md
@@ -1,0 +1,39 @@
+# Issue #1402 PJRT Hosted Archive
+
+## Session summary
+
+Finished the remaining #1402 GPU contract gap: build `tenferro-xla --features
+pjrt` on the hosted Ubuntu 22.04 archive job as a separate nextest archive, and
+run PJRT E2E tests on RunPod / fork `CI_gpu` from that archive instead of
+`cargo test`.
+
+## Context read
+
+- [#1402](https://github.com/tensor4all/tenferro-rs/issues/1402) acceptance:
+  CUDA and PJRT binaries in the hosted artifact; no Cargo on RunPod
+- Post-merge thin-profile RunPod evidence (CUDA archive already on `[profile.ci]`)
+- `runpod-gpu-test.yml` / `CI_gpu.yml` PJRT steps still compiling on the GPU node
+
+## Chosen design
+
+- Two archives (`cuda-tests.tar.zst` and `pjrt-tests.tar.zst`) rather than one
+  multi-feature archive, so `--features cuda` and `--features pjrt` stay
+  isolated.
+- Keep PJRT plugin / cuDNN / NVCC wheel download on the GPU node (runtime-only).
+- Filter nextest with `-E 'test(pjrt_execution)'` to match the previous
+  `cargo test ... pjrt_execution` scope.
+- Bump archive cache keys (`v11` / `v6`) and rust-cache prefixes.
+
+## Rejected alternatives
+
+- Single archive with package-qualified features: more fragile feature
+  unification for little operational gain.
+- Shipping the OpenXLA plugin inside the Rust archive: unnecessary; wheels are
+  already fetched at runtime.
+
+## Residual risks
+
+- First cold archive after merge builds both CUDA and PJRT; wall-clock may rise
+  slightly versus CUDA-only even though RunPod compile (~1.5–2 min) disappears.
+- nextest name filter must keep matching `pjrt_execution::*` tests if modules
+  are renamed.

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -125,7 +125,9 @@ class WorkflowContractTests(unittest.TestCase):
     def test_runpod_cache_key_uses_content_not_ref_identity(self) -> None:
         text = read(".github/workflows/runpod-gpu-test.yml")
         key_line = next(
-            line for line in text.splitlines() if 'key="cuda-archive-' in line
+            line
+            for line in text.splitlines()
+            if 'key="cuda-pjrt-archive-' in line or 'key="cuda-archive-' in line
         )
         self.assertNotIn("TENFERRO_REF", key_line)
         self.assertIn("hashFiles(", key_line)
@@ -139,14 +141,28 @@ class WorkflowContractTests(unittest.TestCase):
             text = read(path)
             with self.subTest(path=path):
                 self.assertIn("cargo nextest archive", text)
-                self.assertIn("--cargo-profile ci", text)
-                archive = text[
-                    text.index("cargo nextest archive") : text.index(
-                        "cargo nextest archive"
-                    )
-                    + 200
-                ]
-                self.assertNotIn("--release", archive)
+                self.assertEqual(text.count("--cargo-profile ci"), text.count("cargo nextest archive"))
+                self.assertNotIn("nextest archive \\\n            --release", text)
+                self.assertNotIn("nextest archive \\\n              --release", text)
+                for match in re.finditer(r"cargo nextest archive[\s\S]{0,280}", text):
+                    self.assertNotIn("--release", match.group(0))
+
+    def test_pjrt_uses_hosted_archive_not_runpod_cargo(self) -> None:
+        for path in (
+            ".github/workflows/runpod-gpu-test.yml",
+            ".github/workflows/CI_gpu.yml",
+        ):
+            text = read(path)
+            with self.subTest(path=path):
+                self.assertIn("PJRT_ARCHIVE:", text)
+                self.assertIn("pjrt-tests.tar.zst", text)
+                self.assertIn("-p tenferro-xla", text)
+                self.assertIn("--features pjrt", text)
+                self.assertIn("Build PJRT test archive", text)
+                self.assertIn("Run OpenXLA PJRT E2E tests from archive", text)
+                self.assertIn("--archive-file \"${PJRT_ARCHIVE}\"", text)
+                self.assertIn("-E 'test(pjrt_execution)'", text)
+                self.assertNotIn("cargo test -p tenferro-xla", text)
 
     def test_runpod_cuda_runtime_matches_cudarc_floor(self) -> None:
         text = read(".github/workflows/runpod-gpu-test.yml")


### PR DESCRIPTION
## Summary
- Build `tenferro-xla --features pjrt` as a separate hosted nextest archive (`pjrt-tests.tar.zst`) next to the CUDA archive.
- Run OpenXLA PJRT E2E tests on RunPod / fork `CI_gpu` via `cargo nextest run --archive-file`, keeping plugin wheel download as runtime-only.
- Lock the contract with workflow tests; bump archive cache keys.

Closes the remaining #1402 gap: CUDA and PJRT binaries in the hosted artifact, no Cargo compilation on RunPod.

Work log: `docs/worklogs/2026-07-18-issue-1402-pjrt-archive.md`

## Test plan
- [x] `python3.11 -m unittest scripts.ci.tests.test_workflow_contracts -v`
- [ ] Hosted RunPod: archive job builds both archives; GPU job has no `Compiling tenferro-xla`
- [ ] `pjrt_execution` tests pass from archive


Made with [Cursor](https://cursor.com)