### PR TITLE
ci: require CUDA 12.8-capable RunPod hosts

### DIFF
--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -277,7 +277,7 @@ jobs:
     steps:
       - name: Checkout trusted RunPod helpers
         uses: actions/checkout@v5
-      - name: Validate configured GPU IDs against live OpenAPI
+      - name: Validate GPU IDs and CUDA versions against live OpenAPI
         env:
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
         run: python3 scripts/ci/runpod_contract.py

--- a/docs/worklogs/2026-07-18-runpod-cuda-driver-filter.md
+++ b/docs/worklogs/2026-07-18-runpod-cuda-driver-filter.md
@@ -1,0 +1,41 @@
+# RunPod CUDA Driver Filter
+
+## Session summary
+
+Fixed intermittent RunPod GPU CI failures caused by assigning CUDA 12.8 PTX
+workloads to hosts whose drivers only support CUDA 12.4.
+
+## Context read
+
+- Failed RunPod run 29628588468: driver 550.127.05 advertised CUDA 12.4 while
+  the workflow loaded NVRTC 12.8, causing
+  `CUDA_ERROR_UNSUPPORTED_PTX_VERSION`
+- Successful same-main-revision run 29627753274: driver 610.43.02
+- RunPod `POST /pods` OpenAPI contract for `allowedCudaVersions`
+- `scripts/ci/runpod_client.py`, `runpod_contract.py`, and their contract tests
+
+## Chosen design
+
+- Request only RunPod hosts advertising CUDA 12.8, 12.9, or 13.0 through
+  `allowedCudaVersions`, matching the workflow's CUDA 12.8 compiler floor.
+- Validate configured CUDA versions against the live OpenAPI schema alongside
+  GPU type IDs before creating a paid pod.
+- Keep the runtime NVRTC version check as defense in depth.
+
+## Rejected alternatives
+
+- Changing only the container image cannot upgrade the host NVIDIA driver.
+- Checking only loaded NVRTC detects an old userspace toolkit but cannot stop
+  CUDA 12.8 PTX from reaching a CUDA 12.4 driver.
+
+## Verification
+
+- Focused RunPod client, contract, and workflow contract unit tests
+- Local CI-only PR gate
+- `actionlint` and Python bytecode compilation
+- Live RunPod OpenAPI schema validation
+
+## Residual risk
+
+- A paid RunPod GPU run is still required to validate scheduling behavior
+  end-to-end.

