### PR TITLE
Add borrowed solve entry points to LinalgBackend

### DIFF
--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -49,6 +49,58 @@ pub trait LinalgBackend: TensorBackend {
         unit_diagonal: bool,
     ) -> tenferro_tensor::Result<Tensor>;
 
+    // INVARIANT: the six flags are the public triangular-solve contract and mirror the owned hook.
+    #[allow(clippy::too_many_arguments)]
+    /// Solve a triangular linear system from tensor read targets.
+    ///
+    /// Backends may canonicalize the inputs inside the same placement family,
+    /// but must not silently transfer between CPU and GPU memory.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::LinalgBackend;
+    /// use tenferro_tensor::{Tensor, TensorRead};
+    ///
+    /// let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 1.0, 3.0])?;
+    /// let b = Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 9.0])?;
+    /// let mut backend = CpuBackend::new();
+    /// let x = backend.triangular_solve_read(
+    ///     TensorRead::from_tensor(&a),
+    ///     TensorRead::from_tensor(&b),
+    ///     true,
+    ///     false,
+    ///     false,
+    ///     false,
+    /// )?;
+    /// let Tensor::F64(x) = x else { unreachable!("F64 inputs return F64 output") };
+    /// assert_eq!(x.host_data()?, &[0.5, 3.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns `Error::Unsupported` because the
+    /// backend does not accept tensor read targets. Implementations may return
+    /// `Error::Validation` for incompatible shapes or dtypes,
+    /// `Error::RuntimeState` for invalid placement, `Error::Extension` for a
+    /// singular system, or a typed backend-source error.
+    fn triangular_solve_read(
+        &mut self,
+        _a: TensorRead<'_>,
+        _b: TensorRead<'_>,
+        _left_side: bool,
+        _lower: bool,
+        _transpose_a: bool,
+        _unit_diagonal: bool,
+    ) -> tenferro_tensor::Result<Tensor> {
+        Err(tenferro_tensor::Error::unsupported(
+            "triangular_solve",
+            "backend does not accept tensor reads at this execution boundary",
+        ))
+    }
+
     /// Compute public LU outputs `(P, L, U, parity)`.
     ///
     /// # Errors
