### PR TITLE
chore: align CubeCL and CubeK revisions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,14 +71,14 @@ tblis-src = { package = "t4a-tblis-src", path = "third_party/t4a-tblis-src", ver
 cudarc = { version = "0.19", default-features = false, features = ["driver", "runtime", "nvrtc", "dynamic-loading", "cuda-12080"] }
 # Pre-publish staging: Cargo uses these fork commits locally, while packaged
 # manifests retain only the crates.io version requirements.
-cubecl = { package = "t4a-cubecl", git = "https://github.com/tensor4all/cubecl.git", rev = "11b52669f13e27bbe188f988fd696df6d989a562", version = "=0.10.0", default-features = false }
-cubecl-cuda = { package = "t4a-cubecl-cuda", git = "https://github.com/tensor4all/cubecl.git", rev = "11b52669f13e27bbe188f988fd696df6d989a562", version = "=0.10.0" }
-cubecl-common = { package = "t4a-cubecl-common", git = "https://github.com/tensor4all/cubecl.git", rev = "11b52669f13e27bbe188f988fd696df6d989a562", version = "=0.10.0" }
-cubecl-runtime = { package = "t4a-cubecl-runtime", git = "https://github.com/tensor4all/cubecl.git", rev = "11b52669f13e27bbe188f988fd696df6d989a562", version = "=0.10.0" }
-cubecl-wgpu = { package = "t4a-cubecl-wgpu", git = "https://github.com/tensor4all/cubecl.git", rev = "11b52669f13e27bbe188f988fd696df6d989a562", version = "=0.10.0" }
-cubek-matmul = { package = "t4a-cubek-matmul", git = "https://github.com/tensor4all/cubek.git", rev = "43e8521885f141cb8ccdf99a766bfde118412010", version = "=0.2.0", default-features = false }
-cubek-std = { package = "t4a-cubek-std", git = "https://github.com/tensor4all/cubek.git", rev = "43e8521885f141cb8ccdf99a766bfde118412010", version = "=0.2.0", default-features = false }
-cubek-fft = { package = "cubek-fft", git = "https://github.com/tensor4all/cubek.git", rev = "43e8521885f141cb8ccdf99a766bfde118412010", version = "=0.2.0", default-features = false }
+cubecl = { package = "t4a-cubecl", git = "https://github.com/tensor4all/cubecl.git", rev = "346135ab43cececf6405d52a3dbc987537402d27", version = "=0.10.0", default-features = false }
+cubecl-cuda = { package = "t4a-cubecl-cuda", git = "https://github.com/tensor4all/cubecl.git", rev = "346135ab43cececf6405d52a3dbc987537402d27", version = "=0.10.0" }
+cubecl-common = { package = "t4a-cubecl-common", git = "https://github.com/tensor4all/cubecl.git", rev = "346135ab43cececf6405d52a3dbc987537402d27", version = "=0.10.0" }
+cubecl-runtime = { package = "t4a-cubecl-runtime", git = "https://github.com/tensor4all/cubecl.git", rev = "346135ab43cececf6405d52a3dbc987537402d27", version = "=0.10.0" }
+cubecl-wgpu = { package = "t4a-cubecl-wgpu", git = "https://github.com/tensor4all/cubecl.git", rev = "346135ab43cececf6405d52a3dbc987537402d27", version = "=0.10.0" }
+cubek-matmul = { package = "t4a-cubek-matmul", git = "https://github.com/tensor4all/cubek.git", rev = "efc43529449b67d83f53e585cc7d71018a252ac7", version = "=0.2.0", default-features = false }
+cubek-std = { package = "t4a-cubek-std", git = "https://github.com/tensor4all/cubek.git", rev = "efc43529449b67d83f53e585cc7d71018a252ac7", version = "=0.2.0", default-features = false }
+cubek-fft = { package = "cubek-fft", git = "https://github.com/tensor4all/cubek.git", rev = "efc43529449b67d83f53e585cc7d71018a252ac7", version = "=0.2.0", default-features = false }
 sha2 = "0.10"
 omeco = "0.2.4"
 computegraph = { git = "https://github.com/tensor4all/computegraph-rs.git", rev = "691def2d82fd4367b397d61209449f68e82050b7", version = "0.1.0" }

--- a/docs/worklogs/2026-07-19-cubecl-u8-test-dependency-alignment.md
+++ b/docs/worklogs/2026-07-19-cubecl-u8-test-dependency-alignment.md
@@ -1,0 +1,38 @@
+# CubeCL `u8` Test Dependency Alignment
+
+## Summary
+
+Updated tenferro's Git dependencies to consume the CubeCL change that gates
+the `u8` branch runtime tests by each backend's supported unsigned-type list.
+The update also advances CubeK because its workspace dependency still pinned
+the preceding CubeCL commit.
+
+## Context Reviewed
+
+- tensor4all shared repository, Rust, performance, documentation, and test rules
+- tenferro `AGENTS.md`, `REPOSITORY_RULES.md`, contribution policy, and bug-fix workflow
+- CubeCL runtime-test generation and backend type lists
+- CubeK workspace CubeCL dependencies
+- tenferro workspace CubeCL and CubeK dependencies
+
+## Decision
+
+Pin all direct CubeCL dependencies to CubeCL PR #14 head
+`346135ab43cececf6405d52a3dbc987537402d27`. Pin all CubeK dependencies to
+CubeK PR #10 head `efc43529449b67d83f53e585cc7d71018a252ac7`, which uses the same
+CubeCL commit.
+
+Updating only tenferro's direct CubeCL dependencies was rejected because Cargo
+then resolved both `11b52669` through CubeK and `346135ab` directly. Separate
+CubeCL runtime and IR crate identities are unsafe for the integration boundary
+and also duplicate compilation.
+
+## Verification
+
+- confirmed the dependency tree contains CubeCL `346135ab` and no `11b52669`
+- `cargo fmt --all --check`
+- `cargo check -p tenferro-gpu --no-default-features --features cpu-faer,webgpu`
+
+The repository-wide PR checks are recorded in the pull request. Hardware CUDA
+execution is left to the existing gated CI lanes; this change does not alter
+kernel or backend behavior.

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -101,7 +101,7 @@ class BuildArtifactContracts(unittest.TestCase):
         manifest = tomllib.loads((ROOT / "Cargo.toml").read_text())
         dependencies = manifest["workspace"]["dependencies"]
 
-        revision = "11b52669f13e27bbe188f988fd696df6d989a562"
+        revision = "346135ab43cececf6405d52a3dbc987537402d27"
         for name in (
             "cubecl",
             "cubecl-cuda",


### PR DESCRIPTION
> [!IMPORTANT]
> New features must start as a feature request issue.
> Please do not open a new-feature implementation PR before maintainers accept
> the issue and agree that implementation should start.
>
> If you already have prototype code, link to a fork branch, gist, or
> repository from the feature request issue instead of opening a PR.
>
> New-feature PRs opened before an accepted issue may be closed and redirected
> to an issue.
>
> If you are using an AI agent for a bug-fix PR, use or follow the
> repository-local `tenferro-bugfix-pr` workflow before editing code.

## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs tensor4all/cubecl#14
Refs tensor4all/cubek#10

## Summary

Align every direct CubeCL dependency with the revision that gates `u8` branch
tests by backend capability, and align every CubeK dependency with its matching
CubeCL revision.

Updating only the direct CubeCL pins resolves two incompatible CubeCL runtime
and IR crate identities because CubeK would continue pulling the preceding
revision. This PR advances both dependency families together and verifies that
the old CubeCL revision no longer appears in the dependency tree.

Dependency order: tensor4all/cubecl#14, then tensor4all/cubek#10, then this PR.

## Work log

[`docs/worklogs/2026-07-19-cubecl-u8-test-dependency-alignment.md`](docs/worklogs/2026-07-19-cubecl-u8-test-dependency-alignment.md)

## Verification

- `cargo tree -p tenferro-gpu --no-default-features --features cpu-faer,webgpu`
- `cargo check -p tenferro-gpu --no-default-features --features cpu-faer,webgpu`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
- `cargo clippy --manifest-path ext/tropical/Cargo.toml --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
- `cargo clippy --manifest-path ext/sparse/Cargo.toml --workspace --all-targets -- -D warnings -D clippy::missing_errors_doc -D clippy::missing_panics_doc`
- `cargo test --workspace --release`
- `cargo llvm-cov --workspace --release --json --output-path coverage.json`
- `python3 scripts/check-coverage.py coverage.json` (167/167 files passed)
- `cargo doc --workspace --no-deps`
- `python3 scripts/check-docs-site.py` (Python 3.12; 4 guides and 13 library crates verified)
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json` (pass, no findings)

Hardware CUDA execution is left to the existing gated CI lanes. This change
does not alter kernels or backend behavior.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its
      findings.
- [x] If this implements a new feature, the linked issue has been accepted by
      maintainers. (Not a new feature.)
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from
      `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and
      linked it above.