--- a/scripts/ci/runpod_client.py
+++ b/scripts/ci/runpod_client.py
@@ -116,6 +116,7 @@ def build_pod_payload(
     return {
         "cloudType": config["cloud_type"],
         "computeType": config["compute_type"],
+        "allowedCudaVersions": config["allowed_cuda_versions"],
         "name": f"tenferro-rs-gpu-ci-{os.environ.get('GITHUB_RUN_ID', 'local')}",
         "imageName": image_name,
         "gpuTypeIds": list(gpu_type_ids),

--- a/scripts/ci/runpod_config.json
+++ b/scripts/ci/runpod_config.json
@@ -3,6 +3,11 @@
   "openapi_url": "https://rest.runpod.io/v1/openapi.json",
   "cloud_type": "SECURE",
   "compute_type": "GPU",
+  "allowed_cuda_versions": [
+    "13.0",
+    "12.9",
+    "12.8"
+  ],
   "gpu_tiers": [
     {
       "name": "cost-preferred",

--- a/scripts/ci/runpod_contract.py
+++ b/scripts/ci/runpod_contract.py
@@ -66,6 +66,25 @@ def configured_gpu_tiers(
     return tiers
 
 
+def configured_cuda_versions(config: Mapping[str, object]) -> tuple[str, ...]:
+    """Validate and return the CUDA driver versions accepted for a pod."""
+
+    value = config.get("allowed_cuda_versions")
+    if (
+        not isinstance(value, Sequence)
+        or isinstance(value, (str, bytes))
+        or not value
+        or any(not isinstance(version, str) or not version for version in value)
+    ):
+        raise ContractError(
+            "runpod_config.json allowed_cuda_versions must be a nonempty "
+            "array of strings"
+        )
+    if len(set(value)) != len(value):
+        raise ContractError("allowed_cuda_versions must not contain duplicates")
+    return tuple(value)
+
+
 def resolve_local_ref(
     document: Mapping[str, object], ref: str
 ) -> Mapping[str, object]:
@@ -96,9 +115,9 @@ def _property(value: Mapping[str, object], name: str, context: str) -> object:
     return value[name]
 
 
-def extract_gpu_type_ids(document: Mapping[str, object]) -> frozenset[str]:
-    """Extract the accepted ``gpuTypeIds`` enum from ``POST /pods``."""
-
+def _pod_create_properties(
+    document: Mapping[str, object],
+) -> Mapping[str, object]:
     try:
         paths = _mapping(_property(document, "paths", "document"), "paths")
         pods = _mapping(_property(paths, "/pods", "paths"), "POST /pods")
@@ -133,23 +152,48 @@ def extract_gpu_type_ids(document: Mapping[str, object]) -> frozenset[str]:
         _property(schema, "properties", "POST /pods schema"),
         "POST /pods properties",
     )
-    gpu_types = _mapping(
-        _property(properties, "gpuTypeIds", "POST /pods properties"),
-        "POST /pods gpuTypeIds",
+    return properties
+
+
+def _extract_string_enum_property(
+    document: Mapping[str, object], property_name: str
+) -> frozenset[str]:
+    properties = _pod_create_properties(document)
+    property_schema = _mapping(
+        _property(properties, property_name, "POST /pods properties"),
+        f"POST /pods {property_name}",
     )
     items = _mapping(
-        _property(gpu_types, "items", "POST /pods gpuTypeIds"),
-        "POST /pods gpuTypeIds items",
+        _property(property_schema, "items", f"POST /pods {property_name}"),
+        f"POST /pods {property_name} items",
     )
-    enum_values = _property(items, "enum", "POST /pods gpuTypeIds items")
+    enum_values = _property(
+        items, "enum", f"POST /pods {property_name} items"
+    )
     if (
         not isinstance(enum_values, Sequence)
         or isinstance(enum_values, (str, bytes))
         or not enum_values
         or any(not isinstance(value, str) for value in enum_values)
     ):
-        raise ContractError("POST /pods gpuTypeIds enum must contain string GPU IDs")
+        raise ContractError(
+            f"POST /pods {property_name} enum must contain strings"
+        )
     return frozenset(enum_values)
+
+
+def extract_gpu_type_ids(document: Mapping[str, object]) -> frozenset[str]:
+    """Extract the accepted ``gpuTypeIds`` enum from ``POST /pods``."""
+
+    return _extract_string_enum_property(document, "gpuTypeIds")
+
+
+def extract_allowed_cuda_versions(
+    document: Mapping[str, object],
+) -> frozenset[str]:
+    """Extract accepted ``allowedCudaVersions`` values from ``POST /pods``."""
+
+    return _extract_string_enum_property(document, "allowedCudaVersions")
 
 
 def validate_gpu_type_ids(
@@ -162,6 +206,20 @@ def validate_gpu_type_ids(
     if invalid:
         raise ContractError(
             "configured RunPod GPU IDs absent from POST /pods schema: "
+            + ", ".join(invalid)
+        )
+
+
+def validate_cuda_versions(
+    document: Mapping[str, object], configured_versions: Sequence[str]
+) -> None:
+    """Require every configured CUDA version to occur in the current schema."""
+
+    accepted = extract_allowed_cuda_versions(document)
+    invalid = sorted(set(configured_versions) - accepted)
+    if invalid:
+        raise ContractError(
+            "configured RunPod CUDA versions absent from POST /pods schema: "
             + ", ".join(invalid)
         )
 
@@ -209,6 +267,7 @@ def main() -> int:
     try:
         config = _load_json(args.config)
         tiers = configured_gpu_tiers(config)
+        cuda_versions = configured_cuda_versions(config)
         configured_ids = [
             gpu_id for _name, gpu_ids in tiers for gpu_id in gpu_ids
         ]
@@ -225,8 +284,10 @@ def main() -> int:
                 raise ContractError("runpod_config.json openapi_url must be a string")
             schema = fetch_openapi(openapi_url, api_key)
         validate_gpu_type_ids(schema, configured_ids)
+        validate_cuda_versions(schema, cuda_versions)
         print(
-            f"RunPod OpenAPI accepts all {len(configured_ids)} configured GPU IDs."
+            f"RunPod OpenAPI accepts all {len(configured_ids)} configured GPU "
+            f"IDs and CUDA versions {', '.join(cuda_versions)}."
         )
     except ContractError as error:
         print(f"RunPod contract error: {error}", file=sys.stderr)

--- a/scripts/ci/tests/test_runpod_client.py
+++ b/scripts/ci/tests/test_runpod_client.py
@@ -221,6 +221,9 @@ class RunPodClientTests(unittest.TestCase):
         )
         self.assertEqual(payload["cloudType"], "SECURE")
         self.assertIs(payload["interruptible"], False)
+        self.assertEqual(
+            payload["allowedCudaVersions"], ["13.0", "12.9", "12.8"]
+        )
         self.assertEqual(payload["gpuTypeIds"], gpu_type_ids)
         self.assertEqual(payload["env"]["RUNNER_JIT_CONFIG"], "jit")
         self.assertEqual(payload["dockerStartCmd"], ["startup"])

--- a/scripts/ci/tests/test_runpod_contract.py
+++ b/scripts/ci/tests/test_runpod_contract.py
@@ -2,9 +2,12 @@ import unittest
 
 from scripts.ci.runpod_contract import (
     ContractError,
+    configured_cuda_versions,
     configured_gpu_tiers,
+    extract_allowed_cuda_versions,
     extract_gpu_type_ids,
     resolve_local_ref,
+    validate_cuda_versions,
     validate_gpu_type_ids,
 )
 
@@ -38,7 +41,11 @@ SCHEMA = {
                                 "NVIDIA GeForce RTX 4090",
                             ]
                         },
-                    }
+                    },
+                    "allowedCudaVersions": {
+                        "type": "array",
+                        "items": {"enum": ["13.0", "12.9", "12.8", "12.4"]},
+                    },
                 },
             }
         }
