### PR TITLE
Route elementwise into defaults through strided

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ lru = "0.12"
 proc-macro2 = "1"
 quote = "1"
 syn = "2"
-strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "06c825829e399dd769504e6ce10dbca8f07b5e15", version = "0.3.0" }
-strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "06c825829e399dd769504e6ce10dbca8f07b5e15", version = "0.3.0" }
-strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "06c825829e399dd769504e6ce10dbca8f07b5e15", version = "0.3.0", features = ["parallel"] }
-strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "06c825829e399dd769504e6ce10dbca8f07b5e15", version = "0.3.0", features = ["parallel"] }
-strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "06c825829e399dd769504e6ce10dbca8f07b5e15", version = "0.3.0", default-features = false }
+strided-view = { git = "https://github.com/tensor4all/strided-rs.git", rev = "649772c8402e5fe95335366326b6623f9a4f5b0a", version = "0.3.0" }
+strided-traits = { git = "https://github.com/tensor4all/strided-rs.git", rev = "649772c8402e5fe95335366326b6623f9a4f5b0a", version = "0.3.0" }
+strided-perm = { git = "https://github.com/tensor4all/strided-rs.git", rev = "649772c8402e5fe95335366326b6623f9a4f5b0a", version = "0.3.0", features = ["parallel"] }
+strided-kernel = { git = "https://github.com/tensor4all/strided-rs.git", rev = "649772c8402e5fe95335366326b6623f9a4f5b0a", version = "0.3.0", features = ["parallel"] }
+strided-einsum2 = { git = "https://github.com/tensor4all/strided-rs.git", rev = "649772c8402e5fe95335366326b6623f9a4f5b0a", version = "0.3.0", default-features = false }
 libloading = "0.8"
 faer = { version = "0.24", default-features = false, features = ["std", "rayon"] }
 cblas-sys = "0.1"

--- a/crates/tenferro-ad/src/eager/tests.rs
+++ b/crates/tenferro-ad/src/eager/tests.rs
@@ -1105,6 +1105,31 @@ fn eager_backend_delegates_broadcast_multiply_fusion_to_cpu_backend() {
 }
 
 #[test]
