### PR TITLE
fix(ci): authorize maintainers by repository role

### DIFF
--- a/.github/workflows/review_bot.yml
+++ b/.github/workflows/review_bot.yml
@@ -210,10 +210,10 @@ jobs:
               repo,
               username: labelActor,
             });
-            if (!allowed.has(data.permission)) {
+            if (!allowed.has(data.role_name)) {
               core.setFailed(
-                `Actor ${labelActor} has ${data.permission} permission; ` +
-                `the ${labelName} label requires maintain or admin permission.`
+                `Actor ${labelActor} has ${data.role_name} repository role; ` +
+                `the ${labelName} label requires the maintain or admin role.`
               );
             }
       - name: Checkout trusted base revision
@@ -377,10 +377,10 @@ jobs:
               repo,
               username: labelActor,
             });
-            if (!allowed.has(data.permission)) {
+            if (!allowed.has(data.role_name)) {
               core.setFailed(
-                `Actor ${labelActor} has ${data.permission} permission; ` +
-                `the ${labelName} label requires maintain or admin permission.`
+                `Actor ${labelActor} has ${data.role_name} repository role; ` +
+                `the ${labelName} label requires the maintain or admin role.`
               );
             }
       - name: Checkout trusted base revision

--- a/.github/workflows/runpod-gpu-test.yml
+++ b/.github/workflows/runpod-gpu-test.yml
@@ -148,16 +148,16 @@ jobs:
           check_permission() {
             local login="$1"
             local role="$2"
-            local perm
+            local repository_role
 
-            perm="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${login}/permission" --jq .permission)"
+            repository_role="$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${login}/permission" --jq .role_name)"
 
-            case "${perm}" in
+            case "${repository_role}" in
               admin|maintain)
-                echo "OK: ${role} ${login} has '${perm}' permission and is allowed to launch RunPod CI."
+                echo "OK: ${role} ${login} has '${repository_role}' repository role and is allowed to launch RunPod CI."
                 ;;
               *)
-                echo "::error::${role} ${login} has '${perm}' permission, which is not allowed to launch RunPod CI (requires admin or maintain)."
+                echo "::error::${role} ${login} has '${repository_role}' repository role, which is not allowed to launch RunPod CI (requires admin or maintain)."
                 exit 1
               ;;
             esac

--- a/docs/worklogs/2026-07-21-issue-1439-repository-role-authorization.md
+++ b/docs/worklogs/2026-07-21-issue-1439-repository-role-authorization.md
@@ -1,0 +1,36 @@
+# Issue #1439 repository-role authorization
+
+## Context
+
+PR #1438 showed that trusted RunPod authorization rejected a collaborator
+assigned the `maintain` repository role. GitHub returned the legacy
+`permission` field as `write` and the actual role in `role_name`. The same
+field mismatch existed in both maintainer-only review-label checks.
+
+The bug-fix scope gate was applied at `upstream/main` commit `85855e27` after
+reviewing `CONTRIBUTING.md`, `AGENTS.md`, `REPOSITORY_RULES.md`, the bug-fix
+workflow, issue #1439, and the existing RunPod and review-bot trust boundaries.
+
+## Decision
+
+- Read required `role_name` values for RunPod and review-label authorization.
+- Preserve the existing `admin|maintain` allowlist and every actor/author
+  check.
+- Fail closed when `role_name` is missing or unknown.
+
+Falling back to legacy `permission` was rejected because it cannot distinguish
+`maintain` from `write`. GPU classification, same-repository and pinned-SHA
+checks, manual author checks, and the 90-minute wrapper remain unchanged.
+
+## Verification
+
+- `python3 -m unittest scripts.ci.tests.test_workflow_contracts` (28 tests)
+- `python3 scripts/ci/run_profile.py ci-config` (154 tests and actionlint 1.7.7)
+- `bash scripts/check-pr-fast.sh --base upstream/main --no-fetch --ci-profile ci-config`
+- `cargo fmt --all --check`
+- committed-head repository-rules review: pass, no findings
+
+## Remaining risk
+
+A trusted exact-SHA RunPod recovery must confirm the live GitHub authorization
+response and GPU workflow before merge.

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -93,6 +93,35 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("GPU validation not required", text)
         self.assertIn("GPU_REQUIRED: ${{ needs.authorize.outputs.gpu_required }}", text)
 
+    def test_runpod_authorization_uses_repository_roles(self) -> None:
+        text = read(".github/workflows/runpod-gpu-test.yml")
+        authorization = text[
+            text.index("          check_permission() {") : text.index(
+                "          classify_pr_paths() {"
+            )
+        ]
+        self.assertIn("--jq .role_name", authorization)
+        self.assertNotIn("--jq .permission", authorization)
+        self.assertIn("admin|maintain)", authorization)
+        self.assertEqual(
+            re.findall(r'^[ \t]+check_permission "[^\n]+$', text, re.MULTILINE),
+            [
+                '            check_permission "${pr_author}" "PR author"',
+                '            check_permission "${WORKFLOW_RUN_ACTOR}" "Source workflow actor"',
+                '            check_permission "${GITHUB_ACTOR}" "Workflow actor"',
+                '              check_permission "${pr_author}" "PR author"',
+            ],
+        )
+
+    def test_review_labels_are_authorized_by_repository_role(self) -> None:
+        text = read(".github/workflows/review_bot.yml")
+        self.assertEqual(
+            text.count('const allowed = new Set(["admin", "maintain"]);'), 2
+        )
+        self.assertEqual(text.count("allowed.has(data.role_name)"), 2)
+        self.assertNotIn("allowed.has(data.permission)", text)
+        self.assertEqual(text.count("has ${data.role_name} repository role"), 2)
+
     def test_runpod_secret_stays_on_trusted_hosted_jobs(self) -> None:
         text = read(".github/workflows/runpod-gpu-test.yml")
         run_gpu = text[


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1439

## Summary

GitHub folds the `maintain` role into `permission=write`, so the trusted RunPod and maintainer-label gates rejected valid maintainers before GPU work could start. This PR reads required `role_name` values instead, with no fallback to the legacy field.

The existing `admin|maintain` allowlist, all four RunPod actor/author checks, same-repository and pinned-SHA checks, manual author checks, GPU classification, and 90-minute wrapper behavior remain unchanged. Workflow contract tests pin both corrected review-label checks and every RunPod authorization call site.

The AI-assisted bug-fix scope gate was applied. A neighborhood search found the same root cause only in the shared RunPod helper and the two review-label authorizers; all are fixed here. No new API, backend, dependency, feature, or policy is introduced.

## Work log

[Issue #1439 repository-role authorization](docs/worklogs/2026-07-21-issue-1439-repository-role-authorization.md)

## Verification

- `python3 -m unittest scripts.ci.tests.test_workflow_contracts` (28 passed)
- `python3 scripts/ci/run_profile.py ci-config` (154 passed; actionlint 1.7.7 passed)
- `bash scripts/check-pr-fast.sh --base upstream/main --no-fetch --ci-profile ci-config`
- `cargo fmt --all --check`
- committed-head repository-rules review: pass, no findings
- independent security review: approve, no findings

A trusted exact-SHA RunPod recovery is still required before merge to validate the live GitHub role response and GPU workflow.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.