### PR TITLE
Delegate CPU hot kernels to strided plans

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "cfe90bd2fba38452f32fcdc9df120bb4dd28d151", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "cfe90bd2fba38452f32fcdc9df120bb4dd28d151", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "cfe90bd2fba38452f32fcdc9df120bb4dd28d151", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "cfe90bd2fba38452f32fcdc9df120bb4dd28d151", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "cfe90bd2fba38452f32fcdc9df120bb4dd28d151", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "20b2def9bf9554605d12fe13762f8770ba732efb", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "20b2def9bf9554605d12fe13762f8770ba732efb", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "20b2def9bf9554605d12fe13762f8770ba732efb", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "20b2def9bf9554605d12fe13762f8770ba732efb", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "20b2def9bf9554605d12fe13762f8770ba732efb", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -680,19 +680,23 @@ Tests follow implementation ownership.
 - No naive CPU loop fallbacks. CPU tensor kernels must use optimized
   implementations unless the operation is explicitly listed as an exception
   below.
-- CPU affine-strided copy, permutation, broadcast, map, zip-map, axis reduction,
-  and gather delegate to `strided-rs`. Tenferro owns tensor semantics, validation, dtype
-  dispatch, placement checks, error translation, execution contexts, and
-  reusable output storage; it does not duplicate the tensor-sized affine
+- CPU affine-strided copy, permutation, broadcast, map, zip-map, fused
+  elementwise replay, sum/product reductions, gather, additive scatter, and
+  fixed-window dynamic slice/update delegate to `strided-rs` when their
+  semantics fit an existing strided plan. Tenferro owns tensor semantics,
+  validation, dtype dispatch, placement checks, error translation, execution
+  contexts, and reusable output storage; it does not duplicate the tensor-sized
   traversal.
 - Required CPU implementations by operation category:
 
   | Category | Required implementation |
   |---|---|
-  | Elementwise (`add`, `mul`, `neg`, `exp`, ...) | `strided-kernel` (`map_into`, `zip_map2_into`, etc.) |
-  | Reduction (`reduce_sum`, `reduce_prod`, ...) | `strided-kernel` (`reduce`, `reduce_axis`) |
+  | Elementwise (`add`, `mul`, `neg`, `exp`, fused eager replay, ...) | `strided-kernel` (`map_into`, `zip_map2_into`, `ErasedFusedPlan`, etc.) |
+  | Reduction (`reduce_sum`, `reduce_prod`) | `strided-kernel` (`ErasedReducePlan::compile_axes`) |
   | Structural (`transpose`, `broadcast`, `extract_diag`) | `strided-kernel` (`permute` + `copy_into`, `broadcast`, `diagonal_view`) |
   | Gather | `strided-kernel` (`ErasedGatherPlan`) |
+  | Additive scatter | `strided-kernel` (`ErasedScatterPlan`) |
+  | Fixed-window dynamic slice/update | `strided-kernel` (`ErasedDynamicSlicePlan`, `ErasedDynamicUpdateSlicePlan`) |
   | GEMM (`dot_general`) | faer (`cpu-faer`) or BLAS (`cpu-blas`) |
   | Linalg (`svd`, `qr`, `cholesky`, `eigh`, `solve`) | faer (`cpu-faer`) or LAPACK (`cpu-blas`) |
 
@@ -702,10 +706,11 @@ Tests follow implementation ownership.
   |---|---|---|
   | Affine-strided copy and permutation | Bulk `copy_into` traversal and serial/parallel kernel selection | Shape, stride, offset, reachable-range, dtype, placement, and destination validation; backend-scoped allocation and error mapping |
   | Broadcast | Zero-stride broadcast views and bulk copy/map traversal | Broadcast dimension semantics, output shape, placement, and allocation |
-  | Unary map and binary zip-map | Affine iteration, tiling, and parallel execution | Operation semantics, dtype dispatch/promotion, capability checks, and errors |
-  | Axis reduction | Per-axis strided reduction kernels | Multi-axis orchestration, axis validation, identities, dtype policy, and output wrapping |
+  | Unary map, binary zip-map, and fused elementwise replay | Affine iteration, tiling, static specialization, and erased replay execution | Operation semantics, dtype dispatch/promotion, capability checks, and errors |
+  | Sum/product reductions | Axis and multi-axis strided reduction replay | Axis validation, identities, dtype policy, output wrapping, and max/min NaN policy exceptions |
   | Gather | Indexed-read traversal and erased replay dispatch | Gather semantics, index validation/normalization, dtype dispatch, output allocation, and error translation |
-  | Scatter and other indirect indexing | No ownership until a suitable general primitive exists | Indirect-index semantics and current dedicated kernels |
+  | Additive scatter and fixed-window dynamic slice/update | Indexed replay traversal for matching erased plans | Index validation/normalization, clamp semantics, dtype dispatch, output allocation, and error translation |
+  | Other indirect indexing | No ownership until a suitable general primitive exists | Indirect-index semantics and current dedicated kernels |
   | Einsum/dot-general | Reusable strided primitives may be consumed where they fit | Planning, optimized preparation, provider integration, and benchmark accountability |
 
 <!-- TENFERRO_CPU_STRIDED_OWNERSHIP_CONTRACT_BEGIN -->
