### PR TITLE
feat: complete reduction, linalg, and FFT API surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runti
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0])?;
-    let y = (&x * &x)?.reduce_sum(&[0])?;
+    let y = (&x * &x)?.reduce_sum(Some(&[0]))?;
 
     let y_value = run(&y)?;
     assert_eq!(y_value.shape(), &[]);

--- a/crates/tenferro-ad/benches/eager_ad_transform_cache.rs
+++ b/crates/tenferro-ad/benches/eager_ad_transform_cache.rs
@@ -24,7 +24,7 @@ fn fixture() -> Fixture {
     .unwrap();
     let x2 = x.mul(&x).unwrap();
     let x3 = x2.mul(&x).unwrap();
-    let loss = x3.reduce_sum(&[0]).unwrap();
+    let loss = x3.reduce_sum(Some(&[0])).unwrap();
     Fixture { ctx, x, loss }
 }
 

--- a/crates/tenferro-ad/examples/eager_backward.rs
+++ b/crates/tenferro-ad/examples/eager_backward.rs
@@ -3,7 +3,7 @@ use tenferro_ad::{EagerRuntime, Tensor};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = EagerRuntime::new();
     let x = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?)?;
-    let loss = x.mul(&x)?.reduce_sum(&[0])?;
+    let loss = x.mul(&x)?.reduce_sum(Some(&[0]))?;
     loss.backward()?;
 
     assert_eq!(x.grad()?.unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);

--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -1093,7 +1093,7 @@ impl EagerRuntime {
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(), ctx.clone()).unwrap();
     /// let y = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]).unwrap(), ctx.clone()).unwrap();
-    /// let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
+    /// let loss = x.mul(&y).unwrap().reduce_sum(Some(&[0])).unwrap();
     /// let _ = loss.backward().unwrap();
     ///
     /// ctx.clear_grads()?;
@@ -1184,7 +1184,7 @@ impl EagerRuntime {
     ///
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let p = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap())?;
-    /// let loss = p.exp().unwrap().reduce_sum(&[0]).unwrap();
+    /// let loss = p.exp().unwrap().reduce_sum(Some(&[0])).unwrap();
     /// let _ = loss.backward().unwrap();
     ///
     /// let grad = p.grad().unwrap().unwrap();
@@ -1544,9 +1544,9 @@ fn validate_seed_tensor(op: &'static str, primal: &EagerTensor, seed: &EagerTens
 ///
 /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
 /// let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(), ctx)?;
-/// let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
+/// let loss = x.mul(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
 /// let _cotangents = loss.backward().unwrap();
-/// let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
+/// let loss = x.mul(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
 /// let _cotangents = loss.backward().unwrap();
 ///
 /// assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[4.0, 8.0, 12.0]);
@@ -1975,7 +1975,7 @@ impl EagerTensor {
     ///
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(), ctx).unwrap();
-    /// let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
+    /// let loss = x.exp().unwrap().reduce_sum(Some(&[0])).unwrap();
     /// let _cotangents = loss.backward().unwrap();
     ///
     /// let grad = x.grad()?.unwrap();
@@ -2015,7 +2015,7 @@ impl EagerTensor {
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(), ctx.clone()).unwrap();
     /// let y = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![3], vec![4.0_f64, 5.0, 6.0]).unwrap(), ctx).unwrap();
-    /// let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
+    /// let loss = x.mul(&y).unwrap().reduce_sum(Some(&[0])).unwrap();
     /// let _ = loss.backward().unwrap();
     ///
     /// x.clear_grad()?;
@@ -2226,9 +2226,9 @@ impl EagerTensor {
     ///
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap(), ctx).unwrap();
-    /// let loss = x.add(&x).unwrap().reduce_sum(&[0]).unwrap();
+    /// let loss = x.add(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
     /// let _cotangents = loss.backward().unwrap();
-    /// let loss = x.add(&x).unwrap().reduce_sum(&[0]).unwrap();
+    /// let loss = x.add(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
     /// let _cotangents = loss.backward().unwrap();
     ///
     /// assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[4.0, 4.0, 4.0]);

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -1234,7 +1234,7 @@ fn untracked_nary_ops_consume_lazy_views_without_materializing_inputs() {
         &[2.0, 6.0, 10.0, 4.0, 8.0, 12.0]
     );
 
-    let reduced = x_t.reduce_sum(&[0]).unwrap();
+    let reduced = x_t.reduce_sum(Some(&[0])).unwrap();
     assert!(!x_t.materialized_cache_is_initialized());
     assert_eq!(
         reduced.materialized().unwrap().as_slice::<f64>().unwrap(),

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -261,7 +261,7 @@ impl EagerTensor {
     ///
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(), ctx.clone()).unwrap();
-    /// let y = x.reduce_sum(&[0, 1]).unwrap();
+    /// let y = x.reduce_sum(None).unwrap();
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[10.0]);
     /// ```
@@ -271,11 +271,10 @@ impl EagerTensor {
     /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
     /// `DuplicateAxis` for an invalid reduction axis, or a typed
     /// unsupported/backend/runtime-state error for the selected dtype.
-    pub fn reduce_sum(&self, axes: &[usize]) -> Result<Self> {
-        validate_eager_axes("EagerTensor::reduce_sum", self.shape().len(), axes)?;
-        self.unary_op(StdTensorOp::ReduceSum {
-            axes: axes.to_vec(),
-        })
+    pub fn reduce_sum(&self, axes: Option<&[usize]>) -> Result<Self> {
+        let axes = axes.map_or_else(|| (0..self.shape().len()).collect(), <[usize]>::to_vec);
+        validate_eager_axes("EagerTensor::reduce_sum", self.shape().len(), &axes)?;
+        self.unary_op(StdTensorOp::ReduceSum { axes })
     }
 
     /// Execute a dot-general contraction eagerly.
@@ -988,7 +987,7 @@ impl EagerTensor {
     ///
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(), ctx.clone()).unwrap();
-    /// let y = x.reduce_prod(&[0, 1]).unwrap();
+    /// let y = x.reduce_prod(None).unwrap();
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[24.0]);
     /// ```
@@ -997,11 +996,10 @@ impl EagerTensor {
     /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
     /// `DuplicateAxis` for an invalid reduction axis, or a typed
     /// unsupported/backend/runtime-state error for the selected dtype.
-    pub fn reduce_prod(&self, axes: &[usize]) -> Result<Self> {
-        validate_eager_axes("EagerTensor::reduce_prod", self.shape().len(), axes)?;
-        self.unary_op(StdTensorOp::ReduceProd {
-            axes: axes.to_vec(),
-        })
+    pub fn reduce_prod(&self, axes: Option<&[usize]>) -> Result<Self> {
+        let axes = axes.map_or_else(|| (0..self.shape().len()).collect(), <[usize]>::to_vec);
+        validate_eager_axes("EagerTensor::reduce_prod", self.shape().len(), &axes)?;
+        self.unary_op(StdTensorOp::ReduceProd { axes })
     }
 
     /// Reduce maximum over the requested axes.
@@ -1014,7 +1012,7 @@ impl EagerTensor {
     ///
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(), ctx.clone()).unwrap();
-    /// let y = x.reduce_max(&[0, 1]).unwrap();
+    /// let y = x.reduce_max(None).unwrap();
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[4.0]);
     /// ```
@@ -1023,11 +1021,10 @@ impl EagerTensor {
     /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
     /// `DuplicateAxis` for an invalid reduction axis, or a typed
     /// unsupported/backend/runtime-state error for the selected dtype.
-    pub fn reduce_max(&self, axes: &[usize]) -> Result<Self> {
-        validate_eager_axes("EagerTensor::reduce_max", self.shape().len(), axes)?;
-        self.unary_op(StdTensorOp::ReduceMax {
-            axes: axes.to_vec(),
-        })
+    pub fn reduce_max(&self, axes: Option<&[usize]>) -> Result<Self> {
+        let axes = axes.map_or_else(|| (0..self.shape().len()).collect(), <[usize]>::to_vec);
+        validate_eager_axes("EagerTensor::reduce_max", self.shape().len(), &axes)?;
+        self.unary_op(StdTensorOp::ReduceMax { axes })
     }
 
     /// Reduce minimum over the requested axes.
@@ -1040,7 +1037,7 @@ impl EagerTensor {
     ///
     /// let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     /// let x = EagerTensor::from_tensor_in(Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(), ctx.clone()).unwrap();
-    /// let y = x.reduce_min(&[0, 1]).unwrap();
+    /// let y = x.reduce_min(None).unwrap();
     ///
     /// assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[1.0]);
     /// ```
@@ -1049,11 +1046,10 @@ impl EagerTensor {
     /// Returns [`tenferro_tensor::Error::Validation`] with `AxisOutOfBounds` or
     /// `DuplicateAxis` for an invalid reduction axis, or a typed
     /// unsupported/backend/runtime-state error for the selected dtype.
-    pub fn reduce_min(&self, axes: &[usize]) -> Result<Self> {
-        validate_eager_axes("EagerTensor::reduce_min", self.shape().len(), axes)?;
-        self.unary_op(StdTensorOp::ReduceMin {
-            axes: axes.to_vec(),
-        })
+    pub fn reduce_min(&self, axes: Option<&[usize]>) -> Result<Self> {
+        let axes = axes.map_or_else(|| (0..self.shape().len()).collect(), <[usize]>::to_vec);
+        validate_eager_axes("EagerTensor::reduce_min", self.shape().len(), &axes)?;
+        self.unary_op(StdTensorOp::ReduceMin { axes })
     }
 
     pub(crate) fn unary_op(&self, op: StdTensorOp) -> Result<Self> {

--- a/crates/tenferro-ad/tests/integration/ad.rs
+++ b/crates/tenferro-ad/tests/integration/ad.rs
@@ -863,7 +863,7 @@ fn grad_x_squared() {
     let x =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0])).unwrap();
     let y = (&x * &x).unwrap();
-    let loss = y.reduce_sum(&[0]).unwrap();
+    let loss = y.reduce_sum(Some(&[0])).unwrap();
     assert_eq!(loss.rank, 0);
     let grad = loss.grad(&x).unwrap();
 
@@ -879,7 +879,7 @@ fn grad_extract_diag_sum() {
     ))
     .unwrap();
     let diag = a.extract_diag(0, 1).unwrap();
-    let loss = diag.reduce_sum(&[0]).unwrap();
+    let loss = diag.reduce_sum(Some(&[0])).unwrap();
     assert_eq!(loss.rank, 0);
     let grad = loss.grad(&a).unwrap();
 
@@ -900,7 +900,7 @@ fn grad_extract_diag_reversed_rectangular_axes_sum() {
     .unwrap();
     let diag = a.extract_diag(1, 0).unwrap();
     assert_eq!(diag.try_concrete_shape(), Some(vec![2]));
-    let loss = diag.reduce_sum(&[0]).unwrap();
+    let loss = diag.reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&a).unwrap();
 
     let result = eval_tensor(grad);
@@ -913,7 +913,7 @@ fn grad_embed_diag_sum() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![2.0, -1.0, 4.0]))
         .unwrap();
     let diag = x.embed_diag(0, 1).unwrap();
-    let loss = diag.reduce_sum(&[0, 1]).unwrap();
+    let loss = diag.reduce_sum(Some(&[0, 1])).unwrap();
     assert_eq!(loss.rank, 0);
     let grad = loss.grad(&x).unwrap();
 
@@ -970,7 +970,7 @@ fn grad_matmul_sum() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 3], a_data.clone())).unwrap();
     let b =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], b_data.clone())).unwrap();
-    let loss = a.matmul(&b).unwrap().reduce_sum(&[0, 1]).unwrap();
+    let loss = a.matmul(&b).unwrap().reduce_sum(Some(&[0, 1])).unwrap();
     assert_eq!(loss.rank, 0);
     let grad = loss.grad(&a).unwrap();
 
@@ -982,7 +982,7 @@ fn grad_matmul_sum() {
             TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 3], xs.to_vec())).unwrap();
         let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], b_data.clone()))
             .unwrap();
-        eval_scalar(a.matmul(&b).unwrap().reduce_sum(&[0, 1]).unwrap())
+        eval_scalar(a.matmul(&b).unwrap().reduce_sum(Some(&[0, 1])).unwrap())
     };
 
     for (index, &grad_value) in grad_data.iter().enumerate().take(a_data.len()) {
@@ -1005,7 +1005,7 @@ fn grad_matmul_sum_wrt_rhs() {
     let b =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], b_data.clone())).unwrap();
     let matmul = a.dot_general(&b, matmul_config()).unwrap();
-    let loss = matmul.reduce_sum(&[0, 1]).unwrap();
+    let loss = matmul.reduce_sum(Some(&[0, 1])).unwrap();
     assert_eq!(loss.rank, 0);
     let grad = loss.grad(&b).unwrap();
 
@@ -1018,7 +1018,7 @@ fn grad_matmul_sum_wrt_rhs() {
         let b =
             TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], xs.to_vec())).unwrap();
         let matmul = a.dot_general(&b, matmul_config()).unwrap();
-        let loss = matmul.reduce_sum(&[0, 1]).unwrap();
+        let loss = matmul.reduce_sum(Some(&[0, 1])).unwrap();
         eval_scalar(loss)
     };
 
@@ -1039,7 +1039,7 @@ fn grad_matmul_sum_shared_input() {
     let a =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], a_data.clone())).unwrap();
     let matmul = a.dot_general(&a, matmul_config()).unwrap();
-    let loss = matmul.reduce_sum(&[0, 1]).unwrap();
+    let loss = matmul.reduce_sum(Some(&[0, 1])).unwrap();
     let grad = loss.grad(&a).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -1049,7 +1049,7 @@ fn grad_matmul_sum_shared_input() {
         let a =
             TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 2], xs.to_vec())).unwrap();
         let matmul = a.dot_general(&a, matmul_config()).unwrap();
-        let loss = matmul.reduce_sum(&[0, 1]).unwrap();
+        let loss = matmul.reduce_sum(Some(&[0, 1])).unwrap();
         eval_scalar(loss)
     };
 
@@ -1075,7 +1075,7 @@ fn grad_batched_matmul_sum() {
     let b = TracedTensor::from_tensor_concrete_shape(f64_tensor(b_shape.clone(), b_data.clone()))
         .unwrap();
     let product = a.dot_general(&b, batched_matmul_config()).unwrap();
-    let loss = product.reduce_sum(&[0, 1, 2]).unwrap();
+    let loss = product.reduce_sum(Some(&[0, 1, 2])).unwrap();
     let grad = loss.grad(&a).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -1088,7 +1088,7 @@ fn grad_batched_matmul_sum() {
             TracedTensor::from_tensor_concrete_shape(f64_tensor(b_shape.clone(), b_data.clone()))
                 .unwrap();
         let product = a.dot_general(&b, batched_matmul_config()).unwrap();
-        let loss = product.reduce_sum(&[0, 1, 2]).unwrap();
+        let loss = product.reduce_sum(Some(&[0, 1, 2])).unwrap();
         eval_scalar(loss)
     };
 
@@ -1108,7 +1108,7 @@ fn grad_mul_sum_wrt_both_inputs() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0])).unwrap();
     let y =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![4.0, 5.0, 6.0])).unwrap();
-    let loss = (&x * &y).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&x * &y).unwrap().reduce_sum(Some(&[0])).unwrap();
 
     let grad_x = loss.grad(&x).unwrap();
     let grad_y = loss.grad(&y).unwrap();
@@ -1171,7 +1171,7 @@ fn jvp_elementwise_add_y_tangent() {
 fn grad_neg_sum() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, -2.0, 3.0]))
         .unwrap();
-    let loss = (-&x).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (-&x).unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let result = eval_tensor(grad);
@@ -1185,7 +1185,7 @@ fn grad_conj_sum_complex() {
         vec![Complex64::new(1.0, 2.0), Complex64::new(-3.0, 0.5)],
     ))
     .unwrap();
-    let loss = x.conj().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.conj().unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let result = eval_tensor(grad);
@@ -1204,7 +1204,7 @@ fn scale_real_eval_and_grad_sum() {
     let y_eval = eval_tensor(y);
     assert_close_slice(get_f64_data(&y_eval), &[2.0, 4.0, 6.0]);
 
-    let loss = x.scale_real(2.0).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.scale_real(2.0).unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
     let grad_eval = eval_tensor(grad);
     assert_close_slice(get_f64_data(&grad_eval), &[2.0, 2.0, 2.0]);
@@ -1226,7 +1226,11 @@ fn scale_complex_eval_and_grad_complex_sum() {
         &[Complex64::new(3.5, -0.5), Complex64::new(-0.75, 4.75)],
     );
 
-    let loss = x.scale_complex(factor).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x
+        .scale_complex(factor)
+        .unwrap()
+        .reduce_sum(Some(&[0]))
+        .unwrap();
     let grad = loss.grad(&x).unwrap();
     let grad_eval = eval_tensor(grad);
     assert_close_slice_c64(get_c64_data(&grad_eval), &[factor.conj(), factor.conj()]);
@@ -2081,7 +2085,7 @@ fn grad_nonscalar_errors() {
 fn grad_full_vector_reduction() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]))
         .unwrap();
-    let loss = x.reduce_sum(&[0]).unwrap();
+    let loss = x.reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let result = eval_tensor(grad);

--- a/crates/tenferro-ad/tests/integration/ad/reductions_and_indexing.rs
+++ b/crates/tenferro-ad/tests/integration/ad/reductions_and_indexing.rs
@@ -211,7 +211,7 @@ fn grad_broadcast_reduce() {
     let x =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0])).unwrap();
     let y = x.broadcast_in_dim(&[3, 3], &[0]).unwrap();
-    let loss = y.reduce_sum(&[0, 1]).unwrap();
+    let loss = y.reduce_sum(Some(&[0, 1])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let result = eval_tensor(grad);
@@ -223,7 +223,7 @@ fn grad_broadcast_add_singleton_lhs() {
     let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![1], vec![1.0])).unwrap();
     let b =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 2.0, 3.0])).unwrap();
-    let loss = (&a + &b).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&a + &b).unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&a).unwrap();
 
     let result = eval_tensor(grad);
@@ -235,7 +235,7 @@ fn grad_reshape() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![4], vec![1.0, 2.0, 3.0, 4.0]))
         .unwrap();
     let y = x.reshape(&[2, 2]).unwrap();
-    let loss = y.reduce_sum(&[0, 1]).unwrap();
+    let loss = y.reduce_sum(Some(&[0, 1])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let result = eval_tensor(grad);
@@ -251,7 +251,7 @@ fn grad_transpose() {
     ))
     .unwrap();
     let y = a.transpose(&[1, 0]).unwrap();
-    let loss = y.reduce_sum(&[0, 1]).unwrap();
+    let loss = y.reduce_sum(Some(&[0, 1])).unwrap();
     let grad = loss.grad(&a).unwrap();
 
     let result = eval_tensor(grad);
@@ -263,7 +263,7 @@ fn grad_transpose() {
 fn grad_exp() {
     let x_data = vec![0.2, -0.7, 1.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.exp().unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -273,7 +273,7 @@ fn grad_exp() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.exp().unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.exp().unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -282,7 +282,7 @@ fn grad_exp() {
 fn grad_log() {
     let x_data = vec![0.8, 1.5, 2.4];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.log().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.log().unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -292,7 +292,7 @@ fn grad_log() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.log().unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.log().unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -303,7 +303,7 @@ fn grad_sin_cos() {
 
     let x_sin =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let sin_loss = x_sin.sin().unwrap().reduce_sum(&[0]).unwrap();
+    let sin_loss = x_sin.sin().unwrap().reduce_sum(Some(&[0])).unwrap();
     let sin_grad = sin_loss.grad(&x_sin).unwrap();
     let sin_grad_tensor = eval_tensor(sin_grad);
     let sin_grad_data = get_f64_data(&sin_grad_tensor);
@@ -312,13 +312,13 @@ fn grad_sin_cos() {
 
     let f_sin = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.sin().unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.sin().unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff(sin_grad_data, &x_data, f_sin);
 
     let x_cos =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let cos_loss = x_cos.cos().unwrap().reduce_sum(&[0]).unwrap();
+    let cos_loss = x_cos.cos().unwrap().reduce_sum(Some(&[0])).unwrap();
     let cos_grad = cos_loss.grad(&x_cos).unwrap();
     let cos_grad_tensor = eval_tensor(cos_grad);
     let cos_grad_data = get_f64_data(&cos_grad_tensor);
@@ -327,7 +327,7 @@ fn grad_sin_cos() {
 
     let f_cos = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.cos().unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.cos().unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff(cos_grad_data, &x_data, f_cos);
 }
@@ -339,7 +339,7 @@ fn grad_div() {
 
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
     let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], y_data.clone())).unwrap();
-    let loss = (&x / &y).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&x / &y).unwrap().reduce_sum(Some(&[0])).unwrap();
 
     let grad_x = loss.grad(&x).unwrap();
     let grad_y = loss.grad(&y).unwrap();
@@ -362,7 +362,7 @@ fn grad_div() {
             TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], lhs.to_vec())).unwrap();
         let y =
             TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], rhs.to_vec())).unwrap();
-        eval_scalar((&x / &y).unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar((&x / &y).unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff_lhs(grad_x_data, &x_data, &y_data, &f);
     assert_grad_matches_finite_diff_rhs(grad_y_data, &x_data, &y_data, &f);
@@ -372,7 +372,7 @@ fn grad_div() {
 fn grad_sqrt() {
     let x_data = vec![0.8, 1.5, 3.2];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.sqrt().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.sqrt().unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -382,7 +382,7 @@ fn grad_sqrt() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.sqrt().unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.sqrt().unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -391,7 +391,7 @@ fn grad_sqrt() {
 fn grad_tanh() {
     let x_data = vec![0.2, -0.7, 1.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.tanh().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.tanh().unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -401,7 +401,7 @@ fn grad_tanh() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.tanh().unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.tanh().unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -412,7 +412,7 @@ fn grad_pow() {
     let y_data = vec![2.0, 2.0, 2.0];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
     let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], y_data.clone())).unwrap();
-    let loss = x.pow(&y).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.pow(&y).unwrap().reduce_sum(Some(&[0])).unwrap();
 
     let grad_x = loss.grad(&x).unwrap();
     let grad_x_tensor = eval_tensor(grad_x);
@@ -425,7 +425,7 @@ fn grad_pow() {
             TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], lhs.to_vec())).unwrap();
         let y =
             TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], rhs.to_vec())).unwrap();
-        eval_scalar(x.pow(&y).unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.pow(&y).unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff_lhs(grad_x_data, &x_data, &y_data, &f);
 }
@@ -436,7 +436,7 @@ fn grad_pow_wrt_base_handles_zero_base_integer_exponent() {
     let y_data = vec![2.0_f64, 3.0, 4.0];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
     let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], y_data.clone())).unwrap();
-    let loss = x.pow(&y).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.pow(&y).unwrap().reduce_sum(Some(&[0])).unwrap();
 
     let grad_x = loss.grad(&x).unwrap();
     let grad_x_tensor = eval_tensor(grad_x);
@@ -449,7 +449,7 @@ fn grad_pow_wrt_base_handles_zero_base_integer_exponent() {
             TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], lhs.to_vec())).unwrap();
         let y =
             TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], rhs.to_vec())).unwrap();
-        eval_scalar(x.pow(&y).unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.pow(&y).unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff_lhs(grad_x_data, &x_data, &y_data, &f);
 }
@@ -460,7 +460,7 @@ fn grad_pow_wrt_exponent() {
     let y_data = vec![0.5, 1.5, 2.0];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
     let y = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], y_data.clone())).unwrap();
-    let loss = x.pow(&y).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.pow(&y).unwrap().reduce_sum(Some(&[0])).unwrap();
 
     let grad_y = loss.grad(&y).unwrap();
     let grad_y_tensor = eval_tensor(grad_y);
@@ -477,7 +477,7 @@ fn grad_pow_wrt_exponent() {
             TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], lhs.to_vec())).unwrap();
         let y =
             TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], rhs.to_vec())).unwrap();
-        eval_scalar(x.pow(&y).unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.pow(&y).unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff_rhs(grad_y_data, &x_data, &y_data, &f);
 }
@@ -486,7 +486,7 @@ fn grad_pow_wrt_exponent() {
 fn grad_abs() {
     let x_data = vec![-1.7, 0.8, 2.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.abs().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.abs().unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -496,7 +496,7 @@ fn grad_abs() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.abs().unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.abs().unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -505,7 +505,7 @@ fn grad_abs() {
 fn grad_sign() {
     let x_data = vec![-1.7, 0.8, 2.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.sign().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.sign().unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -514,7 +514,7 @@ fn grad_sign() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.sign().unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.sign().unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -523,7 +523,7 @@ fn grad_sign() {
 fn grad_rsqrt() {
     let x_data = vec![0.8, 1.5, 3.2];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.rsqrt().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.rsqrt().unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -533,7 +533,7 @@ fn grad_rsqrt() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.rsqrt().unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.rsqrt().unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -542,7 +542,7 @@ fn grad_rsqrt() {
 fn grad_expm1() {
     let x_data = vec![0.2, -0.7, 1.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.expm1().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.expm1().unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -552,7 +552,7 @@ fn grad_expm1() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.expm1().unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.expm1().unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -561,7 +561,7 @@ fn grad_expm1() {
 fn grad_log1p() {
     let x_data = vec![0.2, 0.7, 1.3];
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], x_data.clone())).unwrap();
-    let loss = x.log1p().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.log1p().unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let grad_tensor = eval_tensor(grad);
@@ -571,7 +571,7 @@ fn grad_log1p() {
 
     let f = |xs: &[f64]| {
         let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], xs.to_vec())).unwrap();
-        eval_scalar(x.log1p().unwrap().reduce_sum(&[0]).unwrap())
+        eval_scalar(x.log1p().unwrap().reduce_sum(Some(&[0])).unwrap())
     };
     assert_grad_matches_finite_diff(grad_data, &x_data, f);
 }
@@ -641,7 +641,10 @@ fn grad_traced_index_select_repeated_positions_accumulates() {
             .unwrap();
 
     let selected = x.index_select(0, &[1, 1, 2]).unwrap();
-    let loss = (&selected * &weights).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&selected * &weights)
+        .unwrap()
+        .reduce_sum(Some(&[0]))
+        .unwrap();
     let grad = eval_tensor(loss.grad(&x).unwrap());
 
     assert_eq!(grad.shape(), &[3]);
@@ -678,7 +681,7 @@ fn hvp_traced_index_select_repeated_positions_accumulates() {
     let selected_squared = (&selected * &selected).unwrap();
     let loss = (&selected_squared * &weights)
         .unwrap()
-        .reduce_sum(&[0])
+        .reduce_sum(Some(&[0]))
         .unwrap();
     let grad = loss.grad(&x).unwrap();
     let hvp = eval_tensor(grad.jvp(&x, &tangent).unwrap());

--- a/crates/tenferro-ad/tests/integration/ad_structural_primitives.rs
+++ b/crates/tenferro-ad/tests/integration/ad_structural_primitives.rs
@@ -78,14 +78,14 @@ fn eager_maximum_and_minimum_gradients_match_finite_diff() {
         .unwrap()
         .mul(&max_weights_tensor)
         .unwrap()
-        .reduce_sum(&[0])
+        .reduce_sum(Some(&[0]))
         .unwrap();
     let min_loss = x
         .minimum(&y)
         .unwrap()
         .mul(&min_weights_tensor)
         .unwrap()
-        .reduce_sum(&[0])
+        .reduce_sum(Some(&[0]))
         .unwrap();
     let loss = max_loss.add(&min_loss).unwrap();
     let _ = loss.backward().unwrap();
@@ -163,7 +163,7 @@ fn eager_select_gradients_match_finite_diff() {
         .unwrap()
         .mul(&weights_tensor)
         .unwrap()
-        .reduce_sum(&[0])
+        .reduce_sum(Some(&[0]))
         .unwrap();
     let _ = loss.backward().unwrap();
 
@@ -232,7 +232,7 @@ fn eager_clamp_gradients_match_finite_diff() {
         .unwrap()
         .mul(&weights_tensor)
         .unwrap()
-        .reduce_sum(&[0])
+        .reduce_sum(Some(&[0]))
         .unwrap();
     let _ = loss.backward().unwrap();
 
@@ -288,7 +288,7 @@ fn eager_extract_diag_rectangular_gradient_matches_finite_diff() {
         .unwrap()
         .mul(&weights_tensor)
         .unwrap()
-        .reduce_sum(&[0])
+        .reduce_sum(Some(&[0]))
         .unwrap();
     let _ = loss.backward().unwrap();
 
@@ -328,7 +328,7 @@ fn eager_embed_diag_shifted_axis_gradient_matches_finite_diff() {
         .unwrap()
         .mul(&weights_tensor)
         .unwrap()
-        .reduce_sum(&[0, 1, 2])
+        .reduce_sum(Some(&[0, 1, 2]))
         .unwrap();
     let _ = loss.backward().unwrap();
 
@@ -384,7 +384,7 @@ fn eager_concatenate_gradients_match_finite_diff() {
     let loss = concatenated
         .mul(&weights_tensor)
         .unwrap()
-        .reduce_sum(&[0])
+        .reduce_sum(Some(&[0]))
         .unwrap();
     let _ = loss.backward().unwrap();
 

--- a/crates/tenferro-ad/tests/integration/checkpoint_truncate_integration.rs
+++ b/crates/tenferro-ad/tests/integration/checkpoint_truncate_integration.rs
@@ -42,7 +42,7 @@ fn checkpoint_truncate_loop_grad() {
         x.checkpoint(&mut compiler, &mut executor).unwrap();
     }
 
-    let loss = x.reduce_sum(&[0]).unwrap();
+    let loss = x.reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&a).unwrap();
     let grad_value = get_f64_scalar(&grad.run_with(&mut engine).unwrap());
 

--- a/crates/tenferro-ad/tests/integration/convenience_api.rs
+++ b/crates/tenferro-ad/tests/integration/convenience_api.rs
@@ -53,9 +53,9 @@ fn traced_tensor_shape_helpers_and_aliases_cover_public_surface() {
     assert_eq!(broad.rank, 3);
 
     assert_eq!(a.broadcast_in_dim(&[2, 3], &[0, 1]).unwrap().rank, 2);
-    assert_eq!(a.reduce_max(&[0]).unwrap().rank, 1);
-    assert_eq!(a.reduce_min(&[1]).unwrap().rank, 1);
-    assert_eq!(a.reduce_prod(&[0, 1]).unwrap().rank, 0);
+    assert_eq!(a.reduce_max(Some(&[0])).unwrap().rank, 1);
+    assert_eq!(a.reduce_min(Some(&[1])).unwrap().rank, 1);
+    assert_eq!(a.reduce_prod(Some(&[0, 1])).unwrap().rank, 0);
 }
 
 #[test]

--- a/crates/tenferro-ad/tests/integration/dynamic_truncate.rs
+++ b/crates/tenferro-ad/tests/integration/dynamic_truncate.rs
@@ -217,7 +217,10 @@ fn dynamic_truncate_vjp_correct() {
     let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0)).unwrap();
 
     let truncated = x.dynamic_truncate(&size, 0).unwrap();
-    let loss = (&truncated * &truncated).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&truncated * &truncated)
+        .unwrap()
+        .reduce_sum(Some(&[0]))
+        .unwrap();
 
     let grad = loss.grad(&x).unwrap();
     let grad_data = get_f64_data(&grad.run_with(&mut engine).unwrap());
@@ -235,7 +238,10 @@ fn dynamic_truncate_jvp_correct() {
     let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0)).unwrap();
 
     let truncated = x.dynamic_truncate(&size, 0).unwrap();
-    let loss = (&truncated * &truncated).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&truncated * &truncated)
+        .unwrap()
+        .reduce_sum(Some(&[0]))
+        .unwrap();
 
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![1.0; 5])).unwrap();
     let jvp_result = loss.jvp(&x, &v).unwrap();
@@ -257,7 +263,10 @@ fn dynamic_truncate_hvp_correct() {
     .unwrap();
     let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0)).unwrap();
     let truncated = x.dynamic_truncate(&size, 0).unwrap();
-    let loss = (&truncated * &truncated).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&truncated * &truncated)
+        .unwrap()
+        .reduce_sum(Some(&[0]))
+        .unwrap();
 
     let grad = loss.grad(&x).unwrap();
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![1.0; 5])).unwrap();
@@ -287,7 +296,10 @@ fn dynamic_truncate_hvp_finite_diff() {
             TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], values.to_vec())).unwrap();
         let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0)).unwrap();
         let truncated = x.dynamic_truncate(&size, 0).unwrap();
-        let loss = (&truncated * &truncated).unwrap().reduce_sum(&[0]).unwrap();
+        let loss = (&truncated * &truncated)
+            .unwrap()
+            .reduce_sum(Some(&[0]))
+            .unwrap();
         let grad = loss.grad(&x).unwrap();
         get_f64_data(&grad.run_with(&mut engine).unwrap())
     };