+fn eager_backend_delegates_elementwise_into_hook_to_cpu_variants() {
+    let materializations = Arc::new(AtomicUsize::new(0));
+    let backends = [
+        EagerBackend::cpu(CpuBackend::new()),
+        EagerBackend::recording_cpu(Arc::clone(&materializations)),
+    ];
+
+    for mut backend in backends {
+        let lhs = Tensor::from_vec_col_major(vec![3], vec![2.0_f64, 3.0, 5.0]).unwrap();
+        let rhs = Tensor::from_vec_col_major(vec![3], vec![7.0_f64, 11.0, 13.0]).unwrap();
+        let mut out = Tensor::from_vec_col_major(vec![3], vec![0.0_f64; 3]).unwrap();
+
+        backend
+            .add_read_into(
+                TensorRead::from_tensor(&lhs),
+                TensorRead::from_tensor(&rhs),
+                TensorWrite::from_tensor(&mut out),
+            )
+            .unwrap();
+
+        assert_eq!(out.as_slice::<f64>().unwrap(), &[9.0, 14.0, 18.0]);
+    }
+}
+
+#[test]
 fn untracked_nary_ops_consume_lazy_views_without_materializing_inputs() {
     let ctx = EagerRuntime::with_cpu_backend(CpuBackend::new());
     let x = EagerTensor::from_tensor_in(

--- a/crates/tenferro-ad/src/eager_backend.rs
+++ b/crates/tenferro-ad/src/eager_backend.rs
@@ -13,10 +13,10 @@ use tenferro_runtime::{
 use tenferro_tensor::backend::ElementwiseFusionPlan;
 use tenferro_tensor::{
     BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost, CompareDir, DType,
-    DotGeneralConfig, GatherConfig, PadConfig, Result as TensorResult, ScatterConfig, SliceConfig,
-    Tensor, TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer, TensorDot,
-    TensorElementwise, TensorFusion, TensorIndexing, TensorRead, TensorReduction, TensorStructural,
-    TensorValue, TensorWrite,
+    DotGeneralConfig, ElementwiseReadOp, GatherConfig, PadConfig, Result as TensorResult,
+    ScatterConfig, SliceConfig, Tensor, TensorAnalytic, TensorBackend, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorRead,
+    TensorReduction, TensorStructural, TensorValue, TensorWrite,
 };
 
 pub enum EagerBackend {
@@ -162,6 +162,15 @@ impl BackendRuntimeCache for RecordingBackend {
 
 #[cfg(test)]
 impl TensorElementwise for RecordingBackend {
+    fn elementwise_read_into(
+        &mut self,
+        op: ElementwiseReadOp,
+        inputs: &[TensorRead<'_>],
+        out: TensorWrite<'_>,
+    ) -> TensorResult<()> {
+        self.inner.elementwise_read_into(op, inputs, out)
+    }
+
     delegate_recording_backend_methods! {
         fn add(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
         fn sub(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
@@ -289,6 +298,15 @@ impl BackendRuntimeCache for EagerBackend {
 }
 
 impl TensorElementwise for EagerBackend {
+    fn elementwise_read_into(
+        &mut self,
+        op: ElementwiseReadOp,
+        inputs: &[TensorRead<'_>],
+        out: TensorWrite<'_>,
+    ) -> TensorResult<()> {
+        dispatch!(self, elementwise_read_into(op, inputs, out))
+    }
+
     delegate_tensor_backend_methods! {
         fn add(lhs: &Tensor, rhs: &Tensor) -> TensorResult<Tensor>;
         fn add_read(lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> TensorResult<Tensor>;

--- a/crates/tenferro-cpu/src/backend.rs
+++ b/crates/tenferro-cpu/src/backend.rs
@@ -32,9 +32,9 @@ use tenferro_tensor::backend::{ElementwiseFusionPlan, GroupedGemmConfig};
 use tenferro_tensor::SharedTensorAllocationDomain;
 use tenferro_tensor::{
     AllocationDomainId, BackendCachedDot, BackendRuntimeCache, BackendSession, BackendSessionHost,
-    DotGeneralAccumulation, TensorAnalytic, TensorBackend, TensorBuffer, TensorDeviceTransfer,
-    TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
-    TensorViewCanonicalization,
+    DotGeneralAccumulation, ElementwiseReadOp, TensorAnalytic, TensorBackend, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorReduction, TensorStructural, TensorViewCanonicalization,
 };
 use tenferro_tensor::{
     CompareDir, DotGeneralConfig, GatherConfig, PadConfig, ScatterConfig, SliceConfig,
@@ -61,6 +61,41 @@ pub(crate) fn tag_fresh_output(output: &mut Tensor, domain: CpuDomainId) {
         Tensor::C32(tensor) => tag!(tensor),
         Tensor::C64(tensor) => tag!(tensor),
     }
+}
+
+pub(crate) fn elementwise_read_into_fallback_with_pool(
+    buffers: &mut BufferPool,
+    op: ElementwiseReadOp,
+    inputs: &[TensorRead<'_>],
+    out: TensorWrite<'_>,
+) -> crate::Result<()> {
+    let result = match op {
+        ElementwiseReadOp::Add => {
+            elementwise::add_read_with_pool(buffers, inputs[0].clone(), inputs[1].clone())?
+        }
+        ElementwiseReadOp::Subtract => {
+            elementwise::sub_read_with_pool(buffers, inputs[0].clone(), inputs[1].clone())?
+        }
+        ElementwiseReadOp::Multiply => {
+            elementwise::mul_read_with_pool(buffers, inputs[0].clone(), inputs[1].clone())?
+        }
+        ElementwiseReadOp::Negate => elementwise::neg_read_with_pool(buffers, inputs[0].clone())?,
+        ElementwiseReadOp::Conj => elementwise::conj_read_with_pool(buffers, inputs[0].clone())?,
+        ElementwiseReadOp::Divide => {
+            elementwise::div_read_with_pool(buffers, inputs[0].clone(), inputs[1].clone())?
+        }
+        _ => {
+            return Err(crate::Error::unsupported(
+                "CpuBackend::elementwise_read_into",
+                format!("CPU backend does not implement {op:?}"),
+            ))
+        }
+    };
+    copy_tensor_read_into(
+        "CpuBackend::elementwise_read_into",
+        TensorRead::from_tensor(&result),
+        out,
+    )
 }
 
 pub(crate) trait FreshCpuOutput {
@@ -2389,6 +2424,24 @@ impl BackendRuntimeCache for CpuBackend {
 }
 
 impl TensorElementwise for CpuBackend {
+    fn elementwise_read_into(
+        &mut self,
+        op: ElementwiseReadOp,
+        inputs: &[TensorRead<'_>],
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        self.install_with_pool_context_unmarked(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            tenferro_tensor::backend::elementwise_read_into_with_context(
+                op,
+                inputs,
+                out,
+                &exec_context,
+                |inputs, out| elementwise_read_into_fallback_with_pool(buffers, op, inputs, out),
+            )
+        })
+    }
+
     fn add(&mut self, lhs: &Tensor, rhs: &Tensor) -> crate::Result<Tensor> {
         self.install_with_pool(|buffers| elementwise::add_with_pool(buffers, lhs, rhs))
     }

--- a/crates/tenferro-cpu/src/backend/tests.rs
+++ b/crates/tenferro-cpu/src/backend/tests.rs
@@ -65,8 +65,8 @@ fn fresh_tagging_is_field_only_and_has_no_dynamic_lookup_or_metadata_clone() {
         .split_once("fn tag_fresh_output")
         .expect("CPU backend should define one fresh-output tagger")
         .1
-        .split_once("struct CpuSessionProfileEntry")
-        .expect("session profiling should follow fresh-output tagging")
+        .split_once("pub(crate) fn elementwise_read_into_fallback_with_pool(")
+        .expect("the pooled elementwise fallback should follow fresh-output tagging")
         .0;
 
     assert!(tagging.contains("set_cpu_affinity(Some(domain))"));

--- a/crates/tenferro-cpu/src/exec_session.rs
+++ b/crates/tenferro-cpu/src/exec_session.rs
@@ -2,15 +2,17 @@ use crate::buffer_pool::{BufferPool, PoolScalar};
 use crate::{Tensor, TensorRead, TensorValue, TensorWrite};
 use tenferro_tensor::backend::{ElementwiseFusionPlan, GroupedGemmConfig};
 use tenferro_tensor::{
-    Buffer, CompareDir, ContractionScalar, DType, DotGeneralConfig, GatherConfig, PadConfig,
-    ScatterConfig, SliceConfig, TypedTensor,
+    Buffer, CompareDir, ContractionScalar, DType, DotGeneralConfig, ElementwiseReadOp,
+    GatherConfig, PadConfig, ScatterConfig, SliceConfig, TypedTensor,
 };
 use tenferro_tensor::{
     DotGeneralAccumulation, SessionCachedDot, TensorAnalytic, TensorBuffer, TensorDeviceTransfer,
     TensorDot, TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
 };
 
-use super::backend::{reclaim_typed, tag_fresh_output, FreshCpuOutput};
+use super::backend::{
+    elementwise_read_into_fallback_with_pool, reclaim_typed, tag_fresh_output, FreshCpuOutput,
+};
 use super::provider::{CpuExecutionContext, CpuOperationEntry};
 use super::CpuProviderBundle;
 use super::{
@@ -101,6 +103,22 @@ impl CpuExecSession<'_> {
             .map_err(|error| crate::Error::backend_source("CPU native execution", error))?
     }
 
+    fn run_native_with_context<R: Send>(
+        &mut self,
+        op: impl FnOnce(&CpuExecutionContext<'_>, &mut BufferPool) -> crate::Result<R> + Send,
+    ) -> crate::Result<R> {
+        let buffers = &mut *self.buffers;
+        if let Some(context) = self.entered {
+            return context.with_native_parallelism(|| op(&context, buffers));
+        }
+        let mode = self.entry.preferred_engine_mode();
+        self.entry
+            .enter(mode, |context| {
+                context.with_native_parallelism(|| op(context, buffers))
+            })
+            .map_err(|error| crate::Error::backend_source("CPU native execution", error))?
+    }
+
     fn run_native_fresh_with_context<R: FreshCpuOutput + Send>(
         &mut self,
         op: impl FnOnce(&CpuExecutionContext<'_>, &mut BufferPool) -> crate::Result<R> + Send,
@@ -168,6 +186,24 @@ macro_rules! delegate_with_pool {
 
 impl TensorElementwise for CpuExecSession<'_> {
     // Elementwise — direct delegation within the current session scope.
+    fn elementwise_read_into(
+        &mut self,
+        op: ElementwiseReadOp,
+        inputs: &[TensorRead<'_>],
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        self.run_native_with_context(|context, buffers| {
+            let exec_context = context.strided_exec_context();
+            tenferro_tensor::backend::elementwise_read_into_with_context(
+                op,
+                inputs,
+                out,
+                &exec_context,
+                |inputs, out| elementwise_read_into_fallback_with_pool(buffers, op, inputs, out),
+            )
+        })
+    }
+
     delegate_with_pool!(add(lhs: &Tensor, rhs: &Tensor) => elementwise::add_with_pool);
 
     fn add_read(&mut self, lhs: TensorRead<'_>, rhs: TensorRead<'_>) -> crate::Result<Tensor> {

--- a/crates/tenferro-cpu/tests/integration/backend_capability_contracts.rs
+++ b/crates/tenferro-cpu/tests/integration/backend_capability_contracts.rs
@@ -333,6 +333,28 @@ fn read_elementwise_and_analytic_paths_do_not_materialize_views() {
 }
 
 #[test]
+fn cpu_surfaces_override_elementwise_read_into_with_pooled_context() {
+    let backend_source = include_str!("../../src/backend.rs");
+    let session_source = include_str!("../../src/exec_session.rs");
+
+    for (surface, source) in [
+        ("CpuBackend", backend_source),
+        ("CpuExecSession", session_source),
+    ] {
+        let elementwise_impl = source
+            .split_once(&format!("impl TensorElementwise for {surface}"))
+            .expect("TensorElementwise implementation must exist")
+            .1;
+        let implementation = rust_function_body(elementwise_impl, "elementwise_read_into")
+            .unwrap_or_else(|| panic!("{surface}::elementwise_read_into must be implemented"));
+        assert!(
+            implementation.contains("strided_exec_context"),
+            "{surface}::elementwise_read_into must inject its pooled ExecContext"
+        );
+    }
+}
+
+#[test]
 fn structural_read_paths_dispatch_directly_to_typed_view_helpers() {
     let backend_source = include_str!("../../src/backend.rs");
     let session_source = include_str!("../../src/exec_session.rs");

--- a/crates/tenferro-tensor/Cargo.toml
+++ b/crates/tenferro-tensor/Cargo.toml
@@ -21,6 +21,7 @@ tenferro-tensor-core = { path = "../tenferro-tensor-core", version = "0.2.0" }
 num-traits.workspace = true
 num-complex.workspace = true
 smallvec.workspace = true
+strided-kernel.workspace = true
 tenferro-core-ops = { path = "../tenferro-core-ops", version = "0.2.0" }
 thiserror.workspace = true
 

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -1711,6 +1711,10 @@ fn execute_one_shot_map<T: 'static>(
     mut out: TypedTensorViewMut<'_, T>,
 ) -> crate::Result<()> {
     let input_data = input.host_storage()?;
+    // INVARIANT: dtype and layout come from the same validated typed view, and
+    // its host storage remains borrowed until replay returns.
+    // SAFETY: input_data supplies the pointer and exact byte length; the view
+    // owns the matching shape, signed strides, and in-bounds offset.
     let input_descriptor = unsafe {
         ErasedRawStridedPtr::new(
             dtype,
@@ -1727,6 +1731,8 @@ fn execute_one_shot_map<T: 'static>(
     let out_strides = SmallVec::<[isize; 8]>::from_slice(out.strides());
     let out_offset = out.offset();
     let out_data = out.host_storage_mut()?;
+    // INVARIANT: the copied output layout describes this uniquely borrowed
+    // host storage, already validated as disjoint from every input.
     let mut out_descriptor = ErasedRawStridedMut::new(
         dtype,
         typed_bytes_mut(out_data),
@@ -1748,6 +1754,10 @@ fn execute_one_shot_zip<T: 'static>(
     mut out: TypedTensorViewMut<'_, T>,
 ) -> crate::Result<()> {
     let lhs_data = lhs.host_storage()?;
+    // INVARIANT: dtype and layout come from the same validated typed view, and
+    // its host storage remains borrowed until replay returns.
+    // SAFETY: lhs_data supplies the pointer and exact byte length; the view
+    // owns the matching shape, signed strides, and in-bounds offset.
     let lhs_descriptor = unsafe {
         ErasedRawStridedPtr::new(
             dtype,
@@ -1760,6 +1770,10 @@ fn execute_one_shot_zip<T: 'static>(
     }
     .map_err(|error| Error::backend_source("elementwise_read_into", error))?;
     let rhs_data = rhs.host_storage()?;
+    // INVARIANT: dtype and layout come from the same validated typed view, and
+    // its host storage remains borrowed until replay returns.
+    // SAFETY: rhs_data supplies the pointer and exact byte length; the view
+    // owns the matching shape, signed strides, and in-bounds offset.
     let rhs_descriptor = unsafe {
         ErasedRawStridedPtr::new(
             dtype,
@@ -1776,6 +1790,8 @@ fn execute_one_shot_zip<T: 'static>(
     let out_strides = SmallVec::<[isize; 8]>::from_slice(out.strides());
     let out_offset = out.offset();
     let out_data = out.host_storage_mut()?;
+    // INVARIANT: the copied output layout describes this uniquely borrowed
+    // host storage, already validated as disjoint from every input.
     let mut out_descriptor = ErasedRawStridedMut::new(
         dtype,
         typed_bytes_mut(out_data),

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -7,10 +7,16 @@ use crate::types::{
 };
 use crate::validate::validate_convert_dtype;
 use crate::{
-    DType, Error, RuntimeCacheControl, ShapeMismatch, Tensor, TensorRead, TensorValue, TensorWrite,
-    ValidationError,
+    AllocationDomainId, AllocationId, DType, Error, RuntimeCacheControl, ShapeMismatch, Tensor,
+    TensorRead, TensorValue, TensorWrite, ValidationError,
 };
 use num_complex::{Complex32, Complex64};
+use smallvec::SmallVec;
+use std::ptr::NonNull;
+use strided_kernel::{
+    erased_map_into, erased_zip_into, ErasedMapOp, ErasedRawStridedMut, ErasedRawStridedPtr,
+    ErasedZipOp, ExecContext, KernelDType,
+};
 
 #[cfg(test)]
 mod tests;
@@ -1445,6 +1451,450 @@ impl ElementwiseFusionInst {
     }
 }
 
+/// Runtime operation selected by [`TensorElementwise::elementwise_read_into`].
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ElementwiseReadOp {
+    /// Binary addition.
+    Add,
+    /// Binary subtraction.
+    Subtract,
+    /// Binary multiplication.
+    Multiply,
+    /// Unary negation.
+    Negate,
+    /// Unary conjugation.
+    Conj,
+    /// Binary division.
+    Divide,
+}
+
+impl ElementwiseReadOp {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Add => "add",
+            Self::Subtract => "sub",
+            Self::Multiply => "mul",
+            Self::Negate => "neg",
+            Self::Conj => "conj",
+            Self::Divide => "div",
+        }
+    }
+
+    fn arity(self) -> usize {
+        match self {
+            Self::Negate | Self::Conj => 1,
+            Self::Add | Self::Subtract | Self::Multiply | Self::Divide => 2,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum StorageIdentity {
+    Host {
+        start: usize,
+        end: usize,
+    },
+    Backend {
+        domain: Option<AllocationDomainId>,
+        allocation: Option<AllocationId>,
+        family: &'static str,
+        object: usize,
+    },
+}
+
+fn host_storage_identity<T>(data: &[T]) -> StorageIdentity {
+    let start = data.as_ptr() as usize;
+    let bytes = std::mem::size_of_val(data);
+    StorageIdentity::Host {
+        start,
+        end: start.saturating_add(bytes),
+    }
+}
+
+fn backend_storage_identity<T: 'static>(
+    buffer: &std::sync::Arc<dyn crate::BackendBuffer<T>>,
+) -> StorageIdentity {
+    StorageIdentity::Backend {
+        domain: buffer.allocation_domain(),
+        allocation: buffer.allocation_id(),
+        family: buffer.backend_family(),
+        object: std::sync::Arc::as_ptr(buffer) as *const () as usize,
+    }
+}
+
+fn typed_tensor_storage_identity<T: 'static>(
+    tensor: &TypedTensor<T>,
+) -> crate::Result<StorageIdentity> {
+    match tensor.buffer() {
+        Buffer::Host(data) => Ok(host_storage_identity(data)),
+        Buffer::Backend(buffer) => Ok(backend_storage_identity(buffer)),
+    }
+}
+
+fn typed_view_storage_identity<T: 'static>(
+    view: &TypedTensorView<'_, T>,
+) -> crate::Result<StorageIdentity> {
+    match view.backend_buffer() {
+        Some(buffer) => Ok(backend_storage_identity(buffer)),
+        None => view.host_storage().map(host_storage_identity),
+    }
+}
+
+fn tensor_read_storage_identity(input: &TensorRead<'_>) -> crate::Result<StorageIdentity> {
+    macro_rules! typed_identity {
+        ($value:expr) => {
+            match $value {
+                Tensor::F32(value) => typed_tensor_storage_identity(value),
+                Tensor::F64(value) => typed_tensor_storage_identity(value),
+                Tensor::I32(value) => typed_tensor_storage_identity(value),
+                Tensor::I64(value) => typed_tensor_storage_identity(value),
+                Tensor::Bool(value) => typed_tensor_storage_identity(value),
+                Tensor::C32(value) => typed_tensor_storage_identity(value),
+                Tensor::C64(value) => typed_tensor_storage_identity(value),
+            }
+        };
+    }
+    macro_rules! view_identity {
+        ($value:expr) => {
+            match $value {
+                TensorView::F32(value) => typed_view_storage_identity(value),
+                TensorView::F64(value) => typed_view_storage_identity(value),
+                TensorView::I32(value) => typed_view_storage_identity(value),
+                TensorView::I64(value) => typed_view_storage_identity(value),
+                TensorView::Bool(value) => typed_view_storage_identity(value),
+                TensorView::C32(value) => typed_view_storage_identity(value),
+                TensorView::C64(value) => typed_view_storage_identity(value),
+            }
+        };
+    }
+
+    match input {
+        TensorRead::Tensor(tensor) => typed_identity!(tensor),
+        TensorRead::View(view) => view_identity!(view),
+    }
+}
+
+fn storage_overlaps(lhs: StorageIdentity, rhs: StorageIdentity) -> bool {
+    match (lhs, rhs) {
+        (
+            StorageIdentity::Host {
+                start: lhs_start,
+                end: lhs_end,
+            },
+            StorageIdentity::Host {
+                start: rhs_start,
+                end: rhs_end,
+            },
+        ) => lhs_start < rhs_end && rhs_start < lhs_end,
+        (
+            StorageIdentity::Backend {
+                domain: lhs_domain,
+                allocation: lhs_allocation,
+                family: lhs_family,
+                object: lhs_object,
+            },
+            StorageIdentity::Backend {
+                domain: rhs_domain,
+                allocation: rhs_allocation,
+                family: rhs_family,
+                object: rhs_object,
+            },
+        ) => {
+            lhs_object == rhs_object
+                || matches!(
+                    (lhs_domain, rhs_domain, lhs_allocation, rhs_allocation),
+                    (Some(lhs_domain), Some(rhs_domain), Some(lhs), Some(rhs))
+                        if lhs_domain == rhs_domain && lhs == rhs
+                )
+                || matches!(
+                    (lhs_domain, rhs_domain, lhs_allocation, rhs_allocation),
+                    (None, None, Some(lhs), Some(rhs)) if lhs_family == rhs_family && lhs == rhs
+                )
+        }
+        _ => false,
+    }
+}
+
+fn validate_elementwise_output_disjoint(
+    op: ElementwiseReadOp,
+    inputs: &[TensorRead<'_>],
+    out: &TensorWrite<'_>,
+) -> crate::Result<()> {
+    let output_identity = tensor_read_storage_identity(&out.as_read())?;
+    for (index, input) in inputs.iter().enumerate() {
+        if storage_overlaps(tensor_read_storage_identity(input)?, output_identity) {
+            return Err(Error::invalid_argument(
+                op.label(),
+                "out",
+                format!("destination storage overlaps input {index}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn read_is_host(input: &TensorRead<'_>) -> bool {
+    match input {
+        TensorRead::Tensor(tensor) => !tensor.is_backend_buffer(),
+        TensorRead::View(view) => match view {
+            TensorView::F32(view) => view.backend_buffer().is_none(),
+            TensorView::F64(view) => view.backend_buffer().is_none(),
+            TensorView::I32(view) => view.backend_buffer().is_none(),
+            TensorView::I64(view) => view.backend_buffer().is_none(),
+            TensorView::Bool(view) => view.backend_buffer().is_none(),
+            TensorView::C32(view) => view.backend_buffer().is_none(),
+            TensorView::C64(view) => view.backend_buffer().is_none(),
+        },
+    }
+}
+
+fn write_is_host(out: &TensorWrite<'_>) -> bool {
+    read_is_host(&out.as_read())
+}
+
+fn one_shot_supports(op: ElementwiseReadOp, dtype: DType) -> bool {
+    match op {
+        ElementwiseReadOp::Conj => true,
+        ElementwiseReadOp::Add
+        | ElementwiseReadOp::Subtract
+        | ElementwiseReadOp::Multiply
+        | ElementwiseReadOp::Divide
+        | ElementwiseReadOp::Negate => !matches!(dtype, DType::Bool),
+    }
+}
+
+fn one_shot_eligible(
+    op: ElementwiseReadOp,
+    inputs: &[TensorRead<'_>],
+    out: &TensorWrite<'_>,
+) -> bool {
+    let dtype = out.dtype();
+    write_is_host(out)
+        && one_shot_supports(op, dtype)
+        && inputs.iter().all(|input| {
+            read_is_host(input) && input.dtype() == dtype && input.shape() == out.shape()
+        })
+}
+
+fn tensor_write_view(out: TensorWrite<'_>) -> TensorViewMut<'_> {
+    match out {
+        TensorWrite::Tensor(tensor) => match tensor {
+            Tensor::F32(tensor) => TensorViewMut::F32(tensor.as_view_mut()),
+            Tensor::F64(tensor) => TensorViewMut::F64(tensor.as_view_mut()),
+            Tensor::I32(tensor) => TensorViewMut::I32(tensor.as_view_mut()),
+            Tensor::I64(tensor) => TensorViewMut::I64(tensor.as_view_mut()),
+            Tensor::Bool(tensor) => TensorViewMut::Bool(tensor.as_view_mut()),
+            Tensor::C32(tensor) => TensorViewMut::C32(tensor.as_view_mut()),
+            Tensor::C64(tensor) => TensorViewMut::C64(tensor.as_view_mut()),
+        },
+        TensorWrite::View(view) => view,
+    }
+}
+
+fn non_null_bytes<T>(data: &[T]) -> NonNull<u8> {
+    NonNull::new(data.as_ptr().cast_mut().cast()).unwrap_or_else(NonNull::dangling)
+}
+
+fn typed_bytes_mut<T>(data: &mut [T]) -> &mut [u8] {
+    let len = std::mem::size_of_val(data);
+    // SAFETY: u8 has alignment one and the returned bytes retain the unique
+    // lifetime of the typed destination slice.
+    unsafe { std::slice::from_raw_parts_mut(data.as_mut_ptr().cast(), len) }
+}
+
+fn execute_one_shot_map<T: 'static>(
+    dtype: KernelDType,
+    op: ErasedMapOp,
+    ctx: &ExecContext,
+    input: TypedTensorView<'_, T>,
+    mut out: TypedTensorViewMut<'_, T>,
+) -> crate::Result<()> {
+    let input_data = input.host_storage()?;
+    let input_descriptor = unsafe {
+        ErasedRawStridedPtr::new(
+            dtype,
+            non_null_bytes(input_data),
+            std::mem::size_of_val(input_data),
+            input.shape(),
+            input.strides(),
+            input.offset(),
+        )
+    }
+    .map_err(|error| Error::backend_source("elementwise_read_into", error))?;
+
+    let out_dims = SmallVec::<[usize; 8]>::from_slice(out.shape());
+    let out_strides = SmallVec::<[isize; 8]>::from_slice(out.strides());
+    let out_offset = out.offset();
+    let out_data = out.host_storage_mut()?;
+    let mut out_descriptor = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(out_data),
+        &out_dims,
+        &out_strides,
+        out_offset,
+    )
+    .map_err(|error| Error::backend_source("elementwise_read_into", error))?;
+    erased_map_into(dtype, op, ctx, &mut out_descriptor, &input_descriptor)
+        .map_err(|error| Error::backend_source("elementwise_read_into", error))
+}
+
+fn execute_one_shot_zip<T: 'static>(
+    dtype: KernelDType,
+    op: ErasedZipOp,
+    ctx: &ExecContext,
+    lhs: TypedTensorView<'_, T>,
+    rhs: TypedTensorView<'_, T>,
+    mut out: TypedTensorViewMut<'_, T>,
+) -> crate::Result<()> {
+    let lhs_data = lhs.host_storage()?;
+    let lhs_descriptor = unsafe {
+        ErasedRawStridedPtr::new(
+            dtype,
+            non_null_bytes(lhs_data),
+            std::mem::size_of_val(lhs_data),
+            lhs.shape(),
+            lhs.strides(),
+            lhs.offset(),
+        )
+    }
+    .map_err(|error| Error::backend_source("elementwise_read_into", error))?;
+    let rhs_data = rhs.host_storage()?;
+    let rhs_descriptor = unsafe {
+        ErasedRawStridedPtr::new(
+            dtype,
+            non_null_bytes(rhs_data),
+            std::mem::size_of_val(rhs_data),
+            rhs.shape(),
+            rhs.strides(),
+            rhs.offset(),
+        )
+    }
+    .map_err(|error| Error::backend_source("elementwise_read_into", error))?;
+
+    let out_dims = SmallVec::<[usize; 8]>::from_slice(out.shape());
+    let out_strides = SmallVec::<[isize; 8]>::from_slice(out.strides());
+    let out_offset = out.offset();
+    let out_data = out.host_storage_mut()?;
+    let mut out_descriptor = ErasedRawStridedMut::new(
+        dtype,
+        typed_bytes_mut(out_data),
+        &out_dims,
+        &out_strides,
+        out_offset,
+    )
+    .map_err(|error| Error::backend_source("elementwise_read_into", error))?;
+    erased_zip_into(
+        dtype,
+        op,
+        ctx,
+        &mut out_descriptor,
+        &lhs_descriptor,
+        &rhs_descriptor,
+    )
+    .map_err(|error| Error::backend_source("elementwise_read_into", error))
+}
+
+fn execute_one_shot_elementwise(
+    op: ElementwiseReadOp,
+    inputs: &[TensorRead<'_>],
+    out: TensorWrite<'_>,
+    ctx: &ExecContext,
+) -> crate::Result<()> {
+    let out = tensor_write_view(out);
+    macro_rules! dispatch_map {
+        ($map_op:expr) => {{
+            let input = inputs[0].clone().tensor_view();
+            match (input, out) {
+                (TensorView::F32(input), TensorViewMut::F32(out)) => {
+                    execute_one_shot_map(KernelDType::F32, $map_op, ctx, input, out)
+                }
+                (TensorView::F64(input), TensorViewMut::F64(out)) => {
+                    execute_one_shot_map(KernelDType::F64, $map_op, ctx, input, out)
+                }
+                (TensorView::I32(input), TensorViewMut::I32(out)) => {
+                    execute_one_shot_map(KernelDType::I32, $map_op, ctx, input, out)
+                }
+                (TensorView::I64(input), TensorViewMut::I64(out)) => {
+                    execute_one_shot_map(KernelDType::I64, $map_op, ctx, input, out)
+                }
+                (TensorView::Bool(input), TensorViewMut::Bool(out)) => {
+                    execute_one_shot_map(KernelDType::Bool, $map_op, ctx, input, out)
+                }
+                (TensorView::C32(input), TensorViewMut::C32(out)) => {
+                    execute_one_shot_map(KernelDType::C32, $map_op, ctx, input, out)
+                }
+                (TensorView::C64(input), TensorViewMut::C64(out)) => {
+                    execute_one_shot_map(KernelDType::C64, $map_op, ctx, input, out)
+                }
+                _ => unreachable!("one-shot eligibility validates matching dtypes"),
+            }
+        }};
+    }
+    macro_rules! dispatch_zip {
+        ($zip_op:expr) => {{
+            let lhs = inputs[0].clone().tensor_view();
+            let rhs = inputs[1].clone().tensor_view();
+            match (lhs, rhs, out) {
+                (TensorView::F32(lhs), TensorView::F32(rhs), TensorViewMut::F32(out)) => {
+                    execute_one_shot_zip(KernelDType::F32, $zip_op, ctx, lhs, rhs, out)
+                }
+                (TensorView::F64(lhs), TensorView::F64(rhs), TensorViewMut::F64(out)) => {
+                    execute_one_shot_zip(KernelDType::F64, $zip_op, ctx, lhs, rhs, out)
+                }
+                (TensorView::I32(lhs), TensorView::I32(rhs), TensorViewMut::I32(out)) => {
+                    execute_one_shot_zip(KernelDType::I32, $zip_op, ctx, lhs, rhs, out)
+                }
+                (TensorView::I64(lhs), TensorView::I64(rhs), TensorViewMut::I64(out)) => {
+                    execute_one_shot_zip(KernelDType::I64, $zip_op, ctx, lhs, rhs, out)
+                }
+                (TensorView::C32(lhs), TensorView::C32(rhs), TensorViewMut::C32(out)) => {
+                    execute_one_shot_zip(KernelDType::C32, $zip_op, ctx, lhs, rhs, out)
+                }
+                (TensorView::C64(lhs), TensorView::C64(rhs), TensorViewMut::C64(out)) => {
+                    execute_one_shot_zip(KernelDType::C64, $zip_op, ctx, lhs, rhs, out)
+                }
+                _ => unreachable!("one-shot eligibility validates matching dtypes"),
+            }
+        }};
+    }
+
+    match op {
+        ElementwiseReadOp::Add => dispatch_zip!(ErasedZipOp::Add),
+        ElementwiseReadOp::Subtract => dispatch_zip!(ErasedZipOp::Subtract),
+        ElementwiseReadOp::Multiply => dispatch_zip!(ErasedZipOp::Multiply),
+        ElementwiseReadOp::Divide => dispatch_zip!(ErasedZipOp::Divide),
+        ElementwiseReadOp::Negate => dispatch_map!(ErasedMapOp::Negate),
+        ElementwiseReadOp::Conj => dispatch_map!(ErasedMapOp::Conj),
+    }
+}
+
+/// Execute the shared elementwise-into path with an explicit replay context.
+///
+/// This is backend glue for implementations that own an execution context.
+#[doc(hidden)]
+pub fn elementwise_read_into_with_context(
+    op: ElementwiseReadOp,
+    inputs: &[TensorRead<'_>],
+    out: TensorWrite<'_>,
+    ctx: &ExecContext,
+    fallback: impl FnOnce(&[TensorRead<'_>], TensorWrite<'_>) -> crate::Result<()>,
+) -> crate::Result<()> {
+    if inputs.len() != op.arity() {
+        return Err(Error::invalid_argument(
+            op.label(),
+            "inputs",
+            format!("expected {} inputs, got {}", op.arity(), inputs.len()),
+        ));
+    }
+    validate_elementwise_output_disjoint(op, inputs, &out)?;
+    if one_shot_eligible(op, inputs, &out) {
+        execute_one_shot_elementwise(op, inputs, out, ctx)
+    } else {
+        fallback(inputs, out)
+    }
+}
+
 /// Elementwise tensor operations.
 ///
 /// # Examples
@@ -1455,6 +1905,42 @@ impl ElementwiseFusionInst {
 /// fn accepts_elementwise<B: TensorElementwise>(_backend: &mut B) {}
 /// ```
 pub trait TensorElementwise: TensorStructural {
+    /// Execute an elementwise operation into caller-owned storage.
+    ///
+    /// Backend implementations normally override this hook only to inject
+    /// their explicit execution context and buffer policy. The default uses a
+    /// serial host one-shot kernel and preserves the allocating fallback for
+    /// device storage, dtype promotion, and broadcasting.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed validation error when `inputs` has the wrong arity or
+    /// the destination overlaps an input. Kernel and fallback errors are
+    /// preserved as typed backend or validation errors.
+    fn elementwise_read_into(
+        &mut self,
+        op: ElementwiseReadOp,
+        inputs: &[TensorRead<'_>],
+        out: TensorWrite<'_>,
+    ) -> crate::Result<()> {
+        let ctx = ExecContext::serial();
+        elementwise_read_into_with_context(op, inputs, out, &ctx, |inputs, out| {
+            let result = match op {
+                ElementwiseReadOp::Add => self.add_read(inputs[0].clone(), inputs[1].clone())?,
+                ElementwiseReadOp::Subtract => {
+                    self.sub_read(inputs[0].clone(), inputs[1].clone())?
+                }
+                ElementwiseReadOp::Multiply => {
+                    self.mul_read(inputs[0].clone(), inputs[1].clone())?
+                }
+                ElementwiseReadOp::Negate => self.neg_read(inputs[0].clone())?,
+                ElementwiseReadOp::Conj => self.conj_read(inputs[0].clone())?,
+                ElementwiseReadOp::Divide => self.div_read(inputs[0].clone(), inputs[1].clone())?,
+            };
+            self.copy_read_into(TensorRead::from_tensor(&result), out)
+        })
+    }
+
     /// # Errors
     ///
     /// Returns [`crate::Error::Validation`] with a typed `ValidationError` source
@@ -1553,8 +2039,7 @@ pub trait TensorElementwise: TensorStructural {
         rhs: TensorRead<'_>,
         out: TensorWrite<'_>,
     ) -> crate::Result<()> {
-        let result = self.add_read(lhs, rhs)?;
-        self.copy_read_into(TensorRead::from_tensor(&result), out)
+        self.elementwise_read_into(ElementwiseReadOp::Add, &[lhs, rhs], out)
     }
 
     /// # Errors
@@ -1618,8 +2103,7 @@ pub trait TensorElementwise: TensorStructural {
         rhs: TensorRead<'_>,
         out: TensorWrite<'_>,
     ) -> crate::Result<()> {
-        let result = self.sub_read(lhs, rhs)?;
-        self.copy_read_into(TensorRead::from_tensor(&result), out)
+        self.elementwise_read_into(ElementwiseReadOp::Subtract, &[lhs, rhs], out)
     }
 
     /// # Errors
@@ -1667,8 +2151,7 @@ pub trait TensorElementwise: TensorStructural {
         rhs: TensorRead<'_>,
         out: TensorWrite<'_>,
     ) -> crate::Result<()> {
-        let result = self.mul_read(lhs, rhs)?;
-        self.copy_read_into(TensorRead::from_tensor(&result), out)
+        self.elementwise_read_into(ElementwiseReadOp::Multiply, &[lhs, rhs], out)
     }
 
     /// # Errors
@@ -1707,8 +2190,7 @@ pub trait TensorElementwise: TensorStructural {
     /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
     /// backend execution or storage access cannot provide the requested result.
     fn neg_read_into(&mut self, input: TensorRead<'_>, out: TensorWrite<'_>) -> crate::Result<()> {
-        let result = self.neg_read(input)?;
-        self.copy_read_into(TensorRead::from_tensor(&result), out)
+        self.elementwise_read_into(ElementwiseReadOp::Negate, &[input], out)
     }
 
     /// # Errors
@@ -1747,8 +2229,7 @@ pub trait TensorElementwise: TensorStructural {
     /// [`crate::Error::BackendFailure`] or [`crate::Error::BackendSource`] when
     /// backend execution or storage access cannot provide the requested result.
     fn conj_read_into(&mut self, input: TensorRead<'_>, out: TensorWrite<'_>) -> crate::Result<()> {
-        let result = self.conj_read(input)?;
-        self.copy_read_into(TensorRead::from_tensor(&result), out)
+        self.elementwise_read_into(ElementwiseReadOp::Conj, &[input], out)
     }
 
     /// # Errors
@@ -1796,8 +2277,7 @@ pub trait TensorElementwise: TensorStructural {
         rhs: TensorRead<'_>,
         out: TensorWrite<'_>,
     ) -> crate::Result<()> {
-        let result = self.div_read(lhs, rhs)?;
-        self.copy_read_into(TensorRead::from_tensor(&result), out)
+        self.elementwise_read_into(ElementwiseReadOp::Divide, &[lhs, rhs], out)
     }
 
     /// Elementwise remainder.

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -1914,9 +1914,11 @@ pub trait TensorElementwise: TensorStructural {
     ///
     /// # Errors
     ///
-    /// Returns a typed validation error when `inputs` has the wrong arity or
-    /// the destination overlaps an input. Kernel and fallback errors are
-    /// preserved as typed backend or validation errors.
+    /// Returns [`crate::Error::Validation`] when `inputs` has the wrong arity,
+    /// tensor metadata is invalid, or the destination overlaps an input.
+    /// Returns [`crate::Error::BackendSource`] when the strided kernel rejects
+    /// an eligible host operation. Errors from the allocating backend fallback
+    /// are preserved unchanged.
     fn elementwise_read_into(
         &mut self,
         op: ElementwiseReadOp,

--- a/crates/tenferro-tensor/src/backend.rs
+++ b/crates/tenferro-tensor/src/backend.rs
@@ -1872,6 +1872,13 @@ fn execute_one_shot_elementwise(
 /// Execute the shared elementwise-into path with an explicit replay context.
 ///
 /// This is backend glue for implementations that own an execution context.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::Validation`] when the input arity or tensor
+/// metadata is invalid, or when the destination overlaps an input. Returns
+/// [`crate::Error::BackendSource`] when an eligible strided replay fails.
+/// Errors returned by `fallback` are preserved unchanged.
 #[doc(hidden)]
 pub fn elementwise_read_into_with_context(
     op: ElementwiseReadOp,

--- a/crates/tenferro-tensor/src/lib.rs
+++ b/crates/tenferro-tensor/src/lib.rs
@@ -63,10 +63,10 @@ pub mod validate;
 
 pub use backend::{
     default_backend_session, BackendCachedDot, BackendRuntimeCache, BackendSession,
-    BackendSessionHost, ContractionScalar, DotGeneralAccumulation, SessionCachedDot,
-    TensorAnalytic, TensorBackend, TensorBackendOps, TensorBuffer, TensorDeviceTransfer, TensorDot,
-    TensorElementwise, TensorFusion, TensorIndexing, TensorReduction, TensorStructural,
-    TensorViewCanonicalization,
+    BackendSessionHost, ContractionScalar, DotGeneralAccumulation, ElementwiseReadOp,
+    SessionCachedDot, TensorAnalytic, TensorBackend, TensorBackendOps, TensorBuffer,
+    TensorDeviceTransfer, TensorDot, TensorElementwise, TensorFusion, TensorIndexing,
+    TensorReduction, TensorStructural, TensorViewCanonicalization,
 };
 pub use cache::{CacheStats, RuntimeCacheControl};
 pub use capability::{

--- a/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
+++ b/crates/tenferro-tensor/src/tests/backend_default_read_tests.rs
@@ -642,31 +642,31 @@ fn elementwise_into_defaults_overwrite_outputs_and_validate_output() {
     backend
         .add_into(&a, &b, TensorWrite::from_tensor(&mut out))
         .unwrap();
-    assert_eq!(out.as_slice::<f64>().unwrap(), &[42.0]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[3.0]);
 
     let mut out = Tensor::from_vec_col_major(vec![1], vec![0.0_f64]).unwrap();
     backend
         .sub_into(&a, &b, TensorWrite::from_tensor(&mut out))
         .unwrap();
-    assert_eq!(out.as_slice::<f64>().unwrap(), &[42.0]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[-1.0]);
 
     let mut out = Tensor::from_vec_col_major(vec![1], vec![0.0_f64]).unwrap();
     backend
         .mul_into(&a, &b, TensorWrite::from_tensor(&mut out))
         .unwrap();
-    assert_eq!(out.as_slice::<f64>().unwrap(), &[42.0]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[2.0]);
 
     let mut out = Tensor::from_vec_col_major(vec![1], vec![0.0_f64]).unwrap();
     backend
         .neg_into(&a, TensorWrite::from_tensor(&mut out))
         .unwrap();
-    assert_eq!(out.as_slice::<f64>().unwrap(), &[42.0]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[-1.0]);
 
     let mut out = Tensor::from_vec_col_major(vec![1], vec![0.0_f64]).unwrap();
     backend
         .conj_into(&a, TensorWrite::from_tensor(&mut out))
         .unwrap();
-    assert_eq!(out.as_slice::<f64>().unwrap(), &[42.0]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[1.0]);
 
     let mut out = Tensor::from_vec_col_major(vec![1], vec![0.0_f64]).unwrap();
     backend
@@ -676,7 +676,11 @@ fn elementwise_into_defaults_overwrite_outputs_and_validate_output() {
             TensorWrite::from_tensor(&mut out),
         )
         .unwrap();
-    assert_eq!(out.as_slice::<f64>().unwrap(), &[42.0]);
+    assert_eq!(out.as_slice::<f64>().unwrap(), &[0.5]);
+    assert!(
+        backend.calls.is_empty(),
+        "host elementwise into defaults must not allocate through the backend"
+    );
 
     let mut wrong_shape = Tensor::from_vec_col_major(vec![2], vec![0.0_f64, 0.0]).unwrap();
     let err = backend
@@ -701,6 +705,66 @@ fn elementwise_into_defaults_overwrite_outputs_and_validate_output() {
             ..
         }
     ));
+}
+
+#[test]
+fn elementwise_into_rejects_shared_backend_destination_before_fallback() {
+    let shared: std::sync::Arc<dyn crate::BackendBuffer<f64>> =
+        std::sync::Arc::new(crate::BufferHandle::<f64>::new_with_len(17, 1));
+    let placement = crate::Placement {
+        memory_kind: crate::MemoryKind::Device,
+        device: Some(crate::DeviceId {
+            kind: crate::DeviceKind::Gpu(crate::GpuBackendKind::Cuda),
+            ordinal: 0,
+        }),
+        cpu_affinity: None,
+    };
+    let lhs = Tensor::F64(
+        TypedTensor::from_buffer_col_major(
+            vec![1],
+            crate::Buffer::Backend(std::sync::Arc::clone(&shared)),
+            placement.clone(),
+        )
+        .unwrap(),
+    );
+    let rhs = Tensor::from_vec_col_major(vec![1], vec![2.0_f64]).unwrap();
+    let mut out = Tensor::F64(
+        TypedTensor::from_buffer_col_major(vec![1], crate::Buffer::Backend(shared), placement)
+            .unwrap(),
+    );
+
+    let error = DefaultReadBackend::default()
+        .add_into(&lhs, &rhs, TensorWrite::from_tensor(&mut out))
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        crate::Error::Validation {
+            op: "add",
+            source: crate::ValidationError::InvalidArgument {
+                argument: "out",
+                ..
+            },
+        }
+    ));
+}
+
+#[test]
+fn elementwise_into_updates_caller_view_storage_after_handoff() {
+    let lhs = Tensor::from_vec_col_major(vec![2], vec![1.0_f64, 2.0]).unwrap();
+    let rhs = Tensor::from_vec_col_major(vec![2], vec![3.0_f64, 4.0]).unwrap();
+    let mut storage = vec![-1.0_f64, 0.0, 0.0, -1.0];
+
+    {
+        let view = TypedTensorViewMut::from_slice(vec![2], vec![1], 1, &mut storage).unwrap();
+        DefaultReadBackend::default()
+            .add_into(&lhs, &rhs, TensorWrite::from_view(TensorViewMut::F64(view)))
+            .unwrap();
+    }
+
+    assert_eq!(storage, vec![-1.0, 4.0, 6.0, -1.0]);
+    storage[2] = 9.0;
+    assert_eq!(storage, vec![-1.0, 4.0, 9.0, -1.0]);
 }
 
 #[test]

--- a/docs/worklogs/2026-07-29-elementwise-into-defaults.md
+++ b/docs/worklogs/2026-07-29-elementwise-into-defaults.md
@@ -1,0 +1,75 @@
+# Elementwise Into Defaults
+
+## Summary
+
+Fixed #1504 by routing the six existing elementwise `*_read_into` methods
+through one `TensorElementwise::elementwise_read_into` hook. Equal-shape,
+equal-dtype host operations use strided-kernel's compile-free erased one-shot
+map/zip entry points. Promotion, broadcasting, and backend storage preserve
+the previous allocate-plus-copy fallback.
+
+`CpuBackend` and `CpuExecSession` override only the shared hook. Both enter the
+owned CPU execution domain and map its thread budget to an explicit strided
+`ExecContext`; neither uses `ExecContext::ambient()`. Dispatch wrappers such
+as `EagerBackend` forward the hook to the selected backend so they retain that
+backend's execution context.
+
+## Dependency
+
+The workspace strided-rs pin advances from
+`06c825829e399dd769504e6ce10dbca8f07b5e15` to the merged W1 commit
+`649772c8402e5fe95335366326b6623f9a4f5b0a`. `tenferro-tensor` depends only on
+the dtype-erased `strided-kernel` API.
+
+## Safety And Semantics
+
+- The hook validates destination/input storage disjointness before fallback or
+  mutation. Shared backend allocations return a typed invalid-argument error.
+- The strided one-shot boundary validates raw host buffer overlap before
+  forming input references.
+- Caller-owned strided output views retain their backing storage; tests mutate
+  the backing storage after the operation returns.
+- Tensor trait defaults use `ExecContext::serial()`. CPU implementations
+  replace it with the runtime-owned bounded context.
+- #1502 remains separate. A later caller-owned linear-solve destination should
+  reuse this hook pattern rather than add another default execution boundary.
+
+## Benchmark Evidence
+
+Focused public API rows were measured sequentially on the same 64-core Linux
+host with `cpu-faer`, `PUBLICATION_GATE_PROFILE=full`, 15 measured runs, three
+warmups, and the same release target cache. The exact allocating counterparts
+were measured in the same process configuration.
+
+| row | before t1 ms | after t1 ms | before t4 ms | after t4 ms |
+| --- | ---: | ---: | ---: | ---: |
+| `add_into` | 220.698 | 53.079 | 79.108 | 16.033 |
+| `sub_into` | 223.976 | 61.362 | 81.765 | 17.414 |
+| `mul_into` | 227.839 | 94.802 | 83.214 | 25.662 |
+| `div_into` | 220.185 | 84.867 | 74.667 | 23.396 |
+| `neg_into` | 208.688 | 39.227 | 75.061 | 11.307 |
+| `conj_into` | 209.528 | 25.892 | 74.583 | 11.953 |
+
+All six `*_into` rows now beat their allocating counterparts at t1 and t4.
+The allocating rows changed between about -8.5% and +4.5%; every change
+remains far below the +20% stop-the-line gate. The final formal
+cross-framework gate remains W10.
+
+Raw focused results:
+
+- baseline:
+  `tenferro-benchmark/data/w2-baseline-output-reuse-20260729.csv`
+- candidate:
+  `tenferro-benchmark/data/w2-candidate-final-output-reuse-20260729.csv`
+
+## Verification
+
+```bash
+python3 scripts/ci/run_profile.py fmt
+cargo test -p tenferro-tensor
+cargo test -p tenferro-cpu --test integration
+cargo test -p tenferro-ad --lib eager_backend
+```
+
+Before PR creation, this work also runs `scripts/check-pr-fast.sh` and
+`scripts/repository-rules-review.py` under the repository routing policy.

--- a/scripts/ci/tests/test_build_artifact_contracts.py
+++ b/scripts/ci/tests/test_build_artifact_contracts.py
@@ -72,7 +72,7 @@ class BuildArtifactContracts(unittest.TestCase):
         self.assertFalse(faer["default-features"])
         self.assertEqual(set(faer["features"]), {"std", "rayon"})
 
-        revision = "06c825829e399dd769504e6ce10dbca8f07b5e15"
+        revision = "649772c8402e5fe95335366326b6623f9a4f5b0a"
         for name in (
             "strided-view",
             "strided-traits",


### PR DESCRIPTION
## Summary

- route the six existing elementwise `*_read_into` defaults through one `elementwise_read_into` hook
- execute eligible host operations through strided-kernel's compile-free erased one-shot API
- let CPU backend/session overrides inject their runtime-owned bounded `ExecContext`
- reject destination/input storage overlap with a typed validation error
- bump the strided-rs pin to merged W1 commit `649772c8402e5fe95335366326b6623f9a4f5b0a`

Dispatch wrappers forward the new hook to their selected backend. Promotion,
broadcasting, and device-storage cases retain the allocate-plus-copy fallback.

## Performance

Focused public API full-profile medians (ms, 15 runs, 3 warmups):

| row | before t1 | after t1 | before t4 | after t4 |
| --- | ---: | ---: | ---: | ---: |
| `add_into` | 220.698 | 53.079 | 79.108 | 16.033 |
| `sub_into` | 223.976 | 61.362 | 81.765 | 17.414 |
| `mul_into` | 227.839 | 94.802 | 83.214 | 25.662 |
| `div_into` | 220.185 | 84.867 | 74.667 | 23.396 |
| `neg_into` | 208.688 | 39.227 | 75.061 | 11.307 |
| `conj_into` | 209.528 | 25.892 | 74.583 | 11.953 |

All targeted into rows beat their allocating counterparts at t1 and t4.
Allocating rows changed between about -8.5% and +4.5%, below the +20% gate.

## Verification

- `bash scripts/check-pr-fast.sh --coverage-reviewed ...`
- `cargo test -p tenferro-tensor`
- `cargo test -p tenferro-cpu --test integration`
- `cargo test -p tenferro-ad --lib eager_backend`
- repository rules review: pass, no findings

Worklog: [docs/worklogs/2026-07-29-elementwise-into-defaults.md](https://github.com/tensor4all/tenferro-rs/blob/codex/issue-1504-elementwise-defaults/docs/worklogs/2026-07-29-elementwise-into-defaults.md)

Closes #1504
