### PR TITLE
Cache CUDA cuTENSOR contraction plans

### DIFF
--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -75,3 +75,9 @@ required-features = ["cuda"]
 [[test]]
 name = "integration"
 path = "tests/integration.rs"
+
+[[bench]]
+name = "cutensor_plan_cache"
+path = "benches/cutensor_plan_cache.rs"
+harness = false
+required-features = ["cuda"]

--- a/crates/tenferro-gpu/benches/cutensor_plan_cache.rs
+++ b/crates/tenferro-gpu/benches/cutensor_plan_cache.rs
@@ -1,0 +1,89 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use tenferro_gpu::{gpu_available, upload_tensor, CudaBackend};
+use tenferro_tensor::{DotGeneralConfig, Tensor, TensorDot, TensorScalar};
+
+fn matmul_config() -> DotGeneralConfig {
+    DotGeneralConfig {
+        lhs_contracting_dims: vec![1],
+        rhs_contracting_dims: vec![0],
+        lhs_batch_dims: vec![],
+        rhs_batch_dims: vec![],
+    }
+}
+
+fn matrix<T>(rows: usize, cols: usize) -> Tensor
+where
+    T: TensorScalar + From<f32>,
+{
+    let len = rows * cols;
+    let data = (0..len)
+        .map(|index| T::from(((index % 97) as f32 + 1.0) * 0.001))
+        .collect();
+    Tensor::from_vec_col_major(vec![rows, cols], data).unwrap()
+}
+
+fn bench_case<T>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    label: &str,
+    rows: usize,
+    inner: usize,
+    cols: usize,
+) where
+    T: TensorScalar + From<f32> + 'static,
+{
+    let mut backend = CudaBackend::new(0).unwrap();
+    let lhs = matrix::<T>(rows, inner);
+    let rhs = matrix::<T>(inner, cols);
+    let lhs = upload_tensor(backend.runtime(), &lhs).unwrap();
+    let rhs = upload_tensor(backend.runtime(), &rhs).unwrap();
+    let config = matmul_config();
+
+    let _ = backend.dot_general(&lhs, &rhs, &config).unwrap();
+    backend.runtime().synchronize().unwrap();
+
+    group.bench_function(
+        BenchmarkId::new(format!("{label}/cold_clear_each_iter"), rows),
+        |bench| {
+            bench.iter(|| {
+                backend.clear_cuda_extension_cache().unwrap();
+                let out = backend
+                    .dot_general(black_box(&lhs), black_box(&rhs), black_box(&config))
+                    .unwrap();
+                backend.runtime().synchronize().unwrap();
+                black_box(out);
+            });
+        },
+    );
+
+    let _ = backend.dot_general(&lhs, &rhs, &config).unwrap();
+    backend.runtime().synchronize().unwrap();
+    group.bench_function(
+        BenchmarkId::new(format!("{label}/warm_cache"), rows),
+        |bench| {
+            bench.iter(|| {
+                let out = backend
+                    .dot_general(black_box(&lhs), black_box(&rhs), black_box(&config))
+                    .unwrap();
+                backend.runtime().synchronize().unwrap();
+                black_box(out);
+            });
+        },
+    );
+}
+
+fn cutensor_plan_cache(c: &mut Criterion) {
+    if !gpu_available() {
+        eprintln!("skipping cuTENSOR plan-cache benchmark: no CUDA device available");
+        return;
+    }
+
+    let mut group = c.benchmark_group("cutensor_plan_cache");
+    for &(rows, inner, cols) in &[(64, 64, 64), (256, 256, 256)] {
+        bench_case::<f32>(&mut group, "f32", rows, inner, cols);
+        bench_case::<f64>(&mut group, "f64", rows, inner, cols);
+    }
+    group.finish();
+}
+
+criterion_group!(benches, cutensor_plan_cache);
+criterion_main!(benches);

--- a/crates/tenferro-gpu/src/cubecl/ffi/cutensor.rs
+++ b/crates/tenferro-gpu/src/cubecl/ffi/cutensor.rs
@@ -41,7 +41,7 @@ enum CutensorLoadError {
 }
 
 #[repr(i32)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum CudaDataType {
     R32F = 0,
     R64F = 1,
@@ -50,7 +50,7 @@ pub(crate) enum CudaDataType {
 }
 
 #[repr(i32)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum CutensorOperator {
     Identity = 1,
     Conj = 9,
@@ -69,7 +69,7 @@ pub(crate) enum CutensorJitMode {
 }
 
 #[repr(i32)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum CutensorWorksizePreference {
     Default = 2,
 }

--- a/crates/tenferro-gpu/src/cubecl/gemm.rs
+++ b/crates/tenferro-gpu/src/cubecl/gemm.rs
@@ -1,4 +1,7 @@
+use std::collections::{HashMap, VecDeque};
 use std::ffi::c_void;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
 
 use cubecl::prelude::{CubeElement, CubePrimitive};
 use cubecl_cuda::CudaRuntime as CubeclCudaRuntime;
@@ -23,15 +26,18 @@ use crate::config::DotGeneralConfig;
 use crate::kernels::structural;
 use crate::{col_major_strides, CubeclBuffer, Error, Tensor, TypedTensor};
 use tenferro_tensor::{
-    ContractionScalar, DType, DotGeneralAccumulation, TensorRead, TensorView, TensorViewMut,
-    TensorWrite, TypedTensorView, TypedTensorViewMut,
+    CacheStats, ContractionScalar, DType, DotGeneralAccumulation, TensorRead, TensorView,
+    TensorViewMut, TensorWrite, TypedTensorView, TypedTensorViewMut,
 };
 
 const OP: &str = "dot_general";
 const CUDA_ALLOCATION_ALIGNMENT: u32 = 256;
