### PR TITLE
Adopt strided gather plan in CPU backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "6b0b4a46b7dd9a9ea1677a0d596c0b4adab1acbc", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "6b0b4a46b7dd9a9ea1677a0d596c0b4adab1acbc", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "6b0b4a46b7dd9a9ea1677a0d596c0b4adab1acbc", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "6b0b4a46b7dd9a9ea1677a0d596c0b4adab1acbc", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "6b0b4a46b7dd9a9ea1677a0d596c0b4adab1acbc", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "cfe90bd2fba38452f32fcdc9df120bb4dd28d151", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "cfe90bd2fba38452f32fcdc9df120bb4dd28d151", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "cfe90bd2fba38452f32fcdc9df120bb4dd28d151", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "cfe90bd2fba38452f32fcdc9df120bb4dd28d151", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "cfe90bd2fba38452f32fcdc9df120bb4dd28d151", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -680,8 +680,8 @@ Tests follow implementation ownership.
 - No naive CPU loop fallbacks. CPU tensor kernels must use optimized
   implementations unless the operation is explicitly listed as an exception
   below.
-- CPU affine-strided copy, permutation, broadcast, map, zip-map, and axis reduction
-  delegate to `strided-rs`. Tenferro owns tensor semantics, validation, dtype
+- CPU affine-strided copy, permutation, broadcast, map, zip-map, axis reduction,
+  and gather delegate to `strided-rs`. Tenferro owns tensor semantics, validation, dtype
   dispatch, placement checks, error translation, execution contexts, and
   reusable output storage; it does not duplicate the tensor-sized affine
   traversal.
@@ -692,6 +692,7 @@ Tests follow implementation ownership.
   | Elementwise (`add`, `mul`, `neg`, `exp`, ...) | `strided-kernel` (`map_into`, `zip_map2_into`, etc.) |
   | Reduction (`reduce_sum`, `reduce_prod`, ...) | `strided-kernel` (`reduce`, `reduce_axis`) |
   | Structural (`transpose`, `broadcast`, `extract_diag`) | `strided-kernel` (`permute` + `copy_into`, `broadcast`, `diagonal_view`) |
+  | Gather | `strided-kernel` (`ErasedGatherPlan`) |
   | GEMM (`dot_general`) | faer (`cpu-faer`) or BLAS (`cpu-blas`) |
   | Linalg (`svd`, `qr`, `cholesky`, `eigh`, `solve`) | faer (`cpu-faer`) or LAPACK (`cpu-blas`) |
 
@@ -703,7 +704,8 @@ Tests follow implementation ownership.
   | Broadcast | Zero-stride broadcast views and bulk copy/map traversal | Broadcast dimension semantics, output shape, placement, and allocation |
   | Unary map and binary zip-map | Affine iteration, tiling, and parallel execution | Operation semantics, dtype dispatch/promotion, capability checks, and errors |
   | Axis reduction | Per-axis strided reduction kernels | Multi-axis orchestration, axis validation, identities, dtype policy, and output wrapping |
-  | Gather/scatter and indirect indexing | No ownership until a suitable general primitive exists | Indirect-index semantics and current dedicated kernels |
+  | Gather | Indexed-read traversal and erased replay dispatch | Gather semantics, index validation/normalization, dtype dispatch, output allocation, and error translation |
+  | Scatter and other indirect indexing | No ownership until a suitable general primitive exists | Indirect-index semantics and current dedicated kernels |
   | Einsum/dot-general | Reusable strided primitives may be consumed where they fit | Planning, optimized preparation, provider integration, and benchmark accountability |
 
 <!-- TENFERRO_CPU_STRIDED_OWNERSHIP_CONTRACT_BEGIN -->
