### PR TITLE
Restructure repository rules review routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,9 @@ vendor a copy into this repository. Keep tenferro-specific durable rules in
 `REPOSITORY_RULES.md`. This `AGENTS.md` file is the entry point and
 tenferro-specific orientation; avoid duplicating the detailed performance,
 layout, CPU kernel, slicing, cache, threading, and GPU backend rules here.
+`REPOSITORY_RULES.md` is also routing input for
+`scripts/repository-rules-review.py`; when adding or renaming a `##` section,
+update that script's routed or human-only section lists in the same change.
 
 ## Contribution Workflow Assets
 

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -3,6 +3,11 @@
 These are tenferro-specific rules. Apply them on top of the shared tensor4all
 rules from `tensor4all-agent-rules`.
 
+`scripts/repository-rules-review.py` treats each `##` heading below as a
+routing unit. Sections that should reach the diff-scoped review bot must be
+listed in that script's `ALWAYS_SECTIONS` or `SECTION_TRIGGERS`; human/process
+protocols must be listed in `HUMAN_ONLY_SECTIONS` instead.
+
 ## Public Surface Drift
 
 - `README`, rustdoc, and examples must not claim capabilities beyond the current public surface.
@@ -236,6 +241,9 @@ rules from `tensor4all-agent-rules`.
 
 ## Final Cross-Phase Multi-Agent Audit
 
+Human/process protocol. This section is intentionally not routed to the
+diff-scoped review bot.
+
 Repository-scale, multi-phase implementation programs require one final audit
 after every phase and its task-local reviews are complete, but before the
 umbrella issue or implementation branch is declared ready for integration.
