### PR TITLE
ci: load NVRTC from the selected runtime paths, not the image toolkit

### DIFF
--- a/docs/worklogs/2026-07-18-runpod-smoke-startup-fix.md
+++ b/docs/worklogs/2026-07-18-runpod-smoke-startup-fix.md
@@ -61,6 +61,18 @@ implicated mechanisms.
   byte-identical embedded script check
 - A follow-up live dispatch after merge revalidates end-to-end
 
+## Live-log confirmation and final fix
+
+A `keep`-free re-dispatch after the embed/GraphQL fix reached the pods and
+the RunPod console log gave the definitive root cause: on a driver-13.0 L4
+host, `cuda-nvrtc-12-8` was installed correctly but the smoke loaded
+NVRTC **11.8** — the bare `libnvrtc.so` from the pod image's CUDA 11.8
+toolkit shadows the selected tier because it sits in the default linker
+path. The version-consistency check then correctly failed the proof on
+every otherwise-compatible host. Fixed by ordering NVRTC load candidates
+most-specific-first (`/usr/local/cuda-X.Y/...`) and dropping the bare
+`libnvrtc.so` name entirely (`nvrtc_library_candidates`, unit-tested).
+
 ## Residual risks
 
 - If the live failure was not the raw fetch, the next dispatch will now

--- a/scripts/ci/cuda_smoke_test.py
+++ b/scripts/ci/cuda_smoke_test.py
@@ -122,20 +122,30 @@ def _load_library(names: list[str]) -> ctypes.CDLL:
     raise SmokeFailure(f"none of {names} could be loaded: {last_error}")
 
 
+def nvrtc_library_candidates(runtime: tuple[int, int]) -> list[str]:
+    """NVRTC load order for the SELECTED runtime, most specific first.
+
+    The pod image ships an older CUDA toolkit whose ``libnvrtc.so`` sits in
+    the default linker path, so generic names must never be tried before
+    the versioned install paths of the runtime tier the smoke selected:
+    loading the image's NVRTC (observed: 11.8 via bare ``libnvrtc.so``)
+    fails the proof on every otherwise-compatible host.
+    """
+
+    version = f"{runtime[0]}.{runtime[1]}"
+    major = runtime[0]
+    return [
+        f"/usr/local/cuda-{version}/lib64/libnvrtc.so.{major}",
+        f"/usr/local/cuda-{version}/targets/x86_64-linux/lib/libnvrtc.so.{major}",
+        f"libnvrtc.so.{major}",
+    ]
+
+
 class CudaBindings:
     """Thin ctypes wrapper; tests substitute a fake with the same surface."""
 
     def __init__(self, runtime: tuple[int, int]) -> None:
-        major = runtime[0]
-        self.nvrtc = _load_library(
-            [
-                f"libnvrtc.so.{major}",
-                "libnvrtc.so",
-                f"/usr/local/cuda-{runtime[0]}.{runtime[1]}/lib64/libnvrtc.so.{major}",
-                f"/usr/local/cuda-{runtime[0]}.{runtime[1]}"
-                f"/targets/x86_64-linux/lib/libnvrtc.so.{major}",
-            ]
-        )
+        self.nvrtc = _load_library(nvrtc_library_candidates(runtime))
         self.cuda = _load_library(["libcuda.so.1", "libcuda.so"])
 
     def nvrtc_version(self) -> tuple[int, int]:

--- a/scripts/ci/tests/test_cuda_smoke_test.py
+++ b/scripts/ci/tests/test_cuda_smoke_test.py
@@ -2,6 +2,7 @@ import unittest
 
 from scripts.ci.cuda_smoke_test import (
     EXPECTED_OUTPUT,
+    nvrtc_library_candidates,
     SmokeFailure,
     nvrtc_arch_option,
     nvrtc_package,
@@ -38,6 +39,24 @@ class VersionLogicTests(unittest.TestCase):
         )
         with self.assertRaises(SmokeFailure):
             select_runtime_version((12, 2), minimum=minimum, full=full)
+
+    def test_nvrtc_load_order_prefers_selected_runtime_paths(self) -> None:
+        """The image's older bare libnvrtc.so must never shadow the tier.
+
+        Observed live: bare "libnvrtc.so" resolved to the pod image's NVRTC
+        11.8 and failed the proof on every otherwise-compatible host.
+        """
+
+        candidates = nvrtc_library_candidates((12, 8))
+        self.assertEqual(
+            candidates,
+            [
+                "/usr/local/cuda-12.8/lib64/libnvrtc.so.12",
+                "/usr/local/cuda-12.8/targets/x86_64-linux/lib/libnvrtc.so.12",
+                "libnvrtc.so.12",
+            ],
+        )
+        self.assertNotIn("libnvrtc.so", candidates)
 
     def test_package_and_arch_option_naming(self) -> None:
         self.assertEqual(nvrtc_package((12, 8)), "cuda-nvrtc-12-8")


### PR DESCRIPTION
## Summary

Final root-cause fix for the #1404 smoke failures, diagnosed from the RunPod console log of the live verification pod (L4, driver CUDA API 13.0):

```
cuda-nvrtc-12-8 is already the newest version (12.8.93-1).
Driver CUDA API: 13.0
Selected CUDA runtime tier: 12.8
Loaded NVRTC version: 11.8
SMOKE FAIL: loaded NVRTC 11.8 is older than the selected runtime 12.8
```

The pod image's CUDA 11.8 toolkit places a bare `libnvrtc.so` in the default linker path, and the smoke's load order tried generic names before the selected tier's install paths — so it loaded NVRTC 11.8 on every host and the (correct) version-consistency check rejected every otherwise-compatible candidate. The smoke mechanism itself worked exactly as designed; only the library search order was wrong.

Fix: `nvrtc_library_candidates()` orders candidates most-specific-first (`/usr/local/cuda-X.Y/lib64`, `targets/x86_64-linux/lib`, then the versioned soname `libnvrtc.so.<major>`) and drops the bare `libnvrtc.so` name entirely; unit test pins the order.

Note for the required `CI GPU gate`: it executes main's definition, which contains this very bug, so it cannot pass on this PR (same bootstrap deadlock as #1414) — it will need an admin merge after the CPU checks pass. A post-merge dispatch revalidates end-to-end.

Work log: `docs/worklogs/2026-07-18-runpod-smoke-startup-fix.md` (updated with the console-log confirmation)

## Verification

- `bash scripts/check-pr-fast.sh --test 'python3.11 -m unittest scripts.ci.tests.test_cuda_smoke_test scripts.ci.tests.test_workflow_contracts scripts.ci.tests.test_runpod_provision'` (passed)
- Root cause confirmed against the live pod console log above
- `scripts/repository-rules-review.py` unavailable locally (`DEEPSEEK_API_KEY` unset)

Generated with [Claude Code](https://claude.com/claude-code)
