### PR TITLE
Fix grouped BLAS provider error inference

### DIFF
--- a/crates/tenferro-cpu/src/gemm/blas_gemm.rs
+++ b/crates/tenferro-cpu/src/gemm/blas_gemm.rs
@@ -412,14 +412,14 @@ mod provider_batch {
                         return Err(Error::invalid_argument(
                             "grouped_gemm",
                             "configuration",
-                            "BLAS grouped GEMM metadata is inconsistent".into(),
+                            "BLAS grouped GEMM metadata is inconsistent",
                         ));
                     };
                     *last_size = last_size.checked_add(1).ok_or_else(|| {
                         Error::invalid_argument(
                             "grouped_gemm",
                             "configuration",
-                            "BLAS grouped GEMM group_size overflows i32".into(),
+                            "BLAS grouped GEMM group_size overflows i32",
                         )
                     })?;
                 }


### PR DESCRIPTION
## Why

The explicit `blas-openblas` and `blas-mkl` features compile the grouped provider batch path. Two string literals in that path were converted with `.into()` before being passed to `Error::invalid_argument`, whose message parameter is `impl Into<String>`. That leaves the conversion target ambiguous and causes `E0283` in both provider-feature builds.

## How

Pass the string literals directly to `Error::invalid_argument` so the constructor performs the intended `String` conversion.

## What

- Fix both grouped batch metadata error paths in `PreparedBatch::push_group`.
- Preserve the error messages and runtime behavior.
- Keep the change scoped to the two ambiguous conversions.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p tenferro-cpu --lib --no-default-features --features blas-openblas`
- `cargo check -p tenferro-cpu --lib --no-default-features --features blas-mkl`
- `cargo test -p tenferro-cpu --lib --no-default-features --features blas-openblas grouped_gemm` (5 passed)