+const DEFAULT_CUTENSOR_PLAN_CACHE_MAX_ENTRIES: usize = 64;
+type CutensorPlanCacheState = Arc<Mutex<CutensorContractionPlanCache>>;
 
 trait CutensorScalar: CubeElement + CubePrimitive + Clone + One + Zero {
     const DATA_TYPE: CudaDataType;
+    const DTYPE: DType;
     const IS_COMPLEX: bool;
 
     fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor;
@@ -90,6 +96,7 @@ impl CutensorScalar for f32 {
     cutensor_variant_accessors!(F32);
 
     const DATA_TYPE: CudaDataType = CudaDataType::R32F;
+    const DTYPE: DType = DType::F32;
     const IS_COMPLEX: bool = false;
 
     fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor {
@@ -126,6 +133,7 @@ impl CutensorScalar for f64 {
     cutensor_variant_accessors!(F64);
 
     const DATA_TYPE: CudaDataType = CudaDataType::R64F;
+    const DTYPE: DType = DType::F64;
     const IS_COMPLEX: bool = false;
 
     fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor {
@@ -162,6 +170,7 @@ impl CutensorScalar for Complex32 {
     cutensor_variant_accessors!(C32);
 
     const DATA_TYPE: CudaDataType = CudaDataType::C32F;
+    const DTYPE: DType = DType::C32;
     const IS_COMPLEX: bool = true;
 
     fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor {
@@ -199,6 +208,7 @@ impl CutensorScalar for Complex64 {
     cutensor_variant_accessors!(C64);
 
     const DATA_TYPE: CudaDataType = CudaDataType::C64F;
+    const DTYPE: DType = DType::C64;
     const IS_COMPLEX: bool = true;
 
     fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor {
@@ -259,6 +269,280 @@ impl Workspace {
             ptr: std::ptr::null_mut(),
             size: 0,
         }
+    }
+}
+
+// SAFETY: `Workspace` owns a CubeCL server handle that keeps the device
+// allocation alive. The raw pointer is only submitted back to cuTENSOR while
+// the cached contraction mutex is held.
+unsafe impl Send for Workspace {}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct CutensorOperandLayoutKey {
+    extents: Vec<i64>,
+    strides: Vec<i64>,
+    modes: Vec<i32>,
+}
+
+impl CutensorOperandLayoutKey {
+    fn new(extents: &[i64], strides: &[i64], modes: &[i32]) -> Self {
+        Self {
+            extents: extents.to_vec(),
+            strides: strides.to_vec(),
+            modes: modes.to_vec(),
+        }
+    }
+
+    fn retained_bytes(&self) -> usize {
+        std::mem::size_of::<Self>()
+            .saturating_add(self.extents.capacity() * std::mem::size_of::<i64>())
+            .saturating_add(self.strides.capacity() * std::mem::size_of::<i64>())
+            .saturating_add(self.modes.capacity() * std::mem::size_of::<i32>())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct CutensorContractionKey {
+    dtype: DType,
+    lhs: CutensorOperandLayoutKey,
+    rhs: CutensorOperandLayoutKey,
+    output: CutensorOperandLayoutKey,
+    lhs_alignment_requirement: u32,
+    rhs_alignment_requirement: u32,
+    output_alignment_requirement: u32,
+    lhs_op: CutensorOperator,
+    rhs_op: CutensorOperator,
+    workspace_preference: CutensorWorksizePreference,
+}
+
+impl CutensorContractionKey {
+    fn from_spec<T: CutensorScalar>(spec: &CutensorContractionSpec<'_>) -> Self {
+        Self {
+            dtype: T::DTYPE,
+            lhs: CutensorOperandLayoutKey::new(
+                &spec.layout.lhs_extents,
+                spec.lhs_strides,
+                &spec.layout.lhs_modes,
+            ),
+            rhs: CutensorOperandLayoutKey::new(
+                &spec.layout.rhs_extents,
+                spec.rhs_strides,
+                &spec.layout.rhs_modes,
+            ),
+            output: CutensorOperandLayoutKey::new(
+                &spec.layout.output_extents,
+                spec.output_strides,
+                &spec.layout.output_modes,
+            ),
+            lhs_alignment_requirement: spec.lhs_alignment_requirement,
+            rhs_alignment_requirement: spec.rhs_alignment_requirement,
+            output_alignment_requirement: spec.output_alignment_requirement,
+            lhs_op: cutensor_conj_op::<T>(spec.lhs_conj),
+            rhs_op: cutensor_conj_op::<T>(spec.rhs_conj),
+            workspace_preference: spec.workspace_preference,
+        }
+    }
+
+    fn retained_bytes(&self) -> usize {
+        std::mem::size_of::<Self>()
+            .saturating_add(self.lhs.retained_bytes())
+            .saturating_add(self.rhs.retained_bytes())
+            .saturating_add(self.output.retained_bytes())
+    }
+}
+
+struct CutensorContractionSpec<'a> {
+    layout: &'a DotGeneralLayout,
+    lhs_strides: &'a [i64],
+    rhs_strides: &'a [i64],
+    output_strides: &'a [i64],
+    lhs_alignment_requirement: u32,
+    rhs_alignment_requirement: u32,
+    output_alignment_requirement: u32,
+    lhs_conj: bool,
+    rhs_conj: bool,
+    workspace_preference: CutensorWorksizePreference,
+}
+
+struct CachedCutensorContraction {
+    // Drop the cuTENSOR plan before the descriptor objects it was built from.
+    plan: Plan,
+    _plan_preference: PlanPreference,
+    _operation_descriptor: OperationDescriptor,
+    _output_descriptor: TensorDescriptor,
+    _rhs_descriptor: TensorDescriptor,
+    _lhs_descriptor: TensorDescriptor,
+    workspace: Workspace,
+}
+
+// SAFETY: cached cuTENSOR state is tied to one `CudaBackend` and is only used
+// while holding the enclosing plan-cache mutex. The opaque cuTENSOR handles are
+// created and destroyed through the same loaded cuTENSOR library.
+unsafe impl Send for CachedCutensorContraction {}
+
+impl CachedCutensorContraction {
+    fn new<T>(
+        rt: &CudaRuntime,
+        cutensor: &CutensorHandle,
+        spec: &CutensorContractionSpec<'_>,
+    ) -> crate::Result<Self>
+    where
+        T: CutensorScalar,
+    {
+        let desc_a = TensorDescriptor::new(
+            cutensor,
+            &spec.layout.lhs_extents,
+            spec.lhs_strides,
+            T::DATA_TYPE,
+            spec.lhs_alignment_requirement,
+            OP,
+        )?;
+        let desc_b = TensorDescriptor::new(
+            cutensor,
+            &spec.layout.rhs_extents,
+            spec.rhs_strides,
+            T::DATA_TYPE,
+            spec.rhs_alignment_requirement,
+            OP,
+        )?;
+        let desc_out = TensorDescriptor::new(
+            cutensor,
+            &spec.layout.output_extents,
+            spec.output_strides,
+            T::DATA_TYPE,
+            spec.output_alignment_requirement,
+            OP,
+        )?;
+        let op_desc = OperationDescriptor::new_contraction_with_ops(
+            cutensor,
+            &desc_a,
+            &spec.layout.lhs_modes,
+            cutensor_conj_op::<T>(spec.lhs_conj),
+            &desc_b,
+            &spec.layout.rhs_modes,
+            cutensor_conj_op::<T>(spec.rhs_conj),
+            &desc_out,
+            &spec.layout.output_modes,
+            &desc_out,
+            &spec.layout.output_modes,
+            T::compute_descriptor(cutensor),
+            OP,
+        )?;
+        let pref = PlanPreference::new_default(cutensor, OP)?;
+        let workspace_size =
+            cutensor.estimate_workspace_size(&op_desc, &pref, spec.workspace_preference, OP)?;
+        let plan = Plan::new(cutensor, &op_desc, &pref, workspace_size, OP)?;
+        let workspace = alloc_workspace(rt, workspace_size)?;
+        Ok(Self {
+            plan,
+            _plan_preference: pref,
+            _operation_descriptor: op_desc,
+            _output_descriptor: desc_out,
+            _rhs_descriptor: desc_b,
+            _lhs_descriptor: desc_a,
+            workspace,
+        })
+    }
+
+    fn retained_bytes(&self) -> usize {
+        std::mem::size_of::<Self>()
+            .saturating_add(usize::try_from(self.workspace.size).unwrap_or(usize::MAX))
+    }
+}
+
+struct CutensorContractionPlanCache {
+    max_entries: NonZeroUsize,
+    entries: HashMap<CutensorContractionKey, CachedCutensorContraction>,
+    order: VecDeque<CutensorContractionKey>,
+    stats: CacheStats,
+}
+
+impl CutensorContractionPlanCache {
+    fn new(max_entries: NonZeroUsize) -> Self {
+        Self {
+            max_entries,
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            stats: CacheStats::empty(),
+        }
+    }
+
+    fn ensure<T>(
+        &mut self,
+        rt: &CudaRuntime,
+        cutensor: &CutensorHandle,
+        key: &CutensorContractionKey,
+        spec: &CutensorContractionSpec<'_>,
+    ) -> crate::Result<()>
+    where
+        T: CutensorScalar,
+    {
+        if self.entries.contains_key(key) {
+            self.stats.hits = self.stats.hits.saturating_add(1);
+            self.touch(key);
+            return Ok(());
+        }
+        self.stats.misses = self.stats.misses.saturating_add(1);
+        let cached = CachedCutensorContraction::new::<T>(rt, cutensor, spec)?;
+        self.entries.insert(key.clone(), cached);
+        self.touch(key);
+        self.evict_to_limit();
+        Ok(())
+    }
+
+    fn get(&self, key: &CutensorContractionKey) -> crate::Result<&CachedCutensorContraction> {
+        self.entries.get(key).ok_or_else(|| {
+            Error::runtime_state(
+                "cutensor_plan_cache",
+                "cached cuTENSOR contraction was evicted before use",
+            )
+        })
+    }
+
+    fn touch(&mut self, key: &CutensorContractionKey) {
+        self.order.retain(|existing| existing != key);
+        self.order.push_back(key.clone());
+    }
+
+    fn evict_to_limit(&mut self) {
+        while self.entries.len() > self.max_entries.get() {
+            let Some(oldest) = self.order.pop_front() else {
+                break;
+            };
+            if self.entries.remove(&oldest).is_some() {
+                self.stats.evictions = self.stats.evictions.saturating_add(1);
+            }
+        }
+    }
+
+    fn max_entries(&self) -> NonZeroUsize {
+        self.max_entries
+    }
+
+    fn set_max_entries(&mut self, max_entries: NonZeroUsize) {
+        self.max_entries = max_entries;
+        self.evict_to_limit();
+    }
+
+    fn stats(&self) -> CacheStats {
+        CacheStats {
+            entries: self.entries.len(),
+            retained_bytes: self.retained_bytes(),
+            ..self.stats
+        }
+    }
+
+    fn retained_bytes(&self) -> usize {
+        let entries_bytes =
+            self.entries
+                .iter()
+                .fold(std::mem::size_of::<Self>(), |total, (key, cached)| {
+                    total
+                        .saturating_add(key.retained_bytes())
+                        .saturating_add(cached.retained_bytes())
+                });
+        entries_bytes
+            .saturating_add(self.order.capacity() * std::mem::size_of::<CutensorContractionKey>())
     }
 }
 
@@ -358,6 +642,13 @@ impl<T: 'static> ReadOperand<'_, '_, T> {
     }
 }
 
+fn read_operand_alignment_requirement<T: CutensorScalar>(operand: &ReadOperand<'_, '_, T>) -> u32 {
+    match operand {
+        ReadOperand::Owned(_) => CUDA_ALLOCATION_ALIGNMENT,
+        ReadOperand::View(_) => view_descriptor_alignment_requirement::<T>(),
+    }
+}
+
 /// Write-slot operand for the accumulate path.
 enum WriteOperand<'a, 'b, T> {
     Owned(&'a mut TypedTensor<T>),
@@ -378,6 +669,19 @@ impl<T: 'static> WriteOperand<'_, '_, T> {
             Self::View(view) => view.n_elements(),
         }
     }
+}
+
+fn write_operand_alignment_requirement<T: CutensorScalar>(
+    operand: &WriteOperand<'_, '_, T>,
+) -> u32 {
+    match operand {
+        WriteOperand::Owned(_) => CUDA_ALLOCATION_ALIGNMENT,
+        WriteOperand::View(_) => view_descriptor_alignment_requirement::<T>(),
+    }
+}
+
+fn view_descriptor_alignment_requirement<T: CutensorScalar>() -> u32 {
+    u32::try_from(std::mem::size_of::<T>()).unwrap_or(CUDA_ALLOCATION_ALIGNMENT)
 }
 
 /// Device pointer plus cuTENSOR descriptor metadata for one operand.
@@ -520,64 +824,29 @@ where
         };
     }
 
-    let cutensor = backend.cutensor_handle()?;
-    let desc_a = TensorDescriptor::new(
-        cutensor,
-        &layout.lhs_extents,
-        &lhs_res.strides,
-        T::DATA_TYPE,
-        lhs_res.alignment,
-        OP,
-    )?;
-    let desc_b = TensorDescriptor::new(
-        cutensor,
-        &layout.rhs_extents,
-        &rhs_res.strides,
-        T::DATA_TYPE,
-        rhs_res.alignment,
-        OP,
-    )?;
-    let desc_out = TensorDescriptor::new(
-        cutensor,
-        &layout.output_extents,
-        &out_res.strides,
-        T::DATA_TYPE,
-        out_res.alignment,
-        OP,
-    )?;
-    let op_desc = OperationDescriptor::new_contraction_with_ops(
-        cutensor,
-        &desc_a,
-        &layout.lhs_modes,
-        cutensor_conj_op::<T>(lhs_conj),
-        &desc_b,
-        &layout.rhs_modes,
-        cutensor_conj_op::<T>(rhs_conj),
-        &desc_out,
-        &layout.output_modes,
-        &desc_out,
-        &layout.output_modes,
-        T::compute_descriptor(cutensor),
-        OP,
-    )?;
-    let pref = PlanPreference::new_default(cutensor, OP)?;
-    let workspace_size = cutensor.estimate_workspace_size(
-        &op_desc,
-        &pref,
-        CutensorWorksizePreference::Default,
-        OP,
-    )?;
-    let plan = Plan::new(cutensor, &op_desc, &pref, workspace_size, OP)?;
-    let workspace = alloc_workspace(backend.runtime(), workspace_size)?;
-
     let stream = raw_stream(backend.runtime())?;
+    let spec = CutensorContractionSpec {
+        layout: &layout,
+        lhs_strides: &lhs_res.strides,
+        rhs_strides: &rhs_res.strides,
+        output_strides: &out_res.strides,
+        lhs_alignment_requirement: read_operand_alignment_requirement(&lhs),
+        rhs_alignment_requirement: read_operand_alignment_requirement(&rhs),
+        output_alignment_requirement: write_operand_alignment_requirement(&out),
+        lhs_conj,
+        rhs_conj,
+        workspace_preference: CutensorWorksizePreference::Default,
+    };
+    validate_descriptor_alignment(lhs_res.alignment, spec.lhs_alignment_requirement, "lhs")?;
+    validate_descriptor_alignment(rhs_res.alignment, spec.rhs_alignment_requirement, "rhs")?;
+    validate_descriptor_alignment(out_res.alignment, spec.output_alignment_requirement, "out")?;
     // C = D = out: cuTENSOR reads the destination as the accumulator (skipped
     // by cuTENSOR itself when beta == 0) and writes the result in place.
     // Overlap between the out region and the lhs/rhs regions is the caller's
     // responsibility, as with BLAS-style in-place update APIs.
-    unsafe {
+    cached_cutensor_contraction::<T, _>(backend, &spec, |cutensor, plan, workspace| unsafe {
         cutensor.contract(
-            &plan,
+            plan,
             &alpha as *const T as *const c_void,
             lhs_res.ptr as *const c_void,
             rhs_res.ptr as *const c_void,
@@ -588,9 +857,8 @@ where
             workspace.size,
             stream,
             OP,
-        )?;
-    }
-    Ok(())
+        )
+    })
 }
 
 fn resolve_read_operand<T>(
@@ -800,56 +1068,6 @@ where
         return zero_alloc::<T>(backend.runtime(), &layout.output_shape);
     }
 
-    let cutensor = backend.cutensor_handle()?;
-    let desc_a = TensorDescriptor::new(
-        cutensor,
-        &layout.lhs_extents,
-        &layout.lhs_strides,
-        T::DATA_TYPE,
-        CUDA_ALLOCATION_ALIGNMENT,
-        OP,
-    )?;
-    let desc_b = TensorDescriptor::new(
-        cutensor,
-        &layout.rhs_extents,
-        &layout.rhs_strides,
-        T::DATA_TYPE,
-        CUDA_ALLOCATION_ALIGNMENT,
-        OP,
-    )?;
-    let desc_out = TensorDescriptor::new(
-        cutensor,
-        &layout.output_extents,
-        &layout.output_strides,
-        T::DATA_TYPE,
-        CUDA_ALLOCATION_ALIGNMENT,
-        OP,
-    )?;
-    let op_desc = OperationDescriptor::new_contraction_with_ops(
-        cutensor,
-        &desc_a,
-        &layout.lhs_modes,
-        cutensor_conj_op::<T>(lhs_conj),
-        &desc_b,
-        &layout.rhs_modes,
-        cutensor_conj_op::<T>(rhs_conj),
-        &desc_out,
-        &layout.output_modes,
-        &desc_out,
-        &layout.output_modes,
-        T::compute_descriptor(cutensor),
-        OP,
-    )?;
-    let pref = PlanPreference::new_default(cutensor, OP)?;
-    let workspace_size = cutensor.estimate_workspace_size(
-        &op_desc,
-        &pref,
-        CutensorWorksizePreference::Default,
-        OP,
-    )?;
-    let plan = Plan::new(cutensor, &op_desc, &pref, workspace_size, OP)?;
-    let workspace = alloc_workspace(backend.runtime(), workspace_size)?;
-
     let lhs_ptr = typed_device_ptr(backend.runtime(), lhs)?;
     let rhs_ptr = typed_device_ptr(backend.runtime(), rhs)?;
     let output_ptr = typed_device_ptr(backend.runtime(), &output)?;
@@ -860,9 +1078,21 @@ where
     let alpha = T::one();
     let beta = T::zero();
     let stream = raw_stream(backend.runtime())?;
-    unsafe {
+    let spec = CutensorContractionSpec {
+        layout: &layout,
+        lhs_strides: &layout.lhs_strides,
+        rhs_strides: &layout.rhs_strides,
+        output_strides: &layout.output_strides,
+        lhs_alignment_requirement: CUDA_ALLOCATION_ALIGNMENT,
+        rhs_alignment_requirement: CUDA_ALLOCATION_ALIGNMENT,
+        output_alignment_requirement: CUDA_ALLOCATION_ALIGNMENT,
+        lhs_conj,
+        rhs_conj,
+        workspace_preference: CutensorWorksizePreference::Default,
+    };
+    cached_cutensor_contraction::<T, _>(backend, &spec, |cutensor, plan, workspace| unsafe {
         cutensor.contract(
-            &plan,
+            plan,
             &alpha as *const T as *const c_void,
             lhs_ptr as *const c_void,
             rhs_ptr as *const c_void,
@@ -873,8 +1103,8 @@ where
             workspace.size,
             stream,
             OP,
-        )?;
-    }
+        )
+    })?;
 
     Ok(output)
 }