@@ -47,6 +54,17 @@ SCHEMA = {
 
 
 class RunPodContractTests(unittest.TestCase):
+    def test_configured_cuda_versions_are_required_and_unique(self) -> None:
+        self.assertEqual(
+            configured_cuda_versions(
+                {"allowed_cuda_versions": ["13.0", "12.9", "12.8"]}
+            ),
+            ("13.0", "12.9", "12.8"),
+        )
+        for value in ([], ["12.8", "12.8"], "12.8"):
+            with self.subTest(value=value), self.assertRaises(ContractError):
+                configured_cuda_versions({"allowed_cuda_versions": value})
+
     def test_configured_gpu_tiers_preserve_order(self) -> None:
         tiers = configured_gpu_tiers(
             {
@@ -92,12 +110,20 @@ class RunPodContractTests(unittest.TestCase):
             extract_gpu_type_ids(SCHEMA),
             frozenset({"NVIDIA A40", "NVIDIA GeForce RTX 4090"}),
         )
+        self.assertEqual(
+            extract_allowed_cuda_versions(SCHEMA),
+            frozenset({"13.0", "12.9", "12.8", "12.4"}),
+        )
 
     def test_validate_reports_every_invalid_configured_id(self) -> None:
         with self.assertRaisesRegex(
             ContractError, "Tesla T4.*Unknown GPU"
         ):
             validate_gpu_type_ids(SCHEMA, ["Tesla T4", "Unknown GPU"])
+
+    def test_validate_reports_unsupported_cuda_version(self) -> None:
+        with self.assertRaisesRegex(ContractError, "12.7"):
+            validate_cuda_versions(SCHEMA, ["12.8", "12.7"])
 
     def test_missing_post_schema_is_a_hard_error(self) -> None:
         with self.assertRaisesRegex(ContractError, "POST /pods"):
@@ -122,7 +148,7 @@ class RunPodContractTests(unittest.TestCase):
                 }
             },
         }
