### PR TITLE
Fix Frobenius norm square path

### DIFF
--- a/crates/tenferro-linalg/src/eager_composites.rs
+++ b/crates/tenferro-linalg/src/eager_composites.rs
@@ -111,17 +111,21 @@ pub(crate) fn norm(
     }
     validate_axes("norm", a.shape().len(), &axes)?;
 
-    let out = match axes.len() {
-        1 => vector_norm(a, axes[0], ord)?,
-        2 => matrix_norm(a, &axes, ord)?,
-        _ => {
-            let abs = a.abs()?;
-            match ord {
-                None => frobenius_norm(&abs, &axes)?,
-                Some(p) if p == f64::INFINITY => abs.reduce_max(Some(&axes))?,
-                Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(Some(&axes))?,
-                Some(0.0) => count_nonzero(&abs, &axes)?,
-                Some(p) => p_norm(&abs, &axes, p)?,
+    let out = if can_square_without_abs(a.dtype(), axes.len(), ord) {
+        frobenius_norm(a, &axes)?
+    } else {
+        match axes.len() {
+            1 => vector_norm(a, axes[0], ord)?,
+            2 => matrix_norm(a, &axes, ord)?,
+            _ => {
+                let abs = a.abs()?;
+                match ord {
+                    None => frobenius_norm(&abs, &axes)?,
+                    Some(p) if p == f64::INFINITY => abs.reduce_max(Some(&axes))?,
+                    Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(Some(&axes))?,
+                    Some(0.0) => count_nonzero(&abs, &axes)?,
+                    Some(p) => p_norm(&abs, &axes, p)?,
+                }
             }
         }
     };
@@ -148,6 +152,11 @@ fn ensure_float_or_complex(op: &'static str, dtype: DType) -> Result<()> {
             crate::error::unsupported_dtype(op, dtype),
         )),
     }
+}
+
+fn can_square_without_abs(dtype: DType, axes_len: usize, ord: Option<f64>) -> bool {
+    matches!(dtype, DType::F32 | DType::F64)
+        && (ord.is_none() || (ord == Some(2.0) && axes_len != 2))
 }
 
 fn ensure_min_rank(op: &'static str, actual: usize, expected: usize) -> Result<()> {
@@ -228,9 +237,7 @@ fn matrix_transpose_perm(rank: usize) -> Vec<usize> {
 }
 
 fn frobenius_norm(abs: &EagerTensor, axes: &[usize]) -> Result<EagerTensor> {
-    abs.pow(&scalar_real(abs, 2.0)?)?
-        .reduce_sum(Some(axes))?
-        .sqrt()
+    abs.mul(abs)?.reduce_sum(Some(axes))?.sqrt()
 }
 
 fn p_norm(abs: &EagerTensor, axes: &[usize], p: f64) -> Result<EagerTensor> {
@@ -241,6 +248,9 @@ fn p_norm(abs: &EagerTensor, axes: &[usize], p: f64) -> Result<EagerTensor> {
             "p",
             format!("p-norm order must be finite and nonzero, got {p}"),
         ));
+    }
+    if p == 2.0 {
+        return frobenius_norm(abs, axes);
     }
     abs.pow(&scalar_real(abs, p)?)?
         .reduce_sum(Some(axes))?

--- a/crates/tenferro-linalg/src/tensor_ext.rs
+++ b/crates/tenferro-linalg/src/tensor_ext.rs
@@ -1224,11 +1224,15 @@ fn norm_from_read<B: LinalgBackend>(
         return backend.with_backend_session(|exec| exec.to_contiguous_read(input));
     }
     validate_axes("norm", original_shape.len(), &axes)?;
