### PR TITLE
ci: preload libnvrtc-builtins so NVRTC compilation can resolve it

### DIFF
--- a/docs/worklogs/2026-07-18-runpod-smoke-startup-fix.md
+++ b/docs/worklogs/2026-07-18-runpod-smoke-startup-fix.md
@@ -73,6 +73,19 @@ every otherwise-compatible host. Fixed by ordering NVRTC load candidates
 most-specific-first (`/usr/local/cuda-X.Y/...`) and dropping the bare
 `libnvrtc.so` name entirely (`nvrtc_library_candidates`, unit-tested).
 
+## Second live-log confirmation
+
+The next dispatch confirmed the NVRTC load-order fix (loaded 12.8 on a
+driver-13.0 RTX A4000 host, compute capability and VRAM checks passed)
+and exposed the final layer: NVRTC dlopens ``libnvrtc-builtins.so.12.8``
+by soname at compile time (status 7, ``failed to open``), and the tier's
+install directory is not on the default linker path. Fixed by preloading
+the builtins library from its absolute path with RTLD_GLOBAL before any
+compilation (``nvrtc_builtins_candidates``, unit-tested). The console log
+also confirmed RunPod restarts the container command on exit, so
+incompatible candidates surface as startup timeouts rather than
+container-stop events.
+
 ## Residual risks
 
 - If the live failure was not the raw fetch, the next dispatch will now

--- a/scripts/ci/cuda_smoke_test.py
+++ b/scripts/ci/cuda_smoke_test.py
@@ -122,6 +122,18 @@ def _load_library(names: list[str]) -> ctypes.CDLL:
     raise SmokeFailure(f"none of {names} could be loaded: {last_error}")
 
 
+def _load_library_global(names: list[str]) -> ctypes.CDLL:
+    """Like _load_library but with RTLD_GLOBAL so soname dlopens resolve."""
+
+    last_error: OSError | None = None
+    for name in names:
+        try:
+            return ctypes.CDLL(name, mode=ctypes.RTLD_GLOBAL)
+        except OSError as error:
+            last_error = error
+    raise SmokeFailure(f"none of {names} could be loaded: {last_error}")
+
+
 def nvrtc_library_candidates(runtime: tuple[int, int]) -> list[str]:
     """NVRTC load order for the SELECTED runtime, most specific first.
 
@@ -141,10 +153,33 @@ def nvrtc_library_candidates(runtime: tuple[int, int]) -> list[str]:
     ]
 
 
+def nvrtc_builtins_candidates(runtime: tuple[int, int]) -> list[str]:
+    """Load order for libnvrtc-builtins, most specific first.
+
+    NVRTC dlopens ``libnvrtc-builtins.so.X.Y`` by soname at COMPILE time,
+    and the selected tier's install directory is not on the default linker
+    search path (observed live: ``failed to open libnvrtc-builtins.so.12.8``
+    with status 7). Preloading it with RTLD_GLOBAL from its absolute path
+    lets that soname lookup resolve against the already-loaded library.
+    """
+
+    version = f"{runtime[0]}.{runtime[1]}"
+    return [
+        f"/usr/local/cuda-{version}/lib64/libnvrtc-builtins.so.{version}",
+        f"/usr/local/cuda-{version}/targets/x86_64-linux/lib/libnvrtc-builtins.so.{version}",
+        f"libnvrtc-builtins.so.{version}",
+    ]
+
+
 class CudaBindings:
     """Thin ctypes wrapper; tests substitute a fake with the same surface."""
 
     def __init__(self, runtime: tuple[int, int]) -> None:
+        # Preload builtins BEFORE any NVRTC compilation with RTLD_GLOBAL so
+        # NVRTC's internal soname dlopen resolves to it.
+        self.nvrtc_builtins = _load_library_global(
+            nvrtc_builtins_candidates(runtime)
+        )
         self.nvrtc = _load_library(nvrtc_library_candidates(runtime))
         self.cuda = _load_library(["libcuda.so.1", "libcuda.so"])
 

--- a/scripts/ci/tests/test_cuda_smoke_test.py
+++ b/scripts/ci/tests/test_cuda_smoke_test.py
@@ -2,6 +2,7 @@ import unittest
 
 from scripts.ci.cuda_smoke_test import (
     EXPECTED_OUTPUT,
+    nvrtc_builtins_candidates,
     nvrtc_library_candidates,
     SmokeFailure,
     nvrtc_arch_option,
@@ -57,6 +58,19 @@ class VersionLogicTests(unittest.TestCase):
             ],
         )
         self.assertNotIn("libnvrtc.so", candidates)
+
+    def test_nvrtc_builtins_preload_order(self) -> None:
+        """NVRTC dlopens builtins by soname; absolute paths must come first."""
+
+        candidates = nvrtc_builtins_candidates((12, 8))
+        self.assertEqual(
+            candidates,
+            [
+                "/usr/local/cuda-12.8/lib64/libnvrtc-builtins.so.12.8",
+                "/usr/local/cuda-12.8/targets/x86_64-linux/lib/libnvrtc-builtins.so.12.8",
+                "libnvrtc-builtins.so.12.8",
+            ],
+        )
 
     def test_package_and_arch_option_naming(self) -> None:
         self.assertEqual(nvrtc_package((12, 8)), "cuda-nvrtc-12-8")


### PR DESCRIPTION
## Summary

Third and (per the live console log) final layer of the #1404 smoke fixes. With the NVRTC load-order fix (#1415) in place, the pod log showed:

```
Loaded NVRTC version: 12.8
Device compute capability: 8.6
Device total VRAM: 15.6 GB
SMOKE FAIL: NVRTC compilation failed with status 7: nvrtc: error: failed to open libnvrtc-builtins.so.12.8.
```

NVRTC dlopens `libnvrtc-builtins.so.X.Y` **by soname at compile time**, and the selected tier's install directory is not on the default linker search path (setting `LD_LIBRARY_PATH` at runtime would not help — the dynamic linker reads it at process start). Fix: preload the builtins library from its absolute install paths with `RTLD_GLOBAL` before any compilation (`nvrtc_builtins_candidates`, unit-tested), so NVRTC's soname lookup resolves against the already-loaded library.

The same log also confirmed RunPod restarts the container command on exit, so incompatible candidates surface as bounded startup timeouts (documented in the work log).

Note: the required `CI GPU gate` runs main's definition, which contains this bug, so it cannot pass on this PR (same bootstrap deadlock as #1414/#1415) — admin merge after CPU checks, then a live dispatch revalidates.

Work log: `docs/worklogs/2026-07-18-runpod-smoke-startup-fix.md` (updated)

## Verification

- `bash scripts/check-pr-fast.sh --test 'python3.11 -m unittest scripts.ci.tests.test_cuda_smoke_test scripts.ci.tests.test_workflow_contracts scripts.ci.tests.test_runpod_provision'` (passed)
- Root cause confirmed against the live pod console log above
- `scripts/repository-rules-review.py` unavailable locally (`DEEPSEEK_API_KEY` unset)

Generated with [Claude Code](https://claude.com/claude-code)