-        with self.assertRaisesRegex(ContractError, "string GPU IDs"):
+        with self.assertRaisesRegex(ContractError, "must contain strings"):
             extract_gpu_type_ids(schema)
 
 

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -1,3 +1,4 @@
+import json
 import re
 import unittest
 from pathlib import Path
@@ -151,6 +152,7 @@ class WorkflowContractTests(unittest.TestCase):
     def test_runpod_cuda_runtime_matches_cudarc_floor(self) -> None:
         text = read(".github/workflows/runpod-gpu-test.yml")
         cargo = read("Cargo.toml")
+        runpod_config = json.loads(read("scripts/ci/runpod_config.json"))
         workflow_cudarc = re.search(
             r'^  CUDARC_CUDA_VERSION: "(\d+)"$', text, re.MULTILINE
         )
@@ -175,6 +177,15 @@ class WorkflowContractTests(unittest.TestCase):
         )
         self.assertEqual(int(workflow_cudarc.group(1)), encoded_runtime)
         self.assertEqual(workflow_cudarc.group(1), cargo_cudarc.group(1))
+        required_runtime = (int(runtime.group(1)), int(runtime.group(2)))
+        allowed_versions = [
+            tuple(int(part) for part in version.split("."))
+            for version in runpod_config["allowed_cuda_versions"]
+        ]
+        self.assertIn(required_runtime, allowed_versions)
+        self.assertTrue(
+            all(version >= required_runtime for version in allowed_versions)
+        )
         self.assertIn("nvrtc.nvrtcVersion", text)
         self.assertIn("Loaded NVRTC version:", text)
         self.assertIn("if loaded < required:", text)


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

None. Follow-up to the intermittent failure in RunPod run 29628588468.

## Summary

- Filter RunPod pod creation to hosts advertising CUDA 12.8, 12.9, or 13.0 so CUDA 12.8 PTX is not sent to CUDA 12.4 drivers.
- Validate configured CUDA versions against RunPod's live OpenAPI contract before starting a paid pod.
- Add request-payload, schema-validation, and compiler-floor regression coverage.
- Same-root-cause scan covered the RunPod request builder, live contract preflight, and workflow/runtime CUDA floor; the existing NVRTC runtime check remains as defense in depth.

## Work log

- [RunPod CUDA driver filter](docs/worklogs/2026-07-18-runpod-cuda-driver-filter.md)

## Test plan

- [x] `uv run --python 3.11 bash scripts/check-pr-fast.sh --test 'python3 -m unittest scripts.ci.tests.test_runpod_contract scripts.ci.tests.test_runpod_client scripts.ci.tests.test_workflow_contracts'`
- [x] RunPod configuration validated against the live OpenAPI schema snapshot
- [x] `actionlint .github/workflows/runpod-gpu-test.yml`
- [ ] Paid RunPod GPU scheduling run (left to hosted CI)

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [ ] I ran local repository-rules LLM review and resolved or documented its findings. Attempted, but `DEEPSEEK_API_KEY` is not set in the local environment.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. Not applicable; this is a bug fix.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.

Made with [Cursor](https://cursor.com)