@@ -713,7 +718,7 @@ Tests follow implementation ownership.
   ```text
   schema = tenferro.cpu-strided-ownership.v1
   affine-kernel-owner = strided-rs
-  affine-kernels = copy,permutation,broadcast,map,zip-map,axis-reduction,gather
+  affine-kernels = copy,permutation,broadcast,map,zip-map,fused-elementwise,sum-product-reduction,gather,additive-scatter,dynamic-slice,dynamic-update-slice
   einsum-owner = tenferro:benchmark-backed-exception
   execution-entry = CpuBackend
   execution-resources = persistent-BufferPool,uninitialized-full-overwrite,CpuContext-Rayon,nested-execution,serial-parallel-threshold
@@ -743,8 +748,10 @@ Tests follow implementation ownership.
   backend-neutral tensor/view types therefore expose metadata-only layout
   transforms and do not own data-moving convenience methods.
 - Exceptions with dedicated implementations are `reshape` (metadata-only),
-  `embed_diagonal`, index-dependent triangular masks (`tril`/`triu`), and
-  indexing ops such as scatter, slice, pad, concatenate, and reverse.
+  `embed_diagonal`, index-dependent triangular masks (`tril`/`triu`), max/min
+  reductions until strided exposes matching NaN semantics, and indexing ops
+  without a matching strided plan such as static slice, pad, concatenate, and
+  reverse.
 - CPU provider features are additive. At least one of `cpu-faer` or `cpu-blas`
   must be enabled; enabling both is valid and must compile. `CpuBackend` owns
   the runtime provider selection. `CpuBackend::new()` selects the default

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -173,6 +173,32 @@ fn native_kernel_modules_cannot_select_ambient_or_ad_hoc_execution_policies() {
 }
 
 #[test]
+fn cpu_hot_kernels_delegate_to_erased_strided_replay() {
+    let elementwise = include_str!("../../../tenferro-internal-cpu-kernels/src/elementwise.rs");
+    let indexing = include_str!("../indexing.rs");
+    let reduction = include_str!("../reduction.rs");
+
+    assert!(
+        elementwise.contains("ErasedFusedPlan::compile"),
+        "CPU elementwise fusion should delegate replay to strided-kernel's erased fused plan"
+    );
+    assert!(
+        !elementwise.contains("fused_elementwise_into"),
+        "tenferro-cpu should not instantiate strided generic fused replay directly"
+    );
+    assert!(
+        indexing.contains("ErasedDynamicSlicePlan::compile")
+            && indexing.contains("ErasedDynamicUpdateSlicePlan::compile")
+            && indexing.contains("ErasedScatterPlan::compile"),
+        "CPU indexed slice/update/scatter execution should delegate to erased strided plans"
+    );
+    assert!(
+        reduction.contains("ErasedReducePlan::compile_axes"),
+        "CPU sum/product axis reductions should delegate to erased strided reduce plans"
+    );
+}
+
+#[test]
 fn direct_native_scope_uses_the_selected_rayon_budget() {
     let backend = CpuBackend::with_threads(2).unwrap();
     let participants = backend

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -1,10 +1,10 @@
 use std::mem::size_of_val;
-use std::ops::Add;
 
 use num_traits::Zero;
 use strided_kernel::{
-    col_major_strides, ErasedGatherPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext,
-    GatherSpec, KernelDType,
+    col_major_strides, ErasedDynamicSlicePlan, ErasedDynamicUpdateSlicePlan, ErasedGatherPlan,
+    ErasedRawStridedMut, ErasedRawStridedRef, ErasedScatterPlan, ExecContext, GatherSpec,
+    KernelDType, ScatterSpec,
 };
 
 use super::indexing_alloc::pooled_uninit_tensor;
@@ -14,12 +14,11 @@ use tenferro_tensor::TensorScalar;
 use tenferro_tensor::{DType, GatherConfig, PadConfig, ScatterConfig, SliceConfig};
 use tenferro_tensor::{Tensor, TypedTensor};
 
-// Most indexing-family kernels stay as dedicated sequential loops for now.
-// Scatter/slice/pad/concatenate/reverse still have per-output index transforms
-// without a matching strided-kernel or backend-native parallel primitive.
-// Gather delegates its bulk traversal to strided-kernel's erased gather plan.
-// Backend entrypoints run these kernels inside CpuContext::install, so future
-// parallel implementations can use the same CPU threading policy.
+// Indexed gather, additive scatter, and fixed-window dynamic slice/update
+// delegate bulk traversal to strided-kernel erased plans. Pad/concatenate/
+// reverse still own their operation-specific loops here. Backend entrypoints
+// run these kernels inside CpuContext::install, so future parallel
+// implementations can use the same CPU threading policy.
 
 trait TensorAsTyped<T> {
     fn as_typed(&self) -> Option<&TypedTensor<T>>;
@@ -82,6 +81,15 @@ fn gather_spec(config: &GatherConfig) -> GatherSpec {
         start_index_map: config.start_index_map.clone(),
         index_vector_dim: config.index_vector_dim,
         slice_sizes: config.slice_sizes.clone(),
+    }
+}
+
+fn scatter_spec(config: &ScatterConfig) -> ScatterSpec {
+    ScatterSpec {
+        update_window_dims: config.update_window_dims.clone(),
+        inserted_window_dims: config.inserted_window_dims.clone(),
+        scatter_dims_to_operand_dims: config.scatter_dims_to_operand_dims.clone(),
+        index_vector_dim: config.index_vector_dim,
     }
 }
 
@@ -185,21 +193,6 @@ where
     // SAFETY: the following fill writes every pooled output element.
     let mut out = pooled_uninit_tensor(buffers, shape)?;
     out.host_data_mut()?.fill(fill);
-    Ok(out)
-}
-
-fn clone_host_tensor_from_pool<T>(
-    buffers: &mut BufferPool,
-    op: &'static str,
-    tensor: &TypedTensor<T>,
-) -> crate::Result<TypedTensor<T>>
-where
-    T: Copy + Clone + PoolScalar,
-{
-    // SAFETY: copy_from_slice writes every pooled output element.
-    let mut out = pooled_uninit_tensor(buffers, tensor.shape().to_vec())?;
-    out.host_data_mut()?
-        .copy_from_slice(typed_host_data(op, tensor)?);
     Ok(out)
 }
 
@@ -708,41 +701,6 @@ fn checked_product(op: &'static str, role: &'static str, shape: &[usize]) -> cra
     })
 }
 
-fn linear_offset(op: &'static str, shape: &[usize], indices: &[usize]) -> crate::Result<usize> {
-    if indices.len() != shape.len() {
-        return Err(crate::Error::rank_mismatch(op, shape.len(), indices.len()));
-    }
-    let mut offset = 0usize;
-    let mut stride = 1usize;
-    for (axis, &index) in indices.iter().enumerate() {
-        if index >= shape[axis] {
-            return Err(crate::Error::axis_out_of_bounds(op, axis, shape.len()));
-        }
-        let scaled = index.checked_mul(stride).ok_or_else(|| {
-            crate::Error::invalid_argument(
-                op,
-                "configuration",
-                format!("linear index component overflows usize on axis {axis}"),
-            )
-        })?;
-        offset = offset.checked_add(scaled).ok_or_else(|| {
-            crate::Error::invalid_argument(
-                op,
-                "configuration",
-                format!("linear offset overflows usize on axis {axis}"),
-            )
-        })?;
-        stride = stride.checked_mul(shape[axis]).ok_or_else(|| {
-            crate::Error::invalid_argument(
-                op,
-                "configuration",
-                format!("linear stride overflows usize after axis {axis}"),
-            )
-        })?;
-    }
-    Ok(offset)
-}
-
 fn try_index_vector_size(
     op: &'static str,
     shape: &[usize],
@@ -782,59 +740,6 @@ fn try_index_batch_shape(
         .enumerate()
         .filter_map(|(axis, &dim)| (axis != index_vector_dim).then_some(dim))
         .collect())
-}
-
-fn index_component(
-    op: &'static str,
-    indices: &IndexTensor,
-    batch_idx: &[usize],
-    index_vector_dim: usize,
-    component: usize,
-    index_scratch: &mut [usize],
-) -> crate::Result<i64> {
-    if index_vector_dim == indices.shape.len() {
-        if component != 0 {
-            return Err(crate::Error::invalid_argument(
-                op,
-                "configuration",
-                "implicit index_vector_dim only supports scalar index vectors",
-            ));
-        }
-        return Ok(indices.values[linear_offset(op, &indices.shape, batch_idx)?]);
-    }
-
-    if index_scratch.len() != indices.shape.len() {
-        return Err(crate::Error::invalid_argument(
-            op,
-            "configuration",
-            format!(
-                "index scratch length {} must match index tensor rank {}",
-                index_scratch.len(),
-                indices.shape.len()
-            ),
-        ));
-    }
-    if batch_idx.len() + 1 != indices.shape.len() {
-        return Err(crate::Error::invalid_argument(
-            op,
-            "configuration",
-            format!(
-                "batch index rank {} must be one less than index tensor rank {}",
-                batch_idx.len(),
-                indices.shape.len()
-            ),
-        ));
-    }
-    let mut batch_axis = 0usize;
-    for (axis, slot) in index_scratch.iter_mut().enumerate() {
-        if axis == index_vector_dim {
-            *slot = component;
-        } else {
-            *slot = batch_idx[batch_axis];
-            batch_axis += 1;
-        }
-    }
-    Ok(indices.values[linear_offset(op, &indices.shape, index_scratch)?])
 }
 
 fn clamp_window_start(
@@ -1065,7 +970,7 @@ fn typed_scatter<T>(
     config: &ScatterConfig,
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + Zero + Add<Output = T> + PoolScalar,
+    T: Copy + Clone + PoolScalar + TensorScalar,
 {
     let operand_shape = operand.shape();
     let updates_shape = updates.shape();
@@ -1223,67 +1128,78 @@ where
         let _ = clamp_window_start("scatter", 0, operand_shape[axis], window_shape[axis])?;
     }
 
-    let batch_elems = checked_product("scatter", "batch shape", &batch_shape)?;
-    let window_elems = checked_product("scatter", "window update shape", &window_shape_updates)?;
-    let mut out = clone_host_tensor_from_pool(buffers, "scatter", operand)?;
+    checked_product("scatter", "batch shape", &batch_shape)?;
+    checked_product("scatter", "window update shape", &window_shape_updates)?;
 
-    let mut batch_idx = vec![0usize; batch_shape.len()];
-    let mut window_idx = vec![0usize; window_shape_updates.len()];
-    let mut update_idx = vec![0usize; update_rank];
-    let mut operand_base = vec![0usize; op_rank];
-    let mut operand_idx = vec![0usize; op_rank];
-    let mut index_scratch = vec![0usize; scatter_indices.shape.len()];
+    let dtype = kernel_dtype(T::dtype());
+    let index_dtype = KernelDType::I64;
+    let operand_strides = col_major_strides(operand_shape);
+    let index_strides = col_major_strides(&scatter_indices.shape);
+    let update_strides = col_major_strides(updates_shape);
+    let out_strides = col_major_strides(operand_shape);
+    let plan = ErasedScatterPlan::compile(
+        dtype,
+        index_dtype,
+        operand_shape,
+        &operand_strides,
+        &scatter_indices.shape,
+        &index_strides,
+        updates_shape,
+        &update_strides,
+        operand_shape,
+        &out_strides,
+        scatter_spec(config),
+    )
+    .map_err(|err| crate::Error::backend_source("scatter", err))?;
 
-    for _ in 0..batch_elems {
-        operand_base.fill(0);
-        for (component, &operand_dim) in config.scatter_dims_to_operand_dims.iter().enumerate() {
-            let start = index_component(
-                "scatter",
-                scatter_indices,
-                &batch_idx,
-                config.index_vector_dim,
-                component,
-                &mut index_scratch,
-            )?;
-            operand_base[operand_dim] = clamp_window_start(
-                "scatter",
-                start,
-                operand_shape[operand_dim],
-                window_shape[operand_dim],
-            )?;
-        }
-
-        window_idx.fill(0);
-        for _ in 0..window_elems {
-            let mut batch_axis = 0usize;
-            let mut window_axis = 0usize;
-            for axis in 0..update_rank {
-                if is_update_window_dim[axis] {
-                    update_idx[axis] = window_idx[window_axis];
-                    window_axis += 1;
-                } else {
-                    update_idx[axis] = batch_idx[batch_axis];
-                    batch_axis += 1;
-                }
-            }
-
-            operand_idx.copy_from_slice(&operand_base);
-            for (window_axis, &operand_axis) in window_dims.iter().enumerate() {
-                operand_idx[operand_axis] += window_idx[window_axis];
-            }
-
-            let value = *updates.get(&update_idx)?;
-            let slot = out.get_mut(&operand_idx)?;
-            *slot = *slot + value;
-            advance_col_major_index(&mut window_idx, &window_shape_updates);
-        }
-        advance_col_major_index(&mut batch_idx, &batch_shape);
-    }
+    // INVARIANT: ErasedScatterPlan first copies the full operand into `out`,
+    // then applies every additive update.
+    let mut out = pooled_uninit_tensor(buffers, operand_shape.to_vec())?;
+    let operand_ref = ErasedRawStridedRef::new(
+        dtype,
+        typed_bytes(typed_host_data("scatter", operand)?),
+        operand_shape,
+        &operand_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("scatter", err))?;
+    let index_ref = ErasedRawStridedRef::new(
+        index_dtype,
+        typed_bytes(&scatter_indices.values),
+        &scatter_indices.shape,
+        &index_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("scatter", err))?;
+    let update_ref = ErasedRawStridedRef::new(
+        dtype,
+        typed_bytes(typed_host_data("scatter", updates)?),
+        updates_shape,
+        &update_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("scatter", err))?;
+    let mut out_ref = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(out.host_data_mut()?),
+        operand_shape,
+        &out_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("scatter", err))?;
+    plan.execute(
+        &ExecContext::serial(),
+        &mut out_ref,
+        &operand_ref,
+        &index_ref,
+        &update_ref,
+    )
+    .map_err(|err| crate::Error::backend_source("scatter", err))?;
 
     Ok(out)
 }
 
-fn typed_dynamic_slice<T: Copy + Clone + PoolScalar>(
+fn typed_dynamic_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
     input: &TypedTensor<T>,
     starts: &IndexTensor,
@@ -1316,9 +1232,8 @@ fn typed_dynamic_slice<T: Copy + Clone + PoolScalar>(
         ));
     }
 
-    let mut clamped_starts = vec![0usize; input_shape.len()];
     for axis in 0..input_shape.len() {
-        clamped_starts[axis] = clamp_window_start(
+        let _ = clamp_window_start(
             "dynamic_slice",
             starts.values[axis],
             input_shape[axis],
@@ -1327,23 +1242,58 @@ fn typed_dynamic_slice<T: Copy + Clone + PoolScalar>(
     }
 
     let out_shape = slice_sizes.to_vec();
-    // SAFETY: the dynamic-slice loop below assigns every output coordinate exactly once.
+    let dtype = kernel_dtype(T::dtype());
+    let input_strides = col_major_strides(input_shape);
+    let start_strides = col_major_strides(&starts.shape);
+    let out_strides = col_major_strides(&out_shape);
+    let plan = ErasedDynamicSlicePlan::compile(
+        dtype,
+        KernelDType::I64,
+        input_shape,
+        &input_strides,
+        &starts.shape,
+        &start_strides,
+        &out_shape,
+        &out_strides,
+        slice_sizes,
+    )
+    .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
+    // INVARIANT: ErasedDynamicSlicePlan writes every output coordinate exactly once.
     let mut out = pooled_uninit_tensor(buffers, out_shape.clone())?;
-    let mut out_idx = vec![0usize; out_shape.len()];
-    let mut input_idx = vec![0usize; out_shape.len()];
-
-    for out_value in out.host_data_mut()?.iter_mut() {
-        for axis in 0..out_shape.len() {
-            input_idx[axis] = clamped_starts[axis] + out_idx[axis];
-        }
-        *out_value = *input.get(&input_idx)?;
-        advance_col_major_index(&mut out_idx, &out_shape);
+    if T::dtype() == DType::Bool {
+        out.host_data_mut()?.fill(T::pool_zero());
     }
+    let input_ref = ErasedRawStridedRef::new(
+        dtype,
+        typed_bytes(typed_host_data("dynamic_slice", input)?),
+        input_shape,
+        &input_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
+    let start_ref = ErasedRawStridedRef::new(
+        KernelDType::I64,
+        typed_bytes(&starts.values),
+        &starts.shape,
+        &start_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
+    let mut out_ref = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(out.host_data_mut()?),
+        &out_shape,
+        &out_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
+    plan.execute(&ExecContext::serial(), &mut out_ref, &input_ref, &start_ref)
+        .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
 
     Ok(out)
 }
 
-fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar>(
+fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
     operand: &TypedTensor<T>,
     update: &TypedTensor<T>,
@@ -1377,9 +1327,8 @@ fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar>(
         ));
     }
 
-    let mut clamped_starts = vec![0usize; operand_shape.len()];
     for axis in 0..operand_shape.len() {
-        clamped_starts[axis] = clamp_window_start(
+        let _ = clamp_window_start(
             "dynamic_update_slice",
             starts.values[axis],
             operand_shape[axis],
@@ -1387,17 +1336,70 @@ fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar>(
         )?;
     }
 
-    let mut out = clone_host_tensor_from_pool(buffers, "dynamic_update_slice", operand)?;
-    let mut update_idx = vec![0usize; update_shape.len()];
-    let mut operand_idx = vec![0usize; operand_shape.len()];
-
-    for update_value in update.as_slice()? {
-        for axis in 0..update_shape.len() {
-            operand_idx[axis] = clamped_starts[axis] + update_idx[axis];
-        }
-        *out.get_mut(&operand_idx)? = *update_value;
-        advance_col_major_index(&mut update_idx, update_shape);
+    let dtype = kernel_dtype(T::dtype());
+    let operand_strides = col_major_strides(operand_shape);
+    let start_strides = col_major_strides(&starts.shape);
+    let update_strides = col_major_strides(update_shape);
+    let out_strides = col_major_strides(operand_shape);
+    let plan = ErasedDynamicUpdateSlicePlan::compile(
+        dtype,
+        KernelDType::I64,
+        operand_shape,
+        &operand_strides,
+        &starts.shape,
+        &start_strides,
+        update_shape,
+        &update_strides,
+        operand_shape,
+        &out_strides,
+    )
+    .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
+    // INVARIANT: ErasedDynamicUpdateSlicePlan copies the full operand into
+    // `out` before overwriting the update window.
+    let mut out = pooled_uninit_tensor(buffers, operand_shape.to_vec())?;
+    if T::dtype() == DType::Bool {
+        out.host_data_mut()?.fill(T::pool_zero());
     }
+    let operand_ref = ErasedRawStridedRef::new(
+        dtype,
+        typed_bytes(typed_host_data("dynamic_update_slice", operand)?),
+        operand_shape,
+        &operand_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
+    let update_ref = ErasedRawStridedRef::new(
+        dtype,
+        typed_bytes(typed_host_data("dynamic_update_slice", update)?),
+        update_shape,
+        &update_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
+    let start_ref = ErasedRawStridedRef::new(
+        KernelDType::I64,
+        typed_bytes(&starts.values),
+        &starts.shape,
+        &start_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
+    let mut out_ref = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(out.host_data_mut()?),
+        operand_shape,
+        &out_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
+    plan.execute(
+        &ExecContext::serial(),
+        &mut out_ref,
+        &operand_ref,
+        &update_ref,
+        &start_ref,
+    )
+    .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
 
     Ok(out)
 }

--- a/crates/tenferro-cpu/src/indexing/tests.rs
+++ b/crates/tenferro-cpu/src/indexing/tests.rs
@@ -1,9 +1,6 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
-use super::{
-    dynamic_slice, f32_index_to_i64, f64_index_to_i64, index_component, typed_concatenate,
-    BufferPool, IndexTensor,
-};
+use super::{dynamic_slice, f32_index_to_i64, f64_index_to_i64, typed_concatenate, BufferPool};
 use tenferro_tensor::{Error, Tensor, TypedTensor, ValidationError};
 
 #[test]
@@ -21,28 +18,6 @@ fn typed_concatenate_rejects_empty_typed_inputs_without_panicking() {
             op: "concatenate",
             ..
         }
-    ));
-}
-
-#[test]
-fn index_component_rejects_mismatched_scratch_len_without_panicking() {
-    let mut scratch = vec![0usize; 1];
-    let indices = IndexTensor {
-        shape: vec![1, 1],
-        values: vec![7],
-    };
-
-    let result = catch_unwind(AssertUnwindSafe(|| {
-        index_component("gather", &indices, &[0], 1, 0, &mut scratch)
-    }));
-
-    assert!(
-        result.is_ok(),
-        "index_component should return Err for a malformed scratch buffer"
-    );
-    assert!(matches!(
-        result.unwrap().unwrap_err(),
-        Error::Validation { op: "gather", .. }
     ));
 }
 

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -1,12 +1,17 @@
-use std::ops::{Add, Mul};
+use std::mem::size_of_val;
 
-use num_traits::{Float, One, Zero};
-use strided_kernel::reduce_axis;
+use num_traits::Float;
+use strided_kernel::{
+    col_major_strides, reduce_axis, ErasedRawStridedMut, ErasedRawStridedRef, ErasedReducePlan,
+    ExecContext, KernelDType, ReduceOp,
+};
 
 use super::{typed_host_data, typed_view, typed_view_from_view};
 use crate::buffer_pool::BufferPool;
 use crate::materialize_tensor_read;
-use tenferro_tensor::{Tensor, TensorRank, TensorRead, TensorView, TypedTensor, TypedTensorView};
+use tenferro_tensor::{
+    DType, Tensor, TensorRank, TensorRead, TensorScalar, TensorView, TypedTensor, TypedTensorView,
+};
 
 fn validate_axes(op: &'static str, axes: &[usize], rank: usize) -> crate::Result<()> {
     let mut seen = vec![false; rank];
@@ -100,9 +105,40 @@ fn nan_propagating_min<T: Float>(a: T, b: T) -> T {
     }
 }
 
-trait WrappingReductionElem: Copy + Clone + Send + Sync + Zero + One + 'static {
-    fn wrapping_add_elem(self, other: Self) -> Self;
-    fn wrapping_mul_elem(self, other: Self) -> Self;
+fn kernel_dtype(dtype: DType) -> KernelDType {
+    match dtype {
+        DType::F32 => KernelDType::F32,
+        DType::F64 => KernelDType::F64,
+        DType::I32 => KernelDType::I32,
+        DType::I64 => KernelDType::I64,
+        DType::Bool => KernelDType::Bool,
+        DType::C32 => KernelDType::C32,
+        DType::C64 => KernelDType::C64,
+    }
+}
+
+fn typed_bytes<T>(data: &[T]) -> &[u8] {
+    // SAFETY: `data` is an aligned typed slice. The returned byte slice has
+    // the same lifetime and exact byte length, and is read-only.
+    unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), size_of_val(data)) }
+}
+
+fn typed_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    // SAFETY: `data` is an aligned typed slice. The erased reduction writes
+    // valid scalar values before the buffer is read through its typed view.
+    unsafe { std::slice::from_raw_parts_mut(data.as_mut_ptr().cast::<u8>(), size_of_val(data)) }
+}
+
+fn reduction_output_shape(input_shape: &[usize], axes: &[usize]) -> Vec<usize> {
+    input_shape
+        .iter()
+        .enumerate()
+        .filter(|&(axis, _)| !axes.contains(&axis))
+        .map(|(_, &dim)| dim)
+        .collect()
+}
+
+trait WrappingReductionElem: Copy + Clone + Send + Sync + 'static {
     fn min_value_elem() -> Self;
     fn max_value_elem() -> Self;
     fn max_elem(self, other: Self) -> Self;
@@ -112,14 +148,6 @@ trait WrappingReductionElem: Copy + Clone + Send + Sync + Zero + One + 'static {
 macro_rules! impl_wrapping_reduction_elem {
     ($ty:ty) => {
         impl WrappingReductionElem for $ty {
-            fn wrapping_add_elem(self, other: Self) -> Self {
-                self.wrapping_add(other)
-            }
-
-            fn wrapping_mul_elem(self, other: Self) -> Self {
-                self.wrapping_mul(other)
-            }
-
             fn min_value_elem() -> Self {
                 <$ty>::MIN
             }
@@ -181,56 +209,50 @@ pub(crate) fn reduce_sum_read(
             ensure_host_tensor("reduce_sum", input)?;
             reduce_sum(input, axes)
         }
-        TensorRead::View(TensorView::F32(t)) => Ok(Tensor::F32(typed_reduce_view(
+        TensorRead::View(TensorView::F32(t)) => Ok(Tensor::F32(typed_reduce_view_erased(
+            buffers,
             &t,
             axes,
-            |x| x,
-            |a, b| a + b,
-            f32::zero(),
+            ReduceOp::Sum,
             "reduce_sum",
         )?)),
-        TensorRead::View(TensorView::F64(t)) => Ok(Tensor::F64(typed_reduce_view(
+        TensorRead::View(TensorView::F64(t)) => Ok(Tensor::F64(typed_reduce_view_erased(
+            buffers,
             &t,
             axes,
-            |x| x,
-            |a, b| a + b,
-            f64::zero(),
+            ReduceOp::Sum,
             "reduce_sum",
         )?)),
-        TensorRead::View(TensorView::I32(t)) => Ok(Tensor::I32(typed_reduce_view(
+        TensorRead::View(TensorView::I32(t)) => Ok(Tensor::I32(typed_reduce_view_erased(
+            buffers,
             &t,
             axes,
-            |x| x,
-            |a, b| a.wrapping_add(b),
-            i32::zero(),
+            ReduceOp::Sum,
             "reduce_sum",
         )?)),
-        TensorRead::View(TensorView::I64(t)) => Ok(Tensor::I64(typed_reduce_view(
+        TensorRead::View(TensorView::I64(t)) => Ok(Tensor::I64(typed_reduce_view_erased(
+            buffers,
             &t,
             axes,
-            |x| x,
-            |a, b| a.wrapping_add(b),
-            i64::zero(),
+            ReduceOp::Sum,
             "reduce_sum",
         )?)),
         TensorRead::View(TensorView::Bool(_)) => Err(crate::Error::unsupported(
             "reduce_sum",
             "unsupported dtype Bool",
         )),
-        TensorRead::View(TensorView::C32(t)) => Ok(Tensor::C32(typed_reduce_view(
+        TensorRead::View(TensorView::C32(t)) => Ok(Tensor::C32(typed_reduce_view_erased(
+            buffers,
             &t,
             axes,
-            |x| x,
-            |a, b| a + b,
-            num_complex::Complex32::zero(),
+            ReduceOp::Sum,
             "reduce_sum",
         )?)),
-        TensorRead::View(TensorView::C64(t)) => Ok(Tensor::C64(typed_reduce_view(
+        TensorRead::View(TensorView::C64(t)) => Ok(Tensor::C64(typed_reduce_view_erased(
+            buffers,
             &t,
             axes,
-            |x| x,
-            |a, b| a + b,
-            num_complex::Complex64::zero(),
+            ReduceOp::Sum,
             "reduce_sum",
         )?)),
     }
@@ -275,56 +297,50 @@ pub(crate) fn reduce_prod_read(
             ensure_host_tensor("reduce_prod", input)?;
             reduce_prod(input, axes)
         }
-        TensorRead::View(TensorView::F32(t)) => Ok(Tensor::F32(typed_reduce_view(
+        TensorRead::View(TensorView::F32(t)) => Ok(Tensor::F32(typed_reduce_view_erased(
+            buffers,
             &t,
             axes,
-            |x| x,
-            |a, b| a * b,
-            f32::one(),
+            ReduceOp::Product,
             "reduce_prod",
         )?)),
-        TensorRead::View(TensorView::F64(t)) => Ok(Tensor::F64(typed_reduce_view(
+        TensorRead::View(TensorView::F64(t)) => Ok(Tensor::F64(typed_reduce_view_erased(
+            buffers,
             &t,
             axes,
-            |x| x,
-            |a, b| a * b,
-            f64::one(),
+            ReduceOp::Product,
             "reduce_prod",
         )?)),
-        TensorRead::View(TensorView::I32(t)) => Ok(Tensor::I32(typed_reduce_view(
+        TensorRead::View(TensorView::I32(t)) => Ok(Tensor::I32(typed_reduce_view_erased(
+            buffers,
             &t,
             axes,
-            |x| x,
-            |a, b| a.wrapping_mul(b),
-            i32::one(),
+            ReduceOp::Product,
             "reduce_prod",
         )?)),
-        TensorRead::View(TensorView::I64(t)) => Ok(Tensor::I64(typed_reduce_view(
+        TensorRead::View(TensorView::I64(t)) => Ok(Tensor::I64(typed_reduce_view_erased(
+            buffers,
             &t,
             axes,
-            |x| x,
-            |a, b| a.wrapping_mul(b),
-            i64::one(),
+            ReduceOp::Product,
             "reduce_prod",
         )?)),
         TensorRead::View(TensorView::Bool(_)) => Err(crate::Error::unsupported(
             "reduce_prod",
             "unsupported dtype Bool",
         )),
-        TensorRead::View(TensorView::C32(t)) => Ok(Tensor::C32(typed_reduce_view(
+        TensorRead::View(TensorView::C32(t)) => Ok(Tensor::C32(typed_reduce_view_erased(
+            buffers,
             &t,
             axes,
-            |x| x,
-            |a, b| a * b,
-            num_complex::Complex32::one(),
+            ReduceOp::Product,
             "reduce_prod",
         )?)),
-        TensorRead::View(TensorView::C64(t)) => Ok(Tensor::C64(typed_reduce_view(
+        TensorRead::View(TensorView::C64(t)) => Ok(Tensor::C64(typed_reduce_view_erased(
+            buffers,
             &t,
             axes,
-            |x| x,
-            |a, b| a * b,
-            num_complex::Complex64::one(),
+            ReduceOp::Product,
             "reduce_prod",
         )?)),
     }
@@ -554,6 +570,70 @@ where
     TypedTensor::from_vec_col_major(output_shape, current.into_data())
 }
 
+fn typed_reduce_erased<T>(
+    input: &TypedTensor<T>,
+    axes: &[usize],
+    op: ReduceOp,
+    label: &'static str,
+) -> crate::Result<TypedTensor<T>>
+where
+    T: Copy + Clone + TensorScalar,
+{
+    validate_reduced_axes_nonempty(label, input.shape(), axes)?;
+    if axes.is_empty() {
+        // INVARIANT: empty-axis typed reductions preserve values exactly while
+        // satisfying the owned-output contract.
+        return Ok(input.clone());
+    }
+
+    let output_shape = reduction_output_shape(input.shape(), axes);
+    let output_len =
+        tenferro_tensor::validate::checked_shape_product(label, "output shape", &output_shape)?;
+    let output_strides = col_major_strides(&output_shape);
+    let dtype = kernel_dtype(T::dtype());
+    let input_view = typed_view(label, input)?;
+    let plan = ErasedReducePlan::compile_axes(
+        dtype,
+        op,
+        input_view.dims(),
+        input_view.strides(),
+        &output_shape,
+        &output_strides,
+        axes,
+    )
+    .map_err(|err| crate::Error::backend_source(label, err))?;
+    let source = ErasedRawStridedRef::new(
+        dtype,
+        typed_bytes(input_view.data()),
+        input_view.dims(),
+        input_view.strides(),
+        input_view.offset(),
+    )
+    .map_err(|err| crate::Error::backend_source(label, err))?;
+    // SAFETY: ErasedReducePlan writes every destination element.
+    let mut output = unsafe { uninit_full_overwrite_vec(output_len) };
+    let mut dest = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(&mut output),
+        &output_shape,
+        &output_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source(label, err))?;
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .map_err(|err| crate::Error::backend_source(label, err))?;
+
+    TypedTensor::from_vec_col_major(output_shape, output)
+}
+
+#[allow(clippy::uninit_vec)]
+unsafe fn uninit_full_overwrite_vec<T>(len: usize) -> Vec<T> {
+    let mut output = Vec::with_capacity(len);
+    // SAFETY: the caller promises every element is overwritten before any read.
+    unsafe { output.set_len(len) };
+    output
+}
+
 pub(crate) fn typed_reduce_view<T, M, R, TR>(
     input: &TypedTensorView<'_, T, TR>,
     axes: &[usize],
@@ -605,6 +685,63 @@ where
     TypedTensor::from_vec_col_major(output_shape, current.into_data())
 }
 
+fn typed_reduce_view_erased<T, TR>(
+    buffers: &mut BufferPool,
+    input: &TypedTensorView<'_, T, TR>,
+    axes: &[usize],
+    op: ReduceOp,
+    label: &'static str,
+) -> crate::Result<TypedTensor<T>>
+where
+    T: Copy + Clone + TensorScalar + crate::buffer_pool::PoolScalar + 'static,
+    TR: TensorRank,
+{
+    validate_reduced_axes_nonempty(label, input.shape(), axes)?;
+    if axes.is_empty() {
+        return Err(crate::Error::unsupported(
+            label,
+            "empty-axis view reductions require backend-owned materialization",
+        ));
+    }
+
+    let output_shape = reduction_output_shape(input.shape(), axes);
+    let output_strides = col_major_strides(&output_shape);
+    let dtype = kernel_dtype(T::dtype());
+    let input_view = typed_view_from_view(label, input)?;
+    let plan = ErasedReducePlan::compile_axes(
+        dtype,
+        op,
+        input_view.dims(),
+        input_view.strides(),
+        &output_shape,
+        &output_strides,
+        axes,
+    )
+    .map_err(|err| crate::Error::backend_source(label, err))?;
+    let source = ErasedRawStridedRef::new(
+        dtype,
+        typed_bytes(input_view.data()),
+        input_view.dims(),
+        input_view.strides(),
+        input_view.offset(),
+    )
+    .map_err(|err| crate::Error::backend_source(label, err))?;
+    // SAFETY: ErasedReducePlan writes every destination element.
+    let mut output = unsafe { crate::typed_array_uninit_from_pool(buffers, &output_shape) }?;
+    let mut dest = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(output.data_mut()),
+        &output_shape,
+        &output_strides,
+        0,
+    )
+    .map_err(|err| crate::Error::backend_source(label, err))?;
+    plan.execute(&ExecContext::serial(), &mut dest, &source)
+        .map_err(|err| crate::Error::backend_source(label, err))?;
+
+    Ok(crate::tensor_from_array(output))
+}
+
 /// # Errors
 ///
 /// Returns [`crate::Error::Validation`] with `AxisOutOfBounds`,
@@ -612,9 +749,9 @@ where
 /// reductions, or a typed backend error while materializing the result.
 pub fn typed_reduce_sum<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + Send + Sync + Zero + Add<Output = T>,
+    T: Copy + Clone + Send + Sync + TensorScalar,
 {
-    typed_reduce(input, axes, |x| x, |a, b| a + b, T::zero(), "reduce_sum")
+    typed_reduce_erased(input, axes, ReduceOp::Sum, "reduce_sum")
 }
 
 fn typed_reduce_sum_wrapping<T>(
@@ -622,16 +759,9 @@ fn typed_reduce_sum_wrapping<T>(
     axes: &[usize],
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: WrappingReductionElem,
+    T: WrappingReductionElem + TensorScalar,
 {
-    typed_reduce(
-        input,
-        axes,
-        |x| x,
-        |a, b| a.wrapping_add_elem(b),
-        T::zero(),
-        "reduce_sum",
-    )
+    typed_reduce_erased(input, axes, ReduceOp::Sum, "reduce_sum")
 }
 
 /// # Errors
@@ -641,9 +771,9 @@ where
 /// reductions, or a typed backend error while materializing the result.
 pub fn typed_reduce_prod<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>
 where
-    T: Copy + Clone + Send + Sync + One + Mul<Output = T>,
+    T: Copy + Clone + Send + Sync + TensorScalar,
 {
-    typed_reduce(input, axes, |x| x, |a, b| a * b, T::one(), "reduce_prod")
+    typed_reduce_erased(input, axes, ReduceOp::Product, "reduce_prod")
 }
 
 fn typed_reduce_prod_wrapping<T>(
@@ -651,16 +781,9 @@ fn typed_reduce_prod_wrapping<T>(
     axes: &[usize],
 ) -> crate::Result<TypedTensor<T>>
 where
-    T: WrappingReductionElem,
+    T: WrappingReductionElem + TensorScalar,
 {
-    typed_reduce(
-        input,
-        axes,
-        |x| x,
-        |a, b| a.wrapping_mul_elem(b),
-        T::one(),
-        "reduce_prod",
-    )
+    typed_reduce_erased(input, axes, ReduceOp::Product, "reduce_prod")
 }
 
 /// # Errors

--- a/crates/tenferro-cpu/tests/integration/backend_capability_contracts.rs
+++ b/crates/tenferro-cpu/tests/integration/backend_capability_contracts.rs
@@ -406,16 +406,22 @@ fn concatenate_hot_loop_does_not_linearly_scan_input_segments() {
 }
 
 #[test]
-fn gather_scatter_index_component_reuses_index_scratch() {
+fn indirect_indexed_writes_delegate_to_strided_plans() {
     let indexing_source = include_str!("../../src/indexing.rs");
 
     assert!(
         !indexing_source.contains("let mut full_idx = vec![0usize; indices.shape.len()];"),
-        "gather/scatter should not allocate index vectors for every index component"
+        "indexed kernels should not allocate index vectors for every index component"
     );
     assert!(
-        indexing_source.contains("index_scratch"),
-        "gather/scatter should carry reusable index scratch through index_component"
+        !indexing_source.contains("fn index_component("),
+        "index component decoding should not remain in tenferro after strided plan delegation"
+    );
+    assert!(
+        indexing_source.contains("ErasedScatterPlan::compile")
+            && indexing_source.contains("ErasedDynamicSlicePlan::compile")
+            && indexing_source.contains("ErasedDynamicUpdateSlicePlan::compile"),
+        "scatter and dynamic slice/update replay should be delegated to strided erased plans"
     );
 }
 
@@ -484,12 +490,16 @@ fn strided_kernel_ownership_requires_backend_execution_resources() {
     assert_eq!(
         contract_set(&contract, "affine-kernels"),
         BTreeSet::from([
-            "axis-reduction",
+            "additive-scatter",
             "broadcast",
             "copy",
+            "dynamic-slice",
+            "dynamic-update-slice",
+            "fused-elementwise",
             "gather",
             "map",
             "permutation",
+            "sum-product-reduction",
             "zip-map",
         ])
     );

--- a/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
@@ -1,11 +1,13 @@
+use std::mem::size_of_val;
 use std::ops::{Add, Div, Mul, Neg, Rem as StdRem, Sub};
 use std::sync::Arc;
 
 use num_complex::Complex;
 use num_traits::{One, Zero};
 use strided_kernel::{
-    batched_outer_product_into, broadcast_mul_into, fused_elementwise_into, map_into, mul_into,
-    reduce, zip_map2_into, zip_map3_into, FusedInst, FusedOp, FusedPlan, FusedScalar, StridedView,
+    batched_outer_product_into, broadcast_mul_into, map_into, mul_into, reduce, zip_map2_into,
+    zip_map3_into, ErasedFusedPlan, ErasedRawStridedMut, ErasedRawStridedRef, ExecContext,
+    FusedInst, FusedOp, FusedPlan, KernelDType, StridedArray, StridedView,
 };
 
 use crate::buffer_pool::{BufferPool, PoolScalar};
@@ -188,10 +190,10 @@ fn should_defer_to_broadcast_multiply_special_case(plan: &ElementwiseFusionPlan)
         && plan.ops()[0].op() == ElementwiseFusionOp::Multiply
 }
 
-fn strided_fused_plan(plan: &ElementwiseFusionPlan) -> FusedPlan {
+fn single_output_strided_fused_plan(plan: &ElementwiseFusionPlan, output: usize) -> FusedPlan {
     FusedPlan {
         input_count: plan.input_count(),
-        outputs: plan.outputs().to_vec(),
+        outputs: vec![output],
         ops: plan
             .ops()
             .iter()
@@ -203,115 +205,137 @@ fn strided_fused_plan(plan: &ElementwiseFusionPlan) -> FusedPlan {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum SpecializedBinaryOp {
-    Add,
-    Multiply,
+fn kernel_dtype(dtype: DType) -> KernelDType {
+    match dtype {
+        DType::F32 => KernelDType::F32,
+        DType::F64 => KernelDType::F64,
+        DType::I32 => KernelDType::I32,
+        DType::I64 => KernelDType::I64,
+        DType::Bool => KernelDType::Bool,
+        DType::C32 => KernelDType::C32,
+        DType::C64 => KernelDType::C64,
+    }
 }
 
-impl SpecializedBinaryOp {
-    fn from_fusion_op(op: ElementwiseFusionOp) -> Option<Self> {
-        match op {
-            ElementwiseFusionOp::Add => Some(Self::Add),
-            ElementwiseFusionOp::Multiply => Some(Self::Multiply),
-            _ => None,
+fn typed_bytes<T>(data: &[T]) -> &[u8] {
+    // SAFETY: `data` is an aligned typed slice. The returned byte slice has
+    // the same lifetime and exact byte length, and is read-only.
+    unsafe { std::slice::from_raw_parts(data.as_ptr().cast::<u8>(), size_of_val(data)) }
+}
+
+fn typed_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    // SAFETY: `data` is an aligned typed slice. The returned byte slice has
+    // the same lifetime and exact byte length; erased kernels restore the
+    // dtype-specific byte validity invariant before typed reads resume.
+    unsafe { std::slice::from_raw_parts_mut(data.as_mut_ptr().cast::<u8>(), size_of_val(data)) }
+}
+
+struct ErasedFusionInput<'a> {
+    data: &'a [u8],
+    dims: Vec<usize>,
+    strides: Vec<isize>,
+}
+
+fn tensor_host_bytes<'a>(op: &'static str, input: &'a Tensor) -> crate::Result<&'a [u8]> {
+    macro_rules! bytes {
+        ($tensor:expr) => {
+            typed_host_data(op, $tensor).map(typed_bytes)
+        };
+    }
+
+    match input {
+        Tensor::F32(tensor) => bytes!(tensor),
+        Tensor::F64(tensor) => bytes!(tensor),
+        Tensor::I32(tensor) => bytes!(tensor),
+        Tensor::I64(tensor) => bytes!(tensor),
+        Tensor::Bool(tensor) => bytes!(tensor),
+        Tensor::C32(tensor) => bytes!(tensor),
+        Tensor::C64(tensor) => bytes!(tensor),
+    }
+}
+
+fn erased_fusion_input<'a>(
+    input: &'a Tensor,
+    view: &ElementwiseFusionInputView,
+) -> crate::Result<ErasedFusionInput<'a>> {
+    let data = tensor_host_bytes(ELEMENTWISE_FUSION_OP, input)?;
+    let base_shape = input.shape();
+    let base_strides = col_major_strides(base_shape)?;
+    let ElementwiseFusionInputView::BroadcastInDim { shape, dims } = view else {
+        return Ok(ErasedFusionInput {
+            data,
+            dims: base_shape.to_vec(),
+            strides: base_strides,
+        });
+    };
+
+    if dims.len() != base_shape.len() {
+        return Err(crate::Error::invalid_argument(
+            ELEMENTWISE_FUSION_OP,
+            "configuration",
+            format!(
+                "broadcast dims length {} does not match input rank {}",
+                dims.len(),
+                base_shape.len()
+            ),
+        ));
+    }
+
+    let mut strides = vec![0; shape.len()];
+    let mut seen = vec![false; shape.len()];
+    for (source_axis, &target_axis) in dims.iter().enumerate() {
+        if target_axis >= shape.len() {
+            return Err(crate::Error::axis_out_of_bounds(
+                ELEMENTWISE_FUSION_OP,
+                target_axis,
+                shape.len(),
+            ));
+        }
+        if seen[target_axis] {
+            return Err(crate::Error::duplicate_axis(
+                ELEMENTWISE_FUSION_OP,
+                target_axis,
+                "broadcast dims",
+            ));
+        }
+        seen[target_axis] = true;
+        let source_dim = base_shape[source_axis];
+        let target_dim = shape[target_axis];
+        if source_dim != target_dim && source_dim != 1 {
+            return Err(crate::Error::shape_mismatch(
+                ELEMENTWISE_FUSION_OP,
+                shape.to_vec(),
+                base_shape.to_vec(),
+            ));
+        }
+        if source_dim == target_dim {
+            strides[target_axis] = base_strides[source_axis];
         }
     }
 
-    fn apply<T: FusedScalar>(self, lhs: T, rhs: T) -> T {
-        match self {
-            Self::Add => lhs.fused_add(rhs),
-            Self::Multiply => lhs.fused_multiply(rhs),
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum TwoInputTailOperand {
-    Input(usize),
-    Intermediate,
-}
-
-impl TwoInputTailOperand {
-    fn from_value(value: usize) -> Option<Self> {
-        match value {
-            0 | 1 => Some(Self::Input(value)),
-            2 => Some(Self::Intermediate),
-            _ => None,
-        }
-    }
-
-    fn resolve<T: Copy>(self, inputs: [T; 2], intermediate: T) -> T {
-        match self {
-            Self::Input(index) => inputs[index],
-            Self::Intermediate => intermediate,
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct TwoInputBinaryTailPlan {
-    first_op: SpecializedBinaryOp,
-    first_inputs: [usize; 2],
-    tail_op: SpecializedBinaryOp,
-    tail_inputs: [TwoInputTailOperand; 2],
-}
-
-impl TwoInputBinaryTailPlan {
-    fn evaluate<T: FusedScalar>(self, input0: T, input1: T) -> T {
-        let inputs = [input0, input1];
-        let intermediate = self
-            .first_op
-            .apply(inputs[self.first_inputs[0]], inputs[self.first_inputs[1]]);
-        let lhs = self.tail_inputs[0].resolve(inputs, intermediate);
-        let rhs = self.tail_inputs[1].resolve(inputs, intermediate);
-        self.tail_op.apply(lhs, rhs)
-    }
-}
-
-fn classify_two_input_binary_tail_plan(
-    plan: &ElementwiseFusionPlan,
-) -> Option<TwoInputBinaryTailPlan> {
-    if plan.input_count() != 2
-        || plan.outputs() != [3]
-        || plan.ops().len() != 2
-        || !plan.input_views().iter().all(|view| view.is_identity())
-    {
-        return None;
-    }
-
-    let first = &plan.ops()[0];
-    let tail = &plan.ops()[1];
-    let first_op = SpecializedBinaryOp::from_fusion_op(first.op())?;
-    let tail_op = SpecializedBinaryOp::from_fusion_op(tail.op())?;
-    let first_inputs: [usize; 2] = first.inputs().try_into().ok()?;
-    if !matches!(first_inputs, [0, 1] | [1, 0]) {
-        return None;
-    }
-
-    let raw_tail_inputs: [usize; 2] = tail.inputs().try_into().ok()?;
-    let tail_inputs = [
-        TwoInputTailOperand::from_value(raw_tail_inputs[0])?,
-        TwoInputTailOperand::from_value(raw_tail_inputs[1])?,
-    ];
-    let intermediate_count = tail_inputs
-        .iter()
-        .filter(|input| matches!(input, TwoInputTailOperand::Intermediate))
-        .count();
-    let original_input_count = tail_inputs
-        .iter()
-        .filter(|input| matches!(input, TwoInputTailOperand::Input(_)))
-        .count();
-    if intermediate_count != 1 || original_input_count != 1 {
-        return None;
-    }
-
-    Some(TwoInputBinaryTailPlan {
-        first_op,
-        first_inputs,
-        tail_op,
-        tail_inputs,
+    Ok(ErasedFusionInput {
+        data,
+        dims: shape.to_vec(),
+        strides,
     })
+}
+
+fn typed_array_zeroed_from_pool<T>(
+    buffers: &mut BufferPool,
+    shape: &[usize],
+) -> crate::Result<StridedArray<T>>
+where
+    T: PoolScalar,
+{
+    let total = tenferro_tensor::validate::checked_shape_product(
+        "typed_array_zeroed_from_pool",
+        "shape",
+        shape,
+    )?;
+    let strides = col_major_strides(shape)?;
+    let data = T::pool_acquire_zeroed(buffers, total);
+    StridedArray::from_parts(data, shape, &strides, 0)
+        .map_err(|err| crate::Error::backend_source("typed_array_zeroed_from_pool", err))
 }
 
 #[doc(hidden)]
@@ -1154,100 +1178,23 @@ pub fn elementwise_fusion_with_pool(
     if plan_uses_unfused_op(plan) {
         return Ok(None);
     }
-
-    match plan.dtype() {
-        DType::F32 => {
-            let typed_inputs = inputs
-                .iter()
-                .map(|input| match input {
-                    Tensor::F32(tensor) => Ok(tensor),
-                    _ => Err(crate::Error::dtype_mismatch(
-                        ELEMENTWISE_FUSION_OP,
-                        input.dtype(),
-                        plan.dtype(),
-                    )),
-                })
-                .collect::<crate::Result<Vec<_>>>()?;
-            typed_elementwise_fusion_with_pool(buffers, &typed_inputs, plan, Tensor::F32)
-        }
-        DType::F64 => {
-            let typed_inputs = inputs
-                .iter()
-                .map(|input| match input {
-                    Tensor::F64(tensor) => Ok(tensor),
-                    _ => Err(crate::Error::dtype_mismatch(
-                        ELEMENTWISE_FUSION_OP,
-                        input.dtype(),
-                        plan.dtype(),
-                    )),
-                })
-                .collect::<crate::Result<Vec<_>>>()?;
-            typed_elementwise_fusion_with_pool(buffers, &typed_inputs, plan, Tensor::F64)
-        }
-        DType::C32 => {
-            if plan_uses_ordered_op(plan) {
-                return Ok(None);
-            }
-            let typed_inputs = inputs
-                .iter()
-                .map(|input| match input {
-                    Tensor::C32(tensor) => Ok(tensor),
-                    _ => Err(crate::Error::dtype_mismatch(
-                        ELEMENTWISE_FUSION_OP,
-                        input.dtype(),
-                        plan.dtype(),
-                    )),
-                })
-                .collect::<crate::Result<Vec<_>>>()?;
-            typed_elementwise_fusion_with_pool(buffers, &typed_inputs, plan, Tensor::C32)
-        }
-        DType::C64 => {
-            if plan_uses_ordered_op(plan) {
-                return Ok(None);
-            }
-            let typed_inputs = inputs
-                .iter()
-                .map(|input| match input {
-                    Tensor::C64(tensor) => Ok(tensor),
-                    _ => Err(crate::Error::dtype_mismatch(
-                        ELEMENTWISE_FUSION_OP,
-                        input.dtype(),
-                        plan.dtype(),
-                    )),
-                })
-                .collect::<crate::Result<Vec<_>>>()?;
-            typed_elementwise_fusion_with_pool(buffers, &typed_inputs, plan, Tensor::C64)
-        }
-        DType::I32 | DType::I64 | DType::Bool => Ok(None),
-    }
-}
-
-fn typed_elementwise_fusion_with_pool<T>(
-    buffers: &mut BufferPool,
-    inputs: &[&TypedTensor<T>],
-    plan: &ElementwiseFusionPlan,
-    wrap: fn(TypedTensor<T>) -> Tensor,
-) -> crate::Result<Option<Vec<Tensor>>>
-where
-    T: Copy + Clone + FusedScalar + PoolScalar,
-{
     if should_defer_to_broadcast_multiply_special_case(plan) {
         return Ok(None);
     }
-    if plan.input_views().iter().all(|view| view.is_identity()) {
-        return typed_elementwise_fusion_identity_with_pool(buffers, inputs, plan, wrap);
+    if !dtype_supports_erased_fusion(plan.dtype(), plan) {
+        return Ok(None);
     }
 
-    let input_views = inputs
+    let input_layouts = inputs
         .iter()
         .zip(plan.input_views())
-        .map(|(input, view)| typed_fusion_input_view(input, view))
+        .map(|(input, view)| erased_fusion_input(input, view))
         .collect::<crate::Result<Vec<_>>>()?;
-    let shape = input_views[0].dims().to_vec();
-    if input_views
+    let shape = input_layouts[0].dims.clone();
+    if input_layouts
         .iter()
         .skip(1)
-        .any(|input| input.dims() != shape.as_slice())
+        .any(|input| input.dims != shape)
     {
         return Ok(None);
     }
@@ -1257,162 +1204,205 @@ where
         return Ok(None);
     }
 
-    run_typed_elementwise_fusion_with_views(buffers, &input_views, &shape, plan, wrap)
-}
-
-fn typed_elementwise_fusion_identity_with_pool<T>(
-    buffers: &mut BufferPool,
-    inputs: &[&TypedTensor<T>],
-    plan: &ElementwiseFusionPlan,
-    wrap: fn(TypedTensor<T>) -> Tensor,
-) -> crate::Result<Option<Vec<Tensor>>>
-where
-    T: Copy + Clone + FusedScalar + PoolScalar,
-{
-    let shape = inputs[0].shape();
-    if inputs.iter().skip(1).any(|input| input.shape() != shape) {
-        return Ok(None);
-    }
-    let element_count =
-        tenferro_tensor::validate::checked_shape_product(ELEMENTWISE_FUSION_OP, "shape", shape)?;
-    if element_count < ELEMENTWISE_FUSION_MIN_ELEMENTS {
-        return Ok(None);
-    }
-
-    let input_views = inputs
+    let dtype = kernel_dtype(plan.dtype());
+    let input_refs = input_layouts
         .iter()
-        .map(|input| typed_view(ELEMENTWISE_FUSION_OP, input))
+        .map(|input| {
+            ErasedRawStridedRef::new(dtype, input.data, &input.dims, &input.strides, 0)
+                .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))
+        })
         .collect::<crate::Result<Vec<_>>>()?;
-    run_typed_elementwise_fusion_with_views(buffers, &input_views, shape, plan, wrap)
+
+    execute_erased_fused_outputs(buffers, dtype, &input_refs, &shape, plan).map(Some)
 }
 
-fn run_typed_elementwise_fusion_with_views<T>(
+fn dtype_supports_erased_fusion(dtype: DType, plan: &ElementwiseFusionPlan) -> bool {
+    match dtype {
+        DType::F32 | DType::F64 => true,
+        DType::C32 | DType::C64 => !plan_uses_ordered_op(plan),
+        DType::I32 | DType::I64 => plan.ops().iter().all(|inst| {
+            matches!(
+                inst.op(),
+                ElementwiseFusionOp::Add
+                    | ElementwiseFusionOp::Multiply
+                    | ElementwiseFusionOp::Negate
+                    | ElementwiseFusionOp::Conj
+                    | ElementwiseFusionOp::Abs
+                    | ElementwiseFusionOp::Maximum
+                    | ElementwiseFusionOp::Minimum
+                    | ElementwiseFusionOp::Clamp
+            )
+        }),
+        DType::Bool => plan
+            .ops()
+            .iter()
+            .all(|inst| inst.op() == ElementwiseFusionOp::Conj),
+    }
+}
+
+fn execute_erased_fused_outputs(
     buffers: &mut BufferPool,
-    input_views: &[StridedView<'_, T>],
+    dtype: KernelDType,
+    input_refs: &[ErasedRawStridedRef<'_>],
     shape: &[usize],
     plan: &ElementwiseFusionPlan,
-    wrap: fn(TypedTensor<T>) -> Tensor,
-) -> crate::Result<Option<Vec<Tensor>>>
-where
-    T: Copy + Clone + FusedScalar + PoolScalar,
-{
-    if let Some(outputs) =
-        try_typed_two_input_binary_tail_specialization(buffers, input_views, shape, plan, wrap)?
-    {
-        return Ok(Some(outputs));
-    }
-
-    let fused_plan = strided_fused_plan(plan);
-    let mut output_arrays = Vec::with_capacity(plan.outputs().len());
-    for _ in plan.outputs() {
-        // SAFETY: fused_elementwise_into writes every destination element.
-        output_arrays.push(unsafe { typed_array_uninit_from_pool(buffers, shape) }?);
-    }
-
-    {
-        let mut output_views = output_arrays
-            .iter_mut()
-            .map(|output| output.view_mut())
-            .collect::<Vec<_>>();
-        fused_elementwise_into(&mut output_views, input_views, &fused_plan)
-            .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
-    }
-
-    Ok(Some(
-        output_arrays
-            .into_iter()
-            .map(|output| wrap(tensor_from_array(output)))
+) -> crate::Result<Vec<Tensor>> {
+    match dtype {
+        KernelDType::F32 => plan
+            .outputs()
+            .iter()
+            .map(|&output| {
+                execute_erased_fused_output::<f32>(
+                    buffers,
+                    dtype,
+                    input_refs,
+                    shape,
+                    plan,
+                    output,
+                    false,
+                    Tensor::F32,
+                )
+            })
             .collect(),
-    ))
+        KernelDType::F64 => plan
+            .outputs()
+            .iter()
+            .map(|&output| {
+                execute_erased_fused_output::<f64>(
+                    buffers,
+                    dtype,
+                    input_refs,
+                    shape,
+                    plan,
+                    output,
+                    false,
+                    Tensor::F64,
+                )
+            })
+            .collect(),
+        KernelDType::I32 => plan
+            .outputs()
+            .iter()
+            .map(|&output| {
+                execute_erased_fused_output::<i32>(
+                    buffers,
+                    dtype,
+                    input_refs,
+                    shape,
+                    plan,
+                    output,
+                    false,
+                    Tensor::I32,
+                )
+            })
+            .collect(),
+        KernelDType::I64 => plan
+            .outputs()
+            .iter()
+            .map(|&output| {
+                execute_erased_fused_output::<i64>(
+                    buffers,
+                    dtype,
+                    input_refs,
+                    shape,
+                    plan,
+                    output,
+                    false,
+                    Tensor::I64,
+                )
+            })
+            .collect(),
+        KernelDType::Bool => plan
+            .outputs()
+            .iter()
+            .map(|&output| {
+                execute_erased_fused_output::<bool>(
+                    buffers,
+                    dtype,
+                    input_refs,
+                    shape,
+                    plan,
+                    output,
+                    true,
+                    Tensor::Bool,
+                )
+            })
+            .collect(),
+        KernelDType::C32 => plan
+            .outputs()
+            .iter()
+            .map(|&output| {
+                execute_erased_fused_output::<num_complex::Complex32>(
+                    buffers,
+                    dtype,
+                    input_refs,
+                    shape,
+                    plan,
+                    output,
+                    false,
+                    Tensor::C32,
+                )
+            })
+            .collect(),
+        KernelDType::C64 => plan
+            .outputs()
+            .iter()
+            .map(|&output| {
+                execute_erased_fused_output::<num_complex::Complex64>(
+                    buffers,
+                    dtype,
+                    input_refs,
+                    shape,
+                    plan,
+                    output,
+                    false,
+                    Tensor::C64,
+                )
+            })
+            .collect(),
+        _ => Err(crate::Error::unsupported(
+            ELEMENTWISE_FUSION_OP,
+            format!("unsupported dtype {}", dtype.label()),
+        )),
+    }
 }
 
-fn try_typed_two_input_binary_tail_specialization<T>(
+#[allow(clippy::too_many_arguments)]
+fn execute_erased_fused_output<T>(
     buffers: &mut BufferPool,
-    input_views: &[StridedView<'_, T>],
+    dtype: KernelDType,
+    input_refs: &[ErasedRawStridedRef<'_>],
     shape: &[usize],
     plan: &ElementwiseFusionPlan,
+    output: usize,
+    zeroed_output: bool,
     wrap: fn(TypedTensor<T>) -> Tensor,
-) -> crate::Result<Option<Vec<Tensor>>>
+) -> crate::Result<Tensor>
 where
-    T: Copy + Clone + FusedScalar + PoolScalar,
+    T: Clone + PoolScalar,
 {
-    let Some(classified) = classify_two_input_binary_tail_plan(plan) else {
-        return Ok(None);
+    let fused_plan = single_output_strided_fused_plan(plan, output);
+    let erased_plan = ErasedFusedPlan::compile(dtype, fused_plan)
+        .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
+    let mut out = if zeroed_output {
+        typed_array_zeroed_from_pool(buffers, shape)?
+    } else {
+        // SAFETY: ErasedFusedPlan overwrites every destination element before typed reads resume.
+        unsafe { typed_array_uninit_from_pool(buffers, shape) }?
     };
-    if input_views.len() != 2 {
-        return Ok(None);
-    }
-
-    // SAFETY: zip_map2_into overwrites every output element.
-    let mut out = unsafe { typed_array_uninit_from_pool(buffers, shape) }?;
-    zip_map2_into(
-        &mut out.view_mut(),
-        &input_views[0],
-        &input_views[1],
-        |a, b| classified.evaluate(a, b),
+    let output_strides = col_major_strides(shape)?;
+    let mut dest = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(out.data_mut()),
+        shape,
+        &output_strides,
+        0,
     )
     .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
-    Ok(Some(vec![wrap(tensor_from_array(out))]))
-}
-
-fn typed_fusion_input_view<'a, T>(
-    input: &'a TypedTensor<T>,
-    view: &ElementwiseFusionInputView,
-) -> crate::Result<StridedView<'a, T>>
-where
-    T: Copy,
-{
-    let base = typed_view(ELEMENTWISE_FUSION_OP, input)?;
-    let ElementwiseFusionInputView::BroadcastInDim { shape, dims } = view else {
-        return Ok(base);
-    };
-    if dims.len() != input.shape().len() {
-        return Err(crate::Error::invalid_argument(
-            ELEMENTWISE_FUSION_OP,
-            "configuration",
-            format!(
-                "broadcast dims length {} does not match input rank {}",
-                dims.len(),
-                input.shape().len()
-            ),
-        ));
-    }
-
-    let mut strides = vec![0; shape.len()];
-    let mut seen = Vec::with_capacity(shape.len());
-    seen.resize(shape.len(), false);
-    for (source_axis, &target_axis) in dims.iter().enumerate() {
-        if target_axis >= shape.len() {
-            return Err(crate::Error::axis_out_of_bounds(
-                ELEMENTWISE_FUSION_OP,
-                target_axis,
-                shape.len(),
-            ));
-        }
-        if seen[target_axis] {
-            return Err(crate::Error::duplicate_axis(
-                ELEMENTWISE_FUSION_OP,
-                target_axis,
-                "broadcast dims",
-            ));
-        }
-        seen[target_axis] = true;
-        let source_dim = input.shape()[source_axis];
-        let target_dim = shape[target_axis];
-        if source_dim != target_dim && source_dim != 1 {
-            return Err(crate::Error::shape_mismatch(
-                ELEMENTWISE_FUSION_OP,
-                shape.to_vec(),
-                input.shape().to_vec(),
-            ));
-        }
-        if source_dim == target_dim {
-            strides[target_axis] = base.strides()[source_axis];
-        }
-    }
-
-    StridedView::new(base.data(), shape, &strides, base.offset())
-        .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))
+    erased_plan
+        .execute(&ExecContext::serial(), &mut dest, input_refs)
+        .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
+    Ok(wrap(tensor_from_array(out)))
 }
 
 fn typed_binary_view_with_pool<T, L, R>(

--- a/crates/tenferro-internal-cpu-kernels/src/elementwise/tests.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/elementwise/tests.rs
@@ -69,18 +69,23 @@ fn elementwise_fusion_validation_covers_descriptor_errors_and_empty_outputs() {
 }
 
 #[test]
-fn add_then_multiply_identity_fusion_uses_typed_specialization() {
+fn elementwise_fusion_executes_i32_add_multiply_plan() {
     use tenferro_tensor::backend::ElementwiseFusionInst;
 
     let mut buffers = BufferPool::default();
-    let lhs = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap();
-    let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![10.0, 20.0, 30.0]).unwrap();
-    let input_views = [
-        typed_view(ELEMENTWISE_FUSION_OP, &lhs).unwrap(),
-        typed_view(ELEMENTWISE_FUSION_OP, &rhs).unwrap(),
-    ];
+    let n = ELEMENTWISE_FUSION_MIN_ELEMENTS;
+    let lhs_data = (0..n)
+        .map(|i| if i == 0 { i32::MAX } else { i as i32 })
+        .collect::<Vec<_>>();
+    let rhs_data = (0..n)
+        .map(|i| (i as i32).wrapping_add(1))
+        .collect::<Vec<_>>();
+    let lhs =
+        Tensor::I32(TypedTensor::<i32>::from_vec_col_major(vec![n], lhs_data.clone()).unwrap());
+    let rhs =
+        Tensor::I32(TypedTensor::<i32>::from_vec_col_major(vec![n], rhs_data.clone()).unwrap());
     let plan = ElementwiseFusionPlan::new(
-        DType::F64,
+        DType::I32,
         2,
         vec![3],
         vec![
@@ -89,24 +94,32 @@ fn add_then_multiply_identity_fusion_uses_typed_specialization() {
         ],
     );
 
-    let outputs = try_typed_two_input_binary_tail_specialization(
-        &mut buffers,
-        &input_views,
-        lhs.shape(),
-        &plan,
-        Tensor::F64,
-    )
-    .unwrap()
-    .expect("add-then-multiply identity plans should avoid generic fusion");
+    let outputs = elementwise_fusion_with_pool(&mut buffers, &[&lhs, &rhs], &plan)
+        .unwrap()
+        .expect("I32 add/multiply fusion should be delegated to strided-kernel");
 
     assert_eq!(outputs.len(), 1);
-    assert_eq!(outputs[0].as_slice::<f64>().unwrap(), &[11.0, 44.0, 99.0]);
+    let actual = outputs[0].as_slice::<i32>().unwrap();
+    for &index in &[0usize, 1, n / 2, n - 1] {
+        assert_eq!(
+            actual[index],
+            lhs_data[index]
+                .wrapping_add(rhs_data[index])
+                .wrapping_mul(lhs_data[index])
+        );
+    }
 }
 
 #[test]
-fn two_input_binary_tail_classifier_accepts_commutative_reversed_first_inputs() {
+fn elementwise_fusion_executes_reversed_first_input_plan() {
     use tenferro_tensor::backend::ElementwiseFusionInst;
 
+    let mut buffers = BufferPool::default();
+    let n = ELEMENTWISE_FUSION_MIN_ELEMENTS;
+    let lhs_data = (0..n).map(|i| i as f64 + 1.0).collect::<Vec<_>>();
+    let rhs_data = (0..n).map(|i| (i as f64 + 1.0) * 10.0).collect::<Vec<_>>();
+    let lhs = Tensor::F64(TypedTensor::<f64>::from_vec_col_major(vec![n], lhs_data).unwrap());
+    let rhs = Tensor::F64(TypedTensor::<f64>::from_vec_col_major(vec![n], rhs_data).unwrap());
     let plan = ElementwiseFusionPlan::new(
         DType::F64,
         2,
@@ -117,52 +130,113 @@ fn two_input_binary_tail_classifier_accepts_commutative_reversed_first_inputs() 
         ],
     );
 
-    let classified = classify_two_input_binary_tail_plan(&plan)
-        .expect("commutative first op should be recognized");
+    let outputs = elementwise_fusion_with_pool(&mut buffers, &[&lhs, &rhs], &plan)
+        .unwrap()
+        .expect("reversed first input order should be handled by strided fused replay");
 
-    assert_eq!(classified.first_op, SpecializedBinaryOp::Add);
-    assert_eq!(classified.first_inputs, [1, 0]);
-    assert_eq!(classified.tail_op, SpecializedBinaryOp::Multiply);
-    assert_eq!(
-        classified.tail_inputs,
-        [
-            TwoInputTailOperand::Intermediate,
-            TwoInputTailOperand::Input(1)
-        ]
-    );
+    assert_eq!(outputs.len(), 1);
+    let actual = outputs[0].as_slice::<f64>().unwrap();
+    assert_eq!(actual[0], 110.0);
+    assert_eq!(actual[1], 440.0);
+    assert_eq!(actual[n - 1], 110.0 * (n as f64).powi(2));
 }
 
 #[test]
-fn two_input_binary_tail_classifier_rejects_non_identity_and_ambiguous_plans() {
-    use tenferro_tensor::backend::{ElementwiseFusionInputView, ElementwiseFusionInst};
+fn elementwise_fusion_executes_f32_and_i64_erased_dtype_arms() {
+    use tenferro_tensor::backend::ElementwiseFusionInst;
 
-    let repeated = ElementwiseFusionPlan::new(
-        DType::F64,
+    let mut buffers = BufferPool::default();
+    let n = ELEMENTWISE_FUSION_MIN_ELEMENTS;
+    let f32_lhs_data = (0..n).map(|i| i as f32).collect::<Vec<_>>();
+    let f32_rhs_data = (0..n).map(|i| (i as f32) * 2.0).collect::<Vec<_>>();
+    let f32_lhs =
+        Tensor::F32(TypedTensor::<f32>::from_vec_col_major(vec![n], f32_lhs_data.clone()).unwrap());
+    let f32_rhs =
+        Tensor::F32(TypedTensor::<f32>::from_vec_col_major(vec![n], f32_rhs_data.clone()).unwrap());
+    let add_plan = ElementwiseFusionPlan::new(
+        DType::F32,
         2,
-        vec![3],
-        vec![
-            ElementwiseFusionInst::new(ElementwiseFusionOp::Add, vec![0, 0]),
-            ElementwiseFusionInst::new(ElementwiseFusionOp::Multiply, vec![2, 1]),
-        ],
+        vec![2],
+        vec![ElementwiseFusionInst::new(
+            ElementwiseFusionOp::Add,
+            vec![0, 1],
+        )],
     );
-    assert!(classify_two_input_binary_tail_plan(&repeated).is_none());
 
-    let broadcast = ElementwiseFusionPlan::with_input_views(
-        DType::F64,
-        vec![
-            ElementwiseFusionInputView::broadcast_in_dim(vec![3], vec![0]),
-            ElementwiseFusionInputView::Identity,
-        ],
-        vec![3],
-        vec![
-            ElementwiseFusionInst::new(ElementwiseFusionOp::Add, vec![0, 1]),
-            ElementwiseFusionInst::new(ElementwiseFusionOp::Multiply, vec![2, 1]),
-        ],
+    let f32_outputs = elementwise_fusion_with_pool(&mut buffers, &[&f32_lhs, &f32_rhs], &add_plan)
+        .unwrap()
+        .expect("F32 add fusion should be delegated to strided-kernel");
+    let f32_actual = f32_outputs[0].as_slice::<f32>().unwrap();
+    assert_eq!(f32_actual[3], f32_lhs_data[3] + f32_rhs_data[3]);
+
+    let i64_lhs_data = (0..n).map(|i| i as i64).collect::<Vec<_>>();
+    let i64_rhs_data = (0..n)
+        .map(|i| (i as i64).wrapping_mul(3))
+        .collect::<Vec<_>>();
+    let i64_lhs =
+        Tensor::I64(TypedTensor::<i64>::from_vec_col_major(vec![n], i64_lhs_data.clone()).unwrap());
+    let i64_rhs =
+        Tensor::I64(TypedTensor::<i64>::from_vec_col_major(vec![n], i64_rhs_data.clone()).unwrap());
+    let i64_plan = ElementwiseFusionPlan::new(
+        DType::I64,
+        2,
+        vec![2],
+        vec![ElementwiseFusionInst::new(
+            ElementwiseFusionOp::Add,
+            vec![0, 1],
+        )],
     );
-    assert!(classify_two_input_binary_tail_plan(&broadcast).is_none());
 
-    let multi_output = ElementwiseFusionPlan::new(
-        DType::F64,
+    let i64_outputs = elementwise_fusion_with_pool(&mut buffers, &[&i64_lhs, &i64_rhs], &i64_plan)
+        .unwrap()
+        .expect("I64 add fusion should be delegated to strided-kernel");
+    let i64_actual = i64_outputs[0].as_slice::<i64>().unwrap();
+    assert_eq!(i64_actual[n - 1], i64_lhs_data[n - 1] + i64_rhs_data[n - 1]);
+}
+
+#[test]
+fn elementwise_fusion_executes_bool_and_complex_erased_dtype_arms() {
+    use tenferro_tensor::backend::ElementwiseFusionInst;
+
+    let mut buffers = BufferPool::default();
+    let n = ELEMENTWISE_FUSION_MIN_ELEMENTS;
+    let bool_data = (0..n).map(|i| i % 3 == 0).collect::<Vec<_>>();
+    let bool_input =
+        Tensor::Bool(TypedTensor::<bool>::from_vec_col_major(vec![n], bool_data.clone()).unwrap());
+    let bool_plan = ElementwiseFusionPlan::new(
+        DType::Bool,
+        1,
+        vec![1],
+        vec![ElementwiseFusionInst::new(
+            ElementwiseFusionOp::Conj,
+            vec![0],
+        )],
+    );
+
+    let bool_outputs = elementwise_fusion_with_pool(&mut buffers, &[&bool_input], &bool_plan)
+        .unwrap()
+        .expect("Bool conj fusion should use the zeroed erased destination path");
+    assert_eq!(
+        bool_outputs[0].as_slice::<bool>().unwrap(),
+        bool_data.as_slice()
+    );
+
+    let c32_lhs_data = (0..n)
+        .map(|i| num_complex::Complex32::new(i as f32, 1.0))
+        .collect::<Vec<_>>();
+    let c32_rhs_data = (0..n)
+        .map(|i| num_complex::Complex32::new(2.0, i as f32))
+        .collect::<Vec<_>>();
+    let c32_lhs = Tensor::C32(
+        TypedTensor::<num_complex::Complex32>::from_vec_col_major(vec![n], c32_lhs_data.clone())
+            .unwrap(),
+    );
+    let c32_rhs = Tensor::C32(
+        TypedTensor::<num_complex::Complex32>::from_vec_col_major(vec![n], c32_rhs_data.clone())
+            .unwrap(),
+    );
+    let c32_plan = ElementwiseFusionPlan::new(
+        DType::C32,
         2,
         vec![2, 3],
         vec![
@@ -170,44 +244,98 @@ fn two_input_binary_tail_classifier_rejects_non_identity_and_ambiguous_plans() {
             ElementwiseFusionInst::new(ElementwiseFusionOp::Multiply, vec![2, 1]),
         ],
     );
-    assert!(classify_two_input_binary_tail_plan(&multi_output).is_none());
+
+    let c32_outputs = elementwise_fusion_with_pool(&mut buffers, &[&c32_lhs, &c32_rhs], &c32_plan)
+        .unwrap()
+        .expect("C32 multi-output fusion should be delegated output-by-output");
+    assert_eq!(c32_outputs.len(), 2);
+    assert_eq!(
+        c32_outputs[0].as_slice::<num_complex::Complex32>().unwrap()[5],
+        c32_lhs_data[5] + c32_rhs_data[5]
+    );
+    assert_eq!(
+        c32_outputs[1].as_slice::<num_complex::Complex32>().unwrap()[5],
+        (c32_lhs_data[5] + c32_rhs_data[5]) * c32_rhs_data[5]
+    );
+
+    let c64_lhs_data = (0..n)
+        .map(|i| num_complex::Complex64::new(i as f64, -1.0))
+        .collect::<Vec<_>>();
+    let c64_rhs_data = (0..n)
+        .map(|i| num_complex::Complex64::new(1.0, i as f64))
+        .collect::<Vec<_>>();
+    let c64_lhs = Tensor::C64(
+        TypedTensor::<num_complex::Complex64>::from_vec_col_major(vec![n], c64_lhs_data.clone())
+            .unwrap(),
+    );
+    let c64_rhs = Tensor::C64(
+        TypedTensor::<num_complex::Complex64>::from_vec_col_major(vec![n], c64_rhs_data.clone())
+            .unwrap(),
+    );
+    let c64_plan = ElementwiseFusionPlan::new(
+        DType::C64,
+        2,
+        vec![2],
+        vec![ElementwiseFusionInst::new(
+            ElementwiseFusionOp::Add,
+            vec![0, 1],
+        )],
+    );
+
+    let c64_outputs = elementwise_fusion_with_pool(&mut buffers, &[&c64_lhs, &c64_rhs], &c64_plan)
+        .unwrap()
+        .expect("C64 add fusion should be delegated to strided-kernel");
+    assert_eq!(
+        c64_outputs[0].as_slice::<num_complex::Complex64>().unwrap()[7],
+        c64_lhs_data[7] + c64_rhs_data[7]
+    );
 }
 
 #[test]
-fn reversed_first_input_binary_tail_specialization_computes_result() {
+fn elementwise_fusion_returns_none_for_erased_unsupported_ops() {
     use tenferro_tensor::backend::ElementwiseFusionInst;
 
     let mut buffers = BufferPool::default();
-    let lhs = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![1.0, 2.0, 3.0]).unwrap();
-    let rhs = TypedTensor::<f64>::from_vec_col_major(vec![3], vec![10.0, 20.0, 30.0]).unwrap();
-    let input_views = [
-        typed_view(ELEMENTWISE_FUSION_OP, &lhs).unwrap(),
-        typed_view(ELEMENTWISE_FUSION_OP, &rhs).unwrap(),
-    ];
-    let plan = ElementwiseFusionPlan::new(
-        DType::F64,
+    let n = ELEMENTWISE_FUSION_MIN_ELEMENTS;
+    let lhs = Tensor::I32(TypedTensor::<i32>::from_vec_col_major(vec![n], vec![6; n]).unwrap());
+    let rhs = Tensor::I32(TypedTensor::<i32>::from_vec_col_major(vec![n], vec![2; n]).unwrap());
+    let divide_plan = ElementwiseFusionPlan::new(
+        DType::I32,
         2,
-        vec![3],
-        vec![
-            ElementwiseFusionInst::new(ElementwiseFusionOp::Add, vec![1, 0]),
-            ElementwiseFusionInst::new(ElementwiseFusionOp::Multiply, vec![2, 1]),
-        ],
+        vec![2],
+        vec![ElementwiseFusionInst::new(
+            ElementwiseFusionOp::Divide,
+            vec![0, 1],
+        )],
+    );
+    assert!(
+        elementwise_fusion_with_pool(&mut buffers, &[&lhs, &rhs], &divide_plan)
+            .unwrap()
+            .is_none(),
+        "integer divide is not owned by erased strided fusion"
     );
 
-    let outputs = try_typed_two_input_binary_tail_specialization(
-        &mut buffers,
-        &input_views,
-        lhs.shape(),
-        &plan,
-        Tensor::F64,
-    )
-    .unwrap()
-    .expect("reversed first input order should still use the binary-tail specialization");
-
-    assert_eq!(outputs.len(), 1);
-    assert_eq!(
-        outputs[0].as_slice::<f64>().unwrap(),
-        &[110.0, 440.0, 990.0]
+    let complex = Tensor::C64(
+        TypedTensor::<num_complex::Complex64>::from_vec_col_major(
+            vec![n],
+            vec![num_complex::Complex64::new(1.0, 0.0); n],
+        )
+        .unwrap(),
+    );
+    let ordered_plan = ElementwiseFusionPlan::new(
+        DType::C64,
+        2,
+        vec![2],
+        vec![ElementwiseFusionInst::new(
+            ElementwiseFusionOp::Maximum,
+            vec![0, 1],
+        )],
+    );
+    assert!(
+        elementwise_fusion_with_pool(&mut buffers, &[&complex, &complex], &ordered_plan)
+            .unwrap()
+            .is_none(),
+        "complex ordered ops stay outside erased strided fusion"
     );
 }
 

--- a/docs/worklogs/2026-07-27-strided-delegation-cpu-hot-kernels.md
+++ b/docs/worklogs/2026-07-27-strided-delegation-cpu-hot-kernels.md
@@ -1,0 +1,96 @@
+# 2026-07-27 Strided Delegation For CPU Hot Kernels
+
+## Summary
+
+Updated tenferro-rs to consume `tensor4all/strided-rs@20b2def9bf9554605d12fe13762f8770ba732efb`
+and made `tenferro-cpu` thinner where strided-rs now owns reusable prepared
+kernel replay:
+
+- CPU elementwise fusion delegates each output replay through
+  `strided_kernel::ErasedFusedPlan`.
+- CPU sum/product reductions delegate owned and read-view axis reductions
+  through `strided_kernel::ErasedReducePlan::compile_axes`.
+- CPU additive scatter and fixed-window dynamic slice/update delegate replay
+  through `ErasedScatterPlan`, `ErasedDynamicSlicePlan`, and
+  `ErasedDynamicUpdateSlicePlan`.
+
+Tenferro still owns public tensor semantics, validation, dtype dispatch,
+placement checks, `CpuContext` entry, buffer-pool allocation, and error
+translation.
+
+## Context Read
+
+- `AGENTS.md` and `REPOSITORY_RULES.md`
+- shared tensor4all common/Rust performance, docs/tests, and numerical rules
+- `docs/worklogs/2026-07-27-release-codegen-strided-upstream.md`
+- `docs/worklogs/2026-07-27-strided-gather-adoption.md`
+- `crates/tenferro-internal-cpu-kernels/src/elementwise.rs`
+- `crates/tenferro-cpu/src/indexing.rs`
+- `crates/tenferro-cpu/src/reduction.rs`
+- strided-rs `strided-kernel/src/erased.rs` and erased reduce/indexed plan tests
+
+## Decisions
+
+- Delegate only where strided-rs has a matching prepared erased plan. This
+  removes tenferro-local replay classifiers and tensor-sized indexed loops
+  without moving tenferro validation or resource ownership out of `CpuBackend`.
+- Keep direct eager/broadcast elementwise helpers on existing strided map/zip
+  calls. The change is specifically fused replay, not all elementwise wrapper
+  plumbing.
+- Execute strided plans with `ExecContext::serial()` inside the existing
+  `CpuContext::install` boundary. This preserves the repository rule that
+  `CpuBackend` owns Rayon/thread policy and avoids selecting ambient Rayon from
+  helper code.
+- Keep max/min reductions local for now. Strided `ReduceOp` only covers
+  sum/product, and tenferro's max/min NaN policy must not be changed silently.
+- Initialize bool destinations before constructing erased mutable descriptors
+  where strided validates bool byte values before replay. Non-bool full
+  overwrite outputs continue to use uninitialized pooled storage.
+- Fix integer sum/product overflow in strided-rs instead of adding a tenferro
+  fallback. The upstream bug was that erased integer reductions used normal
+  `+`/`*`; strided-rs #158 changed them to wrapping arithmetic for `i32` and
+  `i64`.
+
+## Rejected Or Deferred
+
+- No C ABI work in this PR. The strided C ABI remains a separate follow-up.
+- No TBLIS dependency or provider change in `tenferro-cpu`.
+- No static slice, pad, concatenate, reverse, triangular mask, or max/min
+  migration. These either lack a matching strided plan or have tenferro-specific
+  semantics that still need an accepted upstream design.
+- No performance claim. This PR is an ownership and correctness cleanup; formal
+  runtime/build benchmark work remains separate.
+
+## Verification
+
+- RED before implementation:
+  - `cargo test -p tenferro-internal-cpu-kernels elementwise_fusion_executes_i32_add_multiply_plan`
+  - `cargo test -p tenferro-cpu cpu_hot_kernels_delegate_to_erased_strided_replay`
+  - strided-rs `cargo test -p strided-kernel erased_reduce_plan_integer -- --nocapture`
+- strided-rs #158:
+  - `cargo fmt --check`
+  - `CARGO_BUILD_JOBS=64 cargo test -p strided-kernel`
+  - `CARGO_BUILD_JOBS=64 cargo test`
+  - `CARGO_BUILD_JOBS=64 cargo llvm-cov --workspace --json --output-path /tmp/strided-coverage-158.json`
+  - GitHub checks passed after rerunning a non-reproducing coverage allocation-count failure.
+- tenferro-rs:
+  - `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo check -p tenferro-internal-cpu-kernels -p tenferro-cpu`
+  - `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu indexing`
+  - `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu test_integer_reduce`
+  - `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-internal-cpu-kernels`
+  - `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu`
+  - `cargo fmt --all --check`
+  - `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu'`
+  - `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
+  - `python3 -m unittest discover -s scripts/ci/tests -v`
+  - `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true python3 scripts/ci/run_profile.py coverage`
+
+## Residual Risk
+
+- Multi-output fused plans are replayed as one strided single-output plan per
+  output. This keeps semantics simple but can recompute intermediates.
+- The ownership contract now assumes strided-rs keeps wrapping integer
+  sum/product semantics for erased reductions. The strided regression tests in
+  #158 cover both full and axis reductions.
+- Some dedicated tenferro loops remain by design. Future migrations should add
+  the general primitive to strided-rs first, then consume it from tenferro.

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "cfe90bd2fba38452f32fcdc9df120bb4dd28d151"
+        revision = "20b2def9bf9554605d12fe13762f8770ba732efb"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
## Summary
- update the workspace strided-rs pin to tensor4all/strided-rs@20b2def9bf9554605d12fe13762f8770ba732efb, which includes the erased integer reduction wrapping fix from strided-rs #158
- make `tenferro-cpu` thinner by delegating sum/product reductions, additive scatter, dynamic slice, and dynamic update replay to strided erased plans
- delegate fused elementwise replay in `tenferro-internal-cpu-kernels` to `ErasedFusedPlan`, removing the local binary-tail classifier/specialized replay path
- document the updated CPU kernel ownership boundary in `REPOSITORY_RULES.md` and the worklog

## Notes
- C ABI work is intentionally out of scope.
- `tenferro-cpu` still does not depend on `t4a-tblis-src` or ship the TBLIS provider dependency.
- Max/min reductions and static slice/pad/concat/reverse remain local because strided does not yet own matching semantics.

## Verification
- `cargo fmt --all --check`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu'`
- `python3 -m unittest discover -s scripts/ci/tests -v`
- `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true python3 scripts/ci/run_profile.py coverage`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
