### PR TITLE
ci: embed the CUDA smoke script and detect container death via GraphQL

### DIFF
--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -71,6 +71,13 @@ on:
         required: false
         default: ""
         type: string
+      keep_failed_pods:
+        description: >-
+          Debug only: keep smoke-rejected pods alive (they keep billing!) so
+          their console logs can be inspected in the RunPod dashboard
+        required: false
+        default: false
+        type: boolean
   workflow_run:
     workflows: ["CI PR workspace tests"]
     types: [completed]
@@ -690,7 +697,7 @@ jobs:
           PROVISION_ORG: ${{ env.ORG_NAME }}
           PROVISION_RUNNER_LABEL: ${{ steps.vars.outputs.runner_label }}
           PROVISION_RUNNER_GROUP_ID: ${{ vars.RUNPOD_RUNNER_GROUP_ID || '1' }}
-          SMOKE_SOURCE_URL: https://raw.githubusercontent.com/${{ env.TENFERRO_REPO }}/${{ github.sha }}/scripts/ci/cuda_smoke_test.py
+          PROVISION_KEEP_FAILED_PODS: ${{ inputs.keep_failed_pods || 'false' }}
         run: |
           set -euo pipefail
 
@@ -726,19 +733,26 @@ jobs:
           free -h
           nproc
 
+          cat > /tmp/cuda_smoke_test.py <<'EMBEDDED_SMOKE_PY'
+          EOS
+          # Embed the smoke script from the trusted checkout between the
+          # startup-script halves so the pod needs no network fetch for it.
+          cat scripts/ci/cuda_smoke_test.py >> /tmp/runpod-startup.sh
+          cat >> /tmp/runpod-startup.sh <<'EOS'
+          EMBEDDED_SMOKE_PY
+
           # CUDA compatibility smoke proof (#1404): NVRTC-compile a tiny
           # kernel, load its PTX through the driver, launch, and synchronize
           # BEFORE registering the runner. On an incompatible host this
           # exits nonzero, the container stops without ever becoming a
           # runner, and the trusted provision loop deletes the pod and
           # retries the next candidate with the same immutable archive.
-          # The script is fetched at the trusted default-branch SHA baked
-          # into SMOKE_SOURCE_URL by the trusted start-runpod job. The
-          # long-lived RunPod/GitHub App credentials never reach the pod;
-          # the single-use JIT runner config necessarily does, so strip it
-          # from the smoke child's environment.
-          curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors \
-            -o /tmp/cuda_smoke_test.py "${SMOKE_SOURCE_URL}"
+          # The smoke script is EMBEDDED below by the trusted start-runpod
+          # job from its own checkout — no runtime network fetch, so pod-side
+          # rate limiting or DNS cannot break the proof. The long-lived
+          # RunPod/GitHub App credentials never reach the pod; the
+          # single-use JIT runner config necessarily does, so strip it from
+          # the smoke child's environment.
           env -u RUNNER_JIT_CONFIG python3 /tmp/cuda_smoke_test.py \
             --min-runtime-version "${SMOKE_MIN_RUNTIME_VERSION}" \
             --full-runtime-version "${SMOKE_FULL_RUNTIME_VERSION}" \

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -796,13 +796,14 @@ jobs:
             --startup-script /tmp/runpod-startup.sh \
             --image-name "${RUNPOD_IMAGE}" \
             --response-file /tmp/runpod-response.json \
-            --pod-env "SMOKE_SOURCE_URL=${SMOKE_SOURCE_URL}" \
             --pod-env "SMOKE_MIN_RUNTIME_VERSION=${CUDA_MIN_RUNTIME_VERSION}" \
             --pod-env "SMOKE_FULL_RUNTIME_VERSION=${CUDA_RUNTIME_VERSION}" \
             --pod-env "SMOKE_MIN_VRAM_GB=${smoke_min_vram_gb}"
 
       - name: Delete pod if runner startup failed
-        if: failure() && steps.create_pod.outputs.pod_id != ''
+        # keep_failed_pods debug dispatches preserve the last failed pod so
+        # its console logs stay readable in the RunPod dashboard.
+        if: failure() && steps.create_pod.outputs.pod_id != '' && inputs.keep_failed_pods != true
         env:
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
           POD_ID: ${{ steps.create_pod.outputs.pod_id }}