@@ -885,6 +1115,109 @@ fn cutensor_conj_op<T: CutensorScalar>(conj: bool) -> CutensorOperator {
     } else {
         CutensorOperator::Identity
     }
+}
+
+fn default_cutensor_plan_cache_max_entries() -> NonZeroUsize {
+    NonZeroUsize::new(DEFAULT_CUTENSOR_PLAN_CACHE_MAX_ENTRIES).unwrap_or(NonZeroUsize::MIN)
+}
+
+fn new_cutensor_plan_cache_state(max_entries: NonZeroUsize) -> CutensorPlanCacheState {
+    Arc::new(Mutex::new(CutensorContractionPlanCache::new(max_entries)))
+}
+
+fn get_or_init_cutensor_plan_cache(backend: &CudaBackend) -> crate::Result<CutensorPlanCacheState> {
+    let guard = backend
+        .cuda_extension_cache()
+        .get_or_try_init::<CutensorPlanCacheState>(|| {
+            Ok(new_cutensor_plan_cache_state(
+                default_cutensor_plan_cache_max_entries(),
+            ))
+        })?;
+    Ok(Arc::clone(&guard))
+}
+
+fn lock_cutensor_plan_cache(
+    cache: &CutensorPlanCacheState,
+) -> crate::Result<std::sync::MutexGuard<'_, CutensorContractionPlanCache>> {
+    cache
+        .lock()
+        .map_err(|_| Error::runtime_state("cutensor_plan_cache", "plan cache lock poisoned"))
+}
+
+pub(super) fn cutensor_plan_cache_stats(backend: &CudaBackend) -> crate::Result<CacheStats> {
+    let Some(plan_cache) = backend
+        .cuda_extension_cache()
+        .get_cloned::<CutensorPlanCacheState>()?
+    else {
+        return Ok(CacheStats::empty());
+    };
+    let plan_cache = lock_cutensor_plan_cache(&plan_cache)?;
+    Ok(plan_cache.stats())
+}
+
+pub(super) fn cutensor_plan_cache_max_entries(
+    backend: &CudaBackend,
+) -> crate::Result<NonZeroUsize> {
+    let Some(plan_cache) = backend
+        .cuda_extension_cache()
+        .get_cloned::<CutensorPlanCacheState>()?
+    else {
+        return Ok(default_cutensor_plan_cache_max_entries());
+    };
+    let plan_cache = lock_cutensor_plan_cache(&plan_cache)?;
+    Ok(plan_cache.max_entries())
+}
+
+pub(super) fn set_cutensor_plan_cache_max_entries(
+    backend: &CudaBackend,
+    max_entries: NonZeroUsize,
+) -> crate::Result<()> {
+    let plan_cache = get_or_init_cutensor_plan_cache(backend)?;
+    let mut plan_cache = lock_cutensor_plan_cache(&plan_cache)?;
+    plan_cache.set_max_entries(max_entries);
+    let retained_bytes = plan_cache.retained_bytes();
+    backend
+        .cuda_extension_cache()
+        .update_retained_bytes::<CutensorPlanCacheState>(retained_bytes)
+}
+
+fn cached_cutensor_contraction<T, R>(
+    backend: &CudaBackend,
+    spec: &CutensorContractionSpec<'_>,
+    execute: impl FnOnce(&CutensorHandle, &Plan, &Workspace) -> crate::Result<R>,
+) -> crate::Result<R>
+where
+    T: CutensorScalar,
+{
+    let cutensor = backend.cutensor_handle()?;
+    let key = CutensorContractionKey::from_spec::<T>(spec);
+    let plan_cache = get_or_init_cutensor_plan_cache(backend)?;
+    let mut plan_cache = lock_cutensor_plan_cache(&plan_cache)?;
+    plan_cache.ensure::<T>(backend.runtime(), cutensor, &key, spec)?;
+    let retained_bytes = plan_cache.retained_bytes();
+    backend
+        .cuda_extension_cache()
+        .update_retained_bytes::<CutensorPlanCacheState>(retained_bytes)?;
+    let cached = plan_cache.get(&key)?;
+    execute(cutensor, &cached.plan, &cached.workspace)
+}
+
+fn validate_descriptor_alignment(
+    actual_alignment: u32,
+    alignment_requirement: u32,
+    slot: &'static str,
+) -> crate::Result<()> {
+    if actual_alignment >= alignment_requirement {
+        return Ok(());
+    }
+    Err(Error::invalid_argument(
+        OP,
+        "alignment",
+        format!(
+            "{slot} device pointer alignment {actual_alignment} is smaller than the cuTENSOR \
+             descriptor requirement {alignment_requirement}"
+        ),
+    ))
 }
 
 fn raw_stream(rt: &CudaRuntime) -> crate::Result<CutensorCudaStream> {

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -346,6 +346,14 @@ impl CudaExtensionCacheInner {
             ..self.stats
         }
     }