-    let abs = backend.with_backend_session(|exec| exec.abs_read(input))?;
-    let reduced = match axes.len() {
-        1 => norm_over_axes(&abs, &axes, ord, backend)?,
-        2 => matrix_norm(&abs, &axes, ord, backend)?,
-        _ => norm_over_axes(&abs, &axes, ord, backend)?,
+    let reduced = if can_square_without_abs(input.dtype(), axes.len(), ord) {
+        frobenius_norm_read(input.clone(), &axes, backend)?
+    } else {
+        let abs = backend.with_backend_session(|exec| exec.abs_read(input))?;
+        match axes.len() {
+            1 => norm_over_axes(&abs, &axes, ord, backend)?,
+            2 => matrix_norm(&abs, &axes, ord, backend)?,
+            _ => norm_over_axes(&abs, &axes, ord, backend)?,
+        }
     };
     if !keepdim {
         return Ok(reduced);
@@ -1284,6 +1288,11 @@ fn ensure_float_or_complex(op: &'static str, dtype: DType) -> tenferro_tensor::R
         DType::F32 | DType::F64 | DType::C32 | DType::C64 => Ok(()),
         _ => Err(crate::error::unsupported_dtype(op, dtype)),
     }
+}
+
+fn can_square_without_abs(dtype: DType, axes_len: usize, ord: Option<f64>) -> bool {
+    matches!(dtype, DType::F32 | DType::F64)
+        && (ord.is_none() || (ord == Some(2.0) && axes_len != 2))
 }
 
 fn validate_axes(op: &'static str, rank: usize, axes: &[usize]) -> tenferro_tensor::Result<()> {
@@ -1493,10 +1502,20 @@ fn frobenius_norm<B: LinalgBackend>(
     axes: &[usize],
     backend: &mut B,
 ) -> tenferro_tensor::Result<Tensor> {
-    let two = scalar_real(abs.dtype(), 2.0)?;
     let squared = backend.with_backend_session(|exec| {
-        exec.pow_read(TensorRead::from_tensor(abs), TensorRead::from_tensor(&two))
+        exec.mul_read(TensorRead::from_tensor(abs), TensorRead::from_tensor(abs))
     })?;
+    let sum = reduce_sum(&squared, axes, backend)?;
+    backend.with_backend_session(|exec| exec.sqrt_read(TensorRead::from_tensor(&sum)))
+}
+
+fn frobenius_norm_read<B: LinalgBackend>(
+    input: TensorRead<'_>,
+    axes: &[usize],
+    backend: &mut B,
+) -> tenferro_tensor::Result<Tensor> {
+    let rhs = input.clone();
+    let squared = backend.with_backend_session(|exec| exec.mul_read(input, rhs))?;
     let sum = reduce_sum(&squared, axes, backend)?;
     backend.with_backend_session(|exec| exec.sqrt_read(TensorRead::from_tensor(&sum)))
 }
@@ -1513,6 +1532,9 @@ fn p_norm<B: LinalgBackend>(
             "p",
             format!("p-norm order must be finite and nonzero, got {p}"),
         ));
+    }
+    if p == 2.0 {
+        return frobenius_norm(abs, axes, backend);
     }
     let power = scalar_real(abs.dtype(), p)?;
     let powered = backend.with_backend_session(|exec| {

--- a/crates/tenferro-linalg/src/traced.rs
+++ b/crates/tenferro-linalg/src/traced.rs
@@ -1392,17 +1392,21 @@ pub fn norm(
         }
     }
 
-    let out = match axes.len() {
-        1 => vector_norm(a, axes[0], ord)?,
-        2 => matrix_norm(a, &axes, ord)?,
-        _ => {
-            let abs = a.abs()?;
-            match ord {
-                None => frobenius_norm(&abs, &axes)?,
-                Some(p) if p == f64::INFINITY => abs.reduce_max(Some(&axes))?,
-                Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(Some(&axes))?,
-                Some(0.0) => count_nonzero(&abs, &axes)?,
-                Some(p) => p_norm(&abs, &axes, p)?,
+    let out = if can_square_without_abs(a.dtype, axes.len(), ord) {
+        frobenius_norm(a, &axes)?
+    } else {
+        match axes.len() {
+            1 => vector_norm(a, axes[0], ord)?,
+            2 => matrix_norm(a, &axes, ord)?,
+            _ => {
+                let abs = a.abs()?;
+                match ord {
+                    None => frobenius_norm(&abs, &axes)?,
+                    Some(p) if p == f64::INFINITY => abs.reduce_max(Some(&axes))?,
+                    Some(p) if p == f64::NEG_INFINITY => abs.reduce_min(Some(&axes))?,
+                    Some(0.0) => count_nonzero(&abs, &axes)?,
+                    Some(p) => p_norm(&abs, &axes, p)?,
+                }
             }
         }
     };
@@ -1538,6 +1542,11 @@ fn ensure_float_or_complex(op: &'static str, dtype: DType) -> Result<()> {
     }
 }
 
+fn can_square_without_abs(dtype: DType, axes_len: usize, ord: Option<f64>) -> bool {
+    matches!(dtype, DType::F32 | DType::F64)
+        && (ord.is_none() || (ord == Some(2.0) && axes_len != 2))
+}
+
 fn ensure_min_rank(op: &'static str, actual: usize, expected: usize) -> Result<()> {
     if actual < expected {
         return Err(Error::TensorRuntime(tenferro_tensor::Error::rank_mismatch(
@@ -1630,7 +1639,7 @@ fn matrix_transpose_perm(rank: usize) -> Vec<usize> {
 }
 
 fn frobenius_norm(abs: &TracedTensor, axes: &[usize]) -> Result<TracedTensor> {
-    let squared = abs.pow(&scalar_real(abs.dtype, 2.0)?)?;
+    let squared = abs.mul(abs)?;
     squared.reduce_sum(Some(axes))?.sqrt()
 }
 
@@ -1642,6 +1651,9 @@ fn p_norm(abs: &TracedTensor, axes: &[usize], p: f64) -> Result<TracedTensor> {
             "p",
             format!("p-norm order must be finite and nonzero, got {p}"),
         ));
+    }
+    if p == 2.0 {
+        return frobenius_norm(abs, axes);
     }
     let power = abs.pow(&scalar_real(abs.dtype, p)?)?;
     let inv_p = scalar_real(abs.dtype, 1.0 / p)?;

--- a/crates/tenferro-linalg/tests/integration/eager_surface_parity.rs
+++ b/crates/tenferro-linalg/tests/integration/eager_surface_parity.rs
@@ -13,6 +13,14 @@ fn eager(data: Vec<f64>, shape: Vec<usize>) -> EagerTensor {
     .unwrap()
 }
 
+fn eager_complex(data: Vec<Complex64>, shape: Vec<usize>) -> EagerTensor {
+    EagerTensor::from_tensor_in(
+        Tensor::from_vec_col_major(shape, data).unwrap(),
+        EagerRuntime::with_cpu_backend(CpuBackend::new()),
+    )
+    .unwrap()
+}
+
 fn f64_values(tensor: &EagerTensor) -> Vec<f64> {
     tensor
         .materialized()
@@ -60,18 +68,47 @@ fn eager_vector_norm_and_keepdim_follow_traced_contract() {
     let x = eager(vec![3.0, 4.0], vec![2]);
 
     let norm = x.norm(Some(2.0), Some(&[0]), true).unwrap();
+    let no_op = x.norm(None, Some(&[]), false).unwrap();
 
     assert_eq!(norm.shape(), &[1]);
     assert!((f64_values(&norm)[0] - 5.0).abs() < 1.0e-12);
+    assert_eq!(no_op.shape(), x.shape());
+    assert_eq!(f64_values(&no_op), f64_values(&x));
 }
 
 #[test]
 fn eager_norm_supports_zero_and_matrix_induced_orders() {
     let vector = eager(vec![1.0, 0.0, 2.0, -3.0], vec![4]);
+    let complex_vector = eager_complex(
+        vec![
+            Complex64::new(3.0, 4.0),
+            Complex64::new(0.0, -12.0),
+            Complex64::new(5.0, 0.0),
+        ],
+        vec![3],
+    );
     let matrix = eager(vec![1.0, 3.0, 2.0, 4.0], vec![2, 2]);
 
     let cases = [
         (vector.norm(Some(0.0), Some(&[0]), false).unwrap(), 3.0),
+        (
+            vector.norm(Some(f64::INFINITY), Some(&[0]), false).unwrap(),
+            3.0,
+        ),
+        (
+            vector
+                .norm(Some(f64::NEG_INFINITY), Some(&[0]), false)
+                .unwrap(),
+            0.0,
+        ),
+        (
+            vector.norm(Some(3.0), Some(&[0]), false).unwrap(),
+            36.0_f64.cbrt(),
+        ),
+        (
+            complex_vector.norm(Some(2.0), Some(&[0]), false).unwrap(),
+            194.0_f64.sqrt(),
+        ),
         (matrix.norm(Some(1.0), Some(&[0, 1]), false).unwrap(), 6.0),
         (matrix.norm(Some(-1.0), Some(&[0, 1]), false).unwrap(), 4.0),
         (

--- a/crates/tenferro-linalg/tests/integration/linalg_internal_path_contract.rs
+++ b/crates/tenferro-linalg/tests/integration/linalg_internal_path_contract.rs
@@ -90,6 +90,119 @@ fn matrix_norm_uses_singular_values_only_path() {
 }
 
 #[test]
+fn norm_fro_and_p2_norm_square_with_mul_not_generic_pow() {
+    let eager_source = crate_source("src/eager_composites.rs");
+    let eager_frobenius = source_section(
+        &eager_source,
+        "fn frobenius_norm(abs: &EagerTensor",
+        "fn p_norm(abs: &EagerTensor",
+    );
+    let eager_p_norm = source_section(
+        &eager_source,
+        "fn p_norm(abs: &EagerTensor",
+        "fn default_pinv_rtol",
+    );
+    assert!(
+        !eager_frobenius.contains(".pow("),
+        "eager Frobenius norm should square with mul, not generic pow"
+    );
+    assert!(
+        eager_p_norm.contains("p == 2.0") && eager_p_norm.contains("frobenius_norm(abs, axes)"),
+        "eager p-norm should special-case p=2.0 through the Frobenius mul path"
+    );
+
+    let concrete_source = crate_source("src/tensor_ext.rs");
+    let concrete_frobenius = source_section(
+        &concrete_source,
+        "fn frobenius_norm<B: LinalgBackend>",
+        "fn p_norm<B: LinalgBackend>",
+    );
+    let concrete_p_norm = source_section(
+        &concrete_source,
+        "fn p_norm<B: LinalgBackend>",
+        "fn count_nonzero<B: LinalgBackend>",
+    );
+    assert!(
+        !concrete_frobenius.contains("exec.pow_read"),
+        "concrete Frobenius norm should square with mul_read, not generic pow_read"
+    );
+    assert!(
+        concrete_p_norm.contains("p == 2.0")
+            && concrete_p_norm.contains("frobenius_norm(abs, axes, backend)"),
+        "concrete p-norm should special-case p=2.0 through the Frobenius mul_read path"
+    );
+
+    let traced_source = crate_source("src/traced.rs");
+    let traced_frobenius = source_section(
+        &traced_source,
+        "fn frobenius_norm(abs: &TracedTensor",
+        "fn p_norm(abs: &TracedTensor",
+    );
+    let traced_p_norm = source_section(
+        &traced_source,
+        "fn p_norm(abs: &TracedTensor",
+        "fn reduced_axes_have_zero_extent",
+    );
+    assert!(
+        !traced_frobenius.contains(".pow("),
+        "traced Frobenius norm should square with mul, not generic pow"
+    );
+    assert!(
+        traced_p_norm.contains("p == 2.0") && traced_p_norm.contains("frobenius_norm(abs, axes)"),
+        "traced p-norm should special-case p=2.0 through the Frobenius mul path"
+    );
+}
+
+#[test]
+fn real_sum_of_squares_norm_skips_abs_materialization_before_square() {
+    let eager_source = crate_source("src/eager_composites.rs");
+    let eager_norm = source_section(
+        &eager_source,
+        "pub(crate) fn norm",
+        "fn scalar_real(anchor: &EagerTensor",
+    );
+    assert!(
+        eager_norm.contains("can_square_without_abs(a.dtype(), axes.len(), ord)")
+            && eager_norm.contains("frobenius_norm(a, &axes)"),
+        "eager real Frobenius and p=2 norms should dispatch to the square path before abs"
+    );
+
+    let concrete_source = crate_source("src/tensor_ext.rs");
+    let concrete_norm = source_section(
+        &concrete_source,
+        "fn norm_from_read<B: LinalgBackend>",
+        "fn scalar_real(dtype: DType",
+    );
+    assert!(
+        concrete_norm.contains("can_square_without_abs(input.dtype(), axes.len(), ord)")
+            && concrete_norm.contains("frobenius_norm_read(input.clone(), &axes, backend)"),
+        "concrete real Frobenius and p=2 norms should dispatch to the square path before abs"
+    );
+
+    let traced_source = crate_source("src/traced.rs");
+    let traced_norm = source_section(&traced_source, "pub fn norm", "fn unexpected_output_count");
+    assert!(
+        traced_norm.contains("can_square_without_abs(a.dtype, axes.len(), ord)")
+            && traced_norm.contains("frobenius_norm(a, &axes)"),
+        "traced real Frobenius and p=2 norms should dispatch to the square path before abs"
+    );
+
+    for (label, source) in [
+        ("eager", eager_source.as_str()),
+        ("concrete", concrete_source.as_str()),
+        ("traced", traced_source.as_str()),
+    ] {
+        let helper = source_section(source, "fn can_square_without_abs", "\n}\n\nfn");
+        assert!(
+            helper.contains("DType::F32 | DType::F64")
+                && helper.contains("ord.is_none()")
+                && helper.contains("ord == Some(2.0) && axes_len != 2"),
+            "{label} helper should skip abs only for real Frobenius or non-matrix p=2 norms"
+        );
+    }
+}
+
+#[test]
 fn traced_eigvalsh_uses_hermitian_values_only_path() {
     let source = crate_source("src/traced.rs");
     let eigvalsh_source = source_section(

--- a/docs/worklogs/2026-07-28-norm-fro-square-path.md
+++ b/docs/worklogs/2026-07-28-norm-fro-square-path.md
@@ -87,7 +87,14 @@ cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration tr
 cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration norm -- --nocapture
 cargo check -p tenferro-linalg --features cpu-faer,autodiff --tests
 cargo fmt --all --check
+cargo llvm-cov -p tenferro-linalg --features cpu-faer,autodiff --test integration --profile ci --json --output-path /tmp/tenferro-linalg-coverage-after.json
 ```
+
+After the first PR run, hosted `coverage` reported
+`crates/tenferro-linalg/src/eager_composites.rs: 79.5% < 80%`. I added eager
+execution coverage for no-op `dim=[]`, vector infinity norms, vector p-norm,
+and complex p=2 norm. The local linalg coverage rerun reported
+`eager_composites.rs` at 81.46%.
 
 ## Remaining Risk
 

--- a/docs/worklogs/2026-07-28-norm-fro-square-path.md
+++ b/docs/worklogs/2026-07-28-norm-fro-square-path.md
@@ -1,0 +1,99 @@
+# 2026-07-28 norm_fro square path
+
+## Summary
+
+Fixed the confirmed `norm_fro` square-path bug from #1505 by replacing the
+generic `pow(x, 2.0)` square with `x * x` across the eager, concrete/read, and
+traced linalg composites. The same p=2 fast path now delegates to the
+Frobenius helper so it cannot regress back to generic `pow`.
+
+I also adopted the issue's second low-risk ambition for real dtypes: real
+Frobenius and non-matrix p=2 norms skip the pre-square `abs` materialization.
+Complex norms still use the existing absolute-value path because closing that
+gap cleanly needs a dedicated complex sum-of-squares expression or the later
+single-pass reduction work.
+
+## Context Read
+
+- `REPOSITORY_RULES.md` and `AGENTS.md`
+- `CONTRIBUTING.md`
+- `ai/contribution-workflows/bugfix-pr.md`
+- `ai/contribution-workflows/repository-remediation.md`
+- #1505 body
+- #1490 benchmark triage context from the task
+- `crates/tenferro-linalg/src/eager_composites.rs`
+- `crates/tenferro-linalg/src/tensor_ext.rs`
+- `crates/tenferro-linalg/src/traced.rs`
+- `tenferro-benchmark/src/bin/benchmark_cpu_public_api.rs`
+
+## Decisions
+
+- Keep the PR as a bug-fix PR. It adds no public API, dependency, feature flag,
+  or backend policy change.
+- Fix the same-root-cause instances in all three linalg surfaces:
+  eager composite, concrete/read extension surface, and traced composite.
+- Use source-contract tests for the internal path choice because the public
+  numerical result remains the same while the bug is specifically a wrong
+  internal operator choice.
+- Do not implement fused multiply-accumulate sum-of-squares in this PR. That
+  would change reduction accumulation behavior and is explicitly blocked until
+  the reduction policy step.
+
+## Benchmark Evidence
+
+Focused public API subset:
+
+```bash
+PUBLICATION_GATE_PROFILE=full \
+BENCH_RUNS=15 \
+BENCH_WARMUPS=3 \
+TENFERRO_CPU_FEATURES=cpu-faer \
+TENFERRO_CPU_BACKEND_KIND=default \
+PUBLIC_API_BENCHMARK_FILTER=norm_fro \
+taskset -c 8-15 nice -n 10 ... --num-threads {1,4}
+```
+
+The host had other CPU-heavy processes, so these are local diagnostic
+before/after numbers rather than the final formal benchmark campaign.
+
+| row | before ms | after ms | change |
+| --- | ---: | ---: | ---: |
+| f64 t1 tenferro-eager | 143.961 | 29.768 | -79.3% |
+| f64 t1 tenferro-trace | 60.845 | 7.358 | -87.9% |
+| f64 t4 tenferro-eager | 58.554 | 11.176 | -80.9% |
+| f64 t4 tenferro-trace | 18.886 | 2.113 | -88.8% |
+| c64 t1 tenferro-eager | 62.919 | 31.036 | -50.7% |
+| c64 t1 tenferro-trace | 62.555 | 25.485 | -59.3% |
+| c64 t4 tenferro-eager | 20.803 | 8.293 | -60.1% |
+| c64 t4 tenferro-trace | 17.827 | 6.682 | -62.5% |
+
+The same run measured PyTorch `norm_fro` f64 t1 at 1.304 ms. The remaining
+f64 eager gap is therefore still larger than the #1505 3x target on this
+machine. A focused `reduce_sum_all` run under the same settings measured
+tenferro t1 at 29.352 ms vs PyTorch t1 at 10.278 ms on `8192x4096`, confirming
+that the residual belongs to the reduction/single-pass sum-of-squares cluster
+rather than another generic `pow` path.
+
+## Verification
+
+Commands run:
+
+```bash
+cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration real_sum_of_squares_norm_skips_abs_materialization_before_square -- --nocapture
+cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration norm_fro_and_p2_norm_square_with_mul_not_generic_pow -- --nocapture
+cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration eager_norm -- --nocapture
+cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration concrete_norm -- --nocapture
+cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration traced_correctness::norm -- --nocapture
+cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration norm -- --nocapture
+cargo check -p tenferro-linalg --features cpu-faer,autodiff --tests
+cargo fmt --all --check
+```
+
+## Remaining Risk
+
+- #1505 should not be closed from this PR alone unless maintainers accept the
+  residual as covered by the reduction cluster. The local f64 t1 public API row
+  is still not within 3x of PyTorch.
+- Complex Frobenius still materializes `abs` before squaring. It improved by
+  removing `pow`, but closing the remaining gap should be handled with the
+  reduction policy work or a separately benchmarked complex sum-of-squares path.


### PR DESCRIPTION
## Type

- [x] Bug fix
- [ ] Documentation
- [ ] Refactor / cleanup
- [ ] Implementation of accepted issue

## Related issue

Refs #1505
Refs #1490

## Summary

This removes the generic `pow(x, 2.0)` square path from Frobenius and p=2 norms across the eager, concrete/read, and traced linalg surfaces. Real Frobenius and non-matrix p=2 norms now skip the pre-square `abs` materialization and square the input directly.

The PR intentionally does not implement a fused single-pass sum-of-squares reduction. That is blocked on the reduction accumulation-order policy in the later reduction step, so #1505 is referenced rather than closed here.

## Work log

`docs/worklogs/2026-07-28-norm-fro-square-path.md`

## Benchmark Evidence

Focused public API subset, pinned to cores 8-15 with `nice -n 10`, `PUBLICATION_GATE_PROFILE=full`, `BENCH_RUNS=15`, `BENCH_WARMUPS=3`, `TENFERRO_CPU_FEATURES=cpu-faer`, `TENFERRO_CPU_BACKEND_KIND=default`, `PUBLIC_API_BENCHMARK_FILTER=norm_fro`.

| row | before ms | after ms | change |
| --- | ---: | ---: | ---: |
| f64 t1 tenferro-eager | 143.961 | 29.768 | -79.3% |
| f64 t1 tenferro-trace | 60.845 | 7.358 | -87.9% |
| f64 t4 tenferro-eager | 58.554 | 11.176 | -80.9% |
| f64 t4 tenferro-trace | 18.886 | 2.113 | -88.8% |
| c64 t1 tenferro-eager | 62.919 | 31.036 | -50.7% |
| c64 t1 tenferro-trace | 62.555 | 25.485 | -59.3% |
| c64 t4 tenferro-eager | 20.803 | 8.293 | -60.1% |
| c64 t4 tenferro-trace | 17.827 | 6.682 | -62.5% |

Residual attribution: the same local run measured PyTorch `norm_fro` f64 t1 at 1.304 ms, so f64 t1 is still outside the #1505 3x target. A focused `reduce_sum_all` run under the same settings measured tenferro t1 at 29.352 ms vs PyTorch t1 at 10.278 ms on `8192x4096`, confirming the remaining gap belongs to the reduction/single-pass sum-of-squares cluster.

## Verification

- `cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration real_sum_of_squares_norm_skips_abs_materialization_before_square -- --nocapture`
- `cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration norm_fro_and_p2_norm_square_with_mul_not_generic_pow -- --nocapture`
- `cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration eager_norm -- --nocapture`
- `cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration concrete_norm -- --nocapture`
- `cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration traced_correctness::norm -- --nocapture`
- `cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration norm -- --nocapture`
- `cargo check -p tenferro-linalg --features cpu-faer,autodiff --tests`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-linalg --features cpu-faer,autodiff --test integration norm -- --nocapture'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --output-json /tmp/repository-rules-review-norm-fro-1505.json` -> pass, no findings

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I added or updated tests/docs as needed.
- [x] I ran local repository-rules LLM review and resolved or documented its findings.
- [x] If this implements a new feature, the linked issue has been accepted by maintainers. Not applicable; bug fix.
- [x] If this is an AI-assisted bug fix, I applied the bug-fix scope gate from `ai/contribution-workflows/bugfix-pr.md`.
- [x] If this PR needs a work log, I added one under `docs/worklogs/` and linked it above.