### PR TITLE
Batch small API, CPU resilience, and FFT cache fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ tenferro-linalg = "0.2"
 ```rust
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::LinalgBackend;
-use tenferro_runtime::{TensorView, TypedTensor, TypedTensorOpsExt};
+use tenferro_runtime::{TensorRead, TensorView, TypedTensor, TypedTensorOpsExt};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -63,7 +63,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(product.shape(), &[2, 2]);
     assert_close(product.host_data()?, &[3.0, 0.0, 0.0, 1.0]);
 
-    let svd = backend.svd_read(TensorView::F64(product.as_view()))?;
+    let svd = backend.svd_read(TensorRead::from_view(TensorView::F64(product.as_view())))?;
     assert_eq!(svd.len(), 3);
     assert_eq!(svd[0].shape(), &[2, 2]);
     assert_eq!(svd[1].shape(), &[2]);

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -47,6 +47,12 @@ rules from `tensor4all-agent-rules`.
 - Tensor operation names are public vocabulary. Use unsuffixed operation names
   for owned compact tensor inputs, and add a `_read` suffix only for APIs that
   explicitly accept borrowed views or `TensorRead`-style input references.
+- Public shape parameters use `impl Into<R::Shape>` when the rank type owns the
+  representation and `impl IntoShapeVec` at dynamic-rank boundaries, so arrays,
+  vectors, slices, and `ShapeVec` values are accepted consistently. Axis lists,
+  dimension mappings, and other borrowed parameter collections use
+  `impl AsRef<[T]>` unless ownership or iteration semantics require a different
+  contract.
 - Metadata-only layout/view operations must use a `_view` suffix, for example
   `transpose_view`, `slice_view`, or `reshape_view`. Do not use `_view` for
   operations that allocate, canonicalize, execute kernels, or transfer data.

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -26,8 +26,8 @@ use tenferro_runtime::ad_support::ones_tensor;
 use tenferro_runtime::ErrorPhase;
 use tenferro_tensor::BackendSessionHost;
 use tenferro_tensor::{
-    CacheStats, DType, Tensor, TensorBackend, TensorElementwise, TensorRead, TensorValue,
-    TypedTensor,
+    CacheStats, DType, IntoShapeVec, Tensor, TensorBackend, TensorElementwise, TensorRead,
+    TensorScalar, TensorValue, TypedTensor,
 };
 use tidu::eager::{self, EagerInput, EagerOutput, KeySource, RecordedGraph, Recorder, Trace};
 use tidu::{ADRuleError, ADRuleKind, LinearizedGraph};
@@ -1615,6 +1615,25 @@ impl EagerTensor {
     /// while materializing the source value.
     pub fn from_tensor_in(tensor: Tensor, ctx: Arc<EagerRuntime>) -> Result<Self> {
         Self::new_leaf(ctx, tensor, false)
+    }
+
+    /// Create an untracked eager tensor from compact column-major data inside
+    /// an existing eager runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::TensorRuntime`] with
+    /// [`tenferro_tensor::ValidationError::ShapeMismatch`] when the shape and
+    /// data length disagree, or with
+    /// [`tenferro_tensor::ValidationError::IntegerOverflow`] when shape
+    /// arithmetic overflows. Returns [`Error::RuntimeState`] when eager
+    /// metadata cannot be registered.
+    pub fn from_vec_col_major_in<T: TensorScalar>(
+        shape: impl IntoShapeVec,
+        data: Vec<T>,
+        ctx: Arc<EagerRuntime>,
+    ) -> Result<Self> {
+        Self::from_tensor_in(Tensor::from_vec_col_major(shape, data)?, ctx)
     }
 
     /// Create a tracked eager leaf inside an existing eager context.

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use computegraph::GraphOperation;
+use num_complex::{Complex32, Complex64};
 use tenferro_ops::broadcast::{
     broadcast_error_to_validation, broadcast_in_dim_extent_error, broadcast_input_plan,
     broadcast_shape, broadcast_shapes,
@@ -329,7 +330,7 @@ impl EagerTensor {
     pub fn dot_general_with_conj(
         &self,
         other: &Self,
-        config: &DotGeneralConfig,
+        config: DotGeneralConfig,
         lhs_conj: bool,
         rhs_conj: bool,
     ) -> Result<Self> {
@@ -341,7 +342,7 @@ impl EagerTensor {
         }
         validate_eager_dot_general_config(
             "EagerTensor::dot_general_with_conj",
-            config,
+            &config,
             self.shape().len(),
             other.shape().len(),
         )?;
@@ -352,7 +353,7 @@ impl EagerTensor {
                 exec_dot_general_with_conj_on_tensor_reads(
                     self.tensor_read(),
                     other.tensor_read(),
-                    config,
+                    &config,
                     lhs_conj,
                     rhs_conj,
                     backend,
@@ -362,18 +363,75 @@ impl EagerTensor {
         }
 
         match (lhs_conj, rhs_conj) {
-            (false, false) => self.dot_general(other, config.clone()),
-            (true, false) => self.conj()?.dot_general(other, config.clone()),
+            (false, false) => self.dot_general(other, config),
+            (true, false) => self.conj()?.dot_general(other, config),
             (false, true) => {
                 let rhs = other.conj()?;
-                self.dot_general(&rhs, config.clone())
+                self.dot_general(&rhs, config)
             }
             (true, true) => {
                 let lhs = self.conj()?;
                 let rhs = other.conj()?;
-                lhs.dot_general(&rhs, config.clone())
+                lhs.dot_general(&rhs, config)
             }
         }
+    }
+
+    /// Scale by a real scalar: `y = factor * x`.
+    ///
+    /// Integer factors are rounded to the nearest integer before multiplication,
+    /// boolean factors map finite zero to `false` and other finite values to
+    /// `true`, and complex tensors receive a zero-imaginary scalar.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::TensorRuntime`] with
+    /// [`tenferro_tensor::ValidationError::InvalidArgument`] when an integer or
+    /// boolean factor is non-finite or outside the input dtype's range. Backend
+    /// and runtime execution failures retain their typed source variants.
+    pub fn scale_real(&self, factor: f64) -> Result<Self> {
+        let scalar = match self.dtype() {
+            DType::F64 => Tensor::from_vec_col_major(vec![], vec![factor])?,
+            DType::F32 => Tensor::from_vec_col_major(vec![], vec![factor as f32])?,
+            DType::I32 => Tensor::from_vec_col_major(vec![], vec![round_real_to_i32(factor)?])?,
+            DType::I64 => Tensor::from_vec_col_major(vec![], vec![round_real_to_i64(factor)?])?,
+            DType::Bool => Tensor::from_vec_col_major(vec![], vec![bool_from_real(factor)?])?,
+            DType::C64 => Tensor::from_vec_col_major(vec![], vec![Complex64::new(factor, 0.0)])?,
+            DType::C32 => {
+                Tensor::from_vec_col_major(vec![], vec![Complex32::new(factor as f32, 0.0)])?
+            }
+        };
+        let scalar = EagerTensor::from_tensor_in(scalar, Arc::clone(&self.ctx))?;
+        self.mul(&scalar)
+    }
+
+    /// Scale a complex tensor by a complex scalar: `y = factor * x`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::TensorRuntime`] with
+    /// [`tenferro_tensor::ValidationError::InvalidArgument`] for a non-complex
+    /// input dtype. Backend and runtime execution failures retain their typed
+    /// source variants.
+    pub fn scale_complex(&self, factor: Complex64) -> Result<Self> {
+        let scalar = match self.dtype() {
+            DType::C64 => Tensor::from_vec_col_major(vec![], vec![factor])?,
+            DType::C32 => Tensor::from_vec_col_major(
+                vec![],
+                vec![Complex32::new(factor.re as f32, factor.im as f32)],
+            )?,
+            dtype => {
+                return Err(Error::TensorRuntime(
+                    tenferro_tensor::Error::invalid_argument(
+                        "scale_complex",
+                        "dtype",
+                        format!("requires complex tensor dtype, got {dtype:?}"),
+                    ),
+                ));
+            }
+        };
+        let scalar = EagerTensor::from_tensor_in(scalar, Arc::clone(&self.ctx))?;
+        self.mul(&scalar)
     }
 
     /// Matrix multiplication for rank-2 tensors.
@@ -1181,4 +1239,47 @@ fn eager_validation_op_name(op: &StdTensorOp) -> &'static str {
         StdTensorOp::Concatenate { .. } => "concatenate",
         _ => "eager_nary_op",
     }
+}
+
+fn finite_real_factor(value: f64) -> Result<f64> {
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err(Error::TensorRuntime(
+            tenferro_tensor::Error::invalid_argument(
+                "scale_real",
+                "factor",
+                format!("real scalar must be finite, got {value}"),
+            ),
+        ))
+    }
+}
+
+fn round_real_to_i64(value: f64) -> Result<i64> {
+    let rounded = finite_real_factor(value)?.round();
+    if rounded < i64::MIN as f64 || rounded >= -(i64::MIN as f64) {
+        return Err(Error::TensorRuntime(
+            tenferro_tensor::Error::invalid_argument(
+                "scale_real",
+                "factor",
+                format!("rounded real scalar {rounded} is out of i64 range"),
+            ),
+        ));
+    }
+    Ok(rounded as i64)
+}
+
+fn round_real_to_i32(value: f64) -> Result<i32> {
+    let rounded = round_real_to_i64(value)?;
+    i32::try_from(rounded).map_err(|_| {
+        Error::TensorRuntime(tenferro_tensor::Error::invalid_argument(
+            "scale_real",
+            "factor",
+            format!("rounded real scalar {rounded} is out of i32 range"),
+        ))
+    })
+}
+
+fn bool_from_real(value: f64) -> Result<bool> {
+    Ok(finite_real_factor(value)? != 0.0)
 }

--- a/crates/tenferro-ad/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-ad/tests/integration/eager_tensor.rs
@@ -350,7 +350,7 @@ fn eager_dot_general_with_conj_uses_untracked_fast_path() {
     let config = matmul_config();
 
     let fused = lhs
-        .dot_general_with_conj(&rhs, &config, true, false)
+        .dot_general_with_conj(&rhs, config.clone(), true, false)
         .unwrap();
     let explicit = lhs.conj().unwrap().dot_general(&rhs, config).unwrap();
 
@@ -384,7 +384,7 @@ fn eager_dot_general_with_conj_validates_config_before_untracked_backend_dispatc
     };
 
     let err = lhs
-        .dot_general_with_conj(&rhs, &config, true, false)
+        .dot_general_with_conj(&rhs, config, true, false)
         .unwrap_err();
 
     assert_eq!(
@@ -396,6 +396,74 @@ fn eager_dot_general_with_conj_validates_config_before_untracked_backend_dispatc
         err,
         RuntimeError::TensorRuntime(TensorError::Validation { .. })
     ));
+}
+
+#[test]
+fn eager_scalar_scaling_matches_traced_dtype_semantics() {
+    let ctx = test_ctx();
+    let real = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, -2.0]).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let scaled = real.scale_real(2.5).unwrap();
+    assert_eq!(
+        f64_data(scaled.materialized().unwrap().as_ref()),
+        &[2.5, -5.0]
+    );
+    assert!(real.scale_complex(Complex64::new(0.0, 1.0)).is_err());
+
+    let integer = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![1], vec![3_i64]).unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    assert_eq!(
+        integer
+            .scale_real(2.5)
+            .unwrap()
+            .materialized()
+            .unwrap()
+            .as_slice::<i64>()
+            .unwrap(),
+        &[9]
+    );
+    assert!(integer.scale_real(f64::NAN).is_err());
+
+    let complex = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 2.0)]).unwrap(),
+        ctx,
+    )
+    .unwrap();
+    assert_eq!(
+        c64_data(
+            complex
+                .scale_complex(Complex64::new(0.0, 1.0))
+                .unwrap()
+                .materialized()
+                .unwrap()
+                .as_ref()
+        ),
+        &[Complex64::new(-2.0, 1.0)]
+    );
+
+    let ctx = test_ctx();
+    let tracked = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2], vec![1.0_f64, -2.0]).unwrap(),
+        ctx,
+    )
+    .unwrap();
+    tracked
+        .scale_real(2.5)
+        .unwrap()
+        .reduce_sum(&[0])
+        .unwrap()
+        .backward()
+        .unwrap();
+    assert_eq!(
+        f64_data(tracked.grad().unwrap().unwrap().as_ref()),
+        &[2.5, 2.5]
+    );
 }
 
 #[test]

--- a/crates/tenferro-ad/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-ad/tests/integration/eager_tensor.rs
@@ -467,6 +467,19 @@ fn eager_scalar_scaling_matches_traced_dtype_semantics() {
 }
 
 #[test]
+fn eager_tensor_has_one_step_column_major_constructor() {
+    let eager =
+        EagerTensor::from_vec_col_major_in([2, 2], vec![1.0_f64, 3.0, 2.0, 4.0], test_ctx())
+            .unwrap();
+
+    assert_eq!(eager.shape(), &[2, 2]);
+    assert_eq!(
+        eager.materialized().unwrap().as_slice::<f64>().unwrap(),
+        &[1.0, 3.0, 2.0, 4.0]
+    );
+}
+
+#[test]
 fn eager_gather_keeps_indices_integer_for_complex_operand() {
     let x = EagerTensor::from_tensor_in(
         Tensor::from_vec_col_major(

--- a/crates/tenferro-ad/tests/integration/fallible_api.rs
+++ b/crates/tenferro-ad/tests/integration/fallible_api.rs
@@ -146,6 +146,10 @@ fn eager_dot_general_surfaces_validate_config_before_dispatch_source_contract() 
         })
         .expect("missing EagerTensor::dot_general_with_conj source section");
     assert!(
+        dot_general_with_conj.contains("config: DotGeneralConfig"),
+        "EagerTensor dot-general surfaces should consistently take owned configs"
+    );
+    assert!(
         dot_general_with_conj.contains("validate_eager_dot_general_config("),
         "EagerTensor::dot_general_with_conj must validate DotGeneralConfig before fast-path dispatch"
     );

--- a/crates/tenferro-ad/tests/integration/memory_order_api.rs
+++ b/crates/tenferro-ad/tests/integration/memory_order_api.rs
@@ -4,8 +4,8 @@ use tenferro_runtime::{GraphCompiler, GraphExecutor, Tensor, TracedTensor};
 #[test]
 fn traced_tensor_col_major_constructor_preserves_shape_and_storage() {
     let traced =
-        TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0])
-            .unwrap();
+        TracedTensor::from_vec_col_major([2, 3], vec![1.0_f64, 4.0, 2.0, 5.0, 3.0, 6.0]).unwrap();
+    assert_eq!(traced.dtype(), tenferro_runtime::DType::F64);
 
     let mut compiler = GraphCompiler::new();
     let program = compiler.compile(&traced).unwrap();
@@ -33,6 +33,6 @@ fn traced_tensor_col_major_constructor_keeps_physical_order() {
 
 #[test]
 fn tensor_col_major_constructor_is_the_facade_import_path() {
-    let tensor = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]).unwrap();
+    let tensor = Tensor::from_vec_col_major([2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]).unwrap();
     assert_eq!(tensor.as_slice::<f64>().unwrap(), &[1.0, 3.0, 2.0, 4.0]);
 }

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -616,7 +616,7 @@ impl CpuBackendState {
         }
     }
 
-    fn initialized_engines(&self) -> Vec<Arc<CpuEngine>> {
+    fn initialized_engines(&self, op: &'static str) -> crate::Result<Vec<Arc<CpuEngine>>> {
         let mut engines = vec![Arc::clone(&self.base_engine)];
         if let Some(engine) = self.all_allowed.get() {
             engines.push(Arc::clone(engine));
@@ -624,14 +624,28 @@ impl CpuBackendState {
         engines.extend(
             self.node_engines
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .map_err(|_| poisoned_cpu_lock(op, "CPU engine registry"))?
                 .values()
                 .cloned(),
         );
         engines.sort_unstable_by_key(|engine| Arc::as_ptr(engine) as usize);
         engines.dedup_by(|left, right| Arc::ptr_eq(left, right));
-        engines
+        Ok(engines)
     }
+}
+
+fn poisoned_cpu_lock(op: &'static str, lock: &'static str) -> crate::Error {
+    crate::Error::runtime_state(op, format!("{lock} lock poisoned"))
+}
+
+fn lock_engine_resources<'a>(
+    engine: &'a CpuEngine,
+    op: &'static str,
+) -> crate::Result<std::sync::MutexGuard<'a, EngineResources>> {
+    engine
+        .resources
+        .lock()
+        .map_err(|_| poisoned_cpu_lock(op, "CPU engine resources"))
 }
 
 /// A cheap cloneable handle to shared CPU execution coordination.