@@ -276,8 +284,10 @@ umbrella issue or implementation branch is declared ready for integration.
   support, but do not replace, call-path review and runtime tests.
 - Apply the existing [Public Boundary Safety Audits](#public-boundary-safety-audits),
   [Unsafe Code Boundary](#unsafe-code-boundary),
-  [Performance And Layout Rules](#performance-and-layout-rules),
+  [Performance-Sensitive Safety Contracts](#performance-sensitive-safety-contracts),
+  [Materialization And Copies](#materialization-and-copies),
   [Performance-Gated Experiment Protocol](#performance-gated-experiment-protocol),
+  [Cache Ownership](#cache-ownership),
   [CPU Threading Contract](#cpu-threading-contract),
   [GPU Backend Contract](#gpu-backend-contract),
   [Documentation Policy](#documentation-policy), and
@@ -305,6 +315,9 @@ umbrella issue or implementation branch is declared ready for integration.
 
 ## External Contribution Intake
 
+Human/process protocol. This section is intentionally not routed to the
+diff-scoped review bot.
+
 - Pull request creation is currently restricted to collaborators. External
   requests, reproducers, proposed regression tests, benchmark reports, and
   prototype branches should be collected in issues first.
@@ -328,6 +341,9 @@ umbrella issue or implementation branch is declared ready for integration.
 
 ## CI Cost Discipline
 
+Human/process protocol. This section is intentionally not routed to the
+diff-scoped review bot.
+
 - Expensive CI lanes, especially GPU or larger-runner jobs, must be gated behind
   cheaper repository-policy and non-GPU checks. Do not trigger hardware-backed
   runners directly on PR updates when an earlier review, lint, docs, or CPU test
@@ -347,7 +363,8 @@ umbrella issue or implementation branch is declared ready for integration.
   extension family; for example the direct
   `tenferro_einsum::TraceContextEinsumExt` /
   `tenferro_einsum::TracedTensorEinsumExt` operation surfaces plus
-  `executor.register_extension(tenferro_einsum::register_runtime)`.
+  `Runtime::builder().install_extension_module(...)` after registering the
+  target engine.
 - Extension runtime dispatch must fail explicitly when a runtime owner is
   available but the extension family is not registered. Do not silently fall
   back from a registered-runtime execution path to an `ExtensionOp::eager_execute`
@@ -525,9 +542,7 @@ Tests follow implementation ownership.
   tests.
 - This rule is enforced by repository contract tests and must stay green in CI.
 
-## Performance And Layout Rules
-
-### Performance-Sensitive Safety Contracts
+## Performance-Sensitive Safety Contracts
 
 - Potentially dangerous operations that are intentionally kept for performance,
   such as raw scratch-buffer acquisition, unchecked indexing after validation,
@@ -543,8 +558,16 @@ Tests follow implementation ownership.
   an explicit zeroed/initialized acquisition path, keep raw acquisition unsafe
   and documented for full-overwrite kernels only, and add regression coverage
   for both contracts.
+- An in-place write into a buffer reachable through `Arc` ownership requires a
+  local uniqueness proof at the write site, such as `Arc::get_mut`,
+  `Arc::try_unwrap`, `Arc::make_mut`, or an `Arc::ptr_eq` alias rejection for
+  backend buffers. The alternative is exclusive runtime ownership of the buffer
+  for its whole lifetime, such as dispatch-loop slots. Do not infer uniqueness
+  from `&mut Tensor` when backend buffers can wrap shared device allocations.
+  Add mutation-after-handoff tests when an optimization preserves aliases or
+  views that a previous implementation copied.
 
-### Complexity Budget
+## Complexity Budget
 
 - Do not introduce accidental `O(n^2)` behavior in graph construction,
   metadata propagation, key hashing/equality, compilation, or execution
@@ -558,7 +581,7 @@ Tests follow implementation ownership.
 - When optimizing compiler or graph-build overhead, measure scaling across
   increasing graph sizes, not only one fixed benchmark case.
 
-### Materialization And Copies
+## Materialization And Copies
 
 - Production tensor paths must not silently materialize dense temporary buffers
   whose memory or time scales with an unconstrained product of tensor
@@ -575,7 +598,7 @@ Tests follow implementation ownership.
   backend limitation, or external ABI boundary, make that boundary explicit in
   the implementation and cover it with tests.
 
-### Device Transfer And Backend Buffer Errors
+## Device Transfer And Backend Buffer Errors
 
 - tenferro follows the PyTorch convention: no implicit CPU-GPU transfer.
   Tensors must already live on the device required by the backend operation.
@@ -605,7 +628,7 @@ Tests follow implementation ownership.
 - Unsupported CUDA op or dtype combinations must return an explicit error, not
   silently fall back to CPU execution.
 
-### Dense Layout And Linear Algebra
+## Dense Layout And Linear Algebra
 
 - tenferro uses column-major (Fortran order) dense storage: the leftmost
   dimension has the smallest stride and varies fastest in memory.
@@ -625,7 +648,7 @@ Tests follow implementation ownership.
   algebra. Do not reimplement linalg kernels locally in downstream layers when
   the CPU/GPU backend already owns the operation.
 
-### Range Checks And Slicing
+## Range Checks And Slicing
 
 - Public indexing and slicing APIs must validate rank, bounds, steps, output
   shape, and empty/singleton boundary behavior at the API boundary or planning
@@ -652,7 +675,7 @@ Tests follow implementation ownership.
   range, empty or singleton slices, lower and upper boundaries, out-of-range
   errors, rank mismatch, and non-contiguous slices.
 
-### CPU Kernel Implementation
+## CPU Kernel Implementation
 
 - No naive CPU loop fallbacks. CPU tensor kernels must use optimized
   implementations unless the operation is explicitly listed as an exception
@@ -736,7 +759,7 @@ Tests follow implementation ownership.
   yet, keep a nearby source comment naming that rationale. Do not let
   undocumented serial loops become the default fallback pattern.
 
-### Tensor Core Data Model
+## Tensor Core Data Model
 
 - `tenferro-tensor-core` owns backend-independent host tensor metadata and
   contiguous host storage: `DType`, `TensorScalar`, `HostTensor<T>`,
@@ -752,7 +775,7 @@ Tests follow implementation ownership.
   implement `PartialEq` for views.
 - `ShapeVec` and `StrideVec` use `SmallVec` with inline rank capacity 8.
 
-### Faer Integration
+## Faer Integration
 
 - Prefer zero-copy `faer::MatRef` / `faer::MatMut` views over packing data into
   temporary dense matrices. Validate shape, bounds, alignment, and aliasing
@@ -767,7 +790,7 @@ Tests follow implementation ownership.
   allocate reusable scratch once for the operation. Avoid repeated `Vec`
   allocation in decomposition, solve, or batched inner loops.
 
-### Performance Anti-Patterns
+## Performance Anti-Patterns
 
 - Do not hand-copy near-identical dtype-specific operation bodies. Prefer
   generic helpers, sealed traits, or macros, and keep any unavoidable dtype
@@ -782,7 +805,7 @@ Tests follow implementation ownership.
 - Do not call `Backend::plan()` or equivalent planning APIs inside execution
   loops. Pre-compute plans before the loop and pass them in.
 
-### Performance-Sensitive Tests And Benchmarks
+## Performance-Sensitive Tests And Benchmarks
 
 - Small reference tests may materialize dense tensors, but should materialize
   each full result once and compare the whole result. Avoid per-element
@@ -802,8 +825,20 @@ Tests follow implementation ownership.
   thread counts. A single fixed-size speedup is not enough evidence for a
   performance-sensitive change.
 
-### Performance-Gated Experiment Protocol
+## Performance-Gated Experiment Protocol
 
+Human/process protocol. This section is intentionally not routed to the
+diff-scoped review bot.
+
+- Performance candidates found by static/source audit alone must pass a
+  need-before-implementation gate before code changes start. First measure the
+  candidate path's share of an end-to-end workload, or another
+  issue-predeclared representative workload. If the path does not occupy a
+  meaningful share under the predeclared threshold, record the measurement or
+  argument in the issue and close or defer it without implementation. A
+  microbenchmark of the targeted helper is useful after the need is established,
+  but by itself it proves only effect, not that the optimization is worth its
+  semantic, aliasing, cache, or maintenance risk.
 - Before running a candidate, record the baseline commit, candidate commit,
   benchmark source, build profile, hardware and affinity configuration,
   provider/thread settings, complete case list, comparison statistic,
@@ -823,7 +858,7 @@ Tests follow implementation ownership.
   redefine the primary metric, or add post-hoc exclusions after seeing the
   candidate.
 
-### Cache Ownership
+## Cache Ownership
 
 - Long-lived runtime/compiler caches must be owned by `Engine` or another
   explicit top-level runtime object, not hidden in thread-local/global state or
@@ -848,7 +883,7 @@ Tests follow implementation ownership.
   capacity, memory behavior, entry/byte accounting, and
   clear/configuration/stats path.
 
-### CPU Threading Contract
+## CPU Threading Contract
 
 - For faer-backed CPU ops, `CpuContext` is the single source of truth for thread-pool policy.
 - Do not derive faer parallelism independently inside individual ops or helper functions.
@@ -862,7 +897,7 @@ Tests follow implementation ownership.
   controlled by provider variables such as `OPENBLAS_NUM_THREADS`,
   `MKL_NUM_THREADS`, `OMP_NUM_THREADS`, and `VECLIB_MAXIMUM_THREADS`.
 
-### GPU Backend Contract
+## GPU Backend Contract
 
 - Before touching CubeCL/GPU backend code, read
   [`docs/design/gpu-backend-design.md`](docs/design/gpu-backend-design.md).
@@ -874,7 +909,7 @@ Tests follow implementation ownership.
   provided by cuSOLVER. `CudaBackend::eig` returns `Unsupported`; users
   must explicitly download to CPU and compute via `CpuBackend::eig`.
 
-### Structured Error Classification
+## Structured Error Classification
 
 - Validation facts use the shared typed vocabulary for shape, rank, axis, dtype,
   configuration, and invalid arguments. Eager and traced paths must report the

--- a/docs/worklogs/2026-07-27-repository-rules-routing.md
+++ b/docs/worklogs/2026-07-27-repository-rules-routing.md
@@ -1,0 +1,35 @@
+# Repository Rules Routing Restructure
+
+## Context
+
+Issue #1491 identified that `REPOSITORY_RULES.md` had become both a human
+policy document and the machine-consumed routing source for
+`scripts/repository-rules-review.py`. The review script splits only on `##`
+headings, so the former `Performance And Layout Rules` section routed roughly
+four hundred lines of CPU, GPU, cache, benchmark, and error-contract text for
+many small diffs.
+
+## Decisions
+
+- Keep one `REPOSITORY_RULES.md` file, but treat every `##` heading as a
+  routing unit.
+- Promote the performance/layout subsections to `##` sections so CPU, tensor,
+  GPU, linalg, cache, and benchmark diffs can select narrower rule text.
+- Mark process-only rules through `HUMAN_ONLY_SECTIONS` rather than sending
+  them to the diff-scoped review bot.
+- Route `Invariant Markers` globally because other routed rules refer to that
+  marker and reviewers need the false-positive policy with the code contracts.
+- Replace the retired `register_runtime` extension-registration example with
+  the current `Runtime::builder().install_extension_module(...)` model.
+- Record the accepted post-U8 policies once: local uniqueness proof for
+  `Arc`-reachable in-place writes, and the need-before-implementation gate for
+  static-audit-derived performance candidates.
+
+## Verification
+
+- Added a doc-consistency check that every `##` rules section is either routed
+  or explicitly human-only, no routed section exceeds the configured line
+  limit, stale `register_runtime` wording is absent from `REPOSITORY_RULES.md`,
+  and the two post-U8 policies appear once.
+- Updated `scripts/test-repository-rules-review.py` for the split section
+  names and added coverage for GPU and benchmark routing.

--- a/scripts/repository-rules-review.py
+++ b/scripts/repository-rules-review.py
@@ -32,6 +32,7 @@ DEFAULT_API_URL = "https://api.deepseek.com/chat/completions"
 MAX_DIFF_CHARS = 120_000
 MAX_FILE_DIFF_CHARS = 40_000
 MAX_FINDINGS_PER_CHUNK = 8
+MAX_ROUTED_SECTION_LINES = 100
 RUNTIME_AD_FORBIDDEN = re.compile(
     r"\b(ADRule|EagerRuntime|EagerTensor|autodiff|chainrules|tidu)\b"
 )
@@ -77,8 +78,18 @@ ALWAYS_SECTIONS = frozenset(
     {
         "Public Surface Discipline",
         "Public Boundary Safety Audits",
+        "Invariant Markers",
         "Work Logs And Design Records",
         "No Ad Hoc Fixes",
+    }
+)
+
+HUMAN_ONLY_SECTIONS = frozenset(
+    {
+        "Final Cross-Phase Multi-Agent Audit",
+        "External Contribution Intake",
+        "CI Cost Discipline",
+        "Performance-Gated Experiment Protocol",
     }
 )
 
@@ -94,12 +105,91 @@ SECTION_TRIGGERS: tuple[tuple[re.Pattern[str], frozenset[str]], ...] = (
         ),
     ),
     (
-        re.compile(r"tenferro-cpu/|tenferro-tensor(?:-core)?/|/kernel/|strided"),
-        frozenset({"Performance And Layout Rules", "Unsafe Code Boundary"}),
+        re.compile(r"tenferro-tensor(?:-core)?/|/layout|/view|strided"),
+        frozenset(
+            {
+                "Performance-Sensitive Safety Contracts",
+                "Complexity Budget",
+                "Materialization And Copies",
+                "Device Transfer And Backend Buffer Errors",
+                "Dense Layout And Linear Algebra",
+                "Range Checks And Slicing",
+                "Tensor Core Data Model",
+                "Performance Anti-Patterns",
+                "Structured Error Classification",
+                "Unsafe Code Boundary",
+            }
+        ),
+    ),
+    (
+        re.compile(r"tenferro-cpu/|/kernel/|strided-kernel|strided-rs|strided-einsum"),
+        frozenset(
+            {
+                "Performance-Sensitive Safety Contracts",
+                "Materialization And Copies",
+                "Dense Layout And Linear Algebra",
+                "Range Checks And Slicing",
+                "CPU Kernel Implementation",
+                "Faer Integration",
+                "Performance Anti-Patterns",
+                "Cache Ownership",
+                "CPU Threading Contract",
+                "Structured Error Classification",
+                "Unsafe Code Boundary",
+            }
+        ),
     ),
     (
         re.compile(r"tenferro-gpu/|cubecl|cuda|cutensor|cublas"),
-        frozenset({"Performance And Layout Rules", "Unsafe Code Boundary"}),
+        frozenset(
+            {
+                "Performance-Sensitive Safety Contracts",
+                "Materialization And Copies",
+                "Device Transfer And Backend Buffer Errors",
+                "Dense Layout And Linear Algebra",
+                "Range Checks And Slicing",
+                "Performance Anti-Patterns",
+                "Cache Ownership",
+                "GPU Backend Contract",
+                "Structured Error Classification",
+                "Unsafe Code Boundary",
+            }
+        ),
+    ),
+    (
+        re.compile(r"tenferro-runtime/|runtime/|cache|executor"),
+        frozenset(
+            {
+                "Performance-Sensitive Safety Contracts",
+                "Complexity Budget",
+                "Device Transfer And Backend Buffer Errors",
+                "Cache Ownership",
+                "Structured Error Classification",
+            }
+        ),
+    ),
+    (
+        re.compile(r"tenferro-linalg/|linalg|faer|lapack|blas|dot_general|gemm"),
+        frozenset(
+            {
+                "Performance-Sensitive Safety Contracts",
+                "Materialization And Copies",
+                "Dense Layout And Linear Algebra",
+                "Faer Integration",
+                "Performance Anti-Patterns",
+                "Cache Ownership",
+                "Structured Error Classification",
+                "Unsafe Code Boundary",
+            }
+        ),
+    ),
+    (
+        re.compile(r"(^|/)benches/|^benchmarks/|criterion|benchmark"),
+        frozenset(
+            {
+                "Performance-Sensitive Tests And Benchmarks",
+            }
+        ),
     ),
     (
         re.compile(r"tenferro-einsum/|tenferro-linalg/|tenferro-fft/|ext/"),

--- a/scripts/test-doc-consistency.py
+++ b/scripts/test-doc-consistency.py
@@ -104,6 +104,17 @@ def load_api_consistency_checker():
     return module
 
 
+def load_repository_rules_review():
+    path = ROOT / "scripts/repository-rules-review.py"
+    spec = importlib.util.spec_from_file_location("repository_rules_review", path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_architecture_svg_lists_cpu_crate_xla_boundary_and_background() -> None:
     svg_path = ROOT / "docs/assets/tenferro-architecture.svg"
     text = svg_path.read_text(encoding="utf-8")
@@ -395,6 +406,36 @@ def test_traced_remainder_docs_distinguish_complex_unsupported_from_float_zero()
     assert "floating-point and complex zero divisors" not in docs
 
 
+def test_repository_rules_sections_are_routed_or_human_only() -> None:
+    reviewer = load_repository_rules_review()
+    sections = reviewer.parse_repository_rules_sections(ROOT / "REPOSITORY_RULES.md")
+
+    routed = set(reviewer.ALWAYS_SECTIONS)
+    for _, section_names in reviewer.SECTION_TRIGGERS:
+        routed.update(section_names)
+    human_only = set(getattr(reviewer, "HUMAN_ONLY_SECTIONS", frozenset()))
+    configured = routed | human_only
+
+    missing_routing = sorted(set(sections) - configured)
+    assert not missing_routing, missing_routing
+
+    missing_sections = sorted(configured - set(sections))
+    assert not missing_sections, missing_sections
+
+    max_lines = getattr(reviewer, "MAX_ROUTED_SECTION_LINES", 100)
+    oversized = {
+        name: len(sections[name].splitlines())
+        for name in sorted(routed)
+        if name in sections and len(sections[name].splitlines()) > max_lines
+    }
+    assert not oversized, oversized
+
+    rules = read("REPOSITORY_RULES.md")
+    assert "register_runtime" not in rules
+    assert rules.count("local uniqueness proof") == 1
+    assert rules.count("need-before-implementation gate") == 1
+
+
 def test_active_ad_docs_use_current_semantic_ad_owner() -> None:
     assert not (ROOT / "docs/architecture/tidu.md").exists()
 
@@ -500,6 +541,7 @@ def main() -> int:
         test_removed_tensor_module_paths_do_not_compile,
         test_documentation_policy_matches_rendered_internals,
         test_traced_remainder_docs_distinguish_complex_unsupported_from_float_zero,
+        test_repository_rules_sections_are_routed_or_human_only,
         test_active_ad_docs_use_current_semantic_ad_owner,
         test_phase4_and_phase5_runtime_ownership_and_dependency_direction_are_canonical,
     ]:

--- a/scripts/test-repository-rules-review.py
+++ b/scripts/test-repository-rules-review.py
@@ -166,8 +166,27 @@ def test_select_rule_sections_includes_performance_for_tensor_crates() -> None:
             "crates/tenferro-tensor/src/view.rs",
         ]
     )
-    assert "Performance And Layout Rules" in sections
+    assert "Performance-Sensitive Safety Contracts" in sections
+    assert "Materialization And Copies" in sections
+    assert "Range Checks And Slicing" in sections
+    assert "Tensor Core Data Model" in sections
+    assert "Performance And Layout Rules" not in sections
     assert "Unsafe Code Boundary" in sections
+
+
+def test_select_rule_sections_includes_gpu_contract_for_gpu_paths() -> None:
+    mod = load_module()
+    sections = mod.select_rule_sections(["crates/tenferro-gpu/src/cuda/runtime.rs"])
+    assert "GPU Backend Contract" in sections
+    assert "Device Transfer And Backend Buffer Errors" in sections
+    assert "Cache Ownership" in sections
+
+
+def test_select_rule_sections_includes_benchmark_rules_for_bench_paths() -> None:
+    mod = load_module()
+    sections = mod.select_rule_sections(["crates/tenferro-cpu/benches/map.rs"])
+    assert "Performance-Sensitive Tests And Benchmarks" in sections
+    assert "Performance-Gated Experiment Protocol" not in sections
 
 
 def test_select_rule_sections_includes_public_boundary_audits() -> None:
@@ -192,11 +211,16 @@ def test_final_cross_phase_multi_agent_audit_contract_is_present() -> None:
     expected_links = [
         ("Public Boundary Safety Audits", "#public-boundary-safety-audits"),
         ("Unsafe Code Boundary", "#unsafe-code-boundary"),
-        ("Performance And Layout Rules", "#performance-and-layout-rules"),
+        (
+            "Performance-Sensitive Safety Contracts",
+            "#performance-sensitive-safety-contracts",
+        ),
+        ("Materialization And Copies", "#materialization-and-copies"),
         (
             "Performance-Gated Experiment Protocol",
             "#performance-gated-experiment-protocol",
         ),
+        ("Cache Ownership", "#cache-ownership"),
         ("CPU Threading Contract", "#cpu-threading-contract"),
         ("GPU Backend Contract", "#gpu-backend-contract"),
         ("Documentation Policy", "#documentation-policy"),
@@ -743,6 +767,8 @@ def main() -> int:
         test_select_rule_sections_includes_ad_for_ad_paths,
         test_select_rule_sections_includes_ad_for_tenferro_ad_crate,
         test_select_rule_sections_includes_performance_for_tensor_crates,
+        test_select_rule_sections_includes_gpu_contract_for_gpu_paths,
+        test_select_rule_sections_includes_benchmark_rules_for_bench_paths,
         test_select_rule_sections_includes_public_boundary_audits,
         test_final_cross_phase_multi_agent_audit_contract_is_present,
         test_extract_json_payload_strips_fence,


### PR DESCRIPTION
## Summary

- Split the former `Performance And Layout Rules` monolith into routed `##` sections so the review bot can select narrower CPU, tensor, GPU, linalg, cache, and benchmark rule text.
- Added `HUMAN_ONLY_SECTIONS` plus a doc-consistency invariant that every rules section is either routed or explicitly human/process-only.
- Fixed the retired extension-registration example to the current `Runtime::builder().install_extension_module(...)` model.
- Recorded the accepted post-U8 aliasing/uniqueness rule and static-audit performance gate once in `REPOSITORY_RULES.md`.
- Added a worklog: `docs/worklogs/2026-07-27-repository-rules-routing.md`.

Closes #1491.
Refs #1489.

## Verification

- `python3 scripts/test-repository-rules-review.py`
- `python3 scripts/test-doc-consistency.py`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1491.json`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'python3 scripts/test-repository-rules-review.py' --test 'python3 scripts/test-doc-consistency.py'`
