### PR TITLE
Route CUDA structural permutation through cuTENSOR

### DIFF
--- a/REPOSITORY_RULES.md
+++ b/REPOSITORY_RULES.md
@@ -914,6 +914,12 @@ diff-scoped review bot.
   runtime shape/stride metadata conventions, launch configuration rules, and
   device transfer behavior. Any change to those conventions must update that
   document in the same PR.
+- CUDA operation paths whose accepted implementation is an NVIDIA vendor
+  library must fail with typed load or provider errors when the required
+  NVIDIA library is unavailable or lacks support. They must not silently fall
+  back to native CubeCL kernels. Native CubeCL kernels are separate provider
+  implementations for operations or dtypes not covered by the accepted
+  vendor-library path, not fallback tiers for missing CUDA libraries.
 - CUDA `eig` (non-symmetric eigenvalue decomposition, LAPACK `dgeev`) is not
   provided by cuSOLVER. `CudaBackend::eig` returns `Unsupported`; users
   must explicitly download to CPU and compute via `CpuBackend::eig`.

--- a/crates/tenferro-gpu/src/cubecl/ffi/cutensor.rs
+++ b/crates/tenferro-gpu/src/cubecl/ffi/cutensor.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use libloading::Library;
 
-const OP: &str = "dot_general";
+const OP: &str = "cuda_cutensor";
 /// Default cuTENSOR search paths. Override with `TENFERRO_CUTENSOR_PATH` env var.
 const CUTENSOR_DEFAULT_PATHS: &[&str] = &[
     "/usr/lib/x86_64-linux-gnu/libcutensor/12/libcutensor.so.2",
@@ -103,6 +103,16 @@ type CutensorCreateContractionFn = unsafe extern "C" fn(
     *const i32,
     CutensorComputeDescriptor,
 ) -> CutensorStatus;
+type CutensorCreatePermutationFn = unsafe extern "C" fn(
+    CutensorHandleRaw,
+    *mut CutensorOperationDescriptorRaw,
+    CutensorTensorDescriptorRaw,
+    *const i32,
+    CutensorOperator,
+    CutensorTensorDescriptorRaw,
+    *const i32,
+    CutensorComputeDescriptor,
+) -> CutensorStatus;
 type CutensorDestroyOperationDescriptorFn =
     unsafe extern "C" fn(CutensorOperationDescriptorRaw) -> CutensorStatus;
 type CutensorCreatePlanPreferenceFn = unsafe extern "C" fn(
@@ -141,6 +151,14 @@ type CutensorContractFn = unsafe extern "C" fn(
     u64,
     CutensorCudaStream,
 ) -> CutensorStatus;
+type CutensorPermuteFn = unsafe extern "C" fn(
+    CutensorHandleRaw,
+    CutensorPlanRaw,
+    *const c_void,
+    *const c_void,
+    *mut c_void,
+    CutensorCudaStream,
+) -> CutensorStatus;
 type CutensorGetErrorStringFn = unsafe extern "C" fn(CutensorStatus) -> *const c_char;
 
 struct CutensorVtable {
@@ -149,6 +167,7 @@ struct CutensorVtable {
     create_tensor_descriptor: CutensorCreateTensorDescriptorFn,
     destroy_tensor_descriptor: CutensorDestroyTensorDescriptorFn,
     create_contraction: CutensorCreateContractionFn,
+    create_permutation: CutensorCreatePermutationFn,
     destroy_operation_descriptor: CutensorDestroyOperationDescriptorFn,
     create_plan_preference: CutensorCreatePlanPreferenceFn,
     destroy_plan_preference: CutensorDestroyPlanPreferenceFn,
@@ -156,6 +175,7 @@ struct CutensorVtable {
     create_plan: CutensorCreatePlanFn,
     destroy_plan: CutensorDestroyPlanFn,
     contract: CutensorContractFn,
+    permute: CutensorPermuteFn,
     get_error_string: CutensorGetErrorStringFn,
     compute_desc_32f: CutensorComputeDescriptor,
     compute_desc_64f: CutensorComputeDescriptor,
@@ -169,6 +189,7 @@ impl CutensorVtable {
             create_tensor_descriptor: load_symbol(lib, b"cutensorCreateTensorDescriptor\0")?,
             destroy_tensor_descriptor: load_symbol(lib, b"cutensorDestroyTensorDescriptor\0")?,
             create_contraction: load_symbol(lib, b"cutensorCreateContraction\0")?,
+            create_permutation: load_symbol(lib, b"cutensorCreatePermutation\0")?,
             destroy_operation_descriptor: load_symbol(
                 lib,
                 b"cutensorDestroyOperationDescriptor\0",
@@ -179,6 +200,7 @@ impl CutensorVtable {
             create_plan: load_symbol(lib, b"cutensorCreatePlan\0")?,
             destroy_plan: load_symbol(lib, b"cutensorDestroyPlan\0")?,
             contract: load_symbol(lib, b"cutensorContract\0")?,
+            permute: load_symbol(lib, b"cutensorPermute\0")?,
             get_error_string: load_symbol(lib, b"cutensorGetErrorString\0")?,
             compute_desc_32f: load_data_symbol(lib, b"CUTENSOR_COMPUTE_DESC_32F\0")?,
             compute_desc_64f: load_data_symbol(lib, b"CUTENSOR_COMPUTE_DESC_64F\0")?,
@@ -251,6 +273,10 @@ unsafe impl Sync for CutensorLibrary {}
 impl CutensorLibrary {
     fn load() -> crate::Result<Arc<Self>> {
         let paths = super::library_search_paths("TENFERRO_CUTENSOR_PATH", CUTENSOR_DEFAULT_PATHS);
+        Self::load_from_paths(paths)
+    }
+
+    fn load_from_paths(paths: Vec<String>) -> crate::Result<Arc<Self>> {
         let mut errors = Vec::new();
         let mut last_source = None;
         for path in &paths {
@@ -311,6 +337,29 @@ impl CutensorLibrary {
         Err(super::super::error::provider_status(
             op, "cuTENSOR", call, status,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn cutensor_loader_missing_library_is_typed_io_error() {
+        let err = match super::CutensorLibrary::load_from_paths(vec![
+            "/definitely/not/libcutensor.so".to_string(),
+        ]) {
+            Ok(_) => panic!("unexpectedly loaded cuTENSOR from a nonexistent path"),
+            Err(err) => err,
+        };
+
+        match err {
+            crate::Error::IoSource { op, source } => {
+                assert_eq!(op, "cuda_cutensor");
+                assert!(source
+                    .to_string()
+                    .contains("failed to load cuTENSOR library"));
+            }
+            other => panic!("expected typed cuTENSOR IoSource, got {other:?}"),
+        }
     }
 }
 
@@ -412,6 +461,19 @@ impl CutensorHandle {
             stream,
         );
         self.lib.check_status(status, op, "cutensorContract")
+    }
+
+    pub(crate) unsafe fn permute(
+        &self,
+        plan: &Plan,
+        alpha: *const c_void,
+        a: *const c_void,
+        b: *mut c_void,
+        stream: CutensorCudaStream,
+        op: &'static str,
+    ) -> crate::Result<()> {
+        let status = (self.lib.vtable.permute)(self.as_raw(), plan.as_raw(), alpha, a, b, stream);
+        self.lib.check_status(status, op, "cutensorPermute")
     }
 }
 
@@ -515,6 +577,38 @@ impl OperationDescriptor {
         handle
             .lib
             .check_status(status, op, "cutensorCreateContraction")?;
+        Ok(Self {
+            lib: Arc::clone(&handle.lib),
+            raw,
+        })
+    }
+
+    pub(crate) fn new_permutation(
+        handle: &CutensorHandle,
+        desc_a: &TensorDescriptor,
+        mode_a: &[i32],
+        op_a: CutensorOperator,
+        desc_b: &TensorDescriptor,
+        mode_b: &[i32],
+        compute_desc: CutensorComputeDescriptor,
+        op: &'static str,
+    ) -> crate::Result<Self> {
+        let mut raw = std::ptr::null_mut();
+        let status = unsafe {
+            (handle.lib.vtable.create_permutation)(
+                handle.as_raw(),
+                &mut raw,
+                desc_a.as_raw(),
+                mode_a.as_ptr(),
+                op_a,
+                desc_b.as_raw(),
+                mode_b.as_ptr(),
+                compute_desc,
+            )
+        };
+        handle
+            .lib
+            .check_status(status, op, "cutensorCreatePermutation")?;
         Ok(Self {
             lib: Arc::clone(&handle.lib),
             raw,

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -122,6 +122,7 @@ mod gemm;
 pub(crate) mod interop;
 mod memory;
 pub(crate) mod op_descriptor;
+mod permutation;
 mod runtime;
 mod runtime_adapter;
 
@@ -666,7 +667,7 @@ impl CudaBackend {
         let _ = self.inner.cutensor.set(handle);
         self.inner.cutensor.get().ok_or_else(|| {
             crate::Error::runtime_state(
-                "dot_general",
+                "cuda_cutensor",
                 "cuTENSOR handle initialization completed without a stored handle",
             )
         })
@@ -777,6 +778,40 @@ impl CudaBackend {
         max_entries: NonZeroUsize,
     ) -> crate::Result<()> {
         gemm::set_cutensor_plan_cache_max_entries(self, max_entries)
+    }
+
+    /// Return cuTENSOR structural permutation plan cache stats.
+    ///
+    /// The returned entry count is the number of retained cuTENSOR permutation
+    /// plans inside the CUDA backend's extension cache entry. Logical retained
+    /// bytes include cached descriptor and plan state.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
+    pub fn cutensor_permutation_plan_cache_stats(&self) -> crate::Result<CacheStats> {
+        permutation::cutensor_permutation_plan_cache_stats(self)
+    }
+
+    /// Return the cuTENSOR structural permutation plan entry bound.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
+    pub fn cutensor_permutation_plan_cache_max_entries(&self) -> crate::Result<NonZeroUsize> {
+        permutation::cutensor_permutation_plan_cache_max_entries(self)
+    }
+
+    /// Configure the cuTENSOR structural permutation plan entry bound.
+    ///
+    /// The cache is initialized if it does not already exist so a setting made
+    /// before the first CUDA structural permutation call is preserved.
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::RuntimeState`] if the cache mutex is poisoned.
+    pub fn set_cutensor_permutation_plan_cache_max_entries(
+        &self,
+        max_entries: NonZeroUsize,
+    ) -> crate::Result<()> {
+        permutation::set_cutensor_permutation_plan_cache_max_entries(self, max_entries)
     }
 
     fn transpose_typed<T>(
@@ -1011,6 +1046,25 @@ impl CudaBackend {
             );
         }
         Ok(output)
+    }
+
+    fn to_contiguous_view_cutensor_or_cubecl<T, R>(
+        &self,
+        view: &TypedTensorView<'_, T, R>,
+        op: &'static str,
+    ) -> crate::Result<TypedTensor<T, R>>
+    where
+        T: permutation::CutensorPermutationScalar,
+        R: TensorRank,
+    {
+        if view.strides().iter().any(|&stride| stride < 0) {
+            // cuTENSOR 2.x rejects negative-stride tensor descriptors. This
+            // keeps existing CUDA view coverage for a layout the vendor
+            // permutation path cannot represent; it is not a missing-library
+            // fallback for cuTENSOR-supported descriptors.
+            return self.to_contiguous_view_typed(view, op);
+        }
+        permutation::to_contiguous_view(self, view, op)
     }
 
     fn copy_view_to_view_typed<T, R>(
@@ -4273,7 +4327,14 @@ impl TensorAnalytic for CudaBackend {
 
 impl TensorStructural for CudaBackend {
     fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
-        macro_rules! materialize {
+        macro_rules! materialize_cutensor {
+            ($variant:ident, $view:expr) => {{
+                let view = $view;
+                self.to_contiguous_view_cutensor_or_cubecl(&view, "CudaBackend::to_contiguous_read")
+                    .map(Tensor::$variant)
+            }};
+        }
+        macro_rules! materialize_cubecl {
             ($variant:ident, $view:expr) => {{
                 let view = $view;
                 self.to_contiguous_view_typed(&view, "CudaBackend::to_contiguous_read")
@@ -4282,26 +4343,26 @@ impl TensorStructural for CudaBackend {
         }
 
         match input {
-            TensorRead::Tensor(Tensor::F32(input)) => materialize!(F32, input.as_view()),
-            TensorRead::Tensor(Tensor::F64(input)) => materialize!(F64, input.as_view()),
-            TensorRead::Tensor(Tensor::I32(input)) => materialize!(I32, input.as_view()),
-            TensorRead::Tensor(Tensor::I64(input)) => materialize!(I64, input.as_view()),
+            TensorRead::Tensor(Tensor::F32(input)) => materialize_cutensor!(F32, input.as_view()),
+            TensorRead::Tensor(Tensor::F64(input)) => materialize_cutensor!(F64, input.as_view()),
+            TensorRead::Tensor(Tensor::I32(input)) => materialize_cubecl!(I32, input.as_view()),
+            TensorRead::Tensor(Tensor::I64(input)) => materialize_cubecl!(I64, input.as_view()),
             TensorRead::Tensor(Tensor::Bool(_)) => Err(unsupported_dtype(
                 "CudaBackend::to_contiguous_read",
                 crate::DType::Bool,
             )),
-            TensorRead::Tensor(Tensor::C32(input)) => materialize!(C32, input.as_view()),
-            TensorRead::Tensor(Tensor::C64(input)) => materialize!(C64, input.as_view()),
-            TensorRead::View(TensorView::F32(input)) => materialize!(F32, input),
-            TensorRead::View(TensorView::F64(input)) => materialize!(F64, input),
-            TensorRead::View(TensorView::I32(input)) => materialize!(I32, input),
-            TensorRead::View(TensorView::I64(input)) => materialize!(I64, input),
+            TensorRead::Tensor(Tensor::C32(input)) => materialize_cutensor!(C32, input.as_view()),
+            TensorRead::Tensor(Tensor::C64(input)) => materialize_cutensor!(C64, input.as_view()),
+            TensorRead::View(TensorView::F32(input)) => materialize_cutensor!(F32, input),
+            TensorRead::View(TensorView::F64(input)) => materialize_cutensor!(F64, input),
+            TensorRead::View(TensorView::I32(input)) => materialize_cubecl!(I32, input),
+            TensorRead::View(TensorView::I64(input)) => materialize_cubecl!(I64, input),
             TensorRead::View(TensorView::Bool(_)) => Err(unsupported_dtype(
                 "CudaBackend::to_contiguous_read",
                 crate::DType::Bool,
             )),
-            TensorRead::View(TensorView::C32(input)) => materialize!(C32, input),
-            TensorRead::View(TensorView::C64(input)) => materialize!(C64, input),
+            TensorRead::View(TensorView::C32(input)) => materialize_cutensor!(C32, input),
+            TensorRead::View(TensorView::C64(input)) => materialize_cutensor!(C64, input),
         }
     }
 
@@ -4364,13 +4425,13 @@ impl TensorStructural for CudaBackend {
 
     fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
         match input {
-            Tensor::F32(t) => self.transpose_typed(t, perm).map(Tensor::F32),
-            Tensor::F64(t) => self.transpose_typed(t, perm).map(Tensor::F64),
+            Tensor::F32(t) => permutation::transpose(self, t, perm).map(Tensor::F32),
+            Tensor::F64(t) => permutation::transpose(self, t, perm).map(Tensor::F64),
             Tensor::I32(t) => self.transpose_typed(t, perm).map(Tensor::I32),
             Tensor::I64(t) => self.transpose_typed(t, perm).map(Tensor::I64),
             Tensor::Bool(t) => self.transpose_bool(t, perm).map(Tensor::Bool),
-            Tensor::C32(t) => self.transpose_typed(t, perm).map(Tensor::C32),
-            Tensor::C64(t) => self.transpose_typed(t, perm).map(Tensor::C64),
+            Tensor::C32(t) => permutation::transpose(self, t, perm).map(Tensor::C32),
+            Tensor::C64(t) => permutation::transpose(self, t, perm).map(Tensor::C64),
         }
     }
 
@@ -5194,7 +5255,34 @@ macro_rules! impl_cubecl_view_canonicalization {
     };
 }
 
-impl_cubecl_view_canonicalization!(f32, f64, i32, i64, Complex32, Complex64);
+macro_rules! impl_cutensor_view_canonicalization {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl<R> TensorViewCanonicalization<$ty, R> for CudaBackend
+            where
+                R: TensorRank,
+            {
+                fn to_contiguous(
+                    &mut self,
+                    view: &TypedTensorView<'_, $ty, R>,
+                ) -> crate::Result<TypedTensor<$ty, R>> {
+                    self.to_contiguous_view_cutensor_or_cubecl(view, "CudaBackend::to_contiguous")
+                }
+
+                fn copy_into(
+                    &mut self,
+                    src: &TypedTensorView<'_, $ty, R>,
+                    dst: &mut TypedTensorViewMut<'_, $ty, R>,
+                ) -> crate::Result<()> {
+                    self.copy_view_to_view_typed(src, dst, "CudaBackend::copy_into")
+                }
+            }
+        )*
+    };
+}
+
+impl_cutensor_view_canonicalization!(f32, f64, Complex32, Complex64);
+impl_cubecl_view_canonicalization!(i32, i64);
 
 impl<R> TensorViewCanonicalization<bool, R> for CudaBackend
 where

--- a/crates/tenferro-gpu/src/cubecl/permutation.rs
+++ b/crates/tenferro-gpu/src/cubecl/permutation.rs
@@ -1,0 +1,756 @@
+use std::collections::{HashMap, VecDeque};
+use std::ffi::c_void;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+use cubecl::prelude::{CubeElement, CubePrimitive};
+use num_complex::{Complex32, Complex64};
+use num_traits::One;
+use tenferro_tensor::{CacheStats, DType, TensorRank, TypedTensorView};
+
+use super::dispatch::{
+    cubecl_buffer, cubecl_view_buffer, ensure_resident_on_runtime, ensure_view_resident_on_runtime,
+};
+use super::ffi::cutensor::{
+    CudaDataType, CutensorComputeDescriptor, CutensorCudaStream, CutensorHandle, CutensorOperator,
+    OperationDescriptor, Plan, PlanPreference, TensorDescriptor,
+};
+use super::interop::cuda_device_ptr_from_addr;
+use super::{CudaBackend, CudaRuntime};
+use crate::{col_major_strides, CubeclBuffer, Error, TypedTensor};
+
+const OP_TRANSPOSE: &str = "transpose";
+const CUDA_ALLOCATION_ALIGNMENT: u32 = 256;
+const DEFAULT_CUTENSOR_PERMUTATION_PLAN_CACHE_MAX_ENTRIES: usize = 64;
+
+type CutensorPermutationPlanCacheState = Arc<Mutex<CutensorPermutationPlanCache>>;
+
+pub(super) trait CutensorPermutationScalar:
+    CubeElement + CubePrimitive + Clone + One + Send + Sync + 'static
+{
+    const DATA_TYPE: CudaDataType;
+    const DTYPE: DType;
+
+    fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor;
+}
+
+impl CutensorPermutationScalar for f32 {
+    const DATA_TYPE: CudaDataType = CudaDataType::R32F;
+    const DTYPE: DType = DType::F32;
+
+    fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor {
+        handle.compute_desc_32f()
+    }
+}
+
+impl CutensorPermutationScalar for f64 {
+    const DATA_TYPE: CudaDataType = CudaDataType::R64F;
+    const DTYPE: DType = DType::F64;
+
+    fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor {
+        handle.compute_desc_64f()
+    }
+}
+
+impl CutensorPermutationScalar for Complex32 {
+    const DATA_TYPE: CudaDataType = CudaDataType::C32F;
+    const DTYPE: DType = DType::C32;
+
+    fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor {
+        handle.compute_desc_32f()
+    }
+}
+
+impl CutensorPermutationScalar for Complex64 {
+    const DATA_TYPE: CudaDataType = CudaDataType::C64F;
+    const DTYPE: DType = DType::C64;
+
+    fn compute_descriptor(handle: &CutensorHandle) -> CutensorComputeDescriptor {
+        handle.compute_desc_64f()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct CutensorPermutationLayoutKey {
+    extents: Vec<i64>,
+    strides: Vec<i64>,
+    modes: Vec<i32>,
+}
+
+impl CutensorPermutationLayoutKey {
+    fn new(extents: &[i64], strides: &[i64], modes: &[i32]) -> Self {
+        Self {
+            extents: extents.to_vec(),
+            strides: strides.to_vec(),
+            modes: modes.to_vec(),
+        }
+    }
+
+    fn retained_bytes(&self) -> usize {
+        std::mem::size_of::<Self>()
+            .saturating_add(self.extents.capacity() * std::mem::size_of::<i64>())
+            .saturating_add(self.strides.capacity() * std::mem::size_of::<i64>())
+            .saturating_add(self.modes.capacity() * std::mem::size_of::<i32>())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct CutensorPermutationKey {
+    dtype: DType,
+    input: CutensorPermutationLayoutKey,
+    output: CutensorPermutationLayoutKey,
+    input_alignment_requirement: u32,
+    output_alignment_requirement: u32,
+    input_op: CutensorOperator,
+}
+
+impl CutensorPermutationKey {
+    fn from_spec<T: CutensorPermutationScalar>(spec: &CutensorPermutationSpec<'_>) -> Self {
+        Self {
+            dtype: T::DTYPE,
+            input: CutensorPermutationLayoutKey::new(
+                spec.input_extents,
+                spec.input_strides,
+                spec.input_modes,
+            ),
+            output: CutensorPermutationLayoutKey::new(
+                spec.output_extents,
+                spec.output_strides,
+                spec.output_modes,
+            ),
+            input_alignment_requirement: spec.input_alignment_requirement,
+            output_alignment_requirement: spec.output_alignment_requirement,
+            input_op: spec.input_op,
+        }
+    }
+
+    fn retained_bytes(&self) -> usize {
+        std::mem::size_of::<Self>()
+            .saturating_add(self.input.retained_bytes())
+            .saturating_add(self.output.retained_bytes())
+    }
+}
+
+struct CutensorPermutationSpec<'a> {
+    input_extents: &'a [i64],
+    input_strides: &'a [i64],
+    input_modes: &'a [i32],
+    output_extents: &'a [i64],
+    output_strides: &'a [i64],
+    output_modes: &'a [i32],
+    input_alignment_requirement: u32,
+    output_alignment_requirement: u32,
+    input_op: CutensorOperator,
+}
+
+struct CachedCutensorPermutation {
+    // Drop the cuTENSOR plan before the descriptor objects it was built from.
+    plan: Plan,
+    _plan_preference: PlanPreference,
+    _operation_descriptor: OperationDescriptor,
+    _output_descriptor: TensorDescriptor,
+    _input_descriptor: TensorDescriptor,
+}
+
+// SAFETY: cached cuTENSOR state is tied to one `CudaBackend` and is only used
+// while holding the enclosing plan-cache mutex. The opaque cuTENSOR handles are
+// created and destroyed through the same loaded cuTENSOR library.
+unsafe impl Send for CachedCutensorPermutation {}
+
+impl CachedCutensorPermutation {
+    fn new<T>(
+        cutensor: &CutensorHandle,
+        spec: &CutensorPermutationSpec<'_>,
+        op: &'static str,
+    ) -> crate::Result<Self>
+    where
+        T: CutensorPermutationScalar,
+    {
+        let desc_input = TensorDescriptor::new(
+            cutensor,
+            spec.input_extents,
+            spec.input_strides,
+            T::DATA_TYPE,
+            spec.input_alignment_requirement,
+            op,
+        )?;
+        let desc_output = TensorDescriptor::new(
+            cutensor,
+            spec.output_extents,
+            spec.output_strides,
+            T::DATA_TYPE,
+            spec.output_alignment_requirement,
+            op,
+        )?;
+        let op_desc = OperationDescriptor::new_permutation(
+            cutensor,
+            &desc_input,
+            spec.input_modes,
+            spec.input_op,
+            &desc_output,
+            spec.output_modes,
+            T::compute_descriptor(cutensor),
+            op,
+        )?;
+        let pref = PlanPreference::new_default(cutensor, op)?;
+        let plan = Plan::new(cutensor, &op_desc, &pref, 0, op)?;
+        Ok(Self {
+            plan,
+            _plan_preference: pref,
+            _operation_descriptor: op_desc,
+            _output_descriptor: desc_output,
+            _input_descriptor: desc_input,
+        })
+    }
+
+    fn retained_bytes(&self) -> usize {
+        std::mem::size_of::<Self>()
+    }
+}
+
+struct CutensorPermutationPlanCache {
+    max_entries: NonZeroUsize,
+    entries: HashMap<CutensorPermutationKey, CachedCutensorPermutation>,
+    order: VecDeque<CutensorPermutationKey>,
+    stats: CacheStats,
+}
+
+impl CutensorPermutationPlanCache {
+    fn new(max_entries: NonZeroUsize) -> Self {
+        Self {
+            max_entries,
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            stats: CacheStats::empty(),
+        }
+    }
+
+    fn ensure<T>(
+        &mut self,
+        cutensor: &CutensorHandle,
+        key: &CutensorPermutationKey,
+        spec: &CutensorPermutationSpec<'_>,
+        op: &'static str,
+    ) -> crate::Result<()>
+    where
+        T: CutensorPermutationScalar,
+    {
+        if self.entries.contains_key(key) {
+            self.stats.hits = self.stats.hits.saturating_add(1);
+            self.touch(key);
+            return Ok(());
+        }
+        self.stats.misses = self.stats.misses.saturating_add(1);
+        let cached = CachedCutensorPermutation::new::<T>(cutensor, spec, op)?;
+        self.entries.insert(key.clone(), cached);
+        self.touch(key);
+        self.evict_to_limit();
+        Ok(())
+    }
+
+    fn get(&self, key: &CutensorPermutationKey) -> crate::Result<&CachedCutensorPermutation> {
+        self.entries.get(key).ok_or_else(|| {
+            Error::runtime_state(
+                "cutensor_permutation_plan_cache",
+                "cached cuTENSOR permutation was evicted before use",
+            )
+        })
+    }
+
+    fn touch(&mut self, key: &CutensorPermutationKey) {
+        self.order.retain(|existing| existing != key);
+        self.order.push_back(key.clone());
+    }
+
+    fn evict_to_limit(&mut self) {
+        while self.entries.len() > self.max_entries.get() {
+            let Some(oldest) = self.order.pop_front() else {
+                break;
+            };
+            if self.entries.remove(&oldest).is_some() {
+                self.stats.evictions = self.stats.evictions.saturating_add(1);
+            }
+        }
+    }
+
+    fn max_entries(&self) -> NonZeroUsize {
+        self.max_entries
+    }
+
+    fn set_max_entries(&mut self, max_entries: NonZeroUsize) {
+        self.max_entries = max_entries;
+        self.evict_to_limit();
+    }
+
+    fn stats(&self) -> CacheStats {
+        CacheStats {
+            entries: self.entries.len(),
+            retained_bytes: self.retained_bytes(),
+            ..self.stats
+        }
+    }
+
+    fn retained_bytes(&self) -> usize {
+        let entries_bytes =
+            self.entries
+                .iter()
+                .fold(std::mem::size_of::<Self>(), |total, (key, cached)| {
+                    total
+                        .saturating_add(key.retained_bytes())
+                        .saturating_add(cached.retained_bytes())
+                });
+        entries_bytes
+            .saturating_add(self.order.capacity() * std::mem::size_of::<CutensorPermutationKey>())
+    }
+}
+
+struct ResolvedPermutationOperand {
+    ptr: *mut c_void,
+    alignment: u32,
+}
+
+pub(super) fn transpose<T>(
+    backend: &CudaBackend,
+    input: &TypedTensor<T>,
+    perm: &[usize],
+) -> crate::Result<TypedTensor<T>>
+where
+    T: CutensorPermutationScalar,
+{
+    super::validate_permutation(OP_TRANSPOSE, perm, input.shape().len())?;
+    backend.runtime().set_current_cuda_context(OP_TRANSPOSE)?;
+    let output_shape: Vec<usize> = perm.iter().map(|&axis| input.shape()[axis]).collect();
+    let output = super::dispatch::alloc_output::<T>(backend.runtime(), &output_shape)?;
+    let input_strides = compact_strides_i64(OP_TRANSPOSE, input.shape())?;
+    let output_strides = compact_strides_i64(OP_TRANSPOSE, output.shape())?;
+    let input_modes = identity_modes(OP_TRANSPOSE, input.shape().len())?;
+    let output_modes = modes_from_perm(OP_TRANSPOSE, perm)?;
+    let input_extents = dims_to_i64(OP_TRANSPOSE, input.shape())?;
+    let output_extents = dims_to_i64(OP_TRANSPOSE, output.shape())?;
+    let input_res = resolve_owned_operand(backend.runtime(), input, OP_TRANSPOSE)?;
+    let output_res = resolve_owned_operand(backend.runtime(), &output, OP_TRANSPOSE)?;
+    if output.n_elements() == 0 {
+        return Ok(output);
+    }
+
+    execute_permutation::<T>(
+        backend,
+        input_res,
+        output_res,
+        CutensorPermutationSpec {
+            input_extents: &input_extents,
+            input_strides: &input_strides,
+            input_modes: &input_modes,
+            output_extents: &output_extents,
+            output_strides: &output_strides,
+            output_modes: &output_modes,
+            input_alignment_requirement: CUDA_ALLOCATION_ALIGNMENT,
+            output_alignment_requirement: CUDA_ALLOCATION_ALIGNMENT,
+            input_op: CutensorOperator::Identity,
+        },
+        OP_TRANSPOSE,
+    )?;
+    Ok(output)
+}
+
+pub(super) fn to_contiguous_view<T, R>(
+    backend: &CudaBackend,
+    view: &TypedTensorView<'_, T, R>,
+    op: &'static str,
+) -> crate::Result<TypedTensor<T, R>>
+where
+    T: CutensorPermutationScalar,
+    R: TensorRank,
+{
+    backend.runtime().set_current_cuda_context(op)?;
+    let output = backend.alloc_ranked_output::<T, R>(view.shape(), op)?;
+    let input_strides = view_strides_i64(view.strides(), op)?;
+    let output_strides = compact_strides_i64(op, output.shape())?;
+    let modes = identity_modes(op, view.shape().len())?;
+    let input_extents = dims_to_i64(op, view.shape())?;
+    let output_extents = dims_to_i64(op, output.shape())?;
+    let input_res = resolve_view_operand(backend.runtime(), view, op)?;
+    let output_res = resolve_owned_operand(backend.runtime(), &output, op)?;
+    if output.n_elements() == 0 {
+        return Ok(output);
+    }
+
+    execute_permutation::<T>(
+        backend,
+        input_res,
+        output_res,
+        CutensorPermutationSpec {
+            input_extents: &input_extents,
+            input_strides: &input_strides,
+            input_modes: &modes,
+            output_extents: &output_extents,
+            output_strides: &output_strides,
+            output_modes: &modes,
+            input_alignment_requirement: view_descriptor_alignment_requirement::<T>(),
+            output_alignment_requirement: CUDA_ALLOCATION_ALIGNMENT,
+            input_op: CutensorOperator::Identity,
+        },
+        op,
+    )?;
+    Ok(output)
+}
+
+fn execute_permutation<T>(
+    backend: &CudaBackend,
+    input_res: ResolvedPermutationOperand,
+    output_res: ResolvedPermutationOperand,
+    spec: CutensorPermutationSpec<'_>,
+    op: &'static str,
+) -> crate::Result<()>
+where
+    T: CutensorPermutationScalar,
+{
+    validate_descriptor_alignment(
+        input_res.alignment,
+        spec.input_alignment_requirement,
+        "input",
+        op,
+    )?;
+    validate_descriptor_alignment(
+        output_res.alignment,
+        spec.output_alignment_requirement,
+        "output",
+        op,
+    )?;
+    let alpha = T::one();
+    let stream = raw_stream(backend.runtime())?;
+    cached_cutensor_permutation::<T, _>(backend, &spec, op, |cutensor, plan| unsafe {
+        cutensor.permute(
+            plan,
+            &alpha as *const T as *const c_void,
+            input_res.ptr as *const c_void,
+            output_res.ptr,
+            stream,
+            op,
+        )
+    })
+}
+
+fn default_cutensor_permutation_plan_cache_max_entries() -> NonZeroUsize {
+    NonZeroUsize::new(DEFAULT_CUTENSOR_PERMUTATION_PLAN_CACHE_MAX_ENTRIES)
+        .unwrap_or(NonZeroUsize::MIN)
+}
+
+fn new_cutensor_permutation_plan_cache_state(
+    max_entries: NonZeroUsize,
+) -> CutensorPermutationPlanCacheState {
+    Arc::new(Mutex::new(CutensorPermutationPlanCache::new(max_entries)))
+}
+
+fn get_or_init_cutensor_permutation_plan_cache(
+    backend: &CudaBackend,
+) -> crate::Result<CutensorPermutationPlanCacheState> {
+    let guard = backend
+        .cuda_extension_cache()
+        .get_or_try_init::<CutensorPermutationPlanCacheState>(|| {
+            Ok(new_cutensor_permutation_plan_cache_state(
+                default_cutensor_permutation_plan_cache_max_entries(),
+            ))
+        })?;
+    Ok(Arc::clone(&guard))
+}
+
+fn lock_cutensor_permutation_plan_cache(
+    cache: &CutensorPermutationPlanCacheState,
+) -> crate::Result<std::sync::MutexGuard<'_, CutensorPermutationPlanCache>> {
+    cache.lock().map_err(|_| {
+        Error::runtime_state(
+            "cutensor_permutation_plan_cache",
+            "plan cache lock poisoned",
+        )
+    })
+}
+
+pub(super) fn cutensor_permutation_plan_cache_stats(
+    backend: &CudaBackend,
+) -> crate::Result<CacheStats> {
+    let Some(plan_cache) = backend
+        .cuda_extension_cache()
+        .get_cloned::<CutensorPermutationPlanCacheState>()?
+    else {
+        return Ok(CacheStats::empty());
+    };
+    let plan_cache = lock_cutensor_permutation_plan_cache(&plan_cache)?;
+    Ok(plan_cache.stats())
+}
+
+pub(super) fn cutensor_permutation_plan_cache_max_entries(
+    backend: &CudaBackend,
+) -> crate::Result<NonZeroUsize> {
+    let Some(plan_cache) = backend
+        .cuda_extension_cache()
+        .get_cloned::<CutensorPermutationPlanCacheState>()?
+    else {
+        return Ok(default_cutensor_permutation_plan_cache_max_entries());
+    };
+    let plan_cache = lock_cutensor_permutation_plan_cache(&plan_cache)?;
+    Ok(plan_cache.max_entries())
+}
+
+pub(super) fn set_cutensor_permutation_plan_cache_max_entries(
+    backend: &CudaBackend,
+    max_entries: NonZeroUsize,
+) -> crate::Result<()> {
+    let plan_cache = get_or_init_cutensor_permutation_plan_cache(backend)?;
+    let mut plan_cache = lock_cutensor_permutation_plan_cache(&plan_cache)?;
+    plan_cache.set_max_entries(max_entries);
+    let retained_bytes = plan_cache.retained_bytes();
+    backend
+        .cuda_extension_cache()
+        .update_retained_bytes::<CutensorPermutationPlanCacheState>(retained_bytes)
+}
+
+fn cached_cutensor_permutation<T, R>(
+    backend: &CudaBackend,
+    spec: &CutensorPermutationSpec<'_>,
+    op: &'static str,
+    execute: impl FnOnce(&CutensorHandle, &Plan) -> crate::Result<R>,
+) -> crate::Result<R>
+where
+    T: CutensorPermutationScalar,
+{
+    let cutensor = backend.cutensor_handle()?;
+    let key = CutensorPermutationKey::from_spec::<T>(spec);
+    let plan_cache = get_or_init_cutensor_permutation_plan_cache(backend)?;
+    let mut plan_cache = lock_cutensor_permutation_plan_cache(&plan_cache)?;
+    plan_cache.ensure::<T>(cutensor, &key, spec, op)?;
+    let retained_bytes = plan_cache.retained_bytes();
+    backend
+        .cuda_extension_cache()
+        .update_retained_bytes::<CutensorPermutationPlanCacheState>(retained_bytes)?;
+    let cached = plan_cache.get(&key)?;
+    execute(cutensor, &cached.plan)
+}
+
+fn resolve_owned_operand<T, R>(
+    rt: &CudaRuntime,
+    tensor: &TypedTensor<T, R>,
+    op: &'static str,
+) -> crate::Result<ResolvedPermutationOperand>
+where
+    T: 'static,
+    R: TensorRank,
+{
+    ensure_resident_on_runtime(rt, tensor, op)?;
+    Ok(ResolvedPermutationOperand {
+        ptr: typed_device_ptr(rt, tensor, op)?,
+        alignment: CUDA_ALLOCATION_ALIGNMENT,
+    })
+}
+
+fn resolve_view_operand<T, R>(
+    rt: &CudaRuntime,
+    view: &TypedTensorView<'_, T, R>,
+    op: &'static str,
+) -> crate::Result<ResolvedPermutationOperand>
+where
+    T: 'static,
+    R: TensorRank,
+{
+    ensure_view_resident_on_runtime(rt, view, op)?;
+    let buffer = cubecl_view_buffer(view, op)?;
+    resolve_device_region(rt, buffer, view.shape(), view.strides(), view.offset(), op)
+}
+
+fn typed_device_ptr<T, R>(
+    rt: &CudaRuntime,
+    tensor: &TypedTensor<T, R>,
+    op: &'static str,
+) -> crate::Result<*mut c_void>
+where
+    T: 'static,
+    R: TensorRank,
+{
+    let buffer = cubecl_buffer(tensor, op)?;
+    let resource = rt
+        .client()
+        .get_resource(buffer.handle().clone())
+        .map_err(|err| Error::backend_source(op, err))?;
+    cuda_device_ptr_from_addr(resource.resource().ptr, op)
+}
+
+fn resolve_device_region<T: 'static>(
+    rt: &CudaRuntime,
+    buffer: &CubeclBuffer<T>,
+    shape: &[usize],
+    strides: &[isize],
+    offset: isize,
+    op: &'static str,
+) -> crate::Result<ResolvedPermutationOperand> {
+    validate_view_region(buffer, shape, strides, offset, op)?;
+    let offset = usize::try_from(offset).map_err(|_| {
+        Error::invalid_argument(
+            op,
+            "layout",
+            format!("view offset {offset} must be nonnegative for cuTENSOR permutation"),
+        )
+    })?;
+    let resource = rt
+        .client()
+        .get_resource(buffer.handle().clone())
+        .map_err(|err| Error::backend_source(op, err))?;
+    let offset_bytes = (offset as u64)
+        .checked_mul(std::mem::size_of::<T>() as u64)
+        .ok_or_else(|| Error::invalid_argument(op, "layout", "view byte offset overflows u64"))?;
+    let addr = resource
+        .resource()
+        .ptr
+        .checked_add(offset_bytes)
+        .ok_or_else(|| {
+            Error::invalid_argument(op, "layout", "view device address overflows u64")
+        })?;
+    Ok(ResolvedPermutationOperand {
+        ptr: cuda_device_ptr_from_addr(addr, op)?,
+        alignment: address_alignment(addr),
+    })
+}
+
+fn validate_view_region<T>(
+    buffer: &CubeclBuffer<T>,
+    shape: &[usize],
+    strides: &[isize],
+    offset: isize,
+    op: &'static str,
+) -> crate::Result<()> {
+    if shape.contains(&0) {
+        return Ok(());
+    }
+    let mut min_offset = offset as i128;
+    let mut max_offset = offset as i128;
+    for (&dim, &stride) in shape.iter().zip(strides) {
+        let span = ((dim - 1) as i128)
+            .checked_mul(stride as i128)
+            .ok_or_else(|| Error::invalid_argument(op, "layout", "view element span overflows"))?;
+        if span < 0 {
+            min_offset = min_offset.checked_add(span).ok_or_else(|| {
+                Error::invalid_argument(op, "layout", "view minimum offset overflows")
+            })?;
+        } else {
+            max_offset = max_offset.checked_add(span).ok_or_else(|| {
+                Error::invalid_argument(op, "layout", "view maximum offset overflows")
+            })?;
+        }
+    }
+    if min_offset < 0 {
+        return Err(Error::invalid_argument(
+            op,
+            "layout",
+            format!("view region reaches negative element offset {min_offset}"),
+        ));
+    }
+    let len = buffer.element_len() as i128;
+    if max_offset >= len {
+        return Err(Error::invalid_argument(
+            op,
+            "layout",
+            format!(
+                "view region reaches element offset {max_offset} but the device buffer holds only {} elements",
+                buffer.element_len()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+fn view_descriptor_alignment_requirement<T>() -> u32 {
+    u32::try_from(std::mem::size_of::<T>()).unwrap_or(CUDA_ALLOCATION_ALIGNMENT)
+}
+
+fn validate_descriptor_alignment(
+    actual_alignment: u32,
+    alignment_requirement: u32,
+    slot: &'static str,
+    op: &'static str,
+) -> crate::Result<()> {
+    if actual_alignment >= alignment_requirement {
+        return Ok(());
+    }
+    Err(Error::invalid_argument(
+        op,
+        "alignment",
+        format!(
+            "{slot} device pointer alignment {actual_alignment} is smaller than the cuTENSOR \
+             descriptor requirement {alignment_requirement}"
+        ),
+    ))
+}
+
+fn raw_stream(rt: &CudaRuntime) -> crate::Result<CutensorCudaStream> {
+    Ok(rt.raw_cuda_stream()? as usize as CutensorCudaStream)
+}
+
+fn dims_to_i64(op: &'static str, dims: &[usize]) -> crate::Result<Vec<i64>> {
+    dims.iter()
+        .map(|&dim| {
+            i64::try_from(dim).map_err(|_| {
+                Error::invalid_argument(
+                    op,
+                    "shape",
+                    format!("dimension {dim} exceeds cuTENSOR i64 extent limit"),
+                )
+            })
+        })
+        .collect()
+}
+
+fn compact_strides_i64(op: &'static str, shape: &[usize]) -> crate::Result<Vec<i64>> {
+    let strides = col_major_strides(shape)?;
+    view_strides_i64(&strides, op)
+}
+
+fn view_strides_i64(strides: &[isize], op: &'static str) -> crate::Result<Vec<i64>> {
+    strides
+        .iter()
+        .map(|&stride| {
+            i64::try_from(stride).map_err(|_| {
+                Error::invalid_argument(
+                    op,
+                    "layout",
+                    format!("view stride {stride} exceeds cuTENSOR i64 stride limit"),
+                )
+            })
+        })
+        .collect()
+}
+
+fn identity_modes(op: &'static str, rank: usize) -> crate::Result<Vec<i32>> {
+    (0..rank)
+        .map(|axis| {
+            i32::try_from(axis).map_err(|_| {
+                Error::invalid_argument(
+                    op,
+                    "rank",
+                    format!("rank {rank} exceeds cuTENSOR i32 mode limit"),
+                )
+            })
+        })
+        .collect()
+}
+
+fn modes_from_perm(op: &'static str, perm: &[usize]) -> crate::Result<Vec<i32>> {
+    perm.iter()
+        .map(|&axis| {
+            i32::try_from(axis).map_err(|_| {
+                Error::invalid_argument(
+                    op,
+                    "rank",
+                    format!("axis {axis} exceeds cuTENSOR i32 mode limit"),
+                )
+            })
+        })
+        .collect()
+}
+
+/// Largest power of two dividing the byte address, capped at the CUDA
+/// allocation alignment cuTENSOR descriptors assume for whole allocations.
+fn address_alignment(addr: u64) -> u32 {
+    if addr == 0 {
+        return CUDA_ALLOCATION_ALIGNMENT;
+    }
+    1u32 << addr.trailing_zeros().min(8)
+}

--- a/crates/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/metadata_tests.rs
@@ -193,6 +193,12 @@ fn cuda_backend_exposes_extension_cache_retained_byte_controls() {
         CudaBackend::cutensor_plan_cache_max_entries;
     let _cutensor_setter: fn(&CudaBackend, NonZeroUsize) -> crate::Result<()> =
         CudaBackend::set_cutensor_plan_cache_max_entries;
+    let _cutensor_permutation_stats: fn(&CudaBackend) -> crate::Result<CacheStats> =
+        CudaBackend::cutensor_permutation_plan_cache_stats;
+    let _cutensor_permutation_getter: fn(&CudaBackend) -> crate::Result<NonZeroUsize> =
+        CudaBackend::cutensor_permutation_plan_cache_max_entries;
+    let _cutensor_permutation_setter: fn(&CudaBackend, NonZeroUsize) -> crate::Result<()> =
+        CudaBackend::set_cutensor_permutation_plan_cache_max_entries;
 }
 
 #[test]

--- a/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
+++ b/crates/tenferro-gpu/src/cubecl/tests/structural_tests.rs
@@ -595,6 +595,74 @@ fn cuda_to_contiguous_keeps_tensor_on_cuda() {
 }
 
 #[test]
+#[ignore = "requires CUDA 12.8+ GPU and cuTENSOR"]
+fn cuda_cutensor_permutation_transpose_and_to_contiguous_match_cpu() {
+    let mut cpu = cpu_backend();
+    let mut gpu = gpu_backend();
+    assert_eq!(
+        gpu.cutensor_permutation_plan_cache_stats().unwrap().entries,
+        0
+    );
+
+    let input = tensor_f64(vec![2, 3], vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    let gpu_input = upload(&gpu, &input);
+    let expected = cpu.transpose(&input, &[1, 0]).unwrap();
+    let actual = gpu.transpose(&gpu_input, &[1, 0]).unwrap();
+    assert_tensor_close(&download(&gpu, &actual), &expected, 1e-12);
+
+    let cache_after_first = gpu.cutensor_permutation_plan_cache_stats().unwrap();
+    assert_eq!(cache_after_first.entries, 1);
+    assert_eq!(cache_after_first.misses, 1);
+
+    let expected = cpu.transpose(&input, &[1, 0]).unwrap();
+    let actual = gpu.transpose(&gpu_input, &[1, 0]).unwrap();
+    assert_tensor_close(&download(&gpu, &actual), &expected, 1e-12);
+    let cache_after_second = gpu.cutensor_permutation_plan_cache_stats().unwrap();
+    assert_eq!(cache_after_second.entries, 1);
+    assert_eq!(cache_after_second.hits, 1);
+
+    let Tensor::F64(gpu_tensor) = &gpu_input else {
+        panic!("expected f64 tensor");
+    };
+    let materialize_view = gpu_tensor.as_view().transpose_view([1, 0]).unwrap();
+    let materialized = gpu
+        .to_contiguous_read(TensorRead::from_view(TensorView::F64(materialize_view)))
+        .unwrap();
+    let actual = download(&gpu, &materialized);
+    assert_eq!(
+        actual.as_slice::<f64>().unwrap(),
+        &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
+    );
+
+    let complex = tensor_c32(
+        vec![2, 2],
+        vec![
+            Complex32::new(1.0, 2.0),
+            Complex32::new(3.0, 4.0),
+            Complex32::new(5.0, 6.0),
+            Complex32::new(7.0, 8.0),
+        ],
+    );
+    let gpu_complex = upload(&gpu, &complex);
+    let expected = cpu.transpose(&complex, &[1, 0]).unwrap();
+    let actual = gpu.transpose(&gpu_complex, &[1, 0]).unwrap();
+    assert_tensor_close(&download(&gpu, &actual), &expected, 0.0);
+
+    let view = gpu_tensor
+        .as_view()
+        .try_slice_axis(0, StridedSliceSpec::reverse())
+        .unwrap()
+        .transpose_view([1, 0])
+        .unwrap();
+    let compact = gpu.to_contiguous(&view).unwrap();
+    let actual = download(&gpu, &Tensor::F64(compact));
+    assert_eq!(
+        actual.as_slice::<f64>().unwrap(),
+        &[2.0, 4.0, 6.0, 1.0, 3.0, 5.0]
+    );
+}
+
+#[test]
 #[ignore = "requires CUDA 12.8+ GPU"]
 fn cuda_runtime_materialization_is_object_safe_and_stays_on_device() {
     let mut gpu = gpu_backend();

--- a/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/cubecl_launch_contract.rs
@@ -1560,6 +1560,102 @@ fn cutensor_contractions_use_structural_plan_cache_without_pointer_alignment_key
 }
 
 #[test]
+fn cutensor_permutations_use_backend_owned_plan_cache_without_pointer_alignment_keys() {
+    let source = cubecl_source("permutation.rs");
+    let key_source = source_section(
+        &source,
+        "struct CutensorPermutationKey",
+        "struct CachedCutensorPermutation",
+    );
+
+    assert!(
+        key_source.contains("alignment_requirement"),
+        "cuTENSOR permutation plan cache keys should store descriptor alignment requirements"
+    );
+    assert!(
+        !key_source.contains("ptr") && !key_source.contains("address_alignment"),
+        "cuTENSOR permutation plan cache keys must not include allocation-specific pointers or actual pointer alignment"
+    );
+    assert!(
+        source.contains("struct CachedCutensorPermutation"),
+        "CUDA structural permutation should cache descriptor and plan state"
+    );
+    assert!(
+        source.contains("fn cached_cutensor_permutation"),
+        "CUDA transpose and to_contiguous should share the cached cuTENSOR permutation path"
+    );
+    assert!(
+        source.contains("update_retained_bytes::<"),
+        "cached cuTENSOR permutation retained bytes should be reported through the runtime-owned cache"
+    );
+    assert!(
+        source.contains("pub(super) fn cutensor_permutation_plan_cache_stats")
+            && source.contains("pub(super) fn set_cutensor_permutation_plan_cache_max_entries"),
+        "cuTENSOR permutation plan cache should expose owner-routed stats and bound configuration"
+    );
+}
+
+#[test]
+fn cutensor_ffi_binds_permutation_symbols() {
+    let source = cubecl_source("ffi/cutensor.rs");
+
+    for needle in [
+        "type CutensorCreatePermutationFn",
+        "type CutensorPermuteFn",
+        "create_permutation: CutensorCreatePermutationFn",
+        "permute: CutensorPermuteFn",
+        "cutensorCreatePermutation\\0",
+        "cutensorPermute\\0",
+        "pub(crate) fn new_permutation",
+        "pub(crate) unsafe fn permute",
+    ] {
+        assert!(
+            source.contains(needle),
+            "cuTENSOR permutation FFI binding is missing: {needle}"
+        );
+    }
+}
+
+#[test]
+fn cuda_float_permutation_routes_through_cutensor_and_policy_is_recorded() {
+    let cuda = cubecl_source("mod.rs");
+    let permutation = cubecl_source("permutation.rs");
+    let rules = std::fs::read_to_string("../../REPOSITORY_RULES.md").unwrap();
+
+    assert!(
+        cuda.contains("mod permutation;"),
+        "CUDA backend should have a dedicated cuTENSOR permutation module"
+    );
+    assert!(
+        cuda.contains("permutation::transpose(self, t, perm)")
+            && cuda.contains("permutation::to_contiguous_view("),
+        "CUDA f32/f64/c32/c64 structural permutation paths should route through cuTENSOR"
+    );
+    for dtype in ["Tensor::F32", "Tensor::F64", "Tensor::C32", "Tensor::C64"] {
+        assert!(
+            cuda.contains(dtype),
+            "CUDA structural dispatch should retain explicit {dtype} routing"
+        );
+    }
+    for dtype in ["Tensor::I32", "Tensor::I64", "Tensor::Bool"] {
+        assert!(
+            cuda.contains(dtype),
+            "CUDA structural dispatch should keep non-cuTENSOR dtype coverage where supported"
+        );
+    }
+    assert!(
+        permutation.contains("cutensor.permute(")
+            && permutation.contains("CutensorOperator::Identity"),
+        "cuTENSOR permutation should execute through cutensorPermute without adding conjugation semantics"
+    );
+    assert!(
+        rules.contains("must fail with typed load or provider errors")
+            && rules.contains("NVIDIA library is unavailable"),
+        "GPU Backend Contract should record the no-silent-fallback NVIDIA library policy"
+    );
+}
+
+#[test]
 fn cutensor_drop_paths_report_destroy_status() {
     let source = cubecl_source("ffi/cutensor.rs");
     for banned in [

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -67,6 +67,7 @@ crates/tenferro-gpu/src/cubecl/
     interop.rs             owner-scoped launch/allocation bridge for operation crates
     fusion/                fused elementwise classification and code generation
     gemm.rs                cuTENSOR/cuBLAS-backed contraction support
+    permutation.rs         cuTENSOR-backed structural permutation support
     linalg.rs              cuSOLVER/cuBLAS-backed linalg support
     ffi/                   runtime-loaded CUDA library bindings
     tests/                 ignored GPU tests
@@ -198,6 +199,15 @@ Local GPU test runs should also set:
 | `LD_LIBRARY_PATH` | CUDA, cuTENSOR, cuSOLVER, and cuBLAS library lookup |
 | `CUBECL_DEBUG_LOG=0` | Suppress generated-kernel log spam |
 
+CUDA paths whose accepted implementation is an NVIDIA vendor library report a
+typed load or provider error when that library is unavailable or lacks support;
+they do not silently fall back to native CubeCL kernels. Native CubeCL kernels
+remain provider implementations for WebGPU/Metal and for CUDA operations or
+dtypes outside a vendor library's supported set. For structural permutation,
+cuTENSOR covers `F32`, `F64`, `C32`, and `C64`; CUDA `I32`, `I64`, and `Bool`
+structural data movement stays on existing CubeCL kernels because cuTENSOR 2.x
+does not provide an integer or bool permutation compute descriptor.
+
 ## Runtime Cache Ownership
 
 `CudaBackend` owns CUDA extension backend-state caches. Extension crates may
@@ -231,6 +241,23 @@ report the retained typed cache entry. Use
 `CudaBackend::cutensor_plan_cache_max_entries`, and
 `CudaBackend::set_cutensor_plan_cache_max_entries` for cuTENSOR plan-entry
 introspection and bound configuration.
+
+CUDA structural permutation for `F32`, `F64`, `C32`, and `C64` stores cuTENSOR
+permutation descriptors and plans in the same backend-owned extension cache
+when the layout is representable by cuTENSOR descriptors. The permutation plan
+key is structural: dtype, input/output extents, strides, modes, unary input
+operator, and descriptor alignment requirements. It must not include allocation
+addresses or actual pointer-specific alignment. Whole allocations keep the CUDA
+allocation alignment requirement; borrowed nonnegative-stride views use a
+conservative dtype-size descriptor alignment requirement so cached plans remain
+valid across offsets. Negative-stride CUDA views are not a missing-library
+fallback: cuTENSOR 2.x rejects those descriptors, so same-device
+canonicalization of such views remains on the native CubeCL structural copy
+kernel. Use
+`CudaBackend::cutensor_permutation_plan_cache_stats`,
+`CudaBackend::cutensor_permutation_plan_cache_max_entries`, and
+`CudaBackend::set_cutensor_permutation_plan_cache_max_entries` for permutation
+plan-entry introspection and bound configuration.
 
 WebGPU provider caches must be owned by `WebGpuBackend` or a WebGPU runtime
 cache object with the same bounded-default, clear, configure, and stats
@@ -421,7 +448,7 @@ CUDA library calls:
 | Allocation/transfer | CUDA allocation, upload, download, raw pointer bridge for all public tensor dtypes |
 | Elementwise | `F32`/`F64` arithmetic, comparison, selection, clamp, and analytic unary ops; `I32`/`I64` add/sub/mul/div/rem, neg/abs/sign/pow, compare/select, and minimum/maximum; `C32`/`C64` add/mul/div/neg/conj and real-output `abs` |
 | Reductions | sum/prod for `F32`, `F64`, `I32`, `I64`, `C32`, and `C64`; min/max for `F32`, `F64`, `I32`, and `I64` |
-| Structural | reshape, transpose, broadcast, reverse, concatenate, diagonal extraction/embedding, triangular masks, slice, and pad support all public tensor dtypes; Bool data movement uses its one-byte device representation |
+| Structural | reshape, transpose, broadcast, reverse, concatenate, diagonal extraction/embedding, triangular masks, slice, and pad support all public tensor dtypes; `F32`/`F64`/`C32`/`C64` transpose and view canonicalization use cuTENSOR permutation on CUDA; integer and Bool data movement use CubeCL kernels because cuTENSOR lacks those permutation compute descriptors |
 | DType conversion | checked `convert` and explicit `cast` cover every CPU-supported pair among the seven public dtypes; explicit real/complex-to-integer validation uses a small device flag and never downloads the input tensor |
 | Indexing | gather and dynamic_slice support `F32`, `F64`, `I32`, `Bool`, `C32`, and `C64` data with CPU-supported `F32`, `F64`, `I32`, or `I64` index tensors; additive scatter remains limited to floating and complex data and explicitly excludes Bool data |
 | Contraction | cuTENSOR-backed paths for supported real and complex floating dtypes |

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -135,6 +135,10 @@ export TENFERRO_CUBLAS_PATH=$CUDA_PATH/lib64/libcublas.so.12
 export CUBECL_DEBUG_LOG=0
 ```
 
+CUDA operations implemented through NVIDIA libraries return typed load or
+provider errors when the required library is missing. They do not silently use
+a slower native CubeCL kernel as a CUDA fallback.
+
 For XLA/PJRT GPU verification, add the PJRT plugin path separately:
 
 ```bash
@@ -315,12 +319,12 @@ descriptor.
 | --- | --- | --- |
 | Allocation, upload, download | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Explicit CPU/GPU transfer only |
 | `reshape` | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Metadata-only shape change |
-| `transpose`, `broadcast_in_dim`, `extract_diagonal`, `embed_diagonal`, `tril`, `triu` | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Structural tensor operations |
+| `transpose`, `broadcast_in_dim`, `extract_diagonal`, `embed_diagonal`, `tril`, `triu` | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Structural tensor operations; CUDA `F32`/`F64`/`C32`/`C64` transpose uses cuTENSOR permutation |
 | checked `convert`, explicit `cast` | All CPU-supported pairs among `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | `convert` remains restricted by the public promotion lattice; explicit `cast` supports lossy narrowing, real-component projection, zero-imaginary injection, integer conversion, and nonzero Bool truthiness. Fallible real/complex-to-integer casts validate on device and return the same typed errors as CPU |
 | `gather` | operand `F32`, `F64`, `I32`, `Bool`, `C32`, `C64`; indices `F32`, `F64`, `I32`, or `I64` | Complex and `Bool` index tensors; `I64` operands are not implemented |
 | `scatter` | operand/update `F32`, `F64`, `C32`, `C64`; indices `F32`, `F64`, `I32`, or `I64` | Add-scatter semantics; complex and `Bool` index tensors and integer/`Bool` operands are not implemented |
 | `slice`, `pad`, `concatenate`, `reverse` | `F32`, `F64`, `I32`, `I64`, `Bool`, `C32`, `C64` | Dense structural/indexing operations |
-| `to_contiguous_read` | `F32`, `F64`, `I32`, `I64`, `C32`, `C64` | Same-device canonicalization of owned tensors and arbitrary valid CUDA views; `Bool` is an explicit current limitation |
+| `to_contiguous_read` | `F32`, `F64`, `I32`, `I64`, `C32`, `C64` | Same-device canonicalization of owned tensors and arbitrary valid CUDA views; CUDA `F32`/`F64`/`C32`/`C64` nonnegative-stride canonicalization uses cuTENSOR permutation, while negative-stride views use the native CUDA structural copy because cuTENSOR does not represent that layout; `Bool` is an explicit current limitation |
 | `copy_read_into` | `F32`, `F64`, `I32`, `I64`, `C32`, `C64` | Source must be compact column-major with offset zero and cover its full allocation; destination may be strided; allocations must not alias; `Bool` is an explicit current limitation |
 | `dynamic_slice` | input `F32`, `F64`, `I32`, `Bool`, `C32`, `C64` with starts `F32`, `F64`, `I32`, or `I64` | Complex and `Bool` start tensors; `I64` inputs are not implemented |
 | `dynamic_update_slice` | No CUDA implementation | Returns an error |

--- a/docs/worklogs/2026-07-28-cuda-cutensor-permutation.md
+++ b/docs/worklogs/2026-07-28-cuda-cutensor-permutation.md
@@ -1,0 +1,60 @@
+# CUDA cuTENSOR Permutation
+
+Issue: tensor4all/tenferro-rs#1506
+
+## Summary
+
+- Added `cutensorCreatePermutation` / `cutensorPermute` to the CUDA cuTENSOR
+  dlopen FFI.
+- Routed CUDA `F32`, `F64`, `C32`, and `C64` `transpose` and nonnegative-stride
+  view canonicalization through cuTENSOR permutation.
+- Added a backend-owned cuTENSOR permutation plan cache in the CUDA extension
+  cache, with bounded entries, retained-byte accounting, clear participation,
+  stats, and bound configuration.
+- Recorded the NVIDIA library no-silent-fallback policy in
+  `REPOSITORY_RULES.md` and the GPU backend design doc.
+
+cuTENSOR 2.5 rejects negative-stride tensor descriptors. CUDA negative-stride
+view canonicalization remains on the existing native CubeCL structural copy
+kernel because that layout is outside the vendor permutation descriptor model;
+this is not a fallback for missing cuTENSOR on supported descriptors.
+
+## A100 Focused Benchmark
+
+Machine: NVIDIA A100 80GB PCIe. Command:
+
+```bash
+CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda \
+LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} \
+GPU_BENCH_DEVICE=0 BENCH_RUNS=5 BENCH_WARMUPS=2 \
+BENCH_OUTPUT=/tmp/gpu-permutation-1506-rust.jsonl \
+./target/release/benchmark_gpu_permutation
+```
+
+The benchmark used the `tenferro-benchmark` Rust GPU permutation runner with
+`extern/tenferro-rs` symlinked to this branch. The tenferro columns allocate a
+fresh device output per public API call; the direct `cutensor` column reuses a
+destination. The measured public-API-plus-allocation overhead stayed within
+3.9% of direct destination-reuse cuTENSOR on every row.
+
+| pattern | tenferro transpose / cuTENSOR | tenferro to_contiguous / cuTENSOR |
+| --- | ---: | ---: |
+| `transpose_2d_32768_16384` | 1.021x | 1.028x |
+| `transpose_3d_1024_1024_512_201` | 1.011x | 1.013x |
+| `transpose_3d_1024_1024_512_102` | 1.039x | 1.039x |
+| `rotation_6d_64_32_32_32_16_16` | 1.033x | 1.020x |
+| `reverse_23d_128x2` | 1.017x | 1.018x |
+| `reverse_18d_3` | 1.022x | 1.034x |
+| `cyclic_18d_3` | 1.012x | 1.011x |
+| `tn_light_415_24d_scattered_to_colmajor_gpu` | n/a | 0.982x |
+| `tn_light_415_24d_contiguous_same_perm_gpu` | 1.034x | 0.999x |
+
+## Verification
+
+- RED: `cargo test -p tenferro-gpu --test integration cutensor -- --nocapture`
+  failed before implementation on missing FFI/module/policy contracts.
+- `cargo test -p tenferro-gpu --test integration cutensor -- --nocapture`
+- `cargo check -p tenferro-gpu --features cuda`
+- `cargo test -p tenferro-gpu --features cuda cutensor_loader_missing_library_is_typed_io_error -- --nocapture`
+- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} CARGO_BUILD_JOBS=64 cargo test -p tenferro-gpu --features cuda cuda_cutensor_permutation_transpose_and_to_contiguous_match_cpu -- --ignored --nocapture`
+- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} CARGO_BUILD_JOBS=64 cargo test -p tenferro-gpu --features cuda structural -- --ignored --nocapture`


### PR DESCRIPTION
Closes #1506.

## Summary

- Bind `cutensorCreatePermutation` / `cutensorPermute` in the runtime-loaded cuTENSOR FFI.
- Route CUDA `F32`, `F64`, `C32`, and `C64` structural `transpose` plus nonnegative-stride `to_contiguous` / `to_contiguous_read` through cuTENSOR permutation.
- Add a backend-owned cuTENSOR permutation plan cache with bounded entries, retained-byte accounting, stats, and configuration APIs.
- Record the CUDA vendor-library no-silent-fallback policy in `REPOSITORY_RULES.md` and GPU docs.

cuTENSOR 2.5 rejects negative-stride tensor descriptors on the local A100 setup, so negative-stride view canonicalization stays on the existing native CUDA structural copy kernel. That keeps coverage for a layout outside cuTENSOR descriptor support; missing cuTENSOR on supported float/complex permutation paths remains a typed load/provider error, not a silent fallback.

## A100 focused benchmark

Machine: NVIDIA A100 80GB PCIe. Runner: `tenferro-benchmark` Rust GPU permutation runner with `extern/tenferro-rs` symlinked to this branch. `BENCH_RUNS=5`, `BENCH_WARMUPS=2`.

The tenferro public API columns allocate a fresh device output per call, while the direct cuTENSOR reference reuses a destination. Allocation-inclusive public API overhead stayed within 3.9% of direct destination-reuse cuTENSOR on every measured row.

| pattern | tenferro transpose / cuTENSOR | tenferro to_contiguous / cuTENSOR |
| --- | ---: | ---: |
| `transpose_2d_32768_16384` | 1.021x | 1.028x |
| `transpose_3d_1024_1024_512_201` | 1.011x | 1.013x |
| `transpose_3d_1024_1024_512_102` | 1.039x | 1.039x |
| `rotation_6d_64_32_32_32_16_16` | 1.033x | 1.020x |
| `reverse_23d_128x2` | 1.017x | 1.018x |
| `reverse_18d_3` | 1.022x | 1.034x |
| `cyclic_18d_3` | 1.012x | 1.011x |
| `tn_light_415_24d_scattered_to_colmajor_gpu` | n/a | 0.982x |
| `tn_light_415_24d_contiguous_same_perm_gpu` | 1.034x | 0.999x |

## Verification

- RED before implementation: `cargo test -p tenferro-gpu --test integration cutensor -- --nocapture` failed on missing FFI/module/policy contracts.
- `python3 scripts/ci/run_profile.py fmt`
- `bash scripts/check-pr-fast.sh --coverage-reviewed --test 'cargo test -p tenferro-gpu --test integration cutensor -- --nocapture' --test 'cargo test -p tenferro-gpu --features cuda cutensor_loader_missing_library_is_typed_io_error -- --nocapture'`
- `python3 scripts/repository-rules-review.py --base origin/main --head HEAD --worktree --dry-run --llm-skipped-reason 'local pre-PR deterministic rules review; LLM review is not required for this local handoff' --output-json /tmp/repository-rules-review-1506.json`
- `cargo test -p tenferro-gpu --test integration -- --nocapture`
- `cargo test -p tenferro-gpu --features cuda --test integration -- --nocapture`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} CARGO_BUILD_JOBS=64 cargo test -p tenferro-gpu --features cuda cuda_cutensor_permutation_transpose_and_to_contiguous_match_cpu -- --ignored --nocapture`
- `CUBECL_DEBUG_LOG=0 CUDA_PATH=/usr/local/cuda LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/libcutensor/12:/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-} CARGO_BUILD_JOBS=64 cargo test -p tenferro-gpu --features cuda structural -- --ignored --nocapture`