@@ -1308,21 +1322,24 @@ impl CpuBackend {
     /// use tenferro_cpu::CpuBackend;
     ///
     /// let backend = CpuBackend::new();
-    /// assert_eq!(backend.buffer_pool_len(), 0);
+    /// assert_eq!(backend.buffer_pool_len()?, 0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn buffer_pool_len(&self) -> usize {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] when the engine registry or an
+    /// initialized engine's resources lock is poisoned.
+    pub fn buffer_pool_len(&self) -> crate::Result<usize> {
         self.shared
-            .initialized_engines()
-            .into_iter()
-            .map(|engine| {
-                engine
-                    .resources
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
-                    .buffers
-                    .len()
+            .initialized_engines("CpuBackend::buffer_pool_len")?
+            .iter()
+            .try_fold(0, |total, engine| {
+                Ok(total
+                    + lock_engine_resources(engine, "CpuBackend::buffer_pool_len")?
+                        .buffers
+                        .len())
             })
-            .sum()
     }
 
     /// Snapshot reusable typed host buffers currently retained by this backend.
@@ -1333,25 +1350,28 @@ impl CpuBackend {
     /// use tenferro_cpu::CpuBackend;
     ///
     /// let backend = CpuBackend::new();
-    /// let stats = backend.buffer_pool_stats();
+    /// let stats = backend.buffer_pool_stats()?;
     /// assert_eq!(stats.buffers, 0);
     /// assert_eq!(stats.capacity_bytes, 0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn buffer_pool_stats(&self) -> BufferPoolStats {
-        self.shared.initialized_engines().into_iter().fold(
-            BufferPoolStats::default(),
-            |mut total, engine| {
-                let stats = engine
-                    .resources
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] when the engine registry or an
+    /// initialized engine's resources lock is poisoned.
+    pub fn buffer_pool_stats(&self) -> crate::Result<BufferPoolStats> {
+        self.shared
+            .initialized_engines("CpuBackend::buffer_pool_stats")?
+            .iter()
+            .try_fold(BufferPoolStats::default(), |mut total, engine| {
+                let stats = lock_engine_resources(engine, "CpuBackend::buffer_pool_stats")?
                     .buffers
                     .stats();
                 total.buffers += stats.buffers;
                 total.capacity_bytes += stats.capacity_bytes;
-                total
-            },
-        )
+                Ok(total)
+            })
     }
 
     /// Return cache-style stats for the CPU buffer pool.
@@ -1362,16 +1382,22 @@ impl CpuBackend {
     /// use tenferro_cpu::CpuBackend;
     ///
     /// let backend = CpuBackend::new();
-    /// let stats = backend.buffer_pool_cache_stats();
+    /// let stats = backend.buffer_pool_cache_stats()?;
     /// assert_eq!(stats.entries, 0);
     /// assert_eq!(stats.retained_bytes, 0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn buffer_pool_cache_stats(&self) -> CacheStats {
-        let stats = self.buffer_pool_stats();
-        CacheStats {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] when the engine registry or an
+    /// initialized engine's resources lock is poisoned.
+    pub fn buffer_pool_cache_stats(&self) -> crate::Result<CacheStats> {
+        let stats = self.buffer_pool_stats()?;
+        Ok(CacheStats {
             entries: stats.buffers,
             retained_bytes: stats.capacity_bytes,
-        }
+        })
     }
 
     /// Current CPU buffer-pool retention limit in bytes.
@@ -1403,22 +1429,37 @@ impl CpuBackend {
     /// use tenferro_cpu::CpuBackend;
     ///
     /// let mut backend = CpuBackend::new();
-    /// backend.set_buffer_pool_limit_bytes(0);
+    /// backend.set_buffer_pool_limit_bytes(0)?;
     /// assert_eq!(backend.buffer_pool_limit_bytes(), 0);
-    /// assert_eq!(backend.buffer_pool_len(), 0);
+    /// assert_eq!(backend.buffer_pool_len()?, 0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn set_buffer_pool_limit_bytes(&mut self, max_retained_capacity_bytes: usize) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] without changing the configured
+    /// limit when the engine registry or any initialized engine's resources
+    /// lock is poisoned.
+    pub fn set_buffer_pool_limit_bytes(
+        &mut self,
+        max_retained_capacity_bytes: usize,
+    ) -> crate::Result<()> {
+        let engines = self
+            .shared
+            .initialized_engines("CpuBackend::set_buffer_pool_limit_bytes")?;
+        let mut resources = engines
+            .iter()
+            .map(|engine| lock_engine_resources(engine, "CpuBackend::set_buffer_pool_limit_bytes"))
+            .collect::<crate::Result<Vec<_>>>()?;
         self.shared
             .buffer_limit
             .store(max_retained_capacity_bytes, Ordering::Relaxed);
-        for engine in self.shared.initialized_engines() {
-            engine
-                .resources
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
+        for resource in &mut resources {
+            resource
                 .buffers
                 .set_max_retained_capacity_bytes(max_retained_capacity_bytes);
         }
+        Ok(())
     }
 
     /// Reset reusable typed host buffers currently retained by this backend.
@@ -1433,18 +1474,28 @@ impl CpuBackend {
     /// use tenferro_cpu::CpuBackend;
     ///
     /// let mut backend = CpuBackend::new();
-    /// backend.reset_buffer_pool();
-    /// assert_eq!(backend.buffer_pool_len(), 0);
+    /// backend.reset_buffer_pool()?;
+    /// assert_eq!(backend.buffer_pool_len()?, 0);
+    /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
-    pub fn reset_buffer_pool(&mut self) {
-        for engine in self.shared.initialized_engines() {
-            engine
-                .resources
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .buffers
-                .clear();
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] without clearing any initialized
+    /// engine when the engine registry or any engine's resources lock is
+    /// poisoned.
+    pub fn reset_buffer_pool(&mut self) -> crate::Result<()> {
+        let engines = self
+            .shared
+            .initialized_engines("CpuBackend::reset_buffer_pool")?;
+        let mut resources = engines
+            .iter()
+            .map(|engine| lock_engine_resources(engine, "CpuBackend::reset_buffer_pool"))
+            .collect::<crate::Result<Vec<_>>>()?;
+        for resource in &mut resources {
+            resource.buffers.clear();
         }
+        Ok(())
     }
 
     /// Run a closure in this backend's CPU execution scope.

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -51,6 +51,45 @@ fn default_backend_kind_prefers_blas_when_compiled() {
 }
 
 #[test]
+fn public_buffer_pool_controls_report_poisoned_engine_resources() {
+    let mut backend = CpuBackend::new();
+    let original_limit = backend.buffer_pool_limit_bytes();
+    let engine = Arc::clone(&backend.engine);
+    let poison = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        let _resources = engine.resources.lock().unwrap();
+        panic!("poison CPU engine resources for regression test");
+    }));
+    assert!(poison.is_err());
+
+    for error in [
+        backend.buffer_pool_len().unwrap_err(),
+        backend.buffer_pool_stats().unwrap_err(),
+        backend.buffer_pool_cache_stats().unwrap_err(),
+        backend.set_buffer_pool_limit_bytes(0).unwrap_err(),
+        backend.reset_buffer_pool().unwrap_err(),
+    ] {
+        assert_eq!(error.kind(), tenferro_tensor::ErrorKind::RuntimeState);
+        assert!(error.to_string().contains("poison"));
+    }
+    assert_eq!(backend.buffer_pool_limit_bytes(), original_limit);
+}
+
+#[test]
+fn public_buffer_pool_controls_report_poisoned_engine_registry() {
+    let backend = CpuBackend::new();
+    let shared = Arc::clone(&backend.shared);
+    let poison = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        let _engines = shared.node_engines.lock().unwrap();
+        panic!("poison CPU engine registry for regression test");
+    }));
+    assert!(poison.is_err());
+
+    let error = backend.buffer_pool_len().unwrap_err();
+    assert_eq!(error.kind(), tenferro_tensor::ErrorKind::RuntimeState);
+    assert!(error.to_string().contains("engine registry lock poisoned"));
+}
+
+#[test]
 fn explicit_backend_kind_constructor_records_selection() {
     let backend = CpuBackend::with_kind(CpuBackendKind::default_compiled()).unwrap();
 
@@ -76,7 +115,7 @@ fn placement_handle_clones_share_coordinator_engine_and_resources() {
     placed.with_linalg_pool(|pool| {
         <f64 as PoolScalar>::pool_release(pool, vec![1.0, 2.0]);
     });
-    assert_eq!(clone.buffer_pool_len(), 1);
+    assert_eq!(clone.buffer_pool_len().unwrap(), 1);
 }
 
 #[test]
@@ -714,7 +753,7 @@ fn unavailable_blas_backend_kind_reports_config_errors() {
         pool.len()
     });
     assert_eq!(retained, 1);
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 
     let lhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
     let rhs = Tensor::from_vec_col_major(vec![1], vec![3.0_f64]).unwrap();
@@ -784,21 +823,21 @@ fn with_linalg_pool_restores_backend_pool_and_context() {
     });
 
     assert_eq!(len_inside_pool, 1);
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 
     #[cfg(feature = "cpu-faer")]
     assert_eq!(backend.linalg_context().num_threads(), 1);
 }
 
 #[test]
-fn linalg_pool_acquire_then_panic_replenishes_retained_buffer() {
+fn linalg_pool_acquire_then_panic_replenishes_buffer_but_reports_poison() {
     let mut backend = CpuBackend::with_threads(1).unwrap();
     backend.with_linalg_pool(|pool| {
         <f64 as PoolScalar>::pool_release(pool, Vec::with_capacity(1024));
     });
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
     assert_eq!(
-        backend.buffer_pool_stats().capacity_bytes,
+        backend.buffer_pool_stats().unwrap().capacity_bytes,
         1024 * std::mem::size_of::<f64>()
     );
 
@@ -811,10 +850,16 @@ fn linalg_pool_acquire_then_panic_replenishes_retained_buffer() {
     }));
 
     assert!(result.is_err());
-    assert_eq!(backend.buffer_pool_len(), 1);
+    let resources = backend.engine.resources.lock().unwrap_err().into_inner();
+    assert_eq!(resources.buffers.len(), 1);
     assert_eq!(
-        backend.buffer_pool_stats().capacity_bytes,
+        resources.buffers.stats().capacity_bytes,
         1024 * std::mem::size_of::<f64>()
+    );
+    drop(resources);
+    assert_eq!(
+        backend.buffer_pool_len().unwrap_err().kind(),
+        tenferro_tensor::ErrorKind::RuntimeState
     );
 }
 

--- a/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/backend_misc.rs
@@ -147,7 +147,7 @@ fn cpu_runtime_copy_handles_strided_source_and_destination_without_allocation() 
     backend.reclaim_buffer(Tensor::I32(
         TypedTensor::from_vec_col_major(vec![4], vec![0_i32; 4]).unwrap(),
     ));
-    let retained_before = backend.buffer_pool_len();
+    let retained_before = backend.buffer_pool_len().unwrap();
     let src_data = [0_i32, 1, 2, 3, 4, 5, 6, 7];
     let src = TypedTensorView::from_slice(vec![2, 2], vec![2, 4], 1, &src_data).unwrap();
     let mut dst_data = [-1_i32; 8];
@@ -161,7 +161,7 @@ fn cpu_runtime_copy_handles_strided_source_and_destination_without_allocation() 
         .unwrap();
 
     assert_eq!(dst_data, [-1, 1, 5, -1, 3, 7, -1, -1]);
-    assert_eq!(backend.buffer_pool_len(), retained_before);
+    assert_eq!(backend.buffer_pool_len().unwrap(), retained_before);
 }
 
 #[test]
@@ -357,7 +357,7 @@ fn cpu_copy_into_rejects_host_destination_with_device_placement() {
 #[test]
 fn test_reclaim_buffer_returns_host_buffer_to_pool() {
     let mut backend = CpuBackend::new();
-    assert_eq!(backend.buffer_pool_len(), 0);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 0);
     let t = TensorElementwise::add(
         &mut backend,
         &Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap()),
@@ -365,7 +365,7 @@ fn test_reclaim_buffer_returns_host_buffer_to_pool() {
     )
     .unwrap();
     backend.reclaim_buffer(t);
-    assert!(backend.buffer_pool_len() > 0);
+    assert!(backend.buffer_pool_len().unwrap() > 0);
 }
 
 #[test]
@@ -374,7 +374,7 @@ fn test_elementwise_add_acquires_output_from_pool() {
     backend.reclaim_buffer(Tensor::F64(
         TypedTensor::from_vec_col_major(vec![4], vec![0.0; 4]).unwrap(),
     ));
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 
     let lhs =
         Tensor::F64(TypedTensor::from_vec_col_major(vec![4], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
@@ -382,11 +382,11 @@ fn test_elementwise_add_acquires_output_from_pool() {
         Tensor::F64(TypedTensor::from_vec_col_major(vec![4], vec![4.0, 3.0, 2.0, 1.0]).unwrap());
     let out = backend.add(&lhs, &rhs).unwrap();
 
-    assert_eq!(backend.buffer_pool_len(), 0);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 0);
     assert_eq!(get_f64(&out, &[0]), 5.0);
     assert_eq!(get_f64(&out, &[3]), 5.0);
     backend.reclaim_buffer(out);
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 }
 
 #[test]
@@ -1183,19 +1183,19 @@ fn test_structural_transpose_acquires_output_from_pool() {
     backend.reclaim_buffer(Tensor::F64(
         TypedTensor::from_vec_col_major(vec![4], vec![0.0; 4]).unwrap(),
     ));
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 
     let input =
         Tensor::F64(TypedTensor::from_vec_col_major(vec![2, 2], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
     let out = backend.transpose(&input, &[1, 0]).unwrap();
 
-    assert_eq!(backend.buffer_pool_len(), 0);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 0);
     assert_eq!(get_f64(&out, &[0, 0]), 1.0);
     assert_eq!(get_f64(&out, &[1, 0]), 3.0);
     assert_eq!(get_f64(&out, &[0, 1]), 2.0);
     assert_eq!(get_f64(&out, &[1, 1]), 4.0);
     backend.reclaim_buffer(out);
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 }
 
 #[test]
@@ -1204,17 +1204,17 @@ fn test_cast_acquires_output_from_dtype_pool() {
     backend.reclaim_buffer(Tensor::F32(
         TypedTensor::from_vec_col_major(vec![4], vec![0.0; 4]).unwrap(),
     ));
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 
     let input =
         Tensor::F64(TypedTensor::from_vec_col_major(vec![4], vec![1.25, 2.5, 3.75, 4.0]).unwrap());
     let out = backend.cast(&input, DType::F32).unwrap();
 
-    assert_eq!(backend.buffer_pool_len(), 0);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 0);
     assert_eq!(get_f32(&out, &[0]), 1.25);
     assert_eq!(get_f32(&out, &[3]), 4.0);
     backend.reclaim_buffer(out);
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 }
 
 #[test]
@@ -1223,7 +1223,7 @@ fn test_slice_acquires_output_from_pool() {
     backend.reclaim_buffer(Tensor::F64(
         TypedTensor::from_vec_col_major(vec![2], vec![0.0; 2]).unwrap(),
     ));
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 
     let input =
         Tensor::F64(TypedTensor::from_vec_col_major(vec![4], vec![1.0, 2.0, 3.0, 4.0]).unwrap());
@@ -1234,11 +1234,11 @@ fn test_slice_acquires_output_from_pool() {
     };
     let out = backend.slice(&input, &config).unwrap();
 
-    assert_eq!(backend.buffer_pool_len(), 0);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 0);
     assert_eq!(get_f64(&out, &[0]), 2.0);
     assert_eq!(get_f64(&out, &[1]), 3.0);
     backend.reclaim_buffer(out);
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 }
 
 #[test]
@@ -1247,7 +1247,7 @@ fn test_pad_acquires_and_zeroes_output_from_pool() {
     backend.reclaim_buffer(Tensor::F64(
         TypedTensor::from_vec_col_major(vec![4], vec![9.0; 4]).unwrap(),
     ));
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 
     let input = Tensor::F64(TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap());
     let config = PadConfig {
@@ -1257,13 +1257,13 @@ fn test_pad_acquires_and_zeroes_output_from_pool() {
     };
     let out = backend.pad(&input, &config).unwrap();
 
-    assert_eq!(backend.buffer_pool_len(), 0);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 0);
     assert_eq!(get_f64(&out, &[0]), 0.0);
     assert_eq!(get_f64(&out, &[1]), 1.0);
     assert_eq!(get_f64(&out, &[2]), 2.0);
     assert_eq!(get_f64(&out, &[3]), 0.0);
     backend.reclaim_buffer(out);
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 }
 
 #[test]
@@ -1272,7 +1272,7 @@ fn test_dynamic_update_slice_acquires_clone_from_pool() {
     backend.reclaim_buffer(Tensor::F64(
         TypedTensor::from_vec_col_major(vec![4], vec![9.0; 4]).unwrap(),
     ));
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 
     let operand =
         Tensor::F64(TypedTensor::from_vec_col_major(vec![4], vec![0.0, 1.0, 2.0, 3.0]).unwrap());
@@ -1282,13 +1282,13 @@ fn test_dynamic_update_slice_acquires_clone_from_pool() {
         .dynamic_update_slice(&operand, &update, &starts)
         .unwrap();
 
-    assert_eq!(backend.buffer_pool_len(), 0);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 0);
     assert_eq!(get_f64(&out, &[0]), 0.0);
     assert_eq!(get_f64(&out, &[1]), 7.0);
     assert_eq!(get_f64(&out, &[2]), 8.0);
     assert_eq!(get_f64(&out, &[3]), 3.0);
     backend.reclaim_buffer(out);
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 }
 
 #[test]
@@ -1304,7 +1304,7 @@ fn test_reclaim_buffer_covers_all_dtypes() {
         TypedTensor::from_vec_col_major(vec![1], vec![Complex64::new(1.0, 0.0)]).unwrap(),
     );
     backend.reclaim_buffer(c64_t);
-    assert!(backend.buffer_pool_len() >= 3);
+    assert!(backend.buffer_pool_len().unwrap() >= 3);
 }
 
 #[test]
@@ -1318,39 +1318,45 @@ fn test_install_with_pool_preserves_buffers() {
     .unwrap();
     assert_eq!(get_f64(&t, &[0]), 4.0);
     assert_eq!(get_f64(&t, &[1]), 6.0);
-    assert_eq!(backend.buffer_pool_len(), 0);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 0);
 }
 
 #[test]
-fn test_with_linalg_pool_restores_buffers_after_panic() {
+fn test_with_linalg_pool_reports_poison_after_panic() {
     let mut backend = CpuBackend::with_threads(1).unwrap();
     backend.reclaim_buffer(Tensor::F64(
         TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap(),
     ));
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         backend.with_linalg_pool::<()>(|_| panic!("forced linalg panic"));
     }));
 
     assert!(result.is_err());
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(
+        backend.buffer_pool_len().unwrap_err().kind(),
+        tenferro_tensor::ErrorKind::RuntimeState
+    );
 }
 
 #[test]
-fn test_backend_session_restores_buffers_after_panic() {
+fn test_backend_session_reports_poison_after_panic() {
     let mut backend = CpuBackend::with_threads(1).unwrap();
     backend.reclaim_buffer(Tensor::F64(
         TypedTensor::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap(),
     ));
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 1);
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         backend.with_backend_session::<()>(|_| panic!("forced session panic"));
     }));
 
     assert!(result.is_err());
-    assert_eq!(backend.buffer_pool_len(), 1);
+    assert_eq!(
+        backend.buffer_pool_len().unwrap_err().kind(),
+        tenferro_tensor::ErrorKind::RuntimeState
+    );
 }
 
 #[test]
@@ -1421,7 +1427,7 @@ fn test_exec_session_read_reductions_and_reclaim_cover_typed_paths() {
         ));
     });
 
