### PR TITLE
refactor(fft): add explicit backend capability

### DIFF
--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -38,6 +38,5 @@ tidu = { workspace = true, optional = true }
 computegraph.workspace = true
 num-complex.workspace = true
 num-traits.workspace = true
-lru.workspace = true
 rustfft = "6"
 thiserror.workspace = true

--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -31,6 +31,7 @@ rocm = ["tenferro-ad?/rocm", "tenferro-internal-ops/rocm"]
 tenferro-runtime = { path = "../tenferro-runtime", version = "0.2.0", default-features = false }
 tenferro-ad = { path = "../tenferro-ad", version = "0.2.0", default-features = false, optional = true }
 tenferro-tensor = { path = "../tenferro-tensor", version = "0.2.0", default-features = false }
+tenferro-cpu = { path = "../tenferro-cpu", version = "0.2.0", default-features = false }
 tenferro-internal-extension-macros = { path = "../tenferro-internal-extension-macros", version = "0.2.0" }
 tenferro-internal-ops = { path = "../tenferro-internal-ops", version = "0.2.0", default-features = false }
 tidu = { workspace = true, optional = true }
@@ -40,6 +41,3 @@ num-traits.workspace = true
 lru.workspace = true
 rustfft = "6"
 thiserror.workspace = true
-
-[dev-dependencies]
-tenferro-cpu = { path = "../tenferro-cpu", version = "0.2.0", default-features = false }

--- a/crates/tenferro-fft/src/backend.rs
+++ b/crates/tenferro-fft/src/backend.rs
@@ -5,17 +5,19 @@ use tenferro_tensor::{Tensor, TensorBackend};
 
 use crate::{FftPlanCache, FftPlanSpec};
 
-pub(crate) enum FftCacheSource<'a> {
-    CallerOwned(&'a mut FftPlanCache),
-    RuntimeOwned(&'a mut ExtensionCacheStore),
+#[derive(Clone, Copy, Debug)]
+enum FftCacheOwner {
+    CallerOwned,
+    RuntimeOwned,
 }
 
 /// Execution-cache state supplied to an [`FftBackend`].
 ///
 /// Direct repeated calls use a caller-owned [`FftPlanCache`], while traced
-/// execution uses the owning runtime's [`ExtensionCacheStore`]. Constructors
-/// keep the representation closed so future backends can add plan/workspace
-/// entries without exposing RustFFT plan types.
+/// execution uses the owning runtime's [`ExtensionCacheStore`]. Both ownership
+/// paths expose the same bounded typed store to a backend, so CPU, Metal, CUDA,
+/// and future implementations can retain private plans or workspaces in their
+/// own cache namespace. Constructors keep the owner representation closed.
 ///
 /// # Examples
 ///
@@ -27,53 +29,49 @@ pub(crate) enum FftCacheSource<'a> {
 /// assert!(format!("{cache:?}").contains("CallerOwned"));
 /// ```
 pub struct FftExecutionCache<'a> {
-    source: FftCacheSource<'a>,
+    owner: FftCacheOwner,
+    store: &'a mut ExtensionCacheStore,
 }
 
 impl fmt::Debug for FftExecutionCache<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self.source {
-            FftCacheSource::CallerOwned(cache) => f
-                .debug_struct("FftExecutionCache")
-                .field("owner", &"CallerOwned")
-                .field("stats", &cache.stats())
-                .finish_non_exhaustive(),
-            FftCacheSource::RuntimeOwned(_) => f
-                .debug_struct("FftExecutionCache")
-                .field("owner", &"RuntimeOwned")
-                .finish_non_exhaustive(),
-        }
+        f.debug_struct("FftExecutionCache")
+            .field("owner", &self.owner)
+            .field(
+                "stats",
+                &self
+                    .store
+                    .stats(tenferro_runtime::ExtensionCacheSelector::All),
+            )
+            .finish_non_exhaustive()
     }
 }
 
 impl<'a> FftExecutionCache<'a> {
-    /// Build a context backed by a caller-owned RustFFT plan cache.
+    /// Build a context backed by a caller-owned typed FFT execution cache.
     pub fn caller_owned(cache: &'a mut FftPlanCache) -> Self {
         Self {
-            source: FftCacheSource::CallerOwned(cache),
+            owner: FftCacheOwner::CallerOwned,
+            store: cache.store_mut(),
         }
     }
 
     /// Build a context backed by an extension runtime cache store.
     pub fn runtime_owned(cache: &'a mut ExtensionCacheStore) -> Self {
         Self {
-            source: FftCacheSource::RuntimeOwned(cache),
+            owner: FftCacheOwner::RuntimeOwned,
+            store: cache,
         }
     }
 
-    /// Borrow the runtime cache store when traced execution owns this context.
+    /// Borrow the bounded typed store owned by the caller or extension runtime.
     ///
-    /// Caller-owned direct execution returns `None`. Backend implementations
-    /// can use the returned store for backend-specific plans or workspaces.
-    pub fn runtime_store_mut(&mut self) -> Option<&mut ExtensionCacheStore> {
-        match &mut self.source {
-            FftCacheSource::CallerOwned(_) => None,
-            FftCacheSource::RuntimeOwned(cache) => Some(cache),
-        }
-    }
-
-    pub(crate) fn into_source(self) -> FftCacheSource<'a> {
-        self.source
+    /// Backend implementations should use a stable family/cache namespace and
+    /// include every plan-identity field in the key discriminator. The store
+    /// owns LRU bounds, typed retrieval, clear behavior, entry counts, and the
+    /// retained-byte estimates supplied at insertion.
+    pub fn store_mut(&mut self) -> &mut ExtensionCacheStore {
+        self.store
     }
 }
 

--- a/crates/tenferro-fft/src/backend.rs
+++ b/crates/tenferro-fft/src/backend.rs
@@ -1,0 +1,131 @@
+use std::fmt;
+
+use tenferro_runtime::ExtensionCacheStore;
+use tenferro_tensor::{Tensor, TensorBackend};
+
+use crate::{FftPlanCache, FftPlanSpec};
+
+pub(crate) enum FftCacheSource<'a> {
+    CallerOwned(&'a mut FftPlanCache),
+    RuntimeOwned(&'a mut ExtensionCacheStore),
+}
+
+/// Execution-cache state supplied to an [`FftBackend`].
+///
+/// Direct repeated calls use a caller-owned [`FftPlanCache`], while traced
+/// execution uses the owning runtime's [`ExtensionCacheStore`]. Constructors
+/// keep the representation closed so future backends can add plan/workspace
+/// entries without exposing RustFFT plan types.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_fft::{FftExecutionCache, FftPlanCache};
+///
+/// let mut plans = FftPlanCache::default();
+/// let cache = FftExecutionCache::caller_owned(&mut plans);
+/// assert!(format!("{cache:?}").contains("CallerOwned"));
+/// ```
+pub struct FftExecutionCache<'a> {
+    source: FftCacheSource<'a>,
+}
+
+impl fmt::Debug for FftExecutionCache<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.source {
+            FftCacheSource::CallerOwned(cache) => f
+                .debug_struct("FftExecutionCache")
+                .field("owner", &"CallerOwned")
+                .field("stats", &cache.stats())
+                .finish_non_exhaustive(),
+            FftCacheSource::RuntimeOwned(_) => f
+                .debug_struct("FftExecutionCache")
+                .field("owner", &"RuntimeOwned")
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
+impl<'a> FftExecutionCache<'a> {
+    /// Build a context backed by a caller-owned RustFFT plan cache.
+    pub fn caller_owned(cache: &'a mut FftPlanCache) -> Self {
+        Self {
+            source: FftCacheSource::CallerOwned(cache),
+        }
+    }
+
+    /// Build a context backed by an extension runtime cache store.
+    pub fn runtime_owned(cache: &'a mut ExtensionCacheStore) -> Self {
+        Self {
+            source: FftCacheSource::RuntimeOwned(cache),
+        }
+    }
+
+    /// Borrow the runtime cache store when traced execution owns this context.
+    ///
+    /// Caller-owned direct execution returns `None`. Backend implementations
+    /// can use the returned store for backend-specific plans or workspaces.
+    pub fn runtime_store_mut(&mut self) -> Option<&mut ExtensionCacheStore> {
+        match &mut self.source {
+            FftCacheSource::CallerOwned(_) => None,
+            FftCacheSource::RuntimeOwned(cache) => Some(cache),
+        }
+    }
+
+    pub(crate) fn into_source(self) -> FftCacheSource<'a> {
+        self.source
+    }
+}
+
+/// Explicit backend capability required by concrete and traced FFT execution.
+///
+/// Implementations must execute on the input's existing placement. Unsupported
+/// dtypes, layouts, placements, or operations return an error; they must never
+/// transfer the tensor or select a different backend.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_fft::FftBackend;
+///
+/// fn accepts_fft_backend<B: FftBackend>(_backend: &mut B) {}
+///
+/// let mut backend = CpuBackend::new();
+/// accepts_fft_backend(&mut backend);
+/// ```
+///
+/// A generic tensor backend without this explicit capability cannot register
+/// the FFT runtime:
+///
+/// ```compile_fail
+/// use tenferro_runtime::ExtensionExecutor;
+/// use tenferro_tensor::{Tensor, TensorBackend};
+/// use tenferro_fft::{FftNorm, TensorFftExt};
+///
+/// fn register_without_fft_capability<B: TensorBackend + 'static>(
+///     executor: &mut ExtensionExecutor<B>,
+///     backend: &mut B,
+///     input: &Tensor,
+/// ) {
+///     tenferro_fft::register_runtime(executor).unwrap();
+///     let _ = input.fft(None, -1, FftNorm::Backward, backend);
+/// }
+/// ```
+pub trait FftBackend: TensorBackend {
+    /// Execute one validated FFT request on `input`'s existing placement.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`tenferro_tensor::Error::Unsupported`] for an unsupported
+    /// operation, dtype, layout, or placement;
+    /// [`tenferro_tensor::Error::Validation`] for inconsistent input/spec
+    /// metadata or checked shape arithmetic; and a typed backend or runtime
+    /// source when plan creation, cache access, or execution fails.
+    fn execute_fft(
+        &mut self,
+        input: &Tensor,
+        spec: &FftPlanSpec,
+        cache: FftExecutionCache<'_>,
+    ) -> tenferro_tensor::Result<Tensor>;
+}

--- a/crates/tenferro-fft/src/backend.rs
+++ b/crates/tenferro-fft/src/backend.rs
@@ -127,3 +127,33 @@ pub trait FftBackend: TensorBackend {
         cache: FftExecutionCache<'_>,
     ) -> tenferro_tensor::Result<Tensor>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execution_cache_debug_identifies_both_owners_and_exposes_the_store() {
+        let mut caller = FftPlanCache::default();
+        let mut caller_cache = FftExecutionCache::caller_owned(&mut caller);
+        assert!(format!("{caller_cache:?}").contains("CallerOwned"));
+        assert_eq!(
+            caller_cache
+                .store_mut()
+                .stats(tenferro_runtime::ExtensionCacheSelector::All)
+                .entries,
+            0
+        );
+
+        let mut runtime = ExtensionCacheStore::default();
+        let mut runtime_cache = FftExecutionCache::runtime_owned(&mut runtime);
+        assert!(format!("{runtime_cache:?}").contains("RuntimeOwned"));
+        assert_eq!(
+            runtime_cache
+                .store_mut()
+                .stats(tenferro_runtime::ExtensionCacheSelector::All)
+                .entries,
+            0
+        );
+    }
+}

--- a/crates/tenferro-fft/src/cache.rs
+++ b/crates/tenferro-fft/src/cache.rs
@@ -4,21 +4,25 @@ use std::hash::{Hash, Hasher};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
-use lru::LruCache;
 use num_traits::{Float, FromPrimitive};
 use rustfft::{Fft, FftNum, FftPlanner};
-use tenferro_runtime::{ExtensionCacheKey, ExtensionCacheSelector, ExtensionCacheStore};
+use tenferro_runtime::{
+    ExtensionCacheKey, ExtensionCacheLimits, ExtensionCacheSelector, ExtensionCacheStore,
+};
 use tenferro_tensor::{CacheStats, RuntimeCacheControl};
 
 use crate::FFT_EXTENSION_FAMILY_ID;
 
-/// Runtime cache namespace used for RustFFT plans.
+/// Runtime cache namespace used for private RustFFT plans.
 pub const FFT_PLAN_CACHE_NAME: &str = "rustfft-plans";
 
-/// Default number of plans retained by a caller-owned [`FftPlanCache`].
+/// Default number of typed entries retained by a caller-owned [`FftPlanCache`].
 pub const DEFAULT_FFT_PLAN_CACHE_CAPACITY: usize = 64;
 
-/// Select the FFT plan entries in an extension runtime cache.
+/// Select the private CPU RustFFT plan entries in an extension runtime cache.
+///
+/// Other [`crate::FftBackend`] implementations use distinct cache names in the
+/// same FFT extension family.
 ///
 /// # Examples
 ///
@@ -33,6 +37,113 @@ pub const fn fft_plan_cache_selector() -> ExtensionCacheSelector {
     ExtensionCacheSelector::Cache {
         family_id: FFT_EXTENSION_FAMILY_ID,
         cache_name: FFT_PLAN_CACHE_NAME,
+    }
+}
+
+/// Bounded, caller-owned typed cache for backend FFT plans and workspaces.
+///
+/// [`crate::FftExecutor`] owns one cache and passes its store to every
+/// [`crate::FftBackend`] through [`crate::FftExecutionCache`]. Backends retain
+/// private `Send + Sync + 'static` values under their own
+/// [`ExtensionCacheKey`] namespace. Entry limits, LRU eviction, clearing,
+/// aggregate entry counts, and retained-byte accounting apply uniformly to CPU
+/// and non-CPU entries.
+///
+/// The CPU backend stores RustFFT plans in the private `rustfft-plans`
+/// namespace. Its retained-byte estimate includes the exact plan key and the
+/// cache-owned `Arc` handle; allocations opaque to RustFFT are excluded.
+///
+/// # Examples
+///
+/// ```
+/// use std::num::NonZeroUsize;
+/// use tenferro_fft::FftPlanCache;
+///
+/// let cache = FftPlanCache::with_capacity(NonZeroUsize::new(2).unwrap());
+/// assert_eq!(cache.capacity().get(), 2);
+/// assert_eq!(cache.stats().entries, 0);
+/// ```
+pub struct FftPlanCache {
+    store: ExtensionCacheStore,
+}
+
+impl fmt::Debug for FftPlanCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FftPlanCache")
+            .field("capacity", &self.capacity())
+            .field("stats", &self.stats())
+            .finish_non_exhaustive()
+    }
+}
+
+impl FftPlanCache {
+    /// Create an empty typed cache with an explicit maximum entry count.
+    pub fn with_capacity(capacity: NonZeroUsize) -> Self {
+        Self {
+            store: ExtensionCacheStore::with_limits(ExtensionCacheLimits::new(capacity)),
+        }
+    }
+
+    /// Maximum number of retained backend entries across all namespaces.
+    pub fn capacity(&self) -> NonZeroUsize {
+        self.store.limits().max_entries()
+    }
+
+    /// Resize the cache, evicting least-recently-used entries when necessary.
+    pub fn set_capacity(&mut self, capacity: NonZeroUsize) {
+        self.store.set_limits(ExtensionCacheLimits::new(capacity));
+    }
+
+    /// Remove every retained backend plan or workspace.
+    pub fn clear(&mut self) {
+        self.store.clear();
+    }
+
+    /// Snapshot aggregate entries and backend-reported retained bytes.
+    pub fn stats(&self) -> CacheStats {
+        self.store.stats(ExtensionCacheSelector::All)
+    }
+
+    pub(crate) fn store_mut(&mut self) -> &mut ExtensionCacheStore {
+        &mut self.store
+    }
+
+    pub(crate) fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>> {
+        ExtensionFftPlanCache::new(&mut self.store).plan_f32(len, forward)
+    }
+
+    pub(crate) fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>> {
+        ExtensionFftPlanCache::new(&mut self.store).plan_f64(len, forward)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains_f64(&mut self, len: usize, forward: bool) -> bool {
+        let key = FftPlanKey {
+            len,
+            forward,
+            dtype: FftPlanDType::F64,
+        };
+        self.store
+            .get::<ExtensionFftPlanEntry>(&extension_plan_key(key))
+            .is_some_and(|entry| entry.matches_f64(key))
+    }
+}
+
+impl Default for FftPlanCache {
+    fn default() -> Self {
+        Self::with_capacity(
+            NonZeroUsize::new(DEFAULT_FFT_PLAN_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN),
+        )
+    }
+}
+
+impl RuntimeCacheControl for FftPlanCache {
+    fn clear(&mut self) {
+        Self::clear(self);
+    }
+
+    fn stats(&self) -> CacheStats {
+        Self::stats(self)
     }
 }
 
@@ -54,119 +165,15 @@ enum CachedFftPlan {
     F64(Arc<dyn Fft<f64>>),
 }
 
-/// Bounded, caller-owned LRU cache of RustFFT plans.
-///
-/// Retained-byte statistics include the cache-owned key and `Arc` handle for
-/// each entry. RustFFT does not expose the allocations owned by an opaque plan,
-/// so those allocations are intentionally excluded from the estimate.
-///
-/// # Examples
-///
-/// ```
-/// use std::num::NonZeroUsize;
-/// use tenferro_fft::FftPlanCache;
-///
-/// let cache = FftPlanCache::with_capacity(NonZeroUsize::new(2).unwrap());
-/// assert_eq!(cache.capacity().get(), 2);
-/// assert_eq!(cache.stats().entries, 0);
-/// ```
-pub struct FftPlanCache {
-    entries: LruCache<FftPlanKey, CachedFftPlan>,
+struct ExtensionFftPlanEntry {
+    key: FftPlanKey,
+    plan: CachedFftPlan,
 }
 
-impl fmt::Debug for FftPlanCache {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("FftPlanCache")
-            .field("capacity", &self.capacity())
-            .field("stats", &self.stats())
-            .finish_non_exhaustive()
-    }
-}
-
-impl FftPlanCache {
-    /// Create an empty plan cache with an explicit maximum entry count.
-    pub fn with_capacity(capacity: NonZeroUsize) -> Self {
-        Self {
-            entries: LruCache::new(capacity),
-        }
-    }
-
-    /// Maximum number of retained plans.
-    pub fn capacity(&self) -> NonZeroUsize {
-        self.entries.cap()
-    }
-
-    /// Resize the cache, evicting least-recently-used plans when necessary.
-    pub fn set_capacity(&mut self, capacity: NonZeroUsize) {
-        self.entries.resize(capacity);
-    }
-
-    /// Remove every retained plan.
-    pub fn clear(&mut self) {
-        self.entries.clear();
-    }
-
-    /// Snapshot the number of plans and known cache-owned bytes retained.
-    pub fn stats(&self) -> CacheStats {
-        CacheStats {
-            entries: self.entries.len(),
-            retained_bytes: self.entries.len().saturating_mul(fft_plan_retained_bytes()),
-        }
-    }
-
-    pub(crate) fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>> {
-        let key = FftPlanKey {
-            len,
-            forward,
-            dtype: FftPlanDType::F32,
-        };
-        if let Some(CachedFftPlan::F32(plan)) = self.entries.get(&key) {
-            return Arc::clone(plan);
-        }
-        let plan = build_fft_plan::<f32>(len, forward);
-        self.entries.put(key, CachedFftPlan::F32(Arc::clone(&plan)));
-        plan
-    }
-
-    pub(crate) fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>> {
-        let key = FftPlanKey {
-            len,
-            forward,
-            dtype: FftPlanDType::F64,
-        };
-        if let Some(CachedFftPlan::F64(plan)) = self.entries.get(&key) {
-            return Arc::clone(plan);
-        }
-        let plan = build_fft_plan::<f64>(len, forward);
-        self.entries.put(key, CachedFftPlan::F64(Arc::clone(&plan)));
-        plan
-    }
-
+impl ExtensionFftPlanEntry {
     #[cfg(test)]
-    pub(crate) fn contains_f64(&self, len: usize, forward: bool) -> bool {
-        self.entries.contains(&FftPlanKey {
-            len,
-            forward,
-            dtype: FftPlanDType::F64,
-        })
-    }
-}
-
-impl Default for FftPlanCache {
-    fn default() -> Self {
-        Self::with_capacity(
-            NonZeroUsize::new(DEFAULT_FFT_PLAN_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN),
-        )
-    }
-}
-
-impl RuntimeCacheControl for FftPlanCache {
-    fn clear(&mut self) {
-        Self::clear(self);
-    }
-
-    fn stats(&self) -> CacheStats {
-        Self::stats(self)
+    fn matches_f64(&self, key: FftPlanKey) -> bool {
+        self.key == key && matches!(self.plan, CachedFftPlan::F64(_))
     }
 }
 
@@ -221,18 +228,6 @@ pub(crate) fn cached_fft_plan<T: CachedFftPlanScalar, P: FftPlanProvider + ?Size
     T::plan(plans, len, forward)
 }
 
-#[derive(Clone)]
-struct ExtensionF32Plan {
-    key: FftPlanKey,
-    plan: Arc<dyn Fft<f32>>,
-}
-
-#[derive(Clone)]
-struct ExtensionF64Plan {
-    key: FftPlanKey,
-    plan: Arc<dyn Fft<f64>>,
-}
-
 pub(crate) struct ExtensionFftPlanCache<'a> {
     entries: &'a mut ExtensionCacheStore,
 }
@@ -261,17 +256,19 @@ impl FftPlanProvider for ExtensionFftPlanCache<'_> {
             dtype: FftPlanDType::F32,
         };
         let cache_key = extension_plan_key(key);