+
+    fn refresh_retained_bytes(&mut self) {
+        self.retained_bytes = self
+            .entries
+            .values()
+            .map(|entry| entry.retained_bytes)
+            .sum();
+    }
 }
 
 impl CudaExtensionCache {
@@ -526,6 +534,50 @@ impl CudaExtensionCache {
             _marker: std::marker::PhantomData,
         })
     }
+
+    pub(crate) fn get_cloned<T>(&self) -> crate::Result<Option<T>>
+    where
+        T: Clone + 'static,
+    {
+        let inner = self.lock_inner()?;
+        inner
+            .entries
+            .get(&TypeId::of::<T>())
+            .map(|entry| {
+                entry.value.downcast_ref::<T>().cloned().ok_or_else(|| {
+                    crate::Error::runtime_state(
+                        "cuda_extension_cache",
+                        format!(
+                            "stored entry for {} is missing or has the wrong type",
+                            std::any::type_name::<T>()
+                        ),
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    /// Update the logical retained-byte estimate for an existing typed entry.
+    ///
+    /// This supports extension states whose own internal cache grows after the
+    /// top-level entry is initialized. If another thread clears or evicts the
+    /// typed entry before the update, the update is treated as a no-op.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
+    pub(crate) fn update_retained_bytes<T: 'static>(
+        &self,
+        retained_bytes: usize,
+    ) -> crate::Result<()> {
+        let type_id = TypeId::of::<T>();
+        let mut inner = self.lock_inner()?;
+        if let Some(entry) = inner.entries.get_mut(&type_id) {
+            entry.retained_bytes = retained_bytes;
+            inner.refresh_retained_bytes();
+            inner.evict_to_limit();
+        }
+        Ok(())
+    }
 }
 
 impl Default for CudaExtensionCache {
@@ -691,6 +743,40 @@ impl CudaBackend {
         self.inner
             .extension_cache
             .set_max_retained_bytes(max_retained_bytes)
+    }
+
+    /// Return cuTENSOR contraction plan cache stats.
+    ///
+    /// The returned entry count is the number of retained cuTENSOR contraction
+    /// plans inside the CUDA backend's extension cache entry. Logical retained
+    /// bytes include cached cuTENSOR device workspace estimates.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
+    pub fn cutensor_plan_cache_stats(&self) -> crate::Result<CacheStats> {
+        gemm::cutensor_plan_cache_stats(self)
+    }
+
+    /// Return the cuTENSOR contraction plan entry bound.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
+    pub fn cutensor_plan_cache_max_entries(&self) -> crate::Result<NonZeroUsize> {
+        gemm::cutensor_plan_cache_max_entries(self)
+    }
+
+    /// Configure the cuTENSOR contraction plan entry bound.
+    ///
+    /// The cache is initialized if it does not already exist so a setting made
+    /// before the first CUDA `dot_general` call is preserved.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
+    pub fn set_cutensor_plan_cache_max_entries(
+        &self,
+        max_entries: NonZeroUsize,
+    ) -> crate::Result<()> {
+        gemm::set_cutensor_plan_cache_max_entries(self, max_entries)
     }
 
     fn transpose_typed<T>(

--- a/crates/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
@@ -9,7 +9,7 @@ use crate::cubecl::{CudaBackend, CudaExtensionCache};
 use crate::{
     Buffer, CubeclBuffer, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, TypedTensor,
 };
-use tenferro_tensor::{Error, ErrorKind, ValidationError, ValidationKind};
+use tenferro_tensor::{CacheStats, Error, ErrorKind, ValidationError, ValidationKind};
 
 #[test]
 fn scalar_reduction_shape_stays_separate_from_cubecl_launch_metadata() {
@@ -163,11 +163,36 @@ fn cuda_extension_cache_has_configurable_retained_byte_bound() {
 }
 
 #[test]
+fn cuda_extension_cache_allows_dynamic_retained_byte_updates() {
+    let cache = CudaExtensionCache::with_max_entries(NonZeroUsize::new(8).unwrap());
+    let value = cache.get_or_try_init::<usize>(|| Ok(17)).unwrap();
+    assert_eq!(*value, 17);
+    drop(value);
+
+    cache.update_retained_bytes::<usize>(4096).unwrap();
+    let stats = cache.stats().unwrap();
+    assert_eq!(stats.entries, 1);
+    assert_eq!(stats.retained_bytes, 4096);
+
+    cache
+        .set_max_retained_bytes(NonZeroUsize::new(1024).unwrap())
+        .unwrap();
+    assert!(cache.is_empty().unwrap());
+    assert_eq!(cache.stats().unwrap().evictions, 1);
+}
+
+#[test]
 fn cuda_backend_exposes_extension_cache_retained_byte_controls() {
     let _getter: fn(&CudaBackend) -> crate::Result<NonZeroUsize> =
         CudaBackend::cuda_extension_cache_max_retained_bytes;
     let _setter: fn(&CudaBackend, NonZeroUsize) -> crate::Result<()> =
         CudaBackend::set_cuda_extension_cache_max_retained_bytes;
+    let _cutensor_stats: fn(&CudaBackend) -> crate::Result<CacheStats> =
+        CudaBackend::cutensor_plan_cache_stats;
+    let _cutensor_getter: fn(&CudaBackend) -> crate::Result<NonZeroUsize> =
+        CudaBackend::cutensor_plan_cache_max_entries;
+    let _cutensor_setter: fn(&CudaBackend, NonZeroUsize) -> crate::Result<()> =
+        CudaBackend::set_cutensor_plan_cache_max_entries;
 }
 
 #[test]

--- a/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
@@ -1516,6 +1516,50 @@ fn cubecl_extension_cache_guard_validates_downcast_before_deref() {
 }
 
 #[test]
+fn cutensor_contractions_use_structural_plan_cache_without_pointer_alignment_keys() {
+    let source = cubecl_source("gemm.rs");
+    let key_source = source_section(
+        &source,
+        "struct CutensorContractionKey",
+        "struct CachedCutensorContraction",
+    );
+
+    assert!(
+        key_source.contains("workspace_preference: CutensorWorksizePreference"),
+        "cuTENSOR plan cache keys should include the workspace preference used to build the plan"
+    );
+    assert!(
+        key_source.contains("alignment_requirement"),
+        "cuTENSOR plan cache keys should store descriptor alignment requirements"
+    );
+    assert!(
+        !key_source.contains("ptr") && !key_source.contains("address_alignment"),
+        "cuTENSOR plan cache keys must not include allocation-specific pointers or actual pointer alignment"
+    );
+    assert!(
+        source.contains("struct CachedCutensorContraction"),
+        "cuTENSOR contractions should cache descriptor/plan/workspace state"
+    );
+    assert!(
+        source.contains("fn cached_cutensor_contraction"),
+        "both CUDA dot_general paths should share the cached cuTENSOR plan construction path"
+    );
+    assert!(
+        source.contains("update_retained_bytes::<"),
+        "cached cuTENSOR workspace bytes should be reported through the runtime-owned cache"
+    );
+    assert!(
+        source.contains("pub(super) fn cutensor_plan_cache_stats")
+            && source.contains("pub(super) fn set_cutensor_plan_cache_max_entries"),
+        "cuTENSOR plan cache should expose owner-routed stats and bound configuration"
+    );
+    assert!(
+        source.contains("workspace.size"),
+        "cuTENSOR retained-byte accounting should include cached device workspace bytes"
+    );
+}
+
+#[test]
 fn cutensor_drop_paths_report_destroy_status() {
     let source = cubecl_source("ffi/cutensor.rs");
     for banned in [

--- a/crates/tenferro-gpu/tests/integration/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/public_surface_contract.rs
@@ -151,9 +151,10 @@ fn cuda_dot_general_stays_cutensor_backed_and_not_cubek_rewired() {
         "CUDA dot_general must remain cuTENSOR-backed in this work"
     );
     assert!(
-        cuda_gemm.contains("alloc_workspace(backend.runtime(), workspace_size)")
+        cuda_gemm.contains("cached_cutensor_contraction::<")
+            && cuda_gemm.contains("alloc_workspace(rt, workspace_size)")
             && cuda_gemm.contains("Plan::new(cutensor, &op_desc"),
-        "CUDA workspace and plan flow must remain visible"
+        "CUDA workspace and plan flow must remain visible through the cuTENSOR cache helper"
     );
     assert!(
         !cuda_gemm.contains("cubek_matmul") && !cuda_gemm.contains("DotGeneralPlan"),

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -215,6 +215,23 @@ logical retained bytes, and event counters with
 Retained bytes are estimates of cache-owned payloads, not process RSS or
 allocator arena usage.
 
+CUDA `dot_general` stores cuTENSOR contraction descriptors, plans, and device
+workspace inside this backend-owned extension cache. The cuTENSOR plan key is
+structural: dtype, extents, strides, modes, conjugation flags, descriptor
+alignment requirements, and workspace preference. It must not include
+allocation addresses or actual pointer-specific alignment. Whole-allocation
+operands keep the CUDA allocation alignment requirement; borrowed views use a
+conservative dtype-size descriptor alignment requirement so the cached plan
+remains valid across different view offsets without using pointer-specific
+alignment. Cached device workspace bytes are included in the logical
+retained-byte estimate and are released by normal extension-cache eviction or
+`CudaBackend::clear_cuda_extension_cache`. The overall extension cache stats
+report the retained typed cache entry. Use
+`CudaBackend::cutensor_plan_cache_stats`,
+`CudaBackend::cutensor_plan_cache_max_entries`, and
+`CudaBackend::set_cutensor_plan_cache_max_entries` for cuTENSOR plan-entry
+introspection and bound configuration.
+
 WebGPU provider caches must be owned by `WebGpuBackend` or a WebGPU runtime
 cache object with the same bounded-default, clear, configure, and stats
 requirements before they become long-lived.
@@ -234,10 +251,11 @@ shape across CUDA, WebGPU, and future ROCm:
 | `high_water_retained_bytes` | Peak logical retained bytes |
 
 This common stats design is future direction only. It must not be introduced by
-rewriting existing CUDA contraction allocation behavior. CUDA `dot_general`
-continues to allocate cuTENSOR workspace through the existing runtime client
-path, and this WebGPU work does not alter CUDA buffer pools, CUDA scratch
-reuse, or CUDA library-call algorithms.
+rewriting existing CUDA contraction allocation behavior into an unowned global
+pool. CUDA `dot_general` may retain cuTENSOR-owned contraction workspace only
+through the explicit `CudaBackend` extension cache described above; WebGPU work
+must not alter CUDA buffer pools, CUDA scratch reuse, or CUDA library-call
+algorithms.
 
 ## Operation-Crate Interop Boundary
 

--- a/docs/worklogs/2026-07-27-cutensor-plan-cache-1485.md
+++ b/docs/worklogs/2026-07-27-cutensor-plan-cache-1485.md
@@ -1,0 +1,67 @@
+# 2026-07-27 cuTENSOR Plan Cache (#1485)
+
+## Scope
+
+CUDA `dot_general` now reuses cuTENSOR contraction descriptors, plans, and
+device workspace through the `CudaBackend` extension cache. The cache is owned
+by the backend, uses bounded defaults, reports logical retained bytes through
+the existing CUDA cache stats, and is cleared by
+`CudaBackend::clear_cuda_extension_cache`.
+
+The key is structural: dtype, extents, strides, modes, conjugation flags,
+descriptor alignment requirements, and workspace preference. It intentionally
+does not include allocation addresses or actual pointer-specific alignment.
+Whole tensors keep the CUDA allocation alignment requirement. Borrowed views
+use a conservative dtype-size alignment requirement; using `1` was rejected by
+cuTENSOR for f64 view descriptors on the local A100 smoke tests.
+
+The inner cuTENSOR plan-entry cache has separate owner-routed introspection and
+bound configuration through `CudaBackend::cutensor_plan_cache_stats`,
+`CudaBackend::cutensor_plan_cache_max_entries`, and
+`CudaBackend::set_cutensor_plan_cache_max_entries`. The outer CUDA extension
+cache still owns the typed cache entry and aggregate retained-byte bound.
+
+## Local A100 Benchmark
+
+Environment:
+
+- GPU: NVIDIA A100 80GB PCIe
+- Driver: 580.126.09
+- cuTENSOR: `/usr/lib/x86_64-linux-gnu/libcutensor/12/libcutensor.so.2`
+- CUDA toolkit: `/usr/local/cuda`
+
+Command:
+
+```bash
+CUDA_PATH=/usr/local/cuda \
+LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} \
+CUBECL_DEBUG_LOG=0 \
+CARGO_BUILD_JOBS=64 \
+cargo bench -p tenferro-gpu --features cuda --bench cutensor_plan_cache -- \
+  --sample-size 10 --warm-up-time 0.1 --measurement-time 0.3
+```
+
+Results compare a cold path that clears `CudaBackend` extension caches before
+each iteration against the warm backend-owned cache:
+
+| Case | Cold clear each iter | Warm cache |
+| --- | ---: | ---: |
+| f32 64x64x64 | 100.84 us | 60.633 us |
+| f64 64x64x64 | 108.77 us | 65.224 us |
+| f32 256x256x256 | 101.99 us | 64.001 us |
+| f64 256x256x256 | 98.891 us | 63.395 us |
+
+This benchmark isolates repeated same-shape cuTENSOR setup overhead. It should
+not be treated as an end-to-end workload share measurement.
+
+## Verification
+
+Focused checks:
+
+```bash
+CARGO_BUILD_JOBS=64 cargo test -p tenferro-gpu --test integration -- --nocapture
+CARGO_BUILD_JOBS=64 cargo test -p tenferro-gpu --features cuda --test integration -- --nocapture
+CUDA_PATH=/usr/local/cuda LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} CUBECL_DEBUG_LOG=0 CARGO_BUILD_JOBS=64 cargo test -p tenferro-gpu --features cuda test_dot_general_matmul -- --ignored --nocapture
+CUDA_PATH=/usr/local/cuda LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} CUBECL_DEBUG_LOG=0 CARGO_BUILD_JOBS=64 cargo test -p tenferro-gpu --features cuda test_accum_ -- --ignored --nocapture
+CARGO_BUILD_JOBS=64 cargo bench -p tenferro-gpu --features cuda --bench cutensor_plan_cache --no-run
+```


### PR DESCRIPTION
## Summary

Closes #1485.
Refs #1489.

- adds a backend-owned cuTENSOR contraction descriptor/plan/workspace cache under `CudaBackend`
- keeps the cache key structural: dtype, extents, strides, modes, conjugation flags, descriptor alignment requirements, and workspace preference; no allocation pointers or actual pointer-specific alignment in the key
- exposes cuTENSOR plan-cache stats and entry-bound configuration through `CudaBackend`
- adds a CUDA benchmark comparing cold-clear per iteration against warm plan/workspace reuse
- documents the cache ownership/key policy and local A100 benchmark results

## Benchmark

Local A100 80GB PCIe, driver 580.126.09, cuTENSOR `/usr/lib/x86_64-linux-gnu/libcutensor/12/libcutensor.so.2`:

| Case | Cold clear each iter | Warm cache |
| --- | ---: | ---: |
| f32 64x64x64 | 100.84 us | 60.633 us |
| f64 64x64x64 | 108.77 us | 65.224 us |
| f32 256x256x256 | 101.99 us | 64.001 us |
| f64 256x256x256 | 98.891 us | 63.395 us |

This isolates repeated same-shape cuTENSOR setup overhead; it is not an end-to-end workload share measurement.

## Verification

- `CARGO_BUILD_JOBS=64 CUDA_PATH=/usr/local/cuda LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} CUBECL_DEBUG_LOG=0 bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-gpu --test integration -- --nocapture' --test 'cargo test -p tenferro-gpu --features cuda -- --nocapture' --test 'cargo bench -p tenferro-gpu --features cuda --bench cutensor_plan_cache --no-run'`
- `CUDA_PATH=/usr/local/cuda LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} CUBECL_DEBUG_LOG=0 CARGO_BUILD_JOBS=64 cargo test -p tenferro-gpu --features cuda test_dot_general_matmul -- --ignored --nocapture`
- `CUDA_PATH=/usr/local/cuda LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} CUBECL_DEBUG_LOG=0 CARGO_BUILD_JOBS=64 cargo test -p tenferro-gpu --features cuda test_accum_ -- --ignored --nocapture`
- `CUDA_PATH=/usr/local/cuda LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} CUBECL_DEBUG_LOG=0 CARGO_BUILD_JOBS=64 cargo bench -p tenferro-gpu --features cuda --bench cutensor_plan_cache -- --sample-size 10 --warm-up-time 0.1 --measurement-time 0.3`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-1485.json`

## Notes

- `cargo clippy -p tenferro-gpu --features cuda --all-targets -- -D warnings` currently fails on existing CUDA-feature lint debt under Rust/Clippy 1.97 unrelated to this diff; default-feature workspace clippy passes through `check-pr-fast`.
