### PR TITLE
Update strided pin for policy thresholds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "f1343692f8afbc1d1c1f4614478772ae5683dcbb", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "f1343692f8afbc1d1c1f4614478772ae5683dcbb", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "f1343692f8afbc1d1c1f4614478772ae5683dcbb", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "f1343692f8afbc1d1c1f4614478772ae5683dcbb", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "f1343692f8afbc1d1c1f4614478772ae5683dcbb", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/docs/worklogs/2026-07-28-strided-policy-threshold-pin.md
+++ b/docs/worklogs/2026-07-28-strided-policy-threshold-pin.md
@@ -1,0 +1,31 @@
+# strided Policy Threshold Pin
+
+## Summary
+
+Updated tenferro-rs to consume `tensor4all/strided-rs@18d74ffacccefee8c476379c21a99eae532b917b`,
+the merge commit for strided-rs PR #164. That strided-rs change makes large
+erased indexed/reduction/static-indexing replay paths honor
+`ExecContext::max_threads(n)` above the shared `MINTHREADLENGTH` threshold.
+
+## Context
+
+- strided-rs #161 identified that erased replay could silently degrade
+  `ExecContext::MaxThreads(n)` to serial execution.
+- tenferro-rs #1501 already removed production hot-path hardcoding of
+  `ExecContext::serial()` by routing CPU backend execution through
+  `CpuExecutionContext::strided_exec_context()`.
+- strided-rs #164 then added the initial threshold-backed parallel replay for
+  axis reductions, gather, dynamic slice, dynamic update overwrite, and pad.
+
+## Decision
+
+Pin all workspace `strided-*` dependencies to strided-rs #164 and update the
+CI source-contract expectation to the same revision. Do not change tenferro
+call sites in this PR: production backend dispatch already passes the explicit
+CPU-derived strided execution context, and remaining `ExecContext::serial()`
+uses are direct helper tests or the intentional one-thread fallback inside
+`CpuExecutionContext::strided_exec_context()`.
+
+## Verification
+
+- `python3 -m unittest scripts.ci.tests.test_build_artifact_contracts -v`

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "f1343692f8afbc1d1c1f4614478772ae5683dcbb"
+        revision = "18d74ffacccefee8c476379c21a99eae532b917b"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
## Summary

- update all workspace `strided-*` git pins to `tensor4all/strided-rs@18d74ffacccefee8c476379c21a99eae532b917b`, the merge commit for strided-rs#164
- update the CI source-contract test so future pin drift is caught at the same revision
- add a short worklog recording that tenferro production call sites already route erased replay through `CpuExecutionContext::strided_exec_context()` from #1501

## Context

strided-rs#164 adds the first threshold-backed parallel replay for large erased axis reductions, gather, dynamic slice/update, and pad paths under non-ambient `ExecContext::max_threads(n)`. tenferro-rs#1501 already removed the production hot-path `ExecContext::serial()` boundary and pinned strided-rs#162; this PR only advances the dependency pin to the threshold implementation.

Refs tensor4all/strided-rs#161.

## Verification

- red check before manifest update: `python3 -m unittest scripts.ci.tests.test_build_artifact_contracts -v` failed on the old `f1343692...` strided pin
- `python3 -m unittest scripts.ci.tests.test_build_artifact_contracts -v`
- `python3 scripts/ci/run_profile.py fmt`
- `git diff --check`
- `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu --features cpu-faer strided --quiet`
- `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p tenferro-cpu --features cpu-faer --quiet`
- `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true cargo check -p tenferro-cpu --features cpu-faer,cpu-blas --tests --quiet`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-strided-policy-pin.json`
- full local PR gate: `CARGO_BUILD_JOBS=64 CARGO_NET_GIT_FETCH_WITH_CLI=true bash scripts/check-pr-fast.sh --coverage-reviewed --test 'python3 -m unittest scripts.ci.tests.test_build_artifact_contracts -v' --test 'cargo test -p tenferro-cpu --features cpu-faer --quiet' --test 'cargo check -p tenferro-cpu --features cpu-faer,cpu-blas --tests --quiet'`