@@ -570,6 +622,48 @@ pub trait LinalgBackend: TensorBackend {
     /// or dtype; `Error::Extension` with `ErrorKind::NumericalFailure` for a
     /// singular system; or a typed backend source for provider failure.
     fn solve(&mut self, a: &Tensor, b: &Tensor) -> tenferro_tensor::Result<Tensor>;
+
+    /// Solve a linear system from tensor read targets.
+    ///
+    /// Backends may canonicalize the inputs inside the same placement family,
+    /// but must not silently transfer between CPU and GPU memory.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_cpu::CpuBackend;
+    /// use tenferro_linalg::LinalgBackend;
+    /// use tenferro_tensor::{Tensor, TensorRead};
+    ///
+    /// let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 3.0])?;
+    /// let b = Tensor::from_vec_col_major(vec![2, 1], vec![4.0_f64, 9.0])?;
+    /// let mut backend = CpuBackend::new();
+    /// let x = backend.solve_read(
+    ///     TensorRead::from_tensor(&a),
+    ///     TensorRead::from_tensor(&b),
+    /// )?;
+    /// let Tensor::F64(x) = x else { unreachable!("F64 inputs return F64 output") };
+    /// assert_eq!(x.host_data()?, &[2.0, 3.0]);
+    /// # Ok::<(), tenferro_tensor::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns `Error::Unsupported` because the
+    /// backend does not accept tensor read targets. Implementations may return
+    /// `Error::Validation` for incompatible shapes or dtypes,
+    /// `Error::RuntimeState` for invalid placement, `Error::Extension` for a
+    /// singular system, or a typed backend-source error.
+    fn solve_read(
+        &mut self,
+        _a: TensorRead<'_>,
+        _b: TensorRead<'_>,
+    ) -> tenferro_tensor::Result<Tensor> {
+        Err(tenferro_tensor::Error::unsupported(
+            "solve",
+            "backend does not accept tensor reads at this execution boundary",
+        ))
+    }
 
     #[doc(hidden)]
     fn lu_solve_prepared(

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -181,6 +181,23 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
+    fn triangular_solve_read(
+        &mut self,
+        a: TensorRead<'_>,
+        b: TensorRead<'_>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+    ) -> tenferro_tensor::Result<Tensor> {
+        ensure_host_tensor_read("triangular_solve", &a)?;
+        ensure_host_tensor_read("triangular_solve", &b)?;
+        ensure_supported_linalg_dtypes("triangular_solve", a.dtype(), b.dtype())?;
+        let a = canonicalize_tensor_read(self, a)?;
+        let b = canonicalize_tensor_read(self, b)?;
+        self.triangular_solve(&a, &b, left_side, lower, transpose_a, unit_diagonal)
+    }
+
     fn lu(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
         ensure_host_tensor("lu", input)?;
         match linalg_provider_kind(self.kind(), "lu")? {
@@ -1276,6 +1293,19 @@ impl LinalgBackend for CpuBackend {
             Ok(result)
         }
     }
+
+    fn solve_read(
+        &mut self,
+        a: TensorRead<'_>,
+        b: TensorRead<'_>,
+    ) -> tenferro_tensor::Result<Tensor> {
+        ensure_host_tensor_read("solve", &a)?;
+        ensure_host_tensor_read("solve", &b)?;
+        ensure_supported_linalg_dtypes("solve", a.dtype(), b.dtype())?;
+        let a = canonicalize_tensor_read(self, a)?;
+        let b = canonicalize_tensor_read(self, b)?;
+        self.solve(&a, &b)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1306,6 +1336,58 @@ fn ensure_host_tensor(op: &'static str, input: &Tensor) -> tenferro_tensor::Resu
     }
 }
 
+fn ensure_host_tensor_read(
+    op: &'static str,
+    input: &TensorRead<'_>,
+) -> tenferro_tensor::Result<()> {
+    match input {
+        TensorRead::Tensor(tensor) => ensure_host_tensor(op, tensor),
+        TensorRead::View(view) => ensure_host_tensor_view(op, view),
+    }
+}
+
+fn ensure_host_tensor_view(
+    op: &'static str,
+    input: &TensorView<'_>,
+) -> tenferro_tensor::Result<()> {
+    let is_backend_buffer = match input {
+        TensorView::F32(view) => view.backend_buffer().is_some(),
+        TensorView::F64(view) => view.backend_buffer().is_some(),
+        TensorView::I32(view) => view.backend_buffer().is_some(),
+        TensorView::I64(view) => view.backend_buffer().is_some(),
+        TensorView::Bool(view) => view.backend_buffer().is_some(),
+        TensorView::C32(view) => view.backend_buffer().is_some(),
+        TensorView::C64(view) => view.backend_buffer().is_some(),
+    };
+    if is_backend_buffer {
+        return Err(Error::runtime_state(
+            op,
+            "CPU linalg backend received a backend buffer; download the tensor to host before CPU execution",
+        ));
+    }
+    Ok(())
+}
+
+fn canonicalize_tensor_read<'a>(
+    backend: &mut CpuBackend,
+    input: TensorRead<'a>,
+) -> tenferro_tensor::Result<std::borrow::Cow<'a, Tensor>> {
+    let input = match input {
+        TensorRead::Tensor(tensor) => return Ok(std::borrow::Cow::Borrowed(tensor)),
+        TensorRead::View(view) => view,
+    };
+    let tensor = match input {
+        TensorView::F32(view) => backend.to_contiguous(&view).map(Tensor::F32),
+        TensorView::F64(view) => backend.to_contiguous(&view).map(Tensor::F64),
+        TensorView::I32(view) => backend.to_contiguous(&view).map(Tensor::I32),
+        TensorView::I64(view) => backend.to_contiguous(&view).map(Tensor::I64),
+        TensorView::Bool(view) => backend.to_contiguous(&view).map(Tensor::Bool),
+        TensorView::C32(view) => backend.to_contiguous(&view).map(Tensor::C32),
+        TensorView::C64(view) => backend.to_contiguous(&view).map(Tensor::C64),
+    }?;
+    Ok(std::borrow::Cow::Owned(tensor))
+}
+
 fn ensure_host_typed_tensor<T: 'static>(
     op: &'static str,
     input: &TypedTensor<T>,
@@ -1324,14 +1406,20 @@ fn ensure_supported_linalg_pair(
     lhs: &Tensor,
     rhs: &Tensor,
 ) -> tenferro_tensor::Result<()> {
-    if lhs.dtype() != rhs.dtype() {
-        return Err(Error::dtype_mismatch(op, lhs.dtype(), rhs.dtype()));
+    ensure_supported_linalg_dtypes(op, lhs.dtype(), rhs.dtype())
+}
+
+fn ensure_supported_linalg_dtypes(
+    op: &'static str,
+    lhs: DType,
+    rhs: DType,
+) -> tenferro_tensor::Result<()> {
+    if lhs != rhs {
+        return Err(Error::dtype_mismatch(op, lhs, rhs));
     }
     match lhs {
-        Tensor::F32(_) | Tensor::F64(_) | Tensor::C32(_) | Tensor::C64(_) => Ok(()),
-        Tensor::I32(_) | Tensor::I64(_) | Tensor::Bool(_) => {
-            Err(unsupported_dtype(op, lhs.dtype()))
-        }
+        DType::F32 | DType::F64 | DType::C32 | DType::C64 => Ok(()),
+        DType::I32 | DType::I64 | DType::Bool => Err(unsupported_dtype(op, lhs)),
     }
 }
 

--- a/crates/tenferro-linalg/src/cpu/tests/linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/linalg.rs
@@ -1,5 +1,92 @@
 use super::*;
 
+fn compiled_linalg_provider_kinds() -> Vec<tenferro_cpu::CpuBackendKind> {
+    vec![
+        #[cfg(feature = "cpu-faer")]
+        tenferro_cpu::CpuBackendKind::Faer,
+        #[cfg(feature = "cpu-blas")]
+        tenferro_cpu::CpuBackendKind::Blas,
+    ]
+}
+
+#[test]
+fn solve_read_accepts_owned_and_strided_inputs_for_compiled_providers() {
+    let a = Tensor::from_vec_col_major([2, 2], vec![3.0_f64, 1.0, 0.0, 2.0]).unwrap();
+    let b = Tensor::from_vec_col_major([2, 1], vec![7.0_f64, 4.0]).unwrap();
+    let a_storage = vec![-1.0, 3.0, -1.0, 1.0, -1.0, -1.0, 0.0, -1.0, 2.0];
+    let b_storage = vec![-1.0, 7.0, -1.0, 4.0];
+
+    for kind in compiled_linalg_provider_kinds() {
+        let mut backend = CpuBackend::with_kind(kind).unwrap();
+        let owned = backend
+            .solve_read(TensorRead::from_tensor(&a), TensorRead::from_tensor(&b))
+            .unwrap();
+        let strided = backend
+            .solve_read(
+                TensorRead::from_view(TensorView::F64(
+                    TypedTensorView::from_slice(vec![2, 2], vec![2, 5], 1, &a_storage).unwrap(),
+                )),
+                TensorRead::from_view(TensorView::F64(
+                    TypedTensorView::from_slice(vec![2, 1], vec![2, 5], 1, &b_storage).unwrap(),
+                )),
+            )
+            .unwrap();
+
+        for row in 0..2 {
+            assert_f64_close(get_f64(&owned, &[row, 0]), get_f64(&strided, &[row, 0]));
+        }
+
+        let vector_b = Tensor::from_vec_col_major([2], vec![7.0_f64, 4.0]).unwrap();
+        let vector_x = backend
+            .solve_read(
+                TensorRead::from_tensor(&a),
+                TensorRead::from_tensor(&vector_b),
+            )
+            .unwrap();
+        assert_eq!(vector_x.shape(), &[2]);
+    }
+}
+
+#[test]
+fn triangular_solve_read_accepts_owned_and_strided_inputs_for_compiled_providers() {
+    let a = Tensor::from_vec_col_major([2, 2], vec![2.0_f64, 0.0, 1.0, 3.0]).unwrap();
+    let b = Tensor::from_vec_col_major([2, 1], vec![5.0_f64, 6.0]).unwrap();
+    let a_storage = vec![-1.0, 2.0, -1.0, 0.0, -1.0, -1.0, 1.0, -1.0, 3.0];
+    let b_storage = vec![-1.0, 5.0, -1.0, 6.0];
+
+    for kind in compiled_linalg_provider_kinds() {
+        let mut backend = CpuBackend::with_kind(kind).unwrap();
+        let owned = backend
+            .triangular_solve_read(
+                TensorRead::from_tensor(&a),
+                TensorRead::from_tensor(&b),
+                true,
+                false,
+                false,
+                false,
+            )
+            .unwrap();
+        let strided = backend
+            .triangular_solve_read(
+                TensorRead::from_view(TensorView::F64(
+                    TypedTensorView::from_slice(vec![2, 2], vec![2, 5], 1, &a_storage).unwrap(),
+                )),
+                TensorRead::from_view(TensorView::F64(
+                    TypedTensorView::from_slice(vec![2, 1], vec![2, 5], 1, &b_storage).unwrap(),
+                )),
+                true,
+                false,
+                false,
+                false,
+            )
+            .unwrap();
+
+        for row in 0..2 {
+            assert_f64_close(get_f64(&owned, &[row, 0]), get_f64(&strided, &[row, 0]));
+        }
+    }
+}
+
 #[test]
 fn svd_read_accepts_an_owned_tensor_read() {
     let input = Tensor::from_vec_col_major([2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]).unwrap();

--- a/crates/tenferro-linalg/src/cpu/tests/mod.rs
+++ b/crates/tenferro-linalg/src/cpu/tests/mod.rs
@@ -16,7 +16,7 @@ use tenferro_tensor::backend::TensorBackend;
 use tenferro_tensor::config::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
 };
-use tenferro_tensor::types::{DType, Tensor, TensorRead, TensorView, TypedTensor};
+use tenferro_tensor::types::{DType, Tensor, TensorRead, TensorView, TypedTensor, TypedTensorView};
 
 fn get_f64(t: &Tensor, idx: &[usize]) -> f64 {
     match t {

--- a/crates/tenferro-linalg/tests/integration/backend_errors.rs
+++ b/crates/tenferro-linalg/tests/integration/backend_errors.rs
@@ -341,6 +341,40 @@ fn default_svd_read_returns_explicit_backend_boundary_error() {
             ref message,
         } if message.contains("tensor reads")
     ));
+
+    let rhs =
+        Tensor::F64(TypedTensor::<f64>::from_vec_col_major(vec![2, 1], vec![1.0, 2.0]).unwrap());
+    let err = backend
+        .solve_read(
+            TensorRead::from_tensor(&owned_input),
+            TensorRead::from_tensor(&rhs),
+        )
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::Unsupported {
+            op: "solve",
+            ref message,
+        } if message.contains("tensor reads")
+    ));
+
+    let err = backend
+        .triangular_solve_read(
+            TensorRead::from_tensor(&owned_input),
+            TensorRead::from_tensor(&rhs),
+            true,
+            true,
+            false,
+            false,
+        )
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::Unsupported {
+            op: "triangular_solve",
+            ref message,
+        } if message.contains("tensor reads")
+    ));
 }
 
 #[test]