-    assert!(backend.buffer_pool_len() >= 7);
+    assert!(backend.buffer_pool_len().unwrap() >= 7);
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
@@ -553,7 +553,7 @@ fn test_cpu_supports_i32_and_bool_structural_paths() {
 fn test_backend_default_and_buffer_pool_len() {
     let backend = CpuBackend::default();
     assert!(backend.num_threads() >= 1);
-    assert_eq!(backend.buffer_pool_len(), 0);
+    assert_eq!(backend.buffer_pool_len().unwrap(), 0);
 }
 
 #[test]
@@ -563,18 +563,18 @@ fn test_backend_buffer_pool_controls_report_and_update_limits() {
 
     assert_eq!(backend.num_threads(), 1);
     assert_eq!(backend.buffer_pool_limit_bytes(), 64);
-    assert_eq!(backend.buffer_pool_len(), 0);
-    let stats = backend.buffer_pool_stats();
+    assert_eq!(backend.buffer_pool_len().unwrap(), 0);
+    let stats = backend.buffer_pool_stats().unwrap();
     assert_eq!(stats.buffers, 0);
     assert_eq!(stats.capacity_bytes, 0);
-    let cache_stats = backend.buffer_pool_cache_stats();
+    let cache_stats = backend.buffer_pool_cache_stats().unwrap();
     assert_eq!(cache_stats.entries, 0);
     assert_eq!(cache_stats.retained_bytes, 0);
 
-    backend.set_buffer_pool_limit_bytes(0);
+    backend.set_buffer_pool_limit_bytes(0).unwrap();
     assert_eq!(backend.buffer_pool_limit_bytes(), 0);
-    backend.reset_buffer_pool();
-    assert_eq!(backend.buffer_pool_len(), 0);
+    backend.reset_buffer_pool().unwrap();
+    assert_eq!(backend.buffer_pool_len().unwrap(), 0);
 }
 
 #[test]

--- a/crates/tenferro-einsum/Cargo.toml
+++ b/crates/tenferro-einsum/Cargo.toml
@@ -46,9 +46,24 @@ blas-mkl = [
     "tenferro-ad?/blas-mkl",
     "tenferro-cpu/blas-mkl",
 ]
-cuda = ["tenferro-ad?/cuda", "tenferro-internal-ops/cuda"]
-webgpu = ["tenferro-ad?/webgpu", "tenferro-internal-ops/webgpu"]
-rocm = ["tenferro-ad?/rocm", "tenferro-internal-ops/rocm"]
+cuda = [
+    "tenferro-ad?/cuda",
+    "tenferro-internal-ops/cuda",
+    "dep:tenferro-gpu",
+    "tenferro-gpu/cuda",
+]
+webgpu = [
+    "tenferro-ad?/webgpu",
+    "tenferro-internal-ops/webgpu",
+    "dep:tenferro-gpu",
+    "tenferro-gpu/webgpu",
+]
+rocm = [
+    "tenferro-ad?/rocm",
+    "tenferro-internal-ops/rocm",
+    "dep:tenferro-gpu",
+    "tenferro-gpu/rocm",
+]
 
 [dependencies]
 tenferro-runtime = { path = "../tenferro-runtime", version = "0.2.0", default-features = false }
@@ -57,6 +72,7 @@ tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-ma
 tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.2.0", default-features = false }
 tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0", default-features = false }
 tenferro-cpu = { path = "../tenferro-cpu", version = "0.2.0", default-features = false }
+tenferro-gpu = { path = "../tenferro-gpu", version = "0.2.0", default-features = false, optional = true }
 computegraph.workspace = true
 tidu = { workspace = true, optional = true }
 lru.workspace = true
@@ -66,7 +82,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.2.0", default-features = false }
-tenferro-gpu = { path = "../tenferro-gpu", version = "0.2.0", default-features = false }
 criterion.workspace = true
 num-complex.workspace = true
 

--- a/crates/tenferro-einsum/src/concrete.rs
+++ b/crates/tenferro-einsum/src/concrete.rs
@@ -10,6 +10,7 @@ use crate::eager::{
     eager_einsum_exec_read_into_accum, eager_einsum_read_subscripts, eager_einsum_subscripts,
     plan_subscripts,
 };
+use crate::TensorDotAxes;
 use crate::{ContractionTree, EinsumSubscripts, Error, Result, Subscripts};
 
 const TENSOR_EINSUM_OP: &str = "TensorEinsumExt::einsum";
@@ -22,6 +23,74 @@ const TYPED_TENSOR_READ_EINSUM_OP: &str = "TypedTensorReadEinsumExt::einsum_read
 const TYPED_TENSOR_READ_EINSUM_INTO_OP: &str = "TypedTensorReadEinsumIntoExt::einsum_read_into";
 const PLAN_PREPARE_OP: &str = "ConcreteEinsumPlan::prepare";
 const PLAN_EXECUTE_OP: &str = "ConcreteEinsumPlan::execute";
+const TYPED_TENSOR_TENSORDOT_OP: &str = "TypedTensorTensordotExt::tensordot";
+
+/// Backend-explicit tensordot sugar for dtype-erased concrete tensors.
+pub trait TensorTensordotExt {
+    /// Contract this tensor with `rhs` over explicit axes or an axis count.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `InvalidArgument`, `RankMismatch`,
+    /// `AxisOutOfBounds`, or `ShapeMismatch` for invalid axes or incompatible
+    /// contracting dimensions, or [`Error::Tensor`] when backend execution
+    /// fails.
+    fn tensordot<B: TensorBackend>(
+        &self,
+        rhs: &Tensor,
+        axes: TensorDotAxes<'_>,
+        backend: &mut B,
+    ) -> Result<Tensor>;
+}
+
+impl TensorTensordotExt for Tensor {
+    fn tensordot<B: TensorBackend>(
+        &self,
+        rhs: &Tensor,
+        axes: TensorDotAxes<'_>,
+        backend: &mut B,
+    ) -> Result<Tensor> {
+        let config =
+            crate::tensordot::dot_general_config(axes, self.shape().len(), rhs.shape().len())?;
+        crate::tensordot::validate_concrete_contract_dims(self.shape(), rhs.shape(), &config)?;
+        backend.dot_general(self, rhs, &config).map_err(Error::from)
+    }
+}
+
+/// Backend-explicit tensordot sugar for typed concrete tensors.
+pub trait TypedTensorTensordotExt<T: TensorScalar> {
+    /// Contract this tensor with `rhs` while preserving its scalar type.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Validation`] with `InvalidArgument`, `RankMismatch`,
+    /// `AxisOutOfBounds`, or `ShapeMismatch` for invalid axes or incompatible
+    /// contracting dimensions, or [`Error::Tensor`] when backend execution
+    /// fails.
+    fn tensordot<B: TensorBackend>(
+        &self,
+        rhs: &TypedTensor<T>,
+        axes: TensorDotAxes<'_>,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>>;
+}
+
+impl<T: TensorScalar> TypedTensorTensordotExt<T> for TypedTensor<T> {
+    fn tensordot<B: TensorBackend>(
+        &self,
+        rhs: &TypedTensor<T>,
+        axes: TensorDotAxes<'_>,
+        backend: &mut B,
+    ) -> Result<TypedTensor<T>> {
+        let config =
+            crate::tensordot::dot_general_config(axes, self.shape().len(), rhs.shape().len())?;
+        crate::tensordot::validate_concrete_contract_dims(self.shape(), rhs.shape(), &config)?;
+        let result = backend
+            .dot_general_read(T::tensor_read(self), T::tensor_read(rhs), &config)
+            .map_err(Error::from)?;
+        into_typed_result(result, TYPED_TENSOR_TENSORDOT_OP)
+    }
+}
 
 /// Backend-explicit einsum methods for dtype-erased concrete tensors.
 ///

--- a/crates/tenferro-einsum/src/concrete_tests.rs
+++ b/crates/tenferro-einsum/src/concrete_tests.rs
@@ -7,8 +7,9 @@ use tenferro_tensor::{
 
 use crate::{
     parse_einsum_subscripts, ConcreteEinsumPlan, Error, TensorEinsumExt, TensorEinsumIntoExt,
-    TensorReadEinsumExt, TensorReadEinsumIntoExt, TypedTensorEinsumExt, TypedTensorEinsumIntoExt,
-    TypedTensorReadEinsumExt, TypedTensorReadEinsumIntoExt,
+    TensorReadEinsumExt, TensorReadEinsumIntoExt, TensorTensordotExt, TypedTensorEinsumExt,
+    TypedTensorEinsumIntoExt, TypedTensorReadEinsumExt, TypedTensorReadEinsumIntoExt,
+    TypedTensorTensordotExt,
 };
 
 fn assert_f64_tensor(tensor: &Tensor, shape: &[usize], expected: &[f64]) {
@@ -27,6 +28,24 @@ fn public_tensor_einsum_ext_executes_dtype_erased_inputs() {
     let result = [&lhs, &rhs].einsum("ij,jk->ik", &mut backend).unwrap();
 
     assert_f64_tensor(&result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn concrete_tensordot_matches_einsum_for_erased_and_typed_tensors() {
+    let mut backend = CpuBackend::new();
+    let lhs = Tensor::from_vec_col_major([2], vec![1.0_f64, 2.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major([2], vec![3.0_f64, 4.0]).unwrap();
+    let erased = lhs
+        .tensordot(&rhs, crate::TensorDotAxes::Count(1), &mut backend)
+        .unwrap();
+    assert_eq!(erased.as_slice::<f64>().unwrap(), &[11.0]);
+
+    let lhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![1.0, 2.0]).unwrap();
+    let rhs = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![3.0, 4.0]).unwrap();
+    let typed = lhs
+        .tensordot(&rhs, crate::TensorDotAxes::Count(1), &mut backend)
+        .unwrap();
+    assert_eq!(typed.as_slice().unwrap(), &[11.0]);
 }
 
 #[test]

--- a/crates/tenferro-einsum/src/lib.rs
+++ b/crates/tenferro-einsum/src/lib.rs
@@ -83,8 +83,8 @@ pub(crate) mod util;
 pub use cache::EINSUM_EXTENSION_FAMILY_ID;
 pub use concrete::{
     ConcreteEinsumPlan, TensorEinsumExt, TensorEinsumIntoExt, TensorReadEinsumExt,
-    TensorReadEinsumIntoExt, TypedTensorEinsumExt, TypedTensorEinsumIntoExt,
-    TypedTensorReadEinsumExt, TypedTensorReadEinsumIntoExt,
+    TensorReadEinsumIntoExt, TensorTensordotExt, TypedTensorEinsumExt, TypedTensorEinsumIntoExt,
+    TypedTensorReadEinsumExt, TypedTensorReadEinsumIntoExt, TypedTensorTensordotExt,
 };
 #[cfg(feature = "autodiff")]
 pub use eager_ad::{EagerEinsumExt, EagerTensorEinsumExt};

--- a/crates/tenferro-einsum/src/tensordot.rs
+++ b/crates/tenferro-einsum/src/tensordot.rs
@@ -91,7 +91,6 @@ pub(crate) fn dot_general_config(
     Ok(config)
 }
 
-#[cfg(feature = "autodiff")]
 pub(crate) fn validate_concrete_contract_dims(
     lhs_shape: &[usize],
     rhs_shape: &[usize],

--- a/crates/tenferro-einsum/src/tests/eager_tests.rs
+++ b/crates/tenferro-einsum/src/tests/eager_tests.rs
@@ -293,7 +293,7 @@ fn eager_einsum_owned_reclaims_consumed_input_buffers() {
 
     assert_f64_tensor(&result, &[2, 2], &[22.0, 28.0, 49.0, 64.0]);
     assert!(
-        ctx.buffer_pool_len() >= 2,
+        ctx.buffer_pool_len().unwrap() >= 2,
         "owned input buffers should be reclaimed after their last use"
     );
 }

--- a/crates/tenferro-einsum/src/typed_eager_tests.rs
+++ b/crates/tenferro-einsum/src/typed_eager_tests.rs
@@ -220,7 +220,7 @@ fn eager_einsum_owned_matches_borrowed() {
         owned.as_slice::<f64>().unwrap(),
         borrowed.as_slice::<f64>().unwrap()
     );
-    assert!(owned_ctx.buffer_pool_len() >= 2);
+    assert!(owned_ctx.buffer_pool_len().unwrap() >= 2);
 }
 
 #[test]

--- a/crates/tenferro-einsum/tests/integration/public_surface_contract.rs
+++ b/crates/tenferro-einsum/tests/integration/public_surface_contract.rs
@@ -61,3 +61,43 @@ fn typed_einsum_view_inputs_use_read_suffix_and_typed_outputs_accept_views() {
         "borrowed typed inputs must not implement the unsuffixed einsum_into surface"
     );
 }
+
+#[test]
+fn gpu_dependency_is_owned_by_opt_in_backend_features() {
+    let manifest_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let manifest = std::fs::read_to_string(manifest_path).expect("read einsum manifest");
+    let dependencies = manifest
+        .split_once("[dependencies]")
+        .and_then(|(_, rest)| rest.split_once("[dev-dependencies]").map(|(body, _)| body))
+        .expect("manifest dependencies section");
+    let dev_dependencies = manifest
+        .split_once("[dev-dependencies]")
+        .map(|(_, rest)| rest)
+        .expect("manifest dev-dependencies section");
+
+    assert!(
+        dependencies.lines().any(|line| {
+            line.starts_with("tenferro-gpu = ") && line.contains("optional = true")
+        }),
+        "tenferro-gpu must be an optional normal dependency"
+    );
+    assert!(
+        !dev_dependencies
+            .lines()
+            .any(|line| line.starts_with("tenferro-gpu = ")),
+        "tenferro-gpu must not be an unconditional dev-dependency"
+    );
+
+    for feature in ["cuda", "webgpu", "rocm"] {
+        let feature_start = format!("{feature} = ");
+        let feature_body = manifest
+            .split_once(&feature_start)
+            .and_then(|(_, rest)| rest.split_once(']').map(|(body, _)| body))
+            .unwrap_or_else(|| panic!("missing or malformed {feature} feature"));
+        assert!(
+            feature_body.contains("dep:tenferro-gpu")
+                && feature_body.contains(&format!("tenferro-gpu/{feature}")),
+            "{feature} must explicitly activate tenferro-gpu and its matching backend feature"
+        );
+    }
+}

--- a/crates/tenferro-einsum/tests/integration/public_surface_contract.rs
+++ b/crates/tenferro-einsum/tests/integration/public_surface_contract.rs
@@ -101,3 +101,17 @@ fn gpu_dependency_is_owned_by_opt_in_backend_features() {
         );
     }
 }
+
+#[test]
+fn eager_extension_registration_preserves_typed_source_errors() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/eager_ad.rs");
+    let source = std::fs::read_to_string(root).expect("read eager tensor source");
+    let registration = source
+        .split_once(".register_extension(register_runtime)")
+        .and_then(|(_, rest)| rest.split_once("let op =").map(|(body, _)| body))
+        .expect("eager extension registration source section");
+
+    assert!(registration.contains("runtime_extension_error("));
+    assert!(!registration.contains("Error::Internal"));
+    assert!(!registration.contains("to_string()"));
+}

--- a/crates/tenferro-einsum/tests/integration/runtime_buffer_pool.rs
+++ b/crates/tenferro-einsum/tests/integration/runtime_buffer_pool.rs
@@ -36,7 +36,7 @@ fn cpu_backend_pool_reuses_nary_einsum_intermediates() {
     let result1 = engine.run(&program1).unwrap();
     assert_eq!(get_f64_data(&result1), &[517.0, 766.0, 625.0, 926.0]);
 
-    let pooled_after_first = engine.backend().buffer_pool_len();
+    let pooled_after_first = engine.backend().buffer_pool_len().unwrap();
     assert!(pooled_after_first > 0);
 
     let ta2 = TracedTensor::from_tensor_concrete_shape(a).unwrap();
@@ -49,6 +49,6 @@ fn cpu_backend_pool_reuses_nary_einsum_intermediates() {
 
     let result2 = engine.run(&program2).unwrap();
     assert_eq!(get_f64_data(&result2), &[517.0, 766.0, 625.0, 926.0]);
-    let pooled_after_second = engine.backend().buffer_pool_len();
+    let pooled_after_second = engine.backend().buffer_pool_len().unwrap();
     assert!(pooled_after_second < pooled_after_first * 2);
 }

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -37,6 +37,7 @@ tidu = { workspace = true, optional = true }
 computegraph.workspace = true
 num-complex.workspace = true
 num-traits.workspace = true
+lru.workspace = true
 rustfft = "6"
 thiserror.workspace = true
 

--- a/crates/tenferro-fft/src/concrete_tests.rs
+++ b/crates/tenferro-fft/src/concrete_tests.rs
@@ -1,8 +1,9 @@
 use num_complex::Complex64;
+use std::num::NonZeroUsize;
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{ErrorKind, Tensor, TensorRead, TensorView, TypedTensorView};
 
-use crate::{cached_fft_plan_from_cache, FftNorm, FftPlanCache, TensorFftExt, TensorReadFftExt};
+use crate::{FftExecutor, FftNorm, FftPlanCache, TensorFftExt, TensorReadFftExt};
 
 fn assert_complex_close(actual: &[Complex64], expected: &[Complex64]) {
     assert_eq!(actual.len(), expected.len());
@@ -144,23 +145,50 @@ fn public_tensor_fft_ext_reports_invalid_dtype_and_shape_errors() {
 }
 
 #[test]
-fn poisoned_fft_plan_cache_returns_typed_error() {
-    let cache: &'static FftPlanCache<f64> = Box::leak(Box::default());
-    let mutex = cache.get_or_init(Default::default);
-    let _ = std::thread::spawn(move || {
-        let _guard = mutex.lock().unwrap();
-        panic!("poison FFT plan cache for regression test");
-    })
-    .join();
+fn fft_plan_cache_is_bounded_lru_and_reports_known_retention() {
+    let mut cache = FftPlanCache::with_capacity(NonZeroUsize::new(2).unwrap());
+    assert_eq!(cache.capacity().get(), 2);
+    let first = cache.plan_f64(4, true);
+    cache.plan_f64(8, true);
+    assert!(std::sync::Arc::ptr_eq(&first, &cache.plan_f64(4, true)));
+    cache.plan_f64(16, true);
 
-    let Err(err) = cached_fft_plan_from_cache(cache, 4, true) else {
-        panic!("poisoned FFT plan cache must return an error");
-    };
-    assert!(matches!(
-        err,
-        tenferro_tensor::Error::RuntimeState {
-            op: "fft_plan_cache",
-            ..
-        }
-    ));
+    assert!(cache.contains_f64(4, true));
+    assert!(!cache.contains_f64(8, true));
+    assert!(cache.contains_f64(16, true));
+    assert_eq!(cache.stats().entries, 2);
+    assert!(cache.stats().retained_bytes > 0);
+    assert!(std::sync::Arc::ptr_eq(&first, &cache.plan_f64(4, true)));
+
+    cache.clear();
+    assert_eq!(cache.stats(), tenferro_tensor::CacheStats::empty());
+    cache.set_capacity(NonZeroUsize::MIN);
+    assert_eq!(cache.capacity(), NonZeroUsize::MIN);
+}
+
+#[test]
+fn caller_owned_fft_executor_reuses_plans() {
+    let mut backend = CpuBackend::new();
+    let input = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let mut executor = FftExecutor::default();
+
+    let full = executor
+        .fft(&input, None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    executor
+        .ifft(&full, None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    let onesided = executor
+        .rfft(&input, None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    executor
+        .irfft(&onesided, Some(4), -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+
+    assert_eq!(executor.cache_stats().entries, 2);
+    assert_eq!(executor.plan_cache().stats().entries, 2);
+    executor.plan_cache_mut().set_capacity(NonZeroUsize::MIN);
+    assert_eq!(executor.cache_stats().entries, 1);
+    executor.clear_cache();
+    assert_eq!(executor.cache_stats().entries, 0);
 }

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -49,13 +49,15 @@
 //! ```
 
 use std::any::Any;
-use std::collections::HashMap;
-use std::hash::Hasher;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::mem::MaybeUninit;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
+use lru::LruCache;
 use num_complex::Complex;
 use num_traits::{Float, FromPrimitive, Zero};
 use rustfft::{Fft, FftNum, FftPlanner};
@@ -73,10 +75,13 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
 use tenferro_ops::SymDim;
 use tenferro_runtime::extension::{apply, ExtensionExecutionContext, ExtensionOp, HostReference};
-use tenferro_runtime::{Error, ErrorPhase, Result, TracedTensor};
+use tenferro_runtime::{
+    Error, ErrorPhase, ExtensionCacheKey, ExtensionCacheSelector, ExtensionCacheStore, Result,
+    TracedTensor,
+};
 use tenferro_tensor::{
-    DType, DeviceKind, ErrorKind, MemoryKind, Placement, Tensor, TensorBackend, TensorRead,
-    TypedTensor, ValidationError,
+    CacheStats, DType, DeviceKind, ErrorKind, MemoryKind, Placement, RuntimeCacheControl, Tensor,
+    TensorBackend, TensorRead, TypedTensor, ValidationError,
 };
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
@@ -92,6 +97,290 @@ use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 /// );
 /// ```
 pub const FFT_EXTENSION_FAMILY_ID: &str = "tenferro-fft.fft.v1";
+
+/// Runtime cache namespace used for RustFFT plans.
+pub const FFT_PLAN_CACHE_NAME: &str = "rustfft-plans";
+
+/// Default number of plans retained by a caller-owned [`FftPlanCache`].
+pub const DEFAULT_FFT_PLAN_CACHE_CAPACITY: usize = 64;
+
+/// Select the FFT plan entries in an extension runtime cache.
+pub const fn fft_plan_cache_selector() -> ExtensionCacheSelector {
+    ExtensionCacheSelector::Cache {
+        family_id: FFT_EXTENSION_FAMILY_ID,
+        cache_name: FFT_PLAN_CACHE_NAME,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum FftPlanDType {
+    F32,
+    F64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct FftPlanKey {
+    len: usize,
+    forward: bool,
+    dtype: FftPlanDType,
+}
+
+enum CachedFftPlan {
+    F32(Arc<dyn Fft<f32>>),
+    F64(Arc<dyn Fft<f64>>),
+}
+
+/// Bounded, caller-owned LRU cache of RustFFT plans.
+///
+/// Retained-byte statistics include the cache-owned key and `Arc` handle for
+/// each entry. RustFFT does not expose the allocations owned by an opaque plan,
+/// so those allocations are intentionally excluded from the estimate.
+pub struct FftPlanCache {
+    entries: LruCache<FftPlanKey, CachedFftPlan>,
+}
+
+impl FftPlanCache {
+    /// Create an empty plan cache with an explicit maximum entry count.
+    pub fn with_capacity(capacity: NonZeroUsize) -> Self {
+        Self {
+            entries: LruCache::new(capacity),
+        }
+    }
+
+    /// Maximum number of retained plans.
+    pub fn capacity(&self) -> NonZeroUsize {
+        self.entries.cap()
+    }
+
+    /// Resize the cache, evicting least-recently-used plans when necessary.
+    pub fn set_capacity(&mut self, capacity: NonZeroUsize) {
+        self.entries.resize(capacity);
+    }
+
+    /// Remove every retained plan.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    /// Snapshot the number of plans and known cache-owned bytes retained.
+    pub fn stats(&self) -> CacheStats {
+        CacheStats {
+            entries: self.entries.len(),
+            retained_bytes: self.entries.len().saturating_mul(fft_plan_retained_bytes()),
+        }
+    }
+
+    fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>> {
+        let key = FftPlanKey {
+            len,
+            forward,
+            dtype: FftPlanDType::F32,
+        };
+        if let Some(CachedFftPlan::F32(plan)) = self.entries.get(&key) {
+            return Arc::clone(plan);
+        }
+        let plan = build_fft_plan::<f32>(len, forward);
+        self.entries.put(key, CachedFftPlan::F32(Arc::clone(&plan)));
+        plan
+    }
+
+    fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>> {
+        let key = FftPlanKey {
+            len,
+            forward,
+            dtype: FftPlanDType::F64,
+        };
+        if let Some(CachedFftPlan::F64(plan)) = self.entries.get(&key) {
+            return Arc::clone(plan);
+        }
+        let plan = build_fft_plan::<f64>(len, forward);
+        self.entries.put(key, CachedFftPlan::F64(Arc::clone(&plan)));
+        plan
+    }
+
+    #[cfg(test)]
+    fn contains_f64(&self, len: usize, forward: bool) -> bool {
+        self.entries.contains(&FftPlanKey {
+            len,
+            forward,
+            dtype: FftPlanDType::F64,
+        })
+    }
+}
+
+impl Default for FftPlanCache {
+    fn default() -> Self {
+        Self::with_capacity(
+            NonZeroUsize::new(DEFAULT_FFT_PLAN_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN),
+        )
+    }
+}
+
+impl RuntimeCacheControl for FftPlanCache {
+    fn clear(&mut self) {
+        Self::clear(self);
+    }
+
+    fn stats(&self) -> CacheStats {
+        Self::stats(self)
+    }
+}
+
+/// Reusable concrete FFT executor with explicitly owned plan state.
+#[derive(Default)]
+pub struct FftExecutor {
+    plans: FftPlanCache,
+}
+
+impl FftExecutor {
+    /// Create an executor from a caller-configured plan cache.
+    pub fn new(plans: FftPlanCache) -> Self {
+        Self { plans }
+    }
+
+    /// Inspect the owned plan cache.
+    pub const fn plan_cache(&self) -> &FftPlanCache {
+        &self.plans
+    }
+
+    /// Mutably inspect or configure the owned plan cache.
+    pub fn plan_cache_mut(&mut self) -> &mut FftPlanCache {
+        &mut self.plans
+    }
+
+    /// Snapshot the owned plan cache statistics.
+    pub fn cache_stats(&self) -> CacheStats {
+        self.plans.stats()
+    }
+
+    /// Remove every retained plan from this executor.
+    pub fn clear_cache(&mut self) {
+        self.plans.clear();
+    }
+
+    /// Execute a complex or full-spectrum real FFT while reusing owned plans.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
+    /// `InvalidArgument` for invalid `axis`/`n`,
+    /// [`tenferro_tensor::Error::Extension`] with [`ErrorKind::Unsupported`]
+    /// for unsupported dtypes, or a typed backend source for execution.
+    pub fn fft<B: TensorBackend>(
+        &mut self,
+        input: &Tensor,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        self.execute(
+            input,
+            concrete_fft_kind("FftExecutor::fft", input.dtype())?,
+            "FftExecutor::fft",
+            n,
+            axis,
+            norm,
+            backend,
+        )
+    }
+
+    /// Execute an inverse complex FFT while reusing owned plans.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
+    /// `InvalidArgument` for invalid `axis`/`n`,
+    /// [`tenferro_tensor::Error::Extension`] with [`ErrorKind::Unsupported`]
+    /// for a non-complex input, or a typed backend source for execution.
+    pub fn ifft<B: TensorBackend>(
+        &mut self,
+        input: &Tensor,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        self.execute(
+            input,
+            concrete_ifft_kind("FftExecutor::ifft", input.dtype())?,
+            "FftExecutor::ifft",
+            n,
+            axis,
+            norm,
+            backend,
+        )
+    }
+
+    /// Execute a real FFT while reusing owned plans.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
+    /// `InvalidArgument` for invalid `axis`/`n`,
+    /// [`tenferro_tensor::Error::Extension`] with [`ErrorKind::Unsupported`]
+    /// for a non-real input, or a typed backend source for execution.
+    pub fn rfft<B: TensorBackend>(
+        &mut self,
+        input: &Tensor,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        self.execute(
+            input,
+            concrete_rfft_kind("FftExecutor::rfft", input.dtype())?,
+            "FftExecutor::rfft",
+            n,
+            axis,
+            norm,
+            backend,
+        )
+    }
+
+    /// Execute an inverse real FFT while reusing owned plans.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds`,
+    /// `InvalidArgument`, or spectrum-length details,
+    /// [`tenferro_tensor::Error::Extension`] with [`ErrorKind::Unsupported`]
+    /// for a non-complex input, or a typed backend source for execution.
+    pub fn irfft<B: TensorBackend>(
+        &mut self,
+        input: &Tensor,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        self.execute(
+            input,
+            concrete_irfft_kind("FftExecutor::irfft", input.dtype())?,
+            "FftExecutor::irfft",
+            n,
+            axis,
+            norm,
+            backend,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn execute<B: TensorBackend>(
+        &mut self,
+        input: &Tensor,
+        kind: FftKind,
+        op_name: &'static str,
+        n: Option<usize>,
+        axis: isize,
+        norm: FftNorm,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        let op = concrete_fft_op(op_name, kind, input.shape(), n, axis, norm)?;
+        execute_concrete_fft_op_with_plans(input, &op, backend, &mut self.plans)
+    }
+}
 
 /// FFT extension methods for [`TracedTensor`].
 pub trait TracedTensorFftExt {
@@ -703,6 +992,15 @@ impl HostReference for FftOp {
 }
 
 fn execute_host_fft_op(op: &FftOp, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
+    let mut plans = FftPlanCache::with_capacity(NonZeroUsize::MIN);
+    execute_host_fft_op_with_plans(op, inputs, &mut plans)
+}
+
+fn execute_host_fft_op_with_plans<P: FftPlanProvider + ?Sized>(
+    op: &FftOp,
+    inputs: &[&Tensor],
+    plans: &mut P,
+) -> tenferro_tensor::Result<Vec<Tensor>> {
     if inputs.len() != 1 {
         return Err(tenferro_tensor::Error::invalid_argument(
             "tenferro-fft",
@@ -716,34 +1014,34 @@ fn execute_host_fft_op(op: &FftOp, inputs: &[&Tensor]) -> tenferro_tensor::Resul
         (FftKind::C2C { forward }, Tensor::C64(input)) => {
             Tensor::C64(TypedTensor::from_vec_col_major(
                 output_shape_c2c(input.shape(), op.axis, op.n)?,
-                execute_c2c(input, op.axis, op.n, forward, op.norm)?,
+                execute_c2c(input, op.axis, op.n, forward, op.norm, plans)?,
             )?)
         }
         (FftKind::C2C { forward }, Tensor::C32(input)) => {
             Tensor::C32(TypedTensor::from_vec_col_major(
                 output_shape_c2c(input.shape(), op.axis, op.n)?,
-                execute_c2c(input, op.axis, op.n, forward, op.norm)?,
+                execute_c2c(input, op.axis, op.n, forward, op.norm, plans)?,
             )?)
         }
         (FftKind::R2C { onesided }, Tensor::F64(input)) => {
             Tensor::C64(TypedTensor::from_vec_col_major(
                 output_shape_r2c(input.shape(), op.axis, op.n, onesided)?,
-                execute_r2c(input, op.axis, op.n, onesided, op.norm)?,
+                execute_r2c(input, op.axis, op.n, onesided, op.norm, plans)?,
             )?)
         }
         (FftKind::R2C { onesided }, Tensor::F32(input)) => {
             Tensor::C32(TypedTensor::from_vec_col_major(
                 output_shape_r2c(input.shape(), op.axis, op.n, onesided)?,
-                execute_r2c(input, op.axis, op.n, onesided, op.norm)?,
+                execute_r2c(input, op.axis, op.n, onesided, op.norm, plans)?,
             )?)
         }
         (FftKind::C2R, Tensor::C64(input)) => Tensor::F64(TypedTensor::from_vec_col_major(
             output_shape_c2r(input.shape(), op.axis, op.n)?,
-            execute_c2r(input, op.axis, op.n, op.norm)?,
+            execute_c2r(input, op.axis, op.n, op.norm, plans)?,
         )?),
         (FftKind::C2R, Tensor::C32(input)) => Tensor::F32(TypedTensor::from_vec_col_major(
             output_shape_c2r(input.shape(), op.axis, op.n)?,
-            execute_c2r(input, op.axis, op.n, op.norm)?,
+            execute_c2r(input, op.axis, op.n, op.norm, plans)?,
         )?),
         (kind, other) => {
             return Err(tensor_unsupported_dtype(
@@ -762,6 +1060,17 @@ fn execute_concrete_fft_op<B: TensorBackend>(
     backend: &mut B,
 ) -> tenferro_tensor::Result<Tensor> {
     backend.with_backend_session(|_exec| single_fft_output(execute_host_fft_op(op, &[input])?))
+}
+
+fn execute_concrete_fft_op_with_plans<B: TensorBackend, P: FftPlanProvider + ?Sized>(
+    input: &Tensor,
+    op: &FftOp,
+    backend: &mut B,
+    plans: &mut P,
+) -> tenferro_tensor::Result<Tensor> {
+    backend.with_backend_session(|_exec| {
+        single_fft_output(execute_host_fft_op_with_plans(op, &[input], plans)?)
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1226,9 +1535,10 @@ pub fn ad_rules() -> std::result::Result<ExtensionRuleSet, ExtensionRegistryErro
 fn execute_fft_extension<B: TensorBackend + 'static>(
     op: &FftOp,
     inputs: &[&Tensor],
-    _ctx: &mut ExtensionExecutionContext<'_, B>,
+    ctx: &mut ExtensionExecutionContext<'_, B>,
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
-    execute_host_fft_op(op, inputs)
+    let mut plans = ExtensionFftPlanCache::new(ctx.caches_mut());
+    execute_host_fft_op_with_plans(op, inputs, &mut plans)
 }
 
 fn execute_fft_extension_reads<B: TensorBackend + 'static>(
@@ -1246,7 +1556,8 @@ fn execute_fft_extension_reads<B: TensorBackend + 'static>(
             .collect::<tenferro_tensor::Result<Vec<_>>>()
     })?;
     let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
-    execute_host_fft_op(op, &input_refs)
+    let mut plans = ExtensionFftPlanCache::new(ctx.caches_mut());
+    execute_host_fft_op_with_plans(op, &input_refs, &mut plans)
 }
 
 define_extension_runtime! {
@@ -1772,68 +2083,150 @@ unsafe fn assume_init_output_vec<T>(mut output: Vec<MaybeUninit<T>>) -> Vec<T> {
     unsafe { Vec::from_raw_parts(ptr, len, capacity) }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct FftPlanKey {
-    len: usize,
-    forward: bool,
+fn build_fft_plan<T: FftNum + 'static>(len: usize, forward: bool) -> Arc<dyn Fft<T>> {
+    let mut planner = FftPlanner::<T>::new();
+    if forward {
+        planner.plan_fft_forward(len)
+    } else {
+        planner.plan_fft_inverse(len)
+    }
+}
+
+const fn fft_plan_retained_bytes() -> usize {
+    std::mem::size_of::<FftPlanKey>() + std::mem::size_of::<CachedFftPlan>()
+}
+
+trait FftPlanProvider: Send {
+    fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>>;
+    fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>>;
+}
+
+impl FftPlanProvider for FftPlanCache {
+    fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>> {
+        Self::plan_f32(self, len, forward)
+    }
+
+    fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>> {
+        Self::plan_f64(self, len, forward)
+    }
 }
 
 trait CachedFftPlanScalar: FftNum + Float + FromPrimitive + 'static {
-    fn cached_fft_plan(len: usize, forward: bool) -> tenferro_tensor::Result<Arc<dyn Fft<Self>>>;
+    fn plan<P: FftPlanProvider + ?Sized>(
+        plans: &mut P,
+        len: usize,
+        forward: bool,
+    ) -> Arc<dyn Fft<Self>>;
 }
 
-type FftPlanStore<T> = HashMap<FftPlanKey, Arc<dyn Fft<T>>>;
-type FftPlanCache<T> = OnceLock<Mutex<FftPlanStore<T>>>;
-
-static F32_FFT_PLAN_CACHE: FftPlanCache<f32> = OnceLock::new();
-static F64_FFT_PLAN_CACHE: FftPlanCache<f64> = OnceLock::new();
-
 impl CachedFftPlanScalar for f32 {
-    fn cached_fft_plan(len: usize, forward: bool) -> tenferro_tensor::Result<Arc<dyn Fft<Self>>> {
-        cached_fft_plan_from_cache(&F32_FFT_PLAN_CACHE, len, forward)
+    fn plan<P: FftPlanProvider + ?Sized>(
+        plans: &mut P,
+        len: usize,
+        forward: bool,
+    ) -> Arc<dyn Fft<Self>> {
+        plans.plan_f32(len, forward)
     }
 }
 
 impl CachedFftPlanScalar for f64 {
-    fn cached_fft_plan(len: usize, forward: bool) -> tenferro_tensor::Result<Arc<dyn Fft<Self>>> {
-        cached_fft_plan_from_cache(&F64_FFT_PLAN_CACHE, len, forward)
+    fn plan<P: FftPlanProvider + ?Sized>(
+        plans: &mut P,
+        len: usize,
+        forward: bool,
+    ) -> Arc<dyn Fft<Self>> {
+        plans.plan_f64(len, forward)
     }
 }
 
-fn cached_fft_plan<T: CachedFftPlanScalar>(
+fn cached_fft_plan<T: CachedFftPlanScalar, P: FftPlanProvider + ?Sized>(
+    plans: &mut P,
     len: usize,
     forward: bool,
-) -> tenferro_tensor::Result<Arc<dyn Fft<T>>> {
-    T::cached_fft_plan(len, forward)
+) -> Arc<dyn Fft<T>> {
+    T::plan(plans, len, forward)
 }
 
-fn cached_fft_plan_from_cache<T: FftNum + 'static>(
-    cache: &'static FftPlanCache<T>,
-    len: usize,
-    forward: bool,
-) -> tenferro_tensor::Result<Arc<dyn Fft<T>>> {
-    let key = FftPlanKey { len, forward };
-    let mut guard = cache
-        .get_or_init(|| Mutex::new(HashMap::new()))
-        .lock()
-        .map_err(|_| {
-            tenferro_tensor::Error::runtime_state(
-                "fft_plan_cache",
-                "FFT plan cache lock is poisoned",
-            )
-        })?;
-    if let Some(plan) = guard.get(&key) {
-        return Ok(Arc::clone(plan));
+#[derive(Clone)]
+struct ExtensionF32Plan {
+    key: FftPlanKey,
+    plan: Arc<dyn Fft<f32>>,
+}
+
+#[derive(Clone)]
+struct ExtensionF64Plan {
+    key: FftPlanKey,
+    plan: Arc<dyn Fft<f64>>,
+}
+
+struct ExtensionFftPlanCache<'a> {
+    entries: &'a mut ExtensionCacheStore,
+}
+
+impl<'a> ExtensionFftPlanCache<'a> {
+    fn new(entries: &'a mut ExtensionCacheStore) -> Self {
+        Self { entries }
+    }
+}
+
+fn extension_plan_key(key: FftPlanKey) -> ExtensionCacheKey {
+    let mut hasher = DefaultHasher::new();
+    key.hash(&mut hasher);
+    ExtensionCacheKey::new(
+        FFT_EXTENSION_FAMILY_ID,
+        FFT_PLAN_CACHE_NAME,
+        hasher.finish(),
+    )
+}
+
+impl FftPlanProvider for ExtensionFftPlanCache<'_> {
+    fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>> {
+        let key = FftPlanKey {
+            len,
+            forward,
+            dtype: FftPlanDType::F32,
+        };
+        let cache_key = extension_plan_key(key);
+        if let Some(cached) = self.entries.get::<ExtensionF32Plan>(&cache_key) {
+            if cached.key == key {
+                return Arc::clone(&cached.plan);
+            }
+        }
+        let plan = build_fft_plan::<f32>(len, forward);
+        self.entries.put(
+            cache_key,
+            ExtensionF32Plan {
+                key,
+                plan: Arc::clone(&plan),
+            },
+            fft_plan_retained_bytes(),
+        );
+        plan
     }
 
-    let mut planner = FftPlanner::<T>::new();
-    let plan = if forward {
-        planner.plan_fft_forward(len)
-    } else {
-        planner.plan_fft_inverse(len)
-    };
-    guard.insert(key, Arc::clone(&plan));
-    Ok(plan)
+    fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>> {
+        let key = FftPlanKey {
+            len,
+            forward,
+            dtype: FftPlanDType::F64,
+        };
+        let cache_key = extension_plan_key(key);
+        if let Some(cached) = self.entries.get::<ExtensionF64Plan>(&cache_key) {
+            if cached.key == key {
+                return Arc::clone(&cached.plan);
+            }
+        }
+        let plan = build_fft_plan::<f64>(len, forward);
+        self.entries.put(
+            cache_key,
+            ExtensionF64Plan {
+                key,
+                plan: Arc::clone(&plan),
+            },
+            fft_plan_retained_bytes(),
+        );
+        plan
+    }
 }
 
 fn execute_c2c<T>(
@@ -1842,6 +2235,7 @@ fn execute_c2c<T>(
     n: Option<usize>,
     forward: bool,
     norm: FftNorm,
+    plans: &mut (impl FftPlanProvider + ?Sized),
 ) -> tenferro_tensor::Result<Vec<Complex<T>>>
 where
     T: CachedFftPlanScalar,
@@ -1853,8 +2247,7 @@ where
     let input_data = input.host_data()?;
     let output_len = checked_shape_product("fft", "output", &out_shape)?;
     let mut output = uninit_output_vec(output_len);
-    // Propagate poisoned FFT plan-cache errors to the public caller.
-    let fft_plan = cached_fft_plan::<T>(fft_len, forward)?;
+    let fft_plan = cached_fft_plan::<T, _>(plans, fft_len, forward);
     let scale: T = scale_for(norm, forward, fft_len)?;
     let mut lane = vec![Complex::zero(); fft_len];
 
@@ -1898,6 +2291,7 @@ fn execute_r2c<T>(
     n: Option<usize>,
     onesided: bool,
     norm: FftNorm,
+    plans: &mut (impl FftPlanProvider + ?Sized),
 ) -> tenferro_tensor::Result<Vec<Complex<T>>>
 where
     T: CachedFftPlanScalar,
@@ -1909,8 +2303,7 @@ where
     let input_data = input.host_data()?;
     let output_len = checked_shape_product("rfft", "output", &out_shape)?;
     let mut output = uninit_output_vec(output_len);
-    // Propagate poisoned FFT plan-cache errors to the public caller.
-    let fft_plan = cached_fft_plan::<T>(fft_len, true)?;
+    let fft_plan = cached_fft_plan::<T, _>(plans, fft_len, true);
     let scale: T = scale_for(norm, true, fft_len)?;
     let mut lane = vec![Complex::zero(); fft_len];
 
@@ -1953,6 +2346,7 @@ fn execute_c2r<T>(
     axis: usize,
     n: Option<usize>,
     norm: FftNorm,
+    plans: &mut (impl FftPlanProvider + ?Sized),
 ) -> tenferro_tensor::Result<Vec<T>>
 where
     T: CachedFftPlanScalar,
@@ -1964,8 +2358,7 @@ where
     let input_data = input.host_data()?;
     let output_len = checked_shape_product("irfft", "output", &out_shape)?;
     let mut output = uninit_output_vec(output_len);
-    // Propagate poisoned FFT plan-cache errors to the public caller.
-    let fft_plan = cached_fft_plan::<T>(out_axis_len, false)?;
+    let fft_plan = cached_fft_plan::<T, _>(plans, out_axis_len, false);
     let scale: T = scale_for(norm, false, out_axis_len)?;
     let mut lane = vec![Complex::zero(); out_axis_len];
 

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -2,7 +2,7 @@ use num_complex::{Complex32, Complex64};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
 use tenferro_cpu::CpuBackend;
-use tenferro_fft::{FftNorm, TracedTensorFftExt};
+use tenferro_fft::{fft_plan_cache_selector, FftNorm, TracedTensorFftExt};
 use tenferro_runtime::{
     DType, Error as RuntimeError, ErrorPhase, GraphCompiler, GraphExecutor, Tensor, TracedTensor,
 };
@@ -199,8 +199,8 @@ fn fft_cpu_execution_reuses_cached_rustfft_plans() {
     let c2r = source_section(source, "fn execute_c2r<T>(", "fn scale_for<T>(");
 
     assert!(
-        source.contains("fn cached_fft_plan<T: CachedFftPlanScalar>"),
-        "FFT CPU execution should centralize RustFFT plan reuse in cached_fft_plan"
+        source.contains("trait FftPlanProvider"),
+        "FFT CPU execution should obtain plans from an explicit owner"
     );
     for (name, section) in [
         ("execute_c2c", c2c),
@@ -215,7 +215,7 @@ fn fft_cpu_execution_reuses_cached_rustfft_plans() {
 }
 
 #[test]
-fn fft_cpu_execution_propagates_plan_cache_errors() {
+fn fft_cpu_execution_uses_explicit_plan_provider() {
     let source = include_str!("../src/lib.rs");
     let c2c = source_section(source, "fn execute_c2c<T>(", "fn execute_r2c<T>(");
     let r2c = source_section(source, "fn execute_r2c<T>(", "fn execute_c2r<T>(");
@@ -227,8 +227,8 @@ fn fft_cpu_execution_propagates_plan_cache_errors() {
         ("execute_c2r", c2r),
     ] {
         let call_start = section
-            .find("cached_fft_plan::<T>")
-            .unwrap_or_else(|| panic!("{name} must call cached_fft_plan::<T>"));
+            .find("cached_fft_plan::<T, _>(plans")
+            .unwrap_or_else(|| panic!("{name} must use its explicit plan provider"));
         let call_end = section[call_start..]
             .find(';')
             .map(|offset| call_start + offset + 1)
@@ -239,10 +239,58 @@ fn fft_cpu_execution_propagates_plan_cache_errors() {
             .join(" ");
 
         assert!(
-            normalized_call.ends_with("?;"),
-            "{name} must propagate its cached_fft_plan error: {normalized_call}"
+            normalized_call.ends_with(");"),
+            "unexpected plan call: {normalized_call}"
         );
     }
+}
+
+#[test]
+fn fft_source_has_no_process_global_plan_cache() {
+    let source = include_str!("../src/lib.rs");
+
+    assert!(!source.contains("static F32_FFT_PLAN_CACHE"));
+    assert!(!source.contains("static F64_FFT_PLAN_CACHE"));
+    assert!(!source.contains("OnceLock<Mutex"));
+}
+
+#[test]
+fn graph_runtime_owns_fft_plan_cache() {
+    let x = TracedTensor::from_vec_col_major(
+        vec![4],
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let y = x.fft(None, -1, FftNorm::Backward).unwrap();
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile(&y).unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    executor
+        .register_extension(tenferro_fft::register_runtime)
+        .unwrap();
+
+    executor.run(&program).unwrap();
+    let stats = executor
+        .extension_executor()
+        .caches()
+        .stats(fft_plan_cache_selector());
+    assert_eq!(stats.entries, 1);
+    assert!(stats.retained_bytes > 0);
+
+    executor.clear_extension_caches();
+    assert_eq!(
+        executor
+            .extension_executor()
+            .caches()
+            .stats(fft_plan_cache_selector())
+            .entries,
+        0
+    );
 }
 
 #[test]

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -1,4 +1,4 @@
-use tenferro_tensor::{Tensor, TensorBackend, TensorView};
+use tenferro_tensor::{Tensor, TensorBackend, TensorRead};
 
 pub(crate) use crate::error::unsupported_dtype;
 use crate::extension::{
@@ -170,9 +170,9 @@ pub trait LinalgBackend: TensorBackend {
         ))
     }
 
-    /// Compute a singular value decomposition from a borrowed tensor view.
+    /// Compute a singular value decomposition from a tensor read target.
     ///
-    /// Backends may canonicalize the view inside the same placement family, but
+    /// Backends may canonicalize the input inside the same placement family, but
     /// must not silently transfer between CPU and GPU memory.
     ///
     /// # Examples
@@ -180,14 +180,14 @@ pub trait LinalgBackend: TensorBackend {
     /// ```rust
     /// use tenferro_linalg::LinalgBackend;
     /// use tenferro_cpu::CpuBackend;
-    /// use tenferro_tensor::{TensorView, TypedTensor};
+    /// use tenferro_tensor::{TensorRead, TensorView, TypedTensor};
     ///
     /// let input = TypedTensor::<f64>::from_vec_col_major(
     ///     vec![2, 2],
     ///     vec![1.0, 0.0, 0.0, 2.0],
     /// )?;
     /// let mut backend = CpuBackend::new();
-    /// let outputs = backend.svd_read(TensorView::F64(input.as_view()))?;
+    /// let outputs = backend.svd_read(TensorRead::from_view(TensorView::F64(input.as_view())))?;
     /// assert_eq!(outputs[1].shape(), &[2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
@@ -195,13 +195,13 @@ pub trait LinalgBackend: TensorBackend {
     /// # Errors
     ///
     /// The default implementation returns `Error::Unsupported` because the
-    /// backend does not accept borrowed views; an implementation may instead
+    /// backend does not accept tensor read targets; an implementation may instead
     /// return validation or typed backend-source errors after canonicalizing
     /// the view.
-    fn svd_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn svd_read(&mut self, _input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         Err(tenferro_tensor::Error::unsupported(
             "svd",
-            "backend does not accept borrowed tensor views at this execution boundary",
+            "backend does not accept tensor reads at this execution boundary",
         ))
     }
 
@@ -261,9 +261,9 @@ pub trait LinalgBackend: TensorBackend {
         Ok(outputs)
     }
 
-    /// Compute public QR outputs `(Q, R)` from a borrowed tensor view.
+    /// Compute public QR outputs `(Q, R)` from a tensor read target.
     ///
-    /// Backends may canonicalize the view inside the same placement family, but
+    /// Backends may canonicalize the input inside the same placement family, but
     /// must not silently transfer between CPU and GPU memory.
     ///
     /// # Examples
@@ -271,14 +271,14 @@ pub trait LinalgBackend: TensorBackend {
     /// ```rust
     /// use tenferro_linalg::LinalgBackend;
     /// use tenferro_cpu::CpuBackend;
-    /// use tenferro_tensor::{TensorView, TypedTensor};
+    /// use tenferro_tensor::{TensorRead, TensorView, TypedTensor};
     ///
     /// let input = TypedTensor::<f64>::from_vec_col_major(
     ///     vec![2, 2],
     ///     vec![1.0, 0.0, 0.0, 2.0],
     /// )?;
     /// let mut backend = CpuBackend::new();
-    /// let outputs = backend.qr_read(TensorView::F64(input.as_view()))?;
+    /// let outputs = backend.qr_read(TensorRead::from_view(TensorView::F64(input.as_view())))?;
     /// assert_eq!(outputs[0].shape(), &[2, 2]);
     /// assert_eq!(outputs[1].shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
@@ -287,12 +287,12 @@ pub trait LinalgBackend: TensorBackend {
     /// # Errors
     ///
     /// The default implementation returns `Error::Unsupported` because the
-    /// backend does not accept borrowed views; implementations may return
+    /// backend does not accept tensor read targets; implementations may return
     /// validation or typed backend-source errors.
-    fn qr_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn qr_read(&mut self, _input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         Err(tenferro_tensor::Error::unsupported(
             "qr",
-            "backend does not accept borrowed tensor views at this execution boundary",
+            "backend does not accept tensor reads at this execution boundary",
         ))
     }
 
@@ -360,9 +360,9 @@ pub trait LinalgBackend: TensorBackend {
         Ok(outputs)
     }
 
-    /// Compute public Hermitian eigendecomposition outputs from a borrowed tensor view.
+    /// Compute public Hermitian eigendecomposition outputs from a tensor read target.
     ///
-    /// Backends may canonicalize the view inside the same placement family, but
+    /// Backends may canonicalize the input inside the same placement family, but
     /// must not silently transfer between CPU and GPU memory.
     ///
     /// # Examples
@@ -370,14 +370,14 @@ pub trait LinalgBackend: TensorBackend {
     /// ```rust
     /// use tenferro_linalg::LinalgBackend;
     /// use tenferro_cpu::CpuBackend;
-    /// use tenferro_tensor::{TensorView, TypedTensor};
+    /// use tenferro_tensor::{TensorRead, TensorView, TypedTensor};
     ///
     /// let input = TypedTensor::<f64>::from_vec_col_major(
     ///     vec![2, 2],
     ///     vec![1.0, 0.0, 0.0, 2.0],
     /// )?;
     /// let mut backend = CpuBackend::new();
-    /// let outputs = backend.eigh_read(TensorView::F64(input.as_view()))?;
+    /// let outputs = backend.eigh_read(TensorRead::from_view(TensorView::F64(input.as_view())))?;
     /// assert_eq!(outputs[0].shape(), &[2]);
     /// assert_eq!(outputs[1].shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
@@ -386,18 +386,18 @@ pub trait LinalgBackend: TensorBackend {
     /// # Errors
     ///
     /// The default implementation returns `Error::Unsupported` because the
-    /// backend does not accept borrowed views; implementations may return
+    /// backend does not accept tensor read targets; implementations may return
     /// validation or typed backend-source errors.
-    fn eigh_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn eigh_read(&mut self, _input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         Err(tenferro_tensor::Error::unsupported(
             "eigh",
-            "backend does not accept borrowed tensor views at this execution boundary",
+            "backend does not accept tensor reads at this execution boundary",
         ))
     }
 
-    /// Compute Cholesky factorization from a borrowed tensor view.
+    /// Compute Cholesky factorization from a tensor read target.
     ///
-    /// Backends may canonicalize the view inside the same placement family, but
+    /// Backends may canonicalize the input inside the same placement family, but
     /// must not silently transfer between CPU and GPU memory.
     ///
     /// # Examples
@@ -405,14 +405,14 @@ pub trait LinalgBackend: TensorBackend {
     /// ```rust
     /// use tenferro_linalg::LinalgBackend;
     /// use tenferro_cpu::CpuBackend;
-    /// use tenferro_tensor::{TensorView, TypedTensor};
+    /// use tenferro_tensor::{TensorRead, TensorView, TypedTensor};
     ///
     /// let input = TypedTensor::<f64>::from_vec_col_major(
     ///     vec![2, 2],
     ///     vec![4.0, 2.0, 2.0, 3.0],
     /// )?;
     /// let mut backend = CpuBackend::new();
-    /// let output = backend.cholesky_read(TensorView::F64(input.as_view()))?;
+    /// let output = backend.cholesky_read(TensorRead::from_view(TensorView::F64(input.as_view())))?;
     /// assert_eq!(output.shape(), &[2, 2]);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
@@ -420,18 +420,18 @@ pub trait LinalgBackend: TensorBackend {
     /// # Errors
     ///
     /// The default implementation returns `Error::Unsupported` because the
-    /// backend does not accept borrowed views; implementations may return
+    /// backend does not accept tensor read targets; implementations may return
     /// validation or typed backend-source errors.
-    fn cholesky_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Tensor> {
+    fn cholesky_read(&mut self, _input: TensorRead<'_>) -> tenferro_tensor::Result<Tensor> {
         Err(tenferro_tensor::Error::unsupported(
             "cholesky",
-            "backend does not accept borrowed tensor views at this execution boundary",
+            "backend does not accept tensor reads at this execution boundary",
         ))
     }
 
-    /// Compute public LU outputs from a borrowed tensor view.
+    /// Compute public LU outputs from a tensor read target.
     ///
-    /// Backends may canonicalize the view inside the same placement family, but
+    /// Backends may canonicalize the input inside the same placement family, but
     /// must not silently transfer between CPU and GPU memory.
     ///
     /// # Examples
@@ -439,14 +439,14 @@ pub trait LinalgBackend: TensorBackend {
     /// ```rust
     /// use tenferro_linalg::LinalgBackend;
     /// use tenferro_cpu::CpuBackend;
-    /// use tenferro_tensor::{TensorView, TypedTensor};
+    /// use tenferro_tensor::{TensorRead, TensorView, TypedTensor};
     ///
     /// let input = TypedTensor::<f64>::from_vec_col_major(
     ///     vec![2, 2],
     ///     vec![1.0, 3.0, 2.0, 4.0],
     /// )?;
     /// let mut backend = CpuBackend::new();
-    /// let outputs = backend.lu_read(TensorView::F64(input.as_view()))?;
+    /// let outputs = backend.lu_read(TensorRead::from_view(TensorView::F64(input.as_view())))?;
     /// assert_eq!(outputs.len(), 4);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
@@ -454,18 +454,18 @@ pub trait LinalgBackend: TensorBackend {
     /// # Errors
     ///
     /// The default implementation returns `Error::Unsupported` because the
-    /// backend does not accept borrowed views; implementations may return
+    /// backend does not accept tensor read targets; implementations may return
     /// validation or typed backend-source errors.
-    fn lu_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn lu_read(&mut self, _input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         Err(tenferro_tensor::Error::unsupported(
             "lu",
-            "backend does not accept borrowed tensor views at this execution boundary",
+            "backend does not accept tensor reads at this execution boundary",
         ))
     }
 
-    /// Compute public full-pivoting LU outputs from a borrowed tensor view.
+    /// Compute public full-pivoting LU outputs from a tensor read target.
     ///
-    /// Backends may canonicalize the view inside the same placement family, but
+    /// Backends may canonicalize the input inside the same placement family, but
     /// must not silently transfer between CPU and GPU memory.
     ///
     /// # Examples
@@ -473,14 +473,14 @@ pub trait LinalgBackend: TensorBackend {
     /// ```rust
     /// use tenferro_linalg::LinalgBackend;
     /// use tenferro_cpu::CpuBackend;
-    /// use tenferro_tensor::{TensorView, TypedTensor};
+    /// use tenferro_tensor::{TensorRead, TensorView, TypedTensor};
     ///
     /// let input = TypedTensor::<f64>::from_vec_col_major(
     ///     vec![2, 2],
     ///     vec![1.0, 3.0, 2.0, 4.0],
     /// )?;
     /// let mut backend = CpuBackend::new();
-    /// let outputs = backend.full_piv_lu_read(TensorView::F64(input.as_view()))?;
+    /// let outputs = backend.full_piv_lu_read(TensorRead::from_view(TensorView::F64(input.as_view())))?;
     /// assert_eq!(outputs.len(), 5);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
@@ -488,18 +488,18 @@ pub trait LinalgBackend: TensorBackend {
     /// # Errors
     ///
     /// The default implementation returns `Error::Unsupported` because the
-    /// backend does not accept borrowed views; implementations may return
+    /// backend does not accept tensor read targets; implementations may return
     /// validation or typed backend-source errors.
-    fn full_piv_lu_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn full_piv_lu_read(&mut self, _input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         Err(tenferro_tensor::Error::unsupported(
             "full_piv_lu",
-            "backend does not accept borrowed tensor views at this execution boundary",
+            "backend does not accept tensor reads at this execution boundary",
         ))
     }
 
-    /// Compute general eigendecomposition outputs from a borrowed tensor view.
+    /// Compute general eigendecomposition outputs from a tensor read target.
     ///
-    /// Backends may canonicalize the view inside the same placement family, but
+    /// Backends may canonicalize the input inside the same placement family, but
     /// must not silently transfer between CPU and GPU memory.
     ///
     /// # Examples
@@ -507,14 +507,14 @@ pub trait LinalgBackend: TensorBackend {
     /// ```rust
     /// use tenferro_linalg::LinalgBackend;
     /// use tenferro_cpu::CpuBackend;
-    /// use tenferro_tensor::{TensorView, TypedTensor};
+    /// use tenferro_tensor::{TensorRead, TensorView, TypedTensor};
     ///
     /// let input = TypedTensor::<f64>::from_vec_col_major(
     ///     vec![2, 2],
     ///     vec![2.0, 0.0, 0.0, 3.0],
     /// )?;
     /// let mut backend = CpuBackend::new();
-    /// let outputs = backend.eig_read(TensorView::F64(input.as_view()))?;
+    /// let outputs = backend.eig_read(TensorRead::from_view(TensorView::F64(input.as_view())))?;
     /// assert_eq!(outputs.len(), 2);
     /// # Ok::<(), tenferro_tensor::Error>(())
     /// ```
@@ -522,12 +522,12 @@ pub trait LinalgBackend: TensorBackend {
     /// # Errors
     ///
     /// The default implementation returns `Error::Unsupported` because the
-    /// backend does not accept borrowed views; implementations may return
+    /// backend does not accept tensor read targets; implementations may return
     /// validation or typed backend-source errors.
-    fn eig_read(&mut self, _input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn eig_read(&mut self, _input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         Err(tenferro_tensor::Error::unsupported(
             "eig",
-            "backend does not accept borrowed tensor views at this execution boundary",
+            "backend does not accept tensor reads at this execution boundary",
         ))
     }
 

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -5,8 +5,8 @@ use super::linalg;
 use num_complex::{Complex32, Complex64};
 use tenferro_cpu::{CpuBackend, CpuBackendKind};
 use tenferro_tensor::{
-    validate::validate_nonsingular_u, DType, Error, Tensor, TensorElementwise, TensorStructural,
-    TensorView, TensorViewCanonicalization, TypedTensor,
+    validate::validate_nonsingular_u, DType, Error, Tensor, TensorElementwise, TensorRead,
+    TensorStructural, TensorView, TensorViewCanonicalization, TypedTensor,
 };
 
 impl LinalgBackend for CpuBackend {
@@ -545,7 +545,8 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
-    fn svd_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn svd_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
         #[cfg(feature = "cpu-faer")]
         if matches!(
             linalg_provider_kind(self.kind(), "svd")?,
@@ -651,7 +652,8 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
-    fn qr_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn qr_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
         #[cfg(feature = "cpu-faer")]
         if matches!(
             linalg_provider_kind(self.kind(), "qr")?,
@@ -756,7 +758,8 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
-    fn eigh_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn eigh_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
         #[cfg(feature = "cpu-faer")]
         if matches!(
             linalg_provider_kind(self.kind(), "eigh")?,
@@ -816,7 +819,8 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
-    fn cholesky_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Tensor> {
+    fn cholesky_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Tensor> {
+        let input = input.tensor_view();
         #[cfg(feature = "cpu-faer")]
         if matches!(
             linalg_provider_kind(self.kind(), "cholesky")?,
@@ -875,7 +879,8 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
-    fn lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn lu_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
         #[cfg(feature = "cpu-faer")]
         if matches!(
             linalg_provider_kind(self.kind(), "lu")?,
@@ -930,7 +935,8 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
-    fn full_piv_lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn full_piv_lu_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
         #[cfg(feature = "cpu-faer")]
         if matches!(
             linalg_provider_kind(self.kind(), "full_piv_lu")?,
@@ -993,7 +999,8 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
-    fn eig_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn eig_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
         // eig has no faer fast-path; always materialize first.
         match input {
             TensorView::F32(view) => {

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -1,6 +1,18 @@
 use super::*;
 
 #[test]
+fn svd_read_accepts_an_owned_tensor_read() {
+    let input = Tensor::from_vec_col_major([2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]).unwrap();
+
+    let outputs = CpuBackend::new()
+        .svd_read(TensorRead::from_tensor(&input))
+        .unwrap();
+
+    assert_eq!(outputs.len(), 3);
+    assert_eq!(outputs[1].shape(), &[2]);
+}
+
+#[test]
 fn lapack_batched_value_factor_paths_reuse_pooled_batch_input() {
     let lu_source = include_str!("../linalg/lapack_linalg/lu.rs");
     let lu_factor = source_from(lu_source, "pub(crate) fn lu_factor");
@@ -24,7 +36,9 @@ fn svd_canonicalizes_transposed_host_view_before_lapack() {
     let data = vec![1.0, -2.0, 3.0, 0.5, -1.0, 4.0];
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], data.clone()).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap();
-    let outputs = CpuBackend::new().svd_read(TensorView::F64(view)).unwrap();
+    let outputs = CpuBackend::new()
+        .svd_read(TensorRead::from_view(TensorView::F64(view)))
+        .unwrap();
 
     assert_eq!(outputs[0].shape(), &[3, 2]);
     assert_eq!(outputs[1].shape(), &[2]);
@@ -55,7 +69,9 @@ fn qr_read_canonicalizes_transposed_host_view_before_lapack() {
     let data = vec![1.0, -2.0, 3.0, 0.5, -1.0, 4.0];
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], data.clone()).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap();
-    let outputs = CpuBackend::new().qr_read(TensorView::F64(view)).unwrap();
+    let outputs = CpuBackend::new()
+        .qr_read(TensorRead::from_view(TensorView::F64(view)))
+        .unwrap();
 
     assert_eq!(outputs.len(), 2);
     assert_eq!(outputs[0].shape(), &[3, 2]);
@@ -83,7 +99,9 @@ fn qr_read_canonicalizes_transposed_complex_host_view_before_lapack() {
     ];
     let a = TypedTensor::<Complex64>::from_vec_col_major(vec![2, 3], data.clone()).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap();
-    let outputs = CpuBackend::new().qr_read(TensorView::C64(view)).unwrap();
+    let outputs = CpuBackend::new()
+        .qr_read(TensorRead::from_view(TensorView::C64(view)))
+        .unwrap();
 
     assert_eq!(outputs.len(), 2);
     assert_eq!(outputs[0].shape(), &[3, 2]);
@@ -104,7 +122,9 @@ fn eigh_read_canonicalizes_transposed_host_view_before_lapack() {
     let data = vec![4.0, 1.0, 1.0, 3.0];
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data.clone()).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap();
-    let outputs = CpuBackend::new().eigh_read(TensorView::F64(view)).unwrap();
+    let outputs = CpuBackend::new()
+        .eigh_read(TensorRead::from_view(TensorView::F64(view)))
+        .unwrap();
 
     assert_eq!(outputs.len(), 2);
     assert_eq!(outputs[0].shape(), &[2]);
@@ -139,7 +159,9 @@ fn eigh_read_canonicalizes_transposed_complex_host_view_before_lapack() {
     ];
     let a = TypedTensor::<Complex64>::from_vec_col_major(vec![2, 2], data.clone()).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap();
-    let outputs = CpuBackend::new().eigh_read(TensorView::C64(view)).unwrap();
+    let outputs = CpuBackend::new()
+        .eigh_read(TensorRead::from_view(TensorView::C64(view)))
+        .unwrap();
 
     assert_eq!(outputs.len(), 2);
     assert_eq!(outputs[0].dtype(), DType::F64);
@@ -193,19 +215,27 @@ fn qr_read_accepts_all_supported_linalg_view_dtypes() {
     let mut backend = CpuBackend::new();
     for (view, dtype) in [
         (
-            TensorView::F32(f32_input.as_view().transpose_view([1, 0]).unwrap()),
+            TensorRead::from_view(TensorView::F32(
+                f32_input.as_view().transpose_view([1, 0]).unwrap(),
+            )),
             DType::F32,
         ),
         (
-            TensorView::F64(f64_input.as_view().transpose_view([1, 0]).unwrap()),
+            TensorRead::from_view(TensorView::F64(
+                f64_input.as_view().transpose_view([1, 0]).unwrap(),
+            )),
             DType::F64,
         ),
         (
-            TensorView::C32(c32_input.as_view().transpose_view([1, 0]).unwrap()),
+            TensorRead::from_view(TensorView::C32(
+                c32_input.as_view().transpose_view([1, 0]).unwrap(),
+            )),
             DType::C32,
         ),
         (
-            TensorView::C64(c64_input.as_view().transpose_view([1, 0]).unwrap()),
+            TensorRead::from_view(TensorView::C64(
+                c64_input.as_view().transpose_view([1, 0]).unwrap(),
+            )),
             DType::C64,
         ),
     ] {
@@ -248,22 +278,30 @@ fn eigh_read_accepts_all_supported_linalg_view_dtypes() {
     let mut backend = CpuBackend::new();
     for (view, value_dtype, vector_dtype) in [
         (
-            TensorView::F32(f32_input.as_view().transpose_view([1, 0]).unwrap()),
+            TensorRead::from_view(TensorView::F32(
+                f32_input.as_view().transpose_view([1, 0]).unwrap(),
+            )),
             DType::F32,
             DType::F32,
         ),
         (
-            TensorView::F64(f64_input.as_view().transpose_view([1, 0]).unwrap()),
+            TensorRead::from_view(TensorView::F64(
+                f64_input.as_view().transpose_view([1, 0]).unwrap(),
+            )),
             DType::F64,
             DType::F64,
         ),
         (
-            TensorView::C32(c32_input.as_view().transpose_view([1, 0]).unwrap()),
+            TensorRead::from_view(TensorView::C32(
+                c32_input.as_view().transpose_view([1, 0]).unwrap(),
+            )),
             DType::F32,
             DType::C32,
         ),
         (
-            TensorView::C64(c64_input.as_view().transpose_view([1, 0]).unwrap()),
+            TensorRead::from_view(TensorView::C64(
+                c64_input.as_view().transpose_view([1, 0]).unwrap(),
+            )),
             DType::F64,
             DType::C64,
         ),
@@ -310,33 +348,45 @@ fn linalg_read_rejects_non_float_view_dtypes() {
 
     let mut backend = CpuBackend::new();
     assert_unsupported_dtype(
-        backend.svd_read(TensorView::I32(i32_input.as_view())),
+        backend.svd_read(TensorRead::from_view(TensorView::I32(i32_input.as_view()))),
         "svd",
     );
     assert_unsupported_dtype(
-        backend.svd_read(TensorView::I64(i64_input.as_view())),
+        backend.svd_read(TensorRead::from_view(TensorView::I64(i64_input.as_view()))),
         "svd",
     );
     assert_unsupported_dtype(
-        backend.svd_read(TensorView::Bool(bool_input.as_view())),
+        backend.svd_read(TensorRead::from_view(TensorView::Bool(
+            bool_input.as_view(),
+        ))),
         "svd",
     );
-    assert_unsupported_dtype(backend.qr_read(TensorView::I32(i32_input.as_view())), "qr");
-    assert_unsupported_dtype(backend.qr_read(TensorView::I64(i64_input.as_view())), "qr");
     assert_unsupported_dtype(
-        backend.qr_read(TensorView::Bool(bool_input.as_view())),
+        backend.qr_read(TensorRead::from_view(TensorView::I32(i32_input.as_view()))),
         "qr",
     );
     assert_unsupported_dtype(
-        backend.eigh_read(TensorView::I32(i32_input.as_view())),
+        backend.qr_read(TensorRead::from_view(TensorView::I64(i64_input.as_view()))),
+        "qr",
+    );
+    assert_unsupported_dtype(
+        backend.qr_read(TensorRead::from_view(TensorView::Bool(
+            bool_input.as_view(),
+        ))),
+        "qr",
+    );
+    assert_unsupported_dtype(
+        backend.eigh_read(TensorRead::from_view(TensorView::I32(i32_input.as_view()))),
         "eigh",
     );
     assert_unsupported_dtype(
-        backend.eigh_read(TensorView::I64(i64_input.as_view())),
+        backend.eigh_read(TensorRead::from_view(TensorView::I64(i64_input.as_view()))),
         "eigh",
     );
     assert_unsupported_dtype(
-        backend.eigh_read(TensorView::Bool(bool_input.as_view())),
+        backend.eigh_read(TensorRead::from_view(TensorView::Bool(
+            bool_input.as_view(),
+        ))),
         "eigh",
     );
 
@@ -363,45 +413,59 @@ fn linalg_read_rejects_non_float_view_dtypes() {
     }
 
     assert_unsupported_dtype_single(
-        backend.cholesky_read(TensorView::I32(i32_input.as_view())),
+        backend.cholesky_read(TensorRead::from_view(TensorView::I32(i32_input.as_view()))),
         "cholesky",
     );
     assert_unsupported_dtype_single(
-        backend.cholesky_read(TensorView::I64(i64_input.as_view())),
+        backend.cholesky_read(TensorRead::from_view(TensorView::I64(i64_input.as_view()))),
         "cholesky",
     );
     assert_unsupported_dtype_single(
-        backend.cholesky_read(TensorView::Bool(bool_input.as_view())),
+        backend.cholesky_read(TensorRead::from_view(TensorView::Bool(
+            bool_input.as_view(),
+        ))),
         "cholesky",
     );
-    assert_unsupported_dtype(backend.lu_read(TensorView::I32(i32_input.as_view())), "lu");
-    assert_unsupported_dtype(backend.lu_read(TensorView::I64(i64_input.as_view())), "lu");
     assert_unsupported_dtype(
-        backend.lu_read(TensorView::Bool(bool_input.as_view())),
+        backend.lu_read(TensorRead::from_view(TensorView::I32(i32_input.as_view()))),
         "lu",
     );
     assert_unsupported_dtype(
-        backend.full_piv_lu_read(TensorView::I32(i32_input.as_view())),
+        backend.lu_read(TensorRead::from_view(TensorView::I64(i64_input.as_view()))),
+        "lu",
+    );
+    assert_unsupported_dtype(
+        backend.lu_read(TensorRead::from_view(TensorView::Bool(
+            bool_input.as_view(),
+        ))),
+        "lu",
+    );
+    assert_unsupported_dtype(
+        backend.full_piv_lu_read(TensorRead::from_view(TensorView::I32(i32_input.as_view()))),
         "full_piv_lu",
     );
     assert_unsupported_dtype(
-        backend.full_piv_lu_read(TensorView::I64(i64_input.as_view())),
+        backend.full_piv_lu_read(TensorRead::from_view(TensorView::I64(i64_input.as_view()))),
         "full_piv_lu",
     );
     assert_unsupported_dtype(
-        backend.full_piv_lu_read(TensorView::Bool(bool_input.as_view())),
+        backend.full_piv_lu_read(TensorRead::from_view(TensorView::Bool(
+            bool_input.as_view(),
+        ))),
         "full_piv_lu",
     );
     assert_unsupported_dtype(
-        backend.eig_read(TensorView::I32(i32_input.as_view())),
+        backend.eig_read(TensorRead::from_view(TensorView::I32(i32_input.as_view()))),
         "eig",
     );
     assert_unsupported_dtype(
-        backend.eig_read(TensorView::I64(i64_input.as_view())),
+        backend.eig_read(TensorRead::from_view(TensorView::I64(i64_input.as_view()))),
         "eig",
     );
     assert_unsupported_dtype(
-        backend.eig_read(TensorView::Bool(bool_input.as_view())),
+        backend.eig_read(TensorRead::from_view(TensorView::Bool(
+            bool_input.as_view(),
+        ))),
         "eig",
     );
 }
@@ -415,7 +479,7 @@ fn cholesky_read_canonicalizes_transposed_host_view_before_factorization() {
     // Transposed view of a symmetric matrix is still the same matrix, so cholesky should succeed.
     let view = a.as_view().transpose_view([1, 0]).unwrap();
     let output = CpuBackend::new()
-        .cholesky_read(TensorView::F64(view))
+        .cholesky_read(TensorRead::from_view(TensorView::F64(view)))
         .unwrap();
     assert_eq!(output.shape(), &[2, 2]);
     // Verify L * L^T ≈ A
@@ -433,7 +497,9 @@ fn lu_read_canonicalizes_transposed_host_view_before_factorization() {
     let data = vec![1.0_f64, 2.0, 3.0, 4.0];
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap();
-    let outputs = CpuBackend::new().lu_read(TensorView::F64(view)).unwrap();
+    let outputs = CpuBackend::new()
+        .lu_read(TensorRead::from_view(TensorView::F64(view)))
+        .unwrap();
     assert_eq!(outputs.len(), 4);
     // P has shape [2, 2], L has shape [2, 2], U has shape [2, 2], parity is scalar []
     assert_eq!(outputs[0].shape(), &[2, 2]);
@@ -460,7 +526,7 @@ fn full_piv_lu_read_canonicalizes_transposed_host_view_before_factorization() {
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap();
     let outputs = CpuBackend::new()
-        .full_piv_lu_read(TensorView::F64(view))
+        .full_piv_lu_read(TensorRead::from_view(TensorView::F64(view)))
         .unwrap();
     assert_eq!(outputs.len(), 5);
     // P_row, L, U, P_col, parity
@@ -490,7 +556,7 @@ fn eig_read_returns_correct_outputs_for_diagonal_matrix() {
     let data = vec![2.0_f64, 0.0, 0.0, 3.0];
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data).unwrap();
     let outputs = CpuBackend::new()
-        .eig_read(TensorView::F64(a.as_view()))
+        .eig_read(TensorRead::from_view(TensorView::F64(a.as_view())))
         .unwrap();
     assert_eq!(outputs.len(), 2);
     // eig on real returns complex outputs
@@ -529,25 +595,25 @@ fn cholesky_read_accepts_all_supported_linalg_view_dtypes() {
     .unwrap();
 
     let out = backend
-        .cholesky_read(TensorView::F32(spd_f32.as_view()))
+        .cholesky_read(TensorRead::from_view(TensorView::F32(spd_f32.as_view())))
         .unwrap();
     assert!(matches!(out, Tensor::F32(_)));
     assert_eq!(out.shape(), &[2, 2]);
 
     let out = backend
-        .cholesky_read(TensorView::F64(spd_f64.as_view()))
+        .cholesky_read(TensorRead::from_view(TensorView::F64(spd_f64.as_view())))
         .unwrap();
     assert!(matches!(out, Tensor::F64(_)));
     assert_eq!(out.shape(), &[2, 2]);
 
     let out = backend
-        .cholesky_read(TensorView::C32(spd_c32.as_view()))
+        .cholesky_read(TensorRead::from_view(TensorView::C32(spd_c32.as_view())))
         .unwrap();
     assert!(matches!(out, Tensor::C32(_)));
     assert_eq!(out.shape(), &[2, 2]);
 
     let out = backend
-        .cholesky_read(TensorView::C64(spd_c64.as_view()))
+        .cholesky_read(TensorRead::from_view(TensorView::C64(spd_c64.as_view())))
         .unwrap();
     assert!(matches!(out, Tensor::C64(_)));
     assert_eq!(out.shape(), &[2, 2]);
@@ -581,19 +647,27 @@ fn lu_read_accepts_all_supported_linalg_view_dtypes() {
     )
     .unwrap();
 
-    let outs = backend.lu_read(TensorView::F32(mat_f32.as_view())).unwrap();
+    let outs = backend
+        .lu_read(TensorRead::from_view(TensorView::F32(mat_f32.as_view())))
+        .unwrap();
     assert_eq!(outs.len(), 4);
     assert!(matches!(outs[0], Tensor::F32(_)));
 
-    let outs = backend.lu_read(TensorView::F64(mat_f64.as_view())).unwrap();
+    let outs = backend
+        .lu_read(TensorRead::from_view(TensorView::F64(mat_f64.as_view())))
+        .unwrap();
     assert_eq!(outs.len(), 4);
     assert!(matches!(outs[0], Tensor::F64(_)));
 
-    let outs = backend.lu_read(TensorView::C32(mat_c32.as_view())).unwrap();
+    let outs = backend
+        .lu_read(TensorRead::from_view(TensorView::C32(mat_c32.as_view())))
+        .unwrap();
     assert_eq!(outs.len(), 4);
     assert!(matches!(outs[0], Tensor::C32(_)));
 
-    let outs = backend.lu_read(TensorView::C64(mat_c64.as_view())).unwrap();
+    let outs = backend
+        .lu_read(TensorRead::from_view(TensorView::C64(mat_c64.as_view())))
+        .unwrap();
     assert_eq!(outs.len(), 4);
     assert!(matches!(outs[0], Tensor::C64(_)));
 }
@@ -627,25 +701,25 @@ fn full_piv_lu_read_accepts_all_supported_linalg_view_dtypes() {
     .unwrap();
 
     let outs = backend
-        .full_piv_lu_read(TensorView::F32(mat_f32.as_view()))
+        .full_piv_lu_read(TensorRead::from_view(TensorView::F32(mat_f32.as_view())))
         .unwrap();
     assert_eq!(outs.len(), 5);
     assert!(matches!(outs[0], Tensor::F32(_)));
 
     let outs = backend
-        .full_piv_lu_read(TensorView::F64(mat_f64.as_view()))
+        .full_piv_lu_read(TensorRead::from_view(TensorView::F64(mat_f64.as_view())))
         .unwrap();
     assert_eq!(outs.len(), 5);
     assert!(matches!(outs[0], Tensor::F64(_)));
 
     let outs = backend
-        .full_piv_lu_read(TensorView::C32(mat_c32.as_view()))
+        .full_piv_lu_read(TensorRead::from_view(TensorView::C32(mat_c32.as_view())))
         .unwrap();
     assert_eq!(outs.len(), 5);
     assert!(matches!(outs[0], Tensor::C32(_)));
 
     let outs = backend
-        .full_piv_lu_read(TensorView::C64(mat_c64.as_view()))
+        .full_piv_lu_read(TensorRead::from_view(TensorView::C64(mat_c64.as_view())))
         .unwrap();
     assert_eq!(outs.len(), 5);
     assert!(matches!(outs[0], Tensor::C64(_)));
@@ -682,7 +756,7 @@ fn eig_read_accepts_all_supported_linalg_view_dtypes() {
 
     // f32 -> C32 outputs
     let outs = backend
-        .eig_read(TensorView::F32(mat_f32.as_view()))
+        .eig_read(TensorRead::from_view(TensorView::F32(mat_f32.as_view())))
         .unwrap();
     assert_eq!(outs.len(), 2);
     assert!(matches!(outs[0], Tensor::C32(_)));
@@ -690,7 +764,7 @@ fn eig_read_accepts_all_supported_linalg_view_dtypes() {
 
     // f64 -> C64 outputs
     let outs = backend
-        .eig_read(TensorView::F64(mat_f64.as_view()))
+        .eig_read(TensorRead::from_view(TensorView::F64(mat_f64.as_view())))
         .unwrap();
     assert_eq!(outs.len(), 2);
     assert!(matches!(outs[0], Tensor::C64(_)));
@@ -698,7 +772,7 @@ fn eig_read_accepts_all_supported_linalg_view_dtypes() {
 
     // C32 -> C32 outputs
     let outs = backend
-        .eig_read(TensorView::C32(mat_c32.as_view()))
+        .eig_read(TensorRead::from_view(TensorView::C32(mat_c32.as_view())))
         .unwrap();
     assert_eq!(outs.len(), 2);
     assert!(matches!(outs[0], Tensor::C32(_)));
@@ -706,7 +780,7 @@ fn eig_read_accepts_all_supported_linalg_view_dtypes() {
 
     // C64 -> C64 outputs
     let outs = backend
-        .eig_read(TensorView::C64(mat_c64.as_view()))
+        .eig_read(TensorRead::from_view(TensorView::C64(mat_c64.as_view())))
         .unwrap();
     assert_eq!(outs.len(), 2);
     assert!(matches!(outs[0], Tensor::C64(_)));
@@ -1408,7 +1482,9 @@ fn svd_read_faer_strided_view_matches_contiguous() {
     let data = vec![1.0_f64, -2.0, 3.0, 0.5, -1.0, 4.0]; // 2x3 col-major
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], data.clone()).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap(); // 3x2 strided
-    let out = CpuBackend::new().svd_read(TensorView::F64(view)).unwrap();
+    let out = CpuBackend::new()
+        .svd_read(TensorRead::from_view(TensorView::F64(view)))
+        .unwrap();
     // For 3x2 input (m=3, n=2), thin SVD gives U:[3,2], S:[2], Vt:[2,2].
     assert_eq!(out[0].shape(), &[3, 2]);
     assert_eq!(out[1].shape(), &[2]);
@@ -1436,7 +1512,9 @@ fn svd_read_faer_strided_c64_view() {
     ];
     let a = TypedTensor::<Complex64>::from_vec_col_major(vec![2, 3], data.clone()).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap(); // 3x2 strided
-    let out = CpuBackend::new().svd_read(TensorView::C64(view)).unwrap();
+    let out = CpuBackend::new()
+        .svd_read(TensorRead::from_view(TensorView::C64(view)))
+        .unwrap();
     assert_eq!(out[0].shape(), &[3, 2]); // U (thin, complex)
     assert_eq!(out[1].shape(), &[2]); // S (real singular values)
     assert_eq!(out[2].shape(), &[2, 2]); // Vt (thin, complex)
@@ -1456,7 +1534,9 @@ fn qr_read_faer_strided_view_matches_contiguous() {
     let data = vec![1.0_f64, -2.0, 3.0, 0.5, -1.0, 4.0];
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 3], data.clone()).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap(); // 3x2 strided
-    let out = CpuBackend::new().qr_read(TensorView::F64(view)).unwrap();
+    let out = CpuBackend::new()
+        .qr_read(TensorRead::from_view(TensorView::F64(view)))
+        .unwrap();
     assert_eq!(out.len(), 2);
     assert_eq!(out[0].shape(), &[3, 2]);
     assert_eq!(out[1].shape(), &[2, 2]);
@@ -1476,7 +1556,9 @@ fn eigh_read_faer_strided_view_matches_contiguous() {
     let data = vec![4.0_f64, 1.0, 1.0, 3.0]; // 2x2 symmetric
     let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], data.clone()).unwrap();
     let view = a.as_view().transpose_view([1, 0]).unwrap(); // 2x2 strided (still symmetric)
-    let out = CpuBackend::new().eigh_read(TensorView::F64(view)).unwrap();
+    let out = CpuBackend::new()
+        .eigh_read(TensorRead::from_view(TensorView::F64(view)))
+        .unwrap();
     assert_eq!(out.len(), 2);
     assert_eq!(out[0].shape(), &[2]); // eigenvalues
     assert_eq!(out[1].shape(), &[2, 2]); // eigenvectors
@@ -1629,7 +1711,9 @@ fn svd_read_to_contiguous_fallback_rank3_all_dtypes() {
 
     let mut backend = CpuBackend::new();
     // F32: view is rank-3 so faer_strided_ok returns false; fallback is taken.
-    let outs = backend.svd_read(TensorView::F32(f32_t.as_view())).unwrap();
+    let outs = backend
+        .svd_read(TensorRead::from_view(TensorView::F32(f32_t.as_view())))
+        .unwrap();
     assert_eq!(outs.len(), 3);
     assert_eq!(outs[0].dtype(), DType::F32);
     assert_eq!(outs[0].shape(), &[2, 2, 2]);
@@ -1637,7 +1721,9 @@ fn svd_read_to_contiguous_fallback_rank3_all_dtypes() {
     assert_eq!(outs[2].shape(), &[2, 2, 2]);
 
     // F64
-    let outs = backend.svd_read(TensorView::F64(f64_t.as_view())).unwrap();
+    let outs = backend
+        .svd_read(TensorRead::from_view(TensorView::F64(f64_t.as_view())))
+        .unwrap();
     assert_eq!(outs.len(), 3);
     assert_eq!(outs[0].dtype(), DType::F64);
     assert_eq!(outs[0].shape(), &[2, 2, 2]);
@@ -1645,7 +1731,9 @@ fn svd_read_to_contiguous_fallback_rank3_all_dtypes() {
     assert_eq!(outs[2].shape(), &[2, 2, 2]);
 
     // C32: SVD of complex inputs returns U (C32), S (F32), Vt (C32).
-    let outs = backend.svd_read(TensorView::C32(c32_t.as_view())).unwrap();
+    let outs = backend
+        .svd_read(TensorRead::from_view(TensorView::C32(c32_t.as_view())))
+        .unwrap();
     assert_eq!(outs.len(), 3);
     assert_eq!(outs[0].dtype(), DType::C32);
     assert_eq!(outs[0].shape(), &[2, 2, 2]);
@@ -1653,7 +1741,9 @@ fn svd_read_to_contiguous_fallback_rank3_all_dtypes() {
     assert_eq!(outs[2].shape(), &[2, 2, 2]);
 
     // C64: SVD of complex inputs returns U (C64), S (F64), Vt (C64).
-    let outs = backend.svd_read(TensorView::C64(c64_t.as_view())).unwrap();
+    let outs = backend
+        .svd_read(TensorRead::from_view(TensorView::C64(c64_t.as_view())))
+        .unwrap();
     assert_eq!(outs.len(), 3);
     assert_eq!(outs[0].dtype(), DType::C64);
     assert_eq!(outs[0].shape(), &[2, 2, 2]);
@@ -1671,10 +1761,22 @@ fn qr_read_to_contiguous_fallback_rank3_all_dtypes() {
 
     let mut backend = CpuBackend::new();
     for (view, dtype) in [
-        (TensorView::F32(f32_t.as_view()), DType::F32),
-        (TensorView::F64(f64_t.as_view()), DType::F64),
-        (TensorView::C32(c32_t.as_view()), DType::C32),
-        (TensorView::C64(c64_t.as_view()), DType::C64),
+        (
+            TensorRead::from_view(TensorView::F32(f32_t.as_view())),
+            DType::F32,
+        ),
+        (
+            TensorRead::from_view(TensorView::F64(f64_t.as_view())),
+            DType::F64,
+        ),
+        (
+            TensorRead::from_view(TensorView::C32(c32_t.as_view())),
+            DType::C32,
+        ),
+        (
+            TensorRead::from_view(TensorView::C64(c64_t.as_view())),
+            DType::C64,
+        ),
     ] {
         let outs = backend.qr_read(view).unwrap();
         assert_eq!(
@@ -1737,7 +1839,7 @@ fn eigh_read_to_contiguous_fallback_rank3_all_dtypes() {
 
     // Real dtypes: eigenvalues are same dtype, eigenvectors same dtype.
     let outs = backend
-        .eigh_read(TensorView::F32(sym_f32.as_view()))
+        .eigh_read(TensorRead::from_view(TensorView::F32(sym_f32.as_view())))
         .unwrap();
     assert_eq!(outs.len(), 2);
     assert_eq!(outs[0].dtype(), DType::F32);
@@ -1746,7 +1848,7 @@ fn eigh_read_to_contiguous_fallback_rank3_all_dtypes() {
     assert_eq!(outs[1].shape(), &[2, 2, 2]);
 
     let outs = backend
-        .eigh_read(TensorView::F64(sym_f64.as_view()))
+        .eigh_read(TensorRead::from_view(TensorView::F64(sym_f64.as_view())))
         .unwrap();
     assert_eq!(outs.len(), 2);
     assert_eq!(outs[0].dtype(), DType::F64);
@@ -1756,7 +1858,7 @@ fn eigh_read_to_contiguous_fallback_rank3_all_dtypes() {
 
     // Complex dtypes: eigenvalues are real, eigenvectors are complex.
     let outs = backend
-        .eigh_read(TensorView::C32(sym_c32.as_view()))
+        .eigh_read(TensorRead::from_view(TensorView::C32(sym_c32.as_view())))
         .unwrap();
     assert_eq!(outs.len(), 2);
     assert_eq!(outs[0].dtype(), DType::F32);
@@ -1765,7 +1867,7 @@ fn eigh_read_to_contiguous_fallback_rank3_all_dtypes() {
     assert_eq!(outs[1].shape(), &[2, 2, 2]);
 
     let outs = backend
-        .eigh_read(TensorView::C64(sym_c64.as_view()))
+        .eigh_read(TensorRead::from_view(TensorView::C64(sym_c64.as_view())))
         .unwrap();
     assert_eq!(outs.len(), 2);
     assert_eq!(outs[0].dtype(), DType::F64);
@@ -1784,25 +1886,25 @@ fn cholesky_read_to_contiguous_fallback_rank3_all_dtypes() {
 
     let mut backend = CpuBackend::new();
     let out = backend
-        .cholesky_read(TensorView::F32(f32_t.as_view()))
+        .cholesky_read(TensorRead::from_view(TensorView::F32(f32_t.as_view())))
         .unwrap();
     assert!(matches!(out, Tensor::F32(_)));
     assert_eq!(out.shape(), &[2, 2, 2]);
 
     let out = backend
-        .cholesky_read(TensorView::F64(f64_t.as_view()))
+        .cholesky_read(TensorRead::from_view(TensorView::F64(f64_t.as_view())))
         .unwrap();
     assert!(matches!(out, Tensor::F64(_)));
     assert_eq!(out.shape(), &[2, 2, 2]);
 
     let out = backend
-        .cholesky_read(TensorView::C32(c32_t.as_view()))
+        .cholesky_read(TensorRead::from_view(TensorView::C32(c32_t.as_view())))
         .unwrap();
     assert!(matches!(out, Tensor::C32(_)));
     assert_eq!(out.shape(), &[2, 2, 2]);
 
     let out = backend
-        .cholesky_read(TensorView::C64(c64_t.as_view()))
+        .cholesky_read(TensorRead::from_view(TensorView::C64(c64_t.as_view())))
         .unwrap();
     assert!(matches!(out, Tensor::C64(_)));
     assert_eq!(out.shape(), &[2, 2, 2]);
@@ -1818,10 +1920,22 @@ fn lu_read_to_contiguous_fallback_rank3_all_dtypes() {
 
     let mut backend = CpuBackend::new();
     for (view, dtype) in [
-        (TensorView::F32(f32_t.as_view()), DType::F32),
-        (TensorView::F64(f64_t.as_view()), DType::F64),
-        (TensorView::C32(c32_t.as_view()), DType::C32),
-        (TensorView::C64(c64_t.as_view()), DType::C64),
+        (
+            TensorRead::from_view(TensorView::F32(f32_t.as_view())),
+            DType::F32,
+        ),
+        (
+            TensorRead::from_view(TensorView::F64(f64_t.as_view())),
+            DType::F64,
+        ),
+        (
+            TensorRead::from_view(TensorView::C32(c32_t.as_view())),
+            DType::C32,
+        ),
+        (
+            TensorRead::from_view(TensorView::C64(c64_t.as_view())),
+            DType::C64,
+        ),
     ] {
         let outs = backend.lu_read(view).unwrap();
         assert_eq!(
@@ -1848,10 +1962,22 @@ fn full_piv_lu_read_to_contiguous_fallback_rank3_all_dtypes() {
 
     let mut backend = CpuBackend::new();
     for (view, dtype) in [
-        (TensorView::F32(f32_t.as_view()), DType::F32),
-        (TensorView::F64(f64_t.as_view()), DType::F64),
-        (TensorView::C32(c32_t.as_view()), DType::C32),
-        (TensorView::C64(c64_t.as_view()), DType::C64),
+        (
+            TensorRead::from_view(TensorView::F32(f32_t.as_view())),
+            DType::F32,
+        ),
+        (
+            TensorRead::from_view(TensorView::F64(f64_t.as_view())),
+            DType::F64,
+        ),
+        (
+            TensorRead::from_view(TensorView::C32(c32_t.as_view())),
+            DType::C32,
+        ),
+        (
+            TensorRead::from_view(TensorView::C64(c64_t.as_view())),
+            DType::C64,
+        ),
     ] {
         let outs = backend.full_piv_lu_read(view).unwrap();
         assert_eq!(

--- a/crates/tenferro-linalg/src/eager_backend.rs
+++ b/crates/tenferro-linalg/src/eager_backend.rs
@@ -1,6 +1,6 @@
 use crate::backend::LinalgBackend;
 use tenferro_ad::EagerBackend;
-use tenferro_tensor::{Tensor, TensorView};
+use tenferro_tensor::{Tensor, TensorRead};
 
 macro_rules! dispatch_linalg {
     ($backend:expr, $method:ident($($arg:expr),* $(,)?)) => {
@@ -61,7 +61,7 @@ impl LinalgBackend for EagerBackend {
         dispatch_linalg!(self, svd_values(input))
     }
 
-    fn svd_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn svd_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         dispatch_linalg!(self, svd_read(input))
     }
 
@@ -69,7 +69,7 @@ impl LinalgBackend for EagerBackend {
         dispatch_linalg!(self, qr(input))
     }
 
-    fn qr_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn qr_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         dispatch_linalg!(self, qr_read(input))
     }
 
@@ -77,23 +77,23 @@ impl LinalgBackend for EagerBackend {
         dispatch_linalg!(self, eigh(input))
     }
 
-    fn eigh_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn eigh_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         dispatch_linalg!(self, eigh_read(input))
     }
 
-    fn cholesky_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Tensor> {
+    fn cholesky_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Tensor> {
         dispatch_linalg!(self, cholesky_read(input))
     }
 
-    fn lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn lu_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         dispatch_linalg!(self, lu_read(input))
     }
 
-    fn full_piv_lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn full_piv_lu_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         dispatch_linalg!(self, full_piv_lu_read(input))
     }
 
-    fn eig_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn eig_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
         dispatch_linalg!(self, eig_read(input))
     }
 

--- a/crates/tenferro-linalg/src/gpu/mod.rs
+++ b/crates/tenferro-linalg/src/gpu/mod.rs
@@ -3,7 +3,7 @@ mod kernels;
 mod linalg;
 
 use tenferro_gpu::CudaBackend;
-use tenferro_tensor::{Tensor, TensorView, TensorViewCanonicalization};
+use tenferro_tensor::{Tensor, TensorRead, TensorView, TensorViewCanonicalization};
 
 use crate::backend::{unsupported_dtype, LinalgBackend};
 
@@ -53,7 +53,8 @@ impl LinalgBackend for CudaBackend {
         linalg::svd_values(self, input)
     }
 
-    fn svd_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn svd_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
         match input {
             TensorView::F32(view) => {
                 let compact = self.to_contiguous(&view)?;
@@ -85,7 +86,8 @@ impl LinalgBackend for CudaBackend {
         linalg::qr(self, input)
     }
 
-    fn qr_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn qr_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
         match input {
             TensorView::F32(view) => {
                 let compact = self.to_contiguous(&view)?;
@@ -117,7 +119,8 @@ impl LinalgBackend for CudaBackend {
         linalg::eigh(self, input)
     }
 
-    fn eigh_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn eigh_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
         match input {
             TensorView::F32(view) => {
                 let compact = self.to_contiguous(&view)?;
@@ -145,7 +148,8 @@ impl LinalgBackend for CudaBackend {
         }
     }
 
-    fn cholesky_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Tensor> {
+    fn cholesky_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Tensor> {
+        let input = input.tensor_view();
         match input {
             TensorView::F32(view) => {
                 let compact = self.to_contiguous(&view)?;
@@ -173,7 +177,8 @@ impl LinalgBackend for CudaBackend {
         }
     }
 
-    fn lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn lu_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
         match input {
             TensorView::F32(view) => {
                 let compact = self.to_contiguous(&view)?;
@@ -201,7 +206,8 @@ impl LinalgBackend for CudaBackend {
         }
     }
 
-    fn full_piv_lu_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn full_piv_lu_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
         match input {
             TensorView::F32(view) => {
                 let compact = self.to_contiguous(&view)?;
@@ -229,7 +235,8 @@ impl LinalgBackend for CudaBackend {
         }
     }
 
-    fn eig_read(&mut self, input: TensorView<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+    fn eig_read(&mut self, input: TensorRead<'_>) -> tenferro_tensor::Result<Vec<Tensor>> {
+        let input = input.tensor_view();
         match input {
             TensorView::F32(view) => {
                 let compact = self.to_contiguous(&view)?;

--- a/crates/tenferro-linalg/tests/integration/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/integration/backend_errors.rs
@@ -9,7 +9,7 @@ use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSessionHost, Buffer, BufferHandle, CompareDir,
     DType, DotGeneralConfig, Error, ErrorKind, GatherConfig, MemoryKind, PadConfig, Placement,
     ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
-    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
     TensorReduction, TensorStructural, TensorView, TypedTensor, ValidationError,
 };
 
@@ -231,8 +231,9 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         } if message.contains("does not implement")
     ));
 
+    let owned_input = Tensor::F64(input.clone());
     let err = backend
-        .svd_read(TensorView::F64(input.as_view()))
+        .svd_read(tenferro_tensor::TensorRead::from_tensor(&owned_input))
         .unwrap_err();
 
     assert!(matches!(
@@ -240,11 +241,11 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         Error::Unsupported {
             op: "svd",
             ref message,
-        } if message.contains("borrowed tensor views")
+        } if message.contains("tensor reads")
     ));
 
     let err = backend
-        .qr_read(TensorView::F64(input.as_view()))
+        .qr_read(TensorRead::from_view(TensorView::F64(input.as_view())))
         .unwrap_err();
 
     assert!(matches!(
@@ -252,11 +253,11 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         Error::Unsupported {
             op: "qr",
             ref message,
-        } if message.contains("borrowed tensor views")
+        } if message.contains("tensor reads")
     ));
 
     let err = backend
-        .eigh_read(TensorView::F64(input.as_view()))
+        .eigh_read(TensorRead::from_view(TensorView::F64(input.as_view())))
         .unwrap_err();
 
     assert!(matches!(
@@ -264,7 +265,7 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
         Error::Unsupported {
             op: "eigh",
             ref message,
-        } if message.contains("borrowed tensor views")
+        } if message.contains("tensor reads")
     ));
 
     let err = backend
@@ -298,47 +299,47 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
     ));
 
     let err = backend
-        .cholesky_read(TensorView::F64(input.as_view()))
+        .cholesky_read(TensorRead::from_view(TensorView::F64(input.as_view())))
         .unwrap_err();
     assert!(matches!(
         err,
         Error::Unsupported {
             op: "cholesky",
             ref message,
-        } if message.contains("borrowed tensor views")
+        } if message.contains("tensor reads")
     ));
 
     let err = backend
-        .lu_read(TensorView::F64(input.as_view()))
+        .lu_read(TensorRead::from_view(TensorView::F64(input.as_view())))
         .unwrap_err();
     assert!(matches!(
         err,
         Error::Unsupported {
             op: "lu",
             ref message,
-        } if message.contains("borrowed tensor views")
+        } if message.contains("tensor reads")
     ));
 
     let err = backend
-        .full_piv_lu_read(TensorView::F64(input.as_view()))
+        .full_piv_lu_read(TensorRead::from_view(TensorView::F64(input.as_view())))
         .unwrap_err();
     assert!(matches!(
         err,
         Error::Unsupported {
             op: "full_piv_lu",
             ref message,
-        } if message.contains("borrowed tensor views")
+        } if message.contains("tensor reads")
     ));
 
     let err = backend
-        .eig_read(TensorView::F64(input.as_view()))
+        .eig_read(TensorRead::from_view(TensorView::F64(input.as_view())))
         .unwrap_err();
     assert!(matches!(
         err,
         Error::Unsupported {
             op: "eig",
             ref message,
-        } if message.contains("borrowed tensor views")
+        } if message.contains("tensor reads")
     ));
 }
 

--- a/crates/tenferro-linalg/tests/integration/linalg_internal_path_contract.rs
+++ b/crates/tenferro-linalg/tests/integration/linalg_internal_path_contract.rs
@@ -18,6 +18,20 @@ fn source_section<'a>(source: &'a str, start: &str, end: &str) -> &'a str {
 }
 
 #[test]
+fn eager_extension_registration_preserves_typed_source_errors() {
+    let source = crate_source("src/eager_ext.rs");
+    let registration = source_section(
+        &source,
+        ".register_extension(register_runtime)",
+        "apply_eager(Arc::new",
+    );
+
+    assert!(registration.contains("Error::runtime_state_source("));
+    assert!(!registration.contains("Error::Internal"));
+    assert!(!registration.contains("to_string()"));
+}
+
+#[test]
 fn traced_solve_builds_factor_then_prepared_solve() {
     let source = crate_source("src/traced.rs");
     let solve_source = source_section(

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -17,8 +17,8 @@ use tenferro_ops::dim_expr::DimExpr;
 use tenferro_ops::input_key::TensorInputKey;
 use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_tensor::{
-    CompareDir, DType, DotGeneralConfig, Error as TensorError, GatherConfig, PadConfig,
-    ScatterConfig, ShapeMismatch, SliceConfig, Tensor, TensorScalar, ValidationError,
+    CompareDir, DType, DotGeneralConfig, Error as TensorError, GatherConfig, IntoShapeVec,
+    PadConfig, ScatterConfig, ShapeMismatch, SliceConfig, Tensor, TensorScalar, ValidationError,
 };
 
 use super::error::{Error, ErrorPhase, Result};
@@ -888,8 +888,16 @@ impl TracedTensor {
     /// `ValidationError::ShapeDataLengthMismatch` when the shape product does
     /// not equal `data.len()`, or `ValidationError::IntegerOverflow` when the
     /// shape product cannot be represented by `usize`.
-    pub fn from_vec_col_major<T: TensorScalar>(shape: Vec<usize>, data: Vec<T>) -> Result<Self> {
+    pub fn from_vec_col_major<T: TensorScalar>(
+        shape: impl IntoShapeVec,
+        data: Vec<T>,
+    ) -> Result<Self> {
         Self::from_tensor_concrete_shape(Tensor::from_vec_col_major(shape, data)?)
+    }
+
+    /// Return the tensor element dtype recorded for this traced value.
+    pub fn dtype(&self) -> DType {
+        self.dtype
     }
 
     /// Returns `true` iff every dim of this tensor's `shape_hint` is a

--- a/crates/tenferro-tensor-core/src/layout.rs
+++ b/crates/tenferro-tensor-core/src/layout.rs
@@ -549,9 +549,10 @@ impl<R: TensorRank> TensorLayout<R> {
     /// overflows.
     pub fn reshape_view_as<R2: TensorRank>(
         &self,
-        shape: R2::Shape,
+        shape: impl Into<R2::Shape>,
         buffer_len: usize,
     ) -> Result<TensorLayout<R2>> {
+        let shape = shape.into();
         if !self.is_compact_col_major()? {
             return Err(ValidationError::NonContiguousViewAsSlice);
         }
@@ -587,10 +588,11 @@ impl<R: TensorRank> TensorLayout<R> {
     /// or [`ValidationError::ViewOutOfBounds`] for an invalid result layout.
     pub fn broadcast_in_dim_view<R2: TensorRank>(
         &self,
-        shape: R2::Shape,
+        shape: impl Into<R2::Shape>,
         broadcast_dims: impl AsRef<[usize]>,
         buffer_len: usize,
     ) -> Result<TensorLayout<R2>> {
+        let shape = shape.into();
         let broadcast_dims = broadcast_dims.as_ref();
         if broadcast_dims.len() != self.shape().len() {
             return Err(ValidationError::RankMismatch {

--- a/crates/tenferro-tensor-core/src/lib.rs
+++ b/crates/tenferro-tensor-core/src/lib.rs
@@ -51,6 +51,24 @@ pub use rank::{DynRank, Rank, TensorRank};
 /// ```
 pub type ShapeVec = SmallVec<[usize; 8]>;
 
+/// Convert a common shape container into the dynamic owned shape type.
+///
+/// Arrays, vectors, slices, and [`ShapeVec`] implement this trait through
+/// their `AsRef<[usize]>` representation.
+pub trait IntoShapeVec {
+    /// Convert this shape container into an owned [`ShapeVec`].
+    fn into_shape_vec(self) -> ShapeVec;
+}
+
+impl<S> IntoShapeVec for S
+where
+    S: AsRef<[usize]>,
+{
+    fn into_shape_vec(self) -> ShapeVec {
+        self.as_ref().iter().copied().collect()
+    }
+}
+
 /// Small tensor stride vector with signed element strides.
 ///
 /// # Examples

--- a/crates/tenferro-tensor-core/tests/core.rs
+++ b/crates/tenferro-tensor-core/tests/core.rs
@@ -572,7 +572,7 @@ fn empty_views_are_contiguous_even_with_degenerate_strides() {
     assert!(layout.is_compact_col_major().unwrap());
     assert_eq!(
         layout
-            .reshape_view_as::<DynRank>(vec![0].into(), data.len())
+            .reshape_view_as::<DynRank>(vec![0], data.len())
             .unwrap()
             .shape(),
         &[0]

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -40,7 +40,11 @@
 /// Execution-capable tensors and backends in this crate remain separate from
 /// the host-only core model during the crate-boundary split.
 pub mod core {
-    pub use tenferro_tensor_core::*;
+    pub use tenferro_tensor_core::{
+        col_major_strides, DType, DynRank, ErrorKind, HostTensor, HostTensorView, Rank, Result,
+        ShapeMismatch, ShapeVec, SliceSpec, StrideVec, Tensor, TensorLayout, TensorRank, TensorRef,
+        TensorScalar, TensorView, ValidationError, ValidationKind,
+    };
 }
 
 pub use tenferro_tensor_core::{
@@ -69,9 +73,17 @@ pub use capability::{
     capability_output_dtype, BackendId, CapabilityAxis, CapabilityQuery, OperationCapability,
     SupportLevel, TensorBackendCapability,
 };
-pub use config::*;
-pub use error::*;
-pub use types::*;
+pub use config::{
+    CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
+};
+pub use error::{BoxError, Error, Result};
+pub use types::{
+    col_major_strides, BackendBuffer, Buffer, BufferHandle, DType, DeviceId, DeviceKind, DynRank,
+    GpuBackendKind, MemoryKind, Placement, Rank, StridedSliceSpec, Tensor, TensorBufferRef,
+    TensorBufferRefMut, TensorLayout, TensorOwnedView, TensorRank, TensorRead, TensorScalar,
+    TensorValue, TensorView, TensorViewMut, TensorWrite, TypedTensor, TypedTensorView,
+    TypedTensorViewMut, TypedTensorViewMutPair, TypedTensorWrite,
+};
 
 pub(crate) fn core_dtype(dtype: DType) -> tenferro_tensor_core::DType {
     match dtype {

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -41,15 +41,15 @@
 /// the host-only core model during the crate-boundary split.
 pub mod core {
     pub use tenferro_tensor_core::{
-        col_major_strides, DType, DynRank, ErrorKind, HostTensor, HostTensorView, Rank, Result,
-        ShapeMismatch, ShapeVec, SliceSpec, StrideVec, Tensor, TensorLayout, TensorRank, TensorRef,
-        TensorScalar, TensorView, ValidationError, ValidationKind,
+        col_major_strides, DType, DynRank, ErrorKind, HostTensor, HostTensorView, IntoShapeVec,
+        Rank, Result, ShapeMismatch, ShapeVec, SliceSpec, StrideVec, Tensor, TensorLayout,
+        TensorRank, TensorRef, TensorScalar, TensorView, ValidationError, ValidationKind,
     };
 }
 
 pub use tenferro_tensor_core::{
-    ErrorKind, ShapeMismatch, ShapeVec, SliceSpec, StrideVec, TensorRef, ValidationError,
-    ValidationKind,
+    ErrorKind, IntoShapeVec, ShapeMismatch, ShapeVec, SliceSpec, StrideVec, TensorRef,
+    ValidationError, ValidationKind,
 };
 
 pub mod backend;

--- a/crates/tenferro-tensor/src/tests/public_surface_contract_tests.rs
+++ b/crates/tenferro-tensor/src/tests/public_surface_contract_tests.rs
@@ -144,6 +144,25 @@ fn tensor_scalar_helpers_do_not_expose_cpu_conjugation_hook() {
 }
 
 #[test]
+fn crate_root_reexports_are_explicit() {
+    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let source = fs::read_to_string(crate_dir.join("src/lib.rs"))
+        .expect("tenferro-tensor lib source must be readable");
+
+    for forbidden in [
+        "pub use config::*;",
+        "pub use error::*;",
+        "pub use types::*;",
+        "pub use tenferro_tensor_core::*;",
+    ] {
+        assert!(
+            !source.contains(forbidden),
+            "crate-root public API must use deliberate explicit re-exports: {forbidden}"
+        );
+    }
+}
+
+#[test]
 fn view_canonicalization_uses_symmetric_copy_into_contract() {
     let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let source = fs::read_to_string(crate_dir.join("src/backend.rs"))

--- a/crates/tenferro-tensor/src/tests/types_tests.rs
+++ b/crates/tenferro-tensor/src/tests/types_tests.rs
@@ -16,6 +16,58 @@ use crate::{
 mod strided_dynamic;
 
 #[test]
+fn placement_default_is_the_canonical_host_placement() {
+    assert_eq!(
+        Placement::default(),
+        Placement {
+            memory_kind: MemoryKind::UnpinnedHost,
+            device: None,
+        }
+    );
+}
+
+#[test]
+fn tensor_view_mut_constructors_cover_every_dtype() {
+    let shape = [1];
+    let mut f32_data = [1.0_f32];
+    let mut f64_data = [1.0_f64];
+    let mut i32_data = [1_i32];
+    let mut i64_data = [1_i64];
+    let mut bool_data = [true];
+    let mut c32_data = [Complex32::new(1.0, 0.0)];
+    let mut c64_data = [Complex64::new(1.0, 0.0)];
+
+    assert_eq!(
+        TensorViewMut::f32(&shape, &mut f32_data).unwrap().dtype(),
+        DType::F32
+    );
+    assert_eq!(
+        TensorViewMut::f64(&shape, &mut f64_data).unwrap().dtype(),
+        DType::F64
+    );
+    assert_eq!(
+        TensorViewMut::i32(&shape, &mut i32_data).unwrap().dtype(),
+        DType::I32
+    );
+    assert_eq!(
+        TensorViewMut::i64(&shape, &mut i64_data).unwrap().dtype(),
+        DType::I64
+    );
+    assert_eq!(
+        TensorViewMut::bool(&shape, &mut bool_data).unwrap().dtype(),
+        DType::Bool
+    );
+    assert_eq!(
+        TensorViewMut::c32(&shape, &mut c32_data).unwrap().dtype(),
+        DType::C32
+    );
+    assert_eq!(
+        TensorViewMut::c64(&shape, &mut c64_data).unwrap().dtype(),
+        DType::C64
+    );
+}
+
+#[test]
 fn tensor_error_preserves_shared_validation_source() {
     let err = Error::validation(
         "add",
@@ -178,7 +230,7 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
     assert_eq!(transposed.shape(), &[3, 2]);
     assert_eq!(transposed.strides(), &[2, 1]);
 
-    let reshaped = owned.reshape_view(&[6]).unwrap();
+    let reshaped = owned.reshape_view([6]).unwrap();
     assert_eq!(reshaped.shape(), &[6]);
 
     let sliced = owned
@@ -198,7 +250,7 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
     }
 
     let vector = TensorOwnedView::from_parts(Arc::clone(&base), vec![2], vec![1], 0).unwrap();
-    let broadcast = vector.broadcast_in_dim_view(&[2, 3], &[0]).unwrap();
+    let broadcast = vector.broadcast_in_dim_view([2, 3], [0]).unwrap();
     assert_eq!(broadcast.shape(), &[2, 3]);
     assert_eq!(broadcast.strides(), &[1, 0]);
 
@@ -241,8 +293,8 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
     let original_order = view_value.transpose_view([1, 0]).unwrap();
     assert_eq!(original_order.shape(), &[2, 3]);
 
-    let compact_view = value.reshape_view(&[6]).unwrap();
-    assert_eq!(compact_view.reshape_view(&[2, 3]).unwrap().shape(), &[2, 3]);
+    let compact_view = value.reshape_view([6]).unwrap();
+    assert_eq!(compact_view.reshape_view([2, 3]).unwrap().shape(), &[2, 3]);
     let sliced_value = compact_view
         .slice_view(&SliceConfig {
             starts: vec![1],
@@ -253,7 +305,7 @@ fn tensor_owned_view_and_tensor_value_cover_lazy_accessors_and_errors() {
     assert_eq!(sliced_value.shape(), &[2]);
     assert_eq!(
         compact_view
-            .broadcast_in_dim_view(&[6, 2], &[0])
+            .broadcast_in_dim_view([6, 2], [0])
             .unwrap()
             .shape(),
         &[6, 2]

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -106,6 +106,12 @@ pub struct Placement {
     pub device: Option<DeviceId>,
 }
 
+impl Default for Placement {
+    fn default() -> Self {
+        default_placement()
+    }
+}
+
 /// Backend-owned buffer handle.
 ///
 /// `BufferHandle::new` creates an empty opaque handle. Use
@@ -2574,10 +2580,14 @@ impl TensorOwnedView {
     /// arithmetic overflow, or
     /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
     /// reshaped view exceeds the base buffer.
-    pub fn reshape_view(&self, shape: &[usize]) -> crate::Result<Self> {
+    pub fn reshape_view(
+        &self,
+        shape: impl tenferro_tensor_core::IntoShapeVec,
+    ) -> crate::Result<Self> {
+        let shape = shape.into_shape_vec();
         let layout = reshape_layout_dyn(
             &self.layout,
-            shape,
+            &shape,
             tensor_buffer_len(&self.base),
             "TensorOwnedView::reshape_view",
         )?;
@@ -2685,14 +2695,15 @@ impl TensorOwnedView {
     /// result exceeds the base buffer, or
     /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
     /// arithmetic overflow.
-    pub fn broadcast_in_dim_view(&self, shape: &[usize], dims: &[usize]) -> crate::Result<Self> {
+    pub fn broadcast_in_dim_view(
+        &self,
+        shape: impl tenferro_tensor_core::IntoShapeVec,
+        dims: impl AsRef<[usize]>,
+    ) -> crate::Result<Self> {
+        let shape = shape.into_shape_vec();
         let layout = self
             .layout
-            .broadcast_in_dim_view::<DynRank>(
-                shape.to_vec().into(),
-                dims,
-                tensor_buffer_len(&self.base),
-            )
+            .broadcast_in_dim_view::<DynRank>(shape, dims, tensor_buffer_len(&self.base))
             .map_err(|err| tensor_layout_error("TensorOwnedView::broadcast_in_dim_view", err))?;
         Ok(Self {
             base: Arc::clone(&self.base),
@@ -2766,10 +2777,14 @@ impl TensorValue {
     /// arithmetic overflow, or
     /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
     /// reshaped view exceeds the backing buffer.
-    pub fn reshape_view(&self, shape: &[usize]) -> crate::Result<Self> {
+    pub fn reshape_view(
+        &self,
+        shape: impl tenferro_tensor_core::IntoShapeVec,
+    ) -> crate::Result<Self> {
+        let shape = shape.into_shape_vec();
         match self {
             Self::Tensor(tensor) => TensorOwnedView::from_tensor(Arc::clone(tensor))
-                .reshape_view(shape)
+                .reshape_view(shape.clone())
                 .map(Self::View),
             Self::View(view) => view.reshape_view(shape).map(Self::View),
         }
@@ -2810,10 +2825,16 @@ impl TensorValue {
     /// result exceeds the backing buffer, or
     /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for layout
     /// arithmetic overflow.
-    pub fn broadcast_in_dim_view(&self, shape: &[usize], dims: &[usize]) -> crate::Result<Self> {
+    pub fn broadcast_in_dim_view(
+        &self,
+        shape: impl tenferro_tensor_core::IntoShapeVec,
+        dims: impl AsRef<[usize]>,
+    ) -> crate::Result<Self> {
+        let shape = shape.into_shape_vec();
+        let dims = dims.as_ref();
         match self {
             Self::Tensor(tensor) => TensorOwnedView::from_tensor(Arc::clone(tensor))
-                .broadcast_in_dim_view(shape, dims)
+                .broadcast_in_dim_view(shape.clone(), dims)
                 .map(Self::View),
             Self::View(view) => view.broadcast_in_dim_view(shape, dims).map(Self::View),
         }
@@ -3287,18 +3308,33 @@ impl<'a> TensorView<'a> {
     }
 }
 
+macro_rules! tensor_view_mut_constructor {
+    ($name:ident, $variant:ident, $scalar:ty) => {
+        /// Create a dynamic mutable view over compact column-major host data.
+        ///
+        /// # Errors
+        ///
+        /// Returns [`crate::Error::Validation`] with
+        /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when
+        /// compact layout arithmetic overflows, or
+        /// [`tenferro_tensor_core::ValidationError::InvalidArgument`] when the
+        /// requested shape exceeds `data`.
+        pub fn $name(shape: &'a [usize], data: &'a mut [$scalar]) -> crate::Result<Self> {
+            Ok(Self::$variant(TypedTensorViewMut::from_col_major(
+                shape, data,
+            )?))
+        }
+    };
+}
+
 impl<'a> TensorViewMut<'a> {
-    /// Create a dynamic `f64` mutable view over compact column-major host data.
-    /// # Errors
-    ///
-    /// Returns [`crate::Error::Validation`] with
-    /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] for compact
-    /// shape or offset arithmetic overflow, or
-    /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
-    /// compact shape reaches beyond `data`.
-    pub fn f64(shape: &'a [usize], data: &'a mut [f64]) -> crate::Result<Self> {
-        Ok(Self::F64(TypedTensorViewMut::from_col_major(shape, data)?))
-    }
+    tensor_view_mut_constructor!(f32, F32, f32);
+    tensor_view_mut_constructor!(f64, F64, f64);
+    tensor_view_mut_constructor!(i32, I32, i32);
+    tensor_view_mut_constructor!(i64, I64, i64);
+    tensor_view_mut_constructor!(bool, Bool, bool);
+    tensor_view_mut_constructor!(c32, C32, Complex32);
+    tensor_view_mut_constructor!(c64, C64, Complex64);
 
     pub fn dtype(&self) -> DType {
         match self {
@@ -3432,6 +3468,17 @@ impl<'a> TensorRead<'a> {
 
     pub fn from_view(view: TensorView<'a>) -> Self {
         Self::View(view)
+    }
+
+    /// Convert this read target into a dtype-erased tensor view.
+    ///
+    /// Owned tensors are borrowed without copying their storage. Existing
+    /// views preserve their layout and placement metadata.
+    pub fn tensor_view(self) -> TensorView<'a> {
+        match self {
+            Self::Tensor(tensor) => tensor_view_with_layout(tensor, tensor_layout(tensor)),
+            Self::View(view) => view,
+        }
     }
 
     pub fn dtype(&self) -> DType {
@@ -4008,7 +4055,7 @@ fn reshape_layout_dyn<R: TensorRank>(
     buffer_len: usize,
     op: &'static str,
 ) -> crate::Result<TensorLayout<DynRank>> {
-    match layout.reshape_view_as::<DynRank>(shape.to_vec().into(), buffer_len) {
+    match layout.reshape_view_as::<DynRank>(shape.to_vec(), buffer_len) {
         Ok(layout) => Ok(layout),
         Err(err) => {
             if !relaxed_col_major_contiguous(layout.shape(), layout.strides(), op)? {
@@ -5000,10 +5047,10 @@ impl Tensor {
     /// [`tenferro_tensor_core::ValidationError::IntegerOverflow`] when shape
     /// arithmetic overflows.
     pub fn from_vec_col_major<T: TensorScalar>(
-        shape: Vec<usize>,
+        shape: impl tenferro_tensor_core::IntoShapeVec,
         data: Vec<T>,
     ) -> crate::Result<Self> {
-        T::into_tensor(shape, data)
+        T::into_tensor(shape.into_shape_vec().to_vec(), data)
     }
 
     /// Tensor shape.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -134,7 +134,7 @@ tenferro-linalg = { path = "/path/to/tenferro-rs/crates/tenferro-linalg", featur
 ```rust
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::LinalgBackend;
-use tenferro_runtime::{TensorView, TypedTensor, TypedTensorOpsExt};
+use tenferro_runtime::{TensorRead, TensorView, TypedTensor, TypedTensorOpsExt};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -157,7 +157,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(product.shape(), &[2, 2]);
     assert_close(product.host_data()?, &[3.0, 0.0, 0.0, 1.0]);
 
-    let svd = backend.svd_read(TensorView::F64(product.as_view()))?;
+    let svd = backend.svd_read(TensorRead::from_view(TensorView::F64(product.as_view())))?;
     assert_eq!(svd.len(), 3);
     assert_eq!(svd[0].shape(), &[2, 2]);
     assert_eq!(svd[1].shape(), &[2]);

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ compilation, CUDA, or experimental WebGPU only when the workflow needs them.
 ```rust
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::LinalgBackend;
-use tenferro_runtime::{TensorView, TypedTensor, TypedTensorOpsExt};
+use tenferro_runtime::{TensorRead, TensorView, TypedTensor, TypedTensorOpsExt};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(product.shape(), &[2, 2]);
     assert_close(product.host_data()?, &[3.0, 0.0, 0.0, 1.0]);
 
-    let svd = backend.svd_read(TensorView::F64(product.as_view()))?;
+    let svd = backend.svd_read(TensorRead::from_view(TensorView::F64(product.as_view())))?;
     assert_eq!(svd.len(), 3);
     assert_eq!(svd[0].shape(), &[2, 2]);
     assert_eq!(svd[1].shape(), &[2]);

--- a/docs/spec/operation-categories.md
+++ b/docs/spec/operation-categories.md
@@ -197,6 +197,19 @@ Constraints (document in the API):
 
 ## Argument convention (fixed across categories)
 
+Shape arguments accept owned or borrowed shape-like values: fixed-rank APIs use
+`impl Into<R::Shape>`, while dynamic-rank APIs use `impl IntoShapeVec`. Axis lists,
+dimension mappings, and similar collections use `impl AsRef<[T]>`.
+
+Axis sign is part of each operation's public contract, not a global coercion.
+Negative `isize` axes are currently accepted only by FFT (`fft`, `ifft`, `rfft`,
+`irfft`), `index_select`, `stack`, and explicit `TensorDotAxes::Axes`; each is
+normalized relative to the input rank and rejects an out-of-range result. Other
+axis-taking APIs, including reductions, `concatenate`, and `reverse`, accept
+non-negative `usize` axes only. New negative-axis support must be added
+deliberately and consistently across the relevant concrete, eager, and traced
+surfaces.
+
 Multi-input structural ops (`concatenate`, `stack`, `split`, …) must accept owned
 values, views, and `IntoIterator` ergonomically, and define behavior for an empty
 input. This pre-empts the owned-vs-view boilerplate complaint seen in NumPy/ndarray

--- a/docs/tutorial-code/src/bin/direct_linalg_quickstart.rs
+++ b/docs/tutorial-code/src/bin/direct_linalg_quickstart.rs
@@ -1,6 +1,6 @@
 use tenferro_cpu::CpuBackend;
 use tenferro_linalg::LinalgBackend;
-use tenferro_runtime::{TensorView, TypedTensor, TypedTensorOpsExt};
+use tenferro_runtime::{TensorRead, TensorView, TypedTensor, TypedTensorOpsExt};
 
 fn assert_close(actual: &[f64], expected: &[f64]) {
     assert_eq!(actual.len(), expected.len());
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(product.shape(), &[2, 2]);
     assert_close(product.host_data()?, &[3.0, 0.0, 0.0, 1.0]);
 
-    let svd = backend.svd_read(TensorView::F64(product.as_view()))?;
+    let svd = backend.svd_read(TensorRead::from_view(TensorView::F64(product.as_view())))?;
     assert_eq!(svd.len(), 3);
     assert_eq!(svd[0].shape(), &[2, 2]);
     assert_eq!(svd[1].shape(), &[2]);


### PR DESCRIPTION
## Summary

This batch resolves a set of independent small maintenance issues while preserving one reviewable commit per issue:

- make the einsum GPU dependency opt-in instead of enabling it from CPU-only/default builds
- align eager and concrete tensor public surfaces, including constructor and parameter conventions
- add the non-breaking portion of the constructor/parameter uniformity design; `TracedTensor::val` privatization remains intentionally out of scope
- propagate poisoned CPU buffer-pool and runtime registry locks as typed runtime-state errors
- replace process-global unbounded RustFFT plan caches with explicit bounded ownership

## Root causes and impact

- Feature wiring pulled GPU code into configurations that did not request it.
- Equivalent eager/concrete operations had avoidable API gaps and inconsistent accepted parameter types.
- CPU pool access used lock paths that could panic or partially mutate state after poisoning.
- FFT plans lived in process-global `OnceLock<Mutex<HashMap<...>>>` stores with no capacity, lifecycle, clearing, or accounting controls.

The FFT path now uses:
- a public caller-owned `FftExecutor` / bounded LRU `FftPlanCache` for repeated concrete execution
- the existing executor-owned bounded extension cache for graph execution
- local non-retained state for one-shot concrete calls

FFT retained-byte stats report known cache-owned key/handle bytes; opaque RustFFT internal allocations are explicitly excluded.

## Validation

- `cargo test --workspace --quiet`
- `cargo check --workspace --all-targets`
- `cargo test -p tenferro-fft --features autodiff`
- `cargo clippy -p tenferro-fft --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p tenferro-fft --no-deps`
- `git diff --check`

## Integration

The five commits are intentionally split by issue. Please use a merge commit rather than squash-merging this PR.

Closes #1308
Closes #1269
Addresses #1281
Closes #1387
Closes #1406