### PR TITLE
Fix dot_general read-into dtype mismatch payload

### DIFF
--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -201,12 +201,12 @@ pub fn validate_dot_general_read_into(
             },
         ));
     }
-    if out.dtype() != lhs.dtype() {
+    if lhs.dtype() != out.dtype() {
         return Err(validation(
             op,
             ValidationError::DTypeMismatch {
-                expected: crate::core_dtype(out.dtype()),
-                actual: crate::core_dtype(lhs.dtype()),
+                expected: crate::core_dtype(lhs.dtype()),
+                actual: crate::core_dtype(out.dtype()),
             },
         ));
     }

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -1,5 +1,7 @@
 use crate::{
-    backend::{validate_grouped_gemm, GroupedGemmConfig, GroupedGemmJob},
+    backend::{
+        validate_dot_general_read_into, validate_grouped_gemm, GroupedGemmConfig, GroupedGemmJob,
+    },
     BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir,
     ContractionScalar, DType, DotGeneralAccumulation, DotGeneralConfig, GatherConfig, PadConfig,
     ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
@@ -750,6 +752,32 @@ fn vector_contract_config() -> DotGeneralConfig {
         rhs_contracting_dims: vec![0],
         lhs_batch_dims: vec![],
         rhs_batch_dims: vec![],
+    }
+}
+
+#[test]
+fn dot_general_read_into_dtype_error_reports_output_as_actual() {
+    let lhs = Tensor::from_vec_col_major(vec![1], vec![1.0_f32]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f32]).unwrap();
+    let mut out = Tensor::from_vec_col_major(vec![], vec![0.0_f64]).unwrap();
+    let err = validate_dot_general_read_into(
+        &TensorRead::from_tensor(&lhs),
+        &TensorRead::from_tensor(&rhs),
+        &vector_contract_config(),
+        &TensorWrite::from_tensor(&mut out),
+        "test_dot_general",
+    )
+    .unwrap_err();
+
+    match err {
+        crate::Error::Validation {
+            source: crate::ValidationError::DTypeMismatch { expected, actual },
+            ..
+        } => {
+            assert_eq!(expected, crate::core_dtype(DType::F32));
+            assert_eq!(actual, crate::core_dtype(DType::F64));
+        }
+        other => panic!("expected dtype mismatch, got {other:?}"),
     }
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> New features must start as a feature request issue.
> Please do not open a new-feature implementation PR before maintainers accept
> the issue and agree that implementation should start.
>
> If you already have prototype code, link to a fork branch, gist, or
> repository from the feature request issue instead of opening a PR.
>
> New-feature PRs opened before an accepted issue may be closed and redirected
> to an issue.
>
> If you are using an AI agent for a bug-fix PR, use or follow the
> repository-local `tenferro-bugfix-pr` workflow before editing code.

## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Fixes #1470

## Summary

`validate_dot_general_read_into` reported the output-buffer dtype as `expected` and the lhs dtype as `actual` when rejecting an output dtype mismatch.

This PR restores the structured error payload contract: the lhs/contraction dtype is `expected`, and the output buffer dtype is `actual`. It also adds a focused regression test that exercises an `f32` dot into an `f64` scalar output buffer.

Bug-fix scope gate applied: this fixes existing validation behavior only; it does not add APIs, dependencies, backend behavior, or dtype semantics.

Same-root-cause scan: searched neighboring `DTypeMismatch` construction and same output/input mismatch patterns in `tenferro-tensor`; no other same-contract production instances were found.

## Work log

N/A: focused two-file bug fix, no durable design decision or nontrivial cleanup stream.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. N/A: bug fix.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above. N/A.

## Verification

- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-tensor dot_general_read_into_dtype_error_reports_output_as_actual -- --nocapture'`
- `cargo test -p tenferro-tensor`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/tenferro-1470-repository-rules-review.json`