### PR TITLE
Add full-matrices SVD and least-squares solve (#1446)

### DIFF
--- a/crates/tenferro-linalg/src/ad.rs
+++ b/crates/tenferro-linalg/src/ad.rs
@@ -128,6 +128,11 @@ impl ExtensionLinearizeRule for LinalgAdRule {
                 derivative_eps,
                 ctx,
             ),
+            // Full-matrices SVD is value-only; AD is intentionally unsupported
+            // (recorded as such in the linalg AD support manifest). Emit no
+            // tangent rather than a silent thin-SVD derivative, matching the
+            // LuFactor unsupported precedent above.
+            LinalgOp::SvdFull => Ok(vec![None; op.output_count()]),
             LinalgOp::SvdVals { derivative_eps } => {
                 rules::linearize_svd_values(builder, primal_in, tangent_in, derivative_eps, ctx)
             }
@@ -224,6 +229,7 @@ impl ExtensionLinearTransposeRule for LinalgAdRule {
             | LinalgOp::LuFactor
             | LinalgOp::FullPivLu
             | LinalgOp::Svd { .. }
+            | LinalgOp::SvdFull
             | LinalgOp::SvdVals { .. }
             | LinalgOp::Qr { .. }
             | LinalgOp::Eigh { .. }
@@ -1049,6 +1055,7 @@ mod tests {
                 derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
                 gauge: SvdGauge::Raw,
             },
+            LinalgOp::SvdFull,
             LinalgOp::SvdVals {
                 derivative_eps: DEFAULT_DECOMPOSITION_DERIVATIVE_EPS,
             },

--- a/crates/tenferro-linalg/src/ad/support.rs
+++ b/crates/tenferro-linalg/src/ad/support.rs
@@ -93,10 +93,11 @@ pub enum LinalgAdOpKind {
     Eig,
     EigVals,
     TriangularSolve,
+    SvdFull,
 }
 
 impl LinalgAdOpKind {
-    pub const COUNT: usize = 14;
+    pub const COUNT: usize = 15;
 
     /// Return the manifest index for this operation kind.
     ///
@@ -123,6 +124,7 @@ impl LinalgAdOpKind {
             Self::Eig => 11,
             Self::EigVals => 12,
             Self::TriangularSolve => 13,
+            Self::SvdFull => 14,
         }
     }
 
@@ -136,6 +138,7 @@ impl LinalgAdOpKind {
             LinalgOp::FullPivLu => Self::FullPivLu,
             LinalgOp::FullPivLuSolve { .. } => Self::FullPivLuSolve,
             LinalgOp::Svd { .. } => Self::Svd,
+            LinalgOp::SvdFull => Self::SvdFull,
             LinalgOp::SvdVals { .. } => Self::SvdVals,
             LinalgOp::Qr { .. } => Self::Qr,
             LinalgOp::Eigh { .. } => Self::Eigh,
@@ -299,6 +302,11 @@ static SVD_VALS_OUTPUTS: [LinalgAdOutputSupport; 1] = [output(
     "singular_values",
     LinalgAdRuleSupport::SupportedViaLinearize,
 )];
+static SVD_FULL_OUTPUTS: [LinalgAdOutputSupport; 3] = [
+    output(0, "u", LinalgAdRuleSupport::Unsupported),
+    output(1, "singular_values", LinalgAdRuleSupport::Unsupported),
+    output(2, "vt", LinalgAdRuleSupport::Unsupported),
+];
 static QR_OUTPUTS: [LinalgAdOutputSupport; 2] = [
     output(0, "q", LinalgAdRuleSupport::SupportedViaLinearize),
     output(1, "r", LinalgAdRuleSupport::SupportedViaLinearize),
@@ -494,6 +502,18 @@ static LINALG_AD_SUPPORT: [LinalgAdSupport; LinalgAdOpKind::COUNT] = [
         ),
         LinalgAdRuleSupport::Supported,
         &SOLUTION_OUTPUTS,
+        &[],
+    ),
+    // Full-matrices SVD is a value-only route: nullspace/kernel extraction does
+    // not require derivatives, and the thin-SVD linearize rule does not extend
+    // to the square factors. AD is intentionally unsupported for every output.
+    support_entry(
+        LinalgAdOpKind::SvdFull,
+        LinalgAdRuleSupport::Unsupported,
+        LinalgAdRuleSupport::Unsupported,
+        mode(LinalgAdRuleSupport::Unsupported, LinalgAdRoute::Unsupported),
+        LinalgAdRuleSupport::Unsupported,
+        &SVD_FULL_OUTPUTS,
         &[],
     ),
 ];

--- a/crates/tenferro-linalg/src/ad/support/tests.rs
+++ b/crates/tenferro-linalg/src/ad/support/tests.rs
@@ -35,6 +35,7 @@ fn manifest_internal_mapping_covers_linalg_op_variants() {
             },
             LinalgAdOpKind::SvdVals,
         ),
+        (LinalgOp::SvdFull, LinalgAdOpKind::SvdFull),
         (
             LinalgOp::Qr {
                 gauge: QrGauge::Raw,

--- a/crates/tenferro-linalg/src/backend.rs
+++ b/crates/tenferro-linalg/src/backend.rs
@@ -211,6 +211,27 @@ pub trait LinalgBackend: TensorBackend {
         Ok(outputs)
     }
 
+    /// Compute public full-matrices SVD outputs `(U, S, Vt)` with `U` shaped
+    /// `m x m` and `Vt` shaped `n x n`, so the trailing `Vt` rows span the
+    /// input's right nullspace.
+    ///
+    /// # Errors
+    ///
+    /// The default implementation returns `Error::Unsupported`: a backend that
+    /// does not implement the full variant reports it explicitly rather than
+    /// silently falling back to the thin decomposition. Implementing backends
+    /// may additionally return `Error::Validation` for an unsupported rank or
+    /// dtype and a typed backend source when the solver fails.
+    fn svd_full(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
+        Err(tenferro_tensor::Error::unsupported(
+            "svd_full",
+            format!(
+                "backend {} does not implement full-matrices SVD",
+                std::any::type_name::<Self>()
+            ),
+        ))
+    }
+
     #[doc(hidden)]
     fn svd_values(&mut self, _input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         Err(tenferro_tensor::Error::unsupported(

--- a/crates/tenferro-linalg/src/cpu/backend.rs
+++ b/crates/tenferro-linalg/src/cpu/backend.rs
@@ -521,6 +521,42 @@ impl LinalgBackend for CpuBackend {
         }
     }
 
+    fn svd_full(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
+        ensure_host_tensor("svd_full", input)?;
+        match linalg_provider_kind(self.kind(), "svd_full")? {
+            CpuLinalgProvider::Faer => {
+                #[cfg(feature = "cpu-faer")]
+                {
+                    let ctx = self.linalg_context();
+                    self.with_linalg_pool(|buffers| match input {
+                        Tensor::F32(t) => linalg::faer::svd_full(ctx.as_ref(), buffers, t)
+                            .map(|outputs| outputs.into_iter().map(Tensor::F32).collect()),
+                        Tensor::F64(t) => linalg::faer::svd_full(ctx.as_ref(), buffers, t)
+                            .map(|outputs| outputs.into_iter().map(Tensor::F64).collect()),
+                        Tensor::C32(t) => linalg::faer::svd_full(ctx.as_ref(), buffers, t)
+                            .and_then(svd_c32_outputs_to_public_tensors),
+                        Tensor::C64(t) => linalg::faer::svd_full(ctx.as_ref(), buffers, t)
+                            .and_then(svd_c64_outputs_to_public_tensors),
+                        _ => Err(unsupported_dtype("svd_full", input.dtype())),
+                    })
+                }
+                #[cfg(not(feature = "cpu-faer"))]
+                {
+                    Err(unsupported_provider("svd_full", self.kind()))
+                }
+            }
+            // The LAPACK provider is intentionally not wired for full-matrices
+            // SVD in this slice; it returns a typed error instead of silently
+            // computing a thin decomposition. Full-SVD callers select the faer
+            // provider (the default) or download to host and use it explicitly.
+            CpuLinalgProvider::Blas => Err(tenferro_tensor::Error::unsupported(
+                "svd_full",
+                "CPU LAPACK provider does not implement full-matrices SVD; \
+                 use the faer provider for full SVD",
+            )),
+        }
+    }
+
     fn svd_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         ensure_host_tensor("svd_values", input)?;
         match linalg_provider_kind(self.kind(), "svd_values")? {

--- a/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
+++ b/crates/tenferro-linalg/src/cpu/linalg/faer_linalg.rs
@@ -64,6 +64,7 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
+        full: bool,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
     fn svd_values_2d(
         ctx: &CpuContext,
@@ -105,6 +106,7 @@ pub(crate) trait FaerLinalg: Copy + Clone + PoolScalar {
         mat: MatRef<'_, Self>,
         m: usize,
         n: usize,
+        full: bool,
         placement: &tenferro_tensor::Placement,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>>;
     fn qr_core(
@@ -1548,10 +1550,11 @@ macro_rules! impl_faer_linalg_for_real {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
+        full: bool,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "svd")?;
         let mat = Self::faer_mat_ref_compact(input.host_data()?, m, n);
-        Self::svd_core(ctx, buffers, mat, m, n, input.placement())
+        Self::svd_core(ctx, buffers, mat, m, n, full, input.placement())
     }
 
     fn svd_values_2d(
@@ -1655,17 +1658,26 @@ macro_rules! impl_faer_linalg_for_real {
         mat: MatRef<'_, Self>,
         m: usize,
         n: usize,
+        full: bool,
         placement: &tenferro_tensor::Placement,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let k = m.min(n);
-        let mut u = Mat::zeros(m, k);
-        let mut v = Mat::zeros(n, k);
+        // Full mode returns the square unitary factors `U (m x m)` and
+        // `V (n x n)`; thin mode keeps only the leading `k` vectors. The
+        // singular-value count is `k` in both modes.
+        let (u_cols, v_cols, vectors) = if full {
+            (m, n, faer::linalg::svd::ComputeSvdVectors::Full)
+        } else {
+            (k, k, faer::linalg::svd::ComputeSvdVectors::Thin)
+        };
+        let mut u = Mat::zeros(m, u_cols);
+        let mut v = Mat::zeros(n, v_cols);
         let mut s = Diag::zeros(k);
         let mut mem = MemBuffer::new(faer::linalg::svd::svd_scratch::<Self>(
             m,
             n,
-            faer::linalg::svd::ComputeSvdVectors::Thin,
-            faer::linalg::svd::ComputeSvdVectors::Thin,
+            vectors,
+            vectors,
             ctx.faer_par(),
             Default::default(),
         ));
@@ -1682,20 +1694,20 @@ macro_rules! impl_faer_linalg_for_real {
         .map_err(|_| decomposition_failed("svd"))?;
 
         let u = tensor_from_vec_with_template(
-            vec![m, k],
+            vec![m, u_cols],
             col_major_vec_from_mat(buffers, u.as_ref())?,
             placement,
         )?;
         let s =
             tensor_from_vec_with_template(vec![k], vec_from_diag(buffers, s.as_ref()), placement)?;
-        let vt_len = checked_product("svd", "right singular vectors", &[k, n])?;
+        let vt_len = checked_product("svd", "right singular vectors", &[v_cols, n])?;
         let mut vt_data = buffers.acquire_with_capacity::<Self>(vt_len);
         for j in 0..n {
-            for i in 0..k {
+            for i in 0..v_cols {
                 vt_data.push(v[(j, i)]);
             }
         }
-        let vt = tensor_from_vec_with_template(vec![k, n], vt_data, placement)?;
+        let vt = tensor_from_vec_with_template(vec![v_cols, n], vt_data, placement)?;
 
         Ok(vec![u, s, vt])
     }
@@ -2424,10 +2436,11 @@ macro_rules! impl_faer_linalg_for_complex {
         ctx: &CpuContext,
         buffers: &mut BufferPool,
         input: &TypedTensor<Self>,
+        full: bool,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         let (m, n) = matrix_dims(input, "svd")?;
         let mat = Self::faer_mat_ref_compact(input.host_data()?, m, n);
-        Self::svd_core(ctx, buffers, mat, m, n, input.placement())
+        Self::svd_core(ctx, buffers, mat, m, n, full, input.placement())
     }
 
     fn svd_values_2d(
@@ -2551,6 +2564,7 @@ macro_rules! impl_faer_linalg_for_complex {
         mat: MatRef<'_, Self>,
         m: usize,
         n: usize,
+        full: bool,
         placement: &tenferro_tensor::Placement,
     ) -> tenferro_tensor::Result<Vec<TypedTensor<Self>>> {
         // Cast Self (Complex32/64) to $faer_complex (faer::c32/c64) for faer calls.
@@ -2565,14 +2579,22 @@ macro_rules! impl_faer_linalg_for_complex {
             )
         };
         let k = m.min(n);
-        let mut u = Mat::zeros(m, k);
-        let mut v = Mat::zeros(n, k);
+        // Full mode returns the square unitary factors `U (m x m)` and
+        // `V (n x n)`; thin mode keeps only the leading `k` vectors. The
+        // singular-value count is `k` in both modes.
+        let (u_cols, v_cols, vectors) = if full {
+            (m, n, faer::linalg::svd::ComputeSvdVectors::Full)
+        } else {
+            (k, k, faer::linalg::svd::ComputeSvdVectors::Thin)
+        };
+        let mut u = Mat::zeros(m, u_cols);
+        let mut v = Mat::zeros(n, v_cols);
         let mut s = Diag::zeros(k);
         let mut mem = MemBuffer::new(faer::linalg::svd::svd_scratch::<$faer_complex>(
             m,
             n,
-            faer::linalg::svd::ComputeSvdVectors::Thin,
-            faer::linalg::svd::ComputeSvdVectors::Thin,
+            vectors,
+            vectors,
             ctx.faer_par(),
             Default::default(),
         ));
@@ -2589,7 +2611,7 @@ macro_rules! impl_faer_linalg_for_complex {
         .map_err(|_| decomposition_failed("svd"))?;
 
         let u = tensor_from_vec_with_template(
-            vec![m, k],
+            vec![m, u_cols],
             $vec_from_mat(buffers, u.as_ref())?,
             placement,
         )?;
@@ -2598,14 +2620,14 @@ macro_rules! impl_faer_linalg_for_complex {
             $vec_from_real_diag(buffers, s.as_ref()),
             placement,
         )?;
-        let vt_len = checked_product("svd", "right singular vectors", &[k, n])?;
+        let vt_len = checked_product("svd", "right singular vectors", &[v_cols, n])?;
         let mut vt_data = buffers.acquire_with_capacity::<Self>(vt_len);
         for j in 0..n {
-            for i in 0..k {
+            for i in 0..v_cols {
                 vt_data.push(v[(j, i)].conj());
             }
         }
-        let vt = tensor_from_vec_with_template(vec![k, n], vt_data, placement)?;
+        let vt = tensor_from_vec_with_template(vec![v_cols, n], vt_data, placement)?;
 
         Ok(vec![u, s, vt])
     }
@@ -3077,7 +3099,38 @@ pub(crate) fn svd<T: FaerLinalg>(
         ]);
     }
     batched_multi_result("svd", buffers, input, 2, |buffers, batch| {
-        T::svd_2d(ctx, buffers, batch)
+        T::svd_2d(ctx, buffers, batch, false)
+    })
+}
+
+pub(crate) fn svd_full<T: FaerLinalg>(
+    ctx: &CpuContext,
+    buffers: &mut BufferPool,
+    input: &TypedTensor<T>,
+) -> tenferro_tensor::Result<Vec<TypedTensor<T>>> {
+    if has_zero_dim(input.shape()) {
+        let (m, n, batch_shape) = matrix_core_and_batch(input, "svd_full")?;
+        let k = m.min(n);
+        return Ok(vec![
+            tensor_from_vec_with_template(
+                matrix_with_batch_shape(m, m, batch_shape),
+                Vec::new(),
+                input.placement(),
+            )?,
+            tensor_from_vec_with_template(
+                vector_with_batch_shape(k, batch_shape),
+                Vec::new(),
+                input.placement(),
+            )?,
+            tensor_from_vec_with_template(
+                matrix_with_batch_shape(n, n, batch_shape),
+                Vec::new(),
+                input.placement(),
+            )?,
+        ]);
+    }
+    batched_multi_result("svd_full", buffers, input, 2, |buffers, batch| {
+        T::svd_2d(ctx, buffers, batch, true)
     })
 }
 
@@ -3224,7 +3277,7 @@ pub(crate) fn svd_view<T: FaerLinalg + 'static>(
     let placement = view.placement().clone();
     let base = host_base_ptr(&view)?;
     let mat = unsafe { T::faer_mat_ref_strided(base, m, n, view.strides()[0], view.strides()[1]) };
-    T::svd_core(ctx, buffers, mat, m, n, &placement)
+    T::svd_core(ctx, buffers, mat, m, n, false, &placement)
 }
 
 pub(crate) fn qr_view<T: FaerLinalg + 'static>(

--- a/crates/tenferro-linalg/src/eager_backend.rs
+++ b/crates/tenferro-linalg/src/eager_backend.rs
@@ -57,6 +57,10 @@ impl LinalgBackend for EagerBackend {
         dispatch_linalg!(self, svd(input))
     }
 
+    fn svd_full(&mut self, input: &Tensor) -> tenferro_tensor::Result<Vec<Tensor>> {
+        dispatch_linalg!(self, svd_full(input))
+    }
+
     fn svd_values(&mut self, input: &Tensor) -> tenferro_tensor::Result<Tensor> {
         dispatch_linalg!(self, svd_values(input))
     }

--- a/crates/tenferro-linalg/src/eager_composites.rs
+++ b/crates/tenferro-linalg/src/eager_composites.rs
@@ -2,7 +2,7 @@ use num_complex::{Complex32, Complex64};
 use tenferro_ad::{CompareDir, DType, DotGeneralConfig, EagerTensor, Error, Result, Tensor};
 use tenferro_runtime::ErrorPhase;
 
-use crate::eager_ext::{eig, eigh, lu, solve, svd};
+use crate::eager_ext::{eig, eigh, lu, qr, solve, svd, triangular_solve};
 
 pub(crate) fn slogdet(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor)> {
     let (_p, _l, u, parity) = lu(a)?;
@@ -22,6 +22,32 @@ pub(crate) fn inv(a: &EagerTensor) -> Result<EagerTensor> {
     ensure_min_rank("inv", a.shape().len(), 2)?;
     let eye = eye_like(a, a.shape()[0])?;
     solve(a, &eye)
+}
+
+pub(crate) fn lstsq(a: &EagerTensor, b: &EagerTensor) -> Result<EagerTensor> {
+    ensure_float_or_complex("lstsq", a.dtype())?;
+    ensure_min_rank("lstsq", a.shape().len(), 2)?;
+    ensure_min_rank("lstsq", b.shape().len(), 2)?;
+    let (m, n) = (a.shape()[0], a.shape()[1]);
+    if m < n {
+        return Err(Error::invalid_argument(
+            "lstsq",
+            ErrorPhase::GraphBuild,
+            "shape",
+            format!(
+                "lstsq requires a tall or square matrix (rows {m} >= cols {n}); \
+                 underdetermined (wide) systems are not supported"
+            ),
+        ));
+    }
+    // Least squares via thin QR: A = Q R (full column rank), so
+    // argmin_x |A x - b| solves R x = Qᴴ b.
+    let (q, r) = qr(a)?;
+    let qh = q
+        .conj()?
+        .transpose(&matrix_transpose_perm(q.shape().len()))?;
+    let qh_b = matmul_preserve_trailing_batch(&qh, b)?;
+    triangular_solve(&r, &qh_b, true, false, false, false)
 }
 
 pub(crate) fn eigvalsh(a: &EagerTensor) -> Result<EagerTensor> {

--- a/crates/tenferro-linalg/src/eager_ext.rs
+++ b/crates/tenferro-linalg/src/eager_ext.rs
@@ -30,6 +30,19 @@ pub trait EagerTensorLinalgExt {
         &self,
         options: SvdOptions,
     ) -> Result<(EagerTensor, EagerTensor, EagerTensor)>;
+    /// Full-matrices SVD returning square `U (m x m)` and `Vh (n x n)`, whose
+    /// trailing `n - rank` rows span the input's right nullspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` for an invalid rank, and `Error::Extension`
+    /// with an unsupported-operation source when the active backend does not
+    /// implement full-matrices SVD (the CPU faer provider supports it; the
+    /// LAPACK provider and GPU backends return an unsupported error in this
+    /// slice). Automatic differentiation through the full variant is
+    /// unsupported and surfaces a typed error rather than a silent thin
+    /// fallback.
+    fn svd_full(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor)>;
     /// # Errors
     ///
     /// Returns `Error::Validation` for invalid matrix rank or shape,
@@ -77,6 +90,18 @@ pub trait EagerTensorLinalgExt {
     /// metadata, `Error::Extension` for an unsupported dtype or singular
     /// system, and `Error::RuntimeState` when the backend is unavailable.
     fn solve(&self, b: &EagerTensor) -> Result<EagerTensor>;
+    /// Least-squares solve `argmin_x ||A x - b||_2` for a tall or square,
+    /// full-column-rank `A`, via the thin QR factorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` when `A` or `b` is not a matrix (rank
+    /// `>= 2`), when `A` is wide (`rows < cols`; underdetermined), or when the
+    /// dtype is not floating-point or complex; `Error::Extension` for backend
+    /// QR or triangular-solve failures; and `Error::RuntimeState` when the
+    /// backend is unavailable. Rank-deficient `A` is not detected and yields an
+    /// ill-defined result.
+    fn lstsq(&self, b: &EagerTensor) -> Result<EagerTensor>;
     /// # Errors
     ///
     /// Returns `Error::Validation` for a non-square or invalid-rank input,
@@ -188,6 +213,10 @@ impl EagerTensorLinalgExt for EagerTensor {
         svd_with_options(self, options)
     }
 
+    fn svd_full(&self) -> Result<(EagerTensor, EagerTensor, EagerTensor)> {
+        svd_full(self)
+    }
+
     fn qr(&self) -> Result<(EagerTensor, EagerTensor)> {
         qr(self)
     }
@@ -218,6 +247,10 @@ impl EagerTensorLinalgExt for EagerTensor {
 
     fn solve(&self, b: &EagerTensor) -> Result<EagerTensor> {
         solve(self, b)
+    }
+
+    fn lstsq(&self, b: &EagerTensor) -> Result<EagerTensor> {
+        eager_composites::lstsq(self, b)
     }
 
     fn cholesky(&self) -> Result<EagerTensor> {
@@ -372,6 +405,52 @@ pub fn svd_with_options(
         (Some(u), Some(s), Some(vt), None) => Ok((u, s, vt)),
         _ => Err(Error::Internal(
             "svd eager op returned an unexpected number of outputs".to_string(),
+        )),
+    }
+}
+
+/// Full-matrices singular value decomposition for eager tensors.
+///
+/// Returns `(U, S, Vh)` with square `U` (`m x m`) and `Vh` (`n x n`); `S` holds
+/// `min(m, n)` singular values. The trailing `n - rank` rows of `Vh` span the
+/// input's right nullspace, which the thin [`svd`] cannot represent.
+///
+/// # Examples
+///
+/// ```rust
+/// use tenferro_ad::{EagerRuntime, EagerTensor, Tensor};
+/// use tenferro_linalg::EagerTensorLinalgExt;
+///
+/// let ctx = EagerRuntime::new();
+/// let a = EagerTensor::from_tensor_in(
+///     Tensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]).unwrap(),
+///     ctx,
+/// ).unwrap();
+/// let (u, s, vh) = a.svd_full()?;
+/// assert_eq!(u.shape(), &[1, 1]);
+/// assert_eq!(s.shape(), &[1]);
+/// assert_eq!(vh.shape(), &[2, 2]);
+/// # Ok::<(), tenferro_ad::Error>(())
+/// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` for an invalid rank and `Error::Extension` with
+/// an unsupported-operation source when the active backend does not implement
+/// full-matrices SVD (the CPU faer provider supports it; the LAPACK provider
+/// and GPU backends are unsupported in this slice). AD through the full variant
+/// is unsupported and surfaces a typed error, not a silent thin fallback.
+pub fn svd_full(a: &EagerTensor) -> Result<(EagerTensor, EagerTensor, EagerTensor)> {
+    let mut outputs = apply_linalg_eager(LinalgOp::SvdFull, &[a])?.into_iter();
+    match (
+        outputs.next(),
+        outputs.next(),
+        outputs.next(),
+        outputs.next(),
+    ) {
+        (Some(u), Some(s), Some(vh), None) => Ok((u, s, vh)),
+        _ => Err(Error::Internal(
+            "svd_full eager op returned an unexpected number of outputs".to_string(),
         )),
     }
 }

--- a/crates/tenferro-linalg/src/extension.rs
+++ b/crates/tenferro-linalg/src/extension.rs
@@ -285,6 +285,10 @@ pub(crate) enum LinalgOp {
         derivative_eps: f64,
         gauge: SvdGauge,
     },
+    /// Full-matrices SVD: `U` is `m x m` and `Vh` is `n x n`, so the trailing
+    /// `Vh` rows span the input's right nullspace. Value-only: AD is
+    /// intentionally unsupported (see the linalg AD support manifest).
+    SvdFull,
     SvdVals {
         derivative_eps: f64,
     },
@@ -322,7 +326,7 @@ impl LinalgOp {
             | Self::LuSolvePrepared { .. }
             | Self::SvdVals { .. }
             | Self::TriangularSolve { .. } => 1,
-            Self::Svd { .. } => 3,
+            Self::Svd { .. } | Self::SvdFull => 3,
             Self::Qr { .. } | Self::Eigh { .. } | Self::Eig { .. } => 2,
             Self::LuFactor => 3,
             Self::Lu => 4,
@@ -354,6 +358,7 @@ impl LinalgOp {
             Self::SvdVals { .. } => 12,
             Self::EighVals { .. } => 13,
             Self::EigVals { .. } => 14,
+            Self::SvdFull => 15,
         }
     }
 }
@@ -504,7 +509,11 @@ impl ExtensionOp for LinalgExtensionOp {
                 hasher.write_u8(u8::from(transpose_a));
                 hasher.write_u8(u8::from(unit_diagonal));
             }
-            LinalgOp::Cholesky | LinalgOp::Lu | LinalgOp::LuFactor | LinalgOp::FullPivLu => {}
+            LinalgOp::Cholesky
+            | LinalgOp::Lu
+            | LinalgOp::LuFactor
+            | LinalgOp::FullPivLu
+            | LinalgOp::SvdFull => {}
         }
     }
 
@@ -583,6 +592,7 @@ impl ExtensionOp for LinalgExtensionOp {
             LinalgOp::LuFactor => lu_factor_meta(input_dtypes[0], input_shapes[0])?,
             LinalgOp::FullPivLu => full_piv_lu_meta(input_dtypes[0], input_shapes[0])?,
             LinalgOp::Svd { .. } => svd_meta(input_dtypes[0], input_shapes[0])?,
+            LinalgOp::SvdFull => svd_full_meta(input_dtypes[0], input_shapes[0])?,
             LinalgOp::SvdVals { .. } => {
                 vec![svd_values_meta(input_dtypes[0], input_shapes[0])?]
             }
@@ -704,6 +714,7 @@ fn execute_linalg<B: LinalgBackend>(
                 gauge,
             },
         ),
+        LinalgOp::SvdFull => backend.svd_full(inputs[0]),
         LinalgOp::SvdVals { .. } => Ok(vec![backend.svd_values(inputs[0])?]),
         LinalgOp::Qr { gauge } => backend.qr_with_options(inputs[0], QrOptions { gauge }),
         LinalgOp::Eigh {
@@ -1129,6 +1140,19 @@ fn svd_meta(dtype: DType, shape: &[SymDim]) -> tenferro_tensor::Result<Vec<(DTyp
         (dtype, matrix_shape(m, k.clone(), batch)),
         (singular_values_dtype(dtype), vector_shape(k.clone(), batch)),
         (dtype, matrix_shape(k, n, batch)),
+    ])
+}
+
+fn svd_full_meta(
+    dtype: DType,
+    shape: &[SymDim],
+) -> tenferro_tensor::Result<Vec<(DType, Vec<SymDim>)>> {
+    let (m, n, batch) = matrix_meta_parts("tenferro-linalg.svd_full", shape)?;
+    let k = m.clone().min(n.clone());
+    Ok(vec![
+        (dtype, matrix_shape(m.clone(), m, batch)),
+        (singular_values_dtype(dtype), vector_shape(k, batch)),
+        (dtype, matrix_shape(n.clone(), n, batch)),
     ])
 }
 

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -42,6 +42,27 @@ pub trait TracedTensorLinalgExt {
         &self,
         options: SvdOptions,
     ) -> Result<(TracedTensor, TracedTensor, TracedTensor)>;
+
+    /// Build a traced full-matrices SVD operation returning square `U (m x m)`
+    /// and `Vh (n x n)`, whose trailing `n - rank` rows span the input's right
+    /// nullspace.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` when the input is not a batched matrix
+    /// (rank `>= 2`), or `Error::Extension` for graph registration failures.
+    ///
+    /// # Deferred errors
+    ///
+    /// The active backend returns `Error::Extension` with
+    /// `ErrorKind::Unsupported` at execution if it does not implement
+    /// full-matrices SVD (only the CPU faer provider does in this slice; the
+    /// LAPACK provider and GPU backends are unsupported). Automatic
+    /// differentiation is intentionally unsupported for the full variant (see
+    /// the linalg AD support manifest) and surfaces a typed AD error rather
+    /// than a silent thin-SVD fallback.
+    fn svd_full(&self) -> Result<(TracedTensor, TracedTensor, TracedTensor)>;
+
     /// Build a traced QR operation.
     ///
     /// # Errors
@@ -166,6 +187,24 @@ pub trait TracedTensorLinalgExt {
     /// Singular systems and concrete shape mismatches are reported as
     /// numerical or validation errors during compile or execution.
     fn solve(&self, b: &TracedTensor) -> Result<TracedTensor>;
+
+    /// Build a traced least-squares solve `argmin_x ||A x - b||_2` for a tall
+    /// or square, full-column-rank `A`, via the thin QR factorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Error::Validation` when `A` or `b` is not a batched matrix
+    /// (rank `>= 2`), when `A` has a symbolic shape, when `A` is wide
+    /// (`rows < cols`, underdetermined), or when the dtype is not
+    /// floating-point or complex.
+    ///
+    /// # Deferred errors
+    ///
+    /// Backend QR and triangular-solve failures and concrete shape mismatches
+    /// are reported during compile or execution. Rank-deficient `A` is not
+    /// detected: `R` is singular and the result is ill-defined, so callers must
+    /// ensure full column rank.
+    fn lstsq(&self, b: &TracedTensor) -> Result<TracedTensor>;
 
     /// Build a traced complete-pivot LU solve operation.
     ///
@@ -315,6 +354,10 @@ impl TracedTensorLinalgExt for TracedTensor {
         svd_with_options(self, options)
     }
 
+    fn svd_full(&self) -> Result<(TracedTensor, TracedTensor, TracedTensor)> {
+        svd_full(self)
+    }
+
     fn qr(&self) -> Result<(TracedTensor, TracedTensor)> {
         qr(self)
     }
@@ -357,6 +400,10 @@ impl TracedTensorLinalgExt for TracedTensor {
 
     fn solve(&self, b: &TracedTensor) -> Result<TracedTensor> {
         solve(self, b)
+    }
+
+    fn lstsq(&self, b: &TracedTensor) -> Result<TracedTensor> {
+        lstsq(self, b)
     }
 
     fn full_piv_lu_solve(&self, b: &TracedTensor) -> Result<TracedTensor> {
@@ -482,6 +529,47 @@ pub fn svd_with_options(
             &[a],
         )?,
         "svd",
+    )
+}
+
+/// Build a traced full-matrices singular value decomposition op.
+///
+/// Unlike [`svd`], the returned factors are square: `U` is `m x m` and `Vh` is
+/// `n x n`, while `S` still holds `min(m, n)` singular values. The trailing
+/// `n - rank` rows of `Vh` span the right nullspace of the input, so this is
+/// the decomposition to use for kernel-basis extraction.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_linalg::TracedTensorLinalgExt;
+/// use tenferro_runtime::TracedTensor;
+///
+/// // A wide 1x2 system: the trailing row of the 2x2 Vh spans the nullspace.
+/// let a = TracedTensor::from_vec_col_major(vec![1, 2], vec![1.0_f64, 1.0]).unwrap();
+/// let (u, s, vh) = a.svd_full().unwrap();
+/// assert_eq!(u.rank, 2);
+/// assert_eq!(s.rank, 1);
+/// assert_eq!(vh.rank, 2);
+/// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` when the input is not a batched matrix
+/// (rank `>= 2`), or `Error::RuntimeState` when extension registration is
+/// unavailable.
+///
+/// # Deferred errors
+///
+/// The active backend returns `Error::Extension` with `ErrorKind::Unsupported`
+/// during execution if it does not implement full-matrices SVD (only the CPU
+/// faer provider does in this slice). Automatic differentiation is
+/// intentionally unsupported for the full variant (see the linalg AD support
+/// manifest) and surfaces a typed AD error, not a silent thin-SVD fallback.
+pub fn svd_full(a: &TracedTensor) -> Result<(TracedTensor, TracedTensor, TracedTensor)> {
+    three_outputs(
+        apply(Arc::new(LinalgExtensionOp::new(LinalgOp::SvdFull)), &[a])?,
+        "svd_full",
     )
 }
 
@@ -827,6 +915,69 @@ pub fn solve(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
         )?,
         "solve",
     )
+}
+
+/// Build a traced least-squares solve `argmin_x ||A x - b||_2` for a tall or
+/// square, full-column-rank `A`.
+///
+/// The solution is computed through the thin QR factorization `A = Q R`: since
+/// `R` is nonsingular for full column rank, `x = R^{-1} (Qᴴ b)`. This composes
+/// existing traced decomposition ops (`qr`, `dot_general`, `triangular_solve`),
+/// so, unlike the value-only [`svd_full`], it participates in autodiff through
+/// its component rules.
+///
+/// # Examples
+///
+/// ```
+/// use tenferro_linalg::TracedTensorLinalgExt;
+/// use tenferro_runtime::TracedTensor;
+///
+/// // Overdetermined 3x2 system.
+/// let a = TracedTensor::from_vec_col_major(
+///     vec![3, 2],
+///     vec![1.0_f64, 1.0, 1.0, 0.0, 1.0, 2.0],
+/// )
+/// .unwrap();
+/// let b = TracedTensor::from_vec_col_major(vec![3, 1], vec![1.0_f64, 2.0, 2.0]).unwrap();
+/// let x = a.lstsq(&b).unwrap();
+/// assert_eq!(x.rank, 2);
+/// ```
+///
+/// # Errors
+///
+/// Returns `Error::Validation` when `A` or `b` is not a batched matrix
+/// (rank `>= 2`), when `A` has a symbolic shape, when `A` is wide
+/// (`rows < cols`, underdetermined), or when the dtype is not floating-point or
+/// complex. Rank-deficient `A` is not detected here: `R` is singular and the
+/// triangular solve yields a non-finite or ill-defined result, so callers must
+/// ensure full column rank.
+///
+/// # Deferred errors
+///
+/// Backend QR and triangular-solve failures and concrete shape mismatches are
+/// reported during compile or execution.
+pub fn lstsq(a: &TracedTensor, b: &TracedTensor) -> Result<TracedTensor> {
+    ensure_float_or_complex("lstsq", a.dtype)?;
+    ensure_min_rank("lstsq", a.rank, 2)?;
+    ensure_min_rank("lstsq", b.rank, 2)?;
+    let a_shape = require_concrete_shape("lstsq", a)?;
+    let (m, n) = (a_shape[0], a_shape[1]);
+    if m < n {
+        return Err(Error::TensorRuntime(
+            tenferro_tensor::Error::invalid_argument(
+                "lstsq",
+                "shape",
+                format!(
+                    "lstsq requires a tall or square matrix (rows {m} >= cols {n}); \
+                     underdetermined (wide) systems are not supported"
+                ),
+            ),
+        ));
+    }
+    let (q, r) = qr(a)?;
+    let qh = q.conj()?.transpose(&matrix_transpose_perm(q.rank))?;
+    let qh_b = matmul_preserve_trailing_batch(&qh, b)?;
+    triangular_solve(&r, &qh_b, true, false, false, false)
 }
 
 /// Build a traced full-pivot LU solve op.

--- a/crates/tenferro-linalg/tests/integration.rs
+++ b/crates/tenferro-linalg/tests/integration.rs
@@ -15,6 +15,8 @@ mod eager_surface_parity;
 mod eager_tensor;
 #[path = "integration/full_piv_lu.rs"]
 mod full_piv_lu;
+#[path = "integration/full_svd_lstsq.rs"]
+mod full_svd_lstsq;
 #[path = "integration/gpu_linalg.rs"]
 mod gpu_linalg;
 #[path = "integration/gpu_linalg_source_contract.rs"]

--- a/crates/tenferro-linalg/tests/integration/ad_support_manifest.rs
+++ b/crates/tenferro-linalg/tests/integration/ad_support_manifest.rs
@@ -30,6 +30,7 @@ fn linalg_ad_support_manifest_covers_all_dispatch_arms_in_order() {
         LinalgAdOpKind::Eig,
         LinalgAdOpKind::EigVals,
         LinalgAdOpKind::TriangularSolve,
+        LinalgAdOpKind::SvdFull,
     ];
 
     let manifest = all_linalg_ad_support();
@@ -70,6 +71,22 @@ fn linalg_ad_support_manifest_marks_partial_decomposition_outputs() {
         LinalgAdRuleSupport::SupportedViaLinearize,
     );
     assert_output_status(eig, "eigenvectors", LinalgAdRuleSupport::Unsupported);
+}
+
+#[test]
+fn linalg_ad_support_manifest_marks_full_svd_unsupported() {
+    let svd_full = linalg_ad_support(LinalgAdOpKind::SvdFull);
+    assert_eq!(svd_full.linearize, LinalgAdRuleSupport::Unsupported);
+    assert_eq!(svd_full.transpose, LinalgAdRuleSupport::Unsupported);
+    assert_eq!(svd_full.jvp.status, LinalgAdRuleSupport::Unsupported);
+    assert_eq!(svd_full.vjp.status, LinalgAdRuleSupport::Unsupported);
+    assert_output_status(svd_full, "u", LinalgAdRuleSupport::Unsupported);
+    assert_output_status(
+        svd_full,
+        "singular_values",
+        LinalgAdRuleSupport::Unsupported,
+    );
+    assert_output_status(svd_full, "vt", LinalgAdRuleSupport::Unsupported);
 }
 
 #[test]

--- a/crates/tenferro-linalg/tests/integration/full_svd_lstsq.rs
+++ b/crates/tenferro-linalg/tests/integration/full_svd_lstsq.rs
@@ -1,0 +1,368 @@
+//! Full-matrices SVD and least-squares behavior tests.
+//!
+//! The full-SVD numeric tests exercise the CPU faer provider and are gated on
+//! `cpu-faer`; the LAPACK provider is intentionally unsupported for the full
+//! variant in this slice and is covered by a separate boundary test. The
+//! `lstsq` tests are provider-agnostic because `lstsq` composes `qr` and
+//! `triangular_solve`, which both providers implement.
+
+use num_complex::Complex64;
+use tenferro_cpu::CpuBackend;
+use tenferro_linalg::TracedTensorLinalgExt;
+use tenferro_runtime::{GraphCompiler, GraphExecutor, Tensor, TracedTensor, TypedTensor};
+
+fn f64_tensor(shape: Vec<usize>, data: Vec<f64>) -> TracedTensor {
+    TracedTensor::from_tensor_concrete_shape(Tensor::F64(
+        TypedTensor::from_vec_col_major(shape, data).unwrap(),
+    ))
+    .unwrap()
+}
+
+fn c64_tensor(shape: Vec<usize>, data: Vec<Complex64>) -> TracedTensor {
+    TracedTensor::from_tensor_concrete_shape(Tensor::C64(
+        TypedTensor::from_vec_col_major(shape, data).unwrap(),
+    ))
+    .unwrap()
+}
+
+fn run_many(outputs: &[&TracedTensor]) -> Vec<Tensor> {
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile_many(outputs).unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    executor
+        .register_extension(tenferro_linalg::register_runtime)
+        .unwrap();
+    executor.run_many(&program).unwrap()
+}
+
+fn f64_data(tensor: &Tensor) -> Vec<f64> {
+    tensor.as_slice::<f64>().unwrap().to_vec()
+}
+
+fn c64_data(tensor: &Tensor) -> Vec<Complex64> {
+    tensor.as_slice::<Complex64>().unwrap().to_vec()
+}
+
+/// Column-major reconstruction `A = U[:, :k] diag(S) Vh[:k, :]` for real inputs.
+#[cfg(feature = "cpu-faer")]
+fn reconstruct_real(m: usize, n: usize, u: &[f64], s: &[f64], vh: &[f64]) -> Vec<f64> {
+    let k = m.min(n);
+    let mut a = vec![0.0_f64; m * n];
+    for j in 0..n {
+        for i in 0..m {
+            let mut acc = 0.0;
+            for t in 0..k {
+                acc += u[i + t * m] * s[t] * vh[t + j * n];
+            }
+            a[i + j * m] = acc;
+        }
+    }
+    a
+}
+
+#[cfg(feature = "cpu-faer")]
+fn reconstruct_complex(
+    m: usize,
+    n: usize,
+    u: &[Complex64],
+    s: &[f64],
+    vh: &[Complex64],
+) -> Vec<Complex64> {
+    let k = m.min(n);
+    let mut a = vec![Complex64::new(0.0, 0.0); m * n];
+    for j in 0..n {
+        for i in 0..m {
+            let mut acc = Complex64::new(0.0, 0.0);
+            for t in 0..k {
+                acc += u[i + t * m] * s[t] * vh[t + j * n];
+            }
+            a[i + j * m] = acc;
+        }
+    }
+    a
+}
+
+fn max_abs_diff_real(lhs: &[f64], rhs: &[f64]) -> f64 {
+    lhs.iter()
+        .zip(rhs)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0, f64::max)
+}
+
+// ---------------------------------------------------------------------------
+// Full-matrices SVD (faer provider).
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn svd_full_tall_real_returns_square_factors_and_reconstructs() {
+    let m = 3;
+    let n = 2;
+    let data = vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 7.0];
+    let a = f64_tensor(vec![m, n], data.clone());
+    let (u, s, vh) = a.svd_full().unwrap();
+    let out = run_many(&[&u, &s, &vh]);
+    assert_eq!(out[0].shape(), &[m, m]);
+    assert_eq!(out[1].shape(), &[n.min(m)]);
+    assert_eq!(out[2].shape(), &[n, n]);
+
+    let recon = reconstruct_real(
+        m,
+        n,
+        &f64_data(&out[0]),
+        &f64_data(&out[1]),
+        &f64_data(&out[2]),
+    );
+    assert!(
+        max_abs_diff_real(&recon, &data) < 1e-10,
+        "reconstruction residual {}",
+        max_abs_diff_real(&recon, &data)
+    );
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn svd_full_wide_real_reconstructs_and_recovers_nullspace() {
+    // rank-2 wide matrix (2 x 3): the trailing Vh row spans the 1-D kernel.
+    let m = 2;
+    let n = 3;
+    let data = vec![1.0_f64, 0.0, 0.0, 1.0, 1.0, 1.0];
+    let a = f64_tensor(vec![m, n], data.clone());
+    let (u, s, vh) = a.svd_full().unwrap();
+    let out = run_many(&[&u, &s, &vh]);
+    assert_eq!(out[0].shape(), &[m, m]);
+    assert_eq!(out[2].shape(), &[n, n]);
+
+    let u = f64_data(&out[0]);
+    let s = f64_data(&out[1]);
+    let vh = f64_data(&out[2]);
+    let recon = reconstruct_real(m, n, &u, &s, &vh);
+    assert!(max_abs_diff_real(&recon, &data) < 1e-10);
+
+    // Trailing Vh rows (index rank..n) span the right nullspace: A v = 0.
+    let rank = 2;
+    for t in rank..n {
+        // v[j] = Vh[t, j]  (column-major (n x n): index t + j*n)
+        for i in 0..m {
+            let mut acc = 0.0;
+            for j in 0..n {
+                acc += data[i + j * m] * vh[t + j * n];
+            }
+            assert!(acc.abs() < 1e-10, "A v residual {acc}");
+        }
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn svd_full_1x2_recovers_one_dimensional_nullspace() {
+    // Smallest wide system: thin SVD would drop the kernel row entirely.
+    let a = f64_tensor(vec![1, 2], vec![1.0_f64, 1.0]);
+    let (u, s, vh) = a.svd_full().unwrap();
+    let out = run_many(&[&u, &s, &vh]);
+    assert_eq!(out[0].shape(), &[1, 1]);
+    assert_eq!(out[2].shape(), &[2, 2]);
+
+    let vh = f64_data(&out[2]);
+    // Kernel row is index 1: [Vh[1,0], Vh[1,1]] with a . [1,1] == 0.
+    let v0 = vh[1]; // t=1, j=0 -> 1 + 0*2
+    let v1 = vh[1 + 1 * 2]; // t=1, j=1 -> 3
+    assert!((v0 + v1).abs() < 1e-10, "nullspace dot {}", v0 + v1);
+    // It is a genuine unit direction, not the zero vector.
+    assert!((v0 * v0 + v1 * v1 - 1.0).abs() < 1e-10);
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn svd_full_random_wide_recovers_nullspace_dimension() {
+    // Deterministic rank-3 (3 x 5) matrix: rows are 3 independent vectors, so
+    // the trailing two Vh rows span the 2-D kernel.
+    let m = 3;
+    let n = 5;
+    #[rustfmt::skip]
+    let data_row_major = [
+        [ 2.0, -1.0,  0.0,  3.0,  1.0],
+        [ 0.0,  4.0, -2.0,  1.0,  5.0],
+        [ 1.0,  1.0,  1.0, -1.0,  2.0],
+    ];
+    let mut data = vec![0.0_f64; m * n];
+    for i in 0..m {
+        for j in 0..n {
+            data[i + j * m] = data_row_major[i][j];
+        }
+    }
+    let a = f64_tensor(vec![m, n], data.clone());
+    let (_u, _s, vh) = a.svd_full().unwrap();
+    let out = run_many(&[&vh]);
+    let vh = f64_data(&out[0]);
+
+    let rank = 3;
+    for t in rank..n {
+        for i in 0..m {
+            let mut acc = 0.0;
+            for j in 0..n {
+                acc += data[i + j * m] * vh[t + j * n];
+            }
+            assert!(acc.abs() < 1e-9, "A v residual {acc} for kernel row {t}");
+        }
+    }
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn svd_full_complex_tall_reconstructs() {
+    let m = 3;
+    let n = 2;
+    let data = vec![
+        Complex64::new(1.0, 1.0),
+        Complex64::new(2.0, -1.0),
+        Complex64::new(0.0, 3.0),
+        Complex64::new(-1.0, 2.0),
+        Complex64::new(4.0, 0.0),
+        Complex64::new(1.0, -2.0),
+    ];
+    let a = c64_tensor(vec![m, n], data.clone());
+    let (u, s, vh) = a.svd_full().unwrap();
+    let out = run_many(&[&u, &s, &vh]);
+    assert_eq!(out[0].shape(), &[m, m]);
+    assert_eq!(out[2].shape(), &[n, n]);
+
+    let recon = reconstruct_complex(
+        m,
+        n,
+        &c64_data(&out[0]),
+        &f64_data(&out[1]),
+        &c64_data(&out[2]),
+    );
+    let residual = recon
+        .iter()
+        .zip(&data)
+        .map(|(a, b)| (a - b).norm())
+        .fold(0.0, f64::max);
+    assert!(
+        residual < 1e-10,
+        "complex reconstruction residual {residual}"
+    );
+}
+
+#[cfg(feature = "cpu-faer")]
+#[test]
+fn svd_full_batch_returns_square_factor_shapes() {
+    // Leading matrix dims [m, n], trailing batch dim.
+    let m = 3;
+    let n = 2;
+    let batch = 2;
+    let data: Vec<f64> = (0..(m * n * batch))
+        .map(|v| (v as f64) * 0.5 + 1.0)
+        .collect();
+    let a = f64_tensor(vec![m, n, batch], data);
+    let (u, s, vh) = a.svd_full().unwrap();
+    let out = run_many(&[&u, &s, &vh]);
+    assert_eq!(out[0].shape(), &[m, m, batch]);
+    assert_eq!(out[1].shape(), &[n.min(m), batch]);
+    assert_eq!(out[2].shape(), &[n, n, batch]);
+}
+
+// The LAPACK provider does not implement full-matrices SVD in this slice; it
+// must surface a typed error rather than silently returning a thin factor.
+#[cfg(all(feature = "cpu-blas", not(feature = "cpu-faer")))]
+#[test]
+fn svd_full_lapack_provider_is_unsupported() {
+    let a = f64_tensor(vec![3, 2], vec![1.0_f64, 2.0, 3.0, 4.0, 5.0, 7.0]);
+    let (u, s, vh) = a.svd_full().unwrap();
+    let mut compiler = GraphCompiler::new();
+    let program = compiler.compile_many(&[&u, &s, &vh]).unwrap();
+    let mut executor = GraphExecutor::new(CpuBackend::new());
+    executor
+        .register_extension(tenferro_linalg::register_runtime)
+        .unwrap();
+    let err = executor.run_many(&program).unwrap_err();
+    assert!(
+        format!("{err}").contains("full-matrices SVD"),
+        "expected typed unsupported error, got {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Least squares (provider-agnostic composition).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lstsq_solves_tall_consistent_real_system() {
+    // Overdetermined 3 x 2 full-column-rank system with a consistent RHS: the
+    // least-squares solution recovers the exact generating x.
+    let m = 3;
+    let n = 2;
+    let a_data = vec![1.0_f64, 1.0, 1.0, 0.0, 1.0, 2.0];
+    let x_true = [2.0_f64, -1.0];
+    // b = A x_true, column-major A is [m, n] -> A[i,j] = a_data[i + j*m].
+    let mut b_data = vec![0.0_f64; m];
+    for i in 0..m {
+        for (j, xj) in x_true.iter().enumerate() {
+            b_data[i] += a_data[i + j * m] * xj;
+        }
+    }
+    let a = f64_tensor(vec![m, n], a_data);
+    let b = f64_tensor(vec![m, 1], b_data);
+    let x = a.lstsq(&b).unwrap();
+    let out = run_many(&[&x]);
+    assert_eq!(out[0].shape(), &[n, 1]);
+    let x = f64_data(&out[0]);
+    assert!(max_abs_diff_real(&x, &x_true) < 1e-9, "lstsq x = {x:?}");
+}
+
+#[test]
+fn lstsq_solves_square_real_system() {
+    let a = f64_tensor(vec![2, 2], vec![2.0_f64, 0.0, 0.0, 4.0]);
+    let b = f64_tensor(vec![2, 1], vec![4.0_f64, 8.0]);
+    let x = a.lstsq(&b).unwrap();
+    let out = run_many(&[&x]);
+    let x = f64_data(&out[0]);
+    assert!(max_abs_diff_real(&x, &[2.0, 2.0]) < 1e-10, "x = {x:?}");
+}
+
+#[test]
+fn lstsq_solves_tall_consistent_complex_system() {
+    let m = 3;
+    let n = 2;
+    let a_data = vec![
+        Complex64::new(1.0, 0.0),
+        Complex64::new(0.0, 1.0),
+        Complex64::new(2.0, 1.0),
+        Complex64::new(1.0, -1.0),
+        Complex64::new(0.0, 2.0),
+        Complex64::new(3.0, 0.0),
+    ];
+    let x_true = [Complex64::new(1.0, -2.0), Complex64::new(-1.0, 1.0)];
+    let mut b_data = vec![Complex64::new(0.0, 0.0); m];
+    for i in 0..m {
+        for (j, xj) in x_true.iter().enumerate() {
+            b_data[i] += a_data[i + j * m] * xj;
+        }
+    }
+    let a = c64_tensor(vec![m, n], a_data);
+    let b = c64_tensor(vec![m, 1], b_data);
+    let x = a.lstsq(&b).unwrap();
+    let out = run_many(&[&x]);
+    let x = c64_data(&out[0]);
+    let residual = x
+        .iter()
+        .zip(&x_true)
+        .map(|(a, b)| (a - b).norm())
+        .fold(0.0, f64::max);
+    assert!(
+        residual < 1e-9,
+        "complex lstsq residual {residual}, x = {x:?}"
+    );
+}
+
+#[test]
+fn lstsq_rejects_wide_system() {
+    let a = f64_tensor(vec![2, 3], vec![1.0_f64, 0.0, 0.0, 1.0, 1.0, 1.0]);
+    let b = f64_tensor(vec![2, 1], vec![1.0_f64, 2.0]);
+    let err = a.lstsq(&b).unwrap_err();
+    assert!(
+        format!("{err}").contains("tall or square"),
+        "expected wide-system rejection, got {err}"
+    );
+}

--- a/docs/worklogs/2026-07-22-issue-1446-full-svd-lstsq.md
+++ b/docs/worklogs/2026-07-22-issue-1446-full-svd-lstsq.md
@@ -1,0 +1,112 @@
+# Full-matrices SVD and least-squares solve (issue #1446)
+
+Base: `origin/main` at `81031f21` (Add Provenance and Citation Policy).
+
+## Summary
+
+Adds two dense-linear-algebra capabilities to `tenferro-linalg`:
+
+- **Full-matrices SVD** (`svd_full`): returns square `U (m x m)` and
+  `Vh (n x n)` so the trailing `n - rank` rows of `Vh` span the input's right
+  nullspace. `S` keeps `min(m, n)` singular values. Value-only; AD unsupported.
+- **Least-squares** (`lstsq`): QR-based solve of tall/square, full-column-rank
+  systems `argmin_x ||A x - b||`.
+
+Both are exposed on the eager (`EagerTensorLinalgExt`) and traced
+(`TracedTensorLinalgExt`) surfaces.
+
+## Context read
+
+- `extension.rs` (`LinalgOp`, `SvdOptions`/`SvdGauge`, `*_meta`,
+  `payload_hash`, `prune_outputs`, `execute_linalg`), `backend.rs`
+  (`LinalgBackend` trait + `Error::unsupported` defaults, `svd_with_options`),
+  `cpu/backend.rs` (`linalg_provider_kind` dispatch), `cpu/linalg/faer_linalg.rs`
+  (`svd_core`/`svd_2d`/`svd_view`, free `svd`), `cpu/linalg/lapack_linalg/svd.rs`.
+- `eager_ext.rs` (direct-op surface), `eager_composites.rs` (`pinv`/`inv`/`solve`
+  compositions — the template for `lstsq`), `eager_backend.rs` (eager
+  `LinalgBackend` forwarder), `traced.rs` (`svd`, `solve`, helpers).
+- AD: `ad.rs` (`linearize`/`linear_transpose` dispatch), `ad/support.rs`
+  (machine-readable AD manifest with `jvp`/`vjp`/`route`/`caveats`) and tests.
+
+The issue body predates the current API: it references an `SvdOptions` struct
+exposing only `gauge`/`derivative_eps` and hardcoded `svd_meta` line numbers.
+On the base commit `SvdOptions` now also drives a `svd_with_options` backend
+entry and a `SvdGauge` canonicalization pass, and the AD manifest has been
+rebuilt around JVP/VJP routes. Design was reconciled against the merged code.
+
+## Design decisions
+
+### Full SVD: separate `svd_full` entry point (not an `SvdOptions` field)
+
+The issue offered two shapes. Even though `SvdOptions` now exists, a separate
+op/entry point is the cleaner fit and matches the existing `svd_values` / `SvdVals`
+sibling-op precedent:
+
+- New value-only `LinalgOp::SvdFull` variant (no `derivative_eps`, no `gauge` —
+  full SVD is raw, leaving thin defaults and gauge conventions untouched).
+- Adding a `full_matrices` flag to `LinalgOp::Svd` would push a flag the thin AD
+  rules, the `prune_outputs` SVD→SvdVals fusion, and the gauge pass must all
+  special-case. A sibling op keeps every one of those paths unchanged.
+- "AD unsupported for the full variant" becomes structural: `SvdFull`'s
+  `linearize` emits no tangent (LuFactor precedent), `linear_transpose` is in
+  the no-tangent group, and the AD manifest records every output `Unsupported`.
+  This is the repo's existing mechanism for an unsupported route — no silent
+  thin-SVD fallback.
+
+Backend plumbing: a `svd_full` hook on `LinalgBackend` whose default returns
+`Error::unsupported`, overridden only by the CPU faer provider. `svd_core` and
+`svd_2d` gained a `full: bool` selecting `ComputeSvdVectors::Full` and square
+`U`/`V` output shapes; `svd_view` and the thin free `svd` pass `false`.
+
+### Provider policy: faer implements, LAPACK typed-unsupported
+
+Per the issue's non-goal ("No GPU/BLAS backend requirement in the first slice;
+typed unsupported is fine"), only the CPU faer provider computes full SVD; the
+LAPACK provider and GPU backend return a typed error. Wiring LAPACK would
+roughly double the FFI macro surface in `lapack_linalg/svd.rs` (gesdd/gesvd
+job-char variants, `ldvt`, complex rwork) for a deferred capability. Faer is the
+default provider, so the numeric acceptance tests run on it; they are gated
+`#[cfg(feature = "cpu-faer")]` so the BLAS-only CI lane
+(`--no-default-features --features cpu-blas`) skips them, and a dedicated
+BLAS-lane test asserts the typed-unsupported boundary.
+
+### `lstsq`: composition, not a new backend op
+
+`lstsq` is composed from existing ops (`qr` → conj-transpose `dot_general` →
+`triangular_solve`), mirroring `solve`/`pinv`/`inv` in `eager_composites.rs` and
+the traced `solve`. Consequences:
+
+- No new backend op, no new AD rule, no new op vocabulary.
+- Because the component ops have AD rules, it stays differentiable through
+  composition — it is *not* AD-unsupported; the issue's "AD unsupported"
+  premise assumed a monolithic op. No unsupported route is added.
+- Scope: tall/square, full column rank. Wide (`m < n`) inputs are rejected with
+  a typed `InvalidArgument`. Rank deficiency is not detected (`R` singular ⇒
+  ill-defined result); documented as a caller precondition, matching the issue's
+  "documented error or min-norm" option.
+
+## Alternatives rejected
+
+- `full_matrices: bool` on `LinalgOp::Svd` / `SvdOptions`: entangles the thin AD
+  rules, gauge pass, and output-pruning fusion. Rejected for a sibling op.
+- Implementing LAPACK full SVD now: deferred per issue non-goal.
+- A monolithic `lstsq` op with a hand-written AD rule: unnecessary; the QR
+  composition reuses audited rules.
+
+## Verification
+
+- Default (faer) `--test integration -- svd_full lstsq`: 10 pass —
+  tall/wide/batch real+complex reconstruction, `1x2` and random `3x5` nullspace
+  recovery, `lstsq` vs known solution (real/complex/square), wide-input
+  rejection.
+- Whole crate `cargo test -p tenferro-linalg` (default) and `--features
+  autodiff`: green, including the AD manifest (`SvdFull` `Unsupported` on all
+  outputs, JVP/VJP unsupported) and eager/traced doctests.
+- BLAS lane (`--no-default-features --features cpu-blas`): green — LAPACK
+  typed-unsupported boundary test and `lstsq`; faer numeric tests skipped; lib
+  compiles warning-free.
+
+## Residual risks / follow-ups
+
+- LAPACK and GPU full SVD remain unsupported (typed error) — future slices.
+- `lstsq` uses unpivoted QR: no rank-revealing rank-deficiency detection.


### PR DESCRIPTION
Closes #1446.

Adds the two dense-linear-algebra capabilities requested in the issue:
full-matrices SVD (for nullspace / kernel-basis extraction) and a QR-based
least-squares solve.

## API choice and justification

The issue offered two shapes for the SVD side (an `SvdOptions` field or a
separate `svd_full` entry point). This PR takes the **separate entry point**:
a value-only `LinalgOp::SvdFull` with public `svd_full` on both the eager
(`EagerTensorLinalgExt`) and traced (`TracedTensorLinalgExt`) surfaces.

- It matches the existing `svd_values`/`SvdVals` sibling-op precedent.
- `SvdOptions` now also drives `svd_with_options`, the `SvdGauge`
  canonicalization pass, and the `Svd`→`SvdVals` output-pruning fusion. A
  `full_matrices` flag would force every one of those paths — plus the thin-SVD
  AD rules — to special-case a mode they do not support. A sibling op leaves the
  thin path, its defaults, and its gauge conventions completely unchanged.
- It makes "AD unsupported for the full variant" structural: `SvdFull` emits no
  tangent (the existing `LuFactor` precedent), and the AD support manifest
  records every output `Unsupported` (JVP/VJP unsupported). No silent thin-SVD
  fallback.

Backend: a `svd_full` hook on `LinalgBackend` whose default returns
`Error::unsupported`, overridden only by the CPU faer provider (`ComputeSvdVectors::Full`).
The LAPACK provider and GPU backend return a typed unsupported error — matching
the issue's first-slice non-goal ("No GPU/BLAS backend requirement; typed
unsupported is fine"). `U` is `m x m`, `Vh` is `n x n`, `S` keeps `min(m, n)`
values; real+complex f64, tall/wide/batch.

`lstsq(a, b)` is a **composition** of `qr` → conj-transpose `dot_general` →
`triangular_solve`, mirroring the existing `solve`/`pinv`/`inv`. It therefore
adds no backend op and no AD rule, and — unlike the value-only `svd_full` — it
stays differentiable through its components rather than adding an unsupported
route (the issue's "AD unsupported" note assumed a monolithic op). Scope: tall
or square, full column rank; wide/underdetermined inputs are rejected with a
typed error; rank deficiency is a documented caller precondition.

Design rationale, alternatives, and residual risks:
`docs/worklogs/2026-07-22-issue-1446-full-svd-lstsq.md`.

## Tests

`crates/tenferro-linalg/tests/integration/full_svd_lstsq.rs`:

- full SVD tall/wide/batch, real + complex f64, reconstruction `U diag(S) Vh ≈ A`
- nullspace recovery: `1x2` (1-D kernel) and a deterministic rank-3 `3x5`
  (2-D kernel) — trailing `Vh` rows satisfy `A v = 0`
- `lstsq` vs known solution: tall real, tall complex, square real
- wide-input rejection
- LAPACK-provider typed-unsupported boundary (BLAS lane)

AD manifest assertions (`SvdFull` `Unsupported` on all outputs, JVP/VJP
unsupported) in `tests/integration/ad_support_manifest.rs`.

## Local gate

`bash scripts/check-pr-fast.sh --base upstream/main --coverage-reviewed --test
'cargo test -p tenferro-linalg --test integration -- svd_full lstsq'` →
`fast PR checks passed` (git-diff-check, `cargo fmt --check`, doc-snippets, 10
focused tests green).

Additionally verified locally: whole crate `cargo test -p tenferro-linalg`
(default) and `--features autodiff` green incl. doctests; BLAS lane
(`--no-default-features --features cpu-blas`) green incl. the unsupported
boundary test, lib compiles warning-free.