### PR TITLE
perf: remove low-risk tensor and eager AD overheads

### DIFF
--- a/crates/tenferro-ad/src/eager.rs
+++ b/crates/tenferro-ad/src/eager.rs
@@ -128,6 +128,10 @@ pub(crate) fn eager_op_profile_enabled() -> bool {
     *ENABLED.get_or_init(|| env::var("TENFERRO_PROFILE_EAGER_OP_AGG").is_ok())
 }
 
+pub(crate) fn eager_op_profile_start() -> Option<Instant> {
+    eager_op_profile_enabled().then(Instant::now)
+}
+
 pub(crate) fn record_eager_op_profile(section: &'static str, elapsed: Duration) {
     if !eager_op_profile_enabled() {
         return;

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -38,9 +38,10 @@ use super::backward::{
     TenferroBackwardCallbacks,
 };
 use super::{
-    eager_op_profile_enabled, eager_op_profile_per_call_us, maybe_print_eager_op_profile,
-    one_like_tensor, print_and_reset_eager_op_profile, profile_eager_op_section,
-    record_eager_op_profile, zero_like_tensor, EagerOpProfileEntry, EagerRuntime, EagerTensor,
+    eager_op_profile_enabled, eager_op_profile_per_call_us, eager_op_profile_start,
+    maybe_print_eager_op_profile, one_like_tensor, print_and_reset_eager_op_profile,
+    profile_eager_op_section, record_eager_op_profile, zero_like_tensor, EagerOpProfileEntry,
+    EagerRuntime, EagerTensor,
 };
 
 fn build_add_mul_reduce_graph(keys: &[TensorInputKey]) -> Arc<Graph<StdTensorOp>> {
@@ -447,6 +448,7 @@ fn eager_op_profile_helpers_cover_enabled_paths() {
     let _guard = EagerOpProfileOverrideGuard::set(true, Some(2));
 
     assert!(eager_op_profile_enabled());
+    assert!(eager_op_profile_start().is_some());
     assert_eq!(profile_eager_op_section("coverage.profile", || 7), 7);
     assert_eq!(
         eager_op_profile_per_call_us(&EagerOpProfileEntry::default()),
@@ -456,6 +458,14 @@ fn eager_op_profile_helpers_cover_enabled_paths() {
     record_eager_op_profile("nary_op.total", Duration::from_micros(5));
     maybe_print_eager_op_profile();
     print_and_reset_eager_op_profile();
+}
+
+#[test]
+fn eager_op_profile_start_respects_enabled_gate() {
+    let _guard = EagerOpProfileOverrideGuard::set(false, None);
+
+    assert!(!eager_op_profile_enabled());
+    assert!(eager_op_profile_start().is_none());
 }
 
 #[test]

--- a/crates/tenferro-ad/src/eager_ops.rs
+++ b/crates/tenferro-ad/src/eager_ops.rs
@@ -14,9 +14,9 @@ use tenferro_tensor::{
 };
 
 use crate::eager::{
-    eager_grad_recording_enabled, exec_single_output, exec_single_output_read,
-    maybe_print_eager_op_profile, profile_eager_op_section, record_eager_op_profile,
-    record_eager_outputs, EagerTensor,
+    eager_grad_recording_enabled, eager_op_profile_start, exec_single_output,
+    exec_single_output_read, maybe_print_eager_op_profile, profile_eager_op_section,
+    record_eager_op_profile, record_eager_outputs, EagerTensor,
 };
 use crate::eager_exec::exec_dot_general_with_conj_on_tensor_reads;
 use crate::error::{Error, Result};
@@ -1111,7 +1111,7 @@ impl EagerTensor {
     }
 
     pub(crate) fn nary_op(tensors: &[&Self], op: StdTensorOp) -> Result<Self> {
-        let total_started = std::time::Instant::now();
+        let total_started = eager_op_profile_start();
         let Some(first) = tensors.first() else {
             return Err(empty_nary_input_error(&op));
         };
@@ -1149,8 +1149,10 @@ impl EagerTensor {
             let result = profile_eager_op_section("nary_op.new_untracked_result", || {
                 Self::new_untracked_result(ctx, output)
             });
-            record_eager_op_profile("nary_op.total", total_started.elapsed());
-            maybe_print_eager_op_profile();
+            if let Some(total_started) = total_started {
+                record_eager_op_profile("nary_op.total", total_started.elapsed());
+                maybe_print_eager_op_profile();
+            }
             return result;
         }
 
@@ -1192,8 +1194,10 @@ impl EagerTensor {
                 metadata_scopes,
             )
         });
-        record_eager_op_profile("nary_op.total", total_started.elapsed());
-        maybe_print_eager_op_profile();
+        if let Some(total_started) = total_started {
+            record_eager_op_profile("nary_op.total", total_started.elapsed());
+            maybe_print_eager_op_profile();
+        }
         result
     }
 }

--- a/crates/tenferro-tensor/Cargo.toml
+++ b/crates/tenferro-tensor/Cargo.toml
@@ -30,3 +30,7 @@ criterion.workspace = true
 [[bench]]
 name = "element_access"
 harness = false
+
+[[bench]]
+name = "dot_accumulation"
+harness = false

--- a/crates/tenferro-tensor/benches/dot_accumulation.rs
+++ b/crates/tenferro-tensor/benches/dot_accumulation.rs
@@ -1,0 +1,32 @@
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use tenferro_tensor::{
+    backend::accumulate_dot_result_into, ContractionScalar, DotGeneralAccumulation, Tensor,
+    TensorWrite,
+};
+
+const ELEMENT_COUNT: usize = 4096;
+
+fn compact_dot_accumulation(c: &mut Criterion) {
+    let dot = Tensor::from_vec_col_major([ELEMENT_COUNT], vec![1.0_f64; ELEMENT_COUNT]).unwrap();
+    let accumulation = DotGeneralAccumulation {
+        lhs_conj: false,
+        rhs_conj: false,
+        alpha: ContractionScalar::F64(1.0),
+        beta: ContractionScalar::F64(1.0),
+    };
+
+    c.bench_function("dot_accumulation/compact_f64/4096", |b| {
+        b.iter_batched(
+            || Tensor::from_vec_col_major([ELEMENT_COUNT], vec![2.0_f64; ELEMENT_COUNT]).unwrap(),
+            |mut out| {
+                let mut write = TensorWrite::from_tensor(&mut out);
+                accumulate_dot_result_into(black_box(&dot), accumulation, &mut write).unwrap();
+                black_box(out);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group!(benches, compact_dot_accumulation);
+criterion_main!(benches);

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -1093,6 +1093,20 @@ where
         + 'static,
 {
     let beta_is_zero = beta == T::zero();
+    if let Some(output) = compact_host_accumulation_slice(out, dot.len())? {
+        for (output, dot_value) in output.iter_mut().zip(dot.iter().copied()) {
+            // INVARIANT: beta == 0 follows BLAS GEMM semantics and does not read
+            // the existing output element; beta != 0 requires an initialized
+            // TensorWrite target and performs a read-modify-write update.
+            *output = if beta_is_zero {
+                alpha * dot_value
+            } else {
+                alpha * dot_value + beta * *output
+            };
+        }
+        return Ok(());
+    }
+
     for (linear, dot_value) in dot.iter().copied().enumerate() {
         let indices = flat_to_multi_for_shape(out.shape(), linear);
         let output = out.get_mut(&indices).ok_or_else(|| {
@@ -1114,6 +1128,35 @@ where
     Ok(())
 }
 
+fn compact_host_accumulation_slice<'a, T: 'static>(
+    out: &'a mut TypedTensorViewMut<'_, T>,
+    expected_len: usize,
+) -> crate::Result<Option<&'a mut [T]>> {
+    if out.backend_buffer().is_some()
+        || out.n_elements() != expected_len
+        || !out.is_col_major_contiguous()?
+    {
+        return Ok(None);
+    }
+
+    let start = usize::try_from(out.offset()).map_err(|_| {
+        invalid_argument("dot_general", "output", "compact output offset is negative")
+    })?;
+    let end = start
+        .checked_add(expected_len)
+        .ok_or_else(|| validation("dot_general", ValidationError::IntegerOverflow))?;
+    out.host_storage_mut()?
+        .get_mut(start..end)
+        .map(Some)
+        .ok_or_else(|| {
+            invalid_argument(
+                "dot_general",
+                "output",
+                "compact output is outside its backing storage",
+            )
+        })
+}
+
 fn flat_to_multi_for_shape(shape: &[usize], mut linear: usize) -> Vec<usize> {
     let mut indices = Vec::with_capacity(shape.len());
     for &dim in shape {
@@ -1125,6 +1168,31 @@ fn flat_to_multi_for_shape(shape: &[usize], mut linear: usize) -> Vec<usize> {
         }
     }
     indices
+}
+
+#[cfg(test)]
+mod accumulation_fast_path_tests {
+    use super::*;
+
+    #[test]
+    fn compact_host_accumulation_slice_selects_only_compact_host_views() {
+        let mut compact_data = [0.0_f64; 4];
+        let mut compact =
+            TypedTensorViewMut::from_slice([2, 2], [1, 2], 0, &mut compact_data).unwrap();
+        assert_eq!(
+            compact_host_accumulation_slice(&mut compact, 4)
+                .unwrap()
+                .unwrap()
+                .len(),
+            4
+        );
+
+        let mut strided_data = [0.0_f64; 3];
+        let mut strided = TypedTensorViewMut::from_slice([2], [2], 0, &mut strided_data).unwrap();
+        assert!(compact_host_accumulation_slice(&mut strided, 2)
+            .unwrap()
+            .is_none());
+    }
 }
 
 /// Canonical elementwise fusion plan shared between segmented execution and backends.

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -12,6 +12,9 @@ use crate::{
 };
 use num_complex::{Complex32, Complex64};
 
+#[cfg(test)]
+mod tests;
+
 fn read_boundary_error(op: &'static str) -> crate::Error {
     crate::Error::unsupported(
         op,
@@ -1168,31 +1171,6 @@ fn flat_to_multi_for_shape(shape: &[usize], mut linear: usize) -> Vec<usize> {
         }
     }
     indices
-}
-
-#[cfg(test)]
-mod accumulation_fast_path_tests {
-    use super::*;
-
-    #[test]
-    fn compact_host_accumulation_slice_selects_only_compact_host_views() {
-        let mut compact_data = [0.0_f64; 4];
-        let mut compact =
-            TypedTensorViewMut::from_slice([2, 2], [1, 2], 0, &mut compact_data).unwrap();
-        assert_eq!(
-            compact_host_accumulation_slice(&mut compact, 4)
-                .unwrap()
-                .unwrap()
-                .len(),
-            4
-        );
-
-        let mut strided_data = [0.0_f64; 3];
-        let mut strided = TypedTensorViewMut::from_slice([2], [2], 0, &mut strided_data).unwrap();
-        assert!(compact_host_accumulation_slice(&mut strided, 2)
-            .unwrap()
-            .is_none());
-    }
 }
 
 /// Canonical elementwise fusion plan shared between segmented execution and backends.

--- a/crates/tenferro-tensor/src/backend/tests.rs
+++ b/crates/tenferro-tensor/src/backend/tests.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+#[test]
+fn compact_host_accumulation_slice_selects_only_compact_host_views() {
+    let mut compact_data = [0.0_f64; 4];
+    let mut compact = TypedTensorViewMut::from_slice([2, 2], [1, 2], 0, &mut compact_data).unwrap();
+    assert_eq!(
+        compact_host_accumulation_slice(&mut compact, 4)
+            .unwrap()
+            .unwrap()
+            .len(),
+        4
+    );
+
+    let mut strided_data = [0.0_f64; 3];
+    let mut strided = TypedTensorViewMut::from_slice([2], [2], 0, &mut strided_data).unwrap();
+    assert!(compact_host_accumulation_slice(&mut strided, 2)
+        .unwrap()
+        .is_none());
+}

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -807,6 +807,49 @@ fn dot_general_accum_default_fallback_updates_tensor_and_view_outputs() {
 }
 
 #[test]
+fn dot_general_accum_beta_zero_does_not_read_compact_output() {
+    let dot = Tensor::from_vec_col_major([2], vec![2.0_f64, -3.0]).unwrap();
+    let mut out = Tensor::from_vec_col_major([2], vec![f64::NAN, f64::NAN]).unwrap();
+    let mut write = TensorWrite::from_tensor(&mut out);
+
+    crate::backend::accumulate_dot_result_into(
+        &dot,
+        DotGeneralAccumulation {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::F64(2.0),
+            beta: ContractionScalar::F64(0.0),
+        },
+        &mut write,
+    )
+    .unwrap();
+
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[4.0, -6.0]);
+}
+
+#[test]
+fn dot_general_accum_keeps_strided_output_fallback() {
+    let dot = Tensor::from_vec_col_major([2], vec![2.0_f64, 3.0]).unwrap();
+    let mut storage = [10.0_f64, 99.0, 20.0];
+    let view = TypedTensorViewMut::from_slice([2], [2], 0, &mut storage).unwrap();
+    let mut write = TensorWrite::from_view(TensorViewMut::F64(view));
+
+    crate::backend::accumulate_dot_result_into(
+        &dot,
+        DotGeneralAccumulation {
+            lhs_conj: false,
+            rhs_conj: false,
+            alpha: ContractionScalar::F64(1.0),
+            beta: ContractionScalar::F64(1.0),
+        },
+        &mut write,
+    )
+    .unwrap();
+
+    assert_eq!(storage, [12.0, 99.0, 23.0]);
+}
+
+#[test]
 fn dot_general_accum_default_fallback_covers_supported_scalar_dtypes() {
     let config = vector_contract_config();
 

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use crate::config::SliceConfig;
 pub use tenferro_tensor_core::{DynRank, Rank, TensorLayout, TensorRank};
+use tenferro_tensor_core::{ShapeVec, StrideVec};
 use tenferro_tensor_core::{SliceSpec as CoreSliceSpec, ValidationError};
 
 mod accessors;
@@ -15,6 +16,30 @@ mod shape_packing;
 mod strided_view;
 
 pub use strided_view::StridedSliceSpec;
+
+fn shape_vec(shape: &[usize]) -> ShapeVec {
+    shape.iter().copied().collect()
+}
+
+fn stride_vec(strides: &[isize]) -> StrideVec {
+    strides.iter().copied().collect()
+}
+
+#[cfg(test)]
+mod inline_metadata_tests {
+    use super::*;
+
+    #[test]
+    fn inline_metadata_collection_keeps_small_shapes_and_strides_inline() {
+        let shape = shape_vec(&[2, 3]);
+        let strides = stride_vec(&[1, 2]);
+
+        assert_eq!(shape.as_slice(), &[2, 3]);
+        assert_eq!(strides.as_slice(), &[1, 2]);
+        assert!(!shape.spilled());
+        assert!(!strides.spilled());
+    }
+}
 
 /// Memory location for tensor storage.
 ///
@@ -819,11 +844,11 @@ impl<'a, T: 'static> TypedTensorView<'a, T, DynRank> {
     /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
     /// requested shape reaches beyond `data`.
     pub fn from_col_major(shape: &[usize], data: &'a [T]) -> crate::Result<Self> {
-        let layout = TensorLayout::<DynRank>::compact(shape.to_vec().into())
+        let layout = TensorLayout::<DynRank>::compact(shape_vec(shape))
             .map_err(|err| tensor_layout_error("TypedTensorView::from_col_major", err))?;
         Self::from_buffer_ref(
-            layout.shape().to_vec(),
-            layout.strides().to_vec(),
+            shape_vec(layout.shape()),
+            stride_vec(layout.strides()),
             layout.offset(),
             TensorBufferRef::Host(data),
             default_placement(),
@@ -1448,11 +1473,11 @@ impl<'a, T: 'static> TypedTensorViewMut<'a, T, DynRank> {
     /// [`tenferro_tensor_core::ValidationError::ViewOutOfBounds`] when the
     /// compact shape reaches beyond `data`.
     pub fn from_col_major(shape: &[usize], data: &'a mut [T]) -> crate::Result<Self> {
-        let layout = TensorLayout::<DynRank>::compact(shape.to_vec().into())
+        let layout = TensorLayout::<DynRank>::compact(shape_vec(shape))
             .map_err(|err| tensor_layout_error("TypedTensorViewMut::from_col_major", err))?;
         Self::from_buffer_ref_mut(
-            layout.shape().to_vec(),
-            layout.strides().to_vec(),
+            shape_vec(layout.shape()),
+            stride_vec(layout.strides()),
             layout.offset(),
             TensorBufferRefMut::Host(data),
             default_placement(),
@@ -4328,9 +4353,9 @@ fn view_mut_from_layout_and_slice<'a, T: 'static, R: TensorRank>(
     data: &'a mut [T],
     placement: Placement,
 ) -> crate::Result<TypedTensorViewMut<'a, T, R>> {
-    let shape = R::shape_from_vec(layout.shape().to_vec().into())
+    let shape = R::shape_from_vec(shape_vec(layout.shape()))
         .map_err(|err| tensor_layout_error("TypedTensorViewMut::try_multi_slice_mut", err))?;
-    let strides = R::strides_from_vec(layout.strides().to_vec().into())
+    let strides = R::strides_from_vec(stride_vec(layout.strides()))
         .map_err(|err| tensor_layout_error("TypedTensorViewMut::try_multi_slice_mut", err))?;
     TypedTensorViewMut::from_buffer_ref_mut(
         shape,
@@ -4399,7 +4424,7 @@ fn reshape_layout_dyn<R: TensorRank>(
     buffer_len: usize,
     op: &'static str,
 ) -> crate::Result<TensorLayout<DynRank>> {
-    match layout.reshape_view_as::<DynRank>(shape.to_vec(), buffer_len) {
+    match layout.reshape_view_as::<DynRank>(shape_vec(shape), buffer_len) {
         Ok(layout) => Ok(layout),
         Err(err) => {
             if !relaxed_col_major_contiguous(layout.shape(), layout.strides(), op)? {
@@ -4413,11 +4438,11 @@ fn reshape_layout_dyn<R: TensorRank>(
                     tenferro_tensor_core::ShapeMismatch::ReshapeElementCount { from, to }.into(),
                 ));
             }
-            TensorLayout::<DynRank>::compact(shape.to_vec().into())
+            TensorLayout::<DynRank>::compact(shape_vec(shape))
                 .and_then(|compact| {
                     TensorLayout::from_parts(
-                        compact.shape().to_vec().into(),
-                        compact.strides().to_vec().into(),
+                        shape_vec(compact.shape()),
+                        stride_vec(compact.strides()),
                         layout.offset(),
                         buffer_len,
                     )
@@ -4745,8 +4770,16 @@ impl<T, R: TensorRank> TypedTensor<T, R> {
     /// preserved buffer cannot hold the rank-converted layout.
     pub fn try_into_rank<const N: usize>(self) -> crate::Result<TypedTensor<T, Rank<N>>> {
         let op = "TypedTensor::try_into_rank";
-        let shape = <Rank<N> as TensorRank>::shape_from_vec(self.shape().to_vec().into())
-            .map_err(|err| tensor_layout_error(op, err))?;
+        let actual = self.shape().len();
+        let shape: [usize; N] = self.shape().try_into().map_err(|_| {
+            tensor_layout_error(
+                op,
+                ValidationError::RankMismatch {
+                    expected: N,
+                    actual,
+                },
+            )
+        })?;
         let layout =
             TensorLayout::<Rank<N>>::compact(shape).map_err(|err| tensor_layout_error(op, err))?;
         Ok(TypedTensor {

--- a/crates/tenferro-tensor/src/types.rs
+++ b/crates/tenferro-tensor/src/types.rs
@@ -14,6 +14,8 @@ use tenferro_tensor_core::{SliceSpec as CoreSliceSpec, ValidationError};
 mod accessors;
 mod shape_packing;
 mod strided_view;
+#[cfg(test)]
+mod tests;
 
 pub use strided_view::StridedSliceSpec;
 
@@ -23,22 +25,6 @@ fn shape_vec(shape: &[usize]) -> ShapeVec {
 
 fn stride_vec(strides: &[isize]) -> StrideVec {
     strides.iter().copied().collect()
-}
-
-#[cfg(test)]
-mod inline_metadata_tests {
-    use super::*;
-
-    #[test]
-    fn inline_metadata_collection_keeps_small_shapes_and_strides_inline() {
-        let shape = shape_vec(&[2, 3]);
-        let strides = stride_vec(&[1, 2]);
-
-        assert_eq!(shape.as_slice(), &[2, 3]);
-        assert_eq!(strides.as_slice(), &[1, 2]);
-        assert!(!shape.spilled());
-        assert!(!strides.spilled());
-    }
 }
 
 /// Memory location for tensor storage.

--- a/crates/tenferro-tensor/src/types/tests.rs
+++ b/crates/tenferro-tensor/src/types/tests.rs
@@ -1,0 +1,12 @@
+use super::*;
+
+#[test]
+fn inline_metadata_collection_keeps_small_shapes_and_strides_inline() {
+    let shape = shape_vec(&[2, 3]);
+    let strides = stride_vec(&[1, 2]);
+
+    assert_eq!(shape.as_slice(), &[2, 3]);
+    assert_eq!(strides.as_slice(), &[1, 2]);
+    assert!(!shape.spilled());
+    assert!(!strides.spilled());
+}

--- a/docs/superpowers/plans/2026-07-19-low-risk-overhead-cleanup.md
+++ b/docs/superpowers/plans/2026-07-19-low-risk-overhead-cleanup.md
@@ -1,0 +1,190 @@
+# Low-risk Overhead Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove three measured-by-construction fixed overheads from tensor accumulation, tensor metadata conversion, and disabled eager profiling without changing observable behavior.
+
+**Architecture:** Add a compact host-output accumulation path that iterates the validated backing slice and retain the indexed path for every other layout. Replace heap-backed intermediate `Vec` conversions with direct `SmallVec` collection, and centralize the optional eager-profile start timestamp behind the existing enabled predicate.
+
+**Tech Stack:** Rust, tenferro tensor/view abstractions, Criterion, Cargo test/Clippy.
+
+---
+
+### Task 1: Compact `dot_general` accumulation
+
+**Files:**
+- Modify: `crates/tenferro-tensor/src/backend.rs:1081-1130`
+- Modify: `crates/tenferro-tensor/src/tests/backend_default_read_tests.rs:757-894`
+- Modify: `crates/tenferro-tensor/Cargo.toml`
+- Create: `crates/tenferro-tensor/benches/dot_accumulation.rs`
+
+- [ ] **Step 1: Write a failing compact-overwrite regression test**
+
+Add a test that performs a two-element contraction result into compact output initialized with `NaN`, using `alpha = 2` and `beta = 0`, and asserts the finite scaled result. Add a unit test in `backend.rs` that calls the not-yet-defined `compact_host_accumulation_slice(out)` and expects `Some(&mut [..])` for offset-zero compact host output and `None` for a strided view.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `cargo test -p tenferro-tensor compact_host_accumulation_slice -- --exact`
+
+Expected: compilation fails because `compact_host_accumulation_slice` does not exist.
+
+- [ ] **Step 3: Implement the compact fast path**
+
+Implement an internal helper with this contract:
+
+```rust
+fn compact_host_accumulation_slice<'a, T>(
+    out: &'a mut TypedTensorViewMut<'_, T>,
+) -> crate::Result<Option<&'a mut [T]>> {
+    if out.backend_buffer().is_some() || !out.is_col_major_contiguous()? {
+        return Ok(None);
+    }
+    let start = usize::try_from(out.offset()).map_err(|_| {
+        invalid_argument("dot_general", "output", "compact output offset is negative")
+    })?;
+    let end = start.checked_add(out.n_elements()).ok_or_else(|| {
+        validation("dot_general", ValidationError::IntegerOverflow)
+    })?;
+    out.host_storage_mut()?
+        .get_mut(start..end)
+        .map(Some)
+        .ok_or_else(|| invalid_argument("dot_general", "output", "compact output is out of bounds"))
+}
+```
+
+Use the returned slice in `accumulate_typed` and apply the same `beta == 0` branch as the fallback. If the helper returns `None`, retain the existing indexed loop unchanged.
+
+- [ ] **Step 4: Verify GREEN and existing fallback behavior**
+
+Run: `cargo test -p tenferro-tensor backend_default_read_tests::dot_general_accum -- --nocapture`
+
+Expected: all matching tests pass, including compact, scalar dtype, and strided-view cases.
+
+- [ ] **Step 5: Add the focused benchmark**
+
+Add a `dot_accumulation` Criterion target that constructs 4096-element compact `f64` dot/output tensors and repeatedly calls `accumulate_dot_result_into` with `alpha = 1`, `beta = 1`, using `iter_batched` so each iteration receives a fresh output.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add crates/tenferro-tensor/src/backend.rs crates/tenferro-tensor/src/tests/backend_default_read_tests.rs crates/tenferro-tensor/Cargo.toml crates/tenferro-tensor/benches/dot_accumulation.rs
+git commit -m "perf(tensor): fast-path compact dot accumulation"
+```
+
+### Task 2: Allocation-free inline metadata conversion
+
+**Files:**
+- Modify: `crates/tenferro-tensor/src/types.rs:822,1451,4331-4334,4416-4420,4748`
+- Modify: `crates/tenferro-tensor/src/tests/types_tests.rs`
+
+- [ ] **Step 1: Add a failing conversion helper test**
+
+Add an internal `collect_shape` helper test that expects an inline `ShapeVec` for rank 2 and an inline `StrideVec` for rank 2. The test must call the not-yet-defined helpers so RED is a compile failure attributable to the missing implementation.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `cargo test -p tenferro-tensor inline_metadata_collection -- --exact`
+
+Expected: compilation fails because the internal helper is not defined.
+
+- [ ] **Step 3: Implement direct SmallVec collection**
+
+Define focused internal helpers:
+
+```rust
+fn shape_vec(shape: &[usize]) -> ShapeVec {
+    shape.iter().copied().collect()
+}
+
+fn stride_vec(strides: &[isize]) -> StrideVec {
+    strides.iter().copied().collect()
+}
+```
+
+Replace every `.to_vec().into()` in `crates/tenferro-tensor/src/types.rs` with these helpers. Preserve each existing `TensorLayout`, `shape_from_vec`, `strides_from_vec`, and error mapping call.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `cargo test -p tenferro-tensor inline_metadata_collection -- --nocapture && cargo test -p tenferro-tensor types_tests -- --nocapture`
+
+Expected: metadata helper and existing shape/layout/view tests pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add crates/tenferro-tensor/src/types.rs crates/tenferro-tensor/src/tests/types_tests.rs
+git commit -m "perf(tensor): avoid heap metadata round trips"
+```
+
+### Task 3: Disabled eager profiling clock gate
+
+**Files:**
+- Modify: `crates/tenferro-ad/src/eager.rs:121-153`
+- Modify: `crates/tenferro-ad/src/eager_ops.rs:1114-1196`
+- Modify: `crates/tenferro-ad/src/eager/tests.rs:446-460`
+
+- [ ] **Step 1: Write a failing disabled-profile test**
+
+Extend the profiling helper imports and add a test that installs `EagerOpProfileOverrideGuard::set(false, None)` and asserts `eager_op_profile_start().is_none()`. Extend the enabled-path test to assert the same helper returns `Some`.
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `cargo test -p tenferro-ad eager_op_profile_start_respects_enabled_gate -- --exact`
+
+Expected: compilation fails because `eager_op_profile_start` does not exist.
+
+- [ ] **Step 3: Implement the lazy clock gate**
+
+Add:
+
+```rust
+pub(crate) fn eager_op_profile_start() -> Option<Instant> {
+    eager_op_profile_enabled().then(Instant::now)
+}
+```
+
+In `nary_op`, replace the unconditional `Instant::now()` with this helper and only record `nary_op.total` and call `maybe_print_eager_op_profile()` inside `if let Some(total_started)`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `cargo test -p tenferro-ad eager_op_profile -- --nocapture`
+
+Expected: enabled and disabled profiling helper tests pass.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add crates/tenferro-ad/src/eager.rs crates/tenferro-ad/src/eager_ops.rs crates/tenferro-ad/src/eager/tests.rs
+git commit -m "perf(ad): skip clock reads when profiling is disabled"
+```
+
+### Task 4: Verification and PR
+
+**Files:**
+- Modify only if verification reveals a defect in the files above.
+
+- [ ] **Step 1: Format and inspect**
+
+Run: `cargo fmt --all -- --check && git diff --check`
+
+Expected: both commands exit successfully.
+
+- [ ] **Step 2: Run targeted tests and Clippy**
+
+Run: `cargo test -p tenferro-tensor -p tenferro-ad && cargo clippy -p tenferro-tensor -p tenferro-ad --all-targets -- -D warnings`
+
+Expected: all tests pass and Clippy emits no warnings.
+
+- [ ] **Step 3: Compile and sample the benchmark**
+
+Run: `cargo bench -p tenferro-tensor --bench dot_accumulation --no-run`
+
+Expected: benchmark target compiles successfully.
+
+- [ ] **Step 4: Run repository pre-PR verification required by `AGENTS.md`**
+
+Run the repository's documented bugfix/pre-PR command set and record exact outcomes in the PR body.
+
+- [ ] **Step 5: Push and open one batch PR**
+
+Push `codex/issue-1426-low-risk-overheads` and open a PR referencing #1426. Explain that public behavior is unchanged, identify the compact fallback boundary, and include test and benchmark evidence.

--- a/docs/superpowers/specs/2026-07-19-low-risk-overhead-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-19-low-risk-overhead-cleanup-design.md
@@ -1,0 +1,54 @@
+# Low-risk overhead cleanup design
+
+## Scope
+
+Address three internal overhead findings from #1426 without changing public APIs,
+numeric results, validation, error behavior, layout semantics, or profiling output:
+
+1. Avoid per-element index-vector allocation when `dot_general` accumulates into
+   a compact column-major output.
+2. Avoid `SmallVec -> Vec -> SmallVec` metadata round trips in tensor view
+   construction where the destination rank representation can be built directly.
+3. Avoid reading the clock for eager AD profiling when profiling is disabled.
+
+## Considered approaches
+
+For `dot_general`, replacing the whole accumulation loop with unchecked pointer
+arithmetic would also remove overhead, but would duplicate layout logic and widen
+the unsafe surface. Reworking the generic tensor iterator would have a larger
+blast radius. The selected approach adds a compact-output slice fast path and
+keeps the existing indexed implementation as the fallback for non-compact views.
+
+For view metadata, changing the public shape types could eliminate more copies,
+but would be an API change. The selected approach only removes conversions that
+are redundant for the existing `SmallVec`-backed representations.
+
+For profiling, changing the profiler API is unnecessary. The selected approach
+moves clock acquisition behind the existing enabled predicate.
+
+## Behavioral contracts
+
+- The compact accumulation fast path preserves `out = alpha * dot + beta * out`.
+- When `beta == 0`, accumulation does not read the previous output value.
+- Non-compact and strided outputs continue through the existing checked path.
+- Shape, stride, offset, dtype, validation, and error behavior remain unchanged.
+- Profiling-enabled event contents and timings retain the same meaning.
+- No public symbols or dependencies are added.
+
+## Verification
+
+- Add or extend tests for compact overwrite and additive accumulation, including
+  a `beta == 0` case whose destination initially contains non-finite values.
+- Retain explicit coverage of a non-compact/strided accumulation destination.
+- Add structural unit coverage where practical for the profiling gate and direct
+  metadata conversion; otherwise rely on existing behavioral tests plus source
+  inspection and benchmarks.
+- Add a focused accumulation benchmark that exercises the compact hot path.
+- Run formatting, targeted crate tests, Clippy for touched crates, and the
+  repository's required pre-PR verification.
+
+## Non-goals
+
+This change does not address eager einsum planning, runtime segment caches, GPU
+planning, host-transfer ownership, dynamic slicing, FFT planning, or public API
+design. Those findings retain their separate performance and ownership risks.

--- a/docs/worklogs/2026-07-19-issue-1426-low-risk-overheads.md
+++ b/docs/worklogs/2026-07-19-issue-1426-low-risk-overheads.md
@@ -1,0 +1,59 @@
+# Issue #1426 low-risk overhead cleanup
+
+## Context
+
+Issue #1426 records static performance risks found at commit `e4eb831f`.
+Before editing, the current `origin/main` implementation was checked at
+`52b07707`. This batch intentionally selects only internal overheads whose
+ownership and behavior boundaries are already established. It does not add or
+change public APIs.
+
+The implementation follows `CONTRIBUTING.md`, `AGENTS.md`,
+`REPOSITORY_RULES.md`, and the repository remediation workflow. The bug-fix
+scope gate was applied because all selected changes preserve existing behavior
+and remain inside the existing tensor and eager-AD architecture.
+
+## Classification ledger
+
+| Finding | Classification | Current evidence | Disposition | Residual risk |
+|---|---|---|---|---|
+| #1426 H6: per-element allocation in `dot_general` accumulation | Auto Fix | `accumulate_typed` allocated an index `Vec` and performed div/mod for every compact output element | Added a compact host-slice fast path; retained the checked indexed fallback for strided, backend, and mismatched-length output | Backend and arbitrary-stride outputs intentionally retain the existing cost |
+| #1426 low: tensor metadata `SmallVec` round trips | Auto Fix | `types.rs` converted inline metadata through heap `Vec` at view/layout construction sites | Replaced the same-contract occurrences with direct `SmallVec` collection and direct fixed-rank slice-to-array conversion | Rank greater than inline capacity still allocates by design |
+| #1426 low: unconditional eager profiling clock read | Auto Fix | `EagerTensor::nary_op` called `Instant::now()` before checking whether aggregate profiling was enabled | Clock acquisition now occurs lazily behind the existing enabled predicate | Profiling-enabled execution intentionally retains timing overhead |
+| #1426 H1-H5, H7-H8, M1-M8, GPU notes | Verify First / Out of Scope | These findings involve separate planners, caches, synchronization, ownership, threading, algorithms, or backends | Deferred unchanged; this PR does not claim to close the umbrella | Each needs its own current-source validation and focused contract |
+
+## Behavioral boundaries
+
+- Compact accumulation still computes `out = alpha * dot + beta * out`.
+- `beta == 0` does not read existing output values; a `NaN`-initialized
+  regression case covers this contract.
+- Noncompact output uses the original indexed implementation. A strided-output
+  regression case confirms its physical gaps remain untouched.
+- Shape, stride, offset, validation, error, dtype, and profiling-output
+  semantics are unchanged.
+
+## Benchmark
+
+The added Criterion benchmark uses a compact 4096-element `f64` accumulation
+with `alpha = beta = 1`. On this development host:
+
+- compact fast path: median **2.90 us**;
+- previous indexed path: median **75.83 us**;
+- observed speedup: approximately **26x**.
+
+The comparison was run in the same worktree and release target. The committed
+implementation was restored afterward and checked byte-for-byte against
+`HEAD` with `git diff --exit-code HEAD`.
+
+## Verification
+
+- `cargo fmt --all -- --check`
+- `cargo test -p tenferro-tensor -p tenferro-ad`
+- `cargo clippy -p tenferro-tensor -p tenferro-ad --all-targets -- -D warnings`
+- `cargo bench -p tenferro-tensor --bench dot_accumulation --no-run`
+- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-tensor dot_general_accum' --test 'cargo test -p tenferro-ad eager_op_profile'`
+- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1426.json` — pass, no findings
+
+GPU checks were not run because this batch changes backend-independent host
+accumulation, tensor metadata construction, and an eager profiling gate only.
+Hosted CI remains responsible for workspace-wide backend variants.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [x] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs #1426

## Summary

- fast-path compact host `dot_general` accumulation with a direct slice loop while preserving the checked strided/backend fallback;
- eliminate heap-backed `Vec` round trips when constructing inline tensor shape and stride metadata;
- skip `Instant::now()` entirely when aggregate eager-op profiling is disabled;
- add regression coverage and a focused Criterion benchmark.

The compact 4096-element `f64` benchmark measured 2.90 us on the fast path versus 75.83 us on the previous indexed path (approximately 26x faster) on the development host.

## Scope and classification

The AI-assisted bug-fix scope gate was applied. All three selected findings are internal `Auto Fix` performance/allocation problems with established behavior contracts. No public API, dtype, layout, validation, error, AD semantics, dependency, backend, or cache policy changes are included.

The remaining H/M/GPU findings in #1426 are `Verify First` or out of scope because they involve separate planner, cache, synchronization, ownership, threading, algorithm, or backend contracts. This PR therefore references rather than closes the umbrella.

Same-root-cause searches covered all `.to_vec().into()` metadata conversions in `tenferro-tensor/src/types.rs`, the complete compact accumulation/fallback boundary, and eager profiling clock acquisition. Related findings outside those verification paths were intentionally deferred.

## Work log

[Issue #1426 low-risk overhead cleanup](docs/worklogs/2026-07-19-issue-1426-low-risk-overheads.md)

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p tenferro-tensor -p tenferro-ad`
- `cargo clippy -p tenferro-tensor -p tenferro-ad --all-targets -- -D warnings`
- `cargo bench -p tenferro-tensor --bench dot_accumulation --no-run`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-tensor dot_general_accum' --test 'cargo test -p tenferro-ad eager_op_profile'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1426-final.json` — pass, no findings

GPU checks were not run because the changed execution path is backend-independent host accumulation plus metadata and profiling gates. Hosted CI remains responsible for workspace-wide backend variants.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. (Not a new feature.)
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.