-        if let Some(cached) = self.entries.get::<ExtensionF32Plan>(&cache_key) {
+        if let Some(cached) = self.entries.get::<ExtensionFftPlanEntry>(&cache_key) {
             if cached.key == key {
-                return Arc::clone(&cached.plan);
+                if let CachedFftPlan::F32(plan) = &cached.plan {
+                    return Arc::clone(plan);
+                }
             }
         }
         let plan = build_fft_plan::<f32>(len, forward);
         self.entries.put(
             cache_key,
-            ExtensionF32Plan {
+            ExtensionFftPlanEntry {
                 key,
-                plan: Arc::clone(&plan),
+                plan: CachedFftPlan::F32(Arc::clone(&plan)),
             },
             fft_plan_retained_bytes(),
         );
@@ -285,17 +282,19 @@ impl FftPlanProvider for ExtensionFftPlanCache<'_> {
             dtype: FftPlanDType::F64,
         };
         let cache_key = extension_plan_key(key);
-        if let Some(cached) = self.entries.get::<ExtensionF64Plan>(&cache_key) {
+        if let Some(cached) = self.entries.get::<ExtensionFftPlanEntry>(&cache_key) {
             if cached.key == key {
-                return Arc::clone(&cached.plan);
+                if let CachedFftPlan::F64(plan) = &cached.plan {
+                    return Arc::clone(plan);
+                }
             }
         }
         let plan = build_fft_plan::<f64>(len, forward);
         self.entries.put(
             cache_key,
-            ExtensionF64Plan {
+            ExtensionFftPlanEntry {
                 key,
-                plan: Arc::clone(&plan),
+                plan: CachedFftPlan::F64(Arc::clone(&plan)),
             },
             fft_plan_retained_bytes(),
         );

--- a/crates/tenferro-fft/src/cache.rs
+++ b/crates/tenferro-fft/src/cache.rs
@@ -1,0 +1,317 @@
+use std::collections::hash_map::DefaultHasher;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use lru::LruCache;
+use num_traits::{Float, FromPrimitive};
+use rustfft::{Fft, FftNum, FftPlanner};
+use tenferro_runtime::{ExtensionCacheKey, ExtensionCacheSelector, ExtensionCacheStore};
+use tenferro_tensor::{CacheStats, RuntimeCacheControl};
+
+use crate::FFT_EXTENSION_FAMILY_ID;
+
+/// Runtime cache namespace used for RustFFT plans.
+pub const FFT_PLAN_CACHE_NAME: &str = "rustfft-plans";
+
+/// Default number of plans retained by a caller-owned [`FftPlanCache`].
+pub const DEFAULT_FFT_PLAN_CACHE_CAPACITY: usize = 64;
+
+/// Select the FFT plan entries in an extension runtime cache.
+///
+/// # Examples
+///
+/// ```
+/// let selector = tenferro_fft::fft_plan_cache_selector();
+/// assert!(matches!(
+///     selector,
+///     tenferro_runtime::ExtensionCacheSelector::Cache { .. }
+/// ));
+/// ```
+pub const fn fft_plan_cache_selector() -> ExtensionCacheSelector {
+    ExtensionCacheSelector::Cache {
+        family_id: FFT_EXTENSION_FAMILY_ID,
+        cache_name: FFT_PLAN_CACHE_NAME,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum FftPlanDType {
+    F32,
+    F64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct FftPlanKey {
+    len: usize,
+    forward: bool,
+    dtype: FftPlanDType,
+}
+
+enum CachedFftPlan {
+    F32(Arc<dyn Fft<f32>>),
+    F64(Arc<dyn Fft<f64>>),
+}
+
+/// Bounded, caller-owned LRU cache of RustFFT plans.
+///
+/// Retained-byte statistics include the cache-owned key and `Arc` handle for
+/// each entry. RustFFT does not expose the allocations owned by an opaque plan,
+/// so those allocations are intentionally excluded from the estimate.
+///
+/// # Examples
+///
+/// ```
+/// use std::num::NonZeroUsize;
+/// use tenferro_fft::FftPlanCache;
+///
+/// let cache = FftPlanCache::with_capacity(NonZeroUsize::new(2).unwrap());
+/// assert_eq!(cache.capacity().get(), 2);
+/// assert_eq!(cache.stats().entries, 0);
+/// ```
+pub struct FftPlanCache {
+    entries: LruCache<FftPlanKey, CachedFftPlan>,
+}
+
+impl fmt::Debug for FftPlanCache {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FftPlanCache")
+            .field("capacity", &self.capacity())
+            .field("stats", &self.stats())
+            .finish_non_exhaustive()
+    }
+}
+
+impl FftPlanCache {
+    /// Create an empty plan cache with an explicit maximum entry count.
+    pub fn with_capacity(capacity: NonZeroUsize) -> Self {
+        Self {
+            entries: LruCache::new(capacity),
+        }
+    }
+
+    /// Maximum number of retained plans.
+    pub fn capacity(&self) -> NonZeroUsize {
+        self.entries.cap()
+    }
+
+    /// Resize the cache, evicting least-recently-used plans when necessary.
+    pub fn set_capacity(&mut self, capacity: NonZeroUsize) {
+        self.entries.resize(capacity);
+    }
+
+    /// Remove every retained plan.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+
+    /// Snapshot the number of plans and known cache-owned bytes retained.
+    pub fn stats(&self) -> CacheStats {
+        CacheStats {
+            entries: self.entries.len(),
+            retained_bytes: self.entries.len().saturating_mul(fft_plan_retained_bytes()),
+        }
+    }
+
+    pub(crate) fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>> {
+        let key = FftPlanKey {
+            len,
+            forward,
+            dtype: FftPlanDType::F32,
+        };
+        if let Some(CachedFftPlan::F32(plan)) = self.entries.get(&key) {
+            return Arc::clone(plan);
+        }
+        let plan = build_fft_plan::<f32>(len, forward);
+        self.entries.put(key, CachedFftPlan::F32(Arc::clone(&plan)));
+        plan
+    }
+
+    pub(crate) fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>> {
+        let key = FftPlanKey {
+            len,
+            forward,
+            dtype: FftPlanDType::F64,
+        };
+        if let Some(CachedFftPlan::F64(plan)) = self.entries.get(&key) {
+            return Arc::clone(plan);
+        }
+        let plan = build_fft_plan::<f64>(len, forward);
+        self.entries.put(key, CachedFftPlan::F64(Arc::clone(&plan)));
+        plan
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains_f64(&self, len: usize, forward: bool) -> bool {
+        self.entries.contains(&FftPlanKey {
+            len,
+            forward,
+            dtype: FftPlanDType::F64,
+        })
+    }
+}
+
+impl Default for FftPlanCache {
+    fn default() -> Self {
+        Self::with_capacity(
+            NonZeroUsize::new(DEFAULT_FFT_PLAN_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN),
+        )
+    }
+}
+
+impl RuntimeCacheControl for FftPlanCache {
+    fn clear(&mut self) {
+        Self::clear(self);
+    }
+
+    fn stats(&self) -> CacheStats {
+        Self::stats(self)
+    }
+}
+
+pub(crate) trait FftPlanProvider: Send {
+    fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>>;
+    fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>>;
+}
+
+impl FftPlanProvider for FftPlanCache {
+    fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>> {
+        Self::plan_f32(self, len, forward)
+    }
+
+    fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>> {
+        Self::plan_f64(self, len, forward)
+    }
+}
+
+pub(crate) trait CachedFftPlanScalar: FftNum + Float + FromPrimitive + 'static {
+    fn plan<P: FftPlanProvider + ?Sized>(
+        plans: &mut P,
+        len: usize,
+        forward: bool,
+    ) -> Arc<dyn Fft<Self>>;
+}
+
+impl CachedFftPlanScalar for f32 {
+    fn plan<P: FftPlanProvider + ?Sized>(
+        plans: &mut P,
+        len: usize,
+        forward: bool,
+    ) -> Arc<dyn Fft<Self>> {
+        plans.plan_f32(len, forward)
+    }
+}
+
+impl CachedFftPlanScalar for f64 {
+    fn plan<P: FftPlanProvider + ?Sized>(
+        plans: &mut P,
+        len: usize,
+        forward: bool,
+    ) -> Arc<dyn Fft<Self>> {
+        plans.plan_f64(len, forward)
+    }
+}
+
+pub(crate) fn cached_fft_plan<T: CachedFftPlanScalar, P: FftPlanProvider + ?Sized>(
+    plans: &mut P,
+    len: usize,
+    forward: bool,
+) -> Arc<dyn Fft<T>> {
+    T::plan(plans, len, forward)
+}
+
+#[derive(Clone)]
+struct ExtensionF32Plan {
+    key: FftPlanKey,
+    plan: Arc<dyn Fft<f32>>,
+}
+
+#[derive(Clone)]
+struct ExtensionF64Plan {
+    key: FftPlanKey,
+    plan: Arc<dyn Fft<f64>>,
+}
+
+pub(crate) struct ExtensionFftPlanCache<'a> {
+    entries: &'a mut ExtensionCacheStore,
+}
+
+impl<'a> ExtensionFftPlanCache<'a> {
+    pub(crate) fn new(entries: &'a mut ExtensionCacheStore) -> Self {
+        Self { entries }
+    }
+}
+
+fn extension_plan_key(key: FftPlanKey) -> ExtensionCacheKey {
+    let mut hasher = DefaultHasher::new();
+    key.hash(&mut hasher);
+    ExtensionCacheKey::new(
+        FFT_EXTENSION_FAMILY_ID,
+        FFT_PLAN_CACHE_NAME,
+        hasher.finish(),
+    )
+}
+
+impl FftPlanProvider for ExtensionFftPlanCache<'_> {
+    fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>> {
+        let key = FftPlanKey {
+            len,
+            forward,
+            dtype: FftPlanDType::F32,
+        };
+        let cache_key = extension_plan_key(key);
+        if let Some(cached) = self.entries.get::<ExtensionF32Plan>(&cache_key) {
+            if cached.key == key {
+                return Arc::clone(&cached.plan);
+            }
+        }
+        let plan = build_fft_plan::<f32>(len, forward);
+        self.entries.put(
+            cache_key,
+            ExtensionF32Plan {
+                key,
+                plan: Arc::clone(&plan),
+            },
+            fft_plan_retained_bytes(),
+        );
+        plan
+    }
+
+    fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>> {
+        let key = FftPlanKey {
+            len,
+            forward,
+            dtype: FftPlanDType::F64,
+        };
+        let cache_key = extension_plan_key(key);
+        if let Some(cached) = self.entries.get::<ExtensionF64Plan>(&cache_key) {
+            if cached.key == key {
+                return Arc::clone(&cached.plan);
+            }
+        }
+        let plan = build_fft_plan::<f64>(len, forward);
+        self.entries.put(
+            cache_key,
+            ExtensionF64Plan {
+                key,
+                plan: Arc::clone(&plan),
+            },
+            fft_plan_retained_bytes(),
+        );
+        plan
+    }
+}
+
+fn build_fft_plan<T: FftNum + 'static>(len: usize, forward: bool) -> Arc<dyn Fft<T>> {
+    let mut planner = FftPlanner::<T>::new();
+    if forward {
+        planner.plan_fft_forward(len)
+    } else {
+        planner.plan_fft_inverse(len)
+    }
+}
+
+const fn fft_plan_retained_bytes() -> usize {
+    std::mem::size_of::<FftPlanKey>() + std::mem::size_of::<CachedFftPlan>()
+}

--- a/crates/tenferro-fft/src/concrete_tests.rs
+++ b/crates/tenferro-fft/src/concrete_tests.rs
@@ -167,6 +167,35 @@ fn fft_plan_cache_is_bounded_lru_and_reports_known_retention() {
 }
 
 #[test]
+fn fft_plan_cache_key_distinguishes_scalar_dtype_length_and_direction() {
+    let mut cache = FftPlanCache::with_capacity(NonZeroUsize::new(8).unwrap());
+
+    let f32_forward_4 = cache.plan_f32(4, true);
+    let f32_forward_8 = cache.plan_f32(8, true);
+    let f64_forward_4 = cache.plan_f64(4, true);
+    let f64_inverse_4 = cache.plan_f64(4, false);
+
+    assert_eq!(cache.stats().entries, 4);
+    assert!(std::sync::Arc::ptr_eq(
+        &f32_forward_4,
+        &cache.plan_f32(4, true)
+    ));
+    assert!(std::sync::Arc::ptr_eq(
+        &f32_forward_8,
+        &cache.plan_f32(8, true)
+    ));
+    assert!(std::sync::Arc::ptr_eq(
+        &f64_forward_4,
+        &cache.plan_f64(4, true)
+    ));
+    assert!(std::sync::Arc::ptr_eq(
+        &f64_inverse_4,
+        &cache.plan_f64(4, false)
+    ));
+    assert!(!std::sync::Arc::ptr_eq(&f64_forward_4, &f64_inverse_4));
+}
+
+#[test]
 fn caller_owned_fft_executor_reuses_plans() {
     let mut backend = CpuBackend::new();
     let input = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();

--- a/crates/tenferro-fft/src/concrete_tests.rs
+++ b/crates/tenferro-fft/src/concrete_tests.rs
@@ -221,3 +221,28 @@ fn caller_owned_fft_executor_reuses_plans() {
     executor.clear_cache();
     assert_eq!(executor.cache_stats().entries, 0);
 }
+
+#[test]
+fn configured_fft_executor_validates_each_public_operation_before_dispatch() {
+    let mut executor = FftExecutor::new(FftPlanCache::default());
+    let mut backend = CpuBackend::new();
+    let real = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let complex = Tensor::from_vec_col_major(
+        vec![2],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+    )
+    .unwrap();
+
+    assert!(executor
+        .fft(&real, Some(0), -1, FftNorm::Backward, &mut backend)
+        .is_err());
+    assert!(executor
+        .ifft(&real, None, -1, FftNorm::Backward, &mut backend)
+        .is_err());
+    assert!(executor
+        .rfft(&complex, None, -1, FftNorm::Backward, &mut backend)
+        .is_err());
+    assert!(executor
+        .irfft(&complex, Some(0), -1, FftNorm::Backward, &mut backend)
+        .is_err());
+}

--- a/crates/tenferro-fft/src/cpu.rs
+++ b/crates/tenferro-fft/src/cpu.rs
@@ -5,7 +5,7 @@ use num_traits::{Float, FromPrimitive, Zero};
 use tenferro_cpu::CpuBackend;
 use tenferro_tensor::{BackendSessionHost, DeviceKind, MemoryKind, Placement, Tensor, TypedTensor};
 
-use crate::backend::{FftCacheSource, FftExecutionCache};
+use crate::backend::FftExecutionCache;
 use crate::cache::{cached_fft_plan, CachedFftPlanScalar, ExtensionFftPlanCache, FftPlanProvider};
 use crate::{
     expected_dtype_description, fft_op_name, output_shape_c2c, output_shape_c2r, output_shape_r2c,
@@ -17,20 +17,13 @@ impl FftBackend for CpuBackend {
         &mut self,
         input: &Tensor,
         spec: &FftPlanSpec,
-        cache: FftExecutionCache<'_>,
+        mut cache: FftExecutionCache<'_>,
     ) -> tenferro_tensor::Result<Tensor> {
         validate_spec_input(input, spec)?;
         validate_host_fft_input(fft_op_name(spec.operation()), input)?;
 
-        match cache.into_source() {
-            FftCacheSource::CallerOwned(plans) => {
-                self.with_backend_session(|_exec| execute_fft_with_plans(input, spec, plans))
-            }
-            FftCacheSource::RuntimeOwned(entries) => {
-                let mut plans = ExtensionFftPlanCache::new(entries);
-                self.with_backend_session(|_exec| execute_fft_with_plans(input, spec, &mut plans))
-            }
-        }
+        let mut plans = ExtensionFftPlanCache::new(cache.store_mut());
+        self.with_backend_session(|_exec| execute_fft_with_plans(input, spec, &mut plans))
     }
 }
 

--- a/crates/tenferro-fft/src/cpu.rs
+++ b/crates/tenferro-fft/src/cpu.rs
@@ -1,0 +1,462 @@
+use std::mem::MaybeUninit;
+
+use num_complex::Complex;
+use num_traits::{Float, FromPrimitive, Zero};
+use tenferro_cpu::CpuBackend;
+use tenferro_tensor::{BackendSessionHost, DeviceKind, MemoryKind, Placement, Tensor, TypedTensor};
+
+use crate::backend::{FftCacheSource, FftExecutionCache};
+use crate::cache::{cached_fft_plan, CachedFftPlanScalar, ExtensionFftPlanCache, FftPlanProvider};
+use crate::{
+    expected_dtype_description, fft_op_name, output_shape_c2c, output_shape_c2r, output_shape_r2c,
+    transform_len, validate_c2r_spectrum_len, FftBackend, FftNorm, FftOperation, FftPlanSpec,
+};
+
+impl FftBackend for CpuBackend {
+    fn execute_fft(
+        &mut self,
+        input: &Tensor,
+        spec: &FftPlanSpec,
+        cache: FftExecutionCache<'_>,
+    ) -> tenferro_tensor::Result<Tensor> {
+        validate_spec_input(input, spec)?;
+        validate_host_fft_input(fft_op_name(spec.operation()), input)?;
+
+        match cache.into_source() {
+            FftCacheSource::CallerOwned(plans) => {
+                self.with_backend_session(|_exec| execute_fft_with_plans(input, spec, plans))
+            }
+            FftCacheSource::RuntimeOwned(entries) => {
+                let mut plans = ExtensionFftPlanCache::new(entries);
+                self.with_backend_session(|_exec| execute_fft_with_plans(input, spec, &mut plans))
+            }
+        }
+    }
+}
+
+fn validate_spec_input(input: &Tensor, spec: &FftPlanSpec) -> tenferro_tensor::Result<()> {
+    if input.dtype() != spec.input_dtype() {
+        return Err(tenferro_tensor::Error::dtype_mismatch(
+            fft_op_name(spec.operation()),
+            spec.input_dtype(),
+            input.dtype(),
+        ));
+    }
+    if input.shape() != spec.input_shape() {
+        return Err(tenferro_tensor::Error::invalid_argument(
+            fft_op_name(spec.operation()),
+            "input shape",
+            format!(
+                "validated FFT spec shape {:?} does not match execution input shape {:?}",
+                spec.input_shape(),
+                input.shape()
+            ),
+        ));
+    }
+    if !spec.requires_compact_column_major() {
+        return Err(tenferro_tensor::Error::unsupported(
+            fft_op_name(spec.operation()),
+            "CpuBackend FFT requires compact column-major input",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn execute_fft_with_plans(
+    input: &Tensor,
+    spec: &FftPlanSpec,
+    plans: &mut (impl FftPlanProvider + ?Sized),
+) -> tenferro_tensor::Result<Tensor> {
+    let operation = spec.operation();
+    let axis = spec.normalized_axis();
+    let n = spec.requested_len();
+    let norm = spec.norm();
+
+    let output = match (operation, input) {
+        (FftOperation::C2cForward, Tensor::C64(input))
+        | (FftOperation::C2cInverse, Tensor::C64(input)) => {
+            Tensor::C64(TypedTensor::from_vec_col_major(
+                output_shape_c2c(input.shape(), axis, n)?,
+                execute_c2c(input, axis, n, operation.is_forward(), norm, plans)?,
+            )?)
+        }
+        (FftOperation::C2cForward, Tensor::C32(input))
+        | (FftOperation::C2cInverse, Tensor::C32(input)) => {
+            Tensor::C32(TypedTensor::from_vec_col_major(
+                output_shape_c2c(input.shape(), axis, n)?,
+                execute_c2c(input, axis, n, operation.is_forward(), norm, plans)?,
+            )?)
+        }
+        (FftOperation::R2cFull, Tensor::F64(input))
+        | (FftOperation::R2cOnesided, Tensor::F64(input)) => {
+            Tensor::C64(TypedTensor::from_vec_col_major(
+                output_shape_r2c(input.shape(), axis, n, operation.is_onesided())?,
+                execute_r2c(input, axis, n, operation.is_onesided(), norm, plans)?,
+            )?)
+        }
+        (FftOperation::R2cFull, Tensor::F32(input))
+        | (FftOperation::R2cOnesided, Tensor::F32(input)) => {
+            Tensor::C32(TypedTensor::from_vec_col_major(
+                output_shape_r2c(input.shape(), axis, n, operation.is_onesided())?,
+                execute_r2c(input, axis, n, operation.is_onesided(), norm, plans)?,
+            )?)
+        }
+        (FftOperation::C2r, Tensor::C64(input)) => Tensor::F64(TypedTensor::from_vec_col_major(
+            output_shape_c2r(input.shape(), axis, n)?,
+            execute_c2r(input, axis, n, norm, plans)?,
+        )?),
+        (FftOperation::C2r, Tensor::C32(input)) => Tensor::F32(TypedTensor::from_vec_col_major(
+            output_shape_c2r(input.shape(), axis, n)?,
+            execute_c2r(input, axis, n, norm, plans)?,
+        )?),
+        (operation, other) => {
+            return Err(crate::tensor_unsupported_dtype(
+                fft_op_name(operation),
+                other.dtype(),
+                expected_dtype_description(operation),
+            ));
+        }
+    };
+    Ok(output)
+}
+
+pub(crate) fn validate_host_fft_input(
+    op: &'static str,
+    input: &Tensor,
+) -> tenferro_tensor::Result<()> {
+    let placement = tensor_placement(input);
+    let is_device = matches!(placement.memory_kind, MemoryKind::Device);
+    if !is_device && !input.is_backend_buffer() {
+        return Ok(());
+    }
+
+    let location = match placement.device.as_ref().map(|device| &device.kind) {
+        Some(DeviceKind::Gpu(kind)) => format!("GPU backend {kind:?}"),
+        Some(kind) => format!("device kind {kind:?}"),
+        None if is_device => "device tensor without device metadata".to_string(),
+        None => "backend buffer".to_string(),
+    };
+    Err(tenferro_tensor::Error::unsupported(
+        op,
+        format!(
+            "tenferro-fft CpuBackend supports host tensors only; unsupported {location} input; \
+             download the tensor to CPU before FFT"
+        ),
+    ))
+}
+
+fn tensor_placement(input: &Tensor) -> &Placement {
+    input.placement()
+}
+
+fn execute_c2c<T>(
+    input: &TypedTensor<Complex<T>>,
+    axis: usize,
+    n: Option<usize>,
+    forward: bool,
+    norm: FftNorm,
+    plans: &mut (impl FftPlanProvider + ?Sized),
+) -> tenferro_tensor::Result<Vec<Complex<T>>>
+where
+    T: CachedFftPlanScalar,
+{
+    let in_shape = input.shape();
+    let fft_len = transform_len(in_shape, axis, n)?;
+    let out_shape = output_shape_c2c(in_shape, axis, n)?;
+    let out_axis_len = out_shape[axis];
+    let input_data = input.host_data()?;
+    let output_len = checked_shape_product("fft", "output", &out_shape)?;
+    let mut output = uninit_output_vec(output_len);
+    let fft_plan = cached_fft_plan::<T, _>(plans, fft_len, forward);
+    let scale: T = scale_for(norm, forward, fft_len)?;
+    let mut lane = vec![Complex::zero(); fft_len];
+
+    for_axis_lane(in_shape, axis, out_axis_len, |lane_ctx| {
+        // INVARIANT: zero-fill is transform padding semantics when the input
+        // lane is shorter than `fft_len`; it is not redundant initialization.
+        lane.fill(Complex::zero());
+        let copy_len = lane_ctx.in_axis_len.min(fft_len);
+        for (slot, offset) in lane
+            .iter_mut()
+            .take(copy_len)
+            .zip(lane_ctx.input_offsets(copy_len))
+        {
+            *slot = input_data[offset];
+        }
+        fft_plan.process(&mut lane);
+        if scale != T::one() {
+            for value in &mut lane {
+                *value = *value * scale;
+            }
+        }
+        for (value, offset) in lane
+            .iter()
+            .take(out_axis_len)
+            .copied()
+            .zip(lane_ctx.output_offsets(out_axis_len))
+        {
+            output[offset].write(value);
+        }
+        Ok(())
+    })?;
+
+    // SAFETY: `for_axis_lane` covers every element in the compact column-major
+    // output exactly once, and each lane writes all `out_axis_len` positions.
+    Ok(unsafe { assume_init_output_vec(output) })
+}
+
+fn execute_r2c<T>(
+    input: &TypedTensor<T>,
+    axis: usize,
+    n: Option<usize>,
+    onesided: bool,
+    norm: FftNorm,
+    plans: &mut (impl FftPlanProvider + ?Sized),
+) -> tenferro_tensor::Result<Vec<Complex<T>>>
+where
+    T: CachedFftPlanScalar,
+{
+    let in_shape = input.shape();
+    let fft_len = transform_len(in_shape, axis, n)?;
+    let out_shape = output_shape_r2c(in_shape, axis, n, onesided)?;
+    let out_axis_len = out_shape[axis];
+    let input_data = input.host_data()?;
+    let output_len = checked_shape_product("rfft", "output", &out_shape)?;
+    let mut output = uninit_output_vec(output_len);
+    let fft_plan = cached_fft_plan::<T, _>(plans, fft_len, true);
+    let scale: T = scale_for(norm, true, fft_len)?;
+    let mut lane = vec![Complex::zero(); fft_len];
+
+    for_axis_lane(in_shape, axis, out_axis_len, |lane_ctx| {
+        // INVARIANT: zero-fill is rfft padding semantics when the real input
+        // lane is shorter than `fft_len`; later writes cover only `copy_len`.
+        lane.fill(Complex::zero());
+        let copy_len = lane_ctx.in_axis_len.min(fft_len);
+        for (slot, offset) in lane
+            .iter_mut()
+            .take(copy_len)
+            .zip(lane_ctx.input_offsets(copy_len))
+        {
+            *slot = Complex::new(input_data[offset], T::zero());
+        }
+        fft_plan.process(&mut lane);
+        if scale != T::one() {
+            for value in &mut lane {
+                *value = *value * scale;
+            }
+        }
+        for (value, offset) in lane
+            .iter()
+            .take(out_axis_len)
+            .copied()
+            .zip(lane_ctx.output_offsets(out_axis_len))
+        {
+            output[offset].write(value);
+        }
+        Ok(())
+    })?;
+
+    // SAFETY: `for_axis_lane` covers every element in the compact column-major
+    // output exactly once, and each lane writes all `out_axis_len` positions.
+    Ok(unsafe { assume_init_output_vec(output) })
+}
+
+fn execute_c2r<T>(
+    input: &TypedTensor<Complex<T>>,
+    axis: usize,
+    n: Option<usize>,
+    norm: FftNorm,
+    plans: &mut (impl FftPlanProvider + ?Sized),
+) -> tenferro_tensor::Result<Vec<T>>
+where
+    T: CachedFftPlanScalar,
+{
+    let in_shape = input.shape();
+    let out_shape = output_shape_c2r(in_shape, axis, n)?;
+    let out_axis_len = out_shape[axis];
+    let expected_half = validate_c2r_spectrum_len(in_shape[axis], out_axis_len)?;
+    let input_data = input.host_data()?;
+    let output_len = checked_shape_product("irfft", "output", &out_shape)?;
+    let mut output = uninit_output_vec(output_len);
+    let fft_plan = cached_fft_plan::<T, _>(plans, out_axis_len, false);
+    let scale: T = scale_for(norm, false, out_axis_len)?;
+    let mut lane = vec![Complex::zero(); out_axis_len];
+
+    for_axis_lane(in_shape, axis, out_axis_len, |lane_ctx| {
+        // INVARIANT: zero-fill clears the inverse lane before writing the
+        // one-sided spectrum and mirrored tail for this lane.
+        lane.fill(Complex::zero());
+        for (slot, offset) in lane
+            .iter_mut()
+            .take(expected_half)
+            .zip(lane_ctx.input_offsets(expected_half))
+        {
+            *slot = input_data[offset];
+        }
+        for k in expected_half..out_axis_len {
+            let mirror = out_axis_len - k;
+            if mirror < lane.len() {
+                lane[k] = lane[mirror].conj();
+            }
+        }
+        fft_plan.process(&mut lane);
+        for (value, offset) in lane
+            .iter()
+            .take(out_axis_len)
+            .zip(lane_ctx.output_offsets(out_axis_len))
+        {
+            output[offset].write(value.re * scale);
+        }
+        Ok(())
+    })?;
+
+    // SAFETY: `for_axis_lane` covers every element in the compact column-major
+    // output exactly once, and each lane writes all `out_axis_len` positions.
+    Ok(unsafe { assume_init_output_vec(output) })
+}
+
+fn scale_for<T>(norm: FftNorm, forward: bool, n: usize) -> tenferro_tensor::Result<T>
+where
+    T: Float + FromPrimitive,
+{
+    let len = T::from_usize(n).ok_or_else(|| {
+        tenferro_tensor::Error::invalid_argument(
+            "tenferro_fft::scale_for",
+            "FFT length",
+            format!("{n} cannot be represented as scalar"),
+        )
+    })?;
+    Ok(match (norm, forward) {
+        (FftNorm::Backward, true) | (FftNorm::Forward, false) => T::one(),
+        (FftNorm::Backward, false) | (FftNorm::Forward, true) => T::one() / len,
+        (FftNorm::Ortho, _) => T::one() / len.sqrt(),
+    })
+}
+
+fn uninit_output_vec<T>(len: usize) -> Vec<MaybeUninit<T>> {
+    let mut output = Vec::with_capacity(len);
+    // SAFETY: Uninitialized bytes are valid for `MaybeUninit<T>` slots. The
+    // slots are converted to `T` only after all output positions are written.
+    unsafe { output.set_len(len) };
+    output
+}
+
+unsafe fn assume_init_output_vec<T>(mut output: Vec<MaybeUninit<T>>) -> Vec<T> {
+    let len = output.len();
+    let capacity = output.capacity();
+    let ptr = output.as_mut_ptr().cast::<T>();
+    std::mem::forget(output);
+    // SAFETY: `MaybeUninit<T>` has the same layout as `T`; the caller
+    // guarantees every slot has been initialized exactly once.
+    unsafe { Vec::from_raw_parts(ptr, len, capacity) }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct LaneContext {
+    input_base: usize,
+    output_base: usize,
+    axis_stride: usize,
+    in_axis_len: usize,
+    out_axis_len: usize,
+}
+
+impl LaneContext {
+    fn input_offsets(self, count: usize) -> impl Iterator<Item = usize> {
+        debug_assert!(count <= self.in_axis_len);
+        lane_offsets(self.input_base, self.axis_stride, count)
+    }
+
+    fn output_offsets(self, count: usize) -> impl Iterator<Item = usize> {
+        debug_assert!(count <= self.out_axis_len);
+        lane_offsets(self.output_base, self.axis_stride, count)
+    }
+}
+
+fn lane_offsets(base: usize, stride: usize, count: usize) -> impl Iterator<Item = usize> {
+    // INVARIANT: `for_axis_lane` checks input/output lane coverage before it
+    // constructs any `LaneContext`, so every `base + k * stride` for
+    // `k < count` stays within the compact column-major buffer.
+    (0..count).map(move |k| base + k * stride)
+}
+
+pub(crate) fn for_axis_lane(
+    in_shape: &[usize],
+    axis: usize,
+    out_axis_len: usize,
+    mut f: impl FnMut(LaneContext) -> tenferro_tensor::Result<()>,
+) -> tenferro_tensor::Result<()> {
+    let in_axis_len = in_shape[axis];
+    let axis_stride = checked_shape_product("fft", "axis stride", &in_shape[..axis])?;
+    let outer = checked_shape_product("fft", "outer lane count", &in_shape[axis + 1..])?;
+    let in_block = checked_mul("fft", "input lane block", axis_stride, in_axis_len)?;
+    let out_block = checked_mul("fft", "output lane block", axis_stride, out_axis_len)?;
+    let _input_len = checked_mul("fft", "input lane coverage", outer, in_block)?;
+    let _output_len = checked_mul("fft", "output lane coverage", outer, out_block)?;
+
+    // INVARIANT: lanes are processed sequentially so one scratch lane can be
+    // reused while writing into a single `MaybeUninit` output buffer. Parallel
+    // lane execution needs disjoint output splitting plus per-worker scratch.
+    for outer_idx in 0..outer {
+        let in_outer_base = checked_mul("fft", "input outer base", outer_idx, in_block)?;
+        let out_outer_base = checked_mul("fft", "output outer base", outer_idx, out_block)?;
+        for inner in 0..axis_stride {
+            let input_base = checked_add("fft", "input lane base", in_outer_base, inner)?;
+            let output_base = checked_add("fft", "output lane base", out_outer_base, inner)?;
+            f(LaneContext {
+                input_base,
+                output_base,
+                axis_stride,
+                in_axis_len,
+                out_axis_len,
+            })?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn checked_shape_product(
+    op: &'static str,
+    role: &'static str,
+    shape: &[usize],
+) -> tenferro_tensor::Result<usize> {
+    shape
+        .iter()
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .ok_or_else(|| {
+            tenferro_tensor::Error::invalid_argument(
+                op,
+                "shape product",
+                format!("{role} shape product overflows usize"),
+            )
+        })
+}
+
+fn checked_mul(
+    op: &'static str,
+    role: &'static str,
+    lhs: usize,
+    rhs: usize,
+) -> tenferro_tensor::Result<usize> {
+    lhs.checked_mul(rhs).ok_or_else(|| {
+        tenferro_tensor::Error::invalid_argument(
+            op,
+            "arithmetic",
+            format!("{role} overflows usize"),
+        )
+    })
+}
+
+fn checked_add(
+    op: &'static str,
+    role: &'static str,
+    lhs: usize,
+    rhs: usize,
+) -> tenferro_tensor::Result<usize> {
+    lhs.checked_add(rhs).ok_or_else(|| {
+        tenferro_tensor::Error::invalid_argument(
+            op,
+            "arithmetic",
+            format!("{role} overflows usize"),
+        )
+    })
+}

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -1,10 +1,12 @@
 //! FFT extension operations for tenferro.
 //!
-//! This crate is an out-of-tree `ExtensionOp` package. The initial
-//! implementation executes on host tensors through `rustfft`; it does not add
-//! FFT to the core `tenferro` backend trait surface. Concrete non-AD execution
-//! uses [`TensorFftExt`] and [`TensorReadFftExt`]. Traced graph construction
-//! uses [`TracedTensorFftExt`].
+//! This crate is an out-of-tree `ExtensionOp` package with an explicit
+//! [`FftBackend`] capability. [`tenferro_cpu::CpuBackend`] implements the
+//! capability through RustFFT. Metal/WebGPU and CUDA backends require separate
+//! explicit implementations; unsupported requests return an error and never
+//! fall back to CPU or transfer tensor data. Concrete non-AD execution uses
+//! [`TensorFftExt`] and [`TensorReadFftExt`]. Traced graph construction uses
+//! [`TracedTensorFftExt`].
 //!
 //! # Examples
 //!
@@ -49,18 +51,12 @@
 //! ```
 
 use std::any::Any;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use std::mem::MaybeUninit;
+use std::hash::Hasher;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 #[cfg(feature = "autodiff")]
 use computegraph::types::{LocalValueId, OperationRole, ValueKey, ValueRef};
-use lru::LruCache;
-use num_complex::Complex;
-use num_traits::{Float, FromPrimitive, Zero};
-use rustfft::{Fft, FftNum, FftPlanner};
 #[cfg(feature = "autodiff")]
 use tenferro_ad::extension::{
     ExtensionLinearTransposeRule, ExtensionLinearizeRule, ExtensionPrimalVjpRule,
@@ -75,16 +71,21 @@ use tenferro_ops::std_tensor_op::StdTensorOp;
 use tenferro_ops::ShapeGuardContext;
 use tenferro_ops::SymDim;
 use tenferro_runtime::extension::{apply, ExtensionExecutionContext, ExtensionOp, HostReference};
-use tenferro_runtime::{
-    Error, ErrorPhase, ExtensionCacheKey, ExtensionCacheSelector, ExtensionCacheStore, Result,
-    TracedTensor,
-};
-use tenferro_tensor::{
-    CacheStats, DType, DeviceKind, ErrorKind, MemoryKind, Placement, RuntimeCacheControl, Tensor,
-    TensorBackend, TensorRead, TypedTensor, ValidationError,
-};
+use tenferro_runtime::{Error, ErrorPhase, Result, TracedTensor};
+use tenferro_tensor::{CacheStats, DType, ErrorKind, Tensor, TensorRead, ValidationError};
 #[cfg(feature = "autodiff")]
 use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
+
+mod backend;
+mod cache;
+mod cpu;
+mod spec;
+
+pub use backend::{FftBackend, FftExecutionCache};
+pub use cache::{
+    fft_plan_cache_selector, FftPlanCache, DEFAULT_FFT_PLAN_CACHE_CAPACITY, FFT_PLAN_CACHE_NAME,
+};
+pub use spec::{FftNorm, FftOperation, FftPlanSpec};
 
 /// Extension family id used by the tenferro FFT extension.
 ///
@@ -97,134 +98,6 @@ use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 /// );
 /// ```
 pub const FFT_EXTENSION_FAMILY_ID: &str = "tenferro-fft.fft.v1";
-
-/// Runtime cache namespace used for RustFFT plans.
-pub const FFT_PLAN_CACHE_NAME: &str = "rustfft-plans";
-
-/// Default number of plans retained by a caller-owned [`FftPlanCache`].
-pub const DEFAULT_FFT_PLAN_CACHE_CAPACITY: usize = 64;
-
-/// Select the FFT plan entries in an extension runtime cache.
-pub const fn fft_plan_cache_selector() -> ExtensionCacheSelector {
-    ExtensionCacheSelector::Cache {
-        family_id: FFT_EXTENSION_FAMILY_ID,
-        cache_name: FFT_PLAN_CACHE_NAME,
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-enum FftPlanDType {
-    F32,
-    F64,
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct FftPlanKey {
-    len: usize,
-    forward: bool,
-    dtype: FftPlanDType,
-}
-
-enum CachedFftPlan {
-    F32(Arc<dyn Fft<f32>>),
-    F64(Arc<dyn Fft<f64>>),
-}
-
-/// Bounded, caller-owned LRU cache of RustFFT plans.
-///
-/// Retained-byte statistics include the cache-owned key and `Arc` handle for
-/// each entry. RustFFT does not expose the allocations owned by an opaque plan,
-/// so those allocations are intentionally excluded from the estimate.
-pub struct FftPlanCache {
-    entries: LruCache<FftPlanKey, CachedFftPlan>,
-}
-
-impl FftPlanCache {
-    /// Create an empty plan cache with an explicit maximum entry count.
-    pub fn with_capacity(capacity: NonZeroUsize) -> Self {
-        Self {
-            entries: LruCache::new(capacity),
-        }
-    }
-
-    /// Maximum number of retained plans.
-    pub fn capacity(&self) -> NonZeroUsize {
-        self.entries.cap()
-    }
-
-    /// Resize the cache, evicting least-recently-used plans when necessary.
-    pub fn set_capacity(&mut self, capacity: NonZeroUsize) {
-        self.entries.resize(capacity);
-    }
-
-    /// Remove every retained plan.
-    pub fn clear(&mut self) {
-        self.entries.clear();
-    }
-
-    /// Snapshot the number of plans and known cache-owned bytes retained.
-    pub fn stats(&self) -> CacheStats {
-        CacheStats {
-            entries: self.entries.len(),
-            retained_bytes: self.entries.len().saturating_mul(fft_plan_retained_bytes()),
-        }
-    }
-
-    fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>> {
-        let key = FftPlanKey {
-            len,
-            forward,
-            dtype: FftPlanDType::F32,
-        };
-        if let Some(CachedFftPlan::F32(plan)) = self.entries.get(&key) {
-            return Arc::clone(plan);
-        }
-        let plan = build_fft_plan::<f32>(len, forward);
-        self.entries.put(key, CachedFftPlan::F32(Arc::clone(&plan)));
-        plan
-    }
-
-    fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>> {
-        let key = FftPlanKey {
-            len,
-            forward,
-            dtype: FftPlanDType::F64,
-        };
-        if let Some(CachedFftPlan::F64(plan)) = self.entries.get(&key) {
-            return Arc::clone(plan);
-        }
-        let plan = build_fft_plan::<f64>(len, forward);
-        self.entries.put(key, CachedFftPlan::F64(Arc::clone(&plan)));
-        plan
-    }
-
-    #[cfg(test)]
-    fn contains_f64(&self, len: usize, forward: bool) -> bool {
-        self.entries.contains(&FftPlanKey {
-            len,
-            forward,
-            dtype: FftPlanDType::F64,
-        })
-    }
-}
-
-impl Default for FftPlanCache {
-    fn default() -> Self {
-        Self::with_capacity(
-            NonZeroUsize::new(DEFAULT_FFT_PLAN_CACHE_CAPACITY).unwrap_or(NonZeroUsize::MIN),
-        )
-    }
-}
-
-impl RuntimeCacheControl for FftPlanCache {
-    fn clear(&mut self) {
-        Self::clear(self);
-    }
-
-    fn stats(&self) -> CacheStats {
-        Self::stats(self)
-    }
-}
 
 /// Reusable concrete FFT executor with explicitly owned plan state.
 #[derive(Default)]
@@ -266,7 +139,7 @@ impl FftExecutor {
     /// `InvalidArgument` for invalid `axis`/`n`,
     /// [`tenferro_tensor::Error::Extension`] with [`ErrorKind::Unsupported`]
     /// for unsupported dtypes, or a typed backend source for execution.
-    pub fn fft<B: TensorBackend>(
+    pub fn fft<B: FftBackend>(
         &mut self,
         input: &Tensor,
         n: Option<usize>,
@@ -276,7 +149,7 @@ impl FftExecutor {
     ) -> tenferro_tensor::Result<Tensor> {
         self.execute(
             input,
-            concrete_fft_kind("FftExecutor::fft", input.dtype())?,
+            concrete_fft_operation("FftExecutor::fft", input.dtype())?,
             "FftExecutor::fft",
             n,
             axis,
@@ -293,7 +166,7 @@ impl FftExecutor {
     /// `InvalidArgument` for invalid `axis`/`n`,
     /// [`tenferro_tensor::Error::Extension`] with [`ErrorKind::Unsupported`]
     /// for a non-complex input, or a typed backend source for execution.
-    pub fn ifft<B: TensorBackend>(
+    pub fn ifft<B: FftBackend>(
         &mut self,
         input: &Tensor,
         n: Option<usize>,
@@ -303,7 +176,7 @@ impl FftExecutor {
     ) -> tenferro_tensor::Result<Tensor> {
         self.execute(
             input,
-            concrete_ifft_kind("FftExecutor::ifft", input.dtype())?,
+            concrete_ifft_operation("FftExecutor::ifft", input.dtype())?,
             "FftExecutor::ifft",
             n,
             axis,
@@ -320,7 +193,7 @@ impl FftExecutor {
     /// `InvalidArgument` for invalid `axis`/`n`,
     /// [`tenferro_tensor::Error::Extension`] with [`ErrorKind::Unsupported`]
     /// for a non-real input, or a typed backend source for execution.
-    pub fn rfft<B: TensorBackend>(
+    pub fn rfft<B: FftBackend>(
         &mut self,
         input: &Tensor,
         n: Option<usize>,
@@ -330,7 +203,7 @@ impl FftExecutor {
     ) -> tenferro_tensor::Result<Tensor> {
         self.execute(
             input,
-            concrete_rfft_kind("FftExecutor::rfft", input.dtype())?,
+            concrete_rfft_operation("FftExecutor::rfft", input.dtype())?,
             "FftExecutor::rfft",
             n,
             axis,
@@ -347,7 +220,7 @@ impl FftExecutor {
     /// `InvalidArgument`, or spectrum-length details,
     /// [`tenferro_tensor::Error::Extension`] with [`ErrorKind::Unsupported`]
     /// for a non-complex input, or a typed backend source for execution.
-    pub fn irfft<B: TensorBackend>(
+    pub fn irfft<B: FftBackend>(
         &mut self,
         input: &Tensor,
         n: Option<usize>,
@@ -357,7 +230,7 @@ impl FftExecutor {
     ) -> tenferro_tensor::Result<Tensor> {
         self.execute(
             input,
-            concrete_irfft_kind("FftExecutor::irfft", input.dtype())?,
+            concrete_irfft_operation("FftExecutor::irfft", input.dtype())?,
             "FftExecutor::irfft",
             n,
             axis,
@@ -367,18 +240,30 @@ impl FftExecutor {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn execute<B: TensorBackend>(
+    fn execute<B: FftBackend>(
         &mut self,
         input: &Tensor,
-        kind: FftKind,
+        operation: FftOperation,
         op_name: &'static str,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor> {
-        let op = concrete_fft_op(op_name, kind, input.shape(), n, axis, norm)?;
-        execute_concrete_fft_op_with_plans(input, &op, backend, &mut self.plans)
+        let spec = concrete_fft_spec(
+            op_name,
+            operation,
+            input.dtype(),
+            input.shape(),
+            n,
+            axis,
+            norm,
+        )?;
+        backend.execute_fft(
+            input,
+            &spec,
+            FftExecutionCache::caller_owned(&mut self.plans),
+        )
     }
 }
 
@@ -491,7 +376,7 @@ pub trait TensorFftExt {
     /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
     /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for an
     /// integer or boolean input, or a typed backend source for execution.
-    fn fft<B: TensorBackend>(
+    fn fft<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
@@ -506,7 +391,7 @@ pub trait TensorFftExt {
     /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
     /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for a
     /// non-complex input, or a typed backend source for execution.
-    fn ifft<B: TensorBackend>(
+    fn ifft<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
@@ -521,7 +406,7 @@ pub trait TensorFftExt {
     /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
     /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for a
     /// non-`F32`/`F64` input, or a typed backend source for execution.
-    fn rfft<B: TensorBackend>(
+    fn rfft<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
@@ -537,7 +422,7 @@ pub trait TensorFftExt {
     /// or spectrum-length details, `Error::Extension` with
     /// `ErrorKind::Unsupported` for a non-complex input, or a typed backend
     /// source for execution.
-    fn irfft<B: TensorBackend>(
+    fn irfft<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
@@ -547,76 +432,80 @@ pub trait TensorFftExt {
 }
 
 impl TensorFftExt for Tensor {
-    fn fft<B: TensorBackend>(
+    fn fft<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor> {
-        let op = concrete_fft_op(
+        let spec = concrete_fft_spec(
             "TensorFftExt::fft",
-            concrete_fft_kind("TensorFftExt::fft", self.dtype())?,
+            concrete_fft_operation("TensorFftExt::fft", self.dtype())?,
+            self.dtype(),
             self.shape(),
             n,
             axis,
             norm,
         )?;
-        execute_concrete_fft_op(self, &op, backend)
+        execute_concrete_fft_op(self, &spec, backend)
     }
 
-    fn ifft<B: TensorBackend>(
+    fn ifft<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor> {
-        let op = concrete_fft_op(
+        let spec = concrete_fft_spec(
             "TensorFftExt::ifft",
-            concrete_ifft_kind("TensorFftExt::ifft", self.dtype())?,
+            concrete_ifft_operation("TensorFftExt::ifft", self.dtype())?,
+            self.dtype(),
             self.shape(),
             n,
             axis,
             norm,
         )?;
-        execute_concrete_fft_op(self, &op, backend)
+        execute_concrete_fft_op(self, &spec, backend)
     }
 
-    fn rfft<B: TensorBackend>(
+    fn rfft<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor> {
-        let op = concrete_fft_op(
+        let spec = concrete_fft_spec(
             "TensorFftExt::rfft",
-            concrete_rfft_kind("TensorFftExt::rfft", self.dtype())?,
+            concrete_rfft_operation("TensorFftExt::rfft", self.dtype())?,
+            self.dtype(),
             self.shape(),
             n,
             axis,
             norm,
         )?;
-        execute_concrete_fft_op(self, &op, backend)
+        execute_concrete_fft_op(self, &spec, backend)
     }
 
-    fn irfft<B: TensorBackend>(
+    fn irfft<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
         norm: FftNorm,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor> {
-        let op = concrete_fft_op(
+        let spec = concrete_fft_spec(
             "TensorFftExt::irfft",
-            concrete_irfft_kind("TensorFftExt::irfft", self.dtype())?,
+            concrete_irfft_operation("TensorFftExt::irfft", self.dtype())?,
+            self.dtype(),
             self.shape(),
             n,
             axis,
             norm,
         )?;
-        execute_concrete_fft_op(self, &op, backend)
+        execute_concrete_fft_op(self, &spec, backend)
     }
 }
 
@@ -651,7 +540,7 @@ pub trait TensorReadFftExt {
     /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for an
     /// integer or boolean input, or a typed backend source for materialization
     /// or execution.
-    fn fft_read<B: TensorBackend>(
+    fn fft_read<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
@@ -666,7 +555,7 @@ pub trait TensorReadFftExt {
     /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
     /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for a
     /// non-complex input, or a typed backend source for materialization.
-    fn ifft_read<B: TensorBackend>(
+    fn ifft_read<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
@@ -681,7 +570,7 @@ pub trait TensorReadFftExt {
     /// Returns `Error::Validation` with `AxisOutOfBounds` or `InvalidArgument`
     /// for `axis`/`n`, `Error::Extension` with `ErrorKind::Unsupported` for a
     /// non-`F32`/`F64` input, or a typed backend source for materialization.
-    fn rfft_read<B: TensorBackend>(
+    fn rfft_read<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
@@ -697,7 +586,7 @@ pub trait TensorReadFftExt {
     /// or spectrum-length details, `Error::Extension` with
     /// `ErrorKind::Unsupported` for a non-complex input, or a typed backend
     /// source for materialization.
-    fn irfft_read<B: TensorBackend>(
+    fn irfft_read<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
@@ -707,7 +596,7 @@ pub trait TensorReadFftExt {
 }
 
 impl TensorReadFftExt for TensorRead<'_> {
-    fn fft_read<B: TensorBackend>(
+    fn fft_read<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
@@ -716,7 +605,7 @@ impl TensorReadFftExt for TensorRead<'_> {
     ) -> tenferro_tensor::Result<Tensor> {
         execute_concrete_fft_read_op(
             self,
-            concrete_fft_kind("TensorReadFftExt::fft_read", self.dtype())?,
+            concrete_fft_operation("TensorReadFftExt::fft_read", self.dtype())?,
             "TensorReadFftExt::fft_read",
             n,
             axis,
@@ -725,7 +614,7 @@ impl TensorReadFftExt for TensorRead<'_> {
         )
     }
 
-    fn ifft_read<B: TensorBackend>(
+    fn ifft_read<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
@@ -734,7 +623,7 @@ impl TensorReadFftExt for TensorRead<'_> {
     ) -> tenferro_tensor::Result<Tensor> {
         execute_concrete_fft_read_op(
             self,
-            concrete_ifft_kind("TensorReadFftExt::ifft_read", self.dtype())?,
+            concrete_ifft_operation("TensorReadFftExt::ifft_read", self.dtype())?,
             "TensorReadFftExt::ifft_read",
             n,
             axis,
@@ -743,7 +632,7 @@ impl TensorReadFftExt for TensorRead<'_> {
         )
     }
 
-    fn rfft_read<B: TensorBackend>(
+    fn rfft_read<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
@@ -752,7 +641,7 @@ impl TensorReadFftExt for TensorRead<'_> {
     ) -> tenferro_tensor::Result<Tensor> {
         execute_concrete_fft_read_op(
             self,
-            concrete_rfft_kind("TensorReadFftExt::rfft_read", self.dtype())?,
+            concrete_rfft_operation("TensorReadFftExt::rfft_read", self.dtype())?,
             "TensorReadFftExt::rfft_read",
             n,
             axis,
@@ -761,7 +650,7 @@ impl TensorReadFftExt for TensorRead<'_> {
         )
     }
 
-    fn irfft_read<B: TensorBackend>(
+    fn irfft_read<B: FftBackend>(
         &self,
         n: Option<usize>,
         axis: isize,
@@ -770,7 +659,7 @@ impl TensorReadFftExt for TensorRead<'_> {
     ) -> tenferro_tensor::Result<Tensor> {
         execute_concrete_fft_read_op(
             self,
-            concrete_irfft_kind("TensorReadFftExt::irfft_read", self.dtype())?,
+            concrete_irfft_operation("TensorReadFftExt::irfft_read", self.dtype())?,
             "TensorReadFftExt::irfft_read",
             n,
             axis,
@@ -778,47 +667,6 @@ impl TensorReadFftExt for TensorRead<'_> {
             backend,
         )
     }
-}
-
-/// FFT normalization convention.
-///
-/// `Backward` matches NumPy, JAX, and PyTorch defaults: the forward transform
-/// is unscaled and the inverse transform is scaled by `1 / n`.
-///
-/// # Examples
-///
-/// ```
-/// use tenferro_fft::FftNorm;
-///
-/// assert_eq!(FftNorm::default(), FftNorm::Backward);
-/// ```
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub enum FftNorm {
-    /// Scale inverse transforms by `1 / n`.
-    #[default]
-    Backward,
-    /// Scale forward transforms by `1 / n`.
-    Forward,
-    /// Scale both forward and inverse transforms by `1 / sqrt(n)`.
-    Ortho,
-}
-
-#[cfg(feature = "autodiff")]
-impl FftNorm {
-    fn c2c_adjoint(self) -> Self {
-        match self {
-            Self::Backward => Self::Forward,
-            Self::Forward => Self::Backward,
-            Self::Ortho => Self::Ortho,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum FftKind {
-    C2C { forward: bool },
-    R2C { onesided: bool },
-    C2R,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -833,16 +681,16 @@ enum FftError {
 
 #[derive(Clone, Debug, PartialEq)]
 struct FftOp {
-    kind: FftKind,
+    operation: FftOperation,
     axis: usize,
     n: Option<usize>,
     norm: FftNorm,
 }
 
 impl FftOp {
-    fn new(kind: FftKind, axis: usize, n: Option<usize>, norm: FftNorm) -> Self {
+    fn new(operation: FftOperation, axis: usize, n: Option<usize>, norm: FftNorm) -> Self {
         Self {
-            kind,
+            operation,
             axis,
             n,
             norm,
@@ -851,14 +699,20 @@ impl FftOp {
 
     #[cfg(feature = "autodiff")]
     fn c2c_adjoint(&self) -> Option<Self> {
-        match self.kind {
-            FftKind::C2C { forward } => Some(Self {
-                kind: FftKind::C2C { forward: !forward },
+        match self.operation {
+            FftOperation::C2cForward => Some(Self {
+                operation: FftOperation::C2cInverse,
                 axis: self.axis,
                 n: self.n,
                 norm: self.norm.c2c_adjoint(),
             }),
-            FftKind::R2C { .. } | FftKind::C2R => None,
+            FftOperation::C2cInverse => Some(Self {
+                operation: FftOperation::C2cForward,
+                axis: self.axis,
+                n: self.n,
+                norm: self.norm.c2c_adjoint(),
+            }),
+            FftOperation::R2cFull | FftOperation::R2cOnesided | FftOperation::C2r => None,
         }
     }
 }
@@ -869,14 +723,14 @@ impl ExtensionOp for FftOp {
     }
 
     fn payload_hash(&self, hasher: &mut dyn Hasher) {
-        let kind = match self.kind {
-            FftKind::C2C { forward: true } => 0,
-            FftKind::C2C { forward: false } => 1,
-            FftKind::R2C { onesided: true } => 2,
-            FftKind::R2C { onesided: false } => 3,
-            FftKind::C2R => 4,
+        let operation = match self.operation {
+            FftOperation::C2cForward => 0,
+            FftOperation::C2cInverse => 1,
+            FftOperation::R2cOnesided => 2,
+            FftOperation::R2cFull => 3,
+            FftOperation::C2r => 4,
         };
-        hasher.write_u8(kind);
+        hasher.write_u8(operation);
         hasher.write_usize(self.axis);
         match self.n {
             Some(n) => {
@@ -931,8 +785,8 @@ impl ExtensionOp for FftOp {
         }
 
         let mut out_shape = input_shape.to_vec();
-        let output_dtype = match self.kind {
-            FftKind::C2C { .. } => {
+        let output_dtype = match self.operation {
+            FftOperation::C2cForward | FftOperation::C2cInverse => {
                 if !matches!(input_dtype, DType::C32 | DType::C64) {
                     return Err(tensor_unsupported_dtype(
                         "tenferro-fft",
@@ -942,9 +796,13 @@ impl ExtensionOp for FftOp {
                 }
                 input_dtype
             }
-            FftKind::R2C { onesided } => {
+            FftOperation::R2cFull | FftOperation::R2cOnesided => {
                 let len = transform_len_dim(self.n, &input_shape[self.axis]);
-                out_shape[self.axis] = if onesided { len / 2usize + 1usize } else { len };
+                out_shape[self.axis] = if self.operation.is_onesided() {
+                    len / 2usize + 1usize
+                } else {
+                    len
+                };
                 match input_dtype {
                     DType::F32 => DType::C32,
                     DType::F64 => DType::C64,
@@ -957,7 +815,7 @@ impl ExtensionOp for FftOp {
                     }
                 }
             }
-            FftKind::C2R => {
+            FftOperation::C2r => {
                 out_shape[self.axis] = output_dim_c2r(&input_shape[self.axis], self.n)?;
                 match input_dtype {
                     DType::C32 => DType::F32,
@@ -973,7 +831,7 @@ impl ExtensionOp for FftOp {
             }
         };
 
-        if matches!(self.kind, FftKind::C2C { .. }) {
+        if self.operation.is_c2c() {
             out_shape[self.axis] = transform_len_dim(self.n, &input_shape[self.axis]);
         }
 
@@ -992,15 +850,6 @@ impl HostReference for FftOp {
 }
 
 fn execute_host_fft_op(op: &FftOp, inputs: &[&Tensor]) -> tenferro_tensor::Result<Vec<Tensor>> {
-    let mut plans = FftPlanCache::with_capacity(NonZeroUsize::MIN);
-    execute_host_fft_op_with_plans(op, inputs, &mut plans)
-}
-
-fn execute_host_fft_op_with_plans<P: FftPlanProvider + ?Sized>(
-    op: &FftOp,
-    inputs: &[&Tensor],
-    plans: &mut P,
-) -> tenferro_tensor::Result<Vec<Tensor>> {
     if inputs.len() != 1 {
         return Err(tenferro_tensor::Error::invalid_argument(
             "tenferro-fft",
@@ -1008,150 +857,169 @@ fn execute_host_fft_op_with_plans<P: FftPlanProvider + ?Sized>(
             format!("expected 1 input, got {}", inputs.len()),
         ));
     }
-    validate_host_fft_input(fft_op_name(op.kind), inputs[0])?;
-
-    let output = match (op.kind, inputs[0]) {
-        (FftKind::C2C { forward }, Tensor::C64(input)) => {
-            Tensor::C64(TypedTensor::from_vec_col_major(
-                output_shape_c2c(input.shape(), op.axis, op.n)?,
-                execute_c2c(input, op.axis, op.n, forward, op.norm, plans)?,
-            )?)
-        }
-        (FftKind::C2C { forward }, Tensor::C32(input)) => {
-            Tensor::C32(TypedTensor::from_vec_col_major(
-                output_shape_c2c(input.shape(), op.axis, op.n)?,
-                execute_c2c(input, op.axis, op.n, forward, op.norm, plans)?,
-            )?)
-        }
-        (FftKind::R2C { onesided }, Tensor::F64(input)) => {
-            Tensor::C64(TypedTensor::from_vec_col_major(
-                output_shape_r2c(input.shape(), op.axis, op.n, onesided)?,
-                execute_r2c(input, op.axis, op.n, onesided, op.norm, plans)?,
-            )?)
-        }
-        (FftKind::R2C { onesided }, Tensor::F32(input)) => {
-            Tensor::C32(TypedTensor::from_vec_col_major(
-                output_shape_r2c(input.shape(), op.axis, op.n, onesided)?,
-                execute_r2c(input, op.axis, op.n, onesided, op.norm, plans)?,
-            )?)
-        }
-        (FftKind::C2R, Tensor::C64(input)) => Tensor::F64(TypedTensor::from_vec_col_major(
-            output_shape_c2r(input.shape(), op.axis, op.n)?,
-            execute_c2r(input, op.axis, op.n, op.norm, plans)?,
-        )?),
-        (FftKind::C2R, Tensor::C32(input)) => Tensor::F32(TypedTensor::from_vec_col_major(
-            output_shape_c2r(input.shape(), op.axis, op.n)?,
-            execute_c2r(input, op.axis, op.n, op.norm, plans)?,
-        )?),
-        (kind, other) => {
-            return Err(tensor_unsupported_dtype(
-                fft_op_name(kind),
-                other.dtype(),
-                expected_dtype_description(kind),
-            ));
-        }
-    };
+    let input = inputs[0];
+    let spec = validated_fft_plan_spec(
+        fft_op_name(op.operation),
+        op.operation,
+        input.dtype(),
+        input.shape(),
+        op.n,
+        op.axis,
+        op.norm,
+    )?;
+    cpu::validate_host_fft_input(fft_op_name(op.operation), input)?;
+    let mut plans = FftPlanCache::with_capacity(NonZeroUsize::MIN);
+    let output = cpu::execute_fft_with_plans(input, &spec, &mut plans)?;
     Ok(vec![output])
 }
 
-fn execute_concrete_fft_op<B: TensorBackend>(
+fn execute_concrete_fft_op<B: FftBackend>(
     input: &Tensor,
-    op: &FftOp,
+    spec: &FftPlanSpec,
     backend: &mut B,
 ) -> tenferro_tensor::Result<Tensor> {
-    backend.with_backend_session(|_exec| single_fft_output(execute_host_fft_op(op, &[input])?))
-}
-
-fn execute_concrete_fft_op_with_plans<B: TensorBackend, P: FftPlanProvider + ?Sized>(
-    input: &Tensor,
-    op: &FftOp,
-    backend: &mut B,
-    plans: &mut P,
-) -> tenferro_tensor::Result<Tensor> {
-    backend.with_backend_session(|_exec| {
-        single_fft_output(execute_host_fft_op_with_plans(op, &[input], plans)?)
-    })
+    let mut plans = FftPlanCache::with_capacity(NonZeroUsize::MIN);
+    backend.execute_fft(input, spec, FftExecutionCache::caller_owned(&mut plans))
 }
 
 #[allow(clippy::too_many_arguments)]
-fn execute_concrete_fft_read_op<B: TensorBackend>(
+fn execute_concrete_fft_read_op<B: FftBackend>(
     input: &TensorRead<'_>,
-    kind: FftKind,
+    operation: FftOperation,
     op_name: &'static str,
     n: Option<usize>,
     axis: isize,
     norm: FftNorm,
     backend: &mut B,
 ) -> tenferro_tensor::Result<Tensor> {
-    let op = concrete_fft_op(op_name, kind, input.shape(), n, axis, norm)?;
-    backend.with_backend_session(|exec| {
-        let materialized = exec.to_contiguous_read(input.clone())?;
-        single_fft_output(execute_host_fft_op(&op, &[&materialized])?)
-    })
+    let spec = concrete_fft_spec(
+        op_name,
+        operation,
+        input.dtype(),
+        input.shape(),
+        n,
+        axis,
+        norm,
+    )?;
+    let materialized =
+        backend.with_backend_session(|exec| exec.to_contiguous_read(input.clone()))?;
+    let mut plans = FftPlanCache::with_capacity(NonZeroUsize::MIN);
+    backend.execute_fft(
+        &materialized,
+        &spec,
+        FftExecutionCache::caller_owned(&mut plans),
+    )
 }
 
-fn single_fft_output(mut outputs: Vec<Tensor>) -> tenferro_tensor::Result<Tensor> {
-    if outputs.len() != 1 {
-        return Err(tenferro_tensor::Error::invalid_argument(
-            "tenferro-fft",
-            "outputs",
-            format!("expected 1 FFT output, got {}", outputs.len()),
-        ));
-    }
-    Ok(outputs.remove(0))
-}
-
-fn concrete_fft_op(
+#[allow(clippy::too_many_arguments)]
+fn concrete_fft_spec(
     op: &'static str,
-    kind: FftKind,
+    operation: FftOperation,
+    input_dtype: DType,
     input_shape: &[usize],
     n: Option<usize>,
     axis: isize,
     norm: FftNorm,
-) -> tenferro_tensor::Result<FftOp> {
+) -> tenferro_tensor::Result<FftPlanSpec> {
     validate_concrete_n(op, n)?;
     let axis = normalize_concrete_axis(op, axis, input_shape.len())?;
-    validate_concrete_transform_len(op, input_shape, n, axis)?;
-    if matches!(kind, FftKind::C2R) {
-        output_shape_c2r(input_shape, axis, n)?;
-    }
-    Ok(FftOp::new(kind, axis, n, norm))
+    validated_fft_plan_spec(op, operation, input_dtype, input_shape, n, axis, norm)
 }
 
-fn concrete_fft_kind(op: &'static str, dtype: DType) -> tenferro_tensor::Result<FftKind> {
+#[allow(clippy::too_many_arguments)]
+fn validated_fft_plan_spec(
+    op: &'static str,
+    operation: FftOperation,
+    input_dtype: DType,
+    input_shape: &[usize],
+    n: Option<usize>,
+    axis: usize,
+    norm: FftNorm,
+) -> tenferro_tensor::Result<FftPlanSpec> {
+    validate_concrete_n(op, n)?;
+    validate_operation_dtype(op, operation, input_dtype)?;
+    validate_axis(op, input_shape, axis)?;
+    validate_concrete_transform_len(op, input_shape, n, axis)?;
+    if operation == FftOperation::C2r {
+        output_shape_c2r(input_shape, axis, n)?;
+    }
+    Ok(FftPlanSpec::new(
+        operation,
+        axis,
+        n,
+        norm,
+        input_dtype,
+        input_shape.to_vec(),
+    ))
+}
+
+fn concrete_fft_operation(op: &'static str, dtype: DType) -> tenferro_tensor::Result<FftOperation> {
     match dtype {
-        DType::C32 | DType::C64 => Ok(FftKind::C2C { forward: true }),
-        DType::F32 | DType::F64 => Ok(FftKind::R2C { onesided: false }),
+        DType::C32 | DType::C64 => Ok(FftOperation::C2cForward),
+        DType::F32 | DType::F64 => Ok(FftOperation::R2cFull),
         DType::I32 | DType::I64 | DType::Bool => {
             Err(tensor_unsupported_dtype(op, dtype, "F32, F64, C32, or C64"))
         }
     }
 }
 
-fn concrete_ifft_kind(op: &'static str, dtype: DType) -> tenferro_tensor::Result<FftKind> {
+fn concrete_ifft_operation(
+    op: &'static str,
+    dtype: DType,
+) -> tenferro_tensor::Result<FftOperation> {
     match dtype {
-        DType::C32 | DType::C64 => Ok(FftKind::C2C { forward: false }),
+        DType::C32 | DType::C64 => Ok(FftOperation::C2cInverse),
         DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => {
             Err(tensor_unsupported_dtype(op, dtype, "C32 or C64"))
         }
     }
 }
 
-fn concrete_rfft_kind(op: &'static str, dtype: DType) -> tenferro_tensor::Result<FftKind> {
+fn concrete_rfft_operation(
+    op: &'static str,
+    dtype: DType,
+) -> tenferro_tensor::Result<FftOperation> {
     match dtype {
-        DType::F32 | DType::F64 => Ok(FftKind::R2C { onesided: true }),
+        DType::F32 | DType::F64 => Ok(FftOperation::R2cOnesided),
         DType::C32 | DType::C64 | DType::I32 | DType::I64 | DType::Bool => {
             Err(tensor_unsupported_dtype(op, dtype, "F32 or F64"))
         }
     }
 }
 
-fn concrete_irfft_kind(op: &'static str, dtype: DType) -> tenferro_tensor::Result<FftKind> {
+fn concrete_irfft_operation(
+    op: &'static str,
+    dtype: DType,
+) -> tenferro_tensor::Result<FftOperation> {
     match dtype {
-        DType::C32 | DType::C64 => Ok(FftKind::C2R),
+        DType::C32 | DType::C64 => Ok(FftOperation::C2r),
         DType::F32 | DType::F64 | DType::I32 | DType::I64 | DType::Bool => {
             Err(tensor_unsupported_dtype(op, dtype, "C32 or C64"))
         }
+    }
+}
+
+fn validate_operation_dtype(
+    op: &'static str,
+    operation: FftOperation,
+    dtype: DType,
+) -> tenferro_tensor::Result<()> {
+    let supported = match operation {
+        FftOperation::C2cForward | FftOperation::C2cInverse | FftOperation::C2r => {
+            matches!(dtype, DType::C32 | DType::C64)
+        }
+        FftOperation::R2cFull | FftOperation::R2cOnesided => {
+            matches!(dtype, DType::F32 | DType::F64)
+        }
+    };
+    if supported {
+        Ok(())
+    } else {
+        Err(tensor_unsupported_dtype(
+            op,
+            dtype,
+            expected_dtype_description(operation),
+        ))
     }
 }
 
@@ -1226,36 +1094,6 @@ fn tensor_unsupported_dtype(
     )
 }
 
-fn tensor_placement(input: &Tensor) -> &Placement {
-    input.placement()
-}
-
-fn tensor_has_backend_buffer(input: &Tensor) -> bool {
-    input.is_backend_buffer()
-}
-
-fn validate_host_fft_input(op: &'static str, input: &Tensor) -> tenferro_tensor::Result<()> {
-    let placement = tensor_placement(input);
-    let is_device = matches!(placement.memory_kind, MemoryKind::Device);
-    if !is_device && !tensor_has_backend_buffer(input) {
-        return Ok(());
-    }
-
-    let location = match placement.device.as_ref().map(|device| &device.kind) {
-        Some(DeviceKind::Gpu(kind)) => format!("GPU backend {kind:?}"),
-        Some(kind) => format!("device kind {kind:?}"),
-        None if is_device => "device tensor without device metadata".to_string(),
-        None => "backend buffer".to_string(),
-    };
-    Err(tenferro_tensor::Error::unsupported(
-        op,
-        format!(
-            "tenferro-fft supports host tensors only; unsupported {location} input; \
-             download the tensor to CPU before FFT"
-        ),
-    ))
-}
-
 #[cfg(feature = "autodiff")]
 #[derive(Debug)]
 struct FftAdRule;
@@ -1276,9 +1114,9 @@ impl ExtensionLinearizeRule for FftAdRule {
         _ctx: &mut ShapeGuardContext,
     ) -> ADRuleResult<Vec<Option<LocalValueId>>> {
         let fft_op = fft_payload(op, ADRuleKind::Jvp)?;
-        if !matches!(fft_op.kind, FftKind::C2C { .. }) {
+        if !fft_op.operation.is_c2c() {
             return Err(ADRuleError::unsupported(
-                fft_ad_family_id(fft_op.kind),
+                fft_ad_family_id(fft_op.operation),
                 ADRuleKind::Jvp,
             ));
         }
@@ -1387,9 +1225,9 @@ fn emit_c2c_adjoint<'a>(
     active_mask: Option<&[bool]>,
 ) -> ADRuleResult<Option<(LocalValueId, &'a FftOp)>> {
     let fft_op = fft_payload(op, ADRuleKind::Transpose)?;
-    if !matches!(fft_op.kind, FftKind::C2C { .. }) {
+    if !fft_op.operation.is_c2c() {
         return Err(ADRuleError::unsupported(
-            fft_ad_family_id(fft_op.kind),
+            fft_ad_family_id(fft_op.operation),
             ADRuleKind::Transpose,
         ));
     }
@@ -1532,22 +1370,40 @@ pub fn ad_rules() -> std::result::Result<ExtensionRuleSet, ExtensionRegistryErro
         .with_primal_vjp(Arc::new(FftAdRule))
 }
 
-fn execute_fft_extension<B: TensorBackend + 'static>(
+fn execute_fft_extension<B: FftBackend + 'static>(
     op: &FftOp,
     inputs: &[&Tensor],
     ctx: &mut ExtensionExecutionContext<'_, B>,
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
-    let mut plans = ExtensionFftPlanCache::new(ctx.caches_mut());
-    execute_host_fft_op_with_plans(op, inputs, &mut plans)
+    if inputs.len() != 1 {
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "tenferro-fft",
+            "inputs",
+            format!("expected 1 input, got {}", inputs.len()),
+        ));
+    }
+    let input = inputs[0];
+    let spec = validated_fft_plan_spec(
+        fft_op_name(op.operation),
+        op.operation,
+        input.dtype(),
+        input.shape(),
+        op.n,
+        op.axis,
+        op.norm,
+    )?;
+    let (backend, caches) = ctx.parts_mut();
+    let output = backend.execute_fft(input, &spec, FftExecutionCache::runtime_owned(caches))?;
+    Ok(vec![output])
 }
 
-fn execute_fft_extension_reads<B: TensorBackend + 'static>(
+fn execute_fft_extension_reads<B: FftBackend + 'static>(
     op: &FftOp,
     inputs: &[TensorRead<'_>],
     ctx: &mut ExtensionExecutionContext<'_, B>,
 ) -> tenferro_tensor::Result<Vec<Tensor>> {
-    // rustfft consumes compact host tensors; materialization is explicit so
-    // backend-backed views produce a normal error instead of an implicit path.
+    // FFT capabilities consume compact tensors on their existing placement;
+    // materialization uses the explicitly selected backend session.
     let materialized_inputs = ctx.backend_mut().with_backend_session(|exec| {
         inputs
             .iter()
@@ -1556,8 +1412,7 @@ fn execute_fft_extension_reads<B: TensorBackend + 'static>(
             .collect::<tenferro_tensor::Result<Vec<_>>>()
     })?;
     let input_refs: Vec<&Tensor> = materialized_inputs.iter().collect();
-    let mut plans = ExtensionFftPlanCache::new(ctx.caches_mut());
-    execute_host_fft_op_with_plans(op, &input_refs, &mut plans)
+    execute_fft_extension(op, &input_refs, ctx)
 }
 
 define_extension_runtime! {
@@ -1567,6 +1422,7 @@ define_extension_runtime! {
     execute = execute_fft_extension,
     execute_reads = execute_fft_extension_reads,
     register_fn = register_runtime,
+    backend_bound = FftBackend,
 }
 
 /// Build a one-dimensional FFT along `axis`.
@@ -1593,9 +1449,9 @@ define_extension_runtime! {
 /// assert_eq!(out.as_slice::<Complex64>().unwrap()[0], Complex64::new(3.0, 0.0));
 /// ```
 fn fft(input: &TracedTensor, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<TracedTensor> {
-    let kind = match input.dtype {
-        DType::C32 | DType::C64 => FftKind::C2C { forward: true },
-        DType::F32 | DType::F64 => FftKind::R2C { onesided: false },
+    let operation = match input.dtype {
+        DType::C32 | DType::C64 => FftOperation::C2cForward,
+        DType::F32 | DType::F64 => FftOperation::R2cFull,
         DType::I32 | DType::I64 | DType::Bool => {
             return Err(runtime_unsupported_dtype(
                 "fft",
@@ -1604,7 +1460,7 @@ fn fft(input: &TracedTensor, n: Option<usize>, axis: isize, norm: FftNorm) -> Re
             ))
         }
     };
-    apply_unary_fft("fft", input, kind, n, axis, norm)
+    apply_unary_fft("fft", input, operation, n, axis, norm)
 }
 
 /// Build a one-dimensional inverse FFT along `axis`.
@@ -1636,14 +1492,7 @@ fn ifft(
     if !matches!(input.dtype, DType::C32 | DType::C64) {
         return Err(runtime_unsupported_dtype("ifft", input.dtype, "C32 or C64"));
     }
-    apply_unary_fft(
-        "ifft",
-        input,
-        FftKind::C2C { forward: false },
-        n,
-        axis,
-        norm,
-    )
+    apply_unary_fft("ifft", input, FftOperation::C2cInverse, n, axis, norm)
 }
 
 /// Build a one-dimensional real FFT along `axis`.
@@ -1679,14 +1528,7 @@ fn rfft(
     if !matches!(input.dtype, DType::F32 | DType::F64) {
         return Err(runtime_unsupported_dtype("rfft", input.dtype, "F32 or F64"));
     }
-    apply_unary_fft(
-        "rfft",
-        input,
-        FftKind::R2C { onesided: true },
-        n,
-        axis,
-        norm,
-    )
+    apply_unary_fft("rfft", input, FftOperation::R2cOnesided, n, axis, norm)
 }
 
 /// Build a one-dimensional inverse real FFT along `axis`.
@@ -1729,13 +1571,13 @@ fn irfft(
             "C32 or C64",
         ));
     }
-    apply_unary_fft("irfft", input, FftKind::C2R, n, axis, norm)
+    apply_unary_fft("irfft", input, FftOperation::C2r, n, axis, norm)
 }
 
 fn apply_unary_fft(
     op_name: &'static str,
     input: &TracedTensor,
-    kind: FftKind,
+    operation: FftOperation,
     n: Option<usize>,
     axis: isize,
     norm: FftNorm,
@@ -1743,12 +1585,12 @@ fn apply_unary_fft(
     validate_n(op_name, n)?;
     let axis = normalize_axis(op_name, axis, input.rank)?;
     validate_resolved_transform_len(op_name, input, n, axis)?;
-    if matches!(kind, FftKind::C2R) {
+    if operation == FftOperation::C2r {
         if let Some(shape) = input.try_concrete_shape() {
             output_shape_c2r(&shape, axis, n)?;
         }
     }
-    let op = Arc::new(FftOp::new(kind, axis, n, norm));
+    let op = Arc::new(FftOp::new(operation, axis, n, norm));
     let mut outputs = apply(op, &[input])?;
     outputs
         .pop()
@@ -1850,33 +1692,33 @@ fn transform_len_dim(n: Option<usize>, input_dim: &SymDim) -> SymDim {
     n.map(SymDim::from).unwrap_or_else(|| input_dim.clone())
 }
 
-fn expected_dtype_description(kind: FftKind) -> &'static str {
-    match kind {
-        FftKind::C2C { .. } | FftKind::C2R => "C32 or C64",
-        FftKind::R2C { .. } => "F32 or F64",
+fn expected_dtype_description(operation: FftOperation) -> &'static str {
+    match operation {
+        FftOperation::C2cForward | FftOperation::C2cInverse | FftOperation::C2r => "C32 or C64",
+        FftOperation::R2cFull | FftOperation::R2cOnesided => "F32 or F64",
     }
 }
 
-fn fft_op_name(kind: FftKind) -> &'static str {
-    match kind {
-        FftKind::C2C { forward: true } => "fft",
-        FftKind::C2C { forward: false } => "ifft",
-        FftKind::R2C { .. } => "rfft",
-        FftKind::C2R => "irfft",
-    }
-}
-
-#[cfg(feature = "autodiff")]
-fn fft_ad_family_id(kind: FftKind) -> &'static str {
-    match kind {
-        FftKind::C2C { .. } => FFT_EXTENSION_FAMILY_ID,
-        FftKind::R2C { .. } => "tenferro-fft.rfft.v1",
-        FftKind::C2R => "tenferro-fft.irfft.v1",
+fn fft_op_name(operation: FftOperation) -> &'static str {
+    match operation {
+        FftOperation::C2cForward => "fft",
+        FftOperation::C2cInverse => "ifft",
+        FftOperation::R2cFull | FftOperation::R2cOnesided => "rfft",
+        FftOperation::C2r => "irfft",
     }
 }
 
 #[cfg(feature = "autodiff")]
-fn fft_payload<'a>(op: &'a dyn ExtensionOp, rule: ADRuleKind) -> ADRuleResult<&'a FftOp> {
+fn fft_ad_family_id(operation: FftOperation) -> &'static str {
+    match operation {
+        FftOperation::C2cForward | FftOperation::C2cInverse => FFT_EXTENSION_FAMILY_ID,
+        FftOperation::R2cFull | FftOperation::R2cOnesided => "tenferro-fft.rfft.v1",
+        FftOperation::C2r => "tenferro-fft.irfft.v1",
+    }
+}
+
+#[cfg(feature = "autodiff")]
+fn fft_payload(op: &dyn ExtensionOp, rule: ADRuleKind) -> ADRuleResult<&FftOp> {
     op.as_any()
         .downcast_ref::<FftOp>()
         .ok_or_else(|| ADRuleError::unsupported(FFT_EXTENSION_FAMILY_ID, rule))
@@ -2018,464 +1860,6 @@ fn validate_axis(op: &'static str, shape: &[usize], axis: usize) -> tenferro_ten
     Ok(())
 }
 
-fn checked_shape_product(
-    op: &'static str,
-    role: &'static str,
-    shape: &[usize],
-) -> tenferro_tensor::Result<usize> {
-    shape
-        .iter()
-        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
-        .ok_or_else(|| {
-            tenferro_tensor::Error::invalid_argument(
-                op,
-                "shape product",
-                format!("{role} shape product overflows usize"),
-            )
-        })
-}
-
-fn checked_mul(
-    op: &'static str,
-    role: &'static str,
-    lhs: usize,
-    rhs: usize,
-) -> tenferro_tensor::Result<usize> {
-    lhs.checked_mul(rhs).ok_or_else(|| {
-        tenferro_tensor::Error::invalid_argument(
-            op,
-            "arithmetic",
-            format!("{role} overflows usize"),
-        )
-    })
-}
-
-fn checked_add(
-    op: &'static str,
-    role: &'static str,
-    lhs: usize,
-    rhs: usize,
-) -> tenferro_tensor::Result<usize> {
-    lhs.checked_add(rhs).ok_or_else(|| {
-        tenferro_tensor::Error::invalid_argument(
-            op,
-            "arithmetic",
-            format!("{role} overflows usize"),
-        )
-    })
-}
-
-fn uninit_output_vec<T>(len: usize) -> Vec<MaybeUninit<T>> {
-    let mut output = Vec::with_capacity(len);
-    // SAFETY: Uninitialized bytes are valid for `MaybeUninit<T>` slots. The
-    // slots are converted to `T` only after all output positions are written.
-    unsafe { output.set_len(len) };
-    output
-}
-
-unsafe fn assume_init_output_vec<T>(mut output: Vec<MaybeUninit<T>>) -> Vec<T> {
-    let len = output.len();
-    let capacity = output.capacity();
-    let ptr = output.as_mut_ptr().cast::<T>();
-    std::mem::forget(output);
-    // SAFETY: `MaybeUninit<T>` has the same layout as `T`; the caller
-    // guarantees every slot has been initialized exactly once.
-    unsafe { Vec::from_raw_parts(ptr, len, capacity) }
-}
-
-fn build_fft_plan<T: FftNum + 'static>(len: usize, forward: bool) -> Arc<dyn Fft<T>> {
-    let mut planner = FftPlanner::<T>::new();
-    if forward {
-        planner.plan_fft_forward(len)
-    } else {
-        planner.plan_fft_inverse(len)
-    }
-}
-
-const fn fft_plan_retained_bytes() -> usize {
-    std::mem::size_of::<FftPlanKey>() + std::mem::size_of::<CachedFftPlan>()
-}
-
-trait FftPlanProvider: Send {
-    fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>>;
-    fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>>;
-}
-
-impl FftPlanProvider for FftPlanCache {
-    fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>> {
-        Self::plan_f32(self, len, forward)
-    }
-
-    fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>> {
-        Self::plan_f64(self, len, forward)
-    }
-}
-
-trait CachedFftPlanScalar: FftNum + Float + FromPrimitive + 'static {
-    fn plan<P: FftPlanProvider + ?Sized>(
-        plans: &mut P,
-        len: usize,
-        forward: bool,
-    ) -> Arc<dyn Fft<Self>>;
-}
-
-impl CachedFftPlanScalar for f32 {
-    fn plan<P: FftPlanProvider + ?Sized>(
-        plans: &mut P,
-        len: usize,
-        forward: bool,
-    ) -> Arc<dyn Fft<Self>> {
-        plans.plan_f32(len, forward)
-    }
-}
-
-impl CachedFftPlanScalar for f64 {
-    fn plan<P: FftPlanProvider + ?Sized>(
-        plans: &mut P,
-        len: usize,
-        forward: bool,
-    ) -> Arc<dyn Fft<Self>> {
-        plans.plan_f64(len, forward)
-    }
-}
-
-fn cached_fft_plan<T: CachedFftPlanScalar, P: FftPlanProvider + ?Sized>(
-    plans: &mut P,
-    len: usize,
-    forward: bool,
-) -> Arc<dyn Fft<T>> {
-    T::plan(plans, len, forward)
-}
-
-#[derive(Clone)]
-struct ExtensionF32Plan {
-    key: FftPlanKey,
-    plan: Arc<dyn Fft<f32>>,
-}
-
-#[derive(Clone)]
-struct ExtensionF64Plan {
-    key: FftPlanKey,
-    plan: Arc<dyn Fft<f64>>,
-}
-
-struct ExtensionFftPlanCache<'a> {
-    entries: &'a mut ExtensionCacheStore,
-}
-
-impl<'a> ExtensionFftPlanCache<'a> {
-    fn new(entries: &'a mut ExtensionCacheStore) -> Self {
-        Self { entries }
-    }
-}
-
-fn extension_plan_key(key: FftPlanKey) -> ExtensionCacheKey {
-    let mut hasher = DefaultHasher::new();
-    key.hash(&mut hasher);
-    ExtensionCacheKey::new(
-        FFT_EXTENSION_FAMILY_ID,
-        FFT_PLAN_CACHE_NAME,
-        hasher.finish(),
-    )
-}
-
-impl FftPlanProvider for ExtensionFftPlanCache<'_> {
-    fn plan_f32(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f32>> {
-        let key = FftPlanKey {
-            len,
-            forward,
-            dtype: FftPlanDType::F32,
-        };
-        let cache_key = extension_plan_key(key);
-        if let Some(cached) = self.entries.get::<ExtensionF32Plan>(&cache_key) {
-            if cached.key == key {
-                return Arc::clone(&cached.plan);
-            }
-        }
-        let plan = build_fft_plan::<f32>(len, forward);
-        self.entries.put(
-            cache_key,
-            ExtensionF32Plan {
-                key,
-                plan: Arc::clone(&plan),
-            },
-            fft_plan_retained_bytes(),
-        );
-        plan
-    }
-
-    fn plan_f64(&mut self, len: usize, forward: bool) -> Arc<dyn Fft<f64>> {
-        let key = FftPlanKey {
-            len,
-            forward,
-            dtype: FftPlanDType::F64,
-        };
-        let cache_key = extension_plan_key(key);
-        if let Some(cached) = self.entries.get::<ExtensionF64Plan>(&cache_key) {
-            if cached.key == key {
-                return Arc::clone(&cached.plan);
-            }
-        }
-        let plan = build_fft_plan::<f64>(len, forward);
-        self.entries.put(
-            cache_key,
-            ExtensionF64Plan {
-                key,
-                plan: Arc::clone(&plan),
-            },
-            fft_plan_retained_bytes(),
-        );
-        plan
-    }
-}
-
-fn execute_c2c<T>(
-    input: &TypedTensor<Complex<T>>,
-    axis: usize,
-    n: Option<usize>,
-    forward: bool,
-    norm: FftNorm,
-    plans: &mut (impl FftPlanProvider + ?Sized),
-) -> tenferro_tensor::Result<Vec<Complex<T>>>
-where
-    T: CachedFftPlanScalar,
-{
-    let in_shape = input.shape();
-    let fft_len = transform_len(in_shape, axis, n)?;
-    let out_shape = output_shape_c2c(in_shape, axis, n)?;
-    let out_axis_len = out_shape[axis];
-    let input_data = input.host_data()?;
-    let output_len = checked_shape_product("fft", "output", &out_shape)?;
-    let mut output = uninit_output_vec(output_len);
-    let fft_plan = cached_fft_plan::<T, _>(plans, fft_len, forward);
-    let scale: T = scale_for(norm, forward, fft_len)?;
-    let mut lane = vec![Complex::zero(); fft_len];
-
-    for_axis_lane(in_shape, axis, out_axis_len, |lane_ctx| {
-        // INVARIANT: zero-fill is transform padding semantics when the input
-        // lane is shorter than `fft_len`; it is not redundant initialization.
-        lane.fill(Complex::zero());
-        let copy_len = lane_ctx.in_axis_len.min(fft_len);
-        for (slot, offset) in lane
-            .iter_mut()
-            .take(copy_len)
-            .zip(lane_ctx.input_offsets(copy_len))
-        {
-            *slot = input_data[offset];
-        }
-        fft_plan.process(&mut lane);
-        if scale != T::one() {
-            for value in &mut lane {
-                *value = *value * scale;
-            }
-        }
-        for (value, offset) in lane
-            .iter()
-            .take(out_axis_len)
-            .copied()
-            .zip(lane_ctx.output_offsets(out_axis_len))
-        {
-            output[offset].write(value);
-        }
-        Ok(())
-    })?;
-
-    // SAFETY: `for_axis_lane` covers every element in the compact column-major
-    // output exactly once, and each lane writes all `out_axis_len` positions.
-    Ok(unsafe { assume_init_output_vec(output) })
-}
-
-fn execute_r2c<T>(
-    input: &TypedTensor<T>,
-    axis: usize,
-    n: Option<usize>,
-    onesided: bool,
-    norm: FftNorm,
-    plans: &mut (impl FftPlanProvider + ?Sized),
-) -> tenferro_tensor::Result<Vec<Complex<T>>>
-where
-    T: CachedFftPlanScalar,
-{
-    let in_shape = input.shape();
-    let fft_len = transform_len(in_shape, axis, n)?;
-    let out_shape = output_shape_r2c(in_shape, axis, n, onesided)?;
-    let out_axis_len = out_shape[axis];
-    let input_data = input.host_data()?;
-    let output_len = checked_shape_product("rfft", "output", &out_shape)?;
-    let mut output = uninit_output_vec(output_len);
-    let fft_plan = cached_fft_plan::<T, _>(plans, fft_len, true);
-    let scale: T = scale_for(norm, true, fft_len)?;
-    let mut lane = vec![Complex::zero(); fft_len];
-
-    for_axis_lane(in_shape, axis, out_axis_len, |lane_ctx| {
-        // INVARIANT: zero-fill is rfft padding semantics when the real input
-        // lane is shorter than `fft_len`; later writes cover only `copy_len`.
-        lane.fill(Complex::zero());
-        let copy_len = lane_ctx.in_axis_len.min(fft_len);
-        for (slot, offset) in lane
-            .iter_mut()
-            .take(copy_len)
-            .zip(lane_ctx.input_offsets(copy_len))
-        {
-            *slot = Complex::new(input_data[offset], T::zero());
-        }
-        fft_plan.process(&mut lane);
-        if scale != T::one() {
-            for value in &mut lane {
-                *value = *value * scale;
-            }
-        }
-        for (value, offset) in lane
-            .iter()
-            .take(out_axis_len)
-            .copied()
-            .zip(lane_ctx.output_offsets(out_axis_len))
-        {
-            output[offset].write(value);
-        }
-        Ok(())
-    })?;
-
-    // SAFETY: `for_axis_lane` covers every element in the compact column-major
-    // output exactly once, and each lane writes all `out_axis_len` positions.
-    Ok(unsafe { assume_init_output_vec(output) })
-}
-
-fn execute_c2r<T>(
-    input: &TypedTensor<Complex<T>>,
-    axis: usize,
-    n: Option<usize>,
-    norm: FftNorm,
-    plans: &mut (impl FftPlanProvider + ?Sized),
-) -> tenferro_tensor::Result<Vec<T>>
-where
-    T: CachedFftPlanScalar,
-{
-    let in_shape = input.shape();
-    let out_shape = output_shape_c2r(in_shape, axis, n)?;
-    let out_axis_len = out_shape[axis];
-    let expected_half = validate_c2r_spectrum_len(in_shape[axis], out_axis_len)?;
-    let input_data = input.host_data()?;
-    let output_len = checked_shape_product("irfft", "output", &out_shape)?;
-    let mut output = uninit_output_vec(output_len);
-    let fft_plan = cached_fft_plan::<T, _>(plans, out_axis_len, false);
-    let scale: T = scale_for(norm, false, out_axis_len)?;
-    let mut lane = vec![Complex::zero(); out_axis_len];
-
-    for_axis_lane(in_shape, axis, out_axis_len, |lane_ctx| {
-        // INVARIANT: zero-fill clears the inverse lane before writing the
-        // one-sided spectrum and mirrored tail for this lane.
-        lane.fill(Complex::zero());
-        for (slot, offset) in lane
-            .iter_mut()
-            .take(expected_half)
-            .zip(lane_ctx.input_offsets(expected_half))
-        {
-            *slot = input_data[offset];
-        }
-        for k in expected_half..out_axis_len {
-            let mirror = out_axis_len - k;
-            if mirror < lane.len() {
-                lane[k] = lane[mirror].conj();
-            }
-        }
-        fft_plan.process(&mut lane);
-        for (value, offset) in lane
-            .iter()
-            .take(out_axis_len)
-            .zip(lane_ctx.output_offsets(out_axis_len))
-        {
-            output[offset].write(value.re * scale);
-        }
-        Ok(())
-    })?;
-
-    // SAFETY: `for_axis_lane` covers every element in the compact column-major
-    // output exactly once, and each lane writes all `out_axis_len` positions.
-    Ok(unsafe { assume_init_output_vec(output) })
-}
-
-fn scale_for<T>(norm: FftNorm, forward: bool, n: usize) -> tenferro_tensor::Result<T>
-where
-    T: Float + FromPrimitive,
-{
-    let len = T::from_usize(n).ok_or_else(|| {
-        tenferro_tensor::Error::invalid_argument(
-            "tenferro_fft::scale_for",
-            "FFT length",
-            format!("{n} cannot be represented as scalar"),
-        )
-    })?;
-    Ok(match (norm, forward) {
-        (FftNorm::Backward, true) | (FftNorm::Forward, false) => T::one(),
-        (FftNorm::Backward, false) | (FftNorm::Forward, true) => T::one() / len,
-        (FftNorm::Ortho, _) => T::one() / len.sqrt(),
-    })
-}
-
-#[derive(Clone, Copy)]
-struct LaneContext {
-    input_base: usize,
-    output_base: usize,
-    axis_stride: usize,
-    in_axis_len: usize,
-    out_axis_len: usize,
-}
-
-impl LaneContext {
-    fn input_offsets(self, count: usize) -> impl Iterator<Item = usize> {
-        debug_assert!(count <= self.in_axis_len);
-        lane_offsets(self.input_base, self.axis_stride, count)
-    }
-
-    fn output_offsets(self, count: usize) -> impl Iterator<Item = usize> {
-        debug_assert!(count <= self.out_axis_len);
-        lane_offsets(self.output_base, self.axis_stride, count)
-    }
-}
-
-fn lane_offsets(base: usize, stride: usize, count: usize) -> impl Iterator<Item = usize> {
-    // INVARIANT: `for_axis_lane` checks input/output lane coverage before it
-    // constructs any `LaneContext`, so every `base + k * stride` for
-    // `k < count` stays within the compact column-major buffer.
-    (0..count).map(move |k| base + k * stride)
-}
-
-fn for_axis_lane(
-    in_shape: &[usize],
-    axis: usize,
-    out_axis_len: usize,
-    mut f: impl FnMut(LaneContext) -> tenferro_tensor::Result<()>,
-) -> tenferro_tensor::Result<()> {
-    let in_axis_len = in_shape[axis];
-    let axis_stride = checked_shape_product("fft", "axis stride", &in_shape[..axis])?;
-    let outer = checked_shape_product("fft", "outer lane count", &in_shape[axis + 1..])?;
-    let in_block = checked_mul("fft", "input lane block", axis_stride, in_axis_len)?;
-    let out_block = checked_mul("fft", "output lane block", axis_stride, out_axis_len)?;
-    let _input_len = checked_mul("fft", "input lane coverage", outer, in_block)?;
-    let _output_len = checked_mul("fft", "output lane coverage", outer, out_block)?;
-
-    // INVARIANT: lanes are processed sequentially so one scratch lane can be
-    // reused while writing into a single `MaybeUninit` output buffer. Parallel
-    // lane execution needs disjoint output splitting plus per-worker scratch.
-    for outer_idx in 0..outer {
-        let in_outer_base = checked_mul("fft", "input outer base", outer_idx, in_block)?;
-        let out_outer_base = checked_mul("fft", "output outer base", outer_idx, out_block)?;
-        for inner in 0..axis_stride {
-            let input_base = checked_add("fft", "input lane base", in_outer_base, inner)?;
-            let output_base = checked_add("fft", "output lane base", out_outer_base, inner)?;
-            f(LaneContext {
-                input_base,
-                output_base,
-                axis_stride,
-                in_axis_len,
-                out_axis_len,
-            })?;
-        }
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod concrete_tests;
 
@@ -2485,7 +1869,7 @@ mod tests {
 
     #[test]
     fn fft_infer_output_meta_rejects_invalid_trait_inputs_without_panicking() {
-        let op = FftOp::new(FftKind::R2C { onesided: true }, 0, None, FftNorm::Backward);
+        let op = FftOp::new(FftOperation::R2cOnesided, 0, None, FftNorm::Backward);
         let shape = [SymDim::from(4usize)];
 
         assert!(
@@ -2502,7 +1886,7 @@ mod tests {
         )
         .is_err());
 
-        let bad_axis = FftOp::new(FftKind::C2C { forward: true }, 2, None, FftNorm::Backward);
+        let bad_axis = FftOp::new(FftOperation::C2cForward, 2, None, FftNorm::Backward);
         assert!(tenferro_ops::ext_op::invoke_extension_shape_inference(
             &bad_axis,
             &[DType::C64],
@@ -2513,7 +1897,7 @@ mod tests {
 
     #[test]
     fn checked_shape_product_rejects_overflow_before_allocation() {
-        let err = checked_shape_product("fft", "output", &[usize::MAX, 2])
+        let err = cpu::checked_shape_product("fft", "output", &[usize::MAX, 2])
             .expect_err("overflowing output shape should be rejected");
 
         assert!(err.to_string().contains("overflows usize"), "{err}");
@@ -2539,7 +1923,7 @@ mod tests {
 
     #[test]
     fn axis_lane_layout_rejects_stride_overflow() {
-        let err = for_axis_lane(&[usize::MAX, 2], 1, 2, |_| Ok(()))
+        let err = cpu::for_axis_lane(&[usize::MAX, 2], 1, 2, |_| Ok(()))
             .expect_err("lane layout should reject stride overflow");
 
         assert!(err.to_string().contains("overflows usize"), "{err}");
@@ -2549,7 +1933,7 @@ mod tests {
     #[test]
     fn fft_transpose_rule_respects_inactive_linearized_input() {
         let rule = FftAdRule;
-        let op = FftOp::new(FftKind::C2C { forward: true }, 0, None, FftNorm::Backward);
+        let op = FftOp::new(FftOperation::C2cForward, 0, None, FftNorm::Backward);
         let mut builder = computegraph::graph::GraphBuilder::<StdTensorOp>::new();
         let cotangent = builder.add_input(tenferro_ops::input_key::TensorInputKey::User { id: 0 });
         let result = rule
@@ -2571,12 +1955,7 @@ mod tests {
     #[test]
     fn fft_transpose_rule_uses_metadata_for_linear_only_matching_length() {
         let rule = FftAdRule;
-        let op = FftOp::new(
-            FftKind::C2C { forward: true },
-            0,
-            Some(4),
-            FftNorm::Backward,
-        );
+        let op = FftOp::new(FftOperation::C2cForward, 0, Some(4), FftNorm::Backward);
         let active_key = ValueKey::Input(tenferro_ops::input_key::TensorInputKey::User { id: 1 });
         let mut ctx = ShapeGuardContext::default();
         ctx.insert_metadata(

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -99,34 +99,34 @@ pub use spec::{FftNorm, FftOperation, FftPlanSpec};
 /// ```
 pub const FFT_EXTENSION_FAMILY_ID: &str = "tenferro-fft.fft.v1";
 
-/// Reusable concrete FFT executor with explicitly owned plan state.
+/// Reusable concrete FFT executor with an explicitly owned backend-neutral cache.
 #[derive(Default)]
 pub struct FftExecutor {
     plans: FftPlanCache,
 }
 
 impl FftExecutor {
-    /// Create an executor from a caller-configured plan cache.
+    /// Create an executor from a caller-configured FFT execution cache.
     pub fn new(plans: FftPlanCache) -> Self {
         Self { plans }
     }
 
-    /// Inspect the owned plan cache.
+    /// Inspect the owned backend-neutral FFT cache.
     pub const fn plan_cache(&self) -> &FftPlanCache {
         &self.plans
     }
 
-    /// Mutably inspect or configure the owned plan cache.
+    /// Mutably inspect or configure the owned backend-neutral FFT cache.
     pub fn plan_cache_mut(&mut self) -> &mut FftPlanCache {
         &mut self.plans
     }
 
-    /// Snapshot the owned plan cache statistics.
+    /// Snapshot aggregate statistics for every backend cache namespace.
     pub fn cache_stats(&self) -> CacheStats {
         self.plans.stats()
     }
 
-    /// Remove every retained plan from this executor.
+    /// Remove every retained backend plan or workspace from this executor.
     pub fn clear_cache(&mut self) {
         self.plans.clear();
     }

--- a/crates/tenferro-fft/src/spec.rs
+++ b/crates/tenferro-fft/src/spec.rs
@@ -1,0 +1,158 @@
+use tenferro_tensor::DType;
+
+/// FFT normalization convention.
+///
+/// `Backward` matches NumPy, JAX, and PyTorch defaults: the forward transform
+/// is unscaled and the inverse transform is scaled by `1 / n`.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_fft::FftNorm;
+///
+/// assert_eq!(FftNorm::default(), FftNorm::Backward);
+/// ```
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum FftNorm {
+    /// Scale inverse transforms by `1 / n`.
+    #[default]
+    Backward,
+    /// Scale forward transforms by `1 / n`.
+    Forward,
+    /// Scale both forward and inverse transforms by `1 / sqrt(n)`.
+    Ortho,
+}
+
+impl FftNorm {
+    #[cfg(feature = "autodiff")]
+    pub(crate) fn c2c_adjoint(self) -> Self {
+        match self {
+            Self::Backward => Self::Forward,
+            Self::Forward => Self::Backward,
+            Self::Ortho => Self::Ortho,
+        }
+    }
+}
+
+/// One-dimensional FFT operation requested from an [`FftBackend`](crate::FftBackend).
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_fft::FftOperation;
+///
+/// assert_ne!(FftOperation::C2cForward, FftOperation::C2cInverse);
+/// assert_ne!(FftOperation::R2cFull, FftOperation::R2cOnesided);
+/// ```
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum FftOperation {
+    /// Forward complex-to-complex FFT.
+    C2cForward,
+    /// Inverse complex-to-complex FFT.
+    C2cInverse,
+    /// Real-to-complex FFT returning the full complex spectrum.
+    R2cFull,
+    /// Real-to-complex FFT returning the non-negative-frequency spectrum.
+    R2cOnesided,
+    /// Complex-to-real FFT consuming a one-sided Hermitian spectrum.
+    C2r,
+}
+
+impl FftOperation {
+    pub(crate) const fn is_c2c(self) -> bool {
+        matches!(self, Self::C2cForward | Self::C2cInverse)
+    }
+
+    pub(crate) const fn is_forward(self) -> bool {
+        matches!(self, Self::C2cForward | Self::R2cFull | Self::R2cOnesided)
+    }
+
+    pub(crate) const fn is_onesided(self) -> bool {
+        matches!(self, Self::R2cOnesided)
+    }
+}
+
+/// Validated, backend-neutral description of one FFT request.
+///
+/// Backends receive this value only after the public FFT surface has validated
+/// dtype, rank, axis, requested length, and inverse-spectrum shape. The layout
+/// requirement is explicit so a backend can reject unsupported storage without
+/// silently materializing or transferring the input.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_fft::{FftOperation, FftPlanSpec};
+///
+/// fn inspect(spec: &FftPlanSpec) {
+///     let operation: FftOperation = spec.operation();
+///     assert_eq!(operation, spec.operation());
+///     assert!(spec.requires_compact_column_major());
+/// }
+/// ```
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FftPlanSpec {
+    operation: FftOperation,
+    normalized_axis: usize,
+    requested_len: Option<usize>,
+    norm: FftNorm,
+    input_dtype: DType,
+    input_shape: Vec<usize>,
+    requires_compact_column_major: bool,
+}
+
+impl FftPlanSpec {
+    pub(crate) fn new(
+        operation: FftOperation,
+        normalized_axis: usize,
+        requested_len: Option<usize>,
+        norm: FftNorm,
+        input_dtype: DType,
+        input_shape: Vec<usize>,
+    ) -> Self {
+        Self {
+            operation,
+            normalized_axis,
+            requested_len,
+            norm,
+            input_dtype,
+            input_shape,
+            requires_compact_column_major: true,
+        }
+    }
+
+    /// Return the transform operation.
+    pub const fn operation(&self) -> FftOperation {
+        self.operation
+    }
+
+    /// Return the non-negative, validated axis.
+    pub const fn normalized_axis(&self) -> usize {
+        self.normalized_axis
+    }
+
+    /// Return the caller-requested transform length, if one was supplied.
+    pub const fn requested_len(&self) -> Option<usize> {
+        self.requested_len
+    }
+
+    /// Return the requested normalization convention.
+    pub const fn norm(&self) -> FftNorm {
+        self.norm
+    }
+
+    /// Return the validated input dtype.
+    pub const fn input_dtype(&self) -> DType {
+        self.input_dtype
+    }
+
+    /// Return the validated input shape.
+    pub fn input_shape(&self) -> &[usize] {
+        &self.input_shape
+    }
+
+    /// Return whether execution requires compact column-major storage.
+    pub const fn requires_compact_column_major(&self) -> bool {
+        self.requires_compact_column_major
+    }
+}

--- a/crates/tenferro-fft/tests/backend_capability.rs
+++ b/crates/tenferro-fft/tests/backend_capability.rs
@@ -1,0 +1,326 @@
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
+
+use num_complex::{Complex32, Complex64};
+use tenferro_cpu::CpuBackend;
+use tenferro_fft::{
+    FftBackend, FftExecutionCache, FftNorm, FftOperation, FftPlanSpec, TensorFftExt,
+};
+use tenferro_runtime::GraphExecutor;
+use tenferro_tensor::{
+    BackendCachedDot, BackendRuntimeCache, BackendSessionHost, Buffer, BufferHandle, CompareDir,
+    DType, DeviceId, DeviceKind, DotGeneralConfig, ErrorKind, GatherConfig, GpuBackendKind,
+    MemoryKind, PadConfig, Placement, ScatterConfig, SliceConfig, Tensor, TensorAnalytic,
+    TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion,
+    TensorIndexing, TensorReduction, TensorStructural, TypedTensor,
+};
+
+macro_rules! unreachable_backend_methods {
+    ($($name:ident($($arg:ident : $argty:ty),*) -> $ret:ty;)+) => {
+        $(
+            fn $name(&mut self, $($arg: $argty),*) -> $ret {
+                $(let _ = &$arg;)*
+                panic!(concat!(stringify!($name), " should not be called by this test"))
+            }
+        )+
+    };
+}
+
+macro_rules! impl_minimal_tensor_backend {
+    ($ty:ty) => {
+        impl BackendRuntimeCache for $ty {
+            type RuntimeCache = ();
+        }
+
+        impl TensorElementwise for $ty {
+            unreachable_backend_methods! {
+                add(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                sub(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                mul(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                neg(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                conj(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                div(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                abs(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                sign(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                maximum(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                minimum(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                compare(lhs: &Tensor, rhs: &Tensor, dir: &CompareDir) -> tenferro_tensor::Result<Tensor>;
+                select(pred: &Tensor, on_true: &Tensor, on_false: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                clamp(input: &Tensor, lower: &Tensor, upper: &Tensor) -> tenferro_tensor::Result<Tensor>;
+            }
+        }
+
+        impl TensorAnalytic for $ty {
+            unreachable_backend_methods! {
+                exp(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                log(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                sin(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                cos(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                tanh(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                sqrt(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                rsqrt(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                pow(lhs: &Tensor, rhs: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                expm1(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                log1p(input: &Tensor) -> tenferro_tensor::Result<Tensor>;
+            }
+        }
+
+        impl TensorStructural for $ty {
+            unreachable_backend_methods! {
+                transpose(input: &Tensor, perm: &[usize]) -> tenferro_tensor::Result<Tensor>;
+                reshape(input: &Tensor, shape: &[usize]) -> tenferro_tensor::Result<Tensor>;
+                broadcast_in_dim(input: &Tensor, shape: &[usize], dims: &[usize]) -> tenferro_tensor::Result<Tensor>;
+                cast(input: &Tensor, to: DType) -> tenferro_tensor::Result<Tensor>;
+                extract_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> tenferro_tensor::Result<Tensor>;
+                embed_diagonal(input: &Tensor, axis_a: usize, axis_b: usize) -> tenferro_tensor::Result<Tensor>;
+                tril(input: &Tensor, k: i64) -> tenferro_tensor::Result<Tensor>;
+                triu(input: &Tensor, k: i64) -> tenferro_tensor::Result<Tensor>;
+            }
+        }
+
+        impl TensorReduction for $ty {
+            unreachable_backend_methods! {
+                reduce_sum(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+                reduce_prod(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+                reduce_max(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+                reduce_min(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+            }
+        }
+
+        impl TensorIndexing for $ty {
+            unreachable_backend_methods! {
+                gather(operand: &Tensor, start_indices: &Tensor, config: &GatherConfig) -> tenferro_tensor::Result<Tensor>;
+                scatter(operand: &Tensor, scatter_indices: &Tensor, updates: &Tensor, config: &ScatterConfig) -> tenferro_tensor::Result<Tensor>;
+                slice(input: &Tensor, config: &SliceConfig) -> tenferro_tensor::Result<Tensor>;
+                dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+                dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) -> tenferro_tensor::Result<Tensor>;
+                pad(input: &Tensor, config: &PadConfig) -> tenferro_tensor::Result<Tensor>;
+                concatenate(inputs: &[&Tensor], axis: usize) -> tenferro_tensor::Result<Tensor>;
+                reverse(input: &Tensor, axes: &[usize]) -> tenferro_tensor::Result<Tensor>;
+            }
+        }
+
+        impl TensorDot for $ty {
+            unreachable_backend_methods! {
+                dot_general(lhs: &Tensor, rhs: &Tensor, config: &DotGeneralConfig) -> tenferro_tensor::Result<Tensor>;
+            }
+        }
+
+        impl TensorFusion for $ty {}
+        impl TensorBuffer for $ty {}
+        impl TensorDeviceTransfer for $ty {
+            fn download_to_host(&mut self, tensor: &Tensor) -> tenferro_tensor::Result<Tensor> {
+                self.record_transfer();
+                Ok(tensor.clone())
+            }
+
+            fn upload_host_tensor(&mut self, tensor: &Tensor) -> tenferro_tensor::Result<Tensor> {
+                self.record_transfer();
+                Ok(tensor.clone())
+            }
+        }
+        impl BackendCachedDot for $ty {}
+        impl BackendSessionHost for $ty {}
+        impl TensorBackend for $ty {}
+    };
+}
+
+#[derive(Debug, Default)]
+struct TensorOnlyBackend;
+
+impl TensorOnlyBackend {
+    fn record_transfer(&self) {}
+}
+
+impl_minimal_tensor_backend!(TensorOnlyBackend);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct RecordedSpec {
+    operation: FftOperation,
+    normalized_axis: usize,
+    requested_len: Option<usize>,
+    norm: FftNorm,
+    input_dtype: DType,
+    input_shape: Vec<usize>,
+    requires_compact_column_major: bool,
+}
+
+#[derive(Debug)]
+struct RecordingFftBackend {
+    cpu: CpuBackend,
+    specs: Arc<Mutex<Vec<RecordedSpec>>>,
+    transfers: Arc<AtomicUsize>,
+}
+
+impl RecordingFftBackend {
+    fn new() -> (Self, Arc<Mutex<Vec<RecordedSpec>>>, Arc<AtomicUsize>) {
+        let specs = Arc::new(Mutex::new(Vec::new()));
+        let transfers = Arc::new(AtomicUsize::new(0));
+        (
+            Self {
+                cpu: CpuBackend::new(),
+                specs: Arc::clone(&specs),
+                transfers: Arc::clone(&transfers),
+            },
+            specs,
+            transfers,
+        )
+    }
+
+    fn record_transfer(&self) {
+        self.transfers.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl_minimal_tensor_backend!(RecordingFftBackend);
+
+impl FftBackend for RecordingFftBackend {
+    fn execute_fft(
+        &mut self,
+        input: &Tensor,
+        spec: &FftPlanSpec,
+        cache: FftExecutionCache<'_>,
+    ) -> tenferro_tensor::Result<Tensor> {
+        self.specs.lock().unwrap().push(RecordedSpec {
+            operation: spec.operation(),
+            normalized_axis: spec.normalized_axis(),
+            requested_len: spec.requested_len(),
+            norm: spec.norm(),
+            input_dtype: spec.input_dtype(),
+            input_shape: spec.input_shape().to_vec(),
+            requires_compact_column_major: spec.requires_compact_column_major(),
+        });
+        self.cpu.execute_fft(input, spec, cache)
+    }
+}
+
+fn assert_fft_backend<B: FftBackend>() {}
+fn assert_tensor_backend<B: TensorBackend>() {}
+
+#[test]
+fn cpu_backend_is_fft_capable_and_runtime_registration_accepts_it() {
+    assert_fft_backend::<CpuBackend>();
+    assert_tensor_backend::<TensorOnlyBackend>();
+
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    executor
+        .register_extension(tenferro_fft::register_runtime)
+        .unwrap();
+}
+
+#[test]
+fn concrete_cpu_execution_preserves_all_four_scalar_dtypes() {
+    let mut backend = CpuBackend::new();
+
+    let f32_input = Tensor::from_vec_col_major(vec![2], vec![1.0_f32, 2.0]).unwrap();
+    let f32_output = f32_input
+        .fft(None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    assert_eq!(
+        f32_output.as_slice::<Complex32>().unwrap()[0],
+        Complex32::new(3.0, 0.0)
+    );
+
+    let f64_input = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let f64_output = f64_input
+        .fft(None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    assert_eq!(
+        f64_output.as_slice::<Complex64>().unwrap()[0],
+        Complex64::new(3.0, 0.0)
+    );
+
+    let c32_input = Tensor::from_vec_col_major(
+        vec![2],
+        vec![Complex32::new(1.0, 0.0), Complex32::new(2.0, 0.0)],
+    )
+    .unwrap();
+    let c32_output = c32_input
+        .fft(None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    assert_eq!(
+        c32_output.as_slice::<Complex32>().unwrap()[0],
+        Complex32::new(3.0, 0.0)
+    );
+
+    let c64_input = Tensor::from_vec_col_major(
+        vec![2],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+    )
+    .unwrap();
+    let c64_output = c64_input
+        .fft(None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    assert_eq!(
+        c64_output.as_slice::<Complex64>().unwrap()[0],
+        Complex64::new(3.0, 0.0)
+    );
+}
+
+#[test]
+fn concrete_execution_delegates_the_validated_plan_spec() {
+    let (mut backend, specs, _) = RecordingFftBackend::new();
+    let input = Tensor::from_vec_col_major(
+        vec![2, 3],
+        vec![
+            Complex64::new(1.0, 0.0),
+            Complex64::new(2.0, 0.0),
+            Complex64::new(3.0, 0.0),
+            Complex64::new(4.0, 0.0),
+            Complex64::new(5.0, 0.0),
+            Complex64::new(6.0, 0.0),
+        ],
+    )
+    .unwrap();
+
+    let output = input
+        .fft(Some(4), -1, FftNorm::Ortho, &mut backend)
+        .unwrap();
+    assert_eq!(output.shape(), &[2, 4]);
+
+    assert_eq!(
+        *specs.lock().unwrap(),
+        vec![RecordedSpec {
+            operation: FftOperation::C2cForward,
+            normalized_axis: 1,
+            requested_len: Some(4),
+            norm: FftNorm::Ortho,
+            input_dtype: DType::C64,
+            input_shape: vec![2, 3],
+            requires_compact_column_major: true,
+        }]
+    );
+}
+
+fn cuda_c64_tensor(shape: Vec<usize>) -> Tensor {
+    let len = shape.iter().product();
+    Tensor::C64(
+        TypedTensor::from_buffer_col_major(
+            shape,
+            Buffer::Backend(Arc::new(BufferHandle::<Complex64>::new_with_len(7, len))),
+            Placement {
+                memory_kind: MemoryKind::Device,
+                device: Some(DeviceId {
+                    kind: DeviceKind::Gpu(GpuBackendKind::Cuda),
+                    ordinal: 0,
+                }),
+            },
+        )
+        .unwrap(),
+    )
+}
+
+#[test]
+fn foreign_placement_is_unsupported_without_transfer() {
+    let (mut backend, _, transfers) = RecordingFftBackend::new();
+    let input = cuda_c64_tensor(vec![2]);
+
+    let error = input
+        .fft(None, -1, FftNorm::Backward, &mut backend)
+        .unwrap_err();
+
+    assert_eq!(error.kind(), ErrorKind::Unsupported);
+    assert_eq!(transfers.load(Ordering::Relaxed), 0);
+}

--- a/crates/tenferro-fft/tests/backend_capability.rs
+++ b/crates/tenferro-fft/tests/backend_capability.rs
@@ -1,3 +1,5 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc, Mutex,
@@ -6,9 +8,10 @@ use std::sync::{
 use num_complex::{Complex32, Complex64};
 use tenferro_cpu::CpuBackend;
 use tenferro_fft::{
-    FftBackend, FftExecutionCache, FftNorm, FftOperation, FftPlanSpec, TensorFftExt,
+    FftBackend, FftExecutionCache, FftExecutor, FftNorm, FftOperation, FftPlanSpec, TensorFftExt,
+    FFT_EXTENSION_FAMILY_ID,
 };
-use tenferro_runtime::GraphExecutor;
+use tenferro_runtime::{ExtensionCacheKey, GraphExecutor};
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSessionHost, Buffer, BufferHandle, CompareDir,
     DType, DeviceId, DeviceKind, DotGeneralConfig, ErrorKind, GatherConfig, GpuBackendKind,
@@ -136,6 +139,67 @@ impl TensorOnlyBackend {
 
 impl_minimal_tensor_backend!(TensorOnlyBackend);
 
+#[derive(Debug, Default)]
+struct MockNonCpuBackend {
+    plan_builds: usize,
+    plan_reuses: usize,
+}
+
+impl MockNonCpuBackend {
+    fn record_transfer(&self) {}
+}
+
+impl_minimal_tensor_backend!(MockNonCpuBackend);
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct MockNonCpuPlanKey {
+    operation: FftOperation,
+    normalized_axis: usize,
+    requested_len: Option<usize>,
+    input_dtype: DType,
+    input_shape: Vec<usize>,
+}
+
+#[derive(Debug)]
+struct MockNonCpuPlan {
+    key: MockNonCpuPlanKey,
+}
+
+impl FftBackend for MockNonCpuBackend {
+    fn execute_fft(
+        &mut self,
+        input: &Tensor,
+        spec: &FftPlanSpec,
+        mut cache: FftExecutionCache<'_>,
+    ) -> tenferro_tensor::Result<Tensor> {
+        let plan_key = MockNonCpuPlanKey {
+            operation: spec.operation(),
+            normalized_axis: spec.normalized_axis(),
+            requested_len: spec.requested_len(),
+            input_dtype: spec.input_dtype(),
+            input_shape: spec.input_shape().to_vec(),
+        };
+        let mut hasher = DefaultHasher::new();
+        plan_key.hash(&mut hasher);
+        let cache_key = ExtensionCacheKey::new(
+            FFT_EXTENSION_FAMILY_ID,
+            "mock-non-cpu-plans",
+            hasher.finish(),
+        );
+        let store = cache.store_mut();
+        if store
+            .get::<MockNonCpuPlan>(&cache_key)
+            .is_some_and(|plan| plan.key == plan_key)
+        {
+            self.plan_reuses += 1;
+        } else {
+            self.plan_builds += 1;
+            store.put(cache_key, MockNonCpuPlan { key: plan_key }, 96);
+        }
+        Ok(input.clone())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct RecordedSpec {
     operation: FftOperation,
@@ -208,6 +272,38 @@ fn cpu_backend_is_fft_capable_and_runtime_registration_accepts_it() {
     executor
         .register_extension(tenferro_fft::register_runtime)
         .unwrap();
+}
+
+#[test]
+fn caller_owned_cache_is_backend_neutral_and_reports_reuse_clear_and_stats() {
+    let input = Tensor::from_vec_col_major(
+        vec![2],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+    )
+    .unwrap();
+    let mut backend = MockNonCpuBackend::default();
+    let mut executor = FftExecutor::default();
+
+    executor
+        .fft(&input, None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    executor
+        .fft(&input, None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+
+    assert_eq!(backend.plan_builds, 1);
+    assert_eq!(backend.plan_reuses, 1);
+    assert_eq!(executor.cache_stats().entries, 1);
+    assert_eq!(executor.cache_stats().retained_bytes, 96);
+
+    executor.clear_cache();
+    assert_eq!(executor.cache_stats().entries, 0);
+    assert_eq!(executor.cache_stats().retained_bytes, 0);
+
+    executor
+        .fft(&input, None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    assert_eq!(backend.plan_builds, 2);
 }
 
 #[test]

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -173,7 +173,7 @@ fn registered_runtime_reports_gpu_input_as_unsupported() {
 
 #[test]
 fn fft_cpu_output_buffers_avoid_zero_fill_but_keep_lane_padding() {
-    let source = include_str!("../src/lib.rs");
+    let source = include_str!("../src/cpu.rs");
 
     assert!(
         !source.contains("let mut output = vec![Complex::zero(); out_shape.iter().product()]"),
@@ -193,13 +193,14 @@ fn fft_cpu_output_buffers_avoid_zero_fill_but_keep_lane_padding() {
 
 #[test]
 fn fft_cpu_execution_reuses_cached_rustfft_plans() {
-    let source = include_str!("../src/lib.rs");
+    let source = include_str!("../src/cpu.rs");
+    let cache_source = include_str!("../src/cache.rs");
     let c2c = source_section(source, "fn execute_c2c<T>(", "fn execute_r2c<T>(");
     let r2c = source_section(source, "fn execute_r2c<T>(", "fn execute_c2r<T>(");
     let c2r = source_section(source, "fn execute_c2r<T>(", "fn scale_for<T>(");
 
     assert!(
-        source.contains("trait FftPlanProvider"),
+        cache_source.contains("trait FftPlanProvider"),
         "FFT CPU execution should obtain plans from an explicit owner"
     );
     for (name, section) in [
@@ -216,7 +217,7 @@ fn fft_cpu_execution_reuses_cached_rustfft_plans() {
 
 #[test]
 fn fft_cpu_execution_uses_explicit_plan_provider() {
-    let source = include_str!("../src/lib.rs");
+    let source = include_str!("../src/cpu.rs");
     let c2c = source_section(source, "fn execute_c2c<T>(", "fn execute_r2c<T>(");
     let r2c = source_section(source, "fn execute_r2c<T>(", "fn execute_c2r<T>(");
     let c2r = source_section(source, "fn execute_c2r<T>(", "fn scale_for<T>(");
@@ -247,11 +248,17 @@ fn fft_cpu_execution_uses_explicit_plan_provider() {
 
 #[test]
 fn fft_source_has_no_process_global_plan_cache() {
-    let source = include_str!("../src/lib.rs");
+    let sources = [
+        include_str!("../src/lib.rs"),
+        include_str!("../src/cache.rs"),
+        include_str!("../src/cpu.rs"),
+    ];
 
-    assert!(!source.contains("static F32_FFT_PLAN_CACHE"));
-    assert!(!source.contains("static F64_FFT_PLAN_CACHE"));
-    assert!(!source.contains("OnceLock<Mutex"));
+    for source in sources {
+        assert!(!source.contains("static F32_FFT_PLAN_CACHE"));
+        assert!(!source.contains("static F64_FFT_PLAN_CACHE"));
+        assert!(!source.contains("OnceLock<Mutex"));
+    }
 }
 
 #[test]
@@ -274,6 +281,7 @@ fn graph_runtime_owns_fft_plan_cache() {
         .register_extension(tenferro_fft::register_runtime)
         .unwrap();
 
+    executor.run(&program).unwrap();
     executor.run(&program).unwrap();
     let stats = executor
         .extension_executor()

--- a/docs/design/fft-backend-execution.md
+++ b/docs/design/fft-backend-execution.md
@@ -1,0 +1,89 @@
+# FFT Backend Execution
+
+`tenferro-fft` separates FFT semantics from backend execution through the
+public `FftBackend` capability. This boundary applies to direct tensor calls,
+caller-owned repeated execution, and registered graph execution. A backend
+that implements only `TensorBackend` is not FFT-capable.
+
+## Validated request boundary
+
+The tensor-facing and runtime entry points validate the operation, dtype,
+axis, transform length, input shape, and real-spectrum constraints before
+calling a backend. They pass the result as an immutable `FftPlanSpec`.
+
+`FftPlanSpec` is a semantic execution request, not a vendor plan. It records:
+
+- the FFT operation and normalization mode;
+- the normalized axis and optional requested transform length;
+- the validated input dtype and shape; and
+- the compact column-major input requirement of the current execution path.
+
+Backend-specific choices such as RustFFT versus cuFFT, algorithm selection,
+workspace size, stream identity, and device handles do not belong in the spec.
+Those choices remain private to each `FftBackend` implementation.
+
+## Placement and fallback
+
+An FFT backend executes on the input's existing placement. If it cannot handle
+the operation, dtype, layout, or placement, it returns `Unsupported`. It must
+not construct another backend, upload or download the tensor, or silently run a
+host implementation.
+
+The CPU implementation therefore accepts host tensors and uses RustFFT. A
+future Metal or CUDA implementation must be registered and selected
+explicitly. Cross-device movement remains a caller-visible operation before or
+after FFT execution.
+
+## Cache ownership
+
+Every backend receives `FftExecutionCache`, which exposes one bounded typed
+`ExtensionCacheStore` regardless of ownership path:
+
+| Execution path | Cache owner | Lifetime and control |
+| --- | --- | --- |
+| `FftExecutor` | Caller-owned `FftPlanCache` | Reused across direct calls; caller configures capacity and uses `cache_stats` / `clear_cache` |
+| Registered extension runtime | Runtime-owned `ExtensionCacheStore` | Reused across graph runs; runtime limits, selectors, aggregate stats, and clear APIs apply |
+| One-shot tensor/read helper | Temporary capacity-one `FftPlanCache` | Exists only for that call; it does not create hidden long-lived state |
+| Host reference | Temporary capacity-one `FftPlanCache` | Explicit reference execution only; never selected as backend fallback |
+
+`FftPlanCache` is a backend-neutral wrapper, despite its historical name. It
+does not contain RustFFT-typed fields. Each backend stores private
+`Send + Sync + 'static` entries through `FftExecutionCache::store_mut` under a
+stable `ExtensionCacheKey` namespace. The global entry bound and LRU order are
+shared across namespaces, so a caller's capacity is a true upper bound for the
+whole executor rather than a per-backend multiplier.
+
+Backends must include every field that changes plan or workspace identity in
+the discriminator and should retain the unhashed identity in the typed value
+when a hash is used. They must provide the logical bytes retained by the cache
+entry at insertion, or use dynamic retained-byte accounting when the value can
+grow. `FftExecutor::cache_stats` aggregates all backend namespaces, and
+`clear_cache` removes them all.
+
+## CPU RustFFT namespace
+
+The CPU adapter owns the private `rustfft-plans` namespace. Its exact plan key
+contains transform length, forward/inverse direction, and scalar dtype (`f32`
+or `f64`). The typed entry retains the exact key to reject discriminator hash
+collisions before reuse. The known retained-byte estimate covers the key and
+cache-owned `Arc` handle; RustFFT's opaque internal allocations cannot be
+reported and are intentionally excluded.
+
+This namespace is an implementation detail. Non-CPU backends use distinct
+names for vendor plans and workspaces and do not depend on RustFFT types.
+
+## Extension requirements
+
+A new FFT backend implementation must:
+
+1. implement `FftBackend` in the crate that owns the backend integration;
+2. validate that the input placement and layout are supported without moving
+   the tensor;
+3. consume only validated request facts from `FftPlanSpec`;
+4. use a backend-specific typed cache namespace for reusable plans/workspaces;
+5. supply stable keys and retained-byte accounting; and
+6. test repeated caller-owned reuse, runtime-owned reuse, eviction/clear/stats,
+   unsupported placement, and absence of implicit transfer.
+
+GPU-specific kernel, stream, and device-resource rules remain governed by
+[GPU Backend Design](./gpu-backend-design.md).

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -18,6 +18,7 @@ migration notes live under [Plans](../plans/), not this active design index.
 | [output-modes.md](./output-modes.md) | Output-update vocabulary for `_read`, `_into`, `_add_to`, and dot `_into_accum` surfaces |
 | [algebra.md](./algebra.md) | Algebra boundary, external numeric extensions, tropical paths |
 | [einsum.md](./einsum.md) | Einsum public API, N-ary contraction tree, algebra dispatch |
+| [fft-backend-execution.md](./fft-backend-execution.md) | FFT backend capability, validated plan descriptors, no-fallback placement semantics, and backend-neutral cache ownership |
 | [contraction-pipeline.md](./contraction-pipeline.md) | Binary contraction pipeline, copy elision |
 | [dot-general-overhead.md](./dot-general-overhead.md) | Fixed-cost analysis for many small `dot_general` contractions |
 | [dynamic-symbolic-shapes.md](./dynamic-symbolic-shapes.md) | Dynamic and symbolic shape architecture. Covers `DynamicTruncate`, `transpose_scatter`, symbolic `slice_sizes`, the `Exact`/`UpperBound`/`Unknown` extent model, and extension equalities from graph-owned scopes through compiled guards. This is the key design doc for understanding how tenferro differs from XLA-style shape-specialized compilation. |

--- a/docs/worklogs/2026-07-19-fft-backend-capability.md
+++ b/docs/worklogs/2026-07-19-fft-backend-capability.md
@@ -1,0 +1,96 @@
+# FFT backend capability and cache-boundary work log
+
+Date: 2026-07-19
+
+## Session summary
+
+This work introduced an explicit `FftBackend` capability for concrete and
+registered FFT execution. It moved CPU RustFFT execution behind that capability,
+centralized validated requests in `FftPlanSpec`, retained exact bounded CPU
+plan caching, and made unsupported placement return an error without transfer
+or fallback.
+
+A follow-up review found that the initial caller-owned `FftExecutionCache`
+accepted a RustFFT-specific `FftPlanCache`, while only runtime-owned execution
+exposed typed storage. The boundary was corrected so `FftPlanCache` wraps the
+same backend-neutral `ExtensionCacheStore` used by graph execution. A recording
+non-CPU backend now proves direct plan reuse, aggregate retained-byte stats, and
+clear behavior.
+
+Durable design intent is recorded in
+[FFT Backend Execution](../design/fft-backend-execution.md).
+
+## Context read
+
+| Source | Why it was read | Decision impact |
+| --- | --- | --- |
+| `AGENTS.md` and `REPOSITORY_RULES.md` | Confirm repository, cache, documentation, and AI worklog requirements. | Kept cache ownership explicit and added both design and worklog records. |
+| Task brief, implementation plan, and review report | Establish capability requirements and the two requested review corrections. | Preserved CPU behavior while widening only the cache storage boundary. |
+| `tenferro-runtime::ExtensionCacheStore` | Inspect the existing bounded typed store, limits, selectors, LRU, and retained-byte APIs. | Reused the runtime abstraction rather than creating a second type-erased cache. |
+| `tenferro-tensor::{CacheStats, RuntimeCacheControl}` | Confirm aggregate clear/stats contracts. | Kept `FftPlanCache` compatible with shared cache control. |
+| Existing FFT concrete/runtime tests and CPU cache implementation | Verify exact key fields, reuse, bounds, dtype coverage, and placement behavior. | Retained RustFFT length/direction/dtype identity and collision checks. |
+| Extension and cache design/worklog precedent | Match durable record scope and structure. | Separated future-facing design rules from session-level rationale. |
+
+CodeGraph was used before direct source search to locate the FFT executor,
+runtime cache API, callers, and cache-control blast radius.
+
+## Decisions made
+
+- **`FftBackend` is the compile-time capability boundary.** Generic
+  `TensorBackend` implementations cannot enter FFT execution or register the
+  FFT runtime without opting into the capability.
+- **`FftPlanSpec` contains validated semantics only.** Vendor plans, handles,
+  workspaces, streams, and device choices remain backend-private.
+- **Caller- and runtime-owned execution expose the same typed store.**
+  `FftExecutionCache::store_mut` works in both paths. Constructor-controlled
+  ownership still prevents a backend from replacing or extending the cache
+  lifetime.
+- **One capacity bounds the full caller-owned cache.** CPU and future GPU
+  namespaces share the wrapper's LRU entry limit, clear operation, and
+  aggregate stats instead of each receiving an independent hidden bound.
+- **RustFFT remains private.** The CPU adapter uses `rustfft-plans` with exact
+  length, direction, and scalar-dtype keys. The stored exact key protects
+  against discriminator hash collisions.
+- **Placement remains explicit.** Unsupported backends return `Unsupported`;
+  FFT execution never performs upload, download, or CPU fallback.
+
+## Rejected or deferred alternatives
+
+- Keeping a RustFFT LRU beside a separate generic caller store was rejected:
+  two independent bounds would make capacity and aggregate eviction behavior
+  misleading, and CPU entries would follow a different storage contract from
+  other backends.
+- Exposing RustFFT plan enums or a backend-specific cache trait was rejected:
+  it would couple future Metal/CUDA integrations to the CPU provider or require
+  a second type-erasure mechanism already provided by `ExtensionCacheStore`.
+- GPU FFT implementation is deferred. This change supplies the capability and
+  storage contract but does not add Metal, CUDA, cuFFT, streams, or device
+  workspaces.
+
+## Verification performed
+
+The implementation was developed test-first. The new non-CPU caller-cache test
+initially failed because `FftExecutionCache::store_mut` did not exist, then
+passed after the shared typed-store boundary was implemented.
+
+- `cargo fmt --all -- --check`
+- `cargo test -p tenferro-fft`
+- `cargo test -p tenferro-fft --features autodiff`
+- `cargo clippy -p tenferro-fft --all-targets --features autodiff -- -D warnings`
+- `cargo doc --workspace --no-deps`
+- `python3 scripts/check-public-error-docs.py --root-dir . --changed-from origin/main`
+- `python3.11 scripts/check-docs-site.py`
+- `git diff --check`
+
+All commands passed. Python 3.11 was selected explicitly because the host's
+default Python 3.9 cannot parse guide dependency snippets.
+
+## Remaining risks and follow-up
+
+- RustFFT does not expose the memory owned by opaque plans, so retained-byte
+  stats cover only the exact key and cache-owned handle.
+- The workspace's mutually exclusive BLAS-provider features prevent a useful
+  `--all-features` clippy invocation. The supported FFT feature matrix is used
+  instead; this conflict is unrelated to the FFT cache boundary.
+- Each future GPU backend must define and test its own exact key identity and
+  logical retained-byte calculation.


### PR DESCRIPTION
## Summary

- add public backend-neutral `FftBackend`, `FftPlanSpec`, `FftOperation`, and execution-cache context
- move existing RustFFT F32/F64/C32/C64 execution behind the explicit CPU capability without changing values, normalization, shape, or AD behavior
- make caller-owned and runtime-owned FFT caches backend-neutral, bounded typed stores with reuse/clear/stats support
- reject unsupported placement without hidden transfer or backend fallback
- document the architecture and work record for future Metal/CUDA adapters

## Verification

- default: 11 unit + 5 capability + 19 integration + 17 doctests
- autodiff: 13 unit + 5 capability + 27 integration + 17 doctests
- clippy with supported `autodiff` feature matrix and `-D warnings`
- fmt, public error docs, docs-site/workspace rustdoc (implementer pass)
- independent re-review: no Critical/Important findings

`--all-features` remains inapplicable because it selects mutually exclusive BLAS provider features; the supported feature matrix is green. RustFFT opaque internal allocations remain excluded from retained-byte estimates.

Part of #1394. #1406 is already fixed separately.