### PR TITLE
Document FFT plan cache reuse path

### DIFF
--- a/crates/tenferro-fft/Cargo.toml
+++ b/crates/tenferro-fft/Cargo.toml
@@ -50,6 +50,14 @@ num-traits.workspace = true
 rustfft = "6"
 thiserror.workspace = true
 
+[dev-dependencies]
+criterion.workspace = true
+
+[[bench]]
+name = "fft_plan_cache"
+path = "benches/fft_plan_cache.rs"
+harness = false
+
 [[test]]
 name = "apple_cpu"
 path = "tests/apple_cpu.rs"

--- a/crates/tenferro-fft/benches/fft_plan_cache.rs
+++ b/crates/tenferro-fft/benches/fft_plan_cache.rs
@@ -1,0 +1,102 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use num_complex::Complex64;
+use tenferro_cpu::CpuBackend;
+use tenferro_fft::{FftExecutor, FftNorm, TensorFftExt};
+use tenferro_tensor::Tensor;
+
+const CASES: &[(usize, usize)] = &[(256, 1), (1024, 16)];
+
+fn c64_input(fft_len: usize, lanes: usize) -> Tensor {
+    let len = fft_len * lanes;
+    let values = (0..len)
+        .map(|index| {
+            let real = ((index * 17 + 3) % 257) as f64 / 257.0 - 0.5;
+            let imag = ((index * 29 + 5) % 263) as f64 / 263.0 - 0.5;
+            Complex64::new(real, imag)
+        })
+        .collect::<Vec<_>>();
+    Tensor::from_vec_col_major(vec![fft_len, lanes], values).unwrap()
+}
+
+fn f64_input(fft_len: usize, lanes: usize) -> Tensor {
+    let len = fft_len * lanes;
+    let values = (0..len)
+        .map(|index| ((index * 31 + 7) % 251) as f64 / 251.0 - 0.5)
+        .collect::<Vec<_>>();
+    Tensor::from_vec_col_major(vec![fft_len, lanes], values).unwrap()
+}
+
+fn bench_c64_fft_plan_cache(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fft_plan_cache/c64_fft_axis0");
+    for &(fft_len, lanes) in CASES {
+        let input = c64_input(fft_len, lanes);
+        let id = format!("{fft_len}x{lanes}");
+        group.throughput(Throughput::Elements((fft_len * lanes) as u64));
+
+        group.bench_function(BenchmarkId::new("direct_one_shot", &id), |bench| {
+            let mut backend = CpuBackend::new();
+            bench.iter(|| {
+                let output = black_box(&input)
+                    .fft(None, 0, FftNorm::Backward, &mut backend)
+                    .unwrap();
+                black_box(output);
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("executor_warm_cache", &id), |bench| {
+            let mut backend = CpuBackend::new();
+            let mut executor = FftExecutor::default();
+            executor
+                .fft(&input, None, 0, FftNorm::Backward, &mut backend)
+                .unwrap();
+            assert_eq!(executor.cache_stats().entries, 1);
+
+            bench.iter(|| {
+                let output = executor
+                    .fft(black_box(&input), None, 0, FftNorm::Backward, &mut backend)
+                    .unwrap();
+                black_box(output);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_f64_rfft_plan_cache(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fft_plan_cache/f64_rfft_axis0");
+    for &(fft_len, lanes) in CASES {
+        let input = f64_input(fft_len, lanes);
+        let id = format!("{fft_len}x{lanes}");
+        group.throughput(Throughput::Elements((fft_len * lanes) as u64));
+
+        group.bench_function(BenchmarkId::new("direct_one_shot", &id), |bench| {
+            let mut backend = CpuBackend::new();
+            bench.iter(|| {
+                let output = black_box(&input)
+                    .rfft(None, 0, FftNorm::Backward, &mut backend)
+                    .unwrap();
+                black_box(output);
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("executor_warm_cache", &id), |bench| {
+            let mut backend = CpuBackend::new();
+            let mut executor = FftExecutor::default();
+            executor
+                .rfft(&input, None, 0, FftNorm::Backward, &mut backend)
+                .unwrap();
+            assert_eq!(executor.cache_stats().entries, 1);
+
+            bench.iter(|| {
+                let output = executor
+                    .rfft(black_box(&input), None, 0, FftNorm::Backward, &mut backend)
+                    .unwrap();
+                black_box(output);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_c64_fft_plan_cache, bench_f64_rfft_plan_cache);
+criterion_main!(benches);

--- a/crates/tenferro-fft/src/lib.rs
+++ b/crates/tenferro-fft/src/lib.rs
@@ -147,6 +147,11 @@ pub use spec::{FftNorm, FftOperation, FftPlanSpec};
 pub const FFT_EXTENSION_FAMILY_ID: &str = "tenferro-fft.fft.v1";
 
 /// Reusable concrete FFT executor with an explicitly owned backend-neutral cache.
+///
+/// Use this executor for repeated concrete FFT calls that should reuse backend
+/// plans. The immediate [`TensorFftExt`] and [`TensorReadFftExt`] methods stay
+/// one-shot and do not retain hidden process-global, thread-local, or
+/// backend-owned plan state between calls.
 #[derive(Default)]
 pub struct FftExecutor {
     plans: FftPlanCache,
@@ -399,6 +404,10 @@ impl TracedTensorFftExt for TracedTensor {
 /// [`TensorReadFftExt`] when the input is a borrowed view or other
 /// [`TensorRead`] value.
 ///
+/// Direct calls intentionally use a call-local one-shot FFT plan cache. Use
+/// [`FftExecutor`] for repeated concrete calls with stable transform lengths,
+/// or traced/runtime execution when the runtime should own the extension cache.
+///
 /// # Examples
 ///
 /// ```
@@ -560,6 +569,10 @@ impl TensorFftExt for Tensor {
 ///
 /// The `_read` suffix follows the repository convention for APIs that
 /// explicitly accept [`TensorRead`] values such as borrowed views.
+///
+/// Direct read calls intentionally materialize through a call-local one-shot
+/// FFT plan cache. Use [`FftExecutor`] on compact owned tensors when repeated
+/// concrete calls should retain backend plans across calls.
 ///
 /// # Examples
 ///

--- a/crates/tenferro-fft/tests/backend_capability.rs
+++ b/crates/tenferro-fft/tests/backend_capability.rs
@@ -319,6 +319,26 @@ fn caller_owned_cache_is_backend_neutral_and_reports_reuse_clear_and_stats() {
 }
 
 #[test]
+fn direct_concrete_api_uses_call_local_one_shot_plan_cache() {
+    let input = Tensor::from_vec_col_major(
+        vec![2],
+        vec![Complex64::new(1.0, 0.0), Complex64::new(2.0, 0.0)],
+    )
+    .unwrap();
+    let mut backend = MockNonCpuBackend::default();
+
+    input
+        .fft(None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+    input
+        .fft(None, -1, FftNorm::Backward, &mut backend)
+        .unwrap();
+
+    assert_eq!(backend.plan_builds, 2);
+    assert_eq!(backend.plan_reuses, 0);
+}
+
+#[test]
 fn concrete_cpu_execution_preserves_all_four_scalar_dtypes() {
     let mut backend = CpuBackend::new();
 

--- a/docs/worklogs/2026-07-27-fft-plan-cache-1484.md
+++ b/docs/worklogs/2026-07-27-fft-plan-cache-1484.md
@@ -1,0 +1,45 @@
+# FFT plan cache #1484
+
+Date: 2026-07-27
+
+#1484 audited the post-U8 FFT cache path instead of adding another implicit
+cache owner. The existing implementation already has the required explicit
+ownership boundaries:
+
+- `FftExecutor` owns a bounded `FftPlanCache` with clear/configure/stats APIs.
+- Runtime extension execution stores FFT plans in the runtime-owned extension
+  cache, so traced repeated execution can reuse plans and report retained bytes.
+- Direct `TensorFftExt` and `TensorReadFftExt` calls keep call-local one-shot
+  plan caches. This avoids hidden process-global, thread-local, or backend
+  mutable plan state in the immediate API.
+- CPU scratch storage is one lane vector per call, reused across lanes. A
+  longer-lived workspace would need another explicit mutable execution owner,
+  so this PR keeps scratch ownership unchanged until profiling shows it matters
+  separately from plan construction.
+
+## Benchmark evidence
+
+The new `tenferro-fft` Criterion bench compares direct one-shot concrete calls
+against a warm caller-owned `FftExecutor` cache for repeated equal-length
+transforms. Local command:
+
+```text
+OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1 RAYON_NUM_THREADS=1 CARGO_BUILD_JOBS=64 cargo bench -p tenferro-fft --bench fft_plan_cache -- --sample-size 10 --warm-up-time 0.1 --measurement-time 0.3
+```
+
+Median local timings:
+
+```text
+fft_plan_cache/c64_fft_axis0/direct_one_shot/256x1       17.020 us
+fft_plan_cache/c64_fft_axis0/executor_warm_cache/256x1   10.564 us
+fft_plan_cache/c64_fft_axis0/direct_one_shot/1024x16     90.321 us
+fft_plan_cache/c64_fft_axis0/executor_warm_cache/1024x16 73.461 us
+
+fft_plan_cache/f64_rfft_axis0/direct_one_shot/256x1       22.918 us
+fft_plan_cache/f64_rfft_axis0/executor_warm_cache/256x1   16.082 us
+fft_plan_cache/f64_rfft_axis0/direct_one_shot/1024x16     88.354 us
+fft_plan_cache/f64_rfft_axis0/executor_warm_cache/1024x16 68.528 us
+```
+
+The warm executor path is the intended repeated-call fast path. The direct API
+remains acceptable one-shot behavior.


### PR DESCRIPTION
## Summary

Closes #1484.
Refs #1489.

This audits the existing FFT cache ownership path and locks in the intended API boundary instead of adding another implicit cache owner:

- adds a `tenferro-fft` Criterion benchmark for repeated equal-length C64 FFT and F64 RFFT calls, comparing direct one-shot concrete calls against a warm caller-owned `FftExecutor` cache
- documents that direct `TensorFftExt` / `TensorReadFftExt` methods intentionally keep call-local one-shot caches, while repeated concrete calls should use `FftExecutor` and traced execution uses runtime-owned extension caches
- adds a backend-neutral behavior test proving direct concrete calls do not secretly reuse hidden plan state across calls
- records the benchmark evidence and scratch-ownership decision in `docs/worklogs/2026-07-27-fft-plan-cache-1484.md`

No process-global, thread-local, or backend-hidden FFT plan cache is introduced.

## Benchmark evidence

Local command:

```text
OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 OMP_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1 RAYON_NUM_THREADS=1 CARGO_BUILD_JOBS=64 cargo bench -p tenferro-fft --bench fft_plan_cache -- --sample-size 10 --warm-up-time 0.1 --measurement-time 0.3
```

Median local timings:

```text
fft_plan_cache/c64_fft_axis0/direct_one_shot/256x1       17.020 us
fft_plan_cache/c64_fft_axis0/executor_warm_cache/256x1   10.564 us
fft_plan_cache/c64_fft_axis0/direct_one_shot/1024x16     90.321 us
fft_plan_cache/c64_fft_axis0/executor_warm_cache/1024x16 73.461 us

fft_plan_cache/f64_rfft_axis0/direct_one_shot/256x1       22.918 us
fft_plan_cache/f64_rfft_axis0/executor_warm_cache/256x1   16.082 us
fft_plan_cache/f64_rfft_axis0/direct_one_shot/1024x16     88.354 us
fft_plan_cache/f64_rfft_axis0/executor_warm_cache/1024x16 68.528 us
```

## Validation

```text
CARGO_BUILD_JOBS=64 cargo test -p tenferro-fft --test backend_capability -- --nocapture
CARGO_BUILD_JOBS=64 cargo test -p tenferro-fft --test fft_ops -- --nocapture
CARGO_BUILD_JOBS=64 cargo test -p tenferro-fft --doc -- --nocapture
CARGO_BUILD_JOBS=64 cargo clippy -p tenferro-fft --all-targets -- -D warnings
CARGO_BUILD_JOBS=64 cargo bench -p tenferro-fft --bench fft_plan_cache --no-run
CARGO_BUILD_JOBS=64 bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-fft --test backend_capability -- --nocapture' --test 'cargo test -p tenferro-fft --test fft_ops -- --nocapture' --test 'cargo test -p tenferro-fft --doc -- --nocapture' --test 'cargo bench -p tenferro-fft --bench fft_plan_cache --no-run'
python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1484.json
```