@@ -1294,6 +1295,10 @@ jobs:
 
     steps:
       - name: Delete RunPod pod
+        # In a keep_failed_pods debug dispatch, a failed provision keeps its
+        # rejected pods for console-log triage; only an ACCEPTED pod (the
+        # start-runpod job succeeded) is still cleaned up unconditionally.
+        if: inputs.keep_failed_pods != true || needs.start-runpod.result == 'success'
         env:
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
           POD_ID: ${{ needs.start-runpod.outputs.pod_id }}

--- a/docs/design/runpod-gpu-provisioning.md
+++ b/docs/design/runpod-gpu-provisioning.md
@@ -47,10 +47,11 @@ before any dependency setup or test execution:
    readback,
 6. VRAM check against `min_vram_gb`.
 
-The script is fetched at the trusted default-branch SHA
-(`${{ github.sha }}`), never from the PR ref, and receives its parameters
-through non-secret pod environment variables. On failure it exits nonzero,
-the container stops, and the pod never becomes a runner.
+The script is embedded into the startup script by the trusted
+start-runpod job from its own checkout (no pod-side network fetch), and
+receives its parameters through non-secret pod environment variables. On
+failure it exits nonzero, the container stops, and the pod never becomes a
+runner.
 
 ## Bounded provision loop
 