@@ -310,7 +322,10 @@ fn dynamic_truncate_hvp_finite_diff() {
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], x_data)).unwrap();
     let size = TracedTensor::from_tensor_concrete_shape(f64_scalar(3.0)).unwrap();
     let truncated = x.dynamic_truncate(&size, 0).unwrap();
-    let loss = (&truncated * &truncated).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&truncated * &truncated)
+        .unwrap()
+        .reduce_sum(Some(&[0]))
+        .unwrap();
     let grad = loss.grad(&x).unwrap();
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], v_data)).unwrap();
     let hv = grad.jvp(&x, &v).unwrap();
@@ -340,7 +355,7 @@ fn pad_to_match_vjp_correct() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![0.0; 5])).unwrap();
 
     let padded = x.pad_to_match(&reference, 0).unwrap();
-    let loss = (&padded * &padded).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&padded * &padded).unwrap().reduce_sum(Some(&[0])).unwrap();
 
     let grad = loss.grad(&x).unwrap();
     let grad_data = get_f64_data(&grad.run_with(&mut engine).unwrap());
@@ -356,7 +371,7 @@ fn pad_to_match_jvp_correct() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![0.0; 5])).unwrap();
 
     let padded = x.pad_to_match(&reference, 0).unwrap();
-    let loss = (&padded * &padded).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&padded * &padded).unwrap().reduce_sum(Some(&[0])).unwrap();
 
     let v =
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3], vec![1.0, 1.0, 1.0])).unwrap();
@@ -377,7 +392,7 @@ fn pad_to_match_hvp_correct() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![5], vec![0.0; 5])).unwrap();
 
     let padded = x.pad_to_match(&reference, 0).unwrap();
-    let loss = (&padded * &padded).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&padded * &padded).unwrap().reduce_sum(Some(&[0])).unwrap();
 
     let grad = loss.grad(&x).unwrap();
     let v =

