### PR TITLE
Pass CPU exec context to strided replay

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "20b2def9bf9554605d12fe13762f8770ba732efb", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "20b2def9bf9554605d12fe13762f8770ba732efb", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "20b2def9bf9554605d12fe13762f8770ba732efb", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "20b2def9bf9554605d12fe13762f8770ba732efb", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "20b2def9bf9554605d12fe13762f8770ba732efb", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "f1343692f8afbc1d1c1f4614478772ae5683dcbb", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "f1343692f8afbc1d1c1f4614478772ae5683dcbb", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "f1343692f8afbc1d1c1f4614478772ae5683dcbb", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "f1343692f8afbc1d1c1f4614478772ae5683dcbb", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "f1343692f8afbc1d1c1f4614478772ae5683dcbb", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -2188,12 +2188,37 @@ impl CpuBackend {
             .map_err(|error| crate::Error::backend_source("CPU tensor execution", error))?
     }
 
+    fn try_install_with_context<R: Send>(
+        &self,
+        op: impl FnOnce(&CpuExecutionContext<'_>) -> crate::Result<R> + Send,
+    ) -> crate::Result<R> {
+        let owner = inherited_or_new_execution_owner();
+        let permit = self.acquire_execution_permit(owner);
+        let entry = CpuOperationEntry::new(self.engine.domain(), &permit);
+        let mode = entry.preferred_engine_mode();
+        entry
+            .enter(mode, |context| {
+                context.with_native_parallelism(|| op(context))
+            })
+            .map_err(|error| crate::Error::backend_source("CPU tensor execution", error))?
+    }
+
     fn try_install_fresh<R: FreshCpuOutput + Send>(
         &self,
         op: impl FnOnce() -> crate::Result<R> + Send,
     ) -> crate::Result<R> {
         let domain = self.engine.domain().id();
         let mut output = self.try_install(op)?;
+        output.tag_fresh(domain);
+        Ok(output)
+    }
+
+    fn try_install_fresh_with_context<R: FreshCpuOutput + Send>(
+        &self,
+        op: impl FnOnce(&CpuExecutionContext<'_>) -> crate::Result<R> + Send,
+    ) -> crate::Result<R> {
+        let domain = self.engine.domain().id();
+        let mut output = self.try_install_with_context(op)?;
         output.tag_fresh(domain);
         Ok(output)
     }
@@ -2218,12 +2243,42 @@ impl CpuBackend {
             .map_err(|error| crate::Error::backend_source("CPU tensor execution", error))?
     }
 
+    fn install_with_pool_context_unmarked<R: Send>(
+        &mut self,
+        op: impl FnOnce(&CpuExecutionContext<'_>, &mut BufferPool) -> crate::Result<R> + Send,
+    ) -> crate::Result<R> {
+        let owner = inherited_or_new_execution_owner();
+        let permit = self.acquire_execution_permit(owner);
+        let entry = CpuOperationEntry::new(self.engine.domain(), &permit);
+        let mode = entry.preferred_engine_mode();
+        entry
+            .enter(mode, |context| {
+                context.with_native_parallelism(|| {
+                    self.with_execution_resources(&permit, |resources| {
+                        let mut buffers = BufferPoolLoan::new(&mut resources.buffers);
+                        op(context, buffers.get_mut())
+                    })
+                })
+            })
+            .map_err(|error| crate::Error::backend_source("CPU tensor execution", error))?
+    }
+
     fn install_with_pool<R: FreshCpuOutput + Send>(
         &mut self,
         op: impl FnOnce(&mut BufferPool) -> crate::Result<R> + Send,
     ) -> crate::Result<R> {
         let domain = self.engine.domain().id();
         let mut output = self.install_with_pool_unmarked(op)?;
+        output.tag_fresh(domain);
+        Ok(output)
+    }
+
+    fn install_with_pool_context<R: FreshCpuOutput + Send>(
+        &mut self,
+        op: impl FnOnce(&CpuExecutionContext<'_>, &mut BufferPool) -> crate::Result<R> + Send,
+    ) -> crate::Result<R> {
+        let domain = self.engine.domain().id();
+        let mut output = self.install_with_pool_context_unmarked(op)?;
         output.tag_fresh(domain);
         Ok(output)
     }
@@ -2652,19 +2707,31 @@ impl TensorStructural for CpuBackend {
 
 impl TensorReduction for CpuBackend {
     fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-        self.try_install_fresh(|| reduction::reduce_sum(input, axes))
+        self.try_install_fresh_with_context(|context| {
+            let exec_context = context.strided_exec_context();
+            reduction::reduce_sum(input, axes, &exec_context)
+        })
     }
 
     fn reduce_sum_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        self.install_with_pool(|buffers| reduction::reduce_sum_read(buffers, input, axes))
+        self.install_with_pool_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            reduction::reduce_sum_read(buffers, input, axes, &exec_context)
+        })
     }
 
     fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
-        self.try_install_fresh(|| reduction::reduce_prod(input, axes))
+        self.try_install_fresh_with_context(|context| {
+            let exec_context = context.strided_exec_context();
+            reduction::reduce_prod(input, axes, &exec_context)
+        })
     }
 
     fn reduce_prod_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        self.install_with_pool(|buffers| reduction::reduce_prod_read(buffers, input, axes))
+        self.install_with_pool_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            reduction::reduce_prod_read(buffers, input, axes, &exec_context)
+        })
     }
 
     fn reduce_max(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
@@ -2817,8 +2884,9 @@ impl TensorIndexing for CpuBackend {
         start_indices: &Tensor,
         config: &GatherConfig,
     ) -> crate::Result<Tensor> {
-        self.install_with_pool(|buffers| {
-            indexing::gather_with_pool(buffers, operand, start_indices, config)
+        self.install_with_pool_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::gather_with_pool(buffers, &exec_context, operand, start_indices, config)
         })
     }
 
@@ -2829,8 +2897,16 @@ impl TensorIndexing for CpuBackend {
         updates: &Tensor,
         config: &ScatterConfig,
     ) -> crate::Result<Tensor> {
-        self.install_with_pool(|buffers| {
-            indexing::scatter_with_pool(buffers, operand, scatter_indices, updates, config)
+        self.install_with_pool_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::scatter_with_pool(
+                buffers,
+                &exec_context,
+                operand,
+                scatter_indices,
+                updates,
+                config,
+            )
         })
     }
 
@@ -2844,8 +2920,9 @@ impl TensorIndexing for CpuBackend {
         starts: &Tensor,
         slice_sizes: &[usize],
     ) -> crate::Result<Tensor> {
-        self.install_with_pool(|buffers| {
-            indexing::dynamic_slice_with_pool(buffers, input, starts, slice_sizes)
+        self.install_with_pool_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::dynamic_slice_with_pool(buffers, &exec_context, input, starts, slice_sizes)
         })
     }
 
@@ -2855,8 +2932,15 @@ impl TensorIndexing for CpuBackend {
         update: &Tensor,
         starts: &Tensor,
     ) -> crate::Result<Tensor> {
-        self.install_with_pool(|buffers| {
-            indexing::dynamic_update_slice_with_pool(buffers, operand, update, starts)
+        self.install_with_pool_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::dynamic_update_slice_with_pool(
+                buffers,
+                &exec_context,
+                operand,
+                update,
+                starts,
+            )
         })
     }
 
@@ -3055,8 +3139,9 @@ impl TensorFusion for CpuBackend {
         inputs: &[&Tensor],
         plan: &ElementwiseFusionPlan,
     ) -> crate::Result<Option<Vec<Tensor>>> {
-        self.install_with_pool(|buffers| {
-            elementwise::elementwise_fusion_with_pool(buffers, inputs, plan)
+        self.install_with_pool_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            elementwise::elementwise_fusion_with_pool(buffers, &exec_context, inputs, plan)
         })
     }
 

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -196,6 +196,17 @@ fn cpu_hot_kernels_delegate_to_erased_strided_replay() {
         reduction.contains("ErasedReducePlan::compile_axes"),
         "CPU sum/product axis reductions should delegate to erased strided reduce plans"
     );
+    for (name, source) in [
+        ("elementwise", elementwise),
+        ("indexing", indexing),
+        ("reduction", reduction),
+    ] {
+        let compact_source = source.split_whitespace().collect::<String>();
+        assert!(
+            !compact_source.contains(".execute(&ExecContext::serial()"),
+            "{name} erased strided replay should inherit CpuExecutionContext, not force serial"
+        );
+    }
 }
 
 #[test]

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -100,6 +100,30 @@ impl CpuExecSession<'_> {
             })
             .map_err(|error| crate::Error::backend_source("CPU native execution", error))?
     }