@@ -64,8 +65,10 @@ credentials stay GitHub-hosted):
   `run-gpu-tests` targets the accepted attempt's label;
 - create one candidate pod at a time, cheapest first;
 - watch two signals: the org runner registry (runner online = smoke proof
-  passed) and the pod status (`EXITED`/`TERMINATED` before registration =
-  smoke or startup failure);
+  passed) and the pod's container state via GraphQL (`desiredStatus` plus
+  the `runtime` object — RunPod keeps `desiredStatus` at RUNNING after the
+  container exits, so a null runtime after boot is the authoritative
+  startup-failure signal);
 - delete a rejected or timed-out pod immediately and move to the next
   candidate, reusing the same immutable per-run archive (#1403) — retries
   never compile Rust;
@@ -105,3 +108,7 @@ plane in `change_policy.py`, so changing them requires the GPU gate.
   promptly; the per-candidate timeout bounds the damage.
 - End-to-end behavior on paid hardware (smoke rejection, candidate
   failover, cost logging) can only be demonstrated in live CI runs.
+- Pod logs are not exposed by any RunPod API; the `keep_failed_pods`
+  dispatch input keeps rejected pods alive (billing!) so their console
+  logs can be read in the RunPod dashboard when a smoke failure needs
+  manual triage.

--- a/docs/worklogs/2026-07-18-runpod-smoke-startup-fix.md
+++ b/docs/worklogs/2026-07-18-runpod-smoke-startup-fix.md
@@ -1,0 +1,70 @@
+# RunPod Smoke Startup Fix After Live Verification
+
+## Session summary
+
+The first live verification dispatch of the #1404 provision loop failed:
+all four created pods (RTX 2000 Ada, L4, A40, RTX 5090) timed out after
+420 s without registering the runner, and the loop exhausted its bounded
+budget (which itself worked as designed, including price ordering,
+per-attempt JIT minting, immediate deletion, and cost logging). This
+session diagnosed the failure from the run logs and fixed the three
+implicated mechanisms.
+
+## Context read
+
+- Live run 29640572328 logs (provision attempts, timings, rejections)
+- Previous-flow timing evidence: pod creation to runner online took 31 s
+  (run 29638763285), so 420 s timeouts on every host indicate a startup
+  script failure, not slow hosts
+- RunPod API docs and community reports: pod logs are not exposed through
+  any public API; `desiredStatus` stays RUNNING after the container exits;
+  the GraphQL `runtime` object is the container-liveness signal
+
+## Diagnosis
+
+- The dead-pod detection polled REST `desiredStatus`, which never reflects
+  container exit — every startup failure burned the full per-candidate
+  timeout and was misreported as "timed out".
+- The most likely common-mode startup failure is the pod-side
+  `raw.githubusercontent.com` fetch of the smoke script (datacenter IPs
+  are aggressively rate-limited for unauthenticated raw fetches); the URL,
+  pod env, and script content were verified correct from the hosted side.
+
+## Chosen design
+
+- Embed `cuda_smoke_test.py` into the startup script from the trusted
+  checkout (heredoc splice, verified byte-identical and py_compile-clean
+  locally) — no pod-side network fetch remains for the proof.
+- Detect container death through GraphQL `pod { desiredStatus runtime }`:
+  once a runtime has been observed, a null runtime before runner
+  registration is an immediate, authoritative failure signal; boot-phase
+  null runtime (image pull) is tolerated.
+- Add a `keep_failed_pods` workflow_dispatch input (default false) that
+  keeps smoke-rejected pods alive for manual console-log triage in the
+  RunPod dashboard — the only place pod logs exist.
+
+## Rejected alternatives
+
+- Fetching the smoke script with authentication: would put a credential on
+  the pod.
+- Serving smoke diagnostics over a pod port: expands the pod's network
+  surface for a debug concern the dashboard already covers.
+- Raising the startup timeout: the 31 s historical baseline shows timeouts
+  were a symptom of broken failure detection, not slow startup.
+
+## Verification
+
+- 150 unit/contract tests pass (new: container-stop fast-fail, boot-grace,
+  keep-mode, GraphQL state parsing; updated: embed and debug-input
+  contracts)
+- `actionlint`; local render of the startup-script composition with a
+  byte-identical embedded script check
+- A follow-up live dispatch after merge revalidates end-to-end
+
+## Residual risks
+
+- If the live failure was not the raw fetch, the next dispatch will now
+  fail fast with "container stopped" and `keep_failed_pods=true` exposes
+  the console logs for direct diagnosis.
+- The GraphQL runtime signal is outside the versioned REST contract;
+  transient query failures degrade to the bounded timeout.

--- a/scripts/ci/runpod_provision.py
+++ b/scripts/ci/runpod_provision.py
@@ -50,8 +50,24 @@ from scripts.ci.runpod_contract import configured_gpu_tiers
 from scripts.ci.runpod_pricing import candidate_plan
 
 # Pod desiredStatus values that mean the startup script stopped without
-# registering the runner (smoke failure or setup failure).
+# registering the runner (smoke failure or setup failure). desiredStatus
+# alone is NOT sufficient: RunPod keeps it at RUNNING after the container
+# exits, so container death is detected through the GraphQL runtime field
+# (present while the container runs, null once it stops).
 _DEAD_POD_STATUSES = frozenset({"EXITED", "TERMINATED", "DEAD", "STOPPED"})
+
+
+@dataclasses.dataclass(frozen=True)
+class PodState:
+    """One observation of a pod: desired status plus container liveness.
+
+    ``has_runtime`` is None when the observation could not determine
+    container state (transient poll failure); True while the container is
+    running; False once GraphQL reports no runtime for the pod.
+    """
+
+    desired: str | None
+    has_runtime: bool | None
 
 
 class ProvisionExhaustedError(RunPodError):
@@ -102,9 +118,10 @@ def provision(
     mint_runner: Callable[[str], str],
     create: Callable[[CreateRequest, str], CreateResult],
     runner_online: Callable[[str], bool],
-    pod_status: Callable[[str], str | None],
+    pod_status: Callable[[str], PodState],
     delete_pod: Callable[[str], bool],
     publish_pod_id: Callable[[str], None] = lambda pod_id: None,
+    keep_failed_pods: bool = False,
     monotonic: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
 ) -> ProvisionResult:
@@ -127,7 +144,17 @@ def provision(
     attempts = 0
     last_reason = "no candidates attempted"
 
+    kept_pods: list[str] = []
+
     def reject_and_delete(pod_id: str, description: str) -> None:
+        if keep_failed_pods:
+            kept_pods.append(pod_id)
+            print(
+                f"DEBUG MODE: keeping failed pod {pod_id} ({description}) "
+                "for console-log inspection. It keeps billing until deleted "
+                "manually in the RunPod dashboard."
+            )
+            return
         if delete_pod(pod_id):
             print(f"Deleted pod {pod_id} before any test setup.")
             return
@@ -178,19 +205,32 @@ def provision(
         started = monotonic()
         deadline = started + startup_timeout
         reason: str | None = None
+        runtime_seen = False
         while True:
             # Check the pod BEFORE trusting the runner registry: the two
             # signals are independently eventually consistent, and a stale
             # online record (or a runner that registered and died) must not
             # accept a dead pod.
-            status = pod_status(result.pod_id)
-            if status in _DEAD_POD_STATUSES:
+            state = pod_status(result.pod_id)
+            if state.desired in _DEAD_POD_STATUSES:
                 reason = (
-                    f"pod exited before runner registration (status {status}); "
+                    f"pod exited before runner registration (status "
+                    f"{state.desired}); CUDA smoke proof or startup failed"
+                )
+                break
+            if state.has_runtime:
+                runtime_seen = True
+            elif runtime_seen and state.has_runtime is False:
+                # The container ran and then stopped without registering
+                # the runner: the startup script (usually the CUDA smoke
+                # proof) failed. desiredStatus stays RUNNING in this case,
+                # so this is the authoritative fast-fail signal.
+                reason = (
+                    "container stopped before runner registration; "
                     "CUDA smoke proof or startup failed"
                 )
                 break
-            if runner_online(label) and status is not None:
+            if runner_online(label) and state.desired is not None:
                 startup_seconds = monotonic() - started
                 print(
                     f"Runner {label} online: pod {result.pod_id} passed the "
@@ -225,8 +265,10 @@ def provision(
         reject_and_delete(result.pod_id, reason or "startup failure")
         last_reason = reason or "unknown failure"
 
+    kept = f"; kept debug pods: {', '.join(kept_pods)}" if kept_pods else ""
     raise ProvisionExhaustedError(
-        f"all {attempts} bounded provision attempts failed; last: {last_reason}"
+        f"all {attempts} bounded provision attempts failed; "
+        f"last: {last_reason}{kept}"
     )
 
 
@@ -335,18 +377,6 @@ def _pod_api(api_url: str, api_key: str):
             print(f"RunPod pod API transport failure (transient): {error}")
             return 0, b""
 
-    def status(pod_id: str) -> str | None:
-        code, body = request(pod_id, "GET")
-        if code != 200:
-            print(f"Pod status poll returned HTTP {code} (transient).")
-            return None
-        try:
-            payload = json.loads(body)
-        except json.JSONDecodeError:
-            return None
-        value = payload.get("desiredStatus") if isinstance(payload, Mapping) else None
-        return str(value) if value else None
-
     def delete(pod_id: str, *, retries: int = 3) -> bool:
         """Delete a pod and only report success when it is confirmed gone."""
 
@@ -366,7 +396,56 @@ def _pod_api(api_url: str, api_key: str):
                 time.sleep(5.0)
         return False
 
-    return status, delete
+    return delete
+
+
+def _pod_state_checker(graphql_url: str, api_key: str) -> Callable[[str], PodState]:
+    """Observe desiredStatus AND container liveness through GraphQL.
+
+    The REST desiredStatus stays RUNNING after the container exits; only
+    the GraphQL ``runtime`` object (null once the container stops) tells
+    whether the startup script is still alive.
+    """
+
+    query = (
+        "query Pod($input: PodFilter!) { pod(input: $input) "
+        "{ desiredStatus runtime { uptimeInSeconds } } }"
+    )
+
+    def check(pod_id: str) -> PodState:
+        body = json.dumps(
+            {"query": query, "variables": {"input": {"podId": pod_id}}}
+        ).encode()
+        request = urllib.request.Request(
+            graphql_url,
+            data=body,
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "User-Agent": "tenferro-ci-runpod-provision/1",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30.0) as response:
+                payload = json.loads(response.read())
+        except (OSError, json.JSONDecodeError) as error:
+            print(f"Pod state poll failed (transient): {error}")
+            return PodState(desired=None, has_runtime=None)
+        data = payload.get("data") if isinstance(payload, Mapping) else None
+        pod = data.get("pod") if isinstance(data, Mapping) else None
+        if not isinstance(pod, Mapping):
+            if isinstance(payload, Mapping) and payload.get("errors"):
+                print(f"Pod state query errors (transient): {payload['errors']!r}")
+            return PodState(desired=None, has_runtime=None)
+        desired = pod.get("desiredStatus")
+        return PodState(
+            desired=str(desired) if desired else None,
+            has_runtime=pod.get("runtime") is not None,
+        )
+
+    return check
 
 
 def _publish(result: ProvisionResult) -> None:
@@ -472,7 +551,14 @@ def main() -> int:
                 secrets=(api_key, jit_config),
             )
 
-        pod_status, delete_pod = _pod_api(str(config["api_url"]), api_key)
+        delete_pod = _pod_api(str(config["api_url"]), api_key)
+        pod_status = _pod_state_checker(
+            str(config.get("graphql_url", "https://api.runpod.io/graphql")),
+            api_key,
+        )
+        keep_failed_pods = (
+            os.environ.get("PROVISION_KEEP_FAILED_PODS", "").lower() == "true"
+        )
 
         def publish_pod_id(pod_id: str) -> None:
             output_path = os.environ.get("GITHUB_OUTPUT")
@@ -490,6 +576,7 @@ def main() -> int:
             pod_status=pod_status,
             delete_pod=delete_pod,
             publish_pod_id=publish_pod_id,
+            keep_failed_pods=keep_failed_pods,
         )
         args.response_file.write_bytes(result.body)
         _publish(result)

--- a/scripts/ci/tests/test_runpod_provision.py
+++ b/scripts/ci/tests/test_runpod_provision.py
@@ -10,6 +10,8 @@ from scripts.ci.runpod_client import (
 )
 from scripts.ci.runpod_provision import (
     PodLeakError,
+    PodState,
+    _pod_state_checker,
     ProvisionExhaustedError,
     _pod_api,
     parse_cost_per_hr,
@@ -28,6 +30,10 @@ PLAN = [
     ("cost-preferred", ["NVIDIA RTX A4000", "NVIDIA A40"]),
     ("premium", ["NVIDIA L40S"]),
 ]
+
+
+def live(desired: str = "RUNNING") -> PodState:
+    return PodState(desired=desired, has_runtime=True)
 
 
 def created(pod_id: str, gpu: str, tier: str, cost: float = 0.44) -> CreateResult:
@@ -78,7 +84,7 @@ class ProvisionTests(unittest.TestCase):
             mint_runner=lambda label: f"jit-{label}",
             create=lambda req, jit: created("pod-1", "NVIDIA A40", req.tier_name),
             runner_online=runner_online,
-            pod_status=lambda pod_id: "RUNNING",
+            pod_status=lambda pod_id: live(),
             delete_pod=lambda pod_id: (deleted.append(pod_id), True)[1],
             monotonic=clock.monotonic,
             sleep=clock.sleep,
@@ -115,7 +121,7 @@ class ProvisionTests(unittest.TestCase):
             mint_runner=lambda label: f"jit-{label}",
             create=create,
             runner_online=lambda label: current["id"] in accepted,
-            pod_status=lambda pod_id: statuses[pod_id],
+            pod_status=lambda pod_id: live(statuses[pod_id]),
             delete_pod=lambda pod_id: (deleted.append(pod_id), True)[1],
             publish_pod_id=published.append,
             monotonic=clock.monotonic,
@@ -137,7 +143,7 @@ class ProvisionTests(unittest.TestCase):
                 mint_runner=lambda label: f"jit-{label}",
                 create=lambda req, jit: created("pod-slow", "NVIDIA A40", req.tier_name),
                 runner_online=lambda label: False,
-                pod_status=lambda pod_id: "RUNNING",
+                pod_status=lambda pod_id: live(),
                 delete_pod=lambda pod_id: (deleted.append(pod_id), True)[1],
                 monotonic=clock.monotonic,
                 sleep=clock.sleep,
@@ -161,7 +167,7 @@ class ProvisionTests(unittest.TestCase):
             mint_runner=lambda label: f"jit-{label}",
             create=create,
             runner_online=lambda label: True,
-            pod_status=lambda pod_id: "RUNNING",
+            pod_status=lambda pod_id: live(),
             delete_pod=lambda pod_id: self.fail("no pod to delete"),
             monotonic=clock.monotonic,
             sleep=clock.sleep,
@@ -197,7 +203,7 @@ class ProvisionTests(unittest.TestCase):
             mint_runner=mint_runner,
             create=lambda req, jit: (jits.append(jit), next(pods))[1],
             runner_online=runner_online,
-            pod_status=lambda pod_id: statuses[pod_id],
+            pod_status=lambda pod_id: live(statuses[pod_id]),
             delete_pod=lambda pod_id: True,
             monotonic=clock.monotonic,
             sleep=clock.sleep,
@@ -230,7 +236,7 @@ class ProvisionTests(unittest.TestCase):
             mint_runner=lambda label: f"jit-{label}",
             create=create,
             runner_online=lambda label: True,
-            pod_status=lambda pod_id: "RUNNING",
+            pod_status=lambda pod_id: live(),
             delete_pod=lambda pod_id: (deleted.append(pod_id), True)[1],
             publish_pod_id=published.append,
             monotonic=clock.monotonic,
@@ -256,7 +262,7 @@ class ProvisionTests(unittest.TestCase):
                 mint_runner=lambda label: f"jit-{label}",
                 create=create,
                 runner_online=lambda label: False,
-                pod_status=lambda pod_id: "EXITED",
+                pod_status=lambda pod_id: live("EXITED"),
                 delete_pod=lambda pod_id: False,
                 monotonic=clock.monotonic,
                 sleep=clock.sleep,
@@ -284,13 +290,83 @@ class ProvisionTests(unittest.TestCase):
             # died-after-registering record); the dead pod must still be
             # rejected.
             runner_online=lambda label: True,
-            pod_status=lambda pod_id: statuses[pod_id],
+            pod_status=lambda pod_id: live(statuses[pod_id]),
             delete_pod=lambda pod_id: (deleted.append(pod_id), True)[1],
             monotonic=clock.monotonic,
             sleep=clock.sleep,
         )
         self.assertEqual(result.pod_id, "pod-live")
         self.assertEqual(deleted, ["pod-dead"])
+
+    def test_container_stop_is_detected_without_desired_status_change(self) -> None:
+        """desiredStatus stays RUNNING after container exit; runtime is the signal."""
+
+        clock = Clock()
+        states = iter(
+            [
+                PodState(desired="RUNNING", has_runtime=True),
+                PodState(desired="RUNNING", has_runtime=False),
+            ]
+        )
+        deleted: list[str] = []
+        with self.assertRaises(ProvisionExhaustedError) as caught:
+            provision(
+                {**CONFIG, "max_provision_attempts": 1},
+                PLAN,
+                label_prefix="runpod-1-1",
+                mint_runner=lambda label: f"jit-{label}",
+                create=lambda req, jit: created("pod-dead", "NVIDIA A40", req.tier_name),
+                runner_online=lambda label: False,
+                pod_status=lambda pod_id: next(states),
+                delete_pod=lambda pod_id: (deleted.append(pod_id), True)[1],
+                monotonic=clock.monotonic,
+                sleep=clock.sleep,
+            )
+        self.assertEqual(deleted, ["pod-dead"])
+        self.assertIn("container stopped", str(caught.exception))
+        # Detected on the second poll, long before the startup timeout.
+        self.assertLess(clock.now, CONFIG["startup_timeout_seconds"])
+
+    def test_boot_phase_null_runtime_is_not_treated_as_death(self) -> None:
+        clock = Clock()
+        boot = {"polls": 0}
+
+        def pod_status(pod_id: str) -> PodState:
+            boot["polls"] += 1
+            # Image pull phase: runtime not yet present.
+            return PodState(desired="RUNNING", has_runtime=boot["polls"] > 3)
+
+        result = provision(
+            CONFIG,
+            PLAN,
+            label_prefix="runpod-1-1",
+            mint_runner=lambda label: f"jit-{label}",
+            create=lambda req, jit: created("pod-boot", "NVIDIA A40", req.tier_name),
+            runner_online=lambda label: boot["polls"] > 5,
+            pod_status=pod_status,
+            delete_pod=lambda pod_id: self.fail("healthy pod must not be deleted"),
+            monotonic=clock.monotonic,
+            sleep=clock.sleep,
+        )
+        self.assertEqual(result.pod_id, "pod-boot")
+
+    def test_keep_failed_pods_skips_deletion_and_reports_ids(self) -> None:
+        clock = Clock()
+        with self.assertRaises(ProvisionExhaustedError) as caught:
+            provision(
+                {**CONFIG, "max_provision_attempts": 1},
+                PLAN,
+                label_prefix="runpod-1-1",
+                mint_runner=lambda label: f"jit-{label}",
+                create=lambda req, jit: created("pod-debug", "NVIDIA A40", req.tier_name),
+                runner_online=lambda label: False,
+                pod_status=lambda pod_id: live("EXITED"),
+                delete_pod=lambda pod_id: self.fail("debug mode must not delete"),
+                keep_failed_pods=True,
+                monotonic=clock.monotonic,
+                sleep=clock.sleep,
+            )
+        self.assertIn("kept debug pods: pod-debug", str(caught.exception))
 
     def test_exhaustion_is_explicit_and_bounded(self) -> None:
         clock = Clock()
@@ -308,7 +384,7 @@ class ProvisionTests(unittest.TestCase):
                 mint_runner=lambda label: f"jit-{label}",
                 create=create,
                 runner_online=lambda label: True,
-                pod_status=lambda pod_id: "RUNNING",
+                pod_status=lambda pod_id: live(),
                 delete_pod=lambda pod_id: True,
                 monotonic=clock.monotonic,
                 sleep=clock.sleep,
@@ -326,14 +402,45 @@ class PodApiTransportTests(unittest.TestCase):
         def failing_urlopen(*args, **kwargs):
             raise urllib.error.URLError("dns hiccup")
 
-        pod_status, delete_pod = _pod_api("https://rest.example/v1/pods", "key")
+        delete_pod = _pod_api("https://rest.example/v1/pods", "key")
+        pod_status = _pod_state_checker("https://gql.example/graphql", "key")
         with mock.patch.object(
             provision_module.urllib.request, "urlopen", failing_urlopen
         ), mock.patch.object(provision_module.time, "sleep"):
-            # status: transient -> None (keep waiting), no exception
-            self.assertIsNone(pod_status("pod-1"))
+            # status: transient -> unknown state (keep waiting), no exception
+            state = pod_status("pod-1")
+            self.assertIsNone(state.desired)
+            self.assertIsNone(state.has_runtime)
             # delete: retries then reports unconfirmed -> False, no exception
             self.assertFalse(delete_pod("pod-1"))
+
+    def test_pod_state_reads_desired_status_and_runtime(self) -> None:
+        import io
+
+        payloads = iter(
+            [
+                b'{"data": {"pod": {"desiredStatus": "RUNNING", "runtime": {"uptimeInSeconds": 12}}}}',
+                b'{"data": {"pod": {"desiredStatus": "RUNNING", "runtime": null}}}',
+            ]
+        )
+
+        class FakeResponse(io.BytesIO):
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        pod_status = _pod_state_checker("https://gql.example/graphql", "key")
+        with mock.patch.object(
+            provision_module.urllib.request,
+            "urlopen",
+            lambda *a, **k: FakeResponse(next(payloads)),
+        ):
+            first = pod_status("pod-1")
+            self.assertEqual(first, PodState(desired="RUNNING", has_runtime=True))
+            second = pod_status("pod-1")
+            self.assertEqual(second, PodState(desired="RUNNING", has_runtime=False))
 
 
 if __name__ == "__main__":

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -139,6 +139,20 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("env -u RUNNER_JIT_CONFIG python3 /tmp/cuda_smoke_test.py", create)
         # Debug switch: keep smoke-rejected pods for console-log triage.
         self.assertIn("PROVISION_KEEP_FAILED_PODS: ${{ inputs.keep_failed_pods || 'false' }}", create)
+        # The stale fetch env must be fully gone: a leftover expansion under
+        # set -u would abort every provision run before pod creation.
+        whole = read(".github/workflows/runpod-gpu-test.yml")
+        self.assertNotIn("SMOKE_SOURCE_URL", whole)
+        # Debug retention must also gate the workflow-side deletion paths,
+        # or the cleanup steps would delete the pod being inspected.
+        self.assertIn(
+            "if: failure() && steps.create_pod.outputs.pod_id != '' && inputs.keep_failed_pods != true",
+            whole,
+        )
+        self.assertIn(
+            "if: inputs.keep_failed_pods != true || needs.start-runpod.result == 'success'",
+            whole,
+        )
         # JIT configs are minted per candidate attempt inside the provision
         # loop; the workflow must not pre-mint a single shared config, and
         # run-gpu-tests must target the ACCEPTED attempt's label.

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -126,9 +126,19 @@ class WorkflowContractTests(unittest.TestCase):
         smoke = create.index("cuda_smoke_test.py")
         runner = create.index("./run.sh --jitconfig")
         self.assertLess(smoke, runner)
+        # The smoke script is embedded from the trusted checkout, never
+        # fetched over the network from the pod (raw.githubusercontent is
+        # rate-limited from datacenter IPs and its failure looked like a
+        # startup timeout in live runs).
+        self.assertIn("cat scripts/ci/cuda_smoke_test.py >> /tmp/runpod-startup.sh", create)
+        self.assertNotIn("raw.githubusercontent.com", create)
+        embed = create.index("cat > /tmp/cuda_smoke_test.py <<'EMBEDDED_SMOKE_PY'")
+        self.assertLess(embed, create.index("env -u RUNNER_JIT_CONFIG python3 /tmp/cuda_smoke_test.py"))
         # The single credential that reaches the pod (the one-shot JIT
         # runner config) must be stripped from the smoke child's env.
         self.assertIn("env -u RUNNER_JIT_CONFIG python3 /tmp/cuda_smoke_test.py", create)
+        # Debug switch: keep smoke-rejected pods for console-log triage.
+        self.assertIn("PROVISION_KEEP_FAILED_PODS: ${{ inputs.keep_failed_pods || 'false' }}", create)
         # JIT configs are minted per candidate attempt inside the provision
         # loop; the workflow must not pre-mint a single shared config, and
         # run-gpu-tests must target the ACCEPTED attempt's label.
@@ -159,11 +169,9 @@ class WorkflowContractTests(unittest.TestCase):
         # Both acceptance paths (discovered toolkit and cached seed tree)
         # must run the completeness check.
         self.assertGreaterEqual(configure.count("cuda_tree_has_runtime_libs "), 2)
-        self.assertIn("${{ github.sha }}/scripts/ci/cuda_smoke_test.py", create)
         self.assertNotIn("TENFERRO_REF", create)
         # Smoke parameters flow through non-secret pod env only.
         for pod_env in (
-            "SMOKE_SOURCE_URL=",
             "SMOKE_MIN_RUNTIME_VERSION=",
             "SMOKE_FULL_RUNTIME_VERSION=",
             "SMOKE_MIN_VRAM_GB=",


### PR DESCRIPTION
## Summary

Follow-up fix for #1404 after the first live verification dispatch (run 29640572328) failed: all four created pods (RTX 2000 Ada, L4, A40, RTX 5090) "timed out" after 420s without registering a runner, while the historical pod-boot baseline is 31s — meaning the startup script was failing on every host and the failure mode was invisible.

Root causes and fixes:

- **Dead-container detection was broken**: REST `desiredStatus` stays `RUNNING` after the container exits, so every startup failure burned the full per-candidate timeout. The provision loop now polls GraphQL `pod { desiredStatus runtime }` and treats a null `runtime` after boot as an immediate, authoritative startup-failure signal (boot-phase null runtime during image pull is tolerated).
- **Pod-side network fetch removed**: the smoke script was fetched from `raw.githubusercontent.com` at pod startup — aggressively rate-limited from datacenter IPs and the prime suspect for the common-mode failure (URL, pod env, and content were verified correct from the hosted side). The trusted `start-runpod` job now embeds `cuda_smoke_test.py` into the startup script from its own checkout via a heredoc splice (verified byte-identical and `py_compile`-clean in a local render).
- **Debuggability**: pod logs are not exposed by any RunPod API. A new `keep_failed_pods` workflow_dispatch input (default false) keeps smoke-rejected pods alive so their console logs can be read in the RunPod dashboard; kept pod ids are listed in the exhaustion error.

The live run otherwise validated the #1404 design: price-ordered candidates ($0.24 → $0.25 → $0.39), per-attempt JIT minting (`-c1`…`-c6`), immediate deletion (HTTP 204), static-tier fallback, cost estimates per rejection, and the explicit bounded-exhaustion failure.

Work log: `docs/worklogs/2026-07-18-runpod-smoke-startup-fix.md`

## Verification

- Focused local verification: `bash scripts/check-pr-fast.sh --test 'python3.11 -m unittest <workflow/pricing/provision/smoke/client/contract/change-policy suites>'` (passed; 150 tests total, new coverage: container-stop fast-fail, boot-grace, keep-mode, GraphQL state parsing, embed/debug-input contracts)
- `actionlint` clean; startup-script composition rendered locally with a byte-identical embedded-script diff check
- `scripts/repository-rules-review.py` unavailable locally (`DEEPSEEK_API_KEY` unset)
- A post-merge live dispatch revalidates end-to-end; if the failure was not the raw fetch, it will now fail fast with "container stopped" and `keep_failed_pods=true` exposes the console logs

## Documentation

- Updated `docs/design/runpod-gpu-provisioning.md` (embedded smoke delivery, GraphQL container-state signal, log-triage input) and added the work log.

Generated with [Claude Code](https://claude.com/claude-code)
