### PR TITLE
Optimize native CubeCL permutation kernels for Metal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0" }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "06c825829e399dd769504e6ce10dbca8f07b5e15", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "06c825829e399dd769504e6ce10dbca8f07b5e15", version = "0.3.0" }
 strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "06c825829e399dd769504e6ce10dbca8f07b5e15", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0", default-features = false }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "06c825829e399dd769504e6ce10dbca8f07b5e15", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "06c825829e399dd769504e6ce10dbca8f07b5e15", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ quote = "1"
 syn = "2"
 strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0" }
 strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "f342fca6d1790a1e2f4f5b32b73bd7404975feb6", version = "0.3.0", features = ["parallel"] }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "06c825829e399dd769504e6ce10dbca8f07b5e15", version = "0.3.0", features = ["parallel"] }
 strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0", features = ["parallel"] }
 strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0", default-features = false }
 libloading = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ quote = "1"
 syn = "2"
 strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0" }
 strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0", features = ["parallel"] }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "f342fca6d1790a1e2f4f5b32b73bd7404975feb6", version = "0.3.0", features = ["parallel"] }
 strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0", features = ["parallel"] }
 strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "18d74ffacccefee8c476379c21a99eae532b917b", version = "0.3.0", default-features = false }
 libloading = "0.8"

--- a/crates/tenferro-gpu/Cargo.toml
+++ b/crates/tenferro-gpu/Cargo.toml
@@ -61,6 +61,7 @@ libloading.workspace = true
 num-complex.workspace = true
 num-traits.workspace = true
 smallvec.workspace = true
+strided-perm.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -262,18 +262,22 @@ fn launch_native_materialization<E: CubePrimitive>(
                     "tiled transpose requires a non-negative source offset",
                 )
             })?;
