### PR TITLE
Fix grouped BLAS provider error inference

### DIFF
--- a/crates/tenferro-cpu/src/gemm/blas_gemm.rs
+++ b/crates/tenferro-cpu/src/gemm/blas_gemm.rs
@@ -412,14 +412,14 @@ mod provider_batch {
                         return Err(Error::invalid_argument(
                             "grouped_gemm",
                             "configuration",
-                            "BLAS grouped GEMM metadata is inconsistent".into(),
+                            "BLAS grouped GEMM metadata is inconsistent",
                         ));
                     };
                     *last_size = last_size.checked_add(1).ok_or_else(|| {
                         Error::invalid_argument(
                             "grouped_gemm",
                             "configuration",
-                            "BLAS grouped GEMM group_size overflows i32".into(),
+                            "BLAS grouped GEMM group_size overflows i32",
                         )
                     })?;
                 }


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Supersedes #1419.

## Summary

Explicit OpenBLAS and MKL builds compile the grouped GEMM provider path. Two `Error::invalid_argument` calls pre-converted string literals with `.into()`, which left the generic `impl Into<String>` argument ambiguous and caused Rust error E0283.

Pass the literals directly so the callee performs the intended conversion. Runtime behavior is unchanged.

This is a maintainer takeover of Ryo-wtnb11's fix from #1419. Commit `b7017a95cc49b7078d8837b5e15aa12f1790aa69` was cherry-picked, and the original author metadata is preserved. The same-pattern scan covered both grouped-provider error sites; no related instances were deferred. The AI-assisted bug-fix scope gate was applied, and this remains a focused existing-behavior compile fix.

## Work log

Not required: this is a two-line contributor-authored compile fix with no design or architectural tradeoff.

## Verification

- `cargo fmt --all --check`
- `cargo check -p tenferro-cpu --lib --no-default-features --features blas-openblas`
- `cargo check -p tenferro-cpu --lib --no-default-features --features blas-mkl`
- `cargo test -p tenferro-cpu --lib --no-default-features --features blas-openblas grouped_gemm` (5 passed)
- `python3 scripts/ci/run_profile.py full` (all test/docs/coverage profiles passed; `ci-config` then rerun with pinned actionlint v1.7.7 because local Go/actionlint was absent)
- `python3 scripts/ci/run_profile.py ci-config` (152 tests and actionlint passed)
- workspace, tropical extension, and sparse extension strict clippy with `-D warnings`, `missing_errors_doc`, and `missing_panics_doc`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-cpu --lib --no-default-features --features blas-openblas grouped_gemm'`
- committed-head repository-rules review: pass, no findings

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed (existing grouped GEMM tests cover this compile path; no behavior/docs changed).
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers (not applicable).
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above (not applicable; rationale above).