--- a/crates/tenferro-ad/tests/integration/eager_fixed_pivot_cross.rs
+++ b/crates/tenferro-ad/tests/integration/eager_fixed_pivot_cross.rs
@@ -98,7 +98,11 @@ fn take_block_backward_accumulates_to_source() {
     .unwrap();
 
     let block = x.take_block(&[2, 0, 2], &[3, 1]).unwrap();
-    let loss = block.mul(&weights).unwrap().reduce_sum(&[0, 1]).unwrap();
+    let loss = block
+        .mul(&weights)
+        .unwrap()
+        .reduce_sum(Some(&[0, 1]))
+        .unwrap();
     let _ = loss.backward().unwrap();
 
     assert_close_slice(

--- a/crates/tenferro-ad/tests/integration/eager_runtime_api.rs
+++ b/crates/tenferro-ad/tests/integration/eager_runtime_api.rs
@@ -12,7 +12,7 @@ fn eager_runtime_replaces_eager_context_public_name() {
         runtime.clone(),
     )
     .unwrap();
-    let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
 
     loss.backward().unwrap();
 

--- a/crates/tenferro-ad/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-ad/tests/integration/eager_tensor.rs
@@ -103,7 +103,7 @@ fn eager_matmul_sum(lhs: &[f64], rhs: &[f64]) -> f64 {
     let loss = a
         .dot_general(&b, matmul_config())
         .unwrap()
-        .reduce_sum(&[0, 1])
+        .reduce_sum(Some(&[0, 1]))
         .unwrap();
     f64_data(loss.materialized().unwrap().as_ref())[0]
 }
@@ -241,7 +241,7 @@ fn eager_reductions_and_reverse_validate_axes_before_ad_recording() {
     )
     .unwrap();
 
-    let out_of_bounds = x.reduce_sum(&[2]).unwrap_err();
+    let out_of_bounds = x.reduce_sum(Some(&[2])).unwrap_err();
     assert!(matches!(
         out_of_bounds,
         tenferro_ad::Error::TensorRuntime(tenferro_tensor::Error::Validation {
@@ -251,10 +251,10 @@ fn eager_reductions_and_reverse_validate_axes_before_ad_recording() {
     ));
 
     for err in [
-        x.reduce_sum(&[0, 0]).unwrap_err(),
-        x.reduce_prod(&[0, 0]).unwrap_err(),
-        x.reduce_max(&[0, 0]).unwrap_err(),
-        x.reduce_min(&[0, 0]).unwrap_err(),
+        x.reduce_sum(Some(&[0, 0])).unwrap_err(),
+        x.reduce_prod(Some(&[0, 0])).unwrap_err(),
+        x.reduce_max(Some(&[0, 0])).unwrap_err(),
+        x.reduce_min(Some(&[0, 0])).unwrap_err(),
         x.reverse(&[0, 0]).unwrap_err(),
     ] {
         assert!(
@@ -305,7 +305,7 @@ fn untracked_eager_intermediate_can_later_feed_tracked_ad() {
         ctx,
     )
     .unwrap();
-    let loss = x.mul(&scale).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&scale).unwrap().reduce_sum(Some(&[0])).unwrap();
     let _ = loss.backward().unwrap();
 
     assert_close_slice(
@@ -456,7 +456,7 @@ fn eager_scalar_scaling_matches_traced_dtype_semantics() {
     tracked
         .scale_real(2.5)
         .unwrap()
-        .reduce_sum(&[0])
+        .reduce_sum(Some(&[0]))
         .unwrap()
         .backward()
         .unwrap();
@@ -673,7 +673,11 @@ fn eager_index_select_repeated_positions_accumulates_grad() {
     .unwrap();
 
     let selected = x.index_select(0, &[1, 1, 2]).unwrap();
-    let loss = selected.mul(&weights).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = selected
+        .mul(&weights)
+        .unwrap()
+        .reduce_sum(Some(&[0]))
+        .unwrap();
     let _ = loss.backward().unwrap();
 
     assert_close_slice(
@@ -691,7 +695,7 @@ fn eager_x_squared_gradient_matches_finite_difference() {
         test_ctx(),
     )
     .unwrap();
-    let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
     let _cotangents = loss.backward().unwrap();
     let grad = x.grad().unwrap().unwrap();
 
@@ -716,7 +720,7 @@ fn eager_repeated_backward_accumulates_across_calls() {
     )
     .unwrap();
 
-    let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
     let _ = loss.backward().unwrap();
     assert_close_slice(
         f64_data(x.grad().unwrap().unwrap().as_ref()),
@@ -724,7 +728,7 @@ fn eager_repeated_backward_accumulates_across_calls() {
         TOL,
     );
 
-    let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
     let _ = loss.backward().unwrap();
     assert_close_slice(
         f64_data(x.grad().unwrap().unwrap().as_ref()),
@@ -751,7 +755,7 @@ fn eager_matmul_gradients_match_finite_difference() {
     let loss = a
         .dot_general(&b, matmul_config())
         .unwrap()
-        .reduce_sum(&[0, 1])
+        .reduce_sum(Some(&[0, 1]))
         .unwrap();
     let _cotangents = loss.backward().unwrap();
 
@@ -778,7 +782,7 @@ fn eager_exp_gradient_matches_primal() {
         test_ctx(),
     )
     .unwrap();
-    let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.exp().unwrap().reduce_sum(Some(&[0])).unwrap();
     let _cotangents = loss.backward().unwrap();
 
     let grad = x.grad().unwrap().unwrap();
@@ -793,7 +797,7 @@ fn eager_fan_out_accumulates_gradient() {
         test_ctx(),
     )
     .unwrap();
-    let loss = x.add(&x).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.add(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
     let _cotangents = loss.backward().unwrap();
 
     let grad = x.grad().unwrap().unwrap();
@@ -814,7 +818,7 @@ fn eager_clear_grad_resets_only_one_leaf() {
     )
     .unwrap();
 
-    let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&y).unwrap().reduce_sum(Some(&[0])).unwrap();
     let _ = loss.backward().unwrap();
 
     x.clear_grad().unwrap();
@@ -826,7 +830,7 @@ fn eager_clear_grad_resets_only_one_leaf() {
         TOL,
     );
 
-    let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
     let _ = loss.backward().unwrap();
 
     assert_close_slice(
@@ -855,7 +859,7 @@ fn eager_context_clear_grads_resets_all_live_leaves() {
     )
     .unwrap();
 
-    let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&y).unwrap().reduce_sum(Some(&[0])).unwrap();
     let _ = loss.backward().unwrap();
 
     ctx.clear_grads().unwrap();
@@ -863,7 +867,7 @@ fn eager_context_clear_grads_resets_all_live_leaves() {
     assert!(x.grad().unwrap().is_none());
     assert!(y.grad().unwrap().is_none());
 
-    let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&y).unwrap().reduce_sum(Some(&[0])).unwrap();
     let _ = loss.backward().unwrap();
 
     assert_close_slice(
@@ -892,7 +896,7 @@ fn eager_unrelated_backward_keeps_existing_leaf_grad() {
     )
     .unwrap();
 
-    let loss_x = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
+    let loss_x = x.mul(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
     let _ = loss_x.backward().unwrap();
     assert_close_slice(
         f64_data(x.grad().unwrap().unwrap().as_ref()),
@@ -900,7 +904,7 @@ fn eager_unrelated_backward_keeps_existing_leaf_grad() {
         TOL,
     );
 
-    let loss_y = y.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
+    let loss_y = y.mul(&y).unwrap().reduce_sum(Some(&[0])).unwrap();
     let _ = loss_y.backward().unwrap();
 
     assert_close_slice(
@@ -950,7 +954,7 @@ fn eager_context_and_tensor_are_backend_erased_public_types() {
     let x = ctx
         .variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap())
         .unwrap();
-    let loss = x.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.mul(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
     loss.backward().unwrap();
 
     assert_eq!(
@@ -967,7 +971,7 @@ fn eager_detach_cuts_one_gradient_path() {
     )
     .unwrap();
     let detached = x.detach();
-    let loss = detached.mul(&x).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = detached.mul(&x).unwrap().reduce_sum(Some(&[0])).unwrap();
     let _cotangents = loss.backward().unwrap();
 
     let grad = x.grad().unwrap().unwrap();
@@ -1068,7 +1072,7 @@ fn eager_tracked_structural_ops_return_lazy_views_and_backprop() {
         other => panic!("expected tracked transpose to remain a lazy f64 view, got {other:?}"),
     }
 
-    let loss = transposed.reduce_sum(&[0, 1]).unwrap();
+    let loss = transposed.reduce_sum(Some(&[0, 1])).unwrap();
     let _cotangents = loss.backward().unwrap();
     let grad = x.grad().unwrap().unwrap();
     assert_close_slice(f64_data(grad.as_ref()), &[1.0; 6], TOL);
@@ -1154,18 +1158,72 @@ fn eager_reduction_primal_ops_reduce_prod() {
     )
     .unwrap();
 
-    let prod = x.reduce_prod(&[0, 1]).unwrap();
+    let prod = x.reduce_prod(Some(&[0, 1])).unwrap();
     assert_close_slice(
         f64_data(prod.materialized().unwrap().as_ref()),
         &[24.0],
         TOL,
     );
 
-    let max = x.reduce_max(&[0, 1]).unwrap();
+    let max = x.reduce_max(Some(&[0, 1])).unwrap();
     assert_close_slice(f64_data(max.materialized().unwrap().as_ref()), &[4.0], TOL);
 
-    let min = x.reduce_min(&[0, 1]).unwrap();
+    let min = x.reduce_min(Some(&[0, 1])).unwrap();
     assert_close_slice(f64_data(min.materialized().unwrap().as_ref()), &[1.0], TOL);
+}
+
+#[test]
+fn eager_reductions_distinguish_all_axes_from_empty_axes() {
+    let x = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
+        test_ctx(),
+    )
+    .unwrap();
+
+    let sum = x.reduce_sum(None).unwrap();
+    assert_close_slice(f64_data(sum.materialized().unwrap().as_ref()), &[10.0], TOL);
+
+    let product = x.reduce_prod(None).unwrap();
+    assert_close_slice(
+        f64_data(product.materialized().unwrap().as_ref()),
+        &[24.0],
+        TOL,
+    );
+
+    let identity = x.reduce_sum(Some(&[])).unwrap();
+    assert_eq!(identity.shape(), &[2, 2]);
+    assert_close_slice(
+        f64_data(identity.materialized().unwrap().as_ref()),
+        &[1.0, 2.0, 3.0, 4.0],
+        TOL,
+    );
+
+    let column_maxima = x.reduce_max(Some(&[0])).unwrap();
+    assert_close_slice(
+        f64_data(column_maxima.materialized().unwrap().as_ref()),
+        &[2.0, 4.0],
+        TOL,
+    );
+
+    let row_minima = x.reduce_min(Some(&[1])).unwrap();
+    assert_close_slice(
+        f64_data(row_minima.materialized().unwrap().as_ref()),
+        &[1.0, 2.0],
+        TOL,
+    );
+
+    let scalar = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap(),
+        test_ctx(),
+    )
+    .unwrap();
+    let scalar_sum = scalar.reduce_sum(None).unwrap();
+    assert_eq!(scalar_sum.shape(), &[]);
+    assert_close_slice(
+        f64_data(scalar_sum.materialized().unwrap().as_ref()),
+        &[3.0],
+        TOL,
+    );
 }
 
 #[test]

--- a/crates/tenferro-ad/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-ad/tests/integration/eager_tensor.rs
@@ -1218,7 +1218,7 @@ fn eager_reductions_distinguish_all_axes_from_empty_axes() {
     )
     .unwrap();
     let scalar_sum = scalar.reduce_sum(None).unwrap();
-    assert_eq!(scalar_sum.shape(), &[]);
+    assert_eq!(scalar_sum.shape(), &[] as &[usize]);
     assert_close_slice(
         f64_data(scalar_sum.materialized().unwrap().as_ref()),
         &[3.0],

--- a/crates/tenferro-ad/tests/integration/eager_tensor/context_and_promotion.rs
+++ b/crates/tenferro-ad/tests/integration/eager_tensor/context_and_promotion.rs
@@ -62,7 +62,7 @@ fn variable_from_creates_tracked_leaf() {
     assert_eq!(p.ctx_id(), ctx.id());
     assert!(p.tracks_grad());
     // backward should work on a tracked variable
-    let loss = p.exp().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = p.exp().unwrap().reduce_sum(Some(&[0])).unwrap();
     let _ = loss.backward().unwrap();
     assert!(p.grad().unwrap().is_some());
 }
@@ -180,7 +180,7 @@ fn detach_into_still_accessible_in_original_context() {
     .unwrap();
     let d = x.detach_into(&ctx_b).unwrap();
     // Original tensor still in ctx_a, should work fine
-    let loss = x.exp().unwrap().reduce_sum(&[0]).unwrap();
+    let loss = x.exp().unwrap().reduce_sum(Some(&[0])).unwrap();
     let _ = loss.backward().unwrap();
     assert!(x.grad().unwrap().is_some());
     // d is in ctx_b, x is in ctx_a

--- a/crates/tenferro-ad/tests/integration/extension_op.rs
+++ b/crates/tenferro-ad/tests/integration/extension_op.rs
@@ -1413,7 +1413,7 @@ fn scale_by_2_grad_against_reduce_sum() {
         .into_iter()
         .next()
         .unwrap();
-    let loss = scaled.reduce_sum(&[0]).unwrap();
+    let loss = scaled.reduce_sum(Some(&[0])).unwrap();
 
     let g = scale_by_2_ad_context().grad(&loss, &x).expect("grad build");
     assert!(
@@ -1442,7 +1442,7 @@ fn scale_by_2_eager_backward_uses_registered_rule() {
         .into_iter()
         .next()
         .expect("single extension output");
-    let loss = scaled.reduce_sum(&[0]).expect("loss");
+    let loss = scaled.reduce_sum(Some(&[0])).expect("loss");
 
     let _ = loss.backward().expect("eager backward");
 
@@ -1460,7 +1460,7 @@ fn ad_context_uses_owned_extension_rules_without_global_fallback() {
         .into_iter()
         .next()
         .unwrap();
-    let loss = scaled.reduce_sum(&[0]).unwrap();
+    let loss = scaled.reduce_sum(Some(&[0])).unwrap();
 
     let empty_ad = AdContext::builder().build().unwrap();
     let err = match empty_ad.grad(&loss, &x) {
@@ -1569,7 +1569,7 @@ fn traced_vjp_falls_back_to_primary_transpose_when_linearize_fails() {
         .expect("single primary_transpose_only output");
     let squared = (&y * &y).unwrap();
     let observable = (&squared + &y).unwrap();
-    let loss = observable.reduce_sum(&[0]).unwrap();
+    let loss = observable.reduce_sum(Some(&[0])).unwrap();
 
     let grad = primary_transpose_only_ad_context()
         .grad(&loss, &x)
@@ -1590,7 +1590,7 @@ fn traced_vjp_primary_transpose_fallback_reports_inactive_wrt() {
         .into_iter()
         .next()
         .expect("single primary_transpose_only output");
-    let loss = y.reduce_sum(&[0]).unwrap();
+    let loss = y.reduce_sum(Some(&[0])).unwrap();
 
     let grad = primary_transpose_only_ad_context()
         .grad_optional(&loss, &z)
@@ -1633,7 +1633,7 @@ fn eager_runtime_ad_context_uses_owned_extension_rules_without_global_fallback()
         .into_iter()
         .next()
         .expect("single extension output");
-    let loss = scaled.reduce_sum(&[0]).expect("loss");
+    let loss = scaled.reduce_sum(Some(&[0])).expect("loss");
     let err = loss
         .backward()
         .expect_err("explicit empty rule set should not use global fallback");
@@ -1656,7 +1656,7 @@ fn eager_runtime_ad_context_uses_owned_extension_rules_without_global_fallback()
         .into_iter()
         .next()
         .expect("single extension output");
-    let loss = scaled.reduce_sum(&[0]).expect("loss");
+    let loss = scaled.reduce_sum(Some(&[0])).expect("loss");
 
     let _ = loss.backward().expect("eager backward");
 
@@ -1683,7 +1683,7 @@ fn assert_probe_identity_eager_backward(probe: Tensor) {
         .into_iter()
         .next()
         .expect("single probe identity output");
-    let loss = y.reduce_sum(&[0]).expect("loss");
+    let loss = y.reduce_sum(Some(&[0])).expect("loss");
 
     let _ = loss.backward().expect("eager backward");
 
@@ -1731,7 +1731,7 @@ fn missing_extension_rule_errors_in_traced_grad() {
         .into_iter()
         .next()
         .expect("single output");
-    let loss = y.reduce_sum(&[0]).unwrap();
+    let loss = y.reduce_sum(Some(&[0])).unwrap();
 
     let err = match loss.grad(&x) {
         Ok(_) => panic!("missing extension AD rule unexpectedly succeeded"),
@@ -1761,7 +1761,7 @@ fn missing_extension_rule_errors_in_eager_backward() {
         .into_iter()
         .next()
         .expect("single output");
-    let loss = y.reduce_sum(&[0]).expect("loss");
+    let loss = y.reduce_sum(Some(&[0])).expect("loss");
 
     let err = loss
         .backward()

--- a/crates/tenferro-ad/tests/integration/extension_op/api_and_registry.rs
+++ b/crates/tenferro-ad/tests/integration/extension_op/api_and_registry.rs
@@ -202,7 +202,7 @@ fn scale_by_2_grad_through_symbolic_placeholder() {
         .into_iter()
         .next()
         .unwrap();
-    let loss = scaled.reduce_sum(&[0]).unwrap();
+    let loss = scaled.reduce_sum(Some(&[0])).unwrap();
 
     let g = scale_by_2_ad_context().grad(&loss, &x).expect("grad build");
     let bound =
@@ -253,7 +253,7 @@ fn swap_grad_routes_cotangents_across_inputs() {
     let out0 = iter.next().unwrap();
     let out1 = iter.next().unwrap();
     let combined = (&out0 + &out1).unwrap();
-    let loss = combined.reduce_sum(&[0]).unwrap();
+    let loss = combined.reduce_sum(Some(&[0])).unwrap();
 
     let ad = swap_ad_context();
     let grad_a = ad.grad(&loss, &a).expect("grad a");
@@ -277,7 +277,7 @@ fn swap_grad_routes_only_through_active_output() {
     let mut iter = swapped.into_iter();
     let _out0 = iter.next().unwrap();
     let out1 = iter.next().unwrap();
-    let loss = out1.reduce_sum(&[0]).unwrap();
+    let loss = out1.reduce_sum(Some(&[0])).unwrap();
 
     let ad = swap_ad_context();
     let grad_a = ad.grad(&loss, &a).expect("grad a");

--- a/crates/tenferro-ad/tests/integration/fallible_api.rs
+++ b/crates/tenferro-ad/tests/integration/fallible_api.rs
@@ -44,19 +44,19 @@ fn eager_axis_ops_validate_before_recording_source_contract() {
 
     for (method, op_variant) in [
         (
-            "pub fn reduce_sum(&self, axes: &[usize])",
+            "pub fn reduce_sum(&self, axes: Option<&[usize]>)",
             "StdTensorOp::ReduceSum",
         ),
         (
-            "pub fn reduce_prod(&self, axes: &[usize])",
+            "pub fn reduce_prod(&self, axes: Option<&[usize]>)",
             "StdTensorOp::ReduceProd",
         ),
         (
-            "pub fn reduce_max(&self, axes: &[usize])",
+            "pub fn reduce_max(&self, axes: Option<&[usize]>)",
             "StdTensorOp::ReduceMax",
         ),
         (
-            "pub fn reduce_min(&self, axes: &[usize])",
+            "pub fn reduce_min(&self, axes: Option<&[usize]>)",
             "StdTensorOp::ReduceMin",
         ),
         (

--- a/crates/tenferro-ad/tests/integration/graph_executor.rs
+++ b/crates/tenferro-ad/tests/integration/graph_executor.rs
@@ -236,7 +236,7 @@ fn graph_executor_runtime_cache_controls_are_available() {
 #[test]
 fn graph_executor_synthesizes_deferred_zero_tangents_from_primal_binding() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
-    let loss = (&x * &x).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&x * &x).unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let mut compiler = GraphCompiler::new();
@@ -255,7 +255,7 @@ fn graph_executor_synthesizes_deferred_zero_tangents_from_primal_binding() {
 #[test]
 fn graph_executor_synthesizes_deferred_zero_tangents_from_borrowed_primal_binding() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
-    let loss = (&x * &x).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&x * &x).unwrap().reduce_sum(Some(&[0])).unwrap();
     let grad = loss.grad(&x).unwrap();
 
     let mut compiler = GraphCompiler::new();

--- a/crates/tenferro-ad/tests/integration/hvp.rs
+++ b/crates/tenferro-ad/tests/integration/hvp.rs
@@ -137,7 +137,7 @@ fn hvp_for_vector_exp_sum() {
     let n = x_data.len();
 
     let x = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![n], x_data.clone())).unwrap();
-    let y = x.exp().unwrap().reduce_sum(&[0]).unwrap();
+    let y = x.exp().unwrap().reduce_sum(Some(&[0])).unwrap();
 
     let g = y.grad(&x).unwrap(); // shape [n]
     let v = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![n], v_data.clone())).unwrap();

--- a/crates/tenferro-ad/tests/integration/primitive_ops.rs
+++ b/crates/tenferro-ad/tests/integration/primitive_ops.rs
@@ -190,7 +190,7 @@ fn test_broadcast_reduce() {
     let v = f64_tensor(vec![3], vec![1.0, 2.0, 3.0]);
     let tv = TracedTensor::from_tensor_concrete_shape(v).unwrap();
     let tb = tv.broadcast_in_dim(&[3, 2], &[0]).unwrap();
-    let tr = tb.reduce_sum(&[1]).unwrap();
+    let tr = tb.reduce_sum(Some(&[1])).unwrap();
     let mut engine = GraphExecutor::new(CpuBackend::new());
     let result = tr.run_with(&mut engine).unwrap();
     assert_eq!(get_f64_data(&result), &[2.0, 4.0, 6.0]);

--- a/crates/tenferro-ad/tests/integration/symbolic_grad.rs
+++ b/crates/tenferro-ad/tests/integration/symbolic_grad.rs
@@ -28,7 +28,7 @@ fn grad_of_sum_of_squares_against_symbolic_input() {
     // f(x) = sum(x * x), df/dx = 2 * x
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
     let sq = (&x * &x).unwrap();
-    let loss = sq.reduce_sum(&[0]).unwrap();
+    let loss = sq.reduce_sum(Some(&[0])).unwrap();
 
     let g = loss.grad(&x).expect("grad build");
 
@@ -47,7 +47,7 @@ fn grad_evaluates_with_different_shapes_from_same_symbolic_graph() {
     // Same symbolic grad graph, eval with shape [3] then shape [5].
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
     let sq = (&x * &x).unwrap();
-    let loss = sq.reduce_sum(&[0]).unwrap();
+    let loss = sq.reduce_sum(Some(&[0])).unwrap();
     let g_template = loss.grad(&x).expect("grad build");
 
     let mut engine = GraphExecutor::new(CpuBackend::new());
@@ -73,7 +73,7 @@ fn grad_of_dot_product_against_two_symbolic_inputs() {
     // df/da = b, df/db = a
     let a = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
     let b = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
-    let loss = (&a * &b).unwrap().reduce_sum(&[0]).unwrap();
+    let loss = (&a * &b).unwrap().reduce_sum(Some(&[0])).unwrap();
 
     let grad_a = loss.grad(&a).expect("grad a");
     let grad_b = loss.grad(&b).expect("grad b");
@@ -98,7 +98,7 @@ fn grad_with_concrete_shape_placeholder() {
     // input_concrete_shape placeholder works for AD too.
     let x = TracedTensor::input_concrete_shape(DType::F64, &[3]).unwrap();
     let sq = (&x * &x).unwrap();
-    let loss = sq.reduce_sum(&[0]).unwrap();
+    let loss = sq.reduce_sum(Some(&[0])).unwrap();
     let g = loss.grad(&x).expect("grad build");
 
     let mut engine = GraphExecutor::new(CpuBackend::new());

--- a/crates/tenferro-einsum/src/eager_ad/tests.rs
+++ b/crates/tenferro-einsum/src/eager_ad/tests.rs
@@ -222,7 +222,7 @@ fn nary_eager_einsum_expanded_standard_ops_preserve_backward() {
 
     let loss = einsum(&[&a, &b, &c], "ij,jk,kl->il")
         .unwrap()
-        .reduce_sum(&[0, 1])
+        .reduce_sum(Some(&[0, 1]))
         .unwrap();
     let _ = loss.backward().unwrap();
 
@@ -254,7 +254,7 @@ fn tracked_nary_einsum_gradients_match_expected_values() {
     let out = einsum(&[&a, &b, &c], "ij,jk,kl->il").unwrap();
     assert_eq!(out.shape(), &[2, 5]);
 
-    let loss = out.reduce_sum(&[0, 1]).unwrap();
+    let loss = out.reduce_sum(Some(&[0, 1])).unwrap();
     let _ = loss.backward().unwrap();
 
     assert_eq!(

--- a/crates/tenferro-einsum/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-einsum/tests/integration/eager_tensor.rs
@@ -233,7 +233,7 @@ fn eager_tensor_einsum_backward_populates_input_grads() {
     .unwrap();
 
     let c = [&a, &b].einsum("ij,jk->ik").unwrap();
-    let loss = c.reduce_sum(&[0, 1]).unwrap();
+    let loss = c.reduce_sum(Some(&[0, 1])).unwrap();
     let _cotangents = loss.backward().unwrap();
 
     let grad_a = a.grad().unwrap().unwrap();
@@ -260,7 +260,7 @@ fn eager_tensor_einsum_repeated_backward_accumulates_across_calls() {
     .unwrap();
 
     let c = [&a, &b].einsum("ij,jk->ik").unwrap();
-    let loss = c.reduce_sum(&[0, 1]).unwrap();
+    let loss = c.reduce_sum(Some(&[0, 1])).unwrap();
     let _ = loss.backward().unwrap();
     assert_eq!(
         f64_data(a.grad().unwrap().unwrap().as_ref()),
@@ -272,7 +272,7 @@ fn eager_tensor_einsum_repeated_backward_accumulates_across_calls() {
     );
 
     let c = [&a, &b].einsum("ij,jk->ik").unwrap();
-    let loss = c.reduce_sum(&[0, 1]).unwrap();
+    let loss = c.reduce_sum(Some(&[0, 1])).unwrap();
     let _ = loss.backward().unwrap();
     assert_eq!(
         f64_data(a.grad().unwrap().unwrap().as_ref()),
@@ -299,7 +299,7 @@ fn eager_tensor_einsum_context_clear_grads_resets_all_live_leaves() {
     .unwrap();
 
     let c = [&a, &b].einsum("ij,jk->ik").unwrap();
-    let loss = c.reduce_sum(&[0, 1]).unwrap();
+    let loss = c.reduce_sum(Some(&[0, 1])).unwrap();
     let _ = loss.backward().unwrap();
 
     ctx.clear_grads().unwrap();
@@ -308,7 +308,7 @@ fn eager_tensor_einsum_context_clear_grads_resets_all_live_leaves() {
     assert!(b.grad().unwrap().is_none());
 
     let c = [&a, &b].einsum("ij,jk->ik").unwrap();
-    let loss = c.reduce_sum(&[0, 1]).unwrap();
+    let loss = c.reduce_sum(Some(&[0, 1])).unwrap();
     let _ = loss.backward().unwrap();
 
     assert_eq!(

--- a/crates/tenferro-einsum/tests/integration/traced_ad_migration.rs
+++ b/crates/tenferro-einsum/tests/integration/traced_ad_migration.rs
@@ -104,7 +104,7 @@ fn grad_einsum_matmul_real_uses_extension_ad_rule() {
     let y = compiler
         .einsum_with(&[&a, &b], "ij,jk->ik", EinsumOptimize::Path(vec![(0, 1)]))
         .unwrap();
-    let grad_a = y.reduce_sum(&[0, 1]).unwrap().grad(&a).unwrap();
+    let grad_a = y.reduce_sum(Some(&[0, 1])).unwrap().grad(&a).unwrap();
     let result = run_traced(&grad_a);
 
     assert_eq!(result.shape(), &[2, 3]);
@@ -127,7 +127,7 @@ fn grad_einsum_matmul_real_matches_finite_diff_for_both_inputs() {
     let y = compiler
         .einsum_with(&[&a, &b], "ij,jk->ik", EinsumOptimize::Path(vec![(0, 1)]))
         .unwrap();
-    let loss = y.reduce_sum(&[0, 1]).unwrap();
+    let loss = y.reduce_sum(Some(&[0, 1])).unwrap();
     let grad_a = run_traced(&loss.grad(&a).unwrap());
     let grad_b = run_traced(&loss.grad(&b).unwrap());
 
@@ -140,7 +140,7 @@ fn grad_einsum_matmul_real_matches_finite_diff_for_both_inputs() {
         let y = compiler
             .einsum_with(&[&a, &b], "ij,jk->ik", EinsumOptimize::Path(vec![(0, 1)]))
             .unwrap();
-        run_traced(&y.reduce_sum(&[0, 1]).unwrap())
+        run_traced(&y.reduce_sum(Some(&[0, 1])).unwrap())
             .as_slice::<f64>()
             .unwrap()[0]
     };
@@ -175,7 +175,7 @@ fn symbolic_grad_einsum_with_explicit_path_uses_extension_ad_rule() {
             tenferro_einsum::EinsumOptimize::Path(vec![(1, 2), (0, 1)]),
         )
         .unwrap();
-    let loss = y.reduce_sum(&[0, 1]).unwrap();
+    let loss = y.reduce_sum(Some(&[0, 1])).unwrap();
     let grad_a = loss.grad(&a).unwrap();
     let grad_b = loss.grad(&b).unwrap();
     let grad_c = loss.grad(&c).unwrap();

--- a/crates/tenferro-einsum/tests/integration/traced_extension.rs
+++ b/crates/tenferro-einsum/tests/integration/traced_extension.rs
@@ -190,7 +190,7 @@ fn traced_einsum_grad_uses_extension_ad_rule() {
             tenferro_einsum::EinsumOptimize::Path(vec![(0, 1)]),
         )
         .unwrap();
-    let grad_a = y.reduce_sum(&[0, 1]).unwrap().grad(&a).unwrap();
+    let grad_a = y.reduce_sum(Some(&[0, 1])).unwrap().grad(&a).unwrap();
     let program = compiler.compile(&grad_a).unwrap();
 
     let mut executor = GraphExecutor::new(CpuBackend::new());

--- a/crates/tenferro-fft/src/eager_ext.rs
+++ b/crates/tenferro-fft/src/eager_ext.rs
@@ -1,0 +1,205 @@
+use std::sync::Arc;
+
+use tenferro_ad::error::{Error, Result};
+use tenferro_ad::extension::apply_eager;
+use tenferro_ad::{EagerBackend, EagerTensor};
+use tenferro_runtime::ErrorPhase;
+use tenferro_tensor::{DType, Tensor};
+
+use crate::{
+    fft_op_name, prepare_runtime_fft_op, register_runtime, require_runtime_dtype,
+    runtime_forward_fft_operation, FftBackend, FftExecutionCache, FftNorm, FftOperation,
+    FftPlanSpec,
+};
+
+/// FFT extension methods for [`EagerTensor`].
+pub trait EagerTensorFftExt {
+    /// Execute a complex FFT, or a full-spectrum FFT for real input.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use num_complex::Complex64;
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_fft::{EagerTensorFftExt, FftNorm};
+    ///
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(),
+    ///     EagerRuntime::new(),
+    /// )?;
+    /// let y = x.fft(None, -1, FftNorm::Backward)?;
+    /// assert_eq!(y.materialized()?.as_slice::<Complex64>().unwrap()[0], Complex64::new(3.0, 0.0));
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a validation error for an invalid axis or transform length, an
+    /// extension error for an unsupported dtype or backend, and a runtime-state
+    /// error when the eager runtime is unavailable.
+    fn fft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<EagerTensor>;
+
+    /// Execute an inverse complex FFT.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use num_complex::Complex64;
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_fft::{EagerTensorFftExt, FftNorm};
+    ///
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![2], vec![Complex64::new(3.0, 0.0), Complex64::new(-1.0, 0.0)]).unwrap(),
+    ///     EagerRuntime::new(),
+    /// )?;
+    /// let y = x.ifft(None, -1, FftNorm::Backward)?;
+    /// assert_eq!(y.shape(), &[2]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a validation error for an invalid axis or transform length, an
+    /// extension error for non-complex input or an unsupported backend, and a
+    /// runtime-state error when the eager runtime is unavailable.
+    fn ifft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<EagerTensor>;
+
+    /// Execute a one-sided real FFT.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_fft::{EagerTensorFftExt, FftNorm};
+    ///
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap(),
+    ///     EagerRuntime::new(),
+    /// )?;
+    /// let y = x.rfft(None, -1, FftNorm::Backward)?;
+    /// assert_eq!(y.shape(), &[3]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a validation error for an invalid axis or transform length, an
+    /// extension error for non-real input or an unsupported backend, and a
+    /// runtime-state error when the eager runtime is unavailable.
+    fn rfft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<EagerTensor>;
+
+    /// Execute an inverse real FFT from a one-sided complex spectrum.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use num_complex::Complex64;
+    /// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+    /// use tenferro_fft::{EagerTensorFftExt, FftNorm};
+    ///
+    /// let x = EagerTensor::from_tensor_in(
+    ///     Tensor::from_vec_col_major(vec![3], vec![Complex64::new(10.0, 0.0), Complex64::new(-2.0, 2.0), Complex64::new(-2.0, 0.0)]).unwrap(),
+    ///     EagerRuntime::new(),
+    /// )?;
+    /// let y = x.irfft(Some(4), -1, FftNorm::Backward)?;
+    /// assert_eq!(y.shape(), &[4]);
+    /// # Ok::<(), tenferro_ad::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a validation error for an invalid axis, transform length, or
+    /// spectrum length, an extension error for non-complex input or an
+    /// unsupported backend, and a runtime-state error when the eager runtime is
+    /// unavailable.
+    fn irfft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<EagerTensor>;
+}
+
+impl EagerTensorFftExt for EagerTensor {
+    fn fft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<EagerTensor> {
+        let operation = runtime_forward_fft_operation(self.dtype())?;
+        apply_eager_fft("fft", self, operation, n, axis, norm)
+    }
+
+    fn ifft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<EagerTensor> {
+        require_runtime_dtype(
+            "ifft",
+            self.dtype(),
+            &[DType::C32, DType::C64],
+            "C32 or C64",
+        )?;
+        apply_eager_fft("ifft", self, FftOperation::C2cInverse, n, axis, norm)
+    }
+
+    fn rfft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<EagerTensor> {
+        require_runtime_dtype(
+            "rfft",
+            self.dtype(),
+            &[DType::F32, DType::F64],
+            "F32 or F64",
+        )?;
+        apply_eager_fft("rfft", self, FftOperation::R2cOnesided, n, axis, norm)
+    }
+
+    fn irfft(&self, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<EagerTensor> {
+        require_runtime_dtype(
+            "irfft",
+            self.dtype(),
+            &[DType::C32, DType::C64],
+            "C32 or C64",
+        )?;
+        apply_eager_fft("irfft", self, FftOperation::C2r, n, axis, norm)
+    }
+}
+
+fn apply_eager_fft(
+    op_name: &'static str,
+    input: &EagerTensor,
+    operation: FftOperation,
+    n: Option<usize>,
+    axis: isize,
+    norm: FftNorm,
+) -> Result<EagerTensor> {
+    let op = prepare_runtime_fft_op(
+        op_name,
+        operation,
+        input.shape().len(),
+        Some(input.shape()),
+        n,
+        axis,
+        norm,
+    )?;
+
+    input
+        .runtime()
+        .register_extension(register_runtime)
+        .map_err(|source| Error::runtime_state_source(op_name, ErrorPhase::GraphBuild, source))?;
+    let mut outputs = apply_eager(Arc::new(op), &[input])?.into_iter();
+    match (outputs.next(), outputs.next()) {
+        (Some(output), None) => Ok(output),
+        _ => Err(Error::Internal(
+            "FFT eager extension returned an unexpected number of outputs".into(),
+        )),
+    }
+}
+
+impl FftBackend for EagerBackend {
+    fn execute_fft(
+        &mut self,
+        input: &Tensor,
+        spec: &FftPlanSpec,
+        cache: FftExecutionCache<'_>,
+    ) -> tenferro_tensor::Result<Tensor> {
+        #[allow(unreachable_patterns)]
+        match self {
+            Self::Cpu(backend) => backend.execute_fft(input, spec, cache),
+            _ => Err(tenferro_tensor::Error::unsupported(
+                fft_op_name(spec.operation()),
+                format!(
+                    "the selected eager backend has no FFT capability for placement {:?}",
+                    input.placement()
+                ),
+            )),
+        }
+    }
+}

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -5,8 +5,9 @@
 //! capability through RustFFT. Metal/WebGPU and CUDA backends require separate
 //! explicit implementations; unsupported requests return an error and never
 //! fall back to CPU or transfer tensor data. Concrete non-AD execution uses
-//! [`TensorFftExt`] and [`TensorReadFftExt`]. Traced graph construction uses
-//! [`TracedTensorFftExt`].
+//! [`TensorFftExt`] and [`TensorReadFftExt`]. Eager execution uses
+//! `EagerTensorFftExt` when `autodiff` is enabled, and traced graph
+//! construction uses [`TracedTensorFftExt`].
 //!
 //! # Examples
 //!
@@ -79,12 +80,16 @@ use tidu::{ADRuleError, ADRuleKind, ADRuleResult};
 mod backend;
 mod cache;
 mod cpu;
+#[cfg(feature = "autodiff")]
+mod eager_ext;
 mod spec;
 
 pub use backend::{FftBackend, FftExecutionCache};
 pub use cache::{
     fft_plan_cache_selector, FftPlanCache, DEFAULT_FFT_PLAN_CACHE_CAPACITY, FFT_PLAN_CACHE_NAME,
 };
+#[cfg(feature = "autodiff")]
+pub use eager_ext::EagerTensorFftExt;
 pub use spec::{FftNorm, FftOperation, FftPlanSpec};
 
 /// Extension family id used by the tenferro FFT extension.
@@ -1449,17 +1454,7 @@ define_extension_runtime! {
 /// assert_eq!(out.as_slice::<Complex64>().unwrap()[0], Complex64::new(3.0, 0.0));
 /// ```
 fn fft(input: &TracedTensor, n: Option<usize>, axis: isize, norm: FftNorm) -> Result<TracedTensor> {
-    let operation = match input.dtype {
-        DType::C32 | DType::C64 => FftOperation::C2cForward,
-        DType::F32 | DType::F64 => FftOperation::R2cFull,
-        DType::I32 | DType::I64 | DType::Bool => {
-            return Err(runtime_unsupported_dtype(
-                "fft",
-                input.dtype,
-                "F32, F64, C32, or C64",
-            ))
-        }
-    };
+    let operation = runtime_forward_fft_operation(input.dtype)?;
     apply_unary_fft("fft", input, operation, n, axis, norm)
 }
 
@@ -1489,9 +1484,7 @@ fn ifft(
     axis: isize,
     norm: FftNorm,
 ) -> Result<TracedTensor> {
-    if !matches!(input.dtype, DType::C32 | DType::C64) {
-        return Err(runtime_unsupported_dtype("ifft", input.dtype, "C32 or C64"));
-    }
+    require_runtime_dtype("ifft", input.dtype, &[DType::C32, DType::C64], "C32 or C64")?;
     apply_unary_fft("ifft", input, FftOperation::C2cInverse, n, axis, norm)
 }
 
@@ -1525,9 +1518,7 @@ fn rfft(
     axis: isize,
     norm: FftNorm,
 ) -> Result<TracedTensor> {
-    if !matches!(input.dtype, DType::F32 | DType::F64) {
-        return Err(runtime_unsupported_dtype("rfft", input.dtype, "F32 or F64"));
-    }
+    require_runtime_dtype("rfft", input.dtype, &[DType::F32, DType::F64], "F32 or F64")?;
     apply_unary_fft("rfft", input, FftOperation::R2cOnesided, n, axis, norm)
 }
 
@@ -1564,13 +1555,12 @@ fn irfft(
     axis: isize,
     norm: FftNorm,
 ) -> Result<TracedTensor> {
-    if !matches!(input.dtype, DType::C32 | DType::C64) {
-        return Err(runtime_unsupported_dtype(
-            "irfft",
-            input.dtype,
-            "C32 or C64",
-        ));
-    }
+    require_runtime_dtype(
+        "irfft",
+        input.dtype,
+        &[DType::C32, DType::C64],
+        "C32 or C64",
+    )?;
     apply_unary_fft("irfft", input, FftOperation::C2r, n, axis, norm)
 }
 
@@ -1582,15 +1572,16 @@ fn apply_unary_fft(
     axis: isize,
     norm: FftNorm,
 ) -> Result<TracedTensor> {
-    validate_n(op_name, n)?;
-    let axis = normalize_axis(op_name, axis, input.rank)?;
-    validate_resolved_transform_len(op_name, input, n, axis)?;
-    if operation == FftOperation::C2r {
-        if let Some(shape) = input.try_concrete_shape() {
-            output_shape_c2r(&shape, axis, n)?;
-        }
-    }
-    let op = Arc::new(FftOp::new(operation, axis, n, norm));
+    let concrete_shape = input.try_concrete_shape();
+    let op = Arc::new(prepare_runtime_fft_op(
+        op_name,
+        operation,
+        input.rank,
+        concrete_shape.as_deref(),
+        n,
+        axis,
+        norm,
+    )?);
     let mut outputs = apply(op, &[input])?;
     outputs
         .pop()
@@ -1628,27 +1619,55 @@ fn validate_n(op: &'static str, n: Option<usize>) -> Result<()> {
     Ok(())
 }
 
-fn validate_resolved_transform_len(
+fn prepare_runtime_fft_op(
     op: &'static str,
-    input: &TracedTensor,
+    operation: FftOperation,
+    rank: usize,
+    concrete_shape: Option<&[usize]>,
     n: Option<usize>,
-    axis: usize,
-) -> Result<()> {
-    if n.is_some() {
-        return Ok(());
-    }
-    if input
-        .try_concrete_shape()
-        .and_then(|shape| shape.get(axis).copied())
-        == Some(0)
-    {
+    axis: isize,
+    norm: FftNorm,
+) -> Result<FftOp> {
+    validate_n(op, n)?;
+    let axis = normalize_axis(op, axis, rank)?;
+    if n.is_none() && concrete_shape.and_then(|shape| shape.get(axis).copied()) == Some(0) {
         return Err(runtime_invalid_argument(
             op,
             "n",
             "transform length must be positive",
         ));
     }
-    Ok(())
+    if operation == FftOperation::C2r {
+        if let Some(shape) = concrete_shape {
+            output_shape_c2r(shape, axis, n)?;
+        }
+    }
+    Ok(FftOp::new(operation, axis, n, norm))
+}
+
+fn runtime_forward_fft_operation(dtype: DType) -> Result<FftOperation> {
+    match dtype {
+        DType::C32 | DType::C64 => Ok(FftOperation::C2cForward),
+        DType::F32 | DType::F64 => Ok(FftOperation::R2cFull),
+        DType::I32 | DType::I64 | DType::Bool => Err(runtime_unsupported_dtype(
+            "fft",
+            dtype,
+            "F32, F64, C32, or C64",
+        )),
+    }
+}
+
+fn require_runtime_dtype(
+    op: &'static str,
+    dtype: DType,
+    supported: &[DType],
+    expected: &'static str,
+) -> Result<()> {
+    if supported.contains(&dtype) {
+        Ok(())
+    } else {
+        Err(runtime_unsupported_dtype(op, dtype, expected))
+    }
 }
 
 fn runtime_invalid_argument(

--- a/crates/tenferro-fft/tests/fft_ops.rs
+++ b/crates/tenferro-fft/tests/fft_ops.rs
@@ -1,7 +1,11 @@
 use num_complex::{Complex32, Complex64};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::Arc;
+#[cfg(feature = "autodiff")]
+use tenferro_ad::{EagerRuntime, EagerTensor};
 use tenferro_cpu::CpuBackend;
+#[cfg(feature = "autodiff")]
+use tenferro_fft::EagerTensorFftExt;
 use tenferro_fft::{fft_plan_cache_selector, FftNorm, TracedTensorFftExt};
 use tenferro_runtime::{
     DType, Error as RuntimeError, ErrorPhase, GraphCompiler, GraphExecutor, Tensor, TracedTensor,
@@ -19,6 +23,11 @@ fn run(output: &TracedTensor) -> Tensor {
         .register_extension(tenferro_fft::register_runtime)
         .unwrap();
     executor.run(&program).unwrap()
+}
+
+#[cfg(feature = "autodiff")]
+fn eager(input: Tensor) -> EagerTensor {
+    EagerTensor::from_tensor_in(input, EagerRuntime::new()).unwrap()
 }
 
 fn assert_c64_close(actual: &[Complex64], expected: &[Complex64]) {
@@ -470,6 +479,156 @@ fn irfft_c32_reconstructs_real_signal() {
 
     assert_eq!(out.shape(), &[4]);
     assert_f32_close(out.as_slice::<f32>().unwrap(), &[1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn eager_fft_matches_traced_fft() {
+    let input = Tensor::from_vec_col_major(
+        vec![4],
+        vec![
+            Complex64::new(1.0, 0.5),
+            Complex64::new(2.0, -0.25),
+            Complex64::new(3.0, 0.75),
+            Complex64::new(4.0, -1.0),
+        ],
+    )
+    .unwrap();
+    let traced = TracedTensor::from_tensor_concrete_shape(input.clone())
+        .unwrap()
+        .fft(Some(3), -1, FftNorm::Ortho)
+        .unwrap();
+    let eager = eager(input).fft(Some(3), -1, FftNorm::Ortho).unwrap();
+
+    assert_c64_close(
+        eager
+            .materialized()
+            .unwrap()
+            .as_slice::<Complex64>()
+            .unwrap(),
+        run(&traced).as_slice::<Complex64>().unwrap(),
+    );
+}
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn eager_ifft_matches_traced_ifft() {
+    let input = Tensor::from_vec_col_major(
+        vec![4],
+        vec![
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+            Complex64::new(-2.0, -2.0),
+        ],
+    )
+    .unwrap();
+    let traced = TracedTensor::from_tensor_concrete_shape(input.clone())
+        .unwrap()
+        .ifft(None, 0, FftNorm::Forward)
+        .unwrap();
+    let eager = eager(input).ifft(None, 0, FftNorm::Forward).unwrap();
+
+    assert_c64_close(
+        eager
+            .materialized()
+            .unwrap()
+            .as_slice::<Complex64>()
+            .unwrap(),
+        run(&traced).as_slice::<Complex64>().unwrap(),
+    );
+}
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn eager_rfft_matches_traced_rfft() {
+    let input = Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+    let traced = TracedTensor::from_tensor_concrete_shape(input.clone())
+        .unwrap()
+        .rfft(None, -1, FftNorm::Backward)
+        .unwrap();
+    let eager = eager(input).rfft(None, -1, FftNorm::Backward).unwrap();
+
+    assert_c64_close(
+        eager
+            .materialized()
+            .unwrap()
+            .as_slice::<Complex64>()
+            .unwrap(),
+        run(&traced).as_slice::<Complex64>().unwrap(),
+    );
+}
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn eager_irfft_matches_traced_irfft() {
+    let input = Tensor::from_vec_col_major(
+        vec![3],
+        vec![
+            Complex64::new(10.0, 0.0),
+            Complex64::new(-2.0, 2.0),
+            Complex64::new(-2.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let traced = TracedTensor::from_tensor_concrete_shape(input.clone())
+        .unwrap()
+        .irfft(Some(4), -1, FftNorm::Backward)
+        .unwrap();
+    let eager = eager(input).irfft(Some(4), -1, FftNorm::Backward).unwrap();
+
+    assert_f64_close(
+        eager.materialized().unwrap().as_slice::<f64>().unwrap(),
+        run(&traced).as_slice::<f64>().unwrap(),
+    );
+}
+
+#[test]
+#[cfg(feature = "autodiff")]
+fn eager_fft_reuses_c2c_vjp_rule() {
+    let ad = fft_ad_context();
+    let ctx = EagerRuntime::with_cpu_backend_and_ad_context(CpuBackend::new(), &ad);
+    let x = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(
+            vec![4],
+            vec![
+                Complex64::new(1.0, 0.0),
+                Complex64::new(2.0, 0.0),
+                Complex64::new(3.0, 0.0),
+                Complex64::new(4.0, 0.0),
+            ],
+        )
+        .unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+    let cotangent = EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(
+            vec![4],
+            vec![
+                Complex64::new(1.0, 1.0),
+                Complex64::new(2.0, -1.0),
+                Complex64::new(-1.0, 0.5),
+                Complex64::new(0.25, -2.0),
+            ],
+        )
+        .unwrap(),
+        ctx.clone(),
+    )
+    .unwrap();
+
+    let y = x.fft(None, -1, FftNorm::Backward).unwrap();
+    let dx = ctx.vjp(&y, &x, &cotangent).unwrap();
+
+    assert_c64_close(
+        dx.materialized().unwrap().as_slice::<Complex64>().unwrap(),
+        &[
+            Complex64::new(2.25, -1.5),
+            Complex64::new(1.0, 2.25),
+            Complex64::new(-2.25, 4.5),
+            Complex64::new(3.0, -1.25),
+        ],
+    );
 }
 
 #[test]

--- a/crates/tenferro-linalg/benches/lu_ad_breakdown.rs
+++ b/crates/tenferro-linalg/benches/lu_ad_breakdown.rs
@@ -111,7 +111,7 @@ fn upper_matrix(n: usize) -> Vec<f64> {
 
 fn reduce_all(tensor: &EagerTensor) -> EagerTensor {
     let axes: Vec<usize> = (0..tensor.shape().len()).collect();
-    tensor.reduce_sum(&axes).unwrap()
+    tensor.reduce_sum(Some(&axes)).unwrap()
 }
 
 fn fixture(n: usize, threads: usize) -> Fixture {

--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -16,7 +16,7 @@
 //!     .unwrap();
 //! let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 0.0, 0.0, 2.0]).unwrap();
 //! let (_u, s, _vt) = x.svd().unwrap();
-//! let loss = s.reduce_sum(&[0]).unwrap();
+//! let loss = s.reduce_sum(Some(&[0])).unwrap();
 //! let grad = ad.grad(&loss, &x).unwrap();
 //! assert_eq!(grad.rank, 2);
 //! ```

--- a/crates/tenferro-linalg/src/eager_composites.rs
+++ b/crates/tenferro-linalg/src/eager_composites.rs
@@ -1,0 +1,327 @@
+use num_complex::{Complex32, Complex64};
+use tenferro_ad::{CompareDir, DType, DotGeneralConfig, EagerTensor, Error, Result, Tensor};
+use tenferro_runtime::ErrorPhase;
+
+use crate::eager_ext::{eig, eigh, lu, solve, svd};
+
+pub(crate) fn slogdet(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
+    let (_p, _l, u, parity) = lu(a)?;
+    let diag_u = u.extract_diag(0, 1)?;
+    let sign_u = diag_u.sign()?.reduce_prod(Some(&[0]))?;
+    let sign = parity.mul(&sign_u)?;
+    let logabsdet = diag_u.abs()?.log()?.reduce_sum(Some(&[0]))?;
+    Ok((sign, logabsdet))
+}
+
+pub(crate) fn det(a: &EagerTensor) -> Result<EagerTensor> {
+    let (sign, logabsdet) = slogdet(a)?;
+    sign.mul(&logabsdet.exp()?)
+}
+
+pub(crate) fn inv(a: &EagerTensor) -> Result<EagerTensor> {
+    ensure_min_rank("inv", a.shape().len(), 2)?;
+    let eye = eye_like(a, a.shape()[0])?;
+    solve(a, &eye)
+}
+
+pub(crate) fn eigvalsh(a: &EagerTensor) -> Result<EagerTensor> {
+    let (values, _vectors) = eigh(a)?;
+    Ok(values)
+}
+
+pub(crate) fn eigvals(a: &EagerTensor) -> Result<EagerTensor> {
+    let (values, _vectors) = eig(a)?;
+    Ok(values)
+}
+
+pub(crate) fn pinv(a: &EagerTensor) -> Result<EagerTensor> {
+    ensure_float_or_complex("pinv", a.dtype())?;
+    let max_dim = match (a.shape().first(), a.shape().get(1)) {
+        (Some(&m), Some(&n)) => m.max(n),
+        (Some(&m), None) => m,
+        _ => 0,
+    };
+    pinv_with_rtol(a, default_pinv_rtol(a.dtype(), max_dim))
+}
+
+pub(crate) fn pinv_with_rtol(a: &EagerTensor, rtol: f64) -> Result<EagerTensor> {
+    ensure_float_or_complex("pinv_with_rtol", a.dtype())?;
+    let (u, s, vt) = svd(a)?;
+    let abs_s = s.abs()?;
+    let s_max = abs_s.reduce_max(Some(&[0]))?;
+    let threshold_scalar = scalar_real(&s, rtol.max(0.0))?;
+    let threshold = s_max.mul(&threshold_scalar)?;
+    let threshold = broadcast_batch_scalar_to_leading_axis(&threshold, s.shape())?;
+    let mask = abs_s
+        .compare(&threshold, CompareDir::Gt)?
+        .convert(s.dtype())?;
+    let ones = ones_like(&s)?;
+    let denom = s.add(&ones.add(&mask.neg()?)?)?;
+    let s_inv = mask.div(&denom)?;
+
+    let v = vt
+        .conj()?
+        .transpose(&matrix_transpose_perm(vt.shape().len()))?;
+    let uh = u
+        .conj()?
+        .transpose(&matrix_transpose_perm(u.shape().len()))?;
+    let vs = scale_matrix_columns(&v, &s_inv)?;
+    matmul_preserve_trailing_batch(&vs, &uh)
+}
+
+pub(crate) fn norm(
+    a: &EagerTensor,
+    ord: Option<f64>,
+    dim: Option<&[usize]>,
+    keepdim: bool,
+) -> Result<EagerTensor> {
+    ensure_float_or_complex("norm", a.dtype())?;
+    let axes = dim.map_or_else(
+        || (0..a.shape().len()).collect::<Vec<_>>(),
+        <[usize]>::to_vec,
+    );
+    if axes.is_empty() {
+        return Ok(a.clone());
+    }
+    validate_axes("norm", a.shape().len(), &axes)?;
+
+    let out = match axes.len() {
+        1 => vector_norm(a, axes[0], ord)?,
+        2 => matrix_norm(a, &axes, ord)?,
+        _ => {
+            let abs = a.abs()?;
+            match ord {
+                None => frobenius_norm(&abs, &axes)?,
+                Some(p) if p == f64::INFINITY => abs.reduce_max(Some(&axes))?,
+                Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(Some(&axes))?,
+                Some(0.0) => count_nonzero(&abs, &axes)?,
+                Some(p) => p_norm(&abs, &axes, p)?,
+            }
+        }
+    };
+    restore_keepdim(out, a.shape(), &axes, keepdim)
+}
+
+fn scalar_real(anchor: &EagerTensor, value: f64) -> Result<EagerTensor> {
+    let tensor = match anchor.dtype() {
+        DType::F64 => Tensor::from_vec_col_major(vec![], vec![value])?,
+        DType::F32 => Tensor::from_vec_col_major(vec![], vec![value as f32])?,
+        DType::I32 => Tensor::from_vec_col_major(vec![], vec![value.round() as i32])?,
+        DType::I64 => Tensor::from_vec_col_major(vec![], vec![value.round() as i64])?,
+        DType::Bool => Tensor::from_vec_col_major(vec![], vec![value != 0.0])?,
+        DType::C64 => Tensor::from_vec_col_major(vec![], vec![Complex64::new(value, 0.0)])?,
+        DType::C32 => Tensor::from_vec_col_major(vec![], vec![Complex32::new(value as f32, 0.0)])?,
+    };
+    EagerTensor::from_tensor_in(tensor, anchor.runtime().clone())
+}
+
+fn ensure_float_or_complex(op: &'static str, dtype: DType) -> Result<()> {
+    match dtype {
+        DType::F32 | DType::F64 | DType::C32 | DType::C64 => Ok(()),
+        DType::I32 | DType::I64 | DType::Bool => Err(Error::TensorRuntime(
+            crate::error::unsupported_dtype(op, dtype),
+        )),
+    }
+}
+
+fn ensure_min_rank(op: &'static str, actual: usize, expected: usize) -> Result<()> {
+    if actual < expected {
+        return Err(Error::TensorRuntime(tenferro_tensor::Error::rank_mismatch(
+            op, expected, actual,
+        )));
+    }
+    Ok(())
+}
+
+fn validate_axes(op: &'static str, rank: usize, axes: &[usize]) -> Result<()> {
+    let mut seen = vec![false; rank];
+    for &axis in axes {
+        if axis >= rank {
+            return Err(Error::TensorRuntime(
+                tenferro_tensor::Error::axis_out_of_bounds(op, axis, rank),
+            ));
+        }
+        if seen[axis] {
+            return Err(Error::invalid_argument(
+                op,
+                ErrorPhase::GraphBuild,
+                "dim",
+                format!("axis {axis} appears more than once"),
+            ));
+        }
+        seen[axis] = true;
+    }
+    Ok(())
+}
+
+fn ones_like(input: &EagerTensor) -> Result<EagerTensor> {
+    broadcast_scalar(scalar_real(input, 1.0)?, input.shape())
+}
+
+fn eye_like(anchor: &EagerTensor, size: usize) -> Result<EagerTensor> {
+    let mut vector_shape = vec![size];
+    vector_shape.extend_from_slice(&anchor.shape()[2..]);
+    broadcast_scalar(scalar_real(anchor, 1.0)?, &vector_shape)?.embed_diag(0, 1)
+}
+
+fn broadcast_scalar(input: EagerTensor, shape: &[usize]) -> Result<EagerTensor> {
+    if input.shape() == shape {
+        return Ok(input);
+    }
+    input.broadcast_in_dim(shape, &[])
+}
+
+fn broadcast_batch_scalar_to_leading_axis(
+    input: &EagerTensor,
+    shape: &[usize],
+) -> Result<EagerTensor> {
+    if input.shape() == shape {
+        return Ok(input.clone());
+    }
+    let dims: Vec<usize> = (1..shape.len()).collect();
+    input.broadcast_in_dim(shape, &dims)
+}
+
+fn matmul_preserve_trailing_batch(lhs: &EagerTensor, rhs: &EagerTensor) -> Result<EagerTensor> {
+    let batch_dims: Vec<usize> = (2..lhs.shape().len()).collect();
+    lhs.dot_general(
+        rhs,
+        DotGeneralConfig {
+            lhs_contracting_dims: vec![1],
+            rhs_contracting_dims: vec![0],
+            lhs_batch_dims: batch_dims.clone(),
+            rhs_batch_dims: batch_dims,
+        },
+    )
+}
+
+fn matrix_transpose_perm(rank: usize) -> Vec<usize> {
+    let mut perm: Vec<usize> = (0..rank).collect();
+    perm.swap(0, 1);
+    perm
+}
+
+fn frobenius_norm(abs: &EagerTensor, axes: &[usize]) -> Result<EagerTensor> {
+    abs.pow(&scalar_real(abs, 2.0)?)?
+        .reduce_sum(Some(axes))?
+        .sqrt()
+}
+
+fn p_norm(abs: &EagerTensor, axes: &[usize], p: f64) -> Result<EagerTensor> {
+    if !p.is_finite() || p == 0.0 {
+        return Err(Error::invalid_argument(
+            "norm",
+            ErrorPhase::GraphBuild,
+            "p",
+            format!("p-norm order must be finite and nonzero, got {p}"),
+        ));
+    }
+    abs.pow(&scalar_real(abs, p)?)?
+        .reduce_sum(Some(axes))?
+        .pow(&scalar_real(abs, 1.0 / p)?)
+}
+
+fn default_pinv_rtol(dtype: DType, max_dim: usize) -> f64 {
+    let eps = match dtype {
+        DType::F32 | DType::C32 => f32::EPSILON as f64,
+        DType::F64 | DType::C64 => f64::EPSILON,
+        DType::I32 | DType::I64 | DType::Bool => 0.0,
+    };
+    eps * max_dim as f64
+}
+
+fn vector_norm(a: &EagerTensor, axis: usize, ord: Option<f64>) -> Result<EagerTensor> {
+    let abs = a.abs()?;
+    match ord {
+        None => frobenius_norm(&abs, &[axis]),
+        Some(0.0) => count_nonzero(&abs, &[axis]),
+        Some(p) if p == f64::INFINITY => abs.reduce_max(Some(&[axis])),
+        Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(Some(&[axis])),
+        Some(p) => p_norm(&abs, &[axis], p),
+    }
+}
+
+fn matrix_norm(a: &EagerTensor, axes: &[usize], ord: Option<f64>) -> Result<EagerTensor> {
+    let matrix = move_axes_to_front(a, axes)?;
+    let abs = matrix.abs()?;
+    match ord {
+        None => frobenius_norm(&abs, &[0, 1]),
+        Some(p) if p == f64::INFINITY => matrix_row_sum_norm(&abs, true),
+        Some(p) if p == f64::NEG_INFINITY => matrix_row_sum_norm(&abs, false),
+        Some(1.0) => matrix_col_sum_norm(&abs, true),
+        Some(-1.0) => matrix_col_sum_norm(&abs, false),
+        Some(2.0) => svd(&matrix)?.1.abs()?.reduce_max(Some(&[0])),
+        Some(-2.0) => svd(&matrix)?.1.abs()?.reduce_min(Some(&[0])),
+        Some(0.0) => count_nonzero(&abs, &[0, 1]),
+        Some(p) => p_norm(&abs, &[0, 1], p),
+    }
+}
+
+fn scale_matrix_columns(matrix: &EagerTensor, scale: &EagerTensor) -> Result<EagerTensor> {
+    let mut scale_shape = vec![1, scale.shape()[0]];
+    scale_shape.extend_from_slice(&matrix.shape()[2..]);
+    let dims: Vec<usize> = (0..matrix.shape().len()).collect();
+    matrix.mul(
+        &scale
+            .reshape(&scale_shape)?
+            .broadcast_in_dim(matrix.shape(), &dims)?,
+    )
+}
+
+fn count_nonzero(abs: &EagerTensor, axes: &[usize]) -> Result<EagerTensor> {
+    abs.compare(&scalar_real(abs, 0.0)?, CompareDir::Gt)?
+        .convert(abs.dtype())?
+        .reduce_sum(Some(axes))
+}
+
+fn matrix_row_sum_norm(abs: &EagerTensor, take_max: bool) -> Result<EagerTensor> {
+    let row_sums = abs.reduce_sum(Some(&[1]))?;
+    if take_max {
+        row_sums.reduce_max(Some(&[0]))
+    } else {
+        row_sums.reduce_min(Some(&[0]))
+    }
+}
+
+fn matrix_col_sum_norm(abs: &EagerTensor, take_max: bool) -> Result<EagerTensor> {
+    let col_sums = abs.reduce_sum(Some(&[0]))?;
+    if take_max {
+        col_sums.reduce_max(Some(&[0]))
+    } else {
+        col_sums.reduce_min(Some(&[0]))
+    }
+}
+
+fn move_axes_to_front(tensor: &EagerTensor, axes: &[usize]) -> Result<EagerTensor> {
+    if axes.iter().enumerate().all(|(index, &axis)| index == axis) {
+        return Ok(tensor.clone());
+    }
+    let mut selected = vec![false; tensor.shape().len()];
+    for &axis in axes {
+        selected[axis] = true;
+    }
+    let mut perm = Vec::with_capacity(tensor.shape().len());
+    perm.extend_from_slice(axes);
+    for (axis, is_selected) in selected.iter().enumerate() {
+        if !*is_selected {
+            perm.push(axis);
+        }
+    }
+    tensor.transpose(&perm)
+}
+
+fn restore_keepdim(
+    reduced: EagerTensor,
+    original_shape: &[usize],
+    axes: &[usize],
+    keepdim: bool,
+) -> Result<EagerTensor> {
+    if !keepdim {
+        return Ok(reduced);
+    }
+    let mut kept_shape = original_shape.to_vec();
+    for &axis in axes {
+        kept_shape[axis] = 1;
+    }
+    reduced.reshape(&kept_shape)
+}

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -5,6 +5,7 @@ use tenferro_ad::extension::apply_eager;
 use tenferro_ad::EagerTensor;
 use tenferro_runtime::ErrorPhase;
 
+use crate::eager_composites;
 use crate::extension::{
     validate_derivative_eps, EighOptions, LinalgExtensionOp, LinalgOp, QrOptions, SvdOptions,
 };
@@ -113,6 +114,22 @@ pub trait EagerTensorLinalgExt {
         transpose_a: bool,
         unit_diagonal: bool,
     ) -> Result<EagerTensor>;
+    /// Return the determinant sign and logarithm of its absolute value.
+    fn slogdet(&self) -> Result<(EagerTensor, EagerTensor)>;
+    /// Return the determinant.
+    fn det(&self) -> Result<EagerTensor>;
+    /// Return the matrix inverse.
+    fn inv(&self) -> Result<EagerTensor>;
+    /// Return Hermitian eigenvalues without eigenvectors.
+    fn eigvalsh(&self) -> Result<EagerTensor>;
+    /// Return general eigenvalues without eigenvectors.
+    fn eigvals(&self) -> Result<EagerTensor>;
+    /// Return the Moore-Penrose pseudoinverse with the default tolerance.
+    fn pinv(&self) -> Result<EagerTensor>;
+    /// Return the Moore-Penrose pseudoinverse with an explicit relative tolerance.
+    fn pinv_with_rtol(&self, rtol: f64) -> Result<EagerTensor>;
+    /// Return a vector, matrix, or tensor norm.
+    fn norm(&self, ord: Option<f64>, dim: Option<&[usize]>, keepdim: bool) -> Result<EagerTensor>;
 }
 
 impl EagerTensorLinalgExt for EagerTensor {
@@ -184,6 +201,38 @@ impl EagerTensorLinalgExt for EagerTensor {
         unit_diagonal: bool,
     ) -> Result<EagerTensor> {
         triangular_solve(self, b, left_side, lower, transpose_a, unit_diagonal)
+    }
+
+    fn slogdet(&self) -> Result<(EagerTensor, EagerTensor)> {
+        eager_composites::slogdet(self)
+    }
+
+    fn det(&self) -> Result<EagerTensor> {
+        eager_composites::det(self)
+    }
+
+    fn inv(&self) -> Result<EagerTensor> {
+        eager_composites::inv(self)
+    }
+
+    fn eigvalsh(&self) -> Result<EagerTensor> {
+        eager_composites::eigvalsh(self)
+    }
+
+    fn eigvals(&self) -> Result<EagerTensor> {
+        eager_composites::eigvals(self)
+    }
+
+    fn pinv(&self) -> Result<EagerTensor> {
+        eager_composites::pinv(self)
+    }
+
+    fn pinv_with_rtol(&self, rtol: f64) -> Result<EagerTensor> {
+        eager_composites::pinv_with_rtol(self, rtol)
+    }
+
+    fn norm(&self, ord: Option<f64>, dim: Option<&[usize]>, keepdim: bool) -> Result<EagerTensor> {
+        eager_composites::norm(self, ord, dim, keepdim)
     }
 }
 

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -164,7 +164,7 @@ pub trait EagerTensorLinalgExt {
     /// # Errors
     ///
     /// Returns `Error::Validation` when `rtol` is negative or non-finite, plus
-    /// the decomposition and output-contract errors reported by [`Self::pinv`].
+    /// the `Error::Extension` and output-contract errors reported by [`Self::pinv`].
     fn pinv_with_rtol(&self, rtol: f64) -> Result<EagerTensor>;
     /// Return a vector, matrix, or tensor norm.
     ///

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -115,20 +115,64 @@ pub trait EagerTensorLinalgExt {
         unit_diagonal: bool,
     ) -> Result<EagerTensor>;
     /// Return the determinant sign and logarithm of its absolute value.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for a non-square input, `Error::Extension`
+    /// for an unsupported dtype or numerical failure, and `Error::Internal`
+    /// if a primitive violates its output contract.
     fn slogdet(&self) -> Result<(EagerTensor, EagerTensor)>;
     /// Return the determinant.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation`, `Error::Extension`, `Error::RuntimeState`,
+    /// or `Error::Internal` under the conditions documented by [`Self::slogdet`].
     fn det(&self) -> Result<EagerTensor>;
     /// Return the matrix inverse.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for invalid matrix metadata,
+    /// `Error::Extension` for an unsupported dtype or singular solve, and
+    /// `Error::RuntimeState` when eager execution cannot access its backend.
     fn inv(&self) -> Result<EagerTensor>;
     /// Return Hermitian eigenvalues without eigenvectors.
+    ///
+    /// # Errors
+    ///
+    /// Returns the validation, unsupported-dtype, numerical-convergence,
+    /// runtime-state, or output-contract errors reported by [`Self::eigh`].
     fn eigvalsh(&self) -> Result<EagerTensor>;
     /// Return general eigenvalues without eigenvectors.
+    ///
+    /// # Errors
+    ///
+    /// Returns the validation, unsupported-dtype, numerical-convergence,
+    /// runtime-state, or output-contract errors reported by [`Self::eig`].
     fn eigvals(&self) -> Result<EagerTensor>;
     /// Return the Moore-Penrose pseudoinverse with the default tolerance.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for invalid matrix metadata,
+    /// `Error::Extension` for unsupported SVD execution, and
+    /// `Error::Internal` for an unexpected decomposition output contract.
     fn pinv(&self) -> Result<EagerTensor>;
     /// Return the Moore-Penrose pseudoinverse with an explicit relative tolerance.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` when `rtol` is negative or non-finite, plus
+    /// the decomposition and output-contract errors reported by [`Self::pinv`].
     fn pinv_with_rtol(&self, rtol: f64) -> Result<EagerTensor>;
     /// Return a vector, matrix, or tensor norm.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for an unsupported order/dimension
+    /// combination or invalid axes, `Error::Extension` when a required matrix
+    /// decomposition is unsupported, and eager runtime/backend failures.
     fn norm(&self, ord: Option<f64>, dim: Option<&[usize]>, keepdim: bool) -> Result<EagerTensor>;
 }
 

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -40,6 +40,7 @@ pub mod error;
 mod extension;
 #[cfg(feature = "cuda")]
 mod gpu;
+mod tensor_ext;
 mod traced;
 
 #[cfg(feature = "autodiff")]
@@ -56,5 +57,9 @@ pub use error::{Error, Result};
 pub use extension::{
     register_runtime, EighGauge, EighOptions, QrGauge, QrOptions, SvdGauge, SvdOptions,
     DEFAULT_DECOMPOSITION_DERIVATIVE_EPS, LINALG_EXTENSION_FAMILY_ID,
+};
+pub use tensor_ext::{
+    LinalgScalar, TensorLinalgExt, TensorReadLinalgExt, TypedEig, TypedFullPivLu, TypedLu,
+    TypedSvd, TypedTensorLinalgExt,
 };
 pub use traced::TracedTensorLinalgExt;

--- a/crates/tenferro-linalg/src/lib.rs
+++ b/crates/tenferro-linalg/src/lib.rs
@@ -33,6 +33,8 @@ mod cpu;
 #[cfg(feature = "autodiff")]
 mod eager_backend;
 #[cfg(feature = "autodiff")]
+mod eager_composites;
+#[cfg(feature = "autodiff")]
 mod eager_ext;
 pub mod error;
 mod extension;

--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -1,0 +1,1385 @@
+//! Receiver-first concrete linear algebra surfaces.
+//!
+//! Owned tensors use [`TensorLinalgExt`], borrowed tensors and views use the
+//! `_read` methods on [`TensorReadLinalgExt`], and typed tensors use
+//! [`TypedTensorLinalgExt`]. All methods reuse a caller-owned backend.
+
+use num_complex::{Complex32, Complex64};
+use tenferro_tensor::{
+    CompareDir, DType, DotGeneralConfig, Tensor, TensorRead, TensorScalar, TypedTensor,
+};
+
+use crate::extension::{
+    apply_eigh_gauge, apply_qr_gauge, apply_svd_gauge, validate_derivative_eps, EighOptions,
+    QrOptions, SvdOptions,
+};
+use crate::LinalgBackend;
+
+/// Scalar types supported by statically typed linear algebra methods.
+pub trait LinalgScalar: TensorScalar + private::Sealed {
+    /// Complex counterpart used by general eigendecomposition.
+    type Complex: TensorScalar;
+}
+
+mod private {
+    pub trait Sealed {}
+    impl Sealed for f32 {}
+    impl Sealed for f64 {}
+    impl Sealed for num_complex::Complex32 {}
+    impl Sealed for num_complex::Complex64 {}
+}
+
+impl LinalgScalar for f32 {
+    type Complex = Complex32;
+}
+impl LinalgScalar for f64 {
+    type Complex = Complex64;
+}
+impl LinalgScalar for Complex32 {
+    type Complex = Complex32;
+}
+impl LinalgScalar for Complex64 {
+    type Complex = Complex64;
+}
+
+/// Fixed typed output tuple for singular value decomposition.
+pub type TypedSvd<T> = (
+    TypedTensor<T>,
+    TypedTensor<<T as TensorScalar>::Real>,
+    TypedTensor<T>,
+);
+/// Fixed typed output tuple for LU decomposition.
+pub type TypedLu<T> = (
+    TypedTensor<T>,
+    TypedTensor<T>,
+    TypedTensor<T>,
+    TypedTensor<<T as TensorScalar>::Real>,
+);
+/// Fixed typed output tuple for complete-pivot LU decomposition.
+pub type TypedFullPivLu<T> = (
+    TypedTensor<T>,
+    TypedTensor<T>,
+    TypedTensor<T>,
+    TypedTensor<T>,
+    TypedTensor<<T as TensorScalar>::Real>,
+);
+/// Fixed typed output tuple for general eigendecomposition.
+pub type TypedEig<T> = (
+    TypedTensor<<T as LinalgScalar>::Complex>,
+    TypedTensor<<T as LinalgScalar>::Complex>,
+);
+
+/// Linear algebra methods for dtype-erased owned tensors.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_linalg::TensorLinalgExt;
+/// use tenferro_tensor::Tensor;
+///
+/// let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+/// let mut backend = CpuBackend::new();
+/// let (_u, singular_values, _vt) = a.svd(&mut backend)?;
+/// assert_eq!(singular_values.as_slice::<f64>()?, &[4.0, 2.0]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
+pub trait TensorLinalgExt {
+    fn svd<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)>;
+    fn svd_with_options<B: LinalgBackend>(
+        &self,
+        options: SvdOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)>;
+    fn qr<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn qr_with_options<B: LinalgBackend>(
+        &self,
+        options: QrOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn lu<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor)>;
+    fn full_piv_lu<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)>;
+    fn full_piv_lu_solve<B: LinalgBackend>(
+        &self,
+        b: &Tensor,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+    fn solve<B: LinalgBackend>(
+        &self,
+        b: &Tensor,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+    fn cholesky<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn eigh<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn eigh_with_options<B: LinalgBackend>(
+        &self,
+        options: EighOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn eig<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    #[allow(clippy::too_many_arguments)]
+    fn triangular_solve<B: LinalgBackend>(
+        &self,
+        b: &Tensor,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+    fn slogdet<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn det<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn inv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn eigvalsh<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn eigvals<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn pinv_with_rtol<B: LinalgBackend>(
+        &self,
+        rtol: f64,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+    fn norm<B: LinalgBackend>(
+        &self,
+        ord: Option<f64>,
+        dim: Option<&[usize]>,
+        keepdim: bool,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+}
+
+/// Linear algebra methods for borrowed tensor reads.
+pub trait TensorReadLinalgExt {
+    fn svd_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)>;
+    fn svd_with_options_read<B: LinalgBackend>(
+        self,
+        options: SvdOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)>;
+    fn qr_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn qr_with_options_read<B: LinalgBackend>(
+        self,
+        options: QrOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn lu_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor)>;
+    fn full_piv_lu_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)>;
+    fn full_piv_lu_solve_read<B: LinalgBackend>(
+        self,
+        b: TensorRead<'_>,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+    fn solve_read<B: LinalgBackend>(
+        self,
+        b: TensorRead<'_>,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+    fn cholesky_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn eigh_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn eigh_with_options_read<B: LinalgBackend>(
+        self,
+        options: EighOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn eig_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    #[allow(clippy::too_many_arguments)]
+    fn triangular_solve_read<B: LinalgBackend>(
+        self,
+        b: TensorRead<'_>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+    fn slogdet_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    fn det_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn inv_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn eigvalsh_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn eigvals_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn pinv_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    fn pinv_with_rtol_read<B: LinalgBackend>(
+        self,
+        rtol: f64,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+    fn norm_read<B: LinalgBackend>(
+        self,
+        ord: Option<f64>,
+        dim: Option<&[usize]>,
+        keepdim: bool,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor>;
+}
+
+/// Linear algebra methods with statically typed inputs and outputs.
+///
+/// Singular values, Hermitian eigenvalues, determinant log-magnitudes, and
+/// norms use `T::Real`; general eigenvalues and eigenvectors use `T::Complex`.
+pub trait TypedTensorLinalgExt<T: LinalgScalar> {
+    fn svd<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedSvd<T>>;
+    fn svd_with_options<B: LinalgBackend>(
+        &self,
+        options: SvdOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedSvd<T>>;
+    fn qr<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)>;
+    fn qr_with_options<B: LinalgBackend>(
+        &self,
+        options: QrOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)>;
+    fn lu<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedLu<T>>;
+    fn full_piv_lu<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedFullPivLu<T>>;
+    fn full_piv_lu_solve<B: LinalgBackend>(
+        &self,
+        b: &TypedTensor<T>,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn solve<B: LinalgBackend>(
+        &self,
+        b: &TypedTensor<T>,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn cholesky<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn eigh<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(TypedTensor<<T as TensorScalar>::Real>, TypedTensor<T>)>;
+    fn eigh_with_options<B: LinalgBackend>(
+        &self,
+        options: EighOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(TypedTensor<<T as TensorScalar>::Real>, TypedTensor<T>)>;
+    fn eig<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedEig<T>>;
+    #[allow(clippy::too_many_arguments)]
+    fn triangular_solve<B: LinalgBackend>(
+        &self,
+        b: &TypedTensor<T>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn slogdet<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<<T as TensorScalar>::Real>)>;
+    fn det<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn inv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn eigvalsh<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<<T as TensorScalar>::Real>>;
+    fn eigvals<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T::Complex>>;
+    fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn pinv_with_rtol<B: LinalgBackend>(
+        &self,
+        rtol: f64,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    fn norm<B: LinalgBackend>(
+        &self,
+        ord: Option<f64>,
+        dim: Option<&[usize]>,
+        keepdim: bool,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<<T as TensorScalar>::Real>>;
+}
+
+impl TensorLinalgExt for Tensor {
+    fn svd<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)> {
+        three(backend.svd(self)?, "svd")
+    }
+    fn svd_with_options<B: LinalgBackend>(
+        &self,
+        options: SvdOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)> {
+        three(backend.svd_with_options(self, options)?, "svd_with_options")
+    }
+    fn qr<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        two(backend.qr(self)?, "qr")
+    }
+    fn qr_with_options<B: LinalgBackend>(
+        &self,
+        options: QrOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        two(backend.qr_with_options(self, options)?, "qr_with_options")
+    }
+    fn lu<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor)> {
+        four(backend.lu(self)?, "lu")
+    }
+    fn full_piv_lu<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)> {
+        five(backend.full_piv_lu(self)?, "full_piv_lu")
+    }
+    fn full_piv_lu_solve<B: LinalgBackend>(
+        &self,
+        b: &Tensor,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        backend.full_piv_lu_solve(self, b, false)
+    }
+    fn solve<B: LinalgBackend>(
+        &self,
+        b: &Tensor,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        backend.solve(self, b)
+    }
+    fn cholesky<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+        backend.cholesky(self)
+    }
+    fn eigh<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        two(backend.eigh(self)?, "eigh")
+    }
+    fn eigh_with_options<B: LinalgBackend>(
+        &self,
+        options: EighOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        two(
+            backend.eigh_with_options(self, options)?,
+            "eigh_with_options",
+        )
+    }
+    fn eig<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        two(backend.eig(self)?, "eig")
+    }
+    fn triangular_solve<B: LinalgBackend>(
+        &self,
+        b: &Tensor,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        backend.triangular_solve(self, b, left_side, lower, transpose_a, unit_diagonal)
+    }
+    fn slogdet<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        slogdet_from_lu(four(backend.lu(self)?, "slogdet")?, backend)
+    }
+    fn det<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+        det_impl(self.slogdet(backend)?, backend)
+    }
+    fn inv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+        inv_owned(self, backend)
+    }
+    fn eigvalsh<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+        Ok(self.eigh(backend)?.0)
+    }
+    fn eigvals<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+        Ok(self.eig(backend)?.0)
+    }
+    fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+        pinv_owned(self, None, backend)
+    }
+    fn pinv_with_rtol<B: LinalgBackend>(
+        &self,
+        rtol: f64,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        pinv_owned(self, Some(rtol), backend)
+    }
+    fn norm<B: LinalgBackend>(
+        &self,
+        ord: Option<f64>,
+        dim: Option<&[usize]>,
+        keepdim: bool,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        norm_from_read(TensorRead::from_tensor(self), ord, dim, keepdim, backend)
+    }
+}
+
+impl TensorReadLinalgExt for TensorRead<'_> {
+    fn svd_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)> {
+        three(backend.svd_read(self)?, "svd_read")
+    }
+    fn svd_with_options_read<B: LinalgBackend>(
+        self,
+        options: SvdOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)> {
+        validate_derivative_eps("svd_with_options_read", options.derivative_eps)?;
+        let mut out = backend.svd_read(self)?;
+        apply_svd_gauge(options.gauge, &mut out)?;
+        three(out, "svd_with_options_read")
+    }
+    fn qr_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        two(backend.qr_read(self)?, "qr_read")
+    }
+    fn qr_with_options_read<B: LinalgBackend>(
+        self,
+        options: QrOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        let mut out = backend.qr_read(self)?;
+        apply_qr_gauge(options.gauge, &mut out)?;
+        two(out, "qr_with_options_read")
+    }
+    fn lu_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor)> {
+        four(backend.lu_read(self)?, "lu_read")
+    }
+    fn full_piv_lu_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)> {
+        five(backend.full_piv_lu_read(self)?, "full_piv_lu_read")
+    }
+    fn full_piv_lu_solve_read<B: LinalgBackend>(
+        self,
+        b: TensorRead<'_>,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        let b_is_vector = b.shape().len() + 1 == self.shape().len();
+        let original_b_shape = b.shape().to_vec();
+        let vector_as_matrix = if b_is_vector {
+            let mut shape = vec![b.shape()[0], 1];
+            shape.extend_from_slice(&b.shape()[1..]);
+            Some(backend.with_backend_session(|exec| exec.reshape_read(b.clone(), &shape))?)
+        } else {
+            None
+        };
+        let b = vector_as_matrix.as_ref().map_or(b, TensorRead::from_tensor);
+        let (p, l, u, q, _parity) = self.full_piv_lu_read(backend)?;
+        let pb = linalg_matmul_read(&p, b, false, backend)?;
+        let z = backend.triangular_solve_read(
+            TensorRead::from_tensor(&l),
+            TensorRead::from_tensor(&pb),
+            true,
+            true,
+            false,
+            true,
+        )?;
+        let w = backend.triangular_solve_read(
+            TensorRead::from_tensor(&u),
+            TensorRead::from_tensor(&z),
+            true,
+            false,
+            false,
+            false,
+        )?;
+        let mut perm: Vec<usize> = (0..q.shape().len()).collect();
+        perm.swap(0, 1);
+        let qt = transpose(&q, &perm, backend)?;
+        let solution = linalg_matmul_read(&qt, TensorRead::from_tensor(&w), false, backend)?;
+        if b_is_vector {
+            reshape(&solution, &original_b_shape, backend)
+        } else {
+            Ok(solution)
+        }
+    }
+    fn solve_read<B: LinalgBackend>(
+        self,
+        b: TensorRead<'_>,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        backend.solve_read(self, b)
+    }
+    fn cholesky_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+        backend.cholesky_read(self)
+    }
+    fn eigh_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        two(backend.eigh_read(self)?, "eigh_read")
+    }
+    fn eigh_with_options_read<B: LinalgBackend>(
+        self,
+        options: EighOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        validate_derivative_eps("eigh_with_options_read", options.derivative_eps)?;
+        let mut out = backend.eigh_read(self)?;
+        apply_eigh_gauge(options.gauge, &mut out)?;
+        two(out, "eigh_with_options_read")
+    }
+    fn eig_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        two(backend.eig_read(self)?, "eig_read")
+    }
+    fn triangular_solve_read<B: LinalgBackend>(
+        self,
+        b: TensorRead<'_>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        backend.triangular_solve_read(self, b, left_side, lower, transpose_a, unit_diagonal)
+    }
+    fn slogdet_read<B: LinalgBackend>(
+        self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+        slogdet_from_lu(four(backend.lu_read(self)?, "slogdet_read")?, backend)
+    }
+    fn det_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+        det_impl(self.slogdet_read(backend)?, backend)
+    }
+    fn inv_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+        inv_read(self, backend)
+    }
+    fn eigvalsh_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+        Ok(self.eigh_read(backend)?.0)
+    }
+    fn eigvals_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+        Ok(self.eig_read(backend)?.0)
+    }
+    fn pinv_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+        pinv_read(self, None, backend)
+    }
+    fn pinv_with_rtol_read<B: LinalgBackend>(
+        self,
+        rtol: f64,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        pinv_read(self, Some(rtol), backend)
+    }
+    fn norm_read<B: LinalgBackend>(
+        self,
+        ord: Option<f64>,
+        dim: Option<&[usize]>,
+        keepdim: bool,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<Tensor> {
+        norm_from_read(self, ord, dim, keepdim, backend)
+    }
+}
+
+impl<T: LinalgScalar> TypedTensorLinalgExt<T> for TypedTensor<T> {
+    fn svd<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedSvd<T>> {
+        typed_svd(T::tensor_read(self).svd_read(backend)?)
+    }
+
+    fn svd_with_options<B: LinalgBackend>(
+        &self,
+        options: SvdOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedSvd<T>> {
+        typed_svd(T::tensor_read(self).svd_with_options_read(options, backend)?)
+    }
+
+    fn qr<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)> {
+        typed_pair_same(T::tensor_read(self).qr_read(backend)?)
+    }
+
+    fn qr_with_options<B: LinalgBackend>(
+        &self,
+        options: QrOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)> {
+        typed_pair_same(T::tensor_read(self).qr_with_options_read(options, backend)?)
+    }
+
+    fn lu<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedLu<T>> {
+        let (p, l, u, parity) = T::tensor_read(self).lu_read(backend)?;
+        Ok((
+            typed_output::<T>(p)?,
+            typed_output::<T>(l)?,
+            typed_output::<T>(u)?,
+            typed_output::<<T as TensorScalar>::Real>(parity)?,
+        ))
+    }
+
+    fn full_piv_lu_solve<B: LinalgBackend>(
+        &self,
+        b: &TypedTensor<T>,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T>> {
+        typed_output::<T>(T::tensor_read(self).full_piv_lu_solve_read(T::tensor_read(b), backend)?)
+    }
+
+    fn full_piv_lu<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedFullPivLu<T>> {
+        let (p, l, u, q, parity) = T::tensor_read(self).full_piv_lu_read(backend)?;
+        Ok((
+            typed_output::<T>(p)?,
+            typed_output::<T>(l)?,
+            typed_output::<T>(u)?,
+            typed_output::<T>(q)?,
+            typed_output::<<T as TensorScalar>::Real>(parity)?,
+        ))
+    }
+
+    fn solve<B: LinalgBackend>(
+        &self,
+        b: &TypedTensor<T>,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T>> {
+        typed_output::<T>(T::tensor_read(self).solve_read(T::tensor_read(b), backend)?)
+    }
+
+    fn cholesky<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T>> {
+        typed_output::<T>(T::tensor_read(self).cholesky_read(backend)?)
+    }
+
+    fn eigh<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(TypedTensor<<T as TensorScalar>::Real>, TypedTensor<T>)> {
+        typed_eigh(T::tensor_read(self).eigh_read(backend)?)
+    }
+
+    fn eigh_with_options<B: LinalgBackend>(
+        &self,
+        options: EighOptions,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(TypedTensor<<T as TensorScalar>::Real>, TypedTensor<T>)> {
+        typed_eigh(T::tensor_read(self).eigh_with_options_read(options, backend)?)
+    }
+
+    fn eig<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedEig<T>> {
+        let (values, vectors) = T::tensor_read(self).eig_read(backend)?;
+        Ok((
+            typed_output::<T::Complex>(values)?,
+            typed_output::<T::Complex>(vectors)?,
+        ))
+    }
+
+    fn triangular_solve<B: LinalgBackend>(
+        &self,
+        b: &TypedTensor<T>,
+        left_side: bool,
+        lower: bool,
+        transpose_a: bool,
+        unit_diagonal: bool,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T>> {
+        typed_output::<T>(T::tensor_read(self).triangular_solve_read(
+            T::tensor_read(b),
+            left_side,
+            lower,
+            transpose_a,
+            unit_diagonal,
+            backend,
+        )?)
+    }
+
+    fn slogdet<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<<T as TensorScalar>::Real>)> {
+        let (sign, logabsdet) = T::tensor_read(self).slogdet_read(backend)?;
+        Ok((
+            typed_output::<T>(sign)?,
+            typed_output::<<T as TensorScalar>::Real>(logabsdet)?,
+        ))
+    }
+
+    fn det<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>> {
+        typed_output::<T>(T::tensor_read(self).det_read(backend)?)
+    }
+
+    fn inv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>> {
+        typed_output::<T>(T::tensor_read(self).inv_read(backend)?)
+    }
+
+    fn eigvalsh<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<<T as TensorScalar>::Real>> {
+        typed_output::<<T as TensorScalar>::Real>(T::tensor_read(self).eigvalsh_read(backend)?)
+    }
+
+    fn eigvals<B: LinalgBackend>(
+        &self,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T::Complex>> {
+        typed_output::<T::Complex>(T::tensor_read(self).eigvals_read(backend)?)
+    }
+
+    fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>> {
+        typed_output::<T>(T::tensor_read(self).pinv_read(backend)?)
+    }
+
+    fn pinv_with_rtol<B: LinalgBackend>(
+        &self,
+        rtol: f64,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<T>> {
+        typed_output::<T>(T::tensor_read(self).pinv_with_rtol_read(rtol, backend)?)
+    }
+
+    fn norm<B: LinalgBackend>(
+        &self,
+        ord: Option<f64>,
+        dim: Option<&[usize]>,
+        keepdim: bool,
+        backend: &mut B,
+    ) -> tenferro_tensor::Result<TypedTensor<<T as TensorScalar>::Real>> {
+        typed_output::<<T as TensorScalar>::Real>(
+            T::tensor_read(self).norm_read(ord, dim, keepdim, backend)?,
+        )
+    }
+}
+
+fn typed_svd<T: LinalgScalar>(
+    (u, s, vt): (Tensor, Tensor, Tensor),
+) -> tenferro_tensor::Result<TypedSvd<T>> {
+    Ok((
+        typed_output::<T>(u)?,
+        typed_output::<<T as TensorScalar>::Real>(s)?,
+        typed_output::<T>(vt)?,
+    ))
+}
+
+fn typed_pair_same<T: LinalgScalar>(
+    (a, b): (Tensor, Tensor),
+) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)> {
+    Ok((typed_output::<T>(a)?, typed_output::<T>(b)?))
+}
+
+fn typed_eigh<T: LinalgScalar>(
+    (values, vectors): (Tensor, Tensor),
+) -> tenferro_tensor::Result<(TypedTensor<<T as TensorScalar>::Real>, TypedTensor<T>)> {
+    Ok((
+        typed_output::<<T as TensorScalar>::Real>(values)?,
+        typed_output::<T>(vectors)?,
+    ))
+}
+
+fn typed_output<T: TensorScalar>(tensor: Tensor) -> tenferro_tensor::Result<TypedTensor<T>> {
+    if tensor.dtype() != T::dtype() {
+        return Err(tenferro_tensor::Error::Internal(format!(
+            "typed linalg backend contract expected {:?}, got {:?}",
+            T::dtype(),
+            tensor.dtype()
+        )));
+    }
+    T::into_typed(tensor)
+}
+
+fn arity(name: &'static str, expected: usize, actual: usize) -> tenferro_tensor::Error {
+    tenferro_tensor::Error::Internal(format!(
+        "{name} backend contract expected {expected} outputs, got {actual}"
+    ))
+}
+fn two(mut out: Vec<Tensor>, name: &'static str) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+    if out.len() != 2 {
+        return Err(arity(name, 2, out.len()));
+    }
+    let b = out.pop().unwrap();
+    let a = out.pop().unwrap();
+    Ok((a, b))
+}
+fn three(
+    mut out: Vec<Tensor>,
+    name: &'static str,
+) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)> {
+    if out.len() != 3 {
+        return Err(arity(name, 3, out.len()));
+    }
+    let c = out.pop().unwrap();
+    let b = out.pop().unwrap();
+    let a = out.pop().unwrap();
+    Ok((a, b, c))
+}
+fn four(
+    mut out: Vec<Tensor>,
+    name: &'static str,
+) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor)> {
+    if out.len() != 4 {
+        return Err(arity(name, 4, out.len()));
+    }
+    let d = out.pop().unwrap();
+    let c = out.pop().unwrap();
+    let b = out.pop().unwrap();
+    let a = out.pop().unwrap();
+    Ok((a, b, c, d))
+}
+fn five(
+    mut out: Vec<Tensor>,
+    name: &'static str,
+) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)> {
+    if out.len() != 5 {
+        return Err(arity(name, 5, out.len()));
+    }
+    let e = out.pop().unwrap();
+    let d = out.pop().unwrap();
+    let c = out.pop().unwrap();
+    let b = out.pop().unwrap();
+    let a = out.pop().unwrap();
+    Ok((a, b, c, d, e))
+}
+
+// Composite implementations are kept below the surface adapters so every
+// backend-visible operation remains explicit and testable.
+fn slogdet_from_lu<B: LinalgBackend>(
+    (_p, _l, u, parity): (Tensor, Tensor, Tensor, Tensor),
+    backend: &mut B,
+) -> tenferro_tensor::Result<(Tensor, Tensor)> {
+    let diag = backend.with_backend_session(|exec| exec.extract_diagonal(&u, 0, 1))?;
+    let sign_u = backend.with_backend_session(|exec| {
+        let sign = exec.sign_read(TensorRead::from_tensor(&diag))?;
+        exec.reduce_prod_read(TensorRead::from_tensor(&sign), &[0])
+    })?;
+    let sign = backend.with_backend_session(|exec| {
+        exec.mul_read(
+            TensorRead::from_tensor(&parity),
+            TensorRead::from_tensor(&sign_u),
+        )
+    })?;
+    let logabsdet = backend.with_backend_session(|exec| {
+        let abs = exec.abs_read(TensorRead::from_tensor(&diag))?;
+        let log = exec.log_read(TensorRead::from_tensor(&abs))?;
+        exec.reduce_sum_read(TensorRead::from_tensor(&log), &[0])
+    })?;
+    Ok((sign, logabsdet))
+}
+fn det_impl<B: LinalgBackend>(
+    (sign, logabsdet): (Tensor, Tensor),
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    backend.with_backend_session(|exec| {
+        let magnitude = exec.exp_read(TensorRead::from_tensor(&logabsdet))?;
+        exec.mul_read(
+            TensorRead::from_tensor(&sign),
+            TensorRead::from_tensor(&magnitude),
+        )
+    })
+}
+fn inv_owned<B: LinalgBackend>(a: &Tensor, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+    let eye = eye_like(a.dtype(), a.shape(), backend)?;
+    backend.solve(a, &eye)
+}
+fn inv_read<B: LinalgBackend>(
+    a: TensorRead<'_>,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let eye = eye_like(a.dtype(), a.shape(), backend)?;
+    backend.solve_read(a, TensorRead::from_tensor(&eye))
+}
+fn pinv_owned<B: LinalgBackend>(
+    a: &Tensor,
+    rtol: Option<f64>,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    ensure_float_or_complex("pinv", a.dtype())?;
+    let outputs = three(backend.svd(a)?, "pinv")?;
+    pinv_from_svd(
+        outputs,
+        rtol.unwrap_or_else(|| default_pinv_rtol(a.dtype(), a.shape())),
+        backend,
+    )
+}
+fn pinv_read<B: LinalgBackend>(
+    a: TensorRead<'_>,
+    rtol: Option<f64>,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    ensure_float_or_complex("pinv", a.dtype())?;
+    let default_rtol = default_pinv_rtol(a.dtype(), a.shape());
+    let outputs = three(backend.svd_read(a)?, "pinv_read")?;
+    pinv_from_svd(outputs, rtol.unwrap_or(default_rtol), backend)
+}
+fn norm_from_read<B: LinalgBackend>(
+    input: TensorRead<'_>,
+    ord: Option<f64>,
+    dim: Option<&[usize]>,
+    keepdim: bool,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    ensure_float_or_complex("norm", input.dtype())?;
+    let original_shape = input.shape().to_vec();
+    let axes = dim.map_or_else(
+        || (0..original_shape.len()).collect::<Vec<_>>(),
+        <[usize]>::to_vec,
+    );
+    if axes.is_empty() {
+        return backend.with_backend_session(|exec| exec.to_contiguous_read(input));
+    }
+    validate_axes("norm", original_shape.len(), &axes)?;
+    let abs = backend.with_backend_session(|exec| exec.abs_read(input))?;
+    let reduced = match axes.len() {
+        1 => norm_over_axes(&abs, &axes, ord, backend)?,
+        2 => matrix_norm(&abs, &axes, ord, backend)?,
+        _ => norm_over_axes(&abs, &axes, ord, backend)?,
+    };
+    if !keepdim {
+        return Ok(reduced);
+    }
+    let mut shape = original_shape;
+    for &axis in &axes {
+        shape[axis] = 1;
+    }
+    reshape(&reduced, &shape, backend)
+}
+
+fn scalar_real(dtype: DType, value: f64) -> tenferro_tensor::Result<Tensor> {
+    match dtype {
+        DType::F32 => Tensor::from_vec_col_major(vec![], vec![value as f32]),
+        DType::F64 => Tensor::from_vec_col_major(vec![], vec![value]),
+        DType::C32 => Tensor::from_vec_col_major(vec![], vec![Complex32::new(value as f32, 0.0)]),
+        DType::C64 => Tensor::from_vec_col_major(vec![], vec![Complex64::new(value, 0.0)]),
+        _ => Err(crate::error::unsupported_dtype("linalg_scalar", dtype)),
+    }
+}
+
+fn broadcast<B: LinalgBackend>(
+    input: &Tensor,
+    shape: &[usize],
+    dims: &[usize],
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    if input.shape() == shape {
+        return Ok(input.clone());
+    }
+    backend.with_backend_session(|exec| {
+        exec.broadcast_in_dim_read(TensorRead::from_tensor(input), shape, dims)
+    })
+}
+
+fn eye_like<B: LinalgBackend>(
+    dtype: DType,
+    shape: &[usize],
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    if shape.len() < 2 {
+        return Err(tenferro_tensor::Error::rank_mismatch("inv", 2, shape.len()));
+    }
+    let mut diagonal_shape = vec![shape[0]];
+    diagonal_shape.extend_from_slice(&shape[2..]);
+    let scalar = scalar_real(dtype, 1.0)?;
+    let diagonal = broadcast(&scalar, &diagonal_shape, &[], backend)?;
+    backend.with_backend_session(|exec| exec.embed_diagonal(&diagonal, 0, 1))
+}
+
+fn ensure_float_or_complex(op: &'static str, dtype: DType) -> tenferro_tensor::Result<()> {
+    match dtype {
+        DType::F32 | DType::F64 | DType::C32 | DType::C64 => Ok(()),
+        _ => Err(crate::error::unsupported_dtype(op, dtype)),
+    }
+}
+
+fn validate_axes(op: &'static str, rank: usize, axes: &[usize]) -> tenferro_tensor::Result<()> {
+    let mut seen = vec![false; rank];
+    for &axis in axes {
+        if axis >= rank {
+            return Err(tenferro_tensor::Error::axis_out_of_bounds(op, axis, rank));
+        }
+        if seen[axis] {
+            return Err(tenferro_tensor::Error::duplicate_axis(op, axis, "dim"));
+        }
+        seen[axis] = true;
+    }
+    Ok(())
+}
+
+fn default_pinv_rtol(dtype: DType, shape: &[usize]) -> f64 {
+    let max_dim = shape
+        .first()
+        .copied()
+        .unwrap_or(0)
+        .max(shape.get(1).copied().unwrap_or(0));
+    let eps = match dtype {
+        DType::F32 | DType::C32 => f32::EPSILON as f64,
+        DType::F64 | DType::C64 => f64::EPSILON,
+        _ => 0.0,
+    };
+    eps * max_dim as f64
+}
+
+fn pinv_from_svd<B: LinalgBackend>(
+    (u, s, vt): (Tensor, Tensor, Tensor),
+    rtol: f64,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let abs_s = backend.with_backend_session(|exec| exec.abs_read(TensorRead::from_tensor(&s)))?;
+    let s_max = reduce_max(&abs_s, &[0], backend)?;
+    let threshold_scalar = scalar_real(abs_s.dtype(), rtol.max(0.0))?;
+    let threshold = binary_mul(&s_max, &threshold_scalar, backend)?;
+    let threshold = broadcast_batch_scalar_to_leading_axis(&threshold, s.shape(), backend)?;
+    let mask = backend.with_backend_session(|exec| {
+        let mask = exec.compare_read(
+            TensorRead::from_tensor(&abs_s),
+            TensorRead::from_tensor(&threshold),
+            &CompareDir::Gt,
+        )?;
+        exec.convert(&mask, s.dtype())
+    })?;
+    let ones = ones_like(&s, backend)?;
+    let neg_mask =
+        backend.with_backend_session(|exec| exec.neg_read(TensorRead::from_tensor(&mask)))?;
+    let offset = binary_add(&ones, &neg_mask, backend)?;
+    let denom = binary_add(&s, &offset, backend)?;
+    let s_inv = backend.with_backend_session(|exec| {
+        exec.div_read(
+            TensorRead::from_tensor(&mask),
+            TensorRead::from_tensor(&denom),
+        )
+    })?;
+    let v = conjugate_transpose(&vt, backend)?;
+    let uh = conjugate_transpose(&u, backend)?;
+    let vs = scale_matrix_columns(&v, &s_inv, backend)?;
+    matmul_preserve_trailing_batch(&vs, &uh, backend)
+}
+
+fn ones_like<B: LinalgBackend>(input: &Tensor, backend: &mut B) -> tenferro_tensor::Result<Tensor> {
+    let one = scalar_real(input.dtype(), 1.0)?;
+    broadcast(&one, input.shape(), &[], backend)
+}
+
+fn binary_add<B: LinalgBackend>(
+    lhs: &Tensor,
+    rhs: &Tensor,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    backend.with_backend_session(|exec| {
+        exec.add_read(TensorRead::from_tensor(lhs), TensorRead::from_tensor(rhs))
+    })
+}
+
+fn binary_mul<B: LinalgBackend>(
+    lhs: &Tensor,
+    rhs: &Tensor,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    backend.with_backend_session(|exec| {
+        exec.mul_read(TensorRead::from_tensor(lhs), TensorRead::from_tensor(rhs))
+    })
+}
+
+fn reduce_max<B: LinalgBackend>(
+    input: &Tensor,
+    axes: &[usize],
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    backend.with_backend_session(|exec| exec.reduce_max_read(TensorRead::from_tensor(input), axes))
+}
+
+fn reduce_sum<B: LinalgBackend>(
+    input: &Tensor,
+    axes: &[usize],
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    backend.with_backend_session(|exec| exec.reduce_sum_read(TensorRead::from_tensor(input), axes))
+}
+
+fn reduce_min<B: LinalgBackend>(
+    input: &Tensor,
+    axes: &[usize],
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    backend.with_backend_session(|exec| exec.reduce_min_read(TensorRead::from_tensor(input), axes))
+}
+
+fn reshape<B: LinalgBackend>(
+    input: &Tensor,
+    shape: &[usize],
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    backend.with_backend_session(|exec| exec.reshape_read(TensorRead::from_tensor(input), shape))
+}
+
+fn transpose<B: LinalgBackend>(
+    input: &Tensor,
+    perm: &[usize],
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    backend.with_backend_session(|exec| exec.transpose_read(TensorRead::from_tensor(input), perm))
+}
+
+fn broadcast_batch_scalar_to_leading_axis<B: LinalgBackend>(
+    input: &Tensor,
+    shape: &[usize],
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let dims: Vec<usize> = (1..shape.len()).collect();
+    broadcast(input, shape, &dims, backend)
+}
+
+fn conjugate_transpose<B: LinalgBackend>(
+    input: &Tensor,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let conj =
+        backend.with_backend_session(|exec| exec.conj_read(TensorRead::from_tensor(input)))?;
+    let mut perm: Vec<usize> = (0..input.shape().len()).collect();
+    perm.swap(0, 1);
+    transpose(&conj, &perm, backend)
+}
+
+fn scale_matrix_columns<B: LinalgBackend>(
+    matrix: &Tensor,
+    scale: &Tensor,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let mut scale_shape = vec![1, scale.shape()[0]];
+    scale_shape.extend_from_slice(&matrix.shape()[2..]);
+    let reshaped = reshape(scale, &scale_shape, backend)?;
+    let dims: Vec<usize> = (0..matrix.shape().len()).collect();
+    let expanded = broadcast(&reshaped, matrix.shape(), &dims, backend)?;
+    binary_mul(matrix, &expanded, backend)
+}
+
+fn matmul_preserve_trailing_batch<B: LinalgBackend>(
+    lhs: &Tensor,
+    rhs: &Tensor,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let batch: Vec<usize> = (2..lhs.shape().len()).collect();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: batch.clone(),
+        rhs_batch_dims: batch,
+    };
+    backend.with_backend_session(|exec| {
+        exec.dot_general_read(
+            TensorRead::from_tensor(lhs),
+            TensorRead::from_tensor(rhs),
+            &config,
+        )
+    })
+}
+
+fn linalg_matmul_read<B: LinalgBackend>(
+    lhs: &Tensor,
+    rhs: TensorRead<'_>,
+    rhs_is_vector: bool,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let lhs_batch_dims: Vec<usize> = (2..lhs.shape().len()).collect();
+    let rhs_batch_start = if rhs_is_vector { 1 } else { 2 };
+    let rhs_batch_dims: Vec<usize> = (rhs_batch_start..rhs.shape().len()).collect();
+    let config = DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims,
+        rhs_batch_dims,
+    };
+    backend.with_backend_session(|exec| {
+        exec.dot_general_read(TensorRead::from_tensor(lhs), rhs, &config)
+    })
+}
+
+fn frobenius_norm<B: LinalgBackend>(
+    abs: &Tensor,
+    axes: &[usize],
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let two = scalar_real(abs.dtype(), 2.0)?;
+    let squared = backend.with_backend_session(|exec| {
+        exec.pow_read(TensorRead::from_tensor(abs), TensorRead::from_tensor(&two))
+    })?;
+    let sum = reduce_sum(&squared, axes, backend)?;
+    backend.with_backend_session(|exec| exec.sqrt_read(TensorRead::from_tensor(&sum)))
+}
+
+fn p_norm<B: LinalgBackend>(
+    abs: &Tensor,
+    axes: &[usize],
+    p: f64,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    if !p.is_finite() || p == 0.0 {
+        return Err(tenferro_tensor::Error::invalid_argument(
+            "norm",
+            "p",
+            format!("p-norm order must be finite and nonzero, got {p}"),
+        ));
+    }
+    let power = scalar_real(abs.dtype(), p)?;
+    let powered = backend.with_backend_session(|exec| {
+        exec.pow_read(
+            TensorRead::from_tensor(abs),
+            TensorRead::from_tensor(&power),
+        )
+    })?;
+    let sum = reduce_sum(&powered, axes, backend)?;
+    let inverse = scalar_real(abs.dtype(), 1.0 / p)?;
+    backend.with_backend_session(|exec| {
+        exec.pow_read(
+            TensorRead::from_tensor(&sum),
+            TensorRead::from_tensor(&inverse),
+        )
+    })
+}
+
+fn count_nonzero<B: LinalgBackend>(
+    abs: &Tensor,
+    axes: &[usize],
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let zero = scalar_real(abs.dtype(), 0.0)?;
+    let mask = backend.with_backend_session(|exec| {
+        exec.compare_read(
+            TensorRead::from_tensor(abs),
+            TensorRead::from_tensor(&zero),
+            &CompareDir::Gt,
+        )
+    })?;
+    let mask = backend.with_backend_session(|exec| exec.convert(&mask, abs.dtype()))?;
+    reduce_sum(&mask, axes, backend)
+}
+
+fn norm_over_axes<B: LinalgBackend>(
+    abs: &Tensor,
+    axes: &[usize],
+    ord: Option<f64>,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    match ord {
+        None => frobenius_norm(abs, axes, backend),
+        Some(p) if p == f64::INFINITY => reduce_max(abs, axes, backend),
+        Some(p) if p == f64::NEG_INFINITY => reduce_min(abs, axes, backend),
+        Some(0.0) => count_nonzero(abs, axes, backend),
+        Some(p) => p_norm(abs, axes, p, backend),
+    }
+}
+
+fn matrix_norm<B: LinalgBackend>(
+    abs: &Tensor,
+    axes: &[usize],
+    ord: Option<f64>,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let matrix = move_axes_to_front(abs, axes, backend)?;
+    match ord {
+        None => frobenius_norm(&matrix, &[0, 1], backend),
+        Some(p) if p == f64::INFINITY => row_sum_norm(&matrix, true, backend),
+        Some(p) if p == f64::NEG_INFINITY => row_sum_norm(&matrix, false, backend),
+        Some(1.0) => col_sum_norm(&matrix, true, backend),
+        Some(-1.0) => col_sum_norm(&matrix, false, backend),
+        Some(2.0) | Some(-2.0) => {
+            let (_, singular_values, _) = three(backend.svd(&matrix)?, "norm")?;
+            if ord == Some(2.0) {
+                reduce_max(&singular_values, &[0], backend)
+            } else {
+                reduce_min(&singular_values, &[0], backend)
+            }
+        }
+        Some(0.0) => count_nonzero(&matrix, &[0, 1], backend),
+        Some(p) => p_norm(&matrix, &[0, 1], p, backend),
+    }
+}
+
+fn row_sum_norm<B: LinalgBackend>(
+    input: &Tensor,
+    take_max: bool,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let sums = reduce_sum(input, &[1], backend)?;
+    if take_max {
+        reduce_max(&sums, &[0], backend)
+    } else {
+        reduce_min(&sums, &[0], backend)
+    }
+}
+
+fn col_sum_norm<B: LinalgBackend>(
+    input: &Tensor,
+    take_max: bool,
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let sums = reduce_sum(input, &[0], backend)?;
+    if take_max {
+        reduce_max(&sums, &[0], backend)
+    } else {
+        reduce_min(&sums, &[0], backend)
+    }
+}
+
+fn move_axes_to_front<B: LinalgBackend>(
+    input: &Tensor,
+    axes: &[usize],
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    if axes.iter().enumerate().all(|(index, &axis)| index == axis) {
+        return Ok(input.clone());
+    }
+    let mut selected = vec![false; input.shape().len()];
+    for &axis in axes {
+        selected[axis] = true;
+    }
+    let mut perm = axes.to_vec();
+    perm.extend(
+        selected
+            .iter()
+            .enumerate()
+            .filter_map(|(axis, selected)| (!selected).then_some(axis)),
+    );
+    transpose(input, &perm, backend)
+}

--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -16,6 +16,15 @@ use crate::extension::{
 use crate::LinalgBackend;
 
 /// Scalar types supported by statically typed linear algebra methods.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_linalg::LinalgScalar;
+///
+/// fn accepts_linalg_scalar<T: LinalgScalar>() {}
+/// accepts_linalg_scalar::<f64>();
+/// ```
 pub trait LinalgScalar: TensorScalar + private::Sealed {
     /// Complex counterpart used by general eigendecomposition.
     type Complex: TensorScalar;
@@ -43,12 +52,24 @@ impl LinalgScalar for Complex64 {
 }
 
 /// Fixed typed output tuple for singular value decomposition.
+///
+/// # Examples
+///
+/// ```rust
+/// let _: Option<tenferro_linalg::TypedSvd<f64>> = None;
+/// ```
 pub type TypedSvd<T> = (
     TypedTensor<T>,
     TypedTensor<<T as TensorScalar>::Real>,
     TypedTensor<T>,
 );
 /// Fixed typed output tuple for LU decomposition.
+///
+/// # Examples
+///
+/// ```rust
+/// let _: Option<tenferro_linalg::TypedLu<f64>> = None;
+/// ```
 pub type TypedLu<T> = (
     TypedTensor<T>,
     TypedTensor<T>,
@@ -56,6 +77,12 @@ pub type TypedLu<T> = (
     TypedTensor<<T as TensorScalar>::Real>,
 );
 /// Fixed typed output tuple for complete-pivot LU decomposition.
+///
+/// # Examples
+///
+/// ```rust
+/// let _: Option<tenferro_linalg::TypedFullPivLu<f64>> = None;
+/// ```
 pub type TypedFullPivLu<T> = (
     TypedTensor<T>,
     TypedTensor<T>,
@@ -64,6 +91,12 @@ pub type TypedFullPivLu<T> = (
     TypedTensor<<T as TensorScalar>::Real>,
 );
 /// Fixed typed output tuple for general eigendecomposition.
+///
+/// # Examples
+///
+/// ```rust
+/// let _: Option<tenferro_linalg::TypedEig<f64>> = None;
+/// ```
 pub type TypedEig<T> = (
     TypedTensor<<T as LinalgScalar>::Complex>,
     TypedTensor<<T as LinalgScalar>::Complex>,
@@ -85,47 +118,86 @@ pub type TypedEig<T> = (
 /// # Ok::<(), tenferro_tensor::Error>(())
 /// ```
 pub trait TensorLinalgExt {
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, unsupported-backend, numerical, or output-contract errors.
     fn svd<B: LinalgBackend>(
         &self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for matrix metadata or options, plus SVD backend errors.
     fn svd_with_options<B: LinalgBackend>(
         &self,
         options: SvdOptions,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, unsupported-backend, numerical, or output-contract errors.
     fn qr<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for matrix metadata or options, plus QR backend errors.
     fn qr_with_options<B: LinalgBackend>(
         &self,
         options: QrOptions,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, unsupported-backend, numerical, or output-contract errors.
     fn lu<B: LinalgBackend>(
         &self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, unsupported-backend, numerical, or output-contract errors.
     fn full_piv_lu<B: LinalgBackend>(
         &self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for incompatible inputs or a backend/singular-system error.
     fn full_piv_lu_solve<B: LinalgBackend>(
         &self,
         b: &Tensor,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for incompatible inputs or a backend/singular-system error.
     fn solve<B: LinalgBackend>(
         &self,
         b: &Tensor,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for a non-square input or backend/numerical errors.
     fn cholesky<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, unsupported-backend, convergence, or output-contract errors.
     fn eigh<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for matrix metadata or options, plus Eigh backend errors.
     fn eigh_with_options<B: LinalgBackend>(
         &self,
         options: EighOptions,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, unsupported-backend, convergence, or output-contract errors.
     fn eig<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for incompatible inputs/flags or backend/numerical errors.
     #[allow(clippy::too_many_arguments)]
     fn triangular_solve<B: LinalgBackend>(
         &self,
@@ -136,20 +208,44 @@ pub trait TensorLinalgExt {
         unit_diagonal: bool,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, unsupported-backend, numerical, or LU output-contract errors.
     fn slogdet<B: LinalgBackend>(
         &self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns the validation, backend, numerical, or contract errors from [`Self::slogdet`].
     fn det<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, unsupported-backend, or singular-solve numerical errors.
     fn inv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns the validation, backend, convergence, or contract errors from [`Self::eigh`].
     fn eigvalsh<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns the validation, backend, convergence, or contract errors from [`Self::eig`].
     fn eigvals<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, unsupported-backend, numerical, or SVD contract errors.
     fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns a validation error for invalid `rtol`, plus errors from [`Self::pinv`].
     fn pinv_with_rtol<B: LinalgBackend>(
         &self,
         rtol: f64,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for axes/order combinations or required backend operations.
     fn norm<B: LinalgBackend>(
         &self,
         ord: Option<f64>,
@@ -160,57 +256,110 @@ pub trait TensorLinalgExt {
 }
 
 /// Linear algebra methods for borrowed tensor reads.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_linalg::TensorReadLinalgExt;
+/// use tenferro_tensor::{Tensor, TensorRead};
+///
+/// let input = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0])?;
+/// let mut backend = CpuBackend::new();
+/// let (_q, r) = TensorRead::from_tensor(&input).qr_read(&mut backend)?;
+/// assert_eq!(r.shape(), &[2, 2]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
 pub trait TensorReadLinalgExt {
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, same-placement materialization, backend, numerical, or contract errors.
     fn svd_read<B: LinalgBackend>(
         self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for metadata/options, plus read/materialization or SVD errors.
     fn svd_with_options_read<B: LinalgBackend>(
         self,
         options: SvdOptions,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, same-placement materialization, backend, numerical, or contract errors.
     fn qr_read<B: LinalgBackend>(
         self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for metadata/options, plus read/materialization or QR errors.
     fn qr_with_options_read<B: LinalgBackend>(
         self,
         options: QrOptions,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, same-placement materialization, backend, numerical, or contract errors.
     fn lu_read<B: LinalgBackend>(
         self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, same-placement materialization, backend, numerical, or contract errors.
     fn full_piv_lu_read<B: LinalgBackend>(
         self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor, Tensor, Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns incompatible-input validation, read/materialization, backend, or singular errors.
     fn full_piv_lu_solve_read<B: LinalgBackend>(
         self,
         b: TensorRead<'_>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns incompatible-input validation, read/materialization, backend, or singular errors.
     fn solve_read<B: LinalgBackend>(
         self,
         b: TensorRead<'_>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns matrix validation, read/materialization, backend, or positive-definiteness errors.
     fn cholesky_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, read/materialization, backend, convergence, or contract errors.
     fn eigh_read<B: LinalgBackend>(
         self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for metadata/options, plus read or Eigh backend errors.
     fn eigh_with_options_read<B: LinalgBackend>(
         self,
         options: EighOptions,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, read/materialization, backend, convergence, or contract errors.
     fn eig_read<B: LinalgBackend>(
         self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns incompatible-input/flag validation, read, backend, or singular errors.
     #[allow(clippy::too_many_arguments)]
     fn triangular_solve_read<B: LinalgBackend>(
         self,
@@ -221,20 +370,44 @@ pub trait TensorReadLinalgExt {
         unit_diagonal: bool,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, read/materialization, backend, numerical, or LU contract errors.
     fn slogdet_read<B: LinalgBackend>(
         self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(Tensor, Tensor)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, read/materialization, backend, numerical, or contract errors.
     fn det_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, read/materialization, backend, or singular-solve errors.
     fn inv_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, read/materialization, backend, convergence, or contract errors.
     fn eigvalsh_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, read/materialization, backend, convergence, or contract errors.
     fn eigvals_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, read/materialization, backend, numerical, or SVD contract errors.
     fn pinv_read<B: LinalgBackend>(self, backend: &mut B) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns a validation error for invalid `rtol`, plus errors from [`Self::pinv_read`].
     fn pinv_with_rtol_read<B: LinalgBackend>(
         self,
         rtol: f64,
         backend: &mut B,
     ) -> tenferro_tensor::Result<Tensor>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for axes/order combinations or required read/backend operations.
     fn norm_read<B: LinalgBackend>(
         self,
         ord: Option<f64>,
@@ -248,51 +421,107 @@ pub trait TensorReadLinalgExt {
 ///
 /// Singular values, Hermitian eigenvalues, determinant log-magnitudes, and
 /// norms use `T::Real`; general eigenvalues and eigenvectors use `T::Complex`.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_cpu::CpuBackend;
+/// use tenferro_linalg::TypedTensorLinalgExt;
+/// use tenferro_tensor::TypedTensor;
+///
+/// let input = TypedTensor::<f64>::from_vec_col_major(
+///     vec![2, 2],
+///     vec![2.0, 0.0, 0.0, 4.0],
+/// )?;
+/// let mut backend = CpuBackend::new();
+/// let (_u, singular_values, _vt) = input.svd(&mut backend)?;
+/// assert_eq!(singular_values.as_slice()?, &[4.0, 2.0]);
+/// # Ok::<(), tenferro_tensor::Error>(())
+/// ```
 pub trait TypedTensorLinalgExt<T: LinalgScalar> {
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
     fn svd<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedSvd<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for metadata/options, plus backend or typed-output errors.
     fn svd_with_options<B: LinalgBackend>(
         &self,
         options: SvdOptions,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedSvd<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
     fn qr<B: LinalgBackend>(
         &self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for metadata/options, plus backend or typed-output errors.
     fn qr_with_options<B: LinalgBackend>(
         &self,
         options: QrOptions,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<T>)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
     fn lu<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedLu<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
     fn full_piv_lu<B: LinalgBackend>(
         &self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedFullPivLu<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns incompatible-input validation, backend, singular, or typed-downcast errors.
     fn full_piv_lu_solve<B: LinalgBackend>(
         &self,
         b: &TypedTensor<T>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns incompatible-input validation, backend, singular, or typed-downcast errors.
     fn solve<B: LinalgBackend>(
         &self,
         b: &TypedTensor<T>,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns matrix validation, backend, positive-definiteness, or typed-downcast errors.
     fn cholesky<B: LinalgBackend>(
         &self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, backend, convergence, output-contract, or typed-downcast errors.
     fn eigh<B: LinalgBackend>(
         &self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(TypedTensor<<T as TensorScalar>::Real>, TypedTensor<T>)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for metadata/options, plus backend or typed-output errors.
     fn eigh_with_options<B: LinalgBackend>(
         &self,
         options: EighOptions,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(TypedTensor<<T as TensorScalar>::Real>, TypedTensor<T>)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, backend, convergence, output-contract, or typed-downcast errors.
     fn eig<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedEig<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns incompatible-input/flag validation, backend, singular, or typed-output errors.
     #[allow(clippy::too_many_arguments)]
     fn triangular_solve<B: LinalgBackend>(
         &self,
@@ -303,26 +532,50 @@ pub trait TypedTensorLinalgExt<T: LinalgScalar> {
         unit_diagonal: bool,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
     fn slogdet<B: LinalgBackend>(
         &self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<(TypedTensor<T>, TypedTensor<<T as TensorScalar>::Real>)>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
     fn det<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, backend, singular-solve, or typed-downcast errors.
     fn inv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, backend, convergence, output-contract, or typed-downcast errors.
     fn eigvalsh<B: LinalgBackend>(
         &self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<<T as TensorScalar>::Real>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, backend, convergence, output-contract, or typed-downcast errors.
     fn eigvals<B: LinalgBackend>(
         &self,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T::Complex>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation, backend, numerical, output-contract, or typed-downcast errors.
     fn pinv<B: LinalgBackend>(&self, backend: &mut B) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns a validation error for invalid `rtol`, plus backend or typed-output errors.
     fn pinv_with_rtol<B: LinalgBackend>(
         &self,
         rtol: f64,
         backend: &mut B,
     ) -> tenferro_tensor::Result<TypedTensor<T>>;
+    /// # Errors
+    /// Returns `tenferro_tensor::Error::Unsupported` when the selected backend does not support the operation.
+    /// Returns validation errors for axes/order combinations, backend, or typed-output errors.
     fn norm<B: LinalgBackend>(
         &self,
         ord: Option<f64>,

--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -1537,6 +1537,7 @@ fn count_nonzero<B: LinalgBackend>(
     backend: &mut B,
 ) -> tenferro_tensor::Result<Tensor> {
     let zero = scalar_real(abs.dtype(), 0.0)?;
+    let zero = broadcast(&zero, abs.shape(), &[], backend)?;
     let mask = backend.with_backend_session(|exec| {
         exec.compare_read(
             TensorRead::from_tensor(abs),

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -950,9 +950,9 @@ pub fn slogdet(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor)> {
         _ => return Err(unexpected_output_count("lu_factor", 3)),
     };
     let diag_u = packed_lu.extract_diag(0, 1)?;
-    let sign_u = diag_u.sign()?.reduce_prod(&[0])?;
+    let sign_u = diag_u.sign()?.reduce_prod(Some(&[0]))?;
     let sign = (&parity * &sign_u)?;
-    let logabsdet = diag_u.abs()?.log()?.reduce_sum(&[0])?;
+    let logabsdet = diag_u.abs()?.log()?.reduce_sum(Some(&[0]))?;
     Ok((sign, logabsdet))
 }
 
@@ -1140,7 +1140,7 @@ pub fn pinv_with_rtol(a: &TracedTensor, rtol: f64) -> Result<TracedTensor> {
     require_concrete_shape("pinv_with_rtol", a)?;
     let (u, s, vt) = svd(a)?;
     let abs_s = s.abs()?;
-    let s_max = abs_s.reduce_max(&[0])?;
+    let s_max = abs_s.reduce_max(Some(&[0]))?;
     let s_max_shape = s_max.concrete_shape()?;
     let threshold_scalar = broadcast_scalar(scalar_real(s.dtype, rtol.max(0.0))?, &s_max_shape)?;
     let threshold = (&s_max * &threshold_scalar)?;
@@ -1207,8 +1207,8 @@ pub fn norm(
             let abs = a.abs()?;
             match ord {
                 None => frobenius_norm(&abs, &axes)?,
-                Some(p) if p == f64::INFINITY => abs.reduce_max(&axes)?,
-                Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(&axes)?,
+                Some(p) if p == f64::INFINITY => abs.reduce_max(Some(&axes))?,
+                Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(Some(&axes))?,
                 Some(0.0) => count_nonzero(&abs, &axes)?,
                 Some(p) => p_norm(&abs, &axes, p)?,
             }
@@ -1414,7 +1414,7 @@ fn matrix_transpose_perm(rank: usize) -> Vec<usize> {
 
 fn frobenius_norm(abs: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
     let squared = abs.pow(&scalar_real(abs.dtype, 2.0)?)?;
-    squared.reduce_sum(axes)?.sqrt()
+    squared.reduce_sum(Some(axes))?.sqrt()
 }
 
 fn p_norm(abs: &TracedTensor, axes: &[usize], p: f64) -> Result<TracedTensor> {
@@ -1428,7 +1428,7 @@ fn p_norm(abs: &TracedTensor, axes: &[usize], p: f64) -> Result<TracedTensor> {
     }
     let power = abs.pow(&scalar_real(abs.dtype, p)?)?;
     let inv_p = scalar_real(abs.dtype, 1.0 / p)?;
-    power.reduce_sum(axes)?.pow(&inv_p)
+    power.reduce_sum(Some(axes))?.pow(&inv_p)
 }
 
 fn default_pinv_rtol(dtype: DType, max_dim: usize) -> f64 {
@@ -1445,8 +1445,8 @@ fn vector_norm(a: &TracedTensor, axis: usize, ord: Option<f64>) -> Result<Traced
     match ord {
         None => frobenius_norm(&abs, &[axis]),
         Some(0.0) => count_nonzero(&abs, &[axis]),
-        Some(p) if p == f64::INFINITY => abs.reduce_max(&[axis]),
-        Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(&[axis]),
+        Some(p) if p == f64::INFINITY => abs.reduce_max(Some(&[axis])),
+        Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(Some(&[axis])),
         Some(p) => p_norm(&abs, &[axis], p),
     }
 }
@@ -1462,11 +1462,11 @@ fn matrix_norm(a: &TracedTensor, axes: &[usize], ord: Option<f64>) -> Result<Tra
         Some(-1.0) => matrix_col_sum_norm(&abs, false),
         Some(2.0) => {
             let singular_values = svd_values(&matrix)?.abs()?;
-            singular_values.reduce_max(&[0])
+            singular_values.reduce_max(Some(&[0]))
         }
         Some(-2.0) => {
             let singular_values = svd_values(&matrix)?.abs()?;
-            singular_values.reduce_min(&[0])
+            singular_values.reduce_min(Some(&[0]))
         }
         Some(0.0) => count_nonzero(&abs, &[0, 1]),
         Some(p) => p_norm(&abs, &[0, 1], p),
@@ -1528,24 +1528,24 @@ fn scale_matrix_columns(matrix: &TracedTensor, scale: &TracedTensor) -> Result<T
 
 fn count_nonzero(abs: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
     let mask = abs.compare(&zero_scalar(abs.dtype)?, CompareDir::Gt)?;
-    mask.convert(abs.dtype)?.reduce_sum(axes)
+    mask.convert(abs.dtype)?.reduce_sum(Some(axes))
 }
 
 fn matrix_row_sum_norm(abs: &TracedTensor, take_max: bool) -> Result<TracedTensor> {
-    let row_sums = abs.reduce_sum(&[1])?;
+    let row_sums = abs.reduce_sum(Some(&[1]))?;
     if take_max {
-        row_sums.reduce_max(&[0])
+        row_sums.reduce_max(Some(&[0]))
     } else {
-        row_sums.reduce_min(&[0])
+        row_sums.reduce_min(Some(&[0]))
     }
 }
 
 fn matrix_col_sum_norm(abs: &TracedTensor, take_max: bool) -> Result<TracedTensor> {
-    let col_sums = abs.reduce_sum(&[0])?;
+    let col_sums = abs.reduce_sum(Some(&[0]))?;
     if take_max {
-        col_sums.reduce_max(&[0])
+        col_sums.reduce_max(Some(&[0]))
     } else {
-        col_sums.reduce_min(&[0])
+        col_sums.reduce_min(Some(&[0]))
     }
 }
 

--- a/crates/tenferro-linalg/tests/integration.rs
+++ b/crates/tenferro-linalg/tests/integration.rs
@@ -2,6 +2,8 @@
 mod ad_support_manifest;
 #[path = "integration/backend_errors.rs"]
 mod backend_errors;
+#[path = "integration/concrete_surface.rs"]
+mod concrete_surface;
 #[path = "integration/cpu_linalg_source_contract.rs"]
 mod cpu_linalg_source_contract;
 #[path = "integration/eager_surface_parity.rs"]

--- a/crates/tenferro-linalg/tests/integration.rs
+++ b/crates/tenferro-linalg/tests/integration.rs
@@ -4,6 +4,8 @@ mod ad_support_manifest;
 mod backend_errors;
 #[path = "integration/cpu_linalg_source_contract.rs"]
 mod cpu_linalg_source_contract;
+#[path = "integration/eager_surface_parity.rs"]
+mod eager_surface_parity;
 #[path = "integration/eager_tensor.rs"]
 mod eager_tensor;
 #[path = "integration/full_piv_lu.rs"]

--- a/crates/tenferro-linalg/tests/integration/concrete_surface.rs
+++ b/crates/tenferro-linalg/tests/integration/concrete_surface.rs
@@ -1,0 +1,158 @@
+use num_complex::Complex64;
+use tenferro_cpu::CpuBackend;
+use tenferro_linalg::{TensorLinalgExt, TensorReadLinalgExt, TypedTensorLinalgExt};
+use tenferro_tensor::{Tensor, TensorRead, TensorScalar, TypedTensor};
+
+#[test]
+fn dynamic_and_read_surfaces_return_fixed_tuples() {
+    let input = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap();
+    let mut backend = CpuBackend::new();
+
+    let (_u, s, _vt) = input.svd(&mut backend).unwrap();
+    let (_q, r) = TensorRead::from_tensor(&input)
+        .qr_read(&mut backend)
+        .unwrap();
+    let (sign, logabsdet) = input.slogdet(&mut backend).unwrap();
+
+    assert_eq!(s.as_slice::<f64>().unwrap(), &[4.0, 2.0]);
+    assert_eq!(r.shape(), &[2, 2]);
+    assert_eq!(sign.as_slice::<f64>().unwrap(), &[1.0]);
+    assert!((logabsdet.as_slice::<f64>().unwrap()[0] - 8.0_f64.ln()).abs() < 1.0e-12);
+}
+
+#[test]
+fn typed_surface_exposes_associated_real_and_complex_outputs() {
+    let real =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap();
+    let complex = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(2.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(4.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let mut backend = CpuBackend::new();
+
+    let (_u, singular_values, _vt): (TypedTensor<f64>, TypedTensor<f64>, TypedTensor<f64>) =
+        real.svd(&mut backend).unwrap();
+    let (eigenvalues, _vectors): (TypedTensor<Complex64>, TypedTensor<Complex64>) =
+        real.eig(&mut backend).unwrap();
+    let (_cu, complex_singular_values, _cvt): (
+        TypedTensor<Complex64>,
+        TypedTensor<f64>,
+        TypedTensor<Complex64>,
+    ) = complex.svd(&mut backend).unwrap();
+
+    assert_eq!(singular_values.as_slice().unwrap(), &[4.0, 2.0]);
+    assert_eq!(complex_singular_values.as_slice().unwrap(), &[4.0, 2.0]);
+    assert_eq!(eigenvalues.shape(), &[2]);
+}
+
+#[test]
+fn typed_input_is_erased_as_a_borrowed_read() {
+    let input =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![4.0_f64, 2.0, 2.0, 3.0]).unwrap();
+    let read = f64::tensor_read(&input);
+    let mut backend = CpuBackend::new();
+
+    let factor = read.cholesky_read(&mut backend).unwrap();
+
+    assert_eq!(factor.shape(), &[2, 2]);
+}
+
+#[test]
+fn dynamic_composites_cover_inverse_pseudoinverse_eigenvalues_and_norm() {
+    let input = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap();
+    let mut backend = CpuBackend::new();
+
+    let det = input.det(&mut backend).unwrap();
+    let inv = input.inv(&mut backend).unwrap();
+    let pinv = input.pinv(&mut backend).unwrap();
+    let eigvalsh = input.eigvalsh(&mut backend).unwrap();
+    let eigvals = input.eigvals(&mut backend).unwrap();
+    let norm = input.norm(None, Some(&[0, 1]), true, &mut backend).unwrap();
+
+    assert!((det.as_slice::<f64>().unwrap()[0] - 8.0).abs() < 1.0e-12);
+    assert_eq!(inv.as_slice::<f64>().unwrap(), &[0.5, 0.0, 0.0, 0.25]);
+    assert_eq!(pinv.as_slice::<f64>().unwrap(), &[0.5, 0.0, 0.0, 0.25]);
+    assert_eq!(eigvalsh.as_slice::<f64>().unwrap(), &[2.0, 4.0]);
+    assert_eq!(eigvals.dtype(), tenferro_tensor::DType::C64);
+    assert_eq!(norm.shape(), &[1, 1]);
+    assert!((norm.as_slice::<f64>().unwrap()[0] - 20.0_f64.sqrt()).abs() < 1.0e-12);
+}
+
+#[test]
+fn read_surface_accepts_a_strided_view_without_an_input_clone() {
+    let input =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 3], vec![1.0, 0.0, 0.0, 2.0, 0.0, 0.0])
+            .unwrap();
+    let transposed = input.as_view().transpose_view([1, 0]).unwrap();
+    let read = TensorRead::from_view(f64::tensor_view(transposed));
+    let mut backend = CpuBackend::new();
+
+    let (_u, singular_values, _vt) = read.svd_read(&mut backend).unwrap();
+
+    assert_eq!(singular_values.as_slice::<f64>().unwrap(), &[2.0, 1.0]);
+}
+
+#[test]
+fn typed_complex_composites_return_real_outputs_where_required() {
+    let input = TypedTensor::<Complex64>::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex64::new(2.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(0.0, 0.0),
+            Complex64::new(4.0, 0.0),
+        ],
+    )
+    .unwrap();
+    let mut backend = CpuBackend::new();
+
+    let (_sign, logabsdet): (TypedTensor<Complex64>, TypedTensor<f64>) =
+        input.slogdet(&mut backend).unwrap();
+    let norm: TypedTensor<f64> = input
+        .norm(None, Some(&[0, 1]), false, &mut backend)
+        .unwrap();
+
+    assert!((logabsdet.as_slice().unwrap()[0] - 8.0_f64.ln()).abs() < 1.0e-12);
+    assert!((norm.as_slice().unwrap()[0] - 20.0_f64.sqrt()).abs() < 1.0e-12);
+}
+
+#[test]
+fn typed_solve_surfaces_accept_vector_and_matrix_rhs() {
+    let a =
+        TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap();
+    let vector = TypedTensor::<f64>::from_vec_col_major(vec![2], vec![4.0, 8.0]).unwrap();
+    let matrix = TypedTensor::<f64>::from_vec_col_major(vec![2, 1], vec![4.0, 8.0]).unwrap();
+    let mut backend = CpuBackend::new();
+
+    let vector_x = a.full_piv_lu_solve(&vector, &mut backend).unwrap();
+    let matrix_x = a.full_piv_lu_solve(&matrix, &mut backend).unwrap();
+    let triangular_x = a
+        .triangular_solve(&matrix, true, false, false, false, &mut backend)
+        .unwrap();
+
+    assert_eq!(vector_x.as_slice().unwrap(), &[2.0, 2.0]);
+    assert_eq!(matrix_x.as_slice().unwrap(), &[2.0, 2.0]);
+    assert_eq!(triangular_x.as_slice().unwrap(), &[2.0, 2.0]);
+}
+
+#[test]
+fn concrete_norm_distinguishes_empty_axes_and_rejects_invalid_axes() {
+    let input = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
+    let mut backend = CpuBackend::new();
+
+    let identity = input
+        .norm(Some(2.0), Some(&[]), false, &mut backend)
+        .unwrap();
+    let error = input
+        .norm(Some(2.0), Some(&[1]), false, &mut backend)
+        .unwrap_err();
+
+    assert_eq!(identity.as_slice::<f64>().unwrap(), &[3.0, 4.0]);
+    assert!(error.to_string().contains("axis 1"));
+}

--- a/crates/tenferro-linalg/tests/integration/concrete_surface.rs
+++ b/crates/tenferro-linalg/tests/integration/concrete_surface.rs
@@ -1,6 +1,8 @@
 use num_complex::Complex64;
 use tenferro_cpu::CpuBackend;
-use tenferro_linalg::{TensorLinalgExt, TensorReadLinalgExt, TypedTensorLinalgExt};
+use tenferro_linalg::{
+    EighOptions, QrOptions, SvdOptions, TensorLinalgExt, TensorReadLinalgExt, TypedTensorLinalgExt,
+};
 use tenferro_tensor::{Tensor, TensorRead, TensorScalar, TypedTensor};
 
 #[test]
@@ -155,4 +157,119 @@ fn concrete_norm_distinguishes_empty_axes_and_rejects_invalid_axes() {
 
     assert_eq!(identity.as_slice::<f64>().unwrap(), &[3.0, 4.0]);
     assert!(error.to_string().contains("axis 1"));
+}
+
+#[test]
+fn read_surface_covers_factorizations_and_composites() {
+    let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]).unwrap();
+    let b = Tensor::from_vec_col_major(vec![2], vec![9.0_f64, 7.0]).unwrap();
+    let mut backend = CpuBackend::new();
+
+    TensorRead::from_tensor(&a)
+        .svd_with_options_read(SvdOptions::default(), &mut backend)
+        .unwrap();
+    TensorRead::from_tensor(&a)
+        .qr_with_options_read(QrOptions::default(), &mut backend)
+        .unwrap();
+    TensorRead::from_tensor(&a).lu_read(&mut backend).unwrap();
+    TensorRead::from_tensor(&a)
+        .full_piv_lu_read(&mut backend)
+        .unwrap();
+    let x = TensorRead::from_tensor(&a)
+        .full_piv_lu_solve_read(TensorRead::from_tensor(&b), &mut backend)
+        .unwrap();
+    TensorRead::from_tensor(&a)
+        .solve_read(TensorRead::from_tensor(&b), &mut backend)
+        .unwrap();
+    TensorRead::from_tensor(&a)
+        .eigh_with_options_read(EighOptions::default(), &mut backend)
+        .unwrap();
+    TensorRead::from_tensor(&a).eig_read(&mut backend).unwrap();
+    TensorRead::from_tensor(&a)
+        .slogdet_read(&mut backend)
+        .unwrap();
+    TensorRead::from_tensor(&a).det_read(&mut backend).unwrap();
+    TensorRead::from_tensor(&a).inv_read(&mut backend).unwrap();
+    TensorRead::from_tensor(&a)
+        .eigvalsh_read(&mut backend)
+        .unwrap();
+    TensorRead::from_tensor(&a)
+        .eigvals_read(&mut backend)
+        .unwrap();
+    TensorRead::from_tensor(&a).pinv_read(&mut backend).unwrap();
+    TensorRead::from_tensor(&a)
+        .pinv_with_rtol_read(1.0e-12, &mut backend)
+        .unwrap();
+    TensorRead::from_tensor(&a)
+        .norm_read(Some(2.0), Some(&[0, 1]), false, &mut backend)
+        .unwrap();
+
+    let actual = x.as_slice::<f64>().unwrap();
+    assert!((actual[0] - 20.0 / 11.0).abs() < 1.0e-12);
+    assert!((actual[1] - 19.0 / 11.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn typed_surface_covers_all_receiver_adapters() {
+    let a = TypedTensor::<f64>::from_vec_col_major(vec![2, 2], vec![4.0, 1.0, 1.0, 3.0]).unwrap();
+    let b = TypedTensor::<f64>::from_vec_col_major(vec![2, 1], vec![9.0, 7.0]).unwrap();
+    let mut backend = CpuBackend::new();
+
+    a.svd_with_options(SvdOptions::default(), &mut backend)
+        .unwrap();
+    a.qr(&mut backend).unwrap();
+    a.qr_with_options(QrOptions::default(), &mut backend)
+        .unwrap();
+    a.lu(&mut backend).unwrap();
+    a.full_piv_lu(&mut backend).unwrap();
+    a.solve(&b, &mut backend).unwrap();
+    a.cholesky(&mut backend).unwrap();
+    a.eigh(&mut backend).unwrap();
+    a.eigh_with_options(EighOptions::default(), &mut backend)
+        .unwrap();
+    a.det(&mut backend).unwrap();
+    a.inv(&mut backend).unwrap();
+    a.eigvalsh(&mut backend).unwrap();
+    a.eigvals(&mut backend).unwrap();
+    a.pinv(&mut backend).unwrap();
+    a.pinv_with_rtol(1.0e-12, &mut backend).unwrap();
+    let norm = a
+        .norm(Some(f64::INFINITY), Some(&[0, 1]), false, &mut backend)
+        .unwrap();
+
+    assert_eq!(norm.as_slice().unwrap(), &[5.0]);
+}
+
+#[test]
+fn concrete_norm_covers_orders_axis_permutation_and_validation() {
+    let matrix = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]).unwrap();
+    let tensor = Tensor::from_vec_col_major(
+        vec![2, 2, 2],
+        vec![1.0_f64, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0],
+    )
+    .unwrap();
+    let mut backend = CpuBackend::new();
+
+    for order in [
+        Some(0.0),
+        Some(1.0),
+        Some(-1.0),
+        Some(2.0),
+        Some(-2.0),
+        Some(f64::INFINITY),
+        Some(f64::NEG_INFINITY),
+    ] {
+        matrix
+            .norm(order, Some(&[0, 1]), false, &mut backend)
+            .unwrap();
+    }
+    tensor
+        .norm(None, Some(&[2, 0]), true, &mut backend)
+        .unwrap();
+    tensor.norm(Some(3.0), None, false, &mut backend).unwrap();
+
+    assert!(tensor
+        .norm(None, Some(&[0, 0]), false, &mut backend)
+        .is_err());
+    assert!(tensor.norm(Some(0.0), None, false, &mut backend).is_ok());
 }

--- a/crates/tenferro-linalg/tests/integration/eager_surface_parity.rs
+++ b/crates/tenferro-linalg/tests/integration/eager_surface_parity.rs
@@ -1,0 +1,116 @@
+#![cfg(feature = "autodiff")]
+
+use num_complex::Complex64;
+use tenferro_ad::{AdContext, EagerRuntime, EagerTensor, Tensor};
+use tenferro_cpu::CpuBackend;
+use tenferro_linalg::EagerTensorLinalgExt;
+
+fn eager(data: Vec<f64>, shape: Vec<usize>) -> EagerTensor {
+    EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(shape, data).unwrap(),
+        EagerRuntime::with_cpu_backend(CpuBackend::new()),
+    )
+    .unwrap()
+}
+
+fn f64_values(tensor: &EagerTensor) -> Vec<f64> {
+    tensor
+        .materialized()
+        .unwrap()
+        .as_slice::<f64>()
+        .unwrap()
+        .to_vec()
+}
+
+#[test]
+fn eager_composites_match_diagonal_matrix_values() {
+    let a = eager(vec![2.0, 0.0, 0.0, 4.0], vec![2, 2]);
+
+    let (sign, logabsdet) = a.slogdet().unwrap();
+    assert_eq!(f64_values(&sign), vec![1.0]);
+    assert!((f64_values(&logabsdet)[0] - 8.0_f64.ln()).abs() < 1.0e-12);
+    assert!((f64_values(&a.det().unwrap())[0] - 8.0).abs() < 1.0e-12);
+    assert_eq!(f64_values(&a.inv().unwrap()), vec![0.5, 0.0, 0.0, 0.25]);
+    assert_eq!(f64_values(&a.eigvalsh().unwrap()), vec![2.0, 4.0]);
+
+    let mut eigvals = a
+        .eigvals()
+        .unwrap()
+        .materialized()
+        .unwrap()
+        .as_slice::<Complex64>()
+        .unwrap()
+        .to_vec();
+    eigvals.sort_by(|lhs, rhs| lhs.re.total_cmp(&rhs.re));
+    assert_eq!(
+        eigvals,
+        vec![Complex64::new(2.0, 0.0), Complex64::new(4.0, 0.0)]
+    );
+
+    assert_eq!(f64_values(&a.pinv().unwrap()), vec![0.5, 0.0, 0.0, 0.25]);
+    assert_eq!(
+        f64_values(&a.pinv_with_rtol(1.0e-12).unwrap()),
+        vec![0.5, 0.0, 0.0, 0.25]
+    );
+    assert!((f64_values(&a.norm(None, None, false).unwrap())[0] - 20.0_f64.sqrt()).abs() < 1.0e-12);
+}
+
+#[test]
+fn eager_vector_norm_and_keepdim_follow_traced_contract() {
+    let x = eager(vec![3.0, 4.0], vec![2]);
+
+    let norm = x.norm(Some(2.0), Some(&[0]), true).unwrap();
+
+    assert_eq!(norm.shape(), &[1]);
+    assert!((f64_values(&norm)[0] - 5.0).abs() < 1.0e-12);
+}
+
+#[test]
+fn eager_norm_supports_zero_and_matrix_induced_orders() {
+    let vector = eager(vec![1.0, 0.0, 2.0, -3.0], vec![4]);
+    let matrix = eager(vec![1.0, 3.0, 2.0, 4.0], vec![2, 2]);
+
+    let cases = [
+        (vector.norm(Some(0.0), Some(&[0]), false).unwrap(), 3.0),
+        (matrix.norm(Some(1.0), Some(&[0, 1]), false).unwrap(), 6.0),
+        (matrix.norm(Some(-1.0), Some(&[0, 1]), false).unwrap(), 4.0),
+        (
+            matrix
+                .norm(Some(f64::INFINITY), Some(&[0, 1]), false)
+                .unwrap(),
+            7.0,
+        ),
+        (
+            matrix
+                .norm(Some(f64::NEG_INFINITY), Some(&[0, 1]), false)
+                .unwrap(),
+            3.0,
+        ),
+    ];
+
+    for (actual, expected) in cases {
+        assert!((f64_values(&actual)[0] - expected).abs() < 1.0e-12);
+    }
+}
+
+#[test]
+fn eager_composite_records_existing_primitives_for_backward() {
+    let ad = AdContext::builder()
+        .with_extension_rules(tenferro_linalg::ad_rules().unwrap())
+        .build()
+        .unwrap();
+    let runtime = EagerRuntime::with_cpu_backend_and_ad_context(CpuBackend::new(), &ad);
+    let a = EagerTensor::requires_grad_in(
+        Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]).unwrap(),
+        runtime,
+    )
+    .unwrap();
+
+    a.det().unwrap().backward().unwrap();
+
+    let grad = a.grad().unwrap().unwrap();
+    let actual = grad.as_slice::<f64>().unwrap();
+    for (&actual, expected) in actual.iter().zip([4.0, 0.0, 0.0, 2.0]) {
+        assert!((actual - expected).abs() < 1.0e-12);
+    }
+}

--- a/crates/tenferro-linalg/tests/integration/eager_surface_parity.rs
+++ b/crates/tenferro-linalg/tests/integration/eager_surface_parity.rs
@@ -114,3 +114,22 @@ fn eager_composite_records_existing_primitives_for_backward() {
         assert!((actual - expected).abs() < 1.0e-12);
     }
 }
+
+#[test]
+fn eager_norm_covers_remaining_orders_permutations_and_errors() {
+    let matrix = eager(vec![1.0, 3.0, 2.0, 4.0], vec![2, 2]);
+    let tensor = eager(vec![1.0, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0], vec![2, 2, 2]);
+
+    for order in [Some(2.0), Some(-2.0), Some(0.0), Some(3.0)] {
+        matrix.norm(order, Some(&[0, 1]), false).unwrap();
+    }
+    tensor.norm(None, Some(&[2, 0]), true).unwrap();
+    tensor.norm(Some(f64::INFINITY), None, false).unwrap();
+    tensor.norm(Some(f64::NEG_INFINITY), None, false).unwrap();
+    tensor.norm(Some(0.0), None, false).unwrap();
+    tensor.norm(Some(3.0), None, false).unwrap();
+
+    assert!(tensor.norm(None, Some(&[0, 0]), false).is_err());
+    assert!(tensor.norm(None, Some(&[3]), false).is_err());
+    assert!(tensor.norm(Some(f64::NAN), None, false).is_err());
+}

--- a/crates/tenferro-linalg/tests/integration/eager_tensor.rs
+++ b/crates/tenferro-linalg/tests/integration/eager_tensor.rs
@@ -60,7 +60,7 @@ fn weighted_square_sum(input: &EagerTensor, weights: Vec<f64>) -> EagerTensor {
     let squared = input.mul(input).unwrap();
     let weighted = squared.mul(&weights).unwrap();
     let axes: Vec<usize> = (0..input.shape().len()).collect();
-    weighted.reduce_sum(&axes).unwrap()
+    weighted.reduce_sum(Some(&axes)).unwrap()
 }
 
 fn matmul2(lhs: &[f64], rhs: &[f64]) -> [f64; 4] {
@@ -154,7 +154,7 @@ fn svd_singular_value_sum_backward_does_not_panic() {
     )
     .unwrap();
     let (_, s, _) = a.svd().unwrap();
-    let loss = s.reduce_sum(&[0]).unwrap();
+    let loss = s.reduce_sum(Some(&[0])).unwrap();
 
     loss.backward().unwrap();
 
@@ -319,7 +319,7 @@ fn batched_solve_sum_backward_wrt_matrix_uses_native_batch_layout() {
     .unwrap();
 
     let x = a.solve(&b).unwrap();
-    let loss = x.reduce_sum(&[0, 1, 2]).unwrap();
+    let loss = x.reduce_sum(Some(&[0, 1, 2])).unwrap();
     let _ = loss.backward().unwrap();
     let grad = a.grad().unwrap().unwrap();
 

--- a/crates/tenferro-linalg/tests/integration/traced_ad_explicit.rs
+++ b/crates/tenferro-linalg/tests/integration/traced_ad_explicit.rs
@@ -42,7 +42,7 @@ fn eval_many(outputs: &[&TracedTensor]) -> Vec<Tensor> {
 
 fn reduce_all(tensor: &TracedTensor) -> TracedTensor {
     let axes: Vec<usize> = (0..tensor.rank).collect();
-    tensor.reduce_sum(&axes).unwrap()
+    tensor.reduce_sum(Some(&axes)).unwrap()
 }
 
 fn graph_op_debugs(tensor: &TracedTensor) -> Vec<String> {
@@ -198,7 +198,7 @@ fn svd_singular_value_sum_jvp_uses_extension_ad_rule() {
     .unwrap();
 
     let (_u, s, _vt) = a.svd().unwrap();
-    let y = s.reduce_sum(&[0]).unwrap();
+    let y = s.reduce_sum(Some(&[0])).unwrap();
     let dy = ad.jvp(&y, &a, &da).unwrap();
     let out = eval(&dy);
 
@@ -216,7 +216,7 @@ fn full_piv_lu_solve_grad_uses_extension_ad_rule() {
         TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![2, 1], vec![-1.0, 5.0])).unwrap();
 
     let x = a.full_piv_lu_solve(&b).unwrap();
-    let loss = x.reduce_sum(&[0, 1]).unwrap();
+    let loss = x.reduce_sum(Some(&[0, 1])).unwrap();
     let grad_b = ad.grad(&loss, &b).unwrap();
     let out = eval(&grad_b);
 
@@ -338,7 +338,7 @@ fn svd_values_grad_matches_finite_diff() {
     let a = TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], data.clone())).unwrap();
 
     let (_u, s, _vt) = a.svd().unwrap();
-    let loss = s.reduce_sum(&[0]).unwrap();
+    let loss = s.reduce_sum(Some(&[0])).unwrap();
     let grad = ad.grad(&loss, &a).unwrap();
     let out = eval(&grad);
 
@@ -351,7 +351,7 @@ fn svd_values_grad_matches_finite_diff() {
                     TracedTensor::from_tensor_concrete_shape(f64_tensor(vec![3, 2], xs.to_vec()))
                         .unwrap();
                 let (_u, s, _vt) = input.svd().unwrap();
-                get_f64_data(&eval(&s.reduce_sum(&[0]).unwrap()))[0]
+                get_f64_data(&eval(&s.reduce_sum(Some(&[0])).unwrap()))[0]
             },
             &data,
             idx,
@@ -1402,7 +1402,7 @@ fn complex_eigh_values_grad_executes_with_complex_input_dtype() {
     ))
     .unwrap();
     let (values, _vectors) = h.eigh().unwrap();
-    let loss = values.reduce_sum(&[0]).unwrap();
+    let loss = values.reduce_sum(Some(&[0])).unwrap();
 
     let grad = ad.grad(&loss, &h).unwrap();
     let out = eval(&grad);
@@ -1428,7 +1428,7 @@ fn batched_solve_sum_grad_wrt_matrix_uses_native_batch_layout() {
     .unwrap();
 
     let x = a.solve(&b).unwrap();
-    let loss = x.reduce_sum(&[0, 1, 2]).unwrap();
+    let loss = x.reduce_sum(Some(&[0, 1, 2])).unwrap();
     let grad_a = ad.grad(&loss, &a).unwrap();
     let out = eval(&grad_a);
 

--- a/crates/tenferro-runtime/src/graph/compiler/constraint_scope_tests.rs
+++ b/crates/tenferro-runtime/src/graph/compiler/constraint_scope_tests.rs
@@ -313,7 +313,7 @@ fn assert_eliminated_layout_keeps_live_constraint(output: TracedTensor) {
 fn graph_scoped_constraint_survives_identity_reshape_elimination() {
     let lhs = TracedTensor::from_vec_col_major(vec![7], vec![1.0_f64; 7]).unwrap();
     let rhs = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
-    let base = lhs.add(&rhs.reduce_sum(&[0]).unwrap()).unwrap();
+    let base = lhs.add(&rhs.reduce_sum(Some(&[0])).unwrap()).unwrap();
     let output = base.reshape(&[7]).unwrap();
 
     assert_eliminated_layout_keeps_live_constraint(attach_violated_scope_to_layout_output(
@@ -325,7 +325,7 @@ fn graph_scoped_constraint_survives_identity_reshape_elimination() {
 fn graph_scoped_constraint_survives_identity_transpose_elimination() {
     let lhs = TracedTensor::from_vec_col_major(vec![7], vec![1.0_f64; 7]).unwrap();
     let rhs = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64; 3]).unwrap();
-    let base = lhs.add(&rhs.reduce_sum(&[0]).unwrap()).unwrap();
+    let base = lhs.add(&rhs.reduce_sum(Some(&[0])).unwrap()).unwrap();
     let output = base.transpose(&[0]).unwrap();
 
     assert_eliminated_layout_keeps_live_constraint(attach_violated_scope_to_layout_output(

--- a/crates/tenferro-runtime/src/traced.rs
+++ b/crates/tenferro-runtime/src/traced.rs
@@ -1823,8 +1823,12 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
-    /// let y = x.reduce_sum(&[0])?;
-    /// let y2 = x.reduce_sum(&[0])?;
+    /// let total = x.reduce_sum(None)?;
+    /// let rows = x.reduce_sum(Some(&[1]))?;
+    /// let identity = x.reduce_sum(Some(&[]))?;
+    /// assert_eq!(total.rank, 0);
+    /// assert_eq!(rows.rank, 1);
+    /// assert_eq!(identity.rank, 2);
     /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
     ///
@@ -1834,13 +1838,12 @@ impl TracedTensor {
     /// outside the input rank or `DuplicateAxis` when `axes` repeats an axis,
     /// or [`Error::RuntimeStateSource`] when output metadata cannot be
     /// registered.
-    pub fn reduce_sum(&self, axes: &[usize]) -> Result<TracedTensor> {
+    pub fn reduce_sum(&self, axes: Option<&[usize]>) -> Result<TracedTensor> {
+        let axes = axes.map_or_else(|| (0..self.rank).collect(), <[usize]>::to_vec);
         let (out_rank, out_shape_hint) =
-            reduction_output_meta(self, axes, "TracedTensor::reduce_sum")?;
+            reduction_output_meta(self, &axes, "TracedTensor::reduce_sum")?;
         apply_unary(
-            StdTensorOp::ReduceSum {
-                axes: axes.to_vec(),
-            },
+            StdTensorOp::ReduceSum { axes },
             self,
             out_rank,
             out_shape_hint,
@@ -1857,7 +1860,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
-    /// let y = x.reduce_max(&[0])?;
+    /// let y = x.reduce_max(Some(&[0]))?;
     /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
     ///
@@ -1868,13 +1871,12 @@ impl TracedTensor {
     /// [`Error::Unsupported`] when a non-empty maximum reduction receives a
     /// complex dtype, or [`Error::RuntimeStateSource`] when output metadata
     /// cannot be registered.
-    pub fn reduce_max(&self, axes: &[usize]) -> Result<TracedTensor> {
+    pub fn reduce_max(&self, axes: Option<&[usize]>) -> Result<TracedTensor> {
+        let axes = axes.map_or_else(|| (0..self.rank).collect(), <[usize]>::to_vec);
         let (out_rank, out_shape_hint) =
-            reduction_output_meta(self, axes, "TracedTensor::reduce_max")?;
+            reduction_output_meta(self, &axes, "TracedTensor::reduce_max")?;
         try_apply_unary(
-            StdTensorOp::ReduceMax {
-                axes: axes.to_vec(),
-            },
+            StdTensorOp::ReduceMax { axes },
             self,
             out_rank,
             out_shape_hint,
@@ -1892,7 +1894,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
-    /// let y = x.reduce_min(&[0])?;
+    /// let y = x.reduce_min(Some(&[0]))?;
     /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
     ///
@@ -1903,13 +1905,12 @@ impl TracedTensor {
     /// [`Error::Unsupported`] when a non-empty minimum reduction receives a
     /// complex dtype, or [`Error::RuntimeStateSource`] when output metadata
     /// cannot be registered.
-    pub fn reduce_min(&self, axes: &[usize]) -> Result<TracedTensor> {
+    pub fn reduce_min(&self, axes: Option<&[usize]>) -> Result<TracedTensor> {
+        let axes = axes.map_or_else(|| (0..self.rank).collect(), <[usize]>::to_vec);
         let (out_rank, out_shape_hint) =
-            reduction_output_meta(self, axes, "TracedTensor::reduce_min")?;
+            reduction_output_meta(self, &axes, "TracedTensor::reduce_min")?;
         try_apply_unary(
-            StdTensorOp::ReduceMin {
-                axes: axes.to_vec(),
-            },
+            StdTensorOp::ReduceMin { axes },
             self,
             out_rank,
             out_shape_hint,
@@ -1924,7 +1925,7 @@ impl TracedTensor {
     /// ```rust
     /// # use tenferro_runtime::TracedTensor;
     /// # let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
-    /// let y = x.reduce_prod(&[0])?;
+    /// let y = x.reduce_prod(Some(&[0]))?;
     /// # Ok::<(), tenferro_runtime::Error>(())
     /// ```
     ///
@@ -1934,13 +1935,12 @@ impl TracedTensor {
     /// outside the input rank or `DuplicateAxis` when `axes` repeats an axis,
     /// or [`Error::RuntimeStateSource`] when output metadata cannot be
     /// registered.
-    pub fn reduce_prod(&self, axes: &[usize]) -> Result<TracedTensor> {
+    pub fn reduce_prod(&self, axes: Option<&[usize]>) -> Result<TracedTensor> {
+        let axes = axes.map_or_else(|| (0..self.rank).collect(), <[usize]>::to_vec);
         let (out_rank, out_shape_hint) =
-            reduction_output_meta(self, axes, "TracedTensor::reduce_prod")?;
+            reduction_output_meta(self, &axes, "TracedTensor::reduce_prod")?;
         apply_unary(
-            StdTensorOp::ReduceProd {
-                axes: axes.to_vec(),
-            },
+            StdTensorOp::ReduceProd { axes },
             self,
             out_rank,
             out_shape_hint,

--- a/crates/tenferro-runtime/src/traced/tests.rs
+++ b/crates/tenferro-runtime/src/traced/tests.rs
@@ -114,7 +114,7 @@ fn dot_general_keeps_existing_success_metadata() {
 fn reductions_reject_invalid_axes_instead_of_saturating_rank() {
     let x = TracedTensor::from_vec_col_major(vec![2, 3], vec![1.0_f64; 6]).unwrap();
 
-    let out_of_bounds = x.reduce_max(&[2]).unwrap_err();
+    let out_of_bounds = x.reduce_max(Some(&[2])).unwrap_err();
     assert!(
         out_of_bounds
             .to_string()
@@ -122,15 +122,28 @@ fn reductions_reject_invalid_axes_instead_of_saturating_rank() {
         "{out_of_bounds}"
     );
 
-    let duplicate = x.reduce_min(&[0, 0]).unwrap_err();
+    let duplicate = x.reduce_min(Some(&[0, 0])).unwrap_err();
     assert!(
         duplicate.to_string().contains("duplicate reduction axis 0"),
         "{duplicate}"
     );
 
-    let y = x.reduce_sum(&[1]).unwrap();
+    let y = x.reduce_sum(Some(&[1])).unwrap();
     assert_eq!(y.rank, 1);
     assert_eq!(y.try_concrete_shape().unwrap(), &[2]);
+}
+
+#[test]
+fn reductions_distinguish_all_axes_from_empty_axes() {
+    let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 2.0, 3.0, 4.0]).unwrap();
+
+    assert_eq!(x.reduce_sum(None).unwrap().rank, 0);
+    assert_eq!(x.reduce_prod(Some(&[])).unwrap().rank, 2);
+    assert_eq!(x.reduce_max(Some(&[0])).unwrap().rank, 1);
+    assert_eq!(x.reduce_min(None).unwrap().rank, 0);
+
+    let scalar = TracedTensor::from_vec_col_major(vec![], vec![3.0_f64]).unwrap();
+    assert_eq!(scalar.reduce_sum(None).unwrap().rank, 0);
 }
 
 #[test]
@@ -369,7 +382,7 @@ fn ordered_reductions_reject_complex_dtype_without_panicking() {
     )
     .unwrap();
 
-    let err = x.reduce_max(&[0]).unwrap_err();
+    let err = x.reduce_max(Some(&[0])).unwrap_err();
 
     assert!(
         err.to_string()

--- a/crates/tenferro-runtime/tests/integration/runtime_public_api.rs
+++ b/crates/tenferro-runtime/tests/integration/runtime_public_api.rs
@@ -260,7 +260,7 @@ fn traced_shape_packing_rejects_symbolic_shapes_as_graph_build_errors() {
 #[test]
 fn graph_executor_runs_elementwise_and_reduction_with_borrowed_inputs() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 1).unwrap();
-    let y = (&x + &x).unwrap().reduce_sum(&[0]).unwrap();
+    let y = (&x + &x).unwrap().reduce_sum(Some(&[0])).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&y, &[(&x, DType::F64, &[2])])
@@ -300,7 +300,7 @@ fn traced_broadcast_binary_accepts_symbolic_same_rank_input() {
 fn traced_reduction_with_too_many_axes_returns_error_without_rank_underflow() {
     let x = TracedTensor::from_vec_col_major(vec![2, 2], vec![1.0_f64; 4]).unwrap();
 
-    let err = x.reduce_max(&[0, 1, 2]).unwrap_err().to_string();
+    let err = x.reduce_max(Some(&[0, 1, 2])).unwrap_err().to_string();
 
     assert!(err.contains("axis 2 out of bounds for rank 2"), "{err}");
 }

--- a/crates/tenferro-xla/tests/integration/stablehlo_lowering.rs
+++ b/crates/tenferro-xla/tests/integration/stablehlo_lowering.rs
@@ -5,7 +5,7 @@ use tenferro_xla::lower_to_stablehlo;
 #[test]
 fn lowers_elementwise_reduce_and_static_shapes() {
     let x = TracedTensor::input_symbolic_shape(DType::F64, 2).unwrap();
-    let y = (&x + &x).unwrap().reduce_sum(&[0]).unwrap();
+    let y = (&x + &x).unwrap().reduce_sum(Some(&[0])).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(&y, &[(&x, DType::F64, &[2, 3])])

--- a/crates/tenferro-xla/tests/integration/xla_tool_execution.rs
+++ b/crates/tenferro-xla/tests/integration/xla_tool_execution.rs
@@ -119,7 +119,7 @@ fn stablehlo_dot_add_reduce_module() -> tenferro_xla::StableHloModule {
             },
         )
         .unwrap();
-    let y = (&dot + &dot).unwrap().reduce_sum(&[0]).unwrap();
+    let y = (&dot + &dot).unwrap().reduce_sum(Some(&[0])).unwrap();
     let mut compiler = GraphCompiler::new();
     let program = compiler
         .compile_with_input_specs(

--- a/docs/design/fft-backend-execution.md
+++ b/docs/design/fft-backend-execution.md
@@ -34,6 +34,11 @@ future Metal or CUDA implementation must be registered and selected
 explicitly. Cross-device movement remains a caller-visible operation before or
 after FFT execution.
 
+`EagerTensorFftExt` registers the same FFT runtime against `EagerBackend`.
+That adapter delegates only to the selected CPU capability today. Other eager
+backend variants return `Unsupported`; the eager surface does not download,
+upload, or select a CPU backend on their behalf.
+
 ## Cache ownership
 
 Every backend receives `FftExecutionCache`, which exposes one bounded typed

--- a/docs/design/linalg.md
+++ b/docs/design/linalg.md
@@ -26,7 +26,9 @@ tenferro-linalg
 `tenferro-linalg` owns:
 
 - shape and option validation
-- public result structs and ergonomic APIs
+- `TensorLinalgExt`, `TensorReadLinalgExt`, and `TypedTensorLinalgExt` for
+  backend-explicit primal execution
+- fixed-arity result tuples and typed real/complex output mappings
 - composite lowering
 - traced extension op payloads and runtime registration
 - optional eager helpers and linalg AD rules behind `autodiff`
@@ -70,6 +72,21 @@ ops, scalar/analytic ops, and the kernel basis above:
 - `inv` and structured `*_ex` wrappers built from solve/factorization kernels
 
 The key rule is that public API breadth does not imply backend kernel breadth.
+
+## Concrete, Read, And Typed Boundary
+
+Owned dynamic tensors call the matching `LinalgBackend` owned hook. Borrowed
+tensor reads use the `_read` surface and preserve strided layouts until the
+selected provider performs documented same-placement canonicalization. Typed
+tensors erase only the borrowed input through `TensorScalar::tensor_read`, then
+validate each dynamic backend output while downcasting it to the fixed typed
+tuple.
+
+`LinalgScalar` is sealed to `f32`, `f64`, `Complex32`, and `Complex64`. It uses
+`TensorScalar::Real` for singular values, Hermitian eigenvalues, determinant
+log-magnitudes, and norms, and supplies a `Complex` associated type for general
+eigendecomposition. These adapters never perform an implicit device transfer;
+unsupported layout or placement combinations remain typed backend errors.
 
 ## Shape Convention
 

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -120,7 +120,7 @@ use tenferro_ad::{EagerRuntime, Tensor};
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ctx = EagerRuntime::new();
     let x = ctx.variable_from(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0])?)?;
-    let loss = x.mul(&x)?.reduce_sum(&[0])?;
+    let loss = x.mul(&x)?.reduce_sum(Some(&[0]))?;
     loss.backward()?;
 
     assert_eq!(x.grad()?.unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0]);

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -211,7 +211,7 @@ fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runti
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0])?;
-    let y = (&x * &x)?.reduce_sum(&[0])?;
+    let y = (&x * &x)?.reduce_sum(Some(&[0]))?;
 
     let y_value = run(&y)?;
     assert_eq!(y_value.shape(), &[]);

--- a/docs/getting-started/pytorch-jax-mapping.md
+++ b/docs/getting-started/pytorch-jax-mapping.md
@@ -27,7 +27,7 @@ This page is a translation guide for readers who already know `torch` or `jax.nu
 | Reshape | `x.reshape(shape)` | `jnp.reshape(x, shape)` | `x.reshape(&shape, &mut ctx)` via `TensorOpsExt` | `x.reshape(&shape)?` |
 | Transpose | `x.transpose(0, 1)` | `jnp.transpose(x, axes)` | `x.transpose(&perm, &mut ctx)` via `TensorOpsExt` | `x.transpose(&perm)` |
 | Broadcast | `x.expand(...)` / implicit broadcast | implicit broadcast in many ops | backend-level op | `x.broadcast_in_dim(&shape, &dims)` |
-| Reduce sum | `x.sum(dim=...)` | `jnp.sum(x, axis=...)` | `x.reduce_sum(&axes, &mut ctx)` via `TensorOpsExt` | `x.reduce_sum(&axes)` |
+| Reduce sum | `x.sum(dim=...)` | `jnp.sum(x, axis=...)` | `x.reduce_sum(&axes, &mut ctx)` via `TensorOpsExt` | `x.reduce_sum(Some(&axes))` |
 | Einsum | `torch.einsum(spec, ...)` | `jnp.einsum(spec, ...)` | `[&a, &b].einsum(...)` via `EagerEinsumExt` | `compiler.einsum(...)` via `GraphCompilerEinsumExt` plus `register_runtime` |
 | SVD | `torch.linalg.svd(x)` | `jnp.linalg.svd(x)` | `tenferro_linalg::LinalgBackend::svd(&mut ctx, &x)?` | `x.svd()?` via `TracedTensorLinalgExt` |
 | QR | `torch.linalg.qr(x)` | `jnp.linalg.qr(x)` | `tenferro_linalg::LinalgBackend::qr(&mut ctx, &x)?` | `x.qr()?` via `TracedTensorLinalgExt` |

--- a/docs/guides/autodiff.md
+++ b/docs/guides/autodiff.md
@@ -81,7 +81,7 @@ use tenferro_linalg::TracedTensorLinalgExt;
 use tenferro_runtime::{GraphCompiler, GraphExecutor, TracedTensor};
 
 let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]);
-let loss = (&x * &x).reduce_sum(&[0]);
+let loss = (&x * &x).reduce_sum(Some(&[0]));
 let ad = AdContext::builder().build().unwrap();
 let grad = ad.grad(&loss, &x).unwrap();
 
@@ -108,7 +108,7 @@ let ad = AdContext::builder()
     .with_extension_rules(tenferro_linalg::ad_rules().unwrap())
     .build()
     .unwrap();
-let loss = factor.reduce_sum(&[0, 1]);
+let loss = factor.reduce_sum(Some(&[0, 1]));
 let grad_a = ad.grad(&loss, &a).unwrap();
 let program = compiler.compile(&grad_a).unwrap();
 

--- a/docs/guides/choosing-an-api.md
+++ b/docs/guides/choosing-an-api.md
@@ -90,7 +90,7 @@ operations.
 | --- | --- | --- | --- |
 | Everyday tensor ops | `TensorOpsExt` / `TypedTensorOpsExt` backend-explicit methods | `EagerTensor` methods / associated functions | `TracedTensor` methods / associated functions |
 | Einsum | `[&a, &b].einsum(...)` via `TensorEinsumExt` / `TypedTensorEinsumExt`; `TensorReadEinsumExt` / `TypedTensorReadEinsumExt` for views; `ConcreteEinsumPlan` for repeated fixed metadata | `[&a, &b].einsum(...)` via `EagerEinsumExt` | `compiler.einsum(...)` via `GraphCompilerEinsumExt` plus `register_runtime` |
-| FFT | `x.fft(...)` via `TensorFftExt`; `read.fft_read(...)` via `TensorReadFftExt` | Not exposed today | `x.fft(...)` via `TracedTensorFftExt` plus `register_runtime` |
+| FFT | `x.fft(...)` via `TensorFftExt`; `read.fft_read(...)` via `TensorReadFftExt` | `x.fft(...)` via `EagerTensorFftExt` with `autodiff` | `x.fft(...)` via `TracedTensorFftExt` plus `register_runtime` |
 | Tensordot sugar | Use `matmul` or `dot_general` directly | `a.tensordot(&b, axes)` via `EagerTensorEinsumExt` | `a.tensordot(&b, axes)` via `TracedTensorEinsumExt` |
 | Linear algebra | `tenferro_linalg::LinalgBackend` methods on a backend | `EagerTensorLinalgExt` methods with `autodiff` | `TracedTensorLinalgExt` methods |
 | Automatic differentiation | Not applicable | `backward()` plus `EagerRuntime` functional `grad`, `vjp`, `jvp`, HVP via composition | `grad`, `vjp`, `jvp`, HVP via composition |

--- a/docs/guides/complex-ad.md
+++ b/docs/guides/complex-ad.md
@@ -76,7 +76,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
     let z = TracedTensor::from_vec_col_major(vec![2], z_data.clone())?;
 
-    let holomorphic_loss = z.exp()?.reduce_sum(&[0])?;
+    let holomorphic_loss = z.exp()?.reduce_sum(Some(&[0]))?;
     let tenferro_grad = holomorphic_loss.grad(&z)?;
     let tenferro_grad_value = run(&tenferro_grad)?;
     let expected_grad: Vec<_> = z_data.iter().map(|z| z.exp().conj()).collect();
@@ -86,7 +86,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let magnitude = z.abs()?;
-    let real_loss = (&magnitude * &magnitude)?.reduce_sum(&[0]);
+    let real_loss = (&magnitude * &magnitude)?.reduce_sum(Some(&[0]));
     let real_loss_grad = real_loss?.grad(&z)?;
     let real_loss_grad_value = run(&real_loss_grad)?;
     let expected_real_loss_grad: Vec<_> = z_data.iter().map(|z| *z * 2.0).collect();

--- a/docs/guides/eager-operations.md
+++ b/docs/guides/eager-operations.md
@@ -231,7 +231,7 @@ let col_sum = a.reduce_sum(&[0], &mut backend).unwrap();
 assert_eq!(col_sum.shape(), &[3]);
 ```
 
-The `reduce_sum(&[0])` call removes axis `0`. For this `[2, 3]` tensor, that
+The `reduce_sum(&[0], &mut backend)` call removes axis `0`. For this `[2, 3]` tensor, that
 means summing down each column and keeping one value per column.
 
 ## Einsum
@@ -287,18 +287,18 @@ let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
 let x = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap(), ctx.clone()).unwrap();
 let y = EagerTensor::requires_grad_in(Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap(), ctx.clone()).unwrap();
 
-let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
+let loss = x.mul(&y).unwrap().reduce_sum(Some(&[0])).unwrap();
 loss.backward().unwrap();
 assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
 
-let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
+let loss = x.mul(&y).unwrap().reduce_sum(Some(&[0])).unwrap();
 loss.backward().unwrap();
 assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[6.0, 8.0]);
 
 x.clear_grad().unwrap();
 assert!(x.grad().unwrap().is_none());
 
-let loss = x.mul(&y).unwrap().reduce_sum(&[0]).unwrap();
+let loss = x.mul(&y).unwrap().reduce_sum(Some(&[0])).unwrap();
 loss.backward().unwrap();
 assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[3.0, 4.0]);
 
@@ -420,7 +420,7 @@ let x = EagerTensor::requires_grad_in(
 let y = a.matmul(&x).unwrap();
 assert_eq!(y.materialized().unwrap().as_slice::<f64>().unwrap(), &[23.0, 34.0]);
 
-let loss = y.mul(&y).unwrap().reduce_sum(&[0, 1]).unwrap();
+let loss = y.mul(&y).unwrap().reduce_sum(Some(&[0, 1])).unwrap();
 assert_eq!(loss.materialized().unwrap().as_slice::<f64>().unwrap(), &[1685.0]);
 
 loss.backward().unwrap();

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -63,13 +63,14 @@ CUDA is a backend/device choice for supported `Tensor`, `EagerTensor`, and
 | Cholesky | `cholesky` | `cholesky` | `cholesky` |
 | SVD | `svd`, `svd_with_options` | `svd`, `svd_with_options` | `svd`, `svd_with_options` |
 | QR | `qr`, `qr_with_options` | `qr`, `qr_with_options` | `qr`, `qr_with_options` |
-| Hermitian eigen | `eigh`, `eigh_with_options` | `eigh`, `eigh_with_options` | `eigh`, `eigh_with_options`, `eigvalsh` |
-| General eigen | `eig` | `eig` | `eig`, `eigvals` |
+| Hermitian eigen | `eigh`, `eigh_with_options` | `eigh`, `eigh_with_options`, `eigvalsh` | `eigh`, `eigh_with_options`, `eigvalsh` |
+| General eigen | `eig` | `eig`, `eigvals` | `eig`, `eigvals` |
 | LU | `lu` | `lu` | `lu` |
 | Complete-pivot LU | `full_piv_lu`, `full_piv_lu_solve` | `full_piv_lu`, `full_piv_lu_solve` | `full_piv_lu`, `full_piv_lu_solve` |
-| Pseudoinverse | `pinv` | - | `pinv`, `pinv_with_rtol` |
-| Determinants | `det`, `slogdet` | - | `det`, `slogdet` |
-| Norms | `norm` | - | `norm` |
+| Pseudoinverse | `pinv` | `pinv`, `pinv_with_rtol` | `pinv`, `pinv_with_rtol` |
+| Determinants | `det`, `slogdet` | `det`, `slogdet` | `det`, `slogdet` |
+| Matrix inverse | - | `inv` | `inv` |
+| Norms | `norm` | `norm` | `norm` |
 
 Concrete methods are exposed by `LinalgBackend`; eager and traced tensor APIs
 are crate-root extension traits.

--- a/docs/guides/linear-algebra.md
+++ b/docs/guides/linear-algebra.md
@@ -1,7 +1,8 @@
 # Linear Algebra
 
 tenferro exposes linear algebra through the `tenferro-linalg` operation crate.
-Use `LinalgBackend` for direct execution without autodiff, `EagerTensorLinalgExt`
+Use `TensorLinalgExt`, `TensorReadLinalgExt`, or `TypedTensorLinalgExt` for direct
+execution without autodiff, `EagerTensorLinalgExt`
 for immediate forward execution and eager `backward()` / functional transform
 workflows under an `EagerRuntime`, and `TracedTensorLinalgExt` when the
 operation should be part of a graph, `grad`/`vjp`/`jvp`, or repeated compile/run
@@ -46,7 +47,7 @@ Box<dyn std::error::Error>>` for a standalone binary.
 
 | Layer | Linear algebra style |
 | --- | --- |
-| Concrete `Tensor` | `tenferro_linalg::LinalgBackend` methods on a backend |
+| Concrete `Tensor` / `TensorRead` / `TypedTensor<T>` | crate-root linalg extension traits; methods take `&mut impl LinalgBackend` |
 | `EagerTensor` | `EagerTensorLinalgExt` methods behind `autodiff`; tracked variables support `backward()` and `EagerRuntime` functional transforms where AD rules support the operation |
 | `TracedTensor` | `TracedTensorLinalgExt` methods for graph execution and `grad`/`vjp`/`jvp` workflows |
 
@@ -69,16 +70,16 @@ CUDA is a backend/device choice for supported `Tensor`, `EagerTensor`, and
 | Complete-pivot LU | `full_piv_lu`, `full_piv_lu_solve` | `full_piv_lu`, `full_piv_lu_solve` | `full_piv_lu`, `full_piv_lu_solve` |
 | Pseudoinverse | `pinv` | `pinv`, `pinv_with_rtol` | `pinv`, `pinv_with_rtol` |
 | Determinants | `det`, `slogdet` | `det`, `slogdet` | `det`, `slogdet` |
-| Matrix inverse | - | `inv` | `inv` |
+| Matrix inverse | `inv` | `inv` | `inv` |
 | Norms | `norm` | `norm` | `norm` |
 
-Concrete methods are exposed by `LinalgBackend`; eager and traced tensor APIs
-are crate-root extension traits.
+Concrete, read, typed, eager, and traced tensor APIs are crate-root extension
+traits. `LinalgBackend` remains the provider contract passed to concrete methods.
 
 ## Concrete Solve
 
 ```rust
-use tenferro_linalg::LinalgBackend;
+use tenferro_linalg::TensorLinalgExt;
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::Tensor;
 
@@ -86,7 +87,7 @@ let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 0.0, 0.0, 9.0]);
 let b = Tensor::from_vec_col_major(vec![2, 1], vec![8.0_f64, 27.0]);
 
-let x = LinalgBackend::solve(&mut backend, &a, &b).unwrap();
+let x = a.solve(&b, &mut backend).unwrap();
 
 assert_eq!(x.shape(), &[2, 1]);
 assert_eq!(x.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
@@ -96,7 +97,7 @@ assert_eq!(x.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
 
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_linalg::LinalgBackend;
+use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{Tensor, TensorOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
@@ -111,7 +112,7 @@ fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![4.0_f64, 1.0, 1.0, 3.0]);
 
-let factor = LinalgBackend::cholesky(&mut backend, &a).unwrap();
+let factor = a.cholesky(&mut backend).unwrap();
 let factor_t = factor.transpose(&[1, 0], &mut backend).unwrap();
 let reconstructed = factor.matmul(&factor_t, &mut backend).unwrap();
 
@@ -146,7 +147,7 @@ let ad = AdContext::builder()
 
 ```rust
 use tenferro_cpu::CpuBackend;
-use tenferro_linalg::{LinalgBackend, QrGauge, QrOptions};
+use tenferro_linalg::TensorLinalgExt;
 use tenferro_runtime::{Tensor, TensorOpsExt};
 
 fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
@@ -160,10 +161,7 @@ fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f64, 3.0, 2.0, 4.0]);
-let outputs = LinalgBackend::svd(&mut backend, &a).unwrap();
-let u = &outputs[0];
-let s = &outputs[1];
-let vt = &outputs[2];
+let (u, s, vt) = a.svd(&mut backend).unwrap();
 
 assert_eq!(u.shape(), &[2, 2]);
 assert_eq!(vt.shape(), &[2, 2]);
@@ -174,7 +172,7 @@ let sigma = Tensor::from_vec_col_major(
     vec![s_values[0], 0.0, 0.0, s_values[1]],
 );
 let us = u.matmul(&sigma, &mut backend).unwrap();
-let reconstructed = us.matmul(vt, &mut backend).unwrap();
+let reconstructed = us.matmul(&vt, &mut backend).unwrap();
 
 assert!(max_abs_diff(&reconstructed, &a) < 1.0e-12);
 ```
@@ -244,7 +242,7 @@ assert_eq!(repeated.concrete_shape().unwrap(), vec![3]);
 ## QR decomposition
 
 ```rust
-use tenferro_linalg::LinalgBackend;
+use tenferro_linalg::{QrGauge, QrOptions, TensorLinalgExt};
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{Tensor, TensorOpsExt};
 
@@ -266,19 +264,17 @@ let a = Tensor::from_vec_col_major(
         3.0, 6.0, 10.0, 5.0,
     ],
 );
-let outputs = LinalgBackend::qr_with_options(
-    &mut backend,
-    &a,
-    QrOptions::default().gauge(QrGauge::PositiveDiagonal),
-)
-.unwrap();
-let q = &outputs[0];
-let r = &outputs[1];
+let (q, r) = a
+    .qr_with_options(
+        QrOptions::default().gauge(QrGauge::PositiveDiagonal),
+        &mut backend,
+    )
+    .unwrap();
 
 assert_eq!(q.shape(), &[4, 3]);
 assert_eq!(r.shape(), &[3, 3]);
 
-let reconstructed = q.matmul(r, &mut backend).unwrap();
+let reconstructed = q.matmul(&r, &mut backend).unwrap();
 let qt = q.transpose(&[1, 0], &mut backend).unwrap();
 let qtq = qt.matmul(q, &mut backend).unwrap();
 let identity = Tensor::from_vec_col_major(
@@ -293,7 +289,7 @@ assert!(max_abs_diff(&qtq, &identity) < 1.0e-12);
 ## Hermitian eigenvalue decomposition
 
 ```rust
-use tenferro_linalg::LinalgBackend;
+use tenferro_linalg::TensorLinalgExt;
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{Tensor, TensorOpsExt};
 
@@ -308,9 +304,7 @@ fn max_abs_diff(lhs: &Tensor, rhs: &Tensor) -> f64 {
 
 let mut backend = CpuBackend::new();
 let a = Tensor::from_vec_col_major(vec![2, 2], vec![2.0_f64, 1.0, 1.0, 2.0]);
-let outputs = LinalgBackend::eigh(&mut backend, &a).unwrap();
-let values = &outputs[0];
-let vectors = &outputs[1];
+let (values, vectors) = a.eigh(&mut backend).unwrap();
 
 assert_eq!(values.shape(), &[2]);
 assert_eq!(vectors.shape(), &[2, 2]);
@@ -373,11 +367,12 @@ assert_eq!(result.as_slice::<f64>().unwrap(), &[2.0, 3.0]);
 `full_piv_lu` returns `(P, L, U, Q, parity)` with the reconstruction convention
 `A = P^T * L * U * Q`, equivalently `P * A * Q^T = L * U`. The `parity` output
 is a scalar real tensor containing `+1` or `-1`: `F32` for `F32`/`C32` inputs
-and `F64` for `F64`/`C64` inputs. `full_piv_lu_solve(..., false)` solves
-`A * x = b`; passing `true` solves `A^T * x = b`.
+and `F64` for `F64`/`C64` inputs. The tensor extension
+`full_piv_lu_solve` solves `A * x = b`; the lower-level backend contract also
+exposes an explicit transpose flag.
 
 ```rust
-use tenferro_linalg::LinalgBackend;
+use tenferro_linalg::TensorLinalgExt;
 use tenferro_cpu::CpuBackend;
 use tenferro_runtime::{Tensor, TensorOpsExt};
 
@@ -402,17 +397,12 @@ let a = Tensor::from_vec_col_major(
 );
 let b = Tensor::from_vec_col_major(vec![4, 1], vec![1.0_f64, 2.0, 3.0, 4.0]);
 
-let outputs = LinalgBackend::full_piv_lu(&mut backend, &a).unwrap();
-let p = &outputs[0];
-let l = &outputs[1];
-let u = &outputs[2];
-let q = &outputs[3];
-let parity = &outputs[4];
+let (p, l, u, q, parity) = a.full_piv_lu(&mut backend).unwrap();
 let pt = p.transpose(&[1, 0], &mut backend).unwrap();
-let pt_l = pt.matmul(l, &mut backend).unwrap();
-let pt_lu = pt_l.matmul(u, &mut backend).unwrap();
-let reconstructed = pt_lu.matmul(q, &mut backend).unwrap();
-let x = LinalgBackend::full_piv_lu_solve(&mut backend, &a, &b, false).unwrap();
+let pt_l = pt.matmul(&l, &mut backend).unwrap();
+let pt_lu = pt_l.matmul(&u, &mut backend).unwrap();
+let reconstructed = pt_lu.matmul(&q, &mut backend).unwrap();
+let x = a.full_piv_lu_solve(&b, &mut backend).unwrap();
 
 assert_eq!(p.shape(), &[4, 4]);
 assert!(max_abs_diff(&reconstructed, &a) < 1.0e-12);

--- a/docs/guides/tenferro-fft.md
+++ b/docs/guides/tenferro-fft.md
@@ -2,8 +2,9 @@
 
 `tenferro-fft` is the FFT extension package for tenferro. It is an extension
 crate imported directly alongside `tenferro-runtime` or `tenferro-tensor`.
-Concrete non-AD execution uses `TensorFftExt` and `TensorReadFftExt`; traced
-graphs use `TracedTensorFftExt`.
+Concrete non-AD execution uses `TensorFftExt` and `TensorReadFftExt`; eager
+execution uses `EagerTensorFftExt` behind `autodiff`; traced graphs use
+`TracedTensorFftExt`.
 
 The current implementation provides one-dimensional CPU-host transforms backed
 by `rustfft` through tenferro extension operations. The public API is ordinary
@@ -104,6 +105,30 @@ assert_eq!(read_full.as_slice::<Complex64>()?[0], Complex64::new(10.0, 0.0));
 change dtype (`rfft` real to complex, `irfft` complex to real), so typed return
 contracts need a separate design.
 
+### Eager Tensors
+
+Use `EagerTensorFftExt` for immediate execution in an `EagerRuntime`. The
+methods have the same names and arguments as `TracedTensorFftExt`, register the
+FFT execution runtime on demand, and record the existing extension operation
+when gradients are enabled.
+
+```rust
+use num_complex::Complex64;
+use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+use tenferro_fft::{EagerTensorFftExt, FftNorm};
+
+let x = EagerTensor::from_tensor_in(
+    Tensor::from_vec_col_major(vec![4], vec![1.0_f64, 2.0, 3.0, 4.0])?,
+    EagerRuntime::new(),
+)?;
+let spectrum = x.rfft(None, -1, FftNorm::Backward)?;
+let restored = spectrum.irfft(Some(4), -1, FftNorm::Backward)?;
+
+assert_eq!(spectrum.shape(), &[3]);
+assert_eq!(restored.materialized()?.as_slice::<f64>()?, &[1.0, 2.0, 3.0, 4.0]);
+# Ok::<(), tenferro_ad::Error>(())
+```
+
 ### Traced Graphs
 
 <!-- snippet-source: crates/tenferro-fft/examples/traced_fft.rs -->
@@ -187,6 +212,8 @@ extension op and normalization.
 
 Use `AdContext` for explicit extension-rule ownership, or import
 `tenferro_ad::TracedTensorAdExt` for the compact traced AD method syntax.
+For eager AD, construct the runtime with
+`EagerRuntime::with_cpu_backend_and_ad_context` using the same `AdContext`.
 
 Real-to-complex and complex-to-real AD are not enabled yet. They require the
 usual Hermitian symmetry handling so cotangents match the half-spectrum

--- a/docs/guides/tensor-operations.md
+++ b/docs/guides/tensor-operations.md
@@ -230,7 +230,7 @@ use tenferro_ad::{EagerRuntime, Tensor};
 
 let ctx = EagerRuntime::new();
 let x = ctx.variable_from(Tensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0]).unwrap()).unwrap();
-let y = (&x * &x).reduce_sum(&[0]).unwrap();
+let y = (&x * &x).reduce_sum(Some(&[0])).unwrap();
 
 y.backward().unwrap();
 assert_eq!(x.grad().unwrap().unwrap().as_slice::<f64>().unwrap(), &[2.0, 4.0, 6.0]);

--- a/docs/spec/operation-categories.md
+++ b/docs/spec/operation-categories.md
@@ -95,6 +95,18 @@ parallelize automatically. For user-supplied closures, parallelism is explicit:
 | `mean` | · | · |
 | `argmax` / `argmin` | · | · |
 
+Reduction axes use one convention on the eager and traced surfaces:
+
+- `None` reduces over every axis;
+- `Some(&[])` is the identity operation; and
+- `Some(axes)` reduces over exactly those validated axes.
+
+The public boundary normalizes `None` to the explicit axis list before graph or
+eager operation construction. Primitive IR and backend reduction contracts
+therefore always contain explicit axes rather than a second all-axes spelling.
+For a rank-zero tensor, `None` normalizes to an empty list and remains the
+identity.
+
 ## 5. Shape / structural
 
 | Operation | Eager | Traced | Notes |

--- a/docs/superpowers/specs/2026-07-19-api-surface-parity-batch-design.md
+++ b/docs/superpowers/specs/2026-07-19-api-surface-parity-batch-design.md
@@ -1,0 +1,254 @@
+# API Surface Parity Batch Design
+
+**Issues:** #1279, #1265, #1264, and #1266
+
+**Goal:** Establish one consistent reduction-axis contract, complete eager and
+concrete linalg surfaces, and add the missing eager FFT surface without changing
+backend mathematics, AD semantics, or device-transfer behavior.
+
+## Scope And Order
+
+The work is one ordered public-surface batch with four independently testable
+slices:
+
+1. #1279 defines reduction-axis semantics used by core eager/traced reductions
+   and linalg `norm`.
+2. #1265 makes eager linalg match the resulting traced linalg vocabulary.
+3. #1264 exposes that vocabulary on concrete erased and typed tensors.
+4. #1266 adds eager FFT after PR #1424 has merged and the branch has been
+   updated to its backend-capability architecture.
+
+The first three slices may proceed immediately. The FFT slice must not resolve
+PR #1424 conflicts piecemeal. If #1424 is not merged when the first three slices
+are ready, the batch remains local or draft until the dependency is resolved.
+
+## Alternatives Considered
+
+### Reduction axes
+
+- **Selected:** public eager/traced methods take `Option<&[usize]>`; `None`
+  means all axes and `Some(&[])` means identity. Normalize to explicit axes
+  before constructing the existing operation.
+- Rejected: keep `&[usize]` and add `reduce_*_all`. This preserves a semantic
+  trap and leaves reduction-like APIs inconsistent.
+- Rejected: add a second all-axes variant to the IR. Rank is known at the public
+  eager/traced boundary, so a second internal representation adds no value.
+
+### Linalg parity implementation
+
+- **Selected:** keep the public traits explicit and implement eager composites
+  in the linalg crate using existing eager primitives. Share focused validation,
+  dtype, option, and output-count helpers where their contracts are genuinely
+  identical; enforce algebraic parity with tests.
+- Rejected: a broad generic abstraction over eager and traced tensor types. The
+  two surfaces differ in symbolic shape handling, runtime ownership, and error
+  timing, so a generic parameter bag would obscure those differences.
+- Rejected: add new backend kernels for composite operations. The linalg design
+  deliberately keeps `det`, `inv`, `pinv`, `norm`, and eigenvalue-only
+  conveniences above the kernel basis.
+
+### Concrete and typed linalg
+
+- **Selected:** crate-root extension traits delegate to existing
+  `LinalgBackend` owned/read hooks. Typed inputs use the existing dtype-erased
+  borrowed-read conversion, avoiding an input clone or a new backend contract.
+- Rejected: teach users to call `LinalgBackend` directly. That leaves linalg
+  inconsistent with einsum and FFT and exposes `Vec<Tensor>` output arity.
+- Rejected: implement typed methods by cloning into an owned `Tensor`. That
+  would create a hidden tensor-sized copy at a public convenience boundary.
+
+### Eager FFT
+
+- **Selected:** add an `autodiff`-gated extension trait that registers and
+  applies existing FFT extension operations through the eager runtime.
+- Rejected: execute a concrete FFT directly and wrap the result. That would
+  bypass eager graph recording and existing FFT AD rules.
+
+## 1. Reduction-Axis Contract
+
+The canonical eager and traced signatures become:
+
+```rust
+fn reduce_sum(&self, axes: Option<&[usize]>) -> Result<Self>;
+fn reduce_prod(&self, axes: Option<&[usize]>) -> Result<Self>;
+fn reduce_max(&self, axes: Option<&[usize]>) -> Result<Self>;
+fn reduce_min(&self, axes: Option<&[usize]>) -> Result<Self>;
+```
+
+Semantics are:
+
+- `None`: expand to `0..rank` and reduce every axis;
+- `Some(&[])`: identity, preserving shape and values;
+- `Some(axes)`: validate uniqueness and bounds, then reduce those axes.
+
+The public methods normalize to `Vec<usize>` before creating `StdTensorOp`.
+`StdTensorOp`, execution IR, and backend reduction traits continue to receive
+explicit axes. A rank-zero tensor expands `None` to an empty axis list and is
+therefore unchanged. No deprecated overload or alternative spelling remains.
+
+`TracedTensorLinalgExt::norm` and the new eager equivalent retain
+`Option<&[usize]>` and the same `None`/empty distinction. The durable contract
+is recorded in `docs/spec/operation-categories.md`.
+
+### Errors
+
+`Some(axes)` preserves typed duplicate-axis and out-of-bounds errors. `None`
+cannot produce an axis-validation error because its axes are derived from the
+input rank. Validation happens before graph mutation or eager execution.
+
+### Tests
+
+Eager and traced tests cover `None`, `Some(&[])`, one explicit axis, all four
+reduction operations, rank zero, duplicate axes, and out-of-range axes.
+Doctests demonstrate the three valid spellings. Existing callers are migrated
+directly to `Some(...)` or `None` according to intent.
+
+## 2. Eager Linalg Parity
+
+`EagerTensorLinalgExt` matches the current `TracedTensorLinalgExt` names and
+signatures. Current option-bearing names such as `svd_with_options`,
+`qr_with_options`, and `eigh_with_options` are canonical; stale `_with_eps`
+wording is not introduced.
+
+The eager surface adds the traced-only composites:
+
+- `slogdet`, `det`, and `inv`;
+- `eigvalsh` and `eigvals`;
+- `pinv` and `pinv_with_rtol`;
+- `norm`.
+
+Each composite uses existing eager linalg extension operations plus core eager
+tensor operations. It registers the linalg runtime through the established
+eager extension path. Defaults, dtype promotion, tuple order, derivative
+options, and error categories match traced behavior. No new primitive,
+backend hook, or AD rule is added.
+
+### Errors
+
+Input dtype, rank, shape, option, and axis validation occurs before applying
+the first eager operation when the corresponding facts are available. Runtime
+and numerical failures retain their existing typed sources. Unexpected
+extension output counts remain internal errors with the operation name.
+
+### Tests
+
+Compile-time trait parity tests compare the complete method vocabulary.
+Value tests compare eager and traced execution for every added family, including
+real and complex cases where output dtype differs. `norm` covers `None`, empty,
+vector, matrix, `keepdim`, and invalid axes. Existing AD numerical coverage is
+reused because the eager composites emit the same established operations; at
+least one gradient path per composite family verifies eager recording.
+
+## 3. Concrete And Typed Linalg Surfaces
+
+The crate root exports:
+
+- `TensorLinalgExt` for owned dynamic-dtype tensors;
+- `TensorReadLinalgExt` for owned references and borrowed views;
+- `TypedTensorLinalgExt<T>` for statically typed tensors.
+
+Methods use the tensor as receiver and accept `&mut B` where
+`B: LinalgBackend`. Unsuffixed owned and typed methods retain normal operation
+names. Borrowed methods use the repository `_read` vocabulary. Multi-output
+operations return tuples with fixed arity rather than `Vec<Tensor>`.
+
+The operation set matches the completed eager/traced public linalg set. Kernel
+operations delegate to the matching `LinalgBackend` owned or read hook.
+Composite operations live in `tenferro-linalg` and use backend-explicit core
+tensor operations; they do not add backend kernels.
+
+Typed dispatch is restricted by a sealed public `LinalgScalar` contract for
+`f32`, `f64`, `Complex32`, and `Complex64`. It associates:
+
+- `Real`: `f32` for `f32`/`Complex32`, `f64` for `f64`/`Complex64`;
+- `Complex`: `Complex32` for `f32`/`Complex32`, `Complex64` for
+  `f64`/`Complex64`.
+
+This gives typed output contracts such as:
+
+```rust
+fn svd<B: LinalgBackend>(
+    &self,
+    backend: &mut B,
+) -> Result<(
+    TypedTensor<T>,
+    TypedTensor<T::Real>,
+    TypedTensor<T>,
+)>;
+
+fn eig<B: LinalgBackend>(
+    &self,
+    backend: &mut B,
+) -> Result<(
+    TypedTensor<T::Complex>,
+    TypedTensor<T::Complex>,
+)>;
+```
+
+`eigh`/`eigvalsh` and `norm` return the associated real dtype where required;
+`eig`/`eigvals` return the associated complex dtype. Same-dtype operations
+return `TypedTensor<T>`. Typed inputs become `TensorRead` through the existing
+scalar erasure hook, so the convenience API does not clone input storage.
+Output downcasts validate the backend contract and report an internal error if
+a backend returns an impossible dtype or arity.
+
+### Placement And Layout
+
+The extension traits do not transfer tensors. Owned methods preserve the
+backend placement contract. Read methods pass views to existing backend read
+hooks; any provider-required same-placement canonicalization remains the
+documented backend boundary. Unsupported placement or layout returns the
+existing typed error rather than falling back to CPU or an owned operation.
+
+### Tests
+
+Tests cover tuple arity and values for all operation families, all four linalg
+scalar dtypes where supported, real/complex associated output dtypes, vector
+and matrix right-hand sides, strided reads, placement errors, dtype mismatch,
+and backend output-contract violations. Rustdoc examples bind and reuse one
+backend. Existing backend-as-receiver examples are rewritten to teach the
+extension traits.
+
+## 4. Eager FFT Surface
+
+After PR #1424 is merged, `tenferro-fft` exports `EagerTensorFftExt` behind
+`autodiff`. Its `fft`, `ifft`, `rfft`, and `irfft` signatures match the
+then-current `TracedTensorFftExt`, including `n`, signed axis handling,
+normalization, and output dtype rules.
+
+Each method validates metadata available at the eager boundary, registers the
+FFT extension runtime on the tensor's eager runtime, and applies the existing
+FFT extension operation. The implementation uses #1424's backend-neutral
+capability/cache architecture and does not construct a private host executor or
+fall back across backends.
+
+### Tests
+
+Runnable doctests cover all four methods. Integration tests compare eager and
+traced values and shapes for every transform kind, normalization modes, explicit
+lengths, negative axes, invalid axes, unsupported dtypes, and round trips.
+Existing FFT AD rules are exercised through at least one eager gradient test.
+
+## Documentation And Enforcement
+
+The implementation updates:
+
+- `docs/spec/operation-categories.md` for reduction semantics and extension
+  surface parity;
+- `docs/design/linalg.md` for the concrete/typed extension boundary;
+- public rustdoc and user examples in the affected crates;
+- the operation-category parity checker if its machine-readable expectations
+  need to recognize the new methods.
+
+One curated work log records the ordered slices, decisions, verification, and
+the #1424 dependency. The final PR closes only issues whose complete acceptance
+criteria and tests are present. The batch is merged with a non-squash merge.
+
+## Non-Goals
+
+- New linalg or FFT mathematics, kernels, providers, or AD rules.
+- CUDA/cuFFT implementation or implicit CPU/GPU transfer.
+- Compatibility shims for the old reduction signature.
+- A generic abstraction that hides differences between eager and traced
+  execution.
+- Prepared factorization or caller-owned output/workspace APIs.

--- a/docs/tutorial-code/src/bin/complex_ad_convention.rs
+++ b/docs/tutorial-code/src/bin/complex_ad_convention.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
     let z = TracedTensor::from_vec_col_major(vec![2], z_data.clone())?;
 
-    let holomorphic_loss = z.exp()?.reduce_sum(&[0])?;
+    let holomorphic_loss = z.exp()?.reduce_sum(Some(&[0]))?;
     let tenferro_grad = holomorphic_loss.grad(&z)?;
     let tenferro_grad_value = run(&tenferro_grad)?;
     let expected_grad: Vec<_> = z_data.iter().map(|z| z.exp().conj()).collect();
@@ -44,7 +44,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let magnitude = z.abs()?;
-    let real_loss = (&magnitude * &magnitude)?.reduce_sum(&[0]);
+    let real_loss = (&magnitude * &magnitude)?.reduce_sum(Some(&[0]));
     let real_loss_grad = real_loss?.grad(&z)?;
     let real_loss_grad_value = run(&real_loss_grad)?;
     let expected_real_loss_grad: Vec<_> = z_data.iter().map(|z| *z * 2.0).collect();

--- a/docs/tutorial-code/src/bin/dynamic_shape_truncated_svd.rs
+++ b/docs/tutorial-code/src/bin/dynamic_shape_truncated_svd.rs
@@ -66,7 +66,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let keep_count = s
         .compare(&threshold, CompareDir::Gt)?
         .convert(DType::F64)?
-        .reduce_sum(&[0])?;
+        .reduce_sum(Some(&[0]))?;
 
     let u_truncated = u.dynamic_truncate(&keep_count, 1)?;
     let s_truncated = s.dynamic_truncate(&keep_count, 0)?;

--- a/docs/tutorial-code/src/bin/eager_autodiff_pytorch_style.rs
+++ b/docs/tutorial-code/src/bin/eager_autodiff_pytorch_style.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?)?;
 
     let prediction = x.mul(&x).unwrap();
-    let loss = prediction.reduce_sum(&[0])?;
+    let loss = prediction.reduce_sum(Some(&[0]))?;
 
     assert_eq!(loss.shape(), &[]);
     assert_close(loss.materialized()?.as_slice::<f64>().unwrap(), &[14.0]);

--- a/docs/tutorial-code/src/bin/einsum_subscripts_to_gradients.rs
+++ b/docs/tutorial-code/src/bin/einsum_subscripts_to_gradients.rs
@@ -78,7 +78,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let y = compiler.einsum_with(&[&a, &b], "ij,jk->ik", EinsumOptimize::Path(vec![(0, 1)]))?;
-    let grad_a = y.reduce_sum(&[0, 1])?.grad(&a)?;
+    let grad_a = y.reduce_sum(Some(&[0, 1]))?.grad(&a)?;
     let grad_value = run(&grad_a)?;
 
     assert_eq!(grad_value.shape(), &[2, 3]);

--- a/docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs
+++ b/docs/tutorial-code/src/bin/traced_autodiff_jax_style.rs
@@ -22,7 +22,7 @@ fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runti
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0])?;
-    let y = (&x * &x)?.reduce_sum(&[0])?;
+    let y = (&x * &x)?.reduce_sum(Some(&[0]))?;
 
     let y_value = run(&y)?;
     assert_eq!(y_value.shape(), &[]);

--- a/docs/tutorials/dynamic-shape-truncated-svd.md
+++ b/docs/tutorials/dynamic-shape-truncated-svd.md
@@ -79,7 +79,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let keep_count = s
         .compare(&threshold, CompareDir::Gt)?
         .convert(DType::F64)?
-        .reduce_sum(&[0])?;
+        .reduce_sum(Some(&[0]))?;
 
     let u_truncated = u.dynamic_truncate(&keep_count, 1)?;
     let s_truncated = s.dynamic_truncate(&keep_count, 0)?;

--- a/docs/tutorials/eager-autodiff-pytorch-style.md
+++ b/docs/tutorials/eager-autodiff-pytorch-style.md
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?)?;
 
     let prediction = x.mul(&x).unwrap();
-    let loss = prediction.reduce_sum(&[0])?;
+    let loss = prediction.reduce_sum(Some(&[0]))?;
 
     assert_eq!(loss.shape(), &[]);
     assert_close(loss.materialized()?.as_slice::<f64>().unwrap(), &[14.0]);

--- a/docs/tutorials/einsum-subscripts-to-gradients.md
+++ b/docs/tutorials/einsum-subscripts-to-gradients.md
@@ -91,7 +91,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let y = compiler.einsum_with(&[&a, &b], "ij,jk->ik", EinsumOptimize::Path(vec![(0, 1)]))?;
-    let grad_a = y.reduce_sum(&[0, 1])?.grad(&a)?;
+    let grad_a = y.reduce_sum(Some(&[0, 1]))?.grad(&a)?;
     let grad_value = run(&grad_a)?;
 
     assert_eq!(grad_value.shape(), &[2, 3]);

--- a/docs/tutorials/sparse-extension.md
+++ b/docs/tutorials/sparse-extension.md
@@ -98,7 +98,7 @@ use tenferro_ext_sparse::sparse_ad_rules;
 let ad = AdContext::builder()
     .with_extension_rules(sparse_ad_rules()?)
     .build()?;
-let loss = out.values().reduce_sum(&[0])?;
+let loss = out.values().reduce_sum(Some(&[0]))?;
 let grad_left_values = ad.grad(&loss, left.values())?;
 ```
 

--- a/docs/tutorials/traced-autodiff-jax-style.md
+++ b/docs/tutorials/traced-autodiff-jax-style.md
@@ -34,7 +34,7 @@ fn run(tensor: &TracedTensor) -> Result<tenferro_runtime::Tensor, tenferro_runti
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let x = TracedTensor::from_vec_col_major(vec![3], vec![1.0_f64, 2.0, 3.0])?;
-    let y = (&x * &x)?.reduce_sum(&[0])?;
+    let y = (&x * &x)?.reduce_sum(Some(&[0]))?;
 
     let y_value = run(&y)?;
     assert_eq!(y_value.shape(), &[]);

--- a/docs/tutorials/tropical-extension.md
+++ b/docs/tutorials/tropical-extension.md
@@ -83,7 +83,7 @@ use tenferro_ext_tropical::tropical_ad_rules;
 let ad = AdContext::builder()
     .with_extension_rules(tropical_ad_rules()?)
     .build()?;
-let loss = out.reduce_sum(&[0, 1])?;
+let loss = out.reduce_sum(Some(&[0, 1]))?;
 let grad_a = ad.grad(&loss, &a)?;
 ```
 

--- a/docs/worklogs/2026-07-19-api-surface-parity-batch.md
+++ b/docs/worklogs/2026-07-19-api-surface-parity-batch.md
@@ -1,0 +1,113 @@
+# API surface parity batch work log
+
+Date: 2026-07-19
+
+## Session summary
+
+This batch resolves four accepted API-surface issues together: optional
+reduction axes (#1279), eager linalg composites (#1265), concrete/read/typed
+linalg extension traits (#1264), and eager FFT methods (#1266). The work keeps
+one canonical operation vocabulary across concrete, eager, and traced layers
+while preserving each layer's ownership, error, placement, and AD contracts.
+
+The FFT work was intentionally delayed until the explicit backend-capability
+refactor in #1424 passed review and CI. That PR was merged first, then its merge
+commit was integrated into this branch before implementing the eager adapter.
+Durable decisions are recorded in the batch design, linalg design, FFT backend
+design, operation categories spec, and affected user guides.
+
+## Classification ledger
+
+| Issue | Classification | Working-hash evidence | Resolution |
+| --- | --- | --- | --- |
+| #1279 | Auto Fix after accepted contract | Eager and traced reduction surfaces used different axis representations and could not express all-axes versus empty-axes consistently. | `Option<&[usize]>`: `None` reduces all axes; `Some(&[])` is identity. All callers and docs migrated together. |
+| #1265 | Auto Fix after accepted contract | Kernel eager linalg methods existed, while traced composites had no eager peers. | Added eager `slogdet`, `det`, `inv`, `eigvalsh`, `eigvals`, `pinv`, `pinv_with_rtol`, and `norm` from existing primitives. |
+| #1264 | Auto Fix after accepted contract | Backend methods were the only direct dynamic surface and returned variable-length vectors for fixed-arity operations. | Added crate-root owned/read/typed extension traits, fixed tuples, sealed scalar mappings, and existing-placement read dispatch. |
+| #1266 | Design Gate resolved by accepted contract and #1424 | Traced and concrete FFT APIs existed, but eager execution had no explicit `FftBackend` route. | After #1424 merged, added `EagerTensorFftExt` using the existing extension op/runtime and AD rules. |
+
+## Context read
+
+| Source | Why it was read | Decision impact |
+| --- | --- | --- |
+| Accepted issue comments for #1279, #1265, #1264, and #1266 | Freeze semantics before implementation. | Prevented compatibility shims and kept the batch limited to agreed surfaces. |
+| `AGENTS.md`, `REPOSITORY_RULES.md`, and shared tensor4all Rust/docs rules | Confirm public API, validation, placement, docs, worklog, and merge requirements. | Added runnable examples, concrete error docs, shared validation helpers, and no-fallback tests. |
+| Runtime eager/traced reduction implementations and callers | Trace the axis vocabulary across public APIs, AD, examples, and tutorials. | Migrated the canonical contract atomically instead of adding parallel overloads. |
+| Linalg backend, traced, eager, and AD support modules | Identify existing kernels, composites, read hooks, and typed scalar contracts. | Reused backend primitives and AD-visible standard ops rather than adding kernels or transfers. |
+| FFT extension op, runtime registration, backend capability, and cache design | Establish the post-#1424 execution boundary. | The eager adapter delegates only to the selected capability and shares validation with traced FFT. |
+| Active linalg/FFT guides and design documents | Find stale entry-point and support claims. | Updated user selection tables, examples, typed-output rules, and placement behavior. |
+
+CodeGraph was refreshed and used before direct source search for reduction,
+linalg, eager-runtime, and FFT dependency tracing.
+
+## Decisions made
+
+- **Reduction absence and emptiness are distinct.** `None` means every axis;
+  `Some(&[])` preserves the input. This matches the accepted contract across
+  eager, traced, AD, docs, and examples without a legacy compatibility path.
+- **Eager linalg composites remain compositions.** They reuse existing eager
+  primitives so execution, error propagation, and AD recording stay visible to
+  the established runtime instead of introducing hidden backend kernels.
+- **Concrete linalg is receiver-first and backend-explicit.** Owned `Tensor`,
+  borrowed `TensorRead`, and `TypedTensor<T>` use crate-root extension traits;
+  decomposition arity is represented by tuples rather than output vectors.
+- **Typed output dtype is part of the adapter contract.** `TensorScalar::Real`
+  represents singular values, Hermitian eigenvalues, log-magnitudes, and norms;
+  sealed `LinalgScalar::Complex` represents general eigen outputs. Backend
+  dtype mismatches are reported rather than silently cast.
+- **Borrowed linalg input stays borrowed until the provider boundary.** Read
+  hooks are used directly. Complete-pivot solve composes read factorization,
+  permutation matmul, and triangular read solves, including vector RHS reshape,
+  without an adapter-level input clone or device transfer.
+- **Eager FFT uses the explicit capability.** The adapter registers the same
+  FFT runtime and applies the same `FftOp`. CPU delegates to its capability;
+  other eager backend variants return `Unsupported` without upload, download,
+  host reference, or a newly constructed CPU backend.
+- **Known FFT validation is shared.** Eager and traced paths prepare the same
+  validated op for dtype, rank, axis, transform length, and C2R spectrum shape.
+
+## Rejected or deferred alternatives
+
+- Legacy reduction overloads were rejected because they would preserve two
+  meanings for an empty axis list and keep caller ambiguity alive.
+- New eager linalg kernels or backend fallbacks were rejected; the requested
+  operations already lower cleanly to supported primitives.
+- Public typed linalg support for integer/bool tensors was rejected. The sealed
+  scalar set is `f32`, `f64`, `Complex32`, and `Complex64`.
+- Adapter-level cloning or implicit transfer for read linalg was rejected.
+  Unsupported layout/placement remains a typed backend error.
+- CUDA/cuFFT and real/complex FFT AD semantics remain out of scope. The eager
+  surface exposes existing support only; unsupported rules remain explicit.
+
+## Verification performed
+
+Development followed a red/green cycle for each issue. Focused crate tests,
+integration tests, doctests, clippy with `-D warnings`, guide snippet checks,
+and the public error-doc audit were run while implementing each unit. The final
+committed head is also checked through the repository PR gate and local
+repository-rules review before publication.
+
+- `cargo test -p tenferro-ad --features cpu-faer`
+- `cargo test -p tenferro-linalg --features autodiff`
+- `cargo test -p tenferro-fft --features autodiff`
+- `cargo clippy -p tenferro-linalg --features autodiff --all-targets -- -D warnings`
+- `cargo clippy -p tenferro-fft --features autodiff --all-targets -- -D warnings`
+- `python3 scripts/check-public-error-docs.py --root-dir . --changed-from origin/main`
+- `python3 scripts/check-doc-snippets.py --check`
+- `python3 scripts/check-guide-dependency-snippets.py`
+- `bash scripts/check-pr-fast.sh --coverage-reviewed` with the three focused
+  crate tests above
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD`
+
+## Remaining risks and follow-up
+
+- The reduction signature migration is intentionally source-breaking; all
+  in-repository callers are migrated, but downstream callers must wrap explicit
+  axes in `Some(...)`.
+- Typed linalg adapters validate provider output dtypes at runtime because the
+  underlying backend contract remains dynamically typed.
+- The concrete/read/typed linalg module is large because three public traits
+  intentionally show their different ownership and output contracts directly;
+  macro generation was avoided so rustdoc, feature behavior, and error
+  boundaries remain reviewable.
+- Eager GPU FFT remains unsupported until the selected GPU backend implements
+  `FftBackend`; the adapter deliberately does not provide a fallback.

--- a/ext/sparse/tests/sparse_ad.rs
+++ b/ext/sparse/tests/sparse_ad.rs
@@ -138,7 +138,7 @@ fn sparse_matmul_sum_gradients_match_dense_reference() -> TestResult {
     let lhs = left_traced(&[2.0, 1.0, 3.0]);
     let rhs = right_traced(&[10.0, 70.0, 20.0]);
     let out = sparse_matmul(&lhs, &rhs)?;
-    let loss = out.values().reduce_sum(&[0])?;
+    let loss = out.values().reduce_sum(Some(&[0]))?;
     let ad = sparse_ad();
 
     let grad_lhs = ad.grad(&loss, lhs.values())?;

--- a/ext/tropical/src/traced.rs
+++ b/ext/tropical/src/traced.rs
@@ -122,7 +122,7 @@ fn checked_tropical_dot_general_impl(
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[23.0, 24.0, 43.0, 44.0]);
 /// ```
 pub fn tropical_dot_general(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
-    checked_tropical_dot_general_impl(a, b, |sum| sum.reduce_max(&[1]), "tropical_dot_general")
+    checked_tropical_dot_general_impl(a, b, |sum| sum.reduce_max(Some(&[1])), "tropical_dot_general")
 }
 
 /// Min-plus matrix multiplication on rank-2 traced tensors.
@@ -160,7 +160,7 @@ pub fn tropical_dot_general(a: &TracedTensor, b: &TracedTensor) -> Result<Traced
 /// assert_eq!(out.as_slice::<f64>().unwrap(), &[6.0, 7.0, 8.0, 9.0]);
 /// ```
 pub fn min_plus_dot_general(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
-    checked_tropical_dot_general_impl(a, b, |sum| sum.reduce_min(&[1]), "min_plus_dot_general")
+    checked_tropical_dot_general_impl(a, b, |sum| sum.reduce_min(Some(&[1])), "min_plus_dot_general")
 }
 
 /// Fused binary tropical einsum over traced tensors.
@@ -511,7 +511,7 @@ fn validate_tropical_einsum_inputs(
 /// [`tenferro_runtime::Error::Internal`] if output metadata registration
 /// fails.
 pub fn tropical_reduce_sum(a: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
-    a.reduce_max(axes)
+    a.reduce_max(Some(axes))
 }
 
 #[cfg(test)]

--- a/ext/tropical/tests/tropical_ad.rs
+++ b/ext/tropical/tests/tropical_ad.rs
@@ -122,7 +122,7 @@ fn assert_sum_gradients(
     let a = TracedTensor::from_vec_col_major(a_shape, a_data).unwrap();
     let b = TracedTensor::from_vec_col_major(b_shape, b_data).unwrap();
     let out = tropical_dot_general_fused(&a, &b).unwrap();
-    let loss = out.reduce_sum(&[0, 1]).unwrap();
+    let loss = out.reduce_sum(Some(&[0, 1])).unwrap();
     let ad = tropical_ad();
 
     let grad_a = ad.grad(&loss, &a).expect("grad wrt a");
@@ -174,7 +174,7 @@ fn finite_difference_gradient_matches_unique_winner_weighted_scalarization() {
     let weights = TracedTensor::from_vec_col_major(vec![2, 2], weights_data.clone()).unwrap();
     let out = tropical_dot_general_fused(&a, &b).unwrap();
     let weighted = (&out * &weights).unwrap();
-    let loss = weighted.reduce_sum(&[0, 1]).unwrap();
+    let loss = weighted.reduce_sum(Some(&[0, 1])).unwrap();
     let ad = tropical_ad();
 
     let grad_a = ad.grad(&loss, &a).expect("grad wrt a");

--- a/samples/kdv-pinn/src/loss.rs
+++ b/samples/kdv-pinn/src/loss.rs
@@ -14,7 +14,7 @@ pub(crate) fn mean_square(
     let neg_target = target.neg()?;
     let diff = pred.add(&neg_target)?;
     let sq = diff.mul(&diff)?;
-    let sum = sq.reduce_sum(&[0, 1])?;
+    let sum = sq.reduce_sum(Some(&[0, 1]))?;
     sum.scale_real(1.0 / n as f64)
 }
 
@@ -24,7 +24,7 @@ pub(crate) fn mean_square(
 pub(crate) fn mean_square_single(tensor: &TracedTensor, n: usize) -> Result<TracedTensor> {
     assert!(n > 0, "mean_square_single count must be positive");
     let sq = tensor.mul(tensor)?;
-    let sum = sq.reduce_sum(&[0, 1])?;
+    let sum = sq.reduce_sum(Some(&[0, 1]))?;
     sum.scale_real(1.0 / n as f64)
 }
 

--- a/samples/kdv-pinn/src/pde/tests.rs
+++ b/samples/kdv-pinn/src/pde/tests.rs
@@ -216,10 +216,10 @@ fn kdv_residual_of_exact_solution_is_small() -> TestResult {
 #[test]
 fn third_derivative_of_cube() -> TestResult {
     let x = TracedTensor::input_concrete_shape(DType::F64, &[3, 1])?;
-    let y = x.mul(&x)?.mul(&x)?.reduce_sum(&[0, 1])?;
+    let y = x.mul(&x)?.mul(&x)?.reduce_sum(Some(&[0, 1]))?;
     let y_x = grad(&y, &x)?;
-    let y_xx = grad(&y_x.reduce_sum(&[0, 1])?, &x)?;
-    let y_xxx = grad(&y_xx.reduce_sum(&[0, 1])?, &x)?;
+    let y_xx = grad(&y_x.reduce_sum(Some(&[0, 1]))?, &x)?;
+    let y_xxx = grad(&y_xx.reduce_sum(Some(&[0, 1]))?, &x)?;
 
     let x_tensor = Tensor::from_vec_col_major(vec![3, 1], vec![1.0_f64, 2.0, 3.0])?;
     let result = eval(&y_xxx, &[(&x, &x_tensor)]);


### PR DESCRIPTION
## Type

- [ ] Bug fix
- [x] Documentation
- [x] Refactor / cleanup
- [x] Implementation of accepted issue

## Related issues

Closes #1279
Closes #1265
Closes #1264
Closes #1266

Dependency #1424 was merged as `28cdad4e` before the eager FFT implementation was added.

## Summary

This is one non-squash batch for four accepted API-surface contracts:

- make eager and traced reductions use `Option<&[usize]>`, with `None` meaning all axes and `Some(&[])` meaning identity;
- complete eager linalg composites from existing primitives and AD-visible operations;
- add crate-root owned/read/typed linalg extension traits with fixed tuples, sealed real/complex output mappings, existing read hooks, and no implicit transfer;
- add `EagerTensorFftExt` after the explicit FFT backend capability landed, reusing the existing runtime, op, cache, validation, and AD rules without CPU fallback.

All in-repository callers, examples, tutorials, rustdoc, guides, design records, and public error contracts were migrated with the implementation.

Base: `origin/main` at `28cdad4e`
Branch: `codex/batch-api-surface-contracts`

## Work log

[API surface parity batch work log](docs/worklogs/2026-07-19-api-surface-parity-batch.md)

The accepted contract and alternatives are also recorded in [the batch design](docs/superpowers/specs/2026-07-19-api-surface-parity-batch-design.md).

## Issue ledger

| Issue | Status | Result |
| --- | --- | --- |
| #1279 | Fixed | Canonical optional-axis contract across eager/traced/AD and all callers. |
| #1265 | Fixed | Eager `slogdet`, `det`, `inv`, `eigvalsh`, `eigvals`, `pinv`, `pinv_with_rtol`, and `norm`. |
| #1264 | Fixed | `TensorLinalgExt`, `TensorReadLinalgExt`, and `TypedTensorLinalgExt` with fixed output contracts. |
| #1266 | Fixed | `EagerTensorFftExt` for fft/ifft/rfft/irfft, including eager-vs-traced parity and c2c VJP reuse. |

## Neighborhood scans

- migrated reduction call sites across runtime, AD, einsum, XLA, extensions, samples, README, guides, and tutorials;
- compared eager linalg composites with the traced vocabulary and existing backend/AD support;
- checked owned/read/typed linalg paths for adapter-level materialization, cloning, and device transfer;
- checked FFT eager dispatch for backend construction, upload/download, host-reference fallback, and validation drift;
- checked stale API selection tables, examples, design docs, and public `Result` error documentation.

## Verification

- `bash scripts/check-pr-fast.sh --coverage-reviewed` with:
  - `cargo test -p tenferro-ad --features cpu-faer`
  - `cargo test -p tenferro-linalg --features autodiff`
  - `cargo test -p tenferro-fft --features autodiff`
- `cargo clippy -p tenferro-linalg --features autodiff --all-targets -- -D warnings`
- `cargo clippy -p tenferro-fft --features autodiff --all-targets -- -D warnings`
- `cargo test -p tenferro-linalg --features autodiff --doc`
- `cargo test -p tenferro-fft --features autodiff --doc`
- `python3 scripts/check-public-error-docs.py --root-dir . --changed-from origin/main`
- `python3 scripts/check-doc-snippets.py --check`
- `python3 scripts/check-guide-dependency-snippets.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD`
  - verdict: pass, no findings
- `git diff --check origin/main...HEAD`

Complete clean workspace, BLAS-provider, coverage, docs-site, and GPU profiles are left to hosted CI as required by `CONTRIBUTING.md`.

## Residual risks

- #1279 is intentionally source-breaking for downstream callers: explicit axes now require `Some(axes)`.
- typed linalg adapters validate dynamically typed provider outputs before downcasting.
- eager FFT returns `Unsupported` on eager backend variants without `FftBackend`; CUDA/cuFFT and rfft/irfft AD are not added here.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] The linked feature issues were accepted by maintainers before implementation.
- [x] I added and linked the required work log.