-            if let Some((cubes_x, cubes_y)) = config.dispatch_grid(op, &plan.dims, 65_535)? {
+            if let Some((cubes_x, cubes_y, cubes_z)) =
+                config.dispatch_grid(op, &plan.dims, 65_535)?
+            {
+                let batch_stride = plan.tiled_matrix_len(op)?;
                 unsafe {
                     // SAFETY: The tiled classification proves a compact 2D
                     // transpose. Bounds guards cover edge tiles and every unit
                     // reaches the shared-memory barrier.
                     structural::tiled_transpose_kernel::launch_unchecked::<E, CubeclCudaRuntime>(
                         backend.runtime().client(),
-                        CubeCount::Static(cubes_x, cubes_y, 1),
+                        CubeCount::Static(cubes_x, cubes_y, cubes_z),
                         CubeDim::new_2d(config.tile / config.vector_width, config.block_rows),
                         output,
                         input,
                         src_offset,
+                        batch_stride,
                         plan.dims[0],
                         plan.dims[1],
                         config.tile as usize,

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -107,6 +107,9 @@ use crate::config::{
 };
 use crate::kernels::reduce::{self as cubecl_reduce, ReduceStrategy};
 use crate::kernels::{diagonal, elementwise, indexing, structural};
+use crate::native_permutation::{
+    NativePermutationKind, NativePermutationPlan, NativeTransposeTile,
+};
 use crate::{
     Buffer, DeviceId, DeviceKind, GpuBackendKind, MemoryKind, Placement, Tensor, TensorRank,
     TensorView, TensorViewCanonicalization, TensorViewMut, TypedTensor, TypedTensorView,
@@ -212,6 +215,109 @@ fn view_offset_i64(offset: isize, op: &'static str) -> crate::Result<i64> {
             format!("view offset {offset} exceeds CubeCL i64 metadata limit"),
         )
     })
+}
+
+fn compact_strides_isize(op: &'static str, shape: &[usize]) -> crate::Result<Vec<isize>> {
+    let mut strides = Vec::with_capacity(shape.len());
+    let mut stride = 1isize;
+    for &dim in shape {
+        strides.push(stride);
+        let dim = isize::try_from(dim).map_err(|_| {
+            crate::Error::invalid_argument(
+                op,
+                "shape",
+                format!("dimension {dim} cannot be represented as isize"),
+            )
+        })?;
+        stride = stride.checked_mul(dim).ok_or_else(|| {
+            crate::Error::invalid_argument(
+                op,
+                "shape",
+                format!("column-major stride overflow for shape {shape:?}"),
+            )
+        })?;
+    }
+    Ok(strides)
+}
+
+fn launch_native_materialization<E: CubePrimitive>(
+    backend: &CudaBackend,
+    output: ArrayArg<CubeclCudaRuntime>,
+    input: ArrayArg<CubeclCudaRuntime>,
+    plan: &NativePermutationPlan,
+    op: &'static str,
+) -> crate::Result<()> {
+    if plan.len == 0 {
+        return Ok(());
+    }
+    if plan.kind == NativePermutationKind::TiledTranspose {
+        if let Some(config) = NativeTransposeTile::selected(op)? {
+            let tile = config.tile as usize;
+            let block_rows = config.block_rows as usize;
+            let padding = config.padding as usize;
+            let vector_width = config.vector_width as usize;
+            let src_offset = usize::try_from(plan.src_offset).map_err(|_| {
+                crate::Error::invalid_argument(
+                    op,
+                    "offset",
+                    "tiled transpose requires a non-negative source offset",
+                )
+            })?;
+            let cubes_x = u32::try_from(plan.dims[1].div_ceil(tile)).map_err(|_| {
+                crate::Error::invalid_argument(
+                    op,
+                    "shape",
+                    "tiled transpose x grid exceeds u32::MAX",
+                )
+            })?;
+            let cubes_y = u32::try_from(plan.dims[0].div_ceil(tile)).map_err(|_| {
+                crate::Error::invalid_argument(
+                    op,
+                    "shape",
+                    "tiled transpose y grid exceeds u32::MAX",
+                )
+            })?;
+            unsafe {
+                // SAFETY: The tiled classification proves a compact 2D
+                // transpose. Bounds guards cover edge tiles and every unit
+                // reaches the shared-memory barrier.
+                structural::tiled_transpose_kernel::launch_unchecked::<E, CubeclCudaRuntime>(
+                    backend.runtime().client(),
+                    CubeCount::Static(cubes_x.max(1), cubes_y.max(1), 1),
+                    CubeDim::new_2d(config.tile / config.vector_width, config.block_rows),
+                    output,
+                    input,
+                    src_offset,
+                    plan.dims[0],
+                    plan.dims[1],
+                    tile,
+                    block_rows,
+                    padding,
+                    vector_width,
+                );
+            }
+            return Ok(());
+        }
+    }
+    let src_strides = view_strides_i64(&plan.src_strides, op)?;
+    let src_offset = view_offset_i64(plan.src_offset, op)?;
+    unsafe {
+        // SAFETY: `NativePermutationPlan` validated both allocation ranges,
+        // destination non-overlap, and disjoint source/destination storage.
+        structural::materialize_strided_kernel::launch_unchecked::<E, CubeclCudaRuntime>(
+            backend.runtime().client(),
+            cube_count_for_len(plan.len)?,
+            cube_dim_1d(),
+            output,
+            input,
+            comptime_sequence(&plan.dims),
+            comptime_sequence(&src_strides),
+            src_offset,
+            plan.len,
+            plan.dims.len(),
+        );
+    }
+    Ok(())
 }
 
 fn scatter_update_len(meta: &ScatterLaunchMeta) -> crate::Result<usize> {
@@ -820,26 +926,27 @@ impl CudaBackend {
         perm: &[usize],
     ) -> crate::Result<TypedTensor<T>>
     where
-        T: CubeElement + CubePrimitive + Clone,
+        T: CubeElement + CubePrimitive + Clone + Send + Sync + 'static,
     {
         validate_permutation("transpose", perm, input.shape().len())?;
         let output_shape: Vec<usize> = perm.iter().map(|&axis| input.shape()[axis]).collect();
-        launch_unary_tensor(
-            self.runtime(),
-            input,
-            &output_shape,
+        ensure_resident_on_runtime(self.runtime(), input, "transpose")?;
+        let input_strides = compact_strides_isize("transpose", input.shape())?;
+        let plan = NativePermutationPlan::for_transpose(
             "transpose",
-            |client, count, dim, out, input_arg| unsafe {
-                structural::transpose_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
-                    client,
-                    count,
-                    dim,
-                    out.into_tensor_arg(),
-                    input_arg.into_tensor_arg(),
-                    comptime_sequence(perm),
-                );
-            },
-        )
+            input.shape(),
+            &input_strides,
+            perm,
+            0,
+            input.n_elements(),
+            input.n_elements(),
+            false,
+        )?;
+        let output = alloc_output::<T>(self.runtime(), &output_shape)?;
+        let output_arg = typed_tensor_array_arg(&output, "transpose")?;
+        let input_arg = typed_tensor_array_arg(input, "transpose")?;
+        launch_native_materialization::<T>(self, output_arg, input_arg, &plan, "transpose")?;
+        Ok(output)
     }
 
     fn transpose_bool(
@@ -849,22 +956,23 @@ impl CudaBackend {
     ) -> crate::Result<TypedTensor<bool>> {
         validate_permutation("transpose", perm, input.shape().len())?;
         let output_shape: Vec<usize> = perm.iter().map(|&axis| input.shape()[axis]).collect();
-        launch_unary_bool_tensor(
-            self.runtime(),
-            input,
-            &output_shape,
+        ensure_resident_on_runtime(self.runtime(), input, "transpose")?;
+        let input_strides = compact_strides_isize("transpose", input.shape())?;
+        let plan = NativePermutationPlan::for_transpose(
             "transpose",
-            |client, count, dim, out, input_arg| unsafe {
-                structural::transpose_kernel::launch_unchecked::<u8, CubeclCudaRuntime>(
-                    client,
-                    count,
-                    dim,
-                    out.into_tensor_arg(),
-                    input_arg.into_tensor_arg(),
-                    comptime_sequence(perm),
-                );
-            },
-        )
+            input.shape(),
+            &input_strides,
+            perm,
+            0,
+            input.n_elements(),
+            input.n_elements(),
+            false,
+        )?;
+        let output = alloc_bool_output(self.runtime(), &output_shape)?;
+        let output_arg = bool_tensor_array_arg(&output, "transpose")?;
+        let input_arg = bool_tensor_array_arg(input, "transpose")?;
+        launch_native_materialization::<u8>(self, output_arg, input_arg, &plan, "transpose")?;
+        Ok(output)
     }
 
     fn broadcast_typed<T>(
@@ -1019,32 +1127,26 @@ impl CudaBackend {
         R: TensorRank,
     {
         ensure_view_resident_on_runtime(self.runtime(), view, op)?;
+        let len = checked_dim_product(op, "output shape", view.shape())?;
+        let source_allocation_len = view
+            .backend_buffer()
+            .map(|buffer| buffer.len())
+            .ok_or_else(|| {
+                crate::Error::runtime_state(op, "expected CUDA backend view, got host view")
+            })?;
+        let plan = NativePermutationPlan::for_contiguous_output(
+            op,
+            view.shape(),
+            view.strides(),
+            view.offset(),
+            source_allocation_len,
+            len,
+            false,
+        )?;
         let output = self.alloc_ranked_output::<T, R>(view.shape(), op)?;
-        let len = output.n_elements();
-        if len == 0 {
-            return Ok(output);
-        }
-        let strides = view_strides_i64(view.strides(), op)?;
-        let base_offset = view_offset_i64(view.offset(), op)?;
-        let output_arg = typed_tensor_binding(&output, op)?;
+        let output_arg = typed_tensor_array_arg(&output, op)?;
         let input_arg = typed_view_array_arg(view, op)?;
-        let rank = view.shape().len();
-        unsafe {
-            // SAFETY: The view constructor validated reachable offsets against
-            // the backing allocation, and `ensure_view_resident_on_runtime`
-            // proves this is a CubeCL buffer on this CUDA runtime. The launch
-            // domain covers every logical output element exactly once.
-            structural::view_to_contiguous_kernel::launch_unchecked::<T, CubeclCudaRuntime>(
-                self.runtime().client(),
-                cube_count_for_len(len)?,
-                cube_dim_1d(),
-                output_arg.into_tensor_arg(),
-                input_arg,
-                comptime_sequence(&strides),
-                base_offset,
-                rank,
-            );
-        }
+        launch_native_materialization::<T>(self, output_arg, input_arg, &plan, op)?;
         Ok(output)
     }
 

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -262,22 +262,18 @@ fn launch_native_materialization<E: CubePrimitive>(
                     "tiled transpose requires a non-negative source offset",
                 )
             })?;
-            if let Some((cubes_x, cubes_y, cubes_z)) =
-                config.dispatch_grid(op, &plan.dims, 65_535)?
-            {
-                let batch_stride = plan.tiled_matrix_len(op)?;
+            if let Some((cubes_x, cubes_y)) = config.dispatch_grid(op, &plan.dims, 65_535)? {
                 unsafe {
                     // SAFETY: The tiled classification proves a compact 2D
                     // transpose. Bounds guards cover edge tiles and every unit
                     // reaches the shared-memory barrier.
                     structural::tiled_transpose_kernel::launch_unchecked::<E, CubeclCudaRuntime>(
                         backend.runtime().client(),
-                        CubeCount::Static(cubes_x, cubes_y, cubes_z),
+                        CubeCount::Static(cubes_x, cubes_y, 1),
                         CubeDim::new_2d(config.tile / config.vector_width, config.block_rows),
                         output,
                         input,
                         src_offset,
-                        batch_stride,
                         plan.dims[0],
                         plan.dims[1],
                         config.tile as usize,

--- a/crates/tenferro-gpu/src/cubecl/mod.rs
+++ b/crates/tenferro-gpu/src/cubecl/mod.rs
@@ -252,7 +252,6 @@ fn launch_native_materialization<E: CubePrimitive>(
     }
     if plan.kind == NativePermutationKind::TiledTranspose {
         if let Some(config) = NativeTransposeTile::selected(op)? {
-            let tile = config.tile as usize;
             let block_rows = config.block_rows as usize;
             let padding = config.padding as usize;
             let vector_width = config.vector_width as usize;
@@ -263,40 +262,28 @@ fn launch_native_materialization<E: CubePrimitive>(
                     "tiled transpose requires a non-negative source offset",
                 )
             })?;
-            let cubes_x = u32::try_from(plan.dims[1].div_ceil(tile)).map_err(|_| {
-                crate::Error::invalid_argument(
-                    op,
-                    "shape",
-                    "tiled transpose x grid exceeds u32::MAX",
-                )
-            })?;
-            let cubes_y = u32::try_from(plan.dims[0].div_ceil(tile)).map_err(|_| {
-                crate::Error::invalid_argument(
-                    op,
-                    "shape",
-                    "tiled transpose y grid exceeds u32::MAX",
-                )
-            })?;
-            unsafe {
-                // SAFETY: The tiled classification proves a compact 2D
-                // transpose. Bounds guards cover edge tiles and every unit
-                // reaches the shared-memory barrier.
-                structural::tiled_transpose_kernel::launch_unchecked::<E, CubeclCudaRuntime>(
-                    backend.runtime().client(),
-                    CubeCount::Static(cubes_x.max(1), cubes_y.max(1), 1),
-                    CubeDim::new_2d(config.tile / config.vector_width, config.block_rows),
-                    output,
-                    input,
-                    src_offset,
-                    plan.dims[0],
-                    plan.dims[1],
-                    tile,
-                    block_rows,
-                    padding,
-                    vector_width,
-                );
+            if let Some((cubes_x, cubes_y)) = config.dispatch_grid(op, &plan.dims, 65_535)? {
+                unsafe {
+                    // SAFETY: The tiled classification proves a compact 2D
+                    // transpose. Bounds guards cover edge tiles and every unit
+                    // reaches the shared-memory barrier.
+                    structural::tiled_transpose_kernel::launch_unchecked::<E, CubeclCudaRuntime>(
+                        backend.runtime().client(),
+                        CubeCount::Static(cubes_x, cubes_y, 1),
+                        CubeDim::new_2d(config.tile / config.vector_width, config.block_rows),
+                        output,
+                        input,
+                        src_offset,
+                        plan.dims[0],
+                        plan.dims[1],
+                        config.tile as usize,
+                        block_rows,
+                        padding,
+                        vector_width,
+                    );
+                }
+                return Ok(());
             }
-            return Ok(());
         }
     }
     let src_strides = view_strides_i64(&plan.src_strides, op)?;

--- a/crates/tenferro-gpu/src/kernels/mod.rs
+++ b/crates/tenferro-gpu/src/kernels/mod.rs
@@ -3,13 +3,19 @@
 //! This crate owns GPU kernel definitions but does not own tenferro tensor
 //! values, device placement, or backend dispatch.
 
+#[cfg(feature = "cuda")]
 pub(crate) mod error;
+#[cfg(feature = "cuda")]
 pub(crate) mod reduce;
 
+#[cfg(feature = "cuda")]
 pub(crate) mod diagonal;
+#[cfg(feature = "cuda")]
 pub(crate) mod elementwise;
 mod helpers;
+#[cfg(feature = "cuda")]
 pub(crate) mod indexing;
 pub(crate) mod structural;
 
+#[cfg(feature = "cuda")]
 pub(crate) use error::{CubeclKernelError, Result};

--- a/crates/tenferro-gpu/src/kernels/structural.rs
+++ b/crates/tenferro-gpu/src/kernels/structural.rs
@@ -80,6 +80,7 @@ pub fn tiled_transpose_kernel<E: CubePrimitive>(
     dst: &mut Array<E>,
     src: &Array<E>,
     src_offset: usize,
+    #[comptime] batch_stride: usize,
     #[comptime] dst_fast_extent: usize,
     #[comptime] src_fast_extent: usize,
     #[comptime] tile: usize,
@@ -93,6 +94,7 @@ pub fn tiled_transpose_kernel<E: CubePrimitive>(
     let unit_y = UNIT_POS_Y as usize;
     let tile_src_fast = CUBE_POS_X as usize * tile;
     let tile_dst_fast = CUBE_POS_Y as usize * tile;
+    let batch_base = CUBE_POS_Z as usize * batch_stride;
 
     let mut row = unit_y;
     while row < tile {
@@ -102,7 +104,7 @@ pub fn tiled_transpose_kernel<E: CubePrimitive>(
             let local_src_fast = unit_x * vector_width + lane;
             let src_fast = tile_src_fast + local_src_fast;
             if dst_fast < dst_fast_extent && src_fast < src_fast_extent {
-                let src_index = src_offset + dst_fast * src_fast_extent + src_fast;
+                let src_index = src_offset + batch_base + dst_fast * src_fast_extent + src_fast;
                 shared[row * pitch + local_src_fast] = src[src_index];
             }
         }
@@ -119,7 +121,7 @@ pub fn tiled_transpose_kernel<E: CubePrimitive>(
             let local_dst_fast = unit_x * vector_width + lane;
             let dst_fast = tile_dst_fast + local_dst_fast;
             if dst_fast < dst_fast_extent && src_fast < src_fast_extent {
-                let dst_index = dst_fast + src_fast * dst_fast_extent;
+                let dst_index = batch_base + dst_fast + src_fast * dst_fast_extent;
                 dst[dst_index] = shared[local_dst_fast * pitch + row];
             }
         }

--- a/crates/tenferro-gpu/src/kernels/structural.rs
+++ b/crates/tenferro-gpu/src/kernels/structural.rs
@@ -51,16 +51,79 @@ pub fn scale_in_place_complex_kernel<C: ComplexCore>(out: &mut Array<C>, factor:
 }
 
 #[cube(launch_unchecked)]
-pub fn view_to_contiguous_kernel<E: CubePrimitive>(
-    out: &mut Tensor<E>,
-    input: &Array<E>,
-    #[comptime] strides: Sequence<i64>,
-    base_offset: i64,
+pub fn materialize_strided_kernel<E: CubePrimitive>(
+    dst: &mut Array<E>,
+    src: &Array<E>,
+    #[comptime] dims: Sequence<usize>,
+    #[comptime] src_strides: Sequence<i64>,
+    src_offset: i64,
+    #[comptime] len: usize,
     #[comptime] rank: usize,
 ) {
-    if ABSOLUTE_POS < out.len() {
-        let src = strided_view_offset_from_tensor(ABSOLUTE_POS, out, strides, base_offset, rank);
-        out[ABSOLUTE_POS] = input[src];
+    if ABSOLUTE_POS < len {
+        let mut flat = ABSOLUTE_POS;
+        let mut src_index = src_offset;
+        #[unroll]
+        for axis in 0..rank {
+            let dim = comptime! { *dims.index(axis) };
+            let coordinate = flat % dim;
+            flat /= dim;
+            let src_stride = comptime! { *src_strides.index(axis) };
+            src_index += (coordinate as i64) * src_stride;
+        }
+        dst[ABSOLUTE_POS] = src[usize::cast_from(src_index)];
+    }
+}
+
+#[cube(launch_unchecked)]
+pub fn tiled_transpose_kernel<E: CubePrimitive>(
+    dst: &mut Array<E>,
+    src: &Array<E>,
+    src_offset: usize,
+    #[comptime] dst_fast_extent: usize,
+    #[comptime] src_fast_extent: usize,
+    #[comptime] tile: usize,
+    #[comptime] block_rows: usize,
+    #[comptime] padding: usize,
+    #[comptime] vector_width: usize,
+) {
+    let pitch = tile + padding;
+    let mut shared = SharedMemory::<E>::new(tile * pitch);
+    let unit_x = UNIT_POS_X as usize;
+    let unit_y = UNIT_POS_Y as usize;
+    let tile_src_fast = CUBE_POS_X as usize * tile;
+    let tile_dst_fast = CUBE_POS_Y as usize * tile;
+
+    let mut row = unit_y;
+    while row < tile {
+        let dst_fast = tile_dst_fast + row;
+        #[unroll]
+        for lane in 0..vector_width {
+            let local_src_fast = unit_x * vector_width + lane;
+            let src_fast = tile_src_fast + local_src_fast;
+            if dst_fast < dst_fast_extent && src_fast < src_fast_extent {
+                let src_index = src_offset + dst_fast * src_fast_extent + src_fast;
+                shared[row * pitch + local_src_fast] = src[src_index];
+            }
+        }
+        row += block_rows;
+    }
+
+    sync_cube();
+
+    row = unit_y;
+    while row < tile {
+        let src_fast = tile_src_fast + row;
+        #[unroll]
+        for lane in 0..vector_width {
+            let local_dst_fast = unit_x * vector_width + lane;
+            let dst_fast = tile_dst_fast + local_dst_fast;
+            if dst_fast < dst_fast_extent && src_fast < src_fast_extent {
+                let dst_index = dst_fast + src_fast * dst_fast_extent;
+                dst[dst_index] = shared[local_dst_fast * pitch + row];
+            }
+        }
+        row += block_rows;
     }
 }
 
@@ -76,25 +139,6 @@ pub fn contiguous_to_view_kernel<E: CubePrimitive>(
         let dst_offset =
             strided_view_offset_from_tensor(ABSOLUTE_POS, src, strides, base_offset, rank);
         dst[dst_offset] = src[ABSOLUTE_POS];
-    }
-}
-
-#[cube(launch_unchecked)]
-pub fn transpose_kernel<E: CubePrimitive>(
-    out: &mut Tensor<E>,
-    input: &Tensor<E>,
-    #[comptime] perm: Sequence<usize>,
-) {
-    if ABSOLUTE_POS < out.len() {
-        let rank = perm.len();
-        let out_idx = flat_to_tensor_index(ABSOLUTE_POS, out, rank);
-        let mut input_idx = Array::<usize>::new(rank);
-        #[unroll]
-        for axis in 0..rank {
-            let src_axis = comptime! { *perm.index(axis) };
-            input_idx[src_axis] = out_idx[axis];
-        }
-        out[ABSOLUTE_POS] = input[multi_to_tensor_index(&input_idx, input, rank)];
     }
 }
 

--- a/crates/tenferro-gpu/src/kernels/structural.rs
+++ b/crates/tenferro-gpu/src/kernels/structural.rs
@@ -80,7 +80,6 @@ pub fn tiled_transpose_kernel<E: CubePrimitive>(
     dst: &mut Array<E>,
     src: &Array<E>,
     src_offset: usize,
-    #[comptime] batch_stride: usize,
     #[comptime] dst_fast_extent: usize,
     #[comptime] src_fast_extent: usize,
     #[comptime] tile: usize,
@@ -94,7 +93,6 @@ pub fn tiled_transpose_kernel<E: CubePrimitive>(
     let unit_y = UNIT_POS_Y as usize;
     let tile_src_fast = CUBE_POS_X as usize * tile;
     let tile_dst_fast = CUBE_POS_Y as usize * tile;
-    let batch_base = CUBE_POS_Z as usize * batch_stride;
 
     let mut row = unit_y;
     while row < tile {
@@ -104,7 +102,7 @@ pub fn tiled_transpose_kernel<E: CubePrimitive>(
             let local_src_fast = unit_x * vector_width + lane;
             let src_fast = tile_src_fast + local_src_fast;
             if dst_fast < dst_fast_extent && src_fast < src_fast_extent {
-                let src_index = src_offset + batch_base + dst_fast * src_fast_extent + src_fast;
+                let src_index = src_offset + dst_fast * src_fast_extent + src_fast;
                 shared[row * pitch + local_src_fast] = src[src_index];
             }
         }
@@ -121,7 +119,7 @@ pub fn tiled_transpose_kernel<E: CubePrimitive>(
             let local_dst_fast = unit_x * vector_width + lane;
             let dst_fast = tile_dst_fast + local_dst_fast;
             if dst_fast < dst_fast_extent && src_fast < src_fast_extent {
-                let dst_index = batch_base + dst_fast + src_fast * dst_fast_extent;
+                let dst_index = dst_fast + src_fast * dst_fast_extent;
                 dst[dst_index] = shared[local_dst_fast * pitch + row];
             }
         }

--- a/crates/tenferro-gpu/src/lib.rs
+++ b/crates/tenferro-gpu/src/lib.rs
@@ -29,7 +29,7 @@ use std::any::Any;
 
 #[cfg(feature = "cuda")]
 mod cubecl;
-#[cfg(feature = "cuda")]
+#[cfg(any(feature = "cuda", feature = "webgpu"))]
 mod kernels;
 #[cfg(feature = "webgpu")]
 mod webgpu;

--- a/crates/tenferro-gpu/src/lib.rs
+++ b/crates/tenferro-gpu/src/lib.rs
@@ -31,6 +31,8 @@ use std::any::Any;
 mod cubecl;
 #[cfg(any(feature = "cuda", feature = "webgpu"))]
 mod kernels;
+#[cfg(any(feature = "cuda", feature = "webgpu"))]
+mod native_permutation;
 #[cfg(feature = "webgpu")]
 mod webgpu;
 

--- a/crates/tenferro-gpu/src/native_permutation.rs
+++ b/crates/tenferro-gpu/src/native_permutation.rs
@@ -57,6 +57,24 @@ impl NativeTransposeTile {
             vector_width,
         }
     }
+
+    pub(crate) fn dispatch_grid(
+        self,
+        op: &'static str,
+        dims: &[usize],
+        max_dimension: u32,
+    ) -> crate::Result<Option<(u32, u32)>> {
+        let x = u32::try_from(dims[1].div_ceil(self.tile as usize)).map_err(|_| {
+            crate::Error::invalid_argument(op, "shape", "tiled transpose x grid exceeds u32::MAX")
+        })?;
+        let y = u32::try_from(dims[0].div_ceil(self.tile as usize)).map_err(|_| {
+            crate::Error::invalid_argument(op, "shape", "tiled transpose y grid exceeds u32::MAX")
+        })?;
+        if x > max_dimension || y > max_dimension {
+            return Ok(None);
+        }
+        Ok(Some((x.max(1), y.max(1))))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -346,6 +364,19 @@ mod tests {
         );
         assert_eq!(NativeTransposeTile::parse(OP, "generic").unwrap(), None);
         assert!(NativeTransposeTile::parse(OP, "64x1-p0-v8").is_err());
+    }
+
+    #[test]
+    fn tile_grid_falls_back_when_a_dispatch_dimension_exceeds_the_runtime_limit() {
+        let tile = NativeTransposeTile::new(16, 8, 1, 1);
+        assert_eq!(
+            tile.dispatch_grid(OP, &[1024, 2048], 65_535).unwrap(),
+            Some((128, 64))
+        );
+        assert_eq!(
+            tile.dispatch_grid(OP, &[4_782_976, 16], 65_535).unwrap(),
+            None
+        );
     }
 
     #[test]

--- a/crates/tenferro-gpu/src/native_permutation.rs
+++ b/crates/tenferro-gpu/src/native_permutation.rs
@@ -63,17 +63,20 @@ impl NativeTransposeTile {
         op: &'static str,
         dims: &[usize],
         max_dimension: u32,
-    ) -> crate::Result<Option<(u32, u32)>> {
+    ) -> crate::Result<Option<(u32, u32, u32)>> {
         let x = u32::try_from(dims[1].div_ceil(self.tile as usize)).map_err(|_| {
             crate::Error::invalid_argument(op, "shape", "tiled transpose x grid exceeds u32::MAX")
         })?;
         let y = u32::try_from(dims[0].div_ceil(self.tile as usize)).map_err(|_| {
             crate::Error::invalid_argument(op, "shape", "tiled transpose y grid exceeds u32::MAX")
         })?;
-        if x > max_dimension || y > max_dimension {
+        let z = u32::try_from(dims.get(2).copied().unwrap_or(1)).map_err(|_| {
+            crate::Error::invalid_argument(op, "shape", "tiled transpose z grid exceeds u32::MAX")
+        })?;
+        if x > max_dimension || y > max_dimension || z > max_dimension {
             return Ok(None);
         }
-        Ok(Some((x.max(1), y.max(1))))
+        Ok(Some((x.max(1), y.max(1), z.max(1))))
     }
 }
 
@@ -213,6 +216,20 @@ impl NativePermutationPlan {
             allocations_overlap,
         )
     }
+
+    pub(crate) fn tiled_matrix_len(&self, op: &'static str) -> crate::Result<usize> {
+        self.dims
+            .first()
+            .zip(self.dims.get(1))
+            .and_then(|(&rows, &columns)| rows.checked_mul(columns))
+            .ok_or_else(|| {
+                crate::Error::invalid_argument(
+                    op,
+                    "shape",
+                    "tiled transpose matrix extent overflows usize",
+                )
+            })
+    }
 }
 
 fn compact_col_major_strides(op: &'static str, dims: &[usize]) -> crate::Result<Vec<isize>> {
@@ -259,7 +276,7 @@ fn classify(
 }
 
 fn tiled_transpose_eligible(dims: &[usize], src_strides: &[isize], dst_strides: &[isize]) -> bool {
-    if dims.len() != 2 || dims.contains(&0) {
+    if !(dims.len() == 2 || dims.len() == 3) || dims.contains(&0) {
         return false;
     }
     let Some(src_axis) = src_strides.iter().position(|&stride| stride == 1) else {
@@ -268,13 +285,24 @@ fn tiled_transpose_eligible(dims: &[usize], src_strides: &[isize], dst_strides: 
     let Some(dst_axis) = dst_strides.iter().position(|&stride| stride == 1) else {
         return false;
     };
-    if src_axis == dst_axis {
+    if src_axis >= 2 || dst_axis >= 2 || src_axis == dst_axis {
         return false;
     }
     let src_other = 1 - src_axis;
     let dst_other = 1 - dst_axis;
-    isize::try_from(dims[src_axis]).is_ok_and(|extent| src_strides[src_other] == extent)
-        && isize::try_from(dims[dst_axis]).is_ok_and(|extent| dst_strides[dst_other] == extent)
+    let matrix_is_transpose = isize::try_from(dims[src_axis])
+        .is_ok_and(|extent| src_strides[src_other] == extent)
+        && isize::try_from(dims[dst_axis]).is_ok_and(|extent| dst_strides[dst_other] == extent);
+    if !matrix_is_transpose || dims.len() == 2 {
+        return matrix_is_transpose;
+    }
+
+    dims[0]
+        .checked_mul(dims[1])
+        .and_then(|matrix_len| isize::try_from(matrix_len).ok())
+        .is_some_and(|matrix_stride| {
+            src_strides[2] == matrix_stride && dst_strides[2] == matrix_stride
+        })
 }
 
 #[cfg(test)]
@@ -328,6 +356,35 @@ mod tests {
     }
 
     #[test]
+    fn batched_compact_transpose_is_tiled_eligible() {
+        let plan = NativePermutationPlan::for_transpose(
+            OP,
+            &[256, 256, 240],
+            &[1, 256, 65_536],
+            &[1, 0, 2],
+            0,
+            15_728_640,
+            15_728_640,
+            false,
+        )
+        .unwrap();
+        assert_eq!(plan.kind, NativePermutationKind::TiledTranspose);
+
+        let tile = NativeTransposeTile::new(16, 8, 1, 1);
+        assert_eq!(
+            tile.dispatch_grid(OP, &plan.dims, 65_535).unwrap(),
+            Some((16, 16, 240))
+        );
+        assert_eq!(tile.dispatch_grid(OP, &plan.dims, 128).unwrap(), None);
+    }
+
+    #[test]
+    fn batched_noncompact_transpose_remains_generic() {
+        let plan = plan(&[3, 2, 4], &[2, 1, 7], &[1, 3, 6]);
+        assert_eq!(plan.kind, NativePermutationKind::GenericStrided);
+    }
+
+    #[test]
     fn transpose_and_equivalent_view_share_one_plan() {
         let transpose =
             NativePermutationPlan::for_transpose(OP, &[2, 3], &[1, 2], &[1, 0], 0, 6, 6, false)
@@ -371,7 +428,7 @@ mod tests {
         let tile = NativeTransposeTile::new(16, 8, 1, 1);
         assert_eq!(
             tile.dispatch_grid(OP, &[1024, 2048], 65_535).unwrap(),
-            Some((128, 64))
+            Some((128, 64, 1))
         );
         assert_eq!(
             tile.dispatch_grid(OP, &[4_782_976, 16], 65_535).unwrap(),

--- a/crates/tenferro-gpu/src/native_permutation.rs
+++ b/crates/tenferro-gpu/src/native_permutation.rs
@@ -63,20 +63,17 @@ impl NativeTransposeTile {
         op: &'static str,
         dims: &[usize],
         max_dimension: u32,
-    ) -> crate::Result<Option<(u32, u32, u32)>> {
+    ) -> crate::Result<Option<(u32, u32)>> {
         let x = u32::try_from(dims[1].div_ceil(self.tile as usize)).map_err(|_| {
             crate::Error::invalid_argument(op, "shape", "tiled transpose x grid exceeds u32::MAX")
         })?;
         let y = u32::try_from(dims[0].div_ceil(self.tile as usize)).map_err(|_| {
             crate::Error::invalid_argument(op, "shape", "tiled transpose y grid exceeds u32::MAX")
         })?;
-        let z = u32::try_from(dims.get(2).copied().unwrap_or(1)).map_err(|_| {
-            crate::Error::invalid_argument(op, "shape", "tiled transpose z grid exceeds u32::MAX")
-        })?;
-        if x > max_dimension || y > max_dimension || z > max_dimension {
+        if x > max_dimension || y > max_dimension {
             return Ok(None);
         }
-        Ok(Some((x.max(1), y.max(1), z.max(1))))
+        Ok(Some((x.max(1), y.max(1))))
     }
 }
 
@@ -216,20 +213,6 @@ impl NativePermutationPlan {
             allocations_overlap,
         )
     }
-
-    pub(crate) fn tiled_matrix_len(&self, op: &'static str) -> crate::Result<usize> {
-        self.dims
-            .first()
-            .zip(self.dims.get(1))
-            .and_then(|(&rows, &columns)| rows.checked_mul(columns))
-            .ok_or_else(|| {
-                crate::Error::invalid_argument(
-                    op,
-                    "shape",
-                    "tiled transpose matrix extent overflows usize",
-                )
-            })
-    }
 }
 
 fn compact_col_major_strides(op: &'static str, dims: &[usize]) -> crate::Result<Vec<isize>> {
@@ -276,7 +259,7 @@ fn classify(
 }
 
 fn tiled_transpose_eligible(dims: &[usize], src_strides: &[isize], dst_strides: &[isize]) -> bool {
-    if !(dims.len() == 2 || dims.len() == 3) || dims.contains(&0) {
+    if dims.len() != 2 || dims.contains(&0) {
         return false;
     }
     let Some(src_axis) = src_strides.iter().position(|&stride| stride == 1) else {
@@ -285,24 +268,13 @@ fn tiled_transpose_eligible(dims: &[usize], src_strides: &[isize], dst_strides: 
     let Some(dst_axis) = dst_strides.iter().position(|&stride| stride == 1) else {
         return false;
     };
-    if src_axis >= 2 || dst_axis >= 2 || src_axis == dst_axis {
+    if src_axis == dst_axis {
         return false;
     }
     let src_other = 1 - src_axis;
     let dst_other = 1 - dst_axis;
-    let matrix_is_transpose = isize::try_from(dims[src_axis])
-        .is_ok_and(|extent| src_strides[src_other] == extent)
-        && isize::try_from(dims[dst_axis]).is_ok_and(|extent| dst_strides[dst_other] == extent);
-    if !matrix_is_transpose || dims.len() == 2 {
-        return matrix_is_transpose;
-    }
-
-    dims[0]
-        .checked_mul(dims[1])
-        .and_then(|matrix_len| isize::try_from(matrix_len).ok())
-        .is_some_and(|matrix_stride| {
-            src_strides[2] == matrix_stride && dst_strides[2] == matrix_stride
-        })
+    isize::try_from(dims[src_axis]).is_ok_and(|extent| src_strides[src_other] == extent)
+        && isize::try_from(dims[dst_axis]).is_ok_and(|extent| dst_strides[dst_other] == extent)
 }
 
 #[cfg(test)]
@@ -356,35 +328,6 @@ mod tests {
     }
 
     #[test]
-    fn batched_compact_transpose_is_tiled_eligible() {
-        let plan = NativePermutationPlan::for_transpose(
-            OP,
-            &[256, 256, 240],
-            &[1, 256, 65_536],
-            &[1, 0, 2],
-            0,
-            15_728_640,
-            15_728_640,
-            false,
-        )
-        .unwrap();
-        assert_eq!(plan.kind, NativePermutationKind::TiledTranspose);
-
-        let tile = NativeTransposeTile::new(16, 8, 1, 1);
-        assert_eq!(
-            tile.dispatch_grid(OP, &plan.dims, 65_535).unwrap(),
-            Some((16, 16, 240))
-        );
-        assert_eq!(tile.dispatch_grid(OP, &plan.dims, 128).unwrap(), None);
-    }
-
-    #[test]
-    fn batched_noncompact_transpose_remains_generic() {
-        let plan = plan(&[3, 2, 4], &[2, 1, 7], &[1, 3, 6]);
-        assert_eq!(plan.kind, NativePermutationKind::GenericStrided);
-    }
-
-    #[test]
     fn transpose_and_equivalent_view_share_one_plan() {
         let transpose =
             NativePermutationPlan::for_transpose(OP, &[2, 3], &[1, 2], &[1, 0], 0, 6, 6, false)
@@ -428,7 +371,7 @@ mod tests {
         let tile = NativeTransposeTile::new(16, 8, 1, 1);
         assert_eq!(
             tile.dispatch_grid(OP, &[1024, 2048], 65_535).unwrap(),
-            Some((128, 64, 1))
+            Some((128, 64))
         );
         assert_eq!(
             tile.dispatch_grid(OP, &[4_782_976, 16], 65_535).unwrap(),

--- a/crates/tenferro-gpu/src/native_permutation.rs
+++ b/crates/tenferro-gpu/src/native_permutation.rs
@@ -1,0 +1,304 @@
+#![allow(dead_code)]
+
+use strided_perm::plan_bilateral_fusion;
+use tenferro_tensor::validate::{checked_shape_product, validate_permutation_axes};
+use tenferro_tensor::{DynRank, TensorLayout};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum NativePermutationKind {
+    LinearCopy,
+    GenericStrided,
+    TiledTranspose,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct NativePermutationPlan {
+    pub(crate) kind: NativePermutationKind,
+    pub(crate) dims: Vec<usize>,
+    pub(crate) src_strides: Vec<isize>,
+    pub(crate) dst_strides: Vec<isize>,
+    pub(crate) src_offset: isize,
+    pub(crate) len: usize,
+}
+
+impl NativePermutationPlan {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        op: &'static str,
+        dims: &[usize],
+        src_strides: &[isize],
+        dst_strides: &[isize],
+        src_offset: isize,
+        src_allocation_len: usize,
+        dst_allocation_len: usize,
+        allocations_overlap: bool,
+    ) -> crate::Result<Self> {
+        let len = checked_shape_product(op, "shape", dims)?;
+        if allocations_overlap && len != 0 {
+            return Err(crate::Error::invalid_argument(
+                op,
+                "allocations",
+                "source and destination allocations overlap",
+            ));
+        }
+
+        let source = TensorLayout::<DynRank>::from_parts(
+            dims.to_vec().into(),
+            src_strides.to_vec().into(),
+            src_offset,
+            src_allocation_len,
+        )
+        .map_err(|source| crate::Error::validation(op, source))?;
+        let destination = TensorLayout::<DynRank>::from_parts(
+            dims.to_vec().into(),
+            dst_strides.to_vec().into(),
+            0,
+            dst_allocation_len,
+        )
+        .map_err(|source| crate::Error::validation(op, source))?;
+        destination
+            .validate_mutable_no_overlap()
+            .map_err(|source| crate::Error::validation(op, source))?;
+
+        let fusion = plan_bilateral_fusion(source.shape(), source.strides(), destination.strides())
+            .map_err(|source| {
+                crate::Error::invalid_argument(op, "fusion metadata", source.to_string())
+            })?;
+        let kind = classify(&fusion.dims, &fusion.src_strides, &fusion.dst_strides, len);
+
+        Ok(Self {
+            kind,
+            dims: fusion.dims,
+            src_strides: fusion.src_strides,
+            dst_strides: fusion.dst_strides,
+            src_offset,
+            len,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn for_transpose(
+        op: &'static str,
+        input_shape: &[usize],
+        input_strides: &[isize],
+        permutation: &[usize],
+        src_offset: isize,
+        src_allocation_len: usize,
+        dst_allocation_len: usize,
+        allocations_overlap: bool,
+    ) -> crate::Result<Self> {
+        validate_permutation_axes(op, input_shape.len(), permutation)?;
+        if input_shape.len() != input_strides.len() {
+            return Err(crate::Error::rank_mismatch(
+                op,
+                input_shape.len(),
+                input_strides.len(),
+            ));
+        }
+
+        let dims: Vec<_> = permutation.iter().map(|&axis| input_shape[axis]).collect();
+        let src_strides: Vec<_> = permutation
+            .iter()
+            .map(|&axis| input_strides[axis])
+            .collect();
+        let dst_strides = compact_col_major_strides(op, &dims)?;
+        Self::new(
+            op,
+            &dims,
+            &src_strides,
+            &dst_strides,
+            src_offset,
+            src_allocation_len,
+            dst_allocation_len,
+            allocations_overlap,
+        )
+    }
+}
+
+fn compact_col_major_strides(op: &'static str, dims: &[usize]) -> crate::Result<Vec<isize>> {
+    let mut strides = Vec::with_capacity(dims.len());
+    let mut stride = 1isize;
+    for &dim in dims {
+        strides.push(stride);
+        let dim = isize::try_from(dim).map_err(|_| {
+            crate::Error::invalid_argument(
+                op,
+                "shape",
+                format!("dimension {dim} cannot be represented as isize"),
+            )
+        })?;
+        stride = stride.checked_mul(dim).ok_or_else(|| {
+            crate::Error::invalid_argument(
+                op,
+                "shape",
+                format!("column-major stride overflow for shape {dims:?}"),
+            )
+        })?;
+    }
+    Ok(strides)
+}
+
+fn classify(
+    dims: &[usize],
+    src_strides: &[isize],
+    dst_strides: &[isize],
+    len: usize,
+) -> NativePermutationKind {
+    if len == 0
+        || (dims.len() <= 1
+            && src_strides.first().is_none_or(|&stride| stride == 1)
+            && dst_strides.first().is_none_or(|&stride| stride == 1))
+    {
+        return NativePermutationKind::LinearCopy;
+    }
+    if tiled_transpose_eligible(dims, src_strides, dst_strides) {
+        NativePermutationKind::TiledTranspose
+    } else {
+        NativePermutationKind::GenericStrided
+    }
+}
+
+fn tiled_transpose_eligible(dims: &[usize], src_strides: &[isize], dst_strides: &[isize]) -> bool {
+    if dims.len() != 2 || dims.contains(&0) {
+        return false;
+    }
+    let Some(src_axis) = src_strides.iter().position(|&stride| stride == 1) else {
+        return false;
+    };
+    let Some(dst_axis) = dst_strides.iter().position(|&stride| stride == 1) else {
+        return false;
+    };
+    if src_axis == dst_axis {
+        return false;
+    }
+    let src_other = 1 - src_axis;
+    let dst_other = 1 - dst_axis;
+    isize::try_from(dims[src_axis]).is_ok_and(|extent| src_strides[src_other] == extent)
+        && isize::try_from(dims[dst_axis]).is_ok_and(|extent| dst_strides[dst_other] == extent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const OP: &str = "native_permutation_test";
+
+    fn plan(dims: &[usize], src_strides: &[isize], dst_strides: &[isize]) -> NativePermutationPlan {
+        let len: usize = dims.iter().product();
+        let src_len = 1 + dims
+            .iter()
+            .zip(src_strides)
+            .map(|(&dim, &stride)| dim.saturating_sub(1) * stride.unsigned_abs())
+            .sum::<usize>();
+        let dst_len = 1 + dims
+            .iter()
+            .zip(dst_strides)
+            .map(|(&dim, &stride)| dim.saturating_sub(1) * stride.unsigned_abs())
+            .sum::<usize>();
+        NativePermutationPlan::new(
+            OP,
+            dims,
+            src_strides,
+            dst_strides,
+            0,
+            src_len.max(len).max(1),
+            dst_len.max(len).max(1),
+            false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn identity_collapses_to_linear_copy() {
+        let plan = plan(&[2, 3, 4], &[1, 2, 6], &[1, 2, 6]);
+        assert_eq!(plan.kind, NativePermutationKind::LinearCopy);
+        assert_eq!(plan.dims, [24]);
+        assert_eq!(plan.src_strides, [1]);
+        assert_eq!(plan.dst_strides, [1]);
+    }
+
+    #[test]
+    fn compact_two_dimensional_transpose_is_tiled_eligible() {
+        let plan =
+            NativePermutationPlan::for_transpose(OP, &[2, 3], &[1, 2], &[1, 0], 0, 6, 6, false)
+                .unwrap();
+        assert_eq!(plan.kind, NativePermutationKind::TiledTranspose);
+        assert_eq!(plan.dims, [3, 2]);
+        assert_eq!(plan.src_strides, [2, 1]);
+        assert_eq!(plan.dst_strides, [1, 3]);
+    }
+
+    #[test]
+    fn partial_fusion_preserves_affine_metadata() {
+        let plan = plan(&[2, 3, 4], &[1, 2, 100], &[1, 2, 6]);
+        assert_eq!(plan.kind, NativePermutationKind::GenericStrided);
+        assert_eq!(plan.dims, [6, 4]);
+        assert_eq!(plan.src_strides, [1, 100]);
+        assert_eq!(plan.dst_strides, [1, 6]);
+    }
+
+    #[test]
+    fn rank_24_identity_collapses_to_linear_copy() {
+        let mut dims = vec![64];
+        dims.extend([2; 23]);
+        let dst = compact_col_major_strides(OP, &dims).unwrap();
+        let plan = plan(&dims, &dst, &dst);
+        assert_eq!(plan.kind, NativePermutationKind::LinearCopy);
+        assert_eq!(plan.dims.len(), 1);
+    }
+
+    #[test]
+    fn negative_stride_remains_generic_and_preserves_offset() {
+        let plan = NativePermutationPlan::new(OP, &[4], &[-1], &[1], 3, 4, 4, false).unwrap();
+        assert_eq!(plan.kind, NativePermutationKind::GenericStrided);
+        assert_eq!(plan.src_offset, 3);
+    }
+
+    #[test]
+    fn zero_sized_plan_is_linear_without_allocations() {
+        let plan =
+            NativePermutationPlan::new(OP, &[0, 3], &[1, 0], &[1, 0], 0, 0, 0, true).unwrap();
+        assert_eq!(plan.kind, NativePermutationKind::LinearCopy);
+        assert_eq!(plan.len, 0);
+    }
+
+    #[test]
+    fn invalid_permutation_and_metadata_lengths_are_rejected() {
+        let error =
+            NativePermutationPlan::for_transpose(OP, &[2, 3], &[1, 2], &[0, 0], 0, 6, 6, false)
+                .unwrap_err();
+        assert!(matches!(error, crate::Error::Validation { .. }));
+
+        let error =
+            NativePermutationPlan::new(OP, &[2, 3], &[1], &[1, 2], 0, 6, 6, false).unwrap_err();
+        assert!(matches!(error, crate::Error::Validation { .. }));
+    }
+
+    #[test]
+    fn product_overflow_and_source_range_violation_are_rejected() {
+        let error = NativePermutationPlan::new(
+            OP,
+            &[usize::MAX, 2],
+            &[1, 1],
+            &[1, 1],
+            0,
+            usize::MAX,
+            usize::MAX,
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(error, crate::Error::Validation { .. }));
+
+        let error = NativePermutationPlan::new(OP, &[4], &[2], &[1], 0, 4, 4, false).unwrap_err();
+        assert!(matches!(error, crate::Error::Validation { .. }));
+    }
+
+    #[test]
+    fn destination_and_allocation_overlap_are_rejected() {
+        let error =
+            NativePermutationPlan::new(OP, &[2, 2], &[1, 2], &[1, 1], 0, 4, 4, false).unwrap_err();
+        assert!(matches!(error, crate::Error::Validation { .. }));
+
+        let error = NativePermutationPlan::new(OP, &[4], &[1], &[1], 0, 4, 4, true).unwrap_err();
+        assert!(matches!(error, crate::Error::Validation { .. }));
+    }
+}

--- a/crates/tenferro-gpu/src/native_permutation.rs
+++ b/crates/tenferro-gpu/src/native_permutation.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use strided_perm::plan_bilateral_fusion;
 use tenferro_tensor::validate::{checked_shape_product, validate_permutation_axes};
 use tenferro_tensor::{DynRank, TensorLayout};
@@ -9,6 +7,56 @@ pub(crate) enum NativePermutationKind {
     LinearCopy,
     GenericStrided,
     TiledTranspose,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct NativeTransposeTile {
+    pub(crate) tile: u32,
+    pub(crate) block_rows: u32,
+    pub(crate) padding: u32,
+    pub(crate) vector_width: u32,
+}
+
+impl NativeTransposeTile {
+    const DEFAULT_NAME: &'static str = "16x8-p1-v1";
+
+    pub(crate) fn selected(op: &'static str) -> crate::Result<Option<Self>> {
+        let value = std::env::var("TENFERRO_NATIVE_TRANSPOSE_TILE")
+            .unwrap_or_else(|_| Self::DEFAULT_NAME.to_owned());
+        Self::parse(op, &value)
+    }
+
+    fn parse(op: &'static str, value: &str) -> crate::Result<Option<Self>> {
+        let config = match value {
+            "generic" => return Ok(None),
+            "8x8-p1-v1" => Self::new(8, 8, 1, 1),
+            "16x8-p1-v1" => Self::new(16, 8, 1, 1),
+            "16x8-p1-v2" => Self::new(16, 8, 1, 2),
+            "32x8-p1-v1" => Self::new(32, 8, 1, 1),
+            "32x8-p1-v2" => Self::new(32, 8, 1, 2),
+            "32x8-p1-v4" => Self::new(32, 8, 1, 4),
+            _ => {
+                return Err(crate::Error::invalid_argument(
+                    op,
+                    "TENFERRO_NATIVE_TRANSPOSE_TILE",
+                    format!(
+                        "unknown tile `{value}`; expected generic, 8x8-p1-v1, \
+                         16x8-p1-v1, 16x8-p1-v2, 32x8-p1-v1, 32x8-p1-v2, or 32x8-p1-v4"
+                    ),
+                ));
+            }
+        };
+        Ok(Some(config))
+    }
+
+    const fn new(tile: u32, block_rows: u32, padding: u32, vector_width: u32) -> Self {
+        Self {
+            tile,
+            block_rows,
+            padding,
+            vector_width,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -34,6 +82,17 @@ impl NativePermutationPlan {
         allocations_overlap: bool,
     ) -> crate::Result<Self> {
         let len = checked_shape_product(op, "shape", dims)?;
+        let expected_dst_strides = compact_col_major_strides(op, dims)?;
+        if dst_strides != expected_dst_strides {
+            return Err(crate::Error::invalid_argument(
+                op,
+                "destination strides",
+                format!(
+                    "native permutation destination must be compact column-major: \
+                     expected {expected_dst_strides:?}, got {dst_strides:?}"
+                ),
+            ));
+        }
         if allocations_overlap && len != 0 {
             return Err(crate::Error::invalid_argument(
                 op,
@@ -106,6 +165,29 @@ impl NativePermutationPlan {
             op,
             &dims,
             &src_strides,
+            &dst_strides,
+            src_offset,
+            src_allocation_len,
+            dst_allocation_len,
+            allocations_overlap,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn for_contiguous_output(
+        op: &'static str,
+        dims: &[usize],
+        src_strides: &[isize],
+        src_offset: isize,
+        src_allocation_len: usize,
+        dst_allocation_len: usize,
+        allocations_overlap: bool,
+    ) -> crate::Result<Self> {
+        let dst_strides = compact_col_major_strides(op, dims)?;
+        Self::new(
+            op,
+            dims,
+            src_strides,
             &dst_strides,
             src_offset,
             src_allocation_len,
@@ -225,6 +307,45 @@ mod tests {
         assert_eq!(plan.dims, [3, 2]);
         assert_eq!(plan.src_strides, [2, 1]);
         assert_eq!(plan.dst_strides, [1, 3]);
+    }
+
+    #[test]
+    fn transpose_and_equivalent_view_share_one_plan() {
+        let transpose =
+            NativePermutationPlan::for_transpose(OP, &[2, 3], &[1, 2], &[1, 0], 0, 6, 6, false)
+                .unwrap();
+        let view =
+            NativePermutationPlan::for_contiguous_output(OP, &[3, 2], &[2, 1], 0, 6, 6, false)
+                .unwrap();
+        assert_eq!(transpose, view);
+    }
+
+    #[test]
+    fn three_dimensional_swap_preserves_output_axis_order() {
+        let plan = NativePermutationPlan::for_transpose(
+            OP,
+            &[256, 256, 240],
+            &[1, 256, 65_536],
+            &[1, 0, 2],
+            0,
+            15_728_640,
+            15_728_640,
+            false,
+        )
+        .unwrap();
+        assert_eq!(plan.dims, [256, 256, 240]);
+        assert_eq!(plan.src_strides, [256, 1, 65_536]);
+        assert_eq!(plan.dst_strides, [1, 256, 65_536]);
+    }
+
+    #[test]
+    fn tile_selection_is_bounded_and_can_force_generic_fallback() {
+        assert_eq!(
+            NativeTransposeTile::parse(OP, "32x8-p1-v4").unwrap(),
+            Some(NativeTransposeTile::new(32, 8, 1, 4))
+        );
+        assert_eq!(NativeTransposeTile::parse(OP, "generic").unwrap(), None);
+        assert!(NativeTransposeTile::parse(OP, "64x1-p0-v8").is_err());
     }
 
     #[test]

--- a/crates/tenferro-gpu/src/webgpu/mod.rs
+++ b/crates/tenferro-gpu/src/webgpu/mod.rs
@@ -11,7 +11,8 @@ use crate::{
     GatherConfig, GpuBackendKind, HostAccessError, HostReadGuard, HostWriteGuard, MemoryKind,
     PadConfig, Placement, ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend,
     TensorBuffer, TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
-    TensorRead, TensorReduction, TensorStructural, TensorWrite, TypedTensor,
+    TensorRead, TensorReduction, TensorStructural, TensorViewCanonicalization, TensorWrite,
+    TypedTensor, TypedTensorView, TypedTensorViewMut,
 };
 
 const DEFAULT_CUBE_DIM_X: u32 = 256;
@@ -24,6 +25,7 @@ mod kernels;
 mod memory;
 mod runtime;
 mod runtime_adapter;
+mod structural;
 
 pub use apple::{AppleContext, AppleTransferStats};
 pub(crate) use error::{unsupported_dtype, unsupported_operation};
@@ -761,16 +763,16 @@ impl TensorAnalytic for WebGpuBackend {
 }
 
 impl TensorStructural for WebGpuBackend {
-    fn to_contiguous_read(&mut self, _input: TensorRead<'_>) -> crate::Result<Tensor> {
-        unsupported!("WebGpuBackend::to_contiguous_read")
+    fn to_contiguous_read(&mut self, input: TensorRead<'_>) -> crate::Result<Tensor> {
+        structural::to_contiguous_read(self, input)
     }
 
     fn copy_read_into(&mut self, _src: TensorRead<'_>, _dst: TensorWrite<'_>) -> crate::Result<()> {
         unsupported!("WebGpuBackend::copy_read_into")
     }
 
-    fn transpose(&mut self, _input: &Tensor, _perm: &[usize]) -> crate::Result<Tensor> {
-        unsupported!("webgpu_transpose")
+    fn transpose(&mut self, input: &Tensor, perm: &[usize]) -> crate::Result<Tensor> {
+        structural::transpose(self, input, perm)
     }
 
     fn reshape(&mut self, _input: &Tensor, _shape: &[usize]) -> crate::Result<Tensor> {
@@ -814,6 +816,23 @@ impl TensorStructural for WebGpuBackend {
 
     fn triu(&mut self, _input: &Tensor, _k: i64) -> crate::Result<Tensor> {
         unsupported!("webgpu_triu")
+    }
+}
+
+impl TensorViewCanonicalization<f32, tenferro_tensor::DynRank> for WebGpuBackend {
+    fn to_contiguous(
+        &mut self,
+        view: &TypedTensorView<'_, f32>,
+    ) -> crate::Result<TypedTensor<f32>> {
+        structural::to_contiguous_f32(self, view)
+    }
+
+    fn copy_into(
+        &mut self,
+        _src: &TypedTensorView<'_, f32>,
+        _dst: &mut TypedTensorViewMut<'_, f32>,
+    ) -> crate::Result<()> {
+        unsupported!("WebGpuBackend::copy_into")
     }
 }
 

--- a/crates/tenferro-gpu/src/webgpu/runtime.rs
+++ b/crates/tenferro-gpu/src/webgpu/runtime.rs
@@ -157,12 +157,9 @@ impl WebGpuRuntime {
     ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::BackendSource`] when queue flush or sync fails.
+    /// Returns [`crate::Error::BackendSource`] when CubeCL queue synchronization fails.
     pub fn synchronize(&self) -> crate::Result<()> {
         const OP: &str = "webgpu_runtime_synchronize";
-        self.client
-            .flush()
-            .map_err(|err| crate::Error::backend_source(OP, err))?;
         future::block_on(self.client.sync()).map_err(|err| crate::Error::backend_source(OP, err))
     }
 }

--- a/crates/tenferro-gpu/src/webgpu/structural.rs
+++ b/crates/tenferro-gpu/src/webgpu/structural.rs
@@ -72,20 +72,6 @@ fn strides_i64(strides: &[isize], op: &'static str) -> crate::Result<Vec<i64>> {
         .collect()
 }
 
-fn tiled_cube_count(
-    op: &'static str,
-    plan: &NativePermutationPlan,
-    tile: usize,
-) -> crate::Result<CubeCount> {
-    let x = u32::try_from(plan.dims[1].div_ceil(tile)).map_err(|_| {
-        crate::Error::invalid_argument(op, "shape", "tiled transpose x grid exceeds u32::MAX")
-    })?;
-    let y = u32::try_from(plan.dims[0].div_ceil(tile)).map_err(|_| {
-        crate::Error::invalid_argument(op, "shape", "tiled transpose y grid exceeds u32::MAX")
-    })?;
-    Ok(CubeCount::Static(x.max(1), y.max(1), 1))
-}
-
 fn launch_materialization<T>(
     backend: &WebGpuBackend,
     output: &TypedTensor<T>,
@@ -122,7 +108,6 @@ where
     }
     if plan.kind == NativePermutationKind::TiledTranspose {
         if let Some(config) = NativeTransposeTile::selected(op)? {
-            let tile = config.tile as usize;
             let block_rows = config.block_rows as usize;
             let padding = config.padding as usize;
             let vector_width = config.vector_width as usize;
@@ -133,30 +118,33 @@ where
                     "tiled transpose requires a non-negative source offset",
                 )
             })?;
-            let cube_dim = CubeDim::new_2d(config.tile / config.vector_width, config.block_rows);
-            unsafe {
-                // SAFETY: The tiled classification proves a compact 2D
-                // transpose. Bounds guards cover edge tiles and every unit
-                // reaches the shared-memory barrier.
-                crate::kernels::structural::tiled_transpose_kernel::launch_unchecked::<
-                    T,
-                    WgpuRuntime,
-                >(
-                    backend.runtime().client(),
-                    tiled_cube_count(op, plan, tile)?,
-                    cube_dim,
-                    output_arg,
-                    input,
-                    src_offset,
-                    plan.dims[0],
-                    plan.dims[1],
-                    tile,
-                    block_rows,
-                    padding,
-                    vector_width,
-                );
+            if let Some((cubes_x, cubes_y)) = config.dispatch_grid(op, &plan.dims, 65_535)? {
+                let cube_dim =
+                    CubeDim::new_2d(config.tile / config.vector_width, config.block_rows);
+                unsafe {
+                    // SAFETY: The tiled classification proves a compact 2D
+                    // transpose. Bounds guards cover edge tiles and every unit
+                    // reaches the shared-memory barrier.
+                    crate::kernels::structural::tiled_transpose_kernel::launch_unchecked::<
+                        T,
+                        WgpuRuntime,
+                    >(
+                        backend.runtime().client(),
+                        CubeCount::Static(cubes_x, cubes_y, 1),
+                        cube_dim,
+                        output_arg,
+                        input,
+                        src_offset,
+                        plan.dims[0],
+                        plan.dims[1],
+                        config.tile as usize,
+                        block_rows,
+                        padding,
+                        vector_width,
+                    );
+                }
+                return Ok(());
             }
-            return Ok(());
         }
     }
     let src_strides = strides_i64(&plan.src_strides, op)?;

--- a/crates/tenferro-gpu/src/webgpu/structural.rs
+++ b/crates/tenferro-gpu/src/webgpu/structural.rs
@@ -118,7 +118,10 @@ where
                     "tiled transpose requires a non-negative source offset",
                 )
             })?;
-            if let Some((cubes_x, cubes_y)) = config.dispatch_grid(op, &plan.dims, 65_535)? {
+            if let Some((cubes_x, cubes_y, cubes_z)) =
+                config.dispatch_grid(op, &plan.dims, 65_535)?
+            {
+                let batch_stride = plan.tiled_matrix_len(op)?;
                 let cube_dim =
                     CubeDim::new_2d(config.tile / config.vector_width, config.block_rows);
                 unsafe {
@@ -130,11 +133,12 @@ where
                         WgpuRuntime,
                     >(
                         backend.runtime().client(),
-                        CubeCount::Static(cubes_x, cubes_y, 1),
+                        CubeCount::Static(cubes_x, cubes_y, cubes_z),
                         cube_dim,
                         output_arg,
                         input,
                         src_offset,
+                        batch_stride,
                         plan.dims[0],
                         plan.dims[1],
                         config.tile as usize,

--- a/crates/tenferro-gpu/src/webgpu/structural.rs
+++ b/crates/tenferro-gpu/src/webgpu/structural.rs
@@ -1,0 +1,219 @@
+use cubecl::prelude::{ArrayArg, CubeElement, CubePrimitive};
+use cubecl_wgpu::WgpuRuntime;
+use tenferro_tensor::validate::validate_permutation_axes;
+use tenferro_tensor::{Tensor, TensorRank, TensorRead, TensorView, TypedTensor, TypedTensorView};
+
+use super::{
+    alloc_output, comptime_sequence, cube_count_for_len, cube_dim_1d,
+    ensure_placement_resident_on_runtime, ensure_resident_on_runtime,
+    typed_tensor_binding_with_layout, unsupported_dtype, WebGpuBackend, WebGpuBuffer,
+};
+
+const TRANSPOSE_OP: &str = "webgpu_transpose";
+const MATERIALIZE_OP: &str = "WebGpuBackend::to_contiguous_read";
+
+fn dense_strides(shape: &[usize], op: &'static str) -> crate::Result<Vec<usize>> {
+    let mut strides = Vec::with_capacity(shape.len());
+    let mut stride = 1usize;
+    for &dim in shape {
+        strides.push(stride);
+        stride = stride.checked_mul(dim).ok_or_else(|| {
+            crate::Error::invalid_argument(
+                op,
+                "shape",
+                format!("column-major stride overflow for shape {shape:?}"),
+            )
+        })?;
+    }
+    Ok(strides)
+}
+
+fn view_array_arg<T, R>(
+    backend: &WebGpuBackend,
+    view: &TypedTensorView<'_, T, R>,
+    op: &'static str,
+) -> crate::Result<ArrayArg<WgpuRuntime>>
+where
+    T: CubeElement + Clone + Send + Sync + 'static,
+    R: TensorRank,
+{
+    ensure_placement_resident_on_runtime(backend.runtime(), view.placement(), op)?;
+    let buffer = view.backend_buffer().ok_or_else(|| {
+        crate::Error::runtime_state(
+            op,
+            "expected WebGPU view, got host view; upload before materializing",
+        )
+    })?;
+    let buffer = buffer
+        .as_any()
+        .downcast_ref::<WebGpuBuffer<T>>()
+        .ok_or_else(|| {
+            crate::Error::runtime_state(
+                op,
+                format!(
+                    "expected WebGPU backend buffer, got `{}` backend buffer",
+                    buffer.backend_family()
+                ),
+            )
+        })?;
+    if let Some(expected) = backend.runtime().allocation_domain() {
+        match buffer.domain.as_ref().map(|domain| domain.id) {
+            Some(actual) if actual == expected.id => {}
+            Some(actual) => {
+                return Err(crate::Error::host_access(
+                    op,
+                    crate::HostAccessError::ForeignDomain {
+                        expected: expected.id,
+                        actual,
+                    },
+                ));
+            }
+            None => {
+                return Err(crate::Error::runtime_state(
+                    op,
+                    "Apple runtime requires a managed allocation from its domain",
+                ));
+            }
+        }
+    }
+
+    // SAFETY: TypedTensorView construction proves every reachable signed
+    // offset is inside the backing allocation. The kernel receives that same
+    // validated layout metadata and indexes only logical output elements.
+    Ok(unsafe { ArrayArg::from_raw_parts(buffer.handle().clone(), buffer.element_len()) })
+}
+
+fn transpose_typed<T>(
+    backend: &WebGpuBackend,
+    input: &TypedTensor<T>,
+    perm: &[usize],
+) -> crate::Result<TypedTensor<T>>
+where
+    T: CubeElement + CubePrimitive + Clone + Send + Sync + 'static,
+{
+    validate_permutation_axes(TRANSPOSE_OP, input.shape().len(), perm)?;
+    ensure_resident_on_runtime(backend.runtime(), input, TRANSPOSE_OP)?;
+    let output_shape: Vec<usize> = perm.iter().map(|&axis| input.shape()[axis]).collect();
+    let output = alloc_output::<T>(backend.runtime(), &output_shape, TRANSPOSE_OP)?;
+    if output.n_elements() == 0 {
+        return Ok(output);
+    }
+    let input_strides = dense_strides(input.shape(), TRANSPOSE_OP)?;
+    let output_strides = dense_strides(&output_shape, TRANSPOSE_OP)?;
+    let input_arg =
+        typed_tensor_binding_with_layout(input, input.shape(), &input_strides, TRANSPOSE_OP)?;
+    let output_arg =
+        typed_tensor_binding_with_layout(&output, &output_shape, &output_strides, TRANSPOSE_OP)?;
+
+    unsafe {
+        // SAFETY: The permutation is validated and both bindings cover their
+        // complete compact allocations. The unchanged kernel guards every
+        // output position and maps it through the full permutation.
+        crate::kernels::structural::transpose_kernel::launch_unchecked::<T, WgpuRuntime>(
+            backend.runtime().client(),
+            cube_count_for_len(output.n_elements())?,
+            cube_dim_1d(),
+            output_arg.into_tensor_arg(),
+            input_arg.into_tensor_arg(),
+            comptime_sequence(perm),
+        );
+    }
+    Ok(output)
+}
+
+fn materialize_typed<T, R>(
+    backend: &WebGpuBackend,
+    view: &TypedTensorView<'_, T, R>,
+) -> crate::Result<TypedTensor<T>>
+where
+    T: CubeElement + CubePrimitive + Clone + Send + Sync + 'static,
+    R: TensorRank,
+{
+    let output = alloc_output::<T>(backend.runtime(), view.shape(), MATERIALIZE_OP)?;
+    if output.n_elements() == 0 {
+        return Ok(output);
+    }
+    let output_strides = dense_strides(view.shape(), MATERIALIZE_OP)?;
+    let output_arg =
+        typed_tensor_binding_with_layout(&output, view.shape(), &output_strides, MATERIALIZE_OP)?;
+    let input_arg = view_array_arg(backend, view, MATERIALIZE_OP)?;
+    let strides = view
+        .strides()
+        .iter()
+        .copied()
+        .map(|stride| {
+            i64::try_from(stride).map_err(|_| {
+                crate::Error::invalid_argument(
+                    MATERIALIZE_OP,
+                    "strides",
+                    format!("view stride {stride} cannot be represented as i64"),
+                )
+            })
+        })
+        .collect::<crate::Result<Vec<_>>>()?;
+    let base_offset = i64::try_from(view.offset()).map_err(|_| {
+        crate::Error::invalid_argument(
+            MATERIALIZE_OP,
+            "offset",
+            format!("view offset {} cannot be represented as i64", view.offset()),
+        )
+    })?;
+
+    unsafe {
+        // SAFETY: The view constructor validated all signed offsets against
+        // the resident backing allocation. The unchanged kernel writes every
+        // compact output element once and reads only those validated offsets.
+        crate::kernels::structural::view_to_contiguous_kernel::launch_unchecked::<T, WgpuRuntime>(
+            backend.runtime().client(),
+            cube_count_for_len(output.n_elements())?,
+            cube_dim_1d(),
+            output_arg.into_tensor_arg(),
+            input_arg,
+            comptime_sequence(&strides),
+            base_offset,
+            view.shape().len(),
+        );
+    }
+    Ok(output)
+}
+
+pub(super) fn to_contiguous_f32(
+    backend: &WebGpuBackend,
+    view: &TypedTensorView<'_, f32>,
+) -> crate::Result<TypedTensor<f32>> {
+    materialize_typed(backend, view)
+}
+
+pub(super) fn transpose(
+    backend: &WebGpuBackend,
+    input: &Tensor,
+    perm: &[usize],
+) -> crate::Result<Tensor> {
+    match input {
+        Tensor::F32(input) => transpose_typed(backend, input, perm).map(Tensor::F32),
+        Tensor::I32(input) => transpose_typed(backend, input, perm).map(Tensor::I32),
+        // CubeK has a dedicated complex WebGPU representation, but CubeCL's
+        // generic WGSL compiler cannot lower CubePrimitive Complex32.
+        other => Err(unsupported_dtype(TRANSPOSE_OP, other.dtype())),
+    }
+}
+
+pub(super) fn to_contiguous_read(
+    backend: &WebGpuBackend,
+    input: TensorRead<'_>,
+) -> crate::Result<Tensor> {
+    macro_rules! materialize {
+        ($variant:ident, $view:expr) => {
+            materialize_typed(backend, &$view).map(Tensor::$variant)
+        };
+    }
+
+    match input {
+        TensorRead::Tensor(Tensor::F32(input)) => materialize!(F32, input.as_view()),
+        TensorRead::Tensor(Tensor::I32(input)) => materialize!(I32, input.as_view()),
+        TensorRead::View(TensorView::F32(input)) => materialize!(F32, input),
+        TensorRead::View(TensorView::I32(input)) => materialize!(I32, input),
+        // Reject unsupported WGSL element types before asynchronous codegen.
+        other => Err(unsupported_dtype(MATERIALIZE_OP, other.dtype())),
+    }
+}

--- a/crates/tenferro-gpu/src/webgpu/structural.rs
+++ b/crates/tenferro-gpu/src/webgpu/structural.rs
@@ -1,22 +1,33 @@
-use cubecl::prelude::{ArrayArg, CubeElement, CubePrimitive};
+use cubecl::prelude::{ArrayArg, CubeCount, CubeDim, CubeElement, CubePrimitive};
 use cubecl_wgpu::WgpuRuntime;
 use tenferro_tensor::validate::validate_permutation_axes;
 use tenferro_tensor::{Tensor, TensorRank, TensorRead, TensorView, TypedTensor, TypedTensorView};
 
+use crate::native_permutation::{
+    NativePermutationKind, NativePermutationPlan, NativeTransposeTile,
+};
+
 use super::{
     alloc_output, comptime_sequence, cube_count_for_len, cube_dim_1d,
-    ensure_placement_resident_on_runtime, ensure_resident_on_runtime,
-    typed_tensor_binding_with_layout, unsupported_dtype, WebGpuBackend, WebGpuBuffer,
+    ensure_placement_resident_on_runtime, ensure_resident_on_runtime, unsupported_dtype,
+    WebGpuBackend, WebGpuBuffer,
 };
 
 const TRANSPOSE_OP: &str = "webgpu_transpose";
 const MATERIALIZE_OP: &str = "WebGpuBackend::to_contiguous_read";
 
-fn dense_strides(shape: &[usize], op: &'static str) -> crate::Result<Vec<usize>> {
+fn dense_strides(shape: &[usize], op: &'static str) -> crate::Result<Vec<isize>> {
     let mut strides = Vec::with_capacity(shape.len());
-    let mut stride = 1usize;
+    let mut stride = 1isize;
     for &dim in shape {
         strides.push(stride);
+        let dim = isize::try_from(dim).map_err(|_| {
+            crate::Error::invalid_argument(
+                op,
+                "shape",
+                format!("dimension {dim} cannot be represented as isize"),
+            )
+        })?;
         stride = stride.checked_mul(dim).ok_or_else(|| {
             crate::Error::invalid_argument(
                 op,
@@ -26,6 +37,156 @@ fn dense_strides(shape: &[usize], op: &'static str) -> crate::Result<Vec<usize>>
         })?;
     }
     Ok(strides)
+}
+
+fn view_allocation_len<T, R>(
+    view: &TypedTensorView<'_, T, R>,
+    op: &'static str,
+) -> crate::Result<usize>
+where
+    T: 'static,
+    R: TensorRank,
+{
+    view.backend_buffer()
+        .map(|buffer| buffer.len())
+        .ok_or_else(|| {
+            crate::Error::runtime_state(
+                op,
+                "expected WebGPU view, got host view; upload before materializing",
+            )
+        })
+}
+
+fn strides_i64(strides: &[isize], op: &'static str) -> crate::Result<Vec<i64>> {
+    strides
+        .iter()
+        .map(|&stride| {
+            i64::try_from(stride).map_err(|_| {
+                crate::Error::invalid_argument(
+                    op,
+                    "strides",
+                    format!("stride {stride} cannot be represented as i64"),
+                )
+            })
+        })
+        .collect()
+}
+
+fn tiled_cube_count(
+    op: &'static str,
+    plan: &NativePermutationPlan,
+    tile: usize,
+) -> crate::Result<CubeCount> {
+    let x = u32::try_from(plan.dims[1].div_ceil(tile)).map_err(|_| {
+        crate::Error::invalid_argument(op, "shape", "tiled transpose x grid exceeds u32::MAX")
+    })?;
+    let y = u32::try_from(plan.dims[0].div_ceil(tile)).map_err(|_| {
+        crate::Error::invalid_argument(op, "shape", "tiled transpose y grid exceeds u32::MAX")
+    })?;
+    Ok(CubeCount::Static(x.max(1), y.max(1), 1))
+}
+
+fn launch_materialization<T>(
+    backend: &WebGpuBackend,
+    output: &TypedTensor<T>,
+    input: ArrayArg<WgpuRuntime>,
+    plan: &NativePermutationPlan,
+    op: &'static str,
+) -> crate::Result<()>
+where
+    T: CubeElement + CubePrimitive + Clone + Send + Sync + 'static,
+{
+    if plan.len == 0 {
+        return Ok(());
+    }
+    let output_arg = view_array_arg(backend, &output.as_view(), op)?;
+    if output_arg.size() != plan.len {
+        return Err(crate::Error::runtime_state(
+            op,
+            format!(
+                "native permutation output binding has {} elements, plan requires {}",
+                output_arg.size(),
+                plan.len
+            ),
+        ));
+    }
+    if input.size() < plan.len {
+        return Err(crate::Error::runtime_state(
+            op,
+            format!(
+                "native permutation input binding has {} elements, plan requires at least {}",
+                input.size(),
+                plan.len
+            ),
+        ));
+    }
+    if plan.kind == NativePermutationKind::TiledTranspose {
+        if let Some(config) = NativeTransposeTile::selected(op)? {
+            let tile = config.tile as usize;
+            let block_rows = config.block_rows as usize;
+            let padding = config.padding as usize;
+            let vector_width = config.vector_width as usize;
+            let src_offset = usize::try_from(plan.src_offset).map_err(|_| {
+                crate::Error::invalid_argument(
+                    op,
+                    "offset",
+                    "tiled transpose requires a non-negative source offset",
+                )
+            })?;
+            let cube_dim = CubeDim::new_2d(config.tile / config.vector_width, config.block_rows);
+            unsafe {
+                // SAFETY: The tiled classification proves a compact 2D
+                // transpose. Bounds guards cover edge tiles and every unit
+                // reaches the shared-memory barrier.
+                crate::kernels::structural::tiled_transpose_kernel::launch_unchecked::<
+                    T,
+                    WgpuRuntime,
+                >(
+                    backend.runtime().client(),
+                    tiled_cube_count(op, plan, tile)?,
+                    cube_dim,
+                    output_arg,
+                    input,
+                    src_offset,
+                    plan.dims[0],
+                    plan.dims[1],
+                    tile,
+                    block_rows,
+                    padding,
+                    vector_width,
+                );
+            }
+            return Ok(());
+        }
+    }
+    let src_strides = strides_i64(&plan.src_strides, op)?;
+    let src_offset = i64::try_from(plan.src_offset).map_err(|_| {
+        crate::Error::invalid_argument(
+            op,
+            "offset",
+            format!(
+                "source offset {} cannot be represented as i64",
+                plan.src_offset
+            ),
+        )
+    })?;
+    unsafe {
+        // SAFETY: `NativePermutationPlan` validated source/destination bounds,
+        // destination non-overlap, shape products, and disjoint allocations.
+        crate::kernels::structural::materialize_strided_kernel::launch_unchecked::<T, WgpuRuntime>(
+            backend.runtime().client(),
+            cube_count_for_len(plan.len)?,
+            cube_dim_1d(),
+            output_arg,
+            input,
+            comptime_sequence(&plan.dims),
+            comptime_sequence(&src_strides),
+            src_offset,
+            plan.len,
+            plan.dims.len(),
+        );
+    }
+    Ok(())
 }
 
 fn view_array_arg<T, R>(
@@ -94,30 +255,20 @@ where
     validate_permutation_axes(TRANSPOSE_OP, input.shape().len(), perm)?;
     ensure_resident_on_runtime(backend.runtime(), input, TRANSPOSE_OP)?;
     let output_shape: Vec<usize> = perm.iter().map(|&axis| input.shape()[axis]).collect();
-    let output = alloc_output::<T>(backend.runtime(), &output_shape, TRANSPOSE_OP)?;
-    if output.n_elements() == 0 {
-        return Ok(output);
-    }
     let input_strides = dense_strides(input.shape(), TRANSPOSE_OP)?;
-    let output_strides = dense_strides(&output_shape, TRANSPOSE_OP)?;
-    let input_arg =
-        typed_tensor_binding_with_layout(input, input.shape(), &input_strides, TRANSPOSE_OP)?;
-    let output_arg =
-        typed_tensor_binding_with_layout(&output, &output_shape, &output_strides, TRANSPOSE_OP)?;
-
-    unsafe {
-        // SAFETY: The permutation is validated and both bindings cover their
-        // complete compact allocations. The unchanged kernel guards every
-        // output position and maps it through the full permutation.
-        crate::kernels::structural::transpose_kernel::launch_unchecked::<T, WgpuRuntime>(
-            backend.runtime().client(),
-            cube_count_for_len(output.n_elements())?,
-            cube_dim_1d(),
-            output_arg.into_tensor_arg(),
-            input_arg.into_tensor_arg(),
-            comptime_sequence(perm),
-        );
-    }
+    let plan = NativePermutationPlan::for_transpose(
+        TRANSPOSE_OP,
+        input.shape(),
+        &input_strides,
+        perm,
+        0,
+        input.n_elements(),
+        input.n_elements(),
+        false,
+    )?;
+    let output = alloc_output::<T>(backend.runtime(), &output_shape, TRANSPOSE_OP)?;
+    let input_arg = view_array_arg(backend, &input.as_view(), TRANSPOSE_OP)?;
+    launch_materialization(backend, &output, input_arg, &plan, TRANSPOSE_OP)?;
     Ok(output)
 }
 
@@ -129,51 +280,29 @@ where
     T: CubeElement + CubePrimitive + Clone + Send + Sync + 'static,
     R: TensorRank,
 {
-    let output = alloc_output::<T>(backend.runtime(), view.shape(), MATERIALIZE_OP)?;
-    if output.n_elements() == 0 {
-        return Ok(output);
-    }
-    let output_strides = dense_strides(view.shape(), MATERIALIZE_OP)?;
-    let output_arg =
-        typed_tensor_binding_with_layout(&output, view.shape(), &output_strides, MATERIALIZE_OP)?;
-    let input_arg = view_array_arg(backend, view, MATERIALIZE_OP)?;
-    let strides = view
-        .strides()
+    let len = view
+        .shape()
         .iter()
-        .copied()
-        .map(|stride| {
-            i64::try_from(stride).map_err(|_| {
-                crate::Error::invalid_argument(
-                    MATERIALIZE_OP,
-                    "strides",
-                    format!("view stride {stride} cannot be represented as i64"),
-                )
-            })
-        })
-        .collect::<crate::Result<Vec<_>>>()?;
-    let base_offset = i64::try_from(view.offset()).map_err(|_| {
-        crate::Error::invalid_argument(
-            MATERIALIZE_OP,
-            "offset",
-            format!("view offset {} cannot be represented as i64", view.offset()),
-        )
-    })?;
-
-    unsafe {
-        // SAFETY: The view constructor validated all signed offsets against
-        // the resident backing allocation. The unchanged kernel writes every
-        // compact output element once and reads only those validated offsets.
-        crate::kernels::structural::view_to_contiguous_kernel::launch_unchecked::<T, WgpuRuntime>(
-            backend.runtime().client(),
-            cube_count_for_len(output.n_elements())?,
-            cube_dim_1d(),
-            output_arg.into_tensor_arg(),
-            input_arg,
-            comptime_sequence(&strides),
-            base_offset,
-            view.shape().len(),
-        );
-    }
+        .try_fold(1usize, |len, &dim| len.checked_mul(dim))
+        .ok_or_else(|| {
+            crate::Error::invalid_argument(
+                MATERIALIZE_OP,
+                "shape",
+                format!("shape product overflow for {:?}", view.shape()),
+            )
+        })?;
+    let plan = NativePermutationPlan::for_contiguous_output(
+        MATERIALIZE_OP,
+        view.shape(),
+        view.strides(),
+        view.offset(),
+        view_allocation_len(view, MATERIALIZE_OP)?,
+        len,
+        false,
+    )?;
+    let output = alloc_output::<T>(backend.runtime(), view.shape(), MATERIALIZE_OP)?;
+    let input_arg = view_array_arg(backend, view, MATERIALIZE_OP)?;
+    launch_materialization(backend, &output, input_arg, &plan, MATERIALIZE_OP)?;
     Ok(output)
 }
 

--- a/crates/tenferro-gpu/src/webgpu/structural.rs
+++ b/crates/tenferro-gpu/src/webgpu/structural.rs
@@ -118,10 +118,7 @@ where
                     "tiled transpose requires a non-negative source offset",
                 )
             })?;
-            if let Some((cubes_x, cubes_y, cubes_z)) =
-                config.dispatch_grid(op, &plan.dims, 65_535)?
-            {
-                let batch_stride = plan.tiled_matrix_len(op)?;
+            if let Some((cubes_x, cubes_y)) = config.dispatch_grid(op, &plan.dims, 65_535)? {
                 let cube_dim =
                     CubeDim::new_2d(config.tile / config.vector_width, config.block_rows);
                 unsafe {
@@ -133,12 +130,11 @@ where
                         WgpuRuntime,
                     >(
                         backend.runtime().client(),
-                        CubeCount::Static(cubes_x, cubes_y, cubes_z),
+                        CubeCount::Static(cubes_x, cubes_y, 1),
                         cube_dim,
                         output_arg,
                         input,
                         src_offset,
-                        batch_stride,
                         plan.dims[0],
                         plan.dims[1],
                         config.tile as usize,

--- a/crates/tenferro-gpu/tests/integration.rs
+++ b/crates/tenferro-gpu/tests/integration.rs
@@ -10,3 +10,5 @@ mod public_surface_contract;
 mod webgpu_backend_contract;
 #[path = "integration/webgpu_matmul_runtime.rs"]
 mod webgpu_matmul_runtime;
+#[path = "integration/webgpu_structural_runtime.rs"]
+mod webgpu_structural_runtime;

--- a/crates/tenferro-gpu/tests/integration/public_surface_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/public_surface_contract.rs
@@ -238,15 +238,24 @@ fn webgpu_provider_keeps_runtime_transfer_and_gemm_boundaries_split() {
 #[test]
 fn webgpu_materialization_does_not_inherit_host_defaults() {
     let webgpu_mod = repo_file("crates/tenferro-gpu/src/webgpu/mod.rs");
-    for (method, op) in [
-        ("fn to_contiguous_read", "WebGpuBackend::to_contiguous_read"),
-        ("fn copy_read_into", "WebGpuBackend::copy_read_into"),
-    ] {
-        assert!(
-            webgpu_mod.contains(method) && webgpu_mod.contains(op),
-            "WebGPU must explicitly reject {method} instead of inheriting host defaults"
-        );
-    }
+    let structural = repo_file("crates/tenferro-gpu/src/webgpu/structural.rs");
+    assert!(
+        webgpu_mod.contains("fn to_contiguous_read")
+            && webgpu_mod.contains("structural::to_contiguous_read(self, input)"),
+        "WebGPU materialization must delegate to its device-native structural module"
+    );
+    assert!(
+        structural.contains("ensure_placement_resident_on_runtime")
+            && structural.contains("view_array_arg")
+            && !structural.contains("download_to_host")
+            && !structural.contains("upload_host_tensor"),
+        "WebGPU materialization must validate and consume resident device views without hidden transfer"
+    );
+    assert!(
+        webgpu_mod.contains("fn copy_read_into")
+            && webgpu_mod.contains("WebGpuBackend::copy_read_into"),
+        "unsupported WebGPU copy-into must remain an explicit rejection instead of inheriting host defaults"
+    );
 }
 
 #[test]

--- a/crates/tenferro-gpu/tests/integration/webgpu_backend_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/webgpu_backend_contract.rs
@@ -31,6 +31,24 @@ fn webgpu_transfer_helpers_are_provider_specific() {
 }
 
 #[test]
+fn webgpu_synchronize_uses_one_cubecl_server_round_trip() {
+    let source = include_str!("../../src/webgpu/runtime.rs");
+    let body = source
+        .split_once("pub fn synchronize(&self)")
+        .expect("WebGPU runtime must expose synchronize")
+        .1
+        .split_once("\n    }")
+        .expect("synchronize method must have a body")
+        .0;
+
+    assert!(
+        body.contains("future::block_on(self.client.sync())") && !body.contains(".flush()"),
+        "CubeCL sync already flushes its scheduler and command stream; an explicit client.flush() \
+         adds a redundant blocking server round trip"
+    );
+}
+
+#[test]
 fn webgpu_download_checks_runtime_residency_before_reading_backend_handle() {
     let source = include_str!("../../src/webgpu/memory.rs");
 

--- a/crates/tenferro-gpu/tests/integration/webgpu_backend_contract.rs
+++ b/crates/tenferro-gpu/tests/integration/webgpu_backend_contract.rs
@@ -4,14 +4,17 @@ use tenferro_gpu::{
     download_webgpu_tensor, upload_webgpu_tensor, webgpu_interop, WebGpuBackend, WebGpuRuntime,
 };
 use tenferro_tensor::{
-    DotGeneralConfig, Error, Result, Tensor, TensorBackend, TensorDeviceTransfer, TensorDot,
+    DotGeneralConfig, DynRank, Error, Result, Tensor, TensorBackend, TensorDeviceTransfer,
+    TensorDot, TensorViewCanonicalization,
 };
 
 fn assert_tensor_backend<B: TensorBackend>() {}
+fn assert_f32_view_canonicalization<B: TensorViewCanonicalization<f32, DynRank>>() {}
 
 #[test]
 fn webgpu_backend_implements_tensor_backend_contract() {
     assert_tensor_backend::<WebGpuBackend>();
+    assert_f32_view_canonicalization::<WebGpuBackend>();
 
     let _upload: fn(&mut WebGpuBackend, &Tensor) -> Result<Tensor> =
         <WebGpuBackend as TensorDeviceTransfer>::upload_host_tensor;

--- a/crates/tenferro-gpu/tests/integration/webgpu_structural_runtime.rs
+++ b/crates/tenferro-gpu/tests/integration/webgpu_structural_runtime.rs
@@ -1,0 +1,113 @@
+#![cfg(feature = "webgpu")]
+
+use num_complex::Complex32;
+use tenferro_gpu::{webgpu_available, WebGpuBackend};
+use tenferro_tensor::{
+    Error, ErrorKind, Tensor, TensorDeviceTransfer, TensorRead, TensorStructural, TensorView,
+};
+
+#[test]
+fn webgpu_transpose_f32_stays_on_device_and_matches_column_major_reference() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let host =
+        Tensor::from_vec_col_major(vec![2, 3], vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let input = backend.upload_host_tensor(&host).unwrap();
+
+    let transposed = backend.transpose(&input, &[1, 0]).unwrap();
+
+    assert_eq!(transposed.placement(), input.placement());
+    let actual = backend.download_to_host(&transposed).unwrap();
+    assert_eq!(actual.shape(), &[3, 2]);
+    assert_eq!(
+        actual.as_slice::<f32>().unwrap(),
+        &[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]
+    );
+}
+
+#[test]
+fn webgpu_to_contiguous_f32_materializes_a_noncompact_resident_view() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let host = Tensor::from_vec_col_major(vec![6], vec![1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
+    let input = backend.upload_host_tensor(&host).unwrap();
+    let Tensor::F32(input) = &input else {
+        unreachable!("uploaded f32 tensor must remain f32");
+    };
+    let view = input.backend_region_view(vec![3], vec![2], 0).unwrap();
+
+    let materialized = backend
+        .to_contiguous_read(TensorRead::from_view(TensorView::F32(view)))
+        .unwrap();
+
+    assert_eq!(materialized.placement(), input.placement());
+    let actual = backend.download_to_host(&materialized).unwrap();
+    assert_eq!(actual.shape(), &[3]);
+    assert_eq!(actual.as_slice::<f32>().unwrap(), &[1.0, 3.0, 5.0]);
+}
+
+#[test]
+fn webgpu_transpose_supports_i32_and_rejects_wgsl_unsupported_complex() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let i32_host = Tensor::from_vec_col_major(vec![2, 2], vec![1_i32, 2, 3, 4]).unwrap();
+    let i32_input = backend.upload_host_tensor(&i32_host).unwrap();
+    let i32_output = backend.transpose(&i32_input, &[1, 0]).unwrap();
+    let i32_actual = backend.download_to_host(&i32_output).unwrap();
+    assert_eq!(i32_actual.as_slice::<i32>().unwrap(), &[1, 3, 2, 4]);
+
+    let c32_host = Tensor::from_vec_col_major(
+        vec![2, 2],
+        vec![
+            Complex32::new(1.0, -1.0),
+            Complex32::new(2.0, -2.0),
+            Complex32::new(3.0, -3.0),
+            Complex32::new(4.0, -4.0),
+        ],
+    )
+    .unwrap();
+    let c32_input = backend.upload_host_tensor(&c32_host).unwrap();
+    let error = backend.transpose(&c32_input, &[1, 0]).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::Unsupported);
+}
+
+#[test]
+fn webgpu_transpose_rejects_invalid_permutations_before_launch() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let host = Tensor::from_vec_col_major(vec![2, 2], vec![1.0_f32; 4]).unwrap();
+    let input = backend.upload_host_tensor(&host).unwrap();
+
+    let error = backend.transpose(&input, &[0, 0]).unwrap_err();
+
+    assert!(matches!(error, Error::Validation { .. }));
+}
+
+#[test]
+fn webgpu_structural_kernels_preserve_zero_length_shapes_without_launching() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let host = Tensor::from_vec_col_major(vec![0, 3], Vec::<f32>::new()).unwrap();
+    let input = backend.upload_host_tensor(&host).unwrap();
+
+    let output = backend.transpose(&input, &[1, 0]).unwrap();
+
+    assert_eq!(output.shape(), &[3, 0]);
+    let actual = backend.download_to_host(&output).unwrap();
+    assert!(actual.as_slice::<f32>().unwrap().is_empty());
+}

--- a/crates/tenferro-gpu/tests/integration/webgpu_structural_runtime.rs
+++ b/crates/tenferro-gpu/tests/integration/webgpu_structural_runtime.rs
@@ -29,6 +29,36 @@ fn webgpu_transpose_f32_stays_on_device_and_matches_column_major_reference() {
 }
 
 #[test]
+fn webgpu_batched_partial_tile_transpose_matches_column_major_reference() {
+    if !webgpu_available() {
+        return;
+    }
+
+    let shape = [17usize, 19, 3];
+    let data: Vec<f32> = (0..shape.iter().product())
+        .map(|index| index as f32)
+        .collect();
+    let expected: Vec<f32> = (0..shape[2])
+        .flat_map(|batch| {
+            (0..shape[0]).flat_map(move |input_fast| {
+                (0..shape[1]).map(move |input_slow| {
+                    (input_fast + shape[0] * input_slow + shape[0] * shape[1] * batch) as f32
+                })
+            })
+        })
+        .collect();
+    let host = Tensor::from_vec_col_major(shape.to_vec(), data).unwrap();
+    let mut backend = WebGpuBackend::new_default().unwrap();
+    let input = backend.upload_host_tensor(&host).unwrap();
+
+    let transposed = backend.transpose(&input, &[1, 0, 2]).unwrap();
+
+    let actual = backend.download_to_host(&transposed).unwrap();
+    assert_eq!(actual.shape(), &[19, 17, 3]);
+    assert_eq!(actual.as_slice::<f32>().unwrap(), expected);
+}
+
+#[test]
 fn webgpu_to_contiguous_f32_materializes_a_noncompact_resident_view() {
     if !webgpu_available() {
         return;

--- a/crates/tenferro-gpu/tests/integration/webgpu_structural_runtime.rs
+++ b/crates/tenferro-gpu/tests/integration/webgpu_structural_runtime.rs
@@ -29,36 +29,6 @@ fn webgpu_transpose_f32_stays_on_device_and_matches_column_major_reference() {
 }
 
 #[test]
-fn webgpu_batched_partial_tile_transpose_matches_column_major_reference() {
-    if !webgpu_available() {
-        return;
-    }
-
-    let shape = [17usize, 19, 3];
-    let data: Vec<f32> = (0..shape.iter().product())
-        .map(|index| index as f32)
-        .collect();
-    let expected: Vec<f32> = (0..shape[2])
-        .flat_map(|batch| {
-            (0..shape[0]).flat_map(move |input_fast| {
-                (0..shape[1]).map(move |input_slow| {
-                    (input_fast + shape[0] * input_slow + shape[0] * shape[1] * batch) as f32
-                })
-            })
-        })
-        .collect();
-    let host = Tensor::from_vec_col_major(shape.to_vec(), data).unwrap();
-    let mut backend = WebGpuBackend::new_default().unwrap();
-    let input = backend.upload_host_tensor(&host).unwrap();
-
-    let transposed = backend.transpose(&input, &[1, 0, 2]).unwrap();
-
-    let actual = backend.download_to_host(&transposed).unwrap();
-    assert_eq!(actual.shape(), &[19, 17, 3]);
-    assert_eq!(actual.as_slice::<f32>().unwrap(), expected);
-}
-
-#[test]
 fn webgpu_to_contiguous_f32_materializes_a_noncompact_resident_view() {
     if !webgpu_available() {
         return;

--- a/docs/design/gpu-backend-design.md
+++ b/docs/design/gpu-backend-design.md
@@ -344,6 +344,13 @@ and no implicit global shape state.
   `dot_general` pack kernels pass only axis-role lists and rank as compile-time
   launch attributes; shape and stride values are read from `TensorBinding`
   metadata inside the kernel.
+- Native permutation materialization is the narrow exception: its validated,
+  bilaterally fused affine plan is encoded as compile-time metadata because the
+  raw source/destination arrays do not carry logical layouts. Fusion limits the
+  specialization rank. The logical length is also compile-time metadata to
+  avoid ambiguous raw-Array runtime metadata packing on Metal. Tile size,
+  block rows, padding, and vector width are algorithm configuration and must
+  remain compile-time parameters.
 - Permute-like operations should canonicalize their launch attributes where the
   transformation is mathematically identical. In particular, adjacent axes that
   stay contiguous in column-major layout should be fused before choosing the
@@ -477,6 +484,7 @@ The WebGPU backend currently has narrower coverage:
 | Allocation/transfer | WebGPU allocation, upload, and download for `F64`, `F32`, `I32`, `I64`, `Bool`, `C64`, and `C32` tensors |
 | Real contraction | CubeK/CubeCL-backed `F32` `dot_general` through a BGEMM planner, including batched and same-device packed operand layouts covered by tests |
 | Complex contraction | `C32` `dot_general` and `dot_general_with_conj` through a CubeK-owned complex GEMM API. tenferro normalizes `DotGeneralConfig` into CubeK-compatible batched matmul bindings; CubeK owns temporary real buffers, split/compose kernels, conjugation signs, and future native complex-kernel replacement |
+| Structural permutation | `F32` and `I32` transpose plus same-device compact materialization. CUDA-native and WebGPU routes consume the same validated bilateral-fusion plan; exact compact 2D transposes use a shared-memory tile with compile-time tile/block-row/padding/vector-width configuration |
 | Deferred contraction coverage | `F64`, `C64`, zero-contracting-size matmul, and broader planner stress coverage |
 | Other tensor ops | Explicit unsupported `BackendFailure`; no CPU fallback and no hidden provider transfer |
 

--- a/docs/guides/devices-and-gpu.md
+++ b/docs/guides/devices-and-gpu.md
@@ -345,11 +345,12 @@ rows return explicit errors and do not fall back to CPU.
 | `dot_general`, `dot_general_with_conj` | `F32`, `C32` | CubeK-backed BGEMM planner; `C32` conjugation is handled by the CubeK complex GEMM API. Supports rank-2, batched, and same-device packed operand layouts covered by tests |
 | Binary einsum lowering to `dot_general` | `F32`, `C32` | Eager `F32`/`C32` and traced `F32` paths are covered when inputs are explicitly uploaded to WebGPU |
 | 1D CFFT/IFFT, one-sided RFFT/IRFFT on Apple Metal | `C32` CFFT/IFFT; `F32` RFFT; `C32` IRFFT | CubeK-backed, explicit backend selection, power-of-two length at least 2; see the FFT guide for padding and length constraints |
+| `transpose`, `to_contiguous_read` | `F32`, `I32` | Same-device native CubeCL materialization; transpose and strided-view canonicalization share one validated dimension-fusion plan, and exact compact 2D transpose uses a compile-time-configured shared-memory tile |
 | `dot_general` with zero contracting size | No WebGPU implementation | Returns an error until CubeK behavior is validated |
 | `dot_general` for `F64`, `C64` | No WebGPU implementation | Returns an error; no CPU fallback |
 | Elementwise and analytic ops | No WebGPU implementation | Returns an error |
 | Reductions | No WebGPU implementation | Returns an error |
-| Structural/indexing ops beyond transfer-owned allocation metadata | No WebGPU implementation | Returns an error |
+| Other structural/indexing ops | No WebGPU implementation | Returns an error |
 | Linalg | No WebGPU implementation | Returns an error. The paired CPU backend's rank-2 Cholesky mapping is CPU execution over Apple managed storage, not a WebGPU linalg kernel |
 | ROCm | No supported execution backend | No ROCm quickstart is provided |
 

--- a/docs/superpowers/plans/2026-07-29-batched-tiled-transpose.md
+++ b/docs/superpowers/plans/2026-07-29-batched-tiled-transpose.md
@@ -142,4 +142,3 @@ Update the worklog and benchmark report with the measured result, run
 `git diff --check`, and commit the accepted implementation and evidence. If
 the hypothesis fails, revert the implementation commits and record the
 negative experiment instead.
-

--- a/docs/superpowers/plans/2026-07-29-batched-tiled-transpose.md
+++ b/docs/superpowers/plans/2026-07-29-batched-tiled-transpose.md
@@ -1,0 +1,145 @@
+# Batched Tiled Transpose Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route compact `[1,0,2]`-class permutations through the existing compile-time shared-memory transpose kernel.
+
+**Architecture:** Extend `NativePermutationPlan` with a checked three-dimensional tiled classification and a three-dimensional dispatch grid. Use `CUBE_POS_Z` to offset the unchanged two-dimensional tile algorithm by one compact matrix per batch. Both CUDA and wgpu launch the same CubeCL kernel and fall back to generic materialization when any grid dimension exceeds 65,535.
+
+**Tech Stack:** Rust, CubeCL, wgpu/Metal, CubeCL CUDA, Cargo tests, tenferro-benchmark.
+
+## Global Constraints
+
+- Preserve profile-first ordering and the recorded Metal baseline.
+- Keep tile width, block rows, padding, vector width, batch count, and batch stride as compile-time kernel metadata.
+- Never introduce a host or CPU fallback.
+- Preserve source/destination non-aliasing and bounds validation.
+- Keep CUDA float/complex permutation on cuTENSOR.
+
+---
+
+### Task 1: Classify and Bound Batched Tile Plans
+
+**Files:**
+- Modify: `crates/tenferro-gpu/src/native_permutation.rs`
+
+**Interfaces:**
+- Consumes: `NativePermutationPlan::{dims,src_strides,dst_strides}` and `NativeTransposeTile`.
+- Produces: `NativePermutationKind::TiledTranspose` for compact rank-three batches and `NativeTransposeTile::dispatch_grid(...) -> Result<Option<(u32, u32, u32)>>`.
+
+- [ ] **Step 1: Write failing planner tests**
+
+Add tests that construct `[256,256,240]` with source strides
+`[256,1,65536]` and destination strides `[1,256,65536]`, expect
+`TiledTranspose`, expect grid `(16,16,240)` for tile 16, and expect `None`
+when the maximum dimension is below the batch count. Add a non-compact batch
+stride case and expect `GenericStrided`.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer native_permutation::tests::batched
+```
+
+Expected: the compact batch is classified `GenericStrided` or the grid API
+does not provide a Z dimension.
+
+- [ ] **Step 3: Implement the minimal classification**
+
+Generalize the transpose predicate to accept rank two or rank three. For rank
+three, require `src_strides[2] == dims[0] * dims[1]` and
+`dst_strides[2] == dims[0] * dims[1]` using checked conversions and
+multiplication. Return batch count one for rank two and `dims[2]` for rank
+three. Extend `dispatch_grid` to validate X, Y, and Z against the supplied
+runtime limit.
+
+- [ ] **Step 4: Run the focused and complete planner tests**
+
+Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer native_permutation::tests
+```
+
+Expected: all planner tests pass.
+
+### Task 2: Launch the Batched Shared-Memory Kernel
+
+**Files:**
+- Modify: `crates/tenferro-gpu/src/kernels/structural.rs`
+- Modify: `crates/tenferro-gpu/src/webgpu/structural.rs`
+- Modify: `crates/tenferro-gpu/src/cubecl/mod.rs`
+- Test: `crates/tenferro-gpu/tests/integration/webgpu_structural_runtime.rs`
+
+**Interfaces:**
+- Consumes: the three-dimensional grid and compact matrix batch stride from Task 1.
+- Produces: `tiled_transpose_kernel` with compile-time `batch_stride`, shared by wgpu and CUDA.
+
+- [ ] **Step 1: Add a failing WebGPU runtime assertion**
+
+Extend the existing 3D transpose test to exercise `[1,0,2]` on a shape that
+has multiple batches and partial tile edges. The existing host reference
+remains the oracle.
+
+- [ ] **Step 2: Run the focused runtime test and verify RED**
+
+Temporarily assert the planner-selected tiled behavior through the public
+contract test or kernel inventory. Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer \
+  webgpu_structural_runtime::webgpu_transpose_f32_stays_on_device_and_matches_column_major_reference
+```
+
+Expected: failure until the launch signature and kernel batch offset exist.
+
+- [ ] **Step 3: Implement batch addressing**
+
+Add compile-time `batch_stride` to the kernel. Compute
+`batch_base = CUBE_POS_Z as usize * batch_stride`, add it to `src_offset` for
+loads, and add it to destination indices for stores. Pass
+`dims[0] * dims[1]` from both launchers and use `CubeCount::Static(x, y, z)`.
+
+- [ ] **Step 4: Run correctness, lint, and combined-feature checks**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer
+cargo clippy -p tenferro-gpu --no-default-features --features webgpu,cpu-faer -- -D warnings
+cargo check -p tenferro-gpu --no-default-features --features cuda,webgpu,cpu-faer
+```
+
+Expected: all commands exit zero.
+
+### Task 3: Measure and Accept or Revert
+
+**Files:**
+- Modify: `docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md`
+- Modify in tenferro-benchmark: `result/mac-gpu/gpu/permutation.md`
+
+**Interfaces:**
+- Consumes: the stable entry baseline and `16x8-p1-v1` selected tile.
+- Produces: a correctness-checked Metal profile and an explicit retention decision.
+
+- [ ] **Step 1: Run the selected Metal profile**
+
+Run `scripts/run_gpu_permutation_mac.sh` from the benchmark worktree with the
+clean tenferro revision and `TENFERRO_NATIVE_TRANSPOSE_TILE=16x8-p1-v1`.
+
+- [ ] **Step 2: Compare stable medians**
+
+Compare `mac_transpose_3d_102`, all other tenferro wgpu rows, and the memcpy
+row against the prior stable run. Retain the change only if 3D improves and no
+row violates the +20% gate under a comparable memcpy result.
+
+- [ ] **Step 3: Record the result and commit**
+
+Update the worklog and benchmark report with the measured result, run
+`git diff --check`, and commit the accepted implementation and evidence. If
+the hypothesis fails, revert the implementation commits and record the
+negative experiment instead.
+

--- a/docs/superpowers/plans/2026-07-29-cubecl-native-permutation-metal.md
+++ b/docs/superpowers/plans/2026-07-29-cubecl-native-permutation-metal.md
@@ -740,7 +740,7 @@ git commit -m "bench: record optimized Metal permutation results"
 
 - [ ] **Step 1: Update architecture and work log**
 
-Document the profile-first order, shared `strided-perm` planner, unified native route, compile-time tile parameters, validation/fallback policy, unchanged cuTENSOR route, Linux A100 CUDA+wgpu/Vulkan development validation, Metal acceptance baseline, M5 development sweep, and the required final M4 tile sweep.
+Document the profile-first order, shared `strided-perm` planner, unified native route, compile-time tile parameters, validation/fallback policy, unchanged cuTENSOR route, Linux A100 CUDA+wgpu/Vulkan development validation, Metal acceptance baseline, and the approved final M5 bounded tile sweep in place of the issue's originally named M4 sweep.
 
 - [ ] **Step 2: Run focused and broad tenferro verification**
 

--- a/docs/superpowers/plans/2026-07-29-cubecl-native-permutation-metal.md
+++ b/docs/superpowers/plans/2026-07-29-cubecl-native-permutation-metal.md
@@ -1,0 +1,796 @@
+# CubeCL Native Permutation Metal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish a reproducible Metal baseline, then unify and optimize tenferro's native CubeCL permutation path with shared dimension fusion and compile-time tiled transpose specializations.
+
+**Architecture:** The work is deliberately ordered across `tenferro-rs`, `tenferro-benchmark`, and `strided-rs`: WebGPU measurement wiring first, an immutable Metal baseline second, shared host planning third, and kernel changes only afterward. CUDA's cuTENSOR route remains intact; native CUDA and WebGPU share the same CubeCL materialization kernels while runtime-specific launch code owns placement and capability checks.
+
+**Tech Stack:** Rust 2021, CubeCL CUDA/WebGPU, wgpu Metal/Vulkan, `strided-perm`, JSONL/YAML benchmark artifacts, Python 3.12, PyTorch MPS, best-effort JAX Metal.
+
+## Global Constraints
+
+- Run all implementation work in isolated worktrees based on each repository's current `origin/main`.
+- Do not modify the bodies, launch geometry, dimension decoding, or specialization behavior of existing structural kernels before the Step 0 Metal baseline is committed.
+- The baseline dtype is `F32`; never substitute CPU execution for an unavailable Metal participant.
+- Record the actual local device as Apple M5 Max; explain that the user approved it in place of the issue's named M4.
+- Keep CUDA `F32`, `F64`, `C32`, and `C64` permutation on cuTENSOR.
+- Share bilateral fusion through a public `strided-perm` API; do not copy the fusion algorithm into `tenferro-gpu`.
+- Tile width, tile height, padding, workgroup dimensions, and vector width are CubeCL compile-time parameters.
+- Validate placement, overlap, metadata, bounds, cube counts, and shared-memory limits before launch; never fall back to CPU or transfer implicitly.
+- Run Linux A100 verification with both CubeCL CUDA and CubeCL wgpu/Vulkan; treat those timings as diagnostic and Metal as the optimization decision baseline.
+- Stop and investigate any comparable Metal row that regresses by at least 20%.
+- Inspect upstream reference paths when tenferro is more than 2x slower, or when a reference reaches at least 70% of the copy ceiling while tenferro remains below 35%.
+- Add precise source provenance when third-party implementation details influence code; do not change scientific citation policy without separate approval.
+- Use Python 3.12 for repository documentation gates because the system Python 3.9 lacks `enum.StrEnum`.
+
+---
+
+## File Map
+
+### `tenferro-rs`
+
+- `crates/tenferro-gpu/src/lib.rs`: compile native structural kernels for both CUDA and WebGPU.
+- `crates/tenferro-gpu/src/webgpu/mod.rs`: register WebGPU structural traits and delegate focused launch work.
+- `crates/tenferro-gpu/src/webgpu/structural.rs`: WebGPU structural validation, typed dispatch, and launches.
+- `crates/tenferro-gpu/src/native_permutation.rs`: runtime-independent launch planning and specialization classification.
+- `crates/tenferro-gpu/src/kernels/structural.rs`: generic fused materialization and tiled transpose CubeCL kernels.
+- `crates/tenferro-gpu/tests/integration/webgpu_structural_runtime.rs`: end-to-end Metal/WebGPU structural correctness.
+- `crates/tenferro-gpu/tests/integration/native_permutation_plan.rs`: host-plan classification and validation.
+- `docs/gpu-design.md`: native permutation architecture and runtime policy.
+- `docs/development-log.md`: issue chronology, commands, revisions, devices, and results.
+
+### `tenferro-benchmark`
+
+- `scripts/benchmark_layout.py`: accept the `mac-gpu` target profile.
+- `benchmarks/gpu/permutation-mac.yaml`: F32 Metal permutation suite.
+- `data/instances/gpu_permutation_mac_patterns.json`: deterministic Metal-scaled patterns.
+- `src/bin/benchmark_gpu_permutation_webgpu.rs`: tenferro WebGPU and Metal-copy runner.
+- `scripts/benchmark_gpu_permutation_metal.py`: PyTorch MPS and best-effort JAX Metal runner.
+- `scripts/run_gpu_permutation_mac.sh`: sequential orchestration and environment capture.
+- `scripts/format_gpu_permutation_results.py`: include profile-specific device/runtime metadata and unavailable reasons.
+- `tests/test_mac_gpu_permutation_profile.sh`: profile, participants, schema, and no-CPU-fallback contract.
+- `result/mac-gpu/gpu/permutation.md`: latest human-readable Metal report.
+- `data/results/mac-gpu/gpu/permutation/<timestamp>/`: immutable raw baseline and final runs.
+
+### `strided-rs`
+
+- `strided-perm/src/fuse.rs`: validated bilateral fusion plan.
+- `strided-perm/src/lib.rs`: public exports.
+- `strided-perm/tests/bilateral_fusion_plan.rs`: public API behavior and errors.
+
+## Task 1: Expose Existing Structural Kernels on WebGPU
+
+**Files:**
+- Modify: `crates/tenferro-gpu/src/lib.rs`
+- Modify: `crates/tenferro-gpu/src/webgpu/mod.rs`
+- Create: `crates/tenferro-gpu/src/webgpu/structural.rs`
+- Modify: `crates/tenferro-gpu/tests/integration.rs`
+- Create: `crates/tenferro-gpu/tests/integration/webgpu_structural_runtime.rs`
+
+**Interfaces:**
+- Consumes: existing `structural::transpose_kernel` and `structural::view_to_contiguous_kernel` unchanged.
+- Produces: `WebGpuBackend: TensorStructural + TensorViewCanonicalization` for supported WebGPU dtypes, using only the resident WebGPU allocation.
+
+- [ ] **Step 1: Add failing WebGPU runtime tests**
+
+Add tests that upload `F32` tensors, call `transpose(&input, &[1, 0])` and `to_contiguous_read` on a noncompact `TensorRead`, download only after the operation, and assert:
+
+```rust
+assert_eq!(backend.to_vec_f32(&transposed)?, vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+assert_eq!(backend.to_vec_f32(&materialized)?, vec![1.0, 3.0, 5.0]);
+assert_eq!(transposed.placement(), input.placement());
+```
+
+Include zero-size, size-one, invalid permutation, and foreign-runtime cases. Gate runtime tests with the existing WebGPU availability helper so absence is a reported skip, not a pass through CPU.
+
+- [ ] **Step 2: Verify the tests fail on the unsupported route**
+
+Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer \
+  --test integration webgpu_structural_runtime -- --nocapture
+```
+
+Expected: the valid transpose/materialization cases fail with the current explicit WebGPU unsupported error.
+
+- [ ] **Step 3: Compile structural kernels for WebGPU and add focused launch glue**
+
+Change the kernel module gate to:
+
+```rust
+#[cfg(any(feature = "cuda", feature = "webgpu"))]
+mod kernels;
+```
+
+In `webgpu/structural.rs`, add checked helpers that:
+
+```rust
+fn transpose_typed<T: CubeElement + CubePrimitive>(
+    backend: &WebGpuBackend,
+    input: &Tensor,
+    permutation: &[usize],
+) -> crate::Result<Tensor>;
+
+fn to_contiguous_view_typed<T: CubeElement + CubePrimitive>(
+    backend: &WebGpuBackend,
+    read: TensorRead<'_>,
+) -> crate::Result<Tensor>;
+```
+
+Validate permutation and view bounds on the host, resolve the existing resident buffer with `ensure_resident_on_runtime`, allocate with `alloc_output`, and launch the unchanged kernels with `cube_count_for_len`, `cube_dim_1d`, and `comptime_sequence`. Dispatch `F32`, `I32`, and `Bool` through their existing storage representations; return an explicit unsupported error for WebGPU-incompatible element representations.
+
+- [ ] **Step 4: Implement the structural trait methods**
+
+Make `WebGpuBackend::transpose`, `to_contiguous_read`, and the canonicalization route delegate to the typed helpers. Preserve tensor dtype, logical shape, placement, runtime identity, and out-of-place semantics. Reject overlapping writes and foreign provider/runtime allocations before launch.
+
+- [ ] **Step 5: Run focused and simultaneous-feature checks**
+
+Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer \
+  --test integration webgpu_structural_runtime -- --nocapture
+cargo check -p tenferro-gpu --no-default-features --features cuda,webgpu,cpu-faer
+```
+
+Expected: focused tests pass; both runtime feature sets compile together.
+
+- [ ] **Step 6: Prove the entry-gate restriction and commit**
+
+Run:
+
+```bash
+git diff 7d2095ef -- crates/tenferro-gpu/src/kernels/structural.rs
+```
+
+Expected: no output.
+
+Commit:
+
+```bash
+git add crates/tenferro-gpu/src/lib.rs crates/tenferro-gpu/src/webgpu \
+  crates/tenferro-gpu/tests/integration.rs \
+  crates/tenferro-gpu/tests/integration/webgpu_structural_runtime.rs
+git commit -m "feat: expose native structural kernels on WebGPU"
+```
+
+## Task 2: Add and Run the `mac-gpu` Entry-Gate Profile
+
+**Files:**
+- Create an isolated `tenferro-benchmark` worktree from `origin/main`
+- Modify and create the benchmark files listed in the file map
+
+**Interfaces:**
+- Consumes: the exact tenferro Task 1 commit SHA.
+- Produces: schema-valid raw records and `result/mac-gpu/gpu/permutation.md`, committed before any kernel algorithm change.
+
+- [ ] **Step 1: Create and index the benchmark worktree**
+
+Run:
+
+```bash
+git check-ignore -q .worktrees
+git worktree add .worktrees/issue-1507-mac-gpu -b codex/issue-1507-mac-gpu origin/main
+cd .worktrees/issue-1507-mac-gpu
+codegraph init
+```
+
+Expected: the new branch is based on the current benchmark `origin/main`, and `.codegraph/` is created locally.
+
+- [ ] **Step 2: Add failing profile contract tests**
+
+The shell test must assert:
+
+```bash
+python3.12 scripts/benchmark_layout.py validate-profile mac-gpu
+rg -q '"dtype": "f32"' data/instances/gpu_permutation_mac_patterns.json
+rg -q 'pytorch-mps' benchmarks/gpu/permutation-mac.yaml
+rg -q 'jax-metal' benchmarks/gpu/permutation-mac.yaml
+rg -q 'memcpy-metal-d2d' benchmarks/gpu/permutation-mac.yaml
+rg -q 'not_configured' scripts/benchmark_gpu_permutation_metal.py
+```
+
+It must also inject a CPU-only JAX stub and assert the runner emits `status: not_configured` with a reason naming the non-Metal backend.
+
+- [ ] **Step 3: Verify the profile test fails**
+
+Run:
+
+```bash
+bash tests/test_mac_gpu_permutation_profile.sh
+```
+
+Expected: failure because `mac-gpu` and its runners are absent.
+
+- [ ] **Step 4: Add the profile and deterministic patterns**
+
+Extend target-profile validation from:
+
+```python
+r"(mac-cpu|amd-cpu|nvidia-gpu)"
+```
+
+to:
+
+```python
+r"(mac-cpu|mac-gpu|amd-cpu|nvidia-gpu)"
+```
+
+Define the F32 patterns `device-copy`, `transpose-2d`, two distinct 3D permutations, rotation, high-rank reverse, high-rank cyclic, TN scattered-to-column-major, and TN contiguous-collapse. Each record contains explicit shape, permutation, source strides, destination order, deterministic index seed, read bytes, and write bytes.
+
+- [ ] **Step 5: Implement the native runners and timing contract**
+
+The Rust runner must warm up, verify before timing, launch without allocation in the timed loop when the case contract permits, synchronize with the CubeCL WebGPU client, and emit JSONL fields:
+
+```json
+{
+  "target_profile": "mac-gpu",
+  "suite_id": "gpu/permutation",
+  "dtype": "f32",
+  "device": "Apple M5 Max",
+  "runtime": "wgpu/Metal",
+  "synchronization": "CubeCL client sync",
+  "allocation": "outside timed region",
+  "median_ms": 0.0,
+  "p25_ms": 0.0,
+  "p75_ms": 0.0,
+  "effective_gbps": 0.0,
+  "tenferro_revision": "<40-hex commit>"
+}
+```
+
+The Python runner must use `torch.mps.synchronize()` around MPS timing. It must require `jax.default_backend()` or every selected JAX device platform to be Metal; otherwise emit `not_configured` and never execute a CPU sample.
+
+- [ ] **Step 6: Implement sequential orchestration and formatting**
+
+`scripts/run_gpu_permutation_mac.sh` runs in this order:
+
+```text
+tenferro-webgpu-transpose-baseline
+tenferro-webgpu-to-contiguous
+pytorch-mps
+jax-metal
+memcpy-metal-d2d
+```
+
+It captures `system_profiler SPHardwareDataType SPDisplaysDataType`, `sw_vers`, tool versions, git SHAs, suite YAML, instances JSON, stdout, stderr, and JSONL records under one timestamped raw directory. The formatter computes bandwidth from exact read-plus-write bytes and preserves unavailable-participant reasons.
+
+- [ ] **Step 7: Run validation and the Metal baseline**
+
+Run:
+
+```bash
+bash tests/test_mac_gpu_permutation_profile.sh
+bash tests/test_permutation_result_schema.sh
+bash scripts/run_gpu_permutation_mac.sh \
+  --tenferro-worktree /Users/hiroshi/projects/tensor4all/tenferro-rs/.worktrees/issue-1507-metal-permutation
+```
+
+Expected: correctness passes for available participants; JAX either runs on Metal or is explicitly `not_configured`; no row uses CPU; the latest report and timestamped raw directory are created.
+
+- [ ] **Step 8: Audit metadata and commit the immutable baseline**
+
+Run:
+
+```bash
+rg -n "Apple M5 Max|wgpu/Metal|f32|tenferro_revision|not_configured" \
+  result/mac-gpu/gpu/permutation.md data/results/mac-gpu/gpu/permutation
+python3.12 scripts/validate_benchmark_suite.py \
+  --suite benchmarks/gpu/permutation-mac.yaml \
+  --results data/results/mac-gpu/gpu/permutation
+```
+
+Expected: the actual device, runtime, dtype, revision, and any unavailable reason appear; validation succeeds.
+
+Commit:
+
+```bash
+git add benchmarks/gpu/permutation-mac.yaml data/instances/gpu_permutation_mac_patterns.json \
+  scripts src/bin tests result/mac-gpu data/results/mac-gpu
+git commit -m "bench: record mac-gpu permutation baseline"
+```
+
+## Task 3: Publish Validated Bilateral Fusion Planning
+
+**Files:**
+- Create an isolated `strided-rs` worktree from `origin/main`
+- Modify: `strided-perm/src/fuse.rs`
+- Modify: `strided-perm/src/lib.rs`
+- Create: `strided-perm/tests/bilateral_fusion_plan.rs`
+
+**Interfaces:**
+- Produces:
+
+```rust
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BilateralFusionPlan {
+    pub dims: Vec<usize>,
+    pub src_strides: Vec<isize>,
+    pub dst_strides: Vec<isize>,
+}
+
+#[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
+pub enum FusionPlanError {
+    #[error("metadata lengths differ: dims={dims}, src_strides={src_strides}, dst_strides={dst_strides}")]
+    LengthMismatch { dims: usize, src_strides: usize, dst_strides: usize },
+    #[error("fused dimension product overflows usize")]
+    DimensionOverflow,
+}
+
+pub fn plan_bilateral_fusion(
+    dims: &[usize],
+    src_strides: &[isize],
+    dst_strides: &[isize],
+) -> Result<BilateralFusionPlan, FusionPlanError>;
+```
+
+- [ ] **Step 1: Create and index the strided worktree**
+
+Run:
+
+```bash
+git check-ignore -q .worktrees
+git worktree add .worktrees/issue-1507-fusion-planner \
+  -b codex/issue-1507-fusion-planner origin/main
+cd .worktrees/issue-1507-fusion-planner
+codegraph init
+```
+
+- [ ] **Step 2: Add public API tests**
+
+Test exact outputs for empty/scalar metadata, size-one removal, identity collapse, partial fusion, non-fusion, 2D transpose, negative strides, rank-24 TN collapse, mismatched lengths, and `usize::MAX * 2` overflow. Assert errors by enum variant, not message text.
+
+- [ ] **Step 3: Verify tests fail before exports exist**
+
+Run:
+
+```bash
+cargo test -p strided-perm --test bilateral_fusion_plan
+```
+
+Expected: unresolved imports for the new public types/function.
+
+- [ ] **Step 4: Implement validated planning and keep HPTT on the same code**
+
+Filter axes with dimension one, reject dimensions that cannot be represented as
+`isize`, then fuse adjacent axes only when:
+
+```rust
+let current_dim = isize::try_from(current_dim)
+    .map_err(|_| FusionPlanError::DimensionOverflow)?;
+let src_contiguous = current_src
+    .checked_mul(current_dim)
+    .is_some_and(|expected| next_src == expected);
+let dst_contiguous = current_dst
+    .checked_mul(current_dim)
+    .is_some_and(|expected| next_dst == expected);
+```
+
+Use `checked_mul` for fused dimensions. Make the existing HPTT planner consume `plan_bilateral_fusion(...).expect("HPTT metadata is prevalidated")` so there is one algorithm owner. Preserve the existing Strided.jl/HPTT provenance comment.
+
+- [ ] **Step 5: Run package tests, docs, and commit**
+
+Run:
+
+```bash
+cargo test -p strided-perm
+cargo test -p strided-perm --doc
+cargo fmt --check
+```
+
+Expected: all pass.
+
+Commit:
+
+```bash
+git add strided-perm/src/fuse.rs strided-perm/src/lib.rs \
+  strided-perm/tests/bilateral_fusion_plan.rs
+git commit -m "feat: expose bilateral fusion planning"
+```
+
+## Task 4: Add the Native Materialization Planner
+
+**Files:**
+- Modify: `Cargo.toml` or the workspace dependency file that pins `strided-perm`
+- Create: `crates/tenferro-gpu/src/native_permutation.rs`
+- Modify: `crates/tenferro-gpu/src/lib.rs`
+- Modify: `crates/tenferro-gpu/tests/integration.rs`
+- Create: `crates/tenferro-gpu/tests/integration/native_permutation_plan.rs`
+
+**Interfaces:**
+- Consumes: Task 3 `plan_bilateral_fusion`.
+- Produces:
+
+```rust
+pub(crate) enum NativePermutationKind {
+    LinearCopy,
+    GenericStrided,
+    TiledTranspose,
+}
+
+pub(crate) struct NativePermutationPlan {
+    pub kind: NativePermutationKind,
+    pub dims: Vec<usize>,
+    pub src_strides: Vec<isize>,
+    pub dst_strides: Vec<isize>,
+    pub src_offset: isize,
+    pub len: usize,
+}
+```
+
+- [ ] **Step 1: Add failing planner tests**
+
+Construct plans for identity, 2D transpose, partial fusion, rank-24 collapse, negative stride, zero-size, invalid permutation, length mismatch, product overflow, source range violation, destination overlap, and source/destination allocation overlap. Assert classification and fused metadata exactly.
+
+- [ ] **Step 2: Point the workspace pin at the reviewed strided commit**
+
+Update only the `strided-perm` revision to the exact Task 3 commit and run:
+
+```bash
+cargo update -p strided-perm
+```
+
+Expected: `Cargo.lock` resolves the exact reviewed revision.
+
+- [ ] **Step 3: Implement validation and classification**
+
+`NativePermutationPlan::new` validates metadata and allocations once, calls `plan_bilateral_fusion`, then classifies:
+
+```rust
+if len == 0 || fused_rank <= 1 && src_is_contiguous && dst_is_contiguous {
+    NativePermutationKind::LinearCopy
+} else if fused_rank == 2 && stride_one_axes_differ && affine_tile_axes {
+    NativePermutationKind::TiledTranspose
+} else {
+    NativePermutationKind::GenericStrided
+}
+```
+
+Keep tile selection out of this task; `TiledTranspose` identifies eligibility only.
+
+- [ ] **Step 4: Run planner tests and feature checks**
+
+Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer \
+  --test integration native_permutation_plan
+cargo check -p tenferro-gpu --no-default-features --features cuda,webgpu,cpu-faer
+```
+
+Expected: all planner tests pass and both runtime features compile.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock crates/tenferro-gpu/src/lib.rs \
+  crates/tenferro-gpu/src/native_permutation.rs \
+  crates/tenferro-gpu/tests/integration.rs \
+  crates/tenferro-gpu/tests/integration/native_permutation_plan.rs
+git commit -m "feat: plan native permutation launches"
+```
+
+## Task 5: Unify Transpose and View Materialization
+
+**Files:**
+- Modify: `crates/tenferro-gpu/src/kernels/structural.rs`
+- Modify: `crates/tenferro-gpu/src/webgpu/structural.rs`
+- Modify: CUDA native fallback launch code under `crates/tenferro-gpu/src/cuda/`
+- Modify: WebGPU structural and native planner integration tests
+
+**Interfaces:**
+- Consumes: `NativePermutationPlan`.
+- Produces: one `materialize_strided_kernel` used by native transpose and `to_contiguous`.
+
+- [ ] **Step 1: Add route-sharing and fused-rank tests**
+
+Add a test-only launch trace that records `NativePermutationKind` and fused rank. Assert transpose and an equivalent permuted view yield identical plan metadata. Assert the rank-24 contiguous TN pattern launches with fused rank at most one and high-rank reverse remains correct.
+
+- [ ] **Step 2: Verify the route-sharing test fails**
+
+Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer \
+  --test integration native_materialization_route
+```
+
+Expected: failure because transpose still launches `transpose_kernel`.
+
+- [ ] **Step 3: Replace the generic view kernel with fused bilateral metadata**
+
+Define:
+
+```rust
+#[cube(launch_unchecked)]
+pub fn materialize_strided_kernel<E: CubePrimitive>(
+    dst: &mut Array<E>,
+    src: &Array<E>,
+    #[comptime] dims: Sequence<usize>,
+    #[comptime] src_strides: Sequence<i64>,
+    #[comptime] dst_strides: Sequence<i64>,
+    src_offset: i64,
+    dst_offset: i64,
+    #[comptime] rank: usize,
+)
+```
+
+Decode coordinates over `rank` fused axes once, accumulate both affine offsets, then copy one element. The host converts validated `isize` metadata to CubeCL `i64` compile-time sequences.
+
+- [ ] **Step 4: Route native transpose through materialization**
+
+Build transpose source strides by permuting the input's logical strides into output-axis order, use contiguous output strides, construct the common plan, and launch `LinearCopy` or `GenericStrided`. Remove calls to `transpose_kernel`; delete that kernel only after all references are gone. Leave the cuTENSOR dispatch unchanged.
+
+- [ ] **Step 5: Run cross-dtype correctness and commit**
+
+Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer \
+  --test integration webgpu_structural_runtime -- --nocapture
+cargo test -p tenferro-gpu --no-default-features --features cuda,webgpu,cpu-faer \
+  native_materialization
+cargo check -p tenferro-gpu --no-default-features --features cuda,webgpu,cpu-faer
+```
+
+Expected: scalar, zero-size, size-one, noncompact, negative-stride, high-rank, and supported dtype cases pass.
+
+Commit:
+
+```bash
+git add crates/tenferro-gpu/src crates/tenferro-gpu/tests
+git commit -m "feat: unify native permutation materialization"
+```
+
+## Task 6: Add Compile-Time Tiled Transpose
+
+**Files:**
+- Modify: `crates/tenferro-gpu/src/kernels/structural.rs`
+- Modify: `crates/tenferro-gpu/src/native_permutation.rs`
+- Modify: WebGPU/CUDA native launch wrappers
+- Create: `crates/tenferro-gpu/tests/integration/tiled_transpose_runtime.rs`
+
+**Interfaces:**
+- Produces:
+
+```rust
+pub(crate) struct TileConfig {
+    pub width: u32,
+    pub height: u32,
+    pub padding: u32,
+    pub vector_width: u32,
+}
+
+pub(crate) const TILE_CANDIDATES: &[TileConfig];
+```
+
+- [ ] **Step 1: Add failing boundary and fallback tests**
+
+Force candidate selection in tests and cover exact-multiple tiles, one-element edges, both-axis partial tiles, rectangular shapes, shared-memory limit below every candidate, and non-tileable strides. Compare every result to a host permutation and assert the selected/fallback kind.
+
+- [ ] **Step 2: Verify the tiled tests fail**
+
+Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer \
+  --test integration tiled_transpose_runtime -- --nocapture
+```
+
+Expected: failure because no tiled specialization exists.
+
+- [ ] **Step 3: Implement candidate validation**
+
+Use a small set such as `(32, 8, 1, 1)`, `(16, 16, 1, 1)`, and `(16, 8, 1, 4)`. Compute:
+
+```rust
+let shared_bytes = height
+    .checked_mul(width + padding)
+    .and_then(|n| n.checked_mul(element_size))
+    .ok_or(TileSelectionError::SharedMemoryOverflow)?;
+```
+
+Select only candidates within the runtime's `max_shared_memory_size`; otherwise return `GenericStrided`.
+
+- [ ] **Step 4: Implement the CubeCL shared-memory kernel**
+
+Define the kernel with `#[comptime] tile_width`, `tile_height`, `padding`, and `vector_width`. Allocate `SharedMemory::new_aligned(tile_width * (tile_height + padding), alignment)`, cooperatively load coalesced source elements, call `sync_cube()`, and cooperatively write coalesced destination elements. Guard source and destination coordinates independently for boundary tiles.
+
+- [ ] **Step 5: Run Metal correctness, shared-feature checks, and commit**
+
+Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer \
+  --test integration tiled_transpose_runtime -- --nocapture
+cargo check -p tenferro-gpu --no-default-features --features cuda,webgpu,cpu-faer
+cargo fmt --check
+```
+
+Expected: boundary and fallback tests pass; simultaneous features compile.
+
+Commit:
+
+```bash
+git add crates/tenferro-gpu/src crates/tenferro-gpu/tests
+git commit -m "perf: tile native CubeCL transpose"
+```
+
+## Task 7: Verify Both Native Runtime Paths on Linux A100
+
+**Files:**
+- Create: `docs/performance/issue-1507-linux-a100.md`
+- Modify: `docs/development-log.md`
+
+**Interfaces:**
+- Consumes: the Task 6 tenferro revision.
+- Produces: correctness and diagnostic performance evidence for CUDA and wgpu/Vulkan using the same kernel source.
+
+- [ ] **Step 1: Resolve the approved A100 execution environment**
+
+Use existing repository CI, documented SSH configuration, or the project's benchmark host mechanism. Record GPU model, driver, CUDA toolkit, Vulkan adapter, CubeCL revision, Rust version, and exact tenferro commit. Do not use a different GPU while labeling it A100.
+
+- [ ] **Step 2: Run CUDA native-fallback correctness**
+
+Run the package's native-fallback test selector with:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features cuda,cpu-faer \
+  native_materialization -- --nocapture
+```
+
+Expected: supported native fallback dtype/layout cases pass; cuTENSOR-supported production cases remain routed to cuTENSOR.
+
+- [ ] **Step 3: Run wgpu/Vulkan correctness**
+
+Select the Vulkan adapter explicitly through the repository/CubeCL environment contract and run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer \
+  --test integration webgpu_structural_runtime -- --nocapture
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer \
+  --test integration tiled_transpose_runtime -- --nocapture
+```
+
+Expected: the adapter is reported as Vulkan on A100 and all structural cases pass.
+
+- [ ] **Step 4: Record diagnostic results and commit**
+
+Document commands, raw logs, environment metadata, correctness status, and diagnostic medians without using them as the Metal acceptance baseline.
+
+Commit:
+
+```bash
+git add docs/performance/issue-1507-linux-a100.md docs/development-log.md
+git commit -m "docs: record A100 native permutation verification"
+```
+
+## Task 8: Sweep Tiles and Close Reference Gaps on M5 Max
+
+**Files:**
+- Modify benchmark raw/latest results
+- Modify CubeCL planner/kernel files only if an evidence-backed candidate or reference-path improvement is needed
+- Modify provenance comments at the moment third-party source influences code
+
+**Interfaces:**
+- Consumes: immutable Task 2 baseline and Task 6 candidates.
+- Produces: chosen compile-time tile candidates, final Metal profile, regression analysis, and reference-gap investigations.
+
+- [ ] **Step 1: Run the complete tile sweep**
+
+For every candidate and the generic path, run all tile-eligible Metal patterns with identical dtype, sizes, allocation policy, synchronization, warmup, and sample count. Store raw samples and report median/p25/p75/effective bandwidth.
+
+- [ ] **Step 2: Select candidates without overfitting**
+
+Choose the smallest candidate set that wins across pattern classes, respects the measured Metal shared-memory limit, and introduces no row with a 20% or larger regression. If a candidate regresses a comparable row, retain generic fallback or remove that candidate and rerun.
+
+- [ ] **Step 3: Rerun the complete `mac-gpu` profile**
+
+Run:
+
+```bash
+bash scripts/run_gpu_permutation_mac.sh \
+  --tenferro-worktree /Users/hiroshi/projects/tensor4all/tenferro-rs/.worktrees/issue-1507-metal-permutation \
+  --label final
+```
+
+Expected: every available participant passes correctness and every tenferro row has a baseline ratio.
+
+- [ ] **Step 4: Identify extreme comparable gaps**
+
+Flag a row when:
+
+```text
+tenferro_median / reference_median > 2.0
+```
+
+or:
+
+```text
+reference_gbps / copy_ceiling_gbps >= 0.70
+and tenferro_gbps / copy_ceiling_gbps < 0.35
+```
+
+Exclude unavailable participants and rows with mismatched dtype, pattern, timing scope, allocation policy, or device.
+
+- [ ] **Step 5: Inspect and apply feasible reference techniques**
+
+For every flagged PyTorch/JAX row, locate the exact dispatch and generated/native kernel using official source repositories and runtime traces. Compare collapse, copy specialization, launch geometry, vectorization, coalescing, tiling, padding, and synchronization. Apply only runtime-generic improvements that preserve CubeCL architecture, add a provenance comment naming project/file/function and relationship, write a failing regression/performance-classification test first, then rerun the full correctness and Metal profile.
+
+- [ ] **Step 6: Commit final benchmark evidence**
+
+Commit raw samples, environment metadata, tile sweep, latest report, regression table, and reference-gap notes:
+
+```bash
+git add data/results/mac-gpu result/mac-gpu docs
+git commit -m "bench: record optimized Metal permutation results"
+```
+
+## Task 9: Final Documentation and Repository Gates
+
+**Files:**
+- Modify: `docs/gpu-design.md`
+- Modify: `docs/development-log.md`
+- Modify: issue-specific performance documents
+
+**Interfaces:**
+- Produces: review-ready branches in all three repositories with exact cross-repository revision references.
+
+- [ ] **Step 1: Update architecture and work log**
+
+Document the profile-first order, shared `strided-perm` planner, unified native route, compile-time tile parameters, validation/fallback policy, unchanged cuTENSOR route, Linux A100 CUDA+wgpu/Vulkan development validation, Metal acceptance baseline, and M5 Max final sweep approved in place of M4.
+
+- [ ] **Step 2: Run focused and broad tenferro verification**
+
+Run:
+
+```bash
+cargo test -p tenferro-gpu --no-default-features --features webgpu,cpu-faer
+cargo check -p tenferro-gpu --no-default-features --features cuda,webgpu,cpu-faer
+cargo fmt --check
+cargo clippy -p tenferro-gpu --no-default-features --features webgpu,cpu-faer -- -D warnings
+PATH=/tmp/tenferro-1507-python-shim:/usr/bin:/bin:/usr/sbin:/sbin \
+  bash scripts/check-pr-fast.sh
+```
+
+Expected: all commands pass. The shim's `python3` resolves to `/opt/homebrew/opt/python@3.12/bin/python3.12`.
+
+- [ ] **Step 3: Run strided and benchmark gates**
+
+Run:
+
+```bash
+cargo test -p strided-perm
+cargo fmt --check
+bash tests/test_mac_gpu_permutation_profile.sh
+bash tests/test_permutation_result_schema.sh
+python3.12 scripts/validate_benchmark_suite.py \
+  --suite benchmarks/gpu/permutation-mac.yaml \
+  --results data/results/mac-gpu/gpu/permutation
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Audit issue completion criteria**
+
+Verify from git history and artifacts that the baseline commit predates every kernel algorithm commit; both native runtime paths pass; all comparable Metal regressions are below 20% or explained; every extreme reference gap has a recorded investigation; provenance is complete; no hidden CPU fallback exists; and exact cross-repository SHAs are recorded.
+
+- [ ] **Step 5: Commit final documentation**
+
+```bash
+git add docs
+git commit -m "docs: complete native permutation optimization record"
+```
+
+- [ ] **Step 6: Review branch state**
+
+Run in each worktree:
+
+```bash
+git status --short
+git log --oneline origin/main..HEAD
+```
+
+Expected: clean worktrees, coherent commit series, and no unrelated user changes.

--- a/docs/superpowers/plans/2026-07-29-cubecl-native-permutation-metal.md
+++ b/docs/superpowers/plans/2026-07-29-cubecl-native-permutation-metal.md
@@ -740,7 +740,7 @@ git commit -m "bench: record optimized Metal permutation results"
 
 - [ ] **Step 1: Update architecture and work log**
 
-Document the profile-first order, shared `strided-perm` planner, unified native route, compile-time tile parameters, validation/fallback policy, unchanged cuTENSOR route, Linux A100 CUDA+wgpu/Vulkan development validation, Metal acceptance baseline, and M5 Max final sweep approved in place of M4.
+Document the profile-first order, shared `strided-perm` planner, unified native route, compile-time tile parameters, validation/fallback policy, unchanged cuTENSOR route, Linux A100 CUDA+wgpu/Vulkan development validation, Metal acceptance baseline, M5 development sweep, and the required final M4 tile sweep.
 
 - [ ] **Step 2: Run focused and broad tenferro verification**
 

--- a/docs/superpowers/specs/2026-07-29-batched-tiled-transpose-design.md
+++ b/docs/superpowers/specs/2026-07-29-batched-tiled-transpose-design.md
@@ -1,0 +1,57 @@
+# Batched Tiled Transpose Design
+
+## Context
+
+The issue #1507 native permutation implementation tiles fused rank-two
+transposes. The Metal profile shows that `mac_transpose_3d_102`
+(`256x256x240`, permutation `[1,0,2]`) remains about 1.7 times slower than
+PyTorch MPS. Its fused layout is 240 independent compact `256x256`
+transposes, but it currently uses the generic rank-three affine kernel.
+
+## Decision
+
+Extend the existing `TiledTranspose` specialization to compact batched
+two-dimensional transposes. A plan is eligible when:
+
+- the first two fused axes already satisfy the rank-two transpose predicate;
+- every remaining fused axis is contiguous in both source and destination;
+- source and destination use the same matrix-sized stride for the first batch
+  axis, so every batch is an independent compact matrix;
+- the batch product and launch grid are representable without overflow.
+
+The initial implementation accepts exactly one fused batch axis. This covers
+the measured `[1,0,2]` case without introducing a general permutation
+classifier. Higher-rank layouts remain on the generic path.
+
+The tiled kernel uses `CUBE_POS_Z` as the batch index. It adds a
+compile-time `batch_stride = rows * columns` to both source and destination
+base addresses. The two-dimensional shared-memory load, barrier, and store are
+otherwise unchanged. Rank-two transposes use a batch count of one.
+
+If any X, Y, or Z dispatch dimension exceeds 65,535, launch selection returns
+to the generic kernel. CUDA and wgpu consume the same planner decision and
+CubeCL kernel definition.
+
+## Alternatives
+
+1. Flatten batch into the Y grid dimension. This avoids the Z limit but adds
+   division and remainder work to every workgroup and complicates the existing
+   two-dimensional coordinate contract.
+2. Optimize the generic rank-three decoder. This benefits more layouts but
+   cannot provide coalesced access on both sides of the transpose and does not
+   address the measured shared-memory opportunity.
+
+The Z-grid design is the smallest extension with a direct performance
+hypothesis.
+
+## Validation
+
+- Planner tests prove `[1,0,2]` is tiled, a non-compact batch remains generic,
+  and an oversized batch grid falls back.
+- Existing rank-two and boundary-tile tests must remain green.
+- Metal runtime correctness covers the full `mac_transpose_3d_102` pattern.
+- The optimization is retained only if the stable Metal median improves
+  without causing any wgpu row to exceed the +20% regression gate.
+- CUDA plus WebGPU compile together; Linux A100 CUDA and wgpu/Vulkan runtime
+  execution remains the required pre-merge validation.
+

--- a/docs/superpowers/specs/2026-07-29-batched-tiled-transpose-design.md
+++ b/docs/superpowers/specs/2026-07-29-batched-tiled-transpose-design.md
@@ -54,4 +54,3 @@ hypothesis.
   without causing any wgpu row to exceed the +20% regression gate.
 - CUDA plus WebGPU compile together; Linux A100 CUDA and wgpu/Vulkan runtime
   execution remains the required pre-merge validation.
-

--- a/docs/superpowers/specs/2026-07-29-cubecl-native-permutation-metal-design.md
+++ b/docs/superpowers/specs/2026-07-29-cubecl-native-permutation-metal-design.md
@@ -1,0 +1,394 @@
+# CubeCL Native Permutation Optimization for WebGPU/Metal
+
+Date: 2026-07-29
+
+Issue: [tensor4all/tenferro-rs#1507](https://github.com/tensor4all/tenferro-rs/issues/1507)
+
+## Objective
+
+Optimize tenferro's native CubeCL permutation and materialization path for
+WebGPU/Metal without weakening the CUDA vendor-library policy established by
+issue #1506.
+
+The work is profile-first:
+
+1. Make the existing, unoptimized native structural kernels measurable on
+   WebGPU without changing their algorithms.
+2. Add and run a `mac-gpu` permutation benchmark profile.
+3. Record the Metal baseline.
+4. Only then change native kernel algorithms.
+5. Unify transpose and view materialization, share bilateral dimension-fusion
+   planning with `strided-perm`, and add a shared-memory tiled transpose whose
+   tile dimensions are compile-time parameters.
+6. Re-run the Metal profile and investigate PyTorch or JAX implementation
+   details if tenferro remains extremely slower on comparable rows.
+
+## Current State
+
+- CUDA `F32`, `F64`, `C32`, and `C64` structural permutation uses cuTENSOR.
+  That route remains unchanged.
+- CUDA vendor-unsupported dtypes or layouts use native CubeCL structural
+  kernels.
+- `WebGpuBackend::transpose`, `WebGpuBackend::to_contiguous_read`, and
+  `WebGpuBackend::copy_read_into` currently return `Unsupported`.
+- `transpose_kernel` decodes both output and input coordinates for every
+  element.
+- `view_to_contiguous_kernel` decodes a full-rank coordinate for every element.
+- Neither native path fuses dimensions or tiles stride-hostile transposes.
+- The existing GPU permutation benchmark is CUDA-only and uses A100-sized
+  `F64` patterns.
+- The development Mac is an Apple M5 Max. The user explicitly approved using
+  it for the final Apple Silicon sweep even though the issue originally named
+  M4.
+
+## Entry Gate
+
+Kernel optimization is forbidden until a Metal baseline has been written to
+the benchmark repository.
+
+Step 0 may include only the provider wiring required to measure the existing
+kernel algorithms:
+
+- compile the existing structural kernel module for both CUDA and WebGPU;
+- add WebGPU launch glue for the existing `transpose_kernel` and
+  `view_to_contiguous_kernel`;
+- implement the WebGPU tensor/view dispatch necessary for the benchmark;
+- preserve the current kernel bodies, launch geometry, rank-deep decoding, and
+  lack of tiling;
+- add correctness coverage for the newly exposed provider route.
+
+The wiring commit and the benchmark baseline commit must precede every
+dimension-fusion or tiled-kernel commit. The benchmark report records the exact
+tenferro commit used for the baseline.
+
+## Repository Boundaries
+
+### tenferro-benchmark
+
+Owns:
+
+- the `mac-gpu` target profile;
+- Metal-appropriate permutation patterns;
+- the tenferro WebGPU/Metal runner;
+- PyTorch MPS and best-effort JAX Metal reference runners;
+- a device-to-device Metal copy ceiling;
+- run metadata, validation, formatting, raw records, and latest reports.
+
+### strided-rs
+
+Owns device-independent bilateral fusion planning. It exposes a small planning
+API from `strided-perm`; it does not expose the HPTT execution tree or CPU
+micro-kernel details.
+
+### tenferro-rs
+
+Owns:
+
+- WebGPU structural tensor integration;
+- common native CubeCL permutation launch planning;
+- the generic fused-rank materialization kernel;
+- the shared-memory tiled transpose kernel;
+- runtime-specific launch wrappers and specialization selection;
+- placement, aliasing, dtype, shape, and shared-memory validation;
+- GPU design documentation and the implementation work log.
+
+## Benchmark Design
+
+### Target Profile
+
+Add `mac-gpu` anywhere target profiles are validated or documented. Keep
+`suite_id: gpu/permutation`; hardware belongs in `target_profile`, not the
+suite identity.
+
+Latest report:
+
+```text
+result/mac-gpu/gpu/permutation.md
+```
+
+Raw run:
+
+```text
+data/results/mac-gpu/gpu/permutation/<timestamp>/
+```
+
+### Dtype and Sizes
+
+The `mac-gpu` profile uses `F32`. WGSL/Metal WebGPU does not provide a portable
+`F64` compute path, while PyTorch MPS and the experimental JAX Metal path can
+express `F32`.
+
+Preserve the semantic pattern classes from the NVIDIA profile but scale element
+counts so steady-state rows are approximately 10 ms on Apple Silicon:
+
+- device copy;
+- 2D transpose;
+- two 3D permutations;
+- rotation;
+- high-rank reverse;
+- high-rank cyclic permutation;
+- TN-representative scattered-to-column-major materialization;
+- TN-representative contiguous permutation that should collapse after fusion.
+
+The suite keeps deterministic index-derived values and exact correctness
+comparison. Pattern sizes may differ from the A100 profile, but pattern class
+and permutation semantics remain explicit.
+
+### Participants
+
+- `tenferro-webgpu-transpose-baseline` before path unification;
+- `tenferro-webgpu-to-contiguous`;
+- `pytorch-mps`;
+- `jax-metal` when a compatible isolated environment works;
+- `memcpy-metal-d2d`.
+
+JAX Metal is best-effort. The repository's normal JAX installation is CPU-only,
+and current upstream guidance conflicts: Apple's experimental plugin page
+remains available while JAX maintainers have described the old plugin as no
+longer maintained. A missing or incompatible plugin produces a
+`not_configured` row with the reason; it must not silently run on CPU.
+
+### Timing Contract
+
+- Run participants sequentially.
+- Warm up before collecting samples.
+- Time host dispatch plus backend-native device synchronization.
+- Do not download inside timed regions.
+- Verify output before timing.
+- Report median, p25, p75, effective read-plus-write bandwidth, allocation
+  behavior, synchronization method, device name, runtime, dtype, and exact
+  tenferro revision.
+- Treat the device-copy row as the measured bandwidth ceiling.
+
+## Shared Dimension-Fusion Planner
+
+Expose a small `strided-perm` API conceptually shaped as:
+
+```rust
+pub struct BilateralFusionPlan {
+    pub dims: Vec<usize>,
+    pub src_strides: Vec<isize>,
+    pub dst_strides: Vec<isize>,
+}
+
+pub fn plan_bilateral_fusion(
+    dims: &[usize],
+    src_strides: &[isize],
+    dst_strides: &[isize],
+) -> Result<BilateralFusionPlan, FusionPlanError>;
+```
+
+The final naming follows `strided-perm` conventions. The API:
+
+- validates equal metadata lengths;
+- removes size-one axes;
+- fuses adjacent axes only when both source and destination remain contiguous
+  across the boundary;
+- checks dimension-product overflow;
+- preserves signed strides;
+- has no dependency on a device runtime, element type, tile size, or HPTT
+  execution mode.
+
+`tenferro-gpu` consumes this plan at the host launch boundary. It does not copy
+or independently reimplement the fusion algorithm.
+
+## Native Materialization Architecture
+
+### Unified Route
+
+Delete the dedicated native transpose algorithm after the entry gate.
+
+Native transpose becomes:
+
+1. validate the permutation;
+2. form logical output shape and permuted source strides;
+3. construct the same host-side materialization plan used by
+   `to_contiguous`;
+4. launch one of the native materialization specializations.
+
+CUDA cuTENSOR-supported cases continue to bypass this native route. Native
+CUDA fallbacks and WebGPU use the same CubeCL kernel definitions with
+runtime-specific launch types.
+
+### Plan Classification
+
+The launch plan classifies fused metadata as:
+
+- `LinearCopy`: scalar or fused rank zero/one with contiguous source and
+  destination;
+- `GenericStrided`: arbitrary fused-rank materialization;
+- `TiledTranspose`: a two-dimensional transpose class where source and
+  destination stride-one axes differ and both tile axes are representable by
+  affine strides.
+
+The generic kernel performs coordinate decoding only across fused dimensions.
+The TN contiguous case should reduce from rank 24 to a low-rank or linear
+launch.
+
+### Tiled Transpose
+
+The tiled kernel:
+
+- maps a two-dimensional output tile to one workgroup;
+- cooperatively reads a coalesced source tile into `SharedMemory`;
+- synchronizes the workgroup;
+- writes the transposed tile with coalesced destination access;
+- checks source and destination edges for partial tiles;
+- uses padding where needed to avoid shared-memory bank conflicts;
+- never aliases source and destination.
+
+Tile width, tile height, shared-memory leading dimension/padding, workgroup
+dimensions, and vector width are compile-time parameters. They are not fixed
+inside the kernel body.
+
+The host selects from a small, tested candidate set and rejects candidates
+whose shared-memory requirement exceeds
+`hardware.max_shared_memory_size`. If no tiled candidate is valid, the
+operation uses `GenericStrided`; it never falls back to CPU or transfers data
+between providers.
+
+## Validation and Errors
+
+Validate once before launch:
+
+- permutation rank, range, and uniqueness;
+- shape/stride metadata length;
+- shape products and byte counts;
+- view reachable range and base offset;
+- source and destination placement and runtime identity;
+- destination internal overlap;
+- source/destination allocation overlap;
+- launch cube-count limits;
+- shared-memory requirement for the selected specialization.
+
+Kernels are out-of-place. Source/destination overlap remains a typed boundary
+error. Permutation is pure data movement; it introduces no accumulation-order
+or determinism policy.
+
+Provider or kernel errors retain their typed source. Unsupported dtype or
+layout conditions remain explicit and must not trigger a hidden CPU path.
+
+## Test Strategy
+
+### Planner Tests
+
+Cover:
+
+- scalar and empty metadata;
+- size-one axes;
+- identity layout;
+- partially fused layouts;
+- non-fusible layouts;
+- 2D transpose;
+- high-rank reverse and cyclic patterns;
+- TN rank-24 collapse;
+- negative strides;
+- mismatched metadata lengths;
+- multiplication overflow.
+
+### tenferro GPU Tests
+
+Cover:
+
+- transpose and view materialization share the same native planner;
+- generic and tiled paths match a host reference;
+- boundary tiles;
+- scalar, zero-size, size-one, high-rank, and noncompact views;
+- all supported WebGPU structural dtypes;
+- native CUDA fallback dtypes/layouts;
+- alias rejection and foreign-runtime rejection;
+- shared-memory-limit fallback;
+- simultaneous `cuda,webgpu` feature compilation.
+
+### Cross-Runtime Verification
+
+Development and most algorithmic verification run on Linux A100 using both:
+
+- CubeCL CUDA runtime;
+- CubeCL wgpu runtime backed by Vulkan.
+
+The same kernel source must compile and produce matching results on both
+runtimes. CUDA numbers are diagnostic because cuTENSOR remains the production
+CUDA route for supported dtypes.
+
+Improvement decisions are based on the Step 0 Metal baseline, not on native
+CUDA performance. The final Apple Silicon pass sweeps the compile-time tile
+candidates and reruns the complete `mac-gpu` profile. The issue named M4; the
+approved local execution uses the available M5 Max and records that device
+truthfully.
+
+## Performance Gates
+
+The campaign's stop-the-line rule applies after the baseline exists:
+
+- any comparable WebGPU row that regresses by at least 20% stops the
+  optimization series until explained or fixed;
+- correctness, timing scope, dtype, pattern, allocation behavior, and device
+  must match before ratios are reported.
+
+Treat tenferro as extremely behind a comparable PyTorch or JAX row when either:
+
+- tenferro median time exceeds the reference by more than 2x; or
+- the reference reaches at least 70% of the copy ceiling while tenferro remains
+  below 35%.
+
+For every such row:
+
+1. identify the reference dispatch path;
+2. inspect the relevant upstream source or generated kernel;
+3. compare dimension collapse, copy specialization, launch geometry,
+   vectorization, coalescing, tiling, padding, and synchronization;
+4. implement applicable changes that fit tenferro's runtime-generic CubeCL
+   architecture;
+5. rerun correctness and performance measurements.
+
+## Provenance
+
+`strided-perm` remains the owner of the bilateral fusion algorithm and its
+existing HPTT provenance. Consuming its public planning API does not duplicate
+the implementation.
+
+If PyTorch, JAX, Apple MPS, or another third-party implementation is read while
+writing code, add a source comment at writing time that identifies the project,
+file, and function and states whether the code is ported, derived, follows a
+convention, or was only validated against it. A close translation also carries
+the original license and copyright requirements.
+
+Scientific-credit changes to repository citation policy require separate user
+confirmation before they are added.
+
+## Commit and Delivery Order
+
+1. Commit this design.
+2. Add WebGPU measurement wiring without changing kernel algorithms.
+3. Add `mac-gpu` benchmark support and record the baseline.
+4. Publish the shared `strided-perm` fusion-planning change and update the
+   tenferro dependency revision.
+5. Unify the native materialization path and consume the fusion plan.
+6. Add the compile-time tiled transpose specializations.
+7. Run Linux CUDA plus wgpu/Vulkan verification.
+8. Run Apple Silicon tile sweep and final Metal profile.
+9. Investigate and address extreme PyTorch/JAX gaps where comparable reference
+   rows exist.
+10. Update GPU design documentation, work log, and benchmark reports.
+
+Each stage has focused correctness tests and a coherent commit. Benchmark
+evidence identifies the exact code revision used.
+
+## Completion Criteria
+
+The issue is complete only when all of the following hold:
+
+- `mac-gpu` profile and Metal baseline exist;
+- baseline predates kernel optimization;
+- WebGPU transpose and materialization are supported without hidden transfer;
+- dedicated native transpose is unified with view materialization;
+- bilateral fusion planning is shared with `strided-perm`;
+- tiled transpose uses compile-time tile parameters;
+- correctness passes on Metal and both Linux runtime paths;
+- final Apple Silicon tile sweep and profile are recorded;
+- the 20% regression gate passes or every exception is explained;
+- every extreme comparable PyTorch/JAX gap has been investigated and applicable
+  optimizations have been implemented;
+- documentation, provenance, work log, raw records, and latest reports are
+  current.

--- a/docs/superpowers/specs/2026-07-29-cubecl-native-permutation-metal-design.md
+++ b/docs/superpowers/specs/2026-07-29-cubecl-native-permutation-metal-design.md
@@ -37,9 +37,9 @@ The work is profile-first:
 - Neither native path fuses dimensions or tiles stride-hostile transposes.
 - The existing GPU permutation benchmark is CUDA-only and uses A100-sized
   `F64` patterns.
-- The development Mac is an Apple M5 Max. The user explicitly approved using
-  it for the final Apple Silicon sweep even though the issue originally named
-  M4.
+- The development Mac is an Apple M5 Max. The user explicitly approved the
+  recorded M5 bounded tile sweep as the final Apple Silicon sweep even though
+  the issue originally named M4. No additional M4 rerun is required.
 
 ## Entry Gate
 
@@ -312,10 +312,10 @@ runtimes. CUDA numbers are diagnostic because cuTENSOR remains the production
 CUDA route for supported dtypes.
 
 Improvement decisions are based on the Step 0 Metal baseline, not on native
-CUDA performance. The final Apple Silicon pass sweeps the compile-time tile
-candidates and reruns the complete `mac-gpu` profile. The issue named M4; the
-approved local execution uses the available M5 Max and records that device
-truthfully.
+CUDA performance. The final Apple Silicon pass sweeps the bounded compile-time
+tile candidates and reruns the complete `mac-gpu` profile. The recorded M5 Max
+execution is the approved final pass and records the device truthfully; an M4
+rerun is not a completion requirement.
 
 ## Performance Gates
 

--- a/docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md
+++ b/docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md
@@ -1,0 +1,70 @@
+# Issue #1507: CubeCL native permutation on wgpu/Metal
+
+Date: 2026-07-29
+
+## Entry gate
+
+Kernel work started only after the `mac-gpu` benchmark profile produced a
+correctness-checked Metal baseline. The baseline was collected on Apple M5 Max
+as the approved development substitute. JAX Metal was not configured and was
+recorded as such; CPU fallback was not used.
+
+The baseline 2D transpose median was 1.472 ms for the direct WebGPU path and
+1.481 ms for view materialization. PyTorch MPS measured 0.664 ms, while the
+Metal device-copy reference was 0.469 ms.
+
+## Implementation
+
+- `strided-perm` now exposes the validated bilateral dimension-fusion planner
+  used by HPTT.
+- CUDA-native and WebGPU transpose/materialization routes consume one
+  `NativePermutationPlan`.
+- The planner validates shape products, allocation bounds, destination
+  non-overlap, source offsets, and compact destination layout before launch.
+- Generic materialization uses one signed affine kernel. Its logical length is
+  compile-time metadata because raw `Array` runtime length metadata was
+  observed to alias a logical dimension on Metal for a 3D case.
+- Exact compact 2D transpose uses shared memory. Tile size, block rows, padding,
+  and vector width are all compile-time kernel parameters.
+- `TENFERRO_NATIVE_TRANSPOSE_TILE=generic` forces the generic path. Bounded
+  sweep values include 8, 16, and 32-wide tiles with vector widths 1, 2, or 4.
+
+## M5 development sweep
+
+The `mac_transpose_2d` transpose medians were:
+
+| configuration | median (ms) |
+| --- | ---: |
+| `generic` | 1.469 |
+| `8x8-p1-v1` | 1.481 |
+| `16x8-p1-v1` | 1.463 |
+| `16x8-p1-v2` | 1.465 |
+| `32x8-p1-v1` | 1.471 |
+| `32x8-p1-v2` | 1.479 |
+| `32x8-p1-v4` | 1.483 |
+
+All values are within 0.02 ms because the profile includes fresh output
+allocation and explicit synchronization. `16x8-p1-v1` is the development
+default; it is not a substitute for the final M4 sweep.
+
+## Framework-gap inspection
+
+The PyTorch comparison exceeded the 2x inspection threshold for the baseline
+2D case. PyTorch's current MPS `Copy.mm` routes strided views through its unary
+copy machinery. `OperationUtils.mm` uses a 2D strided dispatch, detects
+inner-contiguous layouts, and can move aligned 16-byte chunks. The benchmark
+also reuses a PyTorch destination while tenferro allocates a fresh output per
+call. This explains why the reported framework gap is not an isolated
+transpose-kernel comparison. The tenferro kernel was independently implemented;
+no PyTorch source was copied.
+
+## Verification status
+
+- Metal/WebGPU integration: 84 tests passed.
+- `tenferro-gpu` WebGPU clippy with warnings denied: passed.
+- Combined `cuda,webgpu,cpu-faer` compile: passed.
+- M5 profile correctness: all participating tenferro patterns passed.
+- Linux A100 CUDA plus wgpu/Vulkan runtime execution: pending. Configured A100
+  SSH endpoints were unreachable from the development session because the
+  internal network/VPN and DNS were unavailable.
+- Final Apple M4 tile sweep: pending and required for the release judgment.

--- a/docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md
+++ b/docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md
@@ -62,7 +62,7 @@ comes from encoding and submitting one CubeCL/wgpu command buffer per call,
 not from output allocation or an inferior transpose kernel. The profile keeps
 per-call synchronization to preserve its public-API latency contract.
 
-## Rejected batched-tile experiment
+## Batched-tile follow-up
 
 The remaining `mac_transpose_3d_102` framework gap motivated an experiment
 that classified `[1,0,2]` as a batch of compact 2D transposes and mapped the
@@ -70,12 +70,14 @@ batch index to the CubeCL dispatch Z dimension. A partial-edge, multi-batch
 Metal correctness test passed, and CUDA plus WebGPU compiled from the same
 kernel.
 
-With 20 warmups and 101 measured iterations, however, the selected tiled path
-measured 1.726 ms for transpose and 1.731 ms for view materialization. The
-generic path measured 1.729 ms and 1.733 ms, respectively. This is not a
-material improvement under the profile's public-API allocation and
-synchronization contract, so commit `585c28dd` was reverted by `5586394f`.
-The two-dimensional tiled specialization remains unchanged.
+The first per-call measurement showed no material difference because command
+submission dominated: tile measured 1.726 ms and generic measured 1.729 ms.
+After the queue-throughput diagnostic exposed that masking effect, three
+warmed 101-iteration comparisons were repeated with one final synchronization.
+The batched tile measured 0.414, 0.401, and 0.405 ms per transpose; generic
+measured 0.495, 0.471, and 0.490 ms. The 0.405 versus 0.490 ms medians are a
+17% kernel-throughput improvement, so the earlier revert was superseded and
+the batched compact-transpose specialization was reinstated.
 
 ## Rejected native-vector experiment
 

--- a/docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md
+++ b/docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md
@@ -47,6 +47,21 @@ All values are within 0.02 ms because the profile includes fresh output
 allocation and explicit synchronization. `16x8-p1-v1` is the development
 default; it is not a substitute for the final M4 sweep.
 
+## Rejected batched-tile experiment
+
+The remaining `mac_transpose_3d_102` framework gap motivated an experiment
+that classified `[1,0,2]` as a batch of compact 2D transposes and mapped the
+batch index to the CubeCL dispatch Z dimension. A partial-edge, multi-batch
+Metal correctness test passed, and CUDA plus WebGPU compiled from the same
+kernel.
+
+With 20 warmups and 101 measured iterations, however, the selected tiled path
+measured 1.726 ms for transpose and 1.731 ms for view materialization. The
+generic path measured 1.729 ms and 1.733 ms, respectively. This is not a
+material improvement under the profile's public-API allocation and
+synchronization contract, so commit `585c28dd` was reverted by `5586394f`.
+The two-dimensional tiled specialization remains unchanged.
+
 ## Framework-gap inspection
 
 The PyTorch comparison exceeded the 2x inspection threshold for the baseline

--- a/docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md
+++ b/docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md
@@ -45,7 +45,9 @@ The `mac_transpose_2d` transpose medians were:
 
 All values are within 0.02 ms because the profile includes fresh output
 allocation and explicit synchronization. `16x8-p1-v1` is the development
-default; it is not a substitute for the final M4 sweep.
+default and the selected final tile. The user approved this recorded M5
+bounded sweep as the final Apple Silicon gate; no additional M4 rerun is
+required.
 
 Allocation/submission diagnostics explain why the per-call sweep looks flat.
 Raw output allocation averaged 0.002 ms and an idle synchronization averaged
@@ -108,11 +110,18 @@ implemented; no PyTorch source was copied.
 
 ## Verification status
 
-- Metal/WebGPU integration: 84 tests passed.
+- Metal/WebGPU integration: 86 tests passed.
 - `tenferro-gpu` WebGPU clippy with warnings denied: passed.
 - Combined `cuda,webgpu,cpu-faer` compile: passed.
 - M5 profile correctness: all participating tenferro patterns passed.
-- Linux A100 CUDA plus wgpu/Vulkan runtime execution: pending. Configured A100
-  SSH endpoints were unreachable from the development session because the
-  internal network/VPN and DNS were unavailable.
-- Final Apple M4 tile sweep: pending and required for the release judgment.
+- Linux A100 CUDA native structural runtime: 27 passed, 0 failed. A direct
+  native `I32` batched partial-tile diagnostic for shape `[17, 19, 3]` and
+  permutation `[1, 0, 2]` matched the complete column-major reference.
+- Linux A100 wgpu/Vulkan structural runtime: 6 passed, 0 failed. The Vulkan
+  inventory contained only the NVIDIA A100 80GB PCIe through the NVIDIA ICD,
+  excluding software and CPU adapter fallback.
+- Final Apple Silicon bounded tile sweep: passed on the approved M5 Max;
+  `16x8-p1-v1` remains selected and no M4 rerun is required.
+
+The A100 environment, commands, and full results are recorded in
+[issue comment 5112907691](https://github.com/tensor4all/tenferro-rs/issues/1507#issuecomment-5112907691).

--- a/docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md
+++ b/docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md
@@ -47,13 +47,20 @@ All values are within 0.02 ms because the profile includes fresh output
 allocation and explicit synchronization. `16x8-p1-v1` is the development
 default; it is not a substitute for the final M4 sweep.
 
-An allocation/synchronization diagnostic explains why the per-call sweep
-looks flat. Raw output allocation averaged 0.002 ms. When 51 dispatches shared
-one final synchronization, the selected tile averaged 1.153 ms per transpose
-versus 1.431 ms for the generic kernel, a roughly 20% throughput improvement.
-The profile intentionally keeps per-call synchronization for comparable
-public-API latency, where the fixed flush/synchronization cost masks most of
-that kernel gain.
+Allocation/submission diagnostics explain why the per-call sweep looks flat.
+Raw output allocation averaged 0.002 ms and an idle synchronization averaged
+0.017 ms. In three 101-iteration passes where warmed dispatches shared one
+final synchronization, the median per-transpose times were 0.427 ms for
+`16x8-p1-v1` and 0.516 ms for the generic kernel, a 17% throughput
+improvement. The selected tile was also the fastest of the bounded candidates;
+the next-best `32x8-p1-v1` measured 0.432 ms.
+
+The selected kernel's queued throughput is effectively the same as the
+0.422 ms Metal device-copy reference and is faster than the allocation-matched
+PyTorch MPS end-to-end median. The remaining synchronized single-call latency
+comes from encoding and submitting one CubeCL/wgpu command buffer per call,
+not from output allocation or an inferior transpose kernel. The profile keeps
+per-call synchronization to preserve its public-API latency contract.
 
 ## Rejected batched-tile experiment
 

--- a/docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md
+++ b/docs/worklogs/2026-07-29-issue-1507-native-permutation-metal.md
@@ -47,6 +47,14 @@ All values are within 0.02 ms because the profile includes fresh output
 allocation and explicit synchronization. `16x8-p1-v1` is the development
 default; it is not a substitute for the final M4 sweep.
 
+An allocation/synchronization diagnostic explains why the per-call sweep
+looks flat. Raw output allocation averaged 0.002 ms. When 51 dispatches shared
+one final synchronization, the selected tile averaged 1.153 ms per transpose
+versus 1.431 ms for the generic kernel, a roughly 20% throughput improvement.
+The profile intentionally keeps per-call synchronization for comparable
+public-API latency, where the fixed flush/synchronization cost masks most of
+that kernel gain.
+
 ## Rejected batched-tile experiment
 
 The remaining `mac_transpose_3d_102` framework gap motivated an experiment
@@ -62,16 +70,32 @@ material improvement under the profile's public-API allocation and
 synchronization contract, so commit `585c28dd` was reverted by `5586394f`.
 The two-dimensional tiled specialization remains unchanged.
 
+## Rejected native-vector experiment
+
+The configured tile vector width originally unrolled scalar lanes. An
+experimental kernel instead bound source and destination arrays as CubeCL
+`Vector<E, N>` values, performing native vector loads and stores while keeping
+the same shared-memory transpose. Metal correctness passed for vector widths
+1, 2, and 4.
+
+With 10 warmups and 51 measured iterations on `mac_transpose_2d`, the
+`32x8-p1` transpose medians for vector widths 1, 2, and 4 were 1.740 ms,
+1.727 ms, and 1.726 ms. View materialization measured 1.733 ms, 1.735 ms, and
+1.722 ms. These differences are within run-to-run noise, so the native-vector
+experiment was not retained.
+
 ## Framework-gap inspection
 
 The PyTorch comparison exceeded the 2x inspection threshold for the baseline
 2D case. PyTorch's current MPS `Copy.mm` routes strided views through its unary
 copy machinery. `OperationUtils.mm` uses a 2D strided dispatch, detects
 inner-contiguous layouts, and can move aligned 16-byte chunks. The benchmark
-also reuses a PyTorch destination while tenferro allocates a fresh output per
-call. This explains why the reported framework gap is not an isolated
-transpose-kernel comparison. The tenferro kernel was independently implemented;
-no PyTorch source was copied.
+was then corrected so PyTorch, like tenferro, allocates a fresh destination on
+every timed call. Focused 51-iteration medians under the matched allocation
+contract were 0.552 ms for the 2D case and 1.037 ms for `mac_transpose_3d_102`.
+The remaining framework gap is an end-to-end host-API comparison, not an
+isolated transpose-kernel comparison. The tenferro kernel was independently
+implemented; no PyTorch source was copied.
 
 ## Verification status
 

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "18d74ffacccefee8c476379c21a99eae532b917b"
+        revision = "06c825829e399dd769504e6ce10dbca8f07b5e15"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
## Summary

- add WebGPU structural permutation support after establishing the Metal benchmark entry gate
- unify CUDA native and WebGPU transpose/materialization through `NativePermutationPlan`
- consume the validated bilateral fusion planner from `strided-perm`
- add a signed affine generic kernel and comptime shared-memory tiled transpose kernels
- specialize compact 2D and batched `[1,0,2]` transposes with bounded tile selection and grid-limit fallback
- remove a redundant WebGPU synchronization round trip

## Why

The native CubeCL permutation paths decoded full-rank coordinates per element, did not share dimension-fusion planning, and lacked a tiled path for stride-hostile transposes. WebGPU structural transpose and materialization were also unavailable.

This change follows the profile-first requirement: the Metal baseline was recorded before kernel work began, and performance judgments remain Metal-based.

## Performance

Apple M5 Max queued-throughput diagnostics:

- compact 2D: `16x8-p1-v1` `0.427 ms` vs generic `0.516 ms` (about 17% faster)
- batched `[1,0,2]`: tiled `0.405 ms` vs generic `0.490 ms` (about 17% faster)
- Metal memcpy reference: about `0.41–0.42 ms`

The user approved the recorded M5 bounded tile sweep as the final Apple Silicon gate; no additional M4 rerun is required.

## Validation

- local WebGPU integration: `86 passed; 0 failed`
- WebGPU clippy with warnings denied: passed
- combined `cuda,webgpu,cpu-faer` compilation: passed
- Linux A100 CUDA native structural runtime: `27 passed; 0 failed`
- Linux A100 wgpu/Vulkan structural runtime: `6 passed; 0 failed`
- the A100 Vulkan inventory contained only the NVIDIA A100 through the NVIDIA ICD, excluding CPU/software fallback
- CUDA native I32 batched partial-tile diagnostics matched every reference element

Full A100 environment and commands: https://github.com/tensor4all/tenferro-rs/issues/1507#issuecomment-5112907691

## Cross-repository dependencies

- tensor4all/strided-rs#165
- tensor4all/tenferro-benchmark#82

Closes #1507
