### PR TITLE
Add gated oracle replay nightly workflow

### DIFF
--- a/.github/workflows/oracle-replay-nightly.yml
+++ b/.github/workflows/oracle-replay-nightly.yml
@@ -1,0 +1,107 @@
+name: Oracle replay nightly
+
+on:
+  schedule:
+    - cron: "37 17 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Run oracle replay even when the checked ref has no commit in the last 24 hours"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: oracle-replay-nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  recent-commits:
+    name: Check recent default-branch commits
+    runs-on: ubuntu-latest
+    outputs:
+      run_oracle: ${{ steps.recent.outputs.run_oracle }}
+      reason: ${{ steps.recent.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Check for commits in the last 24 hours
+        id: recent
+        env:
+          FORCE_RUN: ${{ github.event.inputs.force == 'true' }}
+        run: |
+          set -euo pipefail
+          recent_commit="$(git log --since="24 hours ago" --format=%H --max-count=1)"
+          if [ "${FORCE_RUN}" = true ]; then
+            echo "run_oracle=true" >> "${GITHUB_OUTPUT}"
+            echo "reason=manual force=true" >> "${GITHUB_OUTPUT}"
+          elif [ -n "${recent_commit}" ]; then
+            echo "run_oracle=true" >> "${GITHUB_OUTPUT}"
+            echo "reason=recent commit ${recent_commit}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "run_oracle=false" >> "${GITHUB_OUTPUT}"
+            echo "reason=no commits in the last 24 hours" >> "${GITHUB_OUTPUT}"
+          fi
+
+  oracle-replay:
+    name: Root-facade oracle replay
+    needs: recent-commits
+    if: always()
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_BUILD_JOBS: "4"
+      ORACLE_REPLAY_JOBS: "4"
+    steps:
+      - uses: actions/checkout@v5
+        if: needs.recent-commits.result == 'success' && needs.recent-commits.outputs.run_oracle == 'true'
+      - uses: dtolnay/rust-toolchain@stable
+        if: needs.recent-commits.result == 'success' && needs.recent-commits.outputs.run_oracle == 'true'
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        if: needs.recent-commits.result == 'success' && needs.recent-commits.outputs.run_oracle == 'true'
+        with:
+          prefix-key: v1-rust-oracle-replay-ubuntu22
+          shared-key: oracle-replay-autodiff
+          cache-all-crates: true
+          cache-workspace-crates: true
+          workspaces: . -> target
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Run root-facade oracle replay
+        if: needs.recent-commits.result == 'success' && needs.recent-commits.outputs.run_oracle == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p target/oracle-replay
+          RUST_TEST_THREADS=1 \
+            RUN_ORACLE_REPLAY=1 \
+            ORACLE_REPLAY_JOBS="${ORACLE_REPLAY_JOBS}" \
+            CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS}" \
+            cargo test -p tenferro-linalg --features autodiff --test integration oracle_replays_supported_db_cases_when_requested -- --nocapture \
+            2>&1 | tee target/oracle-replay/oracle-replay.log
+      - name: Upload oracle replay log
+        if: always() && needs.recent-commits.result == 'success' && needs.recent-commits.outputs.run_oracle == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: oracle-replay-${{ github.run_id }}
+          path: target/oracle-replay/oracle-replay.log
+          if-no-files-found: warn
+      - name: Report oracle replay disposition
+        if: always()
+        env:
+          RECENT_RESULT: ${{ needs.recent-commits.result }}
+          RUN_ORACLE: ${{ needs.recent-commits.outputs.run_oracle }}
+          REASON: ${{ needs.recent-commits.outputs.reason }}
+        run: |
+          set -euo pipefail
+          if [ "${RECENT_RESULT}" != success ]; then
+            echo "Recent-commit gate failed: ${RECENT_RESULT}"
+            exit 1
+          fi
+          if [ "${RUN_ORACLE}" != true ]; then
+            echo "Oracle replay not required: ${REASON}"
+          else
+            echo "Oracle replay requested: ${REASON}"
+          fi

--- a/scripts/ci/tests/test_workflow_contracts.py
+++ b/scripts/ci/tests/test_workflow_contracts.py
@@ -40,6 +40,32 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertGreaterEqual(text.count("needs.policy.result"), 6)
         self.assertIn("Change classification failed", text)
 
+    def test_oracle_replay_nightly_is_gated_by_recent_default_branch_commits(self) -> None:
+        text = read(".github/workflows/oracle-replay-nightly.yml")
+        self.assertIn("name: Oracle replay nightly", text)
+        self.assertIn("schedule:", text)
+        self.assertIn("workflow_dispatch:", text)
+        self.assertIn("fetch-depth: 0", text)
+        self.assertIn("git log --since=\"24 hours ago\"", text)
+        self.assertIn("run_oracle=true", text)
+        self.assertIn("run_oracle=false", text)
+        self.assertIn("github.event.inputs.force == 'true'", text)
+        self.assertIn("RUN_ORACLE_REPLAY=1", text)
+        self.assertIn("ORACLE_REPLAY_JOBS", text)
+        self.assertIn("oracle_replays_supported_db_cases_when_requested", text)
+        self.assertIn(
+            "Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32",
+            text,
+        )
+        self.assertIn("prefix-key: v1-rust-oracle-replay-ubuntu22", text)
+        self.assertIn("shared-key: oracle-replay-autodiff", text)
+        self.assertIn("cache-all-crates: true", text)
+        self.assertIn("cache-workspace-crates: true", text)
+        self.assertIn("workspaces: . -> target", text)
+        self.assertIn("save-if: ${{ github.ref == 'refs/heads/main' }}", text)
+        self.assertIn("actions/upload-artifact@", text)
+        self.assertIn("Oracle replay not required", text)
+
     def test_heavy_workflow_has_explicit_noop_matrix_and_gate_contract(self) -> None:
         text = read(".github/workflows/ci-pr-workspace-tests.yml")
         self.assertIn('"backend":"not-required"', text)


### PR DESCRIPTION
## Summary

- add a scheduled root-facade oracle replay workflow gated by commits in the last 24 hours
- allow manual `workflow_dispatch` runs, with `force=true` bypassing the recent-commit gate
- migrate the Rust dependency/build cache pattern from existing workflows with a pinned `rust-cache` action and a nightly-specific cache namespace
- add a workflow contract test covering the gate, oracle replay command, artifact upload, and cache settings

Refs #1467

## Validation

- `python3 -m unittest scripts.ci.tests.test_workflow_contracts.WorkflowContractTests.test_oracle_replay_nightly_is_gated_by_recent_default_branch_commits -v`
- `python3 -m unittest scripts.ci.tests.test_workflow_contracts -v`
- `PATH="/tmp/actionlint-1.7.7:$PATH" python3 scripts/ci/run_profile.py ci-config`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'python3 -m unittest scripts.ci.tests.test_workflow_contracts -v'`