+
+    fn run_native_fresh_with_context<R: FreshCpuOutput + Send>(
+        &mut self,
+        op: impl FnOnce(&CpuExecutionContext<'_>, &mut BufferPool) -> crate::Result<R> + Send,
+    ) -> crate::Result<R> {
+        let buffers = &mut *self.buffers;
+        if let Some(context) = self.entered {
+            return context.with_native_parallelism(|| {
+                let mut output = op(&context, buffers)?;
+                output.tag_fresh(context.domain_id());
+                Ok(output)
+            });
+        }
+        let mode = self.entry.preferred_engine_mode();
+        self.entry
+            .enter(mode, |context| {
+                context.with_native_parallelism(|| {
+                    let mut output = op(context, buffers)?;
+                    output.tag_fresh(context.domain_id());
+                    Ok(output)
+                })
+            })
+            .map_err(|error| crate::Error::backend_source("CPU native execution", error))?
+    }
 }
 
 impl TensorDeviceTransfer for CpuExecSession<'_> {
@@ -255,16 +279,32 @@ impl TensorStructural for CpuExecSession<'_> {
 
 impl TensorReduction for CpuExecSession<'_> {
     // Reduction
-    delegate!(reduce_sum(input: &Tensor, axes: &[usize]) => reduction::reduce_sum(input, axes));
-
-    fn reduce_sum_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        self.run_native_fresh(|buffers| reduction::reduce_sum_read(buffers, input, axes))
+    fn reduce_sum(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+        self.run_native_fresh_with_context(|context, _| {
+            let exec_context = context.strided_exec_context();
+            reduction::reduce_sum(input, axes, &exec_context)
+        })
     }
 
-    delegate!(reduce_prod(input: &Tensor, axes: &[usize]) => reduction::reduce_prod(input, axes));
+    fn reduce_sum_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
+        self.run_native_fresh_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            reduction::reduce_sum_read(buffers, input, axes, &exec_context)
+        })
+    }
+
+    fn reduce_prod(&mut self, input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+        self.run_native_fresh_with_context(|context, _| {
+            let exec_context = context.strided_exec_context();
+            reduction::reduce_prod(input, axes, &exec_context)
+        })
+    }
 
     fn reduce_prod_read(&mut self, input: TensorRead<'_>, axes: &[usize]) -> crate::Result<Tensor> {
-        self.run_native_fresh(|buffers| reduction::reduce_prod_read(buffers, input, axes))
+        self.run_native_fresh_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            reduction::reduce_prod_read(buffers, input, axes, &exec_context)
+        })
     }
 
     delegate!(reduce_max(input: &Tensor, axes: &[usize]) => reduction::reduce_max(input, axes));
@@ -494,14 +534,52 @@ impl TensorIndexing for CpuExecSession<'_> {
         start_indices: &Tensor,
         config: &GatherConfig,
     ) -> crate::Result<Tensor> {
-        self.run_native_fresh(|buffers| {
-            indexing::gather_with_pool(buffers, operand, start_indices, config)
+        self.run_native_fresh_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::gather_with_pool(buffers, &exec_context, operand, start_indices, config)
         })
     }
-    delegate_with_pool!(scatter(operand: &Tensor, indices: &Tensor, updates: &Tensor, config: &ScatterConfig) => indexing::scatter_with_pool);
+    fn scatter(
+        &mut self,
+        operand: &Tensor,
+        indices: &Tensor,
+        updates: &Tensor,
+        config: &ScatterConfig,
+    ) -> crate::Result<Tensor> {
+        self.run_native_fresh_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::scatter_with_pool(buffers, &exec_context, operand, indices, updates, config)
+        })
+    }
     delegate_with_pool!(slice(input: &Tensor, config: &SliceConfig) => indexing::try_slice_with_pool);
-    delegate_with_pool!(dynamic_slice(input: &Tensor, starts: &Tensor, slice_sizes: &[usize]) => indexing::dynamic_slice_with_pool);
-    delegate_with_pool!(dynamic_update_slice(operand: &Tensor, update: &Tensor, starts: &Tensor) => indexing::dynamic_update_slice_with_pool);
+    fn dynamic_slice(
+        &mut self,
+        input: &Tensor,
+        starts: &Tensor,
+        slice_sizes: &[usize],
+    ) -> crate::Result<Tensor> {
+        self.run_native_fresh_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::dynamic_slice_with_pool(buffers, &exec_context, input, starts, slice_sizes)
+        })
+    }
+    fn dynamic_update_slice(
+        &mut self,
+        operand: &Tensor,
+        update: &Tensor,
+        starts: &Tensor,
+    ) -> crate::Result<Tensor> {
+        self.run_native_fresh_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            indexing::dynamic_update_slice_with_pool(
+                buffers,
+                &exec_context,
+                operand,
+                update,
+                starts,
+            )
+        })
+    }
     delegate_with_pool!(pad(input: &Tensor, config: &PadConfig) => indexing::try_pad_with_pool);
     fn concatenate(&mut self, inputs: &[&Tensor], axis: usize) -> crate::Result<Tensor> {
         self.run_native_fresh(|buffers| indexing::try_concatenate_with_pool(buffers, inputs, axis))
@@ -531,8 +609,9 @@ impl TensorFusion for CpuExecSession<'_> {
         inputs: &[&Tensor],
         plan: &ElementwiseFusionPlan,
     ) -> crate::Result<Option<Vec<Tensor>>> {
-        self.run_native_fresh(|buffers| {
-            elementwise::elementwise_fusion_with_pool(buffers, inputs, plan)
+        self.run_native_fresh_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            elementwise::elementwise_fusion_with_pool(buffers, &exec_context, inputs, plan)
         })
     }
 