@@ -711,7 +713,7 @@ Tests follow implementation ownership.
   ```text
   schema = tenferro.cpu-strided-ownership.v1
   affine-kernel-owner = strided-rs
-  affine-kernels = copy,permutation,broadcast,map,zip-map,axis-reduction
+  affine-kernels = copy,permutation,broadcast,map,zip-map,axis-reduction,gather
   einsum-owner = tenferro:benchmark-backed-exception
   execution-entry = CpuBackend
   execution-resources = persistent-BufferPool,uninitialized-full-overwrite,CpuContext-Rayon,nested-execution,serial-parallel-threshold
@@ -742,7 +744,7 @@ Tests follow implementation ownership.
   transforms and do not own data-moving convenience methods.
 - Exceptions with dedicated implementations are `reshape` (metadata-only),
   `embed_diagonal`, index-dependent triangular masks (`tril`/`triu`), and
-  indexing ops such as gather, scatter, slice, pad, concatenate, and reverse.
+  indexing ops such as scatter, slice, pad, concatenate, and reverse.
 - CPU provider features are additive. At least one of `cpu-faer` or `cpu-blas`
   must be enabled; enabling both is valid and must compile. `CpuBackend` owns
   the runtime provider selection. `CpuBackend::new()` selects the default

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -157,9 +157,12 @@ fn native_kernel_modules_cannot_select_ambient_or_ad_hoc_execution_policies() {
             .count(),
         1
     );
+    assert!(!provider.contains("ExecContext::ambient("));
     for (name, source) in native_modules {
         assert!(
-            !source.contains("ExecutionPolicy::") && !source.contains("with_execution_policy("),
+            !source.contains("ExecutionPolicy::")
+                && !source.contains("with_execution_policy(")
+                && !source.contains("ExecContext::ambient("),
             "{name} must inherit native policy from CpuExecutionContext"
         );
         assert!(

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -1,18 +1,25 @@
+use std::mem::size_of_val;
 use std::ops::Add;
 
 use num_traits::Zero;
+use strided_kernel::{
+    col_major_strides, ErasedGatherPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext,
+    GatherSpec, KernelDType,
+};
 
 use super::indexing_alloc::pooled_uninit_tensor;
 use super::typed_host_data;
 use crate::buffer_pool::{BufferPool, PoolScalar};
-use tenferro_tensor::{GatherConfig, PadConfig, ScatterConfig, SliceConfig};
+use tenferro_tensor::TensorScalar;
+use tenferro_tensor::{DType, GatherConfig, PadConfig, ScatterConfig, SliceConfig};
 use tenferro_tensor::{Tensor, TypedTensor};
 
-// Indexing-family kernels stay as dedicated sequential loops for now. Their
-// per-output gather/scatter/slice/pad/concatenate/reverse index transforms do
-// not currently map to a strided-kernel or backend-native parallel primitive.
-// Backend entrypoints still run these loops inside CpuContext::install, so a
-// future parallel implementation can use the same CPU threading policy.
+// Most indexing-family kernels stay as dedicated sequential loops for now.
+// Scatter/slice/pad/concatenate/reverse still have per-output index transforms
+// without a matching strided-kernel or backend-native parallel primitive.
+// Gather delegates its bulk traversal to strided-kernel's erased gather plan.
+// Backend entrypoints run these kernels inside CpuContext::install, so future
+// parallel implementations can use the same CPU threading policy.
 
 trait TensorAsTyped<T> {
     fn as_typed(&self) -> Option<&TypedTensor<T>>;
@@ -42,6 +49,41 @@ impl_tensor_as_typed!(
     (num_complex::Complex<f32>, C32),
     (num_complex::Complex<f64>, C64),
 );
+
+fn kernel_dtype(dtype: DType) -> KernelDType {
+    match dtype {
+        DType::F32 => KernelDType::F32,
+        DType::F64 => KernelDType::F64,
+        DType::I32 => KernelDType::I32,
+        DType::I64 => KernelDType::I64,
+        DType::Bool => KernelDType::Bool,
+        DType::C32 => KernelDType::C32,
+        DType::C64 => KernelDType::C64,
+    }
+}
+
+fn typed_bytes<T>(data: &[T]) -> &[u8] {
+    // SAFETY: `data` is an aligned typed slice. The returned byte slice has
+    // the same lifetime and exact byte length, and is read-only.
+    unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), size_of_val(data)) }
+}
+
+fn typed_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    // SAFETY: `data` is an aligned typed slice. The returned byte slice has
+    // the same lifetime and exact byte length; callers must preserve the
+    // dtype's byte validity invariants before typed reads resume.
+    unsafe { std::slice::from_raw_parts_mut(data.as_mut_ptr().cast::<u8>(), size_of_val(data)) }
+}
+
+fn gather_spec(config: &GatherConfig) -> GatherSpec {
+    GatherSpec {
+        offset_dims: config.offset_dims.clone(),
+        collapsed_slice_dims: config.collapsed_slice_dims.clone(),
+        start_index_map: config.start_index_map.clone(),
+        index_vector_dim: config.index_vector_dim,
+        slice_sizes: config.slice_sizes.clone(),
+    }
+}
 
 macro_rules! dispatch_tensor_unary_result {
     ($input:expr, |$tensor:ident| $body:expr) => {
@@ -818,7 +860,7 @@ fn operand_window_dims(rank: usize, collapsed_or_inserted: &[usize]) -> Vec<usiz
         .collect()
 }
 
-fn typed_gather<T: Copy + Clone + PoolScalar>(
+fn typed_gather<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
     operand: &TypedTensor<T>,
     start_indices: &IndexTensor,
@@ -954,60 +996,63 @@ fn typed_gather<T: Copy + Clone + PoolScalar>(
         }
     }
 
-    for &operand_dim in &config.start_index_map {
-        let _ = clamp_window_start(
-            "gather",
-            0,
-            operand_shape[operand_dim],
-            config.slice_sizes[operand_dim],
-        )?;
+    for (operand_dim, &dim_size) in operand_shape.iter().enumerate() {
+        let _ = clamp_window_start("gather", 0, dim_size, config.slice_sizes[operand_dim])?;
     }
 
-    // SAFETY: the gather loop below assigns every output coordinate exactly once.
     let mut out = pooled_uninit_tensor(buffers, out_shape.clone())?;
-    let mut out_idx = vec![0usize; out_rank];
-    let mut batch_idx = vec![0usize; batch_shape.len()];
-    let mut operand_idx = vec![0usize; rank];
-    let mut window_offsets = vec![0usize; rank];
-    let mut index_scratch = vec![0usize; start_indices.shape.len()];
-
-    for out_value in out.host_data_mut()?.iter_mut() {
-        batch_axis = 0;
-        window_offsets.fill(0);
-        for out_axis in 0..out_rank {
-            if let Some(operand_dim) = out_axis_to_operand_dim[out_axis] {
-                window_offsets[operand_dim] = out_idx[out_axis];
-            } else {
-                batch_idx[batch_axis] = out_idx[out_axis];
-                batch_axis += 1;
-            }
-        }
-
-        operand_idx.fill(0);
-        for (component, &operand_dim) in config.start_index_map.iter().enumerate() {
-            let start = index_component(
-                "gather",
-                start_indices,
-                &batch_idx,
-                config.index_vector_dim,
-                component,
-                &mut index_scratch,
-            )?;
-            operand_idx[operand_dim] = clamp_window_start(
-                "gather",
-                start,
-                operand_shape[operand_dim],
-                config.slice_sizes[operand_dim],
-            )?;
-        }
-
-        for axis in 0..operand_idx.len() {
-            operand_idx[axis] += window_offsets[axis];
-        }
-
-        *out_value = *operand.get(&operand_idx)?;
-        advance_col_major_index(&mut out_idx, &out_shape);
+    if T::dtype() == DType::Bool {
+        out.host_data_mut()?.fill(T::pool_zero());
     }
+
+    let dtype = kernel_dtype(T::dtype());
+    let operand_strides = col_major_strides(operand_shape);
+    let index_strides = col_major_strides(&start_indices.shape);
+    let out_strides = col_major_strides(&out_shape);
+    let plan = ErasedGatherPlan::compile(
+        dtype,
+        KernelDType::I64,
+        operand_shape,
+        &operand_strides,
+        &start_indices.shape,
+        &index_strides,
+        &out_shape,
+        &out_strides,
+        gather_spec(config),
+    )
+    .map_err(|err| crate::Error::backend_source("gather", err))?;
+
+    let operand_ref = ErasedRawStridedRef::new(
+        dtype,
+        typed_bytes(typed_host_data("gather", operand)?),
+        operand_shape,
+        &operand_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("gather", err))?;
+    let index_ref = ErasedRawStridedRef::new(
+        KernelDType::I64,
+        typed_bytes(&start_indices.values),
+        &start_indices.shape,
+        &index_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("gather", err))?;
+    let mut out_ref = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(out.host_data_mut()?),
+        &out_shape,
+        &out_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("gather", err))?;
+    plan.execute(
+        &ExecContext::serial(),
+        &mut out_ref,
+        &operand_ref,
+        &index_ref,
+    )
+    .map_err(|err| crate::Error::backend_source("gather", err))?;
 
     Ok(out)
 }

--- a/crates/tenferro-cpu/tests/integration/backend_capability_contracts.rs
+++ b/crates/tenferro-cpu/tests/integration/backend_capability_contracts.rs
@@ -420,6 +420,22 @@ fn gather_scatter_index_component_reuses_index_scratch() {
 }
 
 #[test]
+fn gather_delegates_bulk_traversal_to_strided_kernel_plan() {
+    let indexing_source = include_str!("../../src/indexing.rs");
+    let typed_gather = rust_function_body(indexing_source, "typed_gather")
+        .expect("typed_gather implementation should exist");
+
+    assert!(
+        typed_gather.contains("ErasedGatherPlan"),
+        "CPU gather bulk traversal should delegate to strided-kernel ErasedGatherPlan"
+    );
+    assert!(
+        typed_gather.contains(".execute("),
+        "CPU gather should execute the prepared strided gather plan"
+    );
+}
+
+#[test]
 fn cpu_public_ops_require_backend_owner() {
     let lib_source = include_str!("../../src/lib.rs");
     for reexport in [
@@ -471,6 +487,7 @@ fn strided_kernel_ownership_requires_backend_execution_resources() {
             "axis-reduction",
             "broadcast",
             "copy",
+            "gather",
             "map",
             "permutation",
             "zip-map",

--- a/docs/worklogs/2026-07-27-strided-gather-adoption.md
+++ b/docs/worklogs/2026-07-27-strided-gather-adoption.md
@@ -1,0 +1,62 @@
+# 2026-07-27 Strided Gather Adoption
+
+## Summary
+
+Updated tenferro-rs to consume the merged strided-rs gather plan API from
+`tensor4all/strided-rs@cfe90bd2fba38452f32fcdc9df120bb4dd28d151`.
+CPU gather now keeps tenferro-owned validation, dtype dispatch, index
+normalization, output allocation, and error translation, but delegates the
+bulk indexed-read traversal to `strided_kernel::ErasedGatherPlan`.
+
+## Context Read
+
+- `AGENTS.md` and `REPOSITORY_RULES.md`
+- shared tensor4all Rust, performance, numerical, and docs/test rules
+- strided-rs PR #154, which merged explicit strided execution policy and the
+  erased gather/reduce plan APIs into strided main
+- `crates/tenferro-cpu/src/indexing.rs`
+- CPU backend/provider source-contract tests for strided ownership and native
+  threading policy
+
+## Decisions
+
+- Keep gather as a CPU backend operation, not a tensor-core helper. The backend
+  still owns the `BufferPool`, host placement checks, and `CpuContext` entry
+  boundary.
+- Use `ErasedGatherPlan` with compact column-major descriptors. Current
+  tenferro owned tensors are compact column-major, so no extra layout
+  canonicalization is introduced in this PR.
+- Keep index tensors normalized to `i64` through tenferro's existing
+  `try_index_tensor` path, and compile the strided gather plan with
+  `KernelDType::I64` indices.
+- Initialize bool output before constructing the erased mutable descriptor.
+  This is only for byte-validity validation at the erased bool boundary; other
+  dtypes still use uninitialized full-overwrite output allocation.
+- Restore `CpuExecutionContext::with_native_parallelism` as the single source
+  of strided execution policy. Native modules inherit this policy and cannot
+  select ambient Rayon or ad hoc policy locally.
+
+## Rejected Or Deferred
+
+- No i32 index zero-copy path yet. It would need a second compile/execute path
+  and should be benchmarked only if index normalization is shown to matter.
+- No new gather parallelism tuning in tenferro. The execution policy boundary
+  is preserved, but the erased plan is invoked with an explicit serial
+  `ExecContext` until strided's gather planner owns a parallel strategy.
+- Scatter, slice, pad, concatenate, and reverse remain tenferro-owned dedicated
+  loops because there is not yet a matching strided primitive for their current
+  semantics.
+
+## Verification
+
+- `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu gather`
+- `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu native`
+- `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu --test integration strided_kernel_ownership_requires_backend_execution_resources`
+
+## Residual Risk
+
+This PR changes CPU gather's implementation owner but not its public semantics.
+The main residual risk is parity between tenferro's validation and strided's
+plan compiler if either side changes independently. The new source-contract
+test makes the ownership boundary explicit, while value tests continue to cover
+representative gather behavior.

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "6b0b4a46b7dd9a9ea1677a0d596c0b4adab1acbc"
+        revision = "cfe90bd2fba38452f32fcdc9df120bb4dd28d151"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
## Summary

- update strided-rs dependencies to the merged gather/execution-policy commit `cfe90bd2fba38452f32fcdc9df120bb4dd28d151`
- route CPU gather bulk traversal through `strided_kernel::ErasedGatherPlan` while keeping tenferro-owned validation, allocation, dtype dispatch, and error translation
- record gather in the CPU strided ownership contract and add source-contract coverage for the new boundary

## Worklog

- `docs/worklogs/2026-07-27-strided-gather-adoption.md`

## Validation

- `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu gather`
- `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu native`
- `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu --test integration strided_kernel_ownership_requires_backend_execution_resources`
- `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true bash scripts/check-pr-fast.sh --coverage-reviewed --test 'CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu gather' --test 'CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu native'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`

## Dependency

- Requires merged tensor4all/strided-rs#154.