@@ -601,6 +635,30 @@ fn cpu_linalg_rejects_backend_buffers_without_panicking_or_downloading() {
     assert_no_panic_backend_download_error("eigh", || backend.eigh(&a));
     assert_no_panic_backend_download_error("eig", || backend.eig(&a));
     assert_no_panic_backend_download_error("solve", || backend.solve(&a, &b));
+    assert_no_panic_backend_download_error("solve", || {
+        backend.solve_read(TensorRead::from_tensor(&a), TensorRead::from_tensor(&b))
+    });
+    assert_no_panic_backend_download_error("triangular_solve", || {
+        backend.triangular_solve_read(
+            TensorRead::from_tensor(&a),
+            TensorRead::from_tensor(&b),
+            true,
+            true,
+            false,
+            false,
+        )
+    });
+
+    let host_c64 = c64_tensor(
+        vec![2, 1],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+    );
+    assert_no_panic_backend_download_error("solve", || {
+        backend.solve_read(
+            TensorRead::from_tensor(&a),
+            TensorRead::from_tensor(&host_c64),
+        )
+    });
 }
 
 #[test]
@@ -624,6 +682,20 @@ fn solve_rejects_invalid_dtype_pairs_before_zero_dim_fast_path() {
     let i32_b = i32_tensor(vec![0, 1], Vec::new());
 
     let err = backend.solve(&f64_a, &c64_b).unwrap_err();
+    assert!(matches!(
+        err,
+        Error::Validation {
+            op: "solve",
+            source: ValidationError::DTypeMismatch { .. },
+        }
+    ));
+
+    let err = backend
+        .solve_read(
+            TensorRead::from_tensor(&f64_a),
+            TensorRead::from_tensor(&c64_b),
+        )
+        .unwrap_err();
     assert!(matches!(
         err,
         Error::Validation {
@@ -706,6 +778,16 @@ fn solve_rejects_singular_matrix() {
 
     let err = backend.solve(&a, &b).unwrap_err();
 
+    assert_eq!(err.kind(), ErrorKind::NumericalFailure);
+    assert!(matches!(
+        err.source()
+            .and_then(|source| source.downcast_ref::<tenferro_linalg::Error>()),
+        Some(tenferro_linalg::Error::Singular { op: "solve" })
+    ));
+
+    let err = backend
+        .solve_read(TensorRead::from_tensor(&a), TensorRead::from_tensor(&b))
+        .unwrap_err();
     assert_eq!(err.kind(), ErrorKind::NumericalFailure);
     assert!(matches!(
         err.source()

--- a/docs/superpowers/specs/2026-07-19-linalg-read-solves-design.md
+++ b/docs/superpowers/specs/2026-07-19-linalg-read-solves-design.md
@@ -34,7 +34,7 @@ The existing owned `solve` and `triangular_solve` methods remain unchanged.
 
 `CpuBackend` overrides both methods. It validates both read targets as host-accessible tensors, checks dtype pairs consistently with the owned path, and dispatches according to the configured linalg provider.
 
-For Faer, supported strided views use provider view entry points where the existing linalg layout contract permits them. For BLAS/LAPACK, and for Faer layouts outside that contract, the CPU backend explicitly canonicalizes each operand with its pooled materialization path before calling the existing owned implementation. Offset and transposed views must therefore match the owned path without introducing a trait-level hidden fallback.
+Faer's existing unary decomposition kernels expose `MatRef`-based view entry points, but its binary solve kernels and the BLAS/LAPACK ABI currently consume compact operands. Therefore both CPU providers borrow `TensorRead::Tensor` operands without copying and explicitly canonicalize `TensorRead::View` operands with the backend's pooled materialization path before calling the existing owned implementation. Offset and transposed views must match the owned path without introducing a trait-level hidden fallback. Adding provider-native binary view kernels is a separate performance refactor, not part of the public API change in #1267.
 
 Both operands are resolved before numerical execution. Invalid dtype pairs, incompatible shapes, singular systems, non-host placements, and provider failures retain the existing typed error vocabulary.
 

--- a/docs/superpowers/specs/2026-07-19-linalg-read-solves-design.md
+++ b/docs/superpowers/specs/2026-07-19-linalg-read-solves-design.md
@@ -1,0 +1,62 @@
+# Borrowed Linalg Solve Design
+
+## Goal
+
+Resolve #1267 by allowing `solve` and `triangular_solve` to consume owned tensors or borrowed tensor views through `TensorRead`, while preserving the existing owned API and backend capability boundaries.
+
+## Selected API
+
+Add two methods to `LinalgBackend`:
+
+```rust
+fn solve_read(
+    &mut self,
+    a: TensorRead<'_>,
+    b: TensorRead<'_>,
+) -> tenferro_tensor::Result<Tensor>;
+
+fn triangular_solve_read(
+    &mut self,
+    a: TensorRead<'_>,
+    b: TensorRead<'_>,
+    left_side: bool,
+    lower: bool,
+    transpose_a: bool,
+    unit_diagonal: bool,
+) -> tenferro_tensor::Result<Tensor>;
+```
+
+The default implementations return typed `Error::Unsupported`, matching the other `LinalgBackend::*_read` methods. They do not silently materialize inputs because materialization policy belongs to the implementing backend.
+
+The existing owned `solve` and `triangular_solve` methods remain unchanged.
+
+## CPU Execution
+
+`CpuBackend` overrides both methods. It validates both read targets as host-accessible tensors, checks dtype pairs consistently with the owned path, and dispatches according to the configured linalg provider.
+
+For Faer, supported strided views use provider view entry points where the existing linalg layout contract permits them. For BLAS/LAPACK, and for Faer layouts outside that contract, the CPU backend explicitly canonicalizes each operand with its pooled materialization path before calling the existing owned implementation. Offset and transposed views must therefore match the owned path without introducing a trait-level hidden fallback.
+
+Both operands are resolved before numerical execution. Invalid dtype pairs, incompatible shapes, singular systems, non-host placements, and provider failures retain the existing typed error vocabulary.
+
+## Alternatives Rejected
+
+1. **Default trait canonicalization.** Rejected because `LinalgBackend` does not own a universal materialization policy, and a hidden fallback would weaken backend capability reporting.
+2. **`TensorView`-only signatures.** Rejected because #1420 standardized the linalg borrowed-input family on `TensorRead`, which also accepts owned `&Tensor` values.
+3. **CUDA borrowed-view overrides in this issue.** Rejected because #1267 only requires CPU providers; unsupported backends should keep the explicit default error rather than adding unrequested canonicalization or transfer behavior.
+
+## Documentation
+
+Each new trait method includes a compiling example using `TensorRead::from_view`. Error documentation names validation, numerical, unsupported-boundary, and typed provider failures. Existing owned examples and methods remain valid.
+
+## Verification
+
+- A backend that relies on the defaults returns typed `Unsupported` for both methods.
+- `TensorRead::from_tensor` is accepted by the CPU overrides.
+- Offset/strided view operands produce the same results as equivalent owned operands for `solve` and `triangular_solve`.
+- Faer and BLAS/LAPACK feature configurations compile and run their focused tests.
+- Dtype mismatch, shape mismatch, singular-system, and non-host placement behavior stays typed and panic-free.
+- Existing linalg unit, integration, and doctest suites remain green.
+
+## Scope Boundary
+
+This change adds no concrete extension trait, eager/traced operation, new provider, device transfer, or GPU implementation. Those remain separate issues.

--- a/docs/worklogs/2026-07-19-issue-1267-read-solves.md
+++ b/docs/worklogs/2026-07-19-issue-1267-read-solves.md
@@ -1,0 +1,39 @@
+# Issue #1267: borrowed solve entry points
+
+## Session summary
+
+Added explicit `TensorRead` entry points for general and triangular linear solves. The backend trait defaults remain capability-honest by returning `Unsupported`; the CPU backend accepts owned and arbitrary valid host reads, canonicalizes them within host placement when required, and delegates to the existing provider-owned solve implementations.
+
+## Sources reviewed
+
+- GitHub issue #1267 and the merged `TensorRead` API decision from #1420.
+- `AGENTS.md`, `CONTRIBUTING.md`, `REPOSITORY_RULES.md`, and the shared tensor4all Rust/repository rules.
+- `LinalgBackend`, `CpuBackend`, existing unary `_read` hooks, Faer linalg adapters, and LAPACK solve/triangular-solve adapters.
+- Existing read-layout, typed-error, singular-system, and backend-buffer tests.
+
+## Decisions
+
+- Added `solve_read` and `triangular_solve_read` without changing the owned methods.
+- Kept default trait implementations as explicit `Unsupported` errors; materialization policy belongs to each backend.
+- Validated dtype and CPU placement before canonicalization so zero-sized inputs and backend buffers cannot bypass the public boundary.
+- Borrowed `TensorRead::Tensor` operands directly without copying. For `TensorRead::View`, used `CpuBackend`'s existing pooled `to_contiguous` path and then the owned solve methods. This keeps shape validation, vector-RHS restoration, provider dispatch, singular detection, and output placement single-sourced.
+- Did not add CUDA overrides or any implicit CPU/GPU transfer.
+
+## Alternatives considered
+
+- Trait-level fallback to owned solves was rejected because the trait has no backend-neutral placement or materialization policy.
+- `TensorView`-only signatures were rejected because `TensorRead` is the repository-wide borrowed-input contract.
+- New Faer binary `MatRef` solve cores were deferred. Unary decompositions already have view cores, but binary solve implementations currently combine compact RHS copying, factorization, batching, and provider dispatch; separating those kernels is an independent performance refactor.
+
+## Verification
+
+- `cargo fmt --all -- --check`.
+- `cargo clippy -p tenferro-linalg --all-targets --features autodiff -- -D warnings`.
+- `python3 scripts/check-public-error-docs.py`.
+- `cargo test -p tenferro-linalg --features autodiff`: 114 unit and 148 integration tests passed.
+- `cargo test -p tenferro-linalg --doc --features autodiff`: 75 doctests passed.
+- `RUSTFLAGS='-l dylib=openblas -l dylib=lapack' cargo test -p tenferro-linalg --no-default-features --features cpu-blas --lib solve_read_accepts_owned_and_strided_inputs_for_compiled_providers`: both BLAS borrowed-solve tests passed.
+
+## Remaining risk
+
+Borrowed CPU solves currently canonicalize explicit view operands even when a future provider adapter could consume one or both views directly. Owned `TensorRead::Tensor` operands are not copied. The behavior and placement semantics are correct, but a later benchmark-backed provider refactor may remove the remaining view copies without changing the public API.


### PR DESCRIPTION
## Summary

- add `LinalgBackend::solve_read` and `triangular_solve_read` with explicit unsupported defaults
- accept owned and offset/strided `TensorRead` inputs in both CPU providers without copying owned read targets
- preserve owned/read placement, dtype, shape, vector-RHS, and singular-error behavior with regression coverage

## Issue

Closes #1267

## Design record

- [Design](https://github.com/tensor4all/tenferro-rs/blob/codex/issue-1267-read-solves/docs/superpowers/specs/2026-07-19-linalg-read-solves-design.md)
- [Worklog](https://github.com/tensor4all/tenferro-rs/blob/codex/issue-1267-read-solves/docs/worklogs/2026-07-19-issue-1267-read-solves.md)

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p tenferro-linalg --all-targets --features autodiff -- -D warnings`
- `python3 scripts/check-public-error-docs.py`
- `cargo test -p tenferro-linalg --features autodiff` (114 unit, 148 integration, 75 doctests)
- `RUSTFLAGS='-l dylib=openblas -l dylib=lapack' cargo test -p tenferro-linalg --no-default-features --features cpu-blas --lib solve_read_accepts_owned_and_strided_inputs_for_compiled_providers`

## Review

Independent pre-merge review found no remaining Critical or Important issues after placement-order, owned-read copy, and numeric-doctest fixes.