--- a/crates/tenferro-cpu/src/indexing.rs
+++ b/crates/tenferro-cpu/src/indexing.rs
@@ -202,11 +202,20 @@ pub(crate) fn gather(
     start_indices: &Tensor,
     config: &GatherConfig,
 ) -> crate::Result<Tensor> {
-    with_test_pool(|buffers| gather_with_pool(buffers, operand, start_indices, config))
+    with_test_pool(|buffers| {
+        gather_with_pool(
+            buffers,
+            &ExecContext::serial(),
+            operand,
+            start_indices,
+            config,
+        )
+    })
 }
 
 pub(crate) fn gather_with_pool(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     operand: &Tensor,
     start_indices: &Tensor,
     config: &GatherConfig,
@@ -214,6 +223,7 @@ pub(crate) fn gather_with_pool(
     let start_indices = try_index_tensor(start_indices)?;
     dispatch_tensor_unary_result!(operand, |t| typed_gather(
         buffers,
+        exec_context,
         t,
         &start_indices,
         config
@@ -227,11 +237,21 @@ pub(crate) fn scatter(
     updates: &Tensor,
     config: &ScatterConfig,
 ) -> crate::Result<Tensor> {
-    with_test_pool(|buffers| scatter_with_pool(buffers, operand, scatter_indices, updates, config))
+    with_test_pool(|buffers| {
+        scatter_with_pool(
+            buffers,
+            &ExecContext::serial(),
+            operand,
+            scatter_indices,
+            updates,
+            config,
+        )
+    })
 }
 
 pub(crate) fn scatter_with_pool(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     operand: &Tensor,
     scatter_indices: &Tensor,
     updates: &Tensor,
@@ -243,7 +263,7 @@ pub(crate) fn scatter_with_pool(
         operand,
         updates,
         "Bool data tensors are not supported by additive scatter",
-        |op, upd| typed_scatter(buffers, op, &scatter_indices, upd, config)
+        |op, upd| typed_scatter(buffers, exec_context, op, &scatter_indices, upd, config)
     )
 }
 
@@ -261,11 +281,14 @@ pub(crate) fn dynamic_slice(
     starts: &Tensor,
     slice_sizes: &[usize],
 ) -> crate::Result<Tensor> {
-    with_test_pool(|buffers| dynamic_slice_with_pool(buffers, input, starts, slice_sizes))
+    with_test_pool(|buffers| {
+        dynamic_slice_with_pool(buffers, &ExecContext::serial(), input, starts, slice_sizes)
+    })
 }
 
 pub(crate) fn dynamic_slice_with_pool(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     input: &Tensor,
     starts: &Tensor,
     slice_sizes: &[usize],
@@ -273,6 +296,7 @@ pub(crate) fn dynamic_slice_with_pool(
     let starts = try_index_tensor(starts)?;
     dispatch_tensor_unary_result!(input, |t| typed_dynamic_slice(
         buffers,
+        exec_context,
         t,
         &starts,
         slice_sizes
@@ -304,18 +328,21 @@ pub(crate) fn dynamic_update_slice(
     update: &Tensor,
     starts: &Tensor,
 ) -> crate::Result<Tensor> {
-    with_test_pool(|buffers| dynamic_update_slice_with_pool(buffers, operand, update, starts))
+    with_test_pool(|buffers| {
+        dynamic_update_slice_with_pool(buffers, &ExecContext::serial(), operand, update, starts)
+    })
 }
 
 pub(crate) fn dynamic_update_slice_with_pool(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     operand: &Tensor,
     update: &Tensor,
     starts: &Tensor,
 ) -> crate::Result<Tensor> {
     let starts = try_index_tensor(starts)?;
     dispatch_same_dtype_result!("dynamic_update_slice", operand, update, |op, upd| {
-        typed_dynamic_update_slice(buffers, op, upd, &starts)
+        typed_dynamic_update_slice(buffers, exec_context, op, upd, &starts)
     })
 }
 
@@ -767,6 +794,7 @@ fn operand_window_dims(rank: usize, collapsed_or_inserted: &[usize]) -> Vec<usiz
 
 fn typed_gather<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     operand: &TypedTensor<T>,
     start_indices: &IndexTensor,
     config: &GatherConfig,
@@ -951,19 +979,15 @@ fn typed_gather<T: Copy + Clone + PoolScalar + TensorScalar>(
         0,
     )
     .map_err(|err| crate::Error::backend_source("gather", err))?;
-    plan.execute(
-        &ExecContext::serial(),
-        &mut out_ref,
-        &operand_ref,
-        &index_ref,
-    )
-    .map_err(|err| crate::Error::backend_source("gather", err))?;
+    plan.execute(exec_context, &mut out_ref, &operand_ref, &index_ref)
+        .map_err(|err| crate::Error::backend_source("gather", err))?;
 
     Ok(out)
 }
 
 fn typed_scatter<T>(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     operand: &TypedTensor<T>,
     scatter_indices: &IndexTensor,
     updates: &TypedTensor<T>,
@@ -1188,7 +1212,7 @@ where
     )
     .map_err(|err| crate::Error::backend_source("scatter", err))?;
     plan.execute(
-        &ExecContext::serial(),
+        exec_context,
         &mut out_ref,
         &operand_ref,
         &index_ref,
@@ -1201,6 +1225,7 @@ where
 
 fn typed_dynamic_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     input: &TypedTensor<T>,
     starts: &IndexTensor,
     slice_sizes: &[usize],
@@ -1287,7 +1312,7 @@ fn typed_dynamic_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
         0,
     )
     .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
-    plan.execute(&ExecContext::serial(), &mut out_ref, &input_ref, &start_ref)
+    plan.execute(exec_context, &mut out_ref, &input_ref, &start_ref)
         .map_err(|err| crate::Error::backend_source("dynamic_slice", err))?;
 
     Ok(out)
@@ -1295,6 +1320,7 @@ fn typed_dynamic_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
 
 fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     operand: &TypedTensor<T>,
     update: &TypedTensor<T>,
     starts: &IndexTensor,
@@ -1393,7 +1419,7 @@ fn typed_dynamic_update_slice<T: Copy + Clone + PoolScalar + TensorScalar>(
     )
     .map_err(|err| crate::Error::backend_source("dynamic_update_slice", err))?;
     plan.execute(
-        &ExecContext::serial(),
+        exec_context,
         &mut out_ref,
         &operand_ref,
         &update_ref,

--- a/crates/tenferro-cpu/src/provider.rs
+++ b/crates/tenferro-cpu/src/provider.rs
@@ -19,9 +19,9 @@ use crate::buffer_pool::BufferPool;
 use crate::domain_executor::{indexed_jobs, install_scoped};
 #[cfg(feature = "cpu-blas")]
 use crate::provider_capability::builtin_blas_execution_capabilities;
-use crate::provider_capability::{
-    engine_worker_capabilities, serial_capabilities, CpuProviderExecutionCapabilities,
-};
+#[cfg(not(feature = "cpu-blas"))]
+use crate::provider_capability::serial_capabilities;
+use crate::provider_capability::{engine_worker_capabilities, CpuProviderExecutionCapabilities};
 use crate::resource_domain::CpuResourceDomain;
 use crate::{
     CpuDomainExecutorError, CpuDomainId, CpuInnerParallelism, CpuPlacementGuarantee, CpuSet,
@@ -363,6 +363,26 @@ impl<'a> CpuExecutionContext<'a> {
                 faer::Par::rayon(self.thread_budget().get())
             }
             _ => faer::Par::Seq,
+        }
+    }
+
+    pub(crate) fn strided_exec_context(&self) -> strided_kernel::ExecContext {
+        match (
+            self.parallel_mode,
+            self.domain.executor_capabilities().inner_parallelism,
+        ) {
+            (ParallelMode::Inner, CpuInnerParallelism::Rayon) if self.thread_budget().get() > 1 => {
+                // This is only an operation-local thread limit for strided's
+                // replay policy. The Rayon pool itself is the already-entered
+                // CpuContext pool installed by `with_native_parallelism`.
+                match strided_kernel::ExecContext::max_threads(self.thread_budget().get()) {
+                    Ok(context) => context,
+                    // INVARIANT: CpuExecutionContext stores a NonZeroUsize
+                    // thread budget, and this branch passes that positive value.
+                    Err(_) => unreachable!("CpuExecutionContext has a non-zero thread budget"),
+                }
+            }
+            _ => strided_kernel::ExecContext::serial(),
         }
     }
 

--- a/crates/tenferro-cpu/src/provider/tests.rs
+++ b/crates/tenferro-cpu/src/provider/tests.rs
@@ -230,6 +230,27 @@ fn execution_context_is_the_single_source_of_faer_parallelism() {
 }
 
 #[test]
+fn execution_context_is_the_single_source_of_erased_strided_replay_policy() {
+    let single = execution_context_fixture(1);
+    single.with_context(ParallelMode::Sequential, |context| {
+        let strided = context.strided_exec_context();
+        assert!(strided.is_serial());
+        assert_eq!(strided.max_threads_limit(), None);
+    });
+
+    let multi = execution_context_fixture(2);
+    multi.with_context(ParallelMode::Inner, |context| {
+        let strided = context.strided_exec_context();
+        assert_eq!(strided.max_threads_limit(), NonZeroUsize::new(2));
+    });
+    multi.with_context(ParallelMode::Sequential, |context| {
+        let strided = context.strided_exec_context();
+        assert!(strided.is_serial());
+        assert_eq!(strided.max_threads_limit(), None);
+    });
+}
+
+#[test]
 fn outer_mode_is_rejected_before_install_or_operation_mutation() {
     let multi = execution_context_fixture(2);
     let ran = AtomicUsize::new(0);

--- a/crates/tenferro-cpu/src/provider_capability.rs
+++ b/crates/tenferro-cpu/src/provider_capability.rs
@@ -280,6 +280,7 @@ fn uncontrolled_external_capabilities() -> CpuProviderExecutionCapabilities {
     }
 }
 
+#[cfg(any(test, not(feature = "cpu-blas")))]
 pub(crate) fn serial_capabilities() -> CpuProviderExecutionCapabilities {
     CpuProviderExecutionCapabilities {
         thread_count: CpuThreadCountControl::Sequential,

--- a/crates/tenferro-cpu/src/reduction.rs
+++ b/crates/tenferro-cpu/src/reduction.rs
@@ -176,22 +176,34 @@ impl_wrapping_reduction_elem!(i64);
 /// `DuplicateAxis`, or `InvalidArgument` for invalid axes or zero-length
 /// reductions, [`crate::Error::Unsupported`] for `Bool`, or a typed backend
 /// error when the input storage cannot be read.
-pub fn reduce_sum(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+pub(crate) fn reduce_sum(
+    input: &Tensor,
+    axes: &[usize],
+    exec_context: &ExecContext,
+) -> crate::Result<Tensor> {
     if let Some(output) = reduction_empty_axes_noop("reduce_sum", input, axes)? {
         return Ok(output);
     }
 
     match input {
-        Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_sum(t, axes)?)),
-        Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_sum(t, axes)?)),
-        Tensor::I32(t) => Ok(Tensor::I32(typed_reduce_sum_wrapping(t, axes)?)),
-        Tensor::I64(t) => Ok(Tensor::I64(typed_reduce_sum_wrapping(t, axes)?)),
+        Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_sum(t, axes, exec_context)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_sum(t, axes, exec_context)?)),
+        Tensor::I32(t) => Ok(Tensor::I32(typed_reduce_sum_wrapping(
+            t,
+            axes,
+            exec_context,
+        )?)),
+        Tensor::I64(t) => Ok(Tensor::I64(typed_reduce_sum_wrapping(
+            t,
+            axes,
+            exec_context,
+        )?)),
         Tensor::Bool(_) => Err(crate::Error::unsupported(
             "reduce_sum",
             "unsupported dtype Bool",
         )),
-        Tensor::C32(t) => Ok(Tensor::C32(typed_reduce_sum(t, axes)?)),
-        Tensor::C64(t) => Ok(Tensor::C64(typed_reduce_sum(t, axes)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_reduce_sum(t, axes, exec_context)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_reduce_sum(t, axes, exec_context)?)),
     }
 }
 
@@ -199,6 +211,7 @@ pub(crate) fn reduce_sum_read(
     buffers: &mut BufferPool,
     input: TensorRead<'_>,
     axes: &[usize],
+    exec_context: &ExecContext,
 ) -> crate::Result<Tensor> {
     if let Some(output) = reduction_read_empty_axes_noop(buffers, "reduce_sum", &input, axes)? {
         return Ok(output);
@@ -207,7 +220,7 @@ pub(crate) fn reduce_sum_read(
     match input {
         TensorRead::Tensor(input) => {
             ensure_host_tensor("reduce_sum", input)?;
-            reduce_sum(input, axes)
+            reduce_sum(input, axes, exec_context)
         }
         TensorRead::View(TensorView::F32(t)) => Ok(Tensor::F32(typed_reduce_view_erased(
             buffers,
@@ -215,6 +228,7 @@ pub(crate) fn reduce_sum_read(
             axes,
             ReduceOp::Sum,
             "reduce_sum",
+            exec_context,
         )?)),
         TensorRead::View(TensorView::F64(t)) => Ok(Tensor::F64(typed_reduce_view_erased(
             buffers,
@@ -222,6 +236,7 @@ pub(crate) fn reduce_sum_read(
             axes,
             ReduceOp::Sum,
             "reduce_sum",
+            exec_context,
         )?)),
         TensorRead::View(TensorView::I32(t)) => Ok(Tensor::I32(typed_reduce_view_erased(
             buffers,
@@ -229,6 +244,7 @@ pub(crate) fn reduce_sum_read(
             axes,
             ReduceOp::Sum,
             "reduce_sum",
+            exec_context,
         )?)),
         TensorRead::View(TensorView::I64(t)) => Ok(Tensor::I64(typed_reduce_view_erased(
             buffers,
@@ -236,6 +252,7 @@ pub(crate) fn reduce_sum_read(
             axes,
             ReduceOp::Sum,
             "reduce_sum",
+            exec_context,
         )?)),
         TensorRead::View(TensorView::Bool(_)) => Err(crate::Error::unsupported(
             "reduce_sum",
@@ -247,6 +264,7 @@ pub(crate) fn reduce_sum_read(
             axes,
             ReduceOp::Sum,
             "reduce_sum",
+            exec_context,
         )?)),
         TensorRead::View(TensorView::C64(t)) => Ok(Tensor::C64(typed_reduce_view_erased(
             buffers,
@@ -254,6 +272,7 @@ pub(crate) fn reduce_sum_read(
             axes,
             ReduceOp::Sum,
             "reduce_sum",
+            exec_context,
         )?)),
     }
 }
@@ -264,22 +283,34 @@ pub(crate) fn reduce_sum_read(
 /// `DuplicateAxis`, or `InvalidArgument` for invalid axes or zero-length
 /// reductions, [`crate::Error::Unsupported`] for `Bool`, or a typed backend
 /// error when the input storage cannot be read.
-pub fn reduce_prod(input: &Tensor, axes: &[usize]) -> crate::Result<Tensor> {
+pub(crate) fn reduce_prod(
+    input: &Tensor,
+    axes: &[usize],
+    exec_context: &ExecContext,
+) -> crate::Result<Tensor> {
     if let Some(output) = reduction_empty_axes_noop("reduce_prod", input, axes)? {
         return Ok(output);
     }
 
     match input {
-        Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_prod(t, axes)?)),
-        Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_prod(t, axes)?)),
-        Tensor::I32(t) => Ok(Tensor::I32(typed_reduce_prod_wrapping(t, axes)?)),
-        Tensor::I64(t) => Ok(Tensor::I64(typed_reduce_prod_wrapping(t, axes)?)),
+        Tensor::F32(t) => Ok(Tensor::F32(typed_reduce_prod(t, axes, exec_context)?)),
+        Tensor::F64(t) => Ok(Tensor::F64(typed_reduce_prod(t, axes, exec_context)?)),
+        Tensor::I32(t) => Ok(Tensor::I32(typed_reduce_prod_wrapping(
+            t,
+            axes,
+            exec_context,
+        )?)),
+        Tensor::I64(t) => Ok(Tensor::I64(typed_reduce_prod_wrapping(
+            t,
+            axes,
+            exec_context,
+        )?)),
         Tensor::Bool(_) => Err(crate::Error::unsupported(
             "reduce_prod",
             "unsupported dtype Bool",
         )),
-        Tensor::C32(t) => Ok(Tensor::C32(typed_reduce_prod(t, axes)?)),
-        Tensor::C64(t) => Ok(Tensor::C64(typed_reduce_prod(t, axes)?)),
+        Tensor::C32(t) => Ok(Tensor::C32(typed_reduce_prod(t, axes, exec_context)?)),
+        Tensor::C64(t) => Ok(Tensor::C64(typed_reduce_prod(t, axes, exec_context)?)),
     }
 }
 
@@ -287,6 +318,7 @@ pub(crate) fn reduce_prod_read(
     buffers: &mut BufferPool,
     input: TensorRead<'_>,
     axes: &[usize],
+    exec_context: &ExecContext,
 ) -> crate::Result<Tensor> {
     if let Some(output) = reduction_read_empty_axes_noop(buffers, "reduce_prod", &input, axes)? {
         return Ok(output);
@@ -295,7 +327,7 @@ pub(crate) fn reduce_prod_read(
     match input {
         TensorRead::Tensor(input) => {
             ensure_host_tensor("reduce_prod", input)?;
-            reduce_prod(input, axes)
+            reduce_prod(input, axes, exec_context)
         }
         TensorRead::View(TensorView::F32(t)) => Ok(Tensor::F32(typed_reduce_view_erased(
             buffers,
@@ -303,6 +335,7 @@ pub(crate) fn reduce_prod_read(
             axes,
             ReduceOp::Product,
             "reduce_prod",
+            exec_context,
         )?)),
         TensorRead::View(TensorView::F64(t)) => Ok(Tensor::F64(typed_reduce_view_erased(
             buffers,
@@ -310,6 +343,7 @@ pub(crate) fn reduce_prod_read(
             axes,
             ReduceOp::Product,
             "reduce_prod",
+            exec_context,
         )?)),
         TensorRead::View(TensorView::I32(t)) => Ok(Tensor::I32(typed_reduce_view_erased(
             buffers,
@@ -317,6 +351,7 @@ pub(crate) fn reduce_prod_read(
             axes,
             ReduceOp::Product,
             "reduce_prod",
+            exec_context,
         )?)),
         TensorRead::View(TensorView::I64(t)) => Ok(Tensor::I64(typed_reduce_view_erased(
             buffers,
@@ -324,6 +359,7 @@ pub(crate) fn reduce_prod_read(
             axes,
             ReduceOp::Product,
             "reduce_prod",
+            exec_context,
         )?)),
         TensorRead::View(TensorView::Bool(_)) => Err(crate::Error::unsupported(
             "reduce_prod",
@@ -335,6 +371,7 @@ pub(crate) fn reduce_prod_read(
             axes,
             ReduceOp::Product,
             "reduce_prod",
+            exec_context,
         )?)),
         TensorRead::View(TensorView::C64(t)) => Ok(Tensor::C64(typed_reduce_view_erased(
             buffers,
@@ -342,6 +379,7 @@ pub(crate) fn reduce_prod_read(
             axes,
             ReduceOp::Product,
             "reduce_prod",
+            exec_context,
         )?)),
     }
 }
@@ -575,6 +613,7 @@ fn typed_reduce_erased<T>(
     axes: &[usize],
     op: ReduceOp,
     label: &'static str,
+    exec_context: &ExecContext,
 ) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + TensorScalar,
@@ -620,7 +659,7 @@ where
         0,
     )
     .map_err(|err| crate::Error::backend_source(label, err))?;
-    plan.execute(&ExecContext::serial(), &mut dest, &source)
+    plan.execute(exec_context, &mut dest, &source)
         .map_err(|err| crate::Error::backend_source(label, err))?;
 
     TypedTensor::from_vec_col_major(output_shape, output)
@@ -691,6 +730,7 @@ fn typed_reduce_view_erased<T, TR>(
     axes: &[usize],
     op: ReduceOp,
     label: &'static str,
+    exec_context: &ExecContext,
 ) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + TensorScalar + crate::buffer_pool::PoolScalar + 'static,
@@ -736,7 +776,7 @@ where
         0,
     )
     .map_err(|err| crate::Error::backend_source(label, err))?;
-    plan.execute(&ExecContext::serial(), &mut dest, &source)
+    plan.execute(exec_context, &mut dest, &source)
         .map_err(|err| crate::Error::backend_source(label, err))?;
 
     Ok(crate::tensor_from_array(output))
@@ -747,21 +787,26 @@ where
 /// Returns [`crate::Error::Validation`] with `AxisOutOfBounds`,
 /// `DuplicateAxis`, or `InvalidArgument` for invalid axes or zero-length
 /// reductions, or a typed backend error while materializing the result.
-pub fn typed_reduce_sum<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>
+pub(crate) fn typed_reduce_sum<T>(
+    input: &TypedTensor<T>,
+    axes: &[usize],
+    exec_context: &ExecContext,
+) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Send + Sync + TensorScalar,
 {
-    typed_reduce_erased(input, axes, ReduceOp::Sum, "reduce_sum")
+    typed_reduce_erased(input, axes, ReduceOp::Sum, "reduce_sum", exec_context)
 }
 
 fn typed_reduce_sum_wrapping<T>(
     input: &TypedTensor<T>,
     axes: &[usize],
+    exec_context: &ExecContext,
 ) -> crate::Result<TypedTensor<T>>
 where
     T: WrappingReductionElem + TensorScalar,
 {
-    typed_reduce_erased(input, axes, ReduceOp::Sum, "reduce_sum")
+    typed_reduce_erased(input, axes, ReduceOp::Sum, "reduce_sum", exec_context)
 }
 
 /// # Errors
@@ -769,21 +814,26 @@ where
 /// Returns [`crate::Error::Validation`] with `AxisOutOfBounds`,
 /// `DuplicateAxis`, or `InvalidArgument` for invalid axes or zero-length
 /// reductions, or a typed backend error while materializing the result.
-pub fn typed_reduce_prod<T>(input: &TypedTensor<T>, axes: &[usize]) -> crate::Result<TypedTensor<T>>
+pub(crate) fn typed_reduce_prod<T>(
+    input: &TypedTensor<T>,
+    axes: &[usize],
+    exec_context: &ExecContext,
+) -> crate::Result<TypedTensor<T>>
 where
     T: Copy + Clone + Send + Sync + TensorScalar,
 {
-    typed_reduce_erased(input, axes, ReduceOp::Product, "reduce_prod")
+    typed_reduce_erased(input, axes, ReduceOp::Product, "reduce_prod", exec_context)
 }
 
 fn typed_reduce_prod_wrapping<T>(
     input: &TypedTensor<T>,
     axes: &[usize],
+    exec_context: &ExecContext,
 ) -> crate::Result<TypedTensor<T>>
 where
     T: WrappingReductionElem + TensorScalar,
 {
-    typed_reduce_erased(input, axes, ReduceOp::Product, "reduce_prod")
+    typed_reduce_erased(input, axes, ReduceOp::Product, "reduce_prod", exec_context)
 }
 
 /// # Errors

--- a/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/basic_ops.rs
@@ -671,13 +671,13 @@ fn test_reduce_sum() {
     let t = Tensor::F64(
         TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
     );
-    let r = reduce_sum(&t, &[0]).unwrap();
+    let r = reduce_sum(&t, &[0], &strided_kernel::ExecContext::serial()).unwrap();
     assert_eq!(r.shape(), &[3]);
     assert_eq!(get_f64(&r, &[0]), 3.0);
     assert_eq!(get_f64(&r, &[1]), 7.0);
     assert_eq!(get_f64(&r, &[2]), 11.0);
 
-    let all = reduce_sum(&t, &[0, 1]).unwrap();
+    let all = reduce_sum(&t, &[0, 1], &strided_kernel::ExecContext::serial()).unwrap();
     assert!(all.shape().is_empty());
     assert_eq!(get_f64(&all, &[]), 21.0);
 }
@@ -688,13 +688,13 @@ fn test_reduce_prod() {
         TypedTensor::from_vec_col_major(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap(),
     );
 
-    let r = reduce_prod(&t, &[0]).unwrap();
+    let r = reduce_prod(&t, &[0], &strided_kernel::ExecContext::serial()).unwrap();
     assert_eq!(r.shape(), &[3]);
     assert_eq!(get_f64(&r, &[0]), 2.0);
     assert_eq!(get_f64(&r, &[1]), 12.0);
     assert_eq!(get_f64(&r, &[2]), 30.0);
 
-    let all = reduce_prod(&t, &[0, 1]).unwrap();
+    let all = reduce_prod(&t, &[0, 1], &strided_kernel::ExecContext::serial()).unwrap();
     assert!(all.shape().is_empty());
     assert_eq!(get_f64(&all, &[]), 720.0);
 }
@@ -702,19 +702,19 @@ fn test_reduce_prod() {
 #[test]
 fn test_integer_reduce_sum_prod_wrap_on_overflow() {
     let input = Tensor::from_vec_col_major(vec![2, 2], vec![i32::MAX, 1, i32::MAX, 2]).unwrap();
-    let sum = reduce_sum(&input, &[0]).unwrap();
+    let sum = reduce_sum(&input, &[0], &strided_kernel::ExecContext::serial()).unwrap();
     assert_eq!(
         sum.as_slice::<i32>().unwrap(),
         &[i32::MIN, i32::MAX.wrapping_add(2)]
     );
 
     let input = Tensor::from_vec_col_major(vec![2, 2], vec![i32::MIN, -1, i32::MAX, 2]).unwrap();
-    let prod = reduce_prod(&input, &[0]).unwrap();
+    let prod = reduce_prod(&input, &[0], &strided_kernel::ExecContext::serial()).unwrap();
     assert_eq!(prod.as_slice::<i32>().unwrap(), &[i32::MIN, -2]);
 
     let input = Tensor::from_vec_col_major(vec![2], vec![i64::MAX, 2]).unwrap();
-    let sum = reduce_sum(&input, &[0]).unwrap();
-    let prod = reduce_prod(&input, &[0]).unwrap();
+    let sum = reduce_sum(&input, &[0], &strided_kernel::ExecContext::serial()).unwrap();
+    let prod = reduce_prod(&input, &[0], &strided_kernel::ExecContext::serial()).unwrap();
     assert_eq!(sum.as_slice::<i64>().unwrap(), &[i64::MIN.wrapping_add(1)]);
     assert_eq!(prod.as_slice::<i64>().unwrap(), &[-2]);
 }

--- a/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/elementwise_reduction_helpers.rs
@@ -647,14 +647,14 @@ fn reduce_sum_zero_length_axis_is_rejected_like_other_reductions() {
     let empty = Tensor::F64(TypedTensor::from_vec_col_major(vec![0], Vec::<f64>::new()).unwrap());
 
     assert!(matches!(
-        reduce_sum(&empty, &[0]),
+        reduce_sum(&empty, &[0], &strided_kernel::ExecContext::serial()),
         Err(crate::Error::Validation {
             op: "reduce_sum",
             ..
         })
     ));
     assert!(matches!(
-        reduce_prod(&empty, &[0]),
+        reduce_prod(&empty, &[0], &strided_kernel::ExecContext::serial()),
         Err(crate::Error::Validation {
             op: "reduce_prod",
             ..
@@ -682,8 +682,8 @@ fn empty_reduction_axes_are_noop_before_dtype_dispatch() {
     let bools = Tensor::Bool(bool_tensor.clone());
     let mut backend = CpuBackend::new();
 
-    let sum_owned = reduce_sum(&bools, &[]).unwrap();
-    let prod_owned = reduce_prod(&bools, &[]).unwrap();
+    let sum_owned = reduce_sum(&bools, &[], &strided_kernel::ExecContext::serial()).unwrap();
+    let prod_owned = reduce_prod(&bools, &[], &strided_kernel::ExecContext::serial()).unwrap();
     let sum_read = backend
         .reduce_sum_read(TensorRead::from_tensor(&bools), &[])
         .unwrap();
@@ -1001,17 +1001,18 @@ fn test_reduction_helpers_cover_complex_and_error_paths() {
         )
         .unwrap(),
     );
-    let sum = reduce_sum(&complex, &[0]).unwrap();
+    let sum = reduce_sum(&complex, &[0], &strided_kernel::ExecContext::serial()).unwrap();
     assert_eq!(get_c32(&sum, &[0]), Complex32::new(3.0, 1.0));
     assert_eq!(get_c32(&sum, &[1]), Complex32::new(7.0, 1.0));
 
-    let prod = reduce_prod(&complex, &[]).unwrap();
+    let prod = reduce_prod(&complex, &[], &strided_kernel::ExecContext::serial()).unwrap();
     assert_eq!(prod.shape(), &[2, 2]);
 
     assert!(matches!(
         reduce_sum(
             &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap()),
-            &[2]
+            &[2],
+            &strided_kernel::ExecContext::serial()
         ),
         Err(crate::Error::Validation {
             op: "reduce_sum",
@@ -1021,7 +1022,8 @@ fn test_reduction_helpers_cover_complex_and_error_paths() {
     assert!(matches!(
         reduce_prod(
             &Tensor::F32(TypedTensor::from_vec_col_major(vec![2], vec![1.0f32, 2.0]).unwrap()),
-            &[0, 0]
+            &[0, 0],
+            &strided_kernel::ExecContext::serial()
         ),
         Err(crate::Error::Validation {
             op: "reduce_prod",

--- a/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
+++ b/crates/tenferro-cpu/src/tests/cpu_tests/indexing.rs
@@ -544,6 +544,7 @@ fn test_cpu_supports_i32_and_bool_structural_paths() {
     let i32_sum = reduce_sum(
         &Tensor::from_vec_col_major(vec![2, 2], vec![1_i32, 2, 3, 4]).unwrap(),
         &[0],
+        &strided_kernel::ExecContext::serial(),
     )
     .unwrap();
     assert_eq!(i32_sum.as_slice::<i32>().unwrap(), &[3, 7]);

--- a/crates/tenferro-cpu/tests/integration/runtime_error_tests.rs
+++ b/crates/tenferro-cpu/tests/integration/runtime_error_tests.rs
@@ -270,19 +270,19 @@ fn cpu_reductions_use_common_empty_axes_validation_helpers() {
 
     for (start, end, helper, op) in [
         (
-            "pub fn reduce_sum",
+            "pub(crate) fn reduce_sum",
             "pub(crate) fn reduce_sum_read",
             "reduction_empty_axes_noop",
             "reduce_sum",
         ),
         (
             "pub(crate) fn reduce_sum_read",
-            "pub fn reduce_prod",
+            "pub(crate) fn reduce_prod",
             "reduction_read_empty_axes_noop",
             "reduce_sum",
         ),
         (
-            "pub fn reduce_prod",
+            "pub(crate) fn reduce_prod",
             "pub(crate) fn reduce_prod_read",
             "reduction_empty_axes_noop",
             "reduce_prod",

--- a/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/elementwise.rs
@@ -1166,6 +1166,7 @@ fn read_as_cpu_view(input: TensorRead<'_>) -> CpuReadView<'_> {
 #[doc(hidden)]
 pub fn elementwise_fusion_with_pool(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     inputs: &[&Tensor],
     plan: &ElementwiseFusionPlan,
 ) -> crate::Result<Option<Vec<Tensor>>> {
@@ -1213,7 +1214,7 @@ pub fn elementwise_fusion_with_pool(
         })
         .collect::<crate::Result<Vec<_>>>()?;
 
-    execute_erased_fused_outputs(buffers, dtype, &input_refs, &shape, plan).map(Some)
+    execute_erased_fused_outputs(buffers, exec_context, dtype, &input_refs, &shape, plan).map(Some)
 }
 
 fn dtype_supports_erased_fusion(dtype: DType, plan: &ElementwiseFusionPlan) -> bool {
@@ -1242,6 +1243,7 @@ fn dtype_supports_erased_fusion(dtype: DType, plan: &ElementwiseFusionPlan) -> b
 
 fn execute_erased_fused_outputs(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     dtype: KernelDType,
     input_refs: &[ErasedRawStridedRef<'_>],
     shape: &[usize],
@@ -1254,6 +1256,7 @@ fn execute_erased_fused_outputs(
             .map(|&output| {
                 execute_erased_fused_output::<f32>(
                     buffers,
+                    exec_context,
                     dtype,
                     input_refs,
                     shape,
@@ -1270,6 +1273,7 @@ fn execute_erased_fused_outputs(
             .map(|&output| {
                 execute_erased_fused_output::<f64>(
                     buffers,
+                    exec_context,
                     dtype,
                     input_refs,
                     shape,
@@ -1286,6 +1290,7 @@ fn execute_erased_fused_outputs(
             .map(|&output| {
                 execute_erased_fused_output::<i32>(
                     buffers,
+                    exec_context,
                     dtype,
                     input_refs,
                     shape,
@@ -1302,6 +1307,7 @@ fn execute_erased_fused_outputs(
             .map(|&output| {
                 execute_erased_fused_output::<i64>(
                     buffers,
+                    exec_context,
                     dtype,
                     input_refs,
                     shape,
@@ -1318,6 +1324,7 @@ fn execute_erased_fused_outputs(
             .map(|&output| {
                 execute_erased_fused_output::<bool>(
                     buffers,
+                    exec_context,
                     dtype,
                     input_refs,
                     shape,
@@ -1334,6 +1341,7 @@ fn execute_erased_fused_outputs(
             .map(|&output| {
                 execute_erased_fused_output::<num_complex::Complex32>(
                     buffers,
+                    exec_context,
                     dtype,
                     input_refs,
                     shape,
@@ -1350,6 +1358,7 @@ fn execute_erased_fused_outputs(
             .map(|&output| {
                 execute_erased_fused_output::<num_complex::Complex64>(
                     buffers,
+                    exec_context,
                     dtype,
                     input_refs,
                     shape,
@@ -1370,6 +1379,7 @@ fn execute_erased_fused_outputs(
 #[allow(clippy::too_many_arguments)]
 fn execute_erased_fused_output<T>(
     buffers: &mut BufferPool,
+    exec_context: &ExecContext,
     dtype: KernelDType,
     input_refs: &[ErasedRawStridedRef<'_>],
     shape: &[usize],
@@ -1400,7 +1410,7 @@ where
     )
     .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
     erased_plan
-        .execute(&ExecContext::serial(), &mut dest, input_refs)
+        .execute(exec_context, &mut dest, input_refs)
         .map_err(|err| crate::Error::backend_source(ELEMENTWISE_FUSION_OP, err))?;
     Ok(wrap(tensor_from_array(out)))
 }

--- a/crates/tenferro-internal-cpu-kernels/src/elementwise/tests.rs
+++ b/crates/tenferro-internal-cpu-kernels/src/elementwise/tests.rs
@@ -94,9 +94,10 @@ fn elementwise_fusion_executes_i32_add_multiply_plan() {
         ],
     );
 
-    let outputs = elementwise_fusion_with_pool(&mut buffers, &[&lhs, &rhs], &plan)
-        .unwrap()
-        .expect("I32 add/multiply fusion should be delegated to strided-kernel");
+    let outputs =
+        elementwise_fusion_with_pool(&mut buffers, &ExecContext::serial(), &[&lhs, &rhs], &plan)
+            .unwrap()
+            .expect("I32 add/multiply fusion should be delegated to strided-kernel");
 
     assert_eq!(outputs.len(), 1);
     let actual = outputs[0].as_slice::<i32>().unwrap();
@@ -130,9 +131,10 @@ fn elementwise_fusion_executes_reversed_first_input_plan() {
         ],
     );
 
-    let outputs = elementwise_fusion_with_pool(&mut buffers, &[&lhs, &rhs], &plan)
-        .unwrap()
-        .expect("reversed first input order should be handled by strided fused replay");
+    let outputs =
+        elementwise_fusion_with_pool(&mut buffers, &ExecContext::serial(), &[&lhs, &rhs], &plan)
+            .unwrap()
+            .expect("reversed first input order should be handled by strided fused replay");
 
     assert_eq!(outputs.len(), 1);
     let actual = outputs[0].as_slice::<f64>().unwrap();
@@ -163,9 +165,14 @@ fn elementwise_fusion_executes_f32_and_i64_erased_dtype_arms() {
         )],
     );
 
-    let f32_outputs = elementwise_fusion_with_pool(&mut buffers, &[&f32_lhs, &f32_rhs], &add_plan)
-        .unwrap()
-        .expect("F32 add fusion should be delegated to strided-kernel");
+    let f32_outputs = elementwise_fusion_with_pool(
+        &mut buffers,
+        &ExecContext::serial(),
+        &[&f32_lhs, &f32_rhs],
+        &add_plan,
+    )
+    .unwrap()
+    .expect("F32 add fusion should be delegated to strided-kernel");
     let f32_actual = f32_outputs[0].as_slice::<f32>().unwrap();
     assert_eq!(f32_actual[3], f32_lhs_data[3] + f32_rhs_data[3]);
 
@@ -187,9 +194,14 @@ fn elementwise_fusion_executes_f32_and_i64_erased_dtype_arms() {
         )],
     );
 
-    let i64_outputs = elementwise_fusion_with_pool(&mut buffers, &[&i64_lhs, &i64_rhs], &i64_plan)
-        .unwrap()
-        .expect("I64 add fusion should be delegated to strided-kernel");
+    let i64_outputs = elementwise_fusion_with_pool(
+        &mut buffers,
+        &ExecContext::serial(),
+        &[&i64_lhs, &i64_rhs],
+        &i64_plan,
+    )
+    .unwrap()
+    .expect("I64 add fusion should be delegated to strided-kernel");
     let i64_actual = i64_outputs[0].as_slice::<i64>().unwrap();
     assert_eq!(i64_actual[n - 1], i64_lhs_data[n - 1] + i64_rhs_data[n - 1]);
 }
@@ -213,9 +225,14 @@ fn elementwise_fusion_executes_bool_and_complex_erased_dtype_arms() {
         )],
     );
 
-    let bool_outputs = elementwise_fusion_with_pool(&mut buffers, &[&bool_input], &bool_plan)
-        .unwrap()
-        .expect("Bool conj fusion should use the zeroed erased destination path");
+    let bool_outputs = elementwise_fusion_with_pool(
+        &mut buffers,
+        &ExecContext::serial(),
+        &[&bool_input],
+        &bool_plan,
+    )
+    .unwrap()
+    .expect("Bool conj fusion should use the zeroed erased destination path");
     assert_eq!(
         bool_outputs[0].as_slice::<bool>().unwrap(),
         bool_data.as_slice()
@@ -245,9 +262,14 @@ fn elementwise_fusion_executes_bool_and_complex_erased_dtype_arms() {
         ],
     );
 
-    let c32_outputs = elementwise_fusion_with_pool(&mut buffers, &[&c32_lhs, &c32_rhs], &c32_plan)
-        .unwrap()
-        .expect("C32 multi-output fusion should be delegated output-by-output");
+    let c32_outputs = elementwise_fusion_with_pool(
+        &mut buffers,
+        &ExecContext::serial(),
+        &[&c32_lhs, &c32_rhs],
+        &c32_plan,
+    )
+    .unwrap()
+    .expect("C32 multi-output fusion should be delegated output-by-output");
     assert_eq!(c32_outputs.len(), 2);
     assert_eq!(
         c32_outputs[0].as_slice::<num_complex::Complex32>().unwrap()[5],
@@ -282,9 +304,14 @@ fn elementwise_fusion_executes_bool_and_complex_erased_dtype_arms() {
         )],
     );
 
-    let c64_outputs = elementwise_fusion_with_pool(&mut buffers, &[&c64_lhs, &c64_rhs], &c64_plan)
-        .unwrap()
-        .expect("C64 add fusion should be delegated to strided-kernel");
+    let c64_outputs = elementwise_fusion_with_pool(
+        &mut buffers,
+        &ExecContext::serial(),
+        &[&c64_lhs, &c64_rhs],
+        &c64_plan,
+    )
+    .unwrap()
+    .expect("C64 add fusion should be delegated to strided-kernel");
     assert_eq!(
         c64_outputs[0].as_slice::<num_complex::Complex64>().unwrap()[7],
         c64_lhs_data[7] + c64_rhs_data[7]
@@ -309,9 +336,14 @@ fn elementwise_fusion_returns_none_for_erased_unsupported_ops() {
         )],
     );
     assert!(
-        elementwise_fusion_with_pool(&mut buffers, &[&lhs, &rhs], &divide_plan)
-            .unwrap()
-            .is_none(),
+        elementwise_fusion_with_pool(
+            &mut buffers,
+            &ExecContext::serial(),
+            &[&lhs, &rhs],
+            &divide_plan
+        )
+        .unwrap()
+        .is_none(),
         "integer divide is not owned by erased strided fusion"
     );
 
@@ -332,9 +364,14 @@ fn elementwise_fusion_returns_none_for_erased_unsupported_ops() {
         )],
     );
     assert!(
-        elementwise_fusion_with_pool(&mut buffers, &[&complex, &complex], &ordered_plan)
-            .unwrap()
-            .is_none(),
+        elementwise_fusion_with_pool(
+            &mut buffers,
+            &ExecContext::serial(),
+            &[&complex, &complex],
+            &ordered_plan
+        )
+        .unwrap()
+        .is_none(),
         "complex ordered ops stay outside erased strided fusion"
     );
 }

--- a/docs/guides/parallelism-and-caching.md
+++ b/docs/guides/parallelism-and-caching.md
@@ -107,13 +107,14 @@ workers remain provider-owned and may fan out independently.
 
 | Operation family | Threading behavior |
 | --- | --- |
-| Elementwise and analytic ops | `strided-kernel` map/zip kernels use the already-entered context's native policy. Rayon-capable `Inner` may use the selected executor; all other modes above are sequential. |
-| Reductions | `strided-kernel::reduce_axis` uses the same selected native policy and never ambient Rayon. |
+| Elementwise and analytic ops | `strided-kernel` map/zip kernels and erased fused replay use the already-entered context's native policy. Rayon-capable `Inner` may use the selected executor; all other modes above are sequential. |
+| Reductions | sum/product erased replay and typed max/min reductions use the same selected native policy and never ambient Rayon. Upstream strided plan coverage determines whether a specific multi-axis reduction shape can actually partition work. |
 | View materialization, transpose/permute, broadcast, convert, and diagonal extraction | `strided-kernel` copy/map kernels use the same selected native policy; layout fallback and linalg input materialization are included. |
 | `dot_general` through `cpu-faer` | faer receives `Par::rayon(n)` only for `Inner` execution whose selected executor advertises Rayon and whose validated budget is greater than one; otherwise it receives `Par::Seq`. |
 | GEMM and linalg through `cpu-blas` | Threading is owned by the linked BLAS/LAPACK provider, not Rayon. Configure the provider variables below. |
 | Supported `dot_general` contractions through an external TBLIS provider | The example provider clamps TBLIS to one thread per call; unsupported TBLIS shapes fall back to the compiled faer/BLAS provider in preferred mode. |
-| Indexing, scatter/gather, slicing, padding, concatenation, reverse, triangular masks, and `embed_diagonal` | These are dedicated sequential CPU loops today because their per-output indexing patterns do not yet have a strided-kernel/backend-native parallel primitive. They still run inside the selected executor entry, and source comments mark the intentional sequential path. |
+| Indexed gather/scatter and dynamic slice/update | These delegate to strided erased plans with an explicit `ExecContext` derived from `CpuExecutionContext`; upstream strided plan coverage determines whether a specific indexed plan can actually partition work. |
+| Slicing, padding, concatenation, reverse, triangular masks, and `embed_diagonal` | These are dedicated sequential CPU loops today because their per-output indexing patterns do not yet have a strided-kernel/backend-native parallel primitive. They still run inside the selected executor entry, and source comments mark the intentional sequential path. |
 
 CPU affine-strided copy, permutation, broadcast, map, zip-map, and axis
 reduction delegate to `strided-rs`, while tenferro supplies operation semantics,

--- a/docs/worklogs/2026-07-28-strided-exec-context-replay.md
+++ b/docs/worklogs/2026-07-28-strided-exec-context-replay.md
@@ -1,0 +1,67 @@
+# strided ExecContext Replay Adoption
+
+## Summary
+
+Updated tenferro-rs to consume `tensor4all/strided-rs@f1343692f8afbc1d1c1f4614478772ae5683dcbb`
+and removed the tenferro-side `ExecContext::serial()` hardcoding from CPU
+hot paths delegated through strided erased plans.
+
+## Context Read
+
+- `AGENTS.md`
+- `REPOSITORY_RULES.md`
+- `docs/guides/parallelism-and-caching.md`
+- `crates/tenferro-cpu/src/provider.rs`
+- `crates/tenferro-cpu/src/backend.rs`
+- `crates/tenferro-cpu/src/exec_session.rs`
+- `crates/tenferro-cpu/src/reduction.rs`
+- `crates/tenferro-cpu/src/indexing.rs`
+- `crates/tenferro-internal-cpu-kernels/src/elementwise.rs`
+- strided-rs PR #162 / issue #161
+
+## Decisions
+
+- Keep `CpuExecutionContext` as the single owner of CPU native parallelism
+  policy. It now exposes a crate-private `strided_exec_context()` helper that
+  maps Rayon-capable `Inner` execution to `ExecContext::max_threads(n)` and all
+  other contexts to `ExecContext::serial()`.
+- `ExecContext::max_threads(n)` is a strided replay-policy limit, not a
+  thread-pool constructor. Tenferro enters its owned `CpuContext` pool first
+  via `with_native_parallelism`, then strided observes the bounded policy
+  inside that scope.
+- Pass that explicit context into erased strided replay for sum/product
+  reduction, gather/scatter, dynamic slice/update, and fused elementwise replay.
+- Do not use `ExecContext::ambient()`. The CPU backend must not fall back to an
+  ambient global Rayon pool.
+- Do not keep compatibility wrappers for the old internal helper signatures.
+  Tests that call internal helpers directly now pass an explicit serial
+  context.
+- Do not change faer parallelism. faer continues to receive its policy only
+  through `CpuExecutionContext::faer_parallelism()`.
+
+## Residual Risks
+
+- This PR removes tenferro's forced serial replay boundary. It does not claim
+  that every strided indexed plan has a partitioned parallel algorithm. Indexed
+  gather/scatter and dynamic slice/update still depend on upstream strided plan
+  coverage for actual parallel fanout.
+- Full benchmark evidence should be collected in the follow-up benchmark
+  campaign. This change is a correctness repair for the execution-policy
+  plumbing regression, not a performance-claim PR.
+
+## Verification
+
+- `cargo fmt --all -- --check`
+- `cargo check -p tenferro-cpu --features cpu-faer,cpu-blas --tests --quiet`
+- `python3 -m unittest discover -s scripts/ci/tests -v`
+  - 159 CI configuration contract tests passed after updating the pinned
+    strided-rs revision expectation.
+- `cargo test -p tenferro-internal-cpu-kernels --quiet`
+  - 38 unit tests and 19 doctests passed.
+- `cargo test -p tenferro-cpu --features cpu-faer --quiet`
+  - 488 library tests, 1 install allocation test, 47 integration tests, 2
+    provider-boundary allocation tests, and 175 doctests passed.
+- `cargo bench -p tenferro-runtime --features __bench_unification_run_compiled_api --bench elementwise_fusion -- --quick`
+  - Sanity check only; not a formal paired benchmark campaign.
+  - `add_mul/1048576`: 1.4434 ms to 1.4467 ms.
+  - `broadcast_mul_add/1024x1024`: 5.3913 ms to 5.6427 ms.

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "20b2def9bf9554605d12fe13762f8770ba732efb"
+        revision = "f1343692f8afbc1d1c1f4614478772ae5683dcbb"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
## Summary

- update the strided-rs pin to tensor4all/strided-rs@f1343692, which includes `ExecContext::run` support from strided-rs#162
- derive a crate-private strided `ExecContext` from `CpuExecutionContext` and pass it through erased sum/product reductions, gather/scatter, dynamic slice/update, and fused elementwise replay
- keep faer unchanged: faer still receives policy only through `CpuExecutionContext::faer_parallelism()`
- add source-contract, policy-mapping, and CI pin-contract updates; update parallelism docs and record the worklog

## Notes

`ExecContext::max_threads(n)` is used only as a strided replay-policy limit. It does not create a Rayon pool; tenferro enters its owned `CpuContext` pool first through `with_native_parallelism`, then strided observes the bounded policy inside that scope. `ExecContext::ambient()` is not used.

Indexed strided plans still depend on upstream strided plan coverage for actual partitioning. This PR fixes tenferro's forced-serial replay boundary; it is not the formal U8 benchmark campaign.

Refs tensor4all/strided-rs#161
Refs tensor4all/strided-rs#162

## Verification

- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'python3 -m unittest discover -s scripts/ci/tests -v' --test 'cargo test -p tenferro-internal-cpu-kernels --quiet' --test 'cargo test -p tenferro-cpu --features cpu-faer --quiet'`
- `cargo check -p tenferro-cpu --features cpu-faer,cpu-blas --tests --quiet`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review.json`
- `cargo bench -p tenferro-runtime --features __bench_unification_run_compiled_api --bench elementwise_fusion -- --quick`
  - sanity only, not a paired formal benchmark
  - `add_mul/1048576`: 1.4434 ms to 1.4467 ms
  - `broadcast_mul_add/1024x1024`: 5.3913 ms to 5.6427 ms

Local note: `python3 scripts/ci/run_profile.py ci-config` could not fully run locally because this host lacks `go`/`actionlint`; its Python unittest portion now passes 159/159 and CI installs pinned actionlint before running the full profile.